### PR TITLE
fix(release): read frozen auth profile store contract

### DIFF
--- a/scripts/e2e/lib/auth-profile-store-assertions.d.mts
+++ b/scripts/e2e/lib/auth-profile-store-assertions.d.mts
@@ -7,6 +7,8 @@ export type AuthProfileStoreAssertionOptions = {
 
 export declare function readSharedAuthProfileStoreText(stateDir: string): string;
 
+export declare function readCanonicalAuthProfileStoreText(stateDir: string): string;
+
 export declare function assertNoLegacyPrimaryAuthRows(stateDir: string): void;
 
 export declare function assertOpenAiEnvAuthProfileStore(

--- a/scripts/e2e/lib/auth-profile-store-assertions.mjs
+++ b/scripts/e2e/lib/auth-profile-store-assertions.mjs
@@ -45,9 +45,9 @@ function readSharedAuthProfileStore(stateDir) {
       .get(storage.table);
     if (!schema) {
       return {
-        // v13 names the canonical table even when the row is absent. Do not
-        // mistake a broken modern store for the legacy per-agent contract.
-        ownsStore: schemaVersion >= AUTH_PROFILE_MACHINE_STATE_SCHEMA_VERSION,
+        // v7 selects the shared owner. Do not let a missing canonical table
+        // reactivate the retired per-agent contract for a broken target.
+        ownsStore: true,
         text: "",
       };
     }

--- a/scripts/e2e/lib/auth-profile-store-assertions.mjs
+++ b/scripts/e2e/lib/auth-profile-store-assertions.mjs
@@ -4,12 +4,15 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { isRecord } from "../../lib/record-shared.mjs";
 
+// Schema v7 moved primary auth ownership from each agent to shared state.
+// v13 later folded that shared row into config_machine_state.
+const SHARED_AUTH_PROFILE_STORE_SCHEMA_VERSION = 7;
 const AUTH_PROFILE_MACHINE_STATE_SCHEMA_VERSION = 13;
 
-export function readSharedAuthProfileStoreText(stateDir) {
+function readSharedAuthProfileStore(stateDir) {
   const dbPath = path.join(stateDir, "state", "openclaw.sqlite");
   if (!fs.existsSync(dbPath)) {
-    return "";
+    return { ownsStore: false, text: "" };
   }
   let db;
   try {
@@ -17,6 +20,9 @@ export function readSharedAuthProfileStoreText(stateDir) {
     const schemaVersion = db.prepare("PRAGMA user_version").get()?.user_version;
     if (!Number.isInteger(schemaVersion)) {
       throw new Error(`invalid state schema version ${String(schemaVersion)}`);
+    }
+    if (schemaVersion < SHARED_AUTH_PROFILE_STORE_SCHEMA_VERSION) {
+      return { ownsStore: false, text: "" };
     }
     // Release candidates own their persisted schema. Never let a retired row
     // mask a missing canonical row once the v13 fold has occurred.
@@ -38,14 +44,19 @@ export function readSharedAuthProfileStoreText(stateDir) {
       .prepare("SELECT type FROM sqlite_schema WHERE name = ? LIMIT 1")
       .get(storage.table);
     if (!schema) {
-      return "";
+      return {
+        // v13 names the canonical table even when the row is absent. Do not
+        // mistake a broken modern store for the legacy per-agent contract.
+        ownsStore: schemaVersion >= AUTH_PROFILE_MACHINE_STATE_SCHEMA_VERSION,
+        text: "",
+      };
     }
     if (schema.type !== "table") {
       throw new Error(`${storage.table} is ${String(schema.type)}, not a table`);
     }
     const row = db.prepare(storage.query).get(storage.key);
     const value = row?.[storage.column];
-    return typeof value === "string" ? value : "";
+    return { ownsStore: true, text: typeof value === "string" ? value : "" };
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     throw new Error(`could not read the shared auth profile store: ${detail}`, {
@@ -56,7 +67,52 @@ export function readSharedAuthProfileStoreText(stateDir) {
   }
 }
 
+export function readSharedAuthProfileStoreText(stateDir) {
+  return readSharedAuthProfileStore(stateDir).text;
+}
+
+function readLegacyPrimaryAuthProfileStoreText(stateDir) {
+  const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+  if (!fs.existsSync(dbPath)) {
+    return "";
+  }
+  let db;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+    const schema = db
+      .prepare("SELECT type FROM sqlite_schema WHERE name = ? LIMIT 1")
+      .get("auth_profile_store");
+    if (!schema) {
+      return "";
+    }
+    if (schema.type !== "table") {
+      throw new Error(`auth_profile_store is ${String(schema.type)}, not a table`);
+    }
+    const row = db
+      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
+      .get("primary");
+    return typeof row?.store_json === "string" ? row.store_json : "";
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`could not read the legacy primary auth profile store: ${detail}`, {
+      cause: error,
+    });
+  } finally {
+    db?.close();
+  }
+}
+
+// Frozen releases validate the auth store their own persisted schema owns.
+// This keeps a missing modern row from being masked by a retired agent row.
+export function readCanonicalAuthProfileStoreText(stateDir) {
+  const shared = readSharedAuthProfileStore(stateDir);
+  return shared.ownsStore ? shared.text : readLegacyPrimaryAuthProfileStoreText(stateDir);
+}
+
 export function assertNoLegacyPrimaryAuthRows(stateDir) {
+  if (!readSharedAuthProfileStore(stateDir).ownsStore) {
+    return;
+  }
   const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
   if (!fs.existsSync(dbPath)) {
     return;

--- a/scripts/e2e/lib/codex-on-demand/assertions.mjs
+++ b/scripts/e2e/lib/codex-on-demand/assertions.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import {
   assertNoLegacyPrimaryAuthRows,
   assertOpenAiEnvAuthProfileStore,
-  readSharedAuthProfileStoreText,
+  readCanonicalAuthProfileStoreText,
 } from "../auth-profile-store-assertions.mjs";
 import {
   assertPathInside,
@@ -103,7 +103,7 @@ if (providerRuntime && providerRuntime !== "codex") {
 
 const openClawStateDir = stateDir();
 assertNoLegacyPrimaryAuthRows(openClawStateDir);
-const authRaw = readSharedAuthProfileStoreText(openClawStateDir);
+const authRaw = readCanonicalAuthProfileStoreText(openClawStateDir);
 if (!authRaw) {
   throw new Error("auth profile SQLite store row was not persisted");
 }

--- a/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
+++ b/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
@@ -8,7 +8,7 @@ import {
 import {
   assertNoLegacyPrimaryAuthRows,
   assertOpenAiEnvAuthProfileStore,
-  readSharedAuthProfileStoreText,
+  readCanonicalAuthProfileStoreText,
 } from "../auth-profile-store-assertions.mjs";
 import { readPositiveIntEnv } from "../env-limits.mjs";
 import {
@@ -89,7 +89,7 @@ function assertOnboardState() {
     throw new Error("onboard did not write openclaw.json");
   }
   assertNoLegacyPrimaryAuthRows(stateDir);
-  const authStoreText = readSharedAuthProfileStoreText(stateDir);
+  const authStoreText = readCanonicalAuthProfileStoreText(stateDir);
   if (!authStoreText) {
     throw new Error("onboard did not persist auth profile store");
   }

--- a/scripts/e2e/lib/release-scenarios/assertions.mjs
+++ b/scripts/e2e/lib/release-scenarios/assertions.mjs
@@ -8,7 +8,7 @@ import {
 import {
   assertNoLegacyPrimaryAuthRows,
   assertOpenAiEnvAuthProfileStore,
-  readSharedAuthProfileStoreText,
+  readCanonicalAuthProfileStoreText,
 } from "../auth-profile-store-assertions.mjs";
 import {
   applyMockOpenAiModelConfig,
@@ -61,7 +61,7 @@ function readStateText() {
   const paths = [configPath(), authProfilesPath()].filter((file) => fs.existsSync(file));
   return [
     ...paths.map((file) => fs.readFileSync(file, "utf8")),
-    readSharedAuthProfileStoreText(stateDir()),
+    readCanonicalAuthProfileStoreText(stateDir()),
   ]
     .filter(Boolean)
     .join("\n");
@@ -78,7 +78,7 @@ function assertOpenAiEnvRef() {
   const rawKey = process.argv[3];
   assert(fs.existsSync(configPath()), "openclaw.json missing");
   assertNoLegacyPrimaryAuthRows(stateDir());
-  assertOpenAiEnvAuthProfileStore(readSharedAuthProfileStoreText(stateDir()), {
+  assertOpenAiEnvAuthProfileStore(readCanonicalAuthProfileStoreText(stateDir()), {
     missingMessage: "OpenAI env ref was not persisted",
     envRefMessage: "OpenAI env ref was not persisted",
     rawKeyMessage: "raw OpenAI key was persisted",

--- a/test/scripts/auth-profile-store-assertions.test.ts
+++ b/test/scripts/auth-profile-store-assertions.test.ts
@@ -21,6 +21,7 @@ function writeSharedDatabase(
   options: {
     asView?: boolean;
     legacyStoreJson?: string;
+    withoutCanonicalTable?: boolean;
     schemaVersion?: 1 | 7 | 12 | 13;
     storeJson?: string;
   } = {},
@@ -32,7 +33,10 @@ function writeSharedDatabase(
     const schemaVersion = options.schemaVersion ?? 13;
     db.exec(`PRAGMA user_version = ${schemaVersion};`);
     const table = schemaVersion >= 13 ? "config_machine_state" : "auth_profile_stores";
-    if (options.asView) {
+    if (options.withoutCanonicalTable) {
+      // The schema version is authoritative for the owner. Leave this database
+      // intentionally missing its expected table to exercise that boundary.
+    } else if (options.asView) {
       if (table === "config_machine_state") {
         db.exec(`
           CREATE VIEW config_machine_state AS
@@ -193,6 +197,23 @@ describe("auth profile store E2E assertions", () => {
     expect(readSharedAuthProfileStoreText(stateDir)).toBe("");
     expect(readCanonicalAuthProfileStoreText(stateDir)).toBe('{"version":1,"profiles":{}}');
     expect(() => assertNoLegacyPrimaryAuthRows(stateDir)).not.toThrow();
+  });
+
+  it("does not let a retired agent row mask a missing v7 shared table", () => {
+    const stateDir = makeStateDir();
+    writeSharedDatabase(stateDir, {
+      schemaVersion: 7,
+      withoutCanonicalTable: true,
+    });
+    writeAgentDatabase(stateDir, {
+      storeJson: '{"version":1,"profiles":{}}',
+      storeKeys: ["primary"],
+    });
+
+    expect(readCanonicalAuthProfileStoreText(stateDir)).toBe("");
+    expect(() => assertNoLegacyPrimaryAuthRows(stateDir)).toThrow(
+      "onboard preserved a retired primary row in auth_profile_store",
+    );
   });
 
   it("does not let a retired agent row mask a missing v13 canonical row", () => {

--- a/test/scripts/auth-profile-store-assertions.test.ts
+++ b/test/scripts/auth-profile-store-assertions.test.ts
@@ -4,6 +4,7 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   assertNoLegacyPrimaryAuthRows,
+  readCanonicalAuthProfileStoreText,
   readSharedAuthProfileStoreText,
 } from "../../scripts/e2e/lib/auth-profile-store-assertions.mjs";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -20,7 +21,7 @@ function writeSharedDatabase(
   options: {
     asView?: boolean;
     legacyStoreJson?: string;
-    schemaVersion?: 12 | 13;
+    schemaVersion?: 1 | 7 | 12 | 13;
     storeJson?: string;
   } = {},
 ): string {
@@ -43,34 +44,32 @@ function writeSharedDatabase(
             SELECT 'shared' AS store_key, '{}' AS store_json, 1 AS updated_at;
         `);
       }
-    } else {
-      if (table === "config_machine_state") {
-        db.exec(`
+    } else if (table === "config_machine_state") {
+      db.exec(`
           CREATE TABLE config_machine_state (
             state_key TEXT NOT NULL PRIMARY KEY,
             value_json TEXT NOT NULL,
             updated_at_ms INTEGER NOT NULL
           ) STRICT;
         `);
-        db.prepare("INSERT INTO config_machine_state VALUES (?, ?, ?)").run(
-          "authProfiles.store",
-          options.storeJson ?? "{}",
-          Date.now(),
-        );
-      } else {
-        db.exec(`
-          CREATE TABLE auth_profile_stores (
-            store_key TEXT NOT NULL PRIMARY KEY,
-            store_json TEXT NOT NULL,
-            updated_at INTEGER NOT NULL
-          ) STRICT;
-        `);
-        db.prepare("INSERT INTO auth_profile_stores VALUES (?, ?, ?)").run(
-          "shared",
-          options.storeJson ?? "{}",
-          Date.now(),
-        );
-      }
+      db.prepare("INSERT INTO config_machine_state VALUES (?, ?, ?)").run(
+        "authProfiles.store",
+        options.storeJson ?? "{}",
+        Date.now(),
+      );
+    } else {
+      db.exec(`
+        CREATE TABLE auth_profile_stores (
+          store_key TEXT NOT NULL PRIMARY KEY,
+          store_json TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        ) STRICT;
+      `);
+      db.prepare("INSERT INTO auth_profile_stores VALUES (?, ?, ?)").run(
+        "shared",
+        options.storeJson ?? "{}",
+        Date.now(),
+      );
     }
     if (options.legacyStoreJson !== undefined) {
       db.exec(`
@@ -96,6 +95,7 @@ function writeAgentDatabase(
   stateDir: string,
   options: {
     stateKeys?: string[];
+    storeJson?: string;
     storeKeys?: string[];
     storeAsView?: boolean;
   } = {},
@@ -118,7 +118,11 @@ function writeAgentDatabase(
         ) STRICT;
       `);
       for (const key of options.storeKeys ?? []) {
-        db.prepare("INSERT INTO auth_profile_store VALUES (?, '{}', ?)").run(key, Date.now());
+        db.prepare("INSERT INTO auth_profile_store VALUES (?, ?, ?)").run(
+          key,
+          options.storeJson ?? "{}",
+          Date.now(),
+        );
       }
     }
     db.exec(`
@@ -165,6 +169,43 @@ describe("auth profile store E2E assertions", () => {
     expect(readSharedAuthProfileStoreText(stateDir)).toBe("");
   });
 
+  it("reads and permits the pre-v13 primary agent-store contract", () => {
+    const stateDir = makeStateDir();
+    writeAgentDatabase(stateDir, {
+      storeJson: '{"version":1,"profiles":{}}',
+      storeKeys: ["primary"],
+    });
+
+    expect(readCanonicalAuthProfileStoreText(stateDir)).toBe('{"version":1,"profiles":{}}');
+    expect(() => assertNoLegacyPrimaryAuthRows(stateDir)).not.toThrow();
+  });
+
+  it("uses the agent store before the shared-auth schema boundary", () => {
+    const stateDir = makeStateDir();
+    // Candidate 2026.6.35 creates this unused state table at schema v1 while
+    // its auth runtime still owns primary credentials in the agent database.
+    writeSharedDatabase(stateDir, { schemaVersion: 1, storeJson: '{"shared":true}' });
+    writeAgentDatabase(stateDir, {
+      storeJson: '{"version":1,"profiles":{}}',
+      storeKeys: ["primary"],
+    });
+
+    expect(readSharedAuthProfileStoreText(stateDir)).toBe("");
+    expect(readCanonicalAuthProfileStoreText(stateDir)).toBe('{"version":1,"profiles":{}}');
+    expect(() => assertNoLegacyPrimaryAuthRows(stateDir)).not.toThrow();
+  });
+
+  it("does not let a retired agent row mask a missing v13 canonical row", () => {
+    const stateDir = makeStateDir();
+    writeSharedDatabase(stateDir, { storeJson: "" });
+    writeAgentDatabase(stateDir, { storeKeys: ["primary"] });
+
+    expect(readCanonicalAuthProfileStoreText(stateDir)).toBe("");
+    expect(() => assertNoLegacyPrimaryAuthRows(stateDir)).toThrow(
+      "onboard preserved a retired primary row in auth_profile_store",
+    );
+  });
+
   it("returns empty when the shared database or table is absent", () => {
     const stateDir = makeStateDir();
 
@@ -209,6 +250,7 @@ describe("auth profile store E2E assertions", () => {
     "rejects a retired primary row in %s",
     (table) => {
       const stateDir = makeStateDir();
+      writeSharedDatabase(stateDir);
       writeAgentDatabase(stateDir, {
         stateKeys: table === "auth_profile_state" ? ["primary"] : [],
         storeKeys: table === "auth_profile_store" ? ["primary"] : [],
@@ -222,6 +264,7 @@ describe("auth profile store E2E assertions", () => {
 
   it("fails closed for a corrupt main-agent database", () => {
     const stateDir = makeStateDir();
+    writeSharedDatabase(stateDir);
     const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
     mkdirSync(path.dirname(dbPath), { recursive: true });
     writeFileSync(dbPath, "not sqlite");
@@ -233,6 +276,7 @@ describe("auth profile store E2E assertions", () => {
 
   it("fails closed when a retired auth table is replaced by a view", () => {
     const stateDir = makeStateDir();
+    writeSharedDatabase(stateDir);
     writeAgentDatabase(stateDir, { storeAsView: true });
 
     expect(() => assertNoLegacyPrimaryAuthRows(stateDir)).toThrow(

--- a/test/scripts/npm-onboard-channel-agent-assertions.test.ts
+++ b/test/scripts/npm-onboard-channel-agent-assertions.test.ts
@@ -61,6 +61,26 @@ function writeSharedAuthProfileStoreSqlite(home: string, store: unknown): void {
   }
 }
 
+function writeLegacyPrimaryAuthProfileStoreSqlite(home: string, store: unknown): void {
+  const agentDir = path.join(home, ".openclaw", "agents", "main", "agent");
+  fs.mkdirSync(agentDir, { recursive: true });
+  const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
+  try {
+    db.exec(`
+      CREATE TABLE auth_profile_store (
+        store_key TEXT NOT NULL PRIMARY KEY,
+        store_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      ) STRICT;
+    `);
+    db.prepare(
+      "INSERT INTO auth_profile_store (store_key, store_json, updated_at) VALUES (?, ?, ?)",
+    ).run("primary", JSON.stringify(store), Date.now());
+  } finally {
+    db.close();
+  }
+}
+
 function runAssert(home: string, channel: string, ...tokens: string[]) {
   return spawnSync(
     process.execPath,
@@ -242,6 +262,30 @@ describe("npm onboard channel agent assertions", () => {
       expect(result.stderr).toBe("");
       expect(fs.existsSync(agentDir)).toBe(false);
       expect(fs.existsSync(path.join(agentDir, "auth-profiles.json"))).toBe(false);
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("validates OpenAI env refs from a frozen release's primary agent store", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+    try {
+      writeOnboardConfig(tempDir);
+      writeLegacyPrimaryAuthProfileStoreSqlite(tempDir, {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      });
+
+      const result = runOnboardAssert(tempDir);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
     } finally {
       fs.rmSync(tempDir, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Problem

Current trusted release assertions require the post-v13 shared auth profile store for every candidate. Frozen `2026.6.35` still owns the canonical primary profile in `agents/main/agent/openclaw-agent.sqlite`, so its successful npm onboarding fails after completion with `onboard preserved a retired primary row in auth_profile_store`. This is target/harness skew, not a candidate product regression.

Observed in [candidate Release Checks 33692992218](https://github.com/openclaw/openclaw/actions/runs/33692992218), Docker onboarding job [100456651814](https://github.com/openclaw/openclaw/actions/runs/33692992218/job/100456651814). Candidate: `659df8107ce37c07a4cd4364c76ece55a7124e22`; trusted tooling: `1703bd765298b86c078f571b65a3f21aa95e456b`.

## Fix

Resolve the asserted auth row from the frozen target’s persisted schema contract:

- schema v13+ machine state stays strict and rejects a primary per-agent row;
- schema v7–v12 reads the shared `auth_profile_stores[shared]` row;
- pre-v7 targets (including .35’s schema v1) validate `auth_profile_store[primary]` in the agent database.

The v7 boundary is the committed relocation of shared auth ownership ([#123349](https://github.com/openclaw/openclaw/commit/d2dad76ecde4bb3e811b9d03ed9932dc61044b8a)); table existence is deliberately not used as ownership evidence because .35's v1 state schema defines an unused shared table.

No package, runtime, config, migration, schema, tag, npm, or release state changes. This layers beside [#136761](https://github.com/openclaw/openclaw/pull/136761), which owns the other frozen Docker scenario capability failures.

## Proof

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/auth-profile-store-assertions.test.ts test/scripts/npm-onboard-channel-agent-assertions.test.ts test/scripts/release-scenarios-assertions.test.ts` — 41 passed.
- The new caller-level regression constructs .35's v1 unused shared table alongside its canonical primary-agent row; it succeeds only after the schema-boundary selection.
- Modern negative coverage proves a v13 missing shared row is not masked by an old row, and v13 keeps rejecting it.
- Focused OXLint and `git diff --check` passed.
- Direct Codex protocol inspection: `../codex/codex-rs/app-server-protocol/schema/typescript/v2/AskForApproval.ts`, `codex-rs/app-server-protocol/src/protocol/v2/shared.rs`; no Codex protocol behavior changes.

## Scope / LOC

- Release tooling: +69/-11 (net +58), all storage-contract qualification.
- Tests: +112/-24 (net +88), including executable caller regression and strict modern negative.
- Product runtime: 0.


## Exact-head follow-up

Schema v7 is the canonical shared-auth ownership boundary. If a v7–v12 database is missing `auth_profile_stores`, the assertion now stays shared-owned and returns empty; it never falls back to `auth_profile_store[primary]`. The new regression builds that malformed v7 database with a retired primary row and proves both outcomes: canonical read is empty and the legacy row is rejected. It failed on the prior head and passes on this head. Pre-v7 retains its tested early return to the agent-store contract.

