### PR TITLE
fix(cli-runner): report discarded CLI stderr bytes

### DIFF
--- a/src/agents/cli-runner/execute-output-buffer.test.ts
+++ b/src/agents/cli-runner/execute-output-buffer.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { appendCliOutputTail } from "./execute-output-buffer.js";
+import {
+  appendCliOutputTail,
+  CLI_RUNNER_OUTPUT_TAIL_BYTES,
+  formatCliStderrTail,
+} from "./execute-output-buffer.js";
 
-const CLI_RUNNER_OUTPUT_TAIL_BYTES = 64 * 1024;
 const REPLACEMENT_CHARACTER = String.fromCharCode(0xfffd);
 const MULTIBYTE_CHARACTER = String.fromCodePoint(0x1f642);
 
@@ -11,11 +14,12 @@ describe("appendCliOutputTail", () => {
       CLI_RUNNER_OUTPUT_TAIL_BYTES - 3,
     )}`;
 
-    const output = appendCliOutputTail("", chunk);
+    const { tail, droppedBytes } = appendCliOutputTail("", chunk);
 
-    expect(Buffer.byteLength(output)).toBeLessThanOrEqual(CLI_RUNNER_OUTPUT_TAIL_BYTES);
-    expect(output).not.toContain(REPLACEMENT_CHARACTER);
-    expect(output).toBe("y".repeat(CLI_RUNNER_OUTPUT_TAIL_BYTES - 3));
+    expect(Buffer.byteLength(tail)).toBeLessThanOrEqual(CLI_RUNNER_OUTPUT_TAIL_BYTES);
+    expect(tail).not.toContain(REPLACEMENT_CHARACTER);
+    expect(tail).toBe("y".repeat(CLI_RUNNER_OUTPUT_TAIL_BYTES - 3));
+    expect(droppedBytes).toBe(14);
   });
 
   it("keeps appended tails UTF-8 safe when rolling overflow starts inside a character", () => {
@@ -23,10 +27,39 @@ describe("appendCliOutputTail", () => {
       CLI_RUNNER_OUTPUT_TAIL_BYTES - 14,
     )}`;
 
-    const output = appendCliOutputTail(existingTail, "z".repeat(11));
+    const { tail, droppedBytes } = appendCliOutputTail(existingTail, "z".repeat(11));
 
-    expect(Buffer.byteLength(output)).toBeLessThanOrEqual(CLI_RUNNER_OUTPUT_TAIL_BYTES);
-    expect(output).not.toContain(REPLACEMENT_CHARACTER);
-    expect(output).toBe(`${"y".repeat(CLI_RUNNER_OUTPUT_TAIL_BYTES - 14)}${"z".repeat(11)}`);
+    expect(Buffer.byteLength(tail)).toBeLessThanOrEqual(CLI_RUNNER_OUTPUT_TAIL_BYTES);
+    expect(tail).not.toContain(REPLACEMENT_CHARACTER);
+    expect(tail).toBe(`${"y".repeat(CLI_RUNNER_OUTPUT_TAIL_BYTES - 14)}${"z".repeat(11)}`);
+    expect(droppedBytes).toBe(14);
+  });
+
+  it("reports zero dropped bytes when the combined output fits within the cap", () => {
+    const { tail, droppedBytes } = appendCliOutputTail("hello ", "world");
+
+    expect(tail).toBe("hello world");
+    expect(droppedBytes).toBe(0);
+  });
+});
+
+describe("formatCliStderrTail", () => {
+  it("returns the tail unchanged when no bytes were discarded", () => {
+    expect(formatCliStderrTail("error details", 0)).toBe("error details");
+  });
+
+  it("prepends a discard note when bytes were discarded", () => {
+    const formatted = formatCliStderrTail("error details", 1234);
+
+    expect(formatted).toContain("1234 UTF-8 bytes of earlier stderr discarded");
+    expect(formatted).toContain("error details");
+  });
+
+  it("returns only the discard note when the tail is empty but bytes were discarded", () => {
+    const formatted = formatCliStderrTail("   ", 1234);
+
+    expect(formatted).toBe(
+      `[1234 UTF-8 bytes of earlier stderr discarded at the ${CLI_RUNNER_OUTPUT_TAIL_BYTES}-byte retention cap]`,
+    );
   });
 });

--- a/src/agents/cli-runner/execute-output-buffer.ts
+++ b/src/agents/cli-runner/execute-output-buffer.ts
@@ -1,7 +1,28 @@
+import { Buffer } from "node:buffer";
 import { truncateUtf8Suffix } from "../../utils/utf8-truncate.js";
 
-const CLI_RUNNER_OUTPUT_TAIL_BYTES = 64 * 1024;
+export const CLI_RUNNER_OUTPUT_TAIL_BYTES = 64 * 1024;
 
