### PR TITLE
refactor(cron): settle fixture cores before teardown

### DIFF
--- a/src/cron/service/active-run-cancellation.test.ts
+++ b/src/cron/service/active-run-cancellation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { clearCronJobActive, markCronJobActive, noteActiveCronJobRemoval } from "../active-jobs.js";
 import {
   abortActiveCronTaskRuns,
@@ -25,37 +26,43 @@ describe("cron task cancellation tracking", () => {
       activeJobMarker: marker,
     });
 
-    expect(controller.signal.aborted).toBe(true);
-    expect(controller.signal.reason).toBe("Cron job removed by operator.");
-    release?.();
-    clearCronJobActive("removed-before-controller", marker);
+    try {
+      expect(controller.signal.aborted).toBe(true);
+      expect(controller.signal.reason).toBe("Cron job removed by operator.");
+    } finally {
+      release?.();
+      clearCronJobActive("removed-before-controller", marker);
+    }
   });
 
   it("retires restart tracking while keeping an unsettled core suspension-visible", async () => {
     resetActiveCronTaskRunsForTests();
-    let settle = () => {};
-    const core = new Promise<void>((resolve) => {
-      settle = resolve;
-    });
-    trackActiveCronTaskRunSettlement(core);
+    const core = createDeferred();
+    trackActiveCronTaskRunSettlement(core.promise);
 
-    await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({
-      drained: false,
-      active: 1,
-    });
-    expect(getSuspensionVisibleCronTaskRunCount()).toBe(1);
+    try {
+      await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({
+        drained: false,
+        active: 1,
+      });
+      expect(getSuspensionVisibleCronTaskRunCount()).toBe(1);
 
-    retireActiveCronTaskRunTracking();
+      retireActiveCronTaskRunTracking();
 
-    await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({
-      drained: true,
-      active: 0,
-    });
-    expect(getSuspensionVisibleCronTaskRunCount()).toBe(1);
+      await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({
+        drained: true,
+        active: 0,
+      });
+      expect(getSuspensionVisibleCronTaskRunCount()).toBe(1);
 
-    settle();
-    await core;
-    await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+      core.resolve();
+      await core.promise;
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+    } finally {
+      core.resolve();
+      await core.promise;
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+    }
   });
 
   it.each([
@@ -68,7 +75,8 @@ describe("cron task cancellation tracking", () => {
       resetActiveCronTaskRunsForTests();
       const initialWallTimeMs = Date.parse("2026-08-23T12:00:00.000Z");
       vi.setSystemTime(initialWallTimeMs);
-      trackActiveCronTaskRunSettlement(new Promise<never>(() => {}));
+      const core = createDeferred();
+      trackActiveCronTaskRunSettlement(core.promise);
       const observedDrain = vi.fn();
       const drain = waitForActiveCronTaskRuns(1_000).then(observedDrain);
 
@@ -80,9 +88,10 @@ describe("cron task cancellation tracking", () => {
         await vi.advanceTimersByTimeAsync(1);
         expect(observedDrain).toHaveBeenCalledExactlyOnceWith({ drained: false, active: 1 });
       } finally {
+        core.resolve();
+        await Promise.allSettled([core.promise, drain]);
+        await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
         resetActiveCronTaskRunsForTests();
-        await vi.advanceTimersByTimeAsync(25);
-        await drain;
         vi.useRealTimers();
       }
     },
@@ -96,10 +105,7 @@ describe("cron task cancellation tracking", () => {
     async ({ settleCore }) => {
       vi.useFakeTimers();
       resetActiveCronTaskRunsForTests();
-      let settle = () => {};
-      const core = new Promise<void>((resolve) => {
-        settle = resolve;
-      });
+      const core = createDeferred();
       const release = settleCore
         ? undefined
         : registerActiveCronTaskRun({
@@ -107,7 +113,7 @@ describe("cron task cancellation tracking", () => {
             controller: new AbortController(),
           });
       if (settleCore) {
-        trackActiveCronTaskRunSettlement(core);
+        trackActiveCronTaskRunSettlement(core.promise);
       }
       const firstObservedDrain = vi.fn();
       const secondObservedDrain = vi.fn();
@@ -118,7 +124,7 @@ describe("cron task cancellation tracking", () => {
 
       try {
         if (settleCore) {
-          settle();
+          core.resolve();
         } else {
           release?.();
         }
@@ -127,11 +133,11 @@ describe("cron task cancellation tracking", () => {
         expect(firstObservedDrain).toHaveBeenCalledExactlyOnceWith({ drained: true, active: 0 });
         expect(secondObservedDrain).toHaveBeenCalledExactlyOnceWith({ drained: true, active: 0 });
       } finally {
-        settle();
+        core.resolve();
         release?.();
+        await Promise.allSettled([core.promise, drains]);
+        await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
         resetActiveCronTaskRunsForTests();
-        await vi.advanceTimersByTimeAsync(25);
-        await drains;
         vi.useRealTimers();
       }
     },
@@ -144,13 +150,14 @@ describe("cron task cancellation tracking", () => {
     "drops never-settling cron promises after an abort $timing",
     async ({ abortBeforeTracking }) => {
       vi.useFakeTimers();
+      const core = createDeferred();
       try {
         resetActiveCronTaskRunsForTests();
         const controller = new AbortController();
         if (abortBeforeTracking) {
           controller.abort();
         }
-        trackActiveCronTaskRunSettlement(new Promise<never>(() => {}), controller.signal);
+        trackActiveCronTaskRunSettlement(core.promise, controller.signal);
 
         await expect(waitForActiveCronTaskRuns(0)).resolves.toEqual({
           drained: false,
@@ -175,6 +182,9 @@ describe("cron task cancellation tracking", () => {
         });
         expect(getSuspensionVisibleCronTaskRunCount()).toBe(1);
       } finally {
+        core.resolve();
+        await core.promise;
+        await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
         vi.useRealTimers();
         resetActiveCronTaskRunsForTests();
       }
@@ -185,20 +195,15 @@ describe("cron task cancellation tracking", () => {
     vi.useFakeTimers();
     const cancelledController = new AbortController();
     const unaffectedController = new AbortController();
-    let settleCancelled = () => {};
-    let settleUnaffected = () => {};
-    const cancelledRun = new Promise<void>((resolve) => {
-      settleCancelled = resolve;
-    });
-    const unaffectedRun = new Promise<void>((resolve) => {
-      settleUnaffected = resolve;
-    });
+    const cancelledRun = createDeferred();
+    const unaffectedRun = createDeferred();
+    let release: (() => void) | undefined;
 
     try {
       resetActiveCronTaskRunsForTests();
-      trackActiveCronTaskRunSettlement(cancelledRun, cancelledController.signal);
-      trackActiveCronTaskRunSettlement(unaffectedRun, unaffectedController.signal);
-      const release = registerActiveCronTaskRun({
+      trackActiveCronTaskRunSettlement(cancelledRun.promise, cancelledController.signal);
+      trackActiveCronTaskRunSettlement(unaffectedRun.promise, unaffectedController.signal);
+      release = registerActiveCronTaskRun({
         runId: "cancelled-run",
         controller: cancelledController,
       });
@@ -217,9 +222,11 @@ describe("cron task cancellation tracking", () => {
       });
       expect(getSuspensionVisibleCronTaskRunCount()).toBe(2);
     } finally {
-      settleCancelled();
-      settleUnaffected();
-      await Promise.all([cancelledRun, unaffectedRun]);
+      release?.();
+      cancelledRun.resolve();
+      unaffectedRun.resolve();
+      await Promise.allSettled([cancelledRun.promise, unaffectedRun.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
       resetActiveCronTaskRunsForTests();
     }
@@ -232,15 +239,18 @@ describe("cron task cancellation tracking", () => {
   ])("retires $scenario during a bulk shutdown", async ({ cancellableRuns, handlelessRuns }) => {
     vi.useFakeTimers();
     const controller = new AbortController();
+    const cancellableCore = createDeferred();
+    const handlelessCore = createDeferred();
+    let release: (() => void) | undefined;
     try {
       resetActiveCronTaskRunsForTests();
       if (cancellableRuns > 0) {
-        trackActiveCronTaskRunSettlement(new Promise<never>(() => {}), controller.signal);
+        trackActiveCronTaskRunSettlement(cancellableCore.promise, controller.signal);
       }
       if (handlelessRuns > 0) {
-        trackActiveCronTaskRunSettlement(new Promise<never>(() => {}));
+        trackActiveCronTaskRunSettlement(handlelessCore.promise);
       }
-      const release =
+      release =
         cancellableRuns > 0
           ? registerActiveCronTaskRun({ runId: "shutdown-run", controller })
           : undefined;
@@ -261,6 +271,11 @@ describe("cron task cancellation tracking", () => {
       });
       expect(getSuspensionVisibleCronTaskRunCount()).toBe(cancellableRuns + handlelessRuns);
     } finally {
+      release?.();
+      cancellableCore.resolve();
+      handlelessCore.resolve();
+      await Promise.allSettled([cancellableCore.promise, handlelessCore.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
       resetActiveCronTaskRunsForTests();
     }
@@ -269,16 +284,19 @@ describe("cron task cancellation tracking", () => {
   it("keeps suspension blocked until a timed-out core actually settles", async () => {
     resetActiveCronTaskRunsForTests();
     const controller = new AbortController();
-    let settle = () => {};
-    const core = new Promise<void>((resolve) => {
-      settle = resolve;
-    });
-    trackActiveCronTaskRunSettlement(core, controller.signal);
+    const core = createDeferred();
+    trackActiveCronTaskRunSettlement(core.promise, controller.signal);
     controller.abort();
 
-    expect(getSuspensionVisibleCronTaskRunCount()).toBe(1);
-    settle();
-    await core;
-    await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+    try {
+      expect(getSuspensionVisibleCronTaskRunCount()).toBe(1);
+      core.resolve();
+      await core.promise;
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+    } finally {
+      core.resolve();
+      await core.promise;
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+    }
   });
 });

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -36,7 +36,10 @@ import { loadCronStore, saveCronStore } from "../store.js";
 import { cronStoreKey } from "../store/key.js";
 import { readCronTaskRunHistoryPage } from "../task-run-history.js";
 import type { CronAgentExecutionPhaseUpdate, CronJob } from "../types.js";
-import { cancelActiveCronTaskRun } from "./active-run-cancellation.js";
+import {
+  cancelActiveCronTaskRun,
+  getSuspensionVisibleCronTaskRunCount,
+} from "./active-run-cancellation.js";
 import { resetActiveCronTaskRunsForTests } from "./active-run-cancellation.test-support.js";
 import { computeJobNextRunAtMs, recomputeNextRunsForMaintenance } from "./jobs-scheduling.js";
 import { stop } from "./ops-lifecycle.js";
@@ -461,67 +464,76 @@ describe("cron service timer regressions", () => {
     });
 
     const timerPromise = onTimer(state);
-    let settled = false;
-    void timerPromise.finally(() => {
-      settled = true;
-    });
+    try {
+      let settled = false;
+      void timerPromise.finally(() => {
+        settled = true;
+      });
 
-    await vi.advanceTimersByTimeAsync(0);
-    await Promise.resolve();
-    expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+      expect(settled).toBe(false);
 
-    deferredRun.resolve({ status: "ok", summary: "done" });
-    await timerPromise;
+      deferredRun.resolve({ status: "ok", summary: "done" });
+      await timerPromise;
 
-    const job = state.store?.jobs.find((entry) => entry.id === "no-timeout-0");
-    expect(job?.state.lastStatus).toBe("ok");
+      const job = state.store?.jobs.find((entry) => entry.id === "no-timeout-0");
+      expect(job?.state.lastStatus).toBe("ok");
+    } finally {
+      // Shared hooks clear timers and state; finish this core first.
+      stop(state);
+      deferredRun.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([timerPromise, deferredRun.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+    }
   });
 
   it("cancels timeout-disabled cron task runs without waiting for the runner", async () => {
     vi.useFakeTimers();
+    resetTaskRegistryForTests();
+    resetActiveCronTaskRunsForTests();
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:10:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "no-timeout-cancel",
+      name: "no timeout cancel",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "work", timeoutSeconds: 0 },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    const now = scheduledAt;
+    let abortObserved = false;
+    let timerSettled = false;
+    const runnerStarted = createDeferred();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
+        onExecutionStarted?.();
+        runnerStarted.resolve();
+        abortSignal?.addEventListener(
+          "abort",
+          () => {
+            abortObserved = true;
+          },
+          { once: true },
+        );
+        return await runnerResult.promise;
+      }),
+    });
+
+    const timerPromise = onTimer(state).then(() => {
+      timerSettled = true;
+    });
     try {
-      resetTaskRegistryForTests();
-      resetActiveCronTaskRunsForTests();
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-02-15T13:10:00.000Z");
-      const cronJob = createIsolatedRegressionJob({
-        id: "no-timeout-cancel",
-        name: "no timeout cancel",
-        scheduledAt,
-        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 0 },
-        state: { nextRunAtMs: scheduledAt },
-      });
-      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
-
-      const now = scheduledAt;
-      let abortObserved = false;
-      let timerSettled = false;
-      const runnerStarted = createDeferred();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
-          onExecutionStarted?.();
-          runnerStarted.resolve();
-          abortSignal?.addEventListener(
-            "abort",
-            () => {
-              abortObserved = true;
-            },
-            { once: true },
-          );
-          return await new Promise<never>(() => {});
-        }),
-      });
-
-      const timerPromise = onTimer(state).then(() => {
-        timerSettled = true;
-      });
       await runnerStarted.promise;
 
       const runId = `cron:no-timeout-cancel:${scheduledAt}`;
@@ -555,6 +567,10 @@ describe("cron service timer regressions", () => {
       expect(job.state.lastStatus).toBe("error");
       expect(job.state.lastError).toBe("Cancelled by operator.");
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([timerPromise, runnerResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
       resetActiveCronTaskRunsForTests();
       resetTaskRegistryControlRuntimeForTests();
@@ -612,21 +628,28 @@ describe("cron service timer regressions", () => {
     });
 
     const timerPromise = onTimer(state);
-    let settled = false;
-    void timerPromise.finally(() => {
-      settled = true;
-    });
+    try {
+      let settled = false;
+      void timerPromise.finally(() => {
+        settled = true;
+      });
 
-    await vi.advanceTimersByTimeAsync(10 * 60_000 + 1_000);
-    await Promise.resolve();
-    expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(10 * 60_000 + 1_000);
+      await Promise.resolve();
+      expect(settled).toBe(false);
 
-    deferredRun.resolve({ status: "ok", summary: "done" });
-    await timerPromise;
+      deferredRun.resolve({ status: "ok", summary: "done" });
+      await timerPromise;
 
-    const job = state.store?.jobs.find((entry) => entry.id === "agentturn-default-safety-window");
-    expect(job?.state.lastStatus).toBe("ok");
-    expect(job?.state.lastError).toBeUndefined();
+      const job = state.store?.jobs.find((entry) => entry.id === "agentturn-default-safety-window");
+      expect(job?.state.lastStatus).toBe("ok");
+      expect(job?.state.lastError).toBeUndefined();
+    } finally {
+      stop(state);
+      deferredRun.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([timerPromise, deferredRun.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+    }
   });
 
   it("aborts isolated runs when cron timeout fires", async () => {
@@ -676,38 +699,39 @@ describe("cron service timer regressions", () => {
 
   it("unwinds timed cron runs immediately after operator cancellation", async () => {
     vi.useFakeTimers();
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "cancel-before-timeout",
+      name: "cancel before timeout",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "work", timeoutSeconds: FAST_TIMEOUT_SECONDS },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    const now = scheduledAt;
+    const runnerStarted = createDeferred<AbortSignal | undefined>();
+    const cleanupTimedOutAgentRun = vi.fn(async () => {});
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      cleanupTimedOutAgentRun,
+      runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
+        onExecutionStarted?.();
+        runnerStarted.resolve(abortSignal);
+        return await runnerResult.promise;
+      }),
+    });
+
+    const timerPromise = onTimer(state);
     try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
-      const cronJob = createIsolatedRegressionJob({
-        id: "cancel-before-timeout",
-        name: "cancel before timeout",
-        scheduledAt,
-        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-        payload: { kind: "agentTurn", message: "work", timeoutSeconds: FAST_TIMEOUT_SECONDS },
-        state: { nextRunAtMs: scheduledAt },
-      });
-      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
-
-      const now = scheduledAt;
-      const runnerStarted = createDeferred<AbortSignal | undefined>();
-      const cleanupTimedOutAgentRun = vi.fn(async () => {});
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        cleanupTimedOutAgentRun,
-        runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
-          onExecutionStarted?.();
-          runnerStarted.resolve(abortSignal);
-          return await new Promise<never>(() => {});
-        }),
-      });
-
-      const timerPromise = onTimer(state);
       const observedAbortSignal = await runnerStarted.promise;
       const runId = `cron:cancel-before-timeout:${scheduledAt}`;
       let timerSettled = false;
@@ -738,51 +762,56 @@ describe("cron service timer regressions", () => {
       expect(job?.state.lastStatus).toBe("error");
       expect(job?.state.lastError).toBe("Cancelled by operator.");
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([timerPromise, runnerResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });
 
   it("keeps timed-out cron task runs from being overwritten by late cancellation", async () => {
     vi.useFakeTimers();
+    resetTaskRegistryForTests();
+    resetActiveCronTaskRunsForTests();
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:30:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "late-cancel-after-timeout",
+      name: "late cancel after timeout",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "work", timeoutSeconds: FAST_TIMEOUT_SECONDS },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    let now = scheduledAt;
+    const runnerStarted = createDeferred();
+    const cleanupStarted = createDeferred();
+    const releaseCleanup = createDeferred();
+    const cleanupTimedOutAgentRun = vi.fn(async () => {
+      cleanupStarted.resolve();
+      await releaseCleanup.promise;
+    });
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      cleanupTimedOutAgentRun,
+      runIsolatedAgentJob: vi.fn(async ({ onExecutionStarted }) => {
+        onExecutionStarted?.();
+        runnerStarted.resolve();
+        return await runnerResult.promise;
+      }),
+    });
+
+    const timerPromise = onTimer(state);
     try {
-      resetTaskRegistryForTests();
-      resetActiveCronTaskRunsForTests();
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-02-15T13:30:00.000Z");
-      const cronJob = createIsolatedRegressionJob({
-        id: "late-cancel-after-timeout",
-        name: "late cancel after timeout",
-        scheduledAt,
-        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-        payload: { kind: "agentTurn", message: "work", timeoutSeconds: FAST_TIMEOUT_SECONDS },
-        state: { nextRunAtMs: scheduledAt },
-      });
-      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
-
-      let now = scheduledAt;
-      const runnerStarted = createDeferred();
-      const cleanupStarted = createDeferred();
-      const releaseCleanup = createDeferred();
-      const cleanupTimedOutAgentRun = vi.fn(async () => {
-        cleanupStarted.resolve();
-        await releaseCleanup.promise;
-      });
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        cleanupTimedOutAgentRun,
-        runIsolatedAgentJob: vi.fn(async ({ onExecutionStarted }) => {
-          onExecutionStarted?.();
-          runnerStarted.resolve();
-          return await new Promise<never>(() => {});
-        }),
-      });
-
-      const timerPromise = onTimer(state);
       await runnerStarted.promise;
       await vi.advanceTimersByTimeAsync(Math.ceil(FAST_TIMEOUT_SECONDS * 1_000) + 10);
       now += Math.ceil(FAST_TIMEOUT_SECONDS * 1_000) + 10;
@@ -816,6 +845,11 @@ describe("cron service timer regressions", () => {
       expect(finalTask?.status).toBe("timed_out");
       expect(finalTask?.error).toContain("timed out");
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      releaseCleanup.resolve();
+      await Promise.allSettled([timerPromise, runnerResult.promise, releaseCleanup.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
       resetActiveCronTaskRunsForTests();
       resetTaskRegistryControlRuntimeForTests();
@@ -825,52 +859,48 @@ describe("cron service timer regressions", () => {
 
   it("does not spend isolated execution timeout while waiting for the runner lane (#41783)", async () => {
     vi.useFakeTimers();
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "timeout-after-lane-start",
+      name: "timeout after lane start",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "work", timeoutSeconds: FAST_TIMEOUT_SECONDS },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    let now = scheduledAt;
+    const runnerEntered = createDeferred();
+    const laneAcquired = createDeferred();
+    let observedAbortSignal: AbortSignal | undefined;
+    const finishRunner = createDeferred();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
+        observedAbortSignal = abortSignal;
+        runnerEntered.resolve();
+        await laneAcquired.promise;
+        onExecutionStarted?.();
+        if (!abortSignal || abortSignal.aborted) {
+          finishRunner.resolve();
+        } else {
+          abortSignal.addEventListener("abort", () => finishRunner.resolve(), { once: true });
+        }
+        await finishRunner.promise;
+        now += 5;
+        return { status: "ok" as const, summary: "late" };
+      }),
+    });
+
+    const timerPromise = onTimer(state);
     try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
-      const cronJob = createIsolatedRegressionJob({
-        id: "timeout-after-lane-start",
-        name: "timeout after lane start",
-        scheduledAt,
-        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-        payload: { kind: "agentTurn", message: "work", timeoutSeconds: FAST_TIMEOUT_SECONDS },
-        state: { nextRunAtMs: scheduledAt },
-      });
-      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
-
-      let now = scheduledAt;
-      const runnerEntered = createDeferred();
-      const laneAcquired = createDeferred();
-      let observedAbortSignal: AbortSignal | undefined;
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
-          observedAbortSignal = abortSignal;
-          runnerEntered.resolve();
-          await laneAcquired.promise;
-          onExecutionStarted?.();
-          await new Promise<void>((resolve) => {
-            if (!abortSignal) {
-              resolve();
-              return;
-            }
-            if (abortSignal.aborted) {
-              resolve();
-              return;
-            }
-            abortSignal.addEventListener("abort", () => resolve(), { once: true });
-          });
-          now += 5;
-          return { status: "ok" as const, summary: "late" };
-        }),
-      });
-
-      const timerPromise = onTimer(state);
       await runnerEntered.promise;
       await vi.advanceTimersByTimeAsync(Math.ceil(FAST_TIMEOUT_SECONDS * 1_000) + 10);
       expect(observedAbortSignal?.aborted).toBe(false);
@@ -887,78 +917,84 @@ describe("cron service timer regressions", () => {
       expect(job?.state.lastStatus).toBe("error");
       expect(job?.state.lastError).toContain("timed out");
     } finally {
+      stop(state);
+      laneAcquired.resolve();
+      finishRunner.resolve();
+      await Promise.allSettled([timerPromise, laneAcquired.promise, finishRunner.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });
 
   it("keeps resolved provider/model/session on isolated post-runner timeout rows (#95873)", async () => {
     vi.useFakeTimers();
+    resetTaskRegistryForTests();
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "timeout-attribution",
+      name: "timeout attribution",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "work", timeoutSeconds: FAST_TIMEOUT_SECONDS },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    const activeJobMarker = markCronJobActive(cronJob.id);
+
+    let now = scheduledAt;
+    const runnerEntered = createDeferred();
+    const finishRunner = createDeferred();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
+        // Report the resolved run identity the same way the real runner does,
+        // then hang past the wall-clock watchdog so the timer-built timeout
+        // outcome (not the discarded inner result) is what reaches the row.
+        onExecutionStarted?.({
+          jobId: cronJob.id,
+          phase: "tool_execution_started",
+          provider: "deepseek",
+          model: "deepseek-v4-pro",
+          sessionId: "sess-attrib",
+          sessionKey: "key-attrib",
+        });
+        runnerEntered.resolve();
+        if (!abortSignal || abortSignal.aborted) {
+          finishRunner.resolve();
+        } else {
+          abortSignal.addEventListener("abort", () => finishRunner.resolve(), { once: true });
+        }
+        await finishRunner.promise;
+        now += 5;
+        return { status: "ok" as const, summary: "late" };
+      }),
+    });
+
+    const resultPromise = executeJobCoreWithTimeout(state, cronJob, { activeJobMarker });
     try {
-      resetTaskRegistryForTests();
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
-      const cronJob = createIsolatedRegressionJob({
-        id: "timeout-attribution",
-        name: "timeout attribution",
-        scheduledAt,
-        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-        payload: { kind: "agentTurn", message: "work", timeoutSeconds: FAST_TIMEOUT_SECONDS },
-        state: { nextRunAtMs: scheduledAt },
-      });
-      const activeJobMarker = markCronJobActive(cronJob.id);
+      await runnerEntered.promise;
+      await vi.advanceTimersByTimeAsync(Math.ceil(FAST_TIMEOUT_SECONDS * 1_000) + 10);
+      const result = await resultPromise;
 
-      let now = scheduledAt;
-      const runnerEntered = createDeferred();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
-          // Report the resolved run identity the same way the real runner does,
-          // then hang past the wall-clock watchdog so the timer-built timeout
-          // outcome (not the discarded inner result) is what reaches the row.
-          onExecutionStarted?.({
-            jobId: cronJob.id,
-            phase: "tool_execution_started",
-            provider: "deepseek",
-            model: "deepseek-v4-pro",
-            sessionId: "sess-attrib",
-            sessionKey: "key-attrib",
-          });
-          runnerEntered.resolve();
-          await new Promise<void>((resolve) => {
-            if (!abortSignal || abortSignal.aborted) {
-              resolve();
-              return;
-            }
-            abortSignal.addEventListener("abort", () => resolve(), { once: true });
-          });
-          now += 5;
-          return { status: "ok" as const, summary: "late" };
-        }),
-      });
-
-      try {
-        const resultPromise = executeJobCoreWithTimeout(state, cronJob, { activeJobMarker });
-        await runnerEntered.promise;
-        await vi.advanceTimersByTimeAsync(Math.ceil(FAST_TIMEOUT_SECONDS * 1_000) + 10);
-        const result = await resultPromise;
-
-        expect(result.status).toBe("error");
-        expect(result.error).toContain("timed out");
-        // #95873: a post-runner timeout must not blank out task-run history; the
-        // already-resolved attribution carried by the watchdog survives the row.
-        expect(result.provider).toBe("deepseek");
-        expect(result.model).toBe("deepseek-v4-pro");
-        expect(result.sessionId).toBe("sess-attrib");
-        expect(result.sessionKey).toBe("key-attrib");
-      } finally {
-        clearCronJobActive(cronJob.id, activeJobMarker);
-      }
+      expect(result.status).toBe("error");
+      expect(result.error).toContain("timed out");
+      // #95873: a post-runner timeout must not blank out task-run history; the
+      // already-resolved attribution carried by the watchdog survives the row.
+      expect(result.provider).toBe("deepseek");
+      expect(result.model).toBe("deepseek-v4-pro");
+      expect(result.sessionId).toBe("sess-attrib");
+      expect(result.sessionKey).toBe("key-attrib");
     } finally {
+      stop(state);
+      finishRunner.resolve();
+      await Promise.allSettled([resultPromise, finishRunner.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+      clearCronJobActive(cronJob.id, activeJobMarker);
       resetActiveCronTaskRunsForTests();
       resetTaskRegistryForTests();
       vi.useRealTimers();
@@ -967,72 +1003,74 @@ describe("cron service timer regressions", () => {
 
   it("keeps resolved provider/model/session on timeout-disabled cancel rows (#95873)", async () => {
     vi.useFakeTimers();
+    resetTaskRegistryForTests();
+    resetActiveCronTaskRunsForTests();
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:20:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "no-timeout-cancel-attribution",
+      name: "no timeout cancel attribution",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      // timeoutSeconds: 0 takes the no-watchdog branch, so attribution has to
+      // be tracked from the execution callbacks directly (no watchdog snapshot).
+      payload: { kind: "agentTurn", message: "work", timeoutSeconds: 0 },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    const activeJobMarker = markCronJobActive(cronJob.id);
+
+    const now = scheduledAt;
+    const runnerEntered = createDeferred();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async ({ onExecutionStarted }) => {
+        onExecutionStarted?.({
+          jobId: cronJob.id,
+          phase: "tool_execution_started",
+          provider: "deepseek",
+          model: "deepseek-v4-pro",
+          sessionId: "sess-attrib",
+          sessionKey: "key-attrib",
+        });
+        runnerEntered.resolve();
+        return await runnerResult.promise;
+      }),
+    });
+
+    const runId = `cron:no-timeout-cancel-attribution:${scheduledAt}`;
+    const resultPromise = executeJobCoreWithTimeout(state, cronJob, {
+      runId,
+      activeJobMarker,
+    });
     try {
-      resetTaskRegistryForTests();
-      resetActiveCronTaskRunsForTests();
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-02-15T13:20:00.000Z");
-      const cronJob = createIsolatedRegressionJob({
-        id: "no-timeout-cancel-attribution",
-        name: "no timeout cancel attribution",
-        scheduledAt,
-        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-        // timeoutSeconds: 0 takes the no-watchdog branch, so attribution has to
-        // be tracked from the execution callbacks directly (no watchdog snapshot).
-        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 0 },
-        state: { nextRunAtMs: scheduledAt },
+      await runnerEntered.promise;
+      const cancelled = cancelActiveCronTaskRun({
+        runId,
+        reason: "Cancelled by operator.",
       });
-      const activeJobMarker = markCronJobActive(cronJob.id);
+      expect(cancelled).toBe(true);
+      const result = await resultPromise;
 
-      const now = scheduledAt;
-      const runnerEntered = createDeferred();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        runIsolatedAgentJob: vi.fn(async ({ onExecutionStarted }) => {
-          onExecutionStarted?.({
-            jobId: cronJob.id,
-            phase: "tool_execution_started",
-            provider: "deepseek",
-            model: "deepseek-v4-pro",
-            sessionId: "sess-attrib",
-            sessionKey: "key-attrib",
-          });
-          runnerEntered.resolve();
-          return await new Promise<never>(() => {});
-        }),
-      });
-
-      const runId = `cron:no-timeout-cancel-attribution:${scheduledAt}`;
-      try {
-        const resultPromise = executeJobCoreWithTimeout(state, cronJob, {
-          runId,
-          activeJobMarker,
-        });
-        await runnerEntered.promise;
-        const cancelled = cancelActiveCronTaskRun({
-          runId,
-          reason: "Cancelled by operator.",
-        });
-        expect(cancelled).toBe(true);
-        const result = await resultPromise;
-
-        expect(result.status).toBe("error");
-        expect(result.error).toBe("Cancelled by operator.");
-        // #95873 sibling: a timeout-disabled operator-cancel row keeps the
-        // already-resolved attribution instead of going blank.
-        expect(result.provider).toBe("deepseek");
-        expect(result.model).toBe("deepseek-v4-pro");
-        expect(result.sessionId).toBe("sess-attrib");
-        expect(result.sessionKey).toBe("key-attrib");
-      } finally {
-        clearCronJobActive(cronJob.id, activeJobMarker);
-      }
+      expect(result.status).toBe("error");
+      expect(result.error).toBe("Cancelled by operator.");
+      // #95873 sibling: a timeout-disabled operator-cancel row keeps the
+      // already-resolved attribution instead of going blank.
+      expect(result.provider).toBe("deepseek");
+      expect(result.model).toBe("deepseek-v4-pro");
+      expect(result.sessionId).toBe("sess-attrib");
+      expect(result.sessionKey).toBe("key-attrib");
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([resultPromise, runnerResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+      clearCronJobActive(cronJob.id, activeJobMarker);
       resetActiveCronTaskRunsForTests();
       resetTaskRegistryForTests();
       vi.useRealTimers();
@@ -1171,41 +1209,41 @@ describe("cron service timer regressions", () => {
 
   it("notifies setup timeout after startup catch-up finalization", async () => {
     vi.useFakeTimers();
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:02:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "startup-setup-timeout",
+      name: "startup setup timeout",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "work", timeoutSeconds: 120 },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    vi.setSystemTime(scheduledAt);
+    let now = scheduledAt;
+    const started = createDeferred();
+    let observedAbortSignal: AbortSignal | undefined;
+    const onIsolatedAgentSetupTimeout = vi.fn();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      onIsolatedAgentSetupTimeout,
+      runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        observedAbortSignal = abortSignal;
+        started.resolve();
+        return await runnerResult.promise;
+      }),
+    });
+
+    const catchupPromise = runMissedJobs(state);
     try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-02-15T13:02:00.000Z");
-      const cronJob = createIsolatedRegressionJob({
-        id: "startup-setup-timeout",
-        name: "startup setup timeout",
-        scheduledAt,
-        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 120 },
-        state: { nextRunAtMs: scheduledAt },
-      });
-      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
-
-      vi.setSystemTime(scheduledAt);
-      let now = scheduledAt;
-      const started = createDeferred();
-      let observedAbortSignal: AbortSignal | undefined;
-      const onIsolatedAgentSetupTimeout = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        onIsolatedAgentSetupTimeout,
-        runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
-          observedAbortSignal = abortSignal;
-          started.resolve();
-          abortSignal?.addEventListener("abort", () => undefined, { once: true });
-          return await new Promise<never>(() => {});
-        }),
-      });
-
-      const catchupPromise = runMissedJobs(state);
       await started.promise;
       await vi.advanceTimersByTimeAsync(60_100);
       now += 60_100;
@@ -1221,43 +1259,47 @@ describe("cron service timer regressions", () => {
         timeoutMs: 60_000,
       });
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([catchupPromise, runnerResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });
 
   it("keeps scheduling after setup timeout without a notification handler", async () => {
     vi.useFakeTimers();
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:03:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "setup-timeout-no-handler",
+      name: "setup timeout no handler",
+      scheduledAt,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: scheduledAt },
+      payload: { kind: "agentTurn", message: "work", timeoutSeconds: 120 },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    vi.setSystemTime(scheduledAt);
+    let now = scheduledAt;
+    const started = createDeferred();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        started.resolve();
+        return await runnerResult.promise;
+      }),
+    });
+
+    const timerPromise = onTimer(state);
     try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-02-15T13:03:00.000Z");
-      const cronJob = createIsolatedRegressionJob({
-        id: "setup-timeout-no-handler",
-        name: "setup timeout no handler",
-        scheduledAt,
-        schedule: { kind: "every", everyMs: 60_000, anchorMs: scheduledAt },
-        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 120 },
-        state: { nextRunAtMs: scheduledAt },
-      });
-      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
-
-      vi.setSystemTime(scheduledAt);
-      let now = scheduledAt;
-      const started = createDeferred();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
-          started.resolve();
-          abortSignal?.addEventListener("abort", () => undefined, { once: true });
-          return await new Promise<never>(() => {});
-        }),
-      });
-
-      const timerPromise = onTimer(state);
       await started.promise;
       await vi.advanceTimersByTimeAsync(60_100);
       now += 60_100;
@@ -1265,6 +1307,10 @@ describe("cron service timer regressions", () => {
 
       expect(state.timer).not.toBeNull();
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([timerPromise, runnerResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });
@@ -1431,46 +1477,46 @@ describe("cron service timer regressions", () => {
 
   it("keeps user cancellation disabled for main-session cron wrappers", async () => {
     vi.useFakeTimers();
+    resetTaskRegistryForTests();
+
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+    const cronJob: CronJob = {
+      id: "main-session-cancel-boundary",
+      name: "main session cancel boundary",
+      enabled: true,
+      createdAtMs: scheduledAt - 60_000,
+      updatedAtMs: scheduledAt - 60_000,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "queued downstream work" },
+      state: { nextRunAtMs: scheduledAt },
+    };
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    let now = scheduledAt;
+    const heartbeatResult = createDeferred<HeartbeatRunResult>();
+    const runHeartbeatOnce = vi.fn(async (): Promise<HeartbeatRunResult> => {
+      return await heartbeatResult.promise;
+    });
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runHeartbeatOnce,
+      wakeNowHeartbeatBusyMaxWaitMs: 1_000,
+      wakeNowHeartbeatBusyRetryDelayMs: 50,
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+
+    const timerPromise = onTimer(state);
     try {
-      resetTaskRegistryForTests();
-
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
-      const cronJob: CronJob = {
-        id: "main-session-cancel-boundary",
-        name: "main session cancel boundary",
-        enabled: true,
-        createdAtMs: scheduledAt - 60_000,
-        updatedAtMs: scheduledAt - 60_000,
-        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-        sessionTarget: "main",
-        wakeMode: "now",
-        payload: { kind: "systemEvent", text: "queued downstream work" },
-        state: { nextRunAtMs: scheduledAt },
-      };
-      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
-
-      let now = scheduledAt;
-      const heartbeatResult = createDeferred<HeartbeatRunResult>();
-      const runHeartbeatOnce = vi.fn(async (): Promise<HeartbeatRunResult> => {
-        return await heartbeatResult.promise;
-      });
-      const enqueueSystemEvent = vi.fn();
-      const requestHeartbeat = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent,
-        requestHeartbeat,
-        runHeartbeatOnce,
-        wakeNowHeartbeatBusyMaxWaitMs: 1_000,
-        wakeNowHeartbeatBusyRetryDelayMs: 50,
-        runIsolatedAgentJob: createDefaultIsolatedRunner(),
-      });
-
-      const timerPromise = onTimer(state);
       const runId = `cron:main-session-cancel-boundary:${scheduledAt}`;
       for (
         let attempt = 0;
@@ -1523,6 +1569,10 @@ describe("cron service timer regressions", () => {
       );
       expect(requestHeartbeat.mock.calls[0]?.[0]).not.toHaveProperty("sessionKey");
     } finally {
+      stop(state);
+      heartbeatResult.resolve({ status: "ran", durationMs: 0 });
+      await Promise.allSettled([timerPromise, heartbeatResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       resetActiveCronTaskRunsForTests();
       resetTaskRegistryControlRuntimeForTests();
       resetTaskRegistryForTests();
@@ -1532,63 +1582,63 @@ describe("cron service timer regressions", () => {
 
   it("allows cancellation of detached script work targeting the main session", async () => {
     vi.useFakeTimers();
+    resetTaskRegistryForTests();
+    resetActiveCronTaskRunsForTests();
+
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-07-18T12:00:00.000Z");
+    const cronJob: CronJob = {
+      id: "main-script-cancel-boundary",
+      name: "main script cancel boundary",
+      enabled: true,
+      createdAtMs: scheduledAt - 60_000,
+      updatedAtMs: scheduledAt - 60_000,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "script", script: "return { notify: 'done' }", timeoutSeconds: 0 },
+      state: { nextRunAtMs: scheduledAt },
+    };
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    let abortObserved = false;
+    let timerSettled = false;
+    const runnerStarted = createDeferred();
+    const runnerResult = createDeferred<{
+      status: "ok";
+      notify: string;
+      wake: "now";
+    }>();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      cronConfig: { triggers: { enabled: true } },
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+      runScriptJob: vi.fn(async ({ abortSignal }) => {
+        runnerStarted.resolve();
+        abortSignal?.addEventListener(
+          "abort",
+          () => {
+            abortObserved = true;
+          },
+          { once: true },
+        );
+        // Deliberately ignore abort so the cron boundary must suppress any
+        // late notify/wake result after operator cancellation has settled.
+        return await runnerResult.promise;
+      }),
+    });
+
+    const timerPromise = onTimer(state).then(() => {
+      timerSettled = true;
+    });
     try {
-      resetTaskRegistryForTests();
-      resetActiveCronTaskRunsForTests();
-
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-07-18T12:00:00.000Z");
-      const cronJob: CronJob = {
-        id: "main-script-cancel-boundary",
-        name: "main script cancel boundary",
-        enabled: true,
-        createdAtMs: scheduledAt - 60_000,
-        updatedAtMs: scheduledAt - 60_000,
-        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-        sessionTarget: "main",
-        wakeMode: "now",
-        payload: { kind: "script", script: "return { notify: 'done' }", timeoutSeconds: 0 },
-        state: { nextRunAtMs: scheduledAt },
-      };
-      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
-
-      let abortObserved = false;
-      let timerSettled = false;
-      const runnerStarted = createDeferred();
-      const runnerResult = createDeferred<{
-        status: "ok";
-        notify: string;
-        wake: "now";
-      }>();
-      const enqueueSystemEvent = vi.fn();
-      const requestHeartbeat = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        cronConfig: { triggers: { enabled: true } },
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => scheduledAt,
-        enqueueSystemEvent,
-        requestHeartbeat,
-        runIsolatedAgentJob: createDefaultIsolatedRunner(),
-        runScriptJob: vi.fn(async ({ abortSignal }) => {
-          runnerStarted.resolve();
-          abortSignal?.addEventListener(
-            "abort",
-            () => {
-              abortObserved = true;
-            },
-            { once: true },
-          );
-          // Deliberately ignore abort so the cron boundary must suppress any
-          // late notify/wake result after operator cancellation has settled.
-          return await runnerResult.promise;
-        }),
-      });
-
-      const timerPromise = onTimer(state).then(() => {
-        timerSettled = true;
-      });
       await runnerStarted.promise;
 
       const task = findCronTaskByBaseRunId(`cron:${cronJob.id}:${scheduledAt}`);
@@ -1624,6 +1674,10 @@ describe("cron service timer regressions", () => {
       expect(enqueueSystemEvent).not.toHaveBeenCalled();
       expect(requestHeartbeat).not.toHaveBeenCalled();
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", notify: "stale", wake: "now" });
+      await Promise.allSettled([timerPromise, runnerResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       resetActiveCronTaskRunsForTests();
       resetTaskRegistryControlRuntimeForTests();
       resetTaskRegistryForTests();
@@ -1633,45 +1687,45 @@ describe("cron service timer regressions", () => {
 
   it("keeps main-session cron wrappers visible across restart generation advance", async () => {
     vi.useFakeTimers();
+    resetTaskRegistryForTests();
+
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-02-15T13:03:00.000Z");
+    const cronJob: CronJob = {
+      id: "main-session-generation-visible",
+      name: "main session generation visible",
+      enabled: true,
+      createdAtMs: scheduledAt - 60_000,
+      updatedAtMs: scheduledAt - 60_000,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "queued downstream work" },
+      state: { nextRunAtMs: scheduledAt },
+    };
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    let now = scheduledAt;
+    const heartbeatResult = createDeferred<HeartbeatRunResult>();
+    const runHeartbeatOnce = vi.fn(async (): Promise<HeartbeatRunResult> => {
+      return await heartbeatResult.promise;
+    });
+    const requestHeartbeat = vi.fn();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat,
+      runHeartbeatOnce,
+      wakeNowHeartbeatBusyMaxWaitMs: 1_000,
+      wakeNowHeartbeatBusyRetryDelayMs: 50,
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+
+    const timerPromise = onTimer(state);
     try {
-      resetTaskRegistryForTests();
-
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-02-15T13:03:00.000Z");
-      const cronJob: CronJob = {
-        id: "main-session-generation-visible",
-        name: "main session generation visible",
-        enabled: true,
-        createdAtMs: scheduledAt - 60_000,
-        updatedAtMs: scheduledAt - 60_000,
-        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
-        sessionTarget: "main",
-        wakeMode: "now",
-        payload: { kind: "systemEvent", text: "queued downstream work" },
-        state: { nextRunAtMs: scheduledAt },
-      };
-      await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
-
-      let now = scheduledAt;
-      const heartbeatResult = createDeferred<HeartbeatRunResult>();
-      const runHeartbeatOnce = vi.fn(async (): Promise<HeartbeatRunResult> => {
-        return await heartbeatResult.promise;
-      });
-      const requestHeartbeat = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat,
-        runHeartbeatOnce,
-        wakeNowHeartbeatBusyMaxWaitMs: 1_000,
-        wakeNowHeartbeatBusyRetryDelayMs: 50,
-        runIsolatedAgentJob: createDefaultIsolatedRunner(),
-      });
-
-      const timerPromise = onTimer(state);
       for (
         let attempt = 0;
         attempt < 10 && runHeartbeatOnce.mock.calls.length === 0;
@@ -1699,6 +1753,10 @@ describe("cron service timer regressions", () => {
       );
       expect(isCronJobActive(cronJob.id)).toBe(false);
     } finally {
+      stop(state);
+      heartbeatResult.resolve({ status: "ran", durationMs: 0 });
+      await Promise.allSettled([timerPromise, heartbeatResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       resetActiveCronTaskRunsForTests();
       resetTaskRegistryControlRuntimeForTests();
       resetTaskRegistryForTests();
@@ -1741,8 +1799,8 @@ describe("cron service timer regressions", () => {
       }),
     });
 
+    const timerPromise = onTimer(state);
     try {
-      const timerPromise = onTimer(state);
       await entered.promise;
       expect(isCronJobActive(cronJob.id)).toBe(true);
 
@@ -1756,6 +1814,10 @@ describe("cron service timer regressions", () => {
       expect(state.deps.enqueueSystemEvent).not.toHaveBeenCalled();
       expect(state.deps.requestHeartbeat).not.toHaveBeenCalled();
     } finally {
+      stop(state);
+      release.resolve({ status: "ok", notify: "stale" });
+      await Promise.allSettled([timerPromise, release.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       resetActiveCronTaskRunsForTests();
     }
   });
@@ -1819,17 +1881,24 @@ describe("cron service timer regressions", () => {
     });
 
     const timerPromise = onTimer(state);
-    await entered.promise;
-    expect(isCronJobActive(cronJob.id)).toBe(true);
+    try {
+      await entered.promise;
+      expect(isCronJobActive(cronJob.id)).toBe(true);
 
-    advanceCronActiveJobGeneration();
-    release.resolve({ status: "ok", summary: "stale success" });
-    await timerPromise;
+      advanceCronActiveJobGeneration();
+      release.resolve({ status: "ok", summary: "stale success" });
+      await timerPromise;
 
-    const persisted = await loadCronStore(store.storePath);
-    const persistedJob = persisted.jobs.find((job) => job.id === cronJob.id);
-    expect(persistedJob?.state.lastStatus).toBe("ok");
-    expect(persistedJob?.state.runningAtMs).toBeUndefined();
+      const persisted = await loadCronStore(store.storePath);
+      const persistedJob = persisted.jobs.find((job) => job.id === cronJob.id);
+      expect(persistedJob?.state.lastStatus).toBe("ok");
+      expect(persistedJob?.state.runningAtMs).toBeUndefined();
+    } finally {
+      stop(state);
+      release.resolve({ status: "ok", summary: "stale success" });
+      await Promise.allSettled([timerPromise, release.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+    }
   });
 
   it("releases due-job reservations instead of admitting workers after scheduler stop wins", async () => {
@@ -2035,37 +2104,49 @@ describe("cron service timer regressions", () => {
     });
 
     const timerRun = onTimer(state);
-    await firstStarted.promise;
-    expect(state.store?.jobs.find((job) => job.id === second.id)?.state.queuedAtMs).toBeUndefined();
-    expect(state.queuedRunReservationsByJobId.has(second.id)).toBe(false);
-    now += 2 * 60 * 60 * 1000 + 1;
-    recomputeNextRunsForMaintenance(state);
-    expect(state.store?.jobs.find((job) => job.id === second.id)?.state.queuedAtMs).toBeUndefined();
+    try {
+      await firstStarted.promise;
+      expect(
+        state.store?.jobs.find((job) => job.id === second.id)?.state.queuedAtMs,
+      ).toBeUndefined();
+      expect(state.queuedRunReservationsByJobId.has(second.id)).toBe(false);
+      now += 2 * 60 * 60 * 1000 + 1;
+      recomputeNextRunsForMaintenance(state);
+      expect(
+        state.store?.jobs.find((job) => job.id === second.id)?.state.queuedAtMs,
+      ).toBeUndefined();
 
-    releaseFirst.resolve({ status: "ok", summary: "first" });
-    await secondStarted.promise;
-    const secondStartedAt = now;
-    expect(state.store?.jobs.find((job) => job.id === second.id)?.state.runningAtMs).toBe(
-      secondStartedAt,
-    );
-    expect(
-      (await loadCronStore(store.storePath))?.jobs.find((job) => job.id === second.id)?.state
-        .runningAtMs,
-    ).toBe(secondStartedAt);
-    expect(state.queuedRunReservationsByJobId.has(second.id)).toBe(true);
-    now += 2 * 60 * 60 * 1000 + 1;
-    recomputeNextRunsForMaintenance(state);
-    expect(state.store?.jobs.find((job) => job.id === second.id)?.state.runningAtMs).toBe(
-      secondStartedAt,
-    );
-    now += 100;
-    releaseSecond.resolve({ status: "ok", summary: "second" });
+      releaseFirst.resolve({ status: "ok", summary: "first" });
+      await secondStarted.promise;
+      const secondStartedAt = now;
+      expect(state.store?.jobs.find((job) => job.id === second.id)?.state.runningAtMs).toBe(
+        secondStartedAt,
+      );
+      expect(
+        (await loadCronStore(store.storePath))?.jobs.find((job) => job.id === second.id)?.state
+          .runningAtMs,
+      ).toBe(secondStartedAt);
+      expect(state.queuedRunReservationsByJobId.has(second.id)).toBe(true);
+      now += 2 * 60 * 60 * 1000 + 1;
+      recomputeNextRunsForMaintenance(state);
+      expect(state.store?.jobs.find((job) => job.id === second.id)?.state.runningAtMs).toBe(
+        secondStartedAt,
+      );
+      now += 100;
+      releaseSecond.resolve({ status: "ok", summary: "second" });
 
-    await timerRun;
-    const completedSecond = state.store?.jobs.find((job) => job.id === second.id);
-    expect(completedSecond?.state.lastRunAtMs).toBe(secondStartedAt);
-    expect(completedSecond?.state.lastDurationMs).toBe(2 * 60 * 60 * 1000 + 101);
-    expect(state.queuedRunReservationsByJobId.has(second.id)).toBe(false);
+      await timerRun;
+      const completedSecond = state.store?.jobs.find((job) => job.id === second.id);
+      expect(completedSecond?.state.lastRunAtMs).toBe(secondStartedAt);
+      expect(completedSecond?.state.lastDurationMs).toBe(2 * 60 * 60 * 1000 + 101);
+      expect(state.queuedRunReservationsByJobId.has(second.id)).toBe(false);
+    } finally {
+      stop(state);
+      releaseFirst.resolve({ status: "ok", summary: "first" });
+      releaseSecond.resolve({ status: "ok", summary: "second" });
+      await Promise.allSettled([timerRun, releaseFirst.promise, releaseSecond.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+    }
   });
 
   it("rechecks startup catch-up eligibility after an admission wait", async () => {
@@ -2104,39 +2185,51 @@ describe("cron service timer regressions", () => {
     });
 
     const activeRun = runManualCronJob(state, activeManualJob.id, "force");
-    await activeStarted.promise;
-    const catchupRun = runMissedJobs(state);
-    await vi.waitFor(() => {
-      expect(state.store?.jobs.find((job) => job.id === catchupJob.id)?.state.queuedAtMs).toBe(
-        dueAt,
-      );
-    });
+    let catchupRun: ReturnType<typeof runMissedJobs> | undefined;
+    try {
+      await activeStarted.promise;
+      catchupRun = runMissedJobs(state);
+      await vi.waitFor(() => {
+        expect(state.store?.jobs.find((job) => job.id === catchupJob.id)?.state.queuedAtMs).toBe(
+          dueAt,
+        );
+      });
 
-    const rescheduledStore = await loadCronStore(store.storePath);
-    const rescheduledJob = rescheduledStore.jobs.find((job) => job.id === catchupJob.id);
-    if (!rescheduledJob) {
-      throw new Error("Expected startup catch-up job");
+      const rescheduledStore = await loadCronStore(store.storePath);
+      const rescheduledJob = rescheduledStore.jobs.find((job) => job.id === catchupJob.id);
+      if (!rescheduledJob) {
+        throw new Error("Expected startup catch-up job");
+      }
+      rescheduledJob.state.nextRunAtMs = dueAt + 3_600_000;
+      await saveCronStore(store.storePath, rescheduledStore);
+
+      releaseActive.resolve({ status: "ok", summary: "manual" });
+      await Promise.all([activeRun, catchupRun]);
+
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(
+        state.store?.jobs.find((job) => job.id === catchupJob.id)?.state.runningAtMs,
+      ).toBeUndefined();
+      expect(
+        (await loadCronStore(store.storePath)).jobs.find((job) => job.id === catchupJob.id)?.state
+          .runningAtMs,
+      ).toBeUndefined();
+      const receipt = openOpenClawStateDatabase()
+        .db.prepare(
+          "SELECT status FROM cron_run_receipts WHERE store_key = ? AND job_id = ? ORDER BY started_at_ms DESC LIMIT 1",
+        )
+        .get(cronStoreKey(store.storePath), catchupJob.id) as { status: string } | undefined;
+      expect(receipt?.status).toBe("skipped");
+    } finally {
+      stop(state);
+      releaseActive.resolve({ status: "ok", summary: "manual" });
+      await Promise.allSettled([
+        activeRun,
+        ...(catchupRun ? [catchupRun] : []),
+        releaseActive.promise,
+      ]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
     }
-    rescheduledJob.state.nextRunAtMs = dueAt + 3_600_000;
-    await saveCronStore(store.storePath, rescheduledStore);
-
-    releaseActive.resolve({ status: "ok", summary: "manual" });
-    await Promise.all([activeRun, catchupRun]);
-
-    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
-    expect(
-      state.store?.jobs.find((job) => job.id === catchupJob.id)?.state.runningAtMs,
-    ).toBeUndefined();
-    expect(
-      (await loadCronStore(store.storePath)).jobs.find((job) => job.id === catchupJob.id)?.state
-        .runningAtMs,
-    ).toBeUndefined();
-    const receipt = openOpenClawStateDatabase()
-      .db.prepare(
-        "SELECT status FROM cron_run_receipts WHERE store_key = ? AND job_id = ? ORDER BY started_at_ms DESC LIMIT 1",
-      )
-      .get(cronStoreKey(store.storePath), catchupJob.id) as { status: string } | undefined;
-    expect(receipt?.status).toBe("skipped");
   });
 
   it("does not start an admitted due job after stop wins its service-lock wait", async () => {
@@ -2179,57 +2272,64 @@ describe("cron service timer regressions", () => {
     });
 
     const timerRun = onTimer(state);
-    await serviceLockHeld.promise;
-    stop(state);
-    releaseServiceLock.resolve();
-    await timerRun;
+    try {
+      await serviceLockHeld.promise;
+      stop(state);
+      releaseServiceLock.resolve();
+      await timerRun;
 
-    expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+    } finally {
+      stop(state);
+      releaseServiceLock.resolve();
+      await Promise.allSettled([timerRun, releaseServiceLock.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+    }
   });
 
   it("sends one setup-timeout notification when a concurrent cron batch stalls before runners start", async () => {
     vi.useFakeTimers();
+    const store = timerRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:06:01.000Z");
+    const first = createDueIsolatedJob({
+      id: "parallel-setup-timeout-first",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    const second = createDueIsolatedJob({
+      id: "parallel-setup-timeout-second",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    first.payload = { kind: "agentTurn", message: "first", timeoutSeconds: 120 };
+    second.payload = { kind: "agentTurn", message: "second", timeoutSeconds: 120 };
+    await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
+
+    let now = dueAt;
+    let startedCount = 0;
+    const bothStarted = createDeferred();
+    const onIsolatedAgentSetupTimeout = vi.fn();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      testAdmissionLimit: 2,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      onIsolatedAgentSetupTimeout,
+      runIsolatedAgentJob: vi.fn(async () => {
+        startedCount += 1;
+        if (startedCount === 2) {
+          bothStarted.resolve();
+        }
+        return await runnerResult.promise;
+      }),
+    });
+
+    const timerPromise = onTimer(state);
     try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const dueAt = Date.parse("2026-02-06T10:06:01.000Z");
-      const first = createDueIsolatedJob({
-        id: "parallel-setup-timeout-first",
-        nowMs: dueAt,
-        nextRunAtMs: dueAt,
-      });
-      const second = createDueIsolatedJob({
-        id: "parallel-setup-timeout-second",
-        nowMs: dueAt,
-        nextRunAtMs: dueAt,
-      });
-      first.payload = { kind: "agentTurn", message: "first", timeoutSeconds: 120 };
-      second.payload = { kind: "agentTurn", message: "second", timeoutSeconds: 120 };
-      await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
-
-      let now = dueAt;
-      let startedCount = 0;
-      const bothStarted = createDeferred();
-      const onIsolatedAgentSetupTimeout = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        testAdmissionLimit: 2,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        onIsolatedAgentSetupTimeout,
-        runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
-          startedCount += 1;
-          if (startedCount === 2) {
-            bothStarted.resolve();
-          }
-          abortSignal?.addEventListener("abort", () => undefined, { once: true });
-          return await new Promise<never>(() => {});
-        }),
-      });
-
-      const timerPromise = onTimer(state);
       await bothStarted.promise;
       await vi.advanceTimersByTimeAsync(60_100);
       now += 60_100;
@@ -2247,58 +2347,63 @@ describe("cron service timer regressions", () => {
         timeoutMs: 60_000,
       });
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([timerPromise, runnerResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });
 
   it("does not release a running sibling when setup-timeout recovery clears queued jobs", async () => {
     vi.useFakeTimers();
+    const store = timerRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:06:21.000Z");
+    const stalled = createDueIsolatedJob({
+      id: "setup-timeout-stalled",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    const running = createDueIsolatedJob({
+      id: "setup-timeout-running-sibling",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    stalled.payload = { kind: "agentTurn", message: "stall", timeoutSeconds: 120 };
+    running.payload = { kind: "agentTurn", message: "run", timeoutSeconds: 120 };
+    await saveCronStore(store.storePath, { version: 1, jobs: [stalled, running] });
+
+    let now = dueAt;
+    const runningStarted = createDeferred();
+    const finishRunning = createDeferred<{ status: "ok"; summary: string }>();
+    const timeoutNotified = createDeferred();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      testAdmissionLimit: 2,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      onIsolatedAgentSetupTimeout: () => timeoutNotified.resolve(),
+      runIsolatedAgentJob: vi.fn(
+        async ({
+          job,
+          onExecutionStarted,
+        }: Parameters<CronStateParams["runIsolatedAgentJob"]>[0]) => {
+          if (job.id === stalled.id) {
+            return await runnerResult.promise;
+          }
+          onExecutionStarted?.({ jobId: job.id, phase: "model_call_started" });
+          runningStarted.resolve();
+          return await finishRunning.promise;
+        },
+      ),
+    });
+
+    const timerPromise = onTimer(state);
     try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const dueAt = Date.parse("2026-02-06T10:06:21.000Z");
-      const stalled = createDueIsolatedJob({
-        id: "setup-timeout-stalled",
-        nowMs: dueAt,
-        nextRunAtMs: dueAt,
-      });
-      const running = createDueIsolatedJob({
-        id: "setup-timeout-running-sibling",
-        nowMs: dueAt,
-        nextRunAtMs: dueAt,
-      });
-      stalled.payload = { kind: "agentTurn", message: "stall", timeoutSeconds: 120 };
-      running.payload = { kind: "agentTurn", message: "run", timeoutSeconds: 120 };
-      await saveCronStore(store.storePath, { version: 1, jobs: [stalled, running] });
-
-      let now = dueAt;
-      const runningStarted = createDeferred();
-      const finishRunning = createDeferred<{ status: "ok"; summary: string }>();
-      const timeoutNotified = createDeferred();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        testAdmissionLimit: 2,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        onIsolatedAgentSetupTimeout: () => timeoutNotified.resolve(),
-        runIsolatedAgentJob: vi.fn(
-          async ({
-            job,
-            onExecutionStarted,
-          }: Parameters<CronStateParams["runIsolatedAgentJob"]>[0]) => {
-            if (job.id === stalled.id) {
-              return await new Promise<never>(() => {});
-            }
-            onExecutionStarted?.({ jobId: job.id, phase: "model_call_started" });
-            runningStarted.resolve();
-            return await finishRunning.promise;
-          },
-        ),
-      });
-
-      const timerPromise = onTimer(state);
       await runningStarted.promise;
       await vi.advanceTimersByTimeAsync(60_100);
       now += 60_100;
@@ -2315,59 +2420,63 @@ describe("cron service timer regressions", () => {
       });
       expect(requireJob(state, running.id).state.lastStatus).toBe("ok");
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      finishRunning.resolve({ status: "ok", summary: "finished" });
+      await Promise.allSettled([timerPromise, runnerResult.promise, finishRunning.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });
 
   it("notifies timeout recovery before admitting queued manual work", async () => {
     vi.useFakeTimers();
+    const store = timerRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:06:31.000Z");
+    const first = createDueIsolatedJob({
+      id: "serial-timeout-recovery-first",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    const second = createDueIsolatedJob({
+      id: "serial-timeout-recovery-second",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt + 3_600_000,
+    });
+    first.payload = { kind: "agentTurn", message: "first", timeoutSeconds: 120 };
+    second.payload = { kind: "agentTurn", message: "second", timeoutSeconds: 120 };
+    await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
+
+    let now = dueAt;
+    const firstStarted = createDeferred();
+    const secondStarted = createDeferred();
+    const onIsolatedAgentSetupTimeout = vi.fn();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      testAdmissionLimit: 1,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      onIsolatedAgentSetupTimeout,
+      runIsolatedAgentJob: vi.fn(async ({ job }: { job: CronJob }) => {
+        if (job.id === first.id) {
+          firstStarted.resolve();
+          return await runnerResult.promise;
+        }
+        expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledOnce();
+        secondStarted.resolve();
+        return { status: "ok" as const, summary: "second after recovery" };
+      }),
+    });
+
+    const timerPromise = onTimer(state);
+    let manualRun: ReturnType<typeof runManualCronJob> | undefined;
     try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const dueAt = Date.parse("2026-02-06T10:06:31.000Z");
-      const first = createDueIsolatedJob({
-        id: "serial-timeout-recovery-first",
-        nowMs: dueAt,
-        nextRunAtMs: dueAt,
-      });
-      const second = createDueIsolatedJob({
-        id: "serial-timeout-recovery-second",
-        nowMs: dueAt,
-        nextRunAtMs: dueAt + 3_600_000,
-      });
-      first.payload = { kind: "agentTurn", message: "first", timeoutSeconds: 120 };
-      second.payload = { kind: "agentTurn", message: "second", timeoutSeconds: 120 };
-      await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
-
-      let now = dueAt;
-      const firstStarted = createDeferred();
-      const secondStarted = createDeferred();
-      const onIsolatedAgentSetupTimeout = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        testAdmissionLimit: 1,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        onIsolatedAgentSetupTimeout,
-        runIsolatedAgentJob: vi.fn(
-          async ({ job, abortSignal }: { job: CronJob; abortSignal?: AbortSignal }) => {
-            if (job.id === first.id) {
-              firstStarted.resolve();
-              abortSignal?.addEventListener("abort", () => undefined, { once: true });
-              return await new Promise<never>(() => {});
-            }
-            expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledOnce();
-            secondStarted.resolve();
-            return { status: "ok" as const, summary: "second after recovery" };
-          },
-        ),
-      });
-
-      const timerPromise = onTimer(state);
       await firstStarted.promise;
-      const manualRun = runManualCronJob(state, second.id, "force");
+      manualRun = runManualCronJob(state, second.id, "force");
       await vi.advanceTimersByTimeAsync(60_100);
       now += 60_100;
       await secondStarted.promise;
@@ -2378,55 +2487,61 @@ describe("cron service timer regressions", () => {
       expect(state.store?.jobs.find((job) => job.id === first.id)?.state.lastStatus).toBe("error");
       expect(state.store?.jobs.find((job) => job.id === second.id)?.state.lastStatus).toBe("ok");
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([
+        timerPromise,
+        ...(manualRun ? [manualRun] : []),
+        runnerResult.promise,
+      ]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });
 
   it("sends setup-timeout notification after a prior serial cron job completes", async () => {
     vi.useFakeTimers();
+    const store = timerRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:07:01.000Z");
+    const first = createDueIsolatedJob({
+      id: "serial-setup-timeout-first",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    const second = createDueIsolatedJob({
+      id: "serial-setup-timeout-second",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    first.payload = { kind: "agentTurn", message: "first", timeoutSeconds: 120 };
+    second.payload = { kind: "agentTurn", message: "second", timeoutSeconds: 120 };
+    await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
+
+    let now = dueAt;
+    const secondStarted = createDeferred();
+    const onIsolatedAgentSetupTimeout = vi.fn();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      testAdmissionLimit: 1,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      onIsolatedAgentSetupTimeout,
+      runIsolatedAgentJob: vi.fn(async ({ job }: { job: CronJob }) => {
+        if (job.id === first.id) {
+          now += 10;
+          return { status: "ok" as const, summary: "first done" };
+        }
+        secondStarted.resolve();
+        return await runnerResult.promise;
+      }),
+    });
+
+    const timerPromise = onTimer(state);
     try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const dueAt = Date.parse("2026-02-06T10:07:01.000Z");
-      const first = createDueIsolatedJob({
-        id: "serial-setup-timeout-first",
-        nowMs: dueAt,
-        nextRunAtMs: dueAt,
-      });
-      const second = createDueIsolatedJob({
-        id: "serial-setup-timeout-second",
-        nowMs: dueAt,
-        nextRunAtMs: dueAt,
-      });
-      first.payload = { kind: "agentTurn", message: "first", timeoutSeconds: 120 };
-      second.payload = { kind: "agentTurn", message: "second", timeoutSeconds: 120 };
-      await saveCronStore(store.storePath, { version: 1, jobs: [first, second] });
-
-      let now = dueAt;
-      const secondStarted = createDeferred();
-      const onIsolatedAgentSetupTimeout = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        testAdmissionLimit: 1,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        onIsolatedAgentSetupTimeout,
-        runIsolatedAgentJob: vi.fn(
-          async ({ job, abortSignal }: { job: CronJob; abortSignal?: AbortSignal }) => {
-            if (job.id === first.id) {
-              now += 10;
-              return { status: "ok" as const, summary: "first done" };
-            }
-            secondStarted.resolve();
-            abortSignal?.addEventListener("abort", () => undefined, { once: true });
-            return await new Promise<never>(() => {});
-          },
-        ),
-      });
-
-      const timerPromise = onTimer(state);
       await secondStarted.promise;
       expect(isCronJobActive(first.id)).toBe(false);
       expect(isCronJobActive(second.id)).toBe(true);
@@ -2446,58 +2561,61 @@ describe("cron service timer regressions", () => {
       expect(isCronJobActive(first.id)).toBe(false);
       expect(isCronJobActive(second.id)).toBe(false);
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([timerPromise, runnerResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });
 
   it("waits to start a scheduled run until a manual run releases the shared limit", async () => {
     vi.useFakeTimers();
+    const store = timerRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:08:01.000Z");
+    const scheduledJob = createDueIsolatedJob({
+      id: "mixed-setup-timeout-scheduled",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    const manualJob = createDueIsolatedJob({
+      id: "mixed-setup-timeout-manual",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt + 3_600_000,
+    });
+    scheduledJob.payload = { kind: "agentTurn", message: "scheduled", timeoutSeconds: 120 };
+    manualJob.payload = { kind: "agentTurn", message: "manual", timeoutSeconds: 120 };
+    await saveCronStore(store.storePath, { version: 1, jobs: [scheduledJob, manualJob] });
+
+    let now = dueAt;
+    const manualStarted = createDeferred();
+    const scheduledStarted = createDeferred();
+    const onIsolatedAgentSetupTimeout = vi.fn();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      testAdmissionLimit: 1,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      onIsolatedAgentSetupTimeout,
+      runIsolatedAgentJob: vi.fn(async ({ job }: { job: CronJob }) => {
+        if (job.id === manualJob.id) {
+          manualStarted.resolve();
+          return await runnerResult.promise;
+        }
+        scheduledStarted.resolve();
+        return { status: "ok" as const, summary: "scheduled after manual" };
+      }),
+    });
+
+    const manualRun = runManualCronJob(state, manualJob.id, "force");
+    let timerRun: ReturnType<typeof onTimer> | undefined;
     try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const dueAt = Date.parse("2026-02-06T10:08:01.000Z");
-      const scheduledJob = createDueIsolatedJob({
-        id: "mixed-setup-timeout-scheduled",
-        nowMs: dueAt,
-        nextRunAtMs: dueAt,
-      });
-      const manualJob = createDueIsolatedJob({
-        id: "mixed-setup-timeout-manual",
-        nowMs: dueAt,
-        nextRunAtMs: dueAt + 3_600_000,
-      });
-      scheduledJob.payload = { kind: "agentTurn", message: "scheduled", timeoutSeconds: 120 };
-      manualJob.payload = { kind: "agentTurn", message: "manual", timeoutSeconds: 120 };
-      await saveCronStore(store.storePath, { version: 1, jobs: [scheduledJob, manualJob] });
-
-      let now = dueAt;
-      const manualStarted = createDeferred();
-      const scheduledStarted = createDeferred();
-      const onIsolatedAgentSetupTimeout = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        testAdmissionLimit: 1,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        onIsolatedAgentSetupTimeout,
-        runIsolatedAgentJob: vi.fn(
-          async ({ job, abortSignal }: { job: CronJob; abortSignal?: AbortSignal }) => {
-            if (job.id === manualJob.id) {
-              manualStarted.resolve();
-              abortSignal?.addEventListener("abort", () => undefined, { once: true });
-              return await new Promise<never>(() => {});
-            }
-            scheduledStarted.resolve();
-            return { status: "ok" as const, summary: "scheduled after manual" };
-          },
-        ),
-      });
-
-      const manualRun = runManualCronJob(state, manualJob.id, "force");
       await manualStarted.promise;
-      const timerRun = onTimer(state);
+      timerRun = onTimer(state);
       await Promise.resolve();
       await Promise.resolve();
 
@@ -2518,54 +2636,58 @@ describe("cron service timer regressions", () => {
         timeoutMs: 60_000,
       });
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([manualRun, ...(timerRun ? [timerRun] : []), runnerResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });
 
   it("rearms scheduled jobs after manual setup timeout notification", async () => {
     vi.useFakeTimers();
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-05-10T08:58:00.000Z");
+    const manualJob = createDueIsolatedJob({
+      id: "manual-setup-timeout-rearm",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    manualJob.payload = { kind: "agentTurn", message: "manual", timeoutSeconds: 120 };
+    const scheduledJob = createDueIsolatedJob({
+      id: "scheduled-after-manual-setup-timeout",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    scheduledJob.payload = { kind: "agentTurn", message: "scheduled", timeoutSeconds: 120 };
+    await saveCronStore(store.storePath, { version: 1, jobs: [manualJob, scheduledJob] });
+
+    vi.setSystemTime(scheduledAt);
+    let now = scheduledAt;
+    const manualStarted = createDeferred();
+    const scheduledStarted = vi.fn();
+    const onIsolatedAgentSetupTimeout = vi.fn();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      onIsolatedAgentSetupTimeout,
+      runIsolatedAgentJob: vi.fn(async ({ job }) => {
+        if (job.id === manualJob.id) {
+          manualStarted.resolve();
+          return await runnerResult.promise;
+        }
+        scheduledStarted(job.id);
+        return { status: "ok" as const, summary: "scheduled" };
+      }),
+    });
+
+    const manualRun = runManualCronJob(state, manualJob.id, "force");
     try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-05-10T08:58:00.000Z");
-      const manualJob = createDueIsolatedJob({
-        id: "manual-setup-timeout-rearm",
-        nowMs: scheduledAt,
-        nextRunAtMs: scheduledAt,
-      });
-      manualJob.payload = { kind: "agentTurn", message: "manual", timeoutSeconds: 120 };
-      const scheduledJob = createDueIsolatedJob({
-        id: "scheduled-after-manual-setup-timeout",
-        nowMs: scheduledAt,
-        nextRunAtMs: scheduledAt,
-      });
-      scheduledJob.payload = { kind: "agentTurn", message: "scheduled", timeoutSeconds: 120 };
-      await saveCronStore(store.storePath, { version: 1, jobs: [manualJob, scheduledJob] });
-
-      vi.setSystemTime(scheduledAt);
-      let now = scheduledAt;
-      const manualStarted = createDeferred();
-      const scheduledStarted = vi.fn();
-      const onIsolatedAgentSetupTimeout = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        onIsolatedAgentSetupTimeout,
-        runIsolatedAgentJob: vi.fn(async ({ job, abortSignal }) => {
-          if (job.id === manualJob.id) {
-            manualStarted.resolve();
-            abortSignal?.addEventListener("abort", () => undefined, { once: true });
-            return await new Promise<never>(() => {});
-          }
-          scheduledStarted(job.id);
-          return { status: "ok" as const, summary: "scheduled" };
-        }),
-      });
-
-      const manualRun = runManualCronJob(state, manualJob.id, "force");
       await manualStarted.promise;
       await vi.advanceTimersByTimeAsync(60_100);
       now += 60_100;
@@ -2576,6 +2698,10 @@ describe("cron service timer regressions", () => {
       expect(state.timer).not.toBeNull();
       expect(scheduledStarted).not.toHaveBeenCalled();
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([manualRun, runnerResult.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });
@@ -2620,40 +2746,47 @@ describe("cron service timer regressions", () => {
     });
 
     const missedJobs = runMissedJobs(state);
-    await runStarted.promise;
+    try {
+      await runStarted.promise;
 
-    state.stopped = true;
-    const replacementReservationMs = scheduledAt + 123;
-    const replacementStore = await loadCronStore(store.storePath);
-    const replacementPersistedJob = replacementStore.jobs.find(
-      (entry) => entry.id === replacementClaimedJob.id,
-    );
-    if (!replacementPersistedJob) {
-      throw new Error("expected replacement-claimed startup job");
+      state.stopped = true;
+      const replacementReservationMs = scheduledAt + 123;
+      const replacementStore = await loadCronStore(store.storePath);
+      const replacementPersistedJob = replacementStore.jobs.find(
+        (entry) => entry.id === replacementClaimedJob.id,
+      );
+      if (!replacementPersistedJob) {
+        throw new Error("expected replacement-claimed startup job");
+      }
+      replacementPersistedJob.state.queuedAtMs = replacementReservationMs;
+      await saveCronStore(store.storePath, replacementStore);
+
+      releaseRun.resolve({ status: "ok", summary: "old service result" });
+      await missedJobs;
+
+      const persisted = await loadCronStore(store.storePath);
+      const persistedJob = persisted.jobs.find((entry) => entry.id === job.id);
+      const persistedUnstartedJob = persisted.jobs.find((entry) => entry.id === unstartedJob.id);
+      const persistedReplacementClaimedJob = persisted.jobs.find(
+        (entry) => entry.id === replacementClaimedJob.id,
+      );
+      expect(persistedJob?.state.runningAtMs).toBeUndefined();
+      expect(persistedJob?.state.lastStatus).toBe("ok");
+      expect(persistedUnstartedJob?.state.runningAtMs).toBeUndefined();
+      expect(persistedUnstartedJob?.state.lastStatus).toBeUndefined();
+      expect(persistedReplacementClaimedJob?.state.queuedAtMs).toBe(replacementReservationMs);
+      expect(persistedReplacementClaimedJob?.state.lastStatus).toBeUndefined();
+      expect(
+        listTaskRecords().find((entry) => entry.runtime === "cron" && entry.sourceId === job.id)
+          ?.status,
+      ).toBe("succeeded");
+    } finally {
+      stop(state);
+      releaseRun.resolve({ status: "ok", summary: "old service result" });
+      await Promise.allSettled([missedJobs, releaseRun.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
+      resetTaskRegistryForTests();
     }
-    replacementPersistedJob.state.queuedAtMs = replacementReservationMs;
-    await saveCronStore(store.storePath, replacementStore);
-
-    releaseRun.resolve({ status: "ok", summary: "old service result" });
-    await missedJobs;
-
-    const persisted = await loadCronStore(store.storePath);
-    const persistedJob = persisted.jobs.find((entry) => entry.id === job.id);
-    const persistedUnstartedJob = persisted.jobs.find((entry) => entry.id === unstartedJob.id);
-    const persistedReplacementClaimedJob = persisted.jobs.find(
-      (entry) => entry.id === replacementClaimedJob.id,
-    );
-    expect(persistedJob?.state.runningAtMs).toBeUndefined();
-    expect(persistedJob?.state.lastStatus).toBe("ok");
-    expect(persistedUnstartedJob?.state.runningAtMs).toBeUndefined();
-    expect(persistedUnstartedJob?.state.lastStatus).toBeUndefined();
-    expect(persistedReplacementClaimedJob?.state.queuedAtMs).toBe(replacementReservationMs);
-    expect(persistedReplacementClaimedJob?.state.lastStatus).toBeUndefined();
-    expect(
-      listTaskRecords().find((entry) => entry.runtime === "cron" && entry.sourceId === job.id)
-        ?.status,
-    ).toBe("succeeded");
-    resetTaskRegistryForTests();
   });
 
   it("does not clear replacement reservations when stopped timer cleanup releases unclaimed jobs", async () => {
@@ -2690,91 +2823,99 @@ describe("cron service timer regressions", () => {
     });
 
     const timer = onTimer(state);
-    await runStarted.promise;
+    try {
+      await runStarted.promise;
 
-    state.stopped = true;
-    const replacementReservationMs = scheduledAt + 222;
-    const replacementStore = await loadCronStore(store.storePath);
-    const replacementPersistedJob = replacementStore.jobs.find(
-      (entry) => entry.id === replacementClaimedJob.id,
-    );
-    if (!replacementPersistedJob) {
-      throw new Error("expected replacement-claimed timer job");
+      state.stopped = true;
+      const replacementReservationMs = scheduledAt + 222;
+      const replacementStore = await loadCronStore(store.storePath);
+      const replacementPersistedJob = replacementStore.jobs.find(
+        (entry) => entry.id === replacementClaimedJob.id,
+      );
+      if (!replacementPersistedJob) {
+        throw new Error("expected replacement-claimed timer job");
+      }
+      replacementPersistedJob.state.queuedAtMs = replacementReservationMs;
+      await saveCronStore(store.storePath, replacementStore);
+
+      releaseRun.resolve({ status: "ok", summary: "old service result" });
+      await timer;
+
+      const persisted = await loadCronStore(store.storePath);
+      expect(
+        persisted.jobs.find((entry) => entry.id === replacementClaimedJob.id)?.state.queuedAtMs,
+      ).toBe(replacementReservationMs);
+    } finally {
+      stop(state);
+      releaseRun.resolve({ status: "ok", summary: "old service result" });
+      await Promise.allSettled([timer, releaseRun.promise]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
     }
-    replacementPersistedJob.state.queuedAtMs = replacementReservationMs;
-    await saveCronStore(store.storePath, replacementStore);
-
-    releaseRun.resolve({ status: "ok", summary: "old service result" });
-    await timer;
-
-    const persisted = await loadCronStore(store.storePath);
-    expect(
-      persisted.jobs.find((entry) => entry.id === replacementClaimedJob.id)?.state.queuedAtMs,
-    ).toBe(replacementReservationMs);
   });
 
   it("starts the scheduled batch after manual setup-timeout notification", async () => {
     vi.useFakeTimers();
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-05-10T08:59:00.000Z");
+    const manualJob = createDueIsolatedJob({
+      id: "manual-setup-timeout-active-batch",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt + 3_600_000,
+    });
+    manualJob.payload = { kind: "agentTurn", message: "manual", timeoutSeconds: 120 };
+    const firstScheduledJob = createDueIsolatedJob({
+      id: "scheduled-before-manual-recovery",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    const secondScheduledJob = createDueIsolatedJob({
+      id: "scheduled-blocked-by-manual-recovery",
+      nowMs: scheduledAt,
+      nextRunAtMs: scheduledAt,
+    });
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [manualJob, firstScheduledJob, secondScheduledJob],
+    });
+
+    vi.setSystemTime(scheduledAt);
+    let now = scheduledAt;
+    const manualStarted = createDeferred();
+    const firstScheduledStarted = createDeferred();
+    const finishFirstScheduled = createDeferred();
+    const secondScheduledStarted = vi.fn();
+    const onIsolatedAgentSetupTimeout = vi.fn();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      testAdmissionLimit: 1,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      onIsolatedAgentSetupTimeout,
+      runIsolatedAgentJob: vi.fn(async ({ job, onExecutionStarted }) => {
+        if (job.id === manualJob.id) {
+          manualStarted.resolve();
+          return await runnerResult.promise;
+        }
+        if (job.id === firstScheduledJob.id) {
+          firstScheduledStarted.resolve();
+          onExecutionStarted?.();
+          await finishFirstScheduled.promise;
+          return { status: "ok" as const, summary: "first scheduled" };
+        }
+        secondScheduledStarted(job.id);
+        return { status: "ok" as const, summary: "second scheduled" };
+      }),
+    });
+
+    const manualRun = runManualCronJob(state, manualJob.id, "force");
+    let timerRun: ReturnType<typeof onTimer> | undefined;
     try {
-      const store = timerRegressionFixtures.makeStorePath();
-      const scheduledAt = Date.parse("2026-05-10T08:59:00.000Z");
-      const manualJob = createDueIsolatedJob({
-        id: "manual-setup-timeout-active-batch",
-        nowMs: scheduledAt,
-        nextRunAtMs: scheduledAt + 3_600_000,
-      });
-      manualJob.payload = { kind: "agentTurn", message: "manual", timeoutSeconds: 120 };
-      const firstScheduledJob = createDueIsolatedJob({
-        id: "scheduled-before-manual-recovery",
-        nowMs: scheduledAt,
-        nextRunAtMs: scheduledAt,
-      });
-      const secondScheduledJob = createDueIsolatedJob({
-        id: "scheduled-blocked-by-manual-recovery",
-        nowMs: scheduledAt,
-        nextRunAtMs: scheduledAt,
-      });
-      await saveCronStore(store.storePath, {
-        version: 1,
-        jobs: [manualJob, firstScheduledJob, secondScheduledJob],
-      });
-
-      vi.setSystemTime(scheduledAt);
-      let now = scheduledAt;
-      const manualStarted = createDeferred();
-      const firstScheduledStarted = createDeferred();
-      const finishFirstScheduled = createDeferred();
-      const secondScheduledStarted = vi.fn();
-      const onIsolatedAgentSetupTimeout = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
-        storePath: store.storePath,
-        testAdmissionLimit: 1,
-        log: noopLogger,
-        nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        onIsolatedAgentSetupTimeout,
-        runIsolatedAgentJob: vi.fn(async ({ job, abortSignal, onExecutionStarted }) => {
-          if (job.id === manualJob.id) {
-            manualStarted.resolve();
-            abortSignal?.addEventListener("abort", () => undefined, { once: true });
-            return await new Promise<never>(() => {});
-          }
-          if (job.id === firstScheduledJob.id) {
-            firstScheduledStarted.resolve();
-            onExecutionStarted?.();
-            await finishFirstScheduled.promise;
-            return { status: "ok" as const, summary: "first scheduled" };
-          }
-          secondScheduledStarted(job.id);
-          return { status: "ok" as const, summary: "second scheduled" };
-        }),
-      });
-
-      const manualRun = runManualCronJob(state, manualJob.id, "force");
       await manualStarted.promise;
-      const timerRun = onTimer(state);
+      timerRun = onTimer(state);
 
       await vi.advanceTimersByTimeAsync(60_100);
       now += 60_100;
@@ -2791,6 +2932,16 @@ describe("cron service timer regressions", () => {
       expect(onIsolatedAgentSetupTimeout).toHaveBeenCalledTimes(1);
       expect(second.state.runningAtMs).toBeUndefined();
     } finally {
+      stop(state);
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      finishFirstScheduled.resolve();
+      await Promise.allSettled([
+        manualRun,
+        ...(timerRun ? [timerRun] : []),
+        runnerResult.promise,
+        finishFirstScheduled.promise,
+      ]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -248,6 +248,7 @@ import {
   abortActiveCronTaskRuns,
   registerActiveCronTaskRun,
   trackActiveCronTaskRunSettlement,
+  getSuspensionVisibleCronTaskRunCount,
 } from "../cron/service/active-run-cancellation.js";
 import { resetActiveCronTaskRunsForTests } from "../cron/service/active-run-cancellation.test-support.js";
 import type { CronServiceState } from "../cron/service/state.js";
@@ -1094,11 +1095,10 @@ describe("buildGatewayCronService", () => {
 
   it("aborts and drains active cron runs during shutdown", async () => {
     const controller = new AbortController();
-    const coreRun = new Promise<void>((resolve) => {
-      controller.signal.addEventListener("abort", () => resolve(), { once: true });
-    });
+    const coreRun = createDeferred();
+    controller.signal.addEventListener("abort", () => coreRun.resolve(), { once: true });
     const release = registerActiveCronTaskRun({ runId: "run-shutdown", controller });
-    const trackedRun = coreRun.finally(() => release?.());
+    const trackedRun = coreRun.promise.finally(() => release?.());
     trackActiveCronTaskRunSettlement(trackedRun);
 
     const cfg = createCronConfig("server-cron-active-run-shutdown");
@@ -1110,6 +1110,9 @@ describe("buildGatewayCronService", () => {
       await expect(trackedRun).resolves.toBeUndefined();
     } finally {
       state.cron.stop();
+      coreRun.resolve();
+      await trackedRun;
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       resetActiveCronTaskRunsForTests();
     }
   });
@@ -1434,8 +1437,10 @@ describe("buildGatewayCronService", () => {
   it("backs off isolated cron setup timeout without gateway restart", async () => {
     vi.useFakeTimers();
     const runnerEntered = createDeferred();
+    const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const cfg = createCronConfig("server-cron-isolated-setup-timeout");
     const state = loadCronService(cfg);
+    let runPromise: ReturnType<typeof state.cron.run> | undefined;
     try {
       const job = await addCronJob(
         state,
@@ -1443,15 +1448,12 @@ describe("buildGatewayCronService", () => {
         { kind: "agentTurn", message: "work", timeoutSeconds: 120 },
         { schedule: { kind: "at", at: new Date(Date.now()).toISOString() } },
       );
-      runCronIsolatedAgentTurnMock.mockImplementationOnce(
-        async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
-          abortSignal?.addEventListener("abort", () => undefined, { once: true });
-          runnerEntered.resolve();
-          return await new Promise<never>(() => {});
-        },
-      );
+      runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+        runnerEntered.resolve();
+        return await runnerResult.promise;
+      });
 
-      const runPromise = state.cron.run(job.id, "force");
+      runPromise = state.cron.run(job.id, "force");
       await runnerEntered.promise;
       await vi.advanceTimersByTimeAsync(60_100);
       const runResult = await runPromise;
@@ -1460,6 +1462,9 @@ describe("buildGatewayCronService", () => {
       expect(requestSafeGatewayRestartMock).not.toHaveBeenCalled();
     } finally {
       state.cron.stop();
+      runnerResult.resolve({ status: "ok", summary: "done" });
+      await Promise.allSettled([runnerResult.promise, ...(runPromise ? [runPromise] : [])]);
+      await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
       vi.useRealTimers();
     }
   });
@@ -3965,9 +3970,8 @@ describe("fireOnExitJob (on-exit fire routing)", () => {
     noOutputTimedOut: false,
   };
 
-  it("executes an agentTurn payload via the force-run path, not a text wake", async () => {
+  it("executes an agentTurn payload via the force-run path", async () => {
     const run = vi.fn<ForceRunMock>(async () => {});
-    const wake = vi.fn();
     await fireOnExitJob(job({ kind: "agentTurn", message: "go" }), exit, {
       run,
     });
@@ -3979,22 +3983,18 @@ describe("fireOnExitJob (on-exit fire routing)", () => {
       message: expect.stringContaining("stdout:\nbuilt ok"),
     });
     expect(run.mock.calls[0]?.[0]).toBe("job-x");
-    expect(wake).not.toHaveBeenCalled();
   });
 
   it("executes a command payload via the force-run path", async () => {
     const run = vi.fn<ForceRunMock>(async () => {});
-    const wake = vi.fn();
     await fireOnExitJob(job({ kind: "command", argv: ["echo", "hi"] }), exit, {
       run,
     });
     expect(run).toHaveBeenCalledWith("job-x", undefined);
-    expect(wake).not.toHaveBeenCalled();
   });
 
   it("executes a systemEvent payload via the force-run path", async () => {
     const run = vi.fn<ForceRunMock>(async () => {});
-    const wake = vi.fn();
     await fireOnExitJob(
       job({ kind: "systemEvent", text: "done" }, { sessionKey: "sk-1", agentId: "agent-1" }),
       exit,
@@ -4008,7 +4008,6 @@ describe("fireOnExitJob (on-exit fire routing)", () => {
       text: expect.stringContaining("stderr:\nwarned"),
     });
     expect(run.mock.calls[0]?.[0]).toBe("job-x");
-    expect(wake).not.toHaveBeenCalled();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

A maintainer-requested test audit found cron timeout and cancellation fixtures that left underlying cores pending after their outer requests finished. Shared resets hid those cores, and early assertion failures could bypass gate release.

## Why This Change Was Made

Fixtures now retain canonical deferred gates, stop scheduler admission, release owned gates, join admitted requests, and check actual core settlement before shared teardown. Production cancellation, retirement, suspension, and reset/publication contracts remain unchanged. Three disconnected wake assertions and nine empty abort listeners are removed; all 611 meaningful assertions and 204 cases remain.

## User Impact

No runtime, configuration, storage, API, or dependency change. Test failures now finish their fixture work before timers, mocks, and state are reset. Production and test-support delta: 0 lines; tests: +168 lines.

## Evidence

The original and initial cleanup revisions each passed all 204 cases with:

```sh
pnpm test src/cron/service/active-run-cancellation.test.ts src/cron/service/timer.regression.test.ts src/gateway/server-cron.test.ts
```

Temporary controls preserved the original case order. Before the original teardown, setup-timeout fixtures had a fulfilled outer request but one unsettled core; an injected early failure left both the outer request and core pending. Original controls rescued owned work before teardown. With the cleanup, those boundaries reached zero cores through fixture `finally` alone, and the following original cases passed. A separate early failure after lane entry released both pending lane and runner gates. Both deliberate errors remained visible; instrumentation was restored after every run.

After removing the inert listeners, all nine affected cases passed. The full type gate then caught a new fixture value using `text` instead of the existing mock's `summary` contract. Both type and cleanup value were corrected without a cast; its owning Gateway case passed again.

The final revision passed the full configured gate:

```sh
node scripts/check-changed.mjs -- src/cron/service/active-run-cancellation.test.ts src/cron/service/timer.regression.test.ts src/gateway/server-cron.test.ts
```

Both selected test type graphs, all three dead-export scans, and lint passed. Fresh Codex review found no actionable P0–P2 findings. These are synthetic fixture and static checks; they make no live-provider claim.
