### PR TITLE
fix(release): run frozen Docker lane contracts

### DIFF
--- a/scripts/e2e/doctor-install-switch-docker.sh
+++ b/scripts/e2e/doctor-install-switch-docker.sh
@@ -3,11 +3,11 @@
 # git installs. Both fixtures use the same prepared tarball.
 set -euo pipefail
 
-HARNESS_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$HARNESS_ROOT_DIR}" && pwd)"
-DOCKER_E2E_HARNESS_ROOT_DIR="$HARNESS_ROOT_DIR"
-source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-image.sh"
-source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"
+TARGET_CONTRACT_DIR="$TARGET_ROOT_DIR/scripts/e2e/lib/doctor-install-switch"
+source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-doctor-install-switch-e2e" OPENCLAW_DOCTOR_INSTALL_SWITCH_E2E_IMAGE)"
 NPM_INSTALL_TIMEOUT="${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}"
 COMMAND_TIMEOUT="${OPENCLAW_DOCKER_DOCTOR_SWITCH_COMMAND_TIMEOUT:-900s}"
@@ -26,7 +26,7 @@ docker_e2e_build_or_reuse "$IMAGE_NAME" doctor-switch "$ROOT_DIR/scripts/e2e/Doc
 echo "Running doctor install switch E2E..."
 # Maintenance loads the installed unit's canonical PATH. Mount the shims there
 # so the unprivileged container keeps using the fixture manager during inspection.
-SHIM_DIR="${DOCKER_E2E_HARNESS_ROOT_DIR:-$ROOT_DIR}/scripts/e2e/lib/doctor-install-switch/shims"
+SHIM_DIR="$ROOT_DIR/scripts/e2e/lib/doctor-install-switch/shims"
 docker_e2e_run_with_harness \
   -v "$SHIM_DIR/systemctl:/usr/local/bin/systemctl:ro" \
   -v "$SHIM_DIR/loginctl:/usr/local/bin/loginctl:ro" \
@@ -37,5 +37,6 @@ docker_e2e_run_with_harness \
   -e "OPENCLAW_E2E_NPM_INSTALL_TIMEOUT=$NPM_INSTALL_TIMEOUT" \
   -e "OPENCLAW_TEST_STATE_FUNCTION_B64=$OPENCLAW_TEST_STATE_FUNCTION_B64" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
+  -v "$TARGET_CONTRACT_DIR:/app/scripts/e2e/lib/doctor-install-switch:ro" \
   "$IMAGE_NAME" \
   bash scripts/e2e/lib/doctor-install-switch/scenario.sh

--- a/scripts/e2e/doctor-install-switch-docker.sh
+++ b/scripts/e2e/doctor-install-switch-docker.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# Verifies Doctor preserves service definitions and explicit gateway install
-# switches package/git entrypoints. Both fixtures use the same prepared tarball.
+# Verifies the target's Doctor service-maintenance contract across package and
+# git installs. Both fixtures use the same prepared tarball.
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
-source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+HARNESS_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$HARNESS_ROOT_DIR}" && pwd)"
+DOCKER_E2E_HARNESS_ROOT_DIR="$HARNESS_ROOT_DIR"
+source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-doctor-install-switch-e2e" OPENCLAW_DOCTOR_INSTALL_SWITCH_E2E_IMAGE)"
 NPM_INSTALL_TIMEOUT="${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}"
 COMMAND_TIMEOUT="${OPENCLAW_DOCKER_DOCTOR_SWITCH_COMMAND_TIMEOUT:-900s}"

--- a/scripts/e2e/plugin-binding-command-escape-docker.sh
+++ b/scripts/e2e/plugin-binding-command-escape-docker.sh
@@ -12,7 +12,9 @@ IMAGE_NAME="${OPENCLAW_PLUGIN_BINDING_COMMAND_ESCAPE_E2E_IMAGE:-openclaw-plugin-
 CONTAINER_NAME="openclaw-plugin-binding-command-escape-e2e-$$"
 DOCKER_RUN_TIMEOUT="${OPENCLAW_PLUGIN_BINDING_COMMAND_ESCAPE_DOCKER_RUN_TIMEOUT:-900s}"
 RUN_LOG="$(mktemp -t openclaw-plugin-binding-command-escape-log.XXXXXX)"
