### PR TITLE
fix(release): start candidate registry on Windows

### DIFF
--- a/scripts/e2e/lib/plugins/npm-registry-server.mjs
+++ b/scripts/e2e/lib/plugins/npm-registry-server.mjs
@@ -65,8 +65,11 @@ const packages = new Map();
 
 function readPackageManifest(tarballPath, packageName) {
   try {
+    // GNU tar treats Windows drive letters as remote archive hosts. Keep the
+    // archive argument local, as in the prerelease artifact validator.
     const packageJson = JSON.parse(
-      execFileSync("tar", ["-xOf", tarballPath, "package/package.json"], {
+      execFileSync("tar", ["-xOf", path.basename(tarballPath), "package/package.json"], {
+        cwd: path.dirname(tarballPath),
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
       }),

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -731,11 +731,14 @@ ${command}
     }
   });
 
-  it("serves tarball dependencies using the request-visible registry origin", async () => {
+  it("serves drive-qualified tarball dependencies using the request-visible registry origin", async () => {
     const root = autoCleanupTempDirs.make("openclaw-plugin-npm-fixture-package-");
     const packageDir = path.join(root, "package");
     const portFile = path.join(root, "port");
-    const tarballPath = path.join(root, "openclaw.tgz");
+    // On POSIX, a relative D:/ path reproduces GNU tar's Windows remote-archive parsing.
+    const archiveDir = process.platform === "win32" ? root : "D:/packages";
+    const tarballPath = path.join(archiveDir, "openclaw.tgz");
+    mkdirSync(path.resolve(root, archiveDir), { recursive: true });
     mkdirSync(packageDir);
     writeJson(path.join(packageDir, "package.json"), {
       name: "openclaw",
@@ -748,7 +751,8 @@ ${command}
         "sqlite-vec": "0.1.7-alpha.2",
       },
     });
-    const packed = spawnSync("tar", ["-czf", tarballPath, "-C", root, "package"], {
+    const packed = spawnSync("tar", ["-czf", "openclaw.tgz", "-C", root, "package"], {
+      cwd: path.resolve(root, archiveDir),
       encoding: "utf8",
     });
     expect(packed.status, packed.stderr).toBe(0);
@@ -756,17 +760,19 @@ ${command}
     const child = spawn(
       process.execPath,
       [
-        "scripts/e2e/lib/plugins/npm-registry-server.mjs",
+        path.resolve("scripts/e2e/lib/plugins/npm-registry-server.mjs"),
         portFile,
         "openclaw",
         "2026.7.1-beta.3",
         tarballPath,
       ],
       {
-        cwd: process.cwd(),
+        cwd: root,
         env: {
           ...process.env,
           OPENCLAW_NPM_REGISTRY_DIST_TAGS: "latest=0.0.0,beta=2026.7.1-beta.3",
+          // Fail locally if GNU tar mistakes the synthetic drive letter for a remote host.
+          TAR_OPTIONS: "--rsh-command=false",
         },
         stdio: ["ignore", "pipe", "pipe"],
       },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where all three Windows cross-OS release-check lanes fail before installation with `Candidate npm registry did not become ready`, blocking 2026.9.1 Full Release Validation.

Evidence: [Full Release Validation 33697142798](https://github.com/openclaw/openclaw/actions/runs/33697142798), [candidate Release Checks 33698227500](https://github.com/openclaw/openclaw/actions/runs/33698227500), candidate `c92d0ae9c07e757719e676517aa9f9460a40761c`, tooling `37a5c5bd3d88`. The failing jobs are installer fresh [100472400327](https://github.com/openclaw/openclaw/actions/runs/33698227500/job/100472400327), packaged fresh [100472400368](https://github.com/openclaw/openclaw/actions/runs/33698227500/job/100472400368), and packaged upgrade [100472400434](https://github.com/openclaw/openclaw/actions/runs/33698227500/job/100472400434). All six Linux/macOS lanes passed.

## Why This Change Was Made

The shared fixture registry passes absolute Windows drive-letter paths to `tar -xOf`. GNU tar interprets a colon before any slash as a remote archive host; the Windows runner uses Git for Windows GNU tar. The registry suppresses extraction stderr and cannot finish startup before its readiness deadline. Use the archive basename with its parent directory as `cwd`, matching the existing Windows repair in `prepublish-plugin-registry-artifact.mjs` from #120619.

This is a **harness/tooling defect (classification b)**. The new registry startup path from #135639 exposed an existing nonportable extraction call. The fix stays at that shared owner; the readiness deadline and installation/update coverage remain intact. Tooling delta: +4/-1 lines, consisting of the necessary `cwd` option and two lines explaining the GNU tar contract. Test delta: +11/-5, extending an existing real HTTP registry test without adding a production test seam.

## User Impact

Release operators can start the candidate companion registry on Windows so installer, fresh-package, and upgrade validation can proceed. This change affects release/E2E tooling and does not alter the published OpenClaw installer or package.

## Evidence

- All three downloaded Windows summaries report the same failure at `companions.ts:113`, before suite dispatch. Their only logs are `npm-version.log` and an empty registry `server.log`.
- Last green v2026.8.2: publish FRV [33479039101](https://github.com/openclaw/openclaw/actions/runs/33479039101) reused [33476236573](https://github.com/openclaw/openclaw/actions/runs/33476236573); candidate child [33477244009](https://github.com/openclaw/openclaw/actions/runs/33477244009) passed Windows installer, fresh-package, upgrade, gateway/dashboard, and real agent-turn checks. Its tooling was `ce9ef22169f5cc3983a54402864313b20b13e8a6`. The failing and green runs use identical per-lane Node/npm versions: installer/upgrade v24.19.0 / 11.17.0, packaged fresh v24.15.0 / 11.12.1. Registry startup was added between those tooling revisions.
- Dependency proof: [GNU tar archive naming](https://www.gnu.org/software/tar/manual/html_section/file.html), plus direct inspection of GNU tar 1.35 `lib/rmt.h:32-41` and `lib/rtapelib.c:387-453`. The runner job log also shows Git GNU tar being invoked with `--force-local` for cache extraction.
- Built GNU tar 1.35 locally without changing system tools. With its `src` directory prepended to `PATH`, `pnpm test test/scripts/plugins-assertions.test.ts -- -t 'serves drive-qualified'` fails before the fix (`dependencies` is `undefined`) and passes after it. The fixture uses a real POSIX `D:/packages` path to exercise the GNU remote-archive parser; any regression fails locally through `--rsh-command=false`.
- `pnpm test test/scripts/plugins-assertions.test.ts test/scripts/prepublish-plugin-registry-artifact.test.ts test/scripts/openclaw-cross-os-release-checks.test.ts`: **191 tests passed**, including BSD tar behavior, registry proxy behavior, artifact identity checks, and cross-OS harness contracts.
- Real downloaded candidate artifact proof: started the fixed registry under GNU tar with all ten companion packages addressed through drive-qualified paths; ready in **715 ms**; verified exact dependency/optional-dependency metadata and byte-identical tarball downloads for every package; verified clean shutdown.

- `pnpm check:changed`: passed formatting, root-test type-checking, targeted lint, dependency/patch checks, Docker E2E boundary checks, and selected repository guards.
- Independent Codex autoreview: scoped-clean with no actionable P0–P2 findings.

Native Windows end-to-end installation/update is still unproven after this fix: no Windows host is available. The release operator must rerun the three Windows lanes with the corrected tooling. The local GNU tar proof validates the broken dependency contract and registry owner, not native Windows process behavior or the subsequent installer/update steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
