### PR TITLE
fix(release): run dependency evidence from trusted tooling

### DIFF
--- a/scripts/generate-dependency-release-evidence.mts
+++ b/scripts/generate-dependency-release-evidence.mts
@@ -357,6 +357,7 @@ async function runEvidenceReports(
   packageVersion: string,
 ) {
   let riskAcceptance: ReturnType<typeof resolveReleaseDependencyRiskAcceptance> = null;
+  const toolingRoot = path.resolve(import.meta.dirname, "..");
   // Report implementations belong to this tooling checkout; --root selects only the source data.
   // Release branches can keep frozen product bytes while trusted release tooling is repaired.
   for (const report of DEPENDENCY_EVIDENCE_REPORTS) {
@@ -364,8 +365,6 @@ async function runEvidenceReports(
       runCommand(
         "pnpm",
         [
-          "--dir",
-          path.resolve(import.meta.dirname, ".."),
           report.command.slice("pnpm ".length),
           "--",
           "--root",
@@ -376,7 +375,7 @@ async function runEvidenceReports(
           "--markdown",
           reportPath(outputDir, report.markdown),
         ],
-        rootDir,
+        toolingRoot,
         execFileSyncImpl,
       );
     } catch (error) {

--- a/test/scripts/generate-dependency-release-evidence.test.ts
+++ b/test/scripts/generate-dependency-release-evidence.test.ts
@@ -323,7 +323,7 @@ describe("generate-dependency-release-evidence", () => {
         const binDir = path.join(dir, "bin");
         const outputDir = path.join(dir, "evidence");
         const sourceDir = path.join(dir, "candidate");
-        const marker = path.join(dir, "candidate-tooling-executed");
+        const marker = path.join(dir, "pnpm-cwd");
         const githubOutput = path.join(dir, "github-output");
         await mkdir(binDir);
         await mkdir(sourceDir);
@@ -339,9 +339,9 @@ describe("generate-dependency-release-evidence", () => {
             "#!/usr/bin/env node",
             'const { writeFileSync } = require("node:fs");',
             "const args = process.argv.slice(2);",
-            'const toolingRoot = args[0] === "--dir" ? args[1] : process.cwd();',
-            'if (toolingRoot === process.env.RELEASE_TEST_SOURCE_ROOT) { writeFileSync(process.env.RELEASE_TEST_MARKER, "candidate"); throw new Error("Candidate tooling executed"); }',
-            'if (args[2] !== "deps:vuln:gate" || args[args.indexOf("--root") + 1] !== process.env.RELEASE_TEST_SOURCE_ROOT) throw new Error("Wrong report or target");',
+            "writeFileSync(process.env.RELEASE_TEST_MARKER, process.cwd());",
+            'if (args[0] !== "deps:vuln:gate") throw new Error("Wrong report command");',
+            'if (args[args.indexOf("--root") + 1] !== process.env.RELEASE_TEST_SOURCE_ROOT) throw new Error("Wrong report target");',
             'writeFileSync(args[args.indexOf("--json") + 1], JSON.stringify({ blockers: [{ id: "GHSA-fixture" }] }));',
             'writeFileSync(args[args.indexOf("--markdown") + 1], "# Blocking advisory evidence\\n");',
             "process.exitCode = 1;",
@@ -374,9 +374,9 @@ describe("generate-dependency-release-evidence", () => {
           },
         );
 
+        await expect(readFile(marker, "utf8")).resolves.toBe(path.resolve("."));
         expect(result.status).toBe(1);
-        expect(result.stderr).toContain("Command failed: pnpm --dir");
-        await expect(readFile(marker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+        expect(result.stderr).toContain("Command failed: pnpm deps:vuln:gate");
         await expect(readFile(githubOutput, "utf8")).resolves.toBe(`dir=${outputDir}\n`);
         await expect(
           readFile(path.join(outputDir, "dependency-vulnerability-gate.json"), "utf8"),


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/136325

## What Problem This Solves

Fixes an issue where historical and extended-stable npm validation failed when
the release target and trusted tooling checkout pinned different pnpm versions.

## Why This Change Was Made

Run dependency-report package scripts from the trusted tooling checkout while
passing the release checkout only through `--root`.

Corepack selects the package manager from process cwd before pnpm parses
`--dir`, so the previous argument did not establish the intended trust boundary.

## User Impact

Release operators can validate frozen targets without executing target-owned
report tooling or weakening dependency gates. Runtime behavior is unchanged.

## Evidence

- focused cwd regression failed before and passed after
- complete dependency-evidence generator suite: 14 passed
- direct trusted-workflow cwd regression from #136325 passed
- changed-file formatting, erasability, and lint passed
- P1 autoreview found no actionable issues
- Blacksmith Testbox passed the focused suites and complete `check:changed`:
  https://github.com/openclaw/openclaw/actions/runs/33690588679
- ClawSweeper found no blocking correctness or security issue and listed no
  before-merge or rank-up move
- historical failure: https://github.com/openclaw/openclaw/actions/runs/33688937120/job/100442938711
- exact-head required CI pending

`check:changed` reached the global script typecheck, then stopped on unrelated
missing extension and UI dependencies in the sparse local worktree. Neither
changed file appeared in the errors; the same gate passed in Testbox.
