### PR TITLE
refactor(cron): remove the reaper throttle bypass

### DIFF
--- a/src/cron/service.session-reaper-in-finally.test.ts
+++ b/src/cron/service.session-reaper-in-finally.test.ts
@@ -12,9 +12,11 @@ import {
   withCronServiceStateForTest,
 } from "./service.test-harness.js";
 import { createCronServiceState } from "./service/state.js";
+import { ensureLoaded } from "./service/store.js";
 import { onTimer } from "./service/timer.test-support.js";
 import { resetReaperThrottle } from "./session-reaper.test-support.js";
-import { saveCronStore } from "./store.js";
+import * as cronStoreModule from "./store.js";
+import { loadCronStore, saveCronStore } from "./store.js";
 import type { CronJob } from "./types.js";
 
 const noopLogger = createNoopLogger();
@@ -37,6 +39,24 @@ function createDueIsolatedJob(params: { id: string; nowMs: number }): CronJob {
     delivery: { mode: "none" },
     state: { nextRunAtMs: params.nowMs },
   };
+}
+
+async function seedReaperSessions(storePath: string, now: number) {
+  const fresh = {
+    sessionKey: "agent:main:cron:failing-job:run:fresh",
+    entry: { sessionId: "fresh-run", updatedAt: now, delivery: { kind: "none" as const } },
+  };
+  for (const { sessionKey, entry } of [
+    {
+      sessionKey: "agent:main:cron:failing-job:run:stale",
+      entry: { sessionId: "stale-run", updatedAt: now - 25 * 3_600_000 },
+    },
+    fresh,
+  ]) {
+    await replaceSessionEntry({ agentId: "main", storePath, sessionKey }, entry);
+  }
+  expect(listSessionEntriesCore({ agentId: "main", storePath })).toHaveLength(2);
+  return fresh;
 }
 
 describe("CronService - session reaper runs in finally block (#31946)", () => {
@@ -139,17 +159,18 @@ describe("CronService - session reaper runs in finally block (#31946)", () => {
     },
   );
 
-  it("session reaper runs even when job execution throws", async () => {
+  it("prunes expired run sessions after a job execution error", async () => {
     const store = await makeStorePath();
-    const now = Date.parse("2026-02-10T10:00:00.000Z");
+    const now = Date.now();
 
     await saveCronStore(store.storePath, {
       version: 1,
       jobs: [createDueIsolatedJob({ id: "failing-job", nowMs: now })],
     });
 
-    // Create a mock sessionStorePath to track if the reaper is called.
     const sessionStorePath = path.join(path.dirname(store.storePath), "sessions", "sessions.json");
+    const fresh = await seedReaperSessions(sessionStorePath, now);
+    const runIsolatedAgentJob = vi.fn().mockRejectedValue(new Error("gateway down"));
 
     const state = createCronServiceState({
       storePath: store.storePath,
@@ -158,8 +179,7 @@ describe("CronService - session reaper runs in finally block (#31946)", () => {
       nowMs: () => now,
       enqueueSystemEvent: vi.fn(),
       requestHeartbeat: vi.fn(),
-      // This will throw, simulating a failure during job execution.
-      runIsolatedAgentJob: vi.fn().mockRejectedValue(new Error("gateway down")),
+      runIsolatedAgentJob,
       defaultAgentId: "main",
       sessionStorePath,
     });
@@ -167,13 +187,60 @@ describe("CronService - session reaper runs in finally block (#31946)", () => {
     await withCronServiceStateForTest(state, async () => {
       await onTimer(state);
 
-      // After onTimer finishes (even with a job error), state.running must be
-      // false — proving the finally block executed.
+      expect(runIsolatedAgentJob).toHaveBeenCalledOnce();
+      expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
+        lastRunStatus: "error",
+        lastError: "gateway down",
+      });
+      expect(listSessionEntriesCore({ agentId: "main", storePath: sessionStorePath })).toEqual([
+        fresh,
+      ]);
       expect(state.running).toBe(false);
 
-      // The timer must be re-armed.
       if (state.timer === null) {
         throw new Error("expected timer to be re-armed");
+      }
+    });
+  });
+
+  it("prunes expired run sessions while propagating a cron store load failure", async () => {
+    const store = await makeStorePath();
+    const now = Date.now();
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [createDueIsolatedJob({ id: "failing-job", nowMs: now })],
+    });
+    const sessionStorePath = path.join(path.dirname(store.storePath), "sessions", "sessions.json");
+    const fresh = await seedReaperSessions(sessionStorePath, now);
+    const runIsolatedAgentJob = vi.fn();
+    const state = createCronServiceState({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+      defaultAgentId: "main",
+      sessionStorePath,
+    });
+
+    await withCronServiceStateForTest(state, async () => {
+      await ensureLoaded(state, { skipRecompute: true });
+      const failure = new Error("cron store unavailable");
+      const loadSpy = vi
+        .spyOn(cronStoreModule, "loadCronJobsStoreWithConfigJobs")
+        .mockRejectedValueOnce(failure);
+      try {
+        await expect(onTimer(state)).rejects.toBe(failure);
+        expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+        expect(listSessionEntriesCore({ agentId: "main", storePath: sessionStorePath })).toEqual([
+          fresh,
+        ]);
+        expect(state.running).toBe(false);
+        expect(state.timer).not.toBeNull();
+      } finally {
+        loadSpy.mockRestore();
       }
     });
   });

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -148,7 +148,6 @@ describe("sweepCronRunSessions", () => {
       sessionStorePath: storePath,
       nowMs: now,
       log,
-      force: true,
     });
 
     expect(result.swept).toBe(true);
@@ -211,7 +210,6 @@ describe("sweepCronRunSessions", () => {
         sessionStorePath: storePath,
         nowMs: now,
         log: failingLog,
-        force: true,
       });
 
       expect(result).toEqual({ swept: true, pruned: 1 });
@@ -327,7 +325,6 @@ describe("sweepCronRunSessions", () => {
       sessionStorePath: storePath,
       nowMs: now,
       log,
-      force: true,
     });
 
     expect(result).toEqual({ swept: true, pruned: 1 });
@@ -351,7 +348,6 @@ describe("sweepCronRunSessions", () => {
       sessionStorePath: storePath,
       nowMs: now,
       log,
-      force: true,
     });
 
     expect(result.pruned).toBe(0);
@@ -379,7 +375,6 @@ describe("sweepCronRunSessions", () => {
       sessionStorePath: storePath,
       nowMs: now,
       log,
-      force: true,
     });
 
     expect(result.pruned).toBe(0);
@@ -422,7 +417,6 @@ describe("sweepCronRunSessions", () => {
       sessionStorePath: storePath,
       nowMs: now,
       log,
-      force: true,
     });
 
     expect(result.pruned).toBe(2);
@@ -453,7 +447,6 @@ describe("sweepCronRunSessions", () => {
       sessionStorePath: storePath,
       nowMs: now,
       log,
-      force: true,
     });
     const admissionPromise = beginSessionWorkAdmission({
       scope: storePath,
@@ -497,7 +490,6 @@ describe("sweepCronRunSessions", () => {
       sessionStorePath: storePath,
       nowMs: now,
       log,
-      force: true,
     });
 
     expect(result.pruned).toBe(1);
@@ -518,7 +510,6 @@ describe("sweepCronRunSessions", () => {
       sessionStorePath: storePath,
       nowMs: now,
       log,
-      force: true,
     });
 
     expect(result.swept).toBe(false);
@@ -542,7 +533,6 @@ describe("sweepCronRunSessions", () => {
         sessionStorePath: storePath,
         nowMs: now,
         log,
-        force: true,
       });
 
       expect(result.swept).toBe(false);
@@ -580,7 +570,7 @@ describe("sweepCronRunSessions", () => {
     expect(readSessionEntries(storePath)[sessionKey]).toBeUndefined();
   });
 
-  it("throttles sweeps without force", async () => {
+  it("throttles repeated sweeps", async () => {
     const now = Date.now();
     // First sweep runs
     const r1 = await sweepCronRunSessions({
@@ -747,7 +737,6 @@ describe("sweepCronRunSessions", () => {
       sessionStorePath: storePath,
       nowMs: now,
       log,
-      force: true,
     });
 
     expect(result.pruned).toBe(1);
@@ -777,7 +766,6 @@ describe("sweepCronRunSessions", () => {
       sessionStorePath: storePath,
       nowMs: now,
       log,
-      force: true,
     });
 
     expect(result.pruned).toBe(1);

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -84,18 +84,16 @@ export async function removeCronJobBaseSession(params: {
 /**
  * Sweeps completed isolated cron run sessions while preserving base cron sessions.
  *
- * Must run outside the cron service `locked()` section because this acquires
- * the session-store file lock; reversing that order can deadlock timer ticks.
+ * Run outside the cron service `locked()` section: cleanup acquires session
+ * lifecycle and writer ownership, so nesting the queues can deadlock timer ticks.
  */
 export async function sweepCronRunSessions(params: {
   cronConfig?: CronConfig;
   agentId: string;
-  /** Resolved path to sessions.json — required. */
+  /** Resolved session-store target, interpreted by the SQLite accessor. */
   sessionStorePath: string;
   nowMs?: number;
   log: Logger;
-  /** Override for testing — skips the min-interval throttle. */
-  force?: boolean;
 }): Promise<ReaperResult> {
   const retentionMs = resolveRetentionMs(params.cronConfig);
   if (retentionMs === null) {
@@ -110,8 +108,8 @@ export async function sweepCronRunSessions(params: {
   const lastSweepAtMs = lastSweepAtMsByTarget.get(targetKey) ?? 0;
 
   // Timer ticks can be frequent; throttle per agent/store target to avoid
-  // repeated session-store I/O while preserving a force path for tests.
-  if (!params.force && now >= lastSweepAtMs && now - lastSweepAtMs < MIN_SWEEP_INTERVAL_MS) {
+  // repeated session-store I/O.
+  if (now >= lastSweepAtMs && now - lastSweepAtMs < MIN_SWEEP_INTERVAL_MS) {
     return { swept: false, pruned: 0 };
   }
 


### PR DESCRIPTION
## What Problem This Solves

Cron session-reaper tests bypassed the normal throttle even though fresh store paths and the existing reset already isolated them. The service regression for a job execution error also passed with the timer's sweep call disabled, so it did not prove that expired sessions were removed.

## Why This Change Was Made

Remove the test-only `force` parameter and its 12 test arguments so the tests exercise the ordinary throttle path. Keep the Map reset that owns test isolation, and update nearby comments to describe the current SQLite store target and lifecycle writer.

The existing job-error case now checks real expired-row deletion, fresh-row preservation, runner invocation and the recorded error outcome. A separate case checks cleanup while the canonical cron-store loader rejects with the exact error, restoring the escaping-error guarantee originally covered before the SQLite migration. The malformed legacy-file test remains intact.

## User Impact

No user-visible behavior change. Retention, throttling, active-work protection, store ownership and scheduler lifecycle remain unchanged. Developers get stronger cleanup regression coverage without a test-only runtime bypass. Production is reduced by 2 lines; tests grow by 55 lines, for 53 additional lines overall.

## Evidence

- Original baseline: 37 tests passed across both files. With the timer sweep replaced by a temporary no-op, the old job-error case still passed.
- Final candidate: all 38 tests passed. Store and cross-tick sibling proof passed 40 tests across three files using normal project routing.
- The same no-op now fails the strengthened case because the expired row survives. Moving the reaper before `finally` fails the loader-error case for the same reason while preserving exact error propagation. Both temporary controls were fully restored.
- Formatting, diff checks and the normal three-path changed gate passed. Independent managed Codex review found no actionable P0–P2 findings.

Two intermediate fixture runs failed: the inherited February timestamps were eligible for normal real-clock session maintenance, then exact equality exposed the canonical `delivery: { kind: "none" }` value omitted by the fixture. The final tests use a captured current time, verify both seeded rows exist, and supply the canonical delivery value. No maintenance override, fake clock, timeout change or weaker assertion was added; those failures do not establish a production retention defect.
