### PR TITLE
test(macos): isolate approval expiry timing

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovalQueueStore.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalQueueStore.swift
@@ -86,16 +86,26 @@ struct ExecApprovalQueueItem: Decodable, Identifiable {
 final class ExecApprovalQueueStore {
     static let shared = ExecApprovalQueueStore()
 
+    struct ExpiryClock {
+        var nowMs: () -> Int = { Int(Date().timeIntervalSince1970 * 1000) }
+        var now: () -> ContinuousClock.Instant = { ContinuousClock.now }
+        var sleepUntil: (ContinuousClock.Instant) async throws -> Void = {
+            try await Task.sleep(until: $0, clock: .continuous)
+        }
+    }
+
     private(set) var requests: [ExecApprovalQueueItem] = []
 
     @ObservationIgnored private let logger = Logger(subsystem: "ai.openclaw", category: "exec-approvals.queue")
     @ObservationIgnored private let gateway: GatewayConnection
+    @ObservationIgnored private let clock: ExpiryClock
     @ObservationIgnored private var eventTask: Task<Void, Never>?
     @ObservationIgnored private var expiryTasks: [String: Task<Void, Never>] = [:]
     @ObservationIgnored private var refreshGeneration: UInt64 = 0
 
-    init(gateway: GatewayConnection = .shared) {
+    init(gateway: GatewayConnection = .shared, clock: ExpiryClock = .init()) {
         self.gateway = gateway
+        self.clock = clock
     }
 
     func start() {
@@ -127,7 +137,7 @@ final class ExecApprovalQueueStore {
             // A resolution received during the request owns newer state; an old
             // list must never resurrect its already-dismissed approval card.
             guard generation == self.refreshGeneration, !Task.isCancelled else { return }
-            let nowMs = Self.currentTimeMs()
+            let nowMs = self.clock.nowMs()
             let systemApprovals = self.requests.filter { $0.kind == .systemAgent && $0.expiresAtMs > nowMs }
             self.replaceRequests(listed.filter { $0.expiresAtMs > nowMs } + systemApprovals)
         } catch {
@@ -191,7 +201,7 @@ final class ExecApprovalQueueStore {
     }
 
     private func insertRequest(_ request: ExecApprovalQueueItem) {
-        guard request.expiresAtMs > Self.currentTimeMs() else { return }
+        guard request.expiresAtMs > self.clock.nowMs() else { return }
         self.refreshGeneration &+= 1
         self.requests.removeAll { $0.id == request.id }
         self.requests.append(request)
@@ -218,22 +228,18 @@ final class ExecApprovalQueueStore {
 
     private func scheduleExpiry(for request: ExecApprovalQueueItem) {
         self.expiryTasks.removeValue(forKey: request.id)?.cancel()
-        let (remainingMs, overflow) = request.expiresAtMs.subtractingReportingOverflow(Self.currentTimeMs())
+        let (remainingMs, overflow) = request.expiresAtMs.subtractingReportingOverflow(self.clock.nowMs())
         guard !overflow, remainingMs > 0 else {
             self.removeRequest(id: request.id)
             return
         }
         // Task startup may be delayed; keep the Gateway's expiry deadline.
-        let deadline = ContinuousClock.now + .milliseconds(remainingMs)
-        self.expiryTasks[request.id] = Task { [weak self] in
-            try? await Task.sleep(until: deadline, clock: .continuous)
+        let deadline = self.clock.now() + .milliseconds(remainingMs)
+        self.expiryTasks[request.id] = Task { [weak self, clock] in
+            try? await clock.sleepUntil(deadline)
             guard !Task.isCancelled else { return }
             self?.removeRequest(id: request.id)
         }
-    }
-
-    private static func currentTimeMs() -> Int {
-        Int(Date().timeIntervalSince1970 * 1000)
     }
 
     private struct ResolvedApproval: Decodable {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalQueueStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalQueueStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import OpenClawProtocol
 import Testing
 @testable import OpenClaw
@@ -20,11 +21,11 @@ private struct ApprovalFixtureRequest: Encodable, Sendable {
         id: String,
         sessionKey: String = "main",
         command: String = "echo safe",
+        nowMs: Int = Int(Date().timeIntervalSince1970 * 1000),
         createdOffsetMs: Int = 0,
         expiresOffsetMs: Int = 60000,
         allowedDecisions: [String]? = nil)
     {
-        let nowMs = Int(Date().timeIntervalSince1970 * 1000)
         self.id = id
         self.request = Command(command: command, sessionKey: sessionKey, allowedDecisions: allowedDecisions)
         self.createdAtMs = nowMs + createdOffsetMs
@@ -33,6 +34,38 @@ private struct ApprovalFixtureRequest: Encodable, Sendable {
 
     var json: String {
         String(decoding: try! JSONEncoder().encode(self), as: UTF8.self)
+    }
+}
+
+@MainActor
+private final class ApprovalExpiryClock {
+    var nowMs = 1_800_000_000_000
+    private var now = ContinuousClock.now
+    private let ticks = AsyncStream<Void>.makeStream()
+    private let sleeps = AsyncStream<Void>.makeStream()
+
+    var clock: ExecApprovalQueueStore.ExpiryClock {
+        .init(nowMs: { self.nowMs }, now: { self.now }, sleepUntil: { deadline in
+            self.sleeps.continuation.yield(())
+            if self.now >= deadline {
+                return
+            }
+            for await _ in self.ticks.stream where self.now >= deadline {
+                return
+            }
+            try Task.checkCancellation()
+        })
+    }
+
+    func waitForSleep() async {
+        var iterator = self.sleeps.stream.makeAsyncIterator()
+        _ = await iterator.next()
+    }
+
+    func advance(milliseconds: Int) {
+        self.nowMs += milliseconds
+        self.now += .milliseconds(milliseconds)
+        self.ticks.continuation.yield(())
     }
 }
 
@@ -127,10 +160,6 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
         let sequence = await self.requestLog.nextEventSequence()
         let event = #"{"type":"event","event":"\#(name)","seq":\#(sequence),"payload":\#(payload)}"#
         socket.emitReceiveSuccessOnce(.data(Data(event.utf8)))
-    }
-
-    func waitUntilReady() async throws {
-        _ = try await self.readySocket()
     }
 
     private func readySocket() async throws -> GatewayTestWebSocketTask {
@@ -244,45 +273,62 @@ struct ExecApprovalQueueStoreTests {
         try #require(await self.waitUntil { store.requests.isEmpty })
     }
 
-    @Test func `live requests disappear at expiry without a gateway resolution event`() async throws {
-        let fixture = ApprovalGatewayFixture()
-        let store = ExecApprovalQueueStore(gateway: fixture.gateway)
+    @Test(.timeLimit(.minutes(1)), arguments: [false, true])
+    func `requests disappear at expiry without a gateway resolution event`(fromEvent: Bool) async throws {
+        let clock = ApprovalExpiryClock()
+        let request = ApprovalFixtureRequest(id: "short-lived", nowMs: clock.nowMs, expiresOffsetMs: 500)
+        let fixture = ApprovalGatewayFixture(initialRequests: { fromEvent ? [] : [request] })
+        let store = ExecApprovalQueueStore(gateway: fixture.gateway, clock: clock.clock)
         defer { store.stop() }
         store.start()
         await store.refresh()
 
-        try await fixture.waitUntilReady()
-        let request = ApprovalFixtureRequest(id: "short-lived", expiresOffsetMs: 500)
-        try await fixture.sendEvent(name: "exec.approval.requested", payload: request.json)
-
-        try #require(await self.waitUntil { store.requests.map(\.id) == ["short-lived"] })
-        try #require(await self.waitUntil { store.requests.isEmpty })
+        if fromEvent {
+            try await fixture.sendEvent(name: "exec.approval.requested", payload: request.json)
+            try #require(await self.waitUntil { store.requests.map(\.id) == ["short-lived"] })
+        }
+        try #require(store.requests.map(\.id) == ["short-lived"])
+        await clock.waitForSleep()
+        clock.advance(milliseconds: 499)
+        #expect(store.requests.map(\.id) == ["short-lived"])
+        await self.waitForChange(in: store) {
+            clock.advance(milliseconds: 1)
+        }
+        #expect(store.requests.isEmpty)
         #expect(await fixture.requestLog.requests(method: "exec.approval.resolve").isEmpty)
     }
 
-    @Test func `expiry keeps its deadline when the main actor delays task startup`() async {
-        // The child owns the actor stall so parallel suites keep their own deadlines.
-        await #expect(processExitsWith: .success) {
-            try await ExecApprovalQueueStoreTests.checkDelayedExpiry()
-        }
-    }
-
-    private static func checkDelayedExpiry() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func `expiry keeps its deadline when the main actor delays task startup`() async throws {
+        let clock = ApprovalExpiryClock()
+        let nowMs = clock.nowMs
         let fixture = ApprovalGatewayFixture(initialRequests: {
-            [ApprovalFixtureRequest(id: "delayed-expiry-task", expiresOffsetMs: 3000)]
+            [ApprovalFixtureRequest(id: "delayed-expiry-task", nowMs: nowMs, expiresOffsetMs: 3000)]
         })
-        let store = ExecApprovalQueueStore(gateway: fixture.gateway)
+        let store = ExecApprovalQueueStore(gateway: fixture.gateway, clock: clock.clock)
         defer { store.stop() }
 
         await store.refresh()
-        let request = try #require(store.requests.first)
-        // Hold the actor past the published deadline before the queued expiry task can start.
-        Self.blockUntilExpiry(request.expiresAtMs)
-        try #require(await Self().waitUntil { store.requests.isEmpty })
+        try #require(store.requests.map(\.id) == ["delayed-expiry-task"])
+        // Advance before yielding MainActor to the queued expiry task.
+        await self.waitForChange(in: store) {
+            clock.advance(milliseconds: 3000)
+        }
+        #expect(store.requests.isEmpty)
     }
 
-    private static func blockUntilExpiry(_ expiresAtMs: Int) {
-        Thread.sleep(until: Date(timeIntervalSince1970: Double(expiresAtMs) / 1000))
+    private func waitForChange(in store: ExecApprovalQueueStore, perform action: () -> Void) async {
+        // Cancellation must end the wait if broken expiry never changes the queue.
+        let change = AsyncStream<Void>.makeStream()
+        withObservationTracking {
+            _ = store.requests
+        } onChange: {
+            change.continuation.yield(())
+            change.continuation.finish()
+        }
+        action()
+        var iterator = change.stream.makeAsyncIterator()
+        _ = await iterator.next()
     }
 
     @Test func `explicit decision policy excludes allow always and blocks unavailable decisions`() async {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalQueueStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalQueueStoreTests.swift
@@ -89,10 +89,7 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
     let session: GatewayTestWebSocketSession
     let gateway: GatewayConnection
 
-    init(
-        initialRequests: @escaping @Sendable () -> [ApprovalFixtureRequest] = { [] },
-        listResponseDelay: Duration = .zero)
-    {
+    init(initialRequests: @escaping @Sendable () -> [ApprovalFixtureRequest] = { [] }) {
         let requestLog = ApprovalGatewayRequestLog(initialRequests: initialRequests)
         self.requestLog = requestLog
         self.session = GatewayTestWebSocketSession(taskFactory: {
@@ -110,9 +107,6 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
                             details: .init(["reason": reason])))
                     try socket.emitReceiveSuccess(.data(JSONEncoder().encode(response)))
                     return
-                }
-                if request.method == "exec.approval.list", listResponseDelay > .zero {
-                    try await Task.sleep(for: listResponseDelay)
                 }
                 let payload = if request.method == "exec.approval.list" {
                     await requestLog.listResponse()
@@ -133,6 +127,10 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
         let sequence = await self.requestLog.nextEventSequence()
         let event = #"{"type":"event","event":"\#(name)","seq":\#(sequence),"payload":\#(payload)}"#
         socket.emitReceiveSuccessOnce(.data(Data(event.utf8)))
+    }
+
+    func waitUntilReady() async throws {
+        _ = try await self.readySocket()
     }
 
     private func readySocket() async throws -> GatewayTestWebSocketTask {
@@ -170,11 +168,10 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
 @Suite(.serialized)
 @MainActor
 struct ExecApprovalQueueStoreTests {
-    @Test func `refresh seeds direct gateway list and excludes expired approvals`() async {
+    @Test func `refresh seeds and sorts the direct gateway list`() async {
         let fixture = ApprovalGatewayFixture(initialRequests: {
             [
                 ApprovalFixtureRequest(id: "later", sessionKey: "work", createdOffsetMs: 200),
-                ApprovalFixtureRequest(id: "expired", expiresOffsetMs: -100),
                 ApprovalFixtureRequest(id: "earlier", createdOffsetMs: -200),
             ]
         })
@@ -186,6 +183,19 @@ struct ExecApprovalQueueStoreTests {
         #expect(store.requests.map(\.id) == ["earlier", "later"])
         #expect(store.requests.last?.request.sessionKey == "work")
         #expect(store.requests.first?.allowedDecisions == [.allowOnce, .deny])
+        #expect(await fixture.requestLog.requests(method: "exec.approval.list").count == 1)
+    }
+
+    @Test func `refresh excludes approvals that are already expired`() async {
+        let fixture = ApprovalGatewayFixture(initialRequests: {
+            [ApprovalFixtureRequest(id: "expired", expiresOffsetMs: -100)]
+        })
+        let store = ExecApprovalQueueStore(gateway: fixture.gateway)
+        defer { store.stop() }
+
+        await store.refresh()
+
+        #expect(store.requests.isEmpty)
         #expect(await fixture.requestLog.requests(method: "exec.approval.list").count == 1)
     }
 
@@ -234,17 +244,20 @@ struct ExecApprovalQueueStoreTests {
         try #require(await self.waitUntil { store.requests.isEmpty })
     }
 
-    @Test(arguments: [0, 600])
-    func `expired requests disappear without a gateway resolution event`(listResponseDelayMs: Int) async throws {
-        let fixture = ApprovalGatewayFixture(initialRequests: {
-            [ApprovalFixtureRequest(id: "short-lived", expiresOffsetMs: 500)]
-        }, listResponseDelay: .milliseconds(listResponseDelayMs))
+    @Test func `live requests disappear at expiry without a gateway resolution event`() async throws {
+        let fixture = ApprovalGatewayFixture()
         let store = ExecApprovalQueueStore(gateway: fixture.gateway)
         defer { store.stop() }
-
+        store.start()
         await store.refresh()
-        #expect(store.requests.map(\.id) == ["short-lived"])
+
+        try await fixture.waitUntilReady()
+        let request = ApprovalFixtureRequest(id: "short-lived", expiresOffsetMs: 500)
+        try await fixture.sendEvent(name: "exec.approval.requested", payload: request.json)
+
+        try #require(await self.waitUntil { store.requests.map(\.id) == ["short-lived"] })
         try #require(await self.waitUntil { store.requests.isEmpty })
+        #expect(await fixture.requestLog.requests(method: "exec.approval.resolve").isEmpty)
     }
 
     @Test func `expiry keeps its deadline when the main actor delays task startup`() async {


### PR DESCRIPTION
## What Problem This Solves

Resolves intermittent macOS CI failures where approval-expiry tests require a 500 ms request to remain visible after asynchronous delivery or MainActor scheduling has already consumed its lifetime. The production queue correctly filters or removes expired requests.

Related: #136432 (Mac connection compatibility), where the unrelated expiry test failed. Reported by @steipete. This extends @vincentkoc's existing expiry-test repair and preserves his original commit and direct-list coverage.

## Why This Change Was Made

The queue's existing wall-clock reads, monotonic clock, and absolute-deadline sleep are injectable together. Their production defaults and cancellation behavior remain unchanged, including capturing the deadline before the expiry task starts.

One controlled-clock test covers both list and event entry paths: the request remains at 499 ms and disappears at 500 ms without a resolution event. The delayed-MainActor sibling advances time before yielding to the expiry task. Cancellation-aware observation replaces expiry polling and keeps failing tests bounded. The artificial list delay, socket-readiness wrapper, real actor stall, and child-process expiry helper are removed.

## User Impact

No product behavior changes. Maintainers get deterministic approval-expiry coverage, including delayed task admission, without racing a short request lifetime against hosted-runner scheduling.

## Evidence

Candidate: `42bcde680742820f1c792f52e19fae2e686e839a`.

- [Job 100508411454, attempt 4](https://github.com/openclaw/openclaw/actions/runs/33699683106/job/100508411454): the 600 ms case failed at the initial nonempty assertion on `055388a913720b0c5c7c2ce50115dc11148b4146`.
- [Job 100493142562, attempt 3](https://github.com/openclaw/openclaw/actions/runs/33699683106/job/100493142562): inspected as requested; both expiry cases passed. That attempt failed separate socket-auth and cron polling tests, so it is not a second expiry failure.
- Original Full Release Validation context: https://github.com/openclaw/openclaw/actions/runs/33695199734.

### Before and after

With the original production store and test at `c5bde6ac9349d45b71bcd1d60f0048d686ac5964`, a temporary 600 ms delivery stall after the list fixture published its timestamp reproduces the same failure:

```text
listResponseDelayMs → 600
Expectation failed: store.requests.map(\.id) == ["short-lived"]
store.requests.map(\.id) → []
Test run with 7 tests in 1 suite failed with 1 issue.
```

The controlled-clock suite passes the same post-timestamp delivery stall: 8 tests passed in 6.457 seconds. The temporary stall was then removed. The final suite passed 20 consecutive runs in a bounded shell loop that stops on the first failure; each run executes all 8 `ExecApprovalQueueStoreTests` tests, including both list/event arguments.

```text
Native approval queue run 1/20: 8 tests passed
Native approval queue run 20/20: 8 tests passed
```

Native commands:

```sh
swift build --package-path apps/macos --build-system native --build-tests --jobs 8
swift test --package-path apps/macos --build-system native --skip-build --filter ExecApprovalQueueStoreTests
```

The test command ran on macOS 27 / Swift 6.4 inside an OS sandbox with private HOME/state, operator files and Keychain/preferences services blocked, and network denied. The wrapper supplies the selected SDK and XCTest loader paths; SwiftPM's nested manifest sandbox is disabled because the outer OS sandbox owns isolation. No full native suite ran on the operator desktop.

### Live proof

A temporary native test used the normal Gateway connection constructor, a disposable device identity, and a real isolated dev Gateway on port 59608 with a fresh `OPENCLAW_STATE_DIR`. A synthetic manual-list approval used the existing `requireDeliveryRoute: false` request option. After loading the request, the native WebSocket was closed before its three-second deadline. The production default clock removed the request without a resolution event reaching the client:

```text
LIVE: actual Gateway list -> one pending synthetic approval
LIVE: native WebSocket closed before expiry
LIVE: default production expiry removed approval; resolution events=0
Test run with 1 test in 1 suite passed after 3.215 seconds.
```

The temporary probe is removed, and the dev Gateway is stopped. No command execution or model call occurred, and no operator configuration or credentials were used. Synthetic Gateway and device-identity state and the task-owned lifecycle locks were cleaned up.

### Hosted validation

[Canonical PR CI](https://github.com/openclaw/openclaw/actions/runs/33714533516) passed on `42bcde680742820f1c792f52e19fae2e686e839a`, including [Swift tests](https://github.com/openclaw/openclaw/actions/runs/33714533516/job/100521662045), [release compilation](https://github.com/openclaw/openclaw/actions/runs/33714533516/job/100521662055), all three Mac Node groups, and `openclaw/ci-gate`. The exact-head `watch-pr-ci.mjs` watcher returned `GREEN`; the current PR check rollup has no failed or pending checks.

The Blacksmith native queue initially stalled, so the documented hosted recovery paths were also exercised. [Hosted Swift tests](https://github.com/openclaw/openclaw/actions/runs/33715581914/job/100524087928) passed 1,580 shared-kit tests and 1,949 app tests, including both controlled expiry arguments and the delayed-task sibling. The approval suite passed under the full app workload in 34.318 seconds. [macOS Periphery](https://github.com/openclaw/openclaw/actions/runs/33715654993) and [shared-kit Periphery](https://github.com/openclaw/openclaw/actions/runs/33715669229) passed, including both consumers and their intersection.

The recovery run's release phase hit a transient SwiftPM dependency-fetch/cache failure for the existing Peekaboo/AXorcist pins. Both upstream revisions and public fetch endpoints were verified, and canonical PR release compilation subsequently passed with the same pins and no code change. A failed-job-only recovery retry was already running when canonical CI completed.

### Checks and scope

`node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/ExecApprovalQueueStore.swift apps/macos/Tests/OpenClawIPCTests/ExecApprovalQueueStoreTests.swift` passed, including all three Mac Node test groups. Final native build, production SwiftLint, both-file SwiftFormat, and diff checks passed. The final local candidate and committed branch both have clean P2 reviews. Exact-head PR CI and the current check rollup are green. The latest ClawSweeper review covers this head, has no correctness findings, and its native-test rank-up is satisfied.

The full CLI build's declaration phase stopped with `Boundary configuration or resolution topology changed during compilation` while native build artifacts were changing. Runtime bundling had completed and that output ran the live Gateway proof; this is not a claim that the full CLI build passed. The declaration snapshot/native build interaction is a separate tooling follow-up, outside this clock-only repair.

Production: +17/-11, net +6. Tests: +92/-33, net +59. The six production lines add only the explicitly requested clock seam; there was no existing injectable clock, and all existing timing policy remains at the queue owner.

NO-FOLLOW-UP in the touched approval area: the useful clock and fixture consolidation is included; a generic clock framework would add unused surface.
