### PR TITLE
fix: gateway restart hangs while followup drain retries a draining error

### DIFF
--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -420,12 +420,15 @@ describe("followup queue drain restart after idle window", () => {
     const firstFailed = createDeferred();
     const delivered = createDeferred();
     let attempts = 0;
-    let signal: ReturnType<typeof beginGatewayRestartSignalAdmission>;
+    let signal: ReturnType<typeof beginGatewayRestartSignalAdmission> = null;
 
     const runFollowup = async () => {
       attempts += 1;
       if (attempts === 1) {
         signal = beginGatewayRestartSignalAdmission();
+        if (!signal) {
+          throw new Error("expected restart-signal fence");
+        }
         firstFailed.resolve();
         throw new GatewayDrainingError();
       }

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -7,6 +7,7 @@ import {
   withPreparedModelRuntimePluginGenerationScope,
 } from "../../agents/prepared-model-runtime-generation-scope.js";
 import {
+  beginGatewayRestartSignalAdmission,
   GatewayDrainingError,
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
@@ -406,6 +407,48 @@ describe("followup queue drain restart after idle window", () => {
       });
       expect(attempts).toBe(1);
       expect(getExistingFollowupQueue(key)?.items).toHaveLength(1);
+    } finally {
+      clearSessionQueues([key]);
+      resetGatewayWorkAdmission();
+    }
+  });
+
+  it("resumes a queued followup after a restart-signal fence rolls back", async () => {
+    resetGatewayWorkAdmission();
+    const key = `test-restart-signal-rollback-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const firstFailed = createDeferred();
+    const delivered = createDeferred();
+    let attempts = 0;
+    let signal: ReturnType<typeof beginGatewayRestartSignalAdmission>;
+
+    const runFollowup = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        signal = beginGatewayRestartSignalAdmission();
+        firstFailed.resolve();
+        throw new GatewayDrainingError();
+      }
+      delivered.resolve();
+    };
+
+    try {
+      enqueueFollowupRun(key, createRun({ prompt: "queued during pending restart" }), settings);
+      scheduleFollowupDrain(key, runFollowup);
+      await firstFailed.promise;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(attempts).toBe(1);
+      expect(getExistingFollowupQueue(key)?.items).toHaveLength(1);
+      expect(signal?.rollback()).toBe(true);
+      await vi.waitFor(() => {
+        expect(attempts).toBe(2);
+      });
+      await delivered.promise;
+      await vi.waitFor(() => {
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+      });
     } finally {
       clearSessionQueues([key]);
       resetGatewayWorkAdmission();

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -417,19 +417,19 @@ describe("followup queue drain restart after idle window", () => {
     resetGatewayWorkAdmission();
     const key = `test-restart-signal-rollback-${Date.now()}`;
     const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
-    const firstFailed = createDeferred();
+    const firstFailed =
+      createDeferred<NonNullable<ReturnType<typeof beginGatewayRestartSignalAdmission>>>();
     const delivered = createDeferred();
     let attempts = 0;
-    let signal: ReturnType<typeof beginGatewayRestartSignalAdmission> = null;
 
     const runFollowup = async () => {
       attempts += 1;
       if (attempts === 1) {
-        signal = beginGatewayRestartSignalAdmission();
+        const signal = beginGatewayRestartSignalAdmission();
         if (!signal) {
           throw new Error("expected restart-signal fence");
         }
-        firstFailed.resolve();
+        firstFailed.resolve(signal);
         throw new GatewayDrainingError();
       }
       delivered.resolve();
@@ -438,13 +438,13 @@ describe("followup queue drain restart after idle window", () => {
     try {
       enqueueFollowupRun(key, createRun({ prompt: "queued during pending restart" }), settings);
       scheduleFollowupDrain(key, runFollowup);
-      await firstFailed.promise;
+      const signal = await firstFailed.promise;
       await new Promise<void>((resolve) => {
         setImmediate(resolve);
       });
       expect(attempts).toBe(1);
       expect(getExistingFollowupQueue(key)?.items).toHaveLength(1);
-      expect(signal?.rollback()).toBe(true);
+      expect(signal.rollback()).toBe(true);
       await vi.waitFor(() => {
         expect(attempts).toBe(2);
       });

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -7,8 +7,10 @@ import {
   withPreparedModelRuntimePluginGenerationScope,
 } from "../../agents/prepared-model-runtime-generation-scope.js";
 import {
+  GatewayDrainingError,
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
+  markGatewayRestartDraining,
   resetGatewayWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
   tryBeginGatewaySuspendAdmission,
@@ -377,6 +379,37 @@ describe("followup queue drain restart after idle window", () => {
     expect(calls).toHaveLength(2);
     expect(calls[0]?.prompt).toBe("wait-for-lane");
     expect(calls[1]?.prompt).toBe("wait-for-lane");
+  });
+
+  it("does not reschedule a drain after an active restart-drain rejection", async () => {
+    resetGatewayWorkAdmission();
+    const key = `test-restart-drain-rejection-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const firstFailed = createDeferred();
+    let attempts = 0;
+
+    const runFollowup = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        markGatewayRestartDraining();
+        firstFailed.resolve();
+        throw new GatewayDrainingError();
+      }
+    };
+
+    try {
+      enqueueFollowupRun(key, createRun({ prompt: "queued during restart" }), settings);
+      scheduleFollowupDrain(key, runFollowup);
+      await firstFailed.promise;
+      await vi.waitFor(() => {
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+      });
+      expect(attempts).toBe(1);
+      expect(getExistingFollowupQueue(key)?.items).toHaveLength(1);
+    } finally {
+      clearSessionQueues([key]);
+      resetGatewayWorkAdmission();
+    }
   });
 
   it("refreshes the callback used by a deferred active-drain retry", async () => {

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -406,7 +406,72 @@ describe("followup queue drain restart after idle window", () => {
         expect(getActiveGatewayRootWorkCount()).toBe(0);
       });
       expect(attempts).toBe(1);
-      expect(getExistingFollowupQueue(key)?.items).toHaveLength(1);
+      expect(getExistingFollowupQueue(key)).toBeUndefined();
+    } finally {
+      clearSessionQueues([key]);
+      resetGatewayWorkAdmission();
+    }
+  });
+
+  it("retries a draining error when restart admission remains open", async () => {
+    resetGatewayWorkAdmission();
+    const key = `test-draining-error-with-open-admission-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const delivered = createDeferred();
+    let attempts = 0;
+
+    const runFollowup = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new GatewayDrainingError();
+      }
+      delivered.resolve();
+    };
+
+    try {
+      enqueueFollowupRun(key, createRun({ prompt: "retry while admission is open" }), settings);
+      scheduleFollowupDrain(key, runFollowup);
+      await delivered.promise;
+      await vi.waitFor(() => {
+        expect(getExistingFollowupQueue(key)).toBeUndefined();
+      });
+      expect(attempts).toBe(2);
+    } finally {
+      clearSessionQueues([key]);
+      resetGatewayWorkAdmission();
+    }
+  });
+
+  it("does not reschedule when a restart-signal fence commits to drain", async () => {
+    resetGatewayWorkAdmission();
+    const key = `test-restart-signal-commit-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const firstFailed =
+      createDeferred<NonNullable<ReturnType<typeof beginGatewayRestartSignalAdmission>>>();
+    let attempts = 0;
+
+    const runFollowup = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        const signal = beginGatewayRestartSignalAdmission();
+        if (!signal) {
+          throw new Error("expected restart-signal fence");
+        }
+        firstFailed.resolve(signal);
+        throw new GatewayDrainingError();
+      }
+    };
+
+    try {
+      enqueueFollowupRun(key, createRun({ prompt: "queued during restart commit" }), settings);
+      scheduleFollowupDrain(key, runFollowup);
+      await firstFailed.promise;
+      markGatewayRestartDraining();
+      await vi.waitFor(() => {
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+      });
+      expect(attempts).toBe(1);
+      expect(getExistingFollowupQueue(key)).toBeUndefined();
     } finally {
       clearSessionQueues([key]);
       resetGatewayWorkAdmission();
@@ -452,6 +517,7 @@ describe("followup queue drain restart after idle window", () => {
       await vi.waitFor(() => {
         expect(getActiveGatewayRootWorkCount()).toBe(0);
       });
+      expect(getExistingFollowupQueue(key)).toBeUndefined();
     } finally {
       clearSessionQueues([key]);
       resetGatewayWorkAdmission();
@@ -819,5 +885,51 @@ describe("followup queue drain restart after idle window", () => {
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.prompt).toBe("before-idle");
+  });
+
+  it("retires queued followups and callbacks when one-way restart drain begins", async () => {
+    resetGatewayWorkAdmission();
+    const key = `test-lifecycle-restart-clears-queue-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const abandoned = vi.fn();
+    const settled = vi.fn();
+    const staleCalls: FollowupRun[] = [];
+    const queued = createRun({ prompt: "retire on lifecycle restart" });
+    queued.turnAdoptionLifecycle = {
+      admission: "cancel-only",
+      onAdopted: async () => {},
+      onAbandoned: abandoned,
+      onSettled: settled,
+    };
+
+    try {
+      enqueueFollowupRun(
+        key,
+        queued,
+        settings,
+        "message-id",
+        async (run) => {
+          staleCalls.push(run);
+        },
+        false,
+      );
+      expect(getExistingFollowupQueue(key)?.items).toEqual([queued]);
+
+      markGatewayRestartDraining();
+
+      expect(getExistingFollowupQueue(key)).toBeUndefined();
+      expect(abandoned).toHaveBeenCalledOnce();
+      expect(settled).toHaveBeenCalledOnce();
+      resetGatewayWorkAdmission();
+      enqueueFollowupRun(key, createRun({ prompt: "fresh lifecycle" }), settings);
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(staleCalls).toHaveLength(0);
+      expect(getExistingFollowupQueue(key)?.items).toHaveLength(1);
+    } finally {
+      clearSessionQueues([key]);
+      resetGatewayWorkAdmission();
+    }
   });
 });

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -17,7 +17,10 @@ import {
   channelRouteCompactKey,
   channelRouteDedupeKey,
 } from "../../../plugin-sdk/channel-route.js";
-import { runWithGatewayIndependentRootWorkContinuation } from "../../../process/gateway-work-admission.js";
+import {
+  isGatewayRestartDrainError,
+  runWithGatewayIndependentRootWorkContinuation,
+} from "../../../process/gateway-work-admission.js";
 import { defaultRuntime } from "../../../runtime.js";
 import {
   buildPersistedUserTurnMediaInputsFromFields,
@@ -1428,6 +1431,7 @@ export function scheduleFollowupDrain(
   const drainQueuedFollowups = async (): Promise<void> => {
     let retryDeferred = false;
     let waitingForSteer = false;
+    let restartDrainRejected = false;
     try {
       const collectState = { forceIndividualCollect: false };
       while (queue.items.length > 0 || queue.droppedCount > 0) {
@@ -1664,6 +1668,11 @@ export function scheduleFollowupDrain(
       queue.lastEnqueuedAt = Date.now();
       if (isFollowupRunDeferredError(err)) {
         retryDeferred = true;
+      } else if (isGatewayRestartDrainError(err)) {
+        // Restart drain is one-way; another generation cannot succeed.
+        // Persistence/replay stays with that owner. Rescheduling here
+        // keeps the dying process alive until SIGKILL.
+        restartDrainRejected = true;
       } else {
         defaultRuntime.error?.(`followup queue drain failed for ${key}: ${String(err)}`);
       }
@@ -1675,17 +1684,19 @@ export function scheduleFollowupDrain(
         queue.draining = false;
         delete queue.drainOwner;
         const hasPendingQueueWork = queue.items.length > 0 || queue.droppedCount > 0;
-        if (waitingForSteer && hasPendingQueueWork) {
-          if (!queue.items.some((item) => item.steerPending)) {
+        if (!restartDrainRejected) {
+          if (waitingForSteer && hasPendingQueueWork) {
+            if (!queue.items.some((item) => item.steerPending)) {
+              scheduleFollowupDrain(key, effectiveRunFollowup);
+            }
+          } else if (retryDeferred && hasPendingQueueWork) {
+            scheduleFollowupDrain(key, effectiveRunFollowup);
+          } else if (!hasPendingQueueWork) {
+            FOLLOWUP_QUEUES.delete(key);
+            clearFollowupDrainCallback(key);
+          } else {
             scheduleFollowupDrain(key, effectiveRunFollowup);
           }
-        } else if (retryDeferred && hasPendingQueueWork) {
-          scheduleFollowupDrain(key, effectiveRunFollowup);
-        } else if (!hasPendingQueueWork) {
-          FOLLOWUP_QUEUES.delete(key);
-          clearFollowupDrainCallback(key);
-        } else {
-          scheduleFollowupDrain(key, effectiveRunFollowup);
         }
       }
     }

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -19,7 +19,9 @@ import {
 } from "../../../plugin-sdk/channel-route.js";
 import {
   isGatewayRestartDrainError,
+  isGatewayRestartDraining,
   runWithGatewayIndependentRootWorkContinuation,
+  waitForGatewayRestartFenceSettlement,
 } from "../../../process/gateway-work-admission.js";
 import { defaultRuntime } from "../../../runtime.js";
 import {
@@ -1669,10 +1671,11 @@ export function scheduleFollowupDrain(
       if (isFollowupRunDeferredError(err)) {
         retryDeferred = true;
       } else if (isGatewayRestartDrainError(err)) {
-        // Restart drain is one-way; another generation cannot succeed.
-        // Persistence/replay stays with that owner. Rescheduling here
-        // keeps the dying process alive until SIGKILL.
-        restartDrainRejected = true;
+        // Pending-signal fences can roll back. Wait, then stop only if
+        // one-way restart drain is still active. Rescheduling a committed
+        // drain keeps the dying process alive until SIGKILL.
+        await waitForGatewayRestartFenceSettlement();
+        restartDrainRejected = isGatewayRestartDraining();
       } else {
         defaultRuntime.error?.(`followup queue drain failed for ${key}: ${String(err)}`);
       }

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -18,8 +18,8 @@ import {
   channelRouteDedupeKey,
 } from "../../../plugin-sdk/channel-route.js";
 import {
+  getGatewayRestartDrainSignal,
   isGatewayRestartDrainError,
-  isGatewayRestartDraining,
   runWithGatewayIndependentRootWorkContinuation,
   waitForGatewayRestartFenceSettlement,
 } from "../../../process/gateway-work-admission.js";
@@ -43,7 +43,7 @@ import {
   waitForQueueDebounce,
 } from "../../../utils/queue-helpers.js";
 import { isRoutableChannel } from "../route-reply.js";
-import { FOLLOWUP_QUEUES, trimSummaryElisionsToCap } from "./state.js";
+import { clearFollowupQueue, FOLLOWUP_QUEUES, trimSummaryElisionsToCap } from "./state.js";
 import {
   admitFollowupRunLifecycle,
   completeFollowupRunLifecycle,
@@ -71,6 +71,27 @@ const FOLLOWUP_DRAIN_CALLBACKS_KEY = Symbol.for("openclaw.followupDrainCallbacks
 const FOLLOWUP_RUN_CALLBACKS = resolveGlobalMap<string, (run: FollowupRun) => Promise<void>>(
   FOLLOWUP_DRAIN_CALLBACKS_KEY,
 );
+let followedRestartDrainSignal: AbortSignal | undefined;
+
+function bindFollowupRestartDrainSignal(): void {
+  const signal = getGatewayRestartDrainSignal();
+  if (signal === followedRestartDrainSignal) {
+    return;
+  }
+  followedRestartDrainSignal = signal;
+  signal.addEventListener(
+    "abort",
+    () => {
+      // Durable input recovery owns restart replay. Retire process-local queue
+      // authority synchronously so it cannot keep the old Gateway alive.
+      for (const key of FOLLOWUP_RUN_CALLBACKS.keys()) {
+        clearFollowupQueue(key);
+      }
+      FOLLOWUP_RUN_CALLBACKS.clear();
+    },
+    { once: true },
+  );
+}
 
 const QUEUED_ADMISSION_OWNER_STATE_KEY = Symbol.for("openclaw.queuedAdmissionOwnerState");
 const queuedAdmissionOwnerState = resolveGlobalSingleton(QUEUED_ADMISSION_OWNER_STATE_KEY, () => ({
@@ -123,6 +144,7 @@ export function rememberFollowupDrainCallback(
   key: string,
   runFollowup: (run: FollowupRun) => Promise<void>,
 ): void {
+  bindFollowupRestartDrainSignal();
   FOLLOWUP_RUN_CALLBACKS.set(key, runFollowup);
 }
 
@@ -1433,7 +1455,6 @@ export function scheduleFollowupDrain(
   const drainQueuedFollowups = async (): Promise<void> => {
     let retryDeferred = false;
     let waitingForSteer = false;
-    let restartDrainRejected = false;
     try {
       const collectState = { forceIndividualCollect: false };
       while (queue.items.length > 0 || queue.droppedCount > 0) {
@@ -1671,11 +1692,9 @@ export function scheduleFollowupDrain(
       if (isFollowupRunDeferredError(err)) {
         retryDeferred = true;
       } else if (isGatewayRestartDrainError(err)) {
-        // Pending-signal fences can roll back. Wait, then stop only if
-        // one-way restart drain is still active. Rescheduling a committed
-        // drain keeps the dying process alive until SIGKILL.
+        // A reversible signal fence may reopen. One-way abort synchronously
+        // retires the queue above; rollback leaves it here for normal retry.
         await waitForGatewayRestartFenceSettlement();
-        restartDrainRejected = isGatewayRestartDraining();
       } else {
         defaultRuntime.error?.(`followup queue drain failed for ${key}: ${String(err)}`);
       }
@@ -1687,19 +1706,17 @@ export function scheduleFollowupDrain(
         queue.draining = false;
         delete queue.drainOwner;
         const hasPendingQueueWork = queue.items.length > 0 || queue.droppedCount > 0;
-        if (!restartDrainRejected) {
-          if (waitingForSteer && hasPendingQueueWork) {
-            if (!queue.items.some((item) => item.steerPending)) {
-              scheduleFollowupDrain(key, effectiveRunFollowup);
-            }
-          } else if (retryDeferred && hasPendingQueueWork) {
-            scheduleFollowupDrain(key, effectiveRunFollowup);
-          } else if (!hasPendingQueueWork) {
-            FOLLOWUP_QUEUES.delete(key);
-            clearFollowupDrainCallback(key);
-          } else {
+        if (waitingForSteer && hasPendingQueueWork) {
+          if (!queue.items.some((item) => item.steerPending)) {
             scheduleFollowupDrain(key, effectiveRunFollowup);
           }
+        } else if (retryDeferred && hasPendingQueueWork) {
+          scheduleFollowupDrain(key, effectiveRunFollowup);
+        } else if (!hasPendingQueueWork) {
+          FOLLOWUP_QUEUES.delete(key);
+          clearFollowupDrainCallback(key);
+        } else {
+          scheduleFollowupDrain(key, effectiveRunFollowup);
         }
       }
     }

--- a/test/gateway-queued-session-rotation.e2e.test.ts
+++ b/test/gateway-queued-session-rotation.e2e.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { GatewayChatClient } from "../src/tui/gateway-chat.js";
@@ -297,6 +298,130 @@ describe("Gateway queued session rotation", () => {
         expect(JSON.stringify(modelServer.requests[1]?.body)).toContain("OPENCLAW_E2E_AFTER_RESET");
       } finally {
         await client.abortChat({ sessionKey }).catch(() => undefined);
+        void client.stop();
+        modelServer.releaseHeldResponse();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "stops without retrying a queued followup during shutdown",
+    async () => {
+      const fixtureDir = await mkdtemp(path.join(tmpdir(), "openclaw-followup-restart-"));
+      cleanupDirs.push(fixtureDir);
+      const modelServer = await startMockModelServer();
+      modelServers.push(modelServer);
+      const modelRef = "queued-rotation/queued-rotation";
+      const config = {
+        agents: {
+          defaults: {
+            workspace: path.join(fixtureDir, "workspace"),
+            model: { primary: modelRef },
+            models: { [modelRef]: { agentRuntime: { id: "openclaw" } } },
+            skills: [],
+            skipBootstrap: true,
+          },
+          list: [{ id: "main", default: true, model: { primary: modelRef }, skills: [] }],
+        },
+        tools: { profile: "minimal" },
+        models: {
+          mode: "replace",
+          providers: {
+            "queued-rotation": {
+              baseUrl: `${modelServer.baseUrl}/v1`,
+              apiKey: "secret-token",
+              api: "openai-responses",
+              request: { allowPrivateNetwork: true },
+              models: [
+                {
+                  id: "queued-rotation",
+                  name: "queued-rotation",
+                  api: "openai-responses",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128_000,
+                  maxTokens: 4_096,
+                },
+              ],
+            },
+          },
+        },
+        messages: { queue: { mode: "followup" } },
+      } satisfies OpenClawConfig;
+      const instance = await createOpenClawTestInstance({
+        name: "followup-drain-restart",
+        gatewayToken: "secret-token",
+        config,
+        env: {
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        },
+      });
+      instances.push(instance);
+      await instance.startGateway();
+
+      const client = new GatewayChatClient({
+        url: instance.url,
+        token: "secret-token",
+      });
+      client.start();
+      await client.waitForReady();
+      const sessionKey = "agent:main:followup-drain-restart-e2e";
+      let queuedSourceSettled = false;
+      client.onEvent = ({ event, payload }) => {
+        if (
+          event === "chat" &&
+          isRecord(payload) &&
+          payload.runId === "followup-restart-queued" &&
+          payload.state === "final"
+        ) {
+          queuedSourceSettled = true;
+        }
+      };
+      try {
+        const first = await client.sendChat({
+          sessionKey,
+          message: "OPENCLAW_E2E_HELD_BEFORE_RESTART",
+          runId: "followup-restart-held",
+        });
+        expect(first.status).toBe("started");
+        await vi.waitFor(() => expect(modelServer.requests).toHaveLength(1), WAIT_OPTS);
+
+        const second = await client.sendChat({
+          sessionKey,
+          message: "OPENCLAW_E2E_QUEUED_DURING_RESTART",
+          runId: "followup-restart-queued",
+        });
+        expect(second.status).toBe("started");
+        await vi.waitFor(() => {
+          expect(queuedSourceSettled).toBe(true);
+          expect(modelServer.requests).toHaveLength(1);
+        }, WAIT_OPTS);
+
+        const child = instance.child;
+        if (!child) {
+          throw new Error("gateway child is missing");
+        }
+        child.kill("SIGTERM");
+        await vi.waitFor(
+          () => expect(instance.logs()).toContain("received SIGTERM; shutting down"),
+          WAIT_OPTS,
+        );
+        modelServer.releaseHeldResponse();
+
+        await vi.waitFor(() => {
+          const exited = child.exitCode !== null || child.signalCode !== null;
+          const drainFailures = instance.logs().match(/followup queue drain failed/g)?.length ?? 0;
+          expect(exited || drainFailures >= 2).toBe(true);
+        }, WAIT_OPTS);
+
+        const drainFailures = instance.logs().match(/followup queue drain failed/g)?.length ?? 0;
+        expect(drainFailures).toBe(0);
+        expect(modelServer.requests).toHaveLength(1);
+        expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+      } finally {
         void client.stop();
         modelServer.releaseHeldResponse();
       }


### PR DESCRIPTION
Closes #136684

## What Problem This Solves

Fixes an issue where operators restarting a Gateway with a queued follow-up could wait several minutes for shutdown. The queued turn retried after restart admission rejected it, so the old Gateway stayed active until its shutdown deadline.

## Why This Change Was Made

The follow-up queue now follows the existing one-way restart signal. When restart drain commits, it retires process-local queue work and its old callback before the Gateway inspects active work. A reversible restart-signal fence still waits for settlement and retries after rollback.

Durable accepted-input recovery remains the restart owner. The old in-memory queue and execution authority do not cross restart, as documented in `docs/gateway/restart-recovery.md`.

## User Impact

A Gateway with a queued follow-up can finish a supervised restart on the normal shutdown path instead of emitting a retry burst until forced termination. If restart signal admission rolls back, the queued follow-up resumes normally.

## Evidence

Current-main red at `3100ba535f1d003d67a6a7536deacf8666367b38`:

- Blacksmith child-Gateway run: https://github.com/openclaw/openclaw/actions/runs/33711422936
- One held model turn, one confirmed queued same-session follow-up, then `SIGTERM`.
- Queued case reached the real follow-up admission path and emitted `7` `followup queue drain failed` events.
- No-queue control emitted `0` drain failures.

Exact repaired tree at `2baff4f9ed3f84dc9493149dcc20fed441c9baea`:

- Blacksmith exact-tree run: https://github.com/openclaw/openclaw/actions/runs/33714572460
- The same child-Gateway scenario emitted no retry burst and exited in `3.465s`.
- `src/auto-reply/reply/queue.drain-restart.test.ts`: `29` passed.
- `test/gateway-queued-session-rotation.e2e.test.ts`: `2` passed.
- Materialized source hashes matched the local commit on https://github.com/openclaw/openclaw/actions/runs/33715159753.
- Type-aware Oxlint passed on all touched files.
- Oxfmt and `git diff --check` passed.

The focused tests also cover:

- a typed draining error while restart admission stays open;
- restart-signal rollback and queue resume;
- restart-signal promotion to one-way drain;
- synchronous retirement of queued turn ownership and stale callbacks.

Production LOC: `+33/-2` (net `+31`). The growth binds queue authority to the existing restart signal and closes the user-visible shutdown lifecycle gap. Tests: `+316/-0`.

## AI Assistance

AI-assisted repair. The contributor's original restart-fence distinction and credit are preserved. Maintainer follow-up added the real Gateway reproduction, lifecycle retirement, and exact-head proof.
