### PR TITLE
perf(macos): stop unnecessary idle background work

### DIFF
--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -524,7 +524,8 @@ struct GeneralSettings: View {
 
             TailscaleIntegrationSection(
                 connectionMode: self.state.connectionMode,
-                isPaused: self.state.isPaused)
+                isPaused: self.state.isPaused,
+                isActive: self.isActive)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodePresenceReporter.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodePresenceReporter.swift
@@ -30,7 +30,7 @@ final class MacNodePresenceReporter {
     }
 
     private static let eventName = "node.presence.activity"
-    private static let sampleInterval = Duration.seconds(2)
+    private static let sampleInterval: TimeInterval = 2
     private static let activeReportIntervalMs: Int64 = 15000
     private static let keepaliveIntervalMs: Int64 = 180_000
     private static let maximumIdleSeconds = 30 * 24 * 60 * 60
@@ -68,16 +68,21 @@ final class MacNodePresenceReporter {
         self.sender = sender
         self.clearer = clearer
         self.unsupportedClearHandler = onUnsupportedClear
-        self.generation &+= 1
         // Registration creates a fresh server-side node session. Starting disabled
         // therefore needs no clear and cannot turn a legacy reconnect into a loop.
-        self.clearPending = false
-        self.hasDeliveredActivity = false
-        self.unsupportedClearHandled = false
+        self.updateSamplingTask(reportImmediately: true)
+    }
+
+    private func updateSamplingTask(reportImmediately: Bool = false) {
+        guard self.sender != nil, self.reportingEnabled || self.clearPending else {
+            SimpleTaskSupport.stop(task: &self.task)
+            return
+        }
+        guard self.task == nil else { return }
         self.task = Task {
-            while !Task.isCancelled {
+            if reportImmediately { await self.reportCurrentState() }
+            while await SimpleTaskSupport.waitForNextOperation(interval: Self.sampleInterval) {
                 await self.reportCurrentState()
-                try? await Task.sleep(for: Self.sampleInterval)
             }
         }
     }
@@ -85,8 +90,7 @@ final class MacNodePresenceReporter {
     func stop() {
         self.generation &+= 1
         self.routeGeneration &+= 1
-        self.task?.cancel()
-        self.task = nil
+        SimpleTaskSupport.stop(task: &self.task)
         self.sender = nil
         self.clearer = nil
         self.unsupportedClearHandler = nil
@@ -97,6 +101,7 @@ final class MacNodePresenceReporter {
     }
 
     func setReportingEnabled(_ enabled: Bool) async {
+        defer { self.updateSamplingTask() }
         if self.reportingEnabled == enabled {
             if !enabled, self.clearPending {
                 await self.sendPendingClear()
@@ -166,6 +171,8 @@ final class MacNodePresenceReporter {
     }
 
     private func sendPendingClear() async {
+        // An in-flight sample may finish after opt-out; keep only its failed clear retry alive.
+        defer { self.updateSamplingTask() }
         guard self.clearPending,
               let clearer = self.clearer
         else { return }

--- a/apps/macos/Sources/OpenClaw/StatusMenuController.swift
+++ b/apps/macos/Sources/OpenClaw/StatusMenuController.swift
@@ -20,7 +20,6 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
 
     private var statusItem: NSStatusItem?
     private var clickMonitor: Any?
-    private var hostingView: NSHostingView<StatusMenuIconView>?
     private var renderer: StatusMenuRenderer?
     private var refreshTask: Task<Void, Never>?
     private var observationGeneration: UInt64 = 0
@@ -133,7 +132,7 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
 
     private func installButton(in item: NSStatusItem) {
         guard let button = item.button else { return }
-        let host = NSHostingView(rootView: self.makeIconView())
+        let host = NSHostingView(rootView: StatusMenuIconView(state: self.state))
         // The constraints below own sizing; animation must not remeasure the status item.
         host.sizingOptions = []
         host.translatesAutoresizingMaskIntoConstraints = false
@@ -144,7 +143,6 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
             host.widthAnchor.constraint(equalToConstant: 18),
             host.heightAnchor.constraint(equalToConstant: 18),
         ])
-        self.hostingView = host
         button.target = self
         button.action = #selector(self.handleStatusClick(_:))
         self.installClickMonitor()
@@ -197,23 +195,6 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         }
     }
 
-    private func makeIconView() -> StatusMenuIconView {
-        let sleeping = self.isGatewaySleeping
-        return StatusMenuIconView(label: CritterStatusLabel(
-            isPaused: self.state.isPaused,
-            isSleeping: sleeping,
-            isWorking: self.state.isWorking,
-            earBoostActive: self.state.earBoostActive,
-            blinkTick: self.state.blinkTick,
-            sendCelebrationTick: self.state.sendCelebrationTick,
-            gatewayStatus: self.gatewayManager.status,
-            connectionMode: self.state.connectionMode,
-            controlChannelState: self.controlChannel.state,
-            animationsEnabled: self.state.iconAnimationsEnabled && !sleeping,
-            iconState: self.effectiveIconState,
-            voiceWakeMeterActive: self.state.voiceWakeMeterActive))
-    }
-
     private func renderCachedMenu() {
         let connection: StatusMenuDescriptor.Connection = if self.state.connectionMode == .unconfigured {
             .unconfigured
@@ -239,14 +220,18 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
             mainSessionKey: self.activityStore.mainSessionKey,
             approvals: self.approvals.requests,
             gateways: DashboardGatewayMenuModel.items(from: self.dashboard.gatewayEntries))
-        self.renderer?.isSleeping = self.isGatewaySleeping
+        self.renderer?.isSleeping = statusMenuGatewayIsSleeping(state: self.state)
         self.renderer?.reconcile(StatusMenuDescriptor.build(from: snapshot))
     }
 
     private func observeChanges() {
         let generation = self.observationGeneration
         withObservationTracking {
-            _ = self.makeIconView()
+            _ = self.state.isPaused
+            _ = self.state.connectionMode
+            _ = self.gatewayManager.status
+            _ = self.controlChannel.state
+            _ = self.state.voiceWakeMeterActive
             _ = self.state.voicePushToTalkEnabled
             _ = self.state.quickChatEnabled
             _ = self.state.canvasEnabled
@@ -275,7 +260,6 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
             Task { @MainActor [weak self] in
                 guard let self, self.observationGeneration == generation else { return }
                 self.applyStateSideEffects()
-                self.hostingView?.rootView = self.makeIconView()
                 self.updateStatusAppearance()
                 if self.isMenuOpen {
                     self.renderCachedMenu()
@@ -323,34 +307,6 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
             : String(localized: "OpenClaw")
     }
 
-    private var isGatewaySleeping: Bool {
-        guard !self.state.isPaused else { return false }
-        return switch self.state.connectionMode {
-        case .unconfigured:
-            true
-        case .remote:
-            self.controlChannel.state != .connected
-        case .local:
-            switch self.gatewayManager.status {
-            case .running, .starting, .attachedExisting:
-                self.controlChannel.state != .connected
-            case .failed, .stopped:
-                true
-            }
-        }
-    }
-
-    private var effectiveIconState: IconState {
-        let selection = self.state.iconOverride
-        guard selection != .system else { return self.activityStore.iconState }
-        return switch selection.toIconState() {
-        case let .workingMain(kind), let .workingOther(kind), let .overridden(kind):
-            .overridden(kind)
-        case .idle:
-            .idle
-        }
-    }
-
     private func scheduleDebugMenuOpen() {
         #if DEBUG
         // launchctl setenv races `open`; arguments are reliable for captures.
@@ -395,10 +351,55 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     }
 }
 
+@MainActor
+private func statusMenuGatewayIsSleeping(state: AppState) -> Bool {
+    guard !state.isPaused else { return false }
+    return switch state.connectionMode {
+    case .unconfigured:
+        true
+    case .remote:
+        ControlChannel.shared.state != .connected
+    case .local:
+        switch GatewayProcessManager.shared.status {
+        case .running, .starting, .attachedExisting:
+            ControlChannel.shared.state != .connected
+        case .failed, .stopped:
+            true
+        }
+    }
+}
+
+@MainActor
 private struct StatusMenuIconView: View {
-    let label: CritterStatusLabel
+    let state: AppState
 
     var body: some View {
-        self.label.background(SettingsWindowOpenRegistrar())
+        // SwiftUI tracks icon inputs here, independently of menu-only updates.
+        let sleeping = statusMenuGatewayIsSleeping(state: self.state)
+        CritterStatusLabel(
+            isPaused: self.state.isPaused,
+            isSleeping: sleeping,
+            isWorking: self.state.isWorking,
+            earBoostActive: self.state.earBoostActive,
+            blinkTick: self.state.blinkTick,
+            sendCelebrationTick: self.state.sendCelebrationTick,
+            gatewayStatus: GatewayProcessManager.shared.status,
+            connectionMode: self.state.connectionMode,
+            controlChannelState: ControlChannel.shared.state,
+            animationsEnabled: self.state.iconAnimationsEnabled && !sleeping,
+            iconState: self.effectiveIconState,
+            voiceWakeMeterActive: self.state.voiceWakeMeterActive)
+            .background(SettingsWindowOpenRegistrar())
+    }
+
+    private var effectiveIconState: IconState {
+        let selection = self.state.iconOverride
+        guard selection != .system else { return WorkActivityStore.shared.iconState }
+        return switch selection.toIconState() {
+        case let .workingMain(kind), let .workingOther(kind), let .overridden(kind):
+            .overridden(kind)
+        case .idle:
+            .idle
+        }
     }
 }

--- a/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
+++ b/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
@@ -68,6 +68,7 @@ private typealias GatewayTailscaleSettingsSaver = @MainActor @Sendable (
 struct TailscaleIntegrationSection: View {
     let connectionMode: AppState.ConnectionMode
     let isPaused: Bool
+    let isActive: Bool
 
     @Environment(TailscaleService.self) private var tailscaleService
 
@@ -77,12 +78,12 @@ struct TailscaleIntegrationSection: View {
     @State private var password: String = ""
     @State private var statusMessage: String?
     @State private var validationMessage: String?
-    @State private var statusTimer: Timer?
     @State private var lastAppliedSettings: GatewayTailscaleSettingsSnapshot?
 
-    init(connectionMode: AppState.ConnectionMode, isPaused: Bool) {
+    init(connectionMode: AppState.ConnectionMode, isPaused: Bool, isActive: Bool) {
         self.connectionMode = connectionMode
         self.isPaused = isPaused
+        self.isActive = isActive
     }
 
     var body: some View {
@@ -127,15 +128,16 @@ struct TailscaleIntegrationSection: View {
         .background(Color.gray.opacity(0.08))
         .cornerRadius(10)
         .disabled(self.connectionMode != .local)
-        .task {
-            guard !self.hasLoaded else { return }
-            await self.loadConfig()
-            self.hasLoaded = true
-            await self.tailscaleService.checkTailscaleStatus()
-            self.startStatusTimer()
-        }
-        .onDisappear {
-            self.stopStatusTimer()
+        .task(id: self.isActive) {
+            guard self.isActive else { return }
+            if !self.hasLoaded {
+                await self.loadConfig()
+            }
+            guard !Task.isCancelled else { return }
+            // Cached settings panes stay mounted; only the active pane owns polling.
+            repeat {
+                await self.tailscaleService.checkTailscaleStatus()
+            } while await SimpleTaskSupport.waitForNextOperation(interval: 5)
         }
         .onChange(of: self.tailscaleMode) { _, _ in
             Task { await self.applySettings() }
@@ -269,11 +271,13 @@ struct TailscaleIntegrationSection: View {
 
     private func loadConfig() async {
         let root = await ConfigStore.load()
+        guard !Task.isCancelled else { return }
         let loaded = TailscaleIntegrationSection.loadedSettings(from: root)
         self.tailscaleMode = loaded.snapshot.mode
         self.requireCredentialsForServe = loaded.snapshot.requireCredentialsForServe
         self.password = loaded.displayPassword
         self.lastAppliedSettings = loaded.snapshot
+        self.hasLoaded = true
     }
 
     private func applySettings() async {
@@ -490,19 +494,6 @@ struct TailscaleIntegrationSection: View {
             tailscaleMode: settings.mode,
             requireCredentialsForServe: settings.requireCredentialsForServe,
             password: settings.password)
-    }
-
-    private func startStatusTimer() {
-        self.stopStatusTimer()
-        if ProcessInfo.processInfo.isRunningTests { return }
-        self.statusTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { _ in
-            Task { await self.tailscaleService.checkTailscaleStatus() }
-        }
-    }
-
-    private func stopStatusTimer() {
-        self.statusTimer?.invalidate()
-        self.statusTimer = nil
     }
 }
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelRequestTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelRequestTests.swift
@@ -48,7 +48,82 @@ private actor GatewayRequestStartGate {
     }
 }
 
+@MainActor
+private final class GatewayRequestChannelLifetime {
+    weak var channel: GatewayChannelActor?
+
+    init(_ channel: GatewayChannelActor) {
+        self.channel = channel
+    }
+}
+
 struct GatewayChannelRequestTests {
+    enum RequestCompletion: CaseIterable, Sendable {
+        case response, cancellation, disconnect, shutdown
+    }
+
+    @Test(arguments: RequestCompletion.allCases)
+    @MainActor
+    func `completed requests release their channel before the original deadline`(
+        _ completion: RequestCompletion) async throws
+    {
+        let lifetime = try await self.completeRequest(completion)
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while lifetime.channel != nil, clock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(lifetime.channel == nil)
+    }
+
+    @MainActor
+    private func completeRequest(_ completion: RequestCompletion) async throws -> GatewayRequestChannelLifetime {
+        let probe = GatewayRequestProbe()
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(sendHook: { _, message, sendIndex in
+                guard sendIndex == 1,
+                      let requestID = GatewayWebSocketTestSupport.requestID(from: message)
+                else { return }
+                await probe.record(requestID)
+            })
+        })
+        let channel = try GatewayChannelActor(
+            url: #require(URL(string: "ws://example.invalid")),
+            token: nil,
+            session: WebSocketSessionBox(session: session),
+            connectOptions: GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions)
+        let lifetime = GatewayRequestChannelLifetime(channel)
+        let request = Task {
+            try await channel.request(method: "release-deadline", params: nil, timeoutMs: 30000)
+        }
+        do {
+            let requestID = await probe.wait()
+            let socket = try #require(session.latestTask())
+            switch completion {
+            case .response:
+                socket.emitReceiveSuccessOnce(.data(GatewayWebSocketTestSupport.okResponseData(id: requestID)))
+                let response = try await request.value
+                #expect(!response.isEmpty)
+            case .cancellation:
+                request.cancel()
+                await #expect(throws: CancellationError.self) { try await request.value }
+            case .disconnect:
+                socket.emitReceiveFailure()
+                await #expect(throws: (any Error).self) { try await request.value }
+            case .shutdown:
+                await channel.shutdown()
+                await #expect(throws: (any Error).self) { try await request.value }
+            }
+        } catch {
+            request.cancel()
+            await channel.shutdown()
+            throw error
+        }
+        await channel.shutdown()
+        // Returning only a weak reference releases this frame's channel and completed request task.
+        return lifetime
+    }
+
     private func makeSession(requestSendDelayMs: Int) -> GatewayTestWebSocketSession {
         GatewayTestWebSocketSession(
             taskFactory: {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodePresenceReporterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodePresenceReporterTests.swift
@@ -4,6 +4,26 @@ import Testing
 
 @MainActor
 struct MacNodePresenceReporterTests {
+    @Test(arguments: [false, true])
+    func `disabled reporting releases its sampling task`(afterOptOut: Bool) async {
+        weak var releasedReporter: MacNodePresenceReporter?
+        do {
+            let reporter = MacNodePresenceReporter(reportingEnabled: false, idleSecondsProvider: { 0 })
+            releasedReporter = reporter
+            reporter.start(sender: { _, _ in true }, clearer: { .cleared }, onUnsupportedClear: {})
+            if afterOptOut {
+                await reporter.setReportingEnabled(true)
+                await reporter.setReportingEnabled(false)
+            }
+        }
+        for _ in 0..<1000 {
+            if releasedReporter == nil { break }
+            await Task.yield()
+        }
+        #expect(releasedReporter == nil)
+        releasedReporter?.stop()
+    }
+
     @Test func `active computer presence defaults off and honors explicit opt in`() throws {
         let suiteName = "MacNodePresenceReporterTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
@@ -46,7 +66,9 @@ struct MacNodePresenceReporterTests {
             sender: sender.send,
             clearer: clear.clear,
             onUnsupportedClear: clear.handleUnsupported)
-        for _ in 0..<20 { await Task.yield() }
+        for _ in 0..<20 {
+            await Task.yield()
+        }
         reporter.stop()
 
         #expect(idleProbe.calls == 0)
@@ -107,16 +129,17 @@ struct MacNodePresenceReporterTests {
             onUnsupportedClear: clear.handleUnsupported)
         await reporter.setReportingEnabled(true)
         await reporter.setReportingEnabled(false)
-        await reporter.setReportingEnabled(false)
+        await clear.waitForCallCount(2)
         reporter.stop()
 
         #expect(clear.calls == 2)
         #expect(clear.unsupportedCalls == 0)
     }
 
-    @Test func `activity crossing opt out is followed by a clear`() async {
+    @Test(arguments: [false, true])
+    func `activity crossing opt out is followed by a clear`(retryClear: Bool) async {
         let sender = SuspendingPresenceSender()
-        let clear = PresenceClearRecorder()
+        let clear = PresenceClearRecorder(outcomes: retryClear ? [.retry, .cleared] : [.cleared])
         let reporter = MacNodePresenceReporter(
             reportingEnabled: true,
             idleSecondsProvider: { 0 })
@@ -128,10 +151,11 @@ struct MacNodePresenceReporterTests {
 
         await reporter.setReportingEnabled(false)
         sender.finishActivitySend()
-        await clear.waitForCallCount(1)
+        let expectedClears = retryClear ? 2 : 1
+        await clear.waitForCallCount(expectedClears)
         reporter.stop()
 
-        #expect(clear.calls == 1)
+        #expect(clear.calls == expectedClears)
         #expect(clear.unsupportedCalls == 0)
     }
 
@@ -176,7 +200,9 @@ struct MacNodePresenceReporterTests {
             sender: sender.send,
             clearer: clear.clear,
             onUnsupportedClear: clear.handleUnsupported)
-        for _ in 0..<20 { await Task.yield() }
+        for _ in 0..<20 {
+            await Task.yield()
+        }
         reporter.stop()
 
         #expect(sender.payloadObjects.filter { $0["idleSeconds"] != nil }.count == 1)
@@ -205,7 +231,9 @@ struct MacNodePresenceReporterTests {
             clearer: freshClear.clear,
             onUnsupportedClear: freshClear.handleUnsupported)
         staleSender.finishActivitySend()
-        for _ in 0..<20 { await Task.yield() }
+        for _ in 0..<20 {
+            await Task.yield()
+        }
         reporter.stop()
 
         #expect(freshSender.payloads.isEmpty)
@@ -306,9 +334,11 @@ private final class PresenceClearRecorder {
     }
 
     func waitForCallCount(_ expected: Int) async {
-        for _ in 0..<1000 {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(4))
+        while clock.now < deadline {
             if self.calls >= expected { return }
-            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
         }
         Issue.record("timed out waiting for \(expected) presence clear calls")
     }

--- a/apps/macos/Tests/OpenClawIPCTests/TailscaleIntegrationSectionTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TailscaleIntegrationSectionTests.swift
@@ -88,7 +88,8 @@ struct TailscaleIntegrationSectionTests {
         #expect(service.statusError == nil)
     }
 
-    @Test func `concurrent status checks share one request`() async {
+    @Test(arguments: ["neither", "initial", "joined"])
+    func `concurrent status checks share one request despite waiter cancellation`(cancelledWaiter: String) async {
         let loader = TailscaleStatusLoader()
         let completion = TailscaleStatusCompletion()
         let joinBarrier = TailscaleStatusJoinBarrier()
@@ -109,6 +110,11 @@ struct TailscaleIntegrationSectionTests {
             await completion.markFinished()
         }
         await joinBarrier.wait()
+        if cancelledWaiter == "initial" {
+            first.cancel()
+        } else if cancelledWaiter == "joined" {
+            second.cancel()
+        }
 
         #expect(await loader.requestCount == 1)
         #expect(await completion.finishedCount == 0)
@@ -118,6 +124,7 @@ struct TailscaleIntegrationSectionTests {
         await second.value
 
         #expect(await completion.finishedCount == 1)
+        #expect(await loader.requestWasCancelled == false)
         #expect(service.tailscaleIP == "100.66.5.88")
 
         await service.checkTailscaleStatus()
@@ -210,6 +217,7 @@ struct TailscaleIntegrationSectionTests {
 
 private actor TailscaleStatusLoader {
     private(set) var requestCount = 0
+    private(set) var requestWasCancelled = false
     private var requestStartedContinuations: [CheckedContinuation<Void, Never>] = []
     private var requestContinuation: CheckedContinuation<Void, Never>?
     private var shouldSuspendRequest = true
@@ -226,6 +234,7 @@ private actor TailscaleStatusLoader {
                 self.requestContinuation = continuation
             }
         }
+        self.requestWasCancelled = Task.isCancelled
         let data = try JSONEncoder().encode(
             TailscaleService.TailscaleAPIResponse(
                 status: "Running",

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -35,6 +35,11 @@ extension String {
 }
 
 public actor GatewayChannelActor {
+    struct PendingRequest {
+        let continuation: CheckedContinuation<GatewayFrame, Error>
+        var timeoutTask: Task<Void, Never>?
+    }
+
     nonisolated static func resolveRequestTimeoutMs(_ timeoutMs: Double?, defaultMs: Double) -> Double? {
         timeoutMs == 0 ? nil : (timeoutMs ?? defaultMs)
     }
@@ -50,7 +55,7 @@ public actor GatewayChannelActor {
     private let logger = Logger(subsystem: "ai.openclaw", category: "gateway")
     private var task: WebSocketTaskBox?
     private var activeConnectAttemptID: UUID?
-    var pending: [String: CheckedContinuation<GatewayFrame, Error>] = [:]
+    var pending: [String: PendingRequest] = [:]
     private var connected = false
     private var connectAttemptTask: Task<Void, Never>?
     /// Socket ownership epoch. Every callback and send stays bound to the task
@@ -170,7 +175,7 @@ public actor GatewayChannelActor {
         self.task?.cancel(with: .goingAway, reason: nil)
         self.task = nil
 
-        await self.failPending(NSError(
+        self.failPending(NSError(
             domain: "Gateway",
             code: 0,
             userInfo: [NSLocalizedDescriptionKey: "gateway channel shutdown"]))
@@ -1089,7 +1094,7 @@ extension GatewayChannelActor {
         self.disconnectNotificationInProgress = true
         // Lifecycle callbacks may be awaiting an RPC on this same socket. Release
         // those continuations before the callback barrier, or disconnect cycles.
-        await self.failPending(error)
+        self.failPending(error)
         await self.disconnectHandler?(reason, connectionGeneration)
         self.disconnectNotificationInProgress = false
 
@@ -1125,10 +1130,7 @@ extension GatewayChannelActor {
         }
         switch frame {
         case let .res(res):
-            let id = res.id
-            if let waiter = pending.removeValue(forKey: id) {
-                waiter.resume(returning: .res(res))
-            }
+            self.finishRequest(id: res.id, result: .success(.res(res)))
         case let .event(evt):
             if evt.event == "connect.challenge" { return }
             if let seq = evt.seq {
@@ -1438,17 +1440,25 @@ extension GatewayChannelActor {
                         cont.resume(throwing: CancellationError())
                         return
                     }
-                    self.pending[payload.id] = cont
+                    var request = PendingRequest(continuation: cont)
                     if let effectiveTimeout {
-                        Task { [weak self] in
+                        request.timeoutTask = Task { [weak self] in
                             guard let self else { return }
-                            try? await Task.sleep(nanoseconds: UInt64(effectiveTimeout * 1_000_000))
-                            await self.timeoutRequest(id: payload.id, timeoutMs: effectiveTimeout)
+                            guard await self.sleepUnlessCancelled(
+                                nanoseconds: UInt64(effectiveTimeout * 1_000_000))
+                            else { return }
+                            let error = NSError(
+                                domain: "Gateway",
+                                code: 5,
+                                userInfo: [NSLocalizedDescriptionKey:
+                                    "gateway request timed out after \(Int(effectiveTimeout))ms"])
+                            await self.finishRequest(id: payload.id, result: .failure(error))
                         }
                     }
+                    self.pending[payload.id] = request
                     Task {
                         guard !cancellationGate.isCancelled else {
-                            self.cancelRequest(id: payload.id)
+                            self.finishRequest(id: payload.id, result: .failure(CancellationError()))
                             return
                         }
                         do {
@@ -1456,7 +1466,7 @@ extension GatewayChannelActor {
                         } catch is CancellationError {
                             // Cancellation owns only this request. Treating it as socket loss
                             // starts disconnect cleanup and can reject an immediate safe retry.
-                            self.cancelRequest(id: payload.id)
+                            self.finishRequest(id: payload.id, result: .failure(CancellationError()))
                         } catch {
                             let wrapped = self.wrap(error, context: "gateway send \(method)")
                             await self.transitionToDisconnected(
@@ -1469,7 +1479,7 @@ extension GatewayChannelActor {
                 }
             } onCancel: {
                 cancellationGate.cancel()
-                Task { await self.cancelRequest(id: payload.id) }
+                Task { await self.finishRequest(id: payload.id, result: .failure(CancellationError())) }
             }
         } catch {
             #if DEBUG
@@ -1620,26 +1630,17 @@ extension GatewayChannelActor {
         }
     }
 
-    private func failPending(_ error: Error) async {
-        let waiters = self.pending
-        self.pending.removeAll()
-        for (_, waiter) in waiters {
-            waiter.resume(throwing: error)
+    private func failPending(_ error: Error) {
+        for id in Array(self.pending.keys) {
+            self.finishRequest(id: id, result: .failure(error))
         }
     }
 
-    private func timeoutRequest(id: String, timeoutMs: Double) async {
-        guard let waiter = self.pending.removeValue(forKey: id) else { return }
-        let err = NSError(
-            domain: "Gateway",
-            code: 5,
-            userInfo: [NSLocalizedDescriptionKey: "gateway request timed out after \(Int(timeoutMs))ms"])
-        waiter.resume(throwing: err)
-    }
-
-    private func cancelRequest(id: String) {
-        guard let waiter = self.pending.removeValue(forKey: id) else { return }
-        waiter.resume(throwing: CancellationError())
+    private func finishRequest(id: String, result: Result<GatewayFrame, Error>) {
+        guard let request = self.pending.removeValue(forKey: id) else { return }
+        // A deadline belongs to its pending request, including after caller cancellation or disconnect.
+        request.timeoutTask?.cancel()
+        request.continuation.resume(with: result)
     }
 
     private func cancelConnectWaiter(id: UUID) {


### PR DESCRIPTION
Related: #136572

## What Problem This Solves

The macOS app kept scheduling work after presence reporting was disabled, after an RPC completed, and after Connection settings was hidden. Unrelated menu-state changes also reassigned the icon's SwiftUI root.

## Why This Change Was Made

Retire work at its owner: disabled presence sampling stops unless a delivered sample still needs a clear retry; each pending RPC owns its continuation and deadline and retires both through one terminal path; Connection settings polls Tailscale only while active without cancelling the shared status request; SwiftUI observes icon inputs independently of menu side effects.

The existing opt-out clear/reconnect safeguards, zero-as-unbounded RPC deadline, cancellation precedence, shared connection lifetime, menu row sizing and animation cadence remain intact. Removed the unconditional disabled loop, detached completed deadlines, Timer start/stop, and controller-driven icon-root reassignment. No new configuration, dependency, schema, protocol or bitmap cache.

Production: +119/−118 (net +1); tests/support: +125/−11 (net +114). The ownership structures replace the previous retirement/timer paths rather than add another polling layer.

## Completed Validation

Exact native source: `847c1b4023d522133a56f61b9a5e8d71190633e3`; baseline: `2b08972def7ea24b3a5da0dea4491734cd91de22`.

- Independent P0–P2 autoreview: scoped-clean. Pinned SwiftFormat/SwiftLint and the full local changed-files apps gate passed.
- Strict, canary-verified OS-sandbox native proof: **66 declarations / 77 cases passed** across RPC, presence, Tailscale, animation and hidden-menu owners. All **six new lifetime cases fail on unchanged baseline production**. Coverage includes response/cancellation/disconnect/shutdown, opt-out/late-delivery/failed-clear retries, route replacement, and shared-request cancellation. The full native CI test lane passed; it was not run on the operator desktop.
- Signed baseline/candidate live UI: Connection remained functional, the real status menu opened and refreshed, normal animations stayed enabled, presence opt-in populated native-node activity fields, opt-out cleared them, and re-enable populated them again. A final opt-out and local pause/resume returned to one connected native node with no activity fields. Pause/resume intentionally restarted the named test Gateway **after** all paired measurements.
- Tailscale positive controls, each 20 seconds: baseline visible **4 app + 4 CLI checks**, hidden cached pane **4 + 4**; candidate visible **4 + 4**, hidden **0 + 0**, reopened **4 + 4**. Both variants stopped these probes after Settings closed.

## Measurements and Limits

Matched Developer-ID-signed Debug arm64 native builds, normal icon animations, separate channel-free local profile, same Gateway process throughout the paired measurements. These were **native-only** builds sharing identical older runtime/resources from `1623683f478b1e4a2e3d5632585f006ea142e08c`, not rebuilt current-head product packages. No live provider/channel claim.

| Measurement | Baseline | Candidate |
| --- | ---: | ---: |
| Unprofiled app CPU, 240 seconds, % of one core | 3.442% | 3.612% |
| Unprofiled Gateway CPU, same windows | 0.358% | 0.383% |
| Time Profiler + Activity Monitor CPU | 2.914% | 2.728% |
| Trace idle wakeups/sec | 34.073 | 30.214 |
| Actual Activity Monitor interval | 57.524 s | 59.409 s |

**No repeatable overall CPU or battery improvement is established.** This single pair shows removal of unnecessary lifecycle work, not a general CPU win. Randomized animation and uncontrolled desktop activity limit comparisons. One manual `node.list`/`system-presence` probe occurred during the candidate counter window; it is not hidden-menu polling. Closed-window automatic menu polling remained absent; health requests succeeded. Inclusive hosting-layout samples remained substantial (435 ms baseline, 404 ms candidate); raster icon construction was only 10/11 ms. Inclusive weights overlap. One unavailable baseline stack was retained in the denominator; candidate had none. Neither trace entered App Nap.

The first candidate xctrace attempt stalled and produced no usable result; its unchanged-command retry completed successfully with target generation and signed binary hash verified. A naturally slow first Tailscale request was not forced in the live UI; focused cancellation/coalescing tests cover that race's shared owner. No individual CPU delta is claimed for each cleanup.

## Exact-head CI

[CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33696807168) is green, including [full Swift tests](https://github.com/openclaw/openclaw/actions/runs/33696807168/job/100476264081), [Swift release build](https://github.com/openclaw/openclaw/actions/runs/33696807168/job/100476264094), all three macOS tooling lanes, iOS builds/screenshots and the required gate. [macOS](https://github.com/openclaw/openclaw/actions/runs/33696807048), [iOS](https://github.com/openclaw/openclaw/actions/runs/33696807101) and [shared-kit](https://github.com/openclaw/openclaw/actions/runs/33696807181) Periphery passed too.

Initial macOS jobs had no runner or executed steps. Once no work was executing, the documented failed-job retry selected hosted runners and preserved already-passed jobs. No CI test failures. Local native compilation needed an 8-job retry after a 32-job signal-9 resource failure. Both ClawSweeper proof/rank-up requests are addressed by this completed evidence and the captures below.

## Before / After

Synthetic Connection UI only; no operator data or credentials. The pending-health label is the pre-existing empty-channel presentation noted below, while the fixture's health RPC returned `ok: true`.

| Baseline | Candidate |
| --- | --- |
| ![Baseline Connection settings](https://github.com/user-attachments/assets/303de229-cf6c-4d63-a8ee-159ec9619853) | ![Candidate Connection settings](https://github.com/user-attachments/assets/28640e03-780c-4b14-a9dc-0ea2d717d8cb) |

The task app, named Gateway, test profile/preferences and temporary files were removed after verification; raw traces and redacted reports remain local.

## Named Follow-ups

Pre-existing and unchanged: HealthStore presents a completed empty-channel health result as pending; the menu-bar guide's `workingOther` scurry wording differs from the renderer. Neither is hidden by this patch.
