### PR TITLE
fix(whatsapp): show the reason a turn ended instead of going silent

### DIFF
--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.error-delivery.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.error-delivery.test.ts
@@ -1,0 +1,85 @@
+// WhatsApp web auto-reply terminal failure delivery behavior.
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  createMockWebListener,
+  createWebInboundDeliverySpies,
+  installWebAutoReplyTestHomeHooks,
+  installWebAutoReplyUnitTestHooks,
+  sendWebDirectInboundMessage,
+  sendWebGroupInboundMessage,
+} from "./auto-reply.test-harness.js";
+import type { WebInboundCallbackMessage } from "./inbound.js";
+
+installWebAutoReplyTestHomeHooks();
+
+let monitorWebChannel: typeof import("./auto-reply/monitor.js").monitorWebChannel;
+
+const TERMINAL_FAILURE_TEXT = "⚠️ The model ended this turn without answering.";
+const SELF_JID = "123@s.whatsapp.net";
+
+describe("web auto-reply terminal failure delivery", () => {
+  installWebAutoReplyUnitTestHooks({ pinDns: true });
+  type ListenerFactory = NonNullable<Parameters<typeof monitorWebChannel>[1]>;
+
+  beforeAll(async () => {
+    ({ monitorWebChannel } = await import("./auto-reply/monitor.js"));
+  });
+
+  async function startMonitorWithTerminalFailure(): Promise<{
+    spies: ReturnType<typeof createWebInboundDeliverySpies>;
+    onMessage: (msg: WebInboundCallbackMessage) => Promise<void>;
+  }> {
+    const spies = createWebInboundDeliverySpies();
+    const resolver = vi.fn().mockResolvedValue({ text: TERMINAL_FAILURE_TEXT, isError: true });
+    let capturedOnMessage: Parameters<ListenerFactory>[0]["onMessage"] | undefined;
+    const listenerFactory: ListenerFactory = async ({ onMessage }) => {
+      capturedOnMessage = onMessage;
+      return createMockWebListener();
+    };
+
+    await monitorWebChannel(false, listenerFactory, false, resolver);
+    if (!capturedOnMessage) {
+      throw new Error("expected WhatsApp web message handler");
+    }
+    return { spies, onMessage: capturedOnMessage };
+  }
+
+  it("sends a terminal failure final to a direct chat", async () => {
+    const { spies, onMessage } = await startMonitorWithTerminalFailure();
+
+    await sendWebDirectInboundMessage({
+      onMessage,
+      spies,
+      id: "direct-terminal-failure",
+      from: "+1000",
+      to: "+2000",
+      body: "hello",
+    });
+
+    expect(spies.reply).toHaveBeenCalledTimes(1);
+    const sentText = spies.reply.mock.calls[0]?.[0];
+    expect(sentText).toContain(TERMINAL_FAILURE_TEXT);
+    // Suppressing the terminal failure previously left core to substitute its generic
+    // no-visible-reply fallback, which hides the real reason the turn ended.
+    expect(sentText).not.toContain("No reply was generated");
+  });
+
+  it("sends a terminal failure final to a group chat", async () => {
+    const { spies, onMessage } = await startMonitorWithTerminalFailure();
+
+    await sendWebGroupInboundMessage({
+      onMessage,
+      spies,
+      id: "group-terminal-failure",
+      body: "hello",
+      senderE164: "+1000",
+      senderName: "Tester",
+      selfE164: "+2000",
+      selfJid: SELF_JID,
+      mentionedJids: [SELF_JID],
+    });
+
+    expect(spies.reply).toHaveBeenCalledTimes(1);
+    expect(spies.reply.mock.calls[0]?.[0]).toContain(TERMINAL_FAILURE_TEXT);
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -1758,7 +1758,7 @@ describe("whatsapp inbound dispatch", () => {
     expect(deliverReply).not.toHaveBeenCalled();
   });
 
-  it("suppresses error payload text", async () => {
+  it("delivers final error payload text", async () => {
     const deliverReply = vi.fn(async () => acceptedDeliveryResult());
     await dispatchBufferedReply({ deliverReply });
 
@@ -1767,8 +1767,23 @@ describe("whatsapp inbound dispatch", () => {
 
     await deliver?.({ text: "provider exploded", isError: true }, { kind: "final" });
 
-    expect(deliverReply).not.toHaveBeenCalled();
+    expect(deliverReply).toHaveBeenCalledTimes(1);
   });
+
+  it.each([{ kind: "block" as const }, { kind: "tool" as const }])(
+    "suppresses $kind error payload noise",
+    async ({ kind }) => {
+      const deliverReply = vi.fn(async () => acceptedDeliveryResult());
+      await dispatchBufferedReply({ deliverReply });
+
+      const deliver = getCapturedDeliver();
+      expect(deliver).toBeTypeOf("function");
+
+      await deliver?.({ text: "tool call failed", isError: true }, { kind });
+
+      expect(deliverReply).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -14,7 +14,7 @@ import {
   resolveChannelStreamingBlockEnabled,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { buildInboundHistoryFromEntries } from "openclaw/plugin-sdk/reply-history";
-import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import type { FinalizedMsgContext, ReplyDispatchKind } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   requireWhatsAppInboundAdmission,
@@ -59,7 +59,6 @@ import {
   type resolveAgentRoute,
 } from "./runtime-api.js";
 
-type ReplyLifecycleKind = "tool" | "block" | "final";
 type ChannelReplyOnModelSelected = NonNullable<
   ReturnType<typeof createChannelMessageReplyPipeline>["onModelSelected"]
 >;
@@ -90,7 +89,7 @@ type WhatsAppInboundTransportContext = WhatsAppReplyTransportContext & {
   sendComposing: AdmittedWebInboundMessage["platform"]["sendComposing"];
 };
 
-type ReplyDeliveryInfo = { kind: ReplyLifecycleKind };
+type ReplyDeliveryInfo = { kind: ReplyDispatchKind };
 
 type PendingWhatsAppMediaOnlyPayload = {
   info: ReplyDeliveryInfo;
@@ -217,12 +216,15 @@ function resolveWhatsAppDurableReplyToId(params: {
 
 function resolveWhatsAppDeliverablePayload(
   payload: ReplyPayload,
-  info: { kind: ReplyLifecycleKind },
+  info: { kind: ReplyDispatchKind },
 ): ReplyPayload | null {
   if (payload.isReasoning === true || payload.isCompactionNotice === true) {
     return null;
   }
-  if (payload.isError === true) {
+  // Only mid-turn error noise (streamed blocks, tool progress) is suppressed. A final error
+  // payload is the host-owned terminal outcome of the turn; dropping it leaves the chat silent
+  // or replaced by the generic no-visible-reply fallback after a refused or failed run.
+  if (payload.isError === true && info.kind !== "final") {
     return null;
   }
   if (info.kind === "tool") {
@@ -757,7 +759,7 @@ export function createWhatsAppReplyPlan(params: {
   };
   const delivery: ChannelInboundTurnPlan["delivery"] = {
     observeMessageSent: true,
-    preparePayload: async (payload: ReplyPayload, info: { kind: ReplyLifecycleKind }) => {
+    preparePayload: async (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => {
       const deliveryPayload = resolveWhatsAppDeliverablePayload(payload, info);
       if (!deliveryPayload) {
         return null;
@@ -802,7 +804,7 @@ export function createWhatsAppReplyPlan(params: {
         },
       };
     },
-    deliver: async (payload: ReplyPayload, info: { kind: ReplyLifecycleKind }) => {
+    deliver: async (payload: ReplyPayload, info: { kind: ReplyDispatchKind }) => {
       const normalizedDeliveryPayload = payload as DeliverableWhatsAppOutboundPayload<ReplyPayload>;
       const reply = resolveSendableOutboundReplyParts(normalizedDeliveryPayload);
       if (!reply.hasMedia && !reply.text.trim()) {
@@ -897,7 +899,7 @@ export function createWhatsAppReplyPlan(params: {
     finalize: (dispatchResult: {
       observedReplyDelivery?: boolean;
       queuedFinal?: boolean;
-      counts?: Partial<Record<ReplyLifecycleKind, number>>;
+      counts?: Partial<Record<ReplyDispatchKind, number>>;
     }): boolean => {
       const didQueueVisibleReply = hasVisibleInboundReplyDispatch(dispatchResult);
       const didDeliverVisibleReply = didSendReply || dispatchResult.observedReplyDelivery === true;

--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -578,6 +578,30 @@ describe("createWhatsAppOutboundBase", () => {
     );
   });
 
+  it("returns a real platform identity for routed error payloads", async () => {
+    const sendMessageWhatsApp = vi.fn(async () => ({
+      messageId: "msg-error-1",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+    const outbound = createWhatsAppOutboundBase({
+      sendMessageWhatsApp,
+      sendPollWhatsApp: vi.fn(),
+      shouldLogVerbose: () => false,
+      resolveTarget: ({ to }) => ({ ok: true as const, to: to ?? "" }),
+    });
+
+    const result = await outbound.sendPayload!({
+      cfg: {} as never,
+      to: "whatsapp:+15551234567",
+      text: "",
+      payload: { text: "⚠️ the run ended without an answer", isError: true },
+      deps: { sendWhatsApp: sendMessageWhatsApp },
+    });
+
+    expect(sendMessageWhatsApp).toHaveBeenCalledTimes(1);
+    expect(result.messageId).toBe("msg-error-1");
+  });
+
   it("normalizes mediaUrls before payload delivery", async () => {
     const sendMessageWhatsApp = vi.fn(async () => ({
       messageId: "msg-1",

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -172,9 +172,6 @@ export function createWhatsAppOutboundBase({
   return {
     ...outbound,
     sendPayload: async (ctx) => {
-      if (ctx.payload.isError === true) {
-        return { channel: "whatsapp", messageId: "" };
-      }
       const payload = normalizeWhatsAppOutboundPayload(ctx.payload, { normalizeText });
       if (!payload.text && !(payload.mediaUrl || payload.mediaUrls?.length)) {
         if (ctx.payload.interactive || ctx.payload.presentation || ctx.payload.channelData) {


### PR DESCRIPTION
Closes #136560

## What Problem This Solves

Fixes an issue where WhatsApp users whose turn ends in a terminal failure - a model policy refusal, a blocked run, a terminal timeout - see either nothing at all or a misleading generic message, instead of the reason the turn ended.

OpenClaw already builds a sanitized, host-owned final message for these outcomes and marks it as an error payload. WhatsApp threw that message away in two independent places, so the chat went quiet. Core then substituted its own fallback, `No reply was generated for this message. This is usually a temporary model failure - please try again.`, which tells the user to retry something the model actually refused. On the routed send path there was not even that: the adapter returned an empty message id, which core recorded as `adapter_returned_no_identity` and the user never learned anything happened.

This is the repository's worst failure class: an action that ends with no visible outcome.

## Why This Change Was Made

The violated invariant is that every interactive turn ends in a visible outcome or a recorded, intentional non-outcome. The owner of that invariant at this boundary is the WhatsApp delivery seam, and it was the only channel breaking it.

**Where it broke.** `resolveWhatsAppDeliverablePayload()` in `extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts` returned `null` for every payload with `isError === true`, ignoring the lifecycle kind it already receives. `sendPayload()` in `extensions/whatsapp/src/outbound-base.ts` independently returned `{ messageId: "" }` for the same payloads. Both drops are unconditional; the same code path serves direct chats and groups (`createWhatsAppReplyPlan` has one production caller, `extensions/whatsapp/src/auto-reply/monitor/process-message.ts:561`), so both surfaces lose the message.

**Why the drops existed.** They are not a product decision. #71830 added a per-account `channels.whatsapp.exposeErrorText` knob for Telegram parity, defaulting to *expose*; both guards were written as `exposeErrorText === false`. #74642 removed the config surface a day later and collapsed the condition into an unconditional branch, with no stated behavioral rationale and no linked report. Nothing has touched either guard since (`git log -L` over both blocks). Meanwhile `extensions/whatsapp/src/channel-outbound.ts:72` still declares `sendTextOnlyErrorPayloads: true`, which is what forces error payloads down `sendPayload` in the first place (`src/channels/message/capabilities.ts:66-85`, `src/infra/outbound/deliver-core.ts:365-387`) - the channel was opting in to receive error payloads and then discarding what it asked for.

**Why core could not compensate.** Core already distinguishes intentional silence from terminal failure: `markAgentRunFailureReplyPayload` (`src/auto-reply/reply/agent-runner-failure-reply.ts:359-365`) leaves the silent-reply token unmarked and marks everything else `isError` plus deliver-despite-suppression. `src/auto-reply/reply/followup-delivery.ts:181-195` then disables stranded-reply recovery precisely because a terminal failure payload exists and is expected to be delivered. WhatsApp's drop defeated that recovery.

**The fix.** Suppression is scoped to the lifecycle kind that already discriminates noise from outcome. Streamed block and tool error payloads stay silent; final payloads are delivered through the normal receipted path. The outbound empty-identity shortcut is deleted, so a routed final now returns a real platform receipt or a real delivery failure. No string matching on message text, no provider or policy name in production code.

**Pathfinder cleanup in the same seam.** `inbound-dispatch.ts` declared its own `ReplyLifecycleKind = "tool" | "block" | "final"` instead of the canonical `ReplyDispatchKind` the SDK exports, which Discord and Slack already import. Replaced.

**Scope.** This PR owns the delivery boundary only. Classifying a Codex policy block into a structured refusal category, and the wording of the resulting message, is a separate producer-side concern being handled elsewhere; #126144 tracks the misleading copy and is not claimed fixed here. The follow-ups this work uncovered are listed below.

## User Impact

- A refused or failed turn now produces one visible WhatsApp message saying the turn ended, in direct chats and in groups, instead of silence or a retry prompt for something that will not succeed on retry.
- Mid-turn tool and streaming error noise stays suppressed; nothing new appears during a normal turn.
- Routed sends of a final error payload return a real message id, so delivery bookkeeping stops reporting a fake success.
- No configuration change, no migration, no new option. Behavior change is confined to WhatsApp.

## Evidence

### Codex upstream contract (inspected directly in the sibling checkout)

Sibling `../codex` at `b7f710273e14ef2d79d510a06385c2a67285585a`. Read to confirm what a terminal policy block actually looks like on the wire, and that it is terminal rather than retryable:

- `codex-rs/codex-api/src/sse/responses.rs:413-462` - a `response.failed` event maps `cyber_policy` to `ApiError::CyberPolicy`, `misalignment_policy_violation` to `ApiError::MisalignmentPolicyViolation`, and `invalid_prompt` / `bio_policy` to `ApiError::InvalidRequest`.
- `codex-rs/protocol/src/error.rs:137-143` - the `CyberPolicy { message }` and `MisalignmentPolicyViolation { message, misalignment }` variants.
- `codex-rs/protocol/src/error.rs:371-412` - `is_retryable()` returns `false` for both. These end the turn; they are not transient.
- `codex-rs/app-server/src/bespoke_event_handling.rs:1022-1063` - a turn-affecting `EventMsg::Error` is forwarded through `handle_error_notification`.
- `codex-rs/app-server/src/bespoke_event_handling.rs:1715-1730` - that notification carries `will_retry: false`.
- `codex-rs/app-server/src/bespoke_event_handling.rs:1394-1420` - the paired `turn/completed` notification carries the failed status and the `TurnError`.
- `codex-rs/app-server-protocol/src/protocol/v2/shared.rs:123-160` - `CodexErrorInfo` carries `CyberPolicy` and `MisalignmentPolicyViolation` across the app-server boundary.

So the harness does deliver a terminal, non-retryable failure to OpenClaw, and OpenClaw does turn it into a host-owned final error payload. The loss is downstream of both.

### Failing-then-passing proof

Run on Blacksmith Testbox from the branch worktree, not locally.

Command (both runs):

```
node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json -- \
  OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test \
  extensions/whatsapp/src/outbound-base.test.ts \
  extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts \
  extensions/whatsapp/src/auto-reply.web-auto-reply.error-delivery.test.ts
```

**Before the fix** (new and changed tests present, both production guards restored) - provider `blacksmith-testbox`, lease `tbx_01m1jgs9act9ggqyqksg4rm5ps`, exit 1, `Tests 4 failed | 92 passed (96)`:

```
FAIL  extensions/whatsapp/src/auto-reply.web-auto-reply.error-delivery.test.ts
      > sends a terminal failure final to a direct chat
Expected: "⚠️ The model ended this turn without answering."
Received: "No reply was generated for this message. This is usually a temporary model failure - please try again."

FAIL  extensions/whatsapp/src/auto-reply.web-auto-reply.error-delivery.test.ts
      > sends a terminal failure final to a group chat
Expected: "⚠️ The model ended this turn without answering."
Received: "No reply was generated for this message. This is usually a temporary model failure - please try again."

FAIL  extensions/whatsapp/src/outbound-base.test.ts
      > returns a real platform identity for routed error payloads

FAIL  extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
      > delivers final error payload text
```

The direct-chat and group failures are the user-visible symptom captured verbatim: the real reason is replaced by a retry prompt.

**After the fix** - provider `blacksmith-testbox`, lease `tbx_01m1jh57yhnacnt5g1gkn73jz9`, exit 0, `Test Files 3 passed (3)`, `Tests 96 passed (96)`.

**Extensions typecheck** - provider `blacksmith-testbox`, lease `tbx_01m1jgcge19c8h39rwhdw256wk`, `pnpm tsgo:extensions`, exit 0.

The two new direct/group tests are channel-level, not unit-level: they drive the real WhatsApp inbound monitor through `monitorWebChannel` and assert on the transport `reply` spy, so the assertion is on what the channel actually sends.

### Behavior preserved

`inbound-dispatch.test.ts` gains a table-driven case asserting that `block` and `tool` error payloads are still dropped. Those cases pass both before and after the fix, which is the point: the noise suppression this guard was reached for is untouched.

### Sibling coverage

Checked every channel that references `isError` in production code. No sibling has an unconditional terminal-error drop:

- **Telegram** explicitly delivers error finals durably after tearing down the progress window (`extensions/telegram/src/bot-message-dispatch-delivery.ts:472-486`). Its `silentErrorReplies` option maps to `disable_notification`, not suppression.
- **Slack** narrows suppression to passive channel posts that are not DMs, not explicitly addressed, and replaced by a tracked failure notice (`extensions/slack/src/monitor/message-handler/dispatch.ts:109-162`); it already keys other decisions on `info.kind !== "final"` at `:194`.
- **Discord** defers rather than drops, and only for the tool-warning class (`extensions/discord/src/monitor/message-handler.process.ts:56-61`, `:337-349`).
- **Matrix** and **Feishu** use `isError` only for draft redaction and presentation dedupe.
- **Signal**, **iMessage**, **Google Chat**, **LINE**, and the core built-in channels have no `isError` handling at all and deliver these payloads normally.
- `sendTextOnlyErrorPayloads` is declared by exactly two channels: WhatsApp and the QA harness channel, whose `sendPayload` actually sends (`extensions/qa-channel/src/channel.ts:285-289`).

### Premise check

#84569 reported the same WhatsApp loss through an incomplete-turn path. Its candidate fix #84578 proposed the same shape and was **not** rejected on design - the review rated patch quality highly, cleared security, and confirmed the root cause reproducible; it stalled on missing transport-level evidence and was closed by its own author. That is the gap this PR closes with the two channel-level direct/group tests. #87561 asks for the broader typed delivery outcome across channels and explicitly rules that `messageId: ""` must not count as successful delivery for visible final text; deleting the outbound shortcut moves WhatsApp onto the right side of that contract without pre-empting the wider design.

### Production LOC

`git diff --numstat` against `origin/main`, split by hand:

| File | + | - | class |
| --- | --- | --- | --- |
| `extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts` | 10 | 8 | production |
| `extensions/whatsapp/src/outbound-base.ts` | 0 | 3 | production |
| `extensions/whatsapp/src/auto-reply.web-auto-reply.error-delivery.test.ts` | 85 | 0 | test |
| `extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts` | 17 | 2 | test |
| `extensions/whatsapp/src/outbound-base.test.ts` | 24 | 0 | test |

**Production: +10 / -11, net -1.** Three of the added production lines are the inline comment recording why finals must pass while mid-turn noise is suppressed. Tests: +126 / -2.

### Proof gaps

- The Codex harness was not driven live. A real policy refusal needs a provider account and a prompt that trips the upstream filter, neither of which is reproducible on demand. The upstream contract is cited from source above instead, and the OpenClaw-side payload it produces is exercised directly at the delivery boundary, which is the code this PR changes.
- No live WhatsApp account was used. The available WhatsApp installations are personal and not test surfaces. The channel-level tests drive the real monitor and assert on the transport call, which is the strongest proof this repository can produce without one.

### Follow-ups (not fixed here)

- #136860 - memory-flush degradation ends with no visible outcome and no recorded reason. Same doctrine, different owner: `src/agents/command/post-run.ts:339-354` supplies no `onVisibleErrorPayloads` and never reads `outcome`, while `src/auto-reply/reply/agent-runner-execute.ts:207-212` discards the payloads into a verbose log. Filed while investigating this one.
- `nonTerminalToolErrorWarning` has no production writer since `c6cbe92dfc9` (#135148) removed it, so the reader `isReplyPayloadNonTerminalToolErrorWarning` always returns `false` and the tool-noise carve-outs it gates in Discord, Telegram, and Slack are inert. Behavior-neutral to remove, but it spans core plus three channels and a different invariant from this one, so it is called out rather than folded in.