-FOCUSED_TEST_REGEX="lets authorized gateway-style plugin commands escape plugin-owned bindings|keeps authorized unknown slash text in a plugin-owned binding routed to the bound plugin|keeps unauthorized plugin-owned binding slash replies suppressed while routed to the bound plugin"
+# The command-path test was renamed when main split this suite. The two names
+# describe the same required behavior, and only one exists in a target source.
+FOCUSED_TEST_REGEX="lets authorized (plugin-owned binding commands fall through to command processing|gateway-style plugin commands escape plugin-owned bindings)|keeps authorized unknown slash text in a plugin-owned binding routed to the bound plugin|keeps unauthorized plugin-owned binding slash replies suppressed while routed to the bound plugin"
 
 cleanup() {
   docker_e2e_docker_cmd rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6991,9 +6991,10 @@ done
     const doctorRunner = readFileSync(DOCTOR_SWITCH_DOCKER_E2E_PATH, "utf8");
     expect(doctorRunner).toContain("scripts/e2e/lib/doctor-install-switch/scenario.sh");
     expectTextToIncludeAll(doctorRunner, [
-      'ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$HARNESS_ROOT_DIR}" && pwd)"',
-      'DOCKER_E2E_HARNESS_ROOT_DIR="$HARNESS_ROOT_DIR"',
-      'source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-image.sh"',
+      'TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"',
+      'TARGET_CONTRACT_DIR="$TARGET_ROOT_DIR/scripts/e2e/lib/doctor-install-switch"',
+      'source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"',
+      '"$TARGET_CONTRACT_DIR:/app/scripts/e2e/lib/doctor-install-switch:ro"',
     ]);
     expectTextToIncludeAll(doctorScenario, [
       "OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR=1",

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6988,9 +6988,13 @@ done
       pluginUpdateProbe,
     ];
 
-    expect(readFileSync(DOCTOR_SWITCH_DOCKER_E2E_PATH, "utf8")).toContain(
-      "scripts/e2e/lib/doctor-install-switch/scenario.sh",
-    );
+    const doctorRunner = readFileSync(DOCTOR_SWITCH_DOCKER_E2E_PATH, "utf8");
+    expect(doctorRunner).toContain("scripts/e2e/lib/doctor-install-switch/scenario.sh");
+    expectTextToIncludeAll(doctorRunner, [
+      'ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$HARNESS_ROOT_DIR}" && pwd)"',
+      'DOCKER_E2E_HARNESS_ROOT_DIR="$HARNESS_ROOT_DIR"',
+      'source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-image.sh"',
+    ]);
     expectTextToIncludeAll(doctorScenario, [
       "OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR=1",
       "scripts/e2e/lib/package-compat.mjs",
@@ -7682,6 +7686,7 @@ done
       'DOCKER_RUN_TIMEOUT="${OPENCLAW_PLUGIN_BINDING_COMMAND_ESCAPE_DOCKER_RUN_TIMEOUT:-900s}"',
       'DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run --rm',
       'docker_e2e_docker_cmd rm -f "$CONTAINER_NAME"',
+      "plugin-owned binding commands fall through to command processing",
       "lets authorized gateway-style plugin commands escape plugin-owned bindings",
       "keeps unauthorized plugin-owned binding slash replies suppressed while routed to the bound plugin",
       "expected focused Vitest summary for exactly 3 passed tests",

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -7686,8 +7686,7 @@ done
       'DOCKER_RUN_TIMEOUT="${OPENCLAW_PLUGIN_BINDING_COMMAND_ESCAPE_DOCKER_RUN_TIMEOUT:-900s}"',
       'DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run --rm',
       'docker_e2e_docker_cmd rm -f "$CONTAINER_NAME"',
-      "plugin-owned binding commands fall through to command processing",
-      "lets authorized gateway-style plugin commands escape plugin-owned bindings",
+      "lets authorized (plugin-owned binding commands fall through to command processing|gateway-style plugin commands escape plugin-owned bindings)",
       "keeps unauthorized plugin-owned binding slash replies suppressed while routed to the bound plugin",
       "expected focused Vitest summary for exactly 3 passed tests",
     ]);


### PR DESCRIPTION
## What Problem This Solves

The extended-stable 2026.6.35 package-acceptance run applied current-main Docker scenario expectations to the frozen candidate. The Doctor lane rejected the candidate's valid historical service-switch contract, and the plugin-binding lane selected only two of its three historical regression cases after a main-only title rename.

## Solution

Keep the Docker runner, package preparation, image helpers, and shared harness helpers on trusted main. Mount only the selected target's `scripts/e2e/lib/doctor-install-switch/` directory over the corresponding harness path, so the candidate supplies its versioned Doctor assertions and fixtures. The later per-contract mount intentionally overrides the broader trusted `scripts/e2e` harness mount.

For plugin binding, accept the mutually exclusive historical/current names for the same command-path behavior while continuing to require exactly three focused cases.

No SHA/version exception is added. Normal current-main validation resolves the target root to the harness checkout and retains current behavior.

## Evidence

- Failed package-acceptance artifacts: [doctor-switch](https://github.com/openclaw/openclaw/actions/runs/33677409471/job/100407848507), [plugin-binding-command-escape](https://github.com/openclaw/openclaw/actions/runs/33677409471/job/100407848594).
- Candidate `659df810` contains a self-contained historical Doctor contract directory and all three historical plugin-binding cases; current main contains the current Doctor contract and renamed first binding case.
- The mount-order regression assertion failed before the repair and passes against the updated runner.
- `bash -n` passed for both Docker runners; focused Oxfmt, `git diff --check`, and the direct routing contract check passed.
- Focused Vitest remains blocked before collection by the existing shared-worktree dependency/source skew (`configureFsSafeNative is not a function`); exact-head CI is running.
- Fresh autoreview: scoped-clean, patch correct (0.99).

Production/tooling: +9/-4 (net +5) | Tests: +9/-4 (net +5).

No candidate, version, tag, npm selector, or publish state is changed.
