### PR TITLE
fix(skills): avoid eager discovery for ordinary replies

### DIFF
--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -18,7 +18,7 @@ import {
   hasSkillReferenceCandidate,
   listReservedChatSlashCommandNames,
   resolveSkillCommandInvocation,
-} from "../../skills/discovery/chat-commands.js";
+} from "../../skills/discovery/chat-command-invocation.js";
 import type { ExplicitSkillSelection, SkillCommandSpec } from "../../skills/types.js";
 import {
   copyReplyPayloadMetadata,

--- a/src/auto-reply/reply/get-reply.imports.test.ts
+++ b/src/auto-reply/reply/get-reply.imports.test.ts
@@ -1,6 +1,6 @@
 // Tests get-reply import boundaries for lazy runtime and side-effect control.
 import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import ts from "typescript";
@@ -12,9 +12,9 @@ const lazyRuntimeSpecifiers = [
   "./stage-sandbox-media.runtime.js",
 ] as const;
 
-function readGetReplyModuleImports() {
-  const sourceText = readFileSync(getReplyPath, "utf8");
-  const sourceFile = ts.createSourceFile(getReplyPath, sourceText, ts.ScriptTarget.Latest, true);
+function readModuleImports(filePath: string) {
+  const sourceText = readFileSync(filePath, "utf8");
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
   const staticImports = new Set<string>();
   const dynamicImports = new Set<string>();
 
@@ -22,7 +22,23 @@ function readGetReplyModuleImports() {
     if (
       ts.isImportDeclaration(node) &&
       ts.isStringLiteral(node.moduleSpecifier) &&
-      !node.importClause?.isTypeOnly
+      !node.importClause?.isTypeOnly &&
+      (!node.importClause?.namedBindings ||
+        node.importClause.name ||
+        ts.isNamespaceImport(node.importClause.namedBindings) ||
+        node.importClause.namedBindings.elements.some((element) => !element.isTypeOnly))
+    ) {
+      staticImports.add(node.moduleSpecifier.text);
+    }
+
+    if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      !node.isTypeOnly &&
+      (!node.exportClause ||
+        ts.isNamespaceExport(node.exportClause) ||
+        node.exportClause.elements.some((element) => !element.isTypeOnly))
     ) {
       staticImports.add(node.moduleSpecifier.text);
     }
@@ -45,9 +61,28 @@ function readGetReplyModuleImports() {
   return { dynamicImports, staticImports };
 }
 
+function collectStaticImportPaths(entryPath: string): Set<string> {
+  const paths = new Set([entryPath]);
+  for (const filePath of paths) {
+    for (const specifier of readModuleImports(filePath).staticImports) {
+      if (!specifier.startsWith(".")) {
+        continue;
+      }
+      const resolved = expectDefined(
+        ts.resolveModuleName(specifier, filePath, {}, ts.sys).resolvedModule,
+        `${filePath} -> ${specifier}`,
+      );
+      if (!resolved.resolvedFileName.endsWith(".d.ts")) {
+        paths.add(resolved.resolvedFileName);
+      }
+    }
+  }
+  return paths;
+}
+
 describe("get-reply module imports", () => {
   it("keeps heavy runtime boundaries on dynamic imports", () => {
-    const { dynamicImports, staticImports } = readGetReplyModuleImports();
+    const { dynamicImports, staticImports } = readModuleImports(getReplyPath);
 
     for (const specifier of lazyRuntimeSpecifiers) {
       expect(staticImports.has(specifier), `${specifier} should stay lazy`).toBe(false);
@@ -55,5 +90,21 @@ describe("get-reply module imports", () => {
         true,
       );
     }
+  });
+
+  it("keeps skill discovery and dispatch out of the inline-actions static import closure", () => {
+    const skillsRoot = resolve(dirname(getReplyPath), "../../skills");
+    const paths = collectStaticImportPaths(
+      resolve(dirname(getReplyPath), "get-reply-inline-actions.ts"),
+    );
+    const eagerSkillRuntime = [...paths]
+      .map((filePath) => relative(skillsRoot, filePath).replaceAll("\\", "/"))
+      .filter((filePath) =>
+        /^(?:loading\/|library\/|runtime\/|discovery\/(?:chat-commands|command-specs)(?:\.|\/))/.test(
+          filePath,
+        ),
+      );
+
+    expect(eagerSkillRuntime).toEqual([]);
   });
 });

--- a/src/skills/discovery/chat-commands.ts
+++ b/src/skills/discovery/chat-commands.ts
@@ -22,7 +22,6 @@ import { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";
 import { listReservedChatSlashCommandNames } from "./chat-command-invocation.js";
 import { buildWorkspaceSkillCommandSpecs } from "./command-specs.js";
 export {
-  expandBundleCommandPromptTemplate,
   expandExplicitSkillReferences,
   hasSkillReferenceCandidate,
   listReservedChatSlashCommandNames,


### PR DESCRIPTION
## What Problem This Solves

Fixes unnecessary skill-discovery loading on ordinary replies that do not invoke a skill. The inline-action fast path already defers discovery until it sees an authorized skill candidate, but a separate static import pulled the discovery dependency graph into the caller before that decision.

This is a bounded maintainer-requested import-ownership repair, not a change to command semantics or skill eligibility.

## Why This Change Was Made

Import the same five pure invocation helpers directly from their existing owner, keeping actual discovery behind the existing lazy runtime facade. Remove the one internal template-helper re-export that becomes unused after moving its only production consumer; retain the canonical helper and every public SDK export.

Extend the existing import-boundary test to detect transitive relative static value imports and re-exports into skill discovery/loading/library/dispatch. It ignores type-only and dynamic edges and does not require a specific replacement import spelling or a fixed graph-size budget. No new production abstraction, mocks, timeout changes, environment workarounds, or configuration options.

## User Impact

Ordinary replies avoid loading workspace skill discovery through the inline-action helper import. Authorized skill references and commands still use the same discovery, allowlists, reserved names, prompt templates, and tool-dispatch policies. No operator action, migration, or API change is required.

Production LOC: +1/-2 (net -1). Tests: +57/-6 (net +51), for one transitive architecture regression in the existing guard.

## Evidence

The new architecture regression fails with the original production import and passes with the repair. Existing behavior tests were retained unchanged; their runtime-facade mock checked discovery calls but could not catch the independent static import.

| Measurement | Before | After |
| --- | ---: | ---: |
| Inline-actions relative static source closure | 1,317 modules | 416 modules |
| Invocation-owner closure | 308 modules | 308 modules |
| Auto-reply import time, run 1 | 11.39s | 3.56s |
| Auto-reply import time, run 2 | 12.20s | 4.54s |

The measured closure loses 901 modules (68.4%) and gains none. It follows repository-local relative static value imports/re-exports, excluding declarations, package-name imports, and dynamic imports; these numbers are not the entire npm graph or a tree-shaken bundle count. Final recapture after the export cleanup and full build confirmed the same graph. Timings use the same command and host, but host contention and subprocess preparation were noisy; no precise wall-time or RSS improvement is claimed.

Local validation on Node 26:

- **89 tests passed** across the inline-action behavior, skill discovery/invocation, command-spec, and import-boundary suites, rerun after the final re-export removal. Coverage includes authorization, allowlist-hidden skills, multiline and exact prompt bytes, literal dollar arguments, rediscovery with exec overrides, and tool policy.
- Full changed checks passed, including production/test types, targeted lint, all three dead-export scans, runtime sidecar checks, and zero runtime import cycles. The first run caught the newly unused internal re-export; it was deleted rather than suppressed.
- `pnpm build` passed, including SDK export checks and the UI build, with no ineffective dynamic import warning.
- Formatting and `git diff --check` passed.
- Fresh independent Codex autoreview returned scoped-clean at its configured P0-only threshold, with no accepted/actionable findings.

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/skills/discovery/chat-commands.test.ts src/auto-reply/reply/get-reply.imports.test.ts src/skills/discovery/command-specs.test.ts --maxWorkers=1
```

```bash
node scripts/check-changed.mjs -- src/auto-reply/reply/get-reply-inline-actions.ts src/auto-reply/reply/get-reply.imports.test.ts src/skills/discovery/chat-commands.ts
```

```bash
pnpm build
```

No live channel/provider/Gateway flow was exercised: this is behavior-neutral import wiring, proven by the failing/passing static-boundary regression, unchanged behavior tests, and full build. No UI or message-rendering behavior changes. This PR does not attempt to make every upstream reply or Gateway dependency lazy.
