### PR TITLE
fix(docs): preserve redirected maturity section links

### DIFF
--- a/scripts/qa/render-maturity-docs.ts
+++ b/scripts/qa/render-maturity-docs.ts
@@ -258,10 +258,12 @@ function docsLink(docPath: string, docsRouteIndex: DocsRouteIndex): string | und
   const publicRoute = docsRouteIndex.routes.has(withoutExtension)
     ? withoutExtension
     : docsRouteIndex.redirects.get(withoutExtension);
-  if (!publicRoute || !docsRouteIndex.routes.has(publicRoute)) {
+  // Redirect fragments override source fragments; route validation only checks the page.
+  const [publicPage = "", publicAnchor = anchor] = (publicRoute ?? "").split("#", 2);
+  if (!publicPage || !docsRouteIndex.routes.has(publicPage)) {
     return undefined;
   }
-  const publicHref = anchor ? `${publicRoute}#${anchor}` : publicRoute;
+  const publicHref = publicAnchor ? `${publicPage}#${publicAnchor}` : publicPage;
   return `[${markdownEscape(title)}](/${markdownEscape(publicHref)})`;
 }
 

--- a/test/scripts/render-maturity-docs.test.ts
+++ b/test/scripts/render-maturity-docs.test.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 const repoRoot = path.resolve(__dirname, "../..");
@@ -112,10 +112,11 @@ function writeQaEvidence(params: {
   );
 }
 
