### PR TITLE
refactor(channels): restore plugin types at registry

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2246,7 +2246,6 @@ src/channels/plugins/meta-normalization.ts	1
 src/channels/plugins/package-state-probes.ts	2
 src/channels/plugins/read-only-command-defaults.ts	2
 src/channels/plugins/read-only.ts	6
-src/channels/plugins/registry-loaded.ts	1
 src/channels/plugins/registry.ts	1
 src/channels/plugins/session-thread-info-loaded.ts	1
 src/channels/plugins/setup-contract.ts	3

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2102,7 +2102,7 @@ src/agents/worktrees/run-lease.ts	1
 src/audit/execution-identity-admission.ts	3
 src/audit/execution-identity-context-build.ts	3
 src/auto-reply/chunk.ts	4
-src/auto-reply/command-auth.ts	5
+src/auto-reply/command-auth.ts	3
 src/auto-reply/command-turn-context.ts	1
 src/auto-reply/commands-registry.ts	1
 src/auto-reply/heartbeat-filter.ts	4
@@ -2168,8 +2168,7 @@ src/auto-reply/reply/get-reply-run-helpers.ts	1
 src/auto-reply/reply/get-reply.ts	2
 src/auto-reply/reply/history.ts	2
 src/auto-reply/reply/inbound-context.ts	8
-src/auto-reply/reply/inbound-meta.ts	1
-src/auto-reply/reply/mentions.ts	2
+src/auto-reply/reply/mentions.ts	1
 src/auto-reply/reply/model-selection.ts	3
 src/auto-reply/reply/queue/drain.ts	2
 src/auto-reply/reply/queue/enqueue.ts	1
@@ -2241,15 +2240,14 @@ src/channels/plugins/contracts/trace/delivery-trace.ts	1
 src/channels/plugins/dm-access.ts	3
 src/channels/plugins/helpers.ts	3
 src/channels/plugins/legacy-config.ts	4
-src/channels/plugins/lifecycle-startup.ts	1
 src/channels/plugins/message-action-discovery.ts	4
 src/channels/plugins/message-action-dispatch.ts	5
 src/channels/plugins/meta-normalization.ts	1
 src/channels/plugins/package-state-probes.ts	2
 src/channels/plugins/read-only-command-defaults.ts	2
 src/channels/plugins/read-only.ts	6
-src/channels/plugins/registry-loaded.ts	3
-src/channels/plugins/registry.ts	3
+src/channels/plugins/registry-loaded.ts	1
+src/channels/plugins/registry.ts	1
 src/channels/plugins/session-thread-info-loaded.ts	1
 src/channels/plugins/setup-contract.ts	3
 src/channels/plugins/setup-helpers.ts	4

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -929,7 +929,8 @@ unrelated inbound runtime helpers.
   <Step title="Build the channel plugin object">
     The `ChannelPlugin` interface has many optional adapter surfaces. Start with
     the minimum - `id`, `config`, and `setup` - and add adapters as you need
-    them.
+    them. `createChatChannelPlugin` defaults omitted capabilities to direct
+    messages; declare `capabilities.chatTypes` when the channel supports more.
 
     `config.inspectAccount` is synchronous and returns metadata
     for read-only diagnostics, including disabled or configured-but-unavailable

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -9,7 +9,7 @@ import {
   restoreActivePluginRegistrySnapshot,
   setActivePluginRegistry,
 } from "../plugins/runtime.js";
-import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { typedCases } from "../test-utils/typed-cases.js";
 import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import { resolveOwnerPromptNumbers } from "./owner-display.js";
