### PR TITLE
fix(ui): center chat face switch

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1237,6 +1237,119 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("centers the face switch while the identity trail truncates", async () => {
+    const page = await openBrowserPage(800, 180);
+    try {
+      const splitViewCss = readStyleSheet("ui/src/styles/chat/split-view.css");
+      const boardCss = readStyleSheet("ui/src/styles/chat/board.css");
+      const settingsControlsCss = readStyleSheet("ui/src/styles/settings-controls.css");
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}\n${settingsControlsCss}\n${splitViewCss}\n${boardCss}</style></head><body>
+          <div class="chat-pane__header chat-pane__header--centered" style="width: 720px;">
+            <div class="chat-pane__header-leading">
+              <div class="chat-pane__crumbs">
+                <span class="chat-pane__session-title">
+                  <span class="chat-pane__session-title-text">A deliberately long session title that must yield to the centered face switch</span>
+                </span>
+              </div>
+            </div>
+            <div class="chat-pane__header-center">
+              <div class="chat-pane__face-switch">
+                <div class="settings-segmented">
+                  <button class="settings-segmented__btn" type="button">Chat</button>
+                  <button class="settings-segmented__btn settings-segmented__btn--active" type="button">Split</button>
+                  <button class="settings-segmented__btn" type="button">Dashboard</button>
+                </div>
+              </div>
+            </div>
+            <div class="chat-pane__header-trailing">
+              <div class="chat-pane__actions">
+                <button class="btn btn--ghost btn--icon chat-icon-btn" type="button">A</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn" type="button">B</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn" type="button">C</button>
+              </div>
+            </div>
+          </div>
+        </body></html>`,
+      );
+
+      const geometry = await page.locator(".chat-pane__header").evaluate((header) => {
+        const headerElement = header as HTMLElement;
+        const style = getComputedStyle(headerElement);
+        const rect = headerElement.getBoundingClientRect();
+        const centerRect = headerElement
+          .querySelector<HTMLElement>(".chat-pane__header-center")!
+          .getBoundingClientRect();
+        const title = headerElement.querySelector<HTMLElement>(".chat-pane__session-title-text")!;
+        const contentWidth =
+          headerElement.clientWidth -
+          Number.parseFloat(style.paddingLeft) -
+          Number.parseFloat(style.paddingRight);
+        return {
+          contentCenter: rect.left + Number.parseFloat(style.paddingLeft) + contentWidth / 2,
+          faceCenter: centerRect.left + centerRect.width / 2,
+          titleClientWidth: title.clientWidth,
+          titleScrollWidth: title.scrollWidth,
+        };
+      });
+
+      expect(Math.abs(geometry.faceCenter - geometry.contentCenter)).toBeLessThanOrEqual(0.5);
+      expect(geometry.titleScrollWidth).toBeGreaterThan(geometry.titleClientWidth);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it("keeps a constrained no-face header to one flex gap", async () => {
+    const page = await openBrowserPage(360, 180);
+    try {
+      const splitViewCss = readStyleSheet("ui/src/styles/chat/split-view.css");
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}\n${splitViewCss}</style></head><body>
+          <div class="chat-pane__header" style="width: 320px;">
+            <div class="chat-pane__header-leading">
+              <div class="chat-pane__crumbs">
+                <span class="chat-pane__session-title">
+                  <span class="chat-pane__session-title-text">A deliberately long session title for the no-face header</span>
+                </span>
+              </div>
+            </div>
+            <div class="chat-pane__header-trailing">
+              <div class="chat-pane__actions">
+                <button class="btn btn--ghost btn--icon chat-icon-btn" type="button">A</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn" type="button">B</button>
+                <button class="btn btn--ghost btn--icon chat-icon-btn" type="button">C</button>
+              </div>
+            </div>
+          </div>
+        </body></html>`,
+      );
+
+      const geometry = await page.locator(".chat-pane__header").evaluate((header) => {
+        const leading = header.querySelector<HTMLElement>(".chat-pane__header-leading")!;
+        const trailing = header.querySelector<HTMLElement>(".chat-pane__header-trailing")!;
+        const title = header.querySelector<HTMLElement>(".chat-pane__session-title-text")!;
+        const leadingRect = leading.getBoundingClientRect();
+        const trailingRect = trailing.getBoundingClientRect();
+        return {
+          gap: trailingRect.left - leadingRect.right,
+          regionClasses: [...header.children].map((child) => child.className),
+          titleClientWidth: title.clientWidth,
+          titleScrollWidth: title.scrollWidth,
+        };
+      });
+
+      expect(geometry.regionClasses).toEqual([
+        "chat-pane__header-leading",
+        "chat-pane__header-trailing",
+      ]);
+      expect(geometry.gap).toBeCloseTo(8, 0);
+      expect(geometry.titleScrollWidth).toBeGreaterThan(geometry.titleClientWidth);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it("keeps the split-pane close button reachable as the pane narrows", async () => {
     const page = await openBrowserPage(1100, 240);
     try {

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -405,6 +405,35 @@ describe("chat pane header", () => {
     expect(crumbs?.nextElementSibling?.getAttribute("data-slot")).toBe("placement");
   });
 
+  it("separates identity, face, and action controls into balanced header regions", () => {
+    const { container } = mountHeader({
+      placementControl: html`<span data-slot="placement"></span>`,
+      presence: html`<span data-slot="presence"></span>`,
+      faceControl: html`<span data-slot="face"></span>`,
+      sharingControl: html`<span data-slot="sharing"></span>`,
+    });
+
+    expect(container.querySelector('[data-slot="placement"]')?.parentElement?.className).toBe(
+      "chat-pane__header-leading",
+    );
+    expect(container.querySelector('[data-slot="face"]')?.parentElement?.className).toBe(
+      "chat-pane__header-center",
+    );
+    expect(container.querySelector('[data-slot="sharing"]')?.parentElement?.className).toBe(
+      "chat-pane__header-trailing",
+    );
+    expect(container.querySelector(".chat-pane__header--centered")).not.toBeNull();
+  });
+
+  it("uses the full header width when no face switch needs centering", () => {
+    const { container } = mountHeader();
+    expect(container.querySelector(".chat-pane__header--centered")).toBeNull();
+    expect(container.querySelector(".chat-pane__header-center")).toBeNull();
+    expect(
+      [...container.querySelector(".chat-pane__header")!.children].map((child) => child.className),
+    ).toEqual(["chat-pane__header-leading", "chat-pane__header-trailing"]);
+  });
+
   it("leads with the project, then a separator, then the session title", () => {
     const { container } = mountHeader();
     const crumbs = container.querySelector(".chat-pane__crumbs");

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -103,7 +103,6 @@ function revealLabel(platform: string | null): string {
   }
   return t("chat.sessionHeader.revealFileManager");
 }
-
 function branchRelativeTime(updatedAt: string | undefined): string {
   const timestamp = updatedAt ? Date.parse(updatedAt) : Number.NaN;
   return Number.isFinite(timestamp) ? formatRelativeTimestamp(timestamp, { fallback: "" }) : "";
@@ -385,195 +384,211 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
   const copied = props.copiedAction === "copy-path" || props.copiedAction === "copy-branch";
   const drawerLabel = props.navDrawerOpen ? t("nav.collapse") : t("nav.expand");
   const compactSessionActions = props.narrow && props.sessionMenuAction !== nothing;
+  const hasFaceControl = props.faceControl !== undefined && props.faceControl !== nothing;
 
   return html`
-    <div class="chat-pane__header" @mousedown=${beginNativeWindowDrag}>
-      ${props.mergedChrome
-        ? html`<openclaw-tooltip .content=${drawerLabel}>
-            <button
-              class="btn btn--ghost btn--icon chat-icon-btn chat-pane__nav-toggle"
-              type="button"
-              aria-label=${drawerLabel}
-              aria-expanded=${String(Boolean(props.navDrawerOpen))}
-              @click=${(event: MouseEvent) => {
-                window.dispatchEvent(
-                  new CustomEvent<ShellNavDrawerToggleDetail>(SHELL_NAV_DRAWER_TOGGLE_EVENT, {
-                    detail: { trigger: event.currentTarget as HTMLElement },
-                  }),
-                );
-              }}
-            >
-              ${icons.menu}
-            </button>
-          </openclaw-tooltip>`
+    <div
+      class="chat-pane__header ${hasFaceControl ? "chat-pane__header--centered" : ""}"
+      @mousedown=${beginNativeWindowDrag}
+    >
+      <div class="chat-pane__header-leading">
+        ${props.mergedChrome
+          ? html`<openclaw-tooltip .content=${drawerLabel}>
+              <button
+                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__nav-toggle"
+                type="button"
+                aria-label=${drawerLabel}
+                aria-expanded=${String(Boolean(props.navDrawerOpen))}
+                @click=${(event: MouseEvent) => {
+                  window.dispatchEvent(
+                    new CustomEvent<ShellNavDrawerToggleDetail>(SHELL_NAV_DRAWER_TOGGLE_EVENT, {
+                      detail: { trigger: event.currentTarget as HTMLElement },
+                    }),
+                  );
+                }}
+              >
+                ${icons.menu}
+              </button>
+            </openclaw-tooltip>`
+          : nothing}
+        ${props.session?.incognito
+          ? html`<span
+              class="chat-pane__incognito"
+              role="img"
+              aria-label=${t("chat.sessionHeader.incognito")}
+              title=${t("chat.sessionHeader.incognito")}
+              >${icons.lock}</span
+            >`
+          : nothing}
+        ${renderIdentityCrumbs(props, copied, copyPathLabel, copyBranchLabel)}
+        ${renderStandalonePersonLink(
+          renderSessionOwnerChip(
+            props.showOwnerChip ? props.session?.owner?.actor : undefined,
+            "header",
+            props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
+            props.ownerViewing,
+          ),
+          props.showOwnerChip
+            ? personActivityLink(
+                props.session?.owner?.actor.identity?.type === "profile"
+                  ? props.session.owner.actor.identity.id
+                  : undefined,
+                props.personActivity,
+              )
+            : null,
+        )}
+        ${props.showOwnerChip && props.session?.participants?.length
+          ? html`<openclaw-viewer-facepile
+              class="chat-pane__participants"
+              .staticParticipants=${props.session.participants}
+              .totalCount=${props.session.participantCount}
+              .maxVisible=${4}
+              .personActivity=${props.personActivity}
+              variant="session"
+            ></openclaw-viewer-facepile>`
+          : nothing}
+        ${props.placementControl ?? nothing} ${props.presence ?? nothing}
+      </div>
+      ${hasFaceControl
+        ? html`<div class="chat-pane__header-center">${props.faceControl}</div>`
         : nothing}
-      ${props.session?.incognito
-        ? html`<span
-            class="chat-pane__incognito"
-            role="img"
-            aria-label=${t("chat.sessionHeader.incognito")}
-            title=${t("chat.sessionHeader.incognito")}
-            >${icons.lock}</span
-          >`
-        : nothing}
-      ${renderIdentityCrumbs(props, copied, copyPathLabel, copyBranchLabel)}
-      ${renderStandalonePersonLink(
-        renderSessionOwnerChip(
-          props.showOwnerChip ? props.session?.owner?.actor : undefined,
-          "header",
-          props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
-          props.ownerViewing,
-        ),
-        props.showOwnerChip
-          ? personActivityLink(
-              props.session?.owner?.actor.identity?.type === "profile"
-                ? props.session.owner.actor.identity.id
-                : undefined,
-              props.personActivity,
-            )
-          : null,
-      )}
-      ${props.showOwnerChip && props.session?.participants?.length
-        ? html`<openclaw-viewer-facepile
-            class="chat-pane__participants"
-            .staticParticipants=${props.session.participants}
-            .totalCount=${props.session.participantCount}
-            .maxVisible=${4}
-            .personActivity=${props.personActivity}
-            variant="session"
-          ></openclaw-viewer-facepile>`
-        : nothing}
-      ${props.placementControl ?? nothing} ${props.presence ?? nothing}
-      ${props.faceControl ?? nothing} ${props.sharingControl ?? nothing}
-      ${!props.catalog && props.branches.length > 1
-        ? html`
-            <wa-dropdown
-              class="chat-pane__branches-menu"
-              placement="bottom-end"
-              @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-                const leafEntryId = event.detail.item.value;
-                const branch = props.branches.find(
-                  (candidate) => candidate.leafEntryId === leafEntryId,
-                );
-                if (leafEntryId && branch && !branch.active && !props.branchSwitchDisabledReason) {
-                  props.onBranchSelect(leafEntryId);
-                }
-              }}
-            >
-              <button
-                slot="trigger"
-                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__branches-trigger"
-                type="button"
-                ?disabled=${Boolean(props.branchSwitchDisabledReason)}
-                title=${props.branchSwitchDisabledReason ?? t("chat.sessionHeader.branches")}
-                aria-label=${t("chat.sessionHeader.branches")}
+      <div class="chat-pane__header-trailing">
+        ${props.sharingControl ?? nothing}
+        ${!props.catalog && props.branches.length > 1
+          ? html`
+              <wa-dropdown
+                class="chat-pane__branches-menu"
+                placement="bottom-end"
+                @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+                  const leafEntryId = event.detail.item.value;
+                  const branch = props.branches.find(
+                    (candidate) => candidate.leafEntryId === leafEntryId,
+                  );
+                  if (
+                    leafEntryId &&
+                    branch &&
+                    !branch.active &&
+                    !props.branchSwitchDisabledReason
+                  ) {
+                    props.onBranchSelect(leafEntryId);
+                  }
+                }}
               >
-                ${icons.gitBranch}
-              </button>
-              ${props.branches.map((branch) => {
-                const relativeTime = branchRelativeTime(branch.updatedAt);
-                return html`
-                  <wa-dropdown-item
-                    class="chat-pane__branch-item"
-                    value=${branch.leafEntryId}
-                    ?disabled=${branch.active || Boolean(props.branchSwitchDisabledReason)}
-                    data-active=${branch.active ? "true" : "false"}
-                  >
-                    <span class="chat-pane__branch-copy">
-                      <span class="chat-pane__branch-headline"
-                        >${branch.headline || t("chat.sessionHeader.untitledBranch")}</span
-                      >
-                      <span class="chat-pane__branch-meta"
-                        >${t(
-                          branch.messageCount === 1
-                            ? "chat.sessionHeader.oneMessage"
-                            : "chat.sessionHeader.messages",
-                          { count: String(branch.messageCount) },
-                        )}${relativeTime ? ` · ${relativeTime}` : ""}</span
-                      >
-                    </span>
-                    ${branch.active
-                      ? html`<span
-                          class="chat-pane__branch-active"
-                          aria-label=${t("chat.sessionHeader.activeBranch")}
-                          >${icons.check}</span
-                        >`
-                      : nothing}
-                  </wa-dropdown-item>
-                `;
-              })}
-            </wa-dropdown>
-          `
-        : nothing}
-      ${renderGatewayPicker(props)}
-      <div class="chat-pane__actions">
-        ${compactSessionActions ? nothing : props.panelActions}
-        ${compactSessionActions ? nothing : props.discussionAction}
-        ${props.catalog || compactSessionActions
-          ? nothing
-          : html`${props.diffAction} ${props.backgroundTasksAction} ${props.workspaceAction}
-            ${props.sessionRailAction}`}
-        ${props.onOpenSplitView && !compactSessionActions
-          ? html`<openclaw-tooltip .content=${t("chat.splitView.open")}>
-              <button
-                class="btn btn--ghost btn--icon chat-icon-btn chat-open-split-view"
-                type="button"
-                aria-label=${t("chat.splitView.open")}
-                @click=${props.onOpenSplitView}
-              >
-                ${icons.columns2}
-              </button>
-            </openclaw-tooltip>`
+                <button
+                  slot="trigger"
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__branches-trigger"
+                  type="button"
+                  ?disabled=${Boolean(props.branchSwitchDisabledReason)}
+                  title=${props.branchSwitchDisabledReason ?? t("chat.sessionHeader.branches")}
+                  aria-label=${t("chat.sessionHeader.branches")}
+                >
+                  ${icons.gitBranch}
+                </button>
+                ${props.branches.map((branch) => {
+                  const relativeTime = branchRelativeTime(branch.updatedAt);
+                  return html`
+                    <wa-dropdown-item
+                      class="chat-pane__branch-item"
+                      value=${branch.leafEntryId}
+                      ?disabled=${branch.active || Boolean(props.branchSwitchDisabledReason)}
+                      data-active=${branch.active ? "true" : "false"}
+                    >
+                      <span class="chat-pane__branch-copy">
+                        <span class="chat-pane__branch-headline"
+                          >${branch.headline || t("chat.sessionHeader.untitledBranch")}</span
+                        >
+                        <span class="chat-pane__branch-meta"
+                          >${t(
+                            branch.messageCount === 1
+                              ? "chat.sessionHeader.oneMessage"
+                              : "chat.sessionHeader.messages",
+                            { count: String(branch.messageCount) },
+                          )}${relativeTime ? ` · ${relativeTime}` : ""}</span
+                        >
+                      </span>
+                      ${branch.active
+                        ? html`<span
+                            class="chat-pane__branch-active"
+                            aria-label=${t("chat.sessionHeader.activeBranch")}
+                            >${icons.check}</span
+                          >`
+                        : nothing}
+                    </wa-dropdown-item>
+                  `;
+                })}
+              </wa-dropdown>
+            `
           : nothing}
-        ${!props.narrow && props.onSplitDown
-          ? html`<openclaw-tooltip .content=${t("chat.splitView.splitDown")}>
-              <button
-                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down"
-                type="button"
-                aria-label=${t("chat.splitView.splitDown")}
-                @click=${() => props.onSplitDown?.(props.paneId)}
-              >
-                ${icons.panelBottomOpen}
-              </button>
-            </openclaw-tooltip>`
-          : nothing}
-        ${!props.narrow && props.onSplitRight
-          ? html`<openclaw-tooltip .content=${t("chat.splitView.splitRight")}>
-              <button
-                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-right"
-                type="button"
-                aria-label=${t("chat.splitView.splitRight")}
-                @click=${() => props.onSplitRight?.(props.paneId)}
-              >
-                ${icons.panelRightOpen}
-              </button>
-            </openclaw-tooltip>`
-          : nothing}
-        ${props.onClosePane
-          ? html`<openclaw-tooltip .content=${t("chat.splitView.closePane")}>
-              <button
-                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane"
-                type="button"
-                aria-label=${t("chat.splitView.closePane")}
-                @click=${() => props.onClosePane?.(props.paneId)}
-              >
-                ${icons.x}
-              </button>
-            </openclaw-tooltip>`
-          : nothing}
-        ${props.mergedChrome && !compactSessionActions
-          ? html`<openclaw-tooltip .content=${t("chat.openCommandPalette")}>
-              <button
-                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__palette-open"
-                type="button"
-                aria-label=${t("chat.openCommandPalette")}
-                @click=${() => window.dispatchEvent(new Event(COMMAND_PALETTE_OPEN_EVENT))}
-              >
-                ${icons.search}
-              </button>
-            </openclaw-tooltip>`
-          : nothing}
-        ${props.sessionMenuAction}
+        ${renderGatewayPicker(props)}
+        <div class="chat-pane__actions">
+          ${compactSessionActions ? nothing : props.panelActions}
+          ${compactSessionActions ? nothing : props.discussionAction}
+          ${props.catalog || compactSessionActions
+            ? nothing
+            : html`${props.diffAction} ${props.backgroundTasksAction} ${props.workspaceAction}
+              ${props.sessionRailAction}`}
+          ${props.onOpenSplitView && !compactSessionActions
+            ? html`<openclaw-tooltip .content=${t("chat.splitView.open")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-open-split-view"
+                  type="button"
+                  aria-label=${t("chat.splitView.open")}
+                  @click=${props.onOpenSplitView}
+                >
+                  ${icons.columns2}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${!props.narrow && props.onSplitDown
+            ? html`<openclaw-tooltip .content=${t("chat.splitView.splitDown")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down"
+                  type="button"
+                  aria-label=${t("chat.splitView.splitDown")}
+                  @click=${() => props.onSplitDown?.(props.paneId)}
+                >
+                  ${icons.panelBottomOpen}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${!props.narrow && props.onSplitRight
+            ? html`<openclaw-tooltip .content=${t("chat.splitView.splitRight")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-right"
+                  type="button"
+                  aria-label=${t("chat.splitView.splitRight")}
+                  @click=${() => props.onSplitRight?.(props.paneId)}
+                >
+                  ${icons.panelRightOpen}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${props.onClosePane
+            ? html`<openclaw-tooltip .content=${t("chat.splitView.closePane")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane"
+                  type="button"
+                  aria-label=${t("chat.splitView.closePane")}
+                  @click=${() => props.onClosePane?.(props.paneId)}
+                >
+                  ${icons.x}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${props.mergedChrome && !compactSessionActions
+            ? html`<openclaw-tooltip .content=${t("chat.openCommandPalette")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__palette-open"
+                  type="button"
+                  aria-label=${t("chat.openCommandPalette")}
+                  @click=${() => window.dispatchEvent(new Event(COMMAND_PALETTE_OPEN_EVENT))}
+                >
+                  ${icons.search}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${props.sessionMenuAction}
+        </div>
       </div>
     </div>
   `;

--- a/ui/src/styles/chat/board.css
+++ b/ui/src/styles/chat/board.css
@@ -2,7 +2,6 @@
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  margin-left: auto;
   border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
 }
@@ -25,10 +24,6 @@
 
 .chat-pane__face-switch .settings-segmented__btn--active {
   background: var(--panel);
-}
-
-.chat-pane__face-switch + .chat-pane__actions {
-  margin-left: 0;
 }
 
 .chat-pane__dock-caret {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -179,6 +179,39 @@ openclaw-chat-pane {
   -webkit-user-select: none;
 }
 
+.chat-pane__header--centered {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+}
+
+.chat-pane__header-leading,
+.chat-pane__header-center,
+.chat-pane__header-trailing {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+}
+
+.chat-pane__header-leading,
+.chat-pane__header-trailing {
+  gap: 8px;
+}
+
+/* Equal outer tracks keep the face switch on the pane centerline even when
+   either chrome cluster grows; the identity trail owns the shrinkable text. */
+.chat-pane__header-center {
+  justify-self: center;
+}
+
+.chat-pane__header-trailing {
+  margin-left: auto;
+  justify-self: end;
+}
+
+.chat-pane__header--centered .chat-pane__header-trailing {
+  margin-left: 0;
+}
+
 /* Identity trail: project, then session. One flex row owns the alignment of
    every segment, so the 26px project chip and the 12px text segments centre on
    a single line and a future parent-session segment inherits it for free. */


### PR DESCRIPTION
## What Problem This Solves

The Chat / Split / Dashboard selector followed the width of the session identity trail, so long workspace and session names pushed it away from the horizontal center of the chat navbar.

## Why This Change Was Made

The chat header now has explicit leading, centered, and trailing ownership regions. Equal flexible outer tracks keep the face selector centered while the leading identity trail yields and ellipsizes. Headers without a face selector keep the existing full-width flex layout.

The canonical owner is the chat-pane header layout (`chat-pane-header.ts` + `split-view.css`); no downstream positioning workaround or new dependency is introduced.

## User Impact

- Chat / Split / Dashboard stays centered at every title length.
- Long left-hand text truncates before it can displace the selector.
- Non-board chat headers retain their existing layout.

## Evidence

- Chromium geometry regression asserts a zero-pixel center delta and title overflow at a narrow width.
- Header structure tests cover centered and no-face layouts.
- Focused suite and repository changed-file checks pass on the complete stack.
- Production/test LOC: raw production `+226/-183`, tests `+142/-0`; most production churn is template indentation around the new three-region grouping. Net production `+43` establishes the header ownership boundary and center geometry.

Visual proof is attached in a PR comment.
