### PR TITLE
fix(docs-ci): docs config-examples check crashes on a newer local state database

### DIFF
--- a/src/config/doc-baseline.ts
+++ b/src/config/doc-baseline.ts
@@ -1,7 +1,6 @@
 // Builds documentation baselines from config schema metadata.
 import { createHash } from "node:crypto";
 import fsSync from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
@@ -9,6 +8,7 @@ import { sortUniqueStrings } from "@openclaw/normalization-core/string-normaliza
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { replaceFileAtomicSync } from "../infra/replace-file.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { resolveRepoBundledPluginEnv } from "./repo-bundled-plugin-env.js";
 import type { ConfigSchemaResponse } from "./schema.js";
 import { schemaHasChildren } from "./schema.shared.js";
 
@@ -364,12 +364,7 @@ function resolveEntryKind(configPath: string): ConfigDocBaselineKind {
 async function loadBundledConfigSchemaResponse(): Promise<ConfigSchemaResponse> {
   const repoRoot = resolveRepoRoot();
   const runtime = await loadDocBaselineRuntime();
-  const env = {
-    ...process.env,
-    HOME: os.tmpdir(),
-    OPENCLAW_STATE_DIR: path.join(os.tmpdir(), "openclaw-config-doc-baseline-state"),
-    OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(repoRoot, "extensions"),
-  };
+  const env = resolveRepoBundledPluginEnv(path.join(repoRoot, "extensions"));
 
   const manifestRegistry = runtime.loadPluginManifestRegistry({
     env,

--- a/src/config/docs-config-examples.test.ts
+++ b/src/config/docs-config-examples.test.ts
@@ -1,9 +1,18 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import {
+  restoreStateDirEnv,
+  setStateDirEnv,
+  snapshotStateDirEnv,
+} from "../test-helpers/state-dir-env.js";
 import { auditDocsConfigExamples } from "./docs-config-examples.js";
+import { resolveRepoBundledPluginEnv } from "./repo-bundled-plugin-env.js";
 
 type SkipStat = "skippedFragment" | "skippedNonObject" | "skippedOptOut" | "skippedParseFailure";
 
@@ -124,6 +133,34 @@ describe("docs config examples", () => {
     }
     if (issuePath !== undefined) {
       expect(audit.findings[0]?.issuePath).toBe(issuePath);
+    }
+  });
+
+  it("validates plugin-owned keys without opening the operator state database", () => {
+    const poisonedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docs-config-poison-"));
+    const databasePath = resolveOpenClawStateSqlitePath({
+      ...process.env,
+      OPENCLAW_STATE_DIR: poisonedRoot,
+    });
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    const database = new DatabaseSync(databasePath);
+    try {
+      database.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1}`);
+    } finally {
+      database.close();
+    }
+    const envSnapshot = snapshotStateDirEnv();
+    setStateDirEnv(poisonedRoot);
+    try {
+      const audit = auditMarkdown(
+        '```json5\n{ plugins: { entries: { openai: { config: { personalityy: "friendly" } } } } }\n```',
+      );
+      expect(audit.findings).toHaveLength(1);
+      expect(audit.findings[0]?.issuePath).toBe("plugins.entries.openai.config");
+      expect(fs.existsSync(resolveRepoBundledPluginEnv("unused").OPENCLAW_STATE_DIR!)).toBe(false);
+    } finally {
+      restoreStateDirEnv(envSnapshot);
+      fs.rmSync(poisonedRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/config/docs-config-examples.ts
+++ b/src/config/docs-config-examples.ts
@@ -6,6 +6,7 @@ import {
   loadPluginMetadataSnapshot,
   type PluginMetadataSnapshot,
 } from "../plugins/plugin-metadata-snapshot.js";
+import { resolveRepoBundledPluginEnv } from "./repo-bundled-plugin-env.js";
 import { validateConfigObjectRaw, validateConfigObjectRawWithPlugins } from "./validation.js";
 import { OpenClawSchemaShape } from "./zod-schema.root-shape.js";
 
@@ -125,10 +126,7 @@ function stripIncludeKeys(value: unknown): unknown {
 }
 
 function createDocsConfigValidationContext(): DocsConfigValidationContext {
-  const env = {
-    ...process.env,
-    OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(process.cwd(), "extensions"),
-  };
+  const env = resolveRepoBundledPluginEnv(path.join(process.cwd(), "extensions"));
   return {
     env,
     pluginMetadataSnapshot: loadPluginMetadataSnapshot({

--- a/src/config/repo-bundled-plugin-env.ts
+++ b/src/config/repo-bundled-plugin-env.ts
@@ -1,0 +1,12 @@
+import os from "node:os";
+import path from "node:path";
+
+// Validation never creates or writes this state dir: no operator DB is opened,
+// and no operator-installed plugin can leak config keys into the checkout's audit.
+export function resolveRepoBundledPluginEnv(bundledPluginsDir: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    OPENCLAW_STATE_DIR: path.join(os.tmpdir(), "openclaw-repo-bundled-plugin-state"),
+    OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+  };
+}


### PR DESCRIPTION
Related: #136601

## What Problem This Solves

Fixes an issue where `pnpm docs:check-config-examples` crashed with `SqliteSchemaVersionError` on any developer host whose running gateway's `~/.openclaw/state/openclaw.sqlite` is on a newer schema than the checkout (observed 2026-09-02: live schema 16, checkout 15). The docs audit never validated a single fence; the error looked like a code problem but was pure coupling to operator machine state.

The same root cause hit `pnpm prompt:snapshots:gen`/`:check`; that script was already made hermetic by #136601, which is in this branch's history and passes on the same host.

## Why This Change Was Made

The docs config-examples audit threaded `{ ...process.env, OPENCLAW_BUNDLED_PLUGINS_DIR }` into the plugin metadata loader. Plugin-policy hashing (`resolveInstalledPluginIndexPolicyHash` → `readBundledDiscoveryModeMemoized` → `readConfigMachineState`) resolves the state database from that env, i.e. the operator's live `~/.openclaw`, and plugin discovery scanned the operator's installed plugin roots too, so docs validation was silently host-dependent even where it did not crash.

Docs describe the checkout's bundled product, so validation must resolve bundled plugins from the checkout and nothing from the operator machine. The sibling `config:docs:check` lane (`src/config/doc-baseline.ts`) already did this with a fixed, never-written `OPENCLAW_STATE_DIR`. This PR promotes that into one owner, `resolveRepoBundledPluginEnv(bundledPluginsDir)` in `src/config/repo-bundled-plugin-env.ts`, used by both the docs audit and doc-baseline, and drops doc-baseline's dead `HOME` override (with `OPENCLAW_STATE_DIR` set, both `resolveStateDir` and `resolveConfigDir` take the override). The metadata loader with `preferPersisted: false` never writes, so a fixed path is safe; the regression test asserts it stays absent.

Non-goals: no runtime/product behavior change, no new config or env option, no changes under `src/plugins` or `src/state`. A sibling sweep of the other schema/plugin dev scripts (`check:base-config-schema`, `config:channels:check`, `policy:config-coverage`, `lint:plugins:no-monolithic-plugin-sdk-entry-imports`) found no other coupled lane.

## User Impact

Developer-facing only. Maintainers and contributors can run `pnpm docs:check-config-examples`, `pnpm check:docs`, and `pnpm config:docs:check` on a machine with a newer live OpenClaw install without `OPENCLAW_STATE_DIR` workarounds, and docs validation now covers exactly the checkout's bundled plugins regardless of what is installed locally. No operator-visible runtime change.

## Evidence

Reproduction with the default state dir on a host with a live schema-16 DB (pre-fix):

```
SqliteSchemaVersionError: This OpenClaw build cannot open your existing data.
OpenClaw state database /Users/<redacted>/.openclaw/state/openclaw.sqlite uses newer schema version 16; this build supports 15.
    at readConfigMachineState (src/state/config-machine-state.ts:61:10)
    at readBundledDiscoveryMode (src/plugins/bundled-discovery-state.ts:24:17)
    at readBundledDiscoveryModeMemoized (src/plugins/bundled-discovery-state.ts:60:14)
    at resolveInstalledPluginIndexPolicyHash (src/plugins/installed-plugin-index-policy.ts:51:25)
    at resolvePluginMetadataSnapshotCacheKey (src/plugins/plugin-metadata-snapshot.ts:340:13)
    at loadPluginMetadataSnapshot (src/plugins/plugin-metadata-snapshot.ts:386:15)
    at createDocsConfigValidationContext (src/config/docs-config-examples.ts:134:29)
    at auditDocsConfigExamples (src/config/docs-config-examples.ts:256:29)
[check-docs-config-examples] FAILED (exit 1)
```

Regression test `validates plugin-owned keys without opening the operator state database` (`src/config/docs-config-examples.test.ts`): poisons `OPENCLAW_STATE_DIR` with a real SQLite file at `OPENCLAW_STATE_SCHEMA_VERSION + 1`, audits a fence with an unsupported bundled-plugin (OpenAI) config key, and requires the finding, proving bundled-plugin coverage is preserved rather than validation being skipped. Written test-first: fails pre-fix with `SqliteSchemaVersionError` through `readBundledDiscoveryMode`; passes post-fix. Vitest's setup isolates `HOME`/`OPENCLAW_STATE_DIR`, which is why the existing in-process test never caught this; the explicit poison is what makes it meaningful.

Post-fix on the same host, no env overrides:

- `pnpm docs:check-config-examples` → exit 0, `docs_config_files_scanned=746`, `docs_config_fences_validated=1215` (identical to an isolated-state run), hermetic state dir never created
- `pnpm config:docs:check` → `OK docs/.generated/config-baseline.sha256 and docs/.generated/config-baseline.counts.json`
- `pnpm prompt:snapshots:check` → `Prompt snapshots are current (7 files).`
- `pnpm test src/config/docs-config-examples.test.ts src/config/doc-baseline.test.ts` → 16 passed
- `pnpm test src/plugins/bundled-discovery-state.test.ts src/plugins/installed-plugin-index-policy.test.ts src/plugins/plugin-metadata-snapshot.test.ts` → 37 passed (unchanged owner, green)
- `pnpm check:changed` → lanes core + coreTests, all guards green
- Codex autoreview (`--mode uncommitted`, P0) → scoped-clean, 0 findings

Production LOC: +16/-11 (net +5, the shared helper and its invariant comment) | Tests: +37/-0
