### PR TITLE
fix(cli): keep node identity inspection from creating SQLite

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -503,6 +503,8 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     commandPath: ["node"],
     policy: { networkProxy: "bypass" },
   },
+  // Remote pairing verification owns a read-only identity lookup, including before its action.
+  { commandPath: ["node", "identity"], exact: true, policy: PASSIVE_STARTUP_POLICY },
   {
     commandPath: ["node", "worker"],
     exact: true,

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -92,6 +92,7 @@ describe("command-path-policy", () => {
   it.each([
     { commandPath: ["database"], hideBanner: true },
     { commandPath: ["audit"], hideBanner: false },
+    { commandPath: ["node", "identity"], hideBanner: false },
     { commandPath: ["update", "cleanup"], hideBanner: true },
   ])("keeps passive startup for $commandPath", ({ commandPath, hideBanner }) => {
     expectResolvedPolicy(commandPath, {
@@ -132,6 +133,24 @@ describe("command-path-policy", () => {
     // Bare `openclaw nodes` still resolves plugin subcommands from validated config.
     expectResolvedPolicy(["nodes"], { networkProxy: "bypass" });
     expectResolvedPolicy(["nodes", "pair"], { networkProxy: "bypass" });
+  });
+
+  it("retains node host startup outside the exact identity lookup", () => {
+    for (const commandPath of [
+      ["node"],
+      ["node", "install"],
+      ["node", "status"],
+      ["node", "identity", "unknown"],
+    ]) {
+      expectResolvedPolicy(commandPath, { networkProxy: "bypass" });
+    }
+    expectResolvedPolicy(["node", "run"], {});
+    expectResolvedPolicy(["node", "worker"], {
+      configGuard: "validate",
+      hideBanner: true,
+      ownsProtocolStdout: true,
+      networkProxy: "bypass",
+    });
   });
 
   it("keeps gateway-owned node and device mutations off the local config guard", () => {

--- a/src/cli/program/preaction.test-helpers.ts
+++ b/src/cli/program/preaction.test-helpers.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 
 export const COLD_READ_COMMAND_PATHS: string[][] = [
   ["audit"],
+  ["node", "identity"],
   ["skills", "info"],
   ["skills", "search"],
   ["hooks"],
@@ -12,6 +13,11 @@ export const COLD_READ_COMMAND_PATHS: string[][] = [
 ];
 
 export function registerColdReadCommandFixtures(program: Command, skills: Command): void {
+  program
+    .command("node")
+    .command("identity")
+    .option("--json")
+    .action(() => {});
   program
     .command("audit")
     .option("--json")

--- a/test/cli-json-stdout.config.e2e.test.ts
+++ b/test/cli-json-stdout.config.e2e.test.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
@@ -6,6 +7,12 @@ import { runBuiltCli } from "./cli-json-stdout.test-support.js";
 
 describe("cli json stdout contract", () => {
   it.each([
+    {
+      name: "node identity",
+      args: ["node", "identity", "--json"],
+      overrides: {},
+      error: "no node device identity found",
+    },
     {
       name: "routed config get",
       args: ["config", "get", "gateway.port", "--json"],
@@ -38,24 +45,58 @@ describe("cli json stdout contract", () => {
       async (tempHome) => {
         const stateDir = path.join(tempHome, "read-only-state");
         const configPath = path.join(tempHome, "read-only-openclaw.json");
-        await fs.writeFile(
-          configPath,
-          `${JSON.stringify({ gateway: { mode: "local", port: 18789 } })}\n`,
-          "utf8",
+        const config = `${JSON.stringify({
+          gateway: {
+            mode: "local",
+            port: 18789,
+            auth: { mode: "token", token: randomBytes(32).toString("hex") },
+          },
+          plugins: { enabled: false },
+          browser: { enabled: false },
+          discovery: { mdns: { mode: "off" } },
+          logging: { file: path.join(stateDir, "openclaw.log") },
+        })}\n`;
+        await fs.writeFile(configPath, config, "utf8");
+        const configBefore = await fs.stat(configPath);
+        const tmpDir = path.join(tempHome, "tmp");
+        await fs.mkdir(tmpDir);
+
+        const result = runBuiltCli(
+          tempHome,
+          testCase.args,
+          {
+            OPENCLAW_HOME: tempHome,
+            OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_TEST_FAST: undefined,
+            TMPDIR: tmpDir,
+            TMP: tmpDir,
+            TEMP: tmpDir,
+            PATH: path.dirname(process.execPath),
+            ...testCase.overrides,
+          },
+          { inheritEnvironment: false },
         );
 
-        const result = runBuiltCli(tempHome, testCase.args, {
-          OPENCLAW_CONFIG_PATH: configPath,
-          OPENCLAW_STATE_DIR: stateDir,
-          ...testCase.overrides,
-        });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(() => JSON.parse(result.stdout)).not.toThrow();
+        expect(result.error).toBeUndefined();
+        expect(result.status, result.stderr).toBe("error" in testCase ? 1 : 0);
+        if ("error" in testCase) {
+          expect(result.stderr).toContain(testCase.error);
+          expect(result.stdout).toBe("");
+        } else {
+          expect(() => JSON.parse(result.stdout)).not.toThrow();
+        }
         await expect(
           fs.access(path.join(stateDir, "state", "openclaw.sqlite")),
         ).rejects.toMatchObject({
           code: "ENOENT",
+        });
+        expect((await fs.readFile(configPath, "utf8")) === config).toBe(true);
+        expect(await fs.stat(configPath)).toMatchObject({
+          ino: configBefore.ino,
+          mode: configBefore.mode,
+          mtimeMs: configBefore.mtimeMs,
+          ctimeMs: configBefore.ctimeMs,
         });
       },
       { prefix: "openclaw-read-only-config-e2e-" },


### PR DESCRIPTION
Closes #136732

<details>
<summary>Additional instructions</summary>

This is a maintainer-editable branch in the upstream repository.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw node identity --json` on fresh state would create a shared SQLite database even though the command reported that no identity existed. The same command is used by SSH-verified node pairing. This violated the existing [read-only node identity contract](https://docs.openclaw.ai/cli/node).

## Why This Change Was Made

The identity action already uses the artifact-preserving read-only reader, but generic CLI startup ran Doctor/config observation and plugin-index persistence before reaching it. An exact `node identity` catalog entry now reuses `PASSIVE_STARTUP_POLICY`; normal node run/install/status/worker policies, Doctor writers, identity readers, Gateway-local classification, and native-terminal paths are unchanged.

This is the owner-boundary fix rather than a downstream guard or a persistence redesign. No configuration, environment variable, schema, protocol, dependency, or test-only production seam was added. Production LOC: **+2/-0** for the declarative policy and invariant comment. Tests/support: **+78/-12 (net +66)**, extending existing policy, real-Commander, and built-CLI tables.

## User Impact

Identity inspection keeps the existing successful JSON payload and missing-identity exit/error behavior without creating or mutating database, credential, or legacy identity state. Existing diagnostic logging remains available. Legacy-only/claimed state and malformed storage continue to fail visibly without being migrated or repaired by the inspection command.

Stable `v2026.8.2` already contains the startup-routing defect; the original introducing commit is unknown in the available history. This change is unrelated to the landed Gateway-local classification repair or gateway-probe snapshot cost/stabilization work.

## Evidence

All real-CLI fixtures used temporary synthetic HOME/state/config/tmp directories and generated synthetic credentials. No operator state, managed service, real credential, key value, or token value was used or published.

Before the fix, the real `node scripts/run-node.mjs node identity --json` invocation exited 1 with the correct missing-identity message but created SQLite: `device_identities=0`, `device_auth_tokens=0`, `config_health_entries=1`, `config_machine_state=1`, with sole machine-state key `plugins.installedIndex`. After the fix, the same invocation leaves the database absent and config bytes/metadata unchanged.

The new full-CLI regression failed before the production edit at the database-absence assertion, then passed afterward:

```bash
OPENCLAW_E2E_USE_PREBUILT_DIST=1 node scripts/run-vitest.mjs test/cli-json-stdout.config.e2e.test.ts -t 'node identity'
```

Validation completed on the candidate source:

- `pnpm build qaRuntime`: passed, including the final compact policy entry.
- Built CLI/config JSON suite: 18 tests passed.
- Focused startup, identity, read-only store, config-health, and Doctor-persistence suites: 296 tests across 14 files passed.
- Final policy/Commander/built-CLI boundary rerun: 120 tests passed.
- Ten built-CLI filesystem scenarios passed; independently rerun by the lead. Coverage: absent DB, empty DB, canonical identity, canonical plus legacy file/Doctor claim, existing live WAL/SHM, legacy-only, Doctor-claim-only, invalid SQLite, and invalid identity. Database/sidecar/config/credential/legacy-file bytes, modes, inodes, sizes, mtime, and ctime remained unchanged. Error paths may create the explicitly configured diagnostic log; no claim of zero log writes.
- The WAL proof keeps a writer open but does not exercise sustained concurrent write churn; it is not proof for unrelated snapshot-stabilization or performance behavior under load.
- Complete changed-file gate and `git diff --check`: passed. Initial max-lines failure was fixed by using the catalog's existing single-line entry style; no limit or suppression was changed.
- Fresh Codex autoreview: no blocking findings.

The documented behavior already states the repaired contract, so no documentation or changelog change is needed.
