### PR TITLE
fix(ui): recover GitHub previews after dismissing loading cards

### DIFF
--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -31,6 +31,7 @@ type PreviewState = {
 type CacheEntry = {
   expiresAt: number;
   promise: Promise<GitHubPreview>;
+  signal: AbortSignal;
 };
 
 let nextHovercardId = 0;
@@ -598,13 +599,11 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     const key = `${target.kind}:${target.owner.toLowerCase()}/${target.repo.toLowerCase()}#${target.number}`;
     const now = Date.now();
     const cached = this.cache.get(key);
-    if (cached && cached.expiresAt > now) {
-      this.cache.delete(key);
+    this.cache.delete(key);
+    // Dismissal invalidates only that request, even before its rejection settles.
+    if (cached && !cached.signal.aborted && cached.expiresAt > now) {
       this.cache.set(key, cached);
       return cached.promise;
-    }
-    if (cached) {
-      this.cache.delete(key);
     }
 
     const load = async (): Promise<GitHubPreview> => {
@@ -626,6 +625,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
 
     const entry: CacheEntry = {
       expiresAt: now + SUCCESS_CACHE_MS,
+      signal,
       promise: load().catch((error: unknown) => {
         // Keep short-lived failures cached so repeatedly crossing a broken or
         // private link does not burn GitHub's anonymous rate limit.

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { i18n } from "../i18n/index.ts";
 import { GitHubLinkHovercardProvider } from "./github-link-hovercard.runtime.ts";
@@ -287,6 +288,77 @@ describe("openclaw-github-link-hovercard-provider", () => {
     expect(hovercard()).toBeNull();
     await hover(anchor);
     expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["immediate rejection", "late rejection", "late success"])(
+    "reopens an abandoned request without poisoning its replacement cache: %s",
+    async (settlement) => {
+      const abandoned = createDeferred<ReturnType<typeof issuePreviewResponse>>();
+      let requestSignal: AbortSignal | undefined;
+      const request = vi
+        .fn()
+        .mockImplementationOnce(
+          (_method: string, _params: unknown, options: { signal: AbortSignal }) => {
+            requestSignal = options.signal;
+            if (settlement === "immediate rejection") {
+              options.signal.addEventListener(
+                "abort",
+                () => abandoned.reject(new Error("gateway request aborted")),
+                { once: true },
+              );
+            }
+            return abandoned.promise;
+          },
+        )
+        .mockResolvedValue(issuePreviewResponse());
+      const { anchor, provider } = createLink(ISSUE_HREF);
+      provider.client = { request } as unknown as GatewayBrowserClient;
+
+      await hover(anchor);
+      expect(hovercard()?.dataset.loading).toBe("true");
+      leave(anchor);
+      await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS);
+      expect(requestSignal?.aborted).toBe(true);
+      await hover(anchor);
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(hovercard()?.textContent).toContain("Keep hover previews reachable");
+
+      if (settlement === "late success") {
+        abandoned.resolve(issuePreviewResponse({ title: "Abandoned preview" }));
+      } else {
+        abandoned.reject(new Error("gateway request aborted"));
+      }
+      await vi.advanceTimersByTimeAsync(0);
+      expect(hovercard()?.textContent).toContain("Keep hover previews reachable");
+      leave(anchor);
+      await vi.advanceTimersByTimeAsync(GITHUB_HOVERCARD_CLOSE_DELAY_MS);
+      await hover(anchor);
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(hovercard()?.textContent).toContain("Keep hover previews reachable");
+    },
+  );
+
+  it("keeps genuine request failures cached for 30 seconds before retrying on hover", async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("GitHub preview unavailable"))
+      .mockResolvedValue(issuePreviewResponse());
+    const { anchor, provider } = createLink(ISSUE_HREF);
+    provider.client = { request } as unknown as GatewayBrowserClient;
+
+    await hover(anchor);
+    expect(hovercard()?.dataset.state).toBe("unavailable");
+    leave(anchor);
+    await vi.advanceTimersByTimeAsync(29_000);
+    await hover(anchor);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(hovercard()?.dataset.state).toBe("unavailable");
+
+    leave(anchor);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await hover(anchor);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(hovercard()?.textContent).toContain("Keep hover previews reachable");
   });
 
   it("stays open while the pointer travels from the link onto the card", async () => {

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -94,8 +94,7 @@ const pullPreviewResponse = {
   updatedAt: "2026-07-04T09:53:55Z",
 };
 
-// Shared page setup for the two pointer-lifecycle cases below: both only need
-// a single previewable pull-request link, unlike the full walkthrough above.
+// Shared page setup for lifecycle cases that need only one pull-request link.
 async function openPullPreviewPage(deferPreview = false): Promise<{
   card: Locator;
   gateway: Awaited<ReturnType<typeof installMockGateway>>;
@@ -193,6 +192,37 @@ describeControlUiE2e("GitHub link hover cards", () => {
     }
     expect(await card.locator(".skeleton").count()).toBe(0);
     expect(await card.getAttribute("aria-label")).not.toBe("Loading GitHub details…");
+  });
+
+  it("reloads a dismissed pending preview on rehover and caches the successful response", async () => {
+    const proofDir =
+      artifactDir ?? createControlUiE2eArtifactDir("github-link-hovercard-cancellation");
+    const { card, gateway, page, pullLink } = await openPullPreviewPage(true);
+
+    await pullLink.hover();
+    await gateway.waitForRequest("controlUi.githubPreview");
+    await expect.poll(() => card.getAttribute("aria-label")).toBe("Loading GitHub details…");
+    await page.mouse.move(1, 1);
+    await expect.poll(() => card.count()).toBe(0);
+
+    await pullLink.hover();
+    await card.waitFor({ state: "visible" });
+    // The abandoned response arrives after rehover; a fresh request must own
+    // the rendered result, and the retired response must not poison its cache.
+    await gateway.resolveDeferred("controlUi.githubPreview");
+    await expect.poll(() => card.getAttribute("data-loading")).toBe("false");
+    // Capture the settled state even when the title assertion below fails.
+    await page.screenshot({
+      path: path.join(proofDir, "github-hovercard-cancellation-rehover.png"),
+    });
+    await expectText(card, pullPreviewResponse.title);
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(2);
+
+    await page.mouse.move(1, 1);
+    await expect.poll(() => card.count()).toBe(0);
+    await pullLink.hover();
+    await expectText(card, pullPreviewResponse.title);
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(2);
   });
 
   it("previews issue and pull request links while preserving navigation", async () => {


### PR DESCRIPTION
Closes #136765 — GitHub previews stay unavailable after dismissing a loading card.

## What Problem This Solves

Fixes an issue where users reopening a GitHub issue or pull request hovercard would see “GitHub preview unavailable” for 30 seconds after dismissing the card while its request was still loading. Rehover reused the cancelled request instead of asking for the preview again.

## Why This Change Was Made

The hovercard cache now retains the originating request's AbortSignal and reuses only entries that are both unexpired and not aborted. This keeps cancellation ownership with the existing request lifecycle instead of adding retries, matching error messages, or clearing unrelated cached previews. Late completion of an abandoned request cannot replace or evict its successor.

The successful five-minute cache and genuine-failure 30-second cache remain unchanged. No GitHub credential selection, private-repository checks, redirects, Gateway protocol, configuration, or storage behavior changes.

## User Impact

Users can move away from a loading GitHub preview and hover it again immediately without a false unavailable period. Successful previews remain cached, and genuine upstream failures retain their quota-protecting backoff.

## Evidence

- Before-fix component regression: all three abandonment-order cases failed because rehover sent one request instead of two; the existing 22 tests passed.
- Fixed component and Gateway-client proof: **43 tests passed** (25 hovercard, 18 request lifecycle).
- Before-fix real Chromium regression: **1 expected failure**, showing “GitHub preview unavailable” after the dismiss → rehover sequence.
- Fixed Chromium suite: **8 tests passed**, including a fresh request after dismissal, late-response isolation, successful caching on a subsequent hover, navigation, keyboard access, loading states, and ordinary failure rendering.
- Browser screenshots below show the same synthetic transcript and interaction before and after the fix. They use the bundled Control UI with a mocked Gateway WebSocket; they are not authenticated-live GitHub API evidence.
- Scoped changed-file checks, formatting, and `git diff --check` passed. The browser lane also builds the actual UI bundle.

Commands:

```bash
node scripts/run-vitest.mjs ui/src/components/github-link-hovercard.test.ts packages/gateway-client/src/protocol-client.request.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/github-link-hovercard.e2e.test.ts
```

```bash
node scripts/check-changed.mjs -- ui/src/components/github-link-hovercard.runtime.ts ui/src/components/github-link-hovercard.test.ts
```

```bash
node scripts/check-changed.mjs -- ui/src/e2e/github-link-hovercard.e2e.test.ts
```

Production LOC: **+5/−5 (net 0)**. Tests: **+104/−2 (net +102)**. No new production helper, test-only seam, retry path, or dependency.

Related work: #125137 proposes preview prewarming to reduce latency; it does not repair the cancelled browser-promise cache and is not superseded by this fix.

![Before: dismissed loading preview stays unavailable on rehover](https://github.com/user-attachments/assets/fa582b84-9046-42e8-896e-02e1a63cc5e4)

![After: rehover loads a fresh GitHub preview](https://github.com/user-attachments/assets/1ef2820c-0a98-4a5a-9ec0-f00010481c75)

## Review Follow-through

ClawSweeper's [completed exact-head review](https://github.com/openclaw/openclaw/pull/136772#issuecomment-5518678948) found no introduced correctness or security defect. Its one before-merge item asks for data-model compatibility proof because it classified `CacheEntry` as a persistent cache schema.

That classification is not applicable to this patch: `GitHubLinkHovercardProvider` owns `private readonly cache = new Map<string, CacheEntry>()` in browser memory (`ui/src/components/github-link-hovercard.runtime.ts:327`). The entries contain a `Promise` and now its originating `AbortSignal`; `loadPreview` only gets, sets, and deletes entries in that component-local Map. There is no serialization, file or database store, schema version, migration, or change to the Gateway request/response shape. Reloading the UI recreates the component and its cache. The requested migration/upgrade test is therefore skipped because no persistent representation changes; existing success/failure cache behavior and cancellation ordering are covered by the 43 focused tests and 8 Chromium tests above. No additional rank-up moves were listed.
