### PR TITLE
fix: embedded session recall returns newest history for search hits

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2042,7 +2042,7 @@ src/agents/tools/cron-tool-schema.ts	1
 src/agents/tools/cron-tool-write.ts	2
 src/agents/tools/cron-tool.ts	13
 src/agents/tools/dashboard-tool.ts	3
-src/agents/tools/embedded-gateway-stub.ts	8
+src/agents/tools/embedded-gateway-stub.ts	7
 src/agents/tools/gateway-tool.ts	5
 src/agents/tools/gateway.ts	1
 src/agents/tools/goal-tools.ts	4

--- a/docs/concepts/session-search.md
+++ b/docs/concepts/session-search.md
@@ -10,7 +10,14 @@ read_when:
 
 `sessions_search` searches the user and assistant text in visible past sessions. Each result
 includes a `sessionKey`, timestamp, role, and a short matching excerpt. Pass the returned
-`sessionKey` to `sessions_history` when you need the surrounding conversation.
+`sessionKey`, `messageId`, and `sessionId` together to `sessions_history` to reopen the matched
+context, including retained history from before a session reset. Without `messageId`, history
+returns the newest bounded tail instead.
+
+Anchored reads use `limit` to bound the surrounding messages and cannot be combined with `offset`.
+For SQLite transcript history, a missing message returns an empty history; a `sessionId` that does
+not belong to the selected session key is rejected. These rules also apply in local embedded mode,
+without a running Gateway.
 
 ## Visibility and output
 

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -69,7 +69,7 @@ The returned view is intentionally bounded and redacted:
 
 This is structured history, not the plain-text rendering used by [`/subagents log`](/tools/subagents#slash-command). `sessions_history` does not apply that command's assistant prose sanitizer: reasoning tags, `<relevant-memories>` / `<relevant_memories>` scaffolding, plain-text tool-call XML (including malformed MiniMax XML), downgraded tool markers, and model control tokens can remain in returned message text. `includeTools` controls tool-result messages, not those embedded text forms.
 
-Use the returned **session key** (like `"main"`) with `sessions_history`, `sessions_send`, and `session_status`. Use the durable `sessionId` only as the lifecycle identity described above.
+Use the returned **session key** (like `"main"`) with `sessions_history`, `sessions_send`, and `session_status`. To reopen a search hit, also pass its `messageId` and `sessionId` to `sessions_history`; see [Session search](/concepts/session-search). Outside anchored recall, use the durable `sessionId` as the lifecycle identity described above.
 
 If you need the exact raw transcript, inspect the scoped SQLite transcript rows instead of treating `sessions_history` as an unfiltered dump.
 

--- a/src/agents/tools/embedded-gateway-stub.history.test.ts
+++ b/src/agents/tools/embedded-gateway-stub.history.test.ts
@@ -1,0 +1,192 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setRuntimeConfigSnapshot } from "../../config/runtime-snapshot.js";
+import {
+  appendTranscriptMessage,
+  replaceSessionEntrySync,
+} from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import * as serverConstants from "../../gateway/server-constants.js";
+import { readChatHistoryMessageId } from "../../gateway/server-methods/chat-history-pages.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createEmbeddedCallGateway } from "./embedded-gateway-stub.js";
+import { createSessionsHistoryTool } from "./sessions-history-tool.js";
+import { createSessionsSearchTool } from "./sessions-search-tool.js";
+
+const config: OpenClawConfig = {
+  agents: { entries: { main: { default: true }, work: {} } },
+  tools: { sessions: { visibility: "agent" } },
+};
+const scope = {
+  agentId: "work",
+  sessionKey: "agent:work:recall",
+  sessionId: "recall-session",
+};
+const selector = { sessionKey: scope.sessionKey, sessionId: scope.sessionId, messageId: "old" };
+const callGateway = createEmbeddedCallGateway();
+
+function toolsFor(cfg = config, sandboxed = false) {
+  const opts = {
+    config: cfg,
+    agentId: scope.agentId,
+    requesterAgentIdOverride: scope.agentId,
+    agentSessionKey: "agent:work:main",
+    sandboxed,
+    callGateway,
+  };
+  return { search: createSessionsSearchTool(opts), history: createSessionsHistoryTool(opts) };
+}
+
+async function history(params: Record<string, unknown>) {
+  const result = await toolsFor().history.execute("recall", params);
+  return result.details as { messages: unknown[] };
+}
+
+describe("embedded session history anchors", () => {
+  let state: Awaited<ReturnType<typeof createOpenClawTestState>>;
+
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ prefix: "embedded-anchor-test-" });
+    setRuntimeConfigSnapshot(config);
+    replaceSessionEntrySync(scope, { sessionId: scope.sessionId, updatedAt: Date.now() });
+    for (const [index, id] of ["old", "middle", "newest"].entries()) {
+      await appendTranscriptMessage(scope, {
+        eventId: id,
+        message: {
+          role: index === 0 ? "user" : "assistant",
+          content: `${id === "old" ? "quasar question" : id} ${"x".repeat(700)}`,
+          timestamp: 1_700_000_000_000 + index,
+        },
+      });
+    }
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await state.cleanup();
+  });
+
+  it.each([false, true])(
+    "recalls an old search hit outside the newest tail (physical selector: %s)",
+    async (includeSessionId) => {
+      const result = await toolsFor().search.execute("find", { query: "quasar" });
+      const hits = (result.details as { results: (typeof selector)[] }).results;
+      expect(hits).toHaveLength(1);
+      const hit = expectDefined(hits[0], "search hit");
+      expect(hit).toMatchObject(selector);
+      expect(
+        (await history({ sessionKey: hit.sessionKey, limit: 1 })).messages.map(
+          readChatHistoryMessageId,
+        ),
+      ).toEqual(["newest"]);
+      const recalled = await history({
+        sessionKey: hit.sessionKey,
+        messageId: hit.messageId,
+        ...(includeSessionId ? { sessionId: hit.sessionId } : {}),
+        limit: 1,
+      });
+      expect(recalled.messages.map(readChatHistoryMessageId)).toEqual(["old"]);
+      expect(recalled).not.toHaveProperty("nextOffset");
+    },
+  );
+
+  it("returns no history for a missing anchor", async () => {
+    expect(await history({ ...selector, messageId: "missing", limit: 1 })).toMatchObject({
+      messages: [],
+    });
+  });
+
+  it.each(["missing", "wrong-key", "wrong-agent"])(
+    "rejects a %s physical session binding instead of returning the tail",
+    async (binding) => {
+      if (binding !== "missing") {
+        const other = {
+          agentId: binding === "wrong-agent" ? "main" : "work",
+          sessionKey: binding === "wrong-agent" ? "agent:main:recall" : "agent:work:other",
+          sessionId: binding,
+        };
+        replaceSessionEntrySync(other, { sessionId: binding, updatedAt: Date.now() });
+        await appendTranscriptMessage(other, {
+          eventId: "old",
+          message: { role: "user", content: "other session" },
+        });
+      }
+      await expect(history({ ...selector, sessionId: binding, limit: 1 })).rejects.toThrow(
+        "sessionId does not belong to sessionKey",
+      );
+    },
+  );
+
+  it("reopens an archived physical session without the replacement's start boundary", async () => {
+    const archived = { ...scope, sessionId: "archived-session" };
+    await appendTranscriptMessage(archived, {
+      eventId: "announcement",
+      message: {
+        role: "user",
+        provenance: { kind: "inter_session", sourceTool: "subagent_announce" },
+        content: "archived announcement",
+        timestamp: 1_600_000_000_000,
+      },
+    });
+    await appendTranscriptMessage(archived, {
+      eventId: "archived-answer",
+      message: { role: "assistant", content: "archived answer", timestamp: 1_600_000_000_001 },
+    });
+    replaceSessionEntrySync(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: Date.now(),
+      sessionStartedAt: 1_700_000_000_000,
+    });
+    const result = await history({
+      ...selector,
+      sessionId: archived.sessionId,
+      messageId: "archived-answer",
+      limit: 1,
+    });
+    expect(result.messages.map(readChatHistoryMessageId)).toEqual(["archived-answer"]);
+  });
+
+  it("preserves the anchor when the embedded transport byte cap drops neighbors", async () => {
+    vi.spyOn(serverConstants, "getMaxChatHistoryMessagesBytes").mockReturnValue(1_200);
+    const result = await callGateway<{ messages: unknown[] }>({
+      method: "chat.history",
+      params: { ...selector, limit: 3 },
+    });
+    expect(result.messages.map(readChatHistoryMessageId)).toEqual(["old"]);
+    expect(Buffer.byteLength(JSON.stringify(result.messages))).toBeLessThanOrEqual(1_200);
+  });
+
+  it.each(["self", "sandbox", "cross-agent"])(
+    "keeps %s access restrictions intact",
+    async (restriction) => {
+      const cfg: OpenClawConfig = {
+        ...config,
+        tools: {
+          sessions: {
+            visibility:
+              restriction === "self" ? "self" : restriction === "sandbox" ? "all" : "agent",
+          },
+        },
+      };
+      const tools = toolsFor(cfg, restriction === "sandbox");
+      const target =
+        restriction === "cross-agent" ? { ...selector, sessionKey: "agent:main:other" } : selector;
+      expect((await tools.history.execute("denied", target)).details).toMatchObject({
+        status: "forbidden",
+      });
+      expect(
+        (await tools.search.execute("hidden", { query: "quasar", sessionKey: target.sessionKey }))
+          .details,
+      ).toMatchObject({ status: "forbidden" });
+    },
+  );
+
+  it.each([
+    { offset: 0, messageId: "old", error: "offset and messageId cannot be used together" },
+    { sessionId: scope.sessionId, error: "sessionId requires messageId" },
+  ])("rejects incompatible history selectors: $error", async ({ error, ...params }) => {
+    await expect(
+      callGateway({ method: "chat.history", params: { sessionKey: scope.sessionKey, ...params } }),
+    ).rejects.toThrow(error);
+  });
+});

