### PR TITLE
fix(e2e): support legacy Telegram package consent

### DIFF
--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -436,7 +436,7 @@ run_logged_print_heartbeat "npm-telegram-live-suite" 60 docker_e2e_run_with_harn
   ${prepublish_registry_mount_args[@]+"${prepublish_registry_mount_args[@]}"} \
   -v "$npm_prefix_host:/npm-global" \
   -i "$IMAGE_NAME" bash -s <<'EOF'
-set -euo pipefail
+set -Eeuo pipefail
 source scripts/lib/openclaw-e2e-instance.sh
 source scripts/e2e/lib/prepublish-plugin-registry.sh
 
@@ -540,10 +540,14 @@ if [ "${OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH:-0}" != "1" ]; then
     hotpath_model_value="$OPENAI_API_KEY"
   fi
   hotpath_channel_value="$(printf '%s:%s' 123456 "$hotpath_placeholder")"
-  # Non-interactive onboarding cannot approve plugin capabilities. This release
-  # harness explicitly accepts the staged Codex artifact before testing setup.
-  openclaw_e2e_run_command "$sut_command" plugins install @openclaw/codex \
-    --accept-capabilities >/tmp/openclaw-npm-telegram-codex-install.log 2>&1 </dev/null
+  # Older packages own their automatic setup. Successful candidate help, not a
+  # version guess, establishes whether this harness must preinstall Codex.
+  plugin_install_help="$(openclaw_e2e_run_command "$sut_command" plugins install --help)"
+  fixture_consent="$(printf '%s' "$plugin_install_help" | node scripts/e2e/lib/package-compat.mjs fixture-consent)"
+  if [ -n "$fixture_consent" ]; then
+    openclaw_e2e_fixture_plugin_command "$sut_command" -- plugins install @openclaw/codex \
+      >/tmp/openclaw-npm-telegram-codex-install.log 2>&1 </dev/null
+  fi
   OPENAI_API_KEY="$hotpath_model_value" openclaw_e2e_run_command "$sut_command" onboard \
     --non-interactive --accept-risk \
     --mode local \

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -22,6 +22,45 @@ function mkTempRoot() {
   return root;
 }
 
+function runHotpathCandidate(consentSupported: boolean) {
+  const root = mkTempRoot();
+  const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
+  const hotpath = script.slice(
+    script.indexOf('if [ "${OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH:-0}" != "1" ]'),
+    script.indexOf('\nexport OPENCLAW_NPM_TELEGRAM_SUT_COMMAND="$sut_command"'),
+  );
+  writeFileSync(
+    path.join(root, "openclaw"),
+    `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$ARGV_LOG"; if [[ "$*" == "plugins install --help" && "$CONSENT_SUPPORTED" == "1" ]]; then printf '  --accept-capabilities  Accept reviewed plugin capabilities\\n'; fi
+`,
+    { mode: 0o755 },
+  );
+  execFileSync(
+    "bash",
+    [
+      "-c",
+      `set -Eeuo pipefail
+source scripts/lib/openclaw-e2e-instance.sh
+openclaw_e2e_run_command() { "$@"; }
+runtime_home="$FIXTURE_ROOT/runtime"
+mkdir -p "$runtime_home"
+sut_command="$FIXTURE_ROOT/openclaw"
+${hotpath}`,
+    ],
+    {
+      cwd: path.resolve(TEST_DIR, "../.."),
+      env: {
+        ...process.env,
+        ARGV_LOG: path.join(root, "argv.log"),
+        CONSENT_SUPPORTED: consentSupported ? "1" : "0",
+        FIXTURE_ROOT: root,
+      },
+    },
+  );
+  return readFileSync(path.join(root, "argv.log"), "utf8").trim().split("\n");
+}
+
 afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     rmSync(root, { force: true, recursive: true });
@@ -211,6 +250,17 @@ describe("package Telegram live Docker E2E", () => {
     expect(script).not.toContain("/app/node_modules/openclaw/package.json");
     expect(script).not.toContain("link_installed_package_dependency");
   });
