### PR TITLE
fix(ui): restore chat face labels

### DIFF
--- a/ui/src/e2e/session-face-switch.e2e.test.ts
+++ b/ui/src/e2e/session-face-switch.e2e.test.ts
@@ -1,0 +1,93 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import {
+  controlUiBundledSettingsStorageKey,
+  controlUiSessionUrl,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI session face switch",
+  startServerBeforeBrowser: true,
+});
+const sessionKey = "agent:main:dashboard";
+const boardSnapshot = {
+  sessionKey,
+  revision: 1,
+  tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
+  widgets: [],
+};
+
+async function showDashboard(page: Page): Promise<void> {
+  const storageKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+  await page.addInitScript(
+    ({ key, settingsKey }) => {
+      const settings = JSON.parse(localStorage.getItem(settingsKey) ?? "{}") as Record<
+        string,
+        unknown
+      >;
+      settings.boardSessionViews = {
+        ...(settings.boardSessionViews as Record<string, unknown> | undefined),
+        [key]: { activeTabId: "main" },
+      };
+      localStorage.setItem(settingsKey, JSON.stringify(settings));
+    },
+    { key: sessionKey, settingsKey: storageKey },
+  );
+}
+
+suite.define(() => {
+  it("centers session face icons beside their labels", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 760, width: 1600 } });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      sessionKey,
+      featureMethods: ["board.get", "chat.metadata", "chat.startup"],
+      methodResponses: { "board.get": boardSnapshot },
+    });
+    await showDashboard(page);
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey, "dashboard"));
+      const chatOption = page.locator('wa-radio.settings-segmented__btn[value="chat"]');
+      await chatOption.waitFor();
+
+      for (const viewport of [
+        { height: 844, width: 390 },
+        { height: 1024, width: 768 },
+        { height: 768, width: 1366 },
+        { height: 900, width: 1440 },
+      ]) {
+        await page.setViewportSize(viewport);
+        const geometry = await chatOption.evaluate((option) => {
+          const icon = option.querySelector("svg")?.getBoundingClientRect();
+          const label = option.querySelector(".chat-pane__face-label")?.getBoundingClientRect();
+          if (!icon || !label) {
+            throw new Error("Session face option did not render its icon and label");
+          }
+          return {
+            gap: label.left - icon.right,
+            verticalCenterDelta: Math.abs(
+              icon.top + icon.height / 2 - (label.top + label.height / 2),
+            ),
+          };
+        });
+        expect(geometry.gap).toBe(6);
+        expect(geometry.verticalCenterDelta).toBeLessThanOrEqual(0.5);
+      }
+      if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
+        const proofDir = path.join(suite.artifactDir, "session-face-switch");
+        await mkdir(proofDir, { recursive: true });
+        await page.setViewportSize({ height: 760, width: 1600 });
+        await page.locator(".chat-pane__face-switch").screenshot({
+          path: path.join(proofDir, "01-labels-after.png"),
+        });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/pages/chat/board-session-surface.test.ts
+++ b/ui/src/pages/chat/board-session-surface.test.ts
@@ -127,7 +127,7 @@ describe("board session shell", () => {
     ).toBe(activeMode);
   });
 
-  it("renders an icon-only control with an accessible label for every mode", () => {
+  it("renders an icon and visible label for every mode", () => {
     const container = createContainer();
     render(
       renderBoardViewSwitch({
@@ -142,11 +142,10 @@ describe("board session shell", () => {
     );
 
     const radios = [...container.querySelectorAll("wa-radio")];
-    expect(radios.map((radio) => radio.querySelector(".sr-only")?.textContent)).toEqual([
-      "Chat",
-      "Split",
-      "Dashboard",
-    ]);
+    expect(
+      radios.map((radio) => radio.querySelector(".chat-pane__face-label")?.textContent),
+    ).toEqual(["Chat", "Split", "Dashboard"]);
+    expect(radios.every((radio) => radio.querySelector(".sr-only") === null)).toBe(true);
     expect(radios.every((radio) => radio.querySelector("svg") !== null)).toBe(true);
     expect(radios.map((radio) => radio.getAttribute("title"))).toEqual([
       "Chat",

--- a/ui/src/pages/chat/board-session-surface.ts
+++ b/ui/src/pages/chat/board-session-surface.ts
@@ -68,7 +68,7 @@ function dockLabel(dock: BoardVisibleChatDock): string {
 }
 
 function modeLabel(icon: TemplateResult, label: string) {
-  return html`${icon}<span class="sr-only">${label}</span>`;
+  return html`${icon}<span class="chat-pane__face-label">${label}</span>`;
 }
 
 export function renderBoardViewSwitch(props: {

--- a/ui/src/pages/chat/board-session-surface.ts
+++ b/ui/src/pages/chat/board-session-surface.ts
@@ -68,7 +68,9 @@ function dockLabel(dock: BoardVisibleChatDock): string {
 }
 
 function modeLabel(icon: TemplateResult, label: string) {
-  return html`${icon}<span class="chat-pane__face-label">${label}</span>`;
+  return html`<span class="chat-pane__face-option">
+    ${icon}<span class="chat-pane__face-label">${label}</span>
+  </span>`;
 }
 
 export function renderBoardViewSwitch(props: {

--- a/ui/src/styles/chat/board.css
+++ b/ui/src/styles/chat/board.css
@@ -17,6 +17,7 @@
 }
 
 .chat-pane__face-switch .settings-segmented__btn {
+  gap: 5px;
   font-size: 11px;
   padding: 2px 9px;
   border-radius: var(--radius-full);

--- a/ui/src/styles/chat/board.css
+++ b/ui/src/styles/chat/board.css
@@ -17,10 +17,15 @@
 }
 
 .chat-pane__face-switch .settings-segmented__btn {
-  gap: 5px;
   font-size: 11px;
   padding: 2px 9px;
   border-radius: var(--radius-full);
+}
+
+.chat-pane__face-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .chat-pane__face-switch .settings-segmented__btn svg {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Chat, Split, and Dashboard selector showed icons without visible labels, making the modes unnecessarily ambiguous. It also corrects the icon baseline alignment and restores comfortable spacing between each icon and label.

## Why This Change Was Made

The existing mode icons remain, and their translated labels are restored as visible text. Each icon/label pair now uses an inline-flex wrapper with vertical centering and a 6px gap, matching Web Awesome's slotted-label layout contract.

## User Impact

Users can identify each session face from both its icon and label, with consistently centered iconography at mobile, tablet, and desktop widths.

## Evidence

| Before | After |
| --- | --- |
| ![Icons without visible face labels](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/1d02f0afa19277a695f4a66f4874e733b1a5c0a5/01-labels-before.png) | ![Centered icons with Chat, Split, and Dashboard labels](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/3c4a9802d097ac022367dbb500e03a68e9a244f8/01-labels-after.png) |

Playwright capture from the mocked Control UI at 1600x760.

Validation:

- `board-session-surface.test.ts`: 22 passed
- `session-face-switch.e2e.test.ts`: passed at 390x844, 768x1024, 1366x768, and 1440x900
- `pnpm check:changed`: passed
- Fresh autoreview: clean, 0.99 confidence
- Production LOC: +9 / -1; tests: +98 / -6

Production growth is the visible-label wrapper and its alignment rule; the real-browser geometry test is isolated in a dedicated E2E file.
