### PR TITLE
fix(swarm): queue Code Mode fan-out at the bridge limit

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -1164,7 +1164,10 @@ before any further action. Network-controlled tool output and errors retain
 their existing untrusted-content wrapping and sanitization; recovering from a
 failure does not grant new permissions or replay completed side effects.
 
-Parallel nested calls are allowed up to `maxPendingToolCalls`.
+Parallel nested calls are allowed up to `maxPendingToolCalls`. An oversized raw
+tool batch fails before any call in that batch is dispatched. [Swarm](/tools/swarm)
+launches, notes, and result waits instead queue for available bridge slots;
+they do not raise that limit or bypass the run's cancellation and policy checks.
 
 ## Run and snapshot lifecycle
 

--- a/docs/tools/swarm.md
+++ b/docs/tools/swarm.md
@@ -173,10 +173,13 @@ return await agents.run(
 order.
 
 Code Mode separately bounds concurrent guest bridge calls with
-`tools.codeMode.maxPendingToolCalls` (default `16`, maximum `128`). For very
-large groups, launch bounded batches below that limit and leave headroom for
-`phase()`, `log()`, and child wait transitions. `maxConcurrent` limits running
-children; it does not raise the guest bridge-call limit.
+`tools.codeMode.maxPendingToolCalls` (default `16`, maximum `128`). Swarm
+launches, progress notes, and result waits queue automatically when those slots
+are full. Queued requests retain their original arguments across snapshot
+resumes; stopping the run discards requests that have not been admitted.
+`maxConcurrent` still limits running children, and group child limits still
+apply. Raw tool calls do not use this Swarm queue and must remain within the
+bridge-call limit.
 
 ### Loop on a decision gate
 

--- a/src/agents/code-mode-controller-source.ts
+++ b/src/agents/code-mode-controller-source.ts
@@ -5,6 +5,9 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
 (() => {
   const output = [];
   const pending = new Map();
+  const queued = [];
+  const maxPending = globalThis.__openclawMaxPendingToolCalls;
+  delete globalThis.__openclawMaxPendingToolCalls;
   const catalogBindings = Array.isArray(globalThis.__openclawCatalog) ? globalThis.__openclawCatalog : [];
   const apiFiles = Array.isArray(globalThis.__openclawApiFiles) ? globalThis.__openclawApiFiles : [];
   const namespaceDescriptors = Array.isArray(globalThis.__openclawNamespaces) ? globalThis.__openclawNamespaces : [];
@@ -43,20 +46,31 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
     return typeof encoded === "string" ? encoded : String(value);
   }
 
-  function beginRequest(method, args) {
+  function beginRequest(method, args, { queue = false } = {}) {
     const methodName = String(method);
     const sequence = (bridgeSequences.get(methodName) ?? 0) + 1;
     bridgeSequences.set(methodName, sequence);
-    const bridgeId = "bridge:" + methodName + ":" + String(sequence);
-    const id = String(hostRequest(methodName, JSON.stringify(safe(args ?? [])), bridgeId));
-    const promise = new Promise((resolve, reject) => {
-      pending.set(id, { resolve, reject });
-    });
+    const id = "bridge:" + methodName + ":" + String(sequence);
+    const argsJson = JSON.stringify(safe(args ?? []));
+    let callbacks;
+    const promise = new Promise((resolve, reject) => { callbacks = { resolve, reject }; });
+    const admit = () => {
+      hostRequest(methodName, argsJson, id);
+      pending.set(id, callbacks);
+    };
+    if (queue && pending.size >= maxPending) queued.push(admit);
+    else admit();
     return { id, promise };
   }
 
-  function request(method, args) {
-    return beginRequest(method, args).promise;
+  // Swarm queues before admission; raw tools retain all-or-nothing overflow rejection.
+  // Closures and stable IDs live in the bounded VM snapshot, never a second host queue.
+  function drainQueuedRequests() {
+    while (queued.length > 0 && pending.size < maxPending) queued.shift()();
+  }
+
+  function request(method, args, options) {
+    return beginRequest(method, args, options).promise;
   }
 
   function scheduleTimer(callback, delay, args) {
@@ -84,6 +98,7 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
     if (!entry) return;
     pending.delete(requestId);
     entry.resolve(null);
+    drainQueuedRequests();
   }
 
   ${CODE_MODE_SWARM_CONTROLLER_SOURCE}
@@ -132,6 +147,7 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
       const error = new Error(typeof parsed === "string" ? parsed : parsed?.message ?? "nested tool failed");
       entry.reject(error);
     }
+    drainQueuedRequests();
     return true;
   }
 

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -465,7 +465,7 @@ interface AgentsApi {
   run<T>(prompt: string, options: AgentRunOptions & { schema: AgentJsonSchema }): Promise<T>;
 }
 
-/** Spawn collector agents concurrently. */
+/** Spawn collector agents concurrently; requests queue when bridge slots are full. */
 declare const agents: Readonly<AgentsApi>;
 /** Publish a phase heading for this swarm. */
 declare function phase(title: string): void;

--- a/src/agents/code-mode-swarm-controller-source.ts
+++ b/src/agents/code-mode-swarm-controller-source.ts
@@ -13,7 +13,7 @@ export const CODE_MODE_SWARM_CONTROLLER_SOURCE = String.raw`
     if (typeof value !== "string" || !value.trim()) {
       throw new TypeError(kind + " note must be a non-empty string");
     }
-    void request("swarmNote", [{ kind, text: value }]).catch(() => {});
+    void request("swarmNote", [{ kind, text: value }], { queue: true }).catch(() => {});
   }
 
   async function runAgent(prompt, options = {}) {
@@ -27,8 +27,8 @@ export const CODE_MODE_SWARM_CONTROLLER_SOURCE = String.raw`
       throw new TypeError("agents.run phase must be a non-empty string");
     }
     if (options.phase !== undefined) swarmNote("phase", options.phase);
-    const spawned = await request("agentSpawn", [prompt, options]);
-    const completion = await request("agentWait", [spawned.runId]);
+    const spawned = await request("agentSpawn", [prompt, options], { queue: true });
+    const completion = await request("agentWait", [spawned.runId], { queue: true });
     if (!completion || completion.status !== "done") {
       const runId = completion?.runId ?? spawned.runId ?? "unknown";
       const status = completion?.status ?? "failed";

--- a/src/agents/code-mode-swarm.fanout.test.ts
+++ b/src/agents/code-mode-swarm.fanout.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { CodeModeWorkerResult } from "./code-mode-runtime.js";
+import { resolveCodeModeConfig } from "./code-mode.js";
+import { resetCodeModeTestState, testing } from "./code-mode.test-support.js";
+
+afterEach(resetCodeModeTestState);
+
+describe("Swarm pipeline backpressure", () => {
+  it.each([
+    { limit: 1, count: 3, partial: false },
+    { limit: 2, count: 6, partial: false },
+    { limit: 16, count: 20, partial: false },
+    { limit: 3, count: 6, partial: true },
+  ])(
+    "accounts for $count items with $limit slots and partial settlement $partial",
+    async ({ limit, count, partial }) => {
+      const config = resolveCodeModeConfig({
+        tools: { codeMode: { enabled: true, maxPendingToolCalls: limit } },
+      });
+      const source = `
+      const outcomes = await Promise.allSettled(Array.from({ length: ${count} }, async (_, index) => {
+        const next = await agents.run("first-" + index, { phase: "First" });
+        return await agents.run(next, { phase: "Second" });
+      }));
+      return outcomes.map(outcome => outcome.status === "fulfilled"
+        ? { status: outcome.status, value: outcome.value }
+        : { status: outcome.status, error: outcome.reason.message });
+    `;
+      let result: CodeModeWorkerResult = await testing.runCodeModeWorker(
+        {
+          kind: "exec",
+          source,
+          config,
+          catalog: [],
+          apiFiles: [],
+          namespaces: [],
+          swarmEnabled: true,
+        },
+        10_000,
+      );
+      const collectors = new Map<string, string>();
+      const spawnedPrompts: string[] = [];
+      // Drive real worker snapshots with controlled child results; this tests request
+      // admission and resumption, not a mock of the guest's Promise implementation.
+      for (let round = 0; result.status === "waiting" && round < count * 6; round++) {
+        expect(result.pendingRequests.length).toBeGreaterThan(0);
+        expect(result.pendingRequests.length).toBeLessThanOrEqual(limit);
+        const frontier = partial ? result.pendingRequests.slice(-1) : result.pendingRequests;
+        const pendingRequests = partial ? result.pendingRequests.slice(0, -1) : [];
+        const settledRequests = frontier.map((request) => {
+          let value: unknown;
+          if (request.method === "swarmNote") {
+            value = { ok: true };
+          } else if (request.method === "agentSpawn") {
+            const prompt = request.args[0];
+            if (typeof prompt !== "string") {
+              throw new Error("expected a collector prompt");
+            }
+            const runId = `collector-${collectors.size}`;
+            collectors.set(runId, prompt);
+            spawnedPrompts.push(prompt);
+            value = { status: "accepted", runId };
+          } else {
+            expect(request.method).toBe("agentWait");
+            const runId = request.args[0];
+            const prompt = typeof runId === "string" ? collectors.get(runId) : undefined;
+            if (!prompt) {
+              throw new Error("wait must reference an accepted collector");
+            }
+            const nextStage = prompt.startsWith("first-")
+              ? prompt.replace("first-", "second-")
+              : prompt.replace("second-", "done-");
+            value =
+              prompt === "first-1"
+                ? { runId, status: "failed", error: "child intentionally failed" }
+                : { runId, status: "done", result: nextStage };
+          }
+          return { id: request.id, ok: true as const, value };
+        });
+        result = await testing.runCodeModeWorker(
+          { kind: "resume", snapshot: result.snapshot, config, settledRequests, pendingRequests },
+          10_000,
+        );
+      }
+      expect(result.status, result.status === "failed" ? result.error : undefined).toBe(
+        "completed",
+      );
+      if (result.status !== "completed") {
+        throw new Error("pipeline must complete");
+      }
+      expect(result.value.kind).toBe("complete");
+      expect(JSON.parse(result.value.json)).toEqual(
+        Array.from({ length: count }, (_, index) =>
+          index === 1
+            ? { status: "rejected", error: expect.stringContaining("child intentionally failed") }
+            : { status: "fulfilled", value: `done-${index}` },
+        ),
+      );
+      expect(spawnedPrompts).toHaveLength(count * 2 - 1);
+      expect(new Set(spawnedPrompts).size).toBe(spawnedPrompts.length);
+    },
+  );
+
+  it("releases a canceled timer slot without changing queued collector arguments", async () => {
+    const config = resolveCodeModeConfig({
+      tools: { codeMode: { enabled: true, maxPendingToolCalls: 1 } },
+    });
+    const result = await testing.runCodeModeWorker(
+      {
+        kind: "exec",
+        source: `
+          const timer = setTimeout(() => { throw new Error("canceled timer fired"); }, 60_000);
+          const options = { label: "original" };
+          const collector = agents.run("Queued research", options);
+          options.label = "changed";
+          clearTimeout(timer);
+          return await collector;
+        `,
+        config,
+        catalog: [],
+        swarmEnabled: true,
+      },
+      10_000,
+    );
+    expect(result).toMatchObject({
+      status: "waiting",
+      canceledRequestIds: ["bridge:sleep:1"],
+      pendingRequests: [
+        {
+          id: "bridge:agentSpawn:1",
+          method: "agentSpawn",
+          args: ["Queued research", { label: "original" }],
+        },
+      ],
+    });
+  });
+});

--- a/src/agents/code-mode-swarm.test.ts
+++ b/src/agents/code-mode-swarm.test.ts
@@ -20,6 +20,7 @@ import {
   SWARM_CODE_MODE_IDEMPOTENCY_KEY,
   SWARM_CODE_MODE_REQUEST_FINGERPRINT,
 } from "./subagents/swarm/swarm-code-mode.js";
+import { clearToolSearchCatalog } from "./tool-search.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
 
 const swarmMocks = vi.hoisted(() => ({
@@ -470,6 +471,58 @@ describe("Code Mode swarm host bridge", () => {
     expect(swarmMocks.emitSessionLifecycleEvent).not.toHaveBeenCalled();
     expect(harness.spawnTool.execute).not.toHaveBeenCalled();
   });
+
+  it.each(["abort", "catalog"] as const)(
+    "discards queued collector launches after %s closure",
+    async (closure) => {
+      const entered = createDeferred();
+      const release = createDeferred();
+      const launches: Array<Promise<ReturnType<typeof jsonResult>>> = [];
+      const harness = createSwarmHarness(() => {
+        const launch = release.promise.then(() =>
+          jsonResult({ status: "accepted", runId: "late-collector" }),
+        );
+        launches.push(launch);
+        if (launches.length === config.maxPendingToolCalls) {
+          entered.resolve();
+        }
+        return launch;
+      });
+      const controller = new AbortController();
+      const executing = harness.tools[0]!.execute(
+        "queued-collector-closure",
+        {
+          code: `return await Promise.all(Array.from(
+            { length: ${config.maxPendingToolCalls + 4} },
+            (_, index) => agents.run("Research " + index),
+          ));`,
+        },
+        controller.signal,
+      );
+      try {
+        await Promise.race([
+          entered.promise,
+          executing.then(() => {
+            throw new Error("execution ended before the collector frontier started");
+          }),
+        ]);
+        if (closure === "abort") {
+          controller.abort();
+        } else {
+          clearToolSearchCatalog(harness.ctx);
+        }
+        expect(resultDetails(await executing)).toMatchObject({ status: "failed", code: "aborted" });
+      } finally {
+        controller.abort();
+        release.resolve();
+        await Promise.allSettled(launches);
+        await executing;
+      }
+      expect(harness.spawnTool.execute).toHaveBeenCalledTimes(config.maxPendingToolCalls);
+      expect(swarmMocks.waitForCollectorCompletion).not.toHaveBeenCalled();
+      expect(testing.activeRuns.size).toBe(0);
+    },
+  );
 
   it("re-settles a persisted collector after restart without double-spawn", async () => {
     let persisted: SubagentRunRecord | undefined;

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -208,6 +208,7 @@ async function createVm(input: CodeModeWorkerPayload, bridge: BridgeState): Prom
         ["__openclawNamespaces", input.namespaces],
         ["__openclawApiFiles", input.apiFiles ?? []],
         ["__openclawSwarmEnabled", input.swarmEnabled === true],
+        ["__openclawMaxPendingToolCalls", input.config.maxPendingToolCalls],
       ] as const) {
         vm.hostToHandle(value).consume((handle) => vm.global.setProp(name, handle));
       }


### PR DESCRIPTION
Closes #136834 — Swarm fan-out fails at the Code Mode bridge limit.

**Merged** as `a698d5ce3b63b10c4203c0589f5b5de001b90880`. Exact-head CI and native preparation/merge passed. The [fresh landed-source live verification and inspected video](https://github.com/openclaw/openclaw/pull/136845#issuecomment-5520699168) confirm the 20-child Swarm completion flow; retained HTTP warnings and the explicit-enable proof boundary are documented there. The Testbox and temporary remote proof branch were cleaned up.

<details>
<summary>Additional instructions</summary>

Maintainer edits are available on this repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where users composing larger Swarm Code Mode fan-outs receive `too many pending code mode tool calls` for the entire cell. Progress notes and collector wait transitions share those slots, so callers otherwise need manual batching and spare capacity even when the Swarm child scheduler has room to queue work.

## Why This Change Was Made

Swarm requests now queue **before bridge admission**, using the existing guest controller and its bounded QuickJS snapshot. Settling a request or canceling a timer admits the next queued request. Method-specific IDs and serialized arguments are captured at invocation time, and queued work disappears with its closed run.

The host bridge cap is unchanged. Raw tool batches retain the intentional all-or-nothing overflow refusal, so an oversized mutation batch still dispatches nothing. This is not a second host scheduler, retry path, persistent store, or new permission grant.

## User Impact

Parallel `agents.run` calls, phase/log notes, and collector waits can make progress under the existing bridge limit. Each independent item can retain its success or failure through `Promise.allSettled`, including across partial snapshot resumes. Stop and catalog closure prevent queued launches from starting.

Swarm's default, Code Mode enablement, child concurrency/group limits, SDK exports, configuration surface, protocol, and dependencies are unchanged. The separate native collector-availability repair and default-on rollout are not included.

## Evidence

- Before: three real-worker pipeline cases failed on unmodified main `2bb2f63a435f03902b49b65c2411776837a62c46`: 3 items/1 bridge slot, 6 items/2 slots, and 20 items/default 16 slots. Each returned the exact bridge-overflow error.
- After: the full explicit Code Mode family passed **871 tests across 35 files and three shards**. The runner received every discovered `src/agents/code-mode*.test.ts` file, equivalent to:

  ```bash
  node scripts/run-vitest.mjs src/agents/code-mode*.test.ts
  ```

- Coverage includes one failed child with every other item completing exactly once, last-first partial settlement, invocation-time argument retention, canceled timer capacity, abort and catalog closure with 16 admitted plus four queued launches, raw overflow/no dispatch, warm workers, snapshots, namespaces, headless execution, fetch, output, and replay.
- `node scripts/check-changed.mjs` passed, including core and test typechecking, scoped lint/format, zero unused-export findings, import cycles, and boundary guards.
- `node scripts/report-test-temp-creations.mjs --staged --json --fail-on-findings` passed.
- Independent Codex autoreview through P2: scoped-clean, no accepted/actionable findings. The reviewer did not rerun tests.
- Installed QuickJS 3.5.0 snapshot/restore and named callback source was inspected directly. The original raw-overflow safety repair was checked against its raw parent; this PR preserves that invariant.

### Rebased landing candidate

Head `fdaf62b2d63be3073f6bb1ec784a5ce7b1813f3b` is a patch-identical rebase onto main `56d40589c699b79e5c7a1bc9ec086d2b2feecb1a` (`git range-diff` reports `=`). The old startup blocker was resolved upstream by [the landed Control UI baseline reconciliation](https://github.com/openclaw/openclaw/pull/136817), not by a budget change in this PR.

Fresh validation on the rebased candidate passed: **871 tests / 35 files / three shards** in 66.96 seconds; the explicit eight-path changed-check plan; and the full `pnpm build` in 4m46.5s. Startup gzip measured **349549 B <= 350141 B**, using main's existing 349565 B baseline and unchanged allowances. Fresh independent Codex autoreview through P2 is scoped-clean (confidence 0.88), with no accepted findings. Source remained unchanged through validation and review.

[Exact-head CI run 33713412076](https://github.com/openclaw/openclaw/actions/runs/33713412076) and the native preparation/merge gates passed. The inspected recording below remains correctly bound to the previous published head with the identical Swarm patch. The fresh post-merge recording and exact landed-source results are linked in the completion note above.

### Real Gateway / Control UI proof

The exact published head `cd84fd2150b4ecb56b56c444662acc72b412d231` passed a real OpenAI, **20-child Code Mode fan-out** on an isolated Linux Gateway through Crabbox's Blacksmith Testbox backend. One unchanged `exec` program launched all 20 children; the bridge returned all 20 exact results, and the parent final followed collection. The observer matched 20 positive terminal events to the exact child run/session identities and independently verified completed tasks and terminal histories. The UI probe expanded the real sidebar pagination, inspected all 20 Done rows, preserved the original parent, and finished with an idle composer.

The original 26.44-second recording and all three full-resolution screenshots were inspected: synthetic tasks only, no secrets, private data, internal model identifiers, or unrelated desktop content. Video SHA-256: `0ea8a5c78431a135e179123cc87b261e6a9182df18dff5b8c615f7d02d3a45ca`.

https://github.com/user-attachments/assets/12c2f019-19e8-4d8a-be05-4c0c84db57a5

- Backing Testbox run: [33706984495](https://github.com/openclaw/openclaw/actions/runs/33706984495); lease `tbx_01m1jgtee43rzj7dtx0yftjyam` independently confirmed completed after cleanup.
- Trial `completion-03`: assertions passed, command exit 0 in 36.146 seconds; Gateway, driver, and validation process groups joined without force; private state removed; source/config unchanged.
- This proves the explicit `tools.swarm: true` / Code Mode path with a coached exact program and plain-text child results. It is **not** default-on, uncoached reasoning, durable restart replay, live cancellation, physical guest-exit, or exhaustive stress proof.
- Zero page errors. One optional workspace-icon request returned 404 during login; it did not block the flow.
- Preserved failures: the first UI attempt stopped at missing Chromium cache before starting a Gateway or making model calls. After installing the repository-pinned browser, trial `completion-02` completed all 20 children correctly but failed the final UI assertion because the probe expected paginated rows to be immediately visible. Trial 03 used the actual Show more control and scrolled every row; no production changes or weakened result/lifecycle assertions were used to obtain the pass.

### Historical build and CI results on the original head

A fresh exact-head Linux checkout on that Testbox passed the complete `pnpm build` in 2m53.2s, including the startup gzip gate: **349220 B <= 349244 B**. Build ID: `2026.8.1-cd84fd2150b4-2026-09-03T02-20-35.882Z`.

The earlier local `pnpm build` remains a failure: runtime compilation, declarations, SDK generation/export checks, and UI compilation passed, then startup gzip measured **349276 B > 349244 B**. The untouched base's `pnpm ui:build` also failed at **349261 B**. None of this PR's changed Code Mode modules occurs in the UI sourcemaps. An initial remote network-clone setup failed before compilation; the successful build used an exact-SHA clone of the authenticated native Testbox checkout, without copying credentials.

**Original-head failure (preserved):** [exact-head CI run 33706655645](https://github.com/openclaw/openclaw/actions/runs/33706655645) failed the merged-tree build at **349564 B > 349244 B**. Its first attempt also failed `ui/src/components/session-progress-card.test.ts` (`refreshes relative time while connected and stops after disconnect`: expected zero timers, observed one). After the reproduction controls below, [the single targeted test-job rerun passed](https://github.com/openclaw/openclaw/actions/runs/33706655645/job/100508123734) on the unchanged head, finishing September 3 at 03:15:14 UTC. No test assertion or production code was changed to obtain that result; the original timer failure remains unexplained, not claimed fixed. The successful exact-head build/live trial and green test rerun do not override the remaining failed build/CI gate.

[The existing login-recovery lazy-loading PR](https://github.com/openclaw/openclaw/pull/135010) targets startup headroom and remains open/draft. No performance baseline or threshold has been raised. These failures remain recorded, not relabeled as passing.

### Review follow-through

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/136845#issuecomment-5519711619) found no actionable correctness/security defect and retained the guest-controller design. Its CI rank-up item was satisfied by green CI on the rebased head; the following preserves the original-head test-job recovery. The failed `checks-node-compact-large-2` job passed its one bounded rerun after the original 268-file/4364-test cohort passed twice on macOS at the PR head, once on Linux at the PR head, and once on macOS at the exact CI merge `013e539e5e7e2951327a3dd799c7fe957d8c5935`. Temporary failure-only timer diagnostics emitted nothing and were removed. No timer fix or exact worker execution-order reproduction is claimed by those controls. The second attempt carries forward the original build failure; its retained build log is byte-identical to the first attempt, not evidence of another build execution.

The review's automated persistent-data-model flag does **not** describe a storage or upgrade change. QuickJS snapshots remain transient: `CodeModeRunState.snapshot` is held in the process-local `activeRuns` map (`src/agents/code-mode-state.ts:42-69,453-522`), and close/disposal deletes it (`:87-101,199-213`). There is no database/file serialization owner or migration in this patch. The existing [snapshot lifecycle contract](https://docs.openclaw.ai/tools/code-mode#run-and-snapshot-lifecycle) explicitly discards snapshots on Gateway shutdown; same-process resumption of queued state is covered by the worker tests. No cross-version snapshot import is introduced, so adding a persistent migration would be incorrect.

### Change size

Production **+17 net lines** (+29/−12); tests **+190**; docs **+6**. The small production growth supplies queue admission inside the existing owner while retaining the independent raw-tool safety boundary. No new production module or exported API is added.
