### PR TITLE
fix(skills): avoid worker compilation in focused command tests

### DIFF
--- a/src/skills/discovery/chat-commands.test.ts
+++ b/src/skills/discovery/chat-commands.test.ts
@@ -8,7 +8,9 @@ let listSkillCommandsForAgents: typeof import("./chat-commands.js").listSkillCom
 let listSkillCommandsForWorkspace: typeof import("./chat-commands.js").listSkillCommandsForWorkspace;
 let expandExplicitSkillReferences: typeof import("./chat-commands.js").expandExplicitSkillReferences;
 let resolveSkillCommandInvocation: typeof import("./chat-commands.js").resolveSkillCommandInvocation;
-let lastPluginMetadataSnapshot: unknown;
+let lastCommandBuildOptions:
+  | { pluginMetadataSnapshot?: unknown; librarySelections?: unknown }
+  | undefined;
 
 function resolveSkillReferenceInvocations(
   params: Parameters<typeof expandExplicitSkillReferences>[0],
@@ -97,6 +99,7 @@ function buildWorkspaceSkillCommandSpecs(
     skillFilter?: string[];
     agentId?: string;
     pluginMetadataSnapshot?: unknown;
+    librarySelections?: unknown;
     config?: {
       agents?: {
         defaults?: { skills?: string[] };
@@ -105,7 +108,7 @@ function buildWorkspaceSkillCommandSpecs(
     };
   },
 ) {
-  lastPluginMetadataSnapshot = opts?.pluginMetadataSnapshot;
+  lastCommandBuildOptions = opts;
   const used = new Set<string>();
   for (const reserved of opts?.reservedNames ?? []) {
     used.add(reserved.toLowerCase());
@@ -179,7 +182,7 @@ afterAll(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  lastPluginMetadataSnapshot = undefined;
+  lastCommandBuildOptions = undefined;
   resolveNodeExecEligibilityMock.mockReturnValue({ canExec: false });
 });
 
@@ -661,6 +664,22 @@ describe("listSkillCommandsForWorkspace", () => {
       pluginMetadataSnapshot,
     });
 
-    expect(lastPluginMetadataSnapshot).toBe(pluginMetadataSnapshot);
+    expect(lastCommandBuildOptions?.pluginMetadataSnapshot).toBe(pluginMetadataSnapshot);
+  });
+
+  it("delegates pinned library loading to the command entry provider", async () => {
+    const baseDir = tempDirs.make("openclaw-skills-workspace-library-");
+    const workspaceDir = await createWorkspace(baseDir, "main");
+    const librarySelections = [
+      { skillId: "library-guide", revision: "revision", name: "guide", ownerProfileId: "profile" },
+    ];
+
+    listSkillCommandsForWorkspace({
+      workspaceDir,
+      cfg: {},
+      sessionEntry: { skillLibrarySelections: librarySelections },
+    });
+
+    expect(lastCommandBuildOptions?.librarySelections).toBe(librarySelections);
   });
 });

