### PR TITLE
refactor(whatsapp): preserve typed socket events

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1365,14 +1365,14 @@ extensions/whatsapp/src/group-config-path.ts	4
 extensions/whatsapp/src/inbound-policy.ts	1
 extensions/whatsapp/src/inbound/durable-payload.ts	2
 extensions/whatsapp/src/inbound/extract.ts	10
-extensions/whatsapp/src/inbound/group-metadata-cache.ts	7
+extensions/whatsapp/src/inbound/group-metadata-cache.ts	4
 extensions/whatsapp/src/inbound/ingress-lifecycle.ts	2
 extensions/whatsapp/src/inbound/media.ts	4
 extensions/whatsapp/src/inbound/message-delivery.ts	1
 extensions/whatsapp/src/inbound/message-enrichment.ts	3
 extensions/whatsapp/src/inbound/outbound-mentions.ts	1
 extensions/whatsapp/src/inbound/send-api.ts	5
-extensions/whatsapp/src/inbound/socket-session.ts	5
+extensions/whatsapp/src/inbound/socket-session.ts	3
 extensions/whatsapp/src/qa-driver.runtime.ts	1
 extensions/whatsapp/src/quoted-message.ts	1
 extensions/whatsapp/src/reconnect.ts	1

--- a/extensions/whatsapp/src/inbound/group-metadata-cache.ts
+++ b/extensions/whatsapp/src/inbound/group-metadata-cache.ts
@@ -1,5 +1,5 @@
 // Whatsapp plugin module owns group metadata caching and hydration.
-import type { AnyMessageContent, GroupMetadata, WASocket } from "baileys";
+import type { AnyMessageContent, BaileysEventMap, GroupMetadata, WASocket } from "baileys";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -9,6 +9,7 @@ import {
   rememberWhatsAppBaileysCacheEntry,
   type WhatsAppBaileysGroupMetadataCache,
 } from "./baileys-cache.js";
