### PR TITLE
fix: preserve reply code and enabled sibling channels

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3406,7 +3406,7 @@ src/plugins/clawhub.ts	10
 src/plugins/cli-gateway-nodes-runtime.ts	2
 src/plugins/command-registration.ts	3
 src/plugins/computer-use-contract.ts	3
-src/plugins/config-normalization-shared.ts	20
+src/plugins/config-normalization-shared.ts	19
 src/plugins/config-schema.ts	6
 src/plugins/contracts/inventory/bundled-capability-metadata.ts	3
 src/plugins/contracts/registry.ts	1

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.duplicateblocks.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.duplicateblocks.test.ts
@@ -10,6 +10,7 @@ describe("sanitizeUserFacingText duplicate-block collapse", () => {
       "class Worker:",
       "    def run(self):",
       '        self.log("retrying")',
+      '        replacement = "$&"',
       "",
       "    def log(self, msg):",
       "        print(msg)",

--- a/src/plugins/config-activation-shared.ts
+++ b/src/plugins/config-activation-shared.ts
@@ -181,9 +181,8 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
   if (entry?.enabled === false) {
     return decision("disabled", { cause: "disabled-in-config" });
   }
-  // `channels.<id>.enabled: false` is the operator's channel-level off switch. It must win over
-  // `plugins.entries.<id>.enabled: true` left behind by install/enable flows, or the channel
-  // plugin keeps importing (and can fail) for a channel the operator turned off.
+  // An owner-wide channel disable wins over plugin enablement left by install/enable flows.
+  // Enabled or unspecified sibling channels must still be able to load their shared plugin.
   if (
     params.resolveChannelConfigEnablement(
       activationSource.rootConfig ?? params.rootConfig,

--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -1,4 +1,5 @@
 // Shares plugin config normalization helpers across control-plane paths.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeArrayBackedTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { normalizeChatChannelId } from "../channels/ids.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -256,8 +257,8 @@ export function normalizePluginsConfigWithResolverCore(
 }
 
 /**
- * Reads the operator's `channels.<id>.enabled` decision for a channel plugin id.
- * `true`/`false` are explicit channel-level decisions; `undefined` means no signal.
+ * Enables an owner for any enabled channel; disables it only when all channels are off.
+ * Unspecified channels leave the plugin's own activation policy in control.
  */
 export function resolveChannelConfigEnablement(
   cfg: OpenClawConfig | undefined,
@@ -268,22 +269,16 @@ export function resolveChannelConfigEnablement(
   if (!channels) {
     return undefined;
   }
-  // Manifest-owned channel ids come first: a plugin id can differ from its channel key
-  // (for example `openclaw-qqbot` owning `channels.qqbot`), and the built-in catalog only
-  // resolves ids that match.
-  const candidateIds = [
-    ...channelIds.map((channelId) => normalizeChatChannelId(channelId) ?? channelId),
-    normalizeChatChannelId(pluginId),
-  ];
-  for (const channelId of candidateIds) {
+  // Declared ownership is authoritative; infer from the plugin id only when absent.
+  const candidateIds = channelIds.length
+    ? channelIds.map((channelId) => normalizeChatChannelId(channelId) ?? channelId)
+    : [normalizeChatChannelId(pluginId)];
+  const enablement = candidateIds.map((channelId) => {
     const entry = channelId ? channels[channelId] : undefined;
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-      continue;
-    }
-    const enabled = (entry as Record<string, unknown>).enabled;
-    if (typeof enabled === "boolean") {
-      return enabled;
-    }
+    return isRecord(entry) ? entry.enabled : undefined;
+  });
+  if (enablement.includes(true)) {
+    return true;
   }
-  return undefined;
+  return enablement.every((enabled) => enabled === false) ? false : undefined;
 }

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -1,6 +1,7 @@
 // Covers plugin config state normalization and reset behavior.
 import { describe, expect, it, vi } from "vitest";
 import * as bundledChannelCatalog from "../channels/bundled-channel-catalog-read.js";
+import { resolvePolicyPluginActivationState } from "./config-policy.js";
 import {
   createPluginActivationSource,
   normalizePluginsConfig,
@@ -351,6 +352,47 @@ describe("resolveEffectiveEnableState", () => {
 
 describe("resolveEffectivePluginActivationState", () => {
   type ActivationParams = Parameters<typeof resolveEffectivePluginActivationState>[0];
+
+  it.each([
+    { alpha: false, beta: true, pluginEnabled: true, expected: true },
+    { alpha: false, beta: false, pluginEnabled: true, expected: false },
+    { alpha: false, beta: undefined, pluginEnabled: true, expected: true },
+    { alpha: undefined, beta: undefined, pluginEnabled: true, expected: true },
+    { alpha: false, beta: true, pluginEnabled: false, expected: false },
+    // The same-named built-in channel is not owned by these manifest channel IDs.
+    { id: "telegram", alpha: false, beta: false, pluginEnabled: true, expected: false },
+    { id: "telegram", alpha: undefined, beta: undefined, pluginEnabled: true, expected: true },
+  ])(
+    "keeps multi-channel activation independent of order: %j",
+    ({ id = "multi-channel", alpha, beta, pluginEnabled, expected }) => {
+      const rootConfig = {
+        plugins: { entries: { [id]: { enabled: pluginEnabled } } },
+        channels: {
+          alpha: { enabled: alpha },
+          beta: { enabled: beta },
+          telegram: { enabled: !expected },
+        },
+      };
+      for (const channelIds of [
+        ["alpha", "beta"],
+        ["beta", "alpha"],
+      ]) {
+        const params = {
+          id,
+          origin: "config" as const,
+          config: normalizePluginsConfig(rootConfig.plugins),
+          rootConfig,
+          channelIds,
+        };
+        for (const resolve of [
+          resolveEffectivePluginActivationState,
+          resolvePolicyPluginActivationState,
+        ]) {
+          expect(resolve(params)).toMatchObject({ enabled: expected, activated: expected });
+        }
+      }
+    },
+  );
 
   it.each<{
     name: string;

--- a/src/shared/text/text-projection.test.ts
+++ b/src/shared/text/text-projection.test.ts
@@ -120,6 +120,15 @@ describe("duplicate paragraphs", () => {
     },
     { text: "repeat\n\n    repeat\n\nrepeat", expected: "repeat\n\n    repeat\n\nrepeat" },
     { text: "Run `x`.\n\nRun `x`.", expected: "Run `x`." },
+    {
+      text: 'repeat\n\nrepeat\n\n```js\nfunction replacement() {\n\n  return "$$ $& $` $\'";\n}\n```',
+      expected: 'repeat\n\n```js\nfunction replacement() {\n\n  return "$$ $& $` $\'";\n}\n```',
+    },
+    {
+      text: '    const replacement = "$$ $& $` $\'";\n\nrepeat\n\nrepeat',
+      expected: '    const replacement = "$$ $& $` $\'";\n\nrepeat',
+    },
+    { text: "Use ``$$ $& $` $'``.\n\nUse ``$$ $& $` $'``.", expected: "Use ``$$ $& $` $'``." },
     { text: "repeat\n\nrepeat `x`", expected: "repeat\n\nrepeat `x`" },
     { text: "Do `x` repeat\n\nrepeat", expected: "Do `x` repeat\n\nrepeat" },
   ])("preserves canonical separators and whitespace %#", ({ text, expected }) => {

--- a/src/shared/text/text-projection.ts
+++ b/src/shared/text/text-projection.ts
@@ -192,7 +192,8 @@ function collapseDuplicateParagraphs(text: string): string {
   }
   let projected = collapsePlainDuplicateParagraphs(masked + text.slice(cursor));
   for (const { region, token } of protectedRegions) {
-    projected = projected.replace(token, text.slice(region.start, region.end));
+    // Replacement-string dollar sequences must remain literal inside code.
+    projected = projected.replace(token, () => text.slice(region.start, region.end));
   }
   return projected;
 }
@@ -281,8 +282,13 @@ function createDuplicateParagraphProjector(protectCode = true): TextProjector {
     const collapsed = hasDuplicate || duplicate;
     let delta = input.delta;
     if (collapsed) {
+      // Code can expose pending whitespace; the plain suffix cannot safely append across it.
       delta =
-        input.delta === null || !wasCollapsed || duplicate !== wasDuplicate || completedParagraph
+        input.delta === null ||
+        !wasCollapsed ||
+        duplicate !== wasDuplicate ||
+        completedParagraph ||
+        (protectCode && /\s$/.test(text))
           ? null
           : added;
       text =


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where reply deduplication corrupts literal replacement syntax inside fenced, indented, or inline code, including replacing `$&` with an internal placeholder. Streaming the same reply can also repeat or lose code whitespace after adjacent duplicate prose.

Fixes an issue where disabling one channel can disable an entire multi-channel plugin, depending on the order of its manifest channel IDs. An enabled or unspecified sibling must remain loadable under the plugin's existing policy.

## Why This Change Was Made

Restore protected code with a replacement callback so JavaScript does not interpret its dollar sequences. When restored code has already exposed pending trailing whitespace, the incremental projector uses its canonical projection rather than appending a plain-text suffix across that boundary. The existing non-whitespace fast path remains covered.

Aggregate channel decisions at the shared owner: any enabled channel yields enabled; only all explicitly disabled channels yield disabled; otherwise leave plugin policy in control. Declared manifest ownership is authoritative. Explicit plugin/global disable and existing allow/deny policy retain their precedence.

Maintainer decision: adopt aggregate ownership for existing multi-channel configurations. A first-listed disabled channel suppressing an enabled sibling is the regression being repaired, not an intended compatibility contract. The real loader passes with both manifest orders; all-disabled owners still stay disabled and unspecified siblings retain the existing plugin policy. This also resolves the review's activation decision and rank-up item.

The two independent fixes share no new abstraction. No dependency, public configuration, schema, protocol, release, or changelog changes. Production delta is net zero (+6 reply projection, -6 plugin policy); existing test files add 52 lines. The assertion baseline is reduced by one because the canonical record guard removes a type assertion.

## User Impact

Code samples survive reply cleanup byte-for-byte, including across streaming chunk boundaries. Turning off one channel no longer unexpectedly prevents an enabled sibling in the same plugin from loading.

## Evidence

- RED: the final reply cases fail on the unmodified owner (three projection cases and the actual reply sanitizer); multi-channel policy cases and real plugin loading also fail before the fix.
- GREEN: 376 tests across 10 existing files passed, covering actual reply sanitization, every two-way and character-by-character streaming split, both policy views, plugin loading, registry/cache behavior, and CLI metadata.
- Real plugin loader: a synthetic third-party plugin with two channels loads and registers its channels with either manifest order after the fix; it was incorrectly disabled before.
- Real Gateway BEFORE → AFTER: the same loopback mock-provider fixture traverses an actual Gateway and qa-channel. Before, delivery reported success but the replacement string contained the code points `NUL, 0, NUL`. After, the whole outbound payload equals the expected text byte-for-byte, including literal `$&`. Both private-QA builds passed; all Gateway processes, temporary state and loopback listeners were cleaned up.
- Independent Codex review of the final patch: scoped-clean through P2. Full `pnpm build` and the complete `check:changed` gate passed, including production/test typechecks, core/script lint, dead exports, database/storage guards, runtime import cycles, and formatting checks.
- Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/33697699716) and [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/33697699733) passed for `159b005196537675538f57042c22dca8ed37321f`. Native merge preparation verified both workflows in exact-head mode; no rebase or source changes followed review.

The loader proof covers actual plugin registration, not an external messaging service. The Gateway proof uses the repository's isolated mock-provider + ephemeral Gateway + qa-channel flow; no real accounts or running user Gateway are touched.


<details>
<summary>Gateway before/after verdict (synthetic fixture)</summary>

The proof checkout applied the final text-owner patch to the baseline. Its source hash above matches the same file in this PR.

```json
{
  "scenario": "duplicate prose followed by fenced replacement syntax",
  "baseline": "6c7487b2228ba394f21022ad4941b32888104b37",
  "candidateTextSha256": "e7023bc75e14138ffd28650d17fe016caeb723a0e1bcb87c383daba0b1a3e34b",
  "flow": "mock-openai HTTP provider -> actual ephemeral Gateway -> qa-channel outbound",
  "before": {
    "verdict": "FAIL",
    "terminalDelivery": "sent",
    "replacementStringCodePoints": [0, 48, 0]
  },
  "after": {
    "verdict": "PASS",
    "terminalDelivery": "sent",
    "outboundCode": "const replacement = \"$&\";",
    "fullPayloadMatchesExpected": true
  },
  "cleanup": {
    "gatewayProcessesStopped": true,
    "temporaryStateRemoved": true,
    "loopbackEndpointsClosed": true,
    "errors": []
  }
}
```

</details>
