### PR TITLE
fix(release): qualify frozen plugin prerelease harness

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -991,6 +991,7 @@ jobs:
               args=(-f target_ref="$TARGET_SHA" -f expected_sha="$TARGET_SHA" -f full_release_validation=true -f phase="$PHASE" -f dispatch_id="$dispatch_id" -f node_test_exclude_patterns_json="$PLUGIN_PRERELEASE_NODE_EXCLUDE_PATTERNS_JSON")
               if [[ -n "${TARGET_CONTEXT_REF:-}" ]]; then
                 args+=(-f target_context_ref="$TARGET_CONTEXT_REF")
+                args+=(-f allow_frozen_target_scenario_omissions=true)
               fi
               if [[ -n "${CANDIDATE_ARTIFACT_JSON// }" ]]; then
                 args+=(-f candidate_artifact_json="$CANDIDATE_ARTIFACT_JSON")

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1683,6 +1683,7 @@ jobs:
       OPENCLAW_DOCKER_E2E_PACKAGE_ARTIFACT_NAME: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_name || 'docker-e2e-package' }}
       OPENCLAW_DOCKER_E2E_REPO_ROOT: ${{ github.workspace }}
       OPENCLAW_DOCKER_E2E_SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+      OPENCLAW_SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
       OPENCLAW_CODEX_NPM_PLUGIN_SPEC: ${{ inputs.codex_plugin_spec }}
       OPENCLAW_CURRENT_PACKAGE_TGZ: .artifacts/docker-e2e-package/openclaw-current.tgz
       OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION: ${{ needs.prepare_docker_e2e_image.outputs.package_version }}
@@ -1692,6 +1693,7 @@ jobs:
       OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: ${{ matrix.group.published_upgrade_survivor_scenarios || inputs.published_upgrade_survivor_scenarios }}
       OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: ${{ inputs.shared_image_policy == 'no-push-artifact' && '1' || '0' }}
       OPENCLAW_SKIP_DOCKER_BUILD: "1"
+      OPENCLAW_TOOLING_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
       INCLUDE_OPENWEBUI: ${{ inputs.include_openwebui }}
       DOCKER_E2E_LANES: ${{ matrix.group.docker_lanes }}
     steps:

--- a/.github/workflows/plugin-prerelease.yml
+++ b/.github/workflows/plugin-prerelease.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: ""
         type: string
+      allow_frozen_target_scenario_omissions:
+        description: Trusted opt-in to accept documented harness differences in a frozen target
+        required: false
+        default: false
+        type: boolean
       full_release_validation:
         description: Enable release-only Docker prerelease lanes from Full Release Validation
         required: false
@@ -975,6 +980,7 @@ jobs:
       docker_lanes: ${{ needs.preflight.outputs.plugin_prerelease_docker_lanes }}
       targeted_docker_lane_group_size: 2
       allow_unreleased_changelog: true
+      allow_frozen_target_scenario_omissions: ${{ inputs.allow_frozen_target_scenario_omissions }}
       include_live_suites: false
       live_models_only: false
       shared_image_artifact_namespace: plugin-prerelease

--- a/scripts/e2e/bundled-plugin-install-uninstall-docker.sh
+++ b/scripts/e2e/bundled-plugin-install-uninstall-docker.sh
@@ -63,16 +63,16 @@ DOCKER_ENV_ARGS=(
   -e "OPENCLAW_BUNDLED_PLUGIN_RUNTIME_TEARDOWN_KILL_GRACE_MS=$RUNTIME_TEARDOWN_KILL_GRACE_MS"
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64"
 )
-authorization_status=0
-if openclaw_frozen_target_omissions_authorized; then
+capability_status=0
+openclaw_resolve_frozen_plugin_prerelease_capabilities \
+  "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" || capability_status=$?
+[ "$capability_status" -eq 0 ] || exit "$capability_status"
+if [[ "$OPENCLAW_FROZEN_PLUGIN_PRERELEASE_PROFILE" == "legacy" ]]; then
   DOCKER_ENV_ARGS+=(
     -e OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS
     -e OPENCLAW_SELECTED_SHA
     -e OPENCLAW_TOOLING_SHA
   )
-else
-  authorization_status=$?
-  [ "$authorization_status" -eq 1 ] || exit "$authorization_status"
 fi
 for env_name in \
   OPENCLAW_BUNDLED_PLUGIN_SWEEP_TOTAL \

--- a/scripts/e2e/bundled-plugin-install-uninstall-docker.sh
+++ b/scripts/e2e/bundled-plugin-install-uninstall-docker.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-bundled-plugin-install-uninstall-e2e" OPENCLAW_BUNDLED_PLUGIN_INSTALL_UNINSTALL_E2E_IMAGE)"
 LIST_TIMEOUT_MS="$(
   docker_e2e_read_positive_int_env OPENCLAW_BUNDLED_PLUGIN_LIST_TIMEOUT_MS 30000
@@ -62,6 +63,17 @@ DOCKER_ENV_ARGS=(
   -e "OPENCLAW_BUNDLED_PLUGIN_RUNTIME_TEARDOWN_KILL_GRACE_MS=$RUNTIME_TEARDOWN_KILL_GRACE_MS"
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64"
 )
+authorization_status=0
+if openclaw_frozen_target_omissions_authorized; then
+  DOCKER_ENV_ARGS+=(
+    -e OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS
+    -e OPENCLAW_SELECTED_SHA
+    -e OPENCLAW_TOOLING_SHA
+  )
+else
+  authorization_status=$?
+  [ "$authorization_status" -eq 1 ] || exit "$authorization_status"
+fi
 for env_name in \
   OPENCLAW_BUNDLED_PLUGIN_SWEEP_TOTAL \
   OPENCLAW_BUNDLED_PLUGIN_SWEEP_INDEX \

--- a/scripts/e2e/kitchen-sink-plugin-docker.sh
+++ b/scripts/e2e/kitchen-sink-plugin-docker.sh
@@ -58,16 +58,16 @@ DOCKER_ENV_ARGS=(
   -e "KITCHEN_SINK_SCENARIOS=$KITCHEN_SINK_SCENARIOS"
   -e "KITCHEN_SINK_CLI_TIMEOUT=$KITCHEN_SINK_CLI_TIMEOUT"
 )
-authorization_status=0
-if openclaw_frozen_target_omissions_authorized; then
+capability_status=0
+openclaw_resolve_frozen_plugin_prerelease_capabilities \
+  "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" || capability_status=$?
+[ "$capability_status" -eq 0 ] || exit "$capability_status"
+if [[ "$OPENCLAW_FROZEN_PLUGIN_PRERELEASE_PROFILE" == "legacy" ]]; then
   DOCKER_ENV_ARGS+=(
     -e OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS
     -e OPENCLAW_SELECTED_SHA
     -e OPENCLAW_TOOLING_SHA
   )
-else
-  authorization_status=$?
-  [ "$authorization_status" -eq 1 ] || exit "$authorization_status"
 fi
 if [[ "${OPENCLAW_KITCHEN_SINK_LIVE_CLAWHUB:-0}" = "1" ]]; then
   for env_name in \

--- a/scripts/e2e/kitchen-sink-plugin-docker.sh
+++ b/scripts/e2e/kitchen-sink-plugin-docker.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-kitchen-sink-plugin-e2e" OPENCLAW_KITCHEN_SINK_PLUGIN_E2E_IMAGE)"
 OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES="$(
   docker_e2e_read_positive_int_env OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES 65536
@@ -57,6 +58,17 @@ DOCKER_ENV_ARGS=(
   -e "KITCHEN_SINK_SCENARIOS=$KITCHEN_SINK_SCENARIOS"
   -e "KITCHEN_SINK_CLI_TIMEOUT=$KITCHEN_SINK_CLI_TIMEOUT"
 )
