### PR TITLE
fix(ui): sidebar plus button appears brighter and boxed

### DIFF
--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -156,7 +156,7 @@ export function renderAppSidebarBrand(host: AppSidebarRenderHost) {
         >
           <button
             type="button"
-            class="sidebar-brand__icon sidebar-brand__desktop-control sidebar-brand__collapse"
+            class="sidebar-brand__icon sidebar-brand__header-control sidebar-brand__desktop-control sidebar-brand__collapse"
             aria-label=${collapseLabel}
             aria-expanded="true"
             ?disabled=${!host.onToggleSidebar}
@@ -170,7 +170,7 @@ export function renderAppSidebarBrand(host: AppSidebarRenderHost) {
         >
           <button
             type="button"
-            class="sidebar-brand__icon sidebar-brand__desktop-control sidebar-brand__search"
+            class="sidebar-brand__icon sidebar-brand__header-control sidebar-brand__desktop-control sidebar-brand__search"
             aria-label=${t("chat.openCommandPalette")}
             ?disabled=${!host.onOpenPalette}
             @click=${() => host.onOpenPalette?.()}
@@ -181,7 +181,7 @@ export function renderAppSidebarBrand(host: AppSidebarRenderHost) {
         ${renderNewSessionLink({
           basePath: host.basePath,
           agentId: host.expandedAgentId(),
-          className: "shell-chrome-controls__button sidebar-brand__new-thread",
+          className: "sidebar-brand__icon sidebar-brand__header-control sidebar-brand__new-thread",
           label: t("chat.runControls.newSession"),
           disabledReason: newSessionAccess.allowed ? undefined : newSessionAccess.reason,
           onOpen: (agentId, target) => host.requestOpenNewSession(agentId, target),

--- a/ui/src/e2e/native-nav-responsive-layout.e2e.test.ts
+++ b/ui/src/e2e/native-nav-responsive-layout.e2e.test.ts
@@ -145,6 +145,29 @@ suite.define(() => {
         }),
       )
       .toEqual(["28px", "28px", "none"]);
+    const actionStyles = await sidebarBrand
+      .locator(".sidebar-brand__collapse, .sidebar-brand__search, .sidebar-brand__new-thread")
+      .evaluateAll((actions) =>
+        actions.map((action) => {
+          const icon = action.querySelector("svg");
+          const actionStyle = getComputedStyle(action);
+          const iconStyle = icon ? getComputedStyle(icon) : null;
+          return {
+            backgroundColor: actionStyle.backgroundColor,
+            borderStyle: actionStyle.borderTopStyle,
+            borderWidth: actionStyle.borderTopWidth,
+            boxShadow: actionStyle.boxShadow,
+            color: actionStyle.color,
+            iconHeight: iconStyle?.height,
+            iconOpacity: iconStyle?.opacity,
+            iconStrokeWidth: iconStyle?.strokeWidth,
+            iconWidth: iconStyle?.width,
+          };
+        }),
+      );
+    expect(actionStyles).toHaveLength(3);
+    expect(actionStyles[1]).toEqual(actionStyles[0]);
+    expect(actionStyles[2]).toEqual(actionStyles[0]);
 
     const actionInset = async (direction: "ltr" | "rtl") => {
       const [brandBox, actionsBox] = await Promise.all([

--- a/ui/src/e2e/native-nav-responsive-layout.e2e.test.ts
+++ b/ui/src/e2e/native-nav-responsive-layout.e2e.test.ts
@@ -158,16 +158,37 @@ suite.define(() => {
             borderWidth: actionStyle.borderTopWidth,
             boxShadow: actionStyle.boxShadow,
             color: actionStyle.color,
-            iconHeight: iconStyle?.height,
             iconOpacity: iconStyle?.opacity,
             iconStrokeWidth: iconStyle?.strokeWidth,
-            iconWidth: iconStyle?.width,
           };
         }),
       );
     expect(actionStyles).toHaveLength(3);
     expect(actionStyles[1]).toEqual(actionStyles[0]);
     expect(actionStyles[2]).toEqual(actionStyles[0]);
+    await expect
+      .poll(() =>
+        sidebarBrand
+          .locator(".sidebar-brand__collapse, .sidebar-brand__search, .sidebar-brand__new-thread")
+          .evaluateAll((actions) =>
+            actions.map((action) => {
+              const icon = action.querySelector("svg");
+              if (!icon) {
+                return null;
+              }
+              const shapes = Array.from(
+                icon.querySelectorAll<SVGGraphicsElement>(
+                  "circle, ellipse, line, path, polygon, polyline, rect",
+                ),
+              );
+              const bounds = shapes.map((shape) => shape.getBBox());
+              const left = Math.min(...bounds.map((box) => box.x));
+              const right = Math.max(...bounds.map((box) => box.x + box.width));
+              return Math.round((right - left) * (icon.getBoundingClientRect().width / 24));
+            }),
+          ),
+      )
+      .toEqual([12, 12, 12]);
 
     const actionInset = async (direction: "ltr" | "rtl") => {
       const [brandBox, actionsBox] = await Promise.all([

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -461,10 +461,10 @@ suite.define(() => {
       .poll(() =>
         sidebarNewThread.evaluate((element) => {
           const style = getComputedStyle(element);
-          return { borderColor: style.borderTopColor, boxShadow: style.boxShadow };
+          return { borderStyle: style.borderTopStyle, boxShadow: style.boxShadow };
         }),
       )
-      .toEqual({ borderColor: "rgba(0, 0, 0, 0)", boxShadow: "none" });
+      .toEqual({ borderStyle: "none", boxShadow: "none" });
     await page.keyboard.press("Tab");
     await sidebarNewThread.focus();
     await expect

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -220,15 +220,6 @@ html.openclaw-native-web-chrome .sidebar-brand__desktop-control {
   display: none;
 }
 
-html.openclaw-native-web-chrome .sidebar-brand__new-thread {
-  border-color: transparent;
-  box-shadow: none;
-}
-
-html.openclaw-native-web-chrome .sidebar-brand__new-thread:focus-visible {
-  box-shadow: var(--focus-ring);
-}
-
 html:is(.openclaw-native-macos, .openclaw-native-nav, .openclaw-native-web-chrome) .sidebar-brand {
   --sidebar-agent-avatar-size: 32px;
 }
@@ -1062,25 +1053,23 @@ openclaw-settings-save-indicator:empty {
   flex: 0 0 auto;
 }
 
-.sidebar-brand__desktop-control svg {
+.sidebar-brand__header-control svg {
   opacity: 0.72;
   stroke-width: 1.6px;
   transition: opacity var(--duration-fast) ease;
 }
 
-.sidebar-brand__icon.sidebar-brand__desktop-control {
+.sidebar-brand__icon.sidebar-brand__header-control {
   width: var(--shell-chrome-control-size);
   height: var(--shell-chrome-control-size);
 }
 
-.sidebar-brand__desktop-control:hover:not(:disabled) svg {
+.sidebar-brand__header-control:hover:not(:disabled, [aria-disabled="true"]) svg {
   opacity: 1;
 }
 
 .sidebar-brand__new-thread {
   margin-inline-start: 5px;
-  color: var(--text);
-  box-shadow: none;
 }
 
 .sidebar-brand__icon {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1114,6 +1114,12 @@ openclaw-settings-save-indicator:empty {
   stroke-linejoin: round;
 }
 
+.sidebar-brand__new-thread svg {
+  /* The plus path occupies less of its viewBox than the panel/search artwork. */
+  width: 20px;
+  height: 20px;
+}
+
 .sidebar-shell__content {
   display: flex;
   flex: 1;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the sidebar's New session (+) control appeared brighter and boxed while the adjacent collapse and search controls were muted and borderless.

## Why This Change Was Made

The New session link was using the floating shell-control style instead of the sidebar icon style introduced for the other header actions. All three actions now share one header-control visual role, while the existing native-shell visibility behavior remains limited to collapse and search.

## User Impact

The plus icon now matches the color, optical size, stroke, background, hover treatment, and borderless surface of the other sidebar header controls.

## Evidence

| Before | After |
| --- | --- |
| ![Before: the plus control is brighter and enclosed by a border](https://github.com/user-attachments/assets/7bfe5c93-d2a7-4254-887b-b41860443a2d) | ![After: the plus control matches the muted, borderless collapse and search controls, including visible icon size](https://github.com/user-attachments/assets/cfd98b07-ce08-4e30-aa1c-22144d09383f) |

- Regression proof: style parity failed against the original implementation (panel background, 1px solid border, brighter color, full opacity). The follow-up visible-glyph check failed against the nominally equal 16px SVGs (`[12, 12, 9]`) and passes after optical sizing (`[12, 12, 12]`).
- Focused E2E: native responsive layout — 6 passed; native sidebar toggle — 20 passed.
- `node scripts/check-changed.mjs -- ui/src/components/app-sidebar-render.ts ui/src/styles/layout.css ui/src/e2e/native-nav-responsive-layout.e2e.test.ts ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts` — passed.
- Final Autoreview — 0 accepted/actionable findings (0.99 confidence).
- Production delta: +12/−17 (net −5); test delta: +46/−2.