+import type { WhatsAppSocketListen } from "./lifecycle.js";
 import {
   addWhatsAppOutboundMentionsToContent,
   mayContainWhatsAppOutboundMention,
@@ -38,7 +39,7 @@ type GroupMetadataCacheOwnerParams = {
   resolveInboundJid: (jid: string | null | undefined) => Promise<string | null>;
   reconnectCache?: WhatsAppGroupMetadataCache;
   baileysCache?: WhatsAppBaileysGroupMetadataCache;
-  listen: (event: string, listener: (...args: unknown[]) => void) => () => void;
+  listen: WhatsAppSocketListen;
   logVerbose: (message: string) => void;
   logHydrationWarning: (error: string) => void;
 };
@@ -247,18 +248,21 @@ export function createWhatsAppGroupMetadataCacheOwner(params: GroupMetadataCache
       return;
     }
     started = true;
-    const listen = (event: string, listener: (...args: unknown[]) => void) => {
+    const listen = <Event extends keyof BaileysEventMap>(
+      event: Event,
+      listener: (arg: BaileysEventMap[Event]) => void,
+    ) => {
       detachListeners.push(params.listen(event, listener));
     };
 
-    listen("groups.upsert", ((groups: GroupMetadata[]) => {
+    listen("groups.upsert", (groups) => {
       for (const group of groups) {
         if (group.id) {
           rememberFullUpdate(group.id, group);
         }
       }
-    }) as unknown as (...args: unknown[]) => void);
-    listen("groups.update", ((updates: Partial<GroupMetadata>[]) => {
+    });
+    listen("groups.update", (updates) => {
       for (const update of updates) {
         if (!update.id) {
           continue;
@@ -269,10 +273,10 @@ export function createWhatsAppGroupMetadataCacheOwner(params: GroupMetadataCache
         }
         forgetFullMetadata(update.id);
       }
-    }) as unknown as (...args: unknown[]) => void);
-    listen("group-participants.update", ((update: { id: string }) => {
+    });
+    listen("group-participants.update", (update) => {
       forgetFullMetadata(update.id);
-    }) as unknown as (...args: unknown[]) => void);
+    });
 
     void (async () => {
       try {

--- a/extensions/whatsapp/src/inbound/lifecycle.ts
+++ b/extensions/whatsapp/src/inbound/lifecycle.ts
@@ -1,11 +1,12 @@
 // Whatsapp plugin module implements lifecycle behavior.
-type Listener = (...args: unknown[]) => void;
+import type { BaileysEventEmitter, BaileysEventMap } from "baileys";
 
-type OffCapableEmitter = {
-  on: (event: string, listener: Listener) => void;
-  off?: (event: string, listener: Listener) => void;
-  removeListener?: (event: string, listener: Listener) => void;
-};
+type BaileysListener<Event extends keyof BaileysEventMap> = (arg: BaileysEventMap[Event]) => void;
+
+export type WhatsAppSocketListen = <Event extends keyof BaileysEventMap>(
+  event: Event,
+  listener: BaileysListener<Event>,
+) => () => void;
 
 type ClosableSocket = {
   end?: (error: Error | undefined) => void;
@@ -14,21 +15,13 @@ type ClosableSocket = {
   };
 };
 
-export function attachEmitterListener(
-  emitter: OffCapableEmitter,
-  event: string,
-  listener: Listener,
+export function attachEmitterListener<Event extends keyof BaileysEventMap>(
+  emitter: BaileysEventEmitter,
+  event: Event,
+  listener: BaileysListener<Event>,
 ): () => void {
   emitter.on(event, listener);
-  return () => {
-    if (typeof emitter.off === "function") {
-      emitter.off(event, listener);
-      return;
-    }
-    if (typeof emitter.removeListener === "function") {
-      emitter.removeListener(event, listener);
-    }
-  };
+  return () => emitter.off(event, listener);
 }
 
 export function closeInboundMonitorSocket(sock: ClosableSocket): void {

--- a/extensions/whatsapp/src/inbound/socket-session.ts
+++ b/extensions/whatsapp/src/inbound/socket-session.ts
@@ -36,7 +36,11 @@ import {
 import { rememberRecentOutboundMessage } from "./dedupe.js";
 import type { WhatsAppReadReceiptTarget } from "./durable-receive.js";
 import { extractText } from "./extract.js";
-import { attachEmitterListener, closeInboundMonitorSocket } from "./lifecycle.js";
+import {
+  attachEmitterListener,
+  closeInboundMonitorSocket,
+  type WhatsAppSocketListen,
+} from "./lifecycle.js";
 import { DisconnectReason } from "./runtime-api.js";
 import type { WebListenerCloseReason } from "./types.js";
 
@@ -410,16 +414,8 @@ export async function createWhatsAppAttachedSocketSession(options: SocketSession
     );
   };
 
-  const attachSockListener = (event: string, listener: (...args: unknown[]) => void) =>
-    attachEmitterListener(
-      sock.ev as unknown as {
-        on: (event: string, listener: (...args: unknown[]) => void) => void;
-        off?: (event: string, listener: (...args: unknown[]) => void) => void;
-        removeListener?: (event: string, listener: (...args: unknown[]) => void) => void;
-      },
-      event,
-      listener,
-    );
+  const attachSockListener: WhatsAppSocketListen = (event, listener) =>
+    attachEmitterListener(sock.ev, event, listener);
 
   const handleConnectionUpdate = (update: Partial<ConnectionState>) => {
     try {
@@ -445,10 +441,7 @@ export async function createWhatsAppAttachedSocketSession(options: SocketSession
 
   let detachConnectionUpdate: (() => void) | undefined;
   const start = () => {
-    detachConnectionUpdate ??= attachSockListener(
-      "connection.update",
-      handleConnectionUpdate as unknown as (...args: unknown[]) => void,
-    );
+    detachConnectionUpdate ??= attachSockListener("connection.update", handleConnectionUpdate);
   };
   const stop = () => {
     detachConnectionUpdate?.();


### PR DESCRIPTION
## What Problem This Solves

The WhatsApp inbound listener facade erased Baileys event names and payloads to untyped callbacks, forcing handlers to restore their actual event contracts through chained assertions.

## Why This Change Was Made

The listener boundary now preserves `BaileysEventMap` generics from socket registration through connection and group-metadata handlers. Listener cleanup uses the typed Baileys emitter contract already provided by the dependency.

## User Impact

No user-visible behavior change. WhatsApp connection and group metadata listeners now retain their upstream payload contracts at compile time.

## Evidence

- 63 focused WhatsApp inbound tests passed.
- Full `pnpm check:changed` passed, including extension type checks, assertion ratchet, lint, formatting, and import-cycle validation.
- Mandatory P0–P2 autoreview returned `scoped-clean` with no actionable findings (0.97 confidence).
- Diff: 35 additions, 45 deletions overall; complete PR is net -10 lines.