### PR TITLE
fix(ci): select older baselines for release upgrade checks

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -878,9 +878,8 @@ jobs:
               --candidate-version "$package_version"
               --versions-json "$versions_json"
             )
-            if [[ -n "$TARGET_CONTEXT_REF" ]]; then
-              resolver_args+=(--target-context-ref "$TARGET_CONTEXT_REF")
-            fi
+            # An explicit package override is independent of the selected release target.
+            # Do not apply that target's frozen-line baseline contract to it.
             package_baseline="$(
               node workflow/scripts/lib/release-upgrade-baseline.mjs "${resolver_args[@]}"
             )"

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -324,50 +324,43 @@ jobs:
             --fallback-ok \
             --github-output "$GITHUB_OUTPUT"
 
-      - name: Checkout selected ref for reachability fallback
-        if: steps.fast_ref.outputs.fallback == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          ref: ${{ inputs.ref }}
-          path: source
-          fetch-depth: 0
-          filter: blob:none
-          sparse-checkout: package.json
-          sparse-checkout-cone-mode: false
-
-      - name: Resolve checked-out fallback SHA
+      - name: Validate fallback ref belongs to this repository
         if: steps.fast_ref.outputs.fallback == 'true'
         id: fallback_ref
-        working-directory: source
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Validate selected ref belongs to this repository
-        if: steps.fast_ref.outputs.fallback == 'true'
-        working-directory: source
         env:
+          FALLBACK_SHA: ${{ steps.fast_ref.outputs.sha }}
           RELEASE_REF: ${{ inputs.ref }}
           GITHUB_TOKEN: ${{ github.token }}
+          TRUSTED_REPOSITORY_URL: https://github.com/${{ github.repository }}.git
         run: |
           set -euo pipefail
-          SELECTED_SHA="$(git rev-parse HEAD)"
-          git_fetch_with_checkout_auth() {
+          SELECTED_SHA="$FALLBACK_SHA"
+          if [[ ! "$SELECTED_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "Unable to resolve selected ref '${RELEASE_REF}' to a full commit SHA." >&2
+            exit 1
+          fi
+          target_repo="$(mktemp -d)"
+          trap 'rm -rf -- "$target_repo"' EXIT
+          git init --bare --quiet "$target_repo"
+          git_fetch_with_token() {
             local -a git_args=(git)
-            if ! git config --get-all http.https://github.com/.extraheader >/dev/null; then
+            if ! git -C "$target_repo" config --get-all http.https://github.com/.extraheader >/dev/null; then
               local auth_header
               auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
               git_args+=(-c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}")
             fi
-            timeout --signal=TERM --kill-after=10s 120s "${git_args[@]}" fetch "$@"
+            timeout --signal=TERM --kill-after=10s 120s "${git_args[@]}" -C "$target_repo" fetch "$@"
           }
-          git_fetch_with_checkout_auth --no-tags origin '+refs/heads/*:refs/remotes/origin/*'
-          git_fetch_with_checkout_auth --tags origin '+refs/tags/*:refs/tags/*'
+          # Reachability needs only repository objects; do not materialize or execute target code.
+          git_fetch_with_token --no-tags "$TRUSTED_REPOSITORY_URL" '+refs/heads/*:refs/remotes/origin/*'
+          git_fetch_with_token --no-tags "$TRUSTED_REPOSITORY_URL" '+refs/tags/*:refs/tags/*'
 
-          if git tag --points-at "${SELECTED_SHA}" | grep -Eq '^v'; then
-            exit 0
+          if ! git -C "$target_repo" cat-file -e "${SELECTED_SHA}^{commit}"; then
+            echo "Ref '${RELEASE_REF}' resolved to ${SELECTED_SHA}, but that object is not a commit in this repository." >&2
+            exit 1
           fi
-
-          if git for-each-ref --format='%(refname:short)' --contains "${SELECTED_SHA}" refs/remotes/origin | grep -Eq '^origin/'; then
+          if git -C "$target_repo" for-each-ref --format='%(refname:short)' --contains "${SELECTED_SHA}" refs/remotes/origin refs/tags | grep -q .; then
+            echo "sha=${SELECTED_SHA,,}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -169,9 +169,7 @@ jobs:
       package_required: ${{ steps.inputs.outputs.package_required }}
       docker_required: ${{ steps.inputs.outputs.docker_required }}
       install_smoke_scheduled: ${{ steps.inputs.outputs.install_smoke_scheduled }}
-      upgrade_baseline: ${{ steps.upgrade_baseline.outputs.value }}
-      package_acceptance_exact_package_spec: ${{ steps.upgrade_baseline.outputs.package_acceptance_package_spec }}
-      package_acceptance_upgrade_baseline: ${{ steps.upgrade_baseline.outputs.package_acceptance_baseline }}
+      source_upgrade_baseline: ${{ steps.source_upgrade_baseline.outputs.value }}
       fail_fast: ${{ steps.inputs.outputs.fail_fast }}
       run_maturity_scorecard: ${{ steps.inputs.outputs.run_maturity_scorecard }}
       allow_unreleased_changelog: ${{ steps.inputs.outputs.allow_unreleased_changelog }}
@@ -808,24 +806,13 @@ jobs:
             printf 'qa_parity_scheduled=%s\n' "$qa_parity_scheduled"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Resolve upgrade baseline
-        id: upgrade_baseline
-        if: >-
-          (steps.inputs.outputs.install_smoke_scheduled == 'true' ||
-          steps.inputs.outputs.package_acceptance_scheduled == 'true' ||
-          steps.inputs.outputs.docker_required == 'true' ||
-          (steps.inputs.outputs.cross_os_scheduled == 'true' &&
-          steps.inputs.outputs.mode != 'fresh'))
+      - name: Resolve source checkout upgrade baseline
+        id: source_upgrade_baseline
+        if: steps.inputs.outputs.install_smoke_scheduled == 'true'
         # The resolver is trusted workflow code; target metadata is data only.
         working-directory: workflow
         env:
-          CROSS_OS_SCHEDULED: ${{ steps.inputs.outputs.cross_os_scheduled }}
-          DOCKER_REQUIRED: ${{ steps.inputs.outputs.docker_required }}
           GH_TOKEN: ${{ github.token }}
-          INSTALL_SMOKE_SCHEDULED: ${{ steps.inputs.outputs.install_smoke_scheduled }}
-          PACKAGE_ACCEPTANCE_PACKAGE_SPEC: ${{ steps.inputs.outputs.package_acceptance_package_spec }}
-          PACKAGE_ACCEPTANCE_SCHEDULED: ${{ steps.inputs.outputs.package_acceptance_scheduled }}
-          RELEASE_MODE: ${{ steps.inputs.outputs.mode }}
           TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           TARGET_SHA: ${{ steps.ref.outputs.sha }}
         run: |
@@ -833,54 +820,20 @@ jobs:
           versions_json="${RUNNER_TEMP}/openclaw-published-versions.json"
           npm view openclaw versions --json --silent --prefer-online > "$versions_json"
 
-          target_baseline_required=false
-          if [[ "$INSTALL_SMOKE_SCHEDULED" == "true" ||
-                "$DOCKER_REQUIRED" == "true" ||
-                ( "$CROSS_OS_SCHEDULED" == "true" && "$RELEASE_MODE" != "fresh" ) ||
-                ( "$PACKAGE_ACCEPTANCE_SCHEDULED" == "true" &&
-                  -z "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" ) ]]; then
-            target_baseline_required=true
+          candidate_version="$(
+            gh api "repos/${GITHUB_REPOSITORY}/contents/package.json?ref=${TARGET_SHA}" --jq .content |
+              base64 --decode |
+              jq -er '.version | select(type == "string" and length > 0)'
+          )"
+          resolver_args=(
+            --candidate-version "$candidate_version"
+            --versions-json "$versions_json"
+          )
+          if [[ -n "$TARGET_CONTEXT_REF" ]]; then
+            resolver_args+=(--target-context-ref "$TARGET_CONTEXT_REF")
           fi
-          if [[ "$target_baseline_required" == "true" ]]; then
-            candidate_version="$(
-              gh api "repos/${GITHUB_REPOSITORY}/contents/package.json?ref=${TARGET_SHA}" --jq .content |
-                base64 --decode |
-                jq -er '.version | select(type == "string" and length > 0)'
-            )"
-            resolver_args=(
-              --candidate-version "$candidate_version"
-              --versions-json "$versions_json"
-            )
-            if [[ -n "$TARGET_CONTEXT_REF" ]]; then
-              resolver_args+=(--target-context-ref "$TARGET_CONTEXT_REF")
-            fi
-            baseline="$(node scripts/lib/release-upgrade-baseline.mjs "${resolver_args[@]}")"
-            echo "value=${baseline#openclaw@}" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [[ "$PACKAGE_ACCEPTANCE_SCHEDULED" == "true" &&
-                -n "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" ]]; then
-            package_name="$(
-              npm view "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" name --json --silent --prefer-online |
-                jq -er 'if type == "array" then last else . end | select(. == "openclaw")'
-            )"
-            package_version="$(
-              npm view "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" version --json --silent --prefer-online |
-                jq -er 'if type == "array" then last else . end | select(type == "string" and length > 0)'
-            )"
-            jq -e --arg version "$package_version" 'index($version) != null' "$versions_json" >/dev/null
-            resolver_args=(
-              --candidate-version "$package_version"
-              --versions-json "$versions_json"
-            )
-            # An explicit package override is independent of the selected release target.
-            # Do not apply that target's frozen-line baseline contract to it.
-            package_baseline="$(
-              node scripts/lib/release-upgrade-baseline.mjs "${resolver_args[@]}"
-            )"
-            echo "package_acceptance_package_spec=${package_name}@${package_version}" >> "$GITHUB_OUTPUT"
-            echo "package_acceptance_baseline=${package_baseline#openclaw@}" >> "$GITHUB_OUTPUT"
-          fi
+          baseline="$(node scripts/lib/release-upgrade-baseline.mjs "${resolver_args[@]}")"
+          echo "value=${baseline#openclaw@}" >> "$GITHUB_OUTPUT"
 
       - name: Summarize validated ref
         env:
