### PR TITLE
fix(ui): style notification preference controls

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4054,7 +4054,6 @@ ui/src/pages/config/security.ts	1
 ui/src/pages/config/settings-search.ts	1
 ui/src/pages/config/settings-select-row.ts	1
 ui/src/pages/config/talk-page.ts	1
-ui/src/pages/config/talk.ts	1
 ui/src/pages/config/view-appearance-preferences.ts	2
 ui/src/pages/config/view-appearance.ts	1
 ui/src/pages/config/view-diff.ts	6

--- a/ui/src/i18n/locales/en-settings.ts
+++ b/ui/src/i18n/locales/en-settings.ts
@@ -221,6 +221,8 @@ const enSettings = {
       detailed: "Detailed",
       quietHours: "Quiet hours",
       quietHoursWindow: "Quiet hours window",
+      quietHoursStart: "Quiet hours start",
+      quietHoursEnd: "Quiet hours end",
       timeZone: "Time zone",
       onlyAgents: "Only these agents",
       inherit: "Use account default",

--- a/ui/src/pages/config/notifications-section.test.ts
+++ b/ui/src/pages/config/notifications-section.test.ts
@@ -102,3 +102,83 @@ describe("Web Push preference saves", () => {
     expect(preferenceGroup.hasAttribute("inert")).toBe(true);
   });
 });
+
+type DevicePreferencesListener = NonNullable<
+  Parameters<typeof renderNotificationsSection>[0]["onWebPushSetDevicePreferences"]
+>;
+
+describe("Web Push preference controls", () => {
+  function renderPreferences(options: { onDevice?: DevicePreferencesListener } = {}) {
+    const container = document.createElement("div");
+    const user = {
+      ...userPreferences,
+      quietHours: { ...userPreferences.quietHours, enabled: true },
+    };
+    const device = { enabled: true, label: "phone", agentIds: ["main"] };
+    render(
+      renderNotificationsSection({
+        connected: true,
+        onWebPushSetDevicePreferences: options.onDevice,
+        webPush: {
+          supported: true,
+          permission: "granted",
+          subscription: "registered",
+          loading: false,
+          preferences: {
+            durableIdentity: true,
+            user,
+            device,
+            effective: { ...user, ...device },
+          },
+        },
+      }),
+      container,
+    );
+    return container;
+  }
+
+  it("renders every preference control through the shared settings control set", () => {
+    const container = renderPreferences();
+
+    // Native checkboxes bypass the settings toggle; booleans are wa-switch rows.
+    expect(container.querySelectorAll('input[type="checkbox"]')).toHaveLength(0);
+    expect(container.querySelectorAll("wa-switch.settings-toggle")).toHaveLength(7);
+
+    const unstyled = Array.from(container.querySelectorAll<HTMLElement>("select, input"))
+      .filter((control) => {
+        const expectedClass = control.tagName === "SELECT" ? "settings-select" : "settings-input";
+        return !control.classList.contains(expectedClass) || !control.getAttribute("aria-label");
+      })
+      .map((control) => control.outerHTML.slice(0, 60));
+    expect(container.querySelectorAll("select")).toHaveLength(9);
+    expect(container.querySelectorAll('input[type="time"]')).toHaveLength(2);
+    expect(unstyled).toEqual([]);
+  });
+
+  it("patches device preferences from the toggle row and select row", () => {
+    const onDevice = vi.fn<DevicePreferencesListener>();
+    const container = renderPreferences({ onDevice });
+    const deviceGroup = expectDefined(
+      container.querySelectorAll(".settings-page .settings-page .settings-group")[1],
+      "device preference group",
+    );
+
+    const toggle = expectDefined(
+      deviceGroup.querySelector<HTMLElement & { checked: boolean }>("wa-switch"),
+      "deliver toggle",
+    );
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event("change"));
+    expect(onDevice).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: false, label: "phone", agentIds: ["main"] }),
+    );
+
+    const detail = expectDefined(
+      deviceGroup.querySelector<HTMLSelectElement>('select[aria-label="Lock-screen detail"]'),
+      "device lock-screen detail select",
+    );
+    detail.value = "detailed";
+    detail.dispatchEvent(new Event("change"));
+    expect(onDevice).toHaveBeenLastCalledWith(expect.objectContaining({ detailLevel: "detailed" }));
+  });
+});

