### PR TITLE
fix(agents): preserve sibling reroutes and repair Gateway release E2E

### DIFF
--- a/packages/sdk/src/app-sdk-composed-resources.e2e.test.ts
+++ b/packages/sdk/src/app-sdk-composed-resources.e2e.test.ts
@@ -39,7 +39,10 @@ import {
   testState,
   writeSessionStore,
 } from "../../../src/gateway/test-helpers.js";
-import type { WorkerEnvironmentServiceRecord } from "../../../src/gateway/worker-environments/service-contract.js";
+import type {
+  WorkerEnvironmentServiceContract,
+  WorkerEnvironmentServiceRecord,
+} from "../../../src/gateway/worker-environments/service-contract.js";
 import { emitAgentEvent } from "../../../src/infra/agent-events.js";
 import { registerAgentRunContext } from "../../../src/infra/agent-run-registry.js";
 import { withTimeout } from "../../../src/utils/with-timeout.js";
@@ -132,6 +135,10 @@ async function createFakeGateway(): Promise<FakeGateway> {
   const workerEnvironmentService = {
     list: () => [worker],
     get: (environmentId: string) => (environmentId === worker.environmentId ? worker : undefined),
+    inventoryVersion: () => 0,
+    supportsExecutionMode: (profileId, mode) =>
+      profileId === "development" && mode === "worker-turn",
+    listMachineOptions: async () => undefined,
     create: async (_profileId: string, _idempotencyKey: string) => {
       const requested = workerRecord("requested");
       worker = workerRecord("ready");
@@ -145,11 +152,17 @@ async function createFakeGateway(): Promise<FakeGateway> {
       worker = workerRecord("destroyed");
       return worker;
     },
+    observeDesktop: async () => {
+      throw new Error("desktop observation is outside the SDK environment RPC proof");
+    },
+    launchDesktopApp: async () => {
+      throw new Error("desktop launch is outside the SDK environment RPC proof");
+    },
     startTunnel: async () => {
       throw new Error("tunnel start is outside the SDK environment RPC proof");
     },
     stopTunnel: async () => {},
-  };
+  } satisfies WorkerEnvironmentServiceContract;
   const environmentContext = {
     logGateway: { warn: vi.fn() },
     nodeRegistry: { listConnectedForPairingStates: () => [] },
@@ -552,7 +565,14 @@ async function proveDeterministicGatewayContracts(): Promise<void> {
       },
     });
     const environments = await oc.environments.list();
-    expect(environments.profiles).toEqual([{ id: "development", providerId: "testbox" }]);
+    expect(environments.profiles).toEqual([
+      {
+        id: "development",
+        providerId: "testbox",
+        executionMode: "worker-turn",
+        executionModes: ["worker-turn"],
+      },
+    ]);
     expect(environments.environments).toContainEqual({
       id: "worker-sdk-e2e",
       type: "worker",

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -2,6 +2,7 @@
 // drain gating, batch idempotency, and the guards that keep the wake out of
 // nested/cron/single-delivered paths.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
 
@@ -30,7 +31,11 @@ const { registryRuntimeMock } = vi.hoisted(() => ({
       (_rootSessionKey: string, _excludeRunId?: string) => false,
     ),
     listSubagentRunsForRequester: vi.fn((_requesterSessionKey: string): unknown[] => []),
-    getLatestSubagentRunByChildSessionKey: vi.fn((_childSessionKey: string) => undefined),
+    getLatestSubagentRunByChildSessionKey: vi.fn(
+      (
+        _childSessionKey: string,
+      ): Pick<SubagentRunRecord, "runId" | "requesterSessionKey"> | undefined => undefined,
+    ),
     resolveRequesterForChildSession: vi.fn((_childSessionKey: string) => null),
   },
 }));
@@ -215,33 +220,38 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     );
   });
 
