### PR TITLE
fix: heartbeat failure notices omit why the check was refused

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -320,6 +320,7 @@ Heartbeat configuration is strict: only the fields listed above are accepted. Ac
 
   </Accordion>
   <Accordion title="Visibility and skip behavior">
+    - If the heartbeat turn fails before the model can reply, the failure notice names the reason whenever OpenClaw itself refused the run (for example, the session's runtime is still busy in another runner). Raw provider or runtime errors stay behind the verbose failure-detail setting (`/verbose on` or `/verbose full`), as in normal chats.
     - If `showOk`, `showAlerts`, and `useIndicator` are all disabled, the run is skipped up front as `reason=alerts-disabled`.
     - If only alert delivery is disabled, OpenClaw can still run the heartbeat, update due-task timestamps, restore the session idle timestamp, and suppress the outward alert payload.
     - If the channel readiness check blocks an alert, OpenClaw records the non-delivery and retries the heartbeat after a one-minute grace period without consuming its cadence slot. This retry runs the heartbeat again; it does not replay the exact earlier alert. Once a send enters the durable delivery queue, that queue owns transport retries.

--- a/src/agents/failover/user-copy.test.ts
+++ b/src/agents/failover/user-copy.test.ts
@@ -1,15 +1,32 @@
 import { describe, expect, it } from "vitest";
 import {
+  HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
   renderFormatErrorCopy,
   renderBillingReplyCopy,
   renderCliTimeoutReplyCopy,
   renderFailoverCodeUserCopy,
+  renderHeartbeatRunFailureCopy,
   renderMissingApiKeyReplyCopy,
   renderRateLimitOrOverloadedCopy,
   renderRateLimitReplyCopy,
 } from "./user-copy.js";
 
 describe("failover user copy", () => {
+  it.each([
+    [undefined, HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT],
+    ["", HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT],
+    [
+      "Codex session became active in another runner; wait for it to finish before continuing",
+      "⚠️ Heartbeat check failed before it could produce an update: Codex session became active in another runner; wait for it to finish before continuing. The main chat session remains available.",
+    ],
+    [
+      "Codex session became active in another runner; wait for it to finish before continuing.",
+      "⚠️ Heartbeat check failed before it could produce an update: Codex session became active in another runner; wait for it to finish before continuing. The main chat session remains available.",
+    ],
+  ])("renders heartbeat failure copy for %j", (reason, expected) => {
+    expect(renderHeartbeatRunFailureCopy(reason)).toBe(expected);
+  });
+
   const tokenLimitCopy =
     "LLM request rejected: configured maxTokens is 384000, above the provider maximum of 65536. Lower maxTokens and try again.";
 

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -357,8 +357,19 @@ export function renderSanitizedUserFacingText(
 
 export const GENERIC_EXTERNAL_RUN_FAILURE_TEXT =
   "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.";
-export const HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT =
-  "⚠️ Heartbeat check failed before it could produce an update. The main chat session remains available.";
+const HEARTBEAT_FAILURE_LEAD = "⚠️ Heartbeat check failed before it could produce an update";
+const HEARTBEAT_FAILURE_TAIL = "The main chat session remains available.";
+export const HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT = `${HEARTBEAT_FAILURE_LEAD}. ${HEARTBEAT_FAILURE_TAIL}`;
+
+/** `reason` is the failure-reply owner's already sanitized and capped detail. */
+export function renderHeartbeatRunFailureCopy(reason?: string): string {
+  if (!reason) {
+    return HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT;
+  }
+  const terminator = /[.!?]$/u.test(reason) ? "" : ".";
+  return `${HEARTBEAT_FAILURE_LEAD}: ${reason}${terminator} ${HEARTBEAT_FAILURE_TAIL}`;
+}
+
 export const PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE =
   "⚠️ The model provider rejected the conversation state. Please try again, or use /new to start a fresh session.";
 const PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE =

--- a/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
@@ -3,8 +3,12 @@ import { FailoverError } from "../../agents/failover-error.js";
 import {
   formatBillingErrorMessage,
   HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+  renderHeartbeatRunFailureCopy,
 } from "../../agents/failover/user-copy.js";
-import { AgentHarnessSessionSupersededError } from "../../agents/harness/errors.js";
+import {
+  AgentHarnessPreflightError,
+  AgentHarnessSessionSupersededError,
+} from "../../agents/harness/errors.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
@@ -616,6 +620,26 @@ describe("executeAgentTurn: terminal failures", () => {
     }
     expect(result.payload.text).toBe(HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT);
     expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+    expect(result.payload.text).not.toContain("/new");
+  });
+
+  it("includes heartbeat preflight reasons in terminal failure replies", async () => {
+    const message =
+      "Codex session became active in another runner; wait for it to finish before continuing";
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(new AgentHarnessPreflightError(message));
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn({
+      ...createMinimalRunAgentTurnParams(),
+      isHeartbeat: true,
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind !== "final") {
+      throw new Error("expected final reply");
+    }
+    expect(result.payload.text).toBe(renderHeartbeatRunFailureCopy(message));
+    expect(result.payload.isError).toBe(true);
     expect(result.payload.text).not.toContain("/new");
   });
 

--- a/src/auto-reply/reply/agent-runner-failure-reply.test.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.test.ts
@@ -49,8 +49,21 @@ describe("buildEmptyInteractiveReplyPayload", () => {
 });
 
 describe("buildExternalRunFailureReply", () => {
+  it("includes heartbeat preflight reasons without verbose opt-in", () => {
+    const message =
+      "Codex session became active in another runner; wait for it to finish before continuing";
+    const reply = buildExternalRunFailureReply(
+      { message, error: new AgentHarnessPreflightError(message) },
+      { isHeartbeat: true },
+    );
+
+    expect(reply.text).toContain(message);
+    expect(reply.isGenericRunnerFailure).toBe(false);
+    expect(reply.text).not.toContain("/new");
+  });
+
   it.each(["401 unauthorized", "529 overloaded", "503 service unavailable", "402 billing"])(
-    "keeps preflight %s diagnostics behind verbose opt-in",
+    "keeps preflight %s diagnostics verbose-gated except for heartbeats",
     (failure) => {
       const message = `${failure}; reconnect before continuing. diagnostic-canary ${"x".repeat(1500)}`;
       const input = {
@@ -77,14 +90,20 @@ describe("buildExternalRunFailureReply", () => {
         isHeartbeat: true,
         includeDetails: true,
       });
-      expect(heartbeat.text).toBe(HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT);
+      expect(heartbeat.isGenericRunnerFailure).toBe(false);
+      expect(heartbeat.text).toBe(
+        `⚠️ Heartbeat check failed before it could produce an update: ${message.slice(0, 899)}…. The main chat session remains available.`,
+      );
+      expect(heartbeat.text).toContain("reconnect before continuing");
+      expect(heartbeat.text).toContain("diagnostic-canary");
+      expect(heartbeat.text).not.toContain("/new");
       expect(
         resolveExternalRunFailureTextForConversation({
           text: heartbeat.text,
           isGenericRunnerFailure: heartbeat.isGenericRunnerFailure,
           sessionCtx: { Provider: "discord", Surface: "discord", ChatType: "group" },
         }),
-      ).toBe(HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT);
+      ).toBe(heartbeat.text);
       const verbose = buildExternalRunFailureReply(input, { includeDetails: true });
       expect(verbose.isGenericRunnerFailure).toBe(true);
       expect(verbose.text).toContain("reconnect before continuing");
@@ -94,6 +113,21 @@ describe("buildExternalRunFailureReply", () => {
       );
     },
   );
+
+  it("keeps raw heartbeat failure details behind verbose opt-in", () => {
+    const input = { message: "boom-canary", error: new Error("boom-canary") };
+    expect(buildExternalRunFailureReply(input, { isHeartbeat: true })).toEqual({
+      text: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+      isGenericRunnerFailure: false,
+    });
+    const verbose = buildExternalRunFailureReply(input, {
+      isHeartbeat: true,
+      includeDetails: true,
+    });
+    expect(verbose.text).toContain("boom-canary");
+    expect(verbose.text).not.toContain("/new");
+    expect(verbose.isGenericRunnerFailure).toBe(false);
+  });
 
   it("forwards classified provider copy when verbose detail is off", () => {
     const message = "opaque provider response with secret-canary";

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -26,6 +26,7 @@ import {
   renderBillingReplyCopy,
   renderCliTimeoutReplyCopy,
   renderFailoverCodeUserCopy,
+  renderHeartbeatRunFailureCopy,
   renderMissingApiKeyReplyCopy,
   renderRateLimitOrOverloadedCopy,
   renderRateLimitReplyCopy,
@@ -202,19 +203,21 @@ export function buildAuthProfileFailoverFailureText(error: unknown): string | nu
   });
 }
 
-function formatForwardedExternalRunFailureText(message: string): string {
+function resolveExternalRunFailureDetail(message: string): string | undefined {
   const sanitized = message
     .trim()
     .replace(/^⚠️\s*/u, "")
     .replace(/\s+/gu, " ");
-  if (!sanitized) {
-    return GENERIC_EXTERNAL_RUN_FAILURE_TEXT;
-  }
-  const detail =
-    sanitized.length > EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS
-      ? `${truncateUtf16Safe(sanitized, EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS - 1).trimEnd()}…`
-      : sanitized;
-  return `⚠️ Agent failed before reply: ${detail}${/[.!?]$/u.test(detail) ? "" : "."} Please try again, or use /new to start a fresh session.`;
+  return sanitized.length > EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS
+    ? `${truncateUtf16Safe(sanitized, EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS - 1).trimEnd()}…`
+    : sanitized || undefined;
+}
+
+function formatForwardedExternalRunFailureText(message: string): string {
+  const detail = resolveExternalRunFailureDetail(message);
+  return detail
+    ? `⚠️ Agent failed before reply: ${detail}${/[.!?]$/u.test(detail) ? "" : "."} Please try again, or use /new to start a fresh session.`
+    : GENERIC_EXTERNAL_RUN_FAILURE_TEXT;
 }
 
 export function buildExternalRunFailureReply(
@@ -230,16 +233,16 @@ export function buildExternalRunFailureReply(
   const message = typeof input === "string" ? input : input.message;
   const error = typeof input === "string" ? undefined : input.error;
   const normalizedMessage = collapseRepeatedFailureDetail(message);
-  // Preflight detail is diagnostic, not provider copy or an assurance that it is
-  // safe to disclose. Verbose opt-in and the shared detail cap still apply.
+  // A preflight refusal is host-authored and names the next step. Heartbeats run
+  // unattended in the owner's session, so they disclose it without the verbose
+  // opt-in; raw thrown detail further below stays verbose-gated.
   if (isAgentHarnessPreflightError(error)) {
+    const sanitizedMessage = sanitizeUserFacingText(normalizedMessage, { errorContext: true });
     return {
       text: options?.isHeartbeat
-        ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
+        ? renderHeartbeatRunFailureCopy(resolveExternalRunFailureDetail(sanitizedMessage))
         : options?.includeDetails
-          ? formatForwardedExternalRunFailureText(
-              sanitizeUserFacingText(normalizedMessage, { errorContext: true }),
-            )
+          ? formatForwardedExternalRunFailureText(sanitizedMessage)
           : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
       isGenericRunnerFailure: !options?.isHeartbeat,
     };
@@ -326,7 +329,12 @@ export function buildExternalRunFailureReply(
     return { text: missingApiKeyFailure, isGenericRunnerFailure: false };
   }
   if (options?.isHeartbeat) {
-    return { text: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT, isGenericRunnerFailure: false };
+    const detail = options.includeDetails
+      ? resolveExternalRunFailureDetail(
+          sanitizeUserFacingText(normalizedMessage, { errorContext: true }),
+        )
+      : undefined;
+    return { text: renderHeartbeatRunFailureCopy(detail), isGenericRunnerFailure: false };
   }
   const codexAppServerFailure = buildCodexAppServerFailureText(normalizedMessage);
   if (codexAppServerFailure) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators watching the main session (the Control UI Home pane, or the heartbeat's owner delivery target) would see the identical notice "⚠️ Heartbeat check failed before it could produce an update. The main chat session remains available." on every heartbeat tick, with no cause and no next step, when the heartbeat turn was refused before the model ran. In the reported case the Codex runtime refused with "Codex session became active in another runner; wait for it to finish before continuing"; user turns in the same session showed that reason, heartbeat turns hid it.

## Why This Change Was Made

Heartbeat failure notices now carry the reason whenever OpenClaw itself refused the run (a harness preflight error), sanitized and capped with the same detail rule the forwarded-failure copy already uses. Raw, unclassified thrown errors keep the generic sentence unless the verbose failure-detail opt-in is on, exactly as normal chats behave, and the heartbeat copy still never suggests `/new` since heartbeats run in the main session. This deliberately changes the heartbeat expectation added in #135577 (heartbeat plus verbose still generic), by maintainer decision: preflight text is host-authored, states the next step, and is already shown verbatim for user turns in the Control UI. Accepted tradeoff: a heartbeat delivered to a group via `target: "last"` now sees that host-authored sentence too, the same disclosure class as the curated auth and quota copy heartbeats already deliver there.

Non-goals: collapsing consecutive identical heartbeat failure notices into one recorded non-outcome (follow-up), and the underlying Codex thread-active condition itself.

## User Impact

Operators see why a heartbeat failed and what to try next in the notice itself, instead of a repeated dead-end bubble. Example after this change:

`⚠️ Heartbeat check failed before it could produce an update: Codex session became active in another runner; wait for it to finish before continuing. The main chat session remains available.`

Nothing changes for heartbeats that fail with classified provider errors (auth, quota, rate limits keep their curated copy) or for normal chat turns.

## Evidence

- Two fail-first regression tests, both failing on the pre-change code by receiving the generic sentence: `buildExternalRunFailureReply` with a heartbeat preflight error and no verbose opt-in (`src/auto-reply/reply/agent-runner-failure-reply.test.ts`), and the real `executeAgentTurn` path rejecting with an `AgentHarnessPreflightError` during a heartbeat turn (`src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts`), asserting the exact rendered notice and no `/new`.
- Focused suites green: `src/agents/failover/user-copy.test.ts`, `src/auto-reply/reply/agent-runner-failure-reply.test.ts`, `src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts`, `src/auto-reply/reply/agent-runner-execution-probes.test.ts`, `src/infra/heartbeat-runner.tool-response.test.ts`, `src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`.
- `node scripts/check-changed.mjs` green (format, typecheck, lint, guards); `git diff --check` clean; autoreview (Codex) scoped-clean with no findings.
- Production LOC: +19 net (`user-copy.ts` +11 for the shared lead/tail wording and renderer, `agent-runner-failure-reply.ts` +8 for the extracted detail cap and the two heartbeat branches); tests +75; docs +1 (`docs/gateway/heartbeat.md`, visibility and skip behavior).
- UI proof gap, stated: reproducing a heartbeat preflight refusal on a live gateway needs a Codex thread held active by another runner, which is the open runtime condition this PR does not address. The terminal-failure regression drives the real agent-turn path with the same error class and asserts the exact notice text; the before text is the generic sentence quoted above from the operator's live Control UI session.