+authorization_status=0
+if openclaw_frozen_target_omissions_authorized; then
+  DOCKER_ENV_ARGS+=(
+    -e OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS
+    -e OPENCLAW_SELECTED_SHA
+    -e OPENCLAW_TOOLING_SHA
+  )
+else
+  authorization_status=$?
+  [ "$authorization_status" -eq 1 ] || exit "$authorization_status"
+fi
 if [[ "${OPENCLAW_KITCHEN_SINK_LIVE_CLAWHUB:-0}" = "1" ]]; then
   for env_name in \
     OPENCLAW_KITCHEN_SINK_LIVE_CLAWHUB \

--- a/scripts/e2e/kitchen-sink-rpc-docker.sh
+++ b/scripts/e2e/kitchen-sink-rpc-docker.sh
@@ -27,16 +27,16 @@ DOCKER_ENV_ARGS=(
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0
   -e OPENCLAW_ENTRY=/app/openclaw.mjs
 )
-authorization_status=0
-if openclaw_frozen_target_omissions_authorized; then
+capability_status=0
+openclaw_resolve_frozen_plugin_prerelease_capabilities \
+  "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" || capability_status=$?
+[ "$capability_status" -eq 0 ] || exit "$capability_status"
+if [[ "$OPENCLAW_FROZEN_PLUGIN_PRERELEASE_PROFILE" == "legacy" ]]; then
   DOCKER_ENV_ARGS+=(
     -e OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS
     -e OPENCLAW_SELECTED_SHA
     -e OPENCLAW_TOOLING_SHA
   )
-else
-  authorization_status=$?
-  [ "$authorization_status" -eq 1 ] || exit "$authorization_status"
 fi
 
 for env_name in \

--- a/scripts/e2e/kitchen-sink-rpc-docker.sh
+++ b/scripts/e2e/kitchen-sink-rpc-docker.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-kitchen-sink-rpc-e2e" OPENCLAW_KITCHEN_SINK_RPC_E2E_IMAGE)"
 MAX_MEMORY_MIB="$(docker_e2e_read_nonnegative_decimal_env OPENCLAW_KITCHEN_SINK_MAX_MEMORY_MIB 2048)"
@@ -26,6 +27,17 @@ DOCKER_ENV_ARGS=(
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0
   -e OPENCLAW_ENTRY=/app/openclaw.mjs
 )
+authorization_status=0
+if openclaw_frozen_target_omissions_authorized; then
+  DOCKER_ENV_ARGS+=(
+    -e OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS
+    -e OPENCLAW_SELECTED_SHA
+    -e OPENCLAW_TOOLING_SHA
+  )
+else
+  authorization_status=$?
+  [ "$authorization_status" -eq 1 ] || exit "$authorization_status"
+fi
 
 for env_name in \
   OPENCLAW_KITCHEN_SINK_NPM_SPEC \

--- a/scripts/e2e/kitchen-sink-rpc-walk.mts
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mts
@@ -1324,9 +1324,10 @@ async function delayWithAbort(delayMs: number, signal?: AbortSignal) {
   }
 }
 
