### PR TITLE
fix(ui): keep format-constrained settings editable in the config form

### DIFF
--- a/ui/src/components/config-form.analyze.test.ts
+++ b/ui/src/components/config-form.analyze.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { analyzeConfigSchema } from "./config-form.analyze.ts";
+
+describe("analyzeConfigSchema", () => {
+  it("keeps Zod format-constrained strings form-editable and preserves their annotations", () => {
+    const schema = z.toJSONSchema(
+      z.object({
+        relayUrl: z
+          .string()
+          .regex(/^https?:\/\//)
+          .url(),
+        email: z.email(),
+        consentedAt: z.string().datetime(),
+      }),
+    );
+
+    const analysis = analyzeConfigSchema(schema);
+
+    expect(analysis.unsupportedPaths).toEqual([]);
+    expect(analysis.schema?.properties).toMatchObject({
+      relayUrl: { type: "string", format: "uri", pattern: expect.any(String) },
+      email: { type: "string", format: "email", pattern: expect.any(String) },
+      consentedAt: { type: "string", format: "date-time" },
+    });
+  });
+});

--- a/ui/src/components/config-form.analyze.ts
+++ b/ui/src/components/config-form.analyze.ts
@@ -46,6 +46,10 @@ const SUPPORTED_CONSTRAINT_ONLY_KEYS = new Set([
   "minLength",
   "maxLength",
   "pattern",
+  // Zod .url()/z.email()/.datetime() emit `format`; the shared TypeBox validator
+  // checks known formats like `pattern`, and the Gateway validates every write.
+  // Rejecting the keyword sends every such string field to Raw mode.
+  "format",
   "minItems",
   "maxItems",
   "uniqueItems",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators opening Settings → Advanced (and any other schema-driven settings page) would see the banner "N settings in this config can only be edited as text" and the affected rows rendered as "Unsupported schema node. Use Raw mode." with no input, whenever a setting's schema carries a JSON Schema `format` keyword. Every Zod `.url()`, `z.email()`, and `.datetime()` field is affected: `channels.reef.relayUrl`, `channels.reef.email`, `gateway.publicOrigin`, `proxy.proxyUrl`, `telemetry.consentedAt`, the MCP server/OAuth URLs, Telegram's API root, ClickClack/Teams/Discord/Buzz URLs, and more. On a real config with Reef configured, the Advanced page showed 26 Raw-only rows.

## Why This Change Was Made

The Control UI form analyzer decides form-safety with a keyword allowlist. It listed `pattern` but never `format`, so any node with a `format` was treated as something the form could not represent. `format` is a string annotation the form already handles: the shared TypeBox validator checks known formats the same way it checks `pattern`, and the Gateway validates every write through the plugin's Zod runtime schema. The fix accepts `format` in the allowlist (3 production lines) and adds an analyzer regression test built from real Zod output so the producer contract stays covered. Non-goals: no input-type changes, no server-side schema rewriting. `channels.reef.friends` intentionally stays Raw-only (it is `z.unknown()`, an upgrade-only snapshot).

## User Impact

URL, email, and timestamp settings are editable in the form again, with the same inline constraint feedback other string fields get; the "can only be edited as text" banner no longer appears for them. Operators no longer need the Raw editor to change a channel relay URL or owner email.

## Evidence

Live dev gateway (isolated state dir, Reef configured with `relayUrl` + `email`), Control UI rebuilt from this branch; served asset hash changed `index-ClI3KMY_` → `index-BsyRzExo`.

| | Before | After |
| --- | --- | --- |
| Advanced page banner | shown for `channels.reef.relayUrl`, `channels.reef.email` | gone |
| Raw-only rows on Advanced page | 26 | 10 (remaining rows use other unsupported keywords) |
| Reef card Raw-only rows | 3 (Email, Friends, Relay Url) | 1 (Friends, by design) |

Before / after, Advanced page:

![Before: banner on the Advanced settings page](https://github.com/user-attachments/assets/6771af6c-f692-43de-a257-d3e4eba48dbe)

![After: no banner on the Advanced settings page](https://github.com/user-attachments/assets/b0033f07-bee4-4b47-95dc-b12e00420a8d)

Before / after, Reef card:

![Before: Reef card with Email and Relay Url as unsupported rows](https://github.com/user-attachments/assets/ef134b54-40ff-442c-b310-f458172599f1)

![After: Reef card with Email and Relay Url as editable inputs](https://github.com/user-attachments/assets/a5ce96dd-0161-467b-b079-ba17184b4d10)

Live edit through the form: changing Relay Url to a new value triggered `config.set` on the Gateway and the config file on disk updated; typing `not a url` shows the inline invalid state and writes nothing:

![After: invalid Relay Url input shows the constraint state](https://github.com/user-attachments/assets/292e98f4-de24-4180-8efe-16c028a65247)

Tests: `ui/src/components/config-form.analyze.test.ts` fails on pre-fix code with `expected [ 'relayUrl', 'email', 'consentedAt' ] to deeply equal []` and passes with the fix; `config-form.constraints`, `config-form.tiers`, and the three config-form browser integrity suites pass; `node scripts/check-changed.mjs` and Codex autoreview run before commit.
