### PR TITLE
chore(cron): require the previous daily occurrence in tests

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -477,9 +477,7 @@ describe("cron schedule", () => {
       { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
       nowMs,
     );
-    if (previous !== undefined) {
-      expect(previous).toBeLessThan(nowMs);
-    }
+    expect(previous).toBe(Date.parse("2026-02-28T00:00:00.000Z"));
   });
 
   it("reuses compiled cron evaluators for the same expression/timezone", () => {


### PR DESCRIPTION
## What Problem This Solves

The daily cron previous-run test could pass without checking anything when the scheduler returned `undefined`. Its less-than assertion also accepted the wrong earlier date.

## Why This Change Was Made

Require the exact previous occurrence: February 28, 2026 at 08:00 Asia/Shanghai when the cursor is March 1, 2026 at 08:00. This strengthens the existing test of the public scheduling function without adding a helper or changing scheduling behavior.

## User Impact

No runtime behavior change. All 68 cases, including timezone/DST and valid undefined outcomes, remain. Production delta: 0; test delta: −2 lines.

## Evidence

The unchanged full suite passed 68/68. With the public owner temporarily returning `undefined`, the original named case still passed (1 passed, 67 skipped). The same fault now fails the exact assertion: `expected undefined to be 1772236800000`. The corrected full suite passed 68/68; every fault restored the owner exactly after its child joined.

This control demonstrates the named case's former gap; existing DST and exact-value tests retain their broader coverage.

The normal one-path changed gate passed, including core test types and typed lint. Scoped Codex review through P2 passed with no findings.
