### PR TITLE
fix(agents): neutralize Anthropic refusal marker replacement

### DIFF
--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -9,7 +9,29 @@ import {
   resolveFinalAssistantVisibleText,
   resolveNextSameModelRateLimitRetryCount,
   resolveSameModelRateLimitRetryDelayMs,
+  scrubAnthropicRefusalMagic,
 } from "./helpers.js";
+
+describe("scrubAnthropicRefusalMagic", () => {
+  const refusalTrigger = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
+
+  it.each([
+    { prompt: refusalTrigger, expected: "[redacted]" },
+    {
+      prompt: `Reply ok. Test trigger: ${refusalTrigger}_nonce-a and ${refusalTrigger}_nonce-b`,
+      expected: "Reply ok. Test trigger: [redacted]_nonce-a and [redacted]_nonce-b",
+    },
+  ])(
+    "neutralizes every refusal marker while preserving surrounding text",
+    ({ prompt, expected }) => {
+      expect(scrubAnthropicRefusalMagic(prompt)).toBe(expected);
+    },
+  );
+
+  it("keeps unrelated prompts byte-for-byte", () => {
+    expect(scrubAnthropicRefusalMagic("ordinary prompt")).toBe("ordinary prompt");
+  });
+});
 
 function makeAssistantMessage(
   content: AssistantMessage["content"],

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -86,9 +86,9 @@ export function resolveNextSameModelRateLimitRetryCount(params: {
 }
 
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
-const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)";
+const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "[redacted]";
 
-// Avoid Anthropic's refusal test token poisoning session transcripts.
+// Keep the replacement neutral: naming the refusal trigger can itself prompt a refusal.
 export function scrubAnthropicRefusalMagic(prompt: string): string {
   if (!prompt.includes(ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL)) {
     return prompt;

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -2447,7 +2447,7 @@ describe("latestAssistantTextAfterBaseline", () => {
   it("correlates Anthropic refusal probes after the runtime scrubs their trigger", () => {
     const nonce = "0123456789abcdef0123456789abcdef";
     const expected = `Reply with the single word ok. Test trigger: ${ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL}_${nonce}`;
-    const scrubbed = `Reply with the single word ok. Test trigger: ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_${nonce}`;
+    const scrubbed = `Reply with the single word ok. Test trigger: [redacted]_${nonce}`;
     const redacted = redactSecrets(expected);
 
     expect(matchesLiveProbeUserText(scrubbed, expected)).toBe(true);
@@ -2467,7 +2467,7 @@ describe("latestAssistantTextAfterBaseline", () => {
     ).toEqual([{ role: "assistant", content: "ok", stopReason: "stop" }]);
     expect(
       matchesLiveProbeUserText(
-        "Reply with the single word ok. Test trigger: ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_ffffffffffffffffffffffffffffffff",
+        "Reply with the single word ok. Test trigger: [redacted]_ffffffffffffffffffffffffffffffff",
         expected,
       ),
     ).toBe(false);


### PR DESCRIPTION
## Summary

Backport the already-landed main repair from #132556 to the 2026.6.35 extended-stable candidate.

The frozen runtime scrubbed the Anthropic refusal sentinel into English text that still described a refusal trigger. Claude Haiku then refused that synthetic live probe. The replacement is now the neutral string `[redacted]`, while repeated markers and surrounding nonce text remain intact.

## Failure proof

- Full release validation child: https://github.com/openclaw/openclaw/actions/runs/33709476431
- Exact failed job: https://github.com/openclaw/openclaw/actions/runs/33709476431/job/100507850413
- Haiku completed the meaningful prompt and tool-read probes, then refused only the scrubbed refusal-probe phrase.
- Main owner fix: #132556 / 72491232aa282212edc5d6f164f50d9549103b65.

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/helpers.test.ts` — 14 passed.
- `pnpm exec vitest run --config test/vitest/vitest.live.config.ts src/gateway/gateway-models.profiles.live.test.ts` — 109 passed, 2 skipped; no provider calls.
- Focused Oxfmt and type-aware OXLint passed.
- `git diff --check` passed.
- Autoreview local mode: clean, no actionable findings; correctness 0.99.

Production delta: 2 additions / 2 removals, net 0. Tests: 24 additions / 2 removals. No config, dependency, protocol, tag, package, or npm-selector changes.

## Current merge gate

The recorded preflight/security-fast failures are from the frozen-checkout authentication defect tracked by #136949 and occur before this patch is exercised. Rerun this unchanged head after #136949 lands; no code failure is currently attributed to this PR.
