### PR TITLE
refactor(test): centralize forwarded signal state

### DIFF
--- a/scripts/lib/test-projects-delegation.mts
+++ b/scripts/lib/test-projects-delegation.mts
@@ -29,7 +29,6 @@ export function resolveTestProjectsRunnerSpawnParams(
 export function spawnTestProjectsRunner(argv: string[], env: NodeJS.ProcessEnv) {
   const repoRoot = resolveRepoRoot(import.meta.url);
   const testProjectsRunnerPath = path.join(repoRoot, "scripts", "test-projects-child.mts");
-  let forwardedSignal: NodeJS.Signals | null = null;
   const spawnParams = resolveTestProjectsRunnerSpawnParams(env);
   const child = spawn(
     process.execPath,
@@ -38,15 +37,10 @@ export function spawnTestProjectsRunner(argv: string[], env: NodeJS.ProcessEnv) 
   );
   // The orchestrator must join its bounded native children and record their outcomes.
   // A competing leaf-sized force timer kills it before that cleanup can complete.
-  const teardown = installVitestProcessGroupCleanup({
-    child,
-    onSignal: (signal) => {
-      forwardedSignal ??= signal;
-    },
-  });
+  const cleanup = installVitestProcessGroupCleanup({ child });
   const completion = createVitestProcessCompletion({
     child,
     detached: spawnParams.detached,
-  }).finally(teardown);
-  return { child, completion, getForwardedSignal: () => forwardedSignal };
+  }).finally(cleanup.teardown);
+  return { child, completion, getForwardedSignal: cleanup.getForwardedSignal };
 }

