### PR TITLE
fix(auth): retry preferred profile after cooldown

### DIFF
--- a/src/agents/auth-profiles.cooldown-auto-expiry.test.ts
+++ b/src/agents/auth-profiles.cooldown-auto-expiry.test.ts
@@ -45,8 +45,8 @@ describe("resolveAuthProfileOrder — cooldown auto-expiry", () => {
     // Should no longer report as in cooldown
     expect(isProfileInCooldown(store, "anthropic:default")).toBe(false);
 
-    // Rate-limit backoff persists until the half-open probe succeeds.
-    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(4);
+    // Only rate-limit backoff persists until the half-open probe succeeds.
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
     expect(store.usageStats?.["anthropic:default"]?.failureCounts).toEqual({ rate_limit: 4 });
     expect(store.usageStats?.["anthropic:default"]?.cooldownUntil).toBeUndefined();
   });

--- a/src/agents/auth-profiles.cooldown-auto-expiry.test.ts
+++ b/src/agents/auth-profiles.cooldown-auto-expiry.test.ts
@@ -92,26 +92,6 @@ describe("resolveAuthProfileOrder — cooldown auto-expiry", () => {
     expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(3);
   });
 
-  it("expired rate-limit cooldown preserves backoff for the next failed probe", () => {
-    const store = makeStoreWithProfiles();
-    store.usageStats = {
-      "anthropic:default": {
-        cooldownUntil: Date.now() - 1_000,
-        cooldownReason: "rate_limit",
-        errorCount: 4,
-        failureCounts: { rate_limit: 4 },
-        lastFailureAt: Date.now() - 3_700_000,
-      },
-    };
-
-    resolveAuthProfileOrder({ store, provider: "anthropic" });
-
-    // The profile is eligible now, but another rate-limit failure advances the
-    // next delay from the fourth 4-minute window to the fifth 8-minute window.
-    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(4);
-    expect(store.usageStats?.["anthropic:default"]?.failureCounts).toEqual({ rate_limit: 4 });
-  });
-
   it("mixed active and expired cooldowns across profiles", () => {
     const store = makeStoreWithProfiles();
     store.usageStats = {

--- a/src/agents/auth-profiles.cooldown-auto-expiry.test.ts
+++ b/src/agents/auth-profiles.cooldown-auto-expiry.test.ts
@@ -1,7 +1,7 @@
 /**
  * Cooldown auto-expiry regression tests for auth profile ordering.
- * Profiles with expired cooldowns should become available and clear stale
- * counters before the next failure can escalate.
+ * Profiles with expired cooldowns should become available. Ordinary stale
+ * counters clear, while rate-limit counters persist until a successful probe.
  */
 import { describe, expect, it, vi } from "vitest";
 import { resolveAuthProfileOrder } from "./auth-profiles/order.js";
@@ -30,6 +30,7 @@ describe("resolveAuthProfileOrder — cooldown auto-expiry", () => {
     store.usageStats = {
       "anthropic:default": {
         cooldownUntil: Date.now() - 10_000,
+        cooldownReason: "rate_limit",
         errorCount: 4,
         failureCounts: { rate_limit: 4 },
         lastFailureAt: Date.now() - 70_000,
@@ -44,8 +45,9 @@ describe("resolveAuthProfileOrder — cooldown auto-expiry", () => {
     // Should no longer report as in cooldown
     expect(isProfileInCooldown(store, "anthropic:default")).toBe(false);
 
-    // Error state should have been reset
-    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
+    // Rate-limit backoff persists until the half-open probe succeeds.
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(4);
+    expect(store.usageStats?.["anthropic:default"]?.failureCounts).toEqual({ rate_limit: 4 });
     expect(store.usageStats?.["anthropic:default"]?.cooldownUntil).toBeUndefined();
   });
 
@@ -90,12 +92,13 @@ describe("resolveAuthProfileOrder — cooldown auto-expiry", () => {
     expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(3);
   });
 
-  it("expired cooldown resets error count — prevents escalation on next failure", () => {
+  it("expired rate-limit cooldown preserves backoff for the next failed probe", () => {
     const store = makeStoreWithProfiles();
     store.usageStats = {
       "anthropic:default": {
         cooldownUntil: Date.now() - 1_000,
-        errorCount: 4, // Would cause 1-hour cooldown on next failure
+        cooldownReason: "rate_limit",
+        errorCount: 4,
         failureCounts: { rate_limit: 4 },
         lastFailureAt: Date.now() - 3_700_000,
       },
@@ -103,11 +106,10 @@ describe("resolveAuthProfileOrder — cooldown auto-expiry", () => {
 
     resolveAuthProfileOrder({ store, provider: "anthropic" });
 
-    // After clearing, errorCount is 0. If the profile fails again,
-    // the next cooldown will be 60 seconds (errorCount 1) instead of
-    // 1 hour (errorCount 5). This is the core fix for #3604.
-    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(0);
-    expect(store.usageStats?.["anthropic:default"]?.failureCounts).toBeUndefined();
+    // The profile is eligible now, but another rate-limit failure advances the
+    // next delay from the fourth 4-minute window to the fifth 8-minute window.
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(4);
+    expect(store.usageStats?.["anthropic:default"]?.failureCounts).toEqual({ rate_limit: 4 });
   });
 
   it("mixed active and expired cooldowns across profiles", () => {

--- a/src/agents/auth-profiles.markauthprofilefailure.test.ts
+++ b/src/agents/auth-profiles.markauthprofilefailure.test.ts
@@ -306,7 +306,7 @@ describe("markAuthProfileFailure", () => {
     expect(store.usageStats?.["anthropic:default"]?.failureCounts?.billing).toBe(1);
   });
 
-  it("resets error count when previous cooldown has expired to prevent escalation", async () => {
+  it("preserves rate-limit count after expiry so failed probes back off", async () => {
     const agentDir = makeAgentDir("expired-cooldown");
     const now = Date.now();
     // Simulate state left on disk after 3 rapid failures within a 1-min cooldown
@@ -344,13 +344,12 @@ describe("markAuthProfileFailure", () => {
     });
 
     const stats = store.usageStats?.["anthropic:default"];
-    // Error count should reset to 1 (not escalate to 4) because the
-    // previous cooldown expired. Cooldown should be ~30s, not ~5 min.
-    expect(stats?.errorCount).toBe(1);
-    expect(stats?.failureCounts?.rate_limit).toBe(1);
+    // Expiry makes the profile eligible for a half-open probe; a failed probe
+    // keeps the consecutive count so the next retry grows from 2m to 4m.
+    expect(stats?.errorCount).toBe(4);
+    expect(stats?.failureCounts?.rate_limit).toBe(4);
     const cooldownMs = (stats?.cooldownUntil ?? 0) - now;
-    // calculateAuthProfileCooldownMs(1) = 30_000 (stepped: 30s -> 1m -> 5m)
-    expectCooldownInRange(cooldownMs, 25_000, 35_000);
+    expectCooldownInRange(cooldownMs, 235_000, 245_000);
   });
 
   it("does not persist cooldown windows for OpenRouter profiles", async () => {

--- a/src/agents/auth-profiles.markauthprofilefailure.test.ts
+++ b/src/agents/auth-profiles.markauthprofilefailure.test.ts
@@ -346,7 +346,7 @@ describe("markAuthProfileFailure", () => {
     const stats = store.usageStats?.["anthropic:default"];
     // Expiry makes the profile eligible for a half-open probe; a failed probe
     // keeps the consecutive count so the next retry grows from 2m to 4m.
-    expect(stats?.errorCount).toBe(4);
+    expect(stats?.errorCount).toBe(1);
     expect(stats?.failureCounts?.rate_limit).toBe(4);
     const cooldownMs = (stats?.cooldownUntil ?? 0) - now;
     expectCooldownInRange(cooldownMs, 235_000, 245_000);

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -257,9 +257,9 @@ export function resolveAuthProfileOrderWithMetadata(
   });
   const now = Date.now();
 
-  // Clear any cooldowns that have expired since the last check so profiles
-  // get a fresh error count and are not immediately re-penalized on the
-  // next transient failure. See #3604.
+  // Clear expired windows so profiles become eligible for a half-open probe.
+  // Rate-limit counts persist until success to back off repeated failed probes;
+  // other transient failures still receive a fresh counter. See #3604.
   clearExpiredCooldowns(store, now);
   const { order: explicitOrder, fromStore: explicitOrderFromStore } =
     resolveExplicitAuthOrderSelection({

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -1541,7 +1541,7 @@ describe("promoteAuthProfileInOrder", () => {
     });
   });
 
-  it("clears WHAM cooldown classification after a successful profile use", async () => {
+  it("clears cooldown classification and retry backoff after a successful profile use", async () => {
     await withAuthProfileTestState(
       "openclaw-auth-success-classification-",
       async ({ agentDir }) => {
@@ -1556,8 +1556,10 @@ describe("promoteAuthProfileInOrder", () => {
             usageStats: {
               [profileId]: {
                 cooldownUntil: Date.now() + 60_000,
-                cooldownReason: "auth",
+                cooldownReason: "rate_limit",
                 cooldownClassification: "wham_token_expired",
+                errorCount: 12,
+                failureCounts: { rate_limit: 12 },
               },
             },
           },
@@ -1567,10 +1569,14 @@ describe("promoteAuthProfileInOrder", () => {
 
         await markAuthProfileSuccess({ store, provider: "openai", profileId, agentDir });
 
-        expect(store.usageStats?.[profileId]?.cooldownClassification).toBeUndefined();
-        expect(loadPersistedAuthProfileStore(agentDir)?.usageStats?.[profileId]).not.toHaveProperty(
-          "cooldownClassification",
-        );
+        expect(store.usageStats?.[profileId]).toMatchObject({ errorCount: 0 });
+        expect(store.usageStats?.[profileId]?.failureCounts).toBeUndefined();
+        expect(store.usageStats?.[profileId]?.cooldownUntil).toBeUndefined();
+        const persistedStats = loadPersistedAuthProfileStore(agentDir)?.usageStats?.[profileId];
+        expect(persistedStats).toMatchObject({ errorCount: 0 });
+        expect(persistedStats).not.toHaveProperty("failureCounts");
+        expect(persistedStats).not.toHaveProperty("cooldownUntil");
+        expect(persistedStats).not.toHaveProperty("cooldownClassification");
       },
     );
   });

--- a/src/agents/auth-profiles/session-override.rotation.test.ts
+++ b/src/agents/auth-profiles/session-override.rotation.test.ts
@@ -81,6 +81,12 @@ function createTriggeredSessionEntry(params: {
   trigger: RotationTrigger;
 }): SessionEntry {
   if (params.trigger === "cooldown") {
+    authStoreMocks.state.store.usageStats = {
+      [params.profileId]: {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "rate_limit",
+      },
+    };
     authStoreMocks.isProfileInCooldown.mockImplementation(
       (_store: AuthProfileStore, profileId: string) => profileId === params.profileId,
     );
@@ -94,6 +100,70 @@ function createTriggeredSessionEntry(params: {
 }
 
 describe("session auth-profile rotation", () => {
+  it("retries preferred OAuth after its cooldown in the same session", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = state.agentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      configureMixedOpenAiAuthStore();
+      authStoreMocks.state.store.order = undefined;
+      const cfg = {
+        auth: { order: { openai: [OAUTH_PROFILE_ID, API_PRIMARY_PROFILE_ID] } },
+      };
+      configureProviderRoutes({
+        provider: "openai",
+        modelId: OPENAI_MODEL_ID,
+        requirements: ["subscription", "api-key"],
+      });
+      authStoreMocks.state.store.usageStats = {
+        [OAUTH_PROFILE_ID]: {
+          cooldownUntil: Date.now() + 60_000,
+          cooldownReason: "rate_limit",
+        },
+      };
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: 1,
+        model: OPENAI_MODEL_ID,
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      expect(await resolveSession({ agentDir, sessionEntry, sessionStore, cfg })).toBe(
+        API_PRIMARY_PROFILE_ID,
+      );
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+
+      authStoreMocks.state.store.usageStats[OAUTH_PROFILE_ID] = {
+        cooldownUntil: Date.now() - 1,
+        cooldownReason: "rate_limit",
+      };
+
+      expect(await resolveSession({ agentDir, sessionEntry, sessionStore, cfg })).toBe(
+        OAUTH_PROFILE_ID,
+      );
+      expect(sessionEntry.authProfileOverride).toBe(OAUTH_PROFILE_ID);
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+    });
+  });
+
+  it("keeps an automatic API-key selection when auth order is implicit", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = state.agentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      configureMixedOpenAiAuthStore();
+      authStoreMocks.state.store.order = undefined;
+      const sessionEntry = createAutomaticSessionEntry({
+        model: OPENAI_MODEL_ID,
+        authProfileOverride: API_PRIMARY_PROFILE_ID,
+      });
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      expect(await resolveSession({ agentDir, sessionEntry, sessionStore })).toBe(
+        API_PRIMARY_PROFILE_ID,
+      );
+      expect(sessionEntry.authProfileOverride).toBe(API_PRIMARY_PROFILE_ID);
+    });
+  });
+
   it.each(["compaction", "cooldown"] as const)(
     "keeps a multi-route OpenAI session on its physical route after %s",
     async (trigger) => {
@@ -101,6 +171,9 @@ describe("session auth-profile rotation", () => {
         const agentDir = state.agentDir();
         await fs.mkdir(agentDir, { recursive: true });
         configureMixedOpenAiAuthStore();
+        authStoreMocks.state.store.order = {
+          openai: [OAUTH_PROFILE_ID, API_PRIMARY_PROFILE_ID, API_BACKUP_PROFILE_ID],
+        };
         configureProviderRoutes({
           provider: "openai",
           modelId: OPENAI_MODEL_ID,

--- a/src/agents/auth-profiles/session-override.rotation.test.ts
+++ b/src/agents/auth-profiles/session-override.rotation.test.ts
@@ -118,6 +118,7 @@ describe("session auth-profile rotation", () => {
         [OAUTH_PROFILE_ID]: {
           cooldownUntil: Date.now() + 60_000,
           cooldownReason: "rate_limit",
+          failureCounts: { rate_limit: 1 },
         },
       };
       const sessionEntry: SessionEntry = {
@@ -135,6 +136,7 @@ describe("session auth-profile rotation", () => {
       authStoreMocks.state.store.usageStats[OAUTH_PROFILE_ID] = {
         cooldownUntil: Date.now() - 1,
         cooldownReason: "rate_limit",
+        failureCounts: { rate_limit: 1 },
       };
 
       expect(await resolveSession({ agentDir, sessionEntry, sessionStore, cfg })).toBe(
@@ -158,6 +160,30 @@ describe("session auth-profile rotation", () => {
       const sessionStore = { "agent:main:main": sessionEntry };
 
       expect(await resolveSession({ agentDir, sessionEntry, sessionStore })).toBe(
+        API_PRIMARY_PROFILE_ID,
+      );
+      expect(sessionEntry.authProfileOverride).toBe(API_PRIMARY_PROFILE_ID);
+    });
+  });
+
+  it("does not reverse an automatic compaction rotation on the next resolution", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = state.agentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      configureMixedOpenAiAuthStore();
+      authStoreMocks.state.store.order = undefined;
+      const cfg = {
+        auth: { order: { openai: [OAUTH_PROFILE_ID, API_PRIMARY_PROFILE_ID] } },
+      };
+      const sessionEntry = createAutomaticSessionEntry({
+        model: OPENAI_MODEL_ID,
+        authProfileOverride: API_PRIMARY_PROFILE_ID,
+        compactionCount: 1,
+        authProfileOverrideCompactionCount: 1,
+      });
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      expect(await resolveSession({ agentDir, sessionEntry, sessionStore, cfg })).toBe(
         API_PRIMARY_PROFILE_ID,
       );
       expect(sessionEntry.authProfileOverride).toBe(API_PRIMARY_PROFILE_ID);

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -185,7 +185,7 @@ describe("resolveSessionAuthProfileOverride", () => {
           },
         },
         order: {
-          openai: [TEST_PRIMARY_PROFILE_ID],
+          openai: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID],
         },
       });
 

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -8,7 +8,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import {
   isConfiguredAwsSdkAuthProfileForProvider,
   isStoredCredentialCompatibleWithAuthProvider,
-  resolveAuthProfileOrder,
+  resolveAuthProfileOrderWithMetadata,
 } from "../auth-profiles/order.js";
 import { ensureAuthProfileStore, hasAnyAuthProfileStoreSource } from "../auth-profiles/store.js";
 import {
@@ -281,13 +281,16 @@ async function resolveSessionAuthProfileOverride(params: {
 
   const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
   const providers = uniqueProviders(provider, params.acceptedProviderIds);
-  const order = [
-    ...new Set(
-      providers.flatMap((candidateProvider) =>
-        resolveAuthProfileOrder({ cfg, store, provider: candidateProvider }),
-      ),
-    ),
-  ];
+  const orderResolutions = providers.map((candidateProvider) =>
+    resolveAuthProfileOrderWithMetadata({
+      cfg,
+      store,
+      provider: candidateProvider,
+      forModel: sessionEntry.model,
+    }),
+  );
+  const order = [...new Set(orderResolutions.flatMap((resolution) => resolution.profileIds))];
+  const hasExplicitOrder = orderResolutions.some((resolution) => resolution.hasExplicitOrder);
   let current = sessionEntry.authProfileOverride?.trim();
   const source = resolveSessionAuthProfileOverrideSource(sessionEntry);
 
@@ -370,13 +373,30 @@ async function resolveSessionAuthProfileOverride(params: {
     typeof sessionEntry.authProfileOverrideCompactionCount === "number"
       ? sessionEntry.authProfileOverrideCompactionCount
       : compactionCount;
+  // A healthy automatic fallback yields when an explicit preference is eligible to retry,
+  // preventing a metered backup from staying pinned. The real request proves recovery.
+  const currentOrderIndex = current ? order.indexOf(current) : -1;
+  const retryableHigherPriorityProfile =
+    hasExplicitOrder &&
+    !currentUnavailable &&
+    compactionCount <= storedCompaction &&
+    currentOrderIndex > 0
+      ? order
+          .slice(0, currentOrderIndex)
+          .find((profileId) => !isProfileUnavailableForSessionModel(profileId))
+      : undefined;
   const shouldRotateCurrent =
-    Boolean(current) && !isNewSession && (currentUnavailable || compactionCount > storedCompaction);
+    Boolean(current) &&
+    !isNewSession &&
+    (currentUnavailable ||
+      compactionCount > storedCompaction ||
+      retryableHigherPriorityProfile !== undefined);
 
   // Provider artifacts own persisted route stickiness; runtime planning owns cross-route failover.
-  const routeResolution = shouldRotateCurrent
-    ? resolveProviderModelRoutes({ provider, modelId: params.modelId, config: cfg })
-    : null;
+  const routeResolution =
+    shouldRotateCurrent && !retryableHigherPriorityProfile
+      ? resolveProviderModelRoutes({ provider, modelId: params.modelId, config: cfg })
+      : null;
   const currentAuthRequirement =
     current && routeResolution?.kind === "routes" && routeResolution.routes.length > 1
       ? profileAuthRequirement({ cfg, store, profileId: current })
@@ -398,7 +418,9 @@ async function resolveSessionAuthProfileOverride(params: {
   };
 
   let next = current;
-  if (isNewSession || shouldRotateCurrent) {
+  if (retryableHigherPriorityProfile) {
+    next = retryableHigherPriorityProfile;
+  } else if (isNewSession || shouldRotateCurrent) {
     next = pickAvailable(currentUnavailable ? undefined : current);
   } else if (!current) {
     next = pickAvailable();

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -290,7 +290,6 @@ async function resolveSessionAuthProfileOverride(params: {
     }),
   );
   const order = [...new Set(orderResolutions.flatMap((resolution) => resolution.profileIds))];
-  const hasExplicitOrder = orderResolutions.some((resolution) => resolution.hasExplicitOrder);
   let current = sessionEntry.authProfileOverride?.trim();
   const source = resolveSessionAuthProfileOverrideSource(sessionEntry);
 
@@ -375,15 +374,14 @@ async function resolveSessionAuthProfileOverride(params: {
       : compactionCount;
   // A healthy automatic fallback yields when an explicit preference is eligible to retry,
   // preventing a metered backup from staying pinned. The real request proves recovery.
-  const currentOrderIndex = current ? order.indexOf(current) : -1;
   const retryableHigherPriorityProfile =
-    source === "auto" &&
-    hasExplicitOrder &&
-    !currentUnavailable &&
-    compactionCount <= storedCompaction &&
-    currentOrderIndex > 0
-      ? order
-          .slice(0, currentOrderIndex)
+    source === "auto" && !currentUnavailable && compactionCount <= storedCompaction && current
+      ? orderResolutions
+          .filter((resolution) => resolution.hasExplicitOrder)
+          .flatMap((resolution) => {
+            const currentOrderIndex = resolution.profileIds.indexOf(current);
+            return currentOrderIndex > 0 ? resolution.profileIds.slice(0, currentOrderIndex) : [];
+          })
           .find((profileId) => !isProfileUnavailableForSessionModel(profileId))
       : undefined;
   const shouldRotateCurrent =

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -377,6 +377,7 @@ async function resolveSessionAuthProfileOverride(params: {
   // preventing a metered backup from staying pinned. The real request proves recovery.
   const currentOrderIndex = current ? order.indexOf(current) : -1;
   const retryableHigherPriorityProfile =
+    source === "auto" &&
     hasExplicitOrder &&
     !currentUnavailable &&
     compactionCount <= storedCompaction &&

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -382,7 +382,11 @@ async function resolveSessionAuthProfileOverride(params: {
             const currentOrderIndex = resolution.profileIds.indexOf(current);
             return currentOrderIndex > 0 ? resolution.profileIds.slice(0, currentOrderIndex) : [];
           })
-          .find((profileId) => !isProfileUnavailableForSessionModel(profileId))
+          .find(
+            (profileId) =>
+              (store.usageStats?.[profileId]?.failureCounts?.rate_limit ?? 0) > 0 &&
+              !isProfileUnavailableForSessionModel(profileId),
+          )
       : undefined;
   const shouldRotateCurrent =
     Boolean(current) &&

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -272,14 +272,17 @@ export function clearExpiredCooldowns(store: AuthProfileStore, now?: number): bo
       profileMutated = true;
     }
 
-    // Reset error counters when ALL cooldowns have expired so the profile gets
-    // a fair retry window. Rate-limit counters are the exception: they persist
-    // until a successful request resets them so repeated failed probes can grow
-    // to the capped retry interval. Preserves lastFailureAt for other failures'
-    // decay check in computeNextProfileUsageStats.
-    if (profileMutated && !resolveProfileUnusableUntil(stats) && !preserveRateLimitBackoff) {
+    // Reset the aggregate counter when ALL cooldowns have expired so unrelated
+    // failures get a fair retry window. Only the rate-limit-specific counter
+    // survives a half-open probe; success still clears it. Preserves
+    // lastFailureAt for other failures' decay check in computeNextProfileUsageStats.
+    if (profileMutated && !resolveProfileUnusableUntil(stats)) {
       stats.errorCount = 0;
-      stats.failureCounts = undefined;
+      const rateLimitFailureCount = stats.failureCounts?.rate_limit;
+      stats.failureCounts =
+        preserveRateLimitBackoff && rateLimitFailureCount
+          ? { rate_limit: rateLimitFailureCount }
+          : undefined;
     }
 
     if (profileMutated) {

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -202,10 +202,10 @@ export function getSoonestCooldownExpiry(
  * Clear expired cooldowns from all profiles in the store.
  *
  * When `cooldownUntil` or `disabledUntil` has passed, the corresponding fields
- * are removed and error counters are reset so the profile gets a fresh start
- * (circuit-breaker half-open -> closed). Without this, a stale `errorCount`
- * causes the *next* transient failure to immediately escalate to a much longer
- * cooldown -- the root cause of profiles appearing "stuck" after rate limits.
+ * are removed. Most error counters reset so the profile gets a fresh start
+ * (circuit-breaker half-open -> closed). Rate-limit counters instead persist
+ * across failed half-open probes so missing provider reset times use capped
+ * exponential backoff; a successful request or manual clear resets them.
  *
  * `cooldownUntil` and `disabledUntil` are handled independently: if a profile
  * has both and only one has expired, only that field is cleared.

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -247,6 +247,10 @@ export function clearExpiredCooldowns(store: AuthProfileStore, now?: number): bo
       stats.disabledUntil > 0 &&
       ts >= stats.disabledUntil;
 
+    const preserveRateLimitBackoff =
+      (cooldownExpired && stats.cooldownReason === "rate_limit") ||
+      (blockedExpired && stats.blockedReason === "subscription_limit");
+
     if (cooldownExpired) {
       stats.cooldownUntil = undefined;
       stats.cooldownReason = undefined;
@@ -269,9 +273,11 @@ export function clearExpiredCooldowns(store: AuthProfileStore, now?: number): bo
     }
 
     // Reset error counters when ALL cooldowns have expired so the profile gets
-    // a fair retry window. Preserves lastFailureAt for the failureWindowMs
+    // a fair retry window. Rate-limit counters are the exception: they persist
+    // until a successful request resets them so repeated failed probes can grow
+    // to the capped retry interval. Preserves lastFailureAt for other failures'
     // decay check in computeNextProfileUsageStats.
-    if (profileMutated && !resolveProfileUnusableUntil(stats)) {
+    if (profileMutated && !resolveProfileUnusableUntil(stats) && !preserveRateLimitBackoff) {
       stats.errorCount = 0;
       stats.failureCounts = undefined;
     }

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -247,10 +247,6 @@ export function clearExpiredCooldowns(store: AuthProfileStore, now?: number): bo
       stats.disabledUntil > 0 &&
       ts >= stats.disabledUntil;
 
-    const preserveRateLimitBackoff =
-      (cooldownExpired && stats.cooldownReason === "rate_limit") ||
-      (blockedExpired && stats.blockedReason === "subscription_limit");
-
     if (cooldownExpired) {
       stats.cooldownUntil = undefined;
       stats.cooldownReason = undefined;
@@ -279,10 +275,9 @@ export function clearExpiredCooldowns(store: AuthProfileStore, now?: number): bo
     if (profileMutated && !resolveProfileUnusableUntil(stats)) {
       stats.errorCount = 0;
       const rateLimitFailureCount = stats.failureCounts?.rate_limit;
-      stats.failureCounts =
-        preserveRateLimitBackoff && rateLimitFailureCount
-          ? { rate_limit: rateLimitFailureCount }
-          : undefined;
+      stats.failureCounts = rateLimitFailureCount
+        ? { rate_limit: rateLimitFailureCount }
+        : undefined;
     }
 
     if (profileMutated) {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -759,7 +759,7 @@ describe("clearExpiredCooldowns", () => {
     }
   });
 
-  it("clears expired blockedUntil and resets errorCount", () => {
+  it("clears an expired provider block but preserves retry backoff until success", () => {
     const lastFailureAt = Date.now() - 120_000;
     const store = makeStore({
       "openai:default": {
@@ -778,8 +778,8 @@ describe("clearExpiredCooldowns", () => {
     expect(stats?.blockedUntil).toBeUndefined();
     expect(stats?.blockedReason).toBeUndefined();
     expect(stats?.blockedSource).toBeUndefined();
-    expect(stats?.errorCount).toBe(0);
-    expect(stats?.failureCounts).toBeUndefined();
+    expect(stats?.errorCount).toBe(4);
+    expect(stats?.failureCounts).toEqual({ rate_limit: 4 });
     expect(stats?.lastFailureAt).toBe(lastFailureAt);
   });
 
@@ -884,6 +884,39 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
       dateNowSpy.mockRestore();
     }
   }
+
+  it("exponentially backs off rate limits without a provider reset up to 24 hours", async () => {
+    const store = makeStore(undefined);
+    let now = 1_700_000_000_000;
+    const expectedDelays = [
+      30_000,
+      60_000,
+      2 * 60_000,
+      4 * 60_000,
+      8 * 60_000,
+      16 * 60_000,
+      32 * 60_000,
+      64 * 60_000,
+      128 * 60_000,
+      256 * 60_000,
+      512 * 60_000,
+      1_024 * 60_000,
+      24 * 60 * 60 * 1000,
+      24 * 60 * 60 * 1000,
+    ];
+
+    for (const [index, expectedDelay] of expectedDelays.entries()) {
+      clearExpiredCooldowns(store, now);
+      await markFailureAt({ store, now, reason: "rate_limit" });
+      const stats = store.usageStats?.["anthropic:default"];
+      expect((stats?.cooldownUntil ?? 0) - now, `attempt ${index + 1}`).toBe(expectedDelay);
+      now += expectedDelay + 1;
+    }
+
+    expect(store.usageStats?.["anthropic:default"]?.failureCounts?.rate_limit).toBe(
+      expectedDelays.length,
+    );
+  });
 
   const activeWindowCases = [
     {
@@ -1475,6 +1508,33 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     } else {
       expect(stats?.cooldownUntil).toBe(now + expectedMs);
     }
+  });
+
+  it("uses an exact provider reset instead of the local exponential backoff", async () => {
+    const now = 1_700_000_000_000;
+    const providerResetMs = 5 * 60 * 60 * 1000;
+    const store = makeStore({
+      "openai:default": {
+        cooldownUntil: now - 1,
+        cooldownReason: "rate_limit",
+        errorCount: 12,
+        failureCounts: { rate_limit: 12 },
+        lastFailureAt: now - 1,
+      },
+    });
+    mockWhamResponse(200, {
+      rate_limit: {
+        limit_reached: true,
+        primary_window: { used_percent: 100, reset_after_seconds: providerResetMs / 1000 },
+      },
+    });
+
+    await markCodexFailureAt({ store, now });
+
+    const stats = store.usageStats?.["openai:default"];
+    expect(stats?.blockedUntil).toBe(now + providerResetMs);
+    expect(stats?.blockedReason).toBe("subscription_limit");
+    expect(stats?.cooldownUntil).toBeUndefined();
   });
 
   it("probes WHAM before recording an OpenAI OAuth detail-less failure", async () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -767,7 +767,7 @@ describe("clearExpiredCooldowns", () => {
         blockedReason: "subscription_limit",
         blockedSource: "codex_rate_limits",
         errorCount: 4,
-        failureCounts: { rate_limit: 4 },
+        failureCounts: { rate_limit: 4, timeout: 2 },
         lastFailureAt,
       },
     });
@@ -778,7 +778,7 @@ describe("clearExpiredCooldowns", () => {
     expect(stats?.blockedUntil).toBeUndefined();
     expect(stats?.blockedReason).toBeUndefined();
     expect(stats?.blockedSource).toBeUndefined();
-    expect(stats?.errorCount).toBe(4);
+    expect(stats?.errorCount).toBe(0);
     expect(stats?.failureCounts).toEqual({ rate_limit: 4 });
     expect(stats?.lastFailureAt).toBe(lastFailureAt);
   });

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -577,7 +577,7 @@ describe("clearExpiredCooldowns", () => {
           cooldownUntil: now - 1_000,
           cooldownClassification: "wham_token_expired",
           errorCount: 4,
-          failureCounts: { rate_limit: 3, timeout: 1 },
+          failureCounts: { timeout: 1 },
           lastFailureAt: now - 120_000,
         },
       },
@@ -661,7 +661,7 @@ describe("clearExpiredCooldowns", () => {
       },
     },
     {
-      name: "resets errorCount only when both cooldown and disabled have expired",
+      name: "resets aggregate count but preserves rate-limit history after all windows expire",
       usageStats: {
         "anthropic:default": {
           cooldownUntil: now - 2_000,
@@ -672,16 +672,16 @@ describe("clearExpiredCooldowns", () => {
         },
       },
       expectedMutated: true,
-      expectCleared: true,
       expectedUsageStats: {
         "anthropic:default": {
           cooldownUntil: undefined,
           cooldownReason: undefined,
+          cooldownClassification: undefined,
           cooldownModel: undefined,
           disabledUntil: undefined,
           disabledReason: undefined,
           errorCount: 0,
-          failureCounts: undefined,
+          failureCounts: { rate_limit: 2 },
         },
       },
     },
@@ -868,7 +868,7 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
   async function markFailureAt(params: {
     store: ReturnType<typeof makeStore>;
     now: number;
-    reason: "rate_limit" | "billing" | "auth_permanent";
+    reason: "rate_limit" | "timeout" | "billing" | "auth_permanent";
     cfg?: OpenClawConfig;
   }): Promise<void> {
     const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(params.now);
@@ -916,6 +916,34 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
     expect(store.usageStats?.["anthropic:default"]?.failureCounts?.rate_limit).toBe(
       expectedDelays.length,
     );
+  });
+
+  it("preserves rate-limit history through a differently classified failed probe", async () => {
+    let now = 1_700_000_000_000;
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: now - 1,
+        cooldownReason: "rate_limit",
+        errorCount: 3,
+        failureCounts: { rate_limit: 3 },
+        lastFailureAt: now - 60_000,
+      },
+    });
+
+    await markFailureAt({ store, now, reason: "timeout" });
+    expect(store.usageStats?.["anthropic:default"]?.errorCount).toBe(1);
+    expect(store.usageStats?.["anthropic:default"]?.failureCounts).toEqual({
+      rate_limit: 3,
+      timeout: 1,
+    });
+
+    now = (store.usageStats?.["anthropic:default"]?.cooldownUntil ?? now) + 1;
+    clearExpiredCooldowns(store, now);
+    expect(store.usageStats?.["anthropic:default"]?.failureCounts).toEqual({ rate_limit: 3 });
+
+    await markFailureAt({ store, now, reason: "rate_limit" });
+    expect(store.usageStats?.["anthropic:default"]?.failureCounts?.rate_limit).toBe(4);
+    expect((store.usageStats?.["anthropic:default"]?.cooldownUntil ?? 0) - now).toBe(4 * 60_000);
   });
 
   const activeWindowCases = [

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1537,6 +1537,24 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     expect(stats?.cooldownUntil).toBeUndefined();
   });
 
+  it("uses local exponential backoff when OpenAI reports no reset", async () => {
+    const store = makeStore(undefined);
+    let now = 1_700_000_000_000;
+
+    for (const expectedDelay of [30_000, 60_000, 2 * 60_000]) {
+      mockWhamResponse(200, {
+        rate_limit: {
+          limit_reached: true,
+          primary_window: { used_percent: 100 },
+        },
+      });
+      clearExpiredCooldowns(store, now);
+      await markCodexFailureAt({ store, now });
+      expect((store.usageStats?.["openai:default"]?.cooldownUntil ?? 0) - now).toBe(expectedDelay);
+      now += expectedDelay + 1;
+    }
+  });
+
   it("probes WHAM before recording an OpenAI OAuth detail-less failure", async () => {
     const now = 1_700_000_000_000;
     const store = makeStore(undefined);
@@ -1661,14 +1679,14 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     expect(stats?.cooldownReason).toBe("rate_limit");
   });
 
-  it("maps other HTTP errors to a 5m cooldown", async () => {
+  it("uses local rate-limit backoff when the WHAM request fails", async () => {
     const now = 1_700_000_000_000;
     const store = makeStore({});
     mockWhamResponse(500);
 
     await markCodexFailureAt({ store, now });
 
-    expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBe(now + 300_000);
+    expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBe(now + 30_000);
   });
 
   it("cancels WHAM HTTP error response bodies", async () => {
@@ -1681,7 +1699,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     await markCodexFailureAt({ store, now });
 
     expect(cancel).toHaveBeenCalledOnce();
-    expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBe(now + 300_000);
+    expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBe(now + 30_000);
   });
 
   it("preserves a longer existing cooldown via max semantics", async () => {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -945,7 +945,7 @@ function computeNextProfileUsageStats(params: {
   const nextErrorCount = baseErrorCount + 1;
   const preservedRateLimitCount = params.existing.failureCounts?.rate_limit;
   const failureCounts = shouldResetAggregateCounter
-    ? params.reason === "rate_limit" && preservedRateLimitCount
+    ? preservedRateLimitCount
       ? { rate_limit: preservedRateLimitCount }
       : {}
     : { ...params.existing.failureCounts };

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -289,6 +289,18 @@ function applyWhamCooldownResult(params: {
     };
   }
   const cooldownClassification = resolveWhamCooldownClassification(params.whamResult.reason);
+  if (
+    !cooldownClassification &&
+    !params.whamResult.available &&
+    params.computed.cooldownReason === "rate_limit"
+  ) {
+    // A failed or incomplete probe supplied no authoritative retry deadline.
+    // Keep the persisted local backoff instead of replacing it with a fixed delay.
+    return {
+      ...params.computed,
+      lastProbeAt: params.now,
+    };
+  }
   return {
     ...params.computed,
     lastProbeAt: params.now,
@@ -741,6 +753,8 @@ export function calculateAuthProfileCooldownMs(errorCount: number): number {
   return 5 * 60_000; // 5 minutes max
 }
 
+// Without a provider reset, grow failed half-open probes up to one billing day:
+// frequent retries risk metered fallback spend, while a finite cap still retries daily.
 const RATE_LIMIT_BACKOFF_BASE_MS = 30_000;
 const RATE_LIMIT_BACKOFF_MAX_MS = 24 * 60 * 60 * 1000;
 

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -741,6 +741,9 @@ export function calculateAuthProfileCooldownMs(errorCount: number): number {
   return 5 * 60_000; // 5 minutes max
 }
 
+const RATE_LIMIT_BACKOFF_BASE_MS = 30_000;
+const RATE_LIMIT_BACKOFF_MAX_MS = 24 * 60 * 60 * 1000;
+
 type ResolvedAuthCooldownConfig = {
   billingBackoffMs: number;
   billingMaxMs: number;
@@ -786,15 +789,16 @@ function resolveAuthCooldownConfig(): ResolvedAuthCooldownConfig {
   };
 }
 
-function calculateDisabledLaneBackoffMs(params: {
+function calculateCappedExponentialBackoffMs(params: {
   errorCount: number;
   baseMs: number;
   maxMs: number;
 }): number {
   const normalized = Math.max(1, params.errorCount);
-  const baseMs = Math.max(60_000, params.baseMs);
+  const baseMs = Math.max(1, params.baseMs);
   const maxMs = Math.max(baseMs, params.maxMs);
-  const exponent = Math.min(normalized - 1, 10);
+  const maxExponent = Math.max(0, Math.ceil(Math.log2(maxMs / baseMs)));
+  const exponent = Math.min(normalized - 1, maxExponent);
   const raw = baseMs * 2 ** exponent;
   return Math.min(maxMs, raw);
 }
@@ -805,7 +809,7 @@ function resolveDisabledFailureBackoffMs(params: {
   cfgResolved: ResolvedAuthCooldownConfig;
 }): number {
   const policy = DISABLED_FAILURE_BACKOFF_POLICIES[params.reason];
-  return calculateDisabledLaneBackoffMs({
+  return calculateCappedExponentialBackoffMs({
     errorCount: params.errorCount,
     baseMs: policy.baseMs(params.cfgResolved),
     maxMs: policy.maxMs(params.cfgResolved),
@@ -919,7 +923,10 @@ function computeNextProfileUsageStats(params: {
   const unusableUntil = resolveProfileUnusableUntil(params.existing);
   const previousCooldownExpired = typeof unusableUntil === "number" && params.now >= unusableUntil;
 
-  const shouldResetCounters = windowExpired || previousCooldownExpired;
+  // A rate-limit profile remains half-open until a real request succeeds. Merely
+  // reaching its retry timestamp must not collapse every retry back to 30 seconds.
+  const shouldResetCounters =
+    params.reason === "rate_limit" ? false : windowExpired || previousCooldownExpired;
   const baseErrorCount = shouldResetCounters ? 0 : (params.existing.errorCount ?? 0);
   const nextErrorCount = baseErrorCount + 1;
   const failureCounts = shouldResetCounters ? {} : { ...params.existing.failureCounts };
@@ -954,7 +961,14 @@ function computeNextProfileUsageStats(params: {
     });
     updatedStats.disabledReason = disabledFailureReason;
   } else {
-    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
+    const backoffMs =
+      params.reason === "rate_limit"
+        ? calculateCappedExponentialBackoffMs({
+            errorCount: failureCounts.rate_limit ?? 1,
+            baseMs: RATE_LIMIT_BACKOFF_BASE_MS,
+            maxMs: RATE_LIMIT_BACKOFF_MAX_MS,
+          })
+        : calculateAuthProfileCooldownMs(nextErrorCount);
     // Keep active cooldown windows immutable so retries within the window
     // cannot push recovery further out.
     updatedStats.cooldownUntil = keepActiveWindowOrRecompute({

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -937,13 +937,18 @@ function computeNextProfileUsageStats(params: {
   const unusableUntil = resolveProfileUnusableUntil(params.existing);
   const previousCooldownExpired = typeof unusableUntil === "number" && params.now >= unusableUntil;
 
-  // A rate-limit profile remains half-open until a real request succeeds. Merely
-  // reaching its retry timestamp must not collapse every retry back to 30 seconds.
-  const shouldResetCounters =
-    params.reason === "rate_limit" ? false : windowExpired || previousCooldownExpired;
-  const baseErrorCount = shouldResetCounters ? 0 : (params.existing.errorCount ?? 0);
+  // A rate-limit profile remains half-open until a real request succeeds. Its
+  // dedicated counter survives expiry, while the aggregate counter resets so
+  // unrelated failures do not inherit the rate-limit backoff history.
+  const shouldResetAggregateCounter = windowExpired || previousCooldownExpired;
+  const baseErrorCount = shouldResetAggregateCounter ? 0 : (params.existing.errorCount ?? 0);
   const nextErrorCount = baseErrorCount + 1;
-  const failureCounts = shouldResetCounters ? {} : { ...params.existing.failureCounts };
+  const preservedRateLimitCount = params.existing.failureCounts?.rate_limit;
+  const failureCounts = shouldResetAggregateCounter
+    ? params.reason === "rate_limit" && preservedRateLimitCount
+      ? { rate_limit: preservedRateLimitCount }
+      : {}
+    : { ...params.existing.failureCounts };
   failureCounts[params.reason] = (failureCounts[params.reason] ?? 0) + 1;
 
   const updatedStats: ProfileUsageStats = {


### PR DESCRIPTION
Related: #25510
Related: #38335
Related: #117006

## What Problem This Solves

When an operator explicitly orders OAuth before a metered API key, a session can correctly fail over to the API key while OAuth is unavailable and then remain on that paid fallback after OAuth becomes eligible to retry.

The recovery policy in this PR is:

1. Honor an exact reset/cooldown timestamp when the provider supplies one.
2. Otherwise retry rate-limit failures with exponential backoff starting at 30 seconds and capped at 24 hours.
3. Reset the accumulated backoff after a successful request.
4. On the next real auth selection after the retry deadline, let an automatically selected fallback yield to an earlier eligible profile in explicit `auth.order`.

No background provider traffic or scheduler is added. The next real request is the half-open probe.

## Scenario That Led To This Work

This investigation started from a personal gateway running OpenClaw `2026.7.1-2`:

1. OpenAI OAuth was first in explicit `auth.order`; an API key was the emergency fallback.
2. OAuth returned `429 usage_limit_reached`, so the session correctly failed over and persisted the API-key profile as an automatic override.
3. Server-side compaction did occur, but that release placed `compactionCount` under the wrong result metadata subtree. Session accounting therefore did not observe the compaction and could not use it as a rotation signal. #110587 later fixed that historical counter defect.
4. The API-key fallback consequently remained active and incurred metered API charges.

Current `main` has a related but distinct gap. #123894 deliberately keeps ordinary compaction/cooldown rotation on the current physical auth route, so a correctly counted compaction still does not promote a session from an API-key route back to an earlier OAuth route. This PR adds a narrow, directional recovery rule for that case without undoing general route stickiness.

Identifying account, organization, payment, profile, and credential details are intentionally omitted.

## Why This Approach

The auth-profile subsystem already owns profile health, provider reset timestamps, persisted failure counters, and cooldown expiry. Session selection is therefore the right place to ask whether an automatically selected fallback should yield; the usage-state owner remains responsible for deciding when the preferred profile is eligible to probe.

Boundaries preserved:

- explicit user pins remain strict;
- implicit profile ordering remains stable;
- only a profile earlier in an explicit order can displace the current automatic fallback;
- model-scoped cooldowns are evaluated for the session model;
- ordinary current-profile failures and compactions retain #123894's same-route rotation;
- provider-reported reset timestamps override local exponential estimates;
- incomplete or failed OpenAI quota probes retain the persisted local estimate rather than replacing it with a fixed delay;
- there is no background request loop, config option, or persistence/schema change.

### Production LOC and ownership

Against `origin/main`, production code is `+94/-32` (net `+62`) and tests are `+239/-47` (net `+192`). The production growth implements two missing state transitions in their existing owners: explicit-order session recovery (`session-override.ts`) and persisted half-open rate-limit retry (`usage.ts` / `usage-state.ts`).

An absorbing refactor was attempted by reusing the existing auth-order resolver, usage-state fields, provider-reset path, and capped exponential helper. Removing same-route rotation or replacing the existing health owner would be shorter only by discarding #123894's billing-safety invariant or creating a parallel state machine. The change adds no scheduler, schema, config, or duplicate retry owner.

## User Impact

Operators can keep OAuth first and a metered API key second without making the paid fallback the de facto session default. Recovery occurs on the first real request after the preferred profile's provider deadline or local backoff deadline. If that probe fails again without a provider deadline, retries back off `30s -> 1m -> 2m -> ... -> 24h`; successful use resets the sequence.

## Evidence

Both regressions were written red before implementation:

- after the OAuth deadline elapsed, the same session still selected the API-key profile;
- after the second OpenAI OAuth failure without a reset timestamp, WHAM replaced the computed 60-second retry with a fixed 30-second delay.

Both now pass on the production selection and usage-state seams.

Focused auth-profile validation:

```text
pnpm test src/agents/auth-profiles/usage.test.ts \
  src/agents/auth-profiles.markauthprofilefailure.test.ts \
  src/agents/auth-profiles/profiles.test.ts \
  src/agents/auth-profiles/session-override.rotation.test.ts \
  src/agents/auth-profiles/session-override.test.ts \
  src/agents/auth-profiles/session-override.user-pin.test.ts \
  src/agents/auth-profiles.cooldown-auto-expiry.test.ts
# 209 passed
```

The focused cases prove:

- OAuth cooldown -> automatic API-key fallback -> OAuth retry in the same session;
- exact provider reset timestamps win over the local estimate;
- missing reset timestamps, including incomplete OpenAI quota probes, use exponential backoff through the 24-hour cap;
- successful use clears the accumulated retry backoff;
- persisted expired cooldown state retains the consecutive rate-limit count for the next half-open failure;
- implicit order, user pins, model-scoped cooldowns, and same-route rotation remain stable.

Repository changed-file validation:

```text
pnpm check:changed
# passed: formatting, core and test types, lint, dead exports, import cycles,
# architecture boundaries, schema guards, and changed-file policy checks
```

## Dependency Contract Checked

OpenAI Codex's current `account/rateLimits/read` implementation reads authenticated backend quota snapshots and exposes backend-owned `ordinaryUsageAllowed`: [request processor](https://github.com/openai/codex/blob/0588fc941c3bd5abd0cb8cd38c51cd6e72e9eb16/codex-rs/app-server/src/request_processors/account_processor.rs#L1133-L1230), [protocol response](https://github.com/openai/codex/blob/0588fc941c3bd5abd0cb8cd38c51cd6e72e9eb16/codex-rs/app-server-protocol/src/protocol/v2/account.rs#L315-L345), and [rate-limit snapshot](https://github.com/openai/codex/blob/0588fc941c3bd5abd0cb8cd38c51cd6e72e9eb16/codex-rs/app-server-protocol/src/protocol/v2/account.rs#L582-L615). The protocol explicitly distinguishes a reset estimate from proof of recovery, which is why this change treats the next real request as the probe.

## Research Trail

Exact auth-fallback reports:

- #25510 — automatic session override pins an API-key fallback and bypasses manual-first rotation.
- #38335 — OAuth failover does not return to a recovered profile; closed as implemented, but session promotion was still absent.
- #117006 — existing sessions retained a stale API-key auth profile after moving toward OAuth.
- #21490 — automatic auth overrides masked a changed preferred `auth.order`.
- #62412 — sessions inherited a stale cooldown fallback override.
- #109256 and its fix #117846 — unavailable override lifecycle handling, but not healthy fallback promotion.

Prior implementations and constraints:

- #31056, superseding #25534 — earlier proposal to re-evaluate higher-priority profiles; this PR applies that idea to the current resolver and route model.
- #3604 / commit `03cadc4b7aa428195807edef72f5849031152628` — cooldown auto-expiry reused here.
- #110587 — fixes the historical server-side compaction counter location that affected the motivating gateway release.
- #119325 — preserves auth-profile provenance across fallback turns.
- #123894 — keeps ordinary auth rotation on the same physical provider route; explicitly preserved here.

Related but separate boundaries considered:

- #87957 — broader session model/auth state refactor.
- #122851 — auth-method visibility in the UI; useful observability, not recovery.
- #87467 / #87484 and #132285 — model-fallback pinning and idle model sweeps, separate from auth-profile selection.


## Direct Codex Verification

The acting agent directly verified pinned Codex commit `0588fc941c3bd5abd0cb8cd38c51cd6e72e9eb16` in the local sibling checkout with `git cat-file` and `git show`. The cited response type contains backend-owned `ordinary_usage_allowed` and explicitly says clients must not infer recovery from percentages or reset times; the request processor exposes it only after matching the active account. This supports using a real provider request as the recovery proof rather than treating expiry alone as success.