### PR TITLE
fix: auto-height dashboard widgets shrink on every resize report

### DIFF
--- a/ui/src/components/board/board-view-sizing.test.ts
+++ b/ui/src/components/board/board-view-sizing.test.ts
@@ -17,10 +17,10 @@ afterEach(() => {
 describe("board widget sizing", () => {
   it("snaps reported HTML heights to rows with card inset and fixed-mode fallbacks", () => {
     const card = boardWidget({ sizeH: 6 });
-    expect(effectiveBoardWidgetRows(card, 100)).toBe(2);
-    expect(effectiveBoardWidgetRows(card, 101)).toBe(3);
-    expect(effectiveBoardWidgetRows({ ...card, presentation: "full-bleed" }, 124)).toBe(2);
-    expect(effectiveBoardWidgetRows({ ...card, presentation: "frameless" }, 125)).toBe(3);
+    expect(effectiveBoardWidgetRows(card, 98)).toBe(2);
+    expect(effectiveBoardWidgetRows(card, 99)).toBe(3);
+    expect(effectiveBoardWidgetRows({ ...card, presentation: "full-bleed" }, 122)).toBe(2);
+    expect(effectiveBoardWidgetRows({ ...card, presentation: "frameless" }, 123)).toBe(3);
     expect(effectiveBoardWidgetRows(card, 1)).toBe(2);
     expect(effectiveBoardWidgetRows(card, 10_000)).toBe(20);
     expect(effectiveBoardWidgetRows(card, 10_000, 0, 240)).toBeGreaterThan(20);
@@ -37,19 +37,53 @@ describe("board widget sizing", () => {
   it("hugs auto cards to their exact content height inside the quantized cell", () => {
     const card = boardWidget({ sizeH: 6 });
     // Card inset adds 12px per edge; frameless/full-bleed report bare content.
-    expect(exactBoardWidgetHeightPx(card, 300)).toBe(324);
-    expect(exactBoardWidgetHeightPx({ ...card, presentation: "frameless" }, 300)).toBe(300);
+    // Every presentation additionally carries the card's two 1px borders.
+    expect(exactBoardWidgetHeightPx(card, 300)).toBe(326);
+    expect(exactBoardWidgetHeightPx({ ...card, presentation: "frameless" }, 300)).toBe(302);
     // Short content hugs below the 2-row cell minimum: the cell keeps its
     // minimum span, only the card shrinks.
-    expect(exactBoardWidgetHeightPx(card, 60)).toBe(84);
+    expect(exactBoardWidgetHeightPx(card, 60)).toBe(86);
     // At the 20-row cap the card fills the cell exactly and the body clips.
     expect(exactBoardWidgetHeightPx(card, 10_000)).toBe(20 * 56 + 19 * 12);
-    expect(exactBoardWidgetHeightPx(card, 10_000, 0, 240)).toBe(10_024);
+    expect(exactBoardWidgetHeightPx(card, 10_000, 0, 240)).toBe(10_026);
     // Coarse-pointer layouts keep the 38px bar in flow, joining the height.
-    expect(exactBoardWidgetHeightPx(card, 300, 38)).toBe(362);
+    expect(exactBoardWidgetHeightPx(card, 300, 38)).toBe(364);
     expect(exactBoardWidgetHeightPx({ ...card, heightMode: "fixed" }, 300)).toBeUndefined();
     expect(exactBoardWidgetHeightPx(card, undefined)).toBeUndefined();
     expect(exactBoardWidgetHeightPx({ ...card, contentKind: "mcp-app" }, 300)).toBeUndefined();
+  });
+
+  it("leaves the reported content height intact inside the card it sizes", () => {
+    // Regression guard for the auto-height shrink loop: the height this returns
+    // is applied to a border-box .board-widget, whose borders, optional touch
+    // row and card inset are all subtracted again before the iframe gets its
+    // box. If the calculation omits any of them the iframe ends up shorter than
+    // it asked for, its ResizeObserver reports the smaller number, and the
+    // widget walks itself down a couple of pixels per resize round.
+    const borders = 2;
+    const inset = 12 * 2;
+    const contentBox = (
+      widget: Parameters<typeof exactBoardWidgetHeightPx>[0],
+      reported: number,
+      chromeRowPx = 0,
+    ): number | undefined => {
+      const outer = exactBoardWidgetHeightPx(widget, reported, chromeRowPx, 240);
+      if (outer === undefined) {
+        return undefined;
+      }
+      const framed = (widget.presentation ?? "card") === "card" ? inset : 0;
+      return outer - borders - chromeRowPx - framed;
+    };
+
+    const card = boardWidget({ sizeH: 6 });
+    for (const presentation of ["card", "full-bleed", "frameless"] as const) {
+      const widget = { ...card, presentation };
+      // Below the row cap the card hugs content exactly, so a second report of
+      // the same height is a no-op rather than another step downwards.
+      expect(contentBox(widget, 300)).toBe(300);
+      expect(contentBox(widget, 166)).toBe(166);
+      expect(contentBox(widget, 300, 38)).toBe(300);
+    }
   });
 
   it("pins the exact reported height on the card and re-fills while dragging", async () => {
@@ -90,7 +124,7 @@ describe("board widget sizing", () => {
 
     await vi.waitFor(() => {
       const section = cell?.querySelector<HTMLElement>(".board-widget");
-      expect(section?.getAttribute("style")).toContain("height: 10024px");
+      expect(section?.getAttribute("style")).toContain("height: 10026px");
       expect(section?.getAttribute("style")).toContain("span 148");
     });
   });

--- a/ui/src/components/board/board-view.browser.test.ts
+++ b/ui/src/components/board/board-view.browser.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildWidgetDocument } from "../../../../src/canvas/wrap.ts";
 import { BOARD_GRID_GAP, BOARD_GRID_ROW_HEIGHT } from "../../lib/board/grid.ts";
 import type { BoardSnapshot } from "../../lib/board/types.ts";
 import "../../styles/base.css";
@@ -53,6 +54,14 @@ async function mount(applyOps = vi.fn(async () => undefined)): Promise<OpenClawB
     [...view.querySelectorAll("openclaw-board-widget-cell")].map((cell) => cell.updateComplete),
   );
   return view;
+}
+
+async function settleFrames(count = 3): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
 }
 
 function pointer(
@@ -405,9 +414,10 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
         data: { type: "openclaw:widget-size", height: 300 },
       }),
     );
-    // The card hugs its exact content height (300px + 2x12px card inset); the
-    // ceil-to-row slack stays outside the card as grid background.
-    await vi.waitFor(() => expect(Math.round(first.getBoundingClientRect().height)).toBe(324));
+    // The card hugs its exact content height (300px + 2x12px card inset + the
+    // card's two 1px borders); the ceil-to-row slack stays outside the card as
+    // grid background.
+    await vi.waitFor(() => expect(Math.round(first.getBoundingClientRect().height)).toBe(326));
     expect(second.getBoundingClientRect().top).toBeGreaterThan(secondTopBefore);
 
     const cardBody = first.querySelector<HTMLElement>(".board-widget__body");
@@ -420,6 +430,94 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
     second.focus();
     finishDocumentAnimations();
     expect(getComputedStyle(second).borderTopColor).not.toBe("rgba(0, 0, 0, 0)");
+  });
+
+  it("settles an auto-height card on the height its content reported", async () => {
+    const view = await mount();
+    const card = view.querySelector<HTMLElement>('[data-test-id="board-widget"]')!;
+    const frame = card.querySelector<HTMLIFrameElement>("iframe")!;
+
+    // Replay the loop the frame's ResizeObserver drives in production: the
+    // widget reports the height of its own box, the board sizes the card from
+    // that number, and the next report measures whatever box the card left
+    // behind. Reserving less chrome than the card actually spends makes every
+    // round hand back a shorter box, so the widget walks down instead of
+    // holding still. The frame is height:100%, so its box is exactly the space
+    // the card left for the content.
+    const boxes: number[] = [];
+    let reported = 300;
+    for (let round = 0; round < 4; round += 1) {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          source: frame.contentWindow,
+          data: { type: "openclaw:widget-size", height: reported },
+        }),
+      );
+      await view.updateComplete;
+      await settleFrames();
+      reported = Math.round(frame.getBoundingClientRect().height);
+      boxes.push(reported);
+    }
+
+    expect(boxes).toEqual([300, 300, 300, 300]);
+  });
+
+  it("holds a real widget document steady under the production size reporter", async () => {
+    // The synthetic message cases above drive the loop by hand. This one hands
+    // the frame the document the Gateway actually serves -- buildWidgetDocument
+    // wraps the widget with the production bridge, whose ResizeObserver watches
+    // document.body and posts openclaw:widget-size on its own -- and lets the
+    // real loop run. The widget is the shape the bug report describes: content
+    // that fills whatever box it is given, so a card that reserves less chrome
+    // than it spends hands back a shorter box every round and never settles.
+    const widgetDocument = buildWidgetDocument(
+      "Viewport filling widget",
+      "<style>body{margin:0;min-height:100vh}</style><div>filling</div>",
+    );
+    const view = document.createElement("openclaw-board-view");
+    view.snapshot = { ...structuredClone(source), widgets: [structuredClone(source.widgets[0]!)] };
+    view.activeTabId = "main";
+    view.widgetFrameUrl = () =>
+      `data:text/html;charset=utf-8,${encodeURIComponent(widgetDocument)}`;
+    view.callbacks = {
+      applyOps: vi.fn(async () => undefined),
+      grant: vi.fn(async () => undefined),
+      selectTab: vi.fn(),
+    };
+    document.body.append(view);
+    await view.updateComplete;
+    await Promise.all(
+      [...view.querySelectorAll("openclaw-board-widget-cell")].map((cell) => cell.updateComplete),
+    );
+
+    const card = view.querySelector<HTMLElement>('[data-test-id="board-widget"]')!;
+    const frame = card.querySelector<HTMLIFrameElement>("iframe")!;
+    const reports: number[] = [];
+    const collect = (event: MessageEvent) => {
+      if (
+        event.source === frame.contentWindow &&
+        (event.data as { type?: string } | null)?.type === "openclaw:widget-size"
+      ) {
+        reports.push((event.data as { height: number }).height);
+      }
+    };
+    window.addEventListener("message", collect);
+
+    try {
+      const heights: number[] = [];
+      for (let sample = 0; sample < 12; sample += 1) {
+        await settleFrames(2);
+        heights.push(Math.round(card.getBoundingClientRect().height));
+      }
+
+      // The observer reported at least once, and the card reached a fixed point
+      // instead of stepping down on every round.
+      expect(reports.length).toBeGreaterThan(0);
+      expect(new Set(heights.slice(-8)).size).toBe(1);
+      expect(Math.round(frame.getBoundingClientRect().height)).toBe(reports.at(-1));
+    } finally {
+      window.removeEventListener("message", collect);
+    }
   });
 
   it("rejects tab drop targets owned by another board", async () => {

--- a/ui/src/lib/board/grid.ts
+++ b/ui/src/lib/board/grid.ts
@@ -207,6 +207,12 @@ export function toCssPlacement(rect: BoardGridRect): string {
 
 // Keep this numeric inset aligned with the app-level --widget-frame-inset token.
 const BOARD_WIDGET_FRAME_INSET = 12;
+// Mirrors the 1px border on .board-widget in board.css: every presentation keeps
+// the border box (frameless only paints it transparent) and the card is
+// border-box sized, so both edges take from the content area. Omitting them
+// undersizes the card, the iframe's ResizeObserver reports the smaller box back,
+// and the widget steps down again on every resize round instead of settling.
+const BOARD_WIDGET_FRAME_BORDER_PX = 1;
 const BOARD_WIDGET_AUTO_MIN_ROWS = 2;
 const BOARD_WIDGET_AUTO_MAX_ROWS = 20;
 // Mirrors the 38px header grid row in board.css: coarse-pointer layouts keep
@@ -243,6 +249,7 @@ function autoBoardWidgetHeightPx(
   return (
     contentHeightPx +
     chromeRowPx +
+    BOARD_WIDGET_FRAME_BORDER_PX * 2 +
     ((widget.presentation ?? "card") === "card" ? BOARD_WIDGET_FRAME_INSET * 2 : 0)
   );
 }


### PR DESCRIPTION
Closes #136789

## What Problem This Solves

Fixes an issue where users who pin a self-contained HTML widget to a session dashboard would see the widget get shorter on every resize round instead of settling at the height its content asked for. A widget reporting 300px of content was given a 298px box; in production a card walked from 166px down to 134px over twelve animation frames. It affects card, full-bleed and frameless presentations alike, on both fine- and coarse-pointer layouts.

## Why This Change Was Made

The shared content-to-card height calculation reserved the card inset and the coarse-pointer touch row, but not the two 1px borders on `.board-widget`. Those borders are unconditional — frameless only paints the color transparent — and the card is border-box sized, so the outer height came out 2px short of what the content needed. Because that height is applied to the card and the iframe's `ResizeObserver` reports the resulting smaller box back, each round subtracted another 2px: a feedback loop rather than a one-off rounding error.

The fix reserves the borders alongside the inset, so the height that gets applied leaves the reported content height intact and a repeat report is a no-op.

**On the +7 line production delta.** The behavioural change is one term in one sum. The other six lines are one named constant and the five-line comment recording why the borders belong in that sum — the same thing `BOARD_WIDGET_FRAME_INSET` and `BOARD_WIDGET_TOUCH_BAR_PX` directly above it already carry. A bare `+ 2` would be shorter and would be the reason this regresses again: the next reader has to rediscover that `.board-widget` keeps its border box in every presentation, frameless included, and that the card is border-box sized. I would rather leave that written down.

## User Impact

Auto-height dashboard widgets now settle at the height their content reports and stay there. No configuration change; previously pinned widgets correct themselves on the next resize report.

## Evidence

### Runtime trace: the real document under the production reporter

`board-view.browser.test.ts` gains a case that hands the frame the document the Gateway actually serves — `buildWidgetDocument` from `src/canvas/wrap.ts`, whose embedded bridge runs `new ResizeObserver(report).observe(document.body)` and posts `openclaw:widget-size` itself — and then lets that loop run untouched in real Chromium. The widget is the shape this issue describes: `body { min-height: 100vh }`, content that fills whatever box it is given.

Card height, sampled every two animation frames, and every `openclaw:widget-size` the production bridge emitted:

| | card height across 12 samples | reports emitted |
|---|---|---|
| **before the fix** | `192, 190, 186, 184, 182, 180, 178, 176, 174, 172, 170, 168` — still falling | `166, 164, 162, 160, 158, 156, 154, 152, 150, 148, 146, 144` |
| **after the fix** | `192` × 12 | `166` — reported once, then silent |

The bridge's own `if (h && h !== last)` guard is what makes the after-column go quiet: once the card stops taking 2px away, there is nothing new to report. The 166px starting report is the same number the issue reports from production.

Reproduce either column with:

```
PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=<chromium> node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-browser.config.ts \
  -t "holds a real widget document steady" \
  ui/src/components/board/board-view.browser.test.ts
```

The before-column is that same command with `BOARD_WIDGET_FRAME_BORDER_PX` forced back to `0`; the assertion then fails with `expected 8 to be 1` — eight distinct card heights across the last eight samples, i.e. it never settles.

### Synthetic replay and unit level

A second browser case drives the same loop by hand and measures the box the card leaves for the content (`.board-widget__frame` is `height: 100%`, so the frame's box *is* that space): `298, 296, 294, 292` before, `300, 300, 300, 300` after.

The pre-existing browser case `grows an auto-height card from its frame message` has its expectation updated from 324 to 326 — the real card measures 2px taller now because it finally reserves its own borders.

`board-view-sizing.test.ts` gains a case asserting the fixed point directly for each presentation, and its row-boundary probes shift by the same 2px so they keep straddling the boundary they were written to probe.

### Full validation on this branch (rebased onto main at 41419be4)

- `run-vitest --config test/vitest/vitest.ui-browser.config.ts ui/src/components/board/board-view.browser.test.ts` — real Chromium, 21 tests passed
- `run-vitest ui/src/components/board/ ui/src/lib/board/` — 15 files, 214 tests passed
- `run-tsgo -p tsconfig.ui.json` — clean
- `run-tsgo-core-test-shards ui` — clean
- `run-oxlint --tsconfig tsconfig.ui.json <touched files>` — clean
- `oxfmt --check <touched files>` — clean