### PR TITLE
fix(ui): keep session header visible during Gateway reconnects

### DIFF
--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -202,13 +202,13 @@ export function renderApplicationShell(host: ShellViewHost) {
   const lazyElementState = host.lazyCustomElements.visibleState;
   const activeRoute = host.routeState.routeId ?? "chat";
   const sessionRoute = isSessionRouteId(activeRoute);
-  // Chat has an offline outbox, New Session keeps a local draft, and Appearance
-  // persists local preference intent for replay. Their server actions are
-  // independently gated; other pages cannot submit useful disconnected work.
+  // Session routes have an offline outbox, New Session keeps a local draft, and
+  // Appearance persists local preference intent for replay. Their server actions
+  // are independently gated; other pages cannot submit useful disconnected work.
   const pageActionsBlocked =
     gatewaySnapshot.phase === "reload-required" ||
     (!gatewayConnected &&
-      activeRoute !== "chat" &&
+      !sessionRoute &&
       activeRoute !== "new-session" &&
       activeRoute !== "appearance");
   // Plugin tabs share one route; the search picks the active item.

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -6,6 +6,7 @@ import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   captureControlUiE2eFailureDiagnostics,
+  controlUiSessionUrl,
   installMockGateway,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -308,6 +309,54 @@ suite.define(() => {
         path: path.join(RECOVERY_ARTIFACT_DIR, "02-reconnecting-actions-blocked.png"),
         fullPage: true,
       });
+    } finally {
+      await closeContext(context);
+    }
+  });
+
+  it("keeps the session header available while disabling Gateway actions on reconnect", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const page = await context.newPage();
+    const sessionKey = "agent:main:main";
+    const gateway = await installMockGateway(page, { sessionKey });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey, "dashboard"));
+      const header = page.locator(".chat-pane__header");
+      await header.waitFor({ state: "visible" });
+      await gateway.setOnline(false);
+
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const app = document.querySelector("openclaw-app") as HTMLElement & {
+              runtime?: { context: { gateway: { snapshot: { phase: string } } } };
+            };
+            return app.runtime?.context.gateway.snapshot.phase;
+          }),
+        )
+        .toBe("reconnecting");
+      await page.screenshot({
+        path: path.join(RECOVERY_ARTIFACT_DIR, "03-session-reconnecting-after.png"),
+        fullPage: true,
+      });
+
+      expect(await page.locator(".connection-action-block").count()).toBe(0);
+      expect(await page.locator("#control-ui-main").getAttribute("inert")).toBeNull();
+      const outlet = page.locator("openclaw-router-outlet");
+      expect(await outlet.getAttribute("inert")).toBeNull();
+      expect(await outlet.getAttribute("aria-disabled")).toBeNull();
+      expect(await header.isVisible()).toBe(true);
+
+      const headerActions = header.locator(".chat-pane__actions");
+      expect(
+        await headerActions.evaluate((element) => (element as HTMLFieldSetElement).disabled),
+      ).toBe(true);
+      const actionButtons = headerActions.getByRole("button");
+      expect(await actionButtons.count()).toBeGreaterThan(0);
+      for (const button of await actionButtons.all()) {
+        expect(await button.isDisabled()).toBe(true);
+      }
     } finally {
       await closeContext(context);
     }

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -462,6 +462,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       canReveal,
       copiedAction: this.headerCopiedAction,
       renameDisabledReason,
