### PR TITLE
fix(config): align plugin reload guidance

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -387,7 +387,7 @@ openclaw plugins list --json
 </ParamField>
 
 <Note>
-`plugins list` reads the persisted local plugin registry first, with a manifest-only derived fallback when the registry is missing or invalid. It is useful for checking whether a plugin is installed, enabled, and visible to cold startup planning, but it is not a live runtime probe of an already-running Gateway process. After changing plugin code, enablement, hook policy, or `plugins.load.paths`, restart the Gateway that serves the channel before expecting new `register(api)` code or hooks to run. For remote/container deployments, verify you are restarting the actual `openclaw gateway run` child, not only a wrapper process.
+`plugins list` reads the persisted local plugin registry first, with a manifest-only derived fallback when the registry is missing or invalid. It is useful for checking whether a plugin is installed, enabled, and visible to cold startup planning, but it is not a live runtime probe of an already-running Gateway process. After changing plugin code or `plugins.load.paths`, restart the Gateway that serves the channel before expecting new `register(api)` code or hooks to run. With the default hybrid reload mode, enablement and hook policy changes hot-reload the existing plugin runtime unless the plugin declares a restart-triggering prefix. For remote/container deployments, verify you are restarting the actual `openclaw gateway run` child, not only a wrapper process.
 
 `plugins list --json` includes each plugin's `dependencyStatus` from `package.json`
 `dependencies` and `optionalDependencies`. OpenClaw checks whether those package

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -287,7 +287,7 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
 - Loaded from package or bundle directories under `~/.openclaw/extensions` and `<workspace>/.openclaw/extensions`, plus files or directories listed in `plugins.load.paths`.
 - Put standalone plugin files in `plugins.load.paths`; auto-discovered extension roots ignore top-level `.js`, `.mjs`, and `.ts` files so helper scripts in those roots do not block startup.
 - Discovery accepts native OpenClaw plugins plus compatible Codex bundles and Claude bundles, including manifestless Claude default-layout bundles.
-- **Config changes require a gateway restart.**
+- With the default hybrid reload mode, ordinary plugin policy and entry changes hot-reload the plugin runtime. Plugin code, metadata, and discovery-root changes require a Gateway restart; active plugins can also declare restart-triggering config prefixes.
 - `allow`: optional allowlist (only listed plugins load). `deny` wins.
 - `plugins.entries.<id>.apiKey`: plugin-level API key convenience field (when supported by the plugin).
 - `plugins.entries.<id>.env`: plugin-scoped env var map.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -347,7 +347,7 @@ OpenClaw can refresh the skills list mid-session: the skills watcher updates the
 
 Plugins run in-process with the Gateway - treat them as trusted code.
 
-- Only install from sources you trust; prefer explicit `plugins.allow` allowlists; review plugin config before enabling; restart the Gateway after plugin changes.
+- Only install from sources you trust; prefer explicit `plugins.allow` allowlists; review plugin config before enabling. Restart the Gateway after plugin code, metadata, or discovery-root changes. With the default hybrid reload mode, ordinary config and enablement changes hot-reload unless the plugin declares a restart-triggering prefix.
 - Installing/updating plugins runs executable code:
   - The install path is the per-plugin directory under the active plugin install root.
   - ClawHub packages and OpenClaw's bundled/official catalog are trusted sources. A new arbitrary npm, `npm-pack:`, git, local path/archive, or marketplace source warns before install; noninteractive installs require `--force` after you review and trust that source. `--force` confirms provenance and permits overwrite; it does not bypass `security.installPolicy` or remaining install safety checks. Updates reuse the already selected source.

--- a/docs/plugins/admin-http-rpc.md
+++ b/docs/plugins/admin-http-rpc.md
@@ -48,7 +48,9 @@ Enable the bundled plugin:
   </Tab>
 </Tabs>
 
-The route is registered during plugin startup, so restart the Gateway after changing plugin config.
+The route is registered during plugin startup. With the default hybrid reload
+mode, changes to its existing plugin entry hot-reload the plugin runtime;
+restart after plugin code, metadata, or discovery-root changes.
 
 Disable it when you no longer need the HTTP surface:
 
@@ -194,7 +196,7 @@ Shared-token WebSocket clients without a trusted device identity cannot self-dec
 
 `404 Not Found`
 
-: The plugin is disabled, the Gateway has not restarted since enabling it, or the request is going to a different Gateway process.
+: The plugin is disabled, the Gateway has not reloaded it since enablement, or the request is going to a different Gateway process.
 
 `401 Unauthorized`
 