-  it("coalesces concurrent last-sibling settles into one wake", async () => {
-    const children = [makeSettledChild({ runId: "run-a" }), makeSettledChild({ runId: "run-b" })];
+  it.each([
+    { name: "coalesces concurrent last-sibling settles into one wake", restored: false },
+    { name: "coalesces concurrent row restores for one persisted batch", restored: true },
+  ])("$name", async ({ restored }) => {
+    const children = ["run-a", "run-b"].map((runId) =>
+      makeSettledChild({
+        runId,
+        requesterSettleWake: {
+          status: restored ? "dispatching" : "pending",
+          attemptCount: restored ? 1 : 0,
+          ...(restored ? { batchRunIds: ["run-a", "run-b"] } : {}),
+        },
+      }),
+    );
     registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue(children);
-    let releaseDeliveries!: () => void;
-    const deliveryGate = new Promise<void>((resolve) => {
-      releaseDeliveries = resolve;
-    });
-    deliverSpy.mockImplementation(async () => {
-      await deliveryGate;
-      return { delivered: true, path: "direct" };
-    });
+    const deliveryGate = createDeferred<{ delivered: boolean; path: string }>();
+    deliverSpy.mockReturnValueOnce(deliveryGate.promise);
 
     const wakeA = maybeWakeRequesterAfterAllChildrenSettled(
       wakeParams({ settledEntry: children[0] }),
     );
-    const wakeB = maybeWakeRequesterAfterAllChildrenSettled(
-      wakeParams({ settledEntry: children[1] }),
-    );
-    await vi.waitFor(() => expect(deliverSpy).toHaveBeenCalledOnce());
-    await wakeB;
-    releaseDeliveries();
-    await expect(Promise.all([wakeA, wakeB])).resolves.toEqual(
-      expect.arrayContaining([true, false]),
-    );
-
+    try {
+      await vi.waitFor(() => expect(deliverSpy).toHaveBeenCalledOnce());
+      await expect(
+        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: children[1] })),
+      ).resolves.toBe(false);
+      expect(deliverSpy).toHaveBeenCalledOnce();
+    } finally {
+      deliveryGate.resolve({ delivered: true, path: "direct" });
+      await expect(wakeA).resolves.toBe(true);
+    }
     expect(deliveredCallArg().directIdempotencyKey).toBe(requesterSettleKey("run-a,run-b"));
-    deliverSpy.mockReset().mockResolvedValue({ delivered: true, path: "direct" });
   });
 
   it("uses a new batch signature for a later second batch", async () => {
@@ -373,6 +383,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(false);
     expect(deliverSpy).not.toHaveBeenCalled();
+    expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-a", "run-b"]);
   });
 
   it("skips cron requester sessions", async () => {
@@ -382,6 +393,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(false);
     expect(deliverSpy).not.toHaveBeenCalled();
+    expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-b"]);
   });
 
   it("skips requesters whose session entry is gone", async () => {
@@ -418,7 +430,16 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     expect(deliverSpy).not.toHaveBeenCalled();
   });
 
-  it("wakes after a yielded requester's active child completes", async () => {
+  it.each([
+    {
+      name: "wakes after a yielded requester's active child completes",
+      afterRequesterYield: undefined,
+    },
+    {
+      name: "wakes after a requester yields with one already-delivered completion",
+      afterRequesterYield: true,
+    },
+  ])("$name", async ({ afterRequesterYield }) => {
     const child = makeSettledChild({
       runId: "run-b",
       delivery: { status: "delivered" },
@@ -428,6 +449,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
         batchRunIds: ["run-b"],
         requesterYieldBatch: true,
         rearmGeneration: 1,
+        ...(afterRequesterYield ? { afterRequesterYield } : {}),
       },
     });
     registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
@@ -509,38 +531,6 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     });
   });
 
