### PR TITLE
fix(sessions): avoid history scans for native prompt annotation

### DIFF
--- a/src/agents/harness/host-capability.annotation.test.ts
+++ b/src/agents/harness/host-capability.annotation.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { convertMessages } from "../../../packages/ai/src/openai-completions-messages.js";
 import { resolveOpenAICompletionsCompat } from "../../../packages/ai/src/transports/openai-completions-compat.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
 import {
   appendTranscriptMessage,
   listSessionPendingInputReceipts,
@@ -37,7 +38,10 @@ import type {
   CreateUserTurnTranscriptRecorderParams,
   UserTurnTranscriptAnnotation,
 } from "../../sessions/user-turn-transcript.types.js";
-import { runOpenClawAgentWriteTransaction } from "../../state/openclaw-agent-db.js";
+import {
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { normalizeMessagesForLlmBoundary } from "../embedded-agent-runner/run/attempt-llm-boundary.js";
 import { convertToLlm } from "../sessions/messages.js";
@@ -362,7 +366,26 @@ describe("host-owned current admission annotation", () => {
       const updates = vi.fn();
       const unsubscribe = onInternalSessionTranscriptUpdate(updates);
       try {
-        await f.annotate();
+        const { db } = openOpenClawAgentDatabase({ agentId: "main" });
+        const searchRows = () =>
+          db
+            .prepare("SELECT * FROM session_transcript_fts WHERE session_id = ?")
+            .all(f.target.sessionId);
+        const searchBefore = searchRows();
+        const projectionWork = trackSqliteStatementExecutions(db, ["fts", "size"], (sql) =>
+          sql.includes("session_transcript_fts")
+            ? "fts"
+            : sql.includes("octet_length")
+              ? "size"
+              : null,
+        );
+        try {
+          await f.annotate();
+        } finally {
+          projectionWork.restore();
+        }
+        expect(projectionWork.counts).toEqual({ fts: 0, size: 0 });
+        expect(searchRows()).toEqual(searchBefore);
         const refreshed = f.receipt();
         expect(refreshed).toEqual({ ...original, generation: expect.any(String) });
         expect(refreshed.generation).not.toBe(original.generation);

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.test.ts
@@ -1,4 +1,6 @@
+import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
+import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -6,7 +8,31 @@ import {
   runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { appendTranscriptEventInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { readSessionTranscriptActiveStats } from "./session-accessor.sqlite-active-events.js";
+import {
+  readTranscriptGenerationInTransaction,
+  readTranscriptMutationStateInTransaction,
+} from "./session-accessor.sqlite-transcript-state.js";
+import {
+  appendTranscriptEventInTransaction,
+  appendTranscriptEventsInTransaction,
+  rewriteSqliteTranscriptEventRowsInTransaction,
+  updateSqliteTranscriptEventJsonInTransaction,
+} from "./session-accessor.sqlite-transcript-store.js";
+import {
+  SYNC_REBUILD_MAX_BYTES,
+  sessionTranscriptIndexNeedsReconcile,
+} from "./session-transcript-index.js";
+import { SessionTranscriptProjectionUnavailableError } from "./session-transcript-projection-error.js";
+import {
+  prepareSessionTranscriptProjection,
+  claimPreparedSessionTranscriptProjectionInTransaction,
+  finalizePreparedSessionTranscriptProjectionInTransaction,
+  appendPreparedSessionTranscriptProjectionChunkInTransaction,
+} from "./session-transcript-projection-rebuild.js";
+import { waitForSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
+import { searchSessionTranscripts } from "./session-transcript-search.js";
 
 const tempDirs: string[] = [];
 
@@ -58,6 +84,313 @@ describe("SQLite transcript append", () => {
     expect(message).not.toHaveProperty("MediaTypes");
     expect(message["__openclaw"]).toMatchObject({
       media: [expect.objectContaining({ path: "/media/a.png", contentType: "image/png" })],
+    });
+  });
+});
+
+const rewriteEvents = [
+  { type: "custom", id: "root", parentId: null },
+  { type: "message", id: "user", parentId: "root", message: { role: "user", content: "question" } },
+  {
+    type: "message",
+    id: "answer",
+    parentId: "user",
+    message: { role: "assistant", content: "answer" },
+  },
+] as const;
+
+async function withRewriteFixture(
+  run: (f: {
+    db: DatabaseSync;
+    snapshot: () => {
+      raw: Array<Record<string, unknown>>;
+      identities: unknown[];
+      active: unknown[];
+      search: unknown[];
+      generation: string | undefined;
+      updatedAt: number | null;
+    };
+    rewrite: (event: unknown, seq?: number) => void;
+    scope: { agentId: string; sessionId: string; sessionKey: string; env: NodeJS.ProcessEnv };
+  }) => void | Promise<void>,
+) {
+  await withOpenClawTestState({ label: "exact-rewrite" }, async (state) => {
+    const scope = {
+      agentId: "main",
+      sessionId: "rewrite",
+      sessionKey: "agent:main:rewrite",
+      env: state.env,
+    };
+    const owner = openOpenClawAgentDatabase(scope);
+    const { db } = owner;
+    runOpenClawAgentWriteTransaction((database) => {
+      appendTranscriptEventsInTransaction(database, scope, rewriteEvents);
+    }, scope);
+    const snapshot = () => ({
+      raw: db
+        .prepare("SELECT * FROM transcript_events WHERE session_id = ? ORDER BY seq")
+        .all(scope.sessionId),
+      identities: db
+        .prepare("SELECT * FROM transcript_event_identities WHERE session_id = ? ORDER BY seq")
+        .all(scope.sessionId),
+      active: db
+        .prepare(
+          "SELECT * FROM session_transcript_active_events WHERE session_id = ? ORDER BY active_position",
+        )
+        .all(scope.sessionId),
+      search: db
+        .prepare("SELECT * FROM session_transcript_fts WHERE session_id = ? ORDER BY message_id")
+        .all(scope.sessionId),
+      generation: readTranscriptGenerationInTransaction(owner, scope.sessionId),
+      updatedAt: readTranscriptMutationStateInTransaction(owner, scope.sessionId).updatedAt,
+    });
+    const rewrite = (event: unknown, seq = 1) => {
+      const row = db
+        .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = ?")
+        .get(scope.sessionId, seq);
+      if (typeof row?.event_json !== "string") {
+        throw new Error("missing rewrite row");
+      }
+      const expectedEventJson = row.event_json;
+      runOpenClawAgentWriteTransaction((database) => {
+        rewriteSqliteTranscriptEventRowsInTransaction(database, scope, [
+          { seq, event, expectedEventJson },
+        ]);
+      }, scope);
+    };
+    await run({ db, snapshot, rewrite, scope });
+  });
+}
+
+describe("SQLite exact transcript rewrite", () => {
+  it("preserves healthy derived rows without FTS access or size scans while raw mutation advances", async () => {
+    await withRewriteFixture(({ db, snapshot, rewrite, scope }) => {
+      const before = snapshot();
+      const work = trackSqliteStatementExecutions(db, ["fts", "size"], (sql) =>
+        sql.includes("session_transcript_fts")
+          ? "fts"
+          : sql.includes("octet_length")
+            ? "size"
+            : null,
+      );
+      try {
+        rewrite({
+          ...rewriteEvents[1],
+          message: { ...rewriteEvents[1].message, provenance: "new" },
+        });
+      } finally {
+        work.restore();
+      }
+      const after = snapshot();
+      expect(after.generation).not.toBe(before.generation);
+      expect(after.updatedAt).toBeGreaterThan(before.updatedAt!);
+      expect(after.active).toEqual(before.active);
+      expect(after.search).toEqual(before.search);
+      expect(after.raw[0]).toEqual(before.raw[0]);
+      expect(after.raw[2]).toEqual(before.raw[2]);
+      expect(after.raw[1]).toEqual({ ...before.raw[1], event_json: expect.any(String) });
+      expect(after.raw[1]?.event_json).not.toBe(before.raw[1]?.event_json);
+      expect(after.identities).toEqual(before.identities);
+      expect(sessionTranscriptIndexNeedsReconcile(db, scope.sessionId)).toBe(false);
+      expect(work.counts).toEqual({ fts: 0, size: 0 });
+    });
+  });
+
+  it("keeps oversized metadata current but hides changed text until the real worker reconciles", async () => {
+    await withRewriteFixture(async ({ db, rewrite, scope }) => {
+      const message = {
+        ...rewriteEvents[1].message,
+        provenance: "x".repeat(SYNC_REBUILD_MAX_BYTES + 1),
+      };
+      rewrite({ ...rewriteEvents[1], message });
+      expect(sessionTranscriptIndexNeedsReconcile(db, scope.sessionId)).toBe(false);
+      const before = prepareSessionTranscriptProjection(db, scope.sessionId)!;
+      const work = trackSqliteStatementExecutions(db, ["fts"], (sql) =>
+        sql.includes("session_transcript_fts") ? "fts" : null,
+      );
+      try {
+        rewrite({ ...rewriteEvents[1], message: { ...message, content: "changed" } });
+        expect(work.counts.fts).toBe(0);
+      } finally {
+        work.restore();
+      }
+      expect(sessionTranscriptIndexNeedsReconcile(db, scope.sessionId)).toBe(true);
+      expect(() => readSessionTranscriptActiveStats(scope)).toThrow(
+        SessionTranscriptProjectionUnavailableError,
+      );
+      expect(searchSessionTranscripts({ ...scope, query: "question" }).hits).toEqual([]);
+      expect(claimPreparedSessionTranscriptProjectionInTransaction(db, before, -1)).toBe(false);
+      await waitForSessionTranscriptIndexReconcile(scope);
+      expect(sessionTranscriptIndexNeedsReconcile(db, scope.sessionId)).toBe(false);
+      expect(searchSessionTranscripts({ ...scope, query: "changed" }).hits).toMatchObject([
+        { messageId: "user" },
+      ]);
+      expect(readSessionTranscriptActiveStats(scope).eventCount).toBe(3);
+    });
+  });
+
+  it("rolls back all exact writes and mutation state when a later expected row conflicts", async () => {
+    await withRewriteFixture(({ snapshot, scope }) => {
+      const before = snapshot();
+      expect(() =>
+        runOpenClawAgentWriteTransaction((database) => {
+          rewriteSqliteTranscriptEventRowsInTransaction(database, scope, [
+            {
+              seq: 1,
+              expectedEventJson: JSON.stringify(rewriteEvents[1]),
+              event: { ...rewriteEvents[1], message: { role: "user", content: "edited" } },
+            },
+            { seq: 2, expectedEventJson: "stale", event: rewriteEvents[2] },
+          ]);
+        }, scope),
+      ).toThrow("changed before exact rewrite");
+      expect(snapshot()).toEqual(before);
+    });
+  });
+
+  it.each(["dirty", "missing", "lagging", "unclassified", "claimed"] as const)(
+    "recovers %s projections on metadata rewrite and fences stale publication",
+    async (kind) => {
+      await withRewriteFixture(({ db, rewrite, snapshot, scope }) => {
+        const before = snapshot();
+        const plan = prepareSessionTranscriptProjection(db, scope.sessionId)!;
+        if (kind === "missing") {
+          db.prepare("DELETE FROM session_transcript_index_state").run();
+        } else if (kind === "unclassified") {
+          db.prepare("UPDATE session_transcript_active_events SET context_eligible = NULL").run();
+        } else if (kind === "lagging") {
+          db.prepare("UPDATE session_transcript_index_state SET indexed_seq = -1").run();
+        } else {
+          db.prepare("UPDATE session_transcript_index_state SET needs_rebuild = 1").run();
+        }
+        if (kind === "claimed") {
+          expect(claimPreparedSessionTranscriptProjectionInTransaction(db, plan, -1)).toBe(true);
+          db.prepare("DELETE FROM session_transcript_active_events").run();
+          db.prepare("DELETE FROM session_transcript_fts").run();
+        }
+        expect(sessionTranscriptIndexNeedsReconcile(db, scope.sessionId)).toBe(true);
+        rewrite({
+          ...rewriteEvents[1],
+          message: { ...rewriteEvents[1].message, provenance: "new" },
+        });
+        expect(sessionTranscriptIndexNeedsReconcile(db, scope.sessionId)).toBe(false);
+        expect(snapshot().active).toEqual(before.active);
+        expect(snapshot().search).toEqual(before.search);
+        expect(claimPreparedSessionTranscriptProjectionInTransaction(db, plan, -2)).toBe(false);
+        expect(
+          appendPreparedSessionTranscriptProjectionChunkInTransaction(db, {
+            sessionId: scope.sessionId,
+            claimId: -1,
+            ftsRows: plan.ftsRows,
+          }),
+        ).toBe(false);
+        expect(finalizePreparedSessionTranscriptProjectionInTransaction(db, plan, -1)).toBe(false);
+      });
+    },
+  );
+
+  it.each([
+    {
+      name: "content",
+      seq: 1,
+      event: { ...rewriteEvents[1], message: { role: "user", content: "changed" } },
+      texts: ["answer", "changed"],
+      messages: 2,
+    },
+    {
+      name: "role",
+      seq: 1,
+      event: { ...rewriteEvents[1], message: { role: "toolResult", content: "question" } },
+      texts: ["answer"],
+      messages: 2,
+    },
+    {
+      name: "timestamp",
+      seq: 1,
+      event: { ...rewriteEvents[1], timestamp: 99 },
+      texts: ["answer", "question"],
+      messages: 2,
+    },
+    {
+      name: "message presence",
+      seq: 1,
+      event: { type: "message", id: "user", parentId: "root" },
+      texts: ["answer"],
+      messages: 1,
+    },
+    {
+      name: "parent",
+      seq: 2,
+      event: { ...rewriteEvents[2], parentId: "root" },
+      texts: ["answer"],
+      messages: 1,
+    },
+    {
+      name: "leaf control",
+      seq: 2,
+      event: { type: "leaf", id: "answer", parentId: "user", targetId: "user" },
+      texts: ["question"],
+      messages: 1,
+    },
+  ])(
+    "rebuilds changed $name facts without duplicate FTS invalidation",
+    async ({ event, seq, texts, messages, name }) => {
+      await withRewriteFixture(({ db, rewrite, scope }) => {
+        const work = trackSqliteStatementExecutions(db, ["deletes"], (sql) =>
+          /^delete from ["`]?session_transcript_fts["`]? /i.test(sql) ? "deletes" : null,
+        );
+        try {
+          rewrite(event, seq);
+        } finally {
+          work.restore();
+        }
+        const search = db
+          .prepare("SELECT text, timestamp FROM session_transcript_fts ORDER BY message_id")
+          .all();
+        expect(search.map((row) => row.text)).toEqual(texts);
+        if (name === "timestamp") {
+          expect(search[1]?.timestamp).toBe(99);
+        }
+        expect(
+          db
+            .prepare(
+              "SELECT active_message_count FROM session_transcript_index_state WHERE session_id = ?",
+            )
+            .get(scope.sessionId)?.active_message_count,
+        ).toBe(messages);
+        expect(work.counts.deletes).toBeLessThanOrEqual(1);
+      });
+    },
+  );
+
+  it("avoids duplicate FTS invalidation for maintenance text repair and preserves recency", async () => {
+    await withRewriteFixture(({ db, scope, snapshot }) => {
+      const before = snapshot();
+      const work = trackSqliteStatementExecutions(db, ["deletes"], (sql) =>
+        /^delete from ["`]?session_transcript_fts["`]? /i.test(sql) ? "deletes" : null,
+      );
+      try {
+        runOpenClawAgentWriteTransaction(
+          (database) =>
+            updateSqliteTranscriptEventJsonInTransaction(database, scope.sessionId, [
+              {
+                seq: 1,
+                eventJson: JSON.stringify({
+                  ...rewriteEvents[1],
+                  message: { role: "user", content: "repaired" },
+                }),
+              },
+            ]),
+          scope,
+        );
+      } finally {
+        work.restore();
+      }
+      expect(snapshot().updatedAt).toBe(before.updatedAt! + 1);
+      expect(
+        db.prepare("SELECT text FROM session_transcript_fts WHERE message_id = 'user'").get()?.text,
+      ).toBe("repaired");
+      expect(work.counts.deletes).toBeLessThanOrEqual(1);
     });
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import { getCodeModeSourceAppend } from "../../agents/transcript-code-mode-source.js";
@@ -41,8 +42,14 @@ import {
   deleteSessionTranscriptIndexInTransaction,
   markSessionTranscriptIndexDirtyInTransaction,
   reconcileSessionTranscriptIndexInTransaction,
+  sessionTranscriptIndexNeedsReconcile,
   shouldRebuildSessionTranscriptIndexSynchronously,
 } from "./session-transcript-index.js";
+import {
+  extractTranscriptIndexEntry,
+  hasTranscriptMessage,
+  transcriptEventContextEligibility,
+} from "./session-transcript-projection-rebuild.js";
 import { startSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 
@@ -437,18 +444,25 @@ export function rewriteSqliteTranscriptEventRowsInTransaction(
   if (rows.length === 0) {
     return;
   }
-  const rebuildSynchronously = shouldRebuildSessionTranscriptIndexSynchronously(
-    database.db,
-    resolved.sessionId,
-  );
+  const rewrites = rows.map((row) => ({
+    ...row,
+    eventJson: JSON.stringify(canonicalizeTranscriptEventMedia(row.event)),
+  }));
+  const projectionUnchanged =
+    !sessionTranscriptIndexNeedsReconcile(database.db, resolved.sessionId) &&
+    rewrites.every((row) =>
+      transcriptRewritePreservesProjection(row.expectedEventJson, row.eventJson),
+    );
+  const rebuildSynchronously =
+    !projectionUnchanged &&
+    shouldRebuildSessionTranscriptIndexSynchronously(database.db, resolved.sessionId);
   const db = getSessionKysely(database.db);
-  for (const row of rows) {
-    const persistedEvent = canonicalizeTranscriptEventMedia(row.event);
+  for (const row of rewrites) {
     const result = executeSqliteQuerySync(
       database.db,
       db
         .updateTable("transcript_events")
-        .set({ event_json: JSON.stringify(persistedEvent) })
+        .set({ event_json: row.eventJson })
         .where("session_id", "=", resolved.sessionId)
         .where("seq", "=", row.seq)
         .where("event_json", "=", row.expectedEventJson),
@@ -461,12 +475,40 @@ export function rewriteSqliteTranscriptEventRowsInTransaction(
   }
   rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
   touchTranscriptMutationInTransaction(database, resolved.sessionId);
+  if (!projectionUnchanged) {
+    reconcileRewrittenTranscriptIndex(database, resolved.sessionId, rebuildSynchronously);
+  }
+}
+
+function transcriptRewritePreservesProjection(beforeJson: string, afterJson: string): boolean {
+  const before: unknown = JSON.parse(beforeJson);
+  const after: unknown = JSON.parse(afterJson);
+  if (!isRecord(before) || !isRecord(after)) {
+    return false;
+  }
+  const { message: _beforeMessage, ...beforeEnvelope } = before;
+  const { message: _afterMessage, ...afterEnvelope } = after;
+  // Equal envelopes preserve tree topology and timestamp; exact rewrites retain created_at,
+  // so the index extractor's fallback timestamp is identical for both versions as well.
+  return (
+    isDeepStrictEqual(beforeEnvelope, afterEnvelope) &&
+    hasTranscriptMessage(before) === hasTranscriptMessage(after) &&
+    transcriptEventContextEligibility(before) === transcriptEventContextEligibility(after) &&
+    isDeepStrictEqual(extractTranscriptIndexEntry(before, 0), extractTranscriptIndexEntry(after, 0))
+  );
+}
+
+function reconcileRewrittenTranscriptIndex(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  rebuildSynchronously: boolean,
+): void {
+  // Dirty state revokes prepared claims and hides old rows; reconcile alone owns their deletion.
+  markSessionTranscriptIndexDirtyInTransaction(database.db, sessionId);
   if (rebuildSynchronously) {
-    deleteSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
-    reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
+    reconcileSessionTranscriptIndexInTransaction(database.db, sessionId);
   } else {
-    markSessionTranscriptIndexDirtyInTransaction(database.db, resolved.sessionId);
-    scheduleTranscriptProjectionReconcile(database, resolved.sessionId, true, {});
+    scheduleTranscriptProjectionReconcile(database, sessionId, true, {});
   }
 }
 
@@ -497,28 +539,12 @@ export function updateSqliteTranscriptEventJsonInTransaction(
     );
   }
   rotateTranscriptGenerationInTransaction(database, sessionId);
-  if (rebuildSynchronously) {
-    deleteSessionTranscriptIndexInTransaction(database.db, sessionId);
-    reconcileSessionTranscriptIndexInTransaction(database.db, sessionId);
-  } else {
-    markSessionTranscriptIndexDirtyInTransaction(database.db, sessionId);
-  }
-  // Minimally advance transcript_updated_at (prev+1), NOT to now. This is a one-time maintenance
-  // rewrite: bumping to now would reorder legacy sessions to the top of every recency view
-  // (sqlite-history.ts orders by transcript_updated_at). But the watermark must still change,
-  // because it is the in-flight projection-rebuild worker's stale-snapshot key
-  // (session-transcript-projection-rebuild.ts sourceSnapshotMatches) and seq is unchanged here;
-  // leaving it identical would let a concurrent worker apply a stale pre-rewrite index. A null
-  // watermark (session absent from recency views) has no recency to preserve, so touch to now.
-  const currentUpdatedAt = readTranscriptMutationStateInTransaction(database, sessionId).updatedAt;
-  if (currentUpdatedAt === null) {
-    touchTranscriptMutationInTransaction(database, sessionId);
-  } else {
-    advanceTranscriptMutationAtInTransaction(database, sessionId, currentUpdatedAt, {
-      strictly: true,
-    });
-  }
-  scheduleTranscriptProjectionReconcile(database, sessionId, !rebuildSynchronously, {});
+  reconcileRewrittenTranscriptIndex(database, sessionId, rebuildSynchronously);
+  recordTranscriptReplacementMutation(
+    database,
+    sessionId,
+    readTranscriptMutationStateInTransaction(database, sessionId).updatedAt,
+  );
 }
 
 function readIdempotencyKeyOwner(

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { castAgentMessage } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it } from "vitest";
+import { trackSqliteStatementExecutions } from "../../test/helpers/sqlite-statement-execution-counter.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import {
@@ -10,6 +11,7 @@ import {
   persistSessionTranscriptTurn,
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
+import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import {
   buildLateMediaAttachedProjection,
   createUserTurnTranscriptRecorder,
@@ -569,7 +571,27 @@ describe("user turn transcript persistence", () => {
       recorder.markRuntimePersisted(persisted?.message, persisted?.admission);
       const initialGeneration = recorder.getAdmissionReceipt()?.generation;
 
-      await recorder.confirmSteerTargetRunIdForPersistence?.("active-run");
+      const admission = recorder.getAdmissionReceipt();
+      if (!admission) {
+        throw new Error("missing persisted admission");
+      }
+      const { db } = openOpenClawAgentDatabase({
+        agentId: target.agentId,
+        path: admission.storePath,
+      });
+      const work = trackSqliteStatementExecutions(db, ["fts", "size"], (sql) =>
+        sql.includes("session_transcript_fts")
+          ? "fts"
+          : sql.includes("octet_length")
+            ? "size"
+            : null,
+      );
+      try {
+        await recorder.confirmSteerTargetRunIdForPersistence?.("active-run");
+      } finally {
+        work.restore();
+      }
+      expect(work.counts).toEqual({ fts: 0, size: 0 });
 
       expect(recorder.getAdmissionReceipt()?.generation).not.toBe(initialGeneration);
       expect(recorder.getPersistedMessage?.()).toMatchObject({

--- a/test/helpers/sqlite-statement-execution-counter.ts
+++ b/test/helpers/sqlite-statement-execution-counter.ts
@@ -5,7 +5,7 @@ import { clearNodeSqliteKyselyCacheForDatabase } from "../../src/infra/kysely-sy
 /**
  * Count SQLite query executions per caller-defined bucket. Prepared-statement
  * caching (src/infra/kysely-sync.ts) reuses statements across calls, so
- * counting `prepare` invocations undercounts; this wraps `iterate` on matching
+ * counting `prepare` invocations undercounts; this wraps `iterate` and `run` on matching
  * statements and clears the statement cache at attach so statements cached
  * before the spy cannot bypass it.
  */
@@ -21,6 +21,13 @@ export function trackSqliteStatementExecutions<Key extends string>(
     const statement = originalPrepare(sqlText);
     const key = classify(sqlText);
     if (key !== null) {
+      // Preserve both positional and named-binding overloads at the native call boundary.
+      statement.run = new Proxy(statement.run.bind(statement), {
+        apply(run, receiver, args) {
+          counts[key] += 1;
+          return Reflect.apply(run, receiver, args);
+        },
+      });
       const originalIterate = statement.iterate.bind(statement) as (
         ...args: unknown[]
       ) => ReturnType<StatementSync["iterate"]>;


### PR DESCRIPTION
Closes #136831 — native prompt annotation slows down with unrelated transcript history.

<details>
<summary>Additional instructions</summary>

Maintainers can push to this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users starting native Codex turns or confirming steering could incur synchronous transcript-search work proportional to unrelated sessions, even though only metadata on one admitted message changed.

The measured path repeatedly scans the shared FTS5 table for a tiny target transcript. This PR fixes that mechanism; it does not attribute or claim to resolve unrelated multi-second gateway/RPC stalls.

## Why This Change Was Made

The existing exact-row rewrite owner now retains an already-current projection only when canonical searchable text, role, timestamp, message presence, context eligibility, and the unchanged event envelope prove its derived facts are identical. Real invalidation marks the existing projection dirty and lets reconciliation own the single deletion, also consolidating the maintenance-text path.

Exact-byte CAS, raw generation/cursor invalidation, mutation/recency semantics, source custody, current admission/closure checks, worker-claim fencing, and observer publication remain unchanged. No caller bypass flag, Codex-specific metadata whitelist, alternate annotation path, schema/index DDL, migration, configuration, or public/persistent contract is added.

Production LOC: **+59/-33 (net +26)** in one existing owner module. Duplicate invalidation and maintenance bookkeeping were consolidated first; the remaining growth implements current-projection and canonical-fact equivalence checks. Tests: **+382/-4**; existing test support: **+8/-1**. No new production file/export.

## User Impact

Healthy native prompt annotation and confirmed steering metadata writes no longer traverse unrelated searchable history. Actual content, branch, role, timestamp, message-presence, or context-eligibility changes still rebuild correctly; incomplete projections still recover through their existing owner. Operators do not need a config change or migration.

## Evidence

### Calibrated isolated mechanism proof

Real recorder/host-capability annotation -> anchored writer -> actual SQLite, with a constant three-event/701-byte target. Canonical writers seed unrelated sessions containing exactly 445 UTF-8 searchable bytes per row. Two warm-ups, seven measured targets per size, no outliers discarded:

| Unrelated searchable rows | Searchable text bytes | Raw event JSON bytes | Fresh annotation before | After |
| ---: | ---: | ---: | ---: | ---: |
| 1,000 | 445,000 | 624,804 | 4.215 ms | 3.408 ms |
| 52,624 | 23,417,680 | 32,979,818 | 45.886 ms | 3.735 ms |

Every baseline fresh annotation executes **two FTS deletes, two FTS inserts, and one target-size scan**. Every fixed fresh annotation executes **zero FTS operations and zero size scans**. Exact repeats remain idempotent with no FTS work; ordinary appends retain one expected FTS insert. The original deletion query plan is `SCAN session_transcript_fts VIRTUAL TABLE INDEX 0:`; the repaired metadata path never executes it.

Apple M3 Ultra, Darwin arm64, Node v26.8.1, loaded host; per-handle instrumentation disables statement caching consistently before/after. Uniform synthetic prose and the host's scheduling/cache state are not a production latency estimate. The earlier larger-payload probe is not used as the calibrated result.

### Regression and sibling validation

- New work-bound regression demonstrably fails on original production code; healthy metadata reports four FTS operations and one size scan. Duplicate-deletion cases also fail before repair.
- **191 owner/sibling tests across 11 files passed**, including source custody, queued revocation, cursor/outbox, observer once, confirmed steering, exact-CAS rollback, dirty/missing/lagging/unclassified/claimed projections, stale worker publication, content/topology/context changes, real deferred worker rebuilds, search and Doctor recency.
- **142 final affected-surface/Codex tests across five files passed**, including 51 Codex mirror/idempotency cases beyond the earlier run:
  `node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-transcript-store.test.ts src/agents/harness/host-capability.annotation.test.ts src/sessions/user-turn-transcript.test.ts extensions/codex/src/app-server/transcript-mirror.user-idempotency.test.ts extensions/codex/src/app-server/transcript-mirror.test.ts`
- Complete changed-scope gate passed: `node scripts/check-changed.mjs -- src/agents/harness/host-capability.annotation.test.ts src/config/sessions/session-accessor.sqlite-transcript-store.test.ts src/config/sessions/session-accessor.sqlite-transcript-store.ts src/sessions/user-turn-transcript.test.ts test/helpers/sqlite-statement-execution-counter.ts`.
- Fresh independent Codex autoreview: scoped-clean, no actionable findings at its default P0 threshold. Manual owner-boundary review also completed.

Pinned Codex 0.152.1 contracts were inspected directly: [turn acceptance](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/app-server/src/request_processors/turn_processor.rs#L499-L687) and [separate started/completed events](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/app-server/src/bespoke_event_handling.rs#L163-L208). No Codex integration behavior changed.

### Live verification and landing status

[Live native-Gateway evidence, inspected screenshots/video, exact-head CI, and full proof accounting](https://github.com/openclaw/openclaw/pull/136836#issuecomment-5520332253) are complete. Two real-provider Codex turns (initial thread and same-client warm reuse) each preserved admission custody, generation/cursor invalidation, and successful direct delivery while executing zero annotation FTS operations or size scans. Transport and corpus are synthetic; production data/services were untouched. The original driver retained one incorrect cold-resume assertion failure; the separate source-verified read-only completion audit passed against the unchanged captured run. Earlier failed attempts and separate follow-ups are disclosed in the linked evidence.

[Exact-head CI run 33711052154](https://github.com/openclaw/openclaw/actions/runs/33711052154) passed on `9c83de00691725636198152f1ce7fb26d3a841f5` (142 passed / 16 skipped), with fresh focused tests and restricted Codex review. Native review validation, hosted-CI prepare, and merge gates passed. Merged as [5e12310c14e1692171e8bc001348cb8c962a7cf1](https://github.com/openclaw/openclaw/commit/5e12310c14e1692171e8bc001348cb8c962a7cf1); the linked issue is closed. Isolated services stopped, temporary credentials/runtime fixtures removed, and sanitized proof retained.

Related but separate: #134113 proposes incremental recovery of append-lagging projections after imports; this PR only avoids invalidating current projections when their facts have not changed.
