### PR TITLE
perf(text): classify file references without path arrays

### DIFF
--- a/src/shared/text/auto-linked-file-ref.ts
+++ b/src/shared/text/auto-linked-file-ref.ts
@@ -18,13 +18,6 @@ export function isAutoLinkedFileRef(href: string, label: string): boolean {
   if (!FILE_REF_EXTENSIONS_WITH_TLD.has(ext)) {
     return false;
   }
-  const segments = label.split("/");
-  if (segments.length > 1) {
-    for (let i = 0; i < segments.length - 1; i += 1) {
-      if (segments[i]?.includes(".")) {
-        return false;
-      }
-    }
-  }
-  return true;
+  // Only the final path segment may contain dots; parents may be hostnames.
+  return label.indexOf(".") > label.lastIndexOf("/");
 }


### PR DESCRIPTION
## What Problem This Solves

Automatic file-reference classification allocates a path-segment array and scans each parent directory for every recognized extension. Telegram and Matrix formatting use this shared classifier.

## Why This Change Was Made

The existing guards establish the final extension. Compare the first dot with the final slash to determine whether any parent contains a dot. This removes the split array and parent loop while retaining href checks, extension normalization, the mutable extension Set, and conservative hostname handling.

Production LOC: +2/-9 (net -7); tests unchanged.

## User Impact

Rendered file references and authored links remain unchanged, with less temporary work during classification.

## Evidence

- All 242 existing Telegram and Matrix renderer tests passed before and after. Actual-owner results match across 200 string cases and six extension-Set mutation events; the public Telegram API also preserves 14 complete HTML and chunk records.
- The changed-file gate passed. Independent Codex review through P2 was scoped clean.
- A fixed four-pair benchmark removed about 3.20 MB cumulative isolate allocation per 100,000 short-file calls; elapsed time was effectively flat (+0.010 ms). Synthetic 128-parent paths removed about 418 MB allocation and 95% elapsed time per 100,000 calls.
- Short-file median RSS increased by 180,224 bytes. Browser proof overlapped the benchmark. These allocation and elapsed results are specific to the measured owner workloads; they do not establish Gateway RSS or typical channel-latency improvements.
