### PR TITLE
fix(discord): missing response IDs falsely confirm delivery

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -314,6 +314,7 @@ Now create channels and start chatting. The agent sees the channel name, and eac
 - Group DMs are ignored by default (`channels.discord.dm.groupEnabled=false`).
 - Native slash commands run in isolated command sessions (`agent:<agentId>:discord:slash:<userId>`), while still carrying `CommandTargetSessionKey` to the routed conversation session.
 - Text-only cron/heartbeat announce delivery to Discord collapses to the final assistant-visible answer, sent once. Media and structured component payloads remain multi-message when the agent emits multiple deliverable payloads.
+- A send response without a Discord message ID stays unconfirmed. Queued delivery records the missing identity for recovery instead of reporting success or immediately sending a duplicate; inspect delivery warnings with `openclaw health --verbose`.
 
 ## Forum channels
 

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -446,8 +446,7 @@ export async function sendMessageDiscord(
     direction: "outbound",
   });
   return {
-    messageId: result.id || "unknown",
-    channelId: result.channel_id ?? channelId,
+    ...toDiscordSendResult(result, channelId),
     receipt: createDiscordSendReceiptFromResults({ results: deliveredResults }),
   };
 }

--- a/extensions/discord/src/send.receipt.ts
+++ b/extensions/discord/src/send.receipt.ts
@@ -50,7 +50,7 @@ export function createDiscordSendReceipt(params: {
 }): MessageReceipt {
   const platformMessageIds = params.platformMessageIds
     .map((messageId) => messageId.trim())
-    .filter((messageId) => messageId && messageId !== "unknown");
+    .filter(Boolean);
   const results: Array<MessageReceiptSourceResult & { receipt?: MessageReceipt }> =
     platformMessageIds.map((messageId, index) => {
       const result: MessageReceiptSourceResult & { receipt?: MessageReceipt } = {
@@ -94,7 +94,9 @@ export function createDiscordSendResult(params: {
   threadId?: string | number;
   reply?: DiscordReplyReference;
 }): DiscordSendResult {
-  const messageId = params.result.id || "unknown";
+  // A missing Discord ID is ambiguous, not an acknowledgement. Leave it empty
+  // so shared delivery custody cannot mistake a placeholder for platform evidence.
+  const messageId = params.result.id ?? "";
   const channelId = params.result.channel_id ?? params.fallbackChannelId;
   const receiptParams: Parameters<typeof createDiscordSendReceipt>[0] = {
     platformMessageIds: params.result.platformMessageIds?.length

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -216,6 +216,30 @@ describe("resolveDiscordTargetChannelId", () => {
 });
 
 describe("sendMessageDiscord", () => {
+  it("keeps missing platform identity ambiguous in progress and final results", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+    postMock.mockResolvedValue({ channel_id: "789" });
+    const onDeliveryResult = vi.fn();
+
+    const result = await sendMessageDiscord("channel:789", "hello", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      onDeliveryResult,
+    });
+
+    expect(postMock).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    for (const delivery of [result, onDeliveryResult.mock.calls[0]?.[0]]) {
+      expect(delivery).toMatchObject({
+        messageId: "",
+        channelId: "789",
+        receipt: { platformMessageIds: [], parts: [] },
+      });
+    }
+  });
+
   function expectReplyReference(
     body: { message_reference?: unknown } | undefined,
     messageId: string,

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -197,7 +197,7 @@ describe("sendWebhookMessageDiscord proxy support", () => {
       wait: false,
     });
 
-    expect(result.messageId).toBe("unknown");
+    expect(result.messageId).toBe("");
     expect(jsonSpy).not.toHaveBeenCalled();
     globalFetchMock.mockRestore();
   });
@@ -217,7 +217,7 @@ describe("sendWebhookMessageDiscord proxy support", () => {
       wait: true,
     });
 
-    expect(result.messageId).toBe("unknown");
+    expect(result.messageId).toBe("");
     expect(tracked.wasCanceled()).toBe(true);
     globalFetchMock.mockRestore();
   });
@@ -235,7 +235,7 @@ describe("sendWebhookMessageDiscord proxy support", () => {
       wait: true,
     });
 
-    expect(result.messageId).toBe("unknown");
+    expect(result.messageId).toBe("");
     globalFetchMock.mockRestore();
   });
 

--- a/extensions/discord/src/send.webhook.ts
+++ b/extensions/discord/src/send.webhook.ts
@@ -206,7 +206,7 @@ export async function sendWebhookMessageDiscord(
         ...(replyTo ? { replyToId: replyTo } : {}),
       });
       const resultConversationId = result.channelId.trim();
