### PR TITLE
fix(deps): move the qs override off two published advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,7 +136,7 @@ overrides:
   mailparser@3.9.15>nodemailer: 9.1.1
   minimatch: 10.2.6
   path-to-regexp: 8.4.2
-  qs: 6.15.3
+  qs: 6.16.0
   node-domexception: npm:@nolyfill/domexception@1.0.28
   typebox: 1.3.18
   tar: 7.5.22
@@ -8602,8 +8602,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quansync@1.0.0:
@@ -11077,7 +11077,7 @@ snapshots:
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
       protobufjs: 8.7.2
-      qs: 6.15.3
+      qs: 6.16.0
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -11310,7 +11310,7 @@ snapshots:
       '@microsoft/teams.cards': 2.0.15
       '@microsoft/teams.common': 2.0.15(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       jwt-decode: 4.0.0
-      qs: 6.15.3
+      qs: 6.16.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -11343,7 +11343,7 @@ snapshots:
   '@microsoft/teams.graph@2.0.15(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@microsoft/teams.common': 2.0.15(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
-      qs: 6.15.3
+      qs: 6.16.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13374,7 +13374,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -14164,7 +14164,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0(supports-color@10.2.2)
       send: 1.2.1(supports-color@10.2.2)
@@ -16252,7 +16252,7 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -87,7 +87,7 @@ overrides:
   "mailparser@3.9.15>nodemailer": 9.1.1
   minimatch: 10.2.6
   path-to-regexp: 8.4.2
-  qs: 6.15.3
+  qs: 6.16.0
   node-domexception: "npm:@nolyfill/domexception@1.0.28"
   typebox: 1.3.18
   tar: 7.5.22


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw installations resolve `qs@6.15.3`, a version affected by two moderate published dependency advisories: [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) and [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g). Both identify `6.16.0` as the patched version.

## Why This Change Was Made

Updates the existing workspace override to `qs@6.16.0` and regenerates the matching lockfile resolutions. Express 5.2.1 declares `qs: ^6.14.0`, so the update satisfies its existing dependency contract. The seven-day release-age policy remains enforced; no qs cooldown exclusion is needed.

This refresh preserves the original fix and moves it onto `48d1551a3327a154ebba5caab03486ae82bf7479` to resolve the PR's stale-base conflict.

## User Impact

Removes the two known qs dependency advisories from the resolved dependency graph without changing OpenClaw configuration or APIs. These are dependency-advisory findings; this PR does not claim either advisory is exploitable through every OpenClaw HTTP endpoint.

## Evidence

Validation repeated on September 7, 2026 against the refreshed source:

- `pnpm audit --json`: baseline has **2 moderate** findings; patched lockfile has **0 findings** across 1,652 reported dependencies.
- `pnpm install --lockfile-only --ignore-scripts`: supply-chain policy validation passed for 1,643 entries. The generated lockfile is identical to the staged patch.
- Isolated real loopback HTTP smoke using Express 5.2.1 and qs 6.16.0: **5/5 passed** (repeated query keys, nested query objects, Unicode and space decoding, URL-encoded form arrays, and configured parameter-limit rejection). Both Express and body-parser resolve qs 6.16.0. This validates the dependency integration; a full OpenClaw Gateway or live channel was not exercised.
- Dependency source inspection: Express's extended query parser and body-parser's URL-encoded parser use qs; the latter retains its parameter-count and depth checks.
- Formatting and `git diff --check` passed. The direct dependency pin guard passed for 670 dependency specifications across 182 manifests.
- Independent `autoreview` at P2 threshold: scoped-clean, no actionable findings. Outgoing review input passed the required TruffleHog scans.
- `node scripts/check-changed.mjs -- pnpm-workspace.yaml pnpm-lock.yaml`: all 95 npm package-lock validations and the completed protocol, dependency-pin, formatting, plugin-boundary, patch, script-erasability, database-first, media-download, and runtime-sidecar guards passed. **Aggregate validation is incomplete:** during the core typecheck startup, the local process remained in kernel filesystem I/O wait (`jbd2_log_wait_commit`). The task-owned run was stopped; full typechecking and later lint/import-cycle stages are not claimed as passed. The refreshed head's hosted CI is running.

Production TypeScript and tests are unchanged. Diff: one override line plus nine lockfile replacements (10 added / 10 removed).

## Review status

The repository's dependency guard requires an authorized admin/secops approval for the current head before merge. Current head: `b632cc2d59ca914b8bf8f0c2f6cbc5322a782cab`. Its [CI run](https://github.com/openclaw/openclaw/actions/runs/34179567972) has attached and `security-fast` passed; the remaining CI is still running. No merge is requested by this update.
