### PR TITLE
fix(e2e): unblock stable Docker upgrade survivor validation

### DIFF
--- a/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh
+++ b/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh
@@ -39,19 +39,23 @@ trap 'rm -rf "$npm_pack_dir" "$npm_registry_dir"' EXIT
 # The post-core writer applies parent permissions; match its owned-directory contract.
 post_core_result_path="$npm_pack_dir/post-core.json"
 pack_fixture_plugin "$npm_pack_dir" /tmp/demo-corrupt-plugin.tgz demo-corrupt-plugin 0.0.1 demo.corrupt "Demo Corrupt Plugin"
-start_npm_fixture_registry "@openclaw/demo-corrupt-plugin" "0.0.1" /tmp/demo-corrupt-plugin.tgz "$npm_registry_dir"
+(
+  # Restore the candidate registry and stop serving the synthetic plugin before update.
+  # The parent retains the pack directory needed for post-core result evidence.
+  trap - EXIT
+  start_npm_fixture_registry "@openclaw/demo-corrupt-plugin" "0.0.1" /tmp/demo-corrupt-plugin.tgz "$npm_registry_dir"
 
-echo "Installing managed external plugin..."
-if ! openclaw_e2e_fixture_plugin_command node "$entry" -- plugins install "npm:@openclaw/demo-corrupt-plugin@0.0.1" --force >/tmp/openclaw-corrupt-plugin-install.log 2>&1; then
-  openclaw_e2e_print_log /tmp/openclaw-corrupt-plugin-install.log >&2
-  exit 1
-fi
-node "$entry" config set plugins.allow '["demo-corrupt-plugin"]' >/dev/null
-# Disable the unrelated model runtime explicitly without hiding Doctor's bundled health APIs.
-node "$entry" config set plugins.entries.codex.enabled false >/dev/null
-node scripts/e2e/lib/plugin-update/probe.mjs assert-corrupt-policy-preserved "$OPENCLAW_CONFIG_PATH" demo-corrupt-plugin
-node "$entry" plugins inspect demo-corrupt-plugin --runtime --json >/tmp/openclaw-corrupt-plugin-before.json
-unset NPM_CONFIG_REGISTRY npm_config_registry
+  echo "Installing managed external plugin..."
+  if ! openclaw_e2e_fixture_plugin_command node "$entry" -- plugins install "npm:@openclaw/demo-corrupt-plugin@0.0.1" --force >/tmp/openclaw-corrupt-plugin-install.log 2>&1; then
+    openclaw_e2e_print_log /tmp/openclaw-corrupt-plugin-install.log >&2
+    exit 1
+  fi
+  node "$entry" config set plugins.allow '["demo-corrupt-plugin"]' >/dev/null
+  # Disable the unrelated model runtime explicitly without hiding Doctor's bundled health APIs.
+  node "$entry" config set plugins.entries.codex.enabled false >/dev/null
+  node scripts/e2e/lib/plugin-update/probe.mjs assert-corrupt-policy-preserved "$OPENCLAW_CONFIG_PATH" demo-corrupt-plugin
+  node "$entry" plugins inspect demo-corrupt-plugin --runtime --json >/tmp/openclaw-corrupt-plugin-before.json
+)
 
 plugin_dir="$(
   node -e '

