### PR TITLE
fix(gateway): prevent SVG favicon validation freezes

### DIFF
--- a/src/gateway/http-image-response.test.ts
+++ b/src/gateway/http-image-response.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { resolveHttpImageRepresentation, startsWithSvgRootElement } from "./http-image-response.js";
+
+// A closed comment ends at its first `-->`, so this is comment-like markup that
+// never reaches a root element. The pattern this scanner replaced explored every
+// way of splitting the repeats and took exponential time on exactly this shape.
+function buildUnterminatedCommentRun(repeats: number): string {
+  return `<!--${"--><!--".repeat(repeats)}-->X`;
+}
+
+describe("startsWithSvgRootElement", () => {
+  it.each([
+    ["a bare root element", "<svg></svg>"],
+    ["leading whitespace", "\n\t <svg >"],
+    ["an XML declaration", '<?xml version="1.0"?><svg>'],
+    ["an uppercase root element", "<SVG>"],
+    ["a leading comment", "<!-- icon --><svg>"],
+    ["several leading comments", "<!-- a --> <!-- b --><svg>"],
+  ])("accepts %s", (_label, text) => {
+    expect(startsWithSvgRootElement(text)).toBe(true);
+  });
+
+  it.each([
+    ["a non-SVG root element", "<html><svg></svg></html>"],
+    ["a root-like prefix", "<svgx>"],
+    ["a root element with no delimiter", "<svg/>"],
+    ["an unterminated XML declaration", '<?xml version="1.0"'],
+    ["an unterminated comment", "<!-- never closed <svg>"],
+    ["markup between a comment and the root element", "<!-- a --> junk <svg>"],
+    // A comment ends at its first `-->`; the replaced pattern instead let one
+    // comment absorb this text, so keep the stricter reading pinned.
+    ["markup between two comments", "<!-- a --> junk <!-- b --><svg>"],
+    ["no root element at all", "not markup"],
+  ])("rejects %s", (_label, text) => {
+    expect(startsWithSvgRootElement(text)).toBe(false);
+  });
+
+  it("rejects a comment run in linear time instead of backtracking", () => {
+    const started = process.hrtime.bigint();
+    expect(startsWithSvgRootElement(buildUnterminatedCommentRun(64))).toBe(false);
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+    expect(elapsedMs).toBeLessThan(100);
+  });
+});
+
+describe("resolveHttpImageRepresentation", () => {
+  it("rejects a comment-run SVG body without stalling the event loop", async () => {
+    const started = process.hrtime.bigint();
+    await expect(
+      resolveHttpImageRepresentation("icon.svg", Buffer.from(buildUnterminatedCommentRun(64))),
+    ).resolves.toBeUndefined();
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
+
+  it("still serves a valid SVG body", async () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+    await expect(
+      resolveHttpImageRepresentation("icon.svg", Buffer.from(svg)),
+    ).resolves.toMatchObject({ contentType: "image/svg+xml" });
+  });
+});

--- a/src/gateway/http-image-response.test.ts
+++ b/src/gateway/http-image-response.test.ts
@@ -1,16 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { resolveHttpImageRepresentation, startsWithSvgRootElement } from "./http-image-response.js";
-
-// A closed comment ends at its first `-->`, so this is comment-like markup that
-// never reaches a root element. The pattern this scanner replaced explored every
-// way of splitting the repeats and took exponential time on exactly this shape.
-function buildUnterminatedCommentRun(repeats: number): string {
-  return `<!--${"--><!--".repeat(repeats)}-->X`;
-}
+import { startsWithSvgRootElement } from "./http-image-response.js";
 
 describe("startsWithSvgRootElement", () => {
   it.each([
     ["a bare root element", "<svg></svg>"],
+    ["a self-closing root element", "<svg/>"],
     ["leading whitespace", "\n\t <svg >"],
     ["an XML declaration", '<?xml version="1.0"?><svg>'],
     ["an uppercase root element", "<SVG>"],
@@ -23,7 +17,7 @@ describe("startsWithSvgRootElement", () => {
   it.each([
     ["a non-SVG root element", "<html><svg></svg></html>"],
     ["a root-like prefix", "<svgx>"],
-    ["a root element with no delimiter", "<svg/>"],
+    ["an incomplete self-closing root element", "<svg/"],
     ["an unterminated XML declaration", '<?xml version="1.0"'],
     ["an unterminated comment", "<!-- never closed <svg>"],
     ["markup between a comment and the root element", "<!-- a --> junk <svg>"],
@@ -33,30 +27,5 @@ describe("startsWithSvgRootElement", () => {
     ["no root element at all", "not markup"],
   ])("rejects %s", (_label, text) => {
     expect(startsWithSvgRootElement(text)).toBe(false);
-  });
-
-  it("rejects a comment run in linear time instead of backtracking", () => {
-    const started = process.hrtime.bigint();
-    expect(startsWithSvgRootElement(buildUnterminatedCommentRun(64))).toBe(false);
-    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
-    expect(elapsedMs).toBeLessThan(100);
-  });
-});
-
-describe("resolveHttpImageRepresentation", () => {
-  it("rejects a comment-run SVG body without stalling the event loop", async () => {
-    const started = process.hrtime.bigint();
-    await expect(
-      resolveHttpImageRepresentation("icon.svg", Buffer.from(buildUnterminatedCommentRun(64))),
-    ).resolves.toBeUndefined();
-    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
-    expect(elapsedMs).toBeLessThan(1_000);
-  });
-
-  it("still serves a valid SVG body", async () => {
-    const svg = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
-    await expect(
-      resolveHttpImageRepresentation("icon.svg", Buffer.from(svg)),
-    ).resolves.toMatchObject({ contentType: "image/svg+xml" });
   });
 });

--- a/src/gateway/http-image-response.ts
+++ b/src/gateway/http-image-response.ts
@@ -92,7 +92,11 @@ export function startsWithSvgRootElement(text: string): boolean {
     return false;
   }
   const delimiter = text[index + "<svg".length];
-  return delimiter === ">" || (delimiter !== undefined && /\s/u.test(delimiter));
+  return (
+    delimiter === ">" ||
+    (delimiter === "/" && text[index + "<svg/".length] === ">") ||
+    (delimiter !== undefined && /\s/u.test(delimiter))
+  );
 }
 
 /**

--- a/src/gateway/http-image-response.ts
+++ b/src/gateway/http-image-response.ts
@@ -48,6 +48,53 @@ export function createHttpImageRepresentation(
   };
 }
 
+// Sticky `\s*` keeps whitespace skipping identical to the character class used by
+// the pattern this scanner replaced, without rescanning the string.
+const SVG_PROLOGUE_WHITESPACE_RE = /\s*/y;
+
+function skipSvgPrologueWhitespace(text: string, index: number): number {
+  SVG_PROLOGUE_WHITESPACE_RE.lastIndex = index;
+  SVG_PROLOGUE_WHITESPACE_RE.exec(text);
+  return SVG_PROLOGUE_WHITESPACE_RE.lastIndex;
+}
+
+function startsWithToken(text: string, index: number, token: string): boolean {
+  return text.slice(index, index + token.length).toLowerCase() === token;
+}
+
+/**
+ * Recognizes an SVG root element after an optional XML declaration and comments.
+ *
+ * An index scan rather than a regex on purpose: the equivalent
+ * `(?:<!--[\s\S]*?-->\s*)*<svg` backtracks exponentially on comment-like bytes that
+ * never reach a root element, and these bytes arrive from remote icon and
+ * link-favicon responses on the Gateway's single event loop, so one crafted
+ * response would stall every session. A comment ends at its first `-->`, so text
+ * between a closed comment and the root element is rejected, not absorbed.
+ */
+export function startsWithSvgRootElement(text: string): boolean {
+  let index = skipSvgPrologueWhitespace(text, 0);
+  if (startsWithToken(text, index, "<?xml")) {
+    const declarationEnd = text.indexOf(">", index);
+    if (declarationEnd < 0) {
+      return false;
+    }
+    index = skipSvgPrologueWhitespace(text, declarationEnd + 1);
+  }
+  while (startsWithToken(text, index, "<!--")) {
+    const commentEnd = text.indexOf("-->", index + "<!--".length);
+    if (commentEnd < 0) {
+      return false;
+    }
+    index = skipSvgPrologueWhitespace(text, commentEnd + "-->".length);
+  }
+  if (!startsWithToken(text, index, "<svg")) {
+    return false;
+  }
+  const delimiter = text[index + "<svg".length];
+  return delimiter === ">" || (delimiter !== undefined && /\s/u.test(delimiter));
+}
+
 /**
  * SVG images stay self-contained: no script, document expansion, embedded
  * documents, or outbound fetches can reach the browser through an image route.
@@ -62,7 +109,7 @@ function isRenderableHttpSvg(body: Buffer): boolean {
     !/<!doctype|<!entity/iu.test(text) &&
     !/<\s*(?:script|foreignObject|image|use|iframe)\b/iu.test(text) &&
     !/\b(?:href|xlink:href|src)\s*=/iu.test(text) &&
-    /^\s*(?:<\?xml[^>]*>\s*)?(?:<!--[\s\S]*?-->\s*)*<svg(?:\s|>)/iu.test(text)
+    startsWithSvgRootElement(text)
   );
 }
 

--- a/src/gateway/plugin-icon-http.test.ts
+++ b/src/gateway/plugin-icon-http.test.ts
@@ -3,7 +3,9 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
 import { APNG_BYTES } from "./http-image.test-support.js";
+import { AUTH_NONE, sendRequest, withGatewayServer } from "./server-http.test-harness.js";
 
 const mocks = vi.hoisted(() => ({
   authorize: vi.fn(),
@@ -208,6 +210,41 @@ describe("Control UI plugin and catalog icon routes", () => {
       readIdleTimeoutMs: PLUGIN_ICON_REQUEST_TIMEOUT_MS,
     });
     expect(fetchOptions).not.toHaveProperty("ssrfPolicy");
+  });
+
+  it("keeps the Gateway responsive while rejecting an adversarial SVG favicon", async () => {
+    const validationStarted = createDeferredCore();
+    mocks.readRemoteMediaBuffer.mockImplementationOnce(async () => {
+      validationStarted.resolve();
+      return {
+        buffer: Buffer.from(`<!--${"--><!--".repeat(26)}-->X`),
+        contentType: "image/svg+xml",
+      };
+    });
+
+    await withGatewayServer({
+      prefix: "link-favicon-svg-validation-",
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        controlUiEnabled: true,
+        controlUiBasePath: "",
+        getRuntimeConfig: () => ({}),
+      },
+      run: async (gateway) => {
+        const started = process.hrtime.bigint();
+        const favicon = sendRequest(gateway, {
+          path: "/__openclaw__/link-favicon/example.com",
+        });
+        await validationStarted.promise;
+        const health = sendRequest(gateway, { path: "/healthz" });
+        const [faviconResponse, healthResponse] = await Promise.all([favicon, health]);
+        const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+
+        expect(faviconResponse.res.statusCode).toBe(404);
+        expect(healthResponse.res.statusCode).toBe(200);
+        expect(elapsedMs).toBeLessThan(500);
+      },
+    });
   });
 
   it("serves standard ICO favicon bytes without invoking raster processing", async () => {

--- a/src/gateway/plugin-icon-http.ts
+++ b/src/gateway/plugin-icon-http.ts
@@ -25,6 +25,7 @@ import { sendMethodNotAllowed } from "./http-common.js";
 import {
   createHttpImageRepresentation,
   resolveHttpImageMimeType,
+  startsWithSvgRootElement,
   sendHttpImageResponse,
   type HttpImageRepresentation,
 } from "./http-image-response.js";
@@ -72,9 +73,7 @@ async function validateImageMime(body: Buffer, contentType: string): Promise<boo
   if (contentType === SVG_MIME_TYPE) {
     const text = body.toString("utf8");
     return (
-      !text.includes("\0") &&
-      !/<!doctype|<!entity/iu.test(text) &&
-      /^\s*(?:<\?xml[^>]*>\s*)?(?:<!--[\s\S]*?-->\s*)*<svg(?:\s|>)/iu.test(text)
+      !text.includes("\0") && !/<!doctype|<!entity/iu.test(text) && startsWithSvgRootElement(text)
     );
   }
   const detected = await fileTypeFromBuffer(body);


### PR DESCRIPTION
## What Problem This Solves

Control UI link favicons are enabled by default. A linked site can return a small crafted SVG from `/favicon.ico` that makes the Gateway spend unbounded time in regular-expression backtracking. Because validation runs on the Gateway event loop, every session and HTTP route can stop responding.

The same SVG-root check also validates plugin, setup-catalog, channel-avatar, and workspace icons.

## Root Cause

Two production paths used the same nested expression:

```text
(?:<!--[\s\S]*?-->\s*)*<svg
```

Repeated comment-like bytes make the engine explore exponentially many matches. The existing 64 KiB and 256 KiB size limits do not bound that CPU work.

## Fix

- Replace the expression with one linear index scan in the shared HTTP image-response owner.
- Reuse that scanner from the remote plugin, catalog, and favicon validator.
- Keep each caller's existing SVG safety policy.
- End comments at the first `-->`, so markup between a closed comment and `<svg>` fails closed.
- Accept the valid self-closing root `<svg/>` while rejecting an incomplete `<svg/`.
- Add a Gateway-router regression that queues the hostile favicon and `/healthz` requests together.

## Evidence

### Current `main` red

Baseline: `67cfb5770212067667e99882e3c33b4e824a7fff`.

- [Blacksmith proof run](https://github.com/openclaw/openclaw/actions/runs/33713106892): the real Gateway HTTP route reached hostile SVG validation, then the 60-second external watchdog terminated the frozen run.
- [Bounded regression run](https://github.com/openclaw/openclaw/actions/runs/33713636524): the Gateway-router case took `3094.992318 ms` and failed its `<500 ms` ceiling; the other 58 tests passed.

### Exact head green

Head: `4293c513c01cc4e1e37d57c10dbe88e07ff90863`.

- Fresh secretless Linux container with no operator credentials, config, or service data.
- `node scripts/run-vitest.mjs src/gateway/http-image-response.test.ts src/gateway/plugin-icon-http.test.ts --reporter=verbose`: 74 passed.
- The adversarial Gateway-router case completed in `7 ms`; the favicon returned `404`; `/healthz` returned `200`.
- The exact `4/5` core test-type stripe passed.
- Oxfmt and `git diff --check` passed.

## Scope

- No configuration or protocol changes.
- Production: +54 / -4 lines, net +50.
- Tests: +68 / -0 lines.
- The production growth is the shared linear parser required to remove the security failure from both validation owners; the duplicate vulnerable expression is deleted.