--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -169,7 +169,7 @@ When browsing Claude sessions on paired nodes, update those nodes alongside the 
 
 `404 Not Found`
 
-: The Beam plugin is disabled, the Gateway has not restarted since enablement, or the request is reaching another Gateway.
+: The Beam plugin is disabled, the Gateway has not reloaded it since enablement, or the request is reaching another Gateway.
 
 `401 Unauthorized`
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -99,10 +99,10 @@ Grant this plugin access to conversation hooks in `openclaw.json`:
 }
 ```
 
-Merge that entry into your existing config, then restart and inspect:
+Merge that entry into your existing config, then let the default hybrid reload
+mode apply it and inspect:
 
 ```bash
-openclaw gateway restart
 openclaw plugins inspect hook-demo --runtime --json
 ```
 
@@ -118,7 +118,8 @@ the field is only the sender's raw text.
 
 Hook registration does not bypass plugin loading rules. The plugin must be
 loaded and enabled; `plugins.enabled`, `plugins.allow`, and `plugins.deny` still
-apply. Restart the Gateway after changing plugin code or hook configuration.
+apply. Restart the Gateway after changing plugin code. With the default hybrid
+reload mode, hook policy changes hot-reload the existing plugin runtime.
 
 - Non-bundled plugins need explicit
   `plugins.entries.<id>.hooks.allowConversationAccess: true` for

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -95,8 +95,10 @@ bundled, official external, and source-only plugins, see
     openclaw gateway restart
     ```
 
-    Enable/disable update config and the cold registry. Inspect registration
-    next, then verify the running Gateway with an actual hook event or tool call.
+    With the default hybrid reload mode, enable/disable and ordinary plugin
+    config changes hot-reload the existing runtime for new agent turns unless
+    the plugin declares a restart-triggering prefix. Inspect registration next,
+    then verify the running Gateway with an actual hook event or tool call.
 
   </Step>
 
@@ -284,10 +286,12 @@ bypass global disable, deny, or per-plugin enablement policy.
 An explicit hook policy is also startup intent. For example,
 `plugins.entries.<id>.hooks.allowConversationAccess: true` both authorizes
 non-bundled conversation hooks and selects that configured plugin for Gateway