--- a/src/skills/discovery/chat-commands.ts
+++ b/src/skills/discovery/chat-commands.ts
@@ -14,8 +14,6 @@ import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
-import { loadSkillLibrarySelection } from "../library/selection.js";
-import { loadWorkspaceSkills } from "../loading/workspace-skill-loader.js";
 import { getRemoteSkillEligibility } from "../runtime/remote.js";
 import type { SkillCommandSpec } from "../types.js";
 import { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";
@@ -51,17 +49,6 @@ export function listSkillCommandsForWorkspace(params: {
     nodeSkills,
     remote: getRemoteSkillEligibility({ advertiseExecNode: nodeSkills.canExec }),
   };
-  const entries =
-    params.includeAllowlistHidden || params.sessionEntry?.skillLibrarySelections?.length
-      ? loadWorkspaceSkills(params.workspaceDir, {
-          config: params.cfg,
-          eligibility,
-          pluginMetadataSnapshot: params.pluginMetadataSnapshot,
-        })
-      : undefined;
-  if (entries && params.sessionEntry?.skillLibrarySelections?.length) {
-    entries.push(...loadSkillLibrarySelection(params.sessionEntry.skillLibrarySelections));
-  }
   return buildWorkspaceSkillCommandSpecs(params.workspaceDir, {
     config: params.cfg,
     agentId: params.agentId,
@@ -69,7 +56,7 @@ export function listSkillCommandsForWorkspace(params: {
     includeAllowlistHidden: params.includeAllowlistHidden,
     eligibility,
     pluginMetadataSnapshot: params.pluginMetadataSnapshot,
-    ...(entries ? { entries } : {}),
+    librarySelections: params.sessionEntry?.skillLibrarySelections,
     reservedNames: listReservedChatSlashCommandNames(),
   });
 }

--- a/src/skills/discovery/command-specs.test.ts
+++ b/src/skills/discovery/command-specs.test.ts
@@ -26,17 +26,10 @@ vi.mock("../../plugins/bundle-commands.js", () => ({
   loadEnabledClaudeBundleCommands: () => bundleCommandState.entries,
 }));
 
-vi.mock("../loading/workspace-skill-loader.js", async () => {
-  const actual = await vi.importActual<typeof import("../loading/workspace-skill-loader.js")>(
-    "../loading/workspace-skill-loader.js",
-  );
-  return {
-    filterWorkspaceSkills: (entries: SkillEntry[]) => entries,
-    loadMergedWorkspaceSkills: () => [],
-    loadVisibleSkills: () => [],
-    normalizeWorkspaceSkillRoots: actual.normalizeWorkspaceSkillRoots,
-  };
-});
+vi.mock("../loading/workspace-skill-loader.js", () => ({
+  filterWorkspaceSkills: (entries: SkillEntry[]) => entries,
+  loadVisibleSkills: () => [],
+}));
 
 beforeEach(() => {
   vi.resetModules();

--- a/src/skills/discovery/command-specs.ts
+++ b/src/skills/discovery/command-specs.ts
@@ -11,7 +11,12 @@ import { loadEnabledClaudeBundleCommands } from "../../plugins/bundle-commands.j
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { resolveSkillTelemetrySource } from "../loading/source.js";
 import { filterWorkspaceSkills, loadVisibleSkills } from "../loading/workspace-skill-loader.js";
-import type { SkillEligibilityContext, SkillCommandSpec, SkillEntry } from "../types.js";
+import type {
+  SkillEligibilityContext,
+  SkillCommandSpec,
+  SkillEntry,
+  SkillSnapshot,
+} from "../types.js";
 import { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";
 import { sanitizeSkillCommandName, SKILL_COMMAND_MAX_LENGTH } from "./command-name.js";
 import { filterUserInvocableSkillEntries, isSkillPromptVisible } from "./skill-index.js";
@@ -68,6 +73,7 @@ export function buildWorkspaceSkillCommandSpecs(
     managedSkillsDir?: string;
     bundledSkillsDir?: string;
     entries?: SkillEntry[];
+    librarySelections?: SkillSnapshot["librarySelections"];
     agentId?: string;
     skillFilter?: string[];
     includeAllowlistHidden?: boolean;
@@ -89,6 +95,7 @@ export function buildWorkspaceSkillCommandSpecs(
         config: opts?.config,
         managedSkillsDir: opts?.managedSkillsDir,
         bundledSkillsDir: opts?.bundledSkillsDir,
+        librarySelections: opts?.librarySelections,
         skillFilter: effectiveSkillFilter,
         eligibility: opts?.eligibility,
         pluginMetadataSnapshot: opts?.pluginMetadataSnapshot,

--- a/src/skills/library/service.test.ts
+++ b/src/skills/library/service.test.ts
@@ -10,7 +10,7 @@ import {
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
 import { ensureProfileForEmail, linkEmail } from "../../state/user-profiles.js";
-import { withEnvAsync } from "../../test-utils/env.js";
+import { withEnv, withEnvAsync } from "../../test-utils/env.js";
 import { materializeSkillResources, prepareSkillResourceDelivery } from "../runtime/resources.js";
 import { prepareSkillLibraryBundle, skillLibraryRevisionDir } from "./bundle.js";
 import { uploadSkillLibrary } from "./import.js";
@@ -107,6 +107,51 @@ describe("profile-owned skill publication and selection", () => {
       buildWorkspaceSkillCommandSpecs(stateDir, { entries: [copied, ...entries] }),
     ).toThrow("ambiguous");
   });
+  it("discovers pinned commands through the loader without leaking them into workspace state", async () => {
+    const { alice, options, stateDir } = fixture();
+    const saved = await saveSkillLibrary(alice, draft(), options);
+    const pins = seedSkillLibrarySelection(alice, options);
+    await saveSkillLibrary(
+      alice,
+      {
+        ...draft(),
+        skillId: saved.entry.skillId,
+        expectedRevision: saved.entry.revision,
+        content: `${content}\nUpdated`,
+      },
+      options,
+    );
+    const { listSkillCommandsForWorkspace } = await import("../discovery/chat-commands.js");
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      const cfg = { agents: { defaults: { skills: [] } } };
+      const discover = (
+        overrides: Partial<Parameters<typeof listSkillCommandsForWorkspace>[0]> = {},
+      ) =>
+        listSkillCommandsForWorkspace({
+          workspaceDir: stateDir,
+          cfg,
+          agentId: "main",
+          sessionEntry: { skillLibrarySelections: pins },
+          ...overrides,
+        });
+      const commands = discover({ skillFilter: [saved.entry.name] });
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toMatchObject({
+        name: saved.entry.name,
+        skillFile: expect.stringContaining(saved.entry.revision),
+      });
+      expect(discover()).toEqual([]);
+      expect(discover({ includeAllowlistHidden: true })).toContainEqual(commands[0]);
+      expect(
+        discover({
+          includeAllowlistHidden: true,
+          cfg: { ...cfg, skills: { entries: { [saved.entry.name]: { enabled: false } } } },
+        }).map((entry) => entry.name),
+      ).not.toContain(saved.entry.name);
+      expect(discover({ sessionEntry: undefined, skillFilter: [saved.entry.name] })).toEqual([]);
+    });
+  });
+
   it("keeps solo defaults, counts aliases once, and never creates library tables on discovery", () => {
     const { options, admin, alice, actor } = fixture();
     expect(listSkillLibrary(admin, {}, options)).toMatchObject({

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -20,6 +20,7 @@ import {
 } from "../discovery/agent-filter.js";
 import { normalizeSkillFilter } from "../discovery/filter.js";
 import { assertUnambiguousManagedSkillNames } from "../library/command-name.js";
+import { loadSkillLibrarySelection } from "../library/selection.js";
 import { getSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { mergeRemoteNodeSkillEntries } from "../runtime/remote-skills.js";
 import { fingerprintSkillSnapshotConfig } from "../runtime/snapshot-config-fingerprint.js";
@@ -28,6 +29,7 @@ import type {
   ParsedSkillFrontmatter,
   SkillEligibilityContext,
   SkillEntry,
+  SkillSnapshot,
 } from "../types.js";
 import { resolveBundledSkillsDir } from "./bundled-dir.js";
 import { resolveBundledAllowlist, shouldIncludeSkill } from "./config.js";
@@ -687,6 +689,7 @@ export function loadVisibleSkills(
     config?: OpenClawConfig;
     managedSkillsDir?: string;
     bundledSkillsDir?: string;
+    librarySelections?: SkillSnapshot["librarySelections"];
     skillFilter?: string[];
     skillOverrides?: Record<string, boolean>;
     agentId?: string;
@@ -694,10 +697,14 @@ export function loadVisibleSkills(
     pluginMetadataSnapshot?: PluginMetadataSnapshot;
   },
 ): SkillEntry[] {
-  const entries = mergeRemoteNodeSkillEntries(loadSkillEntries(workspaceDir, opts), {
+  let entries = mergeRemoteNodeSkillEntries(loadSkillEntries(workspaceDir, opts), {
     canExec: opts?.eligibility?.nodeSkills?.canExec,
     node: opts?.eligibility?.nodeSkills?.node,
   });
+  if (opts?.librarySelections?.length) {
+    // Pins are session-owned: append before filtering without mutating the workspace cache.
+    entries = entries.concat(loadSkillLibrarySelection(opts.librarySelections));
+  }
   const effectiveSkillFilter = resolveEffectiveWorkspaceSkillFilter(opts);
   return filterSkillEntries(
     entries,


### PR DESCRIPTION
Follow-up to [#136676: keep Gateway method discovery independent of session storage](https://github.com/openclaw/openclaw/pull/136676).

## What Problem This Solves

Resolves focused skill-command tests compiling an unrelated worker fixture graph before running their assertions. After the Gateway metadata repair, the two-file command still took 62.06s cold / 41.01s warm and prepared 7,534 inputs into 3,342 worker outputs per run.

## Why This Change Was Made

Keep command-entry materialization in the existing workspace loader instead of a second path in the chat coordinator. Chat discovery now forwards the admitted library pins to command-specs, which delegates them to `loadVisibleSkills`. The loader appends pinned entries outside its workspace cache and applies the same eligibility/allowlist filters.

The command-spec unit mock also no longer imports the whole real loader just to copy an unused normalization export. Its unused mock exports are removed. There are no new broad mocks, helpers, caches, timeouts, compiler changes, configuration keys, schemas or protocol changes.

Production: +17/-16 (net +1); tests: +73/-16 (net +57). The duplicate coordinator loading path is removed; the one net production line is option/type wiring and the cache-ownership explanation.

## User Impact

Focused developer test startup drops to seconds without sacrificing the original cases. Actual skill discovery preserves pinned revisions, allowlists, config-disabled exclusion, and workspace-cache isolation. No UI/channel-visible behavior or authorization change.

SQLite's synchronous snapshot and POSIX-lock isolation behavior, worker-generation freshness, and runtime snapshot/resource paths remain untouched.

## Evidence

### Measured startup

Same ordered two-file selection, one worker, verbose reporter and import diagnostics; fresh private cold caches reused only by their matching warm runs:

| Metric | Before cold | After cold | Before warm | After warm |
| --- | ---: | ---: | ---: | ---: |
| Wall | 62.06s | 4.34s | 41.01s | 2.70s |
| User CPU | 15.59s | 3.80s | 12.32s | 2.61s |
| System CPU | 15.67s | 1.38s | 13.49s | 0.88s |
| Peak RSS | 1895.5 MiB | 482.3 MiB | 1859.0 MiB | 328.7 MiB |
| Worker preparation | 7534 inputs / 3342 outputs | none | fixed graph | none |

All original 35 cases remain, plus one ownership regression (36 passed after). The original command without additional worker/reporter flags passed in **3.35s wall**. These are same-host single-run observations under unequal load (~103–118 before and ~44–46 after on 32 CPUs), not controlled speedup estimates. The deterministic result is that these tests no longer prepare a worker generation. No memory-leak claim is made.

### Regression and real behavior

The new coordinator regression failed on pre-fix production with `Pinned skill library is unavailable`: the coordinator accessed storage instead of delegating to the command entry provider. It passes after the owner repair.

A new real-library integration case calls actual chat discovery rather than supplying precomposed entries. It verifies an old pinned revision after the library default changes, default/explicit allowlists, include-hidden behavior, config-disabled exclusion, and no pin leakage into a later unselected workspace scan. All 83 real-library/loading/remote/snapshot/embedded-entry siblings passed.

### Validation

- `node scripts/run-vitest.mjs src/skills/discovery/chat-commands.test.ts src/skills/discovery/command-specs.test.ts` — 36 passed.
- `node scripts/run-vitest.mjs src/skills/library/service.test.ts src/skills/loading/skills.test.ts src/skills/loading/workspace-skill-loader.test.ts src/skills/runtime/remote-skills.test.ts src/skills/runtime/session-snapshot.test.ts src/skills/runtime/embedded-run-entries.test.ts --maxWorkers=1` — 83 passed.
- `node scripts/check-changed.mjs -- src/skills/discovery/chat-commands.ts src/skills/discovery/command-specs.ts src/skills/loading/workspace-skill-loader.ts src/skills/discovery/chat-commands.test.ts src/skills/discovery/command-specs.test.ts src/skills/library/service.test.ts` — passed, including core/test types, lint/format, guards and zero runtime cycles.
- `pnpm build qaRuntime` — passed; zero ineffective-dynamic-import warnings. This verifies runtime JavaScript, plugin assets and import closure, not a full release/declaration build.
- The first changed-check run found the new fixture using an async environment helper for a synchronous callback; it was corrected to the existing synchronous helper and both the fixture and full changed gate passed.
- Fresh pre-commit isolated Codex review — scoped-clean, no P0 findings.
- After rebase onto `f3652df7492a4ec060f5efe0a79fcf2a4c3d9e75`, exact head `e77f410f6ada40b4926f08d92090b109ee4ab7bd` passed the same 36 command tests, 83 siblings, and `pnpm build qaRuntime` again. The command run prepared no workers; its wrapper wall time was 7.11s under that run's host conditions. Patch IDs before/after rebase match, and current main's unused reexport removal is preserved. [Exact-head CI run33697280014, attempt1](https://github.com/openclaw/openclaw/actions/runs/33697280014) and the required `openclaw/ci-gate` passed. [ClawSweeper's completed review](https://github.com/openclaw/openclaw/pull/136746#issuecomment-5518255439) found no correctness/security defects and no before-merge actions.

The timings above were collected on trusted main `81c09f48fa625531eab465648b6da87c60fc3b7f` plus this patch. The historical 180-second timeout remains incompletely attributed; this PR removes the demonstrated unnecessary startup work rather than promising a deadline under arbitrary host load.
