### PR TITLE
fix(telegram): record structured pre-dispatch rejection logs

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-authorization.test.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-authorization.test.ts
@@ -13,6 +13,35 @@ import { defaultTelegramBotDeps } from "./bot-deps.js";
 import { createTelegramHandlerAuthorization } from "./bot-handlers.inbound-authorization.js";
 import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
 
+function createTestParams(
+  overrides?: Partial<RegisterTelegramHandlerParams>,
+): RegisterTelegramHandlerParams {
+  const cfg = { channels: { telegram: { enabled: true } } } as OpenClawConfig;
+  return {
+    accountId: "default",
+    ownerAgentId: "main",
+    bot: {} as RegisterTelegramHandlerParams["bot"],
+    cfg,
+    mediaMaxBytes: 1,
+    opts: { token: "test-token" },
+    runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    telegramCfg: cfg.channels?.telegram ?? {},
+    telegramDeps: {
+      ...defaultTelegramBotDeps,
+      getRuntimeConfig: () => cfg,
+      readChannelAllowFromStore: async () => [],
+    },
+    logger: getChildLogger({ module: "telegram/admission-test" }),
+    resolveGroupPolicy: () => ({ allowlistEnabled: true, allowed: true }),
+    resolveGroupActivation: () => undefined,
+    resolveGroupRequireMention: () => false,
+    resolveTelegramGroupConfig: () => ({ groupConfig: undefined, topicConfig: undefined }),
+    shouldSkipUpdate: () => false,
+    processMessage: async () => ({ kind: "completed" as const }),
+    ...overrides,
+  } as RegisterTelegramHandlerParams;
+}
+
 describe("Telegram inbound admission authorization", () => {
   it("binds a forum admission to the finalized parent and topic scope", async () => {
     const chatId = -1001234567890;
@@ -120,5 +149,138 @@ describe("Telegram inbound admission authorization", () => {
       clearOwner();
       clearCollection();
     }
+  });
+});
+
+describe("Telegram inbound preparation rejection records", () => {
+  it("records channel-disabled rejections", async () => {
+    const params = createTestParams();
+    const info = vi.spyOn(params.logger, "info").mockImplementation(() => undefined);
+    const gate = await createTelegramHandlerAuthorization(params).authorizeInboundMessage({
+      msg: {
+        message_id: 1,
+        date: 1_700_000_000,
+        chat: { id: -100, type: "supergroup", title: "X" },
+        from: { id: 1, is_bot: false, first_name: "U" },
+        text: "hi",
+      } as import("grammy/types").Message,
+      chatId: -100,
+      isGroup: true,
+      isForum: false,
+      senderId: "1",
+      senderUsername: "",
+      requireConfiguredGroup: true,
+      dmAccess: "silent",
+    });
+    expect(gate.allowed).toBe(false);
+    expect(info).toHaveBeenCalledExactlyOnceWith(
+      {
+        provider: "telegram",
+        accountId: "default",
+        chatId: -100,
+        senderId: "1",
+        reason: "channel-disabled",
+      },
+      "Telegram inbound event rejected during preparation",
+    );
+  });
+
+  it("records group-disabled rejections", async () => {
+    const params = createTestParams({
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { enabled: false } as TelegramGroupConfig,
+        topicConfig: undefined,
+      }),
+    });
+    const info = vi.spyOn(params.logger, "info").mockImplementation(() => undefined);
+    const gate = await createTelegramHandlerAuthorization(params).authorizeInboundMessage({
+      msg: {
+        message_id: 2,
+        date: 1_700_000_000,
+        chat: { id: -100, type: "supergroup", title: "X" },
+        from: { id: 1, is_bot: false, first_name: "U" },
+        text: "hi",
+      } as import("grammy/types").Message,
+      chatId: -100,
+      isGroup: true,
+      isForum: false,
+      senderId: "1",
+      senderUsername: "",
+      requireConfiguredGroup: false,
+      dmAccess: "silent",
+    });
+    expect(gate.allowed).toBe(false);
+    expect(info).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ reason: "group-disabled" }),
+      "Telegram inbound event rejected during preparation",
+    );
+  });
+
+  it("records dm-disabled rejections", async () => {
+    const cfg = { channels: { telegram: { enabled: true, dmPolicy: "disabled" as const } } };
+    const params = createTestParams({
+      cfg: cfg as unknown as OpenClawConfig,
+      telegramDeps: {
+        ...defaultTelegramBotDeps,
+        getRuntimeConfig: () => cfg as unknown as OpenClawConfig,
+        readChannelAllowFromStore: async () => [],
+      },
+    });
+    const info = vi.spyOn(params.logger, "info").mockImplementation(() => undefined);
+    const gate = await createTelegramHandlerAuthorization(params).authorizeInboundMessage({
+      msg: {
+        message_id: 3,
+        date: 1_700_000_000,
+        chat: { id: 1, type: "private" },
+        from: { id: 1, is_bot: false, first_name: "U" },
+        text: "hi",
+      } as import("grammy/types").Message,
+      chatId: 1,
+      isGroup: false,
+      isForum: false,
+      senderId: "1",
+      senderUsername: "",
+      requireConfiguredGroup: false,
+      dmAccess: "silent",
+    });
+    expect(gate.allowed).toBe(false);
+    expect(info).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ reason: "dm-disabled" }),
+      "Telegram inbound event rejected during preparation",
+    );
+  });
+
+  it("records dm-unauthorized rejections", async () => {
+    const cfg = { channels: { telegram: { enabled: true, dmPolicy: "closed" as const } } };
+    const params = createTestParams({
+      cfg: cfg as unknown as OpenClawConfig,
+      telegramDeps: {
+        ...defaultTelegramBotDeps,
+        getRuntimeConfig: () => cfg as unknown as OpenClawConfig,
+        readChannelAllowFromStore: async () => [],
+      },
+    });
+    const info = vi.spyOn(params.logger, "info").mockImplementation(() => undefined);
+    const gate = await createTelegramHandlerAuthorization(params).authorizeInboundMessage({
+      msg: {
+        message_id: 4,
+        date: 1_700_000_000,
+        chat: { id: 1, type: "private" },
+        from: { id: 1, is_bot: false, first_name: "U" },
+        text: "hi",
+      } as import("grammy/types").Message,
+      chatId: 1,
+      isGroup: false,
+      isForum: false,
+      senderId: "1",
+      senderUsername: "",
+      requireConfiguredGroup: false,
+      dmAccess: "silent",
+    });
+    expect(gate.allowed).toBe(false);
+    expect(info).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ reason: "dm-unauthorized" }),
+      "Telegram inbound event rejected during preparation",
+    );
   });
 });

