### PR TITLE
fix(gateway): hide foreign drafts from session describe

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2891,7 +2891,7 @@ src/gateway/server-methods/sessions-compact.ts	1
 src/gateway/server-methods/sessions-create.ts	1
 src/gateway/server-methods/sessions-messaging.ts	11
 src/gateway/server-methods/sessions-patch-engine.ts	1
-src/gateway/server-methods/sessions-read.ts	2
+src/gateway/server-methods/sessions-read.ts	1
 src/gateway/server-methods/sessions-sharing.ts	1
 src/gateway/server-methods/sessions-suggestions.ts	1
 src/gateway/server-methods/skills-workspace-handler.ts	1

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2083,7 +2083,7 @@ src/agents/utils/frontmatter.ts	2
 src/agents/utils/tools-manager.ts	2
 src/agents/workspace-legacy-state.ts	2
 src/agents/workspace-state-store.ts	1
-src/agents/workspace.ts	7
+src/agents/workspace.ts	8
 src/agents/worktrees/git.ts	2
 src/agents/worktrees/provisioned-files.ts	3
 src/agents/worktrees/registry.ts	11

--- a/src/gateway/server-methods/sessions-read-by-key.ts
+++ b/src/gateway/server-methods/sessions-read-by-key.ts
@@ -59,6 +59,7 @@ export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
     respond(true, { session: row });
   },
   "sessions.get": async ({ params, respond, context, client }) => {
+    // SAFETY: Gateway dispatch supplies object params; each optional field is narrowed before use.
     const p = params as {
       key?: unknown;
       sessionKey?: unknown;

--- a/src/gateway/server-methods/sessions-read-by-key.ts
+++ b/src/gateway/server-methods/sessions-read-by-key.ts
@@ -1,0 +1,139 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { validateSessionsDescribeParams } from "../../../packages/gateway-protocol/src/index.js";
+import { hasOperatorBoundary } from "../operator-role-policy.js";
+import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
+import { createSessionListEntryFilter } from "../session-sharing.js";
+import { readRecentSessionMessagesWithStatsAsync } from "../session-transcript-readers.js";
+import { buildGatewaySessionRow } from "../session-utils.js";
+import { readSessionPlacementFields } from "./session-placement-read-projection.js";
+import { loadSessionEntriesForTarget, requireSessionKey } from "./sessions-shared.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { assertValidParams } from "./validation.js";
+
+function createRoleVisibilityFilter(
+  client: Parameters<typeof hasOperatorBoundary>[0],
+  cfg: Parameters<typeof hasOperatorBoundary>[1],
+) {
+  return hasOperatorBoundary(client, cfg)
+    ? createSessionListEntryFilter({ client, cfg })
+    : undefined;
+}
+
+export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
+  "sessions.describe": ({ params, respond, context, client }) => {
+    if (!assertValidParams(params, validateSessionsDescribeParams, "sessions.describe", respond)) {
+      return;
+    }
+    const key = requireSessionKey(params.key, respond);
+    if (!key) {
+      return;
+    }
+    const cfg = context.getRuntimeConfig();
+    const requestedAgent = resolveRequestedGlobalAgentId(cfg, key);
+    if (!requestedAgent.ok) {
+      respond(false, undefined, requestedAgent.error);
+      return;
+    }
+    const { target, storePath, store, entry } = loadSessionEntriesForTarget({
+      key,
+      cfg,
+      ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
+    });
+    const boundaryFilter = createRoleVisibilityFilter(client, cfg);
+    if (!entry || boundaryFilter?.(target.canonicalKey, entry) === false) {
+      respond(true, { session: null }, undefined);
+      return;
+    }
+    const row = buildGatewaySessionRow({
+      cfg,
+      storePath,
+      store,
+      key: target.canonicalKey,
+      entry,
+      agentId: target.agentId,
+      includeDerivedTitles: params.includeDerivedTitles,
+      includeLastMessage: params.includeLastMessage,
+      transcriptUsageMaxBytes: 64 * 1024,
+    });
+    Object.assign(row, readSessionPlacementFields(context, row.sessionId));
+    respond(true, { session: row });
+  },
+  "sessions.get": async ({ params, respond, context, client }) => {
+    const p = params as {
+      key?: unknown;
+      sessionKey?: unknown;
+      limit?: unknown;
+      agentId?: unknown;
+    };
+    const key = requireSessionKey(p.key ?? p.sessionKey, respond);
+    if (!key) {
+      return;
+    }
+    const limit =
+      typeof p.limit === "number" && Number.isFinite(p.limit)
+        ? Math.max(1, Math.floor(p.limit))
+        : 200;
+
+    const cfg = context.getRuntimeConfig();
+    const requestedAgent = resolveRequestedGlobalAgentId(
+      cfg,
+      key,
+      normalizeOptionalString(p.agentId),
+    );
+    if (!requestedAgent.ok) {
+      respond(false, undefined, requestedAgent.error);
+      return;
+    }
+    const { target, storePath, entry } = loadSessionEntriesForTarget({
+      key,
+      cfg,
+      agentId: requestedAgent.agentId,
+    });
+    const boundaryFilter = createRoleVisibilityFilter(client, cfg);
+    if (!entry?.sessionId || boundaryFilter?.(target.canonicalKey, entry) === false) {
+      respond(true, { messages: [] }, undefined);
+      return;
+    }
+    const sessionId = entry.sessionId;
+    const { messages } = await readRecentSessionMessagesWithStatsAsync(
+      {
+        agentId: target.agentId,
+        sessionEntry: entry,
+        sessionId,
+        sessionKey: target.canonicalKey,
+        storePath,
+      },
+      {
+        maxMessages: limit,
+        maxLines: limit * 20 + 20,
+        allowResetArchiveFallback: true,
+      },
+    );
+    const currentCfg = context.getRuntimeConfig();
+    const currentRequestedAgent = resolveRequestedGlobalAgentId(
+      currentCfg,
+      key,
+      normalizeOptionalString(p.agentId),
+    );
+    const current = currentRequestedAgent.ok
+      ? loadSessionEntriesForTarget({
+          key,
+          cfg: currentCfg,
+          agentId: currentRequestedAgent.agentId,
+        })
+      : null;
+    const currentBoundaryFilter = createRoleVisibilityFilter(client, currentCfg);
+    if (
+      !current ||
+      current.target.agentId !== target.agentId ||
+      current.target.canonicalKey !== target.canonicalKey ||
+      current.storePath !== storePath ||
+      current.entry?.sessionId !== sessionId ||
+      currentBoundaryFilter?.(current.target.canonicalKey, current.entry) === false
+    ) {
+      respond(true, { messages: [] }, undefined);
+      return;
+    }
+    respond(true, { messages }, undefined);
+  },
+};

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -27,6 +27,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { ensureProfileForEmail } from "../../state/user-profiles.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import * as sessionTranscriptReaders from "../session-transcript-readers.js";
 import { testState } from "../test-helpers.js";
 import {
   getGatewayConfigModule,
@@ -35,7 +36,6 @@ import {
   setupGatewaySessionsHandlerTestHarness,
 } from "../test/server-sessions.test-helpers.js";
 import { agentsHandlers } from "./agents.js";
-<<<<<<< HEAD
 import {
   identifiedClient,
   listSessions,
@@ -548,6 +548,51 @@ test("sessions.describe and sessions.get hide foreign drafts at operator role bo
       transcript.payload?.messages.map((message) => message.content),
       name,
     ).toEqual(hidden ? [] : ["foreign draft transcript"]);
+  }
+
+  const originalRead = sessionTranscriptReaders.readRecentSessionMessagesWithStatsAsync;
+  for (const mutation of [
+    { name: "visibility change", sessionId, visibility: "draft" as const },
+    {
+      name: "session replacement",
+      sessionId: `${sessionId}-replacement`,
+      visibility: "shared" as const,
+    },
+  ]) {
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey, storePath },
+      {
+        sessionId,
+        updatedAt: 42,
+        createdActor: { type: "human", source: "profile", id: ownerId },
+        visibility: "shared",
+      },
+    );
+    const readSpy = vi
+      .spyOn(sessionTranscriptReaders, "readRecentSessionMessagesWithStatsAsync")
+      .mockImplementationOnce(async (...args) => {
+        await replaceSessionEntry(
+          { agentId: "main", sessionKey, storePath },
+          {
+            sessionId: mutation.sessionId,
+            updatedAt: 43,
+            createdActor: { type: "human", source: "profile", id: ownerId },
+            visibility: mutation.visibility,
+          },
+        );
+        return await originalRead(...args);
+      });
+    try {
+      const transcript = await directSessionReq<{ messages: Array<{ content?: unknown }> }>(
+        "sessions.get",
+        { key: sessionKey },
+        { client: cases[0].client, context: { getRuntimeConfig: () => cases[0].cfg } },
+      );
+      expect(transcript.ok, mutation.name).toBe(true);
+      expect(transcript.payload?.messages, mutation.name).toEqual([]);
+    } finally {
+      readSpy.mockRestore();
+    }
   }
 });
 

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -440,8 +440,9 @@ test("a hidden-foreign role cannot discover sessions through search, batch previ
   });
 });
 
