### PR TITLE
fix(codex): avoid stale ancestor binaries during managed startup

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -187,7 +187,6 @@ extensions/codex/src/app-server/event-projector-values.ts	2
 extensions/codex/src/app-server/event-projector.ts	1
 extensions/codex/src/app-server/explicit-skill-input.ts	1
 extensions/codex/src/app-server/image-payload-sanitizer.ts	3
-extensions/codex/src/app-server/managed-binary.ts	2
 extensions/codex/src/app-server/native-config-fence.ts	1
 extensions/codex/src/app-server/native-mcp-app.ts	9
 extensions/codex/src/app-server/native-skill-isolation.ts	1

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -184,8 +184,12 @@ codex app-server --listen stdio://
 ```
 
 This keeps the app-server version tied to the official `codex` plugin instead of
-whichever separate Codex CLI happens to be installed locally. Set
-`appServer.command` only when you intentionally want a different executable.
+whichever separate Codex CLI happens to be installed locally. OpenClaw resolves
+`@openai/codex/bin/codex.js` from the loader-selected plugin root using Node
+package resolution, including npm-hoisted and pnpm-linked dependencies. It does
+not search `.bin` shims or global `PATH` for managed startup. On Windows, Node
+runs the same package entrypoint without requiring a `codex.cmd` shim.
+Set `appServer.command` only when you intentionally want a different executable.
 Ordinary managed turns with the default isolated agent home prefer this pinned
 package even when a macOS desktop bundle is installed. When
 [Computer Use](/plugins/codex-computer-use) is enabled, or when `homeScope` is

--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover attempt startup plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   AgentHarnessPreflightError,
   type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
@@ -32,6 +33,7 @@ import {
   resolveCodexAppServerRuntimeOptions,
   resolveCodexComputerUseConfig,
 } from "./config.js";
+import { setManagedCodexPluginRoot } from "./managed-binary.js";
 import { defaultCodexPluginMetadataCache } from "./plugin-metadata-cache.js";
 import { sandboxExecServerRegistry } from "./sandbox-exec-server-registry.js";
 import { releaseCodexSandboxExecServerEnvironment } from "./sandbox-exec-server.js";
@@ -86,9 +88,7 @@ vi.mock("./computer-use.js", async (importOriginal) => {
 
 const tempRoots = new Set<string>();
 
-const pluginConfig: CodexPluginConfig = {
-  appServer: { command: "codex" },
-};
+const pluginConfig: CodexPluginConfig = { appServer: { command: "codex" } };
 
 function startThreadWithHarness(
   startupTimeoutMs: number,
@@ -206,9 +206,7 @@ async function startIsolatedPairedAttempt(params: {
   return { result, sandbox, environmentId };
 }
 
-function threadStartResult(threadId = "thread-1") {
-  return createThreadStartResult(threadId, "/repo");
-}
+const threadStartResult = (threadId = "thread-1") => createThreadStartResult(threadId, "/repo");
 
 function isProcessAlive(pid: number): boolean {
   try {
@@ -225,6 +223,8 @@ describe("startCodexAttemptThread", () => {
     vi.stubEnv("CODEX_API_KEY", "");
     vi.stubEnv("OPENAI_API_KEY", "");
     clearSharedCodexAppServerClient();
+    // Direct runtime tests supply the plugin root normally owned by loader registration.
+    setManagedCodexPluginRoot(fileURLToPath(new URL("../../", import.meta.url)));
     defaultCodexPluginMetadataCache.clear();
     resetCodexTestBindingStore();
     desktopGeneration.current = undefined;
@@ -234,6 +234,7 @@ describe("startCodexAttemptThread", () => {
   afterEach(async () => {
     vi.useRealTimers();
     clearSharedCodexAppServerClient();
+    setManagedCodexPluginRoot(undefined);
     defaultCodexPluginMetadataCache.clear();
     vi.restoreAllMocks();
     vi.unstubAllEnvs();

--- a/extensions/codex/src/app-server/managed-binary.test.ts
+++ b/extensions/codex/src/app-server/managed-binary.test.ts
@@ -1,9 +1,10 @@
 // Codex tests cover managed binary plugin behavior.
-import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import type { CodexAppServerStartOptions } from "./config.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexAppServerStartOptions } from "./config-contracts.js";
+import { resolveCodexAppServerRuntimeOptions } from "./config-runtime.js";
 import {
   resolveManagedCodexAppServerStartOptions,
   resolveManagedCodexNativeCommand,
@@ -25,8 +26,28 @@ function startOptions(
 }
 
 function managedCommandPath(root: string, platform: NodeJS.Platform): string {
-  const pathApi = platform === "win32" ? path.win32 : path.posix;
-  return pathApi.join(root, "node_modules", ".bin", platform === "win32" ? "codex.cmd" : "codex");
+  return path.join(root, "node_modules", ".bin", platform === "win32" ? "codex.cmd" : "codex");
+}
+
+async function writeExecutable(file: string): Promise<void> {
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, "#!/usr/bin/env node\n");
+  await chmod(file, 0o755);
+}
+
+async function writePackageLauncher(owner: string): Promise<string> {
+  const packageRoot = path.join(owner, "node_modules", "@openai", "codex");
+  const launcher = path.join(packageRoot, "bin", "codex.js");
+  await writeExecutable(launcher);
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({
+      name: "@openai/codex",
+      type: "module",
+      bin: { codex: "bin/codex.js" },
+    }),
+  );
+  return launcher;
 }
 
 const MACOS_DESKTOP_CODEX_APP_SERVER_COMMAND = "/Applications/Codex.app/Contents/Resources/codex";
@@ -34,7 +55,14 @@ const MACOS_DESKTOP_CHATGPT_APP_SERVER_COMMAND =
   "/Applications/ChatGPT.app/Contents/Resources/codex";
 
 describe("managed Codex app-server binary", () => {
-  afterEach(() => setManagedCodexPluginRoot(undefined));
+  let root: string;
+  beforeEach(async () => {
+    root = await realpath(await mkdtemp(path.join(os.tmpdir(), "openclaw-codex-owner-")));
+  });
+  afterEach(async () => {
+    setManagedCodexPluginRoot(undefined);
+    await rm(root, { recursive: true, force: true });
+  });
 
   it("resolves the platform-native artifact behind the managed npm launcher", () => {
     const packageJsonPath =
@@ -46,9 +74,9 @@ describe("managed Codex app-server binary", () => {
       resolveManagedCodexNativeCommand("/repo/extensions/codex/node_modules/.bin/codex", {
         platform: "darwin",
         arch: "arm64",
-        resolvePackageJson: (packageName, root) =>
+        resolvePackageJson: (packageName, packageRoot) =>
           packageName === "@openai/codex-darwin-arm64" &&
-          root === "/repo/extensions/codex/node_modules/@openai/codex"
+          packageRoot === "/repo/extensions/codex/node_modules/@openai/codex"
             ? packageJsonPath
             : undefined,
         pathExists: (candidate) => candidate === expected,
@@ -131,259 +159,186 @@ describe("managed Codex app-server binary", () => {
     },
   );
 
-  it("leaves explicit command overrides unchanged without probing managed paths", async () => {
-    const explicitOptions = startOptions("config");
-    const pathExists = vi.fn(async () => false);
+  it.each(["source", "bundled"])(
+    "selects the owner-local package ahead of a stale ancestor shim (%s)",
+    async (layout) => {
+      const installRoot = path.join(root, "node_modules", "openclaw");
+      const pluginRoot =
+        layout === "source"
+          ? path.join(installRoot, "extensions", "codex")
+          : path.join(installRoot, "dist", "extensions", "codex");
+      const launcher = await writePackageLauncher(pluginRoot);
+      await writeExecutable(managedCommandPath(installRoot, "linux"));
+      await writePackageLauncher(installRoot);
+      setManagedCodexPluginRoot(pluginRoot);
 
-    await expect(
-      resolveManagedCodexAppServerStartOptions(explicitOptions, {
-        platform: "darwin",
-        pathExists,
-      }),
-    ).resolves.toBe(explicitOptions);
-    expect(pathExists).not.toHaveBeenCalled();
-  });
+      await expect(
+        resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
+          platform: "linux",
+        }),
+      ).resolves.toEqual({
+        ...startOptions("managed"),
+        command: launcher,
+        commandSource: "resolved-managed",
+      });
+    },
+  );
 
-  it("keeps the pinned package ahead of stale desktop bundles for ordinary turns", async () => {
-    const pluginRoot = path.join("/tmp", "openclaw", "extensions", "codex");
-    const pluginLocalCommand = managedCommandPath(pluginRoot, "darwin");
-    const pathExists = vi.fn(
-      async (filePath: string) =>
-        filePath === MACOS_DESKTOP_CHATGPT_APP_SERVER_COMMAND ||
-        filePath === MACOS_DESKTOP_CODEX_APP_SERVER_COMMAND ||
-        filePath === pluginLocalCommand,
-    );
+  it.each(["linux", "win32"] as const)(
+    "resolves the isolated npm generation package without a local shim (%s)",
+    async (platform) => {
+      const generation = path.join(
+        root,
+        "npm",
+        "projects",
+        "openclaw-codex-fixture--g-0123456789abcdef",
+      );
+      const pluginRoot = path.join(generation, "node_modules", "@openclaw", "codex");
+      await mkdir(pluginRoot, { recursive: true });
+      const launcher = await writePackageLauncher(generation);
+      // The flat project and an ancestor shim do not own this plugin's dependency.
+      await writePackageLauncher(path.join(root, "npm", "projects", "openclaw-codex-fixture"));
+      await writeExecutable(managedCommandPath(root, platform));
 
+      await expect(
+        resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
+          platform,
+          pluginRoot,
+        }),
+      ).resolves.toEqual({
+        ...startOptions("managed"),
+        command: launcher,
+        commandSource: "resolved-managed",
+      });
+    },
+  );
+
+  it("resolves dependencies above a compiled plugin entry without reconstructing roots", async () => {
+    const pluginRoot = path.join(root, "dist", "extensions", "codex");
+    await mkdir(pluginRoot, { recursive: true });
+    const launcher = await writePackageLauncher(root);
     await expect(
       resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
-        platform: "darwin",
+        platform: "linux",
         pluginRoot,
-        pathExists,
       }),
-    ).resolves.toEqual({
-      ...startOptions("managed"),
-      command: pluginLocalCommand,
-      commandSource: "resolved-managed",
-      managedFallbackCommandPaths: [
-        MACOS_DESKTOP_CHATGPT_APP_SERVER_COMMAND,
-        MACOS_DESKTOP_CODEX_APP_SERVER_COMMAND,
-      ],
-    });
+    ).resolves.toMatchObject({ command: launcher, commandSource: "resolved-managed" });
   });
 
-  it("prefers the ChatGPT.app desktop bundle for Computer Use", async () => {
-    const pluginRoot = path.join("/tmp", "openclaw", "extensions", "codex");
-    const pluginLocalCommand = managedCommandPath(pluginRoot, "darwin");
-    const pathExists = vi.fn(
-      async (filePath: string) =>
-        filePath === MACOS_DESKTOP_CHATGPT_APP_SERVER_COMMAND || filePath === pluginLocalCommand,
+  it("resolves the pnpm-linked owner dependency ahead of an ancestor shim", async () => {
+    const pluginRoot = path.join(root, "extensions", "codex");
+    const storeRoot = path.join(root, "node_modules", ".pnpm", "codex-slot");
+    const launcher = await writePackageLauncher(storeRoot);
+    const scope = path.join(pluginRoot, "node_modules", "@openai");
+    await mkdir(scope, { recursive: true });
+    await symlink(
+      path.dirname(path.dirname(launcher)),
+      path.join(scope, "codex"),
+      process.platform === "win32" ? "junction" : "dir",
     );
-
-    await expect(
-      resolveManagedCodexAppServerStartOptions(startOptions("managed", "desktop-first"), {
-        platform: "darwin",
-        pluginRoot,
-        pathExists,
-      }),
-    ).resolves.toEqual({
-      ...startOptions("managed", "desktop-first"),
-      command: MACOS_DESKTOP_CHATGPT_APP_SERVER_COMMAND,
-      commandSource: "resolved-managed",
-      managedFallbackCommandPaths: [pluginLocalCommand],
-    });
-  });
-
-  it("falls back to the legacy Codex.app desktop bundle when ChatGPT.app is absent", async () => {
-    const pluginRoot = path.join("/tmp", "openclaw", "extensions", "codex");
-    const pluginLocalCommand = managedCommandPath(pluginRoot, "darwin");
-    const pathExists = vi.fn(
-      async (filePath: string) =>
-        filePath === MACOS_DESKTOP_CODEX_APP_SERVER_COMMAND || filePath === pluginLocalCommand,
-    );
-
-    await expect(
-      resolveManagedCodexAppServerStartOptions(startOptions("managed", "desktop-first"), {
-        platform: "darwin",
-        pluginRoot,
-        pathExists,
-      }),
-    ).resolves.toEqual({
-      ...startOptions("managed", "desktop-first"),
-      command: MACOS_DESKTOP_CODEX_APP_SERVER_COMMAND,
-      commandSource: "resolved-managed",
-      managedFallbackCommandPaths: [pluginLocalCommand],
-    });
-  });
-
-  it("falls back to the source plugin-local binary when neither desktop bundle exists", async () => {
-    const pluginRoot = path.join("/tmp", "openclaw", "extensions", "codex");
-    const pluginLocalCommand = managedCommandPath(pluginRoot, "darwin");
-    const pathExists = vi.fn(async (filePath: string) => filePath === pluginLocalCommand);
-
-    await expect(
-      resolveManagedCodexAppServerStartOptions(startOptions("managed", "desktop-first"), {
-        platform: "darwin",
-        pluginRoot,
-        pathExists,
-      }),
-    ).resolves.toEqual({
-      ...startOptions("managed", "desktop-first"),
-      command: pluginLocalCommand,
-      commandSource: "resolved-managed",
-    });
-    expect(pathExists).toHaveBeenCalledWith(MACOS_DESKTOP_CHATGPT_APP_SERVER_COMMAND, "darwin");
-    expect(pathExists).toHaveBeenCalledWith(MACOS_DESKTOP_CODEX_APP_SERVER_COMMAND, "darwin");
-  });
-
-  it("finds Codex in the package install root used by packaged plugins", async () => {
-    const installRoot = path.join("/tmp", "openclaw-plugin-package", "codex");
-    const pluginRoot = path.join(installRoot, "dist", "extensions", "codex");
-    const installedCommand = managedCommandPath(installRoot, "linux");
-    const pathExists = vi.fn(async (filePath: string) => filePath === installedCommand);
+    await writeExecutable(managedCommandPath(root, "linux"));
 
     await expect(
       resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
         platform: "linux",
         pluginRoot,
-        pathExists,
       }),
     ).resolves.toEqual({
       ...startOptions("managed"),
-      command: installedCommand,
+      command: launcher,
       commandSource: "resolved-managed",
     });
   });
 
-  it("prefers the bundled plugin binary over a stale hoisted package binary", async () => {
-    const installRoot = path.join("/tmp", "openclaw-package");
-    const packageRoot = path.join(installRoot, "node_modules", "openclaw");
-    const bundledPluginRoot = path.join(packageRoot, "dist", "extensions", "codex");
-    const bundledCommand = managedCommandPath(bundledPluginRoot, "linux");
-    const hoistedCommand = managedCommandPath(installRoot, "linux");
-    const pathExists = vi.fn(
-      async (filePath: string) => filePath === bundledCommand || filePath === hoistedCommand,
-    );
-    setManagedCodexPluginRoot(bundledPluginRoot);
-
+  it("shares the registered owner with separately loaded runtime modules", async () => {
+    const launcher = await writePackageLauncher(root);
+    setManagedCodexPluginRoot(root);
+    vi.resetModules();
+    const runtimeCopy = await import("./managed-binary.js");
     await expect(
-      resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
+      runtimeCopy.resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
         platform: "linux",
-        pathExists,
       }),
-    ).resolves.toEqual({
-      ...startOptions("managed"),
-      command: bundledCommand,
-      commandSource: "resolved-managed",
-      managedFallbackCommandPaths: [hoistedCommand],
-    });
+    ).resolves.toMatchObject({ command: launcher });
   });
 
-  it("falls back to the hoisted package when the bundled plugin binary is absent", async () => {
-    const installRoot = path.join("/tmp", "openclaw-package");
-    const packageRoot = path.join(installRoot, "node_modules", "openclaw");
-    const bundledPluginRoot = path.join(packageRoot, "dist", "extensions", "codex");
-    const hoistedCommand = managedCommandPath(installRoot, "linux");
-    const pathExists = vi.fn(async (filePath: string) => filePath === hoistedCommand);
-    setManagedCodexPluginRoot(bundledPluginRoot);
+  it.each(["config", "env"] as const)(
+    "preserves the %s override without managed discovery",
+    async (source) => {
+      const explicit = resolveCodexAppServerRuntimeOptions({
+        pluginConfig:
+          source === "config" ? { appServer: { command: "/operator/config-codex" } } : {},
+        env: { OPENCLAW_CODEX_APP_SERVER_BIN: "/operator/env-codex" },
+        codexConfigToml: null,
+        requirementsToml: null,
+      }).start;
+      const pathExists = vi.fn(async () => false);
+      expect(explicit.commandSource).toBe(source);
+      expect(explicit.command).toBe(`/operator/${source}-codex`);
+      await expect(
+        resolveManagedCodexAppServerStartOptions(explicit, {
+          pathExists,
+        }),
+      ).resolves.toBe(explicit);
+      expect(pathExists).not.toHaveBeenCalled();
+    },
+  );
 
-    await expect(
-      resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
-        platform: "linux",
-        pathExists,
-      }),
-    ).resolves.toEqual({
-      ...startOptions("managed"),
-      command: hoistedCommand,
-      commandSource: "resolved-managed",
-    });
-  });
+  it.each([
+    { order: "package-first", desktop: "both" },
+    { order: "desktop-first", desktop: "both" },
+    { order: "desktop-first", desktop: "legacy" },
+    { order: "desktop-first", desktop: "none" },
+  ] as const)(
+    "honors macOS $order ordering with $desktop desktop bundles",
+    async ({ order, desktop }) => {
+      const launcher = await writePackageLauncher(root);
+      const desktopCommands =
+        desktop === "both"
+          ? [MACOS_DESKTOP_CHATGPT_APP_SERVER_COMMAND, MACOS_DESKTOP_CODEX_APP_SERVER_COMMAND]
+          : desktop === "legacy"
+            ? [MACOS_DESKTOP_CODEX_APP_SERVER_COMMAND]
+            : [];
+      const commands =
+        order === "package-first" ? [launcher, ...desktopCommands] : [...desktopCommands, launcher];
+      await expect(
+        resolveManagedCodexAppServerStartOptions(startOptions("managed", order), {
+          platform: "darwin",
+          pluginRoot: root,
+          pathExists: async (candidate) =>
+            candidate.startsWith("/Applications/")
+              ? desktopCommands.includes(candidate)
+              : access(candidate).then(
+                  () => true,
+                  () => false,
+                ),
+        }),
+      ).resolves.toEqual({
+        ...startOptions("managed", order),
+        command: commands[0],
+        commandSource: "resolved-managed",
+        ...(commands.length > 1 ? { managedFallbackCommandPaths: commands.slice(1) } : {}),
+      });
+    },
+  );
 
-  it("finds Codex bins hoisted into an isolated npm project root", async () => {
-    const projectRoot = path.join("/tmp", "state", "npm", "projects", "openclaw-codex-hash");
-    const pluginRoot = path.join(projectRoot, "node_modules", "@openclaw", "codex");
-    const installedCommand = managedCommandPath(projectRoot, "linux");
-    const pathExists = vi.fn(async (filePath: string) => filePath === installedCommand);
-
-    await expect(
-      resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
-        platform: "linux",
-        pluginRoot,
-        pathExists,
-      }),
-    ).resolves.toEqual({
-      ...startOptions("managed"),
-      command: installedCommand,
-      commandSource: "resolved-managed",
-    });
-  });
-
-  it("finds a Windows codex.cmd shim in an isolated npm root using win32 paths", async () => {
-    const projectRoot = path.win32.join(
-      "C:\\",
-      "Users",
-      "test",
-      ".openclaw",
-      "npm",
-      "projects",
-      "openclaw-codex-hash",
-    );
-    const pluginRoot = path.win32.join(projectRoot, "node_modules", "@openclaw", "codex");
-    const installedCommand = managedCommandPath(projectRoot, "win32");
-    const pathExists = vi.fn(async (filePath: string) => filePath === installedCommand);
-
-    await expect(
-      resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
-        platform: "win32",
-        pluginRoot,
-        pathExists,
-      }),
-    ).resolves.toEqual({
-      ...startOptions("managed"),
-      command: installedCommand,
-      commandSource: "resolved-managed",
-    });
-  });
-
-  it("falls back to the resolved Codex package bin when no command shim exists", async () => {
-    const installRoot = await mkdtemp(path.join(os.tmpdir(), "openclaw-codex-package-"));
-    const pluginRoot = path.join(installRoot, "dist", "extensions", "codex");
-    const packageRoot = path.join(installRoot, "node_modules", "@openai", "codex");
-    const packageBin = path.join(packageRoot, "bin", "codex.js");
-    await mkdir(path.dirname(packageBin), { recursive: true });
-    await writeFile(
-      path.join(packageRoot, "package.json"),
-      JSON.stringify({
-        name: "@openai/codex",
-        bin: {
-          codex: "bin/codex.js",
-        },
-      }),
-    );
-    await writeFile(packageBin, "#!/usr/bin/env node\n");
-    const resolvedPackageBin = await realpath(packageBin);
-
-    const pathExists = vi.fn(async (filePath: string) => filePath === resolvedPackageBin);
-
+  it("fails clearly when the managed package is absent even with an ancestor shim", async () => {
+    const pluginRoot = path.join(root, "extensions", "codex");
+    await mkdir(pluginRoot, { recursive: true });
+    await writeExecutable(managedCommandPath(root, "linux"));
     await expect(
       resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
         platform: "linux",
         pluginRoot,
-        pathExists,
-      }),
-    ).resolves.toEqual({
-      ...startOptions("managed"),
-      command: resolvedPackageBin,
-      commandSource: "resolved-managed",
-    });
-  });
-
-  it("fails clearly when the managed Codex binary is missing", async () => {
-    await expect(
-      resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
-        platform: "darwin",
-        pluginRoot: path.join("/tmp", "openclaw", "extensions", "codex"),
-        pathExists: vi.fn(async () => false),
       }),
     ).rejects.toThrow("Managed Codex app-server binary was not found");
+  });
+
+  it("requires a loader-registered owner instead of guessing from the runtime module", async () => {
+    await expect(
+      resolveManagedCodexAppServerStartOptions(startOptions("managed"), {
+        platform: "linux",
+      }),
+    ).rejects.toThrow("Codex plugin root is unavailable");
   });
 });

--- a/extensions/codex/src/app-server/managed-binary.ts
+++ b/extensions/codex/src/app-server/managed-binary.ts
@@ -2,19 +2,22 @@
  * Resolves the managed Codex app-server binary shipped with or installed beside
  * the Codex plugin before stdio startup.
  */
-import { constants as fsConstants, existsSync, readFileSync, realpathSync } from "node:fs";
+import { constants as fsConstants, existsSync, realpathSync } from "node:fs";
 import { access } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import { resolveGlobalSingleton } from "openclaw/plugin-sdk/global-singleton";
 import type { CodexAppServerStartOptions, CodexManagedCommandOrder } from "./config.js";
 import { resolveMacOSDesktopCodexAppServerCommandCandidates } from "./desktop-app-paths.js";
 import { MANAGED_CODEX_APP_SERVER_PACKAGE } from "./version.js";
 
-const CODEX_APP_SERVER_MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
-const CODEX_PLUGIN_ROOT = resolveDefaultCodexPluginRoot(CODEX_APP_SERVER_MODULE_DIR);
-let registeredCodexPluginRoot: string | undefined;
+// Registration and lazy runtime artifacts can load separate module copies.
+// They must resolve dependencies from the same loader-owned plugin root.
+const registeredCodexPlugin = resolveGlobalSingleton<{ root?: string }>(
+  Symbol.for("openclaw.codexManagedPluginRoot"),
+  () => ({}),
+);
 
 type ResolveManagedCodexAppServerOptions = {
   platform?: NodeJS.Platform;
@@ -31,7 +34,7 @@ type ResolveManagedCodexNativeCommandOptions = {
 
 /** Records the process-stable plugin root prepared by OpenClaw's plugin loader. */
 export function setManagedCodexPluginRoot(pluginRoot: string | undefined): void {
-  registeredCodexPluginRoot = pluginRoot;
+  registeredCodexPlugin.root = pluginRoot;
 }
 
 /** Rewrites managed stdio start options to point at an executable Codex binary path. */
@@ -43,9 +46,15 @@ export async function resolveManagedCodexAppServerStartOptions(
     return startOptions;
   }
 
+  const pluginRoot = options.pluginRoot ?? registeredCodexPlugin.root;
+  if (!pluginRoot) {
+    throw new Error(
+      "Codex plugin root is unavailable. Load the Codex plugin before starting its managed app-server.",
+    );
+  }
   const platform = options.platform ?? process.platform;
   const candidateCommandPaths = resolveManagedCodexAppServerCommandCandidates(
-    options.pluginRoot ?? registeredCodexPluginRoot ?? CODEX_PLUGIN_ROOT,
+    pluginRoot,
     platform,
     startOptions.managedCommandOrder ?? "package-first",
   );
@@ -203,128 +212,28 @@ function resolveManagedCodexAppServerCommandCandidates(
   platform: NodeJS.Platform,
   managedCommandOrder: CodexManagedCommandOrder,
 ): string[] {
-  const pathApi = pathForPlatform(platform);
-  const commandName = platform === "win32" ? "codex.cmd" : "codex";
-  const roots = resolveManagedCodexAppServerCandidateRoots(pluginRoot, platform);
-  const packageCommandPaths = [
-    ...roots.map((root) => pathApi.join(root, "node_modules", ".bin", commandName)),
-    ...resolveManagedCodexPackageBinCandidates(roots, platform),
-  ];
-  const desktopCommandPaths = resolveDesktopCodexAppServerCommandCandidates(platform);
+  const packageCommand = resolveManagedCodexPackageEntrypoint(pluginRoot);
+  const packageCommandPaths = packageCommand ? [packageCommand] : [];
+  const desktopCommandPaths = resolveMacOSDesktopCodexAppServerCommandCandidates(platform);
   // Ordinary turns must honor the pinned package version. Computer Use opts
   // into the desktop app owner because its macOS TCC permissions live there.
   const orderedCommandPaths =
     managedCommandOrder === "desktop-first"
       ? [...desktopCommandPaths, ...packageCommandPaths]
       : [...packageCommandPaths, ...desktopCommandPaths];
-  return [...new Set(orderedCommandPaths)];
+  return orderedCommandPaths;
 }
 
-function resolveDesktopCodexAppServerCommandCandidates(platform: NodeJS.Platform): string[] {
-  return resolveMacOSDesktopCodexAppServerCommandCandidates(platform);
-}
-
-function resolveDefaultCodexPluginRoot(moduleDir: string): string {
-  const moduleBaseName = path.basename(moduleDir);
-  if (moduleBaseName === "dist" || moduleBaseName === "dist-runtime") {
-    return path.dirname(moduleDir);
-  }
-  return path.resolve(moduleDir, "..", "..");
-}
-
-function resolveManagedCodexAppServerCandidateRoots(
-  pluginRoot: string,
-  platform: NodeJS.Platform,
-): string[] {
-  const pathApi = pathForPlatform(platform);
-  const directRoots = [
-    pluginRoot,
-    pathApi.dirname(pluginRoot),
-    pathApi.dirname(pathApi.dirname(pluginRoot)),
-    isDistExtensionRoot(pluginRoot, platform)
-      ? pathApi.dirname(pathApi.dirname(pathApi.dirname(pluginRoot)))
-      : null,
-  ].filter((root): root is string => Boolean(root));
-  return [
-    ...new Set([...directRoots, ...resolveNearestNodeModulesProjectRoots(directRoots, platform)]),
-  ];
-}
-
-function resolveNearestNodeModulesProjectRoots(
-  roots: readonly string[],
-  platform: NodeJS.Platform,
-): string[] {
-  const pathApi = pathForPlatform(platform);
-  const projectRoots: string[] = [];
-  for (const root of roots) {
-    let current = pathApi.resolve(root);
-    while (true) {
-      if (pathApi.basename(current) === "node_modules") {
-        projectRoots.push(pathApi.dirname(current));
-        break;
-      }
-      const parent = pathApi.dirname(current);
-      if (parent === current) {
-        break;
-      }
-      current = parent;
-    }
-  }
-  return projectRoots;
-}
-
-function resolveManagedCodexPackageBinCandidates(
-  roots: readonly string[],
-  platform: NodeJS.Platform,
-): string[] {
-  if (platform === "win32") {
-    return [];
-  }
-
-  const candidates: string[] = [];
-  for (const root of roots) {
-    const candidate = resolveManagedCodexPackageBinCandidate(root);
-    if (candidate) {
-      candidates.push(candidate);
-    }
-  }
-  return candidates;
-}
-
-function resolveManagedCodexPackageBinCandidate(root: string): string | null {
+function resolveManagedCodexPackageEntrypoint(pluginRoot: string): string | undefined {
   try {
-    const requireFromRoot = createRequire(path.join(root, "package.json"));
-    const packageJsonPath = requireFromRoot.resolve(
-      `${MANAGED_CODEX_APP_SERVER_PACKAGE}/package.json`,
+    // Use the pinned package's official launcher on every OS. It owns platform
+    // selection, manager environment markers, signal forwarding, and exit status.
+    return createRequire(path.join(pluginRoot, "package.json")).resolve(
+      `${MANAGED_CODEX_APP_SERVER_PACKAGE}/bin/codex.js`,
     );
-    const packageRoot = path.dirname(packageJsonPath);
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-      bin?: unknown;
-    };
-    const packageBin =
-      packageJson.bin && typeof packageJson.bin === "object"
-        ? (packageJson.bin as Record<string, unknown>)
-        : undefined;
-    const binPath =
-      typeof packageJson.bin === "string"
-        ? packageJson.bin
-        : typeof packageBin?.codex === "string"
-          ? packageBin.codex
-          : null;
-    return binPath ? path.resolve(packageRoot, binPath) : null;
   } catch {
-    return null;
+    return undefined;
   }
-}
-
-function isDistExtensionRoot(pluginRoot: string, platform: NodeJS.Platform): boolean {
-  const pathApi = pathForPlatform(platform);
-  const extensionsDir = pathApi.dirname(pluginRoot);
-  const distDir = pathApi.dirname(extensionsDir);
-  return (
-    pathApi.basename(extensionsDir) === "extensions" &&
-    (pathApi.basename(distDir) === "dist" || pathApi.basename(distDir) === "dist-runtime")
-  );
 }
 
 function pathForPlatform(platform: NodeJS.Platform): typeof path {

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -1,6 +1,7 @@
 // Codex plugin module implements run attempt test harness behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createOpenClawCodingTools } from "openclaw/plugin-sdk/agent-harness";
 import {
   abortAndDrainAgentHarnessRun,
@@ -35,6 +36,7 @@ import {
 import * as codexRequirements from "./config-requirements.js";
 import { dynamicToolBuildState } from "./dynamic-tool-build-state.js";
 import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
+import { setManagedCodexPluginRoot } from "./managed-binary.js";
 import { nativeHookRelayUnregisterQueue } from "./native-hook-relay-state.js";
 import { defaultCodexPluginMetadataCache } from "./plugin-metadata-cache.js";
 import type { CodexServerNotification } from "./protocol.js";
@@ -694,6 +696,8 @@ export function createRuntimeDynamicTool(name: string): RuntimeDynamicToolForTes
 
 export function setupRunAttemptTestHooks(): void {
   beforeEach(async () => {
+    // Direct runtime tests supply the plugin root normally owned by loader registration.
+    setManagedCodexPluginRoot(fileURLToPath(new URL("../../", import.meta.url)));
     // Machine-managed sandbox requirements must not leak into policy fixtures.
     vi.spyOn(codexRequirements, "readCodexRequirementsToml").mockReturnValue(undefined);
     // An uninitialized real host approvals store intentionally fails closed.
@@ -724,6 +728,7 @@ export function setupRunAttemptTestHooks(): void {
     }
     await sandboxExecServerRegistry.closeAll();
     resetCodexAppServerClientFactoryForTest();
+    setManagedCodexPluginRoot(undefined);
     clearRuntimeAuthProfileStoreSnapshots();
     dynamicToolBuildState.openClawCodingToolsFactory = undefined;
     codexWorkspaceDirCache.clear();

--- a/extensions/codex/src/app-server/runtime-artifact.test.ts
+++ b/extensions/codex/src/app-server/runtime-artifact.test.ts
@@ -94,7 +94,7 @@ async function createNpmLauncherFixture(root: string) {
   await fs.chmod(path.join(binDir, "node"), 0o755);
   const command = path.join(binDir, "codex");
   await fs.symlink(launcher, command);
-  return { command, native, binDir };
+  return { command, launcher, native, binDir };
 }
 
 describe("Codex app-server runtime artifact", () => {
@@ -115,6 +115,7 @@ describe("Codex app-server runtime artifact", () => {
   });
 
   it.runIf(process.platform === "darwin" || process.platform === "linux").each([
+    ["resolved-managed", "package-entrypoint"],
     ["config", "absolute"],
     ["env", "path"],
     ["config", "relative"],
@@ -122,9 +123,15 @@ describe("Codex app-server runtime artifact", () => {
     "binds the official npm launcher selected by %s via %s",
     async (source, selection) => {
       await withTempDir("openclaw-codex-npm-artifact-", async (root) => {
-        const { command, native, binDir } = await createNpmLauncherFixture(root);
+        const { command, launcher, native, binDir } = await createNpmLauncherFixture(root);
         const options = startOptions(
-          selection === "path" ? "codex" : selection === "relative" ? "bin/codex" : command,
+          selection === "package-entrypoint"
+            ? launcher
+            : selection === "path"
+              ? "codex"
+              : selection === "relative"
+                ? "bin/codex"
+                : command,
           {
             commandSource: source,
             cwd: root,

--- a/extensions/codex/src/app-server/transport-stdio.config.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.config.test.ts
@@ -1,10 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { withEphemeralCodexAuthStore } from "./auth-start-options.js";
 import type { CodexAppServerStartOptions } from "./config-contracts.js";
+import { resolveManagedCodexAppServerStartOptions } from "./managed-binary.js";
 import { createCodexNativeTestState } from "./native-app-server.test-support.js";
 import type { CodexConfigReadResponse, CodexInitializeResponse } from "./protocol.js";
 import { createStdioTransport } from "./transport-stdio.js";
@@ -57,9 +59,16 @@ type NativeConfigCase = {
   expected: CodexConfigReadResponse["config"];
   authProfileId?: null;
   posixOnly?: boolean;
+  managed?: boolean;
 };
 
 const cases: NativeConfigCase[] = [
+  {
+    name: "loader-owned managed package entrypoint",
+    invocation: () => ({ command: "codex", args: [...mixedArgs] }),
+    expected: expectedMixedConfig,
+    managed: true,
+  },
   {
     name: "root overrides with injected auth",
     invocation: (command) => ({
@@ -201,12 +210,14 @@ describe("Codex stdio effective configuration", () => {
       const options: CodexAppServerStartOptions = {
         ...testCase.invocation(command, launcher),
         transport: "stdio",
-        commandSource: "config",
+        commandSource: testCase.managed ? "managed" : "config",
         cwd,
         headers: {},
       };
       const start = withEphemeralCodexAuthStore({
-        startOptions: options,
+        startOptions: await resolveManagedCodexAppServerStartOptions(options, {
+          pluginRoot: fileURLToPath(new URL("../../", import.meta.url)),
+        }),
         authProfileId: testCase.authProfileId,
       });
       const { config } = await readNativeConfig(start, env);

--- a/extensions/codex/src/node-exec-server.test.ts
+++ b/extensions/codex/src/node-exec-server.test.ts
@@ -3,14 +3,15 @@ import { once } from "node:events";
 import { access, readFile, realpath } from "node:fs/promises";
 import { createServer } from "node:http";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type { OpenClawPluginNodeHostCommandIo } from "openclaw/plugin-sdk/node-host";
 import type {
   OpenClawPluginNodeHostCommand,
   OpenClawPluginNodeInvokePolicyContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setManagedCodexPluginRoot } from "./app-server/managed-binary.js";
 import {
   createCodexNodeExecServerCommand,
   createCodexNodeExecServerInvokePolicy,
@@ -133,7 +134,12 @@ async function readNodeProcessNotifications(
   );
 }
 
+beforeEach(() => {
+  setManagedCodexPluginRoot(fileURLToPath(new URL("../", import.meta.url)));
+});
+
 afterEach(() => {
+  setManagedCodexPluginRoot(undefined);
   vi.unstubAllEnvs();
 });
 

--- a/src/plugin-sdk/windows-spawn.test.ts
+++ b/src/plugin-sdk/windows-spawn.test.ts
@@ -2,7 +2,7 @@
  * Tests Windows spawn compatibility helpers.
  */
 import { spawnSync } from "node:child_process";
-import { copyFile, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createPluginSdkTestHarness } from "./test-helpers.js";
@@ -43,16 +43,45 @@ describe("resolveWindowsSpawnProgram", () => {
     },
   );
 
-  it("rejects node command strings that include inline entrypoint arguments on Windows", () => {
-    expect(() =>
-      resolveWindowsSpawnProgram({
-        command: "node C:\\Users\\me\\.openclaw\\npm\\node_modules\\@openai\\codex\\bin\\codex.js",
+  it.each(["node script.js", "pnpm exec tool", '"C:\\tools\\pnpm.cmd" exec tool'])(
+    "rejects command strings with inline arguments on Windows: %s",
+    (command) => {
+      expect(() =>
+        resolveWindowsSpawnProgram({
+          command,
+          platform: "win32",
+          env: {},
+          execPath: "C:\\node\\node.exe",
+        }),
+      ).toThrow("Windows spawn command must be an executable path only");
+    },
+  );
+
+  it.each(["pnpm checkout", "node tools"])(
+    "preserves an existing launcher path inside %s on Windows",
+    async (directory) => {
+      const root = await realpath(await createTempDir("openclaw-windows-spawn-test-"));
+      const dir = path.join(root, directory);
+      await mkdir(dir);
+      const launcher = path.join(dir, "launcher.js");
+      await writeFile(launcher, "process.exit(0);\n", "utf8");
+
+      const program = resolveWindowsSpawnProgram({
+        command: launcher,
         platform: "win32",
         env: {},
-        execPath: "C:\\node\\node.exe",
-      }),
-    ).toThrow("Windows spawn command must be an executable path only");
-  });
+        execPath: process.execPath,
+      });
+
+      expect(materializeWindowsSpawnProgram(program, ["--version"])).toEqual({
+        command: process.execPath,
+        argv: [launcher, "--version"],
+        resolution: "node-entrypoint",
+        shell: undefined,
+        windowsHide: true,
+      });
+    },
+  );
 
   it("allows executable paths with spaces on Windows", () => {
     const resolved = resolveWindowsSpawnProgram({

--- a/src/plugin-sdk/windows-spawn.ts
+++ b/src/plugin-sdk/windows-spawn.ts
@@ -129,7 +129,8 @@ export function detectWindowsSpawnCommandInlineArgs(
   }
   const normalizedToken = parsed.token.replace(/\\/g, "/");
   const executable = normalizeLowercaseStringOrEmpty(path.posix.basename(normalizedToken));
-  if (!INLINE_ARGUMENT_EXECUTABLES.has(executable)) {
+  // Existing paths can contain spaces after a directory named node or pnpm.
+  if (!INLINE_ARGUMENT_EXECUTABLES.has(executable) || isFilePath(command)) {
     return null;
   }
   return {


### PR DESCRIPTION
Related: #136203 — Windows upgrade/runtime investigation; this PR fixes an adjacent, independently reproduced ownership bug, **not the exact incident reported in that issue comment**.

## What Problem This Solves

Fixes an issue where users starting managed Codex sessions could run a stale ancestor installation instead of the official plugin's pinned dependency when the plugin's package entrypoint existed but its local command shim did not. Windows additionally rejected a valid package installation with no command shim.

Native Windows verification found a second, bounded launch defect: an existing script below a directory named `pnpm checkout` or `node tools` was mistaken for a command containing inline arguments.

## Why This Change Was Made

Resolve one official `@openai/codex/bin/codex.js` entrypoint through Node package resolution anchored to the loader-provided plugin root. Remove competing ancestor-shim searches, root reconstruction, repeated manifest-bin parsing, and the Windows exclusion. The existing singleton helper carries that registered root across lazy runtime module copies; cold Doctor checks retain their explicitly supplied root.

The upstream launcher still owns platform-package selection, package-manager environment markers, signal forwarding, and exit status. Doctor, runtime attestation, and node exec-server retain their separate native-artifact identity path. The shared Windows SDK change only recognizes an existing complete file path before diagnosing inline arguments; it adds no Codex policy and retains shell-fallback restrictions.

Production LOC: **+28/-118 (net -90)**. Tests and test support: **+259/-245 (net +14)**. The assertion baseline shrinks because the deleted manifest parser contained two unchecked casts. No dependency, public config, schema, or protocol changes.

## User Impact

Managed startup uses the plugin-owned dependency across source, bundled, npm-hoisted, and pnpm-linked layouts without depending on `.bin` shims. Config and environment overrides remain authoritative. macOS Computer Use and user-home startup keep their documented desktop-first ordering; ordinary isolated-home turns remain package-first.

Existing Windows launcher paths containing spaces after `node` or `pnpm` are accepted without relaxing rejection of actual inline command arguments.

See the [Codex harness reference](https://docs.openclaw.ai/plugins/codex-harness-reference#app-server-transport).

## Evidence

### Failing before, passing after

The complete actual resolver ran against real synthetic filesystem trees before production edits: **7 failed / 13 passed**, including source/bundled owner dependency versus stale ancestor shim, shim-free Windows npm generation, pnpm-linked ownership, and shared registration across runtime module copies. The generic Windows path regression independently failed in both `pnpm checkout` and `node tools` cases before its repair.

After repair, **408 Codex tests passed across 9 files**, covering resolver/config, real pinned-native stdio configuration, runtime attestation and invalidation, shared-client lifecycle/fallback, Doctor, node exec-server, and plugin registration. The SDK suite passed **10 tests**, with one unrelated native-Windows-only mixed-PATH case skipped on macOS. A final focused rerun passed all **20 resolver + 10 SDK** cases after a test-only lint rename.

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/managed-binary.test.ts extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/transport-stdio.test.ts extensions/codex/src/app-server/transport-stdio.config.test.ts extensions/codex/src/app-server/runtime-artifact.test.ts extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/doctor.test.ts extensions/codex/src/node-exec-server.test.ts extensions/codex/index.test.ts
```

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/managed-binary.test.ts src/plugin-sdk/windows-spawn.test.ts
```

### Native Windows process proof

Windows 11 ARM64 (build 26100), checksum-verified portable Node 24.20.0, and real npm-installed `@openai/codex@0.152.1`. The probe compiled the actual resolver, unchanged production stdio transport, and SDK—not replacement resolver logic—and used isolated temporary package trees and homes.

| Layout | Before | After |
| --- | --- | --- |
| Owner-local package, missing local shim, stale ancestor shim | Selected ancestor `.bin/codex.cmd` | Selected owner `@openai/codex/bin/codex.js` |
| Isolated npm generation, dependency hoisted within that generation, no shim | Resolver regression fails | Correct package entrypoint and native artifact |
| pnpm-style virtual-store junction under `pnpm checkout` | SDK rejects complete path as inline arguments | Correct package entrypoint and native artifact |

Each candidate layout passed the real process flow: SDK `node-entrypoint` invocation with no shell, `codex-cli 0.152.1`, app-server initialization, `command/exec` verification of `CODEX_MANAGED_PACKAGE_ROOT` and the manager marker, and clean stdin-close exit 0. No inference, provider credentials, operator Gateway, or real user state was used. Native child networking was blocked. All owned children were joined and guest fixtures removed.

This is native ARM64 Windows proof, not an x64 or authenticated Gateway-turn claim. No separate signal-injection experiment was run; signal forwarding remains in the exact unchanged upstream launcher.

### Build, checks, and dependency contract

- Full `pnpm build` passed, including plugin bundles and SDK exports; no ineffective dynamic import warning.
- Complete changed-scope gate passed: formatting, core/plugin/test types, core/plugin/scripts lint, SDK exports/budget, Doctor contracts, boundaries, dead exports, schema/legacy-store/media/sidecar/cycle/webhook/pairing guards.
- Built package entrypoint Doctor check passed with `{"ok":true,"checksRun":1,"checksSkipped":1,"findings":[]}`.
- Independent Codex autoreview returned scoped-clean at its default P0 scope. Fresh pre-commit review is recorded with the landing evidence.
- Earlier check failures were resolved, not bypassed: remove the obsolete assertion-baseline entry and rename one shadowing test callback parameter.

```bash
pnpm build
```

```bash
node scripts/check-changed.mjs -- config/assertion-safety-baseline.txt docs/plugins/codex-harness-reference.md extensions/codex/src/app-server/managed-binary.ts extensions/codex/src/app-server/managed-binary.test.ts extensions/codex/src/app-server/runtime-artifact.test.ts extensions/codex/src/app-server/transport-stdio.config.test.ts extensions/codex/src/node-exec-server.test.ts src/plugin-sdk/windows-spawn.ts src/plugin-sdk/windows-spawn.test.ts
```

The lead and implementation worker each personally inspected sibling Codex source at [`rust-v0.152.1`](https://github.com/openai/codex/blob/rust-v0.152.1/codex-cli/bin/codex.js#L79-L249), commit `3c6cfbab81e44218c729dc8c6b304cb760d1b8a1`. It is byte-identical to the installed launcher (SHA-256 `134063e133f0b4244fa3b251acf973d4fe4b4aeeacbdc135211bf480f59f1477`): package-relative platform resolution, not global PATH; upstream environment and signal ownership retained.

### Incident boundary

The healthy Windows generation `.bin/codex.cmd` described in [the original follow-up](https://github.com/openclaw/openclaw/issues/136203#issuecomment-5507803914) is already selected correctly by the previous resolver. This PR must not close that issue or claim that incident fixed without failing Gateway commandSource, selected command/root, and effective BIN evidence.

### CI fixture follow-up

Current head: `26adad12e200e6560db098e9aa2ba00208ec0ef6`. Hosted CI for this head is **green**: [run33693428419](https://github.com/openclaw/openclaw/actions/runs/33693428419), attempt1, completed successfully. The required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33693428419/job/100461316738) passed for this exact SHA from GitHub Actions app15368.

The prior [CI run 33687987797](https://github.com/openclaw/openclaw/actions/runs/33687987797) exposed omitted registration in two direct-runtime fixture owners. Production already records `api.rootDir` before registering runtime capabilities; these tests bypassed plugin registration while using the real managed resolver. The startup tests failed at the missing-root guard. The settlement test handled the same rejection and then waited for an initialize request that could never arrive. A temporary diagnostic established the shared stack and was removed; the settlement assertions remain unchanged. The connected quiet-long-running-thread cleanup case reproduced the same shared-hook omission.

The existing startup fixture and shared run-attempt setup now call the real root setter before each test and clear it after client cleanup/drain. No resolver mocks, forced command/env overrides, timing changes, weakened assertions, runtime fallback, or production edits. Two trivial fixture expressions were compacted to keep the existing test-file line limit without a suppression. The follow-up is **+12/-6, entirely test/test-support**. Whole PR: **11 files, +293/-366 (net -73)**; production remains **+28/-118 (net -90)**.

Before repair, the unchanged published head reproduced **5 failed /21 passed** across startup and settlement; the quiet-thread sibling also failed independently. After repair, the original CI include sets passed **238 tests/12 files** and **313 tests/12 files**, in the same observed file orders as CI. An additional managed-runtime neighborhood passed **706 tests/17 files**. These broad runs cover **1,257 distinct tests/41 files**, including all 22 consumers of the shared setup hook, with no skipped failures. A final formatting-only follow-up rerun passed **41 tests/3 files**.

Focused failing/passing reproduction and final check:

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-startup.test.ts extensions/codex/src/app-server/run-attempt.settlement.test.ts
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts -t 'preserves a quiet long-running native tool'
node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-startup.test.ts extensions/codex/src/app-server/run-attempt.settlement.test.ts extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
node scripts/run-oxlint.mjs --tsconfig extensions/tsconfig.json extensions/codex/src/app-server/attempt-startup.test.ts extensions/codex/src/app-server/run-attempt-test-harness.ts
pnpm_config_verify_deps_before_run=false node scripts/check-changed.mjs -- extensions/codex/src/app-server/attempt-startup.test.ts extensions/codex/src/app-server/run-attempt-test-harness.ts
```