--- a/scripts/lib/vitest-batch-runner.mts
+++ b/scripts/lib/vitest-batch-runner.mts
@@ -27,7 +27,6 @@ const repoRoot = path.resolve(scriptDir, "../..");
  */
 export async function runVitestBatch(params: VitestBatchRunParams): Promise<number> {
   return await new Promise<number>((resolve, reject) => {
-    let forwardedSignal: NodeJS.Signals | undefined;
     // Match project runs: installed tooling must not rediscover pnpm in an isolated HOME.
     const { child, completion } = spawnOwnedVitestProcess({
       homeMode:
@@ -48,16 +47,14 @@ export async function runVitestBatch(params: VitestBatchRunParams): Promise<numb
       ],
       options: { cwd: repoRoot, env: params.env, stdio: "inherit" },
     });
-    const teardownChildCleanup = installVitestProcessGroupCleanup({
+    const cleanup = installVitestProcessGroupCleanup({
       child,
       forceSignal: "SIGKILL",
       forceSignalDelayMs: 100,
-      onSignal(signal: NodeJS.Signals) {
-        forwardedSignal ??= signal;
-      },
     });
-    completion.finally(teardownChildCleanup).then((result) => {
+    completion.finally(cleanup.teardown).then((result) => {
       const { code, signal } = result;
+      const forwardedSignal = cleanup.getForwardedSignal();
       if (params.onComplete) {
         const outcome = { code: code ?? 1, signal: forwardedSignal ?? signal };
         params.onComplete(outcome);

--- a/scripts/run-vitest-profile.mts
+++ b/scripts/run-vitest-profile.mts
@@ -109,16 +109,13 @@ async function main() {
     }),
     options: { env: process.env, stdio: "inherit" },
   });
-  let forwardedSignal: NodeJS.Signals | undefined;
-  const teardown = installVitestProcessGroupCleanup({
+  const cleanup = installVitestProcessGroupCleanup({
     child,
     forceSignal: "SIGKILL",
     forceSignalDelayMs: 100,
-    onSignal: (signal) => {
-      forwardedSignal ??= signal;
-    },
   });
-  const result = await completion.finally(teardown);
+  const result = await completion.finally(cleanup.teardown);
+  const forwardedSignal = cleanup.getForwardedSignal();
   if (forwardedSignal) {
     console.error(`[run-vitest-profile] FAILED (exit ${signalExitCode(forwardedSignal)})`);
     process.kill(process.pid, forwardedSignal);

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -1217,7 +1217,6 @@ export function spawnWatchedVitestProcess({
   if (homeMode !== "tooling") {
     assertTestHomeSelection(env, homeMode);
   }
-  let forwardedSignal: NodeSignal | null = null;
   let diagnosticsCompletion: Promise<void> | null = null;
   const directNodeArgs = resolveDirectNodeVitestArgs(pnpmArgs);
   if (workerRun && directNodeArgs) {
@@ -1254,13 +1253,10 @@ export function spawnWatchedVitestProcess({
       : createPnpmRunnerSpawnSpec({ pnpmArgs, ...childSpawnParams })),
     homeMode,
   });
-  const teardownChildCleanup = installVitestProcessGroupCleanup({
+  const childCleanup = installVitestProcessGroupCleanup({
     child,
     forceSignal: "SIGKILL",
     forceSignalDelayMs: 100,
-    onSignal: (signal) => {
-      forwardedSignal ??= signal;
-    },
   });
   const teardownNoOutputWatchdog = installVitestNoOutputWatchdog({
     streams: [child.stdout, child.stderr],
@@ -1300,7 +1296,7 @@ export function spawnWatchedVitestProcess({
   ]);
 
   const teardown = () => {
-    teardownChildCleanup();
+    childCleanup.teardown();
     teardownNoOutputWatchdog();
   };
   const completion = Promise.all([childCompletion, forwardedOutput])
@@ -1317,7 +1313,7 @@ export function spawnWatchedVitestProcess({
   return {
     child,
     completion: workerRun ? workerRun.borrow(child, completion) : completion,
-    getForwardedSignal: () => forwardedSignal,
+    getForwardedSignal: childCleanup.getForwardedSignal,
     teardown,
   };
 }

--- a/scripts/test-live-shard.mts
+++ b/scripts/test-live-shard.mts
@@ -61,7 +61,6 @@ const SKIPPED_ASSERTION_STATUSES = new Set(["disabled", "pending", "skipped", "t
 const QA_RUNTIME_LIVE_TEST = "extensions/qa-lab/src/matrix-channel-driver.lifecycle.live.test.ts";
 const QA_RUNTIME_ARTIFACT = "dist/extensions/qa-lab/runtime-api.js";
 const SOURCE_PERFORMANCE_ARTIFACT = `dist/${RUNTIME_POSTBUILD_STAMP_FILE}`;
-type ProcessSignal = `SIG${string}`;
 type LiveShardPreparation = {
   env: NodeJS.ProcessEnv;
   profile: string;
@@ -840,19 +839,16 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
     pnpmArgs: buildLiveShardPnpmArgs(files, addLiveShardReportArgs(passthroughArgs, reportPath)),
     ...spawnParams,
   });
-  let forwardedSignal: ProcessSignal | null = null;
-  const teardown = installVitestProcessGroupCleanup({
+  const cleanup = installVitestProcessGroupCleanup({
     child,
     forceSignal: "SIGKILL",
     forceSignalDelayMs: 100,
-    onSignal: (signal) => {
-      forwardedSignal ??= signal;
-    },
   });
   createVitestProcessCompletion({ child, detached: spawnParams.detached })
-    .finally(teardown)
+    .finally(cleanup.teardown)
     .then(
       ({ code, signal }) => {
+        const forwardedSignal = cleanup.getForwardedSignal();
         if (forwardedSignal) {
           process.kill(process.pid, forwardedSignal);
           return;

--- a/scripts/test-live.mts
+++ b/scripts/test-live.mts
@@ -166,19 +166,15 @@ export function main(argv = process.argv.slice(2), baseEnv = process.env) {
     }),
     homeMode: resolveVitestHomeSelection(buildTestLivePnpmArgs(args), { env }),
   });
-  let forwardedSignal: NodeJS.Signals | null = null;
-  const teardownChildCleanup = installVitestProcessGroupCleanup({
+  const childCleanup = installVitestProcessGroupCleanup({
     child,
     forceSignal: "SIGKILL",
     forceSignalDelayMs: 100,
-    onSignal: (signal) => {
-      forwardedSignal ??= signal;
-    },
   });
 
   const teardown = () => {
     clearInterval(heartbeat);
-    teardownChildCleanup();
+    childCleanup.teardown();
   };
 
   const noteOutput = () => {
@@ -225,6 +221,7 @@ export function main(argv = process.argv.slice(2), baseEnv = process.env) {
 
   completion.finally(teardown).then(
     ({ code, signal }) => {
+      const forwardedSignal = childCleanup.getForwardedSignal();
       if (forwardedSignal) {
         process.kill(process.pid, forwardedSignal);
         return;

--- a/scripts/vitest-process-group.mts
+++ b/scripts/vitest-process-group.mts
@@ -22,7 +22,6 @@ type CleanupParams = ProcessGroupParams & {
   forceSignal?: VitestProcessSignal | null;
   forceSignalDelayMs?: number;
   forwardedSignals?: VitestProcessSignal[];
-  onSignal?: (signal: VitestProcessSignal) => void;
   processObject?: NodeJS.Process;
 };
 type DiagnosticsProbe = (
@@ -631,9 +630,10 @@ export function installVitestProcessGroupCleanup(params: CleanupParams) {
   const forceSignalDelayMs = params.forceSignalDelayMs ?? 0;
   const forwardedSignals = params.forwardedSignals ?? ["SIGINT", "SIGTERM"];
   const child = params.child;
-  const onSignal = params.onSignal;
 
   let active = true;
+  // Parent interruption remains authoritative after teardown; exit cleanup must not claim it.
+  let forwardedSignal: VitestProcessSignal | undefined;
 
   const forward = (signal: VitestProcessSignal) => {
     if (!active) {
@@ -650,7 +650,7 @@ export function installVitestProcessGroupCleanup(params: CleanupParams) {
   const signalHandlers = new Map<VitestProcessSignal, () => void>();
   for (const signal of forwardedSignals) {
     const handler = () => {
-      onSignal?.(signal);
+      forwardedSignal ??= signal;
       forward(signal);
       if (forceSignal) {
         if (forceSignalDelayMs > 0) {
@@ -671,14 +671,17 @@ export function installVitestProcessGroupCleanup(params: CleanupParams) {
   ensureProcessListenerCapacity(processObject, "exit");
   processObject.on("exit", exitHandler);
 
-  return () => {
-    if (!active) {
-      return;
-    }
-    active = false;
-    for (const [signal, handler] of signalHandlers) {
-      processObject.off(signal, handler);
-    }
-    processObject.off("exit", exitHandler);
+  return {
+    getForwardedSignal: () => forwardedSignal,
+    teardown: () => {
+      if (!active) {
+        return;
+      }
+      active = false;
+      for (const [signal, handler] of signalHandlers) {
+        processObject.off(signal, handler);
+      }
+      processObject.off("exit", exitHandler);
+    },
   };
 }

--- a/test/scripts/vitest-process-group.test.ts
+++ b/test/scripts/vitest-process-group.test.ts
@@ -374,7 +374,7 @@ describe("vitest process group helpers", () => {
     expect(kill).not.toHaveBeenCalled();
   });
 
-  it("installs and removes process cleanup listeners", () => {
+  it("retains the first parent signal while installing and removing cleanup listeners", () => {
     const listeners = new Map<string, Set<() => void>>();
     const fakeProcess = {
       on(event: string, handler: () => void) {
@@ -387,27 +387,32 @@ describe("vitest process group helpers", () => {
       },
     };
     const kill = vi.fn();
-    const onSignal = vi.fn();
-    const teardown = installVitestProcessGroupCleanup({
+    const cleanup = installVitestProcessGroupCleanup({
       child: { pid: 4200 },
       processObject: fakeProcess as unknown as NodeJS.Process,
       platform: "darwin",
       kill,
-      onSignal,
     });
 
     expectListenerCount(listeners, "SIGINT", 1);
     expectListenerCount(listeners, "SIGTERM", 1);
     expectListenerCount(listeners, "exit", 1);
+    expect(cleanup.getForwardedSignal()).toBeUndefined();
 
+    getListenerSet(listeners, "exit").values().next().value!();
+    expect(kill).toHaveBeenNthCalledWith(1, -4200, "SIGTERM");
+    expect(cleanup.getForwardedSignal()).toBeUndefined();
     getListenerSet(listeners, "SIGTERM").values().next().value!();
-    expect(onSignal).toHaveBeenCalledWith("SIGTERM");
-    expect(kill).toHaveBeenCalledWith(-4200, "SIGTERM");
+    getListenerSet(listeners, "SIGINT").values().next().value!();
+    expect(kill).toHaveBeenNthCalledWith(2, -4200, "SIGTERM");
+    expect(kill).toHaveBeenNthCalledWith(3, -4200, "SIGINT");
+    expect(cleanup.getForwardedSignal()).toBe("SIGTERM");
 
-    teardown();
+    cleanup.teardown();
     expectListenerCount(listeners, "SIGINT", 0);
     expectListenerCount(listeners, "SIGTERM", 0);
     expectListenerCount(listeners, "exit", 0);
+    expect(cleanup.getForwardedSignal()).toBe("SIGTERM");
   });
 
   it("can force-kill process groups after forwarded parent signals", async () => {
@@ -423,7 +428,7 @@ describe("vitest process group helpers", () => {
       },
     };
     const kill = vi.fn();
-    const teardown = installVitestProcessGroupCleanup({
+    const cleanup = installVitestProcessGroupCleanup({
       child: { pid: 4200 },
       forceSignal: "SIGKILL",
       processObject: fakeProcess as unknown as NodeJS.Process,
@@ -437,7 +442,7 @@ describe("vitest process group helpers", () => {
     expect(kill).toHaveBeenNthCalledWith(1, -4200, "SIGTERM");
     expect(kill).toHaveBeenNthCalledWith(2, -4200, "SIGKILL");
 
-    teardown();
+    cleanup.teardown();
   });
 
   it("raises process listener limits for highly parallel cleanup handlers", () => {
@@ -462,7 +467,7 @@ describe("vitest process group helpers", () => {
       },
     };
 
-    const teardowns = Array.from({ length: 12 }, (_, index) =>
+    const cleanups = Array.from({ length: 12 }, (_, index) =>
       installVitestProcessGroupCleanup({
         child: { pid: 4200 + index },
         processObject: fakeProcess as unknown as NodeJS.Process,
@@ -474,8 +479,8 @@ describe("vitest process group helpers", () => {
     expect(maxListeners).toBeGreaterThan(10);
     expect(fakeProcess.setMaxListeners).toHaveBeenCalled();
 
-    for (const teardown of teardowns) {
-      teardown();
+    for (const cleanup of cleanups) {
+      cleanup.teardown();
     }
     expectListenerCount(listeners, "SIGINT", 0);
     expectListenerCount(listeners, "SIGTERM", 0);


### PR DESCRIPTION
## What Problem This Solves

Vitest wrapper callers separately retained the first forwarded parent signal even though the shared process-group cleanup owner already received that authoritative signal. The repeated state and callbacks made one lifecycle invariant easy to change inconsistently.

## Why This Change Was Made

The shared cleanup owner now retains the first parent `SIGINT` or `SIGTERM` and exposes `{ teardown, getForwardedSignal }`. All six callers read that owner-held fact while preserving their existing force-kill, cleanup, and re-raise policies.

The invocation-level handler in `scripts/run-vitest.mts`, the multi-shard owner in `scripts/test-projects-run.mts`, delegation's no-force-kill policy, and `managed-child-process` remain unchanged.

## User Impact

No user-visible behavior changes. Test tooling has one canonical owner for forwarded parent-signal state, reducing lifecycle drift.

## Evidence

- Owner tests: `38/38` passed in `test/scripts/vitest-process-group.test.ts`.
- Existing lifecycle proof: `733/733` passed across run-vitest, profile, state cleanup, project routing, live, live-shard, worker-shutdown, and E2E global setup tests.
- `node scripts/check-changed.mjs -- <eight changed paths>` passed.
- `pnpm tsgo:scripts` and `pnpm tsgo:test:root` passed.
- Scoped Oxfmt and Oxlint passed; `git diff --check` passed.
- Branch autoreview reported no actionable findings, overall correctness `0.99`.
- Exhaustive live scan covered 2,407 open PRs. The only touched-file overlaps were #133449, #134943, #136244, and #123172; their current hunks do not alter this signal-owner invariant.
- Tooling production: `+33/-53` (net `-20`). Tests: `+17/-12` (net `+5`). Overall: net `-15`.
