### PR TITLE
fix: repeated help flags fail in Vitest profiler

### DIFF
--- a/scripts/run-vitest-profile-child.mts
+++ b/scripts/run-vitest-profile-child.mts
@@ -11,11 +11,9 @@ const finishMain = mode === "main" ? await startVitestProfile(outputDir, false) 
 try {
   const { parseCLI, startVitest } = await import("vitest/node");
   const { normalizePath } = await import("vite");
-  const { z } = await import("zod");
   const { filter, options } = parseCLI(["vitest", ...args]);
-  // parseCLI prints help but does not exit, and its type omits that control flag.
-  const controls = z.object({ help: z.boolean().optional() }).parse(options);
-  if (controls.help) {
+  // Match native help truthiness (including repeated-flag arrays); parseCLI's type omits help.
+  if ("help" in options && options.help) {
     await finishMain?.();
     process.exit(0);
   }

--- a/test/scripts/run-vitest-profile.test.ts
+++ b/test/scripts/run-vitest-profile.test.ts
@@ -4,7 +4,6 @@ import fs from "node:fs";
 import type { HeapProfiler } from "node:inspector";
 import os from "node:os";
 import path from "node:path";
-import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import {
   buildVitestProfileCommandWithArgs,
@@ -13,17 +12,30 @@ import {
 } from "../../scripts/run-vitest-profile.mts";
 import { createScriptTestHarness } from "./test-helpers.js";
 
-function runProfileProcess(command: string, args: string[], root: string) {
-  return promisify(execFile)(command, args, {
-    cwd: root,
-    env: { PATH: process.env.PATH, HOME: root, USERPROFILE: root, CI: "1" },
-  }).then(
-    ({ stdout, stderr }) => ({ code: 0, output: stdout + stderr }),
-    (error: { code: number; stdout: string; stderr: string }) => ({
-      code: error.code,
-      output: error.stdout + error.stderr,
-    }),
-  );
+function runProfileProcess(
+  command: string,
+  args: string[],
+  root: string,
+): Promise<{ code: number; output: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      { cwd: root, env: { PATH: process.env.PATH, HOME: root, USERPROFILE: root, CI: "1" } },
+      (error, stdout, stderr) => {
+        const output = stdout + stderr;
+        if (!error) {
+          resolve({ code: 0, output });
+          return;
+        }
+        if (typeof error.code === "number" && error.code !== 0 && !error.signal) {
+          resolve({ code: error.code, output });
+          return;
+        }
+        reject(new Error(`${error.message}\n${output}`, { cause: error }));
+      },
+    );
+  });
 }
 
 describe("scripts/run-vitest-profile", () => {
@@ -63,39 +75,49 @@ describe("scripts/run-vitest-profile", () => {
     },
   );
 
-  it.each(
-    [
-      { pool: "forks", isolate: true, custom: false, failRun: false },
-      { pool: "threads", isolate: true, custom: false, failRun: true },
-      { pool: "forks", isolate: false, custom: false, failRun: true },
-      { pool: "threads", isolate: false, custom: false, failRun: false },
-      { pool: "forks", isolate: true, custom: true, failRun: true },
-      { pool: "threads", isolate: true, custom: true, failRun: false },
-      { pool: "forks", isolate: true, custom: true, failRun: false, projects: true },
-      { pool: "forks", isolate: false, custom: false, failRun: false, failProfile: true },
-      { pool: "threads", isolate: false, custom: false, failRun: true, failProfile: true },
-      ...["ignore", "filter"].flatMap((errorPolicy) =>
-        [false, true].map((failProfile) => ({
-          pool: errorPolicy === "ignore" ? "forks" : "threads",
-          isolate: false,
-          custom: false,
-          failRun: false,
-          failProfile,
-          unhandled: true,
-          errorPolicy,
-        })),
-      ),
-      { pool: "forks", isolate: false, custom: false, failRun: false, unhandled: true },
-    ].map((testCase) => ({
-      projects: false,
-      failProfile: false,
-      unhandled: false,
-      errorPolicy: "default",
-      ...testCase,
-    })),
-  )(
-    "profiles selected $pool runner (isolated: $isolate, custom: $custom, failed: $failRun, projects: $projects, write failure: $failProfile, unhandled: $unhandled, policy: $errorPolicy)",
-    async ({ pool, isolate, custom, failRun, projects, failProfile, unhandled, errorPolicy }) => {
+  it.each([
+    { pool: "forks", isolate: true, custom: false, failRun: false },
+    { pool: "threads", isolate: true, custom: false, failRun: true },
+    { pool: "forks", isolate: false, custom: false, failRun: true },
+    { pool: "threads", isolate: false, custom: false, failRun: false },
+    { pool: "forks", isolate: true, custom: true, failRun: true },
+    { pool: "threads", isolate: true, custom: true, failRun: false },
+    { pool: "forks", isolate: true, custom: true, failRun: false, projects: true },
+    { pool: "forks", isolate: false, custom: false, failRun: false, failProfile: true },
+    { pool: "threads", isolate: false, custom: false, failRun: true, failProfile: true },
+    ...["ignore", "filter"].flatMap((errorPolicy) =>
+      [false, true].map((failProfile) => ({
+        pool: errorPolicy === "ignore" ? "forks" : "threads",
+        isolate: false,
+        custom: false,
+        failRun: false,
+        failProfile,
+        unhandled: true,
+        errorPolicy,
+      })),
+    ),
+    { pool: "forks", isolate: false, custom: false, failRun: false, unhandled: true },
+  ])(
+    "profiles selected runner %j",
+    async ({
+      pool,
+      isolate,
+      custom,
+      failRun,
+      projects = false,
+      failProfile = false,
+      unhandled = false,
+      errorPolicy = "default",
+    }: {
+      pool: string;
+      isolate: boolean;
+      custom: boolean;
+      failRun: boolean;
+      projects?: boolean;
+      failProfile?: boolean;
+      unhandled?: boolean;
+      errorPolicy?: string;
+    }) => {
       const root = createTempDir("oc-profile-sibling-");
       fs.writeFileSync(path.join(root, "package.json"), '{"private":true,"type":"module"}');
       fs.symlinkSync(
@@ -193,7 +215,9 @@ it("retains the selected execution context", async () => {
         "--exclude",
         "cli-excluded.test.ts",
       ];
-      if (projects) args.push("--reporter", "dot", "--reporter", "json");
+      if (projects) {
+        args.push("--reporter", "dot", "--reporter", "json");
+      }
       const result = await runProfileProcess(process.execPath, args, root);
       const reportPath = path.join(root, "report.json");
       const reportText = fs.existsSync(reportPath) ? fs.readFileSync(reportPath, "utf8") : "";
@@ -203,8 +227,12 @@ it("retains the selected execution context", async () => {
       if (shouldFail) {
         expect(result.output.trimEnd()).toMatch(/\[run-vitest-profile\] FAILED \(exit 1\)$/u);
       }
-      if (failRun) expect(result.output).toContain("intentional profiling sibling failure");
-      if (unhandled) expect(result.output).toContain("intentional unhandled profiling workload");
+      if (failRun) {
+        expect(result.output).toContain("intentional profiling sibling failure");
+      }
+      if (unhandled) {
+        expect(result.output).toContain("intentional unhandled profiling workload");
+      }
       const report = JSON.parse(reportText);
       expect(report.numTotalTests).toBe(2);
       expect(report.numFailedTests).toBe(failRun ? 1 : 0);
@@ -233,7 +261,9 @@ it("retains the selected execution context", async () => {
         expect(cpu.endTime).toBeGreaterThan(cpu.startTime);
         expect(heap.head.children.length).toBeGreaterThan(0);
         const nodes = [heap.head];
-        for (const node of nodes) nodes.push(...node.children);
+        for (const node of nodes) {
+          nodes.push(...node.children);
+        }
         const workload = nodes.find(
           (node) => node.callFrame.functionName === `retain_${name}_heap_workload`,
         );
@@ -245,7 +275,9 @@ it("retains the selected execution context", async () => {
   it.each([
     { mode: "main", flags: ["--help", "--unknown-profile-test-option"] },
     { mode: "runner", flags: ["-h", "--pool"] },
-  ])("prints $mode help without starting a test server", async ({ mode, flags }) => {
+    { mode: "main", flags: ["--help", "--help"] },
+    { mode: "runner", flags: ["--help", "--help"] },
+  ])("prints $mode help for $flags without starting a test server", async ({ mode, flags }) => {
     const root = createTempDir("oc-profile-help-");
     const args = [
       path.join(repoRoot, "scripts/run-vitest-profile.mts"),


### PR DESCRIPTION
Closes #136795

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where developers requesting Vitest profiler help would receive an error exit when `--help` was repeated. Native Vitest accepts the same arguments and exits successfully, but both OpenClaw profiler modes printed help and then failed.

## Why This Change Was Made

Vitest's native parser retains repeated flags as arrays and handles its help control by truthiness. The profiler added a second, boolean-only Zod projection after parsing, incorrectly rejecting that native representation. This removes the redundant projection and follows the native help decision directly, without coercing or removing caller arguments.

Both profiler modes use this one child entrypoint. Capture finalization, process cleanup, invalid-argument validation, normal profiling, and all deadlines remain unchanged. Adding a coercion schema or another parser wrapper would duplicate the dependency's control policy rather than repair its consumer.

## User Impact

Both `main` and `runner` profiler modes now accept repeated help flags and finish successfully. Main mode still writes its CPU profile before exiting; runner-mode help does not start a profiling workload. No bot-runtime, gateway, channel, configuration, dependency, or storage behavior changes.

The existing [test performance tooling documentation](https://docs.openclaw.ai/reference/test#test-performance-tooling) remains accurate; this restores native flag behavior rather than adding a new interface.

## Evidence

- Native Vitest 4.1.11 accepted `run --help --help` with exit 0. Before the repair, both profiler modes printed help then exited 1 with `Invalid input: expected boolean, received array`. These were completed failures, not timeouts.
- The existing real-process help table was extended, not duplicated. Before the production edit, only the two new repeated-help rows failed; both original singular-help/invalid-under-help controls passed. After the edit, all four rows passed.
- Direct installed dependency inspection verified repeated-key accumulation in `node_modules/vitest/dist/chunks/cac.uFydS1Z4.js:14-21`, native help truthiness at lines 535-538, and the patched `parseCLI` handoff at lines 2288-2308.
- The final complete profiler test file passed **34/34** cases, including real fork/thread profiling, independent projects, custom runners/jsdom, CPU/heap content, invalid CLI admission, workload failures, and profile-write failures.
- All **19 selected changed checks passed**, including scripts/root-test typechecking, both lint checks, formatting, and the applicable guards.
- Fresh standalone repeated-help commands both exited 0 with empty stderr and verified process/pipe/temporary-namespace cleanup. Runner completed in 479 ms without starting a profiling workload. Main completed in 439 ms and finalized one valid 102,992-byte CPU profile, with no heap profile.

Commands used from the source checkout with Node 24.15.0 and a fresh external temporary home/root:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/run-vitest-profile.test.ts --reporter=verbose --maxWorkers=1
```

```bash
node scripts/check-changed.mjs --timed -- scripts/run-vitest-profile-child.mts test/scripts/run-vitest-profile.test.ts
```

```bash
node scripts/run-vitest-profile.mts runner --output-dir .artifacts/task390-fixed-runner-repeat-help-g6r88m6i/profiles -- --help --help
```

```bash
node scripts/run-vitest-profile.mts main --output-dir .artifacts/task390-fixed-main-repeat-help-t5wgjy16/profiles -- --help --help
```

The standalone probes retained the existing 15-second managed-command bound and strict process-tree cleanup. These are real local CLI executions, not mocked profiler results.

### Validation corrections

An initial full-file run had 32 passing and two failing cases with the test launcher's temporary fixtures incorrectly placed inside the source repository. The same unchanged suite passed with an external temporary root. The failed run is retained, and no assertion or timeout was relaxed.

The first changed check exposed six existing lint errors in the touched test file. This PR also removes the default-merging map in favor of callback defaults, adds required braces, and uses Node's typed `execFile` callback rather than an unsafe promise-rejection annotation. Unexpected spawn/signal errors remain visible failures with their captured output. An intermediate optional-field type error was corrected with an explicit callback input contract; the final full suite and all selected checks were then rerun successfully.

Fresh isolated Codex autoreview of the final two-file patch completed with `scoped-clean` at the configured P0 threshold and no findings. The earlier clean review was not reused across the test cleanup. Final source fingerprint: `18edd8616c565a0312ee7b8265b9262df82e047cc57c036d4c6f158b9045f913`.

### CI recovery and refreshed-head proof

The first [exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33705937418) built the UI bundle but failed the shared startup-size gate: 349,563 B versus the then-current 349,244 B limit. The missing Discord proof-upload artifact was secondary to that stopped build.

After the independent [startup-baseline correction](https://github.com/openclaw/openclaw/pull/136817) landed as [bf5753075a54](https://github.com/openclaw/openclaw/commit/bf5753075a54b0245695e752031be2f3580681fe), this branch was rebased onto it. The PR's two-file patch and both changed source blobs are byte-for-byte unchanged; no baseline, budget, allowance, or UI source edit was added to this PR.

On refreshed head `1cd0bdd889081e8636402b2adbc59ae6e9b37357`:

- Frozen-lock dependency synchronization passed with no tracked changes.
- Full `pnpm build` passed in 5m 50.4s. Build metadata records that exact commit. Startup JS measured **349,577 B**, below the inherited **350,141 B** enforcement limit by **564 B**.
- The full profiler suite passed **34/34** again in 15.21s; all **19 selected checks** passed again. These repeat the same coverage, not additional distinct cases.
- The final independent review remains bound to the unchanged patch fingerprint; the mechanical rebase did not change the reviewed profiler logic or test cleanup.

```bash
pnpm build
```

The second [exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33708915245) passed the startup JS gate but failed on two separate integrated-main problems: startup CSS was 46,097 B versus the 46,080 B limit, and two artifact-transfer tests still expected timestamp-only changes to outrank a clean matching Git checkout.

The independent [current-main build validation repair](https://github.com/openclaw/openclaw/pull/136878) landed as [507e5faf2850](https://github.com/openclaw/openclaw/commit/507e5faf28500d12b8b43c8d0ad7996190e27d5d), with [successful exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33709162719). It removes a redundant CSS selector and updates the artifact test's obsolete freshness premise while retaining explicit stamp-refresh, identity, digest, contents, symlink, and mode assertions. This branch was refreshed onto that landed prerequisite, again without changing the profiler patch or adding a budget edit.

On refreshed head `6239294ad22f475d251c3734ec93c5f9603bc39e`, `pnpm build:ci-artifacts` passed in 2m 5.7s, and build metadata records that exact commit. Startup JS measured **349,578 / 350,141 B**; startup CSS measured **46,080 / 46,080 B**, with no remaining CSS headroom. The grouped tooling invocation passed **43/43** cases in 13.96s: the same 34 profiler cases plus nine artifact-transfer cases.

```bash
pnpm build:ci-artifacts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/run-vitest-profile.test.ts test/scripts/repo-e2e-artifacts.test.ts --reporter=verbose --maxWorkers=1
```

One earlier grouped run used the private launcher's imposed `umask 077`: all 34 profiler cases passed, but two artifact tests observed restored mode `0700` rather than their expected `0755`. The fixture explicitly chmods the source to `0755`; native tar extraction without `-p` honors the restrictive mask. The successful unchanged run inherited the normal shell mask `022`, while evidence and HOME/TMP parent directories remained `0700` and the raw log `0600`. The failed run is retained. This is not proof of full permission preservation under arbitrary masks; that separate test/transfer-contract assumption is a named follow-up. No assertion, tar flag, or production permission behavior was changed.

All **19 selected changed checks passed again on `6239294ad22f475d251c3734ec93c5f9603bc39e`**. The final isolated review remains bound to the byte-identical two-file patch.

The [02:54 UTC ClawSweeper review](https://github.com/openclaw/openclaw/pull/136830#issuecomment-5519243849) found no patch defect and identified its dependency-free checkout as the remaining proof limitation. That gap is covered by the maintainer's direct installed Vitest parser inspection and real before/after CLI executions described above. No code workaround or reviewer-environment change is needed. Exact-head hosted CI must still pass before native preparation and merge.

### Scope and provenance

Executable tooling: +2/-4, net -2. Regression tests and colocated test support: +82/-50, net +32. Overall: 84 additions and 54 deletions across two files, largely table reindentation plus the typed process callback. No generated files, baseline changes, new helper, or compatibility layer.

The boolean-only projection was present when the profiler child was added in [81a74b23eb1f](https://github.com/openclaw/openclaw/commit/81a74b23eb1f59aeb7fbd9641e7345e5161d9b8d), via [the worker cleanup and tooling repair](https://github.com/openclaw/openclaw/pull/132224), on August 29, 2026. The raw parent header and parent-to-commit file patch were inspected. This locates the source introduction; no first affected stable release is claimed.

The separate historical profiler startup stall is not explained or claimed fixed by this change. No browser, native-app, package-install, Windows, or Bun proof is claimed for this development-CLI repair.
