### PR TITLE
fix: restore current-main build validation

### DIFF
--- a/test/scripts/repo-e2e-artifacts.test.ts
+++ b/test/scripts/repo-e2e-artifacts.test.ts
@@ -92,11 +92,17 @@ describe("repo E2E artifact transfer", () => {
       ]) {
         fs.rmSync(path.join(root, output), { recursive: true });
       }
-      // Reproduce a plain archive restore's false freshness miss before exercising the owner.
+      // Clean Git state outranks archive mtimes; restore still refreshes the local stamp.
       execFileSync("tar", ["-xzf", path.join(artifact, "repo-e2e-build.tar.gz")], { cwd: root });
-      expect(requirement(root)).toMatchObject({ shouldBuild: true, reason: "config_newer" });
+      expect(requirement(root)).toEqual({ shouldBuild: false, reason: "clean" });
+      expect(fs.statSync(path.join(root, "dist/.buildstamp")).mtimeMs).toBeLessThan(
+        fs.statSync(path.join(root, "package.json")).mtimeMs,
+      );
       transferRepoE2eArtifacts("restore", artifact, profile, root);
       expect(requirement(root)).toEqual({ shouldBuild: false, reason: "clean" });
+      expect(fs.statSync(path.join(root, "dist/.buildstamp")).mtimeMs).toBeGreaterThanOrEqual(
+        fs.statSync(path.join(root, "package.json")).mtimeMs,
+      );
       expect(fs.readlinkSync(path.join(root, "dist-runtime/index.js"))).toBe("../dist/index.js");
       expect(fs.statSync(path.join(root, "dist/index.js")).mode & 0o777).toBe(0o755);
       expect(fs.readFileSync(path.join(root, "dist/private-qa.js"), "utf8")).toBe("private QA\n");

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -246,7 +246,7 @@ function renderParticipantMenu(
       </div>`;
     })}
     ${unresolvedCount > 0
-      ? html`<div class="session-hovercard__participant-unresolved" role="listitem">
+      ? html`<div class="session-hovercard__more" role="listitem">
           ${t("sessionHovercard.moreParticipantsLabel", { count: String(unresolvedCount) })}
         </div>`
       : nothing}

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -128,7 +128,6 @@ button.session-hovercard__attribution-others:is(:hover, :focus-visible) {
   color: var(--text);
 }
 
-.session-hovercard__participant-unresolved,
 .session-hovercard__no-pr,
 .session-hovercard__more {
   color: var(--muted);


### PR DESCRIPTION
## What Problem This Solves

Fixes two integrated current-main validation failures that blocked otherwise unrelated pull requests: the Control UI exceeded its enforced startup CSS budget by 17 bytes, and the repo artifact integration test still expected mtime-driven rebuild behavior removed by #136634.

## Why This Change Was Made

The unresolved participant count now reuses the existing muted overflow class, removing a redundant selector without weakening the budget. The artifact test now follows clean-Git precedence while directly proving that canonical restore still refreshes the local build stamp.

## User Impact

No visible product behavior changes. Current-main builds and tooling validation pass their existing contracts again.

## Evidence

- CSS red on unmodified base `41419be40bbb17e5eed318992c8e3bf1aee6199b`: startup CSS 46,097 B gzip, above the 46,080 B limit.
- CSS green on exact head `d78b83741666d09895f2ee77758823142f0f06db`: startup CSS 46,080 B gzip with no performance-budget violations.
- Artifact-test red on the same base: both `full` and `ciArtifacts` cases expected `config_newer` but observed the intentional `clean` result from #136634 (2 failed, 7 passed).
- Artifact-test green on the exact head: 9 passed, including direct before/after build-stamp ordering.
- Adjacent run-node owner suite: 92 passed, including clean-Git, dirty-tree, and Git-unavailable controls.
- Hovercard unit suite: 32 passed.
- UI stylelint, targeted formatting, diff check, and production UI build passed.
- Exact-head max-P2 Autoreview: scoped-clean, no accepted/actionable findings, confidence 0.94.
- Hosted CI: https://github.com/openclaw/openclaw/actions/runs/33709162719

This is the bounded prerequisite for #135654 after the integrated changes in #136719 and #136634 exposed their respective gates.
