### PR TITLE
fix(ui): move sharing into owner slot

### DIFF
--- a/ui/src/e2e/identity-activity-links.e2e.test.ts
+++ b/ui/src/e2e/identity-activity-links.e2e.test.ts
@@ -394,4 +394,68 @@ suite.define(() => {
       },
     );
   });
+
+  it("keeps owner Activity access beside a non-manager draft indicator", async () => {
+    const sessionKey = "agent:main:draft-shared-with-me";
+
+    await suite.withPage(
+      {
+        hasTouch: false,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "session.visibility.set"],
+          historyMessages: [{ role: "assistant", content: [{ type: "text", text: "Ready." }] }],
+          methodResponses: {
+            "sessions.list": chatSessionListResponse([
+              {
+                key: sessionKey,
+                kind: "direct",
+                label: "Draft shared with me",
+                owner: {
+                  actor: {
+                    type: "human",
+                    id: "profile-ada",
+                    identity: { type: "profile", id: "profile-ada" },
+                    label: "Ada King",
+                  },
+                },
+                participantCount: 1,
+                participants: [{ identity: { type: "profile", id: "profile-self" }, label: "You" }],
+                sharingRole: "member",
+                updatedAt: Date.now(),
+                visibility: "draft",
+              },
+            ]),
+          },
+          presenceUsers: [
+            {
+              self: true,
+              id: "profile-self",
+              identity: { type: "profile", id: "profile-self" },
+              name: "You",
+            },
+          ],
+          sessionKey,
+        });
+
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+        await page.getByText("Ready.", { exact: true }).waitFor();
+        await page.locator(".chat-pane__draft-indicator").waitFor({ state: "visible" });
+        const ownerLink = page.locator(
+          ".chat-pane__header a.person-activity-avatar-link:has(openclaw-session-owner-chip)",
+        );
+        await ownerLink.waitFor({ state: "visible" });
+        expect(await ownerLink.getAttribute("href")).toBe("/activity?person=profile-ada");
+
+        await ownerLink.click();
+        await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
+        expect(new URL(page.url()).searchParams.get("person")).toBe("profile-ada");
+        await captureProof(page, "chat-draft-viewer-owner-activity.png");
+      },
+    );
+  });
 });

--- a/ui/src/e2e/identity-activity-links.e2e.test.ts
+++ b/ui/src/e2e/identity-activity-links.e2e.test.ts
@@ -345,6 +345,9 @@ suite.define(() => {
         const ownerLink = page.locator(".chat-pane__sharing-owner a.person-activity-link");
         await ownerLink.waitFor({ state: "visible" });
         expect(await ownerLink.getAttribute("href")).toBe("/activity?person=profile-ada");
+        await page
+          .locator(".chat-pane__sharing-owner .session-owner-chip--away")
+          .waitFor({ state: "visible" });
         const participantLink = page.locator(
           ".chat-pane__participants a.person-activity-avatar-link",
         );
@@ -450,6 +453,7 @@ suite.define(() => {
         );
         await ownerLink.waitFor({ state: "visible" });
         expect(await ownerLink.getAttribute("href")).toBe("/activity?person=profile-ada");
+        await ownerLink.locator(".session-owner-chip--away").waitFor({ state: "visible" });
 
         await ownerLink.click();
         await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });

--- a/ui/src/e2e/identity-activity-links.e2e.test.ts
+++ b/ui/src/e2e/identity-activity-links.e2e.test.ts
@@ -241,6 +241,8 @@ suite.define(() => {
               },
               participants: [{ identity: { type: "profile", id: "profile-mira" }, label: "Mira" }],
               participantCount: 1,
+              sharingRole: "owner",
+              visibility: "shared",
               updatedAt: now - 60_000,
             },
           ]),
