### PR TITLE
fix: Workboard task links recover after cursor rejection

### DIFF
--- a/ui/src/lib/workboard/index.test.ts
+++ b/ui/src/lib/workboard/index.test.ts
@@ -29,6 +29,7 @@ import {
   type WorkboardTaskSummary,
 } from "./index.ts";
 import { normalizeExecution, normalizeMetadata } from "./metadata-normalization.ts";
+import { getWorkboardRuntime } from "./runtime.ts";
 import {
   createGatewaySession,
   createLifecycleHarness,
@@ -73,6 +74,48 @@ function makeSession(overrides: Partial<GatewaySessionRow> = {}) {
 
 function makeTask(overrides: Partial<WorkboardTaskSummary> = {}) {
   return { ...sampleTask, ...overrides } satisfies WorkboardTaskSummary;
+}
+
+function invalidRequest(message: string) {
+  return new GatewayRequestError({ code: "INVALID_REQUEST", message });
+}
+
+function makeDiscoveryCard(id: string, sessionKey: string, taskId?: string) {
+  return makeCard({
+    id,
+    status: "running",
+    sessionKey,
+    runId: `${id}-run`,
+    ...(taskId ? { taskId } : {}),
+  });
+}
+
+function makeCardTask(card: WorkboardCard, taskId: string, progressSummary?: string) {
+  return makeTask({
+    id: taskId,
+    taskId,
+    childSessionKey: card.sessionKey,
+    runId: card.runId,
+    ...(progressSummary ? { progressSummary } : {}),
+  });
+}
+
+function createDiscoveryBatchFixture() {
+  const polledCard = makeDiscoveryCard(
+    "polled-card",
+    "agent:worker:subagent:workboard-polled",
+    "polled-task",
+  );
+  const defaultCard = makeDiscoveryCard("default-card", "subagent:workboard-default-missing");
+  const exactCard = makeDiscoveryCard("exact-card", "agent:worker:subagent:workboard-exact");
+  return {
+    cards: [polledCard, defaultCard, exactCard],
+    polledCard,
+    defaultCard,
+    exactCard,
+    polledTask: makeCardTask(polledCard, "polled-task"),
+    exactTask: makeCardTask(exactCard, "exact-task"),
+  };
 }
 
 function listResult(cards: unknown[] = [sampleCard], statuses: string[] = ["todo", "done"]) {
@@ -1329,6 +1372,276 @@ describe("workboard controller", () => {
       { limit: 500, cursor: "500" },
       { limit: 500 },
     ]);
+  });
+
+  it("retires a rejected stored discovery cursor without publishing its mixed batch", async () => {
+    const { cards, polledCard, exactCard, exactTask, polledTask } = createDiscoveryBatchFixture();
+    cards.push(
+      makeDiscoveryCard("missing-card", "agent:worker:subagent:workboard-missing", "missing-task"),
+    );
+    const preparedTask = { ...polledTask, progressSummary: "Cached task summary" };
+    const refreshedPreparedTask = {
+      ...preparedTask,
+      progressSummary: "New task poll result",
+    };
+    state.tasksByCardId.set(polledCard.id, preparedTask);
+    getWorkboardRuntime(host).defaultTaskDiscoveryCursor = "rejected-cursor";
+    const client = createClient((method, params) => {
+      if (method === "workboard.cards.list") {
+        return listResult(cards, ["todo", "running", "done"]);
+      }
+      if (method === "tasks.get" && (params as { taskId: string }).taskId === "missing-task") {
+        throw invalidRequest("task not found: missing-task");
+      }
+      if (method === "tasks.get") {
+        return { task: refreshedPreparedTask };
+      }
+      if (method === "tasks.list") {
+        const query = params as { cursor?: string; sessionKey?: string };
+        if (query.cursor === "rejected-cursor") {
+          throw invalidRequest("cursor rejected");
+        }
+        if (query.sessionKey) {
+          return { tasks: [exactTask] };
+        }
+        return { tasks: [] };
+      }
+      return {};
+    });
+
+    await refreshBoard(client, "live");
+
+    expect(state.tasksByCardId.get(polledCard.id)).toEqual(preparedTask);
+    expect(state.tasksByCardId.has(exactCard.id)).toBe(false);
+    expect(state.missingTaskIds.has("missing-task")).toBe(false);
+    expect(state.lifecycleTaskRefreshError).toContain("cursor rejected");
+    expect(getWorkboardRuntime(host).defaultTaskDiscoveryCursor).toBeUndefined();
+
+    vi.clearAllMocks();
+    await refreshBoard(client, "live");
+
+    expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
+    expect(client.request).not.toHaveBeenCalledWith("tasks.list", {
+      cursor: "rejected-cursor",
+      limit: 500,
+    });
+  });
+
+  it.each([
+    {
+      name: "tasks.get INVALID_REQUEST",
+      failure: "task-get",
+      initialCursor: "stored-cursor",
+      error: invalidRequest("task lookup rejected"),
+    },
+    {
+      name: "filtered tasks.list INVALID_REQUEST",
+      failure: "filtered-list",
+      initialCursor: "stored-cursor",
+      error: invalidRequest("filtered discovery rejected"),
+    },
+    {
+      name: "cursorless tasks.list INVALID_REQUEST",
+      failure: "unfiltered-list",
+      initialCursor: undefined,
+      error: invalidRequest("cursorless discovery rejected"),
+    },
+    {
+      name: "stored-cursor transport failure",
+      failure: "unfiltered-list",
+      initialCursor: "stored-cursor",
+      error: new Error("task discovery disconnected"),
+    },
+  ] as const)(
+    "does not retire discovery state for $name",
+    async ({ failure, initialCursor, error }) => {
+      const { cards, polledCard, exactCard, polledTask, exactTask } = createDiscoveryBatchFixture();
+      const cursorlessRequest =
+        failure === "unfiltered-list" && !initialCursor ? createDeferred<unknown>() : null;
+      if (initialCursor) {
+        getWorkboardRuntime(host).defaultTaskDiscoveryCursor = initialCursor;
+      }
+      const client = createClient((method, params) => {
+        if (method === "workboard.cards.list") {
+          return listResult(cards, ["todo", "running", "done"]);
+        }
+        if (method === "tasks.get") {
+          if (failure === "task-get") {
+            throw error;
+          }
+          return { task: polledTask };
+        }
+        if (method === "tasks.list") {
+          const query = params as { cursor?: string; sessionKey?: string };
+          if (query.sessionKey) {
+            if (failure === "filtered-list") {
+              throw error;
+            }
+            return { tasks: [exactTask] };
+          }
+          if (failure === "unfiltered-list") {
+            if (cursorlessRequest) {
+              return cursorlessRequest.promise;
+            }
+            throw error;
+          }
+          return { tasks: [], nextCursor: "stored-cursor" };
+        }
+        return {};
+      });
+
+      const refresh = refreshBoard(client, "live");
+      if (cursorlessRequest) {
+        await waitForFast(() => {
+          expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
+        });
+        getWorkboardRuntime(host).defaultTaskDiscoveryCursor = "replacement-cursor";
+        cursorlessRequest.reject(error);
+      }
+      await refresh;
+
+      expect(getWorkboardRuntime(host).defaultTaskDiscoveryCursor).toBe(
+        cursorlessRequest ? "replacement-cursor" : initialCursor,
+      );
+      expect(state.tasksByCardId.has(polledCard.id)).toBe(failure !== "task-get");
+      expect(state.tasksByCardId.has(exactCard.id)).toBe(failure !== "filtered-list");
+      expect(state.lifecycleTaskRefreshError).toContain(error.message);
+      expect(state.lastRefreshError).toContain(error.message);
+    },
+  );
+
+  it("does not let a stale cursor rejection overwrite replacement-generation state", async () => {
+    const stalePolledCard = makeDiscoveryCard(
+      "stale-polled-card",
+      "agent:worker:subagent:workboard-stale-polled",
+      "stale-polled-task",
+    );
+    const staleCard = makeDiscoveryCard("stale-card", "subagent:workboard-stale");
+    const staleExactCard = makeDiscoveryCard(
+      "stale-exact-card",
+      "agent:worker:subagent:workboard-stale-exact",
+    );
+    const stalePolledTask = makeCardTask(stalePolledCard, "stale-polled-task");
+    const staleExactTask = makeCardTask(staleExactCard, "stale-exact-task");
+    const replacementCard = makeDiscoveryCard("replacement-card", "subagent:workboard-replacement");
+    const replacementMissingCard = makeDiscoveryCard(
+      "replacement-missing-card",
+      "agent:worker:subagent:workboard-missing",
+      "replacement-missing",
+    );
+    const replacementTask = makeCardTask(replacementCard, "replacement-task");
+    const staleRequest = createDeferred<unknown>();
+    getWorkboardRuntime(host).defaultTaskDiscoveryCursor = "stale-cursor";
+    const staleClient = createClient((method, params) => {
+      if (method === "workboard.cards.list") {
+        return listResult(
+          [stalePolledCard, staleCard, staleExactCard],
+          ["todo", "running", "done"],
+        );
+      }
+      if (method === "tasks.get") {
+        return { task: stalePolledTask };
+      }
+      if (method === "tasks.list") {
+        if ((params as { sessionKey?: string }).sessionKey) {
+          return { tasks: [staleExactTask] };
+        }
+        return staleRequest.promise;
+      }
+      return {};
+    });
+
+    const staleLoad = loadBoard(staleClient, { taskRefresh: "linked" });
+    await waitForFast(() => {
+      expect(staleClient.request).toHaveBeenCalledWith("tasks.list", {
+        cursor: "stale-cursor",
+        limit: 500,
+      });
+      expect(staleClient.request).toHaveBeenCalledWith("tasks.get", {
+        taskId: stalePolledTask.taskId,
+      });
+      expect(staleClient.request).toHaveBeenCalledWith("tasks.list", {
+        limit: 500,
+        sessionKey: staleExactCard.sessionKey,
+      });
+    });
+    stopWorkboardLifecycleRefresh(host);
+    getWorkboardRuntime(host).defaultTaskDiscoveryCursor = "replacement-start";
+    const replacementClient = createClient((method, params) => {
+      if (method === "workboard.cards.list") {
+        return {
+          boards: [{ id: "replacement-board", total: 2, active: 2, archived: 0, byStatus: {} }],
+          cards: [replacementCard, replacementMissingCard],
+          statuses: ["todo", "running", "done"],
+        };
+      }
+      if (method === "tasks.get") {
+        const taskId = (params as { taskId: string }).taskId;
+        throw invalidRequest(`task not found: ${taskId}`);
+      }
+      if (method === "tasks.list") {
+        expect(params).toEqual({ cursor: "replacement-start", limit: 500 });
+        return { tasks: [replacementTask], nextCursor: "replacement-cursor" };
+      }
+      return {};
+    });
+
+    await expect(loadBoard(replacementClient, { taskRefresh: "linked" })).resolves.toBe(true);
+    state.lastRefreshError = "replacement error";
+    staleRequest.reject(invalidRequest("stale cursor rejected"));
+
+    await expect(staleLoad).resolves.toBe(false);
+    expect(getWorkboardRuntime(host).defaultTaskDiscoveryCursor).toBe("replacement-cursor");
+    expect(state.cards).toEqual([
+      { ...replacementCard, taskId: replacementTask.taskId },
+      replacementMissingCard,
+    ]);
+    expect(state.boards).toEqual([
+      { id: "replacement-board", total: 2, active: 2, archived: 0, byStatus: {} },
+    ]);
+    expect(state.statuses).toEqual(["todo", "running", "done"]);
+    expect(state.tasksByCardId.get(replacementCard.id)).toEqual(replacementTask);
+    expect(state.tasksByCardId.has(stalePolledCard.id)).toBe(false);
+    expect(state.tasksByCardId.has(staleExactCard.id)).toBe(false);
+    expect(state.missingTaskIds).toEqual(new Set(["replacement-missing"]));
+    expect(state.error).toBeNull();
+    expect(state.lifecycleTaskRefreshError).toBeNull();
+    expect(state.lastRefreshError).toBe("replacement error");
+  });
+
+  it("retires a rejected cursor before deferring an interaction-blocked refresh", async () => {
+    const card = makeDiscoveryCard("dragged-card", "subagent:workboard-dragged");
+    const rejectedRequest = createDeferred<unknown>();
+    getWorkboardRuntime(host).defaultTaskDiscoveryCursor = "rejected-cursor";
+    const client = createClient((method) => {
+      if (method === "workboard.cards.list") {
+        return listResult([card], ["todo", "running", "done"]);
+      }
+      if (method === "tasks.list") {
+        return rejectedRequest.promise;
+      }
+      return {};
+    });
+
+    const refresh = refreshBoard(client, "live");
+    await waitForFast(() => {
+      expect(client.request).toHaveBeenCalledWith("tasks.list", {
+        cursor: "rejected-cursor",
+        limit: 500,
+      });
+    });
+    state.draggedCardId = card.id;
+    rejectedRequest.reject(invalidRequest("cursor rejected during drag"));
+
+    await expect(refresh).resolves.toBe(false);
+    expect(getWorkboardRuntime(host).defaultTaskDiscoveryCursor).toBeUndefined();
+    expect(state.lifecycleTaskRefreshError).toContain("cursor rejected during drag");
+    expect(state.lastRefreshError).toContain("cursor rejected during drag");
+
+    state.draggedCardId = null;
+    vi.clearAllMocks();
+    await refreshBoard(client, "live");
+    expect(client.request).toHaveBeenCalledWith("tasks.list", { limit: 500 });
   });
 
   it.each([

--- a/ui/src/lib/workboard/loading.ts
+++ b/ui/src/lib/workboard/loading.ts
@@ -123,6 +123,7 @@ async function loadWorkboardInternal(
       let preserveLifecycleTaskRefreshFailure = false;
       let nextTaskRefreshError: string | null = null;
       let nextUnfilteredCursor: string | null | undefined;
+      let rejectedUnfilteredCursor: string | undefined;
       if (taskLinkState.cards.length > 0) {
         const preparedTaskSummaries = taskLinkState.cards.flatMap((card) => {
           const task = previousTasksByCardId.get(card.id);
@@ -188,6 +189,7 @@ async function loadWorkboardInternal(
             taskRefreshError = confirmationResult.error;
           }
           nextUnfilteredCursor = pollResult?.nextUnfilteredCursor;
+          rejectedUnfilteredCursor = pollResult?.rejectedUnfilteredCursor;
           applyTaskSummariesToState(taskLinkState, taskSummaries, { missingTaskIds });
           preserveLifecycleTaskRefreshFailure =
             params.taskRefresh === "linked" &&
@@ -212,10 +214,24 @@ async function loadWorkboardInternal(
       if (!isCurrentWorkboardLoadGeneration(params.host, generation)) {
         return false;
       }
+      if (
+        rejectedUnfilteredCursor &&
+        runtime.defaultTaskDiscoveryCursor === rejectedUnfilteredCursor
+      ) {
+        delete runtime.defaultTaskDiscoveryCursor;
+      }
       if (params.taskRefresh === "linked" && shouldDeferWorkboardLiveRefresh(state)) {
+        if (rejectedUnfilteredCursor && nextTaskRefreshError) {
+          setWorkboardLifecycleTaskRefreshFailed(state, true, {
+            host: params.host,
+            requestUpdate: params.requestUpdate,
+          });
+          state.lifecycleTaskRefreshError = nextTaskRefreshError;
+          state.lastRefreshError = nextTaskRefreshError;
+        }
         return false;
       }
-      if (nextUnfilteredCursor !== undefined) {
+      if (!rejectedUnfilteredCursor && nextUnfilteredCursor !== undefined) {
         if (nextUnfilteredCursor) {
           runtime.defaultTaskDiscoveryCursor = nextUnfilteredCursor;
         } else {

--- a/ui/src/lib/workboard/task-links.ts
+++ b/ui/src/lib/workboard/task-links.ts
@@ -233,6 +233,7 @@ export async function getWorkboardTaskPollBatch(
   tasks: WorkboardTaskSummary[];
   missingTaskIds: Set<string>;
   nextUnfilteredCursor?: string | null;
+  rejectedUnfilteredCursor?: string;
   error: string | null;
 }> {
   const results = await Promise.allSettled([
@@ -263,8 +264,9 @@ export async function getWorkboardTaskPollBatch(
   const tasks: WorkboardTaskSummary[] = [];
   const missingTaskIds = new Set<string>();
   let nextUnfilteredCursor: string | null | undefined;
+  let rejectedUnfilteredCursor: string | undefined;
   let error: string | null = null;
-  for (const result of results) {
+  for (const [index, result] of results.entries()) {
     if (result.status === "fulfilled") {
       tasks.push(...result.value.tasks);
       if ("missingTaskId" in result.value && result.value.missingTaskId) {
@@ -274,10 +276,28 @@ export async function getWorkboardTaskPollBatch(
         nextUnfilteredCursor = result.value.nextUnfilteredCursor;
       }
     } else {
+      // Promise.allSettled preserves input order, so discovery failures retain
+      // the exact query provenance needed to retire only a rejected stored cursor.
+      const discoveryQuery = discoveryQueries[index - taskIds.length];
+      if (
+        discoveryQuery?.cursor &&
+        !discoveryQuery.sessionKey &&
+        result.reason instanceof GatewayRequestError &&
+        result.reason.gatewayCode === "INVALID_REQUEST"
+      ) {
+        rejectedUnfilteredCursor = discoveryQuery.cursor;
+      }
       error ??= formatError(result.reason);
     }
   }
-  return { tasks, missingTaskIds, nextUnfilteredCursor, error };
+  return rejectedUnfilteredCursor
+    ? {
+        tasks: [],
+        missingTaskIds: new Set(),
+        rejectedUnfilteredCursor,
+        error,
+      }
+    : { tasks, missingTaskIds, nextUnfilteredCursor, error };
 }
 
 type WorkboardTaskIndex = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing Workboard could have running cards stop
rediscovering their linked task when a stored background discovery cursor was
rejected after cursor invalidation or Gateway replacement. Workboard kept
resending the rejected cursor on later bounded refreshes.

## Why This Change Was Made

Workboard owns the per-host discovery cursor and the generation-guarded commit
of task-link refreshes. Its settled batch previously kept fulfilled
`tasks.get` and filtered `tasks.list` siblings when the unfiltered request
carrying the stored cursor was rejected, but it had no correlated result with
which to retire that cursor.

The settled batch now identifies only an `INVALID_REQUEST` from the exact
stored cursor sent by the unfiltered `tasks.list` request. That classified
batch atomically withholds all newly settled tasks, missing-task IDs, and
successor-cursor state; keeps only previously prepared task summaries and the
refresh error; and retires only the matching cursor after the current load
generation is confirmed. Cursor retirement also happens when an active
drag/edit/write/dispatch interaction defers board-state publication, while the
refresh error remains visible.

Other request failures retain their existing partial-success behavior.
Successful cursor advancement and terminal cursor reset are unchanged. This
does not change Gateway pagination, protocol, configuration, persistence,
retry bounds, documentation, or user-facing copy.

## User Impact

Workboard resumes bounded task discovery without the rejected cursor on its next
eligible refresh instead of looping on stale cursor state. Replacement Gateway
generations and concurrent user interactions keep their authoritative task,
board, cursor, and error state.

There is no visible layout or copy change.

## Evidence

### Failure Reproduction

- [Blacksmith Testbox run 33679476706](https://github.com/openclaw/openclaw/actions/runs/33679476706)
  executed an exact test-only transplant tree
  `9882d1182cab47715436108ced6b19c195002c9e` over unchanged base production
  code.
- The focused regression failed because a fulfilled `tasks.get` sibling
  replaced the cached prepared task after the stored unfiltered cursor request
  was rejected with `INVALID_REQUEST`.
- The test patch ID remained
  `6b5acb1369f34bd8ce979b4e62dfa1d976bc7c81`; later negative and race coverage
  did not alter the positive red reproduction.

### Fixed-Head Verification

- [Blacksmith Testbox run 33683552632](https://github.com/openclaw/openclaw/actions/runs/33683552632)
  executed exact publication tree
  `43a50009e06e64029697a30f99e7bcb64ea19e84`.
- Complete Workboard controller suite: 166 passed, 0 failed.
- Hosted PR CI: all 145 checks reached a terminal green or intentional skipped
  state on head `c74b2ca8f4c753f71ac2425afbf578cd7c84b45a`.
- Independent Workloop review: clean.
- Exact-candidate autoreview: scoped clean, no accepted or actionable findings,
  correctness confidence 0.93.
- [Post-CI ClawSweeper review](https://github.com/openclaw/openclaw/pull/136619#issuecomment-5517114059):
  B / Platinum overall and patch quality, no correctness or security findings,
  exact reviewed head `c74b2ca8f4c753f71ac2425afbf578cd7c84b45a`.
- `git range-diff` shows the reviewed candidate and publication commit are
  patch-equivalent.
- `git diff --check`: clean.

Regression coverage includes:

- atomic withholding of fulfilled task, filtered-discovery, and missing-ID
  siblings after the classified stored-cursor rejection;
- clearing the rejected cursor and sending the next unfiltered request without
  it;
- preserving a replacement cursor installed while a cursorless request is in
  flight;
- `INVALID_REQUEST` from `tasks.get` and filtered `tasks.list`;
- transport failure from the stored unfiltered request;
- replacement-generation races with fulfilled siblings;
- drag-deferred retirement with lifecycle and visible refresh errors;
- existing successful pagination and terminal cursor-reset behavior.

Scope is limited to:

- `ui/src/lib/workboard/task-links.ts`
- `ui/src/lib/workboard/loading.ts`
- `ui/src/lib/workboard/index.test.ts`

Production LOC: +39/-3. Test LOC: +313/-0.

### Production LOC Decision

ClawSweeper's positive-production-LOC merge-risk item is accepted for this
repair. The net +36 production lines are the two owner-local pieces the prior
shape could not express: correlated rejected-request provenance in the task
poll result, and generation-guarded retirement plus deferred-error publication
in the Workboard loader. Removing either piece would lose the atomic batch
classification or move cursor mutation outside its lifecycle owner. The change
adds no retry path, fallback, configuration, protocol, persistence, or
duplicate task-discovery flow.

Visual evidence is omitted because the repaired behavior is transient
background request ownership with no distinct render state. Exact request and
runtime-state assertions are the direct proof.