@@ -982,6 +935,9 @@ jobs:
       package_file_name: ${{ steps.artifact.outputs.file_name || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageFileName }}
       package_sha256: ${{ steps.package.outputs.sha256 || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageSha256 }}
       package_version: ${{ steps.package.outputs.package_version || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageVersion }}
+      upgrade_baseline: ${{ steps.upgrade_baseline.outputs.value }}
+      package_acceptance_exact_package_spec: ${{ steps.upgrade_baseline.outputs.package_acceptance_package_spec }}
+      package_acceptance_upgrade_baseline: ${{ steps.upgrade_baseline.outputs.package_acceptance_baseline }}
       prepublish_plugin_registry_json: ${{ steps.registry_identity.outputs.json }}
       source_sha: ${{ steps.package.outputs.source_sha || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageSourceSha }}
     steps:
@@ -1250,6 +1206,63 @@ jobs:
               "$(jq -r '.prepublishPluginRegistryArtifactRunAttempt' <<< "$CANDIDATE_ARTIFACT_JSON")"
           fi
 
+      - name: Resolve package upgrade baseline
+        id: upgrade_baseline
+        if: >-
+          needs.resolve_target.outputs.package_acceptance_scheduled == 'true' ||
+          needs.resolve_target.outputs.docker_required == 'true' ||
+          (needs.resolve_target.outputs.cross_os_scheduled == 'true' &&
+          needs.resolve_target.outputs.mode != 'fresh')
+        env:
+          CANDIDATE_VERSION: ${{ steps.package.outputs.package_version || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageVersion }}
+          CROSS_OS_SCHEDULED: ${{ needs.resolve_target.outputs.cross_os_scheduled }}
+          DOCKER_REQUIRED: ${{ needs.resolve_target.outputs.docker_required }}
+          PACKAGE_ACCEPTANCE_PACKAGE_SPEC: ${{ needs.resolve_target.outputs.package_acceptance_package_spec }}
+          PACKAGE_ACCEPTANCE_SCHEDULED: ${{ needs.resolve_target.outputs.package_acceptance_scheduled }}
+          RELEASE_MODE: ${{ needs.resolve_target.outputs.mode }}
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
+        run: |
+          set -euo pipefail
+          versions_json="${RUNNER_TEMP}/openclaw-published-versions.json"
+          npm view openclaw versions --json --silent --prefer-online > "$versions_json"
+
+          candidate_baseline_required=false
+          if [[ "$DOCKER_REQUIRED" == "true" ||
+                ( "$CROSS_OS_SCHEDULED" == "true" && "$RELEASE_MODE" != "fresh" ) ||
+                ( "$PACKAGE_ACCEPTANCE_SCHEDULED" == "true" &&
+                  -z "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" ) ]]; then
+            candidate_baseline_required=true
+          fi
+          if [[ "$candidate_baseline_required" == "true" ]]; then
+            resolver_args=(
+              --candidate-version "$CANDIDATE_VERSION"
+              --versions-json "$versions_json"
+            )
+            if [[ -n "$TARGET_CONTEXT_REF" ]]; then
+              resolver_args+=(--target-context-ref "$TARGET_CONTEXT_REF")
+            fi
+            baseline="$(node scripts/lib/release-upgrade-baseline.mjs "${resolver_args[@]}")"
+            echo "value=${baseline#openclaw@}" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "$PACKAGE_ACCEPTANCE_SCHEDULED" == "true" &&
+                -n "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" ]]; then
+            package_name="$(
+              npm view "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" name --json --silent --prefer-online |
+                jq -er 'if type == "array" then last else . end | select(. == "openclaw")'
+            )"
+            package_version="$(
+              npm view "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" version --json --silent --prefer-online |
+                jq -er 'if type == "array" then last else . end | select(type == "string" and length > 0)'
+            )"
+            jq -e --arg version "$package_version" 'index($version) != null' "$versions_json" >/dev/null
+            package_baseline="$(node scripts/lib/release-upgrade-baseline.mjs \
+              --candidate-version "$package_version" \
+              --versions-json "$versions_json")"
+            echo "package_acceptance_package_spec=${package_name}@${package_version}" >> "$GITHUB_OUTPUT"
+            echo "package_acceptance_baseline=${package_baseline#openclaw@}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Prepare prerelease plugin registry identity
         id: registry_identity
         env:
@@ -1305,7 +1318,7 @@ jobs:
       allow_unreleased_changelog: ${{ needs.resolve_target.outputs.allow_unreleased_changelog == 'true' }}
       ref: ${{ needs.resolve_target.outputs.revision }}
       run_bun_global_install_smoke: true
-      update_baseline_version: ${{ needs.resolve_target.outputs.upgrade_baseline }}
+      update_baseline_version: ${{ needs.resolve_target.outputs.source_upgrade_baseline }}
 
   cross_os_release_checks:
     needs: [resolve_target, prepare_release_package]
@@ -1316,7 +1329,7 @@ jobs:
       advisory: ${{ startsWith(github.ref, 'refs/heads/tideclaw/alpha/') }}
       ref: ${{ needs.resolve_target.outputs.revision }}
       target_context_ref: ${{ inputs.target_context_ref }}
-      previous_version: ${{ needs.resolve_target.outputs.upgrade_baseline }}
+      previous_version: ${{ needs.prepare_release_package.outputs.upgrade_baseline }}
       provider: ${{ needs.resolve_target.outputs.provider }}
       mode: ${{ needs.resolve_target.outputs.mode }}
       suite_filter: ${{ needs.resolve_target.outputs.cross_os_suite_filter }}
