### PR TITLE
fix(agents): preserve CLI continuity for queued cold turns

### DIFF
--- a/src/agents/cli-runner.runtime.ts
+++ b/src/agents/cli-runner.runtime.ts
@@ -1,10 +1,4 @@
 // Runtime barrel for CLI agent execution and session id helpers. Keeps callers
 // importing this boundary instead of deep CLI runner/session modules.
 export { runCliAgent } from "./cli-runner.js";
-export {
-  clearCliSession,
-  getCliSessionBinding,
-  getCliSessionId,
-  setCliSessionBinding,
-  setCliSessionId,
-} from "./cli-session.js";
+export { getCliSessionBinding } from "./cli-session.js";

--- a/src/agents/cli-runner/cli-run-settlement.test.ts
+++ b/src/agents/cli-runner/cli-run-settlement.test.ts
@@ -140,7 +140,7 @@ describe("CLI native continuity projection", () => {
   it.each(["blocked", "no-native-id", "native", "stateless"])(
     "projects only explicit native continuity from a %s result",
     (kind) => {
-      const context = buildPreparedCliRunContext({ provider: "fixture-cli" });
+      const context = buildPreparedCliRunContext({ provider: "claude-cli" });
       const result =
         kind === "blocked"
           ? buildBlockedCliRunResult({
@@ -162,16 +162,16 @@ describe("CLI native continuity projection", () => {
       const entry: SessionEntry = {
         sessionId: context.params.sessionId,
         updatedAt: 1,
-        cliSessionBindings: { "fixture-cli": { sessionId: "previous-native-session" } },
+        cliSessionBindings: { "claude-cli": { sessionId: "previous-native-session" } },
       };
 
-      applyCliSessionBindingResult(entry, "fixture-cli", result.meta.agentMeta);
+      applyCliSessionBindingResult(entry, "claude-cli", result.meta.agentMeta);
 
       expect(entry.sessionId).toBe(context.params.sessionId);
       expect(result.meta.agentMeta?.sessionId).toBe(
         kind === "native" ? "next-native-session" : context.params.sessionId,
       );
-      expect(getCliSessionBinding(entry, "fixture-cli")?.sessionId).toBe(
+      expect(getCliSessionBinding(entry, "claude-cli")?.sessionId).toBe(
         kind === "native"
           ? "next-native-session"
           : kind === "stateless"

--- a/src/agents/cli-runner/cli-run-settlement.test.ts
+++ b/src/agents/cli-runner/cli-run-settlement.test.ts
@@ -1,10 +1,14 @@
-/** Tests bounded transcript-flush probing before reusing CLI bindings. */
+/** Tests native CLI continuity projection and bounded transcript-flush probing. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
 import {
   isCliBindingFlushed,
   restoreCliRunnerTestDeps,
   setCliRunnerTestDeps,
 } from "../cli-runner.js";
+import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
+import { applyCliSessionBindingResult, getCliSessionBinding } from "../cli-session.js";
+import { buildBlockedCliRunResult, buildCliRunResult } from "./cli-run-settlement.js";
 
 describe("isCliBindingFlushed", () => {
   const workspaceDir = "/tmp/openclaw-workspace";
@@ -130,4 +134,50 @@ describe("isCliBindingFlushed", () => {
     ).toBe(true);
     expect(probe).toHaveBeenCalledTimes(1);
   });
+});
+
+describe("CLI native continuity projection", () => {
+  it.each(["blocked", "no-native-id", "native", "stateless"])(
+    "projects only explicit native continuity from a %s result",
+    (kind) => {
+      const context = buildPreparedCliRunContext({ provider: "fixture-cli" });
+      const result =
+        kind === "blocked"
+          ? buildBlockedCliRunResult({
+              context,
+              message: "Blocked by the test policy",
+              preparedContextAgentMeta: {},
+              sessionBindingDisabled: false,
+            })
+          : buildCliRunResult({
+              context,
+              output: { text: "done" },
+              effectiveCliSessionId: kind === "native" ? "next-native-session" : undefined,
+              bindingFlushOk: kind !== "no-native-id",
+              usedHistoryPrompt: false,
+              userTurnHandled: true,
+              sessionBindingDisabled: kind === "stateless",
+              preparedContextAgentMeta: {},
+            });
+      const entry: SessionEntry = {
+        sessionId: context.params.sessionId,
+        updatedAt: 1,
+        cliSessionBindings: { "fixture-cli": { sessionId: "previous-native-session" } },
+      };
+
+      applyCliSessionBindingResult(entry, "fixture-cli", result.meta.agentMeta);
+
+      expect(entry.sessionId).toBe(context.params.sessionId);
+      expect(result.meta.agentMeta?.sessionId).toBe(
+        kind === "native" ? "next-native-session" : context.params.sessionId,
+      );
+      expect(getCliSessionBinding(entry, "fixture-cli")?.sessionId).toBe(
+        kind === "native"
+          ? "next-native-session"
+          : kind === "stateless"
+            ? undefined
+            : "previous-native-session",
+      );
+    },
+  );
 });

--- a/src/agents/cli-session-store.ts
+++ b/src/agents/cli-session-store.ts
@@ -1,0 +1,145 @@
+import type { InternalSessionEntry, SessionEntry } from "../config/sessions.js";
+import { patchSessionEntryCore } from "../config/sessions/session-accessor.js";
+import {
+  applyCliSessionBindingResult,
+  assertCliSessionBindingResultCommitAllowed,
+  clearCliSession,
+  getCliSessionBinding,
+} from "./cli-session.js";
+import type { EmbeddedAgentRunResult } from "./embedded-agent-runner/types.js";
+
+type CliSessionStoreTarget = {
+  provider: string;
+  sessionKey?: string;
+  storePath?: string;
+  sessionStore?: Record<string, SessionEntry>;
+};
+
+async function patchCliSessionBindingInStore(
+  params: CliSessionStoreTarget & {
+    expectedSession: InternalSessionEntry;
+    fallbackEntry?: SessionEntry;
+    preserveActivity?: boolean;
+    skipMaintenance?: boolean;
+    assertCommitAllowed?: () => void;
+    update: (entry: SessionEntry) => boolean;
+    onCommitted?: () => void;
+  },
+): Promise<SessionEntry | undefined> {
+  const { sessionKey, storePath } = params;
+  if (!sessionKey || !storePath) {
+    return undefined;
+  }
+  const expected = { ...params.expectedSession };
+  let committed: SessionEntry | undefined;
+  await patchSessionEntryCore(
+    { sessionKey, storePath },
+    (entry) => {
+      // Native ids can survive reset. Publication belongs to the exact local lifecycle/writer.
+      if (
+        entry.sessionId !== expected.sessionId ||
+        entry.lifecycleRevision !== expected.lifecycleRevision ||
+        entry.activeWriterRunId !== expected.activeWriterRunId
+      ) {
+        return null;
+      }
+      const next = { ...entry };
+      if (!params.update(next)) {
+        return null;
+      }
+      return {
+        cliSessionIds: next.cliSessionIds,
+        cliSessionBindings: next.cliSessionBindings,
+        claudeCliSessionId: next.claudeCliSessionId,
+      };
+    },
+    {
+      fallbackEntry: params.fallbackEntry,
+      assertCommitAllowed: params.assertCommitAllowed,
+      preserveActivity: params.preserveActivity,
+      skipMaintenance: params.skipMaintenance,
+      onCommitted: (entry) => {
+        committed = entry;
+        params.onCommitted?.();
+        if (params.sessionStore) {
+          params.sessionStore[sessionKey] = entry;
+        }
+      },
+    },
+  );
+  return committed;
+}
+
+/** Publish native continuity before the placement owner releases its session lane. */
+export async function persistCliSessionBindingResult(
+  params: CliSessionStoreTarget & {
+    result: EmbeddedAgentRunResult;
+    expectedSession?: InternalSessionEntry;
+    assertSettlementCurrent: () => void;
+    abortSignal?: AbortSignal;
+  },
+): Promise<void> {
+  if (!params.expectedSession) {
+    return undefined;
+  }
+  await patchCliSessionBindingInStore({
+    ...params,
+    expectedSession: params.expectedSession,
+    preserveActivity: true,
+    skipMaintenance: true,
+    update: (entry) =>
+      applyCliSessionBindingResult(entry, params.provider, params.result.meta.agentMeta),
+    assertCommitAllowed: () =>
+      assertCliSessionBindingResultCommitAllowed(
+        params.result.meta.agentMeta,
+        params.assertSettlementCurrent,
+        params.abortSignal,
+      ),
+  });
+}
+
+/** Clears a failed/invalid native binding; a turn owner supplies its exact commit guard. */
+export async function clearCliSessionInStore(
+  params: CliSessionStoreTarget & {
+    expectedSessionId?: string;
+    expectedCliSessionId?: string;
+    activeSessionEntry?: SessionEntry;
+    assertCommitAllowed?: () => void;
+  },
+): Promise<SessionEntry | undefined> {
+  const entry =
+    params.activeSessionEntry ??
+    (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
+  if (!entry) {
+    return undefined;
+  }
+  const clearEntry = (current: SessionEntry | undefined) => {
+    if (
+      !current ||
+      (params.expectedCliSessionId &&
+        getCliSessionBinding(current, params.provider)?.sessionId !== params.expectedCliSessionId)
+    ) {
+      return false;
+    }
+    clearCliSession(current, params.provider);
+    current.updatedAt = Date.now();
+    return true;
+  };
+  const clearCachedEntries = () => {
+    clearEntry(params.activeSessionEntry);
+    clearEntry(params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
+  };
+  if (!params.sessionKey || !params.storePath) {
+    params.assertCommitAllowed?.();
+    clearCachedEntries();
+    return undefined;
+  }
+  return await patchCliSessionBindingInStore({
+    ...params,
+    expectedSession: { ...entry, sessionId: params.expectedSessionId ?? entry.sessionId },
+    // Pre-run compaction can seed its known row; post-run clears never recreate a deleted session.
+    fallbackEntry: params.expectedSessionId ? undefined : entry,
+    update: clearEntry,
+    onCommitted: clearCachedEntries,
+  });
+}

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -17,7 +17,6 @@ import {
   resolveCliSessionClearReason,
   resolveCliSessionReuse,
   setCliSessionBinding,
-  setCliSessionId,
   shouldClearFailedCliSessionBinding,
 } from "./cli-session.js";
 import { FailoverError } from "./failover-error.js";
@@ -177,9 +176,6 @@ describe("cli-session helpers", () => {
       reseedReceipt: receipt,
     });
     setCliSessionBinding(entry, "claude-cli", { sessionId: "cli-session-1" });
-    expect(getCliSessionBinding(entry, "claude-cli")?.reseedReceipt).toEqual(receipt);
-
-    setCliSessionId(entry, "claude-cli", "cli-session-1");
     expect(getCliSessionBinding(entry, "claude-cli")?.reseedReceipt).toEqual(receipt);
 
     setCliSessionBinding(entry, "claude-cli", { sessionId: "cli-session-2" });

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -14,7 +14,6 @@ import type { FailoverReason } from "./failover/signal.js";
 export {
   clearAllCliSessions,
   getCliSessionBinding,
-  getCliSessionId,
 } from "../config/sessions/cli-session-binding.js";
 
 const CLAUDE_CLI_BACKEND_ID = "claude-cli";
@@ -35,9 +34,37 @@ export function hashCliSessionText(value: string | undefined): string | undefine
   return crypto.createHash("sha256").update(trimmed).digest("hex");
 }
 
-/** Store a reusable CLI session ID without extra reuse guards. */
-export function setCliSessionId(entry: SessionEntry, provider: string, sessionId: string): void {
-  setCliSessionBinding(entry, provider, { sessionId });
+/** Projects explicit native continuity; diagnostic sessionId can name the local session. */
+export function applyCliSessionBindingResult(
+  entry: SessionEntry,
+  provider: string,
+  meta?: {
+    cliSessionBinding?: CliSessionBinding;
+    clearCliSessionBinding?: boolean;
+  },
+): boolean {
+  if (meta?.clearCliSessionBinding === true) {
+    clearCliSession(entry, provider);
+  } else if (meta?.cliSessionBinding?.sessionId.trim()) {
+    setCliSessionBinding(entry, provider, meta.cliSessionBinding);
+  } else {
+    return false;
+  }
+  return true;
+}
+
+/** Revalidates the exact turn owner at native continuity's synchronous commit edge. */
+export function assertCliSessionBindingResultCommitAllowed(
+  meta: { clearCliSessionBinding?: boolean } | undefined,
+  assertSettlementCurrent: () => void,
+  abortSignal?: AbortSignal,
+): void {
+  assertSettlementCurrent();
+  // Explicit invalidation is owner cleanup: abort may clear an unusable
+  // handle, but never through a closed, released, or replaced turn.
+  if (meta?.clearCliSessionBinding !== true) {
+    abortSignal?.throwIfAborted();
+  }
 }
 
 /** Store a CLI session binding and mirror it to legacy/simple session-id fields. */

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -22,6 +22,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import {
   disposeOpenClawAgentDatabaseByPath,
   listOpenClawAgentDatabasesForTest,
@@ -37,9 +38,11 @@ import { saveAuthProfileStore } from "../auth-profiles/store.js";
 import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
 import { buildCliMcpGrantContext } from "../cli-runner/mcp-grant-context.js";
 import { createCronCreatorAuthorityCapability } from "../cron-creator-authority-context.js";
+import { classifyEmbeddedAgentRunResultForModelFallback } from "../embedded-agent-runner/result-fallback-classifier.js";
 import type { RunEmbeddedAgentInternalParams } from "../embedded-agent-runner/run/internal-params.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent.js";
 import { FailoverError } from "../failover-error.js";
+import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../failover/user-copy.js";
 import type { ModelFallbackAttemptProvenance } from "../model-fallback.types.js";
 import { installSessionPlacementAdmissionProvider } from "../session-placement-admission.js";
 import { attachToolAllowlistIntersection } from "../tool-policy.js";
@@ -430,14 +433,15 @@ vi.mock("../embedded-agent.js", () => ({
   runEmbeddedAgent: runEmbeddedAgentMock,
 }));
 
-function makeCliResult(text: string): EmbeddedAgentRunResult {
+function makeCliResult(text: string, sessionId = "session-cli"): EmbeddedAgentRunResult {
   return {
     payloads: [{ text }],
     meta: {
       durationMs: 5,
       finalAssistantVisibleText: text,
       agentMeta: {
-        sessionId: "session-cli",
+        sessionId,
+        ...(sessionId ? { cliSessionBinding: { sessionId } } : {}),
         provider: "claude-cli",
         model: "opus",
         usage: {
@@ -835,6 +839,7 @@ describe("CLI attempt execution", () => {
     cwd?: string;
     onExecutionStarted?: () => void;
     onAgentEvent?: RunAgentAttemptParams["onAgentEvent"];
+    classifyResult?: RunAgentAttemptParams["classifyResult"];
   }) {
     await runAgentAttempt({
       providerOverride: "claude-cli",
@@ -844,6 +849,7 @@ describe("CLI attempt execution", () => {
       workspaceDir: tmpDir,
       cwd: params.cwd,
       body: params.body,
+      classifyResult: params.classifyResult,
       runId: params.runId,
       opts: { onExecutionStarted: params.onExecutionStarted },
       ...(params.onAgentEvent ? { onAgentEvent: params.onAgentEvent } : {}),
@@ -974,10 +980,12 @@ describe("CLI attempt execution", () => {
     },
   );
 
-  async function writeClaudeCliAssistantTranscript(cliSessionId: string) {
+  async function writeClaudeCliAssistantTranscript(
+    cliSessionId: string,
+    homeDir = path.join(tmpDir, `home-${cliSessionId}`),
+  ) {
     // Claude stores resumable sessions under a workspace-derived project dir,
     // so stale-session tests must create the same on-disk shape.
-    const homeDir = path.join(tmpDir, `home-${cliSessionId}`);
     const projectsDir = resolveClaudeCliProjectDirForWorkspace({
       workspaceDir: tmpDir,
       homeDir,
@@ -993,6 +1001,79 @@ describe("CLI attempt execution", () => {
       "utf-8",
     );
   }
+
+  it.each(["accepted", "rejected", "rejected-clear"])(
+    "settles a cold %s CLI binding before the next queued command starts",
+    async (outcome) => {
+      const sessionKey = "agent:main:cli-binding-settlement";
+      const sessionEntry = makeSessionEntry("binding-settlement-session");
+      if (outcome === "rejected-clear") {
+        sessionEntry.cliSessionBindings = {
+          "claude-cli": { sessionId: "previous-native-session" },
+        };
+        await writeClaudeCliAssistantTranscript(
+          "previous-native-session",
+          path.join(tmpDir, "cold-home"),
+        );
+      }
+      const sessionStore = { [sessionKey]: sessionEntry };
+      await writeSessionStoreSeed(sessionStore);
+      await writeClaudeCliAssistantTranscript(
+        "settled-native-session",
+        path.join(tmpDir, "cold-home"),
+      );
+      const firstStarted = createDeferredCore();
+      const finishFirst = createDeferredCore();
+      const binding = {
+        sessionId: "settled-native-session",
+        authProfileId: "anthropic:claude-cli",
+      };
+      runCliAgentMock
+        .mockImplementationOnce(async () => {
+          firstStarted.resolve();
+          await finishFirst.promise;
+          const result = makeCliResult("parent completed");
+          if (outcome !== "accepted") {
+            result.payloads = [{ text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT }];
+            result.meta.finalAssistantVisibleText = GENERIC_EXTERNAL_RUN_FAILURE_TEXT;
+          }
+          if (outcome === "rejected-clear") {
+            result.meta.agentMeta!.clearCliSessionBinding = true;
+          }
+          result.meta.agentMeta!.cliSessionBinding = binding;
+          result.meta.agentMeta!.sessionId = binding.sessionId;
+          return result;
+        })
+        .mockResolvedValueOnce(makeCliResult("follow-up completed"));
+      const run = (runId: string) =>
+        runClaudeCliAttempt({
+          sessionKey,
+          sessionEntry,
+          sessionStore,
+          body: runId,
+          runId,
+          classifyResult: (result) =>
+            classifyEmbeddedAgentRunResultForModelFallback({
+              result,
+              provider: "claude-cli",
+              model: "opus",
+            }),
+        });
+      const first = run("binding-parent");
+      await firstStarted.promise;
+      if (outcome === "rejected-clear") {
+        expect(firstRunCliAgentArg().cliSessionId).toBe("previous-native-session");
+      }
+      const second = run("binding-follow-up");
+      finishFirst.resolve();
+      await Promise.all([first, second]);
+
+      expect(firstRunCliAgentArg(1)).toMatchObject({
+        cliSessionId: outcome === "accepted" ? binding.sessionId : undefined,
+        cliSessionBinding: outcome === "accepted" ? binding : undefined,
+      });
+    },
+  );
 
   function makeClaudeCliSessionEntry(
     openclawSessionId: string,
@@ -1069,12 +1150,12 @@ describe("CLI attempt execution", () => {
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
     expect(firstRunCliAgentArg().cliSessionId).toBe("stale-cli-session");
-    expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
-    expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
+    expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe("session-cli");
+    expect(sessionStore[sessionKey]?.claudeCliSessionId).toBe("session-cli");
 
     const persisted = readSessionStore();
-    expect(persisted[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
-    expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
+    expect(persisted[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe("session-cli");
+    expect(persisted[sessionKey]?.claudeCliSessionId).toBe("session-cli");
   });
 
   it("preserves and resumes a valid Claude CLI binding after format failover", async () => {
@@ -1112,7 +1193,9 @@ describe("CLI attempt execution", () => {
 
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
     expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
-    runCliAgentMock.mockResolvedValueOnce(makeCliResult("hello after retained resume"));
+    runCliAgentMock.mockResolvedValueOnce(
+      makeCliResult("hello after retained resume", cliSessionId),
+    );
 
     await runClaudeCliAttempt({
       sessionEntry,
@@ -1265,7 +1348,7 @@ describe("CLI attempt execution", () => {
       expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
         forkedCliSessionId,
       );
-      return makeCliResult("hello after timeout");
+      return makeCliResult("hello after timeout", forkedCliSessionId);
     });
 
     await runClaudeCliAttempt({
@@ -1322,6 +1405,7 @@ describe("CLI attempt execution", () => {
           sessionId: forkedCliSessionId,
         }),
       ).resolves.toBe(true);
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
       return makeCliResult("hello after fork timeout");
     });
 
@@ -1333,9 +1417,13 @@ describe("CLI attempt execution", () => {
       runId: "run-cli-fork-timeout",
     });
 
-    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toEqual({
+      sessionId: "session-cli",
+    });
     const persisted = readSessionStore();
-    expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]).toEqual({
+      sessionId: "session-cli",
+    });
   });
 
   it("clears a persisted fork successor when recovery fails after rebinding", async () => {
@@ -1615,7 +1703,11 @@ describe("CLI attempt execution", () => {
     };
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
-    runCliAgentMock.mockResolvedValueOnce(makeCliResult("fresh cli response"));
+    runCliAgentMock.mockImplementationOnce(async () => {
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+      expect(readSessionStore()[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+      return makeCliResult("fresh cli response");
+    });
 
     await runClaudeCliAttempt({
       sessionKey,
@@ -1634,14 +1726,18 @@ describe("CLI attempt execution", () => {
       sessionId: "phantom-claude-session",
       authProfileId: "anthropic:claude-cli",
     });
-    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
-    expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
-    expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toEqual({
+      sessionId: "session-cli",
+    });
+    expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe("session-cli");
+    expect(sessionStore[sessionKey]?.claudeCliSessionId).toBe("session-cli");
 
     const persisted = readSessionStore();
-    expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
-    expect(persisted[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
-    expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
+    expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]).toEqual({
+      sessionId: "session-cli",
+    });
+    expect(persisted[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe("session-cli");
+    expect(persisted[sessionKey]?.claudeCliSessionId).toBe("session-cli");
   });
 
   it("keeps the bound claude-cli session id as the reuse candidate when the native transcript is missing (so reseed can recover)", async () => {
@@ -1662,7 +1758,7 @@ describe("CLI attempt execution", () => {
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
     hasClaudeSessionMock.mockReturnValue(true);
-    runCliAgentMock.mockResolvedValueOnce(makeCliResult("ok"));
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("ok", cliSessionId));
 
     await runClaudeCliAttempt({
       sessionKey,
@@ -1730,7 +1826,7 @@ describe("CLI attempt execution", () => {
     };
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
-    runCliAgentMock.mockResolvedValueOnce(makeCliResult("resumed cli response"));
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("resumed cli response", cliSessionId));
 
     await runClaudeCliAttempt({
       sessionKey,
@@ -1775,7 +1871,7 @@ describe("CLI attempt execution", () => {
     const sessionEntry = makeClaudeCliSessionEntry("openclaw-session-cwd", cliSessionId);
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
-    runCliAgentMock.mockResolvedValueOnce(makeCliResult("resumed cli response"));
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("resumed cli response", cliSessionId));
 
     await runClaudeCliAttempt({
       sessionKey,

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -386,7 +386,8 @@ vi.mock("../cli-runner/cli-live-session-registry.js", () => ({
   hasCliLiveSession: hasClaudeSessionMock,
 }));
 
-vi.mock("../model-selection.js", () => ({
+vi.mock("../model-selection.js", async () => ({
+  ...(await vi.importActual<typeof import("../model-selection.js")>("../model-selection.js")),
   isCliProvider: (provider: string, _cfg?: OpenClawConfig) => {
     const normalized = provider.trim().toLowerCase();
     return (
@@ -1002,78 +1003,237 @@ describe("CLI attempt execution", () => {
     );
   }
 
-  it.each(["accepted", "rejected", "rejected-clear"])(
-    "settles a cold %s CLI binding before the next queued command starts",
-    async (outcome) => {
-      const sessionKey = "agent:main:cli-binding-settlement";
-      const sessionEntry = makeSessionEntry("binding-settlement-session");
-      if (outcome === "rejected-clear") {
-        sessionEntry.cliSessionBindings = {
-          "claude-cli": { sessionId: "previous-native-session" },
-        };
-        await writeClaudeCliAssistantTranscript(
-          "previous-native-session",
-          path.join(tmpDir, "cold-home"),
-        );
+  async function runOuterCliFallback(params: {
+    suppression?: "heartbeat" | "preserved-state";
+    sessionKey: string;
+    sessionEntry: SessionEntry;
+    sessionStore: Record<string, SessionEntry>;
+    runId: string;
+  }) {
+    const [
+      { getAcpSessionManager },
+      { prepareAgentCommandExecutionIdentity },
+      { runEmbeddedAgentAttempt },
+      { createModelVisibilityPolicy },
+    ] = await Promise.all([
+      import("../../acp/control-plane/manager.js"),
+      import("../agent-command-execution-identity.js"),
+      import("./run-embedded-attempt.js"),
+      import("../model-visibility-policy.js"),
+    ]);
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { model: { primary: "claude-cli/sonnet", fallbacks: ["claude-cli/opus"] } },
+      },
+    };
+    const opts = {
+      message: "outer fallback",
+      modelFallbacksOverride: ["claude-cli/opus"],
+      bootstrapContextRunKind: params.suppression === "heartbeat" ? "heartbeat" : undefined,
+    } satisfies RunAgentAttemptParams["opts"];
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const prepared: Parameters<typeof runEmbeddedAgentAttempt>[0]["prepared"] = {
+      ...params,
+      opts,
+      cfg,
+      body: opts.message,
+      transcriptBody: opts.message,
+      configuredThinkingCatalog: [],
+      normalizedSpawned: {},
+      agentCfg: undefined,
+      thinkOverride: undefined,
+      thinkOnce: undefined,
+      verboseOverride: undefined,
+      timeoutMs: 10_000,
+      runTimeoutOverrideMs: undefined,
+      sessionId: params.sessionEntry.sessionId,
+      storePath,
+      isNewSession: false,
+      previousSessionId: undefined,
+      persistedThinking: undefined,
+      persistedVerbose: undefined,
+      sessionAgentId: "main",
+      outboundSession: undefined,
+      workspaceDir: tmpDir,
+      cwd: undefined,
+      agentDir,
+      pluginsEnabled: false,
+      manifestMetadataSnapshot: undefined,
+      modelManifestContext: { manifestPlugins: [] },
+      isSubagentLane: false,
+      acpManager: getAcpSessionManager(),
+      acpResolution: null,
+      runLease: undefined,
+    };
+    const admission = prepareAgentCommandExecutionIdentity({
+      opts,
+      prepared,
+      ingress: { kind: "system", boundary: "cold-cli-fallback-test", state: "present" },
+      lifecycleGeneration,
+    });
+    try {
+      const attempt = await runEmbeddedAgentAttempt({
+        preparedRunAdmission: admission,
+        prepared,
+        opts,
+        sessionEntry: params.sessionEntry,
+        lifecycleGeneration,
+        onLifecycleGenerationChanged: () => {},
+        suppressVisibleSessionEffects: false,
+        preserveUserFacingSessionModelState: params.suppression === "preserved-state",
+        trackInternalModelRunTarget: () => {},
+        embeddedSessionState: {
+          sessionEntry: params.sessionEntry,
+          requestedThinkLevel: "off",
+          resolvedVerboseLevel: undefined,
+          skillsSnapshot: { prompt: "", skills: [] },
+          runContext: {},
+        },
+        modelSelection: {
+          sessionEntry: params.sessionEntry,
+          provider: "claude-cli",
+          model: "sonnet",
+          requestedRouteResolution: "resolved",
+          defaultProvider: "claude-cli",
+          defaultModel: "sonnet",
+          configuredDefaultAuthProfileId: undefined,
+          providerForAuthProfileValidation: "claude-cli",
+          visibilityPolicy: createModelVisibilityPolicy({
+            cfg,
+            catalog: [],
+            defaultProvider: "claude-cli",
+            defaultModel: "sonnet",
+          }),
+          hasExplicitRunOverride: false,
+          storedProviderOverride: undefined,
+          storedModelOverride: undefined,
+          storedModelOverrideSource: undefined,
+          hasStoredAutoFallbackProvenance: false,
+          autoFallbackPrimaryProbe: undefined,
+          sessionEntryForAttempt: params.sessionEntry,
+          thinkingCatalog: [],
+          immutableThinkLevel: "off",
+          effectiveTurnThinkLevel: "off",
+          sessionFile: path.join(tmpDir, "session.jsonl"),
+        },
+      });
+      try {
+        await attempt.fallbackTrajectoryRecorder?.flush();
+        return attempt;
+      } finally {
+        await attempt.deferredLifecycle.complete();
       }
-      const sessionStore = { [sessionKey]: sessionEntry };
-      await writeSessionStoreSeed(sessionStore);
+    } finally {
+      await admission.finish();
+    }
+  }
+
+  it.each([
+    "accepted",
+    "rejected",
+    "rejected-clear",
+    "outer-fallback",
+    "heartbeat",
+    "preserved-state",
+  ])("settles a cold %s CLI binding before the next queued command starts", async (outcome) => {
+    const suppression =
+      outcome === "heartbeat" || outcome === "preserved-state" ? outcome : undefined;
+    const outerFallback = outcome === "outer-fallback" || suppression !== undefined;
+    const accepted = outcome === "accepted" || outerFallback;
+    const previousBinding = { sessionId: "previous-native-session" };
+    const sessionKey = "agent:main:cli-binding-settlement";
+    const sessionEntry = makeSessionEntry("binding-settlement-session");
+    if (outcome === "rejected-clear" || suppression) {
+      sessionEntry.cliSessionBindings = { "claude-cli": previousBinding };
       await writeClaudeCliAssistantTranscript(
-        "settled-native-session",
+        "previous-native-session",
         path.join(tmpDir, "cold-home"),
       );
-      const firstStarted = createDeferredCore();
-      const finishFirst = createDeferredCore();
-      const binding = {
-        sessionId: "settled-native-session",
-        authProfileId: "anthropic:claude-cli",
-      };
-      runCliAgentMock
-        .mockImplementationOnce(async () => {
-          firstStarted.resolve();
-          await finishFirst.promise;
-          const result = makeCliResult("parent completed");
-          if (outcome !== "accepted") {
-            result.payloads = [{ text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT }];
-            result.meta.finalAssistantVisibleText = GENERIC_EXTERNAL_RUN_FAILURE_TEXT;
-          }
-          if (outcome === "rejected-clear") {
-            result.meta.agentMeta!.clearCliSessionBinding = true;
-          }
-          result.meta.agentMeta!.cliSessionBinding = binding;
-          result.meta.agentMeta!.sessionId = binding.sessionId;
-          return result;
-        })
-        .mockResolvedValueOnce(makeCliResult("follow-up completed"));
-      const run = (runId: string) =>
-        runClaudeCliAttempt({
+    }
+    const sessionStore = { [sessionKey]: sessionEntry };
+    await writeSessionStoreSeed(sessionStore);
+    await writeClaudeCliAssistantTranscript(
+      "settled-native-session",
+      path.join(tmpDir, "cold-home"),
+    );
+    const firstStarted = createDeferredCore();
+    const finishFirst = createDeferredCore();
+    const binding = {
+      sessionId: "settled-native-session",
+      authProfileId: "anthropic:claude-cli",
+    };
+    if (outerFallback) {
+      runCliAgentMock.mockRejectedValueOnce(
+        new FailoverError("primary capacity", {
+          reason: "rate_limit",
+          provider: "claude-cli",
+          model: "sonnet",
+        }),
+      );
+    }
+    runCliAgentMock
+      .mockImplementationOnce(async () => {
+        firstStarted.resolve();
+        await finishFirst.promise;
+        const result = makeCliResult("parent completed");
+        if (!accepted) {
+          result.payloads = [{ text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT }];
+          result.meta.finalAssistantVisibleText = GENERIC_EXTERNAL_RUN_FAILURE_TEXT;
+        }
+        if (outcome === "rejected-clear") {
+          result.meta.agentMeta!.clearCliSessionBinding = true;
+        }
+        result.meta.agentMeta!.cliSessionBinding = binding;
+        result.meta.agentMeta!.sessionId = binding.sessionId;
+        return result;
+      })
+      .mockResolvedValueOnce(makeCliResult("follow-up completed"));
+    const run = (runId: string) =>
+      runClaudeCliAttempt({
+        sessionKey,
+        sessionEntry,
+        sessionStore,
+        body: runId,
+        runId,
+        classifyResult: (result) =>
+          classifyEmbeddedAgentRunResultForModelFallback({
+            result,
+            provider: "claude-cli",
+            model: "opus",
+          }),
+      });
+    const first = outerFallback
+      ? runOuterCliFallback({
           sessionKey,
           sessionEntry,
           sessionStore,
-          body: runId,
-          runId,
-          classifyResult: (result) =>
-            classifyEmbeddedAgentRunResultForModelFallback({
-              result,
-              provider: "claude-cli",
-              model: "opus",
-            }),
-        });
-      const first = run("binding-parent");
-      await firstStarted.promise;
-      if (outcome === "rejected-clear") {
-        expect(firstRunCliAgentArg().cliSessionId).toBe("previous-native-session");
-      }
-      const second = run("binding-follow-up");
-      finishFirst.resolve();
-      await Promise.all([first, second]);
+          runId: "binding-parent",
+          suppression,
+        })
+      : run("binding-parent");
+    await Promise.race([
+      firstStarted.promise,
+      first.then(() => {
+        throw new Error("first command settled before its CLI started");
+      }),
+    ]);
+    if (outcome === "rejected-clear") {
+      expect(firstRunCliAgentArg().cliSessionId).toBe("previous-native-session");
+    }
+    const second = run("binding-follow-up");
+    finishFirst.resolve();
+    await Promise.all([first, second]);
 
-      expect(firstRunCliAgentArg(1)).toMatchObject({
-        cliSessionId: outcome === "accepted" ? binding.sessionId : undefined,
-        cliSessionBinding: outcome === "accepted" ? binding : undefined,
-      });
-    },
-  );
+    if (outerFallback) {
+      expect(firstRunCliAgentArg(0).model).toBe("sonnet");
+      expect(firstRunCliAgentArg(1).model).toBe("opus");
+    }
+    const expectedBinding = suppression ? previousBinding : accepted ? binding : undefined;
+    expect(firstRunCliAgentArg(outerFallback ? 2 : 1)).toMatchObject({
+      cliSessionId: expectedBinding?.sessionId,
+      cliSessionBinding: expectedBinding,
+    });
+  });
 
   function makeClaudeCliSessionEntry(
     openclawSessionId: string,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -75,6 +75,7 @@ import { runCliAgent } from "../cli-runner.js";
 import { hasCliLiveSession } from "../cli-runner/cli-live-session-registry.js";
 import { buildCliMcpDelegationCapabilityBinding } from "../cli-runner/mcp-grant-context.js";
 import { resolveCliRuntimeToolsAllow } from "../cli-runner/tool-policy.js";
+import { clearCliSessionInStore, persistCliSessionBindingResult } from "../cli-session-store.js";
 import {
   getCliSessionBinding,
   resolveCliSessionClearReason,
@@ -92,6 +93,7 @@ import type { ContextEngineTurnAttemptFacts } from "../harness/context-engine-tu
 import { runAgentHarnessBeforeMessageWriteHook } from "../harness/hook-helpers.js";
 import { resolveAvailableAgentHarnessPolicy } from "../harness/selection.js";
 import { AGENT_LANE_SUBAGENT } from "../lanes.js";
+import type { ModelFallbackResultClassification } from "../model-fallback-attempt.js";
 import type { ModelFallbackAttemptProvenance } from "../model-fallback.types.js";
 import { resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js";
 import { isCliProvider } from "../model-selection.js";
@@ -121,7 +123,6 @@ import {
 } from "./attempt-execution.helpers.js";
 import { resolveAgentRunContext } from "./run-context.js";
 import {
-  clearCliSessionInStore,
   consumeCliSessionForkInStore,
   persistCliSessionForkSuccessorInStore,
   restoreCliSessionForkInStore,
@@ -567,6 +568,8 @@ export function runAgentAttempt(params: {
   body: string;
   transcriptBody?: string;
   isFallbackRetry: boolean;
+  preserveCliSessionBinding?: boolean;
+  classifyResult?: (result: EmbeddedAgentRunResult) => ModelFallbackResultClassification;
   modelRoutingProvenance: ModelFallbackAttemptProvenance;
   resolvedThinkLevel: ThinkLevel;
   fastMode?: FastMode;
@@ -876,7 +879,7 @@ export function runAgentAttempt(params: {
         agentId: params.sessionAgentId,
         runId: params.runId,
       },
-      async () => {
+      async (assertSettlementCurrent) => {
         if (params.sessionKey && params.storePath) {
           params.sessionEntry = loadSessionEntry({
             sessionKey: params.sessionKey,
@@ -939,6 +942,8 @@ export function runAgentAttempt(params: {
                 sessionKey: params.sessionKey,
                 sessionStore: params.sessionStore,
                 storePath: params.storePath,
+                expectedSessionId: params.sessionId,
+                assertCommitAllowed: assertSettlementCurrent,
               }
             : undefined;
         const resolveReusableCliSessionBinding = async () => {
@@ -1004,6 +1009,10 @@ export function runAgentAttempt(params: {
                   provider: cliExecutionProvider,
                   expectedCliSessionId: nextCliSessionId,
                   ...mutableCliSessionStore,
+                  assertCommitAllowed: () => {
+                    assertSettlementCurrent();
+                    (params.deferredLifecycle?.signal ?? params.opts.abortSignal)?.throwIfAborted();
+                  },
                 }
               : undefined;
           return await runCliAgent({
@@ -1203,45 +1212,62 @@ export function runAgentAttempt(params: {
               : {}),
           });
         };
-        return resolveReusableCliSessionBinding().then(async (activeCliSessionBinding) => {
-          try {
-            return await runCliWithSession(
-              activeCliSessionBinding?.sessionId,
-              activeCliSessionBinding,
+        const activeCliSessionBinding = await resolveReusableCliSessionBinding();
+        let result: EmbeddedAgentRunResult;
+        try {
+          result = await runCliWithSession(
+            activeCliSessionBinding?.sessionId,
+            activeCliSessionBinding,
+          );
+        } catch (err) {
+          const failedCliSessionBinding = getCliSessionBinding(
+            params.sessionEntry,
+            cliExecutionProvider,
+          );
+          const failedCliSessionId = failedCliSessionBinding?.sessionId;
+          if (
+            isClaudeCliProvider(cliExecutionProvider) &&
+            shouldClearFailedCliSessionBinding({
+              error: err,
+              binding: failedCliSessionBinding,
+              hasNewGeneratedMediaTask: hasNewGeneratedMediaTaskForSessionKey(
+                params.sessionKey,
+                mediaTaskIdsBefore,
+              ),
+            }) &&
+            failedCliSessionId &&
+            mutableCliSessionStore
+          ) {
+            log.warn(
+              `CLI session cleared after failed reused turn: provider=${sanitizeForLog(cliExecutionProvider)} sessionKey=${mutableCliSessionStore.sessionKey} reason=${sanitizeForLog(resolveCliSessionClearReason(err))}`,
             );
-          } catch (err) {
-            const failedCliSessionBinding = getCliSessionBinding(
-              params.sessionEntry,
-              cliExecutionProvider,
-            );
-            const failedCliSessionId = failedCliSessionBinding?.sessionId;
-            if (
-              isClaudeCliProvider(cliExecutionProvider) &&
-              shouldClearFailedCliSessionBinding({
-                error: err,
-                binding: failedCliSessionBinding,
-                hasNewGeneratedMediaTask: hasNewGeneratedMediaTaskForSessionKey(
-                  params.sessionKey,
-                  mediaTaskIdsBefore,
-                ),
-              }) &&
-              failedCliSessionId &&
-              mutableCliSessionStore
-            ) {
-              log.warn(
-                `CLI session cleared after failed reused turn: provider=${sanitizeForLog(cliExecutionProvider)} sessionKey=${mutableCliSessionStore.sessionKey} reason=${sanitizeForLog(resolveCliSessionClearReason(err))}`,
-              );
 
-              params.sessionEntry =
-                (await clearCliSessionInStore({
-                  provider: cliExecutionProvider,
-                  expectedCliSessionId: failedCliSessionId,
-                  ...mutableCliSessionStore,
-                })) ?? params.sessionEntry;
-            }
-            throw err;
+            params.sessionEntry =
+              (await clearCliSessionInStore({
+                provider: cliExecutionProvider,
+                expectedCliSessionId: failedCliSessionId,
+                ...mutableCliSessionStore,
+              })) ?? params.sessionEntry;
           }
-        });
+          throw err;
+        }
+        const classification = params.classifyResult?.(result);
+        if (
+          !params.preserveCliSessionBinding &&
+          (!classification || result.meta.agentMeta?.clearCliSessionBinding === true)
+        ) {
+          await persistCliSessionBindingResult({
+            provider: cliExecutionProvider,
+            result,
+            sessionKey: params.sessionKey,
+            storePath: params.storePath,
+            sessionStore: params.sessionStore,
+            expectedSession: params.sessionEntry,
+            assertSettlementCurrent,
+            abortSignal: params.deferredLifecycle?.signal ?? params.opts.abortSignal,
+          });
+        }
+        return result;
       },
       {
         lifecycleGeneration: params.lifecycleGeneration,

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -26,6 +26,7 @@ import {
   resolveEffectiveCompactionMode,
 } from "../agent-settings.js";
 import { resolveCliBackendConfig as resolveCliBackendConfigImpl } from "../cli-backends.js";
+import { clearCliSessionInStore as clearCliSessionInStoreImpl } from "../cli-session-store.js";
 import {
   isBenignCompactionSkipReason,
   isBenignCompactionSkipResult,
@@ -51,7 +52,6 @@ import { acquireAgentRunPreparedModelRuntime } from "../prepared-model-runtime.j
 import type { PreparedModelRuntimePluginGeneration } from "../prepared-model-runtime.types.js";
 import { SessionManager } from "../sessions/session-manager.js";
 import {
-  clearCliSessionInStore as clearCliSessionInStoreImpl,
   normalizeSessionTokenCount,
   recordCliCompactionInStore as recordCliCompactionInStoreImpl,
 } from "./session-store.js";
@@ -814,6 +814,7 @@ export async function runCliTurnCompactionLifecycle(
         sessionStore: params.sessionStore,
         storePath: params.storePath,
         expectedSessionId: params.sessionId,
+        assertCommitAllowed: assertActive,
       })) ?? params.sessionEntry
     );
   }

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -21,6 +21,7 @@ import {
   markAutoFallbackPrimaryProbe,
   resolveEffectiveModelFallbacks,
 } from "../agent-scope.js";
+import { isHeartbeatLifecycleRunKind } from "../bootstrap-mode.js";
 import {
   runEmbeddedAgentEntry,
   type EmbeddedAgentRunEntryTerminal,
@@ -498,6 +499,12 @@ export async function runEmbeddedAgentAttempt(params: {
               body,
               transcriptBody,
               isFallbackRetry: runOptions.isFallbackRetry,
+              classifyResult: runOptions.classifyResult,
+              preserveCliSessionBinding:
+                providerOverride !== provider ||
+                modelOverride !== model ||
+                isHeartbeatLifecycleRunKind(logicalTurnOpts.bootstrapContextRunKind) ||
+                params.preserveUserFacingSessionModelState,
               modelRoutingProvenance: runOptions.modelRoutingProvenance,
               resolvedThinkLevel: candidateThinkLevel,
               fastMode,
@@ -628,8 +635,10 @@ export async function runEmbeddedAgentAttempt(params: {
             { cause: err },
           );
         }
-        const previousProvider = provider;
-        const previousModel = model;
+        if (storedModelOverride || err.model !== model || err.provider !== provider) {
+          storedModelOverride = err.model;
+          storedModelOverrideSource = "user";
+        }
         if (autoFallbackPrimaryProbe) {
           autoFallbackPrimaryProbeInterruptedByLiveSwitch = true;
         }
@@ -651,14 +660,6 @@ export async function runEmbeddedAgentAttempt(params: {
             : undefined;
           sessionEntry.authProfileOverrideCompactionCount = undefined;
           sessionEntryForAttempt = sessionEntry;
-        }
-        if (
-          storedModelOverride ||
-          err.model !== previousModel ||
-          err.provider !== previousProvider
-        ) {
-          storedModelOverride = err.model;
-          storedModelOverrideSource = "user";
         }
         attemptLifecycleState.lifecycleEnded = false;
         log.info(

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -501,8 +501,6 @@ export async function runEmbeddedAgentAttempt(params: {
               isFallbackRetry: runOptions.isFallbackRetry,
               classifyResult: runOptions.classifyResult,
               preserveCliSessionBinding:
-                providerOverride !== provider ||
-                modelOverride !== model ||
                 isHeartbeatLifecycleRunKind(logicalTurnOpts.bootstrapContextRunKind) ||
                 params.preserveUserFacingSessionModelState,
               modelRoutingProvenance: runOptions.modelRoutingProvenance,

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -11,9 +11,9 @@ import {
 } from "../../config/sessions.js";
 import * as sessionAccessor from "../../config/sessions/session-accessor.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { clearCliSessionInStore, persistCliSessionBindingResult } from "../cli-session-store.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent.js";
 import {
-  clearCliSessionInStore,
   consumeCliSessionForkInStore,
   persistCliSessionForkSuccessorInStore,
   restoreCliSessionForkInStore,
@@ -764,11 +764,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
 
   it("persists claude-cli session bindings when the backend is configured", async () => {
     await withTempSessionStore(async ({ storePath }) => {
-      const cfg = {
-        agents: {
-          defaults: {},
-        },
-      } as OpenClawConfig;
       const sessionKey = "agent:main:explicit:test-claude-cli";
       const sessionId = "test-openclaw-session";
       const sessionStore: Record<string, SessionEntry> = {
@@ -793,14 +788,13 @@ describe("updateSessionStoreAfterAgentRun", () => {
         },
       };
 
-      await updateSessionStoreAfterAgentRun({
-        cfg,
-        sessionId,
+      await persistCliSessionBindingResult({
+        assertSettlementCurrent: () => {},
+        expectedSession: sessionStore[sessionKey],
+        provider: "claude-cli",
         sessionKey,
         storePath,
         sessionStore,
-        defaultProvider: "claude-cli",
-        defaultModel: "claude-sonnet-4-6",
         result,
       });
 
@@ -823,11 +817,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
 
   it("clears stale CLI bindings when a successful run reports an unflushed replacement", async () => {
     await withTempSessionStore(async ({ storePath }) => {
-      const cfg = {
-        agents: {
-          defaults: {},
-        },
-      } as OpenClawConfig;
       const sessionKey = "agent:main:explicit:test-clear-unflushed-cli";
       const sessionId = "test-openclaw-session";
       const sessionStore: Record<string, SessionEntry> = {
@@ -864,14 +853,13 @@ describe("updateSessionStoreAfterAgentRun", () => {
         },
       };
 
-      await updateSessionStoreAfterAgentRun({
-        cfg,
-        sessionId,
+      await persistCliSessionBindingResult({
+        assertSettlementCurrent: () => {},
+        expectedSession: sessionStore[sessionKey],
+        provider: "claude-cli",
         sessionKey,
         storePath,
         sessionStore,
-        defaultProvider: "claude-cli",
-        defaultModel: "claude-sonnet-4-6",
         result,
       });
 
@@ -1089,10 +1077,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
               provider: "claude-cli",
               model: "claude-sonnet-4-6",
               sessionId: "claude-cli-session-1",
-              cliSessionBinding: {
-                sessionId: "claude-cli-session-1",
-                authEpoch: "auth-epoch-1",
-              },
             },
           },
         } as never,
@@ -1104,15 +1088,15 @@ describe("updateSessionStoreAfterAgentRun", () => {
       });
 
       expect(second.sessionKey).toBe(first.sessionKey);
-      expect(second.sessionEntry?.cliSessionBindings?.["claude-cli"]).toEqual({
-        sessionId: "claude-cli-session-1",
-        authEpoch: "auth-epoch-1",
+      expect(second.sessionEntry).toMatchObject({
+        modelProvider: "claude-cli",
+        model: "claude-sonnet-4-6",
       });
 
       const persisted = loadPersistedSessionEntry(storePath, first.sessionKey!);
-      expect(persisted?.cliSessionBindings?.["claude-cli"]).toEqual({
-        sessionId: "claude-cli-session-1",
-        authEpoch: "auth-epoch-1",
+      expect(persisted).toMatchObject({
+        modelProvider: "claude-cli",
+        model: "claude-sonnet-4-6",
       });
     });
   });
@@ -3105,6 +3089,113 @@ describe("recordCliCompactionInStore", () => {
   );
 });
 
+describe("CLI binding settlement", () => {
+  it.each(["deleted", "session", "lifecycle", "writer"])(
+    "cannot publish a native binding after its owner is %s",
+    async (change) => {
+      await withTempSessionStore(async ({ storePath }) => {
+        const sessionKey = "agent:main:cli-settlement-fence";
+        const entry = {
+          sessionId: "original",
+          lifecycleRevision: "original-lifecycle",
+          activeWriterRunId: "original-writer",
+          updatedAt: 1,
+        };
+        const sessionStore = { [sessionKey]: entry };
+        const current = {
+          ...entry,
+          ...(change === "session" ? { sessionId: "replacement" } : {}),
+          ...(change === "lifecycle" ? { lifecycleRevision: "replacement" } : {}),
+          ...(change === "writer" ? { activeWriterRunId: "replacement" } : {}),
+        };
+        if (change !== "deleted") {
+          await seedSessionStore(storePath, { [sessionKey]: current });
+        }
+        const before = loadPersistedSessionEntry(storePath, sessionKey);
+
+        await persistCliSessionBindingResult({
+          assertSettlementCurrent: () => {},
+          sessionKey,
+          storePath,
+          sessionStore,
+          expectedSession: entry,
+          provider: "claude-cli",
+          result: {
+            meta: {
+              durationMs: 1,
+              agentMeta: {
+                sessionId: "late-native-session",
+                cliSessionBinding: { sessionId: "late-native-session" },
+                provider: "claude-cli",
+                model: "claude-sonnet-4-6",
+              },
+            },
+          },
+        });
+        expect(loadPersistedSessionEntry(storePath, sessionKey)).toEqual(before);
+      });
+    },
+  );
+
+  it.each(["aborted-publish", "aborted-clear", "closed-publish", "closed-clear"])(
+    "revalidates settlement at the commit edge for %s",
+    async (operation) => {
+      await withTempSessionStore(async ({ storePath }) => {
+        const sessionKey = "agent:main:cli-settlement-commit";
+        const entry: SessionEntry = {
+          sessionId: "local-session",
+          updatedAt: 1,
+          cliSessionBindings: { "claude-cli": { sessionId: "existing-native-session" } },
+        };
+        await seedSessionStore(storePath, { [sessionKey]: entry });
+        const before = loadPersistedSessionEntry(storePath, sessionKey);
+        const controller = new AbortController();
+        let open = true;
+        const settlement = persistCliSessionBindingResult({
+          sessionKey,
+          storePath,
+          expectedSession: entry,
+          provider: "claude-cli",
+          abortSignal: controller.signal,
+          assertSettlementCurrent: () => {
+            if (!open) {
+              throw new Error("owner closed");
+            }
+          },
+          result: {
+            meta: {
+              durationMs: 1,
+              agentMeta: {
+                provider: "claude-cli",
+                model: "claude-sonnet-4-6",
+                sessionId: "replacement-native-session",
+                cliSessionBinding: { sessionId: "replacement-native-session" },
+                ...(operation.endsWith("clear") ? { clearCliSessionBinding: true } : {}),
+              },
+            },
+          },
+        });
+        // The row is unchanged; revocation happens after async patch planning starts.
+        if (operation.startsWith("closed")) {
+          open = false;
+        }
+        controller.abort(new Error("run aborted"));
+        if (operation === "aborted-clear") {
+          await settlement;
+          expect(
+            loadPersistedSessionEntry(storePath, sessionKey)?.cliSessionBindings,
+          ).toBeUndefined();
+        } else {
+          await expect(settlement).rejects.toThrow(
+            operation.startsWith("closed") ? "owner closed" : "run aborted",
+          );
+          expect(loadPersistedSessionEntry(storePath, sessionKey)).toEqual(before);
+        }
+      });
+    },
+  );
+});
+
 describe("consumeCliSessionForkInStore", () => {
   it("clears the one-shot marker while preserving the bound source id", async () => {
     await withTempSessionStore(async ({ storePath }) => {
@@ -3241,7 +3332,14 @@ describe("consumeCliSessionForkInStore", () => {
   it.each(
     (["consume", "restore", "successor"] as const).flatMap((operation) =>
       (
-        ["rebound", "deleted", "session-replaced", "lifecycle-replaced", "writer-replaced"] as const
+        [
+          "rebound",
+          "deleted",
+          "session-replaced",
+          "lifecycle-replaced",
+          "writer-replaced",
+          "claim-released",
+        ] as const
       ).map((durableState) => ({ durableState, operation })),
     ),
   )("rejects a stale $operation after the durable row is $durableState", async (testCase) => {
@@ -3281,24 +3379,35 @@ describe("consumeCliSessionForkInStore", () => {
         await seedSessionStore(storePath, { [sessionKey]: durableEntry });
       }
 
+      let open = true;
       const common = {
         provider: "claude-cli",
         sessionKey,
         sessionStore,
         storePath,
         expectedCliSessionId: "claude-source-session",
+        assertCommitAllowed: () => {
+          if (!open) {
+            throw new Error("claim released");
+          }
+        },
       };
       const result =
         operation === "consume"
-          ? await consumeCliSessionForkInStore(common)
+          ? consumeCliSessionForkInStore(common)
           : operation === "restore"
-            ? await restoreCliSessionForkInStore(common)
-            : await persistCliSessionForkSuccessorInStore({
+            ? restoreCliSessionForkInStore(common)
+            : persistCliSessionForkSuccessorInStore({
                 ...common,
                 successorCliSessionId: "claude-successor-session",
               });
 
-      expect(result).toBeUndefined();
+      if (durableState === "claim-released") {
+        open = false;
+        await expect(result).rejects.toThrow("claim released");
+      } else {
+        expect(await result).toBeUndefined();
+      }
       expect(sessionStore[sessionKey]).toEqual(cached);
       expect(loadPersistedSessionEntry(storePath, sessionKey)).toEqual(
         durableState === "deleted" ? undefined : expect.objectContaining(durableEntry),

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -15,18 +15,11 @@ import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-m
 import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createLazyPromise } from "../../shared/lazy-promise.js";
-import {
-  clearAllCliSessions,
-  clearCliSession,
-  getCliSessionBinding,
-  setCliSessionBinding,
-  setCliSessionId,
-} from "../cli-session.js";
+import { clearAllCliSessions, setCliSessionBinding } from "../cli-session.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import type { CompactionAccountingFact } from "../embedded-agent-runner/run/internal-params.js";
 import type { EmbeddedAgentCompactResult } from "../embedded-agent-runner/types.js";
 import { clearMainSessionRecoveryAfterAgentRun } from "../main-session-recovery/main-session-recovery-clear.js";
-import { isCliProvider } from "../model-selection.js";
 import { deriveSessionTotalTokens, hasBillableUsage, hasNonzeroUsage } from "../usage.js";
 
 type RunResult = Awaited<ReturnType<(typeof import("../embedded-agent.js"))["runEmbeddedAgent"]>>;
@@ -41,7 +34,7 @@ export function normalizeSessionTokenCount(value: number | undefined): number | 
   return Math.floor(value);
 }
 
-/** Applies run result metadata, usage, and CLI bindings to a session entry. */
+/** Applies run result metadata and usage to a session entry. */
 export async function updateSessionStoreAfterAgentRun(params: {
   cfg: OpenClawConfig;
   agentDir: string;
@@ -165,19 +158,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
     if (!preserveRuntimeModel) {
       next.agentHarnessId = agentHarnessId;
     }
-    if (!preserveRuntimeModel && isCliProvider(providerUsed, cfg)) {
-      const cliSessionBinding = result.meta.agentMeta?.cliSessionBinding;
-      if (result.meta.agentMeta?.clearCliSessionBinding === true) {
-        clearCliSession(next, providerUsed);
-      } else if (cliSessionBinding?.sessionId?.trim()) {
-        setCliSessionBinding(next, providerUsed, cliSessionBinding);
-      } else {
-        const cliSessionId = result.meta.agentMeta?.sessionId?.trim();
-        if (cliSessionId) {
-          setCliSessionId(next, providerUsed, cliSessionId);
-        }
-      }
-    }
     next.abortedLastRun = result.meta.aborted ?? false;
     clearMainSessionRecoveryAfterAgentRun(next, params.clearRestartRecoveryForceSafeTools);
     if (result.meta.systemPromptReport) {
@@ -276,62 +256,13 @@ export async function updateSessionStoreAfterAgentRun(params: {
   );
 }
 
-/** Clears a stored CLI session binding after a failed or invalidated run. */
-export async function clearCliSessionInStore(params: {
-  provider: string;
-  sessionKey: string;
-  sessionStore: Record<string, SessionEntry>;
-  storePath: string;
-  expectedSessionId?: string;
-  expectedCliSessionId?: string;
-}): Promise<SessionEntry | undefined> {
-  const { provider, sessionKey, sessionStore, storePath, expectedSessionId, expectedCliSessionId } =
-    params;
-  const entry = sessionStore[sessionKey];
-  if (!entry) {
-    return undefined;
-  }
-
-  let didClear = false;
-  const persisted = await patchSessionEntryCore(
-    {
-      storePath,
-      sessionKey,
-    },
-    (currentEntry, context) => {
-      if (
-        expectedSessionId &&
-        (!context.existingEntry || currentEntry.sessionId !== expectedSessionId)
-      ) {
-        return null;
-      }
-      if (
-        expectedCliSessionId &&
-        getCliSessionBinding(currentEntry, provider)?.sessionId !== expectedCliSessionId
-      ) {
-        return null;
-      }
-      const next = { ...currentEntry };
-      clearCliSession(next, provider);
-      next.updatedAt = Date.now();
-      didClear = true;
-      return next;
-    },
-    { fallbackEntry: entry },
-  );
-  if (persisted && didClear) {
-    sessionStore[sessionKey] = persisted;
-    return persisted;
-  }
-  return undefined;
-}
-
 type CliSessionForkStoreParams = {
   provider: string;
   sessionKey: string;
   sessionStore: Record<string, SessionEntry>;
   storePath: string;
   expectedCliSessionId: string;
+  assertCommitAllowed?: () => void;
 };
 
 function isSameSessionLifecycleOwner(
@@ -375,6 +306,7 @@ async function patchCliSessionForkBinding(
       return next;
     },
     {
+      assertCommitAllowed: params.assertCommitAllowed,
       onCommitted: (current) => {
         // Only the commit edge proves this transition and owns cache publication.
         committed = current;

--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -532,6 +532,7 @@ describe("runEmbeddedAgentEntry", () => {
   });
 
   it("accepts an empty result after a committed side effect and finalizes it once", async () => {
+    const hasCommittedSideEffect = vi.fn(() => true);
     state.runWithModelFallback.mockImplementationOnce(async (params: FallbackRunnerParams) => {
       const result = await params.run(params.provider, params.model, initialAttemptOptions(params));
       expect(
@@ -560,15 +561,18 @@ describe("runEmbeddedAgentEntry", () => {
         preparation: { kind: "direct" },
         resolveRuntimeOverride: () => undefined,
       },
-      behavior: { kind: "command-rpc", hasCommittedSideEffect: () => true },
+      behavior: { kind: "command-rpc", hasCommittedSideEffect },
       sessionOverride: { kind: "preserve" },
       runCandidate: async (provider, model, options) => {
         recordTurnAttempt(options.onContextEngineTurnCandidate, "candidate");
-        return makeResult({ provider, model, classification: "empty" });
+        const result = makeResult({ provider, model, classification: "empty" });
+        expect(options.classifyResult(result)).toBeUndefined();
+        return result;
       },
     });
 
     expect(state.finalizedAttempts).toEqual(["candidate"]);
+    expect(hasCommittedSideEffect).toHaveBeenCalledOnce();
   });
 
   it("does not finalize any candidate when fallback is exhausted", async () => {

--- a/src/agents/embedded-agent-runner/run-entry.ts
+++ b/src/agents/embedded-agent-runner/run-entry.ts
@@ -35,6 +35,7 @@ import {
 import type { EmbeddedAgentRunResult, TraceAttempt } from "./types.js";
 
 type RunEntryCandidateOptions = {
+  classifyResult: (result: EmbeddedAgentRunResult) => ModelFallbackResultClassification;
   allowTransientCooldownProbe?: boolean;
   isFinalFallbackAttempt?: boolean;
   isFallbackRetry: boolean;
@@ -45,6 +46,7 @@ type RunEntryCandidateOptions = {
 
 type RunEntryCandidate<T> = {
   result: T;
+  classification?: ModelFallbackResultClassification;
   turnAttempt?: ContextEngineTurnAttemptFacts;
 };
 
@@ -447,33 +449,7 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
       ...(params.behavior.kind === "maintenance"
         ? {}
         : {
-            classifyResult: ({
-              result: candidate,
-              provider,
-              model,
-            }: {
-              result: RunEntryCandidate<T>;
-              provider: string;
-              model: string;
-            }) => {
-              const deliveryEvidence =
-                params.behavior.kind === "channel-delivery"
-                  ? params.behavior.readDeliveryEvidence()
-                  : undefined;
-              const classification = classifyEmbeddedAgentRunResultForModelFallback({
-                result: candidate.result,
-                provider,
-                model,
-                ...deliveryEvidence,
-              });
-              const effectiveClassification =
-                params.behavior.kind === "followup-delivery"
-                  ? preserveFollowupResultForDelivery(classification)
-                  : classification;
-              return effectiveClassification && committedSideEffect?.()
-                ? undefined
-                : effectiveClassification;
-            },
+            classifyResult: ({ result }: { result: RunEntryCandidate<T> }) => result.classification,
           }),
       ...(canFallbackAfterError ? { canFallbackAfterError } : {}),
       ...(params.behavior.kind === "maintenance"
@@ -500,7 +476,35 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
         const isFallbackRetry = candidateIndex > 0;
         candidateIndex += 1;
         let contextEngineTurnCandidate: ContextEngineTurnAttemptFacts | undefined;
+        let classified: { value: ModelFallbackResultClassification } | undefined;
+        const classifyResult = (result: EmbeddedAgentRunResult) => {
+          if (!classified) {
+            const classification =
+              params.behavior.kind === "maintenance"
+                ? undefined
+                : classifyEmbeddedAgentRunResultForModelFallback({
+                    result,
+                    provider,
+                    model,
+                    ...readChannelDeliveryEvidence?.(),
+                  });
+            const effectiveClassification =
+              params.behavior.kind === "followup-delivery"
+                ? preserveFollowupResultForDelivery(classification)
+                : classification;
+            // CLI continuity settles while the session lane is held. The outer
+            // fallback loop consumes this same decision after that owner releases.
+            classified = {
+              value:
+                effectiveClassification && committedSideEffect?.()
+                  ? undefined
+                  : effectiveClassification,
+            };
+          }
+          return classified.value;
+        };
         const result = await params.runCandidate(provider, model, {
+          classifyResult,
           allowTransientCooldownProbe: options?.allowTransientCooldownProbe,
           isFinalFallbackAttempt: options?.isFinalFallbackAttempt,
           isFallbackRetry,
@@ -511,7 +515,11 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
             unsettledContextEngineTurnAttempt = facts;
           },
         });
-        return { result, turnAttempt: contextEngineTurnCandidate };
+        return {
+          result,
+          classification: classifyResult(result),
+          turnAttempt: contextEngineTurnCandidate,
+        };
       },
     });
     const abortFields =

--- a/src/agents/session-placement-admission.test.ts
+++ b/src/agents/session-placement-admission.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
-import { enqueueCommandInLane } from "../process/command-queue.js";
+import { enqueueCommandInLane, resetCommandLane } from "../process/command-queue.js";
 import { createDeferredCore } from "../shared/deferred.js";
 
 const settleRequesterAfterSessionSpawns = vi.hoisted(() => vi.fn(() => true));
@@ -9,6 +9,7 @@ vi.mock("./subagents/registry/subagent-registry.js", () => ({
 }));
 
 import { createTestAdmittedRunContext } from "./admitted-run-context.test-support.js";
+import { resolveSessionLane } from "./embedded-agent-runner/lanes.js";
 import {
   captureSessionPlacementCompactionSuccessorAssertion,
   installSessionPlacementAdmissionProvider,
@@ -459,4 +460,45 @@ describe("local turn placement admission", () => {
 
     expect(events).toEqual(["claim", "turn", "release", "settle"]);
   });
+
+  it.each(["settled", "reset"] as const)(
+    "closes a standalone CLI settlement assertion after its lane task is %s",
+    async (ending) => {
+      const sessionId = `standalone-${ending}`;
+      const started = createDeferredCore<void>();
+      const release = createDeferredCore<void>();
+      let retained: (() => void) | undefined;
+      const running = withLocalSessionPlacementTurnSettlement(
+        { sessionId, runId: sessionId },
+        async (assertCurrent) => {
+          retained = assertCurrent;
+          assertCurrent();
+          started.resolve();
+          await release.promise;
+          return { meta: { durationMs: 1 } };
+        },
+      );
+      await started.promise;
+      try {
+        if (ending === "reset") {
+          expect(resetCommandLane(resolveSessionLane(sessionId))).toBe(1);
+          await withLocalSessionPlacementTurnSettlement(
+            { sessionId, runId: `${sessionId}-replacement` },
+            async (assertCurrent) => {
+              assertCurrent();
+              return { meta: { durationMs: 1 } };
+            },
+          );
+        } else {
+          release.resolve();
+          await running;
+        }
+        expect(retained).toBeDefined();
+        expect(() => retained?.()).toThrow("settlement is closed");
+      } finally {
+        release.resolve();
+        await running;
+      }
+    },
+  );
 });

--- a/src/agents/session-placement-admission.test.ts
+++ b/src/agents/session-placement-admission.test.ts
@@ -465,8 +465,8 @@ describe("local turn placement admission", () => {
     "closes a standalone CLI settlement assertion after its lane task is %s",
     async (ending) => {
       const sessionId = `standalone-${ending}`;
-      const started = createDeferredCore<void>();
-      const release = createDeferredCore<void>();
+      const started = createDeferredCore();
+      const release = createDeferredCore();
       let retained: (() => void) | undefined;
       const running = withLocalSessionPlacementTurnSettlement(
         { sessionId, runId: sessionId },

--- a/src/agents/session-placement-admission.ts
+++ b/src/agents/session-placement-admission.ts
@@ -7,13 +7,14 @@ import {
 } from "../infra/agent-events.js";
 import { registerAgentRunCapacityWait } from "../infra/agent-run-capacity-wait.js";
 import { retainQueuedAgentRunContext } from "../infra/agent-run-registry.js";
-import { enqueueCommandInLane } from "../process/command-queue.js";
+import { enqueueCommandInLane, isCommandLaneTaskMarkerCurrent } from "../process/command-queue.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { resolveSessionLane } from "./embedded-agent-runner/lanes.js";
 import { resolveEmbeddedRunSessionLanePolicy } from "./embedded-agent-runner/run/lane-runtime.js";
 import type { RunEmbeddedAgentParams } from "./embedded-agent-runner/run/params.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent-runner/types.js";
 import type { SandboxContext } from "./sandbox/types.js";
+import { resolveSessionPlacementTurnSettlementAssertion } from "./session-placement-forced-terminal-settlement.js";
 import { settleRequesterAfterSessionSpawns } from "./subagents/registry/subagent-registry.js";
 
 export type LocalTurnPlacementClaim = {
@@ -117,7 +118,7 @@ export async function withSessionPlacementTurnAdmission(
 /** Serializes direct CLI turns with every runtime before acquiring placement ownership. */
 export async function withLocalSessionPlacementTurnSettlement(
   claim: LocalTurnPlacementClaim,
-  task: () => Promise<EmbeddedAgentRunResult>,
+  task: (assertSettlementCurrent: () => void) => Promise<EmbeddedAgentRunResult>,
   options: Pick<
     RunEmbeddedAgentParams,
     "abortSignal" | "lifecycleGeneration" | "trigger" | "inputProvenance"
@@ -126,16 +127,19 @@ export async function withLocalSessionPlacementTurnSettlement(
   const provider = state.provider;
   const lifecycleGeneration =
     options.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(claim.runId);
+  const assertOwnerCurrent = () => {
+    assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+    if (state.provider !== provider) {
+      throw createAbortError("session placement owner changed during turn admission");
+    }
+  };
   const assertCurrent = () => {
     if (options.abortSignal?.aborted) {
       throw options.abortSignal.reason instanceof Error
         ? options.abortSignal.reason
         : createAbortError("Operation aborted", { cause: options.abortSignal.reason });
     }
-    assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
-    if (state.provider !== provider) {
-      throw createAbortError("session placement owner changed during turn admission");
-    }
+    assertOwnerCurrent();
   };
   assertCurrent();
   const releaseQueuedContext = retainQueuedAgentRunContext(claim.runId, lifecycleGeneration);
@@ -143,15 +147,30 @@ export async function withLocalSessionPlacementTurnSettlement(
   try {
     return await enqueueCommandInLane(
       resolveSessionLane(claim.sessionKey?.trim() || claim.sessionId),
-      async () => {
+      async (taskMarker) => {
         assertCurrent();
-        const runLocal = () => {
+        const runLocal = async () => {
           // Placement admission can itself await work. A cancelled or replaced
           // queue owner must never execute through the captured provider.
           assertCurrent();
-          releaseCapacityWait?.();
-          releaseQueuedContext?.("admitted");
-          return task();
+          const assertClaimCurrent = resolveSessionPlacementTurnSettlementAssertion();
+          let open = true;
+          const assertSettlementCurrent = () => {
+            // Queue reset closes this task even if its callback has not returned.
+            if (!open || !isCommandLaneTaskMarkerCurrent(taskMarker)) {
+              throw createAbortError("session placement turn settlement is closed");
+            }
+            assertOwnerCurrent();
+            assertClaimCurrent?.();
+          };
+          try {
+            assertSettlementCurrent();
+            releaseCapacityWait?.();
+            releaseQueuedContext?.("admitted");
+            return await task(assertSettlementCurrent);
+          } finally {
+            open = false;
+          }
         };
         const result = provider
           ? await provider.executeLocalTurn(claim, runLocal)

--- a/src/agents/session-placement-forced-terminal-settlement.ts
+++ b/src/agents/session-placement-forced-terminal-settlement.ts
@@ -4,18 +4,23 @@ import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 // Carry exact local-turn cleanup until the embedded handle captures it; never recover by session id.
 const forcedTerminalSettlement = resolveGlobalSingleton(
   Symbol.for("openclaw.sessionPlacementForcedTerminalSettlement"),
-  () => new AsyncLocalStorage<() => Promise<void>>(),
+  () => new AsyncLocalStorage<{ settle: () => Promise<void>; assertCurrent: () => void }>(),
 );
 
 export function withSessionPlacementForcedTerminalSettlement<T>(
   settle: () => Promise<void>,
+  assertClaimCurrent: () => void,
   task: () => Promise<T>,
 ): Promise<T> {
-  return forcedTerminalSettlement.run(settle, task);
+  return forcedTerminalSettlement.run({ settle, assertCurrent: assertClaimCurrent }, task);
 }
 
 export function resolveSessionPlacementForcedTerminalSettlement():
   | (() => Promise<void>)
   | undefined {
-  return forcedTerminalSettlement.getStore();
+  return forcedTerminalSettlement.getStore()?.settle;
+}
+
+export function resolveSessionPlacementTurnSettlementAssertion(): (() => void) | undefined {
+  return forcedTerminalSettlement.getStore()?.assertCurrent;
 }

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -1,15 +1,22 @@
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { buildCliMcpDelegationCapabilityBinding } from "../../agents/cli-runner/mcp-grant-context.js";
 import {
+  clearCliSessionInStore,
+  persistCliSessionBindingResult,
+} from "../../agents/cli-session-store.js";
+import {
   getCliSessionBinding,
   shouldClearFailedCliSessionBinding,
 } from "../../agents/cli-session.js";
 import { resolveDelegationCapability } from "../../agents/delegation-capability.js";
+import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
 import { findModelInCatalog } from "../../agents/model-catalog-lookup.js";
+import type { ModelFallbackResultClassification } from "../../agents/model-fallback-attempt.js";
 import { createAgentRunSupersededAbortError } from "../../agents/run-termination.js";
 import { withLocalSessionPlacementTurnSettlement } from "../../agents/session-placement-admission.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import {
   getGeneratedMediaTaskIdsForSessionKey,
   hasNewGeneratedMediaTaskForSessionKey,
@@ -17,7 +24,6 @@ import {
 import { createAgentLifecycleTerminalBackstop } from "./agent-lifecycle-terminal.js";
 import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import {
-  clearCliSessionBindingForRun,
   createCliReasoningStreamBridge,
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
@@ -35,6 +41,7 @@ import { resolveFollowupRunToolAuthorityFingerprint } from "./reply-tool-authori
 export async function runCliFallbackCandidate(
   params: AgentFallbackCandidateCommonParams & {
     cliExecutionProvider: string;
+    classifyResult: (result: EmbeddedAgentRunResult) => ModelFallbackResultClassification;
     lifecycleGeneration: string;
   },
 ): Promise<{
@@ -140,7 +147,7 @@ export async function runCliFallbackCandidate(
         agentId: turn.followupRun.run.agentId,
         runId: params.runId,
       },
-      async () => {
+      async (assertSettlementCurrent) => {
         // Placement admission may wait behind an older turn. Snapshot placement,
         // permission, and native resume identity only after this turn owns it.
         const sessionEntry = sessionTarget
@@ -180,13 +187,15 @@ export async function runCliFallbackCandidate(
                   ) {
                     return;
                   }
-                  await clearCliSessionBindingForRun({
+                  await clearCliSessionInStore({
                     provider: params.cliExecutionProvider,
-                    expectedSessionId: cliSessionBinding.sessionId,
+                    expectedCliSessionId: cliSessionBinding.sessionId,
+                    expectedSessionId: sessionEntry?.sessionId,
+                    assertCommitAllowed: assertSettlementCurrent,
                     sessionKey: turn.sessionKey,
                     sessionStore: turn.activeSessionStore,
                     storePath: turn.storePath,
-                    activeSessionEntry: turn.getActiveSessionEntry(),
+                    activeSessionEntry: sessionEntry,
                   });
                 }
               : undefined,
@@ -423,13 +432,33 @@ export async function runCliFallbackCandidate(
           },
         });
         if (droppedCliSessionReplacement) {
-          await clearCliSessionBindingForRun({
+          await clearCliSessionInStore({
             provider: params.cliExecutionProvider,
-            expectedSessionId: cliSessionBinding?.sessionId,
+            expectedCliSessionId: cliSessionBinding?.sessionId,
+            expectedSessionId: sessionEntry?.sessionId,
+            assertCommitAllowed: assertSettlementCurrent,
             sessionKey: turn.sessionKey,
             sessionStore: turn.activeSessionStore,
             storePath: turn.storePath,
-            activeSessionEntry: turn.getActiveSessionEntry(),
+            activeSessionEntry: sessionEntry,
+          });
+        }
+        const classification = params.classifyResult(candidateResult);
+        if (
+          (!classification || candidateResult.meta.agentMeta?.clearCliSessionBinding === true) &&
+          !shouldPreserveUserFacingSessionStateForInputProvenance(
+            turn.followupRun.run.inputProvenance,
+          )
+        ) {
+          await persistCliSessionBindingResult({
+            provider: params.cliExecutionProvider,
+            result: candidateResult,
+            sessionKey,
+            storePath: turn.storePath,
+            sessionStore: turn.activeSessionStore,
+            expectedSession: sessionEntry,
+            assertSettlementCurrent,
+            abortSignal: params.runAbortSignal,
           });
         }
         return candidateResult;

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { withTestAdmittedRunContext } from "../../agents/admitted-run-context.test-support.js";
+import { clearCliSessionInStore } from "../../agents/cli-session-store.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
@@ -14,7 +15,6 @@ import {
   resetAgentEventsForTest,
 } from "../../infra/agent-events.js";
 import {
-  clearCliSessionBindingForRun,
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle as runCliAgentWithLifecycleProduction,
@@ -673,39 +673,62 @@ describe("keepCliSessionBindingOnlyWhenReused", () => {
   });
 });
 
-describe("clearCliSessionBindingForRun", () => {
-  it("clears the expected binding from active and stored session entries", async () => {
-    const activeEntry = {
-      sessionId: "openclaw-active",
-      updatedAt: 1,
-      cliSessionBindings: { "claude-cli": { sessionId: "stale-session" } },
-      cliSessionIds: { "claude-cli": "stale-session" },
-      claudeCliSessionId: "stale-session",
-    };
-    const storedEntry = structuredClone(activeEntry);
-    const storePath = path.join(tempDirs.make("cli-session-cleanup-"), "sessions.json");
-    await replaceSessionEntry({ storePath, sessionKey: "main" }, structuredClone(activeEntry));
+describe("clearCliSessionInStore", () => {
+  it.each(["current", "closed"])(
+    "clears active and stored entries only for a %s owner",
+    async (owner) => {
+      const activeEntry = {
+        sessionId: "openclaw-active",
+        updatedAt: 1,
+        cliSessionBindings: { "claude-cli": { sessionId: "stale-session" } },
+        cliSessionIds: { "claude-cli": "stale-session" },
+        claudeCliSessionId: "stale-session",
+      };
+      const storedEntry = structuredClone(activeEntry);
+      const storePath = path.join(tempDirs.make("cli-session-cleanup-"), "sessions.json");
+      await replaceSessionEntry({ storePath, sessionKey: "main" }, structuredClone(activeEntry));
 
-    await clearCliSessionBindingForRun({
-      provider: "claude-cli",
-      expectedSessionId: "stale-session",
-      sessionKey: "main",
-      sessionStore: { main: storedEntry },
-      storePath,
-      activeSessionEntry: activeEntry,
-    });
+      let open = true;
+      const clear = clearCliSessionInStore({
+        provider: "claude-cli",
+        expectedCliSessionId: "stale-session",
+        expectedSessionId: activeEntry.sessionId,
+        sessionKey: "main",
+        sessionStore: { main: storedEntry },
+        storePath,
+        activeSessionEntry: activeEntry,
+        assertCommitAllowed: () => {
+          if (!open) {
+            throw new Error("owner closed");
+          }
+        },
+      });
+      if (owner === "closed") {
+        open = false;
+        await expect(clear).rejects.toThrow("owner closed");
+        for (const entry of [
+          activeEntry,
+          storedEntry,
+          loadSessionEntry({ storePath, sessionKey: "main" }),
+        ]) {
+          expect(entry?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe("stale-session");
+        }
+        return;
+      }
+      await clear;
 
-    for (const entry of [activeEntry, storedEntry]) {
-      expect(entry.cliSessionBindings?.["claude-cli"]).toBeUndefined();
-      expect(entry.cliSessionIds?.["claude-cli"]).toBeUndefined();
-      expect(entry.claudeCliSessionId).toBeUndefined();
-      expect(entry.updatedAt).toBeGreaterThan(1);
-    }
-    const persisted = loadSessionEntry({ storePath, sessionKey: "main" });
-    expect(persisted?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
-    expect(persisted?.cliSessionIds?.["claude-cli"]).toBeUndefined();
-    expect(persisted?.claudeCliSessionId).toBeUndefined();
-  });
+      for (const entry of [activeEntry, storedEntry]) {
+        expect(entry.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+        expect(entry.cliSessionIds?.["claude-cli"]).toBeUndefined();
+        expect(entry.claudeCliSessionId).toBeUndefined();
+        expect(entry.updatedAt).toBeGreaterThan(1);
+      }
+      const persisted = loadSessionEntry({ storePath, sessionKey: "main" });
+      expect(persisted?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+      expect(persisted?.cliSessionIds?.["claude-cli"]).toBeUndefined();
+      expect(persisted?.claudeCliSessionId).toBeUndefined();
+    },
+  );
 
   it("does not clear a replacement binding adopted by another turn", async () => {
     const entry = {
@@ -716,9 +739,9 @@ describe("clearCliSessionBindingForRun", () => {
       claudeCliSessionId: "replacement-session",
     };
 
-    await clearCliSessionBindingForRun({
+    await clearCliSessionInStore({
       provider: "claude-cli",
-      expectedSessionId: "stale-session",
+      expectedCliSessionId: "stale-session",
       activeSessionEntry: entry,
     });
 

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -3,7 +3,6 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
-import { clearCliSession, getCliSessionBinding } from "../../agents/cli-session.js";
 import type { MediaImageLayout } from "../../agents/embedded-agent-runner/run/prompt-image-metadata.js";
 import { extractToolResultText } from "../../agents/embedded-agent-tool-results.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
@@ -20,8 +19,6 @@ import {
 } from "../../agents/run-termination.js";
 import { inferToolMetaFromArgsCore, isCommandBearingToolCall } from "../../agents/tool-display.js";
 import { normalizeAgentPlanSteps } from "../../channels/streaming.js";
-import type { SessionEntry } from "../../config/sessions.js";
-import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { AgentEventPayload } from "../../infra/agent-events.js";
 import { emitAgentEvent, withAgentRunLifecycleGeneration } from "../../infra/agent-events.js";
 import { FAST_MODE_AUTO_PROGRESS_KIND, type ReplyPayload } from "../reply-payload.js";
@@ -221,44 +218,6 @@ export function keepCliSessionBindingOnlyWhenReused(params: {
       },
     },
   };
-}
-
-export async function clearCliSessionBindingForRun(params: {
-  provider: string;
-  expectedSessionId?: string;
-  sessionKey?: string;
-  sessionStore?: Record<string, SessionEntry>;
-  storePath?: string;
-  activeSessionEntry?: SessionEntry;
-}): Promise<void> {
-  const updatedAt = Date.now();
-  const clearEntry = (entry: SessionEntry | undefined) => {
-    if (!entry) {
-      return;
-    }
-    // A later turn may already have adopted a replacement session; only the
-    // failed run that still owns this binding may clear it.
-    if (
-      params.expectedSessionId &&
-      getCliSessionBinding(entry, params.provider)?.sessionId !== params.expectedSessionId
-    ) {
-      return;
-    }
-    clearCliSession(entry, params.provider);
-    entry.updatedAt = updatedAt;
-  };
-  clearEntry(params.activeSessionEntry);
-  clearEntry(params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
-  if (!params.storePath || !params.sessionKey) {
-    return;
-  }
-  await updateSessionEntry(
-    { storePath: params.storePath, sessionKey: params.sessionKey },
-    (entry) => {
-      clearEntry(entry);
-      return entry;
-    },
-  );
 }
 
 function createToolEventBridge(params: {

--- a/src/auto-reply/reply/agent-runner-execution-cli-admission.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-admission.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { buildPreparedCliRunContext } from "../../agents/cli-runner.test-helpers.js";
+import { buildCliRunResult } from "../../agents/cli-runner/cli-run-settlement.js";
 import { executeDeps } from "../../agents/cli-runner/execute-deps.js";
 import { executePreparedCliRun } from "../../agents/cli-runner/execute.js";
 import { buildCliMcpGrantContext } from "../../agents/cli-runner/mcp-grant-context.js";
 import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
+import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../../agents/failover/user-copy.js";
 import { installSessionPlacementAdmissionProvider } from "../../agents/session-placement-admission.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -12,7 +14,9 @@ import {
   getExecuteAgentTurnForTest,
   createFollowupRun,
   requireMockCall,
+  expectMockCallArgFields,
   initialFallbackAttemptOptions,
+  fallbackAttemptOptions,
   createMinimalRunAgentTurnParams,
   makeTestSessionStorePath,
 } from "./agent-runner-execution.test-support.js";
@@ -25,70 +29,148 @@ function rejectUnexpectedCompactionSuccessor(): never {
 }
 
 describe("executeAgentTurn: CLI admission", () => {
-  it.each(["revised", "revision-established"])(
-    "rejects a %s parent lifecycle before queued CLI execution",
-    async (kind) => {
-      const sessionKey = "agent:main:cli-revision";
-      const storePath = makeTestSessionStorePath();
-      const entry: SessionEntry = {
-        sessionId: "session",
-        updatedAt: 1,
-        ...(kind === "revised" ? { lifecycleRevision: "original" } : {}),
+  it.each([
+    "ordinary",
+    "heartbeat",
+    "preserved",
+    "revised",
+    "revision-established",
+    "rejected",
+    "rejected-clear",
+  ])("settles the %s reply's native binding before releasing placement", async (kind) => {
+    const sessionKey = "agent:main:cli-binding-settlement";
+    const storePath = makeTestSessionStorePath();
+    const entry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      ...(kind === "revised" ? { lifecycleRevision: "original" } : {}),
+    };
+    const rejected = kind === "rejected" || kind === "rejected-clear";
+    const revisionChanged = kind === "revised" || kind === "revision-established";
+    const binding = { sessionId: "admitted-native-session", authProfileId: "anthropic:cli" };
+    const settledBinding = { ...binding, sessionId: "settled-native-session" };
+    await replaceSessionEntry(
+      { sessionKey, storePath },
+      {
+        ...entry,
+        cliSessionBindings: { "claude-cli": binding },
+      },
+    );
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-sonnet-4-6";
+    if (kind === "preserved") {
+      followupRun.run.inputProvenance = {
+        kind: "inter_session",
+        sourceTool: "exec_approval_followup",
       };
-      const binding = { sessionId: "native-session", authProfileId: "anthropic:cli" };
-      await replaceSessionEntry(
-        { sessionKey, storePath },
-        { ...entry, cliSessionBindings: { "claude-cli": binding } },
+    }
+    state.isCliProviderMock.mockImplementation((provider) => provider === "claude-cli");
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
+      const first = await params.run(
+        "claude-cli",
+        "claude-sonnet-4-6",
+        initialFallbackAttemptOptions(params),
       );
-      const followupRun = createFollowupRun();
-      followupRun.run.provider = "claude-cli";
-      followupRun.run.model = "claude-sonnet-4-6";
-      state.isCliProviderMock.mockReturnValue(true);
-      state.runWithModelFallbackMock.mockImplementationOnce(
-        async (params: FallbackRunnerParams) => ({
-          result: await params.run(
-            "claude-cli",
-            "claude-sonnet-4-6",
-            initialFallbackAttemptOptions(params),
-          ),
-          provider: "claude-cli",
-          model: "claude-sonnet-4-6",
-          attempts: [],
-        }),
-      );
-      state.runCliAgentMock.mockResolvedValueOnce({ payloads: [{ text: "done" }], meta: {} });
-      const uninstall = installSessionPlacementAdmissionProvider({
-        assertCompactionSuccessorAllowed: rejectUnexpectedCompactionSuccessor,
-        executeLocalTurn: async (_claim, runLocal) => {
+      if (rejected) {
+        expect(first).toMatchObject({
+          classification: { code: "generic_external_run_failure" },
+        });
+        return {
+          result: await params.run("openai", "gpt-5.4", fallbackAttemptOptions(params, "format")),
+          provider: "openai",
+          model: "gpt-5.4",
+          attempts: [{ provider: "claude-cli", model: "claude-sonnet-4-6", reason: "format" }],
+        };
+      }
+      return {
+        result: first,
+        provider: "claude-cli",
+        model: "claude-sonnet-4-6",
+        attempts: [],
+      };
+    });
+    const candidateResult = {
+      payloads: [{ text: "done" }],
+      meta: {
+        agentMeta: { sessionId: settledBinding.sessionId, cliSessionBinding: settledBinding },
+      },
+    };
+    state.runCliAgentMock.mockResolvedValueOnce(
+      rejected
+        ? buildCliRunResult({
+            context: buildPreparedCliRunContext(),
+            output: { text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT },
+            effectiveCliSessionId: settledBinding.sessionId,
+            bindingFlushOk: kind !== "rejected-clear",
+            usedHistoryPrompt: false,
+            userTurnHandled: true,
+            sessionBindingDisabled: false,
+            preparedContextAgentMeta: {},
+          })
+        : candidateResult,
+    );
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "fallback done" }],
+      meta: {},
+    });
+    let observedBinding: unknown;
+    const uninstall = installSessionPlacementAdmissionProvider({
+      assertCompactionSuccessorAllowed: rejectUnexpectedCompactionSuccessor,
+      executeLocalTurn: async (_claim, runLocal) => {
+        if (revisionChanged) {
           // Mutating the prepared object must not change the captured admission revision.
           entry.lifecycleRevision = "replacement";
           await replaceSessionEntry(
             { sessionKey, storePath },
-            { ...entry, cliSessionBindings: { "claude-cli": binding } },
+            {
+              ...entry,
+              cliSessionBindings: { "claude-cli": binding },
+            },
           );
-          return await runLocal();
-        },
-        executeTurn: async (_claim, _params, runLocal) => await runLocal(),
+        }
+        const result = await runLocal();
+        observedBinding = loadSessionEntry({ sessionKey, storePath })?.cliSessionBindings?.[
+          "claude-cli"
+        ];
+        return result;
+      },
+      executeTurn: async (_claim, _params, runLocal) => await runLocal(),
+    });
+    try {
+      const executeAgentTurn = await getExecuteAgentTurnForTest();
+      const result = await executeAgentTurn({
+        ...createMinimalRunAgentTurnParams({ followupRun }),
+        sessionKey,
+        storePath,
+        isHeartbeat: kind === "heartbeat",
+        activeSessionStore: { [sessionKey]: entry },
+        getActiveSessionEntry: () => entry,
       });
-      try {
-        const executeAgentTurn = await getExecuteAgentTurnForTest();
-        const result = await executeAgentTurn({
-          ...createMinimalRunAgentTurnParams({ followupRun }),
-          sessionKey,
-          storePath,
-          activeSessionStore: { [sessionKey]: entry },
-          getActiveSessionEntry: () => entry,
-        });
+      if (revisionChanged) {
         expect(result.kind).toBe("final");
         expect(state.runCliAgentMock).not.toHaveBeenCalled();
         expect(
           loadSessionEntry({ sessionKey, storePath })?.cliSessionBindings?.["claude-cli"],
         ).toEqual(binding);
-      } finally {
-        uninstall();
+        return;
       }
-    },
-  );
+      expect(result.kind).toBe("success");
+      expectMockCallArgFields(state.runCliAgentMock, 0, "CLI run params", {
+        cliSessionId: binding.sessionId,
+        cliSessionBinding: binding,
+      });
+      expect(observedBinding).toEqual(
+        kind === "rejected-clear"
+          ? undefined
+          : kind === "preserved" || rejected
+            ? binding
+            : settledBinding,
+      );
+    } finally {
+      uninstall();
+    }
+  });
 
   it("carries the admitted session permission and placement into the CLI grant", async () => {
     state.isCliProviderMock.mockReturnValue(true);

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -394,6 +394,7 @@ describe("executeAgentTurn: CLI session routing", () => {
       sessionFile: path.join(path.dirname(storePath), "session.jsonl"),
       updatedAt: 1,
     };
+    await replaceSessionEntry({ sessionKey: "agent:main:main", storePath }, sessionEntry);
     const activeSessionStore = { main: sessionEntry };
 
     await replaceSessionEntry({ sessionKey: "main", storePath }, sessionEntry);

--- a/src/auto-reply/reply/agent-runner-execution-results.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-results.test.ts
@@ -209,8 +209,15 @@ describe("executeAgentTurn: result and tool delivery", () => {
   });
 
   it("does not classify silent NO_REPLY terminal results for fallback", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "NO_REPLY" }],
+      meta: {},
+    });
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
-      const result = { payloads: [{ text: "NO_REPLY" }], meta: {} };
+      const result = requireRecord(
+        await params.run("openai", "gpt-5.4", initialFallbackAttemptOptions(params)),
+        "executed fallback result",
+      );
       expect(
         await params.classifyResult?.({
           result,
@@ -297,8 +304,12 @@ describe("executeAgentTurn: result and tool delivery", () => {
       hasSentPayload: vi.fn(() => false),
       getSentMediaUrls: vi.fn(() => []),
     };
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
-      const result = { payloads: [], meta: {} };
+      const result = requireRecord(
+        await params.run("openai", "gpt-5.4", initialFallbackAttemptOptions(params)),
+        "executed fallback result",
+      );
       expect(
         await params.classifyResult?.({
           result,
@@ -328,8 +339,12 @@ describe("executeAgentTurn: result and tool delivery", () => {
   });
 
   it("classifies final GPT-5 terminal-empty results instead of silently succeeding", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
-      const result = { payloads: [], meta: {} };
+      const result = requireRecord(
+        await params.run("openai", "gpt-5.4", initialFallbackAttemptOptions(params)),
+        "executed fallback result",
+      );
       const classification = await params.classifyResult?.({
         result,
         provider: "openai",

--- a/src/auto-reply/reply/agent-runner-fallback-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-candidate.ts
@@ -290,6 +290,7 @@ export async function runAgentFallbackCandidates(params: AgentFallbackCycleParam
           const candidate = await runCliFallbackCandidate({
             ...common,
             cliExecutionProvider: runtime.cliExecutionProvider,
+            classifyResult: runOptions.classifyResult,
             lifecycleGeneration: params.state.lifecycleGeneration,
           });
           params.state.bootstrapPromptWarningSignaturesSeen =

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -576,6 +576,7 @@ describe("runMemoryFlushIfNeeded", () => {
               options: Parameters<ModelFallbackParams["run"]>[2],
             ) =>
               params.runCandidate(provider, model, {
+                classifyResult: () => undefined,
                 allowTransientCooldownProbe: options.allowTransientCooldownProbe,
                 isFinalFallbackAttempt: options.isFinalFallbackAttempt,
                 isFallbackRetry: false,

--- a/src/auto-reply/reply/agent-runner-result-accounting.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.ts
@@ -1,9 +1,7 @@
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { consolidateLiveModelSwitchAfterRun } from "../../agents/live-model-switch.js";
-import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { logVerbose } from "../../globals.js";
@@ -254,15 +252,6 @@ export async function accountAgentTurn(context: AgentTurnAccountingContext) {
       });
     }
   }
-  const usedCliProvider = isCliProvider(providerUsed, cfg);
-  const cliSessionId = usedCliProvider
-    ? normalizeOptionalString(runResult.meta?.agentMeta?.sessionId)
-    : undefined;
-  const cliSessionBinding = usedCliProvider
-    ? runResult.meta?.agentMeta?.cliSessionBinding
-    : undefined;
-  const clearCliSessionBinding =
-    usedCliProvider && runResult.meta?.agentMeta?.clearCliSessionBinding === true;
   const runtimeContextTokens =
     typeof runResult.meta?.agentMeta?.contextTokens === "number" &&
     Number.isFinite(runResult.meta.agentMeta.contextTokens) &&
@@ -321,9 +310,6 @@ export async function accountAgentTurn(context: AgentTurnAccountingContext) {
     contextBudgetStatus:
       compactionCount === undefined ? runResult.meta?.agentMeta?.contextBudgetStatus : undefined,
     systemPromptReport: runResult.meta?.systemPromptReport,
-    cliSessionId,
-    cliSessionBinding,
-    clearCliSessionBinding,
     preserveFreshTotalTokensOnStaleUsage: preflightCompactionApplied,
     agentHarnessId: runResult.meta?.agentMeta?.agentHarnessId,
   });

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -1,11 +1,7 @@
-/** Persists usage, cost, model, and CLI session metadata after reply runs. */
+/** Persists usage, cost, and model metadata after reply runs. */
 import { asNonNegativeFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  clearCliSession,
-  setCliSessionBinding,
-  setCliSessionId,
-} from "../../agents/cli-session.js";
+import { clearCliSession } from "../../agents/cli-session.js";
 import {
   deriveSessionTotalTokens,
   hasBillableUsage,
@@ -25,11 +21,9 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { estimateAggregateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 
-function applyCliSessionIdToSessionPatch(
+function applyCliSessionClearToSessionPatch(
   params: {
     providerUsed?: string;
-    cliSessionId?: string;
-    cliSessionBinding?: import("../../config/sessions.js").CliSessionBinding;
     clearCliSessionBinding?: boolean;
   },
   entry: SessionEntry,
@@ -42,26 +36,6 @@ function applyCliSessionIdToSessionPatch(
   if (params.clearCliSessionBinding === true) {
     const nextEntry = { ...entry, ...patch };
     clearCliSession(nextEntry, cliProvider);
-    return {
-      ...patch,
-      cliSessionIds: nextEntry.cliSessionIds,
-      cliSessionBindings: nextEntry.cliSessionBindings,
-      claudeCliSessionId: nextEntry.claudeCliSessionId,
-    };
-  }
-  if (params.cliSessionBinding) {
-    const nextEntry = { ...entry, ...patch };
-    setCliSessionBinding(nextEntry, cliProvider, params.cliSessionBinding);
-    return {
-      ...patch,
-      cliSessionIds: nextEntry.cliSessionIds,
-      cliSessionBindings: nextEntry.cliSessionBindings,
-      claudeCliSessionId: nextEntry.claudeCliSessionId,
-    };
-  }
-  if (params.cliSessionId) {
-    const nextEntry = { ...entry, ...patch };
-    setCliSessionId(nextEntry, cliProvider, params.cliSessionId);
     return {
       ...patch,
       cliSessionIds: nextEntry.cliSessionIds,
@@ -124,8 +98,7 @@ export async function persistSessionUsageUpdate(params: {
   promptTokens?: number;
   isHeartbeat?: boolean;
   systemPromptReport?: SessionSystemPromptReport;
-  cliSessionId?: string;
-  cliSessionBinding?: import("../../config/sessions.js").CliSessionBinding;
+  /** Compaction invalidates native continuity with its accounting commit. */
   clearCliSessionBinding?: boolean;
   /** Presence overrides usage inference; undefined tokens explicitly mean current context is unknown. */
   currentContextSnapshot?: { tokens: number | undefined };
@@ -260,7 +233,7 @@ export async function persistSessionUsageUpdate(params: {
           }
           return preserveUserFacingRunState
             ? patch
-            : applyCliSessionIdToSessionPatch(params, entry, patch);
+            : applyCliSessionClearToSessionPatch(params, entry, patch);
         },
         {
           skipMaintenance: true,

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -5588,7 +5588,7 @@ describe("persistSessionUsageUpdate", () => {
     expect(readSessionStoreFast(storePath)[sessionKey]).not.toHaveProperty("agentHarnessId");
   });
 
-  it("accounts exhausted-run usage without committing its model and persists CLI binding", async () => {
+  it("accounts exhausted-run usage without committing its model or native binding", async () => {
     const storePath = await createStorePath("openclaw-usage-exhausted-");
     await seedSessionStore(storePath, sessionKey, {
       sessionId: "s1",
@@ -5613,7 +5613,6 @@ describe("persistSessionUsageUpdate", () => {
       providerUsed: "claude-cli",
       modelUsed: "claude-sonnet-4-6",
       contextTokensUsed: 200_000,
-      cliSessionBinding: { sessionId: "exhausted-cli-session" },
       preserveRuntimeModel: true,
     });
 
@@ -5627,12 +5626,12 @@ describe("persistSessionUsageUpdate", () => {
       totalTokens: 100,
       totalTokensFresh: true,
       cliSessionBindings: {
-        "claude-cli": { sessionId: "exhausted-cli-session" },
+        "claude-cli": { sessionId: "existing-cli-session" },
       },
       cliSessionIds: {
-        "claude-cli": "exhausted-cli-session",
+        "claude-cli": "existing-cli-session",
       },
-      claudeCliSessionId: "exhausted-cli-session",
+      claudeCliSessionId: "existing-cli-session",
     });
   });
 
@@ -5708,101 +5707,20 @@ describe("persistSessionUsageUpdate", () => {
       },
     },
     {
-      name: "persists heartbeat CLI binding while preserving displayed session model",
-      seed: {
-        modelProvider: "openai",
-        model: "gpt-5.4",
-        cliSessionBindings: { "claude-cli": { sessionId: "old-heartbeat-cli-session" } },
-        cliSessionIds: { "claude-cli": "old-heartbeat-cli-session" },
-        claudeCliSessionId: "old-heartbeat-cli-session",
-      },
-      update: {
-        isHeartbeat: true,
-        usage: { input: 1_200, output: 100 },
-        lastCallUsage: { input: 1_200, output: 100 },
-        providerUsed: "claude-cli",
-        modelUsed: "claude-sonnet-4-6",
-        cliSessionBinding: {
-          sessionId: "new-heartbeat-cli-session",
-          authProfileId: "anthropic:heartbeat",
-        },
-        contextTokensUsed: 128_000,
-      },
-      expected: {
-        modelProvider: "openai",
-        model: "gpt-5.4",
-        cliSessionIds: { "claude-cli": "new-heartbeat-cli-session" },
-        cliSessionBindings: {
-          "claude-cli": {
-            sessionId: "new-heartbeat-cli-session",
-            authProfileId: "anthropic:heartbeat",
-          },
-        },
-        claudeCliSessionId: "new-heartbeat-cli-session",
-      },
-    },
-    {
-      name: "honors heartbeat CLI binding clears while preserving displayed session model",
-      seed: {
-        modelProvider: "openai",
-        model: "gpt-5.4",
-        cliSessionIds: {
-          "claude-cli": "old-heartbeat-cli-session",
-          "codex-cli": "codex-cli-session",
-        },
-        cliSessionBindings: {
-          "claude-cli": { sessionId: "old-heartbeat-cli-session" },
-          "codex-cli": { sessionId: "codex-cli-session" },
-        },
-        claudeCliSessionId: "old-heartbeat-cli-session",
-      },
-      update: {
-        isHeartbeat: true,
-        usage: { input: 1_200, output: 100 },
-        lastCallUsage: { input: 1_200, output: 100 },
-        providerUsed: "claude-cli",
-        modelUsed: "claude-sonnet-4-6",
-        clearCliSessionBinding: true,
-        contextTokensUsed: 128_000,
-      },
-      expected: {
-        modelProvider: "openai",
-        model: "gpt-5.4",
-        cliSessionIds: { "codex-cli": "codex-cli-session" },
-        cliSessionBindings: { "codex-cli": { sessionId: "codex-cli-session" } },
-        claudeCliSessionId: undefined,
-      },
-    },
-    {
       name: "treats CLI last-call usage as a fresh context snapshot",
       seed: {},
       update: {
         usage: { input: 24_000, output: 2_000, cacheRead: 8_000 },
         lastCallUsage: { input: 24_000, output: 2_000, cacheRead: 8_000 },
         providerUsed: "claude-cli",
-        cliSessionBinding: {
-          sessionId: "cli-session-1",
-          authProfileId: "anthropic:default",
-          extraSystemPromptHash: "prompt-hash",
-          mcpConfigHash: "mcp-hash",
-        },
       },
       expected: {
         totalTokens: 32_000,
         totalTokensFresh: true,
-        cliSessionIds: { "claude-cli": "cli-session-1" },
-        cliSessionBindings: {
-          "claude-cli": {
-            sessionId: "cli-session-1",
-            authProfileId: "anthropic:default",
-            extraSystemPromptHash: "prompt-hash",
-            mcpConfigHash: "mcp-hash",
-          },
-        },
       },
     },
     {
-      name: "clears stale CLI binding when usage update reports an unflushed replacement",
+      name: "clears stale CLI binding with compaction accounting",
       seed: {
         cliSessionIds: { "claude-cli": "stale-cli-session", "codex-cli": "codex-session" },
         cliSessionBindings: {
@@ -6226,11 +6144,6 @@ describe("persistSessionUsageUpdate", () => {
       lastCallUsage: { input: 39_908, output: 122, cacheRead: 0, cacheWrite: 0 },
       providerUsed: "google",
       modelUsed: "gemini-2.5-flash",
-      cliSessionId: "internal-cli-session",
-      cliSessionBinding: {
-        sessionId: "internal-cli-session",
-        authProfileId: "anthropic:internal",
-      },
       contextTokensUsed: 1_000_000,
     });
     await persistSessionUsageUpdate({
@@ -6239,7 +6152,6 @@ describe("persistSessionUsageUpdate", () => {
       preserveUserFacingSessionModelState: true,
       providerUsed: "claude-cli",
       modelUsed: "claude-sonnet-4-6",
-      cliSessionId: "internal-cli-session-2",
       contextTokensUsed: 900_000,
     });
 

--- a/src/config/sessions/cli-session-binding.ts
+++ b/src/config/sessions/cli-session-binding.ts
@@ -109,14 +109,6 @@ export function getCliSessionBinding(
   return undefined;
 }
 
-/** Read just the reusable CLI session ID for a provider. */
-export function getCliSessionId(
-  entry: CliSessionBindingEntry | undefined,
-  provider: string,
-): string | undefined {
-  return getCliSessionBinding(entry, provider)?.sessionId;
-}
-
 export function clearAllCliSessions(
   entry: Partial<Pick<SessionEntry, "cliSessionBindings" | "cliSessionIds" | "claudeCliSessionId">>,
 ): void {

--- a/src/cron/isolated-agent/run-execution-cli.runtime.ts
+++ b/src/cron/isolated-agent/run-execution-cli.runtime.ts
@@ -1,6 +1,2 @@
 // Heavy CLI-agent runtime imports kept behind the cron execution lazy boundary.
-export {
-  getCliSessionBinding,
-  getCliSessionId,
-  runCliAgent,
-} from "../../agents/cli-runner.runtime.js";
+export { getCliSessionBinding, runCliAgent } from "../../agents/cli-runner.runtime.js";

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -7,6 +7,10 @@ import {
 } from "../../agents/admitted-run-context.js";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
 import { resolveCliRuntimeToolsAllow } from "../../agents/cli-runner/tool-policy.js";
+import {
+  applyCliSessionBindingResult,
+  assertCliSessionBindingResultCommitAllowed,
+} from "../../agents/cli-session.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { createContextEngineLogicalTurnLease } from "../../agents/harness/context-engine-logical-turn.js";
 import {
@@ -77,6 +81,7 @@ import {
   type CronLiveSelection,
   type MutableCronSession,
   type PersistCronSessionEntry,
+  type CronRunContinuationSession,
   setCronSessionAgentHarnessId,
   setCronSessionRuntimeModel,
   syncCronSessionLiveSelection,
@@ -287,7 +292,7 @@ type CronRunExecutionParams = {
   cronSession: MutableCronSession;
   commandBody: string;
   persistSessionEntry: PersistCronSessionEntry;
-  persistRunContinuationSession?: () => Promise<void>;
+  persistRunContinuationSession?: CronRunContinuationSession["sync"];
   setRunContinuationCliExecutionProvider?: (provider?: string) => Promise<void>;
   abortSignal?: AbortSignal;
   abortReason: () => string;
@@ -463,6 +468,22 @@ function createCronPromptExecutor(
     } catch {
       // Non-canonicalizable job config: no grant registration for this run.
     }
+    let candidateClassification:
+      | { value: ReturnType<typeof classifyEmbeddedAgentRunResultForModelFallback> }
+      | undefined;
+    const classifyResult = (
+      candidate: Parameters<typeof classifyEmbeddedAgentRunResultForModelFallback>[0],
+    ) => {
+      if (!candidateClassification) {
+        const classification = classifyEmbeddedAgentRunResultForModelFallback(candidate);
+        // Native continuity and outer fallback must consume the same acceptance
+        // fact, recorded before the CLI session lane releases.
+        candidateClassification = {
+          value: classification && currentAttemptCommittedMedia() ? undefined : classification,
+        };
+      }
+      return candidateClassification.value;
+    };
     const fallbackResult = await runWithModelFallback({
       cfg: params.cfgWithAgentDefaults,
       provider: params.liveSelection.provider,
@@ -499,17 +520,11 @@ function createCronPromptExecutor(
         });
       },
       fallbacksOverride: cronFallbacksOverride,
-      classifyResult: ({ provider, model, result }) => {
-        const classification = classifyEmbeddedAgentRunResultForModelFallback({
-          provider,
-          model,
-          result,
-        });
-        return classification && currentAttemptCommittedMedia() ? undefined : classification;
-      },
+      classifyResult,
       canFallbackAfterError: () => !currentAttemptCommittedMedia(),
       mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
+        candidateClassification = undefined;
         // Default native and direct CLI candidates skip harness preparation.
         params.lifecycle.beginAttempt();
         const isFallback = candidateStarted;
@@ -642,7 +657,7 @@ function createCronPromptExecutor(
               agentId: params.agentId,
               runId,
             },
-            async () => {
+            async (assertSettlementCurrent) => {
               const cliSessionBinding = params.cronSession.isNewSession
                 ? undefined
                 : await getCliSessionBinding(params.cronSession.sessionEntry, executionProvider);
@@ -650,7 +665,7 @@ function createCronPromptExecutor(
                 cliSessionBinding && hasCliSessionReuseMetadata(cliSessionBinding)
                   ? cliSessionBinding
                   : undefined;
-              return await runCliAgent({
+              const result = await runCliAgent({
                 preparedRunAdmission,
                 sessionId: params.cronSession.sessionEntry.sessionId,
                 sessionKey: params.runSessionKey,
@@ -715,6 +730,29 @@ function createCronPromptExecutor(
                   userTurnTranscriptRecorder.hasPersisted() ||
                   userTurnTranscriptRecorder.isBlocked(),
               });
+              const classification = classifyResult({
+                provider: providerOverride,
+                model: modelOverride,
+                result,
+              });
+              // Cleanup can seal this run after rejection. Publish the candidate
+              // to the live entry only once the base persistence owner accepts it.
+              const settledEntry = { ...params.cronSession.sessionEntry };
+              if (
+                (result.meta.agentMeta?.clearCliSessionBinding === true ||
+                  (!params.abortSignal?.aborted && !classification)) &&
+                applyCliSessionBindingResult(settledEntry, executionProvider, result.meta.agentMeta)
+              ) {
+                const assertCommitAllowed = () =>
+                  assertCliSessionBindingResultCommitAllowed(
+                    result.meta.agentMeta,
+                    assertSettlementCurrent,
+                    params.abortSignal,
+                  );
+                await params.persistSessionEntry(assertCommitAllowed, settledEntry);
+                await params.persistRunContinuationSession?.(assertCommitAllowed);
+              }
+              return result;
             },
             { abortSignal: params.abortSignal, trigger: "cron" },
           );

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -665,7 +665,7 @@ function createCronPromptExecutor(
                 cliSessionBinding && hasCliSessionReuseMetadata(cliSessionBinding)
                   ? cliSessionBinding
                   : undefined;
-              const result = await runCliAgent({
+              const candidateResult = await runCliAgent({
                 preparedRunAdmission,
                 sessionId: params.cronSession.sessionEntry.sessionId,
                 sessionKey: params.runSessionKey,
@@ -733,26 +733,30 @@ function createCronPromptExecutor(
               const classification = classifyResult({
                 provider: providerOverride,
                 model: modelOverride,
-                result,
+                result: candidateResult,
               });
               // Cleanup can seal this run after rejection. Publish the candidate
               // to the live entry only once the base persistence owner accepts it.
               const settledEntry = { ...params.cronSession.sessionEntry };
               if (
-                (result.meta.agentMeta?.clearCliSessionBinding === true ||
+                (candidateResult.meta.agentMeta?.clearCliSessionBinding === true ||
                   (!params.abortSignal?.aborted && !classification)) &&
-                applyCliSessionBindingResult(settledEntry, executionProvider, result.meta.agentMeta)
+                applyCliSessionBindingResult(
+                  settledEntry,
+                  executionProvider,
+                  candidateResult.meta.agentMeta,
+                )
               ) {
                 const assertCommitAllowed = () =>
                   assertCliSessionBindingResultCommitAllowed(
-                    result.meta.agentMeta,
+                    candidateResult.meta.agentMeta,
                     assertSettlementCurrent,
                     params.abortSignal,
                   );
                 await params.persistSessionEntry(assertCommitAllowed, settledEntry);
                 await params.persistRunContinuationSession?.(assertCommitAllowed);
               }
-              return result;
+              return candidateResult;
             },
             { abortSignal: params.abortSignal, trigger: "cron" },
           );

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -45,7 +45,6 @@ import {
   DEFAULT_CONTEXT_TOKENS,
   deriveSessionTotalTokens,
   hasNonzeroUsage,
-  isCliProvider,
 } from "./run.runtime.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
 import { cleanupCronRunSessionAfterRun } from "./session-cleanup.js";
@@ -85,11 +84,14 @@ export async function finalizeCronRun(params: {
     if (finalRunResult.meta?.systemPromptReport) {
       prepared.cronSession.sessionEntry.systemPromptReport = finalRunResult.meta.systemPromptReport;
     }
-    adoptCronRunSessionMetadata({
-      entry: prepared.cronSession.sessionEntry,
-      sessionKey: prepared.agentSessionKey,
-      runMeta: finalRunResult.meta?.agentMeta,
-    });
+    // CLI session ids belong to native continuity, never the local transcript owner.
+    if (finalRunResult.meta?.executionTrace?.runner !== "cli") {
+      adoptCronRunSessionMetadata({
+        entry: prepared.cronSession.sessionEntry,
+        sessionKey: prepared.agentSessionKey,
+        runMeta: finalRunResult.meta?.agentMeta,
+      });
+    }
   }
   const usage = finalRunResult.meta?.agentMeta?.usage;
   const diagnosticUsage = finalRunResult.meta?.agentMeta?.diagnosticUsage ?? usage;
@@ -159,20 +161,6 @@ export async function finalizeCronRun(params: {
     });
     prepared.cronSession.sessionEntry.contextTokens = contextTokens;
     prepared.cronSession.sessionEntry.contextTokensSource = contextTokensSource;
-    if (isCliProvider(providerUsed, prepared.cfgWithAgentDefaults)) {
-      const cliSessionBinding = finalRunResult.meta?.agentMeta?.cliSessionBinding;
-      const cliSessionId = finalRunResult.meta?.agentMeta?.sessionId?.trim();
-      if (finalRunResult.meta?.agentMeta?.clearCliSessionBinding === true) {
-        const { clearCliSession } = await import("../../agents/cli-runner.runtime.js");
-        clearCliSession(prepared.cronSession.sessionEntry, providerUsed);
-      } else if (cliSessionBinding?.sessionId?.trim()) {
-        const { setCliSessionBinding } = await import("../../agents/cli-runner.runtime.js");
-        setCliSessionBinding(prepared.cronSession.sessionEntry, providerUsed, cliSessionBinding);
-      } else if (cliSessionId) {
-        const { setCliSessionId } = await import("../../agents/cli-runner.runtime.js");
-        setCliSessionId(prepared.cronSession.sessionEntry, providerUsed, cliSessionId);
-      }
-    }
   }
   let telemetry: CronRunTelemetry = { model: modelUsed, provider: providerUsed };
   if (hasNonzeroUsage(usage)) {

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -309,12 +309,14 @@ export async function prepareCronRunContext(params: {
       fallbackEntry,
       resetBoundaryReason,
       update,
+      assertCommitAllowed,
     }: {
       storePath: string;
       sessionKey: string;
       fallbackEntry: SessionEntry;
       resetBoundaryReason?: "cron-stale";
       update: (entry: SessionEntry | undefined) => SessionEntry;
+      assertCommitAllowed?: () => void;
     }) => {
       const { applySessionEntryLifecycleMutation, patchSessionEntryCore } =
         await loadSessionAccessorRuntime();
@@ -338,7 +340,7 @@ export async function prepareCronRunContext(params: {
       await patchSessionEntryCore(
         { storePath, sessionKey, agentId },
         (_entry, context) => update(context.existingEntry),
-        { fallbackEntry, replaceEntry: true },
+        { fallbackEntry, replaceEntry: true, assertCommitAllowed },
       );
     };
     const persistSessionEntry = createPersistCronSessionEntry({

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -61,15 +61,19 @@ type PersistSessionEntry = (params: {
   sessionKey: string;
   storePath: string;
   update: (currentEntry: SessionEntry | undefined) => SessionEntry;
+  assertCommitAllowed?: () => void;
 }) => Promise<void>;
 
 /** Persists the currently selected mutable cron session entry to the session store. */
-export type PersistCronSessionEntry = () => Promise<void>;
+export type PersistCronSessionEntry = (
+  assertCommitAllowed?: () => void,
+  entry?: MutableCronSessionEntry,
+) => Promise<void>;
 
 /** Hidden exact-run row retained while detached cron work can still resume. */
 export type CronRunContinuationSession = {
   initialize: () => Promise<void>;
-  sync: () => Promise<void>;
+  sync: (assertCommitAllowed?: () => void) => Promise<void>;
   setCliExecutionProvider: (provider?: string) => Promise<void>;
   seal: (options?: { basePersisted?: boolean }) => Promise<void>;
 };
@@ -145,9 +149,12 @@ export function createPersistCronSessionEntry(params: {
   sandbox?: "required";
   persistSessionEntry: PersistSessionEntry;
 }): PersistCronSessionEntry {
-  return async () => {
+  return async (assertCommitAllowed, liveEntry = params.cronSession.sessionEntry) => {
     const resetBoundaryPending = params.cronSession.resetBoundaryPending !== undefined;
-    const liveEntry = params.cronSession.sessionEntry;
+    // Reset admission completes before a CLI turn can own settlement.
+    if (assertCommitAllowed && resetBoundaryPending) {
+      throw new CronSessionLifecycleClaimError(params.agentSessionKey);
+    }
     const persistedEntry =
       isCronSessionKey(params.agentSessionKey) &&
       liveEntry.sessionId &&
@@ -164,6 +171,7 @@ export function createPersistCronSessionEntry(params: {
       storePath: params.cronSession.storePath,
       sessionKey: params.agentSessionKey,
       fallbackEntry: persistedEntry,
+      assertCommitAllowed,
       ...(resetBoundaryPending ? { resetBoundaryReason: "cron-stale" as const } : {}),
       update: (currentEntry) => {
         if (!currentEntry) {
@@ -300,7 +308,12 @@ export function createCronRunContinuationSession(params: {
   };
   const owns = (entry: SessionEntry | undefined) =>
     entry?.cronRunContinuation?.lifecycleRevision === continuation.lifecycleRevision;
-  const persist = async (create: boolean, phase: "running" | "ready", basePersisted = false) => {
+  const persist = async (
+    create: boolean,
+    phase: "running" | "ready",
+    basePersisted = false,
+    assertCommitAllowed?: () => void,
+  ) => {
     const source = structuredClone(params.cronSession.sessionEntry);
     delete source.createdVia;
     delete source.createdActor;
@@ -315,6 +328,7 @@ export function createCronRunContinuationSession(params: {
       storePath: params.cronSession.storePath,
       sessionKey: params.runSessionKey,
       fallbackEntry: source,
+      assertCommitAllowed,
       update: (current) => {
         if ((current && !owns(current)) || (!current && !create)) {
           throw new CronSessionLifecycleClaimError(params.runSessionKey);
@@ -332,6 +346,11 @@ export function createCronRunContinuationSession(params: {
         return {
           ...current,
           ...source,
+          // Snapshot merges remove cleared keys; continuity copies must carry
+          // their absence too, or this row resurrects an invalid native handle.
+          cliSessionBindings: source.cliSessionBindings,
+          cliSessionIds: source.cliSessionIds,
+          claudeCliSessionId: source.claudeCliSessionId,
           ...(!current
             ? buildSessionCreationStamp({
                 via: "cron",
@@ -357,7 +376,8 @@ export function createCronRunContinuationSession(params: {
   };
   return {
     initialize: async () => await persist(true, "running"),
-    sync: async () => await persist(false, "running"),
+    sync: async (assertCommitAllowed) =>
+      await persist(false, "running", false, assertCommitAllowed),
     setCliExecutionProvider: async (provider) => {
       const normalizedProvider = provider?.trim();
       if (normalizedProvider) {

--- a/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
@@ -2,14 +2,18 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { buildPreparedCliRunContext } from "../../agents/cli-runner.test-helpers.js";
+import { buildCliRunResult } from "../../agents/cli-runner/cli-run-settlement.js";
+import { classifyEmbeddedAgentRunResultForModelFallback } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
+import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../../agents/failover/user-copy.js";
 import {
   runFallbackModelAttempt,
   runInitialModelFallbackAttempt,
   type TestModelFallbackRunnerParams,
 } from "../../agents/test-helpers/model-fallback-runner.test-support.js";
 import {
-  clearCliSessionMock,
   clearFastTestEnv,
+  classifyEmbeddedAgentRunResultForModelFallbackMock,
   getCliSessionBindingMock,
   ensureAgentWorkspaceMock,
   isCliProviderMock,
@@ -32,7 +36,6 @@ import {
   restoreFastTestEnv,
   runEmbeddedAgentMock,
   runWithModelFallbackMock,
-  setCliSessionBindingMock,
   runCliAgentMock,
 } from "./run.test-harness.js";
 
@@ -361,6 +364,9 @@ describe("runCronIsolatedAgentTurn — cron model override forwarding (#58065)",
 
   it("clears stale CLI bindings when cron CLI replacement is unflushed", async () => {
     isCliProviderMock.mockReturnValue(true);
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "claude-cli", model: "claude-opus-4-6" },
+    });
     mockRunCronFallbackPassthrough();
     const cronSession = makeCronSession({
       sessionEntry: makeCronSessionEntry({
@@ -392,52 +398,112 @@ describe("runCronIsolatedAgentTurn — cron model override forwarding (#58065)",
     );
 
     expect(result.status).toBe("ok");
-    expect(clearCliSessionMock).toHaveBeenCalledWith(cronSession.sessionEntry, "claude-cli");
+    expect(cronSession.sessionEntry.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(cronSession.sessionEntry.cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "codex-session",
+    });
   });
 
-  it("persists complete CLI bindings after cron runs", async () => {
-    isCliProviderMock.mockReturnValue(true);
-    mockRunCronFallbackPassthrough();
-    const cronSession = makeCronSession({
-      sessionEntry: makeCronSessionEntry(),
-      isNewSession: false,
-    });
-    resolveCronSessionMock.mockReturnValue(cronSession);
-    const cliSessionBinding = {
-      sessionId: "fresh-cli-session",
-      reseedReceipt: {
-        version: 1 as const,
-        promptHash: "a".repeat(64),
-        localSessionId: cronSession.sessionEntry.sessionId,
-        userTurnDisposition: "persisted",
-      },
-    };
-    runCliAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "summary done" }],
-      meta: {
-        agentMeta: {
-          provider: "claude-cli",
-          model: "claude-opus-4-6",
-          sessionId: "fresh-cli-session",
-          cliSessionBinding,
-          usage: { input: 10, output: 20 },
+  it.each(["accepted", "rejected", "rejected-clear"])(
+    "settles %s CLI continuity before cron fallback",
+    async (outcome) => {
+      isCliProviderMock.mockImplementation((provider: string) => provider === "claude-cli");
+      resolveAllowedModelRefMock.mockReturnValue({
+        ref: { provider: "claude-cli", model: "claude-opus-4-6" },
+      });
+      classifyEmbeddedAgentRunResultForModelFallbackMock.mockImplementation(
+        classifyEmbeddedAgentRunResultForModelFallback,
+      );
+      mockRunCronFallbackPassthrough();
+      const cronSession = makeCronSession({
+        sessionEntry: makeCronSessionEntry({
+          cliSessionBindings: { "claude-cli": { sessionId: "previous-cli-session" } },
+        }),
+        isNewSession: false,
+      });
+      resolveCronSessionMock.mockReturnValue(cronSession);
+      const localSessionId = cronSession.sessionEntry.sessionId;
+      const cliSessionBinding = {
+        sessionId: "fresh-cli-session",
+        reseedReceipt: {
+          version: 1 as const,
+          promptHash: "a".repeat(64),
+          localSessionId: cronSession.sessionEntry.sessionId,
+          userTurnDisposition: "persisted",
         },
-      },
-    });
+      };
+      const acceptedResult = {
+        payloads: [{ text: "summary done" }],
+        meta: {
+          durationMs: 1,
+          executionTrace: { runner: "cli" },
+          agentMeta: {
+            provider: "claude-cli",
+            model: "claude-opus-4-6",
+            sessionId: "fresh-cli-session",
+            cliSessionBinding,
+            usage: { input: 10, output: 20 },
+          },
+        },
+      };
+      const candidateResult =
+        outcome === "accepted"
+          ? acceptedResult
+          : buildCliRunResult({
+              context: buildPreparedCliRunContext(),
+              output: { text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT },
+              effectiveCliSessionId: "fresh-cli-session",
+              bindingFlushOk: outcome !== "rejected-clear",
+              usedHistoryPrompt: false,
+              userTurnHandled: true,
+              sessionBindingDisabled: false,
+              preparedContextAgentMeta: {},
+            });
+      runCliAgentMock.mockResolvedValueOnce(candidateResult);
+      runWithModelFallbackMock.mockImplementationOnce(
+        async (
+          params: TestModelFallbackRunnerParams & {
+            classifyResult: typeof classifyEmbeddedAgentRunResultForModelFallback;
+          },
+        ) => {
+          const first = await runInitialModelFallbackAttempt(params);
+          if (outcome === "accepted") {
+            return { result: first, provider: params.provider, model: params.model, attempts: [] };
+          }
+          expect(
+            params.classifyResult({
+              provider: params.provider,
+              model: params.model,
+              result: first,
+            }),
+          ).toMatchObject({ code: "generic_external_run_failure" });
+          const result = await runFallbackModelAttempt(
+            params,
+            "google",
+            "gemini-2.0-flash",
+            "format",
+          );
+          return { result, provider: "google", model: "gemini-2.0-flash", attempts: [] };
+        },
+      );
 
-    const result = await runCronIsolatedAgentTurn(
-      makeParams({
-        job: makeJob({ sessionTarget: "session:existing-cron-session" }),
-      }),
-    );
+      const result = await runCronIsolatedAgentTurn(
+        makeParams({
+          job: makeJob({ sessionTarget: "session:existing-cron-session" }),
+        }),
+      );
 
-    expect(result.status).toBe("ok");
-    expect(setCliSessionBindingMock).toHaveBeenCalledWith(
-      cronSession.sessionEntry,
-      "claude-cli",
-      cliSessionBinding,
-    );
-  });
+      expect(result.status).toBe("ok");
+      expect(cronSession.sessionEntry.sessionId).toBe(localSessionId);
+      expect(cronSession.sessionEntry.cliSessionBindings?.["claude-cli"]).toEqual(
+        outcome === "accepted"
+          ? cliSessionBinding
+          : outcome === "rejected-clear"
+            ? undefined
+            : { sessionId: "previous-cli-session" },
+      );
+    },
+  );
 
   it("validates cron thinking with catalog reasoning metadata", async () => {
     resolveAllowedModelRefMock.mockImplementation(() => ({

--- a/src/cron/isolated-agent/run.runtime.ts
+++ b/src/cron/isolated-agent/run.runtime.ts
@@ -6,7 +6,6 @@ export {
 } from "../../agents/agent-scope-config.js";
 export { resolveCronStyleNow } from "../../agents/current-time.js";
 export { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
-export { isCliProvider } from "../../agents/model-selection-cli.js";
 export { resolveThinkingDefault } from "../../agents/model-thinking-default.js";
 export { resolveSessionRuntimeOverrideForProvider } from "../../agents/session-runtime-compat.js";
 export { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";

--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -22,6 +22,7 @@ import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-d
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import {
   dispatchCronDeliveryMock,
+  isCliProviderMock,
   loadRunCronIsolatedAgentTurn,
   loadSessionEntryMock,
   callGatewayMock,
@@ -33,10 +34,12 @@ import {
   removeCronRunContinuationSessionIfIdleMock,
   resetRunCronIsolatedAgentTurnHarness,
   resolveCronSessionMock,
+  resolveAllowedModelRefMock,
   resolveCronDeliveryPlanMock,
   resolveCronPayloadOutcomeMock,
   resolveDeliveryTargetMock,
   runEmbeddedAgentMock,
+  runCliAgentMock,
   runWithModelFallbackMock,
 } from "./run.test-harness.js";
 
@@ -215,6 +218,132 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
       } finally {
         createLease.mockRestore();
       }
+    },
+  );
+
+  it.each(["base", "continuation", "aborted clear", "interrupted clear"] as const)(
+    "seals only accepted CLI continuity at %s settlement",
+    async (failurePoint) => {
+      const accessor = await vi.importActual<
+        typeof import("../../config/sessions/session-accessor.js")
+      >("../../config/sessions/session-accessor.js");
+      const dir = tempDirs.make("openclaw-cron-binding-settlement-");
+      const target = {
+        agentId: "main",
+        sessionId: `binding-${failurePoint}`,
+        sessionKey: "agent:main:cron:binding-settlement",
+        storePath: path.join(dir, "openclaw-agent.sqlite"),
+      };
+      const previousBinding = { sessionId: "previous-native", authProfileId: "anthropic:cli" };
+      const nextBinding = { ...previousBinding, sessionId: "next-native" };
+      const clearing = failurePoint === "aborted clear" || failurePoint === "interrupted clear";
+      await accessor.replaceSessionEntry(target, {
+        sessionId: target.sessionId,
+        lifecycleRevision: "binding-revision",
+        updatedAt: 1,
+        cliSessionBindings: { "claude-cli": previousBinding },
+      });
+      await accessor.appendTranscriptMessage(target, {
+        message: { role: "user", content: "Synthetic cron continuity prompt" },
+      });
+      const initialSessionEntry = accessor.loadSessionEntry(target);
+      if (!initialSessionEntry) {
+        throw new Error("Expected the persisted CLI parent before admission");
+      }
+      resolveCronSessionMock.mockReturnValue(
+        makeCronSession({
+          storePath: target.storePath,
+          store: { [target.sessionKey]: { ...initialSessionEntry } },
+          initialSessionEntry,
+          isNewSession: false,
+          lifecycleRevision: "binding-revision",
+          sessionEntry: { ...initialSessionEntry },
+        }),
+      );
+      loadSessionEntryMock.mockImplementation(() => accessor.loadSessionEntry(target));
+      isCliProviderMock.mockImplementation((provider) => provider === "claude-cli");
+      resolveAllowedModelRefMock.mockReturnValue({
+        ref: { provider: "claude-cli", model: "claude-sonnet-4-6" },
+      });
+      const controller = new AbortController();
+      let interrupted = false;
+      const interrupt = () => {
+        interrupted = true;
+        controller.abort(new Error("Synthetic binding commit interruption"));
+      };
+      runCliAgentMock.mockImplementationOnce(async () => {
+        if (failurePoint === "aborted clear") {
+          interrupt();
+        }
+        return {
+          payloads: [{ text: "Synthetic cron answer" }],
+          meta: {
+            durationMs: 1,
+            executionTrace: { runner: "cli" },
+            agentMeta: clearing
+              ? { sessionId: "", clearCliSessionBinding: true }
+              : { sessionId: nextBinding.sessionId, cliSessionBinding: nextBinding },
+          },
+        };
+      });
+      const patchWithAbort: typeof accessor.patchSessionEntryCore = (
+        scope,
+        update,
+        options = {},
+      ) => {
+        const assertCommitAllowed = options.assertCommitAllowed;
+        return accessor.patchSessionEntryCore(scope, update, {
+          ...options,
+          ...(assertCommitAllowed
+            ? {
+                assertCommitAllowed: () => {
+                  const isBase = scope.sessionKey === target.sessionKey;
+                  if ((failurePoint !== "continuation") === isBase) {
+                    interrupt();
+                  }
+                  assertCommitAllowed();
+                },
+              }
+            : {}),
+        });
+      };
+      patchSessionEntryMock.mockImplementation(patchWithAbort);
+
+      const result = await runCronIsolatedAgentTurn(
+        makeIsolatedAgentParamsFixture({
+          agentId: "main",
+          // The scheduler's cron key enables the hidden exact-run continuation.
+          sessionKey: "cron:binding-settlement",
+          job: makeIsolatedAgentJobFixture({
+            sessionTarget: `session:${target.sessionKey}`,
+            delivery: { mode: "none" },
+            payload: {
+              kind: "agentTurn",
+              message: "Synthetic cron continuity prompt",
+              model: "claude-cli/claude-sonnet-4-6",
+            },
+          }),
+          abortSignal: controller.signal,
+        }),
+      );
+
+      expect(interrupted).toBe(true);
+      expect(result.status).toBe("error");
+      expect(runCliAgentMock).toHaveBeenCalledOnce();
+      const acceptedBinding = clearing
+        ? undefined
+        : failurePoint === "base"
+          ? previousBinding
+          : nextBinding;
+      expect(accessor.loadSessionEntry(target)?.cliSessionBindings?.["claude-cli"]).toEqual(
+        acceptedBinding,
+      );
+      const continuation = accessor.loadSessionEntry({
+        ...target,
+        sessionKey: `${target.sessionKey}:run:${target.sessionId}`,
+      });
+      expect(continuation?.cronRunContinuation?.phase).toBe("ready");
+      expect(continuation?.cliSessionBindings?.["claude-cli"]).toEqual(acceptedBinding);
     },
   );
 

--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -286,12 +286,8 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
           },
         };
       });
-      const patchWithAbort: typeof accessor.patchSessionEntryCore = (
-        scope,
-        update,
-        options = {},
-      ) => {
-        const assertCommitAllowed = options.assertCommitAllowed;
+      const patchWithAbort: typeof accessor.patchSessionEntryCore = (scope, update, options) => {
+        const assertCommitAllowed = options?.assertCommitAllowed;
         return accessor.patchSessionEntryCore(scope, update, {
           ...options,
           ...(assertCommitAllowed

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -4,6 +4,7 @@ import { vi, type Mock } from "vitest";
 import { resolveFastModeState as resolveFastModeStateImpl } from "../../agents/fast-mode.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
+import type { SessionEntry } from "../../config/sessions.js";
 import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 
@@ -15,6 +16,7 @@ type CronSessionEntry = {
   skillsSnapshot: unknown;
   model?: string;
   modelProvider?: string;
+  cliSessionBindings?: SessionEntry["cliSessionBindings"];
   [key: string]: unknown;
 };
 
@@ -74,9 +76,6 @@ export const runEmbeddedAgentMock = createMock();
 export const runCliAgentMock = createMock();
 export const resolveContextTokensForModelMock = createMock();
 export const getCliSessionBindingMock = createMock();
-const getCliSessionIdMock = createMock();
-export const clearCliSessionMock = createMock();
-export const setCliSessionBindingMock = createMock();
 export const loadSessionEntryMock = createMock();
 const replaceSessionEntryMock = createMock();
 export const patchSessionEntryMock = createMock();
@@ -165,7 +164,6 @@ vi.mock("./run.runtime.js", async () => ({
   supportsXHighThinking: supportsXHighThinkingMock,
   resolveSessionTranscriptPath: resolveSessionTranscriptPathMock,
   setSessionRuntimeModel: setSessionRuntimeModelMock,
-  setCliSessionId: vi.fn(),
   logWarn: (...args: unknown[]) => logWarnMock(...args),
   normalizeAgentId: vi.fn((id: string) => id),
   mapHookExternalContentSource: mapHookExternalContentSourceMock,
@@ -268,7 +266,6 @@ vi.mock("./run-execution.runtime.js", () => ({
   resolveSubagentModelFallbacksOverride: resolveSubagentModelFallbacksOverrideMock,
   resolveBootstrapWarningSignaturesSeen: resolveBootstrapWarningSignaturesSeenMock,
   getCliSessionBinding: getCliSessionBindingMock,
-  getCliSessionId: getCliSessionIdMock,
   runCliAgent: runCliAgentMock,
   resolveFastModeState: resolveFastModeStateMock,
   resolveCandidateThinkingLevel: (params: {
@@ -346,12 +343,6 @@ vi.mock("./run-embedded.runtime.js", () => ({
 vi.mock("./run-subagent-registry.runtime.js", () => ({
   countActiveDescendantRuns: countActiveDescendantRunsMock,
   listDescendantRunsForRequester: listDescendantRunsForRequesterMock,
-}));
-
-vi.mock("../../agents/cli-runner.runtime.js", () => ({
-  clearCliSession: clearCliSessionMock,
-  setCliSessionBinding: setCliSessionBindingMock,
-  setCliSessionId: vi.fn(),
 }));
 
 vi.mock("../../agents/agent-bundle-mcp-tools.js", () => ({
@@ -641,10 +632,7 @@ function resetRunExecutionMocks(): void {
   runEmbeddedAgentMock.mockReset();
   runEmbeddedAgentMock.mockResolvedValue(makeDefaultEmbeddedResult());
   runCliAgentMock.mockReset();
-  clearCliSessionMock.mockReset();
-  setCliSessionBindingMock.mockReset();
   getCliSessionBindingMock.mockReturnValue(undefined);
-  getCliSessionIdMock.mockReturnValue(undefined);
   countActiveDescendantRunsMock.mockReset();
   countActiveDescendantRunsMock.mockReturnValue(0);
   listDescendantRunsForRequesterMock.mockReset();

--- a/src/gateway/worker-environments/worker-turn-admission.ts
+++ b/src/gateway/worker-environments/worker-turn-admission.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { LocalTurnPlacementClaim } from "../../agents/session-placement-admission.js";
 import { withSessionPlacementForcedTerminalSettlement } from "../../agents/session-placement-forced-terminal-settlement.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
+import { createAbortError } from "../../infra/abort-signal.js";
 import { SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS } from "../../sessions/session-lifecycle-admission.js";
 import { projectWorkerSessionTurnClaim } from "./placement-record.js";
 import type {
@@ -190,9 +191,21 @@ export async function executeLocalTurn<T>(params: {
   });
   // Forced terminalization and ordinary completion share this exact-claim closure.
   // Replacement fencing makes a late finally harmless after recovery settles it.
-  const settle = () => releaseClaimIfOwned(params.placements, turnClaim);
+  let closed = false;
+  const settle = () => {
+    closed = true;
+    return releaseClaimIfOwned(params.placements, turnClaim);
+  };
   try {
-    return await withSessionPlacementForcedTerminalSettlement(settle, params.runLocal);
+    return await withSessionPlacementForcedTerminalSettlement(
+      settle,
+      () => {
+        if (closed || !params.placements.validateTurnClaim(turnClaim)) {
+          throw createAbortError("session placement turn settlement is closed");
+        }
+      },
+      params.runLocal,
+    );
   } finally {
     await settle();
   }

--- a/src/gateway/worker-environments/worker-turn-launcher.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test.ts
@@ -8,7 +8,10 @@ import {
   setActiveEmbeddedRun,
 } from "../../agents/embedded-agent-runner/runs.js";
 import { installSessionPlacementAdmissionProvider } from "../../agents/session-placement-admission.js";
-import { resolveSessionPlacementForcedTerminalSettlement } from "../../agents/session-placement-forced-terminal-settlement.js";
+import {
+  resolveSessionPlacementForcedTerminalSettlement,
+  resolveSessionPlacementTurnSettlementAssertion,
+} from "../../agents/session-placement-forced-terminal-settlement.js";
 import { setRuntimeConfigSnapshot } from "../../config/io.js";
 import {
   loadSessionEntry,
@@ -218,10 +221,13 @@ describe("worker turn launcher local placement", () => {
   it("holds a local placement claim around CLI execution", async () => {
     const environments = unusedEnvironments();
     const provider = createWorkerSessionTurnPlacementProvider({ environments, placements });
+    let assertSettlementCurrent: (() => void) | undefined;
 
     const result = await provider.executeLocalTurn(
       { sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main", runId: "run-cli" },
       async () => {
+        assertSettlementCurrent = resolveSessionPlacementTurnSettlementAssertion();
+        assertSettlementCurrent?.();
         expect(placements.get(SESSION_ID)?.turnClaim).toMatchObject({
           owner: "local",
           runId: "run-cli",
@@ -232,6 +238,8 @@ describe("worker turn launcher local placement", () => {
 
     expect(result).toEqual({ kind: "cli" });
     expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
+    expect(assertSettlementCurrent).toBeDefined();
+    expect(() => assertSettlementCurrent?.()).toThrow("settlement is closed");
   });
 
   it("mints a fresh claim token when a later turn reuses the run id", async () => {
@@ -329,6 +337,7 @@ describe("worker turn launcher local placement", () => {
     const finishOldRun = createDeferred();
     const replacementStarted = createDeferred();
     const finishReplacement = createDeferred();
+    let assertOldSettlementCurrent: (() => void) | undefined;
     const handle = {
       queueMessage: async () => {},
       isStreaming: () => true,
@@ -344,6 +353,8 @@ describe("worker turn launcher local placement", () => {
         runId: "run-force-cleared",
       },
       async () => {
+        assertOldSettlementCurrent = resolveSessionPlacementTurnSettlementAssertion();
+        assertOldSettlementCurrent?.();
         setActiveEmbeddedRun(SESSION_ID, handle, SESSION_KEY);
         oldRunStarted.resolve();
         await finishOldRun.promise;
@@ -362,6 +373,8 @@ describe("worker turn launcher local placement", () => {
         reason: "stuck_recovery",
       }),
     ).resolves.toMatchObject({ forceCleared: true });
+    expect(assertOldSettlementCurrent).toBeDefined();
+    expect(() => assertOldSettlementCurrent?.()).toThrow("settlement is closed");
     const killedEntry = loadSessionEntry(sessionTarget);
     expect(killedEntry).toMatchObject({
       sessionId: SESSION_ID,


### PR DESCRIPTION
Related: #136423 (busy-parent subagent completion admission), #134186, #135192.

## What Problem This Solves

Fixes an issue where users queueing another turn on a CLI-backed session could lose native conversation continuity when the next turn started in a fresh CLI process. It also prevents a retired or rejected run from overwriting the continuation that a later turn should use.

## Why This Change Was Made

Native continuation now settles before the same-session admission lane releases, with the exact live placement/turn assertion carried to the existing synchronous store commit. Command, reply, and cron share that ownership rule; duplicate late writers and clear helpers are removed. Local OpenClaw session IDs remain distinct from native CLI IDs, and only the explicit native binding result is persisted.

Accepted fallback candidates may publish continuity. Explicit invalid-binding cleanup still works after abort while that exact owner remains live; closed/replaced owners cannot publish or clear. Cron stages the result until its guarded base commit succeeds so later finalization cannot resurrect a rejected write. Keeping all post-run accounting under the lane would instead risk deadlocking compaction, which can itself enter that lane. This changes no config, environment, database schema, stored representation, protocol, or dependency.

## User Impact

Queued CLI turns resume the preceding accepted native conversation even without a warm CLI process. Aborted, replaced, or rejected candidates cannot silently poison later continuation. Embedded session rollover, provenance-preserved turns, explicit native invalidation, and compaction remain covered.

This is the separately scoped follow-up to #136423; it does not claim to repair the unrelated bootstrap migration, Telegram ingress, or Discord display-size allegations from the original reports. Thanks to Sean van der Walt (@svdwalt007), @Isitjustmefromparis, and @Tony-Clawbot for the reports that led to the admission and continuity investigation.

## Evidence

Validated head: `c4102b45bdc5f43704e4af8987503f7e46550b6c`. [Exact-head CI is green](https://github.com/openclaw/openclaw/actions/runs/33689995303); changed checks, types, lint, three dead-code scans, runtime/UI build, and the [refreshed before/after Gateway fallback proof](https://github.com/openclaw/openclaw/pull/136644#issuecomment-5517513366) passed. Branch review completed with no accepted findings after direct source validation. The proposed storeless-publication gap was rejected: the old writer also returned without a store path, and normal reply sessions supply the canonical path.

- The new real outer-fallback regression failed on `3893ade22c24d6c4c6964a4ff524ffb101b4ff20`: the queued cold command received no native binding. The real Gateway/Control UI direct `agent` RPC probe on that same immutable build also visibly returned `FALLBACK_COLD_RESUME_MISSING`.
- The correction passed 259 wrapper-driven tests (CLI 141, session store 99, reply result handling 19). After two typed fixture corrections, all six cold-turn cases, core-test types, type-aware lint, and scoped review through P2 passed. The six cases include accepted fallback, heartbeat preservation, and explicit session-state preservation.
- Earlier grouped owner regression suites passed 487 tests on rebased implementation `0a0f0cc96b6d0221be7c3d264223cd00ec99eea8`; later typed-fixture and mechanical changes were checked separately. The existing live transcript below is explicitly the previous `3893ade22c24` reply-path proof; the new head's direct-command fallback proof is linked above.

### Review correction and CI follow-up

ClawSweeper's accepted-fallback finding and both rank-up moves are addressed in `c4102b45bdc5f43704e4af8987503f7e46550b6c`: native continuation no longer inherits provider/model display-preservation conditions, and the regression traverses the real `runEmbeddedAgentAttempt` fallback owner before queueing the next cold command. Heartbeat and explicitly preserved turns still retain the original binding. This coupling also existed in the base commit's late writer; the change repairs it without attributing introduction to this PR or a contributor.

The old CI head exposed three reply fixtures that bypassed candidate execution and therefore had no recorded classification; those fixtures now execute the candidate and pass without adding production reclassification. One unrelated Copilot cleanup test also failed: its real 5 ms deadline can expire before `createSession` starts. Named follow-up: make that late-session cleanup fixture trigger its deadline after session creation starts using a controlled clock, not a larger timeout. This is a source-backed timing-flake inference, not a locally reproduced defect; the new-head CI run is now green.

The original cold-process regression queued the second command before the first returned with no warm session registry; the second command received no native binding before the fix. That initial terminal output was captured, but no complete raw tee log was retained. Later full-log regressions cover cold invalidation, rejected fallback candidates, queue reset, exact-owner clear/fork writes, cron rejected-commit followed by finalization, and local/native ID separation. The real-builder scalar-ID test is a before/after correction of the proposed canonical owner, not an unchanged-main run. Introduction provenance is unknown; this PR does not attribute the defect to a particular contributor.

### Final-head live fallback transcript (`c4102b45bdc5`)

The same real Gateway and Control UI flow that failed before the fallback correction now passes. An explicitly synthetic one-shot CLI backend uses existing plugin/auth contracts; two direct `agent` RPC requests from the connected Control UI client each encounter primary capacity failure and complete through the fallback. No warm process, provider credentials, operator state, or product-source fixture changes were used.

```text
22:44:41.138Z first cold fallback starts, pid=5538
22:44:57.385Z second same-session request accepted while first fallback is alive
22:45:11.925Z first fallback exits
22:45:12.136Z Control UI receives FIRST_FALLBACK_FINISHED assistant final
22:45:12.575Z second cold fallback starts, pid=14988, exact native handle resumed
22:45:12.759Z Control UI receives FALLBACK_COLD_RESUME_OK assistant final
ActiveTurnClaimError: 0
```

The verifier requires matching commit/build metadata and actual Control UI/Gateway handshake build IDs, correlated accepted and final RPC payloads, same-session assistant-final events, four one-shot processes, and exact native reuse. Queue acceptance alone is not delivery. [Inspected synthetic-only before/after screenshots and full proof summary](https://github.com/openclaw/openclaw/pull/136644#issuecomment-5517513366). The owned Gateway and browser exited cleanly, isolated state was removed, and the port was verified free. Latest ClawSweeper rank-up moves (exact-head CI and refreshed fallback trace) are complete.

### Previous-head isolated live transcript (`3893ade22c24`)

Real Gateway, canonical session store, and Control UI; explicitly synthetic one-shot CLI dependency using the existing plugin backend and local synthetic-auth discovery contracts. No warm CLI session registry, credentials, operator state, or product source changes were used for the fixture. The first request used the normal composer; the second used the connected Control UI client's normal `chat.send` API with `queueMode: followup` so it reached the Gateway while the first process was busy.

```text
21:41:43.177Z first cold CLI starts, pid=50468, no prior native handle
21:41:56.140Z second same-session chat.send accepted while first CLI is alive
21:42:04.833Z fixture releases first CLI
21:42:04.840Z first CLI exits
21:42:04.883Z Control UI receives FIRST_COLD_CLI_FINISHED assistant final
21:42:05.072Z second cold CLI starts, pid=53275, --resume=<exact first native handle>
21:42:05.076Z second CLI exits
21:42:05.113Z Control UI receives COLD_RESUME_OK assistant final
ActiveTurnClaimError: 0
```

Queued admission and execution have distinct run IDs; the Gateway's recorded `chat.send_timing.agentRunId` mapping connects the accepted second request to its actual assistant final. Queue acceptance alone is not counted as delivery. This live run verifies the user flow after the fix; the deterministic original-order regressions establish the pre-fix race. The parent PR separately contains the real Claude busy-parent completion/abort roundtrip.

Production LOC: +479/-323 (net +156); tests/support: +989/-306 (net +683). Growth supplies the previously missing exact-owner synchronous commit contract and one recorded candidate-classification decision; removed late publication paths and consolidated clearing offset it. Existing continuity behavior is documented at https://docs.openclaw.ai/gateway/cli-backends.

![Two actual Control UI assistant finals from distinct cold CLI processes using the same native handle](https://github.com/user-attachments/assets/386a8c62-095f-4dcc-a8b8-277a29612e8a)