### PR TITLE
fix(cli): preserve profile context in device approval hints

### DIFF
--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -41,6 +41,8 @@ Paired device display names use this precedence: operator label (`operatorLabel`
 
 Approve a pending pairing request by exact `requestId`. Omitting `requestId`, or passing `--latest`, only previews the newest pending request and exits (code 1); rerun with the exact request ID to approve.
 
+The printed approval command keeps your active profile or container, explicit Gateway URL, nondefault timeout, and JSON output mode. Token and password option values are omitted; supply the same credentials again when the preview asks you to reuse those options.
+
 ```bash
 openclaw devices approve
 openclaw devices approve <requestId>

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -36,6 +36,7 @@ import {
 import { formatCliCommand } from "./command-format.js";
 import { callGatewayFromCliWithTransport } from "./gateway-rpc.js";
 import { formatConnectionFlagReminder } from "./nodes-cli/cli-utils.js";
+import { formatPairingApproveCommand } from "./pairing-command-format.js";
 import { quoteCliArg } from "./quote-cli-arg.js";
 
 type DevicesRpcOpts = {
@@ -136,15 +137,6 @@ const callGatewayCli = async (
     sharedStateMode: "read-only",
   });
 
-function buildNodeApproveCommand(opts: DevicesRpcOpts, requestId: string): string {
-  const args = ["openclaw", "nodes", "approve", requestId];
-  const timeout = normalizeOptionalString(opts.timeout);
-  if (timeout && timeout !== String(DEFAULT_DEVICES_TIMEOUT_MS)) {
-    args.push("--timeout", timeout);
-  }
-  return formatCliCommand(args.map(quoteCliArg).join(" "));
-}
-
 function stringsMatch(left: unknown, right: unknown): boolean {
   const normalizedLeft = normalizeOptionalString(left);
   const normalizedRight = normalizeOptionalString(right);
@@ -176,7 +168,7 @@ function buildPendingNodeApprovalNotice(
       normalizeOptionalString(device.nodeSurface?.displayName) ??
       normalizeOptionalString(device.displayName) ??
       device.deviceId,
-    command: buildNodeApproveCommand(opts, requestId),
+    command: formatPairingApproveCommand("nodes", requestId, { timeout: opts.timeout }),
     connectionReminder: formatConnectionFlagReminder(opts),
   };
 }
@@ -279,16 +271,16 @@ function buildFallbackStateMismatchError(
   // each rejected connect re-mints the request, so the held id is stale rather
   // than foreign. Only an empty list suggests a genuinely different store, and
   // shared-auth flags are only a fix when the gateway actually uses shared auth.
-  const guidance =
-    pendingRequestIds.length > 0
-      ? [
-          "That request was superseded by a newer pending request.",
-          `Approve the current request instead: openclaw devices approve ${pendingRequestIds[0]}`,
-        ]
-      : [
-          "The running gateway may be using a different OPENCLAW_PROFILE or OPENCLAW_STATE_DIR than this CLI.",
-          "Rerun with the gateway's profile/state-dir; if the gateway uses shared auth, pass --token/--password to approve through it.",
-        ];
+  const currentRequestId = pendingRequestIds[0];
+  const guidance = currentRequestId
+    ? [
+        "That request was superseded by a newer pending request.",
+        `Approve the current request instead: ${formatPairingApproveCommand("devices", currentRequestId)}`,
+      ]
+    : [
+        "The running gateway may be using a different OPENCLAW_PROFILE or OPENCLAW_STATE_DIR than this CLI.",
+        "Rerun with the gateway's profile/state-dir; if the gateway uses shared auth, pass --token/--password to approve through it.",
+      ];
   return new Error([heading, ...guidance].join("\n"));
 }
 
@@ -754,22 +746,6 @@ function lookupPairedDevice(
   return paired;
 }
 
-function buildExplicitApproveCommand(opts: DevicesRpcOpts, requestId: string): string {
-  const args = ["openclaw", "devices", "approve", requestId];
-  const url = normalizeOptionalString(opts.url);
-  if (url) {
-    args.push("--url", url);
-  }
-  const timeout = normalizeOptionalString(opts.timeout);
-  if (timeout && timeout !== String(DEFAULT_DEVICES_TIMEOUT_MS)) {
-    args.push("--timeout", timeout);
-  }
-  if (opts.json === true) {
-    args.push("--json");
-  }
-  return args.map(quoteCliArg).join(" ");
-}
-
 function formatAuthFlagReminder(opts: DevicesRpcOpts): string {
   const flags: string[] = [];
   if (normalizeOptionalString(opts.token)) {
@@ -1015,7 +991,7 @@ export async function runDevicesApproveCommand(
       req,
       lookupPairedDevice(indexPairedDevices(pairingList?.paired), req),
     );
-    const approveCommand = buildExplicitApproveCommand(opts, req.requestId);
+    const approveCommand = formatPairingApproveCommand("devices", req.requestId, opts);
     const authReminder = formatAuthFlagReminder(opts);
     if (opts.json) {
       defaultRuntime.writeJson({

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -177,6 +177,11 @@ function mockApprovedReplacement() {
 }
 
 const requireRecord = createRequireRecord("object", "label-not-object");
+const approvalCommandContexts = [
+  ["default", undefined, undefined, "openclaw"],
+  ["profile", "work", undefined, "openclaw --profile work"],
+  ["container", "work", "demo", "openclaw --container demo"],
+] as const;
 
 function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
   for (const [key, value] of Object.entries(fields)) {
@@ -449,56 +454,70 @@ describe("devices cli approve", () => {
     expect(hasGatewayMethod("device.pair.approve")).toBe(false);
   });
 
-  it("includes explicit gateway flags in the rerun approval command", async () => {
-    callGateway.mockResolvedValueOnce({
-      pending: [{ requestId: "req-url", deviceId: "device-9", ts: 1000 }],
-    });
+  it.each(approvalCommandContexts)(
+    "includes explicit gateway flags in the %s approval command",
+    async (_context, profile, container, prefix) => {
+      vi.stubEnv("OPENCLAW_PROFILE", profile);
+      vi.stubEnv("OPENCLAW_CONTAINER_HINT", container);
+      callGateway.mockResolvedValueOnce({
+        pending: [{ requestId: "req-url", deviceId: "device-9", ts: 1000 }],
+      });
 
-    await runDevicesApprove([
-      "--latest",
-      "--url",
-      "ws://gateway.example:18789/openclaw?cluster=qa lab",
-      "--timeout",
-      "3000",
-      "--token",
-      "secret-token",
-    ]);
+      await runDevicesApprove([
+        "--latest",
+        "--url",
+        "ws://gateway.example:18789/openclaw?cluster=qa lab",
+        "--timeout",
+        "3000",
+        "--token",
+        "secret-token",
+        "--password",
+        "secret-password",
+      ]);
 
-    const errorOutput = runtime.error.mock.calls.map((c) => readRuntimeCallText(c)).join("\n");
-    expect(errorOutput).toContain(
-      "openclaw devices approve req-url --url 'ws://gateway.example:18789/openclaw?cluster=qa lab' --timeout 3000",
-    );
-    expect(errorOutput).toContain("Reuse the same --token option when rerunning.");
-    expect(errorOutput).not.toContain("secret-token");
-    expect(hasGatewayMethod("device.pair.approve")).toBe(false);
-  });
+      const errorOutput = runtime.error.mock.calls.map((c) => readRuntimeCallText(c)).join("\n");
+      expect(errorOutput).toContain(
+        `${prefix} devices approve req-url --url 'ws://gateway.example:18789/openclaw?cluster=qa lab' --timeout 3000`,
+      );
+      expect(errorOutput).toContain("Reuse the same --token/--password options when rerunning.");
+      expect(errorOutput).not.toContain("secret-token");
+      expect(errorOutput).not.toContain("secret-password");
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(hasGatewayMethod("device.pair.approve")).toBe(false);
+    },
+  );
 
-  it("returns JSON for implicit approval preview in JSON mode", async () => {
-    callGateway.mockResolvedValueOnce({
-      pending: [{ requestId: "req-json", deviceId: "device-json", ts: 1000 }],
-      paired: [],
-    });
+  it.each(approvalCommandContexts)(
+    "returns JSON for the %s implicit approval preview",
+    async (_context, profile, container, prefix) => {
+      vi.stubEnv("OPENCLAW_PROFILE", profile);
+      vi.stubEnv("OPENCLAW_CONTAINER_HINT", container);
+      callGateway.mockResolvedValueOnce({
+        pending: [{ requestId: "req-json", deviceId: "device-json", ts: 1000 }],
+        paired: [],
+      });
 
-    await runDevicesApprove(["--latest", "--json", "--url", "ws://gateway.example:18789"]);
+      await runDevicesApprove(["--latest", "--json", "--url", "ws://gateway.example:18789"]);
 
-    expect(runtime.log).not.toHaveBeenCalled();
-    expect(runtime.error).not.toHaveBeenCalled();
-    expect(runtime.writeJson).toHaveBeenCalledWith({
-      selected: { requestId: "req-json", deviceId: "device-json", ts: 1000 },
-      approvalState: {
-        kind: "new-pairing",
-        requested: { roles: [], scopes: [] },
-        approved: null,
-      },
-      approveCommand: "openclaw devices approve req-json --url ws://gateway.example:18789 --json",
-      requiresAuthFlags: {
-        token: false,
-        password: false,
-      },
-    });
-    expect(runtime.exit).toHaveBeenCalledWith(1);
-    expect(hasGatewayMethod("device.pair.approve")).toBe(false);
-  });
+      expect(runtime.log).not.toHaveBeenCalled();
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(runtime.writeJson).toHaveBeenCalledWith({
+        selected: { requestId: "req-json", deviceId: "device-json", ts: 1000 },
+        approvalState: {
+          kind: "new-pairing",
+          requested: { roles: [], scopes: [] },
+          approved: null,
+        },
+        approveCommand: `${prefix} devices approve req-json --url ws://gateway.example:18789 --json`,
+        requiresAuthFlags: {
+          token: false,
+          password: false,
+        },
+      });
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(hasGatewayMethod("device.pair.approve")).toBe(false);
+    },
+  );
 
   it("prints an error and exits when no pending requests are available", async () => {
     callGateway.mockResolvedValueOnce({ pending: [] });
@@ -940,6 +959,7 @@ describe("devices cli local fallback", () => {
   });
 
   it("points at the current pending request when the gateway request id went stale", async () => {
+    vi.stubEnv("OPENCLAW_PROFILE", "work");
     rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-profile)");
     listDevicePairing.mockResolvedValueOnce({
       pending: [{ requestId: "req-default", deviceId: "device-1", publicKey: "pk", ts: 1 }],
@@ -956,7 +976,7 @@ describe("devices cli local fallback", () => {
       (error: unknown) => String(error),
     );
     expect(failure).toContain("superseded by a newer pending request");
-    expect(failure).toContain("openclaw devices approve req-default");
+    expect(failure).toContain("openclaw --profile work devices approve req-default");
     expect(failure).not.toContain("OPENCLAW_PROFILE");
     expect(failure).not.toContain("--token");
     expect(readRuntimeOutput()).not.toContain(fallbackNotice);
@@ -1021,6 +1041,7 @@ describe("devices cli list", () => {
   });
 
   it("shows pending node approval commands for paired node devices", async () => {
+    vi.stubEnv("OPENCLAW_PROFILE", "work");
     callGateway.mockResolvedValueOnce({
       pending: [],
       paired: [
@@ -1057,7 +1078,7 @@ describe("devices cli list", () => {
     expect(callGateway).toHaveBeenCalledOnce();
     const output = readRuntimeOutput();
     expect(output).toContain("Node reapproval pending for Colin's S25");
-    expect(output).toContain("openclaw nodes approve node-req-1");
+    expect(output).toContain("openclaw --profile work nodes approve node-req-1");
     expect(output).toContain("Reuse the same connection options when rerunning: --url, --token.");
     expect(output).not.toContain("gateway-user");
     expect(output).not.toContain("url-secret");

--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -11,9 +11,8 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
 import { defaultRuntime } from "../../runtime.js";
 import { shortenHomeInString } from "../../utils.js";
-import { formatCliCommand } from "../command-format.js";
+import { formatPairingApproveCommand } from "../pairing-command-format.js";
 import { parseDurationMs } from "../parse-duration.js";
-import { quoteCliArg } from "../quote-cli-arg.js";
 import { formatConnectionFlagReminder, getNodesTheme, runNodesCommand } from "./cli-utils.js";
 import { formatPermissions, parseNodeList, parsePairingList } from "./format.js";
 import { renderPendingPairingRequestsTable } from "./pairing-render.js";
@@ -27,8 +26,6 @@ import type { NodeListNode, NodesRpcOpts, PairedNode } from "./types.js";
 
 type PairedNodeListRow = PairedNode & Partial<NodeListNode>;
 type NodeApprovalState = NonNullable<NodeListNode["approvalState"]>;
-
-const DEFAULT_NODES_RPC_TIMEOUT_MS = 10_000;
 
 function formatVersionLabel(raw: string) {
   const trimmed = raw.trim();
@@ -145,19 +142,6 @@ function isPendingApprovalState(
   state: NodeApprovalState | null,
 ): state is "pending-approval" | "pending-reapproval" {
   return state === "pending-approval" || state === "pending-reapproval";
-}
-
-function formatPendingApprovalCommand(raw: unknown, opts: NodesRpcOpts): string | null {
-  const requestId = normalizeOptionalString(raw);
-  if (!requestId) {
-    return null;
-  }
-  const args = ["openclaw", "nodes", "approve", requestId];
-  const timeout = normalizeOptionalString(opts.timeout);
-  if (timeout && timeout !== String(DEFAULT_NODES_RPC_TIMEOUT_MS)) {
-    args.push("--timeout", timeout);
-  }
-  return formatCliCommand(args.map(quoteCliArg).join(" "));
 }
 
 function parseSinceMs(raw: string | undefined, label: string): number | undefined {
@@ -354,8 +338,11 @@ export function registerNodesStatusCommands(nodes: Command) {
           );
           for (const node of filtered) {
             const approvalState = formatNodeApprovalState(node.approvalState);
-            const approveCommand = formatPendingApprovalCommand(node.pendingRequestId, opts);
-            if (isPendingApprovalState(approvalState) && approveCommand) {
+            const requestId = normalizeOptionalString(node.pendingRequestId);
+            if (isPendingApprovalState(approvalState) && requestId) {
+              const approveCommand = formatPairingApproveCommand("nodes", requestId, {
+                timeout: opts.timeout,
+              });
               const action = approvalState === "pending-reapproval" ? "Reapproval" : "Approval";
               defaultRuntime.log(
                 warn(
@@ -409,9 +396,10 @@ export function registerNodesStatusCommands(nodes: Command) {
             ? obj.pendingDeclaredCommands.map(String).filter(Boolean).toSorted()
             : [];
           const pendingPerms = formatPermissions(obj.pendingDeclaredPermissions);
-          const approveCommand = isPendingApprovalState(approvalState)
-            ? formatPendingApprovalCommand(pendingRequestId, opts)
-            : null;
+          const approveCommand =
+            isPendingApprovalState(approvalState) && pendingRequestId
+              ? formatPairingApproveCommand("nodes", pendingRequestId, { timeout: opts.timeout })
+              : null;
           const connectionReminder = approveCommand ? formatConnectionFlagReminder(opts) : null;
           const family = typeof obj.deviceFamily === "string" ? obj.deviceFamily : null;
           const model = typeof obj.modelIdentifier === "string" ? obj.modelIdentifier : null;

--- a/src/cli/pairing-command-format.ts
+++ b/src/cli/pairing-command-format.ts
@@ -1,0 +1,26 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { formatCliCommand } from "./command-format.js";
+import type { GatewayRpcOpts } from "./gateway-rpc.types.js";
+import { quoteCliArg } from "./quote-cli-arg.js";
+
+/** Format an exact-request approval hint; callers keep token/password flags in reminders. */
+export function formatPairingApproveCommand(
+  group: "devices" | "nodes",
+  requestId: string,
+  opts: Pick<GatewayRpcOpts, "url" | "timeout" | "json"> = {},
+): string {
+  const args = ["openclaw", group, "approve", requestId];
+  const url = normalizeOptionalString(opts.url);
+  if (url) {
+    args.push("--url", url);
+  }
+  const timeout = normalizeOptionalString(opts.timeout);
+  // Both pairing commands default to a 10-second RPC timeout.
+  if (timeout && timeout !== "10000") {
+    args.push("--timeout", timeout);
+  }
+  if (opts.json === true) {
+    args.push("--json");
+  }
+  return formatCliCommand(args.map(quoteCliArg).join(" "));
+}

--- a/src/cli/program.nodes-basic.e2e.test.ts
+++ b/src/cli/program.nodes-basic.e2e.test.ts
@@ -691,6 +691,7 @@ describe("cli program (nodes basics)", () => {
   });
 
   it("keeps explicit gateway options in node reapproval guidance without leaking auth", async () => {
+    vi.stubEnv("OPENCLAW_PROFILE", "work");
     programGatewayCallMock.mockResolvedValue({
       ts: Date.now(),
       nodes: [
@@ -717,7 +718,9 @@ describe("cli program (nodes basics)", () => {
     ]);
 
     const output = getRuntimeOutput();
-    expect(output).toContain("openclaw nodes approve request-reapproval --timeout 3000");
+    expect(output).toContain(
+      "openclaw --profile work nodes approve request-reapproval --timeout 3000",
+    );
     expect(output).toContain("Reuse the same connection options when rerunning: --url, --token.");
     expect(output).not.toContain("gateway-user");
     expect(output).not.toContain("url-secret");


### PR DESCRIPTION
Fixes #136632.

## What Problem This Solves

`openclaw --profile work devices approve --latest --json` selected a pending request from the work profile but printed an approval command without that profile. Copying the exact command connected to the default Gateway. Stale-request recovery guidance also omitted the active context.

## Why This Change Was Made

One private CLI formatter now quotes the exact request and explicit URL, timeout and JSON options, then delegates active profile/container handling to the existing `formatCliCommand` owner. Devices previews and recovery guidance share it with node inventory. Three duplicate builders are removed.

Production **+50 / −60 = −10 LOC**; tests **+74 / −50 = +24**; docs **+2**. The existing exact-request approval boundary remains: implicit selection only previews and exits 1. Node inventory retains separate connection reminders; token/password option values stay out of generated commands. No enrollment, role/scope, fallback authorization, storage or protocol change is made.

## User Impact

Copied approval commands keep the selected profile or container. Explicit Gateway URL, nondefault timeout, JSON mode and request quoting are preserved. Existing operator confirmation and credential reminders remain in place.

## Evidence

Five regression cases failed on the original owner. All 186 focused owner/sibling tests pass, covering profiles/containers, URL quoting, auth redaction, preview-only behavior, node inventory, join-code and timeout handling. The full required changed-file gate and independent cumulative Codex review through P2 pass.

The compiled CLI ran six subprocesses against two isolated synthetic Gateway adapters, in before/after order:

| Real CLI flow | Before | After |
| --- | --- | --- |
| Work-profile preview | Selects work request; hint omits profile | Selects work request; hint includes `--profile work` |
| Execute the exact printed hint | Calls default Gateway | Calls work Gateway |
| Explicit `--profile work` control | Calls work Gateway | Calls work Gateway |

Every adapter rejects all device actions; no enrollment or real approval occurred. All children exit normally with the expected preview/rejection code 1. Container hint rendering is tested; container transport is unchanged and was not invoked. An initial candidate exposed a missing existing join-code import; it was restored before the final tests, build, behavior proof, gate and review.

Root inspected the complete changed owners, canonical formatter, changed tests, original raw-parent history, stable behavior and actual CLI receipts. The raw hint entered in `192ee081e77e755874db4dd8277b503846f56941` (#64160), and the affected owner remains in stable `v2026.8.2`. Current main retains the same affected code.

## Final review disposition

The latest ClawSweeper review has no findings or rank-up moves requiring a change. Root independently inspected the shared owner, affected callers, stable behavior and actual compiled-CLI evidence; current main leaves the changed production owner unchanged and composes cleanly. Required exact-head CI is green.
