### PR TITLE
fix: notification click does nothing when focus is rejected

### DIFF
--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -251,8 +251,8 @@ self.addEventListener("notificationclick", (event) => {
         if (!isInScope(clientUrl)) {
           continue;
         }
-        // Implicit focus and explicit navigation can reject on old or uncontrolled workers;
-        // both preserve the validated open-window fallback.
+        // Focus and navigation can reject after a window is matched;
+        // keep both recovery paths on the validated app scope.
         if (!hasExplicitTarget) {
           return client.focus().catch(() => self.clients.openWindow(targetUrl.href));
         }

--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -251,8 +251,10 @@ self.addEventListener("notificationclick", (event) => {
         if (!isInScope(clientUrl)) {
           continue;
         }
+        // Implicit focus and explicit navigation can reject on old or uncontrolled workers;
+        // both preserve the validated open-window fallback.
         if (!hasExplicitTarget) {
-          return client.focus();
+          return client.focus().catch(() => self.clients.openWindow(targetUrl.href));
         }
 
         // Prefer the existing target tab before repurposing another app tab.
@@ -278,8 +280,6 @@ self.addEventListener("notificationclick", (event) => {
         return self.clients.openWindow(targetUrl.href);
       }
 
-      // Always navigate explicit targets; old or uncontrolled workers can
-      // reject navigation, so preserve the validated open-window fallback.
       return targetClient
         .navigate(targetUrl.href)
         .then((navigatedClient) => (navigatedClient ?? targetClient).focus())

--- a/ui/src/app/service-worker-cache.test.ts
+++ b/ui/src/app/service-worker-cache.test.ts
@@ -685,6 +685,31 @@ describe("Control UI service worker notification scope", () => {
       `${nestedScope}chat?session=42#latest`,
     );
   });
+
+  it("opens the app scope when an implicit notification cannot focus its window", async () => {
+    const worker = createNotificationServiceWorker(nestedScope, [nestedScope], {
+      rejectFocus: true,
+    });
+
+    const close = await worker.dispatchNotificationClick({ url: nestedScope, explicitUrl: false });
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(worker.windowClients[0]?.focus).toHaveBeenCalledOnce();
+    expect(worker.clients.openWindow).toHaveBeenCalledExactlyOnceWith(nestedScope);
+  });
+
+  it("keeps implicit focus recovery attached to the notification lifetime", async () => {
+    const worker = createNotificationServiceWorker(nestedScope, [nestedScope], {
+      rejectFocus: true,
+      rejectOpenWindow: true,
+    });
+
+    await expect(
+      worker.dispatchNotificationClick({ url: nestedScope, explicitUrl: false }),
+    ).rejects.toThrow("Unable to open replacement window");
+    expect(worker.windowClients[0]?.focus).toHaveBeenCalledOnce();
+    expect(worker.clients.openWindow).toHaveBeenCalledExactlyOnceWith(nestedScope);
+  });
 });
 
 type ActivateEventStub = {
@@ -738,11 +763,19 @@ type ServiceWorkerNotificationEventStub = {
 function createNotificationServiceWorker(
   scope: string,
   clientUrls: string[],
-  options: { rejectNavigation?: boolean } = {},
+  options: {
+    rejectFocus?: boolean;
+    rejectNavigation?: boolean;
+    rejectOpenWindow?: boolean;
+  } = {},
 ) {
   const listeners = new Map<string, (event: ServiceWorkerNotificationEventStub) => void>();
   const windowClients = clientUrls.map((url) => {
-    const focus = vi.fn(async () => undefined);
+    const focus = vi.fn(async () => {
+      if (options.rejectFocus) {
+        throw new Error("Window is no longer focusable");
+      }
+    });
     return {
       url,
       focus,
@@ -756,7 +789,12 @@ function createNotificationServiceWorker(
   });
   const clients = {
     matchAll: vi.fn(async () => windowClients),
-    openWindow: vi.fn(async (_url: string) => null),
+    openWindow: vi.fn(async (_url: string) => {
+      if (options.rejectOpenWindow) {
+        throw new Error("Unable to open replacement window");
+      }
+      return null;
+    }),
   };
   const showNotification = vi.fn(
     async (_title: string, _options: ServiceWorkerNotificationOptions) => undefined,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clicking a Control UI notification without an explicit URL could close the notification but neither focus nor open the app when a stale or uncontrolled client rejected `focus()`.

## Why This Change Was Made

The implicit-target path now returns the same validated `openWindow` recovery used by explicit-target navigation when focusing the existing in-scope window fails. Explicit target selection, navigation, and scope validation are unchanged. Production LOC remains net zero (+3/-3).

## User Impact

Notification clicks now reopen the validated Control UI scope instead of silently doing nothing when an existing client cannot be focused. If opening also fails, that rejection remains attached to `event.waitUntil`, preserving the full notification-click lifecycle.

## Evidence

### 1. Behavioral videos

The reader should see the same visible notification and pointer click end with one unchanged tab on main, but create and select a second connected Control UI tab in this PR.

**Before: main**

https://github.com/user-attachments/assets/31ed6981-24ca-4d45-9028-a621c30720c1

**After: this PR**

https://github.com/user-attachments/assets/87a802c6-04a7-4452-9608-2f1c331c50ee

Both recordings include browser chrome, the desktop notification, the pointer click, and the post-click state. They are 3.8 seconds and 4.8 seconds respectively. The run used headed Chromium 151 on Linux, an actual registered production service worker, and a one-shot rejected `WindowClient.focus()` call; notification activation and `Clients.openWindow()` remained browser operations.

### 2. Service-worker trace

The reader should see identical click and rejected-focus inputs at both widths, with only the PR recording an `openWindow()` call and a second connected page.

| Viewport and revision | `clickEvents` | `focusCalls` | Focus outcome | `openWindowCalls` | Connected pages |
| --- | ---: | ---: | --- | ---: | ---: |
| 1440 · main | 1 | 1 | rejected | 0 | 1 |
| 1440 · this PR | 1 | 1 | rejected | 1 | 2 |
| 390 · main | 1 | 1 | rejected | 0 | 1 |
| 390 · this PR | 1 | 1 | rejected | 1 | 2 |

For the PR rows, the target was exactly the registered app scope and every resulting page reported a connected Gateway state with zero page errors. The selected Gateway URL and Control UI settings were persisted on the origin before the click, and the deterministic fixture was installed for every page so the new WindowClient used the same connection path.

### 3. Supporting after-click frame

The reader should see one unchanged browser tab on main and the newly created WindowClient presented as the red-boxed second tab in this PR, already connected and showing the fixture message.

![After-click comparison: main remains on one tab; this PR opens the red-boxed connected tab](https://github.com/user-attachments/assets/09832239-0f92-4657-8fde-1d58cd32aac0)

- Before the production fix, the two new service-worker regressions failed while 53 neighboring cases passed: focus rejection escaped and no `openWindow` fallback occurred.
- After the fix, the service-worker suite passed all 55 tests.
- The Gateway Web Push suite passed all 37 tests, including the explicit human-mention session URL contract.
- The production service-worker update E2E passed both deep-link boot and same-version update cases.
- Changed-surface formatting, core/UI type checks, localization, dead-export scans, lint, and repository guards passed.
- Diff whitespace validation and service-worker syntax validation passed.

## Risk and coverage

- Other branches at risk were explicit notification targets, no matching client, out-of-scope clients, and fallback rejection lifetime. The complete 55-test service-worker listener matrix passes and exercises each branch; the two new cases also prove the fallback promise remains owned by `event.waitUntil`.
- The repaired branch is only for implicit notifications. Ordinary completion, question, task, and cron payloads omit `url`, so the service worker intentionally opens the registered app root. Human-mention notifications include an explicit session URL, and the existing no-client and navigation-rejection fallbacks preserve its exact validated path, query, and hash. No deep link is dropped, so there is no follow-up to name.
- The fix reuses the already validated `targetUrl` and existing `openWindow` recovery. It does not add a second routing policy, change notification payloads, or alter explicit navigation.
- Live proof covered Chromium 151 on Linux at 1440 × 900 and 390 × 844. Firefox and Safari were not live-tested, and a genuinely stale installed client was represented by a one-shot standards-compatible focus rejection rather than waiting for a nondeterministic browser state.

Production LOC: +3/-3 (net 0); tests: +41/-3 (net +38), excluding the maintainer-only comment clarification.

Provenance: fix contributed by @ryrenz; defect reported by @steipete in #127462. The bare implicit `focus()` path originated in `21b7ad58054` and remained present through the latest stable release.

Closes #127462

