### PR TITLE
perf(plugins): resolve hook state once per module

### DIFF
--- a/src/plugins/hook-runner-global-state.ts
+++ b/src/plugins/hook-runner-global-state.ts
@@ -22,19 +22,18 @@ type HookRunnerGlobalState = {
 
 const hookRunnerGlobalStateKey = Symbol.for("openclaw.plugins.hook-runner-global-state");
 
-export function getHookRunnerGlobalState(): HookRunnerGlobalState {
-  return resolveGlobalSingleton<HookRunnerGlobalState>(
-    hookRunnerGlobalStateKey,
-    () => ({
-      hookRunner: null,
-      registry: null,
-    }),
-    (state) => {
-      state.registry = null;
-    },
-    "plugin-registry",
-  );
-}
+// Lifecycle resets mutate this shared slot in place, including across source/built copies.
+export const hookRunnerGlobalState = resolveGlobalSingleton<HookRunnerGlobalState>(
+  hookRunnerGlobalStateKey,
+  () => ({
+    hookRunner: null,
+    registry: null,
+  }),
+  (state) => {
+    state.registry = null;
+  },
+  "plugin-registry",
+);
 
 function resolveRootHookRegistry(
   state: HookRunnerGlobalState,
@@ -155,6 +154,7 @@ export function createLiveHookRegistryFacade(
 
 /** Get the registry view that backs global hook dispatch. */
 export function getGlobalHookRunnerRegistry(): TrustedPolicyHookRunnerRegistry | null {
-  const state = getHookRunnerGlobalState();
-  return resolveHookRegistry(state) ? createLiveHookRegistryFacade(state) : null;
+  return resolveHookRegistry(hookRunnerGlobalState)
+    ? createLiveHookRegistryFacade(hookRunnerGlobalState)
+    : null;
 }

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -13,7 +13,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { GlobalHookRunnerRegistry } from "./hook-registry.types.js";
 import {
   createLiveHookRegistryFacade,
-  getHookRunnerGlobalState,
+  hookRunnerGlobalState as state,
 } from "./hook-runner-global-state.js";
 import type {
   PluginHookGatewayContext,
@@ -31,7 +31,6 @@ const getLog = () => createSubsystemLogger("plugins");
  * instance stays stable so references captured mid-run keep seeing current hooks.
  */
 export function initializeGlobalHookRunner(registry: GlobalHookRunnerRegistry): void {
-  const state = getHookRunnerGlobalState();
   const log = getLog();
   state.registry = registry;
   if (!state.hookRunner) {
@@ -61,7 +60,7 @@ export function initializeGlobalHookRunner(registry: GlobalHookRunnerRegistry): 
  * Returns null if plugins haven't been loaded yet.
  */
 export function getGlobalHookRunner(): HookRunner | null {
-  return getHookRunnerGlobalState().hookRunner;
+  return state.hookRunner;
 }
 
 /**
@@ -69,7 +68,7 @@ export function getGlobalHookRunner(): HookRunner | null {
  * Returns null if plugins haven't been loaded yet.
  */
 export function getGlobalPluginRegistry(): GlobalHookRunnerRegistry | null {
-  return getHookRunnerGlobalState().registry;
+  return state.registry;
 }
 
 /**
@@ -79,7 +78,7 @@ export function hasGlobalHooks<K extends PluginHookName>(
   hookName: K,
   ctx?: Partial<Parameters<PluginHookHandlerMap[K]>[1]>,
 ): boolean {
-  return getHookRunnerGlobalState().hookRunner?.hasHooks(hookName, ctx) ?? false;
+  return state.hookRunner?.hasHooks(hookName, ctx) ?? false;
 }
 
 export async function runGlobalGatewayStopSafely(params: {
@@ -107,7 +106,6 @@ export async function runGlobalGatewayStopSafely(params: {
  * Reset the global hook runner (for testing).
  */
 export function resetGlobalHookRunner(): void {
-  const state = getHookRunnerGlobalState();
   state.hookRunner = null;
   state.registry = null;
 }


### PR DESCRIPTION
Every global hook query re-registered the same lifecycle owner, creating a new registration object and reset callback while returning an unchanged singleton. Resolve that existing slot once when its module loads, then use it directly for initialization, getters, dispatch checks and resets. This removes the private accessor and keeps the public SDK interfaces intact.

Lifecycle drains still mutate the shared slot in place; source/module copies share its identity, and live registry selection still sees request overlays, prepared generations and late registrations. The one small state/registration initialization now occurs at module evaluation. No plugin activation, cache policy, configuration or persistence behavior changes. Production delta: **−2 lines**; tests unchanged.

An actual-source probe ran 1,000 rounds through getters, hasHooks, registry projection and real synchronous dispatch: lifecycle registrations, distinct registration objects and reset callback identities each fell from 4,000 to 0 in that warm loop. Eight semantic records matched, including request scope restoration, late hooks, a second owner module, three awaited drains, explicit reset and successor dispatch. These are allocation identities, not bytes, RSS or timing.

Validation: 66 existing tests across five suites, the full changed gate, and independent managed Codex P0–P2 review passed. All proof processes joined and temporary runtimes were removed. Per-overlay projection allocation remains a separate unproven follow-up; this change leaves that selection logic intact.
