### PR TITLE
fix: stabilize progress-card disconnect coverage

### DIFF
--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -94,19 +94,22 @@ describe("renderSessionProgressCard", () => {
     expect(container.querySelector("time")?.textContent).toBe("Updated 2m ago");
   });
 
-  it("refreshes relative time while connected and stops after disconnect", async () => {
+  it("refreshes relative time while connected and stops after disconnect", () => {
     const container = document.createElement("div");
-    render(
+    const part = render(
       renderSessionProgressCard({ ...progressCard, updatedAt: NOW_MS - 10_000 }, "composer"),
       container,
     );
     expect(container.querySelector("time")?.textContent).toBe("Updated just now");
 
-    await vi.advanceTimersByTimeAsync(60_000);
+    vi.advanceTimersByTime(60_000);
+    expect(container.querySelector("time")?.textContent).toBe("Updated 1m ago");
+
+    part.setConnected(false);
+    vi.advanceTimersByTime(60_000);
     expect(container.querySelector("time")?.textContent).toBe("Updated 1m ago");
 
     render(null, container);
-    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("labels activity from the last minute as just now", () => {


### PR DESCRIPTION
Related: #136878 (artifact/CSS validation repair), #136845 (also blocked by the progress-card flake).

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Resolves a problem where otherwise correct Control UI test runs fail because the progress-card disconnect test assumes the entire fake-timer queue is empty. Main run [33707771767](https://github.com/openclaw/openclaw/actions/runs/33707771767) rendered the expected relative time but reported one pending timer at the final global timer-count assertion.

## Why This Change Was Made

The test already freezes the clock. It now advances that clock synchronously, disconnects the rendered Lit root through its public connection API, and verifies that another minute does not update the retained relative-time label. This directly tests the card's refresh lifecycle without treating unrelated timers or microtasks as leaked card intervals. The interval and formatter implementations are unchanged.

The companion artifact failure from [33708511094](https://github.com/openclaw/openclaw/actions/runs/33708511094) was already fixed by Jason (@fuller-stack-dev) in #136878, merged as `507e5faf28500d12b8b43c8d0ad7996190e27d5d`. Its fixture already separated mtimes by ten seconds; the stale assertion contradicted the intentional clean-Git precedence from #136634. That repair is independently verified here and is not duplicated.

## User Impact

No product behavior changes. CI retains exact connected-refresh and disconnected-cleanup coverage without an intermittent global-queue assertion. Reported by @steipete during the maintainer CI sweep.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/session-progress-card.test.ts`: 20 consecutive clean runs, 32 tests each. The existing artifact repair also passed its complete file 20 times, 9 tests per run.
- Original CI cohort: `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_INCLUDE_FILE=<268-file list from failed CI> node scripts/run-vitest.mjs --config test/vitest/vitest.ui.config.ts`: **268 files / 4,364 tests passed**.
- Cancellation mutation: temporarily removing `disconnected()` cleanup made the new assertion fail with `Updated 2m ago` versus `Updated 1m ago`. Production source was restored byte-for-byte. An earlier repetition attempt overlapped this fault injection and was discarded; the reported 20-run loop was restarted cleanly afterward.
- `node scripts/check-changed.mjs -- ui/src/components/session-progress-card.test.ts` passed, including test typechecking, formatting, scoped lint, i18n, and all three unused-export scans.
- Independent local and branch autoreview through P2: scoped-clean, no accepted/actionable findings. The final rebase added only #136855's unrelated backup-test simplification; the reviewed patch is unchanged.
- Initial broad baseline: 12,957 tests passed; one unrelated suite could not resolve `@openclaw/mermaid-renderer`. One frozen-lockfile dependency refresh repaired the local install before the clean repetition/cohort proof.

### Dependency contract (ClawSweeper follow-up)

Inspected the installed `lit` / `lit-html` **3.3.3** packages and fetched both upstream TypeScript files from the published `lit-html@3.3.3` tag, resolving the reviewer's environment-specific source-access gap:

- [RootPart contract](https://github.com/lit/lit/blob/lit-html%403.3.3/packages/lit-html/src/lit-html.ts#L1786-L1802) explicitly documents `setConnected(false)` as the caller's resource-disposal notification.
- [Connection propagation](https://github.com/lit/lit/blob/lit-html%403.3.3/packages/lit-html/src/lit-html.ts#L1769-L1773) synchronously notifies descendants; [AsyncDirective dispatch](https://github.com/lit/lit/blob/lit-html%403.3.3/packages/lit-html/src/async-directive.ts#L336-L346) calls `disconnected()`.
- [AsyncDirective.setValue](https://github.com/lit/lit/blob/lit-html%403.3.3/packages/lit-html/src/async-directive.ts#L364-L376) commits without a connection guard. Thus the retained-label assertion detects an interval that keeps firing while disconnected, as the cancellation mutation also demonstrated.

No code change or additional compatibility path was needed. No unaddressed rank-up move remains; exact-head CI must still finish green.

### Isolated live gateway smoke

Exact pushed head: `e64623746d9e3a8edb5939652d2b998a736fcf3a`.

```text
$ pnpm build qaRuntime
[build-all] phase timings: total 1m 17.2s; all runtime phases passed
$ node --import ./scripts/tsx.mjs scripts/bench-gateway-startup.ts --case default --runs 1 --warmup 0 --output .artifacts/deflake-gateway-smoke.json
/healthz: HTTP 200 in 12.13s
/readyz: HTTP 200 in 12.13s
Gateway ready observed; graceful teardown exit 0
```

The canonical smoke creates a fresh temporary home/config and `OPENCLAW_STATE_DIR`, selects an OS-assigned loopback port, disables LAN discovery, and removes its state after teardown. Synthetic setup only; no model or channel credentials were supplied. This is real Gateway startup/readiness smoke, not a live model/channel turn. Runtime behavior is unchanged; the changed refresh/disconnect contract is proved by the component tests and cancellation mutation above.

Production LOC: +0/-0. Tests: +7/-4 (net +3).

NO-FOLLOW-UP: this repair uses Lit's existing lifecycle API; a new helper or production refactor would add machinery without improving the tested contract.
