### PR TITLE
fix(ui): keep question sessions to one line

### DIFF
--- a/ui/src/components/app-sidebar-session-projection.ts
+++ b/ui/src/components/app-sidebar-session-projection.ts
@@ -349,6 +349,9 @@ export class SidebarSessionProjection {
     } satisfies SidebarSubtitleParams;
     const value = resolveSidebarSessionSubtitle(params);
     if (!value.subtitle) {
+      if (session.attention.kind === "question") {
+        this.heldSubtitles.delete(session.key);
+      }
       // Transient gaps between event updates keep the last shown line; the
       // hold dies with the run (the hasActiveRun branch above).
       return;

--- a/ui/src/components/session-attention-presentation.ts
+++ b/ui/src/components/session-attention-presentation.ts
@@ -5,10 +5,14 @@ import { formatWebUiIconErrorText } from "./error-presentation.ts";
 import { icons } from "./icons.ts";
 import { resolveSessionAttentionIcon } from "./session-attention-icon-registry.ts";
 
-export function renderSessionAttentionIcon(attention: SidebarSessionAttention) {
+export function renderSessionAttentionIcon(
+  attention: SidebarSessionAttention,
+  showQuestionTooltip = false,
+) {
   if (attention.kind === "none") {
     return nothing;
   }
+  const questionLabel = attention.kind === "question" ? sessionAttentionSubtitle(attention) : null;
   const icon =
     attention.kind === "question"
       ? icons.hand
@@ -17,12 +21,17 @@ export function renderSessionAttentionIcon(attention: SidebarSessionAttention) {
         : attention.kind === "agent"
           ? resolveSessionAttentionIcon(attention.icon)
           : icons.alertTriangle;
-  return html`<span
+  const content = html`<span
     class="sidebar-session-attention__icon sidebar-session-attention__icon--${attention.kind}"
     data-session-attention=${attention.kind}
-    aria-hidden="true"
+    role=${questionLabel ? "img" : nothing}
+    aria-label=${questionLabel ?? nothing}
+    aria-hidden=${questionLabel ? nothing : "true"}
     >${icon}</span
   >`;
+  return showQuestionTooltip && questionLabel
+    ? html`<openclaw-tooltip .content=${questionLabel}>${content}</openclaw-tooltip>`
+    : content;
 }
 
 export function sessionAttentionSubtitle(attention: SidebarSessionAttention): string | undefined {

--- a/ui/src/components/session-attention-presentation.ts
+++ b/ui/src/components/session-attention-presentation.ts
@@ -5,6 +5,11 @@ import { formatWebUiIconErrorText } from "./error-presentation.ts";
 import { icons } from "./icons.ts";
 import { resolveSessionAttentionIcon } from "./session-attention-icon-registry.ts";
 
+function keepQuestionFocusOnTooltip(event: FocusEvent) {
+  // The hand is its own tooltip target; bubbling would also open the row hovercard.
+  event.stopPropagation();
+}
+
 export function renderSessionAttentionIcon(
   attention: SidebarSessionAttention,
   showQuestionTooltip = false,
@@ -27,6 +32,8 @@ export function renderSessionAttentionIcon(
     role=${questionLabel ? "img" : nothing}
     aria-label=${questionLabel ?? nothing}
     aria-hidden=${questionLabel ? nothing : "true"}
+    tabindex=${questionLabel ? "0" : nothing}
+    @focusin=${questionLabel ? keepQuestionFocusOnTooltip : nothing}
     >${icon}</span
   >`;
   return showQuestionTooltip && questionLabel

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -68,7 +68,7 @@ export function renderSessionLeadingState(
       return {
         running,
         leadingIndicator: renderSessionGlyph({
-          content: renderSessionAttentionIcon(session.attention),
+          content: renderSessionAttentionIcon(session.attention, true),
           running,
           queued,
           badge: session.unread && !session.hasActiveRun ? renderSessionUnreadBadge() : nothing,
@@ -117,7 +117,7 @@ export function renderSessionLeadingState(
     return {
       running,
       leadingIndicator: renderSessionGlyph({
-        content: renderSessionAttentionIcon(session.attention),
+        content: renderSessionAttentionIcon(session.attention, true),
         running: false,
       }),
       trailingIndicator,

--- a/ui/src/components/session-row-subtitle.test.ts
+++ b/ui/src/components/session-row-subtitle.test.ts
@@ -121,7 +121,7 @@ describe("resolveSidebarSessionSubtitle", () => {
     ).toEqual({ subtitle: undefined, narration: undefined });
   });
 
-  it("uses attention, agent status, observer, narration, then work subtitle precedence", () => {
+  it("leaves the subtitle empty while question attention is in the leading glyph", () => {
     const session: SidebarRecentSession = {
       ...workSession(),
       hasActiveRun: true,
@@ -148,7 +148,7 @@ describe("resolveSidebarSessionSubtitle", () => {
         observerDigest,
       });
 
-    expect(resolve().subtitle).toBe("Waiting for your answer");
+    expect(resolve()).toEqual({ subtitle: undefined, narration: undefined });
     expect(resolve({ attention: { kind: "none" } }).subtitle).toBe("Waiting for deployment");
     expect(resolve({ attention: { kind: "none" }, agentStatusNote: undefined }).subtitle).toBe(
       "Running checks",
@@ -255,7 +255,7 @@ describe("resolveSidebarSessionSubtitle", () => {
     ).toBe("The final reply is durable.");
   });
 
-  it("keeps attention and agent status ahead of the idle digest and last reply", () => {
+  it("keeps subtitle-owned attention and agent status ahead of the idle digest and last reply", () => {
     const session = {
       ...workSession(),
       lastMessagePreview: "The final reply is durable.",
@@ -281,7 +281,13 @@ describe("resolveSidebarSessionSubtitle", () => {
     expect(resolve({ agentStatusNote: "Waiting for deployment" })).toBe("Waiting for deployment");
     expect(
       resolve({ attention: { kind: "question" }, agentStatusNote: "Waiting for deployment" }),
-    ).toBe("Waiting for your answer");
+    ).toBeUndefined();
+    expect(
+      resolve({
+        attention: { kind: "approval" },
+        agentStatusNote: "Waiting for deployment",
+      }),
+    ).toBe("Waiting for approval");
   });
 
   it("does not let a prior last-message preview displace running activity", () => {

--- a/ui/src/components/session-row-subtitle.ts
+++ b/ui/src/components/session-row-subtitle.ts
@@ -10,7 +10,7 @@ type SidebarSessionSubtitle = {
   narration: string | undefined;
 };
 
-/** Resolves the single subtitle slot without displacing pending attention. */
+/** Resolves the single subtitle slot without displacing visible status. */
 export function resolveSidebarSessionSubtitle(params: {
   session: SidebarRecentSession;
   hasDisplay: boolean;
@@ -24,6 +24,11 @@ export function resolveSidebarSessionSubtitle(params: {
   > | null;
 }): SidebarSessionSubtitle {
   const { session } = params;
+  // Question attention owns the leading hand tooltip; repeating or replacing
+  // it with lower-priority activity here makes the action row needlessly tall.
+  if (session.attention.kind === "question") {
+    return { subtitle: undefined, narration: undefined };
+  }
   const attention = sessionAttentionSubtitle(session.attention);
   const running = session.hasActiveRun;
   const activeRunIds = session.activeRunIds ?? [];
@@ -46,8 +51,9 @@ export function resolveSidebarSessionSubtitle(params: {
     (session.lastReadAt ?? 0) < projectedDigest.updatedAt,
   );
   const observer = running || finalDigestUnread ? projectedDigest?.headline : undefined;
-  // Preview off hides ambient text only. Attention and a critical observer headline
-  // survive the toggle: errors, pending approvals, and the stuck / waiting-on-user
+  // Preview off hides ambient text only. Subtitle-owned attention and a critical
+  // observer headline survive the toggle: errors, pending approvals, and the
+  // stuck / waiting-on-user
   // health states are things the operator must act on. isCriticalObserverHealth owns
   // that classification and the chat pane announces the same two states, so a display
   // preference must not silence them here — that would turn a visible non-outcome into

--- a/ui/src/e2e/question-flow.e2e.test.ts
+++ b/ui/src/e2e/question-flow.e2e.test.ts
@@ -426,6 +426,15 @@ suite.define(() => {
       .locator(`[data-session-key="${questionSessionKey}"] [data-session-attention="question"]`)
       .hover();
     await expect.poll(() => page.locator("openclaw-tooltip wa-tooltip[open]").count()).toBe(1);
+    await page.mouse.move(400, 50);
+    await expect.poll(() => page.locator("openclaw-tooltip wa-tooltip[open]").count()).toBe(0);
+    await page
+      .locator(`[data-session-key="${questionSessionKey}"] [data-session-attention="question"]`)
+      .focus();
+    await expect.poll(() => page.locator("openclaw-tooltip wa-tooltip[open]").count()).toBe(1);
+    await expect
+      .poll(() => page.locator('.session-progress-hovercard[data-open="true"]').count())
+      .toBe(0);
     await screenshot(page, "01-question-pending.png");
 
     await panel.locator(".chat-question-panel__collapse").click();

--- a/ui/src/e2e/question-flow.e2e.test.ts
+++ b/ui/src/e2e/question-flow.e2e.test.ts
@@ -168,13 +168,21 @@ function panelFor(page: Page, prompt: string) {
 
 async function expectQuestionAttention(page: Page, present: boolean): Promise<void> {
   const session = page.locator(`[data-session-key="${questionSessionKey}"]`).first();
+  const questionAttention = session.locator('[data-session-attention="question"]');
   const expectedCount = present ? 1 : 0;
-  await expect
-    .poll(() => session.locator('[data-session-attention="question"]').count())
-    .toBe(expectedCount);
-  await expect
-    .poll(() => session.getByText("Waiting for your answer", { exact: true }).count())
-    .toBe(expectedCount);
+  await expect.poll(() => questionAttention.count()).toBe(expectedCount);
+  if (present) {
+    await expect
+      .poll(() =>
+        questionAttention.evaluate(
+          (element) =>
+            (element.closest("openclaw-tooltip") as (HTMLElement & { content?: string }) | null)
+              ?.content,
+        ),
+      )
+      .toBe("Waiting for your answer");
+    await expect.poll(() => session.locator(".sidebar-recent-session__subtitle").count()).toBe(0);
+  }
 }
 
 async function emitRequested(
@@ -414,6 +422,10 @@ suite.define(() => {
         };
       })
       .toEqual({ left: 0, width: 0 });
+    await page
+      .locator(`[data-session-key="${questionSessionKey}"] [data-session-attention="question"]`)
+      .hover();
+    await expect.poll(() => page.locator("openclaw-tooltip wa-tooltip[open]").count()).toBe(1);
     await screenshot(page, "01-question-pending.png");
 
     await panel.locator(".chat-question-panel__collapse").click();

--- a/ui/src/test-helpers/app-sidebar-cases/attention.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/attention.ts
@@ -148,6 +148,7 @@ describe("AppSidebar session attention", () => {
     const questionAttention = sidebar.querySelector('[data-session-attention="question"]');
     expect(questionAttention).not.toBeNull();
     expect(questionAttention?.getAttribute("aria-label")).toBe("Waiting for your answer");
+    expect(questionAttention?.getAttribute("tabindex")).toBe("0");
     expect(
       (
         questionAttention?.closest("openclaw-tooltip") as

--- a/ui/src/test-helpers/app-sidebar-cases/attention.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/attention.ts
@@ -145,8 +145,21 @@ describe("AppSidebar session attention", () => {
     });
     await sidebar.updateComplete;
 
-    expect(sidebar.querySelector('[data-session-attention="question"]')).not.toBeNull();
-    expect(sidebar.textContent).toContain("Waiting for your answer");
+    const questionAttention = sidebar.querySelector('[data-session-attention="question"]');
+    expect(questionAttention).not.toBeNull();
+    expect(questionAttention?.getAttribute("aria-label")).toBe("Waiting for your answer");
+    expect(
+      (
+        questionAttention?.closest("openclaw-tooltip") as
+          | (HTMLElement & {
+              content?: string;
+            })
+          | null
+      )?.content,
+    ).toBe("Waiting for your answer");
+    expect(
+      sidebar.querySelector(`[data-session-key="${sessionKey}"] .sidebar-recent-session__subtitle`),
+    ).toBeNull();
     expect(sidebar.textContent).not.toContain("Run failed:");
 
     gatewayHarness.publishEvent("question.resolved", {

--- a/ui/src/test-helpers/app-sidebar-cases/narration.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/narration.ts
@@ -125,10 +125,19 @@ describe("AppSidebar live narration", () => {
     await sidebar.updateComplete;
 
     const row = sidebar.querySelector(`[data-session-key="${key}"]`);
-    expect(row?.querySelector("[data-session-attention=question]")).not.toBeNull();
-    expect(row?.querySelector(".sidebar-recent-session__subtitle")?.textContent).toBe(
-      "Waiting for your answer",
-    );
+    const questionAttention = row?.querySelector("[data-session-attention=question]");
+    expect(questionAttention).not.toBeNull();
+    expect(questionAttention?.getAttribute("aria-label")).toBe("Waiting for your answer");
+    expect(
+      (
+        questionAttention?.closest("openclaw-tooltip") as
+          | (HTMLElement & {
+              content?: string;
+            })
+          | null
+      )?.content,
+    ).toBe("Waiting for your answer");
+    expect(row?.querySelector(".sidebar-recent-session__subtitle")).toBeNull();
     expect(row?.textContent).not.toContain("Checking the remaining files.");
     expect(
       row?.querySelector<HTMLAnchorElement>(".sidebar-recent-session__link")?.hasAttribute("title"),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where sessions waiting for a user answer used a second sidebar row for “Waiting for your answer,” making the session entry taller than neighboring rows.

## Why This Change Was Made

Question attention now stays in the leading hand icon, with the same localized status exposed through its tooltip and accessible label. The hand itself is keyboard-focusable and keeps focus from also opening the enclosing session hovercard. The subtitle owner suppresses question text and clears any held narration while leaving approval, error, agent-status, and Home-row behavior unchanged.

Production LOC: +33/-8 (net +25) | Tests/test support: +66/-16

The production growth owns the tooltip, keyboard/accessibility semantics, and held-subtitle cleanup; it adds no CSS, dependency, configuration, or persistence surface.

## User Impact

Sessions waiting for an answer remain one line tall. Hovering or focusing the hand icon reveals “Waiting for your answer,” and assistive technology receives the same label without opening a competing session hovercard.

## Evidence

- Before: the supplied screenshot shows the status as a second visible sidebar row.
- After: production-bundled Playwright proof shows the one-line row with the hand tooltip open; before/after and final keyboard-focus images are attached in the proof comments.
- Focused unit/integration: `session-row-subtitle.test.ts` and `app-sidebar.test.ts` — 341 passed.
- Focused browser flow: `question-flow.e2e.test.ts` — passes hover, keyboard focus, no competing hovercard, no subtitle row, and question resolution assertions; the full file also passed earlier (16 passed).
- Changed-file gate: formatting, UI/core-test types, i18n, assertion/structure guards, production/script dead exports, Oxlint, and Stylelint passed. The aggregate full-tree Knip process hit its fixed 600-second wrapper timeout once; the identical pinned full-tree command then completed cleanly with exit 0.
- Autoreview: fresh full-candidate pass scoped-clean with no accepted/actionable findings.
- ClawSweeper rank-up moves: keyboard-visible status and focused browser coverage addressed in `47fe34f24216`.

Root cause: question attention was mapped into both the leading glyph and the shared subtitle precedence. The sidebar’s held-subtitle projection could also preserve an earlier narration after the question arrived.

Provenance: clearly introduced with the live activity subtitle owner in #111221 (`3a5da4faa8c5`, 2026-07-19), authored and merged by @steipete.

Best-fix verdict: best. The leading attention glyph owns question status and the subtitle projection owns removal of its stale held value. Hiding the row in CSS or special-casing the row renderer would leave duplicate semantic/state ownership.
