### PR TITLE
chore(compat): renew plugin-sdk subpath removal-pending records to 2026-10-01

### DIFF
--- a/docs/plugins/compatibility.md
+++ b/docs/plugins/compatibility.md
@@ -85,7 +85,7 @@ separately tracked so supported upgrade paths can still repair old config.
 
 The remaining dated compatibility areas are:
 
-- the September SDK subpath window listed in the migration guide
+- the renewed October 1 SDK subpath window listed in the migration guide
 - the beta.5 session-store bridge
 - the shipped agent-harness SDK aliases, whose removal is pending a new
   externally documented migration decision

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -1257,14 +1257,15 @@ until the next Plugin SDK major.
 
 | Removal gate            | Tier                               | SDK subpaths                                                                                                                                                                        |
 | ----------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `2026-09-01`            | Earlier compatibility deprecations | `channel-lifecycle`, `channel-message`, `channel-reply-pipeline`, `config-runtime`, `infra-runtime`                                                                                 |
+| `2026-10-01`            | Earlier compatibility deprecations | `channel-lifecycle`, `channel-message`, `channel-reply-pipeline`, `config-runtime`, `infra-runtime`                                                                                 |
 | `next-plugin-sdk-major` | Major-version compatibility gate   | `inbound-reply-dispatch`                                                                                                                                                            |
 | `2026-10-01`            | Media legacy projection            | `agent-media-payload`, plus the non-subpath `MsgContext Media*` fields, channel inbound media payload builders, `buildMediaPayload`, hook media aliases, and `{{Media*}}` templates |
 
 The five September 1 subpaths remain available in 2026.8.2 under an approved
 retention exception; that release’s registry still labels them `deprecated`.
-The post-release registry marks them `removal-pending`, preserving their original
-`2026-09-01` removal target and replacement mappings. Removal awaits verification
+For 2026.9.1, the release maintainer approved renewing their `removeAfter` date
+from `2026-09-01` to `2026-10-01` on September 2, 2026. The registry keeps them
+`removal-pending` with the same replacement mappings. Removal awaits verification
 that supported external plugins have migrated. `infra-runtime` additionally retains
 system-event snapshot inspection and consumption until a modern public replacement
 exists. This changes compatibility tracking only, not the exported SDK or runtime

--- a/src/plugins/compat/plugin-sdk-subpath-records.ts
+++ b/src/plugins/compat/plugin-sdk-subpath-records.ts
@@ -20,7 +20,7 @@ const PLUGIN_SDK_SUBPATH_SEEDS = [
     subpath: "config-runtime",
     status: "removal-pending",
     owner: "config",
-    removeAfter: "2026-09-01",
+    removeAfter: "2026-10-01",
     replacement:
       "`api.pluginConfig`, `openclaw/plugin-sdk/config-mutation`, `openclaw/plugin-sdk/runtime-config-snapshot`, and `openclaw/plugin-sdk/config-contracts`; retain until supported external plugin migration is verified",
   },
@@ -36,7 +36,7 @@ const PLUGIN_SDK_SUBPATH_SEEDS = [
     subpath: "channel-reply-pipeline",
     status: "removal-pending",
     owner: "channel",
-    removeAfter: "2026-09-01",
+    removeAfter: "2026-10-01",
     replacement:
       "`openclaw/plugin-sdk/channel-outbound`; retain until supported external plugin migration is verified",
   },
@@ -45,7 +45,7 @@ const PLUGIN_SDK_SUBPATH_SEEDS = [
     subpath: "infra-runtime",
     status: "removal-pending",
     owner: "sdk",
-    removeAfter: "2026-09-01",
+    removeAfter: "2026-10-01",
     replacement:
       "focused subpaths including `openclaw/plugin-sdk/delivery-queue-runtime`, `openclaw/plugin-sdk/diagnostic-runtime`, `openclaw/plugin-sdk/error-runtime`, `openclaw/plugin-sdk/exec-approvals-runtime`, `openclaw/plugin-sdk/fetch-runtime`, and `openclaw/plugin-sdk/ssrf-runtime`; retain until supported external plugin migration is verified and system-event snapshot inspection and consumption have a modern public replacement",
   },
@@ -101,7 +101,7 @@ const PLUGIN_SDK_SUBPATH_SEEDS = [
     subpath: "channel-lifecycle",
     status: "removal-pending",
     owner: "channel",
-    removeAfter: "2026-09-01",
+    removeAfter: "2026-10-01",
     replacement:
       "`openclaw/plugin-sdk/channel-outbound`; retain until supported external plugin migration is verified",
   },
@@ -110,7 +110,7 @@ const PLUGIN_SDK_SUBPATH_SEEDS = [
     subpath: "channel-message",
     status: "removal-pending",
     owner: "channel",
-    removeAfter: "2026-09-01",
+    removeAfter: "2026-10-01",
     replacement:
       "`openclaw/plugin-sdk/channel-outbound` and `openclaw/plugin-sdk/channel-inbound`; retain until supported external plugin migration is verified",
   },

