### PR TITLE
refactor(config): derive schema response wire types

### DIFF
--- a/src/config/schema.lookup.ts
+++ b/src/config/schema.lookup.ts
@@ -1,3 +1,4 @@
+import type { ConfigSchemaLookupResult as ProtocolConfigSchemaLookupResult } from "../../packages/gateway-protocol/src/schema/config.js";
 import { parseConfigPathArrayIndex } from "../shared/path-array-index.js";
 import type { ConfigUiHint, ConfigUiHints } from "./schema.hints.js";
 import {
@@ -45,18 +46,8 @@ const MAX_LOOKUP_PATH_SEGMENTS = 32;
 const LOOKUP_SCHEMA_COMPOSITION_KEYS = ["anyOf", "oneOf", "allOf"] as const;
 const LOOKUP_SCHEMA_NESTED_FORM_DEPTH = 4;
 
-type ConfigSchemaLookupChild = {
-  key: string;
-  path: string;
-  type?: string | string[];
-  required: boolean;
-  hasChildren: boolean;
-  reloadKind?: ConfigSchemaReloadKind;
-  hint?: ConfigUiHint;
-  hintPath?: string;
-};
-
-type ConfigSchemaReloadKind = "restart" | "hot" | "none";
+type ConfigSchemaLookupChild = ProtocolConfigSchemaLookupResult["children"][number];
+type ConfigSchemaReloadKind = NonNullable<ProtocolConfigSchemaLookupResult["reloadKind"]>;
 
 type ConfigSchemaReloadMetadata = {
   kind: ConfigSchemaReloadKind;
@@ -66,13 +57,8 @@ type ConfigSchemaReloadMetadataResolver = (
   path: string,
 ) => ConfigSchemaReloadMetadata | null | undefined;
 
-type ConfigSchemaLookupResult = {
-  path: string;
+type ConfigSchemaLookupResult = Omit<ProtocolConfigSchemaLookupResult, "schema"> & {
   schema: JsonSchemaNode;
-  reloadKind?: ConfigSchemaReloadKind;
-  hint?: ConfigUiHint;
-  hintPath?: string;
-  children: ConfigSchemaLookupChild[];
 };
 
 function normalizeLookupPath(path: string): string {

--- a/src/config/schema.shared.ts
+++ b/src/config/schema.shared.ts
@@ -1,12 +1,11 @@
 // Provides shared JSON schema helpers for generated config metadata.
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ConfigSchemaResponse as ProtocolConfigSchemaResponse } from "../../packages/gateway-protocol/src/schema/config.js";
 import type { ConfigUiHints } from "../shared/config-ui-hints-types.js";
 
-export type ConfigSchemaResponse = {
+export type ConfigSchemaResponse = Omit<ProtocolConfigSchemaResponse, "schema" | "uiHints"> & {
   schema: Record<string, unknown>;
   uiHints: ConfigUiHints;
-  version: string;
-  generatedAt: string;
 };
 
 export type ConfigJsonSchemaObject = Record<string, unknown> & {


### PR DESCRIPTION
## What Problem This Solves

Config schema lookup and response code manually repeated gateway protocol fields, allowing the internal and wire contracts to drift while requiring parallel maintenance.

## Why This Change Was Made

The config-owned schema specializations now compose directly from the protocol-owned response types. Type-only imports preserve the existing runtime dependency graph and keep config-private JSON schema narrowing local.

## User Impact

No user-visible behavior change. Config schema metadata now has one canonical wire contract, reducing drift risk for Gateway and Control UI consumers.

## Evidence

- 88 focused config schema tests passed.
- Full `pnpm check:changed` passed, including type checks, lint, formatting, and import-cycle validation.
- Mandatory P0–P2 autoreview returned `scoped-clean` with no actionable findings (0.95 confidence).
- Diff: 6 additions, 21 deletions; production TypeScript is net -15 lines.