### PR TITLE
chore(ui): raise Control UI startup CSS ceiling to 45.5 KiB

### DIFF
--- a/scripts/check-control-ui-performance.mts
+++ b/scripts/check-control-ui-performance.mts
@@ -40,7 +40,11 @@ const controlUiPerformanceBudgets = {
   // once those palettes moved out of the startup sheet into public/themes and
   // measured 42.2 KiB — below where they started. Adding a built-in theme no
   // longer costs the default path anything, so this ceiling should stay put.
-  startupCssGzipBytes: 45 * KIB,
+  // 2026-09-03: main measured 46097 B (17 B over 45 KiB) after the chat face
+  // switch / visibility menu and Appearance work; release operator raised the
+  // ceiling to 45.5 KiB so unrelated PRs stop failing build-artifacts. Shrink
+  // the boot sheet before adding more startup CSS rather than raising again.
+  startupCssGzipBytes: 45.5 * KIB,
   largestJsGzipBytes: 215 * KIB,
   // Composer multiline surface (stack #124301) legitimately grew boot CSS;
   // operator decision 2026-08-25 rejected boot splitting due to precedence risk.


### PR DESCRIPTION
## What Problem This Solves

`build-artifacts` fails on every main-based PR: `startup CSS gzip: 45.0 KiB exceeds 45.0 KiB (46097 B vs 46080 B)` (for example https://github.com/openclaw/openclaw/actions/runs/33709705282/job/100506721345 on #136798). The JS budget was re-baselined in #136817; the CSS ceiling is a fixed constant in `scripts/check-control-ui-performance.mts`.

## Why This Change Was Made

Recent Control UI landings (chat face switch and visibility menu #136646–#136650, Appearance work) grew the boot sheet by 17 B past the 45 KiB ceiling. Raising it to 45.5 KiB restores the gate with minimal headroom; the code comment records the operator decision (2026-09-03) and that the boot sheet should shrink before more startup CSS is added.

## User Impact

None at runtime. Unblocks CI for the 2026.9.1 release fix PRs.

## Evidence

- Measured value from the failing job log above.
- `oxfmt --check` clean.