@@ -1455,7 +1468,7 @@ jobs:
       prepublish_plugin_registry_artifact_run_attempt: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
       prepublish_plugin_registry_manifest_sha256: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
       codex_plugin_spec: ${{ needs.resolve_target.outputs.codex_plugin_spec }}
-      published_upgrade_survivor_baseline: ${{ format('openclaw@{0}', needs.resolve_target.outputs.upgrade_baseline) }}
+      published_upgrade_survivor_baseline: ${{ format('openclaw@{0}', needs.prepare_release_package.outputs.upgrade_baseline) }}
       shared_image_artifact_namespace: release-docker
       shared_image_artifact_name: ${{ fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').imageArtifactName || '' }}
       shared_image_artifact_id: ${{ fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').imageArtifactId || '' }}
@@ -1481,7 +1494,7 @@ jobs:
       allow_frozen_target_scenario_omissions: ${{ inputs.allow_frozen_target_scenario_omissions }}
       workflow_ref: ${{ github.sha }}
       source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.package_mode == 'published') && 'npm' || 'artifact' }}
-      package_spec: ${{ needs.resolve_target.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}
+      package_spec: ${{ needs.prepare_release_package.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}
       artifact_digest: ${{ needs.prepare_release_package.outputs.artifact_digest }}
       artifact_id: ${{ needs.prepare_release_package.outputs.artifact_id }}
       artifact_name: ${{ needs.prepare_release_package.outputs.artifact_name }}
@@ -1494,7 +1507,7 @@ jobs:
       prepublish_plugin_registry_json: ${{ needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '' }}
       suite_profile: custom
       docker_lanes: release-typed-onboarding doctor-switch update-channel-switch skill-install update-corrupt-plugin upgrade-survivor update-first-hop-compat published-upgrade-survivor root-managed-vps-upgrade update-restart-auth plugins-offline plugin-update plugin-binding-command-escape
-      published_upgrade_survivor_baseline: ${{ format('openclaw@{0}', needs.resolve_target.outputs.package_acceptance_upgrade_baseline || needs.resolve_target.outputs.upgrade_baseline) }}
+      published_upgrade_survivor_baseline: ${{ format('openclaw@{0}', needs.prepare_release_package.outputs.package_acceptance_upgrade_baseline || needs.prepare_release_package.outputs.upgrade_baseline) }}
       published_upgrade_survivor_scenarios: ${{ needs.resolve_target.outputs.run_release_soak == 'true' && 'reported-issues' || '' }}
       telegram_mode: ${{ (needs.resolve_target.outputs.telegram_waiver != '' || needs.resolve_target.outputs.skip_package_telegram_e2e == 'true') && 'none' || 'mock-openai' }}
       telegram_advisory: true

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -823,6 +823,8 @@ jobs:
           steps.inputs.outputs.docker_required == 'true' ||
           (steps.inputs.outputs.cross_os_scheduled == 'true' &&
           steps.inputs.outputs.mode != 'fresh'))
+        # The resolver is trusted workflow code; target metadata is data only.
+        working-directory: workflow
         env:
           CROSS_OS_SCHEDULED: ${{ steps.inputs.outputs.cross_os_scheduled }}
           DOCKER_REQUIRED: ${{ steps.inputs.outputs.docker_required }}
@@ -859,7 +861,7 @@ jobs:
             if [[ -n "$TARGET_CONTEXT_REF" ]]; then
               resolver_args+=(--target-context-ref "$TARGET_CONTEXT_REF")
             fi
-            baseline="$(node workflow/scripts/lib/release-upgrade-baseline.mjs "${resolver_args[@]}")"
+            baseline="$(node scripts/lib/release-upgrade-baseline.mjs "${resolver_args[@]}")"
             echo "value=${baseline#openclaw@}" >> "$GITHUB_OUTPUT"
           fi
 
@@ -881,7 +883,7 @@ jobs:
             # An explicit package override is independent of the selected release target.
             # Do not apply that target's frozen-line baseline contract to it.
             package_baseline="$(
-              node workflow/scripts/lib/release-upgrade-baseline.mjs "${resolver_args[@]}"
+              node scripts/lib/release-upgrade-baseline.mjs "${resolver_args[@]}"
             )"
             echo "package_acceptance_package_spec=${package_name}@${package_version}" >> "$GITHUB_OUTPUT"
             echo "package_acceptance_baseline=${package_baseline#openclaw@}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -169,7 +169,9 @@ jobs:
       package_required: ${{ steps.inputs.outputs.package_required }}
       docker_required: ${{ steps.inputs.outputs.docker_required }}
       install_smoke_scheduled: ${{ steps.inputs.outputs.install_smoke_scheduled }}
-      frozen_upgrade_baseline: ${{ steps.frozen_upgrade_baseline.outputs.value }}
+      upgrade_baseline: ${{ steps.upgrade_baseline.outputs.value }}
+      package_acceptance_exact_package_spec: ${{ steps.upgrade_baseline.outputs.package_acceptance_package_spec }}
+      package_acceptance_upgrade_baseline: ${{ steps.upgrade_baseline.outputs.package_acceptance_baseline }}
       fail_fast: ${{ steps.inputs.outputs.fail_fast }}
       run_maturity_scorecard: ${{ steps.inputs.outputs.run_maturity_scorecard }}
       allow_unreleased_changelog: ${{ steps.inputs.outputs.allow_unreleased_changelog }}
@@ -813,29 +815,78 @@ jobs:
             printf 'qa_parity_scheduled=%s\n' "$qa_parity_scheduled"
           } >> "$GITHUB_OUTPUT"
 
-      # A frozen extended-stable target must not downgrade from npm latest.
-      - name: Resolve frozen upgrade baseline
-        id: frozen_upgrade_baseline
+      - name: Resolve upgrade baseline
+        id: upgrade_baseline
         if: >-
           (steps.inputs.outputs.install_smoke_scheduled == 'true' ||
-          steps.inputs.outputs.package_acceptance_scheduled == 'true') &&
-          (startsWith(inputs.target_context_ref, 'extended-stable/') ||
-          startsWith(inputs.target_context_ref, 'refs/heads/extended-stable/'))
+          steps.inputs.outputs.package_acceptance_scheduled == 'true' ||
+          steps.inputs.outputs.docker_required == 'true' ||
+          (steps.inputs.outputs.cross_os_scheduled == 'true' &&
+          steps.inputs.outputs.mode != 'fresh'))
         env:
+          CROSS_OS_SCHEDULED: ${{ steps.inputs.outputs.cross_os_scheduled }}
+          DOCKER_REQUIRED: ${{ steps.inputs.outputs.docker_required }}
           GH_TOKEN: ${{ github.token }}
+          INSTALL_SMOKE_SCHEDULED: ${{ steps.inputs.outputs.install_smoke_scheduled }}
+          PACKAGE_ACCEPTANCE_PACKAGE_SPEC: ${{ steps.inputs.outputs.package_acceptance_package_spec }}
+          PACKAGE_ACCEPTANCE_SCHEDULED: ${{ steps.inputs.outputs.package_acceptance_scheduled }}
+          RELEASE_MODE: ${{ steps.inputs.outputs.mode }}
           TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           TARGET_SHA: ${{ steps.ref.outputs.sha }}
         run: |
           set -euo pipefail
