### PR TITLE
fix(deps): update fast-uri security patches

### DIFF
--- a/extensions/acpx/npm-shrinkwrap.json
+++ b/extensions/acpx/npm-shrinkwrap.json
@@ -1404,9 +1404,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "funding": [
         {
           "type": "github",

--- a/extensions/lobster/npm-shrinkwrap.json
+++ b/extensions/lobster/npm-shrinkwrap.json
@@ -53,9 +53,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "funding": [
         {
           "type": "github",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1382,9 +1382,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "funding": [
         {
           "type": "github",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   hono: 4.12.25
   '@hono/node-server': 1.19.14
   axios: 1.18.0
-  fast-uri: 4.1.2
+  fast-uri: 4.1.4
   follow-redirects: 1.16.0
   defu: 6.1.5
   fast-xml-parser: 5.7.0
@@ -5060,6 +5060,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -5366,8 +5367,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@4.1.4:
+    resolution: {integrity: sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -10637,7 +10638,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11398,7 +11399,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.2: {}
+  fast-uri@4.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ packages:
 minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
+  # Current fast-uri security baseline; remove after 2026-09-09.
+  - "fast-uri@4.1.4"
   - "@openclaw/crabline@0.1.6"
   - "@openclaw/fs-safe@0.3.0"
   - "@openclaw/proxyline@0.3.3"
@@ -104,7 +106,7 @@ overrides:
   hono: 4.12.25
   "@hono/node-server": 1.19.14
   axios: 1.18.0
-  fast-uri: 4.1.2
+  fast-uri: 4.1.4
   follow-redirects: 1.16.0
   defu: 6.1.5
   fast-xml-parser: 5.7.0


### PR DESCRIPTION
## Summary

- backport main's current `fast-uri` security baseline from 4.1.2 to 4.1.4
- add a version-scoped release-age exception for the newly published security release
- refresh the root lockfile and all affected independently published npm shrinkwraps

## Why

Full Release Validation's exact candidate CI failed its production dependency audit after four high-severity advisories were published for `fast-uri` 4.1.2:

- https://github.com/advisories/GHSA-5jgf-p345-68v8
- https://github.com/advisories/GHSA-f65p-4m7j-42xc
- https://github.com/advisories/GHSA-fph4-wmhf-6fwf
- https://github.com/advisories/GHSA-jqff-g426-hqxp

Failure: https://github.com/openclaw/openclaw/actions/runs/33692121010/job/100452939822

The first patch used 4.1.3, matching main #133572. ClawSweeper correctly identified that current main subsequently moved to 4.1.4 in #136700 / `4cedaa057a9640d87a4ad74a0e6b1d8958d67946` for the latest security baseline. This head now matches 4.1.4.

## Publication scope

The workspace override affects the root package plus package-local npm shrinkwrap generation. Regenerating **all** shrinkwraps changed exactly these publishable surfaces:

- `openclaw`
- `@openclaw/acpx`
- `@openclaw/lobster`

No other candidate plugin shrinkwrap contains `fast-uri`, and no other generated shrinkwrap changed. In particular, the frozen candidate's Zalo Personal shrinkwrap has no `fast-uri` resolution; the ClawSweeper Zalo finding applies to newer main layout, not this release branch.

## Validation

- `pnpm deps:shrinkwrap:check`
- `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high` — no high-or-higher advisories
- verified all three affected npm shrinkwraps resolve `fast-uri@4.1.4`
- direct installed dependency check: `fast-uri@4.1.4`, integrity matches npm and the lockfiles
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, patch correct 0.97

ClawSweeper finding disposition:

- accepted: update from 4.1.3 to current security baseline 4.1.4 and add the narrow release-age exception
- rejected as inapplicable to this frozen tree: Zalo Personal refresh; its shrinkwrap has no `fast-uri` entry, and an all-package regeneration produces no change there

Native PR preflight/security-fast currently fail before reading the patch because the frozen base branch's unauthenticated custom checkout cannot fetch the now-private repository. Dependency Guard is the expected maintainer authorization gate. The exact release validation uses current authenticated trusted tooling.

Production source delta: 0. Dependency policy/generated metadata only: 18 additions / 15 deletions.
