### PR TITLE
refactor(media): release and join blocked playback fixtures

### DIFF
--- a/src/media/playback-transcode.test-support.ts
+++ b/src/media/playback-transcode.test-support.ts
@@ -20,3 +20,9 @@ export async function waitForPlaybackTranscodeJobsForTest(mode: "next" | "all"):
   await (mode === "next" ? Promise.race(jobs) : Promise.all(jobs));
   return jobs.length;
 }
+
+// Stop issuing requests and release every fixture gate before calling; this joins
+// the existing jobs for cleanup and does not assert that conversion succeeded.
+export async function settlePlaybackTranscodeJobsForTest(): Promise<void> {
+  await Promise.allSettled(getTestApi().getPlaybackTranscodeJobs());
+}

--- a/src/media/playback-transcode.test.ts
+++ b/src/media/playback-transcode.test.ts
@@ -3,7 +3,11 @@ import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
-import { waitForPlaybackTranscodeJobsForTest } from "./playback-transcode.test-support.js";
+import type { PlaybackMediaProbeResult } from "./media-probe.js";
+import {
+  settlePlaybackTranscodeJobsForTest,
+  waitForPlaybackTranscodeJobsForTest,
+} from "./playback-transcode.test-support.js";
 
 const { playbackWarn, probePlaybackMediaFileDescriptor, runFfmpeg } = vi.hoisted(() => ({
   playbackWarn: vi.fn(),
@@ -433,10 +437,7 @@ describe("resolvePlaybackTranscode", () => {
 
   it("does not cache an inconclusive native codec probe", async () => {
     const source = await createSource("probe-retry.mp4");
-    let finishTranscode: (() => void) | undefined;
-    const transcodeGate = new Promise<void>((resolve) => {
-      finishTranscode = resolve;
-    });
+    const transcodeGate = createDeferred();
     probePlaybackMediaFileDescriptor.mockResolvedValueOnce(null).mockResolvedValueOnce({
       durationMs: 1000,
       videoCodec: "hevc",
@@ -445,7 +446,7 @@ describe("resolvePlaybackTranscode", () => {
       audioStreamIndex: 1,
     });
     runFfmpeg.mockImplementationOnce(async (args: string[]) => {
-      await transcodeGate;
+      await transcodeGate.promise;
       await fs.writeFile(args.at(-1) ?? "", "normalized-video");
       return "";
     });
@@ -455,39 +456,38 @@ describe("resolvePlaybackTranscode", () => {
       kind: "video" as const,
     };
 
-    await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
-      kind: "passthrough",
-    });
-    await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
-      kind: "preparing",
-    });
-    await vi.waitFor(() => expect(runFfmpeg).toHaveBeenCalledOnce());
-    expect(probePlaybackMediaFileDescriptor).toHaveBeenCalledTimes(2);
-    finishTranscode?.();
-    await vi.waitFor(async () => {
-      await expect(playback.resolvePlaybackTranscode(params)).resolves.toMatchObject({
-        kind: "transcoded",
+    try {
+      await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
+        kind: "passthrough",
       });
-    });
+      await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
+        kind: "preparing",
+      });
+      await vi.waitFor(() => expect(runFfmpeg).toHaveBeenCalledOnce());
+      expect(probePlaybackMediaFileDescriptor).toHaveBeenCalledTimes(2);
+      transcodeGate.resolve();
+      await vi.waitFor(async () => {
+        await expect(playback.resolvePlaybackTranscode(params)).resolves.toMatchObject({
+          kind: "transcoded",
+        });
+      });
+    } finally {
+      transcodeGate.resolve();
+      await settlePlaybackTranscodeJobsForTest();
+    }
   });
 
   it("single-flights concurrent codec inspections for the same source", async () => {
     const source = await createSource("inspection-single-flight.mp4");
-    let finishProbe: ((value: Record<string, unknown>) => void) | undefined;
-    const probeGate = new Promise<Record<string, unknown>>((resolve) => {
-      finishProbe = resolve;
-    });
-    probePlaybackMediaFileDescriptor.mockImplementationOnce(async () => await probeGate);
+    const probeGate = createDeferred<PlaybackMediaProbeResult>();
+    probePlaybackMediaFileDescriptor.mockImplementationOnce(async () => await probeGate.promise);
     const params = {
       ...source,
       mimeType: "video/mp4",
       kind: "video" as const,
     };
 
-    const first = playback.resolvePlaybackModeForSource(params);
-    const second = playback.resolvePlaybackModeForSource(params);
-    await vi.waitFor(() => expect(probePlaybackMediaFileDescriptor).toHaveBeenCalledOnce());
-    finishProbe?.({
+    const nativeProbe: PlaybackMediaProbeResult = {
       durationMs: 1000,
       videoCodec: "h264",
       videoProfile: "high",
@@ -495,8 +495,17 @@ describe("resolvePlaybackTranscode", () => {
       videoStreamIndex: 0,
       audioCodec: "aac",
       audioStreamIndex: 1,
-    });
-    await expect(Promise.all([first, second])).resolves.toEqual(["native", "native"]);
+    };
+    const first = playback.resolvePlaybackModeForSource(params);
+    const second = playback.resolvePlaybackModeForSource(params);
+    try {
+      await vi.waitFor(() => expect(probePlaybackMediaFileDescriptor).toHaveBeenCalledOnce());
+      probeGate.resolve(nativeProbe);
+      await expect(Promise.all([first, second])).resolves.toEqual(["native", "native"]);
+    } finally {
+      probeGate.resolve(nativeProbe);
+      await Promise.allSettled([first, second]);
+    }
   });
 
   it("fails closed at inspection capacity without blocking supplied probe facts", async () => {
@@ -506,37 +515,40 @@ describe("resolvePlaybackTranscode", () => {
       createSource("inspection-capacity-supplied.mp4"),
       createSource("inspection-capacity-fallback.mp4"),
     ]);
-    let finishProbe: ((value: Record<string, unknown>) => void) | undefined;
-    const probeGate = new Promise<Record<string, unknown>>((resolve) => {
-      finishProbe = resolve;
-    });
-    probePlaybackMediaFileDescriptor.mockImplementation(async () => await probeGate);
+    const probeGate = createDeferred<PlaybackMediaProbeResult>();
+    probePlaybackMediaFileDescriptor.mockImplementation(async () => await probeGate.promise);
     const makeParams = (index: number) => ({
       ...sources[index]!,
       mimeType: "video/mp4",
       kind: "video" as const,
     });
 
-    const first = playback.resolvePlaybackModeForSource(makeParams(0));
-    const second = playback.resolvePlaybackModeForSource(makeParams(1));
-    await vi.waitFor(() => expect(probePlaybackMediaFileDescriptor).toHaveBeenCalledTimes(2));
-    await expect(
-      playback.resolvePlaybackModeForSource({
-        ...makeParams(2),
-        probe: { durationMs: 1000, videoCodec: "hevc", videoStreamIndex: 0 },
-      }),
-    ).resolves.toBe("transcode");
-    await expect(playback.resolvePlaybackModeForSource(makeParams(3))).resolves.toBeUndefined();
-    expect(probePlaybackMediaFileDescriptor).toHaveBeenCalledTimes(2);
-
-    finishProbe?.({
+    const nativeProbe: PlaybackMediaProbeResult = {
       durationMs: 1000,
       videoCodec: "h264",
       videoProfile: "high",
       videoPixelFormat: "yuv420p",
       videoStreamIndex: 0,
-    });
-    await expect(Promise.all([first, second])).resolves.toEqual(["native", "native"]);
+    };
+    const first = playback.resolvePlaybackModeForSource(makeParams(0));
+    const second = playback.resolvePlaybackModeForSource(makeParams(1));
+    try {
+      await vi.waitFor(() => expect(probePlaybackMediaFileDescriptor).toHaveBeenCalledTimes(2));
+      await expect(
+        playback.resolvePlaybackModeForSource({
+          ...makeParams(2),
+          probe: { durationMs: 1000, videoCodec: "hevc", videoStreamIndex: 0 },
+        }),
+      ).resolves.toBe("transcode");
+      await expect(playback.resolvePlaybackModeForSource(makeParams(3))).resolves.toBeUndefined();
+      expect(probePlaybackMediaFileDescriptor).toHaveBeenCalledTimes(2);
+
+      probeGate.resolve(nativeProbe);
+      await expect(Promise.all([first, second])).resolves.toEqual(["native", "native"]);
+    } finally {
+      probeGate.resolve(nativeProbe);
+      await Promise.allSettled([first, second]);
+    }
   });
 
   it("does not cache an inconclusive duration probe for an exotic container", async () => {
@@ -570,10 +582,7 @@ describe("resolvePlaybackTranscode", () => {
 
   it("transcodes HEVC-in-MP4 and reuses its cached codec classification", async () => {
     const source = await createSource("hevc.mp4");
-    let finishTranscode: (() => void) | undefined;
-    const transcodeGate = new Promise<void>((resolve) => {
-      finishTranscode = resolve;
-    });
+    const transcodeGate = createDeferred();
     probePlaybackMediaFileDescriptor.mockResolvedValueOnce({
       durationMs: 1000,
       videoCodec: "hevc",
@@ -582,7 +591,7 @@ describe("resolvePlaybackTranscode", () => {
       audioStreamIndex: 3,
     });
     runFfmpeg.mockImplementationOnce(async (args: string[]) => {
-      await transcodeGate;
+      await transcodeGate.promise;
       await fs.writeFile(args.at(-1) ?? "", "normalized-video");
       return "";
     });
@@ -592,33 +601,35 @@ describe("resolvePlaybackTranscode", () => {
       kind: "video" as const,
     };
 
-    await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
-      kind: "preparing",
-    });
-    await vi.waitFor(() => expect(runFfmpeg).toHaveBeenCalledOnce());
-    await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
-      kind: "preparing",
-    });
-    expect(probePlaybackMediaFileDescriptor).toHaveBeenCalledOnce();
-    finishTranscode?.();
-    await vi.waitFor(async () => {
-      await expect(playback.resolvePlaybackTranscode(params)).resolves.toMatchObject({
-        kind: "transcoded",
+    try {
+      await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
+        kind: "preparing",
       });
-    });
-    expect(runFfmpeg.mock.calls[0]?.[0]).toEqual(
-      expect.arrayContaining(["-f", "mov", "-map", "0:2", "-map", "0:3", "-c:v", "libx264"]),
-    );
+      await vi.waitFor(() => expect(runFfmpeg).toHaveBeenCalledOnce());
+      await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
+        kind: "preparing",
+      });
+      expect(probePlaybackMediaFileDescriptor).toHaveBeenCalledOnce();
+      transcodeGate.resolve();
+      await vi.waitFor(async () => {
+        await expect(playback.resolvePlaybackTranscode(params)).resolves.toMatchObject({
+          kind: "transcoded",
+        });
+      });
+      expect(runFfmpeg.mock.calls[0]?.[0]).toEqual(
+        expect.arrayContaining(["-f", "mov", "-map", "0:2", "-map", "0:3", "-c:v", "libx264"]),
+      );
+    } finally {
+      transcodeGate.resolve();
+      await settlePlaybackTranscodeJobsForTest();
+    }
   });
 
   it("single-flights MIME aliases that target the same cached rendition", async () => {
     const source = await createSource("alias-audio.mp4");
-    let finishTranscode: (() => void) | undefined;
-    const transcodeGate = new Promise<void>((resolve) => {
-      finishTranscode = resolve;
-    });
+    const transcodeGate = createDeferred();
     runFfmpeg.mockImplementationOnce(async (args: string[]) => {
-      await transcodeGate;
+      await transcodeGate.promise;
       await fs.writeFile(args.at(-1) ?? "", "normalized-audio");
       return "";
     });
@@ -628,33 +639,35 @@ describe("resolvePlaybackTranscode", () => {
       probe: { durationMs: 1000, audioCodec: "opus", audioStreamIndex: 0 },
     };
 
-    await expect(
-      Promise.all([
-        playback.resolvePlaybackTranscode({ ...base, mimeType: "audio/mp4" }),
-        playback.resolvePlaybackTranscode({ ...base, mimeType: "audio/x-m4a" }),
-      ]),
-    ).resolves.toEqual([{ kind: "preparing" }, { kind: "preparing" }]);
-    await vi.waitFor(() => expect(runFfmpeg).toHaveBeenCalledOnce());
-    finishTranscode?.();
-    await vi.waitFor(async () => {
+    try {
       await expect(
-        playback.resolvePlaybackTranscode({ ...base, mimeType: "audio/mp4" }),
-      ).resolves.toMatchObject({
-        kind: "transcoded",
-        contentType: "audio/mp4",
-        extension: ".m4a",
+        Promise.all([
+          playback.resolvePlaybackTranscode({ ...base, mimeType: "audio/mp4" }),
+          playback.resolvePlaybackTranscode({ ...base, mimeType: "audio/x-m4a" }),
+        ]),
+      ).resolves.toEqual([{ kind: "preparing" }, { kind: "preparing" }]);
+      await vi.waitFor(() => expect(runFfmpeg).toHaveBeenCalledOnce());
+      transcodeGate.resolve();
+      await vi.waitFor(async () => {
+        await expect(
+          playback.resolvePlaybackTranscode({ ...base, mimeType: "audio/mp4" }),
+        ).resolves.toMatchObject({
+          kind: "transcoded",
+          contentType: "audio/mp4",
+          extension: ".m4a",
+        });
       });
-    });
+    } finally {
+      transcodeGate.resolve();
+      await settlePlaybackTranscodeJobsForTest();
+    }
   });
 
   it("single-flights concurrent requests and reuses the deterministic store entry", async () => {
     const source = await createSource("single-flight.mkv");
-    let finishTranscode: (() => void) | undefined;
-    const transcodeGate = new Promise<void>((resolve) => {
-      finishTranscode = resolve;
-    });
+    const transcodeGate = createDeferred();
     runFfmpeg.mockImplementation(async (args: string[]) => {
-      await transcodeGate;
+      await transcodeGate.promise;
       await fs.writeFile(args.at(-1) ?? "", "normalized-video");
       return "";
     });
@@ -664,62 +677,67 @@ describe("resolvePlaybackTranscode", () => {
       mimeType: "video/x-matroska",
       kind: "video" as const,
     };
-    await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
-      kind: "preparing",
-    });
-    await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
-      kind: "preparing",
-    });
-    await vi.waitFor(() => expect(runFfmpeg).toHaveBeenCalledOnce());
-    finishTranscode?.();
+    try {
+      await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
+        kind: "preparing",
+      });
+      await expect(playback.resolvePlaybackTranscode(params)).resolves.toEqual({
+        kind: "preparing",
+      });
+      await vi.waitFor(() => expect(runFfmpeg).toHaveBeenCalledOnce());
+      transcodeGate.resolve();
 
-    let resolved: Awaited<ReturnType<typeof playback.resolvePlaybackTranscode>> | undefined;
-    await vi.waitFor(async () => {
-      resolved = await playback.resolvePlaybackTranscode(params);
-      expect(resolved.kind).toBe("transcoded");
-    });
-    expect(runFfmpeg).toHaveBeenCalledOnce();
-    expect(resolved).toMatchObject({
-      kind: "transcoded",
-      contentType: "video/mp4",
-      extension: ".mp4",
-    });
-    if (resolved?.kind !== "transcoded") {
-      throw new Error("expected cached playback output");
+      let resolved: Awaited<ReturnType<typeof playback.resolvePlaybackTranscode>> | undefined;
+      await vi.waitFor(async () => {
+        resolved = await playback.resolvePlaybackTranscode(params);
+        expect(resolved.kind).toBe("transcoded");
+      });
+      expect(runFfmpeg).toHaveBeenCalledOnce();
+      expect(resolved).toMatchObject({
+        kind: "transcoded",
+        contentType: "video/mp4",
+        extension: ".mp4",
+      });
+      if (resolved?.kind !== "transcoded") {
+        throw new Error("expected cached playback output");
+      }
+      expect(resolved.path).toContain(`${path.sep}media${path.sep}playback-transcode${path.sep}`);
+      expect(path.basename(resolved.path)).toMatch(/^v2-[a-f0-9]{64}\.mp4$/u);
+      expect(await fs.readFile(resolved.path, "utf8")).toBe("normalized-video");
+      expect(runFfmpeg.mock.calls[0]?.[0]).toEqual(
+        expect.arrayContaining([
+          "-max_alloc",
+          String(256 * 1024 * 1024),
+          "-filter_threads",
+          "2",
+          "-protocol_whitelist",
+          "file",
+          "-f",
+          "matroska,webm",
+          "-max_pixels",
+          String(4096 * 4096),
+          "-threads",
+          "2",
+          "-map",
+          "0:0",
+          "-map",
+          "0:1",
+          "-t",
+          String(20 * 60),
+          "-c:v",
+          "libx264",
+          "-c:a",
+          "aac",
+          "-movflags",
+          "+faststart",
+          "-fs",
+          String(16 * 1024 * 1024 + 1),
+        ]),
+      );
+    } finally {
+      transcodeGate.resolve();
+      await settlePlaybackTranscodeJobsForTest();
     }
-    expect(resolved.path).toContain(`${path.sep}media${path.sep}playback-transcode${path.sep}`);
-    expect(path.basename(resolved.path)).toMatch(/^v2-[a-f0-9]{64}\.mp4$/u);
-    expect(await fs.readFile(resolved.path, "utf8")).toBe("normalized-video");
-    expect(runFfmpeg.mock.calls[0]?.[0]).toEqual(
-      expect.arrayContaining([
-        "-max_alloc",
-        String(256 * 1024 * 1024),
-        "-filter_threads",
-        "2",
-        "-protocol_whitelist",
-        "file",
-        "-f",
-        "matroska,webm",
-        "-max_pixels",
-        String(4096 * 4096),
-        "-threads",
-        "2",
-        "-map",
-        "0:0",
-        "-map",
-        "0:1",
-        "-t",
-        String(20 * 60),
-        "-c:v",
-        "libx264",
-        "-c:a",
-        "aac",
-        "-movflags",
-        "+faststart",
-        "-fs",
-        String(16 * 1024 * 1024 + 1),
-      ]),
-    );
   });
 
   it("retries failed ffmpeg jobs after the bounded cooldown", async () => {
@@ -874,18 +892,16 @@ describe("resolvePlaybackTranscode", () => {
       createSource("pool-second.mkv"),
       createSource("pool-third.mkv"),
     ]);
-    const finishers: Array<() => Promise<void>> = [];
-    const starts = [createDeferred(), createDeferred(), createDeferred()];
-    runFfmpeg.mockImplementation(
-      async (args: string[]) =>
-        await new Promise<string>((resolve) => {
-          starts[finishers.length]?.resolve();
-          finishers.push(async () => {
-            await fs.writeFile(args.at(-1) ?? "", "normalized-video");
-            resolve("");
-          });
-        }),
-    );
+    const starts = sources.map(() => createDeferred());
+    const releases = sources.map(() => createDeferred());
+    let nextJobIndex = 0;
+    runFfmpeg.mockImplementation(async (args: string[]) => {
+      const index = nextJobIndex++;
+      starts[index]!.resolve();
+      await releases[index]!.promise;
+      await fs.writeFile(args.at(-1) ?? "", "normalized-video");
+      return "";
+    });
     const params = sources.map(({ sourcePath, sourceStat }) => ({
       sourcePath,
       sourceStat,
@@ -893,37 +909,46 @@ describe("resolvePlaybackTranscode", () => {
       kind: "video" as const,
     }));
 
-    await expect(playback.resolvePlaybackTranscode(params[0]!)).resolves.toEqual({
-      kind: "preparing",
-    });
-    await expect(playback.resolvePlaybackTranscode(params[1]!)).resolves.toEqual({
-      kind: "preparing",
-    });
-    await Promise.all(starts.slice(0, 2).map(async ({ promise }) => await promise));
-    expect(runFfmpeg).toHaveBeenCalledTimes(2);
-    await expect(playback.resolvePlaybackTranscode(params[2]!)).resolves.toEqual({
-      kind: "preparing",
-    });
-    expect(runFfmpeg).toHaveBeenCalledTimes(2);
+    try {
+      await expect(playback.resolvePlaybackTranscode(params[0]!)).resolves.toEqual({
+        kind: "preparing",
+      });
+      await expect(playback.resolvePlaybackTranscode(params[1]!)).resolves.toEqual({
+        kind: "preparing",
+      });
+      await Promise.all(starts.slice(0, 2).map(async ({ promise }) => await promise));
+      expect(runFfmpeg).toHaveBeenCalledTimes(2);
+      await expect(playback.resolvePlaybackTranscode(params[2]!)).resolves.toEqual({
+        kind: "preparing",
+      });
+      expect(runFfmpeg).toHaveBeenCalledTimes(2);
 
-    const capacityAvailable = waitForPlaybackTranscodeJobsForTest("next");
-    await finishers[0]?.();
-    await expect(capacityAvailable).resolves.toBe(2);
-    await expect(playback.resolvePlaybackTranscode(params[2]!)).resolves.toEqual({
-      kind: "preparing",
-    });
-    await starts[2]!.promise;
-    expect(runFfmpeg).toHaveBeenCalledTimes(3);
-    const remainingJobs = waitForPlaybackTranscodeJobsForTest("all");
-    await Promise.all(finishers.slice(1).map(async (finish) => await finish()));
-    await expect(remainingJobs).resolves.toBe(2);
-    await expect(
-      Promise.all(params.map(async (param) => await playback.resolvePlaybackTranscode(param))),
-    ).resolves.toEqual([
-      expect.objectContaining({ kind: "transcoded" }),
-      expect.objectContaining({ kind: "transcoded" }),
-      expect.objectContaining({ kind: "transcoded" }),
-    ]);
+      const capacityAvailable = waitForPlaybackTranscodeJobsForTest("next");
+      releases[0]!.resolve();
+      await expect(capacityAvailable).resolves.toBe(2);
+      await expect(playback.resolvePlaybackTranscode(params[2]!)).resolves.toEqual({
+        kind: "preparing",
+      });
+      await starts[2]!.promise;
+      expect(runFfmpeg).toHaveBeenCalledTimes(3);
+      const remainingJobs = waitForPlaybackTranscodeJobsForTest("all");
+      for (const release of releases.slice(1)) {
+        release.resolve();
+      }
+      await expect(remainingJobs).resolves.toBe(2);
+      await expect(
+        Promise.all(params.map(async (param) => await playback.resolvePlaybackTranscode(param))),
+      ).resolves.toEqual([
+        expect.objectContaining({ kind: "transcoded" }),
+        expect.objectContaining({ kind: "transcoded" }),
+        expect.objectContaining({ kind: "transcoded" }),
+      ]);
+    } finally {
+      for (const release of releases) {
+        release.resolve();
+      }
+      await settlePlaybackTranscodeJobsForTest();
+    }
   });
 
   it("passes already portable media through without invoking ffmpeg", async () => {


### PR DESCRIPTION
## What Problem This Solves

Playback tests released blocked probe/ffmpeg fixtures only after their assertions. An earlier assertion failure could leave work active when the next test reset mocks or the suite restored its temporary home. A controlled inspection failure blocked the existing next duration-retry case; a controlled pool failure left two real jobs and two temporary workspaces pending at teardown.

## Why This Change Was Made

This maintainer-requested test audit replaces manual optional resolvers with the existing deferred helper and releases/joins owned work in `finally`. Inspection fixtures await their public request promises. Conversion fixtures use a separate cleanup snapshot of the existing production job promises; the pool preallocates all three release gates so late ffmpeg starts are covered.

The strict `next`/`all` job-wait helper and its capacity assertions remain unchanged. Production delta: **0**. Test support: **+6**; test suite: **+25 net**, including cleanup around existing bodies.

## User Impact

Playback behavior is unchanged. A failing test now finishes its owned work before another case runs or temporary storage is removed. All 91 cases and the exact 92 assertion chains remain; cache identity, bounded reads, codec/security checks, cooldown and pool behavior are retained.

## Evidence

The same canonical command passed **91 tests across 2 files before and after**:

```sh
env -u OPENCLAW_TESTBOX node scripts/run-vitest.mjs \
  src/media/playback-transcode.test.ts \
  src/media/store.playback-cache.test.ts
```

Two temporary early-failure controls were run against the original and candidate, then removed after their children joined:

| Control | Original | Candidate |
| --- | --- | --- |
| Fail after two inspection probes start, then run the existing next duration-retry case in original order | Deliberate failure plus next-case failure; next case made 0 probe/ffmpeg calls | Only deliberate failure; next case passes with 3 probes and 1 conversion |
| Fail after two pool ffmpeg jobs start; observe original teardown boundary | 2 actual job promises pending; 2 workspaces present | Both captured jobs joined; 0 active jobs; both workspaces absent |

The pool control did not invent or reorder a later conversion. Safety rescue joined all captured work in both versions; the candidate had already completed cleanup before rescue. All temporary instrumentation was restored to the exact passing candidate.

The configured changed-file gate passed, including core test type graphs, format, guards, all three dead-export scans and changed-file lint:

```sh
env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- \
  src/media/playback-transcode.test-support.ts \
  src/media/playback-transcode.test.ts
```

Fresh managed Codex review found no actionable P0–P2 findings. Final verification matched both tested file afterimages and confirmed all owned proof processes and temporary workspaces were gone.
