### PR TITLE
fix(docker): install workspace dependencies for binding smoke

### DIFF
--- a/scripts/e2e/plugin-binding-command-escape.Dockerfile
+++ b/scripts/e2e/plugin-binding-command-escape.Dockerfile
@@ -9,6 +9,8 @@ RUN corepack enable
 WORKDIR /workspace/openclaw
 COPY . .
 
-RUN OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL=1 pnpm install --frozen-lockfile --ignore-scripts --filter openclaw
+# Source tests resolve workspace packages through aliases, outside the root
+# dependency graph. Install their isolated links along with the root tools.
+RUN OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL=1 pnpm install --frozen-lockfile --ignore-scripts
 
 CMD ["bash"]

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -7700,9 +7700,7 @@ done
     );
 
     expect(dockerfile).toContain("OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL=1");
-    expect(dockerfile).toContain(
-      "pnpm install --frozen-lockfile --ignore-scripts --filter openclaw",
-    );
+    expect(dockerfile).toContain("pnpm install --frozen-lockfile --ignore-scripts\n");
   });
 
   it("routes QR import Docker smoke through the timeout-aware run helper", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Docker plugin-binding regression lane fails before executing any of its three required cases after source installs switched to pnpm's isolated linker. This blocks the core Docker job in [2026.9.1 Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/33698227500/job/100472662119).

## Why This Change Was Made

The lane's dedicated, single-stage Dockerfile ran `pnpm install --filter openclaw`. Its root tools were installed, but private workspaces reached through TypeScript source aliases had no package-local dependency links. `markdown-core` therefore could not import its declared `mdast-util-from-markdown` dependency. The missing links were never installed; the root production Dockerfile's cross-stage copies are not involved in this lane.

Remove the root-only filter and let pnpm install the workspace graph normally, preserving the frozen lockfile, isolated linker, and disabled lifecycle scripts. The existing helper guard now requires that unfiltered install. Using `openclaw...` would still miss source-alias workspaces outside the root's declared dependency graph. This follows pnpm's [package selection contract](https://pnpm.io/filtering#matching).

## User Impact

Release operators can run all three plugin-binding regression cases in Docker again. This changes the test image only. It does not repair the independent plugin/update failures described below or establish that the full release validation is green.

## Evidence

Local Linux/arm64 proof on OrbStack, using the same pinned Node image as CI:

```sh
# Before: exit 1, three failed suites, ERR_MODULE_NOT_FOUND.
OPENCLAW_PLUGIN_BINDING_COMMAND_ESCAPE_E2E_IMAGE=openclaw-rel-fix-binding:before pnpm test:docker:plugin-binding-command-escape

# After: exit 0, OK (3 focused tests).
OPENCLAW_PLUGIN_BINDING_COMMAND_ESCAPE_E2E_IMAGE=openclaw-rel-fix-binding:after pnpm test:docker:plugin-binding-command-escape

# Run against each image: before fails; after exits 0.
docker run --rm --workdir /workspace/openclaw/packages/markdown-core openclaw-rel-fix-binding:after node --input-type=module -e 'await import("mdast-util-from-markdown")'
```

The before image has a root `.pnpm` store but no `packages/markdown-core/node_modules`. The after image has working relative links from both `packages/markdown-core/node_modules/mdast-util-from-markdown` and `extensions/telegram/node_modules/grammy` into that store. No packages were hand-copied.

- `pnpm test test/scripts/docker-build-helper.test.ts`: 273 passed, two existing skips.
- `pnpm check:changed`: passed, including root test typechecking, script lint, Docker boundaries, and changed-test lint.
- Fresh Codex autoreview: scoped-clean at P0, no accepted/actionable findings.
- Local validation ran on `f57aca6ac0fd5c24440d233169c36af554b86944` plus this patch. Clean rebase onto `1842ab774cd60155803b55248aaf0417b6e2bbd1` preserved the patch exactly (`git range-diff`); the focused helper contract and diff checks were rerun afterward.
- Tooling: +3/-1, with the net two lines explaining the workspace-alias invariant; tests: +1/-3. Production runtime LOC: zero.

The core artifact already had eight other constituent lanes passing. Five downloaded Docker artifacts and their job logs show independent remaining failures:

| Lane | Observed failure |
| --- | --- |
| [plugin-update](https://github.com/openclaw/openclaw/actions/runs/33698227500/job/100473215997) | Final missing-payload `update repair --accept-capabilities --yes --json` exits 1: package owner has "no authoritative runtime child list". Reproduced locally with the exact release package and registry below. |
| [plugins/runtime plugins](https://github.com/openclaw/openclaw/actions/runs/33698227500/job/100472662043) | `OpenClaw does not know the command "demo-npm"`. |
| [published-upgrade-survivor](https://github.com/openclaw/openclaw/actions/runs/33698227500/job/100472662074) | `whatsapp plugin version changed: 2026.8.2` after the core update and doctor completed; `update-channel-switch` passed. |
| [upgrade-survivor](https://github.com/openclaw/openclaw/actions/runs/33698227500/job/100473215912) | The prepare-state probe rejects legacy `channels.discord.dm.policy` / `allowFrom` fields. |

The local package-acceptance reproduction used:

```sh
gh run download 33698227500 --repo openclaw/openclaw -n package-under-test-33698227500-1 -D .artifacts/rel-fix-evidence/package
gh run download 33697728959 --repo openclaw/openclaw -n docker-e2e-prepublish-plugin-registry-33697728959-1 -D .artifacts/rel-fix-evidence/registry
OPENCLAW_CURRENT_PACKAGE_TGZ="$PWD/.artifacts/rel-fix-evidence/package/openclaw-current.tgz" OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR="$PWD/.artifacts/rel-fix-evidence/registry" OPENCLAW_PLUGIN_UPDATE_E2E_IMAGE=openclaw-rel-fix-package:bare pnpm test:docker:plugin-update
```

Package SHA-256: `befd59d701091de5f855371ba58d4a4932ca9958d006a0e28442aba76565d264`; registry manifest SHA-256: `c67573da702e9136f756056ad7677ae7c4fab013eccfce9c451e42b59aba666b`; both bind to release source `c92d0ae9c07e757719e676517aa9f9460a40761c`. An initial attempt without the registry failed with `ETARGET @openclaw/ai@2026.9.1`; the verified registry resolves that prerequisite. With it, installation, consent denial/acceptance, repair, and fresh-process update pass before the independent missing-payload failure.

In the inspected earlier-run upgrade and binding logs from `33677409471`, the alleged packageManager errors occur only in echoed setup code. The upgrade lane actually rejected unexpected WhatsApp ClawHub fixture requests; the binding log retained a clipped two-test tail. Neither establishes the same missing-dependency failure.

Not rerun: the full core aggregate, production runtime image, plugin prerelease matrix, or remaining package/update lanes. The independent failures above remain follow-up release blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
