### PR TITLE
fix(ios): enable background refresh wakes with the fetch background mode

### DIFF
--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -60,6 +60,10 @@
 	<string>OpenClaw uses the camera when you scan a Gateway setup QR code or ask your paired Gateway or assistant to capture a photo or short video from this iPhone, for example to connect to your Gateway or show your assistant a document, device screen, or workspace.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>OpenClaw uses your contacts so you can search and reference people while using the assistant.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>OpenClaw reads your steps, sleep, resting heart rate, and workouts from the Apple Health app to create summaries you request and send them through your Gateway to your configured AI provider.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>OpenClaw does not write to the Apple Health app. It uses read-only data to create summaries you request and send them through your Gateway to your configured AI provider.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>OpenClaw discovers and connects to your OpenClaw gateway on the local network.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
@@ -70,10 +74,6 @@
 	<string>OpenClaw uses the microphone for realtime chat, voice wake, push-to-talk, and voice notes.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>OpenClaw may use motion data to support device-aware interactions and automations.</string>
-	<key>NSHealthShareUsageDescription</key>
-	<string>OpenClaw reads your steps, sleep, resting heart rate, and workouts from the Apple Health app to create summaries you request and send them through your Gateway to your configured AI provider.</string>
-	<key>NSHealthUpdateUsageDescription</key>
-	<string>OpenClaw does not write to the Apple Health app. It uses read-only data to create summaries you request and send them through your Gateway to your configured AI provider.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>OpenClaw lets your assistant read photos you allow and lets you choose photos to share.</string>
 	<key>NSRemindersFullAccessUsageDescription</key>
@@ -84,12 +84,12 @@
 	<true/>
 	<key>OpenClawAppGroupIdentifier</key>
 	<string>$(OPENCLAW_ACTIVE_APP_GROUP_ID)</string>
+	<key>OpenClawBuildTimestamp</key>
+	<string>$(OPENCLAW_BUILD_TIMESTAMP)</string>
 	<key>OpenClawCanonicalVersion</key>
 	<string>$(OPENCLAW_IOS_VERSION)</string>
 	<key>OpenClawGitCommit</key>
 	<string>$(OPENCLAW_GIT_COMMIT)</string>
-	<key>OpenClawBuildTimestamp</key>
-	<string>$(OPENCLAW_BUILD_TIMESTAMP)</string>
 	<key>OpenClawPushMode</key>
 	<string>$(OPENCLAW_PUSH_MODE)</string>
 	<key>OpenClawPushRelayBaseURL</key>
@@ -113,6 +113,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>fetch</string>
 		<string>location</string>
 		<string>remote-notification</string>
 	</array>

