### PR TITLE
feat(ui): standardize visibility menu options

### DIFF
--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -71,6 +71,54 @@ describe("chat session sharing menu", () => {
     expect(onMemberChange).toHaveBeenCalledWith("alice", true);
   });
 
+  it("renders standard radio options with visibility icons and one selected checkmark", () => {
+    const root = mount(
+      renderChatSessionSharing({
+        session: {
+          key: "agent:main:main",
+          kind: "direct",
+          updatedAt: 1,
+          visibility: "read-only",
+          sharingRole: "owner",
+        },
+        state: {
+          loading: false,
+          result: {
+            sessionKey: "agent:main:main",
+            members: [],
+            identities: [],
+            role: "owner",
+            allowedVisibilities: ["shared", "read-only", "suggest", "draft"],
+          },
+        },
+        onOpen: vi.fn(),
+        onVisibilityChange: vi.fn(),
+        onMemberChange: vi.fn(),
+      }),
+    );
+
+    const items = [...root.querySelectorAll<HTMLElement>(".chat-pane__sharing-visibility-item")];
+    expect(items).toHaveLength(4);
+    expect(items.every((item) => item.querySelector('[slot="icon"]') !== null)).toBe(true);
+    expect(items.map((item) => item.getAttribute("role"))).toEqual(
+      items.map(() => "menuitemradio"),
+    );
+    expect(items.map((item) => item.getAttribute("aria-checked"))).toEqual([
+      "false",
+      "true",
+      "false",
+      "false",
+    ]);
+    const selected = root.querySelector<HTMLElement>(
+      'wa-dropdown-item[value="visibility:read-only"]',
+    );
+    expect(selected?.hasAttribute("disabled")).toBe(false);
+    expect(selected?.querySelector(".session-menu__check svg")).not.toBeNull();
+    expect(
+      root.querySelectorAll(".chat-pane__sharing-visibility-item .session-menu__check"),
+    ).toHaveLength(1);
+  });
+
   it("renders member presentation from identity.type, not from ID spelling", () => {
     const root = mount(
       renderChatSessionSharing({

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import { ref } from "lit/directives/ref.js";
 import type {
   GatewaySessionRow,
   SessionMembersListEvidenceResult,
@@ -6,7 +7,7 @@ import type {
 } from "../../../api/types.ts";
 import { icons } from "../../../components/icons.ts";
 import { renderSessionOwnerChip } from "../../../components/session-owner-chip.ts";
-import "../../../components/web-awesome.ts";
+import { syncDropdownItemRadio } from "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
 
 export type ChatSessionSharingState = {
@@ -49,8 +50,9 @@ export function selectChatSessionSharingItem(
 ): void {
   const members = new Set(props.state?.result?.members.map((member) => member.identityId) ?? []);
   if (value?.startsWith("visibility:")) {
-    if (!props.visibilityDisabledReason) {
-      props.onVisibilityChange(value.slice("visibility:".length) as SessionVisibility);
+    const visibility = value.slice("visibility:".length) as SessionVisibility;
+    if (!props.visibilityDisabledReason && visibility !== (props.session?.visibility ?? "shared")) {
+      props.onVisibilityChange(visibility);
     }
     return;
   }
@@ -112,21 +114,30 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
     <div class="chat-pane__sharing-title chat-pane__sharing-visibility-title">
       ${t("chat.sessionSharing.visibility")}
     </div>
-    ${visibilityOptions.map(
-      (option) => html`
+    ${visibilityOptions.map((option) => {
+      const checked = option === visibility;
+      return html`
         <wa-dropdown-item
           class="session-menu__item chat-pane__sharing-visibility-item"
           value=${`visibility:${option}`}
-          ?disabled=${option === visibility || Boolean(props.visibilityDisabledReason)}
+          role="menuitemradio"
+          aria-checked=${String(checked)}
+          ${ref((element) => syncDropdownItemRadio(element, checked))}
+          ?disabled=${Boolean(props.visibilityDisabledReason)}
           title=${props.visibilityDisabledReason ?? nothing}
         >
+          <span slot="icon" class="session-menu__icon" aria-hidden="true"
+            >${sharingIcon(option)}</span
+          >
           <span class="session-menu__text">${t(VISIBILITY_LABEL_KEYS[option])}</span>
-          ${option === visibility
-            ? html`<span slot="details" aria-hidden="true">${icons.check}</span>`
+          ${checked
+            ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
+                >${icons.check}</span
+              >`
             : nothing}
         </wa-dropdown-item>
-      `,
-    )}
+      `;
+    })}
     ${membersAvailable
       ? html`
           <div class="chat-pane__sharing-title chat-pane__sharing-members-title">

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -760,11 +760,6 @@ openclaw-chat-pane {
   padding: 6px 12px;
 }
 
-.chat-pane__sharing-visibility-item[disabled] {
-  opacity: 1;
-  color: var(--muted);
-}
-
 .chat-pane__sharing-members-title {
   margin-top: 8px;
 }


### PR DESCRIPTION
## What Problem This Solves

Visibility choices were plain text, and the current choice was represented as a greyed-out disabled row rather than a standard selected option.

## Why This Change Was Made

The menu now uses the existing visibility glyph mapping, the shared Web Awesome radio adapter, and the standard trailing checkmark pattern. The selected option remains a normal enabled menu item; only policy-forbidden options are disabled.

Direct dependency inspection confirmed that `wa-dropdown-item` exposes normal/checkbox variants and icon/details slots, so the repository's established `syncDropdownItemRadio` adapter remains the canonical radio semantic.

## User Impact

- Every visibility choice has the same icon used by the trigger.
- The current choice is a normal row with a checkmark.
- Policy-disabled choices remain visibly and functionally disabled.

## Evidence

- Unit coverage verifies icons, `menuitemradio`, `aria-checked`, one checkmark, and non-disabled selection.
- Bundled Control UI proof exercises the actual dropdown with mock Gateway state.
- Focused suite and repository changed-file checks pass on the complete stack.
- Production/test LOC: production `+21/-15` (net `+6`), tests `+48/-0`; the old grey selected-state styling is removed.

Visual proof is attached in a PR comment.
