### PR TITLE
fix(ui): keep notification settings cards full width

### DIFF
--- a/ui/src/pages/config/notifications-section.test.ts
+++ b/ui/src/pages/config/notifications-section.test.ts
@@ -96,7 +96,10 @@ describe("Web Push preference saves", () => {
       container,
     );
 
-    const preferences = container.querySelector<HTMLElement>(".settings-page .settings-page");
+    // Preference sections stack inside the page column; a nested .settings-page
+    // would reapply the 760px max-width and inset them from the card above.
+    expect(container.querySelector(".settings-page .settings-page")).toBeNull();
+    const preferences = container.querySelector<HTMLElement>(".settings-page .settings-stack");
     const preferenceGroup = expectDefined(preferences, "notification preferences group");
     expect(preferenceGroup.querySelector("input, select")).not.toBeNull();
     expect(preferenceGroup.hasAttribute("inert")).toBe(true);
@@ -159,7 +162,7 @@ describe("Web Push preference controls", () => {
     const onDevice = vi.fn<DevicePreferencesListener>();
     const container = renderPreferences({ onDevice });
     const deviceGroup = expectDefined(
-      container.querySelectorAll(".settings-page .settings-page .settings-group")[1],
+      container.querySelectorAll(".settings-page .settings-stack .settings-group")[1],
       "device preference group",
     );
 

--- a/ui/src/pages/config/notifications-section.ts
+++ b/ui/src/pages/config/notifications-section.ts
@@ -568,7 +568,7 @@ export function renderNotificationsSection(props: NotificationsSectionProps) {
         </div>
       </section>
       ${registered && push.preferences
-        ? html`<div class="settings-page" ?inert=${push.loading}>
+        ? html`<div class="settings-stack" ?inert=${push.loading}>
             ${push.preferences.durableIdentity
               ? renderUserNotificationPreferences(push.preferences.user, (preferences) =>
                   props.onWebPushSetUserPreferences?.(preferences),


### PR DESCRIPTION
Fixes #133513

## What Problem This Solves

Fixes an issue where operators opening Settings > Notifications with an active browser push subscription would see the "Account defaults" and "This browser or app" cards render narrower and inset relative to the "Push notifications" card directly above them. The three cards belong to one settings column, so the mismatched left and right borders read as a rendering glitch.

PR #136602 already covered the other half of #133513 (the preference controls now use the shared settings switch/select set). This is the remaining half: the card widths.

## Why This Change Was Made

The notifications section opened a second `.settings-page` wrapper inside the one it already opens for the whole section. `.settings-page` is the centered settings column: it reapplies `max-width: 760px` and horizontal padding, so nesting it inset every card it contained by one more `--space-4` per side.

The inner wrapper only ever needed section rhythm, which is exactly what `.settings-stack` exists for (`ui/src/styles/settings.css`, "Section rhythm for embedded surfaces ... that host settings sections without .settings-page's centered column"). The agents page uses it for the same job at `ui/src/pages/agents/view.ts` (the `#agent-panel` tab panel). The fix is that one class; nothing else changed.

## User Impact

Settings > Notifications now renders "Push notifications", "Account defaults", and "This browser or app" as one aligned column, with identical card edges, in every theme.

## Evidence

Measured in Chromium at 1440px, `.settings-group` widths inside the section:

- before: `728px` (Push notifications), `696px`, `696px` — the two preference cards are 32px narrower and inset 16px per side
- after: `728px`, `728px`, `728px`

Before / after, dark:

![before dark](https://github.com/user-attachments/assets/295e0496-d993-4d29-a4a4-b1542feb585e)

![after dark](https://github.com/user-attachments/assets/7d3f6c0f-7fe2-4f30-937f-9bc1bd93189a)

Before / after, light:

![before light](https://github.com/user-attachments/assets/7d8816e6-e716-44af-a8d2-91ca618682c6)

![after light](https://github.com/user-attachments/assets/950a87a9-c0d9-41b1-bf0d-0c850392910f)

Screenshots come from the real `renderNotificationsSection` output rendered under the real Control UI stylesheets in Chromium, following the existing `ui/src/**/*.browser.test.ts` layout-proof pattern. The mock gateway (`scripts/control-ui-mock-dev.ts`) has no Web Push preference RPCs and a real subscription needs a live push service, so the Account defaults section cannot be reached on the mock dev server; the harness was scratch-only and is not part of the diff.

Regression coverage: `ui/src/pages/config/notifications-section.test.ts` now asserts the section contains no nested `.settings-page`. That assertion fails on pre-fix code (`expected device preference group to be defined`, 2 errors) and passes after.

```
$ node scripts/run-vitest.mjs ui/src/pages/config/notifications-section.test.ts
Test Files  1 passed (1)
     Tests  6 passed (6)
```

`git diff --numstat` (production vs tests):

```
1  1  ui/src/pages/config/notifications-section.ts        <- production, net 0
5  2  ui/src/pages/config/notifications-section.test.ts   <- tests
```

Blast radius: `.settings-stack` has one other consumer (`ui/src/pages/agents/view.ts`) and no CSS or test depended on the nested `.settings-page`; the two test selectors that did are updated here.

CI history on this branch: the first runs were red on `build-artifacts` / `checks-ui-e2e-real-gateway` (Control UI startup **JS** gzip budget, which `main` itself had already exceeded — reproduced on clean `origin/main` with the same `startup JS gzip: 341.4 KiB exceeds 341.1 KiB`), then on `checks-node-compact-small-*` (`test/scripts/repo-e2e-artifacts.test.ts` from #136634) and the startup **CSS** budget. None of those are reachable from a wrapper class rename. #136817 re-baselined the JS budget and #136878 fixed the other two; this branch is rebased on top of both.