-test("sessions.describe hides foreign drafts at operator role boundaries", async () => {
+test("sessions.describe and sessions.get hide foreign drafts at operator role boundaries", async () => {
   const sessionKey = "agent:main:foreign-draft-describe";
+  const sessionId = "session-foreign-draft-describe";
   const profileId = (name: string) => ensureProfileForEmail(`${name}@example.com`).id;
   const ownerId = profileId("draft-owner");
   const memberId = profileId("draft-member");
@@ -449,12 +450,19 @@ test("sessions.describe hides foreign drafts at operator role boundaries", async
   await replaceSessionEntry(
     { agentId: "main", sessionKey, storePath },
     {
-      sessionId: "session-foreign-draft-describe",
+      sessionId,
       updatedAt: 42,
       createdActor: { type: "human", source: "profile", id: ownerId },
       visibility: "draft",
     },
   );
+  await seedLinearSessionTranscript({
+    agentId: "main",
+    contents: ["foreign draft transcript"],
+    sessionId,
+    sessionKey,
+    storePath,
+  });
   expect(
     addSessionMember(
       { agentId: "main", sessionKey, storePath },
@@ -530,6 +538,16 @@ test("sessions.describe hides foreign drafts at operator role boundaries", async
       expect(described.payload?.session?.participants, name).toHaveLength(4);
       expect(described.payload?.session?.expandedParticipants, name).toHaveLength(5);
     }
+    const transcript = await directSessionReq<{ messages: Array<{ content?: unknown }> }>(
+      "sessions.get",
+      { key: sessionKey },
+      { client, context: { getRuntimeConfig: () => cfg } },
+    );
+    expect(transcript.ok, name).toBe(true);
+    expect(
+      transcript.payload?.messages.map((message) => message.content),
+      name,
+    ).toEqual(hidden ? [] : ["foreign draft transcript"]);
   }
 });
 

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -11,9 +11,11 @@ import {
 } from "../../config/sessions.js";
 import {
   loadSessionEntry,
+  recordSessionParticipant,
   replaceSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { addSessionMember } from "../../config/sessions/session-sharing-store.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { recordAgentProvenance } from "../../state/agent-provenance.js";
@@ -33,6 +35,7 @@ import {
   setupGatewaySessionsHandlerTestHarness,
 } from "../test/server-sessions.test-helpers.js";
 import { agentsHandlers } from "./agents.js";
+<<<<<<< HEAD
 import {
   identifiedClient,
   listSessions,
@@ -435,6 +438,99 @@ test("a hidden-foreign role cannot discover sessions through search, batch previ
     ok: false,
     error: { message: `No session found: ${foreignKey}` },
   });
+});
+
+test("sessions.describe hides foreign drafts at operator role boundaries", async () => {
+  const sessionKey = "agent:main:foreign-draft-describe";
+  const profileId = (name: string) => ensureProfileForEmail(`${name}@example.com`).id;
+  const ownerId = profileId("draft-owner");
+  const memberId = profileId("draft-member");
+  const storePath = resolveStorePath(undefined, { agentId: "main" });
+  await replaceSessionEntry(
+    { agentId: "main", sessionKey, storePath },
+    {
+      sessionId: "session-foreign-draft-describe",
+      updatedAt: 42,
+      createdActor: { type: "human", source: "profile", id: ownerId },
+      visibility: "draft",
+    },
+  );
+  expect(
+    addSessionMember(
+      { agentId: "main", sessionKey, storePath },
+      { identityId: memberId, addedBy: ownerId, addedAt: 1 },
+    ).inserted,
+  ).toBe(true);
+  for (let index = 0; index < 5; index += 1) {
+    expect(
+      recordSessionParticipant(
+        { agentId: "main", sessionKey, storePath },
+        { identity: { type: "profile", id: `participant-${index}` }, promptedAt: index + 1 },
+      ),
+    ).toBe("inserted");
+  }
+  const roleConfig = (others: "view" | "suggest" | "write"): OpenClawConfig => ({
+    gateway: {
+      roles: {
+        default: "limited",
+        definitions: {
+          limited: {
+            sessions: { others },
+            agents: "*",
+            scopes: ["operator.read", "operator.write"],
+          },
+        },
+      },
+    },
+  });
+  const admin = identifiedClient(profileId("draft-admin"));
+  admin.connect!.scopes = ["operator.admin"];
+  const cases = [
+    {
+      name: "view",
+      client: identifiedClient(profileId("draft-viewer")),
+      cfg: roleConfig("view"),
+      hidden: true,
+    },
+    {
+      name: "suggest",
+      client: identifiedClient(profileId("draft-suggester")),
+      cfg: roleConfig("suggest"),
+      hidden: true,
+    },
+    {
+      name: "write",
+      client: identifiedClient(profileId("draft-writer")),
+      cfg: roleConfig("write"),
+      hidden: true,
+    },
+    { name: "member", client: identifiedClient(memberId), cfg: roleConfig("write"), hidden: true },
+    { name: "owner", client: identifiedClient(ownerId), cfg: roleConfig("view"), hidden: false },
+    { name: "admin", client: admin, cfg: roleConfig("view"), hidden: false },
+    {
+      name: "no roles",
+      client: identifiedClient(profileId("draft-outsider")),
+      cfg: {},
+      hidden: false,
+    },
+  ] as const;
+
+  for (const { name, client, cfg, hidden } of cases) {
+    const described = await directSessionReq<{
+      session: { participants?: unknown[]; expandedParticipants?: unknown[] } | null;
+    }>(
+      "sessions.describe",
+      { key: sessionKey },
+      { client, context: { getRuntimeConfig: () => cfg } },
+    );
+    expect(described.ok, name).toBe(true);
+    if (hidden) {
+      expect(described.payload?.session, name).toBeNull();
+    } else {
+      expect(described.payload?.session?.participants, name).toHaveLength(4);
+      expect(described.payload?.session?.expandedParticipants, name).toHaveLength(5);
+    }
+  }
 });
 
 test("bare ownerless reads fail closed without blocking scoped preview siblings", async () => {

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -477,7 +477,7 @@ test("sessions.describe and sessions.get hide foreign drafts at operator role bo
       ),
     ).toBe("inserted");
   }
-  const roleConfig = (others: "view" | "suggest" | "write"): OpenClawConfig => ({
+  const roleConfig = (others: "none" | "view" | "suggest" | "write"): OpenClawConfig => ({
     gateway: {
       roles: {
         default: "limited",
@@ -493,6 +493,8 @@ test("sessions.describe and sessions.get hide foreign drafts at operator role bo
   });
   const admin = identifiedClient(profileId("draft-admin"));
   admin.connect!.scopes = ["operator.admin"];
+  const missingProfile = identifiedClient(profileId("draft-missing-profile"));
+  delete missingProfile.authenticatedUserProfile;
   const cases = [
     {
       name: "view",
@@ -513,6 +515,7 @@ test("sessions.describe and sessions.get hide foreign drafts at operator role bo
       hidden: true,
     },
     { name: "member", client: identifiedClient(memberId), cfg: roleConfig("write"), hidden: true },
+    { name: "missing profile", client: missingProfile, cfg: roleConfig("view"), hidden: true },
     { name: "owner", client: identifiedClient(ownerId), cfg: roleConfig("view"), hidden: false },
     { name: "admin", client: admin, cfg: roleConfig("view"), hidden: false },
     {
@@ -593,6 +596,34 @@ test("sessions.describe and sessions.get hide foreign drafts at operator role bo
     } finally {
       readSpy.mockRestore();
     }
+  }
+
+  await replaceSessionEntry(
+    { agentId: "main", sessionKey, storePath },
+    {
+      sessionId,
+      updatedAt: 44,
+      createdActor: { type: "human", source: "profile", id: ownerId },
+      visibility: "shared",
+    },
+  );
+  let currentCfg = roleConfig("view");
+  const roleDriftRead = vi
+    .spyOn(sessionTranscriptReaders, "readRecentSessionMessagesWithStatsAsync")
+    .mockImplementationOnce(async (...args) => {
+      currentCfg = roleConfig("none");
+      return await originalRead(...args);
+    });
+  try {
+    const transcript = await directSessionReq<{ messages: Array<{ content?: unknown }> }>(
+      "sessions.get",
+      { key: sessionKey },
+      { client: cases[0].client, context: { getRuntimeConfig: () => currentCfg } },
+    );
+    expect(transcript.ok, "role/config change").toBe(true);
+    expect(transcript.payload?.messages, "role/config change").toEqual([]);
+  } finally {
+    roleDriftRead.mockRestore();
   }
 });
 

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -6,7 +6,6 @@ import {
   errorShape,
   type SessionsListParams,
   validateSessionsCleanupParams,
-  validateSessionsDescribeParams,
   validateSessionsListParams,
   validateSessionsPreviewParams,
   validateSessionsResolveParams,
@@ -46,17 +45,13 @@ import {
   resolveSessionVisibility,
 } from "../session-sharing.js";
 import { resolveSessionStoreAgentId } from "../session-store-key.js";
-import {
-  readRecentSessionMessagesWithStatsAsync,
-  readSessionPreviewItemsFromTranscript,
-} from "../session-transcript-readers.js";
+import { readSessionPreviewItemsFromTranscript } from "../session-transcript-readers.js";
 import { projectGatewaySessionActiveRun } from "../session-utils-display.js";
 import {
   createGatewaySessionStoreDiscoveryCache,
   type GatewaySessionStoreCache,
 } from "../session-utils-store-lookup.js";
 import {
-  buildGatewaySessionRow,
   listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGatewayCore,
   resolveCanonicalSessionEntryFromStoreKeys,
@@ -71,14 +66,11 @@ import { readPreparedServerMethodModelCatalog } from "./optional-model-catalog.j
 import { createVisibleActiveSessionRunProjector } from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import { resolveGatewayModelSelectionPolicy } from "./session-model-selection-policy.js";
-import {
-  createSessionPlacementBatchProjector,
-  readSessionPlacementFields,
-} from "./session-placement-read-projection.js";
+import { createSessionPlacementBatchProjector } from "./session-placement-read-projection.js";
 import { listFilter } from "./sessions-board-inventory.js";
 import { respondWithCachedSessionList } from "./sessions-list-cache.js";
+import { sessionByKeyReadHandlers } from "./sessions-read-by-key.js";
 import { resolveSessionSearchScope } from "./sessions-search-scope.js";
-import { loadSessionEntriesForTarget, requireSessionKey } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -607,45 +599,6 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
 
     respond(true, { ts: Date.now(), previews } satisfies SessionsPreviewResult, undefined);
   },
-  "sessions.describe": ({ params, respond, context, client }) => {
-    if (!assertValidParams(params, validateSessionsDescribeParams, "sessions.describe", respond)) {
-      return;
-    }
-    const key = requireSessionKey(params.key, respond);
-    if (!key) {
-      return;
-    }
-    const cfg = context.getRuntimeConfig();
-    const requestedAgent = resolveRequestedGlobalAgentId(cfg, key);
-    if (!requestedAgent.ok) {
-      respond(false, undefined, requestedAgent.error);
-      return;
-    }
-    const { target, storePath, store, entry } = loadSessionEntriesForTarget({
-      key,
-      cfg,
-      ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
-    });
-    const boundaryFilter =
-      hasOperatorBoundary(client, cfg) && createSessionListEntryFilter({ client, cfg });
-    if (!entry || (boundaryFilter && !boundaryFilter(target.canonicalKey, entry))) {
-      respond(true, { session: null }, undefined);
-      return;
-    }
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath,
-      store,
-      key: target.canonicalKey,
-      entry,
-      agentId: target.agentId,
-      includeDerivedTitles: params.includeDerivedTitles,
-      includeLastMessage: params.includeLastMessage,
-      transcriptUsageMaxBytes: 64 * 1024,
-    });
-    Object.assign(row, readSessionPlacementFields(context, row.sessionId));
-    respond(true, { session: row });
-  },
   "sessions.resolve": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateSessionsResolveParams, "sessions.resolve", respond)) {
       return;
@@ -669,57 +622,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
     }
     respond(true, resolved, undefined);
   },
-  "sessions.get": async ({ params, respond, context }) => {
-    const p = params as {
-      key?: unknown;
-      sessionKey?: unknown;
-      limit?: unknown;
-      agentId?: unknown;
-    };
-    const key = requireSessionKey(p.key ?? p.sessionKey, respond);
-    if (!key) {
-      return;
-    }
-    const limit =
-      typeof p.limit === "number" && Number.isFinite(p.limit)
-        ? Math.max(1, Math.floor(p.limit))
-        : 200;
-
-    const cfg = context.getRuntimeConfig();
-    const requestedAgent = resolveRequestedGlobalAgentId(
-      cfg,
-      key,
-      normalizeOptionalString(p.agentId),
-    );
-    if (!requestedAgent.ok) {
-      respond(false, undefined, requestedAgent.error);
-      return;
-    }
-    const { storePath, entry } = loadSessionEntriesForTarget({
-      key,
-      cfg,
-      agentId: requestedAgent.agentId,
-    });
-    if (!entry?.sessionId) {
-      respond(true, { messages: [] }, undefined);
-      return;
-    }
-    const { messages } = await readRecentSessionMessagesWithStatsAsync(
-      {
-        agentId: requestedAgent.agentId,
-        sessionEntry: entry,
-        sessionId: entry.sessionId,
-        sessionKey: key,
-        storePath,
-      },
-      {
-        maxMessages: limit,
-        maxLines: limit * 20 + 20,
-        allowResetArchiveFallback: true,
-      },
-    );
-    respond(true, { messages }, undefined);
-  },
+  ...sessionByKeyReadHandlers,
 };
 
 export const sessionsListHandler = sessionReadHandlers["sessions.list"]!;

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -607,7 +607,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
 
     respond(true, { ts: Date.now(), previews } satisfies SessionsPreviewResult, undefined);
   },
-  "sessions.describe": ({ params, respond, context }) => {
+  "sessions.describe": ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateSessionsDescribeParams, "sessions.describe", respond)) {
       return;
     }
@@ -626,7 +626,9 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
       cfg,
       ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
     });