+      actionsDisabled: this.state?.connected !== true,
       panelActions: html`${browserPanelAction}${backgroundTasksAction}${sidePanelAction}`,
       discussionAction: nothing,
       diffAction: nothing,

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -66,6 +66,7 @@ type ChatPaneHeaderProps = {
   canReveal: boolean;
   copiedAction: ChatPaneHeaderAction | null;
   renameDisabledReason?: string;
+  actionsDisabled?: boolean;
   panelActions: TemplateResult | typeof nothing;
   discussionAction: TemplateResult | typeof nothing;
   diffAction: TemplateResult | typeof nothing;
@@ -522,7 +523,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
             `
           : nothing}
         ${renderGatewayPicker(props)}
-        <div class="chat-pane__actions">
+        <fieldset class="chat-pane__actions" ?disabled=${props.actionsDisabled}>
           ${compactSessionActions ? nothing : props.panelActions}
           ${compactSessionActions ? nothing : props.discussionAction}
           ${props.catalog || compactSessionActions
@@ -590,7 +591,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
               </openclaw-tooltip>`
             : nothing}
           ${props.sessionMenuAction}
-        </div>
+        </fieldset>
       </div>
     </div>
   `;

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -650,12 +650,15 @@ openclaw-chat-pane {
 .chat-pane__actions {
   display: flex;
   align-items: center;
+  border: 0;
   gap: 4px;
   flex: 0 0 auto;
+  min-width: 0;
+  padding: 0;
   /* With the title text-hugging, this claims the leftover width so the
      action cluster stays pinned to the right edge (and doubles as the
      native window-drag surface between chip and actions). */
-  margin-left: auto;
+  margin: 0 0 0 auto;
 }
 
 /* One box model for every action, whatever wraps it. A custom element defaults


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing a dashboard session saw a full-width “Actions are unavailable” banner and a blanket-disabled page whenever the Gateway reconnected, even though the session surface already supports disconnected presentation.

## Why This Change Was Made

Treats Dashboard and Chat as the same session-route policy at the application shell: ordinary reconnects no longer render the page-level banner or inert the whole session surface, while reload-required recovery and non-session pages remain blocked. The session header now owns its unavailable controls through one native disabled fieldset, so its identity stays normal and only its action buttons are disabled.

Root cause: the reconnect fence introduced by 486b272e8cdf863e7dcadea32cbf9d550c88846a exempted only the `chat` route instead of the canonical session-route family. That commit was authored by Peter Steinberger and committed by GitHub through #124772; merger provenance is checked separately before landing.

Codex contract check: OpenAI Codex only exposes thread lifecycle state here; it does not own this Control UI presentation policy. Inspected [`thread.rs:1628-1667`](https://github.com/openai/codex/blob/6be2a6ca952ac9f70676ce4dd07fda27175aa9dd/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L1628-L1667) and [`common.rs:786`](https://github.com/openai/codex/blob/6be2a6ca952ac9f70676ce4dd07fda27175aa9dd/codex-rs/app-server-protocol/src/protocol/common.rs#L786).

## User Impact

During a normal Gateway reconnect, dashboard sessions keep their normal header and readable content. Header action buttons are visibly and natively disabled until the connection returns; Settings and other server-only pages retain the existing reconnect warning and action fence.

## Evidence

| Before | After |
| --- | --- |
| ![Before: dashboard session has a full-width reconnect banner](https://github.com/user-attachments/assets/2e4aaff5-1522-4698-b71b-15d1b371c173) | ![After: banner removed and only header action buttons disabled](https://github.com/user-attachments/assets/d0d5a594-fedb-463f-b817-21b12ecddc7f) |

- Red/green browser regression: the new dashboard reconnect assertion failed before the patch because `.connection-action-block` was present, then passed with no banner/inert outlet and every header action button disabled.
- Exact-head focused UI E2E: 1 passed (`login-gate.e2e.test.ts`, reconnect case).
- Full adjacent UI E2E file: 21 passed.
- Header/session access unit suites: 108 passed.
- Changed-file gate: passed (format, typecheck, assertion/max-lines ratchets, dead-code, lint/style checks).
- Required scoped autoreview: no P0–P2 findings; patch correct (0.94 confidence).
- LOC: production +12/−7 (net +5), tests +49/−0. The production growth is the native grouped disabled boundary and its fieldset box-model reset; route-policy repair itself is net-neutral.
