### PR TITLE
test(doctor): use canonical contribution factory in tests

### DIFF
--- a/src/flows/doctor-health-contributions.test-support.ts
+++ b/src/flows/doctor-health-contributions.test-support.ts
@@ -1,42 +1,14 @@
 import { vi } from "vitest";
 import type { DoctorPrompter } from "../commands/doctor-prompter.js";
 import type { OpenClawConfig, OpenClawConfigInput } from "../config/config.js";
-import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
+import type {
+  DoctorHealthContribution,
+  DoctorHealthFlowContext,
+} from "./doctor-health-contribution-types.js";
 import "./doctor-health-contributions.js";
 import type { runDoctorLintChecks } from "./doctor-lint-flow.js";
-import type { HealthCheckInput, RunnableHealthCheck } from "./health-check-runner-types.js";
-import type { HealthCheck } from "./health-checks.js";
-import type { FlowContribution } from "./types.js";
-
-type DoctorContributionHealthCheck =
-  | (Omit<HealthCheck, "id" | "kind" | "source"> & {
-      readonly id?: string;
-      readonly kind?: "core";
-      readonly source?: string;
-    })
-  | (Omit<RunnableHealthCheck, "id" | "kind" | "source"> & {
-      readonly id?: string;
-      readonly kind?: "core";
-      readonly source?: string;
-    });
-
-type DoctorHealthContribution = FlowContribution & {
-  kind: "core";
-  surface: "health";
-  healthChecks: readonly HealthCheckInput[];
-  healthCheckIds: readonly string[];
-  run: (ctx: DoctorHealthFlowContext) => Promise<void>;
-};
 
 type DoctorHealthContributionTestApi = {
-  createDoctorHealthContribution(params: {
-    id: string;
-    label: string;
-    healthCheckIds?: readonly string[];
-    healthChecks?: DoctorContributionHealthCheck | readonly DoctorContributionHealthCheck[];
-    hint?: string;
-    run?: (ctx: DoctorHealthFlowContext) => Promise<void>;
-  }): DoctorHealthContribution;
   resolveDoctorHealthContributions(): DoctorHealthContribution[];
   runDoctorHealthContributionList(
     ctx: DoctorHealthFlowContext,
@@ -105,12 +77,6 @@ function getTestApi(): DoctorHealthContributionTestApi {
     throw new Error("doctor health contributions test API is unavailable");
   }
   return api as DoctorHealthContributionTestApi;
-}
-
-export function createDoctorHealthContribution(
-  params: Parameters<DoctorHealthContributionTestApi["createDoctorHealthContribution"]>[0],
-): DoctorHealthContribution {
-  return getTestApi().createDoctorHealthContribution(params);
 }
 
 export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -11,10 +11,10 @@ import { migrateLegacySecretRefEnvMarkers } from "../secrets/legacy-secretref-en
 import { readConfigMachineState } from "../state/config-machine-state.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { CORE_HEALTH_CHECKS } from "./doctor-core-checks.js";
+import { createDoctorHealthContribution } from "./doctor-health-contribution.js";
 import { resolveDoctorContributionHealthChecks } from "./doctor-health-contributions.js";
 import {
   createDoctorConfigFixture,
-  createDoctorHealthContribution,
   createDoctorHealthFlowContext,
   createDoctorLintContext,
   resolveDoctorHealthContributions,

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -18,7 +18,6 @@ import {
   resolveDoctorMode,
   resolveDoctorWorkspaceDir,
 } from "./doctor-health-contribution-utils.js";
-import { createDoctorHealthContribution } from "./doctor-health-contribution.js";
 import { resolveFinalDoctorHealthContributions } from "./doctor-health-contributions-final.js";
 import { resolveInitialDoctorHealthContributions } from "./doctor-health-contributions-initial.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
@@ -595,7 +594,6 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[
     Symbol.for("openclaw.doctorHealthContributionsTestApi")
   ] = {
-    createDoctorHealthContribution,
     resolveDoctorHealthContributions,
     runDoctorHealthContributionList,
   };


### PR DESCRIPTION
## What Problem This Solves

This maintainer-requested test audit removes an obsolete Doctor test forwarding path. The contribution factory already has a production export, while the test adapter still carried separate signatures and types that had drifted from the owner.

## Why This Change Was Made

Tests now import the existing factory directly and reuse the canonical contribution types. The resolver and list runner remain available to preserve their ordering, required-failure, config-write refusal and advisory-error coverage. Every test body and the production factory are unchanged.

## User Impact

No user-visible behavior, configuration, migration or public SDK change. The patch removes two production lines used only by the test publication and 34 net test-support lines; the test-file change is an import move.

## Evidence

The same four existing suites passed before and after:

```sh
node scripts/run-vitest.mjs \
  src/flows/doctor-health-contributions.test.ts \
  src/flows/doctor-health-contributions.auth-import-order.test.ts \
  src/flows/doctor-health.test.ts \
  src/flows/doctor-health.update.test.ts
```

```text
Before: Test Files 4 passed (4); Tests 216 passed (216)
After:  Test Files 4 passed (4); Tests 216 passed (216)
```

A bounded fault control removed the real factory's explicit `params.run` precedence. The existing “uses legacy run when a contribution also declares structured health” test failed because the callback had zero calls. Restoring the exact factory bytes made that same test pass. No fault or extra test remains in the patch.

The 169,184 bytes after the test imports are identical. Factory, initial/final builders, runtime entrypoint and related owner hashes are unchanged. The normal changed gate passed, including core and test typechecks, formatting, lint, dead-export and architecture guards. Fresh independent Codex review found no actionable findings. These are local synthetic and fixture-backed proofs; they do not claim authenticated provider execution.
