### PR TITLE
fix(ui): use a Lucide draft visibility icon

### DIFF
--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -100,6 +100,9 @@ describe("chat session sharing menu", () => {
     const items = [...root.querySelectorAll<HTMLElement>(".chat-pane__sharing-visibility-item")];
     expect(items).toHaveLength(4);
     expect(items.every((item) => item.querySelector('[slot="icon"]') !== null)).toBe(true);
+    const draftIcon = root.querySelector('[value="visibility:draft"] [slot="icon"]');
+    expect(draftIcon?.querySelector("svg")).not.toBeNull();
+    expect(draftIcon?.textContent?.trim()).toBe("");
     expect(items.map((item) => item.getAttribute("role"))).toEqual(
       items.map(() => "menuitemradio"),
     );
@@ -214,7 +217,9 @@ describe("chat session sharing menu", () => {
       }),
     );
     expect(root.querySelector("wa-dropdown")).toBeNull();
-    expect(root.querySelector(".chat-pane__draft-indicator")?.textContent).toContain("👻");
+    const indicator = root.querySelector(".chat-pane__draft-indicator");
+    expect(indicator?.querySelector("svg")).not.toBeNull();
+    expect(indicator?.textContent?.trim()).toBe("");
   });
 
   it("publishes a manageable draft through the shared visibility callback", () => {

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -39,7 +39,7 @@ const VISIBILITY_LABEL_KEYS: Record<SessionVisibility, string> = {
 
 function sharingIcon(visibility: SessionVisibility): TemplateResult {
   if (visibility === "draft") {
-    return html`<span aria-hidden="true">👻</span>`;
+    return icons.pencil;
   }
   return visibility === "shared" ? icons.users : icons.lock;
 }
@@ -104,7 +104,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
   if (!canManage) {
     return visibility === "draft"
       ? html`<span class="chat-pane__draft-indicator" title=${t("chat.sessionSharing.draft")}
-          >👻</span
+          >${sharingIcon("draft")}</span
         >`
       : nothing;
   }

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -830,6 +830,11 @@ openclaw-chat-pane {
   font-size: 13px;
 }
 
+.chat-pane__draft-indicator svg {
+  width: 15px;
+  height: 15px;
+}
+
 .chat-pane__header-center .chat-pane__draft-indicator {
   width: 28px;
   height: 28px;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Draft used a ghost emoji while the other visibility choices used the product's standard icon library.

## Why This Change Was Made

Draft now uses the existing Lucide-style pencil icon in both the visibility menu and the read-only draft indicator.

## User Impact

All visibility choices use consistent, theme-compatible icons.

## Evidence

| Before | After |
| --- | --- |
| ![Draft shown with a ghost emoji](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/1d02f0afa19277a695f4a66f4874e733b1a5c0a5/02-draft-before.png) | ![Draft shown with the standard pencil icon](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/1d02f0afa19277a695f4a66f4874e733b1a5c0a5/02-draft-after.png) |

Playwright capture from the mocked Control UI at 1600×760.

Validation:

- `chat-session-sharing.test.ts`: 11 passed
- Full focused UI/browser set at stack head: 204 passed
- Production LOC: +7 / -2; tests: +6 / -1

