### PR TITLE
refactor(browser): centralize raw CDP sender

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -83,13 +83,13 @@ extensions/browser/src/browser/pw-download-capture.ts	1
 extensions/browser/src/browser/pw-role-snapshot.ts	1
 extensions/browser/src/browser/pw-session-actions.ts	2
 extensions/browser/src/browser/pw-session-navigation.ts	1
-extensions/browser/src/browser/pw-session.page-cdp.ts	4
+extensions/browser/src/browser/pw-session.page-cdp.ts	2
 extensions/browser/src/browser/pw-tools-core.interactions.actions.ts	2
 extensions/browser/src/browser/pw-tools-core.interactions.content.ts	1
 extensions/browser/src/browser/pw-tools-core.interactions.execution.ts	4
 extensions/browser/src/browser/pw-tools-core.interactions.navigation.ts	3
 extensions/browser/src/browser/pw-tools-core.snapshot.ts	1
-extensions/browser/src/browser/pw-tools-core.state.ts	3
+extensions/browser/src/browser/pw-tools-core.state.ts	2
 extensions/browser/src/browser/routes/agent.act.normalize.ts	1
 extensions/browser/src/browser/routes/agent.act.shared.ts	3
 extensions/browser/src/browser/routes/agent.act.ts	2

--- a/extensions/browser/src/browser/cdp-page-session.ts
+++ b/extensions/browser/src/browser/cdp-page-session.ts
@@ -14,6 +14,12 @@ const CDP_TARGET_NAVIGATION_RESULT_TIMEOUT_MS = 2_000;
 const CDP_TARGET_NAVIGATION_RESULT_POLL_MS = 50;
 const CDP_TARGET_NAVIGATION_STABILITY_MS = 250;
 
