### PR TITLE
fix(release): accept a queued validation parent when binding artifact producers

### DIFF
--- a/scripts/full-release-artifacts.mjs
+++ b/scripts/full-release-artifacts.mjs
@@ -99,7 +99,10 @@ function validateArtifactParent(request, parent, env) {
       parent.head_repository?.full_name === request.repository &&
       parent.head_sha === request.toolingSha &&
       parent.head_branch === request.workflowRef &&
-      parent.status === "in_progress" &&
+      // GitHub reports a parent as "queued" whenever any of its jobs is still
+      // waiting for a runner, even while this producer runs from it; both mean
+      // the parent is live and unfinished. A completed parent stays rejected.
+      (parent.status === "in_progress" || parent.status === "queued") &&
       parent.conclusion === null &&
       env.GITHUB_SHA === request.toolingSha &&
       env.GITHUB_REF_NAME === request.workflowRef,


### PR DESCRIPTION
## What Problem This Solves

Both artifact producers in Full Release Validation run https://github.com/openclaw/openclaw/actions/runs/33710661893 failed at "Bind exact active validation parent" with `Artifact preparation requires its exact active FRV parent and frozen tooling.` The parent run was live but GitHub reported its status as `queued` because another parent job was waiting for a runner; the binding accepted only `in_progress`.

## Why This Change Was Made

`queued` with a null conclusion is still a live, unfinished parent. The check now accepts `in_progress` or `queued`; a completed parent (non-null conclusion) is still rejected. Every other identity check (run id, attempt, event, workflow path, repository, tooling SHA, workflow ref) is unchanged.

## User Impact

Release tooling only.

## Evidence

- Failing job: https://github.com/openclaw/openclaw/actions/runs/33710794027/job/100509631655 (parent status `queued` at check time; same tooling passed on run 33704822889 when the parent was `in_progress`).
- `test/scripts/full-release-artifacts*` pass locally with the patch; `oxfmt --check` clean.
