### PR TITLE
perf(plugins): read bundle descriptions from the first line

### DIFF
--- a/src/plugins/bundle-commands.ts
+++ b/src/plugins/bundle-commands.ts
@@ -93,12 +93,10 @@ function toDefaultCommandName(rootDir: string, filePath: string): string {
   return withoutExt.split(path.sep).join(":");
 }
 
-function toDefaultDescription(rawName: string, promptTemplate: string): string {
-  const firstLine = promptTemplate
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .find(Boolean);
-  return firstLine || rawName;
+function toDefaultDescription(promptTemplate: string): string {
+  // stripFrontmatterBlock already normalized line endings and trimmed the nonempty body.
+  const lineEnd = promptTemplate.indexOf("\n");
+  return (lineEnd < 0 ? promptTemplate : promptTemplate.slice(0, lineEnd)).trimEnd();
 }
 
 function loadBundleCommandsFromRoot(params: {
@@ -131,8 +129,7 @@ function loadBundleCommandsFromRoot(params: {
       continue;
     }
     const description =
-      normalizeOptionalString(frontmatter.description) ||
-      toDefaultDescription(rawName, promptTemplate);
+      normalizeOptionalString(frontmatter.description) || toDefaultDescription(promptTemplate);
     entries.push({
       pluginId: params.pluginId,
       rawName,


### PR DESCRIPTION
Bundle command descriptions were splitting and trimming the whole prompt body after `stripFrontmatterBlock` had already normalized line endings and trimmed it. The loader also rejects empty bodies before this helper runs. Select the first line directly and remove the unreachable raw-name fallback and parameter. Explicit descriptions, full prompt bodies, command names/order, invocation rules and the file-size boundary remain unchanged.

This removes three production lines (+5/−8), with no test changes. An actual-source counter on a 15,001-line body observed two 15,001-entry arrays and 15,001 trims before; after, the helper returns the same `Long summary` with no arrays and one trimEnd. These are source allocation/pass counts, not an RSS, retained-heap or general speedup claim.

Both source arms pass all 38 existing frontmatter, bundle-command and command-spec tests. A fixed synthetic bundle also passes through real manifest discovery and both public command APIs without registry/parser mocks: all 18 command records and consumer specs match in full, including prompt bytes, Unicode/newline cases, names, collisions, disabled/hidden entries, outside-root exclusion and oversized-file warnings. Common output SHA-256: `60db614ccd8273d2870054aeaacec9a38f94565751ea05f2fab9aaffc7e8fe9c`. Managed Codex P2 review is scoped-clean and the canonical changed gate passes.
