### PR TITLE
fix(googlechat): keep automatic replies in their thread

### DIFF
--- a/extensions/googlechat/src/monitor-reply-target.test.ts
+++ b/extensions/googlechat/src/monitor-reply-target.test.ts
@@ -1,0 +1,122 @@
+// Googlechat tests cover monitor reply target behavior.
+import { describe, expect, it } from "vitest";
+import { normalizeGoogleChatReplyTarget } from "./monitor-reply-target.js";
+
+const SOURCE_MESSAGE = "spaces/AAA/messages/1";
+const REPLY_THREAD = "spaces/AAA/threads/1";
+
+describe("normalizeGoogleChatReplyTarget", () => {
+  // A failure in this group means the reconciliation stopped firing, so automatic
+  // replies are being delivered against the inbound message resource again.
+  describe("retargets the inbound source message", () => {
+    it("replaces the inbound message resource with the inbound thread", () => {
+      expect(
+        normalizeGoogleChatReplyTarget({
+          payload: { replyToId: SOURCE_MESSAGE },
+          sourceMessageName: SOURCE_MESSAGE,
+          replyThreadName: REPLY_THREAD,
+        }),
+      ).toEqual({ replyToId: REPLY_THREAD });
+    });
+
+    it("replaces it with a top-level target when there is no inbound thread", () => {
+      expect(
+        normalizeGoogleChatReplyTarget({
+          payload: { replyToId: SOURCE_MESSAGE },
+          sourceMessageName: SOURCE_MESSAGE,
+          replyThreadName: undefined,
+        }),
+      ).toEqual({ replyToId: undefined });
+    });
+
+    it("preserves every unrelated payload field", () => {
+      expect(
+        normalizeGoogleChatReplyTarget({
+          payload: { text: "hello", replyToTag: true, replyToId: SOURCE_MESSAGE },
+          sourceMessageName: SOURCE_MESSAGE,
+          replyThreadName: REPLY_THREAD,
+        }),
+      ).toEqual({ text: "hello", replyToTag: true, replyToId: REPLY_THREAD });
+    });
+
+    it("does not mutate the caller's payload", () => {
+      const payload = { replyToId: SOURCE_MESSAGE };
+      normalizeGoogleChatReplyTarget({
+        payload,
+        sourceMessageName: SOURCE_MESSAGE,
+        replyThreadName: REPLY_THREAD,
+      });
+      expect(payload.replyToId).toBe(SOURCE_MESSAGE);
+    });
+  });
+
+  // A failure in this group means the reconciliation became too aggressive and is
+  // rewriting targets it must not own, which silently redirects replies.
+  describe("returns the original payload for every other target", () => {
+    it("keeps an explicit thread retarget", () => {
+      const payload = { replyToId: "spaces/AAA/threads/other" };
+      expect(
+        normalizeGoogleChatReplyTarget({
+          payload,
+          sourceMessageName: SOURCE_MESSAGE,
+          replyThreadName: REPLY_THREAD,
+        }),
+      ).toBe(payload);
+    });
+
+    it("keeps a different message resource", () => {
+      const payload = { replyToId: "spaces/AAA/messages/other" };
+      expect(
+        normalizeGoogleChatReplyTarget({
+          payload,
+          sourceMessageName: SOURCE_MESSAGE,
+          replyThreadName: REPLY_THREAD,
+        }),
+      ).toBe(payload);
+    });
+
+    it("keeps a whitespace-padded source message, because the match is exact", () => {
+      const payload = { replyToId: ` ${SOURCE_MESSAGE} ` };
+      expect(
+        normalizeGoogleChatReplyTarget({
+          payload,
+          sourceMessageName: SOURCE_MESSAGE,
+          replyThreadName: REPLY_THREAD,
+        }),
+      ).toBe(payload);
+    });
+
+    it("keeps a payload that carries no reply target", () => {
+      const payload = { text: "hello" };
+      expect(
+        normalizeGoogleChatReplyTarget({
+          payload,
+          sourceMessageName: SOURCE_MESSAGE,
+          replyThreadName: REPLY_THREAD,
+        }),
+      ).toBe(payload);
+    });
+
+    it("keeps the target when the inbound message name is unknown", () => {
+      const payload = { replyToId: SOURCE_MESSAGE };
+      expect(
+        normalizeGoogleChatReplyTarget({
+          payload,
+          sourceMessageName: undefined,
+          replyThreadName: REPLY_THREAD,
+        }),
+      ).toBe(payload);
+    });
+
+    it("keeps the target when the inbound message name is empty", () => {
+      const payload = { replyToId: SOURCE_MESSAGE };
+      expect(
+        normalizeGoogleChatReplyTarget({
+          payload,
+          sourceMessageName: "",
+          replyThreadName: REPLY_THREAD,
+        }),
+      ).toBe(payload);
+    });
+  });
+});

