### PR TITLE
fix(backup): retain the active config through volatile filtering

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -285,6 +285,8 @@ During archive creation, OpenClaw excludes known live-mutation paths before `tar
 | `sandbox/skills-workspaces/**`               | All entries                                           |
 | Any path under the backed-up state directory | `.sock`, `.pid`, `.tmp`                               |
 
+The active config file remains included even when its name or location matches a rule above. This exception keeps only the selected config file; neighboring files under excluded directories stay out of the archive.
+
 These rules do not filter workspace files outside the state directory. They also omit completed transcript and log files that match the table, so retain those records separately when needed. The JSON result's `skippedVolatileCount` reports intentionally omitted volatile entries; regenerable agent temporary roots are listed separately in `skipped` and are not included in that count.
 
 Chromium singleton entries coordinate one running browser on one host and are recreated when that profile starts; the rest of the profile's `user-data/` remains in the archive. Sandbox skills workspaces are generated copies of current skill sources and are materialized again when OpenClaw prepares the next sandbox context after restore; adjacent sandbox registry and other durable state remain included.

--- a/src/commands/backup-resource-inventory.ts
+++ b/src/commands/backup-resource-inventory.ts
@@ -2,6 +2,7 @@
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isVolatileBackupPath } from "../infra/backup-volatile-filter.js";
 import { hasErrnoCode } from "../infra/errno.js";
 import type { ResolvedPluginBackupResource } from "../plugins/manifest-backup-resources.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
@@ -32,6 +33,7 @@ export type BackupResourceInventory = Readonly<{
   isIncluded: (sourcePath: string) => boolean;
   isTraversable: (sourcePath: string) => boolean;
   isPackageContent: (sourcePath: string) => boolean;
+  isVolatile: (sourcePath: string) => boolean;
 }>;
 
 const MANAGED_STATE_ROOTS = ["dev", "git", "npm", "npm-runtime", "tmp", "tools"] as const;
@@ -108,6 +110,7 @@ export async function createBackupResourceInventory(params: {
   onlyConfig?: boolean;
 }): Promise<BackupResourceInventory> {
   const stateDir = path.resolve(params.stateDir);
+  const configPath = path.resolve(params.configPath);
   const agentRoots = Object.freeze(
     params.agentRoots.map((root) =>
       Object.freeze({
@@ -118,7 +121,7 @@ export async function createBackupResourceInventory(params: {
     ),
   );
   const protectedPathSet = new Set<string>([
-    path.resolve(params.configPath),
+    configPath,
     resolveOpenClawStateSqlitePath({ ...process.env, OPENCLAW_STATE_DIR: stateDir }),
   ]);
   const regenerableRoots: BackupRegenerableRoot[] = [];
@@ -241,6 +244,11 @@ export async function createBackupResourceInventory(params: {
     }
     return segments.includes("node_modules");
   };
+  const volatilePlan = { stateDirs: [stateDir] };
+  // Keep the explicit config file; the planner selects it separately when a
+  // volatile parent would otherwise prune it along with its neighbors.
+  const isVolatile = (sourcePath: string): boolean =>
+    path.resolve(sourcePath) !== configPath && isVolatileBackupPath(sourcePath, volatilePlan);
 
   return Object.freeze({
     stateDir,
@@ -249,5 +257,6 @@ export async function createBackupResourceInventory(params: {
     isIncluded,
     isTraversable,
     isPackageContent,
+    isVolatile,
   });
 }

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -196,9 +196,10 @@ async function resolveBackupPlanFromPaths(params: {
   const configInsideState = params.configInsideState ?? false;
   const oauthInsideState = params.oauthInsideState ?? false;
   const canonicalStateDir = await canonicalizePathForContainment(stateDir);
+  const configSourcePath = await canonicalizePathForContainment(configPath);
   const inventory = await createBackupResourceInventory({
     stateDir: canonicalStateDir,
-    configPath: await canonicalizePathForContainment(configPath),
+    configPath: configSourcePath,
     oauthDir: await canonicalizePathForContainment(oauthDir),
     workspaceDirs: await Promise.all(
       workspaceDirs.map((workspaceDir) => canonicalizePathForContainment(workspaceDir)),
@@ -263,9 +264,22 @@ async function resolveBackupPlanFromPaths(params: {
     };
   }
 
+  const isConfigCoveredBy = (sourceRoot: string): boolean => {
+    let ancestor = configSourcePath;
+    while (isPathWithin(ancestor, sourceRoot)) {
+      if (inventory.isVolatile(ancestor)) {
+        return false;
+      }
+      if (ancestor === sourceRoot) {
+        return true;
+      }
+      ancestor = path.dirname(ancestor);
+    }
+    return false;
+  };
   const rawCandidates: Array<Pick<BackupAssetCandidate, "kind" | "sourcePath">> = [
     { kind: "state", sourcePath: path.resolve(stateDir) },
-    ...(configInsideState
+    ...(configInsideState && isConfigCoveredBy(canonicalStateDir)
       ? []
       : [{ kind: "config" as const, sourcePath: path.resolve(configPath) }]),
     ...(oauthInsideState
@@ -336,7 +350,9 @@ async function resolveBackupPlanFromPaths(params: {
     }
 
     const coveredBy = included.find((asset) =>
-      isPathWithin(candidate.canonicalPath, asset.sourcePath),
+      candidate.kind === "config"
+        ? isConfigCoveredBy(asset.sourcePath)
+        : isPathWithin(candidate.canonicalPath, asset.sourcePath),
     );
     if (coveredBy) {
       skipped.push({

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -572,7 +572,8 @@ describe("createBackupVolatileStatCache", () => {
         await state.writeText("settings.json", '{"keep":true}\n');
         const archivePath = state.path("volatile-stat-cache.tar.gz");
         const volatilePlan = { stateDirs: [state.stateDir] };
-        const statCache = createBackupVolatileStatCache(volatilePlan);
+        const isVolatile = (entryPath: string) => isVolatileBackupPath(entryPath, volatilePlan);
+        const statCache = createBackupVolatileStatCache(isVolatile);
         const getCachedStat = statCache.get.bind(statCache);
         let removedBeforeStat = false;
 
@@ -591,7 +592,7 @@ describe("createBackupVolatileStatCache", () => {
             portable: true,
             preservePaths: true,
             statCache,
-            filter: (entryPath) => !isVolatileBackupPath(entryPath, volatilePlan),
+            filter: (entryPath) => !isVolatile(entryPath),
           },
           [state.stateDir],
         );
@@ -606,6 +607,115 @@ describe("createBackupVolatileStatCache", () => {
 });
 
 describe("createBackupArchive", () => {
+  it.each<{
+    configRelativePath: string;
+    onlyConfig: boolean;
+    malformed: boolean;
+    volatileParent?: boolean;
+    absoluteNeighbor?: boolean;
+  }>([
+    { configRelativePath: "openclaw.json.tmp", onlyConfig: false, malformed: false },
+    { configRelativePath: "openclaw.json.tmp", onlyConfig: true, malformed: false },
+    {
+      configRelativePath: "sandbox/skills-workspaces/operator/openclaw.json",
+      onlyConfig: false,
+      malformed: false,
+      volatileParent: true,
+    },
+    {
+      configRelativePath: "sandbox/skills-workspaces/operator/openclaw.json",
+      onlyConfig: true,
+      malformed: false,
+      volatileParent: true,
+    },
+    { configRelativePath: "openclaw.json.tmp", onlyConfig: true, malformed: true },
+    {
+      configRelativePath: "cache.tmp/ordinary/openclaw.json",
+      onlyConfig: false,
+      malformed: false,
+      volatileParent: true,
+    },
+    {
+      configRelativePath: "cache.tmp/ordinary/openclaw.json",
+      onlyConfig: true,
+      malformed: false,
+      volatileParent: true,
+    },
+    {
+      configRelativePath: "cache.tmp/linked/openclaw.json",
+      onlyConfig: false,
+      malformed: false,
+      volatileParent: true,
+      absoluteNeighbor: true,
+    },
+    {
+      configRelativePath: "logs/history.log/openclaw.json",
+      onlyConfig: false,
+      malformed: false,
+      volatileParent: true,
+    },
+  ])(
+    "archives active config bytes at $configRelativePath (onlyConfig=$onlyConfig, malformed=$malformed)",
+    async ({ configRelativePath, onlyConfig, malformed, volatileParent, absoluteNeighbor }) => {
+      await withOpenClawTestState(
+        { layout: "state-only", prefix: "openclaw-backup-active-config-" },
+        async (state) => {
+          const configPath = state.statePath(...configRelativePath.split("/"));
+          const configRaw = malformed ? '{"gateway":' : '{"gateway":{"mode":"local"}}\n';
+          state.envVars.OPENCLAW_CONFIG_PATH = configPath;
+          state.applyEnv();
+          await fs.mkdir(path.dirname(configPath), { recursive: true });
+          await fs.writeFile(configPath, configRaw);
+          await state.writeText("logs/live.log", "live log\n");
+          await state.writeText("scratch.tmp", "temporary state\n");
+          await state.writeText(
+            "sandbox/skills-workspaces/other/generated.json",
+            "generated state\n",
+          );
+          await fs.writeFile(path.join(path.dirname(configPath), "neighbor.tmp"), "temporary\n");
+          await fs.writeFile(path.join(path.dirname(configPath), "neighbor.json"), "{}\n");
+          if (absoluteNeighbor && process.platform !== "win32") {
+            const target = state.path("unrelated.txt");
+            await fs.writeFile(target, "unrelated synthetic file\n");
+            await fs.symlink(target, path.join(path.dirname(configPath), "absolute-link"));
+          }
+
+          const archive = await createBackupArchive({
+            output: state.path("backup.tar.gz"),
+            includeWorkspace: false,
+            onlyConfig,
+          });
+          const entries = await listArchiveEntries(archive.archivePath);
+          const configEntries = entries.filter((entry) =>
+            entry.endsWith(`/state/${configRelativePath}`),
+          );
+          expect(configEntries).toHaveLength(1);
+          expect(entries.some((entry) => entry.endsWith("/live.log"))).toBe(false);
+          expect(
+            entries.some((entry) => entry.endsWith(".tmp") && !configEntries.includes(entry)),
+          ).toBe(false);
+          expect(entries.some((entry) => entry.includes("/skills-workspaces/other"))).toBe(false);
+          expect(entries.some((entry) => entry.endsWith("/neighbor.json"))).toBe(
+            !onlyConfig && !volatileParent,
+          );
+          expect(entries.some((entry) => entry.endsWith("/absolute-link"))).toBe(false);
+          if (onlyConfig) {
+            expect(entries).toHaveLength(2);
+          }
+
+          const extractDir = state.path("extract");
+          await fs.mkdir(extractDir);
+          await tar.x({ file: archive.archivePath, gzip: true, cwd: extractDir });
+          const configEntry = expectDefined(configEntries[0], "active config archive entry");
+          expect(await fs.readFile(path.join(extractDir, configEntry), "utf8")).toBe(configRaw);
+          await expect(verifyBackupArchive(archive.archivePath)).resolves.toMatchObject({
+            ok: true,
+          });
+        },
+      );
+    },
+  );
+
   it.runIf(process.platform !== "win32").each([
     {
       layout: "direct",

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -35,7 +35,6 @@ import {
   createBackupSqliteSnapshotPlan,
 } from "./backup-sqlite-snapshot.js";
 import { writeTarArchiveWithRetry } from "./backup-tar-retry.js";
-import { isVolatileBackupPath } from "./backup-volatile-filter.js";
 import {
   createBackupLinkCache,
   createBackupVolatileStatCache,
@@ -238,50 +237,34 @@ async function chooseBackupTempRoot(params: {
   return fallback;
 }
 
-function buildManifest(params: {
-  createdAt: string;
-  archiveRoot: string;
-  includeWorkspace: boolean;
-  onlyConfig: boolean;
-  assets: BackupAsset[];
-  skipped: BackupCreateResult["skipped"];
-  stateDir: string;
-  configPath: string;
-  oauthDir: string;
-  workspaceDirs: string[];
-  agentRoots: readonly BackupAgentRoot[];
-}): BackupManifest {
+function buildManifest(
+  result: BackupCreateResult,
+  plan: Awaited<ReturnType<typeof resolveBackupPlanFromDisk>>,
+): BackupManifest {
   return {
     schemaVersion: 1,
-    createdAt: params.createdAt,
-    archiveRoot: params.archiveRoot,
+    createdAt: result.createdAt,
+    archiveRoot: result.archiveRoot,
     runtimeVersion: resolveRuntimeServiceVersion(),
     platform: process.platform,
     nodeVersion: process.version,
     options: {
-      includeWorkspace: params.includeWorkspace,
-      onlyConfig: params.onlyConfig,
+      includeWorkspace: result.includeWorkspace,
+      onlyConfig: result.onlyConfig,
     },
     paths: {
-      stateDir: params.stateDir,
-      configPath: params.configPath,
-      oauthDir: params.oauthDir,
-      workspaceDirs: params.workspaceDirs,
-      ...(params.onlyConfig
-        ? {}
-        : {
-            agentRoots: params.agentRoots.map(({ agentId, sourcePath }) => ({
-              agentId,
-              sourcePath,
-            })),
-          }),
+      stateDir: plan.stateDir,
+      configPath: plan.configPath,
+      oauthDir: plan.oauthDir,
+      workspaceDirs: plan.workspaceDirs,
+      ...(result.agentRoots ? { agentRoots: [...result.agentRoots] } : {}),
     },
-    assets: params.assets.map((asset) => ({
+    assets: result.assets.map((asset) => ({
       kind: asset.kind,
       sourcePath: asset.sourcePath,
       archivePath: asset.archivePath,
     })),
-    skipped: params.skipped.map((entry) => ({
+    skipped: result.skipped.map((entry) => ({
       kind: entry.kind,
       sourcePath: entry.sourcePath,
       reason: entry.reason,
@@ -465,24 +448,11 @@ export async function createBackupArchive(
         skippedStateSourcePaths.add(skippedSourcePath);
       }
     }
-    const manifest = buildManifest({
-      createdAt,
-      archiveRoot,
-      includeWorkspace,
-      onlyConfig,
-      assets: result.assets,
-      skipped: result.skipped,
-      stateDir: plan.stateDir,
-      configPath: plan.configPath,
-      oauthDir: plan.oauthDir,
-      workspaceDirs: plan.workspaceDirs,
-      agentRoots: plan.inventory.agentRoots,
-    });
+    const manifest = buildManifest(result, plan);
     await writeJson(manifestPath, manifest, { trailingNewline: true });
 
     const tar = await loadTarRuntime();
     const gatewayLockDir = resolveGatewayLockDir(plan.stateDir);
-    const volatilePlan = { stateDirs: [stateAsset?.sourcePath ?? plan.stateDir] };
     let skippedVolatileCount = 0;
     // node-tar invokes filter/onWriteEntry from async filesystem callbacks, so
     // collect violations there and reject only after tar settles.
@@ -536,7 +506,7 @@ export async function createBackupArchive(
         unexpectedSqliteSourcePaths.push(entryPath);
         return false;
       }
-      if (isVolatileBackupPath(entryPath, volatilePlan)) {
+      if (plan.inventory.isVolatile(resolvedEntryPath)) {
         skippedVolatileCount += 1;
         return false;
       }
@@ -561,7 +531,7 @@ export async function createBackupArchive(
                 portable: true,
                 preservePaths: true,
                 linkCache: createBackupLinkCache(),
-                statCache: createBackupVolatileStatCache(volatilePlan),
+                statCache: createBackupVolatileStatCache(plan.inventory.isVolatile),
                 filter: (entryPath, entryStat) => {
                   reportProgress({ phase: "traversal", entryPath });
                   return tarFilter(entryPath, entryStat);

--- a/src/infra/backup-sqlite-snapshot.ts
+++ b/src/infra/backup-sqlite-snapshot.ts
@@ -13,7 +13,7 @@ import {
   sanitizeOpenClawGlobalStateSnapshot,
   sanitizeOpenClawStateLeaseRows,
 } from "../state/openclaw-state-snapshot-sanitizer.js";
-import { isTransientSqliteBackupPath, isVolatileBackupPath } from "./backup-volatile-filter.js";
+import { isTransientSqliteBackupPath } from "./backup-volatile-filter.js";
 import { hasErrnoCode } from "./errno.js";
 import { formatErrorMessage } from "./errors.js";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
@@ -121,7 +121,6 @@ async function discoverBackupSqliteSources(params: {
   const discoveredSourcePaths = new Set<string>();
   const visitedDirectories = new Set<string>();
   const gatewayLockDir = resolveGatewayLockDir(params.inventory.stateDir);
-  const volatilePlan = { stateDirs: [params.inventory.stateDir] };
 
   async function visit(directoryPath: string): Promise<void> {
     const resolvedDirectoryPath = path.resolve(directoryPath);
@@ -142,10 +141,7 @@ async function discoverBackupSqliteSources(params: {
 
     for (const entry of entries) {
       const entryPath = path.join(resolvedDirectoryPath, entry.name);
-      if (
-        isPathWithin(entryPath, gatewayLockDir) ||
-        isVolatileBackupPath(entryPath, volatilePlan)
-      ) {
+      if (isPathWithin(entryPath, gatewayLockDir) || params.inventory.isVolatile(entryPath)) {
         continue;
       }
       if (entry.isDirectory()) {

--- a/src/infra/backup-volatile-stat-cache.ts
+++ b/src/infra/backup-volatile-stat-cache.ts
@@ -1,7 +1,5 @@
 import type { Stats } from "node:fs";
-import { isVolatileBackupPath } from "./backup-volatile-filter.js";
 
-type VolatileFilterPlan = Parameters<typeof isVolatileBackupPath>[1];
 type BackupLinkCacheKey = `${number}:${number}`;
 
 const VOLATILE_BACKUP_SYNTHETIC_STAT = {
@@ -15,7 +13,7 @@ const VOLATILE_BACKUP_SYNTHETIC_STAT = {
 } as unknown as Stats;
 
 class BackupVolatileStatCache extends Map<string, Stats> {
-  constructor(private readonly volatilePlan: VolatileFilterPlan) {
+  constructor(private readonly isVolatilePath: (sourcePath: string) => boolean) {
     super();
   }
 
@@ -26,9 +24,7 @@ class BackupVolatileStatCache extends Map<string, Stats> {
     }
     // node-tar consults this cache before lstat. Synthetic hits let known
     // volatile paths disappear during a live backup without aborting it.
-    return isVolatileBackupPath(key, this.volatilePlan)
-      ? VOLATILE_BACKUP_SYNTHETIC_STAT
-      : undefined;
+    return this.isVolatilePath(key) ? VOLATILE_BACKUP_SYNTHETIC_STAT : undefined;
   }
 }
 
@@ -45,9 +41,9 @@ class BackupLinkCache extends Map<BackupLinkCacheKey, string> {
 }
 
 export function createBackupVolatileStatCache(
-  volatilePlan: VolatileFilterPlan,
+  isVolatilePath: (sourcePath: string) => boolean,
 ): Map<string, Stats> {
-  return new BackupVolatileStatCache(volatilePlan);
+  return new BackupVolatileStatCache(isVolatilePath);
 }
 
 export function createBackupLinkCache(): Map<BackupLinkCacheKey, string> {


### PR DESCRIPTION
Fixes #136665.

## What Problem This Solves

A verified backup could silently omit the active config when its name or parent matched a volatile-file exclusion. Config-only backups of the same file failed verification. The selected config is now included exactly once, with its original bytes, while neighboring excluded files stay out.

## Why This Change Was Made

The immutable backup inventory now owns the shared volatile predicate. It exempts only the exact canonical config file. Planning checks whether a covering asset can actually reach that file; when a volatile parent would prune it, the planner adds the existing `config` asset type separately. Tar's pre-lstat stat cache, final filter and SQLite discovery consume the same predicate.

The manifest now projects the already prepared result and plan, deleting the duplicate eleven-field forwarding structure and repeated agent-root mapping. Production **+53 / −66 = −13 LOC**; tests **+112 / −2 = +110**; docs **+2**.

## User Impact

Active config files such as `openclaw.json.tmp` and configs beneath excluded generated directories survive full and config-only backups. Malformed config-only recovery still preserves the original bytes. Default and suffix-only manifest shapes remain unchanged; an otherwise pruned config uses a separate existing config asset. Missing-config behavior, volatile neighbors, link rejection, SQLite snapshots, archive validation and output publication are preserved. No new option, storage schema or dependency is introduced.

## Evidence

- Five original real-archive regressions fail before the repair. The final nine-case matrix and **204 owner/sibling tests** pass across three native Vitest shards, including snapshot/restore, sidecars, sanitization, symlinks, volatile-file disappearance and stream cleanup. Platform-named tests ran on macOS; this does not claim a native Windows run.
- Canonical full build and the complete seven-file changed gate pass. Independent cumulative Codex review is clean through P2 in one connected pass with frozen inputs.
- **38 actual compiled CLI calls, 15 created archives and one actual restore** exercise config set/get/file, full/config-only create-and-verify, volatile ancestor neighbors and absolute links, malformed and missing configs, and a state root named `state.tmp`. Archive extraction proves exact config bytes; restore proves the config and SQLite are present and the neighbor is absent. Every child exited and synthetic state was removed.
- The original full backup reported `verified: true` without the config. The final archive includes it exactly once. Ordinary manifest fields remain unchanged. Final CLI entry SHA256: `4b48d748559503adc19a241d0e20ce4254d8ff10e24a5e1ca8d92bb17d9c7138`.
- Independent review caught a first-candidate defect: opening excluded ancestors admitted neighboring JSON and exposed an absolute symlink. Actual CLI/archive reproductions confirmed it. The final planner keeps the parent pruned and selects only the config. This is a resolved candidate finding, not an additional original issue.
- Root directly inspected the complete inventory/planner, archive consumers, original and final proof drivers/results, stable/current-main differences and installed tar 7.5.22 Pack/WriteEntry. Tar consults its stat cache before lstat/filter, so a final-filter-only exception cannot restore a file already represented by a synthetic unsupported entry.

The proof used isolated synthetic state. No operator Gateway or real backup was touched. The Nix symlink repairs in #136343 and #136486 remain separate: this change preserves the existing absolute-link rejection contract.

## Final dependency review

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/136666#issuecomment-5517216902) has no correctness or security finding. Its sole remaining item requests direct dependency inspection. I inspected the installed locked `tar@7.5.22`: `dist/commonjs/pack.js:369-439` consults the supplied stat cache before performing `lstat` and filtering; `dist/commonjs/write-entry.js:115-218` ends an entry without payload for the synthetic excluded type. That explains why a downstream tar filter alone cannot recover a selected config rejected by the earlier cache.

The immutable inventory now supplies the same exact-file exception to planning, stat caching, tar filtering and SQLite discovery. The actual compiled CLI archive/verify/extract/restore matrix confirms the configured file survives while volatile neighbors remain excluded; the volatile-state-root control retains the existing SQLite snapshot. This completes the dependency-contract item. The separate Nix absolute-symlink proposals remain distinct work.

The [required CI gate](https://github.com/openclaw/openclaw/actions/runs/33689072605/job/100448506615) passes on `f7c5706db74104d75c2478fba2778bb401583a82`. The final check snapshot has no pending or failed checks. Direct dependency inspection and native archive/restore proof resolve the review's remaining item; no Rank-up move remains.
