### PR TITLE
fix(exec): show no-output placeholder for empty non-zero exits

### DIFF
--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -21,7 +21,6 @@ import {
   markTerminalPollObserved,
   waitForExecScope,
 } from "./bash-process-registry.js";
-import { EXEC_NO_OUTPUT_PLACEHOLDER } from "./bash-tools.exec-output.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import {
   getGatewayToolCallerIdentity,
@@ -781,31 +780,6 @@ describe("runExecProcess exit outcomes", () => {
     }
     expect(outcome.exitCode).toBe(1);
     expect(outcome.aggregated).toBe("done\n\n(Command exited with code 1)");
-  });
-
-  it("inserts the no-output placeholder before the non-zero exit suffix for empty output", async () => {
-    const { outcome } = await runExecWithExit({
-      stdout: "",
-      exit: {
-        reason: "exit",
-        exitCode: 1,
-        exitSignal: null,
-        durationMs: 123,
-        stdout: "",
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
-      },
-      timeoutSec: 30,
-    });
-    expect(outcome.status).toBe("completed");
-    if (outcome.status !== "completed") {
-      throw new Error(`Expected completed outcome, got ${outcome.status}`);
-    }
-    expect(outcome.exitCode).toBe(1);
-    expect(outcome.aggregated).toBe(
-      `${EXEC_NO_OUTPUT_PLACEHOLDER}\n\n(Command exited with code 1)`,
-    );
   });
 
   it("classifies timed out exits with registered-background guidance", async () => {

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -21,6 +21,7 @@ import {
   markTerminalPollObserved,
   waitForExecScope,
 } from "./bash-process-registry.js";
+import { EXEC_NO_OUTPUT_PLACEHOLDER } from "./bash-tools.exec-output.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import {
   getGatewayToolCallerIdentity,
@@ -780,6 +781,31 @@ describe("runExecProcess exit outcomes", () => {
     }
     expect(outcome.exitCode).toBe(1);
     expect(outcome.aggregated).toBe("done\n\n(Command exited with code 1)");
+  });
+
+  it("inserts the no-output placeholder before the non-zero exit suffix for empty output", async () => {
+    const { outcome } = await runExecWithExit({
+      stdout: "",
+      exit: {
+        reason: "exit",
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 123,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      timeoutSec: 30,
+    });
+    expect(outcome.status).toBe("completed");
+    if (outcome.status !== "completed") {
+      throw new Error(`Expected completed outcome, got ${outcome.status}`);
+    }
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.aggregated).toBe(
+      `${EXEC_NO_OUTPUT_PLACEHOLDER}\n\n(Command exited with code 1)`,
+    );
   });
 
   it("classifies timed out exits with registered-background guidance", async () => {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -48,8 +48,8 @@ import {
 } from "./bash-process-registry.js";
 import {
   appendExecTimeoutRetryGuidance,
-  EXEC_NO_OUTPUT_PLACEHOLDER,
   renderExecExitLabel,
+  renderExecOutputText,
   renderExecUpdateText,
 } from "./bash-tools.exec-output.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
@@ -564,16 +564,13 @@ function buildExecExitOutcome(params: {
     isNormalExit && !isShellFailure ? "completed" : "failed";
   if (status === "completed") {
     const exitMsg = exitCode !== 0 ? `\n\n(Command exited with code ${exitCode})` : "";
-    // Apply the empty-output placeholder before appending the exit-code suffix so
-    // truly empty output is still marked once the suffix makes the value non-empty.
-    const baseOutput = params.aggregated || EXEC_NO_OUTPUT_PLACEHOLDER;
     return {
       status: "completed",
       exitCode,
       exitSignal: params.exit.exitSignal,
       exitReason: params.exit.reason,
       durationMs: params.durationMs,
-      aggregated: baseOutput + exitMsg,
+      aggregated: renderExecOutputText(params.aggregated) + exitMsg,
       timedOut: false,
       noOutputTimedOut: params.exit.noOutputTimedOut,
     };

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -570,7 +570,7 @@ function buildExecExitOutcome(params: {
       exitSignal: params.exit.exitSignal,
       exitReason: params.exit.reason,
       durationMs: params.durationMs,
-      aggregated: renderExecOutputText(params.aggregated) + exitMsg,
+      aggregated: (exitMsg ? renderExecOutputText(params.aggregated) : params.aggregated) + exitMsg,
       timedOut: false,
       noOutputTimedOut: params.exit.noOutputTimedOut,
     };

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -48,6 +48,7 @@ import {
 } from "./bash-process-registry.js";
 import {
   appendExecTimeoutRetryGuidance,
+  EXEC_NO_OUTPUT_PLACEHOLDER,
   renderExecExitLabel,
   renderExecUpdateText,
 } from "./bash-tools.exec-output.js";
@@ -563,13 +564,16 @@ function buildExecExitOutcome(params: {
     isNormalExit && !isShellFailure ? "completed" : "failed";
   if (status === "completed") {
     const exitMsg = exitCode !== 0 ? `\n\n(Command exited with code ${exitCode})` : "";
+    // Apply the empty-output placeholder before appending the exit-code suffix so
+    // truly empty output is still marked once the suffix makes the value non-empty.
+    const baseOutput = params.aggregated || EXEC_NO_OUTPUT_PLACEHOLDER;
     return {
       status: "completed",
       exitCode,
       exitSignal: params.exit.exitSignal,
       exitReason: params.exit.reason,
       durationMs: params.durationMs,
-      aggregated: params.aggregated + exitMsg,
+      aggregated: baseOutput + exitMsg,
       timedOut: false,
       noOutputTimedOut: params.exit.noOutputTimedOut,
     };

--- a/src/agents/bash-tools.process.e2e.test.ts
+++ b/src/agents/bash-tools.process.e2e.test.ts
@@ -155,9 +155,31 @@ test("rejects malformed direct actions before requiring a session id", async () 
   expect(result.details).toMatchObject({ status: "failed" });
 });
 
-test.skipIf(process.platform === "win32")(
-  "renders the no-output placeholder before a real foreground nonzero exit",
-  async () => {
+test.each([
+  {
+    name: "empty nonzero exit",
+    source: "process.exit(1)",
+    expectedText: "(no output)\n\n(Command exited with code 1)",
+    expectedAggregated: "(no output)\n\n(Command exited with code 1)",
+    exitCode: 1,
+  },
+  {
+    name: "nonzero exit with output",
+    source: 'process.stdout.write("VISIBLE"); process.exit(1)',
+    expectedText: "VISIBLE\n\n(Command exited with code 1)",
+    expectedAggregated: "VISIBLE\n\n(Command exited with code 1)",
+    exitCode: 1,
+  },
+  {
+    name: "empty successful exit",
+    source: "process.exit(0)",
+    expectedText: "(no output)",
+    expectedAggregated: "",
+    exitCode: 0,
+  },
+])(
+  "renders a real foreground $name with the expected structured output",
+  async ({ source, expectedText, expectedAggregated, exitCode }) => {
     const execTool = createExecTool({
       host: "gateway",
       security: "full",
@@ -165,16 +187,15 @@ test.skipIf(process.platform === "win32")(
       allowBackground: false,
       timeoutSec: 10,
     });
-    const result = await execTool.execute("foreground-empty-nonzero", {
-      command: "sh -c 'exit 1'",
+    const result = await execTool.execute(`foreground-exit-${exitCode}`, {
+      command: currentNodeEvalCommand(source),
     });
-    const expected = "(no output)\n\n(Command exited with code 1)";
 
-    expect(textContent(result)).toBe(expected);
+    expect(textContent(result)).toBe(expectedText);
     expect(result.details).toMatchObject({
       status: "completed",
-      exitCode: 1,
-      aggregated: expected,
+      exitCode,
+      aggregated: expectedAggregated,
     });
   },
 );

--- a/src/agents/bash-tools.process.e2e.test.ts
+++ b/src/agents/bash-tools.process.e2e.test.ts
@@ -155,6 +155,30 @@ test("rejects malformed direct actions before requiring a session id", async () 
   expect(result.details).toMatchObject({ status: "failed" });
 });
 
+test.skipIf(process.platform === "win32")(
+  "renders the no-output placeholder before a real foreground nonzero exit",
+  async () => {
+    const execTool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      allowBackground: false,
+      timeoutSec: 10,
+    });
+    const result = await execTool.execute("foreground-empty-nonzero", {
+      command: "sh -c 'exit 1'",
+    });
+    const expected = "(no output)\n\n(Command exited with code 1)";
+
+    expect(textContent(result)).toBe(expected);
+    expect(result.details).toMatchObject({
+      status: "completed",
+      exitCode: 1,
+      aggregated: expected,
+    });
+  },
+);
+
 test.skipIf(process.platform === "win32").each([
   { name: "quiet successful exit", exitCode: 0, output: "", expectsNotification: false },
   { name: "quiet nonzero exit", exitCode: 7, output: "", expectsNotification: true },


### PR DESCRIPTION
Closes #136645

## Problem

A completed foreground `exec` command that produced no output and exited non-zero returned only blank lines plus the exit-code suffix. The model could not tell that the command ran and produced no output.

## Root cause

`buildExecExitOutcome` appended the non-zero exit suffix before the shared empty-output renderer ran. The suffix made the value non-empty, so the renderer could never add `(no output)`.

## Fix

Render empty output before appending a non-zero exit suffix. Keep quiet successful exit details raw, and keep non-empty output byte-identical.

The regression test drives a real foreground child process through `createExecTool(...).execute()` for all three cases on the same tool-result boundary.

## Real foreground proof

Current `main` at `2b59eaa1aa01ef89bed50c220e58a3985ddcad75`:

```text
text and aggregated start with two blank lines, then:
(Command exited with code 1)
```

This head at `edc513f66d9701a8b3ba067d4e332f9b7b9cc5b4` in a fresh secretless Linux container:

```text
empty non-zero text and aggregated:
(no output)

(Command exited with code 1)

non-empty non-zero text and aggregated:
VISIBLE

(Command exited with code 1)

empty success text: (no output)
empty success aggregated: empty string
```

## Validation

- `oxfmt --check src/agents/bash-tools.exec-runtime.ts src/agents/bash-tools.process.e2e.test.ts`
- `node scripts/run-vitest.mjs src/agents/bash-tools.process.e2e.test.ts --reporter=verbose` — 12 passed
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-runtime.test.ts --reporter=verbose` — 30 passed
- Exact changed blobs matched the committed head after the isolated run.

Production LOC: +2/-1 (net +1). Tests: +45/-0 against the PR base.
