### PR TITLE
perf: speed up plugin package ownership checks

### DIFF
--- a/src/plugins/installed-plugin-package-ownership.ts
+++ b/src/plugins/installed-plugin-package-ownership.ts
@@ -116,9 +116,10 @@ export function resolveInstalledPluginPackageOwnership(
     return ownershipError(pluginId, `does not belong to package owner "${installOwner}"`);
   }
 
+  const realpathCache = new Map<string, string>();
   const hasUnsafePackageEntry = index.plugins.some(
     (entry) =>
-      installRecordPathMatchesPluginRoot(installRecord, entry.rootDir, env) &&
+      installRecordPathMatchesPluginRoot(installRecord, entry.rootDir, env, realpathCache) &&
       (isInstalledPluginIndexInstallOwnerAmbiguous(entry) ||
         resolveInstalledPluginIndexInstallOwner(entry) !== installOwner),
   );
@@ -148,10 +149,11 @@ export function resolveInstalledPluginLifecycleOwnership(
   ) {
     return ownership;
   }
+  const realpathCache = new Map<string, string>();
   const hasConflictingEntry = index.plugins.some(
     (entry) =>
       entry.pluginId === pluginId ||
-      installRecordPathMatchesPluginRoot(installRecord, entry.rootDir, env),
+      installRecordPathMatchesPluginRoot(installRecord, entry.rootDir, env, realpathCache),
   );
   if (hasConflictingEntry) {
     return ownership;
@@ -164,12 +166,14 @@ export function resolveInstalledPluginLifecycleOwnership(
   };
 }
 
+// Share physical path facts only within one synchronous scan. A later lifecycle
+// check gets a fresh map so replaced package paths are observed again.
 function installRecordPathMatchesPluginRoot(
   record: InstalledPluginInstallRecordInfo,
   rootDir: string,
   env: NodeJS.ProcessEnv,
+  realpathCache: Map<string, string>,
 ): boolean {
-  const realpathCache = new Map<string, string>();
   const resolvedRoot =
     safeRealpathSync(path.resolve(rootDir), realpathCache) ?? path.resolve(rootDir);
   return [record.installPath, record.sourcePath].some((candidate) => {
@@ -190,20 +194,16 @@ export function hasMissingInstalledPluginOwnerMetadata(
     return true;
   }
   const installRecords = Object.entries(index.installRecords);
-  if (
-    index.plugins.some(
-      (plugin) =>
-        isInstalledPluginIndexInstallOwnerAmbiguous(plugin) ||
-        (!resolveInstalledPluginIndexInstallOwner(plugin) &&
-          installRecords.some(([, record]) =>
-            installRecordPathMatchesPluginRoot(record, plugin.rootDir, env),
-          )),
-    )
-  ) {
-    return true;
-  }
+  const realpathCache = new Map<string, string>();
   // An orphaned owner record (for example, package code removed out of band) is
   // already closed by the lifecycle resolver. It must not make every unrelated
   // config read attempt an impossible registry migration with no discoverable rows.
-  return false;
+  return index.plugins.some(
+    (plugin) =>
+      isInstalledPluginIndexInstallOwnerAmbiguous(plugin) ||
+      (!resolveInstalledPluginIndexInstallOwner(plugin) &&
+        installRecords.some(([, record]) =>
+          installRecordPathMatchesPluginRoot(record, plugin.rootDir, env, realpathCache),
+        )),
+  );
 }


### PR DESCRIPTION
## What Problem This Solves

Plugin management listings repeatedly resolve the same installed package path while checking it against the installed inventory. With the bundled inventory present, this adds milliseconds to each prepared listing.

## Why This Change Was Made

Reuse the existing realpath helper's map within each synchronous ownership scan, then discard it. The strict package check, lifecycle/orphan check and missing-owner check each retain their own scope. Later calls still observe replaced paths; failed realpath lookups remain uncached.

This also returns the existing missing-owner predicate directly. Production LOC is +16/-16 (net zero); no test or configuration surface is added.

## User Impact

Faster plugin management listings with the same package ownership decisions, errors, order and returned identities. No process-wide cache, persistence change or new setting.

## Evidence

- The same 62 canonical tests passed on both source variants, including management, installed manifests, package update and ownership behavior. Full `pnpm check` passed; independent Codex source review found no actionable P0–P2 findings.
- Native Node 26.8.1 proof uses real metadata discovery and the complete 151-plugin bundled roster, plus task-owned installed packages. Two fresh correctness hosts precede B0/C0/C1/B1 timing hosts.
- 502 public calls total: 46 correctness calls and 456 timing calls, including 384 measured samples. Another 78 metadata setup calls are recorded separately. Full outputs, input graphs, property order/flags, aliases, native environment, errors and lifecycle closure are retained and compared.
- Seventeen explicit controls cover shared children, ambiguous/missing ownership, physical aliases, orphan cleanup, update capture/reconciliation, and retargeting the same alias between calls.

| Prepared listing | Before median | After median | Forward change | Reverse change |
| --- | ---: | ---: | ---: | ---: |
| Bundled inventory + one installed package | 8.515 ms | 6.386 ms | -25.01% | -27.63% |
| Bundled inventory + two installed packages / three children | 17.901 ms | 10.931 ms | -38.94% | -39.50% |

The small installed-only control was +2.02% (+1.17 µs) forward and -11.45% reverse; retained without resampling. Single first-call observations also retain +20.14% on the installed-only control (forward) and +4.29% on the bundled-only control (reverse); these are individual observations, not measured medians. Kernel peak RSS was +0.95% / +0.76%. Both primaries and all protected controls passed the predeclared gates.

These are whole prepared-management-call measurements, not cold CLI, Gateway, network or model-turn latency claims. Setup/import time remains outside each call and inside the bounded host. The original harness attempt stopped before product imports because of a native environment assertion; its evidence and resource charges remain retained. The fresh successor preserves the original rows, counts, gates and caps.
