### PR TITLE
fix(ui): remove unwanted fade above task progress card

### DIFF
--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -376,6 +376,10 @@ suite.define(() => {
           await expect.poll(() => gateway.getRequests("progressCard.get")).toHaveLength(1);
           const card = page.locator('[data-progress-card-placement="composer"]');
           await expect.poll(() => card.isVisible()).toBe(true);
+          const composerFade = await page
+            .locator(".agent-chat__composer-shell")
+            .evaluate((node) => getComputedStyle(node, "::before").backgroundImage);
+          expect(composerFade).toBe("none");
           const expectMarkerCentered = async () => {
             await expect
               .poll(async () => {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1479,11 +1479,10 @@ button.chat-reply-preview--message:disabled {
   outline: none;
 }
 
-/* Fade the transcript across its whole column before the highest stack surface
-   covers it. The solid tail sits behind rounded corners, so card silhouettes
-   cannot expose unfaded text; its chat-surface color is invisible when there
-   is no transcript behind it. */
-.chat-main__conversation > .agent-chat__composer-shell::before {
+/* Bare composers need this fade to cover transcript underlap. A progress card owns
+   that boundary itself; painting behind it exposes a veil above the card. */
+.chat-main__conversation
+  > .agent-chat__composer-shell:not(:has(> .agent-chat__progress-float))::before {
   position: absolute;
   inset: calc(0px - var(--chat-transcript-fade-height, 20px)) 0 auto;
   height: calc(
@@ -2814,7 +2813,8 @@ button.chat-pr__diff {
     width: calc(100% - 8px);
   }
 
-  .chat-main__conversation > .agent-chat__composer-shell::before {
+  .chat-main__conversation
+    > .agent-chat__composer-shell:not(:has(> .agent-chat__progress-float))::before {
     inset-inline: calc(var(--chat-thread-gutter) - var(--chat-mobile-edge-inset, 4px));
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing a task progress card would see an unintended dark fade above the card because the transcript-underlap gradient also painted behind the card-owned surface.

## Why This Change Was Made

The composer fade remains intentional for bare composer, queue, goal, and question surfaces. This change gates it off only when the composer shell has a direct task progress card, which owns that visual boundary itself, and mirrors the same selector in the responsive inset rule.

## User Impact

Task progress cards now meet the transcript cleanly without the dark blurred veil shown in the report. Other composer states retain their existing transcript-underlap treatment.

## Evidence

- Reproduced in the mocked-Gateway Control UI flow. The new computed-style assertion failed before the fix because the task-card composer exposed a `linear-gradient`; it passes with `backgroundImage === "none"` after the fix.
- Before (same 1600×900 mocked-Gateway task state):

  ![Task progress card with the unwanted transcript fade above it](https://github.com/user-attachments/assets/cc9afaab-f0fa-4515-be24-63a41508613c)

- After:

  ![Task progress card with a clean transcript boundary after the fix](https://github.com/user-attachments/assets/1f3bb738-ba6a-4cc9-bb68-505a1b552fcb)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-progress-live-placement.e2e.test.ts` — 4 passed.
- `node scripts/run-vitest.mjs run ui/src/pages/chat/chat-responsive.browser.test.ts -t 'keeps floating notices clear of mobile chrome'` — 8 passed; protects the retained bare-composer fade geometry.
- `node scripts/check-changed.mjs -- ui/src/styles/chat/layout.css ui/src/e2e/session-progress-live-placement.e2e.test.ts` — passed.
- Autoreview — scoped clean; no accepted/actionable findings.
- Production LOC: +6/−6 (net zero). Test LOC: +4/−0.

The matched screenshots and tests cover the operator-visible behavior. No configuration, storage, protocol, or plugin contract changes.
