### PR TITLE
chore(backup): simplify JSON output assertions

### DIFF
--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -50,15 +50,6 @@ type CapturedBackupManifest = {
 describe("backup commands", () => {
   let tempHome: TempHomeEnv;
 
-  function requireFirstMockArg<T>(mock: { mock: { calls: T[][] } }, label: string): T {
-    const call = mock.mock.calls[0];
-    if (!call) {
-      throw new Error(`expected ${label} call`);
-    }
-    const [arg] = call;
-    return expectDefined(arg, "arg test invariant");
-  }
-
   async function mockWorkspaceBackupPlan(stateDir: string, workspaceDir: string, nowMs: number) {
     vi.spyOn(backupShared, "resolveBackupPlanFromDisk").mockResolvedValue(
       await resolveBackupPlanFromPaths({
@@ -398,13 +389,12 @@ describe("backup commands", () => {
 
       expect(result.skippedVolatileCount).toBe(1);
       expect(runtime.log).toHaveBeenCalledTimes(1);
-      const payload = requireFirstMockArg(vi.mocked(runtime.log), "runtime log");
+      const [payload] = expectDefined(vi.mocked(runtime.log).mock.calls[0], "runtime log call");
       if (typeof payload !== "string") {
         throw new Error("backup test expected JSON string output");
       }
       expect(payload).not.toContain("Backup skipped");
-      const parsedPayload = JSON.parse(payload) as { skippedVolatileCount?: unknown };
-      expect(parsedPayload.skippedVolatileCount).toBe(1);
+      expect(JSON.parse(payload)).toHaveProperty("skippedVolatileCount", 1);
     } finally {
       await fs.rm(backupDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What Problem This Solves

The backup JSON-output test has a one-use mock-argument wrapper and an unnecessary asserted JSON local, adding scaffolding around its existing output checks.

## Why This Change Was Made

Use the existing `expectDefined` helper for the first log call and assert `skippedVolatileCount` directly on the parsed JSON. Preserve the exact string guard, one-call requirement, volatile-file filtering, and cleanup.

## User Impact

No runtime or user-visible change. All existing test cases remain; production LOC is unchanged and test LOC is reduced by 10 lines.

## Evidence

- Unchanged backup baseline: 18 tests passed.
- Updated backup, create/verify, and runtime suites: 31 tests passed across 3 files through the normal test runner.
- Full one-path `check-changed` gate: all 20 configured stages passed, including types, dead-export scans, and typed lint.
- Scoped formatting, diff check, and independent Codex review passed with no actionable findings through P2.
