### PR TITLE
fix(nodes): preserve ambiguity between current node clients

### DIFF
--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -26,6 +26,8 @@ openclaw nodes describe --node <idOrNameOrIp>
 
 `status` and `list` both accept `--connected` (only connected nodes) and `--last-connected <duration>` (e.g. `24h`, `7d`; only nodes that connected within the duration). Both use the Gateway's recorded last connection time, including recent reconnects and disconnected nodes with known connection history. `list` shows pending and paired nodes in separate tables, with paired rows including the most recent connect age (Last Connect); `status` shows one merged table with per-node capability, version, and last-input detail. A connected macOS node reports last input only after the user enables **Active computer detection** and grants Accessibility; the freshest row is marked `active`. See [Active computer presence](/nodes/presence). `describe` prints one node's capabilities, permissions, activity, and effective/pending invoke commands.
 
+`--node` accepts an exact ID, IP address, display name, or ID prefix of at least six characters. Exact ID and IP matches take precedence over names and prefixes. Within the strongest match, connected nodes take precedence. If current clients share a name, use an exact ID to disambiguate; client type does not choose the target. The legacy migration exception prefers a unique OpenClaw client only when every other tied entry is a known Clawdbot or Moldbot client.
+
 ## Pairing
 
 ```bash

--- a/src/agents/bash-tools.exec-host-node-phases.test.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.test.ts
@@ -239,12 +239,14 @@ describe("node execution target resolution", () => {
           {
             nodeId: "node-shared-exec",
             displayName: "build-worker",
+            clientId: "openclaw-macos",
             commands: ["system.run"],
             connected: true,
           },
           {
             nodeId: "node-shared-canvas",
             displayName: "build-worker",
+            clientId: "node-host",
             commands: ["canvas.present"],
             connected: true,
           },

--- a/src/agents/tools/computer-tool.node-resolution.test.ts
+++ b/src/agents/tools/computer-tool.node-resolution.test.ts
@@ -328,10 +328,14 @@ describe("createComputerTool node resolution", () => {
     expect(callGatewayToolMock).not.toHaveBeenCalled();
   });
 
-  it("rejects an ambiguous eligible display-name match", async () => {
+  it("rejects an ambiguous eligible display-name match across current clients", async () => {
     listNodesMock.mockResolvedValue([
-      macComputerNode({ nodeId: "mac-a", displayName: "Shared Desktop" }),
-      macComputerNode({ nodeId: "mac-b", displayName: "Shared Desktop" }),
+      macComputerNode({
+        nodeId: "mac-a",
+        displayName: "Shared Desktop",
+        clientId: "openclaw-macos",
+      }),
+      macComputerNode({ nodeId: "mac-b", displayName: "Shared Desktop", clientId: "node-host" }),
     ]);
     const tool = createComputerTool({ modelHasVision: true });
     await expect(

--- a/src/shared/node-match.test.ts
+++ b/src/shared/node-match.test.ts
@@ -70,6 +70,61 @@ describe("shared/node-match", () => {
     ).toBe("current-mac");
   });
 
+  it.each([
+    { clientIds: ["openclaw-macos", "node-host"] },
+    { clientIds: ["openclaw-macos", "openclaw-linux"] },
+    { clientIds: ["openclaw-macos", undefined] },
+    { clientIds: ["openclaw-macos", "custom-client"] },
+    { clientIds: ["openclaw-macos", "clawdbot-macos", "node-host"] },
+    { clientIds: ["openclaw-macos", "moldbot-macos", undefined] },
+    { clientIds: ["clawdbot-macos", undefined] },
+    { clientIds: ["node-host", "clawdbot-macos"] },
+  ])("keeps non-migration ties ambiguous for $clientIds", ({ clientIds }) => {
+    for (const connected of [true, false, undefined]) {
+      const nodes = clientIds.map((clientId, index) => ({
+        nodeId: `node-${index}`,
+        displayName: "Shared Desk",
+        clientId,
+        connected,
+      }));
+      for (const candidates of [nodes, nodes.toReversed()]) {
+        expect(() => resolveNodeIdFromCandidates(candidates, "Shared Desk")).toThrow(
+          /ambiguous node: Shared Desk/,
+        );
+      }
+    }
+  });
+
+  it.each([true, false, undefined])(
+    "keeps the unique current client in an entirely legacy migration tie (connected=%s)",
+    (connected) => {
+      const nodes = ["clawdbot-macos", "moldbot-macos", " OpenClaw-MacOS "].map(
+        (clientId, index) => ({
+          nodeId: `node-${index}`,
+          displayName: "Shared Desk",
+          clientId,
+          connected,
+        }),
+      );
+      for (const candidates of [nodes, nodes.toReversed()]) {
+        expect(resolveNodeIdFromCandidates(candidates, "Shared Desk")).toBe("node-2");
+      }
+    },
+  );
+
+  it.each(["node-host", "clawdbot-macos", undefined])(
+    "prefers a connected %s client over a disconnected current app",
+    (clientId) => {
+      const nodes = [
+        { nodeId: "app", displayName: "Shared Desk", clientId: "openclaw-macos", connected: false },
+        { nodeId: "live", displayName: "Shared Desk", clientId, connected: true },
+      ];
+      for (const candidates of [nodes, nodes.toReversed()]) {
+        expect(resolveNodeIdFromCandidates(candidates, "Shared Desk")).toBe("live");
+      }
+    },
+  );
+
   it("falls back to raw ambiguous matches when none of them are connected", () => {
     expect(() =>
       resolveNodeIdFromCandidates(

--- a/src/shared/node-match.ts
+++ b/src/shared/node-match.ts
@@ -26,15 +26,6 @@ export type NodeMatchCandidate = {
   clientId?: string;
 };
 
-type ScoredNodeMatch = {
-  /** Candidate that matched one of the accepted query shapes. */
-  node: NodeMatchCandidate;
-  /** Match class strength; higher classes outrank all tie-break heuristics. */
-  matchScore: number;
-  /** Tie-break score within one match class, such as connected/current-client preference. */
-  selectionScore: number;
-};
-
 /** Normalizes human node names into stable lookup keys for fuzzy CLI/API matching. */
 function normalizeNodeKey(value: string) {
   // Emoji components can also be marks (variation selectors and keycaps); drop
@@ -128,44 +119,6 @@ function resolveMatchScore(
   return 0;
 }
 
-function scoreNodeCandidate(node: NodeMatchCandidate, matchScore: number): number {
-  let score = matchScore;
-  if (node.connected === true) {
-    score += 100;
-  }
-  if (isCurrentOpenClawClient(node.clientId)) {
-    score += 10;
-  } else if (isLegacyClawdbotClient(node.clientId)) {
-    score -= 10;
-  }
-  return score;
-}
-
-function resolveScoredMatches(
-  nodes: NodeMatchCandidate[],
-  query: string,
-  allowCompactDisplayName: boolean,
-): ScoredNodeMatch[] {
-  const trimmed = normalizeOptionalString(query);
-  if (!trimmed) {
-    return [];
-  }
-  const normalized = normalizeNodeKey(trimmed);
-  return nodes
-    .map((node) => {
-      const matchScore = resolveMatchScore(node, trimmed, normalized, allowCompactDisplayName);
-      if (matchScore === 0) {
-        return null;
-      }
-      return {
-        node,
-        matchScore,
-        selectionScore: scoreNodeCandidate(node, matchScore),
-      };
-    })
-    .filter((entry): entry is ScoredNodeMatch => entry !== null);
-}
-
 /** Resolves a single node id or throws an operator-readable unknown/ambiguous-node error. */
 export function resolveNodeIdFromCandidates(
   nodes: NodeMatchCandidate[],
@@ -177,35 +130,37 @@ export function resolveNodeIdFromCandidates(
     throw new Error("node required");
   }
 
-  const rawMatches = resolveScoredMatches(nodes, q, allowCompactDisplayName);
-  if (rawMatches.length === 1) {
-    return rawMatches[0]?.node.nodeId ?? "";
-  }
-  if (rawMatches.length === 0) {
+  const normalized = normalizeNodeKey(q);
+  const scoredMatches = nodes
+    .map((node) => ({
+      node,
+      matchScore: resolveMatchScore(node, q, normalized, allowCompactDisplayName),
+    }))
+    .filter((match) => match.matchScore > 0);
+  if (scoredMatches.length === 0) {
     const known = listKnownNodes(nodes);
     throw new Error(`unknown node: ${q}${known ? ` (known: ${known})` : ""}`);
   }
 
-  const topMatchScore = Math.max(...rawMatches.map((match) => match.matchScore));
-  const strongestMatches = rawMatches.filter((match) => match.matchScore === topMatchScore);
-  if (strongestMatches.length === 1) {
-    return strongestMatches[0]?.node.nodeId ?? "";
-  }
+  const topMatchScore = Math.max(...scoredMatches.map((match) => match.matchScore));
+  const strongestMatches = scoredMatches
+    .filter((match) => match.matchScore === topMatchScore)
+    .map((match) => match.node);
 
-  // Only after the strongest match class is isolated do operational tie-breakers
-  // like connected state and current-client preference choose a winner.
-  const topSelectionScore = Math.max(...strongestMatches.map((match) => match.selectionScore));
-  const matches = strongestMatches.filter((match) => match.selectionScore === topSelectionScore);
+  // Connected state only breaks ties within the strongest match class. Client
+  // identity may disambiguate known legacy migrations, never other current nodes.
+  const connectedMatches = strongestMatches.filter((match) => match.connected === true);
+  const matches = connectedMatches.length > 0 ? connectedMatches : strongestMatches;
   if (matches.length === 1) {
-    return matches[0]?.node.nodeId ?? "";
+    return matches[0]?.nodeId ?? "";
   }
 
-  const preferred = pickPreferredLegacyMigrationMatch(matches.map((match) => match.node));
+  const preferred = pickPreferredLegacyMigrationMatch(matches);
   if (preferred) {
     return preferred.nodeId;
   }
 
   throw new Error(
-    `ambiguous node: ${q} (matches: ${matches.map((match) => formatNodeCandidateLabel(match.node)).join(", ")})`,
+    `ambiguous node: ${q} (matches: ${matches.map(formatNodeCandidateLabel).join(", ")})`,
   );
 }


### PR DESCRIPTION
Fixes #136635.

## What Problem This Solves

Two current nodes with the same name could silently resolve to the macOS app instead of reporting ambiguity. For example, equally connected `openclaw-macos` and `node-host` clients named `Shared Desk` caused `nodes describe --node "Shared Desk"` to select the app. The same shared resolver feeds agent tools and node targeting.

## Why This Change Was Made

A numeric client-type bonus discarded alternatives before the existing legacy migration selector could apply its bounded rule. Resolution now selects the strongest match class, prefers connected candidates within that class, then invokes the existing migration selector. Its rule remains unchanged: a unique current OpenClaw client wins a migration tie only when every other match is a known legacy client.

The duplicate scoring/projection flow is removed. Production **+19 / −64 = −45 LOC**; tests **+64 / −3 = +61**; docs **+2**. Exact ID, IP, normalized/compact name, prefix and unique-connected precedence remain intact. No permission, capability, configuration, persistence or protocol change is introduced.

## User Impact

Ambiguous current-node names produce the existing error listing exact node IDs. Operators can select the intended ID; one current client no longer silently wins by branding. Actual legacy migration preference is retained.

## Evidence

Seven matcher cases, two exec-target cases and one Computer Tool case fail on the original source. All 293 focused owner/sibling tests pass, including CLI, exec, Computer Tool, mobile UI, code mode, Canvas, MCP and browser discovery. The full required changed-file gate and single joint Codex review through P2 pass on the frozen five-file patch.

Actual compiled `nodes describe` ran 21 cases before and 21 after against the same synthetic inventory, with captured stdout, stderr, exit status and RPC calls. Nine cases restore ambiguity; twelve controls have byte-identical output and identical RPC traces. Repaired ambiguities perform only `node.list`, with no `node.describe` call. Success controls perform `node.list` then the exact expected `node.describe` ID. All children exit normally; no real node action runs.

The matrix covers reversed node order, disconnected/unknown connection states, missing client metadata, mixtures of legacy and modern clients, true legacy migrations, exact IDs/IPs and normalized names versus prefixes. Source and compiled artifacts are hash-bound: baseline entry `ce8ce0116c248f23e8a29fb3e8cff07d9c162a40f0030c870a5640eb43960835`; repaired entry `b90658be2c10c6ab984b3a646bf7401e3dd157f2d88f31e272bf36b2400bee79`; common fixture `b38d1269aad688966a0ecf057437c643a27adbe2b9b3d3ace48f941b0a752000`.

Root inspected the shared owner, caller eligibility boundaries, current protocol client IDs, actual receipts, raw-parent regression history (`27519cf061577e372a5a49c64470084e7cd1d63a`) and the original bounded migration contract (`f16c176a4cc1df0c07554c1dda5df78b7b376825`). Stable v2026.8.2 and current main contain the affected owner. Canonical E2E preparation built the tested runtime and required declarations; no additional release-build or real-action safety claim is made.

## Final review disposition

The latest ClawSweeper review has no findings or rank-up moves requiring a change. Root independently inspected the shared owner, affected callers, stable behavior and actual compiled-CLI evidence; current main leaves the changed production owner unchanged and composes cleanly. Required exact-head CI is green.
