### PR TITLE
fix(plugins): repair missing payloads and Docker reinstall checks

### DIFF
--- a/scripts/e2e/lib/plugins/assertions.mjs
+++ b/scripts/e2e/lib/plugins/assertions.mjs
@@ -786,6 +786,18 @@ function assertNpmPluginRetained() {
   }
 }
 
+function assertNpmPluginReinstalled() {
+  if (process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS === "1") {
+    return;
+  }
+  assertPluginUninstallConfigState(readOpenClawConfig(), "demo-plugin-npm");
+  const list = readJson(scratchFile("plugins-npm-reinstalled.json"));
+  const plugin = list.plugins?.find((entry) => entry.id === "demo-plugin-npm");
+  if (plugin?.enabled !== false || plugin.status !== "disabled") {
+    throw new Error("reinstalled npm plugin must remain disabled until explicitly enabled");
+  }
+}
+
 function assertInvalidOpenClawExtensionsRejected() {
   const pluginId = "demo-plugin-invalid-metadata";
   for (const expected of ["openclaw.extensions[1]", "non-empty string"]) {
@@ -1061,6 +1073,7 @@ const commands = {
   "plugin-npm": assertNpmPlugin,
   "plugin-npm-update": assertNpmPluginUpdateUnchanged,
   "plugin-npm-retained": assertNpmPluginRetained,
+  "plugin-npm-reinstalled": assertNpmPluginReinstalled,
   "plugin-npm-removed": assertNpmPluginRemoved,
   "invalid-openclaw-extensions": assertInvalidOpenClawExtensionsRejected,
   "bundle-disabled": assertClaudeBundleDisabled,

--- a/scripts/e2e/lib/plugins/sweep.sh
+++ b/scripts/e2e/lib/plugins/sweep.sh
@@ -240,6 +240,10 @@ run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-retained.jso
 node scripts/e2e/lib/plugins/assertions.mjs plugin-npm-retained
 
 run_plugins_fixture_logged reinstall-npm plugins install "npm:@openclaw/demo-plugin-npm@0.0.1" --force
+run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-reinstalled.json" plugins list --json
+node scripts/e2e/lib/plugins/assertions.mjs plugin-npm-reinstalled
+# Reinstall preserves the explicit uninstall marker until the operator enables the plugin.
+run_plugins_fixture_logged enable-reinstalled-npm plugins enable demo-plugin-npm
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-inspect.json" plugins inspect demo-plugin-npm --runtime --json
 run_plugins_shell_logged exec-reinstalled-npm-plugin-cli 'node "$OPENCLAW_ENTRY" demo-npm ping >"$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-cli.txt"'

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -43,6 +43,7 @@ import {
 import { loadInstalledPluginIndex } from "../plugins/installed-plugin-index.js";
 import { resolveInstalledPluginLifecycleOwnership } from "../plugins/installed-plugin-package-ownership.js";
 import { configReferencesNpmInstallPath } from "../plugins/installs.js";
+import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import {
   withPluginLifecycleLease,
   type PluginLifecycleLeaseContext,
@@ -419,7 +420,7 @@ async function runPluginUpdateCommandUnlocked(
     allowPrompt: !params.opts.dryRun,
   });
   const deferredInstallTransactions: PluginInstallTransaction[] = [];
-  let pluginResult;
+  let pluginResult: Awaited<ReturnType<typeof updateNpmInstalledPlugins>>;
   try {
     pluginResult =
       pluginSelection.pluginIds.length > 0
@@ -471,10 +472,13 @@ async function runPluginUpdateCommandUnlocked(
   try {
     if (pluginSelection.pluginIds.length > 0 && pluginResult.changed && !params.opts.dryRun) {
       const nextInstallRecords = pluginResult.config.plugins?.installs ?? {};
-      const afterIndex = loadInstalledPluginIndex({
-        config: pluginResult.config,
-        installRecords: nextInstallRecords,
-      });
+      // The installer may restore or replace bytes at a previously observed path.
+      const afterIndex = withPluginCache(createPluginCache(), () =>
+        loadInstalledPluginIndex({
+          config: pluginResult.config,
+          installRecords: nextInstallRecords,
+        }),
+      );
       const reconciled = reconcilePluginPackageUpdateConfig({
         config: pluginResult.config,
         beforeIndex: installedPluginIndex,

--- a/src/plugins/update-cohort.test.ts
+++ b/src/plugins/update-cohort.test.ts
@@ -1,9 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { attachPluginInstallOwnerMigrations } from "./install-transaction.js";
 import { recordInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
 import type { InstalledPluginIndex, InstalledPluginIndexRecord } from "./installed-plugin-index.js";
+import { createPluginCache, withPluginCache } from "./plugin-cache.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
 const syncPluginsForUpdateChannelMock = vi.fn();
 const updateNpmInstalledPluginsMock = vi.fn();
@@ -76,8 +80,10 @@ function installedIndex(params: {
 }
 
 describe("plugin release cohort package reconciliation", () => {
+  const tempDirs: string[] = [];
+  afterEach(() => cleanupTrackedTempDirs(tempDirs));
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     collectMissingPluginInstallPayloadsMock.mockResolvedValue([]);
     syncPluginsForUpdateChannelMock.mockImplementation(async ({ config }) => ({
       config,
@@ -91,6 +97,87 @@ describe("plugin release cohort package reconciliation", () => {
       },
     }));
   });
+
+  it.each(["missing", "replaced"] as const)(
+    "reconciles %s payloads against the new package metadata",
+    async (state) => {
+      const { loadInstalledPluginIndex } = await vi.importActual<
+        typeof import("./installed-plugin-index.js")
+      >("./installed-plugin-index.js");
+      loadInstalledPluginIndexMock.mockImplementation(loadInstalledPluginIndex);
+      const root = fs.realpathSync(makeTrackedTempDir("openclaw-cohort", tempDirs));
+      const installPath = path.join(root, "package");
+      const env = {
+        ...process.env,
+        HOME: root,
+        OPENCLAW_STATE_DIR: path.join(root, "state"),
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "bundled"),
+      };
+      const writePayload = (pluginId: string) => {
+        fs.mkdirSync(installPath, { recursive: true });
+        fs.writeFileSync(
+          path.join(installPath, "package.json"),
+          JSON.stringify({
+            name: "@example/cohort",
+            version: "1.0.0",
+            openclaw: { extensions: ["./index.js"] },
+          }),
+        );
+        fs.writeFileSync(
+          path.join(installPath, "openclaw.plugin.json"),
+          JSON.stringify({ id: pluginId, configSchema: { type: "object" } }),
+        );
+        fs.writeFileSync(path.join(installPath, "index.js"), "module.exports = {};\n");
+      };
+      if (state === "replaced") {
+        writePayload("retired-child");
+      }
+      const records = {
+        cohort: { source: "npm", spec: "@example/cohort", installPath },
+      } satisfies Record<string, PluginInstallRecord>;
+      const config = {
+        plugins: {
+          installs: records,
+          entries: { "retired-child": { enabled: true }, unrelated: { enabled: false } },
+        },
+      } satisfies OpenClawConfig;
+      if (state === "missing") {
+        collectMissingPluginInstallPayloadsMock.mockResolvedValueOnce([
+          { pluginId: "cohort", installPath, reason: "missing-package-dir" },
+        ]);
+      }
+      updateNpmInstalledPluginsMock.mockImplementation(async ({ config: current }) => {
+        writePayload("current-child");
+        return {
+          config: {
+            ...current,
+            plugins: {
+              ...current.plugins,
+              installs: { cohort: { ...records.cohort, version: "1.0.0" } },
+            },
+          },
+          changed: true,
+          outcomes: [],
+        };
+      });
+
+      const result = await withPluginCache(createPluginCache(), () =>
+        convergePluginReleaseCohort({
+          config,
+          installRecords: records,
+          channel: "stable",
+          timeoutMs: 60_000,
+          env,
+        }),
+      );
+
+      expect(result.config.plugins?.entries?.unrelated).toEqual({ enabled: false });
+      if (state === "replaced") {
+        expect(result.config.plugins?.entries).not.toHaveProperty("retired-child");
+      }
+      expect(result.config.plugins?.installs?.cohort?.version).toBe("1.0.0");
+    },
+  );
 
   it("removes the legacy load path after a successful post-core owner migration", async () => {
     const legacyRoot = "/plugins/qqbot-legacy";

--- a/src/plugins/update-cohort.ts
+++ b/src/plugins/update-cohort.ts
@@ -9,6 +9,7 @@ import {
   collectMissingPluginInstallPayloads,
   type MissingPluginInstallPayload,
 } from "./payload-verification.js";
+import { createPluginCache, withPluginCache } from "./plugin-cache.js";
 import {
   capturePluginPackageUpdateSnapshot,
   reconcilePluginPackageUpdateConfig,
@@ -60,12 +61,14 @@ export async function convergePluginReleaseCohort(params: {
   let config = sync.config;
   let changed = sync.changed;
   let npmChanged = false;
-  const beforeIndex = loadInstalledPluginIndex({
-    config,
-    installRecords: config.plugins?.installs ?? {},
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-  });
+  const beforeIndex = withPluginCache(createPluginCache(), () =>
+    loadInstalledPluginIndex({
+      config,
+      installRecords: config.plugins?.installs ?? {},
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+    }),
+  );
   const packageUpdateSnapshot = capturePluginPackageUpdateSnapshot({
     index: beforeIndex,
     installOwners: Object.keys(config.plugins?.installs ?? {}),
@@ -127,12 +130,16 @@ export async function convergePluginReleaseCohort(params: {
   npmChanged ||= update.changed;
   Object.assign(installOwnerMigrations, resolvePluginInstallOwnerMigrations(update));
 
-  const afterIndex = loadInstalledPluginIndex({
-    config,
-    installRecords: config.plugins?.installs ?? {},
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-  });
+  // Reinstall can restore the same path. Reconciliation needs new filesystem facts,
+  // including formerly missing files, without retiring a retained runtime generation.
+  const afterIndex = withPluginCache(createPluginCache(), () =>
+    loadInstalledPluginIndex({
+      config,
+      installRecords: config.plugins?.installs ?? {},
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+    }),
+  );
   const reconciled = reconcilePluginPackageUpdateConfig({
     config,
     beforeIndex,

--- a/test/scripts/package-compat.test.ts
+++ b/test/scripts/package-compat.test.ts
@@ -11,7 +11,13 @@ const BASH_BIN = process.platform === "win32" ? "bash" : "/bin/bash";
 
 function writeCandidate(
   root: string,
-  options: { commands?: string[]; helpStatus?: number; hang?: boolean; exitCode?: number } = {},
+  options: {
+    commands?: string[];
+    helpStatus?: number;
+    hang?: boolean;
+    exitCode?: number;
+    preserveUninstallIntent?: boolean;
+  } = {},
   name = "candidate.cjs",
 ) {
   const entry = path.join(root, name);
@@ -29,6 +35,17 @@ if (args.includes('--help')) {
   if (options.hang) setInterval(() => {}, 1000);
   else process.exit(options.helpStatus ?? 0);
 } else {
+  if (options.preserveUninstallIntent) {
+    const marker = process.env.ARGV_LOG + '.disabled';
+    if (args[0] === 'plugins' && args[2] === 'demo-plugin-npm') {
+      if (args[1] === 'uninstall') fs.writeFileSync(marker, 'disabled');
+      if (args[1] === 'enable') fs.rmSync(marker, { force: true });
+    }
+    if (args[0] === 'demo-npm' && fs.existsSync(marker)) {
+      console.error('OpenClaw does not know the command "demo-npm".');
+      process.exit(43);
+    }
+  }
   const accepted = args.includes('--accept-capabilities');
   if (accepted && !supported) {
     console.error('unknown option --accept-capabilities');
@@ -140,7 +157,10 @@ describe("package fixture consent compatibility", () => {
     "runs the plugin sweep with selective consent (supported=%s)",
     (supported) => {
       const root = tempDirs.make("openclaw-consent-sweep-");
-      const entry = writeCandidate(root, { commands: supported ? undefined : [] });
+      const entry = writeCandidate(root, {
+        commands: supported ? undefined : [],
+        preserveUninstallIntent: true,
+      });
       const result = runShell(root, entry, sweepFixtureLoader);
       expect(result.status, result.stderr).toBe(0);
       const mutations = result.calls.filter(
@@ -158,7 +178,10 @@ describe("package fixture consent compatibility", () => {
         expect(args.includes(consent), args.join(" ")).toBe(supported && positive);
       }
       expect(mutations.filter((args) => args[1] === "update")).toHaveLength(5);
-      expect(mutations.find((args) => args[1] === "enable")).toContain("claude-bundle-e2e");
+      expect(mutations.filter((args) => args[1] === "enable").map((args) => args[2])).toEqual([
+        "demo-plugin-npm",
+        "claude-bundle-e2e",
+      ]);
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw update repair` would fail with `no authoritative runtime child list` after restoring a missing npm plugin payload. Also repairs the Docker runtime-plugin sweep, which invoked `demo-npm` after reinstalling a plugin that the operator had explicitly uninstalled.

Dependency: #136774 is still open. Its Docker image repair is cherry-picked solely to provide the working image prerequisite; it is not part of the fixes or LOC counts described below.

These are the two plugin-lane blockers observed in [2026.9.1 Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/33697142798), including [the candidate release checks](https://github.com/openclaw/openclaw/actions/runs/33698227500).

## Why This Change Was Made

The product defect belongs to update reconciliation: its before/after installed-plugin indexes shared cached filesystem facts, so restoring a package at the same path retained an earlier missing-file result; replacing metadata could likewise retain the old runtime children. Cohort reconciliation and the sibling manual plugin-update path now use fresh operation-scoped discovery for post-install reads, while preserving strict package ownership and retained gateway cache generations.

The runtime-plugin failure belongs to the harness. Reinstall intentionally preserves the explicit uninstall marker (`enabled: false`), so the second CLI invocation correctly failed. The sweep now asserts that disabled state, explicitly enables the reinstalled fixture, and then checks runtime registration and command execution. The command catalog projection already maps `docks` to `tools` and needs no change.

## User Impact

Missing-payload repair can complete after consent, and replacement packages reconcile against their current runtime children. Existing disabled-plugin intent and capability-consent checks remain intact. The Docker sweep now follows the documented reinstall/enable lifecycle.

No configuration, schema, protocol, or compatibility surface is added. Production changes are +28/-17 lines (net +11): existing cache scopes at lifecycle boundaries, without a new abstraction or fallback. Tests and harness support account for +132/-5 lines.

## Evidence

The original release candidate is `c92d0ae9c07e757719e676517aa9f9460a40761c`, package version `2026.9.1`. The controlled comparison uses the same prepublish registry snapshot and reuses the same OrbStack images.

- Original package SHA-256: `befd59d701091de5f855371ba58d4a4932ca9958d006a0e28442aba76565d264`.
- Repaired package SHA-256: `8cf03e56b36aaeb0564519309bdd3c91fca9521ffd8c55ae7fd03dd119fe1b47`; rebuilt from the release candidate with only the two update-reconciliation source changes. The final CLI type annotation has identical emitted runtime behavior.
- Registry manifest SHA-256: `c67573da702e9136f756056ad7677ae7c4fab013eccfce9c451e42b59aba666b`.

`pnpm test:docker:plugins` failed before with unknown `demo-npm` on the post-reinstall invocation and passed the complete sweep after the harness fix on the **unchanged original package**. Captured state was disabled after reinstall, loaded with `cliCommands: ["demo-npm"]` after enable, then `demo-plugin-npm:pong`. npm, git/update, bundle, marketplace, and local ClawHub fixture scenarios completed.

The unchanged `test/scripts/package-compat.test.ts` suite passed **23/23** in a disposable Linux container with the current scripts and tests mounted read-only and byte-identical dependency manifests (Node 24.19.0, Vitest 4.1.11). The macOS sweep subprocesses hit their existing 30-second bound under host load; the same cases completed in under three seconds each in Linux, with no timeout or assertion changes.

`pnpm test:docker:plugin-update`: the original package failed at `missing-payload-accepted` with `no authoritative runtime child list`; the repaired package now passes both `missing-payload-accepted` and `missing-payload-recovered`, retaining the expected no-consent failures. The full lane exited 0: capability consent, missing-payload repair, unchanged config, package snapshot, and unchanged-update output assertions all passed.

The stateful harness regression also fails with the old sweep in Linux (21 passed / 2 failed, no timeouts); a trace confirms the failure is the second `demo-npm ping` after uninstall/reinstall. With the fixed sweep, 23/23 pass.

`pnpm check:changed` passed, including type checks, lint, dead-export scans, import cycles, and repository guards.

`pnpm test src/plugins/update-cohort.test.ts src/plugins/plugin-package-update.test.ts src/cli/plugins-cli.update.test.ts`: 67 passed, including two real-filesystem regressions that failed before the repair (missing payload and replacement child metadata). `pnpm build` and repaired release-package integrity checks passed. Codex autoreview: no actionable P0–P2 findings.

The full Release Validation workflow and grouped prerelease jobs have not been rerun. Diagnostic follow-up: the bare lane installs to a custom npm prefix, while its log helper searches the default prefix for the redactor; it omits the unchanged-update log. The command/config/snapshot/output assertions ran successfully before that print step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
