### PR TITLE
fix(auto-reply): emit one terminal outcome after finalization

### DIFF
--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -51,6 +51,7 @@ const createReplyMediaPathNormalizerMock = vi.fn();
 const runSessionCompactionIfNeededMock = vi.fn();
 const runMemoryFlushIfNeededMock = vi.fn();
 const executeAgentTurnMock = vi.fn();
+const finalizeReplyAgentRunMock = vi.fn();
 const prepareGitCoauthorAttributionMock = vi.fn();
 const resetReplyRunSessionMock = vi.fn();
 const enqueueFollowupRunMock = vi.fn();
@@ -101,6 +102,10 @@ vi.mock("./agent-runner-execution.js", async () => {
     executeAgentTurn: (...args: unknown[]) => executeAgentTurnMock(...args),
   };
 });
+
+vi.mock("./agent-runner-result.js", () => ({
+  finalizeReplyAgentRun: (...args: unknown[]) => finalizeReplyAgentRunMock(...args),
+}));
 
 vi.mock("../../agents/git-coauthor-attribution.js", async () => {
   const actual = await vi.importActual<typeof import("../../agents/git-coauthor-attribution.js")>(
@@ -282,6 +287,7 @@ describe("runReplyAgent runtime config", () => {
     runSessionCompactionIfNeededMock.mockReset();
     runMemoryFlushIfNeededMock.mockReset();
     executeAgentTurnMock.mockReset();
+    finalizeReplyAgentRunMock.mockReset();
     prepareGitCoauthorAttributionMock.mockReset();
     resetReplyRunSessionMock.mockReset();
     enqueueFollowupRunMock.mockReset();
@@ -296,8 +302,73 @@ describe("runReplyAgent runtime config", () => {
       runId: "runtime-config-test",
       outcome: { kind: "rejected", payload: { text: "main reply" } },
     });
+    finalizeReplyAgentRunMock.mockResolvedValue(undefined);
     prepareGitCoauthorAttributionMock.mockReturnValue(undefined);
     resetReplyRunSessionMock.mockResolvedValue(false);
+  });
+
+  function createTerminalOutcomeFixture() {
+    const { replyParams } = createDirectRuntimeReplyParams({
+      shouldFollowup: false,
+      isActive: false,
+    });
+    const onAgentRunTerminalOutcome = vi.fn();
+    replyParams.opts = { onAgentRunTerminalOutcome };
+    return {
+      onAgentRunTerminalOutcome,
+      run: () => runReplyAgent(replyParams),
+      completeAgentTurn: () => {
+        runSessionCompactionIfNeededMock.mockResolvedValue(undefined);
+        executeAgentTurnMock.mockImplementationOnce(
+          async (params: {
+            opts?: { onAgentRunTerminalOutcome?: (outcome: "completed" | "failed") => void };
+          }) => {
+            params.opts?.onAgentRunTerminalOutcome?.("completed");
+            return {
+              runId: "runtime-config-test",
+              outcome: {
+                kind: "settled" as const,
+                status: "ok" as const,
+                result: { payloads: [], meta: {} },
+                resolved: { provider: "openai", model: "gpt-5.4" },
+                fallback: { exhausted: false, attempts: [] },
+                autoCompactionCount: 0,
+                didLogHeartbeatStrip: false,
+              },
+            };
+          },
+        );
+      },
+    };
+  }
+
+  it("does not report a terminal outcome when pre-run preparation throws", async () => {
+    const fixture = createTerminalOutcomeFixture();
+
+    await expect(fixture.run()).rejects.toBe(sentinelError);
+
+    expect(fixture.onAgentRunTerminalOutcome).not.toHaveBeenCalled();
+    expect(executeAgentTurnMock).not.toHaveBeenCalled();
+  });
+
+  it("upgrades a buffered completion when finalization throws", async () => {
+    const fixture = createTerminalOutcomeFixture();
+    fixture.completeAgentTurn();
+    finalizeReplyAgentRunMock.mockRejectedValueOnce(sentinelError);
+
+    await expect(fixture.run()).rejects.toBe(sentinelError);
+
+    expect(fixture.onAgentRunTerminalOutcome).toHaveBeenCalledExactlyOnceWith("failed");
+  });
+
+  it("reports one completed outcome after successful finalization", async () => {
+    const fixture = createTerminalOutcomeFixture();
+    fixture.completeAgentTurn();
+    finalizeReplyAgentRunMock.mockResolvedValueOnce({ text: "done" });
+
+    await expect(fixture.run()).resolves.toEqual({ text: "done" });
+
+    expect(fixture.onAgentRunTerminalOutcome).toHaveBeenCalledExactlyOnceWith("completed");
   });
 
   it("resolves direct reply runs before early helpers read config", async () => {

--- a/src/auto-reply/reply/agent-runner-execute.ts
+++ b/src/auto-reply/reply/agent-runner-execute.ts
@@ -113,6 +113,38 @@ function markPostCompactionFailureResult(
 export async function executePreparedReplyAgentRun(
   context: ExecutePreparedReplyAgentRunInput,
 ): Promise<ReplyPayload | ReplyPayload[] | undefined> {
+  const onAgentRunTerminalOutcome = context.opts?.onAgentRunTerminalOutcome;
+  if (!onAgentRunTerminalOutcome) {
+    return executePreparedReplyAgentRunInner(context);
+  }
+
+  let terminalOutcome: "completed" | "failed" | undefined;
+  const bufferedContext = {
+    ...context,
+    opts: {
+      ...context.opts,
+      onAgentRunTerminalOutcome: (outcome: "completed" | "failed") => {
+        terminalOutcome = outcome === "failed" ? outcome : (terminalOutcome ?? outcome);
+      },
+    },
+  };
+  try {
+    return await executePreparedReplyAgentRunInner(bufferedContext);
+  } catch (error) {
+    if (terminalOutcome !== undefined) {
+      terminalOutcome = "failed";
+    }
+    throw error;
+  } finally {
+    if (terminalOutcome) {
+      onAgentRunTerminalOutcome(terminalOutcome);
+    }
+  }
+}
+
+async function executePreparedReplyAgentRunInner(
+  context: ExecutePreparedReplyAgentRunInput,
+): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const {
     activeSessionStore,
     admitUserTurn: admitUserTurnWithRecovery,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -750,7 +750,9 @@ describe("runReplyAgent auto-compaction token update", () => {
     async (_label, agentResult, fallback) => {
       const onAgentRunTerminalOutcome = vi.fn();
       const result = await runEmptyDirectReply(agentResult, { onAgentRunTerminalOutcome });
-      expect(onAgentRunTerminalOutcome).toHaveBeenLastCalledWith(fallback ? "failed" : "completed");
+      expect(onAgentRunTerminalOutcome).toHaveBeenCalledExactlyOnceWith(
+        fallback ? "failed" : "completed",
+      );
       if (!fallback) {
         expect(result).toBeUndefined();
         return;

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -4858,6 +4858,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("surfaces a configured backend failure when fallback returns no payloads", async () => {
+    const onAgentRunTerminalOutcome = vi.fn();
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [],
       meta: {},
@@ -4868,6 +4869,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
 
     try {
       const { run } = createMinimalRun({
+        opts: { onAgentRunTerminalOutcome },
         runOverrides: {
           provider: "lmstudio",
           model: "gemma-4-e4b-it",
@@ -4885,6 +4887,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       expect(payload?.text).toContain("configured model backend lmstudio/gemma-4-e4b-it");
       expect(payload?.text).toContain("Fallback used openai/gpt-5.5");
       expect(payload?.text).toContain("no visible reply");
+      expect(onAgentRunTerminalOutcome).toHaveBeenCalledExactlyOnceWith("failed");
     } finally {
       fallbackSpy.mockRestore();
     }


### PR DESCRIPTION
Related: #135177

## What Problem This Solves

Fixes an issue where terminal-outcome consumers could observe `completed` followed by `failed` when a reply initially completed but finalization later rejected an empty, directive-only, or silent-fallback result.

## Why This Change Was Made

`executeAgentTurn` reports its phase outcome before `finalizeReplyAgentRun` performs the final visible-payload checks. The prepared-run owner now buffers those internal observations, keeps failure sticky, and publishes exactly once after the full execute-and-finalize operation. Direct `executeAgentTurn` callers retain their existing behavior, and pre-run failures still publish no terminal outcome.

No changelog entry: this regression has not shipped.

## User Impact

Callers receive one authoritative terminal outcome for each prepared reply run: `failed` for late empty/fallback failures and `completed` for successful finalization.

## Evidence

Pre-fix reproduction:

```text
node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts -t 'accounts for empty interactive direct replies' --reporter=dot
```

Three late-failure cases failed because the callback was invoked twice, first with `completed` and then with `failed`. The intentional completion case passed.

Post-fix focused proof:

```text
PASS 3/3
node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts -t 'terminal outcome|buffered completion|successful finalization|pre-run preparation' --reporter=dot

PASS 4/4
node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts -t 'accounts for empty interactive direct replies' --reporter=dot
```

The targeted silent-fallback E2E assertion is included, but its focused invocation currently stops before Vitest during the unchanged browser plugin declaration build:

```text
extensions/browser/src/browser-tool.schema.ts: TS2883 inferred TypeBox declaration types are not portable
```

`check-changed` completed all scoped guards through the core graph boundary, then stopped in the unrelated core typecheck on mixed TypeBox `1.3.17`/`1.3.18` types. Diff-scoped autoreview found no actionable issue.

Production LOC: `+32/-0`. Tests: `+77/-1`.

Codex hard-gate inspection: `codex-rs/app-server/src/bespoke_event_handling.rs` at commit `5f49aba876922d6f2f55caa153bbb0ed1b46feba` confirms one `TurnComplete` maps to one terminal notification, with failed and interrupted outcomes remaining distinct.