--- a/apps/ios/Sources/OpenClawApp.swift
+++ b/apps/ios/Sources/OpenClawApp.swift
@@ -281,9 +281,11 @@ final class OpenClawAppDelegate: NSObject, UIApplicationDelegate, @preconcurrenc
     }
 
     private func registerBackgroundWakeRefreshTask() {
+        // The launch handler inherits this delegate's main-actor isolation, so it must run on
+        // the main queue; a nil queue would invoke it on the scheduler's background queue.
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: Self.wakeRefreshTaskIdentifier,
-            using: nil)
+            using: .main)
         { [weak self] task in
             guard let refreshTask = task as? BGAppRefreshTask else {
                 task.setTaskCompleted(success: false)

--- a/apps/ios/Tests/OpenClawAppDelegateTests.swift
+++ b/apps/ios/Tests/OpenClawAppDelegateTests.swift
@@ -27,11 +27,17 @@ import UIKit
         #expect(delegate._test_resolvedAppModel() === explicitModel)
     }
 
-    @Test @MainActor func `derives background refresh task identifier from app bundle identifier`() {
+    @Test @MainActor func `background refresh task is permitted and launchable from the app bundle`() throws {
+        // BGTaskScheduler rejects submit with .notPermitted unless the identifier is listed
+        // and the `fetch` background mode is declared; both contracts live in the app Info.plist.
         let delegate = OpenClawAppDelegate()
-        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "ai.openclawfoundation.app.tests"
+        let bundleIdentifier = try #require(Bundle.main.bundleIdentifier)
+        let info = try #require(Bundle.main.infoDictionary)
+        let identifier = delegate._test_wakeRefreshTaskIdentifier()
 
-        #expect(delegate._test_wakeRefreshTaskIdentifier() == "\(bundleIdentifier).bgrefresh")
+        #expect(identifier == "\(bundleIdentifier).bgrefresh")
+        #expect(info["BGTaskSchedulerPermittedIdentifiers"] as? [String] == [identifier])
+        #expect((info["UIBackgroundModes"] as? [String])?.contains("fetch") == true)
     }
 
     @Test @MainActor func `stages a gateway URL when the model is ready`() async throws {

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -164,6 +164,7 @@ targets:
           UIApplicationSupportsMultipleScenes: false
         UIBackgroundModes:
           - audio
+          - fetch
           - location
           - remote-notification
         BGTaskSchedulerPermittedIdentifiers:

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -316,6 +316,8 @@ When iOS wakes the app for a silent push, background refresh, or significant-loc
 
 The app treats a background wake as successfully recorded only when the gateway response includes `handled: true`. Older gateways may acknowledge `node.event` with `{ "ok": true }`; that response is compatible but does not count as a durable last-seen update.
 
+Background refresh wakes are requested through the system BackgroundTasks scheduler whenever the app moves to the background, after a silent push that could not be applied, and again after each refresh run; iOS decides when they actually execute. They stop if Background App Refresh is turned off for OpenClaw in iOS Settings, leaving push and significant-location wakes.
+
 Compatibility note:
 
 - `OPENCLAW_APNS_RELAY_BASE_URL` still works as a temporary env override for the gateway (`gateway.push.apns.relay.baseUrl` is the config-first path).


### PR DESCRIPTION
## What Problem This Solves

The iOS app's background wake refresh path (`registerBackgroundWakeRefreshTask` / `scheduleBackgroundWakeRefresh` / `handleBackgroundWakeRefresh` in `apps/ios/Sources/OpenClawApp.swift`) never ran on devices. `Info.plist` listed the `bgrefresh` task in `BGTaskSchedulerPermittedIdentifiers`, but `UIBackgroundModes` only declared `audio`, `location`, and `remote-notification`. Apple's BackgroundTasks contract (iOS 27 SDK `BGTask.h`: "Executing app refresh tasks requires setting the `fetch` UIBackgroundModes capability"; `BGTaskScheduler.h`: `BGTaskSchedulerErrorCodeNotPermitted` when "The app doesn't set the appropriate mode in the UIBackgroundModes array") means every `BGTaskScheduler.submit` failed, so each scene-background and each unapplied silent push only logged `Failed scheduling background wake refresh ... error=... (BGTaskSchedulerErrorDomain error 3.)` and no background refresh was ever scheduled. The docs (`docs/platforms/ios.md`, "Background alive beacons") promise background-refresh wakes and the gateway accepts the `bg_app_refresh` presence reason, so this was a silently dead product path.

Second, the launch handler was registered with `using: nil`, which the SDK documents as "a default background queue", while the closure is formed inside the `@MainActor` app delegate and synchronously calls main-actor methods. Swift infers main-actor isolation for that closure, so the runtime executor did not match the compile-time isolation (a data race, not a crash).

## Why This Change Was Made

Repair Doctrine: fix the missing capability at its producer. The path already has settlement semantics (#129097, #129026, #127521) that were only ever validated on the simulator, where `BGTaskScheduler` is unavailable, so the missing plist capability went unnoticed.

- `apps/ios/project.yml` + generated `apps/ios/Sources/Info.plist`: add `fetch` to `UIBackgroundModes`.
- `OpenClawApp.swift`: register the launch handler on `.main` so the executor matches the delegate's main-actor isolation and the expiration handler is installed synchronously inside the launch handler (no async hop before `expirationHandler` is set).
- `docs/platforms/ios.md`: describe when refresh wakes are requested and that the iOS Background App Refresh setting controls them.
- `OpenClawAppDelegateTests`: the hosted test now asserts the app bundle's `BGTaskSchedulerPermittedIdentifiers` matches the derived task identifier and that `UIBackgroundModes` includes `fetch`. It fails on the pre-fix plist for exactly the missing `fetch` mode.

Production LOC: +2 plist/project lines, Swift net 0 (queue argument + 2-line invariant comment). No new config, protocol, or schema surface. `BackgroundAliveBeacon.Trigger.bgAppRefresh` and the gateway `node-presence` reason list are unchanged.

## User Impact

Paired iPhones now get periodic background refresh wakes (≥120 s after backgrounding, ≥90 s after a silent push that could not be applied, then ~15 min reschedules at iOS's discretion), so the gateway's `lastSeenAtMs`/`lastSeenReason` presence stays fresh and reconnect attempts happen without a push. This matters most for local/dev builds and gateways without a push relay, where silent pushes are unavailable. Users who disabled Background App Refresh for OpenClaw in iOS Settings see no change (the submit is still refused, and is logged).

Release-note context: fix(ios): background refresh wakes never scheduled because the app lacked the `fetch` background mode; register the refresh launch handler on the main queue. Reporter/author: @steipete.

## Evidence

- Contract source: iOS 27.0 SDK `BackgroundTasks.framework/Headers/BGTask.h` ("Executing app refresh tasks requires setting the `fetch` UIBackgroundModes capability") and `BGTaskScheduler.h` (`BGTaskSchedulerErrorCodeNotPermitted`: "The app doesn't set the appropriate mode in the UIBackgroundModes array"; `registerForTaskWithIdentifier:usingQueue:` "Pass `nil` to use a default background queue").
- Fail-before on the simulator (`OpenClaw BGRefresh`, iPhone 17 Pro, iOS 27.0), pre-fix plist: `OpenClawAppDelegateTests` -> `background refresh task is permitted and launchable from the app bundle` failed at `OpenClawAppDelegateTests.swift:40` with `Expectation failed: (info["UIBackgroundModes"] as? [String])?.contains("fetch") == true`; the permitted-identifier expectation on line 39 already passed.
- Pass-after on the same simulator: `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -configuration Debug -destination 'platform=iOS Simulator,id=<udid>' -parallel-testing-enabled NO -only-testing:OpenClawTests/OpenClawAppDelegateTests -only-testing:OpenClawTests/NodeAppModelInvokeTests CODE_SIGNING_ALLOWED=NO test` -> 259 tests in 2 suites passed (`NodeAppModelInvokeTests` drives the real delegate's silent-push and background-refresh settlement paths).
- Device build: `xcodebuild ... -destination 'generic/platform=iOS' -allowProvisioningUpdates build` succeeds; the built `OpenClaw.app/Info.plist` now reports `UIBackgroundModes = ["audio","fetch","location","remote-notification"]` and `BGTaskSchedulerPermittedIdentifiers = ["<bundle id>.bgrefresh"]`.
- `node scripts/check-changed.mjs -- <changed files>`: format check, `lint:apps` (SwiftLint 0 violations in 385 files, swiftformat lint), and the native state schema version guard all passed. Codex-backed autoreview on the uncommitted diff: scoped-clean, no accepted findings.
- Real-device proof (BackgroundWake log category on a physical iPhone): **not yet captured**. The paired iPhone 17 Pro Max (iOS 27.0) was locked and then dropped to `unavailable` over Wi-Fi during this session, so `devicectl` could neither launch the installed pre-fix build nor install the fixed one, and `log collect --device` requires root. The fixed device binary is built and the capture script is ready (console launch with `OS_ACTIVITY_DT_MODE=YES`, background via Settings, expect `Scheduled background wake refresh reason=scene_background delaySeconds=120` instead of the pre-fix `Failed scheduling background wake refresh ... BGTaskSchedulerErrorDomain error 3`). Will attach the before/after console output as soon as the device is reachable; simulator runs cannot cover this because `BGTaskScheduler` is unavailable there.

CI note: the `iOS Periphery Dead Code` and `Shared OpenClawKit Periphery` runs for this head sat queued on `blacksmith-12vcpu-macos-26` for ~95 minutes while newer runs of the same workflows on other branches completed, so I cancelled and reran both (attempt 2); every other check at the head was already green.

Follow-up (not in this PR): `NodeAppModel.handleBackgroundRefreshWake(trigger: String)` takes a stringly trigger; the watch-prompt caller passes `"watch_prompt_action"`, which `BackgroundAliveBeacon.normalizeTrigger` folds to `.background`. Taking `BackgroundAliveBeacon.Trigger` directly would make that explicit and let `normalizeTrigger` go.
