### PR TITLE
chore(ui): re-baseline Control UI startup JS budget to 349565 B

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 349249,
-  "reason": "Control UI locale refresh (#136659) and chat face switch/visibility menu additions (#136646-#136650) add 581 B (0.17%) over the 348668 B baseline; observed 349249 B on main-based PR builds exceeded the 349244 B enforcement limit by 5 B; fixed 358400 B cap and existing allowances retained",
+  "startupJsGzipBytes": 349565,
+  "reason": "Integrated Control UI and dependency changes since the 348668 B baseline, including chat face/visibility, locale, first-render, Meetings, and Appearance work, now measure 349565 B (+897 B, 0.26%); an independent exact-head build measured 349533 B (32 B lower, within the 64 B build-variance allowance); fixed 358400 B cap and existing allowances retained",
   "updatedAt": "2026-09-03"
 }

--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 348668,
-  "reason": "Model provider defaults consolidation, autosave, and contextual help add 235 B (0.07%) over the reconciled 348433 B main baseline; fixed 358400 B cap and existing allowances retained",
-  "updatedAt": "2026-09-01"
+  "startupJsGzipBytes": 349249,
+  "reason": "Control UI locale refresh (#136659) and chat face switch/visibility menu additions (#136646-#136650) add 581 B (0.17%) over the 348668 B baseline; observed 349249 B on main-based PR builds exceeded the 349244 B enforcement limit by 5 B; fixed 358400 B cap and existing allowances retained",
+  "updatedAt": "2026-09-03"
 }


### PR DESCRIPTION
## What Problem This Solves

`build-artifacts` began failing after integrated Control UI changes moved startup JavaScript beyond the enforcement limit derived from the older `348668 B` baseline.

## Why This Change Was Made

The current integrated startup bundle measures `349565 B`. This re-baselines the observed bundle without changing the fixed `358400 B` cap, the `512 B` growth allowance, or the `64 B` build-variance allowance.

The growth since the prior baseline includes chat face/visibility, locale, first-render, Meetings, and Appearance work.

## User Impact

None at runtime. The change restores accurate CI enforcement for subsequent Control UI growth.

## Evidence

- Hosted exact-head measurement: `349565 B`.
- Independent exact-head build: `349533 B`, a `32 B` spread within the existing `64 B` build-variance allowance.
- Local candidate build: `349559 B`.
- `node --import ./scripts/tsx.mjs scripts/check-control-ui-performance.mts --json`: zero violations; enforcement limit `350141 B`.
- `node scripts/run-vitest.mjs test/scripts/control-ui-performance.test.ts`: 26 tests passed.
- `node scripts/check-changed.mjs --dry-run -- config/control-ui-startup-budget-baseline.json`: tooling lane selected.
- `oxfmt` stdin comparison and `git diff --check`: clean.
- Sol-high autoreview: no accepted or actionable findings.
