### PR TITLE
fix(release): fetch child job logs with --allow-escape-sequences

### DIFF
--- a/scripts/frv.mjs
+++ b/scripts/frv.mjs
@@ -459,7 +459,8 @@ export function createClient(repository, dependencies = {}) {
   const apiJson = dependencies.apiJson ?? ((path) => ghJson(repository, path));
   const apiText =
     dependencies.apiText ??
-    ((path, jq) => readFreshGhApi(repository, path, jq ? ["--paginate", "--jq", jq] : []));
+    ((path, jq, extraArgs = []) =>
+      readFreshGhApi(repository, path, [...(jq ? ["--paginate", "--jq", jq] : []), ...extraArgs]));
   const mutate = dependencies.mutate ?? ((args) => execGh(args));
   const rerun = (runId, action) =>
     mutate(["api", "-X", "POST", `repos/${repository}/actions/runs/${runId}/${action}`]);
@@ -524,7 +525,9 @@ export function createClient(repository, dependencies = {}) {
         : [];
     },
     getJobLog(jobId) {
-      return apiText(`actions/jobs/${jobId}/logs`);
+      // Octopool's gh shim refuses log bodies with terminal escape sequences even off a TTY;
+      // real gh ignores the flag off-TTY, so the controller works with either binary.
+      return apiText(`actions/jobs/${jobId}/logs`, undefined, ["--allow-escape-sequences"]);
     },
     rerunFailed: (runId) => rerun(runId, "rerun-failed-jobs"),
     rerunParent: (runId) => rerun(runId, "rerun"),


### PR DESCRIPTION
## What Problem This Solves

`pnpm frv continue --failed --run <parent>` crashed on maintainer Macs with `the response contains terminal escape sequences; pass --allow-escape-sequences to output it anyway` while fetching a failed child's job log, so the release controller could not rerun failed children (seen during the 2026.9.1 release on run 33704822889).

## Why This Change Was Made

The `gh` on those Macs is the Octopool shim, which applies gh's escape-sequence refusal even off a TTY. Real gh only checks on a TTY and ignores `--allow-escape-sequences` otherwise, so passing the flag on the job-log fetch keeps the controller working with either binary. `apiText` gains an optional trailing `extraArgs` parameter; existing callers are unchanged.

## User Impact

Maintainer tooling only; no runtime change.

## Evidence

- Before: `pnpm frv continue --failed --run 33704822889` -> `[frv] Command failed: gh api repos/openclaw/openclaw/actions/jobs/100491604631/logs ...` (escape-sequence refusal).
- `gh api .../logs --allow-escape-sequences` returns the log body with the same shim.
- `node --check scripts/frv.mjs` passes.
