### PR TITLE
refactor(model-catalog): consolidate overlay fixture resets

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -12,10 +12,7 @@ import {
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
-import {
-  resetRemoteModelCatalogOverlayForTest,
-  setRemoteModelCatalogOverlaySourcesForTest,
-} from "../model-catalog/remote-overlay.test-support.js";
+import { setRemoteModelCatalogOverlaySourcesForTest } from "../model-catalog/remote-overlay.test-support.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import * as usageFormat from "../utils/usage-format.js";
@@ -715,7 +712,6 @@ describe("session cost usage", () => {
         checked_at: 200,
       }),
     });
-    resetRemoteModelCatalogOverlayForTest();
     const config = {
       models: {
         providers: {
@@ -748,7 +744,6 @@ describe("session cost usage", () => {
       });
     } finally {
       setRemoteModelCatalogOverlaySourcesForTest();
-      resetRemoteModelCatalogOverlayForTest();
     }
   });
 

--- a/src/model-catalog/pricing.test.ts
+++ b/src/model-catalog/pricing.test.ts
@@ -23,10 +23,7 @@ import {
   resolveModelCostConfig,
   resolveModelCostConfigFingerprint,
 } from "../utils/usage-format.js";
-import {
-  resetRemoteModelCatalogOverlayForTest,
-  setRemoteModelCatalogOverlaySourcesForTest,
-} from "./remote-overlay.test-support.js";
+import { setRemoteModelCatalogOverlaySourcesForTest } from "./remote-overlay.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const readStoredCatalog = vi.fn();
@@ -34,7 +31,6 @@ const readStoredCatalog = vi.fn();
 beforeEach(() => {
   clearRuntimeConfigSnapshot();
   resetUsageFormatCachesForTest();
-  resetRemoteModelCatalogOverlayForTest();
   readStoredCatalog.mockReset().mockReturnValue({
     source_url: "https://catalog.openclaw.ai/models/v1/catalog.json",
     bundle_json: JSON.stringify({
@@ -104,7 +100,6 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   setRemoteModelCatalogOverlaySourcesForTest();
-  resetRemoteModelCatalogOverlayForTest();
 });
 
 function configFor(baseUrl: string): OpenClawConfig {
@@ -934,7 +929,6 @@ describe("hosted model pricing", () => {
       source_url: "https://catalog.openclaw.ai/models/v1/catalog.json",
       bundle_json: bundleJson,
     });
-    resetRemoteModelCatalogOverlayForTest();
 
     const fingerprint = resolveModelCostConfigFingerprint(configFor("https://api.openai.com/v1"));
     const withoutHostedPricing = configFor("https://api.openai.com/v1");

--- a/src/model-catalog/remote-overlay.test-support.ts
+++ b/src/model-catalog/remote-overlay.test-support.ts
@@ -3,7 +3,6 @@ import "./remote-overlay.js";
 import type { readRemoteModelCatalog } from "./remote-store.js";
 
 type RemoteModelCatalogOverlayTestApi = {
-  resetRemoteModelCatalogOverlayForTest(): void;
   setRemoteModelCatalogOverlaySourcesForTest(sources?: {
     bundledGeneratedAt?: typeof bundledCatalogGeneratedAt;
     readStoredCatalog?: typeof readRemoteModelCatalog;
@@ -14,10 +13,6 @@ function getTestApi(): RemoteModelCatalogOverlayTestApi {
   return (globalThis as Record<PropertyKey, unknown>)[
     Symbol.for("openclaw.remoteModelCatalogOverlayTestApi")
   ] as RemoteModelCatalogOverlayTestApi;
-}
-
-export function resetRemoteModelCatalogOverlayForTest(): void {
-  getTestApi().resetRemoteModelCatalogOverlayForTest();
 }
 
 export function setRemoteModelCatalogOverlaySourcesForTest(

--- a/src/model-catalog/remote-overlay.test.ts
+++ b/src/model-catalog/remote-overlay.test.ts
@@ -3,10 +3,7 @@ import {
   getRemoteModelCatalogPricing,
   getRemoteModelCatalogProviderOverlay,
 } from "./remote-overlay.js";
-import {
-  resetRemoteModelCatalogOverlayForTest,
-  setRemoteModelCatalogOverlaySourcesForTest,
-} from "./remote-overlay.test-support.js";
+import { setRemoteModelCatalogOverlaySourcesForTest } from "./remote-overlay.test-support.js";
 
 const mocks = {
   builtAt: vi.fn<() => number | undefined>(),
@@ -23,7 +20,6 @@ const bundle = {
 };
 
 beforeEach(() => {
-  resetRemoteModelCatalogOverlayForTest();
   mocks.builtAt.mockReset().mockReturnValue(100);
   mocks.read.mockReset().mockReturnValue({
     bundle_json: JSON.stringify(bundle),
@@ -37,7 +33,6 @@ beforeEach(() => {
 
 afterEach(() => {
   setRemoteModelCatalogOverlaySourcesForTest();
-  resetRemoteModelCatalogOverlayForTest();
 });
 
 describe("remote model catalog overlay", () => {
@@ -59,10 +54,12 @@ describe("remote model catalog overlay", () => {
       ),
     ).toBeUndefined();
     expect(mocks.read).not.toHaveBeenCalled();
-    resetRemoteModelCatalogOverlayForTest();
     mocks.builtAt.mockReturnValue(200);
     expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toBeUndefined();
-    resetRemoteModelCatalogOverlayForTest();
+    setRemoteModelCatalogOverlaySourcesForTest({
+      bundledGeneratedAt: mocks.builtAt,
+      readStoredCatalog: mocks.read,
+    });
     mocks.builtAt.mockReturnValue(undefined);
     expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toBeUndefined();
   });

--- a/src/model-catalog/remote-overlay.ts
+++ b/src/model-catalog/remote-overlay.ts
@@ -80,10 +80,6 @@ export function getRemoteModelCatalogPricing(
   return getActiveRemoteModelCatalog(config)?.pricing;
 }
 
-function resetRemoteModelCatalogOverlayForTest(): void {
-  cachedOverlay = undefined;
-}
-
 function setRemoteModelCatalogOverlaySourcesForTest(sources?: {
   bundledGeneratedAt?: typeof bundledCatalogGeneratedAt;
   readStoredCatalog?: typeof readRemoteModelCatalog;
@@ -97,7 +93,6 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[
     Symbol.for("openclaw.remoteModelCatalogOverlayTestApi")
   ] = {
-    resetRemoteModelCatalogOverlayForTest,
     setRemoteModelCatalogOverlaySourcesForTest,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

This maintainer-requested test audit removes duplicate catalog-cache reset plumbing from the overlay, pricing, and session-cost fixtures. The existing source setter already clears the same cache, so the second reset operation adds maintenance without independent coverage.

## Why This Change Was Made

Use the existing setter as the fixture owner and retire the private cache-only reset function, publication member, and test wrapper. At the one meaningful mid-test reset, explicitly reinstall the same two mock readers while clearing the cached result. Keep the setter and shared test publication; the publisher suite already uses that pattern.

## User Impact

No user-visible behavior changes. Catalog caching, source-URL isolation, pricing/privacy rules, and stored usage data remain unchanged. All existing cases and assertions remain: production −5 lines, test support −5, tests −14.

## Evidence

The same normal command passed before and after:

```sh
pnpm test src/model-catalog/remote-overlay.test.ts src/model-catalog/pricing.test.ts src/infra/session-cost-usage.test.ts test/scripts/publish-model-catalog.test.ts
```

```text
Before: 4 files, 166 tests passed (57 unit + 49 tooling + 60 infra).
After:  4 files, 166 tests passed (57 unit + 49 tooling + 60 infra).
```

The retained inventory is 97 test declarations, 424 static assertion sites, and 15 parameter tables. This includes the 40,000-entry catalog regression: input exceeds 2 MiB while persisted usage rows stay below 32 KiB.

A temporary fault removed only the existing setter's cache-clear assignment, then ran the three overlay cases in their original order. The first passed; two existing assertions failed:

```text
stale lookup: expected { models: [ { id: 'new' } ] } to be undefined
URL-change lookup: expected "vi.fn()" to be called 2 times, but got 1 times
Tests  2 failed | 1 passed (3)
```

The native runner was joined before exact source restoration. No fault instrumentation or new test remains. This is synthetic fixture proof, not a live catalog/provider claim.

Fresh isolated Codex review: scoped-clean through P2, no findings (static review; tests were run separately). The configured five-path changed gate passed, including production/test type graphs, unused-export scans, lint, and architecture guards.
