### PR TITLE
fix: env-backed channel probes fail builds with incomplete module metadata

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1471,9 +1471,9 @@ Use it when setup, doctor, status, or read-only presence flows need a cheap yes/
 }
 ```
 
-Use `env.allOf` when every listed variable is required and `env.anyOf` when any one non-empty variable is enough. If a tiny non-runtime check needs more than environment metadata, use `specifier` plus `exportName` as shown for `persistedAuthState`. A complete `specifier` and `exportName` pair takes precedence over `env`; env-only metadata avoids loading a module. If the check needs full config resolution or the real channel runtime, keep that logic in the plugin `config.hasConfiguredState` hook instead.
+Use `env.allOf` when every listed variable is required and `env.anyOf` when any one non-empty variable is enough. If a tiny non-runtime check needs more than environment metadata, use `specifier` plus `exportName` as shown for `persistedAuthState`. A complete, non-empty `specifier` and `exportName` pair takes precedence over `env`. If either field is absent or blank, the probe uses its `env` metadata without loading a module. If the check needs full config resolution or the real channel runtime, keep that logic in the plugin `config.hasConfiguredState` hook instead.
 
-For both state probes, OpenClaw builds rewrite source specifiers to the exact emitted JavaScript artifact, including its `.js` or `.cjs` extension. Built checkout metadata uses paths relative to the plugin root; standalone packages use the plugin-local `dist/` directory.
+For both state probes, OpenClaw builds rewrite source specifiers only for complete module pairs, naming the exact emitted JavaScript artifact, including its `.js` or `.cjs` extension. Env-backed incomplete pairs are preserved unchanged. Built checkout metadata uses paths relative to the plugin root; standalone packages use the plugin-local `dist/` directory.
 
 ## Discovery precedence (duplicate plugin ids)
 

--- a/scripts/lib/plugin-npm-package-manifest.mts
+++ b/scripts/lib/plugin-npm-package-manifest.mts
@@ -170,11 +170,14 @@ export function resolvePluginRuntimeChannelMetadata(
   const packagedChannel: JsonRecord = { ...channel };
   for (const metadataKey of ["configuredState", "persistedAuthState"]) {
     const metadata = channel[metadataKey];
+    // Incomplete pairs may be env-backed; only module-backed probes need outputs.
     if (
       !Object.hasOwn(channel, metadataKey) ||
       !isRecord(metadata) ||
       typeof metadata.specifier !== "string" ||
-      !metadata.specifier.trim()
+      !metadata.specifier.trim() ||
+      typeof metadata.exportName !== "string" ||
+      !metadata.exportName.trim()
     ) {
       continue;
     }

--- a/test/plugin-npm-package-manifest.test.ts
+++ b/test/plugin-npm-package-manifest.test.ts
@@ -24,6 +24,7 @@ import {
   runPluginNpmCiWithRetry,
   withAugmentedPluginNpmManifestForPackage,
 } from "../scripts/lib/plugin-npm-package-manifest.mts";
+import { hasChannelPackageState } from "../src/channels/plugins/package-state-probes.js";
 import { cleanupTempDirs, makeTempDir as makeTempRepoRoot } from "./helpers/temp-dir.js";
 import { writeJsonFile } from "./helpers/temp-repo.js";
 
@@ -728,100 +729,152 @@ describe("plugin npm package manifest staging", () => {
     expect(readFileSync(join(packageDir, "package.json"), "utf8")).toBe(originalText);
   });
 
-  it("packs and loads both mapped channel-state probes from one package artifact", () => {
-    const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-package-state-runtime-");
-    const packageDir = writePublishablePluginPackage(repoDir);
-    const sourcePackageJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
-    sourcePackageJson.openclaw.build = { runtimeFormat: "cjs" };
-    sourcePackageJson.openclaw.channel = {
-      id: "diffs",
-      configuredState: {
-        specifier: "./configured-state",
-        exportName: "hasConfiguredChannelState",
-      },
-      persistedAuthState: {
-        specifier: "./dist/auth-presence.cjs",
-        exportName: "hasPersistedChannelAuth",
-      },
-    };
-    writeJsonFile(join(packageDir, "package.json"), sourcePackageJson);
-    writeFileText(
-      join(packageDir, "configured-state.ts"),
-      "export function hasConfiguredChannelState() {}\n",
-    );
-    writeFileText(
-      join(packageDir, "auth-presence.ts"),
-      "export function hasPersistedChannelAuth() {}\n",
-    );
-    writeFileText(join(packageDir, "dist", "index.cjs"), "module.exports = {};\n");
-    writeFileText(join(packageDir, "dist", "setup-entry.cjs"), "module.exports = {};\n");
-    writeFileText(
-      join(packageDir, "dist", "configured-state.cjs"),
-      "exports.hasConfiguredChannelState = () => true;\n",
-    );
-    writeFileText(
-      join(packageDir, "dist", "auth-presence.cjs"),
-      "exports.hasPersistedChannelAuth = () => true;\n",
-    );
-
-    const originalText = readFileSync(join(packageDir, "package.json"), "utf8");
-    withAugmentedPluginNpmManifestForPackage({ repoRoot: repoDir, packageDir }, () => {
-      const stagedPackageJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
-      expect(stagedPackageJson.openclaw.channel.configuredState).toEqual({
-        specifier: "./dist/configured-state.cjs",
-        exportName: "hasConfiguredChannelState",
-      });
-      expect(stagedPackageJson.openclaw.channel.persistedAuthState).toEqual({
-        specifier: "./dist/auth-presence.cjs",
-        exportName: "hasPersistedChannelAuth",
-      });
-
-      const consumerDir = join(repoDir, "external-consumer");
-      mkdirSync(consumerDir, { recursive: true });
-      writeJsonFile(join(consumerDir, "package.json"), { private: true, type: "module" });
-
-      const packInvocation = resolvePluginNpmCommand([
-        "pack",
-        "--json",
-        "--ignore-scripts",
-        "--pack-destination",
-        consumerDir,
-      ]);
-      const pack = spawnSync(packInvocation.command, packInvocation.args, {
-        cwd: packageDir,
-        encoding: "utf8",
-        ...(packInvocation.env ? { env: packInvocation.env } : {}),
-        ...(packInvocation.shell !== undefined ? { shell: packInvocation.shell } : {}),
-        stdio: ["ignore", "pipe", "pipe"],
-        ...(packInvocation.windowsVerbatimArguments !== undefined
-          ? { windowsVerbatimArguments: packInvocation.windowsVerbatimArguments }
-          : {}),
-      });
-      expect(pack.status, pack.stderr).toBe(0);
-      const packedPackage = parseNpmPackResult(pack.stdout);
-      const packedFiles = packedPackage.files.map((file) => file.path);
-      expect(packedFiles).toContain("dist/configured-state.cjs");
-      expect(packedFiles).toContain("dist/auth-presence.cjs");
-      expect(packedFiles).not.toContain("configured-state.ts");
-      expect(packedFiles).not.toContain("auth-presence.ts");
-
-      const extract = spawnSync(
-        "tar",
-        ["-xzf", join(consumerDir, packedPackage.filename), "-C", consumerDir],
-        {
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "pipe"],
+  it.for([
+    { name: "module", partial: undefined },
+    { name: "env-only", partial: {} },
+    { name: "missing exportName", partial: { specifier: "./absent-probe" } },
+    { name: "blank exportName", partial: { specifier: "./absent-probe", exportName: " \t" } },
+    { name: "missing specifier", partial: { exportName: "hasState" } },
+    { name: "blank specifier", partial: { specifier: " \t", exportName: "hasState" } },
+  ])(
+    "packs and loads both channel-state probes from one package artifact ($name)",
+    ({ partial }) => {
+      const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-package-state-runtime-");
+      const packageDir = writePublishablePluginPackage(repoDir);
+      const sourcePackageJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+      sourcePackageJson.openclaw.build = { runtimeFormat: "cjs" };
+      sourcePackageJson.openclaw.channel = {
+        id: "diffs",
+        configuredState: {
+          specifier: "./configured-state",
+          exportName: "hasConfiguredChannelState",
         },
+        persistedAuthState: {
+          specifier: "./dist/auth-presence.cjs",
+          exportName: "hasPersistedChannelAuth",
+        },
+      };
+      if (partial) {
+        for (const metadataKey of ["configuredState", "persistedAuthState"] as const) {
+          sourcePackageJson.openclaw.channel[metadataKey] = {
+            ...partial,
+            env: { anyOf: ["SYNTHETIC_PLUGIN_TOKEN"] },
+          };
+        }
+      }
+      writeJsonFile(join(packageDir, "package.json"), sourcePackageJson);
+      writeFileText(
+        join(packageDir, "configured-state.ts"),
+        "export function hasConfiguredChannelState() {}\n",
       );
-      expect(extract.status, extract.stderr).toBe(0);
+      writeFileText(
+        join(packageDir, "auth-presence.ts"),
+        "export function hasPersistedChannelAuth() {}\n",
+      );
+      writeFileText(join(packageDir, "dist", "index.cjs"), "module.exports = {};\n");
+      writeFileText(join(packageDir, "dist", "setup-entry.cjs"), "module.exports = {};\n");
+      writeFileText(
+        join(packageDir, "dist", "configured-state.cjs"),
+        "exports.hasConfiguredChannelState = () => true;\n",
+      );
+      writeFileText(
+        join(packageDir, "dist", "auth-presence.cjs"),
+        "exports.hasPersistedChannelAuth = () => true;\n",
+      );
 
-      const packageRoot = join(consumerDir, "package");
-      const load = spawnSync(
-        process.execPath,
-        [
-          "--input-type=module",
-          "--eval",
-          `
+      const originalText = readFileSync(join(packageDir, "package.json"), "utf8");
+      withAugmentedPluginNpmManifestForPackage({ repoRoot: repoDir, packageDir }, () => {
+        const stagedPackageJson = JSON.parse(
+          readFileSync(join(packageDir, "package.json"), "utf8"),
+        );
+        expect(stagedPackageJson.openclaw.channel.configuredState).toEqual(
+          partial
+            ? sourcePackageJson.openclaw.channel.configuredState
+            : {
+                specifier: "./dist/configured-state.cjs",
+                exportName: "hasConfiguredChannelState",
+              },
+        );
+        expect(stagedPackageJson.openclaw.channel.persistedAuthState).toEqual(
+          partial
+            ? sourcePackageJson.openclaw.channel.persistedAuthState
+            : {
+                specifier: "./dist/auth-presence.cjs",
+                exportName: "hasPersistedChannelAuth",
+              },
+        );
+
+        const consumerDir = join(repoDir, "external-consumer");
+        mkdirSync(consumerDir, { recursive: true });
+        writeJsonFile(join(consumerDir, "package.json"), { private: true, type: "module" });
+
+        const packInvocation = resolvePluginNpmCommand([
+          "pack",
+          "--json",
+          "--ignore-scripts",
+          "--pack-destination",
+          consumerDir,
+        ]);
+        const pack = spawnSync(packInvocation.command, packInvocation.args, {
+          cwd: packageDir,
+          encoding: "utf8",
+          ...(packInvocation.env ? { env: packInvocation.env } : {}),
+          ...(packInvocation.shell !== undefined ? { shell: packInvocation.shell } : {}),
+          stdio: ["ignore", "pipe", "pipe"],
+          ...(packInvocation.windowsVerbatimArguments !== undefined
+            ? { windowsVerbatimArguments: packInvocation.windowsVerbatimArguments }
+            : {}),
+        });
+        expect(pack.status, pack.stderr).toBe(0);
+        const packedPackage = parseNpmPackResult(pack.stdout);
+        const packedFiles = packedPackage.files.map((file) => file.path);
+        expect(packedFiles).toContain("dist/configured-state.cjs");
+        expect(packedFiles).toContain("dist/auth-presence.cjs");
+        expect(packedFiles).not.toContain("configured-state.ts");
+        expect(packedFiles).not.toContain("auth-presence.ts");
+
+        const extract = spawnSync(
+          "tar",
+          ["-xzf", join(consumerDir, packedPackage.filename), "-C", consumerDir],
+          {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+          },
+        );
+        expect(extract.status, extract.stderr).toBe(0);
+
+        const packageRoot = join(consumerDir, "package");
+        if (partial) {
+          const channel = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"))
+            .openclaw.channel;
+          expect(channel).toEqual(sourcePackageJson.openclaw.channel);
+          for (const metadataKey of ["configuredState", "persistedAuthState"] as const) {
+            const probe = {
+              entry: {
+                channel,
+                pluginId: "diffs",
+                rootDir: packageRoot,
+                origin: "global" as const,
+              },
+              metadataKey,
+              cfg: {},
+            };
+            expect(hasChannelPackageState({ ...probe, env: {} })).toBe(false);
+            expect(
+              hasChannelPackageState({
+                ...probe,
+                env: { SYNTHETIC_PLUGIN_TOKEN: "synthetic-test-value" },
+              }),
+            ).toBe(true);
+          }
+          return;
+        }
+        const load = spawnSync(
+          process.execPath,
+          [
+            "--input-type=module",
+            "--eval",
+            `
 import fs from "node:fs";
 import { pathToFileURL } from "node:url";
 const root = ${JSON.stringify(packageRoot)};
@@ -833,18 +886,42 @@ for (const key of ["configuredState", "persistedAuthState"]) {
 }
 process.stdout.write("PACKED_PLUGIN_CHANNEL_STATE_OK\\n");
 `,
-        ],
-        {
-          cwd: packageRoot,
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "pipe"],
-        },
-      );
-      expect(load.status, load.stderr).toBe(0);
-      expect(load.stdout).toBe("PACKED_PLUGIN_CHANNEL_STATE_OK\n");
-    });
-    expect(readFileSync(join(packageDir, "package.json"), "utf8")).toBe(originalText);
-  });
+          ],
+          {
+            cwd: packageRoot,
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+          },
+        );
+        expect(load.status, load.stderr).toBe(0);
+        expect(load.stdout).toBe("PACKED_PLUGIN_CHANNEL_STATE_OK\n");
+      });
+      expect(readFileSync(join(packageDir, "package.json"), "utf8")).toBe(originalText);
+      for (const metadataKey of ["configuredState", "persistedAuthState"] as const) {
+        writeJsonFile(join(packageDir, "package.json"), {
+          ...sourcePackageJson,
+          openclaw: {
+            ...sourcePackageJson.openclaw,
+            channel: {
+              id: "diffs",
+              [metadataKey]: {
+                env: { anyOf: ["SYNTHETIC_PLUGIN_TOKEN"] },
+                specifier: "./missing-state",
+                exportName: "hasState",
+              },
+            },
+          },
+        });
+        expect(() =>
+          withAugmentedPluginNpmManifestForPackage({ repoRoot: repoDir, packageDir }, () => {
+            throw new Error("missing module output reached pack callback");
+          }),
+        ).toThrow(
+          `channel ${metadataKey} specifier './missing-state' has no runtime output for diffs`,
+        );
+      }
+    },
+  );
 
   it.each(["default destination", "relative destination", "split destination", "failed command"])(
     "preserves source dependencies while staging npm bundles with %s",

--- a/test/scripts/build-external-plugin-local-dist.test.ts
+++ b/test/scripts/build-external-plugin-local-dist.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../scripts/lib/bundled-plugin-build-entries.mjs";
 import { BUILD_STAMP_FILE } from "../../scripts/lib/local-build-metadata-paths.mts";
 import { resolveBuildRequirement } from "../../scripts/run-node.mts";
+import { hasChannelPackageState } from "../../src/channels/plugins/package-state-probes.js";
 import { resetPluginCache } from "../../src/plugins/plugin-cache.js";
 import { resolvePluginRuntimeArtifact } from "../../src/plugins/plugin-runtime-artifact-resolution.js";
 import { createEmptyPluginRegistry } from "../../src/plugins/registry-empty.js";
@@ -165,19 +166,58 @@ describe("external plugin local dist build", () => {
       const sourceText = fs.readFileSync(sourcePackagePath, "utf8");
       const sourcePackage = JSON.parse(sourceText);
       expect(sourcePackage.openclaw.channel).toEqual({ id, label: id, ...channelStateFixtures });
-      // Env-only declarations have no module to rewrite; invalid module declarations fail the build.
-      sourcePackage.openclaw.channel.configuredState = { env: { anyOf: ["DEMO_TOKEN"] } };
-      fs.writeFileSync(sourcePackagePath, JSON.stringify(sourcePackage));
-      copyBundledPluginMetadata({ repoRoot, env: {} });
-      expect(
-        JSON.parse(fs.readFileSync(path.join(pluginRoot, "package.json"), "utf8")).openclaw.channel
-          .configuredState,
-      ).toEqual(sourcePackage.openclaw.channel.configuredState);
-      sourcePackage.openclaw.channel.persistedAuthState.specifier = "./missing-state";
-      fs.writeFileSync(sourcePackagePath, JSON.stringify(sourcePackage));
-      expect(() => copyBundledPluginMetadata({ repoRoot, env: {} })).toThrow(
-        `channel persistedAuthState specifier './missing-state' has no runtime output for ${id}`,
-      );
+      // Reuse the built graphs: partial pairs must retain env semantics, not require a sidecar.
+      for (const metadataKey of ["configuredState", "persistedAuthState"] as const) {
+        for (const partial of [
+          {},
+          { specifier: "./absent-probe" },
+          { specifier: "./absent-probe", exportName: " \t" },
+          { exportName: "hasState" },
+          { specifier: " \t", exportName: "hasState" },
+        ]) {
+          for (const env of [undefined, { anyOf: ["SYNTHETIC_PLUGIN_TOKEN"] }]) {
+            const declaration = { ...partial, ...(env ? { env } : {}) };
+            sourcePackage.openclaw.channel = {
+              id,
+              label: id,
+              ...channelStateFixtures,
+              [metadataKey]: declaration,
+            };
+            fs.writeFileSync(sourcePackagePath, JSON.stringify(sourcePackage));
+            copyBundledPluginMetadata({ repoRoot, env: {} });
+            const channel = JSON.parse(
+              fs.readFileSync(path.join(pluginRoot, "package.json"), "utf8"),
+            ).openclaw.channel;
+            expect(channel).toEqual({ ...metadata.openclaw.channel, [metadataKey]: declaration });
+            const stateProbe = {
+              entry: { channel, pluginId: id, rootDir: pluginRoot, origin: "bundled" as const },
+              metadataKey,
+              cfg: {},
+            };
+            expect(hasChannelPackageState({ ...stateProbe, env: {} })).toBe(false);
+            expect(
+              hasChannelPackageState({
+                ...stateProbe,
+                env: { SYNTHETIC_PLUGIN_TOKEN: "synthetic-test-value" },
+              }),
+            ).toBe(Boolean(env));
+          }
+        }
+        sourcePackage.openclaw.channel = {
+          id,
+          label: id,
+          ...channelStateFixtures,
+          [metadataKey]: {
+            env: { anyOf: ["SYNTHETIC_PLUGIN_TOKEN"] },
+            specifier: "./missing-state",
+            exportName: "hasState",
+          },
+        };
+        fs.writeFileSync(sourcePackagePath, JSON.stringify(sourcePackage));
+        expect(() => copyBundledPluginMetadata({ repoRoot, env: {} })).toThrow(
+          `channel ${metadataKey} specifier './missing-state' has no runtime output for ${id}`,
+        );
+      }
       fs.writeFileSync(sourcePackagePath, sourceText);
       copyBundledPluginMetadata({ repoRoot, env: {} });
     }


### PR DESCRIPTION
Related: #136499
Follow-up to the [late P2 review on the Teams artifact-path repair](https://github.com/openclaw/openclaw/pull/136509#issuecomment-5514401452).

## What Problem This Solves

Fixes an issue where incomplete module metadata incorrectly required an emitted artifact during plugin builds or packaging. `configuredState` is the installed env-backed form. The shared artifact transform preserves incomplete pairs for both `configuredState` and `persistedAuthState`, in checkout and standalone metadata; incomplete installed persisted-auth pairs remain inert. This does not add installed persisted-auth env support.

The original Teams checker repair in #136509 remains valid. Its [PR proof](https://github.com/openclaw/openclaw/pull/136509#issuecomment-5516065780) and the [closed issue's proof](https://github.com/openclaw/openclaw/issues/136499#issuecomment-5516999778) explicitly left this edge case unresolved; this follow-up does not claim it was fixed by that landing.

## Why This Change Was Made

The shared metadata producer now requires a complete, non-empty string `specifier`/`exportName` pair before mapping a probe to an emitted artifact. This matches the runtime owner's complete-pair module boundary, preserves incomplete metadata unchanged, and retains build failure for complete module declarations with missing outputs. Configured-state env evaluation and installed persisted-auth capability are separate consumer contracts. Fixing the producer avoids a loader fallback or separate caller-specific policy.

The missing export-name check already existed in standalone packaging and was carried into source-checkout metadata by the Teams repair. Raw-parent comparison of `16c07ee67e0e14d4acaaa9d06b88e796e95e1b8a` with `1ec63079e82b40c9a27c9fd141ddcda6ecc24cf9` verifies that distinction; stable tag `v2026.8.2` also contains the runtime env behavior and the older standalone omission.

## User Impact

Env-backed configured-state probes with incomplete module metadata no longer break source builds or plugin packaging. Incomplete persisted-auth pairs are preserved and remain inactive after installed normalization. Complete probes still name the exact selected CommonJS or ESM artifact, including the verified Teams `.cjs` checker. No current affected declaration was found among the 22 checked-in probes; this preserves an existing plugin contract rather than changing current plugin configuration.

No runtime loader change, dependency, configuration option, schema change, or changelog edit. The [manifest contract](https://docs.openclaw.ai/plugins/manifest) is clarified in the source docs.

## Evidence

### Regression and artifact proof

The new boundary coverage produced **3 intended failures before the fix**, all reporting that the incomplete declaration's `./absent-probe` had no runtime output. The same selection passed **all 7 targeted cases** after the repair. The fixtures cover both metadata keys, checkout root `.` and package root `dist`, missing/blank pair members, unchanged metadata, generic raw-helper env evaluation (not installed persisted-auth env support), source restoration, and complete-pair missing-output rejection. Existing real-build CommonJS/ESM siblings and native packed-probe loading remain covered.

```bash
node scripts/run-vitest.mjs test/scripts/build-external-plugin-local-dist.test.ts test/plugin-npm-package-manifest.test.ts --testNamePattern='keeps excluded plugin graphs isolated|packs and loads both channel-state probes'
```

Complete focused suites: **83 passed**, no failures or skips.

```bash
node scripts/run-vitest.mjs test/scripts/build-external-plugin-local-dist.test.ts test/plugin-npm-package-manifest.test.ts test/plugin-npm-runtime-build.test.ts src/channels/plugins/package-state-probes.test.ts
```

The initial scoped check caught a shadowed test variable. It was renamed without a suppression, the affected 7 cases passed again, and the complete scoped gate passed:

```bash
node scripts/check-changed.mjs -- scripts/lib/plugin-npm-package-manifest.mts test/scripts/build-external-plugin-local-dist.test.ts test/plugin-npm-package-manifest.test.ts
```

```bash
node_modules/.bin/oxfmt --check docs/plugins/manifest.md
```

```bash
git diff --check
```

Full local build passed, including 90 isolated plugin builds, 53 native built control-plane load checks, and the SDK/UI gates:

```bash
pnpm build
```

Read-only inspection of the resulting artifacts verified all **22** declarations: **15** env declarations unchanged and **7** module-backed paths natively resolvable. The Teams path is `./configured-state.cjs`. A separate direct producer/runtime matrix passed **24** env-preservation cases, **8** exact CJS/ESM mappings, and **8** missing-complete-output rejections across both keys and roots. Inspection did not invoke real persisted-state checkers or use operator state.

These local runs exercised the four-file candidate based on `8ea5c8f02b995ae052cbba7d22deee598159a9e2`; published source commit is `dacc604f9ed997118353a6d7630a22feca5a75a8`, with the identical reviewed patch. Exact PR-head CI is recorded below. Fresh independent pre-commit Codex autoreview completed with exit 0: scoped-clean, patch is correct, no P0–P2 findings.

### Scope and size

Production/tooling **+4/-1 (net +3)** is two required predicate checks and their invariant comment; no additional flow or helper. Tests **+230/-113 (net +117)** extend existing fixtures rather than adding a production test seam. Docs **+2/-2**. No production host, gateway, real auth checker, release, or package-publication operation was used. Final additional matrix runs explicitly isolate logging; no claim is made that every exploratory run had isolated logging.


### Final review disposition and production-path proof

The earlier presence-policy findings in the [ClawSweeper review](https://github.com/openclaw/openclaw/pull/136737#issuecomment-5518150794) and the initial direct-record reproduction identified different behavior for whitespace-only module fields. Further tracing found that the initial reproduction bypassed the canonical normalization boundary. It did not establish the claimed operator-visible omission.

A fresh, isolated probe writes real temporary `package.json` and `openclaw.plugin.json` files, discovers the configured plugin, and compares raw records with the production registry and presence loaders. It uses a custom env variable matching neither the channel prefix nor the official catalog, an explicitly allowed plugin, isolated temporary state, and `includePersistedAuthState: false`. The plugin runtime entry throws if loaded; no runtime entry or operator state was used.

On unchanged head `dacc604f9ed997118353a6d7630a22feca5a75a8`, before any caller repair:

| Module metadata | Raw registry supplied directly | Canonical registry | Default presence loader | Workspace presence loader |
| --- | --- | --- | --- | --- |
| No module fields | 1 effective row | 1 | 1 | 1 |
| Specifier present, export absent | 1 effective row | 1 | 1 | 1 |
| Specifier present, export whitespace-only | 0 rows | 1 | 1 | 1 |
| Specifier whitespace-only, export present | 0 rows | 1 | 1 | 1 |

The raw record producer is `manifest-registry.ts:480`, but `loadPluginManifestRegistryForPluginRegistry` routes its result through `loadPluginManifestRegistryForInstalledIndex`. Prepared raw registries are mapped through `normalizePreparedManifestRecord`; installed-index candidates pass through `resolveInstalledPackageMetadata`. Both use the configured-state normalizer at `manifest-registry-installed.ts:137`, which trims both members before presence policy sees them. The default config-wide path likewise builds its snapshot through that normalizer (`plugin-metadata-snapshot.ts:582`). Traced startup, read-only, status and doctor callers use these normalized snapshots.

No reachable operator caller passing raw records to this policy was established. Maintainer review of the complete owners and strengthened real-package proof rejects the claimed operator defect. Both Rank-up moves are explicitly skipped: no extra presence predicate is needed because canonical routes normalize first, and no new failing-policy regression is appropriate because all 12 canonical routes already pass on unchanged code. The complete expected effective row was asserted for every case (channel id, manifest-env source, effective=true, owner id, and no blocked reasons), and the result was independently rerun with exit 0. The existing four-file packaging fix remains the best owner-boundary repair. The relevant production paths are also unchanged on inspected main `6b1fe49a36f316b9b1af392d0e88b0fcd34efd62`.

The installed persisted-auth normalizer is a separate contract: `PluginPackageChannel.persistedAuthState` declares only `specifier` and `exportName`, and the manifest docs describe a checker module. Its omission of `env` is not evidence of an additional configured-state presence defect or grounds to expand that API.

No caller change, additional guard/helper, new test seam, configuration option, or migration is warranted. Compatibility preserves the existing runtime contract; the production/tooling net +3 consists solely of the two missing predicate checks and their invariant comment. The earlier full build and fresh independent Codex pre-commit review bind to the byte-identical four-file patch. Local source base: `8ea5c8f02b995ae052cbba7d22deee598159a9e2`; published source/head: `dacc604f9ed997118353a6d7630a22feca5a75a8`. There was no rebase or later tracked edit.

Exact-head [CI run 33696315603, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33696315603) completed successfully, including [openclaw/ci-gate job 100469016736](https://github.com/openclaw/openclaw/actions/runs/33696315603/job/100469016736). Effective branch rules require this GitHub Actions check (integration 15368, non-strict) and linear history; no independent pull-request approval rule is enforced. Native preparation and merge proceed only for the approved exact head.


### Final persisted-auth review adjudication

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/136737#issuecomment-5518150794), reviewed at 2026-09-03 00:22:27 UTC, repeats the persisted-auth P2. Maintainer adjudication **rejects that finding and explicitly skips its Rank-up move** to restore persisted-auth rejection or add an env API.

The installed type and normalizer do not support `persistedAuthState.env`; this PR does not change that. However, incomplete no-env metadata does **not** fall through to a failed module load: [`resolveChannelPackageStateMetadata` returns null at lines 159–160](https://github.com/openclaw/openclaw/blob/dacc604f9ed997118353a6d7630a22feca5a75a8/src/channels/plugins/package-state-probes.ts#L159), then [`resolveChannelPackageStateChecker` returns null at lines 185–187](https://github.com/openclaw/openclaw/blob/dacc604f9ed997118353a6d7630a22feca5a75a8/src/channels/plugins/package-state-probes.ts#L185). The actual synthetic module marker observed **zero incomplete module evaluations**.

An isolated before/after matrix executed exact Git-blob packaging modules from baseline `8ea5c8f02b995ae052cbba7d22deee598159a9e2` and current head `dacc604f9ed997118353a6d7630a22feca5a75a8`, with their dependency closures. It exercised the real runtime build plan, `resolveAugmentedPluginNpmPackageJson`, temporary packaging overlay, real package discovery, canonical installed normalization, and `hasChannelPackageState`. Synthetic emitted artifacts supplied CJS/ESM controls; no real auth state was read.

| Persisted-auth declaration | Baseline | Current |
| --- | --- | --- |
| Missing/blank export, selected output exists | Rewritten; installed runtime false | Preserved; installed runtime false |
| Missing/blank export, selected output absent | Packaging error | Preserved; installed runtime false |
| Missing/blank specifier | Preserved; installed runtime false | Same |
| Complete valid pair, including padded nonblank members | Exact artifact; runtime true | Same |
| Complete pair, selected output absent | Packaging error | Same |
| Complete pair naming a nonexistent export symbol | Artifact accepted; runtime false with diagnostic | Same |

**All 80 rows passed** across CJS/ESM and with/without unsupported extra env metadata: 40 per version, 64 canonical installed cases, 128 runtime calls, and no previously working checker lost. All 40 incomplete installed cases were inert and did not load a module. Source package bytes were restored after each overlay. The env property was discarded by installed normalization in every applicable case, and empty/nonempty synthetic env values did not change persisted-auth results.

```bash
python3 .artifacts/materialize-persisted-assessment.py
node --import ./scripts/tsx.mjs .artifacts/package-state-persisted-assessment.mts baseline
node --import ./scripts/tsx.mjs .artifacts/package-state-persisted-assessment.mts current
```

Final corrected runs exited 0 with temporary HOME/state/config/bundled roots, operation-scoped caches and an explicitly verified temporary log target. The matrix supplies synthetic emitted files rather than rebuilding them; the earlier full build remains separate proof. Generic raw-helper env assertions and artifact pass-through do not establish installed persisted-auth env support.

The old resolver accepted missing/blank exports whenever an artifact existed, and accepted a nonexistent export symbol. It was not an export/schema validator; stable `v2026.8.2` also contains the specifier-only artifact check. The intentional change is removing an incidental absent-output error for incomplete metadata. No promised schema-validation contract or working installed probe regression was established. Preserving incomplete pairs for **both** keys is the requested artifact boundary; neither a configured-state special case nor an installed env API expansion is warranted.

Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 136737` passed with no rebase, push or retry, retaining head `dacc604f9ed997118353a6d7630a22feca5a75a8` and tree `21a7fa1c73769a5e192944fc118f010e24803b88`. No tracked code, tests or docs changed after the reviewed four-file repair.