--- a/src/agents/tools/embedded-gateway-stub.runtime.ts
+++ b/src/agents/tools/embedded-gateway-stub.runtime.ts
@@ -7,6 +7,7 @@
 export { resolveSessionAgentId } from "../../agents/agent-scope.js";
 export { getRuntimeConfig } from "../../config/config.js";
 export { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
+export { resolveTranscriptSessionKeyBySessionId } from "../../config/sessions/session-accessor.js";
 export { searchSessionTranscripts } from "../../config/sessions/session-transcript-search.js";
 export {
   resolveSessionStoreKey,
@@ -19,6 +20,7 @@ export {
   replaceOversizedChatHistoryMessages,
 } from "../../gateway/server-methods/chat.js";
 export {
+  capChatHistoryAroundMessage,
   readChatHistoryPage,
   resolveChatHistoryNextOffset,
   shouldReplayOldestChatHistoryRecord,

--- a/src/agents/tools/embedded-gateway-stub.test.ts
+++ b/src/agents/tools/embedded-gateway-stub.test.ts
@@ -270,19 +270,6 @@ describe("embedded gateway stub", () => {
       params: { sessionKey: "agent:main:main", limit: 1 },
     });
 
-    expect(runtime.readChatHistoryPage).toHaveBeenCalledWith({
-      entry: { sessionId: "sess-main" },
-      provider: "openai",
-      sessionId: "sess-main",
-      storePath: "/tmp/openclaw-sessions.json",
-      sessionAgentId: "main",
-      canonicalKey: "agent:main:main",
-      max: 1,
-      maxHistoryBytes: 100_000,
-      effectiveMaxChars: 100_000,
-      offset: undefined,
-      messageId: undefined,
-    });
     expect(result.messages).toEqual(messages);
     expect(result).not.toHaveProperty("offset");
   });

--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -8,90 +8,27 @@ import type {
   SessionsListParams,
   SessionsResolveParams,
 } from "../../../packages/gateway-protocol/src/index.js";
-import type { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
-import type { searchSessionTranscripts } from "../../config/sessions/session-transcript-search.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CallGatewayOptions } from "../../gateway/call.js";
-import type {
-  readChatHistoryPage,
-  resolveChatHistoryNextOffset,
-  shouldReplayOldestChatHistoryRecord,
-} from "../../gateway/server-methods/chat-history-pages.js";
-import type { SessionsListResult } from "../../gateway/session-utils.types.js";
-import type { SessionsResolveResult } from "../../gateway/sessions-resolve.js";
-import { parseAgentSessionKey } from "../../routing/session-key.js";
-import { readNonNegativeIntegerParam, readPositiveIntegerParam } from "./common.js";
+import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
+import { parseAgentSessionKey, scopeLegacySessionKeyToAgent } from "../../routing/session-key.js";
+import {
+  readNonNegativeIntegerParam,
+  readPositiveIntegerParam,
+  readToolStringParam,
+} from "./common.js";
 
 type EmbeddedCallGateway = <T = Record<string, unknown>>(opts: CallGatewayOptions) => Promise<T>;
 
 const SESSIONS_SEARCH_MAX_QUERY_CHARS = 4096;
 
-interface EmbeddedGatewayRuntime {
-  resolveSessionAgentId: (opts: {
-    sessionKey: string;
-    config: OpenClawConfig;
-    agentId?: string;
-  }) => string;
-  getRuntimeConfig: () => OpenClawConfig;
-  resolveSessionStoreKey: (params: { cfg: OpenClawConfig; sessionKey: string }) => string;
-  resolveStoredSessionKeyForAgentStore: (params: {
-    cfg: OpenClawConfig;
-    agentId: string;
-    sessionKey: string;
-  }) => string;
-  resolveSessionStorePathCore: typeof resolveSessionStorePathCore;
-  searchSessionTranscripts: typeof searchSessionTranscripts;
-  getMaxChatHistoryMessagesBytes: () => number;
-  CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES: number;
-  replaceOversizedChatHistoryMessages: (opts: {
-    messages: unknown[];
-    maxSingleMessageBytes: number;
-  }) => { messages: unknown[] };
-  resolveEffectiveChatHistoryMaxChars: (cfg: OpenClawConfig) => number;
-  capArrayByJsonBytes: (items: unknown[], maxBytes: number) => { items: unknown[] };
-  listSessionsFromStoreAsync: (opts: {
-    cfg: OpenClawConfig;
-    storePath: string;
-    store: unknown;
-    opts: SessionsListParams;
-  }) => Promise<SessionsListResult>;
-  loadCombinedSessionStoreForGatewayCore: (
-    cfg: OpenClawConfig,
-    opts?: { agentId?: string; projection?: "full" | "list" },
-  ) => {
-    storePath: string;
-    store: unknown;
-  };
-  resolveSessionKeyFromResolveParams: (opts: {
-    cfg: OpenClawConfig;
-    client: null;
-    p: SessionsResolveParams;
-  }) => Promise<SessionsResolveResult>;
-  loadSessionEntry: (
-    sessionKey: string,
-    opts?: { agentId?: string },
-  ) => {
-    cfg: OpenClawConfig;
-    storePath: string | undefined;
-    entry: Parameters<typeof readChatHistoryPage>[0]["entry"];
-    canonicalKey: string;
-  };
-  readChatHistoryPage: typeof readChatHistoryPage;
-  resolveChatHistoryNextOffset: typeof resolveChatHistoryNextOffset;
-  shouldReplayOldestChatHistoryRecord: typeof shouldReplayOldestChatHistoryRecord;
-  resolveSessionModelRef: (
-    cfg: OpenClawConfig,
-    entry: unknown,
-    sessionAgentId: string,
-  ) => { provider: string | undefined };
-}
+type EmbeddedGatewayRuntime = typeof import("./embedded-gateway-stub.runtime.js");
 
 let runtimeMod: EmbeddedGatewayRuntime | undefined;
 
 async function getRuntime(): Promise<EmbeddedGatewayRuntime> {
   if (!runtimeMod) {
     // Lazy import keeps embedded tools cheap and gives tests a single mock boundary.
-    runtimeMod = (await import("./embedded-gateway-stub.runtime.js")) as EmbeddedGatewayRuntime;
+    runtimeMod = await import("./embedded-gateway-stub.runtime.js");
   }
   return runtimeMod;
 }
@@ -223,18 +160,49 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
   const requestedAgentId = agentId ?? parsedAgentId;
   const limit = readPositiveIntegerParam(params, "limit");
   const offset = readOffsetParam(params) ?? 0;
+  const messageId = readToolStringParam(params, "messageId", {
+    required: params.messageId !== undefined,
+  });
+  const requestedSessionId = readToolStringParam(params, "sessionId", {
+    required: params.sessionId !== undefined,
+  });
+  if (params.offset !== undefined && messageId !== undefined) {
+    throw new Error("offset and messageId cannot be used together");
+  }
+  if (requestedSessionId !== undefined && messageId === undefined) {
+    throw new Error("sessionId requires messageId");
+  }
 
   const sessionLoadOptions = requestedAgentId ? { agentId: requestedAgentId } : undefined;
   const { cfg, storePath, entry, canonicalKey } = rt.loadSessionEntry(
     sessionKey,
     sessionLoadOptions,
   );
-  const sessionId = entry?.sessionId;
   const sessionAgentId = rt.resolveSessionAgentId({
     sessionKey,
     config: cfg,
     agentId: requestedAgentId,
   });
+  if (requestedSessionId) {
+    const transcriptSessionKey = rt.resolveTranscriptSessionKeyBySessionId({
+      agentId: sessionAgentId,
+      sessionId: requestedSessionId,
+      storePath,
+    });
+    if (
+      !transcriptSessionKey ||
+      scopeLegacySessionKeyToAgent({
+        sessionKey: transcriptSessionKey,
+        agentId: sessionAgentId,
+      }) !== scopeLegacySessionKeyToAgent({ sessionKey: canonicalKey, agentId: sessionAgentId })
+    ) {
+      throw new Error("sessionId does not belong to sessionKey");
+    }
+  }
+  const sessionId = requestedSessionId ?? entry?.sessionId;
+  // Reset archives share a logical key, but not the replacement's start boundary or CLI binding.
+  const historyEntry =
+    requestedSessionId && requestedSessionId !== entry?.sessionId ? undefined : entry;
   const resolvedSessionModel = rt.resolveSessionModelRef(cfg, entry, sessionAgentId);
   const hardMax = 1000;
   const defaultLimit = 200;
@@ -243,7 +211,7 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
   const maxHistoryBytes = rt.getMaxChatHistoryMessagesBytes();
   const effectiveMaxChars = rt.resolveEffectiveChatHistoryMaxChars(cfg);
   const page = await rt.readChatHistoryPage({
-    entry,
+    entry: historyEntry,
     provider: resolvedSessionModel.provider,
     sessionId,
     storePath,
@@ -253,7 +221,7 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
     maxHistoryBytes,
     effectiveMaxChars,
     offset: params.offset === undefined ? undefined : offset,
-    messageId: undefined,
+    messageId,
   });
 
   // Keep transport-level byte limits identical after the shared reader projects the page.
@@ -262,7 +230,15 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
     messages: page.messages,
     maxSingleMessageBytes: perMessageHardCap,
   });
