### PR TITLE
fix(gateway): keep Codex streams connected under load

### DIFF
--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -26,8 +26,14 @@ export class CodexAssistantProjection {
   private latestTerminalAssistantCandidateSuperseded = false;
   private terminalAssistantCandidateEarlierActiveItemIds = new Set<string>();
   private pendingRawTerminalAssistantEchoItemId: string | undefined;
-  private readonly lastCommentaryProgressEventByItem = new Map<string, string>();
-  private readonly lastAnswerCandidateEventByItem = new Map<string, string>();
+  private readonly lastCommentaryProgressEventByItem = new Map<
+    string,
+    { phase: "update" | "end"; text: string }
+  >();
+  private readonly lastAnswerCandidateEventByItem = new Map<
+    string,
+    { status: AnswerCandidateStatus; text: string }
+  >();
   private visibleAnswerCandidateItemId: string | undefined;
   // Codex emits each typed item completion before its matching raw response item.
   // Pair by protocol order because contributors may rewrite only the typed text.
@@ -96,10 +102,10 @@ export class CodexAssistantProjection {
       this.emitCommentaryProgress({ itemId, text, phase: "update" });
       return;
     }
-    if (this.isFinalAnswerAssistantItem(itemId)) {
+    const knownFinalAnswer = this.isFinalAnswerAssistantItem(itemId);
+    if (knownFinalAnswer) {
       this.emitAnswerCandidate(itemId, "candidate");
     }
-    const knownFinalAnswer = this.shouldStreamAssistantPartial(itemId);
     const replace =
       this.streamedPartialAssistantItemId !== undefined &&
       this.streamedPartialAssistantItemId !== itemId;
@@ -501,10 +507,6 @@ export class CodexAssistantProjection {
     return this.assistantPhaseByItem.get(itemId) === "final_answer";
   }
 
-  private shouldStreamAssistantPartial(itemId: string): boolean {
-    return this.assistantPhaseByItem.get(itemId) === "final_answer";
-  }
-
   private emitCommentaryProgress(params: {
     itemId: string;
     text: string;
@@ -514,11 +516,14 @@ export class CodexAssistantProjection {
     // Codex completes an item with the same text as its last delta. Channels
     // need that boundary before their first notifying post, so agents must not
     // collapse completion into a text-only duplicate or invent a timer instead.
-    const signature = `${params.phase}\0${progressText}`;
-    if (!progressText || this.lastCommentaryProgressEventByItem.get(params.itemId) === signature) {
+    const previous = this.lastCommentaryProgressEventByItem.get(params.itemId);
+    if (!progressText || (previous?.phase === params.phase && previous.text === progressText)) {
       return;
     }
-    this.lastCommentaryProgressEventByItem.set(params.itemId, signature);
+    this.lastCommentaryProgressEventByItem.set(params.itemId, {
+      phase: params.phase,
+      text: progressText,
+    });
     this.emitAgentEvent({
       stream: "item",
       data: {
@@ -541,11 +546,11 @@ export class CodexAssistantProjection {
       this.supersedeVisibleAnswerCandidate();
       this.visibleAnswerCandidateItemId = itemId;
     }
-    const signature = `${status}\0${text}`;
-    if (this.lastAnswerCandidateEventByItem.get(itemId) === signature) {
+    const previous = this.lastAnswerCandidateEventByItem.get(itemId);
+    if (previous?.status === status && previous.text === text) {
       return;
     }
-    this.lastAnswerCandidateEventByItem.set(itemId, signature);
+    this.lastAnswerCandidateEventByItem.set(itemId, { status, text });
     this.emitAgentEvent({
       stream: "item",
       data: {

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -73,6 +73,8 @@ export function isChatAbortMarkerCurrent(
 export type BufferedAgentEvent = {
   sessionKey?: string;
   agentId?: string;
+  controlUiVisible?: boolean;
+  isCurrent?: () => boolean;
   payload: AgentEventPayload & { spawnedBy?: string };
 };
 
@@ -101,6 +103,7 @@ type ChatRunRecord = {
   registrations?: ChatRunEntry[];
   rawBuffer?: string;
   buffer?: string;
+  bufferIsCurrent?: () => boolean;
   /** Projection stays valid only while source and managed-media facts match the run state. */
   bufferProjection?: { source: string; suppress: boolean };
   planSnapshot?: ChatRunPlanSnapshot;
@@ -111,15 +114,11 @@ type ChatRunRecord = {
   assistantScope?: { itemId: string; prefix: string };
   managedMediaUrls?: Set<string>;
   deltaLastBroadcastText?: string;
-  agentText?: {
-    assistant?: ChatRunAgentTextState;
-    thinking?: ChatRunAgentTextState;
-  };
+  agentText?: Partial<
+    Record<"assistant" | "thinking" | "preamble" | "answer_candidate", ChatRunAgentTextState>
+  >;
   abortMarker?: ChatAbortMarker;
   toolRecipient?: ChatRunToolRecipientState;
-};
-
-type InternalChatRunRecord = ChatRunRecord & {
   /** Fixed-deadline trailing wake-up owned by this run's buffered state. */
   pendingTextFlushes?: Partial<Record<"chat" | "agent", PendingLiveTextFlush>>;
 };
@@ -151,16 +150,11 @@ function createChatRunRecordStore(): ChatRunRecordStore {
   return { runs, getOrCreate, releaseIfEmpty };
 }
 
-function internalChatRunRecord(record: ChatRunRecord): InternalChatRunRecord {
-  return record;
-}
-
 function clearPendingLiveTextFlushes(record: ChatRunRecord): void {
-  const internal = internalChatRunRecord(record);
-  for (const pending of Object.values(internal.pendingTextFlushes ?? {})) {
+  for (const pending of Object.values(record.pendingTextFlushes ?? {})) {
     clearTimeout(pending.timer);
   }
-  delete internal.pendingTextFlushes;
+  delete record.pendingTextFlushes;
 }
 
 export type ChatRunRegistry = {
@@ -272,6 +266,7 @@ export function createChatRunState(): ChatRunState {
     }
     delete record.rawBuffer;
     delete record.buffer;
+    delete record.bufferIsCurrent;
     delete record.bufferProjection;
     delete record.planSnapshot;
     delete record.progressSnapshot;
@@ -294,7 +289,7 @@ export function createChatRunState(): ChatRunState {
 
   const resolveBuffer = (runId: string, options?: { final?: boolean }) => {
     const record = store.runs.get(runId);
-    if (!record) {
+    if (!record || record.bufferIsCurrent?.() === false) {
       return projectLiveAssistantBufferedText("");
     }
     const rawText = record.rawBuffer;

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -30,6 +30,7 @@ import {
   getAgentEventLifecycleGeneration,
   onAgentRuntimeEvent,
   resetAgentEventsForTest,
+  type AgentEventPayload,
 } from "../infra/agent-events.js";
 import {
   clearAgentRunContext as clearRegisteredAgentRunContext,
@@ -270,6 +271,23 @@ describe("agent event handler", () => {
 
   function agentBroadcastCalls(broadcast: ReturnType<typeof vi.fn>) {
     return broadcast.mock.calls.filter(([event]) => event === "agent");
+  }
+
+  function answerCandidate(
+    itemId: string,
+    progressText: string,
+    status: "candidate" | "selected" | "superseded" = "candidate",
+  ) {
+    return {
+      itemId,
+      kind: "answer_candidate",
+      title: "Answer candidate",
+      phase: "update",
+      status,
+      progressText,
+      source: "codex-app-server",
+      hideFromChannelProgress: true,
+    };
   }
 
   function sessionChatCalls(nodeSendToSession: ReturnType<typeof vi.fn>) {
@@ -858,6 +876,540 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
+  it.each([
+    { audience: "visible", controlUiVisible: true },
+    { audience: "hidden subscribed", controlUiVisible: false },
+  ])("paces $audience answer candidates without losing final bytes", ({ controlUiVisible }) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const {
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      chatRunState,
+      sessionMessageSubscribers,
+      handler,
+    } = createHarness();
+    registerNamedChatRun(chatRunState, "candidate-burst");
+    if (!controlUiVisible) {
+      registerAgentRunContext("run-candidate-burst", {
+        sessionKey: "session-candidate-burst",
+        isControlUiVisible: false,
+        verboseLevel: "off",
+      });
+      sessionMessageSubscribers.subscribe("conn-selected", "session-candidate-burst");
+      sessionMessageSubscribers.subscribe("conn-other", "session-other");
+    }
+    const delivery = controlUiVisible ? broadcast : broadcastToConnIds;
+    const chunks = Array.from({ length: 64 }, (_, index) => `[${index}]${"abc🚀".repeat(64)}.`);
+    const expected = chunks.join("");
+
+    try {
+      let text = "";
+      for (const [index, delta] of chunks.entries()) {
+        text += delta;
+        // The native projector emits its cumulative candidate before each assistant delta.
+        emitAgentEvent(handler, "run-candidate-burst", "item", answerCandidate("answer-1", text), {
+          seq: index * 2 + 1,
+        });
+        emitAgentEvent(
+          handler,
+          "run-candidate-burst",
+          "assistant",
+          { text, delta },
+          { seq: index * 2 + 2 },
+        );
+      }
+
+      vi.advanceTimersByTime(74);
+      expect(agentBroadcastCalls(delivery).length).toBeLessThanOrEqual(controlUiVisible ? 2 : 1);
+      vi.advanceTimersByTime(1);
+
+      const progress = agentBroadcastCalls(delivery).map(
+        ([, payload]) => payload as AgentEventPayload,
+      );
+      expect(progress.length).toBeLessThanOrEqual(controlUiVisible ? 4 : 2);
+      expect(progress.findLast((payload) => payload.stream === "item")?.data).toEqual(
+        answerCandidate("answer-1", expected),
+      );
+      const assistantProgress = progress.filter((payload) => payload.stream === "assistant");
+      if (controlUiVisible) {
+        expect(assistantProgress.map((payload) => payload.data.delta).join("")).toBe(expected);
+        expect(sessionAgentCalls(nodeSendToSession).map((call) => call[2])).toEqual(progress);
+      } else {
+        expect(assistantProgress).toHaveLength(0);
+      }
+
+      emitAgentEvent(
+        handler,
+        "run-candidate-burst",
+        "item",
+        answerCandidate("answer-1", expected, "selected"),
+        { seq: chunks.length * 2 + 1 },
+      );
+      expect(agentBroadcastCalls(delivery).at(-1)?.[1]).toMatchObject({
+        stream: "item",
+        data: answerCandidate("answer-1", expected, "selected"),
+      });
+      emitLifecycleEnd(handler, "run-candidate-burst", chunks.length * 2 + 2);
+
+      expect(
+        agentBroadcastCalls(delivery)
+          .slice(progress.length)
+          .map(([, payload]) => payload),
+      ).toMatchObject([
+        { stream: "item", data: answerCandidate("answer-1", expected, "selected") },
+        { stream: "lifecycle", data: { phase: "end" } },
+      ]);
+      expect(chatDeltaTexts(delivery).join("")).toBe(expected);
+      expect(chatBroadcastCalls(delivery).at(-1)?.[1]).toMatchObject({
+        runId: "client-candidate-burst",
+        state: "final",
+        message: { content: [{ type: "text", text: expected }] },
+      });
+      const completedCalls = delivery.mock.calls.length;
+      vi.advanceTimersByTime(1_000);
+      expect(delivery).toHaveBeenCalledTimes(completedCalls);
+      if (!controlUiVisible) {
+        expect(broadcast).not.toHaveBeenCalled();
+        expect(nodeSendToSession).not.toHaveBeenCalled();
+        for (const call of broadcastToConnIds.mock.calls) {
+          expect(call[2]).toEqual(new Set(["conn-selected"]));
+        }
+      }
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      handler.dispose();
+      chatRunState.clear();
+    }
+  });
+
+  it.each([
+    { audience: "visible", controlUiVisible: true },
+    { audience: "hidden subscribed", controlUiVisible: false },
+  ])(
+    "keeps $audience progress batched while timer callbacks are overdue",
+    async ({ controlUiVisible }) => {
+      vi.useFakeTimers();
+      let now = 10_000;
+      const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+      const {
+        broadcast,
+        broadcastToConnIds,
+        nodeSendToSession,
+        chatRunState,
+        sessionMessageSubscribers,
+        handler,
+      } = createHarness();
+      const runs = Array.from({ length: 32 }, (_, index) => {
+        const name = `overdue-${index}`;
+        const run = {
+          runId: `run-${name}`,
+          clientRunId: `client-${name}`,
+          sessionKey: `session-${name}`,
+          recipient: `conn-${name}`,
+          chunks: Array.from({ length: 5 }, (_chunk, step) => `[${index}:${step}]🚀`),
+        };
+        registerNamedChatRun(chatRunState, name);
+        if (!controlUiVisible) {
+          registerAgentRunContext(run.runId, {
+            sessionKey: run.sessionKey,
+            isControlUiVisible: false,
+          });
+          sessionMessageSubscribers.subscribe(run.recipient, run.sessionKey);
+        }
+        return run;
+      });
+      const delivery = controlUiVisible ? broadcast : broadcastToConnIds;
+      const progressFor = (runId: string) =>
+        agentBroadcastCalls(delivery)
+          .map(([, payload]) => payload as AgentEventPayload)
+          .filter((payload) => payload.runId === runId);
+      const chatFor = (runId: string) =>
+        chatBroadcastCalls(delivery)
+          .map(([, payload]) => payload)
+          .filter((payload) => payload.runId === runId);
+      const emitStep = (step: number) => {
+        for (const run of runs) {
+          const text = run.chunks.slice(0, step + 1).join("");
+          emitAgentEvent(handler, run.runId, "item", answerCandidate("shared-item", text), {
+            seq: step * 2 + 1,
+          });
+          emitAgentEvent(
+            handler,
+            run.runId,
+            "assistant",
+            { text, delta: run.chunks[step] },
+            { seq: step * 2 + 2 },
+          );
+        }
+      };
+      const leadingFrames = controlUiVisible ? 2 : 1;
+
+      try {
+        emitStep(0);
+        now += 1;
+        emitStep(1);
+        // Advance wall time without servicing timers, as when ingress occupies the event loop.
+        now += 100;
+        emitStep(2);
+        for (const run of runs) {
+          expect(progressFor(run.clientRunId)).toHaveLength(leadingFrames);
+          if (controlUiVisible) {
+            expect(chatFor(run.clientRunId)).toHaveLength(1);
+          }
+        }
+        vi.advanceTimersByTime(75);
+        for (const run of runs) {
+          const progress = progressFor(run.clientRunId);
+          expect(progress).toHaveLength(leadingFrames * 2);
+          if (controlUiVisible) {
+            expect(chatFor(run.clientRunId)).toHaveLength(2);
+          }
+          expect(progress.findLast((event) => event.stream === "item")?.data.progressText).toBe(
+            run.chunks.slice(0, 3).join(""),
+          );
+        }
+
+        // A fresh post-idle batch must also wait for a wake, even with no previous tail queued.
+        now += 200;
+        emitStep(3);
+        now += 100;
+        emitStep(4);
+        for (const run of runs) {
+          expect(progressFor(run.clientRunId)).toHaveLength(leadingFrames * 2);
+          if (controlUiVisible) {
+            expect(chatFor(run.clientRunId)).toHaveLength(2);
+          }
+        }
+        vi.advanceTimersByTime(1);
+        for (const run of runs) {
+          const expected = run.chunks.join("");
+          const progress = progressFor(run.clientRunId);
+          expect(progress).toHaveLength(leadingFrames * 3);
+          if (controlUiVisible) {
+            expect(chatFor(run.clientRunId)).toHaveLength(3);
+          }
+          expect(progress.findLast((event) => event.stream === "item")?.data).toEqual(
+            answerCandidate("shared-item", expected),
+          );
+          expect(progress.every((event) => event.sessionKey === run.sessionKey)).toBe(true);
+          expect(
+            progress
+              .filter((event) => event.stream === "assistant")
+              .map((event) => event.data.delta)
+              .join(""),
+          ).toBe(controlUiVisible ? expected : "");
+          emitAgentEvent(
+            handler,
+            run.runId,
+            "item",
+            answerCandidate("shared-item", expected, "selected"),
+            {
+              seq: 11,
+            },
+          );
+          emitLifecycleEnd(handler, run.runId, 12);
+          const chat = chatFor(run.clientRunId);
+          expect(
+            chat
+              .filter((payload) => payload.state === "delta")
+              .map((payload) => payload.deltaText)
+              .join(""),
+          ).toBe(expected);
+          expect(chat.at(-1)).toMatchObject({
+            state: "final",
+            message: { content: [{ type: "text", text: expected }] },
+          });
+          if (!controlUiVisible) {
+            const scopedCalls = delivery.mock.calls.filter(
+              ([, payload]) => payload.runId === run.clientRunId,
+            );
+            for (const [, payload, recipients] of scopedCalls) {
+              expect(payload.sessionKey).toBe(run.sessionKey);
+              expect(recipients).toEqual(new Set([run.recipient]));
+            }
+          }
+        }
+        if (!controlUiVisible) {
+          expect(broadcast).not.toHaveBeenCalled();
+          expect(nodeSendToSession).not.toHaveBeenCalled();
+        }
+        const completedCalls = delivery.mock.calls.length;
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(delivery).toHaveBeenCalledTimes(completedCalls);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        handler.dispose();
+        chatRunState.clear();
+        nowSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each([
+    {
+      name: "selection",
+      stream: "item",
+      data: answerCandidate("answer-1", "Hello", "selected"),
+    },
+    {
+      name: "supersession",
+      stream: "item",
+      data: answerCandidate("answer-1", "Hello", "superseded"),
+    },
+    {
+      name: "native item start",
+      stream: "item",
+      data: { itemId: "command-1", kind: "command", title: "Command", phase: "start" },
+    },
+    {
+      name: "tool start",
+      stream: "tool",
+      data: { phase: "start", name: "read", toolCallId: "read-1" },
+    },
+    {
+      name: "replacement",
+      stream: "assistant",
+      data: { text: "Corrected", delta: "", replace: true },
+    },
+    { name: "terminal", stream: "lifecycle", data: { phase: "end" } },
+  ] as const)("flushes candidate and assistant progress before $name", ({ stream, data }) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const { broadcast, broadcastToConnIds, chatRunState, toolEventRecipients, handler } =
+      createHarness();
+    registerNamedChatRun(chatRunState, "candidate-boundary");
+    toolEventRecipients.add("run-candidate-boundary", "conn-tools");
+
+    try {
+      emitAgentEvents(handler, "run-candidate-boundary", [
+        ["item", answerCandidate("answer-1", "Hel")],
+        ["assistant", { text: "Hel", delta: "Hel" }],
+        ["item", answerCandidate("answer-1", "Hello")],
+        ["assistant", { text: "Hello", delta: "lo" }],
+      ]);
+      expect(agentBroadcastCalls(broadcast).length).toBeLessThanOrEqual(2);
+
+      emitAgentEvent(handler, "run-candidate-boundary", stream, data, { seq: 5 });
+      const delivered = [broadcast, broadcastToConnIds]
+        .flatMap((sink) =>
+          sink.mock.calls.flatMap(([event, payload], index) =>
+            event === "agent"
+              ? [
+                  {
+                    order: expectDefined(sink.mock.invocationCallOrder[index], "agent call order"),
+                    payload: payload as AgentEventPayload,
+                  },
+                ]
+              : [],
+          ),
+        )
+        .toSorted((a, b) => a.order - b.order)
+        .map(({ payload }) => payload);
+      expect(delivered.filter((payload) => payload.seq >= 3)).toMatchObject([
+        { seq: 3, stream: "item", data: answerCandidate("answer-1", "Hello") },
+        { seq: 4, stream: "assistant", data: { text: "Hello" } },
+        { seq: 5, stream, data },
+      ]);
+      expect(
+        delivered
+          .filter((payload) => payload.seq < 5 && payload.stream === "assistant")
+          .map((payload) => payload.data.delta)
+          .join(""),
+      ).toBe("Hello");
+
+      if (stream !== "lifecycle") {
+        emitLifecycleEnd(handler, "run-candidate-boundary", 6);
+      }
+      const completedCalls = broadcast.mock.calls.length;
+      vi.advanceTimersByTime(1_000);
+      expect(broadcast).toHaveBeenCalledTimes(completedCalls);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      handler.dispose();
+      chatRunState.clear();
+    }
+  });
+
+  it("isolates candidate batches across runs and releases an aborted run before session reuse", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const { broadcast, chatRunState, handler } = createHarness();
+    registerNamedChatRun(chatRunState, "candidate-abort");
+    registerNamedChatRun(chatRunState, "candidate-sibling");
+    const deliveredFor = (runId: string) =>
+      agentBroadcastCalls(broadcast)
+        .map(([, payload]) => payload as AgentEventPayload)
+        .filter((payload) => payload.runId === runId);
+
+    try {
+      for (const [runId, prefix] of [
+        ["run-candidate-abort", "Alpha"],
+        ["run-candidate-sibling", "Beta"],
+      ] as const) {
+        emitAgentEvents(handler, runId, [
+          ["item", answerCandidate("shared-item-id", prefix)],
+          ["assistant", { text: prefix, delta: prefix }],
+          ["item", answerCandidate("shared-item-id", `${prefix} tail`)],
+          ["assistant", { text: `${prefix} tail`, delta: " tail" }],
+        ]);
+      }
+      expect(agentBroadcastCalls(broadcast).length).toBeLessThanOrEqual(4);
+      const siblingBeforeAbort = deliveredFor("client-candidate-sibling");
+      emitAgentEvent(
+        handler,
+        "run-candidate-abort",
+        "item",
+        answerCandidate("shared-item-id", "Alpha tail", "superseded"),
+        { seq: 5 },
+      );
+      emitAgentEvent(
+        handler,
+        "run-candidate-abort",
+        "lifecycle",
+        { phase: "error", aborted: true, stopReason: "rpc" },
+        { seq: 6 },
+      );
+      expect(deliveredFor("client-candidate-sibling")).toEqual(siblingBeforeAbort);
+      expect(chatBroadcastCalls(broadcast).at(-1)?.[1]).toMatchObject({
+        runId: "client-candidate-abort",
+        state: "aborted",
+        message: { content: [{ type: "text", text: "Alpha tail" }] },
+      });
+
+      registerChatRun(chatRunState, "run-reuse", "session-candidate-abort", "client-reuse");
+      emitAgentEvents(handler, "run-reuse", [
+        ["item", answerCandidate("shared-item-id", "Fresh")],
+        ["assistant", { text: "Fresh", delta: "Fresh" }],
+        ["item", answerCandidate("shared-item-id", "Fresh", "selected")],
+        ["lifecycle", { phase: "end" }],
+      ]);
+      const abortedDeliveries = deliveredFor("client-candidate-abort");
+      vi.advanceTimersByTime(75);
+      expect(deliveredFor("client-candidate-abort")).toEqual(abortedDeliveries);
+      const sibling = deliveredFor("client-candidate-sibling");
+      expect(sibling.findLast((payload) => payload.stream === "item")?.data).toEqual(
+        answerCandidate("shared-item-id", "Beta tail"),
+      );
+      expect(
+        sibling
+          .filter((payload) => payload.stream === "assistant")
+          .map((payload) => payload.data.delta)
+          .join(""),
+      ).toBe("Beta tail");
+      emitAgentEvent(
+        handler,
+        "run-candidate-sibling",
+        "item",
+        answerCandidate("shared-item-id", "Beta tail", "selected"),
+        { seq: 5 },
+      );
+      emitLifecycleEnd(handler, "run-candidate-sibling", 6);
+      expect(
+        chatBroadcastCalls(broadcast)
+          .map(([, payload]) => payload)
+          .filter((payload) => payload.state === "final")
+          .map((payload) => [payload.runId, payload.message.content[0].text]),
+      ).toEqual([
+        ["client-reuse", "Fresh"],
+        ["client-candidate-sibling", "Beta tail"],
+      ]);
+      const completedCalls = broadcast.mock.calls.length;
+      vi.advanceTimersByTime(1_000);
+      expect(broadcast).toHaveBeenCalledTimes(completedCalls);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      handler.dispose();
+      chatRunState.clear();
+    }
+  });
+
+  it.each([
+    {
+      name: "answer candidates",
+      template: answerCandidate("", ""),
+      terminal: { status: "selected" },
+    },
+    {
+      name: "preambles",
+      template: {
+        kind: "preamble",
+        title: "Preamble",
+        phase: "update",
+        source: "codex-app-server",
+      },
+      terminal: { phase: "end" },
+    },
+  ] as const)(
+    "paces $name without merging different items or delaying their terminal",
+    ({ template, terminal }) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(10_000);
+      const { broadcast, chatRunState, handler } = createHarness();
+      registerNamedChatRun(chatRunState, "item-progress");
+      const emitUpdate = (seq: number, itemId: string, progressText: string) =>
+        emitAgentEvent(
+          handler,
+          "run-item-progress",
+          "item",
+          { ...template, itemId, progressText },
+          { seq },
+        );
+
+      try {
+        emitUpdate(1, "first-item", "First");
+        emitUpdate(2, "first-item", "First updated");
+        expect(agentBroadcastCalls(broadcast)).toHaveLength(1);
+
+        emitUpdate(3, "second-item", "Second");
+        expect(agentBroadcastCalls(broadcast).map(([, payload]) => payload)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              seq: 2,
+              data: { ...template, itemId: "first-item", progressText: "First updated" },
+            }),
+          ]),
+        );
+        emitUpdate(4, "second-item", "Second updated");
+        emitUpdate(5, "first-item", "First final");
+        const beforeTerminal = agentBroadcastCalls(broadcast).map(
+          ([, payload]) => payload as AgentEventPayload,
+        );
+        expect(beforeTerminal.findIndex((payload) => payload.seq === 4)).toBeGreaterThan(
+          beforeTerminal.findIndex((payload) => payload.seq === 2),
+        );
+
+        emitAgentEvent(
+          handler,
+          "run-item-progress",
+          "item",
+          { ...template, itemId: "first-item", progressText: "First final", ...terminal },
+          { seq: 6 },
+        );
+        expect(
+          agentBroadcastCalls(broadcast)
+            .slice(-2)
+            .map(([, payload]) => payload),
+        ).toMatchObject([
+          { seq: 5, data: { ...template, itemId: "first-item", progressText: "First final" } },
+          {
+            seq: 6,
+            data: { ...template, itemId: "first-item", progressText: "First final", ...terminal },
+          },
+        ]);
+        emitLifecycleEnd(handler, "run-item-progress", 7);
+        const completedCalls = broadcast.mock.calls.length;
+        vi.advanceTimersByTime(1_000);
+        expect(broadcast).toHaveBeenCalledTimes(completedCalls);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        handler.dispose();
+        chatRunState.clear();
+      }
+    },
+  );
+
   it("flushes trailing assistant agent text at the fixed pacing deadline", () => {
     vi.useFakeTimers();
     let now = 15_000;
@@ -971,63 +1523,6 @@ describe("agent event handler", () => {
         }
       ).data?.phase,
     ).toBe("end");
-    expect(sessionAgentCalls(nodeSendToSession)).toHaveLength(3);
-    nowSpy.mockRestore();
-  });
-
-  it("flushes pending assistant agent deltas before post-window text", () => {
-    let now = 22_000;
-    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
-    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
-    registerNamedChatRun(chatRunState, "agent-window");
-
-    emitAgentEvent(handler, "run-agent-window", "assistant", { text: "Hel", delta: "Hel" });
-    now = 22_050;
-    emitAgentEvent(
-      handler,
-      "run-agent-window",
-      "assistant",
-      { text: "Hello", delta: "lo" },
-      { seq: 2 },
-    );
-    now = 22_200;
-    emitAgentEvent(
-      handler,
-      "run-agent-window",
-      "assistant",
-      { text: "Hello!", delta: "!" },
-      { seq: 3 },
-    );
-
-    const agentCalls = agentBroadcastCalls(broadcast);
-    expect(agentCalls).toHaveLength(3);
-    expect(
-      (
-        expectDefined(agentCalls[0], "agentCalls[0] test invariant")[1] as {
-          data?: { delta?: string };
-        }
-      ).data?.delta,
-    ).toBe("Hel");
-    expect(
-      (
-        expectDefined(agentCalls[1], "agentCalls[1] test invariant")[1] as {
-          data?: { delta?: string };
-        }
-      ).data?.delta,
-    ).toBe("lo");
-    expect(
-      (expectDefined(agentCalls[1], "agentCalls[1] test invariant")[1] as { seq?: number }).seq,
-    ).toBe(2);
-    expect(
-      (
-        expectDefined(agentCalls[2], "agentCalls[2] test invariant")[1] as {
-          data?: { delta?: string };
-        }
-      ).data?.delta,
-    ).toBe("!");
-    expect(
-      (expectDefined(agentCalls[2], "agentCalls[2] test invariant")[1] as { seq?: number }).seq,
-    ).toBe(3);
     expect(sessionAgentCalls(nodeSendToSession)).toHaveLength(3);
     nowSpy.mockRestore();
   });
@@ -1850,6 +2345,7 @@ describe("agent event handler", () => {
   });
 
   it("marks non-prefix replacement deltas explicitly", () => {
+    vi.useFakeTimers();
     let now = 11_300;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
     const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
@@ -1859,6 +2355,7 @@ describe("agent event handler", () => {
 
     now = 11_500;
     emitAgentEvent(handler, "run-replacement", "assistant", { text: "Goodbye world" }, { seq: 2 });
+    vi.advanceTimersByTime(1);
 
     const chatCalls = chatBroadcastCalls(broadcast);
     expect(chatCalls).toHaveLength(2);
@@ -5098,6 +5595,226 @@ describe("agent event handler", () => {
           { dropIfSlow: true },
         );
       });
+    },
+  );
+
+  it.each(["item", "assistant"] as const)(
+    "drops queued %s progress after release without dropping another run's updates",
+    (stream) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(10_000);
+      const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+      const claim = (runId: string) =>
+        expectDefined(
+          claimAgentRunContext(
+            runId,
+            { sessionKey: `session-${runId}`, isControlUiVisible: true },
+            { exclusive: true, trackOwner: true },
+          ),
+          "preview owner claim",
+        );
+      const retiredRunId = "run-preview-retired";
+      const activeRunId = "run-preview-active";
+      const retiredClaim = claim(retiredRunId);
+      const activeClaim = claim(activeRunId);
+      const stop = onAgentRuntimeEvent(handler);
+
+      try {
+        for (const [runId, claimId] of [
+          [retiredRunId, retiredClaim],
+          [activeRunId, activeClaim],
+        ] as const) {
+          for (const [text, delta] of [
+            ["First", "First"],
+            ["First queued", " queued"],
+          ] as const) {
+            emitAgentEventForOwner(
+              {
+                runId,
+                stream,
+                data: stream === "item" ? answerCandidate("answer-1", text) : { text, delta },
+              },
+              claimId,
+            );
+          }
+        }
+        expect(agentBroadcastCalls(broadcast)).toHaveLength(2);
+
+        releaseAgentRunContext(retiredRunId, retiredClaim);
+        vi.advanceTimersByTime(75);
+
+        const delivered = agentBroadcastCalls(broadcast).map(
+          ([, payload]) => payload as AgentEventPayload,
+        );
+        const expected = [
+          [retiredRunId, "First"],
+          [activeRunId, "First"],
+          [activeRunId, "First queued"],
+        ];
+        expect(
+          delivered.map(({ runId, data }) => [
+            runId,
+            stream === "item" ? data.progressText : data.text,
+          ]),
+        ).toEqual(expected);
+        expect(sessionAgentCalls(nodeSendToSession).map((call) => call[2])).toEqual(delivered);
+        if (stream === "assistant") {
+          const chat = chatBroadcastCalls(broadcast).map(([, payload]) => payload);
+          expect(chat.map((payload) => [payload.runId, payload.message.content[0].text])).toEqual(
+            expected,
+          );
+          expect(chat.map((payload) => payload.deltaText)).toEqual(["First", "First", " queued"]);
+          expect(sessionChatCalls(nodeSendToSession).map((call) => call[2])).toEqual(chat);
+        }
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        stop();
+        releaseAgentRunContext(retiredRunId, retiredClaim);
+        releaseAgentRunContext(activeRunId, activeClaim);
+        handler.dispose();
+        chatRunState.clear();
+      }
+    },
+  );
+
+  it("starts fresh chat text when a new owner reuses a source run id with a queued tail", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const {
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      chatRunState,
+      sessionMessageSubscribers,
+      handler,
+    } = createHarness();
+    const runId = "run-owner-reuse";
+    const claim = () =>
+      expectDefined(
+        claimAgentRunContext(
+          runId,
+          { sessionKey: "session-reuse", isControlUiVisible: false },
+          { exclusive: true, trackOwner: true },
+        ),
+        "reused run owner claim",
+      );
+    const firstClaim = claim();
+    let currentClaim = firstClaim;
+    sessionMessageSubscribers.subscribe("conn-selected", "session-reuse");
+    const stop = onAgentRuntimeEvent(handler);
+    const emitText = (text: string, delta: string) =>
+      emitAgentEventForOwner({ runId, stream: "assistant", data: { text, delta } }, currentClaim);
+
+    try {
+      emitText("First", "First");
+      emitText("First queued", " queued");
+      expect(chatDeltaTexts(broadcastToConnIds)).toEqual(["First"]);
+
+      releaseAgentRunContext(runId, firstClaim);
+      currentClaim = claim();
+      emitText("Fresh", "Fresh");
+      vi.advanceTimersByTime(75);
+
+      expect(
+        chatBroadcastCalls(broadcastToConnIds).map(
+          ([, payload]) => payload.message.content[0].text,
+        ),
+      ).toEqual(["First", "Fresh"]);
+      emitAgentEventForOwner({ runId, stream: "lifecycle", data: { phase: "end" } }, currentClaim);
+      expect(chatBroadcastCalls(broadcastToConnIds).at(-1)?.[1]).toMatchObject({
+        runId,
+        state: "final",
+        message: { content: [{ type: "text", text: "Fresh" }] },
+      });
+      expect(broadcast).not.toHaveBeenCalled();
+      expect(nodeSendToSession).not.toHaveBeenCalled();
+      for (const call of broadcastToConnIds.mock.calls) {
+        expect(call[2]).toEqual(new Set(["conn-selected"]));
+      }
+      const completedCalls = broadcastToConnIds.mock.calls.length;
+      // Terminal plugin hooks clear their safety deadline after their promises settle.
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(broadcastToConnIds).toHaveBeenCalledTimes(completedCalls);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      stop();
+      releaseAgentRunContext(runId, firstClaim);
+      releaseAgentRunContext(runId, currentClaim);
+      handler.dispose();
+      chatRunState.clear();
+    }
+  });
+
+  it.each(["session change", "subscriber removal"] as const)(
+    "keeps queued hidden previews isolated across %s",
+    (change) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(10_000);
+      const {
+        broadcast,
+        broadcastToConnIds,
+        nodeSendToSession,
+        chatRunState,
+        sessionMessageSubscribers,
+        handler,
+      } = createHarness();
+      const runId = "run-hidden-audience";
+      const claimId = expectDefined(
+        claimAgentRunContext(
+          runId,
+          { sessionKey: "session-A", isControlUiVisible: false },
+          { exclusive: true, trackOwner: true },
+        ),
+        "hidden preview owner claim",
+      );
+      sessionMessageSubscribers.subscribe("conn-A", "session-A");
+      sessionMessageSubscribers.subscribe("conn-B", "session-B");
+      const stop = onAgentRuntimeEvent(handler);
+      const preview = (text: string) =>
+        emitAgentEventForOwner(
+          { runId, stream: "item", data: answerCandidate("answer-1", text) },
+          claimId,
+        );
+
+      try {
+        preview("Old visible");
+        preview("Old queued");
+        expect(agentBroadcastCalls(broadcastToConnIds)).toHaveLength(1);
+
+        if (change === "session change") {
+          registerAgentRunContext(runId, { sessionKey: "session-B" }, claimId);
+        } else {
+          sessionMessageSubscribers.unsubscribe("conn-A", "session-A");
+          vi.advanceTimersByTime(75);
+          expect(agentBroadcastCalls(broadcastToConnIds)).toHaveLength(1);
+          sessionMessageSubscribers.subscribe("conn-replacement", "session-A");
+        }
+        preview("New visible");
+        vi.advanceTimersByTime(75);
+
+        expect(
+          agentBroadcastCalls(broadcastToConnIds).map(([, event, recipients]) => {
+            const payload = event as AgentEventPayload;
+            return [payload.sessionKey, payload.data.progressText, recipients];
+          }),
+        ).toEqual([
+          ["session-A", "Old visible", new Set(["conn-A"])],
+          ...(change === "session change"
+            ? [
+                ["session-A", "Old queued", new Set(["conn-A"])],
+                ["session-B", "New visible", new Set(["conn-B"])],
+              ]
+            : [["session-A", "New visible", new Set(["conn-replacement"])]]),
+        ]);
+        expect(broadcast).not.toHaveBeenCalled();
+        expect(nodeSendToSession).not.toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        stop();
+        releaseAgentRunContext(runId, claimId);
+        handler.dispose();
+        chatRunState.clear();
+      }
     },
   );
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -376,22 +376,11 @@ type AgentEventHandler = ((event: AgentEventPayload) => void) & {
   dispose: () => void;
 };
 
-const AGENT_TEXT_THROTTLE_STREAMS = ["assistant", "thinking"] as const;
-
-type AgentTextThrottleStream = (typeof AGENT_TEXT_THROTTLE_STREAMS)[number];
+type ChatRunRecord = ReturnType<ChatRunState["getOrCreate"]>;
+type AgentTextThrottleStream = keyof NonNullable<ChatRunRecord["agentText"]>;
 type LiveTextStream = "chat" | "agent";
-type PendingLiveTextFlush = { timer: NodeJS.Timeout; flush: () => void };
-type InternalChatRunRecord = ReturnType<ChatRunState["getOrCreate"]> & {
-  pendingTextFlushes?: Partial<Record<LiveTextStream, PendingLiveTextFlush>>;
-};
 
-function internalChatRunRecord(
-  record: ReturnType<ChatRunState["getOrCreate"]>,
-): InternalChatRunRecord {
-  return record;
-}
-
-function cancelPendingLiveTextFlush(run: InternalChatRunRecord, stream: LiveTextStream): void {
+function cancelPendingLiveTextFlush(run: ChatRunRecord, stream: LiveTextStream): void {
   const pending = run.pendingTextFlushes?.[stream];
   if (!pending) {
     return;
@@ -404,7 +393,7 @@ function cancelPendingLiveTextFlush(run: InternalChatRunRecord, stream: LiveText
 }
 
 function scheduleLiveTextFlush(
-  run: InternalChatRunRecord,
+  run: ChatRunRecord,
   stream: LiveTextStream,
   delayMs: number,
   flush: () => void,
@@ -502,7 +491,7 @@ export function createAgentEventHandler({
   const cancelPendingChatDeltaFlush = (clientRunId: string) => {
     const record = chatRunState.runs.get(clientRunId);
     if (record) {
-      cancelPendingLiveTextFlush(internalChatRunRecord(record), "chat");
+      cancelPendingLiveTextFlush(record, "chat");
     }
   };
 
@@ -961,8 +950,13 @@ export function createAgentEventHandler({
     delayMs: number,
     controlUiVisible: boolean | undefined,
   ) => {
-    const run = internalChatRunRecord(chatRunState.getOrCreate(clientRunId));
+    const run = chatRunState.getOrCreate(clientRunId);
     const flush = () => {
+      if (run.bufferIsCurrent?.() === false) {
+        chatRunState.clearRun(clientRunId);
+        agentRunSeq.delete(sourceRunId);
+        return;
+      }
       const projected = chatRunState.resolveBuffer(clientRunId);
       if (projected.suppress || shouldHideHeartbeatChatOutput(clientRunId, sourceRunId)) {
         return;
@@ -981,7 +975,7 @@ export function createAgentEventHandler({
     sourceRunId: string,
     seq: number,
     input: NonNullable<ReturnType<typeof resolveAssistantLiveChatInput>>,
-    opts?: { controlUiVisible?: boolean },
+    opts?: { controlUiVisible?: boolean; isCurrent?: () => boolean },
   ) => {
     const run = chatRunState.getOrCreate(clientRunId);
     if (input.managedMediaUrls?.length) {
@@ -1008,20 +1002,20 @@ export function createAgentEventHandler({
     }
     const now = Date.now();
     run.rawBuffer = mergedRawText;
+    run.bufferIsCurrent = opts?.isCurrent;
     run.bufferUpdatedAt = now;
     if (!mergedRawText) {
       broadcastChatDelta(sessionKey, agentId, clientRunId, sourceRunId, seq, "", opts);
       return;
     }
-    const waitedMs = now - (run.deltaSentAt ?? 0);
-    if (waitedMs < LIVE_TEXT_PACING_MS) {
+    if (run.deltaSentAt !== undefined) {
       scheduleChatDeltaFlush(
         sessionKey,
         agentId,
         clientRunId,
         sourceRunId,
         seq,
-        LIVE_TEXT_PACING_MS - waitedMs,
+        LIVE_TEXT_PACING_MS - (now - run.deltaSentAt),
         opts?.controlUiVisible,
       );
       return;
@@ -1227,100 +1221,104 @@ export function createAgentEventHandler({
   const flushBufferedAgentDeltaIfNeeded = (clientRunId: string) => {
     const run = chatRunState.runs.get(clientRunId);
     if (run) {
-      cancelPendingLiveTextFlush(internalChatRunRecord(run), "agent");
+      cancelPendingLiveTextFlush(run, "agent");
     }
-    const bufferedEntries = AGENT_TEXT_THROTTLE_STREAMS.flatMap((currentStream) => {
-      const state = run?.agentText?.[currentStream];
-      const buffered = state?.bufferedEvent;
+    const states = Object.values(run?.agentText ?? {});
+    states.sort(
+      (a, b) => (a.bufferedEvent?.payload.seq ?? 0) - (b.bufferedEvent?.payload.seq ?? 0),
+    );
+    for (const state of states) {
+      const buffered = state.bufferedEvent;
       if (!buffered) {
-        return [];
+        continue;
       }
-      return [{ stream: currentStream, buffered }];
-    });
-    bufferedEntries.sort((a, b) => a.buffered.payload.seq - b.buffered.payload.seq);
-    for (const { stream: currentStream, buffered } of bufferedEntries) {
-      sendAgentPayload(buffered.sessionKey, buffered.payload, { agentId: buffered.agentId });
-      const state = run?.agentText?.[currentStream];
-      if (state) {
-        delete state.bufferedEvent;
-        state.lastSentAt = Date.now();
+      delete state.bufferedEvent;
+      if (buffered.isCurrent?.() === false) {
+        continue;
       }
+      state.lastSentAt = Date.now();
+      sendAgentPayload(buffered.sessionKey, buffered.payload, {
+        agentId: buffered.agentId,
+        controlUiVisible: buffered.controlUiVisible,
+        dropIfSlow: buffered.controlUiVisible === false,
+      });
     }
   };
 
   const resolveAgentTextThrottleStream = (
     evt: AgentEventPayload,
-  ): AgentTextThrottleStream | null =>
-    evt.stream === "assistant" ? "assistant" : evt.stream === "thinking" ? "thinking" : null;
+  ): AgentTextThrottleStream | null => {
+    if (evt.stream === "assistant" || evt.stream === "thinking") {
+      const stream = evt.stream === "assistant" ? "assistant" : "thinking";
+      return typeof evt.data.delta === "string" || evt.data.replace === true ? stream : null;
+    }
+    const { kind, phase, status, itemId, progressText } = evt.data;
+    // Growing previews share text pacing; completion and selection remain ordering barriers.
+    return evt.stream === "item" &&
+      phase === "update" &&
+      (kind === "preamble" || (kind === "answer_candidate" && status === "candidate")) &&
+      typeof itemId === "string" &&
+      typeof progressText === "string"
+      ? kind
+      : null;
+  };
 
   const shouldCoalesceAgentTextEvent = (evt: AgentEventPayload) =>
-    resolveAgentTextThrottleStream(evt) !== null &&
-    typeof evt.data?.text === "string" &&
-    typeof evt.data.delta === "string" &&
-    evt.data.delta.length > 0 &&
     !(Array.isArray(evt.data.mediaUrls) && evt.data.mediaUrls.length > 0) &&
     typeof evt.data.mediaUrl !== "string" &&
     evt.data.replace !== true &&
-    (evt.stream !== "assistant" || !shouldSuppressAssistantEventForLiveChat(evt.data));
+    (evt.stream === "item" ||
+      (typeof evt.data.text === "string" &&
+        typeof evt.data.delta === "string" &&
+        evt.data.delta.length > 0 &&
+        (evt.stream !== "assistant" || !shouldSuppressAssistantEventForLiveChat(evt.data))));
 
-  const mergeBufferedAgentPayload = (
-    previous: BufferedAgentEvent,
-    next: BufferedAgentEvent,
-  ): BufferedAgentEvent => {
-    if (previous.payload.stream !== next.payload.stream) {
-      return next;
-    }
-    const previousDelta = previous.payload.data.delta;
-    const nextDelta = next.payload.data.delta;
-    if (typeof previousDelta !== "string" || typeof nextDelta !== "string") {
-      return next;
-    }
-    return {
-      ...next,
-      payload: {
-        ...next.payload,
-        data: {
-          ...next.payload.data,
-          delta: `${previousDelta}${nextDelta}`,
-        },
-      },
-    };
-  };
-
-  const sendOrBufferAgentTextEvent = (
-    clientRunId: string,
-    sessionKey: string | undefined,
-    agentId: string | undefined,
-    payload: AgentEventPayload & { spawnedBy?: string },
-  ) => {
+  const sendOrBufferAgentTextEvent = (clientRunId: string, next: BufferedAgentEvent) => {
+    const { payload } = next;
     const stream = resolveAgentTextThrottleStream(payload);
-    if (!stream) {
-      sendAgentPayload(sessionKey, payload, { agentId });
-      return;
-    }
     const now = Date.now();
-    const run = chatRunState.getOrCreate(clientRunId);
-    const agentText = (run.agentText ??= {});
-    const state = (agentText[stream] ??= {});
-    const last = state.lastSentAt;
-    if (last !== undefined && now - last < LIVE_TEXT_PACING_MS) {
-      const nextBuffered: BufferedAgentEvent = sessionKey
-        ? { sessionKey, agentId, payload }
-        : { agentId, payload };
-      state.bufferedEvent = state.bufferedEvent
-        ? mergeBufferedAgentPayload(state.bufferedEvent, nextBuffered)
-        : nextBuffered;
-      scheduleLiveTextFlush(
-        internalChatRunRecord(run),
-        "agent",
-        LIVE_TEXT_PACING_MS - (now - last),
-        () => flushBufferedAgentDeltaIfNeeded(clientRunId),
+    const run = stream ? chatRunState.getOrCreate(clientRunId) : undefined;
+    const state = run && stream ? ((run.agentText ??= {})[stream] ??= {}) : undefined;
+    const last = state?.lastSentAt;
+    const previous = state?.bufferedEvent;
+    // Even an overdue wake owns delivery; flushing on ingress defeats batching
+    // while a busy event loop is still draining provider notifications.
+    if (
+      run &&
+      state &&
+      last !== undefined &&
+      shouldCoalesceAgentTextEvent(payload) &&
+      (!previous ||
+        (previous.payload.data.itemId === payload.data.itemId &&
+          previous.sessionKey === next.sessionKey &&
+          previous.agentId === next.agentId &&
+          previous.controlUiVisible === next.controlUiVisible &&
+          previous.isCurrent?.() !== false))
+    ) {
+      // Deltas accumulate, while item progress replaces its cumulative snapshot.
+      const delta = previous?.payload.data.delta;
+      const nextDelta = payload.data.delta;
+      state.bufferedEvent = {
+        ...next,
+        payload:
+          payload.stream !== "item" && typeof delta === "string" && typeof nextDelta === "string"
+            ? { ...payload, data: { ...payload.data, delta: `${delta}${nextDelta}` } }
+            : payload,
+      };
+      scheduleLiveTextFlush(run, "agent", LIVE_TEXT_PACING_MS - (now - last), () =>
+        flushBufferedAgentDeltaIfNeeded(clientRunId),
       );
       return;
     }
     flushBufferedAgentDeltaIfNeeded(clientRunId);
-    sendAgentPayload(sessionKey, payload, { agentId });
-    state.lastSentAt = now;
+    sendAgentPayload(next.sessionKey, payload, {
+      agentId: next.agentId,
+      controlUiVisible: next.controlUiVisible,
+      dropIfSlow: next.controlUiVisible === false,
+    });
+    if (state) {
+      state.lastSentAt = now;
+    }
   };
 
   const resolveToolVerboseLevel = (runId: string, sessionKey?: string) => {
@@ -1352,7 +1350,8 @@ export function createAgentEventHandler({
 
   const handleEvent = (event: AgentEventPayload) => {
     const evt = event as AgentEventRuntimePayload;
-    if (!shouldProcessOwnedEvent(evt)) {
+    const isCurrent = () => shouldProcessOwnedEvent(evt);
+    if (!isCurrent()) {
       return;
     }
     const lifecyclePhase =
@@ -1372,6 +1371,12 @@ export function createAgentEventHandler({
       : undefined;
     const restartRecoveryAgentId = evt.agentId ?? sessionAgentId;
     const clientRunId = chatLink?.clientRunId ?? evt.runId;
+    // A detached worker may reuse its correlation id under a new claim.
+    // Retire its old text before the new owner can append or flush it.
+    if (chatRunState.runs.get(clientRunId)?.bufferIsCurrent?.() === false) {
+      chatRunState.clearRun(clientRunId);
+      agentRunSeq.delete(evt.runId);
+    }
     const eventRunId = chatLink?.clientRunId ?? evt.runId;
     const eventForClients = chatLink ? { ...evt, runId: eventRunId } : evt;
     const isAborted =
@@ -1432,7 +1437,6 @@ export function createAgentEventHandler({
     const toolVerbose = isToolEvent ? resolveToolVerboseLevel(evt.runId, sessionKey) : "off";
     const suppressHeartbeatToolEvents =
       isToolEvent && shouldSuppressHeartbeatToolEvents(clientRunId, evt.runId);
-    const shouldCoalesceAgentEvent = shouldCoalesceAgentTextEvent(evt);
     // Channel/node subscribers respect verbose; authenticated Control UI
     // recipients need tool result payloads to render live tool cards.
     const channelToolPayload =
@@ -1625,44 +1629,31 @@ export function createAgentEventHandler({
         }
         flushBufferedAgentDeltaIfNeeded(clientRunId);
       }
-      if (isControlUiVisible) {
-        if (shouldCoalesceAgentEvent) {
-          sendOrBufferAgentTextEvent(clientRunId, sessionKey, sessionAgentId, agentPayload);
-        } else {
-          flushBufferedAgentDeltaIfNeeded(clientRunId);
-          sendAgentPayload(sessionKey, agentPayload, {
-            agentId: sessionAgentId,
-            controlUiVisible: isControlUiVisible,
-          });
-          const textThrottleStream = resolveAgentTextThrottleStream(evt);
-          if (
-            textThrottleStream &&
-            (typeof evt.data.delta === "string" || evt.data.replace === true)
-          ) {
-            const agentText = (chatRunState.getOrCreate(clientRunId).agentText ??= {});
-            (agentText[textThrottleStream] ??= {}).lastSentAt = Date.now();
-          }
-        }
-      } else if (
-        sessionKey &&
-        hasSessionMessageSubscribers &&
-        (shouldMirrorAgentEventToHiddenSessionMessages(evt) ||
-          (!isAborted &&
-            evt.stream === "assistant" &&
-            shouldMirrorAssistantEventToHiddenSessionMessages(evt.data)))
+      if (
+        isControlUiVisible ||
+        (sessionKey &&
+          hasSessionMessageSubscribers &&
+          (isItemEvent ||
+            shouldMirrorAgentEventToHiddenSessionMessages(evt) ||
+            (!isAborted &&
+              evt.stream === "assistant" &&
+              shouldMirrorAssistantEventToHiddenSessionMessages(evt.data))))
       ) {
-        sendAgentPayload(
+        sendOrBufferAgentTextEvent(clientRunId, {
           sessionKey,
-          { ...agentPayload, ...buildSessionEventSnapshot(sessionKey, undefined, sessionAgentId) },
-          { agentId: sessionAgentId, controlUiVisible: false, dropIfSlow: true },
-        );
-      }
-      if (!isControlUiVisible && isItemEvent && sessionKey && hasSessionMessageSubscribers) {
-        sendAgentPayload(
-          sessionKey,
-          { ...agentPayload, ...buildSessionEventSnapshot(sessionKey, undefined, sessionAgentId) },
-          { agentId: sessionAgentId, controlUiVisible: false, dropIfSlow: true },
-        );
+          agentId: sessionAgentId,
+          controlUiVisible: isControlUiVisible,
+          payload:
+            !isControlUiVisible && sessionKey
+              ? {
+                  ...agentPayload,
+                  ...buildSessionEventSnapshot(sessionKey, undefined, sessionAgentId),
+                }
+              : agentPayload,
+          // The client payload loses non-enumerable ownership on spread.
+          // Delayed sends must still belong to the original run claim.
+          isCurrent,
+        });
       }
     }
 
@@ -1703,6 +1694,7 @@ export function createAgentEventHandler({
             : assistantLiveChatInput,
           {
             controlUiVisible: isControlUiVisible,
+            isCurrent,
           },
         );
       }

--- a/src/tasks/task-registry-activity.ts
+++ b/src/tasks/task-registry-activity.ts
@@ -80,13 +80,13 @@ function markChanged(taskId: string, activity: TaskActivityOverlayState): void {
   scheduleFlush(taskId, activity);
 }
 
-/** Folds streaming-only fields and returns true when durable task mutation should be skipped. */
-export function recordTaskActivityEvent(task: TaskRecord, event: AgentEventPayload): boolean {
+/** Folds transient text and file activity into the in-memory task overlay. */
+export function recordTaskActivityEvent(task: TaskRecord, event: AgentEventPayload): void {
   const textStream = event.stream;
   if (textStream === "assistant" || textStream === "thinking") {
     const activity = activityFor(task);
     if (textStream === "thinking" && activity.hasAssistantActivity) {
-      return true;
+      return;
     }
     const key = textStream === "assistant" ? "assistantText" : "thinkingText";
     let cumulative: string;
@@ -95,13 +95,13 @@ export function recordTaskActivityEvent(task: TaskRecord, event: AgentEventPaylo
     } else if (typeof event.data.delta === "string") {
       cumulative = activity[key] + event.data.delta;
     } else {
-      return true;
+      return;
     }
     // Retain only a suffix for delta-only producers; full snapshots remain authoritative.
     activity[key] = sliceUtf16Safe(cumulative, -STREAM_TEXT_BUFFER_CHARS);
     const snippet = lastLineSnippet(cumulative);
     if (!snippet) {
-      return true;
+      return;
     }
     if (textStream === "assistant") {
       activity.hasAssistantActivity = true;
@@ -111,36 +111,36 @@ export function recordTaskActivityEvent(task: TaskRecord, event: AgentEventPaylo
       activity.lastActivity = snippet;
       markChanged(task.taskId, activity);
     }
-    return true;
+    return;
   }
 
   if (event.stream !== "tool") {
-    return false;
+    return;
   }
   const toolName = typeof event.data.name === "string" ? event.data.name : "";
   const kind = resolveFileMutationToolName(toolName);
   if (!kind) {
-    return false;
+    return;
   }
   const toolCallId = normalizeOptionalString(event.data.toolCallId);
   if (event.data.phase === "start") {
     const args = asOptionalObjectRecord(event.data.args);
     const delta = args ? readCompletedFileMutationDelta(kind, args) : undefined;
     if (!toolCallId || !delta) {
-      return false;
+      return;
     }
     const activity = activityFor(task);
     if (
       !activity.pendingDiffByToolCallId.has(toolCallId) &&
       activity.pendingDiffByToolCallId.size >= MAX_PENDING_DIFFS
     ) {
-      return false;
+      return;
     }
     activity.pendingDiffByToolCallId.set(toolCallId, delta);
-    return false;
+    return;
   }
   if (event.data.phase !== "result") {
-    return false;
+    return;
   }
   const activity = taskActivityByTaskId.get(task.taskId);
   const delta = toolCallId ? activity?.pendingDiffByToolCallId.get(toolCallId) : undefined;
@@ -148,7 +148,7 @@ export function recordTaskActivityEvent(task: TaskRecord, event: AgentEventPaylo
     activity?.pendingDiffByToolCallId.delete(toolCallId);
   }
   if (event.data.isError === true || !delta || !activity) {
-    return event.data.isError !== true;
+    return;
   }
   let changed = delta.added > 0 || delta.removed > 0;
   for (const file of delta.files) {
@@ -161,7 +161,6 @@ export function recordTaskActivityEvent(task: TaskRecord, event: AgentEventPaylo
     activity.removed += delta.removed;
     markChanged(task.taskId, activity);
   }
-  return true;
 }
 
 export function getTaskActivitySnapshot(taskId: string): TaskActivitySnapshot | undefined {

--- a/src/tasks/task-registry-lifecycle.ts
+++ b/src/tasks/task-registry-lifecycle.ts
@@ -43,16 +43,8 @@ function ensureListener() {
       if (isTerminalTaskStatus(current.status) || !hasAuthoritativeTaskBacking(current)) {
         continue;
       }
-      if (recordTaskActivityEvent(current, evt)) {
-        const lastEventAt = current.lastEventAt ?? current.startedAt ?? current.createdAt;
-        if (now - lastEventAt >= ACTIVITY_LIVENESS_WRITE_MS) {
-          updateTask(current.taskId, { lastEventAt: now });
-        }
-        continue;
-      }
-      const patch: Partial<TaskRecord> = {
-        lastEventAt: now,
-      };
+      recordTaskActivityEvent(current, evt);
+      const patch: Partial<TaskRecord> = {};
       if (evt.stream === "lifecycle") {
         const phase = typeof evt.data?.phase === "string" ? evt.data.phase : undefined;
         const eventStartedAt = evt.data?.startedAt;
@@ -112,6 +104,11 @@ function ensureListener() {
           patch.lastToolName = toolName;
         }
       }
+      const lastEventAt = current.lastEventAt ?? current.startedAt ?? current.createdAt;
+      if (Object.keys(patch).length === 0 && now - lastEventAt < ACTIVITY_LIVENESS_WRITE_MS) {
+        continue;
+      }
+      patch.lastEventAt = now;
       const stateChangeEvent =
         patch.status && patch.status !== current.status
           ? appendTaskEvent({

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -735,72 +735,111 @@ describe("task-registry", () => {
     });
   });
 
-  it("bounds durable liveness writes for live activity deltas", async () => {
-    await withTaskRegistryTempDir(async () => {
-      const store = createInMemoryTaskRegistryStore();
-      const upsert = vi.spyOn(store, "upsertTaskWithDeliveryState");
-      configureTaskRegistryRuntime({ store });
-      createTaskFixture("subagent", {
-        childSessionKey: "agent:main:subagent:ephemeral",
-        runId: "run-ephemeral-activity",
-        task: "Keep streaming state in memory",
-      });
-      const initialLastEventAt = requireTaskByRunId("run-ephemeral-activity").lastEventAt!;
-      upsert.mockClear();
-
-      emitAgentEvent({
-        runId: "run-ephemeral-activity",
-        stream: "thinking",
-        data: { text: "Planning" },
-      });
-      emitAgentEvent({
-        runId: "run-ephemeral-activity",
-        stream: "assistant",
-        data: { text: "Editing" },
-      });
-      expect(upsert).not.toHaveBeenCalled();
-      const dateNow = vi.spyOn(Date, "now").mockReturnValue(initialLastEventAt + 60_000);
-      try {
-        emitAgentEvent({
-          runId: "run-ephemeral-activity",
-          stream: "assistant",
-          data: { text: "Still editing" },
+  it.each(["cli", "subagent"] as const)(
+    "bounds durable liveness writes for %s live activity",
+    async (runtime) => {
+      await withTaskRegistryTempDir(async () => {
+        const store = createInMemoryTaskRegistryStore();
+        const upsert = vi.spyOn(store, "upsertTaskWithDeliveryState");
+        configureTaskRegistryRuntime({ store });
+        const runId = "run-ephemeral-activity";
+        const task = createTaskFixture(runtime, {
+          childSessionKey: "agent:main:subagent:ephemeral",
+          runId,
+          task: "Keep streaming state in memory",
         });
-      } finally {
-        dateNow.mockRestore();
-      }
-      expect(upsert).toHaveBeenCalledOnce();
-      expect(requireTaskByRunId("run-ephemeral-activity").lastEventAt).toBe(
-        initialLastEventAt + 60_000,
-      );
-      upsert.mockClear();
-      emitAgentEvent({
-        runId: "run-ephemeral-activity",
-        stream: "tool",
-        data: {
-          phase: "start",
-          name: "write",
-          toolCallId: "write-1",
-          args: { path: "src/example.ts", content: "one\ntwo" },
-        },
-      });
-      expect(upsert).toHaveBeenCalledOnce();
-      upsert.mockClear();
-      emitAgentEvent({
-        runId: "run-ephemeral-activity",
-        stream: "tool",
-        data: { phase: "result", name: "write", toolCallId: "write-1", isError: false },
-      });
+        const initialLastEventAt = requireTaskByRunId(runId).lastEventAt!;
+        const emit = (stream: string, data: Record<string, unknown>) =>
+          emitAgentEvent({ runId, stream, data });
+        const emitCandidate = (progressText: string) =>
+          emit("item", {
+            itemId: "answer-1",
+            kind: "answer_candidate",
+            title: "Answer candidate",
+            phase: "update",
+            status: "candidate",
+            progressText,
+            source: "codex-app-server",
+            hideFromChannelProgress: true,
+          });
+        const dateNow = vi.spyOn(Date, "now").mockReturnValue(initialLastEventAt);
+        upsert.mockClear();
+        try {
+          emit("thinking", { text: "Planning" });
+          let text = "";
+          for (let index = 0; index < 128; index += 1) {
+            const delta = `Line ${index + 1}\n`;
+            text += delta;
+            emitCandidate(text.trimEnd());
+            emit("assistant", { text, delta });
+          }
+          emit("item", {
+            itemId: "preamble-1",
+            kind: "preamble",
+            title: "Preamble",
+            phase: "update",
+            progressText: "Preparing the next step",
+          });
+          emit("plan", {
+            phase: "update",
+            steps: [{ step: "Write the result", status: "in_progress" }],
+          });
+          emit("usage", { outputTokens: 128 });
+          emit("codex_app_server.lifecycle", {
+            phase: "thread_ready",
+            threadId: "thread-1",
+            action: "resumed",
+          });
+          expect(upsert).not.toHaveBeenCalled();
+          expect(getTaskActivitySnapshot(task.taskId)?.lastActivity).toBe("Line 128");
 
-      expect(upsert).not.toHaveBeenCalled();
-      emitAgentEvent({
-        runId: "run-ephemeral-activity",
-        stream: "lifecycle",
-        data: { phase: "end", endedAt: 200 },
+          dateNow.mockReturnValue(initialLastEventAt + 60_000);
+          emitCandidate(text.trimEnd());
+          expect(upsert).toHaveBeenCalledOnce();
+          expect(requireTaskByRunId(runId).lastEventAt).toBe(initialLastEventAt + 60_000);
+          upsert.mockClear();
+          emit("assistant", { text: "Still editing" });
+          expect(upsert).not.toHaveBeenCalled();
+          expect(getTaskActivitySnapshot(task.taskId)?.lastActivity).toBe("Still editing");
+
+          emit("error", { error: "Observed diagnostic failure" });
+          expect(upsert).toHaveBeenCalledOnce();
+          expect(requireTaskByRunId(runId).error).toBe("Observed diagnostic failure");
+          upsert.mockClear();
+          emit("tool", {
+            phase: "start",
+            name: "write",
+            toolCallId: "write-1",
+            args: { path: "src/example.ts", content: "one\ntwo" },
+          });
+          expect(upsert).toHaveBeenCalledOnce();
+          expectRecordFields(requireTaskByRunId(runId), {
+            toolUseCount: 1,
+            lastToolName: "write",
+          });
+          upsert.mockClear();
+          emit("tool", {
+            phase: "update",
+            name: "write",
+            toolCallId: "write-1",
+            partialResult: { content: [{ type: "text", text: "Writing" }] },
+          });
+          emit("tool", {
+            phase: "result",
+            name: "write",
+            toolCallId: "write-1",
+            isError: false,
+          });
+          expect(upsert).not.toHaveBeenCalled();
+          emit("lifecycle", { phase: "end", endedAt: initialLastEventAt + 60_000 });
+          expect(upsert).toHaveBeenCalledOnce();
+          expect(requireTaskByRunId(runId).status).toBe("succeeded");
+        } finally {
+          dateNow.mockRestore();
+        }
       });
-      expect(upsert).toHaveBeenCalledOnce();
-    });
-  });
+    },
+  );
 
   it.each([
     {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users following long Codex replies would lose the Gateway connection during bursts of streaming progress, including concurrent sessions. A captured C32 failure exceeded the 50 MiB outbound-buffer limit: 52,443,608 queued bytes against a 52,428,800-byte limit.

## Why This Change Was Made

Cumulative answer previews bypassed Gateway text pacing, and incoming events could flush an overdue timer's pending work before the timer ran; transient candidate events also triggered durable task updates and synchronous observer broadcasts. The repair unifies progress delivery in the existing run-owned trailing batch, keeps delivery owned by its timer, and makes the task lifecycle owner solely responsible for the existing 60-second liveness-write policy.

This removes duplicate delivery/merge and persistence decisions, plus growing-prefix deduplication signatures. Semantic task updates remain immediate, and buffered delivery revalidates the original run claim.

Production: **174 added / 186 deleted, net −12 lines**. Tests: **877 added / 121 deleted, net +756 lines** across the seven-file change.

## User Impact

Long replies can stream through the verified single-session and concurrent workloads without progress traffic disconnecting the Gateway. Visible and subscribed private sessions share the pacing owner while retaining their audience boundaries. Selection, completion, supersession, replacement, tool/media events and cancellation preserve their ordering and lifecycle behavior.

## Evidence

- **Regression and owner coverage:** 638 focused tests passed: 357 Gateway, 133 Codex projection and 148 task-registry tests. The overdue-timer regression fails on the preceding implementation for visible and private audiences. The task regression captures 132 unwanted durable writes before the repair and zero for the same transient burst afterward, then checks the liveness interval and immediate semantic updates. Changed-surface type graphs, lint, formatting, dead-export/repository guards and the source-performance build passed; the final managed Codex review had no actionable P0–P2 findings.
- **Actual dual-harness stress:** OpenClaw's embedded harness over SSE and the real Codex 0.152.1 app-server over Responses WebSockets each passed C1/C8/C32 against the same deterministic local model endpoint. The six final cells completed **192 exact 92,160-byte replies**, with 4,096 fragments per reply, **192 successful read/exec pairs**, and **six cancellations with exec-child termination and successful reuse**. There were 582 model calls and no captured Gateway outbound-buffer events. C8/C32 used two waves with a shared arrival barrier and deliberate provider pacing. All final workload process groups and pipes joined.
- **Fresh landing-head OpenAI QA:** The [Testbox execution host](https://github.com/openclaw/openclaw/actions/runs/33692734988) ran both harnesses at commit `b651d7091b349fefb4303cf1a11ce56c877a6382` using `openai/gpt-5.6-luna`. Each produced one exact `STREAMING-FINAL-OK` final; QA records matched all six OpenClaw and three Codex selected durable transcript rows. Native Codex 0.152.1 thread/turn identity, final phase and usage reconciled. Both original-command guards matched all **36,743 source paths**, executable modes, symlinks and the committed tree. Independent offline verification checked all 39 exported members, archive hashes and unchanged original DB/WAL/SHM maps. The owned lease was stopped after export. These were **two sequential C1 QA-channel turns**, with a real provider and a local QA channel; they are not live-provider stress or external-channel proof. Audit SHA-256: `b5e6eac18f7fbe10ca5b46fc50d9faacd5ee0380cbd9b15237da7dc987329061`; independent audit: `dfa09918fe45a8a3999203d558416349d7c1c11485fb6f6556faede72cf660df`. An earlier attempt completed both turns but its final source guard did not run due to shell framing; that attempt is preserved as incomplete proof and excluded here.
- **Real dashboard flow:** An isolated Gateway, real Control UI and native Codex completed two concurrent 92,160-byte/4,096-fragment replies, then UI Stop terminated the owned exec child and the same session completed reuse. This used the original V6 production with matching UI assets and the deterministic model fixture. All 149 frames of the sanitized review videos were inspected; all owned processes exited. **Media publication limitation:** the recordings are retained locally because the proof host's classification for public capture export is unverified. They have not been uploaded. UI manifest SHA-256: `0bc8cb3cb04e70c485e6f975aed0acf9760613849c04ebda3216e1b549028e6e`.
- **Exact-head CI:** [CI run 33692334428](https://github.com/openclaw/openclaw/actions/runs/33692334428) completed successfully on `b651d7091b349fefb4303cf1a11ce56c877a6382`; the required `openclaw/ci-gate` is green. The fresh managed Codex review and [ClawSweeper review](https://github.com/openclaw/openclaw/pull/136705#issuecomment-5517602107) have no actionable findings.

A separate matched Codex C8 comparison used the identical earlier fixture on both sides. Its baseline was an **intermediate candidate that already included initial preview batching**, not unmodified main. Only the overdue-timer and task-owner repairs changed within this pair:

| Wave | Wall time before → after | Gateway CPU reduction | Sampled total CPU reduction | Peak sum RSS before → after |
| --- | --- | --- | --- | --- |
| 1 | 24.993 → 9.996 s | 59.8% | 42.1% | 1,931 → 1,589 MiB |
| 2 | 26.277 → 9.011 s | 64.1% | 54.0% | 1,480 → 1,625 MiB |

Thirty-second idle RSS fell 1,078 → 963 MiB, but **second-wave peak RSS increased 9.8%**. This is one before/after pair with different observed host load, not a robust general speedup or memory-reduction claim. Sampled CPU covers the Gateway and observed descendants, excluding the model fixture/controller/observer; short-child exit tails can be unknown. RSS sums can double-count shared pages and miss peaks. Failed and differently paced runs remain excluded from accepted performance comparisons; the six final cells were rerun on one common corrected fixture.

The dependency contract was checked directly against Codex 0.152.1's [item delta and lifecycle notification mapping](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/app-server-protocol/src/protocol/event_mapping.rs#L362-L419). This repairs OpenClaw's progress and task-liveness owners.

**Named follow-up:** Separate transient HTTP 500 failover retry reasons from terminal provider-timeout attribution. The fixture failure exposed this unchanged cross-provider error-classification path; it is recorded separately and is outside this repair.

The landing candidate is based on main at `1e6ac901341cb8754f60f519db56c55f5f18ca47`. All seven edited base files were unchanged from the earlier stress-test base; the seven-file patch is byte-identical (SHA-256 `e2ef2adb38da8e019381c780a7b7b4c0786d516c79cdb0cd65aed751d7d95ab7`). The recorded stress metrics retain that earlier source identity.