-    if (!entry) {
+    const boundaryFilter =
+      hasOperatorBoundary(client, cfg) && createSessionListEntryFilter({ client, cfg });
+    if (!entry || (boundaryFilter && !boundaryFilter(target.canonicalKey, entry))) {
       respond(true, { session: null }, undefined);
       return;
     }

--- a/src/gateway/server.auth.presence-audience.test.ts
+++ b/src/gateway/server.auth.presence-audience.test.ts
@@ -275,22 +275,30 @@ describe("gateway presence audience", () => {
               "sessions.describe",
               { key: draftKey },
             );
-            expect(described, `${scenario.name} sessions.describe visibility`).toMatchObject({
-              ok: true,
-              payload: {
-                session: canReadDraft ? { sessionId: draftSessionId } : null,
-              },
-            });
+            if (scenario.name === "restricted") {
+              expect(described.ok, `${scenario.name} sessions.describe scope`).toBe(false);
+            } else {
+              expect(described, `${scenario.name} sessions.describe visibility`).toMatchObject({
+                ok: true,
+                payload: {
+                  session: canReadDraft ? { sessionId: draftSessionId } : null,
+                },
+              });
+            }
             const transcript = await rpcReq<{ messages: Array<{ content?: unknown }> }>(
               recipient.ws,
               "sessions.get",
               { key: draftKey },
             );
-            expect(transcript.ok, `${scenario.name} sessions.get visibility`).toBe(true);
-            expect(
-              transcript.payload?.messages.map((message) => message.content),
-              `${scenario.name} sessions.get transcript`,
-            ).toEqual(canReadDraft ? ["foreign draft transcript"] : []);
+            if (scenario.name === "restricted") {
+              expect(transcript.ok, `${scenario.name} sessions.get scope`).toBe(false);
+            } else {
+              expect(transcript.ok, `${scenario.name} sessions.get visibility`).toBe(true);
+              expect(
+                transcript.payload?.messages.map((message) => message.content),
+                `${scenario.name} sessions.get transcript`,
+              ).toEqual(canReadDraft ? ["foreign draft transcript"] : []);
+            }
           }
           const presence = await rpcReq(recipient.ws, "system-presence");
           expect(presence.ok, `${scenario.name} system-presence scope`).toBe(canRead);

--- a/src/gateway/server.auth.presence-audience.test.ts
+++ b/src/gateway/server.auth.presence-audience.test.ts
@@ -8,7 +8,10 @@ import { afterEach, describe, expect, test } from "vitest";
 import { PresenceEntrySchema } from "../../packages/gateway-protocol/src/schema/snapshot.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { writeConfigFile } from "../config/config.js";
-import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import {
+  persistSessionTranscriptTurn,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
 import type { GatewayAuthConfig, GatewayOperatorRolesConfig } from "../config/types.gateway.js";
 import { listSystemPresence, type SystemPresence } from "../infra/system-presence.js";
 import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profiles.js";
@@ -92,6 +95,7 @@ describe("gateway presence audience", () => {
     const sharedKey = "agent:main:presence-shared";
     const sharedSessionId = randomUUID();
     const draftKey = "agent:main:presence-draft";
+    const draftSessionId = randomUUID();
     const incognitoKey = "agent:main:dashboard:incognito-presence";
     const restrictedKey = "agent:main:presence-restricted-draft";
     const missingKey = "agent:main:presence-missing";
@@ -109,7 +113,12 @@ describe("gateway presence audience", () => {
         await upsertSessionEntryCore(
           { agentId: "main", sessionKey },
           {
-            sessionId: sessionKey === sharedKey ? sharedSessionId : randomUUID(),
+            sessionId:
+              sessionKey === sharedKey
+                ? sharedSessionId
+                : sessionKey === draftKey
+                  ? draftSessionId
+                  : randomUUID(),
             updatedAt: Date.now(),
             createdVia: "operator",
             createdActor: { type: "human", source: "profile", id: profileId },
@@ -118,6 +127,22 @@ describe("gateway presence audience", () => {
           },
         );
       }
+      await persistSessionTranscriptTurn(
+        { agentId: "main", sessionId: draftSessionId, sessionKey: draftKey },
+        {
+          updateMode: "none",
+          messages: [
+            {
+              message: {
+                role: "user",
+                content: "foreign draft transcript",
+                timestamp: 1,
+              },
+              now: Date.parse("2026-09-04T08:00:00.000Z"),
+            },
+          ],
+        },
+      );
       const sockets: Awaited<ReturnType<typeof openWs>>[] = [];
       const observePresence = (ws: Awaited<ReturnType<typeof openWs>>) => {
         const events: SystemPresence[][] = [];
@@ -244,6 +269,28 @@ describe("gateway presence audience", () => {
                 .toSorted(),
               `${scenario.name} canonical sessions.list visibility`,
             ).toEqual(scenario.allowed.toSorted());
+            const canReadDraft = scenario.allowed.includes(draftKey);
+            const described = await rpcReq<{ session: { sessionId?: string } | null }>(
+              recipient.ws,
+              "sessions.describe",
+              { key: draftKey },
+            );
+            expect(described, `${scenario.name} sessions.describe visibility`).toMatchObject({
+              ok: true,
+              payload: {
+                session: canReadDraft ? { sessionId: draftSessionId } : null,
+              },
+            });
+            const transcript = await rpcReq<{ messages: Array<{ content?: unknown }> }>(
+              recipient.ws,
+              "sessions.get",
+              { key: draftKey },
+            );
+            expect(transcript.ok, `${scenario.name} sessions.get visibility`).toBe(true);
+            expect(
+              transcript.payload?.messages.map((message) => message.content),
+              `${scenario.name} sessions.get transcript`,
+            ).toEqual(canReadDraft ? ["foreign draft transcript"] : []);
           }
           const presence = await rpcReq(recipient.ws, "system-presence");
           expect(presence.ok, `${scenario.name} system-presence scope`).toBe(canRead);


### PR DESCRIPTION
## What Problem This Solves

Operator-role users who knew a foreign draft session key could inspect the
draft through exact-key reads. `sessions.describe` disclosed identity-bearing
metadata, while `sessions.get` could return the draft transcript.

## Why This Change Was Made

Exact-key session reads now share one canonical visibility owner.
`sessions.describe` and `sessions.get` apply the existing operator-boundary
draft policy before disclosure:

- foreign `view`, `suggest`, and `write` callers receive non-disclosing
  successful results;
- draft creators and administrators retain access;
- deployments without configured operator roles retain the shipped
  proof-of-knowledge behavior.

`sessions.get` also revalidates configuration, canonical target, store path,
session identity, and visibility after the asynchronous transcript read. A
draft visibility change or same-key session replacement during that read
returns an empty result instead of stale transcript data.

## User Impact

Foreign drafts are no longer visible through either exact-key metadata or
transcript reads at an operator role boundary. Existing privileged and no-role
behavior is unchanged.

## Evidence

- Exact head: `46b6461b1025df093fdc26e404b29a9b317f621b`
- Current `origin/main` checked: `f0765dff583c78918be4b6cd672a03bfc707f307`;
  the verified head merges without conflicts.
- Pre-fix regression: a foreign `view` caller received the recognizable draft
  transcript instead of an empty result.
- `node scripts/run-vitest.mjs
  src/gateway/server-methods/sessions-read.test.ts
  src/gateway/server.auth.presence-audience.test.ts`: 23 tests passed.
- Real Gateway WebSocket RPC coverage verifies `sessions.describe` and
  `sessions.get` for creator, reader, writer, restricted-agent, and
  administrator callers.
- Direct-handler coverage verifies `view`, `suggest`, `write`, explicit member,
  creator, administrator, and no-role behavior.
- Race coverage pauses transcript reading, then changes visibility to draft or
  replaces the same-key session; both cases return no messages.
- Core production and test typechecks, targeted oxlint, formatting,
  `git diff --check`, and changed-lane classification passed.
- The exact assertion-safety ratchet now passes: the moved `sessions.get`
  assertion carries its dispatch invariant, and the old `sessions-read.ts`
  grandfathered count shrinks from 2 to 1.
- Independent Sol autoreview through P1: scoped-clean, no actionable findings,
  with the exact CI repair rated correct at 0.99.

Production LOC: `+144/-99`, net `+45`. The increase owns both exact-key reads
in one module and adds the required post-await identity/visibility
revalidation; the old handlers were removed. Test LOC: `+220/-3`, net `+217`.

No changelog edit: the release workflow owns generated release notes; this
description carries the release-note context.
