### PR TITLE
fix(gateway): correctly classify same-install CLI nodes

### DIFF
--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -263,6 +263,11 @@ when set):
 | `state/openclaw.sqlite` (`device_identities`, `primary`)                | Signed Ed25519 keypair and derived device ID. For signed connections, this device ID is the routed node ID and pairing identity. |
 | `state/openclaw.sqlite` (`device_auth_tokens`)                          | Paired device tokens, keyed by cryptographic device ID and role.                                                                 |
 
+`gatewayLocal` in `node.list` and `node.describe` marks an exact match with the
+primary device identity in the Gateway's state directory. Overriding `--node-id`
+does not change it. A node with its own state directory and key is separate, even
+on the same machine. Listing or describing nodes does not create identity credentials.
+
 `--node-id` changes only the client instance ID in shared SQLite state. It does
 not change the cryptographic device ID or clear pairing auth. Migrating a retired
 `node.json` with `openclaw doctor --fix` likewise does not reset pairing. To

--- a/src/gateway/server.node-version-mismatch.test.ts
+++ b/src/gateway/server.node-version-mismatch.test.ts
@@ -1,17 +1,25 @@
-// Node version mismatch tests protect local node identity/version checks so the
-// gateway accepts matching node hosts and rejects incompatible local runtimes.
+// Real signed node connects protect same-install classification and version admission.
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
-import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
+import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
+import { ErrorCodes, PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
+import {
+  loadOrCreateDeviceIdentity,
+  publicKeyRawBase64UrlFromPem,
+  type DeviceIdentity,
+} from "../infra/device-identity.js";
+import { approveDevicePairing } from "../infra/device-pairing-approval.js";
 import {
   approveNodePairing,
   listNodePairing,
   requestNodePairing,
 } from "../infra/device-pairing-node.js";
+import { requestDevicePairing } from "../infra/device-pairing.js";
 import { configureNodeHost } from "../node-host/config.js";
+import type { NodeListNode } from "../shared/node-list-types.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
-import { pairDeviceIdentity } from "./device-authz.test-helpers.js";
 import { connectGatewayClient } from "./test-helpers.e2e.js";
 import { installGatewayTestHooks, startServer } from "./test-helpers.js";
 
@@ -19,19 +27,62 @@ installGatewayTestHooks({ scope: "suite" });
 
 const gatewayVersion = resolveRuntimeServiceVersion(process.env);
 
-const TEST_LOCAL_NODE_ID = "test-local-node-version-mismatch";
-
 describe("node host version mismatch guard", () => {
   let port: number;
   let server: Awaited<ReturnType<typeof startServer>>["server"];
+  let localIdentity: DeviceIdentity;
+  let instanceId: string;
+
+  async function pairNode(identity: DeviceIdentity) {
+    const request = await requestDevicePairing({
+      deviceId: identity.deviceId,
+      publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+      role: "node",
+      scopes: [],
+      clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+      clientMode: GATEWAY_CLIENT_MODES.NODE,
+      platform: "macos",
+      deviceFamily: "Mac",
+    });
+    const approved = await approveDevicePairing(request.request.requestId, { callerScopes: [] });
+    expect(approved?.status).toBe("approved");
+    const surface = await requestNodePairing({
+      nodeId: identity.deviceId,
+      platform: "macos",
+      deviceFamily: "Mac",
+      commands: [],
+    });
+    const node = await approveNodePairing(surface.request.requestId, {
+      callerScopes: ["operator.pairing", "operator.write"],
+    });
+    expect(node && "node" in node).toBe(true);
+  }
+
+  function connectNode(overrides: Partial<Parameters<typeof connectGatewayClient>[0]> = {}) {
+    return connectGatewayClient({
+      url: `ws://127.0.0.1:${port}`,
+      token: "secret",
+      role: "node",
+      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
+      clientDisplayName: "test-node",
+      clientVersion: gatewayVersion,
+      instanceId,
+      platform: "macos",
+      deviceFamily: "Mac",
+      mode: GATEWAY_CLIENT_MODES.NODE,
+      scopes: [],
+      commands: [],
+      deviceIdentity: localIdentity,
+      ...overrides,
+    });
+  }
 
   beforeAll(async () => {
-    await configureNodeHost({
-      nodeId: TEST_LOCAL_NODE_ID,
-      displayName: "test-local-node",
-      fallbackDisplayName: "test-local-node",
-      gateway: {},
-    });
+    const config = await configureNodeHost({ fallbackDisplayName: "test-node", gateway: {} });
+    instanceId = config.nodeId;
+    localIdentity = loadOrCreateDeviceIdentity();
+    expect(instanceId).not.toBe(localIdentity.deviceId);
+    await pairNode(localIdentity);
     const started = await startServer("secret");
     port = started.port;
     server = started.server;
@@ -41,59 +92,137 @@ describe("node host version mismatch guard", () => {
     await server?.close();
   });
 
-  test("local node with matching released version connects successfully", async () => {
-    // Use the actual gateway version so versions match
-    let helloProtocol: number | undefined;
-    const client = await connectGatewayClient({
-      url: `ws://127.0.0.1:${port}`,
-      token: "secret",
-      role: "node",
-      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
-      clientDisplayName: "test-node-match",
-      clientVersion: gatewayVersion,
-      instanceId: TEST_LOCAL_NODE_ID,
-      mode: GATEWAY_CLIENT_MODES.NODE,
-      scopes: [],
-      commands: [],
-      onHelloOk: (hello) => {
-        helloProtocol = hello.protocol;
-      },
-    });
-    expect(client).toBeDefined();
-    expect(helloProtocol).toBe(PROTOCOL_VERSION);
-    await client.stopAndWait({ timeoutMs: 2_000 });
-  });
+  test.each([gatewayVersion, "dev", "1.0.0"])(
+    "same-install node with accepted version %s connects",
+    async (clientVersion) => {
+      let helloProtocol: number | undefined;
+      const client = await connectNode({
+        clientVersion,
+        onHelloOk: (hello) => {
+          helloProtocol = hello.protocol;
+        },
+      });
+      try {
+        expect(helloProtocol).toBe(PROTOCOL_VERSION);
+      } finally {
+        await client.stopAndWait({ timeoutMs: 2_000 });
+      }
+    },
+  );
 
-  test("local node with mismatched released version is rejected", async () => {
-    const staleVersion = "2020.1.1";
-    await expect(
-      connectGatewayClient({
+  test.each(["default", "different", "omitted"])(
+    "same-install stale node is rejected with %s instanceId",
+    async (instance) => {
+      const onHelloOk = vi.fn();
+      await expect(
+        connectNode({
+          clientVersion: "2020.1.1",
+          instanceId:
+            instance === "default"
+              ? instanceId
+              : instance === "different"
+                ? "different-instance"
+                : undefined,
+          onHelloOk,
+          timeoutMs: 5_000,
+          timeoutMessage: "expected version mismatch rejection",
+        }).then(async (client) => {
+          await client.stopAndWait({ timeoutMs: 2_000 });
+          return "connected";
+        }),
+      ).rejects.toMatchObject({
+        code: ErrorCodes.INVALID_REQUEST,
+        message: "client version mismatch",
+        details: {
+          code: ConnectErrorDetailCodes.CLIENT_VERSION_MISMATCH,
+          clientVersion: "2020.1.1",
+          gatewayVersion,
+        },
+      });
+      expect(onHelloOk).not.toHaveBeenCalled();
+    },
+  );
+
+  test("list and describe mark only the same-install device despite copied instance metadata", async () => {
+    const independent = await createOpenClawTestState({
+      label: "node-independent",
+      applyEnv: false,
+    });
+    const clients: Awaited<ReturnType<typeof connectGatewayClient>>[] = [];
+    try {
+      const identity = loadOrCreateDeviceIdentity({ env: independent.env });
+      expect(identity.deviceId).not.toBe(localIdentity.deviceId);
+      await pairNode(identity);
+      clients.push(await connectNode());
+      clients.push(await connectNode({ deviceIdentity: identity }));
+      const operator = await connectGatewayClient({
         url: `ws://127.0.0.1:${port}`,
         token: "secret",
-        role: "node",
-        clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
-        clientDisplayName: "test-node-stale",
-        clientVersion: staleVersion,
-        instanceId: TEST_LOCAL_NODE_ID,
-        mode: GATEWAY_CLIENT_MODES.NODE,
-        scopes: [],
-        commands: [],
-        timeoutMs: 5_000,
-        timeoutMessage: "expected version mismatch rejection",
-      }),
-    ).rejects.toThrow(/client version mismatch|version mismatch/i);
+        scopes: ["operator.read"],
+      });
+      clients.push(operator);
+      const list = await operator.request<{ nodes: NodeListNode[] }>("node.list", {});
+      expect(list.nodes.filter((node) => node.gatewayLocal)).toEqual([
+        expect.objectContaining({
+          nodeId: localIdentity.deviceId,
+          gatewayLocal: true,
+          paired: true,
+          connected: true,
+        }),
+      ]);
+      const remote = list.nodes.find((node) => node.nodeId === identity.deviceId);
+      expect(remote).toMatchObject({ paired: true, connected: true, displayName: "test-node" });
+      expect(remote).not.toHaveProperty("gatewayLocal");
+      await expect(
+        operator.request("node.describe", { nodeId: localIdentity.deviceId }),
+      ).resolves.toMatchObject({
+        nodeId: localIdentity.deviceId,
+        gatewayLocal: true,
+        paired: true,
+        connected: true,
+      });
+      const described = await operator.request("node.describe", { nodeId: identity.deviceId });
+      expect(described).toMatchObject({ nodeId: identity.deviceId, paired: true, connected: true });
+      expect(described).not.toHaveProperty("gatewayLocal");
+    } finally {
+      try {
+        await Promise.all(clients.map((client) => client.stopAndWait({ timeoutMs: 2_000 })));
+      } finally {
+        await independent.cleanup();
+      }
+    }
+  });
+
+  test("independently paired stale node connects with the same-install instanceId", async () => {
+    const independent = await createOpenClawTestState({
+      label: "node-independent-stale",
+      applyEnv: false,
+    });
+    let client: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+    try {
+      const identity = loadOrCreateDeviceIdentity({ env: independent.env });
+      await pairNode(identity);
+      const onHelloOk = vi.fn();
+      client = await connectNode({
+        deviceIdentity: identity,
+        clientVersion: "2020.1.1",
+        onHelloOk,
+      });
+      expect(onHelloOk).toHaveBeenCalledWith(
+        expect.objectContaining({ protocol: PROTOCOL_VERSION }),
+      );
+    } finally {
+      try {
+        await client?.stopAndWait({ timeoutMs: 2_000 });
+      } finally {
+        await independent.cleanup();
+      }
+    }
   });
 
   test("rejected local reconnects preserve the active node pending reapproval", async () => {
-    const pairedNode = await pairDeviceIdentity({
-      name: "node-version-mismatch-pending-reapproval",
-      role: "node",
-      scopes: [],
-      clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
-      clientMode: GATEWAY_CLIENT_MODES.NODE,
-    });
     const initial = await requestNodePairing({
-      nodeId: pairedNode.identity.deviceId,
+      nodeId: localIdentity.deviceId,
       platform: "macos",
       deviceFamily: "Mac",
       commands: ["screen.snapshot"],
@@ -102,42 +231,22 @@ describe("node host version mismatch guard", () => {
       callerScopes: ["operator.pairing", "operator.write"],
     });
 
-    const upgraded = await connectGatewayClient({
-      url: `ws://127.0.0.1:${port}`,
-      token: "secret",
-      role: "node",
-      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
-      clientDisplayName: "test-node-upgraded",
-      clientVersion: gatewayVersion,
-      instanceId: TEST_LOCAL_NODE_ID,
-      platform: "macos",
-      deviceFamily: "Mac",
-      mode: GATEWAY_CLIENT_MODES.NODE,
-      scopes: [],
-      commands: ["screen.snapshot", "system.run"],
-      deviceIdentity: pairedNode.identity,
-    });
+    const upgraded = await connectNode({ commands: ["screen.snapshot", "system.run"] });
     try {
       const connectReverted = async (clientVersion: string, clientDisplayName: string) =>
-        await connectGatewayClient({
-          url: `ws://127.0.0.1:${port}`,
-          token: "secret",
-          role: "node",
-          clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
+        await connectNode({
           clientDisplayName,
           clientVersion,
-          instanceId: TEST_LOCAL_NODE_ID,
-          platform: "macos",
-          deviceFamily: "Mac",
-          mode: GATEWAY_CLIENT_MODES.NODE,
-          scopes: [],
+          instanceId: "reconnect-instance-override",
           commands: ["screen.snapshot"],
-          deviceIdentity: pairedNode.identity,
           timeoutMs: 5_000,
           timeoutMessage: "expected rejected reconnect",
+        }).then(async (client) => {
+          await client.stopAndWait({ timeoutMs: 2_000 });
+          return "connected";
         });
       const pendingBefore = (await listNodePairing()).pending.find(
-        (entry) => entry.nodeId === pairedNode.identity.deviceId,
+        (entry) => entry.nodeId === localIdentity.deviceId,
       );
       expect(pendingBefore?.commands).toEqual(["screen.snapshot", "system.run"]);
 
@@ -146,7 +255,7 @@ describe("node host version mismatch guard", () => {
       );
 
       const pendingAfterVersionMismatch = (await listNodePairing()).pending.find(
-        (entry) => entry.nodeId === pairedNode.identity.deviceId,
+        (entry) => entry.nodeId === localIdentity.deviceId,
       );
       expect(pendingAfterVersionMismatch?.requestId).toBe(pendingBefore?.requestId);
       expect(pendingAfterVersionMismatch?.commands).toEqual(["screen.snapshot", "system.run"]);
@@ -177,45 +286,12 @@ describe("node host version mismatch guard", () => {
       }
 
       const pendingAfterHelloFailure = (await listNodePairing()).pending.find(
-        (entry) => entry.nodeId === pairedNode.identity.deviceId,
+        (entry) => entry.nodeId === localIdentity.deviceId,
       );
       expect(pendingAfterHelloFailure?.requestId).toBe(pendingBefore?.requestId);
       expect(pendingAfterHelloFailure?.commands).toEqual(["screen.snapshot", "system.run"]);
     } finally {
       await upgraded.stopAndWait({ timeoutMs: 2_000 });
     }
-  });
-
-  test("local node with dev/test version is allowed (not a released version)", async () => {
-    // "dev" does not match YYYY.M.PATCH, so the guard skips
-    const client = await connectGatewayClient({
-      url: `ws://127.0.0.1:${port}`,
-      token: "secret",
-      role: "node",
-      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
-      clientDisplayName: "test-node-dev",
-      clientVersion: "dev",
-      mode: GATEWAY_CLIENT_MODES.NODE,
-      scopes: [],
-      commands: [],
-    });
-    expect(client).toBeDefined();
-    await client.stopAndWait({ timeoutMs: 2_000 });
-  });
-
-  test("local node with non-date version '1.0.0' is allowed", async () => {
-    const client = await connectGatewayClient({
-      url: `ws://127.0.0.1:${port}`,
-      token: "secret",
-      role: "node",
-      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
-      clientDisplayName: "test-node-semver",
-      clientVersion: "1.0.0",
-      mode: GATEWAY_CLIENT_MODES.NODE,
-      scopes: [],
-      commands: [],
-    });
-    expect(client).toBeDefined();
-    await client.stopAndWait({ timeoutMs: 2_000 });
   });
 });

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -470,15 +470,12 @@ export async function attachAuthenticatedGatewayConnect(
     });
   }
 
-  // Version mismatch: kick the local node host so the OS supervisor restarts it.
-  // Only applies when the connecting node is the same-install local node (verified by
-  // matching instanceId against the local node-host config row). SSH-tunneled remote
-  // nodes also appear as loopback but have different instanceIds, so they are exempt.
-  // Placed before setClient/presence to avoid phantom online state on rejection.
+  // Only an exact cryptographic device match proves the same install; independent
+  // SSH-tunneled or separate-state nodes are exempt even when they appear local.
+  // Reject before registration/presence so supervisor restarts leave no phantom online state.
   if (role === "node" && isLocalClient) {
     const localNodeId = await resolveLocalNodeId();
-    const clientInstanceId = connectParams.client.instanceId?.trim();
-    if (localNodeId && clientInstanceId && clientInstanceId === localNodeId) {
+    if (localNodeId && device?.id === localNodeId) {
       const gatewayVersion = resolveRuntimeServiceVersion(process.env);
       const clientVersion = connectParams.client.version;
       if (

--- a/src/node-host/local-id.test.ts
+++ b/src/node-host/local-id.test.ts
@@ -1,5 +1,9 @@
 import fs from "node:fs/promises";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  loadDeviceIdentityIfPresent,
+  loadOrCreateDeviceIdentity,
+} from "../infra/device-identity.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   createOpenClawTestState,
@@ -10,6 +14,12 @@ import { resolveLocalNodeId } from "./local-id.js";
 
 const states: OpenClawTestState[] = [];
 
+async function createState(label: string) {
+  const state = await createOpenClawTestState({ label, layout: "state-only", applyEnv: false });
+  states.push(state);
+  return state;
+}
+
 afterEach(async () => {
   closeOpenClawStateDatabaseForTest();
   while (states.length > 0) {
@@ -18,51 +28,64 @@ afterEach(async () => {
 });
 
 describe("resolveLocalNodeId", () => {
-  it("reads and process-caches the canonical same-install node id", async () => {
-    const state = await createOpenClawTestState({
-      label: "local-node-id",
-      layout: "state-only",
-    });
-    states.push(state);
-    await configureNodeHost({
-      candidateNodeId: "gateway-local-node",
+  it("uses the primary device identity, not the default runner UUID or instance override", async () => {
+    const state = await createState("local-node-id");
+    const config = await configureNodeHost({
       fallbackDisplayName: "Gateway node",
       gateway: {},
       env: state.env,
-      nowMs: 1,
     });
-
-    await expect(resolveLocalNodeId(state.env)).resolves.toBe("gateway-local-node");
+    const identity = loadOrCreateDeviceIdentity({ env: state.env });
+    expect(config.nodeId).not.toBe(identity.deviceId);
+    await expect(resolveLocalNodeId(state.env)).resolves.toBe(identity.deviceId);
 
     await configureNodeHost({
-      candidateNodeId: "replacement-node",
-      fallbackDisplayName: "Replacement node",
+      nodeId: "replacement-instance",
+      fallbackDisplayName: "Gateway node",
       gateway: {},
       env: state.env,
-      nowMs: 2,
     });
-    await expect(resolveLocalNodeId(state.env)).resolves.toBe("gateway-local-node");
+    await expect(resolveLocalNodeId(state.env)).resolves.toBe(identity.deviceId);
+
+    // Once discovered, the same-install identity stays stable until process restart.
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(state.statePath("state"), { recursive: true });
+    expect(loadDeviceIdentityIfPresent({ env: state.env })).toBeNull();
+    await expect(resolveLocalNodeId(state.env)).resolves.toBe(identity.deviceId);
   });
 
-  it("retries after a failed canonical config read", async () => {
-    const state = await createOpenClawTestState({
-      label: "local-node-id-retry",
-      layout: "state-only",
-    });
-    states.push(state);
-    const legacyPath = state.statePath("node.json");
-    await fs.writeFile(legacyPath, "{}\n", "utf8");
+  it("does not create credentials on a miss and discovers an identity created later", async () => {
+    const state = await createState("local-node-id-missing");
+    await expect(resolveLocalNodeId(state.env)).resolves.toBeNull();
+    expect(await fs.readdir(state.stateDir)).toEqual([]);
 
+    await configureNodeHost({ fallbackDisplayName: "Gateway node", gateway: {}, env: state.env });
+    await expect(resolveLocalNodeId(state.env)).resolves.toBeNull();
+    expect(loadDeviceIdentityIfPresent({ env: state.env })).toBeNull();
+
+    const identity = loadOrCreateDeviceIdentity({ env: state.env });
+    await expect(resolveLocalNodeId(state.env)).resolves.toBe(identity.deviceId);
+  });
+
+  it("keeps independently created state-directory identities separate", async () => {
+    const gateway = await createState("local-node-id-gateway");
+    const independent = await createState("local-node-id-independent");
+    const gatewayIdentity = loadOrCreateDeviceIdentity({ env: gateway.env });
+    const independentIdentity = loadOrCreateDeviceIdentity({ env: independent.env });
+    expect(independentIdentity.deviceId).not.toBe(gatewayIdentity.deviceId);
+
+    await expect(resolveLocalNodeId(gateway.env)).resolves.toBe(gatewayIdentity.deviceId);
+    await expect(resolveLocalNodeId(independent.env)).resolves.toBe(independentIdentity.deviceId);
+    await expect(resolveLocalNodeId(gateway.env)).resolves.toBe(gatewayIdentity.deviceId);
+  });
+
+  it("retries after a failed canonical identity read", async () => {
+    const state = await createState("local-node-id-retry");
+    const legacyPath = await state.writeText("identity/device.json", "{}\n");
     await expect(resolveLocalNodeId(state.env)).rejects.toThrow("openclaw doctor --fix");
 
     await fs.rm(legacyPath);
-    await configureNodeHost({
-      candidateNodeId: "recovered-local-node",
-      fallbackDisplayName: "Recovered node",
-      gateway: {},
-      env: state.env,
-      nowMs: 1,
-    });
-    await expect(resolveLocalNodeId(state.env)).resolves.toBe("recovered-local-node");
+    const identity = loadOrCreateDeviceIdentity({ env: state.env });
+    await expect(resolveLocalNodeId(state.env)).resolves.toBe(identity.deviceId);
   });
 });

--- a/src/node-host/local-id.ts
+++ b/src/node-host/local-id.ts
@@ -1,21 +1,21 @@
 import { resolveStateDir } from "../config/paths.js";
-import { getOrCreatePromise } from "../shared/lazy-promise.js";
-import { loadNodeHostConfig } from "./config.js";
+import { loadDeviceIdentityIfPresent } from "../infra/device-identity.js";
 
-const localNodeIdByStateDir = new Map<string, Promise<string | null>>();
+const localNodeIdByStateDir = new Map<string, string>();
 
-/**
- * Resolve the same-install node host from canonical shared SQLite state.
- * Node-host config changes require restart, so this fact stays process-stable.
- */
+// Keep successful primary identity reads process-stable, without creating credentials.
+// Misses remain retryable because a node may create its identity after Gateway startup.
 export async function resolveLocalNodeId(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string | null> {
   const stateDir = resolveStateDir(env);
-  return await getOrCreatePromise(
-    localNodeIdByStateDir,
-    stateDir,
-    async () => (await loadNodeHostConfig(env))?.nodeId ?? null,
-    { cacheRejections: false },
-  );
+  const cached = localNodeIdByStateDir.get(stateDir);
+  if (cached) {
+    return cached;
+  }
+  const nodeId = loadDeviceIdentityIfPresent({ env })?.deviceId ?? null;
+  if (nodeId) {
+    localNodeIdByStateDir.set(stateDir, nodeId);
+  }
+  return nodeId;
 }


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/136593

<details>
<summary>Additional instructions</summary>

This branch is in the canonical repository and remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where a default CLI node running from the Gateway's own OpenClaw state directory would not receive `gatewayLocal: true` in `node.list` or `node.describe`. Native-session catalog consumers therefore could not apply their existing same-install exclusion.

The same identity-domain confusion also affected the local node version guard: changing or omitting an instance ID bypassed same-install enforcement, while a separately paired node with copied instance metadata could be rejected incorrectly.

## Why This Change Was Made

The node-host configuration ID is a client instance UUID, not the cryptographic device ID used for pairing and registry routing. The shared resolver now uses the existing read-only primary device-identity API, and its version-guard caller compares authenticated `device.id`. Successful identities remain process-cached; misses and errors remain retryable, so an early lookup does not permanently hide an identity created later.

This is an owner-boundary repair: it removes the incorrect configuration lookup and unnecessary promise-cache path rather than adding downstream filters. It preserves the version guard's locality eligibility, released-version checks, error contract, pre-registration rejection ordering, and pending-reapproval cleanup. No hostname/IP identity inference, credential creation, configuration options, schemas, migrations, or pairing-storage changes are introduced.

Related prior work: https://github.com/openclaw/openclaw/pull/123165 fixed list/describe projection parity. This PR fixes the shared identity source and is separate from the native-terminal creation work tracked in https://github.com/openclaw/openclaw/issues/136068. Native catalog, terminal, and UI production code are unchanged.

## User Impact

Both read RPCs correctly identify a same-install node. An independently created and explicitly paired node with another state directory/key remains independent even on the same machine, over loopback, or with copied instance/display metadata. Existing native-catalog exclusions keep working without globally hiding the node or removing its execution capabilities.

The [Node CLI identity documentation](https://docs.openclaw.ai/cli/node#identity-and-pairing-state) explains the distinction. No operator action or state migration is required beyond running the updated Gateway.

## Evidence

Reproduced on macOS/Darwin 27.0.0 with Node 24.20.0, starting from `7b0fc05505aaa4856ab1e19469c6eb0a5929c3f0`. The strengthened tests were run before editing production code:

| Scenario | Before | After |
| --- | --- | --- |
| Default config UUID versus routed device ID | Resolver returned the UUID | Resolver returns the primary cryptographic device ID |
| Same-install node through list and describe | Missing `gatewayLocal` | `gatewayLocal: true` |
| Independent paired key with copied instance metadata | Marker absent, but stale-version connect incorrectly rejected | Marker absent; independent stale-version connect accepted |
| Stale same-install node with different/omitted instance ID | Incorrectly accepted | Rejected with `CLIENT_VERSION_MISMATCH` |
| Identity created after an initial miss | Cached `null` indefinitely | Later read discovers the identity |

Before: **4 intended identity-owner failures and 5 intended WebSocket failures**. After: **20 selected tests passed** across identity, signed WebSocket/RPC, plugin projection, and both native-catalog consumer boundaries. The WebSocket suite uses an isolated real Gateway server, real SQLite identity and pairing owners, explicit pairing, and signed clients; it does not mock the identity resolver. All test-owned clients, servers, and state were cleaned up. This is hermetic Gateway integration proof, not a deployment or native-UI recording.

```bash
node scripts/run-vitest.mjs src/node-host/local-id.test.ts src/gateway/server.node-version-mismatch.test.ts --reporter=verbose
```

13 passed, including preservation of pending reapproval after version rejection and failed hello delivery.

```bash
node scripts/run-vitest.mjs src/gateway/server-methods/nodes.read.test.ts src/gateway/server-plugins.test.ts --reporter=verbose --testNamePattern 'node read projections|filters connected plugin nodes locally'
```

5 selected tests passed; 84 unrelated cases filtered out.

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/gateway-local-catalog-vitest-cache node scripts/run-vitest.mjs extensions/codex/src/session-catalog-node-listing.test.ts extensions/anthropic/session-catalog.test.ts --testNamePattern 'omits the Gateway|keeps remote nodes while isolated state'
```

Both catalog-exclusion tests passed; 90 unrelated cases filtered out.

```bash
node scripts/check-changed.mjs -- src/node-host/local-id.ts src/node-host/local-id.test.ts src/gateway/server/ws-connection/connect-session.ts src/gateway/server.node-version-mismatch.test.ts docs/cli/node.md
```

Passed formatting, core/test typechecks, lint, dead-export scans, import-cycle checks, and selected repository guards. `pnpm docs:list` and `git diff --check` also passed. Independent Codex autoreview at its default P0 threshold was clean; pre-commit review and exact-head CI are recorded in the landing evidence.

Production LOC: **+17/-20 (net -3)**. Tests: **+248/-149 (net +99)**. Docs: **+5**. No operator state or services were accessed or changed.

### Live built-CLI verification

Verified the published head `4be834b1545d21f1f7fc4e71f775f34823ecd3d3` through real, separately running CLI processes after `pnpm build qaRuntime` passed. A standalone loopback Gateway and two `node run` processes used new synthetic state directories with plugins disabled; no operator state, provider credentials, or managed services were used. Both node command surfaces were approved through the documented `nodes approve` CLI.

The same-install node retained its default randomly generated instance UUID. The independent node used that same instance UUID and display name, but generated and paired its own cryptographic identity in a different state directory. Actual CLI calls to `node.list` and `node.describe` returned:

| Node | Connected and paired | Capability approval | List marker | Describe marker |
| --- | --- | --- | --- | --- |
| Gateway state directory | yes | approved | `gatewayLocal: true` | `gatewayLocal: true` |
| Independent state directory/key | yes | approved | absent | absent |

The primary identity row sets were identical before and after the read calls. All test-owned processes were stopped; no listener or open-file owner remained, and the synthetic state directories were removed. Only this projected result is shared; raw node responses containing local path metadata are not attached. This adds real CLI/Gateway proof to the hermetic WebSocket regressions above; no native UI recording was captured because the changed surface is the identity/RPC boundary, not the native catalog or terminal implementation.
