### PR TITLE
fix(plugins): allow intentional uninstall size drops

### DIFF
--- a/src/cli/plugins-cli.uninstall.test.ts
+++ b/src/cli/plugins-cli.uninstall.test.ts
@@ -185,6 +185,19 @@ describe("plugins cli uninstall", () => {
         entries: {},
       },
     });
+    expect(replaceConfigFile).toHaveBeenCalledWith({
+      baseHash: "mock",
+      nextConfig: {
+        plugins: {
+          entries: {},
+        },
+      },
+      writeOptions: {
+        allowConfigSizeDrop: true,
+        afterWrite: { mode: "restart", reason: "plugin source changed" },
+        unsetPaths: [["plugins", "installs"]],
+      },
+    });
     expect(refreshPluginRegistry).toHaveBeenCalledWith({
       config: {
         plugins: {

--- a/src/cli/plugins-uninstall-command.ts
+++ b/src/cli/plugins-uninstall-command.ts
@@ -185,6 +185,7 @@ export async function runPluginUninstallCommand(
         ...(keepFiles ? { retainRemovedNpmInstallRecord: pluginId } : {}),
         ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
         writeOptions: {
+          allowConfigSizeDrop: true,
           afterWrite: { mode: "restart", reason: "plugin source changed" },
         },
       }),


### PR DESCRIPTION
## Summary

Backports `7fbfc2e8ad3` (`fix(plugins): allow intentional uninstall size drops (#110991)`) to the frozen extended-stable candidate.

The full validation Kitchen Sink Plugin scenario ran `openclaw plugins uninstall ... --force`; its known removal plan legitimately contracts the config from 555 to 180 bytes, but the CLI omitted the write owner’s `allowConfigSizeDrop` authorization and rejected its own planned mutation. The repair attaches that authorization only to the uninstall lifecycle commit; suspicious writes elsewhere stay protected.

## Evidence

- Reproduction: Plugin Prerelease exact-frozen run `33707894263`, Kitchen Sink Plugin job `100502023283`, error `Config write rejected ... (size-drop:555->180)`.
- Owner: `src/cli/plugins-uninstall-command.ts` calls `commitPluginInstallRecordsWithConfig` after generating `planPluginUninstall`; it is the authoritative, force-confirmed uninstall mutation.
- Upstream history: source commit `7fbfc2e8ad3` is absent from frozen candidate `659df810` and applies cleanly as this PR commit `8f9ea3b`.
- Regression: the imported CLI unit assertion fails before the source fix because the write options omit `allowConfigSizeDrop`.

## Validation

- `OPENCLAW_FS_SAFE_NATIVE_MODE=off node scripts/run-vitest.mjs run src/cli/plugins-cli.uninstall.test.ts` (10 passed)
- `git diff --check`
- `autoreview --mode branch --base origin/extended-stable/2026.6.33`
- Current gate: this head\x27s preflight/security-fast run predates the frozen-checkout authentication repair #136949 and fails before validation. Rerun after #136949 lands.

## Scope

Production: +1 / -0. Tests: +13 / -0. The test proves the exact write contract. No config schema, plugin contract, release tag, npm state, or frozen-candidate mutation is included.