### PR TITLE
improve: skip unused diagnostics during node selection

### DIFF
--- a/src/shared/node-resolve.ts
+++ b/src/shared/node-resolve.ts
@@ -74,14 +74,13 @@ export function resolveEligibleNodeFromList<TNode extends NodeMatchCandidate>(
   const eligible = nodes.filter(isEligible);
   const trimmed = query?.trim();
   if (trimmed) {
-    const eligibleIds = formatNodeIdList(eligible);
     const lowerTrimmed = trimmed.toLowerCase();
     const exactNode =
       nodes.find((node) => node.nodeId === trimmed) ??
       nodes.find((node) => node.nodeId.toLowerCase() === lowerTrimmed);
     if (exactNode) {
       if (!isEligible(exactNode)) {
-        throw new Error(messages.ineligibleExact(trimmed, eligibleIds));
+        throw new Error(messages.ineligibleExact(trimmed, formatNodeIdList(eligible)));
       }
       return exactNode;
     }
@@ -92,9 +91,12 @@ export function resolveEligibleNodeFromList<TNode extends NodeMatchCandidate>(
         return match;
       }
     } catch (error) {
-      throw new Error(messages.nameResolveFailed(formatErrorMessage(error), eligibleIds), {
-        cause: error,
-      });
+      throw new Error(
+        messages.nameResolveFailed(formatErrorMessage(error), formatNodeIdList(eligible)),
+        {
+          cause: error,
+        },
+      );
     }
     throw new Error(`node not found: ${trimmed}`);
   }


### PR DESCRIPTION
## What Problem This Solves

Node-backed tools prepare a sorted list of eligible node IDs even when selection succeeds and no diagnostic is shown. This adds avoidable work to exact-ID and display-name selection.

## Why This Change Was Made

The shared resolver now formats that list only in the two error branches that use it. Eligibility checks, exact-ID precedence, name matching, returned node identity, error wording and causes stay unchanged. No cache, configuration, dependency or SDK signature changes.

Production: +7/−5 lines (net +2); tests unchanged. The small increase is the formatter wrapping the longer existing error-construction expression. The eager intermediate and its successful-path work are removed.

## User Impact

Same node selection and diagnostics, with less local resolver overhead. These are microsecond-scale savings; no remote-command, Gateway or network latency improvement is claimed.

## Evidence

- The same 56 tests passed before and after across node matching, shared resolution, computer-node resolution and exec-host node phases. The full changed-file check passed.
- Independent source review and managed Codex review through P2 found no actionable defects.
- A fixed native experiment made 6,658 whole resolver calls: 34 finite proof calls and 6,624 timing calls, with 720 measured batch means. It invokes the real export and checks its SDK re-export identity, complete returned objects, callbacks, errors/causes and original stack frames. It does not mock the resolver or time just the formatting helper.
- B0/C0/C1/B1: exact-ID median improved 53.7%/59.8% (0.495/0.721 µs saved); display-name median improved 28.5%/19.1% (1.846/1.294 µs saved).
- All predeclared gates passed. Adverse controls remain: unknown-name errors were 11.2%/3.1% slower (+1.713/+0.487 µs). The protected gate was prospectively both >3% and >1 µs in both orders. Display-name p95 was also 9.7%/14.5% slower. Other one-order regressions and all first/warm/tail values are retained. Kernel maximum RSS changed +0.18%/+0.05%.
- Raw results, source hashes, native process receipts and all unsuccessful campaign experiments remain local. Independent raw-first numerical audit and complete graph readback passed; the semantic oracle and lifecycle checker were reused from independently reviewed code. All native processes closed and source hashes matched. The final retained experiment is 38,998,948 bytes. Selected runtime provenance does not claim an exhaustive toolchain census; Xcode-selected Git was not historically byte-pinned. Exact-head hosted CI remains required before landing.

The existing tests already cover the public selection and diagnostic contracts; no test was added merely to assert that a private formatter is called less often.
