### PR TITLE
fix(media): report fractional storage limits accurately

### DIFF
--- a/extensions/whatsapp/src/inbound/media.node.test.ts
+++ b/extensions/whatsapp/src/inbound/media.node.test.ts
@@ -158,6 +158,19 @@ describe("downloadInboundMedia", () => {
     expect(downloadMediaMessage.mock.calls[0]?.[1]).toBe("stream");
   });
 
+  it("preserves the store's fractional limit error for the message owner", async () => {
+    const limitError = Object.assign(new Error("Media exceeds 256KB limit"), { code: "too-large" });
+    saveMediaStream.mockRejectedValueOnce(limitError);
+
+    await expect(
+      downloadInboundMedia(
+        { message: { imageMessage: { mimetype: "image/jpeg" } } } as never,
+        mockSock as never,
+        0.25 * 1024 * 1024,
+      ),
+    ).rejects.toBe(limitError);
+  });
+
   it("propagates transport download failures to the message owner", async () => {
     downloadMediaMessage.mockRejectedValueOnce(new Error("expired media reference"));
 

--- a/extensions/whatsapp/src/inbound/media.ts
+++ b/extensions/whatsapp/src/inbound/media.ts
@@ -49,12 +49,7 @@ export async function downloadInboundMedia(
     "inbound",
     maxBytes,
     fileName,
-  ).catch((err: unknown) => {
-    if (err instanceof Error && /Media exceeds/i.test(err.message)) {
-      throw new Error(`Media exceeds ${Math.round(maxBytes / (1024 * 1024))}MB limit`);
-    }
-    throw err;
-  });
+  );
   return { saved, mimetype, fileName };
 }
 

--- a/src/agents/tools/video-generate-tool.storage.test.ts
+++ b/src/agents/tools/video-generate-tool.storage.test.ts
@@ -257,6 +257,42 @@ describe("video generation invocation QA", () => {
     });
   });
 
