### PR TITLE
fix(bench): keep synthetic Gateways off LAN discovery

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -666,6 +666,8 @@ Saved output: `pnpm test:startup:bench:smoke` writes `.artifacts/cli-startup-ben
 
 <Accordion title="Gateway startup (scripts/bench-gateway-startup.ts)">
 
+Gateway startup, restart, and agent concurrency benchmark fixtures use temporary home and state directories, loopback binding, and `discovery.mdns.mode: "off"` so synthetic Gateways do not advertise on the LAN, including on macOS.
+
 Defaults to the built CLI entry at `dist/entry.js`; run `pnpm build` first. Pass `--entry scripts/run-node.mjs` to measure the source runner instead, and keep those results separate from built-entry baselines.
 
 ```bash

--- a/scripts/lib/gateway-bench-runtime.ts
+++ b/scripts/lib/gateway-bench-runtime.ts
@@ -39,6 +39,8 @@ export const STALLED_CATALOG_MODEL_ID = "bench-model";
 
 export const BASE_GATEWAY_BENCH_CONFIG = {
   browser: { enabled: false },
+  // Loopback listener binding does not suppress LAN discovery.
+  discovery: { mdns: { mode: "off" } },
   gateway: {
     mode: "local",
     bind: "loopback",

--- a/test/scripts/gateway-bench-runtime.test.ts
+++ b/test/scripts/gateway-bench-runtime.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  BASE_GATEWAY_BENCH_CONFIG,
+  createGatewayBenchEnv,
+  writeGatewayBenchConfig,
+} from "../../scripts/lib/gateway-bench-runtime.js";
+import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
+import { startGatewayPluginDiscovery } from "../../src/gateway/server-startup-early.js";
+import {
+  resolveWideAreaDiscoveryDomain,
+  writeWideAreaGatewayZone,
+} from "../../src/infra/widearea-dns.js";
+import { createEmptyPluginRegistry } from "../../src/plugins/registry-empty.js";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+vi.mock("../../src/infra/machine-name.js", () => ({
+  getMachineDisplayName: async () => "Benchmark fixture",
+}));
+
+vi.mock("../../src/infra/widearea-dns.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/infra/widearea-dns.js")>();
+  return {
+    ...actual,
+    resolveWideAreaDiscoveryDomain: vi.fn(actual.resolveWideAreaDiscoveryDomain),
+    writeWideAreaGatewayZone: vi.fn(async () => ({ changed: false, zonePath: "unused" })),
+  };
+});
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe("gateway benchmark discovery isolation", () => {
+  it.each([
+    { name: "benchmark fixture", enabled: false },
+    { name: "enabled minimal-discovery control", enabled: true },
+  ])("$name reaches the publication boundary with the expected policy", async ({ enabled }) => {
+    const root = tempDirs.make("openclaw-bench-discovery-");
+    const configPath = writeGatewayBenchConfig(
+      root,
+      {
+        ...BASE_GATEWAY_BENCH_CONFIG,
+        ...(enabled ? { discovery: { mdns: { mode: "minimal" } } } : {}),
+      },
+      {},
+    );
+    vi.stubEnv("OPENCLAW_WIDE_AREA_DOMAIN", "inherited.example.test");
+    const childEnv = createGatewayBenchEnv(root, configPath, {});
+    for (const key of [
+      "HOME",
+      "OPENCLAW_HOME",
+      "OPENCLAW_STATE_DIR",
+      "OPENCLAW_CONFIG_PATH",
+      "NODE_ENV",
+      "VITEST",
+      "OPENCLAW_DISABLE_BONJOUR",
+      "OPENCLAW_WIDE_AREA_DOMAIN",
+      "OPENCLAW_TAILNET_DNS",
+      "OPENCLAW_CLI_PATH",
+      "OPENCLAW_SSH_PORT",
+      "OPENCLAW_GATEWAY_DISCOVERY_ADVERTISE_TIMEOUT_MS",
+    ]) {
+      vi.stubEnv(key, childEnv[key]);
+    }
+    const cfgAtStart: OpenClawConfig = JSON.parse(readFileSync(configPath, "utf8"));
+    const stop = vi.fn();
+    const advertise = vi.fn(async () => ({ stop }));
+    const pluginRegistry = createEmptyPluginRegistry();
+    pluginRegistry.gatewayDiscoveryServices.push({
+      pluginId: "fixture-discovery",
+      source: "test",
+      service: { id: "fixture-discovery", advertise },
+    });
+
+    const bonjourStop = await startGatewayPluginDiscovery({
+      minimalTestGateway: false,
+      cfgAtStart,
+      port: 18789,
+      gatewayTls: { enabled: false },
+      gatewayDirectReachable: false,
+      tailscaleMode: "off",
+      logDiscovery: { info: vi.fn(), warn: vi.fn() },
+      pluginRegistry,
+    });
+    await bonjourStop?.();
+
+    expect(childEnv.OPENCLAW_WIDE_AREA_DOMAIN).toBeUndefined();
+    expect(resolveWideAreaDiscoveryDomain).not.toHaveBeenCalled();
+    expect(writeWideAreaGatewayZone).not.toHaveBeenCalled();
+    if (enabled) {
+      expect(advertise).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ gatewayDirectReachable: false, minimal: true }),
+      );
+      expect(stop).toHaveBeenCalledOnce();
+    } else {
+      expect(advertise).not.toHaveBeenCalled();
+      expect(stop).not.toHaveBeenCalled();
+    }
+  });
+});