Targeted lint, both plugin TypeScript programs, and the final scoped changed gate passed, including five Doctor tests in two files. Fresh complete-candidate Codex autoreview returned scoped-clean with zero findings at its stated P0-only scope. The normal commit hook passed and the committed fixture diff matches the reviewed snapshot. The earlier production build/native Windows proof remains applicable because all production bytes are unchanged; no production rebuild or Windows rerun is claimed for this test-only follow-up.

[ClawSweeper's new-head review](https://github.com/openclaw/openclaw/pull/136655#issuecomment-5517113726), reviewed at 23:24 UTC, confirms the direct-fixture blocker is fixed and reports no correctness/security findings or new Rank-up moves. Both earlier moves—register/reset the real root and rerun affected startup/settlement/resolver coverage—are completed.

Disposition of its explicit malformed-install compatibility decision: **accept the intended package-owned failure behavior**. This is the approved repair boundary: a missing official package entrypoint must not silently select an unrelated ancestor shim. Existing failure guidance names reinstall/update (or source dependency installation) and the explicit command/configuration override. Those overrides and documented macOS desktop ordering remain intact; no config migration, new option, or runtime fallback is added. Shim-only/missing-dependency regression tests cover the intentional failure. Restoring ancestor search would restore the reported ownership bug.

Phase1 verification is complete: exact-head [CI run33693428419](https://github.com/openclaw/openclaw/actions/runs/33693428419) is green, and native review artifacts validate as `READY FOR /prepare-pr`. No prepare, merge, or auto-merge has run; final landing remains with the lead. The incident boundary above remains unchanged.