+  it("reports the fractional save cap when a generated video has no provider URL", async () => {
+    const root = tempDirs.make("openclaw-qa-video-fractional-cap-");
+    const maxBytes = createMp4Fixture().byteLength;
+    const provider: VideoGenerationProvider = {
+      id: "qa-capped-video",
+      defaultModel: "capped-v1",
+      models: ["capped-v1"],
+      isConfigured: () => true,
+      capabilities: {},
+      generateVideo: async () => ({
+        videos: [
+          {
+            buffer: Buffer.concat([createMp4Fixture(), Buffer.from([0x00])]),
+            mimeType: "video/mp4",
+          },
+        ],
+      }),
+    };
+    const config = createConfig("qa-capped-video/capped-v1", []);
+    config.agents!.defaults!.mediaMaxMb = maxBytes / (1024 * 1024);
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      const tool = requireVideoTool(
+        createVideoGenerateTool({
+          config,
+          agentDir: path.join(root, "agent"),
+          workspaceDir: root,
+          preparedModelRuntime: createPreparedRuntime([provider]),
+        }),
+      );
+      await expect(
+        tool.execute("qa-video-fractional-cap", { prompt: "Generate a capped QA clip." }),
+      ).rejects.toThrow("Media exceeds 24B limit");
+    });
+  });
+
   it("rejects unknown and wrong-typed provider options before provider invocation", async () => {
     let providerCalls = 0;
     const createProvider = (id: string, model: string): VideoGenerationProvider => ({

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as mediaStore from "../../media/store.js";
+import { SaveMediaSourceError } from "../../media/store.shared.js";
 import * as webMedia from "../../media/web-media.js";
 import * as pluginConfig from "../../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
@@ -993,7 +994,12 @@ describe("createVideoGenerateTool", () => {
       ignoredOverrides: [],
       videos: [
         { buffer: Buffer.from("saved"), mimeType: "video/mp4", fileName: "saved.mp4" },
-        { buffer: Buffer.from("failed"), mimeType: "video/mp4", fileName: "failed.mp4" },
+        {
+          buffer: Buffer.from("failed"),
+          url: "https://media.example/failed.mp4",
+          mimeType: "video/mp4",
+          fileName: "failed.mp4",
+        },
       ],
     });
     const terminalError = new Error("video persistence failed");
@@ -1052,7 +1058,7 @@ describe("createVideoGenerateTool", () => {
       ],
     });
     vi.spyOn(mediaStore, "saveMediaBuffer")
-      .mockRejectedValueOnce(new Error("Media exceeds 16MB limit"))
+      .mockRejectedValueOnce(SaveMediaSourceError.tooLarge(16 * 1024 * 1024))
       .mockResolvedValueOnce({
         path: "/tmp/second.mp4",
         id: "second.mp4",

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -8,6 +8,7 @@ import { parseVideoGenerationModelRef } from "../../media-generation/model-ref.j
 import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { probeMediaFilesWithinBudget } from "../../media/media-probe.js";
 import { saveMediaBuffer } from "../../media/store.js";
+import { SaveMediaSourceError } from "../../media/store.shared.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { readBooleanParam } from "../../plugin-sdk/boolean-param.js";
 import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
@@ -464,10 +465,6 @@ type ExecutedVideoGeneration = {
   wakeResult: string;
 };
 
-function isGeneratedMediaSizeLimitError(error: unknown): boolean {
-  return error instanceof Error && /^Media exceeds \d+MB limit$/.test(error.message);
-}
-
 async function executeVideoGenerationJob(params: {
   effectiveCfg: OpenClawConfig;
   prompt: string;
@@ -565,7 +562,7 @@ async function executeVideoGenerationJob(params: {
           savedMedia,
         };
       } catch (error) {
-        if (video.url && isGeneratedMediaSizeLimitError(error)) {
+        if (video.url && error instanceof SaveMediaSourceError && error.code === "too-large") {
           return {
             value: {
               kind: "url" as const,

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -24,6 +24,7 @@ import { isTransientNetworkError } from "../infra/retryable-network-errors.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
 import { saveMediaStream, type SavedMedia } from "./store.js";
+import { SaveMediaSourceError } from "./store.shared.js";
 
 /** Default remote media fetch cap shared by buffer reads and store writes. */
 const DEFAULT_FETCH_MEDIA_MAX_BYTES = MAX_DOCUMENT_BYTES;
@@ -543,10 +544,6 @@ async function* responseBodyChunks(
   }
 }
 
-function isMediaLimitError(err: unknown): boolean {
-  return err instanceof Error && /Media exceeds .* limit/.test(err.message);
-}
-
 async function saveOkMediaResponse(params: {
   res: Response;
   finalUrl: string;
@@ -590,7 +587,7 @@ async function saveOkMediaResponse(params: {
     if (err instanceof MediaFetchError) {
       throw err;
     }
-    if (isMediaLimitError(err)) {
+    if (err instanceof SaveMediaSourceError && err.code === "too-large") {
       throw new MediaFetchError(
         "max_bytes",
         `Failed to fetch media from ${params.sourceUrl}: payload exceeds maxBytes ${params.maxBytes}`,

--- a/src/media/store.shared.ts
+++ b/src/media/store.shared.ts
@@ -1,7 +1,34 @@
+import { formatByteSize } from "@openclaw/normalization-core";
+
 // Media files remain readable by sandbox container UIDs; the private media
 // directory is the trust boundary. Temp and final writes must use one mode.
 export const MEDIA_FILE_MODE = 0o644;
 
-export function formatMediaLimitMb(maxBytes: number): string {
-  return `${(maxBytes / (1024 * 1024)).toFixed(0)}MB`;
+/** Stable error categories for unsafe or failed source-file ingestion. */
+type SaveMediaSourceErrorCode =
+  | "invalid-path"
+  | "not-found"
+  | "not-file"
+  | "path-mismatch"
+  | "too-large";
+
+/** Media persistence failure with a stable category for callers. */
+export class SaveMediaSourceError extends Error {
+  code: SaveMediaSourceErrorCode;
+
+  constructor(code: SaveMediaSourceErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.code = code;
+    this.name = "SaveMediaSourceError";
+  }
+
+  static tooLarge(maxBytes: number, options?: ErrorOptions): SaveMediaSourceError {
+    const limit = formatByteSize(maxBytes, {
+      style: "legacy-binary",
+      maxUnit: "mega",
+      separator: "",
+      fractionDigits: (value) => (Number.isInteger(value) ? 0 : 2),
+    });
+    return new SaveMediaSourceError("too-large", `Media exceeds ${limit} limit`, options);
+  }
 }

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -35,12 +35,6 @@ describe("media store", () => {
     vi.restoreAllMocks();
   });
 
-  async function withTempStore<T>(
-    fn: (store: typeof import("./store.js"), home: string) => Promise<T>,
-  ): Promise<T> {
-    return await fn(store, home);
-  }
-
   async function expectPathMissing(targetPath: string): Promise<void> {
     let statError: unknown;
     try {
@@ -50,18 +44,6 @@ describe("media store", () => {
     }
     expect(statError).toBeInstanceOf(Error);
     expect((statError as NodeJS.ErrnoException).code).toBe("ENOENT");
-  }
-
-  async function expectOriginalFilenameCase(params: {
-    filename: string;
-    expected: string;
-    basePath?: string;
-  }) {
-    await withTempStore(async (storeLocal23) => {
-      expect(
-        storeLocal23.extractOriginalFilename(`${params.basePath ?? "/path/to"}/${params.filename}`),
-      ).toBe(params.expected);
-    });
   }
 
   async function expectRetryAfterPrunedWriteCase(params: {
@@ -102,12 +84,10 @@ describe("media store", () => {
         import.meta.url,
         mockKey,
       );
-      await withTempStore(async (_store, homeLocal8) => {
-        const saved = await params.run(storeWithMock, homeLocal8);
-        const savedStat = await fs.stat(saved.path);
-        expect(injectedEnoent).toBe(true);
-        expect(savedStat.isFile()).toBe(true);
-      });
+      const saved = await params.run(storeWithMock, home);
+      const savedStat = await fs.stat(saved.path);
+      expect(injectedEnoent).toBe(true);
+      expect(savedStat.isFile()).toBe(true);
     } finally {
       vi.doUnmock("../infra/file-store.js");
     }
@@ -144,23 +124,21 @@ describe("media store", () => {
         import.meta.url,
         mockKey,
       );
-      await withTempStore(async (_store) => {
-        const mediaDir = await storeWithMock.ensureMediaDir();
-        let saveError: unknown;
-        try {
-          await storeWithMock.saveMediaBuffer(Buffer.from("voice"), "audio/ogg", "failed-buffer");
-        } catch (error) {
-          saveError = error;
-        }
-        expect(saveError).toBeInstanceOf(Error);
-        expect((saveError as NodeJS.ErrnoException).code).toBe("ENOSPC");
+      const mediaDir = await storeWithMock.ensureMediaDir();
+      let saveError: unknown;
+      try {
+        await storeWithMock.saveMediaBuffer(Buffer.from("voice"), "audio/ogg", "failed-buffer");
+      } catch (error) {
+        saveError = error;
+      }
+      expect(saveError).toBeInstanceOf(Error);
+      expect((saveError as NodeJS.ErrnoException).code).toBe("ENOSPC");
 
-        const failedDir = path.join(mediaDir, "failed-buffer");
-        const entries = await fs.readdir(failedDir).catch(() => []);
-        expect(attemptedRelPaths).toHaveLength(1);
-        expect(path.basename(attemptedRelPaths[0] ?? "")).toMatch(/^[^/\\]+\.ogg$/);
-        expect(entries).toStrictEqual([]);
-      });
+      const failedDir = path.join(mediaDir, "failed-buffer");
+      const entries = await fs.readdir(failedDir).catch(() => []);
+      expect(attemptedRelPaths).toHaveLength(1);
+      expect(path.basename(attemptedRelPaths[0] ?? "")).toMatch(/^[^/\\]+\.ogg$/);
+      expect(entries).toStrictEqual([]);
     } finally {
       vi.doUnmock("../infra/file-store.js");
     }
@@ -173,32 +151,28 @@ describe("media store", () => {
     expectUuidOnly?: boolean;
     maxBaseNameLength?: number;
   }) {
-    await withTempStore(async (storeLocal22) => {
-      const saved = await storeLocal22.saveMediaBuffer(
-        Buffer.from("test content"),
-        "text/plain",
-        "inbound",
-        5 * 1024 * 1024,
-        params.originalFilename,
-      );
+    const saved = await store.saveMediaBuffer(
+      Buffer.from("test content"),
+      "text/plain",
+      "inbound",
+      5 * 1024 * 1024,
+      params.originalFilename,
+    );
 
-      expect(saved.id).toMatch(params.expectedIdPattern);
-      if (params.expectedExtractedFilename) {
-        expect(storeLocal22.extractOriginalFilename(saved.path)).toBe(
-          params.expectedExtractedFilename,
-        );
-      }
-      if (params.expectUuidOnly) {
-        expect(saved.id).not.toContain("---");
-      }
-      if (params.maxBaseNameLength !== undefined) {
-        const baseName = expectDefined(
-          path.parse(saved.id).name.split("---")[0],
-          'path.parse(saved.id).name.split("---")[0] test invariant',
-        );
-        expect(baseName.length).toBeLessThanOrEqual(params.maxBaseNameLength);
-      }
-    });
+    expect(saved.id).toMatch(params.expectedIdPattern);
+    if (params.expectedExtractedFilename) {
+      expect(store.extractOriginalFilename(saved.path)).toBe(params.expectedExtractedFilename);
+    }
+    if (params.expectUuidOnly) {
+      expect(saved.id).not.toContain("---");
+    }
+    if (params.maxBaseNameLength !== undefined) {
+      const baseName = expectDefined(
+        path.parse(saved.id).name.split("---")[0],
+        'path.parse(saved.id).name.split("---")[0] test invariant',
+      );
+      expect(baseName.length).toBeLessThanOrEqual(params.maxBaseNameLength);
+    }
   }
 
   async function expectSavedSourceCase(params: {
@@ -209,20 +183,18 @@ describe("media store", () => {
     mutateSource?: (filePath: string) => Promise<void>;
     assertSaved: (saved: Awaited<ReturnType<typeof store.saveMediaSource>>) => Promise<void> | void;
   }) {
-    await withTempStore(async (storeLocal21, homeLocal7) => {
-      const sourcePath = path.join(homeLocal7, params.relativeSourcePath);
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(sourcePath, params.contents);
-      await params.mutateSource?.(sourcePath);
-      const saved = await storeLocal21.saveMediaSource(sourcePath);
-      if (params.expectedContentType) {
-        expect(saved.contentType).toBe(params.expectedContentType);
-      }
-      if (params.expectedExtension) {
-        expect(path.extname(saved.path)).toBe(params.expectedExtension);
-      }
-      await params.assertSaved(saved);
-    });
+    const sourcePath = path.join(home, params.relativeSourcePath);
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, params.contents);
+    await params.mutateSource?.(sourcePath);
+    const saved = await store.saveMediaSource(sourcePath);
+    if (params.expectedContentType) {
+      expect(saved.contentType).toBe(params.expectedContentType);
+    }
+    if (params.expectedExtension) {
+      expect(path.extname(saved.path)).toBe(params.expectedExtension);
+    }
+    await params.assertSaved(saved);
   }
 
   async function expectCleanedSavedSourceCase(params: {
@@ -258,18 +230,16 @@ describe("media store", () => {
       buffer: Buffer,
     ) => Promise<void> | void;
   }) {
-    await withTempStore(async (storeLocal20) => {
-      const saved = await storeLocal20.saveMediaBuffer(
-        params.buffer,
-        params.contentType,
-        "inbound",
-        5 * 1024 * 1024,
-        params.originalFilename,
-      );
-      expect(saved.contentType).toBe(params.expectedContentType);
-      expect(saved.path.endsWith(params.expectedExtension)).toBe(true);
-      await params.assertSaved?.(saved, params.buffer);
-    });
+    const saved = await store.saveMediaBuffer(
+      params.buffer,
+      params.contentType,
+      "inbound",
+      5 * 1024 * 1024,
+      params.originalFilename,
+    );
+    expect(saved.contentType).toBe(params.expectedContentType);
+    expect(saved.path.endsWith(params.expectedExtension)).toBe(true);
+    await params.assertSaved?.(saved, params.buffer);
   }
 
   async function expectRejectedSourceCase(params: {
@@ -277,27 +247,25 @@ describe("media store", () => {
     setupSource?: (home: string) => Promise<string>;
     expectedError: string | Record<string, unknown>;
   }) {
-    await withTempStore(async (storeLocal19, homeLocal6) => {
-      const sourcePath =
-        params.setupSource !== undefined
-          ? await params.setupSource(homeLocal6)
-          : path.join(homeLocal6, params.relativeSourcePath ?? "");
-      if (typeof params.expectedError === "string") {
-        const rejection = expect(storeLocal19.saveMediaSource(sourcePath)).rejects;
-        await rejection.toThrow(params.expectedError);
-        return;
-      }
-      let sourceError: unknown;
-      try {
-        await storeLocal19.saveMediaSource(sourcePath);
-      } catch (error) {
-        sourceError = error;
-      }
-      expect(sourceError).toBeInstanceOf(Error);
-      for (const [key, value] of Object.entries(params.expectedError)) {
-        expect((sourceError as Record<string, unknown>)[key]).toStrictEqual(value);
-      }
-    });
+    const sourcePath =
+      params.setupSource !== undefined
+        ? await params.setupSource(home)
+        : path.join(home, params.relativeSourcePath ?? "");
+    if (typeof params.expectedError === "string") {
+      const rejection = expect(store.saveMediaSource(sourcePath)).rejects;
+      await rejection.toThrow(params.expectedError);
+      return;
+    }
+    let sourceError: unknown;
+    try {
+      await store.saveMediaSource(sourcePath);
+    } catch (error) {
+      sourceError = error;
+    }
+    expect(sourceError).toBeInstanceOf(Error);
+    for (const [key, value] of Object.entries(params.expectedError)) {
+      expect((sourceError as Record<string, unknown>)[key]).toStrictEqual(value);
+    }
   }
 
   async function createSymlinkSource(homeLocal5: string) {
@@ -321,79 +289,97 @@ describe("media store", () => {
     }>;
     run: (store: typeof import("./store.js")) => Promise<void>;
   }) {
-    await withTempStore(async (storeLocal18) => {
-      const state = await params.setup(storeLocal18);
-      await params.run(storeLocal18);
-      for (const removedFile of state.removedFiles) {
-        await expectPathMissing(removedFile);
-      }
-      for (const preservedFile of state.preservedFiles) {
-        const stat = await fs.stat(preservedFile);
-        expect(stat.isFile()).toBe(true);
-      }
-      for (const removedDir of state.removedDirs ?? []) {
-        await expectPathMissing(removedDir);
-      }
-      for (const preservedDir of state.preservedDirs ?? []) {
-        const stat = await fs.stat(preservedDir);
-        expect(stat.isDirectory()).toBe(true);
-      }
-    });
+    const state = await params.setup(store);
+    await params.run(store);
+    for (const removedFile of state.removedFiles) {
+      await expectPathMissing(removedFile);
+    }
+    for (const preservedFile of state.preservedFiles) {
+      const stat = await fs.stat(preservedFile);
+      expect(stat.isFile()).toBe(true);
+    }
+    for (const removedDir of state.removedDirs ?? []) {
+      await expectPathMissing(removedDir);
+    }
+    for (const preservedDir of state.preservedDirs ?? []) {
+      const stat = await fs.stat(preservedDir);
+      expect(stat.isDirectory()).toBe(true);
+    }
   }
 
   it.each([
     {
       name: "creates and returns media directory",
       run: async () => {
-        await withTempStore(async (storeLocal17, homeLocal4) => {
-          const dir = await storeLocal17.ensureMediaDir();
-          expect(isPathWithinBase(homeLocal4, dir)).toBe(true);
-          expect(path.normalize(dir)).toContain(`${path.sep}.openclaw${path.sep}media`);
-          const stat = await fs.stat(dir);
-          expect(stat.isDirectory()).toBe(true);
-        });
+        const dir = await store.ensureMediaDir();
+        expect(isPathWithinBase(home, dir)).toBe(true);
+        expect(path.normalize(dir)).toContain(`${path.sep}.openclaw${path.sep}media`);
+        const stat = await fs.stat(dir);
+        expect(stat.isDirectory()).toBe(true);
       },
     },
     {
       name: "enforces the media size limit",
       run: async () => {
-        await withTempStore(async (storeLocal16) => {
-          const huge = Buffer.alloc(5 * 1024 * 1024 + 1);
-          await expect(storeLocal16.saveMediaBuffer(huge)).rejects.toThrow(
-            "Media exceeds 5MB limit",
-          );
+        const huge = Buffer.alloc(5 * 1024 * 1024 + 1);
+        await expect(store.saveMediaBuffer(huge)).rejects.toThrow("Media exceeds 5MB limit");
+      },
+    },
+    {
+      name: "reports fractional buffer size limits",
+      run: async () => {
+        const maxBytes = 0.25 * 1024 * 1024;
+        await expect(
+          store.saveMediaBuffer(
+            Buffer.alloc(maxBytes + 1),
+            "application/octet-stream",
+            "fractional-buffer",
+            maxBytes,
+          ),
+        ).rejects.toThrow("Media exceeds 256KB limit");
+      },
+    },
+    {
+      name: "reports fractional source size limits",
+      run: async () => {
+        const maxBytes = 1.5 * 1024 * 1024;
+        const sourcePath = path.join(home, "fractional-source.bin");
+        await fs.writeFile(sourcePath, Buffer.alloc(maxBytes + 1));
+        await expect(
+          store.saveMediaSource(sourcePath, undefined, "outbound", maxBytes),
+        ).rejects.toMatchObject({
+          name: "SaveMediaSourceError",
+          code: "too-large",
+          message: "Media exceeds 1.50MB limit",
+          cause: expect.any(Error),
         });
       },
     },
     {
       name: "allows callers to override the default source size limit",
       run: async () => {
-        await withTempStore(async (storeLocal15, homeLocal3) => {
-          const sourcePath = path.join(homeLocal3, "large-source.bin");
-          await fs.writeFile(sourcePath, Buffer.alloc(6 * 1024 * 1024, 0x41));
+        const sourcePath = path.join(home, "large-source.bin");
+        await fs.writeFile(sourcePath, Buffer.alloc(6 * 1024 * 1024, 0x41));
 
-          const saved = await storeLocal15.saveMediaSource(
-            sourcePath,
-            undefined,
-            "outbound",
-            8 * 1024 * 1024,
-          );
+        const saved = await store.saveMediaSource(
+          sourcePath,
+          undefined,
+          "outbound",
+          8 * 1024 * 1024,
+        );
 
-          expect(saved.size).toBe(6 * 1024 * 1024);
-        });
+        expect(saved.size).toBe(6 * 1024 * 1024);
       },
     },
     {
       name: "reports the effective source size limit in too-large errors",
       run: async () => {
-        await withTempStore(async (storeLocal14, homeLocal2) => {
-          const sourcePath = path.join(homeLocal2, "too-large-source.bin");
-          await fs.writeFile(sourcePath, Buffer.alloc(7 * 1024 * 1024, 0x41));
+        const sourcePath = path.join(home, "too-large-source.bin");
+        await fs.writeFile(sourcePath, Buffer.alloc(7 * 1024 * 1024, 0x41));
 
-          await expect(
-            storeLocal14.saveMediaSource(sourcePath, undefined, "outbound", 6 * 1024 * 1024),
-          ).rejects.toThrow("Media exceeds 6MB limit");
-        });
+        await expect(
+          store.saveMediaSource(sourcePath, undefined, "outbound", 6 * 1024 * 1024),
+        ).rejects.toThrow("Media exceeds 6MB limit");
       },
     },
     {
@@ -444,160 +430,139 @@ describe("media store", () => {
     {
       name: "uses original filename to detect generic stream content type",
       run: async () => {
-        await withTempStore(async (storeLocal11) => {
-          const saved = await storeLocal11.saveMediaStream(
-            Readable.from([Buffer.from("name,value\none,1\n")]),
-            "application/octet-stream",
-            "stream-inbound",
-            1024,
-            "report.csv",
-          );
+        const saved = await store.saveMediaStream(
+          Readable.from([Buffer.from("name,value\none,1\n")]),
+          "application/octet-stream",
+          "stream-inbound",
+          1024,
+          "report.csv",
+        );
 
-          expect(saved.id).toMatch(/^report---[a-f0-9-]{36}\.csv$/);
-          expect(saved.contentType).toBe("text/csv");
-        });
+        expect(saved.id).toMatch(/^report---[a-f0-9-]{36}\.csv$/);
+        expect(saved.contentType).toBe("text/csv");
       },
     },
     {
       name: "prefers detected stream mime over mixed-case generic zip header extension",
       run: async () => {
-        await withTempStore(async (storeLocal10) => {
-          const saved = await storeLocal10.saveMediaStream(
-            Readable.from([Buffer.from("docx")]),
-            "Application/Zip",
-            "stream-inbound",
-            1024,
-            undefined,
-            "document.docx",
-          );
+        const saved = await store.saveMediaStream(
+          Readable.from([Buffer.from("docx")]),
+          "Application/Zip",
+          "stream-inbound",
+          1024,
+          undefined,
+          "document.docx",
+        );
 
-          expect(saved.id).toMatch(/^[a-f0-9-]{36}\.docx$/);
-          expect(saved.contentType).toBe(
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-          );
-        });
+        expect(saved.id).toMatch(/^[a-f0-9-]{36}\.docx$/);
+        expect(saved.contentType).toBe(
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        );
       },
     },
     {
       name: "rejects oversized streams before writing a final artifact",
       run: async () => {
-        await withTempStore(async (storeLocal9, homeInner) => {
-          await expect(
-            storeLocal9.saveMediaStream(
-              Readable.from([Buffer.alloc(4), Buffer.alloc(4)]),
-              "application/octet-stream",
-              "oversized-stream",
-              7,
-            ),
-          ).rejects.toThrow("Media exceeds 0MB limit");
+        await expect(
+          store.saveMediaStream(
+            Readable.from([Buffer.alloc(4), Buffer.alloc(4)]),
+            "application/octet-stream",
+            "oversized-stream",
+            7,
+          ),
+        ).rejects.toThrow("Media exceeds 7B limit");
 
-          const targetDir = path.join(homeInner, ".openclaw", "media", "oversized-stream");
-          const entries = await fs.readdir(targetDir).catch(() => []);
-          expect(entries).toStrictEqual([]);
-        });
+        const targetDir = path.join(home, ".openclaw", "media", "oversized-stream");
+        const entries = await fs.readdir(targetDir).catch(() => []);
+        expect(entries).toStrictEqual([]);
       },
     },
     {
       name: "saves buffers when the best-effort fsync step reports EPERM",
       run: async () => {
-        await withTempStore(async (storeLocal8) => {
-          const originalOpen = fs.open.bind(fs);
-          vi.spyOn(fs, "open").mockImplementation(async (...args) => {
-            const handle = await originalOpen(...args);
-            const filePath = args[0];
-            if (
-              typeof filePath === "string" &&
-              filePath.includes(`${path.sep}fsync-eperm${path.sep}`)
-            ) {
-              vi.spyOn(handle, "sync").mockRejectedValueOnce(
-                Object.assign(new Error("operation not permitted"), { code: "EPERM" }),
-              );
-            }
-            return handle;
-          });
-
-          const saved = await storeLocal8.saveMediaBuffer(
-            Buffer.from("docx"),
-            "application/zip",
-            "fsync-eperm",
-          );
-
-          await expect(fs.readFile(saved.path, "utf8")).resolves.toBe("docx");
+        const originalOpen = fs.open.bind(fs);
+        vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+          const handle = await originalOpen(...args);
+          const filePath = args[0];
+          if (
+            typeof filePath === "string" &&
+            filePath.includes(`${path.sep}fsync-eperm${path.sep}`)
+          ) {
+            vi.spyOn(handle, "sync").mockRejectedValueOnce(
+              Object.assign(new Error("operation not permitted"), { code: "EPERM" }),
+            );
+          }
+          return handle;
         });
+
+        const saved = await store.saveMediaBuffer(
+          Buffer.from("docx"),
+          "application/zip",
+          "fsync-eperm",
+        );
+
+        await expect(fs.readFile(saved.path, "utf8")).resolves.toBe("docx");
       },
     },
     {
       name: "rejects traversal media subdirs before saving buffers",
       run: async () => {
-        await withTempStore(async (storeLocal7, homeScoped) => {
-          const mediaDir = await storeLocal7.ensureMediaDir();
-          const outsideDir = path.join(homeScoped, "outside-media");
-          const traversalSubdir = path.relative(mediaDir, outsideDir);
+        const mediaDir = await store.ensureMediaDir();
+        const outsideDir = path.join(home, "outside-media");
+        const traversalSubdir = path.relative(mediaDir, outsideDir);
 
-          await expect(
-            storeLocal7.saveMediaBuffer(Buffer.from("escape"), "text/plain", traversalSubdir),
-          ).rejects.toThrow("unsafe media subdir");
-          await expectPathMissing(outsideDir);
-        });
+        await expect(
+          store.saveMediaBuffer(Buffer.from("escape"), "text/plain", traversalSubdir),
+        ).rejects.toThrow("unsafe media subdir");
+        await expectPathMissing(outsideDir);
       },
     },
     {
       name: "rejects traversal media subdirs before resolving IDs",
       run: async () => {
-        await withTempStore(async (storeLocal6, homeItem) => {
-          const mediaDir = await storeLocal6.ensureMediaDir();
-          const outsideDir = path.join(homeItem, "outside-media-resolve");
-          await fs.mkdir(outsideDir, { recursive: true });
-          await fs.writeFile(path.join(outsideDir, "passwd"), "not media");
+        const mediaDir = await store.ensureMediaDir();
+        const outsideDir = path.join(home, "outside-media-resolve");
+        await fs.mkdir(outsideDir, { recursive: true });
+        await fs.writeFile(path.join(outsideDir, "passwd"), "not media");
 
-          await expect(
-            storeLocal6.resolveMediaBufferPath("passwd", path.relative(mediaDir, outsideDir)),
-          ).rejects.toThrow("unsafe media subdir");
-        });
+        await expect(
+          store.resolveMediaBufferPath("passwd", path.relative(mediaDir, outsideDir)),
+        ).rejects.toThrow("unsafe media subdir");
       },
     },
     {
       name: "reads media IDs through the media root boundary",
       run: async () => {
-        await withTempStore(async (storeLocal5) => {
-          const saved = await storeLocal5.saveMediaBuffer(
-            Buffer.from("source bytes"),
-            "text/plain",
-          );
+        const saved = await store.saveMediaBuffer(Buffer.from("source bytes"), "text/plain");
 
-          const read = await storeLocal5.readMediaBuffer(saved.id, "inbound");
+        const read = await store.readMediaBuffer(saved.id, "inbound");
 
-          await expect(fs.realpath(read.path)).resolves.toBe(await fs.realpath(saved.path));
-          expect(read.size).toBe("source bytes".length);
-          expect(read.buffer.toString("utf8")).toBe("source bytes");
-        });
+        await expect(fs.realpath(read.path)).resolves.toBe(await fs.realpath(saved.path));
+        expect(read.size).toBe("source bytes".length);
+        expect(read.buffer.toString("utf8")).toBe("source bytes");
       },
     },
     {
       name: "rejects oversized media ID reads before materializing the file",
       run: async () => {
-        await withTempStore(async (storeLocal4) => {
-          const saved = await storeLocal4.saveMediaBuffer(Buffer.from("too large"), "text/plain");
+        const saved = await store.saveMediaBuffer(Buffer.from("too large"), "text/plain");
 
-          await expect(storeLocal4.readMediaBuffer(saved.id, "inbound", 3)).rejects.toThrow(
-            "maximum is 3 bytes",
-          );
-        });
+        await expect(store.readMediaBuffer(saved.id, "inbound", 3)).rejects.toThrow(
+          "maximum is 3 bytes",
+        );
       },
     },
     {
       name: "rejects traversal media subdirs before reading IDs",
       run: async () => {
-        await withTempStore(async (storeLocal3, homeCandidate) => {
-          const mediaDir = await storeLocal3.ensureMediaDir();
-          const outsideDir = path.join(homeCandidate, "outside-media-read");
-          await fs.mkdir(outsideDir, { recursive: true });
-          await fs.writeFile(path.join(outsideDir, "passwd"), "not media");
+        const mediaDir = await store.ensureMediaDir();
+        const outsideDir = path.join(home, "outside-media-read");
+        await fs.mkdir(outsideDir, { recursive: true });
+        await fs.writeFile(path.join(outsideDir, "passwd"), "not media");
 
-          await expect(
-            storeLocal3.readMediaBuffer("passwd", path.relative(mediaDir, outsideDir)),
-          ).rejects.toThrow("unsafe media subdir");
-        });
+        await expect(
+          store.readMediaBuffer("passwd", path.relative(mediaDir, outsideDir)),
+        ).rejects.toThrow("unsafe media subdir");
       },
     },
     {
@@ -625,22 +590,16 @@ describe("media store", () => {
     {
       name: "cleans old media files in first-level subdirectories",
       run: async () => {
-        await withTempStore(async (storeInner) => {
-          const saved = await storeInner.saveMediaBuffer(
-            Buffer.from("nested"),
-            "text/plain",
-            "inbound",
-          );
-          const inboundDir = path.dirname(saved.path);
-          const past = Date.now() - 10_000;
-          await fs.utimes(saved.path, past / 1000, past / 1000);
+        const saved = await store.saveMediaBuffer(Buffer.from("nested"), "text/plain", "inbound");
+        const inboundDir = path.dirname(saved.path);
+        const past = Date.now() - 10_000;
+        await fs.utimes(saved.path, past / 1000, past / 1000);
 
-          await storeInner.cleanOldMedia(1);
+        await store.cleanOldMedia(1);
 
-          await expectPathMissing(saved.path);
-          const inboundStat = await fs.stat(inboundDir);
-          expect(inboundStat.isDirectory()).toBe(true);
-        });
+        await expectPathMissing(saved.path);
+        const inboundStat = await fs.stat(inboundDir);
+        expect(inboundStat.isDirectory()).toBe(true);
       },
     },
   ] as const)("$name", async ({ run }) => {
@@ -850,24 +809,22 @@ describe("media store", () => {
   it.runIf(process.platform !== "win32")(
     "does not follow symlinked top-level directories during recursive cleanup",
     async () => {
-      await withTempStore(async (storeLocal, homeValue) => {
-        const mediaDir = await storeLocal.ensureMediaDir();
-        const outsideDir = path.join(homeValue, "outside-media");
-        const outsideFile = path.join(outsideDir, "old.txt");
-        const symlinkPath = path.join(mediaDir, "linked-dir");
-        await fs.mkdir(outsideDir, { recursive: true });
-        await fs.writeFile(outsideFile, "outside");
-        const past = Date.now() - 10_000;
-        await fs.utimes(outsideFile, past / 1000, past / 1000);
-        await fs.symlink(outsideDir, symlinkPath);
+      const mediaDir = await store.ensureMediaDir();
+      const outsideDir = path.join(home, "outside-media");
+      const outsideFile = path.join(outsideDir, "old.txt");
+      const symlinkPath = path.join(mediaDir, "linked-dir");
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(outsideFile, "outside");
+      const past = Date.now() - 10_000;
+      await fs.utimes(outsideFile, past / 1000, past / 1000);
+      await fs.symlink(outsideDir, symlinkPath);
 
-        await storeLocal.cleanOldMedia(1_000, { recursive: true, pruneEmptyDirs: true });
+      await store.cleanOldMedia(1_000, { recursive: true, pruneEmptyDirs: true });
 
-        const outsideStat = await fs.stat(outsideFile);
-        const symlinkStat = await fs.lstat(symlinkPath);
-        expect(outsideStat.isFile()).toBe(true);
-        expect(symlinkStat.isSymbolicLink()).toBe(true);
-      });
+      const outsideStat = await fs.stat(outsideFile);
+      const symlinkStat = await fs.lstat(symlinkPath);
+      expect(outsideStat.isFile()).toBe(true);
+      expect(symlinkStat.isSymbolicLink()).toBe(true);
     },
   );
 
@@ -931,32 +888,30 @@ describe("media store", () => {
   });
 
   it("prefers header mime extension when sniffed mime lacks mapping", async () => {
-    await withTempStore(async (_store, homeLocal) => {
-      vi.doMock("@openclaw/media-core/mime", async () => {
-        const actual = await vi.importActual<typeof import("@openclaw/media-core/mime")>(
-          "@openclaw/media-core/mime",
-        );
-        return {
-          ...actual,
-          detectMime: vi.fn(async () => "audio/opus"),
-        };
-      });
-
-      try {
-        const storeWithMock = await importFreshModule<typeof import("./store.js")>(
-          import.meta.url,
-          "./store.js?scope=sniffed-mime-header-extension",
-        );
-        const saved = await storeWithMock.saveMediaBuffer(
-          Buffer.from("fake-audio"),
-          "audio/ogg; codecs=opus",
-        );
-        expect(path.extname(saved.path)).toBe(".ogg");
-        expect(saved.path.startsWith(homeLocal)).toBe(true);
-      } finally {
-        vi.doUnmock("@openclaw/media-core/mime");
-      }
+    vi.doMock("@openclaw/media-core/mime", async () => {
+      const actual = await vi.importActual<typeof import("@openclaw/media-core/mime")>(
+        "@openclaw/media-core/mime",
+      );
+      return {
+        ...actual,
+        detectMime: vi.fn(async () => "audio/opus"),
+      };
     });
+
+    try {
+      const storeWithMock = await importFreshModule<typeof import("./store.js")>(
+        import.meta.url,
+        "./store.js?scope=sniffed-mime-header-extension",
+      );
+      const saved = await storeWithMock.saveMediaBuffer(
+        Buffer.from("fake-audio"),
+        "audio/ogg; codecs=opus",
+      );
+      expect(path.extname(saved.path)).toBe(".ogg");
+      expect(saved.path.startsWith(home)).toBe(true);
+    } finally {
+      vi.doUnmock("@openclaw/media-core/mime");
+    }
   });
 
   describe("extractOriginalFilename", () => {
@@ -1006,8 +961,8 @@ describe("media store", () => {
         expected: "photo.png",
         basePath: String.raw`C:\media/inbound`,
       },
-    ] as const)("$name", async ({ filename, expected, basePath }) => {
-      await expectOriginalFilenameCase({ filename, expected, basePath });
+    ] as const)("$name", ({ filename, expected, basePath }) => {
+      expect(store.extractOriginalFilename(`${basePath ?? "/path/to"}/${filename}`)).toBe(expected);
     });
   });
 

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -24,7 +24,7 @@ import { retryAsync } from "../infra/retry.js";
 import { writeSiblingTempFile } from "../infra/sibling-temp-file.js";
 import { resolveConfigDir } from "../utils.js";
 import { isFsSafeError, readLocalFileSafely, type FsSafeLikeError } from "./store.runtime.js";
-import { formatMediaLimitMb, MEDIA_FILE_MODE } from "./store.shared.js";
+import { MEDIA_FILE_MODE, SaveMediaSourceError } from "./store.shared.js";
 
 const resolveMediaDir = () => path.join(resolveConfigDir(), "media");
 /** Default per-file media-store byte cap used by store and plugin SDK callers. */
@@ -481,7 +481,7 @@ async function writeMediaStreamToFile(params: {
       }
       total += buffer.byteLength;
       if (total > params.maxBytes) {
-        throw new Error(`Media exceeds ${formatMediaLimitMb(params.maxBytes)} limit`);
+        throw SaveMediaSourceError.tooLarge(params.maxBytes);
       }
       if (sniffLen < sniffBuffer.length) {
         // The next pull may reuse the chunk; retain only the prefix we own.
@@ -498,25 +498,6 @@ async function writeMediaStreamToFile(params: {
   }
 }
 
-/** Stable error categories for unsafe or failed source-file ingestion. */
-type SaveMediaSourceErrorCode =
-  | "invalid-path"
-  | "not-found"
-  | "not-file"
-  | "path-mismatch"
-  | "too-large";
-
-/** Error raised when saveMediaSource cannot safely read or persist a source path. */
-class SaveMediaSourceError extends Error {
-  code: SaveMediaSourceErrorCode;
-
-  constructor(code: SaveMediaSourceErrorCode, message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.code = code;
-    this.name = "SaveMediaSourceError";
-  }
-}
-
 function toSaveMediaSourceError(err: FsSafeLikeError, maxBytes = MAX_BYTES): SaveMediaSourceError {
   switch (err.code) {
     case "symlink":
@@ -530,11 +511,7 @@ function toSaveMediaSourceError(err: FsSafeLikeError, maxBytes = MAX_BYTES): Sav
         cause: err,
       });
     case "too-large":
-      return new SaveMediaSourceError(
-        "too-large",
-        `Media exceeds ${formatMediaLimitMb(maxBytes)} limit`,
-        { cause: err },
-      );
+      return SaveMediaSourceError.tooLarge(maxBytes, { cause: err });
     case "not-found":
       return new SaveMediaSourceError("not-found", "Media path does not exist", { cause: err });
     case "outside-workspace":
@@ -593,7 +570,7 @@ export async function saveMediaBuffer(
   detectionFilePathHint?: string,
 ): Promise<SavedMedia> {
   if (buffer.byteLength > maxBytes) {
-    throw new Error(`Media exceeds ${formatMediaLimitMb(maxBytes)} limit`);
+    throw SaveMediaSourceError.tooLarge(maxBytes);
   }
   const dir = resolveMediaScopedDir(subdir, "saveMediaBuffer");
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using fractional media limits received incorrect rejection messages: a 0.25 MiB cap appeared as `0MB`, and a 1.5 MiB cap appeared as `2MB`. This affected stored attachments and generated video; WhatsApp also replaced the original error with another rounded message.

## Why This Change Was Made

Media persistence now creates one typed size-limit error for buffers, streams, and local files, using the existing byte-size formatter. Fetch and video generation classify that error by its existing category instead of matching its English message, so improved diagnostics preserve provider-URL fallback, cancellation, and rollback. WhatsApp forwards the original error.

The existing private error class is shared internally; no public SDK export, dependency, configuration, persistence schema, or byte enforcement threshold changes. Production is +38/−45 (net −7); tests are +335/−325 (net +10). The test cleanup removes redundant wrappers while preserving file lifecycle, assertions, and case order.

## User Impact

Rejections report useful limits such as `256KB`, `1.50MB`, or `7B`; existing whole-MB defaults retain their labels. Oversized generated video can still use the provider URL when available, while other storage failures retain ordered rollback and the original error.

## Evidence

Five behavioral regressions failed before the repair and passed afterward. All 208 cases across the complete media, video-generation, and WhatsApp owners pass, including real local file/stream persistence, provider-URL fallback, non-limit rollback, response cancellation, and partial-file cleanup. All 34 normal changed-code checks pass. After removing redundant test wrappers, the same 51 store cases passed again in the same order.

The normal full build passed. The compiled public SDK smoke passed against that exact output: the facades share error identity, the consumed stream is cancelled exactly once, its reader is released, and no partial artifacts remain. Two isolated full-change code reviews found no actionable P0–P2 defects across three evidence batches each. Runtime proofs were executed separately; no live WhatsApp session, provider API call, or external package installation is claimed. The reviewed files match commit `8b2c051a7d6a69f3333a1850f7e5a3db37a807bb`; [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33690635224) passed on that exact head: 157 successful jobs, 20 skipped, no failures, including the required `openclaw/ci-gate`. The tests use synthetic providers/transports around the real storage and tool owners.

Named follow-ups: Telegram, Feishu, and the separate web-media loader have their own rounded limit displays. They do not depend on this storage error's wording and are outside this repair. Source history confirms the rounding in a stable release; the video fallback's integer-message match made a formatter-only edit unsafe.
