### PR TITLE
fix(ui): move board fullscreen into header actions

### DIFF
--- a/ui/src/pages/chat/board-session-surface.ts
+++ b/ui/src/pages/chat/board-session-surface.ts
@@ -78,7 +78,6 @@ export function renderBoardViewSwitch(props: {
   face: BoardFace;
   dock: BoardTab["chatDock"];
   canChangeDock: boolean;
-  fullscreenControl?: TemplateResult;
   onSelectMode: (mode: BoardViewMode) => void;
   onDockSideChange: (dock: BoardVisibleChatDock) => void;
 }) {
@@ -169,7 +168,6 @@ export function renderBoardViewSwitch(props: {
             </wa-dropdown>
           `
         : nothing}
-      ${mode === "chat" ? nothing : props.fullscreenControl}
     </div>
   `;
 }

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -464,6 +464,8 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       renameDisabledReason,
       actionsDisabled: this.state?.connected !== true,
       panelActions: html`${browserPanelAction}${backgroundTasksAction}${sidePanelAction}`,
+      fullscreenAction:
+        board.hasBoard && board.face !== "chat" ? this.boardFullscreen.renderButton() : nothing,
       discussionAction: nothing,
       diffAction: nothing,
       backgroundTasksAction: nothing,
@@ -483,7 +485,6 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
         face: board.face,
         dock: board.dock,
         canChangeDock: canChangeBoardDock,
-        fullscreenControl: board.hasBoard ? this.boardFullscreen.renderButton() : undefined,
         onSelectMode: (mode) => {
           if (mode === "chat") {
             void this.boardFullscreen.exit();

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -259,11 +259,13 @@ describe("chat pane header", () => {
   it("places the session menu last in the header action row", () => {
     const { container } = mountHeader({
       mergedChrome: true,
+      fullscreenAction: html`<button data-action="fullscreen"></button>`,
       onClosePane: vi.fn(),
       sessionMenuAction: html`<button data-action="session-menu"></button>`,
     });
     const actions = container.querySelector(".chat-pane__actions");
 
+    expect(container.querySelector('[data-action="fullscreen"]')?.parentElement).toBe(actions);
     expect(actions?.lastElementChild?.getAttribute("data-action")).toBe("session-menu");
     expect(actions?.querySelector(".chat-pane__palette-open")).not.toBeNull();
     expect(actions?.querySelector(".chat-pane__close-pane")).not.toBeNull();

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -68,6 +68,7 @@ type ChatPaneHeaderProps = {
   renameDisabledReason?: string;
   actionsDisabled?: boolean;
   panelActions: TemplateResult | typeof nothing;
+  fullscreenAction?: TemplateResult | typeof nothing;
   discussionAction: TemplateResult | typeof nothing;
   diffAction: TemplateResult | typeof nothing;
   backgroundTasksAction: TemplateResult | typeof nothing;
@@ -525,6 +526,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
         ${renderGatewayPicker(props)}
         <fieldset class="chat-pane__actions" ?disabled=${props.actionsDisabled}>
           ${compactSessionActions ? nothing : props.panelActions}
+          ${props.fullscreenAction ?? nothing}
           ${compactSessionActions ? nothing : props.discussionAction}
           ${props.catalog || compactSessionActions
             ? nothing

--- a/ui/src/styles/chat/board.css
+++ b/ui/src/styles/chat/board.css
@@ -41,8 +41,7 @@
   display: inline-flex;
 }
 
-.chat-pane__dock-caret-trigger,
-.board-fullscreen-button {
+.chat-pane__dock-caret-trigger {
   width: 24px;
   min-width: 24px;
   height: 24px;
@@ -60,15 +59,6 @@
   stroke-width: 1.6px;
   stroke-linecap: round;
   stroke-linejoin: round;
-}
-
-.board-fullscreen-button__icon {
-  display: inline-flex;
-}
-
-.board-fullscreen-button svg {
-  width: 14px;
-  height: 14px;
 }
 
 .chat-pane-primary-column:fullscreen {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the dashboard fullscreen action appeared inside the centered Chat/Split/Dashboard selector instead of with the other header actions.

## Why This Change Was Made

Fullscreen is supplied to the shared header action row and remains available only for Split and Dashboard faces. The selector now contains session-face controls only.

## User Impact

Fullscreen appears in the top-right action cluster beside the other session tools.

## Evidence

| Before | After |
| --- | --- |
| ![Fullscreen attached to the face selector](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/1d02f0afa19277a695f4a66f4874e733b1a5c0a5/03-fullscreen-before.png) | ![Fullscreen in the top-right header actions](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/1d02f0afa19277a695f4a66f4874e733b1a5c0a5/03-fullscreen-after.png) |

Playwright capture from the mocked Control UI at 1600×760.

Validation:

- `dashboard-fullscreen.e2e.test.ts`: 9 passed, including enter/exit behavior
- Full focused UI/browser set at stack head: 204 passed
- Production LOC: +5 / -14; tests: +2 / -0