--- a/ui/src/pages/config/notifications-section.ts
+++ b/ui/src/pages/config/notifications-section.ts
@@ -12,11 +12,13 @@ import { icons } from "../../components/icons.ts";
 import {
   renderSettingsRow,
   renderSettingsStatus,
+  renderSettingsToggleRow,
   renderSettingsValue,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { registerSettingsEnglish } from "../../i18n/locales/en-settings.ts";
 import { formatUiExternalText } from "../../lib/format-error.ts";
+import { renderSettingsSelectRow } from "./settings-select-row.ts";
 import { COMMUNICATION_SETTINGS_TARGET_IDS } from "./settings-targets.ts";
 
 registerSettingsEnglish();
@@ -65,13 +67,96 @@ function inputTarget(event: Event): HTMLInputElement {
   return event.currentTarget as HTMLInputElement;
 }
 
-function selectTarget(event: Event): HTMLSelectElement {
-  // SAFETY: callers bind these handlers directly to select elements in this module.
-  return event.currentTarget as HTMLSelectElement;
+type DetailLevel = WebPushNotificationPreferences["detailLevel"];
+
+function detailLevel(value: string): DetailLevel {
+  return value === "identified" || value === "detailed" ? value : "private";
 }
 
-function detailLevel(value: string): WebPushNotificationPreferences["detailLevel"] {
-  return value === "identified" || value === "detailed" ? value : "private";
+type InheritChoice = "inherit" | "on" | "off";
+type QuietHoursWindow = { startMinute: number; endMinute: number; timeZone: string };
+
+function detailLevelOptions(): Array<{ value: DetailLevel; label: string }> {
+  return [
+    { value: "private", label: t("configView.notifications.private") },
+    { value: "identified", label: t("configView.notifications.namesOnly") },
+    { value: "detailed", label: t("configView.notifications.detailed") },
+  ];
+}
+
+function inheritChoiceOptions(
+  inheritLabel: string,
+): Array<{ value: InheritChoice; label: string }> {
+  return [
+    { value: "inherit", label: inheritLabel },
+    { value: "on", label: t("configForm.enumOn") },
+    { value: "off", label: t("configForm.enumOff") },
+  ];
+}
+
+function renderQuietHoursWindowRows<T extends QuietHoursWindow>(
+  quietHours: T,
+  onChange: (quietHours: T) => void,
+) {
+  return html`
+    ${renderSettingsRow({
+      title: t("configView.notifications.quietHoursWindow"),
+      control: html`
+        <input
+          type="time"
+          class="settings-input"
+          aria-label=${t("configView.notifications.quietHoursStart")}
+          .value=${minutesToTime(quietHours.startMinute)}
+          @change=${(event: Event) =>
+            onChange({
+              ...quietHours,
+              startMinute: timeToMinutes(inputTarget(event).value, quietHours.startMinute),
+            })}
+        />
+        <span class="settings-row__value" aria-hidden="true">–</span>
+        <input
+          type="time"
+          class="settings-input"
+          aria-label=${t("configView.notifications.quietHoursEnd")}
+          .value=${minutesToTime(quietHours.endMinute)}
+          @change=${(event: Event) =>
+            onChange({
+              ...quietHours,
+              endMinute: timeToMinutes(inputTarget(event).value, quietHours.endMinute),
+            })}
+        />
+      `,
+    })}
+    ${renderSettingsRow({
+      title: t("configView.notifications.timeZone"),
+      control: html`<input
+        type="text"
+        class="settings-input"
+        aria-label=${t("configView.notifications.timeZone")}
+        .value=${quietHours.timeZone}
+        @change=${(event: Event) => onChange({ ...quietHours, timeZone: inputTarget(event).value })}
+      />`,
+    })}
+  `;
+}
+
+function renderAgentIdsRow(agentIds: string[], onChange: (agentIds: string[]) => void) {
+  return renderSettingsRow({
+    title: t("configView.notifications.onlyAgents"),
+    control: html`<input
+      type="text"
+      class="settings-input"
+      aria-label=${t("configView.notifications.onlyAgents")}
+      .value=${agentIds.join(", ")}
+      @change=${(event: Event) =>
+        onChange(
+          inputTarget(event)
+            .value.split(",")
+            .map((entry) => entry.trim())
+            .filter(Boolean),
+        )}
+    />`,
+  });
 }
 
 function renderUserNotificationPreferences(
@@ -87,116 +172,31 @@ function renderUserNotificationPreferences(
       </div>
       <div class="settings-group">
         ${WEB_PUSH_CATEGORIES.map(([key, label]) =>
-          renderSettingsRow({
+          renderSettingsToggleRow({
             title: label(),
-            control: html`<input
-              type="checkbox"
-              .checked=${preferences.categories[key]}
-              @change=${(event: Event) =>
-                patch({
-                  categories: {
-                    ...preferences.categories,
-                    [key]: inputTarget(event).checked,
-                  },
-                })}
-            />`,
+            checked: preferences.categories[key],
+            onChange: (checked) =>
+              patch({ categories: { ...preferences.categories, [key]: checked } }),
           }),
         )}
-        ${renderSettingsRow({
+        ${renderSettingsSelectRow({
           title: t("configView.notifications.lockScreenDetail"),
           description: t("configView.notifications.lockScreenDetailHint"),
-          control: html`<select
-            .value=${preferences.detailLevel}
-            @change=${(event: Event) =>
-              patch({
-                detailLevel: detailLevel(selectTarget(event).value),
-              })}
-          >
-            <option value="private">${t("configView.notifications.private")}</option>
-            <option value="identified">${t("configView.notifications.namesOnly")}</option>
-            <option value="detailed">${t("configView.notifications.detailed")}</option>
-          </select>`,
+          value: preferences.detailLevel,
+          options: detailLevelOptions(),
+          onChange: (value) => patch({ detailLevel: detailLevel(value) }),
         })}
-        ${renderSettingsRow({
+        ${renderSettingsToggleRow({
           title: t("configView.notifications.quietHours"),
-          control: html`<input
-            type="checkbox"
-            .checked=${preferences.quietHours.enabled}
-            @change=${(event: Event) =>
-              patch({
-                quietHours: {
-                  ...preferences.quietHours,
-                  enabled: inputTarget(event).checked,
-                },
-              })}
-          />`,
+          checked: preferences.quietHours.enabled,
+          onChange: (enabled) => patch({ quietHours: { ...preferences.quietHours, enabled } }),
         })}
         ${preferences.quietHours.enabled
-          ? html`
-              ${renderSettingsRow({
-                title: t("configView.notifications.quietHoursWindow"),
-                control: html`<span>
-                  <input
-                    type="time"
-                    .value=${minutesToTime(preferences.quietHours.startMinute)}
-                    @change=${(event: Event) =>
-                      patch({
-                        quietHours: {
-                          ...preferences.quietHours,
-                          startMinute: timeToMinutes(
-                            inputTarget(event).value,
-                            preferences.quietHours.startMinute,
-                          ),
-                        },
-                      })}
-                  />
-                  –
-                  <input
-                    type="time"
-                    .value=${minutesToTime(preferences.quietHours.endMinute)}
-                    @change=${(event: Event) =>
-                      patch({
-                        quietHours: {
-                          ...preferences.quietHours,
-                          endMinute: timeToMinutes(
-                            inputTarget(event).value,
-                            preferences.quietHours.endMinute,
-                          ),
-                        },
-                      })}
-                  />
-                </span>`,
-              })}
-              ${renderSettingsRow({
-                title: t("configView.notifications.timeZone"),
-                control: html`<input
-                  type="text"
-                  .value=${preferences.quietHours.timeZone}
-                  @change=${(event: Event) =>
-                    patch({
-                      quietHours: {
-                        ...preferences.quietHours,
-                        timeZone: inputTarget(event).value,
-                      },
-                    })}
-                />`,
-              })}
-            `
+          ? renderQuietHoursWindowRows(preferences.quietHours, (quietHours) =>
+              patch({ quietHours }),
+            )
           : nothing}
-        ${renderSettingsRow({
-          title: t("configView.notifications.onlyAgents"),
-          control: html`<input
-            type="text"
-            .value=${preferences.agentIds.join(", ")}
-            @change=${(event: Event) =>
-              patch({
-                agentIds: inputTarget(event)
-                  .value.split(",")
-                  .map((entry) => entry.trim())
-                  .filter(Boolean),
-              })}
-          />`,
-        })}
+        ${renderAgentIdsRow(preferences.agentIds, (agentIds) => patch({ agentIds }))}
       </div>
     </section>
   `;
@@ -214,173 +214,84 @@ function renderDeviceNotificationPreferences(
         <h2 class="settings-section__heading">${t("configView.notifications.installedApp")}</h2>
       </div>
       <div class="settings-group">
-        ${renderSettingsRow({
+        ${renderSettingsToggleRow({
           title: t("configView.notifications.deliverDevice"),
-          control: html`<input
-            type="checkbox"
-            .checked=${preferences.enabled}
-            @change=${(event: Event) => patch({ enabled: inputTarget(event).checked })}
-          />`,
+          checked: preferences.enabled,
+          onChange: (enabled) => patch({ enabled }),
         })}
         ${renderSettingsRow({
           title: t("configView.notifications.notificationLabel"),
           control: html`<input
             type="text"
+            class="settings-input"
+            aria-label=${t("configView.notifications.notificationLabel")}
             maxlength="80"
             .value=${preferences.label}
             @change=${(event: Event) => patch({ label: inputTarget(event).value })}
           />`,
         })}
-        ${renderSettingsRow({
+        ${renderSettingsSelectRow({
           title: t("configView.notifications.lockScreenDetail"),
-          control: html`<select
-            .value=${preferences.detailLevel ?? "inherit"}
-            @change=${(event: Event) => {
-              const value = selectTarget(event).value;
-              patch({
-                detailLevel: value === "inherit" ? undefined : detailLevel(value),
-              });
-            }}
-          >
-            <option value="inherit">${t("configView.notifications.inheritDetail")}</option>
-            <option value="private">${t("configView.notifications.private")}</option>
-            <option value="identified">${t("configView.notifications.namesOnly")}</option>
-            <option value="detailed">${t("configView.notifications.detailed")}</option>
-          </select>`,
+          value: preferences.detailLevel ?? "inherit",
+          options: [
+            { value: "inherit", label: t("configView.notifications.inheritDetail") },
+            ...detailLevelOptions(),
+          ],
+          onChange: (value) =>
+            patch({ detailLevel: value === "inherit" ? undefined : detailLevel(value) }),
         })}
-        ${renderSettingsRow({
+        ${renderSettingsSelectRow({
           title: t("configView.notifications.quietHours"),
-          control: html`<select
-            .value=${preferences.quietHours === undefined
-              ? "inherit"
-              : preferences.quietHours.enabled
-                ? "on"
-                : "off"}
-            @change=${(event: Event) => {
-              const value = selectTarget(event).value;
-              patch({
-                quietHours:
-                  value === "inherit"
-                    ? undefined
-                    : {
-                        enabled: value === "on",
-                        startMinute: preferences.quietHours?.startMinute ?? 22 * 60,
-                        endMinute: preferences.quietHours?.endMinute ?? 7 * 60,
-                        timeZone: preferences.quietHours?.timeZone ?? "UTC",
-                      },
-              });
-            }}
-          >
-            <option value="inherit">${t("configView.notifications.inheritQuietHours")}</option>
-            <option value="on">${t("configForm.enumOn")}</option>
-            <option value="off">${t("configForm.enumOff")}</option>
-          </select>`,
+          value:
+            deviceQuietHours === undefined ? "inherit" : deviceQuietHours.enabled ? "on" : "off",
+          options: inheritChoiceOptions(t("configView.notifications.inheritQuietHours")),
+          onChange: (value) =>
+            patch({
+              quietHours:
+                value === "inherit"
+                  ? undefined
+                  : {
+                      enabled: value === "on",
+                      startMinute: deviceQuietHours?.startMinute ?? 22 * 60,
+                      endMinute: deviceQuietHours?.endMinute ?? 7 * 60,
+                      timeZone: deviceQuietHours?.timeZone ?? "UTC",
+                    },
+            }),
         })}
         ${deviceQuietHours?.enabled
-          ? html`
-              ${renderSettingsRow({
-                title: t("configView.notifications.quietHoursWindow"),
-                control: html`<span>
-                  <input
-                    type="time"
-                    .value=${minutesToTime(deviceQuietHours.startMinute)}
-                    @change=${(event: Event) =>
-                      patch({
-                        quietHours: {
-                          ...deviceQuietHours,
-                          startMinute: timeToMinutes(
-                            inputTarget(event).value,
-                            deviceQuietHours.startMinute,
-                          ),
-                        },
-                      })}
-                  />
-                  –
-                  <input
-                    type="time"
-                    .value=${minutesToTime(deviceQuietHours.endMinute)}
-                    @change=${(event: Event) =>
-                      patch({
-                        quietHours: {
-                          ...deviceQuietHours,
-                          endMinute: timeToMinutes(
-                            inputTarget(event).value,
-                            deviceQuietHours.endMinute,
-                          ),
-                        },
-                      })}
-                  />
-                </span>`,
-              })}
-              ${renderSettingsRow({
-                title: t("configView.notifications.timeZone"),
-                control: html`<input
-                  type="text"
-                  .value=${deviceQuietHours.timeZone}
-                  @change=${(event: Event) =>
-                    patch({
-                      quietHours: {
-                        ...deviceQuietHours,
-                        timeZone: inputTarget(event).value,
-                      },
-                    })}
-                />`,
-              })}
-            `
+          ? renderQuietHoursWindowRows(deviceQuietHours, (quietHours) => patch({ quietHours }))
           : nothing}
-        ${renderSettingsRow({
+        ${renderSettingsSelectRow({
           title: t("configView.notifications.onlyAgents"),
-          control: html`<select
-            .value=${preferences.agentIds === undefined ? "inherit" : "override"}
-            @change=${(event: Event) => {
-              const value = selectTarget(event).value;
-              patch({ agentIds: value === "inherit" ? undefined : [] });
-            }}
-          >
-            <option value="inherit">${t("configView.notifications.inherit")}</option>
-            <option value="override">${t("configView.notifications.overrideAgents")}</option>
-          </select>`,
+          value: preferences.agentIds === undefined ? "inherit" : "override",
+          options: [
+            { value: "inherit", label: t("configView.notifications.inherit") },
+            { value: "override", label: t("configView.notifications.overrideAgents") },
+          ],
+          onChange: (value) => patch({ agentIds: value === "inherit" ? undefined : [] }),
         })}
         ${preferences.agentIds !== undefined
-          ? renderSettingsRow({
-              title: t("configView.notifications.onlyAgents"),
-              control: html`<input
-                type="text"
-                .value=${preferences.agentIds.join(", ")}
-                @change=${(event: Event) =>
-                  patch({
-                    agentIds: inputTarget(event)
-                      .value.split(",")
-                      .map((entry) => entry.trim())
-                      .filter(Boolean),
-                  })}
-              />`,
-            })
+          ? renderAgentIdsRow(preferences.agentIds, (agentIds) => patch({ agentIds }))
           : nothing}
         ${WEB_PUSH_CATEGORIES.map(([key, label]) =>
-          renderSettingsRow({
+          renderSettingsSelectRow({
             title: label(),
-            control: html`<select
-              .value=${preferences.categories?.[key] === undefined
+            value:
+              preferences.categories?.[key] === undefined
                 ? "inherit"
                 : preferences.categories[key]
                   ? "on"
-                  : "off"}
-              @change=${(event: Event) => {
-                const value = selectTarget(event).value;
-                const categories = { ...preferences.categories };
-                if (value === "inherit") {
-                  delete categories[key];
-                } else {
-                  categories[key] = value === "on";
-                }
-                patch({ categories });
-              }}
-            >
-              <option value="inherit">${t("configView.notifications.inherit")}</option>
-              <option value="on">${t("configForm.enumOn")}</option>
-              <option value="off">${t("configForm.enumOff")}</option>
-            </select>`,
+                  : "off",
+            options: inheritChoiceOptions(t("configView.notifications.inherit")),
+            onChange: (value) => {
+              const categories = { ...preferences.categories };
+              if (value === "inherit") {
+                delete categories[key];
+              } else {
+                categories[key] = value === "on";
+              }
+              patch({ categories });
+            },
           }),
         )}
       </div>

--- a/ui/src/pages/config/settings-select-row.ts
+++ b/ui/src/pages/config/settings-select-row.ts
@@ -5,10 +5,12 @@ import { renderSettingsRow } from "../../components/settings-ui.ts";
 export function renderSettingsSelectRow<T extends string>(params: {
   title: string;
   value: T;
-  setting: "send-shortcut" | "follow-up-mode" | "catalog-open-target";
+  /** Stable e2e hook; only the Appearance preference rows carry one. */
+  setting?: "send-shortcut" | "follow-up-mode" | "catalog-open-target";
   options: ReadonlyArray<{ value: T; label: string }>;
   onChange: (value: string) => void;
   description?: unknown;
+  disabled?: boolean;
 }) {
   return renderSettingsRow({
     title: params.title,
@@ -20,6 +22,7 @@ export function renderSettingsSelectRow<T extends string>(params: {
         ?data-settings-follow-up-mode=${params.setting === "follow-up-mode"}
         ?data-settings-catalog-open-target=${params.setting === "catalog-open-target"}
         aria-label=${params.title}
+        ?disabled=${params.disabled ?? false}
         .value=${params.value}
         @change=${(event: Event) =>
           params.onChange((event.currentTarget as HTMLSelectElement).value)}

--- a/ui/src/pages/config/talk.ts
+++ b/ui/src/pages/config/talk.ts
@@ -12,6 +12,7 @@ import {
   renderSettingsValue,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
+import { renderSettingsSelectRow } from "./settings-select-row.ts";
 import { isTalkGptLiveModel, type TalkRealtimeSelection } from "./talk-schema.ts";
 
 /** One realtime provider row from talk.catalog, reduced to what the pickers use. */
@@ -120,38 +121,6 @@ export function effectiveTalkValues(
     speakerVoice ??= entry?.speakerVoice ?? null;
   }
   return { model, speakerVoice };
-}
-
-function renderTalkSelectRow(params: {
-  title: string;
-  description?: string;
-  value: string;
-  options: ReadonlyArray<{ value: string; label: string }>;
-  disabled: boolean;
-  onChange: (value: string) => void;
-}) {
-  return renderSettingsRow({
-    title: params.title,
-    description: params.description,
-    control: html`
-      <select
-        class="settings-select"
-        aria-label=${params.title}
-        ?disabled=${params.disabled}
-        .value=${params.value}
-        @change=${(event: Event) =>
-          params.onChange((event.currentTarget as HTMLSelectElement).value)}
-      >
-        ${params.options.map(
-          (option) => html`
-            <option value=${option.value} ?selected=${params.value === option.value}>
-              ${option.label}
-            </option>
-          `,
-        )}
-      </select>
-    `,
-  });
 }
 
 function renderStatusRow(props: TalkViewProps) {
@@ -271,7 +240,7 @@ function renderVoiceRow(props: TalkViewProps) {
     ...voices.map((value) => ({ value, label: value })),
     ...(voice && !voices.includes(voice) ? [{ value: voice, label: voice }] : []),
   ];
-  return renderTalkSelectRow({
+  return renderSettingsSelectRow({
     title: t("talkPage.voice.title"),
     description: t("talkPage.voice.description"),
     value: voice ?? TALK_PICKER_UNSET,

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -567,6 +567,14 @@ wa-switch.settings-toggle {
   text-align: center;
 }
 
+/* Time inputs hold HH:MM; the shared 340px text width would stretch the paired
+   quiet-hours window into two bars. */
+.settings-row:not(.settings-row--stacked)
+  .settings-row__control
+  > input[type="time"].settings-input {
+  width: auto;
+}
+
 /* ── Secret input (inset reveal toggle; no trailing button) ── */
 
 /* Stacked rows (config form arrays/maps) give the control full width; the


### PR DESCRIPTION
## What Problem This Solves

Settings > Notifications rendered bare `<select>`, `<input>`, and native checkbox elements, so the page showed the browser's stock light-gray widgets inside the dark settings surface, and none of the controls carried an accessible name (row titles are plain text, not labels).

## Why This Change Was Made

Every other settings page goes through the shared settings control set from `ui/docs/design-system/settings-design.md` (`renderSettingsToggleRow`, `.settings-select`, `.settings-input`). The Notifications page was the only surface bypassing it. This moves the page onto the canonical helpers, generalizes `renderSettingsSelectRow` (optional e2e hook, `disabled`) so Talk's private duplicate can be deleted, and folds the copy-pasted quiet-hours window and agent-list rows into two small helpers. One CSS rule keeps time inputs at intrinsic width so the paired quiet-hours window does not become two 340px bars.

## User Impact

Notifications controls now look and behave like every other settings page: switch toggles for booleans, themed selects, shared input widths, and accessible names on every control. Preference values and save behavior are unchanged.

Production LOC: +173/-281 (net -108) | Tests: +80/-0

## Evidence

- New regression test in `ui/src/pages/config/notifications-section.test.ts` asserts the invariant (no native checkboxes, every select/input carries the shared class and an `aria-label`, toggle and select rows patch device preferences). It failed on the pre-fix code for that reason and passes now.
- `node scripts/run-vitest.mjs ui/src/pages/config` — 18 files, 242 tests green.
- `node scripts/run-vitest.mjs ui/src/e2e/settings-layout.e2e.test.ts` — green across all viewports.
- `node scripts/check-changed.mjs -- <touched files>` — green (one shrink-only assertion-safety baseline entry pruned for the deleted Talk helper).
- Codex autoreview on the diff: no findings.

Before / after (mocked dev server, fixture data only, dark theme):

| Before | After |
| --- | --- |
| ![Notifications settings before: native selects and checkboxes](https://github.com/user-attachments/assets/a93c55ae-27b7-4181-8793-4b0abdadabdb) | ![Notifications settings after: shared toggles, selects, inputs](https://github.com/user-attachments/assets/04f58b54-9f16-494e-97d4-2fd40c9859bd) |

Screenshots come from the real page through the real web-push reconcile path against the mock gateway (browser Push API stubbed in Playwright, `push.web.*` answered through the mock's method-response overrides).
