### PR TITLE
fix(macos): use Control UI root for Tailscale dashboard

### DIFF
--- a/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
+++ b/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
@@ -201,19 +201,27 @@ struct TailscaleIntegrationSection: View {
         }
     }
 
+    static func dashboardURL(host: String, localBasePath: String? = nil) -> URL? {
+        guard let gatewayURL = URL(string: "wss://\(host)") else { return nil }
+        let config: GatewayConnection.Config = (gatewayURL, nil, nil)
+        return try? GatewayEndpointStore.dashboardURL(
+            for: config,
+            mode: .local,
+            localBasePath: localBasePath)
+    }
+
     @ViewBuilder
     private var accessURLRow: some View {
         if let host = self.tailscaleService.tailscaleHostname {
-            let url = "https://\(host)/ui/"
             HStack(spacing: 8) {
                 Text("Dashboard URL:")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                if let link = URL(string: url) {
-                    Link(url, destination: link)
+                if let url = Self.dashboardURL(host: host) {
+                    Link(url.absoluteString, destination: url)
                         .font(.system(.caption, design: .monospaced))
                 } else {
-                    Text(url)
+                    Text(host)
                         .font(.system(.caption, design: .monospaced))
                 }
             }

--- a/apps/macos/Tests/OpenClawIPCTests/TailscaleIntegrationSectionTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TailscaleIntegrationSectionTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 import Testing
 @testable import OpenClaw
@@ -5,15 +6,20 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct TailscaleIntegrationSectionTests {
-    @Test func `dashboard link uses the configured Control UI path`() {
+    @Test func `dashboard link uses the configured Control UI path`() async throws {
         let host = "gateway-host.tailnet-example.ts.net"
+        let configPath = TestIsolation.tempConfigPath()
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
 
-        #expect(TailscaleIntegrationSection.dashboardURL(host: host)?.absoluteString ==
-            "https://gateway-host.tailnet-example.ts.net/")
-        #expect(TailscaleIntegrationSection.dashboardURL(
-            host: host,
-            localBasePath: " control ")?.absoluteString ==
-            "https://gateway-host.tailnet-example.ts.net/control/")
+        try await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            #expect(TailscaleIntegrationSection.dashboardURL(host: host)?.absoluteString ==
+                "https://gateway-host.tailnet-example.ts.net/")
+
+            try Data(#"{"gateway":{"controlUi":{"basePath":" control "}}}"#.utf8)
+                .write(to: URL(fileURLWithPath: configPath))
+            #expect(TailscaleIntegrationSection.dashboardURL(host: host)?.absoluteString ==
+                "https://gateway-host.tailnet-example.ts.net/control/")
+        }
     }
 
     @Test func `cli installation requires an executable candidate`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/TailscaleIntegrationSectionTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TailscaleIntegrationSectionTests.swift
@@ -5,6 +5,17 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct TailscaleIntegrationSectionTests {
+    @Test func `dashboard link uses the configured Control UI path`() {
+        let host = "gateway-host.tailnet-example.ts.net"
+
+        #expect(TailscaleIntegrationSection.dashboardURL(host: host)?.absoluteString ==
+            "https://gateway-host.tailnet-example.ts.net/")
+        #expect(TailscaleIntegrationSection.dashboardURL(
+            host: host,
+            localBasePath: " control ")?.absoluteString ==
+            "https://gateway-host.tailnet-example.ts.net/control/")
+    }
+
     @Test func `cli installation requires an executable candidate`() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS Settings > Tailscale dashboard link opened a blank 404 instead of the Control UI when the Gateway used its default dashboard root.

Closes #136576.

## Why This Change Was Made

The link now reuses `GatewayEndpointStore.dashboardURL` in local mode. That existing owner converts the Gateway URL to HTTPS and applies the configured `gateway.controlUi.basePath`, so the native settings surface does not maintain a second routing policy.

## User Impact

The Tailscale dashboard link opens `/` by default and follows custom Control UI base paths such as `/control/`.

## Evidence

- Baseline current main: `037ec02d76e7d8dbd3d019acaa41acb553ed4af0` displayed `https://<hostname>/ui/`, while the Gateway contract serves `/` or the configured `gateway.controlUi.basePath`.
- Before: the `/ui/` route was unclaimed by the default-root Control UI handler and returned the Gateway 404 body, which appeared blank in the native `WKWebView`.
- After: the settings link delegates to `GatewayEndpointStore.dashboardURL` with local mode.
- Regression coverage: the exact integration test reads an isolated config and checks both `/` and configured `/control/` output.
- Hosted proof: GitHub Actions run `33724987817`, including `macos-swift (tests)` on hosted macOS 26, completed GREEN.
- Proof host reason: the exact Swift/AppKit/WebKit boundary requires macOS; Falc0n is Linux and must not run native macOS tests locally.
- Local check: `git diff --check` passed.

## Scope

Production delta is +8 lines net and test delta is +17 lines. The change does not alter Gateway routing, authentication, saved-profile migration, or the installed runtime.
