### PR TITLE
fix(deps): clear fast-uri and nodemailer release gate advisories

### DIFF
--- a/.github/release/vercel-cli/package-lock.json
+++ b/.github/release/vercel-cli/package-lock.json
@@ -2866,9 +2866,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
-      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/.github/release/vercel-cli/package.json
+++ b/.github/release/vercel-cli/package.json
@@ -9,6 +9,7 @@
   "overrides": {
     "@tootallnate/once@2.0.0": "2.0.1",
     "ajv@8.6.3": "8.20.0",
+    "fast-uri@3.1.6": "3.1.7",
     "js-yaml@4.1.1": "4.3.2",
     "minimatch@10.1.1": "10.2.6",
     "path-to-regexp@6.1.0": "6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ overrides:
   '@aws-sdk/xml-builder': 3.972.40
   '@hono/node-server': 2.1.1
   axios: 1.19.0
-  fast-uri: 4.1.3
+  fast-uri: 4.1.4
   follow-redirects: 1.16.0
   defu: 6.1.7
   fast-xml-parser: 5.11.0
@@ -131,6 +131,8 @@ overrides:
   werift-ice@0.2.2>ip: npm:neoip@3.1.0
   ip-address: 10.5.0
   mailparser@3.9.15>html-to-text: 10.0.1
+  mailauth@5.0.2>nodemailer: 9.1.1
+  mailparser@3.9.15>nodemailer: 9.1.1
   minimatch: 10.2.6
   path-to-regexp: 8.4.2
   qs: 6.15.3
@@ -6826,8 +6828,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.3:
-    resolution: {integrity: sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==}
+  fast-uri@4.1.4:
+    resolution: {integrity: sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -8106,12 +8108,8 @@ packages:
     resolution: {integrity: sha512-M6Rm/bbG6De/gKGxOpeOobx/dnGuP0dz40adqx38boqHhlWssBJZgLCPBNtb9NkrmnKYiV04xELq+R6PFOnoLA==}
     engines: {node: '>=4.4.0'}
 
-  nodemailer@9.0.4:
-    resolution: {integrity: sha512-LmJNRVRtfSCULxcZpy0Cpg4WWenlUZ9+zbmTO+S7v9wD6XreYLjXRFtDjtV/4F0HT5p1GyZfA0Ux/myxHb18CQ==}
-    engines: {node: '>=6.0.0'}
-
-  nodemailer@9.0.5:
-    resolution: {integrity: sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==}
+  nodemailer@9.1.1:
+    resolution: {integrity: sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ==}
     engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
@@ -13101,7 +13099,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.3
+      fast-uri: 4.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -14093,7 +14091,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.3: {}
+  fast-uri@4.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -15079,7 +15077,7 @@ snapshots:
       ipaddr.js: 2.5.0
       joi: 18.2.3
       libmime: 5.4.1
-      nodemailer: 9.0.4
+      nodemailer: 9.1.1
       punycode.js: 2.3.1
       tldts: 7.4.10
       undici: 8.10.0
@@ -15093,7 +15091,7 @@ snapshots:
       iconv-lite: 0.7.3
       libmime: 5.4.2
       linkify-it: 5.0.2
-      nodemailer: 9.0.5
+      nodemailer: 9.1.1
       punycode.js: 2.3.1
       tlds: 1.261.0
 
@@ -15686,9 +15684,7 @@ snapshots:
 
   node-wav@0.0.2: {}
 
-  nodemailer@9.0.4: {}
-
-  nodemailer@9.0.5: {}
+  nodemailer@9.1.1: {}
 
   normalize-path@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,10 @@ minimumReleaseAgeStrict: true
 
 # Trusted Codex runtimes are outside the dependency cooldown.
 minimumReleaseAgeExclude:
+  # GHSA-58mr-gqgx-xq4g / GHSA-qw65-cvwx-89v3 security fix; remove after 2026-09-09.
+  - "fast-uri@4.1.4"
+  # GHSA-2x7j-588g-ccc2 security fix; remove after 2026-09-08.
+  - "nodemailer@9.1.1"
   # Reviewed Crabline bundle fix and its required Zod version; remove after 2026-09-10.
   - "@openclaw/crabline@0.1.20"
   - "zod@4.5.2"
@@ -48,7 +52,7 @@ overrides:
   "@aws-sdk/xml-builder": 3.972.40
   "@hono/node-server": 2.1.1
   axios: 1.19.0
-  fast-uri: 4.1.3
+  fast-uri: 4.1.4
   follow-redirects: 1.16.0
   defu: 6.1.7
   fast-xml-parser: 5.11.0
@@ -62,6 +66,8 @@ overrides:
   ip-address: 10.5.0
   # Keep the cooled HTML converter security fix while Mailparser is rolled back.
   "mailparser@3.9.15>html-to-text": 10.0.1
+  "mailauth@5.0.2>nodemailer": 9.1.1
+  "mailparser@3.9.15>nodemailer": 9.1.1
   minimatch: 10.2.6
   path-to-regexp: 8.4.2
   qs: 6.15.3

--- a/scripts/materialize-vercel-cli.sh
+++ b/scripts/materialize-vercel-cli.sh
@@ -8,7 +8,7 @@ github_output="${3:-}"
 
 package_json="${source_root}/package.json"
 package_lock="${source_root}/package-lock.json"
-expected_lock_sha256="b06b20bca67a863ad99cb479d51319b3483fb131b57c6855c26a35a92c2c89b5"
+expected_lock_sha256="e0dfc23d8bc7d5739dd25b70359a0db456099a2bda4914223136e094e3d7bede"
 expected_vercel_integrity="sha512-tQgKXmppJ/uoQZfX+HYAVIxWSUS6V6FMounEEpsHTUqlHyBI/aOATH9sKtkXXD1lQt/JsN4ocWymIGUPLRTxwA=="
 test -f "${package_json}"
 test -f "${package_lock}"


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Full Release Validation cannot pass “Check npm dependencies” because the product and pinned Vercel release-tool dependency graphs contain vulnerable fast-uri and Nodemailer versions. [The failing release job](https://github.com/openclaw/openclaw/actions/runs/33678518939/job/100409260869) reports five HIGH hard blockers.

## Why This Change Was Made

Update the existing product fast-uri override from 4.1.3 to 4.1.4 and the Vercel CLI's fast-uri resolution from 3.1.6 to 3.1.7 for [GHSA-58mr-gqgx-xq4g](https://github.com/fastify/fast-uri/security/advisories/GHSA-58mr-gqgx-xq4g) and [GHSA-qw65-cvwx-89v3](https://github.com/fastify/fast-uri/security/advisories/GHSA-qw65-cvwx-89v3). Keep vercel@59.5.0 and sandbox@4.1.0 pinned, retain the other overrides/integrity checks, and refresh the materializer's whole-lock SHA-256.

For [GHSA-2x7j-588g-ccc2](https://github.com/nodemailer/nodemailer/security/advisories/GHSA-2x7j-588g-ccc2), mailauth@5.0.2 and mailparser@3.9.15 pin Nodemailer **exactly** to 9.0.4 and 9.0.5: 9.1.1 is outside both declared ranges. Two exact-parent overrides are the narrowest repair without updating unrelated parent dependencies. Direct source inspection and installed compatibility probes verify their shared `nodemailer/lib/addressparser` contract, including actual mail parsing and DKIM/DMARC authentication.

Keep `minimumReleaseAge: 10080` and strict enforcement unchanged. Add only exact-version security-fix exclusions: `fast-uri@4.1.4`, remove after **2026-09-09**; `nodemailer@9.1.1`, remove after **2026-09-08**. These are cooldown exceptions, not vulnerability-gate exceptions. No gate policy, runtime code, plugin configuration, or changelog changes.

## User Impact

Release maintainers can clear these five dependency blockers. IMAP mail processing uses the patched address parser, and URI handling rejects the malformed hosts/ports covered by the upstream fixes. No operator configuration or migration is required. Vercel remains a separate release-tool graph; its findings do not imply product runtime exposure.

## Evidence

Before: the linked release job reports five hard blockers. After, the authenticated local scan reports:

```text
PASS dependency vulnerability gate: checked 2045 resolved package versions across 3 separate lockfile graphs; 0 hard blockers, 8 total advisories; npm bulk checked; public upstream partial (981/1020 repositories fully read). This is not comprehensive vulnerability clearance.
```

Validation:

- `pnpm install` — passed; semantic lock comparison confirms unchanged workspace importers and no unrelated dependency updates.
- Vercel lock regenerated with workflow-pinned **Node 24.19.0 / npm 11.17.0**, `npm install --package-lock-only --ignore-scripts --no-audit --no-fund` from `.github/release/vercel-cli`; the only npm-lock entry changed is `node_modules/fast-uri`.
- `bash scripts/materialize-vercel-cli.sh "$PWD/.github/release/vercel-cli" "$PWD/.local/rel-deps/vercel-cli-node24"` with the same pinned toolchain — passed; real `npm ci`, CLI/sandbox executables, version/integrity/checksum checks, and `vercel --version` (59.5.0).
- `OPENCLAW_VITEST_MAX_WORKERS=4 pnpm test test/scripts/vercel-container-registry-publish.test.ts` — 18 tests passed.
- `GH_TOKEN=$(gh auth token) node --import ./scripts/tsx.mjs scripts/dependency-vulnerability-gate.mts -- --root "$PWD" --json /tmp/vuln-gate.json --markdown /tmp/vuln-gate.md` — passed, summary above.
- `pnpm deps:npm-lock:check` — all 94 transient npm locks validated.
- `pnpm check:changed` — passed, including all typecheck/lint lanes and runtime import-cycle checks.
- `OPENCLAW_VITEST_MAX_WORKERS=4 pnpm test extensions/imap` — 53 tests passed in five files.
- Installed dependency probes — both mail consumers resolve Nodemailer 9.1.1; eight address-parser cases; 30,000-address list; real `simpleParser`; real `authenticate` DMARC none/temperror/pass and synthetic RSA DKIM signing/verification. Both patched fast-uri lines reject malformed brackets and injected ports while preserving valid IPv6/ports; the worktree's AJV compiles and validates relative schema references with 4.1.4.
- Fresh independent Codex autoreview — no actionable P0–P2 findings. `git diff --check` passed.

After the rebase, `OPENCLAW_VITEST_MAX_WORKERS=4 pnpm test test/scripts/vercel-container-registry-publish.test.ts extensions/imap` passed both shards again (18 Vercel + 53 IMAP tests) on `ce38a7dbbb2022918ce00a54df898bde021453bc`.

The final mechanical rebase onto current `main` preserved the reviewed patch byte-for-byte; both dependency lock inputs, the advisory gate source, and the IMAP surface are unchanged from the locally validated commit.

Scope: five files; runtime production LOC delta **0**, test LOC delta **0**. The pnpm lock changes only fast-uri/Nodemailer overrides, resolutions, and dependent snapshot references; two Nodemailer resolutions consolidate to one. Vercel lock SHA-256: `e0dfc23d8bc7d5739dd25b70359a0db456099a2bda4914223136e094e3d7bede`. No Bun lock or relevant dependency patches exist.

Limitations: upstream advisory coverage remains partial (550 reported coverage issues); zero blockers is not comprehensive vulnerability clearance. No live mailbox/SMTP transport, full upstream package suites, or full release validation rerun was performed. The synthetic authentication probe uses local DNS fixtures, not live DNS. Follow-up: remove the exact cooldown exclusions after the dates above; unrelated upstream mailauth signing-type/runtime mismatch was observed only in the synthetic signing helper, not OpenClaw's `authenticate` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
