### PR TITLE
feat(ui): embed visibility in face switch

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1261,6 +1261,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                   <button class="settings-segmented__btn" type="button">Dashboard</button>
                 </div>
               </div>
+              <wa-dropdown class="chat-pane__sharing-menu">
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__sharing-trigger" type="button">S</button>
+              </wa-dropdown>
             </div>
             <div class="chat-pane__header-trailing">
               <div class="chat-pane__actions">
@@ -1277,8 +1280,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         const headerElement = header as HTMLElement;
         const style = getComputedStyle(headerElement);
         const rect = headerElement.getBoundingClientRect();
-        const centerRect = headerElement
-          .querySelector<HTMLElement>(".chat-pane__header-center")!
+        const faceRect = headerElement
+          .querySelector<HTMLElement>(".chat-pane__face-switch")!
           .getBoundingClientRect();
         const title = headerElement.querySelector<HTMLElement>(".chat-pane__session-title-text")!;
         const contentWidth =
@@ -1287,7 +1290,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           Number.parseFloat(style.paddingRight);
         return {
           contentCenter: rect.left + Number.parseFloat(style.paddingLeft) + contentWidth / 2,
-          faceCenter: centerRect.left + centerRect.width / 2,
+          faceCenter: faceRect.left + faceRect.width / 2,
           titleClientWidth: title.clientWidth,
           titleScrollWidth: title.scrollWidth,
         };
