### PR TITLE
fix(browser): navigate times out at 20s on a healthy CDP target

### DIFF
--- a/extensions/browser/src/node-host/invoke-browser.test.ts
+++ b/extensions/browser/src/node-host/invoke-browser.test.ts
@@ -463,6 +463,7 @@ describe("runBrowserProxyCommand", () => {
   });
 
   it("retains staged copies when the timeout wins before dispatch settles", async () => {
+    vi.useFakeTimers();
     const now = vi.spyOn(Date, "now").mockReturnValue(0);
     const staged = stagedReportUpload;
     uploadMocks.stageBrowserProxyUploadRequest.mockResolvedValueOnce(staged);
@@ -473,7 +474,7 @@ describe("runBrowserProxyCommand", () => {
         body: { running: true, cdpReady: true, cdpHttp: true },
       });
 
-    await expect(
+    const result = expect(
       runBrowserProxyCommand(
         JSON.stringify({
           method: "POST",
@@ -487,9 +488,9 @@ describe("runBrowserProxyCommand", () => {
         }),
         "browser.proxy.upload.v1",
       ),
-    )
-      .rejects.toThrow("browser proxy timed out")
-      .finally(() => now.mockRestore());
+    ).rejects.toThrow("browser proxy timed out");
+    await vi.advanceTimersByTimeAsync(10_000);
+    await result.finally(() => now.mockRestore());
 
     expect(uploadMocks.discardStagedBrowserProxyUpload).not.toHaveBeenCalled();
   });
@@ -735,7 +736,7 @@ describe("runBrowserProxyCommand", () => {
     ).rejects.toThrow(
       /browser proxy timed out for GET \/snapshot after 5ms; ws-backed browser action; profile=openclaw; status\(running=true, cdpHttp=true, cdpReady=false, cdpUrl=http:\/\/127\.0\.0\.1:18792\)/,
     );
-    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10_000);
     await result;
   });
 
@@ -768,7 +769,7 @@ describe("runBrowserProxyCommand", () => {
     ).rejects.toThrow(
       /browser proxy timed out for GET \/snapshot after 5ms; ws-backed browser action; profile=user; status\(running=true, cdpHttp=true, cdpReady=false, transport=chrome-mcp\)/,
     );
-    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10_000);
     await result;
   });
 
@@ -801,8 +802,32 @@ describe("runBrowserProxyCommand", () => {
     ).rejects.toThrow(
       /status\(running=true, cdpHttp=true, cdpReady=false, cdpUrl=https:\/\/example\.com\/chrome\?token=supers…7890\)/,
     );
-    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10_000);
     await result;
+  });
+
+  it("returns a late omitted-timeout navigation instead of a generic proxy timeout", async () => {
+    vi.useFakeTimers();
+    dispatcherMocks.dispatch.mockImplementationOnce(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20_000);
+      });
+      return { status: 200, body: { ok: true, url: "https://example.org/" } };
+    });
+
+    const pending = runBrowserProxyCommand(
+      JSON.stringify({
+        method: "POST",
+        path: "/navigate",
+        profile: "imported",
+        body: { url: "https://example.org/", targetId: "t2" },
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    await expect(pending).resolves.toBe(
+      JSON.stringify({ result: { ok: true, url: "https://example.org/" } }),
+    );
   });
 
   it.each([

--- a/extensions/browser/src/node-host/invoke-browser.ts
+++ b/extensions/browser/src/node-host/invoke-browser.ts
@@ -3,7 +3,7 @@
  * requests.
  */
 import fsPromises from "node:fs/promises";
-import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { addTimerTimeoutGraceMs, resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   asNullableRecord,
   normalizeStringEntries,
@@ -81,6 +81,10 @@ function readOwnedTabCloseRequest(value: unknown) {
 }
 
 const DEFAULT_BROWSER_PROXY_TIMEOUT_MS = 20_000;
+// Matches the Gateway node-invoke slack so a navigation that consumes its full
+// action budget can still finish target setup/cleanup without the node-host
+// watchdog turning a valid late result into a generic proxy timeout.
+const BROWSER_PROXY_DISPATCH_SLACK_MS = 5_000;
 const BROWSER_PROXY_STATUS_TIMEOUT_MS = 750;
 // Leave one MiB for the fixed node.invoke.result frame around payloadJSON.
 const BROWSER_PROXY_MAX_ENCODED_PAYLOAD_BYTES = 24 * 1024 * 1024;
@@ -180,6 +184,13 @@ function decodeParams<T>(raw?: string | null): T {
 
 function resolveBrowserProxyTimeout(timeoutMs?: number): number {
   return resolveTimerTimeoutMs(timeoutMs, DEFAULT_BROWSER_PROXY_TIMEOUT_MS);
+}
+
+function resolveBrowserProxyDispatchTimeoutMs(remainingTimeoutMs: number): number {
+  return (
+    addTimerTimeoutGraceMs(remainingTimeoutMs, BROWSER_PROXY_DISPATCH_SLACK_MS) ??
+    remainingTimeoutMs
+  );
 }
 
 function isBrowserProxyTimeoutError(err: unknown): boolean {
@@ -441,7 +452,7 @@ export async function runBrowserProxyCommand(
           body,
           signal: combineBrowserProxySignals(timeoutSignal, invocationSignal),
         }),
-      remainingTimeoutMs,
+      resolveBrowserProxyDispatchTimeoutMs(remainingTimeoutMs),
       "browser proxy request",
     );
   } catch (err) {


### PR DESCRIPTION
Closes #136769

## What Problem This Solves

Fixes an issue where users running `browser` `action=navigate` against a healthy CDP-backed managed profile would see a generic `browser proxy timed out for POST /navigate after 20000ms` error, even though `snapshot`, `evaluate`, and later `navigate` calls on the same target succeeded. The tab URL was unchanged, so the failure looked like a site-side navigation block.

## Why This Change Was Made

Default `navigate` omits a per-call timeout, so node-host and Playwright both start a 20s budget. Node-host starts that clock before dispatch, then the navigate route still has to select the target, wait for load, resolve the result, and release relay state. When those extra steps push past the equal outer deadline, a valid late navigation is reported as a proxy timeout.

This change gives node-host dispatch the same 5s completion slack the Gateway already reserves for node invoke, without a new config knob, retry, or stale-target workaround. Staging still fails closed if it exhausts the original action deadline.

## User Impact

Default browser navigations can finish after using their full 20s action budget instead of failing with a healthy-CDP proxy timeout. Explicit `timeoutMs` values get the same dispatch slack. Timeout error text still reports the action budget, not the internal slack window.

## Evidence

- Regression `returns a late omitted-timeout navigation instead of a generic proxy timeout` fails on pre-fix code with `browser proxy timed out for POST /navigate after 20000ms` and passes after the slack window.
- `pnpm test` / `node scripts/run-vitest.mjs extensions/browser/src/node-host/invoke-browser.test.ts`: 38 passed.
- Existing timeout diagnostic tests now advance past the 5s dispatch slack so they still cover the timeout-wins path.
