### PR TITLE
refactor(discord): inline message abort checks

### DIFF
--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -55,10 +55,6 @@ function normalizeDiscordDmOwnerEntry(entry: string): string | undefined {
   return typeof candidate === "string" && /^\d+$/.test(candidate) ? candidate : undefined;
 }
 
-function isContextAborted(abortSignal?: AbortSignal): boolean {
-  return Boolean(abortSignal?.aborted);
-}
-
 export async function buildDiscordMessageProcessContext(params: {
   ctx: DiscordMessagePreflightContext;
   text: string;
@@ -498,7 +494,7 @@ export async function buildDiscordMessageProcessContext(params: {
                     abortSignal,
                   },
                 );
-                return isContextAborted(abortSignal)
+                return abortSignal?.aborted
                   ? []
                   : await toInboundMediaFactsWithMetadata(referencedReplyMediaList, {
                       messageId: replyContext.id,

--- a/extensions/discord/src/monitor/message-handler.preflight-pluralkit.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight-pluralkit.ts
@@ -1,6 +1,6 @@
 // Discord plugin module implements message handler.preflight pluralkit behavior.
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { isPreflightAborted, loadPluralKitRuntime } from "./message-handler.preflight-runtime.js";
+import { loadPluralKitRuntime } from "./message-handler.preflight-runtime.js";
 import type { DiscordMessageEvent } from "./message-handler.preflight.types.js";
 
 export async function resolveDiscordPreflightPluralKitInfo(params: {
@@ -23,7 +23,7 @@ export async function resolveDiscordPreflightPluralKitInfo(params: {
       config: params.config,
       signal: params.abortSignal,
     });
-    return isPreflightAborted(params.abortSignal) ? null : info;
+    return params.abortSignal?.aborted ? null : info;
   } catch (err) {
     logVerbose(`discord: pluralkit lookup failed for ${params.message.id}: ${String(err)}`);
     return null;

--- a/extensions/discord/src/monitor/message-handler.preflight-runtime.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight-runtime.ts
@@ -9,7 +9,3 @@ export const loadPreflightAudioRuntime = createLazyRuntimeModule(
 export const loadSystemEventsRuntime = createLazyRuntimeModule(() => import("./system-events.js"));
 
 export const loadDiscordThreadingRuntime = createLazyRuntimeModule(() => import("./threading.js"));
-
-export function isPreflightAborted(abortSignal?: AbortSignal): boolean {
-  return Boolean(abortSignal?.aborted);
-}

--- a/extensions/discord/src/monitor/message-handler.preflight-thread.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight-thread.ts
@@ -1,10 +1,7 @@
 // Discord plugin module implements message handler.preflight thread behavior.
 import type { ChannelType } from "../internal/discord.js";
 import type { DiscordChannelInfo } from "./message-channel-info.js";
-import {
-  isPreflightAborted,
-  loadDiscordThreadingRuntime,
-} from "./message-handler.preflight-runtime.js";
+import { loadDiscordThreadingRuntime } from "./message-handler.preflight-runtime.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.types.js";
 
 type DiscordPreflightThreadContext = {
@@ -38,7 +35,7 @@ export async function resolveDiscordPreflightThreadContext(params: {
     threadChannel: earlyThreadChannel,
     channelInfo: params.channelInfo,
   });
-  if (isPreflightAborted(params.abortSignal)) {
+  if (params.abortSignal?.aborted) {
     return null;
   }
   return {

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -61,7 +61,6 @@ import {
 } from "./message-handler.preflight-logging.js";
 import { resolveDiscordPreflightPluralKitInfo } from "./message-handler.preflight-pluralkit.js";
 import {
-  isPreflightAborted,
   loadPreflightAudioRuntime,
   loadSystemEventsRuntime,
 } from "./message-handler.preflight-runtime.js";
@@ -201,7 +200,7 @@ async function recordDiscordPendingHistoryEntry(params: {
     limit: params.preflight.historyLimit,
     mediaLimit: DISCORD_HISTORY_MEDIA_MAX_ATTACHMENTS,
     messageId: params.message.id,
-    shouldRecord: () => !isPreflightAborted(params.preflight.abortSignal),
+    shouldRecord: () => !params.preflight.abortSignal?.aborted,
     media: async () =>
       toHistoryMediaEntries(
         await resolveDiscordHistoryMediaForPendingRecord({
@@ -216,7 +215,7 @@ async function recordDiscordPendingHistoryEntry(params: {
 export async function preflightDiscordMessage(
   params: DiscordMessagePreflightParams,
 ): Promise<DiscordMessagePreflightContext | null> {
-  if (isPreflightAborted(params.abortSignal)) {
+  if (params.abortSignal?.aborted) {
     return null;
   }
   const logger = getChildLogger({ module: "discord-auto-reply" });
@@ -248,7 +247,7 @@ export async function preflightDiscordMessage(
     messageChannelId,
   });
   message = hydration.message;
-  if (isPreflightAborted(params.abortSignal)) {
+  if (params.abortSignal?.aborted) {
     return null;
   }
 
@@ -270,7 +269,7 @@ export async function preflightDiscordMessage(
   }
   const isGuildMessage = Boolean(params.data.guild_id);
   const channelInfo = await resolveDiscordChannelInfo(params.client, messageChannelId);
-  if (isPreflightAborted(params.abortSignal)) {
+  if (params.abortSignal?.aborted) {
     return null;
   }
   const { isDirectMessage, isGroupDm } = resolveDiscordPreflightConversationKind({
@@ -321,7 +320,7 @@ export async function preflightDiscordMessage(
     config: pluralkitConfig,
     abortSignal: params.abortSignal,
   });
-  if (isPreflightAborted(params.abortSignal)) {
+  if (params.abortSignal?.aborted) {
     return null;
   }
   const sender = resolveDiscordSenderIdentity({
@@ -366,7 +365,7 @@ export async function preflightDiscordMessage(
       allowNameMatching,
       conversationId: messageChannelId,
     });
-    if (isPreflightAborted(params.abortSignal)) {
+    if (params.abortSignal?.aborted) {
       return null;
     }
     if (!access) {
@@ -604,7 +603,7 @@ export async function preflightDiscordMessage(
       cfg: params.cfg,
       abortSignal: params.abortSignal,
     });
-  if (isPreflightAborted(params.abortSignal)) {
+  if (params.abortSignal?.aborted) {
     return null;
   }
 
@@ -856,7 +855,7 @@ export async function preflightDiscordMessage(
     abortSignal: params.abortSignal,
   };
   const preparedMedia = await resolveMediaList(message, params.mediaMaxBytes, mediaResolveOptions);
-  if (isPreflightAborted(params.abortSignal)) {
+  if (params.abortSignal?.aborted) {
     return null;
   }
   const forwardedMedia = await resolveForwardedMediaList(
@@ -864,7 +863,7 @@ export async function preflightDiscordMessage(
     params.mediaMaxBytes,
     mediaResolveOptions,
   );
-  if (isPreflightAborted(params.abortSignal)) {
+  if (params.abortSignal?.aborted) {
     return null;
   }
   preparedMedia.push(...forwardedMedia);

--- a/extensions/discord/src/monitor/message-handler.process-progress.ts
+++ b/extensions/discord/src/monitor/message-handler.process-progress.ts
@@ -11,10 +11,6 @@ type CallbackPayload<K extends keyof ReplyOptions> =
   NonNullable<ReplyOptions[K]> extends (...args: infer Args) => unknown ? Args[0] : never;
 type DraftPreview = ReturnType<typeof createDiscordDraftPreviewController>;
 
-function isProcessAborted(abortSignal?: AbortSignal): boolean {
-  return Boolean(abortSignal?.aborted);
-}
-
 function isFailedProgress(payload: {
   phase?: string;
   status?: string;
@@ -124,7 +120,7 @@ export function createDiscordMessageProgressRuntime(params: {
     },
     onNarrationUpdate: draftPreview.narrationProgressEnabled
       ? async (payload) => {
-          if (isProcessAborted(abortSignal) || shouldYieldDraftCommentary()) {
+          if (abortSignal?.aborted || shouldYieldDraftCommentary()) {
             return;
           }
           await draftPreview.pushNarrationProgress(payload.text);
@@ -148,7 +144,7 @@ export function createDiscordMessageProgressRuntime(params: {
     },
     streamReasoningInNonStreamModes: reasoningWindowEnabled,
     onToolStart: async (payload) => {
-      if (isProcessAborted(abortSignal)) {
+      if (abortSignal?.aborted) {
         return false;
       }
       await params.reactions.maybeBindToToolReaction(payload);
@@ -188,13 +184,13 @@ export function createDiscordMessageProgressRuntime(params: {
       return await draftPreview.pushPatchEvent(payload);
     },
     onCompactionStart: async () => {
-      if (!isProcessAborted(abortSignal)) {
+      if (!abortSignal?.aborted) {
         await params.reactions.controller.setCompacting();
       }
       return false;
     },
     onCompactionEnd: async () => {
-      if (!isProcessAborted(abortSignal)) {
+      if (!abortSignal?.aborted) {
         params.reactions.controller.cancelPending();
         await params.reactions.controller.setThinking();
       }

--- a/extensions/discord/src/monitor/message-handler.process.abort-retry.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.abort-retry.test.ts
@@ -35,7 +35,7 @@ describe("processDiscordMessage deliver-lambda abort logging", () => {
     // the dispatch mock and then queue a single block reply via the captured
     // dispatcher. The mocked createReplyDispatcherWithTyping (see line ~229)
     // routes sendBlockReply straight into the deliver lambda, where the very
-    // first gate is `if (isProcessAborted(abortSignal)) return;` — the line
+    // first gate is `if (abortSignal?.aborted) return;` — the line
     // the PR added the logVerbose call to.
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       abortController.abort();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -53,10 +53,6 @@ const TARGETED_ONLY_ALLOWED_MENTIONS = {
   parse: ["users", "roles"],
 } as APIAllowedMentions;
 
-function isProcessAborted(abortSignal?: AbortSignal): boolean {
-  return Boolean(abortSignal?.aborted);
-}
-
 function isFallbackOnlyToolWarningFinal(payload: ReplyPayload): boolean {
   if (payload.isError !== true || !isReplyPayloadNonTerminalToolErrorWarning(payload)) {
     return false;
@@ -110,7 +106,7 @@ async function processDiscordMessageInner(
     turnAdoptionLifecycle,
     preparedMedia: mediaList,
   } = ctx;
-  if (isProcessAborted(abortSignal)) {
+  if (abortSignal?.aborted) {
     return;
   }
   const text = messageText;
@@ -255,7 +251,7 @@ async function processDiscordMessageInner(
   });
   let replyLifecycleStarted = false;
   const onDiscordReplyStart = async () => {
-    if (isProcessAborted(abortSignal)) {
+    if (abortSignal?.aborted) {
       return;
     }
     replyLifecycleStarted = true;
@@ -278,7 +274,7 @@ async function processDiscordMessageInner(
       allowProgressBlock?: boolean;
     },
   ) => {
-    if (isProcessAborted(abortSignal)) {
+    if (abortSignal?.aborted) {
       // Surface so operators don't chase missing replies when an abort
       // drops a model-produced text payload.
       logVerbose(
@@ -429,7 +425,7 @@ async function processDiscordMessageInner(
             return undefined;
           },
           editFinal: async (previewMessageId, edit) => {
-            if (isProcessAborted(abortSignal)) {
+            if (abortSignal?.aborted) {
               throw new Error("process aborted");
             }
             notifyFinalReplyStart();
@@ -451,7 +447,7 @@ async function processDiscordMessageInner(
           },
         }),
         deliverNormally: async () => {
-          if (isProcessAborted(abortSignal)) {
+          if (abortSignal?.aborted) {
             return false;
           }
           const fallbackPayload =
@@ -501,7 +497,7 @@ async function processDiscordMessageInner(
         return { visibleReplySent: true };
       }
     }
-    if (isProcessAborted(abortSignal)) {
+    if (abortSignal?.aborted) {
       // Mirror the entry-point abort log so a mid-deliver abort (after
       // the preview path bowed out) does not silently drop the reply.
       logVerbose(
@@ -583,7 +579,7 @@ async function processDiscordMessageInner(
   let dispatchError = false;
   let dispatchAborted = false;
   const deliverPendingToolWarningFinalIfNeeded = async () => {
-    if (!pendingToolWarningFinal || userFacingFinalDelivered || isProcessAborted(abortSignal)) {
+    if (!pendingToolWarningFinal || userFacingFinalDelivered || abortSignal?.aborted) {
       return undefined;
     }
     const pending = pendingToolWarningFinal;
@@ -599,7 +595,7 @@ async function processDiscordMessageInner(
     }
   };
   try {
-    if (isProcessAborted(abortSignal)) {
+    if (abortSignal?.aborted) {
       dispatchAborted = true;
       return;
     }
@@ -670,7 +666,7 @@ async function processDiscordMessageInner(
       return;
     }
     dispatchResult = preparedResult.dispatchResult;
-    if (isProcessAborted(abortSignal)) {
+    if (abortSignal?.aborted) {
       dispatchAborted = true;
       return;
     }
@@ -688,7 +684,7 @@ async function processDiscordMessageInner(
       markFinalReplyDelivered();
     }
   } catch (err) {
-    if (isProcessAborted(abortSignal)) {
+    if (abortSignal?.aborted) {
       dispatchAborted = true;
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

Discord message handling repeated four local wrappers around the native
`AbortSignal.aborted` property. The wrappers added names and an export without
owning policy, while obscuring that cancellation must be reread at each
post-await and callback boundary.

## Why This Change Was Made

This maintainer-requested cleanup removes the four wrappers and replaces all 26
calls in place with live `abortSignal?.aborted` reads. It preserves negation,
short-circuit order, await placement, and callback-time rereads. No helper,
Plugin SDK seam, config, protocol, persistence, or behavior surface is added.

## User Impact

No user-visible behavior changes. Discord cancellation checks now use the
platform primitive directly, with less production code and no exported
predicate alias.

Production LOC: +28/-48 (net -20) | Tests: +1/-1

## Evidence

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.context.test.ts extensions/discord/src/monitor/message-handler.preflight.test.ts extensions/discord/src/monitor/message-handler.process.abort-retry.test.ts extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts extensions/discord/src/monitor/message-handler.process.draft-reasoning.test.ts`
  - 5 files passed, 138 tests passed.
- `node scripts/run-tsgo.mjs -p extensions/discord/tsconfig.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/discord-abort-read.tsbuildinfo`
  - passed.
- `node scripts/run-oxlint.mjs --tsconfig extensions/tsconfig.json <eight changed files>`
  - passed.
- `git diff --check`
  - passed.
- `node scripts/check-changed.mjs -- <eight changed files>`
  - passed 15 lanes through package patch validation, then the all-extension
    typecheck stopped on the untouched browser plugin because the shared
    install lacks its declared `yargs-parser` package.
- Independent autoreview: scoped clean, patch correct at 0.99 confidence.
- Duplicate/overlap search:
  - no live PR search results for the four predicate names or Discord abort
    predicate phrasing;
  - one same-repository file overlap exists with
    https://github.com/openclaw/openclaw/pull/135589, limited to the unrelated
    DM-owner normalizer near the top of `message-handler.context.ts`.
- Codex hard gate inspected:
  - `../codex/codex-rs/cli/src/main.rs:220-245`
  - `../codex/codex-rs/cli/src/main.rs:2840-2870`
  - no Codex protocol/runtime dependency applies.

Native full CI run `33689885926` passed at exact head `1176c0f37e6edd34f82fb061f9f892d84df11791`. Attempt 2 retried only `android-ktlint` after an unrelated Gradle distribution download connection reset; the retry and aggregate gate passed.

