### PR TITLE
perf(media): write QR images without base64 copies

### DIFF
--- a/src/media/qr-image.ts
+++ b/src/media/qr-image.ts
@@ -56,11 +56,7 @@ function resolveQrTempPathSegment(name: string, value: string): string {
   return value;
 }
 
-/** Renders QR text as raw PNG base64 after validating bounded renderer options. */
-export async function renderQrPngBase64(
-  input: string,
-  opts: QrPngRenderOptions = {},
-): Promise<string> {
+async function renderQrPngBuffer(input: string, opts: QrPngRenderOptions): Promise<Buffer> {
   const scale = resolveQrPngIntegerOption({
     name: "scale",
     value: opts.scale,
@@ -76,16 +72,18 @@ export async function renderQrPngBase64(
     max: MAX_QR_PNG_MARGIN_MODULES,
   });
   const qrCode = await loadQrCodeRuntime();
-  const png = await qrCode.toBuffer(input, {
+  return await qrCode.toBuffer(input, {
     margin: marginModules,
     scale,
   });
-  return png.toString("base64");
 }
 
-/** Wraps PNG base64 in the exact data URL prefix expected by chat/media callers. */
-function formatQrPngDataUrl(base64: string): string {
-  return `${QR_PNG_DATA_URL_PREFIX}${base64}`;
+/** Renders QR text as raw PNG base64 after validating bounded renderer options. */
+export async function renderQrPngBase64(
+  input: string,
+  opts: QrPngRenderOptions = {},
+): Promise<string> {
+  return (await renderQrPngBuffer(input, opts)).toString("base64");
 }
 
 /** Renders QR text as a PNG data URL. */
@@ -93,7 +91,7 @@ export async function renderQrPngDataUrl(
   input: string,
   opts: QrPngRenderOptions = {},
 ): Promise<string> {
-  return formatQrPngDataUrl(await renderQrPngBase64(input, opts));
+  return `${QR_PNG_DATA_URL_PREFIX}${await renderQrPngBase64(input, opts)}`;
 }
 
 /** Writes QR PNG output into a scoped temp directory and returns that directory as a media root. */
@@ -103,11 +101,11 @@ export async function writeQrPngTempFile(
 ): Promise<QrPngTempFile> {
   const dirPrefix = resolveQrTempPathSegment("dirPrefix", opts.dirPrefix);
   const fileName = resolveQrTempPathSegment("fileName", opts.fileName ?? "qr.png");
-  const pngBase64 = await renderQrPngBase64(input, opts);
+  const png = await renderQrPngBuffer(input, opts);
   const workspace = await tempWorkspace({ rootDir: opts.tmpRoot, prefix: dirPrefix });
   const dirPath = workspace.dir;
   try {
-    const filePath = await workspace.write(fileName, Buffer.from(pngBase64, "base64"));
+    const filePath = await workspace.write(fileName, png);
     return {
       filePath,
       dirPath,


### PR DESCRIPTION
## What Problem This Solves

Generating a QR image file temporarily converts the rendered PNG to base64 and then decodes it back into another PNG buffer before writing it. Device-pair QR delivery pays for both conversions even though it needs binary bytes.

## Why This Change Was Made

Keep rendering in one private buffer-returning function and encode only at the public base64/data URL boundaries. File generation writes those rendered bytes directly through the existing private temp workspace. The redundant data-URL formatting wrapper is removed. Public exports, option validation, error ordering, file permissions, and cleanup remain unchanged.

Production LOC: +11/-13 (net -2); tests unchanged. This is a maintainer-requested performance cleanup.

## User Impact

QR image file generation allocates fewer intermediate strings and buffers. The generated PNG files and public base64/data URLs are identical.

## Evidence

- Existing `src/media/qr-image.test.ts`: all 13 tests passed, including option validation, defaults, rounding, temp paths, and encoding.
- The repository's complete changed-file gate passed. Its first attempt found missing package-local dependency links in this worktree; the corrected dependency setup passed without source changes.
- Real `qrcode` rendering before/after for plain text, Unicode text, and a large synthetic input produced identical PNG SHA-256 hashes, dimensions, base64/data URLs, and 0600 file permissions. The Unicode images were inspected.
- The large case produced a 60,418-byte PNG. The removed conversion path created an 80,560-character base64 string and another decoded 60,418-byte buffer. These are avoided conversion allocations, not a measured retained-heap or whole-Gateway RSS claim.
- Inspected the actual device-pair caller, shared public facade and Gateway data-URL callers, plus the installed `qrcode` buffer-rendering and private-temp-workspace contracts.
- Independent Codex review through P2: scoped clean, no accepted/actionable findings.