+type CdpGetFrameTreeSend = (
+  method: "Page.getFrameTree",
+  params?: undefined,
+  sessionId?: string,
+) => Promise<unknown>;
+
 type CdpFrameTreeResult = {
   frameTree?: {
     frame?: {
@@ -44,7 +50,7 @@ function readCommittedFrameUrl(
 
 /** Read the browser-owned loader identity for the committed main-frame document. */
 export async function readCdpMainFrameDocumentIdentity(
-  send: CdpSendFn,
+  send: CdpGetFrameTreeSend,
   sessionId?: string,
 ): Promise<string | undefined> {
   const frameTree = (await send("Page.getFrameTree", undefined, sessionId).catch(

--- a/extensions/browser/src/browser/pw-cdp-send.ts
+++ b/extensions/browser/src/browser/pw-cdp-send.ts
@@ -1,0 +1,9 @@
+import type { CDPSession } from "playwright-core";
+import type { CdpSendFn } from "./cdp.helpers.js";
+
+/** Bind Playwright's protocol-generic sender to the browser's raw CDP contract. */
+export function bindPlaywrightCdpSend(session: CDPSession): CdpSendFn {
+  // SAFETY: Playwright's generic overload accepts the same method/params calls; binding preserves its receiver.
+  const send = session.send.bind(session) as unknown as CdpSendFn;
+  return (method, params) => send(method, params);
+}

--- a/extensions/browser/src/browser/pw-cdp-send.ts
+++ b/extensions/browser/src/browser/pw-cdp-send.ts
@@ -1,9 +1,6 @@
 import type { CDPSession } from "playwright-core";
-import type { CdpSendFn } from "./cdp.helpers.js";
 
-/** Bind Playwright's protocol-generic sender to the browser's raw CDP contract. */
-export function bindPlaywrightCdpSend(session: CDPSession): CdpSendFn {
-  // SAFETY: Playwright's generic overload accepts the same method/params calls; binding preserves its receiver.
-  const send = session.send.bind(session) as unknown as CdpSendFn;
-  return (method, params) => send(method, params);
+/** Bind Playwright's generated CDP sender while preserving its protocol types. */
+export function bindPlaywrightCdpSend(session: CDPSession): CDPSession["send"] {
+  return session.send.bind(session);
 }

--- a/extensions/browser/src/browser/pw-session.page-cdp.test.ts
+++ b/extensions/browser/src/browser/pw-session.page-cdp.test.ts
@@ -13,12 +13,15 @@ describe("pw-session page-scoped CDP client", () => {
   });
 
   it("uses Playwright page sessions", async () => {
-    const sessionSend = vi.fn(async () => ({ ok: true }));
     const sessionDetach = vi.fn(async () => {});
-    const newCDPSession = vi.fn(async () => ({
-      send: sessionSend,
+    const session = {
+      send: vi.fn(async function (this: unknown) {
+        expect(this).toBe(session);
+        return { ok: true };
+      }),
       detach: sessionDetach,
-    }));
+    };
+    const newCDPSession = vi.fn(async () => session);
     const page = {
       context: () => ({
         newCDPSession,
@@ -35,7 +38,7 @@ describe("pw-session page-scoped CDP client", () => {
     });
 
     expect(newCDPSession).toHaveBeenCalledWith(page);
-    expect(sessionSend).toHaveBeenCalledWith("Emulation.setLocaleOverride", { locale: "en-US" });
+    expect(session.send).toHaveBeenCalledWith("Emulation.setLocaleOverride", { locale: "en-US" });
     expect(sessionDetach).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/browser/src/browser/pw-session.page-cdp.ts
+++ b/extensions/browser/src/browser/pw-session.page-cdp.ts
@@ -7,8 +7,8 @@
 import { uniqueValues } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { CDPSession, Page } from "playwright-core";
 import { readCdpMainFrameDocumentIdentity } from "./cdp-page-session.js";
+import { bindPlaywrightCdpSend } from "./pw-cdp-send.js";
 
-type PageCdpSend = (method: string, params?: Record<string, unknown>) => Promise<unknown>;
 type MarkBackendDomRef = { ref: string; backendDOMNodeId: number };
 
 /** Attribute used to mark DOM nodes that correspond to generated browser refs. */
@@ -31,17 +31,10 @@ export async function withPageScopedCdpClient<T>(opts: {
   cdpUrl: string;
   page: Page;
   targetId?: string;
-  fn: (send: PageCdpSend) => Promise<T>;
+  fn: (send: ReturnType<typeof bindPlaywrightCdpSend>) => Promise<T>;
 }): Promise<T> {
   return await withPlaywrightPageCdpSession(opts.page, async (session) => {
-    return await opts.fn((method, params) =>
-      (
-        session.send as unknown as (
-          method: string,
-          params?: Record<string, unknown>,
-        ) => Promise<unknown>
-      )(method, params),
-    );
+    return await opts.fn(bindPlaywrightCdpSend(session));
   });
 }
 
@@ -51,15 +44,7 @@ export async function readMainFrameDocumentIdentityForPage(
 ): Promise<string | undefined> {
   return await withPlaywrightPageCdpSession(
     page,
-    async (session) =>
-      await readCdpMainFrameDocumentIdentity((method, params) =>
-        (
-          session.send as unknown as (
-            method: string,
-            params?: Record<string, unknown>,
-          ) => Promise<unknown>
-        )(method, params),
-      ),
+    async (session) => await readCdpMainFrameDocumentIdentity(bindPlaywrightCdpSend(session)),
   );
 }
 

--- a/extensions/browser/src/browser/pw-tools-core.state.ts
+++ b/extensions/browser/src/browser/pw-tools-core.state.ts
@@ -4,6 +4,7 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { CDPSession, Page } from "playwright-core";
 import { getPlaywrightCore } from "./playwright-core.runtime.js";
+import { bindPlaywrightCdpSend } from "./pw-cdp-send.js";
 import type { PageState } from "./pw-session-contracts.js";
 import { ensurePageState, getPageForTargetId } from "./pw-session.js";
 import {
@@ -12,8 +13,6 @@ import {
 } from "./pw-tools-core.interactions.navigation.js";
 
 type DeviceSize = { width: number; height: number };
-type PageCdpSend = (method: string, params?: Record<string, unknown>) => Promise<unknown>;
-
 type PlaywrightDeviceDescriptor = {
   userAgent: string;
   viewport: DeviceSize;
@@ -45,19 +44,10 @@ function resolvePageEmulationSession(page: Page, state: PageState): Promise<CDPS
 async function withPageEmulationCdpClient<T>(params: {
   page: Page;
   state: PageState;
-  run: (send: PageCdpSend, session: CDPSession) => Promise<T>;
+  run: (send: ReturnType<typeof bindPlaywrightCdpSend>, session: CDPSession) => Promise<T>;
 }): Promise<T> {
   const session = await resolvePageEmulationSession(params.page, params.state);
-  return await params.run(
-    (method, values) =>
-      (
-        session.send as unknown as (
-          method: string,
-          values?: Record<string, unknown>,
-        ) => Promise<unknown>
-      )(method, values),
-    session,
-  );
+  return await params.run(bindPlaywrightCdpSend(session), session);
 }
 
 export async function setViewportSizeOnPage(page: Page, state: PageState, viewport: DeviceSize) {


### PR DESCRIPTION
## What Problem This Solves

Browser page-scoped and emulation paths independently erased Playwright CDP sender overloads, duplicated receiver-sensitive adapters, and repeated unsafe chained assertions.

## Why This Change Was Made

A single browser-owned adapter now binds Playwright session receivers and exposes the existing raw CDP send contract. Both call sites reuse that boundary without changing protocol calls or session lifecycle.

## User Impact

No user-visible behavior change. Browser CDP interactions now share one typed Playwright boundary, reducing drift between page and emulation paths.

## Evidence

- 12 focused browser CDP and emulation tests passed.
- Full `pnpm check:changed` passed, including extension type checks, assertion ratchet, lint, formatting, and import-cycle validation.
- Mandatory P0–P2 autoreview returned `scoped-clean` with no actionable findings (0.96 confidence).
- Diff: 18 additions, 34 deletions overall; complete PR is net -16 lines.