### PR TITLE
improve: keep Activity responsive with long session histories

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-title-probes.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-title-probes.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { afterEach, expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -15,7 +15,7 @@ import {
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-test("bounds transcript boundary inspection independently of preview message count", async () => {
+test.each([false, true])("bounds transcript boundary work (compacted: %s)", async (compacted) => {
   const env = captureEnv(["OPENCLAW_STATE_DIR"]);
   const tempDir = tempDirs.make("openclaw-title-probe-work-");
   setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
@@ -41,7 +41,21 @@ test("bounds transcript boundary inspection independently of preview message cou
   const nativeJson = new DatabaseSync(":memory:");
   const extractJson = nativeJson.prepare("SELECT json_extract(?, ?) AS value");
   try {
-    await replaceTranscriptEvents(scope, [...messages, ...metadata]);
+    await replaceTranscriptEvents(scope, [
+      ...messages,
+      ...metadata,
+      ...(compacted
+        ? [
+            {
+              type: "compaction",
+              id: "compaction",
+              parentId: "metadata-19",
+              firstKeptEntryId: "message-0",
+              summary: "Synthetic compaction summary ".repeat(4096),
+            },
+          ]
+        : []),
+    ]);
     const database = openOpenClawAgentDatabase({
       agentId: scope.agentId,
       path: path.join(tempDir, "openclaw-agent.sqlite"),
@@ -54,7 +68,12 @@ test("bounds transcript boundary inspection independently of preview message cou
       return extractJson.get(value, jsonPath)?.value ?? null;
     });
 
+    const parse = vi.spyOn(JSON, "parse");
     const [probe] = readSessionTranscriptTitleProbeBatch([scope]);
+    const boundaryParses = parse.mock.calls.filter(([value]) =>
+      value.includes("Synthetic compaction summary"),
+    ).length;
+    parse.mockRestore();
     expect(probe?.totalMessages).toBe(messages.length);
     expect(probe?.head).toHaveLength(20);
     expect(probe?.tail).toHaveLength(20);
@@ -62,7 +81,9 @@ test("bounds transcript boundary inspection independently of preview message cou
     expect(probe?.tail.at(-1)?.event).toMatchObject({ id: "message-59" });
     expect(boundaryInspections).toBeGreaterThan(0);
     expect(boundaryInspections).toBeLessThanOrEqual(metadata.length * 2);
+    expect(boundaryParses).toBe(compacted ? 1 : 0);
   } finally {
+    vi.restoreAllMocks();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     nativeJson.close();

--- a/src/config/sessions/session-accessor.sqlite-title-probes.ts
+++ b/src/config/sessions/session-accessor.sqlite-title-probes.ts
@@ -28,10 +28,6 @@ export type SessionTranscriptTitleProbe = {
 
 const SESSION_TITLE_PROBE_MESSAGES = 20;
 
-function getTitleProbeKysely(database: Pick<OpenClawAgentDatabase, "db">) {
-  return getNodeSqliteKysely<TitleProbeDatabase>(database.db);
-}
-
 function parseEventType(eventJson: string | null): string | undefined {
   if (!eventJson) {
     return undefined;
@@ -52,131 +48,129 @@ function readTitleProbeChunk(
   database: Pick<OpenClawAgentDatabase, "db" | "path">,
   sessionIds: readonly string[],
 ): Map<string, SessionTranscriptTitleProbe> {
-  const db = getTitleProbeKysely(database);
-  // Materialize lifecycle facts before joining preview rows: SQLite otherwise
-  // repeats the boundary scan for every message in the head and tail.
-  const windows = db.with(
-    (cte) => cte("title_windows").materialized(),
-    (query) =>
-      query
-        .selectFrom("session_windows as window")
-        .leftJoin(
-          "session_transcript_index_state as state",
-          "state.session_id",
-          "window.session_id",
-        )
-        .leftJoin(
-          "transcript_rewrite_watermarks as rewrite",
-          "rewrite.session_id",
-          "window.session_id",
-        )
-        .select((eb) => [
-          "window.session_id",
-          "state.active_message_count",
-          "state.indexed_seq",
-          "state.needs_rebuild",
-          "rewrite.generation",
-          eb
-            .selectFrom("transcript_events as latest")
-            .select("latest.seq")
-            .whereRef("latest.session_id", "=", "window.session_id")
-            .orderBy("latest.seq", "desc")
-            .limit(1)
-            .as("latest_seq"),
-          eb
-            .selectFrom("session_transcript_active_events as boundary")
-            .innerJoin("transcript_events as boundary_event", (join) =>
-              join
-                .onRef("boundary_event.session_id", "=", "boundary.session_id")
-                .onRef("boundary_event.seq", "=", "boundary.event_seq"),
-            )
-            .select("boundary_event.event_json")
-            .whereRef("boundary.session_id", "=", "window.session_id")
-            .where("boundary.message_position", "is", null)
-            // Excluding latest-reset sessions prevents pre-reset text from leaking.
-            .where(sqliteTranscriptBoundaryEventType(), "in", ["reset", "compaction"])
-            .orderBy("boundary.active_position", "desc")
-            .limit(1)
-            .as("latest_boundary_json"),
-        ])
-        .where("window.session_id", "in", sessionIds),
-  );
-  const titleRows = windows.with("title_edges", (query) => {
-    // CROSS JOIN keeps SQLite's outer loop on the selected windows. Separate
-    // ranges seek the message index instead of scanning every session message.
-    const edge = query
-      .selectFrom("title_windows as window")
-      .crossJoin("session_transcript_active_events as active")
-      .innerJoin("transcript_events as event", (join) =>
-        join
-          .onRef("event.session_id", "=", "active.session_id")
-          .onRef("event.seq", "=", "active.event_seq"),
-      )
-      .select(["window.session_id", "active.message_position", "event.event_json"])
-      .whereRef("active.session_id", "=", "window.session_id")
-      .where("active.message_position", "is not", null);
-    return edge
-      .where("active.message_position", "<", SESSION_TITLE_PROBE_MESSAGES)
-      .unionAll(
-        edge.where("active.message_position", ">=", (eb) =>
-          eb.fn<number>("max", [
-            eb.val(SESSION_TITLE_PROBE_MESSAGES),
-            eb("window.active_message_count", "-", SESSION_TITLE_PROBE_MESSAGES),
-          ]),
-        ),
-      );
-  });
-  const rows = runSqliteDeferredTransactionSync(
+  const db = getNodeSqliteKysely<TitleProbeDatabase>(database.db);
+  // Read lifecycle metadata once, without repeating large compaction summaries
+  // beside every preview message. Both reads must share the same snapshot.
+  return runSqliteDeferredTransactionSync(
     database.db,
-    () =>
-      executeSqliteQuerySync(
+    () => {
+      const windows = executeSqliteQuerySync(
         database.db,
-        titleRows
-          .selectFrom("title_windows as window")
-          .leftJoin("title_edges as edge", "edge.session_id", "window.session_id")
-          .selectAll("window")
-          .select(["edge.message_position", "edge.event_json"])
-          .orderBy("window.session_id", "asc")
-          .orderBy("edge.message_position", "asc"),
-      ).rows,
+        db
+          .selectFrom("session_windows as window")
+          .leftJoin(
+            "session_transcript_index_state as state",
+            "state.session_id",
+            "window.session_id",
+          )
+          .leftJoin(
+            "transcript_rewrite_watermarks as rewrite",
+            "rewrite.session_id",
+            "window.session_id",
+          )
+          .select((eb) => [
+            "window.session_id",
+            "state.active_message_count",
+            "state.indexed_seq",
+            "state.needs_rebuild",
+            "rewrite.generation",
+            eb
+              .selectFrom("transcript_events as latest")
+              .select("latest.seq")
+              .whereRef("latest.session_id", "=", "window.session_id")
+              .orderBy("latest.seq", "desc")
+              .limit(1)
+              .as("latest_seq"),
+            eb
+              .selectFrom("session_transcript_active_events as boundary")
+              .innerJoin("transcript_events as boundary_event", (join) =>
+                join
+                  .onRef("boundary_event.session_id", "=", "boundary.session_id")
+                  .onRef("boundary_event.seq", "=", "boundary.event_seq"),
+              )
+              .select("boundary_event.event_json")
+              .whereRef("boundary.session_id", "=", "window.session_id")
+              .where("boundary.message_position", "is", null)
+              // Excluding latest-reset sessions prevents pre-reset text from leaking.
+              .where(sqliteTranscriptBoundaryEventType(), "in", ["reset", "compaction"])
+              .orderBy("boundary.active_position", "desc")
+              .limit(1)
+              .as("latest_boundary_json"),
+          ])
+          .where("window.session_id", "in", sessionIds),
+      ).rows;
+      const probes = new Map<string, SessionTranscriptTitleProbe>();
+      for (const row of windows) {
+        const emptyTranscript = row.latest_seq === null;
+        const projectionCurrent = row.needs_rebuild === 0 && row.indexed_seq === row.latest_seq;
+        if (
+          (!emptyTranscript && !projectionCurrent) ||
+          parseEventType(row.latest_boundary_json) === "reset"
+        ) {
+          continue;
+        }
+        probes.set(row.session_id, {
+          generation: row.generation ?? null,
+          head: [],
+          maxSeq: row.latest_seq ?? null,
+          tail: [],
+          totalMessages: row.active_message_count ?? 0,
+        });
+      }
+      if (probes.size === 0) {
+        return probes;
+      }
+      // CROSS JOIN keeps selected sessions outside the indexed head/tail seeks.
+      const edge = db
+        .selectFrom("session_transcript_index_state as state")
+        .crossJoin("session_transcript_active_events as active")
+        .innerJoin("transcript_events as event", (join) =>
+          join
+            .onRef("event.session_id", "=", "active.session_id")
+            .onRef("event.seq", "=", "active.event_seq"),
+        )
+        .select(["state.session_id", "active.message_position", "event.event_json"])
+        .where("state.session_id", "in", [...probes.keys()])
+        .whereRef("active.session_id", "=", "state.session_id")
+        .where("active.message_position", "is not", null);
+      const rows = executeSqliteQuerySync(
+        database.db,
+        edge
+          .where("active.message_position", "<", SESSION_TITLE_PROBE_MESSAGES)
+          .unionAll(
+            edge.where("active.message_position", ">=", (eb) =>
+              eb.fn<number>("max", [
+                eb.val(SESSION_TITLE_PROBE_MESSAGES),
+                eb("state.active_message_count", "-", SESSION_TITLE_PROBE_MESSAGES),
+              ]),
+            ),
+          )
+          .orderBy("state.session_id", "asc")
+          .orderBy("active.message_position", "asc"),
+      ).rows;
+      for (const row of rows) {
+        if (row.message_position === null) {
+          continue;
+        }
+        const probe = probes.get(row.session_id)!;
+        const event = {
+          event: JSON.parse(row.event_json) as TranscriptEvent,
+          seq: row.message_position + 1,
+        };
+        if (row.message_position < SESSION_TITLE_PROBE_MESSAGES) {
+          probe.head.push(event);
+        }
+        if (row.message_position >= probe.totalMessages - SESSION_TITLE_PROBE_MESSAGES) {
+          probe.tail.push(event);
+        }
+      }
+      return probes;
+    },
     { databaseLabel: database.path, operationLabel: "sessions.list.title-probes" },
   );
-  const probes = new Map<string, SessionTranscriptTitleProbe>();
-  for (const row of rows) {
-    const emptyTranscript = row.latest_seq === null;
-    const projectionCurrent = row.needs_rebuild === 0 && row.indexed_seq === row.latest_seq;
-    if (
-      (!emptyTranscript && !projectionCurrent) ||
-      parseEventType(row.latest_boundary_json) === "reset"
-    ) {
-      continue;
-    }
-    const totalMessages = row.active_message_count ?? 0;
-    const probe = probes.get(row.session_id) ?? {
-      generation: row.generation ?? null,
-      head: [],
-      maxSeq: row.latest_seq ?? null,
-      tail: [],
-      totalMessages,
-    };
-    if (row.event_json !== null && row.message_position !== null) {
-      const event = {
-        event: JSON.parse(row.event_json) as TranscriptEvent,
-        seq: row.message_position + 1,
-      };
-      if (row.message_position < SESSION_TITLE_PROBE_MESSAGES) {
-        probe.head.push(event);
-      }
-      if (row.message_position >= totalMessages - SESSION_TITLE_PROBE_MESSAGES) {
-        probe.tail.push(event);
-      }
-    }
-    probes.set(row.session_id, probe);
-  }
-  return probes;
 }
 
-/** Reads bounded title probes in one statement per opened store (chunked for SQLite limits). */
+/** Reads metadata and bounded title edges in one snapshot, chunked for SQLite limits. */
 export function readSessionTranscriptTitleProbeBatch(
   scopes: readonly SessionTranscriptReadScope[],
 ): Array<SessionTranscriptTitleProbe | undefined> {

--- a/ui/src/e2e/activity-session-refresh.e2e.test.ts
+++ b/ui/src/e2e/activity-session-refresh.e2e.test.ts
@@ -73,6 +73,55 @@ suite.define(() => {
         await expect.poll(() => row.textContent()).toContain("Latest activity");
         expect(await activityRequests()).toBe(initialRequests + 2);
         await page.screenshot({ path: path.join(suite.artifactDir, "03-visible-burst.png") });
+
+        await gateway.emitGatewayEvent("agent", {
+          runId: "run-activity",
+          stream: "tool",
+          sessionKey: "main",
+          data: {
+            phase: "result",
+            name: "exec",
+            toolCallId: "tool-activity",
+            result: { content: [{ type: "text", text: "Retained while viewing sessions." }] },
+          },
+        });
+        await page.getByRole("tab", { name: "Live activity", exact: true }).click();
+        const entry = page.locator(".activity-entry");
+        await expect.poll(() => entry.count()).toBe(1);
+        await entry.locator("summary").click();
+        await entry.getByText("Retained while viewing sessions.", { exact: true }).waitFor();
+        await page.screenshot({ path: path.join(suite.artifactDir, "04-live-activity.png") });
+        for (let index = 0; index < 20; index += 1) {
+          await gateway.emitGatewayEvent("agent", {
+            runId: "run-activity",
+            stream: "tool",
+            sessionKey: "main",
+            data: { phase: "start", name: "exec", toolCallId: `tool-${index}` },
+          });
+        }
+        const stream = page.locator(".activity-stream");
+        await expect
+          .poll(() =>
+            stream.evaluate((element) => element.scrollHeight > element.clientHeight + 120),
+          )
+          .toBe(true);
+        const autoFollow = page.locator(".activity-live-autofollow wa-switch");
+        await autoFollow.click();
+        await stream.evaluate((element) => {
+          element.scrollTop = 0;
+          element.dispatchEvent(new Event("scroll"));
+        });
+        await autoFollow.click();
+        await page.clock.runFor(100);
+        await expect
+          .poll(() =>
+            stream.evaluate(
+              (element) => element.scrollHeight - element.clientHeight - element.scrollTop,
+            ),
+          )
+          .toBeLessThanOrEqual(1);
+        await page.getByRole("tab", { name: "Sessions", exact: true }).click();
+        await expect.poll(() => row.textContent()).toContain("Latest activity");
       },
     );
   });

--- a/ui/src/pages/activity/activity-page.test.ts
+++ b/ui/src/pages/activity/activity-page.test.ts
@@ -5,19 +5,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AuditRunInspectResult } from "../../../../packages/gateway-protocol/src/schema/audit-run.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
-import type { RunInspectorState } from "./run-inspector-model.ts";
+import type { ActivityRouteData, RunInspectorState } from "./run-inspector-model.ts";
 import type { ActivityEntry } from "./tool-activity.ts";
+import * as liveActivity from "./view.ts";
 import "./activity-page.ts";
 
 type TestActivityPage = HTMLElement & {
   context: ApplicationContext;
   entries: ActivityEntry[];
-  routeData: {
-    mode: "run";
-    selector: { kind: "run"; id: string };
-    selectorId: string | null;
-    decisionCursor: string | null;
-  };
+  routeData: ActivityRouteData;
+  render: () => unknown;
   runInspector: RunInspectorState;
   loadRunInspector: (
     gateway: ApplicationContext["gateway"],
@@ -73,6 +70,28 @@ afterEach(() => {
 });
 
 describe("ActivityPage gateway lifecycle", () => {
+  it.each(["sessions", "run"] as const)("skips Live Activity rendering in %s mode", (mode) => {
+    const page = document.createElement("openclaw-activity-page") as TestActivityPage;
+    page.context = { gateway: gateway(), basePath: "" } as unknown as ApplicationContext;
+    page.entries = [staleEntry()];
+    page.routeData =
+      mode === "sessions"
+        ? { mode, filters: { personId: null, query: "", time: "7d" }, selector: null }
+        : { mode, selector: null, selectorId: null, decisionCursor: null };
+    const render = vi.spyOn(liveActivity, "renderActivity");
+    try {
+      page.render();
+      expect(render).not.toHaveBeenCalled();
+      page.routeData = { mode: "live", selector: null };
+      page.render();
+      expect(render).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ entries: page.entries }),
+      );
+    } finally {
+      render.mockRestore();
+    }
+  });
+
   it("replays the active gateway on initial bind and source replacement", () => {
     const page = document.createElement("openclaw-activity-page") as TestActivityPage;
     page.context = { gateway: gateway() } as unknown as ApplicationContext;
@@ -108,14 +127,15 @@ describe("ActivityPage gateway lifecycle", () => {
     } as unknown as ApplicationContext["gateway"];
     const page = document.createElement("openclaw-activity-page") as TestActivityPage;
     page.context = { gateway: activeGateway } as unknown as ApplicationContext;
+    const selector = { kind: "run", id: "run-1" } as const;
     page.routeData = {
       mode: "run",
-      selector: { kind: "run", id: "run-1" },
+      selector,
       selectorId: null,
       decisionCursor: null,
     };
 
-    await page.loadRunInspector(activeGateway, client, page.routeData.selector);
+    await page.loadRunInspector(activeGateway, client, selector);
 
     expect(page.runInspector.status).toBe("ready");
     if (page.runInspector.status === "ready") {
@@ -163,14 +183,15 @@ describe("ActivityPage gateway lifecycle", () => {
     } as unknown as ApplicationContext["gateway"];
     const page = document.createElement("openclaw-activity-page") as TestActivityPage;
     page.context = { gateway: activeGateway } as unknown as ApplicationContext;
+    const selector = { kind: "run", id: "run-1" } as const;
     page.routeData = {
       mode: "run",
-      selector: { kind: "run", id: "run-1" },
+      selector,
       selectorId: "receipt-1",
       decisionCursor: "cursor-1",
     };
 
-    await page.loadRunInspector(activeGateway, client, page.routeData.selector);
+    await page.loadRunInspector(activeGateway, client, selector);
 
     expect(page.runInspector).toEqual({ status: "error", recovery });
   });

--- a/ui/src/pages/activity/activity-page.ts
+++ b/ui/src/pages/activity/activity-page.ts
@@ -42,7 +42,7 @@ import {
 import { renderRunInspector } from "./run-inspector-view.ts";
 import { SessionActivityController } from "./session-activity-controller.ts";
 import { renderSessionActivityView } from "./session-activity-view.ts";
-import { sessionActivitySearch, type SessionActivityFilters } from "./session-activity.ts";
+import { sessionActivitySearch } from "./session-activity.ts";
 import {
   parseActivityEvent,
   updateToolActivity,
@@ -136,12 +136,12 @@ class ActivityPage extends OpenClawLightDomElement {
       this.bindInspectorRoute();
       this.syncSessionActivity();
     }
+    const autoFollowEnabled = this.autoFollow && changed.has("autoFollow");
     if (
-      this.autoFollow &&
-      this.streamFollow.atBottom &&
-      (changed.has("entries") || changed.has("autoFollow"))
+      autoFollowEnabled ||
+      (this.autoFollow && this.streamFollow.atBottom && changed.has("entries"))
     ) {
-      this.streamFollow.schedule(changed.has("autoFollow"));
+      this.streamFollow.schedule(autoFollowEnabled);
     }
   }
 
@@ -459,13 +459,7 @@ class ActivityPage extends OpenClawLightDomElement {
   }
 
   private selectMode(mode: "sessions" | "live") {
-    if (mode === "sessions") {
-      this.context.navigate("activity", { search: "" });
-      return;
-    }
-    if (mode === "live") {
-      this.context.navigate("activity", { search: "?view=live" });
-    }
+    this.context.navigate("activity", { search: mode === "live" ? "?view=live" : "" });
   }
 
   private rebuildEntries(
@@ -553,51 +547,90 @@ class ActivityPage extends OpenClawLightDomElement {
     this.streamFollow.atBottom = true;
   }
 
+  private renderMode() {
+    const route = this.routeData;
+    if (route.mode === "sessions") {
+      return renderSessionActivityView({
+        context: this.context,
+        expandedAutomationDays: this.expandedAutomationDays,
+        filters: {
+          ...route.filters,
+          personId: this.sessionActivity.result?.involvingProfileId ?? route.filters.personId,
+        },
+        presenceViewers: projectPresencePayload(this.presencePayload).users,
+        result: this.sessionActivity.result,
+        loading: this.sessionActivity.loading,
+        error: this.sessionActivity.error,
+        onRetry: () => this.syncSessionActivity(true),
+        onAutomationDayToggle: (dayKey) => {
+          const next = new Set(this.expandedAutomationDays);
+          if (next.has(dayKey)) {
+            next.delete(dayKey);
+          } else {
+            next.add(dayKey);
+          }
+          this.expandedAutomationDays = next;
+        },
+        onFiltersChange: (next) =>
+          this.context.navigate("activity", { search: sessionActivitySearch(next) }),
+      });
+    }
+    if (route.mode === "run") {
+      return html`<a
+          class="activity-run-inspector-back"
+          href=${pathForRoute("activity", this.context.basePath)}
+          >${icons.arrowLeft}${t("activityFeed.backToSessions")}</a
+        >
+        ${renderRunInspector({
+          basePath: this.context.basePath,
+          state: this.runInspector,
+          onLoadMoreExecutions: () => this.loadMoreExecutions(),
+          onLoadMoreDecisions: () => this.loadMoreDecisions(),
+          selectorId: route.selectorId,
+          selector: route.selector,
+          onRestart: () => this.restartRunInspector(),
+          onRetry: () =>
+            this.syncRunInspector(this.context.gateway, this.context.gateway.snapshot, true),
+        })}`;
+    }
+    return html`<div id="activity-live-panel">
+      ${renderActivity({
+        basePath: this.context.basePath,
+        entries: this.entries,
+        filterText: this.filterText,
+        statusFilters: this.statusFilters,
+        toolFilter: this.toolFilter,
+        expandedIds: this.expandedIds,
+        autoFollow: this.autoFollow,
+        onFilterTextChange: (next) => (this.filterText = next),
+        onToolFilterChange: (next) => (this.toolFilter = next),
+        onStatusToggle: (status, enabled) => {
+          this.statusFilters = { ...this.statusFilters, [status]: enabled };
+        },
+        onToggleAutoFollow: (next) => (this.autoFollow = next),
+        onClear: () => this.clearEntries(),
+        onExpandAll: () => {
+          this.expandedIds = new Set(this.entries.map((entry) => entry.id));
+        },
+        onCollapseAll: () => {
+          this.expandedIds = new Set();
+        },
+        onEntryToggle: (id, open) => {
+          const next = new Set(this.expandedIds);
+          if (open) {
+            next.add(id);
+          } else {
+            next.delete(id);
+          }
+          this.expandedIds = next;
+        },
+        onScroll: (event) => this.streamFollow.handleScroll(event),
+      })}
+    </div>`;
+  }
+
   override render() {
-    const liveActivity = renderActivity({
-      basePath: this.context.basePath,
-      entries: this.entries,
-      filterText: this.filterText,
-      statusFilters: this.statusFilters,
-      toolFilter: this.toolFilter,
-      expandedIds: this.expandedIds,
-      autoFollow: this.autoFollow,
-      onFilterTextChange: (next) => (this.filterText = next),
-      onToolFilterChange: (next) => (this.toolFilter = next),
-      onStatusToggle: (status, enabled) => {
-        this.statusFilters = { ...this.statusFilters, [status]: enabled };
-      },
-      onToggleAutoFollow: (next) => {
-        this.autoFollow = next;
-        if (next) {
-          this.streamFollow.schedule(true);
-        }
-      },
-      onClear: () => this.clearEntries(),
-      onExpandAll: () => {
-        this.expandedIds = new Set(this.entries.map((entry) => entry.id));
-      },
-      onCollapseAll: () => {
-        this.expandedIds = new Set();
-      },
-      onEntryToggle: (id, open) => {
-        const next = new Set(this.expandedIds);
-        if (open) {
-          next.add(id);
-        } else {
-          next.delete(id);
-        }
-        this.expandedIds = next;
-      },
-      onScroll: (event) => this.streamFollow.handleScroll(event),
-    });
-    const mode = this.routeData?.mode ?? "live";
-    const filters =
-      this.routeData.mode === "sessions"
-        ? this.routeData.filters
-        : ({ personId: null, query: "", time: "7d" } satisfies SessionActivityFilters);
-    const presenceViewers = projectPresencePayload(this.presencePayload).users;
-    const selectedProfileId = this.sessionActivity.result?.involvingProfileId ?? filters.personId;
+    const mode = this.routeData.mode;
     const body = html`
       ${mode === "run"
         ? nothing
@@ -619,50 +652,7 @@ class ActivityPage extends OpenClawLightDomElement {
         role=${mode === "run" ? nothing : "tabpanel"}
         aria-labelledby=${mode === "run" ? nothing : `activity-mode-tab-${mode}`}
       >
-        ${mode === "sessions"
-          ? renderSessionActivityView({
-              context: this.context,
-              expandedAutomationDays: this.expandedAutomationDays,
-              filters: { ...filters, personId: selectedProfileId },
-              presenceViewers,
-              result: this.sessionActivity.result,
-              loading: this.sessionActivity.loading,
-              error: this.sessionActivity.error,
-              onRetry: () => this.syncSessionActivity(true),
-              onAutomationDayToggle: (dayKey) => {
-                const next = new Set(this.expandedAutomationDays);
-                if (next.has(dayKey)) {
-                  next.delete(dayKey);
-                } else {
-                  next.add(dayKey);
-                }
-                this.expandedAutomationDays = next;
-              },
-              onFiltersChange: (next) =>
-                this.context.navigate("activity", { search: sessionActivitySearch(next) }),
-            })
-          : mode === "run"
-            ? html`<a
-                  class="activity-run-inspector-back"
-                  href=${pathForRoute("activity", this.context.basePath)}
-                  >${icons.arrowLeft}${t("activityFeed.backToSessions")}</a
-                >
-                ${renderRunInspector({
-                  basePath: this.context.basePath,
-                  state: this.runInspector,
-                  onLoadMoreExecutions: () => this.loadMoreExecutions(),
-                  onLoadMoreDecisions: () => this.loadMoreDecisions(),
-                  selectorId: this.routeData.mode === "run" ? this.routeData.selectorId : null,
-                  selector: this.routeData.mode === "run" ? this.routeData.selector : null,
-                  onRestart: () => this.restartRunInspector(),
-                  onRetry: () =>
-                    this.syncRunInspector(
-                      this.context.gateway,
-                      this.context.gateway.snapshot,
-                      true,
-                    ),
-                })}`
-            : html`<div id="activity-live-panel">${liveActivity}</div>`}
+        ${this.renderMode()}
       </div>
     `;
     return html`

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -6,6 +6,7 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { setAvatarGatewayOrigin } from "../../lib/identity-avatar-context.ts";
 import type { PresenceViewer } from "../../lib/presence-users.ts";
+import { SESSION_NAVIGATION_KEY_PARAM } from "../../lib/sessions/route-navigation.ts";
 import { renderSessionActivityView } from "./session-activity-view.ts";
 
 function row(
@@ -92,6 +93,87 @@ describe("session activity semantics", () => {
 
     expect(container.querySelectorAll("main")).toHaveLength(0);
   });
+
+  it.each(["missing", "stale"])(
+    "opens the displayed Activity rows when the sidebar is %s",
+    (sidebar) => {
+      const rows = (["chat", "dashboard"] as const).map((face, index) =>
+        row(
+          `agent:research:${face}:12345678-90ab-cdef-1234-567890abcde${index}`,
+          { id: "owner" },
+          Date.now(),
+          { boardFace: face, displayName: `Research ${face}` },
+        ),
+      );
+      const input = props({ rows });
+      input.context = {
+        ...input.context,
+        basePath: "/control",
+        agentSelection: { state: { selectedId: "other" } },
+        sessions: {
+          state: {
+            agentId: "other",
+            result: {
+              sessions:
+                sidebar === "missing"
+                  ? []
+                  : rows.map((session) => ({ ...session, displayName: "Old title" })),
+            },
+          },
+        },
+      } as unknown as ApplicationContext;
+      const container = document.createElement("div");
+      document.body.append(container);
+
+      render(renderSessionActivityView(input), container);
+
+      const links = container.querySelectorAll<HTMLAnchorElement>("[data-activity-session]");
+      expect(links).toHaveLength(rows.length);
+      for (const [index, session] of rows.entries()) {
+        const link = links[index]!;
+        const pathname = `/control/${session.boardFace}/research/research-${session.boardFace}-12345678`;
+        expect(link.getAttribute("href")).toBe(pathname);
+        link.click();
+        expect(input.context.navigate).toHaveBeenLastCalledWith(session.boardFace, {
+          pathname,
+          search: `?${SESSION_NAVIGATION_KEY_PARAM}=${encodeURIComponent(session.key)}`,
+        });
+      }
+    },
+  );
+
+  it.each([
+    ["workspace", "/control/chat/research", undefined],
+    ["global", "/control/chat/research", undefined],
+    [
+      "catalog:native:gateway%3Alocal:Thread-1",
+      "/control/chat/research",
+      "?catalog=native&host=gateway%3Alocal&thread=Thread-1",
+    ],
+  ] as const)(
+    "preserves configured main and selected-agent routing for %s",
+    (key, pathname, search) => {
+      const input = props({ rows: [row(key, { id: "owner" }, Date.now())] });
+      input.context = {
+        ...input.context,
+        basePath: "/control",
+        agents: { state: { agentsList: { defaultId: "main", mainKey: "workspace" } } },
+        agentSelection: { state: { selectedId: "research" } },
+      } as unknown as ApplicationContext;
+      const container = document.createElement("div");
+      document.body.append(container);
+
+      render(renderSessionActivityView(input), container);
+
+      const link = container.querySelector<HTMLAnchorElement>("[data-activity-session]")!;
+      expect(link.getAttribute("href")).toBe(`${pathname}${search ?? ""}`);
+      link.click();
+      expect(input.context.navigate).toHaveBeenCalledWith(
+        "chat",
+        search ? { pathname, search } : { pathname },
+      );
+    },
+  );
 
   it("renders agent-owned sessions and profile pictures without making agents or channels people", async () => {
     setAvatarGatewayOrigin("https://gateway.example.test");

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -16,9 +16,11 @@ import {
 } from "../../lib/presence-users.ts";
 import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import {
+  resolveSessionNavigationAgentId,
   resolveSessionPreferredFace,
   sessionNavigationTarget,
 } from "../../lib/sessions/route-navigation.ts";
+import { resolveUiConfiguredMainKey } from "../../lib/sessions/session-key.ts";
 import { activityRunInspectorHref } from "./run-inspector-model.ts";
 import {
   ACTIVITY_TIME_FILTERS,
@@ -203,24 +205,6 @@ function renderPeopleControl(
   </div>`;
 }
 
-function navigateToSession(event: MouseEvent, context: ApplicationContext, row: GatewaySessionRow) {
-  if (!shouldHandleNavigationClick(event)) {
-    return;
-  }
-  event.preventDefault();
-  const face = resolveSessionPreferredFace(row);
-  const target = sessionNavigationTarget({ context, face, sessionKey: row.key });
-  context.navigate(face, target.options);
-}
-
-function sessionHref(context: ApplicationContext, row: GatewaySessionRow): string {
-  return sessionNavigationTarget({
-    context,
-    face: resolveSessionPreferredFace(row),
-    sessionKey: row.key,
-  }).href;
-}
-
 function dayLabel(timestamp: number | null, now = Date.now()): string {
   if (timestamp === null) {
     return t("activityFeed.unknownDate");
@@ -243,6 +227,18 @@ function dayLabel(timestamp: number | null, now = Date.now()): string {
 }
 
 function renderSessionLink(context: ApplicationContext, row: GatewaySessionRow) {
+  const face = resolveSessionPreferredFace(row);
+  const target = sessionNavigationTarget({
+    face,
+    sessionKey: row.key,
+    fallbackAgentId: resolveSessionNavigationAgentId(context),
+    basePath: context.basePath,
+    row,
+    mainKey: resolveUiConfiguredMainKey({
+      agentsList: context.agents.state.agentsList,
+      hello: context.gateway.snapshot.hello,
+    }),
+  });
   const owner = sessionActivityOwner(row);
   const ownerName = presenceViewerLabel(owner);
   const activityAt = sessionActivityTimestamp(row);
@@ -262,8 +258,13 @@ function renderSessionLink(context: ApplicationContext, row: GatewaySessionRow) 
     <a
       class="activity-feed__session"
       data-activity-session=${row.key}
-      href=${sessionHref(context, row)}
-      @click=${(event: MouseEvent) => navigateToSession(event, context, row)}
+      href=${target.href}
+      @click=${(event: MouseEvent) => {
+        if (shouldHandleNavigationClick(event)) {
+          event.preventDefault();
+          context.navigate(face, target.options);
+        }
+      }}
     >
       <span class="activity-feed__session-avatar">
         ${row.hasActiveRun === true


### PR DESCRIPTION
Related: #136762

## What Problem This Solves

Resolves a problem where Activity performed work for views that were not selected, and loading session titles repeatedly copied and parsed large compaction summaries. Activity links could also borrow an outdated title from the sidebar or omit the exact session key when that row was absent there.

## Why This Change Was Made

Render only the selected Activity view and prepare each navigation target from the row Activity already owns. Read transcript lifecycle metadata once, then seek the bounded head/tail messages within the same SQLite read transaction; this removes both intermediate query structures and repeated metadata payloads while preserving empty, reset, stale-index, and raw JSON behavior. Auto-follow enablement has one lifecycle owner, following the existing Logs pattern.

## User Impact

Activity does less work while viewing sessions or inspecting runs, opens the displayed session consistently, and stays responsive with large compaction summaries. The existing independent people/time filters, hidden-tab refresh batching, retained Live entries, and auto-follow behavior remain intact.

Production LOC: **+228/-243 (net -15)**. Tests: **+187/-14 (net +173)**. No schema, configuration, or protocol changes.

## Evidence

- **121 tests passed:** 51 backend, 58 UI, and 12 Chromium scenarios. The browser scenarios build the actual UI and use a deterministic mock Gateway.
- Regression tests failed before the fixes: boundary decoding occurred 40 times instead of once; missing/stale sidebar rows produced the wrong Activity link; Sessions/Run modes invoked the unused Live renderer. The browser regression also caught and prevented an auto-follow regression during simplification.
- **11 synthetic transcript fixtures** produced identical probes: empty/short transcripts, overlapping head/tail ranges, long transcripts, reset boundaries, stale indexes, and rebuilding indexes.
- Actual compiled query timing with **128 KiB compaction summaries: 219–274 ms before, 4.98–5.21 ms after**. Equivalent query output fell from **40.7 MB to 1.33 MB**. With 2 KiB summaries, the equivalent comparison was 5.13 ms versus 4.44 ms. These are synthetic query measurements, not an end-to-end production latency claim.
- A two-connection WAL test committed a message, counts, and rewrite generation between metadata and message reads. The candidate retained the original snapshot; a negative control without the transaction observed the concurrent message.
- Full changed-file checks passed, including core/test/UI typechecking, formatting, lint, unused-export scans, import cycles, and repository guards. Independent Codex autoreview was scoped-clean through P2.

Validation commands:

```sh
node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-title-probes.test.ts src/config/sessions/session-accessor.readonly.test.ts src/gateway/session-transcript-title-reader.test.ts src/gateway/server.sessions.list-store-materialization.test.ts
node scripts/run-vitest.mjs run --config ui/vitest.config.ts ui/src/pages/activity/activity-page.test.ts ui/src/pages/activity/session-activity-view.test.ts ui/src/pages/activity/session-activity-controller.test.ts ui/src/pages/activity/view.test.ts ui/src/pages/activity/run-inspector-view.test.ts ui/src/lib/sessions/route-navigation.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/activity-session-refresh.e2e.test.ts ui/src/e2e/activity-summaries.e2e.test.ts ui/src/e2e/activity-run-inspector.e2e.test.ts
node scripts/check-changed.mjs
```

A larger controller consolidation remains separate: the managed-list API currently omits people fields and strips recency filters for archived/all queries. Directly substituting it would lose Activity behavior.

## Visual parity

These synthetic captures show the same Sessions layout before and after. They demonstrate visual parity; the query timings above measure the performance change.

Before — Sessions view on baseline `008d9d2c42d6`.

![Activity Sessions before](https://github.com/user-attachments/assets/e584337d-c4ed-4330-820d-97da991808d0)

After — same Sessions view; layout preserved.

![Activity Sessions after](https://github.com/user-attachments/assets/03495746-621f-4b3f-9e4d-6499b2a184c3)

## Review follow-through

Resolved the current-main comparison gap noted by ClawSweeper: the three affected production files have identical Git blob hashes at baseline `008d9d2c42d6` and main `507e5faf2850`, and the current-main UI blobs materialize locally. The single-snapshot probe and row-owned navigation remain intact. Exact-head CI passed before landing.

CI follow-through: the initial real-Gateway job tested a merge against `41419be4` and stopped before tests because startup CSS exceeded its budget by 17 bytes. Main subsequently fixed this in #136878 (`507e5faf2850`) by reusing existing styling. Refreshed onto main `3100ba535f1`, which includes that fix. The complete Activity diff is byte-for-byte identical before and after rebase. Exact-head CI passed: [run 33711249700](https://github.com/openclaw/openclaw/actions/runs/33711249700), including real-Gateway browser tests and the required aggregate gate. Runner capacity delayed execution, but the refreshed run completed without any job retry. The refreshed ClawSweeper review reports no blocking findings or remaining before-merge actions.