--- a/scripts/e2e/lib/plugins/fixtures.sh
+++ b/scripts/e2e/lib/plugins/fixtures.sh
@@ -264,6 +264,8 @@ start_npm_fixture_registry() {
   for _ in $(seq 1 100); do
     if [[ -s "$server_port_file" ]]; then
       export NPM_CONFIG_REGISTRY="http://127.0.0.1:$(cat "$server_port_file")"
+      # Override both spellings so an inherited prerelease registry cannot win in npm.
+      export npm_config_registry="$NPM_CONFIG_REGISTRY"
       return 0
     fi
     if ! kill -0 "$server_pid" 2>/dev/null; then

--- a/scripts/e2e/lib/plugins/npm-registry-server.mjs
+++ b/scripts/e2e/lib/plugins/npm-registry-server.mjs
@@ -32,7 +32,8 @@ function normalizeUpstreamRegistry(raw) {
 const upstreamRegistry = normalizeUpstreamRegistry(
   process.env.OPENCLAW_NPM_REGISTRY_UPSTREAM || process.env.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_URL,
 );
-const mergeUpstream = process.env.OPENCLAW_NPM_REGISTRY_MERGE_UPSTREAM === "1";
+const upstreamMergeMode = process.env.OPENCLAW_NPM_REGISTRY_MERGE_UPSTREAM;
+const mergeUpstream = upstreamMergeMode === "1" || upstreamMergeMode === "versions";
 const distTagOverrides = new Map(
   (process.env.OPENCLAW_NPM_REGISTRY_DIST_TAGS ?? "")
     .split(",")
@@ -206,12 +207,17 @@ async function metadataWithPublishedVersions(entry, baseUrl) {
     );
   }
   const published = metadataForProxy(await upstreamMetadata.get(entry.packageName), baseUrl);
+  // Baseline installs keep published tags; candidate installs select each local
+  // package's release while retaining published versions for older dependencies.
+  const distTags =
+    upstreamMergeMode === "versions"
+      ? { ...published["dist-tags"], ...local["dist-tags"] }
+      : { ...local["dist-tags"], ...published["dist-tags"] };
   return {
     ...published,
     ...local,
     "dist-tags": {
-      ...local["dist-tags"],
-      ...published["dist-tags"],
+      ...distTags,
       ...Object.fromEntries(distTagOverrides),
     },
     versions: { ...published.versions, ...local.versions },

--- a/scripts/e2e/lib/prepublish-plugin-registry.sh
+++ b/scripts/e2e/lib/prepublish-plugin-registry.sh
@@ -90,6 +90,7 @@ NODE
 
   mkdir -p "$registry_root"
   local port_file="$registry_root/port" log_file="$registry_root/server.log"
+  local merge_upstream="${OPENCLAW_NPM_REGISTRY_MERGE_UPSTREAM:-versions}"
   local dist_tags="${OPENCLAW_NPM_REGISTRY_DIST_TAGS-}"
   if [ -z "${OPENCLAW_NPM_REGISTRY_DIST_TAGS+x}" ]; then
     dist_tags="beta=$candidate_version"
@@ -99,7 +100,7 @@ NODE
   fi
   rm -f "$port_file"
   OPENCLAW_NPM_REGISTRY_DIST_TAGS="$dist_tags" \
-    OPENCLAW_NPM_REGISTRY_MERGE_UPSTREAM="${artifact_dir:+1}" \
+    OPENCLAW_NPM_REGISTRY_MERGE_UPSTREAM="${artifact_dir:+$merge_upstream}" \
     OPENCLAW_NPM_REGISTRY_UPSTREAM="${OPENCLAW_NPM_REGISTRY_UPSTREAM:-https://registry.npmjs.org}" \
     node "$server_script" "$port_file" "${registry_args[@]}" >"$log_file" 2>&1 &
   local server_pid="$!"
@@ -152,7 +153,7 @@ openclaw_prepublish_plugin_registry_run_mounted() (
   trap 'exit 129' HUP
   # Before lane code selects an update target, published baseline selectors must
   # remain published; exact candidate dependencies are already in the package set.
-  OPENCLAW_NPM_REGISTRY_DIST_TAGS="" \
+  OPENCLAW_NPM_REGISTRY_DIST_TAGS="" OPENCLAW_NPM_REGISTRY_MERGE_UPSTREAM=1 \
     openclaw_prepublish_plugin_registry_start_mounted "$registry_root" registry_pid '[]'
   if [ -n "$registry_pid" ]; then
     export OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_URL="$NPM_CONFIG_REGISTRY"

--- a/scripts/e2e/plugin-binding-command-escape.Dockerfile
+++ b/scripts/e2e/plugin-binding-command-escape.Dockerfile
@@ -9,6 +9,8 @@ RUN corepack enable
 WORKDIR /workspace/openclaw
 COPY . .
 
-RUN OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL=1 pnpm install --frozen-lockfile --ignore-scripts --filter openclaw
+# Source tests resolve workspace packages through aliases, outside the root
+# dependency graph. Install their isolated links along with the root tools.
+RUN OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL=1 pnpm install --frozen-lockfile --ignore-scripts
 
 CMD ["bash"]

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -535,6 +535,14 @@ install_companion_plugins() {
       plugins install "npm:@openclaw/codex@$package_version" --pin
     install_status=$?
   fi
+  if [ "$install_status" -eq 0 ]; then
+    # Inspection validates config too; keep the legacy migration specimen parked
+    # until companion installation and its provenance checks have both finished.
+    node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
+      assert-companion-installs "$package_version" \
+      "${OPENCLAW_E2E_LAST_FIXTURE_PLUGIN_CAPABILITY_CONSENT_SUPPORTED:?missing candidate capability-consent support}"
+    install_status=$?
+  fi
   node "$OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER" \
     restore "$OPENCLAW_CONFIG_PATH" "$authored_config"
   restore_status=$?
@@ -546,9 +554,6 @@ install_companion_plugins() {
   if [ "$restore_status" -ne 0 ]; then
     return "$restore_status"
   fi
-  node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
-    assert-companion-installs "$package_version" \
-    "${OPENCLAW_E2E_LAST_FIXTURE_PLUGIN_CAPABILITY_CONSENT_SUPPORTED:?missing candidate capability-consent support}"
 }
 
 openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_FUNCTION_B64:?missing OPENCLAW_TEST_STATE_FUNCTION_B64}"

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -7700,9 +7700,7 @@ done
     );
 
     expect(dockerfile).toContain("OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL=1");
-    expect(dockerfile).toContain(
-      "pnpm install --frozen-lockfile --ignore-scripts --filter openclaw",
-    );
+    expect(dockerfile).toContain("pnpm install --frozen-lockfile --ignore-scripts\n");
   });
 
   it("routes QR import Docker smoke through the timeout-aware run helper", () => {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2763,17 +2763,10 @@ docker_e2e_docker_run_cmd run demo
     const codexInstallIndex = runner.indexOf(
       'openclaw_e2e_fixture_plugin_command openclaw -- \\\n      plugins install "npm:@openclaw/codex@$package_version" --pin',
     );
-    const restoreCompanionIndex = runner.indexOf(
-      'restore "$OPENCLAW_CONFIG_PATH" "$authored_config"',
-    );
-    const assertCompanionIndex = runner.indexOf('assert-companion-installs "$package_version"');
     expect(discordInstallIndex).toBeGreaterThan(-1);
     expect(discordInstallIndex).toBeLessThan(whatsappInstallIndex);
     expect(whatsappInstallIndex).toBeLessThan(clawhubRequestIndex);
     expect(clawhubRequestIndex).toBeLessThan(codexInstallIndex);
-    expect(codexInstallIndex).toBeLessThan(restoreCompanionIndex);
-    expect(restoreCompanionIndex).toBeLessThan(assertCompanionIndex);
-    expect(assertCompanionIndex).toBeLessThan(runnerPrepareIndex);
     expect(
       runner.match(/openclaw_e2e_fixture_plugin_command openclaw -- \\\n\s+plugins install/gu),
     ).toHaveLength(3);

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -480,6 +480,36 @@ ${command}
     }
   });
 
