### PR TITLE
fix(release): use frozen package acceptance baseline

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -169,7 +169,7 @@ jobs:
       package_required: ${{ steps.inputs.outputs.package_required }}
       docker_required: ${{ steps.inputs.outputs.docker_required }}
       install_smoke_scheduled: ${{ steps.inputs.outputs.install_smoke_scheduled }}
-      installer_smoke_update_baseline: ${{ steps.frozen_installer_smoke_baseline.outputs.value }}
+      frozen_upgrade_baseline: ${{ steps.frozen_upgrade_baseline.outputs.value }}
       fail_fast: ${{ steps.inputs.outputs.fail_fast }}
       run_maturity_scorecard: ${{ steps.inputs.outputs.run_maturity_scorecard }}
       allow_unreleased_changelog: ${{ steps.inputs.outputs.allow_unreleased_changelog }}
@@ -814,10 +814,11 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # A frozen extended-stable target must not downgrade from npm latest.
-      - name: Resolve frozen installer update baseline
-        id: frozen_installer_smoke_baseline
+      - name: Resolve frozen upgrade baseline
+        id: frozen_upgrade_baseline
         if: >-
-          steps.inputs.outputs.install_smoke_scheduled == 'true' &&
+          (steps.inputs.outputs.install_smoke_scheduled == 'true' ||
+          steps.inputs.outputs.package_acceptance_scheduled == 'true') &&
           (startsWith(inputs.target_context_ref, 'extended-stable/') ||
           startsWith(inputs.target_context_ref, 'refs/heads/extended-stable/'))
         env:
@@ -1259,7 +1260,7 @@ jobs:
       allow_unreleased_changelog: ${{ needs.resolve_target.outputs.allow_unreleased_changelog == 'true' }}
       ref: ${{ needs.resolve_target.outputs.revision }}
       run_bun_global_install_smoke: true
-      update_baseline_version: ${{ needs.resolve_target.outputs.installer_smoke_update_baseline || 'latest' }}
+      update_baseline_version: ${{ needs.resolve_target.outputs.frozen_upgrade_baseline || 'latest' }}
 
   cross_os_release_checks:
     needs: [resolve_target, prepare_release_package]
@@ -1446,6 +1447,7 @@ jobs:
       prepublish_plugin_registry_json: ${{ needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '' }}
       suite_profile: custom
       docker_lanes: release-typed-onboarding doctor-switch update-channel-switch skill-install update-corrupt-plugin upgrade-survivor published-upgrade-survivor root-managed-vps-upgrade update-restart-auth plugins-offline plugin-update plugin-binding-command-escape
+      published_upgrade_survivor_baseline: ${{ needs.resolve_target.outputs.frozen_upgrade_baseline && format('openclaw@{0}', needs.resolve_target.outputs.frozen_upgrade_baseline) || 'openclaw@latest' }}
       published_upgrade_survivor_scenarios: ${{ needs.resolve_target.outputs.run_release_soak == 'true' && 'reported-issues' || '' }}
       telegram_mode: ${{ (needs.resolve_target.outputs.telegram_waiver != '' || needs.resolve_target.outputs.skip_package_telegram_e2e == 'true') && 'none' || 'mock-openai' }}
       telegram_advisory: true

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -157,16 +157,18 @@ describe("cross-OS release checks workflow", () => {
     expect(baselineMetadata.run).toContain("const entry = resolveNpmJsonEntries(payload).at(-1);");
   });
 
-  it("passes a frozen-line predecessor from target resolution to installer update smoke", () => {
+  it("passes a frozen-line predecessor to every upgrade-validation caller", () => {
     const release = readWorkflow(RELEASE_CHECKS_PATH);
     const target = job(release, "resolve_target");
-    const baseline = step(target, "Resolve frozen installer update baseline");
+    const baseline = step(target, "Resolve frozen upgrade baseline");
     const installSmoke = job(release, "install_smoke_release_checks");
+    const packageAcceptance = job(release, "package_acceptance_release_checks");
 
-    expect(target.outputs?.installer_smoke_update_baseline).toBe(
-      "${{ steps.frozen_installer_smoke_baseline.outputs.value }}",
+    expect(target.outputs?.frozen_upgrade_baseline).toBe(
+      "${{ steps.frozen_upgrade_baseline.outputs.value }}",
     );
     expect(baseline.if).toContain("steps.inputs.outputs.install_smoke_scheduled == 'true'");
+    expect(baseline.if).toContain("steps.inputs.outputs.package_acceptance_scheduled == 'true'");
     expect(baseline.if).toContain("startsWith(inputs.target_context_ref, 'extended-stable/')");
     expect(baseline.env).toMatchObject({
       GH_TOKEN: "${{ github.token }}",
@@ -176,7 +178,10 @@ describe("cross-OS release checks workflow", () => {
     expect(baseline.run).toContain("node workflow/scripts/lib/release-upgrade-baseline.mjs");
     expect(baseline.run).toContain('echo "value=${baseline#openclaw@}"');
     expect(installSmoke.with?.update_baseline_version).toBe(
-      "${{ needs.resolve_target.outputs.installer_smoke_update_baseline || 'latest' }}",
+      "${{ needs.resolve_target.outputs.frozen_upgrade_baseline || 'latest' }}",
+    );
+    expect(packageAcceptance.with?.published_upgrade_survivor_baseline).toBe(
+      "${{ needs.resolve_target.outputs.frozen_upgrade_baseline && format('openclaw@{0}', needs.resolve_target.outputs.frozen_upgrade_baseline) || 'openclaw@latest' }}",
     );
   });
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -7427,6 +7427,8 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       prepublish_plugin_registry_json:
         "${{ needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '' }}",
       suite_profile: "custom",
+      published_upgrade_survivor_baseline:
+        "${{ needs.resolve_target.outputs.frozen_upgrade_baseline && format('openclaw@{0}', needs.resolve_target.outputs.frozen_upgrade_baseline) || 'openclaw@latest' }}",
     });
     expect(packageAcceptanceJob.with?.candidate_artifact_json).toBe(
       "${{ needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.resolve_target.outputs.candidate_artifact_json || '' }}",


### PR DESCRIPTION
## Root cause

Package-acceptance Docker lanes still defaulted to `openclaw@latest` while installer smoke already used the frozen same-line predecessor. The failed 2026.6.35 run used `openclaw@2026.8.2`, then installed 2026.6.35: a schema 15 to schema 1 downgrade which the candidate correctly refused.

## Repair

Reuse the existing frozen-line resolver for every scheduled upgrade-validation caller. Package acceptance receives a fully-qualified package selector; installer smoke retains its bare version contract. Other contexts still use `openclaw@latest`.

No release-branch, package, tag, or npm state changes.

## Proof

- Failure: https://github.com/openclaw/openclaw/actions/runs/33677409471/job/100407848443
- Actionlint, formatting, static YAML contract verification, and diff check passed.
- Focused Vitest cannot collect locally because this linked worktree has an unrelated `configureFsSafeNative is not a function` dependency mismatch before tests load; exact-head CI is required.

Production LOC: +7/-5 (net +2) | Tests: +12/-5 (net +7)

Best-fix verdict: shared release-checks propagation, not a candidate exception.