### PR TITLE
fix: assignment menu drops teammates on a directly opened archived co…

### DIFF
--- a/ui/src/components/session-owner-chip.test.ts
+++ b/ui/src/components/session-owner-chip.test.ts
@@ -3,7 +3,7 @@
 import { afterEach, expect, it, vi } from "vitest";
 import type { SessionParticipant } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar-context.ts";
-import { listAssignableSessionOwners } from "./session-owner-chip.ts";
+import { listAssignableSessionOwners, resolveAssignableOwnerFacet } from "./session-owner-chip.ts";
 
 afterEach(() => {
   document.body.replaceChildren();
@@ -146,6 +146,73 @@ it("treats a present owner facet as authoritative before adding self and configu
       label: "Self",
     },
   ]);
+});
+
+it("offers a resolved owner facet to a conversation that no loaded list contains", () => {
+  // An archived conversation opened by its direct URL while the sidebar lists
+  // active sessions is displayed outside every loaded list. The facet is the
+  // Gateway's owner inventory for the query, not the owners of the returned
+  // rows, so it still answers who can be assigned.
+  const sidebarList = {
+    owners: [
+      { type: "human" as const, id: "profile-ada", label: "Ada" },
+      { type: "human" as const, id: "profile-bob", label: "Bob" },
+    ],
+  };
+
+  expect(resolveAssignableOwnerFacet([sidebarList, undefined])).toEqual([
+    { type: "human", id: "profile-ada", label: "Ada" },
+    { type: "human", id: "profile-bob", label: "Bob" },
+  ]);
+});
+
+it("unions owner facets across lists and keeps the first identity for a shared id", () => {
+  expect(
+    resolveAssignableOwnerFacet([
+      { owners: [{ type: "human", id: "profile-ada", label: "Ada" }] },
+      {
+        owners: [
+          { type: "human", id: "profile-ada" },
+          { type: "human", id: "profile-carol", label: "Carol" },
+        ],
+      },
+    ]),
+  ).toEqual([
+    { type: "human", id: "profile-ada", label: "Ada" },
+    { type: "human", id: "profile-carol", label: "Carol" },
+  ]);
+});
+
+it("keeps the agent identity when two lists disagree about an id's owner type", () => {
+  // Merging lists is what makes this collision reachable at all: a single facet
+  // cannot report one id twice. Downstream, both the self-overwrite guard and
+  // the configured-agent enrichment key off type === "agent", so demoting an
+  // agent to a human here would let "me" overwrite a configured agent's entry.
+  const merged = resolveAssignableOwnerFacet([
+    { owners: [{ type: "human", id: "shared-id", label: "Human first" }] },
+    { owners: [{ type: "agent", id: "shared-id", label: "Agent second" }] },
+  ]);
+  expect(merged).toEqual([{ type: "agent", id: "shared-id", label: "Agent second" }]);
+
+  // The reverse order keeps the agent too, and an agent is never demoted.
+  expect(
+    resolveAssignableOwnerFacet([
+      { owners: [{ type: "agent", id: "shared-id", label: "Agent first" }] },
+      { owners: [{ type: "human", id: "shared-id", label: "Human second" }] },
+    ]),
+  ).toEqual([{ type: "agent", id: "shared-id", label: "Agent first" }]);
+
+  // And the guard downstream still holds: self does not overwrite that entry.
+  expect(
+    listAssignableSessionOwners({ facet: merged, self: { id: "shared-id", name: "Me" } }),
+  ).toEqual([{ type: "agent", id: "shared-id", label: "Agent second" }]);
+});
+
+it("reports an unresolved owner facet while every list is still hydrating", () => {
+  // Distinct from an empty facet: callers read undefined as "not loaded yet",
+  // and an empty array as "the Gateway disclosed nobody".
+  expect(resolveAssignableOwnerFacet([undefined, {}])).toBeUndefined();
+  expect(resolveAssignableOwnerFacet([{ owners: [] }, undefined])).toEqual([]);
 });
 
 it("does not reconstruct assignment candidates when the owner facet is absent", () => {

--- a/ui/src/components/session-owner-chip.ts
+++ b/ui/src/components/session-owner-chip.ts
@@ -12,6 +12,35 @@ import "./viewer-facepile.ts";
 export type SessionCreatedActor = ProtocolSessionCreatedActor;
 export type SessionOwnerOption = NonNullable<SessionsListResult["owners"]>[number];
 
+/**
+ * Picks the owner facet a session's assignment menu should offer. A resolved
+ * facet is the Gateway's owner inventory for that list query, not the owners of
+ * the rows it returned, so demanding the result that *contains* the row leaves a
+ * conversation opened outside every list with no facet at all. Undefined means
+ * no list has resolved yet, not that nobody is assignable.
+ */
+export function resolveAssignableOwnerFacet(
+  results: readonly ({ owners?: SessionsListResult["owners"] } | null | undefined)[],
+): SessionsListResult["owners"] {
+  let facet: Map<string, SessionOwnerOption> | undefined;
+  for (const result of results) {
+    if (result?.owners === undefined) {
+      continue;
+    }
+    facet ??= new Map();
+    for (const owner of result.owners) {
+      const existing = facet.get(owner.id);
+      // First result wins, except that an agent outranks a human for the same
+      // id: the self-overwrite guard and the roster enrichment below both key
+      // off type === "agent", so a demoted agent lets "me" overwrite it.
+      if (!existing || (existing.type !== "agent" && owner.type === "agent")) {
+        facet.set(owner.id, owner);
+      }
+    }
+  }
+  return facet ? [...facet.values()] : undefined;
+}
+
 export function listAssignableSessionOwners(params: {
   facet?: SessionsListResult["owners"];
   agents?: readonly { id: string; name?: string }[];

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -32,7 +32,7 @@ import {
 import "../styles/sidebar-menus.css";
 import { sessionMenuReasons } from "./session-menu-access.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
-import { listAssignableSessionOwners } from "./session-owner-chip.ts";
+import { listAssignableSessionOwners, resolveAssignableOwnerFacet } from "./session-owner-chip.ts";
 import {
   isSidebarAttentionDismissed,
   isUpdateAttentionForced,
@@ -222,12 +222,11 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
     isGatewayMethodAdvertised(context.gateway.snapshot, cloudWorkerStopAction.method) === true,
   );
   const selfUser = context?.gateway.snapshot.selfUser ?? null;
-  const sessionsResult = [
-    host.sessionData.sessionsResult,
-    ...Object.values(host.sessionData.sessionResultsByAgent),
-  ].find((result) => result?.sessions.some((row) => row.key === session.key));
   const ownerOptions = listAssignableSessionOwners({
-    facet: sessionsResult?.owners,
+    facet: resolveAssignableOwnerFacet([
+      host.sessionData.sessionsResult,
+      ...Object.values(host.sessionData.sessionResultsByAgent),
+    ]),
     agents: context?.agents.state.agentsList?.agents,
     self: selfUser,
   });

--- a/ui/src/e2e/session-owner-assignment.e2e.test.ts
+++ b/ui/src/e2e/session-owner-assignment.e2e.test.ts
@@ -58,6 +58,43 @@ function sessionsListResponse() {
   };
 }
 
+const archivedKey = "agent:main:archived-outcome";
+
+// The sidebar's Status filter is on Active, so the archived conversation is
+// absent from every loaded list while its owner facet still carries the whole
+// roster. Opening it by direct URL is what put it outside the lists.
+function activeOnlySessionsListResponse() {
+  const full = sessionsListResponse();
+  return {
+    ...full,
+    count: 1,
+    sessions: full.sessions.filter((session) => session.key === "agent:main:ada-research"),
+  };
+}
+
+// The Control UI resolves a directly opened session with its own key-scoped
+// sessions.list call (archived: "all", search: <key>). Serving that separately
+// from the sidebar's unfiltered list is what puts the row outside every list
+// the sidebar holds.
+function archivedLookupResponse() {
+  const full = sessionsListResponse();
+  return {
+    ...full,
+    count: 1,
+    sessions: [
+      {
+        key: archivedKey,
+        kind: "direct",
+        label: "Archived outcome",
+        archived: true,
+        createdActor: { type: "human", id: "profile-ada", label: "Ada" },
+        owner: { actor: { type: "human", id: "profile-ada", label: "Ada" } },
+        updatedAt: 3,
+      },
+    ],
+  };
+}
+
 async function installOwnerGateway(page: Page) {
   await routeAvatarFixtures(page, [{ id: "profile-ada", background: "#7c3aed", label: "A" }]);
   const gateway = await installMockGateway(page, {
@@ -135,6 +172,55 @@ suite.define(() => {
         );
         await expectBrowser(checked).toHaveCount(1);
         await expectBrowser(checked.locator(":scope > .session-menu__text")).toHaveText("Me");
+        await expectBrowser(
+          assignTo.locator(':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text'),
+        ).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);
+      },
+    );
+  });
+
+  it("offers teammates on an archived conversation opened by its direct URL", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await routeAvatarFixtures(page, [{ id: "profile-ada", background: "#7c3aed", label: "A" }]);
+        await installMockGateway(page, {
+          featureMethods: ["chat.startup", "sessions.assignOwner"],
+          historyMessages: [{ role: "assistant", content: "Archived conversation proof." }],
+          methodResponses: {
+            "sessions.list": {
+              cases: [
+                { match: { search: archivedKey }, response: archivedLookupResponse() },
+                { response: activeOnlySessionsListResponse() },
+              ],
+            },
+          },
+          operatorScopes: ["operator.read", "operator.write"],
+          presenceUsers: [
+            {
+              self: true,
+              id: "profile-ada",
+              name: "Ada",
+              avatarUrl: "/api/users/profile-ada/avatar?v=1",
+            },
+          ],
+          sessionKey: archivedKey,
+        });
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, archivedKey));
+        await page.getByText("Archived conversation proof.", { exact: true }).waitFor();
+
+        const row = page.locator(`[data-session-key="${archivedKey}"]`);
+        await row.hover();
+        await row.getByRole("button", { name: /^Open session menu/ }).click();
+        const assignTo = page.getByRole("menuitem", { name: "Assign to…", exact: true });
+        await assignTo.hover();
+
+        // Before the facet lookup stopped demanding the result that contains the
+        // row, this menu collapsed to Me plus the configured agent.
         await expectBrowser(
           assignTo.locator(':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text'),
         ).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);


### PR DESCRIPTION
Closes #136821

## What Problem This Solves

Fixes an issue where users who open an archived conversation by its direct URL, while the sidebar's Status filter shows Active, get an **Assign to…** menu offering only **Me** and the configured agents. The same Gateway offers the full set of people from any active conversation's menu, so an archived conversation cannot be handed to a teammate through this menu at all.

## Why This Change Was Made

The menu looked up the owner facet from the one loaded list result whose rows contained the selected session. A directly opened archived row is displayed outside every loaded list, so that lookup found nothing and the facet arrived `undefined` — which `listAssignableSessionOwners` correctly reads as "no inventory" rather than "nobody is assignable".

The lookup was never needed. A resolved facet is the Gateway's owner inventory for that list query, not the owners of the rows it returned (`SessionsListResultBase.owners`: *"Complete owner facet for the filtered result, independent of pagination"*), so any resolved facet already answers who can be assigned. `resolveAssignableOwnerFacet` replaces the row lookup: it unions the facets of every resolved list and returns `undefined` only while all of them are still hydrating, so the selected row plays no part in the answer.

**Known boundary, deliberately not addressed here.** The issue's expected behaviour asks for people "independently of the sidebar's filters". This change delivers that for the reported path, because the facet the sidebar already holds contains those teammates. It does not make the facet itself filter-independent: in `src/gateway/session-utils-list.ts` the facet is populated after the `activeCutoff` and search filters, so a teammate who owns *only* archived sessions is still absent from every facet the client can see. Closing that gap changes a Gateway response's semantics and the `ownershipVisible` heuristics that read it, which seems worth a maintainer's decision rather than a drive-by widening of this PR.

## User Impact

An archived conversation opened directly can be assigned to a teammate from its sidebar menu, matching what the same menu offers on an active conversation.

## Evidence

`ui/src/components/session-owner-chip.test.ts` gains three cases on the new helper: a resolved facet is offered to a conversation that no loaded list contains (the reported path), facets union across lists with the first identity winning for a shared id, and an all-unresolved input stays `undefined` so callers can still tell "not loaded yet" from "the Gateway disclosed nobody".

Mutation-checked both invariants, each failing only its own case:

```
last-wins instead of first-wins
  × unions owner facets across lists and keeps the first identity for a shared id
empty map instead of undefined while hydrating
  × reports an unresolved owner facet while every list is still hydrating
      → expected [] to be undefined
```

**Coverage I did not add, stated plainly:** the call site in `sidebar-menus-render.ts` has no unit coverage — the module is reached only through a lazy `import()` in `sidebar-menus-controller.ts`, and no test imports it — so reverting just that call site turns nothing red. The change removes the row lookup entirely, so the failure mode is no longer expressible there, but a test that mounts the sidebar and opens the menu for a row absent from every list would be a stronger guard. I stopped short of building that harness case rather than guess at it; happy to add it if a maintainer would rather have it in this PR.

Validation run locally on this branch (based on main at 11c4ff6c):

- `node scripts/run-vitest.mjs run ui/src/components/session-owner-chip.test.ts ui/src/components/session-menu.test.ts ui/src/components/app-sidebar.test.ts` — 3 files, 382 tests passed
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json` — clean
- `node scripts/run-tsgo-core-test-shards.mjs ui` — clean
- `node scripts/run-oxlint.mjs --tsconfig tsconfig.ui.json <touched files>` — clean
- `oxfmt --check <touched files>` — clean