### PR TITLE
test(android): retain queued input after failed refresh health

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
@@ -764,6 +764,9 @@ class ChatControllerBranchCoordinationTest {
           .getValue("content")
           .jsonPrimitive.content,
       )
+    } else {
+      assertEquals("Failed health refresh must not dispatch after branch reconciliation completes", 0, gateway.callCount("chat.send"))
+      assertEquals(admitted, outbox.load("gateway-a").single())
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

This maintainer-requested Android test-only follow-up closes an assertion gap in the failed-health refresh case: after branch reconciliation completes, the existing test did not explicitly verify that the queued input remained intact and that no `chat.send` was dispatched. No runtime defect is established by this change.

## Why This Change Was Made

Extend the existing shared refresh-health helper with the two post-completion assertions. The helper releases branch reconciliation, joins both captured jobs, and drains current scheduler work before checking failed-health behavior. Full outbox-row equality preserves queued status, identity, attempt and branch epochs, text, and attachment metadata. The healthy sibling continues to verify exactly-once dispatch using the same fixture and ordering.

## User Impact

No user-visible runtime change. This strengthens maintainer-requested coverage only: +3/-0 test lines, 0 production lines. Runtime logic, scheduler behavior, timeouts, schemas, configuration, versions, and release files are unchanged.

## Evidence

- `node --import ./scripts/tsx.mjs scripts/run-android-gradle.mts --no-daemon --build-cache --max-workers=2 :app:testPlayDebugUnitTest --tests ai.openclaw.app.chat.ChatControllerBranchCoordinationTest` — passed; 49 tests, 0 skipped, 0 failures, 0 errors. Both failed-health and healthy refresh-supersession cases passed.
- `GRADLE_OPTS="${GRADLE_OPTS:+$GRADLE_OPTS }-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2" node scripts/check-changed.mjs -- apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt` — passed, including Android ktlint and the native state-schema guard.
- `git diff --check` — passed.
- Fresh isolated Codex autoreview with the complete target test and outbox data contract as context — scoped-clean at P0; no findings.

This is assertion-coverage strengthening, not a production regression fix, so no failing-before/passing-after runtime claim is made. Proof is the existing scripted-gateway/Room JVM test flow, not a live gateway or device run. No rendered behavior changed; device screenshots are not applicable.


CI recovery: [attempt 1 of run 33708008071](https://github.com/openclaw/openclaw/actions/runs/33708008071/attempts/1) failed in [android-test-third-party, job 100501562988](https://github.com/openclaw/openclaw/actions/runs/33708008071/job/100501562988), followed by the aggregate CI gate. The timeout in `TalkModeManagerTest.lateFinalUserTranscriptKeepsTheAnsweredUtteranceStatus` was at the initial `connected.await()` in `withRealtimePlayback` (`TalkModeManagerTest.kt:2186`), before enabling Talk or dispatching scenario audio/transcripts. The failed test comes from the main side of the CI merge, not this PR's submitted branch. The underlying connection stall remains unknown; no runtime-defect or infrastructure-only claim is made.

The exact executed merge [65eb3537d2a8f1a75d27f07dc34f79b2c8f520d7](https://github.com/openclaw/openclaw/commit/65eb3537d2a8f1a75d27f07dc34f79b2c8f520d7) passed unchanged locally:

- `node --import ./scripts/tsx.mjs scripts/run-android-gradle.mts --no-daemon --build-cache --max-workers=2 :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.voice.TalkModeManagerTest.lateFinalUserTranscriptKeepsTheAnsweredUtteranceStatus` — passed, including all 14 internal cases.
- `node --import ./scripts/tsx.mjs scripts/run-android-gradle.mts --no-daemon --build-cache --max-workers=2 :app:testThirdPartyDebugUnitTest` — passed: 2,816 tests, 0 skipped, 0 failures, 0 errors, including 89 voice tests and 49 branch-coordination tests.

After source/history diagnosis and the immutable full-suite pass, the maintainer authorized one controlled `gh run rerun 33708008071 --repo openclaw/openclaw --failed` on unchanged source head `0542fdb39590c739511ebebbc9fc7b7625380bcd`. That single retry completed successfully as attempt 2. The [third-party Android job 100508876291](https://github.com/openclaw/openclaw/actions/runs/33708008071/job/100508876291) and [aggregate gate 100510519927](https://github.com/openclaw/openclaw/actions/runs/33708008071/job/100510519927) both passed. All selected hosted checks are green for the unchanged full head SHA. No source, timeout, mock, or test-exception changes were made.

[ClawSweeper's latest review](https://github.com/openclaw/openclaw/pull/136867#issuecomment-5519512223), reviewed at 03:22 UTC, has no patch findings. Its Before merge and Rank-up request—obtain a successful exact-head third-party Android gate—is satisfied by job 100508876291; the aggregate gate also passed. The maintainer scope decision remains to land the unchanged three-line coverage addition after native gates. If the connection timeout recurs, the named follow-up is to capture connection failure/progress, case identity, and thread state at the existing deadline before choosing a repair. No speculative repair is included here.
