### PR TITLE
feat(ui): add icons to chat face switch

### DIFF
--- a/ui/src/pages/chat/board-session-surface.test.ts
+++ b/ui/src/pages/chat/board-session-surface.test.ts
@@ -127,6 +127,34 @@ describe("board session shell", () => {
     ).toBe(activeMode);
   });
 
+  it("renders an icon-only control with an accessible label for every mode", () => {
+    const container = createContainer();
+    render(
+      renderBoardViewSwitch({
+        hasBoard: true,
+        face: "chat",
+        dock: "right",
+        canChangeDock: true,
+        onSelectMode: () => {},
+        onDockSideChange: () => {},
+      }),
+      container,
+    );
+
+    const radios = [...container.querySelectorAll("wa-radio")];
+    expect(radios.map((radio) => radio.querySelector(".sr-only")?.textContent)).toEqual([
+      "Chat",
+      "Split",
+      "Dashboard",
+    ]);
+    expect(radios.every((radio) => radio.querySelector("svg") !== null)).toBe(true);
+    expect(radios.map((radio) => radio.getAttribute("title"))).toEqual([
+      "Chat",
+      "Split",
+      "Dashboard",
+    ]);
+  });
+
   it("falls back to the two face options when dock changes are unavailable", () => {
     const container = createContainer();
     render(

--- a/ui/src/pages/chat/board-session-surface.ts
+++ b/ui/src/pages/chat/board-session-surface.ts
@@ -67,6 +67,10 @@ function dockLabel(dock: BoardVisibleChatDock): string {
   return t("chat.board.dockRight");
 }
 
+function modeLabel(icon: TemplateResult, label: string) {
+  return html`${icon}<span class="sr-only">${label}</span>`;
+}
+
 export function renderBoardViewSwitch(props: {
   hasBoard: boolean;
   face: BoardFace;
@@ -87,9 +91,21 @@ export function renderBoardViewSwitch(props: {
         value: mode,
         ariaLabel: t("chat.board.faceLabel"),
         options: [
-          { value: "chat", label: t("chat.board.chatFace") },
-          { value: "split", label: t("chat.board.splitFace") },
-          { value: "dashboard", label: t("chat.board.dashboardFace") },
+          {
+            value: "chat",
+            label: modeLabel(icons.messageSquare, t("chat.board.chatFace")),
+            title: t("chat.board.chatFace"),
+          },
+          {
+            value: "split",
+            label: modeLabel(icons.columns2, t("chat.board.splitFace")),
+            title: t("chat.board.splitFace"),
+          },
+          {
+            value: "dashboard",
+            label: modeLabel(icons.layoutDashboard, t("chat.board.dashboardFace")),
+            title: t("chat.board.dashboardFace"),
+          },
         ],
         onChange: (value) => props.onSelectMode(value),
       })
@@ -97,8 +113,16 @@ export function renderBoardViewSwitch(props: {
         value: props.face,
         ariaLabel: t("chat.board.faceLabel"),
         options: [
-          { value: "chat", label: t("chat.board.chatFace") },
-          { value: "dashboard", label: t("chat.board.dashboardFace") },
+          {
+            value: "chat",
+            label: modeLabel(icons.messageSquare, t("chat.board.chatFace")),
+            title: t("chat.board.chatFace"),
+          },
+          {
+            value: "dashboard",
+            label: modeLabel(icons.layoutDashboard, t("chat.board.dashboardFace")),
+            title: t("chat.board.dashboardFace"),
+          },
         ],
         onChange: (value) => props.onSelectMode(value),
       });

--- a/ui/src/styles/chat/board.css
+++ b/ui/src/styles/chat/board.css
@@ -22,6 +22,11 @@
   border-radius: var(--radius-full);
 }
 
+.chat-pane__face-switch .settings-segmented__btn svg {
+  width: 15px;
+  height: 15px;
+}
+
 .chat-pane__face-switch .settings-segmented__btn--active {
   background: var(--panel);
 }


### PR DESCRIPTION
## What Problem This Solves

The centered Chat / Split / Dashboard selector remained text-heavy and wider than necessary.

## Why This Change Was Made

Each existing radio option now renders the repository's shared message, columns, or dashboard icon. Screen-reader labels and titles preserve the full mode names, so the compact presentation does not weaken the control's accessible contract.

## User Impact

- The three modes are compact, familiar icon buttons.
- Keyboard and screen-reader users retain the same named radio choices.

## Evidence

- Unit coverage verifies the three glyphs, titles, accessible names, and radio semantics.
- Focused suite and repository changed-file checks pass on the complete stack.
- Production/test LOC: production `+34/-5` (net `+29`), tests `+28/-0`; growth is the explicit icon/accessible-label mapping and sizing.

Visual proof is attached in a PR comment.
