### PR TITLE
fix: dashboard widgets stop shrinking after opening

### DIFF
--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -69,6 +69,9 @@ never needs the agent.
   medium, large, extra large) from the widget menu. Nobody places pixels —
   not you, not the agent. On narrow boards, widgets stack at full width in
   their saved order; widening the board restores their saved column widths.
+- **Automatic height.** HTML widgets adjust their height to fit their content.
+  Resizing by handle or choosing a size preset fixes the height. Choose
+  **Auto height** from the widget menu to fit the content again.
 - **Tabs.** A board can have several pages — say, an overview tab and a
   focused tab with one big widget. Each tab remembers its own chat-dock
   position.

--- a/ui/src/components/board/board-view-sizing.test.ts
+++ b/ui/src/components/board/board-view-sizing.test.ts
@@ -17,10 +17,10 @@ afterEach(() => {
 describe("board widget sizing", () => {
   it("snaps reported HTML heights to rows with card inset and fixed-mode fallbacks", () => {
     const card = boardWidget({ sizeH: 6 });
-    expect(effectiveBoardWidgetRows(card, 100)).toBe(2);
-    expect(effectiveBoardWidgetRows(card, 101)).toBe(3);
-    expect(effectiveBoardWidgetRows({ ...card, presentation: "full-bleed" }, 124)).toBe(2);
-    expect(effectiveBoardWidgetRows({ ...card, presentation: "frameless" }, 125)).toBe(3);
+    expect(effectiveBoardWidgetRows(card, 98)).toBe(2);
+    expect(effectiveBoardWidgetRows(card, 99)).toBe(3);
+    expect(effectiveBoardWidgetRows({ ...card, presentation: "full-bleed" }, 122)).toBe(2);
+    expect(effectiveBoardWidgetRows({ ...card, presentation: "frameless" }, 123)).toBe(3);
     expect(effectiveBoardWidgetRows(card, 1)).toBe(2);
     expect(effectiveBoardWidgetRows(card, 10_000)).toBe(20);
     expect(effectiveBoardWidgetRows(card, 10_000, 0, 240)).toBeGreaterThan(20);
@@ -36,17 +36,17 @@ describe("board widget sizing", () => {
 
   it("hugs auto cards to their exact content height inside the quantized cell", () => {
     const card = boardWidget({ sizeH: 6 });
-    // Card inset adds 12px per edge; frameless/full-bleed report bare content.
-    expect(exactBoardWidgetHeightPx(card, 300)).toBe(324);
-    expect(exactBoardWidgetHeightPx({ ...card, presentation: "frameless" }, 300)).toBe(300);
+    // Every presentation reserves its border; cards also add 12px per edge.
+    expect(exactBoardWidgetHeightPx(card, 300)).toBe(326);
+    expect(exactBoardWidgetHeightPx({ ...card, presentation: "frameless" }, 300)).toBe(302);
     // Short content hugs below the 2-row cell minimum: the cell keeps its
     // minimum span, only the card shrinks.
-    expect(exactBoardWidgetHeightPx(card, 60)).toBe(84);
+    expect(exactBoardWidgetHeightPx(card, 60)).toBe(86);
     // At the 20-row cap the card fills the cell exactly and the body clips.
     expect(exactBoardWidgetHeightPx(card, 10_000)).toBe(20 * 56 + 19 * 12);
-    expect(exactBoardWidgetHeightPx(card, 10_000, 0, 240)).toBe(10_024);
+    expect(exactBoardWidgetHeightPx(card, 10_000, 0, 240)).toBe(10_026);
     // Coarse-pointer layouts keep the 38px bar in flow, joining the height.
-    expect(exactBoardWidgetHeightPx(card, 300, 38)).toBe(362);
+    expect(exactBoardWidgetHeightPx(card, 300, 38)).toBe(364);
     expect(exactBoardWidgetHeightPx({ ...card, heightMode: "fixed" }, 300)).toBeUndefined();
     expect(exactBoardWidgetHeightPx(card, undefined)).toBeUndefined();
     expect(exactBoardWidgetHeightPx({ ...card, contentKind: "mcp-app" }, 300)).toBeUndefined();
@@ -90,7 +90,7 @@ describe("board widget sizing", () => {
 
     await vi.waitFor(() => {
       const section = cell?.querySelector<HTMLElement>(".board-widget");
-      expect(section?.getAttribute("style")).toContain("height: 10024px");
+      expect(section?.getAttribute("style")).toContain("height: 10026px");
       expect(section?.getAttribute("style")).toContain("span 148");
     });
   });

--- a/ui/src/components/board/board-view.browser.test.ts
+++ b/ui/src/components/board/board-view.browser.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildWidgetDocument } from "../../../../src/canvas/wrap.js";
 import { BOARD_GRID_GAP, BOARD_GRID_ROW_HEIGHT } from "../../lib/board/grid.ts";
 import type { BoardSnapshot } from "../../lib/board/types.ts";
 import "../../styles/base.css";
@@ -405,9 +406,10 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
         data: { type: "openclaw:widget-size", height: 300 },
       }),
     );
-    // The card hugs its exact content height (300px + 2x12px card inset); the
+    // The card hugs its content (300px + 2x12px inset + 2px border); the
     // ceil-to-row slack stays outside the card as grid background.
-    await vi.waitFor(() => expect(Math.round(first.getBoundingClientRect().height)).toBe(324));
+    await vi.waitFor(() => expect(Math.round(frame.getBoundingClientRect().height)).toBe(300));
+    expect(Math.round(first.getBoundingClientRect().height)).toBe(326);
     expect(second.getBoundingClientRect().top).toBeGreaterThan(secondTopBefore);
 
     const cardBody = first.querySelector<HTMLElement>(".board-widget__body");
@@ -421,6 +423,45 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
     finishDocumentAnimations();
     expect(getComputedStyle(second).borderTopColor).not.toBe("rgba(0, 0, 0, 0)");
   });
+
+  it.each(["card", "full-bleed", "frameless"] as const)(
+    "keeps a %s widget stable when its content fills the iframe viewport",
+    async (presentation) => {
+      const view = await mount();
+      view.snapshot = {
+        ...structuredClone(source),
+        widgets: [{ ...source.widgets[0]!, presentation }],
+      };
+      await view.updateComplete;
+      const cell = view.querySelector("openclaw-board-widget-cell")!;
+      await cell.updateComplete;
+      const frame = cell.querySelector("iframe")!;
+      const initialHeight = frame.getBoundingClientRect().height;
+      const reports: number[] = [];
+      const recordSize = (event: MessageEvent) => {
+        if (event.source === frame.contentWindow && event.data?.type === "openclaw:widget-size") {
+          reports.push(event.data.height);
+        }
+      };
+      window.addEventListener("message", recordSize);
+      try {
+        frame.srcdoc = buildWidgetDocument(
+          "Viewport-sized dashboard",
+          "<style>body{min-height:100vh}</style><main>Dashboard content</main>",
+        );
+        await vi.waitFor(() => expect(reports.length).toBeGreaterThan(0));
+        // Each host resize can trigger another content report; allow repeated
+        // layout cycles so a missing border cannot silently shrink the frame.
+        for (let index = 0; index < 12; index += 1) {
+          await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        }
+        expect(frame.getBoundingClientRect().height).toBeCloseTo(initialHeight, 0);
+        expect(reports.every((height) => height === initialHeight)).toBe(true);
+      } finally {
+        window.removeEventListener("message", recordSize);
+      }
+    },
+  );
 
   it("rejects tab drop targets owned by another board", async () => {
     const applyOps = vi.fn(async () => undefined);

--- a/ui/src/components/board/board-view.browser.test.ts
+++ b/ui/src/components/board/board-view.browser.test.ts
@@ -453,7 +453,9 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
         // Each host resize can trigger another content report; allow repeated
         // layout cycles so a missing border cannot silently shrink the frame.
         for (let index = 0; index < 12; index += 1) {
-          await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+          await new Promise<void>((resolve) => {
+            requestAnimationFrame(() => resolve());
+          });
         }
         expect(frame.getBoundingClientRect().height).toBeCloseTo(initialHeight, 0);
         expect(reports.every((height) => height === initialHeight)).toBe(true);

--- a/ui/src/lib/board/grid.ts
+++ b/ui/src/lib/board/grid.ts
@@ -207,6 +207,9 @@ export function toCssPlacement(rect: BoardGridRect): string {
 
 // Keep this numeric inset aligned with the app-level --widget-frame-inset token.
 const BOARD_WIDGET_FRAME_INSET = 12;
+// board.css keeps a 1px border even when frameless. Reserve both edges so
+// viewport-sized content does not lose 2px on every resize report.
+const BOARD_WIDGET_BORDER_PX = 1;
 const BOARD_WIDGET_AUTO_MIN_ROWS = 2;
 const BOARD_WIDGET_AUTO_MAX_ROWS = 20;
 // Mirrors the 38px header grid row in board.css: coarse-pointer layouts keep
@@ -242,6 +245,7 @@ function autoBoardWidgetHeightPx(
   }
   return (
     contentHeightPx +
+    BOARD_WIDGET_BORDER_PX * 2 +
     chromeRowPx +
     ((widget.presentation ?? "card") === "card" ? BOARD_WIDGET_FRAME_INSET * 2 : 0)
   );


### PR DESCRIPTION
Closes #136789

## What Problem This Solves

Fixes an issue where users opening a dashboard would see an auto-height HTML widget continuously shrink when its content fills the iframe viewport. Card, full-bleed, and frameless widgets share the problem.

## Why This Change Was Made

The board converts a content-height report into the card's outer height but omitted its two 1px borders. With border-box sizing, the iframe became 2px shorter; its ResizeObserver then reported that smaller height and repeated the cycle. The shared sizing owner now reserves both borders for exact height and grid-row allocation. This preserves content fitting, existing row caps, manual resizing, and touch chrome without adding a clamp or alternate sizing path.

Production LOC: +4/-0. The added constant, invariant comment, and arithmetic encode the existing CSS border contract in the canonical content-to-card conversion. No configuration, storage, protocol, dependency, or permission changes. The exact-height feedback path dates to #114012; the same missing allowance is present in stable v2026.8.1.

## User Impact

Dashboard widgets retain their content height after opening, including viewport-sized HTML. Users can still pin a height by resizing and restore content fitting with **Auto height**, now explained in the [dashboard docs](https://docs.openclaw.ai/web/dashboards).

## Evidence

- Pre-fix Chromium regression: a 300px report created a 298px iframe; real widget documents shrank 32px over 12 animation frames in all three presentations. The same four regression cases pass after the fix.
- Full Control UI synthetic dashboard: before, 666→0px with 333 resize reports; after, 666→666px with one report over 11 seconds. Touch layout also stayed at 628px with one report, correctly reserving its 38px header. Each run made one `board.get` request and had no browser errors.
- Read-only live Chrome inspection confirmed the deployed card/iframe mismatch. Screenshots below use only synthetic data; the full UI fixture mocks Gateway data and uses the production widget document reporter through a direct sandboxed iframe. The browser tests cover the same owning layout boundary; this is not a backend deployment test.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-browser.config.ts ui/src/components/board/board-view.browser.test.ts` — 22 passed.
- `node scripts/run-vitest.mjs ui/src/components/board/board-view-sizing.test.ts ui/src/components/board/board-widget-frame.test.ts ui/src/lib/board/grid.test.ts` — 36 passed, including row limits, fixed sizing, touch header allowance, frame lifecycle, and scroll handoff.
- `pnpm ui:build` passed. Changed-scope typechecks and guards passed; a test-helper lint error was corrected and the affected lint/browser checks rerun. Independent Codex autoreview found no actionable P0–P2 issues.

### Before

![Synthetic dashboard shrinking after opening](https://github.com/user-attachments/assets/c6144bec-a71e-4b90-a083-2de9200a0ea2)

### After

![Synthetic dashboard retains its full height](https://github.com/user-attachments/assets/68507412-ed85-4a07-b9ac-9e30d7f041fd)
