### PR TITLE
fix(sessions): correct worktree restore capacity advice

### DIFF
--- a/src/gateway/server.sessions.archive-worktree-lifecycle.test.ts
+++ b/src/gateway/server.sessions.archive-worktree-lifecycle.test.ts
@@ -377,6 +377,7 @@ test.each(["checkout-failed", "expired", "source-missing"] as const)(
         error: { code: "UNAVAILABLE", retryable: true },
       });
       expect(restored.error?.message).toContain("worktree");
+      expect(restored.error?.message).not.toMatch(/worktree slot/i);
       expect(restored.error?.message).toContain(
         failure === "checkout-failed" ? "Free disk space" : "new worktree task",
       );

--- a/src/sessions/session-worktree-lifecycle.ts
+++ b/src/sessions/session-worktree-lifecycle.ts
@@ -182,7 +182,7 @@ export async function synchronizeSessionWorktreeArchive(params: {
           );
         }
         throw new SessionWorktreeLifecycleError(
-          "Session worktree could not be restored. Free disk space or an unused worktree slot, check the source repository, then retry. The conversation and snapshot are preserved.",
+          "Session worktree could not be restored. Free disk space if needed, check the source repository, then retry. The conversation and snapshot are preserved.",
           "restore-failed",
         );
       }


### PR DESCRIPTION
Related: #135989 (disk-based managed-worktree admission).

## What Problem This Solves

Fixes an issue where users reopening an archived worktree session would be told to free an unused worktree slot when restore failed. Creation and restore are admitted by available disk space; 100 live managed worktrees is a garbage-collection target, not an admission cap.

## Why This Change Was Made

Remove the obsolete slot advice from the session lifecycle owner's generic restore error while retaining disk-space guidance, source-repository checks, retry instructions, and the conversation/snapshot preservation reassurance. This is a wording-only follow-up: allocation checks, GC policy, ownership protection, and deployment behavior are unchanged.

## User Impact

The error now says: “Session worktree could not be restored. Free disk space if needed, check the source repository, then retry. The conversation and snapshot are preserved.” It does not advise removing active or manual worktrees.

## Evidence

- Extended the existing gateway restore-failure test to reject worktree-slot advice. Before the production edit, the checkout-failed case failed on the exact obsolete message; expired-snapshot and missing-source cases passed.
- `node scripts/run-vitest.mjs src/gateway/server.sessions.archive-worktree-lifecycle.test.ts src/agents/worktrees/service.capacity.test.ts` — 32 tests passed, including creation/restoration beyond 100 live checkouts and insufficient-disk preservation.
- `node scripts/check-changed.mjs -- src/sessions/session-worktree-lifecycle.ts src/gateway/server.sessions.archive-worktree-lifecycle.test.ts` — passed, including core/test typechecks, targeted formatting/lint, and repository guards.
- `git diff --check` — passed. Codex autoreview of the exact uncommitted diff was clean at its default P0 scope.
- Proof uses isolated synthetic repositories/state and the real session RPC handlers with an injected restore failure. No production Gateway, credentials, or deployed controller was used. No browser recording was captured; the changed RPC error is asserted directly at its handler boundary.

Production LOC: +1/-1 (net 0). Tests: +1/-0. The existing managed-worktree documentation already describes the current disk-based policy and needs no change.
