### PR TITLE
fix(ios): keep streamed transcripts stable across tool boundaries

### DIFF
--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -456,39 +456,31 @@ struct ChatProTab: View {
         let deliveryAgentID = self.appModel.chatDeliveryAgentId
         let transportAgentID = Self.transportAgentID(deliveryAgentID)
         let routingContract = self.appModel.chatSessionRoutingContract ?? ""
-        guard let viewModel else {
-            self.viewModelOwnerID = ownerID
-            self.viewModelTransportAgentID = transportAgentID
-            self.viewModelRoutingContract = routingContract
-            self.captureCurrentPresentationIdentity()
-            self.viewModel = self.makeChatViewModel(sessionKey: sessionKey)
-            return
-        }
-        if Self.requiresViewModelRebuild(
+        if let viewModel, !Self.requiresViewModelRebuild(
             currentOwnerID: self.viewModelOwnerID,
             nextOwnerID: ownerID,
             currentTransportAgentID: self.viewModelTransportAgentID,
             nextTransportAgentID: transportAgentID)
         {
-            // Keep recording, staging, and delivery on their captured route.
-            // The pin-change observer replays this rebuild with latest state.
-            guard !viewModel.isAttachmentOwnerPinned else { return }
-            viewModel.endPendingToolActivities()
-            self.viewModelOwnerID = ownerID
-            self.viewModelTransportAgentID = transportAgentID
-            self.viewModelRoutingContract = routingContract
-            self.captureCurrentPresentationIdentity()
-            self.viewModel = self.makeChatViewModel(sessionKey: sessionKey)
+            if self.viewModelRoutingContract != routingContract {
+                self.viewModelRoutingContract = routingContract
+                viewModel.syncSessionRoutingContract(self.appModel.chatSessionRoutingContract)
+            }
+            viewModel.syncSession(to: sessionKey)
+            if !viewModel.isAttachmentOwnerPinned {
+                self.captureCurrentPresentationIdentity()
+            }
             return
         }
-        if self.viewModelRoutingContract != routingContract {
-            self.viewModelRoutingContract = routingContract
-            viewModel.syncSessionRoutingContract(self.appModel.chatSessionRoutingContract)
-        }
-        viewModel.syncSession(to: sessionKey)
-        if !viewModel.isAttachmentOwnerPinned {
-            self.captureCurrentPresentationIdentity()
-        }
+        // Keep recording, staging, and delivery on their captured route.
+        // The pin-change observer replays this rebuild with latest state.
+        guard self.viewModel?.isAttachmentOwnerPinned != true else { return }
+        self.viewModel?.detachTransport()
+        self.viewModelOwnerID = ownerID
+        self.viewModelTransportAgentID = transportAgentID
+        self.viewModelRoutingContract = routingContract
+        self.captureCurrentPresentationIdentity()
+        self.viewModel = self.makeChatViewModel(sessionKey: sessionKey)
     }
 
     private func handleNewChatRequest(_ requestID: Int) async {
@@ -506,6 +498,11 @@ struct ChatProTab: View {
     }
 
     private func makeChatViewModel(sessionKey: String) -> OpenClawChatViewModel {
+        let appModel = self.appModel
+        // Tool activity belongs to this model's captured agent, including while attachment-pinned.
+        // Never relabel an old agent's tools with a newly selected agent's presentation.
+        let agentName = self.viewModelPresentationAgentName
+        let agentBadge = self.viewModelPresentationAgentBadge
         // One gateway facade backs both seams while routing cache and outbox
         // operations to their separate installation-wide databases.
         let offlineStore = self.appModel.makeChatOfflineStore()
@@ -521,15 +518,15 @@ struct ChatProTab: View {
             transcriptCache: offlineStore,
             outbox: offlineStore,
             onSessionChanged: { sessionKey in
-                self.appModel.focusChatSession(sessionKey)
+                appModel.focusChatSession(sessionKey)
             },
             onToolActivity: { id, name, isActive, toolSessionKey in
                 if isActive {
                     LiveActivityManager.shared.showTool(
                         id: id,
                         name: name,
-                        agentName: self.agentDisplayName,
-                        agentBadge: self.agentBadge,
+                        agentName: agentName,
+                        agentBadge: agentBadge,
                         sessionKey: toolSessionKey)
                 } else {
                     LiveActivityManager.shared.endTool(id: id, sessionKey: toolSessionKey)

--- a/apps/ios/Sources/RootSidebarDrawer.swift
+++ b/apps/ios/Sources/RootSidebarDrawer.swift
@@ -173,11 +173,12 @@ struct RootSidebarDrawer<Sidebar: View, Detail: View>: View {
         latchedDisposition: DragDisposition?) -> DragDisposition?
     {
         if let latchedDisposition { return latchedDisposition }
-        if !isPresented, !canOpenFromEdge ||
-            startLocation.x > RootSidebarDrawerMetric.edgeGestureWidth ||
-            startLocation.y <= RootSidebarDrawerMetric.topGestureExclusion
-        {
-            return .rejected
+        if !isPresented {
+            // Opening is an edge gesture; closing may start anywhere on the content card.
+            guard canOpenFromEdge,
+                  startLocation.x <= RootSidebarDrawerMetric.edgeGestureWidth,
+                  startLocation.y > RootSidebarDrawerMetric.topGestureExclusion
+            else { return .rejected }
         }
         let horizontal = isPresented ? -translation.width : translation.width
         let vertical = abs(translation.height)

--- a/apps/ios/Sources/RootSidebarDrawer.swift
+++ b/apps/ios/Sources/RootSidebarDrawer.swift
@@ -10,7 +10,7 @@ private enum RootSidebarDrawerMetric {
 }
 
 struct RootSidebarDrawer<Sidebar: View, Detail: View>: View {
-    private enum DragDisposition: Equatable {
+    enum DragDisposition: Equatable {
         case opening
         case closing
         case rejected
@@ -124,23 +124,20 @@ struct RootSidebarDrawer<Sidebar: View, Detail: View>: View {
         let dragSession = self.dragSession
         return DragGesture(minimumDistance: 8)
             .updating(self.$dragState) { value, state, _ in
-                let disposition: DragDisposition
-                if let latchedDisposition = state.disposition {
-                    disposition = latchedDisposition
-                } else {
-                    disposition = Self.dragDisposition(
-                        for: value,
-                        isPresented: isPresented,
-                        canOpenFromEdge: canOpenFromEdge)
-                    state.disposition = disposition
-                    dragSession.disposition = disposition
-                }
+                let disposition = Self.dragDisposition(
+                    startLocation: value.startLocation,
+                    translation: value.translation,
+                    isPresented: isPresented,
+                    canOpenFromEdge: canOpenFromEdge,
+                    latchedDisposition: state.disposition)
+                state.disposition = disposition
+                dragSession.disposition = disposition
                 switch disposition {
                 case .opening:
                     state.translationWidth = max(0, min(sidebarWidth, value.translation.width))
                 case .closing:
                     state.translationWidth = max(-sidebarWidth, min(0, value.translation.width))
-                case .rejected:
+                case .rejected, nil:
                     break
                 }
             }
@@ -168,16 +165,27 @@ struct RootSidebarDrawer<Sidebar: View, Detail: View>: View {
             }
     }
 
-    private static func dragDisposition(
-        for value: DragGesture.Value,
+    static func dragDisposition(
+        startLocation: CGPoint,
+        translation: CGSize,
         isPresented: Bool,
-        canOpenFromEdge: Bool) -> DragDisposition
+        canOpenFromEdge: Bool,
+        latchedDisposition: DragDisposition?) -> DragDisposition?
     {
-        if isPresented {
-            return self.isClosingDrag(value) ? .closing : .rejected
+        if let latchedDisposition { return latchedDisposition }
+        if !isPresented, !canOpenFromEdge ||
+            startLocation.x > RootSidebarDrawerMetric.edgeGestureWidth ||
+            startLocation.y <= RootSidebarDrawerMetric.topGestureExclusion
+        {
+            return .rejected
         }
-        guard canOpenFromEdge else { return .rejected }
-        return self.isOpeningDrag(value) ? .opening : .rejected
+        let horizontal = isPresented ? -translation.width : translation.width
+        let vertical = abs(translation.height)
+        // Leave marginal diagonals undecided without moving the card; once vertical
+        // scrolling wins, latch rejection so a later thumb arc cannot open the drawer.
+        guard horizontal >= vertical else { return .rejected }
+        guard horizontal >= 16, horizontal > 2 * vertical else { return nil }
+        return isPresented ? .closing : .opening
     }
 
     private static func shouldSettle(
@@ -186,18 +194,6 @@ struct RootSidebarDrawer<Sidebar: View, Detail: View>: View {
     {
         translation > RootSidebarDrawerMetric.settleTranslation ||
             predictedTranslation > RootSidebarDrawerMetric.settlePredictedTranslation
-    }
-
-    private static func isOpeningDrag(_ value: DragGesture.Value) -> Bool {
-        value.startLocation.x <= RootSidebarDrawerMetric.edgeGestureWidth &&
-            value.startLocation.y > RootSidebarDrawerMetric.topGestureExclusion &&
-            value.translation.width > 0 &&
-            value.translation.width > abs(value.translation.height)
-    }
-
-    private static func isClosingDrag(_ value: DragGesture.Value) -> Bool {
-        value.translation.width < 0 &&
-            -value.translation.width > abs(value.translation.height)
     }
 
     private static func contentShape(progress: CGFloat) -> UnevenRoundedRectangle {

--- a/apps/ios/Tests/RootSidebarDrawerGestureTests.swift
+++ b/apps/ios/Tests/RootSidebarDrawerGestureTests.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct RootSidebarDrawerGestureTests {
+    private typealias Drawer = RootSidebarDrawer<EmptyView, EmptyView>
+
+    @Test(arguments: [false, true])
+    func `only clearly horizontal drags commit`(isPresented: Bool) {
+        let committed: Drawer.DragDisposition = isPresented ? .closing : .opening
+        let cases: [(CGSize, Drawer.DragDisposition?)] = [
+            (.zero, nil),
+            (CGSize(width: 8, height: 0), nil),
+            (CGSize(width: 8, height: 7), nil),
+            (CGSize(width: 15, height: 0), nil),
+            (CGSize(width: 16, height: 8), nil),
+            (CGSize(width: 16, height: 7), committed),
+            (CGSize(width: 30, height: -16), nil),
+            (CGSize(width: 40, height: -19), committed),
+            (CGSize(width: 8, height: 9), .rejected),
+            (CGSize(width: -16, height: 0), .rejected),
+        ]
+        for (translation, expected) in cases {
+            let translation = CGSize(
+                width: isPresented ? -translation.width : translation.width,
+                height: translation.height)
+            #expect(Drawer.dragDisposition(
+                startLocation: CGPoint(x: 20, y: 100),
+                translation: translation,
+                isPresented: isPresented,
+                canOpenFromEdge: true,
+                latchedDisposition: nil) == expected)
+        }
+    }
+
+    @Test func `opening respects edge and navigation eligibility while closing works anywhere`() {
+        let cases: [(CGPoint, Bool, Drawer.DragDisposition)] = [
+            (CGPoint(x: 44, y: 45), true, .opening),
+            (CGPoint(x: 45, y: 100), true, .rejected),
+            (CGPoint(x: 20, y: 44), true, .rejected),
+            (CGPoint(x: 20, y: 100), false, .rejected),
+        ]
+        for (startLocation, canOpenFromEdge, expected) in cases {
+            #expect(Drawer.dragDisposition(
+                startLocation: startLocation,
+                translation: CGSize(width: 20, height: 0),
+                isPresented: false,
+                canOpenFromEdge: canOpenFromEdge,
+                latchedDisposition: nil) == expected)
+            #expect(Drawer.dragDisposition(
+                startLocation: startLocation,
+                translation: CGSize(width: -20, height: 0),
+                isPresented: true,
+                canOpenFromEdge: canOpenFromEdge,
+                latchedDisposition: nil) == .closing)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `vertical scrolling wins before a later horizontal thumb arc`(isPresented: Bool) {
+        var disposition: Drawer.DragDisposition?
+        for (translation, expected): (CGSize, Drawer.DragDisposition?) in [
+            (CGSize(width: 8, height: 7), nil),
+            (CGSize(width: 12, height: 20), .rejected),
+            (CGSize(width: 60, height: 0), .rejected),
+        ] {
+            disposition = Drawer.dragDisposition(
+                startLocation: CGPoint(x: 20, y: 100),
+                translation: CGSize(
+                    width: isPresented ? -translation.width : translation.width,
+                    height: translation.height),
+                isPresented: isPresented,
+                canOpenFromEdge: true,
+                latchedDisposition: disposition)
+            #expect(disposition == expected)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `committed drawer drags keep their direction`(isPresented: Bool) {
+        var disposition: Drawer.DragDisposition?
+        for translation in [CGSize(width: 20, height: 5), CGSize(width: 20, height: 40)] {
+            disposition = Drawer.dragDisposition(
+                startLocation: CGPoint(x: 20, y: 100),
+                translation: CGSize(
+                    width: isPresented ? -translation.width : translation.width,
+                    height: translation.height),
+                isPresented: isPresented,
+                canOpenFromEdge: true,
+                latchedDisposition: disposition)
+            #expect(disposition == (isPresented ? .closing : .opening))
+        }
+    }
+}

--- a/apps/ios/Tests/RootSidebarDrawerGestureTests.swift
+++ b/apps/ios/Tests/RootSidebarDrawerGestureTests.swift
@@ -40,6 +40,8 @@ struct RootSidebarDrawerGestureTests {
             (CGPoint(x: 45, y: 100), true, .rejected),
             (CGPoint(x: 20, y: 44), true, .rejected),
             (CGPoint(x: 20, y: 100), false, .rejected),
+            // Content-card start on a presented drawer: closing must still work.
+            (CGPoint(x: 300, y: 400), false, .rejected),
         ]
         for (startLocation, canOpenFromEdge, expected) in cases {
             #expect(Drawer.dragDisposition(

--- a/apps/ios/Tests/RootTabsSidebarRegressionTests.swift
+++ b/apps/ios/Tests/RootTabsSidebarRegressionTests.swift
@@ -61,7 +61,7 @@ struct RootTabsSidebarRegressionTests {
         let drawerGesture = try Self.extract(
             drawerSource,
             from: "private var drawerGesture: some Gesture",
-            to: "private static func dragDisposition(")
+            to: "static func dragDisposition(")
         let detailShell = try Self.extract(
             source,
             from: "private var sidebarDetailShell: some View",
@@ -96,7 +96,6 @@ struct RootTabsSidebarRegressionTests {
         #expect(!contentCard.contains(".shadow("))
 
         #expect(drawerGesture.contains(".updating(self.$dragState)"))
-        #expect(drawerGesture.contains("if let latchedDisposition = state.disposition"))
         #expect(drawerGesture.contains("dragSession.disposition = disposition"))
         #expect(drawerGesture.contains("let disposition = dragSession.disposition"))
         #expect(drawerGesture.contains("dragSession.disposition = nil"))
@@ -104,10 +103,6 @@ struct RootTabsSidebarRegressionTests {
         #expect(drawerGesture.contains("case .closing:"))
         #expect(drawerGesture.contains("onShow()"))
         #expect(drawerGesture.contains("onHide()"))
-        #expect(drawerSource.contains("value.startLocation.x <= RootSidebarDrawerMetric.edgeGestureWidth"))
-        #expect(drawerSource.contains("value.startLocation.y > RootSidebarDrawerMetric.topGestureExclusion"))
-        #expect(drawerSource.contains("value.translation.width > abs(value.translation.height)"))
-        #expect(drawerSource.contains("-value.translation.width > abs(value.translation.height)"))
         #expect(drawerSource.contains("UnevenRoundedRectangle("))
         #expect(drawerSource.contains("topLeadingRadius: RootSidebarDrawerMetric.topLeadingRadius * progress"))
         #expect(drawerSource.contains("bottomLeadingRadius: RootSidebarDrawerMetric.cornerRadius * progress"))
@@ -190,7 +185,7 @@ struct RootTabsSidebarRegressionTests {
 
         let pin = try #require(sessionButton.range(of: "Image(systemName: \"pin.fill\")"))
         let detail = try #require(sessionButton.range(of: "CommandCenterTab.sessionDetail(session)"))
-        let openChat = try #require(sessionButton.range(of: "self.appModel.openChat(sessionKey: session.key)"))
+        let openChat = try #require(sessionButton.range(of: "self.selectSession(session)"))
         let contextActions = try #require(sessionButton.range(of: ".commandSessionActions("))
         #expect(pin.lowerBound < detail.lowerBound)
         #expect(openChat.lowerBound < contextActions.lowerBound)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
@@ -168,10 +168,22 @@ enum ChatMarkdownBlockSegmenter {
             document: document,
             isComplete: isComplete)
         var extractions = mathResult.extractions
+        var proseEnd = source.lines.count
 
         for child in document.children {
             guard let lineRange = source.lineRange(for: child.range) else { continue }
             if mathResult.protectedRanges.contains(where: { $0.contains(lineRange.lowerBound) }) {
+                continue
+            }
+
+            if !isComplete,
+               child is Markdown.Paragraph,
+               source.lines[lineRange].allSatisfy({ $0.trimmingCharacters(in: .whitespaces).hasPrefix("|") }),
+               source.lines[lineRange.upperBound...].allSatisfy({ $0.trimmingCharacters(in: .whitespaces).isEmpty })
+            {
+                // Pending headers and bare row-opening pipes must not enter
+                // prose: the parser can absorb them into a table on the next delta.
+                proseEnd = lineRange.lowerBound
                 continue
             }
 
@@ -214,12 +226,6 @@ enum ChatMarkdownBlockSegmenter {
                 guard let rendered = self.table(table, source: source, lineRange: tableRange) else {
                     continue
                 }
-                let trailingLines = source.lines[tableRange.upperBound...]
-                if !isComplete,
-                   trailingLines.allSatisfy({ $0.trimmingCharacters(in: .whitespaces).isEmpty })
-                {
-                    continue
-                }
                 extractions.append(Extraction(lineRange: tableRange, block: .table(rendered)))
                 continue
             }
@@ -259,7 +265,7 @@ enum ChatMarkdownBlockSegmenter {
             return left.lineRange.upperBound > right.lineRange.upperBound
         }
 
-        let unfolded = self.unfold(extractions, source: source, isComplete: isComplete)
+        let unfolded = self.unfold(extractions, source: source, proseEnd: proseEnd, isComplete: isComplete)
         let blocks = self.foldDisclosures(unfolded)
         let reparsesListContent = blocks.contains { block in
             if case .list = block { return true }
@@ -268,7 +274,7 @@ enum ChatMarkdownBlockSegmenter {
         if blocks.count > 1 || reparsesListContent,
            self.containsReferenceLink(document, source: source)
         {
-            return self.proseOnly(source.lines)
+            return self.proseOnly(Array(source.lines[..<proseEnd]))
         }
         return blocks
     }
@@ -1147,6 +1153,7 @@ extension ChatMarkdownBlockSegmenter {
     fileprivate static func unfold(
         _ extractions: [Extraction],
         source: SourceBuffer,
+        proseEnd: Int,
         isComplete: Bool) -> [UnfoldedBlock]
     {
         var unfolded: [UnfoldedBlock] = []
@@ -1178,7 +1185,7 @@ extension ChatMarkdownBlockSegmenter {
             proseStart = extraction.lineRange.upperBound
         }
 
-        appendProse(until: source.lines.count)
+        appendProse(until: proseEnd)
         return unfolded
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+RunSnapshot.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+RunSnapshot.swift
@@ -60,7 +60,8 @@ extension OpenClawChatViewModel {
         if self.pendingRunOwnerArmIDs[runId] == nil {
             armPendingRunOwner(runId: runId)
         }
-        if !bufferedText.isEmpty {
+        // Chat snapshots concatenate model turns; agent text owns the current item once observed.
+        if self.liveRunStateByRunID[runId]?.hasAgentAssistantText != true, !bufferedText.isEmpty {
             self.updateStreamingAssistantText(bufferedText)
         }
         self.logDiagnostic(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
@@ -704,10 +704,7 @@ extension OpenClawChatViewModel {
         let historyContext = beginHistoryRequest(for: attempt.draft.session)
         let refresh = await refreshHistoryAfterRun(historyRequest: historyContext)
         guard isCurrentSession(attempt.draft.session) else { return }
-        let hasInFlightRunSnapshot = refresh.applied &&
-            refresh.runSnapshotApplied &&
-            refresh.hasInFlightRun
-        if hasInFlightRunSnapshot ||
+        if refresh.hasInFlightRun || (refresh.applied && !refresh.runSnapshotApplied) ||
             !clearPendingRunIfAssistantMessagePresent(
                 runId: response.runId,
                 after: attempt.userMessageTimestamp)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -1,9 +1,10 @@
 import Foundation
 
 struct ChatLiveRunState: Equatable, Sendable {
-    let sequence: Int
-    let outputTokens: Int?
-    let terminal: Bool
+    var sequence = 0
+    var outputTokens: Int?
+    var terminal = false
+    var hasAgentAssistantText = false
 }
 
 extension OpenClawChatViewModel {
@@ -113,24 +114,22 @@ extension OpenClawChatViewModel {
     @discardableResult
     func applyLiveRunUsage(runID: String, sequence: Int, outputTokens: Int) -> Bool {
         guard sequence > 0, outputTokens > 0, self.ownsLiveTelemetryRun(runID) else { return false }
-        let previous = self.liveRunStateByRunID[runID]
-        guard sequence > (previous?.sequence ?? 0), previous?.terminal != true else { return false }
-        self.liveRunStateByRunID[runID] = ChatLiveRunState(
-            sequence: sequence,
-            outputTokens: max(outputTokens, previous?.outputTokens ?? 0),
-            terminal: false)
+        var state = self.liveRunStateByRunID[runID] ?? ChatLiveRunState()
+        guard sequence > state.sequence, !state.terminal else { return false }
+        state.sequence = sequence
+        state.outputTokens = max(outputTokens, state.outputTokens ?? 0)
+        self.liveRunStateByRunID[runID] = state
         return true
     }
 
     @discardableResult
     func applyLiveRunLifecycle(runID: String, sequence: Int, terminal: Bool) -> Bool {
         guard sequence > 0, self.ownsLiveTelemetryRun(runID) else { return false }
-        let previous = self.liveRunStateByRunID[runID]
-        guard sequence > (previous?.sequence ?? 0), previous?.terminal != true else { return false }
-        self.liveRunStateByRunID[runID] = ChatLiveRunState(
-            sequence: sequence,
-            outputTokens: previous?.outputTokens,
-            terminal: terminal)
+        var state = self.liveRunStateByRunID[runID] ?? ChatLiveRunState()
+        guard sequence > state.sequence, !state.terminal else { return false }
+        state.sequence = sequence
+        state.terminal = terminal
+        self.liveRunStateByRunID[runID] = state
         return true
     }
 
@@ -149,10 +148,7 @@ extension OpenClawChatViewModel {
 
     func invalidateIncompleteLiveRunUsage() {
         for (runID, state) in self.liveRunStateByRunID where !state.terminal && state.outputTokens != nil {
-            self.liveRunStateByRunID[runID] = ChatLiveRunState(
-                sequence: state.sequence,
-                outputTokens: nil,
-                terminal: false)
+            self.liveRunStateByRunID[runID]?.outputTokens = nil
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -23,6 +23,7 @@ extension OpenClawChatViewModel {
     }
 
     func handleTransportEvent(_ evt: OpenClawChatTransportEvent) {
+        guard !self.isTransportDetached else { return }
         switch evt {
         case let .health(ok):
             let reconnected = ok && !self.healthOK
@@ -691,6 +692,7 @@ extension OpenClawChatViewModel {
         switch evt.stream {
         case "assistant":
             if let text = evt.data["text"]?.value as? String {
+                self.liveRunStateByRunID[evt.runId, default: ChatLiveRunState()].hasAgentAssistantText = true
                 self.updateActiveSessionRunWithoutChatSnapshot(false)
                 self.updateStreamingAssistantText(text)
             }
@@ -919,8 +921,12 @@ extension OpenClawChatViewModel {
             sessionSnapshot: sessionSnapshot,
             armID: armID)
         else { return false }
+        // Live events advance ownership while history is in flight. A superseded snapshot
+        // must not let message shape retire a run the gateway still reports in flight.
+        if refresh.applied, !refresh.runSnapshotApplied { return true }
         if case let .failed(message)? = terminalState {
             if refresh.applied,
+               !refresh.hasInFlightRun,
                let timestamp,
                self.clearPendingRunIfAssistantMessagePresent(runId: runId, after: timestamp)
             {
@@ -932,7 +938,7 @@ extension OpenClawChatViewModel {
             self.updateStreamingAssistantText(nil)
             return false
         }
-        if refresh.applied, refresh.runSnapshotApplied, refresh.supportsInFlightRunState {
+        if refresh.applied, refresh.supportsInFlightRunState {
             if refresh.hasInFlightRun {
                 return true
             }
@@ -965,7 +971,7 @@ extension OpenClawChatViewModel {
             self.finishPendingRun(runId: runId, terminalState: .completed)
             return false
         }
-        guard let timestamp else { return true }
+        guard !refresh.hasInFlightRun, let timestamp else { return true }
         return !self.clearPendingRunIfAssistantMessagePresent(runId: runId, after: timestamp)
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -239,6 +239,7 @@ public final class OpenClawChatViewModel {
 
     @ObservationIgnored
     private nonisolated(unsafe) var eventTask: Task<Void, Never>?
+    private(set) var isTransportDetached = false
     @ObservationIgnored
     private nonisolated(unsafe) var bootstrapTask: Task<Void, Never>?
     var runOwnershipGeneration: UInt64 = 0
@@ -565,7 +566,14 @@ public final class OpenClawChatViewModel {
     }
 
     isolated deinit {
-        self.reportToolActivityChanges(from: self.pendingToolCallsById, to: [:])
+        self.detachTransport()
+    }
+
+    /// Permanently retires a replaced presentation without aborting its gateway run.
+    public func detachTransport() {
+        guard !self.isTransportDetached else { return }
+        self.isTransportDetached = true
+        self.endPendingToolActivities()
         self.eventTask?.cancel()
         self.bootstrapTask?.cancel()
         self.swarmRefreshTask?.cancel()
@@ -804,7 +812,7 @@ extension OpenClawChatViewModel {
     func isCurrentSession(_ snapshot: SessionSnapshot) -> Bool {
         let contractSensitive = self.usesMutableContractRouting(for: snapshot.sessionRoutingContract) ||
             self.usesMutableContractRouting(for: self.sessionRoutingContract)
-        return self.sessionKey == snapshot.key &&
+        return !self.isTransportDetached && self.sessionKey == snapshot.key &&
             self.sessionGeneration == snapshot.generation &&
             (!self.usesMutableAgentRouting || self.activeAgentId == snapshot.agentID) &&
             (!contractSensitive || self.sessionRoutingContract == snapshot.sessionRoutingContract)
@@ -880,7 +888,7 @@ extension OpenClawChatViewModel {
         paintCachedTranscript: Bool = true)
     {
         let sessionKey = requestedSessionKey ?? self.sessionKey
-        guard sessionKey == self.sessionKey else { return }
+        guard !self.isTransportDetached, sessionKey == self.sessionKey else { return }
         if self.swarmSessionKey != sessionKey {
             self.swarmEnabled = false
             self.resetSwarmProgress()

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
@@ -962,29 +962,74 @@ struct ChatMarkdownBlockSegmenterTests {
         ])
     }
 
-    @Test func `trailing table while streaming stays prose`() {
-        let markdown = "intro\n| a | b |\n| - | - |\n| 1 | 2 |"
-        #expect(self.segments(markdown, isComplete: false) == [.prose(markdown)])
-    }
-
-    @Test func `trailing table with only trailing newline while streaming stays prose`() {
-        // The trailing newline is not a committed blank line: the next delta
-        // may still append rows, so the table must not render rich yet.
-        let markdown = "| a | b |\n| - | - |\n| 1 | 2 |\n"
+    @Test(arguments: ["", "\n"])
+    func `trailing table renders while rows are streaming`(suffix: String) {
+        let markdown = "intro\n| a | b |\n| - | - |\n| 1 | 2 |" + suffix
         #expect(self.segments(markdown, isComplete: false) == [
-            .prose("| a | b |\n| - | - |\n| 1 | 2 |"),
-        ])
-    }
-
-    @Test func `settled table while streaming renders as table`() {
-        let blocks = self.segments("| a | b |\n| - | - |\n| 1 | 2 |\n\nafter", isComplete: false)
-        #expect(blocks == [
+            .prose("intro"),
             .table(ChatMarkdownTable(
                 header: ["a", "b"],
                 alignments: [.leading, .leading],
                 rows: [["1", "2"]])),
-            .prose("after"),
         ])
+    }
+
+    @Test func `streamed table prefixes preserve prose and only grow table rows`() throws {
+        let markdown = """
+        This paragraph reads well.
+
+        | Surface | Owner |
+        | --- | --- |
+        | Chat | Client |
+        | Run | Gateway |
+
+        Closing paragraph.
+        """
+        var previous: [ChatMarkdownBlock] = []
+        for length in 0...markdown.count {
+            let prefix = String(markdown.prefix(length))
+            let blocks = self.segments(prefix, isComplete: false)
+            try #require(blocks.count >= previous.count, "prefix length: \(length)")
+            for (before, after) in zip(previous, blocks) {
+                switch (before, after) {
+                case let (.prose(before), .prose(after)):
+                    #expect(after.hasPrefix(before), "prefix length: \(length)")
+                case let (.table(before), .table(after)):
+                    #expect(after.rows.count >= before.rows.count, "prefix length: \(length)")
+                default:
+                    Issue.record("block changed kind at prefix length: \(length)")
+                }
+            }
+            if prefix.hasSuffix("| --- | --- |") {
+                #expect(blocks.count == 2)
+                guard case let .table(table) = blocks.last else {
+                    Issue.record("delimiter must commit the table before body rows arrive")
+                    return
+                }
+                #expect(table.rows.isEmpty)
+            }
+            previous = blocks
+        }
+        let expected: [ChatMarkdownBlock] = [
+            .prose("This paragraph reads well."),
+            .table(ChatMarkdownTable(
+                header: ["Surface", "Owner"],
+                alignments: [.leading, .leading],
+                rows: [["Chat", "Client"], ["Run", "Gateway"]])),
+            .prose("Closing paragraph."),
+        ]
+        #expect(previous == expected)
+        #expect(self.segments(markdown) == expected)
+    }
+
+    @Test func `streaming table header waits without hiding inline pipes`() {
+        let markdown = "Prose with | x inside a normal sentence.\n\n| a | b |"
+        #expect(self.segments(markdown, isComplete: false) == [
+            .prose("Prose with | x inside a normal sentence."),
+        ])
+        #expect(self.segments(markdown) == [.prose(markdown)])
+        let continuation = "Prose continues\n| x on the next line"
+        #expect(self.segments(continuation, isComplete: false) == [.prose(continuation)])
     }
 
     // MARK: - Tables

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -2672,9 +2672,14 @@ struct ChatViewModelTests {
         let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
         viewModel.upsertQuestion(QuestionRecord(
             id: "ask_secret",
-            questions: [.init(questionid: "credential", header: "Credential", question: "Provide a key", options: [],
-                issecret: true, secretstore: .init(name: "TASK_TOKEN", kind: AnyCodable("secret")))],
-            createdatms: 1_000, expiresatms: Int.max, status: .pending))
+            questions: [.init(
+                questionid: "credential",
+                header: "Credential",
+                question: "Provide a key",
+                options: [],
+                issecret: true,
+                secretstore: .init(name: "TASK_TOKEN", kind: AnyCodable("secret")))],
+            createdatms: 1000, expiresatms: Int.max, status: .pending))
         let model = try #require(viewModel.questionCards.first)
         model.secretStoreAllowedHostsText = "uploads.example.test,\napi.example.test"
         model.setOtherText(questionID: "credential", value: "  synthetic-value  ")
@@ -4952,6 +4957,111 @@ struct ChatViewModelTests {
                 return okReplies.count == 2 && vm.messages.last?.timestamp == now + 4
             }
         }
+    }
+
+    @Test(arguments: [1, 2])
+    func `superseded pending refresh preserves an in-flight run`(refreshIndex: Int) async throws {
+        let historyGate = AsyncGate()
+        let historyStarted = AsyncCounter()
+        let now = Date().timeIntervalSince1970 * 1000 + 10000
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload(), historyPayload()],
+            historyResponseHook: { _, index, runIds in
+                guard index >= refreshIndex, let runId = runIds.last else { return nil }
+                _ = await historyStarted.increment()
+                await historyGate.wait()
+                return historyPayload(
+                    messages: [
+                        chatTextMessage(
+                            role: "user", text: "inspect workspace", timestamp: now,
+                            idempotencyKey: "\(runId):user"),
+                        chatTextMessage(role: "assistant", text: "Let me inspect it.", timestamp: now + 1),
+                    ],
+                    inFlightRun: OpenClawChatInFlightRun(runId: runId, text: "Let me inspect it."))
+            },
+            sendMessageStatus: "pending")
+        await MainActor.run { vm.pendingRunRefreshDelaysMs = [20, 60000] }
+        try await loadAndWaitBootstrap(vm: vm)
+        await sendUserMessage(vm, text: "inspect workspace")
+        let runId = try await waitForLastSentRunId(transport)
+        try await waitUntil("pending history request starts") { await historyStarted.current() == 1 }
+
+        emitAssistantText(transport: transport, runId: runId, text: "Here is the result so far")
+        try await waitUntil("agent text advances ownership during history request") {
+            await MainActor.run { vm.streamingAssistantText == "Here is the result so far" }
+        }
+        await historyGate.open()
+        try await waitUntil("intermediate assistant history applies") {
+            await MainActor.run { vm.messages.contains { $0.content.first?.text == "Let me inspect it." } }
+        }
+
+        #expect(await MainActor.run { vm.pendingRunCount } == 1)
+        #expect(await MainActor.run { vm.streamingAssistantText } == "Here is the result so far")
+        await MainActor.run { vm.clearPendingRuns(reason: nil) }
+    }
+
+    @Test(arguments: ["agent-first", "delta-first", "delta-only"])
+    @MainActor
+    func `agent assistant text owns the run instead of cumulative chat buffers`(delivery: String) async throws {
+        let runId = "run-streaming"
+        let history = historyPayload(
+            inFlightRun: delivery == "delta-only" ? nil : OpenClawChatInFlightRun(runId: runId, text: "seed"))
+        let (_, vm) = await makeViewModel(historyResponses: [history])
+        try await loadAndWaitBootstrap(vm: vm)
+        defer { vm.detachTransport() }
+        let agent = OpenClawChatTransportEvent.agent(OpenClawAgentEventPayload(
+            runId: runId, seq: 1, stream: "assistant", ts: 1,
+            data: ["text": AnyCodable("Here is the result")]))
+        let delta = OpenClawChatTransportEvent.chat(OpenClawChatEventPayload(
+            runId: runId, sessionKey: "main", state: "delta",
+            message: chatTextMessage(role: "assistant", text: "Let me look first.Here is the result", timestamp: 1),
+            errorMessage: nil))
+
+        if delivery == "agent-first" { vm.handleTransportEvent(agent) }
+        vm.handleTransportEvent(delta)
+        if delivery != "agent-first" {
+            #expect(vm.streamingAssistantText == "Let me look first.Here is the result")
+        }
+        if delivery == "delta-only" {
+            #expect(vm.pendingRunCount == 1)
+            return
+        }
+        vm.handleTransportEvent(agent)
+        vm.handleTransportEvent(.agent(usageEvent(runId: runId, outputTokens: 10, seq: 2)))
+        vm.handleTransportEvent(delta)
+        #expect(vm.streamingAssistantText == "Here is the result")
+        await vm.refreshHistoryAfterRun()
+        #expect(vm.streamingAssistantText == "Here is the result")
+    }
+
+    @Test @MainActor func `detached transport ignores late events and in-flight history`() async throws {
+        let historyGate = AsyncGate()
+        let historyStarted = AsyncCounter()
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            historyResponseHook: { _, index, _ in
+                guard index == 1 else { return nil }
+                _ = await historyStarted.increment()
+                await historyGate.wait()
+                return historyPayload(inFlightRun: OpenClawChatInFlightRun(runId: "retired-run", text: "stale"))
+            })
+        try await loadAndWaitBootstrap(vm: vm)
+        let refresh = Task { await vm.refreshHistoryAfterRun() }
+        try await waitUntil("history starts before detachment") { await historyStarted.current() == 1 }
+        vm.detachTransport()
+        vm.detachTransport()
+        let lateEvent = OpenClawChatTransportEvent.chat(OpenClawChatEventPayload(
+            runId: "retired-run", sessionKey: "main", state: "delta",
+            message: chatTextMessage(role: "assistant", text: "late", timestamp: 1), errorMessage: nil))
+        transport.emit(lateEvent)
+        // Also cover an event already dequeued when the presentation retires.
+        vm.handleTransportEvent(lateEvent)
+        await historyGate.open()
+        let result = await refresh.value
+        #expect(!result.applied)
+        #expect(vm.pendingRunCount == 0)
+        #expect(vm.streamingAssistantText == nil)
+        #expect(vm.messages.isEmpty)
     }
 
     @Test func `completion wait refreshes history and clears pending run`() async throws {


### PR DESCRIPTION
## What Problem This Solves

iPhone users report that the chat transcript "jumps up and down constantly", flickers, and shows blank areas while an agent is working (#135250, #135214; a public report on 2026-09-02 that also mentions crashes). Reproduced on an isolated dev gateway with a paced mock model (reasoning → preamble → `read` tool → final reply), recorded on the simulator and analyzed frame by frame. Four independent owner defects in the shared chat UI and the iOS chat tab produce the symptoms:

1. **Two producers wrote the streaming bubble.** After a tool boundary the gateway's `chat` `delta` buffer is run-cumulative (`"Let me look at the workspace first.Here is…"`) while the `agent` `assistant` stream carries the current item's text. The view model applied both, so the bubble alternated between the two texts several times per second and its height oscillated by a line.
2. **The app retired its own run mid-run.** `invalidateRunSnapshots()` bumps the ownership generation on every streaming event, so any `chat.history` refresh in flight during streaming came back superseded; `refreshIfPending` then skipped the gateway's `inFlightRun` fact and fell through to the message-shape heuristic, which cleared the pending run as soon as history contained the assistant message that carries the tool call. From then on every assistant delta was dropped as a foreign run: no working indicator, blank transcript, until the final arrived. App log: `pending refresh delayMs=1500` → `pending cleared` two seconds after send, `agent.wait … CancellationError`.
3. **Rebuilt chat view models leaked and kept processing every event.** `heap` showed three live `OpenClawChatViewModel` instances; each processed every gateway event (`ours=false pending=0` twins in the log), ran its own history polling and haptics. The retain chain went through the model's closures capturing the `ChatProTab` view value and its `@State` saved values.
4. **A streaming table flipped between prose and table.** The block segmenter skipped a trailing table while streaming, so rows were appended to the previous paragraph as prose, the paragraph text was rewritten on every row (restarting the word reveal, text going invisible), and the table popped in only when text followed it: measured as repeated ±25–80 pt up/down shifts.

Also fixes the iPhone edge-drawer drag latching on marginal diagonals (#135250's horizontal shift): a vertical thumb scroll near the left edge could drag the content card sideways and spring back.

## Why This Change Was Made

Each fix lands at the owner that records the fact: the view model keeps one canonical producer for live text and never lets a superseded history snapshot retire a run the gateway reports in flight; the chat tab hands the model closures that do not capture the view and detaches a model's transport loop when it is rebuilt; the segmenter keeps prose prefix-stable while a table streams; the drawer commits only on clearly horizontal drags.

## User Impact

Agentic replies on iPhone stream without flicker or blank gaps, the working indicator stays until the run really ends, tables render once while streaming, scrolling near the left edge no longer shifts the transcript sideways, and the app stops doing every chat event's work three times.

## Evidence

Rig: isolated dev gateway (`OPENCLAW_STATE_DIR`, token auth, port 18899) with a paced Responses-API mock model (35 ms/word, reasoning summary → preamble → `read` tool → 12 s model delay → final reply), iOS 27 simulator driven headlessly with `idb`, recordings analyzed frame by frame (vertical shift of the transcript band; "direction reversals within 1 s" is the up/down signature).

| Metric | Before | After |
| --- | ---: | ---: |
| Live `OpenClawChatViewModel` instances (`heap`) | 3 | 1 |
| Agentic run: direction reversals | 12 | 1 |
| Streamed reply with a table: direction reversals | 5–6 | 2 |
| Own run retired mid-run (`pending cleared` before `run observation terminal`) | yes, at +2 s | no |
| Working indicator during tool phase + model delay | disappears | stays |
| Streaming bubble after tool boundary | alternates between two texts | single per-item text |

App diagnostics after the fix (proof run): `pending refresh` at +2 s, +6 s, +15 s all keep the run; `run observation … completed` → `pending cleared` only at the real end.

Tests:
- `swift test --filter 'ChatViewModelTests|ChatMarkdownBlockSegmenterTests|ChatReaderScrollStateTests|ChatStreamingRevealTests'`: 449 tests, 5 suites, passed. New: `superseded pending refresh preserves an in-flight run` (fails on the previous code on both assertions), `agent assistant text owns the run instead of cumulative chat buffers` (agent-first / delta-first / delta-only), `detached transport ignores late events and in-flight history`, `streamed table prefixes preserve prose and only grow table rows`, `streaming table header waits without hiding inline pipes`.
- `xcodebuild test … -only-testing:OpenClawTests/RootSidebarDrawerGestureTests -only-testing:OpenClawTests/RootTabsSidebarRegressionTests -only-testing:OpenClawTests/RootTabsSourceGuardTests`: passed (exit 0). `RootTabsSidebarRegressionTests` had a stale assertion (expected `openChat(sessionKey:)` in the session button after #132983 switched it to `selectSession`); repaired here, it is not in the CI `-only-testing` list.
- SwiftFormat 0.63.0 (`config/swiftformat`) and SwiftLint 0.65.1: clean. `pnpm ios:build` for the simulator: succeeded.
- Codex autoreview (`--mode uncommitted`): scoped-clean.

LOC: production +107/−99 (net +8: the recorded per-run "agent text seen" fact, the explicit transport detach lifecycle, and the trailing-table hold-back; the drawer predicate and live-state refactor are net negative); tests +176/−26 plus a 95-line new test file.

Accepted tradeoff: while streaming, a trailing paragraph whose every line starts with `|` is held back until its table delimiter row arrives (or the message completes), so ASCII-art-style pipe paragraphs appear late rather than flickering.

Not changed (follow-ups): the gateway replays its buffered chat deltas (100+ events in one burst) at run end, which re-adopts a just-finished run for ~150 ms; a "Select Text" sheet and code-block copy on iOS; the background-wake refresh path is dead (no `fetch` background mode).

Fixes #135250. Refs #135214, #124759; copy/selection landed separately in #135430.
