### PR TITLE
chore(macos): adopt Peekaboo 4.3.0

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "f2127970860a36ea9e0d4a251d63c336e78ecba7ebe74e48f1290de8dc175bef",
+  "originHash" : "4a5551634f350ce9d428f0ffc7c06e99ccda64320adc8e5889c9c11bb6a96a11",
   "pins" : [
     {
       "identity" : "axorcist",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/AXorcist.git",
       "state" : {
-        "revision" : "bab3f2228bac0ce3a34786b8395b65bb36242221",
-        "version" : "0.1.8"
+        "revision" : "37d7ae82ff1443b4b36344ca6f3bf0ad33f13b12",
+        "version" : "0.1.9"
       }
     },
     {
@@ -51,7 +51,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/Peekaboo.git",
       "state" : {
-        "revision" : "8d5e638e6ac9e93fae7d8dcb2ac0a0f01f3d49ec"
+        "revision" : "44eff916c3330739108cc1d73683338d4250503a"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.6"),
         .package(
             url: "https://github.com/openclaw/Peekaboo.git",
-            revision: "8d5e638e6ac9e93fae7d8dcb2ac0a0f01f3d49ec"),
+            revision: "44eff916c3330739108cc1d73683338d4250503a"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.4.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),


### PR DESCRIPTION
## What Problem This Solves

The macOS companion still embeds an older Peekaboo revision after [Peekaboo 4.3.0](https://github.com/openclaw/Peekaboo/releases/tag/v4.3.0) was published and verified. Future OpenClaw Mac builds should consume that released native automation and Bridge implementation.

## Why This Change Was Made

Keep the existing immutable revision policy and pin Peekaboo to the actual published tag commit, `44eff916c3330739108cc1d73683338d4250503a`. Its public Swift package requires [AXorcist 0.1.9](https://github.com/openclaw/AXorcist/releases/tag/v0.1.9), so the lockfile records that exact release too. SwiftPM regenerated `originHash`; all 14 unrelated dependency pins remain unchanged.

Only the manifest and generated lockfile change. No consumer adapters, compatibility fallbacks, dependency overrides, signing allowlist changes, or runtime ownership changes are needed. The embedded package continues to exclude Peekaboo's CLI agent/provider/browser stack.

## User Impact

Future macOS builds inherit the released native automation and Bridge fixes, including bounded detection deadlines and corrected background-process inventory handling. OpenClaw's UI, settings, snapshot retention, background-first policy, and checked Bridge lifecycle remain unchanged. This PR does not install or launch an app, deploy a Gateway, restart production, or publish an OpenClaw release.

## Evidence

- The actual arm64 `OpenClaw` release product compiled with Xcode 27 / Swift 6.4 in 248 seconds, without compiler warning/error lines. A fresh checkout initially lacked generated Mermaid resources; the canonical preparation script supplied them, then the build passed. This is compilation, not a signed distributable or native test execution.
- The full changed-file gate passed, including Swift lint, dependency/schema guards, and **1,074 selected script/fixture tests across 20 files**. The earlier focused provenance selection passed **21 tests**; those overlap the full gate and are not counted again.
- The actual resolved Peekaboo checkout passed the packaging source-verification helper at the exact published SHA. The AXorcist revision is `37d7ae82ff1443b4b36344ca6f3bf0ad33f13b12`; every other pin was compared and retained.
- Manifest SwiftFormat and whitespace checks passed. Scoped Codex P0 autoreview found no actionable findings.
- Upstream publication proof includes all nine public release-asset digests, Foundation signatures, accepted notarization/staples/Gatekeeper, Sparkle verification, and a fresh neutral-directory npm installation reporting the published source commit. See the [release verification section](https://github.com/openclaw/Peekaboo/releases/tag/v4.3.0).

### Direct upstream contract inspection

The exact published dependency was inspected locally, addressing the automated review's dependency-host DNS gap:

- [Peekaboo's public package graph](https://github.com/openclaw/Peekaboo/blob/44eff916c3330739108cc1d73683338d4250503a/Package.swift#L24-L41) exports the native products and requires AXorcist exactly 0.1.9.
- [The embedded runtime and service owner](https://github.com/openclaw/Peekaboo/blob/44eff916c3330739108cc1d73683338d4250503a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooEmbeddedBridgeRuntime.swift#L143-L303) preserves the configuration, construction and checked lifecycle consumed by OpenClaw.
- The complete embedded-runtime, in-memory snapshot-manager and input-policy files are byte-identical between the old and new revisions, confirmed by Git-object existence checks and empty direct diffs. The real consumer build and source verifier passed against the new checkout; native CI remains the compatibility gate.

### Exact-head hosted validation

[CI run 33697424456, final attempt 2](https://github.com/openclaw/openclaw/actions/runs/33697424456/attempts/2) passed for `a349b25f33b1c3c8f64f26614d118f9fd16cd8a4`. The repository-owned exact-SHA hosted fallback unblocked Blacksmith Mac admission without changing global runner settings.

The [native Swift test job](https://github.com/openclaw/openclaw/actions/runs/33697424456/job/100469373836) actually executed successfully in attempt 1 on hosted macOS; those results were retained through the scoped UI retry. Swift reported successful runs of 1,578 tests/121 suites, 1,928 tests/200 suites, 2 tests/1 suite, and 1 test/1 suite. The coordinator and reference-lifecycle suites passed. These are harness-reported counts: the opt-in external CLI handshake was explicitly skipped and is not claimed as executed. Native tests were not run on the operator workstation, following the [isolation policy](https://docs.openclaw.ai/platforms/mac/dev-setup#run-native-tests-safely).

The first `checks-ui (3/3)` job failed before the Vitest Chromium orchestrator connected. One unchanged [job retry](https://github.com/openclaw/openclaw/actions/runs/33697424456/job/100480960392) passed all 293 selected files and 4,639 tests, including 12 actual Chromium modules, with zero unhandled errors. No timeout, source, or coverage change was made; the exact initial scheduling cause remains unknown.

Inspection also identified a separate, pre-existing global-screen scroll intent mismatch. The relevant upstream default and guard are identical under the old and new pins; that native reproduction/repair is recorded as a separate follow-up rather than bundled into this dependency update.

Production runtime LOC: +0/-0. Manifest: +1/-1. Generated lockfile: +4/-4. Tests: +0/-0.
