### PR TITLE
fix(plugins): restore built capability release validation

### DIFF
--- a/src/plugins/capability-provider-runtime.generation.test.ts
+++ b/src/plugins/capability-provider-runtime.generation.test.ts
@@ -75,6 +75,11 @@ export default { id: "${id}", register(api) {
   const builtDir = path.join(root, "dist", "extensions", id);
   mkdirSafe(builtDir);
   fs.writeFileSync(path.join(builtDir, "index.js"), body("built"));
+  // Artifact selection follows the entry format declared by emitted package metadata.
+  fs.writeFileSync(
+    path.join(builtDir, "package.json"),
+    JSON.stringify({ openclaw: { extensions: ["./index.js"] } }),
+  );
   const seed = writePlugin({
     id: "fixture-seed",
     dir: path.join(root, "extensions", "fixture-seed"),


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where 2026.9.1 Full Release Validation fails five built-capability generation tests even though the runtime correctly requires emitted plugin package metadata.

Maintainer-requested release blocker repair for [checks-node-agentic-plugins](https://github.com/openclaw/openclaw/actions/runs/33697209608/job/100468933219), targeting release SHA `c92d0ae9c07e757719e676517aa9f9460a40761c`.

## Why This Change Was Made

This is a **harness defect**. The fixture creates `dist/extensions/fixture-speech/index.js` without its `package.json`. #136399 made emitted package metadata authoritative when choosing JS/CJS/MJS artifacts, preventing stale format neighbors from being loaded. `scripts/copy-bundled-plugin-metadata.mts:301-318` already emits that metadata in real builds; the generation fixture was missed when sibling loader fixtures were updated.

Declare the fixture's emitted `./index.js` entry beside the built module. Every built/source, retained-generation, registry identity, no-rediscovery, and no-re-registration assertion remains unchanged. Production LOC: **0**; test LOC: **+5/-0**. Changing the production selector or accepting source in built assertions would violate the contract this test protects.

## User Impact

No runtime or configuration behavior changes. Release validation once again exercises a representative built plugin through the real capability loader and Gateway generation boundary.

## Evidence

The linked job belongs to **Plugin Prerelease**, specifically `.github/workflows/plugin-prerelease.yml`'s release-only Node shard. Its plan uses `test/vitest/vitest.plugins.config.ts`, `requiresDist: false`, non-isolated sequential test files, no include/exclude filters, and no repository build before testing. This test creates its own artifacts; adding a workflow build would not repair the fixture.

Exact workflow child command and environment, run before and after the patch:

```sh
CI=true NODE_OPTIONS=--max-old-space-size=8192 \
OPENCLAW_VITEST_MAX_WORKERS=2 \
OPENCLAW_VITEST_SHARD_NAME=agentic-plugins \
OPENCLAW_TEST_PROJECTS_PARALLEL=2 \
pnpm test -- test/vitest/vitest.plugins.config.ts --
```

- Before: **5 failed, 4,694 passed, 1 skipped** across 290 files. All five failures match the reported `source:1` / `source:2` versus `built:1` mismatches.
- After: **all 9 generation cases pass**; full shard **4,698 passed, 1 skipped, 1 failed**. The remaining failure is the separate native-loader SDK bridge test's 120-second timeout; it took 108 seconds before this patch and 145 seconds in the post-fix run.
- `pnpm test src/plugins/capability-provider-runtime`: **75 passed** across 2 files, using a separate transform cache.
- `pnpm check:changed`: **passed**, using a separate transform cache.
- Independent Codex autoreview: **scoped-clean through P2**.
- Isolated same-config SDK bridge rerun also timed out at 120 seconds (1 failed, 2 skipped), without running the capability fixture: append `src/plugins/loader.native-module-loader.test.ts -t 'loads published pre-split'` to the full-shard command above.

Local proof used macOS and Node 26.8.1 on base `427d84a011dbedde43585a781cb0320e82fc7352`; the original CI job used Linux and Node 24.19.0. The generation fixture and artifact selector are identical between that base and the reported release SHA. The branch was then cleanly rebased onto `db9847403654`; the fixture and capability/artifact-selection modules are unchanged by that rebase, and all **75 capability tests passed again on final head `58a94ab7c256687fca23e0682335b83621b9129a`**. The wide shard and changed checks were run before that mechanical rebase. The full post-fix shard is not claimed green, and hosted Full Release Validation has not been rerun.

Named follow-up: investigate cold pre-split SDK bridge import latency in `src/plugins/loader.native-module-loader.test.ts`; this PR intentionally repairs only the assigned capability-generation failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