-  it("wakes after a requester yields with one already-delivered completion", async () => {
-    const child = makeSettledChild({
-      runId: "run-b",
-      delivery: { status: "delivered" },
-      requesterSettleWake: {
-        status: "pending",
-        attemptCount: 0,
-        batchRunIds: ["run-b"],
-        requesterYieldBatch: true,
-        afterRequesterYield: true,
-        rearmGeneration: 1,
-      },
-    });
-    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
-
-    const woke = await maybeWakeRequesterAfterAllChildrenSettled(
-      wakeParams({ settledEntry: child }),
-    );
-
-    expect(woke).toBe(true);
-    expect(deliverSpy).toHaveBeenCalledOnce();
-    expect(deliveredCallArg().requireVisibleReply).toBe(true);
-    const message = String(deliveredCallArg().triggerMessage);
-    expect(message).not.toContain("NO_REPLY");
-    expect(message).toContain("original user request still requires your visible final answer");
-    expect(deliveredCallArg().directIdempotencyKey).toBe(requesterSettleKey("run-b:yield-1"));
-    expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
-      delivered: true,
-      path: "direct",
-    });
-  });
-
   it("wakes for a single required completion whose announce never delivered", async () => {
     registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([
       makeSettledChild({
@@ -581,6 +571,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
   it.each([
     {
       name: "visible local route change",
+      requesterOrigin: undefined,
       terminalReply: {
         disposition: "visible",
         text: "authoritative final output",
@@ -590,6 +581,20 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       expected: "authoritative final output",
       expectedRouteInstruction:
         "Preserve this runtime-authored model-route change notice in your final answer.",
+      expectedRouteChange: "Model route changed: requested/model → actual/model.",
+    },
+    {
+      name: "visible shared route change",
+      requesterOrigin: { channel: "discord", to: "channel:shared" },
+      terminalReply: {
+        disposition: "visible",
+        text: "authoritative final output",
+        modelRouteChange: "Model route changed: requested/model → actual/model.",
+      } as const,
+      resultText: "stale child output",
+      expected: "authoritative final output",
+      expectedRouteInstruction:
+        "Keep this runtime-authored model-route change notice internal on this shared surface.",
       expectedRouteChange: "Model route changed: requested/model → actual/model.",
     },
     {
@@ -612,34 +617,88 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       expected,
       expectedRouteChange,
       expectedRouteInstruction,
+      requesterOrigin,
     }) => {
       registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([
-        makeSettledChild({
-          runId: "run-b",
-          delivery: { status: "failed" },
-          completion: {
-            required: true,
-            resultText,
-            fallbackResultText: "stale retained findings",
-            terminalReply,
-          },
-          outcome: { status: "ok" },
-        }),
+        makeSettledChild({ runId: "run-b" }),
+        ...["run-a", "run-c"].map((runId) =>
+          makeSettledChild({
+            runId,
+            delivery: { status: "failed" },
+            completion: {
+              required: true,
+              resultText,
+              fallbackResultText: "stale retained findings",
+              terminalReply,
+            },
+            outcome: { status: "ok" },
+          }),
+        ),
       ]);
 
-      expect(await maybeWakeRequesterAfterAllChildrenSettled(wakeParams())).toBe(true);
+      expect(await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ requesterOrigin }))).toBe(
+        true,
+      );
       const message = String(deliveredCallArg().triggerMessage);
       expect(message).not.toContain("stale retained findings");
       expect(message).not.toContain("stale child output");
       if (expected) {
         expect(message).toContain(expected);
       }
-      if (expectedRouteInstruction) {
-        expect(message).toContain(expectedRouteChange);
+      if (expectedRouteChange) {
+        expect(message.split(expectedRouteChange)).toHaveLength(2);
         expect(message).toContain(expectedRouteInstruction);
       }
     },
   );
+
+  it("bounds sorted route notices and excludes superseded child owners", async () => {
+    const children = Array.from({ length: 8 }, (_, index) =>
+      makeSettledChild({
+        runId: `run-${index}`,
+        completion: {
+          required: true,
+          terminalReply: {
+            disposition: "visible",
+            text: "done",
+            modelRouteChange: `Model route changed: requested/${index} → actual/${"x".repeat(260)}.`,
+          },
+        },
+      }),
+    ).toReversed();
+    const staleChild = makeSettledChild({
+      runId: "run-stale",
+      completion: {
+        required: true,
+        terminalReply: {
+          disposition: "visible",
+          text: "stale output",
+          modelRouteChange: "Model route changed: old/owner → stale/route.",
+        },
+      },
+    });
+    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([staleChild, ...children]);
+    registryRuntimeMock.getLatestSubagentRunByChildSessionKey.mockImplementation((sessionKey) =>
+      sessionKey === staleChild.childSessionKey
+        ? { runId: "run-replacement", requesterSessionKey: "agent:other:main" }
+        : undefined,
+    );
+
+    expect(
+      await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: staleChild })),
+    ).toBe(true);
+    const message = String(deliveredCallArg().triggerMessage);
+    expect(message).not.toContain("stale output");
+    expect(message).not.toContain("old/owner");
+    const routeBlock = message.slice(
+      message.indexOf("Model route changed:"),
+      message.indexOf("\n[Subagent Context] Preserve this runtime-authored"),
+    );
+    expect(routeBlock).toMatch(/^Model route changed: requested\/0/u);
+    expect(routeBlock).toContain("requested/1");
+    expect(routeBlock).toContain("[model-route changes truncated]");
+    expect(routeBlock.length).toBeLessThanOrEqual(1_024);
+  });
 
   it("stays out of pure fire-and-forget batches", async () => {
     registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([
@@ -659,6 +718,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(false);
     expect(deliverSpy).not.toHaveBeenCalled();
+    expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-a", "run-b"]);
   });
 
   it("retries a transiently failed wake with a fresh idempotency suffix", async () => {
@@ -994,39 +1054,6 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       }
     });
 
-    it("coalesces concurrent row restores for one persisted batch", async () => {
-      const state = {
-        status: "dispatching" as const,
-        attemptCount: 1,
-        batchRunIds: ["run-a", "run-b"],
-      };
-      const children = [
-        makeSettledChild({ runId: "run-a", requesterSettleWake: { ...state } }),
-        makeSettledChild({ runId: "run-b", requesterSettleWake: { ...state } }),
-      ];
-      registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue(children);
-      let releaseDelivery: (() => void) | undefined;
-      deliverSpy.mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            releaseDelivery = () => resolve({ delivered: true, path: "direct" });
-          }),
-      );
-
-      const firstWake = maybeWakeRequesterAfterAllChildrenSettled(
-        wakeParams({ settledEntry: children[0] }),
-      );
-      await vi.waitFor(() => expect(deliverSpy).toHaveBeenCalledOnce());
-      const duplicateWake = maybeWakeRequesterAfterAllChildrenSettled(
-        wakeParams({ settledEntry: children[1] }),
-      );
-
-      await expect(duplicateWake).resolves.toBe(false);
-      expect(deliverSpy).toHaveBeenCalledOnce();
-      releaseDelivery?.();
-      await expect(firstWake).resolves.toBe(true);
-    });
-
     it("honors a persisted retry deadline and budget", async () => {
       const state = {
         status: "pending" as const,
@@ -1065,7 +1092,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       }
     });
 
