### PR TITLE
fix(ui): align model provider refresh status

### DIFF
--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -429,7 +429,26 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       });
       expect(headerMetrics.centerOffset).toBeLessThanOrEqual(1);
       expect(headerMetrics.iconWidth).toBeCloseTo(headerMetrics.textSize, 1);
-      expect(headerMetrics.refreshHeight).toBeLessThanOrEqual(20);
+      expect(headerMetrics.refreshHeight).toBe(28);
+
+      await page.setViewportSize({ width: 390, height: 844 });
+      const mobileMetrics = await providerSection.evaluate((section) => {
+        const header = section.querySelector<HTMLElement>(".settings-section__header");
+        const actions = section.querySelector<HTMLElement>(".settings-section__actions");
+        if (!header || !actions) {
+          throw new Error("expected configured-provider mobile header controls");
+        }
+        return {
+          actionsAlignSelf: getComputedStyle(actions).alignSelf,
+          flexDirection: getComputedStyle(header).flexDirection,
+          overflowsViewport: document.documentElement.scrollWidth > window.innerWidth,
+        };
+      });
+      expect(mobileMetrics).toEqual({
+        actionsAlignSelf: "flex-end",
+        flexDirection: "column",
+        overflowsViewport: false,
+      });
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -399,6 +399,37 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
           .locator(".model-providers__provider-list")
           .evaluate((node) => getComputedStyle(node).rowGap),
       ).toBe("18px");
