### PR TITLE
fix(ui): restore startup CSS budget after linked participants

### DIFF
--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -246,7 +246,7 @@ function renderParticipantMenu(
       </div>`;
     })}
     ${unresolvedCount > 0
-      ? html`<div class="session-hovercard__participant-unresolved" role="listitem">
+      ? html`<div class="session-hovercard__more" role="listitem">
           ${t("sessionHovercard.moreParticipantsLabel", { count: String(unresolvedCount) })}
         </div>`
       : nothing}

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -124,11 +124,9 @@
 }
 
 button.session-hovercard__attribution-others:is(:hover, :focus-visible) {
-  background: var(--bg-hover);
   color: var(--text);
 }
 
-.session-hovercard__participant-unresolved,
 .session-hovercard__no-pr,
 .session-hovercard__more {
   color: var(--muted);


### PR DESCRIPTION
## Status

Superseded by #136878, merged as `507e5faf28500d12b8b43c8d0ad7996190e27d5d`.

That repair reused the existing participant-overflow class and removed its redundant selector. Hosted exact-head validation measured startup CSS at the fixed 46,080 B ceiling with no performance-budget violations, and the build-artifacts and aggregate CI gates passed.

## Original Problem

The linked-participant change in #136719 increased startup CSS to 46,097 B, exceeding the fixed 46,080 B budget by 17 bytes.

## Remaining Difference

This closed PR's reviewed head additionally removes a hover background declaration that is overridden by the button's inline transparent background. It has no rendered effect, but it is no longer needed to restore current-main validation and is not being pursued as a standalone cleanup.