@@ -257,7 +259,13 @@ suite.define(() => {
         };
         const associatedSessions = sessionList.sessions;
         await installMockGateway(page, {
-          featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "progressCard.get",
+            "session.members.listEvidence",
+            "session.visibility.set",
+          ],
           hasMultipleSessionSharingIdentities: true,
           presenceUsers: [
             {
@@ -299,6 +307,19 @@ suite.define(() => {
           ],
           methodResponses: {
             "progressCard.get": { card: null },
+            "session.members.listEvidence": {
+              sessionKey,
+              owner: {
+                type: "human",
+                id: "profile-ada",
+                identity: { type: "profile", id: "profile-ada" },
+                label: "Ada King",
+              },
+              members: [],
+              identities: [],
+              role: "owner",
+              allowedVisibilities: ["shared"],
+            },
             "sessions.list": {
               cases: [
                 ...["profile-ada", "profile-mira"].map((involvingProfileId) => ({
@@ -320,9 +341,8 @@ suite.define(() => {
 
         await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
 
-        const ownerLink = page.locator(
-          ".chat-pane__header a.person-activity-avatar-link:has(openclaw-session-owner-chip)",
-        );
+        await page.getByRole("button", { name: "Session sharing" }).click();
+        const ownerLink = page.locator(".chat-pane__sharing-owner a.person-activity-link");
         await ownerLink.waitFor({ state: "visible" });
         expect(await ownerLink.getAttribute("href")).toBe("/activity?person=profile-ada");
         const participantLink = page.locator(
@@ -343,6 +363,12 @@ suite.define(() => {
         expect(await legacyGroup.locator('a[href*="/activity?person="]').count()).toBe(0);
         await captureProof(page, "chat-identity-links.png");
 
+        await ownerLink.click();
+        await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
+        expect(new URL(page.url()).searchParams.get("person")).toBe("profile-ada");
+        await captureProof(page, "chat-owner-activity.png");
+
+        await page.goBack();
         await participantLink.click();
         await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
         expect(new URL(page.url()).searchParams.get("person")).toBe("profile-mira");

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -705,8 +705,7 @@ suite.define(() => {
     await currentPage.getByRole("button", { name: "Session sharing" }).click();
     const dropdown = currentPage.locator(".chat-pane__sharing-menu");
     await expect.poll(() => dropdown.getAttribute("open")).not.toBeNull();
-    expect(await dropdown.locator(".chat-pane__sharing-visibility-title").count()).toBe(1);
-    expect(await dropdown.locator(".chat-pane__sharing-owner-title").count()).toBe(1);
+    expect(await dropdown.locator(".chat-pane__sharing-title").count()).toBe(2);
     await currentPage.getByText("Publish draft", { exact: true }).click();
     await gateway.waitForRequest("session.visibility.set");
     await expect.poll(() => dropdown.getAttribute("open")).toBeNull();

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -705,7 +705,8 @@ suite.define(() => {
     await currentPage.getByRole("button", { name: "Session sharing" }).click();
     const dropdown = currentPage.locator(".chat-pane__sharing-menu");
     await expect.poll(() => dropdown.getAttribute("open")).not.toBeNull();
-    expect(await dropdown.locator(".chat-pane__sharing-title").count()).toBe(1);
+    expect(await dropdown.locator(".chat-pane__sharing-visibility-title").count()).toBe(1);
+    expect(await dropdown.locator(".chat-pane__sharing-owner-title").count()).toBe(1);
     await currentPage.getByText("Publish draft", { exact: true }).click();
     await gateway.waitForRequest("session.visibility.set");
     await expect.poll(() => dropdown.getAttribute("open")).toBeNull();

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5256,6 +5256,7 @@ export const en: TranslationMap & {
       suggest: "Suggest",
       draft: "Draft",
       publishDraft: "Publish draft",
+      owner: "Owner",
       members: "Members",
       selected: "Member",
       noPeople: "No paired people found.",

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -518,7 +518,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       }),
       sharingControl:
         sharing &&
-        !sharing.openDisabledReason &&
+        (!canManageChatSessionSharing(sharing.session) || !sharing.openDisabledReason) &&
         (!this.narrow || !canManageChatSessionSharing(sharing.session))
           ? renderChatSessionSharing(sharing)
           : nothing,

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -517,7 +517,9 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
         onDockSideChange: (dock) => this.handleBoardDockChange(dock),
       }),
       sharingControl:
-        sharing && (!this.narrow || !canManageChatSessionSharing(sharing.session))
+        sharing &&
+        !sharing.openDisabledReason &&
+        (!this.narrow || !canManageChatSessionSharing(sharing.session))
           ? renderChatSessionSharing(sharing)
           : nothing,
       placementControl: renderChatPanePlacement({

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -192,6 +192,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       sharingReadAccess.allowed || sharingVisibilityAccess.allowed
         ? undefined
         : sharingReadAccess.reason;
+    const personActivity = this.personActivityRouting();
     const sharing =
       sharingMethodsSupported && row
         ? {
@@ -209,6 +210,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
             memberRemoveDisabledReason: sharingMemberRemoveAccess.allowed
               ? undefined
               : sharingMemberRemoveAccess.reason,
+            personActivity,
             onOpen: () => void this.loadSessionSharing(row),
             onVisibilityChange: (visibility: SessionVisibility) =>
               void this.setSessionVisibility(row, visibility),
@@ -409,7 +411,6 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       this.context.sessions?.state?.result?.sessions ?? [],
     );
     const showOwnerChip = (result?.owners?.length ?? 0) >= 2 || (row?.participantCount ?? 0) > 0;
-    const personActivity = this.personActivityRouting();
     const renderedOwnerIdentity = showOwnerChip ? row?.owner?.actor.identity : undefined;
     const viewers = catalog
       ? undefined

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -167,6 +167,8 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
           : branchSwitchWorking
             ? t("chat.sessionHeader.branchSwitchUnavailable")
             : null;
+    const result = this.state?.sessionsResult;
+    const showOwnerChip = (result?.owners?.length ?? 0) >= 2 || (row?.participantCount ?? 0) > 0;
     const sharingSnapshot = this.context.gateway.snapshot;
     // Sharing was introduced behind this advertised method. Keep the control
     // hidden for older Gateways that omit method metadata.
@@ -211,6 +213,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
               ? undefined
               : sharingMemberRemoveAccess.reason,
             personActivity,
+            showOwner: showOwnerChip,
             onOpen: () => void this.loadSessionSharing(row),
             onVisibilityChange: (visibility: SessionVisibility) =>
               void this.setSessionVisibility(row, visibility),
@@ -405,12 +408,10 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       row,
     });
     const key = this.state?.sessionKey ?? "";
-    const result = this.state?.sessionsResult;
     const knownGroups = collectKnownSessionGroups(
       this.context.sessions?.state?.groups ?? [],
       this.context.sessions?.state?.result?.sessions ?? [],
     );
-    const showOwnerChip = (result?.owners?.length ?? 0) >= 2 || (row?.participantCount ?? 0) > 0;
     const renderedOwnerIdentity = showOwnerChip ? row?.owner?.actor.identity : undefined;
     const viewers = catalog
       ? undefined

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -169,6 +169,12 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
             : null;
     const result = this.state?.sessionsResult;
     const showOwnerChip = (result?.owners?.length ?? 0) >= 2 || (row?.participantCount ?? 0) > 0;
+    const key = this.state?.sessionKey ?? "";
+    const renderedOwnerIdentity = showOwnerChip ? row?.owner?.actor.identity : undefined;
+    const ownerViewing = projectPresencePayload(this.presencePayload).users.some(
+      (user) =>
+        presenceMatchesProfile(user, renderedOwnerIdentity) && user.watchedSessions.includes(key),
+    );
     const sharingSnapshot = this.context.gateway.snapshot;
     // Sharing was introduced behind this advertised method. Keep the control
     // hidden for older Gateways that omit method metadata.
@@ -212,6 +218,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
             memberRemoveDisabledReason: sharingMemberRemoveAccess.allowed
               ? undefined
               : sharingMemberRemoveAccess.reason,
+            ownerViewing,
             personActivity,
             showOwner: showOwnerChip,
             onOpen: () => void this.loadSessionSharing(row),
@@ -407,12 +414,10 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       restartingKey: this.headerPlacementRestartingKey,
       row,
     });
-    const key = this.state?.sessionKey ?? "";
     const knownGroups = collectKnownSessionGroups(
       this.context.sessions?.state?.groups ?? [],
       this.context.sessions?.state?.result?.sessions ?? [],
     );
-    const renderedOwnerIdentity = showOwnerChip ? row?.owner?.actor.identity : undefined;
     const viewers = catalog
       ? undefined
       : projectPresenceViewers(
@@ -425,10 +430,6 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
             ...(showOwnerChip ? (row?.participants ?? []).map(({ identity }) => identity) : []),
           ],
         );
-    const ownerViewing = projectPresencePayload(this.presencePayload).users.some(
-      (user) =>
-        presenceMatchesProfile(user, renderedOwnerIdentity) && user.watchedSessions.includes(key),
-    );
     const ownerOptions = listAssignableSessionOwners({
       facet: result?.owners,
       agents: this.context.agents.state.agentsList?.agents,

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1252,6 +1252,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                   <span class="chat-pane__session-title-text">A deliberately long session title that must yield to the centered face switch</span>
                 </span>
               </div>
+              <wa-dropdown class="chat-pane__sharing-menu">
+                <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__sharing-trigger" type="button">S</button>
+              </wa-dropdown>
             </div>
             <div class="chat-pane__header-center">
               <div class="chat-pane__face-switch">
@@ -1261,9 +1264,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                   <button class="settings-segmented__btn" type="button">Dashboard</button>
                 </div>
               </div>
-              <wa-dropdown class="chat-pane__sharing-menu">
-                <button class="btn btn--ghost btn--icon chat-icon-btn chat-pane__sharing-trigger" type="button">S</button>
-              </wa-dropdown>
             </div>
             <div class="chat-pane__header-trailing">
               <div class="chat-pane__actions">
@@ -1303,7 +1303,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
-  it("keeps a non-manager draft indicator out of the face switch width", async () => {
+  it("keeps a non-manager draft indicator in the owner slot", async () => {
     const page = await openBrowserPage(800, 180);
     try {
       const splitViewCss = readStyleSheet("ui/src/styles/chat/split-view.css");
@@ -1312,7 +1312,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       await page.setContent(
         `<!doctype html><html><head><style>${readUiCss()}\n${settingsControlsCss}\n${splitViewCss}\n${boardCss}</style></head><body>
           <div class="chat-pane__header chat-pane__header--centered" style="width: 720px;">
-            <div class="chat-pane__header-leading"></div>
+            <div class="chat-pane__header-leading">
+              <span class="chat-pane__draft-indicator" title="Draft">${iconSvg()}</span>
+            </div>
             <div class="chat-pane__header-center">
               <div class="chat-pane__face-switch">
                 <div class="settings-segmented">
@@ -1321,7 +1323,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                   <button class="settings-segmented__btn" type="button">Dashboard</button>
                 </div>
               </div>
-              <span class="chat-pane__draft-indicator" title="Draft">👻</span>
             </div>
             <div class="chat-pane__header-trailing"></div>
           </div>
@@ -1349,7 +1350,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         };
       });
 
-      expect(geometry.draftPosition).toBe("absolute");
+      expect(geometry.draftPosition).toBe("static");
       expect(Math.abs(geometry.faceCenter - geometry.contentCenter)).toBeLessThanOrEqual(0.5);
     } finally {
       await closeBrowserPage(page);

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -407,7 +407,7 @@ describe("chat pane header", () => {
     expect(crumbs?.nextElementSibling?.getAttribute("data-slot")).toBe("placement");
   });
 
-  it("groups visibility with the face switch inside the centered header region", () => {
+  it("places visibility in the owner slot while the face switch stays centered", () => {
     const { container } = mountHeader({
       placementControl: html`<span data-slot="placement"></span>`,
       presence: html`<span data-slot="presence"></span>`,
@@ -422,20 +422,39 @@ describe("chat pane header", () => {
       "chat-pane__header-center",
     );
     expect(container.querySelector('[data-slot="sharing"]')?.parentElement?.className).toBe(
-      "chat-pane__header-center",
+      "chat-pane__header-leading",
     );
   });
 
-  it("keeps visibility with trailing actions when the session has no face switch", () => {
+  it("keeps visibility in the owner slot when the session has no face switch", () => {
     const { container } = mountHeader({
       faceControl: nothing,
       sharingControl: html`<span data-slot="sharing"></span>`,
     });
 
     expect(container.querySelector('[data-slot="sharing"]')?.parentElement?.className).toBe(
-      "chat-pane__header-trailing",
+      "chat-pane__header-leading",
     );
     expect(container.querySelector(".chat-pane__header--centered")).toBeNull();
+  });
+
+  it("replaces the header owner avatar when visibility is available", () => {
+    const actor = {
+      type: "human" as const,
+      id: "profile-ada",
+      identity: { type: "profile" as const, id: "profile-ada" },
+      label: "Ada",
+    };
+    const { container } = mountHeader({
+      session: row({ owner: { actor } }),
+      showOwnerChip: true,
+      sharingControl: html`<span data-slot="sharing"></span>`,
+    });
+
+    expect(container.querySelector("openclaw-session-owner-chip")).toBeNull();
+    expect(container.querySelector('[data-slot="sharing"]')?.parentElement?.className).toBe(
+      "chat-pane__header-leading",
+    );
   });
 
   it("uses the full header width when no face switch needs centering", () => {

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -692,6 +692,35 @@ describe("chat pane header", () => {
     }
   });
 
+  it("keeps the linked owner visible when session sharing cannot open", async () => {
+    const owners = [
+      { type: "human" as const, id: "profile-ada", label: "Ada" },
+      { type: "human" as const, id: "profile-zoe", label: "Zoe" },
+    ];
+    const mounted = mountIntegratedPresenceHeader({ owners, presence: [] });
+    const snapshot = mounted.pane.context.gateway.snapshot;
+    snapshot.hello = {
+      ...snapshot.hello,
+      auth: { role: "operator", scopes: [] },
+      features: {
+        ...snapshot.hello?.features,
+        methods: ["session.visibility.set"],
+      },
+    } as typeof snapshot.hello;
+
+    mounted.renderHeader();
+    const ownerLink = mounted.container.querySelector<HTMLAnchorElement>(
+      "a.person-activity-avatar-link:has(openclaw-session-owner-chip)",
+    );
+    const ownerChip = ownerLink?.querySelector<HTMLElement & { updateComplete?: Promise<unknown> }>(
+      "openclaw-session-owner-chip",
+    );
+    await ownerChip?.updateComplete;
+
+    expect(mounted.container.querySelector(".chat-pane__sharing-trigger")).toBeNull();
+    expect(ownerLink?.getAttribute("href")).toBe("/activity?person=profile-ada");
+  });
+
   it("renders the durable session actor avatar with the header attribution semantics", async () => {
     const mounted = mountHeader({
       showOwnerChip: true,

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -387,6 +387,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
   const drawerLabel = props.navDrawerOpen ? t("nav.collapse") : t("nav.expand");
   const compactSessionActions = props.narrow && props.sessionMenuAction !== nothing;
   const hasFaceControl = props.faceControl !== undefined && props.faceControl !== nothing;
+  const hasSharingControl = props.sharingControl !== undefined && props.sharingControl !== nothing;
 
   return html`
     <div
@@ -423,22 +424,24 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
             >`
           : nothing}
         ${renderIdentityCrumbs(props, copied, copyPathLabel, copyBranchLabel)}
-        ${renderStandalonePersonLink(
-          renderSessionOwnerChip(
-            props.showOwnerChip ? props.session?.owner?.actor : undefined,
-            "header",
-            props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
-            props.ownerViewing,
-          ),
-          props.showOwnerChip
-            ? personActivityLink(
-                props.session?.owner?.actor.identity?.type === "profile"
-                  ? props.session.owner.actor.identity.id
-                  : undefined,
-                props.personActivity,
-              )
-            : null,
-        )}
+        ${hasSharingControl
+          ? props.sharingControl
+          : renderStandalonePersonLink(
+              renderSessionOwnerChip(
+                props.showOwnerChip ? props.session?.owner?.actor : undefined,
+                "header",
+                props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
+                props.ownerViewing,
+              ),
+              props.showOwnerChip
+                ? personActivityLink(
+                    props.session?.owner?.actor.identity?.type === "profile"
+                      ? props.session.owner.actor.identity.id
+                      : undefined,
+                    props.personActivity,
+                  )
+                : null,
+            )}
         ${props.showOwnerChip && props.session?.participants?.length
           ? html`<openclaw-viewer-facepile
               class="chat-pane__participants"
@@ -452,12 +455,9 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
         ${props.placementControl ?? nothing} ${props.presence ?? nothing}
       </div>
       ${hasFaceControl
-        ? html`<div class="chat-pane__header-center">
-            ${props.faceControl} ${props.sharingControl ?? nothing}
-          </div>`
+        ? html`<div class="chat-pane__header-center">${props.faceControl}</div>`
         : nothing}
       <div class="chat-pane__header-trailing">
-        ${hasFaceControl ? nothing : (props.sharingControl ?? nothing)}
         ${!props.catalog && props.branches.length > 1
           ? html`
               <wa-dropdown

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -49,6 +49,7 @@ describe("chat session sharing menu", () => {
             allowedVisibilities: ["shared", "read-only"],
           },
         },
+        ownerViewing: false,
         personActivity: { basePath: "", navigate },
         onOpen: vi.fn(),
         onVisibilityChange,
@@ -69,6 +70,11 @@ describe("chat session sharing menu", () => {
     expect(
       root.querySelector(".chat-pane__sharing-owner openclaw-session-owner-chip"),
     ).not.toBeNull();
+    expect(
+      root.querySelector<HTMLElement & { viewingNow?: boolean }>(
+        ".chat-pane__sharing-owner openclaw-session-owner-chip",
+      )?.viewingNow,
+    ).toBe(false);
     const ownerLink = root.querySelector<HTMLAnchorElement>(
       ".chat-pane__sharing-owner a.person-activity-link",
     );
@@ -240,6 +246,7 @@ describe("chat session sharing menu", () => {
           },
         },
         state: undefined,
+        ownerViewing: false,
         personActivity: { basePath: "", navigate: vi.fn() },
         showOwner: true,
         onOpen: vi.fn(),
@@ -256,6 +263,11 @@ describe("chat session sharing menu", () => {
         .querySelector("a.person-activity-avatar-link:has(openclaw-session-owner-chip)")
         ?.getAttribute("href"),
     ).toBe("/activity?person=owner");
+    expect(
+      root.querySelector<HTMLElement & { viewingNow?: boolean }>(
+        "a.person-activity-avatar-link openclaw-session-owner-chip",
+      )?.viewingNow,
+    ).toBe(false);
   });
 
   it("publishes a manageable draft through the shared visibility callback", () => {

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -20,6 +20,7 @@ describe("chat session sharing menu", () => {
   it("shows the owner picker with policy-gated modes and known identities", () => {
     const onVisibilityChange = vi.fn();
     const onMemberChange = vi.fn();
+    const navigate = vi.fn();
     const root = mount(
       renderChatSessionSharing({
         session: {
@@ -33,7 +34,12 @@ describe("chat session sharing menu", () => {
           loading: false,
           result: {
             sessionKey: "agent:main:main",
-            owner: { type: "human", id: "owner", label: "Owner" },
+            owner: {
+              type: "human",
+              id: "owner",
+              identity: { type: "profile", id: "owner" },
+              label: "Owner",
+            },
             members: [],
             identities: [
               { type: "human", id: "owner", label: "Owner" },
@@ -43,6 +49,7 @@ describe("chat session sharing menu", () => {
             allowedVisibilities: ["shared", "read-only"],
           },
         },
+        personActivity: { basePath: "", navigate },
         onOpen: vi.fn(),
         onVisibilityChange,
         onMemberChange,
@@ -62,7 +69,14 @@ describe("chat session sharing menu", () => {
     expect(
       root.querySelector(".chat-pane__sharing-owner openclaw-session-owner-chip"),
     ).not.toBeNull();
+    const ownerLink = root.querySelector<HTMLAnchorElement>(
+      ".chat-pane__sharing-owner a.person-activity-link",
+    );
+    expect(ownerLink?.getAttribute("href")).toBe("/activity?person=owner");
     expect(root.querySelector(".session-menu__separator")).toBeNull();
+
+    ownerLink?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(navigate).toHaveBeenCalledWith("owner");
 
     dropdown?.dispatchEvent(
       new CustomEvent("wa-select", {

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -55,6 +55,13 @@ describe("chat session sharing menu", () => {
     expect(root.textContent).not.toContain("Suggest");
     expect(root.textContent).toContain("Alice");
     expect(root.querySelector('wa-dropdown-item[value="member:owner"]')).toBeNull();
+    expect(root.querySelector(".chat-pane__sharing-owner-title")?.textContent?.trim()).toBe(
+      "Owner",
+    );
+    expect(root.querySelector(".chat-pane__sharing-owner")?.textContent?.trim()).toBe("Owner");
+    expect(
+      root.querySelector(".chat-pane__sharing-owner openclaw-session-owner-chip"),
+    ).not.toBeNull();
     expect(root.querySelector(".session-menu__separator")).toBeNull();
 
     dropdown?.dispatchEvent(

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -221,7 +221,7 @@ describe("chat session sharing menu", () => {
     expect(root.querySelectorAll(".chat-pane__sharing-member-skeleton .skeleton")).toHaveLength(6);
   });
 
-  it("shows only the draft marker to a non-manager", () => {
+  it("keeps the linked owner beside the draft marker for a non-manager", () => {
     const root = mount(
       renderChatSessionSharing({
         session: {
@@ -230,8 +230,18 @@ describe("chat session sharing menu", () => {
           updatedAt: 1,
           visibility: "draft",
           sharingRole: "member",
+          owner: {
+            actor: {
+              type: "human",
+              id: "owner",
+              identity: { type: "profile", id: "owner" },
+              label: "Owner",
+            },
+          },
         },
         state: undefined,
+        personActivity: { basePath: "", navigate: vi.fn() },
+        showOwner: true,
         onOpen: vi.fn(),
         onVisibilityChange: vi.fn(),
         onMemberChange: vi.fn(),
@@ -241,6 +251,11 @@ describe("chat session sharing menu", () => {
     const indicator = root.querySelector(".chat-pane__draft-indicator");
     expect(indicator?.querySelector("svg")).not.toBeNull();
     expect(indicator?.textContent?.trim()).toBe("");
+    expect(
+      root
+        .querySelector("a.person-activity-avatar-link:has(openclaw-session-owner-chip)")
+        ?.getAttribute("href"),
+    ).toBe("/activity?person=owner");
   });
 
   it("publishes a manageable draft through the shared visibility callback", () => {

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -6,6 +6,12 @@ import type {
   SessionVisibility,
 } from "../../../api/types.ts";
 import { icons } from "../../../components/icons.ts";
+import {
+  personActivityLink,
+  renderPersonAvatarLink,
+  renderPersonName,
+  type PersonActivityRouting,
+} from "../../../components/person-activity-link.ts";
 import { renderSessionOwnerChip } from "../../../components/session-owner-chip.ts";
 import { syncDropdownItemRadio } from "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
@@ -25,6 +31,7 @@ export type ChatSessionSharingProps = {
   visibilityDisabledReason?: string;
   memberAddDisabledReason?: string;
   memberRemoveDisabledReason?: string;
+  personActivity?: PersonActivityRouting;
   onOpen: () => void;
   onVisibilityChange: (visibility: SessionVisibility) => void;
   onMemberChange: (identityId: string, member: boolean) => void;
@@ -110,8 +117,12 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
   }
   const result = props.state?.result;
   const owner = result?.owner ?? session.owner?.actor;
+  const ownerActivity = personActivityLink(
+    owner?.identity?.type === "profile" ? owner.identity.id : undefined,
+    props.personActivity,
+  );
   const members = new Set(result?.members.map((member) => member.identityId) ?? []);
-  // The shared header owner chip presents effective ownership; this picker manages mutable members.
+  // The owner row presents effective ownership; selectable rows below manage mutable members.
   const identities =
     result?.identities.filter((identity) => identity.id !== result.owner?.id) ?? [];
   const allowed = result?.allowedVisibilities ?? props.allowedVisibilities ?? [visibility];
@@ -169,10 +180,17 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
           <div class="chat-pane__sharing-owner">
             <span class="chat-pane__sharing-member-icon" aria-hidden="true">
               ${owner.type === "human"
-                ? renderSessionOwnerChip(owner, "header", "owned")
+                ? renderPersonAvatarLink(
+                    renderSessionOwnerChip(owner, "header", "owned"),
+                    ownerActivity,
+                  )
                 : icons.bot}
             </span>
-            <span class="session-menu__text">${owner.label ?? owner.id}</span>
+            ${renderPersonName(
+              owner.label ?? owner.id ?? t("chat.sessionSharing.owner"),
+              ownerActivity,
+              "session-menu__text",
+            )}
           </div>
         `
       : nothing}

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -32,6 +32,7 @@ export type ChatSessionSharingProps = {
   visibilityDisabledReason?: string;
   memberAddDisabledReason?: string;
   memberRemoveDisabledReason?: string;
+  ownerViewing?: boolean;
   personActivity?: PersonActivityRouting;
   showOwner?: boolean;
   onOpen: () => void;
@@ -120,7 +121,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
     return visibility === "draft"
       ? html`${props.showOwner && owner
             ? renderStandalonePersonLink(
-                renderSessionOwnerChip(owner, "header", "owned"),
+                renderSessionOwnerChip(owner, "header", "owned", props.ownerViewing),
                 ownerActivity,
               )
             : nothing}<span
@@ -190,7 +191,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
             <span class="chat-pane__sharing-member-icon" aria-hidden="true">
               ${owner.type === "human"
                 ? renderPersonAvatarLink(
-                    renderSessionOwnerChip(owner, "header", "owned"),
+                    renderSessionOwnerChip(owner, "header", "owned", props.ownerViewing),
                     ownerActivity,
                   )
                 : icons.bot}

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -172,7 +172,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
                 ? renderSessionOwnerChip(owner, "header", "owned")
                 : icons.bot}
             </span>
-            <span class="chat-pane__sharing-member-label">${owner.label ?? owner.id}</span>
+            <span class="session-menu__text">${owner.label ?? owner.id}</span>
           </div>
         `
       : nothing}

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -109,6 +109,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
       : nothing;
   }
   const result = props.state?.result;
+  const owner = result?.owner ?? session.owner?.actor;
   const members = new Set(result?.members.map((member) => member.identityId) ?? []);
   // The shared header owner chip presents effective ownership; this picker manages mutable members.
   const identities =
@@ -118,7 +119,8 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
   const membersAvailable = props.membersAvailable !== false;
   const visibilityOptions = allowed.filter((option) => !canPublish || option !== "shared");
   const shouldCapMembers =
-    membersAvailable && visibilityOptions.length + identities.length + (canPublish ? 1 : 0) > 12;
+    membersAvailable &&
+    visibilityOptions.length + identities.length + (canPublish ? 1 : 0) + (owner ? 1 : 0) > 12;
   const content = html`
     ${canPublish
       ? html`<wa-dropdown-item
@@ -159,6 +161,21 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
         </wa-dropdown-item>
       `;
     })}
+    ${owner
+      ? html`
+          <div class="chat-pane__sharing-title chat-pane__sharing-owner-title">
+            ${t("chat.sessionSharing.owner")}
+          </div>
+          <div class="chat-pane__sharing-owner">
+            <span class="chat-pane__sharing-member-icon" aria-hidden="true">
+              ${owner.type === "human"
+                ? renderSessionOwnerChip(owner, "header", "owned")
+                : icons.bot}
+            </span>
+            <span class="chat-pane__sharing-member-label">${owner.label ?? owner.id}</span>
+          </div>
+        `
+      : nothing}
     ${membersAvailable
       ? html`
           <div class="chat-pane__sharing-title chat-pane__sharing-members-title">

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -10,6 +10,7 @@ import {
   personActivityLink,
   renderPersonAvatarLink,
   renderPersonName,
+  renderStandalonePersonLink,
   type PersonActivityRouting,
 } from "../../../components/person-activity-link.ts";
 import { renderSessionOwnerChip } from "../../../components/session-owner-chip.ts";
@@ -32,6 +33,7 @@ export type ChatSessionSharingProps = {
   memberAddDisabledReason?: string;
   memberRemoveDisabledReason?: string;
   personActivity?: PersonActivityRouting;
+  showOwner?: boolean;
   onOpen: () => void;
   onVisibilityChange: (visibility: SessionVisibility) => void;
   onMemberChange: (identityId: string, member: boolean) => void;
@@ -108,19 +110,26 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
   }
   const visibility = session.visibility ?? "shared";
   const canManage = canManageChatSessionSharing(session);
-  if (!canManage) {
-    return visibility === "draft"
-      ? html`<span class="chat-pane__draft-indicator" title=${t("chat.sessionSharing.draft")}
-          >${sharingIcon("draft")}</span
-        >`
-      : nothing;
-  }
   const result = props.state?.result;
   const owner = result?.owner ?? session.owner?.actor;
   const ownerActivity = personActivityLink(
     owner?.identity?.type === "profile" ? owner.identity.id : undefined,
     props.personActivity,
   );
+  if (!canManage) {
+    return visibility === "draft"
+      ? html`${props.showOwner && owner
+            ? renderStandalonePersonLink(
+                renderSessionOwnerChip(owner, "header", "owned"),
+                ownerActivity,
+              )
+            : nothing}<span
+            class="chat-pane__draft-indicator"
+            title=${t("chat.sessionSharing.draft")}
+            >${sharingIcon("draft")}</span
+          >`
+      : nothing;
+  }
   const members = new Set(result?.members.map((member) => member.identityId) ?? []);
   // The owner row presents effective ownership; selectable rows below manage mutable members.
   const identities =

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -716,26 +716,6 @@ openclaw-chat-pane {
   flex: 0 0 auto;
 }
 
-.chat-pane__header-center .chat-pane__sharing-menu,
-.chat-pane__header-center .chat-pane__draft-indicator {
-  position: absolute;
-  inset-block-start: 50%;
-  inset-inline-start: 100%;
-  display: inline-flex;
-  transform: translateY(-50%);
-}
-
-.chat-pane__header-center .chat-pane__sharing-trigger {
-  width: 28px;
-  min-width: 28px;
-  height: 28px;
-  min-height: 28px;
-  padding: 0;
-  border-left: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  border-radius: 0 var(--radius-full) var(--radius-full) 0;
-  background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
-}
-
 .chat-pane__sharing-menu::part(menu) {
   width: 260px;
   min-width: min(260px, calc(100vw - 24px));
@@ -765,6 +745,20 @@ openclaw-chat-pane {
 
 .chat-pane__sharing-members-title {
   margin-top: 8px;
+}
+
+.chat-pane__sharing-owner-title {
+  margin-top: 8px;
+}
+
+.chat-pane__sharing-owner {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  min-height: 36px;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  font-size: 12px;
 }
 
 .chat-pane__sharing-member-skeleton {
@@ -827,22 +821,17 @@ openclaw-chat-pane {
 }
 
 .chat-pane__draft-indicator {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
   font-size: 13px;
 }
 
 .chat-pane__draft-indicator svg {
   width: 15px;
   height: 15px;
-}
-
-.chat-pane__header-center .chat-pane__draft-indicator {
-  width: 28px;
-  height: 28px;
-  align-items: center;
-  justify-content: center;
-  border-left: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  border-radius: 0 var(--radius-full) var(--radius-full) 0;
-  background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
 }
 
 /* A full split header measures 793px including insets, so secondary controls


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the owner avatar and visibility control competed for separate header positions, while owner information was absent from the visibility menu.

## Why This Change Was Made

When visibility management is operable, its icon occupies the existing owner slot. The effective owner is shown as a normal row inside the same dropdown; sessions without a sharing control retain the existing owner avatar fallback. An inaccessible manager sharing menu does not displace that fallback, while non-manager Draft state remains visible as a static marker. The owner avatar and name continue to use the standard Activity-link helpers and preserve their live viewing/away state. Non-manager draft viewers keep the linked owner beside the static Draft indicator.

## User Impact

The centered Chat/Split/Dashboard selector stays visually independent, visibility is found where ownership previously appeared, owner context remains available inside the dropdown, and the owner Activity feed stays reachable in manager, draft-viewer, and denied-sharing states.

## Evidence

| Before | After |
| --- | --- |
| ![Owner avatar plus centered visibility control](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/1d02f0afa19277a695f4a66f4874e733b1a5c0a5/04-owner-before.png) | ![Visibility in owner slot with Owner inside the menu](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/1d02f0afa19277a695f4a66f4874e733b1a5c0a5/04-owner-after.png) |

Playwright capture from the mocked Control UI at 1600×760.

Validation:

- Header component/controller suite: 49 passed, including linked-owner fallback when sharing cannot open
- Sharing component unit suite: 11 passed, including owner presence propagation in menu and draft-viewer states
- Mobile sharing browser suite: 3 passed, including non-manager Draft marker
- Session ownership/sharing browser suite: 13 passed
- Identity Activity-link browser suite: 3 passed, including away owner state plus owner-menu and non-manager draft-owner navigation
- Responsive browser layout: 123 passed
- Combined focused UI/browser set at rebased stack head: 204 passed
- dashboard-fullscreen.e2e.test.ts: 9 passed
- Unrelated failed CI test reproduced locally: chat-pane-placement-stop.test.ts 44 passed
- pnpm ui:i18n:verify: passed
- pnpm check:changed: passed at exact local head before the final one-line access-gate narrowing; targeted format, header, and mobile E2E gates passed after it
- Pre-publish autoreview: clean, no accepted/actionable findings
- Production LOC: +106 / -66; tests: +210 / -18
