### PR TITLE
perf(usage): project rollup maps without staging arrays

### DIFF
--- a/src/infra/session-cost-usage-rollup.ts
+++ b/src/infra/session-cost-usage-rollup.ts
@@ -334,9 +334,9 @@ function buildToolUsage(
   if (tools.size === 0) {
     return undefined;
   }
-  const entries = Array.from(tools.entries())
-    .map(([name, count]) => ({ name, count }))
-    .toSorted((a, b) => b.count - a.count || (sortTiesByName ? a.name.localeCompare(b.name) : 0));
+  const entries = Array.from(tools, ([name, count]) => ({ name, count })).toSorted(
+    (a, b) => b.count - a.count || (sortTiesByName ? a.name.localeCompare(b.name) : 0),
+  );
   return {
     totalCalls: entries.reduce((sum, entry) => sum + entry.count, 0),
     uniqueTools: entries.length,
@@ -639,11 +639,10 @@ export function buildSessionCostSummaryFromRollup(params: {
     mergeModels(models, params.rollup.untimestamped.models);
   }
 
-  const dailyLatency = Array.from(dailyLatencies.entries())
-    .map(([date, aggregate]) => {
-      const stats = computeLatencyStats(aggregate);
-      return stats ? Object.assign({ date }, stats) : null;
-    })
+  const dailyLatency = Array.from(dailyLatencies, ([date, aggregate]) => {
+    const stats = computeLatencyStats(aggregate);
+    return stats ? Object.assign({ date }, stats) : null;
+  })
     .filter((entry): entry is SessionDailyLatency => entry !== null)
     .toSorted((a, b) => a.date.localeCompare(b.date));
   const utcQuarterHourMessageCounts = Array.from(quarterMessages.values()).toSorted(
@@ -663,9 +662,9 @@ export function buildSessionCostSummaryFromRollup(params: {
         ? Math.max(0, lastActivity - firstActivity)
         : undefined,
     activityDates: Array.from(activityDates).toSorted(),
-    dailyBreakdown: Array.from(dailyUsage.entries())
-      .map(([date, usage]) => Object.assign({ date }, usage))
-      .toSorted((a, b) => a.date.localeCompare(b.date)),
+    dailyBreakdown: Array.from(dailyUsage, ([date, usage]) =>
+      Object.assign({ date }, usage),
+    ).toSorted((a, b) => a.date.localeCompare(b.date)),
     dailyMessageCounts: Array.from(dailyMessages.values()).toSorted((a, b) =>
       a.date.localeCompare(b.date),
     ),


### PR DESCRIPTION
## What Problem This Solves

Usage rollup summaries first copy Map entries into arrays and then allocate another array to project each entry. This repeats for tool usage, daily latency and daily cost totals.

## Why This Change Was Made

Use the mapper argument of Array.from to build each projected array directly. Keep existing filtering, sorting, cost/latency calculations and caller-owned input unchanged. The three Maps are private to the summary owner.

Production LOC: +10/-11 (net -1); tests unchanged.

## User Impact

Usage reports keep the same values and ordering while avoiding three intermediate arrays when those projections run.

## Evidence

- Actual public rollup build, merge and global-cost summary probes preserve their full output hash and input ownership across 200 timestamped contributions plus an untimestamped contribution. Missing-price formatting and all 52 observed sort-copy calls remain unchanged.
- All 67 existing usage/reporting tests passed on the final candidate. The complete changed-file gate passed; independent Codex review through P2 was scoped clean.
- An earlier local candidate also changed inline sorting and failed the repository lint rule. Those edits were removed; the final gate verifies the remaining projection refactor. No allocated-byte, elapsed-time or Gateway RSS reduction is claimed for this change.
