### PR TITLE
fix(twitch): show the right config path for missing tokens

### DIFF
--- a/extensions/twitch/src/twitch-client.test.ts
+++ b/extensions/twitch/src/twitch-client.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { expectDefined } from "@openclaw/normalization-core";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveTwitchToken } from "./token.js";
@@ -496,14 +497,58 @@ describe("TwitchClientManager", () => {
       expect(mockLogger.error).toHaveBeenCalledWith("Missing Twitch client ID for account testbot");
     });
 
-    it("should throw error when token is missing", async () => {
+    it("should name the default account accessToken path when token is missing", async () => {
       // Override the mock to return empty token
       resolveTwitchTokenMock.mockReturnValue({
         token: "",
         source: "none" as const,
       });
+      const cfg: OpenClawConfig = {
+        channels: {
+          twitch: { ...testAccount, accessToken: "" },
+        },
+      };
 
-      await expect(manager.getClient(testAccount)).rejects.toThrow("Missing Twitch token");
+      await expect(manager.getClient(testAccount, cfg)).rejects.toThrow("Missing Twitch token");
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Missing Twitch token for account default (set channels.twitch.accessToken or OPENCLAW_TWITCH_ACCESS_TOKEN for default)",
+      );
+    });
+
+    it("should name the multi-account default accessToken path when token is missing", async () => {
+      resolveTwitchTokenMock.mockReturnValue({
+        token: "",
+        source: "none" as const,
+      });
+      const cfg: OpenClawConfig = {
+        channels: {
+          twitch: { accounts: { default: { ...testAccount, accessToken: "" } } },
+        },
+      };
+
+      await expect(manager.getClient(testAccount, cfg)).rejects.toThrow("Missing Twitch token");
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Missing Twitch token for account default (set channels.twitch.accounts.default.accessToken or OPENCLAW_TWITCH_ACCESS_TOKEN for default)",
+      );
+    });
+
+    it("should normalize a selected account in missing-token guidance", async () => {
+      resolveTwitchTokenMock.mockReturnValue({
+        token: "",
+        source: "none" as const,
+      });
+      const cfg: OpenClawConfig = {
+        channels: {
+          twitch: { accounts: { "stream-team": { ...testAccount, accessToken: "" } } },
+        },
+      };
+
+      await expect(manager.getClient(testAccount, cfg, " Stream-Team ")).rejects.toThrow(
+        "Missing Twitch token",
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Missing Twitch token for account stream-team (set channels.twitch.accounts.stream-team.accessToken or OPENCLAW_TWITCH_ACCESS_TOKEN for default)",
+      );
     });
 
     it("should set up message handlers on client connection", async () => {

--- a/extensions/twitch/src/twitch-client.test.ts
+++ b/extensions/twitch/src/twitch-client.test.ts
@@ -497,59 +497,52 @@ describe("TwitchClientManager", () => {
       expect(mockLogger.error).toHaveBeenCalledWith("Missing Twitch client ID for account testbot");
     });
 
-    it("should name the default account accessToken path when token is missing", async () => {
-      // Override the mock to return empty token
-      resolveTwitchTokenMock.mockReturnValue({
-        token: "",
-        source: "none" as const,
-      });
-      const cfg: OpenClawConfig = {
-        channels: {
-          twitch: { ...testAccount, accessToken: "" },
+    it.each([
+      {
+        name: "simplified default account",
+        cfg: { channels: { twitch: { ...testAccount, accessToken: "" } } },
+        accountId: undefined,
+        expected:
+          "Missing Twitch token for account default (set channels.twitch.accessToken or OPENCLAW_TWITCH_ACCESS_TOKEN for default)",
+      },
+      {
+        name: "multi-account default",
+        cfg: {
+          channels: {
+            twitch: { accounts: { default: { ...testAccount, accessToken: "" } } },
+          },
         },
-      };
-
-      await expect(manager.getClient(testAccount, cfg)).rejects.toThrow("Missing Twitch token");
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        "Missing Twitch token for account default (set channels.twitch.accessToken or OPENCLAW_TWITCH_ACCESS_TOKEN for default)",
-      );
-    });
-
-    it("should name the multi-account default accessToken path when token is missing", async () => {
-      resolveTwitchTokenMock.mockReturnValue({
-        token: "",
-        source: "none" as const,
-      });
-      const cfg: OpenClawConfig = {
-        channels: {
-          twitch: { accounts: { default: { ...testAccount, accessToken: "" } } },
+        accountId: "default",
+        expected:
+          "Missing Twitch token for account default (set channels.twitch.accounts.default.accessToken or OPENCLAW_TWITCH_ACCESS_TOKEN for default)",
+      },
+      {
+        name: "named account",
+        cfg: {
+          channels: {
+            twitch: { accounts: { "stream-team": { ...testAccount, accessToken: "" } } },
+          },
         },
-      };
+        accountId: "stream-team",
+        expected:
+          "Missing Twitch token for account stream-team (set channels.twitch.accounts.stream-team.accessToken or OPENCLAW_TWITCH_ACCESS_TOKEN for default)",
+      },
+    ] satisfies Array<{
+      name: string;
+      cfg: OpenClawConfig;
+      accountId: string | undefined;
+      expected: string;
+    }>)(
+      "throws actionable missing-token guidance for $name",
+      async ({ cfg, accountId, expected }) => {
+        resolveTwitchTokenMock.mockReturnValue({
+          token: "",
+          source: "none" as const,
+        });
 
-      await expect(manager.getClient(testAccount, cfg)).rejects.toThrow("Missing Twitch token");
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        "Missing Twitch token for account default (set channels.twitch.accounts.default.accessToken or OPENCLAW_TWITCH_ACCESS_TOKEN for default)",
-      );
-    });
-
-    it("should normalize a selected account in missing-token guidance", async () => {
-      resolveTwitchTokenMock.mockReturnValue({
-        token: "",
-        source: "none" as const,
-      });
-      const cfg: OpenClawConfig = {
-        channels: {
-          twitch: { accounts: { "stream-team": { ...testAccount, accessToken: "" } } },
-        },
-      };
-
-      await expect(manager.getClient(testAccount, cfg, " Stream-Team ")).rejects.toThrow(
-        "Missing Twitch token",
-      );
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        "Missing Twitch token for account stream-team (set channels.twitch.accounts.stream-team.accessToken or OPENCLAW_TWITCH_ACCESS_TOKEN for default)",
-      );
-    });
+        await expect(manager.getClient(testAccount, cfg, accountId)).rejects.toThrow(expected);
+      },
+    );
 
     it("should set up message handlers on client connection", async () => {
       await manager.getClient(testAccount);

--- a/extensions/twitch/src/twitch-client.ts
+++ b/extensions/twitch/src/twitch-client.ts
@@ -1,6 +1,7 @@
 // Twitch plugin module implements twitch client behavior.
 import { RefreshingAuthProvider, StaticAuthProvider } from "@twurple/auth";
 import { ChatClient, LogLevel } from "@twurple/chat";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-resolution";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { channelReadyPatch } from "openclaw/plugin-sdk/gateway-runtime";
@@ -154,8 +155,13 @@ export class TwitchClientManager {
     });
 
     if (!tokenResolution.token) {
+      const resolvedAccountId = normalizeAccountId(accountId);
+      const tokenConfigPath =
+        resolvedAccountId === DEFAULT_ACCOUNT_ID && !cfg?.channels?.twitch?.accounts
+          ? "channels.twitch.accessToken"
+          : `channels.twitch.accounts.${resolvedAccountId}.accessToken`;
       this.logger.error(
-        `Missing Twitch token for account ${account.username} (set channels.twitch.accounts.${account.username}.token or OPENCLAW_TWITCH_ACCESS_TOKEN for default)`,
+        `Missing Twitch token for account ${resolvedAccountId} (set ${tokenConfigPath} or OPENCLAW_TWITCH_ACCESS_TOKEN for default)`,
       );
       throw new Error("Missing Twitch token");
     }

--- a/extensions/twitch/src/twitch-client.ts
+++ b/extensions/twitch/src/twitch-client.ts
@@ -1,7 +1,7 @@
 // Twitch plugin module implements twitch client behavior.
 import { RefreshingAuthProvider, StaticAuthProvider } from "@twurple/auth";
 import { ChatClient, LogLevel } from "@twurple/chat";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-resolution";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-resolution";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { channelReadyPatch } from "openclaw/plugin-sdk/gateway-runtime";
@@ -155,15 +155,13 @@ export class TwitchClientManager {
     });
 
     if (!tokenResolution.token) {
-      const resolvedAccountId = normalizeAccountId(accountId);
-      const tokenConfigPath =
-        resolvedAccountId === DEFAULT_ACCOUNT_ID && !cfg?.channels?.twitch?.accounts
-          ? "channels.twitch.accessToken"
-          : `channels.twitch.accounts.${resolvedAccountId}.accessToken`;
-      this.logger.error(
+      const resolvedAccountId = accountId ?? DEFAULT_ACCOUNT_ID;
+      const tokenConfigPath = cfg?.channels?.twitch?.accounts
+        ? `channels.twitch.accounts.${resolvedAccountId}.accessToken`
+        : "channels.twitch.accessToken";
+      throw new Error(
         `Missing Twitch token for account ${resolvedAccountId} (set ${tokenConfigPath} or OPENCLAW_TWITCH_ACCESS_TOKEN for default)`,
       );
-      throw new Error("Missing Twitch token");
     }
 
     this.logger.debug?.(`Using ${tokenResolution.source} token source for ${account.username}`);


### PR DESCRIPTION
## What Problem This Solves

Twitch connection startup reported a path built from the Twitch username and the nonexistent `token` key when credentials were missing. The monitor then exposed only a generic error without the repair action.

## Why This Change Was Made

The missing-token owner now uses the prepared account ID and the active supported config shape. It throws one actionable error so existing monitor and send boundaries retain the repair guidance.

## User Impact

Operators now see the actual supported setting:

- `channels.twitch.accessToken` for simplified default config.
- `channels.twitch.accounts.default.accessToken` for multi-account default config.
- `channels.twitch.accounts.<accountId>.accessToken` for named accounts.

## Evidence

- Current main `507e5faf28500d12b8b43c8d0ad7996190e27d5d` emitted `channels.twitch.accounts.DisplayUser.token` for all three no-token startup cases and exposed only `Failed to connect: Missing Twitch token` through the Twitch monitor.
- Exact head `d6c2d24d251618b17d7289142deb14a534ec83c1` exposes the correct actionable path through the monitor for all three cases before any Twitch client or network call.
- The regression assertions failed on current main for the intended mismatch.
- Four focused Twitch suites pass: 86 tests.
- Focused formatting, lint, line-count, assertion-safety, conflict-marker, and diff checks pass.
- Exact-head Blacksmith CI and exact-head review are required before merge.

Production +7/-3 (net +4); tests +47/-9 (net +38). The four production lines distinguish the two shipped configuration shapes while replacing duplicate logging with one propagated error.

Related: #135421
