### PR TITLE
improve(ui): show linked session participants

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -6422,6 +6422,7 @@ public struct SessionRow: Codable, Sendable {
     public let createdactor: SessionCreatedActor?
     public let owner: SessionOwner?
     public let participants: [SessionParticipant]?
+    public let expandedparticipants: [SessionParticipant]?
     public let participantcount: Int?
     public let visibility: SessionVisibility?
     public let sharingrole: SessionSharingRole?
@@ -6497,6 +6498,7 @@ public struct SessionRow: Codable, Sendable {
         createdactor: SessionCreatedActor? = nil,
         owner: SessionOwner? = nil,
         participants: [SessionParticipant]? = nil,
+        expandedparticipants: [SessionParticipant]? = nil,
         participantcount: Int? = nil,
         visibility: SessionVisibility? = nil,
         sharingrole: SessionSharingRole? = nil,
@@ -6571,6 +6573,7 @@ public struct SessionRow: Codable, Sendable {
         self.createdactor = createdactor
         self.owner = owner
         self.participants = participants
+        self.expandedparticipants = expandedparticipants
         self.participantcount = participantcount
         self.visibility = visibility
         self.sharingrole = sharingrole
@@ -6647,6 +6650,7 @@ public struct SessionRow: Codable, Sendable {
         case createdactor = "createdActor"
         case owner
         case participants
+        case expandedparticipants = "expandedParticipants"
         case participantcount = "participantCount"
         case visibility
         case sharingrole = "sharingRole"

--- a/packages/gateway-protocol/src/schema/session-participant.ts
+++ b/packages/gateway-protocol/src/schema/session-participant.ts
@@ -2,8 +2,11 @@ import { Type, type Static } from "typebox";
 import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
-/** Shared storage and wire bound for one session's retained participant identities. */
-export const SESSION_PARTICIPANT_LIMIT = 32;
+/** Released v4 wire bound for the compact session-row participant summary. */
+export const SESSION_PARTICIPANT_LIMIT = 4;
+
+/** Storage and expanded-projection bound for one session's retained participant identities. */
+export const SESSION_EXPANDED_PARTICIPANT_LIMIT = 32;
 
 /** Product identity, independent of display metadata and authorization. */
 export const SessionParticipantIdentitySchema = Type.Union([

--- a/packages/gateway-protocol/src/schema/session-participant.ts
+++ b/packages/gateway-protocol/src/schema/session-participant.ts
@@ -2,6 +2,9 @@ import { Type, type Static } from "typebox";
 import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
+/** Shared storage and wire bound for one session's retained participant identities. */
+export const SESSION_PARTICIPANT_LIMIT = 32;
+
 /** Product identity, independent of display metadata and authorization. */
 export const SessionParticipantIdentitySchema = Type.Union([
   closedObject({ type: Type.Literal("profile"), id: NonEmptyString }),

--- a/packages/gateway-protocol/src/schema/sessions-row.test.ts
+++ b/packages/gateway-protocol/src/schema/sessions-row.test.ts
@@ -48,6 +48,14 @@ describe("SessionRowSchema", () => {
           identity: { type: "profile", id: `profile-${index}` },
         })),
       }),
+    ).toBe(true);
+    expect(
+      Value.Check(SessionRowSchema, {
+        ...roundTripped,
+        participants: Array.from({ length: 33 }, (_, index) => ({
+          identity: { type: "profile", id: `profile-${index}` },
+        })),
+      }),
     ).toBe(false);
     expect(roundTripped).toMatchObject({
       activeLeafEntryId: "leaf-rendered",

--- a/packages/gateway-protocol/src/schema/sessions-row.test.ts
+++ b/packages/gateway-protocol/src/schema/sessions-row.test.ts
@@ -48,11 +48,19 @@ describe("SessionRowSchema", () => {
           identity: { type: "profile", id: `profile-${index}` },
         })),
       }),
+    ).toBe(false);
+    expect(
+      Value.Check(SessionRowSchema, {
+        ...roundTripped,
+        expandedParticipants: Array.from({ length: 32 }, (_, index) => ({
+          identity: { type: "profile", id: `profile-${index}` },
+        })),
+      }),
     ).toBe(true);
     expect(
       Value.Check(SessionRowSchema, {
         ...roundTripped,
-        participants: Array.from({ length: 33 }, (_, index) => ({
+        expandedParticipants: Array.from({ length: 33 }, (_, index) => ({
           identity: { type: "profile", id: `profile-${index}` },
         })),
       }),

--- a/packages/gateway-protocol/src/schema/sessions-row.ts
+++ b/packages/gateway-protocol/src/schema/sessions-row.ts
@@ -4,6 +4,7 @@ import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 import { SessionClassificationSchema, SessionPeerKindSchema } from "./session-classification.js";
 import {
+  SESSION_PARTICIPANT_LIMIT,
   SessionParticipantSchema,
   SessionParticipantIdentitySchema,
 } from "./session-participant.js";
@@ -140,7 +141,9 @@ export const SessionRowSchema = Type.Object(
     ),
     createdActor: Type.Optional(SessionCreatedActorSchema),
     owner: Type.Optional(SessionOwnerSchema),
-    participants: Type.Optional(Type.Array(SessionParticipantSchema, { maxItems: 4 })),
+    participants: Type.Optional(
+      Type.Array(SessionParticipantSchema, { maxItems: SESSION_PARTICIPANT_LIMIT }),
+    ),
     participantCount: Type.Optional(Type.Integer({ minimum: 0 })),
     visibility: Type.Optional(SessionVisibilitySchema),
     sharingRole: Type.Optional(SessionSharingRoleSchema),

--- a/packages/gateway-protocol/src/schema/sessions-row.ts
+++ b/packages/gateway-protocol/src/schema/sessions-row.ts
@@ -4,6 +4,7 @@ import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 import { SessionClassificationSchema, SessionPeerKindSchema } from "./session-classification.js";
 import {
+  SESSION_EXPANDED_PARTICIPANT_LIMIT,
   SESSION_PARTICIPANT_LIMIT,
   SessionParticipantSchema,
   SessionParticipantIdentitySchema,
@@ -143,6 +144,9 @@ export const SessionRowSchema = Type.Object(
     owner: Type.Optional(SessionOwnerSchema),
     participants: Type.Optional(
       Type.Array(SessionParticipantSchema, { maxItems: SESSION_PARTICIPANT_LIMIT }),
+    ),
+    expandedParticipants: Type.Optional(
+      Type.Array(SessionParticipantSchema, { maxItems: SESSION_EXPANDED_PARTICIPANT_LIMIT }),
     ),
     participantCount: Type.Optional(Type.Integer({ minimum: 0 })),
     visibility: Type.Optional(SessionVisibilitySchema),

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1809,6 +1809,13 @@ async function createChatPickerScenario(
       execCwd: "/Users/demo/Work/openclaw",
       lastReadAt: baseTime - 120_000,
       owner: { actor: MOCK_ACTOR_PETER },
+      participantCount: 4,
+      participants: [
+        { identity: { type: "profile", id: "profile-mira" }, label: "Mira" },
+        { identity: { type: "profile", id: "profile-riley" }, label: "Riley" },
+        { identity: { type: "profile", id: "profile-sam" }, label: "Sam" },
+        { identity: { type: "profile", id: "profile-lee" }, label: "Lee" },
+      ],
       observerDigest: {
         headline: "Done: fixed the flaky retry-window test",
         health: "done",

--- a/src/config/sessions/session-entry-provenance.ts
+++ b/src/config/sessions/session-entry-provenance.ts
@@ -1,4 +1,4 @@
-import { SESSION_PARTICIPANT_LIMIT } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
+import { SESSION_EXPANDED_PARTICIPANT_LIMIT } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
 import type { SkillLibrarySelection } from "../../../packages/gateway-protocol/src/schema/skill-library.js";
 import type { HookExternalContentSource } from "../../security/external-content.js";
 
@@ -20,7 +20,7 @@ export function sessionCreatorProfileId(
 }
 
 export type { SessionParticipant } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
-export const MAX_SESSION_PARTICIPANTS = SESSION_PARTICIPANT_LIMIT;
+export const MAX_SESSION_PARTICIPANTS = SESSION_EXPANDED_PARTICIPANT_LIMIT;
 
 export type SessionOwnerAssignment = {
   actor: SessionActor;

--- a/src/config/sessions/session-entry-provenance.ts
+++ b/src/config/sessions/session-entry-provenance.ts
@@ -1,3 +1,4 @@
+import { SESSION_PARTICIPANT_LIMIT } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
 import type { SkillLibrarySelection } from "../../../packages/gateway-protocol/src/schema/skill-library.js";
 import type { HookExternalContentSource } from "../../security/external-content.js";
 
@@ -19,7 +20,7 @@ export function sessionCreatorProfileId(
 }
 
 export type { SessionParticipant } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
-export const MAX_SESSION_PARTICIPANTS = 32;
+export const MAX_SESSION_PARTICIPANTS = SESSION_PARTICIPANT_LIMIT;
 
 export type SessionOwnerAssignment = {
   actor: SessionActor;

--- a/src/gateway/session-utils-owners.test.ts
+++ b/src/gateway/session-utils-owners.test.ts
@@ -498,6 +498,7 @@ it("deduplicates participants in order, excludes the owner, and filters sessions
       { identity: { type: "profile", id: "profile-carol" }, label: "Bob" },
       { identity: { type: "profile", id: "profile-dana" }, label: "Bob" },
       { identity: { type: "profile", id: "profile-erin" }, label: "Bob" },
+      { identity: { type: "profile", id: "profile-ada" }, label: "Ada" },
     ],
     participantCount: 5,
   });

--- a/src/gateway/session-utils-owners.test.ts
+++ b/src/gateway/session-utils-owners.test.ts
@@ -498,6 +498,12 @@ it("deduplicates participants in order, excludes the owner, and filters sessions
       { identity: { type: "profile", id: "profile-carol" }, label: "Bob" },
       { identity: { type: "profile", id: "profile-dana" }, label: "Bob" },
       { identity: { type: "profile", id: "profile-erin" }, label: "Bob" },
+    ],
+    expandedParticipants: [
+      { identity: { type: "agent", id: "research" }, label: "Research" },
+      { identity: { type: "profile", id: "profile-carol" }, label: "Bob" },
+      { identity: { type: "profile", id: "profile-dana" }, label: "Bob" },
+      { identity: { type: "profile", id: "profile-erin" }, label: "Bob" },
       { identity: { type: "profile", id: "profile-ada" }, label: "Ada" },
     ],
     participantCount: 5,

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -30,7 +30,10 @@ import {
 } from "../config/sessions.js";
 import { resolveSessionModelOverrideSource } from "../config/sessions/model-override-provenance.js";
 import { sessionEntryForkedFromParent } from "../config/sessions/session-entry-lineage.js";
-import { sessionCreatorProfileId } from "../config/sessions/session-entry-provenance.js";
+import {
+  MAX_SESSION_PARTICIPANTS,
+  sessionCreatorProfileId,
+} from "../config/sessions/session-entry-provenance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
@@ -442,7 +445,9 @@ export function buildGatewaySessionRow(params: {
       Boolean(sessionCreatorProfileId(entry?.createdActor)),
     ),
     owner,
-    participants: participants.size ? [...participants.values()].slice(0, 4) : undefined,
+    participants: participants.size
+      ? [...participants.values()].slice(0, MAX_SESSION_PARTICIPANTS)
+      : undefined,
     participantCount: participants.size || undefined,
     createdAt: entry?.createdAt,
     forkSource: entry?.forkSource,

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { asNonNegativeFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { SESSION_PARTICIPANT_LIMIT } from "../../packages/gateway-protocol/src/schema/session-participant.js";
 import { resolveAuthoredModelContextTokens } from "../agents/context-resolution.js";
 import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
@@ -445,7 +446,11 @@ export function buildGatewaySessionRow(params: {
       Boolean(sessionCreatorProfileId(entry?.createdActor)),
     ),
     owner,
+    // Keep the released v4 summary stable; expanded identities are additive for newer clients.
     participants: participants.size
+      ? [...participants.values()].slice(0, SESSION_PARTICIPANT_LIMIT)
+      : undefined,
+    expandedParticipants: participants.size
       ? [...participants.values()].slice(0, MAX_SESSION_PARTICIPANTS)
       : undefined,
     participantCount: participants.size || undefined,

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -190,6 +190,7 @@ export function buildSidebarSessionNavigationState(input: {
       createdActor: row.createdActor,
       owner: row.owner,
       participants: row.participants,
+      expandedParticipants: row.expandedParticipants,
       participantCount: row.participantCount,
       archivedBy: row.archivedBy,
       // The sidebar's zone structure already says what forked from what;

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -67,6 +67,7 @@ export type SidebarRecentSession = {
   createdActor?: SessionCreatedActor;
   owner?: SessionOwner;
   participants?: SessionParticipant[];
+  expandedParticipants?: SessionParticipant[];
   participantCount?: number;
   archivedBy?: SessionCreatedActor;
   label: string;
@@ -151,6 +152,7 @@ export type SidebarSessionHovercardRow = Pick<
   | "hasAutomation"
   | "label"
   | "lastMessagePreview"
+  | "expandedParticipants"
   | "participantCount"
   | "participants"
   | "placementProviderId"

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -601,14 +601,21 @@ describe("renderSessionHovercard", () => {
       "/activity?person=lee",
     ]);
 
-    const participantsTooltip = container.querySelector(
-      "openclaw-tooltip.session-hovercard__participants-tooltip",
+    const participantsTooltip = container.querySelector<
+      HTMLElement & { updateComplete: Promise<boolean> }
+    >("openclaw-tooltip.session-hovercard__participants-tooltip");
+    await participantsTooltip?.updateComplete;
+    expect(participantsTooltip?.hasAttribute("open-on-click")).toBe(true);
+    const participantTrigger = participantsTooltip?.querySelector<HTMLButtonElement>(
+      ".session-hovercard__attribution-others",
     );
-    expect(
-      participantsTooltip?.querySelector<HTMLButtonElement>(
-        ".session-hovercard__attribution-others",
-      )?.textContent,
-    ).toContain("4 others");
+    const touchDown = new MouseEvent("pointerdown", { bubbles: true });
+    Object.defineProperty(touchDown, "pointerType", { value: "touch" });
+    participantTrigger?.dispatchEvent(touchDown);
+    participantTrigger?.dispatchEvent(new MouseEvent("pointerup", { bubbles: true }));
+    participantTrigger?.click();
+    expect(participantsTooltip?.hasAttribute("open")).toBe(true);
+    expect(participantTrigger?.textContent).toContain("4 others");
     expect(
       [
         ...(participantsTooltip?.querySelectorAll<HTMLAnchorElement>(

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -571,6 +571,12 @@ describe("renderSessionHovercard", () => {
             { identity: { type: "profile", id: "mira" }, label: "Mira" },
             { identity: { type: "profile", id: "riley" }, label: "Riley" },
             { identity: { type: "profile", id: "sam" }, label: "Sam" },
+          ],
+          expandedParticipants: [
+            { identity: { type: "profile", id: "self" }, label: "You" },
+            { identity: { type: "profile", id: "mira" }, label: "Mira" },
+            { identity: { type: "profile", id: "riley" }, label: "Riley" },
+            { identity: { type: "profile", id: "sam" }, label: "Sam" },
             { identity: { type: "profile", id: "lee" }, label: "Lee" },
           ],
           participantCount: 5,

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -48,6 +48,17 @@ function progressCard(): ProgressCard {
   };
 }
 
+function attributionSummary(container: ParentNode): string {
+  return [
+    container.querySelector(".session-hovercard__attribution-name")?.textContent,
+    container.querySelector(".session-hovercard__attribution-others")?.textContent,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
 describe("renderSessionHovercard", () => {
   it.each(["purple", undefined, "default"])(
     "reflects the session color %s without unset chrome",
@@ -519,12 +530,7 @@ describe("renderSessionHovercard", () => {
       container,
     );
 
-    expect(
-      container
-        .querySelector(".session-hovercard__attribution-copy")
-        ?.textContent?.replace(/\s+/gu, " ")
-        .trim(),
-    ).toBe("Alice Baker & 5 others");
+    expect(attributionSummary(container)).toBe("Alice Baker & 5 others");
     expect(
       container.querySelector(".session-hovercard__attribution")?.getAttribute("aria-label"),
     ).toBe("Alice Baker, 5 more participants");
@@ -564,6 +570,8 @@ describe("renderSessionHovercard", () => {
             { identity: { type: "profile", id: "self" }, label: "You" },
             { identity: { type: "profile", id: "mira" }, label: "Mira" },
             { identity: { type: "profile", id: "riley" }, label: "Riley" },
+            { identity: { type: "profile", id: "sam" }, label: "Sam" },
+            { identity: { type: "profile", id: "lee" }, label: "Lee" },
           ],
           participantCount: 5,
         }),
@@ -572,12 +580,7 @@ describe("renderSessionHovercard", () => {
       container,
     );
 
-    expect(
-      container
-        .querySelector(".session-hovercard__attribution-copy")
-        ?.textContent?.replace(/\s+/gu, " ")
-        .trim(),
-    ).toBe("Alice Baker & 4 others");
+    expect(attributionSummary(container)).toBe("Alice Baker & 4 others");
     const facepile = container.querySelector<HTMLElement & { updateComplete: Promise<boolean> }>(
       "openclaw-viewer-facepile",
     );
@@ -588,12 +591,40 @@ describe("renderSessionHovercard", () => {
     expect(participantLinks.map((link) => link.getAttribute("href"))).toEqual([
       "/activity?person=mira",
       "/activity?person=riley",
+      "/activity?person=sam",
+      "/activity?person=lee",
+    ]);
+
+    const participantsTooltip = container.querySelector(
+      "openclaw-tooltip.session-hovercard__participants-tooltip",
+    );
+    expect(
+      participantsTooltip?.querySelector<HTMLButtonElement>(
+        ".session-hovercard__attribution-others",
+      )?.textContent,
+    ).toContain("4 others");
+    expect(
+      [
+        ...(participantsTooltip?.querySelectorAll<HTMLAnchorElement>(
+          ".session-hovercard__participant-link",
+        ) ?? []),
+      ].map((link) => link.getAttribute("href")),
+    ).toEqual([
+      "/activity?person=mira",
+      "/activity?person=riley",
+      "/activity?person=sam",
+      "/activity?person=lee",
     ]);
 
     participantLinks[1]?.dispatchEvent(
       new MouseEvent("click", { bubbles: true, cancelable: true }),
     );
     expect(navigate).toHaveBeenCalledWith("riley");
+
+    participantsTooltip
+      ?.querySelector<HTMLAnchorElement>('.session-hovercard__participant-link[href$="lee"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(navigate).toHaveBeenLastCalledWith("lee");
   });
 
   it("uses the first participant as the attribution when the creator is unknown", () => {
@@ -614,12 +645,7 @@ describe("renderSessionHovercard", () => {
       container,
     );
 
-    expect(
-      container
-        .querySelector(".session-hovercard__attribution-copy")
-        ?.textContent?.replace(/\s+/gu, " ")
-        .trim(),
-    ).toBe("Mira & 3 others");
+    expect(attributionSummary(container)).toBe("Mira & 3 others");
   });
 
   it("keeps the identity plain text when no activity route is available", () => {

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -18,7 +18,11 @@ import {
 import { renderSessionColorDot } from "./session-color.ts";
 import { sessionOwnerInitials, type SessionCreatedActor } from "./session-owner-chip.ts";
 import { progressCardHeadsUp, renderProgressCardMarkdown } from "./session-progress-card.ts";
+import "./tooltip.ts";
 import "./viewer-facepile.ts";
+
+// Preserve the pre-dropdown facepile footprint; further identities remain linked in the menu.
+const MAX_VISIBLE_ATTRIBUTION_PARTICIPANTS = 4;
 
 function participantLabel(participant: SessionParticipant): string {
   return participant.label?.trim() || participant.identity.id;
@@ -210,6 +214,42 @@ function sessionAttribution(
   };
 }
 
+function renderParticipantMenu(
+  participants: readonly SessionParticipant[],
+  participantCount: number,
+  personActivity: PersonActivityRouting | undefined,
+) {
+  const unresolvedCount = Math.max(0, participantCount - participants.length);
+  return html`<div
+    slot="content"
+    class="session-hovercard__participant-menu"
+    role="list"
+    aria-label=${t("sessionHovercard.moreParticipantsLabel", {
+      count: String(participantCount),
+    })}
+  >
+    ${participants.map((participant) => {
+      const label = participantLabel(participant);
+      const activity =
+        participant.identity.type === "profile"
+          ? personActivityLink(participant.identity.id, personActivity)
+          : null;
+      return html`<div role="listitem">
+        ${renderPersonName(
+          label,
+          activity,
+          "session-menu__item session-hovercard__participant-link",
+        )}
+      </div>`;
+    })}
+    ${unresolvedCount > 0
+      ? html`<div class="session-hovercard__participant-unresolved" role="listitem">
+          ${t("sessionHovercard.moreParticipantsLabel", { count: String(unresolvedCount) })}
+        </div>`
+      : nothing}
+  </div>`;
+}
+
 function renderSessionAttribution({
   row,
   selfUserId,
@@ -285,18 +325,36 @@ function renderSessionAttribution({
   ]
     .filter(Boolean)
     .join(", ");
+  const otherLabel =
+    otherCount > 0
+      ? t(
+          otherCount === 1
+            ? "sessionHovercard.attributionOther"
+            : "sessionHovercard.attributionOthers",
+          { count: String(otherCount) },
+        )
+      : "";
   return html`<div class="session-hovercard__attribution" aria-label=${attributionLabel}>
     <span class="session-hovercard__attribution-copy">
       ${renderPersonName(primaryLabel, primaryActivity, "session-hovercard__attribution-name")}
       ${otherCount > 0
-        ? html`<span class="session-hovercard__attribution-others"
-            >${t(
-              otherCount === 1
-                ? "sessionHovercard.attributionOther"
-                : "sessionHovercard.attributionOthers",
-              { count: String(otherCount) },
-            )}</span
-          >`
+        ? remainingParticipants.length > 0
+          ? html`<openclaw-tooltip
+              class="session-hovercard__participants-tooltip"
+              .describe=${false}
+            >
+              <button
+                type="button"
+                class="session-hovercard__attribution-others"
+                aria-label=${t("sessionHovercard.moreParticipantsLabel", {
+                  count: String(otherCount),
+                })}
+              >
+                ${otherLabel}
+              </button>
+              ${renderParticipantMenu(remainingParticipants, otherCount, personActivity)}
+            </openclaw-tooltip>`
+          : html`<span class="session-hovercard__attribution-others">${otherLabel}</span>`
         : nothing}
     </span>
     <span class="session-hovercard__attribution-avatars">
@@ -305,7 +363,10 @@ function renderSessionAttribution({
         ? html`<openclaw-viewer-facepile
             .staticParticipants=${remainingParticipants}
             .totalCount=${otherCount}
-            .maxVisible=${remainingParticipants.length}
+            .maxVisible=${Math.min(
+              remainingParticipants.length,
+              MAX_VISIBLE_ATTRIBUTION_PARTICIPANTS,
+            )}
             .personActivity=${personActivity}
           ></openclaw-viewer-facepile>`
         : nothing}

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -224,6 +224,7 @@ function renderParticipantMenu(
     slot="content"
     class="session-hovercard__participant-menu"
     role="list"
+    style="min-width: 150px; max-height: min(280px, 60vh); overflow-y: auto;"
     aria-label=${t("sessionHovercard.moreParticipantsLabel", {
       count: String(participantCount),
     })}
@@ -238,7 +239,7 @@ function renderParticipantMenu(
         ${renderPersonName(
           label,
           activity,
-          "session-menu__item session-hovercard__participant-link",
+          "session-menu__item learn-more-link session-hovercard__participant-link",
         )}
       </div>`;
     })}
@@ -346,6 +347,7 @@ function renderSessionAttribution({
               <button
                 type="button"
                 class="session-hovercard__attribution-others"
+                style="padding: 1px 3px; border: 0; border-radius: var(--radius-sm); background: transparent; font: inherit;"
                 aria-label=${t("sessionHovercard.moreParticipantsLabel", {
                   count: String(otherCount),
                 })}

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -177,18 +177,20 @@ function sessionAttribution(
   const creatorLabel = creator?.label?.trim() || creator?.id?.trim();
   const participantIds = new Set<string>();
   let excludedProjectedCount = 0;
-  const participants = (row.participants ?? []).filter((participant) => {
-    const id = JSON.stringify(participant.identity);
-    if (participantIds.has(id)) {
-      return false;
-    }
-    participantIds.add(id);
-    if (excludesParticipant(participant, creator, selfUserId)) {
-      excludedProjectedCount += 1;
-      return false;
-    }
-    return true;
-  });
+  const participants = (row.expandedParticipants ?? row.participants ?? []).filter(
+    (participant) => {
+      const id = JSON.stringify(participant.identity);
+      if (participantIds.has(id)) {
+        return false;
+      }
+      participantIds.add(id);
+      if (excludesParticipant(participant, creator, selfUserId)) {
+        excludedProjectedCount += 1;
+        return false;
+      }
+      return true;
+    },
+  );
   const participantCount = Math.max(
     participants.length,
     (row.participantCount ?? 0) - excludedProjectedCount,

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -345,6 +345,7 @@ function renderSessionAttribution({
           ? html`<openclaw-tooltip
               class="session-hovercard__participants-tooltip"
               .describe=${false}
+              open-on-click
             >
               <button
                 type="button"

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -420,6 +420,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
             lastMessagePreview: sidebarRow.lastMessagePreview,
             createdActor: sidebarRow.createdActor,
             participants: sidebarRow.participants,
+            expandedParticipants: sidebarRow.expandedParticipants,
             participantCount: sidebarRow.participantCount,
             workContext: sidebarRow.workContext,
             createdAt: sidebarRow.createdAt,

--- a/ui/src/e2e/chat-flow.test-support.ts
+++ b/ui/src/e2e/chat-flow.test-support.ts
@@ -25,6 +25,24 @@ export {
 
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 
+export async function captureUiProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  directory: string,
+  fileName: string,
+): Promise<void> {
+  if (!captureUiProofEnabled) {
+    return;
+  }
+  const artifactDir = path.join(owner.artifactDir, directory);
+  await mkdir(artifactDir, { recursive: true });
+  await page.screenshot({
+    animations: "disabled",
+    fullPage: true,
+    path: path.join(artifactDir, fileName),
+  });
+}
+
 export function createChatFlowE2eSuite() {
   return createControlUiE2eSuite({
     name: "Control UI mocked Gateway E2E",

--- a/ui/src/e2e/identity-activity-links.e2e.test.ts
+++ b/ui/src/e2e/identity-activity-links.e2e.test.ts
@@ -140,8 +140,15 @@ suite.define(() => {
         expect(await identity.getAttribute("href")).toBe("/activity?person=profile-ada");
         await expect
           .poll(async () =>
-            (await card.locator(".session-hovercard__attribution-copy").textContent())
-              ?.replace(/\s+/gu, " ")
+            (
+              await card
+                .locator(
+                  ".session-hovercard__attribution-name, .session-hovercard__attribution-others",
+                )
+                .allTextContents()
+            )
+              .join(" ")
+              .replace(/\s+/gu, " ")
               .trim(),
           )
           .toBe("Ada King & 1 other");

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -357,6 +357,7 @@ suite.define(() => {
         const otherParticipants = attribution.locator(".session-hovercard__attribution-others");
         await otherParticipants.hover();
         const participantMenu = attribution.locator(".session-hovercard__participant-menu");
+        await expect.poll(() => participantMenu.isVisible()).toBe(true);
         expect(
           await participantMenu.locator("a.session-hovercard__participant-link").allTextContents(),
         ).toEqual(["Mira", "Riley", "Sam", "Lee"]);

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -1,12 +1,10 @@
-import { mkdir } from "node:fs/promises";
-import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
 import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
 import {
-  captureUiProofEnabled,
+  captureUiProof,
   chatSessionListResponse,
   controlUiSessionUrl,
   createChatFlowE2eSuite,
@@ -15,15 +13,7 @@ import {
 } from "./chat-flow.test-support.ts";
 
 async function captureProof(page: Page, fileName: string): Promise<void> {
-  if (!captureUiProofEnabled) {
-    return;
-  }
-  await mkdir(path.join(suite.artifactDir, "session-progress-hovercard"), { recursive: true });
-  await page.screenshot({
-    animations: "disabled",
-    fullPage: true,
-    path: path.join(path.join(suite.artifactDir, "session-progress-hovercard"), fileName),
-  });
+  await captureUiProof(suite, page, "session-progress-hovercard", fileName);
 }
 
 async function waitForPullRequestSubscription(
@@ -272,6 +262,8 @@ suite.define(() => {
                   { identity: { type: "profile", id: "profile-self" }, label: "You" },
                   { identity: { type: "profile", id: "profile-mira" }, label: "Mira" },
                   { identity: { type: "profile", id: "profile-riley" }, label: "Riley" },
+                  { identity: { type: "profile", id: "profile-sam" }, label: "Sam" },
+                  { identity: { type: "profile", id: "profile-lee" }, label: "Lee" },
                 ],
                 participantCount: 6,
                 startedAt: now - 89 * 24 * 60 * 60_000,
@@ -334,17 +326,20 @@ suite.define(() => {
           .not.toBe(restingBackground);
         await captureProof(page, "sidebar-row-hovercard-pr-hover.png");
         await expect
-          .poll(async () =>
-            (await card.locator(".session-hovercard__attribution-copy").textContent())
-              ?.replace(/\s+/gu, " ")
-              .trim(),
-          )
+          .poll(async () => {
+            const labels = await card
+              .locator(
+                ".session-hovercard__attribution-name, .session-hovercard__attribution-others",
+              )
+              .allTextContents();
+            return labels.join(" ").replace(/\s+/gu, " ").trim();
+          })
           .toBe("Ada King & 4 others");
         const attribution = card.locator(".session-hovercard__attribution");
         const attributionName = attribution.locator("a.session-hovercard__attribution-name");
         expect(await attributionName.getAttribute("href")).toBe("/activity?person=profile-ada");
         const linkedAvatars = attribution.locator(".person-activity-avatar-link .viewer-avatar");
-        await expect.poll(() => linkedAvatars.count()).toBe(3);
+        await expect.poll(() => linkedAvatars.count()).toBe(5);
         const collapsedSpread = await linkedAvatars.evaluateAll((avatars) => {
           const left = avatars.map((avatar) => avatar.getBoundingClientRect().left);
           return left.at(-1)! - left[0]!;
@@ -359,6 +354,13 @@ suite.define(() => {
           })
           .toBeGreaterThan(collapsedSpread + 5);
         await captureProof(page, "sidebar-row-hovercard-attribution-expanded.png");
+        const otherParticipants = attribution.locator(".session-hovercard__attribution-others");
+        await otherParticipants.hover();
+        const participantMenu = attribution.locator(".session-hovercard__participant-menu");
+        expect(
+          await participantMenu.locator("a.session-hovercard__participant-link").allTextContents(),
+        ).toEqual(["Mira", "Riley", "Sam", "Lee"]);
+        await captureProof(page, "sidebar-row-hovercard-participants-dropdown.png");
         expect(await card.locator(".session-hovercard__attribution").textContent()).not.toContain(
           "You",
         );

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -1,6 +1,7 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
+import type { SessionParticipant } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
 import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
 import {
@@ -167,6 +168,14 @@ suite.define(() => {
     const now = Date.now();
     const selectedSessionKey = "agent:main:selected";
     const sessionKey = "agent:main:other-session";
+    const participants: SessionParticipant[] = [
+      { identity: { type: "profile", id: "profile-ada" }, label: "Ada King" },
+      { identity: { type: "profile", id: "profile-self" }, label: "You" },
+      { identity: { type: "profile", id: "profile-mira" }, label: "Mira" },
+      { identity: { type: "profile", id: "profile-riley" }, label: "Riley" },
+      { identity: { type: "profile", id: "profile-sam" }, label: "Sam" },
+      { identity: { type: "profile", id: "profile-lee" }, label: "Lee" },
+    ];
     const initialMarkdown = [
       "**Building** phase 2",
       "",
@@ -257,14 +266,8 @@ suite.define(() => {
                 kind: "direct",
                 label: "Other session",
                 displayName: "Other session",
-                participants: [
-                  { identity: { type: "profile", id: "profile-ada" }, label: "Ada King" },
-                  { identity: { type: "profile", id: "profile-self" }, label: "You" },
-                  { identity: { type: "profile", id: "profile-mira" }, label: "Mira" },
-                  { identity: { type: "profile", id: "profile-riley" }, label: "Riley" },
-                  { identity: { type: "profile", id: "profile-sam" }, label: "Sam" },
-                  { identity: { type: "profile", id: "profile-lee" }, label: "Lee" },
-                ],
+                participants: participants.slice(0, 4),
+                expandedParticipants: participants,
                 participantCount: 6,
                 startedAt: now - 89 * 24 * 60 * 60_000,
                 updatedAt: now - 21 * 24 * 60 * 60_000,

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -104,6 +104,7 @@
 
 .session-hovercard__attribution-copy {
   display: flex;
+  align-items: center;
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
@@ -119,6 +120,43 @@
 .session-hovercard__attribution-others {
   flex: none;
   margin-left: 0.35em;
+  color: var(--muted);
+}
+
+button.session-hovercard__attribution-others {
+  padding: 1px 3px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  font: inherit;
+  line-height: inherit;
+}
+
+button.session-hovercard__attribution-others:is(:hover, :focus-visible) {
+  background: var(--bg-hover);
+  color: var(--text);
+  outline: none;
+}
+
+openclaw-tooltip.session-hovercard__participants-tooltip {
+  --openclaw-tooltip-max-width: min(240px, calc(100vw - 24px));
+  --openclaw-tooltip-padding: 4px;
+}
+
+.session-hovercard__participant-menu {
+  display: grid;
+  min-width: 150px;
+  max-height: min(280px, 60vh);
+  overflow-y: auto;
+}
+
+.session-hovercard__participant-link {
+  min-height: 28px;
+  text-decoration: none;
+}
+
+.session-hovercard__participant-unresolved {
+  padding: 6px 8px;
   color: var(--muted);
 }
 

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -123,43 +123,12 @@
   color: var(--muted);
 }
 
-button.session-hovercard__attribution-others {
-  padding: 1px 3px;
-  border: 0;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  font: inherit;
-  line-height: inherit;
-}
-
 button.session-hovercard__attribution-others:is(:hover, :focus-visible) {
   background: var(--bg-hover);
   color: var(--text);
-  outline: none;
 }
 
-openclaw-tooltip.session-hovercard__participants-tooltip {
-  --openclaw-tooltip-max-width: min(240px, calc(100vw - 24px));
-  --openclaw-tooltip-padding: 4px;
-}
-
-.session-hovercard__participant-menu {
-  display: grid;
-  min-width: 150px;
-  max-height: min(280px, 60vh);
-  overflow-y: auto;
-}
-
-.session-hovercard__participant-link {
-  min-height: 28px;
-  text-decoration: none;
-}
-
-.session-hovercard__participant-unresolved {
-  padding: 6px 8px;
-  color: var(--muted);
-}
-
+.session-hovercard__participant-unresolved,
 .session-hovercard__no-pr,
 .session-hovercard__more {
   color: var(--muted);


### PR DESCRIPTION
## What Problem This Solves

Session hovercards collapse larger participant groups into an inert “N others” label. Once the compact avatar row fills up, users cannot see who the remaining participants are or open their Activity pages.

## Why This Change Was Made

The hovercard now keeps its compact four-avatar facepile and turns “N others” into a hover/focus/click trigger with a scroll-bounded list of participant names. Known people use the existing Activity-link contract; identities beyond the retained 32-person bound remain count-only.

The released v4 `participants` field remains capped at four. The Gateway supplies the menu through a new optional `expandedParticipants` projection, bounded to the existing 32 retained identities, so older v4 schema consumers continue accepting normal session rows. This adds no config, persistence, schema-version, or protocol-version change.

Production delta: +126/-25 lines (+101 net). Tests, test support, and the mock fixture are +144/-44 lines (+100 net); generated Swift client follow-through is +4 lines.

## User Impact

Hover, keyboard-focus, or tap “N others” to see the remaining participant names, then select a name to open that person’s Activity page. The hovercard’s default footprint and stacked avatar treatment stay unchanged.

## Evidence

### Before

The “4 others” count is inert and the remaining participant names are unavailable.

![Before: close-up of session hovercard with inert 4 others count](https://github.com/user-attachments/assets/c5b89f4e-b187-475f-9220-35c18abace20)

### After — “4 others” hovered

The visibly open menu exposes Mira, Riley, Sam, and Lee as Activity links.

![After: close-up of open linked participant dropdown](https://github.com/user-attachments/assets/ca4f3084-afb9-459f-9b34-1828893f1d37)

- UI component tests: 32 passed
- Touch activation regression: passed through the real `open-on-click` tooltip trigger
- Gateway/protocol tests: 19 passed
- Bundled Control UI browser E2E: 8 passed; the proof test waits for the visible menu before capture
- UI and core type checks: passed
- Production Control UI build: passed startup JS/CSS budgets
- Formatting and focused Oxlint: passed
- Independent exact-head autoreview: scoped-clean with no P0–P2 findings
- ClawSweeper rank-up move applied: the released four-item v4 field is preserved through an additive expanded projection
- Testbox was unavailable during an earlier local changed-file gate, which completed through the repository’s automatic local fallback; hosted exact-head CI remains the landing gate