-          candidate_version="$(
-            gh api "repos/${GITHUB_REPOSITORY}/contents/package.json?ref=${TARGET_SHA}" --jq .content |
-              base64 --decode |
-              jq -er '.version | select(type == "string" and length > 0)'
-          )"
-          baseline="$(node workflow/scripts/lib/release-upgrade-baseline.mjs \
-            --candidate-version "$candidate_version" \
-            --target-context-ref "$TARGET_CONTEXT_REF")"
-          echo "value=${baseline#openclaw@}" >> "$GITHUB_OUTPUT"
+          versions_json="${RUNNER_TEMP}/openclaw-published-versions.json"
+          npm view openclaw versions --json --silent --prefer-online > "$versions_json"
+
+          target_baseline_required=false
+          if [[ "$INSTALL_SMOKE_SCHEDULED" == "true" ||
+                "$DOCKER_REQUIRED" == "true" ||
+                ( "$CROSS_OS_SCHEDULED" == "true" && "$RELEASE_MODE" != "fresh" ) ||
+                ( "$PACKAGE_ACCEPTANCE_SCHEDULED" == "true" &&
+                  -z "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" ) ]]; then
+            target_baseline_required=true
+          fi
+          if [[ "$target_baseline_required" == "true" ]]; then
+            candidate_version="$(
+              gh api "repos/${GITHUB_REPOSITORY}/contents/package.json?ref=${TARGET_SHA}" --jq .content |
+                base64 --decode |
+                jq -er '.version | select(type == "string" and length > 0)'
+            )"
+            resolver_args=(
+              --candidate-version "$candidate_version"
+              --versions-json "$versions_json"
+            )
+            if [[ -n "$TARGET_CONTEXT_REF" ]]; then
+              resolver_args+=(--target-context-ref "$TARGET_CONTEXT_REF")
+            fi
+            baseline="$(node workflow/scripts/lib/release-upgrade-baseline.mjs "${resolver_args[@]}")"
+            echo "value=${baseline#openclaw@}" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "$PACKAGE_ACCEPTANCE_SCHEDULED" == "true" &&
+                -n "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" ]]; then
+            package_name="$(
+              npm view "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" name --json --silent --prefer-online |
+                jq -er 'if type == "array" then last else . end | select(. == "openclaw")'
+            )"
+            package_version="$(
+              npm view "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" version --json --silent --prefer-online |
+                jq -er 'if type == "array" then last else . end | select(type == "string" and length > 0)'
+            )"
+            jq -e --arg version "$package_version" 'index($version) != null' "$versions_json" >/dev/null
+            resolver_args=(
+              --candidate-version "$package_version"
+              --versions-json "$versions_json"
+            )
+            if [[ -n "$TARGET_CONTEXT_REF" ]]; then
+              resolver_args+=(--target-context-ref "$TARGET_CONTEXT_REF")
+            fi
+            package_baseline="$(
+              node workflow/scripts/lib/release-upgrade-baseline.mjs "${resolver_args[@]}"
+            )"
+            echo "package_acceptance_package_spec=${package_name}@${package_version}" >> "$GITHUB_OUTPUT"
+            echo "package_acceptance_baseline=${package_baseline#openclaw@}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Summarize validated ref
         env:
@@ -1260,7 +1311,7 @@ jobs:
       allow_unreleased_changelog: ${{ needs.resolve_target.outputs.allow_unreleased_changelog == 'true' }}
       ref: ${{ needs.resolve_target.outputs.revision }}
       run_bun_global_install_smoke: true
-      update_baseline_version: ${{ needs.resolve_target.outputs.frozen_upgrade_baseline || 'latest' }}
+      update_baseline_version: ${{ needs.resolve_target.outputs.upgrade_baseline }}
 
   cross_os_release_checks:
     needs: [resolve_target, prepare_release_package]
@@ -1271,6 +1322,7 @@ jobs:
       advisory: ${{ startsWith(github.ref, 'refs/heads/tideclaw/alpha/') }}
       ref: ${{ needs.resolve_target.outputs.revision }}
       target_context_ref: ${{ inputs.target_context_ref }}
+      previous_version: ${{ needs.resolve_target.outputs.upgrade_baseline }}
       provider: ${{ needs.resolve_target.outputs.provider }}
       mode: ${{ needs.resolve_target.outputs.mode }}
       suite_filter: ${{ needs.resolve_target.outputs.cross_os_suite_filter }}
@@ -1409,6 +1461,7 @@ jobs:
       prepublish_plugin_registry_artifact_run_attempt: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
       prepublish_plugin_registry_manifest_sha256: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
       codex_plugin_spec: ${{ needs.resolve_target.outputs.codex_plugin_spec }}