+      const providerSection = page
+        .locator(".settings-section")
+        .filter({ has: page.locator(".model-providers__updated") });
+      const headerMetrics = await providerSection.evaluate((section) => {
+        const heading = section.querySelector<HTMLElement>(".settings-section__heading");
+        const actions = section.querySelector<HTMLElement>(".settings-section__actions");
+        const updated = section.querySelector<HTMLElement>(".model-providers__updated");
+        const refresh = section.querySelector<HTMLButtonElement>(
+          ".model-providers__refresh-button",
+        );
+        const icon = refresh?.querySelector<SVGElement>("svg");
+        if (!heading || !actions || !updated || !refresh || !icon) {
+          throw new Error("expected configured-provider header controls");
+        }
+        const headingBounds = heading.getBoundingClientRect();
+        const actionsBounds = actions.getBoundingClientRect();
+        const iconBounds = icon.getBoundingClientRect();
+        return {
+          centerOffset: Math.abs(
+            headingBounds.top +
+              headingBounds.height / 2 -
+              (actionsBounds.top + actionsBounds.height / 2),
+          ),
+          iconWidth: iconBounds.width,
+          textSize: Number.parseFloat(getComputedStyle(updated).fontSize),
+          refreshHeight: refresh.getBoundingClientRect().height,
+        };
+      });
+      expect(headerMetrics.centerOffset).toBeLessThanOrEqual(1);
+      expect(headerMetrics.iconWidth).toBeCloseTo(headerMetrics.textSize, 1);
+      expect(headerMetrics.refreshHeight).toBeLessThanOrEqual(20);
     } finally {
       await context.close();
     }

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -599,7 +599,7 @@ export function renderModelProviders(props: ModelProvidersViewProps) {
           >
             <button
               type="button"
-              class="btn btn--icon btn--sm model-providers__refresh-button"
+              class="btn btn--icon btn--ghost model-providers__refresh-button"
               aria-label=${props.refreshing ? t("modelProviders.refreshing") : t("common.refresh")}
               ?disabled=${props.refreshing}
               @click=${() => props.onRefresh()}

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -599,7 +599,7 @@ export function renderModelProviders(props: ModelProvidersViewProps) {
           >
             <button
               type="button"
-              class="btn btn--icon btn--ghost model-providers__refresh-button"
+              class="btn btn--icon btn--ghost btn--xs model-providers__refresh-button"
               aria-label=${props.refreshing ? t("modelProviders.refreshing") : t("common.refresh")}
               ?disabled=${props.refreshing}
               @click=${() => props.onRefresh()}

--- a/ui/src/styles/channels.css
+++ b/ui/src/styles/channels.css
@@ -2,18 +2,10 @@
    detail overlay, and the guided setup wizard dialog. Everything else uses the
    shared settings design language. */
 
-/* Compact refresh actions should not retain the spacing and top alignment
-   reserved for settings headers with full-size controls. */
+/* Compact refresh actions should not retain the spacing reserved for settings
+   headers with full-size controls. */
 .settings-section:has(.settings-section__actions .btn--xs.btn--icon) {
   gap: var(--space-2);
-}
-
-@media not all and (max-width: 640px) {
-  .settings-section__header:not(:has(.settings-section__desc)):has(
-    .settings-section__actions .btn--xs.btn--icon
-  ) {
-    align-items: center;
-  }
 }
 
 .channels-empty {

--- a/ui/src/styles/model-providers.css
+++ b/ui/src/styles/model-providers.css
@@ -240,21 +240,21 @@
 }
 
 .settings-section__actions .model-providers__refresh-button {
-  width: 20px;
-  min-width: 20px;
-  height: 20px;
-  padding: 0;
   font-size: var(--control-ui-text-xs);
 }
 
-.model-providers__refresh-button svg {
+.settings-section__actions .model-providers__refresh-button.btn--icon.btn--xs svg {
   width: 1em;
   height: 1em;
 }
 
-@media (min-width: 641px) {
+.settings-section__header:has(.model-providers__refresh-button) {
+  align-items: center;
+}
+
+@media (max-width: 640px) {
   .settings-section__header:has(.model-providers__refresh-button) {
-    align-items: center;
+    align-items: stretch;
   }
 }
 

--- a/ui/src/styles/model-providers.css
+++ b/ui/src/styles/model-providers.css
@@ -239,23 +239,9 @@
   font-size: var(--control-ui-text-xs);
 }
 
-.settings-section__actions .model-providers__refresh-button {
-  font-size: var(--control-ui-text-xs);
-}
-
 .settings-section__actions .model-providers__refresh-button.btn--icon.btn--xs svg {
-  width: 1em;
-  height: 1em;
-}
-
-.settings-section__header:has(.model-providers__refresh-button) {
-  align-items: center;
-}
-
-@media (max-width: 640px) {
-  .settings-section__header:has(.model-providers__refresh-button) {
-    align-items: stretch;
-  }
+  width: var(--control-ui-text-xs);
+  height: var(--control-ui-text-xs);
 }
 
 .model-providers__defaults .model-picker {

--- a/ui/src/styles/model-providers.css
+++ b/ui/src/styles/model-providers.css
@@ -239,6 +239,25 @@
   font-size: var(--control-ui-text-xs);
 }
 
+.settings-section__actions .model-providers__refresh-button {
+  width: 20px;
+  min-width: 20px;
+  height: 20px;
+  padding: 0;
+  font-size: var(--control-ui-text-xs);
+}
+
+.model-providers__refresh-button svg {
+  width: 1em;
+  height: 1em;
+}
+
+@media (min-width: 641px) {
+  .settings-section__header:has(.model-providers__refresh-button) {
+    align-items: center;
+  }
+}
+
 .model-providers__defaults .model-picker {
   width: min(420px, 100%);
 }

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -162,6 +162,16 @@
   align-items: flex-start;
 }
 
+/* Compact icon-only actions align with a one-line heading instead of the
+   full-size controls that require top alignment. */
+@media not all and (max-width: 640px) {
+  .settings-section__header:not(:has(.settings-section__desc)):has(
+    .settings-section__actions .btn--xs.btn--icon
+  ) {
+    align-items: center;
+  }
+}
+
 .settings-section__header:has(.settings-section__copy):has(.settings-section__actions) {
   column-gap: var(--space-5);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Models settings page showed the configured-provider update status and refresh control lower than its section heading, with a refresh glyph that was visually oversized beside the timestamp.

## Why This Change Was Made

The shared settings owner now centers no-description headers that use the existing compact icon-action contract, consolidating the same rule previously owned by Channels. The Models page adopts that compact ghost button and sizes only the refresh glyph to the adjacent timestamp text; the 28px click target and existing mobile stacked layout remain intact.

## User Impact

The Configured Providers heading, update timestamp, and refresh glyph now read as one aligned header row on desktop. Mobile retains its stacked, right-aligned action row without horizontal overflow.

## Evidence

- Pre-fix regression proof: the rendered header center offset was `6.4765625px` (expected at most `1px`).
- Post-fix rendered proof: heading/action centers differ by at most `1px`; refresh glyph is `11px`, matching the timestamp text; click target remains `28px`.
- Responsive proof at `390px`: header stacks vertically, actions remain right-aligned, and the page has no horizontal overflow.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/model-providers.e2e.test.ts` — 6 passed.
- `node --import tsx scripts/run-stylelint.mts ui/src/styles/model-providers.css` — passed.
- `pnpm exec oxfmt --check ui/src/styles/model-providers.css ui/src/pages/model-providers/view.ts ui/src/e2e/model-providers.e2e.test.ts` — passed.
- `autoreview --mode branch --base origin/main` — scoped clean, patch correct (0.99).
- ClawSweeper rank-up move applied: compact structural alignment moved from Channels into the shared settings stylesheet; Models retains only glyph sizing locally.
- Production LOC: `+18/-11` (net `+7`). The shared structural rule is a move; the remaining growth is the Models glyph-size contract plus its shared-owner context comment.
- Visual attachment skip: redacted desktop and 390px captures were generated and inspected, but the Codex in-app browser remained unavailable and `gh attach` could not resolve an authenticated cookie source. The rendered geometry and responsive behavior are asserted directly by the browser test above.
