### PR TITLE
fix(gateway): avoid false RSS critical alerts on small hosts

### DIFF
--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -203,6 +203,60 @@ describe("diagnostic memory", () => {
 
   it.each([
     {
+      name: "a 768 MiB default Node heap",
+      isBunRuntime: false,
+      heapSizeLimitBytes: 432 * 1024 ** 2,
+      processMemoryLimitBytes: 768 * 1024 ** 2,
+      physicalMemoryBytes: 64 * 1024 ** 3,
+      samples: [{ rssGiB: 330 / 1024 }, { rssGiB: 385 / 1024 }, { rssGiB: 577 / 1024 }],
+      expectedThresholdsGiB: { warning: 384 / 1024, critical: 576 / 1024 },
+    },
+    {
+      name: "a 768 MiB managed Node heap",
+      isBunRuntime: false,
+      heapSizeLimitBytes: 624 * 1024 ** 2,
+      processMemoryLimitBytes: 768 * 1024 ** 2,
+      physicalMemoryBytes: 64 * 1024 ** 3,
+      samples: [{ rssGiB: 330 / 1024 }, { rssGiB: 385 / 1024 }, { rssGiB: 577 / 1024 }],
+      expectedThresholdsGiB: { warning: 384 / 1024, critical: 576 / 1024 },
+    },
+    {
+      name: "a 1 GiB default Node heap",
+      isBunRuntime: false,
+      heapSizeLimitBytes: 560 * 1024 ** 2,
+      processMemoryLimitBytes: 1024 ** 3,
+      physicalMemoryBytes: 64 * 1024 ** 3,
+      samples: [{ rssGiB: 421 / 1024 }, { rssGiB: 513 / 1024 }, { rssGiB: 769 / 1024 }],
+      expectedThresholdsGiB: { warning: 0.5, critical: 0.75 },
+    },
+    {
+      name: "a 1 GiB managed Node heap",
+      isBunRuntime: false,
+      heapSizeLimitBytes: 816 * 1024 ** 2,
+      processMemoryLimitBytes: 1024 ** 3,
+      physicalMemoryBytes: 64 * 1024 ** 3,
+      samples: [{ rssGiB: 424 / 1024 }, { rssGiB: 513 / 1024 }, { rssGiB: 769 / 1024 }],
+      expectedThresholdsGiB: { warning: 0.5, critical: 0.75 },
+    },
+    {
+      name: "a 2 GiB managed Node heap",
+      isBunRuntime: false,
+      heapSizeLimitBytes: 1584 * 1024 ** 2,
+      processMemoryLimitBytes: 2 * 1024 ** 3,
+      physicalMemoryBytes: 64 * 1024 ** 3,
+      samples: [{ rssGiB: 833 / 1024 }, { rssGiB: 1025 / 1024 }, { rssGiB: 1537 / 1024 }],
+      expectedThresholdsGiB: { warning: 1, critical: 1.5 },
+    },
+    {
+      name: "unknown capacity with a small V8 limit",
+      isBunRuntime: false,
+      heapSizeLimitBytes: 432 * 1024 ** 2,
+      processMemoryLimitBytes: 0,
+      physicalMemoryBytes: 0,
+      samples: [{ rssGiB: 330 / 1024 }, { rssGiB: 1537 / 1024 }, { rssGiB: 3073 / 1024 }],
+      expectedThresholdsGiB: { warning: 1.5, critical: 3 },
+    },
+    {
       name: "an enlarged V8 limit",
       isBunRuntime: false,
       heapSizeLimitBytes: 8 * 1024 ** 3,
@@ -235,7 +289,7 @@ describe("diagnostic memory", () => {
       heapSizeLimitBytes: 16 * 1024 ** 3,
       processMemoryLimitBytes: 4 * 1024 ** 3,
       physicalMemoryBytes: 64 * 1024 ** 3,
-      samples: [{ rssGiB: 2.1 }, { rssGiB: 3.1 }],
+      samples: [{ rssGiB: 1.9 }, { rssGiB: 2.1 }, { rssGiB: 3.1 }],
       expectedThresholdsGiB: { warning: 2, critical: 3 },
     },
     ...[0, -1, Number.NaN, Number.POSITIVE_INFINITY].map((processMemoryLimitBytes) => ({
@@ -253,7 +307,7 @@ describe("diagnostic memory", () => {
       heapSizeLimitBytes: 16 * 1024 ** 3,
       processMemoryLimitBytes: 4 * 1024 ** 3,
       physicalMemoryBytes: Number.NaN,
-      samples: [{ rssGiB: 2.1 }, { rssGiB: 3.1 }],
+      samples: [{ rssGiB: 1.9 }, { rssGiB: 2.1 }, { rssGiB: 3.1 }],
       expectedThresholdsGiB: { warning: 2, critical: 3 },
     },
     {
@@ -271,9 +325,18 @@ describe("diagnostic memory", () => {
       heapSizeLimitBytes: 16 * 1024 ** 3,
       processMemoryLimitBytes: Number.MAX_SAFE_INTEGER,
       physicalMemoryBytes: 4 * 1024 ** 3,
-      samples: [{ rssGiB: 2.1 }, { rssGiB: 3.1 }],
+      samples: [{ rssGiB: 1.9 }, { rssGiB: 2.1 }, { rssGiB: 3.1 }],
       expectedThresholdsGiB: { warning: 2, critical: 3 },
     },
+    ...[0, -1, Number.NaN, Number.POSITIVE_INFINITY].map((heapSizeLimitBytes) => ({
+      name: `unknown capacity with a ${heapSizeLimitBytes} V8 limit`,
+      isBunRuntime: false,
+      heapSizeLimitBytes,
+      processMemoryLimitBytes: 0,
+      physicalMemoryBytes: 0,
+      samples: [{ rssGiB: 1.4 }, { rssGiB: 1.6 }, { rssGiB: 3.1 }],
+      expectedThresholdsGiB: { warning: 1.5, critical: 3 },
+    })),
     {
       name: "Bun compatibility heap statistics",
       isBunRuntime: true,
@@ -337,6 +400,46 @@ describe("diagnostic memory", () => {
       },
     ]);
   });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "keeps default heap pressure thresholds with an invalid V8 limit of %s",
+    (heapSizeLimitBytes) => {
+      const events: DiagnosticEventPayload[] = [];
+      const stop = onDiagnosticEvent((event) => events.push(event));
+      const gb = 1024 ** 3;
+
+      emitDiagnosticMemorySample({
+        now: 11 * 60 * 1000,
+        isBunRuntime: false,
+        heapSizeLimitBytes,
+        processMemoryLimitBytes: 0,
+        physicalMemoryBytes: 0,
+        memoryUsage: memoryUsage({ rss: 100, heapUsed: 1.1 * gb }),
+      });
+      emitDiagnosticMemorySample({
+        now: 22 * 60 * 1000,
+        isBunRuntime: false,
+        heapSizeLimitBytes,
+        processMemoryLimitBytes: 0,
+        physicalMemoryBytes: 0,
+        memoryUsage: memoryUsage({ rss: 100, heapUsed: 2.1 * gb }),
+      });
+      stop();
+
+      expect(
+        events
+          .filter((event) => event.type === "diagnostic.memory.pressure")
+          .map((event) => ({
+            level: event.level,
+            reason: event.reason,
+            threshold: event.thresholdBytes,
+          })),
+      ).toEqual([
+        { level: "warning", reason: "heap_threshold", threshold: gb },
+        { level: "critical", reason: "heap_threshold", threshold: 2 * gb },
+      ]);
+    },
+  );
 
   it("emits pressure when RSS grows quickly", () => {
     const events: DiagnosticEventPayload[] = [];

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -124,12 +124,12 @@ function resolveThresholds(
   const rssWarningBase = useBunRssCaps
     ? BUN_HEAP_WARNING_MAX_BYTES
     : useHeapForRss
-      ? heapWarningBytes
+      ? Math.max(DEFAULT_RSS_WARNING_BYTES, heapWarningBytes)
       : DEFAULT_RSS_WARNING_BYTES;
   const rssCriticalBase = useBunRssCaps
     ? BUN_HEAP_CRITICAL_MAX_BYTES
     : useHeapForRss
-      ? heapCriticalBytes
+      ? Math.max(DEFAULT_RSS_CRITICAL_BYTES, heapCriticalBytes)
       : DEFAULT_RSS_CRITICAL_BYTES;
   const processWarningBytes = hasProcessMemoryLimit
     ? Math.floor(usableProcessMemoryLimitBytes * DEFAULT_HEAP_WARNING_RATIO)


### PR DESCRIPTION
Closes #136640

## What Problem This Solves

Fixes an issue where operators on small constrained hosts could see ordinary Gateway RSS reported as critical memory pressure. On a 768 MiB host with a 432 MiB V8 limit, 330 MiB RSS was classified as critical even though the host-level critical threshold should be 576 MiB.

## Why This Change Was Made

The diagnostic owner used V8 heap thresholds as downward RSS bases before applying process-capacity caps. The repair keeps the existing capacity clamp but makes V8-derived values raise, never lower, the normal Node RSS bases. Bun, heap-used pressure, rapid RSS growth, explicit threshold overrides, and managed heap policy are unchanged.

The production repair is limited to two expressions in `src/logging/diagnostic-memory.ts`:

- warning base: `max(1536 MiB, 50% of V8 limit)`
- critical base: `max(3072 MiB, 75% of V8 limit)`

Process or physical capacity then retains the existing 50%/75% cap.

## User Impact

Stability diagnostics now distinguish normal low-memory operation from real critical RSS pressure:

- 768 MiB capacity: warning 384 MiB, critical 576 MiB.
- 1 GiB capacity: warning 512 MiB, critical 768 MiB.
- Large explicit heaps and constrained large-heap hosts retain their existing thresholds.

This corrects diagnostic classification only. It does not reduce physical memory use, change V8 allocation, alter swap behavior, or prevent kernel/cgroup OOMs.

## Evidence

Pre-fix regression:

```text
node scripts/run-vitest.mjs src/logging/diagnostic-memory.test.ts \
  -t "scales default RSS pressure thresholds with 'a 768 MiB default Node heap'"

1 failed, 25 skipped
received: critical/rss_threshold at 339738624 bytes
expected: warning at 402653184 bytes, then critical at 603979776 bytes
```

Post-fix:

```text
exact formerly-red case: 1 passed, 38 skipped
full owner suite: 39 passed
post-rebase full owner suite: 39 passed
```

The matrix covers 768 MiB, 1 GiB, and 2 GiB default/managed heaps; unknown capacity; 4 GiB constrained large heaps; 8/16/32 GiB heaps; invalid process/V8 limits; Bun compatibility behavior; heap-used thresholds; and rapid RSS growth.

Deterministic event trace:

```text
768 MiB / 432 MiB V8 / 330 MiB RSS: no pressure event
768 MiB / 432 MiB V8 / 385 MiB RSS: warning at 402653184 bytes
768 MiB / 432 MiB V8 / 577 MiB RSS: critical at 603979776 bytes
1 GiB / 560 MiB V8 / 421 MiB RSS: no pressure event
```

Local gates:

```text
oxfmt write/check: passed
focused oxlint: passed
pnpm tsgo:core: passed
pnpm tsgo:test:src: passed
check-changed selected core + coreTests
  all checks through lint/typecheck passed
  sparse native-state guard passed after projecting its tracked input
  remaining database/media/sidecar/cycle/webhook/auth guards passed
autoreview (gpt-5.6-sol, high): scoped-clean, 0.99
git diff --check: passed
```

The post-rebase aggregate `check-changed` rerun was interrupted during its already-passing core-test typecheck stage. Exact-head CI remains the authoritative pending aggregate proof for this draft.

LOC:

```text
production: +2/-2, net 0
tests: +106/-3
```

No Testbox run was used because this is a deterministic classification repair with no environment-dependent runtime behavior.