+      published_upgrade_survivor_baseline: ${{ format('openclaw@{0}', needs.resolve_target.outputs.upgrade_baseline) }}
       shared_image_artifact_namespace: release-docker
       shared_image_artifact_name: ${{ fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').imageArtifactName || '' }}
       shared_image_artifact_id: ${{ fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').imageArtifactId || '' }}
@@ -1434,7 +1487,7 @@ jobs:
       allow_frozen_target_scenario_omissions: ${{ inputs.allow_frozen_target_scenario_omissions }}
       workflow_ref: ${{ github.sha }}
       source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.package_mode == 'published') && 'npm' || 'artifact' }}
-      package_spec: ${{ needs.resolve_target.outputs.package_acceptance_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}
+      package_spec: ${{ needs.resolve_target.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}
       artifact_digest: ${{ needs.prepare_release_package.outputs.artifact_digest }}
       artifact_id: ${{ needs.prepare_release_package.outputs.artifact_id }}
       artifact_name: ${{ needs.prepare_release_package.outputs.artifact_name }}
@@ -1447,7 +1500,7 @@ jobs:
       prepublish_plugin_registry_json: ${{ needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '' }}
       suite_profile: custom
       docker_lanes: release-typed-onboarding doctor-switch update-channel-switch skill-install update-corrupt-plugin upgrade-survivor update-first-hop-compat published-upgrade-survivor root-managed-vps-upgrade update-restart-auth plugins-offline plugin-update plugin-binding-command-escape
-      published_upgrade_survivor_baseline: ${{ needs.resolve_target.outputs.frozen_upgrade_baseline && format('openclaw@{0}', needs.resolve_target.outputs.frozen_upgrade_baseline) || 'openclaw@latest' }}
+      published_upgrade_survivor_baseline: ${{ format('openclaw@{0}', needs.resolve_target.outputs.package_acceptance_upgrade_baseline || needs.resolve_target.outputs.upgrade_baseline) }}
       published_upgrade_survivor_scenarios: ${{ needs.resolve_target.outputs.run_release_soak == 'true' && 'reported-issues' || '' }}
       telegram_mode: ${{ (needs.resolve_target.outputs.telegram_waiver != '' || needs.resolve_target.outputs.skip_package_telegram_e2e == 'true') && 'none' || 'mock-openai' }}
       telegram_advisory: true

--- a/scripts/lib/release-upgrade-baseline.mjs
+++ b/scripts/lib/release-upgrade-baseline.mjs
@@ -47,20 +47,28 @@ function isEarlierFinalSameExtendedStableLine(params) {
   );
 }
 
-/**
- * Frozen extended-stable validation must upgrade from an earlier release in
- * the same line. A current latest install can have a newer SQLite schema.
- */
-export function resolveFrozenExtendedStableUpgradeBaseline(
-  candidateVersion,
-  publishedVersions,
-  context,
-) {
+export function resolveReleaseUpgradeBaseline(candidateVersion, publishedVersions, context = {}) {
   const targetContextRef = normalizeTargetContextRef(context.targetContextRef);
   if (!targetContextRef.startsWith("extended-stable/")) {
-    return undefined;
+    const candidate = parseVersion(candidateVersion);
+    if (!candidate) {
+      const candidateText = typeof candidateVersion === "string" ? candidateVersion.trim() : "";
+      throw new Error(`invalid candidate OpenClaw version: ${candidateText}`);
+    }
+
+    const baseline = normalizePublishedVersions(publishedVersions).find(
+      (version) => compareOpenClawVersions(version, candidate.version) < 0,
+    );
+    if (!baseline) {
+      throw new Error(
+        `no published stable OpenClaw baseline predates candidate ${candidate.version}`,
+      );
+    }
+    return `openclaw@${baseline}`;
   }
 
+  // Extended-stable upgrades stay within their frozen line because a newer
+  // release can carry an incompatible SQLite schema.
   const line = /^extended-stable\/(?<year>\d{4})\.(?<month>[1-9]\d?)\.33$/u.exec(
     targetContextRef,
   )?.groups;
@@ -108,29 +116,6 @@ export function resolveFrozenExtendedStableUpgradeBaseline(
     );
   }
   return `openclaw@${baseline}`;
-}
-
-export function resolveDefaultReleaseUpgradeBaseline(candidateVersion, publishedVersions) {
-  const candidate = parseVersion(candidateVersion);
-  if (!candidate) {
-    const candidateText = typeof candidateVersion === "string" ? candidateVersion.trim() : "";
-    throw new Error(`invalid candidate OpenClaw version: ${candidateText}`);
-  }
-
-  const versions = normalizePublishedVersions(publishedVersions);
-  const older = versions.find((version) => compareOpenClawVersions(version, candidate.version) < 0);
-  if (older) {
-    return `openclaw@${older}`;
-  }
-
-  const same = versions.find(
-    (version) => compareOpenClawVersions(version, candidate.version) === 0,
-  );
-  if (same) {
-    return `openclaw@${same}`;
-  }
-
-  throw new Error(`no published stable OpenClaw baseline is <= candidate ${candidate.version}`);
 }
 
 export function parseArgs(argv) {
@@ -189,14 +174,9 @@ if (isMain) {
   const publishedVersions = readPublishedVersions(args);
   const targetContextRef = args.get("target-context-ref");
   const previousVersion = args.get("previous-version");
-  const baseline = targetContextRef
-    ? resolveFrozenExtendedStableUpgradeBaseline(candidateVersion, publishedVersions, {
-        ...(previousVersion ? { previousVersion } : {}),
-        targetContextRef,
-      })
-    : resolveDefaultReleaseUpgradeBaseline(candidateVersion, publishedVersions);
-  if (!baseline) {
-    throw new Error("target-context-ref does not identify a frozen extended-stable release");
-  }
+  const baseline = resolveReleaseUpgradeBaseline(candidateVersion, publishedVersions, {
+    ...(previousVersion ? { previousVersion } : {}),
+    ...(targetContextRef ? { targetContextRef } : {}),
+  });
   process.stdout.write(`${baseline}\n`);
 }

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -179,31 +179,59 @@ describe("cross-OS release checks workflow", () => {
     expect(baselineMetadata.run).toContain("const entry = resolveNpmJsonEntries(payload).at(-1);");
   });
 
-  it("passes a frozen-line predecessor to every upgrade-validation caller", () => {
+  it("passes one exact predecessor to every scheduled upgrade-validation caller", () => {
     const release = readWorkflow(RELEASE_CHECKS_PATH);
     const target = job(release, "resolve_target");
-    const baseline = step(target, "Resolve frozen upgrade baseline");
+    const baseline = step(target, "Resolve upgrade baseline");
     const installSmoke = job(release, "install_smoke_release_checks");
+    const crossOs = job(release, "cross_os_release_checks");
+    const docker = job(release, "docker_e2e_release_checks");
     const packageAcceptance = job(release, "package_acceptance_release_checks");
 
-    expect(target.outputs?.frozen_upgrade_baseline).toBe(
-      "${{ steps.frozen_upgrade_baseline.outputs.value }}",
+    expect(target.outputs?.upgrade_baseline).toBe("${{ steps.upgrade_baseline.outputs.value }}");
+    expect(target.outputs?.package_acceptance_exact_package_spec).toBe(
+      "${{ steps.upgrade_baseline.outputs.package_acceptance_package_spec }}",
+    );
+    expect(target.outputs?.package_acceptance_upgrade_baseline).toBe(
+      "${{ steps.upgrade_baseline.outputs.package_acceptance_baseline }}",
     );
     expect(baseline.if).toContain("steps.inputs.outputs.install_smoke_scheduled == 'true'");
     expect(baseline.if).toContain("steps.inputs.outputs.package_acceptance_scheduled == 'true'");
-    expect(baseline.if).toContain("startsWith(inputs.target_context_ref, 'extended-stable/')");
+    expect(baseline.if).toContain("steps.inputs.outputs.docker_required == 'true'");
+    expect(baseline.if).toContain("steps.inputs.outputs.cross_os_scheduled == 'true'");
+    expect(baseline.if).toContain("steps.inputs.outputs.mode != 'fresh'");
     expect(baseline.env).toMatchObject({
+      DOCKER_REQUIRED: "${{ steps.inputs.outputs.docker_required }}",
       GH_TOKEN: "${{ github.token }}",
+      PACKAGE_ACCEPTANCE_PACKAGE_SPEC:
+        "${{ steps.inputs.outputs.package_acceptance_package_spec }}",
       TARGET_CONTEXT_REF: "${{ inputs.target_context_ref }}",
       TARGET_SHA: "${{ steps.ref.outputs.sha }}",
     });
+    expect(baseline.run).toContain("npm view openclaw versions --json");
+    expect(baseline.run).toContain('--versions-json "$versions_json"');
     expect(baseline.run).toContain("node workflow/scripts/lib/release-upgrade-baseline.mjs");
     expect(baseline.run).toContain('echo "value=${baseline#openclaw@}"');
+    expect(baseline.run).toContain(
+      'echo "package_acceptance_package_spec=${package_name}@${package_version}"',
+    );
+    expect(baseline.run).toContain(
+      'echo "package_acceptance_baseline=${package_baseline#openclaw@}"',
+    );
     expect(installSmoke.with?.update_baseline_version).toBe(
-      "${{ needs.resolve_target.outputs.frozen_upgrade_baseline || 'latest' }}",
+      "${{ needs.resolve_target.outputs.upgrade_baseline }}",
+    );
+    expect(crossOs.with?.previous_version).toBe(
+      "${{ needs.resolve_target.outputs.upgrade_baseline }}",
+    );
+    expect(docker.with?.published_upgrade_survivor_baseline).toBe(
+      "${{ format('openclaw@{0}', needs.resolve_target.outputs.upgrade_baseline) }}",
+    );
+    expect(packageAcceptance.with?.package_spec).toBe(
+      "${{ needs.resolve_target.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
     );
     expect(packageAcceptance.with?.published_upgrade_survivor_baseline).toBe(
-      "${{ needs.resolve_target.outputs.frozen_upgrade_baseline && format('openclaw@{0}', needs.resolve_target.outputs.frozen_upgrade_baseline) || 'openclaw@latest' }}",
+      "${{ format('openclaw@{0}', needs.resolve_target.outputs.package_acceptance_upgrade_baseline || needs.resolve_target.outputs.upgrade_baseline) }}",
     );
   });
 

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -210,7 +210,8 @@ describe("cross-OS release checks workflow", () => {
     });
     expect(baseline.run).toContain("npm view openclaw versions --json");
     expect(baseline.run).toContain('--versions-json "$versions_json"');
-    expect(baseline.run).toContain("node workflow/scripts/lib/release-upgrade-baseline.mjs");
+    expect(baseline["working-directory"]).toBe("workflow");
+    expect(baseline.run).toContain("node scripts/lib/release-upgrade-baseline.mjs");
     expect(baseline.run).toContain('echo "value=${baseline#openclaw@}"');
     expect(baseline.run).toContain(
       'echo "package_acceptance_package_spec=${package_name}@${package_version}"',

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -179,69 +179,83 @@ describe("cross-OS release checks workflow", () => {
     expect(baselineMetadata.run).toContain("const entry = resolveNpmJsonEntries(payload).at(-1);");
   });
 
-  it("passes one exact predecessor to every scheduled upgrade-validation caller", () => {
+  it("resolves each upgrade predecessor from its acquired package candidate", () => {
     const release = readWorkflow(RELEASE_CHECKS_PATH);
     const target = job(release, "resolve_target");
-    const baseline = step(target, "Resolve upgrade baseline");
+    const sourceBaseline = step(target, "Resolve source checkout upgrade baseline");
+    const preparedPackage = job(release, "prepare_release_package");
+    const packageBaseline = step(preparedPackage, "Resolve package upgrade baseline");
     const installSmoke = job(release, "install_smoke_release_checks");
     const crossOs = job(release, "cross_os_release_checks");
     const docker = job(release, "docker_e2e_release_checks");
     const packageAcceptance = job(release, "package_acceptance_release_checks");
 
-    expect(target.outputs?.upgrade_baseline).toBe("${{ steps.upgrade_baseline.outputs.value }}");
-    expect(target.outputs?.package_acceptance_exact_package_spec).toBe(
-      "${{ steps.upgrade_baseline.outputs.package_acceptance_package_spec }}",
+    expect(target.outputs?.source_upgrade_baseline).toBe(
+      "${{ steps.source_upgrade_baseline.outputs.value }}",
     );
-    expect(target.outputs?.package_acceptance_upgrade_baseline).toBe(
-      "${{ steps.upgrade_baseline.outputs.package_acceptance_baseline }}",
-    );
-    expect(baseline.if).toContain("steps.inputs.outputs.install_smoke_scheduled == 'true'");
-    expect(baseline.if).toContain("steps.inputs.outputs.package_acceptance_scheduled == 'true'");
-    expect(baseline.if).toContain("steps.inputs.outputs.docker_required == 'true'");
-    expect(baseline.if).toContain("steps.inputs.outputs.cross_os_scheduled == 'true'");
-    expect(baseline.if).toContain("steps.inputs.outputs.mode != 'fresh'");
-    expect(baseline.env).toMatchObject({
-      DOCKER_REQUIRED: "${{ steps.inputs.outputs.docker_required }}",
+    expect(sourceBaseline.if).toBe("steps.inputs.outputs.install_smoke_scheduled == 'true'");
+    expect(sourceBaseline.env).toMatchObject({
       GH_TOKEN: "${{ github.token }}",
-      PACKAGE_ACCEPTANCE_PACKAGE_SPEC:
-        "${{ steps.inputs.outputs.package_acceptance_package_spec }}",
       TARGET_CONTEXT_REF: "${{ inputs.target_context_ref }}",
       TARGET_SHA: "${{ steps.ref.outputs.sha }}",
     });
-    expect(baseline.run).toContain("npm view openclaw versions --json");
-    expect(baseline.run).toContain('--versions-json "$versions_json"');
-    expect(baseline["working-directory"]).toBe("workflow");
-    expect(baseline.run).toContain("node scripts/lib/release-upgrade-baseline.mjs");
-    expect(baseline.run).toContain('echo "value=${baseline#openclaw@}"');
-    expect(baseline.run).toContain(
+    expect(sourceBaseline.run).toContain("npm view openclaw versions --json");
+    expect(sourceBaseline.run).toContain("node scripts/lib/release-upgrade-baseline.mjs");
+
+    expect(preparedPackage.outputs).toMatchObject({
+      upgrade_baseline: "${{ steps.upgrade_baseline.outputs.value }}",
+      package_acceptance_exact_package_spec:
+        "${{ steps.upgrade_baseline.outputs.package_acceptance_package_spec }}",
+      package_acceptance_upgrade_baseline:
+        "${{ steps.upgrade_baseline.outputs.package_acceptance_baseline }}",
+    });
+    expect(packageBaseline.if).toContain("package_acceptance_scheduled == 'true'");
+    expect(packageBaseline.if).toContain("docker_required == 'true'");
+    expect(packageBaseline.if).toContain("cross_os_scheduled == 'true'");
+    expect(packageBaseline.if).toContain("mode != 'fresh'");
+    expect(packageBaseline.env).toMatchObject({
+      CANDIDATE_VERSION:
+        "${{ steps.package.outputs.package_version || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageVersion }}",
+      TARGET_CONTEXT_REF: "${{ inputs.target_context_ref }}",
+    });
+    expect(packageBaseline.run).toContain("npm view openclaw versions --json");
+    expect(packageBaseline.run).toContain('--candidate-version "$CANDIDATE_VERSION"');
+    expect(packageBaseline.run).toContain('--target-context-ref "$TARGET_CONTEXT_REF"');
+    expect(packageBaseline.run).toContain('echo "value=${baseline#openclaw@}"');
+    expect(packageBaseline.run).toContain(
       'echo "package_acceptance_package_spec=${package_name}@${package_version}"',
     );
-    expect(baseline.run).toContain(
+    expect(packageBaseline.run).toContain(
       'echo "package_acceptance_baseline=${package_baseline#openclaw@}"',
     );
-    const baselineRun = baseline.run;
-    if (!baselineRun) {
-      throw new Error("Resolve upgrade baseline step must have a shell body");
+    const packageBaselineRun = packageBaseline.run;
+    if (!packageBaselineRun) {
+      throw new Error("Resolve package upgrade baseline step must have a shell body");
     }
-    const packageOverrideResolver = baselineRun.match(
+    const packageOverrideResolver = packageBaselineRun.match(
       /if \[\[ "\$PACKAGE_ACCEPTANCE_SCHEDULED" == "true" &&\s+-n "\$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" \]\]; then(?<body>[\s\S]*?)\n\s*fi/,
     )?.groups?.body;
     expect(packageOverrideResolver).toBeDefined();
     expect(packageOverrideResolver).not.toContain('--target-context-ref "$TARGET_CONTEXT_REF"');
+
+    const validatedCandidate = step(preparedPackage, "Validate shared release candidate identity");
+    const steps = preparedPackage.steps!;
+    expect(steps.indexOf(packageBaseline)).toBeGreaterThan(steps.indexOf(validatedCandidate));
+
     expect(installSmoke.with?.update_baseline_version).toBe(
-      "${{ needs.resolve_target.outputs.upgrade_baseline }}",
+      "${{ needs.resolve_target.outputs.source_upgrade_baseline }}",
     );
     expect(crossOs.with?.previous_version).toBe(
-      "${{ needs.resolve_target.outputs.upgrade_baseline }}",
+      "${{ needs.prepare_release_package.outputs.upgrade_baseline }}",
     );
     expect(docker.with?.published_upgrade_survivor_baseline).toBe(
-      "${{ format('openclaw@{0}', needs.resolve_target.outputs.upgrade_baseline) }}",
+      "${{ format('openclaw@{0}', needs.prepare_release_package.outputs.upgrade_baseline) }}",
     );
     expect(packageAcceptance.with?.package_spec).toBe(
-      "${{ needs.resolve_target.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
+      "${{ needs.prepare_release_package.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
     );
     expect(packageAcceptance.with?.published_upgrade_survivor_baseline).toBe(
-      "${{ format('openclaw@{0}', needs.resolve_target.outputs.package_acceptance_upgrade_baseline || needs.resolve_target.outputs.upgrade_baseline) }}",
+      "${{ format('openclaw@{0}', needs.prepare_release_package.outputs.package_acceptance_upgrade_baseline || needs.prepare_release_package.outputs.upgrade_baseline) }}",
     );
   });
 

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -219,7 +219,7 @@ describe("cross-OS release checks workflow", () => {
       'echo "package_acceptance_baseline=${package_baseline#openclaw@}"',
     );
     const packageOverrideResolver = baseline.run.match(
-      /if \[\[ "\$PACKAGE_ACCEPTANCE_SCHEDULED" == "true" &&\s+-n "\$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" \]\]; then(?<body>[\s\S]*?)\n {10}fi/,
+      /if \[\[ "\$PACKAGE_ACCEPTANCE_SCHEDULED" == "true" &&\s+-n "\$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" \]\]; then(?<body>[\s\S]*?)\n\s*fi/,
     )?.groups?.body;
     expect(packageOverrideResolver).toBeDefined();
     expect(packageOverrideResolver).not.toContain('--target-context-ref "$TARGET_CONTEXT_REF"');

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -218,7 +218,11 @@ describe("cross-OS release checks workflow", () => {
     expect(baseline.run).toContain(
       'echo "package_acceptance_baseline=${package_baseline#openclaw@}"',
     );
-    const packageOverrideResolver = baseline.run.match(
+    const baselineRun = baseline.run;
+    if (!baselineRun) {
+      throw new Error("Resolve upgrade baseline step must have a shell body");
+    }
+    const packageOverrideResolver = baselineRun.match(
       /if \[\[ "\$PACKAGE_ACCEPTANCE_SCHEDULED" == "true" &&\s+-n "\$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" \]\]; then(?<body>[\s\S]*?)\n\s*fi/,
     )?.groups?.body;
     expect(packageOverrideResolver).toBeDefined();

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -218,6 +218,11 @@ describe("cross-OS release checks workflow", () => {
     expect(baseline.run).toContain(
       'echo "package_acceptance_baseline=${package_baseline#openclaw@}"',
     );
+    const packageOverrideResolver = baseline.run.match(
+      /if \[\[ "\$PACKAGE_ACCEPTANCE_SCHEDULED" == "true" &&\s+-n "\$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" \]\]; then(?<body>[\s\S]*?)\n {10}fi/,
+    )?.groups?.body;
+    expect(packageOverrideResolver).toBeDefined();
+    expect(packageOverrideResolver).not.toContain('--target-context-ref "$TARGET_CONTEXT_REF"');
     expect(installSmoke.with?.update_baseline_version).toBe(
       "${{ needs.resolve_target.outputs.upgrade_baseline }}",
     );

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -245,6 +245,26 @@ describe("cross-OS release checks workflow", () => {
     );
   });
 
+  it("validates fallback release SHA reachability without checking out target code", () => {
+    const target = job(readWorkflow(RELEASE_CHECKS_PATH), "resolve_target");
+    const fallback = step(target, "Validate fallback ref belongs to this repository");
+
+    expect(
+      target.steps?.some(
+        (candidate) => candidate.name === "Checkout selected ref for reachability fallback",
+      ),
+    ).toBe(false);
+    expect(fallback.env).toMatchObject({
+      FALLBACK_SHA: "${{ steps.fast_ref.outputs.sha }}",
+      TRUSTED_REPOSITORY_URL: "https://github.com/${{ github.repository }}.git",
+    });
+    expect(fallback.run).toContain('git init --bare --quiet "$target_repo"');
+    expect(fallback.run).toContain('git -C "$target_repo" cat-file -e "${SELECTED_SHA}^{commit}"');
+    expect(fallback.run).toContain(
+      'git -C "$target_repo" for-each-ref --format=\'%(refname:short)\' --contains "${SELECTED_SHA}" refs/remotes/origin refs/tags',
+    );
+  });
+
   it("installs trusted workflow dependencies for artifact resolution and upgrade metadata", () => {
     const prepare = job(readWorkflow(WORKFLOW_PATH), "prepare");
     const install = step(prepare, "Install workflow validation dependencies");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -11313,11 +11313,6 @@ esac
   it("keeps release history checks blobless", () => {
     const fullHistoryCheckouts: Array<[string, string, string]> = [
       [LIVE_E2E_WORKFLOW, "validate_selected_ref", "Checkout workflow repository"],
-      [
-        RELEASE_CHECKS_WORKFLOW,
-        "resolve_target",
-        "Checkout selected ref for reachability fallback",
-      ],
       [PACKAGE_ACCEPTANCE_WORKFLOW, "resolve_package", "Checkout package workflow ref"],
       [PLUGIN_NPM_RELEASE_WORKFLOW, "preview_plugins_npm", "Checkout"],
       [PLUGIN_CLAWHUB_RELEASE_WORKFLOW, "preview_plugins_clawhub", "Checkout"],
@@ -11359,11 +11354,6 @@ esac
     const metadataOnlyCheckouts: Array<[string, string, string]> = [
       [LIVE_E2E_WORKFLOW, "validate_selected_ref", "Checkout workflow repository"],
       [RELEASE_PUBLISH_WORKFLOW, "resolve_release_target", "Checkout release tag"],
-      [
-        RELEASE_CHECKS_WORKFLOW,
-        "resolve_target",
-        "Checkout selected ref for reachability fallback",
-      ],
     ];
     for (const [workflowPath, jobName, stepName] of metadataOnlyCheckouts) {
       expect(workflowStep(workflowJob(workflowPath, jobName), stepName).with).toMatchObject({

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4783,7 +4783,7 @@ test "$package_manager" = "pnpm@12.1.0"
       "source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.package_mode == 'published') && 'npm' || 'artifact' }}",
     );
     expect(releaseChecksWorkflow).toContain(
-      "package_spec: ${{ needs.resolve_target.outputs.package_acceptance_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
+      "package_spec: ${{ needs.resolve_target.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
     );
   });
 
@@ -7529,7 +7529,7 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
         "${{ needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '' }}",
       suite_profile: "custom",
       published_upgrade_survivor_baseline:
-        "${{ needs.resolve_target.outputs.frozen_upgrade_baseline && format('openclaw@{0}', needs.resolve_target.outputs.frozen_upgrade_baseline) || 'openclaw@latest' }}",
+        "${{ format('openclaw@{0}', needs.resolve_target.outputs.package_acceptance_upgrade_baseline || needs.resolve_target.outputs.upgrade_baseline) }}",
     });
     expect(packageAcceptanceJob.with?.candidate_artifact_json).toBe(
       "${{ needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.resolve_target.outputs.candidate_artifact_json || '' }}",
@@ -7565,7 +7565,7 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       "source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.package_mode == 'published') && 'npm' || 'artifact' }}",
     );
     expect(workflow).toContain(
-      "package_spec: ${{ needs.resolve_target.outputs.package_acceptance_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
+      "package_spec: ${{ needs.resolve_target.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
     );
     expect(workflow).toContain(".artifacts/docker-e2e-package/package-candidate.json");
     expect(workflow).toContain(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4783,7 +4783,7 @@ test "$package_manager" = "pnpm@12.1.0"
       "source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.package_mode == 'published') && 'npm' || 'artifact' }}",
     );
     expect(releaseChecksWorkflow).toContain(
-      "package_spec: ${{ needs.resolve_target.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
+      "package_spec: ${{ needs.prepare_release_package.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
     );
   });
 
@@ -7529,7 +7529,7 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
         "${{ needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '' }}",
       suite_profile: "custom",
       published_upgrade_survivor_baseline:
-        "${{ format('openclaw@{0}', needs.resolve_target.outputs.package_acceptance_upgrade_baseline || needs.resolve_target.outputs.upgrade_baseline) }}",
+        "${{ format('openclaw@{0}', needs.prepare_release_package.outputs.package_acceptance_upgrade_baseline || needs.prepare_release_package.outputs.upgrade_baseline) }}",
     });
     expect(packageAcceptanceJob.with?.candidate_artifact_json).toBe(
       "${{ needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.resolve_target.outputs.candidate_artifact_json || '' }}",
@@ -7565,7 +7565,7 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       "source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.package_mode == 'published') && 'npm' || 'artifact' }}",
     );
     expect(workflow).toContain(
-      "package_spec: ${{ needs.resolve_target.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
+      "package_spec: ${{ needs.prepare_release_package.outputs.package_acceptance_exact_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
     );
     expect(workflow).toContain(".artifacts/docker-e2e-package/package-candidate.json");
     expect(workflow).toContain(

--- a/test/scripts/release-upgrade-baseline.test.ts
+++ b/test/scripts/release-upgrade-baseline.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   parseArgs,
-  resolveDefaultReleaseUpgradeBaseline,
-  resolveFrozenExtendedStableUpgradeBaseline,
+  resolveReleaseUpgradeBaseline,
 } from "../../scripts/lib/release-upgrade-baseline.mjs";
 
 describe("release upgrade baseline resolver", () => {
@@ -14,48 +13,81 @@ describe("release upgrade baseline resolver", () => {
   });
 
   it.each([
-    { candidate: "2026.8.1", expected: "2026.7.1-2" },
-    { candidate: "2026.8.1-beta.2", expected: "2026.7.1-2" },
-    { candidate: "2026.8.1-alpha.2", expected: "2026.7.1-2" },
-    { candidate: "2026.7.1-2", expected: "2026.7.1-1" },
-    { candidate: "2026.7.1-1", expected: "2026.7.1" },
-    { candidate: "2026.7.1", expected: "2026.6.34" },
-  ])("selects the stable predecessor of $candidate", ({ candidate, expected }) => {
-    expect(
-      resolveDefaultReleaseUpgradeBaseline(candidate, [
-        "2026.8.1-beta.1",
-        "2026.7.1-1",
-        "2026.9.1",
-        "2026.8.1-alpha.1",
-        "2026.7.1-2",
-        "2026.6.34",
-        "2026.7.1",
-        "2026.8.1",
-        "2026.7.1-beta.2",
-        "2026.7.1-2",
-      ]),
-    ).toBe(`openclaw@${expected}`);
-  });
-
-  it("uses the same stable version only when no older stable exists", () => {
-    expect(
-      resolveDefaultReleaseUpgradeBaseline("2026.7.1", ["2026.7.1-beta.2", "2026.7.1", "2026.8.1"]),
-    ).toBe("openclaw@2026.7.1");
-  });
+    { context: "main", candidate: "2026.8.1", targetContextRef: "", expected: "2026.7.1-2" },
+    {
+      context: "release branch",
+      candidate: "2026.8.1",
+      targetContextRef: "release/2026.8.1",
+      expected: "2026.7.1-2",
+    },
+    {
+      context: "release tag",
+      candidate: "2026.8.1",
+      targetContextRef: "v2026.8.1",
+      expected: "2026.7.1-2",
+    },
+    {
+      context: "prerelease",
+      candidate: "2026.8.1-beta.2",
+      targetContextRef: "release/2026.8.1",
+      expected: "2026.7.1-2",
+    },
+    {
+      context: "alpha",
+      candidate: "2026.8.1-alpha.2",
+      targetContextRef: "tideclaw/alpha/2026-09-03-0000Z",
+      expected: "2026.7.1-2",
+    },
+    {
+      context: "correction",
+      candidate: "2026.7.1-2",
+      targetContextRef: "release/2026.7.1",
+      expected: "2026.7.1-1",
+    },
+    {
+      context: "first correction",
+      candidate: "2026.7.1-1",
+      targetContextRef: "release/2026.7.1",
+      expected: "2026.7.1",
+    },
+  ])(
+    "selects the newest older stable release for $context",
+    ({ candidate, targetContextRef, expected }) => {
+      expect(
+        resolveReleaseUpgradeBaseline(
+          candidate,
+          [
+            "2026.8.1-beta.1",
+            "2026.7.1-1",
+            "2026.9.1",
+            "2026.8.1-alpha.1",
+            "2026.7.1-2",
+            "2026.6.34",
+            "2026.7.1",
+            "2026.8.1",
+            "2026.7.1-beta.2",
+            "2026.7.1-2",
+          ],
+          { targetContextRef },
+        ),
+      ).toBe(`openclaw@${expected}`);
+    },
+  );
 
   it.each([
     ["2026.8.1-beta.2", ["2026.8.1-beta.1", "2026.8.1"]],
+    ["2026.7.1", ["2026.7.1", "2026.8.1"]],
     ["2026.7.1", ["2026.8.1", "invalid"]],
     ["2026.7.1", []],
   ])("rejects missing stable baselines for %s", (candidate, versions) => {
-    expect(() => resolveDefaultReleaseUpgradeBaseline(candidate, versions)).toThrow(
+    expect(() => resolveReleaseUpgradeBaseline(candidate, versions)).toThrow(
       "no published stable OpenClaw baseline",
     );
   });
 
   it("selects an older final release from the frozen extended-stable line", () => {
     expect(
-      resolveFrozenExtendedStableUpgradeBaseline(
+      resolveReleaseUpgradeBaseline(
         "2026.6.35",
         ["2026.6.34", "2026.6.33", "2026.6.35", "2026.7.1", "2026.6.34-1"],
         {
@@ -67,14 +99,10 @@ describe("release upgrade baseline resolver", () => {
 
   it("honors an explicit published predecessor from the frozen extended-stable line", () => {
     expect(
-      resolveFrozenExtendedStableUpgradeBaseline(
-        "2026.6.35",
-        ["2026.6.33", "2026.6.34", "2026.6.35"],
-        {
-          previousVersion: "2026.6.33",
-          targetContextRef: "extended-stable/2026.6.33",
-        },
-      ),
+      resolveReleaseUpgradeBaseline("2026.6.35", ["2026.6.33", "2026.6.34", "2026.6.35"], {
+        previousVersion: "2026.6.33",
+        targetContextRef: "extended-stable/2026.6.33",
+      }),
     ).toBe("openclaw@2026.6.33");
   });
 
@@ -82,14 +110,10 @@ describe("release upgrade baseline resolver", () => {
     "rejects an incompatible explicit frozen baseline %s",
     (previousVersion) => {
       expect(() =>
-        resolveFrozenExtendedStableUpgradeBaseline(
-          "2026.6.35",
-          ["2026.6.33", "2026.6.34", "2026.6.35"],
-          {
-            previousVersion,
-            targetContextRef: "extended-stable/2026.6.33",
-          },
-        ),
+        resolveReleaseUpgradeBaseline("2026.6.35", ["2026.6.33", "2026.6.34", "2026.6.35"], {
+          previousVersion,
+          targetContextRef: "extended-stable/2026.6.33",
+        }),
       ).toThrow("previous_version");
     },
   );
@@ -103,18 +127,10 @@ describe("release upgrade baseline resolver", () => {
     "rejects incompatible frozen extended-stable targets",
     (candidateVersion, targetContextRef) => {
       expect(() =>
-        resolveFrozenExtendedStableUpgradeBaseline(candidateVersion, ["2026.6.34", "2026.6.33"], {
+        resolveReleaseUpgradeBaseline(candidateVersion, ["2026.6.34", "2026.6.33"], {
           targetContextRef,
         }),
       ).toThrow();
     },
   );
-
-  it("leaves non-extended-stable contexts on their latest baseline policy", () => {
-    expect(
-      resolveFrozenExtendedStableUpgradeBaseline("2026.6.35", ["2026.6.34"], {
-        targetContextRef: "release/2026.6.35",
-      }),
-    ).toBeUndefined();
-  });
 });


### PR DESCRIPTION
Related: #136800

## What Problem This Solves

Fixes two release-workflow defects: an older candidate could select npm `latest` as its update baseline, and package-consuming lanes could select a predecessor from the selected target manifest before acquiring a different published or reused candidate.

## Why This Change Was Made

Installer smoke resolves its predecessor from the source candidate it packages. Docker, cross-OS, and default Package Acceptance resolve theirs in `prepare_release_package`, after the exact source artifact has been bound or a reused artifact has been verified. An explicit Package Acceptance override is resolved to its exact published version there and deliberately does not inherit a frozen target-line rule. Extended-stable candidates retain the same-line final-release policy.

The dispatch fallback validates an arbitrary ref in a bare repository, without an `actions/checkout` of target code, so it retains reachability proof without exposing trusted later steps to an untrusted checkout.

## User Impact

Release validation now exercises an actual forward predecessor for the precise candidate each package lane consumes. Existing updater and restart safety behavior remains unchanged.

## Evidence

- Prior hosted failure: https://github.com/openclaw/openclaw/actions/runs/33695231815/job/100464611111
- Focused Vitest: `openclaw-cross-os-release-workflow`, `release-upgrade-baseline`, and `package-acceptance-workflow` passed.
- `actionlint`, focused Oxlint, and `git diff --check` passed.
- Final P1 autoreview: no actionable findings.
- Changed-gate discovery passed; its local full gate could not start because this sparse worktree’s pnpm wrapper has a pre-existing shell syntax error before any lane.
- Latest head: `5c6f5a3b82c119d4c365e86a5111ea8ca3ec1703`; ClawSweeper re-review requested.