### PR TITLE
perf(mcp): prepare scheduler alias lookup once

### DIFF
--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -78,6 +78,11 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
   for (const tool of wrappedTools) {
     toolMap.set(tool.name, { tool, runId: resolveBeforeToolCallRunId(tool) });
   }
+  // "cron" remains an inbound scheduler alias (owner decision, RFC 0026).
+  // Capture the first advertised name without adding another listTools entry;
+  // map lookup keeps the last tool for duplicate names.
+  const automationsName = wrappedTools.find((tool) => isAutomationsToolName(tool.name))?.name;
+  const automationsEntry = automationsName ? toolMap.get(automationsName) : undefined;
 
   return {
     listTools: async () => ({
@@ -88,14 +93,9 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
       })),
     }),
     callTool: async (params: CallPluginToolParams, signal?: AbortSignal) => {
-      // "cron" is a permanently accepted inbound alias for the scheduler tool
-      // (owner decision, RFC 0026; same contract as bash -> exec). Resolve it to
-      // the published canonical tool without re-advertising it in listTools.
       const entry =
         toolMap.get(params.name) ??
-        (isAutomationsToolName(params.name)
-          ? Array.from(toolMap.entries()).find(([name]) => isAutomationsToolName(name))?.[1]
-          : undefined);
+        (isAutomationsToolName(params.name) ? automationsEntry : undefined);
       if (!entry) {
         return {
           content: [{ type: "text", text: `Unknown tool: ${params.name}` }],

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -232,41 +232,47 @@ describe("plugin tools MCP server", () => {
     expect(result.content).toEqual([{ type: "text", text: "Stored." }]);
   });
 
-  it("uses unique ids and releases execution tracking after repeated direct MCP calls", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1_000);
-    const executeSuccess = vi.fn().mockResolvedValue({ content: "Stored." });
-    const executeFailure = vi.fn().mockRejectedValue(new Error("unavailable"));
-    const handlers = createPluginToolsMcpHandlers([
-      {
-        name: "memory_recall",
-        description: "Recall stored memory",
-        parameters: { type: "object", properties: {} },
-        execute: executeSuccess,
-      } as unknown as AnyAgentTool,
-      {
-        name: "memory_forget",
-        description: "Forget stored memory",
-        parameters: { type: "object", properties: {} },
-        execute: executeFailure,
-      } as unknown as AnyAgentTool,
-    ]);
+  it.each([
+    ["memory_recall", "memory_recall"],
+    ["automations", "cron"],
+  ])(
+    "uses unique ids and releases execution tracking for %s called as %s",
+    async (name, callName) => {
+      vi.spyOn(Date, "now").mockReturnValue(1_000);
+      const executeSuccess = vi.fn().mockResolvedValue({ content: "Stored." });
+      const executeFailure = vi.fn().mockRejectedValue(new Error("unavailable"));
+      const handlers = createPluginToolsMcpHandlers([
+        {
+          name,
+          description: "Recall stored memory",
+          parameters: { type: "object", properties: {} },
+          execute: executeSuccess,
+        } as unknown as AnyAgentTool,
+        {
+          name: "memory_forget",
+          description: "Forget stored memory",
+          parameters: { type: "object", properties: {} },
+          execute: executeFailure,
+        } as unknown as AnyAgentTool,
+      ]);
 
-    for (let index = 0; index < 32; index += 1) {
-      await handlers.callTool({ name: "memory_recall", arguments: { index } });
-      await handlers.callTool({ name: "memory_forget", arguments: { index } });
-    }
+      for (let index = 0; index < 32; index += 1) {
+        await handlers.callTool({ name: callName, arguments: { index } });
+        await handlers.callTool({ name: "memory_forget", arguments: { index } });
+      }
 
-    expect(executeSuccess).toHaveBeenCalledTimes(32);
-    expect(executeFailure).toHaveBeenCalledTimes(32);
-    const toolCallIds = [...executeSuccess.mock.calls, ...executeFailure.mock.calls].map(
-      ([toolCallId]) => String(toolCallId),
-    );
-    expect(new Set(toolCallIds).size).toBe(toolCallIds.length);
-    for (const toolCallId of toolCallIds) {
-      expect(consumeTrackedToolExecutionStarted(toolCallId)).toBeUndefined();
-      expect(consumeAdjustedParamsForToolCall(toolCallId)).toBeUndefined();
-    }
-  });
+      expect(executeSuccess).toHaveBeenCalledTimes(32);
+      expect(executeFailure).toHaveBeenCalledTimes(32);
+      const toolCallIds = [...executeSuccess.mock.calls, ...executeFailure.mock.calls].map(
+        ([toolCallId]) => String(toolCallId),
+      );
+      expect(new Set(toolCallIds).size).toBe(toolCallIds.length);
+      for (const toolCallId of toolCallIds) {
+        expect(consumeTrackedToolExecutionStarted(toolCallId)).toBeUndefined();
+        expect(consumeAdjustedParamsForToolCall(toolCallId)).toBeUndefined();
+      }
+    },
+  );
 
   it("serializes source-shaped image tool content with pinned MCP image blocks", async () => {
     const execute = vi.fn().mockResolvedValue({


### PR DESCRIPTION
MCP scheduler alias calls currently turn the complete private tool map into an array before locating the fallback entry. Prepare that entry when the handler is built, preserving direct-name precedence, first matching name order, and the last value for duplicate names. The advertised list, hooks, signals, error projection and execution cleanup are unchanged.

An actual-owner before/after corpus produced 125 matching call observations. A real MCP SDK client/server exchange with duplicate `automations` entries returned the last duplicate for both names:

```json
{"name":"automations","index":2,"args":{"marker":"wire"}}
```

Missing-name and throwing-tool outcomes also matched, and both transports closed. Four alias calls over 1/8/64 synthetic entries previously allocated 4 entry vectors plus 4/32/256 entry pairs; those constructions are removed. The tradeoff is one new constructor scan even if no alias is called. This is scoped work-count evidence, not a heap/RSS or latency claim; larger catalogs are synthetic scaling controls.

Validation: 33 focused MCP tests, canonical changed-file checks, and clean managed P0–P2 review. The existing repeated-call lifecycle test now covers both direct and alias invocation with all assertions retained. Production LOC is unchanged; tests are net +6. No configuration, protocol, dependency or public API change.
