### PR TITLE
perf(llm): release consumed stream payloads immediately

### DIFF
--- a/packages/llm-core/src/utils/event-stream.retention.test-support.ts
+++ b/packages/llm-core/src/utils/event-stream.retention.test-support.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { EventStream } from "./event-stream.js";
+
+const gc = globalThis.gc;
+assert.ok(gc, "The retention child requires --expose-gc");
+const control = new WeakRef({ uncached: true });
+
+async function consumeFirst(completed: boolean) {
+  const stream = new EventStream<{ index: number }, { complete: boolean }>(
+    () => false,
+    () => {
+      throw new Error("No terminal event is used by this fixture");
+    },
+  );
+  const consumed = { index: 0 };
+  const pending = { index: 1 };
+  const final = { complete: true };
+  stream.push(consumed);
+  stream.push(pending);
+  if (completed) {
+    stream.end(final);
+  }
+  const iterator = stream[Symbol.asyncIterator]();
+  assert.deepEqual(await iterator.next(), { value: consumed, done: false });
+  await iterator.return?.();
+  return {
+    completed,
+    stream,
+    consumed: new WeakRef(consumed),
+    pending: new WeakRef(pending),
+    final: new WeakRef(final),
+  };
+}
+
+const held = [await consumeFirst(false), await consumeFirst(true)];
+// Dereferencing during collection would keep the target alive for that job.
+for (let pass = 0; pass < 8; pass += 1) {
+  gc();
+  await setImmediate();
+}
+assert.equal(control.deref(), undefined, "The uncached GC control must be collected");
+const observed = held.map(({ completed, consumed, final }) => ({
+  completed,
+  consumedRetained: consumed.deref() !== undefined,
+  finalRetained: final.deref() !== undefined,
+}));
+for (const { stream, pending } of held) {
+  assert.ok(pending.deref(), "The unread event remains owned by the stream");
+  const iterator = stream[Symbol.asyncIterator]();
+  assert.deepEqual(await iterator.next(), { value: pending.deref(), done: false });
+  await iterator.return?.();
+  stream.end({ complete: true });
+  assert.deepEqual(await stream.result(), { complete: true });
+}
+process.stdout.write(JSON.stringify(observed));

