### PR TITLE
fix(qa): record Discord reply latency in evidence

### DIFF
--- a/extensions/qa-lab/src/live-transports/discord/scenario-runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/discord/scenario-runtime.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  discordQaScenarioSupport,
+  type DiscordQaScenarioImplementation,
+} from "./discord-live.runtime.js";
+import type { DiscordQaScenarioEnvironment } from "./scenario-environment.js";
+import { runDiscordScenario } from "./scenario-runtime.js";
+
+describe("Discord QA scenario runtime", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns structured RTT evidence for a matched reply", async () => {
+    const implementation = {
+      buildRun: () => ({
+        kind: "channel-message",
+        expectReply: true,
+        input: "ping",
+        expectedTextIncludes: ["pong"],
+        matchText: "pong",
+      }),
+    } satisfies DiscordQaScenarioImplementation;
+    const environment = {
+      configureScenario: vi.fn(async () => ({ cfg: {}, run: implementation.buildRun() })),
+      driverIdentity: { id: "423456789012345678", bot: true },
+      observedMessages: [],
+      outputDir: "/unused",
+      runtimeEnv: {
+        guildId: "123456789012345678",
+        channelId: "223456789012345678",
+        driverBotToken: "driver-token",
+        sutBotToken: "sut-token",
+        sutApplicationId: "323456789012345678",
+      },
+      scenario: { id: "discord-canary", timeoutMs: 30_000, title: "Discord canary" },
+      sutAccountId: "sut",
+      sutIdentity: { id: "323456789012345678", bot: true },
+    } as unknown as DiscordQaScenarioEnvironment;
+    const testing = discordQaScenarioSupport.testing;
+    vi.spyOn(testing, "sendChannelMessage").mockResolvedValue({
+      id: "523456789012345678",
+      channel_id: environment.runtimeEnv.channelId,
+      timestamp: "2026-09-02T12:00:00.000Z",
+    });
+    vi.spyOn(testing, "pollChannelMessages").mockResolvedValue({
+      afterSnowflake: "623456789012345678",
+      message: {
+        messageId: "623456789012345678",
+        channelId: environment.runtimeEnv.channelId,
+        senderId: environment.sutIdentity.id,
+        senderIsBot: true,
+        text: "pong",
+        timestamp: "2026-09-02T12:00:01.750Z",
+      },
+    });
+
+    await expect(runDiscordScenario(environment, implementation)).resolves.toEqual({
+      details: "reply matched",
+      requestStartedAt: "2026-09-02T12:00:00.000Z",
+      responseObservedAt: "2026-09-02T12:00:01.750Z",
+      rttMs: 1750,
+      rttMeasurement: {
+        finalMatchedReplyRttMs: 1750,
+        requestStartedAt: "2026-09-02T12:00:00.000Z",
+        responseObservedAt: "2026-09-02T12:00:01.750Z",
+        source: "request-to-observed-message",
+      },
+    });
+  });
+});

--- a/extensions/qa-lab/src/live-transports/discord/scenario-runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/scenario-runtime.ts
@@ -213,7 +213,28 @@ export async function runDiscordScenario(
       expectedTextIncludes: run.expectedTextIncludes,
       message: matched.message,
     });
