### PR TITLE
feat(ui): skeletonize sharing member loading

### DIFF
--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -171,6 +171,32 @@ describe("chat session sharing menu", () => {
     }
   });
 
+  it("shows shape-matched member skeletons while identities load", () => {
+    const root = mount(
+      renderChatSessionSharing({
+        session: {
+          key: "agent:main:main",
+          kind: "direct",
+          updatedAt: 1,
+          visibility: "shared",
+          sharingRole: "owner",
+        },
+        state: { loading: true },
+        allowedVisibilities: ["shared", "read-only"],
+        onOpen: vi.fn(),
+        onVisibilityChange: vi.fn(),
+        onMemberChange: vi.fn(),
+      }),
+    );
+
+    const loading = root.querySelector(".chat-pane__sharing-members-loading");
+    expect(loading?.getAttribute("role")).toBe("status");
+    expect(loading?.getAttribute("aria-busy")).toBe("true");
+    expect(loading?.textContent?.trim()).toBe("");
+    expect(root.querySelectorAll(".chat-pane__sharing-member-skeleton")).toHaveLength(3);
+    expect(root.querySelectorAll(".chat-pane__sharing-member-skeleton .skeleton")).toHaveLength(6);
+  });
+
   it("shows only the draft marker to a non-manager", () => {
     const root = mount(
       renderChatSessionSharing({

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -44,6 +44,27 @@ function sharingIcon(visibility: SessionVisibility): TemplateResult {
   return visibility === "shared" ? icons.users : icons.lock;
 }
 
+function renderMemberSkeletons() {
+  return html`
+    <div
+      class="chat-pane__sharing-members-loading"
+      role="status"
+      aria-busy="true"
+      aria-label=${t("common.loading")}
+    >
+      ${Array.from(
+        { length: 3 },
+        () => html`
+          <div class="chat-pane__sharing-member-skeleton" aria-hidden="true">
+            <span class="skeleton chat-pane__sharing-member-skeleton-icon"></span>
+            <span class="skeleton chat-pane__sharing-member-skeleton-label"></span>
+          </div>
+        `,
+      )}
+    </div>
+  `;
+}
+
 export function selectChatSessionSharingItem(
   props: ChatSessionSharingProps,
   value: string | undefined,
@@ -144,7 +165,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
             ${t("chat.sessionSharing.members")}
           </div>
           ${props.state?.loading
-            ? html`<div class="chat-pane__sharing-status">${t("common.loading")}</div>`
+            ? renderMemberSkeletons()
             : identities.length > 0
               ? identities.map((identity) => {
                   const disabledReason = members.has(identity.id)

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -764,6 +764,34 @@ openclaw-chat-pane {
   margin-top: 8px;
 }
 
+.chat-pane__sharing-member-skeleton {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  min-height: 36px;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+}
+
+.chat-pane__sharing-member-skeleton-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+}
+
+.chat-pane__sharing-member-skeleton-label {
+  width: 72%;
+  height: 10px;
+}
+
+.chat-pane__sharing-member-skeleton:nth-child(2) .chat-pane__sharing-member-skeleton-label {
+  width: 56%;
+}
+
+.chat-pane__sharing-member-skeleton:nth-child(3) .chat-pane__sharing-member-skeleton-label {
+  width: 64%;
+}
+
 .chat-pane__sharing-member {
   gap: 0;
   font-size: 12px;


### PR DESCRIPTION
## What Problem This Solves

Opening the visibility menu while member evidence loaded showed a generic visible “Loading…” line that did not preview the shape of the member list.

## Why This Change Was Made

The loading boundary now renders three member-shaped skeleton rows using the Control UI's existing skeleton primitive: circular avatar placeholders plus bounded name lines. The region retains status/busy semantics and an accessible loading label without visible placeholder copy.

## User Impact

- Member loading is visually stable and matches the content that replaces it.
- Assistive technology still receives an explicit loading state.

## Evidence

- Unit coverage verifies three skeleton rows, avatar/name shapes, busy/status semantics, and no visible loading text.
- Bundled Control UI proof holds the member RPC pending and captures the real dropdown state.
- Focused suite and repository changed-file checks pass on the complete stack.
- Production/test LOC: production `+50/-1` (net `+49`), tests `+26/-0`; growth is the member-row skeleton markup and its reusable shape styling.

Visual proof is attached in a PR comment.
