### PR TITLE
fix(mcp-transport): report discarded MCP stderr line bytes

### DIFF
--- a/src/agents/mcp-transport.test.ts
+++ b/src/agents/mcp-transport.test.ts
@@ -1,7 +1,9 @@
 // Covers MCP HTTP transport redirects, SSRF guardrails, and auth/TLS handoff.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { logDebug } from "../logger.js";
 import { partitionMcpServersByConnectionScope } from "./mcp-connection-resolver.js";
 import type { McpOAuthIdentity } from "./mcp-oauth-identity.js";
+import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
 
 type StreamableTransportOptions = {
@@ -66,6 +68,44 @@ vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
     sseTransportConstructorMock(url, options);
   },
 }));
+
+vi.mock("../logger.js", () => ({
+  logDebug: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+vi.mock("./mcp-stdio-transport.js", () => {
+  function createMockStderr() {
+    const listeners: Record<string, Array<(data?: unknown) => void>> = {};
+    return {
+      on(event: string, handler: (data?: unknown) => void) {
+        (listeners[event] ??= []).push(handler);
+        return this;
+      },
+      off(event: string, handler: (data?: unknown) => void) {
+        const list = listeners[event];
+        if (list) {
+          const index = list.indexOf(handler);
+          if (index >= 0) {
+            list.splice(index, 1);
+          }
+        }
+        return this;
+      },
+      push(data: string) {
+        listeners.data?.forEach((handler) => handler(Buffer.from(data)));
+      },
+      end() {
+        listeners.end?.forEach((handler) => handler());
+      },
+    };
+  }
+  return {
+    OpenClawStdioClientTransport: vi.fn(function Mock(this: unknown, _options: { stderr: "pipe" }) {
+      return { stderr: createMockStderr() };
+    }),
+  };
+});
 
 function redirectResponse(location: string, status = 302): Response {
   return new Response(null, {
@@ -434,5 +474,46 @@ describe("resolveMcpTransport", () => {
     );
     expect(authKeys).toEqual(["authorization"]);
     expect(sentHeaders.authorization).toBe("Bearer operator");
+  });
+});
+
+describe("attachStderrLogging", () => {
+  function latestStdioStderr(): { push(data: string): void; end(): void } {
+    const result = vi.mocked(OpenClawStdioClientTransport).mock.results.at(-1);
+    if (!result || result.type === "throw") {
+      throw new Error("Expected stdio transport to be constructed");
+    }
+    return (result.value as { stderr: { push(data: string): void; end(): void } }).stderr;
+  }
+
+  beforeEach(() => {
+    vi.mocked(logDebug).mockClear();
+    vi.mocked(OpenClawStdioClientTransport).mockClear();
+  });
+
+  it("reports discarded bytes when a pending stderr line exceeds the 8 KiB cap", () => {
+    const result = resolveMcpTransport("probe", { command: "true" });
+    const stderr = latestStdioStderr();
+    const longLine = "x".repeat(9000);
+    const tail = "x".repeat(8192);
+    stderr.push(`${longLine}\n${longLine}`);
+    result?.detachStderr?.();
+
+    const discardMessage = `bundle-mcp:probe: [808 UTF-8 bytes of earlier stderr line discarded at the 8192-byte cap] ${tail}`;
+    expect(logDebug).toHaveBeenCalledTimes(2);
+    expect(logDebug).toHaveBeenNthCalledWith(1, discardMessage);
+    expect(logDebug).toHaveBeenNthCalledWith(2, discardMessage);
+  });
+
+  it("does not add a discard note when stderr lines fit within the cap", () => {
+    const result = resolveMcpTransport("probe", { command: "true" });
+    expect(result).not.toBeNull();
+    expect(result?.detachStderr).toBeTypeOf("function");
+    const stderr = latestStdioStderr();
+    stderr.push("hello\nworld");
+    result?.detachStderr?.();
+
+    expect(logDebug).toHaveBeenCalledWith("bundle-mcp:probe: hello");
+    expect(logDebug).toHaveBeenLastCalledWith("bundle-mcp:probe: world");
   });
 });

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -45,12 +45,16 @@ function attachStderrLogging(serverName: string, transport: OpenClawStdioClientT
   }
   const decoder = new StringDecoder("utf8");
   let pending = "";
-  let truncated = false;
+  let pendingDroppedBytes = 0;
   let progressTimer: ReturnType<typeof setTimeout> | undefined;
-  const emit = (text: string) => {
+  const emit = (text: string, droppedBytes: number) => {
     const tail = truncateUtf8Suffix(text, MAX_MCP_STDERR_LINE_BYTES);
-    const message = `${truncated || tail !== text ? "[stderr line truncated] " : ""}${tail}`.trim();
-    truncated = false;
+    const lineDroppedBytes = droppedBytes + Buffer.byteLength(text) - Buffer.byteLength(tail);
+    const note =
+      lineDroppedBytes > 0
+        ? `[${lineDroppedBytes} UTF-8 bytes of earlier stderr line discarded at the ${MAX_MCP_STDERR_LINE_BYTES}-byte cap] `
+        : "";
+    const message = `${note}${tail}`.trim();
     if (message) {
       logDebug(`bundle-mcp:${serverName}: ${message}`);
     }
@@ -58,18 +62,25 @@ function attachStderrLogging(serverName: string, transport: OpenClawStdioClientT
   const flushProgress = () => {
     progressTimer = undefined;
     const text = pending;
+    const droppedBytes = pendingDroppedBytes;
     pending = "";
-    emit(text);
+    pendingDroppedBytes = 0;
+    emit(text, droppedBytes);
   };
   const onData = (chunk: Buffer | string) => {
     const decoded = decoder.write(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
     const lines = (pending + decoded).split(/[\r\n]/);
     pending = lines.pop() ?? "";
-    for (const line of lines) {
-      emit(line);
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      if (line === undefined) {
+        continue;
+      }
+      emit(line, index === 0 ? pendingDroppedBytes : 0);
     }
+    pendingDroppedBytes = 0;
     const tail = truncateUtf8Suffix(pending, MAX_MCP_STDERR_LINE_BYTES);
-    truncated ||= tail !== pending;
+    pendingDroppedBytes += Buffer.byteLength(pending) - Buffer.byteLength(tail);
     pending = tail;
     // No-newline progress must stay visible even under continuous writes. Flush
     // complete characters within 250ms; only finalization ends the UTF-8 decoder.


### PR DESCRIPTION
## What Problem This Solves

`src/agents/mcp-transport.ts` truncates stdio MCP stderr lines to `MAX_MCP_STDERR_LINE_BYTES` (8 KiB) but only logs a generic `[stderr line truncated]` flag. Operators cannot tell whether truncation happened or how much data was lost, which makes noisy/long-running MCP servers hard to debug.

## Changes

- `src/agents/mcp-transport.ts`: `attachStderrLogging` now tracks UTF-8 bytes discarded by `truncateUtf8Suffix` and reports the count in the debug log (e.g. `[808 UTF-8 bytes of earlier stderr line discarded at the 8192-byte cap]`).
- `src/agents/mcp-transport.test.ts`: added inline tests for the discard note and for lines that fit within the cap.

## Real behavior proof

- **Behavior addressed**: MCP stderr lines exceeding the 8 KiB cap now report the exact number of discarded UTF-8 bytes.
- **Real environment tested**: Debian 12 Docker (`lexiflow-all:latest`) on 10.54.159.54, Node 24.18.0, OpenClaw `/data/openclaw-run` synced from local working tree.
- **Exact steps or command run after this patch**:
  ```bash
  docker run --rm -v /data/openclaw-run:/ws -v /data/openclaw-node:/node -w /ws --user 1000:1000 lexiflow-all:latest /node/bin/node scripts/run-vitest.mjs src/agents/mcp-transport.test.ts --run
  docker run --rm -v /data/openclaw-run:/ws -v /data/openclaw-node:/node -w /ws --user 1000:1000 lexiflow-all:latest /node/bin/node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/mcp-transport.ts src/agents/mcp-transport.test.ts
  docker run --rm -v /data/openclaw-run:/ws -v /data/openclaw-node:/node -w /ws --user 1000:1000 lexiflow-all:latest /node/bin/node scripts/run-tsgo.mjs --project tsconfig.core.json
  ```
- **Evidence after fix**:
  ```
  ✓ attachStderrLogging > reports discarded bytes when a pending stderr line exceeds the 8 KiB cap
  ✓ attachStderrLogging > does not add a discard note when stderr lines fit within the cap
  Test Files  1 passed (1)
  Tests  14 passed (14)
  Found 0 warnings and 0 errors. [oxlint]
  [tsgo core project] exit 0
  ```
- **Observed result after fix**: a 9,000-byte stderr line produces the log `[808 UTF-8 bytes of earlier stderr line discarded at the 8192-byte cap] xxxx...`; a `hello\nworld` line logs the two lines without any discard note.
- **What was not tested**: live stdio MCP server integration; the change is covered by unit tests and follows the same helper pattern as `cli-runner`/`provider-local-service` diagnostics.

## Out of scope

- `provider-local-service.ts` stderr discard reporting was considered but the file already exceeds the 700-line `max-lines` lint limit, so it is left untouched.
- `cli-runner` stderr discard reporting is handled separately in PR #136775.

## Risk

Low. This is a additive diagnostic-only change to debug log text; it does not alter transport behavior, error handling, or config defaults.



Fixes #136853