-    return { details: "reply matched" };
+    const requestStartedAt = sent.timestamp;
+    const responseObservedAt = matched.message.timestamp;
+    const rttMs = discordQaScenarioSupport.testing.computeDiscordRttMs(
+      requestStartedAt,
+      responseObservedAt,
+    );
+    return {
+      details: "reply matched",
+      ...(requestStartedAt === undefined ? {} : { requestStartedAt }),
+      ...(responseObservedAt === undefined ? {} : { responseObservedAt }),
+      ...(rttMs === undefined || requestStartedAt === undefined || responseObservedAt === undefined
+        ? {}
+        : {
+            rttMs,
+            rttMeasurement: {
+              finalMatchedReplyRttMs: rttMs,
+              requestStartedAt,
+              responseObservedAt,
+              source: "request-to-observed-message" as const,
+            },
+          }),
+    };
   } catch (error) {
     if (
       !run.expectReply &&

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -293,6 +293,7 @@ const qaFlowStepSchema = z.object({
   name: z.string().trim().min(1),
   actions: z.array(qaFlowActionSchema).min(1),
   detailsExpr: z.string().trim().min(1).optional(),
+  resultExpr: z.string().trim().min(1).optional(),
 });
 
 const qaFlowSchema = z.object({

--- a/extensions/qa-lab/src/scenario-flow-runner.deadline.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.deadline.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import type { QaScenarioFlow } from "./scenario-catalog.js";
 import { runScenarioFlow } from "./scenario-flow-runner.js";
+import type { QaSuiteStepOutcome } from "./suite-types.js";
 
 type QaFlowAction = QaScenarioFlow["steps"][number]["actions"][number];
 
@@ -87,7 +88,7 @@ describe("scenario flow deadline", () => {
     let markActionStarted!: () => void;
     let releaseAction!: () => void;
     let expireDeadline!: (reason: Error) => void;
-    let pendingStep: Promise<string | void> | undefined;
+    let pendingStep: Promise<QaSuiteStepOutcome | void> | undefined;
     const actionStarted = new Promise<void>((resolve) => {
       markActionStarted = resolve;
     });

--- a/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
@@ -1,11 +1,7 @@
 import { createQaBusState } from "./bus-state.js";
 import { readQaScenarioById, type QaScenarioFlow } from "./scenario-catalog.js";
 import { runScenarioFlow } from "./scenario-flow-runner.js";
-
-type QaFlowStep = {
-  name: string;
-  run: () => Promise<string | void>;
-};
+import type { QaSuiteStep } from "./suite-types.js";
 
 function formatTestTranscript(state: ReturnType<typeof createQaBusState>) {
   return state
@@ -146,10 +142,11 @@ export async function runLoadedScenarioFlow(
       }
       throw new Error(`timed out after ${timeoutMs}ms waiting for outbound marker`);
     },
-    runScenario: async (_name: string, steps: QaFlowStep[]) => {
+    runScenario: async (_name: string, steps: QaSuiteStep[]) => {
       const stepResults = [];
       for (const step of steps) {
-        const details = await step.run();
+        const outcome = await step.run();
+        const details = outcome?.details;
         stepResults.push({
           name: step.name,
           status: "pass" as const,

--- a/extensions/qa-lab/src/scenario-flow-runner.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./scenario-catalog.js";
 import { runScenarioFlow } from "./scenario-flow-runner.js";
 import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+import type { QaSuiteStep } from "./suite-types.js";
 
 function readWebchatTranscriptWaitFlow() {
   const scenario = readQaScenarioById("webchat-direct-reply-routing");
@@ -743,13 +744,10 @@ describe("scenario-flow-runner", () => {
           execution: { kind: "flow" },
         },
         config: {},
-        runScenario: async (
-          _name: string,
-          steps: Array<{ name: string; run: () => Promise<string | void> }>,
-        ) => {
+        runScenario: async (_name: string, steps: QaSuiteStep[]) => {
           const stepResults = [];
           for (const step of steps) {
-            const details = await step.run();
+            const details = (await step.run())?.details;
             stepResults.push({
               name: step.name,
               status: "pass" as const,
@@ -816,13 +814,10 @@ describe("scenario-flow-runner", () => {
           execution: { kind: "flow" },
         },
         config: {},
-        runScenario: async (
-          _name: string,
-          steps: Array<{ name: string; run: () => Promise<string | void> }>,
-        ) => {
+        runScenario: async (_name: string, steps: QaSuiteStep[]) => {
           const stepResults = [];
           for (const step of steps) {
-            const details = await step.run();
+            const details = (await step.run())?.details;
             stepResults.push({
               name: step.name,
               status: "pass" as const,
@@ -881,10 +876,7 @@ describe("scenario-flow-runner", () => {
           execution: { kind: "flow" },
         },
         config: {},
-        runScenario: async (
-          _name: string,
-          steps: Array<{ name: string; run: () => Promise<string | void> }>,
-        ) => {
+        runScenario: async (_name: string, steps: QaSuiteStep[]) => {
           try {
             await steps[0]?.run();
           } catch (error) {

--- a/extensions/qa-lab/src/scenario-flow-runner.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.ts
@@ -2,23 +2,7 @@
 import { isRecord as isPlainObject } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { QaTransportState } from "./qa-transport.js";
 import type { QaScenarioFlow, QaSeedScenarioWithSource } from "./scenario-catalog.js";
-
-type QaSuiteStep = {
-  name: string;
-  run: () => Promise<string | void>;
-};
-
-type QaSuiteScenarioResult = {
-  name: string;
-  status: "pass" | "fail" | "skip";
-  steps: Array<{
-    name: string;
-    status: "pass" | "fail" | "skip";
-    details?: string;
-  }>;
-  details?: string;
-  modelSwitchEvidence?: Record<string, unknown>;
-};
+import type { QaSuiteScenarioResult, QaSuiteStep, QaSuiteStepOutcome } from "./suite-types.js";
 
 type QaFlowApi = Record<string, unknown> & {
   signal?: AbortSignal;
@@ -96,6 +80,16 @@ function formatFlowDetails(details: unknown) {
     return String(details);
   }
   return JSON.stringify(details, null, 2);
+}
+
+function resolveFlowResultRttMs(result: unknown) {
+  if (!isPlainObject(result)) {
+    return undefined;
+  }
+  const timing = isPlainObject(result.timing) ? result.timing : undefined;
+  const measurement = isPlainObject(result.rttMeasurement) ? result.rttMeasurement : undefined;
+  const rttMs = timing?.rttMs ?? measurement?.finalMatchedReplyRttMs ?? result.rttMs;
+  return typeof rttMs === "number" && Number.isFinite(rttMs) && rttMs > 0 ? rttMs : undefined;
 }
 
 function getPathWithParent(
@@ -396,12 +390,24 @@ export async function runScenarioFlow(params: {
       for (const action of step.actions) {
         await runFlowAction(action, params.api, vars);
       }
-      if (!step.detailsExpr) {
+      if (!step.detailsExpr && !step.resultExpr) {
         return undefined;
       }
       throwIfFlowAborted(params.api);
       try {
-        return formatFlowDetails(await evalExpr(step.detailsExpr, params.api, vars));
+        const details = step.detailsExpr
+          ? formatFlowDetails(await evalExpr(step.detailsExpr, params.api, vars))
+          : undefined;
+        const rttMs = step.resultExpr
+          ? resolveFlowResultRttMs(await evalExpr(step.resultExpr, params.api, vars))
+          : undefined;
+        if (rttMs === undefined) {
+          return details === undefined ? undefined : { details };
+        }
+        return {
+          ...(details === undefined ? {} : { details }),
+          timing: { rttMs },
+        } satisfies QaSuiteStepOutcome;
       } finally {
         throwIfFlowAborted(params.api);
       }

--- a/extensions/qa-lab/src/scenario-module-flow.test.ts
+++ b/extensions/qa-lab/src/scenario-module-flow.test.ts
@@ -1,7 +1,61 @@
 import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { buildQaSuiteEvidenceSummary } from "./evidence-summary.js";
+import type { QaScenarioFlow, QaSeedScenarioWithSource } from "./scenario-catalog.js";
+import { runScenarioFlow } from "./scenario-flow-runner.js";
 import { qaScenarioModuleFlow } from "./scenario-module-flow.js";
+import { runQaSuiteScenarioSteps } from "./suite-runtime-flow.js";
 
 describe("QA scenario module flow", () => {
+  it.each([
+    ["canonical timing", { timing: { rttMs: 1750 } }],
+    ["structured measurement", { rttMeasurement: { finalMatchedReplyRttMs: 1750 } }],
+    ["top-level RTT", { rttMs: 1750 }],
+  ])("carries %s from a module result into final QA evidence", async (_label, timingResult) => {
+    const moduleSource = [
+      "export async function runScenario() {",
+      `  return ${JSON.stringify({ details: "reply matched", ...timingResult })};`,
+      "}",
+    ].join("\n");
+    const moduleFlow = qaScenarioModuleFlow.moduleSchema.parse({
+      module: `data:text/javascript,${encodeURIComponent(moduleSource)}`,
+      call: "runScenario",
+    });
+    const flow = qaScenarioModuleFlow.resolveFlow(moduleFlow, "Discord canary") as QaScenarioFlow;
+    const scenario = {
+      id: "discord-canary",
+      title: "Discord canary",
+      sourcePath: "qa/scenarios/discord-canary.yaml",
+      surface: "discord",
+      objective: "measure Discord reply latency",
+      successCriteria: ["matched reply records RTT"],
+      execution: { kind: "flow", flow, flowKind: "module" },
+    } satisfies QaSeedScenarioWithSource;
+
+    const result = await runScenarioFlow({
+      api: {
+        state: createQaBusState(),
+        scenario,
+        config: {},
+        runScenario: runQaSuiteScenarioSteps,
+      },
+      flow,
+      scenarioTitle: scenario.title,
+    });
+    const evidence = buildQaSuiteEvidenceSummary({
+      artifactPaths: [],
+      channelId: "discord",
+      generatedAt: "2026-09-03T00:00:00.000Z",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      providerMode: "mock-openai",
+      scenarioDefinitions: [scenario],
+      scenarioResults: [result],
+    });
+
+    expect(result.timing).toEqual({ rttMs: 1750 });
+    expect(evidence.entries[0]?.result.timing).toEqual({ rttMs: 1750 });
+  });
+
   it("resolves a module export argument against the loaded scenario module", () => {
     const flow = qaScenarioModuleFlow.moduleSchema.parse({
       module: "./scenario-runtime.js",

--- a/extensions/qa-lab/src/scenario-module-flow.ts
+++ b/extensions/qa-lab/src/scenario-module-flow.ts
@@ -253,6 +253,7 @@ function resolveQaScenarioFileFlow<TFlow extends QaScenarioFlowShape>(
         ],
         detailsExpr:
           "result.details ?? (result.artifacts ? JSON.stringify(result.artifacts, null, 2) : undefined)",
+        resultExpr: "result",
       },
     ],
   };

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -318,7 +318,7 @@ describe("qa suite runtime flow", () => {
         };
       }
     ).deps;
-    const scenarioStep = vi.fn(async () => "not reached");
+    const scenarioStep = vi.fn(async () => ({ details: "not reached" }));
     await expect(
       capturedDeps.runScenario("Matrix preparation", [{ name: "Scenario", run: scenarioStep }]),
     ).resolves.toEqual({

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -30,6 +30,7 @@ import * as suiteRuntimeAgent from "./suite-runtime-agent.js";
 import * as suiteRuntimeGateway from "./suite-runtime-gateway.js";
 import * as suiteRuntimeTransport from "./suite-runtime-transport.js";
 import type { QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
+import type { QaSuiteScenarioResult, QaSuiteStep } from "./suite-types.js";
 import { resolveQaGatewayTimeoutWithGraceMs } from "./timer-timeouts.js";
 import * as webRuntime from "./web-runtime.js";
 
@@ -94,33 +95,23 @@ const qaSuiteScenarioIdentityDeps = {
   normalizeLowercaseStringOrEmpty,
 };
 
-type QaSuiteStep = {
-  name: string;
-  run: () => Promise<string | void>;
-};
-
-type QaSuiteScenarioResult = {
-  name: string;
-  status: "pass" | "fail" | "skip";
-  steps: Array<{
-    name: string;
-    status: "pass" | "fail" | "skip";
-    details?: string;
-  }>;
-  details?: string;
-};
-
 export async function runQaSuiteScenarioSteps(
   name: string,
   steps: QaSuiteStep[],
 ): Promise<QaSuiteScenarioResult> {
   const stepResults: QaSuiteScenarioResult["steps"] = [];
+  let timing: QaSuiteScenarioResult["timing"];
   for (const step of steps) {
     try {
       if (process.env.OPENCLAW_QA_DEBUG === "1") {
         console.error(`[qa-suite] start scenario="${name}" step="${step.name}"`);
       }
-      const details = await step.run();
+      const outcome = await step.run();
+      const details = outcome?.details;
+      if (outcome?.timing) {
+        timing ??= {};
+        Object.assign(timing, outcome.timing);
+      }
       if (process.env.OPENCLAW_QA_DEBUG === "1") {
         console.error(`[qa-suite] pass scenario="${name}" step="${step.name}"`);
       }
@@ -133,16 +124,28 @@ export async function runQaSuiteScenarioSteps(
       const details = formatQaErrorMessage(error);
       if (error instanceof QaSuiteScenarioSkipError) {
         stepResults.push({ name: step.name, status: "skip", details });
-        return { name, status: "skip", steps: stepResults, details };
+        return {
+          name,
+          status: "skip",
+          steps: stepResults,
+          details,
+          ...(timing ? { timing } : {}),
+        };
       }
       if (process.env.OPENCLAW_QA_DEBUG === "1") {
         console.error(`[qa-suite] fail scenario="${name}" step="${step.name}" details=${details}`);
       }
       stepResults.push({ name: step.name, status: "fail", details });
-      return { name, status: "fail", steps: stepResults, details };
+      return {
+        name,
+        status: "fail",
+        steps: stepResults,
+        details,
+        ...(timing ? { timing } : {}),
+      };
     }
   }
-  return { name, status: "pass", steps: stepResults };
+  return { name, status: "pass", steps: stepResults, ...(timing ? { timing } : {}) };
 }
 
 type QaSuiteScenarioDepsParams = {

--- a/extensions/qa-lab/src/suite-types.ts
+++ b/extensions/qa-lab/src/suite-types.ts
@@ -16,12 +16,23 @@ import type { QaScorecardChannelDriver, QaScorecardEvidenceMode } from "./scorec
 import type { QaSuiteRoundTripProbe } from "./suite-round-trip.js";
 import type { QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
 
+export type QaSuiteStepOutcome = {
+  details?: string;
+  timing?: QaEvidenceTiming;
+};
+
+export type QaSuiteStep = {
+  name: string;
+  run: () => Promise<QaSuiteStepOutcome | void>;
+};
+
 export type QaSuiteScenarioResult = {
   name: string;
   status: "pass" | "fail" | "skip";
   steps: QaReportCheck[];
   details?: string;
   timing?: QaEvidenceTiming;
+  modelSwitchEvidence?: Record<string, unknown>;
   runtimeParity?: RuntimeParityResult;
 };
 

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -28,15 +28,11 @@ import type {
   QaSuiteEnvironment,
   QaSuiteResult as QaSuiteBaseResult,
   QaSuiteRunParams as QaSuiteBaseRunParams,
-  QaSuiteScenarioResult as QaSuiteBaseScenarioResult,
+  QaSuiteScenarioResult,
   QaSuiteStartLabFn,
 } from "./suite-types.js";
 
-export type QaSuiteScenarioResult = QaSuiteBaseScenarioResult & {
-  modelSwitchEvidence?: Record<string, unknown>;
-};
-
-export type { QaSuiteStartLabFn } from "./suite-types.js";
+export type { QaSuiteScenarioResult, QaSuiteStartLabFn };
 
 export async function createQaSuiteTransportAdapter(params: {
   adapterOptions?: QaSuiteRunParams["adapterOptions"];


### PR DESCRIPTION
Regression provenance: #108429

## What Problem This Solves

Fixes an issue where successful live Discord QA scenarios could match a reply but omit reply latency from final QA evidence. The downstream RTT importer correctly rejects successful scenarios without request/response timing, so Discord RTT rows appeared missing or failed even though the channel scenario passed.

## Why This Change Was Made

PR #108429 introduced two linked data-loss points:

1. The Discord matched-reply producer returned only `{ details: "reply matched" }`, discarding the sent and observed timestamps.
2. Generic module-flow execution saved the producer result but reduced every step to a details string, so structured RTT was still lost before `QaSuiteScenarioResult` reached evidence generation.

The repair records Discord request/response timestamps at the producer, then gives QA flow steps one canonical structured outcome carrying optional `details` and `timing`. Module results explicitly project their RTT into `QaSuiteScenarioResult.timing.rttMs`; the existing evidence builder consumes that canonical field. The projection accepts the existing module result forms: `timing.rttMs`, `rttMeasurement.finalMatchedReplyRttMs`, and top-level `rttMs`.

The canonical suite result now also owns the existing `modelSwitchEvidence` field, and `suite.ts` re-exports that type instead of maintaining a second result alias. All affected tests use the structured step-outcome contract.

This is generic to module-backed QA scenarios and also preserves RTT from sibling producers such as WhatsApp. It does not weaken the RTT importer or add a Discord-specific downstream fallback.

## User Impact

Operators consuming OpenClaw QA evidence can again obtain structured Discord reply latency from successful live scenarios. RTT dashboards and imports receive the actual request-to-observed-reply measurement instead of a passing result with no usable timing.

## ClawSweeper Dispositions

- Slack follow-up: Slack has a separate producer gap across message, approval, and Codex-approval branches. The generic propagation in this PR is the prerequisite, but Slack producer repair is intentionally separate because it needs channel-specific producer tests, live Slack evidence, and direct sibling `../codex` contract inspection for the Codex approval branch. This is non-blocking for the demonstrated Discord RTT regression.
- Compatibility: `resultExpr` is an optional internal source-catalog flow field generated in memory for module flows; it is not persisted user state or config and needs no migration. Existing flow YAML remains valid.

## Evidence

- Exact head: `3a53f40923e3e099bc53c21b90327d99f040ec00`.
- Exact rebase base: `c5bde6ac9349d45b71bcd1d60f0048d686ac5964`.
- Current-main CSS prerequisite: https://github.com/openclaw/openclaw/pull/136878 landed as https://github.com/openclaw/openclaw/commit/507e5faf28500d12b8b43c8d0ad7996190e27d5d, removed the redundant Control UI selector, and proved the startup CSS at the unchanged 45 KiB (`46080 B`) ceiling. Its exact-head `build-artifacts` and `openclaw/ci-gate` checks passed, resolving the inherited UI-budget failure without changing this PR's QA patch.
- Pre-fix integration reproduction: a module returned `rttMeasurement.finalMatchedReplyRttMs: 1750`, but the final suite result had `timing === undefined`. The regression failed with `expected undefined to deeply equal { rttMs: 1750 }`.
- Producer regression: Discord sent timestamp `2026-09-02T12:00:00.000Z` and matched reply timestamp `2026-09-02T12:00:01.750Z` produce `rttMs: 1750` and source `request-to-observed-message`.
- Focused proof:
  `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-module-flow.test.ts extensions/qa-lab/src/scenario-flow-runner.test.ts extensions/qa-lab/src/scenario-flow-runner.deadline.test.ts extensions/qa-lab/src/suite-runtime-flow.test.ts extensions/qa-lab/src/evidence-summary.test.ts extensions/qa-lab/src/live-transports/discord/scenario-runtime.test.ts`
  Result: 6 files passed, 73 tests passed.
- Structured-result coverage proves all three accepted module RTT forms reach final evidence: canonical timing, structured measurement, and top-level RTT.
- Required typecheck: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json` no longer reports the five `modelSwitchEvidence` errors or the two stale string-step errors identified by exact-head review. It still exits nonzero on unrelated stale shared-install errors across ACPX, CUA, Crabline, Telegram, Markdown, TUI, and UI surfaces.
- Formatting: `oxfmt` passed for all changed files.
- Path-scoped lint: direct `oxlint` passed for all changed files.
- Import cycles: 0 runtime value cycles.
- Diff validation: `git diff --check origin/main...HEAD` passed.
- Changed classification: `extensions` and `extensionTests`.
- Changed gate: policy ratchets, formatting, dependency pins, doctor-contract tests, plugin boundaries, package patches, and temp-file checks passed. The gate then stopped in `tsgo:extensions` on the same unrelated stale shared dependency baseline, with no changed-file error.
- Autoreview: exact-head branch-mode scoped-clean at P1, no findings, correctness confidence 0.96.
- Production LOC: +85/-46 (net +39).
- Test LOC: +134/-16 (net +118).
- Test-support LOC: +4/-7 (net -3).
- Live RTT evidence: real pre-fix Discord QA output could report a passing scenario with `details: "reply matched"` while omitting all RTT fields; the strict importer then rejected it as lacking timing. This is the observed live symptom, not a fresh post-fix live-channel run.
- Remote changed gate: the earlier exact-head Crabbox launch stalled before remote command execution and emitted no events. Its task-owned lease/process was stopped cleanly; this PR does not claim that launch as remote proof.
