### PR TITLE
fix(ui): keep format-constrained settings editable in Form mode

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -921,7 +921,7 @@ function buildConfigMocks(options: { swarmEnabled?: boolean; workboardEnabled?: 
   const config = {
     logging: { level: "info", consoleTimestamps: true },
     messages: { queueLimit: 5, responsePrefix: "" },
-    gateway: { port: 18789, bind: "127.0.0.1" },
+    gateway: { port: 18789, bind: "127.0.0.1", publicOrigin: "https://gateway.example" },
     agents: { defaults: { thinkingDefault: "medium" } },
     commands: { native: "auto", nativeSkills: "auto" },
     models: { mode: "merge" },
@@ -1041,6 +1041,9 @@ function buildConfigMocks(options: { swarmEnabled?: boolean; workboardEnabled?: 
         properties: {
           port: { type: "integer", title: "Port", minimum: 1, maximum: 65535 },
           bind: { type: "string", title: "Bind address" },
+          // Zod's .url() emits `format`; keep one such leaf in the fixture so the
+          // form stays provably editable for plugin URL/email settings.
+          publicOrigin: { type: "string", title: "Public origin", format: "uri" },
         },
       },
       agents: {

--- a/ui/src/components/config-form-integrity.browser.test.ts
+++ b/ui/src/components/config-form-integrity.browser.test.ts
@@ -41,6 +41,11 @@ describe("config form integrity", () => {
               type: "string",
               minLength: 3,
             },
+            relayUrl: {
+              type: "string",
+              description: "Relay origin.",
+              format: "uri",
+            },
             explicitEmpty: {
               type: "string",
               minLength: 0,
@@ -85,6 +90,9 @@ describe("config form integrity", () => {
         },
       },
     });
+    // Zod emits `format` for .url()/.email(); the form must keep those fields
+    // editable instead of forcing the whole section into Raw mode.
+    expect(analysis.unsupportedPaths).toEqual([]);
     render(
       renderConfigForm({
         schema: analysis.schema,
@@ -94,6 +102,7 @@ describe("config form integrity", () => {
           laboratory: {
             endpoint: "local-api",
             optionalAlias: "main",
+            relayUrl: "https://relay.example",
             explicitEmpty: "present",
             glyph: "a",
             codes: [],
@@ -141,6 +150,19 @@ describe("config form integrity", () => {
     endpoint.value = "";
     endpoint.dispatchEvent(new Event("input", { bubbles: true }));
     expect(endpoint.getAttribute("aria-invalid")).toBe("true");
+
+    const relayUrl = expectElement(
+      container.querySelector<HTMLInputElement>("input[aria-label='Relay Url']"),
+      "format-constrained string",
+    );
+    relayUrl.value = "relay.example";
+    relayUrl.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(relayUrl.getAttribute("aria-invalid")).toBe("true");
+    expect(onPatch).not.toHaveBeenCalledWith(["laboratory", "relayUrl"], "relay.example");
+    relayUrl.value = "https://relay.example/";
+    relayUrl.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(relayUrl.getAttribute("aria-invalid")).toBe("false");
+    expect(onPatch).toHaveBeenCalledWith(["laboratory", "relayUrl"], "https://relay.example/");
 
     const optionalAlias = expectElement(
       container.querySelector<HTMLInputElement>("input[aria-label='Optional Alias']"),

--- a/ui/src/components/config-form.analyze.ts
+++ b/ui/src/components/config-form.analyze.ts
@@ -46,6 +46,10 @@ const SUPPORTED_CONSTRAINT_ONLY_KEYS = new Set([
   "minLength",
   "maxLength",
   "pattern",
+  // Zod emits `format` for .url()/.email(); isJsonSchemaValueValid enforces the
+  // formats TypeBox knows and admits unknown ones, so the field stays editable
+  // instead of pushing every plugin URL/email setting into Raw mode.
+  "format",
   "minItems",
   "maxItems",
   "uniqueItems",


### PR DESCRIPTION
## What Problem This Solves

The Settings form showed "2 settings in this config can only be edited as text: channels.reef.relayUrl, channels.reef.email" and pushed those fields into the Raw editor. Without a raw editor the row dead-ends as "Unsupported schema node. Use Raw mode." It was not Reef-specific: the shipped channel schemas carry 23 `format: "uri"` fields and one `format: "email"` (Signal, Nostr, MS Teams, Feishu, ClickClack, Buzz, A2A, voice-call, ...), plus `gateway.publicOrigin` in core, and every one of them was form-uneditable.

## Why This Change Was Made

`ui/src/components/config-form.analyze.ts` fails closed on any JSON Schema keyword it does not list, so the form can never render a control that silently drops a constraint (#116282). Zod serializes `.url()` and `z.email()` as `format: "uri"` / `format: "email"`, and `format` was never on that list. Nothing else needs to change: the shared value validator (`isJsonSchemaValueValid`, TypeBox `Check`) already enforces the formats TypeBox knows and admits unknown ones, and the Gateway re-validates every write with the owning Zod schema. So the fix is admitting `format` as a constraint keyword, with an inline comment naming who enforces it. The mock dev server gains a `gateway.publicOrigin` leaf mirroring core so this class stays visually provable in the mock.

## User Impact

Plugin URL and email settings (and `gateway.publicOrigin`) render as normal inputs in Form mode, on both the Settings sections and the Channels config panels, with inline validation for invalid URLs/addresses. Reef's origin-only `pattern` still applies on top. No config values or write semantics change.

Production LOC: +4/-0 (net 4, one keyword plus a three-line comment) | Test support (mock fixture): +4/-1 | Tests: +22/-0

## Evidence

- Extended the existing constraints fixture in `ui/src/components/config-form-integrity.browser.test.ts` with a `format: "uri"` field. Pre-fix it failed with `expected [ 'laboratory.relayUrl' ] to deeply equal []`; post-fix it passes, including the invalid-URL (`aria-invalid="true"`, no patch) and valid-URL (patched) assertions in real Chromium.
- All 14 `ui/src/components/config-form*.test.ts` suites green (5 node + 9 browser, 155 tests).
- `node scripts/run-vitest.mjs ui/src/e2e/settings-layout.e2e.test.ts` green against the changed mock fixture.
- `node scripts/check-changed.mjs` green for the UI files and for `scripts/control-ui-mock-dev.ts` (scripts lane).
- Codex autoreview on the diff: no findings.
- Validator behavior probed directly: `{type:"string",format:"uri"}` rejects `not a url`, accepts `https://reefwire.ai`; `format:"email"` rejects `nope`, accepts `a@b.co`; unknown `format:"jwt"` admits (server validation owns it).

Before / after on the mocked dev server (`/settings/infrastructure`, Advanced settings expanded, `gateway.publicOrigin` fixture):

| Before | After |
| --- | --- |
| ![Public origin row dead-ends: Unsupported schema node. Use Raw mode.](https://github.com/user-attachments/assets/8db5156f-ff9e-4f13-b85e-6f2d04508f26) | ![Public origin renders as an editable, URL-validated input](https://github.com/user-attachments/assets/59f483c9-d29f-4067-af2c-d91fec68b2d1) |
