### PR TITLE
perf(ui,gateway): faster chat deep-link cold load: compress WebSocket frames, gate transcript warming

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2954,7 +2954,6 @@ src/gateway/server/ws-connection/authenticated-request-dispatch.ts	1
 src/gateway/server/ws-connection/connect-device-metadata.ts	1
 src/gateway/server/ws-connection/connect-node-session.ts	1
 src/gateway/server/ws-connection/message-handler.ts	10
-src/gateway/server/ws-connection/worker-connection.ts	2
 src/gateway/session-compaction-checkpoints.ts	7
 src/gateway/session-companion-context.ts	6
 src/gateway/session-companion-rpc.ts	3

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -45,6 +45,11 @@ that supervise the Gateway as a child process, see
   the gateway closes or drops the frame. These events carry `surface`, byte
   sizes, limits, and a safe reason code, never message bodies, attachment
   contents, raw frame bytes, tokens, cookies, or secrets.
+- The Gateway offers `permessage-deflate`. Peers that negotiate it (browsers, `ws`
+  clients) receive frames of 4 KiB and up compressed; smaller frames such as
+  streaming deltas stay raw. Context takeover is disabled in both directions, so
+  each frame compresses independently. Peers that do not offer the extension are
+  unaffected. Payload limits apply to the inflated size.
 
 Frame shapes:
 

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -3,6 +3,10 @@
 export const MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
 export const MAX_BUFFERED_BYTES = 50 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
 export const MAX_PREAUTH_PAYLOAD_BYTES = 64 * 1024;
