### PR TITLE
fix: reuse prepared catalogs and repair Gateway E2E fixtures

### DIFF
--- a/qa/scenarios/runtime/openclaw-sandbox-workspace-isolation.yaml
+++ b/qa/scenarios/runtime/openclaw-sandbox-workspace-isolation.yaml
@@ -8,7 +8,7 @@ scenario:
       - tools.workspace-isolation
   objective: Verify real Docker sandbox mounts isolate host workspaces according to none, read-only, and read-write access.
   successCriteria:
-    - None mode exposes neither the agent workspace nor its sentinel and rejects sandbox workspace mutation.
+    - None mode permits private workspace mutation without exposing or changing the agent workspace.
     - Read-only mode exposes the agent workspace at /agent, rejects mutation, and leaves host content unchanged.
     - Read-write mode persists /workspace mutation to the host workspace.
     - Every mode keeps an unrelated host sentinel inaccessible and cleans up its runtime and state.

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -181,70 +181,74 @@ describe("prepared model catalog access", () => {
     expect(mocks.releaseSnapshot).not.toHaveBeenCalled();
   });
 
-  it("refreshes stale catalog content during an explicit read-only load", async () => {
-    const staleCatalog = {
-      entries: [{ provider: "test", id: "fresh", name: "Fresh" }],
-      routeVariants: [],
-    };
-    const snapshot = {
-      ...fullSnapshot,
-      loadFullModelCatalog: vi.fn(),
-      readFullModelCatalog: vi.fn(() => fullSnapshot.modelCatalog),
-    };
-    mocks.getSnapshot.mockReturnValue(snapshot);
-    mocks.prepareSnapshot.mockResolvedValue(snapshot);
-    mocks.refreshStaleCatalog.mockResolvedValue(staleCatalog);
-    setPreparedModelFullCatalogAuth(staleCatalog, {
-      authStore: fullSnapshot.authStore,
-      authModes: fullSnapshot.authModes,
-    });
+  it.each([
+    { readOnly: true, refreshFullCatalog: "stale" },
+    { readOnly: false, refreshFullCatalog: "stale" },
+    { readOnly: true, refreshFullCatalog: true },
+    { readOnly: false, refreshFullCatalog: true },
+  ] as const)(
+    "refreshes stale content once (readOnly=$readOnly, refresh=$refreshFullCatalog)",
+    async ({ readOnly, refreshFullCatalog }) => {
+      const staleCatalog = {
+        entries: [{ provider: "test", id: "fresh", name: "Fresh" }],
+        routeVariants: [],
+      };
+      const snapshot = {
+        ...fullSnapshot,
+        loadFullModelCatalog: vi.fn(),
+        readFullModelCatalog: vi.fn(() => fullSnapshot.modelCatalog),
+      };
+      mocks.getSnapshot.mockReturnValue(snapshot);
+      mocks.prepareSnapshot.mockResolvedValue(snapshot);
+      mocks.refreshStaleCatalog.mockResolvedValue(staleCatalog);
+      setPreparedModelFullCatalogAuth(staleCatalog, {
+        authStore: fullSnapshot.authStore,
+        authModes: fullSnapshot.authModes,
+      });
 
-    await expect(
-      loadPreparedModelCatalogOwnerSnapshot({ readOnly: true, refreshFullCatalog: true }),
-    ).resolves.toMatchObject({ modelCatalog: staleCatalog });
-    expect(mocks.refreshStaleCatalog).toHaveBeenCalledWith(snapshot);
-    expect(snapshot.readFullModelCatalog).not.toHaveBeenCalled();
-  });
+      await expect(
+        loadPreparedModelCatalogOwnerSnapshot({ readOnly, refreshFullCatalog }),
+      ).resolves.toMatchObject({ modelCatalog: staleCatalog });
+      expect(mocks.refreshStaleCatalog).toHaveBeenCalledWith(snapshot);
+      expect(snapshot.readFullModelCatalog).not.toHaveBeenCalled();
+      expect(snapshot.loadFullModelCatalog).not.toHaveBeenCalled();
+    },
+  );
 
