### PR TITLE
docs(slack): Agent View troubleshooting wrongly says a storage warning turns Agent View off

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -2091,7 +2091,7 @@ openclaw pairing list slack
     - The manifest uses `features.agent_view` with `assistant:write` and subscribes to `app_context_changed`. Apps still on `features.assistant_view` get Assistant View threads instead, and Slack cannot move an app back once it switches to Agent View.
     - OpenClaw has seen an Agent View signal since the app was installed: open the app's **Messages** tab once, or send a DM from the Agent View composer. In verbose logs, `slack suggested prompts update failed for channel D...: internal_error` on a Messages-tab open is expected for an Agent View app and counts as evidence.
     - In HTTP mode, the Gateway has received at least one signed event since it started; `slack app id <id> learned from signed event` in the logs confirms the durable marker can be read. Socket Mode reads the app ID from the app token at startup, so no event is needed.
-    - A `Slack Agent View state failed to persist` warning means the signal was recorded for the running process but the marker was not stored, so it is forgotten on restart. `failed to open` or `failed to load` means a stored marker could not be read, so Agent View stays off until the next signal.
+    - `Slack Agent View state failed to open`, `persist`, or `load` warnings mean the durable marker could not be stored or read. A signal already detected in the running process still applies until the Gateway restarts; after a restart, Agent View stays off until the next signal.
 
     See [Agent View DMs](/channels/slack#agent-view-dms).
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -2091,7 +2091,7 @@ openclaw pairing list slack
     - The manifest uses `features.agent_view` with `assistant:write` and subscribes to `app_context_changed`. Apps still on `features.assistant_view` get Assistant View threads instead, and Slack cannot move an app back once it switches to Agent View.
     - OpenClaw has seen an Agent View signal since the app was installed: open the app's **Messages** tab once, or send a DM from the Agent View composer. In verbose logs, `slack suggested prompts update failed for channel D...: internal_error` on a Messages-tab open is expected for an Agent View app and counts as evidence.
     - In HTTP mode, the Gateway has received at least one signed event since it started; `slack app id <id> learned from signed event` in the logs confirms the durable marker can be read. Socket Mode reads the app ID from the app token at startup, so no event is needed.
-    - `Slack Agent View state failed to open`, `persist`, or `load` warnings mean the durable marker could not be stored or read. A signal already detected in the running process still applies until the Gateway restarts; after a restart, Agent View stays off until the next signal.
+    - `Slack Agent View state failed to open`, `persist`, or `load` warnings mean the durable marker could not be stored or read. A signal already detected in the running process still applies. After a restart, Agent View resumes when OpenClaw successfully reads a stored marker or detects a new signal.
 
     See [Agent View DMs](/channels/slack#agent-view-dms).
 


### PR DESCRIPTION
Related: #136672 (follow-up for the remaining ClawSweeper move on that PR), #126872

## What Problem This Solves

Resolves a problem where the new "Agent View DMs share one session" troubleshooting entry on the Slack page told operators that any `Slack Agent View state failed to open` warning leaves Agent View off. That is only true for the restart lookup path; a signal already detected in the running process keeps Agent View active even when the marker cannot be stored.

## Why This Change Was Made

Reword the bullet by situation instead of by warning verb: the three warnings mean the durable marker could not be stored or read, a signal already detected in the running process still applies until the Gateway restarts, and after a restart Agent View stays off until the next signal. This matches the state owner: `record()` enables the in-process state before opening the store, and the restart lookup returns false on open or load failure. Docs only.

## User Impact

Operators reading the checklist no longer restart a Gateway that is actually working, and know the restart consequence of a storage warning.

## Evidence

- Behavior checked against `extensions/slack/src/monitor/agent-view-state.ts` (`record()` sets `enabled` before `openWorkspaceStore()`; `isEnabled()` returns false on open or load failure) and the existing test `keeps event-derived Agent View when persistent state cannot open` in `extensions/slack/src/monitor/context.test.ts`.
- `pnpm docs:check-mdx` passed; `oxfmt --check` clean; `git diff --check` clean.
- LOC: docs +1/-1.
