### PR TITLE
fix(release): unblock frozen candidate qualification

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -421,7 +421,9 @@ jobs:
 
           python3 -I -S "$CI_GIT_OWNER" --git 0 init -b main "$KOVA_SRC"
           python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" remote add origin "https://github.com/${KOVA_REPOSITORY}.git"
-          python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" fetch --filter=blob:none --depth 1 origin "$KOVA_REF"
+          # The complete worktree is consumed next; do not defer its blobs to a
+          # second unauthenticated promisor fetch during checkout.
+          python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" fetch --depth 1 origin "$KOVA_REF"
           python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" checkout --detach FETCH_HEAD
           npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund
           node - "$KOVA_SRC" <<'NODE'

--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -185,6 +185,9 @@ jobs:
       selected_revision: ${{ steps.validate.outputs.selected_revision }}
       trusted_reason: ${{ steps.validate.outputs.trusted_reason }}
     steps:
+      - name: Prepare Git owner
+        uses: openclaw/openclaw/.github/actions/git-owner@a8fe1a587bb86ffece5dd20d2b8091c82658030f
+
       - name: Checkout selected ref
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -209,11 +212,30 @@ jobs:
             exit 1
           fi
 
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          # Checkout intentionally removes credentials. Refresh trust refs through
+          # the pinned owner, with authentication scoped to this repository only.
+          fetch_selected_refs() {
+            python3 -I -S "$CI_GIT_OWNER" --policy - "$@" <<'PYTHON'
+          import os
+          import sys
+          from ci_git_owner import git_auth_environment, git_output, run_git
+
+          directory = os.getcwd()
+          token = os.environ.pop("GH_TOKEN")
+          repository_url = f"{os.environ['GITHUB_SERVER_URL'].rstrip('/')}/{os.environ['GITHUB_REPOSITORY']}"
+          remote = git_output(directory, "remote", "get-url", "origin").strip()
+          if not token or remote not in (repository_url, repository_url + ".git"):
+              raise ValueError("Selected checkout origin must match the workflow repository")
+          run_git(directory, "fetch", *sys.argv[3:], timeout=120, reclaim_locks=True,
+                  env=git_auth_environment(remote, token))
+          PYTHON
+          }
+
+          fetch_selected_refs --no-tags origin +refs/heads/main:refs/remotes/origin/main
 
           if [[ -n "${EXPECTED_SHA}" ]]; then
-            git fetch --no-tags origin '+refs/heads/*:refs/remotes/origin/*'
-            git fetch --tags origin '+refs/tags/*:refs/tags/*'
+            fetch_selected_refs --no-tags origin '+refs/heads/*:refs/remotes/origin/*'
+            fetch_selected_refs --tags origin '+refs/tags/*:refs/tags/*'
             if git tag --points-at "$selected_revision" | grep -Eq '^v'; then
               trusted_reason="release-tag"
             elif git for-each-ref --format='%(refname:short)' --contains "$selected_revision" refs/remotes/origin | grep -Eq '^origin/'; then
