### PR TITLE
perf(agents): scan tool-call text candidates lazily

### DIFF
--- a/src/shared/text/tool-call-shaped-text.test.ts
+++ b/src/shared/text/tool-call-shaped-text.test.ts
@@ -10,13 +10,17 @@ describe("detectToolCallShapedText", () => {
     });
   });
 
-  it("detects fenced tool_calls JSON", () => {
-    expect(
-      detectToolCallShapedText(
-        '```json\n{"tool_calls":[{"function":{"name":"web_search","arguments":{"query":"x"}}}]}\n```',
-      ),
-    ).toEqual({ kind: "json_tool_call", toolName: "web_search" });
-  });
+  it.each(["", '{"name":"earlier","arguments":{}}\n'])(
+    "prefers fenced tool_calls JSON after %j",
+    (prefix) => {
+      expect(
+        detectToolCallShapedText(
+          prefix +
+            '```json\n{"tool_calls":[{"function":{"name":"web_search","arguments":{"query":"x"}}}]}\n```',
+        ),
+      ).toEqual({ kind: "json_tool_call", toolName: "web_search" });
+    },
+  );
 
   it("detects XML and ReAct-style tool text", () => {
     expect(

--- a/src/shared/text/tool-call-shaped-text.ts
+++ b/src/shared/text/tool-call-shaped-text.ts
@@ -82,18 +82,6 @@ function classifyJsonValue(value: unknown): ToolCallShapedTextDetection | null {
   return null;
 }
 
-function collectFencedJsonCandidates(text: string): string[] {
-  const candidates: string[] = [];
-  const fenceRe = /```(?:json|tool|tool_call|function_call)?[^\n\r]*[\r\n]([\s\S]*?)```/gi;
-  for (const match of text.matchAll(fenceRe)) {
-    const candidate = match[1]?.trim();
-    if (candidate && candidate.length <= MAX_JSON_CANDIDATE_CHARS) {
-      candidates.push(candidate);
-    }
-  }
-  return candidates;
-}
-
 function findBalancedJsonEnd(text: string, start: number): number | null {
   const opening = text[start];
   const closing = opening === "{" ? "}" : opening === "[" ? "]" : "";
@@ -142,9 +130,18 @@ function findBalancedJsonEnd(text: string, start: number): number | null {
   return null;
 }
 
-function collectBalancedJsonCandidates(text: string): string[] {
-  const candidates: string[] = [];
-  for (let index = 0; index < text.length && candidates.length < MAX_JSON_CANDIDATES; index += 1) {
+function* iterateJsonCandidates(text: string): Generator<string> {
+  // Fenced candidates take precedence even when balanced JSON appears earlier.
+  const fenceRe = /```(?:json|tool|tool_call|function_call)?[^\n\r]*[\r\n]([\s\S]*?)```/gi;
+  for (const match of text.matchAll(fenceRe)) {
+    const candidate = match[1]?.trim();
+    if (candidate && candidate.length <= MAX_JSON_CANDIDATE_CHARS) {
+      yield candidate;
+    }
+  }
+
+  let count = 0;
+  for (let index = 0; index < text.length && count < MAX_JSON_CANDIDATES; index += 1) {
     const ch = text[index];
     if (ch !== "{" && ch !== "[") {
       continue;
@@ -155,16 +152,15 @@ function collectBalancedJsonCandidates(text: string): string[] {
     }
     const candidate = text.slice(index, end).trim();
     if (candidate.length > 1) {
-      candidates.push(candidate);
+      count += 1;
+      yield candidate;
     }
     index = end - 1;
   }
-  return candidates;
 }
 
 function detectJsonToolCall(text: string): ToolCallShapedTextDetection | null {
-  const candidates = [...collectFencedJsonCandidates(text), ...collectBalancedJsonCandidates(text)];
-  for (const candidate of candidates) {
+  for (const candidate of iterateJsonCandidates(text)) {
     try {
       const detection = classifyJsonValue(JSON.parse(candidate));
       if (detection) {


### PR DESCRIPTION
## What Problem This Solves

Malformed tool-call diagnostics collected every fenced and balanced JSON candidate before checking the first result. Consume one private iterator instead, preserving fenced-first priority, all existing bounds, classification, and warning metadata. This removes three temporary candidate arrays; an early match also avoids later scans.

## Why This Change Was Made

The detector consumes candidates only until classification succeeds, keeping the same owner, precedence and bounds.

## User Impact

Malformed tool-call warnings keep their current behavior while avoiding unnecessary scans and temporary candidate arrays.

## Evidence

The actual-source corpus preserves 26 detector outputs and seven real warning-callback cases. The existing fenced test now also covers an earlier balanced JSON call without losing its original case. Focused tests: 30 passed. Managed P2 review: scoped-clean. Canonical changed gate: passed.

One fixed four-pair source benchmark showed median paired elapsed changes of −67.35% for early fenced success and −23.10% for late fenced success. Negative fenced input was +5.70% (+1.71 µs/call), and balanced success +1.86% (+0.37 µs/call). Cumulative isolate allocation decreased for the three fenced workloads; it increased slightly for balanced success. These are bounded source-workload results, not Gateway or idle-memory measurements. No resampling was performed.

Production: −4 lines. Tests: +4 lines. Total: unchanged.