@@ -1295,6 +1298,59 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
 
       expect(Math.abs(geometry.faceCenter - geometry.contentCenter)).toBeLessThanOrEqual(0.5);
       expect(geometry.titleScrollWidth).toBeGreaterThan(geometry.titleClientWidth);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it("keeps a non-manager draft indicator out of the face switch width", async () => {
+    const page = await openBrowserPage(800, 180);
+    try {
+      const splitViewCss = readStyleSheet("ui/src/styles/chat/split-view.css");
+      const boardCss = readStyleSheet("ui/src/styles/chat/board.css");
+      const settingsControlsCss = readStyleSheet("ui/src/styles/settings-controls.css");
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}\n${settingsControlsCss}\n${splitViewCss}\n${boardCss}</style></head><body>
+          <div class="chat-pane__header chat-pane__header--centered" style="width: 720px;">
+            <div class="chat-pane__header-leading"></div>
+            <div class="chat-pane__header-center">
+              <div class="chat-pane__face-switch">
+                <div class="settings-segmented">
+                  <button class="settings-segmented__btn" type="button">Chat</button>
+                  <button class="settings-segmented__btn settings-segmented__btn--active" type="button">Split</button>
+                  <button class="settings-segmented__btn" type="button">Dashboard</button>
+                </div>
+              </div>
+              <span class="chat-pane__draft-indicator" title="Draft">👻</span>
+            </div>
+            <div class="chat-pane__header-trailing"></div>
+          </div>
+        </body></html>`,
+      );
+
+      const geometry = await page.locator(".chat-pane__header").evaluate((header) => {
+        const headerElement = header as HTMLElement;
+        const style = getComputedStyle(headerElement);
+        const headerRect = headerElement.getBoundingClientRect();
+        const faceRect = headerElement
+          .querySelector<HTMLElement>(".chat-pane__face-switch")!
+          .getBoundingClientRect();
+        const draftStyle = getComputedStyle(
+          headerElement.querySelector<HTMLElement>(".chat-pane__draft-indicator")!,
+        );
+        const contentWidth =
+          headerElement.clientWidth -
+          Number.parseFloat(style.paddingLeft) -
+          Number.parseFloat(style.paddingRight);
+        return {
+          contentCenter: headerRect.left + Number.parseFloat(style.paddingLeft) + contentWidth / 2,
+          draftPosition: draftStyle.position,
+          faceCenter: faceRect.left + faceRect.width / 2,
+        };
+      });
+
+      expect(geometry.draftPosition).toBe("absolute");
+      expect(Math.abs(geometry.faceCenter - geometry.contentCenter)).toBeLessThanOrEqual(0.5);
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -1,4 +1,4 @@
-import { html, render } from "lit";
+import { html, nothing, render } from "lit";
 /* @vitest-environment jsdom */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../../api/gateway.ts";
@@ -405,7 +405,7 @@ describe("chat pane header", () => {
     expect(crumbs?.nextElementSibling?.getAttribute("data-slot")).toBe("placement");
   });
 
-  it("separates identity, face, and action controls into balanced header regions", () => {
+  it("groups visibility with the face switch inside the centered header region", () => {
     const { container } = mountHeader({
       placementControl: html`<span data-slot="placement"></span>`,
       presence: html`<span data-slot="presence"></span>`,
@@ -420,9 +420,20 @@ describe("chat pane header", () => {
       "chat-pane__header-center",
     );
     expect(container.querySelector('[data-slot="sharing"]')?.parentElement?.className).toBe(
+      "chat-pane__header-center",
+    );
+  });
+
+  it("keeps visibility with trailing actions when the session has no face switch", () => {
+    const { container } = mountHeader({
+      faceControl: nothing,
+      sharingControl: html`<span data-slot="sharing"></span>`,
+    });
+
+    expect(container.querySelector('[data-slot="sharing"]')?.parentElement?.className).toBe(
       "chat-pane__header-trailing",
     );
-    expect(container.querySelector(".chat-pane__header--centered")).not.toBeNull();
+    expect(container.querySelector(".chat-pane__header--centered")).toBeNull();
   });
 
   it("uses the full header width when no face switch needs centering", () => {

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -450,10 +450,12 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
         ${props.placementControl ?? nothing} ${props.presence ?? nothing}
       </div>
       ${hasFaceControl
-        ? html`<div class="chat-pane__header-center">${props.faceControl}</div>`
+        ? html`<div class="chat-pane__header-center">
+            ${props.faceControl} ${props.sharingControl ?? nothing}
+          </div>`
         : nothing}
       <div class="chat-pane__header-trailing">
-        ${props.sharingControl ?? nothing}
+        ${hasFaceControl ? nothing : (props.sharingControl ?? nothing)}
         ${!props.catalog && props.branches.length > 1
           ? html`
               <wa-dropdown

--- a/ui/src/styles/chat/board.css
+++ b/ui/src/styles/chat/board.css
@@ -3,7 +3,7 @@
   flex: 0 0 auto;
   align-items: center;
   border-radius: var(--radius-full);
-  background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
+  background: transparent;
 }
 
 .chat-pane__face-switch .settings-segmented {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -200,7 +200,13 @@ openclaw-chat-pane {
 /* Equal outer tracks keep the face switch on the pane centerline even when
    either chrome cluster grows; the identity trail owns the shrinkable text. */
 .chat-pane__header-center {
+  position: relative;
   justify-self: center;
+}
+
+.chat-pane__header-center:has(.chat-pane__face-switch) {
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
 }
 
 .chat-pane__header-trailing {
@@ -707,6 +713,26 @@ openclaw-chat-pane {
   flex: 0 0 auto;
 }
 
+.chat-pane__header-center .chat-pane__sharing-menu,
+.chat-pane__header-center .chat-pane__draft-indicator {
+  position: absolute;
+  inset-block-start: 50%;
+  inset-inline-start: 100%;
+  display: inline-flex;
+  transform: translateY(-50%);
+}
+
+.chat-pane__header-center .chat-pane__sharing-trigger {
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
+  padding: 0;
+  border-left: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  border-radius: 0 var(--radius-full) var(--radius-full) 0;
+  background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
+}
+
 .chat-pane__sharing-menu::part(menu) {
   width: 260px;
   min-width: min(260px, calc(100vw - 24px));
@@ -776,6 +802,16 @@ openclaw-chat-pane {
 
 .chat-pane__draft-indicator {
   font-size: 13px;
+}
+
+.chat-pane__header-center .chat-pane__draft-indicator {
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-left: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  border-radius: 0 var(--radius-full) var(--radius-full) 0;
+  background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
 }
 
 /* A full split header measures 793px including insets, so secondary controls


### PR DESCRIPTION
## What Problem This Solves

The visibility control sat apart from the Chat / Split / Dashboard selector even though both controls describe the current session view.

## Why This Change Was Made

When the face selector exists, the icon-only visibility trigger is rendered as an attached control in the centered region. It is absolutely anchored to the selector boundary so its width cannot shift the selector itself. Sessions without a face selector keep visibility with the trailing actions.

Independent review caught both centering edge cases before publication. The regression proof now measures the selector itself, explicitly covers the no-face layout, and verifies that the non-manager draft indicator stays out of the centered track.

## User Impact

- Visibility is available inside the tabbed navbar area as an icon-only button.
- The three-mode selector remains exactly centered.
- The current visibility icon and accessible label continue to update with session state.

## Evidence

- Chromium geometry regressions cover both attached sharing states and assert a zero-pixel selector-center delta.
- Header unit tests cover attached and trailing visibility placements.
- Focused suite and repository changed-file checks pass on the complete stack.
- Production/test LOC: production `+41/-3` (net `+38`), tests `+73/-6`; growth owns and proves the attached-control geometry at the header boundary.

Visual proof is attached in a PR comment.
