### PR TITLE
fix: keep clean source CLI commands from rebuilding dist

### DIFF
--- a/scripts/run-node.mts
+++ b/scripts/run-node.mts
@@ -662,13 +662,6 @@ export const resolveBuildRequirement = (deps: RunNodeRequirementDeps): BuildRequ
     return { shouldBuild: true, reason: "missing_dist_entry" };
   }
 
-  for (const filePath of deps.configFiles) {
-    const mtime = statMtime(filePath, deps.fs);
-    if (mtime != null && mtime > stamp.mtime) {
-      return { shouldBuild: true, reason: "config_newer" };
-    }
-  }
-
   const currentHead = resolveGitHead(deps);
   if (currentHead && !stamp.head) {
     return { shouldBuild: true, reason: "build_stamp_missing_head" };
@@ -686,6 +679,13 @@ export const resolveBuildRequirement = (deps: RunNodeRequirementDeps): BuildRequ
         return { shouldBuild: true, reason: "missing_bundled_plugin_dist_entry" };
       }
       return { shouldBuild: false, reason: "clean" };
+    }
+  }
+
+  for (const filePath of deps.configFiles) {
+    const mtime = statMtime(filePath, deps.fs);
+    if (mtime != null && mtime > stamp.mtime) {
+      return { shouldBuild: true, reason: "config_newer" };
     }
   }
 

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -1669,6 +1669,41 @@ describe("run-node script", () => {
     });
   });
 
+  it("ignores newer tracked config mtimes when Git proves the checkout is clean", async ({
+    tmp,
+  }) => {
+    await setupStampedProject(tmp, {
+      files: { [ROOT_TSDOWN]: "export default {};\n" },
+      oldPaths: [ROOT_SRC],
+      newPaths: [ROOT_TSCONFIG, ROOT_PACKAGE, ROOT_TSDOWN],
+    });
+
+    const requirement = resolveBuildRequirement(createBuildRequirementDeps(tmp));
+
+    expect(requirement).toEqual({
+      shouldBuild: false,
+      reason: "clean",
+    });
+  });
+
+  it("uses newer config mtimes when Git state is unavailable", async ({ tmp }) => {
+    await setupStampedProject(tmp, {
+      oldPaths: [ROOT_SRC],
+      newPaths: [ROOT_TSCONFIG, ROOT_PACKAGE],
+    });
+    const { spawnSync } = createSpawnRecorder();
+
+    const requirement = resolveBuildRequirement({
+      ...createBuildRequirementDeps(tmp),
+      spawnSync,
+    });
+
+    expect(requirement).toEqual({
+      shouldBuild: true,
+      reason: "config_newer",
+    });
+  });
+
   it("reports clean in sparse worktrees without bundled plugin sources", async ({ tmp }) => {
     await setupStampedProject(tmp, { oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE] });
     await fs.rm(resolvePath(tmp, "extensions"), { recursive: true, force: true });
@@ -2240,14 +2275,16 @@ describe("run-node script", () => {
     expect(spawnCalls).toEqual([statusCommandSpawn()]);
   });
 
-  it("rebuilds when tsdown config is newer than the build stamp", async ({ tmp }) => {
+  it("rebuilds when tsdown config is dirty", async ({ tmp }) => {
     await setupStampedProject(tmp, {
       files: { [ROOT_TSDOWN]: "export default {};\n" },
       oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
       newPaths: [ROOT_TSDOWN],
     });
 
-    const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder();
+    const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder({
+      gitStatus: ` M ${ROOT_TSDOWN}\n`,
+    });
     const exitCode = await runStatusCommand({
       tmp,
       spawn,


### PR DESCRIPTION
Closes #136631

## What Problem This Solves

`pnpm openclaw` could classify a clean, current source checkout as stale solely because `package.json`, `tsconfig.json`, or `tsdown.config.ts` had an mtime newer than the build stamp. That launched an unnecessary full build. In a source deployment, a later gateway restart could then expose mixed runtime and Control UI generations, leaving the browser disconnected or blank.

## Why This Change Was Made

The config-mtime check ran before the existing Git HEAD and watched-tree checks. This moves the same check into the Git-unavailable fallback path, matching the existing source-root policy:

- matching HEAD plus a clean watched tree is authoritative;
- a real dirty config file still rebuilds;
- config mtimes still protect non-Git or unreadable-Git checkouts.

The production change moves seven existing lines and adds no production LOC.

## User Impact

Read-only CLI commands from a clean source checkout no longer rebuild `dist` because of timestamp-only drift. Legitimate source/config changes and changed HEADs continue to rebuild.

## Evidence

- Regression captured before the fix: expected `clean`, received `config_newer`.
- `pnpm test src/infra/run-node.test.ts` — 92 passed.
- `pnpm check:changed` — passed with exit code 0.
- Post-rebase focused regression/fallback/dirty-config checks — 3 passed.
- `git diff --check` — passed.
- Exact-head `qaRuntime` build — passed in 2m37s, including CLI bootstrap, 53 plugin control-plane load checks, runtime postbuild, and both stamps.

### Real behavior proof

Observed on exact PR head `9a49b3e60e34317443813e3ec609f18b48c3aad4` in the isolated source checkout after the exact-head runtime build:

```text
$ git status --porcelain=v1
# no output: clean

$ cat dist/.buildstamp
{"builtAt":1788385510168,"head":"9a49b3e60e34317443813e3ec609f18b48c3aad4"}

$ sha256sum package.json
97ac89b068940894bccd937044c66b7d764157774b3bf89ef8a9b82ac36155b1  package.json

$ touch package.json
$ git status --porcelain=v1
# no output: still clean

$ sha256sum package.json
97ac89b068940894bccd937044c66b7d764157774b3bf89ef8a9b82ac36155b1  package.json

$ stat -c '%Y %n' dist/.buildstamp package.json
1788385510 dist/.buildstamp
1788385561 package.json

$ OPENCLAW_RUNNER_LOG=1 pnpm openclaw --version
$ node scripts/run-node.mjs --version
OpenClaw 2026.8.1 (9a49b3e)
# exit 0; no "Building TypeScript" runner log

$ sha256sum dist/.buildstamp
2ded1410cc7145232d53f331d922eb3d0bcba6407e871462196058566ea0a4ba  dist/.buildstamp
# identical before and after; mtime remained 1788385510

$ git status --porcelain=v1
# no output: clean
```

This is timestamp-only drift (`package.json` content unchanged, mtime 51 seconds newer than the current build stamp) through the real `pnpm openclaw` wrapper. It launched the CLI without rebuilding or rewriting the build stamp.