-function allProfileScorecardFixture(evidenceEntryCount = 1) {
-  const taxonomy = parseYaml(
-    fs.readFileSync(path.join(repoRoot, "taxonomy.yaml"), "utf8"),
-  ) as TaxonomyFixture;
+function allProfileScorecardFixture(
+  evidenceEntryCount = 1,
+  taxonomyPath = path.join(repoRoot, "taxonomy.yaml"),
+) {
+  const taxonomy = parseYaml(fs.readFileSync(taxonomyPath, "utf8")) as TaxonomyFixture;
   const activeSurfaces = (taxonomy.surfaces ?? []).filter(
     (surface) => surface.status !== "retired",
   );
@@ -198,6 +199,128 @@ function expectedMaturityScorePercent(): number {
 }
 
 describe("maturity docs renderer CLI", () => {
+  it("renders public docs redirects with destination fragments overriding source fragments", () => {
+    const fixtureDir = tempDirs.make("openclaw-maturity-docs-links-");
+    const docsRoot = path.join(fixtureDir, "docs");
+    const taxonomyPath = path.join(fixtureDir, "taxonomy.yaml");
+    const scoresPath = path.join(fixtureDir, "scores.yaml");
+    const evidenceDir = path.join(fixtureDir, "synthetic-evidence");
+    const outputDir = path.join(fixtureDir, "output");
+    const links = [
+      ["docs/legacy-fragment.md", "[Legacy Fragment](/guide#destination-section)"],
+      ["docs/legacy-page.mdx#source-section", "[Source Section](/guide#source-section)"],
+      ["docs/legacy-fragment.md#source-section", "[Source Section](/guide#destination-section)"],
+      ["docs/legacy-empty.md#source-section", "[Source Section](/guide)"],
+      ["docs/guide.md#direct-section", "[Direct Section](/guide#direct-section)"],
+      ["docs/direct.mdx#direct-section", "[Direct Section](/direct#direct-section)"],
+      ["docs/legacy-page.md", "[Legacy Page](/guide)"],
+      ["docs/unknown.md", null],
+      ["docs/legacy-missing.md", null],
+      ["docs/internal/private.md", null],
+      ["docs/legacy-private.md", null],
+      ["https://example.test/guide#external", null],
+      ["docs/legacy-external.md", null],
+      ["docs/legacy-chain.md", null],
+    ] as const;
+    fs.mkdirSync(path.join(docsRoot, "internal"), { recursive: true });
+    for (const file of ["guide.md", "direct.mdx", "internal/private.md"]) {
+      fs.writeFileSync(
+        path.join(docsRoot, file),
+        "# Fixture page\n\n## Direct section\n\n## Source section\n\n## Destination section\n",
+      );
+    }
+    fs.writeFileSync(
+      path.join(docsRoot, "docs.json"),
+      JSON.stringify({
+        redirects: [
+          ["/legacy-fragment", "/guide#destination-section"],
+          ["/legacy-page", "/guide"],
+          ["/legacy-empty", "/guide#"],
+          ["/direct", "/guide#destination-section"],
+          ["/legacy-missing", "/missing#destination-section"],
+          ["/legacy-private", "/internal/private#destination-section"],
+          ["/legacy-external", "https://example.test/guide#external"],
+          ["/legacy-chain", "/legacy-fragment"],
+        ].map(([source, destination]) => ({ source, destination })),
+      }),
+    );
+    const surface = { id: "tools", name: "Fixture tools", family: "core", level: "experimental" };
+    fs.writeFileSync(
+      taxonomyPath,
+      stringifyYaml({
+        version: 1,
+        title: "Synthetic docs link fixture",
+        levels: [{ id: "experimental", code: "M1", label: "Experimental" }],
+        surfaces: [
+          {
+            ...surface,
+            categories: [
+              {
+                id: "links",
+                name: "Docs links",
+                category_note: "Synthetic fixture for renderer links",
+                features: [{ name: "Fixture feature", coverageIds: ["tools.evidence"] }],
+                docs: links.map(([doc]) => doc),
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    const scores = {
+      quality: { score: 0, label: "Experimental" },
+      completeness: { score: 0, label: "Experimental" },
+    };
+    fs.writeFileSync(
+      scoresPath,
+      stringifyYaml({
+        version: 1,
+        process_version: 1,
+        counts: { active_surfaces: 1, category_scores: 1 },
+        rollups: { surface_average: scores, category_average: scores },
+        surfaces: [
+          {
+            ...surface,
+            scores,
+            categories: [
+              {
+                name: "Docs links",
+                ...scores,
+                lts: { supported: false, human_override: false },
+              },
+            ],
+            lts: { supported_categories: 0, total_categories: 1, status: "none" },
+          },
+        ],
+      }),
+    );
+    writeQaEvidence({
+      dir: evidenceDir,
+      entries: [{ id: "synthetic-docs-links", status: "skipped" }],
+      scorecard: allProfileScorecardFixture(1, taxonomyPath),
+    });
+
+    const result = runCli(
+      "--docs-root",
+      docsRoot,
+      "--taxonomy",
+      taxonomyPath,
+      "--scores",
+      scoresPath,
+      "--evidence-dir",
+      evidenceDir,
+      "--output-dir",
+      path.relative(repoRoot, outputDir),
+      "--strict-inputs",
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    const taxonomy = fs.readFileSync(path.join(outputDir, "maturity", "taxonomy.md"), "utf8");
+    const renderedLinks = taxonomy.match(/\[[^\]]+\]\([^)]+\)/g);
+    expect(renderedLinks).toEqual(links.flatMap(([, link]) => (link === null ? [] : [link])));
+  });
+
   it("checks maturity inputs without requiring QA evidence artifacts", () => {
     const result = runCli("--check");
 


### PR DESCRIPTION
Closes #136908

## What Problem This Solves

Fixes an issue where maintainers generating maturity docs would silently lose valid docs links when a redirect destination includes a section fragment. For example, a taxonomy reference to `docs/legacy-fragment.md` redirecting to `/guide#destination-section` was omitted from the generated taxonomy.

## Why This Change Was Made

The renderer validated a full redirect target against a page-only route index. `docsLink` now separates the selected destination page from its fragment, validates the page, and emits the selected fragment. Destination fragments take precedence (including an explicit empty fragment); absent destination fragments inherit the source fragment. Existing direct-page priority, source-derived labels, `.md`/`.mdx` handling, single-hop redirects, and rejection of unknown/private/external targets remain intact.

This repairs the canonical link producer without an alternate resolver or test-only export. Production LOC: +4/-2 (net +2); tests: +128/-5 (net +123). The two added production lines separate page membership from href-fragment identity within the existing flow.

## User Impact

Future maturity renders retain valid redirected section links. Taxonomy IDs, coverage IDs, scores, real QA evidence, `docs/docs.json`, and checked-in `docs/maturity/**` are unchanged. This PR does not regenerate or publish canonical docs, refresh Coverage/LTS results, or change evidence policy. The older checked-in taxonomy output (last changed August 19) and the August 30 source path cleanup are separate from this renderer repair.

## Evidence

- Real subprocess CLI regression with isolated docs, taxonomy, scores, synthetic skipped evidence, output directory, and `--strict-inputs`; no production test seam.
- `node scripts/run-vitest.mjs test/scripts/render-maturity-docs.test.ts`: before the production fix, **1 failed / 6 passed**, with three valid redirect links missing; after the fix, **7 passed**, including a separate confirming rerun.
- The fixture checks destination precedence, source-fragment inheritance, empty destination fragments, direct-page priority, `.md`/`.mdx`, and invalid/private/external/chained redirects.
- `node scripts/check-changed.mjs -- scripts/qa/render-maturity-docs.ts test/scripts/render-maturity-docs.test.ts`: passed formatting, script/root-test type checks, lint, and applicable guards.
- `git diff --check`: passed. Fresh independent Codex review of the exact patch: scoped-clean, no accepted/actionable P0 findings.

The fixture evidence is synthetic input for renderer behavior, not real all/release QA coverage. Real CLI output is the owner-boundary proof for this deterministic tooling change; no gateway, browser deployment, or published-doc repair is claimed. A future canonical regeneration must use genuine QA evidence.


CI recovered; native prepare passed on unchanged reviewed head `289e7996f588e403489ea5e398239eb817aee1f7`. [CI attempt 5](https://github.com/openclaw/openclaw/actions/runs/33710508002/attempts/5) and the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33710508002/job/100520876857) completed successfully.

Recovery history: #136878 resolved the earlier CSS build prerequisite. Attempts 2–4 hit runner shutdowns during core lint (exit 143, no lint diagnostic; [attempt 3](https://github.com/openclaw/openclaw/actions/runs/33710508002/job/100514834203)). The shutdown cause is unproven. A plan/routing mismatch was verified: the run's original preflight selected Blacksmith before the backend changed to hybrid; failed-only retries reused that preflight while running on hosted Ubuntu with monolithic core lint. A full same-run, same-head `gh run rerun 33710508002` recomputed preflight for attempt 5: all five intended hosted core-lint stripes, remaining checks, and aggregate passed. Recovery changed no source, global variable, lint rule, timeout, or baseline.

ClawSweeper follow-through: [completed review](https://github.com/openclaw/openclaw/pull/136910#issuecomment-5519754776) found no correctness/security findings. The earlier net +2 production-line concern is accepted: separating page membership from href-fragment identity is the smallest clear owner repair. Retain the canonical split and CLI fixture. The latest review’s remaining exact-head CI requirement and Rank-up move are satisfied by attempt 5.