-  const capped = rt.capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
+  const capped = messageId
+    ? (rt.capChatHistoryAroundMessage({
+        messages: replaced.messages,
+        messageId,
+        // Reserve array framing and separators without evicting the requested anchor.
+        maxCost: maxHistoryBytes - 1,
+        messageCost: (message) => jsonUtf8Bytes(message) + 1,
+      }) ?? rt.capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items)
+    : rt.capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
   const pagination = params.offset === undefined ? undefined : page.pagination;
   const nextOffset =
     pagination !== undefined


### PR DESCRIPTION
Closes #136656

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed. This PR uses a branch in the canonical repository.

</details>

## What Problem This Solves

Fixes an issue where users reopening an older session-search hit in local embedded mode would receive the newest message instead of the matched context. Missing message IDs and nonexistent or foreign session IDs also silently returned the newest tail, making invalid recall requests appear successful.

## Why This Change Was Made

The embedded dispatcher discarded both selectors even though the canonical history reader and full Gateway already support them. It now validates physical-session ownership in the selected agent/store, forwards the anchor, excludes replacement-only metadata when reading a retained prior session, and reuses the existing anchor-preserving byte cap. The redundant hand-maintained runtime interface is removed in favor of the runtime module's actual type.

No new storage, schema, configuration, dependency, fallback, or visibility-policy surface is introduced. The bundled session-logs skill remains untouched.

