### PR TITLE
test(moonshot): consolidate private helper coverage

### DIFF
--- a/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
@@ -499,11 +499,3 @@ export async function runKimiSearchProviderSetup(
   setProviderWebSearchPluginConfigValue(next, "moonshot", "model", model);
   return next;
 }
-
-export const testing = {
-  resolveKimiApiKey,
-  resolveKimiModel,
-  resolveKimiBaseUrl,
-  extractKimiCitations,
-  extractKimiToolResultContent,
-} as const;

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -1,10 +1,11 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
-import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
+import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createKimiWebSearchProvider } from "./kimi-web-search-provider.js";
-import { testing } from "./kimi-web-search-provider.runtime.js";
 
-const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
+const globalBaseUrl = "https://api.moonshot.ai/v1";
+const cnBaseUrl = "https://api.moonshot.cn/v1";
+const explicitBaseUrl = "https://kimi.example/v1";
+const explicitWebSearch = { baseUrl: `${explicitBaseUrl}/`, model: "kimi-k2" };
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -56,70 +57,54 @@ describe("kimi web search provider", () => {
     });
   });
 
-  it("uses configured model and base url overrides with sane defaults", () => {
-    expect(testing.resolveKimiModel()).toBe("kimi-k2.6");
-    expect(testing.resolveKimiModel({ model: "kimi-k2" })).toBe("kimi-k2");
-    expect(testing.resolveKimiBaseUrl()).toBe("https://api.moonshot.ai/v1");
-    expect(testing.resolveKimiBaseUrl({ baseUrl: "https://kimi.example/v1" })).toBe(
-      "https://kimi.example/v1",
-    );
-  });
-
-  it("inherits native Moonshot chat baseUrl when kimi baseUrl is unset", () => {
-    const cnConfig = {
-      models: { providers: { moonshot: { baseUrl: "https://api.moonshot.cn/v1" } } },
-    } as unknown as OpenClawConfig;
-    const cnConfigWithTrailingSlash = {
-      models: { providers: { moonshot: { baseUrl: "https://api.moonshot.cn/v1/" } } },
-    } as unknown as OpenClawConfig;
-
-    expect(testing.resolveKimiBaseUrl(undefined, cnConfig)).toBe("https://api.moonshot.cn/v1");
-    expect(testing.resolveKimiBaseUrl(undefined, cnConfigWithTrailingSlash)).toBe(
-      "https://api.moonshot.cn/v1",
-    );
-  });
-
-  it("does not inherit non-native Moonshot baseUrl for web search", () => {
-    const proxyConfig = {
-      models: { providers: { moonshot: { baseUrl: "https://proxy.example/v1" } } },
-    } as unknown as OpenClawConfig;
-
-    expect(testing.resolveKimiBaseUrl(undefined, proxyConfig)).toBe("https://api.moonshot.ai/v1");
-  });
-
-  it("keeps explicit kimi baseUrl over models.providers.moonshot.baseUrl", () => {
-    const moonshotConfig = {
-      models: { providers: { moonshot: { baseUrl: "https://api.moonshot.cn/v1" } } },
-    } as unknown as OpenClawConfig;
-
-    expect(
-      testing.resolveKimiBaseUrl({ baseUrl: "https://api.moonshot.ai/v1" }, moonshotConfig),
-    ).toBe("https://api.moonshot.ai/v1");
-  });
-
-  it("extracts unique citations from search results and tool call arguments", () => {
-    expect(
-      testing.extractKimiCitations({
-        search_results: [{ url: "https://a.test" }, { url: "https://b.test" }],
-        choices: [
-          {
-            message: {
-              tool_calls: [
-                {
-                  function: {
-                    arguments: JSON.stringify({
-                      url: "https://a.test",
-                      search_results: [{ url: "https://c.test" }],
-                    }),
+  it.each([
+    ["defaults", undefined, {}, globalBaseUrl, "kimi-k2.6"],
+    ["inherits native CN", `${cnBaseUrl}/`, {}, cnBaseUrl, "kimi-k2.6"],
+    ["rejects proxy inheritance", "https://proxy.example/v1", {}, globalBaseUrl, "kimi-k2.6"],
+    ["prefers explicit Kimi config", cnBaseUrl, explicitWebSearch, explicitBaseUrl, "kimi-k2"],
+  ])(
+    "applies %s configuration at the tool boundary",
+    async (name, chatBaseUrl, webSearch, baseUrl, model) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          search_results: [{ url: "https://a.test" }],
+          choices: [{ finish_reason: "stop", message: { content: "Grounded answer" } }],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const tool = createKimiWebSearchProvider().createTool({
+        config: {
+          ...(chatBaseUrl
+            ? { models: { providers: { moonshot: { baseUrl: chatBaseUrl, models: [] } } } }
+            : {}),
+          plugins: {
+            entries: {
+              moonshot: {
+                config: {
+                  webSearch: {
+                    apiKey: "kimi-config-key",
+                    ...webSearch,
                   },
                 },
-              ],
+              },
             },
           },
-        ],
-      }),
-    ).toEqual(["https://a.test", "https://b.test", "https://c.test"]);
-  });
+        },
+        searchConfig: {},
+      } as never);
+      if (!tool) {
+        throw new Error("Expected tool definition");
+      }
+
+      await tool.execute({ query: `Kimi boundary ${name}` });
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(`${baseUrl}/chat/completions`);
+      const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer kimi-config-key");
+      expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toMatchObject({
+        model,
+      });
+    },
+  );
 
   it("returns a structured failure for ungrounded chat-only responses", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
@@ -179,6 +164,7 @@ describe("kimi web search provider", () => {
   it("accepts final responses backed by Kimi web search tool replay", async () => {
     const toolArguments = JSON.stringify({
       query: "OpenClaw GitHub repository",
+      search_results: [{ url: "https://github.com/openclaw/openclaw" }],
       usage: { total_tokens: 1200 },
     });
     const fetchMock = vi
@@ -221,7 +207,7 @@ describe("kimi web search provider", () => {
 
       expect(result.provider).toBe("kimi");
       expectStringFieldContains(result, "content", "OpenClaw is available on GitHub.");
-      expect(result.citations).toEqual([]);
+      expect(result.citations).toEqual(["https://github.com/openclaw/openclaw"]);
       expect(result).not.toHaveProperty("error");
     });
   });
@@ -380,26 +366,6 @@ describe("kimi web search provider", () => {
     });
   });
 
-  it("returns original tool arguments as tool content", () => {
-    const rawArguments = '  {"query":"MacBook Neo","usage":{"total_tokens":123}}  ';
-
-    expect(
-      testing.extractKimiToolResultContent({
-        function: {
-          arguments: rawArguments,
-        },
-      }),
-    ).toBe(rawArguments);
-
-    expect(
-      testing.extractKimiToolResultContent({
-        function: {
-          arguments: "   ",
-        },
-      }),
-    ).toBeUndefined();
-  });
-
   it("forwards the execution abort signal to an in-flight Kimi search", async () => {
     const fetchMock = vi.fn(
       (_url: string, init?: RequestInit) =>
@@ -463,16 +429,6 @@ describe("kimi web search provider", () => {
       await tool.execute({ query });
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  it("uses config apiKey when provided", () => {
-    expect(testing.resolveKimiApiKey({ apiKey: "kimi-test-key" })).toBe("kimi-test-key");
-  });
-
-  it("falls back to env apiKey", () => {
-    withEnv({ [kimiApiKeyEnv]: "kimi-env-key" }, () => {
-      expect(testing.resolveKimiApiKey({})).toBe("kimi-env-key");
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Kimi web-search tests duplicated model, base-URL, credential, citation, and request helper behavior through a private `testing` facade.

## Why This Change Was Made

The private facade is removed and configuration precedence is exercised through real public tool executions. Defaults, native CN inheritance, proxy rejection, explicit Kimi overrides, authorization, native tool-call citations, grounding, replay, caching, cancellation, and failure behavior remain covered.

## User Impact

No runtime behavior changes. Tests now follow the same provider boundary used by production callers.

## Evidence

- `node scripts/run-vitest.mjs extensions/moonshot/src/kimi-web-search-provider.test.ts` — 17/17 passed
- `pnpm check:changed` — passed
- P3 autoreview — scoped clean (0.98)
- Net change: −52 LOC
