### PR TITLE
fix(ci): restore plugin capability FRV fixture

### DIFF
--- a/src/plugins/capability-provider-runtime.generation.test.ts
+++ b/src/plugins/capability-provider-runtime.generation.test.ts
@@ -75,6 +75,10 @@ export default { id: "${id}", register(api) {
   const builtDir = path.join(root, "dist", "extensions", id);
   mkdirSafe(builtDir);
   fs.writeFileSync(path.join(builtDir, "index.js"), body("built"));
+  fs.writeFileSync(
+    path.join(builtDir, "package.json"),
+    JSON.stringify({ openclaw: { extensions: ["./index.js"] } }),
+  );
   const seed = writePlugin({
     id: "fixture-seed",
     dir: path.join(root, "extensions", "fixture-seed"),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation's plugin capability fixture generated a built plugin without manifest-declared extension metadata, causing the frozen validation run to fail five capability-generation cases.

## Why This Change Was Made

The fixture now emits the same `package.json` `openclaw.extensions` entry expected from a built plugin. The root cause was fixture drift after plugin discovery became manifest-first; production behavior is unchanged.

## User Impact

Release validation no longer reports false plugin capability failures from an incomplete generated fixture. There is no runtime product change.

## Evidence

- Frozen FRV parent: https://github.com/openclaw/openclaw/actions/runs/33695199734
- Failing job: https://github.com/openclaw/openclaw/actions/runs/33695230964/job/100462797846
- Pre-fix focused file: 5 failed, 4 passed.
- Post-fix focused file: 9/9 passed.
- Three-file focused set: 42/42 passed.
- Formatting: passed.
- Scoped `check-changed`: passed.
- `git diff --check`: passed.
- LOC: production +0/-0; tests +4/-0.