-      if (result.messageId !== "unknown" && resultConversationId) {
+      if (result.messageId && resultConversationId) {
         recordOutboundMessageIdentity({
           channel: "discord",
           accountId: account.accountId,


### PR DESCRIPTION
Related: #135305. Companion delivery-owner repair to #136524; neither linked issue is closed by this PR.

## What Problem This Solves

Fixes an issue where users could see a Discord announcement recorded as delivered even when the send response provided no message identity. The transport invented `"unknown"` as an ID, and shared delivery accounting treated that nonempty string as confirmation.

The missing-ID response was found during the isolated announcement-delivery investigation prompted by @Cobblestone-Digital1's #135305 and Elton Lau's Slack field report. This is a synthetic Discord failure reproduction, not a claim that those reporters observed Discord failures.

## Why This Change Was Made

Keep missing Discord IDs empty at the existing send-result producer and reuse that producer for terminal text/media results. Webhook HTTP success still resolves without throwing or immediately retrying; absent identity remains an unknown delivery outcome, not an explicit no-send. The webhook identity recorder no longer depends on the removed placeholder.

Shared receipt rules remain unchanged. Some sibling channels legitimately acknowledge a send without an editable platform ID, so rejecting every empty receipt in core would break their contracts. Public result types, configuration, environment variables, persistence, protocol, and dependencies are unchanged.

Production: +6/-5, net +1; tests: +27/-3, net +24; docs: +1. Runtime code shrinks by one line; two short comment lines protect the non-obvious ambiguity invariant. The duplicate terminal-result construction and placeholder-specific handling are removed.

## User Impact

A queued Discord send without identity is no longer credited solely because of a fabricated ID. Existing delivery custody can record the uncertain outcome. Normal identified text, media, components, voice, forum, and webhook sends retain their behavior, as do intentional no-send outcomes and sibling acknowledgement contracts.

This PR's new fault proof targets one final send. A separate core follow-up is recorded below for mixed identified/unidentified chunks; no universal multi-chunk guarantee is claimed.

## Evidence

Before the patch, an actual isolated Gateway using a mock provider and mock Discord API accepted one final message, while a response-only fault removed its ID. The native Discord plugin returned `messageId: "unknown"` with an empty receipt; the announcement registry was marked delivered and its delivery queue entry was absent. The corrected combined Gateway run passed normally (5m19.472s including a fresh 4m30s build). It used the companion announcement candidate from #136524 plus the exact three Discord production files committed here; it is not presented as a standalone whole-head announcement test. All fourteen combined source hashes were checked. The Discord files match this head exactly: `send.outbound.ts` SHA-256 `444b398be40d9485823cf8c93a16a49e63320e4180d6b5484d86e1577d0e8161`, `send.receipt.ts` `d95ae642a922b0e15230ecb50c929d36776349129a4fad780247795c5d5be491`, and `send.webhook.ts` `0ffda012a09a8222841fb55dbfaaad9b756e5b058aaf4e3341090bf4ddaa86df`.

```text
$ node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts -t 'unidentified send' --reporter=dot
# actual Gateway + built plugins + mock provider/API, isolated synthetic state
# one accepted final; response ID omitted once; one completion
# durable queue: unknown_after_send
# reason: platform send returned no delivery identity
# companion announcement registry: pending / ambiguous / retry scheduled
# normal command exit 0
```

The exact native spawn identity was bound before the requester finished; the worker was released only after that requester became idle. The generic CLI task row remains `not_applicable` by its existing contract; delivery evidence comes from the authoritative subagent registry and queue. The root transport repair preserves queue uncertainty; the companion PR owns announcement classification.

```text
$ node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.webhook.proxy.test.ts
# pre-fix production 8caf8146c60e12edee91b944fc2c9fb90564a6da:
# 4 failed, 102 passed; normal exit 1
# missing native and webhook IDs were "unknown", expected empty

$ node scripts/run-vitest.mjs extensions/discord/src/send.components.test.ts extensions/discord/src/send.creates-thread.chunking.test.ts extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.voice.test.ts extensions/discord/src/send.webhook.chunk-limit.test.ts extensions/discord/src/send.webhook.proxy.test.ts src/channels/message/outbound-bridge.test.ts src/channels/message/receipt.test.ts src/infra/outbound/deliver.test.ts
# candidate: 411 passed across 9 files; normal exit 0 (129.29s)
# includes native/webhook/chunk/forum/components/voice, shared receipts,
# outbound bridge, and all 220 outbound tests including iMessage acknowledgements
```

Independent local and committed-branch reviews found no actionable P0-P2 findings. The local changed-file check passed its initial guards and formatting, then stopped on an unrelated missing `@types/yargs-parser` declaration in this worktree's old dependency installation; the Browser plugin manifest and lockfile already declare it. A fresh prepared Blacksmith Testbox full changed-file check passed normally (3m30.183s) with exact HEAD/base, six-path diff and all six pre/post source hashes verified. No dependency or type workaround was added. Earlier shallow-history transport attempts stopped before checks, and a later posthash shell-quoting failure was corrected and the complete gate rerun; those failed commands are not counted as successful proof. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33683865880) is green at b232558c8c84b39e31350aff3eff427c3ba90cc4.

Dependency contracts: [Discord Create Message](https://docs.discord.com/developers/resources/message#create-message) returns a Message object. [Execute Webhook](https://docs.discord.com/developers/resources/webhook#execute-webhook) documents that `wait=false` can return without an error even when a message was not saved; a no-body HTTP success must not fabricate a message ID.

Named follow-up: `deliver-core.ts` currently records an aggregate payload as sent when at least one chunk has identity, even if another chunk recorded `adapter_returned_no_identity`. Both chunk orders now fail a focused regression against unchanged main production at `fa702b1e83681a4401bef9e20da7471ae625e4f1`: the queue is acknowledged once and the payload is reported sent. Sixteen neighboring controls pass. The exception path preserves the uncertainty, but the mixed-success path needs its own owner-boundary repair. This existing core behavior is outside the single-final Discord producer repair and is not claimed fixed here.

Maintainer disposition of the September 2 ClawSweeper review: retain the two-line invariant comment and accept the justified net +1 production line; executable code is net -1 and no fallback handling is added. Its stated best-fix direction is already implemented at the producer. Mixed-chunk aggregation remains the separately named, reproduced core follow-up above; it is not silently delegated to #136524, whose announcement classification is a different owner. No other rank-up move or code finding was listed.

Follow-up tracking: [#131609](https://github.com/openclaw/openclaw/pull/131609) is an existing open repair candidate for this shared-core mixed-chunk defect (its C2 case), plus adjacent custody and routing behavior. The two-order reproduction above independently confirms the current defect; that PR is not reviewed, adopted, or claimed landed by this repair.
