### PR TITLE
refactor(terminal): reduce temporary memory for styled text

### DIFF
--- a/packages/terminal-core/src/ansi-sequences.ts
+++ b/packages/terminal-core/src/ansi-sequences.ts
@@ -11,6 +11,7 @@ type AnsiSegment =
   | { kind: "text"; value: string };
 
 export function matchAnsiOscAt(input: string, index: number): string | undefined {
+  // Reset the sticky matcher when callers interleave segment iterators.
   ansiOscAtIndexRegex.lastIndex = index;
   return ansiOscAtIndexRegex.exec(input)?.[0];
 }
@@ -291,8 +292,7 @@ export function scanAnsiCsiAt(input: string, index: number): AnsiCsiScan | undef
   return { controls, ended, value: input.slice(index, cursor) };
 }
 
-export function splitAnsiSegments(input: string): AnsiSegment[] {
-  const segments: AnsiSegment[] = [];
+export function* iterateAnsiSegments(input: string): Generator<AnsiSegment, void> {
   let position = 0;
   let index = 0;
 
@@ -311,14 +311,13 @@ export function splitAnsiSegments(input: string): AnsiSegment[] {
       continue;
     }
     if (index > position) {
-      segments.push({ kind: "text", value: input.slice(position, index) });
+      yield { kind: "text", value: input.slice(position, index) };
     }
-    segments.push({ controls: csi?.controls ?? [], kind: "ansi", value });
+    yield { controls: csi?.controls ?? [], kind: "ansi", value };
     index += value.length;
     position = index;
   }
   if (position < input.length) {
-    segments.push({ kind: "text", value: input.slice(position) });
+    yield { kind: "text", value: input.slice(position) };
   }
-  return segments;
 }

--- a/packages/terminal-core/src/ansi.test.ts
+++ b/packages/terminal-core/src/ansi.test.ts
@@ -1,6 +1,6 @@
 // Terminal Core tests cover ansi behavior.
 import { describe, expect, it } from "vitest";
-import { AnsiSequenceStripper } from "./ansi-sequences.js";
+import { AnsiSequenceStripper, iterateAnsiSegments } from "./ansi-sequences.js";
 import {
   sanitizeForLog,
   splitGraphemes,
@@ -349,5 +349,20 @@ describe("terminal ansi helpers", () => {
       truncateToVisibleWidth("\u001B]8;;https://openclaw.ai\u001B\\link\u001B]8;;\u001B\\", 2),
     ).toBe("\u001B]8;;https://openclaw.ai\u001B\\li\u001B]8;;\u001B\\");
     expect(truncateToVisibleWidth("\u001B[32mxy\u001B[0m", 1)).toBe("\u001B[32mx\u001B[0m");
+  });
+
+  it("isolates interleaved segment scans and closes an unfinished iterator", () => {
+    const input = "before\x1b]8;;https://example.test/\x07link\x1b]8;;\x07after";
+    const expected = [...iterateAnsiSegments(input)];
+    const outer = iterateAnsiSegments(input);
+    const inner = iterateAnsiSegments("other" + input);
+    const first = outer.next().value;
+    expect(inner.next().value).toEqual({ kind: "text", value: "otherbefore" });
+    expect(stripAnsi("nested" + input)).toBe("nestedbeforelinkafter");
+    expect([first, ...outer]).toEqual(expected);
+
+    inner.return();
+    expect(inner.next().done).toBe(true);
+    expect([...iterateAnsiSegments(input)]).toEqual(expected);
   });
 });

