### PR TITLE
perf(plugins): extract package basenames without splitting

### DIFF
--- a/src/infra/install-safe-path.ts
+++ b/src/infra/install-safe-path.ts
@@ -10,10 +10,7 @@ export {
 /** Returns the package basename for scoped npm names while preserving plain ids. */
 export function unscopedPackageName(name: string): string {
   const trimmed = name.trim();
-  if (!trimmed) {
-    return trimmed;
-  }
-  return trimmed.includes("/") ? (trimmed.split("/").pop() ?? trimmed) : trimmed;
+  return trimmed.slice(trimmed.lastIndexOf("/") + 1);
 }
 
 /** Matches a requested install id against either the full package name or unscoped basename. */


### PR DESCRIPTION
## What Problem This Solves

The shared package-name helper scans for a slash, splits the entire name into an array, and removes its last element just to obtain a suffix. Plugin and hook installation and update identity matching all use this helper.

## Why This Change Was Made

Slice after the final slash directly. This removes the temporary split array, a redundant empty-input branch, and the impossible missing-array-element fallback. Existing input trimming and caller validation are unchanged.

Production LOC: +1/-4 (net -3); tests unchanged.

## User Impact

Package identity matching does less temporary work and returns the same names.

## Evidence

- 24 existing path/helper tests passed, along with four existing real directory-install cases covering scoped package/manifest identity and legacy unscoped update keys.
- Actual-source before/after probes matched for 15 cases, including whitespace, empty input, trailing and repeated slashes, backslashes and Unicode; five identity-matching checks also passed.
- The complete changed-file gate passed. Independent Codex review through P2 was scoped clean.
- The improvement removes a split array and unnecessary branches. No elapsed-time, retained-heap or Gateway RSS reduction is claimed for this helper.
