### PR TITLE
fix(e2e): allow recovery upgrade tests from the current stable release

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/recovery-cleanup.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/recovery-cleanup.mjs
@@ -519,11 +519,14 @@ async function packageEvidence() {
   assert(version, "package evidence requires the installed baseline version");
   // Resolve mutable tags once at installation; evidence must describe those same bytes.
   const exactBaseline = `openclaw@${version}`;
-  const metadata = await command(
-    "baseline-package",
-    ["view", exactBaseline, "version", "dist", "--json"],
-    { binary: "npm" },
+  const entries = resolveNpmJsonEntries(
+    await command("baseline-package", ["view", exactBaseline, "version", "dist", "--json"], {
+      binary: "npm",
+    }),
   );
+  assert.equal(entries.length, 1);
+  const metadata = entries[0];
+  assert(metadata && typeof metadata === "object");
   assert.equal(metadata.version, version);
   assert(typeof metadata.dist.integrity === "string" && metadata.dist.integrity.length > 0);
   // npm pack computes integrity from the fetched tarball even with --dry-run.

--- a/scripts/e2e/lib/upgrade-survivor/recovery-cleanup.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/recovery-cleanup.mjs
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
+import { resolveNpmJsonEntries } from "../../../lib/npm-json-output.mts";
 import {
   assertRecoveryApplied,
   assertRecoveryHistory,
@@ -514,18 +515,38 @@ async function customRestore() {
 async function packageEvidence() {
   const [baseline, candidate] = process.argv.slice(3);
   assert(baseline && candidate, "package evidence requires baseline and candidate");
+  const version = process.env.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_VERSION;
+  assert(version, "package evidence requires the installed baseline version");
+  // Resolve mutable tags once at installation; evidence must describe those same bytes.
+  const exactBaseline = `openclaw@${version}`;
   const metadata = await command(
     "baseline-package",
-    ["view", baseline, "version", "dist", "--json"],
+    ["view", exactBaseline, "version", "dist", "--json"],
     { binary: "npm" },
   );
-  assert.equal(metadata.version, "2026.7.1-2");
-  assert.equal(
-    metadata.dist.integrity,
-    "sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==",
+  assert.equal(metadata.version, version);
+  assert(typeof metadata.dist.integrity === "string" && metadata.dist.integrity.length > 0);
+  // npm pack computes integrity from the fetched tarball even with --dry-run.
+  const packed = resolveNpmJsonEntries(
+    await command(
+      "baseline-package-pack",
+      ["pack", exactBaseline, "--ignore-scripts", "--dry-run", "--json"],
+      { binary: "npm" },
+    ),
   );
+  assert.equal(packed.length, 1);
+  const artifact = packed[0];
+  assert(artifact && typeof artifact === "object");
+  assert.equal(artifact.name, "openclaw");
+  assert.equal(artifact.version, version);
+  assert.equal(artifact.integrity, metadata.dist.integrity);
   saveEvidence({
     baseline: metadata,
+    baselineArtifact: {
+      name: artifact.name,
+      version: artifact.version,
+      integrity: artifact.integrity,
+    },
     candidate: recoveryFileIdentity(candidate),
     storage: [stateDir, process.env.TMPDIR].map((directory) => {
       const stat = fs.statfsSync(directory);

--- a/test/scripts/upgrade-survivor-recovery-cleanup.test.ts
+++ b/test/scripts/upgrade-survivor-recovery-cleanup.test.ts
@@ -33,11 +33,13 @@ describe.skipIf(process.platform === "win32")("recovery survivor package provena
     requested = "openclaw@2026.7.1-2",
     installedVersion = "2026.7.1-2",
     packShape = "array",
+    viewShape = "object",
     fault,
   }: {
     requested?: string;
     installedVersion?: string;
     packShape?: "array" | "name-keyed";
+    viewShape?: "object" | "array";
     fault?: PackageFault;
   } = {}) {
     const root = temporary();
@@ -82,7 +84,7 @@ if (args[1] !== ${JSON.stringify(`openclaw@${installedVersion}`)}) {
   throw new Error("package evidence must use the installed exact baseline");
 }
 if (args[0] === "view") {
-  console.log(JSON.stringify(${JSON.stringify(metadata)}));
+  console.log(JSON.stringify(${JSON.stringify(viewShape === "array" ? [metadata] : metadata)}));
 } else if (args[0] === "pack") {
   console.log(JSON.stringify(${JSON.stringify(packShape === "array" ? [packed] : { openclaw: packed })}));
 } else {
@@ -127,7 +129,12 @@ if (args[0] === "view") {
 
   it.each([
     { requested: "openclaw@2026.7.1-2", installedVersion: "2026.7.1-2", packShape: "array" },
-    { requested: "openclaw@2026.8.2", installedVersion: "2026.8.2", packShape: "name-keyed" },
+    {
+      requested: "openclaw@2026.8.2",
+      installedVersion: "2026.8.2",
+      packShape: "name-keyed",
+      viewShape: "array",
+    },
     { requested: "openclaw@latest", installedVersion: "2026.8.2", packShape: "array" },
   ] as const)(
     "verifies $requested against installed $installedVersion ($packShape)",

--- a/test/scripts/upgrade-survivor-recovery-cleanup.test.ts
+++ b/test/scripts/upgrade-survivor-recovery-cleanup.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -14,10 +15,151 @@ import {
   seedRecoveryFixture,
   writeRecoveryTranscript,
 } from "../../scripts/e2e/lib/upgrade-survivor/recovery-cleanup-fixture.mjs";
+import { runNodeScript } from "../helpers/run-node-script.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const temporary = () => fs.realpathSync(tempDirs.make("upgrade-recovery-assertions-"));
+
+describe.skipIf(process.platform === "win32")("recovery survivor package provenance", () => {
+  type PackageFault =
+    | "metadata-version"
+    | "pack-version"
+    | "integrity-mismatch"
+    | "missing-metadata-integrity"
+    | "missing-pack-integrity";
+
+  async function packageEvidence({
+    requested = "openclaw@2026.7.1-2",
+    installedVersion = "2026.7.1-2",
+    packShape = "array",
+    fault,
+  }: {
+    requested?: string;
+    installedVersion?: string;
+    packShape?: "array" | "name-keyed";
+    fault?: PackageFault;
+  } = {}) {
+    const root = temporary();
+    const artifacts = path.join(root, "artifacts");
+    const state = path.join(root, "state");
+    const runtime = path.join(root, "runtime");
+    const bin = path.join(root, "bin");
+    for (const directory of [artifacts, state, runtime, bin]) {
+      fs.mkdirSync(directory);
+    }
+    const integrity =
+      installedVersion === "2026.7.1-2"
+        ? "sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g=="
+        : `sha512-${createHash("sha512").update(installedVersion).digest("base64")}`;
+    const metadata = {
+      version: fault === "metadata-version" ? "2026.1.1" : installedVersion,
+      dist: {
+        tarball: `https://registry.npmjs.org/openclaw/-/openclaw-${installedVersion}.tgz`,
+        ...(fault === "missing-metadata-integrity" ? {} : { integrity }),
+      },
+    };
+    const packed = {
+      name: "openclaw",
+      version: fault === "pack-version" ? "2026.1.1" : installedVersion,
+      ...(fault === "missing-pack-integrity"
+        ? {}
+        : {
+            integrity:
+              fault === "integrity-mismatch"
+                ? `sha512-${createHash("sha512").update("different bytes").digest("base64")}`
+                : integrity,
+          }),
+    };
+    const calls = path.join(root, "npm-calls.jsonl");
+    fs.writeFileSync(
+      path.join(bin, "npm"),
+      `#!${process.execPath}
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + "\\n");
+if (args[1] !== ${JSON.stringify(`openclaw@${installedVersion}`)}) {
+  throw new Error("package evidence must use the installed exact baseline");
+}
+if (args[0] === "view") {
+  console.log(JSON.stringify(${JSON.stringify(metadata)}));
+} else if (args[0] === "pack") {
+  console.log(JSON.stringify(${JSON.stringify(packShape === "array" ? [packed] : { openclaw: packed })}));
+} else {
+  throw new Error("unexpected npm command");
+}
+`,
+      { mode: 0o755 },
+    );
+    const candidate = path.join(root, "candidate.tgz");
+    const candidateBytes = "candidate package fixture";
+    fs.writeFileSync(candidate, candidateBytes);
+    const result = await runNodeScript(
+      [
+        path.resolve("scripts/e2e/lib/upgrade-survivor/recovery-cleanup.mjs"),
+        "packages",
+        requested,
+        candidate,
+      ],
+      {
+        PATH: [bin, path.dirname(process.execPath), "/usr/bin", "/bin"].join(path.delimiter),
+        HOME: root,
+        TMPDIR: runtime,
+        OPENCLAW_STATE_DIR: state,
+        OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT: artifacts,
+        OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT: runtime,
+        OPENCLAW_UPGRADE_SURVIVOR_BASELINE_VERSION: installedVersion,
+      },
+      10_000,
+    );
+    return {
+      result,
+      metadata,
+      calls: fs
+        .readFileSync(calls, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+      evidencePath: path.join(artifacts, "recovery-evidence.json"),
+      candidateSha256: createHash("sha256").update(candidateBytes).digest("hex"),
+    };
+  }
+
+  it.each([
+    { requested: "openclaw@2026.7.1-2", installedVersion: "2026.7.1-2", packShape: "array" },
+    { requested: "openclaw@2026.8.2", installedVersion: "2026.8.2", packShape: "name-keyed" },
+    { requested: "openclaw@latest", installedVersion: "2026.8.2", packShape: "array" },
+  ] as const)(
+    "verifies $requested against installed $installedVersion ($packShape)",
+    async (entry) => {
+      const fixture = await packageEvidence(entry);
+      expect(fixture.result.error).toBeUndefined();
+      expect(fixture.result.status, fixture.result.stderr).toBe(0);
+      const exactSpec = `openclaw@${entry.installedVersion}`;
+      expect(fixture.calls).toEqual([
+        ["view", exactSpec, "version", "dist", "--json"],
+        ["pack", exactSpec, "--ignore-scripts", "--dry-run", "--json"],
+      ]);
+      expect(JSON.parse(fs.readFileSync(fixture.evidencePath, "utf8"))).toMatchObject({
+        baseline: fixture.metadata,
+        candidate: { sha256: fixture.candidateSha256 },
+      });
+    },
+  );
+
+  it.each<PackageFault>([
+    "metadata-version",
+    "pack-version",
+    "integrity-mismatch",
+    "missing-metadata-integrity",
+    "missing-pack-integrity",
+  ])("rejects %s without recording successful package evidence", async (fault) => {
+    const fixture = await packageEvidence({ fault });
+    expect(fixture.result.error).toBeUndefined();
+    expect(fixture.result.status).toBe(1);
+    expect(fs.existsSync(fixture.evidencePath)).toBe(false);
+  });
+});
 
 describe("recovery survivor evidence", () => {
   it("uses the existing volume controls and rejects unsafe counts", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where maintainers cannot run recovery-cleanup upgrade validation from the current stable release. Selecting and installing `openclaw@2026.8.2` fails before update because package evidence requires `2026.7.1-2` and its July tarball integrity. npm 12 also wraps registry metadata in an array, which the old direct field access cannot read.

## Why This Change Was Made

Anchor provenance to the exact baseline version already installed by the survivor runner. Normalize both `npm view` and `npm pack` JSON through the existing adapter, require one package result, and compare registry version/integrity with the identity computed from the downloaded tarball. `--ignore-scripts --dry-run` preserves a real byte-integrity check without executing lifecycle hooks or writing a package copy.

This removes the release-specific pin and mutable-tag race at the E2E package-evidence owner. Product runtime, config contracts, and database schemas are unchanged. Runtime LOC delta is **0**; E2E harness **+32/-8**, regression tests **+149/-0**. The harness growth adds downloaded-byte verification and supports both npm output contracts.

## User Impact

Maintainers can validate recovery upgrades from the selected published baseline on npm 11 and 12, while rejecting mismatched package versions or integrity. Completed upgrade flows required no product runtime code change.

## Evidence

| Proof | Result |
| --- | --- |
| Final-head recovery upgrade | **Passed, one attempt, 142 s** on [Blacksmith Testbox run 33710924062](https://github.com/openclaw/openclaw/actions/runs/33710924062). Exact head `0760b18ec6d43ed232cc67c5c1bf021c3840ca0b`, tree `93f408d3b24e81a5526a1c071e5bbbd99a113024`, clean tracked diff verified before building. |
| Broader published-baseline matrix | **14 distinct survivor scenarios passed** across [run 33700047324](https://github.com/openclaw/openclaw/actions/runs/33700047324) and the recovery repeats. Includes SQLite volume: 4,800 sessions, 23,890 events, 2,200 cron records, and 512 plugin-state records. Original main target: `b7fa0f52c6a9cb04ebffb5d6c9c743224cde45d4`. |
| Service and switch flows | [Run 33707341387](https://github.com/openclaw/openclaw/actions/runs/33707341387) passed recovery **172 s**, authenticated service restart **186 s**, root-managed VPS upgrade **94 s**, and channel switching **93 s**, all on exact pre-rebase head `1b62b815746d1674ea4898ee75e4087cc19f146d`. |
| Real npm 12 | Isolated published **npm 12.0.2** passed the complete `packages` command in **5.59 s**: singleton-array view, name-keyed pack, matching `2026.8.2` version/integrity, and independently checked synthetic candidate hash. Direct npm source inspection verified both output shapes and dry-run hashing. |
| Regressions and review | Original pin: **6 failing cases before repair**. npm 12 view fixture: **1 failure before normalization**. Final recovery/config suites: **45 passed** on the final head. Changed-file checks exited 0. Independent Codex autoreview found no actionable P0–P2 findings. |

Final recovery proved migration before standalone Doctor, custom-store restore, live cleanup refusal/read-only checks, offline cleanup with exact disposal accounting and protected originals, and preserved public history after Gateway restart. It disposed two custom-restore files and nine primary originals while preserving five history streams across ten SQLite entries. All task-owned Testboxes were stopped and verified completed.

Final candidate SHA-256: `c8ab5b795110d1a8618e537c29a1a693bb267112eb9db32fc1786a09d319708e`. Matching registry-manifest SHA-256: `f1491e9967e3ca209878ff1493fa211786e13c45bb06074a749d1fc293a32f8d`. The main package still reports `2026.8.1`; the verified source commit/tree and artifact hashes identify the candidate.

Reproduce from the PR checkout with Docker available:

```bash
OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@2026.8.2 \
OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS=openclaw@2026.8.2 \
OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS=recovery-cleanup \
OPENCLAW_DOCKER_ALL_LANES=published-upgrade-survivor \
node scripts/test-docker-all.mjs
```

ClawSweeper's finding and all three Rank-up moves are addressed: normalize view metadata, cover its singleton-array shape, and rerun full recovery on the repaired head. Its final review of `0760b18ec6d` found no actionable code findings and accepted the exact-head recovery proof. Its remaining generic checklist items are satisfied: this was reviewed and landed through the maintainer-authorized native flow, and the flagged recovery-helper path changes no persistent data model. The recorded exact-head recovery run supplies migration and upgrade compatibility evidence.

Initial CI hit unrelated main JavaScript/CSS budgets and stale artifact-transfer fixture expectations. Existing main fixes #136817 and #136878 were incorporated by mechanical rebases; `git range-diff` confirmed identical repair patches. Required [final-head CI](https://github.com/openclaw/openclaw/actions/runs/33710812989) passed: 102 successful jobs and 17 skipped. Eleven heavy jobs initially waited for Blacksmith runners, then completed on the original attempt without a retry or CI configuration change.

Limits: native auth-storage continuity used synthetic API-key/token/OAuth profiles, not provider authentication. The direct `update --channel dev` source-install attempt hit anonymous GitHub clone/fetch errors before candidate execution; channel-switch proof uses the existing local Git fixture. ACPX initially timed out and passed an unchanged-package replay; its timeout cause remains unproven. Earlier externally cancelled Testbox attempts are excluded from successful proof.

Historical context: #133864 introduced the fixed July pin. This repair is distinct from the registry/config-fixture work in #136796.