-    it("resolves mixed keep/delete, nested, cron, and fire-and-forget obligations", async () => {
+    it("resolves mixed keep/delete obligations", async () => {
       const mixed = [
         makeSettledChild({ runId: "run-delete", cleanup: "delete" }),
         makeSettledChild({ runId: "run-keep", cleanup: "keep" }),
@@ -1078,52 +1105,6 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
         delivered: true,
         path: "direct",
       });
-
-      deliverSpy.mockClear();
-      completeBatchSpy.mockClear();
-      const fireAndForget = [
-        makeSettledChild({
-          runId: "run-ff-a",
-          expectsCompletionMessage: false,
-          delivery: { status: "not_required" },
-        }),
-        makeSettledChild({
-          runId: "run-ff-b",
-          expectsCompletionMessage: false,
-          delivery: { status: "not_required" },
-        }),
-      ];
-      registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue(fireAndForget);
-      expect(
-        await maybeWakeRequesterAfterAllChildrenSettled(
-          wakeParams({ settledEntry: fireAndForget[1] }),
-        ),
-      ).toBe(false);
-      expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-ff-a", "run-ff-b"]);
-      expect(deliverSpy).not.toHaveBeenCalled();
-
-      completeBatchSpy.mockClear();
-      const nestedRequester = "agent:main:subagent:middle";
-      const nested = [
-        makeSettledChild({ runId: "run-nested-a", requesterSessionKey: nestedRequester }),
-        makeSettledChild({ runId: "run-nested-b", requesterSessionKey: nestedRequester }),
-      ];
-      registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue(nested);
-      expect(
-        await maybeWakeRequesterAfterAllChildrenSettled(
-          wakeParams({ requesterSessionKey: nestedRequester, settledEntry: nested[1] }),
-        ),
-      ).toBe(false);
-      expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-nested-a", "run-nested-b"]);
-
-      completeBatchSpy.mockClear();
-      const cron = makeSettledChild({ runId: "run-cron" });
-      expect(
-        await maybeWakeRequesterAfterAllChildrenSettled(
-          wakeParams({ requesterSessionKey: "agent:main:cron:daily", settledEntry: cron }),
-        ),
-      ).toBe(false);
-      expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-cron"]);
     });
   });
 });

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -4,6 +4,7 @@
  * Lifecycle owns the persisted outbox state on retained subagent run rows;
  * this module selects a drained wave and delivers its synthesized wake.
  */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { getRuntimeConfig } from "../../../config/config.js";
 import { logWarn } from "../../../logger.js";
@@ -49,6 +50,8 @@ export type RequesterSettleWakeBatchState = Omit<RequesterSettleWakeState, "reti
 const REQUESTER_SETTLE_WAKE_MAX_ATTEMPTS = 3;
 const REQUESTER_SETTLE_WAKE_MAX_AMBIGUOUS_REPLAYS = 3;
 const REQUESTER_SETTLE_WAKE_MAX_DEFERRALS = 10;
+const REQUESTER_SETTLE_WAKE_ROUTE_NOTICE_MAX_CHARS = 1_024;
+const ROUTE_NOTICE_TRUNCATION = "\n[model-route changes truncated]";
 const REQUESTER_SETTLE_WAKE_RETRY_DELAYS_MS = [30_000, 120_000] as const;
 const activeRequesterSettleWakeBatches = new Set<string>();
 
@@ -384,20 +387,34 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
     return false;
   }
 
