### PR TITLE
fix(plugins): reject unverifiable pinned npm installs

### DIFF
--- a/src/infra/npm-integrity.test.ts
+++ b/src/infra/npm-integrity.test.ts
@@ -3,6 +3,25 @@ import { describe, expect, it, vi } from "vitest";
 import { resolveNpmIntegrityDriftWithDefaultMessage } from "./npm-integrity.js";
 
 describe("resolveNpmIntegrityDrift", () => {
+  it("rejects a missing resolved integrity when an expected pin exists", async () => {
+    const onIntegrityDrift = vi.fn(async () => true);
+
+    const result = await resolveNpmIntegrityDriftWithDefaultMessage({
+      spec: "@openclaw/test@1.0.0",
+      expectedIntegrity: "sha512-trusted",
+      resolution: {
+        resolvedSpec: "@openclaw/test@1.0.0",
+        resolvedAt: "2026-01-01T00:00:00.000Z",
+      },
+      onIntegrityDrift,
+    });
+
+    expect(result).toEqual({
+      error: "aborted: npm package integrity missing for @openclaw/test@1.0.0",
+    });
+    expect(onIntegrityDrift).not.toHaveBeenCalled();
+  });
+
   it("formats default warning and abort error messages", async () => {
     const warn = vi.fn();
     const warningResult = await resolveNpmIntegrityDriftWithDefaultMessage({

--- a/src/infra/npm-integrity.test.ts
+++ b/src/infra/npm-integrity.test.ts
@@ -3,6 +3,15 @@ import { describe, expect, it, vi } from "vitest";
 import { resolveNpmIntegrityDriftWithDefaultMessage } from "./npm-integrity.js";
 
 describe("resolveNpmIntegrityDrift", () => {
+  it("allows missing resolved integrity when no expected pin exists", async () => {
+    await expect(
+      resolveNpmIntegrityDriftWithDefaultMessage({
+        spec: "@openclaw/test@1.0.0",
+        resolution: { resolvedSpec: "@openclaw/test@1.0.0" },
+      }),
+    ).resolves.toEqual({});
+  });
+
   it("rejects a missing resolved integrity when an expected pin exists", async () => {
     const onIntegrityDrift = vi.fn(async () => true);
 

--- a/src/infra/npm-integrity.ts
+++ b/src/infra/npm-integrity.ts
@@ -9,66 +9,9 @@ export type NpmIntegrityDriftPayload = {
   resolution: NpmSpecResolution;
 };
 
-type ResolveNpmIntegrityDriftParams<TPayload> = {
-  spec: string;
-  expectedIntegrity?: string;
-  resolution: NpmSpecResolution;
-  createPayload: (params: {
-    spec: string;
-    expectedIntegrity: string;
-    actualIntegrity: string;
-    resolution: NpmSpecResolution;
-  }) => TPayload;
-  onIntegrityDrift?: (payload: TPayload) => boolean | Promise<boolean>;
-  warn?: (payload: TPayload) => void;
-};
-
-type ResolveNpmIntegrityDriftResult<TPayload> = {
-  integrityDrift?: NpmIntegrityDrift;
-  proceed: boolean;
-  payload?: TPayload;
-};
-
 function normalizeIntegrity(value: string | undefined): string | undefined {
   const normalized = value?.trim();
   return normalized ? normalized : undefined;
-}
-
-/**
- * Compares expected and resolved npm integrity values and asks the caller
- * whether a drifted archive may still be installed.
- */
-async function resolveNpmIntegrityDrift<TPayload>(
-  params: ResolveNpmIntegrityDriftParams<TPayload>,
-): Promise<ResolveNpmIntegrityDriftResult<TPayload>> {
-  const expectedIntegrity = normalizeIntegrity(params.expectedIntegrity);
-  const actualIntegrity = normalizeIntegrity(params.resolution.integrity);
-  if (!expectedIntegrity || !actualIntegrity) {
-    return { proceed: true };
-  }
-  if (expectedIntegrity === actualIntegrity) {
-    return { proceed: true };
-  }
-
-  const integrityDrift: NpmIntegrityDrift = {
-    expectedIntegrity,
-    actualIntegrity,
-  };
-  const payload = params.createPayload({
-    spec: params.spec,
-    expectedIntegrity: integrityDrift.expectedIntegrity,
-    actualIntegrity: integrityDrift.actualIntegrity,
-    resolution: params.resolution,
-  });
-
-  let proceed = false;
-  if (params.onIntegrityDrift) {
-    proceed = await params.onIntegrityDrift(payload);
-  } else {
-    params.warn?.(payload);
-  }
-
-  return { integrityDrift, proceed, payload };
 }
 
 type ResolveNpmIntegrityDriftWithDefaultMessageParams = {
@@ -86,25 +29,38 @@ type ResolveNpmIntegrityDriftWithDefaultMessageParams = {
 export async function resolveNpmIntegrityDriftWithDefaultMessage(
   params: ResolveNpmIntegrityDriftWithDefaultMessageParams,
 ): Promise<{ integrityDrift?: NpmIntegrityDrift; error?: string }> {
-  const driftResult = await resolveNpmIntegrityDrift<NpmIntegrityDriftPayload>({
-    spec: params.spec,
-    expectedIntegrity: params.expectedIntegrity,
-    resolution: params.resolution,
-    createPayload: (drift) => ({ ...drift }),
-    onIntegrityDrift: params.onIntegrityDrift,
-    warn: (driftPayload) => {
-      params.warn?.(
-        `Integrity drift detected for ${driftPayload.resolution.resolvedSpec ?? driftPayload.spec}: expected ${driftPayload.expectedIntegrity}, got ${driftPayload.actualIntegrity}`,
-      );
-    },
-  });
-
-  if (!driftResult.proceed && driftResult.payload) {
-    return {
-      integrityDrift: driftResult.integrityDrift,
-      error: `aborted: npm package integrity drift detected for ${driftResult.payload.resolution.resolvedSpec ?? driftResult.payload.spec}`,
-    };
+  const expectedIntegrity = normalizeIntegrity(params.expectedIntegrity);
+  if (!expectedIntegrity) {
+    return {};
   }
 
-  return { integrityDrift: driftResult.integrityDrift };
+  const subject = params.resolution.resolvedSpec ?? params.spec;
+  const actualIntegrity = normalizeIntegrity(params.resolution.integrity);
+  if (!actualIntegrity) {
+    return { error: `aborted: npm package integrity missing for ${subject}` };
+  }
+  if (expectedIntegrity === actualIntegrity) {
+    return {};
+  }
+
+  const integrityDrift: NpmIntegrityDrift = { expectedIntegrity, actualIntegrity };
+  const payload: NpmIntegrityDriftPayload = {
+    spec: params.spec,
+    expectedIntegrity,
+    actualIntegrity,
+    resolution: params.resolution,
+  };
+  let proceed = false;
+  if (params.onIntegrityDrift) {
+    proceed = await params.onIntegrityDrift(payload);
+  } else {
+    params.warn?.(
+      `Integrity drift detected for ${subject}: expected ${expectedIntegrity}, got ${actualIntegrity}`,
+    );
+  }
+
+  return {
+    integrityDrift,
+    ...(proceed ? {} : { error: `aborted: npm package integrity drift detected for ${subject}` }),
+  };
 }

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -80,11 +80,13 @@ function useRegistry(registry: string): void {
 
 async function installNpmPlugin(params: {
   config?: OpenClawConfig;
+  expectedIntegrity?: string;
   npmRoot: string;
   spec: string;
 }) {
   return await installPluginFromNpmSpec({
     ...(params.config ? { config: params.config } : {}),
+    ...(params.expectedIntegrity ? { expectedIntegrity: params.expectedIntegrity } : {}),
     spec: params.spec,
     npmDir: params.npmRoot,
     logger: { info: () => {}, warn: () => {} },
@@ -952,5 +954,28 @@ describe("installPluginFromNpmSpec e2e", () => {
     const installedLockEntry = lock.packages?.[`node_modules/${packageName}`];
     expect(installedLockEntry?.integrity).toBe(versions[0]?.integrity);
     expect(installedLockEntry?.version).toBe("1.0.0");
+  });
+
+  it("rejects a trusted pin when a real registry omits dist.integrity", async () => {
+    const { rootDir, npmRoot } = await makeInstallFixture("missing-registry-integrity-e2e");
+    const packageName = uniquePackageName("missing-registry-integrity-plugin");
+    await useStaticRegistry(
+      await registryPackages(rootDir, [{ packageName, omitIntegrity: true }]),
+    );
+
+    const result = await installNpmPlugin({
+      spec: `${packageName}@1.0.0`,
+      expectedIntegrity: `sha512-${Buffer.alloc(64, 1).toString("base64")}`,
+      npmRoot,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: `aborted: npm package integrity missing for ${packageName}@1.0.0`,
+    });
+    await expect(fs.access(pluginNpmProjectRoot(npmRoot, packageName))).rejects.toHaveProperty(
+      "code",
+      "ENOENT",
+    );
   });
 });

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -324,6 +324,7 @@ type MockNpmPackage = {
   versions?: string[];
   installedVersion?: string;
   installedIntegrity?: string;
+  omitViewIntegrity?: boolean;
   omitInstalledVersion?: boolean;
   omitInstalledIntegrity?: boolean;
   materializesRootOpenClaw?: boolean;
@@ -484,7 +485,9 @@ function mockNpmViewAndInstallMany(packages: MockNpmPackage[]) {
             name: viewPackage.packageName,
             version: viewPackage.version,
             dist: {
-              integrity: viewPackage.integrity ?? "sha512-plugin-test",
+              ...(viewPackage.omitViewIntegrity
+                ? {}
+                : { integrity: viewPackage.integrity ?? "sha512-plugin-test" }),
               shasum: viewPackage.shasum ?? "pluginshasum",
             },
             ...(viewPackage.openclaw ? { openclaw: viewPackage.openclaw } : {}),
@@ -1340,6 +1343,38 @@ describe("installPluginFromNpmSpec", () => {
       false,
     );
     expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, "drift-plugin"))).toBe(false);
+  });
+
+  it("rejects a trusted pin when registry metadata omits integrity before install", async () => {
+    const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
+    const packageName = "missing-registry-integrity-plugin";
+    mockNpmViewAndInstall({
+      spec: `${packageName}@latest`,
+      packageName,
+      version: "1.0.0",
+      pluginId: packageName,
+      integrity: "sha512-substituted",
+      shasum: "substituted-shasum",
+      omitViewIntegrity: true,
+      npmRoot,
+      expectedDependencySpec: "1.0.0",
+    });
+
+    const result = await installPluginFromNpmSpec({
+      spec: `${packageName}@latest`,
+      expectedIntegrity: "sha512-trusted",
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: `aborted: npm package integrity missing for ${packageName}@1.0.0`,
+    });
+    expect(
+      runCommandWithTimeoutMock.mock.calls.some(([argv]) => isManagedNpmInstallCommand(argv)),
+    ).toBe(false);
+    expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, packageName))).toBe(false);
   });
 
   it("rejects npm installs when the installed version drifts from verified metadata", async () => {

--- a/src/plugins/test-helpers/npm-registry-fixtures.ts
+++ b/src/plugins/test-helpers/npm-registry-fixtures.ts
@@ -35,6 +35,7 @@ type PackPluginParams = {
 
 export type RegistryPackage = {
   latest: string;
+  omitIntegrity?: boolean;
   packageName: string;
   versions: PackedVersion[];
 };
@@ -148,12 +149,16 @@ export async function packPlugins(
 
 export async function registryPackages(
   rootDir: string,
-  packages: [PackPluginParams & { latest?: string }, ...(PackPluginParams & { latest?: string })[]],
+  packages: [
+    PackPluginParams & { latest?: string; omitIntegrity?: boolean },
+    ...(PackPluginParams & { latest?: string; omitIntegrity?: boolean })[],
+  ],
 ): Promise<RegistryPackage[]> {
   const versions = await packPlugins(rootDir, packages);
   return packages.map((params, index) => ({
     packageName: params.packageName,
     latest: params.latest ?? params.version ?? "1.0.0",
+    ...(params.omitIntegrity ? { omitIntegrity: true } : {}),
     versions: [expectDefined(versions[index], "packed fixture version")],
   }));
 }
@@ -209,7 +214,7 @@ export async function startStaticRegistry(
                     ? { peerDependenciesMeta: entry.peerDependenciesMeta }
                     : {}),
                   dist: {
-                    integrity: entry.integrity,
+                    ...(pkg.omitIntegrity ? {} : { integrity: entry.integrity }),
                     shasum: entry.shasum,
                     tarball: `${baseUrl}/${pkg.encodedPackageName}/-/${entry.tarballName}`,
                   },


### PR DESCRIPTION
## Summary

Make pinned npm plugin installs stop when package metadata cannot provide the integrity value needed to validate the pin.

## Changes

- distinguish unpinned installs from pinned installs with missing integrity metadata
- preserve the existing explicit consent flow for present integrity mismatches
- cover the policy with unit, mocked-installer, and real-registry tests

## Validation

- `node scripts/run-vitest.mjs run src/infra/npm-integrity.test.ts --reporter=dot`
- `node scripts/run-vitest.mjs run src/plugins/install.npm-spec.test.ts --reporter=dot`
- `node scripts/run-vitest.mjs run src/plugins/install.npm-spec.e2e.test.ts -t 'rejects a trusted pin when a real registry omits dist.integrity' --reporter=dot`
- `node scripts/check-changed.mjs -- src/infra/npm-integrity.ts src/infra/npm-integrity.test.ts src/plugins/install.npm-spec.test.ts src/plugins/install.npm-spec.e2e.test.ts src/plugins/test-helpers/npm-registry-fixtures.ts`

## Notes

- No configuration, schema, migration, CLI, protocol, or plugin SDK changes.
- Unpinned npm plugin installs retain their existing behavior.
- Production code is net 44 lines smaller.
