### PR TITLE
perf(agents): remove lexical ranking staging arrays

### DIFF
--- a/src/agents/tool-search-ranking.test.ts
+++ b/src/agents/tool-search-ranking.test.ts
@@ -142,6 +142,22 @@ describe("tokenizeQuery", () => {
 });
 
 describe("scoreLexical", () => {
+  it("includes empty documents in length normalization without creating search hits", () => {
+    const value = { id: "match" };
+    const index = buildLexicalIndex([
+      { value, terms: ["needle", "needle"] },
+      { value: { id: "empty" }, terms: [] },
+    ]);
+
+    expect(index.documentCount).toBe(2);
+    expect(index.averageLength).toBe(1);
+    const hits = scoreLexical(index, [{ term: "needle", weight: 1 }]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.value).toBe(value);
+    expect(hits[0]?.matchedLiteral).toBe(true);
+    expect(hits[0]?.score).toBeCloseTo((Math.log(2) * 2 * 2.2) / (2 + 1.2 * 1.75));
+  });
+
   it("returns nothing for a query with no usable terms", () => {
     const index = buildLexicalIndex([{ value: "a", terms: tokenizeDocument("search the web") }]);
 

--- a/src/agents/tool-search-ranking.ts
+++ b/src/agents/tool-search-ranking.ts
@@ -281,8 +281,7 @@ function stemVariants(word: string): string[] {
 export function tokenizeDocument(input: string): string[] {
   return splitWords(input)
     .filter((word) => !STOPWORDS.has(word))
-    .flatMap(stemVariants)
-    .filter(Boolean);
+    .flatMap(stemVariants);
 }
 
 /**
@@ -299,10 +298,10 @@ function normalizeTrigger(word: string): string {
 }
 
 const NORMALIZED_EXPANSIONS: ReadonlyArray<{
-  triggers: ReadonlySet<string>;
+  triggers: readonly string[];
   add: readonly string[];
 }> = QUERY_EXPANSIONS.map((group) => ({
-  triggers: new Set(group.terms.map(normalizeTrigger)),
+  triggers: group.terms.map(normalizeTrigger),
   add: group.add.map(stem),
 }));
 
@@ -319,12 +318,12 @@ type WeightedTerm = { term: string; weight: number };
 export function tokenizeQuery(input: string): WeightedTerm[] {
   const words = splitWords(input).filter((word) => !STOPWORDS.has(word));
   const weights = new Map<string, number>();
-  for (const term of words.flatMap(stemVariants).filter(Boolean)) {
+  for (const term of words.flatMap(stemVariants)) {
     weights.set(term, 1);
   }
   const triggers = new Set(words.map(normalizeTrigger));
   for (const group of NORMALIZED_EXPANSIONS) {
-    if (![...group.triggers].some((trigger) => triggers.has(trigger))) {
+    if (!group.triggers.some((trigger) => triggers.has(trigger))) {
       continue;
     }
     for (const addition of group.add) {
@@ -347,7 +346,9 @@ type LexicalIndex<T> = {
 
 export function buildLexicalIndex<T>(documents: ReadonlyArray<RankedDocument<T>>): LexicalIndex<T> {
   const postings = new Map<string, Map<IndexedDocument<T>, number>>();
-  const prepared = documents.map((document, position) => {
+  const documentCount = documents.length;
+  let totalLength = 0;
+  documents.forEach((document, position) => {
     const indexed = { value: document.value, length: document.terms.length, position };
     for (const term of document.terms) {
       let matches = postings.get(term);
@@ -357,13 +358,12 @@ export function buildLexicalIndex<T>(documents: ReadonlyArray<RankedDocument<T>>
       }
       matches.set(indexed, (matches.get(indexed) ?? 0) + 1);
     }
-    return indexed;
+    totalLength += indexed.length;
   });
-  const totalLength = prepared.reduce((sum, document) => sum + document.length, 0);
   return {
     postings,
-    documentCount: prepared.length,
-    averageLength: prepared.length > 0 ? totalLength / prepared.length : 0,
+    documentCount,
+    averageLength: documentCount > 0 ? totalLength / documentCount : 0,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Tool Search creates a temporary document vector only to sum its lengths, and copies ten prepared trigger sets back into arrays on every query. Neither allocation contributes to ranking.

## Why This Change Was Made

Accumulate document lengths while building the existing postings, preserving the original captured document count and sparse-array behavior. Keep private expansion triggers in their consumed array form and remove two redundant empty-term filters. Ranking weights, scores, catalog lifetime, schema boundaries and result ordering remain unchanged.

Production LOC: +11/-11 (net 0). Tests: +16. This is a maintainer-requested performance cleanup.

## User Impact

Tool Search avoids temporary arrays and a second index-length scan while returning the same results.

## Evidence

- 256 existing ranking, runtime and control tests passed. The added preservation case covers empty documents in length normalization.
- The complete changed-file gate passed; independent Codex review through P2 was scoped clean.
- Actual-source before/after checks matched token arrays, weights, postings, scores and complete Runtime.search results, including sparse slots, array growth during iteration, Unicode, catalog replacement and allowed-ID restrictions.
- Disclosed operation instrumentation confirms removal of the 5,000-slot staging vector and its reduction in the index case, plus ten Set-to-array iterations per query. These are logical allocation counts, not retained-memory measurements.
- A fixed eight-process, four-pair timing series found cold Runtime.search faster in all four pairs (median paired change -0.103 ms per call, -3.99%). Other lanes were mixed: index construction +2.07%, query tokenization -6.71%, warm search +2.46%. This does not establish a general speedup.
- Whole-process post-GC RSS changed by median paired +1.711 MiB, with a -30.578 to +14.859 MiB range. No RSS or retained-heap reduction is claimed. These synthetic-catalog runs exercise the real owner and caller, not a Gateway/provider workload.