-  const findings = buildChildCompletionFindings(
-    dedupeLatestChildCompletionRows(
-      filterCurrentDirectChildCompletionRows(settledBatch, {
-        requesterSessionKey,
-        requesterAgentId,
-        getLatestSubagentRunByChildSessionKey,
-      }),
-    ),
+  const completionRows = dedupeLatestChildCompletionRows(
+    filterCurrentDirectChildCompletionRows(settledBatch, {
+      requesterSessionKey,
+      requesterAgentId,
+      getLatestSubagentRunByChildSessionKey,
+    }),
   );
+  const findings = buildChildCompletionFindings(completionRows);
   const requesterSessionOrigin = normalizeDeliveryContext(params.requesterOrigin);
   const directOrigin = resolveAnnounceOrigin(requesterEntry, requesterSessionOrigin);
-  const terminalReply = currentSettledEntry.completion?.terminalReply;
+  // The scheduling row need not be the rerouted child. Keep every current
+  // child's producer-owned notice, with stable bytes and one batch-wide cap.
+  const routeNotices = [
+    ...new Set(
+      completionRows.flatMap(({ completion }) => {
+        const reply = completion?.terminalReply;
+        return reply?.disposition === "visible" && reply.modelRouteChange
+          ? [reply.modelRouteChange]
+          : [];
+      }),
+    ),
+  ]
+    .toSorted()
+    .join("\n");
   const modelRouteChange =
-    terminalReply?.disposition === "visible" ? terminalReply.modelRouteChange : undefined;
+    routeNotices.length > REQUESTER_SETTLE_WAKE_ROUTE_NOTICE_MAX_CHARS
+      ? `${truncateUtf16Safe(routeNotices, REQUESTER_SETTLE_WAKE_ROUTE_NOTICE_MAX_CHARS - ROUTE_NOTICE_TRUNCATION.length)}${ROUTE_NOTICE_TRUNCATION}`
+      : routeNotices;
   const completionChannel = normalizeMessageChannel(directOrigin?.channel);
   const wakeMessage = buildRequesterSettleWakeMessage({
     findings,

--- a/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -743,7 +743,7 @@ describe("subagent registry lifecycle error grace", () => {
     emitLifecycleEvent("run-transient-error", {
       phase: "error",
       error: "rate limit",
-      endedAt: 1_000,
+      endedAt: Date.now(),
     });
     await flushAsync();
     expect(getAgentCalls()).toHaveLength(0);
@@ -751,7 +751,7 @@ describe("subagent registry lifecycle error grace", () => {
     await vi.advanceTimersByTimeAsync(14_999);
     expect(getAgentCalls()).toHaveLength(0);
 
-    emitLifecycleEvent("run-transient-error", { phase: "start", startedAt: 1_050 });
+    emitLifecycleEvent("run-transient-error", { phase: "start", startedAt: Date.now() });
     await flushAsync();
 
     await vi.advanceTimersByTimeAsync(20_000);
@@ -759,7 +759,7 @@ describe("subagent registry lifecycle error grace", () => {
 
     emitLifecycleEvent("run-transient-error", {
       phase: "end",
-      endedAt: 1_250,
+      endedAt: Date.now(),
       terminalReply: { disposition: "visible", text: "Final answer transient" },
     });
     await flushAsync();
@@ -775,7 +775,7 @@ describe("subagent registry lifecycle error grace", () => {
     emitLifecycleEvent("run-terminal-error", {
       phase: "error",
       error: "fatal failure",
-      endedAt: 2_000,
+      endedAt: Date.now(),
     });
     await flushAsync();
     expect(getAgentCalls()).toHaveLength(0);
@@ -1005,7 +1005,7 @@ describe("subagent registry lifecycle error grace", () => {
       status: "timeout",
       timeoutPhase: "provider",
       providerStarted: true,
-      endedAt: 3_000,
+      endedAt: Date.now(),
       error: "provider timed out",
     });
     await flushAsync();
@@ -1033,7 +1033,7 @@ describe("subagent registry lifecycle error grace", () => {
       status: "timeout",
       timeoutPhase: "provider",
       providerStarted: true,
-      endedAt: 4_000,
+      endedAt: Date.now(),
     });
     await flushAsync();
     expect(getAgentCalls()).toHaveLength(0);
@@ -1041,7 +1041,7 @@ describe("subagent registry lifecycle error grace", () => {
     // Before the grace window, the run successfully ends (non-aborted)
     emitLifecycleEvent("run-timeout-cancel", {
       phase: "end",
-      endedAt: 4_500,
+      endedAt: Date.now(),
       terminalReply: { disposition: "visible", text: "Final answer after recovery" },
     });
     await flushAsync();

--- a/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -50,6 +50,7 @@ type GatewayRequest = Omit<CallGatewayOptions, "params"> & { params?: GatewayAge
 let lifecycleHandler: ((evt: LifecycleEvent) => void) | undefined;
 let agentCallPlan: Array<"ok" | "throw"> = [];
 let agentCallGates = new Map<string, Promise<void>>();
+let releaseAgentCallGate: (() => void) | undefined;
 let chatHistoryBySessionKey = new Map<string, Array<Record<string, unknown>>>();
 let sessionStore: Record<string, SessionStoreEntry> = {};
 
@@ -75,7 +76,12 @@ const callGatewayMock = vi.fn(async (request: GatewayRequest) => {
     if (next === "throw") {
       throw new Error("announce delivery failed");
     }
-    return { result: { payloads: [{ text: "completion delivered" }] } };
+    return {
+      result: {
+        payloads: [{ text: "completion delivered" }],
+        deliveryStatus: { status: "sent", resultCount: 1 },
+      },
+    };
   }
   return {};
 });
@@ -202,7 +208,11 @@ describe("subagent registry lifecycle error grace", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Failed assertions must also release the delivery owned by this test.
+    releaseAgentCallGate?.();
+    releaseAgentCallGate = undefined;
+    await vi.advanceTimersByTimeAsync(0);
     lifecycleHandler = undefined;
     subagentAnnounceDeliveryTesting.setDepsForTest();
     subagentAnnounceOutputTesting.setDepsForTest();
@@ -362,16 +372,7 @@ describe("subagent registry lifecycle error grace", () => {
   }
 
   function readFirstAnnounceOutcome() {
-    const first = getAgentCalls()[0];
-    const internalEvents = first?.params?.internalEvents;
-    const event =
-      Array.isArray(internalEvents) && internalEvents[0] && typeof internalEvents[0] === "object"
-        ? (internalEvents[0] as { status?: string; statusLabel?: string })
-        : undefined;
-    return {
-      status: event?.status,
-      error: event?.statusLabel,
-    };
+    return getAgentCalls()[0]?.params?.internalEvents?.[0];
   }
 
   function setAssistantOutput(sessionKey: string, text: string) {
@@ -568,11 +569,10 @@ describe("subagent registry lifecycle error grace", () => {
     setAssistantOutput(alphaSessionKey, "alpha complete");
     setAssistantOutput(betaSessionKey, "beta complete");
 
-    let releaseBetaDelivery: (() => void) | undefined;
     agentCallGates.set(
       betaSessionKey,
       new Promise<void>((resolve) => {
-        releaseBetaDelivery = resolve;
+        releaseAgentCallGate = resolve;
       }),
     );
 
@@ -582,6 +582,7 @@ describe("subagent registry lifecycle error grace", () => {
       terminalReply: { disposition: "visible", text: "alpha complete" },
     });
     await waitForAgentCallCount(1);
+    await waitForDeliveredCleanup("run-yield-alpha", { allowPendingRequesterSettleWake: true });
 
     emitLifecycleEvent("run-yield-beta", {
       phase: "end",
@@ -619,8 +620,7 @@ describe("subagent registry lifecycle error grace", () => {
       ],
     });
 
-    await vi.advanceTimersByTimeAsync(0);
-    await flushAsync();
+    await waitForDeliveredCleanup("run-yield-alpha");
 
     const yieldedBatch = mod.listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY);
     expect(
@@ -651,7 +651,7 @@ describe("subagent registry lifecycle error grace", () => {
     expect(getRequesterWakeCalls()).toHaveLength(1);
 
     agentCallGates.delete(betaSessionKey);
-    releaseBetaDelivery?.();
+    releaseAgentCallGate?.();
     await waitForDeliveredCleanup("run-yield-alpha");
     await waitForDeliveredCleanup("run-yield-beta");
 
@@ -785,7 +785,7 @@ describe("subagent registry lifecycle error grace", () => {
 
     await waitForAgentCallCount(1);
     expect(readFirstAnnounceOutcome()?.status).toBe("error");
-    expect(readFirstAnnounceOutcome()?.error).toContain("fatal failure");
+    expect(readFirstAnnounceOutcome()?.statusLabel).toContain("fatal failure");
   });
 
   it("freezes completion result at run termination across deferred announce retries", async () => {

--- a/src/agents/subagents/registry/subagent-registry.requester-wake.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.requester-wake.e2e.test.ts
@@ -36,6 +36,7 @@ type GatewayRequest = Omit<CallGatewayOptions, "params"> & {
 
 let lifecycleHandler: ((event: LifecycleEvent) => void) | undefined;
 let agentCallGates = new Map<string, Promise<void>>();
+let releaseAgentCallGate: (() => void) | undefined;
 let chatHistoryBySessionKey = new Map<string, Array<Record<string, unknown>>>();
 let sessionStore: Record<string, SessionStoreEntry> = {};
 let rejectNextRequesterWake = false;
@@ -53,7 +54,12 @@ const callGatewayMock = vi.fn(async (request: GatewayRequest) => {
     if (gate) {
       await gate;
     }
-    return { result: { payloads: [{ text: "completion delivered" }] } };
+    return {
+      result: {
+        payloads: [{ text: "completion delivered" }],
+        deliveryStatus: { status: "sent", resultCount: 1 },
+      },
+    };
   }
   return {};
 });
@@ -164,7 +170,11 @@ describe("requester settle wake product flow", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Failed assertions must also release the delivery owned by this test.
+    releaseAgentCallGate?.();
+    releaseAgentCallGate = undefined;
+    await vi.advanceTimersByTimeAsync(0);
     lifecycleHandler = undefined;
     subagentAnnounceDeliveryTesting.setDepsForTest();
     subagentAnnounceOutputTesting.setDepsForTest();
@@ -205,13 +215,16 @@ describe("requester settle wake product flow", () => {
     throw new Error(`expected ${expectedCount} agent calls, got ${getAgentCalls().length}`);
   };
 
-  const waitForDeliveredCleanup = async (runId: string) => {
+  const waitForDeliveredCleanup = async (
+    runId: string,
+    options?: { allowPendingRequesterSettleWake?: boolean },
+  ) => {
     for (let attempt = 0; attempt < 80; attempt += 1) {
       const run = registry.getSubagentRunByRunId(runId);
       if (
         run?.delivery?.status === "delivered" &&
         typeof run.cleanupCompletedAt === "number" &&
-        run.requesterSettleWake === undefined
+        (options?.allowPendingRequesterSettleWake === true || run.requesterSettleWake === undefined)
       ) {
         return;
       }
@@ -294,15 +307,15 @@ describe("requester settle wake product flow", () => {
     await spawnVisibleChild({ ...alpha, requesterTurnRunId });
     await spawnVisibleChild({ ...beta, requesterTurnRunId });
 
-    let releaseBetaDelivery: (() => void) | undefined;
     agentCallGates.set(
       beta.childSessionKey,
       new Promise<void>((resolve) => {
-        releaseBetaDelivery = resolve;
+        releaseAgentCallGate = resolve;
       }),
     );
     emitCompleted(alpha.runId, alpha.childSessionKey, "alpha complete");
     await waitForAgentCallCount(1);
+    await waitForDeliveredCleanup(alpha.runId, { allowPendingRequesterSettleWake: true });
     const modelRouteChange = "Model route changed: requested/model → actual/model.";
     emitCompleted(beta.runId, beta.childSessionKey, "beta complete", modelRouteChange);
     await waitForAgentCallCount(2);
@@ -353,10 +366,8 @@ describe("requester settle wake product flow", () => {
         },
       }),
     );
-    await vi.advanceTimersByTimeAsync(0);
-    await flushAsync();
-
     await waitForAgentCallCount(rejectRequesterWake ? 2 : 3);
+    await waitForDeliveredCleanup(alpha.runId);
     expect(getRequesterWakeCalls()).toHaveLength(rejectRequesterWake ? 0 : 1);
     if (!rejectRequesterWake) {
       const wakeMessage = getRequesterWakeCalls()[0]?.params?.message;
@@ -373,7 +384,7 @@ describe("requester settle wake product flow", () => {
     }
 
     agentCallGates.delete(beta.childSessionKey);
-    releaseBetaDelivery?.();
+    releaseAgentCallGate?.();
     await waitForDeliveredCleanup(alpha.runId);
     await waitForDeliveredCleanup(beta.runId);
     await registry.testing.sweepOnceForTests();

--- a/src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts
+++ b/src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts
@@ -26,7 +26,7 @@ describe("doctor database schema preflight", () => {
   it("lets a successful interactive update replace the stale doctor", async () => {
     writeStateSchemaVersion(OPENCLAW_STATE_SCHEMA_VERSION + 1);
     mockDoctorConfigSnapshot();
-    mockInteractiveGitUpdate("ok");
+    mockInteractiveGitUpdate({ status: "ok" });
 
     await expect(doctorCommand(createDoctorRuntime())).resolves.toBeUndefined();
 
@@ -35,10 +35,10 @@ describe("doctor database schema preflight", () => {
     expect(readConfigFileSnapshot).not.toHaveBeenCalled();
   });
 
-  it("refuses after an interactive update does not handle doctor", async () => {
+  it("refuses after an interactive update reports already-current", async () => {
     writeStateSchemaVersion(OPENCLAW_STATE_SCHEMA_VERSION + 1);
     mockDoctorConfigSnapshot();
-    mockInteractiveGitUpdate("skipped");
+    mockInteractiveGitUpdate({ status: "skipped", reason: "already-current" });
 
     await expect(doctorCommand(createDoctorRuntime())).rejects.toThrow(
       /Doctor refused to continue.*database schema.*newer than this build/iu,
@@ -91,7 +91,9 @@ describe("doctor database schema preflight", () => {
   });
 });
 
-function mockInteractiveGitUpdate(status: "ok" | "skipped"): void {
+function mockInteractiveGitUpdate(
+  outcome: { status: "ok" } | { status: "skipped"; reason: "already-current" },
+): void {
   delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
   resolveOpenClawPackageRoot.mockResolvedValue("/repo");
   runCommandWithTimeout.mockResolvedValue({
@@ -102,7 +104,7 @@ function mockInteractiveGitUpdate(status: "ok" | "skipped"): void {
     killed: false,
   });
   runGatewayUpdate.mockResolvedValue({
-    status,
+    ...outcome,
     mode: "git",
     root: "/repo",
     steps: [],


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the 2026.9.1 stable release's Gateway E2E validation failed, including a requester wake that dropped a sibling's model-route change notice.

Failure evidence: [Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/33697142798), [Gateway 4/4 job](https://github.com/openclaw/openclaw/actions/runs/33697211727/job/100470668179), release SHA `c92d0ae9c07e757719e676517aa9f9460a40761c`.

## Why This Change Was Made

Requester settle wakes now collect route notices from the same current, deduplicated children as completion findings. Notices are sorted, deduplicated, and bounded to 1,024 characters including an explicit truncation marker. The existing local/shared-channel visibility policy remains authoritative.

The other failures came from fixtures that no longer described current owner contracts:

- The App SDK worker-service fixture hid missing required methods behind a context cast. It now satisfies `WorkerEnvironmentServiceContract` and proves execution-mode projection. The call was introduced by #126585; #135583 removed the method-level optional guard. The real service already implements it.
- Requester and sibling lifecycle fixtures returned assistant text without a confirmed outbound delivery receipt. They now return terminal send receipts and wait for committed delivery state; failed assertions also release gated delivery work.
- Doctor's reasonless `skipped` update is a failed update, not a continuation. The fixture now explicitly supplies the supported `already-current` no-op and retains the schema-refusal assertion.
- Four sibling lifecycle cases dated their fresh events in 1970 while the fake clock was in 2026, immediately hitting the delivery deadline. Event timestamps now come from the fixture clock; grace timing and assertions are preserved.

Each independent cause has its own commit. The change restores the existing [subagent handoff and delivery contracts](https://docs.openclaw.ai/tools/subagents) without adding configuration, persistence, schema, or protocol changes. Production delta is +27/-10; the net 17 lines implement current-batch aggregation, deterministic ordering, and a bounded prompt block.

## User Impact

Parents receive route-change notices from rerouted siblings even when another child triggers the consolidated wake. External-channel parents continue to keep those notices internal. Release validation now exercises realistic environment, update, and delivery contracts.

Related: #136390 addresses overlapping-wave deferral, a separate invariant; this PR does not include that change.

## Evidence

All four original failures reproduced in **3/3** runs before edits and passed **3/3** after repairs, using `test/vitest/vitest.e2e.config.ts`, two workers, and the prepared E2E runtime. Fixture-only proof fixed App SDK, doctor, and rejected-wake tests while the visible-wake test still failed on the missing sibling notice before the production fix.

The final combined E2E run passed **22/22 tests across four files**, including the sibling lifecycle suite. The eight initial sibling failures reduced to four after receipt fixes, then zero after correcting event timestamps.

```sh
OPENCLAW_E2E_WORKERS=2 OPENCLAW_E2E_USE_PREBUILT_DIST=1 \
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts \
  packages/sdk/src/app-sdk-composed-resources.e2e.test.ts \
  src/agents/subagents/registry/subagent-registry.requester-wake.e2e.test.ts \
  src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts \
  src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
```

The initial invocation omitted `OPENCLAW_E2E_USE_PREBUILT_DIST` and successfully built the runtime, local plugin artifacts, and subprocess prerequisites. Local proof used macOS and Node 26.8.1; the release job uses Linux and Node 24.19.0.

A recent [scheduled main E2E run](https://github.com/openclaw/openclaw/actions/runs/33591394471) already had the exact App SDK failure in shard 1 and doctor failure in shard 2. Weighted assignment differed; the requester-wake file was absent from that earlier run. Normal `ci.yml` does not run this full Gateway E2E matrix.

Owner unit suites passed **107/107** (39 requester-wake, 33 environment, 35 doctor-update). The final requester-wake suite passed again after test consolidation; the two deferred delivery cases also passed after adopting the existing promise helper.

```sh
node scripts/run-vitest.mjs \
  src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts \
  src/gateway/server-methods/environments.test.ts \
  src/commands/doctor-update.test.ts
pnpm check:changed
```

`pnpm check:changed` completed successfully with every selected gate enabled. Earlier attempts identified test-file line limits and an unsupported TypeScript library reference in the test consolidation; duplicate setup was consolidated and the canonical deferred-promise helper reused. No assertions, gates, or type targets were weakened. Final independent Codex review found no actionable P0–P2 issues. Production is +27/-10; tests are +206/-192. The complete Gateway shard and full release matrix have not been rerun; this PR is the focused repair and local proof for the release owner to integrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