-  it("keeps auth-only reads on the current catalog facts", async () => {
-    const snapshot = {
-      ...fullSnapshot,
-      loadFullModelCatalog: vi.fn(),
-      readFullModelCatalog: vi.fn(() => fullSnapshot.modelCatalog),
-    };
-    mocks.getSnapshot.mockReturnValue(snapshot);
-    mocks.prepareSnapshot.mockResolvedValue(snapshot);
-    setPreparedModelFullCatalogAuth(snapshot.modelCatalog, {
-      authStore: fullSnapshot.authStore,
-      authModes: fullSnapshot.authModes,
-    });
+  it.each([
+    { readOnly: true, refreshFullCatalog: undefined },
+    { readOnly: true, refreshFullCatalog: false },
+    { readOnly: false, refreshFullCatalog: undefined },
+    { readOnly: false, refreshFullCatalog: false },
+  ] as const)(
+    "does not refresh current facts without intent (readOnly=$readOnly, refresh=$refreshFullCatalog)",
+    async ({ readOnly, refreshFullCatalog }) => {
+      const snapshot = {
+        ...fullSnapshot,
+        loadFullModelCatalog: vi.fn(async () => fullSnapshot.modelCatalog),
+        readFullModelCatalog: vi.fn(() => fullSnapshot.modelCatalog),
+      };
+      mocks.getSnapshot.mockReturnValue(snapshot);
+      mocks.prepareSnapshot.mockResolvedValue(snapshot);
+      mocks.refreshStaleCatalog.mockRejectedValue(new Error("full discovery was awaited"));
+      setPreparedModelFullCatalogAuth(snapshot.modelCatalog, {
+        authStore: fullSnapshot.authStore,
+        authModes: fullSnapshot.authModes,
+      });
 
-    await expect(
-      loadPreparedModelCatalogOwnerSnapshot({ readOnly: true, refreshFullCatalog: false }),
-    ).resolves.toMatchObject({ modelCatalog: fullSnapshot.modelCatalog });
-    expect(mocks.refreshStaleCatalog).not.toHaveBeenCalled();
-    expect(snapshot.readFullModelCatalog).toHaveBeenCalledOnce();
-  });
-
-  it("does not await a stale full catalog for read-only request paths", async () => {
-    const snapshot = {
-      ...fullSnapshot,
-      loadFullModelCatalog: vi.fn(),
-      readFullModelCatalog: vi.fn(() => fullSnapshot.modelCatalog),
-    };
-    mocks.getSnapshot.mockReturnValue(snapshot);
-    mocks.prepareSnapshot.mockResolvedValue(snapshot);
-    mocks.refreshStaleCatalog.mockRejectedValue(new Error("full discovery was awaited"));
-    setPreparedModelFullCatalogAuth(snapshot.modelCatalog, {
-      authStore: fullSnapshot.authStore,
-      authModes: fullSnapshot.authModes,
-    });
-
-    await expect(loadPreparedModelCatalogSnapshot({ readOnly: true })).resolves.toBe(
-      snapshot.modelCatalog,
-    );
-    expect(mocks.refreshStaleCatalog).not.toHaveBeenCalled();
-  });
+      await expect(
+        loadPreparedModelCatalogOwnerSnapshot({ readOnly, refreshFullCatalog }),
+      ).resolves.toMatchObject({ modelCatalog: fullSnapshot.modelCatalog });
+      expect(mocks.refreshStaleCatalog).not.toHaveBeenCalled();
+      if (readOnly) {
+        expect(snapshot.readFullModelCatalog).toHaveBeenCalledOnce();
+        expect(snapshot.loadFullModelCatalog).not.toHaveBeenCalled();
+      } else {
+        expect(snapshot.loadFullModelCatalog).toHaveBeenCalledExactlyOnceWith({ refresh: false });
+        expect(snapshot.readFullModelCatalog).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("reuses a published full generation for a provider-scoped read-only load", async () => {
     mocks.prepareSnapshot.mockResolvedValue(fullSnapshot);
@@ -288,7 +292,7 @@ describe("prepared model catalog access", () => {
     );
   });
 
-  it("keeps read-only catalog reads on configured facts and materializes full reads once", async () => {
+  it("keeps read-only facts, cached full reads, and forced refreshes distinct", async () => {
     const configuredCatalog = {
       entries: [{ provider: "test", id: "configured", name: "Configured" }],
       routeVariants: [],
@@ -317,7 +321,11 @@ describe("prepared model catalog access", () => {
     expect(materialized.modelCatalog).toBe(discoveredCatalog);
     expect(materialized).not.toHaveProperty("authStore");
     expect(getPreparedModelRuntimeAuthStore(materialized)).toBe(authStore);
-    expect(loadFullModelCatalog).toHaveBeenCalledOnce();
+    expect(loadFullModelCatalog).toHaveBeenCalledExactlyOnceWith({ refresh: false });
+
+    await loadPreparedModelCatalogOwnerSnapshot({ readOnly: false, refreshFullCatalog: true });
+    expect(loadFullModelCatalog).toHaveBeenCalledTimes(2);
+    expect(loadFullModelCatalog).toHaveBeenLastCalledWith({ refresh: true });
 
     mocks.getSnapshot.mockReturnValue(snapshot);
     expect(getPreparedModelCatalogSnapshot({ readOnly: true })).toBe(configuredCatalog);

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -53,8 +53,8 @@ export type LoadPreparedModelCatalogParams = {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   providerDiscoveryProviderIds?: readonly string[];
-  /** Rebuilds a completed full catalog instead of reusing this generation's cache. */
-  refreshFullCatalog?: boolean;
+  /** Refreshes auth-stale inventory; true also rebuilds a fresh full catalog on writable reads. */
+  refreshFullCatalog?: boolean | "stale";
   /** Scoped read-only loads may run live discovery for the scoped providers only. */
   scopedLiveProviderDiscovery?: boolean;
   allowGatewaySubagentBinding?: boolean;
@@ -70,19 +70,21 @@ type PreparedModelCatalogConfigPolicy = "exact" | "published";
 async function materializeRequestedModelCatalog(
   snapshot: PreparedModelRuntimeSnapshot,
   readOnly: boolean | undefined,
-  refreshFullCatalog: boolean | undefined,
+  refreshFullCatalog: LoadPreparedModelCatalogParams["refreshFullCatalog"],
 ): Promise<PreparedModelRuntimeSnapshot> {
   if (!snapshot.loadFullModelCatalog) {
     return snapshot;
   }
+  // Inventory reads repair auth-stale content without making turn-path reads start discovery.
   const staleCatalog =
-    readOnly === true && refreshFullCatalog === true
+    refreshFullCatalog === "stale" || refreshFullCatalog === true
       ? await refreshStalePreparedModelRuntimeCatalog(snapshot)
       : undefined;
   const modelCatalog =
-    readOnly === true
-      ? (staleCatalog ?? snapshot.readFullModelCatalog?.())
-      : await snapshot.loadFullModelCatalog({ refresh: refreshFullCatalog === true });
+    staleCatalog ??
+    (readOnly === true
+      ? snapshot.readFullModelCatalog?.()
+      : await snapshot.loadFullModelCatalog({ refresh: refreshFullCatalog === true }));
   if (!modelCatalog) {
     return snapshot;
   }

--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -44,17 +44,18 @@ describe("appendWorkspaceMountArgs", () => {
   });
 
   it("omits agent workspace mount when workspaceAccess is none", () => {
+    const workspaceDir = makeTempWorkspace();
+    const agentWorkspaceDir = makeTempWorkspace();
     const args: string[] = [];
     appendWorkspaceMountArgs({
       args,
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/agent-workspace",
+      workspaceDir,
+      agentWorkspaceDir,
       workdir: "/workspace",
       workspaceAccess: "none",
     });
 
-    const mounts = args.filter((arg) => arg.startsWith("/tmp/"));
-    expect(mounts).toEqual(["/tmp/workspace:/workspace:z"]);
+    expect(args).toEqual(["-v", `${workspaceDir}:/workspace:z`]);
   });
 
   it("omits agent workspace mount when paths are identical", () => {

--- a/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
@@ -91,6 +91,8 @@ function visibleAgentResponse(runId = "run-main") {
       payloads: [{ text: "announced" }],
       didSendViaMessagingTool: true,
       messagingToolSentTexts: ["announced"],
+      didDeliverSourceReplyViaMessageTool: true,
+      messagingToolSourceReplyPayloads: [{ text: "announced", sourceReplyFinal: true }],
     },
   };
 }

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -331,7 +331,7 @@ describe("handleModelsCommand", () => {
     await handleModelsCommand(buildParams("/models"), true);
 
     expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.readOnly).toBe(true);
-    expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.refreshFullCatalog).toBe(true);
+    expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.refreshFullCatalog).toBe("stale");
     const authCheckerParams = preparedAuthCheckerParams();
     expect(authCheckerParams?.allowPluginSyntheticAuth).toBe(false);
     expect(authCheckerParams?.discoverExternalCliAuth).toBe(false);
@@ -363,6 +363,7 @@ describe("handleModelsCommand", () => {
     await handleModelsCommand(params, true);
 
     expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.readOnly).toBe(false);
+    expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.refreshFullCatalog).toBe("stale");
     expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.workspaceDir).toBe(
       "/tmp/spawned-workspace",
     );

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -207,7 +207,7 @@ async function buildPreparedDataForConfig(
       loadedOwner = await preparedModelCatalog.loadPreparedModelCatalogOwnerSnapshot({
         config: cfg,
         readOnly,
-        refreshFullCatalog: true,
+        refreshFullCatalog: "stale",
         ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
         ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
       });

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -289,7 +289,7 @@ describe("loadListModelCatalogSnapshot", () => {
     await loadListModelCatalogSnapshot(createRowContext({ authIndex }));
 
     expect(mocks.loadModelCatalogSnapshot).toHaveBeenCalledWith(
-      expect.objectContaining({ readOnly: true, refreshFullCatalog: true }),
+      expect.objectContaining({ readOnly: true, refreshFullCatalog: "stale" }),
     );
   });
 });

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -381,7 +381,7 @@ export async function loadListModelCatalogSnapshot(
     agentDir: context.agentDir,
     ...(workspaceDir ? { workspaceDir } : {}),
     readOnly: true,
-    refreshFullCatalog: true,
+    refreshFullCatalog: "stale",
   });
 }
 

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -445,7 +445,7 @@ export async function prepareModelsListResult(
       loadedSnapshot = await loadDeferredCatalog(params.context, initialAgentId, {
         readOnly: loadedReadOnly,
         refreshAuth: refresh && loadedReadOnly,
-        ...(!preparedOnly ? { refreshFullCatalog: true } : {}),
+        ...(!preparedOnly ? { refreshFullCatalog: refresh ? true : "stale" } : {}),
       });
       return loadedSnapshot;
     },
@@ -473,7 +473,7 @@ export async function prepareModelsListResult(
         fullSnapshot = await loadDeferredCatalog(params.context, escalationAgentId, {
           readOnly,
           refreshAuth: refresh && readOnly,
-          refreshFullCatalog: true,
+          refreshFullCatalog: refresh ? true : "stale",
         });
         return fullSnapshot;
       },

--- a/src/gateway/server-model-catalog-auth.ts
+++ b/src/gateway/server-model-catalog-auth.ts
@@ -1,4 +1,5 @@
 import type { RuntimeAuthMaterialization } from "../agents/auth-profiles/runtime-materializations.js";
+import type { LoadPreparedModelCatalogParams } from "../agents/prepared-model-catalog.js";
 import type { ResolvedPublishedModelCatalogOwner } from "../agents/prepared-model-catalog.types.js";
 import type { PreparedModelRuntimeAuthScope } from "../agents/prepared-model-runtime-auth.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
@@ -15,7 +16,7 @@ type GatewayModelCatalogReadParams = {
   authScope?: PreparedModelRuntimeAuthScope;
   readOnly?: boolean;
   refreshAuth?: boolean;
-  refreshFullCatalog?: boolean;
+  refreshFullCatalog?: LoadPreparedModelCatalogParams["refreshFullCatalog"];
   workspaceDir?: string;
 };
 

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -1,4 +1,5 @@
 import { resolvePublishedModelCatalogOwner } from "../agents/prepared-model-catalog-owner.js";
+import type { LoadPreparedModelCatalogParams } from "../agents/prepared-model-catalog.js";
 import type {
   PublishedModelCatalogOwnerCandidate,
   ResolvedPublishedModelCatalogOwner,
@@ -27,7 +28,7 @@ type LoadPublishedPreparedModelCatalogOwnerSnapshot = (params: {
   agentDir?: string;
   config: GatewayModelCatalogConfig;
   readOnly?: boolean;
-  refreshFullCatalog?: boolean;
+  refreshFullCatalog?: LoadPreparedModelCatalogParams["refreshFullCatalog"];
   workspaceDir?: string;
 }) => Promise<PublishedModelCatalogOwnerCandidate>;
 type LoadGatewayModelCatalogParams = {
@@ -36,7 +37,7 @@ type LoadGatewayModelCatalogParams = {
   getConfig?: () => GatewayModelCatalogConfig;
   loadPublishedPreparedModelCatalogOwnerSnapshot?: LoadPublishedPreparedModelCatalogOwnerSnapshot;
   readOnly?: boolean;
-  refreshFullCatalog?: boolean;
+  refreshFullCatalog?: LoadPreparedModelCatalogParams["refreshFullCatalog"];
   workspaceDir?: string;
 };
 type LoadPreparedGatewayModelCatalogParams = LoadGatewayModelCatalogParams & {

--- a/test/e2e/qa-lab/runtime/openclaw-sandbox-workspace-isolation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/openclaw-sandbox-workspace-isolation.e2e.test.ts
@@ -116,8 +116,10 @@ test("Docker enforces none, read-only, and read-write workspace isolation", asyn
             'test ! -e /agent && test ! -e /workspace/host-sentinel.txt && test ! -e "$1"',
             [hostSentinel],
           );
-          const mutation = await run(sandbox, "printf blocked > /workspace/blocked.txt", [], true);
-          expect(mutation.code).not.toBe(0);
+          await expectOk(
+            sandbox,
+            'printf private > /workspace/host-sentinel.txt && test "$(cat /workspace/host-sentinel.txt)" = private',
+          );
           await expect(fs.readFile(hostSentinel, "utf8")).resolves.toBe("original-none");
         } else if (access === "ro") {
           await expectOk(

--- a/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
@@ -26,6 +26,7 @@ const BOT_TOKEN = "424242:telegram-model-picker-proof";
 const CHAT_ID = 2468;
 const MESSAGE_ID = 9001;
 const PREPARED_MODEL = "prepared-model";
+const DISCOVERED_MODEL = "discovered-model";
 const REPLACEMENT_MODEL = "replacement-model";
 const REPLACEMENT_PROVIDER = "qa-picker";
 const REPLACEMENT_MODEL_REF = `${REPLACEMENT_PROVIDER}/${REPLACEMENT_MODEL}`;
@@ -448,10 +449,10 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
         writeJson(res, 503, { ok: false, error: "provider discovery frozen after warmup" });
         return;
       }
-      succeed(res, {
+      writeJson(res, 200, {
         models: [
           {
-            name: PREPARED_MODEL,
+            name: DISCOVERED_MODEL,
             modified_at: "2026-08-16T00:00:00Z",
             digest: "prepared-model-digest",
             size: 1,
@@ -468,7 +469,7 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
         writeJson(res, 503, { ok: false, error: "provider discovery frozen after warmup" });
         return;
       }
-      succeed(res, {
+      writeJson(res, 200, {
         model_info: { "general.context_length": 8192 },
         capabilities: ["completion", "tools"],
       });
@@ -518,7 +519,7 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
     } else if (
       method === "editMessageText" &&
       pickerStage === "models" &&
-      hasCallback({ method, body }, `mdl_sel_ollama/${PREPARED_MODEL}`)
+      hasCallback({ method, body }, `mdl_sel_ollama/${DISCOVERED_MODEL}`)
     ) {
       pickerStage = "repeated-providers";
       queueCallback("mdl_prov");
@@ -556,7 +557,7 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
         const gatewayOwner = createQaGatewayChild();
         try {
           const repoRoot = path.resolve(import.meta.dirname, "../../../..");
-          await gatewayOwner.start({
+          const gateway = await gatewayOwner.start({
             repoRoot,
             useRepoCli: true,
             transportBaseUrl: apiRoot,
@@ -632,11 +633,18 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
           pendingUpdates.push(initialModelsUpdate());
 
           await expect
-            .poll(() => ({ stage: pickerStage, discoveryRequests }), {
+            .poll(() => pickerStage, {
               interval: 50,
               timeout: 30_000,
             })
-            .toEqual({ stage: "providers", discoveryRequests: 2 });
+            .toBe("providers");
+          const warmedModels = await gateway.call("models.list", { view: "all" });
+          expect(warmedModels).toMatchObject({
+            models: expect.arrayContaining([
+              expect.objectContaining({ provider: "ollama", id: DISCOVERED_MODEL }),
+            ]),
+          });
+          expect(discoveryRequests).toBeGreaterThan(0);
           const warmDiscoveryRequests = discoveryRequests;
           discoveryFrozen = true;
           queueCallback("mdl_prov");
@@ -664,15 +672,33 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
           expect(hasCallback(pickerEdits[2]!, "mdl_list_ollama_1")).toBe(true);
           expect(
             pickerEdits[1] &&
-              keyboardCallbackData(pickerEdits[1]).includes(`mdl_sel_ollama/${PREPARED_MODEL}`),
+              keyboardCallbackData(pickerEdits[1]).includes(`mdl_sel_ollama/${DISCOVERED_MODEL}`),
           ).toBe(true);
           expect(pickerEdits[3] && hasCallback(pickerEdits[3], "mdl_list_ollama_1")).toBe(true);
 
           expect(
             telegramCalls.filter((call) => call.method === "answerCallbackQuery"),
           ).toHaveLength(4);
+          const preparedModels = await gateway.call("models.list", { view: "default" });
+          expect(preparedModels).toMatchObject({
+            models: expect.arrayContaining([
+              expect.objectContaining({ provider: "ollama", id: DISCOVERED_MODEL }),
+            ]),
+          });
           expect(discoveryRequests).toBe(warmDiscoveryRequests);
           expect(postWarmDiscoveryAttempts).toBe(0);
+
+          discoveryFrozen = false;
+          const refreshedModels = await gateway.call("models.list", {
+            view: "default",
+            refresh: true,
+          });
+          expect(refreshedModels).toMatchObject({
+            models: expect.arrayContaining([
+              expect.objectContaining({ provider: "ollama", id: DISCOVERED_MODEL }),
+            ]),
+          });
+          expect(discoveryRequests).toBeGreaterThan(warmDiscoveryRequests);
         } finally {
           await settleCleanup(async () => await stopQaGatewayFixture(gatewayOwner));
         }

--- a/test/e2e/qa-lab/runtime/webhooks-taskflow-cancellation-authz.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/webhooks-taskflow-cancellation-authz.e2e.test.ts
@@ -262,12 +262,6 @@ describe("webhooks TaskFlow child cancellation authority", () => {
               stateDir: acpxStateDir,
               permissionMode: "deny-all",
               timeoutSeconds: 15,
-              agents: {
-                codex: {
-                  command: process.execPath,
-                  args: [path.resolve("node_modules/@agentclientprotocol/codex-acp/dist/index.js")],
-                },
-              },
             },
             runtime: acpxRuntime,
             registerService: (service) => {
@@ -524,8 +518,8 @@ describe("webhooks TaskFlow child cancellation authority", () => {
             throw new Error("failed to create persisted ACP projection");
           }
 
-          const elicitationEntered = createDeferred<void>();
-          const releaseElicitation = createDeferred<void>();
+          const elicitationEntered = createDeferred();
+          const releaseElicitation = createDeferred();
           const replacementAcpTurn = acpManager.runTurn({
             admittedRunContext: createTestAdmittedRunContext(reusedAcpRunId),
             cfg: config,
@@ -586,8 +580,8 @@ describe("webhooks TaskFlow child cancellation authority", () => {
             mode: "persistent",
             backendId: "acpx",
           });
-          const queuedTargetEntered = createDeferred<void>();
-          const releaseQueuedTarget = createDeferred<void>();
+          const queuedTargetEntered = createDeferred();
+          const releaseQueuedTarget = createDeferred();
           const queuedTargetTurn = acpManager.runTurn({
             admittedRunContext: createTestAdmittedRunContext(queuedAcpRunId),
             cfg: config,
@@ -614,8 +608,8 @@ describe("webhooks TaskFlow child cancellation authority", () => {
           const interruptsBeforeQueuedCancel = (await readAcpTraceMethods(acpxTracePath)).filter(
             (method) => method === "turn/interrupt",
           ).length;
-          const queuedSuccessorEntered = createDeferred<void>();
-          const releaseQueuedSuccessor = createDeferred<void>();
+          const queuedSuccessorEntered = createDeferred();
+          const releaseQueuedSuccessor = createDeferred();
           const queuedSuccessorTurn = acpManager.runTurn({
             admittedRunContext: createTestAdmittedRunContext(queuedAcpRunId),
             cfg: config,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users browsing models through Telegram or Gateway RPC repeatedly triggered provider discovery instead of reusing the prepared catalog. Also repairs three stale Gateway E2E fixtures that blocked release validation: confirmed announcement delivery, private sandbox workspace writes, and ACP adapter startup.

These failures were already present on `c92d0ae9c07e` in [Full Release Validation run 1 / Release Checks](https://github.com/openclaw/openclaw/actions/runs/33697211727), as well as on `a41af7eb71a95` in [run 2 / Release Checks](https://github.com/openclaw/openclaw/actions/runs/33704895939). They were not introduced by the intervening release cherry-picks. The duplicated CI summaries account for the reported 42 announcement failures and two ACP failures.

## Why This Change Was Made

Inventory callers now refresh content when the catalog owner marks it stale after authentication changes. Ordinary reads reuse the prepared generation, and explicit refresh still forces discovery. The shared catalog owner handles that policy for Telegram commands, CLI listing, and Gateway `models.list`; turn-path reads retain their existing behavior. Production delta: +4 lines, needed to distinguish those refresh intents and propagate the owner's type. No configuration, environment, schema, or protocol surface is added.

The announcement fixture now supplies the committed source-reply receipt required by production. The Docker test verifies that `none` permits private writes without exposing or modifying the host workspace. The ACP fixture delegates adapter resolution to its owning plugin instead of hardcoding a nonexistent root dependency path. No delivery guard, sibling-reroute fix, sandbox boundary, or cancellation check is removed. The sandbox owner test also uses its temporary-workspace helper so existing `/tmp/workspace/skills` content cannot alter the fixture.

## User Impact

Prepared models remain available while browsing when discovery is unavailable. Explicit refresh and auth-change recovery remain supported. The other changes improve release validation without changing runtime behavior.

## Evidence

| Item | Before | After |
| --- | --- | --- |
| A — announce formatting | 21/87 failed locally at both release tips | 87/87 passed |
| B — prepared model picker | Original CI: 6 discovery calls vs 2; strengthened local fixture: 8 vs 3 | Both picker cases passed; discovery stayed frozen until explicit refresh |
| C — workspace isolation | Test incorrectly rejected successful private write | Real OrbStack Docker: none/ro/rw passed; host sentinel preserved |
| D — ACP cancellation | Deterministic `MODULE_NOT_FOUND` for root adapter path | Real adapter process passed replacement and queued-successor cancellation proof |

The picker fixture uses the Ollama API's raw response shape, waits for full catalog readiness, and verifies a model absent from configuration across callbacks and RPC with discovery disabled. It separately verifies explicit refresh reaches the provider. The replacement-catalog callback case remains covered.

ACP dependency inspection also covered the installed adapter's `CODEX_PATH` entry point and Codex app-server [initialization](https://github.com/openai/codex/blob/94cbbddafc1776d5e377bca1b05932c697e82238/codex-rs/app-server/src/request_processors/initialize_processor.rs#L44) and [turn interruption](https://github.com/openai/codex/blob/94cbbddafc1776d5e377bca1b05932c697e82238/codex-rs/app-server/src/request_processors/turn_processor.rs#L1590). The fixture repair preserves that process protocol.

Asserted Gateway behavior from the passing run:

```json
{"scenario":"telegram-model-picker-prepared-gateway","verdict":"pass","callbackAcknowledgements":4,"postWarmDiscoveryAttempts":0,"discoveredOnlyModelRetained":true,"explicitRefreshReachedProvider":true,"replacementCallbackRecovered":true}
```

On the release-based candidate, all 12 owner test files pass (482 tests), including 39 requester-wake cases and 259 announcement-delivery cases. The final independent review found no actionable P0–P2 findings. The committed private-QA runtime build passed and the combined four-file E2E run passed 91/91 on release-based head `01f106dd37a0979ea71724932d7103a48a3f05c3`. The broad `pnpm check:changed` run passed all architecture, type, full-lint, and import-cycle checks, then found six pre-existing redundant `<void>` arguments in the ACP fixture. Those were removed; the focused `pnpm check:changed --base HEAD --head HEAD -- test/e2e/qa-lab/runtime/webhooks-taskflow-cancellation-authz.e2e.test.ts` recovery run passed. The ACP E2E also passed again after that type-only cleanup.

Initial local Gateway timeouts were missing private-QA build artifacts; building the same private-QA profile used by CI fixed startup without increasing timeouts. Full Release Validation itself has not been rerun. Telegram/Ollama proof uses a real Gateway with mock HTTP services; ACP uses the installed adapter with a synthetic app-server fixture; sandbox proof uses Docker.

Release cherry-picks, in order:

- `8229b8fcb61fa3a4e5b0c80acff087547a7904d4`
- `1dfddb6e8fa7f57fcc60c4f01384b679e88ad77a`
- `85079b8ca7571f48537ef3b0ce5d393880b8b0c7`
- `1e15a1d9ce4cb7ff9d1364ea8b4fe2528ef81c55`

These four commits rebased cleanly onto `41419be40bbb17e5eed318992c8e3bf1aee6199b`. Applying their patches sequentially to `a41af7eb71a95f7fc1ebc83d1b34d8a7a4ed0fe7` reproduced the verified release candidate tree exactly (`5fcea21d19edfc87037f2c8ff75504da269970cd`). The private-QA build and all 91 E2E cases also passed on final main-based head `1e15a1d9ce4cb7ff9d1364ea8b4fe2528ef81c55`.

Named follow-up: replace the existing literal-only thread-routing cases in the announcement format suite with runtime-backed assertions; those unrelated cases are unchanged here.

Focused E2E invocation (after the private-QA runtime build):

```sh
OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 \
OPENCLAW_E2E_WORKERS=2 OPENCLAW_E2E_USE_PREBUILT_DIST=1 \
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts \
  src/agents/subagents/announce/subagent-announce.format.e2e.test.ts \
  test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts \
  test/e2e/qa-lab/runtime/openclaw-sandbox-workspace-isolation.e2e.test.ts \
  test/e2e/qa-lab/runtime/webhooks-taskflow-cancellation-authz.e2e.test.ts
```