--- a/extensions/googlechat/src/monitor-reply-target.ts
+++ b/extensions/googlechat/src/monitor-reply-target.ts
@@ -1,0 +1,22 @@
+// Googlechat plugin module implements monitor reply target behavior.
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+
+/**
+ * Google Chat only accepts a thread resource (`spaces/x/threads/y`) as a reply
+ * target. The automatic reply pipeline supplies the inbound *message* resource
+ * (`spaces/x/messages/y`) instead, which delivery would read as an intentional
+ * retarget and use to discard the typing placeholder. Reconcile that exact
+ * source-message target back to the inbound thread before delivery, and leave
+ * every other target untouched so explicit retargeting still works.
+ */
+export function normalizeGoogleChatReplyTarget(params: {
+  payload: ReplyPayload;
+  sourceMessageName?: string;
+  replyThreadName?: string;
+}): ReplyPayload {
+  const sourceMessageName = params.sourceMessageName;
+  if (!sourceMessageName || params.payload.replyToId !== sourceMessageName) {
+    return params.payload;
+  }
+  return { ...params.payload, replyToId: params.replyThreadName };
+}

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -201,6 +201,40 @@ describe("Google Chat reply delivery", () => {
     });
   });
 
+  it("replaces the typing message for a valid explicit thread target", async () => {
+    const core = createCore();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/reply" });
+
+    await deliverGoogleChatReply({
+      payload: {
+        text: "retargeted reply",
+        replyToId: "spaces/AAA/threads/other",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime: createRuntime(),
+      core,
+      config,
+      typingMessage: createGoogleChatTypingMessage({
+        messageName: "spaces/AAA/messages/typing",
+        requestedThreadName: "spaces/AAA/threads/root",
+        deliveredThreadName: "spaces/AAA/threads/root",
+      }),
+    });
+
+    expect(mocks.deleteGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      messageName: "spaces/AAA/messages/typing",
+    });
+    expect(mocks.updateGoogleChatMessage).not.toHaveBeenCalled();
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "retargeted reply",
+      thread: "spaces/AAA/threads/other",
+    });
+  });
+
   it("keeps the requested thread when the provider omits thread metadata", async () => {
     const core = createCore({ chunks: ["first chunk", "second chunk"] });
     const runtime = createRuntime();

--- a/extensions/googlechat/src/monitor.reply-target.test.ts
+++ b/extensions/googlechat/src/monitor.reply-target.test.ts
@@ -1,0 +1,283 @@
+// Googlechat tests cover automatic reply target reconciliation at the monitor boundary.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
+import "./monitor.js";
+import type { GoogleChatEvent } from "./types.js";
+
+const apiMocks = vi.hoisted(() => ({
+  deleteGoogleChatMessage: vi.fn(),
+  downloadGoogleChatMedia: vi.fn(),
+  sendGoogleChatMessage: vi.fn(),
+  updateGoogleChatMessage: vi.fn(),
+}));
+
+const accessMocks = vi.hoisted(() => ({
+  applyGoogleChatInboundAccessPolicy: vi.fn(),
+}));
+
+const routingMocks = vi.hoisted(() => ({
+  processEvent: undefined as
+    | ((event: GoogleChatEvent, target: Record<string, unknown>) => Promise<void>)
+    | undefined,
+}));
+
+const inboundMocks = vi.hoisted(() => ({
+  resolveChannelInboundRouteEnvelope: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>()),
+  resolveChannelInboundRouteEnvelope: inboundMocks.resolveChannelInboundRouteEnvelope,
+}));
+
+vi.mock("./api.js", () => ({
+  deleteGoogleChatMessage: apiMocks.deleteGoogleChatMessage,
+  downloadGoogleChatMedia: apiMocks.downloadGoogleChatMedia,
+  sendGoogleChatMessage: apiMocks.sendGoogleChatMessage,
+  updateGoogleChatMessage: apiMocks.updateGoogleChatMessage,
+}));
+
+vi.mock("./monitor-access.js", () => ({
+  applyGoogleChatInboundAccessPolicy: accessMocks.applyGoogleChatInboundAccessPolicy,
+}));
+
+vi.mock("./monitor-routing.js", () => ({
+  registerGoogleChatWebhookTarget: vi.fn(),
+  setGoogleChatWebhookEventProcessor: vi.fn(
+    (
+      eventProcessor: (event: GoogleChatEvent, target: Record<string, unknown>) => Promise<void>,
+    ) => {
+      routingMocks.processEvent = eventProcessor;
+    },
+  ),
+}));
+
+type GoogleChatTestReplyPayload = { text: string; replyToId?: string };
+type GoogleChatTestDelivery = {
+  durable: (payload: GoogleChatTestReplyPayload, info: { kind: string }) => unknown;
+  deliver: (payload: GoogleChatTestReplyPayload) => Promise<void>;
+};
+
+beforeEach(() => {
+  apiMocks.deleteGoogleChatMessage.mockReset();
+  apiMocks.downloadGoogleChatMedia.mockReset();
+  apiMocks.sendGoogleChatMessage.mockReset().mockResolvedValue(null);
+  apiMocks.updateGoogleChatMessage.mockReset().mockResolvedValue({});
+  accessMocks.applyGoogleChatInboundAccessPolicy.mockReset().mockResolvedValue({
+    ok: true,
+    commandAuthorized: undefined,
+    effectiveWasMentioned: undefined,
+    groupBotLoopProtection: undefined,
+    groupSystemPrompt: undefined,
+  });
+  inboundMocks.resolveChannelInboundRouteEnvelope.mockReset().mockReturnValue({
+    route: {
+      agentId: "agent-1",
+      accountId: "work",
+      sessionKey: "session-1",
+    },
+    buildEnvelope: ({ body }: { body: string }) => body,
+  });
+});
+
+function createCore(params: {
+  run: (delivery: GoogleChatTestDelivery) => Promise<void>;
+  chunks?: string[];
+}) {
+  return {
+    logging: { shouldLogVerbose: () => false },
+    channel: {
+      inbound: {
+        buildContext: vi.fn((payload: unknown) => payload),
+        run: vi.fn(
+          async (turn: {
+            adapter: { resolveTurn: () => { delivery: GoogleChatTestDelivery } };
+          }) => {
+            await params.run(turn.adapter.resolveTurn().delivery);
+          },
+        ),
+      },
+      text: {
+        resolveChunkMode: vi.fn(() => "markdown"),
+        chunkMarkdownTextWithMode: vi.fn((text: string) => params.chunks ?? [text]),
+      },
+    },
+  } as unknown as GoogleChatCoreRuntime;
+}
+
+function createEvent(params?: { messageName?: string; threadName?: string }): GoogleChatEvent {
+  return {
+    type: "MESSAGE",
+    space: { name: "spaces/CLASSIFY", spaceType: "SPACE" },
+    message: {
+      name: params?.messageName ?? "spaces/CLASSIFY/messages/1",
+      text: "hello",
+      thread: { name: params?.threadName ?? "spaces/CLASSIFY/threads/requested" },
+      sender: { name: "users/alice", displayName: "Alice", type: "HUMAN" },
+    },
+  } satisfies GoogleChatEvent;
+}
+
+function createAccount(config: ResolvedGoogleChatAccount["config"]): ResolvedGoogleChatAccount {
+  return {
+    accountId: "work",
+    config,
+    credentialSource: "inline",
+  } as ResolvedGoogleChatAccount;
+}
+
+async function processEvent(params: {
+  account: ResolvedGoogleChatAccount;
+  core: GoogleChatCoreRuntime;
+  event?: GoogleChatEvent;
+  runtime?: GoogleChatRuntimeEnv;
+}) {
+  if (!routingMocks.processEvent) {
+    throw new Error("Expected Google Chat webhook event processor registration");
+  }
+  await routingMocks.processEvent(params.event ?? createEvent(), {
+    account: params.account,
+    config: {},
+    runtime: params.runtime ?? { error: vi.fn(), log: vi.fn() },
+    core: params.core,
+    mediaMaxMb: 10,
+    path: "/googlechat",
+  });
+}
+
+describe("Google Chat automatic reply target reconciliation", () => {
+  it("keeps the typing thread when automatic delivery supplies the source message name", async () => {
+    const sourceMessageName = "spaces/CLASSIFY/messages/1";
+    const requestedThread = "spaces/CLASSIFY/threads/requested";
+    const deliveredThread = "spaces/CLASSIFY/threads/fallback";
+    const account = createAccount({ replyToMode: "all" });
+    const core = createCore({
+      chunks: ["first chunk", "second chunk"],
+      run: async (delivery) => {
+        await delivery.deliver({ text: "two chunks", replyToId: sourceMessageName });
+      },
+    });
+    apiMocks.sendGoogleChatMessage
+      .mockResolvedValueOnce({
+        messageName: "spaces/CLASSIFY/messages/typing",
+        threadName: deliveredThread,
+      })
+      .mockResolvedValueOnce({
+        messageName: "spaces/CLASSIFY/messages/second",
+        threadName: deliveredThread,
+      });
+
+    await processEvent({ account, core });
+
+    expect(apiMocks.updateGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      messageName: "spaces/CLASSIFY/messages/typing",
+      text: "first chunk",
+    });
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenNthCalledWith(2, {
+      account,
+      space: "spaces/CLASSIFY",
+      text: "second chunk",
+      thread: deliveredThread,
+    });
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenNthCalledWith(1, {
+      account,
+      space: "spaces/CLASSIFY",
+      text: "_OpenClaw is typing..._",
+      thread: requestedThread,
+    });
+  });
+
+  it("reconciles delivery and durable metadata without a typing message", async () => {
+    const sourceMessageName = "spaces/CLASSIFY/messages/1";
+    const replyThreadName = "spaces/CLASSIFY/threads/requested";
+    let durableResult: unknown;
+    const account = createAccount({ replyToMode: "all", typingIndicator: "none" });
+    const core = createCore({
+      run: async (delivery) => {
+        const payload = { text: "threaded reply", replyToId: sourceMessageName };
+        durableResult = delivery.durable(payload, { kind: "final" });
+        await delivery.deliver(payload);
+      },
+    });
+    apiMocks.sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/CLASSIFY/messages/reply",
+      threadName: replyThreadName,
+    });
+
+    await processEvent({ account, core });
+
+    expect(durableResult).toEqual({
+      to: "spaces/CLASSIFY",
+      replyToId: replyThreadName,
+      threadId: replyThreadName,
+    });
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenCalledOnce();
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/CLASSIFY",
+      text: "threaded reply",
+      thread: replyThreadName,
+    });
+  });
+
+  it("reconciles delivery after the typing message fails", async () => {
+    const sourceMessageName = "spaces/CLASSIFY/messages/1";
+    const replyThreadName = "spaces/CLASSIFY/threads/requested";
+    const account = createAccount({ replyToMode: "all" });
+    const core = createCore({
+      run: async (delivery) => {
+        await delivery.deliver({ text: "threaded reply", replyToId: sourceMessageName });
+      },
+    });
+    const runtime = { error: vi.fn(), log: vi.fn() };
+    apiMocks.sendGoogleChatMessage
+      .mockRejectedValueOnce(new Error("typing unavailable"))
+      .mockResolvedValueOnce({
+        messageName: "spaces/CLASSIFY/messages/reply",
+        threadName: replyThreadName,
+      });
+
+    await processEvent({ account, core, runtime });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Failed sending typing message: Error: typing unavailable",
+    );
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenNthCalledWith(2, {
+      account,
+      space: "spaces/CLASSIFY",
+      text: "threaded reply",
+      thread: replyThreadName,
+    });
+  });
+
+  it.each([
+    ["different message", "spaces/CLASSIFY/messages/other"],
+    ["whitespace-decorated message", " spaces/CLASSIFY/messages/1 "],
+  ])("does not reinterpret a %s target", async (_name, targetMessageName) => {
+    let durableResult: unknown;
+    const account = createAccount({ replyToMode: "all", typingIndicator: "none" });
+    const core = createCore({
+      run: async (delivery) => {
+        const payload = { text: "explicit reply", replyToId: targetMessageName };
+        durableResult = delivery.durable(payload, { kind: "final" });
+        await delivery.deliver(payload);
+      },
+    });
+
+    await processEvent({ account, core });
+
+    expect(durableResult).toEqual({
+      to: "spaces/CLASSIFY",
+      replyToId: targetMessageName.trim(),
+      threadId: targetMessageName.trim(),
+    });
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/CLASSIFY",
+      text: "explicit reply",
+      thread: targetMessageName.trim(),
+    });
+  });
+});