+// permessage-deflate applies from this frame size up. Streaming deltas and acks stay
+// raw (zlib round trips cost more than they save); transcript and roster payloads
+// compress 5-8x, which is what keeps chat.startup off the cold-load critical path.
+export const WS_COMPRESSION_THRESHOLD_BYTES = 4 * 1024;
 export const WEBSOCKET_OPEN_READY_STATE = 1;
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -29,7 +29,7 @@ import {
 import { createSandboxHostHttpServer } from "./mcp-app-sandbox-http.js";
 import { isLoopbackHost, resolveGatewayListenHosts } from "./net.js";
 import { createGatewayPortalService, type GatewayPortalService } from "./portals/portal-service.js";
-import { MAX_PREAUTH_PAYLOAD_BYTES } from "./server-constants.js";
+import { MAX_PREAUTH_PAYLOAD_BYTES, WS_COMPRESSION_THRESHOLD_BYTES } from "./server-constants.js";
 import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import type { HookClientIpConfig, HooksRequestHandler } from "./server/hooks-request-handler.js";
@@ -306,6 +306,16 @@ export async function createGatewayHttpTransport(params: {
     // Yield between buffered frames so one RPC burst cannot monopolize the
     // event loop before other connections and HTTP probes can run.
     allowSynchronousEvents: false,
+    // Peers that offer permessage-deflate (browsers, ws clients) get large frames
+    // compressed. No context takeover keeps zlib memory per connection at one reset
+    // stream instead of a retained sliding window, and the threshold keeps small
+    // frames raw. The extension inherits maxPayload for inflated frames, so the
+    // post-auth receiver handoff must raise it too (prepareGatewayReceiverHandoff).
+    perMessageDeflate: {
+      serverNoContextTakeover: true,
+      clientNoContextTakeover: true,
+      threshold: WS_COMPRESSION_THRESHOLD_BYTES,
+    },
   });
   const preauthConnectionBudget = createPreauthConnectionBudget();
 

--- a/src/gateway/server.public-worker-ingress.test.ts
+++ b/src/gateway/server.public-worker-ingress.test.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import {
@@ -337,7 +338,8 @@ describe("public worker ingress", () => {
     ["receiver", (receiver: PayloadLimited) => receiver],
     [
       "negotiated deflate",
-      (receiver: PayloadLimited) => receiver["_extensions"]["permessage-deflate"],
+      (receiver: PayloadLimited) =>
+        expectDefined(receiver["_extensions"]["permessage-deflate"], "negotiated deflate"),
     ],
   ])(
     "rejects an admitted worker before hello when the %s payload limit is unusable",

--- a/src/gateway/server.public-worker-ingress.test.ts
+++ b/src/gateway/server.public-worker-ingress.test.ts
@@ -44,6 +44,11 @@ const WORKER_GATEWAY_PATH = "/__openclaw__/worker";
 const RESOLVED_AUTH: ResolvedGatewayAuth = { mode: "none", allowTailscale: false };
 const activeHarnesses: PublicWorkerHarness[] = [];
 
+type PayloadLimited = {
+  _maxPayload: number;
+  _extensions: Record<string, PayloadLimited>;
+};
+
 type RejectedWorker = {
   response: unknown;
   close: { code: number; reason: string };
@@ -148,7 +153,17 @@ class PublicWorkerHarness {
   readonly store: WorkerEnvironmentStore;
   readonly workerService: WorkerConnectionService;
   readonly clients = new Set<GatewayWsClient>();
-  readonly wss = new WebSocketServer({ noServer: true, maxPayload: 64 * 1024 });
+  // Mirrors the production server options so a client that offers
+  // permessage-deflate negotiates it here too (server-runtime-state.ts).
+  readonly wss = new WebSocketServer({
+    noServer: true,
+    maxPayload: 64 * 1024,
+    perMessageDeflate: {
+      serverNoContextTakeover: true,
+      clientNoContextTakeover: true,
+      threshold: 4 * 1024,
+    },
+  });
   readonly preauthBudget: ReturnType<typeof createPreauthConnectionBudget>;
   readonly publicRateLimiter: ReturnType<typeof createAuthRateLimiter>;
   readonly logWsControl = createGatewayWsTestLogger();
@@ -317,6 +332,50 @@ describe("public worker ingress", () => {
       expect(harness.publicRateLimiter.size()).toBe(0);
     });
   });
+
+  it.each([
+    ["receiver", (receiver: PayloadLimited) => receiver],
+    [
+      "negotiated deflate",
+      (receiver: PayloadLimited) => receiver["_extensions"]["permessage-deflate"],
+    ],
+  ])(
+    "rejects an admitted worker before hello when the %s payload limit is unusable",
+    async (_label, selectLimit) => {
+      await withHarness({}, async (harness) => {
+        // The Gateway's own connection listener runs first; freezing the limit
+        // afterwards still precedes the connect frame that admits the worker.
+        harness.wss.on("connection", (socket) => {
+          const receiver = (socket as WebSocket & { _receiver: PayloadLimited })["_receiver"];
+          const limit = selectLimit(receiver);
+          Object.defineProperty(limit, "_maxPayload", {
+            value: limit["_maxPayload"],
+            writable: false,
+          });
+        });
+
+        const rejected = await rejectWorker(harness.url(), workerConnect(harness.credential));
+
+        expect(rejected).toEqual({
+          response: {
+            type: "res",
+            id: "connect-1",
+            ok: false,
+            error: {
+              code: "UNAVAILABLE",
+              message: "unsupported Gateway WebSocket receiver",
+              details: { reason: "gateway-unavailable" },
+            },
+          },
+          close: { code: 1011, reason: "gateway-unavailable" },
+        });
+        expect(harness.logWsControl.warn).toHaveBeenCalledWith(
+          "worker admission rejected reason=unsupported-websocket-receiver",
+        );
+        expect(harness.clients.size).toBe(0);
+      });
+    },
+  );
 
   it("returns one opaque failure while retaining precise server reasons", async () => {
     await withHarness({}, async (harness) => {

--- a/src/gateway/server/ws-connection/request-start.server.test.ts
+++ b/src/gateway/server/ws-connection/request-start.server.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
 import { createDeferredCore } from "../../../shared/deferred.js";
+import { MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
 import {
   connectOk,
   connectReq,
@@ -382,6 +383,46 @@ describe("authenticated operator request starts", () => {
       }
     },
   );
+
+  it("compresses large frames for peers that offer permessage-deflate and accepts compressed post-auth frames above the preauth cap", async () => {
+    // Regression: the deflate extension keeps its own copy of the preauth maxPayload,
+    // so without the extension-aware handoff an authenticated compressed request above
+    // 64 KiB closed the socket with 1009 even though the receiver limit was raised.
+    const registry = createEmptyPluginRegistry();
+    registry.gatewayHandlers["test.echo"] = async ({ req, respond }) => {
+      respond(true, { echoed: (req.params as { text: string }).text });
+    };
+    setTestPluginRegistry(registry);
+    const token = "gateway-compression-test-token";
+    const port = await getGatewayTestPort();
+    let server: Awaited<ReturnType<typeof startTestGatewayServer>> | undefined;
+    let ws: WebSocket | undefined;
+    try {
+      server = await startTestGatewayServer(port, {
+        auth: { mode: "token", token },
+        bind: "loopback",
+        controlUiEnabled: false,
+      });
+      ws = await openOperatorSocket(port, token);
+      expect(ws.extensions).toContain("permessage-deflate");
+      const text = "x".repeat(MAX_PREAUTH_PAYLOAD_BYTES * 2);
+      const response = onceMessage<{
+        type: "res";
+        id: string;
+        ok: boolean;
+        payload: { echoed: string };
+      }>(ws, (value) => value.type === "res" && value.id === "big");
+      ws.send(JSON.stringify({ type: "req", id: "big", method: "test.echo", params: { text } }));
+      await expect(response).resolves.toMatchObject({ ok: true, payload: { echoed: text } });
+    } finally {
+      ws?.terminate();
+      try {
+        await server?.close();
+      } finally {
+        resetTestPluginRegistry();
+      }
+    }
+  });
 
   it("rejects an operator handshake visibly when the receiver handoff field is not writable", async () => {
     const token = "gateway-receiver-contract-test-token";

--- a/src/gateway/server/ws-connection/request-start.test.ts
+++ b/src/gateway/server/ws-connection/request-start.test.ts
@@ -1,7 +1,13 @@
 import { performance } from "node:perf_hooks";
 import { setImmediate as nextTurn } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { scheduleGatewayRequestStart } from "./request-start.js";
+import type { WebSocket } from "ws";
+import { MAX_PAYLOAD_BYTES, MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
+import {
+  prepareGatewayReceiverHandoff,
+  raiseGatewayReceiverPayloadLimit,
+  scheduleGatewayRequestStart,
+} from "./request-start.js";
 
 const permissions: Promise<void>[] = [];
 function requestStart(bytes = 1): Promise<void> {
@@ -107,5 +113,66 @@ describe("Gateway request start fairness", () => {
     expect(scheduleGatewayRequestStart(1)).toBeNull();
     await Promise.all([first, second, third]);
     await expect(requestStart(25 * 1024 * 1024)).resolves.toBeUndefined();
+  });
+});
+
+function receiverSocket(params: { deflate?: { _maxPayload: number } | "readonly" }): WebSocket {
+  const deflate =
+    params.deflate === "readonly"
+      ? Object.defineProperty({}, "_maxPayload", { value: MAX_PREAUTH_PAYLOAD_BYTES })
+      : params.deflate;
+  return {
+    _receiver: {
+      _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
+      _allowSynchronousEvents: false,
+      ...(deflate ? { _extensions: { "permessage-deflate": deflate } } : {}),
+    },
+  } as unknown as WebSocket;
+}
+
+function payloadLimits(socket: WebSocket): { receiver: number; deflate: number | undefined } {
+  const receiver = (
+    socket as unknown as {
+      _receiver: {
+        _maxPayload: number;
+        _extensions?: { "permessage-deflate"?: { _maxPayload: number } };
+      };
+    }
+  )["_receiver"];
+  return {
+    receiver: receiver["_maxPayload"],
+    deflate: receiver["_extensions"]?.["permessage-deflate"]?.["_maxPayload"],
+  };
+}
+
+describe("authenticated receiver payload limits", () => {
+  it("raises the receiver and the negotiated deflate extension together after connect", () => {
+    const socket = receiverSocket({ deflate: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES } });
+    const handoff = prepareGatewayReceiverHandoff(socket, "operator");
+    expect(handoff).not.toBeNull();
+    expect(payloadLimits(socket)).toEqual({
+      receiver: MAX_PREAUTH_PAYLOAD_BYTES,
+      deflate: MAX_PREAUTH_PAYLOAD_BYTES,
+    });
+    handoff?.();
+    expect(payloadLimits(socket)).toEqual({
+      receiver: MAX_PAYLOAD_BYTES,
+      deflate: MAX_PAYLOAD_BYTES,
+    });
+  });
+
+  it("keeps working for peers that did not negotiate compression", () => {
+    const socket = receiverSocket({});
+    expect(raiseGatewayReceiverPayloadLimit(socket, 1_024)).toBe(true);
+    expect(payloadLimits(socket)).toEqual({ receiver: 1_024, deflate: undefined });
+  });
+
+  it("refuses the handoff when the deflate limit cannot be raised", () => {
+    // A non-writable extension limit would silently keep the preauth cap on
+    // compressed frames, so the handshake must fail visibly instead.
+    const socket = receiverSocket({ deflate: "readonly" });
+    expect(prepareGatewayReceiverHandoff(socket, "operator")).toBeNull();
+    expect(raiseGatewayReceiverPayloadLimit(socket, 1_024)).toBe(false);
+    expect(payloadLimits(socket).receiver).toBe(MAX_PREAUTH_PAYLOAD_BYTES);
   });
 });

--- a/src/gateway/server/ws-connection/request-start.ts
+++ b/src/gateway/server/ws-connection/request-start.ts
@@ -6,26 +6,73 @@ import { BoundedSerialQueue } from "../../../shared/bounded-serial-queue.js";
 import type { GatewayRole } from "../../role-policy.js";
 import { MAX_PAYLOAD_BYTES } from "../../server-constants.js";
 
-type GatewayReceiver = { _maxPayload?: number; _allowSynchronousEvents?: boolean };
+type PayloadLimited = { _maxPayload?: number };
+type GatewayReceiver = PayloadLimited & {
+  _allowSynchronousEvents?: boolean;
+  _extensions?: Record<string, PayloadLimited | undefined>;
+};
+const PERMESSAGE_DEFLATE_EXTENSION = "permessage-deflate";
+
+function hasWritablePayloadLimit(target: PayloadLimited | undefined): target is PayloadLimited {
+  return (
+    typeof target?.["_maxPayload"] === "number" &&
+    Object.getOwnPropertyDescriptor(target, "_maxPayload")?.writable === true
+  );
+}
+
+/**
+ * Resolves the ws receiver and every payload limit an authenticated frame passes through.
+ * A negotiated permessage-deflate extension checks inflated size against its own copy of
+ * the server maxPayload, so raising only the receiver would still reject compressed
+ * post-auth frames above the preauth cap. Null when any limit is not writable.
+ */
+function gatewayReceiverPayloadLimits(
+  socket: WebSocket,
+): { receiver: GatewayReceiver; limits: PayloadLimited[] } | null {
+  // SAFETY: ws owns these private per-frame fields; validate each before the handoff.
+  const receiver = (socket as WebSocket & { _receiver?: GatewayReceiver })["_receiver"];
+  if (!hasWritablePayloadLimit(receiver)) {
+    return null;
+  }
+  const deflate = receiver["_extensions"]?.[PERMESSAGE_DEFLATE_EXTENSION];
+  if (deflate === undefined) {
+    return { receiver, limits: [receiver] };
+  }
+  return hasWritablePayloadLimit(deflate) ? { receiver, limits: [receiver, deflate] } : null;
+}
+
+/** Raises the authenticated frame limit on the receiver and its deflate extension together. */
+export function raiseGatewayReceiverPayloadLimit(socket: WebSocket, maxPayload: number): boolean {
+  const resolved = gatewayReceiverPayloadLimits(socket);
+  if (!resolved) {
+    return false;
+  }
+  for (const limit of resolved.limits) {
+    limit["_maxPayload"] = maxPayload;
+  }
+  return true;
+}
 
 export function prepareGatewayReceiverHandoff(
   socket: WebSocket,
   role: GatewayRole,
 ): (() => void) | null {
-  // SAFETY: ws owns these private per-frame fields; validate each before the handoff.
-  const receiver = (socket as WebSocket & { _receiver?: GatewayReceiver })["_receiver"];
+  const resolved = gatewayReceiverPayloadLimits(socket);
+  if (!resolved) {
+    return null;
+  }
+  const { receiver, limits } = resolved;
   if (
-    !receiver ||
-    typeof receiver["_maxPayload"] !== "number" ||
-    Object.getOwnPropertyDescriptor(receiver, "_maxPayload")?.writable !== true ||
-    (role === "operator" &&
-      (typeof receiver["_allowSynchronousEvents"] !== "boolean" ||
-        Object.getOwnPropertyDescriptor(receiver, "_allowSynchronousEvents")?.writable !== true))
+    role === "operator" &&
+    (typeof receiver["_allowSynchronousEvents"] !== "boolean" ||
+      Object.getOwnPropertyDescriptor(receiver, "_allowSynchronousEvents")?.writable !== true)
   ) {
     return null;
   }
   return () => {
-    receiver["_maxPayload"] = MAX_PAYLOAD_BYTES;
+    for (const limit of limits) {
+      limit["_maxPayload"] = MAX_PAYLOAD_BYTES;
+    }
     if (role === "operator") {
       receiver["_allowSynchronousEvents"] = true;
     }

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -29,6 +29,7 @@ import { MAX_RUNNING_WORKER_SESSION_TOOL_OPERATIONS } from "../../worker-environ
 import { runWorkerTurnAdmissionContinuation } from "../../worker-environments/placement-turn-claim-events.js";
 import type { PublicWorkerIngressContext } from "../public-worker-ingress-context.js";
 import type { GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
+import { raiseGatewayReceiverPayloadLimit } from "./request-start.js";
 import { runWorkerAdmissionBoundary } from "./worker-admission-boundary.js";
 import {
   dispatchWorkerRequest,
@@ -65,13 +66,6 @@ type WorkerWsMessageHandlerParams = {
   logWsControl: WorkerLogger;
   publicAdmission?: PublicWorkerIngressContext;
 };
-
-function setSocketMaxPayload(socket: WebSocket, maxPayload: number): void {
-  const receiver = (socket as { _receiver?: unknown })["_receiver"];
-  if (receiver) {
-    (receiver as { _maxPayload?: number })["_maxPayload"] = maxPayload;
-  }
-}
 
 /** Dedicated ingress handler: worker frames never enter the generic message handler. */
 export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParams): () => void {
@@ -206,7 +200,7 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
     }
     params.setHandshakeState("connected");
     params.advanceHandshakePhase("session_attached");
-    setSocketMaxPayload(params.socket, workerMaxPayload(admission.identity));
+    raiseGatewayReceiverPayloadLimit(params.socket, workerMaxPayload(admission.identity));
     params.advanceHandshakePhase("hello_payload_prepared");
     params.send({ type: "res", id, ok: true, payload: buildWorkerHello(admission.identity) });
     if (disposed || params.isClosed()) {

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -198,9 +198,23 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
       rejectAdmission({ id, reason: admission.reason, opaqueOnPublicIngress: true });
       return;
     }
+    if (!raiseGatewayReceiverPayloadLimit(params.socket, workerMaxPayload(admission.identity))) {
+      // Worker frames may exceed the pre-auth cap; without a writable receiver
+      // limit they would close mid-frame later instead of failing visibly here.
+      rejectAdmission({
+        id,
+        reason: "gateway-unavailable",
+        internalReason: "unsupported-websocket-receiver",
+        error: workerProtocolError("gateway-unavailable", {
+          code: ErrorCodes.UNAVAILABLE,
+          message: "unsupported Gateway WebSocket receiver",
+        }),
+        code: 1011,
+      });
+      return;
+    }
     params.setHandshakeState("connected");
     params.advanceHandshakePhase("session_attached");
-    raiseGatewayReceiverPayloadLimit(params.socket, workerMaxPayload(admission.identity));
     params.advanceHandshakePhase("hello_payload_prepared");
     params.send({ type: "res", id, ok: true, payload: buildWorkerHello(admission.identity) });
     if (disposed || params.isClosed()) {

--- a/ui/src/e2e/chat-session-prefetch-gating.e2e.test.ts
+++ b/ui/src/e2e/chat-session-prefetch-gating.e2e.test.ts
@@ -1,0 +1,113 @@
+// Control UI E2E: background session warming must never share the socket with the
+// transcript the user is looking at, including a reload that a Gateway event starts
+// inside the pane itself, where nothing re-renders the page.
+import { expect, it } from "vitest";
+import {
+  installMockGateway,
+  pauseVirtualClock,
+  type MockGatewayControls,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiSessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI chat session prefetch gating",
+  startServerBeforeBrowser: true,
+});
+
+const MAIN_SESSION_KEY = "agent:main:main";
+const WARM_SESSION_KEY = "agent:main:warm-later";
+const CLOCK_START = Date.UTC(2026, 8, 3, 12, 0, 0);
+
+function transcript(text: string, seq: number) {
+  return {
+    messages: [
+      {
+        role: "assistant",
+        content: [{ type: "text", text }],
+        timestamp: CLOCK_START - 60_000 + seq,
+        __openclaw: { id: `msg-${seq}`, seq },
+      },
+    ],
+  };
+}
+
+async function historyRequestCount(
+  gateway: MockGatewayControls,
+  sessionKey: string,
+): Promise<number> {
+  const requests = await gateway.getRequests("chat.history");
+  return requests.filter(
+    (request) => (request.params as { sessionKey?: string } | undefined)?.sessionKey === sessionKey,
+  ).length;
+}
+
+suite.define(() => {
+  it("keeps queued warm-ups off the socket while the presented transcript reloads", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { width: 1280, height: 900 },
+    });
+    const page = await context.newPage();
+    await page.clock.install({ time: CLOCK_START });
+    const mainSession = createControlUiSessionRow(MAIN_SESSION_KEY, "Main", CLOCK_START - 1_000);
+    const gateway = await installMockGateway(page, {
+      // The presented pane boots through chat.startup, so the first chat.history
+      // on the wire is the background warm-up of the other session.
+      deferredMethods: ["chat.history"],
+      historyMessages: [],
+      sessions: [
+        mainSession,
+        createControlUiSessionRow(WARM_SESSION_KEY, "Warm later", CLOCK_START - 2_000),
+      ],
+      sessionTranscripts: {
+        [MAIN_SESSION_KEY]: transcript("Main transcript", 1),
+        [WARM_SESSION_KEY]: transcript("Warm transcript", 2),
+      },
+    });
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      await page.locator(".chat-bubble", { hasText: "Main transcript" }).first().waitFor();
+      await expect.poll(() => historyRequestCount(gateway, WARM_SESSION_KEY)).toBe(1);
+      // A failed warm-up leaves the session eligible and arms the prefetcher's own
+      // cooldown retry timer, which fires without any page update in between.
+      // Not retryable: the Gateway client would otherwise re-issue the request itself.
+      await gateway.rejectDeferred("chat.history", { code: "UNAVAILABLE", message: "warm later" });
+
+      // A peer message makes the presented pane reload its transcript from inside
+      // the pane; hold that reload on the wire.
+      await gateway.deferNext("chat.history", { sessionKey: MAIN_SESSION_KEY });
+      await gateway.emitGatewayEvent("session.message", {
+        sessionKey: MAIN_SESSION_KEY,
+        session: mainSession,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Peer message arrived." }],
+          __openclaw: { id: "peer-message", seq: 5 },
+        },
+        messageId: "peer-message",
+        messageSeq: 5,
+      });
+      await expect.poll(() => historyRequestCount(gateway, MAIN_SESSION_KEY)).toBe(1);
+
+      // Fire every prefetch timer, including the cooldown retry, while the
+      // presented transcript is still in flight.
+      await pauseVirtualClock(page);
+      await page.clock.runFor(35_000);
+      expect(await historyRequestCount(gateway, WARM_SESSION_KEY)).toBe(1);
+
+      // Once the presented transcript commits, warming resumes on its own.
+      await gateway.resolveDeferred("chat.history", {
+        ...transcript("Main transcript reloaded", 6),
+        sessionId: mainSession.sessionId,
+      });
+      await page.locator(".chat-bubble", { hasText: "Main transcript reloaded" }).first().waitFor();
+      await page.clock.runFor(35_000);
+      await expect.poll(() => historyRequestCount(gateway, WARM_SESSION_KEY)).toBe(2);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-history-hydration.ts
+++ b/ui/src/pages/chat/chat-history-hydration.ts
@@ -22,12 +22,12 @@ import {
   clearHistoryCursor,
 } from "./chat-history-snapshot.ts";
 import {
-  chatHistoryRequests,
   beginHistoryRequest,
   ownsHistoryRequest,
   acceptsHistoryResult,
   resetChatHistoryProjection,
   setChatError,
+  setChatHistoryLoad,
 } from "./chat-history-state.ts";
 import {
   materializeVisibleAssistantStreamMessages,
@@ -417,7 +417,7 @@ export async function hydrateChatHistory(
       state.chatThinkingLevel = null;
       state.chatVerboseLevel = null;
     }
-    chatHistoryRequests(state).historyLoad = {
+    setChatHistoryLoad(state, {
       phase: "failed",
       sessionKey,
       requestAgentId,
@@ -426,7 +426,7 @@ export async function hydrateChatHistory(
         ? formatMissingOperatorReadScopeMessage("existing chat history")
         : formatUiError(err),
       retryable: err instanceof GatewayRequestError && err.retryable,
-    };
+    });
     state.requestUpdate?.();
   } finally {
     if (ownsHistoryRequest(state, ownership)) {

--- a/ui/src/pages/chat/chat-history-state.ts
+++ b/ui/src/pages/chat/chat-history-state.ts
@@ -56,6 +56,23 @@ export function chatHistoryRequests(owner: object): ChatHistoryPaneRequests {
   return requests;
 }
 
+/** Dispatched by a pane whenever its authoritative transcript starts or stops loading. */
+export const CHAT_TRANSCRIPT_LOADING_CHANGED_EVENT = "openclaw-chat-transcript-loading-changed";
+
+function isChatHistoryLoading(load: ChatHistoryLoadState): boolean {
+  return load.phase === "pending-connection" || load.phase === "in-flight";
+}
+
+/** Records the transcript load phase and reports loading edges to the pane. */
+export function setChatHistoryLoad(state: ChatState, load: ChatHistoryLoadState): void {
+  const requests = chatHistoryRequests(state);
+  const wasLoading = isChatHistoryLoading(requests.historyLoad);
+  requests.historyLoad = load;
+  if (wasLoading !== isChatHistoryLoading(load)) {
+    state.transcriptLoadingChanged?.();
+  }
+}
+
 export function getChatHistoryLoadState(state: ChatState): ChatHistoryLoadState {
   const requests = chatHistoryRequests(state);
   const load = requests.historyLoad;
@@ -70,6 +87,8 @@ export function getChatHistoryLoadState(state: ChatState): ChatHistoryLoadState 
       ? load.key === `${state.sessionKey}\u0000${requestAgentId ?? ""}`
       : load.sessionKey === state.sessionKey && load.requestAgentId === requestAgentId;
   if (!current) {
+    // Lazy repair of a load left behind by a session switch; the switch's own
+    // load reports its edge, so this stays a silent write (readers see idle).
     requests.historyLoad = { phase: "idle" };
     state.chatLoading = false;
   } else if (
@@ -150,7 +169,7 @@ export function resetChatHistoryProjection(state: ChatState, agentId?: string): 
   // A destructive reset keeps the session key, so invalidate both the old
   // snapshot owner and its coalesced request before creating the next epoch.
   requests.historyVersion += 1;
-  requests.historyLoad = { phase: "idle" };
+  setChatHistoryLoad(state, { phase: "idle" });
   state.chatLoading = false;
   const scope = readChatSessionProjectionScope(state, { agentId });
   // Destructive operations keep the public session key, so only an explicit

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -11,7 +11,11 @@ import { loadChatBranches } from "./chat-history-branches.ts";
 import { hydrateChatHistory } from "./chat-history-hydration.ts";
 import { CHAT_HISTORY_REQUEST_LIMIT } from "./chat-history-request.ts";
 import type { ChatHistoryResult } from "./chat-history-snapshot.ts";
-import { chatHistoryRequests, getChatHistoryLoadState } from "./chat-history-state.ts";
+import {
+  chatHistoryRequests,
+  getChatHistoryLoadState,
+  setChatHistoryLoad,
+} from "./chat-history-state.ts";
 import { readChatInputRunIds } from "./chat-pending-inputs.ts";
 import type { ChatRunStartupPhase } from "./chat-run-startup.ts";
 import type { ChatState } from "./chat-state-contract.ts";
@@ -36,7 +40,7 @@ export async function loadChatHistory(
   const startup = opts.startup === true;
   const requests = chatHistoryRequests(state);
   if (!state.client || !state.connected) {
-    requests.historyLoad = { phase: "pending-connection", sessionKey, requestAgentId, startup };
+    setChatHistoryLoad(state, { phase: "pending-connection", sessionKey, requestAgentId, startup });
     state.chatLoading = true;
     state.requestUpdate?.();
     return undefined;
@@ -94,10 +98,10 @@ export async function loadChatHistory(
     const current = requests.historyLoad;
     if (current.phase === "in-flight" && current.promise === promise) {
       if (result) {
-        requests.historyLoad = {
+        setChatHistoryLoad(state, {
           phase: "committed",
           key: `${sessionKey}\u0000${requestAgentId ?? ""}`,
-        };
+        });
       } else if (
         state.sessionKey === sessionKey &&
         (!isUiSelectedGlobalSessionKey(state, sessionKey) ||
@@ -106,22 +110,22 @@ export async function loadChatHistory(
           current.client !== state.client ||
           current.connectionEpoch !== state.connectionEpoch)
       ) {
-        requests.historyLoad = {
+        setChatHistoryLoad(state, {
           phase: "pending-connection",
           sessionKey,
           requestAgentId,
           startup,
-        };
+        });
         state.chatLoading = true;
       } else {
-        requests.historyLoad = { phase: "idle" };
+        setChatHistoryLoad(state, { phase: "idle" });
         state.chatLoading = false;
       }
       state.requestUpdate?.();
     }
     return result;
   });
-  requests.historyLoad = {
+  setChatHistoryLoad(state, {
     phase: "in-flight",
     client,
     connectionEpoch,
@@ -130,7 +134,7 @@ export async function loadChatHistory(
     sessionKey,
     requestAgentId,
     startup,
-  };
+  });
   return promise;
 }
 

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -43,6 +43,7 @@ import { PollController } from "../../lit/poll-controller.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { ChatComposerCapabilityHost } from "./chat-composer-capability-host.ts";
 import { GitHubPublicationController } from "./chat-github-publication.ts";
+import { getChatHistoryLoadState } from "./chat-history-state.ts";
 import { sendSessionObserverVisibility } from "./chat-observer.ts";
 import type {
   ChatPaneConnectionScope,
@@ -150,6 +151,11 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     this.presentedChanged(value);
   }
   protected presentedChanged(_presented: boolean): void {}
+  /** True while the authoritative transcript for this pane is still being fetched. */
+  get transcriptLoading(): boolean {
+    const phase = this.state ? getChatHistoryLoadState(this.state).phase : "idle";
+    return phase === "pending-connection" || phase === "in-flight";
+  }
   protected get headerOutcomeOwner(): string {
     return `${this.connectionGeneration}:${this.headerPresentationGeneration}`;
   }

--- a/ui/src/pages/chat/chat-pane-transcript-loading.test.ts
+++ b/ui/src/pages/chat/chat-pane-transcript-loading.test.ts
@@ -1,0 +1,63 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import type { ChatHistoryResult } from "./chat-history-snapshot.ts";
+import { loadChatHistory } from "./chat-history.ts";
+import {
+  createInitializationContext,
+  createRenderTestChatPane,
+  createSessionCapabilityFixture,
+} from "./chat-pane.test-support.ts";
+
+describe("chat pane transcript loading signal", () => {
+  it("reports each transcript loading edge from the load owner without a render", async () => {
+    const pane = createRenderTestChatPane();
+    const first = createDeferred<ChatHistoryResult>();
+    const second = createDeferred<ChatHistoryResult>();
+    const pending = [first.promise, second.promise];
+    const request = vi.fn(() => pending.shift());
+    const client = { request } as unknown as GatewayBrowserClient;
+    const context: ApplicationContext = {
+      ...createInitializationContext(),
+      sessions: createSessionCapabilityFixture({
+        state: { result: null, agentId: "main", modelOverrides: {} },
+        think: () => undefined,
+        reconcile: vi.fn(),
+      }),
+    };
+    context.gateway.snapshot.client = client;
+    context.gateway.snapshot.phase = "connected";
+    const state = pane.initialize(context);
+    state.client = client;
+    state.connected = true;
+    state.sessionKey = "agent:main:signal";
+    const invalidate = vi.spyOn(state.renderLifecycle, "invalidate");
+    const changed = vi.fn();
+    pane.addEventListener("openclaw-chat-transcript-loading-changed", changed);
+
+    // Session-event reloads never re-render the page, so the load owner reports
+    // the edge itself, without spending a frame on it.
+    const firstLoad = loadChatHistory(state);
+    expect(pane.transcriptLoading).toBe(true);
+    expect(changed).toHaveBeenCalledOnce();
+    expect(invalidate).not.toHaveBeenCalled();
+
+    // A coalesced re-entry into the same in-flight request is not an edge.
+    void loadChatHistory(state);
+    expect(changed).toHaveBeenCalledOnce();
+
+    first.resolve({ completeSnapshot: true, messages: [], sessionId: "id:signal" });
+    await firstLoad;
+    expect(pane.transcriptLoading).toBe(false);
+    expect(changed).toHaveBeenCalledTimes(2);
+
+    const secondLoad = loadChatHistory(state);
+    expect(changed).toHaveBeenCalledTimes(3);
+    second.resolve({ completeSnapshot: true, messages: [], sessionId: "id:signal" });
+    await secondLoad;
+    expect(changed).toHaveBeenCalledTimes(4);
+  });
+});

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -91,7 +91,7 @@ function makeChatPageHost({
   const host = createPageState(
     context,
     { invalidate: vi.fn(), afterCommit: () => () => {} },
-    { querySelector: () => null },
+    { dispatchEvent: () => true, querySelector: () => null },
   );
   Object.assign(host, { client, hello, connected: true }, overrides);
   return Object.assign(host, { request });

--- a/ui/src/pages/chat/chat-state-contract.ts
+++ b/ui/src/pages/chat/chat-state-contract.ts
@@ -75,4 +75,6 @@ export type ChatState = StreamCausalBoundaryState & {
   chatBranchesSessionKey?: string | null;
   chatBranchesConnectionEpoch?: number | null;
   requestUpdate?: () => void;
+  /** Reports transcript loading edges; see CHAT_TRANSCRIPT_LOADING_CHANGED_EVENT. */
+  transcriptLoadingChanged?: () => void;
 };

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -17,6 +17,7 @@ import {
   isUiSelectedGlobalSessionKey,
 } from "../../lib/sessions/session-key.ts";
 import { resolveAgentIdForSession } from "./chat-avatar.ts";
+import { CHAT_TRANSCRIPT_LOADING_CHANGED_EVENT } from "./chat-history-state.ts";
 import { removeQueuedMessage } from "./chat-queue.ts";
 import { attachChatRealtimeActions, createInitialChatRealtimeState } from "./chat-realtime.ts";
 import {
@@ -65,6 +66,7 @@ import type { RunOutputUsage } from "./tool-stream-contract.ts";
 import { resetToolStream } from "./tool-stream.ts";
 
 type ChatPageElement = {
+  dispatchEvent: (event: Event) => boolean;
   getBoundingClientRect?: () => DOMRect;
   querySelector: (selectors: string) => Element | null;
 };
@@ -273,6 +275,12 @@ export function createPageState(
     ...createInitialChatRealtimeState(),
     renderLifecycle,
     requestUpdate: () => renderLifecycle.invalidate(),
+    // Background warming gates on these edges. Session-event reloads never
+    // re-render the page, so no update can carry the fact to it.
+    transcriptLoadingChanged: () =>
+      page.dispatchEvent(
+        new CustomEvent(CHAT_TRANSCRIPT_LOADING_CHANGED_EVENT, { bubbles: true, composed: true }),
+      ),
     sessionWorkspaceState: undefined,
     backgroundTasksState: undefined,
     querySelector: page.querySelector.bind(page),

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -2561,6 +2561,7 @@ describe("ChatStateController render lifecycle", () => {
       createPageContext(),
       { invalidate: vi.fn(), afterCommit: () => () => {} },
       {
+        dispatchEvent: () => true,
         getBoundingClientRect: () => new DOMRect(0, 0, 1_440, 0),
         querySelector: () => null,
       },
@@ -3210,6 +3211,7 @@ describe("ChatStateController render lifecycle", () => {
     controller.hostConnected();
     const renderLifecycle = controller.createRenderLifecycle();
     const state = createPageState(createPageContext(), renderLifecycle, {
+      dispatchEvent: () => true,
       querySelector: () => null,
     });
     const stop = vi.fn(() => {
@@ -3498,7 +3500,7 @@ describe("image lightbox lifecycle", () => {
     const state = createPageState(
       context,
       { invalidate: vi.fn(), afterCommit: () => () => {} },
-      { querySelector: () => null },
+      { dispatchEvent: () => true, querySelector: () => null },
     );
 
     const source = "data:video/mp4;base64,AAAA";
@@ -3552,7 +3554,7 @@ describe("image lightbox lifecycle", () => {
         invalidate,
         afterCommit: () => () => {},
       },
-      { querySelector: () => null },
+      { dispatchEvent: () => true, querySelector: () => null },
     );
     const release = vi.fn();
     state.imageLightbox = {
@@ -3613,7 +3615,7 @@ describe("loadPageAssistantIdentity", () => {
     const state = createPageState(
       context,
       { invalidate: vi.fn(), afterCommit: () => () => {} },
-      { querySelector: () => null },
+      { dispatchEvent: () => true, querySelector: () => null },
     );
     state.client = client;
     state.connected = true;

--- a/ui/src/pages/chat/route-draft-focus-handoff.ts
+++ b/ui/src/pages/chat/route-draft-focus-handoff.ts
@@ -19,6 +19,7 @@ export type ChatPaneElement = HTMLElement & {
   prepareForEviction?: () => void;
   presented?: boolean;
   sessionKey?: string;
+  transcriptLoading?: boolean;
   visuallyPresented?: boolean;
 };
 

--- a/ui/src/pages/chat/session-prefetch.test.ts
+++ b/ui/src/pages/chat/session-prefetch.test.ts
@@ -420,6 +420,48 @@ describe("recent session prefetch", () => {
     expect(request.mock.calls.map(sessionKeyFromCall)).toEqual(["agent:main:recent"]);
   });
 
+  it("rechecks readiness after the persisted snapshot read before requesting history", async () => {
+    const sessionKey = "agent:main:stored";
+    const stored = historySnapshot("stored", "session-stored");
+    store.write(sessionKey, stored);
+    await store.flush();
+    cache.clear();
+    const read = createDeferred<ChatSessionSnapshot | null>();
+    const readSpy = vi.spyOn(store, "read").mockReturnValueOnce(read.promise);
+    const request = vi.fn(async (_method: string, params: unknown) =>
+      historyResult((params as { sessionKey: string }).sessionKey),
+    );
+    const state: SessionPrefetchUpdate = {
+      client: { request } as unknown as GatewayBrowserClient,
+      listRevision: 1,
+      openSessionKeys: ["agent:main:main"],
+      rows: [row("agent:main:main", NOW - 1), row(sessionKey, NOW + 1)],
+    };
+    updatePrefetch(state);
+    await vi.advanceTimersByTimeAsync(300);
+    await settlePromises();
+    expect(readSpy).toHaveBeenCalledWith(sessionKey);
+    expect(request).not.toHaveBeenCalled();
+
+    // The presented pane starts loading while IndexedDB is still answering.
+    const pane = host.firstElementChild as HTMLElement & { transcriptLoading: boolean };
+    pane.transcriptLoading = true;
+    pane.dispatchEvent(
+      new CustomEvent("openclaw-chat-transcript-loading-changed", { bubbles: true }),
+    );
+    read.resolve(stored);
+    await settlePromises();
+    expect(request).not.toHaveBeenCalled();
+
+    pane.transcriptLoading = false;
+    pane.dispatchEvent(
+      new CustomEvent("openclaw-chat-transcript-loading-changed", { bubbles: true }),
+    );
+    await vi.advanceTimersByTimeAsync(300);
+    await settlePromises();
+    expect(request.mock.calls.map(sessionKeyFromCall)).toEqual([sessionKey]);
+  });
+
   it("keeps repeated roster refreshes within the bounded recent-session snapshot window", async () => {
     const request = vi.fn(async (_method: string, params: unknown) =>
       historyResult((params as { sessionKey: string }).sessionKey),

--- a/ui/src/pages/chat/session-prefetch.test.ts
+++ b/ui/src/pages/chat/session-prefetch.test.ts
@@ -27,6 +27,8 @@ type SessionPrefetchUpdate = {
   client: GatewayBrowserClient | null;
   listRevision: number;
   openSessionKeys: readonly string[];
+  /** Presented panes still fetching their transcript; omitted panes report committed. */
+  loadingSessionKeys?: readonly string[];
   rows: readonly GatewaySessionRow[] | null;
 };
 
@@ -185,10 +187,32 @@ describe("recent session prefetch", () => {
     current = update;
     host.replaceChildren(
       ...update.openSessionKeys.map((sessionKey) =>
-        Object.assign(document.createElement("openclaw-chat-pane"), { sessionKey }),
+        Object.assign(document.createElement("openclaw-chat-pane"), {
+          sessionKey,
+          transcriptLoading: update.loadingSessionKeys?.includes(sessionKey) === true,
+        }),
       ),
     );
     controller.hostUpdated?.();
+  }
+
+  /** Resolves pending history requests in arrival order, one per settle, like a serial socket. */
+  async function drainSequentially(
+    pending: Array<{
+      resolve: (value: ReturnType<typeof historyResult>) => void;
+      sessionKey: string;
+    }>,
+    request: { mock: { calls: unknown[][] } },
+    expectedOrder: readonly string[],
+  ): Promise<void> {
+    for (const [index, sessionKey] of expectedOrder.entries()) {
+      // Only the head of the queue is on the wire until it resolves.
+      expect(request.mock.calls.map(sessionKeyFromCall)).toEqual(expectedOrder.slice(0, index + 1));
+      const head = pending.shift();
+      expect(head?.sessionKey).toBe(sessionKey);
+      head?.resolve(historyResult(sessionKey));
+      await settlePromises();
+    }
   }
 
   it("does not repopulate a removed session from an in-flight prefetch before the next list revision", async () => {
@@ -213,7 +237,7 @@ describe("recent session prefetch", () => {
     expect(await store.read(key)).toBeNull();
   });
 
-  it("quickly warms five eligible sessions together without reopening fresh or active history", async () => {
+  it("warms five eligible sessions one at a time without reopening fresh or active history", async () => {
     store.write("agent:main:fresh", historySnapshot("fresh"));
     await store.flush();
     const open = vi.spyOn(indexedDB, "open");
@@ -259,24 +283,14 @@ describe("recent session prefetch", () => {
     expect(request).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(300);
     await settlePromises();
-    expect(request).toHaveBeenCalledTimes(5);
-
-    for (let index = 0; index < 5; index += 1) {
-      const pendingRequest = pending[index];
-      if (!pendingRequest) {
-        throw new Error(`missing pending history request ${index}`);
-      }
-      pendingRequest.resolve(historyResult(pendingRequest.sessionKey));
-    }
-    await settlePromises();
-
-    expect(request.mock.calls.map(sessionKeyFromCall)).toEqual([
+    await drainSequentially(pending, request, [
       "agent:main:eligible-1",
       "agent:main:eligible-2",
       "agent:main:eligible-3",
       "agent:main:eligible-4",
       "agent:main:eligible-5",
     ]);
+    expect(request).toHaveBeenCalledTimes(5);
     expect(request.mock.calls.every((call) => (call[1] as { limit: number }).limit === 800)).toBe(
       true,
     );
@@ -303,6 +317,107 @@ describe("recent session prefetch", () => {
     await vi.advanceTimersByTimeAsync(2_000);
     await settlePromises();
     expect(open).not.toHaveBeenCalled();
+  });
+
+  it("waits for the presented transcript to commit before warming other sessions", async () => {
+    const request = vi.fn(async (_method: string, params: unknown) =>
+      historyResult((params as { sessionKey: string }).sessionKey),
+    );
+    const state: SessionPrefetchUpdate = {
+      client: { request } as unknown as GatewayBrowserClient,
+      listRevision: 1,
+      openSessionKeys: ["agent:main:main"],
+      loadingSessionKeys: ["agent:main:main"],
+      rows: [row("agent:main:main", NOW - 1), row("agent:main:recent", NOW - 2)],
+    };
+    updatePrefetch(state);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await settlePromises();
+    // The visible transcript owns the socket until it has committed.
+    expect(request).not.toHaveBeenCalled();
+
+    updatePrefetch({ ...state, loadingSessionKeys: [] });
+    host.dispatchEvent(
+      new CustomEvent("openclaw-chat-transcript-loading-changed", { bubbles: true }),
+    );
+    await vi.advanceTimersByTimeAsync(300);
+    await settlePromises();
+    expect(request.mock.calls.map(sessionKeyFromCall)).toEqual(["agent:main:recent"]);
+  });
+
+  it("stops the queued warming when a presented transcript starts loading mid-cycle", async () => {
+    const pending: Array<{
+      resolve: (value: ReturnType<typeof historyResult>) => void;
+      sessionKey: string;
+    }> = [];
+    const request = vi.fn((_method: string, params: unknown) => {
+      const sessionKey = (params as { sessionKey: string }).sessionKey;
+      return new Promise<ReturnType<typeof historyResult>>((resolve) => {
+        pending.push({ resolve, sessionKey });
+      });
+    });
+    const state: SessionPrefetchUpdate = {
+      client: { request } as unknown as GatewayBrowserClient,
+      listRevision: 1,
+      openSessionKeys: ["agent:main:main"],
+      rows: [
+        row("agent:main:main", NOW - 1),
+        row("agent:main:recent-1", NOW - 2),
+        row("agent:main:recent-2", NOW - 3),
+      ],
+    };
+    updatePrefetch(state);
+    await vi.advanceTimersByTimeAsync(300);
+    await settlePromises();
+    expect(request.mock.calls.map(sessionKeyFromCall)).toEqual(["agent:main:recent-1"]);
+
+    // The user opens another session while the first warm-up is in flight.
+    updatePrefetch({ ...state, loadingSessionKeys: ["agent:main:main"] });
+    pending.shift()?.resolve(historyResult("agent:main:recent-1"));
+    await settlePromises();
+    expect(request.mock.calls.map(sessionKeyFromCall)).toEqual(["agent:main:recent-1"]);
+
+    updatePrefetch({ ...state, loadingSessionKeys: [] });
+    host.dispatchEvent(
+      new CustomEvent("openclaw-chat-transcript-loading-changed", { bubbles: true }),
+    );
+    await vi.advanceTimersByTimeAsync(300);
+    await settlePromises();
+    expect(request.mock.calls.map(sessionKeyFromCall)).toEqual([
+      "agent:main:recent-1",
+      "agent:main:recent-2",
+    ]);
+  });
+
+  it("resamples when a presented pane reports a transcript loading edge", async () => {
+    const request = vi.fn(async (_method: string, params: unknown) =>
+      historyResult((params as { sessionKey: string }).sessionKey),
+    );
+    const state: SessionPrefetchUpdate = {
+      client: { request } as unknown as GatewayBrowserClient,
+      listRevision: 1,
+      openSessionKeys: ["agent:main:main"],
+      rows: [row("agent:main:main", NOW - 1), row("agent:main:recent", NOW - 2)],
+    };
+    updatePrefetch(state);
+    // The pane starts its load inside its own update; the page never re-renders,
+    // so only the pane's signal can retire the "ready" snapshot the page sampled.
+    const pane = host.firstElementChild as HTMLElement & { transcriptLoading: boolean };
+    pane.transcriptLoading = true;
+    pane.dispatchEvent(
+      new CustomEvent("openclaw-chat-transcript-loading-changed", { bubbles: true }),
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+    await settlePromises();
+    expect(request).not.toHaveBeenCalled();
+
+    pane.transcriptLoading = false;
+    pane.dispatchEvent(
+      new CustomEvent("openclaw-chat-transcript-loading-changed", { bubbles: true }),
+    );
+    await vi.advanceTimersByTimeAsync(300);
+    await settlePromises();
+    expect(request.mock.calls.map(sessionKeyFromCall)).toEqual(["agent:main:recent"]);
   });
 
   it("keeps repeated roster refreshes within the bounded recent-session snapshot window", async () => {

--- a/ui/src/pages/chat/session-prefetch.ts
+++ b/ui/src/pages/chat/session-prefetch.ts
@@ -220,20 +220,21 @@ class SessionPrefetcher {
     client: GatewayBrowserClient,
     candidate: SessionPrefetchCandidate,
   ): Promise<void> {
-    if (
-      !this.isCurrent(snapshot, candidate.snapshotKey) ||
-      this.isOpen(candidate.snapshotKey, this.snapshot)
-    ) {
+    // Every network request re-reads readiness: a presented pane can start
+    // loading during the persisted snapshot read or between history pages.
+    const mayRequest = () =>
+      this.isCurrent(snapshot, candidate.snapshotKey) &&
+      this.snapshot?.presentedTranscriptsReady === true;
+    if (!mayRequest() || this.isOpen(candidate.snapshotKey, this.snapshot)) {
       return;
     }
-    this.lastAttemptAt.set(candidate.snapshotKey, Date.now());
     try {
       let existing = readChatSessionSnapshot(this.cache, snapshot.snapshotHost, {
         sessionKey: candidate.snapshotKey,
       });
       if (!existing && this.snapshotStore.readSavedAt(candidate.snapshotKey) !== null) {
         existing = await this.snapshotStore.read(candidate.snapshotKey);
-        if (!this.isCurrent(snapshot, candidate.snapshotKey)) {
+        if (!mayRequest()) {
           return;
         }
         if (existing) {
@@ -245,11 +246,14 @@ class SessionPrefetcher {
           );
         }
       }
+      // The cooldown counts network attempts; a candidate yielded before its
+      // request stays eligible for the cycle after the presented transcript commits.
+      this.lastAttemptAt.set(candidate.snapshotKey, Date.now());
       let result = await requestChatSessionSnapshot(
         client,
         candidate.snapshotKey,
         this,
-        () => this.isCurrent(snapshot, candidate.snapshotKey),
+        mayRequest,
         existing?.deltaCursor,
       );
       if (!this.isCurrent(snapshot, candidate.snapshotKey)) {
@@ -266,9 +270,10 @@ class SessionPrefetcher {
           );
           existing = withoutCursor;
         }
-        result = await requestChatSessionSnapshot(client, candidate.snapshotKey, this, () =>
-          this.isCurrent(snapshot, candidate.snapshotKey),
-        );
+        if (!mayRequest()) {
+          return;
+        }
+        result = await requestChatSessionSnapshot(client, candidate.snapshotKey, this, mayRequest);
         if (!this.isCurrent(snapshot, candidate.snapshotKey)) {
           return;
         }

--- a/ui/src/pages/chat/session-prefetch.ts
+++ b/ui/src/pages/chat/session-prefetch.ts
@@ -5,6 +5,8 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import { requestChatSessionSnapshot } from "./chat-history-request.ts";
+import { CHAT_TRANSCRIPT_LOADING_CHANGED_EVENT } from "./chat-history-state.ts";
+import type { ChatPaneElement } from "./route-draft-focus-handoff.ts";
 import { MAX_CACHED_CHAT_SESSIONS } from "./session-cache.ts";
 import {
   appendChatMessageToCache,
@@ -27,6 +29,8 @@ type SessionPrefetchSnapshot = {
   client: GatewayBrowserClient | null;
   listRevision: number;
   openSessionKeys: readonly string[];
+  /** False while a presented pane is still fetching its transcript. */
+  presentedTranscriptsReady: boolean;
   rows: readonly GatewaySessionRow[] | null;
   snapshotHost: ChatSnapshotKeyHost;
 };
@@ -90,6 +94,7 @@ class SessionPrefetcher {
       !previous ||
       previous.client !== snapshot.client ||
       previous.listRevision !== snapshot.listRevision ||
+      previous.presentedTranscriptsReady !== snapshot.presentedTranscriptsReady ||
       !sameKeys(previous.openSessionKeys, snapshot.openSessionKeys)
     ) {
       this.schedule();
@@ -168,9 +173,12 @@ class SessionPrefetcher {
 
   private async prefetchEligibleSessions(): Promise<void> {
     const snapshot = this.snapshot;
+    // A presented transcript still in flight owns the socket; the pane's
+    // loading-changed event reschedules this cycle, so waiting costs no polling.
     if (
       !snapshot?.client ||
       !snapshot.rows ||
+      !snapshot.presentedTranscriptsReady ||
       document.visibilityState === "hidden" ||
       !this.connected
     ) {
@@ -196,114 +204,126 @@ class SessionPrefetcher {
     if (selection.deferMs !== null) {
       this.schedule(selection.deferMs);
     }
-    await Promise.all(
-      selection.candidates.map(async (candidate) => {
-        if (
-          !this.isCurrent(snapshot, candidate.snapshotKey) ||
-          this.isOpen(candidate.snapshotKey, this.snapshot)
-        ) {
+    // One transcript at a time: warming is background work, and a burst of full
+    // histories would starve the user's next click on the same socket. A pane
+    // that starts loading mid-cycle wins too; its loading-changed event resumes the rest.
+    for (const candidate of selection.candidates) {
+      if (!this.snapshot?.presentedTranscriptsReady) {
+        return;
+      }
+      await this.prefetchCandidate(snapshot, client, candidate);
+    }
+  }
+
+  private async prefetchCandidate(
+    snapshot: SessionPrefetchSnapshot,
+    client: GatewayBrowserClient,
+    candidate: SessionPrefetchCandidate,
+  ): Promise<void> {
+    if (
+      !this.isCurrent(snapshot, candidate.snapshotKey) ||
+      this.isOpen(candidate.snapshotKey, this.snapshot)
+    ) {
+      return;
+    }
+    this.lastAttemptAt.set(candidate.snapshotKey, Date.now());
+    try {
+      let existing = readChatSessionSnapshot(this.cache, snapshot.snapshotHost, {
+        sessionKey: candidate.snapshotKey,
+      });
+      if (!existing && this.snapshotStore.readSavedAt(candidate.snapshotKey) !== null) {
+        existing = await this.snapshotStore.read(candidate.snapshotKey);
+        if (!this.isCurrent(snapshot, candidate.snapshotKey)) {
           return;
         }
-        this.lastAttemptAt.set(candidate.snapshotKey, Date.now());
-        try {
-          let existing = readChatSessionSnapshot(this.cache, snapshot.snapshotHost, {
-            sessionKey: candidate.snapshotKey,
-          });
-          if (!existing && this.snapshotStore.readSavedAt(candidate.snapshotKey) !== null) {
-            existing = await this.snapshotStore.read(candidate.snapshotKey);
-            if (!this.isCurrent(snapshot, candidate.snapshotKey)) {
-              return;
-            }
-            if (existing) {
-              cacheChatSessionSnapshot(
-                this.cache,
-                snapshot.snapshotHost,
-                { sessionKey: candidate.snapshotKey },
-                existing,
-              );
-            }
-          }
-          let result = await requestChatSessionSnapshot(
-            client,
-            candidate.snapshotKey,
-            this,
-            () => this.isCurrent(snapshot, candidate.snapshotKey),
-            existing?.deltaCursor,
-          );
-          if (!this.isCurrent(snapshot, candidate.snapshotKey)) {
-            return;
-          }
-          if (result.kind === "reset") {
-            if (existing?.deltaCursor !== undefined) {
-              const { deltaCursor: _deltaCursor, ...withoutCursor } = existing;
-              cacheChatSessionSnapshot(
-                this.cache,
-                snapshot.snapshotHost,
-                { sessionKey: candidate.snapshotKey },
-                withoutCursor,
-              );
-              existing = withoutCursor;
-            }
-            result = await requestChatSessionSnapshot(client, candidate.snapshotKey, this, () =>
-              this.isCurrent(snapshot, candidate.snapshotKey),
-            );
-            if (!this.isCurrent(snapshot, candidate.snapshotKey)) {
-              return;
-            }
-          }
-          if (
-            this.isOpen(candidate.snapshotKey, this.snapshot) ||
-            this.currentActivityAt(candidate.snapshotKey) > candidate.activityAt
-          ) {
-            return;
-          }
-          let cached: ChatSessionSnapshot;
-          if (result.kind === "delta") {
-            for (const payload of result.messages) {
-              const event = asOptionalRecord(payload);
-              if (!event || !Object.hasOwn(event, "message")) {
-                continue;
-              }
-              appendChatMessageToCache(
-                this.cache,
-                snapshot.snapshotHost,
-                { sessionKey: candidate.snapshotKey },
-                event.message,
-                event,
-              );
-            }
-            const updated = readChatSessionSnapshot(this.cache, snapshot.snapshotHost, {
-              sessionKey: candidate.snapshotKey,
-            });
-            if (!updated) {
-              return;
-            }
-            cached = {
-              ...updated,
-              // Prefetch does not own transient run replay. Keep the prior cursor
-              // so the opening pane can consume the same authoritative snapshot.
-              ...(result.inFlightRun ? {} : { deltaCursor: result.deltaCursor }),
-              ...(Object.hasOwn(result.sessionInfo, "activeLeafEntryId")
-                ? { displayedLeafEntryId: result.sessionInfo.activeLeafEntryId?.trim() || null }
-                : {}),
-              sessionId: result.sessionInfo.sessionId?.trim() || updated.sessionId,
-            };
-          } else if (result.kind === "snapshot") {
-            cached = result.snapshot;
-          } else {
-            throw new Error("chat history page request returned a cursor reset");
-          }
+        if (existing) {
           cacheChatSessionSnapshot(
             this.cache,
             snapshot.snapshotHost,
             { sessionKey: candidate.snapshotKey },
-            cached,
+            existing,
           );
-        } catch (error) {
-          debugSessionPrefetch(`history fetch failed for ${candidate.snapshotKey}`, error);
         }
-      }),
-    );
+      }
+      let result = await requestChatSessionSnapshot(
+        client,
+        candidate.snapshotKey,
+        this,
+        () => this.isCurrent(snapshot, candidate.snapshotKey),
+        existing?.deltaCursor,
+      );
+      if (!this.isCurrent(snapshot, candidate.snapshotKey)) {
+        return;
+      }
+      if (result.kind === "reset") {
+        if (existing?.deltaCursor !== undefined) {
+          const { deltaCursor: _deltaCursor, ...withoutCursor } = existing;
+          cacheChatSessionSnapshot(
+            this.cache,
+            snapshot.snapshotHost,
+            { sessionKey: candidate.snapshotKey },
+            withoutCursor,
+          );
+          existing = withoutCursor;
+        }
+        result = await requestChatSessionSnapshot(client, candidate.snapshotKey, this, () =>
+          this.isCurrent(snapshot, candidate.snapshotKey),
+        );
+        if (!this.isCurrent(snapshot, candidate.snapshotKey)) {
+          return;
+        }
+      }
+      if (
+        this.isOpen(candidate.snapshotKey, this.snapshot) ||
+        this.currentActivityAt(candidate.snapshotKey) > candidate.activityAt
+      ) {
+        return;
+      }
+      let cached: ChatSessionSnapshot;
+      if (result.kind === "delta") {
+        for (const payload of result.messages) {
+          const event = asOptionalRecord(payload);
+          if (!event || !Object.hasOwn(event, "message")) {
+            continue;
+          }
+          appendChatMessageToCache(
+            this.cache,
+            snapshot.snapshotHost,
+            { sessionKey: candidate.snapshotKey },
+            event.message,
+            event,
+          );
+        }
+        const updated = readChatSessionSnapshot(this.cache, snapshot.snapshotHost, {
+          sessionKey: candidate.snapshotKey,
+        });
+        if (!updated) {
+          return;
+        }
+        cached = {
+          ...updated,
+          // Prefetch does not own transient run replay. Keep the prior cursor
+          // so the opening pane can consume the same authoritative snapshot.
+          ...(result.inFlightRun ? {} : { deltaCursor: result.deltaCursor }),
+          ...(Object.hasOwn(result.sessionInfo, "activeLeafEntryId")
+            ? { displayedLeafEntryId: result.sessionInfo.activeLeafEntryId?.trim() || null }
+            : {}),
+          sessionId: result.sessionInfo.sessionId?.trim() || updated.sessionId,
+        };
+      } else if (result.kind === "snapshot") {
+        cached = result.snapshot;
+      } else {
+        throw new Error("chat history page request returned a cursor reset");
+      }
+      cacheChatSessionSnapshot(
+        this.cache,
+        snapshot.snapshotHost,
+        { sessionKey: candidate.snapshotKey },
+        cached,
+      );
+    } catch (error) {
+      debugSessionPrefetch(`history fetch failed for ${candidate.snapshotKey}`, error);
+    }
   }
 
   private selectCandidates(snapshot: SessionPrefetchSnapshot): {
@@ -437,6 +457,9 @@ class SessionPrefetchController implements ReactiveController {
   }
 
   hostConnected(): void {
+    // Panes start and finish transcript loads inside their own updates, which
+    // never re-render the page; the pane reports both edges instead.
+    this.host.addEventListener(CHAT_TRANSCRIPT_LOADING_CHANGED_EVENT, this.sync);
     this.prefetcher.connect();
     this.sync();
   }
@@ -446,6 +469,7 @@ class SessionPrefetchController implements ReactiveController {
   }
 
   hostDisconnected(): void {
+    this.host.removeEventListener(CHAT_TRANSCRIPT_LOADING_CHANGED_EVENT, this.sync);
     this.clearSubscriptions();
     this.prefetcher.disconnect();
   }
@@ -465,17 +489,16 @@ class SessionPrefetchController implements ReactiveController {
     if (!context) {
       return;
     }
-    const panes = this.host.querySelectorAll<Element & { sessionKey?: string }>(
-      "openclaw-chat-pane",
-    );
-    const openSessionKeys = [...panes].flatMap((pane) =>
-      pane.sessionKey ? [pane.sessionKey] : [],
-    );
+    const panes = [...this.host.querySelectorAll<ChatPaneElement>("openclaw-chat-pane")];
+    const openSessionKeys = panes.flatMap((pane) => (pane.sessionKey ? [pane.sessionKey] : []));
     this.prefetcher.update({
       client:
         context.gateway.snapshot.phase === "connected" ? context.gateway.snapshot.client : null,
       listRevision: context.sessions.canonicalListRevision,
       openSessionKeys,
+      presentedTranscriptsReady: !panes.some(
+        (pane) => pane.presented !== false && pane.transcriptLoading === true,
+      ),
       rows: context.sessions.state.result?.sessions ?? null,
       snapshotHost: {
         assistantAgentId: context.gateway.snapshot.assistantAgentId,


### PR DESCRIPTION
## What Problem This Solves

Opening a chat deep link such as `/chat/main/question-about-using-7k-b9d6252e` on a personal Gateway showed a long serial waterfall and a multi-second tail in DevTools. Measured against a copy of that Gateway's state (338-message session, five other recent sessions):

- `chat.startup` for the visible session is a **1.92 MB** WebSocket frame. The Gateway never offered `permessage-deflate`, so the transcript went over the wire uncompressed (gzip would be ~263 KB).
- 250 ms after connect, `session-prefetch.ts` warmed the five most recently active sessions with **five parallel `chat.history` (limit 800) requests totalling 12.7 MB**, on the same socket the visible transcript was still using. In the live tab this is what stretched `/avatar/main`, fonts, and provider icons out to 7–9 s.

## Why This Change Was Made

- **Gateway WebSocket compression** (`server-runtime-state.ts`): offer `permessage-deflate` with no context takeover and a 4 KiB threshold. Streaming deltas stay raw; transcripts, rosters, and history pages compress 5–8×. The deflate extension keeps its own copy of the pre-auth `maxPayload`, so the post-auth receiver handoff now raises the receiver **and** the extension limit together (`raiseGatewayReceiverPayloadLimit`, shared with worker connections). Without that, an authenticated compressed request above 64 KiB closed the socket with 1009.
- **Transcript warming yields to the visible transcript** (`session-prefetch.ts`): the prefetcher waits until every presented pane's history has committed (pane exposes `transcriptLoading`; the pane dispatches `openclaw-chat-transcript-committed` after its post-commit hydration), and warms candidates one at a time instead of five in parallel.
- Not included, found on the way: `context.preload("chat", { pathname })` for a session path is a silent no-op (the router matches exact paths only), so the New Session → Chat `prepare` step never preloads anything; and a boot-time warm-up of the route's page chunks moved chat chunks one download wave earlier. Both change route ordering that current e2e contracts encode (URL before chat module; progressive pages self-loading before their loader), so they are tracked as follow-ups rather than folded in here.

## User Impact

Chat deep links reach the transcript sooner and the post-load tail shrinks: the visible transcript no longer competes with background warming, and large frames are ~7× smaller on the wire for browsers and `ws` clients. Peers that do not offer the extension are unaffected.

## Evidence

**Live tab (Chrome DevTools trace of the real Gateway at main `87dc48eed0c`, warm HTTP cache):** TTFB 263 ms, first paint 500 ms (behind the render-blocking `/themes/<theme>.css` request), FCP 832 ms, LCP 1,837 ms with 1,574 ms render delay. After startup, `/avatar/main`, fonts, and provider icons stretched to 7–9 s while the socket carried the five background `chat.history` frames.

**Real-payload measurement (`openclaw gateway call` on the Gateway host, this session):** `chat.startup` = 1,921,039 B raw, 263,089 B gzip; `chat.history` limit 1000 = 1,864,368 B raw.

**Local rig on a copy of the Gateway's state (same session, same sidebar), Playwright + CDP frame capture, 40 ms RTT / 50 Mbps emulation:**

| | before | after |
| --- | --- | --- |
| WebSocket extensions negotiated | none | `permessage-deflate; server_no_context_takeover; client_no_context_takeover` |
| background `chat.history` for other sessions | five in parallel, 430 ms after `chat.startup`, while the visible transcript was still in flight (12.7 MB) | one at a time, only after the presented transcript committed |

Transcript paint time itself is dominated by Gateway response time on this rig and varied more between Gateway restarts than between builds; the mock-Gateway harness (RPC ≈ 0) shows the same client-side cost for both builds (composer ≈ 500–630 ms, transcript ≈ 530–670 ms, 3 runs each).

**Tests:** `src/gateway/server/ws-connection/request-start.test.ts` (handoff raises receiver + deflate limits, refuses non-writable), `request-start.server.test.ts` (a real Gateway negotiates `permessage-deflate` and accepts a 128 KiB compressed post-auth request; fails on pre-fix code), `ui/src/pages/chat/session-prefetch.test.ts` (waits for the presented transcript; warms one session at a time).

**Prefetch readiness is owner-reported (ClawSweeper re-review):** every transcript load phase write goes through `setChatHistoryLoad` (`chat-history-state.ts`), which calls the pane-wired `transcriptLoadingChanged` hook on each loading edge; the pane dispatches `openclaw-chat-transcript-loading-changed` and the prefetch controller resamples on that one event. No render is spent on the edge. Regressions at three levels, each failing on the previous head: `session-prefetch.test.ts` (controller resamples without a host update), `chat-pane-history.test.ts` (real ChatPane state reports start and commit edges from `loadChatHistory`), and `ui/src/e2e/chat-session-prefetch-gating.e2e.test.ts` (Playwright + mock Gateway: a `session.message` reload of the presented pane is held on the wire while the prefetcher's cooldown retry fires; warming must not start, and resumes once the reload commits).

**Review races closed (third ClawSweeper pass):** a worker whose payload-limit handoff is unusable is rejected before `worker-hello-ok` (`UNAVAILABLE`, close 1011 `gateway-unavailable`; `server.public-worker-ingress.test.ts` freezes the receiver and the negotiated deflate limits against a real ws server), and the prefetcher re-evaluates readiness immediately before every network request, including after its IndexedDB snapshot read and between history pages (`session-prefetch.test.ts` holds the persisted read while the presented pane starts loading). Both regressions fail on the previous head.

**WebSocket consumers (live):** Control UI, Node CLI, iOS simulator, Android emulator (OkHttp 5.4.0, handshake + inflated-frame capture: `chat.history` 134,320 B on the wire for 934,761 B of JSON), macOS (same OpenClawKit transport), Tauri (no extension offer, unaffected) — details in the compatibility comment on this PR. No consumer needed a code change.