### PR DESCRIPTION
Closes #136791

<details>
<summary>Additional instructions</summary>

Maintainers can push to this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where developers running Gateway startup, restart, or concurrency benchmarks on macOS could advertise synthetic Gateways on their local network despite the benchmark's loopback listener and temporary state directories.

## Why This Change Was Made

The shared benchmark fixture now uses the existing `discovery.mdns.mode: "off"` configuration. Loopback binding controls the listener, not Bonjour publication, and the benchmark's deliberate environment allowlist does not inherit discovery-disable or test-mode variables. Repairing the shared fixture covers all three benchmark consumers without changing product discovery defaults, disabling the Bonjour plugin globally, widening environment inheritance, or adding a configuration option.

## User Impact

Gateway benchmarks remain local fixtures rather than appearing in nearby clients' discovery results, including on macOS where Bonjour is enabled by default. Normal Gateway discovery, wide-area DNS-SD, operator configuration, and persistent stores are unchanged.

## Evidence

- Safe red/green reproduction through actual fixture serialization, the real startup adapter, and the real discovery policy with a fake publisher: before the repair, the no-advertisement assertion failed because publication was invoked once; after the repair, both the isolation case and the explicitly enabled positive control passed. No real network publication occurred during the failing reproduction.
- The boundary test also verifies that an inherited wide-area domain is filtered and no wide-area publisher is called. Environment and temporary-directory cleanup use the existing test helpers.
- All 106 focused tests passed across the shared fixture, startup/restart/concurrency benchmark consumers, and Gateway startup/discovery owners:

  ```bash
  node scripts/run-vitest.mjs test/scripts/gateway-bench-runtime.test.ts test/scripts/bench-gateway-startup.test.ts test/scripts/bench-gateway-restart.test.ts test/scripts/bench-gateway-concurrency.test.ts src/gateway/server-discovery-runtime.test.ts src/gateway/server-startup-early.test.ts
  ```

- Changed-file checks passed, including script/root-test typechecks, focused lint, formatting, erasability, and repository guards:

  ```bash
  node scripts/check-changed.mjs -- scripts/lib/gateway-bench-runtime.ts test/scripts/gateway-bench-runtime.test.ts docs/reference/test.md
  ```

- `git diff --check` passed. Independent Codex autoreview reported no accepted/actionable findings at its default P0 scope; a fresh pre-commit pass is recorded in the landing evidence.
- Source inspection: the shared benchmark owner and all three consumers, startup discovery mapping, discovery policy, Bonjour manifest/entry/advertiser, and the installed mDNS dependency's advertising contract. The implicated fixture/startup/discovery sources remained unchanged at main `8afdea07a1521a308ad7edf9faab1227dc95ceb4`; the shared helper also matched stable tag `v2026.8.2`. Introduction provenance is unknown; no last-known-good revision is claimed.

Production application LOC: **+0/-0**. Benchmark tooling: **+2/-0** (one existing config entry and its rationale comment). Tests: **+104/-0**. Docs: **+2/-0**. The small tooling growth establishes the fixture's network-isolation invariant at its owner; there is no duplicate policy or old path to remove.

No live deployment, operator config, or production database was touched. Exact-head [CI run 33703292734](https://github.com/openclaw/openclaw/actions/runs/33703292734) passed on source commit `3e2af5c946a1eab112b494df4c37d1ad34319c01`; the bounded CI watcher completed GREEN with no pending checks. The red/green proof above is a no-network boundary test, not a packet capture or production-incident diagnosis.


### Real macOS startup smoke

The reviewed fixture passed a real default Gateway startup sample on macOS with the Bonjour plugin still registered. Before launch, an executable preflight serialized the actual shared fixture and verified mDNS off, absent wide-area domain, loopback binding, Tailscale/browser off, and temporary child HOME/config/state. No environment-based discovery override was supplied.

```bash
pnpm build qaRuntime
```

Runtime-only build passed in 1m34.3s (not a full SDK/declaration/UI build).

```bash
node --import ./scripts/tsx.mjs scripts/bench-gateway-startup.ts --case default --runs 1 --warmup 0 --timeout-ms 60000 --output .artifacts/benchmark-isolation/startup-smoke.json
```

Result: 1 default sample; `/healthz` and `/readyz` both HTTP 200 at approximately 9.70s, normal readiness, no premature process exit, child exit 0, and clean shutdown in 184ms. The Bonjour plugin loaded and registered normally; the real discovery startup span completed in 3.5ms. The benchmark owned its temporary home/state and its own dynamically allocated loopback port.

Scope of proof: this is a real post-fix startup smoke, not a packet capture or a performance comparison. The independent red/green publication-boundary test proves zero discovery invocation without relying on absent logs; no real pre-fix Gateway was launched. No operator Gateway, live deployment, operator configuration, or production database was accessed. The build and smoke completed without source changes; the published repair is source commit 3e2af5c946a1eab112b494df4c37d1ad34319c01.
