### PR TITLE
perf(process): normalize diagnostic redraws without line arrays

### DIFF
--- a/src/process/command-error.ts
+++ b/src/process/command-error.ts
@@ -6,11 +6,10 @@ import type { runCommandBuffered } from "./exec.js";
 
 export function formatCommandOutput(output: string | Buffer, maxChars = 800): string {
   // CR redraws replace the current frame; trim before making edge tabs visible.
+  // Anchor each CR run/frame so unmatched runs do not repeatedly scan their suffixes.
   const text = stripAnsi(output.toString())
-    .replace(/\r\n/g, "\n")
-    .split("\n")
-    .map((line) => line.replace(/\r+$/, "").split("\r").at(-1) ?? "")
-    .join("\n")
+    .replace(/(^|[^\r])\r+(?=\n|$)/g, "$1")
+    .replace(/(^|\n)[^\n]*\r/g, "$1")
     .trim()
     .replace(/[^\n]+/g, sanitizeTerminalText);
   const tail = text.split("\n").slice(-12).join("\n");


### PR DESCRIPTION
Command failure diagnostics previously split and mapped every output line, then split each redraw frame again before joining the same final text. Normalize CR runs and last redraw frames directly in the canonical formatter, removing those temporary arrays while preserving ANSI/control handling, trim order, UTF-16-safe tails and error budgets. The patterns anchor each run or line so unmatched carriage-return suffixes are not repeatedly scanned.

Production delta: **−1 line**. No test, configuration or dependency changes.

Validation passed: the existing 22 owner tests before and after, the canonical changed gate, and independent managed P0–P2 review. Separate baseline/candidate actual-source probes matched 19,039 observations across 1,572 inputs, plus a real child emitting synthetic ANSI/CR/Unicode diagnostics and exiting 7. Its result remained:

```text
synthetic child failed (code=7, termination=exit)
stderr: warning\tfield
recovery
stdout: new 🦞
ready
```

Instrumented split/map/slice arrays fell from 7→2 for a 25-byte diagnostic and 69→2 for a synthetic 64-line progress diagnostic. A larger synthetic 64 KiB/1,024-line case fell from 1,029→2. These are operation counts, not retained-memory or latency measurements. Sixteen adversarial CR/no-CR cases up to 512 KiB matched expected output. All owned proof processes joined and temporary runtimes were removed.