@@ -1581,7 +1581,7 @@ describe("buildAgentSystemPrompt", () => {
     const registrations = ["zeta-channel", "alpha-channel"].map((id) => ({
       pluginId: id,
       source: "test" as const,
-      plugin: { id },
+      plugin: createChannelTestPluginBase({ id }),
     }));
     const buildPrompt = () =>
       buildAgentSystemPrompt({ workspaceDir: "/tmp/openclaw", toolNames: ["message"] });

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -127,7 +127,7 @@ function probeInferredProviders(ctx: MsgContext, cfg: OpenClawConfig) {
   const candidates: ProviderResolution[] = [];
   for (const plugin of listLoadedChannelPlugins()) {
     const resolved = resolveProviderAllowFrom({
-      plugin: plugin as ChannelPlugin,
+      plugin,
       cfg,
       accountId: ctx.AccountId,
     });
@@ -476,9 +476,7 @@ function resolveCommandAuthorizationState(params: CommandAuthorizationParams): {
     ctx,
     cfg,
   );
-  const plugin = providerId
-    ? ((getLoadedChannelPluginById(providerId) as ChannelPlugin | undefined) ?? undefined)
-    : undefined;
+  const plugin = providerId ? getLoadedChannelPluginById(providerId) : undefined;
   const from = normalizeOptionalString(ctx.From) ?? "";
   const to = normalizeOptionalString(ctx.To) ?? "";
   const commandsAllowFromConfigured = Boolean(

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -5,7 +5,6 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { CurrentInboundPromptContext } from "../../agents/embedded-agent-runner/run/params.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { getLoadedChannelPluginById } from "../../channels/plugins/registry-loaded.js";
-import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import { resolveSessionGoalDisplayState } from "../../config/sessions/goals.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
@@ -550,8 +549,7 @@ function resolveInboundFormattingHints(
     return undefined;
   }
   const normalizedChannel = normalizeAnyChannelId(channelValue) ?? channelValue;
-  const agentPrompt = (getLoadedChannelPluginById(normalizedChannel) as ChannelPlugin | undefined)
-    ?.agentPrompt;
+  const agentPrompt = getLoadedChannelPluginById(normalizedChannel)?.agentPrompt;
   return agentPrompt?.inboundFormattingHints?.({
     cfg,
     accountId: normalizePromptMetadataString(ctx.AccountId) ?? undefined,

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -8,7 +8,6 @@ import { resolveAgentConfig } from "../../agents/agent-scope.js";
 import { resolveMentionPatternPolicy } from "../../channels/mention-pattern-policy.js";
 import type { ChannelId } from "../../channels/plugins/channel-id.types.js";
 import { getLoadedChannelPluginById } from "../../channels/plugins/registry-loaded.js";
-import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -446,7 +445,7 @@ export function stripMentions(
     (normalizeOptionalLowercaseString(ctx.Provider) as ChannelId | undefined) ??
     null;
   const providerMentions = providerId
-    ? (getLoadedChannelPluginById(providerId) as ChannelPlugin | undefined)?.mentions
+    ? getLoadedChannelPluginById(providerId)?.mentions
     : undefined;
   const resolvedPatterns = resolveMentionPatterns(cfg, agentId);
   const configRegexes = compileMentionPatternsCached({

--- a/src/channels/plugins/lifecycle-startup.ts
+++ b/src/channels/plugins/lifecycle-startup.ts
@@ -1,7 +1,6 @@
 /** Invokes optional startup maintenance for loaded channel plugins. */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { listLoadedChannelPlugins } from "./registry-loaded.js";
-import type { ChannelPlugin } from "./types.plugin.js";
 
 type ChannelStartupLogger = {
   info?: (message: string) => void;
@@ -18,7 +17,7 @@ export async function runChannelPluginStartupMaintenance(params: {
   trigger?: string;
   logPrefix?: string;
 }): Promise<void> {
-  for (const plugin of listLoadedChannelPlugins() as ChannelPlugin[]) {
+  for (const plugin of listLoadedChannelPlugins()) {
     const runStartupMaintenance = plugin.lifecycle?.runStartupMaintenance;
     if (!runStartupMaintenance) {
       continue;

--- a/src/channels/plugins/registry-loaded.ts
+++ b/src/channels/plugins/registry-loaded.ts
@@ -47,14 +47,7 @@ function coerceLoadedChannelPlugin(
   if (!plugin || !id) {
     return null;
   }
-  if (!plugin.meta || typeof plugin.meta !== "object") {
-    // Loaded plugin metadata is optional at the runtime-state boundary, but
-    // channel sorting expects an object so normalize it once at read time.
-    plugin.meta = {};
-  }
-  // Active registry entries originate only from normalizeRegisteredChannelPlugin;
-  // this read boundary restores the full validated contract once after light storage.
-  return plugin as LoadedChannelPlugin;
+  return plugin;
 }
 
 function resolveChannelPlugins(registry?: ActivePluginChannelRegistry): ChannelPluginView {

--- a/src/channels/plugins/registry-loaded.ts
+++ b/src/channels/plugins/registry-loaded.ts
@@ -20,9 +20,8 @@ import type { ChannelId } from "./types.public.js";
 /**
  * Loaded channel plugin shape after id/meta normalization.
  */
-type LoadedChannelPlugin = ActiveChannelPluginRuntimeShape & {
-  id: string;
-  meta: NonNullable<ActiveChannelPluginRuntimeShape["meta"]>;
+type LoadedChannelPlugin = ChannelPlugin & {
+  meta: NonNullable<ChannelPlugin["meta"]>;
 };
 
 /**
@@ -53,6 +52,8 @@ function coerceLoadedChannelPlugin(
     // channel sorting expects an object so normalize it once at read time.
     plugin.meta = {};
   }
+  // Active registry entries originate only from normalizeRegisteredChannelPlugin;
+  // this read boundary restores the full validated contract once after light storage.
   return plugin as LoadedChannelPlugin;
 }
 
@@ -122,7 +123,7 @@ export function listLoadedChannelPlugins(): LoadedChannelPlugin[] {
 export function listLoadedChannelPluginsForRegistry(
   registry: ActivePluginChannelRegistry,
 ): ChannelPlugin[] {
-  return resolveChannelPlugins(registry).sorted.slice() as ChannelPlugin[];
+  return resolveChannelPlugins(registry).sorted.slice();
 }
 
 /**
@@ -138,7 +139,7 @@ export function getLoadedChannelPluginById(id: string): LoadedChannelPlugin | un
 
 /** Returns one loaded channel plugin without triggering bundled discovery. */
 export function getLoadedChannelPluginForRead(id: ChannelId): ChannelPlugin | undefined {
-  return getLoadedChannelPluginById(id) as ChannelPlugin | undefined;
+  return getLoadedChannelPluginById(id);
 }
 
 /**

--- a/src/channels/plugins/registry.ts
+++ b/src/channels/plugins/registry.ts
@@ -11,13 +11,13 @@ import {
 import type { ChannelPlugin } from "./types.plugin.js";
 import type { ChannelId } from "./types.public.js";
 
-export const listChannelPlugins = () => listLoadedChannelPlugins() as ChannelPlugin[];
+export const listChannelPlugins = (): ChannelPlugin[] => listLoadedChannelPlugins();
 
 /**
  * Returns a loaded channel plugin without falling back to bundled metadata.
  */
 export function getLoadedChannelPlugin(id: ChannelId): ChannelPlugin | undefined {
-  return getLoadedChannelPluginById(id) as ChannelPlugin | undefined;
+  return getLoadedChannelPluginById(id);
 }
 
 /**

--- a/src/infra/outbound/message-account-selection.test.ts
+++ b/src/infra/outbound/message-account-selection.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
+import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
 import { validateExplicitMessageAccountSelection } from "./message-account-selection.js";
 
 afterEach(() => {
@@ -89,20 +90,22 @@ describe("validateExplicitMessageAccountSelection", () => {
 });
 
 describe("resolveMessageBroadcastAccountPlan (registry-scoped channel plugins)", () => {
-  const scopedPlugin = {
-    id: "scopex",
-    config: {
-      listAccountIds: () => ["ops"],
-      resolveAccount: (_cfg: OpenClawConfig, accountId?: string | null) => ({
-        accountId,
-        enabled: true,
-      }),
-    },
+  const scopedPlugin: ChannelPlugin = {
+    ...createChannelTestPluginBase({
+      id: "scopex",
+      config: {
+        listAccountIds: () => ["ops"],
+        resolveAccount: (_cfg: OpenClawConfig, accountId?: string | null) => ({
+          accountId,
+          enabled: true,
+        }),
+      },
+    }),
     outbound: {
       deliveryMode: "direct",
-      sendText: async () => ({ messageId: "scopex-message" }),
+      sendText: async () => ({ channel: "scopex", messageId: "scopex-message" }),
     },
-  } as unknown as ChannelPlugin;
+  };
   const unavailablePlugin: ChannelPlugin = {
     ...scopedPlugin,
     id: "scopex-unavailable",

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -610,12 +610,12 @@ export function defineSetupPluginEntry<TPlugin>(plugin: TPlugin) {
 
 type ChatChannelPluginBase<TResolvedAccount, Probe, Audit> = Omit<
   ChannelPlugin<TResolvedAccount, Probe, Audit>,
-  "security" | "pairing" | "threading" | "outbound"
+  "capabilities" | "security" | "pairing" | "threading" | "outbound"
 > &
   Partial<
     Pick<
       ChannelPlugin<TResolvedAccount, Probe, Audit>,
-      "security" | "pairing" | "threading" | "outbound"
+      "capabilities" | "security" | "pairing" | "threading" | "outbound"
     >
   >;
 
@@ -825,6 +825,7 @@ export function createChatChannelPlugin<
 }): ChannelPlugin<TResolvedAccount, Probe, Audit> {
   return {
     ...params.base,
+    capabilities: params.base.capabilities ?? { chatTypes: ["direct"] },
     conversationBindings: {
       supportsCurrentConversationBinding: true,
       ...params.base.conversationBindings,

--- a/src/plugins/channel-registry-state.types.ts
+++ b/src/plugins/channel-registry-state.types.ts
@@ -1,25 +1,8 @@
-/** Runtime shape needed to expose an active plugin channel registration. */
-export type ActiveChannelPluginRuntimeShape = {
-  id?: string | null;
-  meta?: {
-    aliases?: readonly string[];
-    markdownCapable?: boolean;
-    order?: number;
-  } | null;
-  messaging?: {
-    targetPrefixes?: readonly string[];
-    resolveConversationRouteOwner?: (...args: never[]) => unknown;
-  } | null;
-  capabilities?: {
-    nativeCommands?: boolean;
-  } | null;
-  conversationBindings?: {
-    supportsCurrentConversationBinding?: boolean;
-    isCurrentConversationBindingSupported?: (params: { accountId: string }) => boolean;
-    bindingStore?: "adapter";
-    createManager?: unknown;
-  } | null;
-};
+/** Validated channel plugin retained by the active runtime registry. */
+export type ActiveChannelPluginRuntimeShape =
+  import("../channels/plugins/types.plugin.js").ChannelPlugin & {
+    meta: NonNullable<import("../channels/plugins/types.plugin.js").ChannelPlugin["meta"]>;
+  };
 
 /** Active channel registration with owning plugin metadata. */
 export type ActivePluginChannelRegistration = {

--- a/src/plugins/channel-validation.ts
+++ b/src/plugins/channel-validation.ts
@@ -70,6 +70,15 @@ export function normalizeRegisteredChannelPlugin(params: {
     });
     return null;
   }
+  if (!Array.isArray(params.plugin.capabilities?.chatTypes)) {
+    params.pushDiagnostic({
+      level: "error",
+      pluginId: params.pluginId,
+      source: params.source,
+      message: `channel "${id}" registration missing required capabilities.chatTypes`,
+    });
+    return null;
+  }
   if (
     typeof params.plugin.config?.listAccountIds !== "function" ||
     typeof params.plugin.config?.resolveAccount !== "function"

--- a/src/plugins/channel-validation.ts
+++ b/src/plugins/channel-validation.ts
@@ -50,6 +50,12 @@ function collectMissingChannelMetaFields(meta?: Partial<ChannelMeta> | null): st
   return missing;
 }
 
+function isChannelCapabilityChatType(value: unknown): boolean {
+  // Capability declarations use the canonical public contract literals.
+  // Channel-specific aliases are normalized at message ingress, not registration.
+  return value === "direct" || value === "group" || value === "channel" || value === "thread";
+}
+
 /** Validates and normalizes a channel plugin registration before runtime catalog insertion. */
 export function normalizeRegisteredChannelPlugin(params: {
   pluginId: string;
@@ -70,12 +76,16 @@ export function normalizeRegisteredChannelPlugin(params: {
     });
     return null;
   }
-  if (!Array.isArray(params.plugin.capabilities?.chatTypes)) {
+  const chatTypes = params.plugin.capabilities?.chatTypes;
+  if (
+    !Array.isArray(chatTypes) ||
+    chatTypes.some((chatType) => !isChannelCapabilityChatType(chatType))
+  ) {
     params.pushDiagnostic({
       level: "error",
       pluginId: params.pluginId,
       source: params.source,
-      message: `channel "${id}" registration missing required capabilities.chatTypes`,
+      message: `channel "${id}" registration missing or invalid required capabilities.chatTypes`,
     });
     return null;
   }

--- a/src/plugins/channel-validation.ts
+++ b/src/plugins/channel-validation.ts
@@ -75,6 +75,7 @@ export function normalizeRegisteredChannelPlugin(params: {
   const chatTypes = params.plugin.capabilities?.chatTypes;
   if (
     !Array.isArray(chatTypes) ||
+    chatTypes.length === 0 ||
     chatTypes.some((chatType) => !CHANNEL_CAPABILITY_CHAT_TYPES.has(chatType))
   ) {
     params.pushDiagnostic({

--- a/src/plugins/channel-validation.ts
+++ b/src/plugins/channel-validation.ts
@@ -50,11 +50,7 @@ function collectMissingChannelMetaFields(meta?: Partial<ChannelMeta> | null): st
   return missing;
 }
 
-function isChannelCapabilityChatType(value: unknown): boolean {
-  // Capability declarations use the canonical public contract literals.
-  // Channel-specific aliases are normalized at message ingress, not registration.
-  return value === "direct" || value === "group" || value === "channel" || value === "thread";
-}
+const CHANNEL_CAPABILITY_CHAT_TYPES = new Set(["direct", "group", "channel", "thread"]);
 
 /** Validates and normalizes a channel plugin registration before runtime catalog insertion. */
 export function normalizeRegisteredChannelPlugin(params: {
@@ -79,7 +75,7 @@ export function normalizeRegisteredChannelPlugin(params: {
   const chatTypes = params.plugin.capabilities?.chatTypes;
   if (
     !Array.isArray(chatTypes) ||
-    chatTypes.some((chatType) => !isChannelCapabilityChatType(chatType))
+    chatTypes.some((chatType) => !CHANNEL_CAPABILITY_CHAT_TYPES.has(chatType))
   ) {
     params.pushDiagnostic({
       level: "error",

--- a/src/plugins/registry.channel-guard.test.ts
+++ b/src/plugins/registry.channel-guard.test.ts
@@ -40,23 +40,26 @@ function createChannelPlugin(id: string, label: string): ChannelPlugin {
 }
 
 describe("plugin registry channel guard", () => {
-  it("rejects incomplete channel plugins at the registrar boundary", () => {
-    const pluginRegistry = createTestRegistry();
-    const record = createPluginRecord({ id: "incomplete-channel-owner", origin: "global" });
-    const plugin = createChannelPlugin("incomplete-channel", "Incomplete Channel");
-    plugin.capabilities = undefined as never;
+  it.each([undefined, { chatTypes: ["forum"] }, { chatTypes: [1] }])(
+    "rejects incomplete or invalid channel plugins at the registrar boundary",
+    (capabilities) => {
+      const pluginRegistry = createTestRegistry();
+      const record = createPluginRecord({ id: "incomplete-channel-owner", origin: "global" });
+      const plugin = createChannelPlugin("incomplete-channel", "Incomplete Channel");
+      plugin.capabilities = capabilities as never;
 
-    pluginRegistry.registry.plugins.push(record);
-    pluginRegistry
-      .createApi(record, { config: {} as OpenClawConfig, registrationMode: "full" })
-      .registerChannel({ plugin });
+      pluginRegistry.registry.plugins.push(record);
+      pluginRegistry
+        .createApi(record, { config: {} as OpenClawConfig, registrationMode: "full" })
+        .registerChannel({ plugin });
 
-    expect(pluginRegistry.registry.channelSetups).toHaveLength(0);
-    expect(pluginRegistry.registry.channels).toHaveLength(0);
-    expect(pluginRegistry.registry.diagnostics.map((diag) => diag.message)).toContain(
-      'channel "incomplete-channel" registration missing required capabilities.chatTypes',
-    );
-  });
+      expect(pluginRegistry.registry.channelSetups).toHaveLength(0);
+      expect(pluginRegistry.registry.channels).toHaveLength(0);
+      expect(pluginRegistry.registry.diagnostics.map((diag) => diag.message)).toContain(
+        'channel "incomplete-channel" registration missing or invalid required capabilities.chatTypes',
+      );
+    },
+  );
 
   it("rejects channel registration from disabled workspace plugins", () => {
     const pluginRegistry = createTestRegistry();

--- a/src/plugins/registry.channel-guard.test.ts
+++ b/src/plugins/registry.channel-guard.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createChatChannelPlugin } from "../plugin-sdk/channel-core.js";
 import { createPluginRegistry } from "./registry.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { createPluginRecord } from "./status.test-fixtures.js";
@@ -40,7 +41,7 @@ function createChannelPlugin(id: string, label: string): ChannelPlugin {
 }
 
 describe("plugin registry channel guard", () => {
-  it.each([undefined, { chatTypes: ["forum"] }, { chatTypes: [1] }])(
+  it.each([undefined, { chatTypes: [] }, { chatTypes: ["forum"] }, { chatTypes: [1] }])(
     "rejects incomplete or invalid channel plugins at the registrar boundary",
     (capabilities) => {
       const pluginRegistry = createTestRegistry();
@@ -140,13 +141,18 @@ describe("plugin registry channel guard", () => {
       origin: "workspace",
       enabled: true,
     });
+    const plugin = createChannelPlugin("telegram", "Trusted Workspace Telegram");
+    plugin.capabilities = undefined as never;
 
     pluginRegistry.registry.plugins.push(record);
     pluginRegistry.createApi(record, { config, registrationMode: "setup-only" }).registerChannel({
-      plugin: createChannelPlugin("telegram", "Trusted Workspace Telegram"),
+      plugin: createChatChannelPlugin({ base: plugin }),
     });
 
     expect(pluginRegistry.registry.channelSetups).toHaveLength(1);
+    expect(pluginRegistry.registry.channelSetups[0]?.plugin.capabilities.chatTypes).toEqual([
+      "direct",
+    ]);
     expect(pluginRegistry.registry.channelSetups[0]).toMatchObject({
       pluginId: "trusted-workspace-shadow",
       enabled: true,

--- a/src/plugins/registry.channel-guard.test.ts
+++ b/src/plugins/registry.channel-guard.test.ts
@@ -40,6 +40,24 @@ function createChannelPlugin(id: string, label: string): ChannelPlugin {
 }
 
 describe("plugin registry channel guard", () => {
+  it("rejects incomplete channel plugins at the registrar boundary", () => {
+    const pluginRegistry = createTestRegistry();
+    const record = createPluginRecord({ id: "incomplete-channel-owner", origin: "global" });
+    const plugin = createChannelPlugin("incomplete-channel", "Incomplete Channel");
+    plugin.capabilities = undefined as never;
+
+    pluginRegistry.registry.plugins.push(record);
+    pluginRegistry
+      .createApi(record, { config: {} as OpenClawConfig, registrationMode: "full" })
+      .registerChannel({ plugin });
+
+    expect(pluginRegistry.registry.channelSetups).toHaveLength(0);
+    expect(pluginRegistry.registry.channels).toHaveLength(0);
+    expect(pluginRegistry.registry.diagnostics.map((diag) => diag.message)).toContain(
+      'channel "incomplete-channel" registration missing required capabilities.chatTypes',
+    );
+  });
+
   it("rejects channel registration from disabled workspace plugins", () => {
     const pluginRegistry = createTestRegistry();
     const config = {} as OpenClawConfig;


### PR DESCRIPTION
## What Problem This Solves

Loaded channel plugins were stored through a lightweight registry shape and repeatedly asserted back to the full plugin contract across authorization, reply formatting, mention handling, and startup paths.

## Why This Change Was Made

The registrar now validates the required full channel contract before retaining it in active registry state, and downstream getters expose that proven contract without repeated assertions. Validation rejects missing, empty, unknown, and non-string chat types.

The public chat-plugin builder supplies a direct-message capability when callers omit capabilities, preserving the documented construction path while keeping strict validation at the registry owner.

## User Impact

Existing plugins built through `createChatChannelPlugin` remain registerable when capabilities were omitted. Malformed raw registrations fail with a targeted diagnostic instead of entering active state with a contract the runtime cannot safely consume.

## Evidence

- 19 focused Plugin SDK and production-registrar tests passed at the final candidate.
- Full `node scripts/check-changed.mjs` passed, including core/extension typechecks, SDK surface and boundary checks, lint, assertion ratchets, dead-code scans, and import-cycle validation.
- Final mandatory P0–P2 autoreview returned `scoped-clean` with no actionable findings (0.90 confidence).
- GitHub diff: production source +36/-48 (net -12), tests +46/-16 (net +30), docs +2/-1, baseline +3/-6; total +85/-69 (net +16).