@@ -224,7 +246,7 @@ jobs:
           elif git tag --points-at "$selected_revision" | grep -Eq '^v'; then
             trusted_reason="release-tag"
           elif [[ "$INPUT_REF" =~ ^release/[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
-            git fetch --no-tags origin "+refs/heads/${INPUT_REF}:refs/remotes/origin/${INPUT_REF}"
+            fetch_selected_refs --no-tags origin "+refs/heads/${INPUT_REF}:refs/remotes/origin/${INPUT_REF}"
             release_branch_sha="$(git rev-parse "refs/remotes/origin/${INPUT_REF}")"
             if [[ "$selected_revision" == "$release_branch_sha" ]]; then
               trusted_reason="release-branch-head"

--- a/scripts/generate-dependency-release-evidence.mts
+++ b/scripts/generate-dependency-release-evidence.mts
@@ -2,11 +2,16 @@
 
 // Generates release dependency evidence artifacts and summaries.
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { appendFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import type { runDependencyVulnerabilityGate } from "./dependency-vulnerability-gate.mts";
 import { parseFlagArgs, stringFlag } from "./lib/arg-utils.mts";
+import {
+  RELEASE_DEPENDENCY_RISK_LOCKFILES,
+  resolveReleaseDependencyRiskAcceptance,
+} from "./lib/release-dependency-risk-acceptance.mts";
 
 /**
  * Dependency evidence reports generated for release artifacts.
@@ -344,34 +349,73 @@ export function renderDependencyEvidenceStepSummary({
   ].join("\n")}\n`;
 }
 
-function runEvidenceReports(
+async function runEvidenceReports(
   rootDir: string,
   outputDir: string,
   baseRef: string,
   execFileSyncImpl: ExecFileSyncLike,
+  packageVersion: string,
 ) {
+  let riskAcceptance: ReturnType<typeof resolveReleaseDependencyRiskAcceptance> = null;
   // Report implementations belong to this tooling checkout; --root selects only the source data.
   // Release branches can keep frozen product bytes while trusted release tooling is repaired.
   for (const report of DEPENDENCY_EVIDENCE_REPORTS) {
-    runCommand(
-      "pnpm",
-      [
-        "--dir",
-        path.resolve(import.meta.dirname, ".."),
-        report.command.slice("pnpm ".length),
-        "--",
-        "--root",
+    try {
+      runCommand(
+        "pnpm",
+        [
+          "--dir",
+          path.resolve(import.meta.dirname, ".."),
+          report.command.slice("pnpm ".length),
+          "--",
+          "--root",
+          rootDir,
+          ...(report.json === "dependency-changes-report.json" ? ["--base-ref", baseRef] : []),
+          "--json",
+          reportPath(outputDir, report.json),
+          "--markdown",
+          reportPath(outputDir, report.markdown),
+        ],
         rootDir,
-        ...(report.json === "dependency-changes-report.json" ? ["--base-ref", baseRef] : []),
-        "--json",
-        reportPath(outputDir, report.json),
-        "--markdown",
-        reportPath(outputDir, report.markdown),
-      ],
-      rootDir,
-      execFileSyncImpl,
-    );
+        execFileSyncImpl,
+      );
+    } catch (error) {
+      if (
+        report.json !== "dependency-vulnerability-gate.json" ||
+        !(error instanceof Error) ||
+        !("status" in error) ||
+        error.status !== 1 ||
+        packageVersion !== "2026.9.1"
+      ) {
+        throw error;
+      }
+      const vulnerability = await readJson<
+        Awaited<ReturnType<typeof runDependencyVulnerabilityGate>>
+      >(reportPath(outputDir, report.json));
+      const lockfileSha256 = Object.fromEntries(
+        await Promise.all(
+          Object.keys(RELEASE_DEPENDENCY_RISK_LOCKFILES).map(async (file) => [
+            file,
+            createHash("sha256")
+              .update(await readFile(path.join(rootDir, file)))
+              .digest("hex"),
+          ]),
+        ),
+      );
+      riskAcceptance = resolveReleaseDependencyRiskAcceptance({
+        packageVersion,
+        lockfileSha256,
+        blockers: vulnerability.blockers,
+      });
+      if (!riskAcceptance) {
+        throw error;
+      }
+      console.warn(
+        "WARNING: 2026.9.1 dependency risks accepted by maintainer; scan findings remain unresolved.",
+      );
+    }
   }
+  return riskAcceptance;
 }
 
 /**
@@ -419,19 +463,28 @@ async function generateDependencyReleaseEvidence({
   const dependencyChangeBaseRef =
     baseRef ?? resolvePreviousReleaseTag({ rootDir, execFileSyncImpl });
 
-  runEvidenceReports(rootDir, outputDir, dependencyChangeBaseRef, execFileSyncImpl);
-
-  const manifest = createDependencyEvidenceManifest({
-    generatedAt: now.toISOString(),
-    releaseTag,
-    releaseRef,
-    releaseSha,
-    npmDistTag,
-    packageVersion,
-    workflowRunId,
-    workflowRunAttempt,
+  const riskAcceptance = await runEvidenceReports(
+    rootDir,
+    outputDir,
     dependencyChangeBaseRef,
-  });
+    execFileSyncImpl,
+    packageVersion,
+  );
+
+  const manifest = {
+    ...createDependencyEvidenceManifest({
+      generatedAt: now.toISOString(),
+      releaseTag,
+      releaseRef,
+      releaseSha,
+      npmDistTag,
+      packageVersion,
+      workflowRunId,
+      workflowRunAttempt,
+      dependencyChangeBaseRef,
+    }),
+    ...(riskAcceptance ? { riskAcceptance } : {}),
+  };
   await writeFile(
     reportPath(outputDir, "dependency-evidence-manifest.json"),
     `${JSON.stringify(manifest, null, 2)}\n`,
@@ -446,7 +499,10 @@ async function generateDependencyReleaseEvidence({
       releaseSha,
       baseRef: dependencyChangeBaseRef,
       counts,
-    }),
+    }) +
+      (riskAcceptance
+        ? "\n## Operator-accepted dependency risk\n\nThe maintainer accepted the five recorded advisory blockers for 2026.9.1 with unchanged dependencies. They remain unresolved, not a clean security scan. Exact graph hashes and findings are retained in dependency-evidence-manifest.json.\n"
+        : ""),
     "utf8",
   );
 
@@ -457,7 +513,10 @@ async function generateDependencyReleaseEvidence({
         evidenceArtifactName: `openclaw-release-dependency-evidence-${releaseRef}`,
         baseRef: dependencyChangeBaseRef,
         counts,
-      }),
+      }) +
+        (riskAcceptance
+          ? "\nWARNING: Five dependency advisory blockers remain unresolved and were explicitly accepted for 2026.9.1. See the dependency evidence manifest.\n"
+          : ""),
       "utf8",
     );
   }

--- a/scripts/lib/live-docker-stage.sh
+++ b/scripts/lib/live-docker-stage.sh
@@ -317,6 +317,16 @@ openclaw_live_stage_node_modules() {
 
   mkdir -p "$target_dir"
   cp -aRs /app/node_modules/. "$target_dir"
+  local source_modules staged_modules
+  # Source staging excludes node_modules everywhere. Restore each workspace's
+  # dependency links too, or package-local imports cannot reach the pnpm store.
+  for source_modules in /app/packages/*/node_modules /app/extensions/*/node_modules /app/ui/node_modules; do
+    [ -d "$source_modules" ] || continue
+    staged_modules="$dest_dir/${source_modules#/app/}"
+    [ -d "$(dirname "$staged_modules")" ] || continue
+    mkdir -p "$staged_modules"
+    cp -aRs "$source_modules/." "$staged_modules"
+  done
   rm -rf "$target_dir/.vite-temp"
   mkdir -p "$target_dir/.vite-temp"
 }

--- a/scripts/lib/plugin-npm-security-scan.mts
+++ b/scripts/lib/plugin-npm-security-scan.mts
@@ -199,6 +199,7 @@ const FROZEN_EXTENDED_STABLE_2026_6_33_LAYOUT = {
 };
 
 const FROZEN_RELEASE_SECURITY_INVENTORY_POLICIES = new Map<string, PluginSecurityInventoryPolicy>([
+  ["release/2026.9.1", CURRENT_SECURITY_INVENTORY_POLICY],
   [
     "extended-stable/2026.6.33",
     {

--- a/scripts/lib/release-dependency-risk-acceptance.mts
+++ b/scripts/lib/release-dependency-risk-acceptance.mts
@@ -1,0 +1,57 @@
+import type { runDependencyVulnerabilityGate } from "../dependency-vulnerability-gate.mts";
+
+type Blocker = Awaited<ReturnType<typeof runDependencyVulnerabilityGate>>["blockers"][number];
+
+// Maintainer accepted these existing dependency risks for 2026.9.1 without
+// dependency updates. Exact graph bytes and findings prevent this decision
+// from admitting another release, a changed graph, or an additional advisory.
+export const RELEASE_DEPENDENCY_RISK_LOCKFILES = {
+  "pnpm-lock.yaml": "60ec3478d55f958efd41f314b32e0975a5becb4e0a90216c3cf9f9c6365e1443",
+  ".github/release/vercel-cli/package-lock.json":
+    "b06b20bca67a863ad99cb479d51319b3483fb131b57c6855c26a35a92c2c89b5",
+  ".github/release/clawhub-cli/package-lock.json":
+    "adc9d3613a752dfe00597a8826f45fab82e7651478d16ba1bf5354369157fee9",
+};
+
+const acceptedFindings = new Set([
+  "pnpm-lock.yaml|fast-uri|GHSA-58mr-gqgx-xq4g|4.1.3",
+  "pnpm-lock.yaml|fast-uri|GHSA-qw65-cvwx-89v3|4.1.3",
+  ".github/release/vercel-cli/package-lock.json|fast-uri|GHSA-58mr-gqgx-xq4g|3.1.6",
+  ".github/release/vercel-cli/package-lock.json|fast-uri|GHSA-qw65-cvwx-89v3|3.1.6",
+  "pnpm-lock.yaml|nodemailer|GHSA-2x7j-588g-ccc2|9.0.4,9.0.5",
+]);
+
+export function resolveReleaseDependencyRiskAcceptance(params: {
+  packageVersion: string;
+  lockfileSha256: Record<string, string>;
+  blockers: Blocker[];
+}) {
+  const { packageVersion, lockfileSha256, blockers } = params;
+  const keys = blockers.map(
+    (finding) =>
+      `${finding.lockfile}|${finding.packageName}|${finding.id}|${(finding.matchedVersions ?? []).toSorted().join(",")}`,
+  );
+  if (
+    packageVersion !== "2026.9.1" ||
+    Object.entries(RELEASE_DEPENDENCY_RISK_LOCKFILES).some(
+      ([file, digest]) => lockfileSha256[file] !== digest,
+    ) ||
+    keys.length !== acceptedFindings.size ||
+    new Set(keys).size !== acceptedFindings.size ||
+    keys.some((key) => !acceptedFindings.has(key)) ||
+    blockers.some(
+      (finding) => finding.severity !== "high" || finding.malware || finding.graph !== "production",
+    )
+  ) {
+    return null;
+  }
+  return {
+    kind: "operator-accepted-dependency-risk" as const,
+    packageVersion,
+    acceptedOn: "2026-09-02",
+    decision:
+      "Release with unchanged dependencies; retain known advisory findings as accepted risk.",
+    lockfileSha256,
+    blockers,
+  };
+}

--- a/test/scripts/ci-git-owner-auth.test.ts
+++ b/test/scripts/ci-git-owner-auth.test.ts
@@ -1,38 +1,111 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { expect, it } from "vitest";
+import { parse } from "yaml";
 import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
+
+async function runAuthFixture(mode: string, script?: string) {
+  let stdout = "";
+  let stderr = "";
+  const code = await runManagedCommand({
+    bin: "python3",
+    args: [
+      "-I",
+      "-S",
+      "test/scripts/fixtures/ci-checkout-auth.py",
+      path.resolve(".github/actions/git-owner/owner.py"),
+      mode,
+      ...(script ? [script] : []),
+    ],
+    stdio: ["ignore", "pipe", "pipe"],
+    timeoutMs: 30_000,
+    timeoutKillGraceMs: 12_000,
+    requireProcessTreeExit: true,
+    onReady(child) {
+      child.stdout?.on("data", (chunk) => (stdout += String(chunk)));
+      child.stderr?.on("data", (chunk) => (stderr += String(chunk)));
+    },
+  });
+  expect(code, stderr).toBe(0);
+  return JSON.parse(stdout);
+}
 
 it.skipIf(process.platform === "win32").each(["fetch-only", "checkout"])(
   "keeps checkout HTTP authentication transient and scoped (%s)",
   async (mode) => {
-    let stdout = "";
-    let stderr = "";
-    const code = await runManagedCommand({
-      bin: "python3",
-      args: [
-        "-I",
-        "-S",
-        "test/scripts/fixtures/ci-checkout-auth.py",
-        path.resolve(".github/actions/git-owner/owner.py"),
-        mode,
-      ],
-      stdio: ["ignore", "pipe", "pipe"],
-      timeoutMs: 30_000,
-      timeoutKillGraceMs: 12_000,
-      requireProcessTreeExit: true,
-      onReady(child) {
-        child.stdout?.on("data", (chunk) => (stdout += String(chunk)));
-        child.stderr?.on("data", (chunk) => (stderr += String(chunk)));
-      },
-    });
-    expect(code, stderr).toBe(0);
-    expect(JSON.parse(stdout)).toMatchObject({
+    expect(await runAuthFixture(mode)).toMatchObject({
       mode,
       fetchAuthenticated: true,
       missingBlobBeforeCheckout: true,
       lazyCheckoutSucceeded: mode === "checkout",
       credentialPersisted: false,
     });
+  },
+  50_000,
+);
+
+function workflowScript(file: string, job: string, name: string) {
+  const workflow = parse(readFileSync(`.github/workflows/${file}`, "utf8")) as {
+    jobs: Record<string, { steps: { name: string; run?: string }[] }>;
+  };
+  const script = workflow.jobs[job]?.steps.find((step) => step.name === name)?.run;
+  return expectDefined(script, "workflow script");
+}
+
+it.skipIf(process.platform === "win32").each([
+  { mode: "qa-main", code: 0, reason: "main-ancestor" },
+  { mode: "qa-main-no-dotgit", code: 0, reason: "main-ancestor" },
+  { mode: "qa-exact", code: 0, reason: "repository-branch" },
+  { mode: "qa-tag", code: 0, reason: "release-tag" },
+  { mode: "qa-branch", code: 0, reason: "release-branch-head" },
+  { mode: "qa-mismatch", code: 1, reason: "" },
+  { mode: "qa-untrusted", code: 1, reason: "" },
+  { mode: "qa-pr", code: 0, reason: "open-pr-head" },
+  { mode: "qa-api-error", code: 23, reason: "" },
+  { mode: "qa-foreign-origin", code: 125, reason: "" },
+])(
+  "QA selected-ref validation owns authenticated fetches without changing trust ($mode)",
+  async ({ mode, code, reason }) => {
+    const report = await runAuthFixture(
+      mode,
+      workflowScript(
+        "qa-live-transports-convex.yml",
+        "validate_selected_ref",
+        "Validate selected ref",
+      ),
+    );
+    expect(report.exitCode, report.stderr).toBe(code);
+    expect(report).toMatchObject({ credentialPersisted: false, trustedReason: reason });
+    expect(report.selectedRevisionMatched).toBe(code === 0);
+    if (mode === "qa-mismatch" || mode === "qa-foreign-origin") {
+      expect(report.requests).toHaveLength(0);
+    } else {
+      expect(report.requests.length).toBeGreaterThan(0);
+      expect(report.fetchAuthenticated).toBe(true);
+    }
+  },
+  50_000,
+);
+
+it.skipIf(process.platform === "win32")(
+  "Kova checkout is complete after its initial public fetch closes",
+  async () => {
+    const report = await runAuthFixture(
+      "kova",
+      workflowScript("openclaw-performance.yml", "kova", "Install OCM and Kova"),
+    );
+    expect(report.exitCode, report.stderr).toBe(0);
+    expect(report).toMatchObject({
+      checkoutComplete: true,
+      sessions: 1,
+      credentialPersisted: false,
+    });
+    expect(
+      report.requests.every(
+        (request: { authorizationPresent: boolean }) => !request.authorizationPresent,
+      ),
+    ).toBe(true);
   },
   50_000,
 );

--- a/test/scripts/fixtures/ci-checkout-auth.py
+++ b/test/scripts/fixtures/ci-checkout-auth.py
@@ -54,6 +54,16 @@ with tempfile.TemporaryDirectory(prefix="checkout-auth-") as directory:
             "commit", "-m", "fixture", cwd=source)
     revision = checked(git, "rev-parse", "HEAD", cwd=source)
     historical_revision = revision
+    if mode.startswith("qa-") and mode not in ("qa-main", "qa-main-no-dotgit", "qa-mismatch", "qa-foreign-origin"):
+        checked(git, "checkout", "-b", "release/2026.9.1", cwd=source)
+        (source / "payload.txt").write_text("release candidate outside main\n")
+        checked(git, "add", "payload.txt", cwd=source)
+        checked(git, "-c", "user.name=Checkout Fixture", "-c", "user.email=fixture@example.invalid",
+                "commit", "-m", "release candidate", cwd=source)
+        revision = checked(git, "rev-parse", "HEAD", cwd=source)
+        if mode == "qa-tag":
+            checked(git, "-c", "user.name=Checkout Fixture", "-c", "user.email=fixture@example.invalid",
+                    "tag", "-a", "v2026.9.1", "-m", "release", cwd=source)
     if mode == "historical":
         (source / "payload.txt").write_text("current checkout\n")
         checked(git, "add", "payload.txt", cwd=source)
@@ -61,14 +71,17 @@ with tempfile.TemporaryDirectory(prefix="checkout-auth-") as directory:
                 "commit", "-m", "current", cwd=source)
         revision = checked(git, "rev-parse", "HEAD", cwd=source)
     blob = checked(git, "rev-parse", "HEAD:payload.txt", cwd=source)
-    bare = root / "repo.git"
+    bare = root / ("repo" if mode == "qa-main-no-dotgit" else "repo.git")
     checked(git, "clone", "--bare", str(source), str(bare))
     checked(git, "config", "uploadpack.allowFilter", "true", cwd=bare)
     checked(git, "config", "uploadpack.allowAnySHA1InWant", "true", cwd=bare)
+    if mode in ("qa-untrusted", "qa-pr", "qa-api-error"):
+        checked(git, "update-ref", "-d", "refs/heads/release/2026.9.1", cwd=bare)
     token = "synthetic-checkout-fixture"
     encoded = base64.b64encode(f"x-access-token:{token}".encode()).decode()
     authorization = f"Basic {encoded}"
     requests = []
+    kova_methods = []
     redirect = False
 
     class Handler(BaseHTTPRequestHandler):
@@ -96,7 +109,10 @@ with tempfile.TemporaryDirectory(prefix="checkout-auth-") as directory:
                 self.send_header("Content-Length", "0")
                 self.end_headers()
                 return
-            if not authenticated:
+            if mode == "kova":
+                kova_methods.append(self.command)
+            public_fetch = mode == "kova" and kova_methods.count("GET") == 1
+            if not authenticated and not public_fetch:
                 self.send_response(401)
                 self.send_header("WWW-Authenticate", 'Basic realm="checkout fixture"')
                 self.send_header("Content-Length", "0")
@@ -131,10 +147,84 @@ with tempfile.TemporaryDirectory(prefix="checkout-auth-") as directory:
     thread = threading.Thread(target=server.serve_forever)
     thread.start()
     try:
-        remote = f"http://127.0.0.1:{server.server_port}/repo.git"
+        remote = f"http://127.0.0.1:{server.server_port}/{bare.name}"
         workspace = root / "workspace"
+        if mode == "kova":
+            # Keep the whole workflow body intact. Only unrelated OCM/npm tools
+            # are stubbed; Git talks to the real server for every object it needs.
+            workspace = root / "kova-src"
+            (root / "ocm-install").mkdir()
+            (root / "ocm-install/ocm").write_text("#!/bin/sh\nexit 0\n")
+            script = '''curl() { :; }
+sha256sum() { cat >/dev/null; }
+tar() { :; }
+npm() { test -s "$KOVA_SRC/payload.txt"; }
+node() { :; }
+''' + sys.argv[3]
+            config = home / ".gitconfig"
+            checked(git, "config", "--file", str(config), f"url.{remote}.insteadOf",
+                    "https://github.com/fixture/kova.git")
+            result = command("bash", "-e", "-o", "pipefail", "-c", script, extra={
+                "GIT_CONFIG_GLOBAL": str(config), "CI_GIT_OWNER": owner,
+                "RUNNER_TEMP": str(root), "KOVA_HOME": str(home / "kova"),
+                "GITHUB_ENV": str(root / "environment"), "GITHUB_PATH": str(root / "path"),
+                "OCM_VERSION": "fixture", "OCM_LINUX_X64_SHA256": "fixture",
+                "KOVA_REPOSITORY": "fixture/kova", "KOVA_REF": revision})
+            complete = result.returncode == 0 and (workspace / "payload.txt").read_text() == (source / "payload.txt").read_text()
+            local_config = (workspace / ".git/config").read_text()
+            assert token not in result.stdout + result.stderr + local_config
+            assert encoded not in result.stdout + result.stderr + local_config
+            print(json.dumps({"mode": mode, "exitCode": result.returncode, "stderr": result.stderr,
+                              "checkoutComplete": complete, "sessions": kova_methods.count("GET"),
+                              "credentialPersisted": "extraheader" in local_config.lower(), "requests": requests}))
+            raise SystemExit(0)
         checked(git, "init", str(workspace))
         checked(git, "remote", "add", "origin", remote, cwd=workspace)
+        if mode.startswith("qa-"):
+            # Reproduce checkout@v7's complete authenticated ref snapshot, then
+            # remove its credential scope before executing the actual validator.
+            seed_auth = {"GIT_CONFIG_COUNT": "1", "GIT_CONFIG_KEY_0": f"http.{remote}.extraHeader",
+                         "GIT_CONFIG_VALUE_0": f"Authorization: Basic {encoded}"}
+            checked(git, "fetch", "--no-tags", "--prune", "origin",
+                    "+refs/heads/*:refs/remotes/origin/*", "+refs/tags/*:refs/tags/*", cwd=workspace, extra=seed_auth)
+            if mode in ("qa-untrusted", "qa-pr", "qa-api-error"):
+                checked(git, "fetch", "--no-tags", "origin", revision, cwd=workspace, extra=seed_auth)
+            checked(git, "checkout", "--detach", revision, cwd=workspace)
+            requests.clear()
+            if mode == "qa-foreign-origin":
+                checked(git, "remote", "set-url", "origin", remote.replace("/repo.git", "/other.git"), cwd=workspace)
+            output = root / "output"
+            summary = root / "summary"
+            fixture_bin = root / "bin"
+            fixture_bin.mkdir()
+            gh = fixture_bin / "gh"
+            gh.write_text(f'''#!{sys.executable}
+import os, sys
+assert os.environ["GH_TOKEN"] == {token!r}
+print("1")
+sys.exit({23 if mode == "qa-api-error" else 0})
+''')
+            gh.chmod(0o755)
+            expected = revision if mode in ("qa-exact", "qa-untrusted") else ""
+            if mode == "qa-mismatch":
+                expected = "f" * 40
+            result = command("bash", "-e", "-o", "pipefail", "-c", sys.argv[3], cwd=workspace, extra={
+                "PATH": str(fixture_bin) + os.pathsep + env["PATH"], "CI_GIT_OWNER": owner,
+                "GH_TOKEN": token, "GITHUB_REPOSITORY": "repo",
+                "GITHUB_SERVER_URL": f"http://127.0.0.1:{server.server_port}",
+                "GITHUB_OUTPUT": str(output), "GITHUB_STEP_SUMMARY": str(summary),
+                "EXPECTED_SHA": expected,
+                "INPUT_REF": "release/2026.9.1" if mode == "qa-branch" else revision})
+            outputs = dict(line.split("=", 1) for line in output.read_text().splitlines()) if output.exists() else {}
+            local_config = (workspace / ".git/config").read_text()
+            published = result.stdout + result.stderr + local_config + (output.read_text() if output.exists() else "")
+            assert token not in published and encoded not in published
+            print(json.dumps({"mode": mode, "exitCode": result.returncode, "stderr": result.stderr,
+                              "trustedReason": outputs.get("trusted_reason", ""),
+                              "selectedRevisionMatched": outputs.get("selected_revision") == revision,
+                              "fetchAuthenticated": all(item["authenticated"] for item in requests),
+                              "credentialPersisted": "extraheader" in local_config.lower(), "requests": requests}))
+            raise SystemExit(0)
         policy = root / "policy.py"
         policy.write_text('''from ci_git_owner import run_git, git_output
 import json, os, sys

--- a/test/scripts/generate-dependency-release-evidence.test.ts
+++ b/test/scripts/generate-dependency-release-evidence.test.ts
@@ -15,6 +15,10 @@ import {
   resolvePreviousReleaseTag,
   resolveReleaseTag,
 } from "../../scripts/generate-dependency-release-evidence.mts";
+import {
+  RELEASE_DEPENDENCY_RISK_LOCKFILES,
+  resolveReleaseDependencyRiskAcceptance,
+} from "../../scripts/lib/release-dependency-risk-acceptance.mts";
 
 async function writeJson(dir: string, fileName: string, value: unknown) {
   await writeFile(path.join(dir, fileName), `${JSON.stringify(value, null, 2)}\n`, "utf8");
@@ -38,6 +42,96 @@ function expectNoNodeStack(stderr: string) {
 }
 
 describe("generate-dependency-release-evidence", () => {
+  function acceptedRiskInput(): Parameters<typeof resolveReleaseDependencyRiskAcceptance>[0] {
+    return {
+      packageVersion: "2026.9.1",
+      lockfileSha256: { ...RELEASE_DEPENDENCY_RISK_LOCKFILES },
+      blockers: [
+        ...["GHSA-58mr-gqgx-xq4g", "GHSA-qw65-cvwx-89v3"].flatMap((id) =>
+          [
+            { lockfile: "pnpm-lock.yaml", matchedVersions: ["4.1.3"] },
+            {
+              lockfile: ".github/release/vercel-cli/package-lock.json",
+              matchedVersions: ["3.1.6"],
+            },
+          ].map(({ lockfile, matchedVersions }) => ({
+            lockfile,
+            matchedVersions,
+            packageName: "fast-uri",
+            id,
+            severity: "high" as const,
+            graph: "production" as const,
+            malware: false,
+            source: "github-repository" as const,
+            title: "URI authority validation",
+            url: `https://github.com/fastify/fast-uri/security/advisories/${id}`,
+            vulnerableVersions: "<4.1.4",
+          })),
+        ),
+        {
+          lockfile: "pnpm-lock.yaml",
+          packageName: "nodemailer",
+          matchedVersions: ["9.0.4", "9.0.5"],
+          id: "GHSA-2x7j-588g-ccc2",
+          severity: "high",
+          graph: "production",
+          malware: false,
+          source: "github-repository",
+          title: "Address list denial of service",
+          url: "https://github.com/nodemailer/nodemailer/security/advisories/GHSA-2x7j-588g-ccc2",
+          vulnerableVersions: "<9.1.0",
+        },
+      ],
+    };
+  }
+
+  it("retains every accepted advisory and exact graph binding without declaring the scan clean", () => {
+    const input = acceptedRiskInput();
+    const original = structuredClone(input);
+    const acceptance = resolveReleaseDependencyRiskAcceptance(input);
+    expect(acceptance).toMatchObject({
+      kind: "operator-accepted-dependency-risk",
+      packageVersion: "2026.9.1",
+      blockers: original.blockers,
+      lockfileSha256: original.lockfileSha256,
+    });
+    expect(input).toEqual(original);
+  });
+
+  it("never carries acceptance to another release, graph, or unaccepted finding", () => {
+    const mutations = [
+      (input: ReturnType<typeof acceptedRiskInput>) => {
+        input.packageVersion = "2026.9.2";
+      },
+      (input: ReturnType<typeof acceptedRiskInput>) => {
+        input.lockfileSha256["pnpm-lock.yaml"] = "changed";
+      },
+      (input: ReturnType<typeof acceptedRiskInput>) => {
+        input.blockers[0]!.severity = "critical";
+      },
+      (input: ReturnType<typeof acceptedRiskInput>) => {
+        input.blockers[0]!.malware = true;
+      },
+      (input: ReturnType<typeof acceptedRiskInput>) => {
+        input.blockers[0]!.id = "GHSA-unaccepted";
+      },
+      (input: ReturnType<typeof acceptedRiskInput>) => {
+        input.blockers[0]!.matchedVersions = ["4.1.2"];
+      },
+      (input: ReturnType<typeof acceptedRiskInput>) => {
+        input.blockers.push({ ...input.blockers[0]! });
+      },
+      (input: ReturnType<typeof acceptedRiskInput>) => {
+        input.blockers[0] = { ...input.blockers[1]! };
+      },
+    ];
+    for (const mutate of mutations) {
+      const input = acceptedRiskInput();
+      mutate(input);
+      expect(resolveReleaseDependencyRiskAcceptance(input)).toBeNull();
+    }
+  });
+
   it("defines the release evidence command list and policy classifications", () => {
     expect(DEPENDENCY_EVIDENCE_REPORTS.map(({ command, policy }) => ({ command, policy }))).toEqual(
       [

--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import { basename, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { resolveNpmJsonEntries } from "../../scripts/lib/npm-json-output.mts";
 import {
   assertCanonicalNpmPackageName,
   assertCompleteScannerSummary,
@@ -100,7 +101,9 @@ function writePluginArtifact(params: {
     ["pack", "--json", "--ignore-scripts", "--pack-destination", artifactDir],
     { cwd: packageRoot, encoding: "utf8" },
   );
-  const packEntries = JSON.parse(packOutput) as Array<{ filename?: unknown }>;
+  const packEntries = resolveNpmJsonEntries(JSON.parse(packOutput)) as Array<{
+    filename?: unknown;
+  }>;
   const tarballName = packEntries[0]?.filename;
   if (typeof tarballName !== "string") {
     throw new Error("npm pack fixture did not return a tarball filename");
@@ -221,6 +224,9 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
     ];
 
     expect(resolveReviewedSourceLayout(current)?.id).toBe("current");
+    expect(resolveReviewedSourceLayout(current, "release/2026.9.1")?.id).toBe("current");
+    expect(resolveReviewedSourceLayout(frozenLegacy, "release/2026.9.1")).toBeUndefined();
+    expect(resolveReviewedSourceLayout(current, "release/2026.9.2")).toBeUndefined();
     expect(resolveReviewedSourceLayout(frozenLegacy)).toBeUndefined();
     expect(resolveReviewedSourceLayout(frozenLegacy, "extended-stable/2026.6.33")?.id).toBe(
       "extended-stable-2026.6.33",


### PR DESCRIPTION
## What Problem This Solves

Resolves failures that prevented the frozen 2026.9.1 candidate from reaching release qualification in [Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/33678418387). These are trusted-tooling corrections; the product candidate and dependency versions are not updated by this PR.

## Why This Change Was Made

QA selected-ref validation refreshed refs anonymously after checkout removed credentials. Route those fetches through the existing immutable Git owner with transient repository-bound authentication, retaining every ref-admission check. Kova needs a complete checkout immediately, so remove its unnecessary blob filter instead of deferring blobs to a failing unauthenticated promisor request.

Live Docker staging excluded all workspace-local node_modules but restored only the root graph. Preserve the installed package/plugin/UI dependency links alongside the already-staged source. All 17 affected live jobs failed before their scenarios on the same missing markdown-core dependency.

Select the existing current security inventory for the canonical release/2026.9.1 context. Its findings, multiplicity caps, malicious-package rejection, and inert lifecycle checks are unchanged.

The maintainer explicitly requested this release with unchanged dependencies. Record an exception only for version 2026.9.1, the three exact existing lockfile hashes, and the five exact existing high-severity advisory findings. Keep the original vulnerability report and unresolved blockers, add a visible warning and risk-acceptance manifest, and reject any changed graph, additional advisory, critical/malware finding, or other report failure. This is accepted risk, not a clean security scan or an advisory fix.

## User Impact

Release qualification can exercise the frozen candidate using its actual dependency layout and authenticated ref checks. No product runtime, dependency version, runner setting, credential, configuration option, or persistent-state change.

## Evidence

- Integrated focused tooling suite: 101 tests passed across dependency evidence/gate, Docker staging, plugin scan, and real-HTTP Git authentication owners.
- QA/Kova unchanged baseline: nine failures reproduced; connected final cases and lifecycle fences passed. Kova fixture proves checkout completeness, not performance qualification.
- Linux Docker staging reproduction: unchanged helper fails to import a workspace-local dependency; repaired helper imports both package and plugin dependencies successfully with networking disabled.
- Plugin scan: original 50 observations map to the existing 27 inventory keys; no finding or cap added. New release context, wrong layout, unknown release, malicious package, caps, and npm 12 output covered.
- Dependency acceptance: original five findings retained byte-for-byte in the integration fixture; exact-graph acceptance succeeds while old tooling fails. Negative cases reject changed version, locks, advisory, matched versions, duplicates, severity, and malware. This fixture is not a fresh advisory scan.
- Local proof is not hosted exact-head CI or final release qualification. Those remain required.

Known accepted advisories: fast-uri GHSA-58mr-gqgx-xq4g and GHSA-qw65-cvwx-89v3 in the root and Vercel tool graphs; nodemailer GHSA-2x7j-588g-ccc2 in the root graph. No dependency updates are included.