--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -3,9 +3,9 @@ import {
   ANSI_COMPAT_CONTROL_SEQUENCE_PATTERN,
   ANSI_OSC_INTRODUCER_PATTERN,
   ANSI_STRING_TERMINATOR_PATTERN,
+  iterateAnsiSegments,
   matchAnsiOscAt,
   scanAnsiCsiAt,
-  splitAnsiSegments,
 } from "./ansi-sequences.js";
 
 /*
@@ -294,7 +294,7 @@ export function truncateToVisibleWidth(input: string, maxWidth: number): string 
     used += fittedWidth;
     budgetSpent = true;
   };
-  for (const segment of splitAnsiSegments(input)) {
+  for (const segment of iterateAnsiSegments(input)) {
     if (segment.kind === "ansi") {
       // CSI retains only C0/DEL controls; TAB is the sole visible-width member.
       const widthControls = segment.controls.filter((control) => control === "\t");

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -1,4 +1,4 @@
-import { splitAnsiSegments } from "./ansi-sequences.js";
+import { iterateAnsiSegments } from "./ansi-sequences.js";
 import { splitGraphemes, truncateToVisibleWidth, visibleWidth } from "./ansi.js";
 import { createDisplayStringFormatter } from "./display-string.js";
 import { sanitizeTerminalText } from "./safe-text.js";
@@ -280,7 +280,7 @@ function wrapLine(text: string, width: number): string[] {
   // Table cells are padded and bordered per physical line, so wrapped lines
   // must not leak styling into padding while the next continuation keeps it.
   const tokens: AnsiToken[] = [];
-  for (const segment of splitAnsiSegments(text)) {
+  for (const segment of iterateAnsiSegments(text)) {
     let value = segment.value;
     if (segment.kind === "ansi") {
       if (segment.controls.includes("\t")) {

--- a/src/tui/components/hyperlink-markdown.test.ts
+++ b/src/tui/components/hyperlink-markdown.test.ts
@@ -1,12 +1,12 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
-import { splitAnsiSegments } from "../../../packages/terminal-core/src/ansi-sequences.js";
+import { iterateAnsiSegments } from "../../../packages/terminal-core/src/ansi-sequences.js";
 import { normalizeTestText } from "../../../test/helpers/normalize-text.js";
 import { markdownTheme } from "../theme/theme.js";
 import { HyperlinkMarkdown } from "./hyperlink-markdown.js";
 
 function osc8Targets(raw: string) {
-  return splitAnsiSegments(raw).flatMap((segment) => {
+  return [...iterateAnsiSegments(raw)].flatMap((segment) => {
     if (segment.kind !== "ansi" || !segment.value.startsWith("\x1b]8;;")) {
       return [];
     }

--- a/src/tui/components/tool-execution.test.ts
+++ b/src/tui/components/tool-execution.test.ts
@@ -1,6 +1,6 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
-import { splitAnsiSegments } from "../../../packages/terminal-core/src/ansi-sequences.js";
+import { iterateAnsiSegments } from "../../../packages/terminal-core/src/ansi-sequences.js";
 import { normalizeTestText } from "../../../test/helpers/normalize-text.js";
 import { ToolExecutionComponent } from "./tool-execution.js";
 
@@ -164,7 +164,7 @@ describe("ToolExecutionComponent", () => {
     const raw = lines.join("\n");
     const normalized = normalizeTestText(raw).replace(/[\u2067\u2069]/gu, "");
     const linkedRtl = lines.find((line) => line.includes("عنصر") && line.includes("\x1b]8;;"));
-    const targets = splitAnsiSegments(raw).flatMap((segment) => {
+    const targets = [...iterateAnsiSegments(raw)].flatMap((segment) => {
       if (segment.kind !== "ansi" || !segment.value.startsWith("\x1b]8;;")) {
         return [];
       }

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -1,5 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
-import { splitAnsiSegments } from "../../packages/terminal-core/src/ansi-sequences.js";
+import { iterateAnsiSegments } from "../../packages/terminal-core/src/ansi-sequences.js";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 
 /** Allow one level of balanced parentheses inside a URL so markdown link
@@ -215,7 +215,7 @@ function applyOsc8Ranges(line: string, ranges: UrlRange[]): string {
   let rangeIndex = 0;
   let range = ranges[rangeIndex];
 
-  for (const segment of splitAnsiSegments(line)) {
+  for (const segment of iterateAnsiSegments(line)) {
     if (segment.kind === "ansi") {
       let code = segment.value;
       if (code.startsWith("\x1b]8;")) {

--- a/src/tui/tui-hyperlinks-pty.e2e.test.ts
+++ b/src/tui/tui-hyperlinks-pty.e2e.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { splitAnsiSegments } from "../../packages/terminal-core/src/ansi-sequences.js";
+import { iterateAnsiSegments } from "../../packages/terminal-core/src/ansi-sequences.js";
 import {
   objectFieldEquals,
   startTuiFixture,
@@ -9,7 +9,7 @@ import {
 function linkedText(output: string) {
   let target = "";
   const spans: Array<{ target: string; text: string }> = [];
-  for (const segment of splitAnsiSegments(output)) {
+  for (const segment of iterateAnsiSegments(output)) {
     if (segment.kind === "ansi") {
       if (segment.value.startsWith("\x1b]8;;")) {
         const terminatorLength = segment.value.endsWith("\x1b\\") ? 2 : 1;

--- a/src/tui/tui-pty-harness-assertion-test-support.ts
+++ b/src/tui/tui-pty-harness-assertion-test-support.ts
@@ -209,7 +209,7 @@ function replayTerminalState(
   if (!terminalOutputIsComplete(raw)) {
     return undefined;
   }
-  for (const segment of ansiSequences.splitAnsiSegments(raw)) {
+  for (const segment of ansiSequences.iterateAnsiSegments(raw)) {
     if (segment.kind === "text") {
       // pi-tui expands visible tabs and does not use literal HT/BS for output layout.
       // Captured HT/BS bytes are invalid evidence, not terminal operations to replay.


### PR DESCRIPTION
## What Problem This Solves

Formatting large styled terminal text temporarily keeps every parsed ANSI/text segment alive, even though truncation, table wrapping and hyperlink formatting consume segments once. A 359,106-byte colored Unicode input produced a live vector of 66,561 segment records.

## Why This Change Was Made

Yield segments from the existing canonical scanner and migrate all internal consumers, including the two hyperlink callers added on current main. This removes the eager vector without changing parsing, visible-width handling, control bytes, style resets or hyperlink destinations. Iterator cursors remain private; the shared sticky matcher resets on each call, so nested and interleaved consumers remain independent. No compatibility wrapper or public API is added.

## User Impact

Large styled text needs less temporary live heap while formatting. This is a memory tradeoff: the fixed long-table benchmark is about 0.63 ms/call slower, and short plain truncation adds about 0.12 microseconds/call. There is no general speedup, idle-leak or Gateway RSS claim. Output remains byte-identical.

## Evidence

The actual-source before/after corpus matched all 315 cases, including 3,780 public truncation/table output results per arm and ordered segment/control records across Unicode and malformed/incomplete sequences. Separate checks preserve interleaved and nested parsing and returned-record mutation behavior; a candidate-only assertion verifies early iterator closure, followed by a fresh scan.

At the same first-segment checkpoint inside each actual formatter, after three forced GCs:

| Caller | Eager heapUsed | Iterator heapUsed | Difference |
| --- | ---: | ---: | ---: |
| Truncation | 19,330,904 B | 13,362,320 B | −5,968,584 B |
| Table wrapping | 19,102,512 B | 13,161,392 B | −5,941,120 B |

Independent raw V8 snapshot inspection verified the baseline's strong Stack-roots → Array-Iterator → segment-vector path. The vector, segment objects and distinct control arrays account for 4,624,568 B of shallow storage, excluding strings. The candidate has no matching vector. This is an instrumented synchronous checkpoint, not dominator retained size or an asynchronous production leak. Completed output hashes match.

All eight timing processes were retained in four fixed alternating pairs. Median paired changes per complete call:

| Workload | Time change | Percent change |
| --- | ---: | ---: |
| Short plain truncation | +0.0001165 ms | +7.43% |
| Short styled truncation | −0.0000483 ms | −2.16% |
| Long styled truncation | −0.3945308 ms | −4.80% |
| Short plain table | +0.0000516 ms | +0.65% |
| Short styled table | +0.0024413 ms | +3.26% |
| Long styled table | +0.6282988 ms | +9.98% |

Long-table and short-plain-truncation timings worsened in all four pairs; the other cells are mixed. Both formatters still parse all segments. Measurements use Node 26.8.1/V8 14.6.202.34; they do not establish Windows or Gateway performance. The three measured production owner files are byte-identical in the final current-main integration; the added hyperlink migrations are not counted as a separate measured gain.

The final integration on `c449bd284f472c4390a07975d7eb72fa76b4619c` passed 255 focused tests and three real PTY cases (100-column VS Code, wrapped 36-column VS Code and unidentified terminal). The native TUI with a synthetic backend preserved the authored link targets, completed its visible frame and exited normally. The OSC8 unit suite additionally checks destinations with pi-tui’s independent column/link parser. These PTY checks cover the native TUI path; Gateway/provider behavior is outside their scope.

The complete nine-file changed gate passed in 321.47 seconds, including production/test types, lint, dead exports and the other canonical guards. Independent managed Codex review through P2 returned no actionable findings across both passes. Source and evidence pins stayed unchanged; supervised processes joined, their recorded groups were absent and test temporary directories were removed. Native PTY cleanup is supported by the existing awaited exit/disposal assertions. Independent parent and proof-caption reviews checked the raw heap graph, paired arithmetic and source bindings.

Production +11/−12 = −1; behavioral tests +22/−7 = +15; test support +1/−1 = 0. No configuration, storage, protocol or public export changes. Frozen measurement report SHA-256: `711369b0b07f9f58af39552273ed2207a155c1b2267a83f324778cb08fa2d6c9`; corpus output SHA-256: `ae51ae04a8021019a1e1b6f9e9b08e2d811c44998680d8ba22179aac0d629f2e`; final nine-file patch SHA-256: `6c28ebdc6ec2440602011dc9141a0890b9e43b1a66182b0393fcef78168ceb3d`.
