### PR TITLE
fix(ui): align board menu labels and sizing

### DIFF
--- a/ui/src/components/board/board-view.test.ts
+++ b/ui/src/components/board/board-view.test.ts
@@ -672,7 +672,7 @@ describe("openclaw-board-view", () => {
     expect(refreshWidgetAppView).not.toHaveBeenCalled();
   });
 
-  it("shows stale MCP Apps with retry and remove without breaking the board", async () => {
+  it("shows stale MCP Apps with retry and delete without breaking the board", async () => {
     if (!customElements.get("mcp-app-view")) {
       customElements.define("mcp-app-view", class extends HTMLElement {});
     }
@@ -698,7 +698,7 @@ describe("openclaw-board-view", () => {
     const buttons = view.querySelectorAll<HTMLButtonElement>(
       '[data-test-id="board-mcp-app-stale"] button',
     );
-    expect([...buttons].map((button) => button.textContent?.trim())).toEqual(["Retry", "Remove"]);
+    expect([...buttons].map((button) => button.textContent?.trim())).toEqual(["Retry", "Delete"]);
     buttons[1]?.click();
     await vi.waitFor(() =>
       expect(applyOps).toHaveBeenCalledWith([{ kind: "widget_remove", name: "alpha" }]),

--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -753,31 +753,39 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
     });
   }
 
-  it("renders the remove action with the menu font size and a leading trash icon", async () => {
+  it("renders consistent menu options with a leading trash icon", async () => {
     const page = await browser.newPage();
     try {
       await page.goto(fixtureServer.url, { waitUntil: "networkidle" });
       await openWidgetMenu(page);
       const presentation = await page
         .locator(".board-widget__menu[open] .board-widget__menu-danger")
-        .evaluate((remove) => {
-          const preset = remove.parentElement?.querySelector(".board-widget__preset");
-          const icon = remove.querySelector('[slot="icon"]');
-          if (!(preset instanceof HTMLElement)) {
-            throw new Error("board fixture menu did not expose a resize preset");
+        .evaluate((action) => {
+          const menu = action.parentElement;
+          const move = menu?.querySelector('wa-dropdown-item[value^="move:"]');
+          const preset = menu?.querySelector(".board-widget__preset");
+          const icon = action.querySelector('[slot="icon"]');
+          if (!(move instanceof HTMLElement) || !(preset instanceof HTMLElement)) {
+            throw new Error("board fixture menu did not expose move and resize options");
           }
           return {
-            fontSize: getComputedStyle(remove).fontSize,
+            actionFontSize: getComputedStyle(action).fontSize,
+            actionText: action.textContent?.trim(),
             iconHidden: icon?.getAttribute("aria-hidden"),
             iconSvg: Boolean(icon?.querySelector("svg")),
+            moveFontSize: getComputedStyle(move).fontSize,
             presetFontSize: getComputedStyle(preset).fontSize,
           };
         });
       expect({
-        fontSizesMatch: presentation.fontSize === presentation.presetFontSize,
+        actionText: presentation.actionText,
+        fontSizesMatch:
+          presentation.moveFontSize === presentation.presetFontSize &&
+          presentation.actionFontSize === presentation.presetFontSize,
         iconHidden: presentation.iconHidden,
         iconSvg: presentation.iconSvg,
       }).toEqual({
+        actionText: "Delete",
         fontSizesMatch: true,
         iconHidden: "true",
         iconSvg: true,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3910,7 +3910,7 @@ export const en: TranslationMap & {
       noOtherTabs: "No other tabs",
       resize: "Resize",
       autoHeight: "Auto height",
-      remove: "Remove",
+      remove: "Delete",
       needsApproval: "Needs approval",
       needsApprovalDetail: "This widget requested additional access.",
       networkAccess: "Network origins",

--- a/ui/src/styles/board.css
+++ b/ui/src/styles/board.css
@@ -271,8 +271,7 @@ openclaw-board-widget-cell {
   padding: 5px 9px;
 }
 
-.board-widget__preset,
-.board-widget__menu-danger {
+.board-widget__menu wa-dropdown-item {
   font-size: 11px;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where board widget destination rows used larger text than the resize options, while the destructive action still read “Remove.”

## Why This Change Was Made

The board menu now owns one font-size rule for every dropdown item instead of styling only resize and destructive rows. The shared board action copy now says “Delete,” so menu, stale-widget, and rejected-widget removal controls use the same wording.

## User Impact

Board widget menus present tab destinations, resize choices, and Delete at a consistent size, with the trash icon retained on the destructive row.

## Evidence

| Before | After |
| --- | --- |
| ![Before: Operations is larger and the action says Remove](https://github.com/user-attachments/assets/76e63c2f-e2c1-49f7-be5e-9f5e27929125) | ![After: all menu options match and the action says Delete](https://github.com/user-attachments/assets/9d512f34-618e-4101-9cf8-7853717cbfd4) |

Interaction proof:

https://github.com/user-attachments/assets/4f673ee8-a556-4cef-9aec-3c530a2b3aa7

- Regression proof failed before the production edit with `actionText: Remove` and `fontSizesMatch: false`, then passed with `actionText: Delete` and all menu rows at 11px.
- `node scripts/run-vitest.mjs ui/src/e2e/board-fixture.e2e.test.ts` — 17 passed.
- `node scripts/run-vitest.mjs ui/src/components/board/board-view.test.ts` — 41 passed, including the stale-widget Delete copy.
- Control UI i18n verification, UI/core typechecks, OXLint, stylelint, formatting, and repository policy guards passed locally. The sparse checkout could not resolve the advisory full-tree Knip graph; exact-head CI covers the full workspace.
- Fresh autoreview: no accepted/actionable findings.
