### PR TITLE
chore(macos): bump Peekaboo to 4.3.0

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "f2127970860a36ea9e0d4a251d63c336e78ecba7ebe74e48f1290de8dc175bef",
+  "originHash" : "7034cd2d532c99dcb62c81ffc67fa3c73b8e8896d937064875bc6a2d37a91f16",
   "pins" : [
     {
       "identity" : "axorcist",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/AXorcist.git",
       "state" : {
-        "revision" : "bab3f2228bac0ce3a34786b8395b65bb36242221",
-        "version" : "0.1.8"
+        "revision" : "37d7ae82ff1443b4b36344ca6f3bf0ad33f13b12",
+        "version" : "0.1.9"
       }
     },
     {
@@ -51,7 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/Peekaboo.git",
       "state" : {
-        "revision" : "8d5e638e6ac9e93fae7d8dcb2ac0a0f01f3d49ec"
+        "revision" : "44eff916c3330739108cc1d73683338d4250503a",
+        "version" : "4.3.0"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.6"),
         .package(
             url: "https://github.com/openclaw/Peekaboo.git",
-            revision: "8d5e638e6ac9e93fae7d8dcb2ac0a0f01f3d49ec"),
+            exact: "4.3.0"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.4.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixture.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixture.swift
@@ -46,7 +46,7 @@ final class DashboardHTTPFixture {
         listener.start(queue: .main)
         do {
             let deadline = ContinuousClock.now + .seconds(5)
-            while ContinuousClock.now < deadline {
+            while true {
                 try Task.checkCancellation()
                 switch listener.state {
                 case .ready:
@@ -63,10 +63,10 @@ final class DashboardHTTPFixture {
                 case .cancelled:
                     throw CancellationError()
                 default:
+                    guard ContinuousClock.now < deadline else { throw URLError(.timedOut) }
                     try await Task.sleep(for: .milliseconds(10))
                 }
             }
-            throw URLError(.timedOut)
         } catch {
             listener.cancel()
             throw error

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
@@ -460,13 +460,14 @@ extension DashboardWindowOwnershipTests {
 
     private func waitForQueuedToggles(_ manager: DashboardManager) async throws -> DashboardWindowController {
         let deadline = ContinuousClock.now + .seconds(5)
-        while ContinuousClock.now < deadline {
+        while true {
             if let controller = manager._testController(), controller.isWindowOpen,
                let commands = try? await controller.webView.evaluateJavaScript("window.commandEvents") as? [String],
                commands.filter({ $0 == "toggle" }).count == 2
             {
                 return controller
             }
+            guard ContinuousClock.now < deadline else { break }
             try await Task.sleep(for: .milliseconds(10))
         }
         throw URLError(.timedOut)
@@ -480,15 +481,17 @@ extension DashboardWindowOwnershipTests {
 
     private func waitForDashboard(_ controller: DashboardWindowController, path: String) async throws {
         let deadline = ContinuousClock.now + .seconds(5)
-        while ContinuousClock.now < deadline {
+        while true {
             if controller.canDeliverNativeCommands, !controller.webView.isLoading,
                controller.webView.url?.path == path
             {
                 return
             }
+            guard ContinuousClock.now < deadline else { break }
             try await Task.sleep(for: .milliseconds(10))
         }
         #expect(controller.canDeliverNativeCommands)
+        #expect(!controller.webView.isLoading)
         #expect(controller.webView.url?.path == path)
         throw URLError(.timedOut)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/PipeReadStreamTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PipeReadStreamTests.swift
@@ -1,21 +1,22 @@
 import Darwin
 import Foundation
+import Synchronization
 import Testing
 @testable import OpenClaw
 
 struct PipeReadStreamTests {
-    @Test func `cancelled finish still joins reader cleanup`() throws {
+    @Test func `cancelled finish still joins reader cleanup`() async throws {
         let pipe = Pipe()
         let probe = PipeReadProbe()
-        let entered = DispatchSemaphore(value: 0)
+        let entered = AsyncTestGate()
         let release = DispatchSemaphore(value: 0)
-        let started = DispatchSemaphore(value: 0)
-        let joined = DispatchSemaphore(value: 0)
+        let started = AsyncTestGate()
+        let joined = Mutex(false)
         let reader = try PipeReadStream(
             handle: pipe.fileHandleForReading,
             onData: { data in
                 probe.append(data)
-                entered.signal()
+                entered.open()
                 release.wait()
             },
             onClose: { probe.finish() })
@@ -26,17 +27,18 @@ struct PipeReadStreamTests {
         }
         try pipe.fileHandleForReading.close()
         try pipe.fileHandleForWriting.write(contentsOf: Data("first".utf8))
-        try #require(entered.wait(timeout: .now() + 2) == .success)
+        await entered.wait()
         let closing = Task {
-            started.signal()
+            started.open()
             await reader.finish()
-            joined.signal()
+            joined.withLock { $0 = true }
         }
         closing.cancel()
-        try #require(started.wait(timeout: .now() + 2) == .success)
-        #expect(joined.wait(timeout: .now() + 0.1) == .timedOut)
+        await started.wait()
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(!joined.withLock { $0 })
         release.signal()
-        #expect(joined.wait(timeout: .now() + 2) == .success)
+        await closing.value
         #expect(probe.finishCount == 1)
     }
 


### PR DESCRIPTION
## What Problem This Solves

The macOS app embeds a Peekaboo source revision from before the 4.3.0 release. This updates its automation and bridge libraries to the requested [Peekaboo 4.3.0 release](https://github.com/openclaw/Peekaboo/releases/tag/v4.3.0).

## Why This Change Was Made

Pin the Swift package to exactly `4.3.0` and regenerate `Package.resolved`. The release resolves to `44eff916c3330739108cc1d73683338d4250503a` and requires AXorcist `0.1.9`; other dependency versions remain unchanged. Packaging continues to obtain the full source revision from the lockfile.

Required CI also exposed a scheduling race in the existing pipe-cleanup test. Its synchronous semaphore wait could time out before a cancelled async task resumed. The test now uses the existing async gate for entry/start synchronization and awaits the task after releasing the native callback. It retains the negative join-before-release assertion and exactly-once cleanup check. Production pipe behavior is unchanged; no timeout was increased.

## User Impact

The macOS app consumes the released Peekaboo automation and bridge updates. No OpenClaw settings or UI layout changes are included. The adjacent test repair makes CI verify pipe cleanup without blocking a cooperative executor thread while awaiting task completion.

## Evidence

- Verified the upstream `v4.3.0` tag and directly inspected its Swift package manifest and embedded bridge API.
- `swift package --package-path apps/macos resolve` and `swift build --package-path apps/macos --target PeekabooBridge` passed for the dependency update.
- [Hosted CI 33696614721](https://github.com/openclaw/openclaw/actions/runs/33696614721) passed on the original dependency-only head, including the full macOS release build, shared/app tests, all three macOS Node lanes, and broader fallback checks. This covered the initial local full-app build limitation from missing generated Mermaid assets. New-head CI is required after the test repair.
- All three pipe tests passed in an isolated SwiftPM harness using unchanged copied production sources (`PipeReadStream.swift`, `FileHandle+SIGPIPE.swift`) and the complete candidate pipe test file plus its existing async gate. Removing the production cleanup join in the disposable harness made the candidate test fail on the intended early-return and cleanup assertions. No harness mutation entered this PR.
- SwiftFormat lint, whitespace checks, and independent Codex P2 review passed for the final candidate.
- No live GUI proof is claimed.

### CI recovery and remaining follow-up

The original PR workflow waited on unassigned Blacksmith macOS jobs. A successful manual fallback supplied build proof but did not replace the required PR check selected by GitHub. The original run was cancelled only after confirming it had no active jobs, assigned runners, or executed queued steps, then retried through the supported hosted-runner path.

Original-run attempt 2 had a GitHub checkout connection reset in macOS Node lane 3; that lane passed on attempt 3. The Swift suite first exposed the existing approval-expiry test race below, then passed that test on attempt 3 but failed the pipe cleanup test repaired here.

Named follow-up: **make approval queue expiry proof deterministic across Gateway delivery and MainActor admission**. The unchanged test expects a 500 ms approval to remain visible after asynchronous refresh, although it may legitimately have expired by admission time. The earlier response-time fixture repair still leaves that scheduling gap. The same suite passed in the full hosted run. A deterministic clock/expiry ownership design deserves separate review; this PR does not add a test-only production clock hook, extend TTLs, or relax the approval assertions.

ClawSweeper found no dependency patch defect. Its upstream DNS limitation is covered by direct local source/tag inspection; its requested macOS build proof is available in the hosted run. The bounded pipe test repair is accompanied by new-head CI and independent review.

Scope: dependency manifest +1/-1, generated lockfile +5/-4, tests/test-support +20/-15; production implementation +0/-0.


### Dashboard setup race found during final-head CI

Run 33702353399 attempt 2 passed release compilation and all macOS Node lanes. The pipe repair and approval-expiry case passed; its only Swift failure was the dashboard notification window-close setup timing out. Three nearby fixture/poll helpers checked the deadline before observing readiness, allowing a delayed poll to reject an already-ready listener, page, or queued-toggle state. They now observe readiness first; the five-second deadline, 10 ms polling, all success predicates, and cancellation/cleanup behavior are unchanged. Timeout diagnostics also check the page loading state. The original log does not distinguish the two setup throw sites, so no more specific historical attribution is claimed.

A disposable Swift harness extracted the actual before/after helper bodies and controlled their clock/dependencies: all 12 cases passed. Each old helper rejected readiness after a delayed poll; each repaired helper accepted it. All still-pending cases continued to time out after the same single sleep. SwiftFormat, whitespace checks, and final five-file Codex P2 review passed. Full new-head CI remains the integration gate.

### Bridge signer-contract verification

Directly inspected Peekaboo commit `44eff916c3330739108cc1d73683338d4250503a`: [trusted signer constants](https://github.com/openclaw/Peekaboo/blob/44eff916c3330739108cc1d73683338d4250503a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift#L9) retain the expected two teams. [Client authentication](https://github.com/openclaw/Peekaboo/blob/44eff916c3330739108cc1d73683338d4250503a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHost%2BClients.swift#L240) binds the live audit identity, process generation, and code hash before accepting an allowed team; unsigned access is DEBUG-only. [Signature validation](https://github.com/openclaw/Peekaboo/blob/44eff916c3330739108cc1d73683338d4250503a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeCodeSignatureIdentity.swift#L251) checks the Apple-anchored identifier and certificate team requirement. [Routing](https://github.com/openclaw/Peekaboo/blob/44eff916c3330739108cc1d73683338d4250503a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer%2BRouting.swift#L24) validates the peer before dispatch; [the validator](https://github.com/openclaw/Peekaboo/blob/44eff916c3330739108cc1d73683338d4250503a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift#L711) enforces team, bundle, and same-user requirements. Handshake also verifies supported protocol and allowlists. OpenClaw continues to supply its existing team set and exact `boo.peekaboo.peekaboo` bundle allowlist. This addresses ClawSweeper's source-inspection request; it is source/build evidence, not a claimed live signed-client round trip.

### Latest review disposition

ClawSweeper's signer-contract request is addressed by the exact-source references above. Final-head macOS release compilation, shared/app Swift tests, and all three macOS Node lanes passed in run 33704652960 attempt 2; the aggregate required gate is awaiting its runner.

The suggested short per-gate timeouts are intentionally not restored. The pipe regression protects cancellation-safe cleanup ordering, not a two-second executor scheduling SLA. It uses the repository's existing cancellation-aware async gate, and the negative early-return assertion plus exactly-once close assertion remain; the real-source mutation check proves these still detect the contract violation. Accepted tradeoff: a broken fixture that never delivers a callback can consume the enclosing CI job deadline instead of reporting a two-second local failure. Adding a new timeout race around ordinary test-task scheduling would retain the cause of load-sensitive failures and add test-only machinery. No production wait or timeout changed.

### Final merge proof

[PR CI run 33704652960, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33704652960/attempts/2) passed for final head `441a276a0e419ccdb6c804b453655eab821b8069`: all three macOS Node lanes, Swift release compilation, shared/app Swift tests, and the required `openclaw/ci-gate`. The aggregate gate obtained its runner and completed successfully. The failed earlier runs and named approval-expiry follow-up remain documented above; no required check is bypassed.
