### PR TITLE
fix(test): preserve trailing CLI overflow diagnostics

### DIFF
--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -390,18 +390,19 @@ describe("openclaw test instance", () => {
               ? resolveMaxOutputBytes(undefined, "stdout")
               : resolveMaxOutputBytes(undefined, "stdout") / 2;
         const command = trackOperation(instance.cli([String(characters), mode]));
-        if (control) {
-          await withTestTimeout(control.reached, 5_000, "overflow close control gate");
-          await control.release();
-        }
         if (mode !== "complete") {
-          const outcome = await command.then(
+          const outcomePromise = command.then(
             (result) => ({
               code: result.code,
               stdoutBytes: Buffer.byteLength(result.stdout),
             }),
             (error: unknown) => error,
           );
+          if (control) {
+            await withTestTimeout(control.reached, 5_000, "overflow close control gate");
+            await control.release();
+          }
+          const outcome = await outcomePromise;
           if (!(outcome instanceof Error)) {
             throw new Error(`Expected command output overflow failure: ${JSON.stringify(outcome)}`);
           }

--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -221,6 +221,25 @@ const env = Object.fromEntries(["HOME", "OPENCLAW_CONFIG_PATH", "OPENCLAW_GATEWA
 appendFileSync(tracePath, JSON.stringify({ argv, config: JSON.parse(readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8")), cwd: process.cwd(), env, pid: process.pid, port }) + "\\n");
 const kind = (process.env.OPENCLAW_FAKE_GATEWAY_SEQUENCE || "ready").split(",")[attempt - 1] || "ready";
 if (kind === "cli-json") {
+  if (argv[1] === "overflow-close") {
+    const splitCodePoint = Buffer.from([0xf0, 0x9f, 0xa6, 0x8a]);
+    const first = Buffer.concat([
+      Buffer.alloc(Number(argv[0]) - 2, 0x61),
+      splitCodePoint.subarray(0, 2),
+    ]);
+    await new Promise((resolve) => process.stdout.write(first, resolve));
+    await (await fetch(controlUrl + "/wait")).text();
+    await new Promise((resolve) =>
+      process.stdout.write(
+        Buffer.concat([
+          splitCodePoint.subarray(2),
+          Buffer.from("\\ntrailing overflow output\\n"),
+        ]),
+        resolve,
+      ),
+    );
+    process.exit(0);
+  }
   const json = JSON.stringify({ first: "complete", payload: "é".repeat(Number(argv[0])), providerCredentialPresent: Object.hasOwn(process.env, "OPENAI_API_KEY"), last: "complete" });
   await Promise.all([
     new Promise((resolve) => process.stdout.write(json, resolve)),
@@ -355,12 +374,26 @@ describe("openclaw test instance", () => {
     "owns complete CLI JSON and diagnostic tails (%s)",
     async (mode) => {
       await withEnvAsync({ OPENAI_API_KEY: "ambient-provider-fixture" }, async () => {
-        const { instance, readAttempts } = await createFakeGateway("cli-json");
+        const control = mode === "overflow-close" ? await createGatewayControl() : undefined;
+        const { instance, readAttempts } = await createFakeGateway(
+          "cli-json",
+          1_000,
+          1_500,
+          control ? { url: control.url } : undefined,
+        );
         // The command must not merge a removed credential back from its parent.
         delete instance.env.OPENAI_API_KEY;
         const characters =
-          mode === "complete" ? 160 * 1024 : resolveMaxOutputBytes(undefined, "stdout") / 2;
+          mode === "complete"
+            ? 160 * 1024
+            : mode === "overflow-close"
+              ? resolveMaxOutputBytes(undefined, "stdout")
+              : resolveMaxOutputBytes(undefined, "stdout") / 2;
         const command = trackOperation(instance.cli([String(characters), mode]));
+        if (control) {
+          await withTestTimeout(control.reached, 5_000, "overflow close control gate");
+          await control.release();
+        }
         if (mode !== "complete") {
           const outcome = await command.then(
             (result) => ({
@@ -373,7 +406,13 @@ describe("openclaw test instance", () => {
             throw new Error(`Expected command output overflow failure: ${JSON.stringify(outcome)}`);
           }
           expect(outcome.message).toContain("command stdout exceeded capture limit");
-          expect(outcome.message).toContain('"last":"complete"');
+          if (mode === "overflow") {
+            expect(outcome.message).toContain('"last":"complete"');
+          } else {
+            expect(outcome.message).toContain(String.fromCodePoint(0x1f98a));
+            expect(outcome.message).toContain("trailing overflow output");
+            expect(outcome.message).not.toContain("\uFFFD");
+          }
           expect(Buffer.byteLength(outcome.message)).toBeLessThan(600 * 1024);
         } else {
           const result = await command;

--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -351,7 +351,7 @@ function createGatewayProcessState(
 }
 
 describe("openclaw test instance", () => {
-  it.each(["complete", "overflow"] as const)(
+  it.each(["complete", "overflow", "overflow-close"] as const)(
     "owns complete CLI JSON and diagnostic tails (%s)",
     async (mode) => {
       await withEnvAsync({ OPENAI_API_KEY: "ambient-provider-fixture" }, async () => {
@@ -361,7 +361,7 @@ describe("openclaw test instance", () => {
         const characters =
           mode === "complete" ? 160 * 1024 : resolveMaxOutputBytes(undefined, "stdout") / 2;
         const command = trackOperation(instance.cli([String(characters), mode]));
-        if (mode === "overflow") {
+        if (mode !== "complete") {
           const outcome = await command.then(
             (result) => ({
               code: result.code,
@@ -373,6 +373,7 @@ describe("openclaw test instance", () => {
             throw new Error(`Expected command output overflow failure: ${JSON.stringify(outcome)}`);
           }
           expect(outcome.message).toContain("command stdout exceeded capture limit");
+          expect(outcome.message).toContain('"last":"complete"');
           expect(Buffer.byteLength(outcome.message)).toBeLessThan(600 * 1024);
         } else {
           const result = await command;

--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -22,7 +22,7 @@ import { withEnvAsync } from "../../src/test-utils/env.js";
 import { createBoundedChildOutput } from "./bounded-child-output.js";
 import { createFixtureLifetime } from "./fixture-lifetime.js";
 import { createOpenClawTestInstance, testing } from "./openclaw-test-instance.js";
-import { isProcessAlive, waitForDead } from "./process-wait.js";
+import { isProcessAlive, waitForDead, waitForFile } from "./process-wait.js";
 import { createDeferred, withTestTimeout } from "./promise.js";
 import { runQaGatewayFixture } from "./qa-gateway-cleanup.js";
 
@@ -199,7 +199,7 @@ recordFixtureProcess(process.pid);
       path.join(distDir, "index.mjs"),
       `
 import { execFileSync, spawn } from "node:child_process";
-import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 ${processReceipt}
 const tracePath = process.env.OPENCLAW_FAKE_GATEWAY_TRACE;
@@ -223,14 +223,20 @@ const kind = (process.env.OPENCLAW_FAKE_GATEWAY_SEQUENCE || "ready").split(",")[
 if (kind === "cli-json") {
   if (argv[1] === "overflow-close") {
     const splitCodePoint = Buffer.from([0xf0, 0x9f, 0xa6, 0x8a]);
+    const releasePath = tracePath + ".overflow-release";
     const first = Buffer.concat([
       Buffer.alloc(Number(argv[0]) - 2, 0x61),
       splitCodePoint.subarray(0, 2),
     ]);
     await new Promise((resolve) => process.stdout.write(first, resolve));
-    await (await fetch(controlUrl + "/wait")).text();
+    writeFileSync(tracePath + ".overflow-ready", "");
+    const releaseDeadline = Date.now() + 5_000;
+    while (!existsSync(releasePath)) {
+      if (Date.now() >= releaseDeadline) throw new Error("overflow release timed out");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
     await new Promise((resolve) =>
-      process.stdout.write(
+      process.stdout.end(
         Buffer.concat([
           splitCodePoint.subarray(2),
           Buffer.from("\\ntrailing overflow output\\n"),
@@ -238,7 +244,8 @@ if (kind === "cli-json") {
         resolve,
       ),
     );
-    process.exit(0);
+    setInterval(() => {}, 1_000);
+    await new Promise(() => {});
   }
   const json = JSON.stringify({ first: "complete", payload: "é".repeat(Number(argv[0])), providerCredentialPresent: Object.hasOwn(process.env, "OPENAI_API_KEY"), last: "complete" });
   await Promise.all([
@@ -374,12 +381,10 @@ describe("openclaw test instance", () => {
     "owns complete CLI JSON and diagnostic tails (%s)",
     async (mode) => {
       await withEnvAsync({ OPENAI_API_KEY: "ambient-provider-fixture" }, async () => {
-        const control = mode === "overflow-close" ? await createGatewayControl() : undefined;
-        const { instance, readAttempts } = await createFakeGateway(
+        const { instance, tracePath, readAttempts } = await createFakeGateway(
           "cli-json",
           1_000,
           1_500,
-          control ? { url: control.url } : undefined,
         );
         // The command must not merge a removed credential back from its parent.
         delete instance.env.OPENAI_API_KEY;
@@ -398,9 +403,9 @@ describe("openclaw test instance", () => {
             }),
             (error: unknown) => error,
           );
-          if (control) {
-            await withTestTimeout(control.reached, 5_000, "overflow close control gate");
-            await control.release();
+          if (mode === "overflow-close") {
+            await waitForFile(`${tracePath}.overflow-ready`, 5_000);
+            await fs.writeFile(`${tracePath}.overflow-release`, "");
           }
           const outcome = await outcomePromise;
           if (!(outcome instanceof Error)) {

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -738,6 +738,7 @@ async function runCommand(params: {
   const maxStdoutBytes = resolveMaxOutputBytes(undefined, "stdout");
   const outputLimit = new AbortController();
   const readStdout = () => finalizeCapturedOutput(stdout, "head", true).toString("utf8");
+  const stdoutDiagnostic = createBoundedStringLog();
   const stderr = createBoundedStringLog();
   let child!: ChildProcess;
   try {
@@ -758,6 +759,7 @@ async function runCommand(params: {
         child.stderr?.setEncoding("utf8");
         child.stdout?.on("data", (chunk) => {
           appendCapturedOutput(stdout, chunk, maxStdoutBytes, "head");
+          appendLogChunk(stdoutDiagnostic, chunk);
           if (stdout.truncatedBytes > 0) {
             outputLimit.abort();
           }
@@ -773,7 +775,7 @@ async function runCommand(params: {
         : error instanceof Error
           ? error.message
           : String(error);
-    throw new Error(`${message}\n${formatLogs([readStdout()], stderr)}`, { cause: error });
+    throw new Error(`${message}\n${formatLogs(stdoutDiagnostic, stderr)}`, { cause: error });
   }
   return {
     code: child.exitCode,

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import type { Readable } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   BUILD_STAMP_FILE,
@@ -739,6 +740,7 @@ async function runCommand(params: {
   const outputLimit = new AbortController();
   const readStdout = () => finalizeCapturedOutput(stdout, "head", true).toString("utf8");
   const stdoutDiagnostic = createBoundedStringLog();
+  const stdoutDiagnosticDecoder = new StringDecoder("utf8");
   const stderr = createBoundedStringLog();
   let child!: ChildProcess;
   try {
@@ -759,7 +761,7 @@ async function runCommand(params: {
         child.stderr?.setEncoding("utf8");
         child.stdout?.on("data", (chunk) => {
           appendCapturedOutput(stdout, chunk, maxStdoutBytes, "head");
-          appendLogChunk(stdoutDiagnostic, chunk);
+          appendLogChunk(stdoutDiagnostic, stdoutDiagnosticDecoder.write(chunk));
           if (stdout.truncatedBytes > 0) {
             outputLimit.abort();
           }
@@ -768,6 +770,7 @@ async function runCommand(params: {
       },
     });
   } catch (error) {
+    appendLogChunk(stdoutDiagnostic, stdoutDiagnosticDecoder.end());
     const message = hasErrnoCode(error, "ETIMEDOUT")
       ? `command timed out after ${params.timeoutMs}ms: ${params.args.join(" ")}`
       : stdout.truncatedBytes > 0


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/136286

## What Problem This Solves

Fixes an issue where oversized CLI output from shared test instances omitted the
actual trailing stdout bytes from failure diagnostics. The diagnostic path also
now decodes stdout as one continuous UTF-8 stream, so pipe chunk boundaries
cannot corrupt valid multibyte characters.

## Why This Change Was Made

Successful command results still retain complete stdout up to the existing
16 MiB limit. Failure diagnostics now independently retain a bounded 256 KiB
true stdout tail with the existing truncation marker. Raw head capture, output
limits, process lifecycle, cleanup, and timeout/overflow/error precedence remain
unchanged.

## User Impact

CI failures now include the final CLI output needed to diagnose oversized or
malformed responses. Production runtime behavior is unchanged.

## Evidence

- Original red: the quick-close overflow regression failed because the error
  omitted `"last":"complete"`.
- UTF-8 red on reviewed head `632a76bd37a`: the gated overflow-close fixture
  preserved the tail marker but rendered a deliberately split four-byte code
  point as replacement characters.
- UTF-8 green on `dea46ee96e0`: focused overflow-close regression passed with
  the intact code point, tail marker, no replacement character, bounded error,
  and dead child.
- Windows red on `dea46ee96e0`: exact-head CI run `33691697741` reached the
  expected overflow rejection while the test still awaited gate release, so
  Vitest attributed the transient rejection to the test and retained the shard.
- Observation-order green on `c09bea296ce`: the overflow outcome handler was
  attached before releasing the child, and all three focused modes passed
  locally. Exact-head Windows run `33696719291` still retained shard 2 for more
  than twice the recent successful baseline while the HTTP gate remained live.
- Socket-free green on `a1ba1df3f97`: the same real-child regression uses a
  filesystem ready/release handshake, preserving the split code point, trailing
  marker, bounded error, and dead-child assertions without a server or fetch;
  all three focused modes passed.
- Abort-owned green on `5b4cdd4ae291`: the child writes the completed UTF-8
  diagnostic tail, closes stdout, remains alive, and is terminated only by the
  existing overflow abort. The focused regression and its following
  cleanup-sensitive case passed: 4 passed, 39 skipped.
- Full shared-helper run on `5b4cdd4ae291`: 41 passed and 1 platform skip. The
  unrelated existing UTF-8 trimming subprocess test timed out twice before
  emitting stdout or stderr during local cold startup; no code in that surface
  changed.
- Windows changed-scope routing: 29 passed.
- Fresh P1 autoreview on `5b4cdd4ae291` was scoped-clean with no P0/P1
  findings.
- Local changed-scope guards passed through formatting and graph-boundary checks;
  the test-root typecheck was blocked by unrelated missing shared dependencies,
  so exact-head hosted CI remains required.
- Exact-head native Testbox proof is pending and will replace prior-head
  evidence during `scripts/pr prepare-run`.