--- a/packages/llm-core/src/utils/event-stream.test.ts
+++ b/packages/llm-core/src/utils/event-stream.test.ts
@@ -1,4 +1,6 @@
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { runNodeScript } from "../../../../test/helpers/run-node-script.js";
 import { EventStream } from "./event-stream.js";
 
 function createNumberStream(): EventStream<number, number> {
@@ -9,6 +11,33 @@ function createNumberStream(): EventStream<number, number> {
 }
 
 describe("EventStream", () => {
+  it("releases consumed events while retaining unread events and the final result", async ({
+    signal,
+  }) => {
+    const result = await runNodeScript(
+      [
+        "--expose-gc",
+        "--import",
+        "tsx",
+        fileURLToPath(new URL("./event-stream.retention.test-support.ts", import.meta.url)),
+      ],
+      { ...process.env, NODE_OPTIONS: "", TSX_DISABLE_CACHE: "1" },
+      15_000,
+      {
+        cwd: fileURLToPath(new URL("../../../../", import.meta.url)),
+        signal,
+        maxBuffer: 64 * 1024,
+        requireProcessTreeExit: process.platform !== "win32",
+      },
+    );
+    expect(result.error, result.stderr).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual([
+      { completed: false, consumedRetained: false, finalRetained: false },
+      { completed: true, consumedRetained: false, finalRetained: true },
+    ]);
+  }, 30_000);
+
   it("preserves interleaved queued and waiting push/pull order", async () => {
     const stream = createNumberStream();
     const iterator = stream[Symbol.asyncIterator]();

--- a/packages/llm-core/src/utils/event-stream.ts
+++ b/packages/llm-core/src/utils/event-stream.ts
@@ -1,4 +1,3 @@
-// LLM Core module implements event stream behavior.
 import type {
   AssistantMessage,
   AssistantMessageEvent,
@@ -7,33 +6,25 @@ import type {
 
 /** Generic async-iterable event stream with a separately awaited final result. */
 export class EventStream<T, R = T> implements AsyncIterable<T> {
-  private queue: T[] = [];
+  private queue: (T | undefined)[] = [];
   private queueHead = 0;
   private waiting: ((value: IteratorResult<T>) => void)[] = [];
   private done = false;
   private resultSettled = false;
   private finalResultPromise: Promise<R>;
-  private resolveFinalResult: (result: R) => void;
-  private rejectFinalResult: (error: Error) => void;
+  // Promise invokes its executor before construction returns.
+  private resolveFinalResult!: (result: R) => void;
+  private rejectFinalResult!: (error: Error) => void;
   private isComplete: (event: T) => boolean;
   private extractResult: (event: T) => R;
 
   constructor(isComplete: (event: T) => boolean, extractResult: (event: T) => R) {
     this.isComplete = isComplete;
     this.extractResult = extractResult;
-    const resolvers: Array<(result: R) => void> = [];
-    const rejecters: Array<(error: Error) => void> = [];
     this.finalResultPromise = new Promise((resolve, reject) => {
-      resolvers.push(resolve);
-      rejecters.push(reject);
+      this.resolveFinalResult = resolve;
+      this.rejectFinalResult = reject;
     });
-    const resolveFinalResult = resolvers.at(0);
-    const rejectFinalResult = rejecters.at(0);
-    if (!resolveFinalResult || !rejectFinalResult) {
-      throw new Error("event stream result promise did not initialize its resolver");
-    }
-    this.resolveFinalResult = resolveFinalResult;
-    this.rejectFinalResult = rejectFinalResult;
   }
 
   push(event: T): void {
@@ -85,6 +76,8 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
     while (true) {
       if (this.queueHead < this.queue.length) {
         const event = this.queue[this.queueHead] as T;
+        // The consumer owns this event now; compaction must not delay payload release.
+        this.queue[this.queueHead] = undefined;
         this.queueHead += 1;
         // Compact only after a substantial consumed prefix reaches half the
         // backing array, keeping dequeue amortized O(1) when consumers lag.


### PR DESCRIPTION
## What Problem This Solves

A retained EventStream also retained already consumed events until its amortized queue compaction ran. A short stream could therefore keep every consumed payload alive after its iterator finished. Clear each dequeued slot while preserving the cursor and compaction policy; unread events and the separately awaited final result keep their existing ownership. The constructor also initializes its resolvers directly in the synchronous Promise executor, removing two temporary arrays and their impossible initialization guard.

## Why This Change Was Made

Release consumed payloads at the queue owner, keeping final-result ownership separate. This preserves the public stream API and amortized dequeue behavior.

## User Impact

Keeping a drained stream reachable no longer keeps all of its consumed events reachable.

## Evidence

The new regression uses public iteration in an isolated GC child, rather than inspecting queue internals. On the original owner both open and completed streams reported `consumedRetained: true`; the repair reports `false`, while unread events remain deliverable and completed results remain retained.

A separate before/after actual-owner witness used two retained streams with 64 unique 128 KiB synthetic payloads each. After draining and closing the iterators, raw heap snapshots showed:

| Scoped checkpoint | Before | After |
| --- | ---: | ---: |
| Consumed event objects | 128 | 0 |
| Payload string self-size | 16,779,264 B | 0 B |
| Event object self-size | 6,144 B | 0 B |
| Tiny final-result objects | 1 | 1 |

The baseline retainer is `EventStream → queue → array element → event → payload`. Both arms release payloads after their stream owners are released; holding only the result promise continues to hold its result. This is one synthetic owner-retention pair, not a Gateway RSS, latency, or dominator-size claim.

Reproduce the regression and adapter coverage with:

```sh
node scripts/run-vitest.mjs packages/llm-core/src/utils/event-stream.test.ts src/llm/stream.test.ts src/agents/custom-api-registry.test.ts
```

All 12 tests pass; the regression fails on the pre-fix owner. The production changed gate and managed P0–P2 review passed. The final test/support-only changed gate also passed. Production +8/−15 (net −7); tests +29 and isolated test support +56. No new API, configuration, dependency, or production test seam.


A real OpenAI Responses request through the changed provider/stream composition completed successfully with seven events. After draining, none of those event objects remained reachable through WeakRefs; the final result remained available. The probe asserted that the actual provider used the exact changed EventStream constructor. An earlier baseline live probe failed its combined assertion without recording which assertion; it is retained as inconclusive and is not a successful before/after comparison. The candidate probe added terminal diagnostics without changing the request or success assertions.
