### PR TITLE
fix(mcp): require owner for Claude permission replies

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -253,7 +253,7 @@ Current bridge behavior:
 
 - inbound `user` transcript messages are forwarded as `notifications/claude/channel`
 - Claude permission requests received over MCP are tracked in-memory
-- if the linked conversation later sends `yes abcde` or `no abcde`, the bridge converts that to `notifications/claude/channel/permission`
+- if the command owner in the linked conversation later sends `yes abcde` or `no abcde`, the bridge converts that to `notifications/claude/channel/permission`
 - these notifications are live-session only; if the MCP client disconnects, there is no push target
 
 This is intentionally client-specific. Generic MCP clients should rely on the standard polling tools.

--- a/scripts/e2e/mcp-channels-docker-client.ts
+++ b/scripts/e2e/mcp-channels-docker-client.ts
@@ -1,5 +1,6 @@
 // Mcp Channels Docker Client script supports OpenClaw repository automation.
 import { randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import {
   assert,
   ClaudeChannelNotificationSchema,
@@ -28,6 +29,8 @@ function summarizeSessionRows(rows: Array<Record<string, unknown>> | undefined) 
     lastThreadId: entry.lastThreadId,
   }));
 }
+
+const NON_OWNER_PERMISSION_QUIET_WINDOW_MS = 1_000;
 
 function formatUnknownError(error: unknown): string {
   if (error instanceof Error) {
@@ -96,6 +99,7 @@ async function main() {
   assert(gatewayToken, "missing GW_TOKEN");
 
   const gateway = await connectGateway({ url: gatewayUrl, token: gatewayToken });
+  let nonOwnerGateway: GatewayRpcClient | undefined;
   let mcpHandle: Awaited<ReturnType<typeof connectMcpClient>> | undefined;
   const mcpTempState = createMcpClientTempState({ gatewayToken });
 
@@ -349,6 +353,36 @@ async function main() {
       },
     });
 
+    nonOwnerGateway = await connectGateway({
+      url: gatewayUrl,
+      token: gatewayToken,
+      scopes: ["operator.read", "operator.write"],
+    });
+    await nonOwnerGateway.request("chat.send", {
+      sessionKey: "agent:main:main",
+      message: "yes abcde",
+      idempotencyKey: randomUUID(),
+    });
+    await waitFor(
+      "non-owner reply forwarded as an ordinary Claude channel message",
+      () =>
+        mcpHandle.rawMessages
+          .map((entry) => ClaudeChannelNotificationSchema.safeParse(entry))
+          .find(
+            (entry) =>
+              entry.success &&
+              entry.data.params.meta.session_key === "agent:main:main" &&
+              entry.data.params.content === "yes abcde",
+          )?.data.params,
+      60_000,
+    );
+    await delay(NON_OWNER_PERMISSION_QUIET_WINDOW_MS);
+    const nonOwnerPermission = mcpHandle.rawMessages
+      .map((entry) => ClaudePermissionNotificationSchema.safeParse(entry))
+      .find((entry) => entry.success && entry.data.params.request_id === "abcde");
+    assert(!nonOwnerPermission, "non-owner reply must not resolve the Claude permission");
+
+    const ownerNotificationStart = mcpHandle.rawMessages.length;
     await gateway.request("chat.send", {
       sessionKey: "agent:main:main",
       message: "yes abcde",
@@ -360,6 +394,7 @@ async function main() {
         "Claude permission notification",
         () =>
           mcpHandle.rawMessages
+            .slice(ownerNotificationStart)
             .map((entry) => ClaudePermissionNotificationSchema.safeParse(entry))
             .find((entry) => entry.success && entry.data.params.request_id === "abcde")?.data
             .params,
@@ -389,6 +424,9 @@ async function main() {
         {
           ok: true,
           sessionKey: "agent:main:main",
+          nonOwnerReplyForwarded: true,
+          nonOwnerPermissionBlocked: true,
+          ownerPermissionAllowed: permission.behavior === "allow",
           rawNotifications: mcpHandle.rawMessages.filter(
             (entry) =>
               ClaudeChannelNotificationSchema.safeParse(entry).success ||
@@ -401,6 +439,9 @@ async function main() {
     );
   } finally {
     const closeTasks: Array<Promise<unknown>> = [gateway.close()];
+    if (nonOwnerGateway) {
+      closeTasks.push(nonOwnerGateway.close());
+    }
     if (mcpHandle) {
       closeTasks.push(mcpHandle.client.close(), mcpHandle.transport.close());
     }

--- a/scripts/e2e/mcp-channels-harness.ts
+++ b/scripts/e2e/mcp-channels-harness.ts
@@ -112,6 +112,7 @@ export async function waitFor<T>(
 export async function connectGateway(params: {
   url: string;
   token: string;
+  scopes?: readonly string[];
 }): Promise<GatewayRpcClient> {
   const startedAt = Date.now();
   let attempt = 0;
@@ -136,8 +137,14 @@ export async function connectGateway(params: {
 async function connectGatewayOnce(params: {
   url: string;
   token: string;
+  scopes?: readonly string[];
 }): Promise<GatewayRpcClient> {
-  const requestedScopes = ["operator.read", "operator.write", "operator.pairing", "operator.admin"];
+  const requestedScopes = params.scopes ?? [
+    "operator.read",
+    "operator.write",
+    "operator.pairing",
+    "operator.admin",
+  ];
   const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
   const gatewayClient = createGatewayWsClient({
     handshakeTimeoutMs: GATEWAY_WS_OPEN_TIMEOUT_MS,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2809,6 +2809,9 @@ describe("runPreparedReply media-only handling", () => {
 
     const call = requireRunReplyAgentCall();
     expect(call?.followupRun.run.senderIsOwner).toBe(true);
+    expect(call?.followupRun.userTurnTranscriptRecorder?.message).toMatchObject({
+      __openclaw: { senderIsOwner: true },
+    });
   });
 
   it("keeps sender ownership when drained system events are present", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1230,6 +1230,7 @@ export async function runPreparedReply(
     userTurnTranscriptText !== undefined || userTurnMediaForPersistence.length > 0
       ? {
           text: userTurnTranscriptText,
+          senderIsOwner: command.senderIsOwner,
           ...(inputProvenance ? { provenance: inputProvenance } : {}),
           ...(userTurnMediaForPersistence.length > 0
             ? {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -4350,6 +4350,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       content: "bench update",
       timestamp: expect.any(Number),
       idempotencyKey: "idem-system-provenance-acp:user",
+      __openclaw: { senderIsOwner: true },
       provenance: {
         ...provenance,
         sourceSessionKey: undefined,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1273,7 +1273,7 @@ function isAcpBridgeClient(client: GatewayRequestHandlerOptions["client"]): bool
   );
 }
 
-function canInjectSystemProvenance(client: GatewayRequestHandlerOptions["client"]): boolean {
+function hasGatewayAdminScope(client: GatewayRequestHandlerOptions["client"]): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
   return scopes.includes(ADMIN_SCOPE);
 }
@@ -3185,7 +3185,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         p.systemProvenanceReceipt ||
         suppressCommandInterpretation ||
         explicitOriginResult.value) &&
-      !canInjectSystemProvenance(client)
+      !hasGatewayAdminScope(client)
     ) {
       respond(
         false,
@@ -3632,6 +3632,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         text: rawMessage,
         timestamp: now,
         idempotencyKey: `${clientRunId}:user`,
+        ...(hasGatewayAdminScope(client) ? { senderIsOwner: true } : {}),
         ...(systemInputProvenance ? { provenance: systemInputProvenance } : {}),
       };
       const userTurnInputPromise: Promise<UserTurnInput> = userTurnMediaPromise.then((media) => ({

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -43,12 +43,18 @@ function createHandler(projectSessionActive: boolean) {
   return { broadcastToConnIds, handler };
 }
 
-async function emitAssistantTranscriptUpdate(projectSessionActive: boolean) {
+async function emitAssistantTranscriptUpdate(
+  projectSessionActive: boolean,
+  message: Record<string, unknown> = {
+    role: "assistant",
+    content: [{ type: "text", text: "Final answer" }],
+  },
+) {
   const { broadcastToConnIds, handler } = createHandler(projectSessionActive);
   handler({
     sessionFile: "/tmp/sess-main.jsonl",
     sessionKey: "agent:main:main",
-    message: { role: "assistant", content: [{ type: "text", text: "Final answer" }] },
+    message,
     messageId: "message-1",
     messageSeq: 1,
   });
@@ -77,6 +83,17 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       sessionKey: "agent:main:main",
       hasActiveRun: false,
       session: { hasActiveRun: false },
+    });
+  });
+  it("broadcasts the authenticated sender ownership decision", async () => {
+    await expect(
+      emitAssistantTranscriptUpdate(false, {
+        role: "user",
+        content: [{ type: "text", text: "Owner turn" }],
+        __openclaw: { senderIsOwner: true },
+      }),
+    ).resolves.toMatchObject({
+      senderIsOwner: true,
     });
   });
 });

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -1,6 +1,7 @@
 // Gateway session event broadcaster.
 // Projects transcript and lifecycle updates to websocket subscribers.
 import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/io.js";
@@ -29,6 +30,11 @@ import {
 
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
+
+function readMessageSenderIsOwner(message: unknown): boolean | undefined {
+  const value = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"])?.["senderIsOwner"];
+  return typeof value === "boolean" ? value : undefined;
+}
 
 function resolveSessionMessageBroadcastKeys(sessionKey: string, agentId?: string): string[] {
   // Global sessions can be subscribed through either the raw global key or the
@@ -173,6 +179,7 @@ async function handleTranscriptUpdateBroadcast(
     includeSession: true,
     hasActiveRun,
   });
+  const senderIsOwner = readMessageSenderIsOwner(update.message);
   const rawMessage = attachOpenClawTranscriptMeta(update.message, {
     ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
     ...(messageSeq !== undefined ? { seq: messageSeq } : {}),
@@ -183,6 +190,7 @@ async function handleTranscriptUpdateBroadcast(
       "session.message",
       {
         sessionKey,
+        ...(senderIsOwner === undefined ? {} : { senderIsOwner }),
         ...(visibleAgentId ? { agentId: visibleAgentId } : {}),
         message,
         ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),

--- a/src/mcp/channel-bridge.test.ts
+++ b/src/mcp/channel-bridge.test.ts
@@ -16,7 +16,10 @@ type BridgeInternals = {
   pendingClaudePermissions: Map<string, unknown>;
   pendingApprovals: Map<string, unknown>;
   pendingSweepInterval: NodeJS.Timeout | null;
-  pollEvents: (filter: WaitFilter, limit?: number) => {
+  pollEvents: (
+    filter: WaitFilter,
+    limit?: number,
+  ) => {
     events: QueueEvent[];
     nextCursor: number;
   };
@@ -31,6 +34,11 @@ type BridgeInternals = {
     event: string;
     payload?: Record<string, unknown>;
   }) => Promise<void>;
+  handleSessionMessageEvent: (payload: {
+    sessionKey: string;
+    senderIsOwner?: boolean;
+    message: { role: string; content: unknown };
+  }) => Promise<void>;
   listPendingApprovals: () => unknown[];
   close: () => Promise<void>;
   server: { server: { notification: (n: unknown) => Promise<void> } } | null;
@@ -43,6 +51,72 @@ function makeBridge(verbose = false): BridgeInternals {
     verbose,
   }) as unknown as BridgeInternals;
 }
+
+describe("OpenClawChannelBridge — Claude permission authorization", () => {
+  test.each([
+    { name: "non-owner", senderIsOwner: false, role: "user" },
+    { name: "missing owner metadata", senderIsOwner: undefined, role: "user" },
+    { name: "assistant message", senderIsOwner: true, role: "assistant" },
+  ])("does not resolve a pending permission from a $name reply", async (reply) => {
+    const bridge = makeBridge();
+    const notification = vi.fn(async () => undefined);
+    bridge.server = { server: { notification } };
+    try {
+      await bridge.handleClaudePermissionRequest({
+        requestId: "abcde",
+        toolName: "Bash",
+        description: "run npm test",
+        inputPreview: "{}",
+      });
+
+      await bridge.handleSessionMessageEvent({
+        sessionKey: "agent:main:telegram:group:-100123",
+        senderIsOwner: reply.senderIsOwner,
+        message: {
+          role: reply.role,
+          content: [{ type: "text", text: "yes abcde" }],
+        },
+      });
+
+      expect(notification).not.toHaveBeenCalled();
+      expect(bridge.pendingClaudePermissions.has("abcde")).toBe(true);
+      expect(bridge.queue.at(-1)).toMatchObject({ type: "message", text: "yes abcde" });
+    } finally {
+      await bridge.close();
+    }
+  });
+
+  test("resolves a pending permission from an owner user reply", async () => {
+    const bridge = makeBridge();
+    const notification = vi.fn(async () => undefined);
+    bridge.server = { server: { notification } };
+    try {
+      await bridge.handleClaudePermissionRequest({
+        requestId: "abcde",
+        toolName: "Bash",
+        description: "run npm test",
+        inputPreview: "{}",
+      });
+
+      await bridge.handleSessionMessageEvent({
+        sessionKey: "agent:main:telegram:group:-100123",
+        senderIsOwner: true,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "yes abcde" }],
+        },
+      });
+
+      expect(notification).toHaveBeenCalledWith({
+        method: "notifications/claude/channel/permission",
+        params: { request_id: "abcde", behavior: "allow" },
+      });
+      expect(bridge.pendingClaudePermissions.has("abcde")).toBe(false);
+    } finally {
+      await bridge.close();
+    }
+  });
+});
 
 describe("OpenClawChannelBridge — pendingClaudePermissions / pendingApprovals memory bounds", () => {
   beforeEach(() => {

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -584,7 +584,9 @@ export class OpenClawChannelBridge {
     const role = toText(payload.message?.role);
     const text = extractFirstTextBlock(payload.message);
     const permissionMatch = text ? CLAUDE_PERMISSION_REPLY_RE.exec(text) : null;
-    if (permissionMatch) {
+    // Ownership is decided at authenticated channel ingress and carried on the
+    // live transcript event. Missing metadata fails closed for approvals.
+    if (role === "user" && payload.senderIsOwner === true && permissionMatch) {
       const requestId = normalizeOptionalLowercaseString(permissionMatch[2]);
       if (requestId && this.pendingClaudePermissions.has(requestId)) {
         this.pendingClaudePermissions.delete(requestId);

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -324,6 +324,7 @@ describe("openclaw channel mcp server", () => {
             }
           ).handleSessionMessageEvent({
             sessionKey,
+            senderIsOwner: true,
             lastChannel: "imessage",
             lastTo: "+15551234567",
             messageId: "msg-user-1",
@@ -358,6 +359,7 @@ describe("openclaw channel mcp server", () => {
             }
           ).handleSessionMessageEvent({
             sessionKey,
+            senderIsOwner: true,
             lastChannel: "imessage",
             lastTo: "+15551234567",
             messageId: "msg-user-2",

--- a/src/mcp/channel-shared.ts
+++ b/src/mcp/channel-shared.ts
@@ -71,6 +71,7 @@ export type ChatHistoryResult = {
 /** Gateway session.message payload fields consumed by the MCP event bridge. */
 export type SessionMessagePayload = {
   sessionKey?: string;
+  senderIsOwner?: boolean;
   messageId?: string;
   messageSeq?: number;
   message?: { role?: string; content?: unknown; [key: string]: unknown };

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -272,6 +272,7 @@ describe("user turn transcript persistence", () => {
           text: "What is in this image?",
           media: [{ path: "/tmp/image.png", contentType: "image/png" }],
           timestamp: 123,
+          senderIsOwner: true,
           provenance,
         },
         updateMode: "none",
@@ -287,6 +288,7 @@ describe("user turn transcript persistence", () => {
           role: "user",
           content: "What is in this image?",
           MediaPath: "/tmp/image.png",
+          __openclaw: { senderIsOwner: true },
           provenance,
           MediaType: "image/png",
         }),
@@ -398,6 +400,7 @@ describe("user turn transcript persistence", () => {
         input: {
           text: "secret prompt",
           idempotencyKey: "chat-run-1:user",
+          senderIsOwner: true,
           provenance,
         },
         beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
@@ -407,6 +410,7 @@ describe("user turn transcript persistence", () => {
         input: {
           text: "secret prompt",
           idempotencyKey: "chat-run-1:user",
+          senderIsOwner: true,
           provenance,
         },
         beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
@@ -417,6 +421,7 @@ describe("user turn transcript persistence", () => {
           role: "user",
           content: "[redacted by hook]",
           idempotencyKey: "chat-run-1:user",
+          __openclaw: { senderIsOwner: true },
           provenance,
         }),
       ]);

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -243,6 +243,9 @@ function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurn
     content,
     timestamp: params.timestamp ?? Date.now(),
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
+    ...(params.senderIsOwner === undefined
+      ? {}
+      : { __openclaw: { senderIsOwner: params.senderIsOwner } }),
     ...mediaFields,
   } as PersistedUserTurnMessage;
   return applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage;
@@ -317,12 +320,26 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
   const nextUserMessage = provenance
     ? (applyInputProvenanceToUserMessage(nextMessage, provenance) as PersistedUserTurnMessage)
     : nextMessage;
-  return idempotencyKey
-    ? ({
-        ...(nextUserMessage as unknown as Record<string, unknown>),
-        idempotencyKey,
-      } as unknown as PersistedUserTurnMessage)
-    : nextUserMessage;
+  const originalOpenClaw = (message as unknown as { __openclaw?: unknown })["__openclaw"];
+  const senderIsOwner =
+    originalOpenClaw && typeof originalOpenClaw === "object"
+      ? (originalOpenClaw as { senderIsOwner?: unknown }).senderIsOwner
+      : undefined;
+  if (!idempotencyKey && typeof senderIsOwner !== "boolean") {
+    return nextUserMessage;
+  }
+  const nextRecord = nextUserMessage as unknown as Record<string, unknown>;
+  const nextOpenClaw =
+    nextRecord["__openclaw"] && typeof nextRecord["__openclaw"] === "object"
+      ? (nextRecord["__openclaw"] as Record<string, unknown>)
+      : {};
+  return {
+    ...nextRecord,
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+    ...(typeof senderIsOwner === "boolean"
+      ? { __openclaw: { ...nextOpenClaw, senderIsOwner } }
+      : {}),
+  } as unknown as PersistedUserTurnMessage;
 }
 
 export async function appendUserTurnTranscriptMessage(

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -23,6 +23,7 @@ export type UserTurnInput = {
   media?: readonly PersistedUserTurnMediaInput[] | null;
   timestamp?: number;
   idempotencyKey?: string;
+  senderIsOwner?: boolean;
   provenance?: InputProvenance;
   mediaOnlyText?: string;
 };


### PR DESCRIPTION
## Summary

Backports `b885c81479d` (`fix(mcp): require owner for Claude permission replies (#98256)`) to the frozen extended-stable candidate.

The exact frozen MCP lane showed the candidate consumes a matching `yes abcde` from any user as an MCP permission response. A non-admin Gateway client can therefore resolve an outstanding Claude permission. This backport carries the authenticated `senderIsOwner` fact from ingress through the persisted user turn and session broadcast, then makes the MCP bridge resolve only an owner user reply. Non-owner or unproven replies remain ordinary channel messages.

## Evidence

- Reproduction: Plugin Prerelease exact-frozen run `33709410737`, MCP channels job `100506487790`; expected non-owner channel-forwarding timed out because the candidate consumed it as a permission response.
- Root cause: frozen `src/mcp/channel-bridge.ts` handles `permissionMatch` before queue/Claude channel delivery, without a role/owner predicate.
- Upstream security fix `b885c81479d` is absent from frozen candidate `659df810` and is the canonical owner-boundary repair.
- Adaptation: two merge conflicts in session event metadata were resolved by preserving candidate behavior and forwarding only `senderIsOwner`; the unrelated upstream idempotency-key assertion was not added because the candidate lacks that precondition.

## Validation

- `node scripts/run-vitest.mjs run src/mcp/channel-bridge.test.ts src/mcp/channel-server.test.ts src/gateway/server-session-events.test.ts src/sessions/user-turn-transcript.test.ts` — 60 passed.
- `node scripts/run-vitest.mjs run src/gateway/server-methods/chat.directive-tags.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts` — 343 passed.
- `git diff --check`; formatting; autoreview passed.
- Current gate: this head\x27s preflight/security-fast run predates the frozen-checkout authentication repair #136949 and fails before validation. Rerun after #136949 lands.

## Scope

Production +52 / -9; tests +148 / -3; docs +1 / -1. This is a source-compatible security/lifecycle backport. No config schema, package, tag, npm, or candidate ref mutation is included.