+
+  it.each([false, true])(
+    "runs the onboarding hotpath with candidate consent support=%s",
+    (supported) => {
+      const calls = runHotpathCandidate(supported);
+      expect(calls.filter((call) => call.startsWith("plugins install @openclaw/codex"))).toEqual(
+        supported ? ["plugins install @openclaw/codex --accept-capabilities"] : [],
+      );
+      expect(calls.some((call) => call.startsWith("onboard "))).toBe(true);
+    },
+  );
 
   it("adds private SDK exports only to the trusted harness manifest", () => {
     const root = mkTempRoot();


### PR DESCRIPTION
Related: #136523

## What Problem This Solves

Fixes an issue where the package Telegram E2E harness failed before onboarding when validating an older OpenClaw package whose `plugins install` command did not support `--accept-capabilities`.

## Why This Change Was Made

The harness now checks the candidate's successful `plugins install --help`, parses support through the existing `fixture-consent` compatibility helper, and preinstalls Codex through `openclaw_e2e_fixture_plugin_command` only when consent is advertised. The existing hotpath error trap remains in place with inherited ERR handling, and it is cleared immediately before the live runner.

This is a lean maintainer replacement for #136523 because that branch cannot be edited by maintainers. It intentionally rejects the original failure-phase metadata and run-metadata helper: no workflow consumes that data, and the existing three-field run metadata contract remains unchanged.

## User Impact

Release validation can exercise older package candidates without passing an unsupported flag, while current candidates still receive explicit capability consent and continue through onboarding into Telegram delivery proof.

## Evidence

- Red proof on pristine `main`: the new behavioral test recorded an unconditional `plugins install @openclaw/codex --accept-capabilities` for a legacy fake candidate and failed before this repair.
- Green proof: `node scripts/run-vitest.mjs test/scripts/npm-telegram-live.test.ts` passed 46 tests, including legacy and modern candidate argv plus onboarding reachability.
- `bash -n scripts/e2e/npm-telegram-live-docker.sh`
- `git diff --check`
- Test audit: observable Bash/argv boundary, credible pre-fix failure, no duplicate coverage, and no test-only production seam.
- Diff-scoped deslop: no findings.
- Codex autoreview through P2: scoped clean, no accepted or actionable findings.
- Codex dependency contract inspected directly at `rust-v0.150.1` and `rust-v0.152.1`: the npm launcher forwards CLI argv unchanged to the platform binary, and `app-server` remains a first-class CLI runtime.
- Tooling delta: `+9/-5` (net `+4`). Tests: `+50/-0`.
- Exact legacy package proof: [NPM Telegram Beta E2E run 33699434859](https://github.com/openclaw/openclaw/actions/runs/33699434859) used harness head `9302066dcdd8a53a1ee088e0b52167a60926747f` with `openclaw@2026.9.1-beta.1`. The package installed, reported `OpenClaw 2026.9.1-beta.1 (1d96e5a)`, and completed the installed-package onboarding recovery hotpath (`Workspace OK`, `Sessions OK`, and config update) before the Telegram live scenario started. Reaching onboarding on this legacy candidate proves the harness did not pass its unsupported capability-consent flag.
- Concrete live-proof infeasibility: after the package and onboarding proof succeeded, the eligible Telegram flow reached a ready Gateway and then the leased Telegram Test Server group rejected the tester's `sendMessage` with `400 Have no write access to the chat`. This is an external credential/group permission failure, unrelated to the consent compatibility patch. A successful live-send assertion, including the equivalent modern/current-head rerun, is skipped only for this concrete reason; all package Telegram flow scenarios use the same leased physical group, so rerunning that fixture would repeat the known boundary failure.
- Exact-head CI will run after this PR is marked ready.

## Credit

Replacement preserves the original work by RoboClaw and VACInc through commit co-author trailers. #136523 will remain open until this replacement lands.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":9,"user":4,"assistant":4,"toolCalls":209,"toolOutputsDropped":208,"web":0,"redactions":5,"omittedUnsafe":0,"rawEntries":29}

[user]
[instructions recap omitted; policy/config text, not task dialogue]

Execute the independently audited/reviewed replacement for OpenClaw PR https://github.com/openclaw/openclaw/pull/136523 end to end. Repo [LOCAL_PATH] Do NOT modify original uneditable branch (`maintainerCanModify=false`). Verify live protected main, then create fresh shared GWT `gwt new fix/npm-telegram-consent-compat-lean <exact-main-sha>` and `tt sync`; verify node_modules symlink, never pnpm install in GWT. Read full root/scripts/test AGENTS, CONTRIBUTING, PR template, and skills openclaw-pr-maintainer, release-openclaw-ci, telegram-e2e-userbot, crabbox, openclaw-testing, test-audit, autoreview, deslop, agent-transcript. Personally inspect sibling ../codex exact relevant tag/source before verdict/PR/merge.

Approved scope: retain only `set -Eeuo pipefail`, candidate `plugins install --help`, `fixture-consent` parsing, conditional Codex preinstall through existing `openclaw_e2e_fixture_plugin_command`, hotpath ERR trap, and `trap - ERR` immediately before live runner. Remove/split all failure-phase metadata from original PR: no run-metadata helper, no failure_phase/record/handle code, no phase assignments, no RUN_METADATA_PATH or changes to existing 3-field run-metadata writer. No workflow consumer exists; do not create one. No refactor of duplicate help probe.

Add executable behavioral tests in test/scripts/npm-telegram-live.test.ts: legacy fake candidate help omits consent, install must not run and onboarding marker reached; modern help advertises consent, install runs exactly once with --accept-capabilities and onboarding marker reached. Execute via Bash + recorded argv; no source-string mirror tests. Capture red proof on pristine main (legacy fails due unconditional flag) then green both. Tooling delta target +4, hard ceiling +10; tests ≤50 net if practical.

Create maintainer-owned DRAFT replacement PR first via ghx, assign vincentkoc, semantic title, real body file + live readback, scrub private data, include agent transcript. Preserve RoboClaw/VACInc credit with public noreply co-author trailer. Explain original PR relationship and why metadata is rejected.

Proof: bash -n; focused tests npm-telegram-live + package-compat; pnpm check:changed. Use exact repaired-head legacy package proof for openclaw@2026.9.1-beta.1 and modern/current-head package/Telegram proof through repo-approved workflow/telegram-e2e-userbot; verify actual workflow inputs before dispatch. Both must demonstrate successful intended delivery/boundary, not merely runner entry. No publish/tag/release. Use Blacksmith Testbox/Crabbox only where required, no AWS.

Run test-audit, autoreview, deslop, latest ClawSweeper review/moves, exact-head CI, no release hold, native scripts/pr squash merge. After replacement lands, post one explanation with landed commit on #136523 and close it as superseded, preserving credit; no duplicate close comment. Report replacement PR URL/head/merge, original closure, tests, live runs/provider/lease/results, LOC, or one precise blocker.

[assistant]
hi. i’m locking this to the approved lean replacement scope, then I’ll build, prove, review, and land it without touching the contributor branch.

the local checkout is intentionally stale, so I’m taking the live protected `main` SHA directly from GitHub and will base the shared worktree on that immutable commit. gitcrawl is cloud-only here; live GitHub remains the authority.

`main` is protected by active repository rulesets and currently points to signed commit `62907ff9ac0ff235f013842a8676ef8cf1b0c209`. I’m creating the authorized shared worktree at exactly that SHA now.

the first SHA observation raced with a new signed `main` commit. I’m letting `gwt` finish cleanly, then I’ll re-anchor before edits so the branch starts from the actual latest protected head, not a stale observation.

`gwt` is still materializing the sparse checkout; the process is active inside its own new worktree and I’m not interrupting it. No source edits or branch mutations have happened yet.

[user]
<turn_aborted>
The user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.
</turn_aborted>

STOP edits/pushes immediately. External read-only check of `[LOCAL_PATH]` shows the entire tracked tree as deleted plus the same files untracked, branch at 62907ff9ac0. This is worktree/index integrity, not a valid patch. Enter recovery: verify cwd/repo root/branch, `.git` worktree pointer, `git status`, index file existence, node_modules symlink, disk. Do not reset/checkout/clean/recreate/remove the GWT and do not touch other sessions. Determine cause and recover only via repo/GWT-safe non-destructive method; if current worktree cannot be proven intact, stop and report exact blocker. No GitHub mutation.

[assistant]
hi. stopping all mutation. i’m auditing the worktree pointer, index, checkout process, and filesystem state read-only; I will not reset, checkout, clean, recreate, remove, or touch GitHub.

the pointer is valid, but the worktree index is currently absent because the original `gwt` child is still actively running `git checkout -f`. `node_modules` has not been linked yet. this looks like an incomplete checkout, not a patch; I’m checking its lock/temp state and will only wait for that exact task-owned process to finish.

[user]
Recovery update: do NOT treat this as crashed. `lsof` shows index.lock actively owned by git PID 88670, child of your `git fetch ... && gwt new ...` shell PID 87282; command is `git -C ... checkout -f` and remains live. The zero index/all-D status was observed mid-checkout. Do not clear lock/reset/recreate/kill. Wait for your original gwt command to finish, then verify clean status and node_modules symlink; resume approved work only if clean. Report if checkout exits nonzero.

[assistant]
understood. the active `index.lock` confirms a live checkout, not corruption. I’m waiting on the original `gwt` process only; after it exits I’ll verify its exit status, clean index/worktree, exact branch SHA, and `node_modules` symlink before doing anything else.

recovery is clean. the original `gwt` exited `0`; index is present, lock is gone, status is clean, `node_modules` is the required symlink, and both task-owned PIDs are gone. the all-deleted view was purely mid-checkout. I’m resuming from this intact worktree.

the repository and scoped policies are loaded. before touching code, I’m finishing the mandated workflow reads and reconstructing the exact owner path, test harness seam, shipped regression, and Codex dependency contract.

the owner path is clear: the harness hardcodes a new candidate CLI flag before onboarding, while the existing fixture helper already probes candidate help and appends consent only when supported. the lean fix can reuse that exact contract with no metadata surface or duplicate probe refactor. I’m finishing the mandatory Codex `0.152.1` source check now, then I’ll write the two executable regression cases first and capture the red run.

[user]
Checkout has now completed cleanly; node_modules is correctly symlinked to the owner checkout. Resume the approved lean Telegram replacement in this GWT.

[assistant]
I’m adding only the two boundary regressions now. they execute the real hotpath block under Bash against a fake candidate CLI, record actual argv, and assert onboarding proceeds; no copied implementation assertions or test-only production seam. I’ll run them on pristine code first to capture the required legacy failure.

the red proof is exact: legacy mode recorded one unconditional `plugins install @openclaw/codex --accept-capabilities`; modern mode passed. I’m now making the four-line tooling delta: enable inherited ERR handling, probe candidate help, parse `fixture-consent`, and conditionally route the install through the existing helper while leaving `trap - ERR` before the live runner.

the repaired behavior is green for both legacy and modern candidates. I’m waiting for the existing package-compat suite to finish before tightening the test diff to the requested ≤50-line target; no edits while Vitest is active.

the owner test is green. the untouched package-compat sweep hit its pre-existing 30-second subprocess ceiling on this loaded host, with only its two largest sweep cases timing out; I’ll rerun that surface in the approved remote path later. first I’m compacting the new test harness without changing behavior so the test delta meets the requested ceiling.

the formatter leaves the test at +51, one line over the practical target. I’m removing one unnecessary local without weakening the executable proof, then rerunning the owner test and static checks.

the final diff is at the requested limits: tooling `+4 net`, tests `+50`. test-audit passes: the cases protect observable argv/onboarding behavior, reproduce the real pre-fix failure, add no production seam, and cover a gap not owned by the existing parser/helper tests. I’m doing the diff-scoped deslop and independent P2 autoreview before publication.

deslop found no behavioral or style noise beyond the intentional compatibility branch. autoreview is now reviewing the complete local candidate through P2 with the rejected metadata/refactor scope stated explicitly.

autoreview’s first attempt stopped before review because `codex` resolved to a local launcher incompatible with isolation. I’m rerunning the same frozen scope with the installed standalone Codex binary; no code changed.

autoreview has completed isolation and source-integrity scanning and is in the final review phase. the candidate remains unchanged and the review target is still the exact two-file diff.

autoreview is scoped-clean through P2 with no actionable findings. I’m committing only the two reviewed files with both RoboClaw and VACInc credited, then I’ll push the maintainer branch and open the required draft replacement PR from a real body file with transcript/readback verification.

the reviewed head is `9302066dcdd8a53a1ee088e0b52167a60926747f` and is published only on the new maintainer branch. I found the current session for the approved transcript; I’m generating the sanitized body locally, then creating the PR as draft and verifying the live body is non-empty and exact.

[tool summary]
42 read, 2 write, 165 execute; raw tool outputs dropped: 208
````

</details>
<!-- agent-transcript:end -->