-function configureKitchenSink(env: KitchenSinkEnv, port: number) {
+export function configureKitchenSink(env: KitchenSinkEnv, port: number) {
   const configPath = env.OPENCLAW_CONFIG_PATH;
   const config = asRecord(fs.existsSync(configPath) ? readJson(configPath) : {});
+  const frozenTarget = env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS === "1";
   const gateway = asRecord(config.gateway);
   const plugins = asRecord(config.plugins);
   const pluginEntries = asRecord(plugins.entries);
@@ -1351,7 +1352,11 @@ function configureKitchenSink(env: KitchenSinkEnv, port: number) {
   config.plugins = {
     ...plugins,
     enabled: true,
-    allow: [...new Set([...(Array.isArray(plugins.allow) ? plugins.allow : []), PLUGIN_ID])],
+    ...(frozenTarget
+      ? {}
+      : {
+          allow: [...new Set([...(Array.isArray(plugins.allow) ? plugins.allow : []), PLUGIN_ID])],
+        }),
     entries: {
       ...pluginEntries,
       [PLUGIN_ID]: {
@@ -1379,8 +1384,7 @@ function configureKitchenSink(env: KitchenSinkEnv, port: number) {
       ...new Set([...(Array.isArray(tools.alsoAllow) ? tools.alsoAllow : []), ...EXPECTED_TOOLS]),
     ],
   };
-  config.tts = {
-    ...tts,
+  const ttsConfig = {
     provider: tts.provider ?? speechProvider,
     providers: {
       ...ttsProviders,
@@ -1389,6 +1393,12 @@ function configureKitchenSink(env: KitchenSinkEnv, port: number) {
       },
     },
   };
+  if (frozenTarget) {
+    const messages = asRecord(config.messages);
+    config.messages = { ...messages, tts: { ...asRecord(messages.tts), ...ttsConfig } };
+  } else {
+    config.tts = { ...tts, ...ttsConfig };
+  }
   writeJson(configPath, config);
 }
 

--- a/scripts/e2e/lib/bundled-plugin-install-uninstall/probe.mjs
+++ b/scripts/e2e/lib/bundled-plugin-install-uninstall/probe.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { readPluginInstallRecords } from "../plugin-index-sqlite.mjs";
-import { isExplicitPluginDisableMarker } from "../plugin-uninstall-assertions.mjs";
+import { hasExpectedPluginUninstallConfigState } from "../plugin-uninstall-assertions.mjs";
 
 const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
 const normalizePathForProbe = (value) => String(value ?? "").replace(/\\/g, "/");
@@ -277,7 +277,7 @@ function assertUninstalled(pluginId, pluginDir) {
   if (paths.some((entry) => pathReferencesBundledRuntime(entry, pluginDir))) {
     throw new Error(`load path still present after uninstall for ${pluginId}`);
   }
-  if (!isExplicitPluginDisableMarker(config, pluginId)) {
+  if (!hasExpectedPluginUninstallConfigState(config, pluginId)) {
     throw new Error(`exact disabled uninstall marker missing for ${pluginId}`);
   }
   if ((config.plugins?.allow || []).includes(pluginId)) {

--- a/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
+++ b/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
@@ -326,6 +326,22 @@ export function activateSmokePlugin(config, pluginId, channels = []) {
   };
 }
 
+export function withSmokeTtsConfig(config, tts) {
+  if (process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS === "1") {
+    return {
+      ...config,
+      messages: { ...config.messages, tts: { ...config.messages?.tts, ...tts } },
+    };
+  }
+  return { ...config, tts: { ...config.tts, ...tts } };
+}
+
+export function readSmokeTtsConfig(config) {
+  return process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS === "1"
+    ? config.messages?.tts
+    : config.tts;
+}
+
 function channelActivationEnvName(channel) {
   return `${channel
     .replace(/[^a-z0-9]+/giu, "_")
@@ -1048,23 +1064,23 @@ async function smokePlugin(pluginId, pluginDir, requiresConfig, pluginIndex, plu
   const manifest = loadManifest(pluginDir, pluginRoot);
   const plan = buildPluginPlan(manifest);
   const port = resolveRuntimeSmokePort(pluginIndex);
-  const config = ensureGatewayConfig(
+  let config = ensureGatewayConfig(
     activateSmokePlugin(readConfig(), pluginId, plan.channels),
     port,
   );
   const env = withManifestChannelActivationEnv(process.env, plan.channels);
   if (plan.speechProviders[0]) {
     const provider = plan.speechProviders[0];
-    config.tts = {
-      ...config.tts,
+    const existingTts = readSmokeTtsConfig(config);
+    config = withSmokeTtsConfig(config, {
       provider,
       providers: {
-        ...config.tts?.providers,
+        ...existingTts?.providers,
         [provider]: {
-          ...config.tts?.providers?.[provider],
+          ...existingTts?.providers?.[provider],
         },
       },
-    };
+    });
   }
   writeConfig(config);
 
@@ -1394,14 +1410,16 @@ async function smokeTtsGlobalDisable(pluginId, pluginDir, provider, pluginIndex,
   const env = createIsolatedStateEnv(`tts-disabled-${pluginId}`);
   writeConfig(
     ensureGatewayConfig(
-      {
-        plugins: {
-          enabled: false,
+      withSmokeTtsConfig(
+        {
+          plugins: {
+            enabled: false,
+          },
         },
-        tts: {
+        {
           provider: selectedProvider,
         },
-      },
+      ),
       port,
     ),
     env,
@@ -1444,15 +1462,17 @@ async function smokeOpenAiTts(pluginIndex) {
   const env = createIsolatedStateEnv("tts-openai-live");
   writeConfig(
     ensureGatewayConfig(
-      {
-        plugins: {
-          enabled: true,
-          allow: ["openai"],
-          entries: {
-            openai: { enabled: true },
+      withSmokeTtsConfig(
+        {
+          plugins: {
+            enabled: true,
+            allow: ["openai"],
+            entries: {
+              openai: { enabled: true },
+            },
           },
         },
-        tts: {
+        {
           provider: "openai",
           providers: {
             openai: {
@@ -1460,7 +1480,7 @@ async function smokeOpenAiTts(pluginIndex) {
             },
           },
         },
-      },
+      ),
       port,
     ),
     env,

--- a/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
+++ b/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { readPluginInstallRecords } from "../plugin-index-sqlite.mjs";
-import { isExplicitPluginDisableMarker } from "../plugin-uninstall-assertions.mjs";
+import { hasExpectedPluginUninstallConfigState } from "../plugin-uninstall-assertions.mjs";
 
 const command = process.argv[2];
 const scratchRoot = process.env.KITCHEN_SINK_TMP_DIR || os.tmpdir();
@@ -362,14 +362,24 @@ function assertExpectedDiagnostics(surfaceMode, errorMessages) {
   const optionalErrorMessages = new Set([
     "agent event subscription registration requires id and handle",
   ]);
+  const frozenTargetErrorMessages = new Set();
+  if (process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS === "1") {
+    frozenTargetErrorMessages.add(
+      "plugin must own memory slot or declare contracts.memoryEmbeddingProviders for adapter: kitchen-sink-memory-embedding-provider",
+    );
+  }
   const allowedErrorMessages = new Set([...expectedErrorMessages, ...optionalErrorMessages]);
   if (!INVALID_PROBE_DIAGNOSTIC_SURFACE_MODES.has(surfaceMode)) {
-    if (errorMessages.size > 0) {
-      throw new Error(
-        `unexpected kitchen-sink diagnostic errors: ${[...errorMessages].join(", ")}`,
-      );
+    const unexpected = [...errorMessages].filter(
+      (message) => !frozenTargetErrorMessages.has(message),
+    );
+    if (unexpected.length > 0) {
+      throw new Error(`unexpected kitchen-sink diagnostic errors: ${unexpected.join(", ")}`);
     }
     return;
+  }
+  for (const message of frozenTargetErrorMessages) {
+    allowedErrorMessages.add(message);
   }
   for (const message of errorMessages) {
     if (!allowedErrorMessages.has(message)) {
@@ -669,7 +679,7 @@ function assertRemoved() {
   }
 
   const { config } = readConfig();
-  if (!isExplicitPluginDisableMarker(config, pluginId)) {
+  if (!hasExpectedPluginUninstallConfigState(config, pluginId)) {
     throw new Error(`kitchen-sink exact disabled uninstall marker missing: ${pluginId}`);
   }
   if ((config.plugins?.allow || []).includes(pluginId)) {

--- a/scripts/e2e/lib/mcp-channels-attachment-contract.mjs
+++ b/scripts/e2e/lib/mcp-channels-attachment-contract.mjs
@@ -1,0 +1,26 @@
+import { isDeepStrictEqual } from "node:util";
+
+const CANONICAL_SEEDED_ATTACHMENT = {
+  type: "openclaw_media",
+  media: {
+    url: "media://inbound/seeded-image.png",
+    contentType: "image/png",
+    kind: "image",
+    fileName: "seeded-image.png",
+    sizeBytes: 3,
+    transcribed: false,
+  },
+};
+
+const LEGACY_SEEDED_ATTACHMENT = {
+  type: "image",
+  source: { type: "base64", media_type: "image/png", data: "abc" },
+};
+
+/** Match the candidate's persisted-media contract selected by the trusted Docker harness. */
+export function hasExpectedSeededMcpAttachment(attachment, frozenTarget) {
+  return isDeepStrictEqual(
+    attachment,
+    frozenTarget ? LEGACY_SEEDED_ATTACHMENT : CANONICAL_SEEDED_ATTACHMENT,
+  );
+}

--- a/scripts/e2e/lib/plugin-uninstall-assertions.mjs
+++ b/scripts/e2e/lib/plugin-uninstall-assertions.mjs
@@ -8,3 +8,15 @@ export function isExplicitPluginDisableMarker(config, pluginId) {
     Object.keys(entry).length === 1
   );
 }
+
+export function hasExpectedPluginUninstallConfigState(config, pluginId) {
+  if (isExplicitPluginDisableMarker(config, pluginId)) {
+    return true;
+  }
+  // The outer trusted workflow admits this only for a distinct frozen target.
+  // That target predates the durable disable marker but still removes all plugin state.
+  return (
+    process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS === "1" &&
+    !config.plugins?.entries?.[pluginId]
+  );
+}

--- a/scripts/e2e/lib/plugin-uninstall-assertions.mjs
+++ b/scripts/e2e/lib/plugin-uninstall-assertions.mjs
@@ -17,6 +17,6 @@ export function hasExpectedPluginUninstallConfigState(config, pluginId) {
   // That target predates the durable disable marker but still removes all plugin state.
   return (
     process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS === "1" &&
-    !config.plugins?.entries?.[pluginId]
+    !Object.hasOwn(config.plugins?.entries ?? {}, pluginId)
   );
 }

--- a/scripts/e2e/lib/plugins/assertions.mjs
+++ b/scripts/e2e/lib/plugins/assertions.mjs
@@ -12,7 +12,7 @@ import {
   readPluginInstallRecords,
   writePluginInstallIndexForE2E,
 } from "../plugin-index-sqlite.mjs";
-import { isExplicitPluginDisableMarker } from "../plugin-uninstall-assertions.mjs";
+import { hasExpectedPluginUninstallConfigState } from "../plugin-uninstall-assertions.mjs";
 import { readTextFileTail } from "../text-file-utils.mjs";
 
 const command = process.argv[2];
@@ -149,14 +149,7 @@ function readRequiredOpenClawConfig() {
 }
 
 function assertPluginUninstallConfigState(config, pluginId, label = pluginId) {
-  const entry = config.plugins?.entries?.[pluginId];
-  if (process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS === "1") {
-    if (entry) {
-      throw new Error(`${label} config entry still present after uninstall`);
-    }
-    return;
-  }
-  if (!isExplicitPluginDisableMarker(config, pluginId)) {
+  if (!hasExpectedPluginUninstallConfigState(config, pluginId)) {
     throw new Error(`${label} exact disabled uninstall marker missing`);
   }
 }

--- a/scripts/e2e/lib/release-plugin-marketplace/lifecycle-assertions.mjs
+++ b/scripts/e2e/lib/release-plugin-marketplace/lifecycle-assertions.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { readPluginInstallIndex } from "../plugin-index-sqlite.mjs";
-import { isExplicitPluginDisableMarker } from "../plugin-uninstall-assertions.mjs";
+import { hasExpectedPluginUninstallConfigState } from "../plugin-uninstall-assertions.mjs";
 
 function assert(condition, message) {
   if (!condition) {
@@ -179,7 +179,7 @@ function assertMarketplaceUninstalled() {
     `installed plugin index still includes ${pluginId}`,
   );
   assert(
-    isExplicitPluginDisableMarker(config, pluginId),
+    hasExpectedPluginUninstallConfigState(config, pluginId),
     `exact disabled uninstall marker missing for ${pluginId}`,
   );
   assert(!config.plugins?.allow?.includes(pluginId), `allowlist still includes ${pluginId}`);

--- a/scripts/e2e/lib/release-scenarios/assertions.mjs
+++ b/scripts/e2e/lib/release-scenarios/assertions.mjs
@@ -15,7 +15,7 @@ import {
   parseMockOpenAiPort,
 } from "../fixtures/mock-openai-config.mjs";
 import { readPluginInstallRecords } from "../plugin-index-sqlite.mjs";
-import { isExplicitPluginDisableMarker } from "../plugin-uninstall-assertions.mjs";
+import { hasExpectedPluginUninstallConfigState } from "../plugin-uninstall-assertions.mjs";
 import {
   ERROR_DETAIL_TAIL_BYTES,
   fileContainsText,
@@ -211,7 +211,7 @@ function assertPluginUninstalled() {
   const installRecords = readPluginInstallRecords({ configPath: configPath() });
   assert(!installRecords[pluginId], `install record still present for ${pluginId}`);
   assert(
-    isExplicitPluginDisableMarker(cfg, pluginId),
+    hasExpectedPluginUninstallConfigState(cfg, pluginId),
     `exact disabled uninstall marker missing for ${pluginId}`,
   );
   const managedRoot = path.join(

--- a/scripts/e2e/lib/release-user-journey/assertions.mjs
+++ b/scripts/e2e/lib/release-user-journey/assertions.mjs
@@ -15,7 +15,7 @@ import {
   parseMockOpenAiPort,
 } from "../fixtures/mock-openai-config.mjs";
 import { readPluginInstallRecords } from "../plugin-index-sqlite.mjs";
-import { isExplicitPluginDisableMarker } from "../plugin-uninstall-assertions.mjs";
+import { hasExpectedPluginUninstallConfigState } from "../plugin-uninstall-assertions.mjs";
 import {
   ERROR_DETAIL_TAIL_BYTES,
   fileContainsText,
@@ -218,7 +218,7 @@ function assertPluginUninstalled() {
   const records = installRecords();
   assert(!records[pluginId], `install record still present for ${pluginId}`);
   assert(
-    isExplicitPluginDisableMarker(cfg, pluginId),
+    hasExpectedPluginUninstallConfigState(cfg, pluginId),
     `exact disabled uninstall marker missing for ${pluginId}`,
   );
   assert(!(cfg.plugins?.allow ?? []).includes(pluginId), `allowlist still contains ${pluginId}`);

--- a/scripts/e2e/mcp-channels-docker.sh
+++ b/scripts/e2e/mcp-channels-docker.sh
@@ -21,16 +21,16 @@ trap cleanup EXIT
 docker_e2e_build_or_reuse "$IMAGE_NAME" mcp-channels
 OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 mcp-channels empty)"
 DOCKER_ENV_ARGS=()
-authorization_status=0
-if openclaw_frozen_target_omissions_authorized; then
+capability_status=0
+openclaw_resolve_frozen_plugin_prerelease_capabilities \
+  "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" || capability_status=$?
+[ "$capability_status" -eq 0 ] || exit "$capability_status"
+if [[ "$OPENCLAW_FROZEN_PLUGIN_PRERELEASE_PROFILE" == "legacy" ]]; then
   DOCKER_ENV_ARGS+=(
     -e OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS
     -e OPENCLAW_SELECTED_SHA
     -e OPENCLAW_TOOLING_SHA
   )
-else
-  authorization_status=$?
-  [ "$authorization_status" -eq 1 ] || exit "$authorization_status"
 fi
 
 echo "Running in-container gateway + MCP smoke..."

--- a/scripts/e2e/mcp-channels-docker.sh
+++ b/scripts/e2e/mcp-channels-docker.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-mcp-channels-e2e" OPENCLAW_IMAGE)"
 PORT="18789"
 TOKEN="mcp-e2e-$(date +%s)-$$"
@@ -19,6 +20,18 @@ trap cleanup EXIT
 
 docker_e2e_build_or_reuse "$IMAGE_NAME" mcp-channels
 OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 mcp-channels empty)"
+DOCKER_ENV_ARGS=()
+authorization_status=0
+if openclaw_frozen_target_omissions_authorized; then
+  DOCKER_ENV_ARGS+=(
+    -e OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS
+    -e OPENCLAW_SELECTED_SHA
+    -e OPENCLAW_TOOLING_SHA
+  )
+else
+  authorization_status=$?
+  [ "$authorization_status" -eq 1 ] || exit "$authorization_status"
+fi
 
 echo "Running in-container gateway + MCP smoke..."
 # Harness files are mounted read-only; the app under test comes from /app/dist.
@@ -36,6 +49,7 @@ docker_e2e_run_with_harness \
   -e "GW_URL=ws://127.0.0.1:$PORT" \
   -e "GW_TOKEN=$TOKEN" \
   -e "OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1" \
+  "${DOCKER_ENV_ARGS[@]}" \
   "$IMAGE_NAME" \
   bash -lc "set -euo pipefail
     source scripts/lib/openclaw-e2e-instance.sh

--- a/scripts/e2e/mcp-channels-seed.ts
+++ b/scripts/e2e/mcp-channels-seed.ts
@@ -2,20 +2,14 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import {
-  normalizeSessionDeliveryState,
-  upsertSessionEntry,
-} from "openclaw/plugin-sdk/session-store-runtime";
-import { appendSessionTranscriptMessagesByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
 import { applyDockerOpenAiProviderConfig, type OpenClawConfig } from "./docker-openai-seed.ts";
 
 async function main() {
   const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || path.join(os.homedir(), ".openclaw");
   const configPath =
     process.env.OPENCLAW_CONFIG_PATH?.trim() || path.join(stateDir, "openclaw.json");
-  const storePath = resolveOpenClawAgentSqlitePath({ agentId: "main" });
   const now = Date.now();
+  const frozenTarget = process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS === "1";
 
   await fs.mkdir(path.dirname(configPath), { recursive: true });
 
@@ -23,6 +17,7 @@ async function main() {
     {
       gateway: {
         controlUi: {
+          ...(frozenTarget ? { allowInsecureAuth: true } : {}),
           enabled: false,
         },
       },
@@ -41,6 +36,74 @@ async function main() {
   );
 
   await fs.writeFile(configPath, JSON.stringify(seededConfig, null, 2), "utf-8");
+
+  if (frozenTarget) {
+    const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
+    const sessionFile = path.join(sessionsDir, "sess-main.jsonl");
+    const storePath = path.join(sessionsDir, "sessions.json");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId: "sess-main",
+          sessionFile,
+          updatedAt: now,
+          deliveryContext: {
+            channel: "imessage",
+            to: "+15551234567",
+            accountId: "imessage-default",
+            threadId: "thread-42",
+          },
+          displayName: "Docker MCP Channel Smoke",
+          derivedTitle: "Docker MCP Channel Smoke",
+          lastMessagePreview: "seeded transcript",
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", version: 1, id: "sess-main" }),
+        JSON.stringify({
+          id: "msg-1",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "hello from seeded transcript" }],
+            timestamp: now,
+          },
+        }),
+        JSON.stringify({
+          id: "msg-attachment",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "seeded image attachment" },
+              { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" } },
+            ],
+            timestamp: now + 1,
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    process.stdout.write(
+      `${JSON.stringify({ ok: true, stateDir, configPath, sessionFile, storePath })}\n`,
+    );
+    return;
+  }
+
+  const [
+    { normalizeSessionDeliveryState, upsertSessionEntry },
+    { appendSessionTranscriptMessagesByIdentity },
+    { resolveOpenClawAgentSqlitePath },
+  ] = await Promise.all([
+    import("openclaw/plugin-sdk/session-store-runtime"),
+    import("openclaw/plugin-sdk/session-transcript-runtime"),
+    import("openclaw/plugin-sdk/sqlite-runtime"),
+  ]);
+  const storePath = resolveOpenClawAgentSqlitePath({ agentId: "main" });
 
   await upsertSessionEntry({
     agentId: "main",

--- a/scripts/e2e/plugins-docker.sh
+++ b/scripts/e2e/plugins-docker.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-plugins-e2e" OPENCLAW_PLUGINS_E2E_IMAGE)"
 OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES="$(
   docker_e2e_read_positive_int_env OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES 65536
@@ -26,6 +27,17 @@ DOCKER_ENV_ARGS=(
   -e "OPENCLAW_PLUGINS_CLI_TIMEOUT=$PLUGINS_CLI_TIMEOUT"
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64"
 )
+capability_status=0
+openclaw_resolve_frozen_plugin_prerelease_capabilities \
+  "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" || capability_status=$?
+[ "$capability_status" -eq 0 ] || exit "$capability_status"
+if [[ "$OPENCLAW_FROZEN_PLUGIN_PRERELEASE_PROFILE" == "legacy" ]]; then
+  DOCKER_ENV_ARGS+=(
+    -e OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS
+    -e OPENCLAW_SELECTED_SHA
+    -e OPENCLAW_TOOLING_SHA
+  )
+fi
 for env_name in \
   OPENCLAW_PLUGIN_LIFECYCLE_TRACE \
   OPENCLAW_PLUGINS_E2E_CLAWHUB \

--- a/scripts/lib/frozen-target-compat.sh
+++ b/scripts/lib/frozen-target-compat.sh
@@ -25,3 +25,30 @@ openclaw_frozen_target_omissions_authorized() {
     return 2
   fi
 }
+
+openclaw_resolve_frozen_plugin_prerelease_capabilities() {
+  local source_root="${1:?missing selected source root}" authorization_status=0
+
+  # Default to current assertions. A frozen target may use legacy fixtures only
+  # when its checked-out source proves the complete pre-SQLite plugin profile.
+  export OPENCLAW_FROZEN_PLUGIN_PRERELEASE_PROFILE="current"
+
+  openclaw_frozen_target_omissions_authorized || authorization_status=$?
+  [ "$authorization_status" -eq 1 ] && return 0
+  [ "$authorization_status" -eq 0 ] || return "$authorization_status"
+
+  if [ "$(git -C "$source_root" rev-parse HEAD 2>/dev/null)" != "$OPENCLAW_SELECTED_SHA" ]; then
+    echo "selected source checkout does not match OPENCLAW_SELECTED_SHA" >&2
+    return 2
+  fi
+
+  if git -C "$source_root" show "$OPENCLAW_SELECTED_SHA:src/config/types.messages.ts" 2>/dev/null |
+    grep -Fq 'tts?: TtsConfig;' &&
+    git -C "$source_root" show "$OPENCLAW_SELECTED_SHA:src/config/types.plugins.ts" 2>/dev/null |
+      grep -Fq 'bundledDiscovery?: "compat" | "allowlist";' &&
+    git -C "$source_root" show "$OPENCLAW_SELECTED_SHA:src/plugin-sdk/session-store-runtime.ts" 2>/dev/null |
+      grep -Fq 'before SQLite migration' &&
+    ! git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:src/plugins/uninstall-package-plan.ts" 2>/dev/null; then
+    export OPENCLAW_FROZEN_PLUGIN_PRERELEASE_PROFILE="legacy"
+  fi
+}

--- a/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
+++ b/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
@@ -1,6 +1,7 @@
 // MCP channels Docker client drives the QA-owned channel bridge smoke.
 import { randomUUID } from "node:crypto";
 import { setTimeout as delay } from "node:timers/promises";
+import { hasExpectedSeededMcpAttachment } from "../../../../scripts/e2e/lib/mcp-channels-attachment-contract.mjs";
 import {
   assert,
   assertGatewayScopes,
@@ -100,6 +101,7 @@ async function waitForGatewaySeededConversation(gateway: GatewayRpcClient) {
 async function main() {
   const gatewayUrl = process.env.GW_URL?.trim();
   const gatewayToken = process.env.GW_TOKEN?.trim();
+  const frozenTarget = process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS === "1";
   assert(gatewayUrl, "missing GW_URL");
   assert(gatewayToken, "missing GW_TOKEN");
 
@@ -234,19 +236,8 @@ async function main() {
       "expected one seeded attachment",
     );
     assert(
-      JSON.stringify(attachments.structuredContent?.attachments?.[0]) ===
-        JSON.stringify({
-          type: "openclaw_media",
-          media: {
-            url: "media://inbound/seeded-image.png",
-            contentType: "image/png",
-            kind: "image",
-            fileName: "seeded-image.png",
-            sizeBytes: 3,
-            transcribed: false,
-          },
-        }),
-      `expected canonical persisted media attachment: ${JSON.stringify(attachments.structuredContent)}`,
+      hasExpectedSeededMcpAttachment(attachments.structuredContent?.attachments?.[0], frozenTarget),
+      `expected persisted media attachment: ${JSON.stringify(attachments.structuredContent)}`,
     );
 
     let waitCursor = 0;
@@ -513,7 +504,7 @@ async function main() {
           nonOwnerReplyForwarded: true,
           nonOwnerPermissionBlocked: true,
           ownerPermissionAllowed: permission.behavior === "allow",
-          canonicalMediaAttachmentFound: true,
+          mediaAttachmentFound: true,
           rawNotifications: connectedMcp.rawMessages.filter(
             (entry) =>
               ClaudeChannelNotificationSchema.safeParse(entry).success ||

--- a/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
+++ b/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
@@ -1424,6 +1424,36 @@ describe("bundled plugin install/uninstall probe", () => {
     expect(fs.existsSync(path.dirname(env.HOME))).toBe(false);
   });
 
+  it("uses the candidate TTS config dialect only for an authorized frozen target", async () => {
+    const frozen = await withEnvAsync(
+      { OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1" },
+      async () => {
+        const runtimeSmoke = await import(pathToFileURL(runtimeSmokePath).href);
+        const configured = runtimeSmoke.withSmokeTtsConfig(
+          { messages: { other: true } },
+          { enabled: false },
+        );
+        return { configured, tts: runtimeSmoke.readSmokeTtsConfig(configured) };
+      },
+    );
+    expect(frozen.configured).toEqual({ messages: { other: true, tts: { enabled: false } } });
+    expect(frozen.tts).toEqual({ enabled: false });
+
+    const current = await withEnvAsync(
+      { OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: undefined },
+      async () => {
+        const runtimeSmoke = await import(pathToFileURL(runtimeSmokePath).href);
+        const configured = runtimeSmoke.withSmokeTtsConfig(
+          { messages: { other: true } },
+          { enabled: false },
+        );
+        return { configured, tts: runtimeSmoke.readSmokeTtsConfig(configured) };
+      },
+    );
+    expect(current.configured).toEqual({ messages: { other: true }, tts: { enabled: false } });
+    expect(current.tts).toEqual({ enabled: false });
+  });
+
   it("selects packaged installable bundled sources instead of raw dist extension dirs", () => {
     const root = makePackageRoot();
     fs.mkdirSync(path.join(root, "dist", "extensions", "qa-channel"), { recursive: true });

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5792,6 +5792,10 @@ server.listen(0, "127.0.0.1", () => {
     expect(releaseChecks.jobs.validate_docker_lanes.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS).toBe(
       "${{ matrix.group.published_upgrade_survivor_scenarios || inputs.published_upgrade_survivor_scenarios }}",
     );
+    expect(releaseChecks.jobs.validate_docker_lanes.env).toMatchObject({
+      OPENCLAW_SELECTED_SHA: "${{ needs.validate_selected_ref.outputs.selected_sha }}",
+      OPENCLAW_TOOLING_SHA: "${{ needs.validate_selected_ref.outputs.workflow_sha }}",
+    });
   });
 
   it("persists Node 22 declarations through trusted bounded artifacts", () => {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6420,6 +6420,7 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
   it("resolves plugin Docker legacy fixtures from the selected source profile", () => {
     for (const runnerPath of [
       "scripts/e2e/bundled-plugin-install-uninstall-docker.sh",
+      PLUGINS_DOCKER_E2E_PATH,
       KITCHEN_SINK_PLUGIN_DOCKER_E2E_PATH,
       KITCHEN_SINK_RPC_DOCKER_E2E_PATH,
       "scripts/e2e/mcp-channels-docker.sh",

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6417,7 +6417,7 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     expect(missing).toEqual([]);
   });
 
-  it("forwards authorized frozen-target context into plugin Docker lanes", () => {
+  it("resolves plugin Docker legacy fixtures from the selected source profile", () => {
     for (const runnerPath of [
       "scripts/e2e/bundled-plugin-install-uninstall-docker.sh",
       KITCHEN_SINK_PLUGIN_DOCKER_E2E_PATH,
@@ -6426,7 +6426,9 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     ]) {
       const runner = readFileSync(runnerPath, "utf8");
       expect(runner).toContain('source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"');
-      expect(runner).toContain("openclaw_frozen_target_omissions_authorized");
+      expect(runner).toContain("openclaw_resolve_frozen_plugin_prerelease_capabilities");
+      expect(runner).toContain("OPENCLAW_DOCKER_E2E_REPO_ROOT");
+      expect(runner).toContain('OPENCLAW_FROZEN_PLUGIN_PRERELEASE_PROFILE" == "legacy"');
       expect(runner).toContain("OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS");
       expect(runner).toContain("OPENCLAW_SELECTED_SHA");
       expect(runner).toContain("OPENCLAW_TOOLING_SHA");

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6417,6 +6417,22 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     expect(missing).toEqual([]);
   });
 
+  it("forwards authorized frozen-target context into plugin Docker lanes", () => {
+    for (const runnerPath of [
+      "scripts/e2e/bundled-plugin-install-uninstall-docker.sh",
+      KITCHEN_SINK_PLUGIN_DOCKER_E2E_PATH,
+      KITCHEN_SINK_RPC_DOCKER_E2E_PATH,
+      "scripts/e2e/mcp-channels-docker.sh",
+    ]) {
+      const runner = readFileSync(runnerPath, "utf8");
+      expect(runner).toContain('source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"');
+      expect(runner).toContain("openclaw_frozen_target_omissions_authorized");
+      expect(runner).toContain("OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS");
+      expect(runner).toContain("OPENCLAW_SELECTED_SHA");
+      expect(runner).toContain("OPENCLAW_TOOLING_SHA");
+    }
+  });
+
   it("keeps the kitchen-sink RPC Docker watchdog above the internal walk budgets", () => {
     const runner = readFileSync(KITCHEN_SINK_RPC_DOCKER_E2E_PATH, "utf8");
     expect(runner).toContain(

--- a/test/scripts/kitchen-sink-plugin-assertions.test.ts
+++ b/test/scripts/kitchen-sink-plugin-assertions.test.ts
@@ -26,6 +26,8 @@ const REQUIRED_FULL_DIAGNOSTIC_CANARIES = [
   'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
   "session scheduler job registration requires unique id, sessionKey, and kind",
 ];
+const FROZEN_MEMORY_EMBEDDING_DIAGNOSTIC =
+  "plugin must own memory slot or declare contracts.memoryEmbeddingProviders for adapter: kitchen-sink-memory-embedding-provider";
 
 function writeJson(filePath: string, value: unknown) {
   mkdirSync(path.dirname(filePath), { recursive: true });
@@ -325,6 +327,26 @@ describe("kitchen-sink plugin assertions", () => {
     expect(result.stderr).toContain(
       "unexpected kitchen-sink diagnostic errors: plugin must declare contracts.tools for: kitchen-sink-tool",
     );
+  });
+
+  it("accepts only the candidate memory diagnostic for an authorized frozen target", () => {
+    const result = runAssertInstalled({
+      diagnostics: diagnosticErrors([FROZEN_MEMORY_EMBEDDING_DIAGNOSTIC]),
+      env: { OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1" },
+      surfaceMode: "conformance",
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  it("rejects the candidate memory diagnostic for an ordinary target", () => {
+    const result = runAssertInstalled({
+      diagnostics: diagnosticErrors([FROZEN_MEMORY_EMBEDDING_DIAGNOSTIC]),
+      surfaceMode: "conformance",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(FROZEN_MEMORY_EMBEDDING_DIAGNOSTIC);
   });
 
   it("persists the scenario personality in plugin config", () => {

--- a/test/scripts/kitchen-sink-rpc-walk.test.ts
+++ b/test/scripts/kitchen-sink-rpc-walk.test.ts
@@ -31,6 +31,7 @@ import {
   assertResourceCeiling,
   assertTtsProviderCoverage,
   cleanupKitchenSinkEnv,
+  configureKitchenSink,
   createGatewayReadyLogScanner,
   createRpcCliRunOptions,
   extractPluginCommandNames,
@@ -317,6 +318,24 @@ describe("kitchen-sink RPC isolated state", () => {
     await expect(cleanupKitchenSinkEnv(root)).resolves.toBe(true);
 
     expect(existsSync(root)).toBe(false);
+  });
+
+  it("uses the candidate config dialect only for an authorized frozen target", async () => {
+    const { root, env } = makeEnv();
+    try {
+      configureKitchenSink({ ...env, OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1" }, 18888);
+      const frozenConfig = JSON.parse(readFileSync(env.OPENCLAW_CONFIG_PATH, "utf8"));
+      expect(frozenConfig.plugins.allow).toBeUndefined();
+      expect(frozenConfig.messages.tts).toMatchObject({ provider: "kitchen-sink-speech" });
+      expect(frozenConfig.tts).toBeUndefined();
+
+      configureKitchenSink(env, 18889);
+      const currentConfig = JSON.parse(readFileSync(env.OPENCLAW_CONFIG_PATH, "utf8"));
+      expect(currentConfig.plugins.allow).toContain("openclaw-kitchen-sink-fixture");
+      expect(currentConfig.tts).toMatchObject({ provider: "kitchen-sink-speech" });
+    } finally {
+      await cleanupKitchenSinkEnv(root);
+    }
   });
 
   it("can fail the walk when generated temp cleanup cannot remove the root", async () => {

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -1,5 +1,5 @@
 // Live Docker Stage tests cover live docker stage script behavior.
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,6 +9,7 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const stageScriptPath = path.join(repoRoot, "scripts/lib/live-docker-stage.sh");
+const frozenTargetCompatPath = path.join(repoRoot, "scripts/lib/frozen-target-compat.sh");
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("live Docker state staging", () => {
@@ -354,6 +355,80 @@ export function parseRegistryNpmSpec(spec: string) {
     });
     expect(malformed.status).toBe(2);
     expect(malformed.stderr).toContain("invalid OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS");
+  });
+
+  it("selects plugin prerelease legacy fixtures only for the complete selected source profile", () => {
+    const createSource = (profile: "legacy" | "partial") => {
+      const root = tempDirs.make(`openclaw-frozen-plugin-profile-${profile}-`);
+      const writeSource = (relativePath: string, content: string) => {
+        const filePath = path.join(root, relativePath);
+        mkdirSync(path.dirname(filePath), { recursive: true });
+        writeFileSync(filePath, content);
+      };
+      writeSource("src/config/types.messages.ts", "tts?: TtsConfig;\n");
+      writeSource("src/config/types.plugins.ts", 'bundledDiscovery?: "compat" | "allowlist";\n');
+      writeSource(
+        "src/plugin-sdk/session-store-runtime.ts",
+        "// Callers must migrate away before SQLite migration.\n",
+      );
+      if (profile === "partial") {
+        writeSource("src/plugins/uninstall-package-plan.ts", "export {};\n");
+      }
+      execFileSync("git", ["init", "-q", root]);
+      execFileSync("git", ["-C", root, "config", "user.email", "test@example.invalid"]);
+      execFileSync("git", ["-C", root, "config", "user.name", "OpenClaw Test"]);
+      execFileSync("git", ["-C", root, "add", "-A"]);
+      execFileSync("git", ["-C", root, "commit", "-qm", profile]);
+      return {
+        root,
+        sha: execFileSync("git", ["-C", root, "rev-parse", "HEAD"], {
+          encoding: "utf8",
+        }).trim(),
+      };
+    };
+    const run = (
+      source: ReturnType<typeof createSource>,
+      {
+        authorized = true,
+        selectedSha = source.sha,
+      }: { authorized?: boolean; selectedSha?: string } = {},
+    ) =>
+      spawnSync(
+        "bash",
+        [
+          "-c",
+          [
+            'set -euo pipefail; source "$1"',
+            'openclaw_resolve_frozen_plugin_prerelease_capabilities "$2"',
+            'printf "%s\\n" "$OPENCLAW_FROZEN_PLUGIN_PRERELEASE_PROFILE"',
+          ].join("; "),
+          "test",
+          frozenTargetCompatPath,
+          source.root,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            ...(authorized ? { OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1" } : {}),
+            OPENCLAW_SELECTED_SHA: selectedSha,
+            OPENCLAW_TOOLING_SHA: "f".repeat(40),
+          },
+        },
+      );
+
+    const legacy = createSource("legacy");
+    expect(run(legacy).stdout.trim()).toBe("legacy");
+
+    const unauthorized = run(legacy, { authorized: false });
+    expect(unauthorized.stdout.trim()).toBe("current");
+
+    const partial = createSource("partial");
+    expect(run(partial).stdout.trim()).toBe("current");
+
+    const mismatched = run(legacy, { selectedSha: "e".repeat(40) });
+    expect(mismatched.status).toBe(2);
+    expect(mismatched.stderr).toContain("selected source checkout");
   });
 
   it.each([

--- a/test/scripts/mcp-channels-attachment-contract.test.ts
+++ b/test/scripts/mcp-channels-attachment-contract.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { hasExpectedSeededMcpAttachment } from "../../scripts/e2e/lib/mcp-channels-attachment-contract.mjs";
+
+describe("MCP channels Docker attachment contract", () => {
+  it("accepts the shipped legacy attachment only for an authorized frozen target", () => {
+    const legacyAttachment = {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "abc" },
+    };
+    const canonicalAttachment = {
+      type: "openclaw_media",
+      media: {
+        url: "media://inbound/seeded-image.png",
+        contentType: "image/png",
+        kind: "image",
+        fileName: "seeded-image.png",
+        sizeBytes: 3,
+        transcribed: false,
+      },
+    };
+
+    expect(hasExpectedSeededMcpAttachment(canonicalAttachment, false)).toBe(true);
+    expect(hasExpectedSeededMcpAttachment(legacyAttachment, false)).toBe(false);
+    expect(hasExpectedSeededMcpAttachment(legacyAttachment, true)).toBe(true);
+    expect(hasExpectedSeededMcpAttachment({ type: "image" }, true)).toBe(false);
+  });
+});

--- a/test/scripts/mcp-channels-seed.built-cli.e2e.test.ts
+++ b/test/scripts/mcp-channels-seed.built-cli.e2e.test.ts
@@ -106,4 +106,44 @@ describe("MCP channels Docker seed", () => {
       },
     );
   });
+
+  it("keeps the pre-SQLite session seed only for an authorized frozen target", async () => {
+    await withOpenClawTestState(
+      { label: "mcp-channels-seed-frozen", scenario: "empty" },
+      async (state) => {
+        const tsconfigPath = state.path("tsconfig.json");
+        await fs.writeFile(tsconfigPath, "{}");
+        await execFileAsync(
+          process.execPath,
+          ["--import", "tsx", "scripts/e2e/mcp-channels-seed.ts"],
+          {
+            cwd: process.cwd(),
+            env: {
+              PATH: process.env.PATH,
+              ...state.envVars,
+              OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1",
+              TSX_TSCONFIG_PATH: tsconfigPath,
+              TSX_DISABLE_CACHE: "1",
+            },
+            timeout: 30_000,
+          },
+        );
+
+        const config = JSON.parse(await fs.readFile(state.configPath, "utf8"));
+        expect(config.gateway.controlUi).toMatchObject({ allowInsecureAuth: true, enabled: false });
+        const sessionsPath = path.join(state.sessionsDir(), "sessions.json");
+        await expect(fs.readFile(sessionsPath, "utf8")).resolves.toContain(
+          '"sessionId":"sess-main"',
+        );
+        await expect(
+          fs.readFile(path.join(state.sessionsDir(), "sess-main.jsonl"), "utf8"),
+        ).resolves.toContain('"id":"msg-attachment"');
+        await expect(
+          fs.stat(path.join(state.agentDir(), "openclaw-agent.sqlite")),
+        ).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      },
+    );
+  });
 });

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -701,6 +701,9 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     expect(normalCiDispatchCase).not.toContain("full_release_validation=true");
     expect(pluginPrereleaseScript).toContain('-f phase="$PHASE"');
     expect(pluginPrereleaseScript).toContain(
+      "args+=(-f allow_frozen_target_scenario_omissions=true)",
+    );
+    expect(pluginPrereleaseScript).toContain(
       'args+=(-f candidate_artifact_json="$CANDIDATE_ARTIFACT_JSON")',
     );
     expect(pluginPrereleaseScript).toContain(
@@ -730,6 +733,14 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       description: "Branch, tag, or full commit SHA to validate",
       required: false,
       type: "string",
+    });
+    expect(
+      pluginWorkflow.on.workflow_dispatch.inputs.allow_frozen_target_scenario_omissions,
+    ).toEqual({
+      default: false,
+      description: "Trusted opt-in to accept documented harness differences in a frozen target",
+      required: false,
+      type: "boolean",
     });
     expect(pluginWorkflow.on.workflow_dispatch.inputs.full_release_validation).toEqual({
       default: false,

--- a/test/scripts/plugin-uninstall-assertions.test.ts
+++ b/test/scripts/plugin-uninstall-assertions.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hasExpectedPluginUninstallConfigState } from "../../scripts/e2e/lib/plugin-uninstall-assertions.mjs";
+
+describe("plugin uninstall assertions", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("accepts an absent legacy plugin entry but rejects every present falsy residue", () => {
+    vi.stubEnv("OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS", "1");
+
+    expect(hasExpectedPluginUninstallConfigState({ plugins: { entries: {} } }, "fixture")).toBe(
+      true,
+    );
+    for (const entry of [null, false, 0, ""]) {
+      expect(
+        hasExpectedPluginUninstallConfigState(
+          { plugins: { entries: { fixture: entry } } },
+          "fixture",
+        ),
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Routes the existing, trusted frozen-target omission authorization from Full Release Validation into Plugin Prerelease, then forwards its validated identity into the affected Docker lanes.

The candidate-specific harness contracts are selected only after the existing `openclaw_frozen_target_omissions_authorized` validation: pre-SQLite MCP session seed, pre-consolidation TTS shape, no bundled-discovery allowlist, pre-marker plugin uninstall state, and the published Kitchen Sink package legacy memory diagnostic. Current-target assertions remain strict.

The reusable targeted-Docker job maps canonical selected and tooling SHAs once, at the workflow-to-scheduler boundary. Nested Docker lanes therefore receive the same validated identity rather than an incompatible `OPENCLAW_DOCKER_E2E_SELECTED_SHA`-only shape.

This update also makes MCP persisted-media assertions reflect the selected target contract: current targets require the canonical `openclaw_media` fact; only the already-authorized frozen target accepts its shipped JSONL image block. It creates no SHA/version exception and does not weaken current conformance.

This does not change the frozen candidate, tags, npm state, or product runtime. The follow-up includes the generic `plugins-docker.sh` owner after the exact frozen proof identified it as the remaining forwarding boundary.

## Evidence

- Initial failure: https://github.com/openclaw/openclaw/actions/runs/33692985954
- Prior exact proof: https://github.com/openclaw/openclaw/actions/runs/33707031520
- MCP residual proof: https://github.com/openclaw/openclaw/actions/runs/33707894263 job `100502023247`.
- Candidate: `659df8107ce37c07a4cd4364c76ece55a7124e22`.
- Frozen `src/mcp/channel-shared.ts` returns the persisted non-text JSONL image block. Current canonical projection was introduced by `10e707435ae`; the exact-frozen run correctly exposed their different representations.
- The completed npm-onboard failures are the separate pre-v13 auth assertion owned by #136828. The plugins-offline and bundled-plugin disabled-marker failures are the separate #136761 forwarding repair.
- Kitchen Sink config size-drop rejection is a separate candidate product omission, covered by release PR #136903; this harness PR does not hide it.

## Verification

- New contract regression: `OPENCLAW_FS_SAFE_NATIVE_MODE=off node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts test/scripts/mcp-channels-attachment-contract.test.ts` (1 passed).
- Changed files: `node scripts/check-changed.mjs -- scripts/e2e/lib/mcp-channels-attachment-contract.mjs test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts test/scripts/mcp-channels-attachment-contract.test.ts` (passed all local gates).
- `pnpm lint:docker-e2e`, changed-file format/oxlint/type graph, `git diff --check`, and `autoreview --mode branch --base origin/main` passed.
- The source-only MCP seed E2E is rebuilding in this isolated worktree; replacement exact-frozen Docker proof is dispatched after this head update.

## Scope

Whole PR: production/harness +420 / -67; the MCP increment is test/harness support +13 / -9 plus a 27-line regression test. The harness is deliberately larger because it centralizes target identity at the workflow owner, then preserves current strict behavior along each versioned scenario.

## Follow-up: exact source-profile gate

Commit `7d981b8e1ae` addresses the current ClawSweeper P1/P2 without a SHA or version exception. The shared resolver defaults every target to current assertions, validates the checked-out source matches the selected SHA, then enables the plugin Docker legacy fixture only when all four source-derived pre-SQLite traits are present: legacy `messages.tts`, `bundledDiscovery` union, legacy session-store implementation, and no `uninstall-package-plan` module. All four plugin Docker outer owners apply that profile before forwarding the omission flag. A source with any missing trait remains strict.

The legacy uninstall assertion now requires that the plugin entry key is absent, rather than merely falsy; `null`, `false`, `0`, and empty-string residues are rejected.

Verification: `node scripts/run-vitest.mjs test/scripts/live-docker-stage.test.ts test/scripts/plugin-uninstall-assertions.test.ts --reporter=dot` (21 passed); `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts --reporter=dot`; `node --import ./scripts/tsx.mjs scripts/check-docker-e2e-boundaries.mts`; `node --import ./scripts/tsx.mjs scripts/check-no-raw-http2-imports.mts`; `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts`; `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.root.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-root.tsbuildinfo`; formatting, `bash -n`, `actionlint`, and `git diff --check` passed. `autoreview --mode commit --commit 7d981b8e1ae --max-priority P1` found no actionable P0/P1 issue. `scripts/check-changed.mjs` remains blocked before its checks by this machine's malformed pnpm wrapper; the relevant underlying checks above were run directly.

Follow-up delta: harness production +48/-21 (the four wrapper substitutions are net-neutral); tests +110/-3. The source-profile regression fails before this commit because the resolver does not exist, and the uninstall test fails before it because falsy entries pass.

## Follow-up: generic plugins Docker owner

Exact frozen proof [`33716433968`](https://github.com/openclaw/openclaw/actions/runs/33716433968) exposed one final forwarding boundary on this PR: the generic `scripts/e2e/plugins-docker.sh` lane did not resolve/forward the already-authorized source profile, unlike the other plugin Docker owners. Commit `eddc3885301` gives that owner the same checked-source capability resolution and only forwards the three identity inputs for the legacy profile. The static owner-coverage test now includes this wrapper, and fails without the forwarding.

The same valid run also separates candidate defects from harness behavior: Kitchen Sink’s intentional uninstall write is rejected by the frozen candidate size-drop guard ([#136903](https://github.com/openclaw/openclaw/pull/136903)); owner-gated Claude permission replies are absent from the candidate ([#136924](https://github.com/openclaw/openclaw/pull/136924)); and the pre-v13 auth-store assertion belongs to [#136828](https://github.com/openclaw/openclaw/pull/136828). These assertions are not weakened here.

Verification: `bash -n scripts/e2e/plugins-docker.sh`; `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts --reporter=dot`; `node scripts/check-docker-e2e-boundaries.mts`; targeted script lint; `git diff --check`; and `autoreview --mode commit --commit eddc3885301 --max-priority P1` (scoped-clean).

## Replacement exact-frozen proof

Replacement proof [`33718180176`](https://github.com/openclaw/openclaw/actions/runs/33718180176) ran `eddc3885301` against selected candidate `659df8107ce37c07a4cd4364c76ece55a7124e22`, release context `extended-stable/2026.6.33`, with the authorized frozen omission flag enabled. It confirms the generic plugins wrapper now passes its former legacy disabled-marker boundary: execution progresses through the tgz/local/npm install flows. The remaining suite failures are candidate product behavior, not a profile-forwarding failure: managed npm project cleanup (upstream `d6e6d67adc6`, pending release backport), Kitchen Sink intentional uninstall size-drop ([#136903](https://github.com/openclaw/openclaw/pull/136903)), owner-gated MCP permission reply ([#136924](https://github.com/openclaw/openclaw/pull/136924)), and pre-v13 auth-store assertion ([#136828](https://github.com/openclaw/openclaw/pull/136828)).