### PR TITLE
fix(agents): bound grep JSON record intake

### DIFF
--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -20,6 +20,9 @@ vi.mock("../../utils/tools-manager.js", () => ({
 }));
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const GREP_JSON_RECORD_MAX_BYTES = 1024 * 1024;
+const GREP_JSON_RECORD_OVERSIZED_ERROR =
+  "grep stopped because ripgrep emitted a JSON record larger than 1 MiB";
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -29,17 +32,21 @@ type MockChild = ChildProcessWithoutNullStreams & {
   nodeChildProcess: ChildProcessWithoutNullStreams;
   stdout: PassThrough;
   stderr: PassThrough;
+  readonly killCallCount: number;
 };
 
 function createChild(): MockChild {
   let killed = false;
+  let killCallCount = 0;
   const child = Object.assign(new EventEmitter(), {
     stdin: new PassThrough(),
     stdout: new PassThrough(),
     stderr: new PassThrough(),
   }) as unknown as MockChild;
   Object.defineProperty(child, "killed", { get: () => killed });
+  Object.defineProperty(child, "killCallCount", { get: () => killCallCount });
   child.kill = vi.fn(() => {
+    killCallCount += 1;
     killed = true;
     return true;
   });
@@ -63,11 +70,40 @@ function grepRow(
   })}\n`;
 }
 
+function grepRowWithWireBytes(bytes: number): Buffer {
+  const emptyRow = grepRow(1, { text: "" }).slice(0, -1);
+  return Buffer.from(
+    grepRow(1, { text: "x".repeat(bytes - Buffer.byteLength(emptyRow)) }).slice(0, -1),
+  );
+}
+
 function textContent(
   result: Awaited<ReturnType<ReturnType<typeof createGrepToolDefinition>["execute"]>>,
 ): string {
   const first = result.content[0];
   return first?.type === "text" ? (first.text ?? "") : "";
+}
+
+async function startMockGrep(signal?: AbortSignal) {
+  const child = createChild();
+  const expectedSpawns = vi.mocked(spawnCommand).mock.calls.length + 1;
+  vi.mocked(spawnCommand).mockReturnValueOnce(child as never);
+  vi.mocked(ensureTool).mockResolvedValue("rg");
+  const result = createGrepToolDefinition(process.cwd()).execute(
+    "framing",
+    { pattern: "foo" },
+    signal,
+    undefined,
+    {} as never,
+  );
+  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledTimes(expectedSpawns));
+  return { child, result };
+}
+
+function closeChild(child: MockChild, code: number | null, stdout?: string | Buffer) {
+  child.stdout.end(stdout);
+  child.stderr.end();
+  child.emit("close", code);
 }
 
 describe("grep tool streaming", () => {
@@ -713,7 +749,161 @@ describe("grep tool streaming", () => {
     },
   );
 
-  it("keeps stdout guarded after a stderr failure closes readline", async () => {
+  it("rejects an oversized ripgrep JSON record before EOF", async () => {
+    const { child, result } = await startMockGrep();
+    const rejection = result.catch((error: unknown) => error);
+
+    try {
+      for (let chunk = 0; chunk < 17; chunk += 1) {
+        child.stdout.write(Buffer.alloc(64 * 1024, 0x78));
+      }
+      await vi.waitFor(() => expect(child.killCallCount).toBe(1));
+      await expect(rejection).resolves.toEqual(
+        expect.objectContaining({
+          message: expect.stringContaining(GREP_JSON_RECORD_OVERSIZED_ERROR),
+        }),
+      );
+    } finally {
+      closeChild(child, 1);
+    }
+  });
+
+  it("frames below-cap JSON split across chunks and UTF-8 boundaries", async () => {
+    const { child, result } = await startMockGrep();
+
+    const row = Buffer.from(grepRow(1, { text: `needle ${"中".repeat(4096)}\n` }));
+    const split = row.indexOf(Buffer.from("中")) + 1;
+    child.stdout.write(row.subarray(0, split));
+    for (let offset = split; offset < row.length; offset += 257) {
+      child.stdout.write(row.subarray(offset, offset + 257));
+    }
+    closeChild(child, 0);
+
+    expect(textContent(await result)).toContain("needle 中中中");
+  });
+
+  it("processes multiple records from one chunk", async () => {
+    const { child, result } = await startMockGrep();
+    closeChild(child, 0, grepRow(1) + grepRow(2));
+
+    expect(textContent(await result)).toBe("match.txt:1: foo\nmatch.txt:2: foo");
+  });
+
+  it("accepts a JSON record exactly at the wire-record ceiling", async () => {
+    const { child, result } = await startMockGrep();
+    closeChild(
+      child,
+      0,
+      Buffer.concat([grepRowWithWireBytes(GREP_JSON_RECORD_MAX_BYTES), Buffer.from("\n")]),
+    );
+
+    await expect(result).resolves.toMatchObject({
+      details: { linesTruncated: true },
+    });
+    expect(child.killed).toBe(false);
+  });
+
+  it("accepts an exact-ceiling record with CRLF split across chunks", async () => {
+    const { child, result } = await startMockGrep();
+    child.stdout.write(grepRowWithWireBytes(GREP_JSON_RECORD_MAX_BYTES));
+    child.stdout.write("\r");
+    closeChild(child, 0, "\n");
+
+    await expect(result).resolves.toMatchObject({
+      details: { linesTruncated: true },
+    });
+    expect(child.killed).toBe(false);
+  });
+
+  it("rejects byte 1,048,577 before parsing or returning partial matches", async () => {
+    const { child, result } = await startMockGrep();
+    const rejection = result.catch((error: unknown) => error);
+
+    child.stdout.write(grepRow(1));
+    child.stdout.write(Buffer.alloc(GREP_JSON_RECORD_MAX_BYTES + 1, 0x78));
+    await expect(rejection).resolves.toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining(GREP_JSON_RECORD_OVERSIZED_ERROR),
+      }),
+    );
+    expect(child.killed).toBe(true);
+    closeChild(child, null);
+  });
+
+  it("does not parse an oversized record or a later record in the same chunk", async () => {
+    const { child, result } = await startMockGrep();
+
+    child.stdout.write(
+      Buffer.concat([
+        Buffer.alloc(GREP_JSON_RECORD_MAX_BYTES + 1, 0x78),
+        Buffer.from(`\n${grepRow(1)}`),
+      ]),
+    );
+    await expect(result).rejects.toThrow(GREP_JSON_RECORD_OVERSIZED_ERROR);
+    closeChild(child, null);
+  });
+
+  it("recovers on the next grep after terminating an oversized record", async () => {
+    const first = await startMockGrep();
+    first.child.stdout.write(Buffer.alloc(GREP_JSON_RECORD_MAX_BYTES + 1, 0x78));
+    await expect(first.result).rejects.toThrow(GREP_JSON_RECORD_OVERSIZED_ERROR);
+    closeChild(first.child, null);
+
+    const second = await startMockGrep();
+    closeChild(second.child, 0, grepRow(1));
+
+    expect(textContent(await second.result)).toBe("match.txt:1: foo");
+    expect(second.child.killed).toBe(false);
+  });
+
+  it.each([
+    { name: "abort first", first: "abort", expected: "Operation aborted" },
+    { name: "overflow first", first: "overflow", expected: GREP_JSON_RECORD_OVERSIZED_ERROR },
+  ] as const)("keeps first settlement when $name", async ({ first, expected }) => {
+    const controller = new AbortController();
+    const { child, result } = await startMockGrep(controller.signal);
+    const rejection = result.catch((error: unknown) => error);
+
+    if (first === "abort") {
+      controller.abort();
+      child.stdout.write(Buffer.alloc(GREP_JSON_RECORD_MAX_BYTES + 1, 0x78));
+    } else {
+      child.stdout.write(Buffer.alloc(GREP_JSON_RECORD_MAX_BYTES + 1, 0x78));
+      controller.abort();
+    }
+    await expect(rejection).resolves.toEqual(
+      expect.objectContaining({ message: expect.stringContaining(expected) }),
+    );
+    expect(child.killCallCount).toBe(1);
+    closeChild(child, null);
+  });
+
+  it("handles late stream and child errors after overflow", async () => {
+    const { child, result } = await startMockGrep();
+
+    child.stdout.write(Buffer.alloc(GREP_JSON_RECORD_MAX_BYTES + 1, 0x78));
+    await expect(result).rejects.toThrow(GREP_JSON_RECORD_OVERSIZED_ERROR);
+    expect(() => {
+      child.stdout.emit("error", new Error("late stdout"));
+      child.stderr.emit("error", new Error("late stderr"));
+      child.emit("error", new Error("late child"));
+    }).not.toThrow();
+    closeChild(child, null);
+  });
+
+  it.each([
+    { name: "unterminated EOF", prefix: "", suffix: "" },
+    { name: "carriage-return EOF", prefix: "", suffix: "\r" },
+    { name: "CRLF", prefix: "", suffix: "\r\n" },
+    { name: "malformed then valid", prefix: "{not json}\n", suffix: "\n" },
+  ])("preserves $name record handling", async ({ prefix, suffix }) => {
+    const { child, result } = await startMockGrep();
+    closeChild(child, 0, `${prefix}${grepRow(1).slice(0, -1)}${suffix}`);
+
+    expect(textContent(await result)).toBe("match.txt:1: foo");
+  });
+
+  it("keeps stdout guarded after a stderr failure", async () => {
     const child = createChild();
     vi.mocked(spawnCommand).mockReturnValue(child as never);
     vi.mocked(ensureTool).mockResolvedValue("rg");

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -5,7 +5,6 @@
  */
 import { statSync } from "node:fs";
 import path from "node:path";
-import { createInterface } from "node:readline";
 import { resolveNonNegativeIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { Type } from "typebox";
 import { releaseChildProcessOutputAfterExit } from "../../../process/child-process.js";
@@ -52,6 +51,10 @@ const grepSchema = Type.Object({
   limit: Type.Optional(Type.Number({ description: "Max matches; default 100." })),
 });
 const DEFAULT_LIMIT = 100;
+const GREP_JSON_RECORD_MAX_BYTES = 1024 * 1024;
+const GREP_JSON_CARRIAGE_RETURN = Buffer.from([0x0d]);
+const GREP_JSON_RECORD_OVERSIZED_ERROR =
+  "grep stopped because ripgrep emitted a JSON record larger than 1 MiB; narrow the path or pattern, exclude generated/minified files, or inspect the file with a bounded read";
 
 type RipgrepJsonText = { text?: string; bytes?: string };
 
@@ -173,10 +176,8 @@ export function createGrepToolDefinition(
             }
           | undefined;
         let childClosed = false;
-        let rl: ReturnType<typeof createInterface> | undefined;
         let killedDueToLimit = false;
         const cleanup = () => {
-          rl?.close();
           signal?.removeEventListener("abort", onAbort);
         };
         const settle = (fn: () => void): boolean => {
@@ -266,13 +267,15 @@ export function createGrepToolDefinition(
             });
             releaseChildProcessOutputAfterExit(spawnedChild.nodeChildProcess);
             child = spawnedChild;
-            rl = createInterface({ input: spawnedChild.stdout });
             let stderr = "";
             let stderrDroppedBytes = 0;
             let matchCount = 0;
             let matchLimitReached = false;
             let linesTruncated = false;
             const outputLines: string[] = [];
+            let recordParts: Buffer[] = [];
+            let recordBytes = 0;
+            let pendingCarriageReturn = false;
 
             // Decode stderr as UTF-8 at the stream so pipe chunk boundaries
             // cannot split multibyte characters into U+FFFD replacement noise.
@@ -290,9 +293,6 @@ export function createGrepToolDefinition(
                 stopChild();
               }
             };
-            // readline re-emits input failures, then drops its input listener on close.
-            // Keep the direct guard until child exit so later stdout errors stay handled.
-            rl.on("error", (error) => onStreamError("stdout", error));
             spawnedChild.stdout?.on("error", (error) => onStreamError("stdout", error));
             spawnedChild.stderr?.on("error", (error) => onStreamError("stderr", error));
 
@@ -303,7 +303,7 @@ export function createGrepToolDefinition(
               lineText?: string;
             }> = [];
             const nativeFiles = new Map<string, Map<number, string>>();
-            rl.on("line", (line) => {
+            const handleJsonRecord = (line: string) => {
               if (!line.trim() || settled || killedDueToLimit) {
                 return;
               }
@@ -362,6 +362,73 @@ export function createGrepToolDefinition(
               if (matchLimitReached && (customOps || !inLastWindow || lineNumber === windowEnd)) {
                 stopChild(true);
               }
+            };
+            const appendRecordPart = (part: Buffer): boolean => {
+              if (part.length === 0) {
+                return true;
+              }
+              const nextBytes = recordBytes + part.length;
+              if (nextBytes > GREP_JSON_RECORD_MAX_BYTES) {
+                recordParts = [];
+                recordBytes = 0;
+                if (settle(() => reject(new Error(GREP_JSON_RECORD_OVERSIZED_ERROR)))) {
+                  stopChild();
+                }
+                return false;
+              }
+              recordParts.push(part);
+              recordBytes = nextBytes;
+              return true;
+            };
+            const emitRecord = () => {
+              const line = Buffer.concat(recordParts, recordBytes).toString("utf8");
+              recordParts = [];
+              recordBytes = 0;
+              handleJsonRecord(line);
+            };
+            spawnedChild.stdout?.on("data", (chunk: Buffer) => {
+              if (settled || killedDueToLimit) {
+                return;
+              }
+              let offset = 0;
+              if (pendingCarriageReturn) {
+                pendingCarriageReturn = false;
+                if (chunk[0] === 0x0a) {
+                  emitRecord();
+                  if (settled || killedDueToLimit) {
+                    return;
+                  }
+                  offset = 1;
+                } else if (!appendRecordPart(GREP_JSON_CARRIAGE_RETURN)) {
+                  return;
+                }
+              }
+              for (let index = offset; index < chunk.length; index += 1) {
+                if (chunk[index] !== 0x0a) {
+                  continue;
+                }
+                let recordEnd = index;
+                if (index > offset && chunk[index - 1] === 0x0d) {
+                  recordEnd -= 1;
+                }
+                if (!appendRecordPart(chunk.subarray(offset, recordEnd))) {
+                  return;
+                }
+                emitRecord();
+                if (settled || killedDueToLimit) {
+                  return;
+                }
+                offset = index + 1;
+              }
+              const tail = chunk.subarray(offset);
+              if (tail.at(-1) === 0x0d) {
+                if (!appendRecordPart(tail.subarray(0, -1))) {
+                  return;
+                }
+                pendingCarriageReturn = true;
+                return;
+              }
+              appendRecordPart(tail);
             });
 
             spawnedChild.nodeChildProcess.on("error", (error) => {
@@ -370,6 +437,10 @@ export function createGrepToolDefinition(
             });
             spawnedChild.nodeChildProcess.on("close", (code) => {
               childClosed = true;
+              pendingCarriageReturn = false;
+              if (recordBytes > 0 && !settled && !killedDueToLimit) {
+                emitRecord();
+              }
               void (async () => {
                 if (settled) {
                   return;


### PR DESCRIPTION
Fixes #136622

## Problem

The built-in grep tool previously passed ripgrep JSON stdout through `readline`. A single newline-free JSON record could therefore be buffered and UTF-8 decoded without a hard bound before OpenClaw's later result truncation applied.

## Repair

- Frame ripgrep JSON stdout as raw bytes.
- Enforce a hard 1 MiB wire-record ceiling before UTF-8 decode or `JSON.parse`.
- On overflow, terminate the child and return an actionable error with no partial grep output.
- Preserve current stderr diagnostics, ripgrep/tool selection, cancellation, first-settlement behavior, malformed-record handling, and the existing stream-error coverage.
- Add no configuration surface.

## Accepted 1 MiB tradeoff

The 1 MiB ceiling is an intentional OpenClaw availability boundary, not an upstream ripgrep limit. A syntactically valid ripgrep JSON record larger than 1 MiB now fails and asks the caller to narrow the search instead of entering the previous unbounded buffering path. This compatibility tradeoff is explicitly accepted for the deterministic memory bound.

The boundary is inclusive: a wire record of exactly 1,048,576 bytes is accepted; byte 1,048,577 is rejected before decode/parse.

## Ripgrep 15.2.0 contract

Direct source inspection used official ripgrep 15.2.0 revision `e89fff89ac9af12e8d4ce9d5fd07beb408ca730f`:

- `crates/printer/src/json.rs`: compact JSON is written and then terminated by `\n`.
- `crates/printer/src/json.rs`: match/context messages can represent one or more input lines.
- `crates/printer/src/jsont.rs`: invalid UTF-8 data can be represented as base64.
- `crates/core/flags/defs.rs`: `--json` is a JSON Lines stream with five message types, and ordinary output-size controls do not cap JSON records.

Ripgrep defines framing but no record-size ceiling. That is why the cap is documented here as an accepted OpenClaw resource boundary rather than claimed as upstream-transparent behavior.

## Proof

- Pre-fix reproduction: after 1,114,112 newline-free stdout bytes, current main had not killed the child.
- Rebased head: `543c476584bffebfddb49384cf441a014558eede`.
- Focused local checks after rebase: 53 passed; one real-ripgrep Linux-only case skipped on macOS as expected.
- Boundary coverage: exact 1 MiB; 1 MiB + 1; split UTF-8; split CRLF; CRLF and unterminated EOF; multiple records per chunk; parse suppression after overflow; child termination; first-settlement ordering; late stream/child errors; and recovery on the next grep.
- Linux Testbox deterministic suite: 54/54 passed against the source-identical production/test blobs retained by the clean rebase.
- Linux Testbox real ripgrep 15.2.0 adversarial proof: a 33,554,432-byte input was rejected with no partial output, the child terminated, and the next grep recovered.
- Constrained cgroup for that adversarial proof: `memory.max=536870912`, `memory.swap.max=0`, `memory.peak=163565568`; elapsed 35 ms.
- Full `check:changed` passed on the source-identical candidate before the clean touched-file rebase.
- Independent final review of the retained source/test blobs: no P0-P2 findings.
- Exact-head GitHub CI and a fresh ClawSweeper review are requested after this push and remain the landing gates.

## Surface

- Production: +79/-8, net **+71**
- Tests: +191/-1, net **+190**
- Total: +270/-9 across two files

The production growth is the local raw-byte framing state needed to enforce the resource boundary at the subprocess owner before decoding. No suitable shared bounded JSONL subprocess helper exists in the current owner path.

## Scope

Only `src/agents/sessions/tools/grep.ts` and `src/agents/sessions/tools/grep.stream-errors.test.ts` change. Code Mode, Talk, config, protocol, and unrelated failures are untouched.