--- a/src/plugins/compat/registry.test.ts
+++ b/src/plugins/compat/registry.test.ts
@@ -83,23 +83,26 @@ describe("plugin compatibility registry", () => {
       (record) =>
         record.status === "removal-pending" &&
         record.removeAfter !== undefined &&
-        record.removeAfter <= "2026-07-30",
+        record.removeAfter <= "2026-09-02",
     );
 
     expect(staleRemovalWindows).toEqual([]);
-    const septemberSubpaths = [...records.values()].filter(
-      (record) => record.code.startsWith("plugin-sdk-") && record.removeAfter === "2026-09-01",
-    );
-    expect(septemberSubpaths).toHaveLength(5);
-    for (const record of septemberSubpaths) {
+    for (const code of [
+      "plugin-sdk-config-runtime-subpath",
+      "plugin-sdk-channel-reply-pipeline-subpath",
+      "plugin-sdk-infra-runtime-subpath",
+      "plugin-sdk-channel-lifecycle-subpath",
+      "plugin-sdk-channel-message-subpath",
+    ] as const satisfies readonly PluginCompatCode[]) {
+      const record = records.get(code);
       expect(record).toMatchObject({
         status: "removal-pending",
         deprecated: "2026-07-06",
         warningStarts: "2026-07-06",
-        removeAfter: "2026-09-01",
+        removeAfter: "2026-10-01",
         docsPath: "/plugins/sdk-migration",
       });
-      expect(record.replacement).toMatch(
+      expect(record?.replacement).toMatch(
         /retain until supported external plugin migration is verified/u,
       );
     }

--- a/test/scripts/plugin-boundary-report.test.ts
+++ b/test/scripts/plugin-boundary-report.test.ts
@@ -37,13 +37,13 @@ describe("plugin-boundary-report", () => {
     expect(summary.compat?.removalPendingCount).toBe(8);
     expect(summary.compat?.removalPendingDueCount).toEqual(expect.any(Number));
     expect(summary.compat?.removalPending?.map((record) => record.code)).toEqual([
+      "plugin-sdk-media-understanding-public-demotion",
+      "plugin-sdk-memory-host-core-public-demotion",
       "plugin-sdk-channel-lifecycle-subpath",
       "plugin-sdk-channel-message-subpath",
       "plugin-sdk-channel-reply-pipeline-subpath",
       "plugin-sdk-config-runtime-subpath",
       "plugin-sdk-infra-runtime-subpath",
-      "plugin-sdk-media-understanding-public-demotion",
-      "plugin-sdk-memory-host-core-public-demotion",
       "plugin-sdk-plugin-config-runtime-public-demotion",
     ]);
     for (const record of summary.compat?.removalPending ?? []) {


### PR DESCRIPTION
Related: #136024 (correct retained Plugin SDK migration paths and deadlines).

<details>
<summary>Additional instructions</summary>

This PR uses a branch in openclaw/openclaw that maintainers can update.

</details>

## What Problem This Solves

The 2026.9.1 release review finds five retained Plugin SDK subpaths already due for review on September 1, despite their external-plugin migration blockers still being open. Release maintainer Peter Steinberger approved on September 2, 2026 keeping these subpaths and renewing their review date to October 1 rather than removing them in 2026.9.1.

## Why This Change Was Made

Renew `removeAfter` from `2026-09-01` to `2026-10-01` for `config-runtime`, `channel-reply-pipeline`, `infra-runtime`, `channel-lifecycle`, and `channel-message`. Keep `removal-pending`, the original deprecation/warning dates, and all replacement/blocker text unchanged. The owning plugin compatibility type has no `previousRemoveAfter` field; that convention belongs to the separate doctor registry, so this change records renewal history in this PR, the commit, and the migration guide without extending the schema.

Update the hand-maintained compatibility and migration pages and the existing registry/report tests. There is no generated compatibility table; the boundary report consumes the canonical registry directly. The registry test selects these five IDs explicitly so other October 1 compatibility families do not accidentally enter the assertion. The report test retains date-ordered output, with September 30 records now first.

## User Impact

Existing plugins keep the same SDK exports and runtime behavior in 2026.9.1. The review deadline is renewed, not the removal authorization: retain until supported external plugin migration is verified. `infra-runtime` also remains blocked until system-event snapshot inspection and consumption have a modern public replacement. No config, storage, package-export, or runtime changes; no paths removed.

## Evidence

- Regression proof: the updated registry test failed on the original records (11 passed, 1 failed) because all five still had the expired September 1 date.
- `pnpm test src/plugins/compat`: passed, 12 tests.
- `pnpm test src/plugins/compat test/scripts/plugin-boundary-report.test.ts`: passed, 16 tests across two shards.
- `pnpm plugins:boundary-report:ci`: passed, zero date-eligible deprecated records and zero pending records due for review.
- `pnpm plugins:boundary-report --json`: compared before/after; exactly five dates changed, pending-due count 5 → 0, and statuses, blockers, reader references, and other pending records stayed unchanged.
- `pnpm docs:check-mdx`: passed, 752 files.
- `pnpm docs:check-links`: passed, 7,262 internal links, zero broken links.
- `pnpm check:changed`: passed, including formatting, core/core-test/root-test typechecks, lint, compatibility/deprecated-API/dead-export guards, and remaining repository guards.
- `git diff --check`: passed.
- Independent Codex autoreview through P2: scoped-clean, no accepted/actionable findings.

Rebased onto current `main` (`e93fc3aee72`) before pushing; `git range-diff` confirms the reviewed patch is identical. The complete changed check, docs checks, release preflight, and autoreview ran before that mechanical rebase; focused tests and the compatibility audit were rerun on the final head.

Production LOC: +5/-5 (net zero). Tests: +13/-10. Docs: +5/-4.

Full generated release validation was run with `pnpm release:generated:check` and failed on unrelated existing inputs: stale `docs/plugins/plugin-inventory.md`, Control UI catalog fallback baseline drift, and missing native locale translation `native.apple.4adc28ed0e25f735`. Those generator/input/artifact surfaces are unchanged by this PR. The remaining release-preflight checks passed, including SDK exports/surface, config-generated artifacts, and 94 npm package locks. Refresh those release artifacts in their owning release work; this PR does not claim a green full release preflight.

External plugin migration remains unverified by design and is still the removal blocker. No live plugin/package roundtrip was run because this changes review metadata and docs only, not exports or runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
