### PR TITLE
fix(process): release discarded command head buffers

### DIFF
--- a/src/process/exec-output.retention.test-support.ts
+++ b/src/process/exec-output.retention.test-support.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { runUtf8CommandWithTimeout } from "./exec-runner.js";
+
+const gc = globalThis.gc;
+assert.ok(gc, "The retention child requires --expose-gc");
+const emittedBytes = 128 * 1024;
+const cap = 16;
+const observed = [];
+for (const mode of ["head", "combined-head", "tail"] as const) {
+  let clipped: WeakRef<ArrayBufferLike> | undefined;
+  let bytes = 0;
+  const output = createDeferred();
+  const control = new WeakRef(new ArrayBuffer(1024));
+  const abort = new AbortController();
+  const command = runUtf8CommandWithTimeout(
+    [
+      process.execPath,
+      "-e",
+      `process.stdout.write(Buffer.alloc(${emittedBytes}, 88)); setInterval(() => {}, 1000);`,
+    ],
+    {
+      baseEnv: {},
+      timeoutMs: 10_000,
+      signal: abort.signal,
+      outputCapture: mode === "tail" ? "tail" : "head",
+      maxOutputBytes: mode === "combined-head" ? emittedBytes : cap,
+      ...(mode === "combined-head" ? { maxCombinedOutputBytes: cap } : {}),
+      onOutputChunk(chunk, stream) {
+        assert.equal(stream, "stdout");
+        if (bytes < cap && bytes + chunk.byteLength > cap) {
+          clipped = new WeakRef(chunk.buffer);
+        }
+        bytes += chunk.byteLength;
+        if (bytes === emittedBytes) {
+          output.resolve();
+        }
+      },
+    },
+  );
+  try {
+    await Promise.race([
+      output.promise,
+      command.then(() => {
+        throw new Error("Command finished before the retention checkpoint");
+      }),
+    ]);
+    assert.ok(clipped, "The child must emit a buffer crossing the capture boundary");
+    // Dereferencing during collection would keep the target alive for that job.
+    for (let pass = 0; pass < 8; pass += 1) {
+      await setImmediate();
+      gc();
+    }
+    assert.equal(control.deref(), undefined, "The uncached GC control must be collected");
+    observed.push({ mode, retained: clipped.deref() !== undefined });
+  } finally {
+    abort.abort();
+    const result = await command;
+    assert.equal(result.stdout, "X".repeat(cap));
+    assert.equal(result.stderr, "");
+    assert.equal(result.stdoutTruncatedBytes, emittedBytes - cap);
+    assert.equal(result.termination, "signal");
+  }
+}
+process.stdout.write(JSON.stringify(observed));

--- a/src/process/exec-output.retention.test.ts
+++ b/src/process/exec-output.retention.test.ts
@@ -1,0 +1,31 @@
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+import { runNodeScript } from "../../test/helpers/run-node-script.js";
+
+it("releases discarded backing buffers while capped commands are still running", async ({
+  signal,
+}) => {
+  const result = await runNodeScript(
+    [
+      "--expose-gc",
+      "--import",
+      "tsx",
+      fileURLToPath(new URL("./exec-output.retention.test-support.ts", import.meta.url)),
+    ],
+    { ...process.env, NODE_OPTIONS: "", TSX_DISABLE_CACHE: "1" },
+    15_000,
+    {
+      cwd: fileURLToPath(new URL("../../", import.meta.url)),
+      signal,
+      maxBuffer: 64 * 1024,
+      requireProcessTreeExit: process.platform !== "win32",
+    },
+  );
+  expect(result.error, result.stderr).toBeUndefined();
+  expect(result.status, result.stderr).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual([
+    { mode: "head", retained: false },
+    { mode: "combined-head", retained: false },
+    { mode: "tail", retained: false },
+  ]);
+}, 30_000);

--- a/src/process/exec-output.ts
+++ b/src/process/exec-output.ts
@@ -88,7 +88,8 @@ export function appendCapturedOutput(
     const remaining = Math.max(0, maxBytes - capture.bytes);
     if (remaining > 0) {
       const kept = buffer.subarray(0, remaining);
-      capture.chunks.push(kept);
+      // A clipped prefix must not retain the discarded backing bytes.
+      capture.chunks.push(kept.byteLength < buffer.byteLength ? Buffer.from(kept) : kept);
       capture.bytes += kept.byteLength;
     }
     capture.truncatedBytes += Math.max(0, buffer.byteLength - remaining);

--- a/src/process/exec-runner.ts
+++ b/src/process/exec-runner.ts
@@ -308,10 +308,8 @@ async function runCommandWithOutputEncoding(
       }
     } else {
       const remaining = Math.max(0, maxCombinedOutputBytes - combinedBytesBeforeChunk);
-      if (remaining > 0) {
-        appendCapturedOutput(capture, buffer.subarray(0, remaining), maxBytes, captureMode);
-      }
-      capture.truncatedBytes += Math.max(0, buffer.byteLength - remaining);
+      const maxCaptureBytes = Math.min(maxBytes, capture.bytes + remaining);
+      appendCapturedOutput(capture, buffer, maxCaptureBytes, captureMode);
     }
     if (
       (combinedLimitExceeded &&


### PR DESCRIPTION
## What Problem This Solves

A capped command head retains discarded output while its child keeps running: a 16-byte prefix can pin the entire 64 KiB pipe buffer that supplied it. This affects both per-stream and combined head limits.

## Why This Change Was Made

Copy only a clipped head prefix, matching the existing tail ownership rule. Pass the original buffer and effective combined/per-stream cap to the capture owner so that it owns clipping and truncation accounting together. Fully admitted chunks remain borrowed.

Production LOC: +4/-5 (net -1). Regression test: +31 lines; test support: +66 lines.

## User Impact

Long-running commands that retain a short output head release the discarded backing buffer sooner. Captured text, truncation counts, raw output observation, decoding, cancellation and limits are preserved.

## Evidence

- A real child wrote 128 KiB and waited at a controlled checkpoint. For each head mode, reachable original pipe-buffer storage changed from 65,536 to 0 bytes; the tail sibling was 0 in both versions. All six runs returned the same 16-byte text, 131,056 truncated bytes and normal exit, and all children and sockets joined.
- This measures original backing-buffer reachability, not whole-process RSS. The new small prefix copy may use Node's buffer pool, which is not included in that figure.
- The public-API lifetime regression failed before and passed after. Existing head/tail/combined limits, UTF-8, Windows decoding, cancellation and watchdog checks passed: 85 tests and one existing skip across four files.
- The complete changed-file gate passed. Independent review caught a detached child in the new fixture; removing that option keeps it in the outer managed group. Controlled cancellation reproduced the fixture leak before and clean cleanup after. Final focused, format and typed-lint checks passed, followed by a clean independent Codex P2 review. The complete gate preceded only that fixture-property deletion; production was unchanged.