-export function appendCliOutputTail(tail: string, chunk: string): string {
-  return truncateUtf8Suffix(`${tail}${chunk}`, CLI_RUNNER_OUTPUT_TAIL_BYTES);
+export interface CliOutputTail {
+  tail: string;
+  droppedBytes: number;
+}
+
+export function appendCliOutputTail(tail: string, chunk: string): CliOutputTail {
+  const combined = `${tail}${chunk}`;
+  const truncated = truncateUtf8Suffix(combined, CLI_RUNNER_OUTPUT_TAIL_BYTES);
+  return {
+    tail: truncated,
+    droppedBytes: Buffer.byteLength(combined, "utf8") - Buffer.byteLength(truncated, "utf8"),
+  };
+}
+
+/** Labels lost stderr before the retained diagnostic so it cannot look complete. */
+export function formatCliStderrTail(tail: string, droppedBytes: number): string {
+  const diagnostic = tail.trim();
+  if (droppedBytes === 0) {
+    return diagnostic;
+  }
+  const note = `[${droppedBytes} UTF-8 bytes of earlier stderr discarded at the ${CLI_RUNNER_OUTPUT_TAIL_BYTES}-byte retention cap]`;
+  return diagnostic ? `${note}\n${diagnostic}` : note;
 }

--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -15,7 +15,7 @@ import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import type { CliExecuteDeps } from "./execute-deps.js";
 import type { CliEventHandlers } from "./execute-events.js";
 import { createCliAbortError, executeNodeClaudeRun } from "./execute-node-claude.js";
-import { appendCliOutputTail } from "./execute-output-buffer.js";
+import { appendCliOutputTail, formatCliStderrTail } from "./execute-output-buffer.js";
 import { executePluginOwnedProcess } from "./execute-plugin.js";
 import type { CliToolTracking } from "./execute-tool-tracking.js";
 import {
@@ -136,6 +136,7 @@ export async function executeCliProcess(params: {
   const stdoutHash = crypto.createHash("sha256");
   let stdoutParseExceeded = false;
   let stderrTail = "";
+  let stderrDroppedBytes = 0;
   let stderrParseBuffer: Buffer = Buffer.alloc(0);
   let stderrBytes = 0;
   const stderrHash = crypto.createHash("sha256");
@@ -145,7 +146,7 @@ export async function executeCliProcess(params: {
     params.diagnostics?.observeCliOutput(chunk, "stdout", chunkBytes);
     stdoutBytes += chunkBytes;
     stdoutHash.update(chunk);
-    stdoutTail = appendCliOutputTail(stdoutTail, chunk);
+    stdoutTail = appendCliOutputTail(stdoutTail, chunk).tail;
     if (!stdoutParseExceeded) {
       const next = appendCliOutputParseBuffer(stdoutParseBuffer, chunk);
       stdoutParseBuffer = next.buffer;
@@ -157,7 +158,9 @@ export async function executeCliProcess(params: {
     params.diagnostics?.observeCliOutput(chunk, "stderr");
     stderrBytes += Buffer.byteLength(chunk);
     stderrHash.update(chunk);
-    stderrTail = appendCliOutputTail(stderrTail, chunk);
+    const { tail, droppedBytes } = appendCliOutputTail(stderrTail, chunk);
+    stderrTail = tail;
+    stderrDroppedBytes += droppedBytes;
     if (!stderrParseExceeded) {
       const next = appendCliOutputParseBuffer(stderrParseBuffer, chunk);
       stderrParseBuffer = next.buffer;
@@ -335,7 +338,7 @@ export async function executeCliProcess(params: {
   let stdout: string | undefined;
   const readStdout = () => (stdout ??= stdoutParseBuffer.toString("utf8").trim());
   const stdoutDiagnostic = stdoutTail.trim();
-  const stderrDiagnostic = stderrTail.trim();
+  const stderrDiagnostic = formatCliStderrTail(stderrTail, stderrDroppedBytes);
   const processDiagnostics = {
     backendId: context.backendResolved.id,
     processReason: result.reason,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the CLI runner could produce a large stderr stream, truncate it to the 64 KiB retention cap, and present the remaining tail to users/operators without any indication that content had been discarded. This made truncated error diagnostics look complete, leading to confusion when debugging CLI failures.

## Why This Change Was Made

`appendCliOutputTail` in `src/agents/cli-runner/execute-output-buffer.ts` previously returned only the truncated tail string. It now returns both the tail and the number of UTF-8 bytes discarded by the truncation. `execute-process.ts` accumulates the discarded byte count for stderr and prefixes the retained diagnostic with a clear note when any bytes were lost, matching the pattern already used for session search tools (`src/agents/sessions/tools/limits.ts`).

## User Impact

Users and operators reviewing CLI failure diagnostics will now see a leading note such as `[1234 UTF-8 bytes of earlier stderr discarded at the 65536-byte retention cap]` whenever the stderr tail was truncated, so they know the displayed output may be incomplete.

## Evidence

- Added/updated unit tests in `src/agents/cli-runner/execute-output-buffer.test.ts`:
  - `appendCliOutputTail` now reports `droppedBytes` for both single-chunk and rolling-overflow truncation scenarios.
  - New `formatCliStderrTail` tests verify the discard note is prepended only when bytes were dropped and that an empty tail still reports the note.
- Focused test run:
  ```bash
  node scripts/run-vitest.mjs src/agents/cli-runner/execute-output-buffer.test.ts --run
  # Test Files  1 passed (1)
  #      Tests  6 passed (6)
  ```
- Local lint/typecheck:
  ```bash
  node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
    src/agents/cli-runner/execute-output-buffer.ts \
    src/agents/cli-runner/execute-process.ts \
    src/agents/cli-runner/execute-output-buffer.test.ts
  # exit 0
  node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental \
    --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
  # exit 0
  ```

## Risk checklist

- User-visible behavior change? Yes — CLI failure diagnostics now include a discard note when stderr was truncated.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? No.
- Highest-risk area: the discard note could be misread as an error itself; mitigated by keeping it concise and only appearing when truncation actually occurred.



Fixes #136852
