### PR TITLE
perf(acp): reuse replay ledger eviction order

### DIFF
--- a/src/acp/event-ledger.memory.ts
+++ b/src/acp/event-ledger.memory.ts
@@ -30,12 +30,8 @@ function createEmptyStore(): LedgerStore {
   };
 }
 
-function serializeLedgerStore(store: LedgerStore): string {
-  return JSON.stringify(store);
-}
-
 function getSerializedLedgerByteLength(store: LedgerStore): number {
-  return Buffer.byteLength(serializeLedgerStore(store), "utf8");
+  return Buffer.byteLength(JSON.stringify(store), "utf8");
 }
 
 function getOrCreateSession(
@@ -74,7 +70,8 @@ function getOrCreateSession(
 }
 
 function trimLedger(state: MemoryLedgerState): void {
-  for (const session of Object.values(state.store.sessions)) {
+  const sessions = Object.values(state.store.sessions);
+  for (const session of sessions) {
     if (session.events.length <= state.maxEventsPerSession) {
       continue;
     }
@@ -82,7 +79,6 @@ function trimLedger(state: MemoryLedgerState): void {
     session.complete = false;
   }
 
-  const sessions = Object.values(state.store.sessions);
   if (sessions.length > state.maxSessions) {
     for (const session of sessions
       .toSorted((a, b) => b.updatedAt - a.updatedAt)
@@ -92,23 +88,23 @@ function trimLedger(state: MemoryLedgerState): void {
   }
 
   let serializedBytes = getSerializedLedgerByteLength(state.store);
-  while (serializedBytes > state.maxSerializedBytes) {
-    const session = Object.values(state.store.sessions)
-      .filter((candidate) => candidate.events.length > 0)
-      .toSorted((a, b) => a.updatedAt - b.updatedAt)[0];
-    if (!session) {
-      break;
-    }
-    session.events.shift();
-    session.complete = false;
-    serializedBytes = getSerializedLedgerByteLength(state.store);
+  if (serializedBytes <= state.maxSerializedBytes) {
+    return;
   }
-
-  while (serializedBytes > state.maxSerializedBytes) {
-    const session = Object.values(state.store.sessions).toSorted(
-      (a, b) => a.updatedAt - b.updatedAt,
-    )[0];
-    if (!session) {
+  // Trimming changes neither timestamps nor session order; reuse one stable
+  // eviction order while preserving the events-before-session-rows policy.
+  const oldestFirst = Object.values(state.store.sessions).toSorted(
+    (a, b) => a.updatedAt - b.updatedAt,
+  );
+  for (const session of oldestFirst) {
+    while (serializedBytes > state.maxSerializedBytes && session.events.length > 0) {
+      session.events.shift();
+      session.complete = false;
+      serializedBytes = getSerializedLedgerByteLength(state.store);
+    }
+  }
+  for (const session of oldestFirst) {
+    if (serializedBytes <= state.maxSerializedBytes) {
       break;
     }
     delete state.store.sessions[session.sessionId];


### PR DESCRIPTION
## What Problem This Solves

When an ephemeral ACP replay ledger exceeds its byte budget, every discarded event repeats the same session collection, filtering and sorting. A large incoming event can trigger many such scans while the bridge records it.

## Why This Change Was Made

Collect sessions once for the count/event limits. Only on byte overflow, prepare one stable eviction order and reuse it while removing events and then empty session rows. Keep every byte-budget check and the existing retention order. Inline the one-use serialization wrapper.

Production LOC: +18/-22 (net -4); tests unchanged. SQLite storage, schemas, retention limits and replay policy are unchanged.

## User Impact

The in-memory bridge ledger performs less temporary work while trimming. Complete and incomplete replay behavior, sequence numbers, session rebinding and reset behavior are preserved.

## Evidence

- Actual ledger operations preserve all 1,312 observed serialized intermediate states and 396 public replay results across 36 cases: equal/increasing/decreasing timestamps, numeric session keys, session/event/byte limits, oversized events and metadata, and resets.
- In that fixed corpus, Object.values calls decrease from 2,400 to 1,246, sort-copy calls from 504 to 394, and filter calls from 286 to 36. These are logical operation counts; no allocated-byte or Gateway RSS reduction is claimed.
- All 21 existing ledger, translator replay and disconnect tests passed. The complete changed-file gate passed, and independent Codex review through P2 was scoped clean.
