### PR TITLE
fix: show profile picture for Me assignee

### DIFF
--- a/ui/src/components/session-owner-menu.ts
+++ b/ui/src/components/session-owner-menu.ts
@@ -45,7 +45,9 @@ export function renderSessionOwnerAssignmentOptions(
           ?disabled=${params.disabled || selfChecked}
           title=${title}
         >
-          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.users}</span>
+          <span slot="icon" class="session-menu__icon" aria-hidden="true"
+            >${renderSessionOwnerAvatar(params.selfOwner)}</span
+          >
           <span class="session-menu__text">${t("sessionsView.assignToMe")}</span>
           ${selfChecked
             ? html`<span slot="details" class="session-menu__check" aria-hidden="true"

--- a/ui/src/e2e/session-owner-assignment.e2e.test.ts
+++ b/ui/src/e2e/session-owner-assignment.e2e.test.ts
@@ -11,6 +11,7 @@ import {
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 import { readThemedPopupPaint } from "./popup-theme.test-support.ts";
 import { openSessionMenuSubmenu } from "./session-management.test-support.ts";
+import { routeAvatarFixtures } from "./session-ownership-visuals.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI session owner assignment mocked Gateway E2E",
@@ -58,12 +59,20 @@ function sessionsListResponse() {
 }
 
 async function installOwnerGateway(page: Page) {
+  await routeAvatarFixtures(page, [{ id: "profile-ada", background: "#7c3aed", label: "A" }]);
   const gateway = await installMockGateway(page, {
     featureMethods: ["chat.startup", "sessions.assignOwner"],
     historyMessages: [{ role: "assistant", content: "Owner assignment outcome proof." }],
     methodResponses: { "sessions.list": sessionsListResponse() },
     operatorScopes: ["operator.read", "operator.write"],
-    presenceUsers: [{ self: true, id: "profile-ada", name: "Ada" }],
+    presenceUsers: [
+      {
+        self: true,
+        id: "profile-ada",
+        name: "Ada",
+        avatarUrl: "/api/users/profile-ada/avatar?v=1",
+      },
+    ],
     sessionKey,
   });
   await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
@@ -166,6 +175,14 @@ suite.define(() => {
           ':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text',
         );
         await expectBrowser(ownerItems).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);
+        await captureProof(page, "assignment-submenu");
+        const selfAvatar = assignTo
+          .getByRole("menuitemradio", { name: "Me", exact: true })
+          .locator("openclaw-viewer-avatar img");
+        await expectBrowser(selfAvatar).toHaveCount(1);
+        await expect
+          .poll(() => selfAvatar.evaluate((image) => (image as HTMLImageElement).naturalWidth))
+          .toBeGreaterThan(0);
         const avatarSizes = await assignTo
           .locator(':scope > wa-dropdown-item[slot="submenu"] .viewer-avatar')
           .evaluateAll((avatars) =>
@@ -187,8 +204,6 @@ suite.define(() => {
               Math.abs(width - height) < 0.01 && cssWidth === "14px" && cssHeight === "14px",
           ),
         ).toBe(true);
-        await captureProof(page, "assignment-submenu");
-
         await assignTo.getByRole("menuitemradio", { name: "Carol", exact: true }).click();
         await expectAssignmentRequest(gateway, "profile-carol");
         await gateway.resolveDeferred("sessions.assignOwner", {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening **Assign to…** would see a generic people icon for **Me**, even when their profile picture was available.

## Why This Change Was Made

The self shortcut bypassed the shared assignee-avatar renderer introduced with the session-menu refactor. It now renders the already-resolved self owner through the same canonical component as every named assignee, preserving initials fallback when no image is available.

## User Impact

**Me** displays the current user's profile picture when available and continues to fall back to their initials otherwise.

## Evidence

### Before

The mocked current user has an avatar URL, but **Me** shows the generic people glyph.

![Before: Me shows a generic people glyph](https://github.com/user-attachments/assets/8742e490-b190-43e3-82e6-dba02c8bdbad)

### After

The same browser flow renders the current user's loaded avatar image.

![After: Me shows the current user's profile avatar](https://github.com/user-attachments/assets/fb74adfb-7f4c-4360-bf32-9cdc591343e4)

### Validation

- Red regression proof before the production change: the browser test expected one loaded avatar image in **Me** and received none.
- `OPENCLAW_OWNER_ASSIGNMENT_PROOF_PHASE=after node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-owner-assignment.e2e.test.ts` — 5/5 passed.
- `node scripts/run-vitest.mjs run ui/src/components/session-menu.test.ts` — 46/46 passed.
- `pnpm check:changed` — passed.
- Autoreview — scoped clean, no accepted/actionable findings.

Production LOC: semantic delta 0; raw `+3/-1` is the one renderer substitution plus formatter wrapping. Test delta: `+18/-3`.

Provenance: the generic self icon originated in #125478's menu extraction; raw-parent inspection confirms sibling owner rows already used the shared avatar renderer there.