--- a/extensions/telegram/src/bot-handlers.inbound-authorization.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-authorization.ts
@@ -45,6 +45,37 @@ export type TelegramEventAuthorizationMode =
   | "callback-allowlist"
   | "callback-runtime-allowlist";
 
+type TelegramInboundDropReason =
+  | "channel-disabled"
+  | "group-disabled"
+  | "topic-disabled"
+  | "group-allowFrom-override"
+  | "dm-requireTopic-missing"
+  | "dm-disabled"
+  | "dm-unauthorized"
+  | "group-policy-disabled"
+  | "group-policy-allowlist-no-sender"
+  | "group-policy-allowlist-empty"
+  | "group-policy-allowlist-unauthorized"
+  | "not-allowed";
+
+function recordTelegramInboundDrop(
+  logger: RegisterTelegramHandlerParams["logger"],
+  accountId: string,
+  params: { chatId: number; senderId?: string; reason: TelegramInboundDropReason },
+) {
+  logger.info(
+    {
+      provider: "telegram",
+      accountId,
+      chatId: params.chatId,
+      senderId: params.senderId,
+      reason: params.reason,
+    },
+    "Telegram inbound event rejected during preparation",
+  );
+}
+
 export interface TelegramHandlerAuthorization {
   resolveTelegramEventAuthorizationContext: (params: {
     cfg: OpenClawConfig;
@@ -385,25 +416,34 @@ export function createTelegramHandlerAuthorization({
 
     if (params.requireConfiguredGroup && (!groupConfig || groupConfig.enabled === false)) {
       logVerbose(`Blocked telegram channel ${params.chatId} (channel disabled)`);
+      recordTelegramInboundDrop(logger, accountId, {
+        chatId: params.chatId,
+        senderId: params.senderId,
+        reason: "channel-disabled",
+      });
       return { allowed: false };
     }
 
-    if (
-      shouldSkipGroupMessage({
-        isGroup: params.isGroup,
+    const groupSkipReason = shouldSkipGroupMessage({
+      isGroup: params.isGroup,
+      chatId: params.chatId,
+      chatTitle: params.msg.chat.title,
+      resolvedThreadId,
+      senderId: params.senderId,
+      senderUsername: params.senderUsername,
+      effectiveGroupAllow,
+      hasGroupAllowOverride,
+      groupConfig,
+      topicConfig,
+      cfg: authorizationCfg,
+      telegramCfg: authorizationTelegramCfg,
+    });
+    if (groupSkipReason) {
+      recordTelegramInboundDrop(logger, accountId, {
         chatId: params.chatId,
-        chatTitle: params.msg.chat.title,
-        resolvedThreadId,
         senderId: params.senderId,
-        senderUsername: params.senderUsername,
-        effectiveGroupAllow,
-        hasGroupAllowOverride,
-        groupConfig,
-        topicConfig,
-        cfg: authorizationCfg,
-        telegramCfg: authorizationTelegramCfg,
-      })
-    ) {
+        reason: groupSkipReason,
+      });
       return { allowed: false };
     }
 
@@ -412,6 +452,11 @@ export function createTelegramHandlerAuthorization({
         groupConfig && "requireTopic" in groupConfig ? groupConfig.requireTopic : undefined;
       if (requireTopic === true && dmThreadId == null) {
         logVerbose(`Blocked telegram DM ${params.chatId}: requireTopic=true but no topic present`);
+        recordTelegramInboundDrop(logger, accountId, {
+          chatId: params.chatId,
+          senderId: params.senderId,
+          reason: "dm-requireTopic-missing",
+        });
         return { allowed: false };
       }
       const dmAuthorized =
@@ -435,6 +480,11 @@ export function createTelegramHandlerAuthorization({
               accountId,
             });
       if (!dmAuthorized) {
+        recordTelegramInboundDrop(logger, accountId, {
+          chatId: params.chatId,
+          senderId: params.senderId,
+          reason: dmPolicy === "disabled" ? "dm-disabled" : "dm-unauthorized",
+        });
         return { allowed: false };
       }
     }
@@ -523,7 +573,7 @@ function shouldSkipTelegramGroupMessage(
     telegramCfg: TelegramAccountConfig;
   },
   runtime: Pick<RegisterTelegramHandlerParams, "logger" | "resolveGroupPolicy">,
-): boolean {
+): TelegramInboundDropReason | undefined {
   const {
     isGroup,
     chatId,
@@ -552,19 +602,19 @@ function shouldSkipTelegramGroupMessage(
   if (!baseAccess.allowed) {
     if (baseAccess.reason === "group-disabled") {
       logVerbose(`Blocked telegram group ${chatId} (group disabled)`);
-      return true;
+      return "group-disabled";
     }
     if (baseAccess.reason === "topic-disabled") {
       logVerbose(
         `Blocked telegram topic ${chatId} (${resolvedThreadId ?? "unknown"}) (topic disabled)`,
       );
-      return true;
+      return "topic-disabled";
     }
     logVerbose(`Blocked telegram group sender ${senderId || "unknown"} (group allowFrom override)`);
-    return true;
+    return "group-allowFrom-override";
   }
   if (!isGroup) {
-    return false;
+    return undefined;
   }
   const policyAccess = evaluateTelegramGroupPolicyAccess({
     isGroup,
@@ -584,29 +634,29 @@ function shouldSkipTelegramGroupMessage(
     checkChatAllowlist: true,
   });
   if (policyAccess.allowed) {
-    return false;
+    return undefined;
   }
   if (policyAccess.reason === "group-policy-disabled") {
     logVerbose("Blocked telegram group message (groupPolicy: disabled)");
-    return true;
+    return "group-policy-disabled";
   }
   if (policyAccess.reason === "group-policy-allowlist-no-sender") {
     logVerbose("Blocked telegram group message (no sender ID, groupPolicy: allowlist)");
-    return true;
+    return "group-policy-allowlist-no-sender";
   }
   if (policyAccess.reason === "group-policy-allowlist-empty") {
     logVerbose(
       "Blocked telegram group message (groupPolicy: allowlist, no group allowlist entries)",
     );
-    return true;
+    return "group-policy-allowlist-empty";
   }
   if (policyAccess.reason === "group-policy-allowlist-unauthorized") {
     logVerbose(`Blocked telegram group message from ${senderId} (groupPolicy: allowlist)`);
-    return true;
+    return "group-policy-allowlist-unauthorized";
   }
   runtime.logger.info(
     { chatId, title: chatTitle, reason: "not-allowed" },
     "skipping group message",
   );
-  return true;
+  return "not-allowed";
 }


### PR DESCRIPTION
## What Problem This Solves

Telegram inbound message preparation can reject updates for many reasons (channel disabled, group disabled, DM policy blocks, group-allowlist blocks, missing topic, etc.), but the rejections are either logged with free-form verbose text or not recorded at all. Operators cannot query or aggregate which updates were dropped and why.

Sibling channel Slack already emits a structured `Slack inbound event rejected during preparation` info log (#132723). Telegram lacked the equivalent.

## Changes

- `extensions/telegram/src/bot-handlers.inbound-authorization.ts`:
  - Added `TelegramInboundDropReason` union and `recordTelegramInboundDrop` helper.
  - `authorizeInboundMessage` now emits a structured info log before every `allowed: false` return, including `provider`, `accountId`, `chatId`, `senderId`, and `reason`.
  - `shouldSkipTelegramGroupMessage` returns the specific reason instead of a boolean so the rejection record can distinguish `group-disabled`, `topic-disabled`, `group-policy-allowlist-unauthorized`, etc.
- `extensions/telegram/src/bot-handlers.inbound-authorization.test.ts`:
  - Added inline tests for `channel-disabled`, `group-disabled`, `dm-disabled`, and `dm-unauthorized` rejection records.

## Real behavior proof

- **Behavior addressed**: `authorizeInboundMessage` now emits a structured `Telegram inbound event rejected during preparation` log for rejected updates.
- **Real environment tested**: Local checkout, Node 24.18.0 (via nvm).
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs extensions/telegram/src/bot-handlers.inbound-authorization.test.ts --run
  node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json extensions/telegram/src/bot-handlers.inbound-authorization.ts extensions/telegram/src/bot-handlers.inbound-authorization.test.ts
  node scripts/run-tsgo.mjs --project extensions/telegram/tsconfig.json
  ```
- **Evidence after fix**:
  ```
  ✓ Telegram inbound preparation rejection records > records channel-disabled rejections
  ✓ Telegram inbound preparation rejection records > records group-disabled rejections
  ✓ Telegram inbound preparation rejection records > records dm-disabled rejections
  ✓ Telegram inbound preparation rejection records > records dm-unauthorized rejections
  Test Files  1 passed (1)
  Tests  5 passed (5)
  oxlint: 0 warnings / 0 errors
  tsgo --project extensions/telegram/tsconfig.json: exit 0
  ```
- **Observed result after fix**: a DM with `dmPolicy: "disabled"` produces `{ provider: "telegram", accountId: "default", chatId: 1, senderId: "1", reason: "dm-disabled" } "Telegram inbound event rejected during preparation"`.
- **What was not tested**: full `tsconfig.extensions.json` typecheck fails on an unrelated pre-existing `yargs-parser` declaration error in `extensions/browser`; the Telegram-only project compiles cleanly.

## Out of scope

- Other Telegram rejection paths such as `shouldSkipUpdate` (deduplication), bot-authored self-message skip, and media-group buffering are intentionally unchanged; this PR mirrors Slack's preparation-rejection scope only.

## Risk

Low. This is an additive, diagnostic-only logging change inside the Telegram plugin. It does not alter authorization decisions, transport behavior, or config defaults.

Fixes #136883
