### PR TITLE
fix(macos): deliver completion before notification status arrives

### DIFF
--- a/ui/src/app/native-notifications.test.ts
+++ b/ui/src/app/native-notifications.test.ts
@@ -127,7 +127,7 @@ describe("native notifications", () => {
   });
 
   it.each(["unknown", "notDetermined", "denied", "granted"] as const)(
-    "sends private background completion only with granted permission: %s",
+    "forwards completion to the native permission owner without prompting: %s",
     (permission) => {
       const postMessage = installBridge();
       capability = createNativeNotificationsCapability();
@@ -142,11 +142,9 @@ describe("native notifications", () => {
 
       capability?.backgroundSessionCompleted({ runId: "run-1", path: "/chat/research" });
 
-      expect(postMessage.mock.calls).toEqual(
-        permission === "granted"
-          ? [[{ type: "background-session-completed", runId: "run-1", path: "/chat/research" }]]
-          : [],
-      );
+      expect(postMessage.mock.calls).toEqual([
+        [{ type: "background-session-completed", runId: "run-1", path: "/chat/research" }],
+      ]);
     },
   );
 

--- a/ui/src/app/native-notifications.ts
+++ b/ui/src/app/native-notifications.ts
@@ -139,9 +139,7 @@ export function createNativeNotificationsCapability(): NativeNotificationsCapabi
       postMessage({ type: "send-test" });
     },
     backgroundSessionCompleted(completion) {
-      if (snapshot.permission === "granted") {
-        postMessage({ type: "background-session-completed", ...completion });
-      }
+      postMessage({ type: "background-session-completed", ...completion });
     },
     dispose() {
       window.removeEventListener(NATIVE_NOTIFICATIONS_STATUS_EVENT, handleStatus);

--- a/ui/src/pages/new-session/draft-submission-background.test.ts
+++ b/ui/src/pages/new-session/draft-submission-background.test.ts
@@ -20,11 +20,6 @@ function nativeBackgroundFixture(options: Parameters<typeof createDraftFixture>[
   const nativeNotifications = createNativeNotificationsCapability();
   const fixture = createDraftFixture(options);
   Object.assign(fixture.context, { nativeNotifications, basePath: "" });
-  window.dispatchEvent(
-    new CustomEvent("openclaw:native-notifications-status", {
-      detail: { permission: "granted", test: null },
-    }),
-  );
   vi.mocked(fixture.context.sessions.createResult).mockResolvedValue({
     key: "agent:main:dashboard:background",
     initialRun: { status: "started", runId: "run-background" },
@@ -56,7 +51,7 @@ function failedPlacement(
 }
 
 describe("DraftSubmissionFlow background completion", () => {
-  it("delivers an accepted background completion to the native dashboard bridge", async () => {
+  it("delivers an accepted background completion before the first native status reply", async () => {
     const { context, flow, postMessage, dispose } = nativeBackgroundFixture({
       request: async (method) => (method === "agent.wait" ? { status: "ok", endedAt: 1 } : {}),
     });


### PR DESCRIPTION
Related: #136519

## What Problem This Solves

Fixes an issue where macOS users with notifications already enabled could miss a background-session completion immediately after opening the dashboard, before its initial permission status arrived. It also prevents an outdated denied/not-requested display from suppressing completion after permission changes in System Settings.

This follows up the [late startup-permission finding](https://github.com/openclaw/openclaw/pull/136519#issuecomment-5514529063) on #136519. Thanks to [김훈기](https://discord.com/channels/1456350064065904867/1456350065223270435/1544577265294250025) for the original missing-completion-notification report.

## Why This Change Was Made

The UI now forwards completion to the existing native owner instead of making a second permission decision from an asynchronous display snapshot. The native sender already checks current macOS authorization and explicitly disables permission requests for background completion; that authoritative check is unchanged.

There is no unknown-state fallback, queued replay, new configuration, environment variable, persistent store, or Gateway protocol change. The 2026.8.2 macOS app publication lag remains a separate release-process item.

## User Impact

An already-authorized background completion can reach Notification Center even before the dashboard learns the current permission. Denied or undetermined OS permission still prevents delivery, without an automatic prompt. Explicit notification settings and the existing first-send permission flow remain unchanged.

## Evidence

The existing four-state capability test now requires the same completion handoff for unknown, granted, denied, and not-determined UI snapshots, and asserts the complete posted-message list, excluding any permission request. Removing the artificial granted-status setup from the existing background-submission fixture exercises all 11 integration cases before the first native status reply; no new test seam or duplicate fixture was added.

```text
Before owner repair, production at merged 868aae3c56db67af6d7fdcabc1dd26739a7f6c5e:
node scripts/run-vitest.mjs ui/src/app/native-notifications.test.ts ui/src/pages/new-session/draft-submission-background.test.ts
2 files: 12 failed, 13 passed
Failure: completion message absent for 3 non-granted UI snapshots and 9 completed-run cases.
Selected-session and replaced-Gateway suppression controls still pass.

After owner repair:
node scripts/run-vitest.mjs ui/src/app/native-notifications.test.ts ui/src/app/notifications-auto-prompt.test.ts ui/src/app/app-host-native-shell.test.ts ui/src/pages/new-session/draft-submission-flow.test.ts ui/src/pages/new-session/draft-submission-background.test.ts
5 files: 112 passed; wrapper 10.97 seconds
```

The native no-prompt boundary was inspected directly: `BackgroundSessionNotifications.send` passes `requestPermission: false`; `NotificationManager.send` reads fresh OS settings and returns for not-determined permission before `requestAuthorization`, and returns for denied permission. The native bridge, bounded action lifetime, target/window routing, and OS permission policy are unchanged.

The unchanged native completion/window owners also passed 53 tests across eight suites in a disposable macOS VM (18.782 seconds): all 52 window/Gateway/Settings siblings, plus the existing notification-authorization test covering authorized, provisional, denied, not-determined, and ephemeral OS states. This is native authorization-policy and lifecycle coverage, not an injected-OS-state test of `NotificationManager.send`. No OS permission setting changed.

Production: +1/-3, net -2 lines. Tests: +5/-12, net -7 lines. The fix deletes the duplicated permission gate and the test setup that hid it. Existing notification documentation already describes the intended behavior and needs no change.

Independent local and exact committed-branch P2 reviews and targeted type-aware lint passed with no actionable findings. The changed-file check passed its guardrails, formatting, core graph and UI i18n checks, then stopped at the pre-existing borrowed-dependency gap: `packages/mermaid-renderer/src/renderer.ts:3` cannot resolve `mermaid` (TS2307). No dependency mutation or bypass was used; this is not a local full-check pass. The initial ordinary commit hook stopped at the dependency-less worktree's missing formatter. The identical candidate was then committed with normal hooks in the prepared checkout; its reviewed source hashes are unchanged. The production UI build passes (9.81 seconds), including all 792 precompressed sidecars and the existing startup/performance budgets. The [complete exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33690639130) passed for `22e4d614d57b3f6020213c44bd04cee862c5229d`; the required watcher ended GREEN. The fresh rollup has 126 successful checks and 75 intentional skips, none pending or failed. The fresh-dependency checks close the local dependency coverage gap without relabeling the local command as a pass. [Recent main CI](https://github.com/openclaw/openclaw/actions/runs/33690820297) is also green. A bounded real-Chromium replay of the existing New Session flow also passed in 33.06 seconds. With the first native status reply withheld, the original merged module produced zero completion messages, while the fixed module produced exactly one; both produced zero permission requests, retained an unknown display snapshot, showed the Done toast, and opened the exact session. Gateway and native transport were mocked, so this is interactive browser-harness proof, not a native OS banner. The earlier signed real banner/click proof in #136519 does not exercise this startup-status race. A fresh native OS-banner capture is currently constrained by unapproved OS permission prompts in the isolated VM; no permission choice or bypass is authorized by this fix.

NO-FOLLOW-UP: removing the duplicate permission decision is the rent-paying owner simplification; no independent refactor remains in this three-file change.

The [fresh review of this exact head](https://github.com/openclaw/openclaw/pull/136683#issuecomment-5517411239) found no correctness or security defect and listed no remaining pre-merge or rank-up item. The exact-head CI gate is fulfilled.

The final Developer-ID-signed development composite includes the exact `22e4d614d57b3f6020213c44bd04cee862c5229d` UI. A fresh disposable-VM extraction passed archive checksum `76d39d94a1b7a446f9a7022e3965c1f003e140c1b5204171d632be595572e253`, deep strict signature verification, matching app/worker base build identities and the exact UI index hash. The app was not launched and no OS permission changed. This is signed-artifact verification, not a release build or new OS-banner capture. The unchanged native window/authorization suite was also repeated successfully on the final combined native build: 53 tests in eight suites, 15.529 seconds.
