### PR TITLE
fix(release): forward-port remaining 2026.9.1 harness repairs

### DIFF
--- a/src/channels/plugins/contracts/test-helpers/runtime-artifacts.ts
+++ b/src/channels/plugins/contracts/test-helpers/runtime-artifacts.ts
@@ -4,24 +4,33 @@
  * Resolves generated contract artifacts through runtime records with local workspace fallback.
  */
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { vi } from "vitest";
 import { listBundledChannelPluginMetadata } from "../../../../plugins/bundled-channel-runtime.js";
 import { resolvePluginRuntimeModulePath } from "../../../../plugins/runtime/runtime-plugin-boundary.js";
 import { resolveRelativeBundledPluginPublicModuleId } from "../../../../test-utils/bundled-plugin-public-surface.js";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../../../", import.meta.url));
 
-/** Loads a public source artifact when a host contract must mock its transport dependency. */
+/** Installs plugin-owned transport mocks before loading a public source artifact. */
 export async function importBundledChannelContractSourceArtifact<T extends object>(
   pluginId: string,
   artifactBasename: string,
+  mockFactories: Record<string, () => Record<string, unknown>>,
 ): Promise<T> {
   const moduleId = resolveRelativeBundledPluginPublicModuleId({
     fromModuleUrl: import.meta.url,
     pluginId,
     artifactBasename,
   });
+  const requirePlugin = createRequire(new URL(moduleId, import.meta.url));
+  // Lazy transport imports still need these mocks after this loader returns;
+  // the test runner clears the mock registry between files.
+  for (const [dependency, factory] of Object.entries(mockFactories)) {
+    vi.doMock(requirePlugin.resolve(dependency), factory);
+  }
   return (await import(moduleId)) as T;
 }
 

--- a/src/plugins/registry-runtime.twitch-ingress.test.ts
+++ b/src/plugins/registry-runtime.twitch-ingress.test.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
   configureChannelAdmissionEvidenceCollection,
@@ -8,6 +9,7 @@ import { importBundledChannelContractSourceArtifact } from "../channels/plugins/
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runChannelInboundEvent } from "../plugin-sdk/channel-inbound.js";
+import { resolveBundledPluginPublicModulePath } from "../test-utils/bundled-plugin-public-surface.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createRuntimeEnv } from "../test-utils/plugin-runtime-env.js";
 import { markPluginRegistryActive, markPluginRegistryRetired } from "./registry-lifecycle.js";
@@ -73,7 +75,12 @@ const transport = await vi.hoisted(async () => {
   return { ChatClient, createDeferred };
 });
 
-vi.mock("@twurple/chat", () => ({
+const requireTwitch = createRequire(
+  resolveBundledPluginPublicModulePath({ pluginId: "twitch", artifactBasename: "api.js" }),
+);
+
+// Transport dependencies resolve from their owning plugin, not the core test package.
+vi.doMock(requireTwitch.resolve("@twurple/chat"), () => ({
   ChatClient: transport.ChatClient,
   LogLevel: { WARNING: "warning" },
 }));

--- a/src/plugins/registry-runtime.twitch-ingress.test.ts
+++ b/src/plugins/registry-runtime.twitch-ingress.test.ts
@@ -1,4 +1,3 @@
-import { createRequire } from "node:module";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
   configureChannelAdmissionEvidenceCollection,
@@ -9,7 +8,6 @@ import { importBundledChannelContractSourceArtifact } from "../channels/plugins/
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runChannelInboundEvent } from "../plugin-sdk/channel-inbound.js";
-import { resolveBundledPluginPublicModulePath } from "../test-utils/bundled-plugin-public-surface.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createRuntimeEnv } from "../test-utils/plugin-runtime-env.js";
 import { markPluginRegistryActive, markPluginRegistryRetired } from "./registry-lifecycle.js";
@@ -75,20 +73,15 @@ const transport = await vi.hoisted(async () => {
   return { ChatClient, createDeferred };
 });
 
-const requireTwitch = createRequire(
-  resolveBundledPluginPublicModulePath({ pluginId: "twitch", artifactBasename: "api.js" }),
-);
-
-// Transport dependencies resolve from their owning plugin, not the core test package.
-vi.doMock(requireTwitch.resolve("@twurple/chat"), () => ({
-  ChatClient: transport.ChatClient,
-  LogLevel: { WARNING: "warning" },
-}));
-
 const { twitchPlugin, setTwitchRuntime } = await importBundledChannelContractSourceArtifact<{
   twitchPlugin: ChannelPlugin<unknown>;
   setTwitchRuntime: (runtime: PluginRuntime) => void;
-}>("twitch", "api.js");
+}>("twitch", "api.js", {
+  "@twurple/chat": () => ({
+    ChatClient: transport.ChatClient,
+    LogLevel: { WARNING: "warning" },
+  }),
+});
 
 type Policy = { allowFrom?: string[]; allowedRoles?: string[] };
 type EvidenceResult = ReturnType<typeof consumeChannelAdmissionEvidence>;

--- a/test/openclaw-prepack.test.ts
+++ b/test/openclaw-prepack.test.ts
@@ -64,7 +64,10 @@ function linkFixtureParent(packageRoot: string) {
   );
 }
 
