### PR TITLE
perf: skip inactive Code Mode source scans

### DIFF
--- a/src/agents/transcript-code-mode-source.ts
+++ b/src/agents/transcript-code-mode-source.ts
@@ -151,7 +151,7 @@ export function readCodeModeSourceFields(
 ): ReadonlyMap<object, ReadonlyMap<string, string>> {
   const state = token && sourceAppends.get(token);
   const slots = state?.active && state.message === message ? state.slots : [];
-  const calls = outerCalls(message);
+  const calls = slots.length ? outerCalls(message) : [];
   const fields = new Map<object, ReadonlyMap<string, string>>();
   for (const slot of slots) {
     const block = calls.find((call) => call === slot.block);


### PR DESCRIPTION
Related: #129816

<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers with write access can edit it.

</details>

## What Problem This Solves

Ordinary transcript redaction scans assistant tool-call blocks even when there is no active Code Mode source to preserve. That scan allocates a filtered array whose contents cannot be used.

## Why This Change Was Made

`readCodeModeSourceFields` already determines which private source slots belong to the exact active message. Only scan its outer calls when that selection is nonempty. The source owner remains responsible for the decision; callers gain no duplicated policy or cache. Active block identity, ID, name, language, argument and duplicate-ID checks remain unchanged, as does the fresh result Map.

Production LOC: +1/-1 (net 0). Tests: unchanged. No configuration, schema, provider protocol or public API changes.

## User Impact

Less work when reading inactive Code Mode source metadata. The direct read measured 47–55% faster, saving roughly 1.9–2.7 microseconds per call in these fixtures. This is not a claim that complete agent turns or transcript redaction are 47–55% faster.

## Evidence

The frozen experiment used actual source-owner functions and the full transcript redactor with synthetic assistant messages: B0, C0, C1, B1; eight rows; eight calls per observation; one first, three warm and twenty measured observations per row/host. All 6,192 target calls passed complete result, mutation, alias and lifecycle checks; 640 measured batch means were retained. An independent raw-first arithmetic/graph audit reproduces the numbers below. Its final audit also verified all 583 selected pins, 7,281 evidence files, nine stage exits, and absence of all 26 recorded process IDs and nine process groups.

Median time change (negative is faster):

| Path | B0 → C0 | B1 → C1 |
| --- | ---: | ---: |
| Inactive direct source read | −54.815% | −47.049% |
| Full ordinary transcript redaction | −43.499% | −0.575% |
| Closed source read | −30.575% | −14.069% |
| Full clean-message redaction | −20.551% | +10.235% |
| Active source read | +12.001% | −11.438% |
| Active source-preserving redaction | −15.666% | +4.121% |
| Empty-slot source read | −47.504% | −22.985% |
| Wrong-message source read | −47.210% | −45.682% |

**The original experiment failed its preset 3% improvement threshold for full ordinary redaction in the reverse order.** That rejection is retained unchanged. The maintainer explicitly accepted the direct-path benefit as worth landing; no rerun, threshold adjustment or aggregate rescue was used.

The slower reverse-order controls were +6.716µs for clean-message redaction and +16.409µs for active redaction. Active redaction p95 was worse in both orders (+7.576%/+19.637%). Kernel peak RSS was +6.815%/+2.189%. These small host samples do not establish an end-to-end latency or memory improvement; all first/warm/measured samples and adverse results remain in the raw evidence.

Correctness: the same 106 existing cases pass before and after across `src/agents/sessions/agent-session-code-mode-source.test.ts` and `src/agents/transcript-redact.test.ts`, including active/inactive ownership, redaction, persistence/reopen and subsequent context behavior. The repository changed-check completed successfully in 312.238s. Fresh managed Codex P2 review is scoped-clean with no findings. Current main was compared with the frozen base; the owner and these caller/test surfaces are unchanged. No additional implementation-mirroring test was added for this one-line change.

Frozen baseline: `3e66de0cb5c3061ec6a993d3173ad0ab5a9d2577`. Candidate owner SHA-256: `1e0fefa904adc40330eb18e7e76456cae6662b82cc0da7325e947c83d07362ee`. Immutable original experiment final SHA-256: `1bc5aa5a0aaf156b8c4ba0193104da225d00f625e7faef433a7c6d92c868dc51`. The raw fixture/measurement bundle is retained locally; it contains synthetic data and no live provider timing claim. Independent audit seal SHA-256: `2dafd33822c816162224939d5c1bc8c138c6e9fb55a8bfbe0768e0a52b0e1595`. The audit independently reconstructed the raw arithmetic and full graph/identity checks; its author also prepared the original fixtures, so it is not a second independent fixture author. Earlier preparation contains acknowledged unknown positive clock gaps; the recorded 161.248s is the declared family charge, not a reconstruction of total preparation time.
