### PR TITLE
fix(codex): stop post-tool summaries switching accounts and models

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -595,7 +595,10 @@ and settled-turn finalization use private temporary homes and OpenClaw auth
 even when ordinary sessions share the user home. A Chat created
 through Codex Sessions uses its private supervision connection instead, which
 preserves the native connection's auth and provider configuration for the
-canonical branch and future resumes.
+canonical branch and future resumes. If that supervised turn finishes tool work
+without a final answer, OpenClaw does not borrow host credentials to generate
+one. It delivers the [settled-tool fallback](/plugins/codex-harness-runtime#final-answers-after-settled-tool-work)
+without repeating completed actions.
 
 In a model-locked supervised Chat, `codex_threads` cannot attach a different
 fork or archive the Chat's bound native thread. List and metadata-only read

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -208,6 +208,31 @@ or notify. Heartbeat turns use the same Codex Default collaboration mode as
 ordinary chat turns. The heartbeat monitor's cron scratch is appended to the
 scheduled heartbeat user message when present.
 
+## Final answers after settled tool work
+
+For ordinary host-authenticated Codex turns that finish tool work without a
+visible answer, OpenClaw can request a bounded final-answer turn in a private
+temporary home. It uses the completed thread's model selection and the original
+host auth route or resolved profile, rather than selecting a model from outer
+request metadata. The existing environment, dynamic-tool, MCP, and native-hook
+restrictions remain. Completed actions are transcript evidence, not instructions
+to replay. Preserving a native model does not, by itself, disable host-authenticated
+finalization.
+
+A Chat created through Codex Sessions is different: its private supervision
+connection owns native authentication. Stock Codex does not expose a generic
+tool-free summary operation that preserves that connection's account. OpenClaw
+marks this finalization context unavailable instead of choosing host credentials,
+copying native credentials, or starting another native turn. If a final reply is
+required, the host delivers its existing fallback:
+
+> The tool run finished, but no final summary was produced. I did not repeat any completed actions.
+
+The original completed outcome, native binding, and tool receipts remain intact.
+Native turns that return a final answer are delivered normally. The ordinary
+`homeScope: "user"` opt-in retains its documented private host-auth finalization;
+see [Auth and environment isolation](/plugins/codex-harness-reference#auth-and-environment-isolation).
+
 ## Hook boundaries
 
 For ordinary persistent conversations, a `before_prompt_build` result containing

--- a/extensions/codex/media-understanding-provider.test.ts
+++ b/extensions/codex/media-understanding-provider.test.ts
@@ -347,7 +347,6 @@ describe("codex media understanding provider", () => {
         { type: "image", url: "data:image/png;base64,aW1hZ2UtYnl0ZXM=" },
       ],
       approvalPolicy: "on-request",
-      model: "gpt-5.4",
       effort: "low",
     });
   });