## User Impact

Embedded recall now reopens the matched message, including retained history from before a session reset. Missing SQLite message anchors return an empty history, and missing or foreign physical-session bindings are rejected. Newest-tail reads and session access restrictions retain their existing behavior. The session-search and session-tool docs explain the search-hit selector tuple.

## Evidence

Real `createSessionsSearchTool` and `createSessionsHistoryTool` calls through `createEmbeddedCallGateway` were exercised against fresh synthetic SQLite state, without mocked storage/history readers or an external provider. The independent post-fix rerun passed all nine invariants.

| Scenario | Before | After |
| --- | --- | --- |
| Old search hit, `limit: 1` | Newest assistant message | Matched older user message |
| Missing message ID | Newest message | Empty history |
| Missing or foreign session ID | Newest message | Binding error |
| Retained prior session ID | Replacement session's message | Original matched message |
| Restricted visibility | Denied/hidden | Denied/hidden |

The new boundary suite had **10 failing cases and 3 passing restriction cases before repair; all 13 pass afterward**. The complete focused run passed **120 tests across 9 files**:

```bash
node scripts/run-vitest.mjs src/agents/tools/embedded-gateway-stub.history.test.ts src/agents/tools/embedded-gateway-stub.test.ts src/agents/tools/sessions-history-tool.test.ts src/agents/tools/sessions-search-tool.test.ts src/gateway/session-transcript-readers.test.ts src/gateway/server-methods/chat-history-handler.test.ts src/gateway/server-methods/chat-history-pages.test.ts src/gateway/server-methods/chat-history-budget.test.ts src/config/sessions/session-accessor.sqlite-history-events.test.ts
```