-startup; normal plugin policy still applies. After changing manifest or hook
-policy, inspect registration with `openclaw plugins inspect <id> --runtime --json`,
-restart the Gateway, and trigger an event to verify the running process. See
-[Plugin hooks](/plugins/hooks#quick-start) for a complete example.
+startup; normal plugin policy still applies. Restart the Gateway after changing
+the plugin manifest. With the default hybrid reload mode, hook policy changes
+hot-reload the existing plugin runtime. Inspect registration with
+`openclaw plugins inspect <id> --runtime --json`, then trigger an event to verify
+the running process. See [Plugin hooks](/plugins/hooks#quick-start) for a complete
+example.
 
 ## Verify the active Gateway
 
@@ -310,15 +314,15 @@ serves your channels, not only a wrapper or supervisor.
 
 ## Troubleshooting
 
-| Symptom                                                        | Check                                                                                                                                      | Fix                                                                                                     |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| Plugin appears in `plugins list` but runtime hooks do not run  | Use `openclaw plugins inspect <id> --runtime --json` and confirm the active Gateway with `gateway status --deep --require-rpc`             | Restart the live Gateway after install, update, config, or source changes                               |
-| Duplicate channel or tool ownership diagnostics appear         | Run `openclaw plugins list --enabled --verbose`, inspect each suspected plugin with `--runtime --json`, and compare channel/tool ownership | Disable one owner, remove stale installs, or use manifest `preferOver` for intentional replacement      |
-| Config says a plugin is missing                                | Check [Plugin inventory](/plugins/plugin-inventory) for whether it is bundled, official external, or source-only                           | Install the external package, enable the bundled plugin, or remove stale config                         |
-| Config is invalid during install                               | Read the validation message and run `openclaw doctor --fix` if it points to stale plugin state                                             | Doctor can quarantine invalid plugin config by disabling the entry and removing the invalid payload     |
-| Plugin path is blocked for suspicious ownership or permissions | Inspect the diagnostic before the config error                                                                                             | Fix filesystem ownership/permissions, then run `openclaw plugins registry --refresh`                    |
-| `OPENCLAW_NIX_MODE=1` blocks lifecycle commands                | Confirm the install is managed by Nix                                                                                                      | Change plugin selection in the Nix source instead of using plugin mutator commands                      |
-| Dependency import fails at runtime                             | Check whether the plugin was installed through npm/git/ClawHub or loaded from a local path                                                 | Run `openclaw plugins update <id>`, reinstall the source, or install local plugin dependencies yourself |
+| Symptom                                                        | Check                                                                                                                                      | Fix                                                                                                                   |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| Plugin appears in `plugins list` but runtime hooks do not run  | Use `openclaw plugins inspect <id> --runtime --json` and confirm the active Gateway with `gateway status --deep --require-rpc`             | Restart after install, update, or source changes; for config changes, confirm reload mode and plugin restart prefixes |
+| Duplicate channel or tool ownership diagnostics appear         | Run `openclaw plugins list --enabled --verbose`, inspect each suspected plugin with `--runtime --json`, and compare channel/tool ownership | Disable one owner, remove stale installs, or use manifest `preferOver` for intentional replacement                    |
+| Config says a plugin is missing                                | Check [Plugin inventory](/plugins/plugin-inventory) for whether it is bundled, official external, or source-only                           | Install the external package, enable the bundled plugin, or remove stale config                                       |
+| Config is invalid during install                               | Read the validation message and run `openclaw doctor --fix` if it points to stale plugin state                                             | Doctor can quarantine invalid plugin config by disabling the entry and removing the invalid payload                   |
+| Plugin path is blocked for suspicious ownership or permissions | Inspect the diagnostic before the config error                                                                                             | Fix filesystem ownership/permissions, then run `openclaw plugins registry --refresh`                                  |
+| `OPENCLAW_NIX_MODE=1` blocks lifecycle commands                | Confirm the install is managed by Nix                                                                                                      | Change plugin selection in the Nix source instead of using plugin mutator commands                                    |
+| Dependency import fails at runtime                             | Check whether the plugin was installed through npm/git/ClawHub or loaded from a local path                                                 | Run `openclaw plugins update <id>`, reinstall the source, or install local plugin dependencies yourself               |
 
 When an enabled managed plugin fails payload verification during Gateway
 startup, OpenClaw quarantines that exact installed plugin root for the boot and

--- a/src/config/schema.help.agents.ts
+++ b/src/config/schema.help.agents.ts
@@ -29,7 +29,7 @@ export const AGENT_FIELD_HELP: Record<string, string> = {
   "plugins.entries":
     "Per-plugin settings keyed by plugin ID including enablement and plugin-specific runtime configuration payloads. Use this for scoped plugin tuning without changing global loader policy.",
   "plugins.entries.*.enabled":
-    "Per-plugin enablement override for a specific entry, applied on top of global plugin policy. Changes hot reload the plugin runtime without a Gateway restart unless the plugin declares its own restart-triggering prefixes. Use this to stage plugin rollout gradually across environments.",
+    "Per-plugin enablement override for a specific entry, applied on top of global plugin policy. With the default hybrid reload mode, changes hot-reload the plugin runtime for new agent turns without restarting the Gateway unless the plugin requires a restart for this path. Use this to stage plugin rollout gradually across environments.",
   "plugins.entries.*.hooks":
     "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
   "plugins.entries.*.hooks.allowPromptInjection":

--- a/src/config/schema.help.agents.ts
+++ b/src/config/schema.help.agents.ts
@@ -29,7 +29,7 @@ export const AGENT_FIELD_HELP: Record<string, string> = {
   "plugins.entries":
     "Per-plugin settings keyed by plugin ID including enablement and plugin-specific runtime configuration payloads. Use this for scoped plugin tuning without changing global loader policy.",
   "plugins.entries.*.enabled":
-    "Per-plugin enablement override for a specific entry, applied on top of global plugin policy (restart required). Use this to stage plugin rollout gradually across environments.",
+    "Per-plugin enablement override for a specific entry, applied on top of global plugin policy. Changes hot reload the plugin runtime without a Gateway restart unless the plugin declares its own restart-triggering prefixes. Use this to stage plugin rollout gradually across environments.",
   "plugins.entries.*.hooks":
     "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
   "plugins.entries.*.hooks.allowPromptInjection":

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -1,7 +1,6 @@
 // Checks config help text quality and coverage.
 
 import { describe, expect, it } from "vitest";
-import { resolveConfigReloadMetadata } from "../gateway/config-reload-plan.js";
 import { computeBaseConfigSchemaResponse } from "./schema-base.js";
 import { FIELD_HELP } from "./schema.help.js";
 import {
@@ -348,13 +347,6 @@ describe("config help copy quality", () => {
       }
     },
   );
-
-  it("keeps plugins.entries.*.enabled help aligned with the hot reload planner", () => {
-    const help = requireHelp("plugins.entries.*.enabled");
-    expect(help).not.toMatch(/restart required/i);
-    expect(help).toMatch(/hot reload/i);
-    expect(resolveConfigReloadMetadata("plugins.entries.sample-plugin.enabled").kind).toBe("hot");
-  });
 });
 
 describe("config tier coverage", () => {

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -1,6 +1,7 @@
 // Checks config help text quality and coverage.
 
 import { describe, expect, it } from "vitest";
+import { resolveConfigReloadMetadata } from "../gateway/config-reload-plan.js";
 import { computeBaseConfigSchemaResponse } from "./schema-base.js";
 import { FIELD_HELP } from "./schema.help.js";
 import {
@@ -347,6 +348,13 @@ describe("config help copy quality", () => {
       }
     },
   );
+
+  it("keeps plugins.entries.*.enabled help aligned with the hot reload planner", () => {
+    const help = requireHelp("plugins.entries.*.enabled");
+    expect(help).not.toMatch(/restart required/i);
+    expect(help).toMatch(/hot reload/i);
+    expect(resolveConfigReloadMetadata("plugins.entries.sample-plugin.enabled").kind).toBe("hot");
+  });
 });
 
 describe("config tier coverage", () => {

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -1000,6 +1000,30 @@ describe("gateway config methods", () => {
     expect(res.payload?.schema?.properties).toBeUndefined();
   });
 
+  it("returns consistent help and reload metadata for plugin enablement", async () => {
+    const res = await rpcReq<{
+      path: string;
+      schema?: { description?: string };
+      reloadKind?: string;
+      hintPath?: string;
+      hint?: { help?: string };
+    }>(requireWs(), "config.schema.lookup", {
+      path: "plugins.entries.sample-plugin.enabled",
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.payload).toMatchObject({
+      path: "plugins.entries.sample-plugin.enabled",
+      reloadKind: "hot",
+      hintPath: "plugins.entries.*.enabled",
+    });
+    const description = res.payload?.schema?.description;
+    expect(description).toMatch(/default hybrid reload mode/i);
+    expect(description).toMatch(/hot-reload the plugin runtime/i);
+    expect(description).not.toMatch(/restart required/i);
+    expect(res.payload?.hint?.help).toBe(description);
+  });
+
   it("rejects config.schema.lookup when the path is missing", async () => {
     const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.schema.lookup", {
       path: "gateway.notReal.path",


### PR DESCRIPTION
Closes #136710

## Problem

`config.schema.lookup` reported `reloadKind: "hot"` for `plugins.entries.*.enabled`, but its schema help said a restart was required. Several plugin docs repeated the stale restart guidance.

## Product path

```bash
openclaw gateway call config.schema.lookup \
  --params '{"path":"plugins.entries.<plugin>.enabled"}' \
  --json
```

## Root cause

Plugin enablement moved to the in-process plugin reload path, but the older help and lifecycle docs did not move with it. The generic plugin reload rule is hot. An active plugin can still declare a restart-triggering prefix, and `gateway.reload.mode: "off"` still disables config reload.

## Fix

- Describe the default hybrid reload mode and plugin-specific restart exception in schema help.
- Align the generic plugin lifecycle docs with the existing runtime behavior.
- Move the regression from a copy-quality test into the real Gateway WebSocket lookup boundary.
- Keep reload planning, configuration defaults, schemas, and protocol behavior unchanged.

## Compatibility

This is a wording and regression-test repair. It does not change configuration, defaults, reload planning, stored data, or the Gateway protocol.

## Proof

- Current-main red: [Blacksmith run 33714053532](https://github.com/openclaw/openclaw/actions/runs/33714053532) returned `reloadKind: "hot"` beside help containing `(restart required)` for two wildcard plugin paths.
- Regression red: [Blacksmith run 33714561306](https://github.com/openclaw/openclaw/actions/runs/33714561306) failed the new WebSocket lookup test on the stale help.
- Exact-tree green: formatter, `pnpm docs:list --headings`, the WebSocket regression, 24 help-quality tests, and three plugin reload sibling tests passed in [Blacksmith run 33715965706](https://github.com/openclaw/openclaw/actions/runs/33715965706).
- Live green: [Blacksmith run 33716204027](https://github.com/openclaw/openclaw/actions/runs/33716204027) returned matching `hot` metadata and hybrid-mode help for the reported path and a second wildcard path.
- Exact-head Autoreview passed with no P0 findings.

## Credit

This repair preserves @LiuwqGit's original commit and intent.