@@ -691,14 +690,13 @@ describe("codex media understanding provider", () => {
       | {
           threadId?: unknown;
           approvalPolicy?: unknown;
-          model?: unknown;
           input?: Array<{ type?: unknown; text?: unknown; text_elements?: unknown; url?: unknown }>;
           effort?: unknown;
         }
       | undefined;
     expect(turnParams?.threadId).toBe("thread-1");
     expect(turnParams?.approvalPolicy).toBe("on-request");
-    expect(turnParams?.model).toBe("gpt-5.4");
+    expect(turnParams).not.toHaveProperty("model");
     expect(turnParams).not.toHaveProperty("cwd");
     expect(turnParams?.effort).toBe("low");
     expect(turnParams?.input).toHaveLength(3);

--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -28,14 +28,14 @@ function codexModel(model = "gpt-5.4", id = model) {
   };
 }
 
-function threadStartResult(model: string) {
+function threadStartResult(model: string, modelProvider = "openai") {
   return {
     thread: {
       id: "thread-finalizer",
       sessionId: "session-finalizer",
       preview: "",
       ephemeral: true,
-      modelProvider: "openai",
+      modelProvider,
       createdAt: 1,
       updatedAt: 1,
       status: { type: "idle" },
@@ -49,7 +49,7 @@ function threadStartResult(model: string) {
       turns: [],
     },
     model,
-    modelProvider: "openai",
+    modelProvider,
     cwd: "/tmp/finalizer",
     approvalPolicy: "on-request",
     approvalsReviewer: "user",
@@ -110,6 +110,7 @@ function createClientFactory(
     emptyAnswer?: boolean;
     completeTurn?: boolean;
     models?: ReturnType<typeof codexModel>[];
+    modelProvider?: string;
   } = {},
 ) {
   const methods: string[] = [];
@@ -132,7 +133,7 @@ function createClientFactory(
       return { requirements: null };
     }
     if (method === "thread/start" && isRecord(params) && typeof params.model === "string") {
-      return threadStartResult(params.model);
+      return threadStartResult(params.model, options.modelProvider);
     }
     if (method === "mcpServerStatus/list") {
       return {
@@ -561,11 +562,15 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
     ).toMatchObject({ sandbox: "read-only", approvalPolicy: "on-request" });
   });
 
-  it("preserves the configured native model provider when no override is supplied", async () => {
-    const fake = createClientFactory();
+  it("preserves and reports the configured native provider when no override is supplied", async () => {
+    const model = "gpt-5.6-luna";
+    const fake = createClientFactory({
+      modelProvider: "synthetic-native-provider",
+      models: [codexModel(model)],
+    });
 
-    await runBoundedCodexAppServerTurn({
-      model: { mode: "required", id: "gpt-5.4" },
+    const result = await runBoundedCodexAppServerTurn({
+      model: { mode: "required", id: model },
       timeoutMs: 5_000,
       options: {
         clientFactory: fake.factory,
@@ -581,6 +586,10 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
 
     const startParams = fake.request.mock.calls.find(([method]) => method === "thread/start")?.[1];
     expect(startParams).not.toHaveProperty("modelProvider");
+    expect(result.nativeSelection).toEqual({
+      model,
+      modelProvider: "synthetic-native-provider",
+    });
     expect(fake.factory).toHaveBeenCalledWith(
       expect.objectContaining({ startOptions: expect.objectContaining({ homeScope: "user" }) }),
     );
@@ -619,12 +628,16 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
         requiredModalities: ["text"],
         isolation: "configured-transport",
       }),
-    ).resolves.toMatchObject({ model: id, text: "The message was sent successfully." });
+    ).resolves.toMatchObject({
+      model: id,
+      nativeSelection: { model: "codex-execution-model", modelProvider: "openai" },
+      text: "The message was sent successfully.",
+    });
 
     const threadStart = fake.request.mock.calls.find(([method]) => method === "thread/start")?.[1];
     const turnStart = fake.request.mock.calls.find(([method]) => method === "turn/start")?.[1];
     expect(threadStart).toMatchObject({ model: "codex-execution-model" });
-    expect(turnStart).toMatchObject({ model: "codex-execution-model" });
+    expect(turnStart).not.toHaveProperty("model");
   });
 
   it("keeps hidden models out of live-default selection", async () => {
@@ -649,13 +662,14 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
       }),
     ).resolves.toMatchObject({
       model: "visible-model",
+      nativeSelection: { model: "visible-execution-model", modelProvider: "openai" },
       text: "The message was sent successfully.",
     });
 
     const threadStart = fake.request.mock.calls.find(([method]) => method === "thread/start")?.[1];
     const turnStart = fake.request.mock.calls.find(([method]) => method === "turn/start")?.[1];
     expect(threadStart).toMatchObject({ model: "visible-execution-model" });
-    expect(turnStart).toMatchObject({ model: "visible-execution-model" });
+    expect(turnStart).not.toHaveProperty("model");
   });
 
   it("rejects a missing required model before starting a thread", async () => {

--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -83,6 +83,7 @@ type CodexBoundedTurnResult = {
   text: string;
   items: CodexThreadItem[];
   model: string;
+  nativeSelection: { model: string; modelProvider?: string | null };
   usage?: ReturnType<typeof normalizeCodexResponseTokenUsage>;
 };
 
@@ -309,14 +310,14 @@ async function runBoundedCodexAppServerTurnInWorkspace(
     );
     try {
       const turn = assertCodexTurnStartResponse(
-        // Inherit the empty thread environment; a cwd override recreates native tools.
+        // Inherit the admitted model and empty environment; another model/cwd
+        // override would replace the native selection or recreate native tools.
         await client.request<unknown>(
           "turn/start",
           {
             threadId: thread.thread.id,
             input: params.input,
             approvalPolicy: "on-request",
-            model: modelSelection.runtimeModelId,
             effort: "low",
           } satisfies CodexTurnStartParams,
           { timeoutMs, signal: abortController.signal },
@@ -332,6 +333,7 @@ async function runBoundedCodexAppServerTurnInWorkspace(
           timeoutError,
         })),
         model: modelSelection.catalogId,
+        nativeSelection: { model: thread.model, modelProvider: thread.modelProvider },
       };
     } finally {
       await interruptPromise;
@@ -584,7 +586,7 @@ function createCodexBoundedTurnCollector(
     async collect(
       startedTurn: CodexTurn,
       options: { signal: AbortSignal; timeoutError: CodexBoundedTurnTimeoutError },
-    ): Promise<Omit<CodexBoundedTurnResult, "model">> {
+    ): Promise<Omit<CodexBoundedTurnResult, "model" | "nativeSelection">> {
       turnId = startedTurn.id;
       if (isTerminalTurnStatus(startedTurn.status)) {
         completedTurn = startedTurn;

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -312,20 +312,30 @@ export async function finalizeCodexAttempt(
     result.assistantTexts.every((text) => !text.trim()) &&
     result.messagesSnapshot.some((message) => message.role === "toolResult") &&
     (!finalPromptError || activeProjector.settledTurnFailureFinalizationAllowed);
+  // Supervised auth belongs to its native connection, which has no generic stock
+  // tool-free summary operation. Retain fallback eligibility instead of selecting host auth.
   const settledTurnFinalizationContext = shouldCaptureSettledTurnFinalizationContext
-    ? ((await captureCodexSettledTurnFinalizationContext({
-        ...activeTranscriptTarget,
-        mirroredMessages: mirrorOutcome.mirroredMessages,
-        settledMessages: result.messagesSnapshot,
-        turnId: activeTurnId,
-      })) ?? Object.freeze({ source: "unavailable" as const }))
+    ? ((!usesSupervisionConnection
+        ? await captureCodexSettledTurnFinalizationContext({
+            ...activeTranscriptTarget,
+            model: resourceState.thread.model,
+            modelProvider: resourceState.thread.modelProvider,
+            authProfileId: startupAuthProfileId,
+            mirroredMessages: mirrorOutcome.mirroredMessages,
+            settledMessages: result.messagesSnapshot,
+            turnId: activeTurnId,
+          })
+        : undefined) ?? Object.freeze({ source: "unavailable" as const }))
     : undefined;
   if (settledTurnFinalizationContext?.source === "unavailable") {
-    // Unavailable evidence forbids native inference, but must not revoke this
-    // eligible turn's path to the existing host-owned fallback.
+    // Unavailability must not revoke the completed turn's host-owned fallback.
     embeddedAgentLog.warn("codex settled-turn finalization context is unavailable", {
+      runId: params.runId,
       threadId: resourceState.thread.threadId,
       turnId: activeTurnId,
+      reason: usesSupervisionConnection
+        ? "native_auth_finalization_unsupported"
+        : "context_unavailable",
     });
   }
   runAgentHarnessLlmOutputHook({

--- a/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
@@ -72,6 +72,8 @@ describe("Codex app-server main thread cleanup", () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const requests: Array<{ method: string; params: unknown }> = [];
+    const turnStarted = createDeferred<void>();
+    const abort = new AbortController();
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     const request = vi.fn(async (method: string, params?: unknown) => {
       requests.push({ method, params });
@@ -79,6 +81,7 @@ describe("Codex app-server main thread cleanup", () => {
         return threadStartResult();
       }
       if (method === "turn/start") {
+        turnStarted.resolve();
         return turnStartResult();
       }
       return {};
@@ -98,23 +101,32 @@ describe("Codex app-server main thread cleanup", () => {
     });
 
     const run = runCodexAppServerAttempt(
-      { ...createParams(sessionFile, workspaceDir), contextEngine },
+      { ...createParams(sessionFile, workspaceDir), contextEngine, abortSignal: abort.signal },
       { bindingStore: testCodexAppServerBindingStore, clientFactory },
     );
-    await vi.waitFor(() => expect(requests.map((entry) => entry.method)).toContain("turn/start"), {
-      interval: 1,
-      timeout: 5_000,
-    });
-    await notify({
-      method: "turn/completed",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        turn: { id: "turn-1", status: "completed" },
-      },
-    });
-
-    const result = await run;
+    let result: Awaited<typeof run>;
+    try {
+      // Cold preparation has no five-second contract. Wait for the native request,
+      // but surface an early run failure instead of leaving its promise unobserved.
+      await Promise.race([
+        turnStarted.promise,
+        run.then(() => {
+          throw new Error("Codex attempt completed before requesting a turn");
+        }),
+      ]);
+      await notify({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "completed" },
+        },
+      });
+      result = await run;
+    } finally {
+      abort.abort();
+      await run.catch(() => undefined);
+    }
     expect(readAttemptTerminal(result).aborted).toBe(false);
     const firstBinding = await readCodexAppServerBinding(sessionFile);
     expect({

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -118,6 +118,7 @@ import {
   testCodexAppServerBindingStore,
   writeCodexAppServerBinding,
 } from "./session-binding.test-helpers.js";
+import * as settledTurnContext from "./settled-turn-context.js";
 import * as sharedClientModule from "./shared-client.js";
 import type { CodexAppServerClientOptions } from "./shared-client.js";
 import { attachSqliteSessionTarget } from "./sqlite-session.test-helpers.js";
@@ -4931,6 +4932,12 @@ describe("runCodexAppServerAttempt", () => {
     [
       { label: "completed turn", failure: undefined, expectedContext: true },
       {
+        label: "preserve-only host-auth turn",
+        failure: undefined,
+        expectedContext: true,
+        preserveNativeModel: true,
+      },
+      {
         label: "provider overload after the tool result",
         failure: {
           message: "Selected model is at capacity. Please try a different model.",
@@ -4959,14 +4966,42 @@ describe("runCodexAppServerAttempt", () => {
     ),
   )(
     "preserves settled finalization eligibility for a $scenario.label (oversized history: $oversizedHistory)",
-    async ({ scenario: { failure, expectedContext }, oversizedHistory }) => {
+    async ({ scenario, oversizedHistory }) => {
+      const { failure, expectedContext } = scenario;
+      const preserveNativeModel = "preserveNativeModel" in scenario;
       const storePath = path.join(tempDir, "settled-finalization-context.sqlite");
       const sessionId = "session-settled-finalization-context";
       const sessionFile = `agent:main:${sessionId}`;
       const workspaceDir = path.join(tempDir, "workspace-settled-finalization-context");
-      const harness = createStartedThreadHarness();
+      const sourceSelection = { model: "gpt-5.6-luna", modelProvider: "openai" };
+      const onStart = vi.fn();
+      const harness = createStartedThreadHarness(
+        async (method) =>
+          method === "thread/start" || method === "thread/resume"
+            ? { ...threadStartResult(), ...sourceSelection }
+            : undefined,
+        { onStart, ...(preserveNativeModel ? { persistedThreads: ["thread-1"] } : {}) },
+      );
       const params = createParams(sessionFile, workspaceDir);
+      params.modelId = "synthetic-outer-model";
+      params.authProfileStore = {
+        version: 1,
+        order: { openai: ["openai:ordered"] },
+        profiles: {
+          "openai:ordered": { type: "api_key", provider: "openai", key: "synthetic-ordered-key" },
+          "openai:binding": { type: "api_key", provider: "openai", key: "synthetic-binding-key" },
+        },
+      };
       await attachSqliteSessionTarget(params, storePath, sessionId);
+      if (preserveNativeModel) {
+        registerCodexTestSessionIdentity(sessionFile, params.sessionId, params.sessionKey);
+        await writeExistingBinding(sessionFile, workspaceDir, {
+          threadId: "thread-1",
+          model: "synthetic-previous-model",
+          preserveNativeModel: true,
+          authProfileId: "openai:binding",
+        });
+      }
       if (oversizedHistory) {
         for (let index = 0; index < 201; index += 1) {
           await appendSqliteHistoryMessage(
@@ -5017,7 +5052,22 @@ describe("runCodexAppServerAttempt", () => {
         await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
       }
       const result = await run;
+      const selectedProfile = preserveNativeModel ? "openai:binding" : "openai:ordered";
+      expect(onStart).toHaveBeenCalledWith(selectedProfile, expect.anything(), expect.anything());
+      if (preserveNativeModel) {
+        expectResumeRequest(harness.requests, { threadId: "thread-1" });
+        const resume = harness.requests.find((request) => request.method === "thread/resume");
+        expect(resume?.params).not.toHaveProperty("model");
+        await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
+          preserveNativeModel: true,
+          authProfileId: selectedProfile,
+          ...sourceSelection,
+        });
+      }
       expect(Boolean(readAttemptTerminal(result).promptError)).toBe(Boolean(failure));
+      if (!failure) {
+        expect(result.terminal).toEqual({ kind: "ok" });
+      }
       expect(Boolean(result.settledTurnFinalizationContext)).toBe(expectedContext);
       expect(result.currentAttemptAssistant).toBeDefined();
       expect(result.replayMetadata).toMatchObject({
@@ -5035,6 +5085,7 @@ describe("runCodexAppServerAttempt", () => {
       } else if (result.settledTurnFinalizationContext) {
         expect(result.settledTurnFinalizationContext).toMatchObject({
           source: "harness",
+          selection: { ...sourceSelection, authProfileId: selectedProfile },
           data: [
             expect.objectContaining({ role: "user" }),
             expect.objectContaining({ type: "function_call" }),
@@ -7313,6 +7364,15 @@ describe("runCodexAppServerAttempt", () => {
       params.modelId = "claude-opus-4-6";
       params.model = createCodexTestModel("anthropic");
       params.fastMode = true;
+      await attachSqliteSessionTarget(
+        params,
+        path.join(tempDir, "supervised-settlement.sqlite"),
+        params.sessionId,
+      );
+      await appendSqliteHistoryMessage(params, userMessage("Preserve the prior conversation.", 1));
+      const priorTranscript = await readTranscriptMessagesByIdentity(params);
+      const capture = vi.spyOn(settledTurnContext, "captureCodexSettledTurnFinalizationContext");
+      const warn = vi.spyOn(embeddedAgentLog, "warn");
       setCodexTestModelSupportsTools(params, false);
       params.config = {
         ...params.config,
@@ -7338,15 +7398,64 @@ describe("runCodexAppServerAttempt", () => {
             throw new Error("Codex attempt ended before turn/start", { cause: result });
           }),
         ]);
+        for (const method of ["item/started", "item/completed"]) {
+          harness.send({
+            method,
+            params: {
+              threadId: "thread-existing",
+              turnId: "turn-1",
+              item: {
+                type: "commandExecution",
+                id: "settled-supervised-command",
+                command: "printf synthetic-completed-work",
+                cwd: workspaceDir,
+                status: method === "item/started" ? "inProgress" : "completed",
+                ...(method === "item/completed"
+                  ? { aggregatedOutput: "synthetic-completed-work", exitCode: 0 }
+                  : {}),
+              },
+            },
+          });
+        }
         harness.send({
           method: "turn/completed",
           params: { threadId: "thread-existing", turn: { id: "turn-1", status: "completed" } },
         });
-        expect(readAttemptTerminal(await run)).toMatchObject({
-          aborted: false,
-          timedOut: false,
-          promptError: null,
+        const result = await run;
+        expect(result.terminal).toEqual({ kind: "ok" });
+        expect(result.settledTurnFinalizationContext).toEqual({ source: "unavailable" });
+        expect(Object.isFrozen(result.settledTurnFinalizationContext)).toBe(true);
+        expect(capture).not.toHaveBeenCalled();
+        expect(warn).toHaveBeenCalledWith(
+          "codex settled-turn finalization context is unavailable",
+          expect.objectContaining({
+            runId: params.runId,
+            threadId: "thread-existing",
+            turnId: "turn-1",
+            reason: "native_auth_finalization_unsupported",
+          }),
+        );
+        expect(result.messagesSnapshot).toContainEqual(
+          expect.objectContaining({
+            role: "toolResult",
+            toolCallId: "settled-supervised-command",
+            isError: false,
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                type: "toolResult",
+                text: "synthetic-completed-work",
+              }),
+            ]),
+          }),
+        );
+        expect(result.replayMetadata).toMatchObject({
+          hadPotentialSideEffects: true,
+          replaySafe: false,
         });
+        const transcript = await readTranscriptMessagesByIdentity(params);
+        expect(transcript.slice(0, priorTranscript.length)).toEqual(priorTranscript);
+        expect(transcript).toContainEqual(expect.objectContaining({ role: "toolResult" }));
+        expect(requests.filter(({ method }) => method === "turn/start")).toHaveLength(1);
       } finally {
         start.mockRestore();
         await harness.client.closeAndWait();

--- a/extensions/codex/src/app-server/session-history.test.ts
+++ b/extensions/codex/src/app-server/session-history.test.ts
@@ -208,6 +208,7 @@ describe("readCodexMirroredSessionHistoryMessages", () => {
           ...sessionTarget,
           sessionTarget,
           sessionFile: marker,
+          model: "gpt-5.6-luna",
           settledMessages,
           mirroredMessages: settledMessages,
           turnId: "settled",

--- a/extensions/codex/src/app-server/settled-turn-context.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-context.test.ts
@@ -66,6 +66,9 @@ async function captureContext(params: {
   mirroredMessages: AgentMessage[];
   settledMessages: AgentMessage[];
   turnId?: string;
+  model?: string;
+  modelProvider?: string;
+  authProfileId?: string;
 }) {
   mocks.readHistory.mockImplementation(
     (_target, read: (messages: Iterable<AgentMessage>) => unknown) => read(params.historyMessages),
@@ -76,6 +79,9 @@ async function captureContext(params: {
     mirroredMessages: params.mirroredMessages,
     settledMessages: params.settledMessages,
     turnId: params.turnId ?? "turn-2",
+    model: params.model ?? "gpt-5.6-luna",
+    modelProvider: params.modelProvider,
+    authProfileId: params.authProfileId,
   });
 }
 
@@ -84,34 +90,67 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
     mocks.readHistory.mockReset();
   });
 
-  it("freezes the complete active branch exactly through the current tool-result boundary", async () => {
-    const prior = message({ role: "user", content: "Alice is the recipient." }, "turn-1:prompt");
-    const settledMessages = settledTurn();
-    const later = message({ role: "user", content: "later message" }, "turn-3:prompt");
-    const historyMessages = [prior, ...settledMessages, later];
+  it.each([undefined, "openai"])(
+    "freezes source selection and the exact settled branch (provider: %s)",
+    async (modelProvider) => {
+      const prior = message({ role: "user", content: "Alice is the recipient." }, "turn-1:prompt");
+      const settledMessages = settledTurn();
+      const later = message({ role: "user", content: "later message" }, "turn-3:prompt");
+      const historyMessages = [prior, ...settledMessages, later];
+      const selection = { model: "gpt-5.6-luna", modelProvider, authProfileId: "openai:captured" };
 
-    const context = await captureContext({
-      historyMessages,
-      mirroredMessages: settledMessages,
-      settledMessages,
-      turnId: "turn-2",
-    });
+      const context = await captureContext({
+        historyMessages,
+        mirroredMessages: settledMessages,
+        settledMessages,
+        turnId: "turn-2",
+        ...selection,
+      });
 
-    Object.assign(prior, { content: "changed after capture" });
-    expect(context?.data).toEqual([
-      {
-        type: "message",
-        role: "user",
-        content: [{ type: "input_text", text: "Alice is the recipient." }],
-      },
-      { type: "message", role: "user", content: [{ type: "input_text", text: "Send it." }] },
-      { type: "function_call", call_id: "call-2", name: "message", arguments: "{}" },
-      { type: "function_call_output", call_id: "call-2", output: "sent" },
-    ]);
-    expect(Object.isFrozen(context)).toBe(true);
-    expect(Object.isFrozen(context?.data)).toBe(true);
-    expect(Object.isFrozen(context?.data[0])).toBe(true);
-  });
+      Object.assign(prior, { content: "changed after capture" });
+      Object.assign(selection, { model: "changed-model", authProfileId: "openai:changed" });
+      expect(context?.data).toEqual([
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Alice is the recipient." }],
+        },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "Send it." }] },
+        { type: "function_call", call_id: "call-2", name: "message", arguments: "{}" },
+        { type: "function_call_output", call_id: "call-2", output: "sent" },
+      ]);
+      expect(context?.selection).toEqual({
+        model: "gpt-5.6-luna",
+        modelProvider,
+        authProfileId: "openai:captured",
+      });
+      expect(Object.isFrozen(context)).toBe(true);
+      expect(Object.isFrozen(context?.data)).toBe(true);
+      expect(Object.isFrozen(context?.data[0])).toBe(true);
+      expect(Object.isFrozen(context?.selection)).toBe(true);
+    },
+  );
+
+  it.each([undefined, ""])(
+    "refuses missing model %j without reading transcript evidence",
+    async (model) => {
+      const messages = settledTurn();
+      mocks.readHistory.mockImplementation(
+        (_target, read: (messages: Iterable<AgentMessage>) => unknown) => read(messages),
+      );
+      await expect(
+        captureCodexSettledTurnFinalizationContext({
+          sessionFile: "/tmp/session.jsonl",
+          sessionId: "session-1",
+          mirroredMessages: messages,
+          settledMessages: messages,
+          turnId: "turn-2",
+          model,
+        }),
+      ).resolves.toBeUndefined();
+      expect(mocks.readHistory).not.toHaveBeenCalled();
+    },
+  );
 
   it("refuses unannotated host prompts even with the same durable key and adjacent native messages", async () => {
     const turn = settledHostPromptTurn();
@@ -200,6 +239,7 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
       captureCodexSettledTurnFinalizationContext({
         sessionFile: "/tmp/session.jsonl",
         sessionId: "session-1",
+        model: "gpt-5.6-luna",
         mirroredMessages: settledTurn(),
         settledMessages: settledTurn(),
         turnId: "turn-2",
@@ -238,6 +278,7 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
       captureCodexSettledTurnFinalizationContext({
         sessionFile: "/tmp/session.jsonl",
         sessionId: "session-1",
+        model: "gpt-5.6-luna",
         mirroredMessages: settledMessages,
         settledMessages,
         turnId: "turn-2",

--- a/extensions/codex/src/app-server/settled-turn-context.ts
+++ b/extensions/codex/src/app-server/settled-turn-context.ts
@@ -21,12 +21,22 @@ function freezeProjection(value: JsonValue): void {
   }
 }
 
+type CodexSettledTurnSelection = {
+  model: string;
+  modelProvider?: string;
+  authProfileId?: string;
+};
+
 /** Only the Codex owner interprets this bounded, detached replay projection. */
 export class CodexSettledTurnContext {
   readonly source = "harness";
 
-  constructor(readonly data: JsonValue[]) {
+  constructor(
+    readonly data: JsonValue[],
+    readonly selection: CodexSettledTurnSelection,
+  ) {
     freezeProjection(data);
+    Object.freeze(selection);
     Object.freeze(this);
   }
 }
@@ -110,14 +120,21 @@ function* verifiedSettledMessages(
 
 /** Verifies and freezes a complete replay projection while reading the active branch. */
 export async function captureCodexSettledTurnFinalizationContext(
-  params: CodexMirroredSessionHistoryTarget & SettledTurnMessages,
+  params: CodexMirroredSessionHistoryTarget &
+    SettledTurnMessages &
+    Partial<CodexSettledTurnSelection>,
 ): Promise<CodexSettledTurnContext | undefined> {
   try {
+    const { model, modelProvider, authProfileId } = params;
+    if (!model) {
+      throw new Error("Codex settled-turn model selection is unavailable");
+    }
     return await readCodexMirroredSessionHistory(
       params,
       (messages) =>
         new CodexSettledTurnContext(
           projectSettledCodexMessages(verifiedSettledMessages(messages, params)),
+          { model, modelProvider, authProfileId },
         ),
     );
   } catch (error) {

--- a/extensions/codex/src/app-server/settled-turn-finalizer.native.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.native.test.ts
@@ -1,0 +1,755 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { AuthProfileStore } from "openclaw/plugin-sdk/agent-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { readVisibleSessionTranscriptMessageEntries } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { describe, expect, it, vi, type MockInstance } from "vitest";
+import * as authBridge from "./auth-bridge.js";
+import { runBoundedCodexAppServerTurn } from "./bounded-turn.js";
+import { CodexAppServerClient } from "./client.js";
+import { resolveCodexSupervisionAppServerRuntimeOptions } from "./config.js";
+import { dynamicToolBuildState } from "./dynamic-tool-build-state.js";
+import { createCodexNativeTestState } from "./native-app-server.test-support.js";
+import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
+import { assertCodexThreadStartResponse } from "./protocol-validators.js";
+import { isJsonObject, type JsonObject } from "./protocol.js";
+import {
+  createCodexRuntimePlanFixture,
+  createNativeRunParams,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+} from "./run-attempt-test-harness.js";
+import {
+  readCodexAppServerBinding,
+  registerCodexTestSessionIdentity,
+  seedCodexTestBinding,
+} from "./session-binding.test-helpers.js";
+import * as settledContext from "./settled-turn-context.js";
+import { runCodexSettledTurnFinalization } from "./settled-turn-finalizer.js";
+import * as sharedClients from "./shared-client.js";
+import type { CodexAppServerClientFactory } from "./shared-client.js";
+import { attachSqliteSessionTarget } from "./sqlite-session.test-helpers.js";
+import { CODEX_APP_SERVER_VERSION } from "./version.js";
+
+setupRunAttemptTestHooks();
+
+// Same native multi-agent generation keeps model-selection proof separate from migration.
+const NATIVE_MODEL = "gpt-5.6-sol";
+const HOST_MODEL = "gpt-5.6-terra";
+const NATIVE_KEY = "synthetic-native-account";
+const HOST_KEY = "synthetic-host-account";
+const HOST_PROFILE = "openai:host-fixture";
+const OTHER_PROFILE = "openai:other-fixture";
+const SUMMARY = "The action completed once.";
+
+type NativeFixture = Awaited<ReturnType<typeof createNativeFixture>>;
+type NativeRunParams = ReturnType<typeof createNativeRunParams>;
+type Cleanup = () => Promise<void>;
+type NativePhase = "probe" | "action" | "summary" | "health";
+
+async function closeNativeClient(client: CodexAppServerClient): Promise<void> {
+  expect(await client.closeAndWait()).toBe(true);
+}
+
+async function createNativeFixture(cleanups: Cleanup[], failures: unknown[]) {
+  const root = await fs.realpath(tempDir);
+  const native = await createCodexNativeTestState(root);
+  for (const [name, value] of Object.entries(native.env)) {
+    if (value !== undefined) {
+      vi.stubEnv(name, value);
+    }
+  }
+  const requests: Array<{ body: JsonObject; account: string | undefined }> = [];
+  let phase: NativePhase = "probe";
+  let actionRequests = 0;
+  const server = http.createServer((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      try {
+        if (request.url !== "/v1/responses" || request.method !== "POST") {
+          response.writeHead(404).end();
+          return;
+        }
+        const parsed: unknown = JSON.parse(body);
+        if (!isJsonObject(parsed)) {
+          response.writeHead(400).end();
+          return;
+        }
+        const account = request.headers.authorization;
+        requests.push({ body: parsed, account });
+        if (account !== `Bearer ${NATIVE_KEY}` && account !== `Bearer ${HOST_KEY}`) {
+          response.writeHead(401).end();
+          return;
+        }
+        if (parsed.model !== NATIVE_MODEL && parsed.model !== HOST_MODEL) {
+          response.writeHead(400).end();
+          return;
+        }
+        if (phase === "action") {
+          actionRequests += 1;
+        }
+        const item =
+          phase === "action"
+            ? actionRequests === 1
+              ? {
+                  type: "function_call",
+                  call_id: "completed-action",
+                  name: "exec_command",
+                  arguments: JSON.stringify({
+                    cmd: "printf 'completed-once\\n' >> completed-actions.txt; cat completed-actions.txt",
+                    shell: "/bin/sh",
+                    login: false,
+                    max_output_tokens: 1000,
+                  }),
+                }
+              : undefined
+            : {
+                type: "message",
+                role: "assistant",
+                id: `answer-${requests.length}`,
+                content: [{ type: "output_text", text: phase === "summary" ? SUMMARY : "Ready." }],
+              };
+        const events = [
+          { type: "response.created", response: { id: `response-${requests.length}` } },
+          ...(item ? [{ type: "response.output_item.done", item }] : []),
+          {
+            type: "response.completed",
+            response: {
+              id: `response-${requests.length}`,
+              usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+            },
+          },
+        ];
+        response.writeHead(200, { "Content-Type": "text/event-stream" });
+        response.end(
+          events
+            .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+            .join(""),
+        );
+      } catch (error) {
+        failures.push(error);
+        response.writeHead(500).end();
+      }
+    });
+  });
+  cleanups.push(async () => {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Loopback provider has no TCP address");
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+  const agentDir = path.join(root, "agent");
+  const authProfileStore: AuthProfileStore = {
+    version: 1,
+    profiles: {
+      [HOST_PROFILE]: { type: "api_key", provider: "openai", key: HOST_KEY },
+      [OTHER_PROFILE]: { type: "api_key", provider: "openai", key: NATIVE_KEY },
+    },
+  };
+  const pluginConfig = {
+    supervision: { enabled: true },
+    appServer: {
+      command: native.command,
+      args: ["app-server", "-c", `openai_base_url=${JSON.stringify(baseUrl)}`],
+      homeScope: "user" as const,
+    },
+  };
+  return {
+    native,
+    root,
+    agentDir,
+    baseUrl,
+    pluginConfig,
+    authProfileStore,
+    requests,
+    marker: path.join(native.cwd, "completed-actions.txt"),
+    setPhase(next: NativePhase) {
+      phase = next;
+      requests.length = 0;
+      actionRequests = 0;
+    },
+  };
+}
+
+async function withNativeFixture(
+  run: (fixture: NativeFixture, cleanups: Cleanup[]) => Promise<void>,
+): Promise<void> {
+  const cleanups: Cleanup[] = [];
+  const failures: unknown[] = [];
+  try {
+    await run(await createNativeFixture(cleanups, failures), cleanups);
+  } catch (error) {
+    failures.push(error);
+  } finally {
+    // Join children before the shared harness afterEach removes their homes.
+    for (const cleanup of cleanups.toReversed()) {
+      try {
+        await cleanup();
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+  }
+  if (failures.length) {
+    throw new AggregateError(failures, "Native finalization proof or cleanup failed");
+  }
+}
+
+async function writeNativeConfig(
+  fixture: NativeFixture,
+  codexHome: string,
+  provider: "openai" | "settled-fixture",
+  nativeFileAuth = false,
+) {
+  await fs.mkdir(codexHome, { recursive: true });
+  await fs.writeFile(
+    path.join(codexHome, "config.toml"),
+    [
+      `model=${JSON.stringify(NATIVE_MODEL)}`,
+      `model_provider=${JSON.stringify(provider)}`,
+      `cli_auth_credentials_store=${JSON.stringify(nativeFileAuth ? "file" : "ephemeral")}`,
+      'web_search="disabled"',
+      'approval_policy="never"',
+      'sandbox_mode="workspace-write"',
+      "allow_login_shell=false",
+      "[features]",
+      "shell_snapshot=false",
+      "[analytics]",
+      "enabled=false",
+      "[feedback]",
+      "enabled=false",
+      ...(provider === "settled-fixture"
+        ? [
+            "[model_providers.settled-fixture]",
+            'name="Synthetic settled-turn provider"',
+            `base_url=${JSON.stringify(fixture.baseUrl)}`,
+            'wire_api="responses"',
+            "requires_openai_auth=false",
+            `experimental_bearer_token=${JSON.stringify(NATIVE_KEY)}`,
+            "supports_websockets=false",
+            "request_max_retries=0",
+            "stream_max_retries=0",
+          ]
+        : []),
+    ].join("\n"),
+  );
+  if (nativeFileAuth) {
+    await fs.writeFile(
+      path.join(codexHome, "auth.json"),
+      JSON.stringify({ OPENAI_API_KEY: NATIVE_KEY }),
+    );
+  }
+}
+
+async function runNativePrompt(client: CodexAppServerClient, threadId: string, prompt: string) {
+  const completed = createDeferred<{ id: string; status: string }>();
+  void completed.promise.catch(() => undefined);
+  const removeHandler = client.addNotificationHandler((notification) => {
+    if (
+      notification.method === "turn/completed" &&
+      isJsonObject(notification.params) &&
+      notification.params.threadId === threadId &&
+      isJsonObject(notification.params.turn) &&
+      typeof notification.params.turn.id === "string" &&
+      typeof notification.params.turn.status === "string"
+    ) {
+      completed.resolve({
+        id: notification.params.turn.id,
+        status: notification.params.turn.status,
+      });
+    }
+  });
+  const timer = setTimeout(
+    () => completed.reject(new Error("Native fixture turn timed out")),
+    15_000,
+  );
+  timer.unref?.();
+  try {
+    await client.request(
+      "turn/start",
+      { threadId, input: [{ type: "text", text: prompt, text_elements: [] }] },
+      { timeoutMs: 15_000 },
+    );
+    const turn = await completed.promise;
+    expect(turn.status).toBe("completed");
+    return turn.id;
+  } finally {
+    clearTimeout(timer);
+    removeHandler();
+  }
+}
+
+async function createRunParams(fixture: NativeFixture) {
+  const params = createNativeRunParams(
+    path.join(fixture.root, "session.jsonl"),
+    fixture.native.cwd,
+  );
+  await attachSqliteSessionTarget(
+    params,
+    path.join(fixture.root, "transcript.sqlite"),
+    "settled-native",
+  );
+  params.agentDir = fixture.agentDir;
+  params.prompt = "Record the completed action once.";
+  params.provider = "openai";
+  params.modelId = NATIVE_MODEL;
+  params.model = { ...params.model, id: NATIVE_MODEL, provider: "openai", api: "openai-responses" };
+  params.authProfileId = HOST_PROFILE;
+  params.authProfileStore = fixture.authProfileStore;
+  params.resolvedApiKey = HOST_KEY;
+  params.disableTools = false;
+  params.permissionMode = "full";
+  params.timeoutMs = 20_000;
+  params.config = { tools: { web: { search: { enabled: false } } } };
+  dynamicToolBuildState.openClawCodingToolsFactory = () => [];
+  registerCodexTestSessionIdentity(params.sessionFile, params.sessionId, params.sessionKey);
+  return params;
+}
+
+function usePreparedApiKey(params: NativeRunParams, baseUrl: string) {
+  const runtimePlan = createCodexRuntimePlanFixture();
+  params.runtimePlan = {
+    ...runtimePlan,
+    auth: {
+      ...runtimePlan.auth,
+      providerForAuth: "openai",
+      authProfileProviderForAuth: "openai",
+      selectedAuthMode: "api-key",
+      modelRoute: {
+        provider: "openai",
+        modelId: params.modelId,
+        api: "openai-responses",
+        baseUrl,
+        authRequirement: "api-key",
+        requestTransportOverrides: "none",
+      },
+    },
+  };
+}
+
+function transcriptTarget(params: NativeRunParams) {
+  return {
+    agentId: "main",
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey!,
+    storePath: params.sessionTarget!.storePath,
+  };
+}
+
+function trackSharedClient(cleanups: Cleanup[]) {
+  let current: CodexAppServerClient | undefined;
+  const factory: CodexAppServerClientFactory = async (options) => {
+    const client = await sharedClients.getLeasedSharedCodexAppServerClient(options);
+    if (client !== current) {
+      cleanups.push(async () => {
+        await sharedClients.clearSharedCodexAppServerClientIfCurrentAndWait(client);
+        await closeNativeClient(client);
+      });
+      current = client;
+    }
+    return client;
+  };
+  return {
+    factory,
+    client() {
+      if (!current) {
+        throw new Error("The native attempt did not acquire its shared client");
+      }
+      return current;
+    },
+  };
+}
+
+// Admission and binding seeding are fixtures, not Gateway/catalog or live OAuth
+// proof. Native execution, host auth, settlement, and transcript writes are real;
+// every model HTTP response comes from the isolated loopback provider.
+// This fixture executes /bin/sh; the owner-boundary unit tests are platform-independent.
+describe.skipIf(process.platform === "win32")(
+  "stock Codex settled-turn finalization ownership",
+  () => {
+    it(
+      "refuses supervised finalization even when different host credentials and model work",
+      { timeout: 60_000 },
+      async () => {
+        await withNativeFixture(async (fixture, cleanups) => {
+          const { native, pluginConfig, agentDir, requests, authProfileStore } = fixture;
+          await writeNativeConfig(fixture, native.codexHome, "settled-fixture");
+          // A successful private turn makes wrong-account fallback an available path,
+          // rather than letting this regression pass only because host auth is broken.
+          const hostProbe = await runBoundedCodexAppServerTurn({
+            model: { mode: "required", id: HOST_MODEL },
+            profile: HOST_PROFILE,
+            authProfileStore,
+            agentDir,
+            timeoutMs: 15_000,
+            options: { pluginConfig },
+            taskLabel: "host auth proof",
+            developerInstructions: "Reply Ready.",
+            input: [{ type: "text", text: "Verify the host account.", text_elements: [] }],
+            requiredModalities: ["text"],
+            isolation: "private-stdio",
+            requireNoExternalCapabilities: true,
+          });
+          expect(hostProbe.text).toBe("Ready.");
+          expect(requests.map(({ body, account }) => ({ model: body.model, account }))).toEqual([
+            { model: HOST_MODEL, account: `Bearer ${HOST_KEY}` },
+          ]);
+          fixture.setPhase("probe");
+          const appServer = resolveCodexSupervisionAppServerRuntimeOptions({ pluginConfig });
+          const sourceClient = await sharedClients.createIsolatedCodexAppServerClient({
+            startOptions: appServer.start,
+            authProfileId: null,
+            agentDir,
+            config: {},
+            timeoutMs: 15_000,
+          });
+          cleanups.push(() => closeNativeClient(sourceClient));
+          expect(sourceClient.getRuntimeIdentity()?.serverVersion).toBe(CODEX_APP_SERVER_VERSION);
+          const source = assertCodexThreadStartResponse(
+            await sourceClient.request(
+              "thread/start",
+              { cwd: native.cwd, dynamicTools: [] },
+              { timeoutMs: 15_000 },
+            ),
+          );
+          expect(source.model).toBe(NATIVE_MODEL);
+          expect(source.modelProvider).toBe("settled-fixture");
+          const sourceTurnId = await runNativePrompt(
+            sourceClient,
+            source.thread.id,
+            "Initialize the source.",
+          );
+          await sourceClient.request(
+            "thread/unsubscribe",
+            { threadId: source.thread.id },
+            { timeoutMs: 15_000 },
+          );
+          await closeNativeClient(sourceClient);
+
+          const params = await createRunParams(fixture);
+          params.modelId = HOST_MODEL;
+          params.model = { ...params.model, id: HOST_MODEL };
+          usePreparedApiKey(params, fixture.baseUrl);
+          seedCodexTestBinding(params.sessionFile, {
+            threadId: source.thread.id,
+            cwd: native.cwd,
+            connectionScope: "supervision",
+            supervisionSourceThreadId: source.thread.id,
+            model: source.model,
+            modelProvider: source.modelProvider ?? undefined,
+            preserveNativeModel: true,
+            conversationSourceTransferComplete: true,
+            pendingSupervisionBranch: {
+              sourceThreadId: source.thread.id,
+              lastTurnId: sourceTurnId,
+              connectionFingerprint: buildCodexAppServerConnectionFingerprint(appServer, agentDir),
+            },
+            appServerRuntimeFingerprint: buildCodexAppServerConnectionFingerprint(
+              appServer,
+              agentDir,
+            ),
+          });
+          const captureContext = vi.spyOn(
+            settledContext,
+            "captureCodexSettledTurnFinalizationContext",
+          );
+          const warn = vi.spyOn(embeddedAgentLog, "warn");
+          const shared = trackSharedClient(cleanups);
+          fixture.setPhase("action");
+          const settledAttempt = await runCodexAppServerAttempt(params, {
+            pluginConfig,
+            clientFactory: shared.factory,
+            nativeHookRelay: { enabled: false },
+          });
+          const client = shared.client();
+          expect(settledAttempt.terminal).toEqual({ kind: "ok" });
+          expect(settledAttempt.messagesSnapshot).toContainEqual(
+            expect.objectContaining({
+              role: "toolResult",
+              toolCallId: "completed-action",
+              isError: false,
+            }),
+          );
+          expect(await fs.readFile(fixture.marker, "utf8")).toBe("completed-once\n");
+          expect(requests.map(({ body, account }) => ({ model: body.model, account }))).toEqual([
+            { model: NATIVE_MODEL, account: `Bearer ${NATIVE_KEY}` },
+            { model: NATIVE_MODEL, account: `Bearer ${NATIVE_KEY}` },
+          ]);
+          const context = settledAttempt.settledTurnFinalizationContext;
+          const sibling = assertCodexThreadStartResponse(
+            await client.request(
+              "thread/start",
+              { cwd: native.cwd, ephemeral: true, dynamicTools: [] },
+              { timeoutMs: 15_000 },
+            ),
+          );
+          const before = structuredClone({
+            terminal: settledAttempt.terminal,
+            messages: settledAttempt.messagesSnapshot,
+            tools: settledAttempt.toolMetas,
+            lifecycle: settledAttempt.itemLifecycle,
+            replay: settledAttempt.replayMetadata,
+          });
+          const bindingBefore = structuredClone(
+            await readCodexAppServerBinding(params.sessionFile),
+          );
+          const transcriptBefore = await readVisibleSessionTranscriptMessageEntries(
+            transcriptTarget(params),
+          );
+          const sourceIsCurrent = sharedClients.captureSharedCodexAppServerCatalogLifetime(client);
+          const nativeRequests = vi.spyOn(client, "request");
+          const createClient = vi.spyOn(sharedClients, "createIsolatedCodexAppServerClient");
+          const startClient = vi.spyOn(CodexAppServerClient, "start");
+          const resolveHandoff = vi.spyOn(authBridge, "resolveCodexAppServerPreparedAuthHandoff");
+          const resolveHostProfile = vi.spyOn(
+            authBridge,
+            "resolveCodexAppServerAuthProfileIdForAgent",
+          );
+          const resolveHostStore = vi.spyOn(authBridge, "resolveCodexAppServerAuthProfileStore");
+          const applyHostAuth = vi.spyOn(authBridge, "applyCodexAppServerAuthProfile");
+          const { hostCapabilities: _hostCapabilities, ...attempt } = params;
+          fixture.setPhase("summary");
+          await expect(
+            runCodexSettledTurnFinalization(
+              {
+                attempt: { ...attempt, prompt: "Summarize the completed action." },
+                settledAttempt,
+              },
+              { pluginConfig },
+            ),
+          ).rejects.toThrow("Codex settled-turn finalization context is unavailable");
+          expect(createClient).not.toHaveBeenCalled();
+          expect(startClient).not.toHaveBeenCalled();
+          expect(resolveHandoff).not.toHaveBeenCalled();
+          expect(resolveHostProfile).not.toHaveBeenCalled();
+          expect(resolveHostStore).not.toHaveBeenCalled();
+          expect(applyHostAuth).not.toHaveBeenCalled();
+          expect(nativeRequests).not.toHaveBeenCalled();
+          expect(requests).toHaveLength(0);
+          expect(context).toEqual({ source: "unavailable" });
+          expect(Object.isFrozen(context)).toBe(true);
+          expect(captureContext).not.toHaveBeenCalled();
+          expect(warn).toHaveBeenCalledWith(
+            "codex settled-turn finalization context is unavailable",
+            expect.objectContaining({ reason: "native_auth_finalization_unsupported" }),
+          );
+          expect(settledAttempt.settledTurnFinalizationContext).toBe(context);
+          expect({
+            terminal: settledAttempt.terminal,
+            messages: settledAttempt.messagesSnapshot,
+            tools: settledAttempt.toolMetas,
+            lifecycle: settledAttempt.itemLifecycle,
+            replay: settledAttempt.replayMetadata,
+          }).toEqual(before);
+          expect(await readCodexAppServerBinding(params.sessionFile)).toEqual(bindingBefore);
+          expect(
+            await readVisibleSessionTranscriptMessageEntries(transcriptTarget(params)),
+          ).toEqual(transcriptBefore);
+          expect(sourceIsCurrent()).toBe(true);
+          expect(client.getCloseError()).toBeUndefined();
+          expect(sharedClients.releaseLeasedSharedCodexAppServerClient(client)).toBe(false);
+          await expect(
+            client.request(
+              "thread/read",
+              { threadId: source.thread.id, includeTurns: true },
+              { timeoutMs: 15_000 },
+            ),
+          ).resolves.toMatchObject({
+            thread: { id: source.thread.id },
+          });
+          fixture.setPhase("health");
+          await runNativePrompt(client, sibling.thread.id, "Confirm the sibling still works.");
+          expect(requests).toHaveLength(1);
+          expect(requests[0]?.account).toBe(`Bearer ${NATIVE_KEY}`);
+          expect(await fs.readFile(fixture.marker, "utf8")).toBe("completed-once\n");
+        });
+      },
+    );
+
+    it.for([
+      {
+        label: "ordinary prepared API key",
+        homeScope: "agent" as const,
+        preserveNativeModel: false,
+        prepared: true,
+      },
+      {
+        label: "preserveNativeModel-only host profile",
+        homeScope: "agent" as const,
+        preserveNativeModel: true,
+        prepared: false,
+      },
+      {
+        label: "ordinary user-home private host profile",
+        homeScope: "user" as const,
+        preserveNativeModel: false,
+        prepared: false,
+      },
+    ])(
+      "persists a host-authorized summary with the actual native selection ($label)",
+      { timeout: 60_000 },
+      async (scenario) => {
+        await withNativeFixture(async (fixture, cleanups) => {
+          const pluginConfig = {
+            ...fixture.pluginConfig,
+            appServer: { ...fixture.pluginConfig.appServer, homeScope: scenario.homeScope },
+          };
+          const sourceHome =
+            scenario.homeScope === "user"
+              ? fixture.native.codexHome
+              : authBridge.resolveCodexAppServerHomeDir(fixture.agentDir);
+          await writeNativeConfig(fixture, sourceHome, "openai", scenario.homeScope === "user");
+          const nativeAuthBefore =
+            scenario.homeScope === "user"
+              ? await fs.readFile(path.join(sourceHome, "auth.json"), "utf8")
+              : undefined;
+          const params = await createRunParams(fixture);
+          if (scenario.prepared) {
+            // The prepared key wins over a usable, differently authenticated profile.
+            params.authProfileId = OTHER_PROFILE;
+            usePreparedApiKey(params, fixture.baseUrl);
+          }
+          const shared = trackSharedClient(cleanups);
+          const runOptions = {
+            pluginConfig,
+            clientFactory: shared.factory,
+            nativeHookRelay: { enabled: false },
+          };
+          const initialized = await runCodexAppServerAttempt(
+            { ...params, prompt: "Initialize the source." },
+            runOptions,
+          );
+          expect(initialized.terminal).toEqual({ kind: "ok" });
+          const initialBinding = await readCodexAppServerBinding(params.sessionFile);
+          if (!initialBinding) {
+            throw new Error("The ordinary native turn did not commit its binding");
+          }
+          expect(initialBinding.model).toBe(NATIVE_MODEL);
+          expect(initialBinding.connectionScope).not.toBe("supervision");
+          if (scenario.preserveNativeModel) {
+            seedCodexTestBinding(params.sessionFile, {
+              ...initialBinding,
+              preserveNativeModel: true,
+            });
+            params.modelId = HOST_MODEL;
+            params.model = { ...params.model, id: HOST_MODEL };
+          }
+          fixture.setPhase("action");
+          params.runId = "run-settled-action";
+          const settledAttempt = await runCodexAppServerAttempt(params, runOptions);
+          expect(settledAttempt.terminal).toEqual({ kind: "ok" });
+          const context = settledAttempt.settledTurnFinalizationContext;
+          expect(context).toBeInstanceOf(settledContext.CodexSettledTurnContext);
+          expect(Object.isFrozen(context)).toBe(true);
+          const sourceKey = scenario.homeScope === "user" ? NATIVE_KEY : HOST_KEY;
+          expect(
+            fixture.requests.map(({ body, account }) => ({ model: body.model, account })),
+          ).toEqual([
+            { model: NATIVE_MODEL, account: `Bearer ${sourceKey}` },
+            { model: NATIVE_MODEL, account: `Bearer ${sourceKey}` },
+          ]);
+          expect(await fs.readFile(fixture.marker, "utf8")).toBe("completed-once\n");
+          const bindingBefore = structuredClone(
+            await readCodexAppServerBinding(params.sessionFile),
+          );
+          const transcriptBefore = await readVisibleSessionTranscriptMessageEntries(
+            transcriptTarget(params),
+          );
+          const sourceClient = shared.client();
+          const sourceRequests = vi.spyOn(sourceClient, "request");
+          const realCreateClient = sharedClients.createIsolatedCodexAppServerClient;
+          let summaryClient: CodexAppServerClient | undefined;
+          let summaryRequests: MockInstance<CodexAppServerClient["request"]> | undefined;
+          const createClient = vi
+            .spyOn(sharedClients, "createIsolatedCodexAppServerClient")
+            .mockImplementation(async (options) =>
+              realCreateClient({
+                ...options,
+                onStartedClient(client) {
+                  summaryClient = client;
+                  summaryRequests = vi.spyOn(client, "request");
+                  cleanups.push(() => closeNativeClient(client));
+                  options?.onStartedClient?.(client);
+                },
+              }),
+            );
+          fixture.setPhase("summary");
+          const { hostCapabilities: _hostCapabilities, ...attempt } = params;
+          const finalization = await runCodexSettledTurnFinalization(
+            { attempt: { ...attempt, prompt: "Summarize the completed action." }, settledAttempt },
+            { pluginConfig },
+          );
+          expect(createClient).toHaveBeenCalledOnce();
+          expect(summaryClient).not.toBe(sourceClient);
+          expect(summaryClient?.getRuntimeIdentity()?.serverVersion).toBe(CODEX_APP_SERVER_VERSION);
+          expect(sourceRequests).not.toHaveBeenCalled();
+          expect(sourceClient.getCloseError()).toBeUndefined();
+          expect(
+            fixture.requests.map(({ body, account }) => ({ model: body.model, account })),
+          ).toEqual([{ model: NATIVE_MODEL, account: `Bearer ${HOST_KEY}` }]);
+          expect(
+            summaryRequests?.mock.calls
+              .filter(([method]) => method === "account/login/start")
+              .map(([, request]) => request),
+          ).toEqual([{ type: "apiKey", apiKey: HOST_KEY }]);
+          const startCall = summaryRequests?.mock.calls.find(
+            ([method]) => method === "thread/start",
+          );
+          expect(startCall?.[1]).toMatchObject({
+            model: NATIVE_MODEL,
+            ephemeral: true,
+            environments: [],
+            dynamicTools: [],
+          });
+          expect(
+            summaryRequests?.mock.calls.filter(([method]) => method === "thread/inject_items"),
+          ).toHaveLength(1);
+          const turns = summaryRequests?.mock.calls.filter(([method]) => method === "turn/start");
+          expect(turns).toHaveLength(1);
+          expect(finalization).toMatchObject({
+            assistantTranscriptOwned: true,
+            assistant: {
+              provider: "openai",
+              model: NATIVE_MODEL,
+              api: "openai-responses",
+              content: [{ type: "text", text: SUMMARY }],
+            },
+          });
+          const transcript = await readVisibleSessionTranscriptMessageEntries(
+            transcriptTarget(params),
+          );
+          expect(transcript.slice(0, transcriptBefore.length)).toEqual(transcriptBefore);
+          expect(transcript.slice(transcriptBefore.length).map((entry) => entry.message)).toEqual([
+            finalization.assistant,
+          ]);
+          expect(await readCodexAppServerBinding(params.sessionFile)).toEqual(bindingBefore);
+          expect(await fs.readFile(fixture.marker, "utf8")).toBe("completed-once\n");
+          if (nativeAuthBefore !== undefined) {
+            expect(await fs.readFile(path.join(sourceHome, "auth.json"), "utf8")).toBe(
+              nativeAuthBefore,
+            );
+          }
+        });
+      },
+    );
+  },
+);

--- a/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
@@ -1,7 +1,9 @@
 import { normalizeUsage, type AgentHarnessV2 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import * as agentAuth from "openclaw/plugin-sdk/agent-runtime";
 import type { Model } from "openclaw/plugin-sdk/llm";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import * as authBridge from "./auth-bridge.js";
 import { CodexSettledTurnContext } from "./settled-turn-context.js";
 import { projectSettledCodexMessages } from "./settled-turn-projection.js";
 import {
@@ -14,8 +16,7 @@ const mocks = vi.hoisted(() => ({
   mirror: vi.fn(),
 }));
 
-vi.mock("./bounded-turn.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./bounded-turn.js")>()),
+vi.mock("./bounded-turn.js", () => ({
   runBoundedCodexAppServerTurn: mocks.runBounded,
 }));
 
@@ -29,30 +30,63 @@ type SettledTurnFinalizationAttemptParams = Parameters<
   NonNullable<AgentHarnessV2["finalizeSettledTurn"]>
 >[0]["attempt"];
 
-function createAttempt(): SettledTurnFinalizationAttemptParams {
+function createAttempt(
+  authRequirement?: "api-key" | "subscription",
+): SettledTurnFinalizationAttemptParams {
   return {
     prompt: "Produce the final user-visible answer now.",
     sessionId: "session-1",
     sessionKey: "agent:main:session-1",
     sessionFile: "/tmp/session.jsonl",
     workspaceDir: "/tmp/workspace",
+    agentDir: "/tmp/synthetic-finalizer-agent",
     runId: "run-1",
     timeoutMs: 5_000,
-    provider: "codex",
-    modelId: "gpt-5.4",
+    provider: "irrelevant-outer-provider",
+    modelId: "irrelevant-outer-model",
     model: {
-      id: "gpt-5.4",
-      provider: "codex",
+      id: "irrelevant-outer-model",
+      provider: "irrelevant-outer-provider",
       api: "openai-chatgpt-responses",
     } as Model,
+    authProfileId: "openai:outer",
     authStorage: {} as never,
-    authProfileStore: { version: 1, profiles: {} },
+    authProfileStore: {
+      version: 1,
+      profiles: {
+        "openai:captured": { type: "api_key", provider: "openai", key: "synthetic-captured-key" },
+        "openai:outer": { type: "api_key", provider: "openai", key: "synthetic-wrong-outer-key" },
+      },
+    },
+    runtimePlan: authRequirement
+      ? {
+          auth: {
+            providerForAuth: "openai",
+            authProfileProviderForAuth: "openai",
+            forwardedAuthProfileId: "openai:outer",
+            modelRoute: {
+              provider: "openai",
+              modelId: "irrelevant-outer-model",
+              api: "openai-responses",
+              baseUrl: "https://api.openai.com/v1",
+              authRequirement,
+              requestTransportOverrides: "none",
+            },
+          },
+          observability: { harnessId: "codex" },
+        }
+      : undefined,
     modelRegistry: {} as never,
     thinkLevel: "low",
   } as SettledTurnFinalizationAttemptParams;
 }
 
-function createSettledAttempt(): EmbeddedRunAttemptResult {
+function createSettledAttempt(
+  selection: ConstructorParameters<typeof CodexSettledTurnContext>[1] = {
+    model: "gpt-5.6-luna",
+    authProfileId: "openai:captured",
+  },
+): EmbeddedRunAttemptResult {
   return {
     terminal: { kind: "ok" },
     sessionIdUsed: "session-1",
@@ -82,6 +116,7 @@ function createSettledAttempt(): EmbeddedRunAttemptResult {
           content: [{ type: "text", text: "Message sent." }],
         } as never,
       ]),
+      selection,
     ),
     assistantTexts: [],
     toolMetas: [{ toolName: "message", replaySafe: false }],
@@ -103,25 +138,27 @@ function createSettledAttempt(): EmbeddedRunAttemptResult {
   };
 }
 
+function boundedResult() {
+  return {
+    text: "The update was sent successfully.",
+    items: [],
+    model: "synthetic-catalog-id",
+    nativeSelection: { model: "synthetic-summary-model", modelProvider: "openai" },
+    usage: { input: 5, output: 4, cacheRead: 2, cacheWrite: 1, reasoningTokens: 3, total: 12 },
+  };
+}
+
 describe("runCodexSettledTurnFinalization", () => {
   beforeEach(() => {
-    mocks.runBounded.mockReset();
-    mocks.runBounded.mockResolvedValue({
-      text: "The update was sent successfully.",
-      items: [],
-      model: "gpt-5.4",
-      usage: {
-        input: 5,
-        output: 4,
-        cacheRead: 2,
-        cacheWrite: 1,
-        reasoningTokens: 3,
-        total: 12,
-      },
-    });
+    vi.spyOn(authBridge, "resolveCodexAppServerPreparedAuthHandoff");
+    mocks.runBounded.mockReset().mockResolvedValue(boundedResult());
     mocks.mirror.mockReset();
     mocks.mirror.mockImplementation(
-      async (params: { messages: EmbeddedRunAttemptResult["messagesSnapshot"] }) => {
+      async (params: {
+        messages: EmbeddedRunAttemptResult["messagesSnapshot"];
+        assertCurrent?: () => void;
+      }) => {
+        params.assertCurrent?.();
         const assistant = params.messages[0]!;
         return {
           assistantMirrorIdentitiesOwned: ["settled-finalizer:run-1"],
@@ -139,6 +176,10 @@ describe("runCodexSettledTurnFinalization", () => {
     );
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("binds tool-result failure status into mirror attestations", () => {
     const toolResult = {
       role: "toolResult",
@@ -152,93 +193,202 @@ describe("runCodexSettledTurnFinalization", () => {
     );
   });
 
-  it("runs an isolated history-backed final turn and returns only its visible answer", async () => {
-    const attempt = createAttempt();
-    attempt.prepareAssistantTranscriptMessage = (message) => message;
-    const result = await runCodexSettledTurnFinalization(
-      { attempt, settledAttempt: createSettledAttempt() },
-      { pluginConfig: {} },
-    );
+  it.each([undefined, "openai"])(
+    "uses captured model/profile and returned native attribution (captured provider: %s)",
+    async (modelProvider) => {
+      const attempt = createAttempt();
+      attempt.prepareAssistantTranscriptMessage = (message) => message;
+      const settledAttempt = createSettledAttempt({
+        model: "gpt-5.6-luna",
+        modelProvider,
+        authProfileId: "openai:captured",
+      });
+      const settledBefore = structuredClone(settledAttempt);
+      const result = await runCodexSettledTurnFinalization(
+        { attempt, settledAttempt },
+        { pluginConfig: {} },
+      );
 
-    expect(mocks.runBounded).toHaveBeenCalledWith(
-      expect.objectContaining({
-        isolation: "private-stdio",
-        requireNoExternalCapabilities: true,
-        historyItems: [
-          expect.objectContaining({ type: "message", role: "user" }),
-          expect.objectContaining({ type: "function_call", call_id: "call-1" }),
-          expect.objectContaining({ type: "function_call_output", call_id: "call-1" }),
-        ],
-        input: [
-          {
-            type: "text",
-            text: "Produce the final user-visible answer now.",
-            text_elements: [],
+      expect(authBridge.resolveCodexAppServerPreparedAuthHandoff).toHaveBeenCalledWith(
+        expect.objectContaining({
+          homeScope: "agent",
+          authProfileId: "openai:captured",
+          authProfileStore: attempt.authProfileStore,
+        }),
+      );
+      expect(mocks.runBounded).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: { mode: "required", id: "gpt-5.6-luna" },
+          modelProvider,
+          profile: "openai:captured",
+          isolation: "private-stdio",
+          requireNoExternalCapabilities: true,
+          allowEmptyText: true,
+          historyItems: [
+            expect.objectContaining({ type: "message", role: "user" }),
+            expect.objectContaining({ type: "function_call", call_id: "call-1" }),
+            expect.objectContaining({ type: "function_call_output", call_id: "call-1" }),
+          ],
+          input: [{ type: "text", text: attempt.prompt, text_elements: [] }],
+        }),
+      );
+      expect(mocks.mirror).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: "session-1",
+          idempotencyScope: "codex-settled-finalizer:run-1",
+          skipBeforeMessageWriteHooks: true,
+          prepareAssistantTranscriptMessage: attempt.prepareAssistantTranscriptMessage,
+          messages: [
+            expect.objectContaining({
+              role: "assistant",
+              provider: "openai",
+              model: "synthetic-summary-model",
+            }),
+          ],
+        }),
+      );
+      expect(result).toMatchObject({
+        assistantTranscriptOwned: true,
+        assistantTranscriptIdempotencyKey: "codex-settled-finalizer:run-1:assistant",
+        usage: boundedResult().usage,
+        assistant: {
+          role: "assistant",
+          api: "openai-chatgpt-responses",
+          provider: "openai",
+          model: "synthetic-summary-model",
+          content: [{ type: "text", text: "The update was sent successfully." }],
+        },
+      });
+      expect(normalizeUsage(result.assistant.usage)?.reasoningTokens).toBe(3);
+      expect(structuredClone(settledAttempt)).toEqual(settledBefore);
+    },
+  );
+
+  it.each([undefined, "openai:outer"])(
+    "uses the prepared API key without resolving a profile (outer profile: %s)",
+    async (outerProfile) => {
+      const attempt = createAttempt("api-key");
+      attempt.authProfileId = outerProfile;
+      attempt.resolvedApiKey = "synthetic-resolved-api-key";
+      attempt.model = { ...attempt.model, api: "openai-responses" };
+      const resolveProfile = vi.spyOn(agentAuth, "resolveApiKeyForProfile");
+
+      const result = await runCodexSettledTurnFinalization(
+        { attempt, settledAttempt: createSettledAttempt() },
+        {},
+      );
+
+      expect(mocks.runBounded).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preparedAuth: { kind: "api-key", apiKey: "synthetic-resolved-api-key" },
+          authRequirement: "api-key",
+          authProfileStore: attempt.authProfileStore,
+        }),
+      );
+      expect(mocks.runBounded.mock.calls[0]?.[0]).not.toHaveProperty("profile");
+      expect(resolveProfile).not.toHaveBeenCalled();
+      expect(result.assistant).toMatchObject({
+        api: "openai-responses",
+        provider: "openai",
+        model: "synthetic-summary-model",
+      });
+    },
+  );
+
+  it.each(["agent", "user"])(
+    "uses the selected scoped subscription for a private side turn (ordinary home: %s)",
+    async (homeScope) => {
+      const attempt = createAttempt("subscription");
+      const token = [
+        Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+        Buffer.from(
+          JSON.stringify({
+            "https://api.openai.com/auth": { chatgpt_account_id: "synthetic-account" },
+          }),
+        ).toString("base64url"),
+        "synthetic-signature",
+      ].join(".");
+      attempt.authProfileStore.profiles["openai:captured"] = {
+        type: "token",
+        provider: "openai",
+        token,
+      };
+      const resolveProfile = vi.spyOn(agentAuth, "resolveApiKeyForProfile").mockResolvedValue({
+        apiKey: token,
+        provider: "openai",
+        profileId: "openai:captured",
+        profileType: "token",
+      });
+      const ordinaryNativeHome = homeScope === "user";
+      if (ordinaryNativeHome) {
+        attempt.runtimePlan!.auth.forwardedAuthProfileId = "openai:captured";
+      }
+      const settledAttempt = createSettledAttempt({
+        model: "gpt-5.6-luna",
+        authProfileId: ordinaryNativeHome ? undefined : "openai:captured",
+      });
+      const options = { pluginConfig: { appServer: { homeScope } } };
+
+      await runCodexSettledTurnFinalization({ attempt, settledAttempt }, options);
+
+      expect(resolveProfile).toHaveBeenCalledExactlyOnceWith({
+        store: attempt.authProfileStore,
+        profileId: "openai:captured",
+        agentDir: attempt.agentDir,
+      });
+      expect(authBridge.resolveCodexAppServerPreparedAuthHandoff).toHaveBeenCalledWith(
+        expect.objectContaining({
+          homeScope: "agent",
+          authProfileId: "openai:captured",
+          authProfileStore: attempt.authProfileStore,
+          authRequirement: "subscription",
+        }),
+      );
+      expect(mocks.runBounded).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isolation: "private-stdio",
+          options,
+          authRequirement: "subscription",
+          preparedAuth: {
+            kind: "profile",
+            profileId: "openai:captured",
+            store: attempt.authProfileStore,
+            snapshot: expect.objectContaining({
+              loginParams: {
+                type: "chatgptAuthTokens",
+                accessToken: token,
+                chatgptAccountId: "synthetic-account",
+                chatgptPlanType: null,
+              },
+            }),
           },
-        ],
-      }),
-    );
-    expect(mocks.mirror).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: "session-1",
-        idempotencyScope: "codex-settled-finalizer:run-1",
-        skipBeforeMessageWriteHooks: true,
-        prepareAssistantTranscriptMessage: attempt.prepareAssistantTranscriptMessage,
-        messages: [expect.objectContaining({ role: "assistant" })],
-      }),
-    );
-    expect(result).toMatchObject({
-      assistantTranscriptOwned: true,
-      assistantTranscriptIdempotencyKey: "codex-settled-finalizer:run-1:assistant",
-      usage: {
-        input: 5,
-        output: 4,
-        cacheRead: 2,
-        cacheWrite: 1,
-        reasoningTokens: 3,
-        total: 12,
-      },
-      assistant: {
-        role: "assistant",
-        content: [{ type: "text", text: "The update was sent successfully." }],
-      },
-    });
-    expect(result.assistant.content).toEqual([
-      { type: "text", text: "The update was sent successfully." },
-    ]);
-    expect(result.assistant.usage).toMatchObject({
-      input: 5,
-      output: 4,
-      cacheRead: 2,
-      cacheWrite: 1,
-      totalTokens: 12,
-    });
-    expect(normalizeUsage(result.assistant.usage)?.reasoningTokens).toBe(3);
-  });
+        }),
+      );
+      expect(mocks.runBounded.mock.calls[0]?.[0]).not.toHaveProperty("profile");
+    },
+  );
 
-  it("returns an empty completed final answer for lifecycle classification", async () => {
-    mocks.runBounded.mockResolvedValue({ text: " ", items: [], model: "gpt-5.4" });
+  it.each([" ", "NO_REPLY"])(
+    "returns completed-empty output with native attribution for %j without transcript mutation",
+    async (text) => {
+      mocks.runBounded.mockResolvedValue({ ...boundedResult(), text });
 
-    await expect(
-      runCodexSettledTurnFinalization(
-        { attempt: createAttempt(), settledAttempt: createSettledAttempt() },
-        {},
-      ),
-    ).resolves.toMatchObject({ assistant: { content: [{ type: "text", text: "" }] } });
-    expect(mocks.mirror).not.toHaveBeenCalled();
-  });
-
-  it("returns an intentionally silent final answer as completed empty before transcript mutation", async () => {
-    mocks.runBounded.mockResolvedValue({ text: "NO_REPLY", items: [], model: "gpt-5.4" });
-
-    await expect(
-      runCodexSettledTurnFinalization(
-        { attempt: createAttempt(), settledAttempt: createSettledAttempt() },
-        {},
-      ),
-    ).resolves.toMatchObject({ assistant: { content: [{ type: "text", text: "" }] } });
-    expect(mocks.mirror).not.toHaveBeenCalled();
-  });
+      await expect(
+        runCodexSettledTurnFinalization(
+          { attempt: createAttempt(), settledAttempt: createSettledAttempt() },
+          {},
+        ),
+      ).resolves.toMatchObject({
+        assistant: {
+          provider: "openai",
+          model: "synthetic-summary-model",
+          content: [{ type: "text", text: "" }],
+        },
+      });
+      expect(mocks.runBounded).toHaveBeenCalledOnce();
+      expect(mocks.mirror).not.toHaveBeenCalled();
+    },
+  );
 
   it("does not mutate the transcript when the bounded turn is interrupted", async () => {
     mocks.runBounded.mockRejectedValue(
@@ -254,13 +404,29 @@ describe("runCodexSettledTurnFinalization", () => {
     expect(mocks.mirror).not.toHaveBeenCalled();
   });
 
+  it.each([undefined, null])(
+    "rejects missing native provider %s instead of using outer attribution",
+    async (modelProvider) => {
+      mocks.runBounded.mockResolvedValue({
+        ...boundedResult(),
+        nativeSelection: { model: "synthetic-summary-model", modelProvider },
+      });
+      await expect(
+        runCodexSettledTurnFinalization(
+          { attempt: createAttempt(), settledAttempt: createSettledAttempt() },
+          {},
+        ),
+      ).rejects.toThrow("did not report its native model provider");
+      expect(mocks.mirror).not.toHaveBeenCalled();
+    },
+  );
+
   it.each(["commandExecution", "contextCompaction", "mcpToolCall", "futureCapabilityItem"])(
     "rejects unexpected native %s evidence before transcript mutation",
     async (type) => {
       mocks.runBounded.mockResolvedValue({
-        text: "The update was sent successfully.",
+        ...boundedResult(),
         items: [{ id: "item-1", type }],
-        model: "gpt-5.4",
       });
 
       await expect(
@@ -276,7 +442,7 @@ describe("runCodexSettledTurnFinalization", () => {
   it("accepts the exact current-turn prompt echo once", async () => {
     const attempt = createAttempt();
     mocks.runBounded.mockResolvedValue({
-      text: "The update was sent successfully.",
+      ...boundedResult(),
       items: [
         {
           id: "prompt-echo",
@@ -285,7 +451,6 @@ describe("runCodexSettledTurnFinalization", () => {
         },
         { id: "answer", type: "agentMessage", text: "The update was sent successfully." },
       ],
-      model: "gpt-5.4",
     });
 
     await expect(
@@ -294,51 +459,37 @@ describe("runCodexSettledTurnFinalization", () => {
     expect(mocks.mirror).toHaveBeenCalledOnce();
   });
 
-  it("rejects a mismatched current-turn prompt echo before transcript mutation", async () => {
-    mocks.runBounded.mockResolvedValue({
-      text: "The update was sent successfully.",
-      items: [
-        {
-          id: "prompt-echo",
-          type: "userMessage",
-          content: [{ type: "text", text: "A different prompt.", text_elements: [] }],
-        },
-      ],
-      model: "gpt-5.4",
-    });
+  it.each(["mismatched", "duplicate"])(
+    "rejects a %s current-turn prompt echo before transcript mutation",
+    async (kind) => {
+      const attempt = createAttempt();
+      const promptEcho = {
+        type: "userMessage",
+        content: [
+          {
+            type: "text",
+            text: kind === "mismatched" ? "A different prompt." : attempt.prompt,
+            text_elements: [],
+          },
+        ],
+      };
+      mocks.runBounded.mockResolvedValue({
+        ...boundedResult(),
+        items: [
+          { id: "prompt-echo-1", ...promptEcho },
+          ...(kind === "duplicate" ? [{ id: "prompt-echo-2", ...promptEcho }] : []),
+        ],
+      });
 
-    await expect(
-      runCodexSettledTurnFinalization(
-        { attempt: createAttempt(), settledAttempt: createSettledAttempt() },
-        {},
-      ),
-    ).rejects.toThrow("unexpected native item: userMessage");
-    expect(mocks.mirror).not.toHaveBeenCalled();
-  });
-
-  it("rejects a duplicate current-turn prompt echo before transcript mutation", async () => {
-    const attempt = createAttempt();
-    const promptEcho = {
-      type: "userMessage",
-      content: [{ type: "text", text: attempt.prompt, text_elements: [] }],
-    };
-    mocks.runBounded.mockResolvedValue({
-      text: "The update was sent successfully.",
-      items: [
-        { id: "prompt-echo-1", ...promptEcho },
-        { id: "prompt-echo-2", ...promptEcho },
-      ],
-      model: "gpt-5.4",
-    });
-
-    await expect(
-      runCodexSettledTurnFinalization({ attempt, settledAttempt: createSettledAttempt() }, {}),
-    ).rejects.toThrow("unexpected native item: userMessage");
-    expect(mocks.mirror).not.toHaveBeenCalled();
-  });
+      await expect(
+        runCodexSettledTurnFinalization({ attempt, settledAttempt: createSettledAttempt() }, {}),
+      ).rejects.toThrow("unexpected native item: userMessage");
+      expect(mocks.mirror).not.toHaveBeenCalled();
+    },
+  );
 
   it.each(["missing", "foreign", "unavailable"])(
-    "rejects %s context before starting the isolated turn",
+    "rejects %s context before host auth or an isolated client can be used",
     async (kind) => {
       const settledAttempt = createSettledAttempt();
       settledAttempt.settledTurnFinalizationContext =
@@ -346,14 +497,70 @@ describe("runCodexSettledTurnFinalization", () => {
           ? undefined
           : kind === "foreign"
             ? { source: "harness", data: [] }
-            : { source: "unavailable" };
+            : Object.freeze({ source: "unavailable" });
+      const before = structuredClone(settledAttempt);
+      const clientFactory = vi.fn();
       await expect(
-        runCodexSettledTurnFinalization({ attempt: createAttempt(), settledAttempt }, {}),
+        runCodexSettledTurnFinalization(
+          { attempt: createAttempt(), settledAttempt },
+          { clientFactory },
+        ),
       ).rejects.toThrow("finalization context is unavailable");
+      expect(authBridge.resolveCodexAppServerPreparedAuthHandoff).not.toHaveBeenCalled();
       expect(mocks.runBounded).not.toHaveBeenCalled();
+      expect(clientFactory).not.toHaveBeenCalled();
       expect(mocks.mirror).not.toHaveBeenCalled();
+      expect(structuredClone(settledAttempt)).toEqual(before);
     },
   );
+
+  it.each([
+    "before auth",
+    "after auth",
+    "after inference",
+    "at mirror write",
+    "after mirror write",
+  ])("rejects cancellation %s without returning a stale final answer", async (stage) => {
+    const caller = new AbortController();
+    const attempt = { ...createAttempt(), abortSignal: caller.signal };
+    const reason = new Error("finalizer cancelled");
+    if (stage === "before auth") {
+      caller.abort(reason);
+    } else if (stage === "after auth") {
+      vi.mocked(authBridge.resolveCodexAppServerPreparedAuthHandoff).mockImplementationOnce(
+        async () => {
+          caller.abort(reason);
+          return { nativeAuthProfile: false, authProfileId: "openai:captured" };
+        },
+      );
+    } else if (stage === "after inference") {
+      mocks.runBounded.mockImplementationOnce(async () => {
+        caller.abort(reason);
+        return boundedResult();
+      });
+    } else {
+      const mirror = mocks.mirror.getMockImplementation()!;
+      mocks.mirror.mockImplementationOnce(async (params) => {
+        if (stage === "at mirror write") {
+          caller.abort(reason);
+        }
+        const result = await mirror(params);
+        caller.abort(reason);
+        return result;
+      });
+    }
+
+    await expect(
+      runCodexSettledTurnFinalization({ attempt, settledAttempt: createSettledAttempt() }, {}),
+    ).rejects.toBe(reason);
+    if (stage === "before auth") {
+      expect(authBridge.resolveCodexAppServerPreparedAuthHandoff).not.toHaveBeenCalled();
+    }
+    if (stage === "before auth" || stage === "after auth") {
+      expect(mocks.runBounded).not.toHaveBeenCalled();
+    }
+    expect(mocks.mirror).toHaveBeenCalledTimes(stage.includes("mirror") ? 1 : 0);
+  });
 
   it("rejects a stale idempotency hit instead of delivering an unpersisted answer", async () => {
     mocks.mirror.mockImplementation(

--- a/extensions/codex/src/app-server/settled-turn-finalizer.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.ts
@@ -3,8 +3,10 @@ import type {
   AgentHarnessSettledTurnFinalizationResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { isSilentReplyText } from "openclaw/plugin-sdk/reply-runtime";
+import { resolveCodexAppServerPreparedAuthHandoff } from "./auth-bridge.js";
 import { runBoundedCodexAppServerTurn, type CodexBoundedTurnOptions } from "./bounded-turn.js";
-import { createAssistantMessage } from "./event-projector-assistant-message.js";
+import { createAttributedCodexAssistantMessage } from "./event-projector-assistant-message.js";
+import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import { isJsonObject, type CodexThreadItem } from "./protocol.js";
 import { CodexSettledTurnContext } from "./settled-turn-context.js";
 import {
@@ -31,16 +33,42 @@ export async function runCodexSettledTurnFinalization(
   options: CodexBoundedTurnOptions,
 ): Promise<AgentHarnessSettledTurnFinalizationResult> {
   const { attempt, settledAttempt } = operation;
+  const assertActive = () => attempt.abortSignal?.throwIfAborted();
+  assertActive();
   const finalizationContext = settledAttempt.settledTurnFinalizationContext;
   if (!(finalizationContext instanceof CodexSettledTurnContext)) {
     throw new Error("Codex settled-turn finalization context is unavailable");
   }
-  const historyItems = finalizationContext.data;
+  const { selection, data: historyItems } = finalizationContext;
+  const hostAuthPlan = attempt.runtimePlan?.auth;
+  const authRequirement = hostAuthPlan?.modelRoute?.authRequirement;
+  // Capture fixes binding/ordered-profile selection. Ordinary user-home sessions
+  // intentionally authorize private side turns through the host plan instead.
+  const authProfileId =
+    selection.authProfileId ?? hostAuthPlan?.forwardedAuthProfileId ?? attempt.authProfileId;
+  const authHandoff = await resolveCodexAppServerPreparedAuthHandoff({
+    authRequirement,
+    resolvedApiKey: attempt.resolvedApiKey,
+    authProfileId,
+    authProfileStore: attempt.authProfileStore,
+    agentDir: attempt.agentDir,
+    homeScope: "agent",
+    config: attempt.config,
+    subscriptionProfileRequiredError:
+      "Prepared Codex settled-turn finalization requires its selected OpenAI subscription profile.",
+    subscriptionProfileUnusableError:
+      "The selected OpenAI subscription profile cannot finalize this settled turn.",
+  });
+  assertActive();
+  const authSelection = authHandoff.preparedAuth
+    ? { preparedAuth: authHandoff.preparedAuth }
+    : { profile: authHandoff.authProfileId };
   const bounded = await runBoundedCodexAppServerTurn({
     config: attempt.config,
-    model: { mode: "required", id: attempt.modelId },
-    modelProvider: "openai",
-    profile: attempt.authProfileId,
+    model: { mode: "required", id: selection.model },
+    modelProvider: selection.modelProvider,
+    ...authSelection,
+    authRequirement,
     timeoutMs: attempt.runTimeoutOverrideMs ?? attempt.timeoutMs,
     signal: attempt.abortSignal,
     agentDir: attempt.agentDir,
@@ -55,6 +83,16 @@ export async function runCodexSettledTurnFinalization(
     requireNoExternalCapabilities: true,
     allowEmptyText: true,
   });
+  assertActive();
+  const { model, modelProvider } = bounded.nativeSelection;
+  if (!modelProvider) {
+    throw new Error("Codex settled-turn finalization did not report its native model provider");
+  }
+  const attribution = {
+    modelId: model,
+    provider: modelProvider,
+    api: resolveCodexLocalRuntimeAttribution(attempt).api,
+  };
   let promptEchoSeen = false;
   let unexpectedItem: CodexThreadItem | undefined;
   for (const item of bounded.items) {
@@ -85,7 +123,7 @@ export async function runCodexSettledTurnFinalization(
   const text = bounded.text.trim();
   if (!text || isSilentReplyText(text)) {
     return {
-      assistant: createAssistantMessage(attempt, "", {
+      assistant: createAttributedCodexAssistantMessage(attribution, "", {
         tokenUsage: bounded.usage,
         aborted: false,
         promptError: null,
@@ -96,7 +134,7 @@ export async function runCodexSettledTurnFinalization(
 
   const mirrorIdentity = `settled-finalizer:${attempt.runId}`;
   const assistant = attachCodexMirrorIdentity(
-    createAssistantMessage(attempt, text, {
+    createAttributedCodexAssistantMessage(attribution, text, {
       tokenUsage: bounded.usage,
       aborted: false,
       promptError: null,
@@ -104,6 +142,7 @@ export async function runCodexSettledTurnFinalization(
     mirrorIdentity,
   );
   const mirrorResult = await codexTranscriptMirrorRuntime.mirror({
+    assertCurrent: assertActive,
     sessionId: attempt.sessionId,
     sessionKey: attempt.sessionKey,
     agentId: attempt.agentId,
@@ -117,6 +156,7 @@ export async function runCodexSettledTurnFinalization(
     config: attempt.config,
     skipBeforeMessageWriteHooks: true,
   });
+  assertActive();
   const persistedMessage = mirrorResult.messagesPresent.find(
     (message) => readMirrorIdentity(message) === mirrorIdentity,
   );

--- a/extensions/codex/src/web-search-provider.test.ts
+++ b/extensions/codex/src/web-search-provider.test.ts
@@ -4,7 +4,11 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import { createCodexWebSearchProvider as createContractCodexWebSearchProvider } from "../web-search-contract-api.js";
 import type { CodexAppServerClient } from "./app-server/client.js";
 import type { CodexAppServerStartOptions } from "./app-server/config.js";
-import type { CodexServerNotification, JsonValue } from "./app-server/protocol.js";
+import {
+  isJsonObject,
+  type CodexServerNotification,
+  type JsonValue,
+} from "./app-server/protocol.js";
 import { createCodexWebSearchProvider } from "./web-search-provider.js";
 
 function codexModel(
@@ -34,7 +38,7 @@ function codexModel(
   };
 }
 
-function threadStartResult() {
+function threadStartResult(model: string) {
   return {
     thread: {
       id: "thread-1",
@@ -57,7 +61,7 @@ function threadStartResult() {
       name: null,
       turns: [],
     },
-    model: "gpt-5.5",
+    model,
     modelProvider: "openai",
     serviceTier: null,
     cwd: "/tmp/openclaw-agent",
@@ -95,8 +99,8 @@ function createFakeClient(options?: {
     if (method === "model/list") {
       return { data: options?.models ?? [codexModel()], nextCursor: null };
     }
-    if (method === "thread/start") {
-      return threadStartResult();
+    if (method === "thread/start" && isJsonObject(params) && typeof params.model === "string") {
+      return threadStartResult(params.model);
     }
     if (method === "turn/start") {
       for (const notify of notifications) {
@@ -358,9 +362,7 @@ describe("codex web search provider", () => {
     expect(requests[1]?.params).toEqual(
       expect.objectContaining({ model: "available-default-wire" }),
     );
-    expect(requests[2]?.params).toEqual(
-      expect.objectContaining({ model: "available-default-wire" }),
-    );
+    expect(requests[2]?.params).not.toHaveProperty("model");
   });
 
   it("fails closed when the live catalog has no text-capable model", async () => {

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test-support.ts
@@ -1,0 +1,96 @@
+import { vi } from "vitest";
+import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
+import type { AdmittedRunContext } from "../../admitted-run-context.js";
+import { createUsageAccumulator } from "../usage-accumulator.js";
+import type { EmbeddedRunAttemptWithReceiptEvidence } from "./attempt-result.js";
+import { createEmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
+import { createEmbeddedRunLaneController } from "./lane-controller.js";
+import type { prepareTerminalWithSettledTurnFinalization } from "./settled-turn-finalization.js";
+import { resolveEmbeddedRunAttemptTerminalState } from "./terminal-outcome.js";
+
+export function createSettledFinalizationTestInput(
+  attempt: EmbeddedRunAttemptWithReceiptEvidence,
+  admittedRunContext: AdmittedRunContext,
+) {
+  let lifecycleGeneration = getAgentEventLifecycleGeneration();
+  const laneController = createEmbeddedRunLaneController({
+    getLifecycleGeneration: () => lifecycleGeneration,
+    getParams: () => ({
+      admittedRunContext,
+      sessionFile: "/tmp/session-settled.jsonl",
+      sessionId: "session-settled",
+      runId: "run-settled",
+      workspaceDir: "/tmp/openclaw-test",
+      prompt: "finish the task",
+      timeoutMs: 60_000,
+    }),
+    globalLane: "settled-finalization-global",
+    sessionLane: "settled-finalization-session",
+    initialQueuedLifecycleGeneration: lifecycleGeneration,
+    setLifecycleGeneration: (value) => {
+      lifecycleGeneration = value;
+    },
+    setParams: () => {},
+  });
+  const usageAccumulator = createUsageAccumulator();
+  usageAccumulator.assistantTurns = 1;
+  usageAccumulator.bridgeCalls = { search: 1, describe: 2, call: 3 };
+  return {
+    initial: {
+      attempt,
+      attemptAssistant: attempt.currentAttemptAssistant,
+      currentAttemptCompletedAssistant: undefined,
+      sessionIdUsed: attempt.sessionIdUsed,
+      sessionFileUsed: attempt.sessionFileUsed,
+      terminalState: resolveEmbeddedRunAttemptTerminalState({
+        attempt,
+        assistant: attempt.currentAttemptAssistant,
+      }),
+      attemptCompactionCount: 0,
+    },
+    terminalBase: {
+      runParams: {
+        admittedRunContext,
+        sessionId: "session-settled",
+        runId: "run-settled",
+        workspaceDir: "/tmp/openclaw-test",
+        prompt: "finish the task",
+        trigger: "cron",
+        terminalReplyExpectation: "required",
+        timeoutMs: 60_000,
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      activeErrorContext: { provider: "openai", model: "gpt-5.6-luna" },
+      authProfileStore: { version: 1, profiles: {} },
+      outerContextTokenMeta: {},
+      usageAccumulator,
+      contextRecoveryState: createEmbeddedRunContextRecoveryState(),
+      resolvedToolResultFormat: "markdown",
+    },
+    lastRunPromptUsage: undefined,
+    finalization: {
+      preparedAttempt: {
+        admittedRunContext,
+        runId: "run-settled",
+        sessionId: "session-settled",
+        workspaceDir: "/tmp/openclaw-test",
+        prompt: "finish the task",
+        timeoutMs: 60_000,
+      },
+      harness: {
+        id: "test-harness",
+        label: "Test harness",
+        supports: () => ({ supported: true }),
+        runAttempt: vi.fn(),
+        finalizeSettledTurn: vi.fn(),
+      },
+      modelApi: "openai-responses",
+      executionContract: undefined,
+      hasTerminalToolPresentation: false,
+      createAttemptControls: vi.fn(laneController.createAttemptControls),
+      abortSignal: laneController.abortSignal,
+    },
+  } as unknown as Parameters<typeof prepareTerminalWithSettledTurnFinalization>[0];
+}

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { SessionTranscriptWriterClaimReboundError } from "../../../config/sessions/transcript-write-context.js";
-import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
 import {
   prepareSystemAgentRunAdmission,
   type AdmittedRunContext,
@@ -12,12 +11,10 @@ import {
   buildEmbeddedRunnerAssistant,
   makeEmbeddedRunnerAttempt,
 } from "../../test-helpers/embedded-agent-runner-e2e-fixtures.js";
-import { createUsageAccumulator } from "../usage-accumulator.js";
 import type { EmbeddedRunAttemptWithReceiptEvidence } from "./attempt-result.js";
-import { createEmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
-import { createEmbeddedRunLaneController } from "./lane-controller.js";
 import { EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS } from "./lane-runtime.js";
 import { prepareTerminalWithSettledTurnFinalization } from "./settled-turn-finalization.js";
+import { createSettledFinalizationTestInput } from "./settled-turn-finalization.test-support.js";
 import { resolveEmbeddedRunAttemptTerminalState } from "./terminal-outcome.js";
 import { resolveSettledTurnFinalizationRequest } from "./terminal-resolution.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
@@ -108,87 +105,7 @@ function settledFailedAttempt(): EmbeddedRunAttemptWithReceiptEvidence {
 let admittedRunContext: AdmittedRunContext;
 
 function finalizationInput(attempt: ReturnType<typeof settledFailedAttempt>) {
-  let lifecycleGeneration = getAgentEventLifecycleGeneration();
-  const laneController = createEmbeddedRunLaneController({
-    getLifecycleGeneration: () => lifecycleGeneration,
-    getParams: () => ({
-      admittedRunContext,
-      sessionFile: "/tmp/session-settled.jsonl",
-      sessionId: "session-settled",
-      runId: "run-settled",
-      workspaceDir: "/tmp/openclaw-test",
-      prompt: "finish the task",
-      timeoutMs: 60_000,
-    }),
-    globalLane: "settled-finalization-global",
-    sessionLane: "settled-finalization-session",
-    initialQueuedLifecycleGeneration: lifecycleGeneration,
-    setLifecycleGeneration: (value) => {
-      lifecycleGeneration = value;
-    },
-    setParams: () => {},
-  });
-  const usageAccumulator = createUsageAccumulator();
-  usageAccumulator.assistantTurns = 1;
-  usageAccumulator.bridgeCalls = { search: 1, describe: 2, call: 3 };
-  return {
-    initial: {
-      attempt,
-      attemptAssistant: attempt.currentAttemptAssistant,
-      currentAttemptCompletedAssistant: undefined,
-      sessionIdUsed: attempt.sessionIdUsed,
-      sessionFileUsed: attempt.sessionFileUsed,
-      terminalState: resolveEmbeddedRunAttemptTerminalState({
-        attempt,
-        assistant: attempt.currentAttemptAssistant,
-      }),
-      attemptCompactionCount: 0,
-    },
-    terminalBase: {
-      runParams: {
-        admittedRunContext,
-        sessionId: "session-settled",
-        runId: "run-settled",
-        workspaceDir: "/tmp/openclaw-test",
-        prompt: "finish the task",
-        trigger: "cron",
-        terminalReplyExpectation: "required",
-        timeoutMs: 60_000,
-        sourceReplyDeliveryMode: "message_tool_only",
-      },
-      provider: "openai",
-      model: "gpt-5.6-luna",
-      activeErrorContext: { provider: "openai", model: "gpt-5.6-luna" },
-      authProfileStore: { version: 1, profiles: {} },
-      outerContextTokenMeta: {},
-      usageAccumulator,
-      contextRecoveryState: createEmbeddedRunContextRecoveryState(),
-      resolvedToolResultFormat: "markdown",
-    },
-    lastRunPromptUsage: undefined,
-    finalization: {
-      preparedAttempt: {
-        admittedRunContext,
-        runId: "run-settled",
-        sessionId: "session-settled",
-        workspaceDir: "/tmp/openclaw-test",
-        prompt: "finish the task",
-        timeoutMs: 60_000,
-      },
-      harness: {
-        id: "test-harness",
-        label: "Test harness",
-        supports: () => ({ supported: true }),
-        runAttempt: vi.fn(),
-        finalizeSettledTurn: vi.fn(),
-      },
-      modelApi: "openai-responses",
-      executionContract: undefined,
-      hasTerminalToolPresentation: false,
-      createAttemptControls: vi.fn(laneController.createAttemptControls),
-      abortSignal: laneController.abortSignal,
-    },
-  } as unknown as Parameters<typeof prepareTerminalWithSettledTurnFinalization>[0];
+  return createSettledFinalizationTestInput(attempt, admittedRunContext);
 }
 
 describe("resolveSettledTurnFinalizationRequest", () => {

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.unavailable.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.unavailable.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
+import { replaceSessionEntry } from "../../../config/sessions/session-accessor.js";
+import { useTempSessionsFixture } from "../../../config/sessions/test-helpers.js";
+import {
+  appendSessionTranscriptMessageByIdentity,
+  readVisibleSessionTranscriptMessageEntries,
+} from "../../../plugin-sdk/session-transcript-runtime.js";
+import { prepareSystemAgentRunAdmission } from "../../admitted-run-context.js";
+import {
+  buildEmbeddedRunnerAssistant,
+  createResolvedEmbeddedRunnerModel,
+  makeEmbeddedRunnerAttempt,
+} from "../../test-helpers/embedded-agent-runner-e2e-fixtures.js";
+import { prepareTerminalWithSettledTurnFinalization } from "./settled-turn-finalization.js";
+import { createSettledFinalizationTestInput } from "./settled-turn-finalization.test-support.js";
+
+const FALLBACK =
+  "The tool run finished, but no final summary was produced. I did not repeat any completed actions.";
+
+describe("unavailable finalization through the real core backend", () => {
+  const fixture = useTempSessionsFixture("settled-finalization-unavailable-");
+  let admission: ReturnType<typeof prepareSystemAgentRunAdmission>;
+
+  beforeEach(() => {
+    admission = prepareSystemAgentRunAdmission({}, "run-settled", "main", "unavailable-finalizer");
+  });
+  afterEach(() => admission.close());
+
+  it("persists and prepares one honest fallback without replaying completed work", async () => {
+    const admittedRunContext = await admission.admit("embedded");
+    const assistant = buildEmbeddedRunnerAssistant({
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      stopReason: "toolUse",
+      content: [{ type: "toolCall", id: "completed-command", name: "exec", arguments: {} }],
+    });
+    const attempt = makeEmbeddedRunnerAttempt({
+      terminal: { kind: "ok" },
+      sessionIdUsed: "session-settled",
+      assistantTexts: [],
+      currentAttemptAssistant: undefined,
+      currentAttemptCompletedAssistant: undefined,
+      lastAssistant: undefined,
+      messagesSnapshot: [
+        { role: "user", content: "Run the command once.", timestamp: 1 },
+        assistant,
+        {
+          role: "toolResult",
+          toolCallId: "completed-command",
+          toolName: "exec",
+          content: [{ type: "text", text: "completed-once" }],
+          isError: false,
+          timestamp: 3,
+        },
+      ],
+      toolMetas: [{ toolName: "exec", toolCallId: "completed-command", replaySafe: false }],
+      itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+      settledTurnFinalizationContext: Object.freeze({ source: "unavailable" }),
+    });
+    const original = JSON.stringify(attempt);
+    const storePath = path.join(fs.realpathSync(fixture.sessionsDir()), "sessions.json");
+    const target = {
+      agentId: "main",
+      sessionId: "session-settled",
+      sessionKey: "agent:main:settled",
+      storePath,
+    };
+    await replaceSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
+    for (const message of attempt.messagesSnapshot) {
+      await appendSessionTranscriptMessageByIdentity({ ...target, message });
+    }
+    const prefix = await readVisibleSessionTranscriptMessageEntries(target);
+    const input = createSettledFinalizationTestInput(attempt, admittedRunContext);
+    input.terminalBase.runParams.trigger = "user";
+    input.terminalBase.runParams.sessionKey = target.sessionKey;
+    Object.assign(
+      input.finalization.preparedAttempt,
+      createResolvedEmbeddedRunnerModel("openai", "gpt-5.6-sol"),
+      {
+        provider: "openai",
+        modelId: "gpt-5.6-sol",
+        agentId: "main",
+        sessionKey: target.sessionKey,
+        sessionTarget: target,
+        authProfileStore: { version: 1, profiles: {} },
+        resolvedApiKey: "synthetic-unused-host-key",
+      },
+    );
+    const finalize = vi.fn(async () => {
+      throw new Error("Harness-owned finalization is unavailable");
+    });
+    const runAttempt = vi.fn(async () => {
+      throw new Error("Completed work must not be replayed");
+    });
+    input.finalization.harness.finalizeSettledTurn = finalize;
+    input.finalization.harness.runAttempt = runAttempt;
+
+    const result = await prepareTerminalWithSettledTurnFinalization(input);
+
+    expect(finalize).toHaveBeenCalledOnce();
+    expect(finalize).toHaveBeenCalledWith(expect.objectContaining({ settledAttempt: attempt }));
+    expect(runAttempt).not.toHaveBeenCalled();
+    expect(result.finalizationOutcome).toBe("failed");
+    expect(result.prepared.payloadsWithToolMedia).toEqual([
+      expect.objectContaining({ text: FALLBACK }),
+    ]);
+    expect(getReplyPayloadMetadata(result.prepared.payloadsWithToolMedia?.[0] ?? {})).toMatchObject(
+      {
+        assistantTranscriptOwned: true,
+        assistantTranscriptIdempotencyKey: "run-settled:settled-finalization-fallback",
+        deliverDespiteSourceReplySuppression: true,
+      },
+    );
+    expect(result.attempt.currentAttemptAssistant).toMatchObject({
+      provider: assistant.provider,
+      model: assistant.model,
+    });
+    expect(JSON.stringify(attempt)).toBe(original);
+    expect(attempt.terminal).toEqual({ kind: "ok" });
+    const transcript = await readVisibleSessionTranscriptMessageEntries(target);
+    expect(transcript.slice(0, prefix.length)).toEqual(prefix);
+    expect(transcript.slice(prefix.length)).toMatchObject([
+      {
+        message: {
+          provider: "openclaw",
+          model: "delivery-mirror",
+          content: [{ type: "text", text: FALLBACK }],
+        },
+      },
+    ]);
+    expect(transcript).toHaveLength(prefix.length + 1);
+  });
+});


### PR DESCRIPTION
Closes #136724

## What Problem This Solves

Fixes an issue where Codex users completed tool work but the post-tool summary switched to an outer account/model, or failed because those unrelated host settings were unavailable. A supervised native connection owns its authentication; a fresh private Codex home cannot inherit that account.

## Why This Change Was Made

The settled-turn owner now records the ready thread's model/provider and resolved host profile selector alongside the existing bounded, verified transcript projection. Ordinary finalization reuses the canonical prepared-auth handoff, including the exact prepared API key or selected subscription profile, and retains its existing private-stdio isolation. The bounded turn inherits the model admitted by `thread/start`; final assistant attribution comes from that response while the bounded result's catalog-ID contract remains unchanged for other callers.

Genuine supervision instead publishes the existing frozen `source: "unavailable"` marker with an explicit diagnostic reason. Keeping the finalizer callback present preserves the core's established honest fallback. No host account is selected, no native credentials are copied, no follow-up native inference is attempted, and completed actions are not replayed. Stock Codex has no generic attested zero-tool summary operation on that native connection; this change does not invent one.

This is OpenClaw-only: no Codex changes or custom binary, dependency bump, configuration/environment surface, SQLite migration, sidebar changes, or terminal UI changes. The existing private-turn capability restrictions and bounded empty-answer retry remain unchanged.

## User Impact

Ordinary host-authorized summaries continue to work, including preserve-native-model-only bindings and the documented ordinary `homeScope: "user"` private-host-auth sidecall. Supervised turns that already return a final answer are unchanged. When a supervised tool-only turn needs a reply, users receive:

> The tool run finished, but no final summary was produced. I did not repeat any completed actions.

The completed outcome, tool receipts, transcript prefix, and native binding remain intact. The distinction is documented in [Codex runtime behavior](https://docs.openclaw.ai/plugins/codex-harness-runtime#final-answers-after-settled-tool-work) and [auth/environment isolation](https://docs.openclaw.ai/plugins/codex-harness-reference#auth-and-environment-isolation).

## Evidence

### Reproduction and ownership proof

The composed fixture uses the stock managed Codex **0.152.1** binary, disposable homes, two synthetic accounts, a loopback Responses server, real native command execution, and real transcript persistence. Against pre-fix `65e5b2e19c9db6460494682bacc4bee10db755fd`, three cases failed and the ordinary user-home contrast passed. All four cases pass with the repair:

| Case | Pre-fix observation | Repaired observation |
| --- | --- | --- |
| Supervised source; different usable host account/model | Returned an outer-model summary through the host account | No finalizer auth/client/RPC/model request; unavailable marker; original binding, receipts, and healthy sibling preserved |
| Prepared API key plus a different usable profile hint | Summary used the profile's account instead of the prepared key | Summary uses the exact prepared key |
| Preserve-native-model-only host binding | Summary selected the outer model | Summary uses the ready native model and the original host profile |
| Ordinary user-home session | Private host-authorized summary succeeded | Same supported behavior; native auth file remains unchanged |

The source command marker remains exactly one line. The model contrast uses two stock models in the same native multi-agent generation, without overriding catalog/model metadata. The native command fixture is POSIX-only; the owner-boundary tests are platform-independent.

Core tests separately exercise the actual finalization backend and SQLite persistence for an unavailable harness, proving one fallback payload/row, unchanged original evidence, and no original-attempt replay. API-key/subscription selection, normalized-away provider metadata, cancellation/write fencing, empty output, catalog aliases, media, hosted search, and isolated completion are covered by focused sibling tests.

### User-visible delivery proof

Both existing QA scenarios passed against the built candidate using an isolated real Gateway, mock provider, and synthetic QA channel:

```json
{
  "providerMode": "mock-openai",
  "channelDriver": "qa-channel",
  "gateway": "isolated real child",
  "results": [
    {
      "scenario": "settled-write-finalizer-exhaustion-fallback",
      "status": "pass",
      "providerRequests": 4,
      "writes": 1,
      "finalizationRequests": 2,
      "outboundFallbackReplies": 1
    },
    {
      "scenario": "gateway-settled-finalizer-exhaustion-fallback",
      "status": "pass",
      "providerRequests": 4,
      "finalizationRequests": 2,
      "fallbackRowsInChatHistory": 1
    }
  ]
}
```

These QA scenarios cover the common fallback-delivery path after empty-finalizer exhaustion. The unavailable-native producer and thrown-unavailable core path are covered separately above. This is not live OAuth/OpenAI, native catalog admission, a full native-to-Gateway flow, or a real external-channel claim. No production account, Gateway, or state was used.

### Dependency contract checked

Directly inspected `openai/codex` tag `rust-v0.152.1`, peeled commit `5adb68a49933ae446bf11935662c83dba55a0804`: [thread start parameters and returned selection](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L62-L184), [turn model override semantics](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L177-L211), [model metadata overriding code-mode flags](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/core/src/tools/mod.rs#L68-L89), and [exec/wait registration](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/core/src/tools/spec_plan.rs#L791-L895). Ordinary inference still uses `tool_choice: "auto"`; disabling environments is not a generic no-tools acknowledgement.

### Validation and scope

Focused coverage spans **358 tests across 13 files**, including four stock-native cases and 22 core finalization tests. The last broad run had three stale sibling assertions expecting the removed per-turn model override; those were corrected and both sibling files passed **23/23** on rerun. The final real-backend fallback fixture also passed after replacing an unbound-method assertion with an explicitly owned replay spy.

The build passed with `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`. All steps selected by `check:changed` were completed: its aggregate run reached core lint after the structural guards and all typechecks passed; the test-only lint issue was fixed, then the affected canonical type graph, core/plugin lint, and remaining storage/media/sidecar/import-cycle gates passed. There are **0 runtime import cycles**. This records resumed validation, not a claim that one aggregate invocation exited green. Fresh independent Codex autoreview at P1 returned scoped-clean with no accepted/actionable findings.

<details>
<summary>Local proof commands</summary>

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/settled-turn-finalizer.native.test.ts extensions/codex/src/app-server/settled-turn-finalizer.test.ts extensions/codex/src/app-server/settled-turn-context.test.ts extensions/codex/src/app-server/settled-turn-projection.test.ts extensions/codex/src/app-server/bounded-turn.test.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/session-history.test.ts extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts extensions/codex/media-understanding-provider.test.ts extensions/codex/src/web-search-provider.test.ts extensions/codex/src/app-server/isolated-completion.test.ts src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts src/agents/embedded-agent-runner/run/settled-turn-finalization.unavailable.test.ts
```

```bash
node scripts/run-vitest.mjs extensions/codex/media-understanding-provider.test.ts extensions/codex/src/web-search-provider.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/settled-turn-finalization.unavailable.test.ts
```

```bash
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.agents-other.json --builders 1
```

```bash
OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
```

```bash
OPENCLAW_STATE_DIR="$(mktemp -d)" node scripts/check-changed.mjs
```

```bash
qa_state="$(mktemp -d)" && env -u CODEX_HOME -u CODEX_API_KEY -u OPENAI_API_KEY OPENCLAW_STATE_DIR="$qa_state" OPENCLAW_CONFIG_PATH="$qa_state/openclaw.json" OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 OPENCLAW_DISABLE_BUNDLED_PLUGINS=0 node openclaw.mjs qa suite --repo-root "$PWD" --provider-mode mock-openai --channel-driver qa-channel --scenario settled-write-finalizer-exhaustion-fallback --scenario gateway-settled-finalizer-exhaustion-fallback --concurrency 1 --output-dir .artifacts/qa-e2e/settled-stock-fallback
```

</details>

LOC: production **89 added / 20 removed (+69)**; tests/support **1,598 added / 308 removed (+1,290)**; docs **29 added / 1 removed (+28)**. No generated, lockfile, or dependency changes.

Production delta is **+69 lines** across four existing plugin modules; no new production module. The growth carries source-owned selection, reuses prepared auth, records unsupported native ownership, and fences final writes rather than retaining a borrowed native client or adding a second execution path. Test/test-support and documentation deltas are reported separately.

The nearby thread-cleanup fixture now waits for actual `turn/start` readiness and aborts/joins its attempt on failure instead of imposing a five-second cold-start assumption. No runtime timeout was enlarged.

A cross-generation preserve-model fixture also exposed a separate pre-finalization rotation path. That finding was handed to the active native-ownership work; this PR does not change rotation or session-lock policy.
