### PR TITLE
fix(ui): make board Remove action match its menu

### DIFF
--- a/ui/src/components/board/board-widget-cell-render.ts
+++ b/ui/src/components/board/board-widget-cell-render.ts
@@ -3,6 +3,7 @@ import { t } from "../../i18n/index.ts";
 import type { BoardTab, BoardWidget } from "../../lib/board/types.ts";
 import type { BoardGrantDecision } from "../../lib/board/view-types.ts";
 import { formatUiError } from "../../lib/format-error.ts";
+import { icons } from "../icons.ts";
 import { renderBoardPendingCapabilities } from "./board-widget-capabilities.ts";
 
 export const BOARD_SIZE_PRESETS = {
@@ -74,6 +75,7 @@ export function renderBoardWidgetMenu(options: {
         : nothing}
       <div class="board-widget__menu-separator" role="separator"></div>
       <wa-dropdown-item class="board-widget__menu-danger" value="remove" ?disabled=${disabled}>
+        <span slot="icon" class="board-widget__menu-icon" aria-hidden="true">${icons.trash}</span>
         ${t("board.widget.remove")}
       </wa-dropdown-item>
     </wa-dropdown>

--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -753,6 +753,40 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
     });
   }
 
+  it("renders the remove action with the menu font size and a leading trash icon", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.goto(fixtureServer.url, { waitUntil: "networkidle" });
+      await openWidgetMenu(page);
+      const presentation = await page
+        .locator(".board-widget__menu[open] .board-widget__menu-danger")
+        .evaluate((remove) => {
+          const preset = remove.parentElement?.querySelector(".board-widget__preset");
+          const icon = remove.querySelector('[slot="icon"]');
+          if (!(preset instanceof HTMLElement)) {
+            throw new Error("board fixture menu did not expose a resize preset");
+          }
+          return {
+            fontSize: getComputedStyle(remove).fontSize,
+            iconHidden: icon?.getAttribute("aria-hidden"),
+            iconSvg: Boolean(icon?.querySelector("svg")),
+            presetFontSize: getComputedStyle(preset).fontSize,
+          };
+        });
+      expect({
+        fontSizesMatch: presentation.fontSize === presentation.presetFontSize,
+        iconHidden: presentation.iconHidden,
+        iconSvg: presentation.iconSvg,
+      }).toEqual({
+        fontSizesMatch: true,
+        iconHidden: "true",
+        iconSvg: true,
+      });
+    } finally {
+      await page.close();
+    }
+  });
+
   it("follows live system color-scheme changes", async () => {
     const context = await browser.newContext({ colorScheme: "dark" });
     try {

--- a/ui/src/styles/board.css
+++ b/ui/src/styles/board.css
@@ -271,7 +271,8 @@ openclaw-board-widget-cell {
   padding: 5px 9px;
 }
 
-.board-widget__preset {
+.board-widget__preset,
+.board-widget__menu-danger {
   font-size: 11px;
 }
 
@@ -282,6 +283,12 @@ openclaw-board-widget-cell {
 
 .board-widget__menu-danger {
   color: var(--danger);
+}
+
+.board-widget__menu-icon,
+.board-widget__menu-icon svg {
+  height: 14px;
+  width: 14px;
 }
 
 .board-widget__body {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the board widget's **Remove** action rendered larger than the resize options and lacked a visual delete affordance.

## Why This Change Was Made

The board menu now uses the shared trash icon in Web Awesome's leading icon slot, marks it decorative for assistive technology, and shares the existing 11px menu-item font rule with the resize actions. No menu behavior or removal semantics changed.

## User Impact

The destructive action now visually matches the rest of the widget menu and is easier to identify at a glance.

## Evidence

| Before | After |
| --- | --- |
| ![Before: oversized Remove label without an icon](https://github.com/user-attachments/assets/00a3429d-b2c8-4e7a-9900-7b78b02a19c7) | ![After: 11px Remove label with a leading trash icon](https://github.com/user-attachments/assets/2978f077-2889-44de-b7b8-0114009e2d59) |

Observed in the real board fixture:

- Remove font: `11px`
- Resize-option font: `11px`
- Trash icon: `14px × 14px`, `aria-hidden="true"`

Validation:

- Pre-fix focused UI E2E: failed on font mismatch and missing icon
- Post-fix focused UI E2E: passed
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 pnpm check:changed`: passed (canonical full-tree dead-export scan remains covered by CI)
- Targeted Stylelint and `git diff --check`: passed
- Autoreview: no actionable findings (0.99 correct)

Production LOC: `+10/-1` (net `+9`, shared icon rendering and sizing). Test LOC: `+34/-0`.