--- a/extensions/googlechat/src/monitor.reply-target.test.ts
+++ b/extensions/googlechat/src/monitor.reply-target.test.ts
@@ -106,14 +106,21 @@ function createCore(params: {
   } as unknown as GoogleChatCoreRuntime;
 }
 
-function createEvent(params?: { messageName?: string; threadName?: string }): GoogleChatEvent {
+function createEvent(params?: {
+  messageName?: string;
+  // `null` omits the inbound thread entirely (unthreaded group message); `undefined` uses the default.
+  threadName?: string | null;
+  spaceType?: string;
+}): GoogleChatEvent {
+  const threadName =
+    params?.threadName === undefined ? "spaces/CLASSIFY/threads/requested" : params.threadName;
   return {
     type: "MESSAGE",
-    space: { name: "spaces/CLASSIFY", spaceType: "SPACE" },
+    space: { name: "spaces/CLASSIFY", spaceType: params?.spaceType ?? "SPACE" },
     message: {
       name: params?.messageName ?? "spaces/CLASSIFY/messages/1",
       text: "hello",
-      thread: { name: params?.threadName ?? "spaces/CLASSIFY/threads/requested" },
+      ...(threadName ? { thread: { name: threadName } } : {}),
       sender: { name: "users/alice", displayName: "Alice", type: "HUMAN" },
     },
   } satisfies GoogleChatEvent;
@@ -279,5 +286,73 @@ describe("Google Chat automatic reply target reconciliation", () => {
       text: "explicit reply",
       thread: targetMessageName.trim(),
     });
+  });
+
+  it("delivers top-level in a direct message when automatic delivery supplies the source message name", async () => {
+    // Regression guard: DMs have no inbound thread, so `replyThreadName` is undefined. The
+    // source-message target must collapse to top-level rather than being sent as a message
+    // resource (which Google Chat rejects as a thread), and the placeholder must not be deleted.
+    const sourceMessageName = "spaces/CLASSIFY/messages/1";
+    let durableResult: unknown;
+    const account = createAccount({ replyToMode: "all", typingIndicator: "none" });
+    const core = createCore({
+      run: async (delivery) => {
+        const payload = { text: "dm reply", replyToId: sourceMessageName };
+        durableResult = delivery.durable(payload, { kind: "final" });
+        await delivery.deliver(payload);
+      },
+    });
+    apiMocks.sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/CLASSIFY/messages/reply",
+      threadName: undefined,
+    });
+
+    await processEvent({ account, core, event: createEvent({ spaceType: "DIRECT_MESSAGE" }) });
+
+    expect(durableResult).toEqual({ to: "spaces/CLASSIFY", replyToId: null });
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenCalledOnce();
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/CLASSIFY",
+      text: "dm reply",
+      thread: undefined,
+    });
+    expect(apiMocks.deleteGoogleChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("delivers top-level in a group space that carries no inbound thread", async () => {
+    // Regression guard: a group message can arrive without a thread resource, so
+    // `replyThreadName` is undefined here too. The source-message target must still collapse
+    // to top-level instead of echoing the message resource back as the thread.
+    const sourceMessageName = "spaces/CLASSIFY/messages/1";
+    let durableResult: unknown;
+    const account = createAccount({ replyToMode: "all", typingIndicator: "none" });
+    const core = createCore({
+      run: async (delivery) => {
+        const payload = { text: "group reply", replyToId: sourceMessageName };
+        durableResult = delivery.durable(payload, { kind: "final" });
+        await delivery.deliver(payload);
+      },
+    });
+    apiMocks.sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/CLASSIFY/messages/reply",
+      threadName: undefined,
+    });
+
+    await processEvent({
+      account,
+      core,
+      event: createEvent({ spaceType: "SPACE", threadName: null }),
+    });
+
+    expect(durableResult).toEqual({ to: "spaces/CLASSIFY", replyToId: null });
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenCalledOnce();
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/CLASSIFY",
+      text: "group reply",
+      thread: undefined,
+    });
+    expect(apiMocks.deleteGoogleChatMessage).not.toHaveBeenCalled();
   });
 });

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -12,6 +12,7 @@ import { channelBlockedPatch, channelReadyPatch } from "openclaw/plugin-sdk/gate
 import { MediaFetchError } from "openclaw/plugin-sdk/media-runtime";
 import { parseDateStringTimestampMs as resolveGoogleChatTimestampMs } from "openclaw/plugin-sdk/number-runtime";
 import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { resolveWebhookPath } from "../runtime-api.js";