+  it("routes npm through both registry environment spellings after replacing a parent registry", () => {
+    const root = autoCleanupTempDirs.make("openclaw-plugin-npm-fixture-routing-");
+    writeFileSync(path.join(root, "fixture.tgz"), "fixture package archive");
+    const result = runPluginsSweepShell(
+      `
+set -euo pipefail
+source scripts/e2e/lib/plugins/fixtures.sh
+unset NPM_CONFIG_REGISTRY npm_config_registry
+export NPM_CONFIG_REGISTRY=http://127.0.0.1:1 npm_config_registry=http://127.0.0.1:1
+start_npm_fixture_registry fixture-pkg 1.0.0 "$REGISTRY_ROOT/fixture.tgz" "$REGISTRY_ROOT"
+# Duplicate-case precedence depends on environment order; exercise each accepted spelling.
+for registry_key in NPM_CONFIG_REGISTRY npm_config_registry; do
+  env -u "$registry_key" npm view fixture-pkg@1.0.0 version --json --fetch-retries=0 --fetch-timeout=1000 --cache "$REGISTRY_ROOT/cache"
+done
+`,
+      {
+        HOME: root,
+        REGISTRY_ROOT: root,
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(
+      result.stdout
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toEqual(["1.0.0", "1.0.0"]);
+  });
+
   it("cleans npm fixture registry children when readiness times out", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugin-npm-fixture-cleanup-"));
     try {

--- a/test/scripts/prepublish-plugin-registry-shell.test.ts
+++ b/test/scripts/prepublish-plugin-registry-shell.test.ts
@@ -37,7 +37,7 @@ function createTarball(
   return tarball;
 }
 
-function registryFixture(root: string, names: string[]) {
+function registryFixture(root: string, names: string[], version = VERSION) {
   const artifactDir = join(root, "artifact");
   mkdirSync(artifactDir);
   const packages = names
@@ -49,10 +49,10 @@ function registryFixture(root: string, names: string[]) {
         artifactDir,
         name,
         tarball,
-        VERSION,
-        name === "openclaw" ? { dependencies: { "@openclaw/ai": VERSION } } : {},
+        version,
+        name === "openclaw" ? { dependencies: { "@openclaw/ai": version } } : {},
       );
-      return { name, version: VERSION, tarball, sha256: sha256(file) };
+      return { name, version, tarball, sha256: sha256(file) };
     });
   const manifestPath = join(artifactDir, "prepublish-plugin-registry.json");
   writeFileSync(
@@ -61,7 +61,7 @@ function registryFixture(root: string, names: string[]) {
       schema: "openclaw.prepublish-plugin-registry/v1",
       schemaVersion: 1,
       sourceSha: SOURCE_SHA,
-      candidateVersion: VERSION,
+      candidateVersion: version,
       packages,
     }),
   );
@@ -71,7 +71,7 @@ function registryFixture(root: string, names: string[]) {
     env: {
       OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: artifactDir,
       OPENCLAW_DOCKER_E2E_SELECTED_SHA: SOURCE_SHA,
-      OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION: VERSION,
+      OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION: version,
       OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256: sha256(manifestPath),
     },
   };
@@ -79,7 +79,7 @@ function registryFixture(root: string, names: string[]) {
 
 async function withPublishedRegistry(root: string, run: (url: string) => void | Promise<void>) {
   const portFile = join(root, "upstream-port");
-  const args = ["openclaw", "@openclaw/ai"].flatMap((name, index) => [
+  const args = ["openclaw", "@openclaw/ai", "@openclaw/discord"].flatMap((name, index) => [
     name,
     BASELINE_VERSION,
     createTarball(
@@ -193,18 +193,20 @@ console.log(JSON.stringify({ url, first: first.status, second: second.status, bo
     }
   });
 
-  it("installs a published baseline before the exact candidate and reaps its registry on failure", async () => {
-    const root = tempDirs.make("openclaw-prepublish-command-");
-    const fixture = registryFixture(root, ["openclaw", "@openclaw/ai"]);
-    const registryUrl = join(root, "registry-url");
-    await withPublishedRegistry(root, async (upstream) => {
-      const result = spawnSync(
-        "bash",
-        [
-          resolve(SCRIPT),
+  it.each([VERSION, "2026.8.1", "2026.8.1-2"])(
+    "installs a published baseline before candidate %s and reaps its registry on failure",
+    async (version) => {
+      const root = tempDirs.make("openclaw-prepublish-command-");
+      const fixture = registryFixture(root, ["openclaw", "@openclaw/ai"], version);
+      const registryUrl = join(root, "registry-url");
+      await withPublishedRegistry(root, async (upstream) => {
+        const result = spawnSync(
           "bash",
-          "-c",
-          `
+          [
+            resolve(SCRIPT),
+            "bash",
+            "-c",
+            `
 set -euo pipefail
 test "$BUN_CONFIG_REGISTRY" = "$NPM_CONFIG_REGISTRY"
 npm install --prefix "$INSTALL_DIR" openclaw@latest --ignore-scripts --no-fund --no-audit --package-lock=false --userconfig=/dev/null --cache "$INSTALL_DIR/cache"
@@ -213,29 +215,30 @@ npm install --prefix "$INSTALL_DIR" "$ROOT_TARBALL" --ignore-scripts --no-fund -
 node -e 'const fs=require("node:fs"); const root=require(process.env.INSTALL_DIR+"/node_modules/openclaw/package.json"); const ai=require(process.env.INSTALL_DIR+"/node_modules/@openclaw/ai/package.json"); if(root.dependencies["@openclaw/ai"] !== ai.version) process.exit(1); fs.writeFileSync(process.env.REGISTRY_URL_FILE, process.env.NPM_CONFIG_REGISTRY);'
 exit 17
 `,
-        ],
-        {
-          cwd: root,
-          encoding: "utf8",
-          timeout: 30_000,
-          env: {
-            ...process.env,
-            ...fixture.env,
-            OPENCLAW_NPM_REGISTRY_UPSTREAM: upstream,
-            BASELINE_VERSION,
-            INSTALL_DIR: join(root, "install"),
-            ROOT_TARBALL: join(fixture.artifactDir, "openclaw.tgz"),
-            REGISTRY_URL_FILE: registryUrl,
+          ],
+          {
+            cwd: root,
+            encoding: "utf8",
+            timeout: 30_000,
+            env: {
+              ...process.env,
+              ...fixture.env,
+              OPENCLAW_NPM_REGISTRY_UPSTREAM: upstream,
+              BASELINE_VERSION,
+              INSTALL_DIR: join(root, "install"),
+              ROOT_TARBALL: join(fixture.artifactDir, "openclaw.tgz"),
+              REGISTRY_URL_FILE: registryUrl,
+            },
           },
-        },
-      );
+        );
 
-      expect(result.status, result.stdout + result.stderr).toBe(17);
-      await expect(
-        fetch(readFileSync(registryUrl, "utf8"), { signal: AbortSignal.timeout(1_000) }),
-      ).rejects.toThrow();
-    });
-  });
+        expect(result.status, result.stdout + result.stderr).toBe(17);
+        await expect(
+          fetch(readFileSync(registryUrl, "utf8"), { signal: AbortSignal.timeout(1_000) }),
+        ).rejects.toThrow();
+      });
+    },
+  );
 
   it("carries verified registry bytes and their expected identity into the Docker context", () => {
     const root = tempDirs.make("openclaw-prepublish-build-context-");
@@ -483,16 +486,10 @@ NODE
 
   it.each(["2026.8.1", "2026.8.1-2"])(
     "resolves stable candidate %s from an unversioned npm spec",
-    (version) => {
+    async (version) => {
       const root = tempDirs.make("openclaw-stable-prepublish-registry-shell-");
       const registryRoot = join(root, "registry");
-      const discordTarball = createTarball(
-        root,
-        root,
-        "@openclaw/discord",
-        `openclaw-discord-${version}.tgz`,
-        version,
-      );
+      const fixture = registryFixture(root, ["@openclaw/discord"], version);
       const fixtureVersion = "2026.5.2";
       const braveTarball = createTarball(
         root,
@@ -501,11 +498,12 @@ NODE
         `openclaw-brave-${fixtureVersion}.tgz`,
         fixtureVersion,
       );
-      const result = spawnSync(
-        "bash",
-        [
-          "-c",
-          `
+      await withPublishedRegistry(root, (upstream) => {
+        const result = spawnSync(
+          "bash",
+          [
+            "-c",
+            `
 set -euo pipefail
 source "$HELPER"
 registry_pid=""
@@ -516,29 +514,32 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
-openclaw_prepublish_plugin_registry_start \
-  "" "" "$VERSION" "" "$REGISTRY_ROOT" registry_pid \
-  "@openclaw/discord" "$VERSION" "$DISCORD_TARBALL" \
+openclaw_prepublish_plugin_registry_start_mounted \
+  "$REGISTRY_ROOT" registry_pid '[]' \
   "@openclaw/brave-plugin" "$FIXTURE_VERSION" "$BRAVE_TARBALL"
 test "$(npm view @openclaw/discord version)" = "$VERSION"
+test "$(npm view @openclaw/discord@$BASELINE_VERSION version)" = "$BASELINE_VERSION"
 test "$(npm view @openclaw/brave-plugin version)" = "$FIXTURE_VERSION"
 `,
-        ],
-        {
-          encoding: "utf8",
-          env: {
-            ...process.env,
-            BRAVE_TARBALL: braveTarball,
-            DISCORD_TARBALL: discordTarball,
-            FIXTURE_VERSION: fixtureVersion,
-            HELPER: SCRIPT,
-            REGISTRY_ROOT: registryRoot,
-            VERSION: version,
+          ],
+          {
+            encoding: "utf8",
+            env: {
+              ...process.env,
+              ...fixture.env,
+              OPENCLAW_NPM_REGISTRY_UPSTREAM: upstream,
+              BASELINE_VERSION,
+              BRAVE_TARBALL: braveTarball,
+              FIXTURE_VERSION: fixtureVersion,
+              HELPER: SCRIPT,
+              REGISTRY_ROOT: registryRoot,
+              VERSION: version,
+            },
           },
-        },
-      );
+        );
 
-      expect(result.status, result.stderr).toBe(0);
+        expect(result.status, result.stderr).toBe(0);
+      });
     },
   );
 

--- a/test/scripts/upgrade-survivor-config-parking.test.ts
+++ b/test/scripts/upgrade-survivor-config-parking.test.ts
@@ -371,42 +371,48 @@ ${conditional ? 'probe_status=0; phase preparation handler || probe_status=$?; e
     expect(existsSync(snapshotPath)).toBe(false);
   });
 
-  it("restores authored bytes and preserves the failing companion install status", () => {
-    const root = tempDirs.make("openclaw-companion-install-failure-");
-    const binDir = path.join(root, "bin");
-    const configPath = path.join(root, "openclaw.json");
-    const invocationPath = path.join(root, "openclaw-invocations");
-    const runnerPath = path.join(root, "run-companion-install.sh");
-    const authoredConfig =
-      '{"channels":{"discord":{"dm":{"policy":"allowlist","allowFrom":["123"]}}}}\n';
-    mkdirSync(binDir);
-    writeFileSync(configPath, authoredConfig);
-    const survivorScript = readFileSync(SURVIVOR_SCRIPT_PATH, "utf8");
-    const functionStart = survivorScript.indexOf("install_companion_plugins() {");
-    const functionEnd = survivorScript.indexOf(
-      "\n}\n\nopenclaw_e2e_eval_test_state_from_b64",
-      functionStart,
-    );
-    expect(functionStart).toBeGreaterThan(-1);
-    expect(functionEnd).toBeGreaterThan(functionStart);
-    const functionSource = survivorScript.slice(functionStart, functionEnd + 2);
-    const e2eInstanceScript = readFileSync(E2E_INSTANCE_SCRIPT_PATH, "utf8");
-    const fixtureCommandStart = e2eInstanceScript.indexOf(
-      "openclaw_e2e_fixture_plugin_command() {",
-    );
-    const fixtureCommandEnd = e2eInstanceScript.indexOf(
-      "\n}\nopenclaw_e2e_enable_openclaw_cli_timeout",
-      fixtureCommandStart,
-    );
-    expect(fixtureCommandStart).toBeGreaterThan(-1);
-    expect(fixtureCommandEnd).toBeGreaterThan(fixtureCommandStart);
-    const fixtureCommandSource = e2eInstanceScript.slice(
-      fixtureCommandStart,
-      fixtureCommandEnd + 2,
-    );
-    writeFileSync(
-      path.join(binDir, "openclaw"),
-      `#!/usr/bin/env bash
+  it.each([
+    { installStatus: 0, inspectStatus: 0 },
+    { installStatus: 23, inspectStatus: 0 },
+    { installStatus: 0, inspectStatus: 29 },
+  ])(
+    "parks companion inspection and restores authored bytes (install=$installStatus, inspect=$inspectStatus)",
+    ({ installStatus, inspectStatus }) => {
+      const root = tempDirs.make("openclaw-companion-install-failure-");
+      const binDir = path.join(root, "bin");
+      const configPath = path.join(root, "openclaw.json");
+      const invocationPath = path.join(root, "openclaw-invocations");
+      const runnerPath = path.join(root, "run-companion-install.sh");
+      const authoredConfig =
+        '{"channels":{"discord":{"dm":{"policy":"allowlist","allowFrom":["123"]}}}}\n';
+      mkdirSync(binDir);
+      writeFileSync(configPath, authoredConfig);
+      const survivorScript = readFileSync(SURVIVOR_SCRIPT_PATH, "utf8");
+      const functionStart = survivorScript.indexOf("install_companion_plugins() {");
+      const functionEnd = survivorScript.indexOf(
+        "\n}\n\nopenclaw_e2e_eval_test_state_from_b64",
+        functionStart,
+      );
+      expect(functionStart).toBeGreaterThan(-1);
+      expect(functionEnd).toBeGreaterThan(functionStart);
+      const functionSource = survivorScript.slice(functionStart, functionEnd + 2);
+      const e2eInstanceScript = readFileSync(E2E_INSTANCE_SCRIPT_PATH, "utf8");
+      const fixtureCommandStart = e2eInstanceScript.indexOf(
+        "openclaw_e2e_fixture_plugin_command() {",
+      );
+      const fixtureCommandEnd = e2eInstanceScript.indexOf(
+        "\n}\nopenclaw_e2e_enable_openclaw_cli_timeout",
+        fixtureCommandStart,
+      );
+      expect(fixtureCommandStart).toBeGreaterThan(-1);
+      expect(fixtureCommandEnd).toBeGreaterThan(fixtureCommandStart);
+      const fixtureCommandSource = e2eInstanceScript.slice(
+        fixtureCommandStart,
+        fixtureCommandEnd + 2,
+      );
+      writeFileSync(
+        path.join(binDir, "openclaw"),
+        `#!/usr/bin/env bash
 set -euo pipefail
 count=0
 if [ -f "$OPENCLAW_INVOCATION_PATH" ]; then
@@ -415,39 +421,66 @@ fi
 count=$((count + 1))
 printf '%s' "$count" >"$OPENCLAW_INVOCATION_PATH"
 if [ "$count" -eq 2 ]; then
-  exit 23
+  exit "$PROBE_INSTALL_STATUS"
 fi
 `,
-    );
-    chmodSync(path.join(binDir, "openclaw"), 0o755);
-    writeFileSync(
-      runnerPath,
-      `#!/usr/bin/env bash
+      );
+      chmodSync(path.join(binDir, "openclaw"), 0o755);
+      writeFileSync(
+        path.join(binDir, "node"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  scripts/e2e/lib/upgrade-survivor/assertions.mjs)
+    cp "$OPENCLAW_CONFIG_PATH" "$PROBE_INSPECT_CONFIG"
+    "$PROBE_NODE" -e 'const config = require(process.env.OPENCLAW_CONFIG_PATH); if (config.channels || config.plugins?.enabled !== false) process.exit(37);'
+    exit "$PROBE_INSPECT_STATUS" ;;
+  unused) exit 0 ;;
+  *) exec "$PROBE_NODE" "$@" ;;
+esac
+`,
+        { mode: 0o755 },
+      );
+      writeFileSync(
+        runnerPath,
+        `#!/usr/bin/env bash
 set -euo pipefail
 ${fixtureCommandSource}
 ${functionSource}
 install_companion_plugins
 `,
-    );
+      );
 
-    const result = spawnSync("bash", [runnerPath], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        OPENCLAW_CONFIG_PATH: configPath,
-        OPENCLAW_INVOCATION_PATH: invocationPath,
-        OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT: root,
-        OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER: SCRIPT_PATH,
-        OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER: "unused",
-        PATH: `${binDir}:${process.env.PATH ?? ""}`,
-        package_version: "2026.8.1",
-      },
-    });
+      const result = spawnSync("bash", [runnerPath], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_INVOCATION_PATH: invocationPath,
+          OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT: root,
+          OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER: SCRIPT_PATH,
+          OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER: "unused",
+          OPENCLAW_CLAWHUB_URL: "http://fixture.invalid",
+          OPENCLAW_E2E_LAST_FIXTURE_PLUGIN_CAPABILITY_CONSENT_SUPPORTED: "1",
+          PROBE_NODE: process.execPath,
+          PROBE_INSPECT_CONFIG: path.join(root, "inspect-config.json"),
+          PROBE_INSTALL_STATUS: String(installStatus),
+          PROBE_INSPECT_STATUS: String(inspectStatus),
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          package_version: "2026.8.1",
+        },
+      });
 
-    expect(result.status, result.stderr).toBe(23);
-    expect(readFileSync(configPath, "utf8")).toBe(authoredConfig);
-    expect(existsSync(path.join(root, "companion-install-authored.json"))).toBe(false);
-  });
+      expect(result.status, result.stderr).toBe(installStatus || inspectStatus);
+      if (!installStatus) {
+        expect(JSON.parse(readFileSync(path.join(root, "inspect-config.json"), "utf8"))).toEqual({
+          plugins: { enabled: false },
+        });
+      }
+      expect(readFileSync(configPath, "utf8")).toBe(authoredConfig);
+      expect(existsSync(path.join(root, "companion-install-authored.json"))).toBe(false);
+    },
+  );
 
   it("rejects malformed config without changing authored bytes", () => {
     const root = tempDirs.make("openclaw-invalid-config-parking-");


### PR DESCRIPTION
Related: Full Release Validation [33697142798](https://github.com/openclaw/openclaw/actions/runs/33697142798), candidate checks [33698227500](https://github.com/openclaw/openclaw/actions/runs/33698227500).

Dependency: #136774 is still open. This branch carries its unchanged Docker workspace-install commit, followed by one commit per upgrade-lane root cause. Drop that cherry-pick once #136774 lands.

## What Problem This Solves

Resolves a problem where stable release validation reported failed 2026.8.2 → 2026.9.1 upgrades before exercising the intended product behavior. Published survivors, root-managed VPS, and restart-auth encountered stale WhatsApp artifacts; the synthetic survivor rejected legacy Discord configuration during setup; corrupt-plugin tolerance failed while preparing its synthetic package.

## Why This Change Was Made

All three root causes belong to the Docker harness:

- The prepared npm registry merged public `latest` over candidate tags. Stable official plugins correctly selected `latest`, which still pointed at 2026.8.2 even though exact 2026.9.1 tarballs were present. Preserve published tags for baseline setup, then prefer each prepared package's own tags for candidate updates while retaining published dependency versions and independently versioned fixtures.
- Companion inspection validates config. It ran after restoring the intentionally invalid migration specimen, so Discord's legacy keys were rejected before update or Doctor. Keep inspection inside the existing parked-config lifetime and restore authored bytes on success and failure. The owning Discord Doctor migration already exists, including in 2026.8.2.
- The corrupt-plugin fixture replaced only one npm registry environment spelling, then unset both before update. That first caused a synthetic-package 404 and subsequently an `@openclaw/ai@2026.9.1` ETARGET against the public registry. Set both spellings and scope the synthetic registry to setup so cleanup restores the parent candidate registry and retains post-core evidence.

No product runtime, configuration contract, persistence, or Doctor migration changes. For the three repairs, runtime LOC delta is **0**, harness delta is **+18**, and test delta is **+57**. The harness growth expresses distinct baseline/candidate selection and fixture ownership; obsolete source-order assertions are removed in favor of shell execution tests. The separate #136774 dependency is excluded from those counts.

## User Impact

Maintainers can validate the actual published-baseline upgrade and corrupt-plugin recovery behavior. These failures do not establish a product regression for users upgrading from 2026.8.2: with the registry serving the intended candidate, the unchanged release package upgrades its official plugins, migrates the legacy fixture, preserves state, and starts a healthy Gateway. A real stable publication must still publish its companion packages and tags correctly.

## Evidence

Local OrbStack Docker runs use the original CI candidate, not a rebuilt package: source `c92d0ae9c07e757719e676517aa9f9460a40761c`, version `2026.9.1`, baseline `openclaw@2026.8.2`. Candidate [artifact 9872648429](https://github.com/openclaw/openclaw/actions/runs/33698227500/artifacts/9872648429) SHA-256: `befd59d701091de5f855371ba58d4a4932ca9958d006a0e28442aba76565d264`. Prepared registry [artifact 9872454819](https://github.com/openclaw/openclaw/actions/runs/33697728959/artifacts/9872454819) manifest SHA-256: `c67573da702e9136f756056ad7677ae7c4fab013eccfce9c451e42b59aba666b`.

| Lane | Before | Repaired harness, same release artifacts |
| --- | --- | --- |
| Published upgrade survivor, base | Core 2026.9.1 but WhatsApp 2026.8.2 | Passed update, exact candidate plugin/provenance checks, migrations, state survival, Gateway health/readiness/RPC |
| Synthetic `upgrade-survivor` | Legacy Discord rejected during `prepare-state`, before update | Passed migration, state survival, Gateway startup and RPC |
| `update-corrupt-plugin` | Synthetic-package 404; after spelling repair alone, candidate dependency ETARGET | Passed full upgrade and corrupt-plugin tolerance, preserving allowlist and explicit runtime opt-out |
| Published configured-plugin-installs (Matrix) | Same stale-tag path in original published-survivor jobs | Passed exact candidate plugin checks, config/state survival, Gateway startup and RPC |
| `root-managed-vps-upgrade` | Stale WhatsApp in original CI | Passed update, root-owned CLI usability, migration/state checks and Gateway probes |
| `update-restart-auth` | Stale WhatsApp in original CI | Passed configured-auth service replacement by the candidate updater, with no recovery repair; final Gateway health/readiness/RPC passed |

All six local Docker after-runs exited 0. The regression tests fail on the old harness. Focused proof passed: 15 prepared-registry tests, 37 official-plugin selection tests, three config-parking lifecycle cases, the existing companion-order helper case, and the real-npm registry-spelling case. `pnpm check:changed`, shell syntax checks, and independent Codex autoreview at the configured P0 threshold passed. After rebasing onto main's #136771 Windows archive-path repair, both registry test files passed together: **59 tests**, including the real npm contracts and archive-path case; `pnpm check:changed` also passed again on the final head.

<details>
<summary>Reproduce the published baseline lane with the original candidate</summary>

```bash
gh run download 33698227500 --repo openclaw/openclaw \
  -n package-under-test-33698227500-1 -D .artifacts/repro-before/package
gh run download 33697728959 --repo openclaw/openclaw \
  -n docker-e2e-prepublish-plugin-registry-33697728959-1 \
  -D .artifacts/repro-before/registry
docker build --target bare -t openclaw-upgrade-lanes:bare -f scripts/e2e/Dockerfile .
OPENCLAW_DOCKER_E2E_REPO_ROOT="$PWD" \
OPENCLAW_SKIP_DOCKER_BUILD=1 \
OPENCLAW_UPGRADE_SURVIVOR_E2E_IMAGE=openclaw-upgrade-lanes:bare \
OPENCLAW_CURRENT_PACKAGE_TGZ="$PWD/.artifacts/repro-before/package/openclaw-current.tgz" \
OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR="$PWD/.artifacts/repro-before/registry" \
OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION=2026.9.1 \
OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256=c67573da702e9136f756056ad7677ae7c4fab013eccfce9c451e42b59aba666b \
OPENCLAW_DOCKER_E2E_SELECTED_SHA=c92d0ae9c07e757719e676517aa9f9460a40761c \
OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 \
OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@2026.8.2 \
OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=base \
OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_DIR="$PWD/.artifacts/proof/published" \
bash scripts/e2e/upgrade-survivor-docker.sh
```

The same runner selects Matrix with `OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=configured-plugin-installs`, root-managed VPS with `OPENCLAW_UPGRADE_SURVIVOR_ROOT_MANAGED_VPS=1`, and restart-auth with `OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE=auto-auth`. Omit the published-baseline flags for the synthetic survivor. Corrupt-plugin proof uses `scripts/e2e/update-corrupt-plugin-docker.sh`, `OPENCLAW_UPDATE_CORRUPT_PLUGIN_E2E_IMAGE=openclaw-upgrade-lanes:bare`, and `OPENCLAW_UPDATE_CORRUPT_PLUGIN_BASELINE=openclaw@2026.8.2` with the same candidate registry environment.

</details>

The full release workflow, all published-survivor scenario permutations, native Windows, and live channel/provider traffic are not rerun here. Docker evidence exercises the original immutable candidate with the repaired harness; it does not validate a newly packed current-main product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
