### PR TITLE
perf(matrix): simplify list paragraph bookkeeping

### DIFF
--- a/extensions/matrix/src/matrix/format.ts
+++ b/extensions/matrix/src/matrix/format.ts
@@ -498,31 +498,25 @@ function mutateInlineTokensWithMentions(params: {
 function compactLooseListTokens(tokens: MarkdownToken[]): void {
   const listItemStack: Array<{
     level: number;
-    immediateParagraphOpenIndexes: number[];
-    immediateParagraphCloseIndexes: number[];
+    // null keeps multi-paragraph items visible, including after later paragraphs.
+    paragraphIndex: number | null | undefined;
   }> = [];
 
   for (const [index, token] of tokens.entries()) {
     if (token.type === "list_item_open") {
       listItemStack.push({
         level: token.level,
-        immediateParagraphOpenIndexes: [],
-        immediateParagraphCloseIndexes: [],
+        paragraphIndex: undefined,
       });
       continue;
     }
 
     if (token.type === "list_item_close") {
       const item = listItemStack.pop();
-      if (
-        item &&
-        item.immediateParagraphOpenIndexes.length === 1 &&
-        item.immediateParagraphCloseIndexes.length === 1
-      ) {
-        const openIndex = item.immediateParagraphOpenIndexes[0];
-        const closeIndex = item.immediateParagraphCloseIndexes[0];
-        const openToken = openIndex === undefined ? undefined : tokens[openIndex];
-        const closeToken = closeIndex === undefined ? undefined : tokens[closeIndex];
+      if (typeof item?.paragraphIndex === "number") {
+        // markdown-it emits each paragraph as open, inline, close tokens.
+        const openToken = tokens[item.paragraphIndex];
+        const closeToken = tokens[item.paragraphIndex + 2];
         if (openToken && closeToken) {
           openToken.hidden = true;
           closeToken.hidden = true;
@@ -537,9 +531,7 @@ function compactLooseListTokens(tokens: MarkdownToken[]): void {
     }
 
     if (token.type === "paragraph_open") {
-      currentItem.immediateParagraphOpenIndexes.push(index);
-    } else if (token.type === "paragraph_close") {
-      currentItem.immediateParagraphCloseIndexes.push(index);
+      currentItem.paragraphIndex = currentItem.paragraphIndex === undefined ? index : null;
     }
   }
 }


### PR DESCRIPTION
Matrix list formatting collected opening and closing paragraph indexes in two arrays for every list item, then only checked whether each array contained one index. Replace those arrays with one three-state opener index. The private markdown-it parser emits each paragraph as consecutive open/inline/close tokens, so the closer is already known. Items with two or more immediate paragraphs keep their wrappers, including nested lists and the existing multi-paragraph regression.

The change removes eight production lines (+8/−16) with no test, configuration or dependency changes. Actual-source observation found two temporary array references per list item before and none after: 512→0 for the fixed 256-item fixture. This is a source allocation/reference result, not an RSS, retained-heap or general speedup claim.

Validation: all 81 existing Matrix formatter tests pass before and after. A fixed actual-owner probe preserves 21 direct HTML cases and 84 variants through the real outbound content builder, including full body/HTML/mention fields, prepared body, rejected synthetic identity lookup and awaited-call interleaving. Two- and three-paragraph goldens remain byte-identical. Common output SHA-256: `c61fffe7cc59eef6d3a0749a98c994ea726abea756bf2f775126f88bc91e0419`. No Matrix server or Gateway was used. Managed Codex P2 review is scoped-clean; the canonical changed gate passes.

Related follow-up: the Markdown formatting docs still describe non-Signal/Telegram spoilers as literal text, although existing Matrix behavior already supports spoilers. This PR leaves that separate documentation mismatch unchanged.