-function createBundledChannelSmokeFixture(entrySource: string, prepared = false) {
+function createBundledChannelSmokeFixture(
+  entrySource: string,
+  options: { prepared?: boolean; missingTransitive?: boolean } = {},
+) {
   const rootDir = tempDirs.make("openclaw-prepack-standalone-smoke-");
   for (const relativePath of standaloneBundledChannelSmokeFiles) {
     const destination = path.join(rootDir, relativePath);
@@ -72,7 +75,7 @@ function createBundledChannelSmokeFixture(entrySource: string, prepared = false)
     copyFileSync(path.join(process.cwd(), relativePath), destination);
   }
 
-  const packageRoot = prepared ? rootDir : path.join(rootDir, "package");
+  const packageRoot = options.prepared ? rootDir : path.join(rootDir, "package");
   const extensionRoot = path.join(packageRoot, "dist", "extensions", "fixture-channel");
   mkdirSync(extensionRoot, { recursive: true });
   writeFileSync(path.join(packageRoot, "package.json"), '{"files":[]}\n');
@@ -94,6 +97,9 @@ function createBundledChannelSmokeFixture(entrySource: string, prepared = false)
   );
   const parentRoot = path.join(parentStoreRoot, "fixture-parent");
   const siblingRoot = path.join(parentStoreRoot, "fixture-sibling");
+  const siblingSpecifier = options.missingTransitive
+    ? "fixture-missing-transitive"
+    : "fixture-sibling";
   mkdirSync(parentRoot, { recursive: true });
   mkdirSync(siblingRoot);
   writeFileSync(
@@ -102,7 +108,7 @@ function createBundledChannelSmokeFixture(entrySource: string, prepared = false)
   );
   writeFileSync(
     path.join(parentRoot, "index.js"),
-    'import { value } from "fixture-sibling"; export const fixtureValue = value;\n',
+    `import { value } from "${siblingSpecifier}"; export const fixtureValue = value;\n`,
   );
   writeFileSync(
     path.join(siblingRoot, "package.json"),
@@ -122,7 +128,7 @@ function createBundledChannelSmokeFixture(entrySource: string, prepared = false)
 }
 
 function createPreparedPrepackFixture(entrySource: string) {
-  const { rootDir } = createBundledChannelSmokeFixture(entrySource, true);
+  const { rootDir } = createBundledChannelSmokeFixture(entrySource, { prepared: true });
   mkdirSync(path.join(rootDir, "node_modules"), { recursive: true });
   symlinkSync(
     path.dirname(fileURLToPath(import.meta.resolve("tsx/package.json"))),
@@ -234,8 +240,12 @@ process.exit(result.status ?? 1);
 
 type BundledChannelSmokeLayout = "source" | "installed-env" | "installed-path";
 
-function runStandaloneBundledChannelSmoke(entrySource: string, layout: BundledChannelSmokeLayout) {
-  const fixture = createBundledChannelSmokeFixture(entrySource);
+function runStandaloneBundledChannelSmoke(
+  entrySource: string,
+  layout: BundledChannelSmokeLayout,
+  missingTransitive = false,
+) {
+  const fixture = createBundledChannelSmokeFixture(entrySource, { missingTransitive });
   const { dependencyFiles, rootDir } = fixture;
   let { packageRoot } = fixture;
   if (layout === "installed-path") {
@@ -315,27 +325,40 @@ function runStandaloneBundledChannelSmoke(entrySource: string, layout: BundledCh
 describe("standalone bundled channel smoke", () => {
   const layouts = ["source", "installed-env", "installed-path"] as const;
   it.each(
-    layouts.flatMap((layout) => [
-      { layout, invalid: false },
-      { layout, invalid: true },
-    ]),
+    layouts.flatMap((layout) =>
+      ["valid", "invalid-entry", "missing-transitive"].map((outcome) => ({ layout, outcome })),
+    ),
   )(
-    "preserves the result and releases its layout for $layout with invalid=$invalid",
-    ({ layout, invalid }) => {
-      const entrySource = invalid
-        ? 'import "fixture-parent"; export default [];\n'
-        : `import { fixtureValue } from "fixture-parent";
-          export default {
-            kind: "bundled-channel-entry",
-            loadChannelPlugin() { return { id: fixtureValue }; },
-          };\n`;
-      const observed = runStandaloneBundledChannelSmoke(entrySource, layout);
+    "preserves the result and releases its layout for $layout with outcome=$outcome",
+    ({ layout, outcome }) => {
+      const entrySource = `
+        import assert from "node:assert/strict";
+        import { realpathSync } from "node:fs";
+        import { fileURLToPath } from "node:url";
+        import { fixtureValue } from "fixture-parent";
+        if (${layout !== "installed-env"}) {
+          const modulePath = realpathSync(fileURLToPath(import.meta.url)).replaceAll("\\\\", "/");
+          assert.ok(modulePath.includes("/node_modules/openclaw/dist/"));
+        }
+        export default ${
+          outcome === "invalid-entry"
+            ? "[]"
+            : '{ kind: "bundled-channel-entry", loadChannelPlugin() { return { id: fixtureValue }; } }'
+        };
+      `;
+      const missingTransitive = outcome === "missing-transitive";
+      const observed = runStandaloneBundledChannelSmoke(entrySource, layout, missingTransitive);
       const { result } = observed;
       expect(result.error).toBeUndefined();
       expect(result.signal).toBeNull();
-      expect(result.status, result.stderr).toBe(invalid ? 1 : 0);
-      if (invalid) {
-        expect(result.stderr).toContain("AssertionError");
+      expect(result.status, result.stderr).toBe(outcome === "valid" ? 0 : 1);
+      if (outcome !== "valid") {
+        expect(result.stderr).toContain(
+          missingTransitive ? "ERR_MODULE_NOT_FOUND" : "AssertionError",
+        );
+        if (missingTransitive) {
+          expect(result.stderr).toContain("fixture-missing-transitive");
+        }
         expect(result.stdout).not.toContain("[build-smoke]");
       } else {
         expect(result.stdout).toContain("channel=1");


### PR DESCRIPTION
## What Problem This Solves

Resolves the remaining validation gaps from the maintainer-requested forward-port of [release/2026.9.1](https://github.com/openclaw/openclaw/tree/release/2026.9.1), so the next release cut retains its installer, updater, and prepack repairs. On current main, the Twitch ingress fixture still misses its plugin-owned transport mock and starts the real client instead of exercising the synthetic ingress/reply flow.

## Why This Change Was Made

Cherry-pick the remaining parts of `74e894d3f88` with `-x` and original authorship. Resolve transport mocks from the plugin public path inside the existing channel contract source loader, before importing that source. The core ingress test supplies only its mock factory, so plugin path resolution stays inside its permitted owner. Mocks remain alive for lazy transport imports and the existing test runner clears them between files. Fold the release's physical installed-path and missing-transitive checks into main's existing prepack fixture instead of duplicating its dependency graph.

The other release hunks are already present under different commit subjects:

| Release change | Existing main equivalent / resolution |
| --- | --- |
| `bdf508b8ad7` + `d3deb20a78e`: npm archive/update identity, prepared-plugin acceptance, installer fixture cleanup | [#136316 — npm 12 archives and prepared plugins](https://github.com/openclaw/openclaw/pull/136316), `a944ac24d51`; combined patch IDs match exactly. Omitted duplicates; retain newer PowerShell error reporting. |
| `46dc9d8dad2`: circular CSSOM serialization | [#136434 — release validation repair](https://github.com/openclaw/openclaw/pull/136434), `a8fe1a587bb`; all hunks already present. Retain the additional probe normalization from [#136402](https://github.com/openclaw/openclaw/pull/136402). |
| `74e894d3f88`: installed-package smoke and WhatsApp hint | Physical package copy and normal Node dependency resolution already landed in [#136308 — side-effect-free package imports](https://github.com/openclaw/openclaw/pull/136308), `ff6fb73f012`; npm repair-hint expectations already landed in [#136211](https://github.com/openclaw/openclaw/pull/136211), `a220e67a929`. Preserve main's clone optimization and dependency-link behavior; retain only the missing coverage and Twitch mock repair. |

## User Impact

No additional production, UI, configuration, dependency, or persistence behavior changes. The already-landed npm 12/update-global fix remains intact, while release validation exercises the intended synthetic transport and actual installed-module layout.

Production LOC: **+0/-0**. Tests: **+52/-29** (net +23); existing contract test support: **+10/-1** (net +9). Three files change, with no generated or lockfile changes. No changelog or version changes. `431d778f545` is explicitly excluded. Its native/Android i18n literal-decoding changes are also excluded; **native literal-decoding forward-port** is a separate follow-up.

## Evidence

Node 24.19.0 / pnpm 12.1.0 on macOS arm64:

```sh
pnpm test test/scripts/install-cli.test.ts test/scripts/install-sh.test.ts test/scripts/install-ps1.test.ts test/openclaw-prepack.test.ts src/infra/update-global.test.ts src/infra/update-runner.test.ts test/scripts/prepublish-plugin-registry-shell.test.ts ui/src/styles/corner-shape.browser.test.ts
```

**550 passed across eight files**; 28 PowerShell runtime cases skipped because PowerShell is absent on this Mac. All three Chromium corner-shape tests executed and passed.

```sh
pnpm test src/plugins/registry-runtime.twitch-ingress.test.ts src/plugins/official-external-plugin-repair-hints.test.ts src/infra/update-global-lifecycle.test.ts src/infra/package-update-steps.test.ts src/cli/update-cli.test.ts test/scripts/package-acceptance-workflow.test.ts
```

**765 passed across six files**, including all ten Twitch ingress/reply cases. Before the fix, the Twitch suite failed in setup with the real Twurple/IRC/WebSocket client stack and could not run those ten cases. Direct module-resolution proof confirms the core package cannot resolve `@twurple/chat`, while the Twitch plugin resolves its owned dependency.

An isolated six-case Node probe also compared the historical smoke owner (`74e894d3f88^`) with current main: pnpm-linked transitive imports and physical installed realpaths fail before the existing main repair and pass afterward. Both versions correctly reject genuinely missing transitive imports; all cases preserve source bytes and caller-owned temporary siblings.

Codex autoreview of the final patch: **scoped-clean at P0–P3**, no accepted/actionable findings. `git diff --check` passed. This test-only forward-port does not change production channel behavior; synthetic ingress and real Node/pnpm/browser execution provide the scoped behavior proof.

The first [exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33690226684) caught a main-branch architectural constraint that the direct release cherry-pick violated: core tests may not import the low-level bundled-plugin path helper. Reproduced locally (1 boundary failure), then repaired in the existing channel contract loader without changing the guard. Boundary and Twitch suites passed all 20 cases afterward.

Reran the eight-file focused command above together with `test/extension-test-boundary.test.ts`, `src/plugins/registry-runtime.twitch-ingress.test.ts`, and `src/channels/plugins/contracts/session-binding.registry-backed.contract.test.ts`: **575 passed across 11 files**, including all five session-binding contracts and all three Chromium cases; the same 28 local PowerShell cases skipped.

`pnpm check:changed` passed again: core-test and root-test typechecks, targeted lint/format, script lint, boundary guards, and all unused-export scans. No gates were skipped.

After a clean rebase onto `7818c524d35`, the reviewed patch ID stayed unchanged. Reran boundary, Twitch ingress, prepack, and session-binding suites on head `31321c6d8a43`: **54 passed**. The 16 intervening main commits did not change these owners or the smoke/boundary implementation.


Final exact-head CI: **green** for `31321c6d8a43a2f63ea283dcb896def791a09859` in [run 33692880742](https://github.com/openclaw/openclaw/actions/runs/33692880742), including the previously failing built-artifact boundary check. The native CI watcher completed successfully.

### Latest ClawSweeper checklist disposition

The [23:04 UTC exact-head review](https://github.com/openclaw/openclaw/pull/136678#issuecomment-5517381167) found no code or security defect, but could not materialize current-main blobs in its own environment. Closed that source-inspection gap independently: fully materialized all 14 changed/owner/caller/sibling files at reviewed base `7818c524d35`, the bot's baseline `a394c3724e01`, and current main `9c2b626e2588`. Their contents match byte-for-byte across all three commits, including the contract loader, Twitch API/client/startup/monitor, public-artifact resolver, mock-reset owner, boundary guard, prepack caller/smoke implementation, and session-binding helpers. No owner delta or extra runtime repair is missing.

The requested integration mitigation is satisfied by the green exact-head CI run above, the fresh clean Codex review, and the post-rebase 54-case sanity pass. **Waiting for the bot to republish a higher confidence rating is explicitly skipped**: its documented infrastructure limitation is now covered by independent source and integration proof, with no actionable code/security finding remaining. This does not claim that the bot itself reverified that evidence. No code or CI gate was weakened.
