### PR TITLE
fix(release): keep frozen plugin uninstall contract

### DIFF
--- a/scripts/e2e/lib/plugins/assertions.mjs
+++ b/scripts/e2e/lib/plugins/assertions.mjs
@@ -148,6 +148,19 @@ function readRequiredOpenClawConfig() {
   }
 }
 
+function assertPluginUninstallConfigState(config, pluginId, label = pluginId) {
+  const entry = config.plugins?.entries?.[pluginId];
+  if (process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS === "1") {
+    if (entry) {
+      throw new Error(`${label} config entry still present after uninstall`);
+    }
+    return;
+  }
+  if (!isExplicitPluginDisableMarker(config, pluginId)) {
+    throw new Error(`${label} exact disabled uninstall marker missing`);
+  }
+}
+
 function assertPluginRemoved(params) {
   const list = readJson(params.listFile);
   if ((list.plugins || []).some((entry) => entry.id === params.pluginId)) {
@@ -160,9 +173,7 @@ function assertPluginRemoved(params) {
   }
 
   const config = readOpenClawConfig();
-  if (!isExplicitPluginDisableMarker(config, params.pluginId)) {
-    throw new Error(`${params.pluginId} exact disabled uninstall marker missing`);
-  }
+  assertPluginUninstallConfigState(config, params.pluginId);
   if ((config.plugins?.allow || []).includes(params.pluginId)) {
     throw new Error(`${params.pluginId} allowlist entry still present after uninstall`);
   }
@@ -1012,9 +1023,7 @@ function assertClawHubRemoved() {
   const configAfterUninstall = fs.existsSync(configAfterUninstallPath)
     ? readJson(configAfterUninstallPath)
     : {};
-  if (!isExplicitPluginDisableMarker(configAfterUninstall, pluginId)) {
-    throw new Error(`ClawHub exact disabled uninstall marker missing: ${pluginId}`);
-  }
+  assertPluginUninstallConfigState(configAfterUninstall, pluginId, `ClawHub ${pluginId}`);
   if ((configAfterUninstall.plugins?.allow || []).includes(pluginId)) {
     throw new Error(`ClawHub allowlist entry still present after uninstall: ${pluginId}`);
   }

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -1553,6 +1553,47 @@ ${command}
     }
   });
 
+  it("allows the pre-marker uninstall contract only for frozen-target validation", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugins-assertions-"));
+    const home = path.join(root, "home");
+    const scratchRoot = path.join(root, "scratch");
+    const removedInstallPath = path.join(home, ".openclaw", "extensions", "demo-plugin-tgz");
+
+    try {
+      writeJson(path.join(scratchRoot, "plugins2-uninstalled.json"), { plugins: [] });
+      writeFileSync(
+        path.join(scratchRoot, "plugins2-install-path.txt"),
+        removedInstallPath,
+        "utf8",
+      );
+      writeJson(path.join(home, ".openclaw", "plugins", "installs.json"), {
+        installRecords: {},
+      });
+
+      const baseEnv = {
+        ...process.env,
+        HOME: home,
+        OPENCLAW_CONFIG_PATH: path.join(home, ".openclaw", "openclaw.json"),
+        OPENCLAW_PLUGINS_TMP_DIR: scratchRoot,
+        OPENCLAW_STATE_DIR: path.join(home, ".openclaw"),
+      };
+      const current = spawnSync(process.execPath, [ASSERTIONS_SCRIPT, "plugin-tgz-removed"], {
+        encoding: "utf8",
+        env: baseEnv,
+      });
+      const frozen = spawnSync(process.execPath, [ASSERTIONS_SCRIPT, "plugin-tgz-removed"], {
+        encoding: "utf8",
+        env: { ...baseEnv, OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1" },
+      });
+
+      expect(current.status).not.toBe(0);
+      expect(current.stderr).toContain("exact disabled uninstall marker missing");
+      expect(frozen.status).toBe(0);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("rejects unreadable config during plugin uninstall proof", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugins-assertions-"));
     const home = path.join(root, "home");


### PR DESCRIPTION
## Why

#135729 added an exact disabled-marker contract after the `.35` candidate froze. Package acceptance currently sends the explicit frozen-target compatibility mode, but the plugin assertion still applies that newer contract to the frozen package. The failed `plugins-offline` job is here: https://github.com/openclaw/openclaw/actions/runs/33677409471/job/100407848572

## Scope

Normal validation still requires the exact `{ enabled: false }` uninstall marker. Only the already-authorized frozen-target mode accepts the older contract: no listed plugin, no install record, no config entry, and no allow/deny entry. It does not skip the uninstall proof or modify candidate behavior; it stops the harness from asserting a feature that the frozen package never shipped.

No version/SHA branch, package change, or release-state mutation.

## Proof

- `node scripts/run-vitest.mjs test/scripts/plugins-assertions.test.ts` — 43 passed
- focused Oxfmt and OXLint; `git diff --check`

Production: +15/-6 | Tests: +41/-0