### PR TITLE
docs: correct v2026.9.1 release notes

### DIFF
--- a/docs/releases/2026.9.1.md
+++ b/docs/releases/2026.9.1.md
@@ -1,6 +1,6 @@
 ---
 title: "v2026.9.1"
-summary: "Mermaid diagrams in chat, a fuller Android experience, safer update recovery, and less overhead across long-running work."
+summary: "Mermaid diagrams across chat surfaces, a fuller Android experience, safer update recovery, and lower overhead for long conversations and large installations."
 description: "Detailed OpenClaw v2026.9.1 release notes covering setup, the Control UI, updates, messaging, memory, skills, native apps, models, automations, browser and computer use, plugins, security, performance, fixes, and maintainer changes."
 keywords:
   - OpenClaw
@@ -13,80 +13,128 @@ keywords:
 
 # v2026.9.1
 
-Mermaid diagrams now render directly inside conversations in the Control UI, Android, iPhone, iPad, and Mac, while Android gets a much fuller chat, session, model, permission, navigation, and appearance experience. Updates preserve more of a working setup, stop before known readiness problems become broken restarts, and leave clearer recovery paths when something does fail, while measured paths through long conversations, large saved-session histories, streaming, commands, and busy Gateways do less repeated work and retain less temporary state. Getting to that work is easier too, with a Quick Start path that can reuse working AI access and open the web dashboard after one choice. Once inside, teammates on shared Gateways can build and reuse personal skills, publish pull requests through an explicitly selected personal GitHub account, and let sandbox-required guests code inside private writable storage without exposing the shared workspace, all alongside a much wider reliability pass across messaging, memory, models, automations, integrations, and everyday recovery.
+Mermaid diagrams now render directly inside conversations in the Control UI, Android, iPhone, iPad, and Mac, and Android gains a fuller chat and session experience. Updates preserve more of a working setup and stop before a known problem becomes a broken restart. When an update does fail, OpenClaw gives you a clearer path back to a working installation. Testing also found lower memory use and less repeated work while OpenClaw handled long conversations and large installations.
 
-**Release scale:** 1,186 pull requests, 21 direct commits, and 281 contributors.
+**Release scale:** 1,186 pull requests, 28 direct commits, and 281 contributors.
 
 ## Installation and Onboarding
 
-Getting from a fresh install to a useful conversation is shorter when the computer already has working AI access, and the longer paths now do a better job of keeping existing choices intact when setup is cancelled, interrupted, or aimed at the wrong place. Windows installation, macOS AI setup, local archives, shell completion, and one-time Connect handoffs also fail more clearly without quietly discarding useful state.
+Getting OpenClaw running now takes a shorter path when the machine already has usable AI access, while longer setup paths leave existing choices and files alone when a check fails or a different route is selected. This release also tightens Windows installation, macOS AI setup, shell configuration, Connect handoffs, and managed local-model downloads.
 
 <AccordionGroup>
 
-<Accordion title="Guided setup and verified AI access">
+<Accordion title="Quick Start to the Web Dashboard">
 
-On a fresh local install, the recommended [Quick Start](/start/wizard) path can reuse verified Claude Code or Codex access, or an existing provider key, and open the web dashboard after one choice. The Gateway stays in the current terminal until it is stopped with Ctrl+C, the saved configuration remains afterward, and installing a background service is still an explicit later step. On a headless machine, the same path provides a one-time authenticated dashboard link and an SSH tunnel template instead of exposing reusable Gateway credentials.
+On a fresh local install, the recommended Quick Start path can reuse verified Claude Code or Codex access, or an existing provider key, and open the web dashboard after one choice. The [installation](/install) and [guided setup](/start/wizard) flow keeps the Gateway in the current terminal until you stop it with Ctrl+C, preserves the configuration afterward, and leaves background service installation as an explicit later step.
 
-Guided setup can once again configure custom and local providers, including endpoints that do not need an API key, and makes the model active only after a real reply succeeds. Imported model settings can be checked before the first agent is named, setup reruns preserve an existing roster and workspace, and failed or cancelled checks leave the previous configuration alone. Before guarded local setup writes, OpenClaw also compares the CLI's selected state and configuration paths with the Gateway's paths, stopping a proven mismatch with both locations and a recovery command while leaving offline setup available when there is no installed service to compare against.
-
-On macOS, AI setup now shows the selected provider and real installation or verification activity instead of turning elapsed time into a percentage. Input controls appear only when an answer is needed, capability consent remains explicit, and cancelled, failed, or replaced attempts stay attached to the correct setup session. Windows onboarding can find eligible npm-installed CLI backends by their ordinary command name through PATHEXT while preserving the neighboring Git Bash launcher, but relative, unresolved, and unsupported wrappers remain rejected, and the separate Claude PATH-shim security concern remains unresolved.
+On a headless machine, the same path provides a one-time authenticated dashboard link and an SSH tunnel template instead of exposing reusable Gateway credentials. Custom setup, remote Gateway onboarding, and non-interactive setup keep their existing paths when Quick Start is not the right fit.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Reach the web dashboard through the foreground Quick Start path ([#134221](https://github.com/openclaw/openclaw/pull/134221)). Thanks @fuller-stack-dev.
-
-**Bug fixes**
-
-- Verify imported model settings without attaching temporary setup state to an existing agent ([#132477](https://github.com/openclaw/openclaw/pull/132477)).
-- Show cancelled macOS AI setup as a clear retryable outcome ([#134654](https://github.com/openclaw/openclaw/pull/134654)).
-- Restore verified custom and local providers in guided onboarding ([#134907](https://github.com/openclaw/openclaw/pull/134907)).
-- Show provider-aware macOS setup activity and keep replies with the current attempt ([#135041](https://github.com/openclaw/openclaw/pull/135041)).
-- Resolve eligible npm-installed Windows CLI backends through PATHEXT while retaining command-safety boundaries ([#135138](https://github.com/openclaw/openclaw/pull/135138)). Thanks @gaoanze888 and @Vasanthdev2004.
-
-**Security and trust**
-
-- Stop proven CLI and Gateway state-path mismatches before guarded writes ([#134403](https://github.com/openclaw/openclaw/pull/134403)). Thanks @obviyus.
-- Keep managed llama.cpp archives and required loader aliases inside the installation tree ([#129035](https://github.com/openclaw/openclaw/pull/129035)). Thanks @pgondhi987.
-
-**Limits and compatibility**
-
-- Native macOS and Windows managed llama.cpp server launch was not directly observed at the final head, and remote or protected Gateways can warn about a state-path mismatch without proving one.
-- Windows bare-command backend discovery does not resolve the separate Claude PATH-shim security concern, and its proof does not cover a complete account-authenticated onboarding session.
+- Reach the web dashboard from the recommended Quick Start path ([#134221](https://github.com/openclaw/openclaw/pull/134221)). Thanks @fuller-stack-dev.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Installers, packages, state paths, and safe removal">
+<Accordion title="Provider Choices and Setup State">
 
-Windows installation now gets through several failures that looked more final than they were. Windows PowerShell 5.1 no longer treats harmless npm or Corepack warnings as command failures, portable Git can download without an interactive document-parsing step when Git is missing, and a noisy native tar failure can still reach the existing portable Node ZIP fallback. The warnings and command output remain visible, real nonzero exits still fail, and PowerShell 7 keeps its existing download behavior.
+Guided onboarding can once again configure custom and local providers, including endpoints that do not need an API key, and verifies a real response before making the new model active. Failed or cancelled checks leave the previous configuration alone, while setup reruns preserve an existing agent roster and workspace instead of attaching temporary verification work to them.
 
-Packaged installs are steadier too. Built OpenClaw packages and bundled channel entry points can load from pnpm-style installed layouts without doing premature filesystem work, while npm 12 can install or update from local `.tgz` and `.tar.gz` archives when the full path contains no commas. A comma-containing npm 12 path is still unsupported, but it now stops with guidance before package mutation rather than failing partway through.
-
-When a shell install does fail, it keeps the useful terminal details and npm's durable debug log without pointing to a temporary installer log that has already disappeared. [Shell completion](/cli/completion) installation and reinstall preserve literal state-cache paths containing quotes, dollar signs, or backslashes without replacing unrelated profile commands. The existing [`openclaw connect`](/cli/connect) command is easier to find, and its target-file handoff reads only bounded regular files, preserves rejected inputs, and removes a file only after it was consumed successfully.
+OpenClaw also compares the CLI's selected state and configuration paths with the local Gateway before guarded setup actions. When a mismatch is proven, it shows both locations and a command that targets the Gateway's store before credentials are written; offline setup remains available when there is no installed service to compare against.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
+- Verify imported model settings without attaching temporary setup state to an existing agent ([#132477](https://github.com/openclaw/openclaw/pull/132477)).
+- Restore verified custom and local providers in guided onboarding ([#134907](https://github.com/openclaw/openclaw/pull/134907)).
+
+**Security and trust**
+
+- Stop proven CLI and Gateway state-directory mismatches before guarded writes ([#134403](https://github.com/openclaw/openclaw/pull/134403)). Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Windows Installation and CLI Backends">
+
+Windows PowerShell 5.1 installation no longer treats harmless npm or Corepack warnings as command failures, and the portable Git bootstrap can complete without an interactive document-parsing step when Git is not already installed. The warnings remain visible, real nonzero exits still fail, and PowerShell 7 keeps its existing download behavior.
+
+Eligible npm-installed CLI backends can also be selected by their ordinary command name during Windows onboarding. OpenClaw now follows the platform's PATHEXT lookup while retaining the neighboring POSIX launcher used by Git Bash, so there is no need to hard-code a `.cmd` path or delete one of npm's shims.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Resolve npm-installed Windows CLI backends through PATHEXT ([#135138](https://github.com/openclaw/openclaw/pull/135138)). Thanks @gaoanze888, @Vasanthdev2004.
 - Let Windows PowerShell 5.1 continue past harmless npm or Corepack warnings, download portable Git without interactive parsing, and retain the portable Node ZIP fallback after noisy tar failures ([#134385](https://github.com/openclaw/openclaw/pull/134385), [#134412](https://github.com/openclaw/openclaw/pull/134412), [#135410](https://github.com/openclaw/openclaw/pull/135410)). Thanks @ly85206559.
-- Keep useful npm failure diagnostics without pointing to a deleted temporary installer log ([#134655](https://github.com/openclaw/openclaw/pull/134655)). Thanks @mohamedelrefaiy.
-- Preserve rejected Connect target files and remove only successfully consumed regular files or symlink handoffs ([#134957](https://github.com/openclaw/openclaw/pull/134957)). Thanks @xialonglee and @obviyus.
-- Preserve literal completion cache paths across supported shell hooks ([#136241](https://github.com/openclaw/openclaw/pull/136241)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="AI Setup on macOS">
+
+The macOS AI setup sheet now shows the selected provider and the actual installation or verification activity instead of presenting an elapsed-time percentage as progress. Input controls appear when the setup needs an answer, capability consent remains explicit, and late responses from an older attempt no longer replace the current setup state.
+
+When someone declines capability review or cancels activation, the app now says that setup was cancelled and offers a clear retry instead of calling it a Gateway failure. Failed or unconfirmed cancellation stays visible, so another connection can be chosen without mistaking the outcome for a completed setup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Show confirmed macOS setup cancellation as a retryable outcome ([#134654](https://github.com/openclaw/openclaw/pull/134654)).
+- Show real macOS AI setup activity and keep replies attached to the current attempt ([#135041](https://github.com/openclaw/openclaw/pull/135041)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Shell Setup and Connect Handoffs">
+
+When an npm install fails, the shell installer still shows the useful terminal details and npm's durable debug log, but no longer points to a temporary installer log that has already been removed. Shell completion installation and reinstall also preserve literal cache paths containing quotes, dollar signs, or backslashes across Bash, zsh, Fish, and the emitted PowerShell command, without replacing unrelated profile commands.
+
+The existing `openclaw connect` command is easier to find in the CLI reference, and its target-file handoff now accepts bounded regular-file inputs without deleting a rejected, unreadable, or oversized file. Successful regular-file and symlink handoffs retain their single-use behavior, while failed inputs stay available for inspection or recovery.
+
+Packaged installs now load reliably from pnpm-style layouts, and npm 12 can install or update from local archive paths when the resolved path contains no comma. Unsupported comma-containing paths stop with guidance before package mutation.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Remove the missing installer-log breadcrumb while preserving useful diagnostics ([#134655](https://github.com/openclaw/openclaw/pull/134655)). Thanks @mohamedelrefaiy.
+- Preserve rejected Connect target files and bound reads to regular files ([#134957](https://github.com/openclaw/openclaw/pull/134957)). Thanks @xialonglee, @obviyus.
+- Preserve literal completion cache paths across supported shells ([#136241](https://github.com/openclaw/openclaw/pull/136241)).
 - Load built packages and bundled channel entry points reliably from pnpm-style installed layouts ([#136308](https://github.com/openclaw/openclaw/pull/136308)). Thanks @vincentkoc.
 - Support npm 12 local archive installs and updates when their resolved path contains no comma ([#136316](https://github.com/openclaw/openclaw/pull/136316)).
 
 **Documentation**
 
-- Add the existing Connect command to the CLI overview and command tree ([#134917](https://github.com/openclaw/openclaw/pull/134917)). Thanks @qingminglong.
+- Add the existing Connect command to the CLI index ([#134917](https://github.com/openclaw/openclaw/pull/134917)). Thanks @qingminglong.
 
-**Limits and compatibility**
+</details>
 
-- Comma-containing npm 12 archive paths remain unsupported, native PowerShell execution of the completion hook was unavailable in the submitted evidence, and the packaged-import evidence does not establish how often the failure affected installations outside release validation.
+</Accordion>
+
+<Accordion title="Managed llama.cpp Installation">
+
+Managed llama.cpp server installation remains automatic, but downloaded ZIP and TAR archives now pass through the bounded extractor used elsewhere in OpenClaw. Malformed or hostile archives fail without writing outside the installation tree, archive-provided links are skipped, and the required loader aliases are recreated as contained regular files.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Keep managed llama.cpp archives and loader aliases inside the installation tree ([#129035](https://github.com/openclaw/openclaw/pull/129035)). Thanks @pgondhi987.
 
 </details>
 
@@ -96,73 +144,34 @@ When a shell install does fail, it keeps the useful terminal details and npm's d
 
 ## The New Web UI
 
-The [Control UI](/web/control-ui) now gives the conversation and the workspace around it more room to behave as one place. Diagrams render where they are discussed, a first prompt appears before the new session has finished opening, and the interface holds on to more of what you sent, what the agent already showed you, and where you were reading while live work becomes saved history.
+The [Control UI](/web/control-ui) now gives visual answers, active work, and long-running conversations more room to behave like one workspace. Diagrams render where they are discussed, starting or returning to a session takes less waiting and repeated work, and the interface does a better job of holding what you sent, your reading position, and the agent or session you were actually looking at.
 
 <AccordionGroup>
 
-<Accordion title="Visual answers and conversations that hold together">
+<Accordion title="Mermaid Diagrams Inside the Conversation">
 
-Completed Mermaid fences now render as diagrams directly in chat, with the exact source, copy, expansion, and zoom controls kept beside the result. The diagram follows the active theme and stays in place while the rest of an answer arrives, while incomplete, invalid, oversized, or externally dependent diagrams remain readable as source instead of being treated as successful renders.
+Completed Mermaid fences now render as diagrams directly in chat, with the exact source, copy, expansion, and zoom controls kept beside the result. The diagram follows the active theme and stays in place while the rest of an answer arrives, so a flowchart or sequence diagram can be read without moving it into another tool.
 
-Starting a conversation feels more immediate too. New Session can prepare a suggested name after you pause on an eligible first prompt, then shows that prompt and its images as soon as you send without waiting for the confirmed session to make the round trip. The suggestion never delays Start, but eligible draft text is sent to the configured utility model before submission, so incognito, short, attachment, command, dictation, and active-composition drafts are deliberately excluded. Chat and New Session also load lighter payloads and do less repeated work on measured paths, though the supplied timings do not establish the same speedup for every browser or Gateway and include small regressions on some warm or cold readiness paths.
-
-Once work is moving, the transcript is less likely to lose its shape. Reconnects and refreshes keep one copy of a completed answer, queued prompts remain above the replies they produced, commentary stays distinct from the final answer, images remain visible while saved history takes ownership of them, and manually taking over the scroll position is less likely to be undone by delayed layout work. Compaction settles into one durable inline marker, attachment and Office-file failures no longer poison later turns through known display blocks, and a failed cloud or paired-device session can be restarted from Chat when a compatible target is available, preserving its identity and last reconciled worktree while sending remains disabled during the transition.
+The renderer is lazy-loaded and isolated from the rest of the page, and model-authored output is reduced to passive SVG before display. Incomplete fences remain code, while invalid, oversized, or externally dependent diagrams fall back to readable source with an error instead of being treated as a successful render.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Prepare an eligible new-session name after idle typing without delaying Start ([#133724](https://github.com/openclaw/openclaw/pull/133724)).
 - Render completed Mermaid diagrams with source, copy, expansion, and zoom controls ([#134913](https://github.com/openclaw/openclaw/pull/134913)).
-- Replace compaction's button-like spinner with a calm, accessible folding status ([#135988](https://github.com/openclaw/openclaw/pull/135988)).
-- Copy complete chat-error diagnostics without expanding the details panel first ([#136085](https://github.com/openclaw/openclaw/pull/136085)).
-- Load lighter New Session and Chat payloads and reuse live display preferences across tabs ([#136362](https://github.com/openclaw/openclaw/pull/136362)).
-
-**Bug fixes**
-
-- Show recoverable file-editor load failures instead of a blank retry loop ([#123220](https://github.com/openclaw/openclaw/pull/123220)). Thanks @wanyongstar.
-- Make staged attachments easier to remove by touch in Chat and New Session ([#123893](https://github.com/openclaw/openclaw/pull/123893)).
-- Clear stale working controls after an interrupted run is confirmed in history ([#134457](https://github.com/openclaw/openclaw/pull/134457)). Thanks @RomneyDa.
-- Make long task-progress cards scroll without moving the page or hiding the composer ([#134517](https://github.com/openclaw/openclaw/pull/134517)). Thanks @VACInc, @cpgeek, @nybbs2003.
-- Restore Ask OpenClaw launcher compatibility and preserve the conversation during recovery ([#134776](https://github.com/openclaw/openclaw/pull/134776)).
-- Reconcile live and saved commentary by run and item identity ([#134888](https://github.com/openclaw/openclaw/pull/134888)).
-- Restart an established failed cloud or device session from Chat on a compatible target ([#135024](https://github.com/openclaw/openclaw/pull/135024)). Thanks @jalehman.
-- Insert late dictation once into the current draft after Stop ([#135109](https://github.com/openclaw/openclaw/pull/135109)). Thanks @obviyus, @jadabreu.
-- Retain one clear warning when an exec or Bash failure is the only visible reply ([#135119](https://github.com/openclaw/openclaw/pull/135119)).
-- Keep attachment display cards out of model history and restore Office document sends ([#135185](https://github.com/openclaw/openclaw/pull/135185)). Thanks @gaoanze888, @obviyus, @snls1994, @gordonzhy.
-- Let the next prompt accept input immediately after the current one is sent ([#135345](https://github.com/openclaw/openclaw/pull/135345)). Thanks @Takhoffman.
-- Restore replies and source navigation for attachment-only assistant messages ([#135393](https://github.com/openclaw/openclaw/pull/135393)).
-- Preserve the real terminal timeout reason in the sidebar and clear stale failures after success ([#135466](https://github.com/openclaw/openclaw/pull/135466)).
-- Keep recovered queued prompts above the replies they produced ([#135568](https://github.com/openclaw/openclaw/pull/135568)).
-- Prevent a saved assistant reply from appearing twice during reconnect or history refresh ([#135715](https://github.com/openclaw/openclaw/pull/135715)). Thanks @starship863, @dustin-nowak.
-- Remove queued input without restoring an old draft or showing a false storage error ([#135790](https://github.com/openclaw/openclaw/pull/135790)).
-- Remove the redundant waiting receipt after a chat message is accepted ([#135901](https://github.com/openclaw/openclaw/pull/135901)).
-- Show commentary progress before a plugin finishes validating the final reply ([#135954](https://github.com/openclaw/openclaw/pull/135954)). Thanks @JosephNatsu.
-- Reduce unnecessary startup work on New Session and Chat while keeping saved panels restorable ([#136021](https://github.com/openclaw/openclaw/pull/136021)).
-- Show the first new-session message immediately and restore its contents if creation fails ([#136069](https://github.com/openclaw/openclaw/pull/136069)).
-- Keep sent images visible while saved history takes ownership of the message ([#136072](https://github.com/openclaw/openclaw/pull/136072)).
-- Carry compaction from its live status into one persistent transcript marker ([#136169](https://github.com/openclaw/openclaw/pull/136169)).
-- Show when the Gateway is suspending or suspended in Control UI account footers ([#136220](https://github.com/openclaw/openclaw/pull/136220)).
-- Retain participant names in copied and downloaded conversation exports ([#136439](https://github.com/openclaw/openclaw/pull/136439)).
-- Keep sent image bubbles and captions visually stable on hover ([#136440](https://github.com/openclaw/openclaw/pull/136440)).
-- Keep already-loaded chat images visible through temporary Gateway outages ([#136446](https://github.com/openclaw/openclaw/pull/136446)).
-
-**Security and trust**
-
-- Present optionless credential and free-text questions without misleading choice controls ([#134598](https://github.com/openclaw/openclaw/pull/134598)). Thanks @Patrick-Erichsen, @goslingmanagment.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Navigation, settings, and busy workspaces">
+<Accordion title="Starting, Switching, and Repairing Sessions">
 
-The rest of the Control UI is easier to understand when a Claw has more than one agent, session, person, or piece of work in motion. Dashboards and background tasks stay with the selected agent, hovercards expose ownership, participants, pull requests, progress, and useful links without disappearing before you can reach them, and the session sidebar does less repeated work when it contains hundreds of retained conversations. Groups remain compact until you expand them, assignment and appearance controls are less scattered, and the Chat, Split, and Dashboard selector stays centered even beside long names and sharing controls.
+New Session now puts the first prompt and its images on screen as soon as you send them, keeps the draft available if creation fails, and moves into the confirmed conversation without an extra lookup. Chat and New Session also load fewer closed workspace features up front, while larger session lists do less repeated sidebar work when you switch between conversations. Those performance results come from controlled local and synthetic large-roster tests, not a promise that every browser or Gateway will see the same speedup, and the measured warm Chat path included a small composer-readiness regression.
 
-Settings and working surfaces have had the same pass. Narrow dashboards use their available width, long task reviews fill their side panels, Usage filters and historical hour labels behave more predictably, current assets survive stale cache checks, and URL, email, notification, model, appearance, secret, publishing, and policy controls are easier to read or edit. Sharing menus make the current visibility and blocked choices clearer without changing who is allowed to share, while permission, approval, and trusted-proxy messages show the state or requester more accurately without expanding anyone's authority.
+Returning to existing work is steadier too. Dashboards and background tasks stay with the selected agent, interrupted or timed-out sessions show a more truthful state, failed cloud or device sessions can be restarted from Chat when a compatible target is available, and Ask OpenClaw keeps the conversation and draft visible while its runtime is repaired. Sidebar groups, hovercards, assignment menus, status icons, and keyboard navigation make large or multi-agent workspaces easier to scan without changing the underlying session, permission, or placement boundaries.
 
-There is a long tail of polish here that matters most in a busy workspace, including stable keyboard focus, localized composer and recovery text, reduced-motion loading states, correct animated workspace icons, safer encoded asset paths, and more compact question, Workboard, and session controls. The measured navigation gains come from controlled local or synthetic large-roster tests rather than a universal performance promise, cloud and device recovery still needs a compatible target, and the shorter pin label retains one known accessibility cost because it no longer repeats the session-specific context for assistive technology.
+New Session can also prepare a suggested name after an eligible draft sits briefly idle without delaying Start. Chat and New Session load lighter payloads and reuse display preferences for the connected Gateway, while account footers show when that Gateway is suspending or suspended and clear when work admission returns.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -170,18 +179,106 @@ There is a long tail of polish here that matters most in a busy workspace, inclu
 **Improvements**
 
 - Bring collapse, search, and new-session controls into the agent header ([#134365](https://github.com/openclaw/openclaw/pull/134365)). Thanks @vyctorbrzezowski.
-- Give Side chat one direct clear action and consistent naming ([#134478](https://github.com/openclaw/openclaw/pull/134478)). Thanks @Patrick-Erichsen.
 - Make session ownership, current work, and progress easier to scan in hovercards ([#134636](https://github.com/openclaw/openclaw/pull/134636)). Thanks @Patrick-Erichsen.
-- Replace ambiguous settings loading text with accessible page-shaped placeholders ([#134684](https://github.com/openclaw/openclaw/pull/134684)). Thanks @Patrick-Erichsen.
 - Give session titles and their status icons clearer separation ([#134764](https://github.com/openclaw/openclaw/pull/134764)). Thanks @Patrick-Erichsen.
-- Simplify pull request hovercard statistics while preserving the full PR link ([#134791](https://github.com/openclaw/openclaw/pull/134791)). Thanks @Patrick-Erichsen.
 - Reduce repeated work when switching sessions and loading conversation branches ([#135021](https://github.com/openclaw/openclaw/pull/135021)).
-- Defer Settings-only English text to leave more room in the initial download ([#135131](https://github.com/openclaw/openclaw/pull/135131)).
 - Trim additional sidebar work when switching through large session lists ([#135332](https://github.com/openclaw/openclaw/pull/135332)).
 - Consolidate session assignment and appearance controls into clearer menus ([#135526](https://github.com/openclaw/openclaw/pull/135526)). Thanks @vyctorbrzezowski.
-- Place Theme and Accent color together in Appearance settings ([#135547](https://github.com/openclaw/openclaw/pull/135547)). Thanks @vyctorbrzezowski.
 - Speed up retained-chat switching in measured large-session workflows ([#135574](https://github.com/openclaw/openclaw/pull/135574)).
-- Refresh localized update-disconnect and recovery guidance ([#135669](https://github.com/openclaw/openclaw/pull/135669)).
+- Prepare an eligible new-session name after idle typing without delaying Start ([#133724](https://github.com/openclaw/openclaw/pull/133724)).
+- Load lighter New Session and Chat payloads and reuse live display preferences across tabs ([#136362](https://github.com/openclaw/openclaw/pull/136362)).
+
+**Bug fixes**
+
+- Keep compressed archived sessions under their real identities in Usage history ([#131017](https://github.com/openclaw/openclaw/pull/131017)). Thanks @Alix-007, @emes.
+- Match session-group action contrast to the Sessions toolbar ([#134631](https://github.com/openclaw/openclaw/pull/134631)). Thanks @Patrick-Erichsen.
+- Keep dashboards and background tasks attached to the selected agent ([#134714](https://github.com/openclaw/openclaw/pull/134714)). Thanks @ctbritt, @MertBasar0.
+- Show pinned sessions with a filled neutral pin ([#134775](https://github.com/openclaw/openclaw/pull/134775)). Thanks @Patrick-Erichsen.
+- Restore Ask OpenClaw launcher compatibility and preserve the conversation during recovery ([#134776](https://github.com/openclaw/openclaw/pull/134776)).
+- Keep quickly reopened menus dismissible and restore focus correctly ([#135006](https://github.com/openclaw/openclaw/pull/135006)). Thanks @vyctorbrzezowski.
+- Remove the duplicate Ask OpenClaw shortcut from Inbox while retaining its other entry points ([#135008](https://github.com/openclaw/openclaw/pull/135008)).
+- Restart an established failed cloud or device session from Chat on a compatible target ([#135024](https://github.com/openclaw/openclaw/pull/135024)). Thanks @jalehman.
+- Preserve the real terminal timeout reason in the sidebar and clear stale failures after success ([#135466](https://github.com/openclaw/openclaw/pull/135466)).
+- Hide the unusable Rewind action while an agent is working ([#135521](https://github.com/openclaw/openclaw/pull/135521)). Thanks @Patrick-Erichsen.
+- Keep long sidebar group titles on one readable marquee line ([#135523](https://github.com/openclaw/openclaw/pull/135523)). Thanks @Patrick-Erichsen.
+- Tighten Recent Chats alignment, spacing, and hover feedback ([#135524](https://github.com/openclaw/openclaw/pull/135524)). Thanks @Patrick-Erichsen.
+- Return keyboard focus to the visible menu after switching submenus ([#135629](https://github.com/openclaw/openclaw/pull/135629)).
+- Use device-specific wording while paired-device sessions start ([#135681](https://github.com/openclaw/openclaw/pull/135681)).
+- Reduce unnecessary startup work on New Session and Chat while keeping saved panels restorable ([#136021](https://github.com/openclaw/openclaw/pull/136021)).
+- Keep large catalog groups compact with independent Show more controls ([#136040](https://github.com/openclaw/openclaw/pull/136040)). Thanks @fuller-stack-dev.
+- Show the first new-session message immediately and restore its contents if creation fails ([#136069](https://github.com/openclaw/openclaw/pull/136069)).
+- Show when the Gateway is suspending or suspended in Control UI account footers ([#136220](https://github.com/openclaw/openclaw/pull/136220)).
+- Show the current user's profile picture in Assign to Me when available ([#136668](https://github.com/openclaw/openclaw/pull/136668)). Thanks @Patrick-Erichsen.
+
+**Security and trust**
+
+- Show inherited Full Access as active as soon as a session opens ([#134732](https://github.com/openclaw/openclaw/pull/134732)). Thanks @Patrick-Erichsen.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Conversation Order and Reading Position">
+
+The chat transcript now holds together more consistently as live events become saved history. Reconnects and refreshes keep one copy of a completed answer, queued prompts stay above the replies they produced, commentary remains distinct from the final answer, and manually taking over the scroll position is less likely to be undone by delayed layout work. Compaction now appears as one calm inline marker that settles into a durable completed state instead of splitting itself across temporary and saved notices.
+
+The composer is less fragile around the edges of an active turn. You can begin the next prompt immediately after sending, remove queued input without a false storage warning, keep late dictation after pressing Stop, and reply to attachment-only messages with a useful reference. Sent images remain visible while history takes ownership of them, Office attachment failures no longer wedge later turns through known display blocks, and silent command failures or plugin-delayed final replies still leave timely, visible progress or warning text.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Replace compaction's button-like spinner with a calm, accessible folding status ([#135988](https://github.com/openclaw/openclaw/pull/135988)).
+- Copy complete chat-error diagnostics without expanding the details panel first ([#136085](https://github.com/openclaw/openclaw/pull/136085)).
+
+**Bug fixes**
+
+- Make staged attachments easier to remove by touch in Chat and New Session ([#123893](https://github.com/openclaw/openclaw/pull/123893)).
+- Clear stale working controls after an interrupted run is confirmed in history ([#134457](https://github.com/openclaw/openclaw/pull/134457)). Thanks @RomneyDa.
+- Keep long collapsed prompts readable without overlapping text ([#134833](https://github.com/openclaw/openclaw/pull/134833)).
+- Reconcile live and saved commentary by run and item identity ([#134888](https://github.com/openclaw/openclaw/pull/134888)).
+- Insert late dictation once into the current draft after Stop ([#135109](https://github.com/openclaw/openclaw/pull/135109)). Thanks @obviyus, @jadabreu.
+- Retain one clear warning when an exec or Bash failure is the only visible reply ([#135119](https://github.com/openclaw/openclaw/pull/135119)).
+- Keep attachment display cards out of model history and restore Office document sends ([#135185](https://github.com/openclaw/openclaw/pull/135185)). Thanks @gaoanze888, @obviyus, @snls1994, @gordonzhy.
+- Let the next prompt accept input immediately after the current one is sent ([#135345](https://github.com/openclaw/openclaw/pull/135345)). Thanks @Takhoffman.
+- Restore replies and source navigation for attachment-only assistant messages ([#135393](https://github.com/openclaw/openclaw/pull/135393)).
+- Keep recovered queued prompts above the replies they produced ([#135568](https://github.com/openclaw/openclaw/pull/135568)).
+- Prevent a saved assistant reply from appearing twice during reconnect or history refresh ([#135715](https://github.com/openclaw/openclaw/pull/135715)). Thanks @starship863, @dustin-nowak.
+- Respect manual transcript scrolling during delayed row measurement ([#135738](https://github.com/openclaw/openclaw/pull/135738)).
+- Remove queued input without restoring an old draft or showing a false storage error ([#135790](https://github.com/openclaw/openclaw/pull/135790)).
+- Remove the redundant waiting receipt after a chat message is accepted ([#135901](https://github.com/openclaw/openclaw/pull/135901)).
+- Restore compact token-count labels without changing the underlying totals ([#135951](https://github.com/openclaw/openclaw/pull/135951)).
+- Show commentary progress before a plugin finishes validating the final reply ([#135954](https://github.com/openclaw/openclaw/pull/135954)). Thanks @JosephNatsu.
+- Keep sent images visible while saved history takes ownership of the message ([#136072](https://github.com/openclaw/openclaw/pull/136072)).
+- Carry compaction from its live status into one persistent transcript marker ([#136169](https://github.com/openclaw/openclaw/pull/136169)).
+- Retain participant names in copied and downloaded conversation exports ([#136439](https://github.com/openclaw/openclaw/pull/136439)).
+- Keep already-loaded chat images visible through temporary Gateway outages ([#136446](https://github.com/openclaw/openclaw/pull/136446)).
+- Keep loaded chat images mounted through ordinary media rerenders ([#136597](https://github.com/openclaw/openclaw/pull/136597)).
+
+**Security and trust**
+
+- Explain denied WebChat resets without weakening the required administrator permission ([#134696](https://github.com/openclaw/openclaw/pull/134696)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Everyday Workspace Polish">
+
+The surfaces around the conversation have had the same attention. Dashboards fill narrow screens, long task progress and Review content use the space available to them, settings show useful loading shapes, and the model picker, agent picker, Side chat, Appearance, Usage, publication controls, and pull request previews are easier to scan. Keyboard menus recover cleanly, scrollbars remain visible beside fades, stale assets are less likely to survive a cache check, and smaller initial Settings data leaves more startup headroom without claiming a measured end-user latency gain.
+
+Accessibility and authority state are clearer in several places, including a stable localized name for the composer, reduced-motion loading indicators, properly displayed wildcard tool policies, named approval requesters, optionless credential prompts, and specific recovery guidance for trusted-proxy sign-in failures. One regression remains in the sidebar. Shorter pin and unpin tooltips also became the icon buttons' accessible names, so assistive-technology users can lose the session-specific context that used to be repeated there.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Give Side chat one direct clear action and consistent naming ([#134478](https://github.com/openclaw/openclaw/pull/134478)). Thanks @Patrick-Erichsen.
+- Replace ambiguous settings loading text with accessible page-shaped placeholders ([#134684](https://github.com/openclaw/openclaw/pull/134684)). Thanks @Patrick-Erichsen.
+- Defer Settings-only English text to leave more room in the initial download ([#135131](https://github.com/openclaw/openclaw/pull/135131)).
+- Place Theme and Accent color together in Appearance settings ([#135547](https://github.com/openclaw/openclaw/pull/135547)). Thanks @vyctorbrzezowski.
 - Clarify model-selection scope and the session reset action on wide and narrow screens ([#136160](https://github.com/openclaw/openclaw/pull/136160)).
 - Make every projected participant in a multi-person session hovercard individually reachable ([#136542](https://github.com/openclaw/openclaw/pull/136542)). Thanks @Patrick-Erichsen.
 - Add a compact icon selector for Chat, Split, and Dashboard while retaining accessible names ([#136647](https://github.com/openclaw/openclaw/pull/136647)). Thanks @Patrick-Erichsen.
@@ -192,42 +289,30 @@ There is a long tail of polish here that matters most in a busy workspace, inclu
 
 **Bug fixes**
 
-- Keep compressed archived sessions under their real identities in Usage history ([#131017](https://github.com/openclaw/openclaw/pull/131017)). Thanks @Alix-007, @emes.
+- Show recoverable file-editor load failures instead of a blank retry loop ([#123220](https://github.com/openclaw/openclaw/pull/123220)). Thanks @wanyongstar.
 - Make dashboard cards fill narrow screens and preserve their desktop arrangement ([#133814](https://github.com/openclaw/openclaw/pull/133814)). Thanks @MoerAI, @vyctorbrzezowski.
 - Give the chat composer one stable accessible name across changing states ([#133829](https://github.com/openclaw/openclaw/pull/133829)). Thanks @aniruddhaadak80.
-- Keep session permission choices visible and reconcile overlapping updates against Gateway state ([#134413](https://github.com/openclaw/openclaw/pull/134413)). Thanks @vyctorbrzezowski.
-- Match session-group action contrast to the Sessions toolbar ([#134631](https://github.com/openclaw/openclaw/pull/134631)). Thanks @Patrick-Erichsen.
+- Make long task-progress cards scroll without moving the page or hiding the composer ([#134517](https://github.com/openclaw/openclaw/pull/134517)). Thanks @VACInc, @cpgeek, @nybbs2003.
 - Delay incidental microphone-picker motion while keeping keyboard interaction immediate ([#134653](https://github.com/openclaw/openclaw/pull/134653)). Thanks @Patrick-Erichsen.
 - Align settings headings and make automation failures easier to find ([#134659](https://github.com/openclaw/openclaw/pull/134659)). Thanks @Patrick-Erichsen.
 - Remove the repeated Agent picker label and keep the opening menu opaque ([#134680](https://github.com/openclaw/openclaw/pull/134680)). Thanks @Patrick-Erichsen.
-- Keep dashboards and background tasks attached to the selected agent ([#134714](https://github.com/openclaw/openclaw/pull/134714)). Thanks @ctbritt, @MertBasar0.
-- Show pinned sessions with a filled neutral pin ([#134775](https://github.com/openclaw/openclaw/pull/134775)). Thanks @Patrick-Erichsen.
-- Keep long collapsed prompts readable without overlapping text ([#134833](https://github.com/openclaw/openclaw/pull/134833)).
-- Keep quickly reopened menus dismissible and restore focus correctly ([#135006](https://github.com/openclaw/openclaw/pull/135006)). Thanks @vyctorbrzezowski.
-- Remove the duplicate Ask OpenClaw shortcut from Inbox while retaining its other entry points ([#135008](https://github.com/openclaw/openclaw/pull/135008)).
+- Simplify pull request hovercard statistics while preserving the full PR link ([#134791](https://github.com/openclaw/openclaw/pull/134791)). Thanks @Patrick-Erichsen.
 - Keep Usage peak-error hour labels correct through daylight-saving changes ([#135153](https://github.com/openclaw/openclaw/pull/135153)).
-- Hide the unusable Rewind action while an agent is working ([#135521](https://github.com/openclaw/openclaw/pull/135521)). Thanks @Patrick-Erichsen.
-- Keep long sidebar group titles on one readable marquee line ([#135523](https://github.com/openclaw/openclaw/pull/135523)). Thanks @Patrick-Erichsen.
-- Tighten Recent Chats alignment, spacing, and hover feedback ([#135524](https://github.com/openclaw/openclaw/pull/135524)). Thanks @Patrick-Erichsen.
 - Keep sidebar and transcript fades from covering visible scrollbars ([#135564](https://github.com/openclaw/openclaw/pull/135564)). Thanks @vyctorbrzezowski.
 - Return current Control UI assets when a cached entity tag is stale ([#135619](https://github.com/openclaw/openclaw/pull/135619)).
-- Return keyboard focus to the visible menu after switching submenus ([#135629](https://github.com/openclaw/openclaw/pull/135629)).
-- Use device-specific wording while paired-device sessions start ([#135681](https://github.com/openclaw/openclaw/pull/135681)).
-- Keep Inbox alerts out of Settings as navigation changes ([#135722](https://github.com/openclaw/openclaw/pull/135722)). Thanks @vyctorbrzezowski.
-- Respect manual transcript scrolling during delayed row measurement ([#135738](https://github.com/openclaw/openclaw/pull/135738)).
-- Keep blank MCP environment and header fields editable while masking stored secrets ([#135798](https://github.com/openclaw/openclaw/pull/135798)). Thanks @SunnyShu0925, @markhaines.
 - Let long task reviews fill docked and expanded side panels ([#135926](https://github.com/openclaw/openclaw/pull/135926)). Thanks @obviyus, @asgeirtj.
-- Restore compact token-count labels without changing the underlying totals ([#135951](https://github.com/openclaw/openclaw/pull/135951)).
 - Make publishing-account controls compact while keeping the selected identity reachable ([#136002](https://github.com/openclaw/openclaw/pull/136002)).
 - Add localized composer accessibility labels across supported non-English locales ([#136006](https://github.com/openclaw/openclaw/pull/136006)).
-- Keep large catalog groups compact with independent Show more controls ([#136040](https://github.com/openclaw/openclaw/pull/136040)). Thanks @fuller-stack-dev.
 - Remove the bright static shimmer band when reduced motion is enabled ([#136153](https://github.com/openclaw/openclaw/pull/136153)).
+- Keep session permission choices visible and reconcile overlapping updates against Gateway state ([#134413](https://github.com/openclaw/openclaw/pull/134413)). Thanks @vyctorbrzezowski.
+- Keep Inbox alerts out of Settings as navigation changes ([#135722](https://github.com/openclaw/openclaw/pull/135722)). Thanks @vyctorbrzezowski.
+- Keep blank MCP environment and header fields editable while masking stored secrets ([#135798](https://github.com/openclaw/openclaw/pull/135798)). Thanks @SunnyShu0925, @markhaines.
 - Display APNG workspace icons and channel avatars through the shared safe-image policy ([#136417](https://github.com/openclaw/openclaw/pull/136417)).
+- Keep sent image bubbles and captions visually stable on hover ([#136440](https://github.com/openclaw/openclaw/pull/136440)).
 - Load encoded and contained symlinked Control UI assets correctly ([#136444](https://github.com/openclaw/openclaw/pull/136444)).
 - Let Escape close the visible session popover after keyboard session switching ([#136445](https://github.com/openclaw/openclaw/pull/136445)).
 - Give session pull-request links clear hover and keyboard-focus feedback ([#136527](https://github.com/openclaw/openclaw/pull/136527)). Thanks @Patrick-Erichsen.
 - Clear equivalent mixed-case or quoted Usage filters from their menus ([#136569](https://github.com/openclaw/openclaw/pull/136569)).
-- Keep loaded chat images mounted through ordinary media rerenders ([#136597](https://github.com/openclaw/openclaw/pull/136597)).
 - Give notification preferences themed controls and accessible names ([#136602](https://github.com/openclaw/openclaw/pull/136602)).
 - Keep URL- and email-formatted settings editable in Form mode ([#136603](https://github.com/openclaw/openclaw/pull/136603)).
 - Keep question sessions compact while preserving their waiting status accessibly ([#136606](https://github.com/openclaw/openclaw/pull/136606)). Thanks @Patrick-Erichsen.
@@ -237,15 +322,17 @@ There is a long tail of polish here that matters most in a busy workspace, inclu
 - Recover Workboard task links after a saved cursor is rejected ([#136619](https://github.com/openclaw/openclaw/pull/136619)). Thanks @shakkernerd.
 - Make the board Remove action visually consistent with its menu ([#136637](https://github.com/openclaw/openclaw/pull/136637)). Thanks @Patrick-Erichsen.
 - Keep the Chat, Split, and Dashboard selector centered beside long names ([#136646](https://github.com/openclaw/openclaw/pull/136646)). Thanks @Patrick-Erichsen.
-- Show the current user's profile picture in Assign to Me when available ([#136668](https://github.com/openclaw/openclaw/pull/136668)). Thanks @Patrick-Erichsen.
 
 **Security and trust**
 
-- Explain denied WebChat resets without weakening the required administrator permission ([#134696](https://github.com/openclaw/openclaw/pull/134696)).
-- Show inherited Full Access as active as soon as a session opens ([#134732](https://github.com/openclaw/openclaw/pull/134732)). Thanks @Patrick-Erichsen.
+- Present optionless credential and free-text questions without misleading choice controls ([#134598](https://github.com/openclaw/openclaw/pull/134598)). Thanks @Patrick-Erichsen, @goslingmanagment.
 - Give trusted-proxy login failures specific, redacted recovery guidance ([#135584](https://github.com/openclaw/openclaw/pull/135584)).
 - Display wildcard tool policies accurately without changing policy enforcement ([#135786](https://github.com/openclaw/openclaw/pull/135786)).
 - Name the requesting session on projected approval cards without changing approval authority ([#136091](https://github.com/openclaw/openclaw/pull/136091)).
+
+**Documentation**
+
+- Refresh Gateway update and disconnect recovery translations ([#135669](https://github.com/openclaw/openclaw/pull/135669)).
 
 **Limits and compatibility**
 
@@ -259,60 +346,97 @@ There is a long tail of polish here that matters most in a busy workspace, inclu
 
 ## Updates and Maintenance
 
-[Updates](/install/updating) now make a clearer distinction between work OpenClaw can finish safely and work that needs your attention first. The updater preserves more of the setup already on the machine, hands service-owned restarts to a process that can survive them, and leaves recoverable failures with enough context for [Doctor](/cli/doctor) or a configured coding agent to take over the investigation.
+[Updates](/install/updating) now make a clearer distinction between work OpenClaw can finish safely and work that needs your attention first. The updater protects more of the setup already on the machine, hands service-owned restarts to a process that can survive them, and leaves recoverable failures with enough context for Doctor or a configured coding agent to take over the investigation.
 
 <AccordionGroup>
 
-<Accordion title="Update gates, rollback, and plugin readiness">
+<Accordion title="Update Readiness and Restart Handoffs">
 
-Before OpenClaw restarts, it now checks the parts of your installation that actually need to be ready for the new version. Missing local-memory setup or unresolved plugin consent stops the update with a specific repair path, plugin version drift is surfaced before restart, and a migration warning that does not make required state unsafe can leave the Gateway reachable in a clearly degraded state so you can run Doctor instead of watching a supervisor restart it forever. A blocked readiness or consent check deliberately leaves the Gateway stopped, and `--yes` does not approve a plugin's new capabilities for you.
+Before OpenClaw restarts, it now checks the parts of your installation that actually need to be ready for the new version. Missing local-memory setup, unresolved plugin consent, or incomplete approval migration stops the update with a specific repair path, while a migration warning that does not make required state unsafe can leave the Gateway reachable in a clearly degraded state so you can run Doctor instead of watching a supervisor restart it forever.
 
-Agent-started updates on managed Linux and macOS Gateways can hand the work to a detached helper before the service stops, while a global npm candidate rejected by Doctor now restores the prior package and launchers for inspection. The initial agent response confirms that the handoff was accepted, not that the update finished. Rollback does not undo persistent state Doctor may already have changed, does not cover pnpm or Bun, and keeps the managed Gateway stopped rather than guessing that a restart is safe.
+Updates started by an agent on a managed Linux or macOS Gateway can hand the work to a detached helper before the service stops, and Windows agent-initiated restarts use the Gateway-owned restart path rather than dying with the old process tree. That handoff confirms the update was accepted, not that it finished, and npm 12 local archives still need a comma-free path.
 
-When an interactive update gets far enough to fail operationally, OpenClaw can carry a bounded, sanitized record of that attempt into its existing triage flow instead of making you reconstruct the failure from scratch. The CLI can offer a configured Claude Code, Codex, OpenCode, or Pi session after updater cleanup, and the Control UI can open Ask OpenClaw with the recorded cause. That investigation cannot retry the update, repair state, or restart the Gateway on its own, and unattended runs retain the original failure while printing the next commands for an operator.
+If a global npm update is rejected by Doctor, OpenClaw now restores the previous package and launchers and leaves the managed Gateway stopped for inspection. Service-less Linux updates can proceed only after OpenClaw proves there is no service definition, active Gateway lock, or listener to restart.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Eligible update failures can open bounded diagnostics in the CLI or Ask OpenClaw without granting repair or restart authority ([#134865](https://github.com/openclaw/openclaw/pull/134865)).
+- Leaner installations without unused Sharp and ONNX dependency chains, with Chromium or Chrome now required for meme PNG output ([#134923](https://github.com/openclaw/openclaw/pull/134923)).
 
 **Bug fixes**
 
-- Failed updates preserve covered configuration and plugin intent and can hand investigation to an installed coding agent after cleanup ([#134490](https://github.com/openclaw/openclaw/pull/134490)). Thanks @fuller-stack-dev.
+- Windows agent-initiated Gateway restarts survive the old process tree ([#134549](https://github.com/openclaw/openclaw/pull/134549)). Thanks @nerclid, @w1130150306.
+- Updates stop before restarting when a selected plugin readiness check fails ([#134699](https://github.com/openclaw/openclaw/pull/134699)). Thanks @Patrick-Erichsen, @vyctorbrzezowski.
+- Blank backup intervals fail instead of silently creating a 24-hour schedule ([#134799](https://github.com/openclaw/openclaw/pull/134799)). Thanks @marmar9615-cloud.
+- Update readiness loads only the Doctor integrations needed for the selected checks ([#135161](https://github.com/openclaw/openclaw/pull/135161)).
+- Blank Gateway suspension waits fail before a lease is acquired ([#135270](https://github.com/openclaw/openclaw/pull/135270)). Thanks @qingminglong.
+- Agent-launched updates move to the managed helper before stopping the Gateway ([#135701](https://github.com/openclaw/openclaw/pull/135701)).
+- Nonfatal migration warnings allow a visible degraded startup with Doctor guidance ([#135713](https://github.com/openclaw/openclaw/pull/135713)). Thanks @Zak-Finance.
 - Doctor compares active official plugins with the managed service package that will load after restart ([#134663](https://github.com/openclaw/openclaw/pull/134663)). Thanks @jalehman, @r0ckvn, @Finn763, @yubingjiaocn.
-- Updates stop before restarting when an owner-declared plugin readiness check fails ([#134699](https://github.com/openclaw/openclaw/pull/134699)). Thanks @Patrick-Erichsen, @vyctorbrzezowski.
-- Post-upgrade Doctor reports enabled official plugins that remain on an older OpenClaw release ([#134719](https://github.com/openclaw/openclaw/pull/134719)). Thanks @Lendersmark, @oshunter.
-- Update readiness loads only the Doctor integrations required for the selected checks ([#135161](https://github.com/openclaw/openclaw/pull/135161)).
-- Managed Tailscale Serve or Funnel can adopt an exact predecessor root route after an upgrade while leaving external and shared routes alone; stale-host rename recovery remains manual, and the predecessor is not restored if a new claim fails ([#135394](https://github.com/openclaw/openclaw/pull/135394)). Thanks @jjjhenriksen, @Lendersmark.
 - A rejected global npm update restores the prior package and launchers and keeps the managed Gateway stopped for inspection ([#135462](https://github.com/openclaw/openclaw/pull/135462)). Thanks @fuller-stack-dev.
-- Agent-launched updates move to a detached managed helper before stopping Linux or macOS Gateways ([#135701](https://github.com/openclaw/openclaw/pull/135701)).
-- Nonfatal migration warnings allow a visible degraded startup with Doctor guidance while unsafe state still blocks startup ([#135713](https://github.com/openclaw/openclaw/pull/135713)). Thanks @Zak-Finance.
-- Upgrade and install repair preserves refreshed credentials, legacy cron intent, rollback state, and memory-provider activation ([#135736](https://github.com/openclaw/openclaw/pull/135736)).
-- Doctor and update repair preserve valid external companion plugins and recover missing payloads without hiding the underlying error ([#135791](https://github.com/openclaw/openclaw/pull/135791)). Thanks @hannesrudolph, @weirdo-world, @xiaomijituan.
-- Linux systemd diagnostics include the supported Tailscale operator-grant command when noninteractive sudo is unavailable ([#135825](https://github.com/openclaw/openclaw/pull/135825)). Thanks @pengzh1, @obviyus, @ezimerman.
-- Doctor recognizes valid path-installed Codex app bundles instead of recommending that they be reinstalled ([#135828](https://github.com/openclaw/openclaw/pull/135828)). Thanks @griswomw2, @obviyus.
-- Plugin repair follows the package root that owns a missing-entry diagnostic instead of replacing a healthy same-ID install ([#135834](https://github.com/openclaw/openclaw/pull/135834)).
-- Built source checkouts reuse compiled plugin artifacts during cold Doctor validation while respecting explicit source paths and overlays ([#136399](https://github.com/openclaw/openclaw/pull/136399)).
 - Let service-less Linux updates proceed only after proving there is no service definition, manager state, active Gateway lock, or listener, while unknown state still blocks and the 2026.8.2 `--no-restart` workaround remains limited to a confirmed stopped Gateway ([`f78a574`](https://github.com/openclaw/openclaw/commit/f78a5746dd4b7b520323e4338d5a1f8ca832f931)).
 
 **Security and trust**
 
-- Missing-record npm plugin recovery verifies registry provenance and capability consent before publishing a trusted install record ([#135451](https://github.com/openclaw/openclaw/pull/135451)).
-- Unresolved plugin capability consent blocks update finalization before bindings change or the Gateway restarts ([#135460](https://github.com/openclaw/openclaw/pull/135460)). Thanks @hannesrudolph, @xiaomijituan, @weirdo-world.
+- Incomplete exec-approval repairs keep the Gateway stopped and return failure ([#135454](https://github.com/openclaw/openclaw/pull/135454)).
+- Unresolved plugin consent blocks update finalization before bindings change or the Gateway restarts ([#135460](https://github.com/openclaw/openclaw/pull/135460)). Thanks @hannesrudolph, @xiaomijituan, and @weirdo-world.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Doctor, migration, backup, and service recovery">
+<Accordion title="Settings and State Through Updates">
 
-Doctor can now resolve more of the old state that used to leave an installation stuck between versions, including empty legacy roots and approval stubs, stale workspace setup files, malformed scheduled jobs, incomplete Skill Workshop proposals, and narrowly safe database, roster, credential, channel-ownership, and workspace migrations. Repair stays deliberately conservative. Conflicting or populated state remains available for recovery, invalid cron jobs go to quarantine with their identity and reason, and successful repairs are designed to stay clean on the next pass.
+An update or Doctor repair now does more to preserve the setup you already authored, including configuration includes and environment expressions, agent rosters and workspaces, plugin payloads and policy, credentials, scheduled work, device pairings, and session history. When old and new state disagree, repairs either prove the change is safe or stop before writing, and concurrent Gateway work no longer gets silently replaced by an older Doctor snapshot.
 
-The same care now reaches backups and removal. Verified backups retain the exact active configuration even when its path resembles generated data, workspace exclusions are applied before traversal, and ACPX scratch symlinks no longer make an otherwise portable archive fail. Interactive uninstall keeps local state, configuration, and workspaces unless you explicitly select them, while Windows snapshots work in mixed PowerShell installations.
+The same rule reaches the edges of maintenance. Interactive uninstall keeps local state and workspaces unless you explicitly select them, Windows snapshots work in mixed PowerShell installations, workspace exclusions are applied before backup traversal, and plugin recovery publishes a trusted install record only after it has verified what it is installing.
 
-When Doctor cannot finish automatically, its diagnostics point more directly at the thing that needs attention, including retained custom databases and workspace files, pending device-auth migration, shared credential health, unowned channel routes, and copied state that still reaches an explicitly configured external path. Ambiguous ownership, populated legacy approval data, conflicting credentials, and unsafe workspace state still fail closed rather than being guessed through. Several Windows, SSH, Tailscale, and external-plugin paths have narrower live proof, and the source-build state-check fix covers complete module pairs and environment-only declarations rather than incomplete optional module pairs.
+Verified full and configuration-only backups retain the exact active configuration even when its path resembles generated data, and portable ACPX backups no longer require operators to remove temporary helper symlinks first.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Windows snapshots work when PowerShell 7 is installed alongside Windows PowerShell ([#121618](https://github.com/openclaw/openclaw/pull/121618)). Thanks @fr-meyer.
+- Doctor preserves newer cron definitions, runtime state, and authorization during concurrent repairs ([#127999](https://github.com/openclaw/openclaw/pull/127999)). Thanks @yetval.
+- Valid device pairings survive contaminated legacy records during migration ([#134483](https://github.com/openclaw/openclaw/pull/134483)). Thanks @qdivan, @obviyus, @samson1357924.
+- Identical legacy session events no longer block transcript migration ([#134568](https://github.com/openclaw/openclaw/pull/134568)). Thanks @shakkernerd.
+- Doctor retains recognized official plugin settings written before installation ([#134717](https://github.com/openclaw/openclaw/pull/134717)). Thanks @obviyus, @abacha.
+- Explicit multi-agent roster repairs preserve supported per-agent settings ([#134758](https://github.com/openclaw/openclaw/pull/134758)). Thanks @Lendersmark, @vdruts.
+- Valid per-agent authentication overrides no longer look like unfinished shared-auth migration ([#134808](https://github.com/openclaw/openclaw/pull/134808)). Thanks @fuller-stack-dev.
+- Legacy agent-list upgrades keep the first agent on its established workspace ([#134892](https://github.com/openclaw/openclaw/pull/134892)). Thanks @Lendersmark.
+- Interrupted shared-credential migrations can restore verified archived credentials ([#134952](https://github.com/openclaw/openclaw/pull/134952)). Thanks @erameson.
+- Redundant legacy credential subsets can converge without deleting the richer shared store ([#135096](https://github.com/openclaw/openclaw/pull/135096)). Thanks @jodok, @felixboenkost-droid.
+- Historical completed migrations can recover credentials when the archive and missing migrated credentials are verified ([#135346](https://github.com/openclaw/openclaw/pull/135346)). Thanks @erameson.
+- Doctor preserves authored includes, environment expressions, and identifiable legacy agents ([#135671](https://github.com/openclaw/openclaw/pull/135671)). Thanks @fuller-stack-dev.
+- Update and installation rollback preserves current credentials, cron behavior, and owned plugin or hook state ([#135736](https://github.com/openclaw/openclaw/pull/135736)).
+- External companion plugin payloads survive Doctor and bundled-to-external update repair ([#135791](https://github.com/openclaw/openclaw/pull/135791)). Thanks @hannesrudolph, @weirdo-world, @xiaomijituan.
+- Backup workspace exclusions are applied before traversal while included absolute links remain protected ([#135830](https://github.com/openclaw/openclaw/pull/135830)). Thanks @obviyus, @jarvismazz, @yubingjiaocn, @ericcaiwx-star, @ruel225.
+- Plugin repair diagnostics follow the recorded install root instead of a broken same-ID source copy ([#135834](https://github.com/openclaw/openclaw/pull/135834)).
+- ACPX-owned scratch symlinks no longer prevent creation of a verified portable backup, while unrelated unsafe symlinks still fail closed ([#136215](https://github.com/openclaw/openclaw/pull/136215)). Thanks @LiuwqGit, @obviyus, @wave-workflow.
+- Verified full and config-only backups retain the exact active configuration through volatile-path filtering; absolute configuration symlinks remain outside this repair ([#136666](https://github.com/openclaw/openclaw/pull/136666)).
+
+**Security and trust**
+
+- Interactive uninstall defaults preserve local state, configuration, and workspaces ([#134299](https://github.com/openclaw/openclaw/pull/134299)). Thanks @PollyBot13, @kodi.
+- Missing-record npm plugin recovery verifies registry provenance before publishing trust ([#135451](https://github.com/openclaw/openclaw/pull/135451)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Doctor Repairs for Older State">
+
+Doctor can now resolve more of the old state that used to leave an installation stuck between versions, including empty legacy roots and approval stubs, stale workspace setup files, malformed scheduled jobs, incomplete Skill Workshop proposals, and narrowly safe database, roster, and workspace migrations. Repair stays deliberately conservative. Conflicting or populated state remains available for recovery, invalid cron jobs go to quarantine with their identity and reason, and successful repairs are designed to stay clean on the next pass.
+
+When Doctor cannot finish automatically, its diagnostics now point more directly at the thing that needs attention, including retained workspace files, plugin version drift, shared credential health, managed Tailscale ownership, and externally configured paths that a copied-state rehearsal can still reach. Long database maintenance keeps its lease while it works, and managed Tailscale upgrades can reclaim only the ordinary exclusive route that still points to the configured local Gateway.
+
+Windows Doctor now works across display languages, repairs an unambiguous retained shared workspace, and rejects unusable live workspace switches before activation. Path-installed Codex bundles, source-built Microsoft Teams checks, and compiled plugin artifacts are recognized more accurately during health checks.
+
+Large retained Memory Core event logs now import in bounded resumable batches during Doctor instead of migrating one row at a time, reducing upgrade delays without changing the automatic migration or database schema.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -320,61 +444,67 @@ When Doctor cannot finish automatically, its diagnostics point more directly at 
 **Improvements**
 
 - Repeated Doctor bootstrap-size warnings reuse their number-formatting work without changing thresholds or advice ([#136500](https://github.com/openclaw/openclaw/pull/136500)).
-- Installations drop unused Sharp and Transformers or ONNX dependency chains while preserving WhatsApp media fallback and LanceDB vector search; meme PNG output now requires Playwright Chromium or system Google Chrome ([#134923](https://github.com/openclaw/openclaw/pull/134923)).
+- Import large retained legacy Memory Core event logs in bounded resumable batches during Doctor ([`730dc39`](https://github.com/openclaw/openclaw/commit/730dc392a5bc198774971f2ec61ee28ba46aba36)).
 
 **Bug fixes**
 
 - Empty legacy state roots converge on the active OpenClaw state without replacing populated state ([#114678](https://github.com/openclaw/openclaw/pull/114678)). Thanks @harjothkhara, @obviyus, @xiaodongEdtech.
-- Doctor refuses stale cron repairs that would overwrite newer jobs, runtime state, or authorization ([#127999](https://github.com/openclaw/openclaw/pull/127999)). Thanks @yetval.
 - Gateway startup under load exposes health earlier and improves scoped recovery behavior ([#132186](https://github.com/openclaw/openclaw/pull/132186)). Thanks @galiniliev.
 - Incomplete Skill Workshop proposal migrations preserve recoverable files and converge on later Doctor runs ([#132917](https://github.com/openclaw/openclaw/pull/132917)). Thanks @xydt-juyaohui, @obviyus, @lakemike.
-- Doctor reports retained legacy device-auth state with a profile-aware repair command ([#133978](https://github.com/openclaw/openclaw/pull/133978)). Thanks @yetval.
-- Schema-17 session repair rolls back the whole attempt when a later migration check rejects the database ([#134272](https://github.com/openclaw/openclaw/pull/134272)). Thanks @RileyJJY, @obviyus, @abacha.
-- Doctor continues channel-security audits through unowned routes and repairs an exact account binding only when ownership is unambiguous ([#136463](https://github.com/openclaw/openclaw/pull/136463)). Thanks @ctbritt, @JunfXiao, @oshunter, @WoodyKim554.
-- Windows Doctor and service checks no longer depend on display language, and unsafe retained-workspace switches are rejected before activation ([#136578](https://github.com/openclaw/openclaw/pull/136578)). Thanks @Aivexa, @DasX, @LiuwqGit, @hermannmetzker-ai.
-- Verified full and config-only backups retain the exact active configuration through volatile-path filtering; absolute configuration symlinks remain outside this repair ([#136666](https://github.com/openclaw/openclaw/pull/136666)).
-- Valid device pairings survive contaminated legacy records during migration ([#134483](https://github.com/openclaw/openclaw/pull/134483)). Thanks @qdivan, @obviyus, @samson1357924.
-- Windows agent-initiated Gateway restarts survive the old process tree ([#134549](https://github.com/openclaw/openclaw/pull/134549)). Thanks @nerclid, @w1130150306.
-- Identical legacy session events no longer block transcript migration while genuinely conflicting records remain recoverable ([#134568](https://github.com/openclaw/openclaw/pull/134568)). Thanks @shakkernerd.
+- Schema-17 session repair now rolls back the whole attempt when migration is rejected ([#134272](https://github.com/openclaw/openclaw/pull/134272)). Thanks @RileyJJY, @obviyus, @abacha.
 - Doctor safely clears empty reserved workspace attestations that block agent turns ([#134641](https://github.com/openclaw/openclaw/pull/134641)). Thanks @leilei3167, @obviyus, @rosssaunders, @courtneyr-dev, @guarismo.
-- MCP lint finishes against busy live state and avoids duplicate false failures ([#134698](https://github.com/openclaw/openclaw/pull/134698)). Thanks @obviyus, @pfrederiksen.
+- MCP lint finishes against private state when live SQLite state is busy ([#134698](https://github.com/openclaw/openclaw/pull/134698)). Thanks @obviyus, @pfrederiksen.
 - Malformed legacy cron jobs are quarantined so valid jobs and Gateway startup can continue ([#134704](https://github.com/openclaw/openclaw/pull/134704)). Thanks @obviyus, @Nielsh82.
 - Doctor repairs markerless keyed and legacy multi-agent rosters without changing routing choices ([#134706](https://github.com/openclaw/openclaw/pull/134706)). Thanks @Lendersmark.
-- Doctor retains recognized official plugin settings written before installation ([#134717](https://github.com/openclaw/openclaw/pull/134717)). Thanks @obviyus, @abacha.
-- Blocked workspace cleanup warnings name the exact retained legacy file ([#134751](https://github.com/openclaw/openclaw/pull/134751)). Thanks @rosssaunders.
-- Explicit multi-agent roster repairs preserve supported per-agent settings ([#134758](https://github.com/openclaw/openclaw/pull/134758)). Thanks @Lendersmark, @vdruts.
-- Healthy legacy heartbeat and cron artifacts no longer produce false transcript corruption warnings ([#134765](https://github.com/openclaw/openclaw/pull/134765)). Thanks @obviyus, @LiuwqGit, @sblindt, @ayaangazali.
-- Blank backup intervals fail instead of silently creating a 24-hour schedule ([#134799](https://github.com/openclaw/openclaw/pull/134799)). Thanks @marmar9615-cloud.
-- Valid per-agent authentication overrides no longer look like unfinished shared-auth migration ([#134808](https://github.com/openclaw/openclaw/pull/134808)). Thanks @fuller-stack-dev.
+- Post-upgrade Doctor reports official plugin version drift with an actionable update command ([#134719](https://github.com/openclaw/openclaw/pull/134719)). Thanks @Lendersmark, @oshunter.
+- Blocked workspace cleanup warnings name the retained legacy file ([#134751](https://github.com/openclaw/openclaw/pull/134751)). Thanks @rosssaunders.
+- Healthy legacy heartbeat artifacts no longer produce false transcript corruption warnings ([#134765](https://github.com/openclaw/openclaw/pull/134765)). Thanks @obviyus, @LiuwqGit, @sblindt, @ayaangazali.
 - BOOT.md startup checks use their own temporary session without overwriting retained history ([#134831](https://github.com/openclaw/openclaw/pull/134831)). Thanks @miguelarios.
 - Long database scans and migrations renew their maintenance lease while Doctor works ([#134880](https://github.com/openclaw/openclaw/pull/134880)).
-- Legacy agent-list upgrades keep the first agent on its established workspace ([#134892](https://github.com/openclaw/openclaw/pull/134892)). Thanks @Lendersmark.
 - Shared credential health remains visible in explicit fleets without a default agent ([#134902](https://github.com/openclaw/openclaw/pull/134902)). Thanks @Lendersmark.
-- Interrupted shared-credential migrations can restore verified archived credentials ([#134952](https://github.com/openclaw/openclaw/pull/134952)). Thanks @erameson.
-- Redundant legacy credential subsets converge without deleting the richer shared store ([#135096](https://github.com/openclaw/openclaw/pull/135096)). Thanks @jodok, @felixboenkost-droid.
-- Blank Gateway suspension waits fail before a lease is acquired while zero remains a valid single attempt ([#135270](https://github.com/openclaw/openclaw/pull/135270)). Thanks @qingminglong.
+- Managed Tailscale upgrades reclaim only an exclusive predecessor route for the configured Gateway ([#135394](https://github.com/openclaw/openclaw/pull/135394)). Thanks @jjjhenriksen, @Lendersmark.
+- Stale workspace setup migrations preserve canonical facts, archive the source, and converge ([#135755](https://github.com/openclaw/openclaw/pull/135755)). Thanks @jjjhenriksen, @Deregtx, @guarismo.
+- Managed Tailscale sudo failures on Linux now include the supported operator-grant command ([#135825](https://github.com/openclaw/openclaw/pull/135825)). Thanks @pengzh1, @obviyus, @ezimerman.
+- Doctor reports retained legacy device-auth state with a profile-aware repair command ([#133978](https://github.com/openclaw/openclaw/pull/133978)). Thanks @yetval.
 - Doctor explains retained custom agent databases and why it will not remove them automatically ([#135295](https://github.com/openclaw/openclaw/pull/135295)). Thanks @PollyBot13, @obviyus, @aaajiao.
-- Historical completed migrations recover credentials only when the legacy receipt and matching archive can be verified ([#135346](https://github.com/openclaw/openclaw/pull/135346)). Thanks @erameson.
-- Doctor and upgrade repair preserve authored includes, environment expressions, and unambiguously identifiable legacy agents ([#135671](https://github.com/openclaw/openclaw/pull/135671)). Thanks @fuller-stack-dev.
-- Stale workspace setup migrations preserve a verified backup and converge instead of repeatedly blocking channel startup ([#135755](https://github.com/openclaw/openclaw/pull/135755)). Thanks @jjjhenriksen, @Deregtx, @guarismo.
-- Backup workspace exclusions are applied before traversal while included absolute links remain protected ([#135830](https://github.com/openclaw/openclaw/pull/135830)). Thanks @obviyus, @jarvismazz, @yubingjiaocn, @ericcaiwx-star, @ruel225.
-- ACPX-owned scratch symlinks no longer prevent creation of a verified portable backup, while unrelated unsafe symlinks still fail closed ([#136215](https://github.com/openclaw/openclaw/pull/136215)). Thanks @LiuwqGit, @obviyus, @wave-workflow.
+- Doctor recognizes valid path-installed Codex app bundles instead of recommending that they be reinstalled ([#135828](https://github.com/openclaw/openclaw/pull/135828)). Thanks @griswomw2, @obviyus.
+- Built source checkouts reuse compiled plugin artifacts during cold Doctor validation while respecting explicit source paths and overlays ([#136399](https://github.com/openclaw/openclaw/pull/136399)).
+- Doctor continues channel-security audits through unowned routes and repairs an exact account binding only when ownership is unambiguous ([#136463](https://github.com/openclaw/openclaw/pull/136463)). Thanks @ctbritt, @JunfXiao, @oshunter, @WoodyKim554.
+- Windows Doctor and service checks no longer depend on display language, and unsafe retained-workspace switches are rejected before activation ([#136578](https://github.com/openclaw/openclaw/pull/136578)). Thanks @Aivexa, @DasX, @LiuwqGit, @hermannmetzker-ai.
 
 **Security and trust**
 
-- Interactive uninstall defaults preserve local state, configuration, and workspaces ([#134299](https://github.com/openclaw/openclaw/pull/134299)). Thanks @PollyBot13, @kodi.
-- Incomplete exec-approval repairs keep a stopped Gateway stopped and return failure ([#135454](https://github.com/openclaw/openclaw/pull/135454)).
-- Doctor retires only policy-free legacy exec-approval stubs while malformed or populated data still fails closed ([#135981](https://github.com/openclaw/openclaw/pull/135981)). Thanks @Ma77h3hac83r.
+- Policy-free legacy exec-approval stubs can be archived and retired without replacing SQLite policy ([#135981](https://github.com/openclaw/openclaw/pull/135981)). Thanks @Ma77h3hac83r.
 
 **Documentation**
 
-- The CLI index links the existing database preflight and ownership commands ([#135279](https://github.com/openclaw/openclaw/pull/135279)). Thanks @qingminglong.
-- Doctor guidance warns that copied state can still modify explicitly configured external workspaces or stores ([#135312](https://github.com/openclaw/openclaw/pull/135312)). Thanks @vdruts.
+- The CLI index now links the existing database preflight and ownership commands ([#135279](https://github.com/openclaw/openclaw/pull/135279)). Thanks @qingminglong.
+- Doctor guidance explains how copied-state repairs can still reach explicitly configured external paths ([#135312](https://github.com/openclaw/openclaw/pull/135312)). Thanks @vdruts.
 
 **Limits and compatibility**
 
-- Windows snapshots work when PowerShell 7 is installed alongside Windows PowerShell without weakening private-path checks ([#121618](https://github.com/openclaw/openclaw/pull/121618)). Thanks @fr-meyer.
 - Source builds point complete module-backed channel state checks at emitted JavaScript or CommonJS artifacts ([#136509](https://github.com/openclaw/openclaw/pull/136509)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Investigating a Failed Update">
+
+When an interactive update gets far enough to fail operationally, OpenClaw can now carry a bounded, sanitized record of that attempt into its existing triage flow instead of making you reconstruct the failure from scratch. The CLI can offer a configured Claude Code, Codex, OpenCode, or Pi session after updater cleanup, and the Control UI can open Ask OpenClaw with the recorded cause for an investigation-first conversation.
+
+That investigation does not get authority to retry the update, repair state, or restart the Gateway on its own, and a successful investigation does not turn the original update into a success. JSON, `--yes`, background, and managed-service runs remain diagnostic-only, preserving the original exit result while printing the next commands for an operator to use.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Built-in triage carries sanitized failure context into the CLI or Control UI after eligible update failures ([#134865](https://github.com/openclaw/openclaw/pull/134865)).
+
+**Bug fixes**
+
+- Failed updates preserve configuration and can hand investigation to an installed coding agent ([#134490](https://github.com/openclaw/openclaw/pull/134490)). Thanks @fuller-stack-dev.
 
 </details>
 
@@ -384,17 +514,60 @@ When Doctor cannot finish automatically, its diagnostics point more directly at 
 
 ## Messaging
 
-Messages across [channels](/channels) are less likely to arrive blank, damaged, duplicated, or detached from the conversation that made them useful. This release tightens both halves of that experience, keeping the reply itself intact as it crosses a channel's limits while making the channel around it easier to recover, inspect, and control when something goes wrong.
+Messaging in [channels](/channels) is less about whether a reply was technically sent and more about whether it arrived in the right conversation with its context, controls, and final outcome intact. This release carries that work across approvals, thread routing, rich replies, queues, restarts, voice, and the failure paths that used to leave either the person or the operator guessing.
 
 <AccordionGroup>
 
-<Accordion title="Delivery, formatting, and attachment fidelity">
+<Accordion title="Approving Delegated Changes from Chat">
 
-Long and structured replies now survive more of the trip from the agent to the person reading them. Fenced code keeps its indentation and repeated lines, task lists keep their checkboxes when a message is split, and literal Markdown, image links, citations, and labeled links are less likely to disappear or turn into the wrong kind of attachment. Microsoft Teams threads retain their parent and sibling context, cross-session deliveries are written into the conversation that received them, and remote-Mac iMessage attachments get a short bounded retry when the file is still materializing.
+When a delegated system agent asks to change OpenClaw configuration or plugins, operators can now approve or deny the request from a configured channel and see whether it was applied, denied, cancelled, expired, or could not be applied. The request remains tied to the run that created it, so closing that run also closes its authority to make the change, while Telegram keeps the approval and completion messages in the forum or direct-message topic where the request began.
 
-The channel-specific presentation paths got the same kind of attention without pretending they all work alike. Matrix and Feishu or Lark keep offered controls, while LINE preserves card text, questions, and every choice when media is unavailable or the native card is too large. LINE still exposes only the first 13 choices as native quick replies and keeps the rest readable as text, and a WhatsApp reply whose quote has expired now arrives unquoted rather than as an empty bubble.
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
 
-Delivery outcomes are also more conservative where uncertainty used to create either silence or duplication. Slack sends short final answers before later progress cleanup can fail and keeps queued or ordinary replies on the admitted thread root, while Discord avoids replaying uncertain webhook sends through a second bot path and no longer treats a response without a real message ID as confirmed delivery. These repairs are specific to the named paths, and several external-service checks used synthetic endpoints rather than live accounts.
+**Improvements**
+
+- Approve delegated configuration and plugin changes from supported channels ([#134670](https://github.com/openclaw/openclaw/pull/134670)). Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Reply Context and Agent Identity">
+
+Replies now hold onto more of the context that made them meaningful. Microsoft Teams channel threads include their parent and sibling messages even when Teams omits reply metadata, cross-session deliveries are written into the receiving conversation, and LINE tells the answering turn whether a group message actually addressed the bot. Wildcard peer routes no longer change with lookup order, and Slack RPC replies keep the selected agent’s configured name and emoji.
+
+Slack Agent View roots now keep separate conversation context through both Socket Mode and HTTP Request URL restarts, and threaded replies continue targeting the established thread. Long-running WhatsApp replies remain readable after quote context expires by falling back to an unquoted message.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep the configured Slack agent identity on RPC-delivered replies ([#122078](https://github.com/openclaw/openclaw/pull/122078)). Thanks @Iskam31.
+- Restore parent and sibling context in Microsoft Teams channel threads ([#129345](https://github.com/openclaw/openclaw/pull/129345)). Thanks @amalysh.
+- Record cross-session deliveries in the receiving conversation history ([#134083](https://github.com/openclaw/openclaw/pull/134083)). Thanks @edenfunf, @VACInc, @abacha.
+- Carry LINE group-mention context into the turn that answers ([#135195](https://github.com/openclaw/openclaw/pull/135195)). Thanks @edenfunf.
+- Route unknown direct messages through the configured wildcard peer consistently ([#135351](https://github.com/openclaw/openclaw/pull/135351)). Thanks @teddytennant, @obviyus.
+- Fall back to a readable unquoted WhatsApp reply when quote details have expired ([#127959](https://github.com/openclaw/openclaw/pull/127959)). Thanks @Finn763 and @markswitch83.
+- Keep Slack Agent View conversations isolated in Socket Mode ([#136510](https://github.com/openclaw/openclaw/pull/136510)). Thanks @danielduerr.
+- Preserve Slack Agent View isolation across HTTP-mode Gateway restarts ([#136559](https://github.com/openclaw/openclaw/pull/136559)). Thanks @danielduerr.
+- Keep Slack replies and queued notices on the existing thread root ([#136566](https://github.com/openclaw/openclaw/pull/136566)). Thanks @Cobblestone-Digital1 and @shannon0430.
+
+**Documentation**
+
+- Explain Slack Agent View session boundaries, detection, persistence, and troubleshooting ([#136672](https://github.com/openclaw/openclaw/pull/136672)). Thanks @danielduerr.
+- Correct Slack Agent View recovery guidance after a storage warning ([#136704](https://github.com/openclaw/openclaw/pull/136704)). Thanks @danielduerr.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Complete Controls, Cards, and Formatted Replies">
+
+Rich replies are less likely to lose the part somebody actually needed. Matrix and Feishu or Lark deliver offered controls, while LINE preserves card text, buttons, questions, and overflow choices when media is unavailable or a generated card is too large for the platform. Long task lists keep their structure across message chunks, and ordinary Markdown examples, citations, image URLs, and labeled links survive parsing without disappearing or triggering the wrong fetch.
+
+Delivered replies now retain fenced-code indentation and repeated lines while still collapsing duplicate prose. Remote-Mac iMessage attachments wait through short materialization delays so the agent receives the file instead of an incomplete message.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -405,92 +578,129 @@ Delivery outcomes are also more conservative where uncertainty used to create ei
 
 **Bug fixes**
 
-- Finish rejected webhook responses before closing bundled channel connections ([#126818](https://github.com/openclaw/openclaw/pull/126818)). Thanks @edenfunf and @obviyus.
-- Fall back to a readable unquoted WhatsApp reply when quote details have expired ([#127959](https://github.com/openclaw/openclaw/pull/127959)). Thanks @Finn763 and @markswitch83.
-- Preserve Matrix code containing double pipes without hiding the reply ([#128453](https://github.com/openclaw/openclaw/pull/128453)). Thanks @ruel225 and @petergaultney.
-- Restore parent and sibling context in Microsoft Teams channel threads ([#129345](https://github.com/openclaw/openclaw/pull/129345)). Thanks @amalysh.
+- Preserve Matrix code containing double pipes without hiding the reply ([#128453](https://github.com/openclaw/openclaw/pull/128453)). Thanks @ruel225, @petergaultney.
 - Keep LINE card text and controls when optional media is unavailable ([#132571](https://github.com/openclaw/openclaw/pull/132571)). Thanks @edenfunf.
-- Stop active link fetches and processors when their reply is cancelled ([#132883](https://github.com/openclaw/openclaw/pull/132883)). Thanks @SunnyShu0925.
-- Deliver buttons and selections in Matrix agent replies ([#133268](https://github.com/openclaw/openclaw/pull/133268)). Thanks @edenfunf and @ml12580.
-- Record cross-session deliveries in the receiving conversation history ([#134083](https://github.com/openclaw/openclaw/pull/134083)). Thanks @edenfunf, @VACInc, and @abacha.
+- Deliver buttons and selections in Matrix agent replies ([#133268](https://github.com/openclaw/openclaw/pull/133268)). Thanks @edenfunf, @ml12580.
+- Let LINE agents offer the controls the channel already supports ([#134915](https://github.com/openclaw/openclaw/pull/134915)). Thanks @edenfunf.
 - Preserve LINE quick-reply questions and every offered choice ([#134976](https://github.com/openclaw/openclaw/pull/134976)). Thanks @edenfunf.
-- Run browser messages accepted during startup recovery exactly once afterward ([#135016](https://github.com/openclaw/openclaw/pull/135016)). Thanks @jesse-merhi and @snarflakes.
-- Complete auto-replies whose prompt ends with context, attachments, or metadata ([#135070](https://github.com/openclaw/openclaw/pull/135070)).
-- Reconcile generated commentary as one update during runs and reconnects ([#135081](https://github.com/openclaw/openclaw/pull/135081)). Thanks @akagifreeez, @obviyus, and @tomroberts78.
-- Send ordinary Tlon hashtag lines without stalling the parser ([#135181](https://github.com/openclaw/openclaw/pull/135181)).
-- Carry LINE group-mention context into the turn that answers ([#135195](https://github.com/openclaw/openclaw/pull/135195)). Thanks @edenfunf.
 - Preserve task lists and structured Markdown across message chunks ([#135200](https://github.com/openclaw/openclaw/pull/135200)).
 - Fall back to complete text when a generated LINE card is too large ([#135229](https://github.com/openclaw/openclaw/pull/135229)). Thanks @edenfunf.
 - Deliver Feishu and Lark controls, links, attachments, and accurate partial results ([#135255](https://github.com/openclaw/openclaw/pull/135255)). Thanks @edenfunf.
-- Keep Markdown citations from being mistaken for pasted URLs to fetch ([#135341](https://github.com/openclaw/openclaw/pull/135341)). Thanks @teddytennant and @obviyus.
-- Route unknown direct messages through the configured wildcard peer consistently ([#135351](https://github.com/openclaw/openclaw/pull/135351)). Thanks @teddytennant and @obviyus.
-- Preserve fenced code byte for byte through duplicate-prose cleanup ([#135945](https://github.com/openclaw/openclaw/pull/135945)). Thanks @ruel225, @obviyus, and @yetval.
-- Deliver long Discord webhook replies without duplicate bot fallback messages ([#135963](https://github.com/openclaw/openclaw/pull/135963)).
-- Preserve Google Chat link labels that contain spaces ([#136151](https://github.com/openclaw/openclaw/pull/136151)). Thanks @ericcaiwx-star, @obviyus, and @KimOckHyun.
+- Keep Markdown citations from being mistaken for pasted URLs to fetch ([#135341](https://github.com/openclaw/openclaw/pull/135341)). Thanks @teddytennant, @obviyus.
+- Preserve Google Chat link labels that contain spaces ([#136151](https://github.com/openclaw/openclaw/pull/136151)). Thanks @ericcaiwx-star, @obviyus, @KimOckHyun.
 - Preserve literal Markdown images and balanced image URL punctuation ([#136228](https://github.com/openclaw/openclaw/pull/136228)).
+- Preserve fenced code byte for byte through duplicate-prose cleanup ([#135945](https://github.com/openclaw/openclaw/pull/135945)). Thanks @ruel225, @obviyus, and @yetval.
 - Retry remote-Mac iMessage attachments through short materialization delays ([#136301](https://github.com/openclaw/openclaw/pull/136301)). Thanks @zhangguiping-xydt, @obviyus, and @zqchris.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Channel Queues Through Restarts">
+
+Several channel failures now recover without making a healthy conversation look dead. Telegram can move past a stale session start and acknowledges stored button presses before a busy chat finishes earlier work, while channel routes release cleanly during replacement, Matrix can repair an upgraded sync database with Doctor, and Slack Socket Mode or relay accounts no longer depend on an inactive HTTP-only secret. Failed configured channels remain visible as blocked with a safe recovery hint instead of disappearing from status and health.
+
+Older supported Feishu, Telegram, WhatsApp, and Matrix plugins keep dispatching inbound replies after the host updates, installed external channels work with generic message actions and broadcast planning, and narrower Slack lookup problems and Tlon parser stalls are repaired. These are channel-specific repairs rather than a claim that every transport now behaves identically.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reuse Slack Enterprise thread lookups across matching events ([#121598](https://github.com/openclaw/openclaw/pull/121598)). Thanks @mikasa0818.
+- Show why Slack rejected an inbound attempt before dispatch ([#132723](https://github.com/openclaw/openclaw/pull/132723)). Thanks @zhangguiping-xydt, @Phillis, @ayaangazali.
+- Release abandoned channel routes so account recovery can continue ([#133297](https://github.com/openclaw/openclaw/pull/133297)). Thanks @zhangguiping-xydt, @goffern.
+- Acknowledge durably stored Telegram button presses promptly ([#133379](https://github.com/openclaw/openclaw/pull/133379)). Thanks @Paeddy87, @zhangguiping-xydt.
+- Repair stale Matrix sync databases while preserving existing state ([#134742](https://github.com/openclaw/openclaw/pull/134742)). Thanks @w9n, @obviyus.
+- Start Slack Socket Mode and relay without resolving an unused HTTP secret ([#134827](https://github.com/openclaw/openclaw/pull/134827)).
+- Keep failed configured channels visible in status and health ([#135082](https://github.com/openclaw/openclaw/pull/135082)). Thanks @vguyon-dev, @0xCyda, @liemnhoang.
+- Let Telegram queues recover from a stale session start ([#135154](https://github.com/openclaw/openclaw/pull/135154)). Thanks @brettdaman, @obviyus.
+- Keep older supported channel plugins dispatching replies after host updates ([#135179](https://github.com/openclaw/openclaw/pull/135179)). Thanks @nissl24, @fridaylans2000-art, @obviyus, @jooey, @fufales, @itanyplus, @dtump, @XXlaoxxc, @desksk, @chengoak.
+- Send ordinary Tlon hashtag lines without stalling the parser ([#135181](https://github.com/openclaw/openclaw/pull/135181)).
+- Use installed external channels in generic message actions and broadcasts ([#135831](https://github.com/openclaw/openclaw/pull/135831)). Thanks @ruel225, @obviyus, @TailsProwerWorks.
+- Let Gateway restart and channel shutdown finish without a busy ingress loop ([#133871](https://github.com/openclaw/openclaw/pull/133871)). Thanks @SebTardif and @obviyus.
+- Run browser messages accepted during startup recovery exactly once afterward ([#135016](https://github.com/openclaw/openclaw/pull/135016)). Thanks @jesse-merhi and @snarflakes.
 - Deliver short native-streamed Slack replies before progress finalization ([#136460](https://github.com/openclaw/openclaw/pull/136460)). Thanks @shannon0430.
-- Keep Slack replies and queued notices on the existing thread root ([#136566](https://github.com/openclaw/openclaw/pull/136566)). Thanks @Cobblestone-Digital1 and @shannon0430.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Clear Outcomes for Delivery Failures">
+
+When delivery cannot finish, the result is now less ambiguous. Rejected webhook uploads across bundled channels receive their complete response before the connection closes, malformed Signal response text fails visibly, and an affected iMessage send explains that its bridge stopped responding and gives the operator the two recovery commands. Context-only prompts no longer hang at completion, while Discord thread replies split after mention expansion and avoid replaying an uncertain or partially accepted webhook delivery as a duplicate bot message.
+
+Signal stops retrying permanent SSE rejections and reports a blocked state with recovery guidance, LINE distinguishes an exhausted monthly allowance from transient rate limiting, and Discord leaves sends without a real response ID unconfirmed rather than claiming delivery.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reject corrupted text in Signal JSON responses with a visible failure ([#121569](https://github.com/openclaw/openclaw/pull/121569)). Thanks @sunlit-deng.
+- Finish webhook rejection responses before closing the connection ([#126818](https://github.com/openclaw/openclaw/pull/126818)). Thanks @edenfunf, @obviyus.
+- Explain an unresponsive iMessage bridge and show the recovery commands ([#134572](https://github.com/openclaw/openclaw/pull/134572)). Thanks @omarshahine.
+- Complete auto-replies whose prompt ends with context or metadata ([#135070](https://github.com/openclaw/openclaw/pull/135070)).
+- Deliver long Discord webhook replies without duplicate fallback messages ([#135963](https://github.com/openclaw/openclaw/pull/135963)).
+- Distinguish exhausted LINE monthly allowance from transient rate limits ([#133445](https://github.com/openclaw/openclaw/pull/133445)). Thanks @edenfunf.
+- Stop Signal reconnects on permanent event-stream rejection and show recovery guidance ([#136178](https://github.com/openclaw/openclaw/pull/136178)). Thanks @masatohoshino and @obviyus.
 - Leave Discord sends unconfirmed when no real response ID is returned ([#136620](https://github.com/openclaw/openclaw/pull/136620)). Thanks @Cobblestone-Digital1.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Channel lifecycle, identity, voice, and administration">
+<Accordion title="Stopping Replies and Progress">
 
-Configured channels now explain more of their own state instead of disappearing or failing behind a generic status. Operators can approve or deny delegated configuration and plugin changes from supported chat channels and see the actual applied, denied, cancelled, expired, or not-applied result, with the request's authority ending when its originating run closes. Failed channel plugins remain visible as blocked with a safe Doctor hint, Signal stops retrying permanent event-stream rejections, and an unresponsive iMessage private-API bridge returns the recovery commands on the first affected send.
+Stopping or replacing a turn now does a better job of stopping the work and narration attached to it. Active link fetches and processors are cancelled with the reply, obsolete narration cannot update a newer draft, Control UI commentary reconciles as one update, and Slack waits for a complete first preamble while keeping quiet-preview settings quiet. Successful reaction-only and background work also avoid misleading missing-reply fallbacks.
 
-Slack Agent View now keeps each visible message root in its own conversation, including across Gateway restarts in Socket Mode and HTTP Request URL setups, while ordinary Slack direct messages and Assistant View remain unchanged. Telegram button presses are acknowledged once they are durably stored and stale session starts no longer hold every later message behind them, channel routes release cleanly during recovery, and older supported Feishu, Telegram, WhatsApp, and Matrix plugins keep dispatching replies after the OpenClaw host updates.
-
-The active turn also owns more of what it starts. Progress narration stops when a turn ends, quiet Slack previews wait for a complete first thought, Discord respects quiet reply policy during session conflicts, and cancelled Discord voice consults no longer turn into late error speech. Discord voice capture now has one owner per speaker and rejects oversized batch utterances with an actionable warning instead of emitting a partial transcript, while configured automatic voice replies can preserve the inbound-audio decision for Codex message-tool responses. These voice and recovery changes keep their existing provider, channel, and transport boundaries rather than establishing cross-channel parity.
+Discord follows the same final-outcome discipline in several focused paths. Cancelled voice consults remain quiet, model-picker choices report their real result, and ambient or message-tool-only work does not leak a session-busy warning that its reply policy said to suppress.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
-**Improvements**
+**Bug fixes**
 
-- Approve delegated configuration and plugin changes from supported channels ([#134670](https://github.com/openclaw/openclaw/pull/134670)). Thanks @obviyus.
+- Stop active link fetches and processors when their reply is cancelled ([#132883](https://github.com/openclaw/openclaw/pull/132883)). Thanks @SunnyShu0925.
+- Keep quiet Slack previews on the latest authored preamble ([#134716](https://github.com/openclaw/openclaw/pull/134716)). Thanks @pash-openai.
+- Cancel obsolete progress narration when its turn ends ([#134839](https://github.com/openclaw/openclaw/pull/134839)).
+- Reconcile generated commentary as one update during runs and reconnects ([#135081](https://github.com/openclaw/openclaw/pull/135081)). Thanks @akagifreeez, @obviyus, @tomroberts78.
+- Keep cancelled Discord voice consults quiet and reusable ([#135380](https://github.com/openclaw/openclaw/pull/135380)).
+- Apply Discord model-picker choices without false failure replies ([#135382](https://github.com/openclaw/openclaw/pull/135382)). Thanks @Call44, @BoatAngle.
+- Respect quiet reply policy for Discord session-busy notices ([#135444](https://github.com/openclaw/openclaw/pull/135444)).
+- Keep connected apps available and wait for a complete Slack preamble ([#136092](https://github.com/openclaw/openclaw/pull/136092)). Thanks @pash-openai.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Voice Replies and Discord Voice Sessions">
+
+Discord voice capture now has one owner per speaker and stops oversized batch utterances with an actionable warning instead of accumulating memory or sending a partial transcript. For inbound WhatsApp voice notes, Codex dynamic replies can once again return voice when automatic inbound TTS is enabled, while later text-only turns remain text and the audio decision stays attached to the reply that received it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Report a shadowed WhatsApp acknowledgement emoji during migration ([#119501](https://github.com/openclaw/openclaw/pull/119501)). Thanks @harjothkhara, @obviyus, and @abacha.
-- Reject corrupted text in Signal JSON responses with a visible failure ([#121569](https://github.com/openclaw/openclaw/pull/121569)). Thanks @sunlit-deng.
-- Reuse Slack Enterprise thread lookups across matching events ([#121598](https://github.com/openclaw/openclaw/pull/121598)). Thanks @mikasa0818.
-- Keep the configured Slack agent identity on RPC-delivered replies ([#122078](https://github.com/openclaw/openclaw/pull/122078)). Thanks @Iskam31.
-- Warn when WhatsApp acknowledgement scope cannot be preserved ([#129825](https://github.com/openclaw/openclaw/pull/129825)). Thanks @zhangguiping-xydt and @obviyus.
-- Show why Slack rejected an inbound attempt before dispatch ([#132723](https://github.com/openclaw/openclaw/pull/132723)). Thanks @zhangguiping-xydt, @Phillis, and @ayaangazali.
-- Release abandoned channel routes so account recovery can continue ([#133297](https://github.com/openclaw/openclaw/pull/133297)). Thanks @zhangguiping-xydt and @goffern.
-- Acknowledge durably stored Telegram button presses promptly ([#133379](https://github.com/openclaw/openclaw/pull/133379)). Thanks @Paeddy87 and @zhangguiping-xydt.
-- Distinguish exhausted LINE monthly allowance from transient rate limits ([#133445](https://github.com/openclaw/openclaw/pull/133445)). Thanks @edenfunf.
-- Let Gateway restart and channel shutdown finish without a busy ingress loop ([#133871](https://github.com/openclaw/openclaw/pull/133871)). Thanks @SebTardif and @obviyus.
-- Explain an unresponsive iMessage bridge and show the recovery commands ([#134572](https://github.com/openclaw/openclaw/pull/134572)). Thanks @omarshahine.
-- Keep quiet Slack previews on the latest authored preamble ([#134716](https://github.com/openclaw/openclaw/pull/134716)). Thanks @pash-openai.
-- Repair stale Matrix sync databases while preserving existing state ([#134742](https://github.com/openclaw/openclaw/pull/134742)). Thanks @w9n and @obviyus.
-- Start Slack Socket Mode and relay without resolving an unused HTTP secret ([#134827](https://github.com/openclaw/openclaw/pull/134827)).
-- Cancel obsolete progress narration when its turn ends ([#134839](https://github.com/openclaw/openclaw/pull/134839)).
-- Let LINE agents offer the controls the channel already supports ([#134915](https://github.com/openclaw/openclaw/pull/134915)). Thanks @edenfunf.
-- Keep failed configured channels visible in status and health ([#135082](https://github.com/openclaw/openclaw/pull/135082)). Thanks @vguyon-dev, @0xCyda, and @liemnhoang.
-- Let Telegram queues recover from a stale session start ([#135154](https://github.com/openclaw/openclaw/pull/135154)). Thanks @brettdaman and @obviyus.
-- Keep cancelled Discord voice consults quiet and reusable ([#135380](https://github.com/openclaw/openclaw/pull/135380)).
-- Apply Discord model-picker choices without false failure replies ([#135382](https://github.com/openclaw/openclaw/pull/135382)). Thanks @Call44 and @BoatAngle.
-- Respect quiet reply policy for Discord session-busy notices ([#135444](https://github.com/openclaw/openclaw/pull/135444)).
-- Use installed external channels in generic message actions and broadcasts ([#135831](https://github.com/openclaw/openclaw/pull/135831)). Thanks @ruel225, @obviyus, and @TailsProwerWorks.
-- Bound Discord voice capture and clean up each speaker's session ([#135870](https://github.com/openclaw/openclaw/pull/135870)). Thanks @LZY3538.
+- Bound Discord voice capture and clean up each speaker’s session ([#135870](https://github.com/openclaw/openclaw/pull/135870)). Thanks @LZY3538.
 - Preserve inbound audio for automatic Codex voice replies ([#135884](https://github.com/openclaw/openclaw/pull/135884)). Thanks @hyper-sdn.
-- Keep connected apps available and wait for a complete Slack preamble ([#136092](https://github.com/openclaw/openclaw/pull/136092)). Thanks @pash-openai.
-- Keep Slack Agent View conversations isolated in Socket Mode ([#136510](https://github.com/openclaw/openclaw/pull/136510)). Thanks @danielduerr.
-- Preserve Slack Agent View isolation across HTTP-mode Gateway restarts ([#136559](https://github.com/openclaw/openclaw/pull/136559)). Thanks @danielduerr.
-- Stop Signal reconnects on permanent event-stream rejection and show recovery guidance ([#136178](https://github.com/openclaw/openclaw/pull/136178)). Thanks @masatohoshino and @obviyus.
 
-**Documentation**
+</details>
 
-- Explain Slack Agent View session boundaries, detection, persistence, and troubleshooting ([#136672](https://github.com/openclaw/openclaw/pull/136672)). Thanks @danielduerr.
-- Correct Slack Agent View recovery guidance after a storage warning ([#136704](https://github.com/openclaw/openclaw/pull/136704)). Thanks @danielduerr.
+</Accordion>
 
-**Limits and compatibility**
+<Accordion title="WhatsApp Acknowledgement Migration">
 
-- Keep older supported Feishu, Telegram, WhatsApp, and Matrix plugins dispatching replies after host updates ([#135179](https://github.com/openclaw/openclaw/pull/135179)). Thanks @nissl24, @fridaylans2000-art, @obviyus, @jooey, @fufales, @itanyplus, @dtump, @XXlaoxxc, @desksk, and @chengoak.
+Doctor now says when a legacy WhatsApp acknowledgement setting could not survive migration exactly as written. It identifies a shadowed emoji, shows which shared emoji remains active, and warns when the old acknowledgement scope changes or cannot be represented so operators can review `messages.ackReactionScope` instead of accepting a misleading clean migration.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Report a shadowed WhatsApp acknowledgement emoji during migration ([#119501](https://github.com/openclaw/openclaw/pull/119501)). Thanks @harjothkhara, @obviyus, @abacha.
+- Warn when WhatsApp acknowledgement scope cannot be preserved ([#129825](https://github.com/openclaw/openclaw/pull/129825)). Thanks @zhangguiping-xydt, @obviyus.
 
 </details>
 
@@ -500,38 +710,32 @@ The active turn also owns more of what it starts. Progress narration stops when 
 
 ## Memory
 
-[Memory](/concepts/memory) is easier to repair without sacrificing the conversations it is meant to remember. Rebuildable indexes can now be reset while sessions and transcripts stay put, ordinary searches avoid needless rebuilding, and recall is more careful about which result, agent, provider, and archive it belongs to.
+[Memory](/concepts/memory) now keeps rebuildable index work separate from the conversations people need to protect. There is a safe reset path that leaves sessions and transcripts in place, search avoids needless full rebuilds for healthy or ordinarily dirty indexes, legacy retrieval settings survive Doctor upgrades, and long conversations retain capture progress through compaction while closed transcript views release message text they no longer need.
 
 <AccordionGroup>
 
-<Accordion title="Index repair, reset, and incremental search">
+<Accordion title="Resetting and Rebuilding Memory Indexes">
 
-Built-in Memory now has an explicit `openclaw memory reset` path for one agent or every configured agent. It removes only rebuildable memory-index data while preserving sessions, transcripts, memory source files, and unrelated database tables, asks before acting, requires `--yes` when nobody is there to confirm, and refuses to race indexing already in progress. This is a recovery tool, not a privacy purge or a way to shrink the database.
+Built-in Memory now has an explicit `openclaw memory reset` path that discards only rebuildable index data for one agent or every configured agent while preserving sessions, transcripts, memory source files, and other durable agent state. It asks before acting, requires `--yes` in non-interactive use, treats an absent or empty index as a successful no-op, and refuses to race indexing already in progress.
 
-Healthy one-shot searches can return without starting needless indexing work, while ordinary file and session changes are applied incrementally instead of repeatedly selecting a full rebuild. LanceDB automatic capture keeps its place through conversation compaction and drains pending work before the plugin closes. Replies also remain available while a legacy index repairs in the background, though automatic project and trigger recall can be empty until that repair finishes. Doctor keeps each agent's retrieval paths and session-memory choices during legacy upgrades, and one symlinked or otherwise non-regular workspace file no longer takes every regular memory file out with it.
-
-The harder failure paths are less destructive too. Replacement caches are bounded before publication, failed full rebuilds leave the current cache intact, one concurrent change gets a fresh automatic attempt, and abandoned workspace locks can recover after a crash and later process-ID reuse. Recovery guidance keeps the correct agent-scoped command visible, identifies whether OpenClaw or configuration owns an index mismatch, shows the unreadable source path, and warns when an explicit rebuild may contact a paid embedding provider.
+Full reindexes are safer around that path. Replacement caches are bounded before publication, failed full rebuilds leave the previously published cache intact, a memory change during automatic maintenance gets one retry against current content, and abandoned workspace locks can recover after process-ID reuse. Recovery messages identify whether an incompatible index belongs to OpenClaw or configuration, warn when an explicit rebuild may contact a paid embedding provider, and retain the unreadable source path; ordinary replies remain available while a legacy index is repaired in the background, and combined memory and wiki searches continue to show the affected agent's repair instructions.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Reset rebuildable memory indexes without deleting sessions or transcripts ([#135653](https://github.com/openclaw/openclaw/pull/135653)). Thanks @AlexisBallo2.
+- Reset derived memory indexes without deleting sessions or transcripts ([#135653](https://github.com/openclaw/openclaw/pull/135653)). Thanks @AlexisBallo2.
 
 **Bug fixes**
 
-- Preserve LanceDB capture progress through compaction and plugin shutdown ([#131329](https://github.com/openclaw/openclaw/pull/131329)). Thanks @hartmark.
-- Retry automatic index maintenance once when memory changes during a rebuild ([#134333](https://github.com/openclaw/openclaw/pull/134333)). Thanks @TheAngryPit, @obviyus.
-- Preserve each agent's memory-search settings during legacy Doctor upgrades ([#134760](https://github.com/openclaw/openclaw/pull/134760)). Thanks @obviyus, @vdruts.
-- Skip linked and other non-regular workspace memory files without aborting indexing ([#135042](https://github.com/openclaw/openclaw/pull/135042)). Thanks @ruel225, @obviyus, @kiranvk-2011.
+- Retry automatic index maintenance once after a concurrent memory change ([#134333](https://github.com/openclaw/openclaw/pull/134333)). Thanks @TheAngryPit, @obviyus.
 - Recover abandoned Memory Core locks after process-ID reuse ([#135051](https://github.com/openclaw/openclaw/pull/135051)). Thanks @pengzh1, @obviyus, @gru-10k.
-- Keep replies available while a legacy index repairs in the background ([#135062](https://github.com/openclaw/openclaw/pull/135062)). Thanks @LifeViwer.
-- Bound forced-reindex cache publication and preserve the current cache after failure ([#135373](https://github.com/openclaw/openclaw/pull/135373)). Thanks @AlexisBallo2.
-- Keep agent-scoped memory repair instructions beside successful wiki results ([#135415](https://github.com/openclaw/openclaw/pull/135415)).
-- Let healthy one-shot memory searches return without reindexing ([#135520](https://github.com/openclaw/openclaw/pull/135520)). Thanks @gaoanze888, @obviyus, @LifeViwer.
+- Keep replies available while a legacy index is repaired in the background ([#135062](https://github.com/openclaw/openclaw/pull/135062)). Thanks @LifeViwer.
+- Bound forced-reindex cache publication and preserve the live cache after failure ([#135373](https://github.com/openclaw/openclaw/pull/135373)). Thanks @AlexisBallo2.
+- Keep agent-scoped repair instructions beside successful wiki results ([#135415](https://github.com/openclaw/openclaw/pull/135415)).
 - Identify index-mismatch ownership and retain unreadable-source details ([#135864](https://github.com/openclaw/openclaw/pull/135864)). Thanks @yetval, @obviyus, @CjTruHeart.
-- Apply pending memory changes without repeatedly rebuilding the full index ([#136064](https://github.com/openclaw/openclaw/pull/136064)). Thanks @ThatGuySizemore.
+- Avoid false critical memory-pressure alerts on small Gateway hosts ([#136641](https://github.com/openclaw/openclaw/pull/136641)). Thanks @vincentkoc.
 
 **Documentation**
 
@@ -539,21 +743,42 @@ The harder failure paths are less destructive too. Replacement caches are bounde
 
 **Limits and compatibility**
 
-- Reset does not shrink existing SQLite allocation, restore deleted history, or erase source data, and the planned separate index database remains future work.
-- Automatic recall can remain empty during legacy repair, and rebuilding may contact the configured paid embedding provider.
-- Symlink targets remain intentionally unread, and shared mutable state directories across concurrent Gateways remain unsupported.
+- Reset does not shrink existing SQLite allocation, restore already deleted history, or act as a privacy purge, and the planned separate derived-index database remains future work.
+- Automatic project and trigger recall remains unavailable while legacy source classification is pending, and an explicit rebuild may use a paid embedding provider.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Embedding access, recall anchoring, history, and diagnostics">
+<Accordion title="Search Without Needless Rebuilding">
 
-Recall now returns the history around the result somebody actually selected, including retained history from before a session reset, instead of quietly substituting the newest messages. Missing anchors return no history and foreign session bindings are rejected. In eligible private chats, Active Memory also tells the model when recall was intentionally skipped or unavailable, without putting provider errors or sensitive search details into model context, so a failed lookup is less likely to masquerade as a successful search that found nothing.
+One-shot `openclaw memory search` commands can reuse a healthy persisted index and exit instead of starting indexing work after they already found the answer. The command still checks its sources, so a real change starts maintenance and becomes searchable rather than leaving the clean state frozen forever.
 
-Embedding access follows the route the operator chose more faithfully. Custom OpenAI-compatible providers can resolve saved API-key or bearer-token profiles and use matching HTTP or HTTPS proxy settings, while invalid profile bindings stop before network egress and `NO_PROXY` exclusions keep their direct route. The official Linux x64 Docker image includes the runtime needed for managed local llama.cpp embeddings, and malformed Amazon Bedrock responses now fail clearly instead of being accepted with altered encoding. These boundaries remain provider-specific, and nothing here changes where remote embedding requests go or whether they may incur provider cost.
+When an index is dirty, ordinary memory-file and session changes can be applied incrementally while searches remain available instead of repeatedly selecting a full rebuild. Workspace discovery also skips symlinked and other non-regular memory entries rather than allowing one linked `USER.md` to abort indexing for every regular file.
 
-Memory also holds onto the right owner and history through more of its lifecycle. Deep Memory Core consolidation stays attached to the explicitly selected agent, and session deletion can publish a recoverable archive even when a durable session ID is too long for a filename. Large transcript scans retain less full-message text up front and release recovered text when a chat closes, short session listings stop pinning retired metadata snapshots, and memory diagnostics no longer label ordinary use on a small constrained host as critical pressure.
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Skip linked and other non-regular workspace memory files without aborting the sync ([#135042](https://github.com/openclaw/openclaw/pull/135042)). Thanks @ruel225, @obviyus, @kiranvk-2011.
+- Let clean one-shot memory searches return without reindexing ([#135520](https://github.com/openclaw/openclaw/pull/135520)). Thanks @gaoanze888, @obviyus, @LifeViwer.
+- Apply pending memory changes without repeatedly rebuilding the full index ([#136064](https://github.com/openclaw/openclaw/pull/136064)). Thanks @ThatGuySizemore.
+
+**Limits and compatibility**
+
+- Symlink targets remain intentionally unread, and a separate multimodal file-replacement race is not fixed here.
+- The improvement from incremental maintenance varies by index and workload, while full publication and retry policy remain unchanged.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Retrieval Settings and Embedding Providers">
+
+Running `openclaw doctor --fix` on an older configuration no longer silently drops an agent's knowledge paths or session-memory choices and falls back to global defaults. Custom OpenAI-compatible embedding providers can also resolve a saved API-key or bearer-token profile before indexing or search, while invalid or unavailable bindings stop before a network request rather than selecting a different credential.
+
+The packaged local path is less fragile too. The official Linux x64 Docker image now includes the runtime needed for managed llama.cpp embeddings to pass their executable preflight, and malformed Amazon Bedrock embedding responses produce a clear error instead of being accepted through replacement decoding.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -563,21 +788,64 @@ Memory also holds onto the right owner and history through more of its lifecycle
 - Reject malformed Amazon Bedrock embedding-response encoding ([#133716](https://github.com/openclaw/openclaw/pull/133716)). Thanks @RileyJJY.
 - Include the managed llama.cpp runtime prerequisite in the Linux x64 Docker image ([#134532](https://github.com/openclaw/openclaw/pull/134532)). Thanks @chelsealong, @henrique-simoes.
 - Resolve saved API-key and bearer-token profiles for compatible embedding providers ([#134744](https://github.com/openclaw/openclaw/pull/134744)). Thanks @0x-Parzival.
+- Preserve each agent's memory-search settings during legacy Doctor upgrades ([#134760](https://github.com/openclaw/openclaw/pull/134760)). Thanks @obviyus, @vdruts.
 - Route OpenAI-compatible memory embeddings through matching environment proxies ([#134858](https://github.com/openclaw/openclaw/pull/134858)). Thanks @Artemeey, @obviyus, @XIYBHK.
+
+**Limits and compatibility**
+
+- Managed llama.cpp support here is limited to Linux x64, and this repair does not add managed ARM64 support.
+- Saved profiles apply to compatible embedding APIs, while literal and blank keys retain their existing behavior.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Visible Recall Outcomes">
+
+On eligible private-chat turns, Active Memory now tells the main model when deep recall was intentionally skipped or unavailable, so an absent lookup is not mistaken for a successful search that found nothing relevant. The note stays bounded and leaves provider errors and sensitive search details out of model context.
+
+Memory Core Dreaming also carries an explicitly selected agent through deep consolidation in multi-agent setups, letting recalled facts consolidate under the right owner instead of silently falling back to append-only storage. When no owner is available, that safer append-only fallback remains.
+
+Embedded session recall now reopens history around the selected search result, including retained pre-reset history, instead of dropping the reader at unrelated newest messages.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
 - Keep deep memory consolidation attached to its selected agent ([#135166](https://github.com/openclaw/openclaw/pull/135166)). Thanks @zhangguiping-xydt, @obviyus, @giangthb.
 - Tell the model when Active Memory recall was skipped or unavailable ([#135193](https://github.com/openclaw/openclaw/pull/135193)). Thanks @Alix-007, @obviyus, @wave-workflow.
-- Release recovered transcript text when its chat view closes ([#135326](https://github.com/openclaw/openclaw/pull/135326)).
-- Publish recoverable transcript archives for sessions with unusually long IDs ([#136171](https://github.com/openclaw/openclaw/pull/136171)). Thanks @efe-arv, @liri-ha, @obviyus.
-- Release retired session metadata after short Gateway listings ([#136567](https://github.com/openclaw/openclaw/pull/136567)).
-- Avoid false critical memory-pressure alerts on small Gateway hosts ([#136641](https://github.com/openclaw/openclaw/pull/136641)). Thanks @vincentkoc.
 - Reopen embedded session history around the selected search result ([#136657](https://github.com/openclaw/openclaw/pull/136657)).
 
 **Limits and compatibility**
 
-- Managed local llama.cpp support here is limited to Linux x64, while remote embedding behavior, cost, and proxy routing remain specific to the configured provider.
-- Active Memory outcome notes apply to eligible private-chat turns, and timeout-budget alignment remains unchanged.
-- Embedded missing-anchor handling for externally imported CLI history and a possible large-store archive-query limit remain outside these repairs.
-- Transcript and session-listing changes do not establish lower ordinary idle memory, lower process-wide peak memory, or universal performance gains.
+- Active Memory outcome notes apply to eligible private-chat turns, and timeout-budget alignment remains unimplemented.
+- Deep consolidation under an explicit owner is limited to Memory Core Dreaming in multi-agent setups.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Memory Capture in Long Conversations">
+
+LanceDB auto-capture now keeps its place when a long conversation is compacted, avoids embedding facts it has already handled, serializes overlapping capture for the same conversation, and lets in-flight automatic capture finish before the plugin closes. New facts are less likely to disappear behind retained messages after compaction.
+
+Large transcript scans can begin processing without first retaining every message payload, while each active chat view owns the recovered full text it needs and releases that text when the view closes. Split panes keep their own valid content, so closing one does not strip the conversation from another that is still open.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve LanceDB auto-capture progress through compaction and shutdown ([#131329](https://github.com/openclaw/openclaw/pull/131329)). Thanks @hartmark.
+- Release recovered transcript text when its chat view closes ([#135326](https://github.com/openclaw/openclaw/pull/135326)).
+- Publish recoverable transcript archives for sessions with unusually long IDs ([#136171](https://github.com/openclaw/openclaw/pull/136171)). Thanks @efe-arv, @liri-ha, @obviyus.
+- Release retired session metadata after short Gateway listings ([#136567](https://github.com/openclaw/openclaw/pull/136567)).
+
+**Limits and compatibility**
+
+- The shutdown guarantee covers automatic capture, not explicit memory tools or automatic recall, and completed-text history remains bounded.
+- Transcript handling does not establish lower ordinary idle memory, lower peak process memory, or faster scan latency.
 
 </details>
 
@@ -587,31 +855,54 @@ Memory also holds onto the right owner and history through more of its lifecycle
 
 ## Skills
 
-Skills now belong more naturally to the person doing the work. Signed-in teammates on a shared Gateway can keep their own libraries and share them deliberately without handing over edit rights, while local agents can work in a real project directory without moving their managed instructions or memory. The work around those skills also keeps more of its identity and history intact, so a handoff, restart, or tool follow-up is less likely to quietly become a different task.
+Skills are becoming something a team can own without turning the host into a ticket queue. People sharing a Gateway can keep their own libraries, share work deliberately, and carry the exact selected revision into the session that needs it, while overwrites, policy failures, and optional runtime dependencies leave clearer recovery paths.
 
 <AccordionGroup>
 
-<Accordion title="Personal skill libraries, identity, and safe guidance">
+<Accordion title="Personal Skill Libraries for Shared Teams">
 
-[Skills](/tools/skills) can now live in private libraries for each signed-in teammate on a shared Gateway. People can create, import, revise, and reuse complete skill bundles without host access, choose when to share them, and transfer ownership when a skill becomes team work. The selected revision, supporting files, and executable permissions follow the session through handoffs, restarts, and supported local, sandbox, cloud, or node-worker placement, so the worker receives the skill that was actually chosen rather than whichever copy happens to be newest.
+Signed-in teammates on a shared Gateway can create, import, update, and reuse skills without host access. A library starts private, sharing does not hand over edit rights, and ownership can move to a team when the skill itself becomes shared work, so routine authoring no longer has to pass through an administrator.
 
-Finding and changing the intended skill is safer too. An exact skill name now wins over a metadata alias, ambiguous aliases stop instead of silently choosing one, and Skill Workshop carries the resolved canonical name through revisions. Claude migration also backs up the whole generated skill before an explicit overwrite and leaves the target untouched when the source has disappeared.
-
-Bundled diagnosis and channel-setup guidance now keeps its first pass read-only, uses supported commands, and identifies Telegram senders by numeric user ID. Obsolete file-search guidance for conversation recall is gone as well, leaving the native visibility-scoped session tools as the supported route. These guidance changes do not grant new authority or loosen existing access rules.
+ZIP imports now reserve room across profiles as well. One person with many unfinished uploads cannot occupy every pending slot, while existing uploads can still finish and linked or merged identities continue to share one allowance. Each session also keeps the immutable skill revision that was selected, including its supporting files and executable permissions, as work moves through local, sandbox, cloud, or node workers.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Give signed-in teammates private, shareable personal skill libraries ([#134068](https://github.com/openclaw/openclaw/pull/134068)). Thanks @RomneyDa.
+- Give signed-in teammates private, shareable skill libraries ([#134068](https://github.com/openclaw/openclaw/pull/134068)). Thanks @RomneyDa.
+
+**Bug fixes**
+
+- Reserve personal-skill ZIP-import capacity across profiles ([#135593](https://github.com/openclaw/openclaw/pull/135593)).
+
+**Limits and compatibility**
+
+- Revision delivery preserves the existing solo workspace-skills workflow and stays within one trusted Gateway domain.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Skill Editing, Migration, and Runtime Checks">
+
+Claude migration can overwrite a generated skill without making local edits disposable. `migrate apply claude --overwrite` now backs up the whole target skill directory, records the recovery path even if a later write fails, and checks that the command source still exists before changing the target.
+
+The surrounding runtime reports and installs are more truthful too. Source-run Gateways can load compiled OpenAI and Memory Core plugins again, context-free harness checks distinguish allowlist, denylist, and disabled-plugin policy from a missing installation, and copied hook packs attempt the optional runtime packages their handlers need.
+
+Exact skill names now open and update the intended skill while ambiguous aliases fail instead of silently selecting another one. Bundled diagnosis and channel guidance stays read-only by default and conversation recall uses the supported visibility-scoped session tools.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
 - Back up an overwritten generated skill before Claude migration ([#134302](https://github.com/openclaw/openclaw/pull/134302)). Thanks @PollyBot13.
+- Restore compiled plugin loading in source Gateways ([#135077](https://github.com/openclaw/openclaw/pull/135077)).
+- Explain allowlist, denylist, and disabled-plugin harness failures accurately ([#135206](https://github.com/openclaw/openclaw/pull/135206)). Thanks @fuller-stack-dev, @goslingmanagment.
+- Install optional hook-pack runtime dependencies when npm can provide them ([#136050](https://github.com/openclaw/openclaw/pull/136050)).
 - Preserve canonical skill names and reject ambiguous aliases during discovery and Workshop updates ([#136495](https://github.com/openclaw/openclaw/pull/136495)).
 - Retire obsolete file-based conversation-recall guidance in favor of native session tools ([#136615](https://github.com/openclaw/openclaw/pull/136615)). Thanks @jetd1.
-- Reserve personal-skill ZIP-import capacity across profiles ([#135593](https://github.com/openclaw/openclaw/pull/135593)).
 
 **Documentation**
 
@@ -619,59 +910,7 @@ Bundled diagnosis and channel-setup guidance now keeps its first pass read-only,
 
 **Limits and compatibility**
 
-- Personal libraries are for signed-in teammates within one trusted Gateway domain, not hostile-tenant isolation, and sharing a skill does not grant editing rights.
-- Pending ZIP imports remain capped at 16 per canonical profile within 32 per Gateway, expire after one hour, and existing over-limit uploads can still finish.
-- Exact-name resolution does not rewrite pending drafts, and conversation recall remains bound by existing session visibility. The separate embedded-history anchor defect is not fixed here.
-- The diagnosis and setup edits change instructions only. They do not alter runtime authorization, repairs, access policy, or migration safeguards.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Agent workspaces, session continuity, and tool follow-up">
-
-Local agents can now use a configured project directory from [agent settings](/gateway/config-agents#agentsdefaultscwd) for their tools and deliverables while keeping instructions and memory in OpenClaw's managed workspace. Existing setups keep their old behavior until a separate directory is configured, which makes it possible to point an agent at a real repository without turning that repository into its identity.
-
-Supervised Codex Chats can use **Fork from here** on newer canonical messages, keep their native conversation history through a Gateway restart, and open the selected input as an unsent draft without changing the source conversation. Supporting session repairs keep nested writes in order, bound malformed ancestry instead of hanging, and stop an older local CLI recovery attempt from replacing the newer session.
-
-The tools around that work explain what happens next more accurately. Background commands tell Code Mode how to retrieve their eventual output, developing tool loops reach the agent before critical blocking, and completed fallback reports on the covered CLI path cannot launch the delegated work again. Final results retain successful document analysis, report real terminal outcomes, clear stale nested-tool summaries, and identify policy or agent ownership without inventing a successful result.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Preserve native history when supervised Codex Chats fork canonical messages ([#134660](https://github.com/openclaw/openclaw/pull/134660)). Thanks @kevin2966n.
-- Let local agents work in a configured project directory while retaining their managed workspace ([#135080](https://github.com/openclaw/openclaw/pull/135080)).
-
-**Bug fixes**
-
-- Keep nested session writes in their expected order ([#131456](https://github.com/openclaw/openclaw/pull/131456)). Thanks @gaoanze888, @Grynn.
-- Return bounded context for cyclic session ancestry ([#131567](https://github.com/openclaw/openclaw/pull/131567)). Thanks @igs-rogenlo.
-- Tell background commands how to retrieve their eventual output ([#132756](https://github.com/openclaw/openclaw/pull/132756)). Thanks @sashankh, @shad0wca7.
-- Show real failure codes and signals for authorized chat bash commands ([#133414](https://github.com/openclaw/openclaw/pull/133414)). Thanks @MoerAI.
-- Retain successful PDF and image analysis in Code Mode and Tool Search ([#135037](https://github.com/openclaw/openclaw/pull/135037)).
-- Restore compiled OpenAI and Memory Core plugin loading in source Gateways ([#135077](https://github.com/openclaw/openclaw/pull/135077)).
-- Finish subagent cleanup when plugin-runtime setup or completion hooks fail ([#135098](https://github.com/openclaw/openclaw/pull/135098)).
-- Show developing tool-loop warnings to the agent before critical blocking ([#135103](https://github.com/openclaw/openclaw/pull/135103)).
-- Stop stale local CLI recovery from replacing a newer session ([#135168](https://github.com/openclaw/openclaw/pull/135168)). Thanks @mushuiyu886, @obviyus.
-- Explain allowlist, denylist, and disabled-plugin harness blockers accurately ([#135206](https://github.com/openclaw/openclaw/pull/135206)). Thanks @fuller-stack-dev, @goslingmanagment.
-- Finalize accepted nested-tool summaries and clear stale presentation state ([#135398](https://github.com/openclaw/openclaw/pull/135398)).
-- Use the selected agent for explicit-fleet status and internal diagnostics ([#135447](https://github.com/openclaw/openclaw/pull/135447)). Thanks @Hansen1018, @abacha.
-- Attempt optional hook-pack runtime dependencies during copied installs ([#136050](https://github.com/openclaw/openclaw/pull/136050)).
-
-**Security and trust**
-
-- Keep completed CLI fallback reports from launching delegated work again on the covered report-only path ([#115405](https://github.com/openclaw/openclaw/pull/115405)). Thanks @MertBasar0.
-- Newly agent-visible media analysis on compact Code Mode and Tool Search paths retains an unresolved review concern around the existing untrusted-content wrapper.
-
-**Limits and compatibility**
-
-- Separate working directories apply only to supported unsandboxed runs. Session-created directories take precedence, paired and connected-agent sessions retain node-owned directories, and there is no per-message directory option.
-- Canonical-message forks require recorded native provenance, and older canonical messages plus creator-required sandbox configurations remain unsupported. The prepared proof covers local macOS acceptance rather than every managed Desktop, Windows, crash, or multiwriter path.
-- The report-only delegation gate covers CLI-backed fallback producers and the Gateway loopback route. It does not cover primary auto-reply CLI dispatch, the subscription-auth CLI orchestrator, or peer-conversation policy.
-- Background-command guidance fixes the producer side only. Wait-side ID diagnostics and the other reported dead ends remain separate.
-- Compiled plugin loading is scoped to source Gateway runs, while optional hook packages are attempted rather than guaranteed to install. Harness policy diagnostics do not install, enable, trust, or probe a plugin.
+- Compiled plugin loading is scoped to source Gateway runs, and optional hook packages are attempted rather than guaranteed to install.
 
 </details>
 
@@ -681,19 +920,15 @@ The tools around that work explain what happens next more accurately. Background
 
 ## Native Apps
 
-The native apps take two visible steps forward in this release. [Android](/platforms/android) gets a much fuller everyday workspace for chat, sessions, navigation, and appearance, while Android, [iPhone and iPad](/platforms/ios), and [macOS](/platforms/macos) can now turn Mermaid source into readable diagrams inside the conversation. Around those larger changes, reconnects do a better job of preserving what already happened, voice work stays with the turn that started it, and several platform-specific setup and helper paths recover more cleanly.
+The native apps take two visible steps forward in this release. [Android](/platforms/android) gets a much fuller everyday workspace for chat, sessions, navigation, and appearance, while Android, [iPhone and iPad](/platforms/ios), and [macOS](/platforms/macos) can turn Mermaid source into readable diagrams inside the conversation. Around those larger changes, reconnects hold on to accepted work, voice stays with the turn that started it, and several platform-specific setup and helper paths handle failure more cleanly.
 
 <AccordionGroup>
 
-<Accordion title="Android chat, diagrams, and reconnect recovery">
+<Accordion title="Android’s Fuller Everyday Workspace">
 
 The Android app now brings the pieces people reach for during a normal conversation into one more complete native experience. The composer has a full-width writing area with compact actions, model names remain readable, and searchable controls expose models, effort, Fast Mode, and permissions without crowding the transcript. Sessions can be browsed or created from the native catalog, the sidebar can be arranged around the places you use, and theme families and accents stay with the correct profile through offline changes, reconnects, and app recreation.
 
-Mermaid diagrams now render locally inside Android chat instead of stopping at raw source, with copy, retry, source, and sharp full-screen zoom and pan controls that keep working offline. Streaming, invalid, oversized, or temporarily failed diagrams remain readable as source, and the controls and recovery guidance are available across the supported locales. The diagram interaction was verified with an emulator rather than physical Android hardware, and the separate foldable-keyboard clipping report remains open.
-
-The rest of the work makes everyday chat harder to knock off course. Longer drafts can grow to six visible lines, guided setup under Settings → OpenClaw follows new replies without stealing an older reading position, and New chat shows its own progress while blocking duplicate creation. Android also gives people an explicit voice-note option when on-device dictation is unavailable, and warns before sending with an explicitly selected model whose authentication is unavailable. That model check still depends on availability reported by a connected Gateway and does not cover the Default selection path.
-
-Reconnect and refresh ownership is tighter throughout. The replacement Gateway connection stays in charge while older cleanup settles, acknowledged offline messages move beyond Sending, a newly created chat remains selected, and a deleted queued message stays deleted even when an older refresh returns late. Refresh rechecks Gateway health while preserving queued work, and newer chat, appearance, settings, and session choices no longer lose to stale work. Most of these paths were proven with emulators, previews, or isolated native owners rather than a complete physical-device and network matrix.
+That work also keeps the app usable on narrow screens and with larger text, and it gives an actionable Providers and Models route before sending with an explicitly selected model whose authentication is unavailable. That check still follows the availability reported by the connected Gateway and is scoped to explicitly selected models.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -701,22 +936,56 @@ Reconnect and refresh ownership is tighter throughout. The replacement Gateway c
 **Improvements**
 
 - Bring Android chat, sessions, the sidebar, and appearance closer to the browser workspace ([#134939](https://github.com/openclaw/openclaw/pull/134939)). Thanks @IWhatsskill, @obviyus.
-- Render Mermaid diagrams locally in Android chat with source, retry, copy, and full-screen controls ([#135342](https://github.com/openclaw/openclaw/pull/135342)).
-- Localize Android Mermaid controls, progress, and recovery guidance across supported locales ([#135600](https://github.com/openclaw/openclaw/pull/135600)).
 - Let Android chat drafts grow to six visible lines before scrolling ([#135923](https://github.com/openclaw/openclaw/pull/135923)). Thanks @BennyAI2.
-- Refresh current session, permission, Fast Mode, pinning, diagram, and status translations across the native apps ([#136304](https://github.com/openclaw/openclaw/pull/136304)).
 
 **Bug fixes**
 
 - Explain authentication problems before sending with an explicitly selected unavailable model ([#134884](https://github.com/openclaw/openclaw/pull/134884)). Thanks @fuller-stack-dev.
-- Keep drafts and chat controls readable on narrow or large-text layouts and recover overlapping reconnect history ([#135432](https://github.com/openclaw/openclaw/pull/135432)). Thanks @KangBumS.
-- Refresh Android camera, image, and diagram libraries and include all packaged license notices ([#135563](https://github.com/openclaw/openclaw/pull/135563)).
-- Preserve Android chat and pairing state through the Room update and accept the highest valid Unicode input in KaTeX ([#135670](https://github.com/openclaw/openclaw/pull/135670)).
-- Offer voice-note recording when Android dictation is unavailable without losing the draft ([#135794](https://github.com/openclaw/openclaw/pull/135794)). Thanks @RaviTharuma.
+- Keep drafts and chat controls readable on narrow or large-text layouts ([#135432](https://github.com/openclaw/openclaw/pull/135432)). Thanks @KangBumS.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Mermaid Diagrams Across Android, iOS, and macOS">
+
+Mermaid diagrams no longer have to be read as raw code in supported native chats. Android and iOS render completed diagrams inline with source, copy, retry, and expanded-preview controls, while macOS brings diagrams to both full chat and Quick Chat and keeps that window open while a larger preview is in use. Each app keeps readable source for streaming, invalid, oversized, or temporarily failed diagrams instead of replacing it with an empty box.
+
+Rendering stays local rather than depending on a network diagram service. Android offers a sharp full-screen view with zoom and pan, iOS adds an offline-capable vector preview with zoom, pan, and rotation, and macOS uses compact desktop controls with native Close and Escape behavior. The exact controls follow each platform rather than pretending the three implementations are identical.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Render Mermaid diagrams in Android chat with source, retry, and full-screen controls ([#135342](https://github.com/openclaw/openclaw/pull/135342)).
+- Render Mermaid diagrams in iOS chat with an offline-capable vector preview ([#135470](https://github.com/openclaw/openclaw/pull/135470)).
+- Localize Android Mermaid controls and recovery guidance across supported locales ([#135600](https://github.com/openclaw/openclaw/pull/135600)).
+- Render Mermaid diagrams in macOS full chat and Quick Chat while preserving equations and preview ownership ([#135746](https://github.com/openclaw/openclaw/pull/135746)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Reconnects, Retries, and Queued Messages">
+
+Android now keeps the replacement Gateway connection in charge while an older connection finishes shutting down, so retired cleanup is less likely to publish a false offline state or discard an accepted request outcome. Messages acknowledged after reconnect move past Sending, a new conversation remains selected for the next message, later queued sends keep moving, and a queued message you delete stays gone even if an older refresh finishes afterward.
+
+The same ownership cleanup reaches other native conversation paths. Apple chat can retry immediately after a session-settings failure, iPhone history refreshes reconcile a streamed reply with its canonical transcript row instead of leaving an older duplicate, and native session progress cards retain the selected agent and workspace context.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Make Retry Send available immediately after Apple session-settings failures ([#134752](https://github.com/openclaw/openclaw/pull/134752)).
+- Keep the selected agent and workspace on native session progress cards ([#135426](https://github.com/openclaw/openclaw/pull/135426)). Thanks @obviyus, @rwinkelman, @Synthetic2802.
+- Remove stale duplicate iPhone replies after history refresh or cache restore ([#135789](https://github.com/openclaw/openclaw/pull/135789)).
 - Keep replacement Android Gateway connections authoritative during reconnect cleanup ([#135878](https://github.com/openclaw/openclaw/pull/135878)).
 - Advance acknowledged Android messages beyond Sending after reconnect ([#135961](https://github.com/openclaw/openclaw/pull/135961)).
 - Keep new Android conversations selected and later queued sends moving ([#136078](https://github.com/openclaw/openclaw/pull/136078)).
 - Stop deleted Android queued messages from returning after a delayed refresh ([#136161](https://github.com/openclaw/openclaw/pull/136161)).
+- Open an existing iPhone chat at its newest response ([#135429](https://github.com/openclaw/openclaw/pull/135429)).
 - Preserve selected chats and newer appearance or settings state across archives, agent switches, and reconnects ([#136173](https://github.com/openclaw/openclaw/pull/136173)). Thanks @Kaneki-x, @aniruddhaadak80.
 - Recheck Android Gateway health when Refresh overlaps a queued send ([#136413](https://github.com/openclaw/openclaw/pull/136413)).
 - Keep the Android guided-setup conversation at the intended reading position and follow new replies when appropriate ([#136550](https://github.com/openclaw/openclaw/pull/136550)).
@@ -726,66 +995,131 @@ Reconnect and refresh ownership is tighter throughout. The replacement Gateway c
 
 </Accordion>
 
-<Accordion title="Apple chat, voice, Watch, and background work">
+<Accordion title="Voice Ownership Across Native Apps">
 
-On iPhone, iPad, and Mac, Mermaid diagrams now become readable native chat content without depending on a network rendering service. iOS adds inline diagrams with source, copy, retry, and an expanded vector view with zoom, pan, and rotation, while macOS brings diagrams to full chat and Quick Chat with desktop controls that keep Quick Chat open around the preview. Incomplete, invalid, oversized, or failed diagrams remain readable as source. The iOS path was not tested on a physical iPhone, and physical Mac trackpad pinch-to-zoom remained unverified.
+Talk and realtime voice now carry the acknowledged agent, run, and reply through the clients involved in the conversation, which keeps a consult on the intended agent, prevents an unrelated newer chat reply from being read back, and makes Stop target the work that actually started. Host cancellation is also reported as cancellation instead of a tool failure while the voice call remains open.
 
-Apple chat is easier to control around those diagrams too. iPhone dashboards open directly at phone width, reopened chats land at the newest response, refreshed history no longer leaves a stale duplicate answer, and assistant text can be selected normally while message actions remain available. The iOS model picker explains whether a choice changes the session, agent, or global default and blocks choices or live sends only when the connected Gateway has authoritative permanent-authentication information. On Mac, the full chat window gets a cleaner two-row composer that keeps its important controls available in narrow windows, while failed AI setup once again reveals the rejected key, error, and retry path.
+On Apple Watch, dictated messages, spoken replies, playback, and retries remain attached to their original chat, and a spoken reply that outlasts the Watch’s wait points the user back to Chat on iPhone. Android offers an explicit voice-note recording path when on-device dictation is unavailable without discarding the draft, while macOS reuses a compatible speech recognizer, keeps the Talk overlay visible through a quick toggle, and packages the resources required by local MLX speech. The recognizer change removes one source of avoidable churn, but it does not establish that the broader open Apple speech-service memory report is fully fixed.
 
-Background work now behaves more like background work. A New Session task started from the macOS app can post a generic native completion notice and reopen the exact finished session, including when a fast task completes before the dashboard receives notification status. This requires notification permission that was already granted and the originating dashboard to remain loaded, does not prompt for permission, and suppresses the notice when that session is already being viewed. The Mac status menu also stops its own Devices and Automations polling after it closes while an open Cron Jobs settings pane keeps its separate refresh, and embedded web pages can be widened beyond half the app window while the dashboard uses compact navigation.
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
 
-Voice and Watch work keeps the original turn in charge for longer. Talk consults retain the Gateway-approved agent and run through completion, history, and Stop, iOS realtime voice waits for its own reply, and cancelled Apple node requests stop before starting new notifications, Watch transfers, speech, or overlays. Apple Watch dictation, spoken replies, playback, and retries stay attached to their original chat, and a Watch that stops waiting after 90 seconds points the user to Chat on iPhone without cancelling the underlying run. Revoked or replaced Watch connections can no longer collect new commands or return late results. These Watch paths were not verified on physical Watch hardware, and the Talk and realtime voice proofs used synthetic or isolated transports rather than complete microphone and speaker sessions.
+**Bug fixes**
 
-The supporting native and desktop paths are narrower but still useful. Packaged local MLX speech includes its required resources, compatible macOS speech recognizers are reused while the language is unchanged, helper pipes preserve short readiness messages and final diagnostics, and private node workers exit after owned cleanup. Linux first-run setup again exposes the remote-Gateway choice without requiring a local CLI, paired-node Claude runs can use native Claude Code login when forwarded credentials are blank, Windows worker turns release their temporary state normally, and SSH worker desktops avoid overlong Unix-socket paths. Those fixes retain their platform boundaries and do not establish broad physical-device, provider, Wayland, Windows-GUI, or signed-distribution coverage.
+- Keep Voice Call sessions open when host work is cancelled and settle tool failures once ([#134924](https://github.com/openclaw/openclaw/pull/134924)).
+- Preserve the acknowledged agent and run across Talk consults, history, and Stop ([#135031](https://github.com/openclaw/openclaw/pull/135031)). Thanks @astra-openclaw.
+- Reuse compatible macOS speech recognizers across repeated voice captures ([#135401](https://github.com/openclaw/openclaw/pull/135401)). Thanks @Colton-Harris.
+- Package the resources required by local MLX speech on macOS ([#135592](https://github.com/openclaw/openclaw/pull/135592)).
+- Keep Apple Watch replies, playback, and retries with their original voice turn ([#135697](https://github.com/openclaw/openclaw/pull/135697)).
+- Preserve the macOS Talk overlay through quick toggles ([#135731](https://github.com/openclaw/openclaw/pull/135731)). Thanks @HuzaifaChaudary.
+- Explain when Apple Watch stops waiting to speak a reply ([#135765](https://github.com/openclaw/openclaw/pull/135765)).
+- Offer voice-note recording when Android dictation is unavailable without losing the draft ([#135794](https://github.com/openclaw/openclaw/pull/135794)). Thanks @RaviTharuma.
+- Keep iOS realtime voice consults attached to their own replies ([#135795](https://github.com/openclaw/openclaw/pull/135795)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Apple App Setup, Chat Controls, and Watch Authorization">
+
+macOS onboarding now brings failed AI setup, rejected-key details, and the retry action back into view instead of leaving someone stranded between setup and chat. Once inside chat, a cleaner two-row composer keeps context, model, effort, voice, send, attachment, branch, and verbosity controls reachable in narrow windows without duplicating model and usage details in the toolbar.
+
+iOS now explains whether a model choice changes the current session, the agent default, or the global default, and it blocks unavailable choices or permanent authentication failures before a live send while still allowing offline queueing and temporary cooldowns. Localization coverage catches more dynamic macOS text and newer Apple controls, while a revoked or replaced Watch connection can no longer receive another command or submit a late result through the retired connection.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Refresh Apple interface translations and correct the Hindi used-versus-total token counter ([#134627](https://github.com/openclaw/openclaw/pull/134627)).
-- Render Mermaid diagrams locally in iOS chat with source, retry, copy, and an expanded vector preview ([#135470](https://github.com/openclaw/openclaw/pull/135470)).
-- Localize Apple model sign-in, credential, cooldown, and default-selection messages ([#135543](https://github.com/openclaw/openclaw/pull/135543)).
-- Refresh compatible desktop-companion dependencies and local-service discovery behavior while retaining the Windows updater pin ([#135557](https://github.com/openclaw/openclaw/pull/135557)).
+- Refresh localized native labels and correct the Hindi token-usage counter ([#134627](https://github.com/openclaw/openclaw/pull/134627)).
+- Add supported-locales coverage for newer Apple model setup and status messages ([#135543](https://github.com/openclaw/openclaw/pull/135543)).
 - Keep essential macOS chat controls accessible in a cleaner narrow-window composer ([#135608](https://github.com/openclaw/openclaw/pull/135608)).
-- Render Mermaid diagrams in macOS full chat and Quick Chat with readable source fallbacks ([#135746](https://github.com/openclaw/openclaw/pull/135746)).
-- Translate the macOS background-session opening error and retire obsolete Android locale strings ([e975bce](https://github.com/openclaw/openclaw/commit/e975bce03d998e3a0d12ff43fa01b0beec72d46a)).
 - Translate iOS session-dashboard labels and Gateway connection guidance across supported locales ([#136438](https://github.com/openclaw/openclaw/pull/136438)).
 
 **Bug fixes**
 
-- Open published iOS session dashboards directly at phone width with complete scrolling ([#132983](https://github.com/openclaw/openclaw/pull/132983)). Thanks @fuller-stack-dev.
-- Make Retry Send available immediately after Apple session-settings failures ([#134752](https://github.com/openclaw/openclaw/pull/134752)).
 - Reveal macOS onboarding failures and restore immediate setup retries ([#134756](https://github.com/openclaw/openclaw/pull/134756)).
-- Close Windows worker state before removing its runtime directory ([#134911](https://github.com/openclaw/openclaw/pull/134911)).
-- Keep Voice Call sessions open when host work is cancelled and settle synchronous tool failures once ([#134924](https://github.com/openclaw/openclaw/pull/134924)).
-- Preserve native Claude Code login when paired-node credentials are blank ([#134932](https://github.com/openclaw/openclaw/pull/134932)). Thanks @rockytanf.
-- Preserve the acknowledged agent and run across Talk consults, history, and Stop ([#135031](https://github.com/openclaw/openclaw/pull/135031)). Thanks @astra-openclaw.
 - Explain iOS model-selection scope and block unavailable authenticated sends ([#135044](https://github.com/openclaw/openclaw/pull/135044)). Thanks @fuller-stack-dev, @goslingmanagment.
-- Report native Gateway timeouts only when the timeout actually wins ([#135287](https://github.com/openclaw/openclaw/pull/135287)).
-- Reuse compatible macOS speech recognizers across repeated voice captures ([#135401](https://github.com/openclaw/openclaw/pull/135401)). Thanks @Colton-Harris.
-- Keep the selected agent and workspace on native session progress cards ([#135426](https://github.com/openclaw/openclaw/pull/135426)). Thanks @obviyus, @rwinkelman, @Synthetic2802.
-- Open an existing iPhone chat at its newest response ([#135429](https://github.com/openclaw/openclaw/pull/135429)).
+- Open published iOS session dashboards directly at phone width with complete scrolling ([#132983](https://github.com/openclaw/openclaw/pull/132983)). Thanks @fuller-stack-dev.
 - Preserve standard text selection and message actions for iOS assistant responses ([#135430](https://github.com/openclaw/openclaw/pull/135430)). Thanks @Solvely-Colin, @nikolaihack.
-- Keep SSH worker desktops working when the host temporary path is too long, on supported Unix hosts ([#135456](https://github.com/openclaw/openclaw/pull/135456)). Thanks @ly85206559.
-- Package the resources required by local MLX speech on macOS ([#135592](https://github.com/openclaw/openclaw/pull/135592)).
-- Restore Linux first-run local and remote Gateway choices without requiring the CLI ([#135650](https://github.com/openclaw/openclaw/pull/135650)).
-- Let private node workers exit after successful owned cleanup ([#135665](https://github.com/openclaw/openclaw/pull/135665)). Thanks @Colton-Harris, @obviyus.
-- Keep Apple Watch replies, playback, and retries with their original voice turn ([#135697](https://github.com/openclaw/openclaw/pull/135697)).
-- Preserve the macOS Talk overlay through quick toggles ([#135731](https://github.com/openclaw/openclaw/pull/135731)). Thanks @HuzaifaChaudary.
-- Explain when Apple Watch stops waiting to speak a reply without cancelling the chat run ([#135765](https://github.com/openclaw/openclaw/pull/135765)).
-- Remove stale duplicate iPhone replies after history refresh or cache restore ([#135789](https://github.com/openclaw/openclaw/pull/135789)).
-- Keep iOS realtime voice consults attached to their own replies ([#135795](https://github.com/openclaw/openclaw/pull/135795)).
 - Stop cancelled or replaced Apple node requests before they start new native side effects ([#135796](https://github.com/openclaw/openclaw/pull/135796)).
 - Let macOS embedded web pages expand beyond half the app window ([#136168](https://github.com/openclaw/openclaw/pull/136168)).
-- Preserve short readiness messages and final diagnostics across macOS helper pipes ([#136214](https://github.com/openclaw/openclaw/pull/136214)).
-- Notify when macOS background sessions finish and reopen the exact completed session ([#136519](https://github.com/openclaw/openclaw/pull/136519)).
-- Stop menu-owned Devices and Automations polling after the macOS status menu closes ([#136572](https://github.com/openclaw/openclaw/pull/136572)).
-- Deliver fast macOS background-session completions to the existing native notification owner ([#136683](https://github.com/openclaw/openclaw/pull/136683)).
 
 **Security and trust**
 
-- Stop revoked or replaced Apple Watch connections from receiving work or returning late results ([#135904](https://github.com/openclaw/openclaw/pull/135904)).
+- Stop revoked or replaced Watch connections from receiving work or returning late results ([#135904](https://github.com/openclaw/openclaw/pull/135904)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Desktop Setup and Remote Work">
+
+Fresh Linux desktop installs can again choose a Gateway on another computer before installing a local CLI, while local setup keeps its existing installer path. The desktop companion also receives a compatible local-discovery refresh, with its Windows updater deliberately held on the earlier version until an upstream cleanup conflict is resolved.
+
+Remote and supervised work recovers in a few narrower places as well. Paired-node Claude runs can fall back to the node’s native Claude login when forwarded credentials are blank, SSH worker desktops avoid Unix-socket failures caused by long temporary paths, and completed Windows worker turns close their owned state before removing the runtime directory so the slot can be reclaimed normally.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Refresh compatible desktop-companion dependencies and local discovery behavior ([#135557](https://github.com/openclaw/openclaw/pull/135557)).
+
+**Bug fixes**
+
+- Close Windows worker state before removing its runtime directory ([#134911](https://github.com/openclaw/openclaw/pull/134911)).
+- Preserve native Claude login when paired-node credentials are blank ([#134932](https://github.com/openclaw/openclaw/pull/134932)). Thanks @rockytanf.
+- Keep SSH worker desktops working when the host temporary path is too long ([#135456](https://github.com/openclaw/openclaw/pull/135456)). Thanks @ly85206559.
+- Restore Linux first-run local and remote Gateway choices without requiring the CLI ([#135650](https://github.com/openclaw/openclaw/pull/135650)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Native Packaging and Background Helpers">
+
+Several less visible repairs keep the apps from failing around dependencies and helper processes. iOS development can resolve the available WebRTC 152 package again, Android refreshes camera, image, diagram, local-storage, and math-rendering foundations while preserving its existing database schemas and stored state, and the Licenses screen now includes the missing packaged notices.
+
+Background ownership is tighter too. Native Gateway invocations no longer report a timeout after the operation has already settled, private node workers exit after their owned cleanup even when stdin or a plugin child keeps the event loop active, and macOS helper pipes accept short readiness messages while retaining split or final diagnostics from MLX speech, SSH, node workers, computer control, and cookie sync.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Refresh current session, permission, Fast Mode, pinning, diagram, and status translations across the native apps ([#136304](https://github.com/openclaw/openclaw/pull/136304)).
+
+**Bug fixes**
+
+- Report native Gateway timeouts only when the timeout actually wins ([#135287](https://github.com/openclaw/openclaw/pull/135287)).
+- Refresh Android libraries and include missing packaged license notices ([#135563](https://github.com/openclaw/openclaw/pull/135563)).
+- Let private node workers exit after successful owned cleanup ([#135665](https://github.com/openclaw/openclaw/pull/135665)). Thanks @Colton-Harris, @obviyus.
+- Preserve Android stored state while updating Room and correct the highest valid Unicode input in KaTeX ([#135670](https://github.com/openclaw/openclaw/pull/135670)).
+- Keep macOS native helper reads bounded while preserving readiness and final diagnostics ([#136214](https://github.com/openclaw/openclaw/pull/136214)).
+- Stop menu-owned Devices and Automations polling after the macOS status menu closes ([#136572](https://github.com/openclaw/openclaw/pull/136572)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Background Session Notifications">
+
+A New Session task started from the macOS app can now post a generic native completion notice and reopen the exact finished session, including when a fast task completes before notification status reaches the dashboard. The notice requires previously granted notification permission and a loaded originating dashboard, does not prompt for permission, and stays quiet when that session is already being viewed.
+
+Localized recovery text explains when the completed session cannot be opened, while the notification handoff remains tied to the task and session that produced it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Translate the macOS background-session opening error and retire obsolete Android locale strings ([e975bce](https://github.com/openclaw/openclaw/commit/e975bce03d998e3a0d12ff43fa01b0beec72d46a)).
+
+**Bug fixes**
+
+- Notify when macOS background sessions finish and reopen the exact completed session ([#136519](https://github.com/openclaw/openclaw/pull/136519)).
+- Deliver fast macOS background-session completions to the existing native notification owner ([#136683](https://github.com/openclaw/openclaw/pull/136683)).
 
 </details>
 
@@ -795,129 +1129,207 @@ The supporting native and desktop paths are narrower but still useful. Packaged 
 
 ## Models and Providers
 
-Choosing a model now gives you a clearer picture of what will change, which account will be used, and whether the route can actually run before OpenClaw saves it. [Model selection](/concepts/models) and [provider setup](/concepts/model-providers) also stay current through more login, catalog, and settings changes without making a Gateway restart the normal way to see what you just configured.
+Choosing a model should not be an exercise in wondering what else the click changed. [Model selection](/concepts/models) now tells you whether a choice is for this session, one agent, or the global default before it is saved, while provider logins and catalog changes flow into the model list without the ritual Gateway restart. This release also tightens the less visible part of that promise, so a temporary provider failure, a quiet Codex turn, or a disconnected node is much less likely to send work down the wrong route.
 
 <AccordionGroup>
 
-<Accordion title="Model discovery, selection, authentication, and defaults">
+<Accordion title="Model Selection, Defaults, and Reasoning">
 
-The Control UI brings the main model, utility model, first fallback, thinking level, and Fast Mode into one autosaving Defaults card, while the picker explains whether a model change applies to this session, one agent, or the global default before you make it. Changing the first fallback preserves the rest of the ordered chain, choosing no fallback clears it, and the complete chain still belongs to the CLI. OpenClaw also stops a selection before it changes anything when the required harness plugin is missing, disabled, or denied, though that check does not install a plugin, grant consent, authenticate a provider, or cover the `/model` directive.
+The Control UI now gathers the main model, utility model, first fallback, thinking level, and Fast Mode in one autosaving Defaults card, with the scope of a model change shown before you make it. It preserves the rest of an ordered fallback chain when the first choice changes, and refuses to replace a working model when the required harness cannot be activated. The full fallback order still lives in the CLI, and the scope disclosure is currently a Control UI feature rather than a native-app picker feature.
 
-Provider setup is easier to verify as well. Model Setup can show whether detected Codex or Claude access comes from an account or API key and can display the email reported by that runtime without exposing keys or tokens. The provider page no longer counts unrelated tool credentials as model accounts, externally authenticated OpenAI models remain visible without a second OpenClaw login, and compatible login, credential, settings, and hot-reload changes refresh the catalog without a restart. Explicit refreshes and real provider, plugin, authentication, environment, or workspace changes can still replace that inventory, explicit provider disablement or denial still wins, and an authentication-order conflict now tells you that the credential was saved but was not promoted instead of claiming the new route is active. Doctor preserves environment-backed custom-provider secrets during repair, although some availability and picker paths may still choose a stored profile, so this is not complete credential-precedence consistency.
-
-The choices themselves expand carefully. Claude Fable 5.1 is available through the Anthropic API and Claude CLI with shared model metadata, moving the rolling Fable alias while leaving explicit Fable 5 pins intact, although native Claude CLI inference was not tested with live credentials. Supported local Ollama routes can be selected directly, while remote or explicitly credential-owned Ollama routes still require authentication. Eligible Sol and Terra Codex sessions retain Ultra across turns and supported child sessions, and configured native account models expose the reasoning levels they advertise, while Luna remains capped at Max. The hidden model used to prove that catalog repair advertised Ultra but did not complete upstream, so advertised availability is not a promise that every model will answer. Native Model Studio and DashScope routes now apply ephemeral cache markers by default and honor explicit short, long, or no-retention choices, while custom proxies remain opt-in, the embedded Chat Completions transport still lacks marker support, and no live cache hit was captured.
-
-OAuth-authenticated SuperGrok accounts can show quota, reset, plan, and balance information when xAI returns it, but API-key billing is separate, partial responses may display zero values, and no successful live OAuth billing response was captured. Anthropic Vertex Sonnet 5 estimates now use the current global and US or EU multi-region rates, which corrects OpenClaw's estimate rather than changing or proving Google billing.
+Reasoning choices now stay attached to the runtime that actually owns them. Eligible Sol and Terra turns keep Ultra through supported child-session boundaries, configured native Codex models show the effort levels their account advertises, and Luna remains capped at Max. Anthropic Fable 5.1 joins the shared API and Claude CLI catalogs, supported local Ollama routes remain selectable, and status views keep an authored context cap when a model runs through a provider alias.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Show the detected Codex or Claude sign-in method and runtime-reported account email ([#136521](https://github.com/openclaw/openclaw/pull/136521)).
-- Bring primary, fallback, utility, thinking, and Fast Mode defaults into one autosaving card ([#134813](https://github.com/openclaw/openclaw/pull/134813)). Thanks @Patrick-Erichsen.
-- Scope full catalog refreshes to the plugin runtimes that can contribute models ([#135486](https://github.com/openclaw/openclaw/pull/135486)). Thanks @zeroaltitude, @obviyus.
-- Add Claude Fable 5.1 to shared Anthropic and Claude CLI model metadata ([#135638](https://github.com/openclaw/openclaw/pull/135638)).
-- Show SuperGrok usage for OAuth-authenticated xAI accounts ([#135766](https://github.com/openclaw/openclaw/pull/135766)).
+- Bring model defaults into one autosaving card ([#134813](https://github.com/openclaw/openclaw/pull/134813)). Thanks @Patrick-Erichsen.
+- Add Anthropic Fable 5.1 to shared model metadata ([#135638](https://github.com/openclaw/openclaw/pull/135638)).
 
 **Bug fixes**
 
-- Clear stale automatic OpenAI route state without removing intentional choices ([#102180](https://github.com/openclaw/openclaw/pull/102180)). Thanks @849261680, @cpwilhelmi.
-- Finish thinking lookup and Model Setup when a catalog owner is replaced during reload ([#127284](https://github.com/openclaw/openclaw/pull/127284)). Thanks @RomneyDa, @karkarl.
-- Apply configured thinking mappings when a one-shot request omits its thinking level ([#132697](https://github.com/openclaw/openclaw/pull/132697)). Thanks @wangjx-xydt, @nina-grech.
-- Compact and retry current llama.cpp context-limit failures ([#133888](https://github.com/openclaw/openclaw/pull/133888)). Thanks @gokay-ai, @Areson.
-- Keep tool-only credentials out of the model-provider inventory ([#134218](https://github.com/openclaw/openclaw/pull/134218)). Thanks @wantosure, @beastyrabbit.
-- Refresh model catalogs after a new provider login ([#134361](https://github.com/openclaw/openclaw/pull/134361)). Thanks @obviyus.
+- Apply configured thinking mappings when a request omits `--thinking` ([#132697](https://github.com/openclaw/openclaw/pull/132697)). Thanks @wangjx-xydt, @nina-grech.
 - Show model-selection scope before saving ([#134473](https://github.com/openclaw/openclaw/pull/134473)). Thanks @fuller-stack-dev, @goslingmanagment, @Marvinthebored.
-- Avoid leaving an empty legacy Claude CLI route after activation ([#134779](https://github.com/openclaw/openclaw/pull/134779)). Thanks @leilei3167, @obviyus, @aaajiao.
-- Preserve the working model when its harness plugin cannot be activated ([#134837](https://github.com/openclaw/openclaw/pull/134837)). Thanks @goslingmanagment.
-- Retain refreshed credentials for matching custom agent directories ([#134862](https://github.com/openclaw/openclaw/pull/134862)). Thanks @Lendersmark.
-- Keep externally authenticated OpenAI models in normal model menus ([#135046](https://github.com/openclaw/openclaw/pull/135046)). Thanks @goslingmanagment.
-- Refresh model catalogs after credential and settings changes ([#135063](https://github.com/openclaw/openclaw/pull/135063)). Thanks @elikampf.
-- Honor native Model Studio cache defaults and explicit retention choices ([#135093](https://github.com/openclaw/openclaw/pull/135093)).
+- Keep the working selection when a model harness cannot activate ([#134837](https://github.com/openclaw/openclaw/pull/134837)). Thanks @goslingmanagment.
 - Keep supported local Ollama routes selectable ([#135095](https://github.com/openclaw/openclaw/pull/135095)). Thanks @obviyus, @BoatAngle.
-- Show concise, redacted ChatGPT OAuth recovery errors ([#135112](https://github.com/openclaw/openclaw/pull/135112)). Thanks @shakkernerd.
-- Auto-enable configured Google and Google Vertex provider plugins when allowed ([#135239](https://github.com/openclaw/openclaw/pull/135239)). Thanks @Solvely-Colin.
-- Retain discovered and authenticated models through compatible hot reloads ([#135353](https://github.com/openclaw/openclaw/pull/135353)). Thanks @goslingmanagment.
-- Repair stale OpenAI profile order after a successful relogin ([#135355](https://github.com/openclaw/openclaw/pull/135355)). Thanks @obviyus, @mattcbianco.
-- Preserve custom-provider SecretRefs through Doctor repair ([#135357](https://github.com/openclaw/openclaw/pull/135357)). Thanks @obviyus, @dannevang.
-- Preserve Ultra across supported Codex runtime and child-session boundaries ([#135397](https://github.com/openclaw/openclaw/pull/135397)).
-- Report when login saved a credential but could not promote its active order ([#135443](https://github.com/openclaw/openclaw/pull/135443)). Thanks @lzhan011, @obviyus.
-- Discover models behind llama.cpp-compatible web-app endpoints ([#135445](https://github.com/openclaw/openclaw/pull/135445)). Thanks @gaoanze888, @Bloodis94.
-- Keep Anthropic Vertex Sonnet 5 estimates on current regional rates ([#135761](https://github.com/openclaw/openclaw/pull/135761)).
-- Publish refreshed provider-auth priority to a running Gateway ([#135847](https://github.com/openclaw/openclaw/pull/135847)). Thanks @josephbergvinson, @obviyus, @yetval.
-- Skip unused runtime discovery for read-only catalog preparation ([#136020](https://github.com/openclaw/openclaw/pull/136020)). Thanks @609NFT, @LiuwqGit.
+- Preserve Ultra across runtimes and child sessions ([#135397](https://github.com/openclaw/openclaw/pull/135397)).
+- Report configured context caps through provider aliases ([#135580](https://github.com/openclaw/openclaw/pull/135580)). Thanks @VACInc.
 - Restore advertised reasoning choices for configured native Codex models ([#136061](https://github.com/openclaw/openclaw/pull/136061)).
 
 </details>
 
 </Accordion>
 
-<Accordion title="Provider execution, retries, native CLI sessions, and usage">
+<Accordion title="Provider Accounts and Model Catalogs">
 
-Once a model is running, recovery is now less likely to multiply the problem. Transient provider failures have one bounded retry owner, so a brief interruption can recover while a persistent one reaches normal fallback or a useful error within 90 seconds, although that fixed window can end a larger configured attempt budget early. Busy-session conflicts stop after the first candidate instead of making every fallback appear broken, hard Anthropic and Bedrock refusals stop retries and model fallback with revise-and-retry guidance, and eligible pre-output connection failures can continue after settled tools without running those tools again. That last path is limited to empty-output transient failures, two continuation attempts, and already completed tools.
+Provider state is now much closer to what you actually configured. Model Provider settings stop counting unrelated web-search and extraction credentials as model accounts, externally authenticated OpenAI models remain visible without a second login, and compatible catalog updates survive both credential changes and hot reloads. A new provider login, a settings edit, or a compatible model change can refresh the inventory when it is next requested instead of leaving the old list in place until a restart.
 
-Native coding sessions hold onto more of the work they already accepted. Quiet Codex turns keep running within their configured execution budget, where `timeoutSeconds` set to `0` remains the explicit unlimited setting, while late output cannot change an already settled result or crash the Gateway. Idle chats can resume alongside unrelated work, queued cold follow-ups retain the accepted native conversation, sub-plugin changes take effect on the next message, and long or concurrent replies pace progress so they remain connected through the final answer. None of that establishes a general speed or memory gain. Codex and Claude Code can also open from the catalog into a reconnectable terminal on an eligible local or paired host, but the completed proof covered macOS and a separately paired process on the same Mac rather than Windows, Linux, or a physically remote machine.
+The recovery path is less mysterious too. OpenAI relogin can repair stale profile order, Doctor preserves custom-provider environment references instead of turning them into broken stored keys, forced login clears the credential owner it is meant to replace, and a changed provider priority reaches a running Gateway. Google and Vertex configuration can also restore their bundled provider plugin through restrictive allowlists, while read-only catalog work and GitHub Copilot authentication avoid loading discovery or agent-runtime work they cannot use.
 
-The surrounding provider paths now fail and report more truthfully. Local and nested parents can see when a subagent completed on a different fallback model, though end-to-end non-disclosure to external destinations was not proven. Eligible OpenAI OAuth accounts can transcribe inbound voice notes and batch audio without a separate Platform API key, but access, quota, and billing remain account-specific and an upload failure does not silently switch providers. DeepInfra estimates now follow native advertised prices and discounts while leaving conditional or unavailable schedules unknown, with operator overrides still taking precedence and no change to provider billing or model availability. Linux deployments give managed local model and embedding services stronger shutdown and memory-pressure containment, while the shutdown proof is scoped to Linux and systemd, shell-controlled or carrier-collision fallback spawns do not receive the OOM preference, and provider recovery is not guaranteed. Claude CLI setup works through supported mise and asdf shims, but an argv0-dispatching shim may still choose a credential-consuming executable outside the verified runtime fingerprint, so that path retains a material security boundary.
+Ordinary model inventory browsing now reuses a prepared catalog unless authentication is stale or a refresh was explicitly requested, so lists and pickers keep discovered models through temporary discovery failures without repeating full provider discovery.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Load GitHub Copilot provider authentication without the broad agent runtime ([#134626](https://github.com/openclaw/openclaw/pull/134626)).
-- Identify OpenClaw consistently on native OpenCode Go routes ([#135588](https://github.com/openclaw/openclaw/pull/135588)). Thanks @VACInc.
-- Align managed Codex installs and release checks on 0.152.1 ([#136184](https://github.com/openclaw/openclaw/pull/136184)).
+- Load GitHub Copilot provider authentication without the full agent runtime ([#134626](https://github.com/openclaw/openclaw/pull/134626)).
+- Scope full catalog refreshes to the plugin runtimes that can contribute models ([#135486](https://github.com/openclaw/openclaw/pull/135486)). Thanks @zeroaltitude, @obviyus.
 
 **Bug fixes**
 
-- Retain context usage when an Anthropic-compatible provider writes only one valid cache counter ([#126473](https://github.com/openclaw/openclaw/pull/126473)). Thanks @ayaangazali, @Oliverbot26.
-- Preserve admitted channel identity through Codex prompt and compaction hooks ([#129402](https://github.com/openclaw/openclaw/pull/129402)). Thanks @ashawwal.
-- Bound managed llama.cpp server inspection responses ([#132490](https://github.com/openclaw/openclaw/pull/132490)). Thanks @RileyJJY.
-- Keep late CLI output from crashing the Gateway or changing a settled result ([#132582](https://github.com/openclaw/openclaw/pull/132582)). Thanks @TARSDrakon.
+- Keep tool-only credentials out of the model-provider inventory ([#134218](https://github.com/openclaw/openclaw/pull/134218)). Thanks @wantosure, @beastyrabbit.
+- Refresh the model catalog after provider login ([#134361](https://github.com/openclaw/openclaw/pull/134361)). Thanks @obviyus.
+- Retain refreshed credentials for matching custom agent directories ([#134862](https://github.com/openclaw/openclaw/pull/134862)). Thanks @Lendersmark.
+- Keep externally authenticated providers in model menus ([#135046](https://github.com/openclaw/openclaw/pull/135046)). Thanks @goslingmanagment.
+- Refresh model catalogs after credentials and settings change ([#135063](https://github.com/openclaw/openclaw/pull/135063)). Thanks @elikampf.
+- Show concise, redacted OAuth recovery errors in the Control UI ([#135112](https://github.com/openclaw/openclaw/pull/135112)). Thanks @shakkernerd.
+- Auto-enable configured Google and Vertex provider plugins ([#135239](https://github.com/openclaw/openclaw/pull/135239)). Thanks @Solvely-Colin.
+- Retain discovered models through compatible hot reloads ([#135353](https://github.com/openclaw/openclaw/pull/135353)). Thanks @goslingmanagment.
+- Repair stale OpenAI profile order after relogin ([#135355](https://github.com/openclaw/openclaw/pull/135355)). Thanks @obviyus, @mattcbianco.
+- Preserve custom-provider SecretRefs through Doctor repair ([#135357](https://github.com/openclaw/openclaw/pull/135357)). Thanks @obviyus, @dannevang.
+- Diagnose shared-auth relocation conflicts and clear forced-login owners ([#135739](https://github.com/openclaw/openclaw/pull/135739)). Thanks @Deregtx, @cksagente-dot.
+- Publish refreshed provider priority to a running Gateway ([#135847](https://github.com/openclaw/openclaw/pull/135847)). Thanks @josephbergvinson, @obviyus, @yetval.
+- Skip unused runtime discovery for read-only catalog queries ([#136020](https://github.com/openclaw/openclaw/pull/136020)). Thanks @609NFT, @LiuwqGit.
+- Finish thinking lookup and Model Setup when a catalog owner is replaced during reload ([#127284](https://github.com/openclaw/openclaw/pull/127284)). Thanks @RomneyDa, @karkarl.
+- Identify OpenClaw consistently on native OpenCode Go provider routes ([#135588](https://github.com/openclaw/openclaw/pull/135588)). Thanks @VACInc.
+- Report when login saved a credential but could not promote its active order ([#135443](https://github.com/openclaw/openclaw/pull/135443)). Thanks @lzhan011, @obviyus.
+- Reuse prepared model catalogs during inventory browsing and preserve discovered models through temporary discovery failures ([`7e9563c`](https://github.com/openclaw/openclaw/commit/7e9563ccff50e3a275a97e623579ab2075bd0756)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Provider Usage and Price Estimates">
+
+Provider status now has one genuinely useful addition for xAI users, with OAuth-authenticated SuperGrok accounts able to show usage, reset time, plan, and prepaid balance in the usual status surfaces when xAI supplies them. API-key billing remains a separate bucket. DeepInfra and Anthropic Vertex estimates also follow their current advertised and regional rates more closely, but these are OpenClaw estimates rather than a change to what either provider bills.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Show SuperGrok usage for OAuth-authenticated xAI accounts ([#135766](https://github.com/openclaw/openclaw/pull/135766)).
+
+**Bug fixes**
+
+- Refresh DeepInfra estimates from native pricing ([#134893](https://github.com/openclaw/openclaw/pull/134893)).
+- Keep Anthropic Vertex Sonnet 5 estimates on current regional rates ([#135761](https://github.com/openclaw/openclaw/pull/135761)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Model Retries and Fallbacks">
+
+Temporary provider failures now have one bounded retry owner, so a brief outage can recover quietly while a persistent one reaches the normal profile or model fallback path, or gives you an actionable error, within the retry window. A busy session stops after the first model candidate instead of making every fallback look broken, while hard Anthropic and Bedrock refusals stop immediately with revise-and-retry guidance rather than resending the request. Doctor can also remove a stale automatic OpenAI route without disturbing an intentional model choice.
+
+The recovery details matter just as much as the retry count. Affected llama.cpp context-limit failures can compact and retry, OpenAI Responses conversations keep compact continuation when tool lists or safely admitted large-integer arguments change, and pre-output transport failures can resume after completed tools without running them again. Provider and context diagnostics now survive more of these paths, while the official failover guide matches the controller that actually owns them.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Repair stale Doctor route pins without removing intentional choices ([#102180](https://github.com/openclaw/openclaw/pull/102180)). Thanks @849261680, @cpwilhelmi.
+- Keep context usage when Anthropic-compatible providers omit a cache counter ([#126473](https://github.com/openclaw/openclaw/pull/126473)). Thanks @ayaangazali, @Oliverbot26.
 - Preserve OpenAI Responses continuation when tool lists change ([#132951](https://github.com/openclaw/openclaw/pull/132951)). Thanks @hartmark.
-- Reject corrupted text bytes in BytePlus and Volcengine speech responses ([#134010](https://github.com/openclaw/openclaw/pull/134010)). Thanks @ZengWen-DT.
-- Stop busy-session conflicts before cycling through model fallbacks ([#134219](https://github.com/openclaw/openclaw/pull/134219)). Thanks @obviyus, @svdwalt007, @tzlwn1.
+- Compact and retry current llama.cpp context-limit failures ([#133888](https://github.com/openclaw/openclaw/pull/133888)). Thanks @gokay-ai, @Areson.
+- Stop busy-session conflicts before cycling through fallbacks ([#134219](https://github.com/openclaw/openclaw/pull/134219)). Thanks @obviyus, @svdwalt007, @tzlwn1.
 - Give transient model failures one bounded retry controller ([#134281](https://github.com/openclaw/openclaw/pull/134281)). Thanks @obviyus.
-- Preserve OpenAI Responses continuation across admitted large-integer tool arguments ([#134423](https://github.com/openclaw/openclaw/pull/134423)). Thanks @hartmark.
-- Stop interrupting active Codex turns during quiet native work ([#134755](https://github.com/openclaw/openclaw/pull/134755)). Thanks @obviyus, @ernestrolfson-design.
-- Retain bounded, credential-redacted diagnostics from failed Claude subprocesses ([#134794](https://github.com/openclaw/openclaw/pull/134794)).
-- Stop managed local providers before Gateway shutdown completes ([#134890](https://github.com/openclaw/openclaw/pull/134890)). Thanks @MoerAI, @obviyus, @Deregtx.
-- Refresh DeepInfra estimates from native advertised pricing and discounts ([#134893](https://github.com/openclaw/openclaw/pull/134893)).
-- Stop retries and model fallback after hard Anthropic and Bedrock refusals ([#134980](https://github.com/openclaw/openclaw/pull/134980)). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus.
-- Preserve bounded provider details on failed chat events ([#135102](https://github.com/openclaw/openclaw/pull/135102)).
-- Continue eligible pre-output connection failures without replaying completed tools ([#135105](https://github.com/openclaw/openclaw/pull/135105)).
-- Explain unavailable model harnesses and their recovery paths ([#135118](https://github.com/openclaw/openclaw/pull/135118)). Thanks @fuller-stack-dev, @goslingmanagment.
-- Apply request timeouts to Local CLI speech synthesis ([#135222](https://github.com/openclaw/openclaw/pull/135222)).
+- Preserve OpenAI Responses continuation across admitted tool arguments ([#134423](https://github.com/openclaw/openclaw/pull/134423)). Thanks @hartmark.
+- Stop retries and fallbacks after hard Anthropic and Bedrock refusals ([#134980](https://github.com/openclaw/openclaw/pull/134980)). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus.
+- Preserve safe provider details on failed chat events ([#135102](https://github.com/openclaw/openclaw/pull/135102)).
+- Recover eligible pre-output transport failures without replaying completed tools ([#135105](https://github.com/openclaw/openclaw/pull/135105)).
 - Preserve the latest valid context reading from Anthropic-compatible proxies ([#135467](https://github.com/openclaw/openclaw/pull/135467)). Thanks @Yigtwxx.
-- Resolve the selected web-fetch provider before unrelated credential checks ([#135504](https://github.com/openclaw/openclaw/pull/135504)).
 - Show requested and effective models when a subagent completes through fallback ([#135531](https://github.com/openclaw/openclaw/pull/135531)). Thanks @MertBasar0, @obviyus, @nbarthelemy.
 - Report every current sibling's model reroute in a batched requester wake while preserving deduplication, ordering, stale-owner exclusion, and the 1,024-character notice cap ([`2ef043e`](https://github.com/openclaw/openclaw/commit/2ef043efe7d33cf99a18d0da0cb19bad86cec840)).
-- Stop persistent Codex conversations from using stale prompt-hook instructions ([#135577](https://github.com/openclaw/openclaw/pull/135577)).
-- Keep authored context caps through runtime provider aliases ([#135580](https://github.com/openclaw/openclaw/pull/135580)). Thanks @VACInc.
-- Route utility completions through the selected Claude CLI runtime ([#135711](https://github.com/openclaw/openclaw/pull/135711)). Thanks @goslingmanagment.
-- Diagnose shared-auth relocation conflicts and clear forced-login owners ([#135739](https://github.com/openclaw/openclaw/pull/135739)). Thanks @Deregtx, @cksagente-dot.
-- Restore audio transcription for eligible OpenAI OAuth accounts ([#135855](https://github.com/openclaw/openclaw/pull/135855)). Thanks @yungchentang, @kAIborg24.
-- Keep Codex replies working after sub-plugin policy changes ([#135863](https://github.com/openclaw/openclaw/pull/135863)). Thanks @vyctorbrzezowski.
+
+**Documentation**
+
+- Align failover guidance with the current retry controller ([#135374](https://github.com/openclaw/openclaw/pull/135374)). Thanks @Marvinthebored, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Codex and Claude CLI Work">
+
+Long-running Codex work no longer ends just because its progress is quiet, and finite time limits follow elapsed time without throwing away useful partial output. Idle Codex chats can resume while other chats and catalog reads share the same app server, and prompt-hook changes either take effect safely on the next persistent turn or stop before inference with a recovery path instead of silently keeping stale instructions.
+
+Claude CLI setup now works through supported mise and asdf shims, local Claude failures keep bounded credential-redacted diagnostics, and Claude CLI-backed utility models can produce digests, progress, and tool titles through the runtime that owns their authentication. Codex and CLI agents only offer remote shell execution when a connected node can actually run commands, existing broken harnesses explain which plugin needs attention, and the official plugin now aligns managed installs and checks on Codex 0.152.1. Claude Code session catalogs also avoid rescanning an unchanged projects tree on every poll, with the improvement depending on the size of the catalog, disk load, and watcher availability.
+
+The Codex and Claude Code catalog can open the selected native CLI in a reconnectable terminal on an eligible local or paired host. Codex-backed agents keep the configured timezone across normal turns and side questions, while long concurrent Codex streams shed progress pressure without losing the answer.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Align managed Codex installs and release checks on 0.152.1 ([#136184](https://github.com/openclaw/openclaw/pull/136184)).
+- Reuse watched Claude Code catalog snapshots between polls ([#136222](https://github.com/openclaw/openclaw/pull/136222)). Thanks @giangthb.
+- Show the detected Codex or Claude sign-in method and runtime-reported account email ([#136521](https://github.com/openclaw/openclaw/pull/136521)).
+
+**Bug fixes**
+
+- Preserve admitted channel identity through Codex hooks and compaction ([#129402](https://github.com/openclaw/openclaw/pull/129402)). Thanks @ashawwal.
+- Keep late CLI output from crashing the Gateway after timeout ([#132582](https://github.com/openclaw/openclaw/pull/132582)). Thanks @TARSDrakon.
+- Stop interrupting active Codex turns during quiet native work ([#134755](https://github.com/openclaw/openclaw/pull/134755)). Thanks @obviyus, @ernestrolfson-design.
+- Avoid a redundant legacy model key after Claude CLI activation ([#134779](https://github.com/openclaw/openclaw/pull/134779)). Thanks @leilei3167, @obviyus, @aaajiao.
+- Retain credential-redacted diagnostics from failed Claude subprocesses ([#134794](https://github.com/openclaw/openclaw/pull/134794)).
+- Explain unavailable model harnesses and their recovery paths ([#135118](https://github.com/openclaw/openclaw/pull/135118)). Thanks @fuller-stack-dev, @goslingmanagment.
+- Let Claude CLI connect through supported PATH shims ([#135124](https://github.com/openclaw/openclaw/pull/135124)). Thanks @zhangguiping-xydt, @obviyus, @masatokawano.
+- Stop using stale instructions after Codex prompt-hook changes ([#135577](https://github.com/openclaw/openclaw/pull/135577)).
+- Route utility completions through the selected runtime ([#135711](https://github.com/openclaw/openclaw/pull/135711)). Thanks @goslingmanagment.
 - Hide Codex node execution when no capable node is connected ([#136000](https://github.com/openclaw/openclaw/pull/136000)).
 - Hide CLI remote execution when no executable node is connected ([#136067](https://github.com/openclaw/openclaw/pull/136067)).
+- Let idle Codex chats resume while unrelated chats keep running ([#136196](https://github.com/openclaw/openclaw/pull/136196)).
+- Keep Codex replies working after sub-plugin policy changes ([#135863](https://github.com/openclaw/openclaw/pull/135863)). Thanks @vyctorbrzezowski.
 - Give Codex-backed agents the configured user timezone across warm turns ([#136172](https://github.com/openclaw/openclaw/pull/136172)). Thanks @NianJiuZst, @obviyus, @davidcittadini.
-- Let idle Codex chats resume while unrelated work shares the app server ([#136196](https://github.com/openclaw/openclaw/pull/136196)).
-- Reuse watched Claude Code catalog snapshots between polls ([#136222](https://github.com/openclaw/openclaw/pull/136222)). Thanks @giangthb.
 - Open Codex and Claude Code from the catalog in a reconnectable native terminal ([#136230](https://github.com/openclaw/openclaw/pull/136230)).
-- Prefer managed local model and embedding services as the Linux OOM victim ([#136276](https://github.com/openclaw/openclaw/pull/136276)). Thanks @vincentkoc, @novahe.
 - Show persisted ACP runtime and model metadata for the selected agent ([#136280](https://github.com/openclaw/openclaw/pull/136280)).
 - Preserve native CLI continuity for queued cold follow-ups ([#136644](https://github.com/openclaw/openclaw/pull/136644)). Thanks @svdwalt007, @Isitjustmefromparis, @Tony-Clawbot.
 - Keep long and concurrent Codex streams connected through the final reply ([#136705](https://github.com/openclaw/openclaw/pull/136705)).
 
-**Documentation**
+</details>
 
-- Align model-failover guidance with the current retry controller and incomplete-turn behavior ([#135374](https://github.com/openclaw/openclaw/pull/135374)). Thanks @Marvinthebored, @obviyus.
+</Accordion>
 
-**Limits and compatibility**
+<Accordion title="Local and Self-Hosted Models">
 
-- Support Claude CLI setup through mise and asdf PATH shims while retaining the argv0 dispatch boundary ([#135124](https://github.com/openclaw/openclaw/pull/135124)). Thanks @zhangguiping-xydt, @obviyus, @masatokawano.
+Self-hosted model routes now behave more like services OpenClaw can actually live with. Existing llama.cpp-compatible web apps can fall back to `/v1/models` when their root models endpoint serves HTML or unusable data, managed diagnostics stop reading oversized response bodies without a bound, and OpenClaw waits for managed local model processes to stop before finishing shutdown. The shutdown proof is scoped to Linux and systemd, and the discovery fallback was exercised at the provider boundary rather than as a complete Unsloth inference run.
+
+On Linux, managed local model and embedding services are preferred as the out-of-memory victim so the Gateway can remain available for connections and diagnostics.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Bound managed llama.cpp diagnostic responses ([#132490](https://github.com/openclaw/openclaw/pull/132490)). Thanks @RileyJJY.
+- Stop managed local providers before Gateway shutdown completes ([#134890](https://github.com/openclaw/openclaw/pull/134890)). Thanks @MoerAI, @obviyus, @Deregtx.
+- Discover models behind llama.cpp-compatible web app endpoints ([#135445](https://github.com/openclaw/openclaw/pull/135445)). Thanks @gaoanze888, @Bloodis94.
+- Prefer managed local model and embedding services as the Linux OOM victim ([#136276](https://github.com/openclaw/openclaw/pull/136276)). Thanks @vincentkoc, @novahe.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Provider-Backed Tools">
+
+Provider choice now carries more cleanly into the tools around a conversation. Native Model Studio and Qwen routes honor prompt-cache retention, a selected web-fetch provider no longer trips over credentials for providers it never intended to use, and Local CLI speech generation follows the request timeout. Corrupted Volcengine speech responses fail clearly, while eligible OpenAI OAuth accounts can again transcribe inbound voice notes and configured batch audio without a separate API key. OAuth entitlement and quota are still account-specific, and custom Model Studio proxies remain opt-in for cache markers.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reject corrupted text bytes in Volcengine TTS responses ([#134010](https://github.com/openclaw/openclaw/pull/134010)). Thanks @ZengWen-DT.
+- Honor Model Studio cache defaults and retention ([#135093](https://github.com/openclaw/openclaw/pull/135093)).
+- Apply request timeouts to Local CLI speech generation ([#135222](https://github.com/openclaw/openclaw/pull/135222)).
+- Resolve the selected web-fetch provider before unrelated credential checks ([#135504](https://github.com/openclaw/openclaw/pull/135504)).
+- Restore OpenAI OAuth audio transcription ([#135855](https://github.com/openclaw/openclaw/pull/135855)). Thanks @yungchentang, @kAIborg24.
 
 </details>
 
@@ -927,53 +1339,94 @@ The surrounding provider paths now fail and report more truthfully. Local and ne
 
 ## Automations and Scheduling
 
-[Scheduled work](/automation/cron-jobs) now has a clearer life from the moment you create a job through its next run, restart, and final delivery. OpenClaw is more careful about keeping the schedule you chose, recovering work that was interrupted, and telling you whether a result was delivered, deliberately silent, or still uncertain, which means fewer jobs that look finished while their useful result has gone missing.
+[Scheduled work](/automation/cron-jobs) now keeps more of its identity from creation through delivery. An automation can begin with the access somebody already configured, make it through a restart without quietly becoming a different job, and leave a result that is easier to find and understand afterward. Recurring work also gets a deliberate choice about missed jobs, while one-time jobs keep their separate recovery behavior.
 
 <AccordionGroup>
 
-<Accordion title="Schedule recovery after restarts and upgrades">
+<Accordion title="Creating Automations with Existing Access">
 
-One-time jobs now keep their latest retry time through a restart, immediate one-shot jobs can still wake the selected agent when periodic heartbeats are disabled, and Cron retries stay active until the underlying work has actually settled. Recurring jobs gain a separate choice for downtime through `cron.skipMissedJobs` set to `true`, which advances an overdue schedule to its next future run instead of replaying stale reminders or digests. That setting is off by default, it deliberately drops the missed occurrences when enabled, and it never skips one-time jobs.
+Configured Codex app-server users can create app-backed automations through the authenticated connection they already use, without preparing a second OpenClaw profile or supplying a separate tool allowlist. Reauthenticating the same endpoint keeps the automation usable, while a removed endpoint, changed connection identity, unavailable plugin, or newly disallowed app or tool stops before app work and leaves an actionable recorded failure.
 
-Older schedules are handled more carefully too. Upgrades preserve whether a legacy job was enabled, malformed rows are quarantined with a reason while valid jobs keep loading, and uncommon expanded-year dates retain their selected time zone. The migration cannot reconstruct enabled state for a database that already passed through the earlier faulty path, and quarantine is deliberately safer than guessing what a malformed job was meant to do.
+Creation now also returns the resolved announcement route or the reason it failed closed before the job is saved, so an operator can fix delivery before trusting it. Integrations that call CronService directly can switch a job between command, script, and agent-turn payloads without inventing omitted optional fields, while malformed environments remain rejected.
 
-The surrounding details now keep more of the same identity. Creation shows the resolved announcement route or the reason delivery will fail closed, recipient suggestions stop mixing in account identities that cannot receive a result, restricted operators get complete pages of the history they are allowed to see, and scheduled backups can still be disabled after a rename or when they sit deep in a large job list. System heartbeats also return to their configured provider after a clean restart, without adding a broader retry or fallback promise.
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Create app-backed automations with configured Codex app-server authentication ([#134525](https://github.com/openclaw/openclaw/pull/134525)). Thanks @sjf-oa.
+- Preserve optional fields when direct CronService callers change a job's payload kind ([#134639](https://github.com/openclaw/openclaw/pull/134639)). Thanks @solomonneas.
+- Show the resolved announcement route or fail-closed reason when an isolated job is created ([#135003](https://github.com/openclaw/openclaw/pull/135003)). Thanks @ericcaiwx-star, @obviyus.
+- Keep account identities out of scheduled-delivery recipient suggestions ([#134368](https://github.com/openclaw/openclaw/pull/134368)). Thanks @BryanTegomoh, @rogerallen1.
+
+</details>
+
+</Accordion>
+
+<Accordion title="One-Time Schedules Through Restarts and Unusual Dates">
+
+One-time jobs keep their newer retry time when the Gateway restarts, and an immediate main-session job can still wake its selected agent when periodic heartbeats are disabled. Successful one-shot jobs configured for deletion are removed as expected rather than being left behind in a disabled state.
+
+Older schedules are handled more carefully too. Upgrades that have not yet completed the affected legacy migration preserve whether a job was enabled, malformed legacy rows are quarantined without preventing valid jobs from loading, and expanded-year one-time dates honor their selected time zone and display the correct year. The migration repair does not reconstruct enabled state for databases that already passed through the earlier faulty v13 path.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve legacy automation enabled state while upgrading older databases ([#132868](https://github.com/openclaw/openclaw/pull/132868)). Thanks @CanReader, @obviyus.
+- Run immediate one-shot main-session jobs when periodic heartbeats are disabled ([#134648](https://github.com/openclaw/openclaw/pull/134648)). Thanks @sunlit-deng, @obviyus, @LowCode191.
+- Keep a one-time job's durable retry time through Gateway startup recovery ([#135083](https://github.com/openclaw/openclaw/pull/135083)). Thanks @rwinkelman, @obviyus, @meircohen.
+- Quarantine invalid legacy schedule rows without blocking valid jobs ([#135829](https://github.com/openclaw/openclaw/pull/135829)). Thanks @teddytennant, @obviyus.
+- Apply selected time zones and correct year display to expanded-year one-time dates ([#135973](https://github.com/openclaw/openclaw/pull/135973)).
+- Let cancelled work settle promptly while Cron retries continue until execution really ends, with related New Session and safe browser Fetch continuation recovery ([#133747](https://github.com/openclaw/openclaw/pull/133747)). Thanks @shakkernerd.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choosing What Happens to Missed Recurring Jobs">
+
+Operators who do not want stale reminders, digests, or model calls after downtime can enable `cron.skipMissedJobs: true`. On startup, OpenClaw advances overdue recurring schedules to their next future occurrence and saves that decision before normal scheduling resumes. The setting is opt-in, so leaving it unset or false preserves the existing catch-up behavior, and one-time jobs are not skipped.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Add an opt-in choice to skip missed recurring jobs after downtime while leaving one-time jobs unchanged ([#135071](https://github.com/openclaw/openclaw/pull/135071)).
-
-**Bug fixes**
-
-- Preserve legacy jobs' enabled or disabled state during schema migration ([#132868](https://github.com/openclaw/openclaw/pull/132868)). Thanks @CanReader, @obviyus.
-- Keep account identities out of scheduled-delivery recipient suggestions ([#134368](https://github.com/openclaw/openclaw/pull/134368)). Thanks @BryanTegomoh, @rogerallen1.
-- Let cancelled work settle promptly while Cron retries continue until execution really ends, with related New Session and safe browser Fetch continuation recovery ([#133747](https://github.com/openclaw/openclaw/pull/133747)). Thanks @shakkernerd.
-- Preserve optional fields when direct CronService integrations change a job's payload kind ([#134639](https://github.com/openclaw/openclaw/pull/134639)). Thanks @solomonneas.
-- Run immediate one-shot main-session jobs when periodic heartbeats are disabled ([#134648](https://github.com/openclaw/openclaw/pull/134648)). Thanks @sunlit-deng, @obviyus, @LowCode191.
-- Show a resolved announcement route or fail-closed reason before saving an isolated job ([#135003](https://github.com/openclaw/openclaw/pull/135003)). Thanks @ericcaiwx-star, @obviyus.
-- Keep a one-time job's durable retry time through startup recovery ([#135083](https://github.com/openclaw/openclaw/pull/135083)). Thanks @rwinkelman, @obviyus, @meircohen.
-- Quarantine invalid legacy rows without preventing valid schedules from loading ([#135829](https://github.com/openclaw/openclaw/pull/135829)). Thanks @teddytennant, @obviyus.
-- Apply the selected time zone and correct year display to expanded-year one-time dates ([#135973](https://github.com/openclaw/openclaw/pull/135973)).
-- Page automation history after applying the operator's existing session visibility ([#136043](https://github.com/openclaw/openclaw/pull/136043)).
-- Find managed backup schedules by stable identity across renames and complete inventories ([#136133](https://github.com/openclaw/openclaw/pull/136133)).
-- Keep scheduled system heartbeats connected to their configured provider after a restart ([#136256](https://github.com/openclaw/openclaw/pull/136256)). Thanks @obviyus, @Famyoff.
+- Add an opt-in setting to skip missed recurring jobs after downtime ([#135071](https://github.com/openclaw/openclaw/pull/135071)).
 
 </details>
 
 </Accordion>
 
-<Accordion title="Delivery, heartbeats, and child-session completion">
+<Accordion title="Heartbeat Routes, Quiet Replies, and Deadlines">
 
-A completed background job is not necessarily a delivered result, so the Tasks view now distinguishes a confirmed handoff from an uncertain one or a result intentionally blocked by policy instead of crediting every completion as delivered. Cron results and child-session announcements can retry a temporary adapter failure only while OpenClaw can prove the send never started. Once delivery may have begun, the outcome remains uncertain rather than risking a duplicate, and settled failure alerts now show whether they were delivered, not delivered, or genuinely unknown.
+Scheduled agent work now keeps model aliases attached to the selected agent, and system-owned heartbeats can reach their configured provider after a clean Gateway restart by using the currently published runtime. Long or unlimited heartbeat runs honor the configured deadline instead of inheriting a fixed ten-minute cutoff, while destination-only wakes retain the rest of the configured heartbeat behavior.
 
-Intentional silence is clearer as well. A scheduled job that finishes successful tool work with `NO_REPLY` stays silent, while agents can explicitly start fire-and-forget child sessions that do not interrupt the requester when they finish. Swarm collectors and thread-bound child sessions now receive instructions that match how their results really arrive, and finished isolated jobs clean up the run-specific sessions they no longer need.
+The delivery edges are quieter and more accurate as well. An explicit `NO_REPLY` after successful tool work stays silent, the first-alert explanation appears only on the first alert for an isolated default route, and bounded `agents_wait` calls keep their requested duration when the system clock moves forward or backward.
 
-Configured Codex app-server users can also create app-backed automations through the authenticated connection they already use, without preparing a second OpenClaw profile or manually repeating a tool allowlist. The saved authority is checked again before a run, so removing the endpoint, changing its identity, losing the plugin, or tightening app or tool policy stops before app work and leaves an inspectable failure. Same-endpoint reauthentication remains usable, but the final proof did not cover a live external connector backend, and the wider delivery repairs were not verified across every channel.
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
 
-Heartbeat work follows the same more truthful shape. Long or unlimited runs honor their configured deadline, the first-alert explanation appears once, administrators can inspect the stored checklist in the read-only monitor, and scheduled model aliases stay with the selected agent. Automation links also open the intended job and highlighted run beyond the current list page or agent filter, with a visible error when the job is unavailable.
+**Bug fixes**
+
+- Keep scheduled model aliases scoped to the selected agent ([#135069](https://github.com/openclaw/openclaw/pull/135069)). Thanks @elikampf.
+- Measure `agents_wait` deadlines consistently through system clock changes ([#135292](https://github.com/openclaw/openclaw/pull/135292)). Thanks @qingminglong.
+- Show the first-alert explanation once for isolated default routes ([#135849](https://github.com/openclaw/openclaw/pull/135849)). Thanks @obviyus, @rwinkelman, @virtexvirtuoso.
+- Preserve deliberate silent completion after scheduled tool work ([#135919](https://github.com/openclaw/openclaw/pull/135919)). Thanks @leilei3167, @obviyus, @Frank683456.
+- Honor configured finite and unlimited heartbeat deadlines ([#135925](https://github.com/openclaw/openclaw/pull/135925)). Thanks @xialonglee, @obviyus, @jaxonparrott.
+- Bind scheduled system heartbeats to the published runtime after restart ([#136256](https://github.com/openclaw/openclaw/pull/136256)). Thanks @obviyus, @Famyoff.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Automation Links, History, and Alerts">
+
+An Automations link now opens the intended job and highlighted run even when that job sits beyond the loaded page or outside the current agent filter, with a visible lookup error when it is no longer available. Session-restricted operators receive complete pages and accurate totals for the run history they are allowed to see, while large name-sorted job lists avoid repeating the same locale setup for every comparison.
+
+Schedule and history durations also keep all meaningful units across locales, and a settled failure alert appears as delivered, not delivered, or genuinely unknown in the live job view. Confirmed non-delivery retains a bounded redacted error and the existing in-app fallback, while immutable run-history entries remain unchanged.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -981,21 +1434,47 @@ Heartbeat work follows the same more truthful shape. Long or unlimited runs hono
 **Bug fixes**
 
 - Show complete duration quantities across localized schedules and run history ([#133224](https://github.com/openclaw/openclaw/pull/133224)).
+- Persist settled failure-alert outcomes in live automation status ([#135516](https://github.com/openclaw/openclaw/pull/135516)). Thanks @RayWangyangMa, @obviyus, @bassmediagroup.
+- Open linked jobs and highlighted runs beyond the loaded list or active filter ([#136012](https://github.com/openclaw/openclaw/pull/136012)).
+- Page run history after applying existing session-visibility rules ([#136043](https://github.com/openclaw/openclaw/pull/136043)).
+- Show an administrator the stored heartbeat checklist in the read-only Automations monitor ([#135508](https://github.com/openclaw/openclaw/pull/135508)). Thanks @gaoanze888, @obviyus, @itsuzef.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Child Sessions and Completion Delivery">
+
+Successful isolated jobs now release their run ownership before removing an unused continuation session, avoiding the stale row and misleading competing-work warning that could remain after completion. Generated-media jobs use the same ordering before the final Gateway response, with cleanup kept to the lifecycle that owns the run.
+
+Child-session results now distinguish confirmed delivery, uncertain delivery, and intentional suppression. Fire-and-forget work can deliberately skip requester interruption, temporary pre-dispatch failures can retry before delivery begins, and Swarm or quiet subagents receive completion guidance that matches how their results actually arrive.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Remove unused isolated-job continuation sessions after successful completion ([#135155](https://github.com/openclaw/openclaw/pull/135155)). Thanks @brettdaman, @obviyus.
+- Clean up generated-media run sessions before the final Gateway response ([#135517](https://github.com/openclaw/openclaw/pull/135517)). Thanks @jmewing, @obviyus, @goslingmanagment, @giangthb.
+- Match Swarm and child-session completion guidance to the actual result-delivery path ([#133660](https://github.com/openclaw/openclaw/pull/133660)).
+- Retry temporary proven-not-sent adapter failures without retrying ambiguous or already-dispatched sends ([#135985](https://github.com/openclaw/openclaw/pull/135985)). Thanks @gaoanze888, @obviyus, @yetval.
 - Distinguish confirmed, uncertain, and policy-suppressed child-session delivery in Tasks ([#136524](https://github.com/openclaw/openclaw/pull/136524)). Thanks @Cobblestone-Digital1.
 - Expose the existing fire-and-forget child-session option to agents and document how it behaves ([#136570](https://github.com/openclaw/openclaw/pull/136570)). Thanks @alfredjbclaw.
-- Match Swarm and child-session completion guidance to the actual result-delivery path ([#133660](https://github.com/openclaw/openclaw/pull/133660)).
-- Create app-backed scheduled jobs with configured Codex app-server authentication and recheck saved authority before execution ([#134525](https://github.com/openclaw/openclaw/pull/134525)). Thanks @sjf-oa.
-- Keep scheduled model aliases scoped to the selected agent in multi-workspace setups ([#135069](https://github.com/openclaw/openclaw/pull/135069)). Thanks @elikampf.
-- Remove unused run-specific continuation sessions after successful isolated jobs finish ([#135155](https://github.com/openclaw/openclaw/pull/135155)). Thanks @brettdaman, @obviyus.
-- Keep `agents_wait` deadlines accurate when the system clock changes ([#135292](https://github.com/openclaw/openclaw/pull/135292)). Thanks @qingminglong.
-- Show an administrator the stored heartbeat checklist in the read-only Automations monitor ([#135508](https://github.com/openclaw/openclaw/pull/135508)). Thanks @gaoanze888, @obviyus, @itsuzef.
-- Persist settled failure-alert delivery outcomes in live automation status ([#135516](https://github.com/openclaw/openclaw/pull/135516)). Thanks @RayWangyangMa, @obviyus, @bassmediagroup.
-- Clean up generated-media run sessions after delivery settles ([#135517](https://github.com/openclaw/openclaw/pull/135517)). Thanks @jmewing, @obviyus, @goslingmanagment, @giangthb.
-- Show the first-alert explanation once for isolated heartbeat routes ([#135849](https://github.com/openclaw/openclaw/pull/135849)). Thanks @obviyus, @rwinkelman, @virtexvirtuoso.
-- Preserve deliberate silent completion after scheduled tool work ([#135919](https://github.com/openclaw/openclaw/pull/135919)). Thanks @leilei3167, @obviyus, @Frank683456.
-- Honor configured finite and unlimited heartbeat deadlines while retaining destination-only wake settings ([#135925](https://github.com/openclaw/openclaw/pull/135925)). Thanks @xialonglee, @obviyus, @jaxonparrott.
-- Retry temporary proven-not-sent adapter failures without retrying ambiguous or already-dispatched sends ([#135985](https://github.com/openclaw/openclaw/pull/135985)). Thanks @gaoanze888, @obviyus, @yetval.
-- Open linked jobs and highlighted runs beyond the loaded page or active agent filter ([#136012](https://github.com/openclaw/openclaw/pull/136012)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Disabling Managed Scheduled Backups">
+
+`openclaw backup disable` can find the managed backup after its schedule has been renamed or moved beyond the first 200 jobs in a larger automation inventory. It follows the schedule's stable declaration identity, so an unrelated automation with the same name is left alone.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Find managed backup schedules by stable identity across renames and complete inventories ([#136133](https://github.com/openclaw/openclaw/pull/136133)).
 
 </details>
 
@@ -1005,86 +1484,113 @@ Heartbeat work follows the same more truthful shape. Long or unlimited runs hono
 
 ## Browser and Computer Use
 
-Browser work now stays closer to the tab, page, and machine it was meant for. OpenClaw can cancel supported actions without knocking unrelated tabs offline, keep tab-heavy Chrome and Brave sessions usable, take complete screenshots without upsetting mobile emulation, and stop before acting when a browser endpoint or paired node is not the one the operator allowed.
-
-Computer use gets the same tighter ownership. Commands report which capable node ran them, duplicate node names require an explicit choice, Mac input and screenshot coordinates line up more reliably, and a Windows remote desktop can hand control back and forth without dropping the only authenticated viewer.
+Browser control is more predictable from the first local screenshot to an attached Chrome tab or a remote desktop. Standalone agents can reach the local browser without borrowing Gateway credentials, selected tabs keep valid commands through ordinary group changes, paired-machine actions report where they ran, and Chrome MCP endpoint checks happen before a connection begins.
 
 <AccordionGroup>
 
-<Accordion title="Browser tabs, screenshots, web search, and endpoint policy">
+<Accordion title="Local Browser Runs and Screenshots">
 
-[Browser control](/tools/browser-control) now keeps pending clicks, typing, and uploads with their selected page, so cancelling one supported action does not disconnect work in another tab or let the cancelled action take effect later. Newly created tabs keep their authority through ordinary group setup, genuine access changes still revoke stale work, and tab listing gets enough time to finish in healthy Chrome or Brave extension sessions with many allowed tabs. Malformed form-fill requests also fail before changing the page, while an unexpected sessionless browser-worker event no longer has to take the Gateway and its active browser sessions down with it.
+Standalone agents with the `browser` tool enabled now default to the local browser when no Gateway or node route was selected. Viewport, full-page, and element screenshots capture through the page session that owns the current device settings, preserving mobile scale and touch behavior, while an interrupted Chromium capture returns a recovery error instead of leaving later screenshots or resizes stuck.
 
-Standalone agents whose policy allows browser use now default to the local browser when no Gateway or node route was selected. Screenshot capture stays with the page that owns its viewport, which keeps viewport, full-page, and element captures complete while preserving mobile scale and touch settings, and interrupted captures stop with a recovery error instead of leaving later screenshot or resize work stuck. People who relied on implicit node discovery from a standalone run now need to select automatic node routing or a specific node explicitly.
-
-Existing-session Chrome attachments resolve the effective MCP endpoint before launch, apply hostname policy to that endpoint, and use the same address for tab ownership and cleanup. The built-in launcher is pinned to the reviewed Chrome DevTools MCP 1.8.0 contract rather than following a moving latest release, while custom executables remain operator controlled. Brave and Tavily search results also preserve valid absolute publication dates, making freshness-sensitive work more useful without treating relative ages, fetch times, or arbitrary date-like text as publication metadata.
+That host-first default is an intentional change for unpinned standalone runs. Anyone who relied on implicit browser-node discovery should select `auto` or an explicit node, and full-page capture after pinch zoom remains a Chromium edge case. Malformed form-fill requests also stop before changing the page and identify the unsupported field instead of silently accepting only part of the request.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Reject unsupported browser form-fill fields before changing the page [#131400](https://github.com/openclaw/openclaw/pull/131400) — by [@LiuwqGit](https://github.com/LiuwqGit), with thanks to [@obviyus](https://github.com/obviyus) and [@srb11e](https://github.com/srb11e)
-- Keep attached-browser sessions alive after malformed sessionless worker events [#134853](https://github.com/openclaw/openclaw/pull/134853) — by [@cmanrav](https://github.com/cmanrav), with thanks to [@obviyus](https://github.com/obviyus)
-- Preserve valid selected-tab commands through ordinary tab-group updates [#135186](https://github.com/openclaw/openclaw/pull/135186)
-- Keep new Chrome tabs usable while revoking and cleaning up genuinely stale work [#135210](https://github.com/openclaw/openclaw/pull/135210)
-- Let tab listing finish in healthy Chrome and Brave sessions with many allowed tabs [#135219](https://github.com/openclaw/openclaw/pull/135219) — by [@SunnyShu0925](https://github.com/SunnyShu0925), with thanks to [@obviyus](https://github.com/obviyus) and [@alexph-dev](https://github.com/alexph-dev)
-- Route unpinned standalone browser work locally and preserve complete screenshots and emulation state [#135315](https://github.com/openclaw/openclaw/pull/135315)
-- Preserve valid Brave and Tavily publication dates in web-search results [#136017](https://github.com/openclaw/openclaw/pull/136017) — with thanks to [@rogerallen1](https://github.com/rogerallen1)
-- Cancel supported browser actions and uploads without disrupting unrelated tabs [#136465](https://github.com/openclaw/openclaw/pull/136465)
-
-**Security and trust**
-
-- Apply Browser hostname policy to the Chrome MCP endpoint actually used [#135857](https://github.com/openclaw/openclaw/pull/135857)
-- Pin default existing-session attachments to reviewed Chrome DevTools MCP 1.8.0 [#136121](https://github.com/openclaw/openclaw/pull/136121)
-
-**Limits and compatibility**
-
-- Cancellation covers pending locator clicks, typing, and uploads, not raw keyboard or mouse primitives, arbitrary scheduled page code, or changes that already completed.
-- Full-page capture after pinch zoom and a separate early-reconnect empty-target case remain unresolved.
-- Offline hosts need Chrome DevTools MCP 1.8.0 already cached or an operator-managed executable, and custom launch commands remain operator controlled.
-- Publication dates are limited to valid absolute metadata from Brave and Tavily, and upstream provider behavior was verified without authenticated provider calls.
+- Reject unsupported browser form fields before changing the page ([#131400](https://github.com/openclaw/openclaw/pull/131400)). Thanks @LiuwqGit, @obviyus, @srb11e.
+- Route standalone agents to the local browser and return complete, recoverable screenshots ([#135315](https://github.com/openclaw/openclaw/pull/135315)).
 
 </details>
 
 </Accordion>
 
-<Accordion title="Computer use, remote desktops, and node targeting">
+<Accordion title="Selected Chrome Tabs and Existing Sessions">
 
-Node-host commands now consider only paired, connected machines that can actually execute them, choose automatically only when one eligible machine remains, and report the effective node with successful, failed, and timed-out results. If several current nodes share a name, OpenClaw returns their exact IDs instead of guessing, while a CLI node using the Gateway installation's own signed identity is recognized as local without folding separately paired nodes into it.
+Selected-tab automation now keeps newly admitted commands valid while older group lookups finish and while a new tab goes through normal group setup. Genuine access changes still revoke stale work, restored access can recover, and a tab created during a relay disconnect is cleaned up instead of being left behind.
 
-On macOS, typing and key actions through paired Peekaboo nodes return success after they execute instead of inviting a duplicate retry, documented Command shortcuts select correctly, and large fragmented CUA responses require less temporary copying and peak memory on the measured path. Screenshot-grounded coordinates now stay aligned across compact, portrait, Retina, rounded, and one-pixel captures. The same repair makes Settings usable on a 1024 by 768 display, preserves pasted WebVNC line breaks, and avoids the affected Mac discovery teardown crash.
+Existing-session attachments now use the reviewed Chrome DevTools MCP 1.8.0 release rather than following a moving `latest` tag. Custom launch commands remain operator-managed, while offline hosts need that exact package cached or an operator-provided executable.
 
-Windows remote desktops can switch between view-only and control while keeping the existing authenticated viewer connected but unable to send input until its replacement is ready. That handoff was exercised with Windows Server 2022 and TightVNC, not macOS ARD, while the paired Mac input boundary was proven in an isolated signed producer-consumer setup rather than a complete packaged-app run. Browser Talk also keeps newly generated consultation prompts out of later model context without removing genuine speech, assistant results, or lossless exports, and agent guidance now distinguishes widgets, dashboards, portals, and separate browser previews while requiring unverified interaction to be disclosed as such.
+Pending clicks, typing, and uploads now remain scoped to the selected tab, so cancellation does not disrupt unrelated pages or allow the cancelled action to run later. Attached-browser automation also survives malformed sessionless worker events without taking down the Gateway or its active browser sessions.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve selected-tab commands when an older group lookup finishes late ([#135186](https://github.com/openclaw/openclaw/pull/135186)).
+- Keep new Chrome tabs authorized through ordinary group setup and clean up interrupted creations ([#135210](https://github.com/openclaw/openclaw/pull/135210)).
+- Pin default existing-session attachments to the reviewed Chrome MCP release ([#136121](https://github.com/openclaw/openclaw/pull/136121)).
+- Keep attached-browser sessions alive after malformed sessionless worker events [#134853](https://github.com/openclaw/openclaw/pull/134853) — by [@cmanrav](https://github.com/cmanrav), with thanks to [@obviyus](https://github.com/obviyus)
+- Let tab listing finish in healthy Chrome and Brave sessions with many allowed tabs [#135219](https://github.com/openclaw/openclaw/pull/135219) — by [@SunnyShu0925](https://github.com/SunnyShu0925), with thanks to [@obviyus](https://github.com/obviyus) and [@alexph-dev](https://github.com/alexph-dev)
+- Cancel supported browser actions and uploads without disrupting unrelated tabs [#136465](https://github.com/openclaw/openclaw/pull/136465)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Paired Computers and Remote Desktops">
+
+Commands sent to paired nodes now consider only connected machines that can actually execute them. OpenClaw selects a node automatically only when one eligible target remains, asks for an explicit choice when several qualify, and includes the effective node in successful, failed, and timed-out results instead of silently redirecting work to the wrong computer.
+
+Computer input is more faithful to what the agent and user can see. Successful typing and key actions on paired macOS Peekaboo nodes report success after the action occurs, screenshot-grounded clicks share one bounded frame across unusual capture shapes, smaller-Mac Settings can resize and scroll, and multiline WebVNC text keeps its line breaks. Windows remote-desktop handoff retains the authenticated TightVNC viewer until its replacement is ready, while large macOS CUA Computer responses use less temporary memory without changing the existing response limit or setup.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Reduce temporary copying and peak memory for large fragmented macOS CUA responses [#135094](https://github.com/openclaw/openclaw/pull/135094)
+- Reduce temporary memory pressure for large macOS CUA Computer responses ([#135094](https://github.com/openclaw/openclaw/pull/135094)).
 
 **Bug fixes**
 
-- Return successful Mac computer input without inviting duplicate retries [#134689](https://github.com/openclaw/openclaw/pull/134689) — by [@gaoanze888](https://github.com/gaoanze888), with thanks to [@wbstrbt](https://github.com/wbstrbt)
-- Keep Windows remote desktops connected through view-only and control handoffs [#134903](https://github.com/openclaw/openclaw/pull/134903)
-- Align computer-use screenshots and coordinates, preserve WebVNC line breaks, and make Mac Settings fit smaller displays [#135582](https://github.com/openclaw/openclaw/pull/135582)
+- Report completed macOS typing and key actions as successful ([#134689](https://github.com/openclaw/openclaw/pull/134689)). Thanks @gaoanze888, @wbstrbt.
+- Keep the authenticated Windows desktop viewer during control handoff ([#134903](https://github.com/openclaw/openclaw/pull/134903)).
+- Align desktop actions with their screenshots and improve small-screen Settings and WebVNC text entry ([#135582](https://github.com/openclaw/openclaw/pull/135582)).
 - Restore Mac Command shortcuts and harden native and portable worker packaging [#136018](https://github.com/openclaw/openclaw/pull/136018)
-- Guide agents to distinguish embedded UI surfaces from browser previews and disclose unverified delivery [#136195](https://github.com/openclaw/openclaw/pull/136195)
 - Classify same-install CLI nodes as local without merging independently paired nodes [#136604](https://github.com/openclaw/openclaw/pull/136604)
 - Preserve ambiguity when current node clients share a display name [#136636](https://github.com/openclaw/openclaw/pull/136636)
 
 **Security and trust**
 
-- Select only capable node-execution targets and stop on ambiguity before dispatch [#131767](https://github.com/openclaw/openclaw/pull/131767) — by [@vyctorbrzezowski](https://github.com/vyctorbrzezowski)
-- Keep Browser Talk's generated consult prompts out of later model context [#135423](https://github.com/openclaw/openclaw/pull/135423) — with thanks to [@Conan-Scott](https://github.com/Conan-Scott)
+- Select only capable execution nodes, require a choice when several qualify, and report the target ([#131767](https://github.com/openclaw/openclaw/pull/131767)). Thanks @vyctorbrzezowski.
 
-**Limits and compatibility**
+</details>
 
-- The automatic same-name legacy migration exception remains only when every competing node client is known to be legacy.
-- Large-response memory evidence is limited to the tested macOS response size and host and does not establish broader Gateway performance.
-- Existing Browser Talk records without the new exclusion marker remain eligible for later context, and separate answer-presentation behavior remains unresolved.
-- Presentation guidance does not add rendering tools or authentication, and generated previews remain unverified until someone exercises the delivered interaction.
+</Accordion>
+
+<Accordion title="Browser Policy and Private Talk Context">
+
+Custom Chrome MCP endpoint arguments now pass through the same hostname policy as the endpoint OpenClaw will actually use, before a subprocess or network connection begins. Unsafe, malformed, empty, duplicate, or conflicting arguments fail clearly without echoing credential-bearing URLs, while trusted overrides and host-local attachment continue to work.
+
+New Browser Talk conversations also keep the internal consultation question, context, and speaking instructions out of later model turns while preserving genuine speech, assistant results, and lossless exports. Existing unflagged records are not rewritten, and the separate decision about how a consultation answer should be presented remains open.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Keep new Browser Talk consultation prompts out of later model context ([#135423](https://github.com/openclaw/openclaw/pull/135423)). Thanks @Conan-Scott.
+- Apply hostname policy to the effective Chrome MCP endpoint before connecting ([#135857](https://github.com/openclaw/openclaw/pull/135857)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Search Dates and Presented Browser Output">
+
+Brave and Tavily search results now preserve valid absolute publication dates in the existing `published` field, helping freshness-sensitive work distinguish when a source was published without treating relative ages, fetch times, arbitrary text, or search filters as publication dates.
+
+Agents also receive clearer guidance for presenting a widget, dashboard, portal, or separate browser preview. The guidance keeps token-bearing launch links private, uses the presentation surface that is actually available, and says when an interaction was not verified. This changes how existing tools are described and selected, not what they can render or which tools are available.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve valid Brave and Tavily publication dates for freshness-sensitive searches ([#136017](https://github.com/openclaw/openclaw/pull/136017)). Thanks @rogerallen1.
+- Distinguish widgets, dashboards, portals, and browser previews while keeping launch links private ([#136195](https://github.com/openclaw/openclaw/pull/136195)).
 
 </details>
 
@@ -1094,138 +1600,261 @@ Windows remote desktops can switch between view-only and control while keeping t
 
 ## Plugins and Integrations
 
-Plugins are easier to install, update, inspect, and remove without letting a convenient recovery path quietly change who owns the code or what it may do. The integrations built on top of them also keep more of their identity and state intact, from a personal GitHub account on a shared Gateway to MCP tools, dashboards, external channels, and plugin-owned transcripts.
+Plugins now behave more like installed software that stays under the operator's control. Updates preserve reviewed state, managed provider removals remain removed after restart, channel setup follows the agent that was actually selected, and the integrations around them do a better job of keeping credentials, errors, and cleanup inside the right boundary.
 
 <AccordionGroup>
 
-<Accordion title="Plugin install, update, consent, disablement, and cleanup">
+<Accordion title="Plugin State Through Installs and Updates">
 
-[Plugin management](/plugins/manage-plugins) now treats the operator's decisions as durable state. An uninstalled managed plugin stays uninstalled after a restart, reinstalling a disabled plugin leaves it disabled until someone explicitly enables it, and setting a channel's `enabled` value to `false` keeps that channel plugin and all of its contributions inactive even when an older plugin entry still says otherwise. Updates from verified first-party sources can skip the blanket capability prompt only when the package and every available official source record agree. Local artifacts, custom registries, conflicting provenance, changed third-party capabilities, and incomplete identity still require review or stop safely, and that first-party exemption does not grant OAuth, operating-system, or runtime tool permissions.
+Verified first-party plugins can move through installation, updates, re-enablement, and Doctor repair without stopping for a capability prompt that OpenClaw can already resolve from matching catalog, package, and source identity. That exception remains deliberately narrow, so local artifacts, third-party packages, custom registries, and conflicting or incomplete provenance still require explicit review.
 
-Removal and recovery are more careful about ownership too. OpenClaw can clean up an exact nonconflicting orphaned path install without deleting another plugin's channel settings, and preserves the working legacy QQ Bot record until its renamed official replacement is runnable. A copied state directory now stops before a plugin-registry refresh can load managed code from the original tree, although intentional external managed npm projects with the same layout are rejected as well and must be reinstalled under the selected state directory.
+Older installs also behave more predictably. Capability acceptance is saved against the replacement artifact during a legacy update, reinstalling a deliberately disabled plugin leaves it disabled until the operator enables it, and registry or inventory reads no longer mistake build-only metadata for a changed plugin. Catalog work does less repeated processing, bundle capabilities remain visible in JSON and verbose inventory, and complete POSIX source builds keep their external plugin dependencies after the checkout moves.
 
-The edges around that lifecycle received a long set of smaller repairs. Plugin inspection preserves the original actionable load failure across retries, older registry records no longer look stale merely because they lack build-only stamps, typed JSX state checkers load correctly, and shutdown or replacement paths clean up each plugin attempt without duplicating teardown. Docker builds that explicitly select WhatsApp now include its runtime, current catalog installs select the compatible Weixin package, and read-only operators can discover why an action is unavailable without gaining permission to perform it. The WhatsApp and Weixin work covers packaging, loading, and compatibility rather than authenticated messaging, the activation-planning optimization does not establish faster total Gateway startup, and the separate source-build dependency-link design remains open.
+An explicit channel-level `enabled: false` now keeps the plugin and all of its contributions inactive. Copied state fails closed before loading managed plugin code from its original tree, and updates rediscover restored or replaced package contents instead of acting on stale filesystem observations.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Reuse prepared plugin aliases during activation planning ([#134812](https://github.com/openclaw/openclaw/pull/134812)).
+- Reuse prepared plugin catalog details across management actions ([#135260](https://github.com/openclaw/openclaw/pull/135260)).
 
 **Bug fixes**
 
-- Include explicitly selected WhatsApp runtime files in source-built Docker images ([#120660](https://github.com/openclaw/openclaw/pull/120660)). Thanks @fr-meyer.
-- Migrate trusted QQ Bot installs from the former npm package without losing channel settings ([#130894](https://github.com/openclaw/openclaw/pull/130894)). Thanks @cxyhhhhh.
-- Defer optional plugin command code until its command is selected ([#133105](https://github.com/openclaw/openclaw/pull/133105)). Thanks @ly85206559.
-- Recover exact nonconflicting orphaned path installs through normal update and uninstall commands ([#134590](https://github.com/openclaw/openclaw/pull/134590)). Thanks @MoerAI, @obviyus, and @abacha.
-- Preserve channel settings owned by another plugin during uninstall ([#134759](https://github.com/openclaw/openclaw/pull/134759)). Thanks @MoerAI, and @abacha.
-- Stop build-only stamps from making unchanged plugin registries look stale ([#134780](https://github.com/openclaw/openclaw/pull/134780)). Thanks @RayWangyangMa, @obviyus, and @axiom-ncis.
-- Select the current SDK-compatible Weixin package and document recovery from 2.4.6 ([#134854](https://github.com/openclaw/openclaw/pull/134854)).
-- Explain blocked plugin actions without duplicating the read-only warning ([#134860](https://github.com/openclaw/openclaw/pull/134860)). Thanks @Patrick-Erichsen.
-- Preserve the original actionable plugin load error across repeated attempts ([#134874](https://github.com/openclaw/openclaw/pull/134874)). Thanks @0xCyda and @Lendersmark.
-- Keep Plugin SDK SQLite WAL retries bounded by a monotonic clock ([#135019](https://github.com/openclaw/openclaw/pull/135019)). Thanks @xialonglee and @obviyus.
-- Retire plugin loads that finish after Gateway shutdown begins ([#135122](https://github.com/openclaw/openclaw/pull/135122)). Thanks @elikampf.
-- Keep explicitly uninstalled managed plugins removed across Gateway restarts ([#135729](https://github.com/openclaw/openclaw/pull/135729)). Thanks @devzeroLL and @obviyus.
-- Load `.mtsx` and `.ctsx` state checkers for source plugins ([#135820](https://github.com/openclaw/openclaw/pull/135820)).
-- Run each interrupted plugin service's stop callback at most once ([#135993](https://github.com/openclaw/openclaw/pull/135993)).
+- Save accepted capabilities when updating an enabled legacy plugin ([#134172](https://github.com/openclaw/openclaw/pull/134172)). Thanks @RileyJJY, @beastyrabbit.
+- Ignore build-only stamps when deciding whether the plugin registry is fresh ([#134780](https://github.com/openclaw/openclaw/pull/134780)). Thanks @RayWangyangMa, @obviyus, @axiom-ncis.
+- Preserve bundle capabilities in JSON and verbose plugin inventory ([#135245](https://github.com/openclaw/openclaw/pull/135245)). Thanks @ssaade01, @tayoun.
+- Keep external plugin dependencies valid after relocating a complete POSIX source build ([#135903](https://github.com/openclaw/openclaw/pull/135903)).
+- Warn when plugin inspection is incomplete and preserve mixed-case configured policy ([#136596](https://github.com/openclaw/openclaw/pull/136596)).
 - Refresh package state around plugin updates so restored or replaced payloads are rediscovered and retired child-plugin entries are removed, while strict package ownership and running-Gateway cache generations remain unchanged ([`d93a9b3`](https://github.com/openclaw/openclaw/commit/d93a9b3497dfed71ea01e0c0369f340fc95608c1)).
 
 **Security and trust**
 
-- Persist accepted capabilities for enabled legacy plugin updates without granting consent silently ([#134172](https://github.com/openclaw/openclaw/pull/134172)). Thanks @RileyJJY and @beastyrabbit.
-- Waive blanket capability prompts only for catalog-verified first-party plugins ([#134933](https://github.com/openclaw/openclaw/pull/134933)).
+- Bypass capability consent only for catalog-verified first-party plugins ([#134933](https://github.com/openclaw/openclaw/pull/134933)).
 - Make a channel-level off switch authoritative over stale enabled plugin entries ([#136211](https://github.com/openclaw/openclaw/pull/136211)).
 - Reject managed plugin roots that ambiguously point outside a copied state directory ([#136373](https://github.com/openclaw/openclaw/pull/136373)). Thanks @LiuwqGit, @obviyus, and @Dresch63.
 
 **Documentation**
 
-- Clarify that reinstall preserves explicit disablement and `--force` does not replace capability consent ([#134875](https://github.com/openclaw/openclaw/pull/134875)).
-
-**Limits and compatibility**
-
-- Exact orphan recovery still fails closed for conflicting ownership, and one inverse nested-path conflict shape was not explicitly covered by the prepared shipped tests.
-- Copied-state protection cannot distinguish an accidental foreign managed root from an intentional external managed npm project with the same layout. Explicit path plugins are unaffected.
-- The separate source-build dependency-link packaging design remains unresolved, and the Weixin and Docker repairs were not verified with authenticated live message roundtrips.
+- Clarify that reinstalling a disabled plugin does not enable it ([#134875](https://github.com/openclaw/openclaw/pull/134875)).
 
 </details>
 
 </Accordion>
 
-<Accordion title="Plugin inspection, SDKs, MCP, GitHub, and connected services">
+<Accordion title="Uninstalling and Repairing Plugins">
 
-People sharing one Gateway can now connect a personal GitHub account and explicitly choose it for **Publish PR** without replacing the system account. A signed-in person manages only their own connection, administrators retain the System and per-agent accounts, and publication is bound to the authenticated owner, the selected connection generation, the authorized session, and the accepted worktree. If that authority changes, OpenClaw stops instead of falling back to another credential, and unfinished personal publication after a restart must be confirmed by the same owner. This connection does not replace ordinary shell credentials, change OpenClaw roles, or turn a personal publication connection into a general GitHub identity for agent commands.
+Uninstalling a managed provider plugin now means it stays uninstalled after the Gateway restarts, even when an old model, provider, or channel choice still refers to it. Reinstalling later does not silently reactivate it, so the final enable step remains an explicit operator choice.
 
-The same identity boundary now reaches authenticated dashboards and local commands. Dashboard widgets can read GitHub Actions through an approved repository-scoped binding without embedding a token, but it is not a generic authenticated proxy and older arbitrary-fetch widgets must migrate. Gateway-hosted local commands use the selected managed GitHub identity at launch or fail with reconnect guidance rather than considering a native account. A running command keeps the credential it launched with, native Codex shell and non-local hosts remain separate, and the Publish PR account chooser only reuses recent successful checks for configured profiles. A remote revocation can therefore remain cached for up to 60 seconds, while an unconfigured host `gh` identity still pays its keyring lookup cost.
+The recovery paths around removal are safer too. Exact orphaned path-source records can be cleaned up through the normal CLI instead of by editing OpenClaw state, another plugin's channel configuration is preserved during that cleanup, and versionless scoped ClawHub packages produce the expected warning when existing Claws still depend on them. Malformed archive names no longer derail staging, while updated 1Password guidance explains how to recover after Homebrew moves the `op` executable without pinning another disposable path.
 
-MCP and plugin tools are less likely to disappear midway through a turn. Explicitly allowed namespaced tools remain visible without changing deny precedence or runtime grants, requester-scoped MCP connections stay alive while their tools are being resolved, and configured MCP can move to OpenClaw's policy-filtered surface when Codex native tools are disabled. Each turn still has one configured-MCP owner, approvals and durable grants remain enforced, and approval-requiring tools are not persisted into app views. OAuth-enabled Streamable HTTP and SSE servers that require sized request bodies can now initialize and refresh correctly, but the separate in-Gateway bearer-placeholder defect remains open.
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
 
-Plugin authors and integration operators get clearer building blocks around those workflows. Inventories now show bundle skills, commands, and MCP servers, TSX plugins produce runnable artifacts, packaged setup providers and migrations are discovered, source mounts win after the documented restart, and custom transcript stores remain consistent across reads, writes, locks, publication, and catalog imports. Voice Call setup catches an unowned multi-agent configuration before provisioning, Feishu document results stop claiming rejected permission or image operations succeeded, Twitch errors name the correct credential key, and channel commands preserve the explicitly selected agent through plugin discovery. The retained Plugin SDK paths remain available only through the renewed October 1 review window while external migrations and one modern public replacement are still unfinished.
+**Bug fixes**
+
+- Recover exact orphan plugin records through normal update and uninstall commands ([#134590](https://github.com/openclaw/openclaw/pull/134590)). Thanks @MoerAI, @obviyus, @abacha.
+- Preserve another plugin's channel settings during orphan cleanup ([#134759](https://github.com/openclaw/openclaw/pull/134759)). Thanks @MoerAI and @abacha.
+- Keep explicitly uninstalled managed provider plugins removed after restart ([#135729](https://github.com/openclaw/openclaw/pull/135729)). Thanks @devzeroLL, @obviyus.
+- Warn before removing scoped ClawHub plugins that still support existing Claws ([#135749](https://github.com/openclaw/openclaw/pull/135749)). Thanks @teddytennant, @obviyus.
+- Give malformed ClawHub archive names a safe temporary target ([#135803](https://github.com/openclaw/openclaw/pull/135803)). Thanks @teddytennant.
+
+**Documentation**
+
+- Explain recovery after Homebrew changes a 1Password CLI path ([#134832](https://github.com/openclaw/openclaw/pull/134832)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Channel Setup for the Selected Agent">
+
+Multi-agent operators can select the intended agent for channel add, channel-specific capabilities, login, logout, remove, and resolve, with that workspace retained while OpenClaw discovers, installs, or reloads the channel plugin. The existing System Agent, sole-agent, and legacy-owner rules still apply when no selector is supplied, while ambiguous or invalid ownership stops before authentication or setup begins.
+
+Channel status also stops advertising accounts that were explicitly disabled, and Twitch's outbound setup error now names the real `accessToken` setting. The separate Twitch connection-time diagnostic still needs the same wording correction.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Hide explicitly disabled manifest accounts from channel capabilities and status ([#135417](https://github.com/openclaw/openclaw/pull/135417)). Thanks @ly85206559.
+- Name Twitch's `accessToken` setting in outbound setup errors ([#135421](https://github.com/openclaw/openclaw/pull/135421)). Thanks @ly85206559.
+- Preserve the selected agent across channel setup and plugin discovery ([#135505](https://github.com/openclaw/openclaw/pull/135505)). Thanks @abacha, @Hansen1018.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Personal GitHub Accounts and Authenticated Dashboards">
+
+People sharing a Gateway can connect their own GitHub account from Profile and explicitly choose it for Publish PR without replacing the System account or an agent account. Publication remains bound to the signed-in owner, selected connection, authorized session, and accepted worktree state, and an uncertain publication can be confirmed by that same owner after a restart. This does not replace ordinary shell credentials or turn a personal publication connection into a general GitHub identity for agent commands.
+
+Gateway-hosted commands that use a managed GitHub profile stay with the credential selected at process launch. If that profile disappears or loses its token, later commands stop with reconnect guidance instead of falling back to a native account, while already running commands retain their launch credential. Dashboards can read GitHub Actions through a repository-scoped grant and the owning agent's authenticated access without exposing a token or creating a general authenticated proxy; existing anonymous widgets need to be updated or regenerated, and Publish PR credential checks may remain cached for up to 60 seconds.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Let shared-Gateway users connect a personal GitHub account and select it explicitly for Publish PR ([#133799](https://github.com/openclaw/openclaw/pull/133799)).
-- Defer bundled web-search provider code until the selected provider runs ([#135073](https://github.com/openclaw/openclaw/pull/135073)).
-- Reduce repeated plugin catalog processing while preserving authority and output ([#135260](https://github.com/openclaw/openclaw/pull/135260)).
-- Give plugin authors a supported facade over OpenClaw's node CLI helpers ([#135303](https://github.com/openclaw/openclaw/pull/135303)).
-- Reuse recent successful GitHub credential checks in the Publish PR chooser ([#136223](https://github.com/openclaw/openclaw/pull/136223)).
+- Connect personal GitHub accounts alongside System and agent accounts ([#133799](https://github.com/openclaw/openclaw/pull/133799)).
+- Reuse recent successful credential checks in the Publish PR account chooser ([#136223](https://github.com/openclaw/openclaw/pull/136223)).
+
+**Bug fixes**
+
+- Show GitHub connection failures once in Profile settings ([#135428](https://github.com/openclaw/openclaw/pull/135428)).
+- Replace dashboard widget records instead of returning stale props ([#135748](https://github.com/openclaw/openclaw/pull/135748)). Thanks @teddytennant, @obviyus.
+- Check for the `gh` CLI before beginning GitHub device authorization ([#135301](https://github.com/openclaw/openclaw/pull/135301)). Thanks @mushuiyu886, @obviyus, and @jadabreu.
+
+**Security and trust**
+
+- Stop managed GitHub exec from falling back to a native account ([#134351](https://github.com/openclaw/openclaw/pull/134351)).
+- Read GitHub Actions through the owning agent's bounded repository grant ([#135740](https://github.com/openclaw/openclaw/pull/135740)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="WhatsApp, QQ Bot, and Weixin Plugin Updates">
+
+Source-built Docker images now include the WhatsApp runtime when it is explicitly selected, rather than accepting the choice and producing an image without the channel. Existing QQ Bot installs recorded under the former `@openclaw/qqbot` package can move to `@tencent-connect/openclaw-qqbot` 2.0.3 while preserving channel configuration and credentials, with failed updates leaving the working legacy record in place.
+
+Catalog-driven Weixin installs now select the SDK-compatible 2.4.8 package, and affected 2.4.6 operators have explicit update and restart guidance. The evidence verifies package selection, integrity, and compatibility rather than an authenticated Weixin message roundtrip.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Package the explicitly selected WhatsApp runtime in Docker source builds ([#120660](https://github.com/openclaw/openclaw/pull/120660)). Thanks @fr-meyer.
+- Migrate trusted legacy QQ Bot installs to the renamed official package ([#130894](https://github.com/openclaw/openclaw/pull/130894)). Thanks @cxyhhhhh.
+- Select the Weixin package compatible with the current Plugin SDK ([#134854](https://github.com/openclaw/openclaw/pull/134854)).
+
+**Documentation**
+
+- Align Matrix, Signal, and WhatsApp guides with npm-first plugin installation ([#136605](https://github.com/openclaw/openclaw/pull/136605)). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Voice Call Setup and Feishu Document Results">
+
+Voice Call setup now catches a missing response owner before telephony resources start on a multi-agent installation and points directly to `plugins.entries.voice-call.config.agentId`. Single-agent and explicitly owned setups keep their existing behavior, while affected multi-agent operators need to rerun setup and restart the Gateway after choosing the owner.
+
+Voice Call diagnostic commands now stream large custom logs with backpressure, follow rotation and truncation more carefully, and honor whether SQLite history should start with retained records or only new ones. Feishu document actions also stop counting rejected access grants or image replacements as successes, while retaining a document that was created successfully and continuing with later images after one replacement fails.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Report missing Voice Call ownership during multi-agent setup ([#134739](https://github.com/openclaw/openclaw/pull/134739)). Thanks @felixboenkost-droid.
+- Stream Voice Call diagnostics with backpressure and correct history handling ([#134838](https://github.com/openclaw/openclaw/pull/134838)). Thanks @sunlit-deng.
+- Validate Feishu access grants and image replacements before reporting success ([#135106](https://github.com/openclaw/openclaw/pull/135106)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Plugin Startup and Shutdown">
+
+Optional command implementations for memory-wiki, policy, QA Lab, and Voice Call now load only when their command is selected, while bundled web-search providers keep executable runtime code unloaded until OpenClaw chooses one. Activation planning reuses prepared alias work as well, but those component improvements do not establish a universal or end-to-end Gateway startup speedup.
+
+When a plugin does fail, retries preserve the original actionable load error instead of making a rejected module graph appear to recover through a fallback. SQLite-backed plugin state keeps its bounded WAL retry through wall-clock changes, loads that finish after shutdown begins are retired, and interrupted service startup shares one cleanup result so a stop handler is not called twice for the same attempt.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reuse plugin alias resolution during activation planning ([#134812](https://github.com/openclaw/openclaw/pull/134812)).
+- Defer bundled web-search provider runtimes until a provider is selected ([#135073](https://github.com/openclaw/openclaw/pull/135073)).
 - Create temporary provider objects only for the providers selected by a lookup ([#136398](https://github.com/openclaw/openclaw/pull/136398)).
 
 **Bug fixes**
 
-- Keep explicitly allowed namespaced plugin and connected-node tools visible to agents ([#132753](https://github.com/openclaw/openclaw/pull/132753)). Thanks @tommyjoseph.
-- Announce completed ClawHub searches and result counts to screen readers ([#133091](https://github.com/openclaw/openclaw/pull/133091)). Thanks @SunnyShu0925.
-- Build runnable TSX plugins and discover packaged setup providers and migrations ([#136458](https://github.com/openclaw/openclaw/pull/136458)).
+- Delay optional plugin CLI implementations until their commands are invoked ([#133105](https://github.com/openclaw/openclaw/pull/133105)). Thanks @ly85206559.
+- Preserve the original plugin load error across retries ([#134874](https://github.com/openclaw/openclaw/pull/134874)). Thanks @0xCyda, @Lendersmark.
+- Keep Plugin SDK SQLite WAL retries bounded across wall-clock changes ([#135019](https://github.com/openclaw/openclaw/pull/135019)). Thanks @xialonglee, @obviyus.
+- Retire plugin loads that complete after Gateway shutdown begins ([#135122](https://github.com/openclaw/openclaw/pull/135122)). Thanks @elikampf.
+- Run an interrupted plugin service's stop handler once per startup attempt ([#135993](https://github.com/openclaw/openclaw/pull/135993)).
 - Refresh persisted registries when bundled-plugin source mounts change ([#136517](https://github.com/openclaw/openclaw/pull/136517)).
 - Run command-owned plugin cleanup before local message actions exit ([#136564](https://github.com/openclaw/openclaw/pull/136564)). Thanks @gumadeiras.
-- Warn when plugin inspection is incomplete and preserve mixed-case configured policy ([#136596](https://github.com/openclaw/openclaw/pull/136596)).
-- Align the Plugins Workshop column with the rest of the hub ([61404b6](https://github.com/openclaw/openclaw/commit/61404b6c2a91871b2a4f5819ca98b06a90077796), from [#134871](https://github.com/openclaw/openclaw/pull/134871)). Thanks @Patrick-Erichsen.
-- Stop Voice Call setup before provisioning when a multi-agent installation has no response owner ([#134739](https://github.com/openclaw/openclaw/pull/134739)). Thanks @felixboenkost-droid.
-- Keep requester-scoped MCP runtimes alive throughout active resolution ([#134819](https://github.com/openclaw/openclaw/pull/134819)). Thanks @qingminglong and @obviyus.
-- Stream large Voice Call diagnostic logs with bounded reads and output backpressure ([#134838](https://github.com/openclaw/openclaw/pull/134838)). Thanks @sunlit-deng.
-- Preserve configured MCP tools in native-disabled Codex turns ([#134941](https://github.com/openclaw/openclaw/pull/134941)). Thanks @itsuzef and @obviyus.
-- Report rejected Feishu permission grants and image replacements truthfully ([#135106](https://github.com/openclaw/openclaw/pull/135106)).
-- Show plugin bundle skills, commands, and MCP servers in JSON and verbose inventory ([#135245](https://github.com/openclaw/openclaw/pull/135245)). Thanks @ssaade01 and @tayoun.
-- Check for the `gh` CLI before beginning GitHub device authorization ([#135301](https://github.com/openclaw/openclaw/pull/135301)). Thanks @mushuiyu886, @obviyus, and @jadabreu.
-- Stop channel status from advertising explicitly disabled manifest accounts ([#135417](https://github.com/openclaw/openclaw/pull/135417)). Thanks @ly85206559.
-- Name Twitch's actual `accessToken` key in setup and missing-credential errors ([#135421](https://github.com/openclaw/openclaw/pull/135421)). Thanks @ly85206559.
-- Show GitHub connection failures once and keep them visible outside collapsed details ([#135428](https://github.com/openclaw/openclaw/pull/135428)).
-- Preserve the selected agent through multi-agent channel add, login, logout, remove, resolve, and capability checks ([#135505](https://github.com/openclaw/openclaw/pull/135505)). Thanks @abacha and @Hansen1018.
-- Clear stale dashboard widget props consistently across updates and reopen ([#135748](https://github.com/openclaw/openclaw/pull/135748)). Thanks @teddytennant and @obviyus.
-- Warn before uninstalling versionless scoped ClawHub plugins used by existing Claws ([#135749](https://github.com/openclaw/openclaw/pull/135749)). Thanks @teddytennant and @obviyus.
-- Stage and clean up ClawHub archives whose sanitized names become dot segments ([#135803](https://github.com/openclaw/openclaw/pull/135803)). Thanks @teddytennant.
-- Keep external plugin dependencies valid after relocating a complete POSIX source build ([#135903](https://github.com/openclaw/openclaw/pull/135903)).
-- Load bundled artwork for trusted first-party plugin icons ([#135957](https://github.com/openclaw/openclaw/pull/135957)). Thanks @obviyus and @Grynn.
-- Resolve optional strict transcript appends through the selected store ([#136201](https://github.com/openclaw/openclaw/pull/136201)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Plugin SDK Compatibility and Session APIs">
+
+External plugins built against the 2026.8.1 SDK keep their conversation-binding inspection import, and accepted legacy `docks` commands remain reachable under Tools after upgrade. Plugin authors also gain a supported facade for the same node CLI helpers OpenClaw uses, while source plugins can load `.mtsx` and `.ctsx` configured-state or persisted-auth checkers without falsely reporting that state as absent.
+
+Strict single-message and atomic-batch transcript appends can once again omit the documented optional `storePath` and resolve the selected agent's configured or default store. Explicit-environment integrations can create and reopen non-main incognito sessions without replacing the process environment, with incognito data remaining memory-only. Corrected migration guidance separates public SDK exports, retained compatibility imports, injected alternatives, and compatibility deadlines without claiming new runtime exports.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Publish supported node CLI helpers for plugin authors and Canvas ([#135303](https://github.com/openclaw/openclaw/pull/135303)).
+
+**Bug fixes**
+
+- Preserve external plugin inspection imports and legacy command definitions through upgrade ([#135322](https://github.com/openclaw/openclaw/pull/135322)).
+- Load `.mtsx` and `.ctsx` source-plugin state checkers ([#135820](https://github.com/openclaw/openclaw/pull/135820)).
+- Resolve the optional store path for strict transcript appends ([#136201](https://github.com/openclaw/openclaw/pull/136201)).
+- Keep explicit environments attached to incognito session creation ([#136227](https://github.com/openclaw/openclaw/pull/136227)).
+- Keep explicitly allowed namespaced plugin and connected-node tools visible to agents ([#132753](https://github.com/openclaw/openclaw/pull/132753)). Thanks @tommyjoseph.
 - Keep plugin transcript operations in the configured custom store ([#136221](https://github.com/openclaw/openclaw/pull/136221)).
-- Keep explicit-environment incognito session creation and reopen on the same owner ([#136227](https://github.com/openclaw/openclaw/pull/136227)).
-- Send sized OAuth-authenticated MCP request bodies on initial and refreshed attempts ([#136234](https://github.com/openclaw/openclaw/pull/136234)). Thanks @LiuwqGit, @obviyus, and @Volevanius.
-
-**Security and trust**
-
-- Bind Gateway-hosted local commands to the selected managed GitHub identity or fail closed ([#134351](https://github.com/openclaw/openclaw/pull/134351)).
-- Read GitHub Actions through the owning agent's repository-scoped dashboard grant ([#135740](https://github.com/openclaw/openclaw/pull/135740)).
+- Build runnable TSX plugins and discover packaged setup providers and migrations ([#136458](https://github.com/openclaw/openclaw/pull/136458)).
 
 **Documentation**
 
-- Explain recovery from Homebrew `op` path changes through the managed 1Password plugin ([#134832](https://github.com/openclaw/openclaw/pull/134832)).
-- Align Matrix, Signal, and WhatsApp guides with npm-first plugin installation ([#136605](https://github.com/openclaw/openclaw/pull/136605)). Thanks @vincentkoc.
-- Correct Plugin SDK migration paths and compatibility-deadline guidance ([#136024](https://github.com/openclaw/openclaw/pull/136024)).
+- Correct Plugin SDK migration paths and compatibility deadline guidance ([#136024](https://github.com/openclaw/openclaw/pull/136024)).
 
 **Limits and compatibility**
 
-- Retain the shipped conversation-binding inspection import and legacy command definitions for external plugins ([#135322](https://github.com/openclaw/openclaw/pull/135322)).
 - Renew the review window for five removal-pending Plugin SDK paths through October 1, 2026 ([#136698](https://github.com/openclaw/openclaw/pull/136698)).
-- Personal GitHub publication does not change verified sign-in identity, OpenClaw roles, ordinary shell credentials, model-initiated publication, repository previews, or cloud-worker credentials, and no real personal push or PR creation was demonstrated.
-- Authenticated dashboard reads are repository-scoped and require migration from arbitrary-fetch widgets. They do not expose a generic authenticated proxy or use preview and publication-only credentials.
-- Managed GitHub exec binds credentials at process launch. Immediate revocation, native Codex shell, non-local hosts, and operating-system user isolation remain separate boundaries.
-- Configured MCP has one owner per turn, and the OAuth request-size repair does not fix the separate in-Gateway bearer-placeholder defect.
-- Versionless scoped ClawHub dependency warnings cover canonical package records, parseable specifications, and plugin-ID fallback, not older records that retain only a resolved specification.
-- POSIX source-build relocation is covered, while Windows relocation remains unsupported and untested. Native MJS reload and cache invalidation also remain unresolved.
-- The compatibility window changes review timing only. External-plugin migrations remain unverified, one retained path still lacks a modern public replacement, and readiness by October 1 is unknown.
+
+</details>
+
+</Accordion>
+
+<Accordion title="MCP Connections, Tools, and Request Sizing">
+
+OpenClaw can connect to OAuth-enabled Streamable HTTP and SSE MCP servers that reject POST requests without a known size, including through `openclaw mcp probe`. The initial authenticated request and one token-refresh retry now reuse the same sized payload while changing only the bearer authorization. This does not fix the separate in-Gateway path that can send an unexpanded bearer-token placeholder.
+
+Configured MCP tools remain available in Codex turns when native tools are disabled, with approvals, grants, naming, and cleanup still enforced. Requester-scoped connections stay alive for the tools that depend on them, alongside the existing sized OAuth request and token-refresh behavior.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Send OAuth MCP requests with a known request size across token refresh ([#136234](https://github.com/openclaw/openclaw/pull/136234)). Thanks @LiuwqGit, @obviyus, @Volevanius.
+- Keep requester-scoped MCP runtimes alive throughout active resolution ([#134819](https://github.com/openclaw/openclaw/pull/134819)). Thanks @qingminglong and @obviyus.
+- Preserve configured MCP tools in native-disabled Codex turns ([#134941](https://github.com/openclaw/openclaw/pull/134941)). Thanks @itsuzef and @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Plugins Hub Accessibility and Polish">
+
+ClawHub search now tells screen-reader users when a search finishes and how many results it found, while preserving the visible layout and stale-result protection. Read-only operators see one permissions warning instead of a duplicate page alert, and blocked actions can explain themselves through focus, hover, or tap without attempting a mutation.
+
+First-party catalog entries use artwork already bundled with OpenClaw when it is available, avoiding fallback letter tiles and unnecessary remote icon requests when the CDN is blocked, while third-party artwork retains the authenticated proxy path. The Workshop tab also lines up with the shared Plugins content column on wide screens without changing its narrow layout.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Announce ClawHub search completion and result counts to assistive technology ([#133091](https://github.com/openclaw/openclaw/pull/133091)). Thanks @SunnyShu0925.
+- Replace the duplicate plugin admin warning with explanations on blocked actions ([#134860](https://github.com/openclaw/openclaw/pull/134860)). Thanks @Patrick-Erichsen.
+- Use bundled artwork for trusted scoped first-party plugin icons ([#135957](https://github.com/openclaw/openclaw/pull/135957)). Thanks @obviyus, @Grynn.
+- Align Plugins Workshop with the shared content column for #134871 ([`61404b6c2a`](https://github.com/openclaw/openclaw/commit/61404b6c2a91871b2a4f5819ca98b06a90077796)). Thanks @Patrick-Erichsen.
 
 </details>
 
@@ -1235,91 +1864,89 @@ Plugin authors and integration operators get clearer building blocks around thos
 
 ## Security and Privacy
 
-OpenClaw can now remember an eligible approval without turning it into blanket permission, and delegated work keeps checking the authority that started it before new persistent effects begin. Around that core, private workspaces, diagnostics, credential entry, saved reasoning, sign-in, and network-facing integrations each get narrower protections of their own, with the remaining boundaries called out where they still matter.
+OpenClaw can now remember an eligible approval without turning it into blanket permission. Durable MCP grants remain tied to one agent, configured server, and tool, remote Codex placement grants remain tied to the process and placement that earned them, and stricter session or server policy still wins. The same boundary now follows delegated agent creation more carefully, while private diagnostics, saved reasoning, network requests, guest workspaces, and administrative automation each get narrower protections of their own.
 
 <AccordionGroup>
 
-<Accordion title="Approvals, delegation, and durable authority">
+<Accordion title="Scoped Durable Approvals">
 
-Codex now follows the effective session posture when deciding whether an MCP tool needs approval, so default full-permission sessions do not stop for repeated cards while stricter postures and explicit server overrides still win. Allow Always follows an approved tool across argument and working-directory changes for the current session, and eligible tools on OpenClaw-configured servers can receive a durable grant tied to the exact agent, server, and tool. Those durable grants survive later Codex sessions and Gateway restarts, can be inspected or revoked through the existing approvals workflow, and still exclude Codex apps, native plugin servers, and computer-use servers. An explicit `prompt` mode continues to ask every time, and ambiguous tool matches fail closed.
+Codex now follows the effective session posture when deciding whether an MCP tool needs approval, so a default full-permission session can use an unannotated tool without stopping for a permission card on every call. Stricter postures and explicit server overrides still apply, and Allow Always follows the tool across argument and working-directory changes for the current session. For an eligible MCP tool on an OpenClaw-configured server, that choice can also become a durable grant for the exact agent, server, and tool across later sessions and Gateway restarts; Codex apps, native plugin servers, computer-use servers, explicit `prompt` mode, and ambiguous matches remain outside it.
 
-Remote Codex placement approvals deliberately remember less. They can be reused only while the same placement, pairing, environment, workspace, parent approval, and Gateway process remain valid, so a restart, move, re-pairing, authority change, or expiry requires a fresh decision. Approval lifetimes entered through the CLI must now be whole positive days within the existing range, and authorized operators can rotate or revoke approved scoped node tokens without gaining a broader role or scope than the device was approved for.
-
-The same authority boundary now reaches later into delegated agent creation and delegated setup. When the requesting run closes, OpenClaw stops before beginning the next workspace, identity, session, configuration, or migration effect, while a write that already started may finish and a fully published agent remains available. Earlier completed setup effects also remain, and an interrupted legacy-session migration may still need normal startup recovery or `openclaw doctor --fix`.
-
-Sandbox-required guests can once again edit files, run project-local commands, and delegate child work inside private writable storage without exposing the shared workspace. Explicit read-only workspaces remain read-only, managed skill overlays remain read-only, existing containers are recreated for the new mount format, and networking stays off unless an operator enables it. The bundled autoreview also stays within the selected checkout and scans complete frozen inputs before dispatch, but TruffleHog is now a fail-closed requirement and global Git line endings and streaming capture remain separate follow-up work.
+Remote Codex placement approvals use a narrower lifetime. Allow Always can be reused while the same placement, pairing, environment, workspace, parent approval, and Gateway process remain valid, but a restart, move, re-pairing, authority change, or expiry requires a fresh decision. Approval lifetimes entered through the CLI must now be whole positive days within the existing range, so malformed input leaves the approval pending instead of silently choosing a different duration.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Reuse approval for the same active remote Codex placement [#132370](https://github.com/openclaw/openclaw/pull/132370). Thanks @jalehman.
-- Preserve eligible MCP tool grants across Codex sessions and Gateway restarts [#136019](https://github.com/openclaw/openclaw/pull/136019).
+- Reuse Allow Always for the same active remote Codex placement ([#132370](https://github.com/openclaw/openclaw/pull/132370)). Thanks @jalehman.
+- Persist eligible MCP tool grants across Codex sessions and Gateway restarts ([#136019](https://github.com/openclaw/openclaw/pull/136019)).
 
 **Bug fixes**
 
-- Reject malformed approval lifetimes without resolving the pending request [#133806](https://github.com/openclaw/openclaw/pull/133806). Thanks @qingminglong.
-- Restore authorized rotation and revocation of approved scoped node tokens [#135617](https://github.com/openclaw/openclaw/pull/135617).
-- Restore writable guest coding and child work inside private sandboxes [#135702](https://github.com/openclaw/openclaw/pull/135702). Thanks @whyuds.
-- Follow the Codex session posture and honor Allow Always across tool inputs [#135812](https://github.com/openclaw/openclaw/pull/135812).
-
-**Security and trust**
-
-- Stop delegated agent creation before new effects begin after authority closes [#136090](https://github.com/openclaw/openclaw/pull/136090).
-- Stop delegated setup writes after the requesting run closes [#136247](https://github.com/openclaw/openclaw/pull/136247).
-- Keep bundled autoreview input inside one checkout and scan it before dispatch [#136278](https://github.com/openclaw/openclaw/pull/136278). Thanks @jodok.
-
-**Documentation**
-
-- Explain the existing authority required to resume an incognito API session [#126419](https://github.com/openclaw/openclaw/pull/126419). Thanks @drobison00.
+- Reject malformed approval grant lifetimes without resolving the approval ([#133806](https://github.com/openclaw/openclaw/pull/133806)). Thanks @qingminglong.
+- Follow the Codex session posture and honor Allow Always across tool inputs ([#135812](https://github.com/openclaw/openclaw/pull/135812)).
+- Preserve hidden plugin-tool progress settings through caching and provider normalization [#132266](https://github.com/openclaw/openclaw/pull/132266). Thanks @MonkeyLeeT and @mir-stream.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Credentials, privacy, role recovery, sandboxing, and network limits">
+<Accordion title="Delegated Agent Authority">
 
-Several places that legitimately handle private data now expose less of it. Doctor no longer scans sibling account homes and masks secret-shaped archive errors before persisting recovery failures, iOS no longer records complete agent deep-link URLs in diagnostics, and Gateway configuration responses redact credentials and SecretRef identifiers from pre-migration snapshots. Android now masks Gateway credentials and secret replies, preserves secret whitespace, and returns to ordinary input after a sensitive step, although password-style input flags cannot guarantee what a third-party keyboard stores and changing sensitivity can require tapping the field again.
+Delegated agent creation now keeps checking the authority of the run that requested it through workspace, identity, session, and configuration writes. If that run ends while creation is still being prepared, OpenClaw stops before starting the next persistent effect instead of finishing later and reporting success for a request that is no longer authorized. Users can check `openclaw agents list` and retry from an active run.
 
-New Codex turns also keep saved reasoning as typed thinking instead of showing it as ordinary answer text. It appears under **Worked** only when the session explicitly uses `/reasoning on` and the local **View → Reasoning** control is enabled. Previously malformed transcript rows are not rewritten, and separate provider or channel-streaming reasoning leaks are outside this fix.
-
-Linux Gateway reinstall and uninstall now remove credentials from managed systemd backups, restrict those files to the owner, and let Status and Doctor identify unsafe remnants without printing their contents. Operators who find one should reinstall and rotate the affected credential. The prepared review still records an unresolved blank-line parsing risk in systemd sanitization, so this is not a claim that every backup shape is handled safely. Container and Fleet guidance now also makes the actual storage boundary explicit, since ordinary OpenClaw state and its backups can contain usable OAuth credentials while the separate key directory applies only to legacy encrypted-sidecar recovery. That guidance and the dependency advisory updates do not by themselves establish a broader exploitable product path.
-
-Authentication and ingress failures stop more cleanly. Named-role Gateway clients pause instead of reconnecting forever when verified identity is required, rejected mobile setup codes point people to a fresh code and the paired-device list, Azure OpenAI BYOK proxy requests are authenticated as belonging to the active Copilot session, and authenticated A2A, managed webhook, and SMS callback paths have tighter resource and client boundaries. These are scoped repairs rather than a general security guarantee, and some proofs used controlled services instead of live external traffic.
-
-Operators can now deny exact hosts and wildcard subdomains across browser access, guarded web fetches, and automation webhooks before existing allow rules run. Wildcards cover subdomains but not the apex host, the blocklist is not a complete browser egress firewall, and supported Chrome MCP endpoints supplied only through `mcpArgs` remain outside the shipped check. Conditional configuration updates and machine-readable Secrets CLI failures make administrative automation less likely to overwrite changed state or mishandle an error, without changing secret storage or weakening existing policy.
+The boundary is forward-looking rather than destructive. A filesystem write that already started may finish, a fully published agent remains available, and its required bookkeeping can complete rather than leaving partial state behind.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
-**Improvements**
+**Security and trust**
 
-- Add deny-first hostname blocklists for browser, web-fetch, and webhook traffic [#135097](https://github.com/openclaw/openclaw/pull/135097).
-- Guard direct configuration updates with an expected current value [#136137](https://github.com/openclaw/openclaw/pull/136137). Thanks @vincentkoc.
+- Stop delegated agent creation after the requesting run loses authority ([#136090](https://github.com/openclaw/openclaw/pull/136090)).
+- Stop delegated setup writes after the requesting run closes [#136247](https://github.com/openclaw/openclaw/pull/136247).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Guest Coding Inside Private Workspaces">
+
+Sandbox-required guests can once again write files, patch code, run project-local commands, and delegate work inside a private workspace with `workspaceAccess` set to `none`. The shared agent workspace and host credentials remain outside that boundary, managed skill overlays remain read-only, an explicit `ro` workspace remains read-only, and networking stays off unless an operator enables it.
+
+Existing containers are recreated once to adopt the new mount format. Public cloning and dependency downloads still need operator-enabled networking, and arbitrary shell enforcement on a remote host still depends on that remote operator's filesystem policy.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Keep sibling account paths out of Doctor state checks [#122586](https://github.com/openclaw/openclaw/pull/122586). Thanks @vincentkoc, @lidge-jun, and @richard-scott.
-- Preserve hidden plugin-tool progress settings through caching and provider normalization [#132266](https://github.com/openclaw/openclaw/pull/132266). Thanks @MonkeyLeeT and @mir-stream.
-- Fail GitHub-backed named-role sign-in clearly when identity cannot be verified [#134724](https://github.com/openclaw/openclaw/pull/134724).
-- Give rejected mobile setup codes an actionable recovery path [#134795](https://github.com/openclaw/openclaw/pull/134795). Thanks @eleqtrizit.
-- Keep Secrets CLI failures machine-readable in JSON mode [#136142](https://github.com/openclaw/openclaw/pull/136142). Thanks @qingminglong and @obviyus.
-- Pause clients and show recovery guidance when Gateway roles require verified identity [#136420](https://github.com/openclaw/openclaw/pull/136420). Thanks @obviyus and @aoclaw-glitch.
+- Restore writable guest coding and delegated work inside private isolated workspaces ([#135702](https://github.com/openclaw/openclaw/pull/135702)). Thanks @whyuds.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Private Data in Inputs, Backups, and Diagnostics">
+
+Doctor now compares the selected state directory only with the effective account's default, avoiding sibling home-directory paths and unrelated backup warnings on shared systems. If a targeted session import or restore cannot archive a transcript, its durable migration record keeps useful failure details and the original recovery source while masking secret-shaped values; iOS agent deep links omit the complete incoming URL from diagnostics, and configuration responses redact credentials, SecretRef identifiers, and internal plugin metadata from pre-migration snapshots.
+
+These protections are scoped to the named Doctor, iOS, and configuration-response paths. Snapshot redaction does not change stored configuration or migration inputs, and it does not repair the separate startup or runtime corruption symptoms that were not reproduced by the configuration fix.
+
+Android masks Gateway credentials and secret replies, preserves intentional whitespace, and returns to ordinary input after a sensitive step. Linux Gateway reinstall and uninstall also remove reusable credentials from managed systemd backups, restrict retained files to their owner, and let Doctor identify unsafe remnants without printing their contents.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
 
 **Security and trust**
 
-- Redact secret-shaped values from durable Doctor archive failures [#122628](https://github.com/openclaw/openclaw/pull/122628). Thanks @sunlit-deng and @obviyus.
+- Keep sibling account paths out of Doctor state-directory checks ([#122586](https://github.com/openclaw/openclaw/pull/122586)). Thanks @vincentkoc, @lidge-jun, @richard-scott.
+- Redact secret-shaped values from durable Doctor archive failures ([#122628](https://github.com/openclaw/openclaw/pull/122628)). Thanks @sunlit-deng, @obviyus.
+- Omit iOS agent deep-link URLs from diagnostic logs ([#134738](https://github.com/openclaw/openclaw/pull/134738)). Thanks @eleqtrizit.
+- Redact pre-migration configuration snapshots returned by diagnostics ([#134940](https://github.com/openclaw/openclaw/pull/134940)). Thanks @joemc1470.
 - Sanitize and restrict managed Linux Gateway backup files [#131786](https://github.com/openclaw/openclaw/pull/131786). Thanks @vyctorbrzezowski.
-- Bound authenticated A2A batches and response sizes [#134603](https://github.com/openclaw/openclaw/pull/134603). Thanks @eleqtrizit.
-- Attribute managed webhook rate limits to the validated client [#134622](https://github.com/openclaw/openclaw/pull/134622). Thanks @eleqtrizit.
-- Omit complete iOS agent deep-link URLs from diagnostic logs [#134738](https://github.com/openclaw/openclaw/pull/134738). Thanks @eleqtrizit.
-- Authenticate Azure OpenAI BYOK proxy requests from the active Copilot session [#134781](https://github.com/openclaw/openclaw/pull/134781). Thanks @eleqtrizit.
-- Redact pre-migration credentials returned by configuration diagnostics [#134940](https://github.com/openclaw/openclaw/pull/134940). Thanks @joemc1470.
-- Keep newly saved Codex reasoning hidden unless explicitly enabled [#136008](https://github.com/openclaw/openclaw/pull/136008).
-- Limit simultaneous unauthenticated SMS webhook body reads [#136504](https://github.com/openclaw/openclaw/pull/136504). Thanks @drobison00.
+- Keep bundled autoreview input inside one checkout and scan it before dispatch [#136278](https://github.com/openclaw/openclaw/pull/136278). Thanks @jodok.
 - Mask Android credentials and secret replies during sensitive input [#136352](https://github.com/openclaw/openclaw/pull/136352).
-- Update affected URI and mail dependencies to patched versions [#136700](https://github.com/openclaw/openclaw/pull/136700).
 
 **Documentation**
 
@@ -1329,76 +1956,240 @@ Operators can now deny exact hosts and wildcard subdomains across browser access
 
 </Accordion>
 
-</AccordionGroup>
+<Accordion title="Saved Codex Reasoning">
 
-## Quality-of-Life Improvements
+Newly recorded Codex dashboard turns now keep reasoning as typed thinking instead of mirroring it into ordinary answer text. Saved reasoning appears under **Worked** only when the session explicitly uses `/reasoning on` and the local **View → Reasoning** control is enabled, while `off` and `stream` keep it hidden after reload without hiding the final answer.
 
-OpenClaw does less avoidable work while a conversation, installation, or command gets larger. The result is not one blanket speed claim, but a collection of practical improvements where long replies, large session histories, busy Gateways, routine commands, and the tools used to understand them keep less temporary state and give more accurate feedback.
+Previously malformed transcript rows are not rewritten. This change is also limited to saved Codex reasoning in the Control UI and does not resolve separate provider or channel-streaming leakage reports.
 
-<AccordionGroup>
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
 
-<Accordion title="Lower overhead in conversations, catalogs, streams, and Gateways">
+**Security and trust**
 
-Large saved-session histories now stay lighter during ordinary conversations, and opening a full model catalog, resetting a very large conversation, or leaving a code-heavy chat releases substantially more of the memory those paths used to retain. Large agent rosters also reuse work while they start, allowing real HTTP health checks to answer again much sooner in the tested synthetic setup, while session lists and metadata reads avoid opening or parsing conversation data they do not need.
+- Keep newly saved Codex reasoning hidden until it is explicitly enabled ([#136008](https://github.com/openclaw/openclaw/pull/136008)).
 
-Long and concurrent replies follow the same principle. In the defined local workloads, OpenClaw spent substantially less CPU and memory preparing, sanitizing, chunking, and delivering streamed text, while preserving tool order, corrections, reply targets, Markdown, media, and final answers. Those measurements cover OpenClaw's own runtime work, not model or network latency, and a few neighboring readiness and session-list tail measurements regressed in individual tests, so this should not be read as a universal latency or capacity guarantee.
+</details>
 
-Code Mode can reuse bounded warm workers and transfer snapshots with fewer copies, making repeated work much faster once those workers are warm, though the pool can retain materially more process memory and does not yet have a process-wide memory budget. Retained Control UI assets also use less memory on the tested 768 MiB and 1 GiB ARM64 hosts, but 512 MiB without swap still failed when status work overlapped startup. Managed worktrees now use available disk space rather than an arbitrary checkout count when deciding whether a new session or restore can proceed, while 100 remains the automatic cleanup target.
+</Accordion>
+
+<Accordion title="Network Destinations and Azure BYOK Requests">
+
+Operators can now deny selected destinations across browser access, guarded web fetches, and automation webhooks without maintaining a complete allowlist. Exact hostnames and wildcard subdomains are rejected before DNS resolution and before allow or private-network exceptions, while an absent or empty blocklist leaves existing behavior unchanged. This is a destination policy rather than a complete browser egress firewall, a wildcard does not cover its apex host, and supported Chrome MCP endpoints supplied only through `mcpArgs` remain outside the shipped hostname check.
+
+Azure OpenAI BYOK traffic through the Copilot extension also gains a separate request boundary. Each local proxy receives a fresh credential, verifies it before accepting request-body data, and removes it before forwarding upstream, while configured provider headers and the existing non-Azure nonce path remain intact. The Azure path relies on header forwarding verified for the shipped Copilot SDK version.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Reduce repeated Gateway startup and first-dashboard configuration work ([#134807](https://github.com/openclaw/openclaw/pull/134807)).
-- Prepare agent turns without unused session snapshot and deletion reads ([#134814](https://github.com/openclaw/openclaw/pull/134814)).
-- Scan long session histories from the newest entries without making copies ([#134930](https://github.com/openclaw/openclaw/pull/134930)).
-- Reuse bounded warm workers and exact session reads for Code Mode ([#134935](https://github.com/openclaw/openclaw/pull/134935)).
-- Avoid a full-body temporary copy when reading large HTTP responses ([#134954](https://github.com/openclaw/openclaw/pull/134954)).
-- Reuse owned response buffers for speech and generated media downloads ([#135014](https://github.com/openclaw/openclaw/pull/135014)).
-- Transfer Code Mode snapshots without another storage-format copy ([#135040](https://github.com/openclaw/openclaw/pull/135040)).
-- Avoid full-size temporary copies while preparing supported multipart uploads ([#135162](https://github.com/openclaw/openclaw/pull/135162)).
-- Decode large command results and errors without another byte copy ([#135189](https://github.com/openclaw/openclaw/pull/135189)).
-- Reduce local CPU work for concurrent long streaming replies ([#135751](https://github.com/openclaw/openclaw/pull/135751)).
-- Truncate very long terminal and table lines with less temporary work ([#135918](https://github.com/openclaw/openclaw/pull/135918)).
-- Skip unused formatting work for large console logs ([#136028](https://github.com/openclaw/openclaw/pull/136028)).
-- Reduce local CPU work for concurrent final-answer streams ([#136041](https://github.com/openclaw/openclaw/pull/136041)).
-- Load optional command-review and follow-up paths only when needed ([#136124](https://github.com/openclaw/openclaw/pull/136124)).
-- Reuse verified plugin metadata during foreground Gateway startup ([#136141](https://github.com/openclaw/openclaw/pull/136141)).
-- Reduce CPU and memory use while several long replies stream ([#136180](https://github.com/openclaw/openclaw/pull/136180)).
-- Load optional Control UI styles with the surfaces that use them ([#136186](https://github.com/openclaw/openclaw/pull/136186)).
-- Coalesce obsolete pending snapshots for slow reply consumers ([#136249](https://github.com/openclaw/openclaw/pull/136249)).
-- Reduce repeated subscription work during streaming event delivery ([#136296](https://github.com/openclaw/openclaw/pull/136296)).
-- Skip code-fence interiors while planning long Markdown message chunks ([#136350](https://github.com/openclaw/openclaw/pull/136350)).
-- Stop decoding preserved command output after its quota is full ([#136380](https://github.com/openclaw/openclaw/pull/136380)).
-- Skip ordinary prose while scanning streamed Markdown for code fences ([#136389](https://github.com/openclaw/openclaw/pull/136389)).
-- Keep large saved prompts out of lightweight Gateway metadata reads ([#136391](https://github.com/openclaw/openclaw/pull/136391)).
+- Add hostname blocklists to browser, web-fetch, and automation-webhook policies ([#135097](https://github.com/openclaw/openclaw/pull/135097)).
 
-**Bug fixes**
+**Security and trust**
 
-- Reduce memory spikes in model catalogs, conversation resets, and code-heavy chat navigation ([#134722](https://github.com/openclaw/openclaw/pull/134722)).
-- Retain less Gateway and Activity memory with large saved-session histories ([#134891](https://github.com/openclaw/openclaw/pull/134891)). Thanks @petercheng.
-- Keep terminal replay responsive during bulk buffered-output eviction ([#135183](https://github.com/openclaw/openclaw/pull/135183)).
-- Keep real HTTP health checks responsive while large agent rosters start ([#135773](https://github.com/openclaw/openclaw/pull/135773)). Thanks @LiuwqGit, @609NFT, and @obviyus.
-- Keep large session listings lightweight and fresh after equal-timestamp edits ([#135976](https://github.com/openclaw/openclaw/pull/135976)).
-- Use available disk space instead of checkout count for managed-worktree admission ([#135989](https://github.com/openclaw/openclaw/pull/135989)).
-- Release completed file-log payloads while slow writes continue ([#136030](https://github.com/openclaw/openclaw/pull/136030)).
-- Bound retained Control UI asset memory on constrained hosts ([#136108](https://github.com/openclaw/openclaw/pull/136108)). Thanks @vincentkoc.
-- Move automatic session maintenance out of the Discord and Telegram dispatch path ([#136283](https://github.com/openclaw/openclaw/pull/136283)). Thanks @obviyus and @anyech.
-- Release replaced conversation histories during active agent runs ([#136340](https://github.com/openclaw/openclaw/pull/136340)).
-- Release discarded file-log payloads when a stalled queue overflows ([#136416](https://github.com/openclaw/openclaw/pull/136416)).
+- Authenticate Azure OpenAI BYOK proxy requests from active Copilot sessions ([#134781](https://github.com/openclaw/openclaw/pull/134781)). Thanks @eleqtrizit.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Clearer CLI, status, diagnostics, and everyday recovery">
+<Accordion title="Scoped Sign-In and Device Tokens">
 
-The everyday tools around OpenClaw now say more precisely what actually happened. Agent lists reflect a newly configured identity, multi-account health checks show the active account rather than an unconfigured preferred one, remote session ages use the Gateway's clock, and `sessions tail` distinguishes a completed turn from an error, abort, or timeout. Media limits keep their fractional size, invalid session targets return the normal JSON failure shape, and copied approval commands retain the selected profile, container, and connection context without printing credentials.
+GitHub-backed Cloudflare Access and Tailscale sign-in can use the Gateway's existing GitHub credential for public profile verification, reducing failures caused by the anonymous API quota. Named operator roles are still admitted only after identity is verified, and an unavailable verification service now produces an accurate retryable error instead of opening a session with no usable scope.
 
-The terminal is less likely to become part of the problem it is helping you fix. Ctrl+C leaves model, agent, context, and session pickers across supported keyboard encodings, authored TUI links keep their intended destinations, Bash and zsh completion preserve the right command context and literal descriptions, and temporary login-shell failures can recover on the next lookup without a Gateway restart. SSH-backed probes now cancel and reap their tunnel before returning. Node wake and reconnect timing tolerates clock changes, stale presence expires correctly after rollback or suspend, and remote health uses Gateway-relative ages.
+Authorized operators can also rotate or revoke approved scoped node tokens through `openclaw devices`. The operation cannot add a role or widen the approved scope baseline, under-scoped callers remain blocked, and operator-token operations with broader stored scopes may still require a broader authenticated connection.
 
-Managed worktrees can now place new checkouts on a dedicated absolute or home-relative storage root without moving the rest of OpenClaw's state. Existing worktrees continue to use their recorded locations and still need that original storage to remain available. Alongside the disk-based admission change above, 100 is now a cleanup target rather than a hard ceiling, and restore failures point to disk space instead of asking people to delete a worktree slot that no longer exists.
+Gateway clients that require a verified role now stop endless reconnects and show the applicable trusted-proxy, Tailscale, token, or password recovery path. Rejected mobile setup codes point users toward a fresh code and the paired-device list instead of encouraging reuse.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep GitHub-backed named-role sign-in scoped through profile verification ([#134724](https://github.com/openclaw/openclaw/pull/134724)).
+- Restore authorized rotation and revocation of approved scoped node tokens ([#135617](https://github.com/openclaw/openclaw/pull/135617)).
+- Give rejected mobile setup codes an actionable recovery path [#134795](https://github.com/openclaw/openclaw/pull/134795). Thanks @eleqtrizit.
+- Pause clients and show recovery guidance when Gateway roles require verified identity [#136420](https://github.com/openclaw/openclaw/pull/136420). Thanks @obviyus and @aoclaw-glitch.
+
+**Documentation**
+
+- Explain the existing authority required to resume an incognito API session [#126419](https://github.com/openclaw/openclaw/pull/126419). Thanks @drobison00.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Configuration and Secrets Automation">
+
+Automation can now guard one direct `config set` operation with an expectation that the current value is absent or exactly matches supplied JSON. A mismatch writes nothing, reveals neither value, and leaves the existing final snapshot guard in place for later races. The expectation does not apply to batch or dry-run mode, redirected SecretRef writes, or roster updates.
+
+Secrets commands using `--json` now return one parseable document on success or failure across reload, audit, configure, apply, and store list or get operations. Human-readable output and documented exit codes remain unchanged, and this is an output-contract repair rather than a change to secret contents, storage, or security policy.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add compare-and-set expectations to direct configuration updates ([#136137](https://github.com/openclaw/openclaw/pull/136137)). Thanks @vincentkoc.
+
+**Bug fixes**
+
+- Keep Secrets CLI JSON failures machine-readable ([#136142](https://github.com/openclaw/openclaw/pull/136142)). Thanks @qingminglong, @obviyus.
+
+**Security and trust**
+
+- Update affected URI and mail dependencies to patched versions [#136700](https://github.com/openclaw/openclaw/pull/136700).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Ingress Limits and Client Attribution">
+
+Network-facing integrations now put firmer bounds around work before it can crowd out valid traffic. A2A JSON-RPC batches and responses have explicit limits, incomplete SMS webhook uploads cannot consume unbounded pre-authentication reads, and managed webhook traffic behind a trusted proxy is rate-limited by validated client rather than one proxy-wide identity.
+
+These are scoped resource and attribution controls, not a general security guarantee, and their prepared evidence includes controlled services rather than every live external provider.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Bound authenticated A2A batches and response sizes [#134603](https://github.com/openclaw/openclaw/pull/134603). Thanks @eleqtrizit.
+- Attribute managed webhook rate limits to the validated client [#134622](https://github.com/openclaw/openclaw/pull/134622). Thanks @eleqtrizit.
+- Limit simultaneous unauthenticated SMS webhook body reads [#136504](https://github.com/openclaw/openclaw/pull/136504). Thanks @drobison00.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Quality-of-Life Improvements
+
+OpenClaw spends less time repeating work you never asked it to do. Long conversations and concurrent replies use less CPU and memory in the measured workloads, large installations give health checks and session views more room to respond, and routine starts, commands, files, worktrees, logs, and remote checks shed a long tail of avoidable overhead.
+
+<AccordionGroup>
+
+<Accordion title="Long Conversations and Concurrent Replies">
+
+Large conversations no longer drag as much unrelated history through every nearby task. Resets read only the navigation data they need, session inspection walks backward without copying the history, and ordinary turns avoid several unnecessary session reads, which leaves more room for the conversation itself.
+
+The streaming path also does less work as replies grow. Concurrent long replies reuse their prepared text instead of repeatedly rebuilding it, producing substantially lower CPU and memory use in the tested workloads while preserving tool ordering, corrections, reply targeting, and final media. These measurements cover the built-in runtime on defined local workloads rather than model-provider latency.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Prepare agent turns with lighter session reads ([#134814](https://github.com/openclaw/openclaw/pull/134814)).
+- Scan long session histories without copying them ([#134930](https://github.com/openclaw/openclaw/pull/134930)).
+- Reduce overhead for concurrent streaming replies ([#135751](https://github.com/openclaw/openclaw/pull/135751)).
+- Reduce CPU work for concurrent final-answer streams ([#136041](https://github.com/openclaw/openclaw/pull/136041)).
+- Reduce CPU and memory use while several long replies stream ([#136180](https://github.com/openclaw/openclaw/pull/136180)).
+- Coalesce obsolete pending snapshots for slow reply consumers ([#136249](https://github.com/openclaw/openclaw/pull/136249)).
+- Reduce repeated subscription work during streaming event delivery ([#136296](https://github.com/openclaw/openclaw/pull/136296)).
+- Skip code-fence interiors while planning long Markdown message chunks ([#136350](https://github.com/openclaw/openclaw/pull/136350)).
+- Keep large saved prompts out of lightweight Gateway metadata reads ([#136391](https://github.com/openclaw/openclaw/pull/136391)).
+
+**Bug fixes**
+
+- Reduce memory spikes in model catalogs, conversation resets, and code-heavy chats ([#134722](https://github.com/openclaw/openclaw/pull/134722)).
+- Release replaced conversation histories during active agent runs ([#136340](https://github.com/openclaw/openclaw/pull/136340)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Code Mode with Less Repeated Work">
+
+Repeated Code Mode work can reuse bounded warm workers and look up only the requested session, cutting preparation and CPU work once those workers are warm. Snapshot buffers also move between tool calls without another storage-format copy. The warm pools can retain materially more process memory, so this improves the measured Code Mode workloads without establishing a general Gateway capacity or throughput gain.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reuse warm Code Mode workers and perform exact session lookups ([#134935](https://github.com/openclaw/openclaw/pull/134935)).
+- Transfer Code Mode snapshots without storage-format copies ([#135040](https://github.com/openclaw/openclaw/pull/135040)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Large Installation Health and Session Views">
+
+Gateways with large agent rosters now reuse prepared roster, model, and workspace facts during one startup batch, which lets real HTTP health checks answer again instead of leaving a listening socket that never becomes useful. Other fleet startup costs can still produce noticeable post-listen delays, but the repeated discovery work covered here is gone.
+
+Installations with large saved-session histories also keep less conversation data in memory and do far less work to count or list sessions, while read-only diagnostics stay out of SQLite's writer lifecycle. Retained Control UI assets use less memory on constrained ARM64 hosts as well, improving headroom in the tested 768 MiB and 1 GiB setups, though 512 MiB without swap can still fail when status work overlaps startup.
+
+Discord and Telegram turns on large SQLite session stores no longer wait for full-store maintenance before dispatch; bounded cleanup continues afterward.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Retain less Gateway and Activity memory with large session histories ([#134891](https://github.com/openclaw/openclaw/pull/134891)). Thanks @petercheng.
+- Keep HTTP health checks responsive while large agent rosters start ([#135773](https://github.com/openclaw/openclaw/pull/135773)). Thanks @LiuwqGit, @609NFT, @obviyus.
+- Keep large session listings lightweight and fresh after equal-timestamp edits ([#135976](https://github.com/openclaw/openclaw/pull/135976)).
+- Keep read-only diagnostics out of SQLite writer state ([#136010](https://github.com/openclaw/openclaw/pull/136010)). Thanks @obviyus, @Grynn.
+- Bound retained Control UI asset memory on constrained hosts ([#136108](https://github.com/openclaw/openclaw/pull/136108)). Thanks @vincentkoc.
+- Move automatic session maintenance out of the Discord and Telegram dispatch path ([#136283](https://github.com/openclaw/openclaw/pull/136283)). Thanks @obviyus and @anyech.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Startup and Command Overhead">
+
+Common startup paths now load less optional code and reuse more work they have already verified. Gateway readiness avoids repeated Doctor and plugin-metadata preparation, ordinary shell commands defer model review and follow-up delivery until those paths are actually needed, and concurrent first turns share one workspace Git setup. Approval, elevation, cancellation, and delivery rules stay where they were.
+
+Everyday command feedback is less surprising too. A temporary login-shell failure can recover on a later lookup without restarting the Gateway, `/agents` takes one coherent view of the subagent registry, automatic TTS leaves routine command output as text, zsh completion keeps examples literal, and strict-JSON errors point to the safer file-backed patch workflow.
+
+Deep configuration mutations now fail with bounded validation instead of exhausting the call stack, session CLI commands reject invalid or blank targets without selecting another agent, and Bash completion handles spaced and equals-separated option values more reliably.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reduce repeated Gateway startup and configuration work ([#134807](https://github.com/openclaw/openclaw/pull/134807)).
+- Remove redundant payload from npm installations ([#135478](https://github.com/openclaw/openclaw/pull/135478)).
+- Load optional exec review and follow-up paths only when needed ([#136124](https://github.com/openclaw/openclaw/pull/136124)).
+- Reuse verified plugin metadata during foreground Gateway startup ([#136141](https://github.com/openclaw/openclaw/pull/136141)).
+- Load optional Control UI styles with the surfaces that use them ([#136186](https://github.com/openclaw/openclaw/pull/136186)).
+
+**Bug fixes**
+
+- Retry environment and command discovery after a transient login-shell failure ([#125378](https://github.com/openclaw/openclaw/pull/125378)). Thanks @qdivan.
+- Bound oversized telemetry update responses without replacing valid cached state ([#132492](https://github.com/openclaw/openclaw/pull/132492)). Thanks @RileyJJY.
+- Share workspace Git setup across concurrent first turns ([#134537](https://github.com/openclaw/openclaw/pull/134537)).
+- Keep `/agents` status on one coherent registry snapshot ([#134677](https://github.com/openclaw/openclaw/pull/134677)). Thanks @vincentkoc.
+- Keep routine terminal command replies out of automatic TTS ([#134802](https://github.com/openclaw/openclaw/pull/134802)). Thanks @najef1979-code.
+- Preserve literal examples in zsh completion descriptions ([#135114](https://github.com/openclaw/openclaw/pull/135114)). Thanks @walker1211.
+- Point strict-JSON parse failures to the file-backed patch workflow ([#135203](https://github.com/openclaw/openclaw/pull/135203)). Thanks @SunnyShu0925.
+- Keep deeply nested configuration changes from exhausting memory or the call stack ([#129918](https://github.com/openclaw/openclaw/pull/129918)). Thanks @SunnyShu0925, @obviyus, and @hpyhandsome.
+- Make Ctrl+C close terminal pickers across legacy and modern keyboard encodings ([#133151](https://github.com/openclaw/openclaw/pull/133151)). Thanks @aniruddhaadak80.
+- Keep tabbed CLI table columns aligned ([#136312](https://github.com/openclaw/openclaw/pull/136312)).
+- Label recorded session outcomes as error, aborted, timeout, or done ([#136407](https://github.com/openclaw/openclaw/pull/136407)). Thanks @Grynn.
+- Preserve authored hyperlink destinations in the terminal UI ([#136469](https://github.com/openclaw/openclaw/pull/136469)).
+- Make OC Path dry-run patches preserve exact line endings and final-newline state ([#136531](https://github.com/openclaw/openclaw/pull/136531)).
+- Show configured agent identity immediately in human and JSON listings ([#136537](https://github.com/openclaw/openclaw/pull/136537)).
+- Complete Bash option values without missing choices or duplicate prefixes ([#136557](https://github.com/openclaw/openclaw/pull/136557)).
+- Return a redacted approvals snapshot for successful JSON no-op mutations ([#136574](https://github.com/openclaw/openclaw/pull/136574)).
+- Preserve profile, container, and connection context in copied approval hints ([#136633](https://github.com/openclaw/openclaw/pull/136633)).
+- Standardize invalid session-target errors and reject blank tail-agent selectors ([#136664](https://github.com/openclaw/openclaw/pull/136664)).
+- Report fractional media storage limits accurately ([#136685](https://github.com/openclaw/openclaw/pull/136685)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Managed Worktrees on Other Storage">
+
+Managed worktrees can now live on another chosen disk or folder without moving the rest of OpenClaw's state, and existing worktrees keep using the locations already recorded for them. This release first raised the shared checkout target to 100, then removed the hard admission ceiling entirely, so sufficient disk space governs new worktrees and restores while 100 remains the automatic cleanup target. Manual and protected worktrees keep their existing safeguards.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1406,58 +2197,152 @@ Managed worktrees can now place new checkouts on a dedicated absolute or home-re
 **Improvements**
 
 - Add a global storage root for new managed worktrees ([#134872](https://github.com/openclaw/openclaw/pull/134872)).
-- Ship a smaller npm installation without redundant native and plugin-build payload ([#135478](https://github.com/openclaw/openclaw/pull/135478)).
-- Raise the managed-worktree cleanup target from 30 to 100 ([#135885](https://github.com/openclaw/openclaw/pull/135885)).
+- Raise the shared managed-worktree target to 100 ([#135885](https://github.com/openclaw/openclaw/pull/135885)).
 
 **Bug fixes**
 
-- Retry environment and command discovery after a temporary login-shell failure ([#125378](https://github.com/openclaw/openclaw/pull/125378)). Thanks @qdivan.
-- Keep deeply nested configuration changes from exhausting memory or the call stack ([#129918](https://github.com/openclaw/openclaw/pull/129918)). Thanks @SunnyShu0925, @obviyus, and @hpyhandsome.
-- Bound oversized telemetry update responses without replacing valid cached state ([#132492](https://github.com/openclaw/openclaw/pull/132492)). Thanks @RileyJJY.
-- Make Ctrl+C close terminal pickers across legacy and modern keyboard encodings ([#133151](https://github.com/openclaw/openclaw/pull/133151)). Thanks @aniruddhaadak80.
-- Stop obsolete session observers from scheduling work they cannot save ([#133220](https://github.com/openclaw/openclaw/pull/133220)). Thanks @SunnyShu0925 and @ruel225.
-- Keep node wake retries and reconnect waits correct through clock changes ([#133354](https://github.com/openclaw/openclaw/pull/133354)). Thanks @qingminglong.
-- Distinguish socat forwards from real Gateways in busy-port status ([#133381](https://github.com/openclaw/openclaw/pull/133381)). Thanks @ericcaiwx-star and @obviyus.
-- Wait for SSH tunnel processes to exit before stop returns ([#133847](https://github.com/openclaw/openclaw/pull/133847)). Thanks @aniruddhaadak80.
-- Share workspace Git setup across concurrent first turns ([#134537](https://github.com/openclaw/openclaw/pull/134537)).
-- Keep `/agents` output on one coherent subagent registry snapshot ([#134677](https://github.com/openclaw/openclaw/pull/134677)). Thanks @vincentkoc.
-- Expire stale Gateway presence correctly after clock rollback or suspend ([#134737](https://github.com/openclaw/openclaw/pull/134737)). Thanks @lzhan011 and @obviyus.
-- Keep routine slash-command and plugin-command replies out of automatic TTS ([#134802](https://github.com/openclaw/openclaw/pull/134802)). Thanks @najef1979-code.
-- Keep protected placeholders from repeatedly stalling documentation translation ([#134934](https://github.com/openclaw/openclaw/pull/134934)).
-- Preserve literal examples in zsh subcommand descriptions ([#135114](https://github.com/openclaw/openclaw/pull/135114)). Thanks @walker1211.
-- Cancel interrupted SSH-backed probes and release their forwarded ports ([#135182](https://github.com/openclaw/openclaw/pull/135182)). Thanks @aniruddhaadak80 and @obviyus.
-- Point strict-JSON failures to the file-backed patch workflow ([#135203](https://github.com/openclaw/openclaw/pull/135203)). Thanks @SunnyShu0925.
-- Wait for active Codex-backed turns before manual native compaction begins ([#135441](https://github.com/openclaw/openclaw/pull/135441)). Thanks @jjjhenriksen and @obviyus.
-- Release requester sessions after a subagent settlement wake times out ([#135854](https://github.com/openclaw/openclaw/pull/135854)). Thanks @obviyus, @nikolascostello, and @pengzh1.
-- Reuse text-console styles without crashing on inherited-looking subsystem names ([#135932](https://github.com/openclaw/openclaw/pull/135932)).
-- Keep memory status and session diagnostics out of SQLite writer state ([#136010](https://github.com/openclaw/openclaw/pull/136010)). Thanks @obviyus and @Grynn.
-- Preserve redacted trace stacks without duplicate file-log errors ([#136066](https://github.com/openclaw/openclaw/pull/136066)).
-- Show Gateway-relative ages and cleaner heartbeat details in remote status ([#136093](https://github.com/openclaw/openclaw/pull/136093)). Thanks @jeffrey4341.
-- Keep tabbed CLI table columns aligned ([#136312](https://github.com/openclaw/openclaw/pull/136312)).
-- Preserve the intended size error and complete-byte prefix for fractional download limits ([#136402](https://github.com/openclaw/openclaw/pull/136402)). Thanks @ly85206559.
-- Label recorded session outcomes as error, aborted, timeout, or done ([#136407](https://github.com/openclaw/openclaw/pull/136407)). Thanks @Grynn.
-- Preserve authored hyperlink destinations in the terminal UI ([#136469](https://github.com/openclaw/openclaw/pull/136469)).
-- Make OC Path dry-run patches preserve exact line endings and final-newline state ([#136531](https://github.com/openclaw/openclaw/pull/136531)).
-- Show configured agent identity immediately in human and JSON listings ([#136537](https://github.com/openclaw/openclaw/pull/136537)).
-- Report timed-out channel capability checks and continue through later accounts ([#136539](https://github.com/openclaw/openclaw/pull/136539)).
-- Complete Bash option values without missing choices or duplicate prefixes ([#136557](https://github.com/openclaw/openclaw/pull/136557)).
-- Return a redacted approvals snapshot for successful JSON no-op mutations ([#136574](https://github.com/openclaw/openclaw/pull/136574)).
-- Show active multi-account channel probes even when the preferred account is unconfigured ([#136599](https://github.com/openclaw/openclaw/pull/136599)).
-- Preserve profile, container, and connection context in copied approval hints ([#136633](https://github.com/openclaw/openclaw/pull/136633)).
-- Standardize invalid session-target errors and reject blank tail-agent selectors ([#136664](https://github.com/openclaw/openclaw/pull/136664)).
-- Report fractional media storage limits accurately ([#136685](https://github.com/openclaw/openclaw/pull/136685)).
+- Use available disk space instead of checkout count for new worktree admission ([#135989](https://github.com/openclaw/openclaw/pull/135989)).
 - Correct archived-worktree restore advice after the move to disk-based admission ([#136717](https://github.com/openclaw/openclaw/pull/136717)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Project Directories for Local Agents">
+
+Local agents can work directly in an existing project directory while their instructions and memory remain in OpenClaw's managed workspace. Existing setups keep their old behavior unless a separate directory is configured, session-created and paired-agent directories still take precedence, and the split-directory option is limited to unsandboxed runs.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Let local agents work in a configured project directory ([#135080](https://github.com/openclaw/openclaw/pull/135080)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Conversation Branches and Session Continuity">
+
+Supervised Codex Chats can use **Fork from here** on newer canonical messages, retain the native conversation history through a Gateway restart, and open the chosen input as an unsent draft without changing the source conversation. Descendant forks and paginated `/btw` side questions retain that native lineage as well.
+
+Underneath that workflow, nested session writes remain ordered, malformed cyclic ancestry returns bounded context instead of hanging, and a stale local CLI recovery attempt can no longer replace a newer session. Older canonical messages without recorded native provenance remain outside the new fork path.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Keep native history when supervised Codex Chats fork canonical messages ([#134660](https://github.com/openclaw/openclaw/pull/134660)). Thanks @kevin2966n.
+
+**Bug fixes**
+
+- Keep nested session writes in their expected order ([#131456](https://github.com/openclaw/openclaw/pull/131456)). Thanks @gaoanze888, @Grynn.
+- Return bounded context for cyclic session ancestry ([#131567](https://github.com/openclaw/openclaw/pull/131567)). Thanks @igs-rogenlo.
+- Stop stale local CLI recovery from replacing a newer session ([#135168](https://github.com/openclaw/openclaw/pull/135168)). Thanks @mushuiyu886, @obviyus.
+- Wait for active Codex-backed turns before manual native compaction begins ([#135441](https://github.com/openclaw/openclaw/pull/135441)). Thanks @jjjhenriksen and @obviyus.
+
+**Limits and compatibility**
+
+- Canonical-message forks require recorded native provenance and were accepted locally on macOS, not across every managed Desktop, Windows, crash, or multiwriter path.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Large Files, Terminal Output, and Logs">
+
+Large downloads, generated media, multipart uploads, and command results now avoid several full-size temporary copies while preserving the same bytes, limits, timeouts, and error details. Terminal replay evicts old buffered output in one pass, and very long styled or Unicode lines reach their existing width limit with much less temporary work.
+
+Logging follows the same theme. Text loggers reuse stable formatting, JSON console output skips work it does not need, completed payloads are released as slow writes finish, and `console.trace()` keeps one readable redacted stack instead of producing a duplicate error record.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Avoid duplicate allocations while reading large HTTP response bodies ([#134954](https://github.com/openclaw/openclaw/pull/134954)).
+- Reuse owned response buffers for speech and generated media ([#135014](https://github.com/openclaw/openclaw/pull/135014)).
+- Avoid full-size intermediate copies for supported multipart uploads ([#135162](https://github.com/openclaw/openclaw/pull/135162)).
+- Decode large command output without another byte copy ([#135189](https://github.com/openclaw/openclaw/pull/135189)).
+- Truncate long terminal text with less temporary memory and latency ([#135918](https://github.com/openclaw/openclaw/pull/135918)).
+- Skip unused formatting work for large console logs ([#136028](https://github.com/openclaw/openclaw/pull/136028)).
+- Stop decoding preserved command output after its quota is full ([#136380](https://github.com/openclaw/openclaw/pull/136380)).
+- Skip ordinary prose while scanning streamed Markdown for code fences ([#136389](https://github.com/openclaw/openclaw/pull/136389)).
+
+**Bug fixes**
+
+- Keep terminal replay responsive during bulk buffered-output eviction ([#135183](https://github.com/openclaw/openclaw/pull/135183)).
+- Reuse console styles without crashing on inherited subsystem names ([#135932](https://github.com/openclaw/openclaw/pull/135932)).
+- Release completed log payloads while slow writes continue ([#136030](https://github.com/openclaw/openclaw/pull/136030)).
+- Preserve redacted trace stacks without duplicate file-log errors ([#136066](https://github.com/openclaw/openclaw/pull/136066)).
+- Preserve the intended size error and complete-byte prefix for fractional download limits ([#136402](https://github.com/openclaw/openclaw/pull/136402)). Thanks @ly85206559.
+- Release discarded file-log payloads when a stalled queue overflows ([#136416](https://github.com/openclaw/openclaw/pull/136416)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Remote Gateway Timing and Cleanup">
+
+Remote Gateway and paired-node operations now hold their timing and cleanup boundaries through clock changes, suspend, cancellation, and concurrent shutdown. Node wake retries use elapsed time, stale presence expires in the intended order, and an SSH-backed probe does not call itself stopped until its child process and forwarded port are gone. Remote health output also uses the Gateway's own ages, avoiding misleading status when the two machines' clocks disagree.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep node wake retries and reconnect waits correct through clock changes ([#133354](https://github.com/openclaw/openclaw/pull/133354)). Thanks @qingminglong.
+- Wait for SSH tunnel processes to exit before stop returns ([#133847](https://github.com/openclaw/openclaw/pull/133847)). Thanks @aniruddhaadak80.
+- Expire stale Gateway presence correctly after clock rollback or suspend ([#134737](https://github.com/openclaw/openclaw/pull/134737)). Thanks @lzhan011, @obviyus.
+- Cancel interrupted SSH-backed probes and release their forwarded ports ([#135182](https://github.com/openclaw/openclaw/pull/135182)). Thanks @aniruddhaadak80, @obviyus.
+- Show Gateway-relative ages and cleaner heartbeat details in remote status ([#136093](https://github.com/openclaw/openclaw/pull/136093)). Thanks @jeffrey4341.
+- Distinguish socat forwards from real Gateways in busy-port status ([#133381](https://github.com/openclaw/openclaw/pull/133381)). Thanks @ericcaiwx-star and @obviyus.
+- Report timed-out channel capability checks and continue through later accounts ([#136539](https://github.com/openclaw/openclaw/pull/136539)).
+- Show active multi-account channel probes even when the preferred account is unconfigured ([#136599](https://github.com/openclaw/openclaw/pull/136599)).
 
 **Documentation**
 
-- List only the supported `/login` aliases in the command reference ([#118045](https://github.com/openclaw/openclaw/pull/118045)). Thanks @AAliKKhan.
+- Explain that node approvals live on the paired-device record ([#122726](https://github.com/openclaw/openclaw/pull/122726)). Thanks @191612731-cloud, @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Background Work and Conversation Concurrency">
+
+Removed or replaced sessions no longer leave an obsolete observer scheduling utility-model work that cannot be saved. A subagent settlement wake that reaches its deadline also cancels the exact accepted run and releases the requester's single-concurrency lane, letting later messages continue instead of piling up behind stale retries. That cancellation is scoped to settlement wakes and the shared direct-announcement deadline path.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Stop obsolete session observers from scheduling work they cannot persist ([#133220](https://github.com/openclaw/openclaw/pull/133220)). Thanks @SunnyShu0925, @ruel225.
+- Release requester sessions after a subagent settlement wake times out ([#135854](https://github.com/openclaw/openclaw/pull/135854)). Thanks @obviyus, @nikolascostello, @pengzh1.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Documentation for Existing Paths">
+
+Several places where the product already had a working route but the documentation did not make it obvious are now clearer. Supported `/login` aliases, SecretRef defaults, TaskFlow audit warnings, uv-managed Python execution, and dead-letter recovery commands are documented where people look for them, retired pages lead to current migration guidance, and the Lite Mode Showcase link reaches the actual skill. Translation handling is less likely to strand localized pages on protected placeholders, while the expanded v2026.8.2 page is easier to navigate by topic and remains historical documentation.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Show the supported `/login` aliases in the command reference ([#118045](https://github.com/openclaw/openclaw/pull/118045)). Thanks @AAliKKhan.
 - Point the Showcase Lite Mode card to the published skill ([#120645](https://github.com/openclaw/openclaw/pull/120645)). Thanks @firepinn.
-- Explain that node approvals live on the paired-device record ([#122726](https://github.com/openclaw/openclaw/pull/122726)). Thanks @191612731-cloud and @vincentkoc.
-- Explain the built-in default aliases for environment and store SecretRefs ([#122730](https://github.com/openclaw/openclaw/pull/122730)). Thanks @191612731-cloud and @fujixm5.
-- Explain the TaskFlow timestamp warning and shared audit-code groups ([#124672](https://github.com/openclaw/openclaw/pull/124672)). Thanks @qingminglong.
+- Explain the built-in default aliases for environment and store SecretRefs ([#122730](https://github.com/openclaw/openclaw/pull/122730)). Thanks @191612731-cloud, @fujixm5.
+- Explain the TaskFlow timestamp warning and which audit codes apply ([#124672](https://github.com/openclaw/openclaw/pull/124672)). Thanks @qingminglong.
 - Document uv-managed Python environments for exec ([#129930](https://github.com/openclaw/openclaw/pull/129930)). Thanks @ralphptorres.
-- Add channel dead-letter inspection and resubmission commands to the CLI index ([#134711](https://github.com/openclaw/openclaw/pull/134711)). Thanks @qingminglong.
-- Route retired pages to maintained migration and removal guidance ([#134712](https://github.com/openclaw/openclaw/pull/134712)).
+- List channel dead-letter inspection and resubmission commands in the CLI index ([#134711](https://github.com/openclaw/openclaw/pull/134711)). Thanks @qingminglong.
+- Redirect retired pages to maintained migration guidance ([#134712](https://github.com/openclaw/openclaw/pull/134712)).
+- Keep protected placeholders from stalling documentation translation ([#134934](https://github.com/openclaw/openclaw/pull/134934)).
 - Replace rejected configuration examples with accepted, merge-preserving CLI commands ([#136269](https://github.com/openclaw/openclaw/pull/136269)). Thanks @yetval and @obviyus.
 
 </details>
@@ -1468,53 +2353,118 @@ Managed worktrees can now place new checkouts on a dedicated absolute or home-re
 
 ## Other Bug Fixes
 
-The smaller fixes in this release share a useful theme. When work is interrupted, rejected, or given ambiguous input, OpenClaw is less likely to lose the useful result, act on a plausible substitute, or leave stale work behind. Sessions keep more of what actually happened, command-line tools stop before guessing, and status or logs are clearer about what failed and what remains unfinished.
+The smaller fixes in this release are easier to understand when they stay attached to the place you actually notice them. Sessions now keep interrupted requests and finished child work attached to the right run, attachments hold on to their real text and type, command-line tools stop on ambiguous targets, and status, logs, remote connections, and channel-specific edges report what actually happened instead of quietly substituting a plausible answer.
 
 <AccordionGroup>
 
-<Accordion title="Agent, subagent, and session settlement">
+<Accordion title="Interrupted Sessions and Child Work">
 
-Interrupted agent work now keeps its shape through more restarts and busy turns. A request interrupted by a Gateway restart remains in later model context exactly once, while [subagent](/tools/subagents) results wait for a busy parent to finish or resume after a CLI-backed parent yields instead of colliding with the active turn or disappearing. Successful child work with no final message can finish quietly, and a rejected requester wake settles instead of retrying forever. Work invalidated by cancellation, replacement, expiry, or failed revalidation still stays blocked rather than running late.
+Interrupted work now keeps its shape through restart and cleanup. A user message interrupted by a Gateway restart remains in later model context, cloud-session cleanup failures stay visible and retryable without discarding accepted workspace changes, and retried agent or CLI commands remain attached to the process tree that actually owns their cancellation, output, and diagnostics.
 
-Long-running commands and cloud sessions now hold on to the process or cleanup work they actually own. Retried agent and CLI commands remain cancellable, fragmented UTF-8 output counts as activity instead of looking idle, and cloud-session Stop or recovery keeps failed cleanup visible and retryable without discarding accepted workspace changes. Source-built cloud sessions also package their files more reliably, and shutdown or replacement waits for its own worker and plugin cleanup to settle.
+Child work also settles more cleanly. Completion-required CLI-backed results resume after the parent yields without replaying an already delivered result, a successful child with no final message can finish quietly, and a rejected requester wake no longer retries forever. Catalog-backed sessions retain the runtime they were created with, ordinary wait deadlines are no longer mislabeled as Gateway shutdown, and simultaneous session starts avoid repeating the same Git preparation work.
 
-The surrounding failure paths are less misleading too. Catalog-backed sessions validate the runtime they selected, `agent exec` preserves the original failure and exit code when cleanup also fails, and incomplete search diagnostics say when earlier error output was discarded. Failover logs agree on their current counters, policy migration warnings no longer suggest grants an active deny would block, and an unauthorized native `/compact` returns a refusal without starting model or session work. A failed background completion is logged without taking down the Gateway or interrupting unrelated work.
+Background subagent failures are logged without taking down the Gateway, and completions wait for a busy parent turn before delivering instead of colliding, disappearing, or repeatedly claiming the same result.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Keep failed background subagent completion from taking down the Gateway ([#131735](https://github.com/openclaw/openclaw/pull/131735)). Thanks @ruel225.
-- Explain when failed search diagnostics discarded earlier error output ([#132627](https://github.com/openclaw/openclaw/pull/132627)). Thanks @Alix-007 and @gustav-bliss.
-- Resume completion-required CLI child results after a parent yields ([#134974](https://github.com/openclaw/openclaw/pull/134974)). Thanks @VACInc and @aoclaw-glitch.
+- Avoid duplicate Git preparation during concurrent session starts ([#134912](https://github.com/openclaw/openclaw/pull/134912)).
+- Resume completion-required CLI child results after a parent yields ([#134974](https://github.com/openclaw/openclaw/pull/134974)). Thanks @VACInc, @aoclaw-glitch.
 - Keep the selected catalog runtime through session creation ([#135048](https://github.com/openclaw/openclaw/pull/135048)).
-- Preserve the original `agent exec` failure when cleanup also fails ([#135273](https://github.com/openclaw/openclaw/pull/135273)). Thanks @SebTardif.
-- Keep cloud sessions stopped and cleanup failures visible and retryable ([#135583](https://github.com/openclaw/openclaw/pull/135583)).
-- Keep current failover counters consistent across console and structured logs ([#135844](https://github.com/openclaw/openclaw/pull/135844)).
-- Let successful subagents with no final message finish quietly ([#135846](https://github.com/openclaw/openclaw/pull/135846)). Thanks @jakestenger, @louisfy, and @obviyus.
-- Preserve an interrupted user message through Gateway restart recovery ([#136023](https://github.com/openclaw/openclaw/pull/136023)). Thanks @leilei3167, @obviyus, and @yetval.
-- Stop rejected subagent requester wakes from retrying forever ([#136033](https://github.com/openclaw/openclaw/pull/136033)). Thanks @obviyus and @Grynn.
-- Keep command retries bound to the process and output activity they own ([#136053](https://github.com/openclaw/openclaw/pull/136053)).
+- Keep cloud sessions stopped and make cleanup failures retryable ([#135583](https://github.com/openclaw/openclaw/pull/135583)).
+- Distinguish ordinary wait deadlines from Gateway shutdown ([#135797](https://github.com/openclaw/openclaw/pull/135797)).
+- Let successful subagents with no final message finish quietly ([#135846](https://github.com/openclaw/openclaw/pull/135846)). Thanks @jakestenger, @louisfy, @obviyus.
+- Preserve an interrupted user message through Gateway restart recovery ([#136023](https://github.com/openclaw/openclaw/pull/136023)). Thanks @leilei3167, @obviyus, @yetval.
+- Stop rejected subagent requester wakes from retrying forever ([#136033](https://github.com/openclaw/openclaw/pull/136033)). Thanks @obviyus, @Grynn.
+- Keep command retries bound to the correct lifecycle and output activity ([#136053](https://github.com/openclaw/openclaw/pull/136053)).
+- Keep failed background subagent completion from taking down the Gateway ([#131735](https://github.com/openclaw/openclaw/pull/131735)). Thanks @ruel225.
 - Keep cloud source packaging and worker, plugin, and shutdown cleanup attached until settlement ([#136084](https://github.com/openclaw/openclaw/pull/136084)).
 - Deliver subagent completions after busy parent turns finish ([#136423](https://github.com/openclaw/openclaw/pull/136423)). Thanks @svdwalt007, @Tony-Clawbot, and @Isitjustmefromparis.
-
-**Security and trust**
-
-- Return an explicit refusal for unauthorized native `/compact` commands ([#131408](https://github.com/openclaw/openclaw/pull/131408)). Thanks @igs-rogenlo.
-- Stop tool-profile warnings from recommending grants blocked by active policy ([#132623](https://github.com/openclaw/openclaw/pull/132623)). Thanks @sunlit-deng, @shbernal, and @SuperMarioYL.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Focused input, process, node, and state recovery">
+<Accordion title="Agent Runs and Tool Results">
 
-Narrow input failures now stop with the useful answer instead of quietly choosing another one. Explicitly blank agent-session, session-store, and dead-letter account selectors are rejected before they can fall back to a default target, while omitting those selectors keeps the existing default behavior. MCP read commands return the normal JSON failure document on early errors, invalid fixed UTC offsets no longer produce usage totals for the wrong day, and Windows command lookup ignores empty `PATHEXT` entries instead of treating an extensionless file as runnable.
+Long-running work gives the agent more useful signals before it goes off course. A background command tells Code Mode how to poll for its eventual output, early tool-loop warnings reach the model before the blocking threshold, completed fallback reports stop delegated work from launching again on the covered CLI path, and cleanup can finish even when plugin setup fails.
 
-Attachments retain more of what the sender actually provided. Dot-segment metadata falls back to a usable filename, a UTF-8 character crossing the inspection boundary no longer makes a text file look binary, streamed files keep a type and extension that match the saved bytes, and inferred legacy text keeps accents, currency symbols, and other non-ASCII characters. Rejected URL downloads release their transport promptly, while repeatedly changing one conversation avatar no longer pushes other sessions' current avatars out of the cache.
+The result is easier to trust as well. Chat `/bash` replies show the real exit code or signal, successful PDF and image analysis remains available to Code Mode and Tool Search, nested calls retire stale terminal summaries after the accepted result settles, and explicit multi-agent fleets use the selected agent for status and diagnostics instead of requiring an unrelated System Agent owner.
 
-Recovery and diagnostics now follow the same preference for observed state over a convenient guess. Detailed status reports show inbound queue pressure and dead letters even when channels look healthy, though they do not repair the stalled delivery themselves. Rolling log tails read the active file, session-observer warnings include a redacted cause, Git snapshot failures retain useful redacted detail, and plugin validation reports every genuinely missing field in one pass. Remote Gateway tunnels keep their listener timeout through clock changes and clean up failed readiness work, recent nodes remain inside the requested age window, and the genuine Gateway stays visible in a bounded Devices roster. Equal-timestamp Buzz updates resolve consistently, HTTP clients that reject HTML receive the existing error response, and concurrent session starts share overlapping Git preparation without retaining a stale result.
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Stop CLI fallback completion reports from launching delegated work again ([#115405](https://github.com/openclaw/openclaw/pull/115405)). Thanks @MertBasar0.
+- Tell background commands how to retrieve their eventual output ([#132756](https://github.com/openclaw/openclaw/pull/132756)). Thanks @sashankh, @shad0wca7.
+- Show real failure codes and signals for chat `/bash` commands ([#133414](https://github.com/openclaw/openclaw/pull/133414)). Thanks @MoerAI.
+- Retain successful PDF and image analysis in Code Mode and Tool Search ([#135037](https://github.com/openclaw/openclaw/pull/135037)).
+- Finish subagent cleanup when plugin setup fails ([#135098](https://github.com/openclaw/openclaw/pull/135098)).
+- Show tool-loop warnings to the agent before blocking ([#135103](https://github.com/openclaw/openclaw/pull/135103)).
+- Finalize nested Tool Search summaries and release stale presentation state ([#135398](https://github.com/openclaw/openclaw/pull/135398)).
+- Use explicitly selected agents for fleet status and diagnostics ([#135447](https://github.com/openclaw/openclaw/pull/135447)). Thanks @Hansen1018, @abacha.
+
+**Security and trust**
+
+- Compact Code Mode and Tool Search paths still have an unresolved review concern around wrapping newly visible media-analysis text as untrusted content.
+
+**Limits and compatibility**
+
+- Background-command guidance is only the producer-side part of the reported wait problem, and the fallback delegation gate does not cover the explicitly excluded primary CLI, subscription-auth orchestrator, or peer-conversation paths.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Attachments and Conversation Media">
+
+Attachments now arrive with their identity intact across several awkward boundaries. Paths ending in dot segments fall back to a usable name, long UTF-8 text remains recognizable when a character crosses the inspection boundary, streamed files keep a type and extension that match the saved bytes, and inferred legacy text keeps accents, currency symbols, and other non-ASCII characters. Rejected URL downloads also release their transport promptly, while repeatedly changing one conversation avatar no longer pushes other current avatars out of the cache.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Release superseded avatar data without evicting other current avatars ([#134978](https://github.com/openclaw/openclaw/pull/134978)).
+- Keep usable attachment names when path metadata ends in dot segments ([#135135](https://github.com/openclaw/openclaw/pull/135135)). Thanks @arpe1618.
+- Recognize UTF-8 text when a character crosses the attachment inspection boundary ([#135227](https://github.com/openclaw/openclaw/pull/135227)).
+- Preserve the correct type and extension for streamed attachments ([#135232](https://github.com/openclaw/openclaw/pull/135232)).
+- Preserve inferred text encoding and release rejected downloads promptly ([#135928](https://github.com/openclaw/openclaw/pull/135928)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="CLI Automation and Target Selection">
+
+Command-line automation now fails without guessing. MCP read commands return the normal JSON failure document on early errors, `agent exec` preserves the original run failure and exit code when cleanup also fails, and Windows command lookup ignores empty `PATHEXT` entries instead of treating an extensionless file as runnable.
+
+Explicitly blank session, store, and dead-letter account selectors now stop before OpenClaw can fall back to a default target. Omitting those selectors still keeps the existing default behavior, so scripts can choose between a deliberate default and an explicit target without an empty variable quietly changing what the command touches.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Return the standard JSON failure document from MCP read commands ([#132379](https://github.com/openclaw/openclaw/pull/132379)). Thanks @wangmiao0668000666.
+- Reject blank agent session selectors before dispatch ([#134797](https://github.com/openclaw/openclaw/pull/134797)). Thanks @marmar9615-cloud.
+- Preserve the original `agent exec` failure when cleanup also fails ([#135273](https://github.com/openclaw/openclaw/pull/135273)). Thanks @SebTardif.
+- Reject a blank session-store selector instead of choosing the default store ([#135742](https://github.com/openclaw/openclaw/pull/135742)). Thanks @marmar9615-cloud, @obviyus.
+- Ignore empty `PATHEXT` entries during Windows command lookup ([#135807](https://github.com/openclaw/openclaw/pull/135807)). Thanks @teddytennant.
+- Reject blank dead-letter account selectors instead of choosing the default account ([#135848](https://github.com/openclaw/openclaw/pull/135848)). Thanks @masatohoshino, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Status, Logs, and Diagnostics">
+
+Status and logs now make a problem visible without overstating what is healthy. Detailed status reports show inbound queue pressure and dead letters even when channel connectivity looks fine, usage requests reject unsupported fixed offsets instead of returning totals for the wrong day, and Telegram and TUI status retain known context usage after tool-only turns.
+
+The same principle carries through troubleshooting. Rolling log tails read the file OpenClaw is currently writing, session-observer warnings show a redacted cause instead of an empty object, failover counters agree across console and structured logs, and failed search or Git snapshot diagnostics explain what was lost while keeping sensitive values out of persisted output. Plugin validation reports every genuinely missing field in one pass, tool-policy warnings stop recommending grants that an active deny would block, and native PR quota failures once again include safe manual retry guidance for both observed GraphQL variants while failed SSH tunnel startup cleans up its readiness work.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1522,36 +2472,56 @@ Recovery and diagnostics now follow the same preference for observed state over 
 **Bug fixes**
 
 - Report every missing plugin configuration field with accurate dependency guidance ([#93842](https://github.com/openclaw/openclaw/pull/93842)). Thanks @bladin.
-- Reject invalid fixed UTC offsets before loading usage totals ([#124568](https://github.com/openclaw/openclaw/pull/124568)). Thanks @zyw02.
-- Return the standard JSON failure document from MCP read commands ([#132379](https://github.com/openclaw/openclaw/pull/132379)). Thanks @wangmiao0668000666.
-- Keep context usage visible after tool-only turns when exact data is available ([#134634](https://github.com/openclaw/openclaw/pull/134634)). Thanks @goslingmanagment and @dmsrg399.
-- Keep the genuine Gateway visible in a bounded Devices roster ([#134740](https://github.com/openclaw/openclaw/pull/134740)). Thanks @lzhan011.
-- Reject blank agent-session selectors before dispatch ([#134797](https://github.com/openclaw/openclaw/pull/134797)). Thanks @marmar9615-cloud.
-- Resolve equal-timestamp Buzz profile and room updates consistently ([#134861](https://github.com/openclaw/openclaw/pull/134861)). Thanks @vincentkoc.
+- Reject invalid fixed UTC offsets in usage date requests ([#124568](https://github.com/openclaw/openclaw/pull/124568)). Thanks @zyw02.
+- Explain when failed search diagnostics discarded earlier error output ([#132627](https://github.com/openclaw/openclaw/pull/132627)). Thanks @Alix-007, @gustav-bliss.
+- Keep context usage visible after tool-only turns ([#134634](https://github.com/openclaw/openclaw/pull/134634)). Thanks @goslingmanagment, @dmsrg399.
 - Show delivery-queue pressure and dead letters in detailed status reports ([#134889](https://github.com/openclaw/openclaw/pull/134889)). Thanks @Lendersmark.
-- Avoid duplicate Git preparation during concurrent session starts ([#134912](https://github.com/openclaw/openclaw/pull/134912)).
-- Release superseded avatar data without evicting other current avatars ([#134978](https://github.com/openclaw/openclaw/pull/134978)).
-- Keep usable attachment names when path metadata ends in dot segments ([#135135](https://github.com/openclaw/openclaw/pull/135135)). Thanks @arpe1618.
-- Recognize UTF-8 text when a character crosses the attachment inspection boundary ([#135227](https://github.com/openclaw/openclaw/pull/135227)).
-- Preserve the correct type and extension for streamed attachments ([#135232](https://github.com/openclaw/openclaw/pull/135232)).
-- Keep SSH tunnel listener timeouts stable across system clock changes ([#135281](https://github.com/openclaw/openclaw/pull/135281)). Thanks @xialonglee.
-- Show the redacted cause of session-observer failures ([#135337](https://github.com/openclaw/openclaw/pull/135337)). Thanks @LiuwqGit and @Cobblestone-Digital1.
-- Reject a blank session-store selector instead of choosing the default store ([#135742](https://github.com/openclaw/openclaw/pull/135742)). Thanks @marmar9615-cloud and @obviyus.
+- Show the redacted cause of session-observer failures ([#135337](https://github.com/openclaw/openclaw/pull/135337)). Thanks @LiuwqGit, @Cobblestone-Digital1.
 - Tail the active file when logging uses a configured rolling path ([#135769](https://github.com/openclaw/openclaw/pull/135769)).
-- Distinguish ordinary wait deadlines from Gateway shutdown ([#135797](https://github.com/openclaw/openclaw/pull/135797)).
-- Reject blank dead-letter account selectors instead of choosing the default account ([#135848](https://github.com/openclaw/openclaw/pull/135848)). Thanks @masatohoshino and @obviyus.
+- Keep failover counters current in console diagnostics ([#135844](https://github.com/openclaw/openclaw/pull/135844)).
 - Restore GitHub quota retry guidance and clean up failed SSH tunnel startup ([#135873](https://github.com/openclaw/openclaw/pull/135873)).
-- Preserve inferred text encoding and release rejected downloads promptly ([#135928](https://github.com/openclaw/openclaw/pull/135928)).
-- Keep recently connected nodes inside CLI age filters ([#135936](https://github.com/openclaw/openclaw/pull/135936)).
 
 **Security and trust**
 
-- Preserve useful Git snapshot failure details while redacting sensitive values ([#135455](https://github.com/openclaw/openclaw/pull/135455)). Thanks @ly85206559 and @obviyus.
+- Stop tool-profile warnings from recommending grants blocked by active policy ([#132623](https://github.com/openclaw/openclaw/pull/132623)). Thanks @sunlit-deng, @shbernal, @SuperMarioYL.
+- Preserve useful Git snapshot failure details while redacting sensitive values ([#135455](https://github.com/openclaw/openclaw/pull/135455)). Thanks @ly85206559, @obviyus.
 
-**Limits and compatibility**
+</details>
+
+</Accordion>
+
+<Accordion title="Connected Device and Remote Gateway State">
+
+Remote and connected setups now hold on to the state they actually observed. SSH tunnel startup keeps its configured listener timeout even if the system clock changes, node age filters use the Gateway's latest recorded connection time, and the Devices roster keeps the genuine Gateway visible while remaining bounded under peer pressure and hostname collisions. At the HTTP edge, clients that explicitly reject HTML receive the existing startup or not-found response instead of an unwanted app shell, while ordinary browser navigation keeps working as before.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
 
 - Respect explicit HTML rejection in Gateway content negotiation ([#118197](https://github.com/openclaw/openclaw/pull/118197)). Thanks @peterolkhov.
-- Ignore empty `PATHEXT` entries during Windows command lookup ([#135807](https://github.com/openclaw/openclaw/pull/135807)). Thanks @teddytennant.
+- Keep the genuine Gateway visible in a bounded Devices roster ([#134740](https://github.com/openclaw/openclaw/pull/134740)). Thanks @lzhan011.
+- Keep SSH tunnel listener timeouts stable across system clock changes ([#135281](https://github.com/openclaw/openclaw/pull/135281)). Thanks @xialonglee.
+- Keep recently connected nodes inside CLI age filters ([#135936](https://github.com/openclaw/openclaw/pull/135936)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Channel Commands and Relay Ordering">
+
+Two narrower channel fixes remove behavior that depended on the wrong condition. Native `/compact` now gives an explicit authorization refusal without starting compaction work when the sender is not allowed to use it, while Buzz applies stable event ordering when profile or room updates share a timestamp instead of letting arrival order decide which state wins.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Return an explicit refusal for unauthorized native `/compact` commands ([#131408](https://github.com/openclaw/openclaw/pull/131408)). Thanks @igs-rogenlo.
+
+**Bug fixes**
+
+- Resolve equal-timestamp Buzz profile and room updates deterministically ([#134861](https://github.com/openclaw/openclaw/pull/134861)). Thanks @vincentkoc.
 
 </details>
 
@@ -1561,11 +2531,11 @@ Recovery and diagnostics now follow the same preference for observed state over 
 
 ## Maintainer and Internal Changes
 
-This release includes exactly 526 maintainer-only units covering the machinery behind how OpenClaw is tested, reviewed, built, translated, packaged, and released, along with behavior-preserving refactors and internal performance work. They belong in one place because none defines a separate product workflow. The complete accounting stays here for maintainers and is not used to support the opening or any product claim above.
+This release includes 531 maintainer-only units covering the machinery behind how OpenClaw is tested, reviewed, built, translated, packaged, and released. They tighten the evidence we rely on, remove duplicated internal work, and keep tooling failures from looking like successful validation, but they do not add a separate user workflow and should not be read as public product claims.
 
 <AccordionGroup>
 
-<Accordion title="Build, test, release, and internal foundations">
+<Accordion title="CI and test reliability">
 
 CI and focused test work now exposes skipped, crashed, mistimed, or incompletely cleaned validation more clearly, while reusing safe fixtures and build inputs to shorten maintainer feedback without changing product behavior.
 
@@ -1709,43 +2679,12 @@ CI and focused test work now exposes skipped, crashed, mistimed, or incompletely
 - Share session branch fixture history ([#136209](https://github.com/openclaw/openclaw/pull/136209)).
 - Adopt prepared entry in Gateway QA fixtures ([#136245](https://github.com/openclaw/openclaw/pull/136245)).
 - Prove auth-profile rotation with tighter agent fixtures ([#136254](https://github.com/openclaw/openclaw/pull/136254)).
-- Exercise complete embedded preparation in authentication-pin regression tests ([#136430](https://github.com/openclaw/openclaw/pull/136430)).
-- Split Gateway-backed CLI process tests under the repository line cap ([`aef65cc574`](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c)).
-- Share state and configuration path policy across private E2E harnesses ([#135793](https://github.com/openclaw/openclaw/pull/135793)). Thanks @vincentkoc.
 - Retain canonical package checks while removing a redundant AI source scanner ([#136037](https://github.com/openclaw/openclaw/pull/136037)). Thanks @RomneyDa.
 - Exercise parallel provider tests through the public execution boundary ([#136038](https://github.com/openclaw/openclaw/pull/136038)). Thanks @RomneyDa.
 - Use canonical persisted session rows in subagent depth and capability tests ([#136094](https://github.com/openclaw/openclaw/pull/136094)). Thanks @RomneyDa.
-- Share startup-duration filtering across performance reports ([#136176](https://github.com/openclaw/openclaw/pull/136176)). Thanks @vincentkoc.
-- Skip process-only runtime preparation in ordinary Doctor tests ([#136229](https://github.com/openclaw/openclaw/pull/136229)).
-- Synchronize Control UI typography and cloud-picker fixtures more directly ([#136263](https://github.com/openclaw/openclaw/pull/136263)).
-- Run Gateway provider-refusal QA from the prepared bundle ([#136287](https://github.com/openclaw/openclaw/pull/136287)).
 - Use capacity-aware scheduling and fewer shards for broad pull-request CI ([#136295](https://github.com/openclaw/openclaw/pull/136295)).
-- Give device-scope browser tests shared E2E lifecycle ownership ([#136305](https://github.com/openclaw/openclaw/pull/136305)).
-- Share one real-flow context across Doctor persistence suites ([#136323](https://github.com/openclaw/openclaw/pull/136323)).
-- Wait for Android outbox publication before branch-coordination assertions ([#136335](https://github.com/openclaw/openclaw/pull/136335)).
-- Share lifecycle ownership across session-diff browser coverage ([#136347](https://github.com/openclaw/openclaw/pull/136347)).
-- Assert real unverified-receipt provenance in activity-inspector tests ([#136351](https://github.com/openclaw/openclaw/pull/136351)).
-- Preserve original failures while cloud-workspace browser fixtures clean up ([#136353](https://github.com/openclaw/openclaw/pull/136353)).
-- Prove skipped-midnight chart boundaries in a real Santiago browser timezone ([#136448](https://github.com/openclaw/openclaw/pull/136448)).
-- Remove redundant Markdown code-span coverage ([#136461](https://github.com/openclaw/openclaw/pull/136461)).
-- Remove redundant timezone wrappers from auto-reply timestamp tests ([#136483](https://github.com/openclaw/openclaw/pull/136483)).
-- Exercise real daylight-saving transitions in Gateway usage-date tests ([#136501](https://github.com/openclaw/openclaw/pull/136501)).
-- Consolidate logs timestamp coverage at the command boundary ([#136511](https://github.com/openclaw/openclaw/pull/136511)).
-- Keep configuration schema-hint test data out of production code ([#136520](https://github.com/openclaw/openclaw/pull/136520)).
-- Distinguish real rejection handling from timeout recovery in macOS approval tests ([#136522](https://github.com/openclaw/openclaw/pull/136522)).
-- Exercise the production snapshot-cache path in CLI configuration tests ([#136532](https://github.com/openclaw/openclaw/pull/136532)).
 - Avoid a second hosted-runner queue for eligible Blacksmith aggregate gates ([#136534](https://github.com/openclaw/openclaw/pull/136534)).
-- Protect machine-name subprocess isolation with focused tests ([#136540](https://github.com/openclaw/openclaw/pull/136540)).
 - Guard prefetched comparison bases with smaller Gateway CLI fixtures ([#136541](https://github.com/openclaw/openclaw/pull/136541)).
-- Validate native Gateway timeout budgets without host-scheduling false failures ([#136571](https://github.com/openclaw/openclaw/pull/136571)).
-- Generate Codex prompt snapshots in hermetic state ([#136601](https://github.com/openclaw/openclaw/pull/136601)).
-- Exercise real cache-loader boundaries in session-cost retry tests ([#136616](https://github.com/openclaw/openclaw/pull/136616)).
-- Exercise production entry points in compile-cache startup tests ([#136658](https://github.com/openclaw/openclaw/pull/136658)).
-- Give Vitest wrappers one owner for the first forwarded shutdown signal ([#136667](https://github.com/openclaw/openclaw/pull/136667)). Thanks @vincentkoc.
-- Simplify Discord cancellation checks without changing cancellation behavior ([#136670](https://github.com/openclaw/openclaw/pull/136670)). Thanks @vincentkoc.
-- Exercise real stop handles and restart ownership in session-delivery tests ([#136675](https://github.com/openclaw/openclaw/pull/136675)).
-- Exercise real semantic events in diagnostic progress tests ([#136688](https://github.com/openclaw/openclaw/pull/136688)).
-- Use the production contribution factory in Doctor health-check tests ([#136695](https://github.com/openclaw/openclaw/pull/136695)).
 
 **Bug fixes**
 
@@ -1782,18 +2721,7 @@ CI and focused test work now exposes skipped, crashed, mistimed, or incompletely
 - Accept string content in QA Responses messages ([#136109](https://github.com/openclaw/openclaw/pull/136109)).
 - Retain bounded bootstrap diagnostics after timeouts ([#136111](https://github.com/openclaw/openclaw/pull/136111)).
 - Format IPv6 QA listener URLs at their owners ([#136132](https://github.com/openclaw/openclaw/pull/136132)).
-- Prevent the residual-process watchdog from racing fixture readiness ([#136185](https://github.com/openclaw/openclaw/pull/136185)).
-- Keep approval tracking scoped to the run that owns each lifecycle event ([#136205](https://github.com/openclaw/openclaw/pull/136205)). Thanks @quangtran88.
-- Resolve managed OpenTelemetry preloads from the SDK-owned dependency tree ([#136272](https://github.com/openclaw/openclaw/pull/136272)).
-- Keep Android Debug test filters from requesting release-signing credentials ([#136273](https://github.com/openclaw/openclaw/pull/136273)).
-- Retain CLI lifecycle ownership until delayed output closes ([#136286](https://github.com/openclaw/openclaw/pull/136286)).
-- Join SQLite migration-proof cleanup and retain its diagnostics ([#136291](https://github.com/openclaw/openclaw/pull/136291)).
-- Extend cold GitHub-hosted Android fallback build timeouts ([#136307](https://github.com/openclaw/openclaw/pull/136307)).
-- Finish failed Gateway test-client cleanup before teardown ([#136344](https://github.com/openclaw/openclaw/pull/136344)).
-- Join placement-dialog operations before fixture teardown ([#136354](https://github.com/openclaw/openclaw/pull/136354)).
 - Catch missing mobile protocol-event coverage in local changed-file checks ([#136470](https://github.com/openclaw/openclaw/pull/136470)).
-- Wait for both queued WebChat turns in Gateway recovery tests ([#136473](https://github.com/openclaw/openclaw/pull/136473)).
-- Restore Gateway cancellation-test environments after teardown failures ([#136590](https://github.com/openclaw/openclaw/pull/136590)).
 - Match generated-plugin capability fixtures to emitted package metadata ([`4a76681`](https://github.com/openclaw/openclaw/commit/4a76681e3f3997dbf3f7ac57511f413d6ede1a2c)).
 - Install workspace dependencies in the Docker plugin-binding smoke image ([`ef256f9`](https://github.com/openclaw/openclaw/commit/ef256f9696995d9f5ae84a362dddd94e41346a32)).
 - Enforce the current App SDK worker-environment fixture contract ([`23ca4bc`](https://github.com/openclaw/openclaw/commit/23ca4bcb960f0e8bd761549abaec4da0443b30b8)).
@@ -1812,7 +2740,9 @@ CI and focused test work now exposes skipped, crashed, mistimed, or incompletely
 
 </details>
 
-**Release and package tooling**
+</Accordion>
+
+<Accordion title="Release and package tooling">
 
 Release preparation retains stronger artifact identity, retry, review, and publication boundaries, while removing repeated builds from the protected path where the frozen evidence supports reuse.
 
@@ -1821,7 +2751,6 @@ Release preparation retains stronger artifact identity, retry, review, and publi
 
 **Improvements**
 
-- Record the refreshed v2026.9.1 audited boundary and contribution ledger ([`a41af7e`](https://github.com/openclaw/openclaw/commit/a41af7eb71a95f7fc1ebc83d1b34d8a7a4ed0fe7)).
 - Add macOS 2026.8.2 to the stable Sparkle feed ([#135680](https://github.com/openclaw/openclaw/pull/135680)).
 - Isolate Plugin SDK cleanup from runner metadata ([#134443](https://github.com/openclaw/openclaw/pull/134443)). Thanks @RomneyDa.
 - Share compiler-consumed declaration inputs ([#134734](https://github.com/openclaw/openclaw/pull/134734)).
@@ -1840,21 +2769,16 @@ Release preparation retains stronger artifact identity, retry, review, and publi
 - Reuse Docker work and narrow plugin verification inputs ([#135960](https://github.com/openclaw/openclaw/pull/135960)).
 - Centralize JSON key sorter ([#135157](https://github.com/openclaw/openclaw/pull/135157)). Thanks @vincentkoc.
 - Share canonical Docker CLI flag parser ([#135207](https://github.com/openclaw/openclaw/pull/135207)).
-- Align app, package, plugin, compatibility, and generated catalog metadata for 2026.9.1 ([`f8fdfb950d`](https://github.com/openclaw/openclaw/commit/f8fdfb950dc070b0117954c6ea0587b2e5f1bf71)).
-- Share dependency-report argument diagnostics without changing CLI behavior ([#135859](https://github.com/openclaw/openclaw/pull/135859)). Thanks @vincentkoc.
 - Reuse receipt-bound release artifacts while independent qualification work overlaps ([#136105](https://github.com/openclaw/openclaw/pull/136105)).
 - Hydrate release source and Tideclaw ancestry progressively within a bounded preflight ([#136309](https://github.com/openclaw/openclaw/pull/136309)). Thanks @vincentkoc.
 - Prepare Mermaid assets before linked-worktree iOS and macOS builds ([#136315](https://github.com/openclaw/openclaw/pull/136315)). Thanks @vincentkoc.
 - Coordinate Android and iOS release versions through one manifest and two-phase cutter ([#136366](https://github.com/openclaw/openclaw/pull/136366)). Thanks @vincentkoc.
 - Expand release validation across synthetic Twitch ingress and installed-package layouts ([#136678](https://github.com/openclaw/openclaw/pull/136678)).
+- Align app, package, plugin, compatibility, and generated catalog metadata for 2026.9.1 ([`f8fdfb950d`](https://github.com/openclaw/openclaw/commit/f8fdfb950dc070b0117954c6ea0587b2e5f1bf71)).
+- Record the refreshed v2026.9.1 audited boundary and contribution ledger ([`a41af7e`](https://github.com/openclaw/openclaw/commit/a41af7eb71a95f7fc1ebc83d1b34d8a7a4ed0fe7)).
 
 **Bug fixes**
 
-- Start the candidate package registry on Windows without drive-qualified tar path failures ([`0e2789a`](https://github.com/openclaw/openclaw/commit/0e2789a12ad7b87c2069a4e914b53a6eaaaf38c5)).
-- Resolve prepared candidate plugins during stable-to-candidate upgrade validation ([`9461eac`](https://github.com/openclaw/openclaw/commit/9461eac258fe152e3c458bb443354de4c2ca7192)).
-- Preserve the candidate registry during corrupt-plugin setup validation ([`d7153a4`](https://github.com/openclaw/openclaw/commit/d7153a4ea53bfd58ba82d79a12f99fabfdb9a881)).
-- Inspect survivor plugins before restoring the exact legacy configuration bytes ([`0ab85e8`](https://github.com/openclaw/openclaw/commit/0ab85e8f0e53f1147b155b8d5a10060265c515bc)).
-- Enable the reinstalled npm fixture before proving its CLI while retaining disablement checks ([`57559b5`](https://github.com/openclaw/openclaw/commit/57559b57ff048fe7fe88846ad9244bac7ffdea55)).
 - Generate stable appcasts correctly with macOS Bash ([#135687](https://github.com/openclaw/openclaw/pull/135687)).
 - Keep mixed skill and core changes in normal maintainer review ([#131619](https://github.com/openclaw/openclaw/pull/131619)). Thanks @MertBasar0, @shojikumaru.
 - Use a supported baseline for frozen installer validation ([#134519](https://github.com/openclaw/openclaw/pull/134519)). Thanks @RomneyDa.
@@ -1885,8 +2809,9 @@ Release preparation retains stronger artifact identity, retry, review, and publi
 - Preserve ignored files during PR worktree preparation ([#135500](https://github.com/openclaw/openclaw/pull/135500)).
 - Protect package markers during concurrent builds ([#134835](https://github.com/openclaw/openclaw/pull/134835)).
 - Keep macOS worker packaging on the destination volume ([#134857](https://github.com/openclaw/openclaw/pull/134857)).
-- Restore iOS dependency resolution with the available WebRTC 152 artifact ([#134942](https://github.com/openclaw/openclaw/pull/134942)).
 - Run Plugin SDK qualification from the trusted tooling checkout across pnpm versions ([#136233](https://github.com/openclaw/openclaw/pull/136233)). Thanks @RomneyDa.
+- Keep Android Debug test filters from requesting release-signing credentials ([#136273](https://github.com/openclaw/openclaw/pull/136273)).
+- Extend cold GitHub-hosted Android fallback build timeouts ([#136307](https://github.com/openclaw/openclaw/pull/136307)).
 - Validate real Android app and Wear signing material during release preflight ([#136319](https://github.com/openclaw/openclaw/pull/136319)). Thanks @vincentkoc.
 - Run remaining trusted release-validation installs from the tooling checkout ([#136325](https://github.com/openclaw/openclaw/pull/136325)). Thanks @vincentkoc.
 - Bind release publication and resume to the exact selected preflight run ([#136336](https://github.com/openclaw/openclaw/pull/136336)).
@@ -1896,6 +2821,13 @@ Release preparation retains stronger artifact identity, retry, review, and publi
 - Match frozen Docker acceptance to the selected Doctor and plugin-binding contracts ([#136627](https://github.com/openclaw/openclaw/pull/136627)). Thanks @RomneyDa.
 - Recognize the historical absence-based uninstall contract for frozen packages ([#136628](https://github.com/openclaw/openclaw/pull/136628)). Thanks @RomneyDa.
 - Run frozen-release dependency evidence from trusted tooling across pnpm versions ([#136681](https://github.com/openclaw/openclaw/pull/136681)). Thanks @vincentkoc.
+- Start the candidate package registry on Windows without drive-qualified tar path failures ([`0e2789a`](https://github.com/openclaw/openclaw/commit/0e2789a12ad7b87c2069a4e914b53a6eaaaf38c5)).
+- Resolve prepared candidate plugins during stable-to-candidate upgrade validation ([`9461eac`](https://github.com/openclaw/openclaw/commit/9461eac258fe152e3c458bb443354de4c2ca7192)).
+- Preserve the candidate registry during corrupt-plugin setup validation ([`d7153a4`](https://github.com/openclaw/openclaw/commit/d7153a4ea53bfd58ba82d79a12f99fabfdb9a881)).
+- Inspect survivor plugins before restoring the exact legacy configuration bytes ([`0ab85e8`](https://github.com/openclaw/openclaw/commit/0ab85e8f0e53f1147b155b8d5a10060265c515bc)).
+- Enable the reinstalled npm fixture before proving its CLI while retaining disablement checks ([`57559b5`](https://github.com/openclaw/openclaw/commit/57559b57ff048fe7fe88846ad9244bac7ffdea55)).
+- Move iOS builds to an available validated WebRTC 152 release ([#134942](https://github.com/openclaw/openclaw/pull/134942)).
+- Launch ACPX release validation through the plugin-owned adapter path ([`9f31b4d`](https://github.com/openclaw/openclaw/commit/9f31b4d643d27d264e374c1601c467e69eb06bd5)).
 
 **Security and trust**
 
@@ -1903,14 +2835,26 @@ Release preparation retains stronger artifact identity, retry, review, and publi
 - Stop Docker promotion on unrelated lookup failures ([#135113](https://github.com/openclaw/openclaw/pull/135113)). Thanks @vincentkoc.
 - Bind ClawHub source attribution to the authorized commit ([#135368](https://github.com/openclaw/openclaw/pull/135368)).
 
+**Documentation**
+
+- Record the aggregate 2026.9.1 story and contribution accounting in the changelog ([`c92d0ae9c0`](https://github.com/openclaw/openclaw/commit/c92d0ae9c07e757719e676517aa9f9460a40761c)).
+- Refresh the audited v2026.9.1 contribution boundary and ledger entries ([`ab217a0`](https://github.com/openclaw/openclaw/commit/ab217a004c499160cc3c4e0d2074298ac3900905)).
+- Advance the audited v2026.9.1 history endpoint without changing the contribution total ([`21616f1`](https://github.com/openclaw/openclaw/commit/21616f1a5cac00c236a363a3f404f5f166f74855)).
+
 </details>
 
-**Documentation and localization**
+</Accordion>
+
+<Accordion title="Documentation and localization">
 
 Documentation and generated localization work keeps maintainer guidance, release history, translation inputs, and native locale generation aligned with the code they describe.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep dynamic macOS text inside generated localization coverage ([#135511](https://github.com/openclaw/openclaw/pull/135511)).
 
 **Documentation**
 
@@ -1939,14 +2883,14 @@ Documentation and generated localization work keeps maintainer guidance, release
 - Reserve changelog edits for release preparation ([#135136](https://github.com/openclaw/openclaw/pull/135136)).
 - Move the historical beta clarification into a footnote ([#135595](https://github.com/openclaw/openclaw/pull/135595)). Thanks @hannesrudolph.
 - Add release scale and contribution totals to prior pages ([#135822](https://github.com/openclaw/openclaw/pull/135822)). Thanks @hannesrudolph.
-- Keep dynamic macOS UI copy inside generated localization verification ([#135511](https://github.com/openclaw/openclaw/pull/135511)).
-- Replace the historical v2026.8.2 page with topic-organized notes and source accounting ([#135805](https://github.com/openclaw/openclaw/pull/135805)). Thanks @hannesrudolph.
 - Keep the lasting automations terminology rule in Control UI localization verification ([#136138](https://github.com/openclaw/openclaw/pull/136138)). Thanks @RomneyDa.
-- Record the aggregate 2026.9.1 story and contribution accounting in the changelog ([`c92d0ae9c0`](https://github.com/openclaw/openclaw/commit/c92d0ae9c07e757719e676517aa9f9460a40761c)).
+- Expand the historical v2026.8.2 release page with topic and source detail ([#135805](https://github.com/openclaw/openclaw/pull/135805)). Thanks @hannesrudolph.
 
 </details>
 
-**Internal refactors and performance**
+</Accordion>
+
+<Accordion title="Internal refactors and performance">
 
 Behavior-preserving refactors consolidate duplicated ownership and trim repeated parsing, copying, allocation, and setup across the runtime and repository.
 
@@ -2106,13 +3050,13 @@ Behavior-preserving refactors consolidate duplicated ownership and trim repeated
 - Drop retired voice UI and unify command ownership ([#136192](https://github.com/openclaw/openclaw/pull/136192)).
 - Streamline shared message rendering ([#136216](https://github.com/openclaw/openclaw/pull/136216)).
 - Reduce full plugin scans for known contribution owners ([#135953](https://github.com/openclaw/openclaw/pull/135953)).
-- Share bounded diagnostic output across maintainer scripts and E2E runners ([#135802](https://github.com/openclaw/openclaw/pull/135802)). Thanks @vincentkoc.
-- Reuse one collation function within name-sorted cron lists ([#135597](https://github.com/openclaw/openclaw/pull/135597)).
 - Share provider-prefix normalization across Feishu routing paths ([#135744](https://github.com/openclaw/openclaw/pull/135744)). Thanks @vincentkoc.
+- Share bounded diagnostic output across maintainer scripts and E2E runners ([#135802](https://github.com/openclaw/openclaw/pull/135802)). Thanks @vincentkoc.
 - Share one home-directory policy across Claude catalog operations ([#135824](https://github.com/openclaw/openclaw/pull/135824)). Thanks @vincentkoc.
+- Share dependency-report argument diagnostics without changing CLI behavior ([#135859](https://github.com/openclaw/openclaw/pull/135859)). Thanks @vincentkoc.
 - Share one bounded thinking-policy path across Bedrock Opus 4.7 and 4.8 ([#136107](https://github.com/openclaw/openclaw/pull/136107)). Thanks @vincentkoc.
+- Share startup-duration filtering across performance reports ([#136176](https://github.com/openclaw/openclaw/pull/136176)). Thanks @vincentkoc.
 - Give the context-window cache loader one asynchronous ownership path ([#136265](https://github.com/openclaw/openclaw/pull/136265)).
-- Import the update snapshot validator without the full restoration system ([#136298](https://github.com/openclaw/openclaw/pull/136298)).
 - Share one iterative retry lifecycle across OpenAI and Azure Responses ([#136359](https://github.com/openclaw/openclaw/pull/136359)).
 - Avoid unused result wrappers on plugin cache hits ([#136381](https://github.com/openclaw/openclaw/pull/136381)).
 - Reuse prepared payload byte counts in the file logger ([#136393](https://github.com/openclaw/openclaw/pull/136393)).
@@ -2128,11 +3072,13 @@ Behavior-preserving refactors consolidate duplicated ownership and trim repeated
 - Deduplicate repeated callbacks with less allocation and map work ([#136457](https://github.com/openclaw/openclaw/pull/136457)).
 - Sanitize terminal upload filenames with less temporary processing ([#136479](https://github.com/openclaw/openclaw/pull/136479)).
 - Use one hydration path for interactive plugin callback state ([#136481](https://github.com/openclaw/openclaw/pull/136481)).
+- Remove redundant timezone wrappers from auto-reply timestamp tests ([#136483](https://github.com/openclaw/openclaw/pull/136483)).
 - Route unknown direct messages through one canonical internal resolver ([#136580](https://github.com/openclaw/openclaw/pull/136580)).
 - Reduce temporary heap while styling terminal text ([#136626](https://github.com/openclaw/openclaw/pull/136626)).
 - Skip error-only diagnostic formatting after successful node selection ([#136654](https://github.com/openclaw/openclaw/pull/136654)).
 - Avoid eager session-storage initialization during Gateway method discovery ([#136676](https://github.com/openclaw/openclaw/pull/136676)).
 - Defer skill discovery imports for ordinary replies ([#136716](https://github.com/openclaw/openclaw/pull/136716)).
+- Reuse locale-aware comparison work within large name-sorted job lists ([#135597](https://github.com/openclaw/openclaw/pull/135597)).
 
 **Security and trust**
 
@@ -2141,12 +3087,48 @@ Behavior-preserving refactors consolidate duplicated ownership and trim repeated
 
 </details>
 
-**QA and maintainer workflow fixes**
+</Accordion>
+
+<Accordion title="QA and maintainer workflow fixes">
 
 The remaining maintainer fixes repair local previews, QA simulators, merge helpers, packaging checks, and other contributor workflows without turning those changes into public product claims.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Share state and configuration path policy across private E2E harnesses ([#135793](https://github.com/openclaw/openclaw/pull/135793)). Thanks @vincentkoc.
+- Skip process-only runtime preparation in ordinary Doctor tests ([#136229](https://github.com/openclaw/openclaw/pull/136229)).
+- Synchronize Control UI typography and cloud-picker fixtures more directly ([#136263](https://github.com/openclaw/openclaw/pull/136263)).
+- Run Gateway provider-refusal QA from the prepared bundle ([#136287](https://github.com/openclaw/openclaw/pull/136287)).
+- Import the update snapshot validator without the full restoration system ([#136298](https://github.com/openclaw/openclaw/pull/136298)).
+- Give device-scope browser tests shared E2E lifecycle ownership ([#136305](https://github.com/openclaw/openclaw/pull/136305)).
+- Share one real-flow context across Doctor persistence suites ([#136323](https://github.com/openclaw/openclaw/pull/136323)).
+- Wait for Android outbox publication before branch-coordination assertions ([#136335](https://github.com/openclaw/openclaw/pull/136335)).
+- Share lifecycle ownership across session-diff browser coverage ([#136347](https://github.com/openclaw/openclaw/pull/136347)).
+- Assert real unverified-receipt provenance in activity-inspector tests ([#136351](https://github.com/openclaw/openclaw/pull/136351)).
+- Preserve original failures while cloud-workspace browser fixtures clean up ([#136353](https://github.com/openclaw/openclaw/pull/136353)).
+- Exercise complete embedded preparation in authentication-pin regression tests ([#136430](https://github.com/openclaw/openclaw/pull/136430)).
+- Prove skipped-midnight chart boundaries in a real Santiago browser timezone ([#136448](https://github.com/openclaw/openclaw/pull/136448)).
+- Remove redundant Markdown code-span coverage ([#136461](https://github.com/openclaw/openclaw/pull/136461)).
+- Exercise real daylight-saving transitions in Gateway usage-date tests ([#136501](https://github.com/openclaw/openclaw/pull/136501)).
+- Consolidate logs timestamp coverage at the command boundary ([#136511](https://github.com/openclaw/openclaw/pull/136511)).
+- Keep configuration schema-hint test data out of production code ([#136520](https://github.com/openclaw/openclaw/pull/136520)).
+- Distinguish real rejection handling from timeout recovery in macOS approval tests ([#136522](https://github.com/openclaw/openclaw/pull/136522)).
+- Exercise the production snapshot-cache path in CLI configuration tests ([#136532](https://github.com/openclaw/openclaw/pull/136532)).
+- Protect machine-name subprocess isolation with focused tests ([#136540](https://github.com/openclaw/openclaw/pull/136540)).
+- Validate native Gateway timeout budgets without host-scheduling false failures ([#136571](https://github.com/openclaw/openclaw/pull/136571)).
+- Generate Codex prompt snapshots in hermetic state ([#136601](https://github.com/openclaw/openclaw/pull/136601)).
+- Exercise real cache-loader boundaries in session-cost retry tests ([#136616](https://github.com/openclaw/openclaw/pull/136616)).
+- Exercise production entry points in compile-cache startup tests ([#136658](https://github.com/openclaw/openclaw/pull/136658)).
+- Give Vitest wrappers one owner for the first forwarded shutdown signal ([#136667](https://github.com/openclaw/openclaw/pull/136667)). Thanks @vincentkoc.
+- Simplify Discord cancellation checks without changing cancellation behavior ([#136670](https://github.com/openclaw/openclaw/pull/136670)). Thanks @vincentkoc.
+- Exercise real stop handles and restart ownership in session-delivery tests ([#136675](https://github.com/openclaw/openclaw/pull/136675)).
+- Exercise real semantic events in diagnostic progress tests ([#136688](https://github.com/openclaw/openclaw/pull/136688)).
+- Use the production contribution factory in Doctor health-check tests ([#136695](https://github.com/openclaw/openclaw/pull/136695)).
+- Split Gateway-backed CLI process tests under the repository line cap ([`aef65cc574`](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c)).
+- Verify private sandbox writes without exposing or mutating the host workspace ([`9688399`](https://github.com/openclaw/openclaw/commit/96883993741d7f637e0cb81fd0b18221fc591569)).
 
 **Bug fixes**
 
@@ -2162,7 +3144,17 @@ The remaining maintainer fixes repair local previews, QA simulators, merge helpe
 - Keep preview avatar requests away from the operator Gateway ([#134686](https://github.com/openclaw/openclaw/pull/134686)).
 - Isolate concurrent standalone previews from external connections ([#135724](https://github.com/openclaw/openclaw/pull/135724)).
 - Reject oversized QA uploads without crashing shutdown ([#135938](https://github.com/openclaw/openclaw/pull/135938)).
+- Prevent the residual-process watchdog from racing fixture readiness ([#136185](https://github.com/openclaw/openclaw/pull/136185)).
+- Keep approval tracking scoped to the run that owns each lifecycle event ([#136205](https://github.com/openclaw/openclaw/pull/136205)). Thanks @quangtran88.
+- Resolve managed OpenTelemetry preloads from the SDK-owned dependency tree ([#136272](https://github.com/openclaw/openclaw/pull/136272)).
+- Retain CLI lifecycle ownership until delayed output closes ([#136286](https://github.com/openclaw/openclaw/pull/136286)).
+- Join SQLite migration-proof cleanup and retain its diagnostics ([#136291](https://github.com/openclaw/openclaw/pull/136291)).
+- Finish failed Gateway test-client cleanup before teardown ([#136344](https://github.com/openclaw/openclaw/pull/136344)).
+- Join placement-dialog operations before fixture teardown ([#136354](https://github.com/openclaw/openclaw/pull/136354)).
+- Wait for both queued WebChat turns in Gateway recovery tests ([#136473](https://github.com/openclaw/openclaw/pull/136473)).
 - Preserve built-CLI SQLite failure diagnostics when plugin inspection fails ([#136478](https://github.com/openclaw/openclaw/pull/136478)).
+- Restore Gateway cancellation-test environments after teardown failures ([#136590](https://github.com/openclaw/openclaw/pull/136590)).
+- Model confirmed source-reply delivery in subagent announcement fixtures ([`2ca23b3`](https://github.com/openclaw/openclaw/commit/2ca23b36df1c85a0ffc2ef6ad67b0a19175a85ea)).
 
 </details>
 

--- a/docs/releases/2026.9.1.md
+++ b/docs/releases/2026.9.1.md
@@ -1,6 +1,6 @@
 ---
 title: "v2026.9.1"
-summary: "Mermaid diagrams across chat surfaces, a fuller Android experience, safer update recovery, and lower overhead for long conversations and large installations."
+summary: "Mermaid diagrams in chat, a fuller Android experience, safer update recovery, and less overhead across long-running work."
 description: "Detailed OpenClaw v2026.9.1 release notes covering setup, the Control UI, updates, messaging, memory, skills, native apps, models, automations, browser and computer use, plugins, security, performance, fixes, and maintainer changes."
 keywords:
   - OpenClaw
@@ -13,125 +13,80 @@ keywords:
 
 # v2026.9.1
 
-Mermaid diagrams now render directly inside conversations in the Control UI, Android, iPhone, iPad, and Mac, and Android gains a fuller chat and session experience. Updates preserve more of a working setup and stop before a known problem becomes a broken restart. When an update does fail, OpenClaw gives you a clearer path back to a working installation. Testing also found lower memory use and less repeated work while OpenClaw handled long conversations and large installations.
+Mermaid diagrams now render directly inside conversations in the Control UI, Android, iPhone, iPad, and Mac, while Android gets a much fuller chat, session, model, permission, navigation, and appearance experience. Updates preserve more of a working setup, stop before known readiness problems become broken restarts, and leave clearer recovery paths when something does fail, while measured paths through long conversations, large saved-session histories, streaming, commands, and busy Gateways do less repeated work and retain less temporary state. Getting to that work is easier too, with a Quick Start path that can reuse working AI access and open the web dashboard after one choice. Once inside, teammates on shared Gateways can build and reuse personal skills, publish pull requests through an explicitly selected personal GitHub account, and let sandbox-required guests code inside private writable storage without exposing the shared workspace, all alongside a much wider reliability pass across messaging, memory, models, automations, integrations, and everyday recovery.
 
-**Release scale:** 922 pull requests, 6 direct commits, and 241 contributors.
+**Release scale:** 1,186 pull requests, 21 direct commits, and 281 contributors.
 
 ## Installation and Onboarding
 
-Getting OpenClaw running now takes a shorter path when the machine already has usable AI access, while longer setup paths leave existing choices and files alone when a check fails or a different route is selected. This release also tightens Windows installation, macOS AI setup, shell configuration, Connect handoffs, and managed local-model downloads.
+Getting from a fresh install to a useful conversation is shorter when the computer already has working AI access, and the longer paths now do a better job of keeping existing choices intact when setup is cancelled, interrupted, or aimed at the wrong place. Windows installation, macOS AI setup, local archives, shell completion, and one-time Connect handoffs also fail more clearly without quietly discarding useful state.
 
 <AccordionGroup>
 
-<Accordion title="Quick Start to the Web Dashboard">
+<Accordion title="Guided setup and verified AI access">
 
-On a fresh local install, the recommended Quick Start path can reuse verified Claude Code or Codex access, or an existing provider key, and open the web dashboard after one choice. The [installation](/install) and [guided setup](/start/wizard) flow keeps the Gateway in the current terminal until you stop it with Ctrl+C, preserves the configuration afterward, and leaves background service installation as an explicit later step.
+On a fresh local install, the recommended [Quick Start](/start/wizard) path can reuse verified Claude Code or Codex access, or an existing provider key, and open the web dashboard after one choice. The Gateway stays in the current terminal until it is stopped with Ctrl+C, the saved configuration remains afterward, and installing a background service is still an explicit later step. On a headless machine, the same path provides a one-time authenticated dashboard link and an SSH tunnel template instead of exposing reusable Gateway credentials.
 
-On a headless machine, the same path provides a one-time authenticated dashboard link and an SSH tunnel template instead of exposing reusable Gateway credentials. Custom setup, remote Gateway onboarding, and non-interactive setup keep their existing paths when Quick Start is not the right fit.
+Guided setup can once again configure custom and local providers, including endpoints that do not need an API key, and makes the model active only after a real reply succeeds. Imported model settings can be checked before the first agent is named, setup reruns preserve an existing roster and workspace, and failed or cancelled checks leave the previous configuration alone. Before guarded local setup writes, OpenClaw also compares the CLI's selected state and configuration paths with the Gateway's paths, stopping a proven mismatch with both locations and a recovery command while leaving offline setup available when there is no installed service to compare against.
+
+On macOS, AI setup now shows the selected provider and real installation or verification activity instead of turning elapsed time into a percentage. Input controls appear only when an answer is needed, capability consent remains explicit, and cancelled, failed, or replaced attempts stay attached to the correct setup session. Windows onboarding can find eligible npm-installed CLI backends by their ordinary command name through PATHEXT while preserving the neighboring Git Bash launcher, but relative, unresolved, and unsupported wrappers remain rejected, and the separate Claude PATH-shim security concern remains unresolved.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Reach the web dashboard from the recommended Quick Start path ([#134221](https://github.com/openclaw/openclaw/pull/134221)). Thanks @fuller-stack-dev.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Provider Choices and Setup State">
-
-Guided onboarding can once again configure custom and local providers, including endpoints that do not need an API key, and verifies a real response before making the new model active. Failed or cancelled checks leave the previous configuration alone, while setup reruns preserve an existing agent roster and workspace instead of attaching temporary verification work to them.
-
-OpenClaw also compares the CLI's selected state and configuration paths with the local Gateway before guarded setup actions. When a mismatch is proven, it shows both locations and a command that targets the Gateway's store before credentials are written; offline setup remains available when there is no installed service to compare against.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
+- Reach the web dashboard through the foreground Quick Start path ([#134221](https://github.com/openclaw/openclaw/pull/134221)). Thanks @fuller-stack-dev.
 
 **Bug fixes**
 
 - Verify imported model settings without attaching temporary setup state to an existing agent ([#132477](https://github.com/openclaw/openclaw/pull/132477)).
+- Show cancelled macOS AI setup as a clear retryable outcome ([#134654](https://github.com/openclaw/openclaw/pull/134654)).
 - Restore verified custom and local providers in guided onboarding ([#134907](https://github.com/openclaw/openclaw/pull/134907)).
+- Show provider-aware macOS setup activity and keep replies with the current attempt ([#135041](https://github.com/openclaw/openclaw/pull/135041)).
+- Resolve eligible npm-installed Windows CLI backends through PATHEXT while retaining command-safety boundaries ([#135138](https://github.com/openclaw/openclaw/pull/135138)). Thanks @gaoanze888 and @Vasanthdev2004.
 
 **Security and trust**
 
-- Stop proven CLI and Gateway state-directory mismatches before guarded writes ([#134403](https://github.com/openclaw/openclaw/pull/134403)). Thanks @obviyus.
+- Stop proven CLI and Gateway state-path mismatches before guarded writes ([#134403](https://github.com/openclaw/openclaw/pull/134403)). Thanks @obviyus.
+- Keep managed llama.cpp archives and required loader aliases inside the installation tree ([#129035](https://github.com/openclaw/openclaw/pull/129035)). Thanks @pgondhi987.
+
+**Limits and compatibility**
+
+- Native macOS and Windows managed llama.cpp server launch was not directly observed at the final head, and remote or protected Gateways can warn about a state-path mismatch without proving one.
+- Windows bare-command backend discovery does not resolve the separate Claude PATH-shim security concern, and its proof does not cover a complete account-authenticated onboarding session.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Windows Installation and CLI Backends">
+<Accordion title="Installers, packages, state paths, and safe removal">
 
-Windows PowerShell 5.1 installation no longer treats harmless npm or Corepack warnings as command failures, and the portable Git bootstrap can complete without an interactive document-parsing step when Git is not already installed. The warnings remain visible, real nonzero exits still fail, and PowerShell 7 keeps its existing download behavior.
+Windows installation now gets through several failures that looked more final than they were. Windows PowerShell 5.1 no longer treats harmless npm or Corepack warnings as command failures, portable Git can download without an interactive document-parsing step when Git is missing, and a noisy native tar failure can still reach the existing portable Node ZIP fallback. The warnings and command output remain visible, real nonzero exits still fail, and PowerShell 7 keeps its existing download behavior.
 
-Eligible npm-installed CLI backends can also be selected by their ordinary command name during Windows onboarding. OpenClaw now follows the platform's PATHEXT lookup while retaining the neighboring POSIX launcher used by Git Bash, so there is no need to hard-code a `.cmd` path or delete one of npm's shims.
+Packaged installs are steadier too. Built OpenClaw packages and bundled channel entry points can load from pnpm-style installed layouts without doing premature filesystem work, while npm 12 can install or update from local `.tgz` and `.tar.gz` archives when the full path contains no commas. A comma-containing npm 12 path is still unsupported, but it now stops with guidance before package mutation rather than failing partway through.
+
+When a shell install does fail, it keeps the useful terminal details and npm's durable debug log without pointing to a temporary installer log that has already disappeared. [Shell completion](/cli/completion) installation and reinstall preserve literal state-cache paths containing quotes, dollar signs, or backslashes without replacing unrelated profile commands. The existing [`openclaw connect`](/cli/connect) command is easier to find, and its target-file handoff reads only bounded regular files, preserves rejected inputs, and removes a file only after it was consumed successfully.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Let harmless npm and Corepack warnings pass on Windows PowerShell 5.1 ([#134385](https://github.com/openclaw/openclaw/pull/134385)). Thanks @ly85206559.
-- Download portable Git without interactive parsing on Windows PowerShell 5.1 ([#134412](https://github.com/openclaw/openclaw/pull/134412)). Thanks @ly85206559.
-- Resolve npm-installed Windows CLI backends through PATHEXT ([#135138](https://github.com/openclaw/openclaw/pull/135138)). Thanks @gaoanze888, @Vasanthdev2004.
-
-</details>
-
-</Accordion>
-
-<Accordion title="AI Setup on macOS">
-
-The macOS AI setup sheet now shows the selected provider and the actual installation or verification activity instead of presenting an elapsed-time percentage as progress. Input controls appear when the setup needs an answer, capability consent remains explicit, and late responses from an older attempt no longer replace the current setup state.
-
-When someone declines capability review or cancels activation, the app now says that setup was cancelled and offers a clear retry instead of calling it a Gateway failure. Failed or unconfirmed cancellation stays visible, so another connection can be chosen without mistaking the outcome for a completed setup.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Show confirmed macOS setup cancellation as a retryable outcome ([#134654](https://github.com/openclaw/openclaw/pull/134654)).
-- Show real macOS AI setup activity and keep replies attached to the current attempt ([#135041](https://github.com/openclaw/openclaw/pull/135041)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Shell Setup and Connect Handoffs">
-
-When an npm install fails, the shell installer still shows the useful terminal details and npm's durable debug log, but no longer points to a temporary installer log that has already been removed. Shell completion installation and reinstall also preserve literal cache paths containing quotes, dollar signs, or backslashes across Bash, zsh, Fish, and the emitted PowerShell command, without replacing unrelated profile commands.
-
-The existing `openclaw connect` command is easier to find in the CLI reference, and its target-file handoff now accepts bounded regular-file inputs without deleting a rejected, unreadable, or oversized file. Successful regular-file and symlink handoffs retain their single-use behavior, while failed inputs stay available for inspection or recovery.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Remove the missing installer-log breadcrumb while preserving useful diagnostics ([#134655](https://github.com/openclaw/openclaw/pull/134655)). Thanks @mohamedelrefaiy.
-- Preserve rejected Connect target files and bound reads to regular files ([#134957](https://github.com/openclaw/openclaw/pull/134957)). Thanks @xialonglee, @obviyus.
-- Preserve literal completion cache paths across supported shells ([#136241](https://github.com/openclaw/openclaw/pull/136241)). Thanks @steipete.
+- Let Windows PowerShell 5.1 continue past harmless npm or Corepack warnings, download portable Git without interactive parsing, and retain the portable Node ZIP fallback after noisy tar failures ([#134385](https://github.com/openclaw/openclaw/pull/134385), [#134412](https://github.com/openclaw/openclaw/pull/134412), [#135410](https://github.com/openclaw/openclaw/pull/135410)). Thanks @ly85206559.
+- Keep useful npm failure diagnostics without pointing to a deleted temporary installer log ([#134655](https://github.com/openclaw/openclaw/pull/134655)). Thanks @mohamedelrefaiy.
+- Preserve rejected Connect target files and remove only successfully consumed regular files or symlink handoffs ([#134957](https://github.com/openclaw/openclaw/pull/134957)). Thanks @xialonglee and @obviyus.
+- Preserve literal completion cache paths across supported shell hooks ([#136241](https://github.com/openclaw/openclaw/pull/136241)).
+- Load built packages and bundled channel entry points reliably from pnpm-style installed layouts ([#136308](https://github.com/openclaw/openclaw/pull/136308)). Thanks @vincentkoc.
+- Support npm 12 local archive installs and updates when their resolved path contains no comma ([#136316](https://github.com/openclaw/openclaw/pull/136316)).
 
 **Documentation**
 
-- Add the existing Connect command to the CLI index ([#134917](https://github.com/openclaw/openclaw/pull/134917)). Thanks @qingminglong.
+- Add the existing Connect command to the CLI overview and command tree ([#134917](https://github.com/openclaw/openclaw/pull/134917)). Thanks @qingminglong.
 
-</details>
+**Limits and compatibility**
 
-</Accordion>
-
-<Accordion title="Managed llama.cpp Installation">
-
-Managed llama.cpp server installation remains automatic, but downloaded ZIP and TAR archives now pass through the bounded extractor used elsewhere in OpenClaw. Malformed or hostile archives fail without writing outside the installation tree, archive-provided links are skipped, and the required loader aliases are recreated as contained regular files.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Security and trust**
-
-- Keep managed llama.cpp archives and loader aliases inside the installation tree ([#129035](https://github.com/openclaw/openclaw/pull/129035)). Thanks @pgondhi987.
+- Comma-containing npm 12 archive paths remain unsupported, native PowerShell execution of the completion hook was unavailable in the submitted evidence, and the packaged-import evidence does not establish how often the failure affected installations outside release validation.
 
 </details>
 
@@ -141,32 +96,73 @@ Managed llama.cpp server installation remains automatic, but downloaded ZIP and 
 
 ## The New Web UI
 
-The [Control UI](/web/control-ui) now gives visual answers, active work, and long-running conversations more room to behave like one workspace. Diagrams render where they are discussed, starting or returning to a session takes less waiting and repeated work, and the interface does a better job of holding what you sent, your reading position, and the agent or session you were actually looking at.
+The [Control UI](/web/control-ui) now gives the conversation and the workspace around it more room to behave as one place. Diagrams render where they are discussed, a first prompt appears before the new session has finished opening, and the interface holds on to more of what you sent, what the agent already showed you, and where you were reading while live work becomes saved history.
 
 <AccordionGroup>
 
-<Accordion title="Mermaid Diagrams Inside the Conversation">
+<Accordion title="Visual answers and conversations that hold together">
 
-Completed Mermaid fences now render as diagrams directly in chat, with the exact source, copy, expansion, and zoom controls kept beside the result. The diagram follows the active theme and stays in place while the rest of an answer arrives, so a flowchart or sequence diagram can be read without moving it into another tool.
+Completed Mermaid fences now render as diagrams directly in chat, with the exact source, copy, expansion, and zoom controls kept beside the result. The diagram follows the active theme and stays in place while the rest of an answer arrives, while incomplete, invalid, oversized, or externally dependent diagrams remain readable as source instead of being treated as successful renders.
 
-The renderer is lazy-loaded and isolated from the rest of the page, and model-authored output is reduced to passive SVG before display. Incomplete fences remain code, while invalid, oversized, or externally dependent diagrams fall back to readable source with an error instead of being treated as a successful render.
+Starting a conversation feels more immediate too. New Session can prepare a suggested name after you pause on an eligible first prompt, then shows that prompt and its images as soon as you send without waiting for the confirmed session to make the round trip. The suggestion never delays Start, but eligible draft text is sent to the configured utility model before submission, so incognito, short, attachment, command, dictation, and active-composition drafts are deliberately excluded. Chat and New Session also load lighter payloads and do less repeated work on measured paths, though the supplied timings do not establish the same speedup for every browser or Gateway and include small regressions on some warm or cold readiness paths.
+
+Once work is moving, the transcript is less likely to lose its shape. Reconnects and refreshes keep one copy of a completed answer, queued prompts remain above the replies they produced, commentary stays distinct from the final answer, images remain visible while saved history takes ownership of them, and manually taking over the scroll position is less likely to be undone by delayed layout work. Compaction settles into one durable inline marker, attachment and Office-file failures no longer poison later turns through known display blocks, and a failed cloud or paired-device session can be restarted from Chat when a compatible target is available, preserving its identity and last reconciled worktree while sending remains disabled during the transition.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
+- Prepare an eligible new-session name after idle typing without delaying Start ([#133724](https://github.com/openclaw/openclaw/pull/133724)).
 - Render completed Mermaid diagrams with source, copy, expansion, and zoom controls ([#134913](https://github.com/openclaw/openclaw/pull/134913)).
+- Replace compaction's button-like spinner with a calm, accessible folding status ([#135988](https://github.com/openclaw/openclaw/pull/135988)).
+- Copy complete chat-error diagnostics without expanding the details panel first ([#136085](https://github.com/openclaw/openclaw/pull/136085)).
+- Load lighter New Session and Chat payloads and reuse live display preferences across tabs ([#136362](https://github.com/openclaw/openclaw/pull/136362)).
+
+**Bug fixes**
+
+- Show recoverable file-editor load failures instead of a blank retry loop ([#123220](https://github.com/openclaw/openclaw/pull/123220)). Thanks @wanyongstar.
+- Make staged attachments easier to remove by touch in Chat and New Session ([#123893](https://github.com/openclaw/openclaw/pull/123893)).
+- Clear stale working controls after an interrupted run is confirmed in history ([#134457](https://github.com/openclaw/openclaw/pull/134457)). Thanks @RomneyDa.
+- Make long task-progress cards scroll without moving the page or hiding the composer ([#134517](https://github.com/openclaw/openclaw/pull/134517)). Thanks @VACInc, @cpgeek, @nybbs2003.
+- Restore Ask OpenClaw launcher compatibility and preserve the conversation during recovery ([#134776](https://github.com/openclaw/openclaw/pull/134776)).
+- Reconcile live and saved commentary by run and item identity ([#134888](https://github.com/openclaw/openclaw/pull/134888)).
+- Restart an established failed cloud or device session from Chat on a compatible target ([#135024](https://github.com/openclaw/openclaw/pull/135024)). Thanks @jalehman.
+- Insert late dictation once into the current draft after Stop ([#135109](https://github.com/openclaw/openclaw/pull/135109)). Thanks @obviyus, @jadabreu.
+- Retain one clear warning when an exec or Bash failure is the only visible reply ([#135119](https://github.com/openclaw/openclaw/pull/135119)).
+- Keep attachment display cards out of model history and restore Office document sends ([#135185](https://github.com/openclaw/openclaw/pull/135185)). Thanks @gaoanze888, @obviyus, @snls1994, @gordonzhy.
+- Let the next prompt accept input immediately after the current one is sent ([#135345](https://github.com/openclaw/openclaw/pull/135345)). Thanks @Takhoffman.
+- Restore replies and source navigation for attachment-only assistant messages ([#135393](https://github.com/openclaw/openclaw/pull/135393)).
+- Preserve the real terminal timeout reason in the sidebar and clear stale failures after success ([#135466](https://github.com/openclaw/openclaw/pull/135466)).
+- Keep recovered queued prompts above the replies they produced ([#135568](https://github.com/openclaw/openclaw/pull/135568)).
+- Prevent a saved assistant reply from appearing twice during reconnect or history refresh ([#135715](https://github.com/openclaw/openclaw/pull/135715)). Thanks @starship863, @dustin-nowak.
+- Remove queued input without restoring an old draft or showing a false storage error ([#135790](https://github.com/openclaw/openclaw/pull/135790)).
+- Remove the redundant waiting receipt after a chat message is accepted ([#135901](https://github.com/openclaw/openclaw/pull/135901)).
+- Show commentary progress before a plugin finishes validating the final reply ([#135954](https://github.com/openclaw/openclaw/pull/135954)). Thanks @JosephNatsu.
+- Reduce unnecessary startup work on New Session and Chat while keeping saved panels restorable ([#136021](https://github.com/openclaw/openclaw/pull/136021)).
+- Show the first new-session message immediately and restore its contents if creation fails ([#136069](https://github.com/openclaw/openclaw/pull/136069)).
+- Keep sent images visible while saved history takes ownership of the message ([#136072](https://github.com/openclaw/openclaw/pull/136072)).
+- Carry compaction from its live status into one persistent transcript marker ([#136169](https://github.com/openclaw/openclaw/pull/136169)).
+- Show when the Gateway is suspending or suspended in Control UI account footers ([#136220](https://github.com/openclaw/openclaw/pull/136220)).
+- Retain participant names in copied and downloaded conversation exports ([#136439](https://github.com/openclaw/openclaw/pull/136439)).
+- Keep sent image bubbles and captions visually stable on hover ([#136440](https://github.com/openclaw/openclaw/pull/136440)).
+- Keep already-loaded chat images visible through temporary Gateway outages ([#136446](https://github.com/openclaw/openclaw/pull/136446)).
+
+**Security and trust**
+
+- Present optionless credential and free-text questions without misleading choice controls ([#134598](https://github.com/openclaw/openclaw/pull/134598)). Thanks @Patrick-Erichsen, @goslingmanagment.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Starting, Switching, and Repairing Sessions">
+<Accordion title="Navigation, settings, and busy workspaces">
 
-New Session now puts the first prompt and its images on screen as soon as you send them, keeps the draft available if creation fails, and moves into the confirmed conversation without an extra lookup. Chat and New Session also load fewer closed workspace features up front, while larger session lists do less repeated sidebar work when you switch between conversations. Those performance results come from controlled local and synthetic large-roster tests, not a promise that every browser or Gateway will see the same speedup, and the measured warm Chat path included a small composer-readiness regression.
+The rest of the Control UI is easier to understand when a Claw has more than one agent, session, person, or piece of work in motion. Dashboards and background tasks stay with the selected agent, hovercards expose ownership, participants, pull requests, progress, and useful links without disappearing before you can reach them, and the session sidebar does less repeated work when it contains hundreds of retained conversations. Groups remain compact until you expand them, assignment and appearance controls are less scattered, and the Chat, Split, and Dashboard selector stays centered even beside long names and sharing controls.
 
-Returning to existing work is steadier too. Dashboards and background tasks stay with the selected agent, interrupted or timed-out sessions show a more truthful state, failed cloud or device sessions can be restarted from Chat when a compatible target is available, and Ask OpenClaw keeps the conversation and draft visible while its runtime is repaired. Sidebar groups, hovercards, assignment menus, status icons, and keyboard navigation make large or multi-agent workspaces easier to scan without changing the underlying session, permission, or placement boundaries.
+Settings and working surfaces have had the same pass. Narrow dashboards use their available width, long task reviews fill their side panels, Usage filters and historical hour labels behave more predictably, current assets survive stale cache checks, and URL, email, notification, model, appearance, secret, publishing, and policy controls are easier to read or edit. Sharing menus make the current visibility and blocked choices clearer without changing who is allowed to share, while permission, approval, and trusted-proxy messages show the state or requester more accurately without expanding anyone's authority.
+
+There is a long tail of polish here that matters most in a busy workspace, including stable keyboard focus, localized composer and recovery text, reduced-motion loading states, correct animated workspace icons, safer encoded asset paths, and more compact question, Workboard, and session controls. The measured navigation gains come from controlled local or synthetic large-roster tests rather than a universal performance promise, cloud and device recovery still needs a compatible target, and the shorter pin label retains one known accessibility cost because it no longer repeats the session-specific context for assistive technology.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -174,123 +170,81 @@ Returning to existing work is steadier too. Dashboards and background tasks stay
 **Improvements**
 
 - Bring collapse, search, and new-session controls into the agent header ([#134365](https://github.com/openclaw/openclaw/pull/134365)). Thanks @vyctorbrzezowski.
+- Give Side chat one direct clear action and consistent naming ([#134478](https://github.com/openclaw/openclaw/pull/134478)). Thanks @Patrick-Erichsen.
 - Make session ownership, current work, and progress easier to scan in hovercards ([#134636](https://github.com/openclaw/openclaw/pull/134636)). Thanks @Patrick-Erichsen.
+- Replace ambiguous settings loading text with accessible page-shaped placeholders ([#134684](https://github.com/openclaw/openclaw/pull/134684)). Thanks @Patrick-Erichsen.
 - Give session titles and their status icons clearer separation ([#134764](https://github.com/openclaw/openclaw/pull/134764)). Thanks @Patrick-Erichsen.
+- Simplify pull request hovercard statistics while preserving the full PR link ([#134791](https://github.com/openclaw/openclaw/pull/134791)). Thanks @Patrick-Erichsen.
 - Reduce repeated work when switching sessions and loading conversation branches ([#135021](https://github.com/openclaw/openclaw/pull/135021)).
+- Defer Settings-only English text to leave more room in the initial download ([#135131](https://github.com/openclaw/openclaw/pull/135131)).
 - Trim additional sidebar work when switching through large session lists ([#135332](https://github.com/openclaw/openclaw/pull/135332)).
 - Consolidate session assignment and appearance controls into clearer menus ([#135526](https://github.com/openclaw/openclaw/pull/135526)). Thanks @vyctorbrzezowski.
+- Place Theme and Accent color together in Appearance settings ([#135547](https://github.com/openclaw/openclaw/pull/135547)). Thanks @vyctorbrzezowski.
 - Speed up retained-chat switching in measured large-session workflows ([#135574](https://github.com/openclaw/openclaw/pull/135574)).
+- Refresh localized update-disconnect and recovery guidance ([#135669](https://github.com/openclaw/openclaw/pull/135669)).
+- Clarify model-selection scope and the session reset action on wide and narrow screens ([#136160](https://github.com/openclaw/openclaw/pull/136160)).
+- Make every projected participant in a multi-person session hovercard individually reachable ([#136542](https://github.com/openclaw/openclaw/pull/136542)). Thanks @Patrick-Erichsen.
+- Add a compact icon selector for Chat, Split, and Dashboard while retaining accessible names ([#136647](https://github.com/openclaw/openclaw/pull/136647)). Thanks @Patrick-Erichsen.
+- Keep session visibility beside the centered chat view selector ([#136648](https://github.com/openclaw/openclaw/pull/136648)). Thanks @Patrick-Erichsen.
+- Make sharing visibility choices and policy-blocked options easier to distinguish ([#136649](https://github.com/openclaw/openclaw/pull/136649)). Thanks @Patrick-Erichsen.
+- Show stable member-shaped loading rows in the chat sharing menu ([#136650](https://github.com/openclaw/openclaw/pull/136650)). Thanks @Patrick-Erichsen.
+- Refresh recent setup, identity, notification, connection, and session-group translations ([#136659](https://github.com/openclaw/openclaw/pull/136659)).
 
 **Bug fixes**
 
 - Keep compressed archived sessions under their real identities in Usage history ([#131017](https://github.com/openclaw/openclaw/pull/131017)). Thanks @Alix-007, @emes.
+- Make dashboard cards fill narrow screens and preserve their desktop arrangement ([#133814](https://github.com/openclaw/openclaw/pull/133814)). Thanks @MoerAI, @vyctorbrzezowski.
+- Give the chat composer one stable accessible name across changing states ([#133829](https://github.com/openclaw/openclaw/pull/133829)). Thanks @aniruddhaadak80.
+- Keep session permission choices visible and reconcile overlapping updates against Gateway state ([#134413](https://github.com/openclaw/openclaw/pull/134413)). Thanks @vyctorbrzezowski.
 - Match session-group action contrast to the Sessions toolbar ([#134631](https://github.com/openclaw/openclaw/pull/134631)). Thanks @Patrick-Erichsen.
+- Delay incidental microphone-picker motion while keeping keyboard interaction immediate ([#134653](https://github.com/openclaw/openclaw/pull/134653)). Thanks @Patrick-Erichsen.
+- Align settings headings and make automation failures easier to find ([#134659](https://github.com/openclaw/openclaw/pull/134659)). Thanks @Patrick-Erichsen.
+- Remove the repeated Agent picker label and keep the opening menu opaque ([#134680](https://github.com/openclaw/openclaw/pull/134680)). Thanks @Patrick-Erichsen.
 - Keep dashboards and background tasks attached to the selected agent ([#134714](https://github.com/openclaw/openclaw/pull/134714)). Thanks @ctbritt, @MertBasar0.
 - Show pinned sessions with a filled neutral pin ([#134775](https://github.com/openclaw/openclaw/pull/134775)). Thanks @Patrick-Erichsen.
-- Restore Ask OpenClaw launcher compatibility and preserve the conversation during recovery ([#134776](https://github.com/openclaw/openclaw/pull/134776)).
+- Keep long collapsed prompts readable without overlapping text ([#134833](https://github.com/openclaw/openclaw/pull/134833)).
 - Keep quickly reopened menus dismissible and restore focus correctly ([#135006](https://github.com/openclaw/openclaw/pull/135006)). Thanks @vyctorbrzezowski.
 - Remove the duplicate Ask OpenClaw shortcut from Inbox while retaining its other entry points ([#135008](https://github.com/openclaw/openclaw/pull/135008)).
-- Restart an established failed cloud or device session from Chat on a compatible target ([#135024](https://github.com/openclaw/openclaw/pull/135024)). Thanks @jalehman.
-- Preserve the real terminal timeout reason in the sidebar and clear stale failures after success ([#135466](https://github.com/openclaw/openclaw/pull/135466)). Thanks @steipete.
+- Keep Usage peak-error hour labels correct through daylight-saving changes ([#135153](https://github.com/openclaw/openclaw/pull/135153)).
 - Hide the unusable Rewind action while an agent is working ([#135521](https://github.com/openclaw/openclaw/pull/135521)). Thanks @Patrick-Erichsen.
 - Keep long sidebar group titles on one readable marquee line ([#135523](https://github.com/openclaw/openclaw/pull/135523)). Thanks @Patrick-Erichsen.
 - Tighten Recent Chats alignment, spacing, and hover feedback ([#135524](https://github.com/openclaw/openclaw/pull/135524)). Thanks @Patrick-Erichsen.
+- Keep sidebar and transcript fades from covering visible scrollbars ([#135564](https://github.com/openclaw/openclaw/pull/135564)). Thanks @vyctorbrzezowski.
+- Return current Control UI assets when a cached entity tag is stale ([#135619](https://github.com/openclaw/openclaw/pull/135619)).
 - Return keyboard focus to the visible menu after switching submenus ([#135629](https://github.com/openclaw/openclaw/pull/135629)).
 - Use device-specific wording while paired-device sessions start ([#135681](https://github.com/openclaw/openclaw/pull/135681)).
-- Reduce unnecessary startup work on New Session and Chat while keeping saved panels restorable ([#136021](https://github.com/openclaw/openclaw/pull/136021)). Thanks @steipete.
-- Keep large catalog groups compact with independent Show more controls ([#136040](https://github.com/openclaw/openclaw/pull/136040)). Thanks @fuller-stack-dev.
-- Show the first new-session message immediately and restore its contents if creation fails ([#136069](https://github.com/openclaw/openclaw/pull/136069)).
-
-**Security and trust**
-
-- Show inherited Full Access as active as soon as a session opens ([#134732](https://github.com/openclaw/openclaw/pull/134732)). Thanks @Patrick-Erichsen.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Conversation Order and Reading Position">
-
-The chat transcript now holds together more consistently as live events become saved history. Reconnects and refreshes keep one copy of a completed answer, queued prompts stay above the replies they produced, commentary remains distinct from the final answer, and manually taking over the scroll position is less likely to be undone by delayed layout work. Compaction now appears as one calm inline marker that settles into a durable completed state instead of splitting itself across temporary and saved notices.
-
-The composer is less fragile around the edges of an active turn. You can begin the next prompt immediately after sending, remove queued input without a false storage warning, keep late dictation after pressing Stop, and reply to attachment-only messages with a useful reference. Sent images remain visible while history takes ownership of them, Office attachment failures no longer wedge later turns through known display blocks, and silent command failures or plugin-delayed final replies still leave timely, visible progress or warning text.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Replace compaction's button-like spinner with a calm, accessible folding status ([#135988](https://github.com/openclaw/openclaw/pull/135988)). Thanks @steipete.
-
-**Bug fixes**
-
-- Make staged attachments easier to remove by touch in Chat and New Session ([#123893](https://github.com/openclaw/openclaw/pull/123893)).
-- Clear stale working controls after an interrupted run is confirmed in history ([#134457](https://github.com/openclaw/openclaw/pull/134457)). Thanks @RomneyDa.
-- Keep long collapsed prompts readable without overlapping text ([#134833](https://github.com/openclaw/openclaw/pull/134833)). Thanks @steipete.
-- Reconcile live and saved commentary by run and item identity ([#134888](https://github.com/openclaw/openclaw/pull/134888)).
-- Insert late dictation once into the current draft after Stop ([#135109](https://github.com/openclaw/openclaw/pull/135109)). Thanks @obviyus, @jadabreu.
-- Retain one clear warning when an exec or Bash failure is the only visible reply ([#135119](https://github.com/openclaw/openclaw/pull/135119)).
-- Keep attachment display cards out of model history and restore Office document sends ([#135185](https://github.com/openclaw/openclaw/pull/135185)). Thanks @gaoanze888, @obviyus, @snls1994, @gordonzhy.
-- Let the next prompt accept input immediately after the current one is sent ([#135345](https://github.com/openclaw/openclaw/pull/135345)). Thanks @Takhoffman.
-- Restore replies and source navigation for attachment-only assistant messages ([#135393](https://github.com/openclaw/openclaw/pull/135393)).
-- Keep recovered queued prompts above the replies they produced ([#135568](https://github.com/openclaw/openclaw/pull/135568)).
-- Prevent a saved assistant reply from appearing twice during reconnect or history refresh ([#135715](https://github.com/openclaw/openclaw/pull/135715)). Thanks @starship863, @dustin-nowak.
+- Keep Inbox alerts out of Settings as navigation changes ([#135722](https://github.com/openclaw/openclaw/pull/135722)). Thanks @vyctorbrzezowski.
 - Respect manual transcript scrolling during delayed row measurement ([#135738](https://github.com/openclaw/openclaw/pull/135738)).
-- Remove queued input without restoring an old draft or showing a false storage error ([#135790](https://github.com/openclaw/openclaw/pull/135790)).
-- Remove the redundant waiting receipt after a chat message is accepted ([#135901](https://github.com/openclaw/openclaw/pull/135901)).
+- Keep blank MCP environment and header fields editable while masking stored secrets ([#135798](https://github.com/openclaw/openclaw/pull/135798)). Thanks @SunnyShu0925, @markhaines.
+- Let long task reviews fill docked and expanded side panels ([#135926](https://github.com/openclaw/openclaw/pull/135926)). Thanks @obviyus, @asgeirtj.
 - Restore compact token-count labels without changing the underlying totals ([#135951](https://github.com/openclaw/openclaw/pull/135951)).
-- Show commentary progress before a plugin finishes validating the final reply ([#135954](https://github.com/openclaw/openclaw/pull/135954)). Thanks @JosephNatsu.
-- Keep sent images visible while saved history takes ownership of the message ([#136072](https://github.com/openclaw/openclaw/pull/136072)). Thanks @steipete.
-- Carry compaction from its live status into one persistent transcript marker ([#136169](https://github.com/openclaw/openclaw/pull/136169)).
+- Make publishing-account controls compact while keeping the selected identity reachable ([#136002](https://github.com/openclaw/openclaw/pull/136002)).
+- Add localized composer accessibility labels across supported non-English locales ([#136006](https://github.com/openclaw/openclaw/pull/136006)).
+- Keep large catalog groups compact with independent Show more controls ([#136040](https://github.com/openclaw/openclaw/pull/136040)). Thanks @fuller-stack-dev.
+- Remove the bright static shimmer band when reduced motion is enabled ([#136153](https://github.com/openclaw/openclaw/pull/136153)).
+- Display APNG workspace icons and channel avatars through the shared safe-image policy ([#136417](https://github.com/openclaw/openclaw/pull/136417)).
+- Load encoded and contained symlinked Control UI assets correctly ([#136444](https://github.com/openclaw/openclaw/pull/136444)).
+- Let Escape close the visible session popover after keyboard session switching ([#136445](https://github.com/openclaw/openclaw/pull/136445)).
+- Give session pull-request links clear hover and keyboard-focus feedback ([#136527](https://github.com/openclaw/openclaw/pull/136527)). Thanks @Patrick-Erichsen.
+- Clear equivalent mixed-case or quoted Usage filters from their menus ([#136569](https://github.com/openclaw/openclaw/pull/136569)).
+- Keep loaded chat images mounted through ordinary media rerenders ([#136597](https://github.com/openclaw/openclaw/pull/136597)).
+- Give notification preferences themed controls and accessible names ([#136602](https://github.com/openclaw/openclaw/pull/136602)).
+- Keep URL- and email-formatted settings editable in Form mode ([#136603](https://github.com/openclaw/openclaw/pull/136603)).
+- Keep question sessions compact while preserving their waiting status accessibly ([#136606](https://github.com/openclaw/openclaw/pull/136606)). Thanks @Patrick-Erichsen.
+- Remove the unwanted dark fade above task-progress cards ([#136607](https://github.com/openclaw/openclaw/pull/136607)). Thanks @Patrick-Erichsen.
+- Align model-provider refresh status and controls without mobile overflow ([#136609](https://github.com/openclaw/openclaw/pull/136609)). Thanks @Patrick-Erichsen.
+- Remove unnecessary ellipses from session-group menu actions ([#136614](https://github.com/openclaw/openclaw/pull/136614)). Thanks @Patrick-Erichsen.
+- Recover Workboard task links after a saved cursor is rejected ([#136619](https://github.com/openclaw/openclaw/pull/136619)). Thanks @shakkernerd.
+- Make the board Remove action visually consistent with its menu ([#136637](https://github.com/openclaw/openclaw/pull/136637)). Thanks @Patrick-Erichsen.
+- Keep the Chat, Split, and Dashboard selector centered beside long names ([#136646](https://github.com/openclaw/openclaw/pull/136646)). Thanks @Patrick-Erichsen.
+- Show the current user's profile picture in Assign to Me when available ([#136668](https://github.com/openclaw/openclaw/pull/136668)). Thanks @Patrick-Erichsen.
 
 **Security and trust**
 
 - Explain denied WebChat resets without weakening the required administrator permission ([#134696](https://github.com/openclaw/openclaw/pull/134696)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Everyday Workspace Polish">
-
-The surfaces around the conversation have had the same attention. Dashboards fill narrow screens, long task progress and Review content use the space available to them, settings show useful loading shapes, and the model picker, agent picker, Side chat, Appearance, Usage, publication controls, and pull request previews are easier to scan. Keyboard menus recover cleanly, scrollbars remain visible beside fades, stale assets are less likely to survive a cache check, and smaller initial Settings data leaves more startup headroom without claiming a measured end-user latency gain.
-
-Accessibility and authority state are clearer in several places, including a stable localized name for the composer, reduced-motion loading indicators, properly displayed wildcard tool policies, named approval requesters, optionless credential prompts, and specific recovery guidance for trusted-proxy sign-in failures. One regression remains in the sidebar. Shorter pin and unpin tooltips also became the icon buttons' accessible names, so assistive-technology users can lose the session-specific context that used to be repeated there.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Give Side chat one direct clear action and consistent naming ([#134478](https://github.com/openclaw/openclaw/pull/134478)). Thanks @Patrick-Erichsen.
-- Replace ambiguous settings loading text with accessible page-shaped placeholders ([#134684](https://github.com/openclaw/openclaw/pull/134684)). Thanks @Patrick-Erichsen.
-- Defer Settings-only English text to leave more room in the initial download ([#135131](https://github.com/openclaw/openclaw/pull/135131)). Thanks @steipete.
-- Place Theme and Accent color together in Appearance settings ([#135547](https://github.com/openclaw/openclaw/pull/135547)). Thanks @vyctorbrzezowski.
-- Clarify model-selection scope and the session reset action on wide and narrow screens ([#136160](https://github.com/openclaw/openclaw/pull/136160)).
-
-**Bug fixes**
-
-- Show recoverable file-editor load failures instead of a blank retry loop ([#123220](https://github.com/openclaw/openclaw/pull/123220)). Thanks @wanyongstar.
-- Make dashboard cards fill narrow screens and preserve their desktop arrangement ([#133814](https://github.com/openclaw/openclaw/pull/133814)). Thanks @MoerAI, @vyctorbrzezowski.
-- Give the chat composer one stable accessible name across changing states ([#133829](https://github.com/openclaw/openclaw/pull/133829)). Thanks @aniruddhaadak80.
-- Make long task-progress cards scroll without moving the page or hiding the composer ([#134517](https://github.com/openclaw/openclaw/pull/134517)). Thanks @VACInc, @cpgeek, @nybbs2003.
-- Delay incidental microphone-picker motion while keeping keyboard interaction immediate ([#134653](https://github.com/openclaw/openclaw/pull/134653)). Thanks @Patrick-Erichsen.
-- Align settings headings and make automation failures easier to find ([#134659](https://github.com/openclaw/openclaw/pull/134659)). Thanks @Patrick-Erichsen.
-- Remove the repeated Agent picker label and keep the opening menu opaque ([#134680](https://github.com/openclaw/openclaw/pull/134680)). Thanks @Patrick-Erichsen.
-- Simplify pull request hovercard statistics while preserving the full PR link ([#134791](https://github.com/openclaw/openclaw/pull/134791)). Thanks @Patrick-Erichsen.
-- Keep Usage peak-error hour labels correct through daylight-saving changes ([#135153](https://github.com/openclaw/openclaw/pull/135153)).
-- Keep sidebar and transcript fades from covering visible scrollbars ([#135564](https://github.com/openclaw/openclaw/pull/135564)). Thanks @vyctorbrzezowski.
-- Return current Control UI assets when a cached entity tag is stale ([#135619](https://github.com/openclaw/openclaw/pull/135619)).
-- Let long task reviews fill docked and expanded side panels ([#135926](https://github.com/openclaw/openclaw/pull/135926)). Thanks @obviyus, @asgeirtj.
-- Make publishing-account controls compact while keeping the selected identity reachable ([#136002](https://github.com/openclaw/openclaw/pull/136002)).
-- Add localized composer accessibility labels across supported non-English locales ([#136006](https://github.com/openclaw/openclaw/pull/136006)).
-- Remove the bright static shimmer band when reduced motion is enabled ([#136153](https://github.com/openclaw/openclaw/pull/136153)).
-
-**Security and trust**
-
-- Present optionless credential and free-text questions without misleading choice controls ([#134598](https://github.com/openclaw/openclaw/pull/134598)). Thanks @Patrick-Erichsen, @goslingmanagment.
+- Show inherited Full Access as active as soon as a session opens ([#134732](https://github.com/openclaw/openclaw/pull/134732)). Thanks @Patrick-Erichsen.
 - Give trusted-proxy login failures specific, redacted recovery guidance ([#135584](https://github.com/openclaw/openclaw/pull/135584)).
-- Display wildcard tool policies accurately without changing policy enforcement ([#135786](https://github.com/openclaw/openclaw/pull/135786)). Thanks @steipete.
+- Display wildcard tool policies accurately without changing policy enforcement ([#135786](https://github.com/openclaw/openclaw/pull/135786)).
 - Name the requesting session on projected approval cards without changing approval authority ([#136091](https://github.com/openclaw/openclaw/pull/136091)).
 
 **Limits and compatibility**
@@ -305,138 +259,122 @@ Accessibility and authority state are clearer in several places, including a sta
 
 ## Updates and Maintenance
 
-[Updates](/install/updating) now make a clearer distinction between work OpenClaw can finish safely and work that needs your attention first. The updater protects more of the setup already on the machine, hands service-owned restarts to a process that can survive them, and leaves recoverable failures with enough context for Doctor or a configured coding agent to take over the investigation.
+[Updates](/install/updating) now make a clearer distinction between work OpenClaw can finish safely and work that needs your attention first. The updater preserves more of the setup already on the machine, hands service-owned restarts to a process that can survive them, and leaves recoverable failures with enough context for [Doctor](/cli/doctor) or a configured coding agent to take over the investigation.
 
 <AccordionGroup>
 
-<Accordion title="Update Readiness and Restart Handoffs">
+<Accordion title="Update gates, rollback, and plugin readiness">
 
-Before OpenClaw restarts, it now checks the parts of your installation that actually need to be ready for the new version. Missing local-memory setup, unresolved plugin consent, or incomplete approval migration stops the update with a specific repair path, while a migration warning that does not make required state unsafe can leave the Gateway reachable in a clearly degraded state so you can run Doctor instead of watching a supervisor restart it forever.
+Before OpenClaw restarts, it now checks the parts of your installation that actually need to be ready for the new version. Missing local-memory setup or unresolved plugin consent stops the update with a specific repair path, plugin version drift is surfaced before restart, and a migration warning that does not make required state unsafe can leave the Gateway reachable in a clearly degraded state so you can run Doctor instead of watching a supervisor restart it forever. A blocked readiness or consent check deliberately leaves the Gateway stopped, and `--yes` does not approve a plugin's new capabilities for you.
 
-Updates started by an agent on a managed Linux or macOS Gateway can hand the work to a detached helper before the service stops, and Windows agent-initiated restarts use the Gateway-owned restart path rather than dying with the old process tree. That handoff confirms the update was accepted, not that it finished, and npm 12 local archives still need a comma-free path.
+Agent-started updates on managed Linux and macOS Gateways can hand the work to a detached helper before the service stops, while a global npm candidate rejected by Doctor now restores the prior package and launchers for inspection. The initial agent response confirms that the handoff was accepted, not that the update finished. Rollback does not undo persistent state Doctor may already have changed, does not cover pnpm or Bun, and keeps the managed Gateway stopped rather than guessing that a restart is safe.
+
+When an interactive update gets far enough to fail operationally, OpenClaw can carry a bounded, sanitized record of that attempt into its existing triage flow instead of making you reconstruct the failure from scratch. The CLI can offer a configured Claude Code, Codex, OpenCode, or Pi session after updater cleanup, and the Control UI can open Ask OpenClaw with the recorded cause. That investigation cannot retry the update, repair state, or restart the Gateway on its own, and unattended runs retain the original failure while printing the next commands for an operator.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Leaner installations without unused Sharp and ONNX dependency chains, with Chromium or Chrome now required for meme PNG output ([#134923](https://github.com/openclaw/openclaw/pull/134923)).
+- Eligible update failures can open bounded diagnostics in the CLI or Ask OpenClaw without granting repair or restart authority ([#134865](https://github.com/openclaw/openclaw/pull/134865)).
 
 **Bug fixes**
 
-- Windows agent-initiated Gateway restarts survive the old process tree ([#134549](https://github.com/openclaw/openclaw/pull/134549)). Thanks @nerclid, @w1130150306.
-- Updates stop before restarting when a selected plugin readiness check fails ([#134699](https://github.com/openclaw/openclaw/pull/134699)). Thanks @Patrick-Erichsen, @vyctorbrzezowski.
-- Blank backup intervals fail instead of silently creating a 24-hour schedule ([#134799](https://github.com/openclaw/openclaw/pull/134799)). Thanks @marmar9615-cloud.
-- Update readiness loads only the Doctor integrations needed for the selected checks ([#135161](https://github.com/openclaw/openclaw/pull/135161)).
-- Blank Gateway suspension waits fail before a lease is acquired ([#135270](https://github.com/openclaw/openclaw/pull/135270)). Thanks @qingminglong.
-- Agent-launched updates move to the managed helper before stopping the Gateway ([#135701](https://github.com/openclaw/openclaw/pull/135701)). Thanks @steipete.
-- Nonfatal migration warnings allow a visible degraded startup with Doctor guidance ([#135713](https://github.com/openclaw/openclaw/pull/135713)). Thanks @Zak-Finance.
-- npm 12 accepts comma-free local release archives through installer and updater paths ([`bdf508b8ad`](https://github.com/openclaw/openclaw/commit/bdf508b8ad7e02b06f4e944c29ef835ced2bef22)). Thanks @steipete.
+- Failed updates preserve covered configuration and plugin intent and can hand investigation to an installed coding agent after cleanup ([#134490](https://github.com/openclaw/openclaw/pull/134490)). Thanks @fuller-stack-dev.
+- Doctor compares active official plugins with the managed service package that will load after restart ([#134663](https://github.com/openclaw/openclaw/pull/134663)). Thanks @jalehman, @r0ckvn, @Finn763, @yubingjiaocn.
+- Updates stop before restarting when an owner-declared plugin readiness check fails ([#134699](https://github.com/openclaw/openclaw/pull/134699)). Thanks @Patrick-Erichsen, @vyctorbrzezowski.
+- Post-upgrade Doctor reports enabled official plugins that remain on an older OpenClaw release ([#134719](https://github.com/openclaw/openclaw/pull/134719)). Thanks @Lendersmark, @oshunter.
+- Update readiness loads only the Doctor integrations required for the selected checks ([#135161](https://github.com/openclaw/openclaw/pull/135161)).
+- Managed Tailscale Serve or Funnel can adopt an exact predecessor root route after an upgrade while leaving external and shared routes alone; stale-host rename recovery remains manual, and the predecessor is not restored if a new claim fails ([#135394](https://github.com/openclaw/openclaw/pull/135394)). Thanks @jjjhenriksen, @Lendersmark.
+- A rejected global npm update restores the prior package and launchers and keeps the managed Gateway stopped for inspection ([#135462](https://github.com/openclaw/openclaw/pull/135462)). Thanks @fuller-stack-dev.
+- Agent-launched updates move to a detached managed helper before stopping Linux or macOS Gateways ([#135701](https://github.com/openclaw/openclaw/pull/135701)).
+- Nonfatal migration warnings allow a visible degraded startup with Doctor guidance while unsafe state still blocks startup ([#135713](https://github.com/openclaw/openclaw/pull/135713)). Thanks @Zak-Finance.
+- Upgrade and install repair preserves refreshed credentials, legacy cron intent, rollback state, and memory-provider activation ([#135736](https://github.com/openclaw/openclaw/pull/135736)).
+- Doctor and update repair preserve valid external companion plugins and recover missing payloads without hiding the underlying error ([#135791](https://github.com/openclaw/openclaw/pull/135791)). Thanks @hannesrudolph, @weirdo-world, @xiaomijituan.
+- Linux systemd diagnostics include the supported Tailscale operator-grant command when noninteractive sudo is unavailable ([#135825](https://github.com/openclaw/openclaw/pull/135825)). Thanks @pengzh1, @obviyus, @ezimerman.
+- Doctor recognizes valid path-installed Codex app bundles instead of recommending that they be reinstalled ([#135828](https://github.com/openclaw/openclaw/pull/135828)). Thanks @griswomw2, @obviyus.
+- Plugin repair follows the package root that owns a missing-entry diagnostic instead of replacing a healthy same-ID install ([#135834](https://github.com/openclaw/openclaw/pull/135834)).
+- Built source checkouts reuse compiled plugin artifacts during cold Doctor validation while respecting explicit source paths and overlays ([#136399](https://github.com/openclaw/openclaw/pull/136399)).
+- Let service-less Linux updates proceed only after proving there is no service definition, manager state, active Gateway lock, or listener, while unknown state still blocks and the 2026.8.2 `--no-restart` workaround remains limited to a confirmed stopped Gateway ([`f78a574`](https://github.com/openclaw/openclaw/commit/f78a5746dd4b7b520323e4338d5a1f8ca832f931)).
 
 **Security and trust**
 
-- Incomplete exec-approval repairs keep the Gateway stopped and return failure ([#135454](https://github.com/openclaw/openclaw/pull/135454)). Thanks @steipete.
-- Unresolved plugin consent blocks update finalization before bindings change or the Gateway restarts ([#135460](https://github.com/openclaw/openclaw/pull/135460)). Thanks @steipete, @hannesrudolph, @xiaomijituan, @weirdo-world.
+- Missing-record npm plugin recovery verifies registry provenance and capability consent before publishing a trusted install record ([#135451](https://github.com/openclaw/openclaw/pull/135451)).
+- Unresolved plugin capability consent blocks update finalization before bindings change or the Gateway restarts ([#135460](https://github.com/openclaw/openclaw/pull/135460)). Thanks @hannesrudolph, @xiaomijituan, @weirdo-world.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Settings and State Through Updates">
+<Accordion title="Doctor, migration, backup, and service recovery">
 
-An update or Doctor repair now does more to preserve the setup you already authored, including configuration includes and environment expressions, agent rosters and workspaces, plugin payloads and policy, credentials, scheduled work, device pairings, and session history. When old and new state disagree, repairs either prove the change is safe or stop before writing, and concurrent Gateway work no longer gets silently replaced by an older Doctor snapshot.
+Doctor can now resolve more of the old state that used to leave an installation stuck between versions, including empty legacy roots and approval stubs, stale workspace setup files, malformed scheduled jobs, incomplete Skill Workshop proposals, and narrowly safe database, roster, credential, channel-ownership, and workspace migrations. Repair stays deliberately conservative. Conflicting or populated state remains available for recovery, invalid cron jobs go to quarantine with their identity and reason, and successful repairs are designed to stay clean on the next pass.
 
-The same rule reaches the edges of maintenance. Interactive uninstall keeps local state and workspaces unless you explicitly select them, Windows snapshots work in mixed PowerShell installations, workspace exclusions are applied before backup traversal, and plugin recovery publishes a trusted install record only after it has verified what it is installing.
+The same care now reaches backups and removal. Verified backups retain the exact active configuration even when its path resembles generated data, workspace exclusions are applied before traversal, and ACPX scratch symlinks no longer make an otherwise portable archive fail. Interactive uninstall keeps local state, configuration, and workspaces unless you explicitly select them, while Windows snapshots work in mixed PowerShell installations.
 
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Windows snapshots work when PowerShell 7 is installed alongside Windows PowerShell ([#121618](https://github.com/openclaw/openclaw/pull/121618)). Thanks @fr-meyer.
-- Doctor preserves newer cron definitions, runtime state, and authorization during concurrent repairs ([#127999](https://github.com/openclaw/openclaw/pull/127999)). Thanks @yetval.
-- Valid device pairings survive contaminated legacy records during migration ([#134483](https://github.com/openclaw/openclaw/pull/134483)). Thanks @qdivan, @obviyus, @samson1357924.
-- Identical legacy session events no longer block transcript migration ([#134568](https://github.com/openclaw/openclaw/pull/134568)). Thanks @shakkernerd.
-- Doctor retains recognized official plugin settings written before installation ([#134717](https://github.com/openclaw/openclaw/pull/134717)). Thanks @obviyus, @abacha.
-- Explicit multi-agent roster repairs preserve supported per-agent settings ([#134758](https://github.com/openclaw/openclaw/pull/134758)). Thanks @Lendersmark, @vdruts.
-- Valid per-agent authentication overrides no longer look like unfinished shared-auth migration ([#134808](https://github.com/openclaw/openclaw/pull/134808)). Thanks @fuller-stack-dev.
-- Legacy agent-list upgrades keep the first agent on its established workspace ([#134892](https://github.com/openclaw/openclaw/pull/134892)). Thanks @Lendersmark.
-- Interrupted shared-credential migrations can restore verified archived credentials ([#134952](https://github.com/openclaw/openclaw/pull/134952)). Thanks @steipete, @erameson.
-- Redundant legacy credential subsets can converge without deleting the richer shared store ([#135096](https://github.com/openclaw/openclaw/pull/135096)). Thanks @jodok, @felixboenkost-droid.
-- Historical completed migrations can recover credentials when the archive and missing migrated credentials are verified ([#135346](https://github.com/openclaw/openclaw/pull/135346)). Thanks @steipete, @erameson.
-- Doctor preserves authored includes, environment expressions, and identifiable legacy agents ([#135671](https://github.com/openclaw/openclaw/pull/135671)). Thanks @fuller-stack-dev.
-- Update and installation rollback preserves current credentials, cron behavior, and owned plugin or hook state ([#135736](https://github.com/openclaw/openclaw/pull/135736)).
-- External companion plugin payloads survive Doctor and bundled-to-external update repair ([#135791](https://github.com/openclaw/openclaw/pull/135791)). Thanks @hannesrudolph, @weirdo-world, @xiaomijituan.
-- Backup workspace exclusions are applied before traversal while included absolute links remain protected ([#135830](https://github.com/openclaw/openclaw/pull/135830)). Thanks @obviyus, @jarvismazz, @yubingjiaocn, @ericcaiwx-star, @ruel225.
-- Plugin repair diagnostics follow the recorded install root instead of a broken same-ID source copy ([#135834](https://github.com/openclaw/openclaw/pull/135834)).
-
-**Security and trust**
-
-- Interactive uninstall defaults preserve local state, configuration, and workspaces ([#134299](https://github.com/openclaw/openclaw/pull/134299)). Thanks @PollyBot13, @kodi.
-- Missing-record npm plugin recovery verifies registry provenance before publishing trust ([#135451](https://github.com/openclaw/openclaw/pull/135451)). Thanks @steipete.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Doctor Repairs for Older State">
-
-Doctor can now resolve more of the old state that used to leave an installation stuck between versions, including empty legacy roots and approval stubs, stale workspace setup files, malformed scheduled jobs, incomplete Skill Workshop proposals, and narrowly safe database, roster, and workspace migrations. Repair stays deliberately conservative. Conflicting or populated state remains available for recovery, invalid cron jobs go to quarantine with their identity and reason, and successful repairs are designed to stay clean on the next pass.
-
-When Doctor cannot finish automatically, its diagnostics now point more directly at the thing that needs attention, including retained workspace files, plugin version drift, shared credential health, managed Tailscale ownership, and externally configured paths that a copied-state rehearsal can still reach. Long database maintenance keeps its lease while it works, and managed Tailscale upgrades can reclaim only the ordinary exclusive route that still points to the configured local Gateway.
+When Doctor cannot finish automatically, its diagnostics point more directly at the thing that needs attention, including retained custom databases and workspace files, pending device-auth migration, shared credential health, unowned channel routes, and copied state that still reaches an explicitly configured external path. Ambiguous ownership, populated legacy approval data, conflicting credentials, and unsafe workspace state still fail closed rather than being guessed through. Several Windows, SSH, Tailscale, and external-plugin paths have narrower live proof, and the source-build state-check fix covers complete module pairs and environment-only declarations rather than incomplete optional module pairs.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Repeated Doctor bootstrap-size warnings reuse their number-formatting work without changing thresholds or advice ([#136500](https://github.com/openclaw/openclaw/pull/136500)).
+- Installations drop unused Sharp and Transformers or ONNX dependency chains while preserving WhatsApp media fallback and LanceDB vector search; meme PNG output now requires Playwright Chromium or system Google Chrome ([#134923](https://github.com/openclaw/openclaw/pull/134923)).
 
 **Bug fixes**
 
 - Empty legacy state roots converge on the active OpenClaw state without replacing populated state ([#114678](https://github.com/openclaw/openclaw/pull/114678)). Thanks @harjothkhara, @obviyus, @xiaodongEdtech.
+- Doctor refuses stale cron repairs that would overwrite newer jobs, runtime state, or authorization ([#127999](https://github.com/openclaw/openclaw/pull/127999)). Thanks @yetval.
 - Gateway startup under load exposes health earlier and improves scoped recovery behavior ([#132186](https://github.com/openclaw/openclaw/pull/132186)). Thanks @galiniliev.
 - Incomplete Skill Workshop proposal migrations preserve recoverable files and converge on later Doctor runs ([#132917](https://github.com/openclaw/openclaw/pull/132917)). Thanks @xydt-juyaohui, @obviyus, @lakemike.
-- Schema-17 session repair now rolls back the whole attempt when migration is rejected ([#134272](https://github.com/openclaw/openclaw/pull/134272)). Thanks @RileyJJY, @obviyus, @abacha.
+- Doctor reports retained legacy device-auth state with a profile-aware repair command ([#133978](https://github.com/openclaw/openclaw/pull/133978)). Thanks @yetval.
+- Schema-17 session repair rolls back the whole attempt when a later migration check rejects the database ([#134272](https://github.com/openclaw/openclaw/pull/134272)). Thanks @RileyJJY, @obviyus, @abacha.
+- Doctor continues channel-security audits through unowned routes and repairs an exact account binding only when ownership is unambiguous ([#136463](https://github.com/openclaw/openclaw/pull/136463)). Thanks @ctbritt, @JunfXiao, @oshunter, @WoodyKim554.
+- Windows Doctor and service checks no longer depend on display language, and unsafe retained-workspace switches are rejected before activation ([#136578](https://github.com/openclaw/openclaw/pull/136578)). Thanks @Aivexa, @DasX, @LiuwqGit, @hermannmetzker-ai.
+- Verified full and config-only backups retain the exact active configuration through volatile-path filtering; absolute configuration symlinks remain outside this repair ([#136666](https://github.com/openclaw/openclaw/pull/136666)).
+- Valid device pairings survive contaminated legacy records during migration ([#134483](https://github.com/openclaw/openclaw/pull/134483)). Thanks @qdivan, @obviyus, @samson1357924.
+- Windows agent-initiated Gateway restarts survive the old process tree ([#134549](https://github.com/openclaw/openclaw/pull/134549)). Thanks @nerclid, @w1130150306.
+- Identical legacy session events no longer block transcript migration while genuinely conflicting records remain recoverable ([#134568](https://github.com/openclaw/openclaw/pull/134568)). Thanks @shakkernerd.
 - Doctor safely clears empty reserved workspace attestations that block agent turns ([#134641](https://github.com/openclaw/openclaw/pull/134641)). Thanks @leilei3167, @obviyus, @rosssaunders, @courtneyr-dev, @guarismo.
-- MCP lint finishes against private state when live SQLite state is busy ([#134698](https://github.com/openclaw/openclaw/pull/134698)). Thanks @obviyus, @pfrederiksen.
+- MCP lint finishes against busy live state and avoids duplicate false failures ([#134698](https://github.com/openclaw/openclaw/pull/134698)). Thanks @obviyus, @pfrederiksen.
 - Malformed legacy cron jobs are quarantined so valid jobs and Gateway startup can continue ([#134704](https://github.com/openclaw/openclaw/pull/134704)). Thanks @obviyus, @Nielsh82.
 - Doctor repairs markerless keyed and legacy multi-agent rosters without changing routing choices ([#134706](https://github.com/openclaw/openclaw/pull/134706)). Thanks @Lendersmark.
-- Post-upgrade Doctor reports official plugin version drift with an actionable update command ([#134719](https://github.com/openclaw/openclaw/pull/134719)). Thanks @Lendersmark, @oshunter.
-- Blocked workspace cleanup warnings name the retained legacy file ([#134751](https://github.com/openclaw/openclaw/pull/134751)). Thanks @rosssaunders.
-- Healthy legacy heartbeat artifacts no longer produce false transcript corruption warnings ([#134765](https://github.com/openclaw/openclaw/pull/134765)). Thanks @obviyus, @LiuwqGit, @sblindt, @ayaangazali.
+- Doctor retains recognized official plugin settings written before installation ([#134717](https://github.com/openclaw/openclaw/pull/134717)). Thanks @obviyus, @abacha.
+- Blocked workspace cleanup warnings name the exact retained legacy file ([#134751](https://github.com/openclaw/openclaw/pull/134751)). Thanks @rosssaunders.
+- Explicit multi-agent roster repairs preserve supported per-agent settings ([#134758](https://github.com/openclaw/openclaw/pull/134758)). Thanks @Lendersmark, @vdruts.
+- Healthy legacy heartbeat and cron artifacts no longer produce false transcript corruption warnings ([#134765](https://github.com/openclaw/openclaw/pull/134765)). Thanks @obviyus, @LiuwqGit, @sblindt, @ayaangazali.
+- Blank backup intervals fail instead of silently creating a 24-hour schedule ([#134799](https://github.com/openclaw/openclaw/pull/134799)). Thanks @marmar9615-cloud.
+- Valid per-agent authentication overrides no longer look like unfinished shared-auth migration ([#134808](https://github.com/openclaw/openclaw/pull/134808)). Thanks @fuller-stack-dev.
 - BOOT.md startup checks use their own temporary session without overwriting retained history ([#134831](https://github.com/openclaw/openclaw/pull/134831)). Thanks @miguelarios.
 - Long database scans and migrations renew their maintenance lease while Doctor works ([#134880](https://github.com/openclaw/openclaw/pull/134880)).
+- Legacy agent-list upgrades keep the first agent on its established workspace ([#134892](https://github.com/openclaw/openclaw/pull/134892)). Thanks @Lendersmark.
 - Shared credential health remains visible in explicit fleets without a default agent ([#134902](https://github.com/openclaw/openclaw/pull/134902)). Thanks @Lendersmark.
-- Managed Tailscale upgrades reclaim only an exclusive predecessor route for the configured Gateway ([#135394](https://github.com/openclaw/openclaw/pull/135394)). Thanks @jjjhenriksen, @Lendersmark.
-- Stale workspace setup migrations preserve canonical facts, archive the source, and converge ([#135755](https://github.com/openclaw/openclaw/pull/135755)). Thanks @jjjhenriksen, @Deregtx, @guarismo.
-- Managed Tailscale sudo failures on Linux now include the supported operator-grant command ([#135825](https://github.com/openclaw/openclaw/pull/135825)). Thanks @pengzh1, @obviyus, @ezimerman.
+- Interrupted shared-credential migrations can restore verified archived credentials ([#134952](https://github.com/openclaw/openclaw/pull/134952)). Thanks @erameson.
+- Redundant legacy credential subsets converge without deleting the richer shared store ([#135096](https://github.com/openclaw/openclaw/pull/135096)). Thanks @jodok, @felixboenkost-droid.
+- Blank Gateway suspension waits fail before a lease is acquired while zero remains a valid single attempt ([#135270](https://github.com/openclaw/openclaw/pull/135270)). Thanks @qingminglong.
+- Doctor explains retained custom agent databases and why it will not remove them automatically ([#135295](https://github.com/openclaw/openclaw/pull/135295)). Thanks @PollyBot13, @obviyus, @aaajiao.
+- Historical completed migrations recover credentials only when the legacy receipt and matching archive can be verified ([#135346](https://github.com/openclaw/openclaw/pull/135346)). Thanks @erameson.
+- Doctor and upgrade repair preserve authored includes, environment expressions, and unambiguously identifiable legacy agents ([#135671](https://github.com/openclaw/openclaw/pull/135671)). Thanks @fuller-stack-dev.
+- Stale workspace setup migrations preserve a verified backup and converge instead of repeatedly blocking channel startup ([#135755](https://github.com/openclaw/openclaw/pull/135755)). Thanks @jjjhenriksen, @Deregtx, @guarismo.
+- Backup workspace exclusions are applied before traversal while included absolute links remain protected ([#135830](https://github.com/openclaw/openclaw/pull/135830)). Thanks @obviyus, @jarvismazz, @yubingjiaocn, @ericcaiwx-star, @ruel225.
+- ACPX-owned scratch symlinks no longer prevent creation of a verified portable backup, while unrelated unsafe symlinks still fail closed ([#136215](https://github.com/openclaw/openclaw/pull/136215)). Thanks @LiuwqGit, @obviyus, @wave-workflow.
 
 **Security and trust**
 
-- Policy-free legacy exec-approval stubs can be archived and retired without replacing SQLite policy ([#135981](https://github.com/openclaw/openclaw/pull/135981)). Thanks @Ma77h3hac83r.
+- Interactive uninstall defaults preserve local state, configuration, and workspaces ([#134299](https://github.com/openclaw/openclaw/pull/134299)). Thanks @PollyBot13, @kodi.
+- Incomplete exec-approval repairs keep a stopped Gateway stopped and return failure ([#135454](https://github.com/openclaw/openclaw/pull/135454)).
+- Doctor retires only policy-free legacy exec-approval stubs while malformed or populated data still fails closed ([#135981](https://github.com/openclaw/openclaw/pull/135981)). Thanks @Ma77h3hac83r.
 
 **Documentation**
 
-- The CLI index now links the existing database preflight and ownership commands ([#135279](https://github.com/openclaw/openclaw/pull/135279)). Thanks @qingminglong.
-- Doctor guidance explains how copied-state repairs can still reach explicitly configured external paths ([#135312](https://github.com/openclaw/openclaw/pull/135312)). Thanks @vdruts.
+- The CLI index links the existing database preflight and ownership commands ([#135279](https://github.com/openclaw/openclaw/pull/135279)). Thanks @qingminglong.
+- Doctor guidance warns that copied state can still modify explicitly configured external workspaces or stores ([#135312](https://github.com/openclaw/openclaw/pull/135312)). Thanks @vdruts.
 
-</details>
+**Limits and compatibility**
 
-</Accordion>
-
-<Accordion title="Investigating a Failed Update">
-
-When an interactive update gets far enough to fail operationally, OpenClaw can now carry a bounded, sanitized record of that attempt into its existing triage flow instead of making you reconstruct the failure from scratch. The CLI can offer a configured Claude Code, Codex, OpenCode, or Pi session after updater cleanup, and the Control UI can open Ask OpenClaw with the recorded cause for an investigation-first conversation.
-
-That investigation does not get authority to retry the update, repair state, or restart the Gateway on its own, and a successful investigation does not turn the original update into a success. JSON, `--yes`, background, and managed-service runs remain diagnostic-only, preserving the original exit result while printing the next commands for an operator to use.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Built-in triage carries sanitized failure context into the CLI or Control UI after eligible update failures ([#134865](https://github.com/openclaw/openclaw/pull/134865)).
-
-**Bug fixes**
-
-- Failed updates preserve configuration and can hand investigation to an installed coding agent ([#134490](https://github.com/openclaw/openclaw/pull/134490)). Thanks @fuller-stack-dev.
+- Windows snapshots work when PowerShell 7 is installed alongside Windows PowerShell without weakening private-path checks ([#121618](https://github.com/openclaw/openclaw/pull/121618)). Thanks @fr-meyer.
+- Source builds point complete module-backed channel state checks at emitted JavaScript or CommonJS artifacts ([#136509](https://github.com/openclaw/openclaw/pull/136509)).
 
 </details>
 
@@ -446,13 +384,66 @@ That investigation does not get authority to retry the update, repair state, or 
 
 ## Messaging
 
-Messaging in [channels](/channels) is less about whether a reply was technically sent and more about whether it arrived in the right conversation with its context, controls, and final outcome intact. This release carries that work across approvals, thread routing, rich replies, queues, restarts, voice, and the failure paths that used to leave either the person or the operator guessing.
+Messages across [channels](/channels) are less likely to arrive blank, damaged, duplicated, or detached from the conversation that made them useful. This release tightens both halves of that experience, keeping the reply itself intact as it crosses a channel's limits while making the channel around it easier to recover, inspect, and control when something goes wrong.
 
 <AccordionGroup>
 
-<Accordion title="Approving Delegated Changes from Chat">
+<Accordion title="Delivery, formatting, and attachment fidelity">
 
-When a delegated system agent asks to change OpenClaw configuration or plugins, operators can now approve or deny the request from a configured channel and see whether it was applied, denied, cancelled, expired, or could not be applied. The request remains tied to the run that created it, so closing that run also closes its authority to make the change, while Telegram keeps the approval and completion messages in the forum or direct-message topic where the request began.
+Long and structured replies now survive more of the trip from the agent to the person reading them. Fenced code keeps its indentation and repeated lines, task lists keep their checkboxes when a message is split, and literal Markdown, image links, citations, and labeled links are less likely to disappear or turn into the wrong kind of attachment. Microsoft Teams threads retain their parent and sibling context, cross-session deliveries are written into the conversation that received them, and remote-Mac iMessage attachments get a short bounded retry when the file is still materializing.
+
+The channel-specific presentation paths got the same kind of attention without pretending they all work alike. Matrix and Feishu or Lark keep offered controls, while LINE preserves card text, questions, and every choice when media is unavailable or the native card is too large. LINE still exposes only the first 13 choices as native quick replies and keeps the rest readable as text, and a WhatsApp reply whose quote has expired now arrives unquoted rather than as an empty bubble.
+
+Delivery outcomes are also more conservative where uncertainty used to create either silence or duplication. Slack sends short final answers before later progress cleanup can fail and keeps queued or ordinary replies on the admitted thread root, while Discord avoids replaying uncertain webhook sends through a second bot path and no longer treats a response without a real message ID as confirmed delivery. These repairs are specific to the named paths, and several external-service checks used synthetic endpoints rather than live accounts.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reduce local Microsoft Teams reply-formatting work while preserving rendered output ([#136377](https://github.com/openclaw/openclaw/pull/136377)).
+
+**Bug fixes**
+
+- Finish rejected webhook responses before closing bundled channel connections ([#126818](https://github.com/openclaw/openclaw/pull/126818)). Thanks @edenfunf and @obviyus.
+- Fall back to a readable unquoted WhatsApp reply when quote details have expired ([#127959](https://github.com/openclaw/openclaw/pull/127959)). Thanks @Finn763 and @markswitch83.
+- Preserve Matrix code containing double pipes without hiding the reply ([#128453](https://github.com/openclaw/openclaw/pull/128453)). Thanks @ruel225 and @petergaultney.
+- Restore parent and sibling context in Microsoft Teams channel threads ([#129345](https://github.com/openclaw/openclaw/pull/129345)). Thanks @amalysh.
+- Keep LINE card text and controls when optional media is unavailable ([#132571](https://github.com/openclaw/openclaw/pull/132571)). Thanks @edenfunf.
+- Stop active link fetches and processors when their reply is cancelled ([#132883](https://github.com/openclaw/openclaw/pull/132883)). Thanks @SunnyShu0925.
+- Deliver buttons and selections in Matrix agent replies ([#133268](https://github.com/openclaw/openclaw/pull/133268)). Thanks @edenfunf and @ml12580.
+- Record cross-session deliveries in the receiving conversation history ([#134083](https://github.com/openclaw/openclaw/pull/134083)). Thanks @edenfunf, @VACInc, and @abacha.
+- Preserve LINE quick-reply questions and every offered choice ([#134976](https://github.com/openclaw/openclaw/pull/134976)). Thanks @edenfunf.
+- Run browser messages accepted during startup recovery exactly once afterward ([#135016](https://github.com/openclaw/openclaw/pull/135016)). Thanks @jesse-merhi and @snarflakes.
+- Complete auto-replies whose prompt ends with context, attachments, or metadata ([#135070](https://github.com/openclaw/openclaw/pull/135070)).
+- Reconcile generated commentary as one update during runs and reconnects ([#135081](https://github.com/openclaw/openclaw/pull/135081)). Thanks @akagifreeez, @obviyus, and @tomroberts78.
+- Send ordinary Tlon hashtag lines without stalling the parser ([#135181](https://github.com/openclaw/openclaw/pull/135181)).
+- Carry LINE group-mention context into the turn that answers ([#135195](https://github.com/openclaw/openclaw/pull/135195)). Thanks @edenfunf.
+- Preserve task lists and structured Markdown across message chunks ([#135200](https://github.com/openclaw/openclaw/pull/135200)).
+- Fall back to complete text when a generated LINE card is too large ([#135229](https://github.com/openclaw/openclaw/pull/135229)). Thanks @edenfunf.
+- Deliver Feishu and Lark controls, links, attachments, and accurate partial results ([#135255](https://github.com/openclaw/openclaw/pull/135255)). Thanks @edenfunf.
+- Keep Markdown citations from being mistaken for pasted URLs to fetch ([#135341](https://github.com/openclaw/openclaw/pull/135341)). Thanks @teddytennant and @obviyus.
+- Route unknown direct messages through the configured wildcard peer consistently ([#135351](https://github.com/openclaw/openclaw/pull/135351)). Thanks @teddytennant and @obviyus.
+- Preserve fenced code byte for byte through duplicate-prose cleanup ([#135945](https://github.com/openclaw/openclaw/pull/135945)). Thanks @ruel225, @obviyus, and @yetval.
+- Deliver long Discord webhook replies without duplicate bot fallback messages ([#135963](https://github.com/openclaw/openclaw/pull/135963)).
+- Preserve Google Chat link labels that contain spaces ([#136151](https://github.com/openclaw/openclaw/pull/136151)). Thanks @ericcaiwx-star, @obviyus, and @KimOckHyun.
+- Preserve literal Markdown images and balanced image URL punctuation ([#136228](https://github.com/openclaw/openclaw/pull/136228)).
+- Retry remote-Mac iMessage attachments through short materialization delays ([#136301](https://github.com/openclaw/openclaw/pull/136301)). Thanks @zhangguiping-xydt, @obviyus, and @zqchris.
+- Deliver short native-streamed Slack replies before progress finalization ([#136460](https://github.com/openclaw/openclaw/pull/136460)). Thanks @shannon0430.
+- Keep Slack replies and queued notices on the existing thread root ([#136566](https://github.com/openclaw/openclaw/pull/136566)). Thanks @Cobblestone-Digital1 and @shannon0430.
+- Leave Discord sends unconfirmed when no real response ID is returned ([#136620](https://github.com/openclaw/openclaw/pull/136620)). Thanks @Cobblestone-Digital1.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Channel lifecycle, identity, voice, and administration">
+
+Configured channels now explain more of their own state instead of disappearing or failing behind a generic status. Operators can approve or deny delegated configuration and plugin changes from supported chat channels and see the actual applied, denied, cancelled, expired, or not-applied result, with the request's authority ending when its originating run closes. Failed channel plugins remain visible as blocked with a safe Doctor hint, Signal stops retrying permanent event-stream rejections, and an unresponsive iMessage private-API bridge returns the recovery commands on the first affected send.
+
+Slack Agent View now keeps each visible message root in its own conversation, including across Gateway restarts in Socket Mode and HTTP Request URL setups, while ordinary Slack direct messages and Assistant View remain unchanged. Telegram button presses are acknowledged once they are durably stored and stale session starts no longer hold every later message behind them, channel routes release cleanly during recovery, and older supported Feishu, Telegram, WhatsApp, and Matrix plugins keep dispatching replies after the OpenClaw host updates.
+
+The active turn also owns more of what it starts. Progress narration stops when a turn ends, quiet Slack previews wait for a complete first thought, Discord respects quiet reply policy during session conflicts, and cancelled Discord voice consults no longer turn into late error speech. Discord voice capture now has one owner per speaker and rejects oversized batch utterances with an actionable warning instead of emitting a partial transcript, while configured automatic voice replies can preserve the inbound-audio decision for Codex message-tool responses. These voice and recovery changes keep their existing provider, channel, and transport boundaries rather than establishing cross-channel parity.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -461,151 +452,45 @@ When a delegated system agent asks to change OpenClaw configuration or plugins, 
 
 - Approve delegated configuration and plugin changes from supported channels ([#134670](https://github.com/openclaw/openclaw/pull/134670)). Thanks @obviyus.
 
-</details>
-
-</Accordion>
-
-<Accordion title="Reply Context and Agent Identity">
-
-Replies now hold onto more of the context that made them meaningful. Microsoft Teams channel threads include their parent and sibling messages even when Teams omits reply metadata, cross-session deliveries are written into the receiving conversation, and LINE tells the answering turn whether a group message actually addressed the bot. Wildcard peer routes no longer change with lookup order, and Slack RPC replies keep the selected agent’s configured name and emoji.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
 **Bug fixes**
 
-- Keep the configured Slack agent identity on RPC-delivered replies ([#122078](https://github.com/openclaw/openclaw/pull/122078)). Thanks @Iskam31.
-- Restore parent and sibling context in Microsoft Teams channel threads ([#129345](https://github.com/openclaw/openclaw/pull/129345)). Thanks @amalysh.
-- Record cross-session deliveries in the receiving conversation history ([#134083](https://github.com/openclaw/openclaw/pull/134083)). Thanks @edenfunf, @VACInc, @abacha.
-- Carry LINE group-mention context into the turn that answers ([#135195](https://github.com/openclaw/openclaw/pull/135195)). Thanks @edenfunf.
-- Route unknown direct messages through the configured wildcard peer consistently ([#135351](https://github.com/openclaw/openclaw/pull/135351)). Thanks @teddytennant, @obviyus.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Complete Controls, Cards, and Formatted Replies">
-
-Rich replies are less likely to lose the part somebody actually needed. Matrix and Feishu or Lark deliver offered controls, while LINE preserves card text, buttons, questions, and overflow choices when media is unavailable or a generated card is too large for the platform. Long task lists keep their structure across message chunks, and ordinary Markdown examples, citations, image URLs, and labeled links survive parsing without disappearing or triggering the wrong fetch.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Preserve Matrix code containing double pipes without hiding the reply ([#128453](https://github.com/openclaw/openclaw/pull/128453)). Thanks @ruel225, @petergaultney.
-- Keep LINE card text and controls when optional media is unavailable ([#132571](https://github.com/openclaw/openclaw/pull/132571)). Thanks @edenfunf.
-- Deliver buttons and selections in Matrix agent replies ([#133268](https://github.com/openclaw/openclaw/pull/133268)). Thanks @edenfunf, @ml12580.
-- Let LINE agents offer the controls the channel already supports ([#134915](https://github.com/openclaw/openclaw/pull/134915)). Thanks @edenfunf.
-- Preserve LINE quick-reply questions and every offered choice ([#134976](https://github.com/openclaw/openclaw/pull/134976)). Thanks @edenfunf.
-- Preserve task lists and structured Markdown across message chunks ([#135200](https://github.com/openclaw/openclaw/pull/135200)).
-- Fall back to complete text when a generated LINE card is too large ([#135229](https://github.com/openclaw/openclaw/pull/135229)). Thanks @edenfunf.
-- Deliver Feishu and Lark controls, links, attachments, and accurate partial results ([#135255](https://github.com/openclaw/openclaw/pull/135255)). Thanks @edenfunf.
-- Keep Markdown citations from being mistaken for pasted URLs to fetch ([#135341](https://github.com/openclaw/openclaw/pull/135341)). Thanks @teddytennant, @obviyus.
-- Preserve Google Chat link labels that contain spaces ([#136151](https://github.com/openclaw/openclaw/pull/136151)). Thanks @ericcaiwx-star, @obviyus, @KimOckHyun.
-- Preserve literal Markdown images and balanced image URL punctuation ([#136228](https://github.com/openclaw/openclaw/pull/136228)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Channel Queues Through Restarts">
-
-Several channel failures now recover without making a healthy conversation look dead. Telegram can move past a stale session start and acknowledges stored button presses before a busy chat finishes earlier work, while channel routes release cleanly during replacement, Matrix can repair an upgraded sync database with Doctor, and Slack Socket Mode or relay accounts no longer depend on an inactive HTTP-only secret. Failed configured channels remain visible as blocked with a safe recovery hint instead of disappearing from status and health.
-
-Older supported Feishu, Telegram, WhatsApp, and Matrix plugins keep dispatching inbound replies after the host updates, installed external channels work with generic message actions and broadcast planning, and narrower Slack lookup problems and Tlon parser stalls are repaired. These are channel-specific repairs rather than a claim that every transport now behaves identically.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Reuse Slack Enterprise thread lookups across matching events ([#121598](https://github.com/openclaw/openclaw/pull/121598)). Thanks @mikasa0818.
-- Show why Slack rejected an inbound attempt before dispatch ([#132723](https://github.com/openclaw/openclaw/pull/132723)). Thanks @zhangguiping-xydt, @Phillis, @ayaangazali.
-- Release abandoned channel routes so account recovery can continue ([#133297](https://github.com/openclaw/openclaw/pull/133297)). Thanks @zhangguiping-xydt, @goffern.
-- Acknowledge durably stored Telegram button presses promptly ([#133379](https://github.com/openclaw/openclaw/pull/133379)). Thanks @Paeddy87, @zhangguiping-xydt.
-- Repair stale Matrix sync databases while preserving existing state ([#134742](https://github.com/openclaw/openclaw/pull/134742)). Thanks @w9n, @obviyus.
-- Start Slack Socket Mode and relay without resolving an unused HTTP secret ([#134827](https://github.com/openclaw/openclaw/pull/134827)).
-- Keep failed configured channels visible in status and health ([#135082](https://github.com/openclaw/openclaw/pull/135082)). Thanks @vguyon-dev, @0xCyda, @liemnhoang.
-- Let Telegram queues recover from a stale session start ([#135154](https://github.com/openclaw/openclaw/pull/135154)). Thanks @brettdaman, @obviyus.
-- Keep older supported channel plugins dispatching replies after host updates ([#135179](https://github.com/openclaw/openclaw/pull/135179)). Thanks @nissl24, @fridaylans2000-art, @obviyus, @jooey, @fufales, @itanyplus, @dtump, @XXlaoxxc, @desksk, @chengoak.
-- Send ordinary Tlon hashtag lines without stalling the parser ([#135181](https://github.com/openclaw/openclaw/pull/135181)).
-- Use installed external channels in generic message actions and broadcasts ([#135831](https://github.com/openclaw/openclaw/pull/135831)). Thanks @ruel225, @obviyus, @TailsProwerWorks.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Clear Outcomes for Delivery Failures">
-
-When delivery cannot finish, the result is now less ambiguous. Rejected webhook uploads across bundled channels receive their complete response before the connection closes, malformed Signal response text fails visibly, and an affected iMessage send explains that its bridge stopped responding and gives the operator the two recovery commands. Context-only prompts no longer hang at completion, while Discord thread replies split after mention expansion and avoid replaying an uncertain or partially accepted webhook delivery as a duplicate bot message.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
+- Report a shadowed WhatsApp acknowledgement emoji during migration ([#119501](https://github.com/openclaw/openclaw/pull/119501)). Thanks @harjothkhara, @obviyus, and @abacha.
 - Reject corrupted text in Signal JSON responses with a visible failure ([#121569](https://github.com/openclaw/openclaw/pull/121569)). Thanks @sunlit-deng.
-- Finish webhook rejection responses before closing the connection ([#126818](https://github.com/openclaw/openclaw/pull/126818)). Thanks @edenfunf, @obviyus.
+- Reuse Slack Enterprise thread lookups across matching events ([#121598](https://github.com/openclaw/openclaw/pull/121598)). Thanks @mikasa0818.
+- Keep the configured Slack agent identity on RPC-delivered replies ([#122078](https://github.com/openclaw/openclaw/pull/122078)). Thanks @Iskam31.
+- Warn when WhatsApp acknowledgement scope cannot be preserved ([#129825](https://github.com/openclaw/openclaw/pull/129825)). Thanks @zhangguiping-xydt and @obviyus.
+- Show why Slack rejected an inbound attempt before dispatch ([#132723](https://github.com/openclaw/openclaw/pull/132723)). Thanks @zhangguiping-xydt, @Phillis, and @ayaangazali.
+- Release abandoned channel routes so account recovery can continue ([#133297](https://github.com/openclaw/openclaw/pull/133297)). Thanks @zhangguiping-xydt and @goffern.
+- Acknowledge durably stored Telegram button presses promptly ([#133379](https://github.com/openclaw/openclaw/pull/133379)). Thanks @Paeddy87 and @zhangguiping-xydt.
+- Distinguish exhausted LINE monthly allowance from transient rate limits ([#133445](https://github.com/openclaw/openclaw/pull/133445)). Thanks @edenfunf.
+- Let Gateway restart and channel shutdown finish without a busy ingress loop ([#133871](https://github.com/openclaw/openclaw/pull/133871)). Thanks @SebTardif and @obviyus.
 - Explain an unresponsive iMessage bridge and show the recovery commands ([#134572](https://github.com/openclaw/openclaw/pull/134572)). Thanks @omarshahine.
-- Complete auto-replies whose prompt ends with context or metadata ([#135070](https://github.com/openclaw/openclaw/pull/135070)).
-- Deliver long Discord webhook replies without duplicate fallback messages ([#135963](https://github.com/openclaw/openclaw/pull/135963)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Stopping Replies and Progress">
-
-Stopping or replacing a turn now does a better job of stopping the work and narration attached to it. Active link fetches and processors are cancelled with the reply, obsolete narration cannot update a newer draft, Control UI commentary reconciles as one update, and Slack waits for a complete first preamble while keeping quiet-preview settings quiet. Successful reaction-only and background work also avoid misleading missing-reply fallbacks.
-
-Discord follows the same final-outcome discipline in several focused paths. Cancelled voice consults remain quiet, model-picker choices report their real result, and ambient or message-tool-only work does not leak a session-busy warning that its reply policy said to suppress.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Stop active link fetches and processors when their reply is cancelled ([#132883](https://github.com/openclaw/openclaw/pull/132883)). Thanks @SunnyShu0925, @steipete.
 - Keep quiet Slack previews on the latest authored preamble ([#134716](https://github.com/openclaw/openclaw/pull/134716)). Thanks @pash-openai.
+- Repair stale Matrix sync databases while preserving existing state ([#134742](https://github.com/openclaw/openclaw/pull/134742)). Thanks @w9n and @obviyus.
+- Start Slack Socket Mode and relay without resolving an unused HTTP secret ([#134827](https://github.com/openclaw/openclaw/pull/134827)).
 - Cancel obsolete progress narration when its turn ends ([#134839](https://github.com/openclaw/openclaw/pull/134839)).
-- Reconcile generated commentary as one update during runs and reconnects ([#135081](https://github.com/openclaw/openclaw/pull/135081)). Thanks @akagifreeez, @obviyus, @tomroberts78.
+- Let LINE agents offer the controls the channel already supports ([#134915](https://github.com/openclaw/openclaw/pull/134915)). Thanks @edenfunf.
+- Keep failed configured channels visible in status and health ([#135082](https://github.com/openclaw/openclaw/pull/135082)). Thanks @vguyon-dev, @0xCyda, and @liemnhoang.
+- Let Telegram queues recover from a stale session start ([#135154](https://github.com/openclaw/openclaw/pull/135154)). Thanks @brettdaman and @obviyus.
 - Keep cancelled Discord voice consults quiet and reusable ([#135380](https://github.com/openclaw/openclaw/pull/135380)).
-- Apply Discord model-picker choices without false failure replies ([#135382](https://github.com/openclaw/openclaw/pull/135382)). Thanks @Call44, @BoatAngle.
+- Apply Discord model-picker choices without false failure replies ([#135382](https://github.com/openclaw/openclaw/pull/135382)). Thanks @Call44 and @BoatAngle.
 - Respect quiet reply policy for Discord session-busy notices ([#135444](https://github.com/openclaw/openclaw/pull/135444)).
-- Keep connected apps available and wait for a complete Slack preamble ([#136092](https://github.com/openclaw/openclaw/pull/136092)). Thanks @pash-openai.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Voice Replies and Discord Voice Sessions">
-
-Discord voice capture now has one owner per speaker and stops oversized batch utterances with an actionable warning instead of accumulating memory or sending a partial transcript. For inbound WhatsApp voice notes, Codex dynamic replies can once again return voice when automatic inbound TTS is enabled, while later text-only turns remain text and the audio decision stays attached to the reply that received it.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Bound Discord voice capture and clean up each speaker’s session ([#135870](https://github.com/openclaw/openclaw/pull/135870)). Thanks @LZY3538.
+- Use installed external channels in generic message actions and broadcasts ([#135831](https://github.com/openclaw/openclaw/pull/135831)). Thanks @ruel225, @obviyus, and @TailsProwerWorks.
+- Bound Discord voice capture and clean up each speaker's session ([#135870](https://github.com/openclaw/openclaw/pull/135870)). Thanks @LZY3538.
 - Preserve inbound audio for automatic Codex voice replies ([#135884](https://github.com/openclaw/openclaw/pull/135884)). Thanks @hyper-sdn.
+- Keep connected apps available and wait for a complete Slack preamble ([#136092](https://github.com/openclaw/openclaw/pull/136092)). Thanks @pash-openai.
+- Keep Slack Agent View conversations isolated in Socket Mode ([#136510](https://github.com/openclaw/openclaw/pull/136510)). Thanks @danielduerr.
+- Preserve Slack Agent View isolation across HTTP-mode Gateway restarts ([#136559](https://github.com/openclaw/openclaw/pull/136559)). Thanks @danielduerr.
+- Stop Signal reconnects on permanent event-stream rejection and show recovery guidance ([#136178](https://github.com/openclaw/openclaw/pull/136178)). Thanks @masatohoshino and @obviyus.
 
-</details>
+**Documentation**
 
-</Accordion>
+- Explain Slack Agent View session boundaries, detection, persistence, and troubleshooting ([#136672](https://github.com/openclaw/openclaw/pull/136672)). Thanks @danielduerr.
+- Correct Slack Agent View recovery guidance after a storage warning ([#136704](https://github.com/openclaw/openclaw/pull/136704)). Thanks @danielduerr.
 
-<Accordion title="WhatsApp Acknowledgement Migration">
+**Limits and compatibility**
 
-Doctor now says when a legacy WhatsApp acknowledgement setting could not survive migration exactly as written. It identifies a shadowed emoji, shows which shared emoji remains active, and warns when the old acknowledgement scope changes or cannot be represented so operators can review `messages.ackReactionScope` instead of accepting a misleading clean migration.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Report a shadowed WhatsApp acknowledgement emoji during migration ([#119501](https://github.com/openclaw/openclaw/pull/119501)). Thanks @harjothkhara, @obviyus, @abacha.
-- Warn when WhatsApp acknowledgement scope cannot be preserved ([#129825](https://github.com/openclaw/openclaw/pull/129825)). Thanks @zhangguiping-xydt, @obviyus.
+- Keep older supported Feishu, Telegram, WhatsApp, and Matrix plugins dispatching replies after host updates ([#135179](https://github.com/openclaw/openclaw/pull/135179)). Thanks @nissl24, @fridaylans2000-art, @obviyus, @jooey, @fufales, @itanyplus, @dtump, @XXlaoxxc, @desksk, and @chengoak.
 
 </details>
 
@@ -615,31 +500,38 @@ Doctor now says when a legacy WhatsApp acknowledgement setting could not survive
 
 ## Memory
 
-[Memory](/concepts/memory) now keeps rebuildable index work separate from the conversations people need to protect. There is a safe reset path that leaves sessions and transcripts in place, search avoids needless full rebuilds for healthy or ordinarily dirty indexes, legacy retrieval settings survive Doctor upgrades, and long conversations retain capture progress through compaction while closed transcript views release message text they no longer need.
+[Memory](/concepts/memory) is easier to repair without sacrificing the conversations it is meant to remember. Rebuildable indexes can now be reset while sessions and transcripts stay put, ordinary searches avoid needless rebuilding, and recall is more careful about which result, agent, provider, and archive it belongs to.
 
 <AccordionGroup>
 
-<Accordion title="Resetting and Rebuilding Memory Indexes">
+<Accordion title="Index repair, reset, and incremental search">
 
-Built-in Memory now has an explicit `openclaw memory reset` path that discards only rebuildable index data for one agent or every configured agent while preserving sessions, transcripts, memory source files, and other durable agent state. It asks before acting, requires `--yes` in non-interactive use, treats an absent or empty index as a successful no-op, and refuses to race indexing already in progress.
+Built-in Memory now has an explicit `openclaw memory reset` path for one agent or every configured agent. It removes only rebuildable memory-index data while preserving sessions, transcripts, memory source files, and unrelated database tables, asks before acting, requires `--yes` when nobody is there to confirm, and refuses to race indexing already in progress. This is a recovery tool, not a privacy purge or a way to shrink the database.
 
-Full reindexes are safer around that path. Replacement caches are bounded before publication, failed full rebuilds leave the previously published cache intact, a memory change during automatic maintenance gets one retry against current content, and abandoned workspace locks can recover after process-ID reuse. Recovery messages identify whether an incompatible index belongs to OpenClaw or configuration, warn when an explicit rebuild may contact a paid embedding provider, and retain the unreadable source path; ordinary replies remain available while a legacy index is repaired in the background, and combined memory and wiki searches continue to show the affected agent's repair instructions.
+Healthy one-shot searches can return without starting needless indexing work, while ordinary file and session changes are applied incrementally instead of repeatedly selecting a full rebuild. LanceDB automatic capture keeps its place through conversation compaction and drains pending work before the plugin closes. Replies also remain available while a legacy index repairs in the background, though automatic project and trigger recall can be empty until that repair finishes. Doctor keeps each agent's retrieval paths and session-memory choices during legacy upgrades, and one symlinked or otherwise non-regular workspace file no longer takes every regular memory file out with it.
+
+The harder failure paths are less destructive too. Replacement caches are bounded before publication, failed full rebuilds leave the current cache intact, one concurrent change gets a fresh automatic attempt, and abandoned workspace locks can recover after a crash and later process-ID reuse. Recovery guidance keeps the correct agent-scoped command visible, identifies whether OpenClaw or configuration owns an index mismatch, shows the unreadable source path, and warns when an explicit rebuild may contact a paid embedding provider.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Reset derived memory indexes without deleting sessions or transcripts ([#135653](https://github.com/openclaw/openclaw/pull/135653)). Thanks @AlexisBallo2.
+- Reset rebuildable memory indexes without deleting sessions or transcripts ([#135653](https://github.com/openclaw/openclaw/pull/135653)). Thanks @AlexisBallo2.
 
 **Bug fixes**
 
-- Retry automatic index maintenance once after a concurrent memory change ([#134333](https://github.com/openclaw/openclaw/pull/134333)). Thanks @TheAngryPit, @obviyus.
+- Preserve LanceDB capture progress through compaction and plugin shutdown ([#131329](https://github.com/openclaw/openclaw/pull/131329)). Thanks @hartmark.
+- Retry automatic index maintenance once when memory changes during a rebuild ([#134333](https://github.com/openclaw/openclaw/pull/134333)). Thanks @TheAngryPit, @obviyus.
+- Preserve each agent's memory-search settings during legacy Doctor upgrades ([#134760](https://github.com/openclaw/openclaw/pull/134760)). Thanks @obviyus, @vdruts.
+- Skip linked and other non-regular workspace memory files without aborting indexing ([#135042](https://github.com/openclaw/openclaw/pull/135042)). Thanks @ruel225, @obviyus, @kiranvk-2011.
 - Recover abandoned Memory Core locks after process-ID reuse ([#135051](https://github.com/openclaw/openclaw/pull/135051)). Thanks @pengzh1, @obviyus, @gru-10k.
-- Keep replies available while a legacy index is repaired in the background ([#135062](https://github.com/openclaw/openclaw/pull/135062)). Thanks @LifeViwer.
-- Bound forced-reindex cache publication and preserve the live cache after failure ([#135373](https://github.com/openclaw/openclaw/pull/135373)). Thanks @AlexisBallo2.
-- Keep agent-scoped repair instructions beside successful wiki results ([#135415](https://github.com/openclaw/openclaw/pull/135415)).
+- Keep replies available while a legacy index repairs in the background ([#135062](https://github.com/openclaw/openclaw/pull/135062)). Thanks @LifeViwer.
+- Bound forced-reindex cache publication and preserve the current cache after failure ([#135373](https://github.com/openclaw/openclaw/pull/135373)). Thanks @AlexisBallo2.
+- Keep agent-scoped memory repair instructions beside successful wiki results ([#135415](https://github.com/openclaw/openclaw/pull/135415)).
+- Let healthy one-shot memory searches return without reindexing ([#135520](https://github.com/openclaw/openclaw/pull/135520)). Thanks @gaoanze888, @obviyus, @LifeViwer.
 - Identify index-mismatch ownership and retain unreadable-source details ([#135864](https://github.com/openclaw/openclaw/pull/135864)). Thanks @yetval, @obviyus, @CjTruHeart.
+- Apply pending memory changes without repeatedly rebuilding the full index ([#136064](https://github.com/openclaw/openclaw/pull/136064)). Thanks @ThatGuySizemore.
 
 **Documentation**
 
@@ -647,42 +539,21 @@ Full reindexes are safer around that path. Replacement caches are bounded before
 
 **Limits and compatibility**
 
-- Reset does not shrink existing SQLite allocation, restore already deleted history, or act as a privacy purge, and the planned separate derived-index database remains future work.
-- Automatic project and trigger recall remains unavailable while legacy source classification is pending, and an explicit rebuild may use a paid embedding provider.
+- Reset does not shrink existing SQLite allocation, restore deleted history, or erase source data, and the planned separate index database remains future work.
+- Automatic recall can remain empty during legacy repair, and rebuilding may contact the configured paid embedding provider.
+- Symlink targets remain intentionally unread, and shared mutable state directories across concurrent Gateways remain unsupported.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Search Without Needless Rebuilding">
+<Accordion title="Embedding access, recall anchoring, history, and diagnostics">
 
-One-shot `openclaw memory search` commands can reuse a healthy persisted index and exit instead of starting indexing work after they already found the answer. The command still checks its sources, so a real change starts maintenance and becomes searchable rather than leaving the clean state frozen forever.
+Recall now returns the history around the result somebody actually selected, including retained history from before a session reset, instead of quietly substituting the newest messages. Missing anchors return no history and foreign session bindings are rejected. In eligible private chats, Active Memory also tells the model when recall was intentionally skipped or unavailable, without putting provider errors or sensitive search details into model context, so a failed lookup is less likely to masquerade as a successful search that found nothing.
 
-When an index is dirty, ordinary memory-file and session changes can be applied incrementally while searches remain available instead of repeatedly selecting a full rebuild. Workspace discovery also skips symlinked and other non-regular memory entries rather than allowing one linked `USER.md` to abort indexing for every regular file.
+Embedding access follows the route the operator chose more faithfully. Custom OpenAI-compatible providers can resolve saved API-key or bearer-token profiles and use matching HTTP or HTTPS proxy settings, while invalid profile bindings stop before network egress and `NO_PROXY` exclusions keep their direct route. The official Linux x64 Docker image includes the runtime needed for managed local llama.cpp embeddings, and malformed Amazon Bedrock responses now fail clearly instead of being accepted with altered encoding. These boundaries remain provider-specific, and nothing here changes where remote embedding requests go or whether they may incur provider cost.
 
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Skip linked and other non-regular workspace memory files without aborting the sync ([#135042](https://github.com/openclaw/openclaw/pull/135042)). Thanks @ruel225, @obviyus, @kiranvk-2011.
-- Let clean one-shot memory searches return without reindexing ([#135520](https://github.com/openclaw/openclaw/pull/135520)). Thanks @gaoanze888, @obviyus, @LifeViwer.
-- Apply pending memory changes without repeatedly rebuilding the full index ([#136064](https://github.com/openclaw/openclaw/pull/136064)). Thanks @ThatGuySizemore.
-
-**Limits and compatibility**
-
-- Symlink targets remain intentionally unread, and a separate multimodal file-replacement race is not fixed here.
-- The improvement from incremental maintenance varies by index and workload, while full publication and retry policy remain unchanged.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Retrieval Settings and Embedding Providers">
-
-Running `openclaw doctor --fix` on an older configuration no longer silently drops an agent's knowledge paths or session-memory choices and falls back to global defaults. Custom OpenAI-compatible embedding providers can also resolve a saved API-key or bearer-token profile before indexing or search, while invalid or unavailable bindings stop before a network request rather than selecting a different credential.
-
-The packaged local path is less fragile too. The official Linux x64 Docker image now includes the runtime needed for managed llama.cpp embeddings to pass their executable preflight, and malformed Amazon Bedrock embedding responses produce a clear error instead of being accepted through replacement decoding.
+Memory also holds onto the right owner and history through more of its lifecycle. Deep Memory Core consolidation stays attached to the explicitly selected agent, and session deletion can publish a recoverable archive even when a durable session ID is too long for a filename. Large transcript scans retain less full-message text up front and release recovered text when a chat closes, short session listings stop pinning retired metadata snapshots, and memory diagnostics no longer label ordinary use on a small constrained host as critical pressure.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -692,58 +563,21 @@ The packaged local path is less fragile too. The official Linux x64 Docker image
 - Reject malformed Amazon Bedrock embedding-response encoding ([#133716](https://github.com/openclaw/openclaw/pull/133716)). Thanks @RileyJJY.
 - Include the managed llama.cpp runtime prerequisite in the Linux x64 Docker image ([#134532](https://github.com/openclaw/openclaw/pull/134532)). Thanks @chelsealong, @henrique-simoes.
 - Resolve saved API-key and bearer-token profiles for compatible embedding providers ([#134744](https://github.com/openclaw/openclaw/pull/134744)). Thanks @0x-Parzival.
-- Preserve each agent's memory-search settings during legacy Doctor upgrades ([#134760](https://github.com/openclaw/openclaw/pull/134760)). Thanks @obviyus, @vdruts.
-
-**Limits and compatibility**
-
-- Managed llama.cpp support here is limited to Linux x64, and this repair does not add managed ARM64 support.
-- Saved profiles apply to compatible embedding APIs, while literal and blank keys retain their existing behavior.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Visible Recall Outcomes">
-
-On eligible private-chat turns, Active Memory now tells the main model when deep recall was intentionally skipped or unavailable, so an absent lookup is not mistaken for a successful search that found nothing relevant. The note stays bounded and leaves provider errors and sensitive search details out of model context.
-
-Memory Core Dreaming also carries an explicitly selected agent through deep consolidation in multi-agent setups, letting recalled facts consolidate under the right owner instead of silently falling back to append-only storage. When no owner is available, that safer append-only fallback remains.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
+- Route OpenAI-compatible memory embeddings through matching environment proxies ([#134858](https://github.com/openclaw/openclaw/pull/134858)). Thanks @Artemeey, @obviyus, @XIYBHK.
 - Keep deep memory consolidation attached to its selected agent ([#135166](https://github.com/openclaw/openclaw/pull/135166)). Thanks @zhangguiping-xydt, @obviyus, @giangthb.
 - Tell the model when Active Memory recall was skipped or unavailable ([#135193](https://github.com/openclaw/openclaw/pull/135193)). Thanks @Alix-007, @obviyus, @wave-workflow.
-
-**Limits and compatibility**
-
-- Active Memory outcome notes apply to eligible private-chat turns, and timeout-budget alignment remains unimplemented.
-- Deep consolidation under an explicit owner is limited to Memory Core Dreaming in multi-agent setups.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Memory Capture in Long Conversations">
-
-LanceDB auto-capture now keeps its place when a long conversation is compacted, avoids embedding facts it has already handled, serializes overlapping capture for the same conversation, and lets in-flight automatic capture finish before the plugin closes. New facts are less likely to disappear behind retained messages after compaction.
-
-Large transcript scans can begin processing without first retaining every message payload, while each active chat view owns the recovered full text it needs and releases that text when the view closes. Split panes keep their own valid content, so closing one does not strip the conversation from another that is still open.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Preserve LanceDB auto-capture progress through compaction and shutdown ([#131329](https://github.com/openclaw/openclaw/pull/131329)). Thanks @hartmark.
 - Release recovered transcript text when its chat view closes ([#135326](https://github.com/openclaw/openclaw/pull/135326)).
+- Publish recoverable transcript archives for sessions with unusually long IDs ([#136171](https://github.com/openclaw/openclaw/pull/136171)). Thanks @efe-arv, @liri-ha, @obviyus.
+- Release retired session metadata after short Gateway listings ([#136567](https://github.com/openclaw/openclaw/pull/136567)).
+- Avoid false critical memory-pressure alerts on small Gateway hosts ([#136641](https://github.com/openclaw/openclaw/pull/136641)). Thanks @vincentkoc.
+- Reopen embedded session history around the selected search result ([#136657](https://github.com/openclaw/openclaw/pull/136657)).
 
 **Limits and compatibility**
 
-- The shutdown guarantee covers automatic capture, not explicit memory tools or automatic recall, and completed-text history remains bounded.
-- Transcript handling does not establish lower ordinary idle memory, lower peak process memory, or faster scan latency.
+- Managed local llama.cpp support here is limited to Linux x64, while remote embedding behavior, cost, and proxy routing remain specific to the configured provider.
+- Active Memory outcome notes apply to eligible private-chat turns, and timeout-budget alignment remains unchanged.
+- Embedded missing-anchor handling for externally imported CLI history and a possible large-store archive-query limit remain outside these repairs.
+- Transcript and session-listing changes do not establish lower ordinary idle memory, lower process-wide peak memory, or universal performance gains.
 
 </details>
 
@@ -753,54 +587,91 @@ Large transcript scans can begin processing without first retaining every messag
 
 ## Skills
 
-Skills are becoming something a team can own without turning the host into a ticket queue. People sharing a Gateway can keep their own libraries, share work deliberately, and carry the exact selected revision into the session that needs it, while overwrites, policy failures, and optional runtime dependencies leave clearer recovery paths.
+Skills now belong more naturally to the person doing the work. Signed-in teammates on a shared Gateway can keep their own libraries and share them deliberately without handing over edit rights, while local agents can work in a real project directory without moving their managed instructions or memory. The work around those skills also keeps more of its identity and history intact, so a handoff, restart, or tool follow-up is less likely to quietly become a different task.
 
 <AccordionGroup>
 
-<Accordion title="Personal Skill Libraries for Shared Teams">
+<Accordion title="Personal skill libraries, identity, and safe guidance">
 
-Signed-in teammates on a shared Gateway can create, import, update, and reuse skills without host access. A library starts private, sharing does not hand over edit rights, and ownership can move to a team when the skill itself becomes shared work, so routine authoring no longer has to pass through an administrator.
+[Skills](/tools/skills) can now live in private libraries for each signed-in teammate on a shared Gateway. People can create, import, revise, and reuse complete skill bundles without host access, choose when to share them, and transfer ownership when a skill becomes team work. The selected revision, supporting files, and executable permissions follow the session through handoffs, restarts, and supported local, sandbox, cloud, or node-worker placement, so the worker receives the skill that was actually chosen rather than whichever copy happens to be newest.
 
-ZIP imports now reserve room across profiles as well. One person with many unfinished uploads cannot occupy every pending slot, while existing uploads can still finish and linked or merged identities continue to share one allowance. Each session also keeps the immutable skill revision that was selected, including its supporting files and executable permissions, as work moves through local, sandbox, cloud, or node workers.
+Finding and changing the intended skill is safer too. An exact skill name now wins over a metadata alias, ambiguous aliases stop instead of silently choosing one, and Skill Workshop carries the resolved canonical name through revisions. Claude migration also backs up the whole generated skill before an explicit overwrite and leaves the target untouched when the source has disappeared.
+
+Bundled diagnosis and channel-setup guidance now keeps its first pass read-only, uses supported commands, and identifies Telegram senders by numeric user ID. Obsolete file-search guidance for conversation recall is gone as well, leaving the native visibility-scoped session tools as the supported route. These guidance changes do not grant new authority or loosen existing access rules.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Give signed-in teammates private, shareable skill libraries ([#134068](https://github.com/openclaw/openclaw/pull/134068)). Thanks @RomneyDa, @steipete.
+- Give signed-in teammates private, shareable personal skill libraries ([#134068](https://github.com/openclaw/openclaw/pull/134068)). Thanks @RomneyDa.
 
 **Bug fixes**
 
+- Back up an overwritten generated skill before Claude migration ([#134302](https://github.com/openclaw/openclaw/pull/134302)). Thanks @PollyBot13.
+- Preserve canonical skill names and reject ambiguous aliases during discovery and Workshop updates ([#136495](https://github.com/openclaw/openclaw/pull/136495)).
+- Retire obsolete file-based conversation-recall guidance in favor of native session tools ([#136615](https://github.com/openclaw/openclaw/pull/136615)). Thanks @jetd1.
 - Reserve personal-skill ZIP-import capacity across profiles ([#135593](https://github.com/openclaw/openclaw/pull/135593)).
+
+**Documentation**
+
+- Keep bundled diagnosis read-only and correct channel and Telegram setup instructions ([#136600](https://github.com/openclaw/openclaw/pull/136600)).
 
 **Limits and compatibility**
 
-- Revision delivery preserves the existing solo workspace-skills workflow and stays within one trusted Gateway domain.
+- Personal libraries are for signed-in teammates within one trusted Gateway domain, not hostile-tenant isolation, and sharing a skill does not grant editing rights.
+- Pending ZIP imports remain capped at 16 per canonical profile within 32 per Gateway, expire after one hour, and existing over-limit uploads can still finish.
+- Exact-name resolution does not rewrite pending drafts, and conversation recall remains bound by existing session visibility. The separate embedded-history anchor defect is not fixed here.
+- The diagnosis and setup edits change instructions only. They do not alter runtime authorization, repairs, access policy, or migration safeguards.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Skill Editing, Migration, and Runtime Checks">
+<Accordion title="Agent workspaces, session continuity, and tool follow-up">
 
-Claude migration can overwrite a generated skill without making local edits disposable. `migrate apply claude --overwrite` now backs up the whole target skill directory, records the recovery path even if a later write fails, and checks that the command source still exists before changing the target.
+Local agents can now use a configured project directory from [agent settings](/gateway/config-agents#agentsdefaultscwd) for their tools and deliverables while keeping instructions and memory in OpenClaw's managed workspace. Existing setups keep their old behavior until a separate directory is configured, which makes it possible to point an agent at a real repository without turning that repository into its identity.
 
-The surrounding runtime reports and installs are more truthful too. Source-run Gateways can load compiled OpenAI and Memory Core plugins again, context-free harness checks distinguish allowlist, denylist, and disabled-plugin policy from a missing installation, and copied hook packs attempt the optional runtime packages their handlers need.
+Supervised Codex Chats can use **Fork from here** on newer canonical messages, keep their native conversation history through a Gateway restart, and open the selected input as an unsent draft without changing the source conversation. Supporting session repairs keep nested writes in order, bound malformed ancestry instead of hanging, and stop an older local CLI recovery attempt from replacing the newer session.
+
+The tools around that work explain what happens next more accurately. Background commands tell Code Mode how to retrieve their eventual output, developing tool loops reach the agent before critical blocking, and completed fallback reports on the covered CLI path cannot launch the delegated work again. Final results retain successful document analysis, report real terminal outcomes, clear stale nested-tool summaries, and identify policy or agent ownership without inventing a successful result.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
+**Improvements**
+
+- Preserve native history when supervised Codex Chats fork canonical messages ([#134660](https://github.com/openclaw/openclaw/pull/134660)). Thanks @kevin2966n.
+- Let local agents work in a configured project directory while retaining their managed workspace ([#135080](https://github.com/openclaw/openclaw/pull/135080)).
+
 **Bug fixes**
 
-- Back up an overwritten generated skill before Claude migration ([#134302](https://github.com/openclaw/openclaw/pull/134302)). Thanks @PollyBot13, @steipete.
-- Restore compiled plugin loading in source Gateways ([#135077](https://github.com/openclaw/openclaw/pull/135077)).
-- Explain allowlist, denylist, and disabled-plugin harness failures accurately ([#135206](https://github.com/openclaw/openclaw/pull/135206)). Thanks @fuller-stack-dev, @goslingmanagment.
-- Install optional hook-pack runtime dependencies when npm can provide them ([#136050](https://github.com/openclaw/openclaw/pull/136050)).
+- Keep nested session writes in their expected order ([#131456](https://github.com/openclaw/openclaw/pull/131456)). Thanks @gaoanze888, @Grynn.
+- Return bounded context for cyclic session ancestry ([#131567](https://github.com/openclaw/openclaw/pull/131567)). Thanks @igs-rogenlo.
+- Tell background commands how to retrieve their eventual output ([#132756](https://github.com/openclaw/openclaw/pull/132756)). Thanks @sashankh, @shad0wca7.
+- Show real failure codes and signals for authorized chat bash commands ([#133414](https://github.com/openclaw/openclaw/pull/133414)). Thanks @MoerAI.
+- Retain successful PDF and image analysis in Code Mode and Tool Search ([#135037](https://github.com/openclaw/openclaw/pull/135037)).
+- Restore compiled OpenAI and Memory Core plugin loading in source Gateways ([#135077](https://github.com/openclaw/openclaw/pull/135077)).
+- Finish subagent cleanup when plugin-runtime setup or completion hooks fail ([#135098](https://github.com/openclaw/openclaw/pull/135098)).
+- Show developing tool-loop warnings to the agent before critical blocking ([#135103](https://github.com/openclaw/openclaw/pull/135103)).
+- Stop stale local CLI recovery from replacing a newer session ([#135168](https://github.com/openclaw/openclaw/pull/135168)). Thanks @mushuiyu886, @obviyus.
+- Explain allowlist, denylist, and disabled-plugin harness blockers accurately ([#135206](https://github.com/openclaw/openclaw/pull/135206)). Thanks @fuller-stack-dev, @goslingmanagment.
+- Finalize accepted nested-tool summaries and clear stale presentation state ([#135398](https://github.com/openclaw/openclaw/pull/135398)).
+- Use the selected agent for explicit-fleet status and internal diagnostics ([#135447](https://github.com/openclaw/openclaw/pull/135447)). Thanks @Hansen1018, @abacha.
+- Attempt optional hook-pack runtime dependencies during copied installs ([#136050](https://github.com/openclaw/openclaw/pull/136050)).
+
+**Security and trust**
+
+- Keep completed CLI fallback reports from launching delegated work again on the covered report-only path ([#115405](https://github.com/openclaw/openclaw/pull/115405)). Thanks @MertBasar0.
+- Newly agent-visible media analysis on compact Code Mode and Tool Search paths retains an unresolved review concern around the existing untrusted-content wrapper.
 
 **Limits and compatibility**
 
-- Compiled plugin loading is scoped to source Gateway runs, and optional hook packages are attempted rather than guaranteed to install.
+- Separate working directories apply only to supported unsandboxed runs. Session-created directories take precedence, paired and connected-agent sessions retain node-owned directories, and there is no per-message directory option.
+- Canonical-message forks require recorded native provenance, and older canonical messages plus creator-required sandbox configurations remain unsupported. The prepared proof covers local macOS acceptance rather than every managed Desktop, Windows, crash, or multiwriter path.
+- The report-only delegation gate covers CLI-backed fallback producers and the Gateway loopback route. It does not cover primary auto-reply CLI dispatch, the subscription-auth CLI orchestrator, or peer-conversation policy.
+- Background-command guidance fixes the producer side only. Wait-side ID diagnostics and the other reported dead ends remain separate.
+- Compiled plugin loading is scoped to source Gateway runs, while optional hook packages are attempted rather than guaranteed to install. Harness policy diagnostics do not install, enable, trust, or probe a plugin.
 
 </details>
 
@@ -810,15 +681,19 @@ The surrounding runtime reports and installs are more truthful too. Source-run G
 
 ## Native Apps
 
-The native apps take two visible steps forward in this release. [Android](/platforms/android) gets a much fuller everyday workspace for chat, sessions, navigation, and appearance, while Android, [iPhone and iPad](/platforms/ios), and [macOS](/platforms/macos) can turn Mermaid source into readable diagrams inside the conversation. Around those larger changes, reconnects hold on to accepted work, voice stays with the turn that started it, and several platform-specific setup and helper paths handle failure more cleanly.
+The native apps take two visible steps forward in this release. [Android](/platforms/android) gets a much fuller everyday workspace for chat, sessions, navigation, and appearance, while Android, [iPhone and iPad](/platforms/ios), and [macOS](/platforms/macos) can now turn Mermaid source into readable diagrams inside the conversation. Around those larger changes, reconnects do a better job of preserving what already happened, voice work stays with the turn that started it, and several platform-specific setup and helper paths recover more cleanly.
 
 <AccordionGroup>
 
-<Accordion title="Android’s Fuller Everyday Workspace">
+<Accordion title="Android chat, diagrams, and reconnect recovery">
 
 The Android app now brings the pieces people reach for during a normal conversation into one more complete native experience. The composer has a full-width writing area with compact actions, model names remain readable, and searchable controls expose models, effort, Fast Mode, and permissions without crowding the transcript. Sessions can be browsed or created from the native catalog, the sidebar can be arranged around the places you use, and theme families and accents stay with the correct profile through offline changes, reconnects, and app recreation.
 
-That work also keeps the app usable on narrow screens and with larger text, and it gives an actionable Providers and Models route before sending with an explicitly selected model whose authentication is unavailable. That check still follows the availability reported by the connected Gateway and is scoped to explicitly selected models.
+Mermaid diagrams now render locally inside Android chat instead of stopping at raw source, with copy, retry, source, and sharp full-screen zoom and pan controls that keep working offline. Streaming, invalid, oversized, or temporarily failed diagrams remain readable as source, and the controls and recovery guidance are available across the supported locales. The diagram interaction was verified with an emulator rather than physical Android hardware, and the separate foldable-keyboard clipping report remains open.
+
+The rest of the work makes everyday chat harder to knock off course. Longer drafts can grow to six visible lines, guided setup under Settings → OpenClaw follows new replies without stealing an older reading position, and New chat shows its own progress while blocking duplicate creation. Android also gives people an explicit voice-note option when on-device dictation is unavailable, and warns before sending with an explicitly selected model whose authentication is unavailable. That model check still depends on availability reported by a connected Gateway and does not cover the Default selection path.
+
+Reconnect and refresh ownership is tighter throughout. The replacement Gateway connection stays in charge while older cleanup settles, acknowledged offline messages move beyond Sending, a newly created chat remains selected, and a deleted queued message stays deleted even when an older refresh returns late. Refresh rechecks Gateway health while preserving queued work, and newer chat, appearance, settings, and session choices no longer lose to stale work. Most of these paths were proven with emulators, previews, or isolated native owners rather than a complete physical-device and network matrix.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -826,157 +701,91 @@ That work also keeps the app usable on narrow screens and with larger text, and 
 **Improvements**
 
 - Bring Android chat, sessions, the sidebar, and appearance closer to the browser workspace ([#134939](https://github.com/openclaw/openclaw/pull/134939)). Thanks @IWhatsskill, @obviyus.
+- Render Mermaid diagrams locally in Android chat with source, retry, copy, and full-screen controls ([#135342](https://github.com/openclaw/openclaw/pull/135342)).
+- Localize Android Mermaid controls, progress, and recovery guidance across supported locales ([#135600](https://github.com/openclaw/openclaw/pull/135600)).
+- Let Android chat drafts grow to six visible lines before scrolling ([#135923](https://github.com/openclaw/openclaw/pull/135923)). Thanks @BennyAI2.
+- Refresh current session, permission, Fast Mode, pinning, diagram, and status translations across the native apps ([#136304](https://github.com/openclaw/openclaw/pull/136304)).
 
 **Bug fixes**
 
 - Explain authentication problems before sending with an explicitly selected unavailable model ([#134884](https://github.com/openclaw/openclaw/pull/134884)). Thanks @fuller-stack-dev.
-- Keep drafts and chat controls readable on narrow or large-text layouts ([#135432](https://github.com/openclaw/openclaw/pull/135432)). Thanks @KangBumS.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Mermaid Diagrams Across Android, iOS, and macOS">
-
-Mermaid diagrams no longer have to be read as raw code in supported native chats. Android and iOS render completed diagrams inline with source, copy, retry, and expanded-preview controls, while macOS brings diagrams to both full chat and Quick Chat and keeps that window open while a larger preview is in use. Each app keeps readable source for streaming, invalid, oversized, or temporarily failed diagrams instead of replacing it with an empty box.
-
-Rendering stays local rather than depending on a network diagram service. Android offers a sharp full-screen view with zoom and pan, iOS adds an offline-capable vector preview with zoom, pan, and rotation, and macOS uses compact desktop controls with native Close and Escape behavior. The exact controls follow each platform rather than pretending the three implementations are identical.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Render Mermaid diagrams in Android chat with source, retry, and full-screen controls ([#135342](https://github.com/openclaw/openclaw/pull/135342)). Thanks @steipete.
-- Render Mermaid diagrams in iOS chat with an offline-capable vector preview ([#135470](https://github.com/openclaw/openclaw/pull/135470)). Thanks @steipete.
-- Localize Android Mermaid controls and recovery guidance across supported locales ([#135600](https://github.com/openclaw/openclaw/pull/135600)).
-- Render Mermaid diagrams in macOS full chat and Quick Chat while preserving equations and preview ownership ([#135746](https://github.com/openclaw/openclaw/pull/135746)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Reconnects, Retries, and Queued Messages">
-
-Android now keeps the replacement Gateway connection in charge while an older connection finishes shutting down, so retired cleanup is less likely to publish a false offline state or discard an accepted request outcome. Messages acknowledged after reconnect move past Sending, a new conversation remains selected for the next message, later queued sends keep moving, and a queued message you delete stays gone even if an older refresh finishes afterward.
-
-The same ownership cleanup reaches other native conversation paths. Apple chat can retry immediately after a session-settings failure, iPhone history refreshes reconcile a streamed reply with its canonical transcript row instead of leaving an older duplicate, and native session progress cards retain the selected agent and workspace context.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Make Retry Send available immediately after Apple session-settings failures ([#134752](https://github.com/openclaw/openclaw/pull/134752)).
-- Keep the selected agent and workspace on native session progress cards ([#135426](https://github.com/openclaw/openclaw/pull/135426)). Thanks @obviyus, @rwinkelman, @Synthetic2802.
-- Remove stale duplicate iPhone replies after history refresh or cache restore ([#135789](https://github.com/openclaw/openclaw/pull/135789)).
+- Keep drafts and chat controls readable on narrow or large-text layouts and recover overlapping reconnect history ([#135432](https://github.com/openclaw/openclaw/pull/135432)). Thanks @KangBumS.
+- Refresh Android camera, image, and diagram libraries and include all packaged license notices ([#135563](https://github.com/openclaw/openclaw/pull/135563)).
+- Preserve Android chat and pairing state through the Room update and accept the highest valid Unicode input in KaTeX ([#135670](https://github.com/openclaw/openclaw/pull/135670)).
+- Offer voice-note recording when Android dictation is unavailable without losing the draft ([#135794](https://github.com/openclaw/openclaw/pull/135794)). Thanks @RaviTharuma.
 - Keep replacement Android Gateway connections authoritative during reconnect cleanup ([#135878](https://github.com/openclaw/openclaw/pull/135878)).
 - Advance acknowledged Android messages beyond Sending after reconnect ([#135961](https://github.com/openclaw/openclaw/pull/135961)).
 - Keep new Android conversations selected and later queued sends moving ([#136078](https://github.com/openclaw/openclaw/pull/136078)).
 - Stop deleted Android queued messages from returning after a delayed refresh ([#136161](https://github.com/openclaw/openclaw/pull/136161)).
+- Preserve selected chats and newer appearance or settings state across archives, agent switches, and reconnects ([#136173](https://github.com/openclaw/openclaw/pull/136173)). Thanks @Kaneki-x, @aniruddhaadak80.
+- Recheck Android Gateway health when Refresh overlaps a queued send ([#136413](https://github.com/openclaw/openclaw/pull/136413)).
+- Keep the Android guided-setup conversation at the intended reading position and follow new replies when appropriate ([#136550](https://github.com/openclaw/openclaw/pull/136550)).
+- Keep only the newest Android Settings refresh result and show owned New-chat progress ([#136643](https://github.com/openclaw/openclaw/pull/136643)).
 
 </details>
 
 </Accordion>
 
-<Accordion title="Voice Ownership Across Native Apps">
+<Accordion title="Apple chat, voice, Watch, and background work">
 
-Talk and realtime voice now carry the acknowledged agent, run, and reply through the clients involved in the conversation, which keeps a consult on the intended agent, prevents an unrelated newer chat reply from being read back, and makes Stop target the work that actually started. Host cancellation is also reported as cancellation instead of a tool failure while the voice call remains open.
+On iPhone, iPad, and Mac, Mermaid diagrams now become readable native chat content without depending on a network rendering service. iOS adds inline diagrams with source, copy, retry, and an expanded vector view with zoom, pan, and rotation, while macOS brings diagrams to full chat and Quick Chat with desktop controls that keep Quick Chat open around the preview. Incomplete, invalid, oversized, or failed diagrams remain readable as source. The iOS path was not tested on a physical iPhone, and physical Mac trackpad pinch-to-zoom remained unverified.
 
-On Apple Watch, dictated messages, spoken replies, playback, and retries remain attached to their original chat, and a spoken reply that outlasts the Watch’s wait points the user back to Chat on iPhone. Android offers an explicit voice-note recording path when on-device dictation is unavailable without discarding the draft, while macOS reuses a compatible speech recognizer, keeps the Talk overlay visible through a quick toggle, and packages the resources required by local MLX speech. The recognizer change removes one source of avoidable churn, but it does not establish that the broader open Apple speech-service memory report is fully fixed.
+Apple chat is easier to control around those diagrams too. iPhone dashboards open directly at phone width, reopened chats land at the newest response, refreshed history no longer leaves a stale duplicate answer, and assistant text can be selected normally while message actions remain available. The iOS model picker explains whether a choice changes the session, agent, or global default and blocks choices or live sends only when the connected Gateway has authoritative permanent-authentication information. On Mac, the full chat window gets a cleaner two-row composer that keeps its important controls available in narrow windows, while failed AI setup once again reveals the rejected key, error, and retry path.
 
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
+Background work now behaves more like background work. A New Session task started from the macOS app can post a generic native completion notice and reopen the exact finished session, including when a fast task completes before the dashboard receives notification status. This requires notification permission that was already granted and the originating dashboard to remain loaded, does not prompt for permission, and suppresses the notice when that session is already being viewed. The Mac status menu also stops its own Devices and Automations polling after it closes while an open Cron Jobs settings pane keeps its separate refresh, and embedded web pages can be widened beyond half the app window while the dashboard uses compact navigation.
 
-**Bug fixes**
+Voice and Watch work keeps the original turn in charge for longer. Talk consults retain the Gateway-approved agent and run through completion, history, and Stop, iOS realtime voice waits for its own reply, and cancelled Apple node requests stop before starting new notifications, Watch transfers, speech, or overlays. Apple Watch dictation, spoken replies, playback, and retries stay attached to their original chat, and a Watch that stops waiting after 90 seconds points the user to Chat on iPhone without cancelling the underlying run. Revoked or replaced Watch connections can no longer collect new commands or return late results. These Watch paths were not verified on physical Watch hardware, and the Talk and realtime voice proofs used synthetic or isolated transports rather than complete microphone and speaker sessions.
 
-- Keep Voice Call sessions open when host work is cancelled and settle tool failures once ([#134924](https://github.com/openclaw/openclaw/pull/134924)).
-- Preserve the acknowledged agent and run across Talk consults, history, and Stop ([#135031](https://github.com/openclaw/openclaw/pull/135031)). Thanks @astra-openclaw.
-- Reuse compatible macOS speech recognizers across repeated voice captures ([#135401](https://github.com/openclaw/openclaw/pull/135401)). Thanks @Colton-Harris.
-- Package the resources required by local MLX speech on macOS ([#135592](https://github.com/openclaw/openclaw/pull/135592)).
-- Keep Apple Watch replies, playback, and retries with their original voice turn ([#135697](https://github.com/openclaw/openclaw/pull/135697)).
-- Preserve the macOS Talk overlay through quick toggles ([#135731](https://github.com/openclaw/openclaw/pull/135731)). Thanks @HuzaifaChaudary.
-- Explain when Apple Watch stops waiting to speak a reply ([#135765](https://github.com/openclaw/openclaw/pull/135765)).
-- Offer voice-note recording when Android dictation is unavailable without losing the draft ([#135794](https://github.com/openclaw/openclaw/pull/135794)). Thanks @RaviTharuma.
-- Keep iOS realtime voice consults attached to their own replies ([#135795](https://github.com/openclaw/openclaw/pull/135795)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Apple App Setup, Chat Controls, and Watch Authorization">
-
-macOS onboarding now brings failed AI setup, rejected-key details, and the retry action back into view instead of leaving someone stranded between setup and chat. Once inside chat, a cleaner two-row composer keeps context, model, effort, voice, send, attachment, branch, and verbosity controls reachable in narrow windows without duplicating model and usage details in the toolbar.
-
-iOS now explains whether a model choice changes the current session, the agent default, or the global default, and it blocks unavailable choices or permanent authentication failures before a live send while still allowing offline queueing and temporary cooldowns. Localization coverage catches more dynamic macOS text and newer Apple controls, while a revoked or replaced Watch connection can no longer receive another command or submit a late result through the retired connection.
+The supporting native and desktop paths are narrower but still useful. Packaged local MLX speech includes its required resources, compatible macOS speech recognizers are reused while the language is unchanged, helper pipes preserve short readiness messages and final diagnostics, and private node workers exit after owned cleanup. Linux first-run setup again exposes the remote-Gateway choice without requiring a local CLI, paired-node Claude runs can use native Claude Code login when forwarded credentials are blank, Windows worker turns release their temporary state normally, and SSH worker desktops avoid overlong Unix-socket paths. Those fixes retain their platform boundaries and do not establish broad physical-device, provider, Wayland, Windows-GUI, or signed-distribution coverage.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Refresh localized native labels and correct the Hindi token-usage counter ([#134627](https://github.com/openclaw/openclaw/pull/134627)). Thanks @steipete.
-- Add supported-locales coverage for newer Apple model setup and status messages ([#135543](https://github.com/openclaw/openclaw/pull/135543)).
+- Refresh Apple interface translations and correct the Hindi used-versus-total token counter ([#134627](https://github.com/openclaw/openclaw/pull/134627)).
+- Render Mermaid diagrams locally in iOS chat with source, retry, copy, and an expanded vector preview ([#135470](https://github.com/openclaw/openclaw/pull/135470)).
+- Localize Apple model sign-in, credential, cooldown, and default-selection messages ([#135543](https://github.com/openclaw/openclaw/pull/135543)).
+- Refresh compatible desktop-companion dependencies and local-service discovery behavior while retaining the Windows updater pin ([#135557](https://github.com/openclaw/openclaw/pull/135557)).
 - Keep essential macOS chat controls accessible in a cleaner narrow-window composer ([#135608](https://github.com/openclaw/openclaw/pull/135608)).
+- Render Mermaid diagrams in macOS full chat and Quick Chat with readable source fallbacks ([#135746](https://github.com/openclaw/openclaw/pull/135746)).
+- Translate the macOS background-session opening error and retire obsolete Android locale strings ([e975bce](https://github.com/openclaw/openclaw/commit/e975bce03d998e3a0d12ff43fa01b0beec72d46a)).
+- Translate iOS session-dashboard labels and Gateway connection guidance across supported locales ([#136438](https://github.com/openclaw/openclaw/pull/136438)).
 
 **Bug fixes**
 
+- Open published iOS session dashboards directly at phone width with complete scrolling ([#132983](https://github.com/openclaw/openclaw/pull/132983)). Thanks @fuller-stack-dev.
+- Make Retry Send available immediately after Apple session-settings failures ([#134752](https://github.com/openclaw/openclaw/pull/134752)).
 - Reveal macOS onboarding failures and restore immediate setup retries ([#134756](https://github.com/openclaw/openclaw/pull/134756)).
+- Close Windows worker state before removing its runtime directory ([#134911](https://github.com/openclaw/openclaw/pull/134911)).
+- Keep Voice Call sessions open when host work is cancelled and settle synchronous tool failures once ([#134924](https://github.com/openclaw/openclaw/pull/134924)).
+- Preserve native Claude Code login when paired-node credentials are blank ([#134932](https://github.com/openclaw/openclaw/pull/134932)). Thanks @rockytanf.
+- Preserve the acknowledged agent and run across Talk consults, history, and Stop ([#135031](https://github.com/openclaw/openclaw/pull/135031)). Thanks @astra-openclaw.
 - Explain iOS model-selection scope and block unavailable authenticated sends ([#135044](https://github.com/openclaw/openclaw/pull/135044)). Thanks @fuller-stack-dev, @goslingmanagment.
-- Keep dynamic macOS text inside generated localization coverage ([#135511](https://github.com/openclaw/openclaw/pull/135511)).
+- Report native Gateway timeouts only when the timeout actually wins ([#135287](https://github.com/openclaw/openclaw/pull/135287)).
+- Reuse compatible macOS speech recognizers across repeated voice captures ([#135401](https://github.com/openclaw/openclaw/pull/135401)). Thanks @Colton-Harris.
+- Keep the selected agent and workspace on native session progress cards ([#135426](https://github.com/openclaw/openclaw/pull/135426)). Thanks @obviyus, @rwinkelman, @Synthetic2802.
+- Open an existing iPhone chat at its newest response ([#135429](https://github.com/openclaw/openclaw/pull/135429)).
+- Preserve standard text selection and message actions for iOS assistant responses ([#135430](https://github.com/openclaw/openclaw/pull/135430)). Thanks @Solvely-Colin, @nikolaihack.
+- Keep SSH worker desktops working when the host temporary path is too long, on supported Unix hosts ([#135456](https://github.com/openclaw/openclaw/pull/135456)). Thanks @ly85206559.
+- Package the resources required by local MLX speech on macOS ([#135592](https://github.com/openclaw/openclaw/pull/135592)).
+- Restore Linux first-run local and remote Gateway choices without requiring the CLI ([#135650](https://github.com/openclaw/openclaw/pull/135650)).
+- Let private node workers exit after successful owned cleanup ([#135665](https://github.com/openclaw/openclaw/pull/135665)). Thanks @Colton-Harris, @obviyus.
+- Keep Apple Watch replies, playback, and retries with their original voice turn ([#135697](https://github.com/openclaw/openclaw/pull/135697)).
+- Preserve the macOS Talk overlay through quick toggles ([#135731](https://github.com/openclaw/openclaw/pull/135731)). Thanks @HuzaifaChaudary.
+- Explain when Apple Watch stops waiting to speak a reply without cancelling the chat run ([#135765](https://github.com/openclaw/openclaw/pull/135765)).
+- Remove stale duplicate iPhone replies after history refresh or cache restore ([#135789](https://github.com/openclaw/openclaw/pull/135789)).
+- Keep iOS realtime voice consults attached to their own replies ([#135795](https://github.com/openclaw/openclaw/pull/135795)).
+- Stop cancelled or replaced Apple node requests before they start new native side effects ([#135796](https://github.com/openclaw/openclaw/pull/135796)).
+- Let macOS embedded web pages expand beyond half the app window ([#136168](https://github.com/openclaw/openclaw/pull/136168)).
+- Preserve short readiness messages and final diagnostics across macOS helper pipes ([#136214](https://github.com/openclaw/openclaw/pull/136214)).
+- Notify when macOS background sessions finish and reopen the exact completed session ([#136519](https://github.com/openclaw/openclaw/pull/136519)).
+- Stop menu-owned Devices and Automations polling after the macOS status menu closes ([#136572](https://github.com/openclaw/openclaw/pull/136572)).
+- Deliver fast macOS background-session completions to the existing native notification owner ([#136683](https://github.com/openclaw/openclaw/pull/136683)).
 
 **Security and trust**
 
-- Stop revoked or replaced Watch connections from receiving work or returning late results ([#135904](https://github.com/openclaw/openclaw/pull/135904)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Desktop Setup and Remote Work">
-
-Fresh Linux desktop installs can again choose a Gateway on another computer before installing a local CLI, while local setup keeps its existing installer path. The desktop companion also receives a compatible local-discovery refresh, with its Windows updater deliberately held on the earlier version until an upstream cleanup conflict is resolved.
-
-Remote and supervised work recovers in a few narrower places as well. Paired-node Claude runs can fall back to the node’s native Claude login when forwarded credentials are blank, SSH worker desktops avoid Unix-socket failures caused by long temporary paths, and completed Windows worker turns close their owned state before removing the runtime directory so the slot can be reclaimed normally.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Refresh compatible desktop-companion dependencies and local discovery behavior ([#135557](https://github.com/openclaw/openclaw/pull/135557)). Thanks @steipete.
-
-**Bug fixes**
-
-- Close Windows worker state before removing its runtime directory ([#134911](https://github.com/openclaw/openclaw/pull/134911)).
-- Preserve native Claude login when paired-node credentials are blank ([#134932](https://github.com/openclaw/openclaw/pull/134932)). Thanks @rockytanf.
-- Keep SSH worker desktops working when the host temporary path is too long ([#135456](https://github.com/openclaw/openclaw/pull/135456)). Thanks @ly85206559.
-- Restore Linux first-run local and remote Gateway choices without requiring the CLI ([#135650](https://github.com/openclaw/openclaw/pull/135650)). Thanks @steipete.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Native Packaging and Background Helpers">
-
-Several less visible repairs keep the apps from failing around dependencies and helper processes. iOS development can resolve the available WebRTC 152 package again, Android refreshes camera, image, diagram, local-storage, and math-rendering foundations while preserving its existing database schemas and stored state, and the Licenses screen now includes the missing packaged notices.
-
-Background ownership is tighter too. Native Gateway invocations no longer report a timeout after the operation has already settled, private node workers exit after their owned cleanup even when stdin or a plugin child keeps the event loop active, and macOS helper pipes accept short readiness messages while retaining split or final diagnostics from MLX speech, SSH, node workers, computer control, and cookie sync.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Report native Gateway timeouts only when the timeout actually wins ([#135287](https://github.com/openclaw/openclaw/pull/135287)). Thanks @steipete.
-- Refresh Android libraries and include missing packaged license notices ([#135563](https://github.com/openclaw/openclaw/pull/135563)).
-- Let private node workers exit after successful owned cleanup ([#135665](https://github.com/openclaw/openclaw/pull/135665)). Thanks @Colton-Harris, @obviyus.
-- Preserve Android stored state while updating Room and correct the highest valid Unicode input in KaTeX ([#135670](https://github.com/openclaw/openclaw/pull/135670)).
-- Keep macOS native helper reads bounded while preserving readiness and final diagnostics ([#136214](https://github.com/openclaw/openclaw/pull/136214)).
-
-**Limits and compatibility**
-
-- Move iOS builds to an available validated WebRTC 152 release ([#134942](https://github.com/openclaw/openclaw/pull/134942)).
+- Stop revoked or replaced Apple Watch connections from receiving work or returning late results ([#135904](https://github.com/openclaw/openclaw/pull/135904)).
 
 </details>
 
@@ -986,187 +795,129 @@ Background ownership is tighter too. Native Gateway invocations no longer report
 
 ## Models and Providers
 
-Choosing a model should not be an exercise in wondering what else the click changed. [Model selection](/concepts/models) now tells you whether a choice is for this session, one agent, or the global default before it is saved, while provider logins and catalog changes flow into the model list without the ritual Gateway restart. This release also tightens the less visible part of that promise, so a temporary provider failure, a quiet Codex turn, or a disconnected node is much less likely to send work down the wrong route.
+Choosing a model now gives you a clearer picture of what will change, which account will be used, and whether the route can actually run before OpenClaw saves it. [Model selection](/concepts/models) and [provider setup](/concepts/model-providers) also stay current through more login, catalog, and settings changes without making a Gateway restart the normal way to see what you just configured.
 
 <AccordionGroup>
 
-<Accordion title="Model Selection, Defaults, and Reasoning">
+<Accordion title="Model discovery, selection, authentication, and defaults">
 
-The Control UI now gathers the main model, utility model, first fallback, thinking level, and Fast Mode in one autosaving Defaults card, with the scope of a model change shown before you make it. It preserves the rest of an ordered fallback chain when the first choice changes, and refuses to replace a working model when the required harness cannot be activated. The full fallback order still lives in the CLI, and the scope disclosure is currently a Control UI feature rather than a native-app picker feature.
+The Control UI brings the main model, utility model, first fallback, thinking level, and Fast Mode into one autosaving Defaults card, while the picker explains whether a model change applies to this session, one agent, or the global default before you make it. Changing the first fallback preserves the rest of the ordered chain, choosing no fallback clears it, and the complete chain still belongs to the CLI. OpenClaw also stops a selection before it changes anything when the required harness plugin is missing, disabled, or denied, though that check does not install a plugin, grant consent, authenticate a provider, or cover the `/model` directive.
 
-Reasoning choices now stay attached to the runtime that actually owns them. Eligible Sol and Terra turns keep Ultra through supported child-session boundaries, configured native Codex models show the effort levels their account advertises, and Luna remains capped at Max. Anthropic Fable 5.1 joins the shared API and Claude CLI catalogs, supported local Ollama routes remain selectable, and status views keep an authored context cap when a model runs through a provider alias.
+Provider setup is easier to verify as well. Model Setup can show whether detected Codex or Claude access comes from an account or API key and can display the email reported by that runtime without exposing keys or tokens. The provider page no longer counts unrelated tool credentials as model accounts, externally authenticated OpenAI models remain visible without a second OpenClaw login, and compatible login, credential, settings, and hot-reload changes refresh the catalog without a restart. Explicit refreshes and real provider, plugin, authentication, environment, or workspace changes can still replace that inventory, explicit provider disablement or denial still wins, and an authentication-order conflict now tells you that the credential was saved but was not promoted instead of claiming the new route is active. Doctor preserves environment-backed custom-provider secrets during repair, although some availability and picker paths may still choose a stored profile, so this is not complete credential-precedence consistency.
+
+The choices themselves expand carefully. Claude Fable 5.1 is available through the Anthropic API and Claude CLI with shared model metadata, moving the rolling Fable alias while leaving explicit Fable 5 pins intact, although native Claude CLI inference was not tested with live credentials. Supported local Ollama routes can be selected directly, while remote or explicitly credential-owned Ollama routes still require authentication. Eligible Sol and Terra Codex sessions retain Ultra across turns and supported child sessions, and configured native account models expose the reasoning levels they advertise, while Luna remains capped at Max. The hidden model used to prove that catalog repair advertised Ultra but did not complete upstream, so advertised availability is not a promise that every model will answer. Native Model Studio and DashScope routes now apply ephemeral cache markers by default and honor explicit short, long, or no-retention choices, while custom proxies remain opt-in, the embedded Chat Completions transport still lacks marker support, and no live cache hit was captured.
+
+OAuth-authenticated SuperGrok accounts can show quota, reset, plan, and balance information when xAI returns it, but API-key billing is separate, partial responses may display zero values, and no successful live OAuth billing response was captured. Anthropic Vertex Sonnet 5 estimates now use the current global and US or EU multi-region rates, which corrects OpenClaw's estimate rather than changing or proving Google billing.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Bring model defaults into one autosaving card ([#134813](https://github.com/openclaw/openclaw/pull/134813)). Thanks @Patrick-Erichsen.
-- Add Anthropic Fable 5.1 to shared model metadata ([#135638](https://github.com/openclaw/openclaw/pull/135638)).
+- Show the detected Codex or Claude sign-in method and runtime-reported account email ([#136521](https://github.com/openclaw/openclaw/pull/136521)).
+- Bring primary, fallback, utility, thinking, and Fast Mode defaults into one autosaving card ([#134813](https://github.com/openclaw/openclaw/pull/134813)). Thanks @Patrick-Erichsen.
+- Scope full catalog refreshes to the plugin runtimes that can contribute models ([#135486](https://github.com/openclaw/openclaw/pull/135486)). Thanks @zeroaltitude, @obviyus.
+- Add Claude Fable 5.1 to shared Anthropic and Claude CLI model metadata ([#135638](https://github.com/openclaw/openclaw/pull/135638)).
+- Show SuperGrok usage for OAuth-authenticated xAI accounts ([#135766](https://github.com/openclaw/openclaw/pull/135766)).
 
 **Bug fixes**
 
-- Apply configured thinking mappings when a request omits `--thinking` ([#132697](https://github.com/openclaw/openclaw/pull/132697)). Thanks @wangjx-xydt, @nina-grech.
+- Clear stale automatic OpenAI route state without removing intentional choices ([#102180](https://github.com/openclaw/openclaw/pull/102180)). Thanks @849261680, @cpwilhelmi.
+- Finish thinking lookup and Model Setup when a catalog owner is replaced during reload ([#127284](https://github.com/openclaw/openclaw/pull/127284)). Thanks @RomneyDa, @karkarl.
+- Apply configured thinking mappings when a one-shot request omits its thinking level ([#132697](https://github.com/openclaw/openclaw/pull/132697)). Thanks @wangjx-xydt, @nina-grech.
+- Compact and retry current llama.cpp context-limit failures ([#133888](https://github.com/openclaw/openclaw/pull/133888)). Thanks @gokay-ai, @Areson.
+- Keep tool-only credentials out of the model-provider inventory ([#134218](https://github.com/openclaw/openclaw/pull/134218)). Thanks @wantosure, @beastyrabbit.
+- Refresh model catalogs after a new provider login ([#134361](https://github.com/openclaw/openclaw/pull/134361)). Thanks @obviyus.
 - Show model-selection scope before saving ([#134473](https://github.com/openclaw/openclaw/pull/134473)). Thanks @fuller-stack-dev, @goslingmanagment, @Marvinthebored.
-- Keep the working selection when a model harness cannot activate ([#134837](https://github.com/openclaw/openclaw/pull/134837)). Thanks @steipete, @goslingmanagment.
+- Avoid leaving an empty legacy Claude CLI route after activation ([#134779](https://github.com/openclaw/openclaw/pull/134779)). Thanks @leilei3167, @obviyus, @aaajiao.
+- Preserve the working model when its harness plugin cannot be activated ([#134837](https://github.com/openclaw/openclaw/pull/134837)). Thanks @goslingmanagment.
+- Retain refreshed credentials for matching custom agent directories ([#134862](https://github.com/openclaw/openclaw/pull/134862)). Thanks @Lendersmark.
+- Keep externally authenticated OpenAI models in normal model menus ([#135046](https://github.com/openclaw/openclaw/pull/135046)). Thanks @goslingmanagment.
+- Refresh model catalogs after credential and settings changes ([#135063](https://github.com/openclaw/openclaw/pull/135063)). Thanks @elikampf.
+- Honor native Model Studio cache defaults and explicit retention choices ([#135093](https://github.com/openclaw/openclaw/pull/135093)).
 - Keep supported local Ollama routes selectable ([#135095](https://github.com/openclaw/openclaw/pull/135095)). Thanks @obviyus, @BoatAngle.
-- Preserve Ultra across runtimes and child sessions ([#135397](https://github.com/openclaw/openclaw/pull/135397)). Thanks @steipete.
-- Report configured context caps through provider aliases ([#135580](https://github.com/openclaw/openclaw/pull/135580)). Thanks @VACInc.
+- Show concise, redacted ChatGPT OAuth recovery errors ([#135112](https://github.com/openclaw/openclaw/pull/135112)). Thanks @shakkernerd.
+- Auto-enable configured Google and Google Vertex provider plugins when allowed ([#135239](https://github.com/openclaw/openclaw/pull/135239)). Thanks @Solvely-Colin.
+- Retain discovered and authenticated models through compatible hot reloads ([#135353](https://github.com/openclaw/openclaw/pull/135353)). Thanks @goslingmanagment.
+- Repair stale OpenAI profile order after a successful relogin ([#135355](https://github.com/openclaw/openclaw/pull/135355)). Thanks @obviyus, @mattcbianco.
+- Preserve custom-provider SecretRefs through Doctor repair ([#135357](https://github.com/openclaw/openclaw/pull/135357)). Thanks @obviyus, @dannevang.
+- Preserve Ultra across supported Codex runtime and child-session boundaries ([#135397](https://github.com/openclaw/openclaw/pull/135397)).
+- Report when login saved a credential but could not promote its active order ([#135443](https://github.com/openclaw/openclaw/pull/135443)). Thanks @lzhan011, @obviyus.
+- Discover models behind llama.cpp-compatible web-app endpoints ([#135445](https://github.com/openclaw/openclaw/pull/135445)). Thanks @gaoanze888, @Bloodis94.
+- Keep Anthropic Vertex Sonnet 5 estimates on current regional rates ([#135761](https://github.com/openclaw/openclaw/pull/135761)).
+- Publish refreshed provider-auth priority to a running Gateway ([#135847](https://github.com/openclaw/openclaw/pull/135847)). Thanks @josephbergvinson, @obviyus, @yetval.
+- Skip unused runtime discovery for read-only catalog preparation ([#136020](https://github.com/openclaw/openclaw/pull/136020)). Thanks @609NFT, @LiuwqGit.
 - Restore advertised reasoning choices for configured native Codex models ([#136061](https://github.com/openclaw/openclaw/pull/136061)).
 
 </details>
 
 </Accordion>
 
-<Accordion title="Provider Accounts and Model Catalogs">
+<Accordion title="Provider execution, retries, native CLI sessions, and usage">
 
-Provider state is now much closer to what you actually configured. Model Provider settings stop counting unrelated web-search and extraction credentials as model accounts, externally authenticated OpenAI models remain visible without a second login, and compatible catalog updates survive both credential changes and hot reloads. A new provider login, a settings edit, or a compatible model change can refresh the inventory when it is next requested instead of leaving the old list in place until a restart.
+Once a model is running, recovery is now less likely to multiply the problem. Transient provider failures have one bounded retry owner, so a brief interruption can recover while a persistent one reaches normal fallback or a useful error within 90 seconds, although that fixed window can end a larger configured attempt budget early. Busy-session conflicts stop after the first candidate instead of making every fallback appear broken, hard Anthropic and Bedrock refusals stop retries and model fallback with revise-and-retry guidance, and eligible pre-output connection failures can continue after settled tools without running those tools again. That last path is limited to empty-output transient failures, two continuation attempts, and already completed tools.
 
-The recovery path is less mysterious too. OpenAI relogin can repair stale profile order, Doctor preserves custom-provider environment references instead of turning them into broken stored keys, forced login clears the credential owner it is meant to replace, and a changed provider priority reaches a running Gateway. Google and Vertex configuration can also restore their bundled provider plugin through restrictive allowlists, while read-only catalog work and GitHub Copilot authentication avoid loading discovery or agent-runtime work they cannot use.
+Native coding sessions hold onto more of the work they already accepted. Quiet Codex turns keep running within their configured execution budget, where `timeoutSeconds` set to `0` remains the explicit unlimited setting, while late output cannot change an already settled result or crash the Gateway. Idle chats can resume alongside unrelated work, queued cold follow-ups retain the accepted native conversation, sub-plugin changes take effect on the next message, and long or concurrent replies pace progress so they remain connected through the final answer. None of that establishes a general speed or memory gain. Codex and Claude Code can also open from the catalog into a reconnectable terminal on an eligible local or paired host, but the completed proof covered macOS and a separately paired process on the same Mac rather than Windows, Linux, or a physically remote machine.
 
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Load GitHub Copilot provider authentication without the full agent runtime ([#134626](https://github.com/openclaw/openclaw/pull/134626)).
-
-**Bug fixes**
-
-- Keep tool-only credentials out of the model-provider inventory ([#134218](https://github.com/openclaw/openclaw/pull/134218)). Thanks @wantosure, @beastyrabbit.
-- Refresh the model catalog after provider login ([#134361](https://github.com/openclaw/openclaw/pull/134361)). Thanks @obviyus.
-- Retain refreshed credentials for matching custom agent directories ([#134862](https://github.com/openclaw/openclaw/pull/134862)). Thanks @Lendersmark.
-- Keep externally authenticated providers in model menus ([#135046](https://github.com/openclaw/openclaw/pull/135046)). Thanks @goslingmanagment.
-- Refresh model catalogs after credentials and settings change ([#135063](https://github.com/openclaw/openclaw/pull/135063)). Thanks @elikampf.
-- Show concise, redacted OAuth recovery errors in the Control UI ([#135112](https://github.com/openclaw/openclaw/pull/135112)). Thanks @shakkernerd.
-- Auto-enable configured Google and Vertex provider plugins ([#135239](https://github.com/openclaw/openclaw/pull/135239)). Thanks @Solvely-Colin.
-- Retain discovered models through compatible hot reloads ([#135353](https://github.com/openclaw/openclaw/pull/135353)). Thanks @goslingmanagment.
-- Repair stale OpenAI profile order after relogin ([#135355](https://github.com/openclaw/openclaw/pull/135355)). Thanks @obviyus, @mattcbianco.
-- Preserve custom-provider SecretRefs through Doctor repair ([#135357](https://github.com/openclaw/openclaw/pull/135357)). Thanks @obviyus, @dannevang.
-- Diagnose shared-auth relocation conflicts and clear forced-login owners ([#135739](https://github.com/openclaw/openclaw/pull/135739)). Thanks @Deregtx, @cksagente-dot.
-- Publish refreshed provider priority to a running Gateway ([#135847](https://github.com/openclaw/openclaw/pull/135847)). Thanks @josephbergvinson, @obviyus, @yetval.
-- Skip unused runtime discovery for read-only catalog queries ([#136020](https://github.com/openclaw/openclaw/pull/136020)). Thanks @609NFT, @LiuwqGit.
-- Recover setup and agent admission when a catalog owner is replaced (#127284) ([`bf599a7217`](https://github.com/openclaw/openclaw/commit/bf599a721784849e350c18ff703c9e75de939e0d)). Thanks @RomneyDa, @karkarl, @AndrewEAUS.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Provider Usage and Price Estimates">
-
-Provider status now has one genuinely useful addition for xAI users, with OAuth-authenticated SuperGrok accounts able to show usage, reset time, plan, and prepaid balance in the usual status surfaces when xAI supplies them. API-key billing remains a separate bucket. DeepInfra and Anthropic Vertex estimates also follow their current advertised and regional rates more closely, but these are OpenClaw estimates rather than a change to what either provider bills.
+The surrounding provider paths now fail and report more truthfully. Local and nested parents can see when a subagent completed on a different fallback model, though end-to-end non-disclosure to external destinations was not proven. Eligible OpenAI OAuth accounts can transcribe inbound voice notes and batch audio without a separate Platform API key, but access, quota, and billing remain account-specific and an upload failure does not silently switch providers. DeepInfra estimates now follow native advertised prices and discounts while leaving conditional or unavailable schedules unknown, with operator overrides still taking precedence and no change to provider billing or model availability. Linux deployments give managed local model and embedding services stronger shutdown and memory-pressure containment, while the shutdown proof is scoped to Linux and systemd, shell-controlled or carrier-collision fallback spawns do not receive the OOM preference, and provider recovery is not guaranteed. Claude CLI setup works through supported mise and asdf shims, but an argv0-dispatching shim may still choose a credential-consuming executable outside the verified runtime fingerprint, so that path retains a material security boundary.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Show SuperGrok usage for OAuth-authenticated xAI accounts ([#135766](https://github.com/openclaw/openclaw/pull/135766)). Thanks @steipete.
+- Load GitHub Copilot provider authentication without the broad agent runtime ([#134626](https://github.com/openclaw/openclaw/pull/134626)).
+- Identify OpenClaw consistently on native OpenCode Go routes ([#135588](https://github.com/openclaw/openclaw/pull/135588)). Thanks @VACInc.
+- Align managed Codex installs and release checks on 0.152.1 ([#136184](https://github.com/openclaw/openclaw/pull/136184)).
 
 **Bug fixes**
 
-- Refresh DeepInfra estimates from native pricing ([#134893](https://github.com/openclaw/openclaw/pull/134893)).
-- Keep Anthropic Vertex Sonnet 5 estimates on current regional rates ([#135761](https://github.com/openclaw/openclaw/pull/135761)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Model Retries and Fallbacks">
-
-Temporary provider failures now have one bounded retry owner, so a brief outage can recover quietly while a persistent one reaches the normal profile or model fallback path, or gives you an actionable error, within the retry window. A busy session stops after the first model candidate instead of making every fallback look broken, while hard Anthropic and Bedrock refusals stop immediately with revise-and-retry guidance rather than resending the request. Doctor can also remove a stale automatic OpenAI route without disturbing an intentional model choice.
-
-The recovery details matter just as much as the retry count. Affected llama.cpp context-limit failures can compact and retry, OpenAI Responses conversations keep compact continuation when tool lists or safely admitted large-integer arguments change, and pre-output transport failures can resume after completed tools without running them again. Provider and context diagnostics now survive more of these paths, while the official failover guide matches the controller that actually owns them.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Repair stale Doctor route pins without removing intentional choices ([#102180](https://github.com/openclaw/openclaw/pull/102180)). Thanks @849261680, @cpwilhelmi.
-- Keep context usage when Anthropic-compatible providers omit a cache counter ([#126473](https://github.com/openclaw/openclaw/pull/126473)). Thanks @ayaangazali, @Oliverbot26.
+- Retain context usage when an Anthropic-compatible provider writes only one valid cache counter ([#126473](https://github.com/openclaw/openclaw/pull/126473)). Thanks @ayaangazali, @Oliverbot26.
+- Preserve admitted channel identity through Codex prompt and compaction hooks ([#129402](https://github.com/openclaw/openclaw/pull/129402)). Thanks @ashawwal.
+- Bound managed llama.cpp server inspection responses ([#132490](https://github.com/openclaw/openclaw/pull/132490)). Thanks @RileyJJY.
+- Keep late CLI output from crashing the Gateway or changing a settled result ([#132582](https://github.com/openclaw/openclaw/pull/132582)). Thanks @TARSDrakon.
 - Preserve OpenAI Responses continuation when tool lists change ([#132951](https://github.com/openclaw/openclaw/pull/132951)). Thanks @hartmark.
-- Compact and retry current llama.cpp context-limit failures ([#133888](https://github.com/openclaw/openclaw/pull/133888)). Thanks @gokay-ai, @Areson.
-- Stop busy-session conflicts before cycling through fallbacks ([#134219](https://github.com/openclaw/openclaw/pull/134219)). Thanks @obviyus, @svdwalt007, @tzlwn1.
+- Reject corrupted text bytes in BytePlus and Volcengine speech responses ([#134010](https://github.com/openclaw/openclaw/pull/134010)). Thanks @ZengWen-DT.
+- Stop busy-session conflicts before cycling through model fallbacks ([#134219](https://github.com/openclaw/openclaw/pull/134219)). Thanks @obviyus, @svdwalt007, @tzlwn1.
 - Give transient model failures one bounded retry controller ([#134281](https://github.com/openclaw/openclaw/pull/134281)). Thanks @obviyus.
-- Preserve OpenAI Responses continuation across admitted tool arguments ([#134423](https://github.com/openclaw/openclaw/pull/134423)). Thanks @hartmark.
-- Stop retries and fallbacks after hard Anthropic and Bedrock refusals ([#134980](https://github.com/openclaw/openclaw/pull/134980)). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus.
-- Preserve safe provider details on failed chat events ([#135102](https://github.com/openclaw/openclaw/pull/135102)). Thanks @steipete.
-- Recover eligible pre-output transport failures without replaying completed tools ([#135105](https://github.com/openclaw/openclaw/pull/135105)).
+- Preserve OpenAI Responses continuation across admitted large-integer tool arguments ([#134423](https://github.com/openclaw/openclaw/pull/134423)). Thanks @hartmark.
+- Stop interrupting active Codex turns during quiet native work ([#134755](https://github.com/openclaw/openclaw/pull/134755)). Thanks @obviyus, @ernestrolfson-design.
+- Retain bounded, credential-redacted diagnostics from failed Claude subprocesses ([#134794](https://github.com/openclaw/openclaw/pull/134794)).
+- Stop managed local providers before Gateway shutdown completes ([#134890](https://github.com/openclaw/openclaw/pull/134890)). Thanks @MoerAI, @obviyus, @Deregtx.
+- Refresh DeepInfra estimates from native advertised pricing and discounts ([#134893](https://github.com/openclaw/openclaw/pull/134893)).
+- Stop retries and model fallback after hard Anthropic and Bedrock refusals ([#134980](https://github.com/openclaw/openclaw/pull/134980)). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus.
+- Preserve bounded provider details on failed chat events ([#135102](https://github.com/openclaw/openclaw/pull/135102)).
+- Continue eligible pre-output connection failures without replaying completed tools ([#135105](https://github.com/openclaw/openclaw/pull/135105)).
+- Explain unavailable model harnesses and their recovery paths ([#135118](https://github.com/openclaw/openclaw/pull/135118)). Thanks @fuller-stack-dev, @goslingmanagment.
+- Apply request timeouts to Local CLI speech synthesis ([#135222](https://github.com/openclaw/openclaw/pull/135222)).
 - Preserve the latest valid context reading from Anthropic-compatible proxies ([#135467](https://github.com/openclaw/openclaw/pull/135467)). Thanks @Yigtwxx.
+- Resolve the selected web-fetch provider before unrelated credential checks ([#135504](https://github.com/openclaw/openclaw/pull/135504)).
+- Show requested and effective models when a subagent completes through fallback ([#135531](https://github.com/openclaw/openclaw/pull/135531)). Thanks @MertBasar0, @obviyus, @nbarthelemy.
+- Report every current sibling's model reroute in a batched requester wake while preserving deduplication, ordering, stale-owner exclusion, and the 1,024-character notice cap ([`2ef043e`](https://github.com/openclaw/openclaw/commit/2ef043efe7d33cf99a18d0da0cb19bad86cec840)).
+- Stop persistent Codex conversations from using stale prompt-hook instructions ([#135577](https://github.com/openclaw/openclaw/pull/135577)).
+- Keep authored context caps through runtime provider aliases ([#135580](https://github.com/openclaw/openclaw/pull/135580)). Thanks @VACInc.
+- Route utility completions through the selected Claude CLI runtime ([#135711](https://github.com/openclaw/openclaw/pull/135711)). Thanks @goslingmanagment.
+- Diagnose shared-auth relocation conflicts and clear forced-login owners ([#135739](https://github.com/openclaw/openclaw/pull/135739)). Thanks @Deregtx, @cksagente-dot.
+- Restore audio transcription for eligible OpenAI OAuth accounts ([#135855](https://github.com/openclaw/openclaw/pull/135855)). Thanks @yungchentang, @kAIborg24.
+- Keep Codex replies working after sub-plugin policy changes ([#135863](https://github.com/openclaw/openclaw/pull/135863)). Thanks @vyctorbrzezowski.
+- Hide Codex node execution when no capable node is connected ([#136000](https://github.com/openclaw/openclaw/pull/136000)).
+- Hide CLI remote execution when no executable node is connected ([#136067](https://github.com/openclaw/openclaw/pull/136067)).
+- Give Codex-backed agents the configured user timezone across warm turns ([#136172](https://github.com/openclaw/openclaw/pull/136172)). Thanks @NianJiuZst, @obviyus, @davidcittadini.
+- Let idle Codex chats resume while unrelated work shares the app server ([#136196](https://github.com/openclaw/openclaw/pull/136196)).
+- Reuse watched Claude Code catalog snapshots between polls ([#136222](https://github.com/openclaw/openclaw/pull/136222)). Thanks @giangthb.
+- Open Codex and Claude Code from the catalog in a reconnectable native terminal ([#136230](https://github.com/openclaw/openclaw/pull/136230)).
+- Prefer managed local model and embedding services as the Linux OOM victim ([#136276](https://github.com/openclaw/openclaw/pull/136276)). Thanks @vincentkoc, @novahe.
+- Show persisted ACP runtime and model metadata for the selected agent ([#136280](https://github.com/openclaw/openclaw/pull/136280)).
+- Preserve native CLI continuity for queued cold follow-ups ([#136644](https://github.com/openclaw/openclaw/pull/136644)). Thanks @svdwalt007, @Isitjustmefromparis, @Tony-Clawbot.
+- Keep long and concurrent Codex streams connected through the final reply ([#136705](https://github.com/openclaw/openclaw/pull/136705)).
 
 **Documentation**
 
-- Align failover guidance with the current retry controller ([#135374](https://github.com/openclaw/openclaw/pull/135374)). Thanks @Marvinthebored, @obviyus.
+- Align model-failover guidance with the current retry controller and incomplete-turn behavior ([#135374](https://github.com/openclaw/openclaw/pull/135374)). Thanks @Marvinthebored, @obviyus.
 
-</details>
+**Limits and compatibility**
 
-</Accordion>
-
-<Accordion title="Codex and Claude CLI Work">
-
-Long-running Codex work no longer ends just because its progress is quiet, and finite time limits follow elapsed time without throwing away useful partial output. Idle Codex chats can resume while other chats and catalog reads share the same app server, and prompt-hook changes either take effect safely on the next persistent turn or stop before inference with a recovery path instead of silently keeping stale instructions.
-
-Claude CLI setup now works through supported mise and asdf shims, local Claude failures keep bounded credential-redacted diagnostics, and Claude CLI-backed utility models can produce digests, progress, and tool titles through the runtime that owns their authentication. Codex and CLI agents only offer remote shell execution when a connected node can actually run commands, existing broken harnesses explain which plugin needs attention, and the official plugin now aligns managed installs and checks on Codex 0.152.1. Claude Code session catalogs also avoid rescanning an unchanged projects tree on every poll, with the improvement depending on the size of the catalog, disk load, and watcher availability.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Align managed Codex installs and release checks on 0.152.1 ([#136184](https://github.com/openclaw/openclaw/pull/136184)). Thanks @steipete.
-- Reuse watched Claude Code catalog snapshots between polls ([#136222](https://github.com/openclaw/openclaw/pull/136222)). Thanks @giangthb.
-
-**Bug fixes**
-
-- Preserve admitted channel identity through Codex hooks and compaction ([#129402](https://github.com/openclaw/openclaw/pull/129402)). Thanks @ashawwal.
-- Keep late CLI output from crashing the Gateway after timeout ([#132582](https://github.com/openclaw/openclaw/pull/132582)). Thanks @TARSDrakon.
-- Stop interrupting active Codex turns during quiet native work ([#134755](https://github.com/openclaw/openclaw/pull/134755)). Thanks @obviyus, @ernestrolfson-design.
-- Avoid a redundant legacy model key after Claude CLI activation ([#134779](https://github.com/openclaw/openclaw/pull/134779)). Thanks @leilei3167, @obviyus, @aaajiao.
-- Retain credential-redacted diagnostics from failed Claude subprocesses ([#134794](https://github.com/openclaw/openclaw/pull/134794)).
-- Explain unavailable model harnesses and their recovery paths ([#135118](https://github.com/openclaw/openclaw/pull/135118)). Thanks @fuller-stack-dev, @goslingmanagment.
-- Let Claude CLI connect through supported PATH shims ([#135124](https://github.com/openclaw/openclaw/pull/135124)). Thanks @zhangguiping-xydt, @obviyus, @masatokawano.
-- Stop using stale instructions after Codex prompt-hook changes ([#135577](https://github.com/openclaw/openclaw/pull/135577)).
-- Route utility completions through the selected runtime ([#135711](https://github.com/openclaw/openclaw/pull/135711)). Thanks @goslingmanagment.
-- Hide Codex node execution when no capable node is connected ([#136000](https://github.com/openclaw/openclaw/pull/136000)).
-- Hide CLI remote execution when no executable node is connected ([#136067](https://github.com/openclaw/openclaw/pull/136067)).
-- Let idle Codex chats resume while unrelated chats keep running ([#136196](https://github.com/openclaw/openclaw/pull/136196)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Local and Self-Hosted Models">
-
-Self-hosted model routes now behave more like services OpenClaw can actually live with. Existing llama.cpp-compatible web apps can fall back to `/v1/models` when their root models endpoint serves HTML or unusable data, managed diagnostics stop reading oversized response bodies without a bound, and OpenClaw waits for managed local model processes to stop before finishing shutdown. The shutdown proof is scoped to Linux and systemd, and the discovery fallback was exercised at the provider boundary rather than as a complete Unsloth inference run.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Bound managed llama.cpp diagnostic responses ([#132490](https://github.com/openclaw/openclaw/pull/132490)). Thanks @RileyJJY, @steipete.
-- Stop managed local providers before Gateway shutdown completes ([#134890](https://github.com/openclaw/openclaw/pull/134890)). Thanks @MoerAI, @obviyus, @Deregtx.
-- Discover models behind llama.cpp-compatible web app endpoints ([#135445](https://github.com/openclaw/openclaw/pull/135445)). Thanks @gaoanze888, @Bloodis94.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Provider-Backed Tools">
-
-Provider choice now carries more cleanly into the tools around a conversation. Native Model Studio and Qwen routes honor prompt-cache retention, a selected web-fetch provider no longer trips over credentials for providers it never intended to use, and Local CLI speech generation follows the request timeout. Corrupted Volcengine speech responses fail clearly, while eligible OpenAI OAuth accounts can again transcribe inbound voice notes and configured batch audio without a separate API key. OAuth entitlement and quota are still account-specific, and custom Model Studio proxies remain opt-in for cache markers.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Reject corrupted text bytes in Volcengine TTS responses ([#134010](https://github.com/openclaw/openclaw/pull/134010)). Thanks @ZengWen-DT.
-- Honor Model Studio cache defaults and retention ([#135093](https://github.com/openclaw/openclaw/pull/135093)).
-- Apply request timeouts to Local CLI speech generation ([#135222](https://github.com/openclaw/openclaw/pull/135222)).
-- Resolve the selected web-fetch provider before unrelated credential checks ([#135504](https://github.com/openclaw/openclaw/pull/135504)).
-- Restore OpenAI OAuth audio transcription ([#135855](https://github.com/openclaw/openclaw/pull/135855)). Thanks @yungchentang, @kAIborg24.
+- Support Claude CLI setup through mise and asdf PATH shims while retaining the argv0 dispatch boundary ([#135124](https://github.com/openclaw/openclaw/pull/135124)). Thanks @zhangguiping-xydt, @obviyus, @masatokawano.
 
 </details>
 
@@ -1176,137 +927,75 @@ Provider choice now carries more cleanly into the tools around a conversation. N
 
 ## Automations and Scheduling
 
-[Scheduled work](/automation/cron-jobs) now keeps more of its identity from creation through delivery. An automation can begin with the access somebody already configured, make it through a restart without quietly becoming a different job, and leave a result that is easier to find and understand afterward. Recurring work also gets a deliberate choice about missed jobs, while one-time jobs keep their separate recovery behavior.
+[Scheduled work](/automation/cron-jobs) now has a clearer life from the moment you create a job through its next run, restart, and final delivery. OpenClaw is more careful about keeping the schedule you chose, recovering work that was interrupted, and telling you whether a result was delivered, deliberately silent, or still uncertain, which means fewer jobs that look finished while their useful result has gone missing.
 
 <AccordionGroup>
 
-<Accordion title="Creating Automations with Existing Access">
+<Accordion title="Schedule recovery after restarts and upgrades">
 
-Configured Codex app-server users can create app-backed automations through the authenticated connection they already use, without preparing a second OpenClaw profile or supplying a separate tool allowlist. Reauthenticating the same endpoint keeps the automation usable, while a removed endpoint, changed connection identity, unavailable plugin, or newly disallowed app or tool stops before app work and leaves an actionable recorded failure.
+One-time jobs now keep their latest retry time through a restart, immediate one-shot jobs can still wake the selected agent when periodic heartbeats are disabled, and Cron retries stay active until the underlying work has actually settled. Recurring jobs gain a separate choice for downtime through `cron.skipMissedJobs` set to `true`, which advances an overdue schedule to its next future run instead of replaying stale reminders or digests. That setting is off by default, it deliberately drops the missed occurrences when enabled, and it never skips one-time jobs.
 
-Creation now also returns the resolved announcement route or the reason it failed closed before the job is saved, so an operator can fix delivery before trusting it. Integrations that call CronService directly can switch a job between command, script, and agent-turn payloads without inventing omitted optional fields, while malformed environments remain rejected.
+Older schedules are handled more carefully too. Upgrades preserve whether a legacy job was enabled, malformed rows are quarantined with a reason while valid jobs keep loading, and uncommon expanded-year dates retain their selected time zone. The migration cannot reconstruct enabled state for a database that already passed through the earlier faulty path, and quarantine is deliberately safer than guessing what a malformed job was meant to do.
 
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Create app-backed automations with configured Codex app-server authentication ([#134525](https://github.com/openclaw/openclaw/pull/134525)). Thanks @sjf-oa.
-- Preserve optional fields when direct CronService callers change a job's payload kind ([#134639](https://github.com/openclaw/openclaw/pull/134639)). Thanks @solomonneas.
-- Show the resolved announcement route or fail-closed reason when an isolated job is created ([#135003](https://github.com/openclaw/openclaw/pull/135003)). Thanks @ericcaiwx-star, @obviyus.
-
-</details>
-
-</Accordion>
-
-<Accordion title="One-Time Schedules Through Restarts and Unusual Dates">
-
-One-time jobs keep their newer retry time when the Gateway restarts, and an immediate main-session job can still wake its selected agent when periodic heartbeats are disabled. Successful one-shot jobs configured for deletion are removed as expected rather than being left behind in a disabled state.
-
-Older schedules are handled more carefully too. Upgrades that have not yet completed the affected legacy migration preserve whether a job was enabled, malformed legacy rows are quarantined without preventing valid jobs from loading, and expanded-year one-time dates honor their selected time zone and display the correct year. The migration repair does not reconstruct enabled state for databases that already passed through the earlier faulty v13 path.
+The surrounding details now keep more of the same identity. Creation shows the resolved announcement route or the reason delivery will fail closed, recipient suggestions stop mixing in account identities that cannot receive a result, restricted operators get complete pages of the history they are allowed to see, and scheduled backups can still be disabled after a rename or when they sit deep in a large job list. System heartbeats also return to their configured provider after a clean restart, without adding a broader retry or fallback promise.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
+**Improvements**
+
+- Add an opt-in choice to skip missed recurring jobs after downtime while leaving one-time jobs unchanged ([#135071](https://github.com/openclaw/openclaw/pull/135071)).
+
 **Bug fixes**
 
-- Preserve legacy automation enabled state while upgrading older databases ([#132868](https://github.com/openclaw/openclaw/pull/132868)). Thanks @CanReader, @obviyus.
+- Preserve legacy jobs' enabled or disabled state during schema migration ([#132868](https://github.com/openclaw/openclaw/pull/132868)). Thanks @CanReader, @obviyus.
+- Keep account identities out of scheduled-delivery recipient suggestions ([#134368](https://github.com/openclaw/openclaw/pull/134368)). Thanks @BryanTegomoh, @rogerallen1.
+- Let cancelled work settle promptly while Cron retries continue until execution really ends, with related New Session and safe browser Fetch continuation recovery ([#133747](https://github.com/openclaw/openclaw/pull/133747)). Thanks @shakkernerd.
+- Preserve optional fields when direct CronService integrations change a job's payload kind ([#134639](https://github.com/openclaw/openclaw/pull/134639)). Thanks @solomonneas.
 - Run immediate one-shot main-session jobs when periodic heartbeats are disabled ([#134648](https://github.com/openclaw/openclaw/pull/134648)). Thanks @sunlit-deng, @obviyus, @LowCode191.
-- Keep a one-time job's durable retry time through Gateway startup recovery ([#135083](https://github.com/openclaw/openclaw/pull/135083)). Thanks @rwinkelman, @obviyus, @meircohen.
-- Quarantine invalid legacy schedule rows without blocking valid jobs ([#135829](https://github.com/openclaw/openclaw/pull/135829)). Thanks @teddytennant, @obviyus.
-- Apply selected time zones and correct year display to expanded-year one-time dates ([#135973](https://github.com/openclaw/openclaw/pull/135973)).
+- Show a resolved announcement route or fail-closed reason before saving an isolated job ([#135003](https://github.com/openclaw/openclaw/pull/135003)). Thanks @ericcaiwx-star, @obviyus.
+- Keep a one-time job's durable retry time through startup recovery ([#135083](https://github.com/openclaw/openclaw/pull/135083)). Thanks @rwinkelman, @obviyus, @meircohen.
+- Quarantine invalid legacy rows without preventing valid schedules from loading ([#135829](https://github.com/openclaw/openclaw/pull/135829)). Thanks @teddytennant, @obviyus.
+- Apply the selected time zone and correct year display to expanded-year one-time dates ([#135973](https://github.com/openclaw/openclaw/pull/135973)).
+- Page automation history after applying the operator's existing session visibility ([#136043](https://github.com/openclaw/openclaw/pull/136043)).
+- Find managed backup schedules by stable identity across renames and complete inventories ([#136133](https://github.com/openclaw/openclaw/pull/136133)).
+- Keep scheduled system heartbeats connected to their configured provider after a restart ([#136256](https://github.com/openclaw/openclaw/pull/136256)). Thanks @obviyus, @Famyoff.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Choosing What Happens to Missed Recurring Jobs">
+<Accordion title="Delivery, heartbeats, and child-session completion">
 
-Operators who do not want stale reminders, digests, or model calls after downtime can enable `cron.skipMissedJobs: true`. On startup, OpenClaw advances overdue recurring schedules to their next future occurrence and saves that decision before normal scheduling resumes. The setting is opt-in, so leaving it unset or false preserves the existing catch-up behavior, and one-time jobs are not skipped.
+A completed background job is not necessarily a delivered result, so the Tasks view now distinguishes a confirmed handoff from an uncertain one or a result intentionally blocked by policy instead of crediting every completion as delivered. Cron results and child-session announcements can retry a temporary adapter failure only while OpenClaw can prove the send never started. Once delivery may have begun, the outcome remains uncertain rather than risking a duplicate, and settled failure alerts now show whether they were delivered, not delivered, or genuinely unknown.
 
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
+Intentional silence is clearer as well. A scheduled job that finishes successful tool work with `NO_REPLY` stays silent, while agents can explicitly start fire-and-forget child sessions that do not interrupt the requester when they finish. Swarm collectors and thread-bound child sessions now receive instructions that match how their results really arrive, and finished isolated jobs clean up the run-specific sessions they no longer need.
 
-**Improvements**
+Configured Codex app-server users can also create app-backed automations through the authenticated connection they already use, without preparing a second OpenClaw profile or manually repeating a tool allowlist. The saved authority is checked again before a run, so removing the endpoint, changing its identity, losing the plugin, or tightening app or tool policy stops before app work and leaves an inspectable failure. Same-endpoint reauthentication remains usable, but the final proof did not cover a live external connector backend, and the wider delivery repairs were not verified across every channel.
 
-- Add an opt-in setting to skip missed recurring jobs after downtime ([#135071](https://github.com/openclaw/openclaw/pull/135071)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Heartbeat Routes, Quiet Replies, and Deadlines">
-
-Scheduled agent work now keeps model aliases attached to the selected agent, and system-owned heartbeats can reach their configured provider after a clean Gateway restart by using the currently published runtime. Long or unlimited heartbeat runs honor the configured deadline instead of inheriting a fixed ten-minute cutoff, while destination-only wakes retain the rest of the configured heartbeat behavior.
-
-The delivery edges are quieter and more accurate as well. An explicit `NO_REPLY` after successful tool work stays silent, the first-alert explanation appears only on the first alert for an isolated default route, and bounded `agents_wait` calls keep their requested duration when the system clock moves forward or backward.
+Heartbeat work follows the same more truthful shape. Long or unlimited runs honor their configured deadline, the first-alert explanation appears once, administrators can inspect the stored checklist in the read-only monitor, and scheduled model aliases stay with the selected agent. Automation links also open the intended job and highlighted run beyond the current list page or agent filter, with a visible error when the job is unavailable.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Keep scheduled model aliases scoped to the selected agent ([#135069](https://github.com/openclaw/openclaw/pull/135069)). Thanks @elikampf.
-- Measure `agents_wait` deadlines consistently through system clock changes ([#135292](https://github.com/openclaw/openclaw/pull/135292)). Thanks @qingminglong, @steipete.
-- Show the first-alert explanation once for isolated default routes ([#135849](https://github.com/openclaw/openclaw/pull/135849)). Thanks @obviyus, @rwinkelman, @virtexvirtuoso.
-- Preserve deliberate silent completion after scheduled tool work ([#135919](https://github.com/openclaw/openclaw/pull/135919)). Thanks @leilei3167, @obviyus, @Frank683456.
-- Honor configured finite and unlimited heartbeat deadlines ([#135925](https://github.com/openclaw/openclaw/pull/135925)). Thanks @xialonglee, @obviyus, @jaxonparrott.
-- Bind scheduled system heartbeats to the published runtime after restart ([#136256](https://github.com/openclaw/openclaw/pull/136256)). Thanks @obviyus, @Famyoff.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Automation Links, History, and Alerts">
-
-An Automations link now opens the intended job and highlighted run even when that job sits beyond the loaded page or outside the current agent filter, with a visible lookup error when it is no longer available. Session-restricted operators receive complete pages and accurate totals for the run history they are allowed to see, while large name-sorted job lists avoid repeating the same locale setup for every comparison.
-
-Schedule and history durations also keep all meaningful units across locales, and a settled failure alert appears as delivered, not delivered, or genuinely unknown in the live job view. Confirmed non-delivery retains a bounded redacted error and the existing in-app fallback, while immutable run-history entries remain unchanged.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Reuse locale-aware comparison work within large name-sorted job lists ([#135597](https://github.com/openclaw/openclaw/pull/135597)).
 
 **Bug fixes**
 
 - Show complete duration quantities across localized schedules and run history ([#133224](https://github.com/openclaw/openclaw/pull/133224)).
-- Persist settled failure-alert outcomes in live automation status ([#135516](https://github.com/openclaw/openclaw/pull/135516)). Thanks @RayWangyangMa, @obviyus, @bassmediagroup.
-- Open linked jobs and highlighted runs beyond the loaded list or active filter ([#136012](https://github.com/openclaw/openclaw/pull/136012)). Thanks @steipete.
-- Page run history after applying existing session-visibility rules ([#136043](https://github.com/openclaw/openclaw/pull/136043)). Thanks @steipete.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Completed Automation Session Cleanup">
-
-Successful isolated jobs now release their run ownership before removing an unused continuation session, avoiding the stale row and misleading competing-work warning that could remain after completion. Generated-media jobs use the same ordering before the final Gateway response, with cleanup kept to the lifecycle that owns the run.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Remove unused isolated-job continuation sessions after successful completion ([#135155](https://github.com/openclaw/openclaw/pull/135155)). Thanks @brettdaman, @obviyus.
-- Clean up generated-media run sessions before the final Gateway response ([#135517](https://github.com/openclaw/openclaw/pull/135517)). Thanks @jmewing, @obviyus, @goslingmanagment, @giangthb.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Disabling Managed Scheduled Backups">
-
-`openclaw backup disable` can find the managed backup after its schedule has been renamed or moved beyond the first 200 jobs in a larger automation inventory. It follows the schedule's stable declaration identity, so an unrelated automation with the same name is left alone.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Find managed backup schedules by stable identity across renames and complete inventories ([#136133](https://github.com/openclaw/openclaw/pull/136133)).
+- Distinguish confirmed, uncertain, and policy-suppressed child-session delivery in Tasks ([#136524](https://github.com/openclaw/openclaw/pull/136524)). Thanks @Cobblestone-Digital1.
+- Expose the existing fire-and-forget child-session option to agents and document how it behaves ([#136570](https://github.com/openclaw/openclaw/pull/136570)). Thanks @alfredjbclaw.
+- Match Swarm and child-session completion guidance to the actual result-delivery path ([#133660](https://github.com/openclaw/openclaw/pull/133660)).
+- Create app-backed scheduled jobs with configured Codex app-server authentication and recheck saved authority before execution ([#134525](https://github.com/openclaw/openclaw/pull/134525)). Thanks @sjf-oa.
+- Keep scheduled model aliases scoped to the selected agent in multi-workspace setups ([#135069](https://github.com/openclaw/openclaw/pull/135069)). Thanks @elikampf.
+- Remove unused run-specific continuation sessions after successful isolated jobs finish ([#135155](https://github.com/openclaw/openclaw/pull/135155)). Thanks @brettdaman, @obviyus.
+- Keep `agents_wait` deadlines accurate when the system clock changes ([#135292](https://github.com/openclaw/openclaw/pull/135292)). Thanks @qingminglong.
+- Show an administrator the stored heartbeat checklist in the read-only Automations monitor ([#135508](https://github.com/openclaw/openclaw/pull/135508)). Thanks @gaoanze888, @obviyus, @itsuzef.
+- Persist settled failure-alert delivery outcomes in live automation status ([#135516](https://github.com/openclaw/openclaw/pull/135516)). Thanks @RayWangyangMa, @obviyus, @bassmediagroup.
+- Clean up generated-media run sessions after delivery settles ([#135517](https://github.com/openclaw/openclaw/pull/135517)). Thanks @jmewing, @obviyus, @goslingmanagment, @giangthb.
+- Show the first-alert explanation once for isolated heartbeat routes ([#135849](https://github.com/openclaw/openclaw/pull/135849)). Thanks @obviyus, @rwinkelman, @virtexvirtuoso.
+- Preserve deliberate silent completion after scheduled tool work ([#135919](https://github.com/openclaw/openclaw/pull/135919)). Thanks @leilei3167, @obviyus, @Frank683456.
+- Honor configured finite and unlimited heartbeat deadlines while retaining destination-only wake settings ([#135925](https://github.com/openclaw/openclaw/pull/135925)). Thanks @xialonglee, @obviyus, @jaxonparrott.
+- Retry temporary proven-not-sent adapter failures without retrying ambiguous or already-dispatched sends ([#135985](https://github.com/openclaw/openclaw/pull/135985)). Thanks @gaoanze888, @obviyus, @yetval.
+- Open linked jobs and highlighted runs beyond the loaded page or active agent filter ([#136012](https://github.com/openclaw/openclaw/pull/136012)).
 
 </details>
 
@@ -1316,105 +1005,86 @@ Successful isolated jobs now release their run ownership before removing an unus
 
 ## Browser and Computer Use
 
-Browser control is more predictable from the first local screenshot to an attached Chrome tab or a remote desktop. Standalone agents can reach the local browser without borrowing Gateway credentials, selected tabs keep valid commands through ordinary group changes, paired-machine actions report where they ran, and Chrome MCP endpoint checks happen before a connection begins.
+Browser work now stays closer to the tab, page, and machine it was meant for. OpenClaw can cancel supported actions without knocking unrelated tabs offline, keep tab-heavy Chrome and Brave sessions usable, take complete screenshots without upsetting mobile emulation, and stop before acting when a browser endpoint or paired node is not the one the operator allowed.
+
+Computer use gets the same tighter ownership. Commands report which capable node ran them, duplicate node names require an explicit choice, Mac input and screenshot coordinates line up more reliably, and a Windows remote desktop can hand control back and forth without dropping the only authenticated viewer.
 
 <AccordionGroup>
 
-<Accordion title="Local Browser Runs and Screenshots">
+<Accordion title="Browser tabs, screenshots, web search, and endpoint policy">
 
-Standalone agents with the `browser` tool enabled now default to the local browser when no Gateway or node route was selected. Viewport, full-page, and element screenshots capture through the page session that owns the current device settings, preserving mobile scale and touch behavior, while an interrupted Chromium capture returns a recovery error instead of leaving later screenshots or resizes stuck.
+[Browser control](/tools/browser-control) now keeps pending clicks, typing, and uploads with their selected page, so cancelling one supported action does not disconnect work in another tab or let the cancelled action take effect later. Newly created tabs keep their authority through ordinary group setup, genuine access changes still revoke stale work, and tab listing gets enough time to finish in healthy Chrome or Brave extension sessions with many allowed tabs. Malformed form-fill requests also fail before changing the page, while an unexpected sessionless browser-worker event no longer has to take the Gateway and its active browser sessions down with it.
 
-That host-first default is an intentional change for unpinned standalone runs. Anyone who relied on implicit browser-node discovery should select `auto` or an explicit node, and full-page capture after pinch zoom remains a Chromium edge case. Malformed form-fill requests also stop before changing the page and identify the unsupported field instead of silently accepting only part of the request.
+Standalone agents whose policy allows browser use now default to the local browser when no Gateway or node route was selected. Screenshot capture stays with the page that owns its viewport, which keeps viewport, full-page, and element captures complete while preserving mobile scale and touch settings, and interrupted captures stop with a recovery error instead of leaving later screenshot or resize work stuck. People who relied on implicit node discovery from a standalone run now need to select automatic node routing or a specific node explicitly.
 
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Reject unsupported browser form fields before changing the page ([#131400](https://github.com/openclaw/openclaw/pull/131400)). Thanks @LiuwqGit, @obviyus, @srb11e.
-- Route standalone agents to the local browser and return complete, recoverable screenshots ([#135315](https://github.com/openclaw/openclaw/pull/135315)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Selected Chrome Tabs and Existing Sessions">
-
-Selected-tab automation now keeps newly admitted commands valid while older group lookups finish and while a new tab goes through normal group setup. Genuine access changes still revoke stale work, restored access can recover, and a tab created during a relay disconnect is cleaned up instead of being left behind.
-
-Existing-session attachments now use the reviewed Chrome DevTools MCP 1.8.0 release rather than following a moving `latest` tag. Custom launch commands remain operator-managed, while offline hosts need that exact package cached or an operator-provided executable.
+Existing-session Chrome attachments resolve the effective MCP endpoint before launch, apply hostname policy to that endpoint, and use the same address for tab ownership and cleanup. The built-in launcher is pinned to the reviewed Chrome DevTools MCP 1.8.0 contract rather than following a moving latest release, while custom executables remain operator controlled. Brave and Tavily search results also preserve valid absolute publication dates, making freshness-sensitive work more useful without treating relative ages, fetch times, or arbitrary date-like text as publication metadata.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Preserve selected-tab commands when an older group lookup finishes late ([#135186](https://github.com/openclaw/openclaw/pull/135186)).
-- Keep new Chrome tabs authorized through ordinary group setup and clean up interrupted creations ([#135210](https://github.com/openclaw/openclaw/pull/135210)).
-- Pin default existing-session attachments to the reviewed Chrome MCP release ([#136121](https://github.com/openclaw/openclaw/pull/136121)). Thanks @steipete.
+- Reject unsupported browser form-fill fields before changing the page [#131400](https://github.com/openclaw/openclaw/pull/131400) — by [@LiuwqGit](https://github.com/LiuwqGit), with thanks to [@obviyus](https://github.com/obviyus) and [@srb11e](https://github.com/srb11e)
+- Keep attached-browser sessions alive after malformed sessionless worker events [#134853](https://github.com/openclaw/openclaw/pull/134853) — by [@cmanrav](https://github.com/cmanrav), with thanks to [@obviyus](https://github.com/obviyus)
+- Preserve valid selected-tab commands through ordinary tab-group updates [#135186](https://github.com/openclaw/openclaw/pull/135186)
+- Keep new Chrome tabs usable while revoking and cleaning up genuinely stale work [#135210](https://github.com/openclaw/openclaw/pull/135210)
+- Let tab listing finish in healthy Chrome and Brave sessions with many allowed tabs [#135219](https://github.com/openclaw/openclaw/pull/135219) — by [@SunnyShu0925](https://github.com/SunnyShu0925), with thanks to [@obviyus](https://github.com/obviyus) and [@alexph-dev](https://github.com/alexph-dev)
+- Route unpinned standalone browser work locally and preserve complete screenshots and emulation state [#135315](https://github.com/openclaw/openclaw/pull/135315)
+- Preserve valid Brave and Tavily publication dates in web-search results [#136017](https://github.com/openclaw/openclaw/pull/136017) — with thanks to [@rogerallen1](https://github.com/rogerallen1)
+- Cancel supported browser actions and uploads without disrupting unrelated tabs [#136465](https://github.com/openclaw/openclaw/pull/136465)
+
+**Security and trust**
+
+- Apply Browser hostname policy to the Chrome MCP endpoint actually used [#135857](https://github.com/openclaw/openclaw/pull/135857)
+- Pin default existing-session attachments to reviewed Chrome DevTools MCP 1.8.0 [#136121](https://github.com/openclaw/openclaw/pull/136121)
+
+**Limits and compatibility**
+
+- Cancellation covers pending locator clicks, typing, and uploads, not raw keyboard or mouse primitives, arbitrary scheduled page code, or changes that already completed.
+- Full-page capture after pinch zoom and a separate early-reconnect empty-target case remain unresolved.
+- Offline hosts need Chrome DevTools MCP 1.8.0 already cached or an operator-managed executable, and custom launch commands remain operator controlled.
+- Publication dates are limited to valid absolute metadata from Brave and Tavily, and upstream provider behavior was verified without authenticated provider calls.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Paired Computers and Remote Desktops">
+<Accordion title="Computer use, remote desktops, and node targeting">
 
-Commands sent to paired nodes now consider only connected machines that can actually execute them. OpenClaw selects a node automatically only when one eligible target remains, asks for an explicit choice when several qualify, and includes the effective node in successful, failed, and timed-out results instead of silently redirecting work to the wrong computer.
+Node-host commands now consider only paired, connected machines that can actually execute them, choose automatically only when one eligible machine remains, and report the effective node with successful, failed, and timed-out results. If several current nodes share a name, OpenClaw returns their exact IDs instead of guessing, while a CLI node using the Gateway installation's own signed identity is recognized as local without folding separately paired nodes into it.
 
-Computer input is more faithful to what the agent and user can see. Successful typing and key actions on paired macOS Peekaboo nodes report success after the action occurs, screenshot-grounded clicks share one bounded frame across unusual capture shapes, smaller-Mac Settings can resize and scroll, and multiline WebVNC text keeps its line breaks. Windows remote-desktop handoff retains the authenticated TightVNC viewer until its replacement is ready, while large macOS CUA Computer responses use less temporary memory without changing the existing response limit or setup.
+On macOS, typing and key actions through paired Peekaboo nodes return success after they execute instead of inviting a duplicate retry, documented Command shortcuts select correctly, and large fragmented CUA responses require less temporary copying and peak memory on the measured path. Screenshot-grounded coordinates now stay aligned across compact, portrait, Retina, rounded, and one-pixel captures. The same repair makes Settings usable on a 1024 by 768 display, preserves pasted WebVNC line breaks, and avoids the affected Mac discovery teardown crash.
+
+Windows remote desktops can switch between view-only and control while keeping the existing authenticated viewer connected but unable to send input until its replacement is ready. That handoff was exercised with Windows Server 2022 and TightVNC, not macOS ARD, while the paired Mac input boundary was proven in an isolated signed producer-consumer setup rather than a complete packaged-app run. Browser Talk also keeps newly generated consultation prompts out of later model context without removing genuine speech, assistant results, or lossless exports, and agent guidance now distinguishes widgets, dashboards, portals, and separate browser previews while requiring unverified interaction to be disclosed as such.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Reduce temporary memory pressure for large macOS CUA Computer responses ([#135094](https://github.com/openclaw/openclaw/pull/135094)).
+- Reduce temporary copying and peak memory for large fragmented macOS CUA responses [#135094](https://github.com/openclaw/openclaw/pull/135094)
 
 **Bug fixes**
 
-- Report completed macOS typing and key actions as successful ([#134689](https://github.com/openclaw/openclaw/pull/134689)). Thanks @gaoanze888, @wbstrbt.
-- Keep the authenticated Windows desktop viewer during control handoff ([#134903](https://github.com/openclaw/openclaw/pull/134903)).
-- Align desktop actions with their screenshots and improve small-screen Settings and WebVNC text entry ([#135582](https://github.com/openclaw/openclaw/pull/135582)).
+- Return successful Mac computer input without inviting duplicate retries [#134689](https://github.com/openclaw/openclaw/pull/134689) — by [@gaoanze888](https://github.com/gaoanze888), with thanks to [@wbstrbt](https://github.com/wbstrbt)
+- Keep Windows remote desktops connected through view-only and control handoffs [#134903](https://github.com/openclaw/openclaw/pull/134903)
+- Align computer-use screenshots and coordinates, preserve WebVNC line breaks, and make Mac Settings fit smaller displays [#135582](https://github.com/openclaw/openclaw/pull/135582)
+- Restore Mac Command shortcuts and harden native and portable worker packaging [#136018](https://github.com/openclaw/openclaw/pull/136018)
+- Guide agents to distinguish embedded UI surfaces from browser previews and disclose unverified delivery [#136195](https://github.com/openclaw/openclaw/pull/136195)
+- Classify same-install CLI nodes as local without merging independently paired nodes [#136604](https://github.com/openclaw/openclaw/pull/136604)
+- Preserve ambiguity when current node clients share a display name [#136636](https://github.com/openclaw/openclaw/pull/136636)
 
 **Security and trust**
 
-- Select only capable execution nodes, require a choice when several qualify, and report the target ([#131767](https://github.com/openclaw/openclaw/pull/131767)). Thanks @vyctorbrzezowski.
+- Select only capable node-execution targets and stop on ambiguity before dispatch [#131767](https://github.com/openclaw/openclaw/pull/131767) — by [@vyctorbrzezowski](https://github.com/vyctorbrzezowski)
+- Keep Browser Talk's generated consult prompts out of later model context [#135423](https://github.com/openclaw/openclaw/pull/135423) — with thanks to [@Conan-Scott](https://github.com/Conan-Scott)
 
-</details>
+**Limits and compatibility**
 
-</Accordion>
-
-<Accordion title="Browser Policy and Private Talk Context">
-
-Custom Chrome MCP endpoint arguments now pass through the same hostname policy as the endpoint OpenClaw will actually use, before a subprocess or network connection begins. Unsafe, malformed, empty, duplicate, or conflicting arguments fail clearly without echoing credential-bearing URLs, while trusted overrides and host-local attachment continue to work.
-
-New Browser Talk conversations also keep the internal consultation question, context, and speaking instructions out of later model turns while preserving genuine speech, assistant results, and lossless exports. Existing unflagged records are not rewritten, and the separate decision about how a consultation answer should be presented remains open.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Security and trust**
-
-- Keep new Browser Talk consultation prompts out of later model context ([#135423](https://github.com/openclaw/openclaw/pull/135423)). Thanks @Conan-Scott.
-- Apply hostname policy to the effective Chrome MCP endpoint before connecting ([#135857](https://github.com/openclaw/openclaw/pull/135857)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Search Dates and Presented Browser Output">
-
-Brave and Tavily search results now preserve valid absolute publication dates in the existing `published` field, helping freshness-sensitive work distinguish when a source was published without treating relative ages, fetch times, arbitrary text, or search filters as publication dates.
-
-Agents also receive clearer guidance for presenting a widget, dashboard, portal, or separate browser preview. The guidance keeps token-bearing launch links private, uses the presentation surface that is actually available, and says when an interaction was not verified. This changes how existing tools are described and selected, not what they can render or which tools are available.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Preserve valid Brave and Tavily publication dates for freshness-sensitive searches ([#136017](https://github.com/openclaw/openclaw/pull/136017)). Thanks @rogerallen1.
-- Distinguish widgets, dashboards, portals, and browser previews while keeping launch links private ([#136195](https://github.com/openclaw/openclaw/pull/136195)).
+- The automatic same-name legacy migration exception remains only when every competing node client is known to be legacy.
+- Large-response memory evidence is limited to the tested macOS response size and host and does not establish broader Gateway performance.
+- Existing Browser Talk records without the new exclusion marker remain eligible for later context, and separate answer-presentation behavior remains unresolved.
+- Presentation guidance does not add rendering tools or authentication, and generated previews remain unverified until someone exercises the delivered interaction.
 
 </details>
 
@@ -1424,236 +1094,138 @@ Agents also receive clearer guidance for presenting a widget, dashboard, portal,
 
 ## Plugins and Integrations
 
-Plugins now behave more like installed software that stays under the operator's control. Updates preserve reviewed state, managed provider removals remain removed after restart, channel setup follows the agent that was actually selected, and the integrations around them do a better job of keeping credentials, errors, and cleanup inside the right boundary.
+Plugins are easier to install, update, inspect, and remove without letting a convenient recovery path quietly change who owns the code or what it may do. The integrations built on top of them also keep more of their identity and state intact, from a personal GitHub account on a shared Gateway to MCP tools, dashboards, external channels, and plugin-owned transcripts.
 
 <AccordionGroup>
 
-<Accordion title="Plugin State Through Installs and Updates">
+<Accordion title="Plugin install, update, consent, disablement, and cleanup">
 
-Verified first-party plugins can move through installation, updates, re-enablement, and Doctor repair without stopping for a capability prompt that OpenClaw can already resolve from matching catalog, package, and source identity. That exception remains deliberately narrow, so local artifacts, third-party packages, custom registries, and conflicting or incomplete provenance still require explicit review.
+[Plugin management](/plugins/manage-plugins) now treats the operator's decisions as durable state. An uninstalled managed plugin stays uninstalled after a restart, reinstalling a disabled plugin leaves it disabled until someone explicitly enables it, and setting a channel's `enabled` value to `false` keeps that channel plugin and all of its contributions inactive even when an older plugin entry still says otherwise. Updates from verified first-party sources can skip the blanket capability prompt only when the package and every available official source record agree. Local artifacts, custom registries, conflicting provenance, changed third-party capabilities, and incomplete identity still require review or stop safely, and that first-party exemption does not grant OAuth, operating-system, or runtime tool permissions.
 
-Older installs also behave more predictably. Capability acceptance is saved against the replacement artifact during a legacy update, reinstalling a deliberately disabled plugin leaves it disabled until the operator enables it, and registry or inventory reads no longer mistake build-only metadata for a changed plugin. Catalog work does less repeated processing, bundle capabilities remain visible in JSON and verbose inventory, and complete POSIX source builds keep their external plugin dependencies after the checkout moves.
+Removal and recovery are more careful about ownership too. OpenClaw can clean up an exact nonconflicting orphaned path install without deleting another plugin's channel settings, and preserves the working legacy QQ Bot record until its renamed official replacement is runnable. A copied state directory now stops before a plugin-registry refresh can load managed code from the original tree, although intentional external managed npm projects with the same layout are rejected as well and must be reinstalled under the selected state directory.
+
+The edges around that lifecycle received a long set of smaller repairs. Plugin inspection preserves the original actionable load failure across retries, older registry records no longer look stale merely because they lack build-only stamps, typed JSX state checkers load correctly, and shutdown or replacement paths clean up each plugin attempt without duplicating teardown. Docker builds that explicitly select WhatsApp now include its runtime, current catalog installs select the compatible Weixin package, and read-only operators can discover why an action is unavailable without gaining permission to perform it. The WhatsApp and Weixin work covers packaging, loading, and compatibility rather than authenticated messaging, the activation-planning optimization does not establish faster total Gateway startup, and the separate source-build dependency-link design remains open.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Reuse prepared plugin catalog details across management actions ([#135260](https://github.com/openclaw/openclaw/pull/135260)).
+- Reuse prepared plugin aliases during activation planning ([#134812](https://github.com/openclaw/openclaw/pull/134812)).
 
 **Bug fixes**
 
-- Save accepted capabilities when updating an enabled legacy plugin ([#134172](https://github.com/openclaw/openclaw/pull/134172)). Thanks @RileyJJY, @beastyrabbit.
-- Ignore build-only stamps when deciding whether the plugin registry is fresh ([#134780](https://github.com/openclaw/openclaw/pull/134780)). Thanks @RayWangyangMa, @obviyus, @axiom-ncis.
-- Preserve bundle capabilities in JSON and verbose plugin inventory ([#135245](https://github.com/openclaw/openclaw/pull/135245)). Thanks @ssaade01, @tayoun.
+- Include explicitly selected WhatsApp runtime files in source-built Docker images ([#120660](https://github.com/openclaw/openclaw/pull/120660)). Thanks @fr-meyer.
+- Migrate trusted QQ Bot installs from the former npm package without losing channel settings ([#130894](https://github.com/openclaw/openclaw/pull/130894)). Thanks @cxyhhhhh.
+- Defer optional plugin command code until its command is selected ([#133105](https://github.com/openclaw/openclaw/pull/133105)). Thanks @ly85206559.
+- Recover exact nonconflicting orphaned path installs through normal update and uninstall commands ([#134590](https://github.com/openclaw/openclaw/pull/134590)). Thanks @MoerAI, @obviyus, and @abacha.
+- Preserve channel settings owned by another plugin during uninstall ([#134759](https://github.com/openclaw/openclaw/pull/134759)). Thanks @MoerAI, and @abacha.
+- Stop build-only stamps from making unchanged plugin registries look stale ([#134780](https://github.com/openclaw/openclaw/pull/134780)). Thanks @RayWangyangMa, @obviyus, and @axiom-ncis.
+- Select the current SDK-compatible Weixin package and document recovery from 2.4.6 ([#134854](https://github.com/openclaw/openclaw/pull/134854)).
+- Explain blocked plugin actions without duplicating the read-only warning ([#134860](https://github.com/openclaw/openclaw/pull/134860)). Thanks @Patrick-Erichsen.
+- Preserve the original actionable plugin load error across repeated attempts ([#134874](https://github.com/openclaw/openclaw/pull/134874)). Thanks @0xCyda and @Lendersmark.
+- Keep Plugin SDK SQLite WAL retries bounded by a monotonic clock ([#135019](https://github.com/openclaw/openclaw/pull/135019)). Thanks @xialonglee and @obviyus.
+- Retire plugin loads that finish after Gateway shutdown begins ([#135122](https://github.com/openclaw/openclaw/pull/135122)). Thanks @elikampf.
+- Keep explicitly uninstalled managed plugins removed across Gateway restarts ([#135729](https://github.com/openclaw/openclaw/pull/135729)). Thanks @devzeroLL and @obviyus.
+- Load `.mtsx` and `.ctsx` state checkers for source plugins ([#135820](https://github.com/openclaw/openclaw/pull/135820)).
+- Run each interrupted plugin service's stop callback at most once ([#135993](https://github.com/openclaw/openclaw/pull/135993)).
+- Refresh package state around plugin updates so restored or replaced payloads are rediscovered and retired child-plugin entries are removed, while strict package ownership and running-Gateway cache generations remain unchanged ([`d93a9b3`](https://github.com/openclaw/openclaw/commit/d93a9b3497dfed71ea01e0c0369f340fc95608c1)).
+
+**Security and trust**
+
+- Persist accepted capabilities for enabled legacy plugin updates without granting consent silently ([#134172](https://github.com/openclaw/openclaw/pull/134172)). Thanks @RileyJJY and @beastyrabbit.
+- Waive blanket capability prompts only for catalog-verified first-party plugins ([#134933](https://github.com/openclaw/openclaw/pull/134933)).
+- Make a channel-level off switch authoritative over stale enabled plugin entries ([#136211](https://github.com/openclaw/openclaw/pull/136211)).
+- Reject managed plugin roots that ambiguously point outside a copied state directory ([#136373](https://github.com/openclaw/openclaw/pull/136373)). Thanks @LiuwqGit, @obviyus, and @Dresch63.
+
+**Documentation**
+
+- Clarify that reinstall preserves explicit disablement and `--force` does not replace capability consent ([#134875](https://github.com/openclaw/openclaw/pull/134875)).
+
+**Limits and compatibility**
+
+- Exact orphan recovery still fails closed for conflicting ownership, and one inverse nested-path conflict shape was not explicitly covered by the prepared shipped tests.
+- Copied-state protection cannot distinguish an accidental foreign managed root from an intentional external managed npm project with the same layout. Explicit path plugins are unaffected.
+- The separate source-build dependency-link packaging design remains unresolved, and the Weixin and Docker repairs were not verified with authenticated live message roundtrips.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Plugin inspection, SDKs, MCP, GitHub, and connected services">
+
+People sharing one Gateway can now connect a personal GitHub account and explicitly choose it for **Publish PR** without replacing the system account. A signed-in person manages only their own connection, administrators retain the System and per-agent accounts, and publication is bound to the authenticated owner, the selected connection generation, the authorized session, and the accepted worktree. If that authority changes, OpenClaw stops instead of falling back to another credential, and unfinished personal publication after a restart must be confirmed by the same owner. This connection does not replace ordinary shell credentials, change OpenClaw roles, or turn a personal publication connection into a general GitHub identity for agent commands.
+
+The same identity boundary now reaches authenticated dashboards and local commands. Dashboard widgets can read GitHub Actions through an approved repository-scoped binding without embedding a token, but it is not a generic authenticated proxy and older arbitrary-fetch widgets must migrate. Gateway-hosted local commands use the selected managed GitHub identity at launch or fail with reconnect guidance rather than considering a native account. A running command keeps the credential it launched with, native Codex shell and non-local hosts remain separate, and the Publish PR account chooser only reuses recent successful checks for configured profiles. A remote revocation can therefore remain cached for up to 60 seconds, while an unconfigured host `gh` identity still pays its keyring lookup cost.
+
+MCP and plugin tools are less likely to disappear midway through a turn. Explicitly allowed namespaced tools remain visible without changing deny precedence or runtime grants, requester-scoped MCP connections stay alive while their tools are being resolved, and configured MCP can move to OpenClaw's policy-filtered surface when Codex native tools are disabled. Each turn still has one configured-MCP owner, approvals and durable grants remain enforced, and approval-requiring tools are not persisted into app views. OAuth-enabled Streamable HTTP and SSE servers that require sized request bodies can now initialize and refresh correctly, but the separate in-Gateway bearer-placeholder defect remains open.
+
+Plugin authors and integration operators get clearer building blocks around those workflows. Inventories now show bundle skills, commands, and MCP servers, TSX plugins produce runnable artifacts, packaged setup providers and migrations are discovered, source mounts win after the documented restart, and custom transcript stores remain consistent across reads, writes, locks, publication, and catalog imports. Voice Call setup catches an unowned multi-agent configuration before provisioning, Feishu document results stop claiming rejected permission or image operations succeeded, Twitch errors name the correct credential key, and channel commands preserve the explicitly selected agent through plugin discovery. The retained Plugin SDK paths remain available only through the renewed October 1 review window while external migrations and one modern public replacement are still unfinished.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Let shared-Gateway users connect a personal GitHub account and select it explicitly for Publish PR ([#133799](https://github.com/openclaw/openclaw/pull/133799)).
+- Defer bundled web-search provider code until the selected provider runs ([#135073](https://github.com/openclaw/openclaw/pull/135073)).
+- Reduce repeated plugin catalog processing while preserving authority and output ([#135260](https://github.com/openclaw/openclaw/pull/135260)).
+- Give plugin authors a supported facade over OpenClaw's node CLI helpers ([#135303](https://github.com/openclaw/openclaw/pull/135303)).
+- Reuse recent successful GitHub credential checks in the Publish PR chooser ([#136223](https://github.com/openclaw/openclaw/pull/136223)).
+- Create temporary provider objects only for the providers selected by a lookup ([#136398](https://github.com/openclaw/openclaw/pull/136398)).
+
+**Bug fixes**
+
+- Keep explicitly allowed namespaced plugin and connected-node tools visible to agents ([#132753](https://github.com/openclaw/openclaw/pull/132753)). Thanks @tommyjoseph.
+- Announce completed ClawHub searches and result counts to screen readers ([#133091](https://github.com/openclaw/openclaw/pull/133091)). Thanks @SunnyShu0925.
+- Build runnable TSX plugins and discover packaged setup providers and migrations ([#136458](https://github.com/openclaw/openclaw/pull/136458)).
+- Refresh persisted registries when bundled-plugin source mounts change ([#136517](https://github.com/openclaw/openclaw/pull/136517)).
+- Run command-owned plugin cleanup before local message actions exit ([#136564](https://github.com/openclaw/openclaw/pull/136564)). Thanks @gumadeiras.
+- Warn when plugin inspection is incomplete and preserve mixed-case configured policy ([#136596](https://github.com/openclaw/openclaw/pull/136596)).
+- Align the Plugins Workshop column with the rest of the hub ([61404b6](https://github.com/openclaw/openclaw/commit/61404b6c2a91871b2a4f5819ca98b06a90077796), from [#134871](https://github.com/openclaw/openclaw/pull/134871)). Thanks @Patrick-Erichsen.
+- Stop Voice Call setup before provisioning when a multi-agent installation has no response owner ([#134739](https://github.com/openclaw/openclaw/pull/134739)). Thanks @felixboenkost-droid.
+- Keep requester-scoped MCP runtimes alive throughout active resolution ([#134819](https://github.com/openclaw/openclaw/pull/134819)). Thanks @qingminglong and @obviyus.
+- Stream large Voice Call diagnostic logs with bounded reads and output backpressure ([#134838](https://github.com/openclaw/openclaw/pull/134838)). Thanks @sunlit-deng.
+- Preserve configured MCP tools in native-disabled Codex turns ([#134941](https://github.com/openclaw/openclaw/pull/134941)). Thanks @itsuzef and @obviyus.
+- Report rejected Feishu permission grants and image replacements truthfully ([#135106](https://github.com/openclaw/openclaw/pull/135106)).
+- Show plugin bundle skills, commands, and MCP servers in JSON and verbose inventory ([#135245](https://github.com/openclaw/openclaw/pull/135245)). Thanks @ssaade01 and @tayoun.
+- Check for the `gh` CLI before beginning GitHub device authorization ([#135301](https://github.com/openclaw/openclaw/pull/135301)). Thanks @mushuiyu886, @obviyus, and @jadabreu.
+- Stop channel status from advertising explicitly disabled manifest accounts ([#135417](https://github.com/openclaw/openclaw/pull/135417)). Thanks @ly85206559.
+- Name Twitch's actual `accessToken` key in setup and missing-credential errors ([#135421](https://github.com/openclaw/openclaw/pull/135421)). Thanks @ly85206559.
+- Show GitHub connection failures once and keep them visible outside collapsed details ([#135428](https://github.com/openclaw/openclaw/pull/135428)).
+- Preserve the selected agent through multi-agent channel add, login, logout, remove, resolve, and capability checks ([#135505](https://github.com/openclaw/openclaw/pull/135505)). Thanks @abacha and @Hansen1018.
+- Clear stale dashboard widget props consistently across updates and reopen ([#135748](https://github.com/openclaw/openclaw/pull/135748)). Thanks @teddytennant and @obviyus.
+- Warn before uninstalling versionless scoped ClawHub plugins used by existing Claws ([#135749](https://github.com/openclaw/openclaw/pull/135749)). Thanks @teddytennant and @obviyus.
+- Stage and clean up ClawHub archives whose sanitized names become dot segments ([#135803](https://github.com/openclaw/openclaw/pull/135803)). Thanks @teddytennant.
 - Keep external plugin dependencies valid after relocating a complete POSIX source build ([#135903](https://github.com/openclaw/openclaw/pull/135903)).
+- Load bundled artwork for trusted first-party plugin icons ([#135957](https://github.com/openclaw/openclaw/pull/135957)). Thanks @obviyus and @Grynn.
+- Resolve optional strict transcript appends through the selected store ([#136201](https://github.com/openclaw/openclaw/pull/136201)).
+- Keep plugin transcript operations in the configured custom store ([#136221](https://github.com/openclaw/openclaw/pull/136221)).
+- Keep explicit-environment incognito session creation and reopen on the same owner ([#136227](https://github.com/openclaw/openclaw/pull/136227)).
+- Send sized OAuth-authenticated MCP request bodies on initial and refreshed attempts ([#136234](https://github.com/openclaw/openclaw/pull/136234)). Thanks @LiuwqGit, @obviyus, and @Volevanius.
 
 **Security and trust**
 
-- Bypass capability consent only for catalog-verified first-party plugins ([#134933](https://github.com/openclaw/openclaw/pull/134933)).
+- Bind Gateway-hosted local commands to the selected managed GitHub identity or fail closed ([#134351](https://github.com/openclaw/openclaw/pull/134351)).
+- Read GitHub Actions through the owning agent's repository-scoped dashboard grant ([#135740](https://github.com/openclaw/openclaw/pull/135740)).
 
 **Documentation**
 
-- Clarify that reinstalling a disabled plugin does not enable it ([#134875](https://github.com/openclaw/openclaw/pull/134875)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Uninstalling and Repairing Plugins">
-
-Uninstalling a managed provider plugin now means it stays uninstalled after the Gateway restarts, even when an old model, provider, or channel choice still refers to it. Reinstalling later does not silently reactivate it, so the final enable step remains an explicit operator choice.
-
-The recovery paths around removal are safer too. Exact orphaned path-source records can be cleaned up through the normal CLI instead of by editing OpenClaw state, another plugin's channel configuration is preserved during that cleanup, and versionless scoped ClawHub packages produce the expected warning when existing Claws still depend on them. Malformed archive names no longer derail staging, while updated 1Password guidance explains how to recover after Homebrew moves the `op` executable without pinning another disposable path.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Recover exact orphan plugin records through normal update and uninstall commands ([#134590](https://github.com/openclaw/openclaw/pull/134590)). Thanks @MoerAI, @obviyus, @abacha.
-- Preserve another plugin's channel settings during orphan cleanup ([#134759](https://github.com/openclaw/openclaw/pull/134759)). Thanks @steipete, @MoerAI, @abacha.
-- Keep explicitly uninstalled managed provider plugins removed after restart ([#135729](https://github.com/openclaw/openclaw/pull/135729)). Thanks @devzeroLL, @obviyus.
-- Warn before removing scoped ClawHub plugins that still support existing Claws ([#135749](https://github.com/openclaw/openclaw/pull/135749)). Thanks @teddytennant, @obviyus.
-- Give malformed ClawHub archive names a safe temporary target ([#135803](https://github.com/openclaw/openclaw/pull/135803)). Thanks @teddytennant.
-
-**Documentation**
-
-- Explain recovery after Homebrew changes a 1Password CLI path ([#134832](https://github.com/openclaw/openclaw/pull/134832)). Thanks @steipete.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Channel Setup for the Selected Agent">
-
-Multi-agent operators can select the intended agent for channel add, channel-specific capabilities, login, logout, remove, and resolve, with that workspace retained while OpenClaw discovers, installs, or reloads the channel plugin. The existing System Agent, sole-agent, and legacy-owner rules still apply when no selector is supplied, while ambiguous or invalid ownership stops before authentication or setup begins.
-
-Channel status also stops advertising accounts that were explicitly disabled, and Twitch's outbound setup error now names the real `accessToken` setting. The separate Twitch connection-time diagnostic still needs the same wording correction.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Hide explicitly disabled manifest accounts from channel capabilities and status ([#135417](https://github.com/openclaw/openclaw/pull/135417)). Thanks @ly85206559.
-- Name Twitch's `accessToken` setting in outbound setup errors ([#135421](https://github.com/openclaw/openclaw/pull/135421)). Thanks @ly85206559.
-- Preserve the selected agent across channel setup and plugin discovery ([#135505](https://github.com/openclaw/openclaw/pull/135505)). Thanks @abacha, @Hansen1018.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Personal GitHub Accounts and Authenticated Dashboards">
-
-People sharing a Gateway can connect their own GitHub account from Profile and explicitly choose it for Publish PR without replacing the System account or an agent account. Publication remains bound to the signed-in owner, selected connection, authorized session, and accepted worktree state, and an uncertain publication can be confirmed by that same owner after a restart. This does not replace ordinary shell credentials or turn a personal publication connection into a general GitHub identity for agent commands.
-
-Gateway-hosted commands that use a managed GitHub profile stay with the credential selected at process launch. If that profile disappears or loses its token, later commands stop with reconnect guidance instead of falling back to a native account, while already running commands retain their launch credential. Dashboards can read GitHub Actions through a repository-scoped grant and the owning agent's authenticated access without exposing a token or creating a general authenticated proxy; existing anonymous widgets need to be updated or regenerated, and Publish PR credential checks may remain cached for up to 60 seconds.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Connect personal GitHub accounts alongside System and agent accounts ([#133799](https://github.com/openclaw/openclaw/pull/133799)). Thanks @steipete.
-- Reuse recent successful credential checks in the Publish PR account chooser ([#136223](https://github.com/openclaw/openclaw/pull/136223)).
-
-**Bug fixes**
-
-- Show GitHub connection failures once in Profile settings ([#135428](https://github.com/openclaw/openclaw/pull/135428)). Thanks @steipete.
-- Replace dashboard widget records instead of returning stale props ([#135748](https://github.com/openclaw/openclaw/pull/135748)). Thanks @teddytennant, @obviyus.
-
-**Security and trust**
-
-- Stop managed GitHub exec from falling back to a native account ([#134351](https://github.com/openclaw/openclaw/pull/134351)).
-- Read GitHub Actions through the owning agent's bounded repository grant ([#135740](https://github.com/openclaw/openclaw/pull/135740)). Thanks @steipete.
-
-</details>
-
-</Accordion>
-
-<Accordion title="WhatsApp, QQ Bot, and Weixin Plugin Updates">
-
-Source-built Docker images now include the WhatsApp runtime when it is explicitly selected, rather than accepting the choice and producing an image without the channel. Existing QQ Bot installs recorded under the former `@openclaw/qqbot` package can move to `@tencent-connect/openclaw-qqbot` 2.0.3 while preserving channel configuration and credentials, with failed updates leaving the working legacy record in place.
-
-Catalog-driven Weixin installs now select the SDK-compatible 2.4.8 package, and affected 2.4.6 operators have explicit update and restart guidance. The evidence verifies package selection, integrity, and compatibility rather than an authenticated Weixin message roundtrip.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Package the explicitly selected WhatsApp runtime in Docker source builds ([#120660](https://github.com/openclaw/openclaw/pull/120660)). Thanks @fr-meyer.
-- Migrate trusted legacy QQ Bot installs to the renamed official package ([#130894](https://github.com/openclaw/openclaw/pull/130894)). Thanks @cxyhhhhh.
-- Select the Weixin package compatible with the current Plugin SDK ([#134854](https://github.com/openclaw/openclaw/pull/134854)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Voice Call Setup and Feishu Document Results">
-
-Voice Call setup now catches a missing response owner before telephony resources start on a multi-agent installation and points directly to `plugins.entries.voice-call.config.agentId`. Single-agent and explicitly owned setups keep their existing behavior, while affected multi-agent operators need to rerun setup and restart the Gateway after choosing the owner.
-
-Voice Call diagnostic commands now stream large custom logs with backpressure, follow rotation and truncation more carefully, and honor whether SQLite history should start with retained records or only new ones. Feishu document actions also stop counting rejected access grants or image replacements as successes, while retaining a document that was created successfully and continuing with later images after one replacement fails.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Report missing Voice Call ownership during multi-agent setup ([#134739](https://github.com/openclaw/openclaw/pull/134739)). Thanks @felixboenkost-droid.
-- Stream Voice Call diagnostics with backpressure and correct history handling ([#134838](https://github.com/openclaw/openclaw/pull/134838)). Thanks @sunlit-deng.
-- Validate Feishu access grants and image replacements before reporting success ([#135106](https://github.com/openclaw/openclaw/pull/135106)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Plugin Startup and Shutdown">
-
-Optional command implementations for memory-wiki, policy, QA Lab, and Voice Call now load only when their command is selected, while bundled web-search providers keep executable runtime code unloaded until OpenClaw chooses one. Activation planning reuses prepared alias work as well, but those component improvements do not establish a universal or end-to-end Gateway startup speedup.
-
-When a plugin does fail, retries preserve the original actionable load error instead of making a rejected module graph appear to recover through a fallback. SQLite-backed plugin state keeps its bounded WAL retry through wall-clock changes, loads that finish after shutdown begins are retired, and interrupted service startup shares one cleanup result so a stop handler is not called twice for the same attempt.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Reuse plugin alias resolution during activation planning ([#134812](https://github.com/openclaw/openclaw/pull/134812)).
-- Defer bundled web-search provider runtimes until a provider is selected ([#135073](https://github.com/openclaw/openclaw/pull/135073)).
-
-**Bug fixes**
-
-- Delay optional plugin CLI implementations until their commands are invoked ([#133105](https://github.com/openclaw/openclaw/pull/133105)). Thanks @ly85206559.
-- Preserve the original plugin load error across retries ([#134874](https://github.com/openclaw/openclaw/pull/134874)). Thanks @0xCyda, @Lendersmark.
-- Keep Plugin SDK SQLite WAL retries bounded across wall-clock changes ([#135019](https://github.com/openclaw/openclaw/pull/135019)). Thanks @xialonglee, @obviyus.
-- Retire plugin loads that complete after Gateway shutdown begins ([#135122](https://github.com/openclaw/openclaw/pull/135122)). Thanks @elikampf.
-- Run an interrupted plugin service's stop handler once per startup attempt ([#135993](https://github.com/openclaw/openclaw/pull/135993)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Plugin SDK Compatibility and Session APIs">
-
-External plugins built against the 2026.8.1 SDK keep their conversation-binding inspection import, and accepted legacy `docks` commands remain reachable under Tools after upgrade. Plugin authors also gain a supported facade for the same node CLI helpers OpenClaw uses, while source plugins can load `.mtsx` and `.ctsx` configured-state or persisted-auth checkers without falsely reporting that state as absent.
-
-Strict single-message and atomic-batch transcript appends can once again omit the documented optional `storePath` and resolve the selected agent's configured or default store. Explicit-environment integrations can create and reopen non-main incognito sessions without replacing the process environment, with incognito data remaining memory-only. Corrected migration guidance separates public SDK exports, retained compatibility imports, injected alternatives, and compatibility deadlines without claiming new runtime exports.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Publish supported node CLI helpers for plugin authors and Canvas ([#135303](https://github.com/openclaw/openclaw/pull/135303)).
-
-**Bug fixes**
-
-- Preserve external plugin inspection imports and legacy command definitions through upgrade ([#135322](https://github.com/openclaw/openclaw/pull/135322)). Thanks @steipete.
-- Load `.mtsx` and `.ctsx` source-plugin state checkers ([#135820](https://github.com/openclaw/openclaw/pull/135820)). Thanks @steipete.
-- Resolve the optional store path for strict transcript appends ([#136201](https://github.com/openclaw/openclaw/pull/136201)).
-- Keep explicit environments attached to incognito session creation ([#136227](https://github.com/openclaw/openclaw/pull/136227)).
-
-**Documentation**
-
-- Correct Plugin SDK migration paths and compatibility deadline guidance ([#136024](https://github.com/openclaw/openclaw/pull/136024)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="OAuth MCP Servers with Strict Request Sizing">
-
-OpenClaw can connect to OAuth-enabled Streamable HTTP and SSE MCP servers that reject POST requests without a known size, including through `openclaw mcp probe`. The initial authenticated request and one token-refresh retry now reuse the same sized payload while changing only the bearer authorization. This does not fix the separate in-Gateway path that can send an unexpanded bearer-token placeholder.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Send OAuth MCP requests with a known request size across token refresh ([#136234](https://github.com/openclaw/openclaw/pull/136234)). Thanks @LiuwqGit, @obviyus, @Volevanius.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Plugins Hub Accessibility and Polish">
-
-ClawHub search now tells screen-reader users when a search finishes and how many results it found, while preserving the visible layout and stale-result protection. Read-only operators see one permissions warning instead of a duplicate page alert, and blocked actions can explain themselves through focus, hover, or tap without attempting a mutation.
-
-First-party catalog entries use artwork already bundled with OpenClaw when it is available, avoiding fallback letter tiles and unnecessary remote icon requests when the CDN is blocked, while third-party artwork retains the authenticated proxy path. The Workshop tab also lines up with the shared Plugins content column on wide screens without changing its narrow layout.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Announce ClawHub search completion and result counts to assistive technology ([#133091](https://github.com/openclaw/openclaw/pull/133091)). Thanks @SunnyShu0925.
-- Replace the duplicate plugin admin warning with explanations on blocked actions ([#134860](https://github.com/openclaw/openclaw/pull/134860)). Thanks @Patrick-Erichsen.
-- Use bundled artwork for trusted scoped first-party plugin icons ([#135957](https://github.com/openclaw/openclaw/pull/135957)). Thanks @obviyus, @Grynn.
-- Align Plugins Workshop with the shared content column for #134871 ([`61404b6c2a`](https://github.com/openclaw/openclaw/commit/61404b6c2a91871b2a4f5819ca98b06a90077796)). Thanks @Patrick-Erichsen.
+- Explain recovery from Homebrew `op` path changes through the managed 1Password plugin ([#134832](https://github.com/openclaw/openclaw/pull/134832)).
+- Align Matrix, Signal, and WhatsApp guides with npm-first plugin installation ([#136605](https://github.com/openclaw/openclaw/pull/136605)). Thanks @vincentkoc.
+- Correct Plugin SDK migration paths and compatibility-deadline guidance ([#136024](https://github.com/openclaw/openclaw/pull/136024)).
+
+**Limits and compatibility**
+
+- Retain the shipped conversation-binding inspection import and legacy command definitions for external plugins ([#135322](https://github.com/openclaw/openclaw/pull/135322)).
+- Renew the review window for five removal-pending Plugin SDK paths through October 1, 2026 ([#136698](https://github.com/openclaw/openclaw/pull/136698)).
+- Personal GitHub publication does not change verified sign-in identity, OpenClaw roles, ordinary shell credentials, model-initiated publication, repository previews, or cloud-worker credentials, and no real personal push or PR creation was demonstrated.
+- Authenticated dashboard reads are repository-scoped and require migration from arbitrary-fetch widgets. They do not expose a generic authenticated proxy or use preview and publication-only credentials.
+- Managed GitHub exec binds credentials at process launch. Immediate revocation, native Codex shell, non-local hosts, and operating-system user isolation remain separate boundaries.
+- Configured MCP has one owner per turn, and the OAuth request-size repair does not fix the separate in-Gateway bearer-placeholder defect.
+- Versionless scoped ClawHub dependency warnings cover canonical package records, parseable specifications, and plugin-ID fallback, not older records that retain only a resolved specification.
+- POSIX source-build relocation is covered, while Windows relocation remains unsupported and untested. Native MJS reload and cache invalidation also remain unresolved.
+- The compatibility window changes review timing only. External-plugin migrations remain unverified, one retained path still lacks a modern public replacement, and readiness by October 1 is unknown.
 
 </details>
 
@@ -1663,159 +1235,95 @@ First-party catalog entries use artwork already bundled with OpenClaw when it is
 
 ## Security and Privacy
 
-OpenClaw can now remember an eligible approval without turning it into blanket permission. Durable MCP grants remain tied to one agent, configured server, and tool, remote Codex placement grants remain tied to the process and placement that earned them, and stricter session or server policy still wins. The same boundary now follows delegated agent creation more carefully, while private diagnostics, saved reasoning, network requests, guest workspaces, and administrative automation each get narrower protections of their own.
+OpenClaw can now remember an eligible approval without turning it into blanket permission, and delegated work keeps checking the authority that started it before new persistent effects begin. Around that core, private workspaces, diagnostics, credential entry, saved reasoning, sign-in, and network-facing integrations each get narrower protections of their own, with the remaining boundaries called out where they still matter.
 
 <AccordionGroup>
 
-<Accordion title="Scoped Durable Approvals">
+<Accordion title="Approvals, delegation, and durable authority">
 
-Codex now follows the effective session posture when deciding whether an MCP tool needs approval, so a default full-permission session can use an unannotated tool without stopping for a permission card on every call. Stricter postures and explicit server overrides still apply, and Allow Always follows the tool across argument and working-directory changes for the current session. For an eligible MCP tool on an OpenClaw-configured server, that choice can also become a durable grant for the exact agent, server, and tool across later sessions and Gateway restarts; Codex apps, native plugin servers, computer-use servers, explicit `prompt` mode, and ambiguous matches remain outside it.
+Codex now follows the effective session posture when deciding whether an MCP tool needs approval, so default full-permission sessions do not stop for repeated cards while stricter postures and explicit server overrides still win. Allow Always follows an approved tool across argument and working-directory changes for the current session, and eligible tools on OpenClaw-configured servers can receive a durable grant tied to the exact agent, server, and tool. Those durable grants survive later Codex sessions and Gateway restarts, can be inspected or revoked through the existing approvals workflow, and still exclude Codex apps, native plugin servers, and computer-use servers. An explicit `prompt` mode continues to ask every time, and ambiguous tool matches fail closed.
 
-Remote Codex placement approvals use a narrower lifetime. Allow Always can be reused while the same placement, pairing, environment, workspace, parent approval, and Gateway process remain valid, but a restart, move, re-pairing, authority change, or expiry requires a fresh decision. Approval lifetimes entered through the CLI must now be whole positive days within the existing range, so malformed input leaves the approval pending instead of silently choosing a different duration.
+Remote Codex placement approvals deliberately remember less. They can be reused only while the same placement, pairing, environment, workspace, parent approval, and Gateway process remain valid, so a restart, move, re-pairing, authority change, or expiry requires a fresh decision. Approval lifetimes entered through the CLI must now be whole positive days within the existing range, and authorized operators can rotate or revoke approved scoped node tokens without gaining a broader role or scope than the device was approved for.
 
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
+The same authority boundary now reaches later into delegated agent creation and delegated setup. When the requesting run closes, OpenClaw stops before beginning the next workspace, identity, session, configuration, or migration effect, while a write that already started may finish and a fully published agent remains available. Earlier completed setup effects also remain, and an interrupted legacy-session migration may still need normal startup recovery or `openclaw doctor --fix`.
 
-**Improvements**
-
-- Reuse Allow Always for the same active remote Codex placement ([#132370](https://github.com/openclaw/openclaw/pull/132370)). Thanks @jalehman.
-- Persist eligible MCP tool grants across Codex sessions and Gateway restarts ([#136019](https://github.com/openclaw/openclaw/pull/136019)).
-
-**Bug fixes**
-
-- Reject malformed approval grant lifetimes without resolving the approval ([#133806](https://github.com/openclaw/openclaw/pull/133806)). Thanks @qingminglong.
-- Follow the Codex session posture and honor Allow Always across tool inputs ([#135812](https://github.com/openclaw/openclaw/pull/135812)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Delegated Agent Authority">
-
-Delegated agent creation now keeps checking the authority of the run that requested it through workspace, identity, session, and configuration writes. If that run ends while creation is still being prepared, OpenClaw stops before starting the next persistent effect instead of finishing later and reporting success for a request that is no longer authorized. Users can check `openclaw agents list` and retry from an active run.
-
-The boundary is forward-looking rather than destructive. A filesystem write that already started may finish, a fully published agent remains available, and its required bookkeeping can complete rather than leaving partial state behind.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Security and trust**
-
-- Stop delegated agent creation after the requesting run loses authority ([#136090](https://github.com/openclaw/openclaw/pull/136090)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Guest Coding Inside Private Workspaces">
-
-Sandbox-required guests can once again write files, patch code, run project-local commands, and delegate work inside a private workspace with `workspaceAccess` set to `none`. The shared agent workspace and host credentials remain outside that boundary, managed skill overlays remain read-only, an explicit `ro` workspace remains read-only, and networking stays off unless an operator enables it.
-
-Existing containers are recreated once to adopt the new mount format. Public cloning and dependency downloads still need operator-enabled networking, and arbitrary shell enforcement on a remote host still depends on that remote operator's filesystem policy.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Restore writable guest coding and delegated work inside private isolated workspaces ([#135702](https://github.com/openclaw/openclaw/pull/135702)). Thanks @whyuds.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Private Data in Diagnostics">
-
-Doctor now compares the selected state directory only with the effective account's default, avoiding sibling home-directory paths and unrelated backup warnings on shared systems. If a targeted session import or restore cannot archive a transcript, its durable migration record keeps useful failure details and the original recovery source while masking secret-shaped values; iOS agent deep links omit the complete incoming URL from diagnostics, and configuration responses redact credentials, SecretRef identifiers, and internal plugin metadata from pre-migration snapshots.
-
-These protections are scoped to the named Doctor, iOS, and configuration-response paths. Snapshot redaction does not change stored configuration or migration inputs, and it does not repair the separate startup or runtime corruption symptoms that were not reproduced by the configuration fix.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Security and trust**
-
-- Keep sibling account paths out of Doctor state-directory checks ([#122586](https://github.com/openclaw/openclaw/pull/122586)). Thanks @vincentkoc, @lidge-jun, @richard-scott.
-- Redact secret-shaped values from durable Doctor archive failures ([#122628](https://github.com/openclaw/openclaw/pull/122628)). Thanks @sunlit-deng, @obviyus.
-- Omit iOS agent deep-link URLs from diagnostic logs ([#134738](https://github.com/openclaw/openclaw/pull/134738)). Thanks @eleqtrizit.
-- Redact pre-migration configuration snapshots returned by diagnostics ([#134940](https://github.com/openclaw/openclaw/pull/134940)). Thanks @joemc1470.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Saved Codex Reasoning">
-
-Newly recorded Codex dashboard turns now keep reasoning as typed thinking instead of mirroring it into ordinary answer text. Saved reasoning appears under **Worked** only when the session explicitly uses `/reasoning on` and the local **View → Reasoning** control is enabled, while `off` and `stream` keep it hidden after reload without hiding the final answer.
-
-Previously malformed transcript rows are not rewritten. This change is also limited to saved Codex reasoning in the Control UI and does not resolve separate provider or channel-streaming leakage reports.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Security and trust**
-
-- Keep newly saved Codex reasoning hidden until it is explicitly enabled ([#136008](https://github.com/openclaw/openclaw/pull/136008)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Network Destinations and Azure BYOK Requests">
-
-Operators can now deny selected destinations across browser access, guarded web fetches, and automation webhooks without maintaining a complete allowlist. Exact hostnames and wildcard subdomains are rejected before DNS resolution and before allow or private-network exceptions, while an absent or empty blocklist leaves existing behavior unchanged. This is a destination policy rather than a complete browser egress firewall, a wildcard does not cover its apex host, and supported Chrome MCP endpoints supplied only through `mcpArgs` remain outside the shipped hostname check.
-
-Azure OpenAI BYOK traffic through the Copilot extension also gains a separate request boundary. Each local proxy receives a fresh credential, verifies it before accepting request-body data, and removes it before forwarding upstream, while configured provider headers and the existing non-Azure nonce path remain intact. The Azure path relies on header forwarding verified for the shipped Copilot SDK version.
+Sandbox-required guests can once again edit files, run project-local commands, and delegate child work inside private writable storage without exposing the shared workspace. Explicit read-only workspaces remain read-only, managed skill overlays remain read-only, existing containers are recreated for the new mount format, and networking stays off unless an operator enables it. The bundled autoreview also stays within the selected checkout and scans complete frozen inputs before dispatch, but TruffleHog is now a fail-closed requirement and global Git line endings and streaming capture remain separate follow-up work.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Add hostname blocklists to browser, web-fetch, and automation-webhook policies ([#135097](https://github.com/openclaw/openclaw/pull/135097)).
-
-**Security and trust**
-
-- Authenticate Azure OpenAI BYOK proxy requests from active Copilot sessions ([#134781](https://github.com/openclaw/openclaw/pull/134781)). Thanks @eleqtrizit.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Scoped Sign-In and Device Tokens">
-
-GitHub-backed Cloudflare Access and Tailscale sign-in can use the Gateway's existing GitHub credential for public profile verification, reducing failures caused by the anonymous API quota. Named operator roles are still admitted only after identity is verified, and an unavailable verification service now produces an accurate retryable error instead of opening a session with no usable scope.
-
-Authorized operators can also rotate or revoke approved scoped node tokens through `openclaw devices`. The operation cannot add a role or widen the approved scope baseline, under-scoped callers remain blocked, and operator-token operations with broader stored scopes may still require a broader authenticated connection.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
+- Reuse approval for the same active remote Codex placement [#132370](https://github.com/openclaw/openclaw/pull/132370). Thanks @jalehman.
+- Preserve eligible MCP tool grants across Codex sessions and Gateway restarts [#136019](https://github.com/openclaw/openclaw/pull/136019).
 
 **Bug fixes**
 
-- Keep GitHub-backed named-role sign-in scoped through profile verification ([#134724](https://github.com/openclaw/openclaw/pull/134724)).
-- Restore authorized rotation and revocation of approved scoped node tokens ([#135617](https://github.com/openclaw/openclaw/pull/135617)).
+- Reject malformed approval lifetimes without resolving the pending request [#133806](https://github.com/openclaw/openclaw/pull/133806). Thanks @qingminglong.
+- Restore authorized rotation and revocation of approved scoped node tokens [#135617](https://github.com/openclaw/openclaw/pull/135617).
+- Restore writable guest coding and child work inside private sandboxes [#135702](https://github.com/openclaw/openclaw/pull/135702). Thanks @whyuds.
+- Follow the Codex session posture and honor Allow Always across tool inputs [#135812](https://github.com/openclaw/openclaw/pull/135812).
+
+**Security and trust**
+
+- Stop delegated agent creation before new effects begin after authority closes [#136090](https://github.com/openclaw/openclaw/pull/136090).
+- Stop delegated setup writes after the requesting run closes [#136247](https://github.com/openclaw/openclaw/pull/136247).
+- Keep bundled autoreview input inside one checkout and scan it before dispatch [#136278](https://github.com/openclaw/openclaw/pull/136278). Thanks @jodok.
+
+**Documentation**
+
+- Explain the existing authority required to resume an incognito API session [#126419](https://github.com/openclaw/openclaw/pull/126419). Thanks @drobison00.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Configuration and Secrets Automation">
+<Accordion title="Credentials, privacy, role recovery, sandboxing, and network limits">
 
-Automation can now guard one direct `config set` operation with an expectation that the current value is absent or exactly matches supplied JSON. A mismatch writes nothing, reveals neither value, and leaves the existing final snapshot guard in place for later races. The expectation does not apply to batch or dry-run mode, redirected SecretRef writes, or roster updates.
+Several places that legitimately handle private data now expose less of it. Doctor no longer scans sibling account homes and masks secret-shaped archive errors before persisting recovery failures, iOS no longer records complete agent deep-link URLs in diagnostics, and Gateway configuration responses redact credentials and SecretRef identifiers from pre-migration snapshots. Android now masks Gateway credentials and secret replies, preserves secret whitespace, and returns to ordinary input after a sensitive step, although password-style input flags cannot guarantee what a third-party keyboard stores and changing sensitivity can require tapping the field again.
 
-Secrets commands using `--json` now return one parseable document on success or failure across reload, audit, configure, apply, and store list or get operations. Human-readable output and documented exit codes remain unchanged, and this is an output-contract repair rather than a change to secret contents, storage, or security policy.
+New Codex turns also keep saved reasoning as typed thinking instead of showing it as ordinary answer text. It appears under **Worked** only when the session explicitly uses `/reasoning on` and the local **View → Reasoning** control is enabled. Previously malformed transcript rows are not rewritten, and separate provider or channel-streaming reasoning leaks are outside this fix.
+
+Linux Gateway reinstall and uninstall now remove credentials from managed systemd backups, restrict those files to the owner, and let Status and Doctor identify unsafe remnants without printing their contents. Operators who find one should reinstall and rotate the affected credential. The prepared review still records an unresolved blank-line parsing risk in systemd sanitization, so this is not a claim that every backup shape is handled safely. Container and Fleet guidance now also makes the actual storage boundary explicit, since ordinary OpenClaw state and its backups can contain usable OAuth credentials while the separate key directory applies only to legacy encrypted-sidecar recovery. That guidance and the dependency advisory updates do not by themselves establish a broader exploitable product path.
+
+Authentication and ingress failures stop more cleanly. Named-role Gateway clients pause instead of reconnecting forever when verified identity is required, rejected mobile setup codes point people to a fresh code and the paired-device list, Azure OpenAI BYOK proxy requests are authenticated as belonging to the active Copilot session, and authenticated A2A, managed webhook, and SMS callback paths have tighter resource and client boundaries. These are scoped repairs rather than a general security guarantee, and some proofs used controlled services instead of live external traffic.
+
+Operators can now deny exact hosts and wildcard subdomains across browser access, guarded web fetches, and automation webhooks before existing allow rules run. Wildcards cover subdomains but not the apex host, the blocklist is not a complete browser egress firewall, and supported Chrome MCP endpoints supplied only through `mcpArgs` remain outside the shipped check. Conditional configuration updates and machine-readable Secrets CLI failures make administrative automation less likely to overwrite changed state or mishandle an error, without changing secret storage or weakening existing policy.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Add compare-and-set expectations to direct configuration updates ([#136137](https://github.com/openclaw/openclaw/pull/136137)). Thanks @vincentkoc.
+- Add deny-first hostname blocklists for browser, web-fetch, and webhook traffic [#135097](https://github.com/openclaw/openclaw/pull/135097).
+- Guard direct configuration updates with an expected current value [#136137](https://github.com/openclaw/openclaw/pull/136137). Thanks @vincentkoc.
 
 **Bug fixes**
 
-- Keep Secrets CLI JSON failures machine-readable ([#136142](https://github.com/openclaw/openclaw/pull/136142)). Thanks @qingminglong, @obviyus.
+- Keep sibling account paths out of Doctor state checks [#122586](https://github.com/openclaw/openclaw/pull/122586). Thanks @vincentkoc, @lidge-jun, and @richard-scott.
+- Preserve hidden plugin-tool progress settings through caching and provider normalization [#132266](https://github.com/openclaw/openclaw/pull/132266). Thanks @MonkeyLeeT and @mir-stream.
+- Fail GitHub-backed named-role sign-in clearly when identity cannot be verified [#134724](https://github.com/openclaw/openclaw/pull/134724).
+- Give rejected mobile setup codes an actionable recovery path [#134795](https://github.com/openclaw/openclaw/pull/134795). Thanks @eleqtrizit.
+- Keep Secrets CLI failures machine-readable in JSON mode [#136142](https://github.com/openclaw/openclaw/pull/136142). Thanks @qingminglong and @obviyus.
+- Pause clients and show recovery guidance when Gateway roles require verified identity [#136420](https://github.com/openclaw/openclaw/pull/136420). Thanks @obviyus and @aoclaw-glitch.
+
+**Security and trust**
+
+- Redact secret-shaped values from durable Doctor archive failures [#122628](https://github.com/openclaw/openclaw/pull/122628). Thanks @sunlit-deng and @obviyus.
+- Sanitize and restrict managed Linux Gateway backup files [#131786](https://github.com/openclaw/openclaw/pull/131786). Thanks @vyctorbrzezowski.
+- Bound authenticated A2A batches and response sizes [#134603](https://github.com/openclaw/openclaw/pull/134603). Thanks @eleqtrizit.
+- Attribute managed webhook rate limits to the validated client [#134622](https://github.com/openclaw/openclaw/pull/134622). Thanks @eleqtrizit.
+- Omit complete iOS agent deep-link URLs from diagnostic logs [#134738](https://github.com/openclaw/openclaw/pull/134738). Thanks @eleqtrizit.
+- Authenticate Azure OpenAI BYOK proxy requests from the active Copilot session [#134781](https://github.com/openclaw/openclaw/pull/134781). Thanks @eleqtrizit.
+- Redact pre-migration credentials returned by configuration diagnostics [#134940](https://github.com/openclaw/openclaw/pull/134940). Thanks @joemc1470.
+- Keep newly saved Codex reasoning hidden unless explicitly enabled [#136008](https://github.com/openclaw/openclaw/pull/136008).
+- Limit simultaneous unauthenticated SMS webhook body reads [#136504](https://github.com/openclaw/openclaw/pull/136504). Thanks @drobison00.
+- Mask Android credentials and secret replies during sensitive input [#136352](https://github.com/openclaw/openclaw/pull/136352).
+- Update affected URI and mail dependencies to patched versions [#136700](https://github.com/openclaw/openclaw/pull/136700).
+
+**Documentation**
+
+- Clarify that container state and backups can contain usable OAuth credentials [#136505](https://github.com/openclaw/openclaw/pull/136505). Thanks @drobison00.
 
 </details>
 
@@ -1825,106 +1333,72 @@ Secrets commands using `--json` now return one parseable document on success or 
 
 ## Quality-of-Life Improvements
 
-OpenClaw spends less time repeating work you never asked it to do. Long conversations and concurrent replies use less CPU and memory in the measured workloads, large installations give health checks and session views more room to respond, and routine starts, commands, files, worktrees, logs, and remote checks shed a long tail of avoidable overhead.
+OpenClaw does less avoidable work while a conversation, installation, or command gets larger. The result is not one blanket speed claim, but a collection of practical improvements where long replies, large session histories, busy Gateways, routine commands, and the tools used to understand them keep less temporary state and give more accurate feedback.
 
 <AccordionGroup>
 
-<Accordion title="Long Conversations and Concurrent Replies">
+<Accordion title="Lower overhead in conversations, catalogs, streams, and Gateways">
 
-Large conversations no longer drag as much unrelated history through every nearby task. Resets read only the navigation data they need, session inspection walks backward without copying the history, and ordinary turns avoid several unnecessary session reads, which leaves more room for the conversation itself.
+Large saved-session histories now stay lighter during ordinary conversations, and opening a full model catalog, resetting a very large conversation, or leaving a code-heavy chat releases substantially more of the memory those paths used to retain. Large agent rosters also reuse work while they start, allowing real HTTP health checks to answer again much sooner in the tested synthetic setup, while session lists and metadata reads avoid opening or parsing conversation data they do not need.
 
-The streaming path also does less work as replies grow. Concurrent long replies reuse their prepared text instead of repeatedly rebuilding it, producing substantially lower CPU and memory use in the tested workloads while preserving tool ordering, corrections, reply targeting, and final media. These measurements cover the built-in runtime on defined local workloads rather than model-provider latency.
+Long and concurrent replies follow the same principle. In the defined local workloads, OpenClaw spent substantially less CPU and memory preparing, sanitizing, chunking, and delivering streamed text, while preserving tool order, corrections, reply targets, Markdown, media, and final answers. Those measurements cover OpenClaw's own runtime work, not model or network latency, and a few neighboring readiness and session-list tail measurements regressed in individual tests, so this should not be read as a universal latency or capacity guarantee.
+
+Code Mode can reuse bounded warm workers and transfer snapshots with fewer copies, making repeated work much faster once those workers are warm, though the pool can retain materially more process memory and does not yet have a process-wide memory budget. Retained Control UI assets also use less memory on the tested 768 MiB and 1 GiB ARM64 hosts, but 512 MiB without swap still failed when status work overlapped startup. Managed worktrees now use available disk space rather than an arbitrary checkout count when deciding whether a new session or restore can proceed, while 100 remains the automatic cleanup target.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Prepare agent turns with lighter session reads ([#134814](https://github.com/openclaw/openclaw/pull/134814)). Thanks @steipete.
-- Scan long session histories without copying them ([#134930](https://github.com/openclaw/openclaw/pull/134930)). Thanks @steipete.
-- Reduce overhead for concurrent streaming replies ([#135751](https://github.com/openclaw/openclaw/pull/135751)).
-- Reduce CPU work for concurrent final-answer streams ([#136041](https://github.com/openclaw/openclaw/pull/136041)).
+- Reduce repeated Gateway startup and first-dashboard configuration work ([#134807](https://github.com/openclaw/openclaw/pull/134807)).
+- Prepare agent turns without unused session snapshot and deletion reads ([#134814](https://github.com/openclaw/openclaw/pull/134814)).
+- Scan long session histories from the newest entries without making copies ([#134930](https://github.com/openclaw/openclaw/pull/134930)).
+- Reuse bounded warm workers and exact session reads for Code Mode ([#134935](https://github.com/openclaw/openclaw/pull/134935)).
+- Avoid a full-body temporary copy when reading large HTTP responses ([#134954](https://github.com/openclaw/openclaw/pull/134954)).
+- Reuse owned response buffers for speech and generated media downloads ([#135014](https://github.com/openclaw/openclaw/pull/135014)).
+- Transfer Code Mode snapshots without another storage-format copy ([#135040](https://github.com/openclaw/openclaw/pull/135040)).
+- Avoid full-size temporary copies while preparing supported multipart uploads ([#135162](https://github.com/openclaw/openclaw/pull/135162)).
+- Decode large command results and errors without another byte copy ([#135189](https://github.com/openclaw/openclaw/pull/135189)).
+- Reduce local CPU work for concurrent long streaming replies ([#135751](https://github.com/openclaw/openclaw/pull/135751)).
+- Truncate very long terminal and table lines with less temporary work ([#135918](https://github.com/openclaw/openclaw/pull/135918)).
+- Skip unused formatting work for large console logs ([#136028](https://github.com/openclaw/openclaw/pull/136028)).
+- Reduce local CPU work for concurrent final-answer streams ([#136041](https://github.com/openclaw/openclaw/pull/136041)).
+- Load optional command-review and follow-up paths only when needed ([#136124](https://github.com/openclaw/openclaw/pull/136124)).
+- Reuse verified plugin metadata during foreground Gateway startup ([#136141](https://github.com/openclaw/openclaw/pull/136141)).
 - Reduce CPU and memory use while several long replies stream ([#136180](https://github.com/openclaw/openclaw/pull/136180)).
+- Load optional Control UI styles with the surfaces that use them ([#136186](https://github.com/openclaw/openclaw/pull/136186)).
+- Coalesce obsolete pending snapshots for slow reply consumers ([#136249](https://github.com/openclaw/openclaw/pull/136249)).
+- Reduce repeated subscription work during streaming event delivery ([#136296](https://github.com/openclaw/openclaw/pull/136296)).
+- Skip code-fence interiors while planning long Markdown message chunks ([#136350](https://github.com/openclaw/openclaw/pull/136350)).
+- Stop decoding preserved command output after its quota is full ([#136380](https://github.com/openclaw/openclaw/pull/136380)).
+- Skip ordinary prose while scanning streamed Markdown for code fences ([#136389](https://github.com/openclaw/openclaw/pull/136389)).
+- Keep large saved prompts out of lightweight Gateway metadata reads ([#136391](https://github.com/openclaw/openclaw/pull/136391)).
 
 **Bug fixes**
 
-- Reduce memory spikes in model catalogs, conversation resets, and code-heavy chats ([#134722](https://github.com/openclaw/openclaw/pull/134722)). Thanks @steipete.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Code Mode with Less Repeated Work">
-
-Repeated Code Mode work can reuse bounded warm workers and look up only the requested session, cutting preparation and CPU work once those workers are warm. Snapshot buffers also move between tool calls without another storage-format copy. The warm pools can retain materially more process memory, so this improves the measured Code Mode workloads without establishing a general Gateway capacity or throughput gain.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Reuse warm Code Mode workers and perform exact session lookups ([#134935](https://github.com/openclaw/openclaw/pull/134935)).
-- Transfer Code Mode snapshots without storage-format copies ([#135040](https://github.com/openclaw/openclaw/pull/135040)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Large Installation Health and Session Views">
-
-Gateways with large agent rosters now reuse prepared roster, model, and workspace facts during one startup batch, which lets real HTTP health checks answer again instead of leaving a listening socket that never becomes useful. Other fleet startup costs can still produce noticeable post-listen delays, but the repeated discovery work covered here is gone.
-
-Installations with large saved-session histories also keep less conversation data in memory and do far less work to count or list sessions, while read-only diagnostics stay out of SQLite's writer lifecycle. Retained Control UI assets use less memory on constrained ARM64 hosts as well, improving headroom in the tested 768 MiB and 1 GiB setups, though 512 MiB without swap can still fail when status work overlaps startup.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Retain less Gateway and Activity memory with large session histories ([#134891](https://github.com/openclaw/openclaw/pull/134891)). Thanks @petercheng.
-- Keep HTTP health checks responsive while large agent rosters start ([#135773](https://github.com/openclaw/openclaw/pull/135773)). Thanks @LiuwqGit, @609NFT, @obviyus.
+- Reduce memory spikes in model catalogs, conversation resets, and code-heavy chat navigation ([#134722](https://github.com/openclaw/openclaw/pull/134722)).
+- Retain less Gateway and Activity memory with large saved-session histories ([#134891](https://github.com/openclaw/openclaw/pull/134891)). Thanks @petercheng.
+- Keep terminal replay responsive during bulk buffered-output eviction ([#135183](https://github.com/openclaw/openclaw/pull/135183)).
+- Keep real HTTP health checks responsive while large agent rosters start ([#135773](https://github.com/openclaw/openclaw/pull/135773)). Thanks @LiuwqGit, @609NFT, and @obviyus.
 - Keep large session listings lightweight and fresh after equal-timestamp edits ([#135976](https://github.com/openclaw/openclaw/pull/135976)).
-- Keep read-only diagnostics out of SQLite writer state ([#136010](https://github.com/openclaw/openclaw/pull/136010)). Thanks @obviyus, @Grynn.
+- Use available disk space instead of checkout count for managed-worktree admission ([#135989](https://github.com/openclaw/openclaw/pull/135989)).
+- Release completed file-log payloads while slow writes continue ([#136030](https://github.com/openclaw/openclaw/pull/136030)).
 - Bound retained Control UI asset memory on constrained hosts ([#136108](https://github.com/openclaw/openclaw/pull/136108)). Thanks @vincentkoc.
+- Move automatic session maintenance out of the Discord and Telegram dispatch path ([#136283](https://github.com/openclaw/openclaw/pull/136283)). Thanks @obviyus and @anyech.
+- Release replaced conversation histories during active agent runs ([#136340](https://github.com/openclaw/openclaw/pull/136340)).
+- Release discarded file-log payloads when a stalled queue overflows ([#136416](https://github.com/openclaw/openclaw/pull/136416)).
 
 </details>
 
 </Accordion>
 
-<Accordion title="Startup and Command Overhead">
+<Accordion title="Clearer CLI, status, diagnostics, and everyday recovery">
 
-Common startup paths now load less optional code and reuse more work they have already verified. Gateway readiness avoids repeated Doctor and plugin-metadata preparation, ordinary shell commands defer model review and follow-up delivery until those paths are actually needed, and concurrent first turns share one workspace Git setup. Approval, elevation, cancellation, and delivery rules stay where they were.
+The everyday tools around OpenClaw now say more precisely what actually happened. Agent lists reflect a newly configured identity, multi-account health checks show the active account rather than an unconfigured preferred one, remote session ages use the Gateway's clock, and `sessions tail` distinguishes a completed turn from an error, abort, or timeout. Media limits keep their fractional size, invalid session targets return the normal JSON failure shape, and copied approval commands retain the selected profile, container, and connection context without printing credentials.
 
-Everyday command feedback is less surprising too. A temporary login-shell failure can recover on a later lookup without restarting the Gateway, `/agents` takes one coherent view of the subagent registry, automatic TTS leaves routine command output as text, zsh completion keeps examples literal, and strict-JSON errors point to the safer file-backed patch workflow.
+The terminal is less likely to become part of the problem it is helping you fix. Ctrl+C leaves model, agent, context, and session pickers across supported keyboard encodings, authored TUI links keep their intended destinations, Bash and zsh completion preserve the right command context and literal descriptions, and temporary login-shell failures can recover on the next lookup without a Gateway restart. SSH-backed probes now cancel and reap their tunnel before returning. Node wake and reconnect timing tolerates clock changes, stale presence expires correctly after rollback or suspend, and remote health uses Gateway-relative ages.
 
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Reduce repeated Gateway startup and configuration work ([#134807](https://github.com/openclaw/openclaw/pull/134807)).
-- Remove redundant payload from npm installations ([#135478](https://github.com/openclaw/openclaw/pull/135478)). Thanks @steipete.
-- Load optional exec review and follow-up paths only when needed ([#136124](https://github.com/openclaw/openclaw/pull/136124)). Thanks @steipete.
-- Reuse verified plugin metadata during foreground Gateway startup ([#136141](https://github.com/openclaw/openclaw/pull/136141)). Thanks @steipete.
-- Load optional Control UI styles with the surfaces that use them ([#136186](https://github.com/openclaw/openclaw/pull/136186)). Thanks @steipete.
-
-**Bug fixes**
-
-- Retry environment and command discovery after a transient login-shell failure ([#125378](https://github.com/openclaw/openclaw/pull/125378)). Thanks @qdivan.
-- Bound oversized telemetry update responses without replacing valid cached state ([#132492](https://github.com/openclaw/openclaw/pull/132492)). Thanks @RileyJJY.
-- Share workspace Git setup across concurrent first turns ([#134537](https://github.com/openclaw/openclaw/pull/134537)).
-- Keep `/agents` status on one coherent registry snapshot ([#134677](https://github.com/openclaw/openclaw/pull/134677)). Thanks @vincentkoc.
-- Keep routine terminal command replies out of automatic TTS ([#134802](https://github.com/openclaw/openclaw/pull/134802)). Thanks @najef1979-code.
-- Preserve literal examples in zsh completion descriptions ([#135114](https://github.com/openclaw/openclaw/pull/135114)). Thanks @walker1211.
-- Point strict-JSON parse failures to the file-backed patch workflow ([#135203](https://github.com/openclaw/openclaw/pull/135203)). Thanks @SunnyShu0925.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Managed Worktrees on Other Storage">
-
-Managed worktrees can now live on another chosen disk or folder without moving the rest of OpenClaw's state, and existing worktrees keep using the locations already recorded for them. This release first raised the shared checkout target to 100, then removed the hard admission ceiling entirely, so sufficient disk space governs new worktrees and restores while 100 remains the automatic cleanup target. Manual and protected worktrees keep their existing safeguards.
+Managed worktrees can now place new checkouts on a dedicated absolute or home-relative storage root without moving the rest of OpenClaw's state. Existing worktrees continue to use their recorded locations and still need that original storage to remain available. Alongside the disk-based admission change above, 100 is now a cleanup target rather than a hard ceiling, and restore failures point to disk space instead of asking people to delete a worktree slot that no longer exists.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1932,144 +1406,59 @@ Managed worktrees can now live on another chosen disk or folder without moving t
 **Improvements**
 
 - Add a global storage root for new managed worktrees ([#134872](https://github.com/openclaw/openclaw/pull/134872)).
-- Raise the shared managed-worktree target to 100 ([#135885](https://github.com/openclaw/openclaw/pull/135885)).
+- Ship a smaller npm installation without redundant native and plugin-build payload ([#135478](https://github.com/openclaw/openclaw/pull/135478)).
+- Raise the managed-worktree cleanup target from 30 to 100 ([#135885](https://github.com/openclaw/openclaw/pull/135885)).
 
 **Bug fixes**
 
-- Use available disk space instead of checkout count for new worktree admission ([#135989](https://github.com/openclaw/openclaw/pull/135989)). Thanks @steipete.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Project Directories for Local Agents">
-
-Local agents can work directly in an existing project directory while their instructions and memory remain in OpenClaw's managed workspace. Existing setups keep their old behavior unless a separate directory is configured, session-created and paired-agent directories still take precedence, and the split-directory option is limited to unsandboxed runs.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Let local agents work in a configured project directory ([#135080](https://github.com/openclaw/openclaw/pull/135080)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Conversation Branches and Session Continuity">
-
-Supervised Codex Chats can use **Fork from here** on newer canonical messages, retain the native conversation history through a Gateway restart, and open the chosen input as an unsent draft without changing the source conversation. Descendant forks and paginated `/btw` side questions retain that native lineage as well.
-
-Underneath that workflow, nested session writes remain ordered, malformed cyclic ancestry returns bounded context instead of hanging, and a stale local CLI recovery attempt can no longer replace a newer session. Older canonical messages without recorded native provenance remain outside the new fork path.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Keep native history when supervised Codex Chats fork canonical messages ([#134660](https://github.com/openclaw/openclaw/pull/134660)). Thanks @kevin2966n.
-
-**Bug fixes**
-
-- Keep nested session writes in their expected order ([#131456](https://github.com/openclaw/openclaw/pull/131456)). Thanks @gaoanze888, @Grynn.
-- Return bounded context for cyclic session ancestry ([#131567](https://github.com/openclaw/openclaw/pull/131567)). Thanks @igs-rogenlo.
-- Stop stale local CLI recovery from replacing a newer session ([#135168](https://github.com/openclaw/openclaw/pull/135168)). Thanks @mushuiyu886, @obviyus.
-
-**Limits and compatibility**
-
-- Canonical-message forks require recorded native provenance and were accepted locally on macOS, not across every managed Desktop, Windows, crash, or multiwriter path.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Large Files, Terminal Output, and Logs">
-
-Large downloads, generated media, multipart uploads, and command results now avoid several full-size temporary copies while preserving the same bytes, limits, timeouts, and error details. Terminal replay evicts old buffered output in one pass, and very long styled or Unicode lines reach their existing width limit with much less temporary work.
-
-Logging follows the same theme. Text loggers reuse stable formatting, JSON console output skips work it does not need, completed payloads are released as slow writes finish, and `console.trace()` keeps one readable redacted stack instead of producing a duplicate error record.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Improvements**
-
-- Avoid duplicate allocations while reading large HTTP response bodies ([#134954](https://github.com/openclaw/openclaw/pull/134954)).
-- Reuse owned response buffers for speech and generated media ([#135014](https://github.com/openclaw/openclaw/pull/135014)).
-- Avoid full-size intermediate copies for supported multipart uploads ([#135162](https://github.com/openclaw/openclaw/pull/135162)).
-- Decode large command output without another byte copy ([#135189](https://github.com/openclaw/openclaw/pull/135189)). Thanks @steipete.
-- Truncate long terminal text with less temporary memory and latency ([#135918](https://github.com/openclaw/openclaw/pull/135918)).
-- Skip unused formatting work for large console logs ([#136028](https://github.com/openclaw/openclaw/pull/136028)).
-
-**Bug fixes**
-
-- Keep terminal replay responsive during bulk buffered-output eviction ([#135183](https://github.com/openclaw/openclaw/pull/135183)).
-- Reuse console styles without crashing on inherited subsystem names ([#135932](https://github.com/openclaw/openclaw/pull/135932)). Thanks @steipete.
-- Release completed log payloads while slow writes continue ([#136030](https://github.com/openclaw/openclaw/pull/136030)). Thanks @steipete.
-- Preserve redacted trace stacks without duplicate file-log errors ([#136066](https://github.com/openclaw/openclaw/pull/136066)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="Remote Gateway Timing and Cleanup">
-
-Remote Gateway and paired-node operations now hold their timing and cleanup boundaries through clock changes, suspend, cancellation, and concurrent shutdown. Node wake retries use elapsed time, stale presence expires in the intended order, and an SSH-backed probe does not call itself stopped until its child process and forwarded port are gone. Remote health output also uses the Gateway's own ages, avoiding misleading status when the two machines' clocks disagree.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
+- Retry environment and command discovery after a temporary login-shell failure ([#125378](https://github.com/openclaw/openclaw/pull/125378)). Thanks @qdivan.
+- Keep deeply nested configuration changes from exhausting memory or the call stack ([#129918](https://github.com/openclaw/openclaw/pull/129918)). Thanks @SunnyShu0925, @obviyus, and @hpyhandsome.
+- Bound oversized telemetry update responses without replacing valid cached state ([#132492](https://github.com/openclaw/openclaw/pull/132492)). Thanks @RileyJJY.
+- Make Ctrl+C close terminal pickers across legacy and modern keyboard encodings ([#133151](https://github.com/openclaw/openclaw/pull/133151)). Thanks @aniruddhaadak80.
+- Stop obsolete session observers from scheduling work they cannot save ([#133220](https://github.com/openclaw/openclaw/pull/133220)). Thanks @SunnyShu0925 and @ruel225.
 - Keep node wake retries and reconnect waits correct through clock changes ([#133354](https://github.com/openclaw/openclaw/pull/133354)). Thanks @qingminglong.
+- Distinguish socat forwards from real Gateways in busy-port status ([#133381](https://github.com/openclaw/openclaw/pull/133381)). Thanks @ericcaiwx-star and @obviyus.
 - Wait for SSH tunnel processes to exit before stop returns ([#133847](https://github.com/openclaw/openclaw/pull/133847)). Thanks @aniruddhaadak80.
-- Expire stale Gateway presence correctly after clock rollback or suspend ([#134737](https://github.com/openclaw/openclaw/pull/134737)). Thanks @lzhan011, @obviyus.
-- Cancel interrupted SSH-backed probes and release their forwarded ports ([#135182](https://github.com/openclaw/openclaw/pull/135182)). Thanks @aniruddhaadak80, @obviyus.
+- Share workspace Git setup across concurrent first turns ([#134537](https://github.com/openclaw/openclaw/pull/134537)).
+- Keep `/agents` output on one coherent subagent registry snapshot ([#134677](https://github.com/openclaw/openclaw/pull/134677)). Thanks @vincentkoc.
+- Expire stale Gateway presence correctly after clock rollback or suspend ([#134737](https://github.com/openclaw/openclaw/pull/134737)). Thanks @lzhan011 and @obviyus.
+- Keep routine slash-command and plugin-command replies out of automatic TTS ([#134802](https://github.com/openclaw/openclaw/pull/134802)). Thanks @najef1979-code.
+- Keep protected placeholders from repeatedly stalling documentation translation ([#134934](https://github.com/openclaw/openclaw/pull/134934)).
+- Preserve literal examples in zsh subcommand descriptions ([#135114](https://github.com/openclaw/openclaw/pull/135114)). Thanks @walker1211.
+- Cancel interrupted SSH-backed probes and release their forwarded ports ([#135182](https://github.com/openclaw/openclaw/pull/135182)). Thanks @aniruddhaadak80 and @obviyus.
+- Point strict-JSON failures to the file-backed patch workflow ([#135203](https://github.com/openclaw/openclaw/pull/135203)). Thanks @SunnyShu0925.
+- Wait for active Codex-backed turns before manual native compaction begins ([#135441](https://github.com/openclaw/openclaw/pull/135441)). Thanks @jjjhenriksen and @obviyus.
+- Release requester sessions after a subagent settlement wake times out ([#135854](https://github.com/openclaw/openclaw/pull/135854)). Thanks @obviyus, @nikolascostello, and @pengzh1.
+- Reuse text-console styles without crashing on inherited-looking subsystem names ([#135932](https://github.com/openclaw/openclaw/pull/135932)).
+- Keep memory status and session diagnostics out of SQLite writer state ([#136010](https://github.com/openclaw/openclaw/pull/136010)). Thanks @obviyus and @Grynn.
+- Preserve redacted trace stacks without duplicate file-log errors ([#136066](https://github.com/openclaw/openclaw/pull/136066)).
 - Show Gateway-relative ages and cleaner heartbeat details in remote status ([#136093](https://github.com/openclaw/openclaw/pull/136093)). Thanks @jeffrey4341.
+- Keep tabbed CLI table columns aligned ([#136312](https://github.com/openclaw/openclaw/pull/136312)).
+- Preserve the intended size error and complete-byte prefix for fractional download limits ([#136402](https://github.com/openclaw/openclaw/pull/136402)). Thanks @ly85206559.
+- Label recorded session outcomes as error, aborted, timeout, or done ([#136407](https://github.com/openclaw/openclaw/pull/136407)). Thanks @Grynn.
+- Preserve authored hyperlink destinations in the terminal UI ([#136469](https://github.com/openclaw/openclaw/pull/136469)).
+- Make OC Path dry-run patches preserve exact line endings and final-newline state ([#136531](https://github.com/openclaw/openclaw/pull/136531)).
+- Show configured agent identity immediately in human and JSON listings ([#136537](https://github.com/openclaw/openclaw/pull/136537)).
+- Report timed-out channel capability checks and continue through later accounts ([#136539](https://github.com/openclaw/openclaw/pull/136539)).
+- Complete Bash option values without missing choices or duplicate prefixes ([#136557](https://github.com/openclaw/openclaw/pull/136557)).
+- Return a redacted approvals snapshot for successful JSON no-op mutations ([#136574](https://github.com/openclaw/openclaw/pull/136574)).
+- Show active multi-account channel probes even when the preferred account is unconfigured ([#136599](https://github.com/openclaw/openclaw/pull/136599)).
+- Preserve profile, container, and connection context in copied approval hints ([#136633](https://github.com/openclaw/openclaw/pull/136633)).
+- Standardize invalid session-target errors and reject blank tail-agent selectors ([#136664](https://github.com/openclaw/openclaw/pull/136664)).
+- Report fractional media storage limits accurately ([#136685](https://github.com/openclaw/openclaw/pull/136685)).
+- Correct archived-worktree restore advice after the move to disk-based admission ([#136717](https://github.com/openclaw/openclaw/pull/136717)).
 
 **Documentation**
 
-- Explain that node approvals live on the paired-device record ([#122726](https://github.com/openclaw/openclaw/pull/122726)). Thanks @191612731-cloud, @vincentkoc.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Background Work and Conversation Concurrency">
-
-Removed or replaced sessions no longer leave an obsolete observer scheduling utility-model work that cannot be saved. A subagent settlement wake that reaches its deadline also cancels the exact accepted run and releases the requester's single-concurrency lane, letting later messages continue instead of piling up behind stale retries. That cancellation is scoped to settlement wakes and the shared direct-announcement deadline path.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Stop obsolete session observers from scheduling work they cannot persist ([#133220](https://github.com/openclaw/openclaw/pull/133220)). Thanks @SunnyShu0925, @ruel225.
-- Release requester sessions after a subagent settlement wake times out ([#135854](https://github.com/openclaw/openclaw/pull/135854)). Thanks @obviyus, @nikolascostello, @pengzh1.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Documentation for Existing Paths">
-
-Several places where the product already had a working route but the documentation did not make it obvious are now clearer. Supported `/login` aliases, SecretRef defaults, TaskFlow audit warnings, uv-managed Python execution, and dead-letter recovery commands are documented where people look for them, retired pages lead to current migration guidance, and the Lite Mode Showcase link reaches the actual skill. Translation handling is less likely to strand localized pages on protected placeholders, while the expanded v2026.8.2 page is easier to navigate by topic and remains historical documentation.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Documentation**
-
-- Show the supported `/login` aliases in the command reference ([#118045](https://github.com/openclaw/openclaw/pull/118045)). Thanks @AAliKKhan.
+- List only the supported `/login` aliases in the command reference ([#118045](https://github.com/openclaw/openclaw/pull/118045)). Thanks @AAliKKhan.
 - Point the Showcase Lite Mode card to the published skill ([#120645](https://github.com/openclaw/openclaw/pull/120645)). Thanks @firepinn.
-- Explain the built-in default aliases for environment and store SecretRefs ([#122730](https://github.com/openclaw/openclaw/pull/122730)). Thanks @191612731-cloud, @fujixm5.
-- Explain the TaskFlow timestamp warning and which audit codes apply ([#124672](https://github.com/openclaw/openclaw/pull/124672)). Thanks @qingminglong.
+- Explain that node approvals live on the paired-device record ([#122726](https://github.com/openclaw/openclaw/pull/122726)). Thanks @191612731-cloud and @vincentkoc.
+- Explain the built-in default aliases for environment and store SecretRefs ([#122730](https://github.com/openclaw/openclaw/pull/122730)). Thanks @191612731-cloud and @fujixm5.
+- Explain the TaskFlow timestamp warning and shared audit-code groups ([#124672](https://github.com/openclaw/openclaw/pull/124672)). Thanks @qingminglong.
 - Document uv-managed Python environments for exec ([#129930](https://github.com/openclaw/openclaw/pull/129930)). Thanks @ralphptorres.
-- List channel dead-letter inspection and resubmission commands in the CLI index ([#134711](https://github.com/openclaw/openclaw/pull/134711)). Thanks @qingminglong.
-- Redirect retired pages to maintained migration guidance ([#134712](https://github.com/openclaw/openclaw/pull/134712)).
-- Keep protected placeholders from stalling documentation translation ([#134934](https://github.com/openclaw/openclaw/pull/134934)). Thanks @steipete.
-- Expand the historical v2026.8.2 release page with topic and source detail ([#135805](https://github.com/openclaw/openclaw/pull/135805)). Thanks @hannesrudolph.
+- Add channel dead-letter inspection and resubmission commands to the CLI index ([#134711](https://github.com/openclaw/openclaw/pull/134711)). Thanks @qingminglong.
+- Route retired pages to maintained migration and removal guidance ([#134712](https://github.com/openclaw/openclaw/pull/134712)).
+- Replace rejected configuration examples with accepted, merge-preserving CLI commands ([#136269](https://github.com/openclaw/openclaw/pull/136269)). Thanks @yetval and @obviyus.
 
 </details>
 
@@ -2079,113 +1468,53 @@ Several places where the product already had a working route but the documentati
 
 ## Other Bug Fixes
 
-The smaller fixes in this release are easier to understand when they stay attached to the place you actually notice them. Sessions now keep interrupted requests and finished child work attached to the right run, attachments hold on to their real text and type, command-line tools stop on ambiguous targets, and status, logs, remote connections, and channel-specific edges report what actually happened instead of quietly substituting a plausible answer.
+The smaller fixes in this release share a useful theme. When work is interrupted, rejected, or given ambiguous input, OpenClaw is less likely to lose the useful result, act on a plausible substitute, or leave stale work behind. Sessions keep more of what actually happened, command-line tools stop before guessing, and status or logs are clearer about what failed and what remains unfinished.
 
 <AccordionGroup>
 
-<Accordion title="Interrupted Sessions and Child Work">
+<Accordion title="Agent, subagent, and session settlement">
 
-Interrupted work now keeps its shape through restart and cleanup. A user message interrupted by a Gateway restart remains in later model context, cloud-session cleanup failures stay visible and retryable without discarding accepted workspace changes, and retried agent or CLI commands remain attached to the process tree that actually owns their cancellation, output, and diagnostics.
+Interrupted agent work now keeps its shape through more restarts and busy turns. A request interrupted by a Gateway restart remains in later model context exactly once, while [subagent](/tools/subagents) results wait for a busy parent to finish or resume after a CLI-backed parent yields instead of colliding with the active turn or disappearing. Successful child work with no final message can finish quietly, and a rejected requester wake settles instead of retrying forever. Work invalidated by cancellation, replacement, expiry, or failed revalidation still stays blocked rather than running late.
 
-Child work also settles more cleanly. Completion-required CLI-backed results resume after the parent yields without replaying an already delivered result, a successful child with no final message can finish quietly, and a rejected requester wake no longer retries forever. Catalog-backed sessions retain the runtime they were created with, ordinary wait deadlines are no longer mislabeled as Gateway shutdown, and simultaneous session starts avoid repeating the same Git preparation work.
+Long-running commands and cloud sessions now hold on to the process or cleanup work they actually own. Retried agent and CLI commands remain cancellable, fragmented UTF-8 output counts as activity instead of looking idle, and cloud-session Stop or recovery keeps failed cleanup visible and retryable without discarding accepted workspace changes. Source-built cloud sessions also package their files more reliably, and shutdown or replacement waits for its own worker and plugin cleanup to settle.
+
+The surrounding failure paths are less misleading too. Catalog-backed sessions validate the runtime they selected, `agent exec` preserves the original failure and exit code when cleanup also fails, and incomplete search diagnostics say when earlier error output was discarded. Failover logs agree on their current counters, policy migration warnings no longer suggest grants an active deny would block, and an unauthorized native `/compact` returns a refusal without starting model or session work. A failed background completion is logged without taking down the Gateway or interrupting unrelated work.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Avoid duplicate Git preparation during concurrent session starts ([#134912](https://github.com/openclaw/openclaw/pull/134912)).
-- Resume completion-required CLI child results after a parent yields ([#134974](https://github.com/openclaw/openclaw/pull/134974)). Thanks @VACInc, @aoclaw-glitch.
+- Keep failed background subagent completion from taking down the Gateway ([#131735](https://github.com/openclaw/openclaw/pull/131735)). Thanks @ruel225.
+- Explain when failed search diagnostics discarded earlier error output ([#132627](https://github.com/openclaw/openclaw/pull/132627)). Thanks @Alix-007 and @gustav-bliss.
+- Resume completion-required CLI child results after a parent yields ([#134974](https://github.com/openclaw/openclaw/pull/134974)). Thanks @VACInc and @aoclaw-glitch.
 - Keep the selected catalog runtime through session creation ([#135048](https://github.com/openclaw/openclaw/pull/135048)).
-- Keep cloud sessions stopped and make cleanup failures retryable ([#135583](https://github.com/openclaw/openclaw/pull/135583)).
-- Distinguish ordinary wait deadlines from Gateway shutdown ([#135797](https://github.com/openclaw/openclaw/pull/135797)).
-- Let successful subagents with no final message finish quietly ([#135846](https://github.com/openclaw/openclaw/pull/135846)). Thanks @jakestenger, @louisfy, @obviyus.
-- Preserve an interrupted user message through Gateway restart recovery ([#136023](https://github.com/openclaw/openclaw/pull/136023)). Thanks @leilei3167, @obviyus, @yetval.
-- Stop rejected subagent requester wakes from retrying forever ([#136033](https://github.com/openclaw/openclaw/pull/136033)). Thanks @obviyus, @Grynn.
-- Keep command retries bound to the correct lifecycle and output activity ([#136053](https://github.com/openclaw/openclaw/pull/136053)). Thanks @steipete.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Agent Runs and Tool Results">
-
-Long-running work gives the agent more useful signals before it goes off course. A background command tells Code Mode how to poll for its eventual output, early tool-loop warnings reach the model before the blocking threshold, completed fallback reports stop delegated work from launching again on the covered CLI path, and cleanup can finish even when plugin setup fails.
-
-The result is easier to trust as well. Chat `/bash` replies show the real exit code or signal, successful PDF and image analysis remains available to Code Mode and Tool Search, nested calls retire stale terminal summaries after the accepted result settles, and explicit multi-agent fleets use the selected agent for status and diagnostics instead of requiring an unrelated System Agent owner.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Stop CLI fallback completion reports from launching delegated work again ([#115405](https://github.com/openclaw/openclaw/pull/115405)). Thanks @MertBasar0.
-- Tell background commands how to retrieve their eventual output ([#132756](https://github.com/openclaw/openclaw/pull/132756)). Thanks @sashankh, @shad0wca7.
-- Show real failure codes and signals for chat `/bash` commands ([#133414](https://github.com/openclaw/openclaw/pull/133414)). Thanks @MoerAI.
-- Retain successful PDF and image analysis in Code Mode and Tool Search ([#135037](https://github.com/openclaw/openclaw/pull/135037)).
-- Finish subagent cleanup when plugin setup fails ([#135098](https://github.com/openclaw/openclaw/pull/135098)).
-- Show tool-loop warnings to the agent before blocking ([#135103](https://github.com/openclaw/openclaw/pull/135103)). Thanks @steipete.
-- Finalize nested Tool Search summaries and release stale presentation state ([#135398](https://github.com/openclaw/openclaw/pull/135398)).
-- Use explicitly selected agents for fleet status and diagnostics ([#135447](https://github.com/openclaw/openclaw/pull/135447)). Thanks @Hansen1018, @abacha.
+- Preserve the original `agent exec` failure when cleanup also fails ([#135273](https://github.com/openclaw/openclaw/pull/135273)). Thanks @SebTardif.
+- Keep cloud sessions stopped and cleanup failures visible and retryable ([#135583](https://github.com/openclaw/openclaw/pull/135583)).
+- Keep current failover counters consistent across console and structured logs ([#135844](https://github.com/openclaw/openclaw/pull/135844)).
+- Let successful subagents with no final message finish quietly ([#135846](https://github.com/openclaw/openclaw/pull/135846)). Thanks @jakestenger, @louisfy, and @obviyus.
+- Preserve an interrupted user message through Gateway restart recovery ([#136023](https://github.com/openclaw/openclaw/pull/136023)). Thanks @leilei3167, @obviyus, and @yetval.
+- Stop rejected subagent requester wakes from retrying forever ([#136033](https://github.com/openclaw/openclaw/pull/136033)). Thanks @obviyus and @Grynn.
+- Keep command retries bound to the process and output activity they own ([#136053](https://github.com/openclaw/openclaw/pull/136053)).
+- Keep cloud source packaging and worker, plugin, and shutdown cleanup attached until settlement ([#136084](https://github.com/openclaw/openclaw/pull/136084)).
+- Deliver subagent completions after busy parent turns finish ([#136423](https://github.com/openclaw/openclaw/pull/136423)). Thanks @svdwalt007, @Tony-Clawbot, and @Isitjustmefromparis.
 
 **Security and trust**
 
-- Compact Code Mode and Tool Search paths still have an unresolved review concern around wrapping newly visible media-analysis text as untrusted content.
-
-**Limits and compatibility**
-
-- Background-command guidance is only the producer-side part of the reported wait problem, and the fallback delegation gate does not cover the explicitly excluded primary CLI, subscription-auth orchestrator, or peer-conversation paths.
+- Return an explicit refusal for unauthorized native `/compact` commands ([#131408](https://github.com/openclaw/openclaw/pull/131408)). Thanks @igs-rogenlo.
+- Stop tool-profile warnings from recommending grants blocked by active policy ([#132623](https://github.com/openclaw/openclaw/pull/132623)). Thanks @sunlit-deng, @shbernal, and @SuperMarioYL.
 
 </details>
 
 </Accordion>
 
-<Accordion title="Attachments and Conversation Media">
+<Accordion title="Focused input, process, node, and state recovery">
 
-Attachments now arrive with their identity intact across several awkward boundaries. Paths ending in dot segments fall back to a usable name, long UTF-8 text remains recognizable when a character crosses the inspection boundary, streamed files keep a type and extension that match the saved bytes, and inferred legacy text keeps accents, currency symbols, and other non-ASCII characters. Rejected URL downloads also release their transport promptly, while repeatedly changing one conversation avatar no longer pushes other current avatars out of the cache.
+Narrow input failures now stop with the useful answer instead of quietly choosing another one. Explicitly blank agent-session, session-store, and dead-letter account selectors are rejected before they can fall back to a default target, while omitting those selectors keeps the existing default behavior. MCP read commands return the normal JSON failure document on early errors, invalid fixed UTC offsets no longer produce usage totals for the wrong day, and Windows command lookup ignores empty `PATHEXT` entries instead of treating an extensionless file as runnable.
 
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
+Attachments retain more of what the sender actually provided. Dot-segment metadata falls back to a usable filename, a UTF-8 character crossing the inspection boundary no longer makes a text file look binary, streamed files keep a type and extension that match the saved bytes, and inferred legacy text keeps accents, currency symbols, and other non-ASCII characters. Rejected URL downloads release their transport promptly, while repeatedly changing one conversation avatar no longer pushes other sessions' current avatars out of the cache.
 
-**Bug fixes**
-
-- Release superseded avatar data without evicting other current avatars ([#134978](https://github.com/openclaw/openclaw/pull/134978)).
-- Keep usable attachment names when path metadata ends in dot segments ([#135135](https://github.com/openclaw/openclaw/pull/135135)). Thanks @arpe1618.
-- Recognize UTF-8 text when a character crosses the attachment inspection boundary ([#135227](https://github.com/openclaw/openclaw/pull/135227)).
-- Preserve the correct type and extension for streamed attachments ([#135232](https://github.com/openclaw/openclaw/pull/135232)).
-- Preserve inferred text encoding and release rejected downloads promptly ([#135928](https://github.com/openclaw/openclaw/pull/135928)).
-
-</details>
-
-</Accordion>
-
-<Accordion title="CLI Automation and Target Selection">
-
-Command-line automation now fails without guessing. MCP read commands return the normal JSON failure document on early errors, `agent exec` preserves the original run failure and exit code when cleanup also fails, and Windows command lookup ignores empty `PATHEXT` entries instead of treating an extensionless file as runnable.
-
-Explicitly blank session, store, and dead-letter account selectors now stop before OpenClaw can fall back to a default target. Omitting those selectors still keeps the existing default behavior, so scripts can choose between a deliberate default and an explicit target without an empty variable quietly changing what the command touches.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Return the standard JSON failure document from MCP read commands ([#132379](https://github.com/openclaw/openclaw/pull/132379)). Thanks @wangmiao0668000666.
-- Reject blank agent session selectors before dispatch ([#134797](https://github.com/openclaw/openclaw/pull/134797)). Thanks @marmar9615-cloud.
-- Preserve the original `agent exec` failure when cleanup also fails ([#135273](https://github.com/openclaw/openclaw/pull/135273)). Thanks @SebTardif.
-- Reject a blank session-store selector instead of choosing the default store ([#135742](https://github.com/openclaw/openclaw/pull/135742)). Thanks @marmar9615-cloud, @obviyus.
-- Ignore empty `PATHEXT` entries during Windows command lookup ([#135807](https://github.com/openclaw/openclaw/pull/135807)). Thanks @teddytennant.
-- Reject blank dead-letter account selectors instead of choosing the default account ([#135848](https://github.com/openclaw/openclaw/pull/135848)). Thanks @masatohoshino, @obviyus.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Status, Logs, and Diagnostics">
-
-Status and logs now make a problem visible without overstating what is healthy. Detailed status reports show inbound queue pressure and dead letters even when channel connectivity looks fine, usage requests reject unsupported fixed offsets instead of returning totals for the wrong day, and Telegram and TUI status retain known context usage after tool-only turns.
-
-The same principle carries through troubleshooting. Rolling log tails read the file OpenClaw is currently writing, session-observer warnings show a redacted cause instead of an empty object, failover counters agree across console and structured logs, and failed search or Git snapshot diagnostics explain what was lost while keeping sensitive values out of persisted output. Plugin validation reports every genuinely missing field in one pass, tool-policy warnings stop recommending grants that an active deny would block, and native PR quota failures once again include safe manual retry guidance for both observed GraphQL variants while failed SSH tunnel startup cleans up its readiness work.
+Recovery and diagnostics now follow the same preference for observed state over a convenient guess. Detailed status reports show inbound queue pressure and dead letters even when channels look healthy, though they do not repair the stalled delivery themselves. Rolling log tails read the active file, session-observer warnings include a redacted cause, Git snapshot failures retain useful redacted detail, and plugin validation reports every genuinely missing field in one pass. Remote Gateway tunnels keep their listener timeout through clock changes and clean up failed readiness work, recent nodes remain inside the requested age window, and the genuine Gateway stays visible in a bounded Devices roster. Equal-timestamp Buzz updates resolve consistently, HTTP clients that reject HTML receive the existing error response, and concurrent session starts share overlapping Git preparation without retaining a stale result.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -2193,56 +1522,36 @@ The same principle carries through troubleshooting. Rolling log tails read the f
 **Bug fixes**
 
 - Report every missing plugin configuration field with accurate dependency guidance ([#93842](https://github.com/openclaw/openclaw/pull/93842)). Thanks @bladin.
-- Reject invalid fixed UTC offsets in usage date requests ([#124568](https://github.com/openclaw/openclaw/pull/124568)). Thanks @zyw02.
-- Explain when failed search diagnostics discarded earlier error output ([#132627](https://github.com/openclaw/openclaw/pull/132627)). Thanks @Alix-007, @gustav-bliss.
-- Keep context usage visible after tool-only turns ([#134634](https://github.com/openclaw/openclaw/pull/134634)). Thanks @goslingmanagment, @dmsrg399.
-- Show delivery-queue pressure and dead letters in detailed status reports ([#134889](https://github.com/openclaw/openclaw/pull/134889)). Thanks @Lendersmark.
-- Show the redacted cause of session-observer failures ([#135337](https://github.com/openclaw/openclaw/pull/135337)). Thanks @LiuwqGit, @Cobblestone-Digital1.
-- Tail the active file when logging uses a configured rolling path ([#135769](https://github.com/openclaw/openclaw/pull/135769)).
-- Keep failover counters current in console diagnostics ([#135844](https://github.com/openclaw/openclaw/pull/135844)).
-- Restore GitHub quota retry guidance and clean up failed SSH tunnel startup ([#135873](https://github.com/openclaw/openclaw/pull/135873)).
-
-**Security and trust**
-
-- Stop tool-profile warnings from recommending grants blocked by active policy ([#132623](https://github.com/openclaw/openclaw/pull/132623)). Thanks @sunlit-deng, @shbernal, @SuperMarioYL.
-- Preserve useful Git snapshot failure details while redacting sensitive values ([#135455](https://github.com/openclaw/openclaw/pull/135455)). Thanks @ly85206559, @obviyus.
-
-</details>
-
-</Accordion>
-
-<Accordion title="Connected Device and Remote Gateway State">
-
-Remote and connected setups now hold on to the state they actually observed. SSH tunnel startup keeps its configured listener timeout even if the system clock changes, node age filters use the Gateway's latest recorded connection time, and the Devices roster keeps the genuine Gateway visible while remaining bounded under peer pressure and hostname collisions. At the HTTP edge, clients that explicitly reject HTML receive the existing startup or not-found response instead of an unwanted app shell, while ordinary browser navigation keeps working as before.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- Respect explicit HTML rejection in Gateway content negotiation ([#118197](https://github.com/openclaw/openclaw/pull/118197)). Thanks @peterolkhov.
+- Reject invalid fixed UTC offsets before loading usage totals ([#124568](https://github.com/openclaw/openclaw/pull/124568)). Thanks @zyw02.
+- Return the standard JSON failure document from MCP read commands ([#132379](https://github.com/openclaw/openclaw/pull/132379)). Thanks @wangmiao0668000666.
+- Keep context usage visible after tool-only turns when exact data is available ([#134634](https://github.com/openclaw/openclaw/pull/134634)). Thanks @goslingmanagment and @dmsrg399.
 - Keep the genuine Gateway visible in a bounded Devices roster ([#134740](https://github.com/openclaw/openclaw/pull/134740)). Thanks @lzhan011.
+- Reject blank agent-session selectors before dispatch ([#134797](https://github.com/openclaw/openclaw/pull/134797)). Thanks @marmar9615-cloud.
+- Resolve equal-timestamp Buzz profile and room updates consistently ([#134861](https://github.com/openclaw/openclaw/pull/134861)). Thanks @vincentkoc.
+- Show delivery-queue pressure and dead letters in detailed status reports ([#134889](https://github.com/openclaw/openclaw/pull/134889)). Thanks @Lendersmark.
+- Avoid duplicate Git preparation during concurrent session starts ([#134912](https://github.com/openclaw/openclaw/pull/134912)).
+- Release superseded avatar data without evicting other current avatars ([#134978](https://github.com/openclaw/openclaw/pull/134978)).
+- Keep usable attachment names when path metadata ends in dot segments ([#135135](https://github.com/openclaw/openclaw/pull/135135)). Thanks @arpe1618.
+- Recognize UTF-8 text when a character crosses the attachment inspection boundary ([#135227](https://github.com/openclaw/openclaw/pull/135227)).
+- Preserve the correct type and extension for streamed attachments ([#135232](https://github.com/openclaw/openclaw/pull/135232)).
 - Keep SSH tunnel listener timeouts stable across system clock changes ([#135281](https://github.com/openclaw/openclaw/pull/135281)). Thanks @xialonglee.
+- Show the redacted cause of session-observer failures ([#135337](https://github.com/openclaw/openclaw/pull/135337)). Thanks @LiuwqGit and @Cobblestone-Digital1.
+- Reject a blank session-store selector instead of choosing the default store ([#135742](https://github.com/openclaw/openclaw/pull/135742)). Thanks @marmar9615-cloud and @obviyus.
+- Tail the active file when logging uses a configured rolling path ([#135769](https://github.com/openclaw/openclaw/pull/135769)).
+- Distinguish ordinary wait deadlines from Gateway shutdown ([#135797](https://github.com/openclaw/openclaw/pull/135797)).
+- Reject blank dead-letter account selectors instead of choosing the default account ([#135848](https://github.com/openclaw/openclaw/pull/135848)). Thanks @masatohoshino and @obviyus.
+- Restore GitHub quota retry guidance and clean up failed SSH tunnel startup ([#135873](https://github.com/openclaw/openclaw/pull/135873)).
+- Preserve inferred text encoding and release rejected downloads promptly ([#135928](https://github.com/openclaw/openclaw/pull/135928)).
 - Keep recently connected nodes inside CLI age filters ([#135936](https://github.com/openclaw/openclaw/pull/135936)).
 
-</details>
-
-</Accordion>
-
-<Accordion title="Channel Commands and Relay Ordering">
-
-Two narrower channel fixes remove behavior that depended on the wrong condition. Native `/compact` now gives an explicit authorization refusal without starting compaction work when the sender is not allowed to use it, while Buzz applies stable event ordering when profile or room updates share a timestamp instead of letting arrival order decide which state wins.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
 **Security and trust**
 
-- Return an explicit refusal for unauthorized native `/compact` commands ([#131408](https://github.com/openclaw/openclaw/pull/131408)). Thanks @igs-rogenlo.
+- Preserve useful Git snapshot failure details while redacting sensitive values ([#135455](https://github.com/openclaw/openclaw/pull/135455)). Thanks @ly85206559 and @obviyus.
 
-**Bug fixes**
+**Limits and compatibility**
 
-- Resolve equal-timestamp Buzz profile and room updates deterministically ([#134861](https://github.com/openclaw/openclaw/pull/134861)). Thanks @vincentkoc.
+- Respect explicit HTML rejection in Gateway content negotiation ([#118197](https://github.com/openclaw/openclaw/pull/118197)). Thanks @peterolkhov.
+- Ignore empty `PATHEXT` entries during Windows command lookup ([#135807](https://github.com/openclaw/openclaw/pull/135807)). Thanks @teddytennant.
 
 </details>
 
@@ -2252,11 +1561,11 @@ Two narrower channel fixes remove behavior that depended on the wrong condition.
 
 ## Maintainer and Internal Changes
 
-This release includes 415 maintainer-only units covering the machinery behind how OpenClaw is tested, reviewed, built, translated, packaged, and released. They tighten the evidence we rely on, remove duplicated internal work, and keep tooling failures from looking like successful validation, but they do not add a separate user workflow and should not be read as public product claims.
+This release includes exactly 526 maintainer-only units covering the machinery behind how OpenClaw is tested, reviewed, built, translated, packaged, and released, along with behavior-preserving refactors and internal performance work. They belong in one place because none defines a separate product workflow. The complete accounting stays here for maintainers and is not used to support the opening or any product claim above.
 
 <AccordionGroup>
 
-<Accordion title="CI and test reliability">
+<Accordion title="Build, test, release, and internal foundations">
 
 CI and focused test work now exposes skipped, crashed, mistimed, or incompletely cleaned validation more clearly, while reusing safe fixtures and build inputs to shorten maintainer feedback without changing product behavior.
 
@@ -2275,8 +1584,8 @@ CI and focused test work now exposes skipped, crashed, mistimed, or incompletely
 - Serve avatar fixtures without screenshot capture ([#135101](https://github.com/openclaw/openclaw/pull/135101)).
 - Execute Swift release builds and tests in parallel ([#135108](https://github.com/openclaw/openclaw/pull/135108)).
 - Reduce hard-link archive fixture races ([#135165](https://github.com/openclaw/openclaw/pull/135165)).
-- Give source-launching command tests their own CI lane ([#135170](https://github.com/openclaw/openclaw/pull/135170)). Thanks @steipete.
-- Separate artifact writers while verification runs in parallel ([#135226](https://github.com/openclaw/openclaw/pull/135226)). Thanks @steipete.
+- Give source-launching command tests their own CI lane ([#135170](https://github.com/openclaw/openclaw/pull/135170)).
+- Separate artifact writers while verification runs in parallel ([#135226](https://github.com/openclaw/openclaw/pull/135226)).
 - Retain compiler caches across helper checkouts ([#135269](https://github.com/openclaw/openclaw/pull/135269)).
 - Tie shard timings to test membership ([#135288](https://github.com/openclaw/openclaw/pull/135288)).
 - Split lint work while sharing native SDK declarations ([#135302](https://github.com/openclaw/openclaw/pull/135302)).
@@ -2287,33 +1596,32 @@ CI and focused test work now exposes skipped, crashed, mistimed, or incompletely
 - Preserve split test families in separate jobs ([#135816](https://github.com/openclaw/openclaw/pull/135816)).
 - Populate transform caches during test collection ([#135875](https://github.com/openclaw/openclaw/pull/135875)).
 - Reduce waiting for delegated approval expiry ([#135891](https://github.com/openclaw/openclaw/pull/135891)).
-- Normalize installer fixtures for changed-file release lint ([`d3deb20a78`](https://github.com/openclaw/openclaw/commit/d3deb20a78e3c4c10997d9df022500e6799f52fa)).
-- Add regression coverage for stale one-shot delivery retention ([#131691](https://github.com/openclaw/openclaw/pull/131691)). Thanks @LiuwqGit, @steipete.
+- Add regression coverage for stale one-shot delivery retention ([#131691](https://github.com/openclaw/openclaw/pull/131691)). Thanks @LiuwqGit.
 - Verify model selection through image-tool execution ([#134536](https://github.com/openclaw/openclaw/pull/134536)).
 - Drop redundant registration coverage ([#134548](https://github.com/openclaw/openclaw/pull/134548)).
 - Drop duplicate task detail reset case ([#134637](https://github.com/openclaw/openclaw/pull/134637)).
 - Centralize title-retention disk fixtures across isolated readers ([#134642](https://github.com/openclaw/openclaw/pull/134642)).
-- Run sender-role coverage through the real Tlon monitor ([#134646](https://github.com/openclaw/openclaw/pull/134646)). Thanks @steipete.
-- Coordinate Reef inbox entry and wait for cleanup ([#134652](https://github.com/openclaw/openclaw/pull/134652)). Thanks @steipete.
+- Run sender-role coverage through the real Tlon monitor ([#134646](https://github.com/openclaw/openclaw/pull/134646)).
+- Coordinate Reef inbox entry and wait for cleanup ([#134652](https://github.com/openclaw/openclaw/pull/134652)).
 - Wait directly for Raft bridge startup ([#134656](https://github.com/openclaw/openclaw/pull/134656)).
 - Centralize bounded response fixtures and remove duplicate coverage ([#134661](https://github.com/openclaw/openclaw/pull/134661)).
-- Set pointer state before testing submenu highlight clearing ([#134669](https://github.com/openclaw/openclaw/pull/134669)). Thanks @steipete.
+- Set pointer state before testing submenu highlight clearing ([#134669](https://github.com/openclaw/openclaw/pull/134669)).
 - Wait for WebSocket receive callbacks directly ([#134671](https://github.com/openclaw/openclaw/pull/134671)).
-- Drop duplicate thinking normalization case ([#134674](https://github.com/openclaw/openclaw/pull/134674)). Thanks @steipete.
+- Drop duplicate thinking normalization case ([#134674](https://github.com/openclaw/openclaw/pull/134674)).
 - Initialize pairing diagnostics once for the Doctor suite ([#134675](https://github.com/openclaw/openclaw/pull/134675)).
 - Bypass file setup for supplied playback probes ([#134676](https://github.com/openclaw/openclaw/pull/134676)).
-- Coordinate macOS worker backpressure without timing races ([#134702](https://github.com/openclaw/openclaw/pull/134702)). Thanks @steipete.
+- Coordinate macOS worker backpressure without timing races ([#134702](https://github.com/openclaw/openclaw/pull/134702)).
 - Share the dev-branch filesystem fixture ([#134707](https://github.com/openclaw/openclaw/pull/134707)).
 - Share startup owners across each suite ([#134720](https://github.com/openclaw/openclaw/pull/134720)).
 - Share immutable native-host fixtures ([#134728](https://github.com/openclaw/openclaw/pull/134728)).
 - Centralize Rastermill metadata setup ([#134733](https://github.com/openclaw/openclaw/pull/134733)).
 - Limit Windows encoding module resets ([#134747](https://github.com/openclaw/openclaw/pull/134747)).
 - Coordinate provider property probes without sleep delays ([#134754](https://github.com/openclaw/openclaw/pull/134754)).
-- Share QA facade graphs within suites ([#134763](https://github.com/openclaw/openclaw/pull/134763)). Thanks @steipete.
-- Share the native extension loader owner ([#134792](https://github.com/openclaw/openclaw/pull/134792)). Thanks @steipete.
+- Share QA facade graphs within suites ([#134763](https://github.com/openclaw/openclaw/pull/134763)).
+- Share the native extension loader owner ([#134792](https://github.com/openclaw/openclaw/pull/134792)).
 - Share immutable registry fixture archives ([#134804](https://github.com/openclaw/openclaw/pull/134804)).
 - Give one owner to Vitest include selection ([#134805](https://github.com/openclaw/openclaw/pull/134805)). Thanks @vincentkoc.
-- Unify startup parser CLI coverage ([#134811](https://github.com/openclaw/openclaw/pull/134811)). Thanks @steipete.
+- Unify startup parser CLI coverage ([#134811](https://github.com/openclaw/openclaw/pull/134811)).
 - Share the Gmail diagnostics module graph ([#134825](https://github.com/openclaw/openclaw/pull/134825)).
 - Bypass discarded native fixture copies ([#134840](https://github.com/openclaw/openclaw/pull/134840)).
 - Streamline retry and timeout fixtures ([#134852](https://github.com/openclaw/openclaw/pull/134852)).
@@ -2334,17 +1642,17 @@ CI and focused test work now exposes skipped, crashed, mistimed, or incompletely
 - Adopt shell command fixtures for baseline selection ([#134991](https://github.com/openclaw/openclaw/pull/134991)).
 - Adopt native CRC32 for the large paste fixture ([#135001](https://github.com/openclaw/openclaw/pull/135001)).
 - Unify abortable sleep timing coverage ([#135004](https://github.com/openclaw/openclaw/pull/135004)).
-- Limit Git identity to maintenance fixture lifetime ([#135011](https://github.com/openclaw/openclaw/pull/135011)). Thanks @steipete.
-- Check CI retry delays without a real wait ([#135020](https://github.com/openclaw/openclaw/pull/135020)). Thanks @steipete.
+- Limit Git identity to maintenance fixture lifetime ([#135011](https://github.com/openclaw/openclaw/pull/135011)).
+- Check CI retry delays without a real wait ([#135020](https://github.com/openclaw/openclaw/pull/135020)).
 - Separate static provider catalogs from network-capable discovery ([#135074](https://github.com/openclaw/openclaw/pull/135074)).
-- Give QA suite verdict accounting one implementation ([#135078](https://github.com/openclaw/openclaw/pull/135078)). Thanks @steipete.
-- Centralize mock assistant streaming event construction ([#135090](https://github.com/openclaw/openclaw/pull/135090)). Thanks @steipete.
-- Keep bounded live provider failure diagnostics ([#135120](https://github.com/openclaw/openclaw/pull/135120)). Thanks @steipete.
+- Give QA suite verdict accounting one implementation ([#135078](https://github.com/openclaw/openclaw/pull/135078)).
+- Centralize mock assistant streaming event construction ([#135090](https://github.com/openclaw/openclaw/pull/135090)).
+- Keep bounded live provider failure diagnostics ([#135120](https://github.com/openclaw/openclaw/pull/135120)).
 - Retain update fixture plugin and temporary-file ownership ([#135141](https://github.com/openclaw/openclaw/pull/135141)).
 - End the Doctor memory probe after flushing its result ([#135146](https://github.com/openclaw/openclaw/pull/135146)). Thanks @vincentkoc.
-- Centralize evidence builder execution context ([#135158](https://github.com/openclaw/openclaw/pull/135158)). Thanks @steipete.
+- Centralize evidence builder execution context ([#135158](https://github.com/openclaw/openclaw/pull/135158)).
 - Centralize Mantis report rendering and summary fields ([#135160](https://github.com/openclaw/openclaw/pull/135160)).
-- Centralize standard live transport CLI composition ([#135325](https://github.com/openclaw/openclaw/pull/135325)). Thanks @steipete.
+- Centralize standard live transport CLI composition ([#135325](https://github.com/openclaw/openclaw/pull/135325)).
 - Coordinate CUA transport and recording fixtures directly ([#135363](https://github.com/openclaw/openclaw/pull/135363)).
 - Share commit-resolution setup ([#135560](https://github.com/openclaw/openclaw/pull/135560)).
 - Share packed artifact identity fixture ([#135572](https://github.com/openclaw/openclaw/pull/135572)).
@@ -2353,8 +1661,8 @@ CI and focused test work now exposes skipped, crashed, mistimed, or incompletely
 - Wait for version diagnostic completion ([#135594](https://github.com/openclaw/openclaw/pull/135594)).
 - Unify root help fast-path coverage ([#135605](https://github.com/openclaw/openclaw/pull/135605)).
 - Give one owner to PR wrapper fixture identities ([#135611](https://github.com/openclaw/openclaw/pull/135611)).
-- Streamline library wire proof assertions ([#135616](https://github.com/openclaw/openclaw/pull/135616)). Thanks @steipete.
-- Share directory archive runtime ([#135624](https://github.com/openclaw/openclaw/pull/135624)). Thanks @steipete.
+- Streamline library wire proof assertions ([#135616](https://github.com/openclaw/openclaw/pull/135616)).
+- Share directory archive runtime ([#135624](https://github.com/openclaw/openclaw/pull/135624)).
 - Centralize immutable GitHub CLI fixture commands ([#135640](https://github.com/openclaw/openclaw/pull/135640)).
 - Share immutable oversized stream chunks ([#135643](https://github.com/openclaw/openclaw/pull/135643)).
 - Reduce leaked concurrent node configuration workers ([#135644](https://github.com/openclaw/openclaw/pull/135644)).
@@ -2368,7 +1676,7 @@ CI and focused test work now exposes skipped, crashed, mistimed, or incompletely
 - Share immutable import URL fixtures ([#135712](https://github.com/openclaw/openclaw/pull/135712)).
 - Add regression coverage for startup consent convergence ([#135718](https://github.com/openclaw/openclaw/pull/135718)). Thanks @ge0el, @boramyleng.
 - Share deferred gates in terminal lifecycle tests ([#135719](https://github.com/openclaw/openclaw/pull/135719)).
-- Close Gateway fixture peers after assertion failures ([#135721](https://github.com/openclaw/openclaw/pull/135721)). Thanks @steipete.
+- Close Gateway fixture peers after assertion failures ([#135721](https://github.com/openclaw/openclaw/pull/135721)).
 - Share notice runtime and stabilize capability navigation ([#135733](https://github.com/openclaw/openclaw/pull/135733)).
 - Share unchanged declaration groups ([#135735](https://github.com/openclaw/openclaw/pull/135735)).
 - Give Vault resolver wire fixtures one lifecycle owner ([#135741](https://github.com/openclaw/openclaw/pull/135741)).
@@ -2391,16 +1699,53 @@ CI and focused test work now exposes skipped, crashed, mistimed, or incompletely
 - Share compiled cron ownership workers ([#135967](https://github.com/openclaw/openclaw/pull/135967)).
 - Share prepared CLI in lifecycle E2E suites ([#135971](https://github.com/openclaw/openclaw/pull/135971)).
 - End finite Google Meet fake process streams promptly ([#136003](https://github.com/openclaw/openclaw/pull/136003)).
-- Limit shared fixtures and join failed downloads ([#136027](https://github.com/openclaw/openclaw/pull/136027)). Thanks @steipete.
+- Limit shared fixtures and join failed downloads ([#136027](https://github.com/openclaw/openclaw/pull/136027)).
 - Pack npm fixtures once per install scenario ([#136044](https://github.com/openclaw/openclaw/pull/136044)).
 - Build Microsoft Teams retention rows in batches ([#136055](https://github.com/openclaw/openclaw/pull/136055)).
 - Centralize browser lifetime across isolated contexts ([#136101](https://github.com/openclaw/openclaw/pull/136101)).
 - Give Control UI fixtures one cleanup owner ([#136150](https://github.com/openclaw/openclaw/pull/136150)).
 - Close every Control UI Board fixture resource ([#136182](https://github.com/openclaw/openclaw/pull/136182)).
 - Limit direct-reference planning searches to test sources ([#136193](https://github.com/openclaw/openclaw/pull/136193)).
-- Share session branch fixture history ([#136209](https://github.com/openclaw/openclaw/pull/136209)). Thanks @steipete.
+- Share session branch fixture history ([#136209](https://github.com/openclaw/openclaw/pull/136209)).
 - Adopt prepared entry in Gateway QA fixtures ([#136245](https://github.com/openclaw/openclaw/pull/136245)).
 - Prove auth-profile rotation with tighter agent fixtures ([#136254](https://github.com/openclaw/openclaw/pull/136254)).
+- Exercise complete embedded preparation in authentication-pin regression tests ([#136430](https://github.com/openclaw/openclaw/pull/136430)).
+- Split Gateway-backed CLI process tests under the repository line cap ([`aef65cc574`](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c)).
+- Share state and configuration path policy across private E2E harnesses ([#135793](https://github.com/openclaw/openclaw/pull/135793)). Thanks @vincentkoc.
+- Retain canonical package checks while removing a redundant AI source scanner ([#136037](https://github.com/openclaw/openclaw/pull/136037)). Thanks @RomneyDa.
+- Exercise parallel provider tests through the public execution boundary ([#136038](https://github.com/openclaw/openclaw/pull/136038)). Thanks @RomneyDa.
+- Use canonical persisted session rows in subagent depth and capability tests ([#136094](https://github.com/openclaw/openclaw/pull/136094)). Thanks @RomneyDa.
+- Share startup-duration filtering across performance reports ([#136176](https://github.com/openclaw/openclaw/pull/136176)). Thanks @vincentkoc.
+- Skip process-only runtime preparation in ordinary Doctor tests ([#136229](https://github.com/openclaw/openclaw/pull/136229)).
+- Synchronize Control UI typography and cloud-picker fixtures more directly ([#136263](https://github.com/openclaw/openclaw/pull/136263)).
+- Run Gateway provider-refusal QA from the prepared bundle ([#136287](https://github.com/openclaw/openclaw/pull/136287)).
+- Use capacity-aware scheduling and fewer shards for broad pull-request CI ([#136295](https://github.com/openclaw/openclaw/pull/136295)).
+- Give device-scope browser tests shared E2E lifecycle ownership ([#136305](https://github.com/openclaw/openclaw/pull/136305)).
+- Share one real-flow context across Doctor persistence suites ([#136323](https://github.com/openclaw/openclaw/pull/136323)).
+- Wait for Android outbox publication before branch-coordination assertions ([#136335](https://github.com/openclaw/openclaw/pull/136335)).
+- Share lifecycle ownership across session-diff browser coverage ([#136347](https://github.com/openclaw/openclaw/pull/136347)).
+- Assert real unverified-receipt provenance in activity-inspector tests ([#136351](https://github.com/openclaw/openclaw/pull/136351)).
+- Preserve original failures while cloud-workspace browser fixtures clean up ([#136353](https://github.com/openclaw/openclaw/pull/136353)).
+- Prove skipped-midnight chart boundaries in a real Santiago browser timezone ([#136448](https://github.com/openclaw/openclaw/pull/136448)).
+- Remove redundant Markdown code-span coverage ([#136461](https://github.com/openclaw/openclaw/pull/136461)).
+- Remove redundant timezone wrappers from auto-reply timestamp tests ([#136483](https://github.com/openclaw/openclaw/pull/136483)).
+- Exercise real daylight-saving transitions in Gateway usage-date tests ([#136501](https://github.com/openclaw/openclaw/pull/136501)).
+- Consolidate logs timestamp coverage at the command boundary ([#136511](https://github.com/openclaw/openclaw/pull/136511)).
+- Keep configuration schema-hint test data out of production code ([#136520](https://github.com/openclaw/openclaw/pull/136520)).
+- Distinguish real rejection handling from timeout recovery in macOS approval tests ([#136522](https://github.com/openclaw/openclaw/pull/136522)).
+- Exercise the production snapshot-cache path in CLI configuration tests ([#136532](https://github.com/openclaw/openclaw/pull/136532)).
+- Avoid a second hosted-runner queue for eligible Blacksmith aggregate gates ([#136534](https://github.com/openclaw/openclaw/pull/136534)).
+- Protect machine-name subprocess isolation with focused tests ([#136540](https://github.com/openclaw/openclaw/pull/136540)).
+- Guard prefetched comparison bases with smaller Gateway CLI fixtures ([#136541](https://github.com/openclaw/openclaw/pull/136541)).
+- Validate native Gateway timeout budgets without host-scheduling false failures ([#136571](https://github.com/openclaw/openclaw/pull/136571)).
+- Generate Codex prompt snapshots in hermetic state ([#136601](https://github.com/openclaw/openclaw/pull/136601)).
+- Exercise real cache-loader boundaries in session-cost retry tests ([#136616](https://github.com/openclaw/openclaw/pull/136616)).
+- Exercise production entry points in compile-cache startup tests ([#136658](https://github.com/openclaw/openclaw/pull/136658)).
+- Give Vitest wrappers one owner for the first forwarded shutdown signal ([#136667](https://github.com/openclaw/openclaw/pull/136667)). Thanks @vincentkoc.
+- Simplify Discord cancellation checks without changing cancellation behavior ([#136670](https://github.com/openclaw/openclaw/pull/136670)). Thanks @vincentkoc.
+- Exercise real stop handles and restart ownership in session-delivery tests ([#136675](https://github.com/openclaw/openclaw/pull/136675)).
+- Exercise real semantic events in diagnostic progress tests ([#136688](https://github.com/openclaw/openclaw/pull/136688)).
+- Use the production contribution factory in Doctor health-check tests ([#136695](https://github.com/openclaw/openclaw/pull/136695)).
 
 **Bug fixes**
 
@@ -2411,8 +1756,8 @@ CI and focused test work now exposes skipped, crashed, mistimed, or incompletely
 - Verify usable SSH access on native Windows Testboxes ([#134828](https://github.com/openclaw/openclaw/pull/134828)).
 - Report one final failure for each test invocation ([#134850](https://github.com/openclaw/openclaw/pull/134850)).
 - Treat active Windows SSH sessions as non-idle ([#134927](https://github.com/openclaw/openclaw/pull/134927)).
-- Send Swift metadata changes to their owner tests ([#134983](https://github.com/openclaw/openclaw/pull/134983)). Thanks @steipete.
-- Finish draft setup before measuring composer renders ([#135075](https://github.com/openclaw/openclaw/pull/135075)). Thanks @steipete.
+- Send Swift metadata changes to their owner tests ([#134983](https://github.com/openclaw/openclaw/pull/134983)).
+- Finish draft setup before measuring composer renders ([#135075](https://github.com/openclaw/openclaw/pull/135075)).
 - Surface matching full-release decisions sooner ([#135076](https://github.com/openclaw/openclaw/pull/135076)).
 - Run type-aware lint for changed root tests ([#135123](https://github.com/openclaw/openclaw/pull/135123)).
 - Run browser checks for browser-harness-only changes ([#136125](https://github.com/openclaw/openclaw/pull/136125)).
@@ -2421,34 +1766,53 @@ CI and focused test work now exposes skipped, crashed, mistimed, or incompletely
 - Retain crash exit codes and failure evidence for test shards ([#134688](https://github.com/openclaw/openclaw/pull/134688)).
 - Make forked-context QA fail without child history ([#134708](https://github.com/openclaw/openclaw/pull/134708)). Thanks @RomneyDa.
 - Retain nested suite ownership and share progress transitions ([#135027](https://github.com/openclaw/openclaw/pull/135027)).
-- Keep repository test wrappers interruptible during cleanup ([#135439](https://github.com/openclaw/openclaw/pull/135439)). Thanks @steipete.
+- Keep repository test wrappers interruptible during cleanup ([#135439](https://github.com/openclaw/openclaw/pull/135439)).
 - Stop concurrent macOS fixtures from starving child cleanup ([#135501](https://github.com/openclaw/openclaw/pull/135501)).
 - Retain retained inputs across nested Vitest cleanup ([#135647](https://github.com/openclaw/openclaw/pull/135647)).
 - Stop canceled fixtures from outliving test cleanup ([#135883](https://github.com/openclaw/openclaw/pull/135883)).
 - Keep Codex sandbox tests inside isolated state homes ([#135943](https://github.com/openclaw/openclaw/pull/135943)).
-- Finish QA tool progress from completed result status ([#135995](https://github.com/openclaw/openclaw/pull/135995)). Thanks @steipete.
+- Finish QA tool progress from completed result status ([#135995](https://github.com/openclaw/openclaw/pull/135995)).
 - Finish cleanup when subprocess errors contain cycles ([#136057](https://github.com/openclaw/openclaw/pull/136057)).
 - Keep mixed Control UI test runs scoped to requested paths ([#136136](https://github.com/openclaw/openclaw/pull/136136)).
 - Keep Crabline crypto inside bundled QA builds ([#136166](https://github.com/openclaw/openclaw/pull/136166)).
 - Emit complete QA Responses stream lifecycles ([#136167](https://github.com/openclaw/openclaw/pull/136167)).
 - Fail empty named-file test runs unless explicitly allowed ([#135609](https://github.com/openclaw/openclaw/pull/135609)).
 - Retain partial Anthropic output when QA completions fail ([#136001](https://github.com/openclaw/openclaw/pull/136001)).
-- Return nonstreaming QA Responses in the expected SDK shape ([#136062](https://github.com/openclaw/openclaw/pull/136062)). Thanks @steipete.
-- Accept string content in QA Responses messages ([#136109](https://github.com/openclaw/openclaw/pull/136109)). Thanks @steipete.
-- Retain bounded bootstrap diagnostics after timeouts ([#136111](https://github.com/openclaw/openclaw/pull/136111)). Thanks @steipete.
+- Return nonstreaming QA Responses in the expected SDK shape ([#136062](https://github.com/openclaw/openclaw/pull/136062)).
+- Accept string content in QA Responses messages ([#136109](https://github.com/openclaw/openclaw/pull/136109)).
+- Retain bounded bootstrap diagnostics after timeouts ([#136111](https://github.com/openclaw/openclaw/pull/136111)).
 - Format IPv6 QA listener URLs at their owners ([#136132](https://github.com/openclaw/openclaw/pull/136132)).
+- Prevent the residual-process watchdog from racing fixture readiness ([#136185](https://github.com/openclaw/openclaw/pull/136185)).
+- Keep approval tracking scoped to the run that owns each lifecycle event ([#136205](https://github.com/openclaw/openclaw/pull/136205)). Thanks @quangtran88.
+- Resolve managed OpenTelemetry preloads from the SDK-owned dependency tree ([#136272](https://github.com/openclaw/openclaw/pull/136272)).
+- Keep Android Debug test filters from requesting release-signing credentials ([#136273](https://github.com/openclaw/openclaw/pull/136273)).
+- Retain CLI lifecycle ownership until delayed output closes ([#136286](https://github.com/openclaw/openclaw/pull/136286)).
+- Join SQLite migration-proof cleanup and retain its diagnostics ([#136291](https://github.com/openclaw/openclaw/pull/136291)).
+- Extend cold GitHub-hosted Android fallback build timeouts ([#136307](https://github.com/openclaw/openclaw/pull/136307)).
+- Finish failed Gateway test-client cleanup before teardown ([#136344](https://github.com/openclaw/openclaw/pull/136344)).
+- Join placement-dialog operations before fixture teardown ([#136354](https://github.com/openclaw/openclaw/pull/136354)).
+- Catch missing mobile protocol-event coverage in local changed-file checks ([#136470](https://github.com/openclaw/openclaw/pull/136470)).
+- Wait for both queued WebChat turns in Gateway recovery tests ([#136473](https://github.com/openclaw/openclaw/pull/136473)).
+- Restore Gateway cancellation-test environments after teardown failures ([#136590](https://github.com/openclaw/openclaw/pull/136590)).
+- Match generated-plugin capability fixtures to emitted package metadata ([`4a76681`](https://github.com/openclaw/openclaw/commit/4a76681e3f3997dbf3f7ac57511f413d6ede1a2c)).
+- Install workspace dependencies in the Docker plugin-binding smoke image ([`ef256f9`](https://github.com/openclaw/openclaw/commit/ef256f9696995d9f5ae84a362dddd94e41346a32)).
+- Enforce the current App SDK worker-environment fixture contract ([`23ca4bc`](https://github.com/openclaw/openclaw/commit/23ca4bcb960f0e8bd761549abaec4da0443b30b8)).
+- Model an explicit already-current Doctor result before newer-schema refusal ([`d7f18f9`](https://github.com/openclaw/openclaw/commit/d7f18f94ec99c7fe37dd31cadc8b9fe4876229f5)).
+- Confirm subagent delivery before requester-settlement assertions ([`5fc4754`](https://github.com/openclaw/openclaw/commit/5fc4754b7570037e4bdad92c77ae333cccc94167)).
+- Timestamp subagent lifecycle fixtures from their active clock ([`eb2c349`](https://github.com/openclaw/openclaw/commit/eb2c349a5c1bc963dc0249e1e9420dea61ffff67)).
 
 **Security and trust**
 
-- Fetch security-scan history before removing checkout credentials ([#136232](https://github.com/openclaw/openclaw/pull/136232)). Thanks @steipete.
+- Fetch security-scan history before removing checkout credentials ([#136232](https://github.com/openclaw/openclaw/pull/136232)).
 - Require transport tests to prove SSRF denial ([#134879](https://github.com/openclaw/openclaw/pull/134879)).
 - Centralize trust audit fixture lifetime ([#136243](https://github.com/openclaw/openclaw/pull/136243)).
+- Run fast security checks from pinned local hooks and immutable policy ([#136388](https://github.com/openclaw/openclaw/pull/136388)). Thanks @vincentkoc.
+- Add a tested dependency-free private-key scanner for later CI rollout ([#136419](https://github.com/openclaw/openclaw/pull/136419)).
+- Run private-key scanning from trusted base-ref code earlier in CI ([#136577](https://github.com/openclaw/openclaw/pull/136577)).
 
 </details>
 
-</Accordion>
-
-<Accordion title="Release and package tooling">
+**Release and package tooling**
 
 Release preparation retains stronger artifact identity, retry, review, and publication boundaries, while removing repeated builds from the protected path where the frozen evidence supports reuse.
 
@@ -2457,6 +1821,7 @@ Release preparation retains stronger artifact identity, retry, review, and publi
 
 **Improvements**
 
+- Record the refreshed v2026.9.1 audited boundary and contribution ledger ([`a41af7e`](https://github.com/openclaw/openclaw/commit/a41af7eb71a95f7fc1ebc83d1b34d8a7a4ed0fe7)).
 - Add macOS 2026.8.2 to the stable Sparkle feed ([#135680](https://github.com/openclaw/openclaw/pull/135680)).
 - Isolate Plugin SDK cleanup from runner metadata ([#134443](https://github.com/openclaw/openclaw/pull/134443)). Thanks @RomneyDa.
 - Share compiler-consumed declaration inputs ([#134734](https://github.com/openclaw/openclaw/pull/134734)).
@@ -2466,19 +1831,30 @@ Release preparation retains stronger artifact identity, retry, review, and publi
 - Qualify npm betas without unrelated release jobs ([#134966](https://github.com/openclaw/openclaw/pull/134966)).
 - Bypass full history for release artifact consumers ([#135128](https://github.com/openclaw/openclaw/pull/135128)).
 - Centralize version script argument parsing ([#135264](https://github.com/openclaw/openclaw/pull/135264)).
-- Reuse prepared packages and overlap publication work ([#135367](https://github.com/openclaw/openclaw/pull/135367)). Thanks @steipete.
+- Reuse prepared packages and overlap publication work ([#135367](https://github.com/openclaw/openclaw/pull/135367)).
 - Recover with an explicitly approved replacement PR head ([#135622](https://github.com/openclaw/openclaw/pull/135622)).
 - Assemble publication artifacts during validation ([#135639](https://github.com/openclaw/openclaw/pull/135639)).
-- Create macOS release architectures concurrently ([#135753](https://github.com/openclaw/openclaw/pull/135753)). Thanks @steipete.
+- Create macOS release architectures concurrently ([#135753](https://github.com/openclaw/openclaw/pull/135753)).
 - Trim Docker cache export overhead ([#135832](https://github.com/openclaw/openclaw/pull/135832)).
-- Reduce copying and cache transfer during image preparation ([#135877](https://github.com/openclaw/openclaw/pull/135877)). Thanks @steipete.
+- Reduce copying and cache transfer during image preparation ([#135877](https://github.com/openclaw/openclaw/pull/135877)).
 - Reuse Docker work and narrow plugin verification inputs ([#135960](https://github.com/openclaw/openclaw/pull/135960)).
-- Synchronize packages, native metadata, and generated 2026.9.1 artifacts ([`431d778f54`](https://github.com/openclaw/openclaw/commit/431d778f545386a812912b80bc6f75aa7a449dd4)).
 - Centralize JSON key sorter ([#135157](https://github.com/openclaw/openclaw/pull/135157)). Thanks @vincentkoc.
-- Share canonical Docker CLI flag parser ([#135207](https://github.com/openclaw/openclaw/pull/135207)). Thanks @steipete.
+- Share canonical Docker CLI flag parser ([#135207](https://github.com/openclaw/openclaw/pull/135207)).
+- Align app, package, plugin, compatibility, and generated catalog metadata for 2026.9.1 ([`f8fdfb950d`](https://github.com/openclaw/openclaw/commit/f8fdfb950dc070b0117954c6ea0587b2e5f1bf71)).
+- Share dependency-report argument diagnostics without changing CLI behavior ([#135859](https://github.com/openclaw/openclaw/pull/135859)). Thanks @vincentkoc.
+- Reuse receipt-bound release artifacts while independent qualification work overlaps ([#136105](https://github.com/openclaw/openclaw/pull/136105)).
+- Hydrate release source and Tideclaw ancestry progressively within a bounded preflight ([#136309](https://github.com/openclaw/openclaw/pull/136309)). Thanks @vincentkoc.
+- Prepare Mermaid assets before linked-worktree iOS and macOS builds ([#136315](https://github.com/openclaw/openclaw/pull/136315)). Thanks @vincentkoc.
+- Coordinate Android and iOS release versions through one manifest and two-phase cutter ([#136366](https://github.com/openclaw/openclaw/pull/136366)). Thanks @vincentkoc.
+- Expand release validation across synthetic Twitch ingress and installed-package layouts ([#136678](https://github.com/openclaw/openclaw/pull/136678)).
 
 **Bug fixes**
 
+- Start the candidate package registry on Windows without drive-qualified tar path failures ([`0e2789a`](https://github.com/openclaw/openclaw/commit/0e2789a12ad7b87c2069a4e914b53a6eaaaf38c5)).
+- Resolve prepared candidate plugins during stable-to-candidate upgrade validation ([`9461eac`](https://github.com/openclaw/openclaw/commit/9461eac258fe152e3c458bb443354de4c2ca7192)).
+- Preserve the candidate registry during corrupt-plugin setup validation ([`d7153a4`](https://github.com/openclaw/openclaw/commit/d7153a4ea53bfd58ba82d79a12f99fabfdb9a881)).
+- Inspect survivor plugins before restoring the exact legacy configuration bytes ([`0ab85e8`](https://github.com/openclaw/openclaw/commit/0ab85e8f0e53f1147b155b8d5a10060265c515bc)).
+- Enable the reinstalled npm fixture before proving its CLI while retaining disablement checks ([`57559b5`](https://github.com/openclaw/openclaw/commit/57559b57ff048fe7fe88846ad9244bac7ffdea55)).
 - Generate stable appcasts correctly with macOS Bash ([#135687](https://github.com/openclaw/openclaw/pull/135687)).
 - Keep mixed skill and core changes in normal maintainer review ([#131619](https://github.com/openclaw/openclaw/pull/131619)). Thanks @MertBasar0, @shojikumaru.
 - Use a supported baseline for frozen installer validation ([#134519](https://github.com/openclaw/openclaw/pull/134519)). Thanks @RomneyDa.
@@ -2490,7 +1866,7 @@ Release preparation retains stronger artifact identity, retry, review, and publi
 - Require durable completed ClawSweeper review evidence ([#134926](https://github.com/openclaw/openclaw/pull/134926)). Thanks @vincentkoc.
 - Keep Doctor health discovery available in packaged QA fixtures ([#134944](https://github.com/openclaw/openclaw/pull/134944)).
 - Continue unaffected advisory checks after access denials ([#135015](https://github.com/openclaw/openclaw/pull/135015)).
-- Publish the frozen Codex plugin with its approved pin ([#135246](https://github.com/openclaw/openclaw/pull/135246)). Thanks @steipete.
+- Publish the frozen Codex plugin with its approved pin ([#135246](https://github.com/openclaw/openclaw/pull/135246)).
 - Publish verified plugin tarballs without rebuilding them ([#135289](https://github.com/openclaw/openclaw/pull/135289)).
 - Load npm configuration for trusted plugin publication ([#135323](https://github.com/openclaw/openclaw/pull/135323)).
 - Restore serializable protocol declaration builds ([#135360](https://github.com/openclaw/openclaw/pull/135360)).
@@ -2503,12 +1879,23 @@ Release preparation retains stronger artifact identity, retry, review, and publi
 - Accept historical npm targets with an existing UI bundle ([#136054](https://github.com/openclaw/openclaw/pull/136054)). Thanks @vincentkoc.
 - Reuse matching prepared artifacts after failed release jobs ([#136112](https://github.com/openclaw/openclaw/pull/136112)).
 - Validate frozen releases against their available capabilities ([#136127](https://github.com/openclaw/openclaw/pull/136127)). Thanks @vincentkoc.
-- Accept numbered draft changelogs during validation ([#136134](https://github.com/openclaw/openclaw/pull/136134)). Thanks @steipete.
+- Accept numbered draft changelogs during validation ([#136134](https://github.com/openclaw/openclaw/pull/136134)).
 - Keep macOS tooling out of Linux upgrade proofs ([#136152](https://github.com/openclaw/openclaw/pull/136152)).
 - Finish merge receipts safely after main advances ([#135396](https://github.com/openclaw/openclaw/pull/135396)).
 - Preserve ignored files during PR worktree preparation ([#135500](https://github.com/openclaw/openclaw/pull/135500)).
-- Protect package markers during concurrent builds ([#134835](https://github.com/openclaw/openclaw/pull/134835)). Thanks @steipete.
-- Keep macOS worker packaging on the destination volume ([#134857](https://github.com/openclaw/openclaw/pull/134857)). Thanks @steipete.
+- Protect package markers during concurrent builds ([#134835](https://github.com/openclaw/openclaw/pull/134835)).
+- Keep macOS worker packaging on the destination volume ([#134857](https://github.com/openclaw/openclaw/pull/134857)).
+- Restore iOS dependency resolution with the available WebRTC 152 artifact ([#134942](https://github.com/openclaw/openclaw/pull/134942)).
+- Run Plugin SDK qualification from the trusted tooling checkout across pnpm versions ([#136233](https://github.com/openclaw/openclaw/pull/136233)). Thanks @RomneyDa.
+- Validate real Android app and Wear signing material during release preflight ([#136319](https://github.com/openclaw/openclaw/pull/136319)). Thanks @vincentkoc.
+- Run remaining trusted release-validation installs from the tooling checkout ([#136325](https://github.com/openclaw/openclaw/pull/136325)). Thanks @vincentkoc.
+- Bind release publication and resume to the exact selected preflight run ([#136336](https://github.com/openclaw/openclaw/pull/136336)).
+- Honor the GitHub-hosted runner override across release-validation workflows ([#136434](https://github.com/openclaw/openclaw/pull/136434)). Thanks @masatohoshino, @obviyus.
+- Repair frozen-candidate fetch, staging, inventory, and dependency evidence paths ([#136621](https://github.com/openclaw/openclaw/pull/136621)).
+- Use a same-line predecessor for frozen extended-stable package checks ([#136624](https://github.com/openclaw/openclaw/pull/136624)). Thanks @RomneyDa.
+- Match frozen Docker acceptance to the selected Doctor and plugin-binding contracts ([#136627](https://github.com/openclaw/openclaw/pull/136627)). Thanks @RomneyDa.
+- Recognize the historical absence-based uninstall contract for frozen packages ([#136628](https://github.com/openclaw/openclaw/pull/136628)). Thanks @RomneyDa.
+- Run frozen-release dependency evidence from trusted tooling across pnpm versions ([#136681](https://github.com/openclaw/openclaw/pull/136681)). Thanks @vincentkoc.
 
 **Security and trust**
 
@@ -2518,9 +1905,7 @@ Release preparation retains stronger artifact identity, retry, review, and publi
 
 </details>
 
-</Accordion>
-
-<Accordion title="Documentation and localization">
+**Documentation and localization**
 
 Documentation and generated localization work keeps maintainer guidance, release history, translation inputs, and native locale generation aligned with the code they describe.
 
@@ -2554,13 +1939,14 @@ Documentation and generated localization work keeps maintainer guidance, release
 - Reserve changelog edits for release preparation ([#135136](https://github.com/openclaw/openclaw/pull/135136)).
 - Move the historical beta clarification into a footnote ([#135595](https://github.com/openclaw/openclaw/pull/135595)). Thanks @hannesrudolph.
 - Add release scale and contribution totals to prior pages ([#135822](https://github.com/openclaw/openclaw/pull/135822)). Thanks @hannesrudolph.
-- Refresh Gateway update and disconnect recovery translations ([#135669](https://github.com/openclaw/openclaw/pull/135669)).
+- Keep dynamic macOS UI copy inside generated localization verification ([#135511](https://github.com/openclaw/openclaw/pull/135511)).
+- Replace the historical v2026.8.2 page with topic-organized notes and source accounting ([#135805](https://github.com/openclaw/openclaw/pull/135805)). Thanks @hannesrudolph.
+- Keep the lasting automations terminology rule in Control UI localization verification ([#136138](https://github.com/openclaw/openclaw/pull/136138)). Thanks @RomneyDa.
+- Record the aggregate 2026.9.1 story and contribution accounting in the changelog ([`c92d0ae9c0`](https://github.com/openclaw/openclaw/commit/c92d0ae9c07e757719e676517aa9f9460a40761c)).
 
 </details>
 
-</Accordion>
-
-<Accordion title="Internal refactors and performance">
+**Internal refactors and performance**
 
 Behavior-preserving refactors consolidate duplicated ownership and trim repeated parsing, copying, allocation, and setup across the runtime and repository.
 
@@ -2570,11 +1956,11 @@ Behavior-preserving refactors consolidate duplicated ownership and trim repeated
 **Improvements**
 
 - Streamline configured-channel presence ([#134362](https://github.com/openclaw/openclaw/pull/134362)).
-- Unify report formatting ownership ([#134466](https://github.com/openclaw/openclaw/pull/134466)). Thanks @steipete.
-- Move prepared plugin metadata maps without copying ([#134581](https://github.com/openclaw/openclaw/pull/134581)). Thanks @steipete.
-- Unify storage mutation parsing ([#134585](https://github.com/openclaw/openclaw/pull/134585)). Thanks @steipete.
+- Unify report formatting ownership ([#134466](https://github.com/openclaw/openclaw/pull/134466)).
+- Move prepared plugin metadata maps without copying ([#134581](https://github.com/openclaw/openclaw/pull/134581)).
+- Unify storage mutation parsing ([#134585](https://github.com/openclaw/openclaw/pull/134585)).
 - Preserve Doctor plugin contracts lightweight ([#134601](https://github.com/openclaw/openclaw/pull/134601)).
-- Unify command diagnostic tails ([#134607](https://github.com/openclaw/openclaw/pull/134607)). Thanks @steipete, @vincentkoc.
+- Unify command diagnostic tails ([#134607](https://github.com/openclaw/openclaw/pull/134607)). Thanks @vincentkoc.
 - Remove brittle Android screenshot source mirrors ([#134613](https://github.com/openclaw/openclaw/pull/134613)). Thanks @RomneyDa.
 - Remove brittle live CLI backend source mirrors ([#134614](https://github.com/openclaw/openclaw/pull/134614)). Thanks @RomneyDa.
 - Drop redundant system-agent source mirror ([#134615](https://github.com/openclaw/openclaw/pull/134615)). Thanks @RomneyDa.
@@ -2590,15 +1976,15 @@ Behavior-preserving refactors consolidate duplicated ownership and trim repeated
 - Centralize SQLite reliability stderr formatting ([#134762](https://github.com/openclaw/openclaw/pull/134762)). Thanks @vincentkoc.
 - Centralize spawn output coercion ([#134821](https://github.com/openclaw/openclaw/pull/134821)). Thanks @vincentkoc.
 - Give mock previews shared state and request handling ([#134836](https://github.com/openclaw/openclaw/pull/134836)).
-- Drop duplicated Claude model checks ([#134842](https://github.com/openclaw/openclaw/pull/134842)). Thanks @steipete.
+- Drop duplicated Claude model checks ([#134842](https://github.com/openclaw/openclaw/pull/134842)).
 - Centralize person-page classification ([#134844](https://github.com/openclaw/openclaw/pull/134844)). Thanks @vincentkoc.
 - Streamline agent migration traversal ([#134845](https://github.com/openclaw/openclaw/pull/134845)).
 - Update Control UI boot manifest ([#134876](https://github.com/openclaw/openclaw/pull/134876)). Thanks @vincentkoc.
 - Centralize env reference normalization ([#134904](https://github.com/openclaw/openclaw/pull/134904)). Thanks @vincentkoc.
-- Unify hook requirement reports ([#134905](https://github.com/openclaw/openclaw/pull/134905)). Thanks @steipete.
-- Unify table style metadata ([#134908](https://github.com/openclaw/openclaw/pull/134908)). Thanks @steipete.
-- Centralize span clipping logic ([#134910](https://github.com/openclaw/openclaw/pull/134910)). Thanks @steipete.
-- Trim repeated work during turn preparation ([#134921](https://github.com/openclaw/openclaw/pull/134921)). Thanks @steipete.
+- Unify hook requirement reports ([#134905](https://github.com/openclaw/openclaw/pull/134905)).
+- Unify table style metadata ([#134908](https://github.com/openclaw/openclaw/pull/134908)).
+- Centralize span clipping logic ([#134910](https://github.com/openclaw/openclaw/pull/134910)).
+- Trim repeated work during turn preparation ([#134921](https://github.com/openclaw/openclaw/pull/134921)).
 - Centralize lazy runtime forwarding ([#134945](https://github.com/openclaw/openclaw/pull/134945)).
 - Centralize terminal report context ([#134946](https://github.com/openclaw/openclaw/pull/134946)).
 - Drop duplicate metric inventory ([#134947](https://github.com/openclaw/openclaw/pull/134947)).
@@ -2608,14 +1994,14 @@ Behavior-preserving refactors consolidate duplicated ownership and trim repeated
 - Centralize token style and block transitions ([#134965](https://github.com/openclaw/openclaw/pull/134965)).
 - Centralize wildcard callback host check ([#134977](https://github.com/openclaw/openclaw/pull/134977)). Thanks @vincentkoc.
 - Reduce intermediate timestamp objects ([#134979](https://github.com/openclaw/openclaw/pull/134979)).
-- Share canonical tool result envelopes ([#134984](https://github.com/openclaw/openclaw/pull/134984)). Thanks @steipete.
+- Share canonical tool result envelopes ([#134984](https://github.com/openclaw/openclaw/pull/134984)).
 - Share validators for rebuilt tool schemas ([#134988](https://github.com/openclaw/openclaw/pull/134988)).
 - Call Memory Wiki source synchronization through its canonical path ([#134992](https://github.com/openclaw/openclaw/pull/134992)). Thanks @vincentkoc.
 - Discard superseded message-tool catalogs after registry replacement ([#134998](https://github.com/openclaw/openclaw/pull/134998)).
 - Centralize API success assertion ([#135005](https://github.com/openclaw/openclaw/pull/135005)). Thanks @vincentkoc.
 - Share the current process start identity ([#135007](https://github.com/openclaw/openclaw/pull/135007)).
 - Drop runtime getter aliases ([#135012](https://github.com/openclaw/openclaw/pull/135012)). Thanks @vincentkoc.
-- Give one owner to skipped stage outcomes ([#135029](https://github.com/openclaw/openclaw/pull/135029)). Thanks @steipete.
+- Give one owner to skipped stage outcomes ([#135029](https://github.com/openclaw/openclaw/pull/135029)).
 - Give one owner to document table patch actions ([#135030](https://github.com/openclaw/openclaw/pull/135030)).
 - Use one alias parser for Android Talk directives ([#135033](https://github.com/openclaw/openclaw/pull/135033)).
 - Share normalized stream tool-call facts ([#135034](https://github.com/openclaw/openclaw/pull/135034)).
@@ -2625,7 +2011,7 @@ Behavior-preserving refactors consolidate duplicated ownership and trim repeated
 - Centralize concrete select menu construction ([#135064](https://github.com/openclaw/openclaw/pull/135064)).
 - Share Feishu Drive comment preparation and pagination ([#135065](https://github.com/openclaw/openclaw/pull/135065)).
 - Centralize tool registration and result adapters ([#135066](https://github.com/openclaw/openclaw/pull/135066)).
-- Centralize rich-text fallback rendering ([#135072](https://github.com/openclaw/openclaw/pull/135072)). Thanks @steipete.
+- Centralize rich-text fallback rendering ([#135072](https://github.com/openclaw/openclaw/pull/135072)).
 - Reduce redundant catalog sanitization ([#135091](https://github.com/openclaw/openclaw/pull/135091)).
 - Unify executable search providers ([#135099](https://github.com/openclaw/openclaw/pull/135099)).
 - Centralize text and media dispatch preparation ([#135100](https://github.com/openclaw/openclaw/pull/135100)).
@@ -2640,48 +2026,48 @@ Behavior-preserving refactors consolidate duplicated ownership and trim repeated
 - Create only the requested provider index ([#135169](https://github.com/openclaw/openclaw/pull/135169)).
 - Trim repeated schema reads during database opens ([#135172](https://github.com/openclaw/openclaw/pull/135172)).
 - Source output types from protocol schema ([#135174](https://github.com/openclaw/openclaw/pull/135174)).
-- Bypass empty tool-result planning branches ([#135204](https://github.com/openclaw/openclaw/pull/135204)). Thanks @steipete.
+- Bypass empty tool-result planning branches ([#135204](https://github.com/openclaw/openclaw/pull/135204)).
 - Trim work when preparing explicit replies ([#135208](https://github.com/openclaw/openclaw/pull/135208)).
 - Share accepted tool-result transcript snapshots ([#135220](https://github.com/openclaw/openclaw/pull/135220)).
-- Route Apple Watch inbound events through one owner ([#135235](https://github.com/openclaw/openclaw/pull/135235)). Thanks @steipete.
+- Route Apple Watch inbound events through one owner ([#135235](https://github.com/openclaw/openclaw/pull/135235)).
 - Unify inbound and outbound sending ([#135254](https://github.com/openclaw/openclaw/pull/135254)).
 - Source shared meeting types from the canonical owner ([#135257](https://github.com/openclaw/openclaw/pull/135257)).
 - Centralize bounded Graph pagination ([#135258](https://github.com/openclaw/openclaw/pull/135258)).
-- Reduce redundant image auth lookup ([#135259](https://github.com/openclaw/openclaw/pull/135259)). Thanks @steipete.
+- Reduce redundant image auth lookup ([#135259](https://github.com/openclaw/openclaw/pull/135259)).
 - Share protocol-owned model and checkpoint types ([#135265](https://github.com/openclaw/openclaw/pull/135265)).
-- Centralize grouped report argument parsing ([#135271](https://github.com/openclaw/openclaw/pull/135271)). Thanks @steipete.
+- Centralize grouped report argument parsing ([#135271](https://github.com/openclaw/openclaw/pull/135271)).
 - Drop unused web runtime facades ([#135274](https://github.com/openclaw/openclaw/pull/135274)).
 - Source session projections from protocol types ([#135275](https://github.com/openclaw/openclaw/pull/135275)).
 - Give one owner to failure output at the CLI owner ([#135284](https://github.com/openclaw/openclaw/pull/135284)).
-- Share command display sanitization ([#135285](https://github.com/openclaw/openclaw/pull/135285)). Thanks @steipete.
+- Share command display sanitization ([#135285](https://github.com/openclaw/openclaw/pull/135285)).
 - Build release profiles from shared ordered phases ([#135294](https://github.com/openclaw/openclaw/pull/135294)).
 - Assemble Control UI encoding preferences once ([#135304](https://github.com/openclaw/openclaw/pull/135304)).
-- Centralize effective catalog model projection ([#135306](https://github.com/openclaw/openclaw/pull/135306)). Thanks @steipete.
+- Centralize effective catalog model projection ([#135306](https://github.com/openclaw/openclaw/pull/135306)).
 - Reduce PNG checksum buffer copies ([#135313](https://github.com/openclaw/openclaw/pull/135313)).
 - Drop unused CLI runtime plumbing ([#135317](https://github.com/openclaw/openclaw/pull/135317)).
-- Centralize message payload projections ([#135319](https://github.com/openclaw/openclaw/pull/135319)). Thanks @steipete.
+- Centralize message payload projections ([#135319](https://github.com/openclaw/openclaw/pull/135319)).
 - Release Tool Search catalogs when agent runs end ([#135321](https://github.com/openclaw/openclaw/pull/135321)).
 - Drop duplicate native send flow ([#135336](https://github.com/openclaw/openclaw/pull/135336)).
 - Share MCP metadata during inventory reads ([#135369](https://github.com/openclaw/openclaw/pull/135369)).
 - Trim work for ordinary log records ([#135375](https://github.com/openclaw/openclaw/pull/135375)).
-- Give one owner to generic image hook ownership ([#135386](https://github.com/openclaw/openclaw/pull/135386)). Thanks @steipete.
+- Give one owner to generic image hook ownership ([#135386](https://github.com/openclaw/openclaw/pull/135386)).
 - Share prepared provider auth environment candidates ([#135390](https://github.com/openclaw/openclaw/pull/135390)).
 - Preserve refusal display independent of runtime policy ([#135391](https://github.com/openclaw/openclaw/pull/135391)). Thanks @Marvinthebored, @obviyus.
 - Streamline transcript reads and recovery state ([#135392](https://github.com/openclaw/openclaw/pull/135392)).
 - Reduce discarded body buffers ([#135405](https://github.com/openclaw/openclaw/pull/135405)).
 - Reduce full-string encoding for bounded prefixes ([#135412](https://github.com/openclaw/openclaw/pull/135412)).
-- Reduce cloning credentials for presence checks ([#135464](https://github.com/openclaw/openclaw/pull/135464)). Thanks @steipete.
+- Reduce cloning credentials for presence checks ([#135464](https://github.com/openclaw/openclaw/pull/135464)).
 - Share measured widths while wrapping terminal tables ([#135473](https://github.com/openclaw/openclaw/pull/135473)).
 - Reduce copying outbound node duplex fragments ([#135475](https://github.com/openclaw/openclaw/pull/135475)).
 - Share sorted ranges while rendering context maps ([#135476](https://github.com/openclaw/openclaw/pull/135476)).
-- Drop unused Gateway metadata scope hashing ([#135477](https://github.com/openclaw/openclaw/pull/135477)). Thanks @steipete.
+- Drop unused Gateway metadata scope hashing ([#135477](https://github.com/openclaw/openclaw/pull/135477)).
 - Unify selection handling ([#135497](https://github.com/openclaw/openclaw/pull/135497)).
 - Streamline discovery, setup, and update reporting ([#135598](https://github.com/openclaw/openclaw/pull/135598)). Thanks @abacha, @Bloodis94, @Hansen1018.
 - Reduce materializing unused process output ([#135602](https://github.com/openclaw/openclaw/pull/135602)).
 - Drop redundant finalize-hook message copy ([#135607](https://github.com/openclaw/openclaw/pull/135607)).
 - Reduce transient executable-header buffers ([#135625](https://github.com/openclaw/openclaw/pull/135625)).
 - Store tool-set snapshots directly in context memory ([#135626](https://github.com/openclaw/openclaw/pull/135626)).
-- Share full catalog rendering ([#135674](https://github.com/openclaw/openclaw/pull/135674)). Thanks @steipete.
+- Share full catalog rendering ([#135674](https://github.com/openclaw/openclaw/pull/135674)).
 - Trim temporary reply-formatting allocations ([#135725](https://github.com/openclaw/openclaw/pull/135725)).
 - Streamline upgrade and triage tests ([#135799](https://github.com/openclaw/openclaw/pull/135799)).
 - Reuse Control UI asset parent directories during retention ([#135806](https://github.com/openclaw/openclaw/pull/135806)).
@@ -2699,7 +2085,7 @@ Behavior-preserving refactors consolidate duplicated ownership and trim repeated
 - Load update recovery support only when an update starts ([#135942](https://github.com/openclaw/openclaw/pull/135942)).
 - Trim allocations when rendering attributed Markdown ([#135950](https://github.com/openclaw/openclaw/pull/135950)).
 - Give one owner to model accounting at stream ingress ([#135956](https://github.com/openclaw/openclaw/pull/135956)).
-- Reduce unused bundle builds in standalone E2E runs ([#135962](https://github.com/openclaw/openclaw/pull/135962)). Thanks @steipete.
+- Reduce unused bundle builds in standalone E2E runs ([#135962](https://github.com/openclaw/openclaw/pull/135962)).
 - Validate Control UI manifests without redundant sorting ([#135972](https://github.com/openclaw/openclaw/pull/135972)).
 - Assemble file log fields once per record ([#135974](https://github.com/openclaw/openclaw/pull/135974)).
 - Reduce a redundant copy when building the base config schema ([#135986](https://github.com/openclaw/openclaw/pull/135986)).
@@ -2712,14 +2098,41 @@ Behavior-preserving refactors consolidate duplicated ownership and trim repeated
 - Centralize session visibility types ([#136065](https://github.com/openclaw/openclaw/pull/136065)). Thanks @RomneyDa.
 - Source run history type from wire schema ([#136075](https://github.com/openclaw/openclaw/pull/136075)). Thanks @RomneyDa.
 - Check sessions yield stream contract ([#136077](https://github.com/openclaw/openclaw/pull/136077)). Thanks @RomneyDa.
-- Compute model catalog runtime capabilities once ([#136080](https://github.com/openclaw/openclaw/pull/136080)). Thanks @steipete.
-- Reduce materializing text and media for presence checks ([#136099](https://github.com/openclaw/openclaw/pull/136099)). Thanks @steipete.
+- Compute model catalog runtime capabilities once ([#136080](https://github.com/openclaw/openclaw/pull/136080)).
+- Reduce materializing text and media for presence checks ([#136099](https://github.com/openclaw/openclaw/pull/136099)).
 - Trim Linux CI fixture process scans ([#136114](https://github.com/openclaw/openclaw/pull/136114)).
 - Unify shared session menu rendering ([#136119](https://github.com/openclaw/openclaw/pull/136119)).
 - Share captured model-catalog visibility state ([#136162](https://github.com/openclaw/openclaw/pull/136162)).
 - Drop retired voice UI and unify command ownership ([#136192](https://github.com/openclaw/openclaw/pull/136192)).
 - Streamline shared message rendering ([#136216](https://github.com/openclaw/openclaw/pull/136216)).
-- Reduce full plugin scans for known contribution owners ([#135953](https://github.com/openclaw/openclaw/pull/135953)). Thanks @steipete.
+- Reduce full plugin scans for known contribution owners ([#135953](https://github.com/openclaw/openclaw/pull/135953)).
+- Share bounded diagnostic output across maintainer scripts and E2E runners ([#135802](https://github.com/openclaw/openclaw/pull/135802)). Thanks @vincentkoc.
+- Reuse one collation function within name-sorted cron lists ([#135597](https://github.com/openclaw/openclaw/pull/135597)).
+- Share provider-prefix normalization across Feishu routing paths ([#135744](https://github.com/openclaw/openclaw/pull/135744)). Thanks @vincentkoc.
+- Share one home-directory policy across Claude catalog operations ([#135824](https://github.com/openclaw/openclaw/pull/135824)). Thanks @vincentkoc.
+- Share one bounded thinking-policy path across Bedrock Opus 4.7 and 4.8 ([#136107](https://github.com/openclaw/openclaw/pull/136107)). Thanks @vincentkoc.
+- Give the context-window cache loader one asynchronous ownership path ([#136265](https://github.com/openclaw/openclaw/pull/136265)).
+- Import the update snapshot validator without the full restoration system ([#136298](https://github.com/openclaw/openclaw/pull/136298)).
+- Share one iterative retry lifecycle across OpenAI and Azure Responses ([#136359](https://github.com/openclaw/openclaw/pull/136359)).
+- Avoid unused result wrappers on plugin cache hits ([#136381](https://github.com/openclaw/openclaw/pull/136381)).
+- Reuse prepared payload byte counts in the file logger ([#136393](https://github.com/openclaw/openclaw/pull/136393)).
+- Select Gateway observer model slots without temporary arrays or sorting ([#136401](https://github.com/openclaw/openclaw/pull/136401)).
+- Reuse owned collections during model catalog planning ([#136403](https://github.com/openclaw/openclaw/pull/136403)).
+- Trim newly owned log-tail arrays in place ([#136404](https://github.com/openclaw/openclaw/pull/136404)).
+- Reuse prepared entries during shared string normalization ([#136418](https://github.com/openclaw/openclaw/pull/136418)).
+- Encode agent PTY modifiers from prepared key sequences ([#136425](https://github.com/openclaw/openclaw/pull/136425)).
+- Reuse prepared byte counts in shared tool-output truncation ([#136428](https://github.com/openclaw/openclaw/pull/136428)).
+- Avoid buffer copies for complete local exec and approval JSONL lines ([#136435](https://github.com/openclaw/openclaw/pull/136435)).
+- Build configuration schemas with fewer temporary collections ([#136450](https://github.com/openclaw/openclaw/pull/136450)).
+- Style terminal tables without temporary character arrays ([#136451](https://github.com/openclaw/openclaw/pull/136451)).
+- Deduplicate repeated callbacks with less allocation and map work ([#136457](https://github.com/openclaw/openclaw/pull/136457)).
+- Sanitize terminal upload filenames with less temporary processing ([#136479](https://github.com/openclaw/openclaw/pull/136479)).
+- Use one hydration path for interactive plugin callback state ([#136481](https://github.com/openclaw/openclaw/pull/136481)).
+- Route unknown direct messages through one canonical internal resolver ([#136580](https://github.com/openclaw/openclaw/pull/136580)).
+- Reduce temporary heap while styling terminal text ([#136626](https://github.com/openclaw/openclaw/pull/136626)).
+- Skip error-only diagnostic formatting after successful node selection ([#136654](https://github.com/openclaw/openclaw/pull/136654)).
+- Avoid eager session-storage initialization during Gateway method discovery ([#136676](https://github.com/openclaw/openclaw/pull/136676)).
+- Defer skill discovery imports for ordinary replies ([#136716](https://github.com/openclaw/openclaw/pull/136716)).
 
 **Security and trust**
 
@@ -2728,9 +2141,7 @@ Behavior-preserving refactors consolidate duplicated ownership and trim repeated
 
 </details>
 
-</Accordion>
-
-<Accordion title="QA and maintainer workflow fixes">
+**QA and maintainer workflow fixes**
 
 The remaining maintainer fixes repair local previews, QA simulators, merge helpers, packaging checks, and other contributor workflows without turning those changes into public product claims.
 
@@ -2744,13 +2155,14 @@ The remaining maintainer fixes repair local previews, QA simulators, merge helpe
 - Restore the CLI test type gate for optional TTY overrides ([#135407](https://github.com/openclaw/openclaw/pull/135407)). Thanks @itsuzef.
 - Stabilize state-directory safety proof under CI load ([#135495](https://github.com/openclaw/openclaw/pull/135495)). Thanks @lzhan011.
 - Tie exec approval fixtures to the canonical cwd owner ([#134937](https://github.com/openclaw/openclaw/pull/134937)).
-- Allow macOS shell-timeout fixtures a startup margin ([#134969](https://github.com/openclaw/openclaw/pull/134969)). Thanks @steipete.
+- Allow macOS shell-timeout fixtures a startup margin ([#134969](https://github.com/openclaw/openclaw/pull/134969)).
 - Make native plugin-loading regressions visible to tests ([#135425](https://github.com/openclaw/openclaw/pull/135425)).
 - Reach the package update in Docker survivor validation ([#135561](https://github.com/openclaw/openclaw/pull/135561)). Thanks @fuller-stack-dev.
 - Use isolated linking for eligible macOS source installs ([#135728](https://github.com/openclaw/openclaw/pull/135728)).
 - Keep preview avatar requests away from the operator Gateway ([#134686](https://github.com/openclaw/openclaw/pull/134686)).
-- Isolate concurrent standalone previews from external connections ([#135724](https://github.com/openclaw/openclaw/pull/135724)). Thanks @steipete.
+- Isolate concurrent standalone previews from external connections ([#135724](https://github.com/openclaw/openclaw/pull/135724)).
 - Reject oversized QA uploads without crashing shutdown ([#135938](https://github.com/openclaw/openclaw/pull/135938)).
+- Preserve built-CLI SQLite failure diagnostics when plugin inspection fails ([#136478](https://github.com/openclaw/openclaw/pull/136478)).
 
 </details>
 


### PR DESCRIPTION
## What Problem This Solves

The existing v2026.9.1 release page accounts for only 924 of the 1,214 current release units. An earlier corrective draft filled that gap but imposed a uniform two-topic-per-section structure, collapsing 96 distinct reader workflows into 29 broad accordions. Complete source links alone did not preserve the page's established information architecture or make every meaningful change easy for people and LLMs to understand.

## Why This Change Was Made

This revision is bound to release snapshot `21616f1a5cac00c236a363a3f404f5f166f74855`. It retains all 96 approved topics, adds two evidence-backed stories for background-session notifications and ingress limits, and broadens three titles without merging or removing an approved topic. The resulting 98-topic structure follows the scope of the content rather than a numeric quota or line-count target.

The page accounts for all 1,214 release units exactly once: 1,186 pull requests and 28 direct commits, with 683 public units and 531 maintainer-only units. Narrow fixes, test mechanics, and release machinery remain in informative collapsed source disclosures; material changes remain named in readable prose or source labels.

The correction also keeps PR #136440 limited to the sent-image hover and caption repair. Incorrect descriptions of PR #136178 and PR #136402 are not treated as relationships or repeated in the page.

An external OpenAI Embeddings API pilot supplied advisory grouping context for the exact 683-unit public corpus using `text-embedding-3-small` over HTTPS with 1,536-dimensional vectors. It reused 681 cryptographically verified rows and called the API for only two new public inputs. Embeddings had no classification or approval authority.

## User Impact

Readers get a complete v2026.9.1 reference that preserves the established release-note formula: fixed product categories, content-driven topic accordions, concise outcome-led explanations, nearby cautions, and exhaustive source accounting. The document is detailed enough to support human and LLM-assisted investigation without promoting implementation noise into the visible story.

This is a documentation correction only. It does not change product behavior, merge itself, or publish a release.

## Evidence

- The completed `21616f1a` manifest contains 1,186 PR units and 28 direct commits, for 1,214 unique units and 281 contributors under the established verified-credit exclusions.
- Independent full-page review reports `APPROVED_FOR_HUMAN_REVIEW` at candidate digest `16011d28961ff321f20599b55eb629ae0a243a23cc384de40feadf1079dd439f`, with no unresolved critical or major finding.
- Every manifest unit appears once; all 683 public units precede `Maintainer and Internal Changes`, and all 531 maintainer-only units appear only there.
- One additional PR URL, #134871, is contextual provenance for direct-commit unit `61404b6`; it is not an additional release unit or part of the 1,186-PR total.
- The page contains all 15 canonical H2 sections, 98 balanced topic accordions, 98 balanced source disclosures, and no excluded maintainer credit.
- Focused validation passes for MDX, Markdown lint, formatting, docs listing, glossary, internal links, and diff hygiene. The link audit checked 7,299 internal links with zero breaks.
- The target diff changes only `docs/releases/2026.9.1.md`, and that file matches the independently reviewed 3,163-line candidate byte for byte.