The final changed gate passed core and test typechecks, core/scripts lint, dead-export scans, import-cycle checks, and the selected boundary guards:

```bash
node scripts/check-changed.mjs -- config/assertion-safety-baseline.txt docs/concepts/session-search.md docs/concepts/session-tool.md src/agents/tools/embedded-gateway-stub.ts src/agents/tools/embedded-gateway-stub.runtime.ts src/agents/tools/embedded-gateway-stub.test.ts src/agents/tools/embedded-gateway-stub.history.test.ts
```

Formatting and `git diff --check` passed. Removing the redundant runtime cast required tightening the assertion baseline from 8 to 7; the initial ratchet failure was resolved by that shrink, not by weakening validation. Fresh pre-commit Codex autoreview completed successfully with no findings at its requested P0-only threshold; exact-head CI and native review results are recorded below.

**Scope:** production +54/−76 (**net −22**); tests +192/−13 (**net +179**); documentation and the shrink-only assertion ratchet are separate. No lazy import boundary moved. No full local build or live-channel E2E was run: this defect is in standalone embedded dispatch, while the Control UI uses the already-correct full Gateway handler and does not exercise it. The real tool/SQLite boundary reproduction is the relevant operator-visible proof.

**Follow-up:** separately investigate missing-anchor behavior in external CLI-imported history. This repair does not change that existing shared-reader path.

**Pre-landing checkpoint:** [CI run 33688158935](https://github.com/openclaw/openclaw/actions/runs/33688158935) completed successfully on `57bd8216a0799dafd0a8e4671c05da5b74b95998`, including [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33688158935/job/100445744910). The native watcher exited 0 with GREEN; the consolidated snapshot has 181 passing checks, 51 skipped checks, and no pending or failed checks. Native review artifacts validated with zero findings. [ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/136657#issuecomment-5517147861) found no correctness/security issues and listed no before-merge actions or Rank-up moves. No source changes or CI reruns were needed during publication. Prepare and merge are paused at the final maintainer checkpoint.
