### PR TITLE
fix(agents): native questions disappear in multi-agent channel sessions

### DIFF
--- a/.agents/skills/telegram-e2e-userbot/scripts/run-mock-sut-user-e2e.mjs
+++ b/.agents/skills/telegram-e2e-userbot/scripts/run-mock-sut-user-e2e.mjs
@@ -560,6 +560,9 @@ async function telegram(token, method, body = {}, lease, fetchImpl = fetch) {
 
 export async function drainSutUpdates(sutToken, lease, fetchImpl = fetch) {
   const before = await telegram(sutToken, "getWebhookInfo", {}, lease, fetchImpl);
+  if (before.url) {
+    await telegram(sutToken, "deleteWebhook", { drop_pending_updates: true }, lease, fetchImpl);
+  }
   const updates = await telegram(
     sutToken,
     "getUpdates",
@@ -1131,7 +1134,14 @@ async function driveWithTelegramProxy(args, repoRoot, creds) {
     const startGateway = async () => {
       const command = "node";
       const gatewayArgs = args.sourceGateway
-        ? ["--import", "tsx", "src/entry.ts", "gateway", "--port", String(args.gatewayPort)]
+        ? [
+            "--import",
+            "./scripts/tsx.mjs",
+            "src/entry.ts",
+            "gateway",
+            "--port",
+            String(args.gatewayPort),
+          ]
         : ["dist/entry.js", "gateway", "--port", String(args.gatewayPort)];
       const child = spawnProcess(command, gatewayArgs, { cwd: repoRoot, env: gatewayEnv });
       try {

--- a/.agents/skills/telegram-e2e-userbot/scripts/run-mock-sut-user-e2e.test.mjs
+++ b/.agents/skills/telegram-e2e-userbot/scripts/run-mock-sut-user-e2e.test.mjs
@@ -331,6 +331,40 @@ test("lease revocation between startup Bot API calls prevents update polling", a
   assert.deepEqual(methods, ["getWebhookInfo"]);
 });
 
+test("clears a leased bot webhook before polling updates", async () => {
+  const methods = [];
+  const bodies = [];
+  const results = [
+    { url: "https://example.test/webhook", pending_update_count: 2 },
+    true,
+    [],
+    { url: "", pending_update_count: 0 },
+  ];
+  const fetchImpl = async (url, init) => {
+    methods.push(new URL(url).pathname.split("/").at(-1));
+    bodies.push(JSON.parse(init.body));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, result: results.shift() }),
+    };
+  };
+  const result = await drainSutUpdates(
+    "sut-token",
+    { assertHealthy: () => {}, whenUnhealthy: new Promise(() => {}) },
+    fetchImpl,
+  );
+
+  assert.deepEqual(methods, ["getWebhookInfo", "deleteWebhook", "getUpdates", "getWebhookInfo"]);
+  assert.deepEqual(bodies[1], { drop_pending_updates: true });
+  assert.deepEqual(result, {
+    webhookUrlSet: true,
+    pendingBefore: 2,
+    drained: 0,
+    pendingAfter: 0,
+  });
+});
+
 test("lease loss during a credential command stops every owned child before its side effect", async (context) => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "telegram-command-lease-fence-"));
   const sideEffect = path.join(temp, "sent");

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -238,6 +238,7 @@ describe("plugin-owned CLI execution host boundary", () => {
       runId: "plugin-user-input",
       nativeTools: ["AskUserQuestion"],
     });
+    context.params.sessionKey = "main";
     context.params.runtimePolicySessionKey = "agent:main:telegram:default:direct:canonical-sender";
     let promptDelivered = createDeferred();
     const onBlockReply = vi.fn(async () => {

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -238,6 +238,7 @@ describe("plugin-owned CLI execution host boundary", () => {
       runId: "plugin-user-input",
       nativeTools: ["AskUserQuestion"],
     });
+    context.params.runtimePolicySessionKey = "agent:main:telegram:default:direct:canonical-sender";
     let promptDelivered = createDeferred();
     const onBlockReply = vi.fn(async () => {
       promptDelivered.resolve();
@@ -245,8 +246,13 @@ describe("plugin-owned CLI execution host boundary", () => {
     context.params.onBlockReply = onBlockReply;
     const requests = new Map<string, { questions: Array<{ questionId: string }> }>();
     mockCallGatewayTool.mockImplementation(async (method, _opts, rawParams) => {
-      const params = rawParams as { id: string; questions?: Array<{ questionId: string }> };
+      const params = rawParams as {
+        id: string;
+        questions?: Array<{ questionId: string }>;
+        sessionKey?: string;
+      };
       if (method === "question.request") {
+        expect(params.sessionKey).toBe(context.params.runtimePolicySessionKey);
         requests.set(params.id, { questions: params.questions ?? [] });
         return { id: params.id };
       }

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -253,7 +253,7 @@ describe("plugin-owned CLI execution host boundary", () => {
         sessionKey?: string;
       };
       if (method === "question.request") {
-        expect(params.sessionKey).toBe(context.params.runtimePolicySessionKey);
+        expect(params.sessionKey).toBe(context.params.sessionKey);
         requests.set(params.id, { questions: params.questions ?? [] });
         return { id: params.id };
       }
@@ -292,27 +292,6 @@ describe("plugin-owned CLI execution host boundary", () => {
             isOther: true,
             options: [{ label: "A" }, { label: "B" }],
           },
-          {
-            id: "two",
-            header: "Two",
-            question: "Second question?",
-            isOther: true,
-            options: [{ label: "A" }, { label: "B" }],
-          },
-          {
-            id: "three",
-            header: "Three",
-            question: "Third question?",
-            isOther: true,
-            options: [{ label: "A" }, { label: "B" }],
-          },
-          {
-            id: "four",
-            header: "Four",
-            question: "Fourth question?",
-            isOther: true,
-            options: [{ label: "A" }, { label: "B" }],
-          },
         ],
       });
       yield SUCCESS_RESULT;
@@ -322,14 +301,10 @@ describe("plugin-owned CLI execution host boundary", () => {
       status: "answered",
       answers: {
         one: ["one"],
-        two: ["two"],
-        three: ["three"],
-        four: ["four"],
       },
     });
-    expect([...requests.keys()]).toEqual(["claude-question:0", "claude-question:1"]);
-    expect([...requests.values()].map((request) => request.questions.length)).toEqual([3, 1]);
-    expect(onBlockReply).toHaveBeenCalledTimes(2);
+    expect([...requests.keys()]).toEqual(["claude-question:0"]);
+    expect(onBlockReply).toHaveBeenCalledOnce();
   });
 
   it("restarts true fresh sessions while preserving legitimate no-resume warm reuse", async () => {

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -300,7 +300,7 @@ function createPluginUserInputHandler(params: {
           })),
           intro: request.intro?.trim() || "Agent needs input:",
         }),
-        sessionKey: run.runtimePolicySessionKey ?? run.sessionKey ?? run.sessionId,
+        sessionKey: run.sessionKey ?? run.sessionId,
         agentId: run.agentId,
         runId: run.runId,
         timeoutMs: run.timeoutMs,

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -300,7 +300,7 @@ function createPluginUserInputHandler(params: {
           })),
           intro: request.intro?.trim() || "Agent needs input:",
         }),
-        sessionKey: run.sessionKey ?? run.sessionId,
+        sessionKey: run.runtimePolicySessionKey ?? run.sessionKey ?? run.sessionId,
         agentId: run.agentId,
         runId: run.runId,
         timeoutMs: run.timeoutMs,

--- a/src/agents/harness/gateway-question.test.ts
+++ b/src/agents/harness/gateway-question.test.ts
@@ -332,6 +332,12 @@ describe("gateway harness questions", () => {
       questionId: "ask_44444444444444444444444444444444",
     });
     await vi.waitFor(() => expect(onBlockReply).toHaveBeenCalledOnce());
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        deliveryIntentId: "block-reply:v1:agent-question:ask_44444444444444444444444444444444",
+      }),
+    );
 
     await expect(
       cancelPendingAgentQuestionForSession({

--- a/src/agents/harness/user-input-bridge.ts
+++ b/src/agents/harness/user-input-bridge.ts
@@ -216,7 +216,12 @@ export async function deliverAgentHarnessQuestionPrompt(
   signal?.throwIfAborted();
   const payload = buildAgentHarnessQuestionPromptPayload({ questionId, questions, options });
   if (params.onBlockReply) {
-    await params.onBlockReply(payload, signal ? { abortSignal: signal } : undefined);
+    // The agent cannot finish until this prompt is answered. Give channel delivery
+    // an independent stable intent so it does not wait behind the blocked stream.
+    await params.onBlockReply(payload, {
+      ...(signal ? { abortSignal: signal } : {}),
+      deliveryIntentId: `block-reply:v1:agent-question:${questionId}`,
+    });
     return;
   }
   signal?.throwIfAborted();

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -429,6 +429,10 @@ export async function runCliFallbackCandidate(
               toolAuthorityRoute,
             ),
             abortSignal: params.runAbortSignal,
+            // Native input is already host-authored. Keep its stable delivery
+            // context out of the model-output normalization wrapper.
+            onBlockReply: turn.opts?.onBlockReply,
+            onPartialReply: turn.opts?.onPartialReply,
             onExecutionPhase: params.signalExecutionPhaseForTyping,
             replyOperation: turn.replyOperation,
           },

--- a/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
@@ -220,6 +220,47 @@ describe("executeAgentTurn: CLI durable commentary", () => {
     }
   });
 
+  it("forwards channel presentation callbacks to native CLI input", async () => {
+    useClaudeCliFallback();
+    state.createBlockReplyDeliveryHandlerMock.mockImplementationOnce(
+      (params: { onBlockReply: NonNullable<GetReplyOptions["onBlockReply"]> }) =>
+        params.onBlockReply,
+    );
+    state.runCliAgentMock.mockImplementationOnce(async (params: RunCliAgentParams) => {
+      await params.onBlockReply?.({
+        text: "Which color?",
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                {
+                  label: "Blue",
+                  action: { type: "question", questionId: "question-1", optionValue: "Blue" },
+                },
+              ],
+            },
+          ],
+        },
+      });
+      await params.onPartialReply?.({ text: "Fallback question" });
+      return { payloads: [{ text: "Answered." }], meta: {} };
+    });
+
+    const onBlockReply = vi.fn<NonNullable<GetReplyOptions["onBlockReply"]>>(async () => undefined);
+    const onPartialReply = vi.fn<NonNullable<GetReplyOptions["onPartialReply"]>>(
+      async () => undefined,
+    );
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+
+    await executeAgentTurn(createTurnParams({ onBlockReply, onPartialReply }, false));
+
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Which color?", presentation: expect.any(Object) }),
+    );
+    expect(onPartialReply).toHaveBeenCalledWith({ text: "Fallback question" });
+  });
+
   it("delivers commentary payloads without block streaming", async () => {
     useClaudeCliFallback();
     state.createBlockReplyDeliveryHandlerMock.mockImplementationOnce(

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -1,4 +1,5 @@
 import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
+import { claimPendingAgentQuestionAnswer } from "../../agents/harness/gateway-question.js";
 import { settleProgressVisibilityCallbackResult } from "../../channels/progress-visibility.js";
 import { hasRestartRecoverySourceClaim } from "../../config/sessions/restart-recovery-state.js";
 import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -203,6 +204,38 @@ export async function runReplyAgent(
           activeSessionStore[sessionKey] = retired;
         }
       }
+    }
+    releaseAdmissionTicket();
+    typing.cleanup();
+    return undefined;
+  }
+
+  const pendingQuestionText = (
+    transcriptCommandBody ??
+    followupRun.transcriptPrompt ??
+    commandBody
+  ).trim();
+  const isExternalUserInput =
+    followupRun.run.inputProvenance === undefined ||
+    followupRun.run.inputProvenance.kind === "external_user";
+  if (
+    !isHeartbeat &&
+    isExternalUserInput &&
+    pendingQuestionText &&
+    !followupRun.images?.length &&
+    !followupRun.media?.length &&
+    (await claimPendingAgentQuestionAnswer({
+      sessionKey,
+      text: pendingQuestionText,
+      persist: followupRun.userTurnTranscriptRecorder
+        ? async () => {
+            await followupRun.userTurnTranscriptRecorder?.persistApproved();
+          }
+        : undefined,
+    }))
+  ) {
+    if (replyOperationRunState) {
+      replyOperationRunState.admission = { status: "accepted", mode: "steer" };
     }
     releaseAdmissionTicket();
     typing.cleanup();

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -12,6 +12,7 @@ import {
   isEmbeddedAgentRunActive,
 } from "../../agents/embedded-agent-runner/runs.js";
 import { testing as embeddedRunTesting } from "../../agents/embedded-agent-runner/runs.test-support.js";
+import { registerPendingAgentQuestion } from "../../agents/harness/gateway-question.js";
 import {
   runFallbackModelAttempt,
   runInitialModelFallbackAttempt,
@@ -49,6 +50,7 @@ import {
 } from "./agent-runner.test-fixtures.js";
 import type { FollowupRun } from "./queue.js";
 import { enqueueFollowupRun, scheduleFollowupDrain } from "./queue.js";
+import { REPLY_OPERATION_RUN_STATE } from "./reply-operation-run-state.js";
 import { createReplyOperation, replyRunRegistry } from "./reply-run-registry.js";
 import { testing as replyRunRegistryTesting } from "./reply-run-registry.test-support.js";
 import { createMockTypingController } from "./test-helpers.js";
@@ -440,6 +442,64 @@ afterEach(() => {
   clearMemoryPluginState();
   replyRunRegistryTesting.resetReplyRunRegistry();
   embeddedRunTesting.resetActiveEmbeddedRuns();
+});
+
+describe("runReplyAgent pending operator input", () => {
+  it("claims a direct CLI answer before active-run queueing", async () => {
+    const gatewayCall = vi.fn(async (_method, _opts, params) => ({
+      status: "answered",
+      answers: (params as { answers: { answers: Record<string, string[]> } }).answers,
+    }));
+    const reservation = registerPendingAgentQuestion({
+      questionId: "ask_direct_cli_answer",
+      sessionKey: "main",
+      questions: [
+        {
+          id: "color",
+          header: "Color",
+          question: "Which color?",
+          options: [{ label: "Blue" }, { label: "Green" }],
+        },
+      ],
+      gatewayCall,
+      answer: Promise.resolve({ status: "pending" }),
+    });
+    reservation.attachRegistration(Promise.resolve({ id: "ask_direct_cli_answer" }));
+    const replyOperationRunState = {};
+    const testRun = createBaseRun({
+      context: { agentText: "Green" },
+      followup: { transcriptPrompt: "Green" },
+      reply: {
+        commandBody: "Green",
+        transcriptCommandBody: "Green",
+        sessionKey: "main",
+        isActive: true,
+        shouldSteer: true,
+        opts: { [REPLY_OPERATION_RUN_STATE]: replyOperationRunState },
+      },
+    });
+
+    try {
+      await expect(testRun.run()).resolves.toBeUndefined();
+      expect(gatewayCall).toHaveBeenCalledWith(
+        "question.resolve",
+        {},
+        {
+          id: "ask_direct_cli_answer",
+          answers: { answers: { color: ["Green"] } },
+          resolvedBy: "plain-text",
+        },
+      );
+      expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+      expect(runCliAgentMock).not.toHaveBeenCalled();
+      expect(testRun.typing.cleanup).toHaveBeenCalledOnce();
+      expect(replyOperationRunState).toEqual({
+        admission: { status: "accepted", mode: "steer" },
+      });
+    } finally {
+      reservation.dispose();
+    }
+  });
 });
 
 describe("runReplyAgent auto-compaction token update", () => {


### PR DESCRIPTION
Closes #135668

## What Problem This Solves

Native Claude questions could disappear in a channel-backed multi-agent session. The run stayed active, but the user saw no question and could not answer it.

## Why This Change Was Made

The direct CLI candidate dropped the channel delivery callbacks before it entered the shared native-input bridge. Even with those callbacks present, a blocked question needed its own durable delivery intent so it could bypass the blocked final-answer stream. A plain-text answer also entered normal steer or queue policy instead of claiming the pending question first.

The repair keeps the canonical transcript session key for question ownership, forwards the existing channel callbacks, gives each native question a stable delivery intent, and claims external text answers before active-run queueing. It also fixes the Telegram proof harness source loader and clears stale leased-bot webhooks before polling.

## User Impact

Telegram and other channel users now receive native Claude `AskUserQuestion` prompts in the originating conversation. Their answer resolves the prompt and resumes the same run without a generic fallback reply.

## Evidence

- Current-main red at `c5bde6ac9349`: Telegram showed only `Working / AskUserQuestion` for 61 seconds. No question or option button appeared.
- Exact-head Telegram Test Server green at `78f45fdff2f1`: the question appeared at 7.2 seconds, `Blue` was sent at 10.2 seconds, the prompt changed to `Answered: Blue`, and Claude replied `NATIVE_QUESTION_RESUMED_BLUE` at 13.3 seconds.
- Anti-cheat: the green run changed the attempted answer from the baseline `Green` click to plain-text `Blue` and observed the selected value in both the prompt edit and Claude's resumed output.
- Blacksmith Actions run `33721439808`: full `pnpm check`, 88 auto-reply tests, 43 agent-support tests, and 18 Telegram harness tests passed.
- Blacksmith Actions run `33721807023`: full exact-head build passed, including runtime post-build and all 149 public plugin SDK subpaths.
- `git diff --check origin/main...HEAD` and formatting checks passed.
- Exact-head Autoreview reported no P0 findings with 0.98 correctness confidence.

The original contributor's focused session-key regression remains, reduced to one question because batching already has owner-level coverage in `src/agents/harness/structured-input-execution.test.ts`.
