### PR TITLE
docs(plugins): align npm-first install guidance

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -14,7 +14,7 @@ Matrix is a downloadable channel plugin (`@openclaw/matrix`) built on the offici
 openclaw plugins install @openclaw/matrix
 ```
 
-Bare plugin specs try ClawHub first, then npm fallback. Force a source with `openclaw plugins install clawhub:@openclaw/matrix` or `npm:@openclaw/matrix`. From a local checkout: `openclaw plugins install ./path/to/local/matrix-plugin`.
+`@openclaw/matrix` installs from npm first, then falls back to its declared ClawHub package only when the npm target is unavailable. Use `npm:` or `clawhub:` to force a source. From a local checkout: `openclaw plugins install ./path/to/local/matrix-plugin`.
 
 `plugins install` registers and enables the plugin; no separate `enable` step is needed. The channel still does nothing until configured below. See [Plugins](/tools/plugin) for general install rules.
 

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -20,7 +20,7 @@ Signal is a downloadable channel plugin (`@openclaw/signal`). The gateway talks 
 openclaw plugins install @openclaw/signal
 ```
 
-Bare plugin specs try ClawHub first, then npm fallback. Force a source with `openclaw plugins install clawhub:@openclaw/signal` or `npm:@openclaw/signal`. `plugins install` registers and enables the plugin; no separate `enable` step is needed. See [Plugins](/tools/plugin) for general install rules.
+`@openclaw/signal` installs from npm first, then falls back to its declared ClawHub package only when the npm target is unavailable. Use `npm:` or `clawhub:` to force a source. `plugins install` registers and enables the plugin; no separate `enable` step is needed. See [Plugins](/tools/plugin) for general install rules.
 
 ## Quick setup
 

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -9,13 +9,13 @@ Status: production-ready via WhatsApp Web (Baileys). The gateway owns the linked
 
 ## Install
 
-`openclaw onboard` and `openclaw channels add --channel whatsapp` prompt to install the plugin the first time you select it; `openclaw channels login --channel whatsapp` offers the same install flow if the plugin is missing. Dev checkouts use the local plugin path; stable/beta installs `@openclaw/whatsapp` from ClawHub first, falling back to npm. The WhatsApp runtime ships outside the core OpenClaw npm package, so its runtime dependencies stay with the external plugin. Manual install:
+`openclaw onboard` and `openclaw channels add --channel whatsapp` prompt to install the plugin the first time you select it; `openclaw channels login --channel whatsapp` offers the same install flow if the plugin is missing. Dev checkouts use the local plugin path; stable/beta installs `@openclaw/whatsapp` from npm first, then falls back to its declared ClawHub package only when the npm target is unavailable. The WhatsApp runtime ships outside the core OpenClaw npm package, so its runtime dependencies stay with the external plugin. Manual install:
 
 ```bash
-openclaw plugins install clawhub:@openclaw/whatsapp
+openclaw plugins install @openclaw/whatsapp
 ```
 
-Use the bare npm package (`@openclaw/whatsapp`) only for the registry fallback; pin an exact version only for a reproducible install.
+Use `npm:@openclaw/whatsapp` or `clawhub:@openclaw/whatsapp` to force a source; pin an exact version only for a reproducible install.
 
 <CardGroup cols={3}>
   <Card title="Pairing" icon="link" href="/channels/pairing">

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -266,7 +266,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[longcat](/plugins/reference/longcat)** (`@openclaw/longcat-provider`) - npm; ClawHub: `clawhub:@openclaw/longcat-provider`. OpenClaw LongCat provider plugin.
 
-- **[matrix](/plugins/reference/matrix)** (`@openclaw/matrix`) - ClawHub: `clawhub:@openclaw/matrix`; npm. OpenClaw Matrix channel plugin for rooms and direct messages.
+- **[matrix](/plugins/reference/matrix)** (`@openclaw/matrix`) - npm; ClawHub: `clawhub:@openclaw/matrix`. OpenClaw Matrix channel plugin for rooms and direct messages.
 
 - **[mattermost](/plugins/reference/mattermost)** (`@openclaw/mattermost`) - npm; ClawHub: `clawhub:@openclaw/mattermost`. Adds the Mattermost channel surface for sending and receiving OpenClaw messages.
 
@@ -344,7 +344,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[vydra](/plugins/reference/vydra)** (`@openclaw/vydra-provider`) - npm; ClawHub: `clawhub:@openclaw/vydra-provider`. Adds Vydra model provider support to OpenClaw.
 
-- **[whatsapp](/plugins/reference/whatsapp)** (`@openclaw/whatsapp`) - ClawHub: `clawhub:@openclaw/whatsapp`; npm. OpenClaw WhatsApp channel plugin for WhatsApp Web chats.
+- **[whatsapp](/plugins/reference/whatsapp)** (`@openclaw/whatsapp`) - npm; ClawHub: `clawhub:@openclaw/whatsapp`. OpenClaw WhatsApp channel plugin for WhatsApp Web chats.
 
 - **[xiaomi](/plugins/reference/xiaomi)** (`@openclaw/xiaomi-provider`) - npm; ClawHub: `clawhub:@openclaw/xiaomi-provider`. Adds Xiaomi, Xiaomi Token Plan model provider support to OpenClaw.
 

--- a/docs/plugins/reference/matrix.md
+++ b/docs/plugins/reference/matrix.md
@@ -12,7 +12,7 @@ OpenClaw Matrix channel plugin for rooms and direct messages.
 ## Distribution
 
 - Package: `@openclaw/matrix`
-- Install route: ClawHub: `clawhub:@openclaw/matrix`; npm
+- Install route: npm; ClawHub: `clawhub:@openclaw/matrix`
 
 ## Surface
 

--- a/docs/plugins/reference/whatsapp.md
+++ b/docs/plugins/reference/whatsapp.md
@@ -12,7 +12,7 @@ OpenClaw WhatsApp channel plugin for WhatsApp Web chats.
 ## Distribution
 
 - Package: `@openclaw/whatsapp`
-- Install route: ClawHub: `clawhub:@openclaw/whatsapp`; npm
+- Install route: npm; ClawHub: `clawhub:@openclaw/whatsapp`
 
 ## Surface
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where generated plugin inventory pages and the Matrix, WhatsApp, and Signal channel guides contradicted the npm-first plugin install route by presenting ClawHub as the default source.

## Why This Change Was Made

Regenerates the canonical plugin inventory and reference pages from current plugin metadata, then aligns the authored channel guides with package-specific npm-first resolution and the declared ClawHub fallback. `npm:` and `clawhub:` remain available as explicit source overrides. No runtime behavior or source metadata changes.

## User Impact

Operators now get consistent npm-first installation guidance across the plugin inventory and channel setup pages, including the correct bare-package manual install command for WhatsApp.

## Evidence

- `pnpm docs:list`
- `pnpm plugins:inventory:check`
- `pnpm check:docs`
- `pnpm check:changed`
- `git diff --check`
- Cumulative scope: 6 docs, +9/-9; production/tests: 0
- Autoreview: scoped-clean, no actionable findings (0.85)