@@ -67,6 +68,18 @@ function normalizeAudienceType(value?: string | null): GoogleChatAudienceType | 
     return "project-number";
   }
   return undefined;
+}
+
+function normalizeGoogleChatReplyTarget(params: {
+  payload: ReplyPayload;
+  sourceMessageName?: string;
+  replyThreadName?: string;
+}): ReplyPayload {
+  const sourceMessageName = params.sourceMessageName;
+  if (!sourceMessageName || params.payload.replyToId !== sourceMessageName) {
+    return params.payload;
+  }
+  return { ...params.payload, replyToId: params.replyThreadName };
 }
 
 function resolveGoogleChatBotLoopProtection(params: {
@@ -448,14 +461,22 @@ async function processMessageWithPipeline(params: {
         delivery: {
           durable: (payload, info) =>
             resolveGoogleChatDurableReplyOptions({
-              payload,
+              payload: normalizeGoogleChatReplyTarget({
+                payload,
+                sourceMessageName: message.name,
+                replyThreadName,
+              }),
               infoKind: info.kind,
               spaceId,
               hasTypingMessage: Boolean(typingMessage),
             }),
           deliver: async (payload) => {
             await deliverGoogleChatReply({
-              payload,
+              payload: normalizeGoogleChatReplyTarget({
+                payload,
+                sourceMessageName: message.name,
+                replyThreadName,
+              }),
               account,
               spaceId,
               runtime,

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -12,7 +12,6 @@ import { channelBlockedPatch, channelReadyPatch } from "openclaw/plugin-sdk/gate
 import { MediaFetchError } from "openclaw/plugin-sdk/media-runtime";
 import { parseDateStringTimestampMs as resolveGoogleChatTimestampMs } from "openclaw/plugin-sdk/number-runtime";
 import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-runtime";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { resolveWebhookPath } from "../runtime-api.js";
@@ -31,6 +30,7 @@ import {
   deliverGoogleChatReply,
   type GoogleChatTypingMessage,
 } from "./monitor-reply-delivery.js";
+import { normalizeGoogleChatReplyTarget } from "./monitor-reply-target.js";
 import {
   registerGoogleChatWebhookTarget,
   setGoogleChatWebhookEventProcessor,
@@ -68,18 +68,6 @@ function normalizeAudienceType(value?: string | null): GoogleChatAudienceType | 
     return "project-number";
   }
   return undefined;
-}
-
-function normalizeGoogleChatReplyTarget(params: {
-  payload: ReplyPayload;
-  sourceMessageName?: string;
-  replyThreadName?: string;
-}): ReplyPayload {
-  const sourceMessageName = params.sourceMessageName;
-  if (!sourceMessageName || params.payload.replyToId !== sourceMessageName) {
-    return params.payload;
-  }
-  return { ...params.payload, replyToId: params.replyThreadName };
 }
 
 function resolveGoogleChatBotLoopProtection(params: {


### PR DESCRIPTION
Fixes #136653

Related: #104402, #115638, #116717, #117053

## What Problem This Solves

Fixes an issue where Google Chat users replying in an existing thread could see the typing placeholder disappear and the final automatic reply land outside the intended thread. The failure occurred when the automatic reply pipeline supplied the inbound message resource (`spaces/.../messages/...`) where Google Chat delivery requires the inbound thread resource (`spaces/.../threads/...`). It also affected threaded delivery when typing indicators were disabled or the placeholder could not be created.

## Why This Change Was Made

The Google Chat monitor now reconciles only the exact inbound source message name to the authoritative inbound thread name before both durable fallback and live delivery. The channel-owned boundary has both values and can distinguish the automatic source-message target from explicit targets.

Valid explicit thread retargeting, unrelated message identifiers, direct-message behavior, top-level replies, generic reply construction, and typing-placeholder fallback behavior remain unchanged.

## User Impact

Automatic Google Chat replies remain in the originating thread whether the typing placeholder succeeds, is disabled, or fails to send. Users no longer see the placeholder disappear followed by a displaced or missing-looking reply for this identifier mismatch.

## Evidence

- Reproduced on current upstream `main`: a generated automatic reply carried the inbound message resource while the typing placeholder was associated with the inbound thread, causing reconciliation to delete the placeholder.
- Added monitor-boundary regression coverage for:
  - successful threaded typing with provider thread fallback;
  - `typingIndicator: "none"` with both durable metadata and live delivery;
  - typing-placeholder creation failure;
  - unrelated same-space message resources;
  - whitespace-decorated near matches;
  - valid explicit thread retargeting.
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/googlechat/src/monitor.reply-target.test.ts extensions/googlechat/src/monitor.reply-delivery.test.ts extensions/googlechat/src/monitor.test.ts` — 3 files, 47 tests passed.
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/googlechat` — 34 files, 365 tests passed on the rebased PR head.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` passed.
- Targeted extension lint, formatting, and `git diff --check` passed.
- Google documents message names as `spaces/{space}/messages/{message}` and threaded sends as requiring `thread.name`: https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages/create

## Real Google Chat proof — September 9, 2026

The PR's exact normalization helper from `937da19775fee3236cf6c89385b63c16691d8cef`, with TypeScript annotations removed, was transplanted into the installed OpenClaw2026.9.3 Google Chat adapter and used at both durable and live delivery boundaries. The previous custom normalization was removed. **This tests the PR correction on the current runtime, not a complete build of this source branch.** Metadata-only diagnostic wrappers remained installed.

A human sent `FORGE-PR136689-CHECK-01` in an existing thread. The final acknowledgment remained in that thread and updated the typing message in place. Correlated gateway records show **one typing POST followed by one successful PATCH of the same message, no DELETE and no replacement POST**. Independent Google Chat `messages.get` calls returned HTTP200 for the human and final bot messages with identical thread IDs. Final delivery took14.77 seconds; the human also confirmed correct visible behavior.

[Evidence report, extracted PR helper, sanitized trace and platform records](https://github.com/ScientificProgrammer/openclaw/tree/e36960a9901d7f1ed0a684ac6d435cd2919cec00). Resource IDs are consistently pseudonymized; account chrome and unrelated messages are excluded from the screenshot. The screenshot shows the completed reply marked Edited; the typing-to-final lifecycle is established by the trace, not a typing-phase screenshot.

![Real Google Chat test: human request and edited final reply](https://raw.githubusercontent.com/ScientificProgrammer/openclaw/e36960a9901d7f1ed0a684ac6d435cd2919cec00/visible-reply.png)

The deployed candidate passed syntax validation and14 replay checks, and its hash was verified after the live exchange. The source-suite results above remain the earlier PR-head results; this update does not claim a fresh full-source-suite run. The normal threaded path was tested live; other delivery branches retain replay/source-test coverage. No PR code was changed for this evidence update.

