### PR TITLE
refactor: share background capacity across dreaming and skill reviews

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -733,7 +733,6 @@ extensions/memory-core/src/cli-runtime-common.ts	2
 extensions/memory-core/src/cli-status.runtime.ts	2
 extensions/memory-core/src/cli.ts	1
 extensions/memory-core/src/concept-vocabulary.ts	1
-extensions/memory-core/src/dreaming-narrative.ts	1
 extensions/memory-core/src/dreaming-phases.ts	2
 extensions/memory-core/src/dreaming.ts	1
 extensions/memory-core/src/memory/embeddings.ts	2

--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -135,8 +135,6 @@ extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
 extensions/mattermost/src/mattermost/slash-http.ts
 extensions/memory-core/doctor-contract-api.test.ts
 extensions/memory-core/src/cli.test.ts
-extensions/memory-core/src/dreaming-narrative.test.ts
-extensions/memory-core/src/dreaming-narrative.ts
 extensions/memory-core/src/dreaming-phases.test.ts
 extensions/memory-core/src/dreaming-phases.ts
 extensions/memory-core/src/dreaming.test.ts

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -57,7 +57,7 @@ Dreaming runs three cooperative phases per sweep, in order: light -> REM -> deep
   <Accordion title="Deep phase">
     - Ranks candidates with weighted scoring and threshold gates (`minScore`, `minRecallCount`, `minUniqueQueries` must all pass).
     - Rehydrates snippets from live daily files before writing, so stale/deleted snippets are skipped.
-    - Passes gated owner and agent-derived candidates to a consolidation subagent with the current `MEMORY.md`.
+    - Passes gated owner and agent-derived candidates to a tool-free consolidation completion with the current `MEMORY.md`.
     - Rewrites `MEMORY.md` only when the result preserves enough prior entries, includes candidate source references, and fits the bootstrap budget.
     - Falls back to the previous append-only promotion path when the model is unavailable or the rewrite fails validation.
     - Writes a `## Deep Sleep` summary into `DREAMS.md` and optionally `memory/dreaming/deep/YYYY-MM-DD.md`.
@@ -100,7 +100,9 @@ memory framing in the Generative Agents research.
 
 ## Dream Diary
 
-Dreaming keeps a narrative **Dream Diary** in `DREAMS.md`. After each phase has enough material, `memory-core` runs a best-effort background subagent turn and appends a short diary entry, using the default runtime model unless `dreaming.model` is configured. If the configured model is unavailable, the diary run retries once with the session default model; trust or allowlist failures are not retried and stay visible in logs instead of silently falling back to a generic diary entry.
+Dreaming keeps a narrative **Dream Diary** in `DREAMS.md`. After each phase has enough material, `memory-core` runs a tool-free background completion and appends a short diary entry, using the workspace agent's default model unless `dreaming.model` is configured. If the configured model is unavailable, the diary run retries once with that agent's default model. Trust or allowlist failures are not retried.
+
+Diary and consolidation completions use fresh contexts without retaining conversation sessions or delivering chat replies. Failed or empty diary generation writes a local fallback entry and reports a degraded outcome, so missing model output leaves a visible trace.
 
 <Note>
 The diary is for human reading in the Dreams UI, not a promotion source. Diary/report artifacts are excluded from short-term promotion; only grounded memory snippets are eligible to promote into `MEMORY.md`.
@@ -154,6 +156,8 @@ Light and REM phase hits recorded in SQLite-backed plugin state add a small rece
 ## Scheduling
 
 When enabled, `memory-core` auto-manages one cron job for a full dreaming sweep, deduped across the primary runtime workspace and any configured agent workspaces so subagent workspace fan-out does not exclude the main agent's `DREAMS.md` and memory state.
+
+Dreaming completions share the [background work budget](/concepts/queue#background-work) with Skill Workshop and other plugin completions: at most three runs in total, with up to three available to `memory-core`. The sweep coordinator does not consume a completion slot while it waits for phase work. System busyness shows these runs together in the `background` row.
 
 An explicit multi-agent fleet needs an [ambient system owner](/gateway/config-agents#agentsdefaultssystemagent) for this job. If logs report `Agent-less cron job has no resolvable owner`, choose an existing agent to own the sweep. For example, if that agent is `ops`:
 
@@ -268,14 +272,14 @@ All settings live under `plugins.entries.memory-core.config.dreaming`.
   Cron cadence for the full dreaming sweep.
 </ParamField>
 <ParamField path="model" type="string">
-  Optional Dream Diary subagent model override. Use a canonical `provider/model` value when also setting a subagent `allowedModels` allowlist.
+  Optional Dream Diary completion model override. Use a canonical `provider/model` value when also setting a subagent `allowedModels` allowlist.
 </ParamField>
 <ParamField path="phases.deep.maxPromotedSnippetTokens" type="number" default="160">
   Maximum estimated token count kept from each short-term recall snippet promoted into `MEMORY.md`. Ranking provenance remains visible.
 </ParamField>
 
 <Warning>
-`dreaming.model` requires `plugins.entries.memory-core.subagent.allowModelOverride: true`. To restrict it, also set `plugins.entries.memory-core.subagent.allowedModels`. The automatic retry only covers model-unavailable errors; trust or allowlist failures stay visible in logs instead of falling back silently.
+`dreaming.model` requires `plugins.entries.memory-core.subagent.allowModelOverride: true`. To restrict it, also set `plugins.entries.memory-core.subagent.allowedModels`. The automatic retry only covers model-unavailable errors; trust or allowlist failures produce a fallback diary trace and a degraded outcome instead of silently switching models.
 </Warning>
 
 <Note>

--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -1,8 +1,9 @@
 ---
-summary: "Auto-reply queue modes, defaults, and per-session overrides"
+summary: "Auto-reply queue modes, shared background capacity, and per-session overrides"
 read_when:
   - Changing auto-reply execution or concurrency
   - Explaining /queue modes or message steering behavior
+  - Inspecting background work and command-lane diagnostics
 title: "Command queue"
 ---
 
@@ -146,6 +147,14 @@ Host sleep that preserves the process can continue the existing queue normally.
 - Additional lanes may exist (e.g. `cron`, `cron-nested`, `nested`, `subagent`) so background jobs can run in parallel without blocking inbound replies. Isolated cron agent turns hold a `cron` slot while their inner agent execution uses `cron-nested`. Shared non-cron `nested` flows keep their own lane behavior. These detached runs are tracked as [background tasks](/automation/tasks).
 - Per-session lanes guarantee that only one agent run touches a given session at a time.
 - No external dependencies or background worker threads; pure TypeScript + promises.
+
+## Background work
+
+Skill Workshop reviews and plugin background completions, including [dreaming](/concepts/dreaming), share a separate budget of **three concurrent runs**. Workshop reviews use at most one slot; each plugin can use up to three available slots. This keeps maintenance work out of foreground reply capacity while bounding its total concurrency. These limits are built in and need no configuration.
+
+Schedulers that await background work do not occupy this budget themselves. Only the dispatched work holds a slot, through completion or cancellation cleanup, so a scheduler cannot block the child it is waiting for. Cancelled queued work is removed before it starts; Gateway restart or runtime retirement prevents stale completions from starting or returning results.
+
+The Control UI **System busyness** overlay and `diagnostics.lanes` report this work in one `background` row. Its active and queued counts include every owner; owner lanes are not counted again in the dynamic session-lane totals.
 
 ## Troubleshooting
 

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -310,6 +310,13 @@ route and scoped profiles, or the harness's native account when the plan leaves
 auth to the harness. The harness must not switch routes, reuse a native thread,
 attach tools, invoke agent lifecycle hooks, or deliver output.
 
+When supplied, call `params.assertCurrent()` immediately before each inference
+request or process start, including after preparation awaits and on retries.
+It revalidates the caller's live authority and expires when the completion ends.
+A thrown assertion ends execution; do not treat it as a credential failure or
+retry with another profile. Continue to honor `abortSignal`; cleanup must remain
+available after authority expires.
+
 Return `{ assistant: AssistantMessage }`. Core accepts only terminal text/thinking
 content with a `stop` or `length` stop reason; tool calls, failed stops, and empty
 output are rejected. Title requests set `outputTextPolicy: "strict-visible"`:

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -500,6 +500,38 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
   <Accordion title="api.runtime.subagent">
     Launch and manage background subagent runs.
 
+    For a tool-free completion that needs no retained session or reply delivery,
+    use `complete(...)`:
+
+    ```typescript
+    const { text } = await api.runtime.subagent.complete({
+      agentId: "research", // required configured agent that owns this work
+      message: "Summarize these notes.",
+      extraSystemPrompt: "Return a concise summary.", // optional
+      timeoutMs: 30_000, // optional; defaults to 30 seconds
+      // model: "openai/gpt-5.6-luna", // optional authorized override
+      // signal: abortController.signal, // optional cancellation
+    });
+    ```
+
+    `agentId` and `message` are required. `extraSystemPrompt`, `model`,
+    `timeoutMs`, and `signal` are optional. The selected agent supplies its
+    configured default model and credential owner when `model` is omitted.
+    The result is `{ text: string }`; no session creation, message polling,
+    deletion, or completion delivery is needed. The configured runtime must
+    support fresh, tool-free isolated inference; unsupported runtimes fail
+    before inference.
+
+    Completions use the [shared background queue](/concepts/queue#background-work),
+    with up to three runs per plugin within the three-run total budget.
+    Cancellation removes queued work immediately. Running work keeps its slot
+    until underlying runtime cleanup finishes, then rejects; late output is not
+    returned after cancellation, timeout, or runtime retirement. Calls require
+    a live Gateway binding and plugin identity. Model overrides retain the
+    existing subagent authorization and `allowedModels` policy below.
+
+    Use `run(...)` when you need a session or an agent tool surface:
+
     ```typescript
     // Start a subagent run
     const { runId, sessionKey } = await api.runtime.subagent.run({
@@ -533,8 +565,12 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
     `waitForRun(...)` returns the canonical Gateway wait result. `status` is `"ok"`, `"error"`, `"timeout"`, or `"pending"`; pending is a normal nonterminal observation, not an exception. Optional `error`, `startedAt`, `endedAt`, `stopReason`, `livenessState`, `yielded`, `pendingError`, `timeoutPhase`, `providerStarted`, and `terminalReply` metadata is preserved so callers can distinguish observation timeouts from terminal outcomes. `timeoutMs` bounds the wait call; it does not cancel the run.
 
     <Warning>
-    Model overrides (`provider`/`model`) require operator opt-in via `plugins.entries.<id>.subagent.allowModelOverride: true` in config. Untrusted plugins can still run subagents, but override requests are rejected.
+    Outside an authorized Gateway request, model overrides require operator opt-in via `plugins.entries.<id>.subagent.allowModelOverride: true` in config. Plugins without that opt-in can use the configured model, but override requests are rejected.
     </Warning>
+
+    `plugins.entries.<id>.subagent.allowedModels` can restrict overrides to
+    canonical `provider/model` targets. The same policy applies to `complete`;
+    request-scoped calls retain their authenticated client's override authority.
 
     `toolsAlsoAllow` adds exact, uniquely owned tools registered by the calling plugin to the worker's normal tool surface. The runtime rejects core tools and names shared with another plugin. Profiles and operator tool policies still apply, including explicit allowlists and denies.
 

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -527,7 +527,10 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
     Cancellation removes queued work immediately. Running work keeps its slot
     until underlying runtime cleanup finishes, then rejects; late output is not
     returned after cancellation, timeout, or runtime retirement. Calls require
-    a live Gateway binding and plugin identity. Model overrides retain the
+    a live Gateway binding and plugin identity. Request-scoped calls retain the
+    caller's operator scopes and agent access; completions started inside an
+    operator tool invocation are cancelled when that invocation ends.
+    Model overrides retain the
     existing subagent authorization and `allowedModels` policy below.
 
     Use `run(...)` when you need a session or an agent tool surface:

--- a/docs/tools/self-learning.md
+++ b/docs/tools/self-learning.md
@@ -69,8 +69,9 @@ Experience review starts only when all of these conditions hold:
 
 A later foreground completion in the same session restarts the quiet period.
 Pending reviews belong to an agent and session together, so agents using `global`
-retain separate candidates. Only one experience review runs at a time. The
-foreground answer is never delayed.
+retain separate candidates. Experience, history, and collection reviews share
+one Workshop slot within the [shared background work budget](/concepts/queue#background-work).
+The foreground answer is never delayed.
 
 The reviewer continues the finished turn from the same transcript prefix, but
 runs under a private detached session identity. This keeps the foreground session

--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./codex-app-server.test-fixtures.js";
 import type { JsonValue } from "./protocol.js";
 import type { CodexAppServerClientFactory } from "./shared-client.js";
+import { createClientHarness } from "./test-support.js";
 
 function codexModel(model = "gpt-5.4", id = model) {
   return {
@@ -203,6 +204,62 @@ function createClientFactory(
 }
 
 describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
+  it.each(["thread/start", "turn/start"] as const)(
+    "rejects expired authority before the physical %s write after setup",
+    async (blockedMethod) => {
+      let current = true;
+      const expired = new Error("completion owner expired during setup");
+      const harness = createClientHarness({
+        onWrite: (line, send) => {
+          const request = JSON.parse(line) as { id: number; method: string };
+          const results: Record<string, unknown> = {
+            "model/list": { data: [codexModel()], nextCursor: null },
+            "config/read": { config: {}, layers: [] },
+            "configRequirements/read": { requirements: null },
+            "thread/start": threadStartResult("gpt-5.4"),
+            "mcpServerStatus/list": { data: [], nextCursor: null },
+            "turn/start": completedTurnResult(),
+          };
+          if (request.method === "mcpServerStatus/list" && blockedMethod === "turn/start") {
+            current = false;
+          }
+          send({ id: request.id, result: results[request.method] });
+        },
+      });
+      const releaseFence = vi.fn();
+      harness.client.setThreadSessionRequestGuard(async () => {
+        if (blockedMethod === "thread/start") {
+          current = false;
+        }
+        return releaseFence;
+      });
+      try {
+        await expect(
+          runBoundedCodexAppServerTurn({
+            model: { mode: "required", id: "gpt-5.4" },
+            timeoutMs: 5_000,
+            assertCurrent: () => {
+              if (!current) {
+                throw expired;
+              }
+            },
+            options: { clientFactory: async () => harness.client },
+            taskLabel: "isolated completion",
+            developerInstructions: "Answer only.",
+            input: [{ type: "text", text: "Name this conversation.", text_elements: [] }],
+            requiredModalities: ["text"],
+            isolation: "configured-transport",
+            requireNoExternalCapabilities: true,
+          }),
+        ).rejects.toBe(expired);
+        expect(harness.writes.map((line) => JSON.parse(line).method)).not.toContain(blockedMethod);
+        expect(releaseFence).toHaveBeenCalledOnce();
+      } finally {
+        harness.client.close();
+      }
+    },
+  );
+
   it("returns an explicit unsupported decline for interactive MCP input", async () => {
     const fake = createClientFactory({ completeTurn: false });
     const run = runBoundedCodexAppServerTurn({

--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -107,6 +107,7 @@ type CodexBoundedTurnParams = {
   authRequirement?: CodexAppServerAuthRequirement;
   timeoutMs: number;
   signal?: AbortSignal;
+  assertCurrent?: () => void;
   agentDir?: string;
   authProfileStore?: AuthProfileStore;
   options: CodexBoundedTurnOptions;
@@ -187,12 +188,14 @@ async function runBoundedCodexAppServerTurnInWorkspace(
         agentDir,
         config: params.config,
         timeoutMs,
+        assertCurrent: params.assertCurrent,
         ...(params.signal ? { abandonSignal: params.signal } : {}),
       })
     : await import("./shared-client.js").then(({ createIsolatedCodexAppServerClient }) =>
         createIsolatedCodexAppServerClient({
           startOptions,
           timeoutMs,
+          assertCurrent: params.assertCurrent,
           ...authSelection,
           authRequirement: params.authRequirement,
           agentDir,
@@ -235,6 +238,11 @@ async function runBoundedCodexAppServerTurnInWorkspace(
   timeout.unref?.();
 
   let retrySelection = false;
+  const requestOptions = {
+    timeoutMs,
+    signal: abortController.signal,
+    assertCurrent: params.assertCurrent,
+  };
   try {
     const modelSelection = await resolveCodexBoundedTurnModel({
       client,
@@ -242,6 +250,7 @@ async function runBoundedCodexAppServerTurnInWorkspace(
       requiredModalities: params.requiredModalities,
       timeoutMs,
       signal: abortController.signal,
+      assertCurrent: params.assertCurrent,
     });
     const inheritedMcpServerNames = params.requireNoExternalCapabilities
       ? await readCodexInheritedMcpServerNames(client, workspace.cwd, abortController.signal)
@@ -275,7 +284,7 @@ async function runBoundedCodexAppServerTurnInWorkspace(
           experimentalRawEvents: true,
           ephemeral: true,
         } satisfies CodexThreadStartParams,
-        { timeoutMs, signal: abortController.signal },
+        requestOptions,
       ),
     );
     activeThreadId = thread.thread.id;
@@ -296,7 +305,7 @@ async function runBoundedCodexAppServerTurnInWorkspace(
       await client.request(
         "thread/inject_items",
         { threadId: thread.thread.id, items: params.historyItems },
-        { timeoutMs, signal: abortController.signal },
+        requestOptions,
       );
     }
     const collector = createCodexBoundedTurnCollector(
@@ -320,7 +329,7 @@ async function runBoundedCodexAppServerTurnInWorkspace(
             approvalPolicy: "on-request",
             effort: "low",
           } satisfies CodexTurnStartParams,
-          { timeoutMs, signal: abortController.signal },
+          requestOptions,
         ),
       );
       activeTurnId = turn.turn.id;
@@ -471,11 +480,16 @@ async function resolveCodexBoundedTurnModel(params: {
   requiredModalities: string[];
   timeoutMs: number;
   signal: AbortSignal;
+  assertCurrent?: () => void;
 }): Promise<{ catalogId: string; runtimeModelId: string }> {
   const result = await params.client.request<unknown>(
     "model/list",
     { limit: null, cursor: null, includeHidden: params.selection.mode === "required" },
-    { timeoutMs: Math.min(params.timeoutMs, 5_000), signal: params.signal },
+    {
+      timeoutMs: Math.min(params.timeoutMs, 5_000),
+      signal: params.signal,
+      assertCurrent: params.assertCurrent,
+    },
   );
   const listed = readModelListResult(result).models;
   if (params.selection.mode === "live-default") {

--- a/extensions/codex/src/app-server/isolated-completion.test.ts
+++ b/extensions/codex/src/app-server/isolated-completion.test.ts
@@ -87,6 +87,7 @@ describe("runCodexIsolatedCompletion", () => {
 
   it("uses native authorization on a ring-zero configured-transport turn", async () => {
     const params = createParams();
+    params.assertCurrent = vi.fn();
 
     await expect(runCodexIsolatedCompletion(params, {})).resolves.toEqual({
       assistant: expect.objectContaining({
@@ -118,6 +119,7 @@ describe("runCodexIsolatedCompletion", () => {
         authRequirement: "subscription",
         isolation: "configured-transport",
         requireNoExternalCapabilities: true,
+        assertCurrent: params.assertCurrent,
         developerInstructions: "Name the conversation.",
         input: [{ type: "text", text: "Help me plan a garden.", text_elements: [] }],
       }),

--- a/extensions/codex/src/app-server/isolated-completion.ts
+++ b/extensions/codex/src/app-server/isolated-completion.ts
@@ -47,6 +47,7 @@ export async function runCodexIsolatedCompletion(
     authRequirement,
     timeoutMs: params.timeoutMs,
     signal: params.abortSignal,
+    assertCurrent: params.assertCurrent,
     agentDir: params.agentDir,
     authProfileStore: authorization.authProfileStore,
     options,

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -318,6 +318,8 @@ export type CodexAppServerClientOptions = {
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
   onStartedClient?: (client: CodexAppServerClient) => void;
   abandonSignal?: AbortSignal;
+  /** Caller authority for startup of an isolated, caller-owned client. */
+  assertCurrent?: () => void;
 };
 
 /** Factory used by attempt startup and side turns to acquire a leased client. */
@@ -928,6 +930,7 @@ function createSharedCodexAppServerClientStartup(params: {
 export async function createIsolatedCodexAppServerClient(
   options?: CodexAppServerClientOptions,
 ): Promise<CodexAppServerClient> {
+  options?.assertCurrent?.();
   if (options?.abandonSignal?.aborted) {
     throw new CodexAppServerStartupError("aborted", "codex app-server initialize aborted");
   }
@@ -968,6 +971,7 @@ export async function createIsolatedCodexAppServerClient(
     config: options?.config,
     timeoutMs: resolveRemainingAcquireTimeout(timeoutMs, acquireStartedAt),
     abandonSignal: options?.abandonSignal,
+    assertCurrent: options?.assertCurrent,
     onStartedClient: (client) => {
       trackIsolatedCodexAppServerClient(client);
       options?.onStartedClient?.(client);
@@ -1002,6 +1006,7 @@ async function startInitializedCodexAppServerClient(params: {
   abandonSignal?: AbortSignal;
   onStartedClient?: (client: CodexAppServerClient) => void;
   onInitializedClient?: () => void;
+  assertCurrent?: () => void;
 }): Promise<CodexAppServerClient> {
   const acquireStartedAt = Date.now();
   const timeoutMs = params.timeoutMs ?? 0;
@@ -1017,6 +1022,7 @@ async function startInitializedCodexAppServerClient(params: {
           )
         : undefined);
     const assertDesktopGenerationCurrent = () => {
+      params.assertCurrent?.();
       if (params.abandonSignal?.aborted) {
         throw new CodexAppServerStartupError("aborted", "codex app-server initialize aborted");
       }

--- a/extensions/copilot/harness.test.ts
+++ b/extensions/copilot/harness.test.ts
@@ -720,6 +720,49 @@ describe("createCopilotAgentHarness", () => {
     expect(session.disconnect).toHaveBeenCalledOnce();
   });
 
+  it.each(["client acquisition", "session creation"] as const)(
+    "rejects expired completion authority after %s without sending the prompt",
+    async (checkpoint) => {
+      let current = true;
+      const expired = new Error("completion owner expired during setup");
+      const session = {
+        abort: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        sendAndWait: vi.fn(),
+      };
+      const createSession = vi.fn(async () => {
+        current = false;
+        return session;
+      });
+      const client = createMockCopilotClient({ createSession });
+      const handle = { client, key: TEST_POOL_KEY };
+      const pool = makePoolMock();
+      pool.acquire.mockImplementation(async () => {
+        if (checkpoint === "client acquisition") {
+          current = false;
+        }
+        return handle;
+      });
+      const harness = createCopilotAgentHarness({ pool });
+
+      await expect(
+        harness.runIsolatedCompletionV2?.({
+          ...ISOLATED_COMPLETION_PARAMS,
+          assertCurrent: () => {
+            if (!current) {
+              throw expired;
+            }
+          },
+        }),
+      ).rejects.toBe(expired);
+      await flushAsyncWork();
+      expect(session.sendAndWait).not.toHaveBeenCalled();
+      expect(createSession).toHaveBeenCalledTimes(checkpoint === "session creation" ? 1 : 0);
+      expect(session.disconnect).toHaveBeenCalledTimes(checkpoint === "session creation" ? 1 : 0);
+      expect(pool.release).toHaveBeenCalledExactlyOnceWith(handle);
+    },
+  );
+
   it("does not start a request when cancellation wins the send boundary", async () => {
     const controller = new AbortController();
     let boundaryRegistrations = 0;

--- a/extensions/copilot/src/isolated-completion.ts
+++ b/extensions/copilot/src/isolated-completion.ts
@@ -24,6 +24,7 @@ type IsolatedSession = {
 
 type CompletionBoundary = {
   abortSignal?: AbortSignal;
+  assertCurrent?: () => void;
   deadlineMs: number;
   timeoutMs: number;
 };
@@ -110,6 +111,7 @@ async function awaitWithinCompletionBoundary<T>(params: {
       if (boundaryWon) {
         throw boundaryError ?? createTimeoutError(params.boundary.timeoutMs);
       }
+      params.boundary.assertCurrent?.();
       return params.start(remainingMs);
     })
     .then(async (value) => {
@@ -164,6 +166,7 @@ export async function runCopilotIsolatedCompletion(
   }
   const boundary: CompletionBoundary = {
     abortSignal: params.abortSignal,
+    assertCurrent: params.assertCurrent,
     deadlineMs: Date.now() + params.timeoutMs,
     timeoutMs: params.timeoutMs,
   };

--- a/extensions/memory-core/api.ts
+++ b/extensions/memory-core/api.ts
@@ -9,7 +9,7 @@ export {
   dedupeDreamDiaryEntries,
   removeBackfillDiaryEntries,
   writeBackfillDiaryEntries,
-} from "./src/dreaming-narrative.js";
+} from "./src/dreaming-dreams-file.js";
 export { previewGroundedRemMarkdown } from "./src/rem-evidence.js";
 export { filterRecallEntriesWithinLookback } from "./src/dreaming-phases.js";
 export { previewRemHarness } from "./src/rem-harness.js";

--- a/extensions/memory-core/src/cli-rem.runtime.ts
+++ b/extensions/memory-core/src/cli-rem.runtime.ts
@@ -5,7 +5,7 @@ import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { resolveMemoryPluginConfig, withMemoryCommand } from "./cli-runtime-common.js";
 import { defaultRuntime, shortenHomePath, theme } from "./cli.host.runtime.js";
 import type { MemoryRemBackfillOptions, MemoryRemHarnessOptions } from "./cli.types.js";
-import { removeBackfillDiaryEntries, writeBackfillDiaryEntries } from "./dreaming-narrative.js";
+import { removeBackfillDiaryEntries, writeBackfillDiaryEntries } from "./dreaming-dreams-file.js";
 import { seedHistoricalDailyMemorySignals } from "./dreaming-phases.js";
 import type { MemoryCoreRuntimeHost } from "./memory/runtime-host.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";

--- a/extensions/memory-core/src/dreaming-consolidation-projects.test.ts
+++ b/extensions/memory-core/src/dreaming-consolidation-projects.test.ts
@@ -2,12 +2,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { applyMemoryConsolidationPlan } from "./dreaming-consolidation.js";
 import type { PromotionCandidate } from "./short-term-promotion.js";
-import {
-  consolidateMemoryForTests as consolidateMemory,
-  createMemoryCoreTestHarness,
-} from "./test-helpers.js";
+import { consolidateMemoryForTests as consolidateMemory } from "./test-helpers.js";
 
-const { createTempWorkspace } = createMemoryCoreTestHarness();
 const logger = { info: vi.fn(), warn: vi.fn() };
 
 type ConsolidationPrompt = {
@@ -62,28 +58,15 @@ function createPromptResponder(
     }>;
   },
 ) {
-  const responses = new Map<string, string>();
   return {
-    run: vi.fn(async (options: unknown) => {
-      const { message, sessionKey } = options as { message: string; sessionKey: string };
-      responses.set(
-        sessionKey,
-        JSON.stringify(respond(JSON.parse(message) as ConsolidationPrompt)),
-      );
-      return { runId: sessionKey };
-    }),
-    waitForRun: vi.fn(async () => ({ status: "ok" })),
-    getSessionMessages: vi.fn(async (options: unknown) => {
-      const { sessionKey } = options as { sessionKey: string };
-      return { messages: [{ role: "assistant", content: responses.get(sessionKey) ?? "" }] };
-    }),
-    deleteSession: vi.fn(async (_options: unknown) => undefined),
+    complete: vi.fn(async (options: { message: string }) => ({
+      text: JSON.stringify(respond(JSON.parse(options.message) as ConsolidationPrompt)),
+    })),
   };
 }
 
 describe("memory consolidation project groups", () => {
   it("consolidates global and project candidates in deterministic isolated passes", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-project-groups-");
     const existingMemory = "# Memory\n\n- Existing global fact.\n";
     const candidates = [
       projectCandidate("beta", "Beta deployment uses blue.", "github.com/acme/beta"),
@@ -102,7 +85,6 @@ describe("memory consolidation project groups", () => {
 
     const plan = await consolidateMemory({
       subagent,
-      workspaceDir,
       existingMemory,
       candidates,
       maxPriorEntryLossFraction: 0.25,
@@ -114,18 +96,11 @@ describe("memory consolidation project groups", () => {
       return;
     }
 
-    const promptedGroups = subagent.run.mock.calls.map(([options]) => {
+    const promptedGroups = subagent.complete.mock.calls.map(([options]) => {
       const prompt = JSON.parse((options as { message: string }).message) as ConsolidationPrompt;
       return prompt.candidates.map((item) => item.projectKey);
     });
     expect(promptedGroups).toEqual([[null], ["github.com/acme/alpha"], ["github.com/acme/beta"]]);
-    expect(
-      subagent.run.mock.calls.every(
-        ([options]) =>
-          (options as { disableTools?: boolean; promptMode?: string }).disableTools === true &&
-          (options as { promptMode?: string }).promptMode === "minimal",
-      ),
-    ).toBe(true);
 
     const result = applyMemoryConsolidationPlan({
       existingMemory,
@@ -147,7 +122,6 @@ describe("memory consolidation project groups", () => {
   });
 
   it("rejects a cross-project merge after completing the isolated group passes", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-project-reject-");
     const betaPrior = "- Shared deployment uses blue. <!-- project: github.com/acme/beta -->";
     const existingMemory = `# Memory\n\n${betaPrior}\n- Two.\n- Three.\n- Four.\n`;
     const candidates = [
@@ -176,7 +150,6 @@ describe("memory consolidation project groups", () => {
     await expect(
       consolidateMemory({
         subagent,
-        workspaceDir,
         existingMemory,
         candidates,
         maxPriorEntryLossFraction: 0.25,
@@ -184,14 +157,13 @@ describe("memory consolidation project groups", () => {
         logger,
       }),
     ).resolves.toBeNull();
-    expect(subagent.run).toHaveBeenCalledTimes(3);
+    expect(subagent.complete).toHaveBeenCalledTimes(3);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("output crosses project groups for candidate alpha"),
     );
   });
 
   it("rejects groups whose code-applied aggregate exceeds the memory budget", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-project-budget-");
     const existingMemory = "# Memory\n";
     const candidates = [
       projectCandidate("global", "Use metric units globally."),
@@ -215,7 +187,6 @@ describe("memory consolidation project groups", () => {
 
     const fullPlan = await consolidateMemory({
       subagent: createBudgetSubagent(),
-      workspaceDir,
       existingMemory,
       candidates,
       maxPriorEntryLossFraction: 0.25,
@@ -233,7 +204,6 @@ describe("memory consolidation project groups", () => {
     await expect(
       consolidateMemory({
         subagent: createBudgetSubagent(),
-        workspaceDir,
         existingMemory,
         candidates,
         maxPriorEntryLossFraction: 0.25,

--- a/extensions/memory-core/src/dreaming-consolidation.test.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.test.ts
@@ -68,15 +68,13 @@ function resultEntryFor(promoted: PromotionCandidate, text = promoted.snippet): 
 
 function createSubagent(output: string, status = "ok", onWait?: () => Promise<void>) {
   return {
-    run: vi.fn(async (_options: unknown) => ({ runId: "run-1" })),
-    waitForRun: vi.fn(async () => {
+    complete: vi.fn(async (_options: unknown) => {
       await onWait?.();
-      return { status };
+      if (status !== "ok") {
+        throw new Error(`completion ${status}`);
+      }
+      return { text: output };
     }),
-    getSessionMessages: vi.fn(async () => ({
-      messages: [{ role: "assistant", content: output }],
-    })),
-    deleteSession: vi.fn(async (_options: unknown) => undefined),
   };
 }
 
@@ -144,7 +142,6 @@ describe("memory consolidation", () => {
     await expect(
       consolidateMemory({
         subagent,
-        workspaceDir: await createTempWorkspace("memory-consolidation-taint-"),
         existingMemory: "# Memory\n",
         candidates: [candidate("untrusted"), candidate("system")],
         maxPriorEntryLossFraction: 0.25,
@@ -152,11 +149,10 @@ describe("memory consolidation", () => {
         logger,
       }),
     ).resolves.toBeNull();
-    expect(subagent.run).not.toHaveBeenCalled();
+    expect(subagent.complete).not.toHaveBeenCalled();
   });
 
-  it("accepts a bounded rewrite and stores its preimage in SQLite plugin state", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-accept-");
+  it("accepts a bounded rewrite using the owning agent", async () => {
     const promoted = candidate("owner");
     const sourceRef = "memory/2026-07-01.md#L1-L1";
     const resultEntry = resultEntryFor(promoted);
@@ -167,28 +163,23 @@ describe("memory consolidation", () => {
       operations: [{ candidateKey: promoted.key, action: "added", resultEntry, priorEntries: [] }],
     });
     const subagent = createSubagent(output);
-    const [result] = await Promise.all(
-      [0, 1].map(() =>
-        consolidateMemory({
-          subagent,
-          workspaceDir,
-          existingMemory: `# Memory\n\n${annotatedPrior}\n`,
-          candidates: [promoted],
-          maxPriorEntryLossFraction: 0.25,
-          nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
-          logger,
-        }),
-      ),
-    );
+    const result = await consolidateMemory({
+      subagent,
+      existingMemory: `# Memory\n\n${annotatedPrior}\n`,
+      candidates: [promoted],
+      maxPriorEntryLossFraction: 0.25,
+      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
+      logger,
+    });
 
     expect(result?.memory).toContain(`Source: ${sourceRef}`);
     expect(result?.memory).toContain(annotatedPrior);
-    const sessionKeys = subagent.run.mock.calls.map(
-      ([options]) => (options as { sessionKey: string }).sessionKey,
+    expect(subagent.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "memory-core-test",
+        timeoutMs: 60_000,
+      }),
     );
-    expect(new Set(sessionKeys).size).toBe(2);
-    expect(sessionKeys.every((key) => key.startsWith("agent:memory-core-test:"))).toBe(true);
-    expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
   });
 
   it("keeps consolidation history bounded and attached to each operation's lineage", () => {
@@ -216,7 +207,6 @@ describe("memory consolidation", () => {
   });
 
   it("rejects a rewrite that loses too many prior entries", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-reject-");
     const promoted = candidate("owner");
     const resultEntry = resultEntryFor(promoted);
     const output = JSON.stringify({
@@ -226,7 +216,6 @@ describe("memory consolidation", () => {
     await expect(
       consolidateMemory({
         subagent: createSubagent(output),
-        workspaceDir,
         existingMemory: "# Memory\n\n- One.\n- Two.\n- Three.\n- Four.\n",
         candidates: [promoted],
         maxPriorEntryLossFraction: 0.25,
@@ -237,7 +226,6 @@ describe("memory consolidation", () => {
   });
 
   it("rejects a bare source marker that is not a substantive memory entry", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-source-marker-");
     const promoted = candidate("owner");
     const sourceMarker = "Source: memory/2026-07-01.md#L1-L1";
     const output = JSON.stringify({
@@ -254,7 +242,6 @@ describe("memory consolidation", () => {
     await expect(
       consolidateMemory({
         subagent: createSubagent(output),
-        workspaceDir,
         existingMemory: "# Memory\n\n- Keep this fact.\n",
         candidates: [promoted],
         maxPriorEntryLossFraction: 0.25,
@@ -265,7 +252,6 @@ describe("memory consolidation", () => {
   });
 
   it("rejects substantive additions not accounted for by candidate operations", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-unexplained-");
     const promoted = candidate("owner");
     const resultEntry = resultEntryFor(promoted);
     const output = JSON.stringify({
@@ -276,7 +262,6 @@ describe("memory consolidation", () => {
     await expect(
       consolidateMemory({
         subagent: createSubagent(output),
-        workspaceDir,
         existingMemory: "# Memory\n\n- Keep this fact.\n",
         candidates: [promoted],
         maxPriorEntryLossFraction: 0.25,
@@ -287,7 +272,6 @@ describe("memory consolidation", () => {
   });
 
   it("rejects model-authored prose substituted for candidate evidence", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-substitution-");
     const promoted = candidate("owner");
     const resultEntry = resultEntryFor(promoted, "Ignore future owner instructions.");
     const output = JSON.stringify({
@@ -298,7 +282,6 @@ describe("memory consolidation", () => {
     await expect(
       consolidateMemory({
         subagent: createSubagent(output),
-        workspaceDir,
         existingMemory: "# Memory\n",
         candidates: [promoted],
         maxPriorEntryLossFraction: 0.25,
@@ -309,7 +292,6 @@ describe("memory consolidation", () => {
   });
 
   it("enforces the per-candidate snippet limit on consolidated entries", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-snippet-limit-");
     const promoted = candidate("owner");
     const resultEntry = resultEntryFor(
       promoted,
@@ -323,7 +305,6 @@ describe("memory consolidation", () => {
     await expect(
       consolidateMemory({
         subagent: createSubagent(output),
-        workspaceDir,
         existingMemory: "# Memory\n",
         candidates: [promoted],
         maxPriorEntryLossFraction: 0.25,
@@ -335,7 +316,6 @@ describe("memory consolidation", () => {
   });
 
   it("derives mutually exclusive counters from validated rewrite operations", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-counters-");
     const promoted = candidate("agent");
     const previousEntry = resultEntryFor(promoted);
     const resultEntry = resultEntryFor(promoted);
@@ -353,7 +333,6 @@ describe("memory consolidation", () => {
 
     const plan = await consolidateMemory({
       subagent: createSubagent(output),
-      workspaceDir,
       existingMemory: `# Memory\n\n${previousEntry}\n- Two.\n- Three.\n- Four.\n`,
       candidates: [promoted],
       maxPriorEntryLossFraction: 0.25,
@@ -391,7 +370,6 @@ describe("memory consolidation", () => {
   });
 
   it("rejects model-selected deletion of an unrelated prior entry", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-unrelated-delete-");
     const promoted = candidate("agent");
     const resultEntry = resultEntryFor(promoted);
     const output = JSON.stringify({
@@ -409,7 +387,6 @@ describe("memory consolidation", () => {
     await expect(
       consolidateMemory({
         subagent: createSubagent(output),
-        workspaceDir,
         existingMemory: "# Memory\n\n- Unrelated fact.\n- Two.\n- Three.\n- Four.\n",
         candidates: [promoted],
         maxPriorEntryLossFraction: 0.25,
@@ -420,7 +397,6 @@ describe("memory consolidation", () => {
   });
 
   it("does not merge facts that differ in bracketed values", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-bracket-value-");
     const promoted = {
       ...candidate("agent"),
       snippet: "Take medicine [10mg]",
@@ -441,7 +417,6 @@ describe("memory consolidation", () => {
     await expect(
       consolidateMemory({
         subagent: createSubagent(output),
-        workspaceDir,
         existingMemory: "# Memory\n\n- Take medicine [100mg]\n- Two.\n- Three.\n- Four.\n",
         candidates: [promoted],
         maxPriorEntryLossFraction: 0.25,
@@ -452,7 +427,6 @@ describe("memory consolidation", () => {
   });
 
   it("preserves duplicate prior-entry multiplicity", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-duplicates-");
     const promoted = candidate("agent");
     const resultEntry = resultEntryFor(promoted);
     const output = JSON.stringify({
@@ -470,7 +444,6 @@ describe("memory consolidation", () => {
     await expect(
       consolidateMemory({
         subagent: createSubagent(output),
-        workspaceDir,
         existingMemory:
           "# Memory\n\n- User prefers green tea.\n- User prefers green tea.\n- Two.\n- Three.\n- Four.\n",
         candidates: [promoted],
@@ -482,7 +455,6 @@ describe("memory consolidation", () => {
   });
 
   it("requires a supersession marker to belong to the exact removed entry", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-lineage-");
     const base = candidate("agent");
     const promoted = {
       ...base,
@@ -525,7 +497,6 @@ describe("memory consolidation", () => {
     await expect(
       consolidateMemory({
         subagent: createSubagent(output),
-        workspaceDir,
         existingMemory: previous,
         candidates: [promoted],
         maxPriorEntryLossFraction: 0.25,
@@ -536,7 +507,6 @@ describe("memory consolidation", () => {
   });
 
   it("removes attached metadata with an exactly matched superseded entry", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-lineage-apply-");
     const base = candidate("agent");
     const promoted = {
       ...base,
@@ -567,7 +537,6 @@ describe("memory consolidation", () => {
     });
     const plan = await consolidateMemory({
       subagent: createSubagent(output),
-      workspaceDir,
       existingMemory: previous,
       candidates: [promoted],
       maxPriorEntryLossFraction: 0.25,
@@ -592,7 +561,6 @@ describe("memory consolidation", () => {
   });
 
   it("rejects adding beside an existing matching lineage", async () => {
-    const workspaceDir = await createTempWorkspace("memory-consolidation-lineage-duplicate-");
     const base = candidate("agent");
     const promoted = {
       ...base,
@@ -618,7 +586,6 @@ describe("memory consolidation", () => {
     await expect(
       consolidateMemory({
         subagent: createSubagent(output),
-        workspaceDir,
         existingMemory: previous,
         candidates: [promoted],
         maxPriorEntryLossFraction: 0.25,
@@ -840,7 +807,7 @@ describe("memory consolidation", () => {
     });
 
     expect(applied).toMatchObject({ applied: 1, appended: 0, reconciledExisting: 1 });
-    expect(subagent.run).not.toHaveBeenCalled();
+    expect(subagent.complete).not.toHaveBeenCalled();
   });
 
   it("rejects a candidate downgraded in the recall store during consolidation", async () => {

--- a/extensions/memory-core/src/dreaming-consolidation.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.ts
@@ -1,5 +1,4 @@
 // Memory Core plugin module owns bounded deep-phase MEMORY.md consolidation.
-import { createHash, randomUUID } from "node:crypto";
 import {
   DEFAULT_MEMORY_DEEP_DREAMING_MAX_PROMOTED_SNIPPET_TOKENS,
   formatMemoryDreamingDay,
@@ -8,20 +7,17 @@ import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MemoryConsolidationResult } from "./dreaming-consolidation-artifacts.js";
 import { filterConsolidationCandidates } from "./dreaming-consolidation-candidates.js";
-import type { SubagentSurface } from "./dreaming-narrative.js";
-import { extractAssistantText } from "./dreaming-shared.js";
+import type { DreamingCompletion } from "./dreaming-narrative.js";
 import { DEFAULT_MEMORY_FILE_MAX_CHARS } from "./memory-budget.js";
 import { buildPromotionMarker } from "./short-term-promotion-memory-write.js";
 import {
   buildPromotionRecallAnnotations,
   groupPromotionCandidatesByProjectKey,
   memoryEntryMatchesPromotionProjectGroup,
-  type PromotionProjectGroup,
 } from "./short-term-promotion-metadata.js";
 import type { PromotionCandidate } from "./short-term-promotion-types.js";
 
 const CONSOLIDATION_TIMEOUT_MS = 60_000;
-const CONSOLIDATION_MESSAGE_LIMIT = 5;
 const PROMOTED_SNIPPET_CHARS_PER_TOKEN_ESTIMATE = 4;
 const CONSOLIDATION_SYSTEM_PROMPT = [
   "Revise the supplied MEMORY.md using only the supplied candidates as new evidence.",
@@ -482,8 +478,7 @@ export function applyMemoryConsolidationPlan(params: {
 
 export async function consolidateMemory(params: {
   agentId: string;
-  subagent: SubagentSurface;
-  workspaceDir: string;
+  subagent: DreamingCompletion;
   existingMemory: string;
   candidates: PromotionCandidate[];
   model?: string;
@@ -497,12 +492,6 @@ export async function consolidateMemory(params: {
   if (candidates.length === 0) {
     return null;
   }
-  const sessionPrefix = `agent:${params.agentId}:dreaming-narrative-consolidation-${createHash(
-    "sha1",
-  )
-    .update(params.workspaceDir)
-    .digest("hex")
-    .slice(0, 12)}-${randomUUID()}`;
   const maxPromotedSnippetTokens = Math.max(
     1,
     Math.floor(
@@ -517,16 +506,24 @@ export async function consolidateMemory(params: {
   const outputs: ConsolidationOutput[] = [];
   let rejected = false;
 
-  for (const [groupIndex, group] of groups.entries()) {
-    const sessionKey = `${sessionPrefix}-${groupIndex}`;
+  for (const group of groups) {
     try {
-      const output = await runConsolidationGroup({
-        ...params,
-        group,
-        sessionKey,
-        maxPromotedSnippetTokens,
+      const result = await params.subagent.complete({
+        agentId: params.agentId,
+        message: buildConsolidationPrompt(
+          params.existingMemory,
+          group.candidates,
+          maxPromotedSnippetTokens,
+        ),
+        extraSystemPrompt: CONSOLIDATION_SYSTEM_PROMPT,
+        ...(params.model ? { model: params.model } : {}),
+        timeoutMs: CONSOLIDATION_TIMEOUT_MS,
       });
+      const output = parseConsolidatedMemory(result.text);
       if (!output) {
+        params.logger.warn(
+          "memory-core: consolidation produced no structured output; using append-only fallback.",
+        );
         rejected = true;
         continue;
       }
@@ -552,8 +549,6 @@ export async function consolidateMemory(params: {
         `memory-core: consolidation failed (${error instanceof Error ? error.message : String(error)}); using append-only fallback.`,
       );
       rejected = true;
-    } finally {
-      await params.subagent.deleteSession({ sessionKey }).catch(() => undefined);
     }
   }
 
@@ -587,62 +582,4 @@ export async function consolidateMemory(params: {
   }
   plan.memory = aggregate.content;
   return plan;
-}
-
-async function runConsolidationGroup(params: {
-  subagent: SubagentSurface;
-  existingMemory: string;
-  group: PromotionProjectGroup;
-  model?: string;
-  nowMs: number;
-  sessionKey: string;
-  maxPromotedSnippetTokens: number;
-  logger: Logger;
-}): Promise<ConsolidationOutput | null> {
-  try {
-    const run = await params.subagent.run({
-      idempotencyKey: `${params.sessionKey}-${params.nowMs}`,
-      sessionKey: params.sessionKey,
-      message: buildConsolidationPrompt(
-        params.existingMemory,
-        params.group.candidates,
-        params.maxPromotedSnippetTokens,
-      ),
-      disableTools: true,
-      ...(params.model ? { model: params.model } : {}),
-      extraSystemPrompt: CONSOLIDATION_SYSTEM_PROMPT,
-      promptMode: "minimal",
-      lane: `dreaming-consolidation:${params.sessionKey}`,
-      lightContext: true,
-      deliver: false,
-    });
-    const terminal = await params.subagent.waitForRun({
-      runId: run.runId,
-      timeoutMs: CONSOLIDATION_TIMEOUT_MS,
-    });
-    if (terminal.status !== "ok") {
-      params.logger.warn(
-        `memory-core: consolidation ended with status=${terminal.status}; using append-only fallback.`,
-      );
-      return null;
-    }
-    const { messages } = await params.subagent.getSessionMessages({
-      sessionKey: params.sessionKey,
-      limit: CONSOLIDATION_MESSAGE_LIMIT,
-    });
-    const assistantText = extractAssistantText(messages);
-    const output = assistantText ? parseConsolidatedMemory(assistantText) : null;
-    if (!output) {
-      params.logger.warn(
-        "memory-core: consolidation produced no structured output; using append-only fallback.",
-      );
-      return null;
-    }
-    return output;
-  } catch (error) {
-    params.logger.warn(
-      `memory-core: consolidation failed (${error instanceof Error ? error.message : String(error)}); using append-only fallback.`,
-    );
-    return null;
-  }
 }

--- a/extensions/memory-core/src/dreaming-dreams-file.test.ts
+++ b/extensions/memory-core/src/dreaming-dreams-file.test.ts
@@ -1,0 +1,317 @@
+// Memory Core tests cover managed Dream Diary artifacts.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  dedupeDreamDiaryEntries,
+  readRecentDreamDiaryEntries,
+  removeBackfillDiaryEntries,
+  updateDreamsFile,
+  writeBackfillDiaryEntries,
+} from "./dreaming-dreams-file.js";
+import {
+  SHORT_TERM_LOCK_MAX_ENTRIES,
+  SHORT_TERM_LOCK_NAMESPACE,
+  memoryCoreWorkspaceStateKey,
+  openMemoryCoreStateStore,
+} from "./dreaming-state.js";
+import { forgetMemoryEntries } from "./memory-forget.js";
+import { createMemoryCoreTestHarness } from "./test-helpers.js";
+
+const { createTempWorkspace } = createMemoryCoreTestHarness();
+const EXPECTS_POSIX_PRIVATE_FILE_MODE = process.platform !== "win32";
+
+function setNarrativeTestEnv(stateDir: string): void {
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("dream diary file behavior", () => {
+  it("does not restore deleted diary content from an update already in progress", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-forget-update-");
+    setNarrativeTestEnv(path.join(workspaceDir, ".state"));
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+    const claim = "A private cobalt archive phrase.";
+    await fs.writeFile(dreamsPath, `# Diary\n\n## Session ID: forgotten\n${claim}\n`);
+    const prepared = createDeferred<void>();
+    const publish = createDeferred<void>();
+    const update = updateDreamsFile({
+      workspaceDir,
+      updater: async (existing) => {
+        expect(existing).toContain(claim);
+        prepared.resolve();
+        await publish.promise;
+        return { content: `${existing}\n## Other\nA new unrelated entry.\n`, result: undefined };
+      },
+    });
+    let forgotten: ReturnType<typeof forgetMemoryEntries> | undefined;
+    try {
+      await prepared.promise;
+      const writerOwnsLock = await openMemoryCoreStateStore({
+        namespace: SHORT_TERM_LOCK_NAMESPACE,
+        maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
+      }).lookup(memoryCoreWorkspaceStateKey(workspaceDir));
+      forgotten = forgetMemoryEntries({
+        cfg: { agents: { entries: { main: { workspace: workspaceDir } } } },
+        agentId: "main",
+        sessionIds: ["forgotten"],
+      });
+      if (!writerOwnsLock) {
+        await forgotten;
+      }
+      publish.resolve();
+      await Promise.all([update, forgotten]);
+      const content = await fs.readFile(dreamsPath, "utf8");
+      expect(content).not.toContain(claim);
+      expect(content).toContain("A new unrelated entry.");
+    } finally {
+      publish.resolve();
+      await Promise.allSettled([update, ...(forgotten ? [forgotten] : [])]);
+    }
+  });
+
+  it("writes, reads, deduplicates, and removes backfill entries", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-narrative-backfill-");
+    const written = await writeBackfillDiaryEntries({
+      workspaceDir,
+      entries: [
+        {
+          isoDay: "2026-04-05",
+          bodyLines: ["The archive remembered a durable fact."],
+          sourcePath: "memory/2026-04-05.md",
+        },
+      ],
+      timezone: "UTC",
+    });
+    expect(written.written).toBe(1);
+
+    const existing = await fs.readFile(written.dreamsPath, "utf8");
+    const startMarker = "<!-- openclaw:dreaming:diary:start -->";
+    const endMarker = "<!-- openclaw:dreaming:diary:end -->";
+    const block = existing.slice(
+      existing.indexOf(startMarker) + startMarker.length,
+      existing.indexOf(endMarker),
+    );
+    await fs.writeFile(written.dreamsPath, existing.replace(endMarker, `${block}\n${endMarker}`));
+
+    await expect(dedupeDreamDiaryEntries({ workspaceDir })).resolves.toMatchObject({ removed: 1 });
+    await expect(readRecentDreamDiaryEntries({ workspaceDir })).resolves.toHaveLength(1);
+    await expect(removeBackfillDiaryEntries({ workspaceDir })).resolves.toMatchObject({
+      removed: 1,
+    });
+  });
+
+  it("refuses to overwrite a symlinked DREAMS.md", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-narrative-symlink-");
+    const targetPath = path.join(workspaceDir, "outside.txt");
+    await fs.writeFile(targetPath, "outside\n", "utf8");
+    await fs.symlink(targetPath, path.join(workspaceDir, "DREAMS.md"));
+
+    await expect(
+      writeBackfillDiaryEntries({
+        workspaceDir,
+        entries: [
+          {
+            isoDay: "2026-04-05",
+            bodyLines: ["The archive remembered a durable fact."],
+          },
+        ],
+        timezone: "UTC",
+      }),
+    ).rejects.toThrow("Refusing to write symlinked DREAMS.md");
+    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("outside\n");
+  });
+
+  it("keeps truncated recent diary entries UTF-16 safe", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-narrative-utf16-");
+    const prefix = "a".repeat(359);
+    await writeBackfillDiaryEntries({
+      workspaceDir,
+      entries: [
+        {
+          isoDay: "2026-04-05",
+          bodyLines: [`${prefix}😀tail`],
+        },
+      ],
+      timezone: "UTC",
+    });
+
+    await expect(readRecentDreamDiaryEntries({ workspaceDir, limit: 1 })).resolves.toEqual([
+      `${prefix}...`,
+    ]);
+  });
+
+  it("skips symlinked and non-file DREAMS.md when reading recent context", async () => {
+    const symlinkWorkspace = await createTempWorkspace("dreaming-narrative-read-symlink-");
+    const targetPath = path.join(symlinkWorkspace, "target-dreams.md");
+    await fs.writeFile(
+      targetPath,
+      [
+        "# Dream Diary",
+        "",
+        "<!-- openclaw:dreaming:diary:start -->",
+        "---",
+        "",
+        "*April 5, 2026*",
+        "",
+        "Symlink target diary text must not enter the prompt.",
+        "",
+        "<!-- openclaw:dreaming:diary:end -->",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.symlink(targetPath, path.join(symlinkWorkspace, "DREAMS.md"));
+
+    await expect(
+      readRecentDreamDiaryEntries({ workspaceDir: symlinkWorkspace, limit: 3 }),
+    ).resolves.toEqual([]);
+
+    const directoryWorkspace = await createTempWorkspace("dreaming-narrative-read-directory-");
+    await fs.mkdir(path.join(directoryWorkspace, "DREAMS.md"));
+    await expect(
+      readRecentDreamDiaryEntries({ workspaceDir: directoryWorkspace, limit: 3 }),
+    ).resolves.toEqual([]);
+  });
+
+  it("keeps existing content intact when the atomic replace fails", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-narrative-atomic-");
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+    await fs.writeFile(dreamsPath, "# Existing\n", "utf8");
+    vi.spyOn(fs, "rename").mockRejectedValueOnce(
+      Object.assign(new Error("replace failed"), { code: "ENOSPC" }),
+    );
+
+    await expect(
+      writeBackfillDiaryEntries({
+        workspaceDir,
+        entries: [
+          {
+            isoDay: "2026-04-05",
+            bodyLines: ["The archive remembered a durable fact."],
+          },
+        ],
+        timezone: "UTC",
+      }),
+    ).rejects.toThrow("replace failed");
+    await expect(fs.readFile(dreamsPath, "utf8")).resolves.toBe("# Existing\n");
+  });
+
+  it("preserves restrictive DREAMS.md permissions across atomic replace", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-narrative-mode-");
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+    await fs.writeFile(dreamsPath, "# Existing\n", { encoding: "utf8", mode: 0o600 });
+    await fs.chmod(dreamsPath, 0o600);
+
+    await writeBackfillDiaryEntries({
+      workspaceDir,
+      entries: [
+        {
+          isoDay: "2026-04-05",
+          bodyLines: ["The archive remembered a durable fact."],
+        },
+      ],
+      timezone: "UTC",
+    });
+
+    if (EXPECTS_POSIX_PRIVATE_FILE_MODE) {
+      expect((await fs.stat(dreamsPath)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("deduplicates exact matches while keeping distinct timestamps", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-narrative-dedupe-");
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+    await fs.writeFile(
+      dreamsPath,
+      [
+        "# Dream Diary",
+        "",
+        "<!-- openclaw:dreaming:diary:start -->",
+        "---",
+        "",
+        "*April 11, 2026, 8:00 AM*",
+        "",
+        "The server room smelled like rain.",
+        "",
+        "---",
+        "",
+        "*April 11, 2026, 8:00 AM*",
+        "",
+        "<!-- transient comment -->",
+        "",
+        "The server room smelled like rain.",
+        "",
+        "---",
+        "",
+        "*April 11, 2026, 8:30 AM*",
+        "",
+        "The server room smelled like rain.",
+        "",
+        "<!-- openclaw:dreaming:diary:end -->",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await expect(dedupeDreamDiaryEntries({ workspaceDir })).resolves.toMatchObject({
+      removed: 1,
+      kept: 2,
+    });
+    const content = await fs.readFile(dreamsPath, "utf8");
+    expect(content.match(/The server room smelled like rain\./g)?.length).toBe(2);
+    expect(content).toContain("*April 11, 2026, 8:00 AM*");
+    expect(content).toContain("*April 11, 2026, 8:30 AM*");
+  });
+
+  it("serializes concurrent writes and deduplication", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-narrative-concurrent-");
+    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+    await fs.writeFile(
+      dreamsPath,
+      [
+        "# Dream Diary",
+        "",
+        "<!-- openclaw:dreaming:diary:start -->",
+        "---",
+        "",
+        "*April 11, 2026, 8:00 AM*",
+        "",
+        "The server room smelled like rain.",
+        "",
+        "---",
+        "",
+        "*April 11, 2026, 8:00 AM*",
+        "",
+        "The server room smelled like rain.",
+        "",
+        "<!-- openclaw:dreaming:diary:end -->",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await Promise.all([
+      dedupeDreamDiaryEntries({ workspaceDir }),
+      writeBackfillDiaryEntries({
+        workspaceDir,
+        entries: [
+          {
+            isoDay: "2026-04-11",
+            bodyLines: ["A fresh signal arrived after the cleanup started."],
+          },
+        ],
+        timezone: "UTC",
+      }),
+    ]);
+
+    const content = await fs.readFile(dreamsPath, "utf8");
+    expect(content.match(/The server room smelled like rain\./g)?.length).toBe(1);
+    expect(content).toContain("A fresh signal arrived after the cleanup started.");
+  });
+});

--- a/extensions/memory-core/src/dreaming-dreams-file.ts
+++ b/extensions/memory-core/src/dreaming-dreams-file.ts
@@ -12,7 +12,7 @@ export const DREAMS_FILENAMES = ["DREAMS.md", "dreams.md"] as const;
 const DEEP_START_MARKER = "<!-- openclaw:dreaming:deep:start -->";
 const DEEP_END_MARKER = "<!-- openclaw:dreaming:deep:end -->";
 
-export async function resolveDreamsPath(workspaceDir: string): Promise<string> {
+async function resolveDreamsPath(workspaceDir: string): Promise<string> {
   for (const name of DREAMS_FILENAMES) {
     const target = path.join(workspaceDir, name);
     try {

--- a/extensions/memory-core/src/dreaming-dreams-file.ts
+++ b/extensions/memory-core/src/dreaming-dreams-file.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import { extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
 import { replaceManagedMarkdownBlock } from "openclaw/plugin-sdk/memory-host-markdown";
 import { readRegularFile, replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
+import { readStore } from "./short-term-promotion-store.js";
 
 export const DREAMS_FILENAMES = ["DREAMS.md", "dreams.md"] as const;
 const DEEP_START_MARKER = "<!-- openclaw:dreaming:deep:start -->";
@@ -126,5 +128,399 @@ export async function updateDeepDreamsFile(params: {
       }),
       result: dreamsPath,
     }),
+  });
+}
+
+const DIARY_START_MARKER = "<!-- openclaw:dreaming:diary:start -->";
+const DIARY_END_MARKER = "<!-- openclaw:dreaming:diary:end -->";
+const BACKFILL_ENTRY_MARKER = "openclaw:dreaming:backfill-entry";
+const RECENT_DIARY_CONTEXT_LIMIT = 3;
+const RECENT_DIARY_CONTEXT_MAX_CHARS = 360;
+
+// ── Date formatting ────────────────────────────────────────────────────
+
+function formatNarrativeDate(epochMs: number, timezone?: string): string {
+  const opts: Intl.DateTimeFormatOptions = {
+    timeZone: timezone ?? process.env.TZ,
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    // Always include the timezone abbreviation so the reader knows which
+    // timezone the timestamp refers to.  Without this, users who haven't
+    // configured a timezone see bare times that look local but are actually
+    // UTC, causing confusion (see #65027).
+    timeZoneName: "short",
+  };
+  return new Intl.DateTimeFormat("en-US", opts).format(new Date(epochMs));
+}
+
+// ── DREAMS.md file I/O ─────────────────────────────────────────────────
+
+function ensureDiarySection(existing: string): string {
+  if (existing.includes(DIARY_START_MARKER) && existing.includes(DIARY_END_MARKER)) {
+    return existing;
+  }
+  const diarySection = `# Dream Diary\n\n${DIARY_START_MARKER}\n${DIARY_END_MARKER}\n`;
+  if (existing.trim().length === 0) {
+    return diarySection;
+  }
+  return diarySection + "\n" + existing;
+}
+
+function replaceDiaryContent(existing: string, diaryContent: string): string {
+  const ensured = ensureDiarySection(existing);
+  const startIdx = ensured.indexOf(DIARY_START_MARKER);
+  const endIdx = ensured.indexOf(DIARY_END_MARKER);
+  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
+    return ensured;
+  }
+  const before = ensured.slice(0, startIdx + DIARY_START_MARKER.length);
+  const after = ensured.slice(endIdx);
+  const normalized = diaryContent.trim().length > 0 ? `\n${diaryContent.trim()}\n` : "\n";
+  return before + normalized + after;
+}
+
+function splitDiaryBlocks(diaryContent: string): string[] {
+  return diaryContent
+    .split(/\n---\n/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0);
+}
+
+export function clampDreamDiaryContextEntry(entry: string): string {
+  const normalized = entry.replace(/\s+/g, " ").trim();
+  if (normalized.length <= RECENT_DIARY_CONTEXT_MAX_CHARS) {
+    return normalized;
+  }
+  return `${truncateUtf16Safe(normalized, RECENT_DIARY_CONTEXT_MAX_CHARS).trimEnd()}...`;
+}
+
+function normalizeDiaryBlockBody(block: string): string {
+  const bodyLines: string[] = [];
+  for (const line of block.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("<!--") || trimmed.startsWith("#")) {
+      continue;
+    }
+    if (trimmed.startsWith("*") && trimmed.endsWith("*") && trimmed.length > 2) {
+      continue;
+    }
+    bodyLines.push(trimmed);
+  }
+  return clampDreamDiaryContextEntry(bodyLines.join(" "));
+}
+
+function isOptionalDiaryContextReadError(err: unknown): boolean {
+  const code = extractErrorCode(err);
+  if (
+    code === "EACCES" ||
+    code === "EPERM" ||
+    code === "ENOENT" ||
+    code === "ENOTDIR" ||
+    code === "not-found" ||
+    code === "not-file" ||
+    code === "path-alias" ||
+    code === "path-mismatch" ||
+    code === "symlink"
+  ) {
+    return true;
+  }
+  return err instanceof Error && err.message === "path must be a regular file";
+}
+
+function getDiaryContextEntries(existing: string): string[] {
+  const startIdx = existing.indexOf(DIARY_START_MARKER);
+  const endIdx = existing.indexOf(DIARY_END_MARKER);
+  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
+    return [];
+  }
+  const inner = existing.slice(startIdx + DIARY_START_MARKER.length, endIdx);
+  return splitDiaryBlocks(inner)
+    .map(normalizeDiaryBlockBody)
+    .filter((entry) => entry.length > 0);
+}
+
+export async function readRecentDreamDiaryEntries(params: {
+  workspaceDir: string;
+  limit?: number;
+}): Promise<string[]> {
+  const limit = Math.max(0, Math.floor(params.limit ?? RECENT_DIARY_CONTEXT_LIMIT));
+  if (limit === 0) {
+    return [];
+  }
+  let existing: string;
+  try {
+    const dreamsPath = await resolveDreamsPath(params.workspaceDir);
+    existing = await readDreamsFile(dreamsPath);
+  } catch (err) {
+    if (isOptionalDiaryContextReadError(err)) {
+      return [];
+    }
+    throw err;
+  }
+  return getDiaryContextEntries(existing).slice(-limit).toReversed();
+}
+
+function normalizeDiaryBlockFingerprint(block: string): string {
+  const lines = block
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  let dateLine = "";
+  const bodyLines: string[] = [];
+  for (const line of lines) {
+    if (!dateLine && line.startsWith("*") && line.endsWith("*") && line.length > 2) {
+      dateLine = line.slice(1, -1).trim();
+      continue;
+    }
+    if (line.startsWith("<!--") || line.startsWith("#")) {
+      continue;
+    }
+    bodyLines.push(line);
+  }
+  const normalizedDate = dateLine.replace(/\s+/g, " ").trim();
+  const normalizedBody = bodyLines
+    .join("\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+  return `${normalizedDate}\n${normalizedBody}`;
+}
+
+function joinDiaryBlocks(blocks: string[]): string {
+  if (blocks.length === 0) {
+    return "";
+  }
+  return blocks.map((block) => `---\n\n${block.trim()}\n`).join("\n");
+}
+
+function stripBackfillDiaryBlocks(existing: string): { updated: string; removed: number } {
+  const ensured = ensureDiarySection(existing);
+  const startIdx = ensured.indexOf(DIARY_START_MARKER);
+  const endIdx = ensured.indexOf(DIARY_END_MARKER);
+  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
+    return { updated: ensured, removed: 0 };
+  }
+  const inner = ensured.slice(startIdx + DIARY_START_MARKER.length, endIdx);
+  const kept: string[] = [];
+  let removed = 0;
+  for (const block of splitDiaryBlocks(inner)) {
+    if (block.includes(BACKFILL_ENTRY_MARKER)) {
+      removed += 1;
+      continue;
+    }
+    kept.push(block);
+  }
+  return {
+    updated: replaceDiaryContent(ensured, joinDiaryBlocks(kept)),
+    removed,
+  };
+}
+
+function formatBackfillDiaryDate(isoDay: string, _timezone?: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDay);
+  if (!match) {
+    return isoDay;
+  }
+  const [, year, month, day] = match;
+  const opts: Intl.DateTimeFormatOptions = {
+    // Preserve the source iso day exactly; backfill labels should not drift by timezone.
+    timeZone: "UTC",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+  const epochMs = Date.UTC(Number(year), Number(month) - 1, Number(day), 12);
+  return new Intl.DateTimeFormat("en-US", opts).format(new Date(epochMs));
+}
+
+function buildBackfillDiaryEntry(params: {
+  isoDay: string;
+  bodyLines: string[];
+  sourcePath?: string;
+  timezone?: string;
+}): string {
+  const dateStr = formatBackfillDiaryDate(params.isoDay, params.timezone);
+  const marker = `<!-- ${BACKFILL_ENTRY_MARKER} day=${params.isoDay}${params.sourcePath ? ` source=${params.sourcePath}` : ""} -->`;
+  const body = params.bodyLines
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim();
+  return [`*${dateStr}*`, marker, body].filter((part) => part.length > 0).join("\n\n");
+}
+
+export async function writeBackfillDiaryEntries(params: {
+  workspaceDir: string;
+  entries: Array<{
+    isoDay: string;
+    bodyLines: string[];
+    sourcePath?: string;
+  }>;
+  preserveExisting?: boolean;
+  timezone?: string;
+}): Promise<{ dreamsPath: string; written: number; replaced: number }> {
+  return await updateDreamsFile({
+    workspaceDir: params.workspaceDir,
+    updater: (existing, dreamsPath) => {
+      const stripped = params.preserveExisting
+        ? { updated: existing, removed: 0 }
+        : stripBackfillDiaryBlocks(existing);
+      const startIdx = stripped.updated.indexOf(DIARY_START_MARKER);
+      const endIdx = stripped.updated.indexOf(DIARY_END_MARKER);
+      const inner =
+        startIdx >= 0 && endIdx > startIdx
+          ? stripped.updated.slice(startIdx + DIARY_START_MARKER.length, endIdx)
+          : "";
+      const preservedBlocks = splitDiaryBlocks(inner);
+      const additions = params.entries.map((entry) =>
+        buildBackfillDiaryEntry({
+          isoDay: entry.isoDay,
+          bodyLines: entry.bodyLines,
+          sourcePath: entry.sourcePath,
+          timezone: params.timezone,
+        }),
+      );
+      const existingFingerprints = new Set(
+        preservedBlocks.map((block) => normalizeDiaryBlockFingerprint(block)),
+      );
+      const appended = params.preserveExisting
+        ? additions.filter((block) => {
+            const fingerprint = normalizeDiaryBlockFingerprint(block);
+            if (existingFingerprints.has(fingerprint)) {
+              return false;
+            }
+            existingFingerprints.add(fingerprint);
+            return true;
+          })
+        : additions;
+      const nextBlocks = [...preservedBlocks, ...appended];
+      return {
+        content: replaceDiaryContent(stripped.updated, joinDiaryBlocks(nextBlocks)),
+        result: {
+          dreamsPath,
+          written: appended.length,
+          replaced: stripped.removed,
+        },
+      };
+    },
+  });
+}
+
+export async function removeBackfillDiaryEntries(params: {
+  workspaceDir: string;
+}): Promise<{ dreamsPath: string; removed: number }> {
+  return await updateDreamsFile({
+    workspaceDir: params.workspaceDir,
+    updater: (existing, dreamsPath) => {
+      const stripped = stripBackfillDiaryBlocks(existing);
+      return {
+        content: stripped.updated,
+        result: {
+          dreamsPath,
+          removed: stripped.removed,
+        },
+        shouldWrite: stripped.removed > 0 || existing.length > 0,
+      };
+    },
+  });
+}
+
+export async function dedupeDreamDiaryEntries(params: {
+  workspaceDir: string;
+}): Promise<{ dreamsPath: string; removed: number; kept: number }> {
+  return await updateDreamsFile({
+    workspaceDir: params.workspaceDir,
+    updater: (existing, dreamsPath) => {
+      const ensured = ensureDiarySection(existing);
+      const startIdx = ensured.indexOf(DIARY_START_MARKER);
+      const endIdx = ensured.indexOf(DIARY_END_MARKER);
+      if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
+        return {
+          content: ensured,
+          result: { dreamsPath, removed: 0, kept: 0 },
+          shouldWrite: false,
+        };
+      }
+      const inner = ensured.slice(startIdx + DIARY_START_MARKER.length, endIdx);
+      const blocks = splitDiaryBlocks(inner);
+      const seen = new Set<string>();
+      const keptBlocks: string[] = [];
+      let removed = 0;
+      for (const block of blocks) {
+        const fingerprint = normalizeDiaryBlockFingerprint(block);
+        if (seen.has(fingerprint)) {
+          removed += 1;
+          continue;
+        }
+        seen.add(fingerprint);
+        keptBlocks.push(block);
+      }
+      return {
+        content: replaceDiaryContent(ensured, joinDiaryBlocks(keptBlocks)),
+        result: {
+          dreamsPath,
+          removed,
+          kept: keptBlocks.length,
+        },
+        shouldWrite: removed > 0,
+      };
+    },
+  });
+}
+
+function buildDiaryEntry(narrative: string, dateStr: string): string {
+  return `\n---\n\n*${dateStr}*\n\n${narrative}\n`;
+}
+
+export async function appendNarrativeEntry(params: {
+  workspaceDir: string;
+  narrative: string;
+  nowMs: number;
+  timezone?: string;
+  sourceEntryKeys?: readonly string[];
+  recentDiaryEntries?: readonly string[];
+}): Promise<string | undefined> {
+  const dateStr = formatNarrativeDate(params.nowMs, params.timezone);
+  const entry = buildDiaryEntry(params.narrative, dateStr);
+  return await updateDreamsFile<string | undefined>({
+    workspaceDir: params.workspaceDir,
+    updater: async (existing, dreamsPath) => {
+      const sourceKeys = params.sourceEntryKeys ?? [];
+      const currentSources =
+        sourceKeys.length > 0
+          ? (await readStore(params.workspaceDir, new Date(params.nowMs).toISOString())).entries
+          : undefined;
+      const currentDiary = new Set(getDiaryContextEntries(existing));
+      // The updater holds the purge lock. Model work ran outside it, so both
+      // staged inputs and prior diary quotes must survive until this commit.
+      if (
+        sourceKeys.some((key) => !currentSources?.[key]) ||
+        params.recentDiaryEntries?.some(
+          (block) => !currentDiary.has(clampDreamDiaryContextEntry(block)),
+        )
+      ) {
+        return { content: existing, result: undefined, shouldWrite: false };
+      }
+      let updated: string;
+      if (existing.includes(DIARY_START_MARKER) && existing.includes(DIARY_END_MARKER)) {
+        const endIdx = existing.lastIndexOf(DIARY_END_MARKER);
+        updated = existing.slice(0, endIdx) + entry + "\n" + existing.slice(endIdx);
+      } else if (existing.includes(DIARY_START_MARKER)) {
+        const startIdx = existing.indexOf(DIARY_START_MARKER) + DIARY_START_MARKER.length;
+        updated =
+          existing.slice(0, startIdx) +
+          entry +
+          "\n" +
+          DIARY_END_MARKER +
+          "\n" +
+          existing.slice(startIdx);
+      } else {
+        const diarySection = `# Dream Diary\n\n${DIARY_START_MARKER}${entry}\n${DIARY_END_MARKER}\n`;
+        updated = existing.trim().length === 0 ? diarySection : `${diarySection}\n${existing}`;
+      }
+      return { content: updated, result: dreamsPath };
+    },
   });
 }

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1,1353 +1,211 @@
-// Memory Core tests cover dreaming narrative plugin behavior.
-import { createHash } from "node:crypto";
+// Memory Core tests cover prompt-only dreaming and publication boundaries.
 import fs from "node:fs/promises";
 import path from "node:path";
-import {
-  RequestScopedSubagentRuntimeError,
-  SUBAGENT_RUNTIME_REQUEST_SCOPE_ERROR_CODE,
-} from "openclaw/plugin-sdk/error-runtime";
+import { RequestScopedSubagentRuntimeError } from "openclaw/plugin-sdk/error-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
-import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
-import { resolveStateDir } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
-import * as runtimeConfigSnapshotModule from "openclaw/plugin-sdk/runtime-config-snapshot";
-import {
-  listSessionEntries,
-  loadTranscriptEventsSync,
-  upsertSessionEntry,
-  type SessionEntry,
-} from "openclaw/plugin-sdk/session-store-runtime";
-import { appendSqliteSessionTranscriptEventForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { updateDreamsFile } from "./dreaming-dreams-file.js";
-import {
-  dedupeDreamDiaryEntries,
-  readRecentDreamDiaryEntries,
-  removeBackfillDiaryEntries,
-  runDreamNarrative,
-  writeBackfillDiaryEntries,
-} from "./dreaming-narrative.js";
-import {
-  SHORT_TERM_LOCK_MAX_ENTRIES,
-  SHORT_TERM_LOCK_NAMESPACE,
-  memoryCoreWorkspaceStateKey,
-  openMemoryCoreStateStore,
-} from "./dreaming-state.js";
+import { readRecentDreamDiaryEntries, writeBackfillDiaryEntries } from "./dreaming-dreams-file.js";
+import { runDreamNarrative, type DreamingCompletion } from "./dreaming-narrative.js";
 import { forgetMemoryEntries } from "./memory-forget.js";
 import { SESSION_CORPUS_RELATIVE_DIR } from "./session-ingestion.js";
 import { readShortTermRecallEntries, recordShortTermRecalls } from "./short-term-promotion.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
 
-vi.mock("openclaw/plugin-sdk/memory-core-host-runtime-core", { spy: true });
-
 const { createTempWorkspace } = createMemoryCoreTestHarness();
-const NARRATIVE_SESSION_LOCKS_KEY = Symbol.for(
-  "openclaw.memoryCore.dreamingNarrative.sessionLocks",
-);
-const EXPECTS_POSIX_PRIVATE_FILE_MODE = process.platform !== "win32";
-const originalNarrativeStateDir = process.env.OPENCLAW_STATE_DIR;
-
 function setNarrativeTestEnv(stateDir: string): void {
-  Reflect.set(process.env, "OPENCLAW_STATE_DIR", stateDir);
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
 }
-
-function restoreNarrativeTestEnv(): void {
-  if (originalNarrativeStateDir === undefined) {
-    Reflect.deleteProperty(process.env, "OPENCLAW_STATE_DIR");
-  } else {
-    Reflect.set(process.env, "OPENCLAW_STATE_DIR", originalNarrativeStateDir);
-  }
+function createLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 }
-
-type MockCallSource = { mock: { calls: Array<Array<unknown>> } };
-
-function mockCallArg(source: MockCallSource, label: string, callIndex = 0, argIndex = 0): unknown {
-  const call = source.mock.calls[callIndex];
-  if (!call) {
-    throw new Error(`Expected ${label} call ${callIndex} to exist`);
-  }
-  if (!(argIndex in call)) {
-    throw new Error(`Expected ${label} call ${callIndex} argument ${argIndex} to exist`);
-  }
-  return call[argIndex];
+function expectLogIncludes(source: ReturnType<typeof vi.fn>, text: string) {
+  expect(source.mock.calls.some((call) => String(call[0]).includes(text))).toBe(true);
 }
-
-function mockObjectArg(
-  source: MockCallSource,
-  label: string,
-  callIndex = 0,
-  argIndex = 0,
-): Record<string, unknown> {
-  const value = mockCallArg(source, label, callIndex, argIndex);
-  if (!value || typeof value !== "object") {
-    throw new Error(`Expected ${label} call ${callIndex} argument ${argIndex} to be an object`);
-  }
-  return value as Record<string, unknown>;
+function createCompletion(text = "The repository whispered of forgotten endpoints.") {
+  return { complete: vi.fn<DreamingCompletion["complete"]>().mockResolvedValue({ text }) };
 }
-
-function logIncludes(source: MockCallSource, text: string): boolean {
-  return source.mock.calls.some((call) => String(call[0]).includes(text));
-}
-
-function expectLogIncludes(source: MockCallSource, text: string): void {
-  expect(logIncludes(source, text), `Expected log to include ${text}`).toBe(true);
-}
-
-function expectLogExcludes(source: MockCallSource, text: string): void {
-  expect(logIncludes(source, text), `Expected log not to include ${text}`).toBe(false);
-}
-
-async function seedSessionStore(
-  storePath: string,
-  entries: Record<string, SessionEntry>,
-): Promise<void> {
-  for (const [sessionKey, entry] of Object.entries(entries)) {
-    await upsertSessionEntry({ storePath, sessionKey, entry });
-  }
-}
-
-function readSessionStoreEntries(storePath: string): Record<string, SessionEntry> {
-  return Object.fromEntries(
-    listSessionEntries({ storePath }).map(({ sessionKey, entry }) => [sessionKey, entry]),
-  );
-}
-
-async function seedDreamingTranscriptEvent(params: {
-  sessionId: string;
-  sessionKey: string;
-  storePath: string;
-  timestampMs: number;
-  runId?: string;
-}): Promise<void> {
-  await appendSqliteSessionTranscriptEventForTest({
-    agentId: "main",
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    storePath: params.storePath,
-    event: {
-      type: "metadata",
-      timestamp: params.timestampMs,
-      runId: params.runId ?? `dreaming-narrative-${params.sessionId}`,
-    },
-  });
-}
-
-async function flushNarrativeSettleTimers<T>(operation: Promise<T>): Promise<T> {
-  await vi.runAllTimersAsync();
-  return operation;
-}
-
-async function expectPathMissing(targetPath: string): Promise<void> {
-  const accessResult = await fs
-    .access(targetPath)
-    .then(() => "exists")
-    .catch((error: unknown) => (error as { code?: unknown }).code);
-  expect(accessResult).toBe("ENOENT");
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
-  restoreNarrativeTestEnv();
-  resolveGlobalMap<string, unknown>(NARRATIVE_SESSION_LOCKS_KEY).clear();
-});
-
-describe("dream diary file behavior", () => {
-  it("does not restore deleted diary content from an update already in progress", async () => {
-    const workspaceDir = await createTempWorkspace("dreaming-forget-update-");
-    setNarrativeTestEnv(path.join(workspaceDir, ".state"));
-    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
-    const claim = "A private cobalt archive phrase.";
-    await fs.writeFile(dreamsPath, `# Diary\n\n## Session ID: forgotten\n${claim}\n`);
-    const prepared = createDeferred<void>();
-    const publish = createDeferred<void>();
-    const update = updateDreamsFile({
-      workspaceDir,
-      updater: async (existing) => {
-        expect(existing).toContain(claim);
-        prepared.resolve();
-        await publish.promise;
-        return { content: `${existing}\n## Other\nA new unrelated entry.\n`, result: undefined };
-      },
-    });
-    let forgotten: ReturnType<typeof forgetMemoryEntries> | undefined;
-    try {
-      await prepared.promise;
-      const writerOwnsLock = await openMemoryCoreStateStore({
-        namespace: SHORT_TERM_LOCK_NAMESPACE,
-        maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
-      }).lookup(memoryCoreWorkspaceStateKey(workspaceDir));
-      forgotten = forgetMemoryEntries({
-        cfg: { agents: { entries: { main: { workspace: workspaceDir } } } },
-        agentId: "main",
-        sessionIds: ["forgotten"],
-      });
-      if (!writerOwnsLock) {
-        await forgotten;
-      }
-      publish.resolve();
-      await Promise.all([update, forgotten]);
-      const content = await fs.readFile(dreamsPath, "utf8");
-      expect(content).not.toContain(claim);
-      expect(content).toContain("A new unrelated entry.");
-    } finally {
-      publish.resolve();
-      await Promise.allSettled([update, ...(forgotten ? [forgotten] : [])]);
-    }
-  });
-
-  it("writes, reads, deduplicates, and removes backfill entries", async () => {
-    const workspaceDir = await createTempWorkspace("dreaming-narrative-backfill-");
-    const written = await writeBackfillDiaryEntries({
-      workspaceDir,
-      entries: [
-        {
-          isoDay: "2026-04-05",
-          bodyLines: ["The archive remembered a durable fact."],
-          sourcePath: "memory/2026-04-05.md",
-        },
-      ],
-      timezone: "UTC",
-    });
-    expect(written.written).toBe(1);
-
-    const existing = await fs.readFile(written.dreamsPath, "utf8");
-    const startMarker = "<!-- openclaw:dreaming:diary:start -->";
-    const endMarker = "<!-- openclaw:dreaming:diary:end -->";
-    const block = existing.slice(
-      existing.indexOf(startMarker) + startMarker.length,
-      existing.indexOf(endMarker),
-    );
-    await fs.writeFile(written.dreamsPath, existing.replace(endMarker, `${block}\n${endMarker}`));
-
-    await expect(dedupeDreamDiaryEntries({ workspaceDir })).resolves.toMatchObject({ removed: 1 });
-    await expect(readRecentDreamDiaryEntries({ workspaceDir })).resolves.toHaveLength(1);
-    await expect(removeBackfillDiaryEntries({ workspaceDir })).resolves.toMatchObject({
-      removed: 1,
-    });
-  });
-
-  it("refuses to overwrite a symlinked DREAMS.md", async () => {
-    const workspaceDir = await createTempWorkspace("dreaming-narrative-symlink-");
-    const targetPath = path.join(workspaceDir, "outside.txt");
-    await fs.writeFile(targetPath, "outside\n", "utf8");
-    await fs.symlink(targetPath, path.join(workspaceDir, "DREAMS.md"));
-
-    await expect(
-      writeBackfillDiaryEntries({
-        workspaceDir,
-        entries: [
-          {
-            isoDay: "2026-04-05",
-            bodyLines: ["The archive remembered a durable fact."],
-          },
-        ],
-        timezone: "UTC",
-      }),
-    ).rejects.toThrow("Refusing to write symlinked DREAMS.md");
-    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("outside\n");
-  });
-
-  it("keeps truncated recent diary entries UTF-16 safe", async () => {
-    const workspaceDir = await createTempWorkspace("dreaming-narrative-utf16-");
-    const prefix = "a".repeat(359);
-    await writeBackfillDiaryEntries({
-      workspaceDir,
-      entries: [
-        {
-          isoDay: "2026-04-05",
-          bodyLines: [`${prefix}😀tail`],
-        },
-      ],
-      timezone: "UTC",
-    });
-
-    await expect(readRecentDreamDiaryEntries({ workspaceDir, limit: 1 })).resolves.toEqual([
-      `${prefix}...`,
-    ]);
-  });
-
-  it("skips symlinked and non-file DREAMS.md when reading recent context", async () => {
-    const symlinkWorkspace = await createTempWorkspace("dreaming-narrative-read-symlink-");
-    const targetPath = path.join(symlinkWorkspace, "target-dreams.md");
-    await fs.writeFile(
-      targetPath,
-      [
-        "# Dream Diary",
-        "",
-        "<!-- openclaw:dreaming:diary:start -->",
-        "---",
-        "",
-        "*April 5, 2026*",
-        "",
-        "Symlink target diary text must not enter the prompt.",
-        "",
-        "<!-- openclaw:dreaming:diary:end -->",
-        "",
-      ].join("\n"),
-      "utf8",
-    );
-    await fs.symlink(targetPath, path.join(symlinkWorkspace, "DREAMS.md"));
-
-    await expect(
-      readRecentDreamDiaryEntries({ workspaceDir: symlinkWorkspace, limit: 3 }),
-    ).resolves.toEqual([]);
-
-    const directoryWorkspace = await createTempWorkspace("dreaming-narrative-read-directory-");
-    await fs.mkdir(path.join(directoryWorkspace, "DREAMS.md"));
-    await expect(
-      readRecentDreamDiaryEntries({ workspaceDir: directoryWorkspace, limit: 3 }),
-    ).resolves.toEqual([]);
-  });
-
-  it("keeps existing content intact when the atomic replace fails", async () => {
-    const workspaceDir = await createTempWorkspace("dreaming-narrative-atomic-");
-    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
-    await fs.writeFile(dreamsPath, "# Existing\n", "utf8");
-    vi.spyOn(fs, "rename").mockRejectedValueOnce(
-      Object.assign(new Error("replace failed"), { code: "ENOSPC" }),
-    );
-
-    await expect(
-      writeBackfillDiaryEntries({
-        workspaceDir,
-        entries: [
-          {
-            isoDay: "2026-04-05",
-            bodyLines: ["The archive remembered a durable fact."],
-          },
-        ],
-        timezone: "UTC",
-      }),
-    ).rejects.toThrow("replace failed");
-    await expect(fs.readFile(dreamsPath, "utf8")).resolves.toBe("# Existing\n");
-  });
-
-  it("preserves restrictive DREAMS.md permissions across atomic replace", async () => {
-    const workspaceDir = await createTempWorkspace("dreaming-narrative-mode-");
-    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
-    await fs.writeFile(dreamsPath, "# Existing\n", { encoding: "utf8", mode: 0o600 });
-    await fs.chmod(dreamsPath, 0o600);
-
-    await writeBackfillDiaryEntries({
-      workspaceDir,
-      entries: [
-        {
-          isoDay: "2026-04-05",
-          bodyLines: ["The archive remembered a durable fact."],
-        },
-      ],
-      timezone: "UTC",
-    });
-
-    if (EXPECTS_POSIX_PRIVATE_FILE_MODE) {
-      expect((await fs.stat(dreamsPath)).mode & 0o777).toBe(0o600);
-    }
-  });
-
-  it("deduplicates exact matches while keeping distinct timestamps", async () => {
-    const workspaceDir = await createTempWorkspace("dreaming-narrative-dedupe-");
-    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
-    await fs.writeFile(
-      dreamsPath,
-      [
-        "# Dream Diary",
-        "",
-        "<!-- openclaw:dreaming:diary:start -->",
-        "---",
-        "",
-        "*April 11, 2026, 8:00 AM*",
-        "",
-        "The server room smelled like rain.",
-        "",
-        "---",
-        "",
-        "*April 11, 2026, 8:00 AM*",
-        "",
-        "<!-- transient comment -->",
-        "",
-        "The server room smelled like rain.",
-        "",
-        "---",
-        "",
-        "*April 11, 2026, 8:30 AM*",
-        "",
-        "The server room smelled like rain.",
-        "",
-        "<!-- openclaw:dreaming:diary:end -->",
-        "",
-      ].join("\n"),
-      "utf8",
-    );
-
-    await expect(dedupeDreamDiaryEntries({ workspaceDir })).resolves.toMatchObject({
-      removed: 1,
-      kept: 2,
-    });
-    const content = await fs.readFile(dreamsPath, "utf8");
-    expect(content.match(/The server room smelled like rain\./g)?.length).toBe(2);
-    expect(content).toContain("*April 11, 2026, 8:00 AM*");
-    expect(content).toContain("*April 11, 2026, 8:30 AM*");
-  });
-
-  it("serializes concurrent writes and deduplication", async () => {
-    const workspaceDir = await createTempWorkspace("dreaming-narrative-concurrent-");
-    const dreamsPath = path.join(workspaceDir, "DREAMS.md");
-    await fs.writeFile(
-      dreamsPath,
-      [
-        "# Dream Diary",
-        "",
-        "<!-- openclaw:dreaming:diary:start -->",
-        "---",
-        "",
-        "*April 11, 2026, 8:00 AM*",
-        "",
-        "The server room smelled like rain.",
-        "",
-        "---",
-        "",
-        "*April 11, 2026, 8:00 AM*",
-        "",
-        "The server room smelled like rain.",
-        "",
-        "<!-- openclaw:dreaming:diary:end -->",
-        "",
-      ].join("\n"),
-      "utf8",
-    );
-
-    await Promise.all([
-      dedupeDreamDiaryEntries({ workspaceDir }),
-      writeBackfillDiaryEntries({
-        workspaceDir,
-        entries: [
-          {
-            isoDay: "2026-04-11",
-            bodyLines: ["A fresh signal arrived after the cleanup started."],
-          },
-        ],
-        timezone: "UTC",
-      }),
-    ]);
-
-    const content = await fs.readFile(dreamsPath, "utf8");
-    expect(content.match(/The server room smelled like rain\./g)?.length).toBe(1);
-    expect(content).toContain("A fresh signal arrived after the cleanup started.");
-  });
+  vi.unstubAllEnvs();
 });
 
 describe("runDreamNarrative", () => {
-  function createMockSubagent(responseText: string) {
-    return {
-      run: vi.fn().mockResolvedValue({ runId: "run-123" }),
-      waitForRun: vi.fn().mockResolvedValue({ status: "ok" }),
-      getSessionMessages: vi.fn().mockResolvedValue({
-        messages: [
-          { role: "user", content: "prompt" },
-          { role: "assistant", content: responseText },
-        ],
-      }),
-      deleteSession: vi.fn().mockResolvedValue(undefined),
-    };
-  }
-
-  function createMockLogger() {
-    return {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
-  }
-
-  it("generates narrative and writes diary entry", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("The repository whispered of forgotten endpoints.");
-    const logger = createMockLogger();
-    const nowMs = Date.parse("2026-04-05T03:00:00Z");
-    const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedRunKey = `dreaming-narrative-main-light-${workspaceHash}`;
-    const expectedSessionKey = `agent:main:dreaming-narrative-memory-core-v2-light-${workspaceHash}`;
-
+  it("writes the completion using the workspace owner's configured model", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-completion-");
+    const subagent = createCompletion();
     const outcome = await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: {
-        phase: "light",
-        snippets: ["API endpoints need authentication"],
-      },
-      nowMs,
-      timezone: "UTC",
-      model: "anthropic/claude-sonnet-4-6",
-      logger,
-    });
-
-    expect(subagent.run).toHaveBeenCalledOnce();
-    const runOptions = mockObjectArg(subagent.run, "subagent run");
-    // The runId keeps the scrub marker's `dreaming-narrative-` prefix ahead of the agent scope.
-    expect(runOptions.idempotencyKey).toBe(`${expectedRunKey}-${nowMs}`);
-    expect(runOptions.idempotencyKey).toMatch(/^dreaming-narrative-/);
-    expect(runOptions.sessionKey).toBe(expectedSessionKey);
-    expect(runOptions.lane).toBe(`dreaming-narrative:${expectedSessionKey}`);
-    expect(runOptions.lightContext).toBe(true);
-    expect(runOptions.deliver).toBe(false);
-    expect(runOptions.disableTools).toBe(true);
-    expect(runOptions.promptMode).toBe("minimal");
-    expect(runOptions.model).toBe("anthropic/claude-sonnet-4-6");
-    expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
-    expect(outcome).toEqual({ status: "completed" });
-
-    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    expect(content).toContain("The repository whispered of forgotten endpoints.");
-    expect(logger.info).toHaveBeenCalled();
-  });
-
-  it("keeps creation and cleanup on the memory-core-owned session identity", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-owner-");
-    const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const legacyUnownedKey = `agent:blockdigest:dreaming-narrative-rem-${workspaceHash}`;
-    const ownedKey = `agent:blockdigest:dreaming-narrative-memory-core-v2-rem-${workspaceHash}`;
-    const subagent = createMockSubagent("The digest folded itself into a paper moon.");
-    subagent.deleteSession.mockImplementation(async ({ sessionKey }: { sessionKey: string }) => {
-      if (sessionKey === legacyUnownedKey) {
-        throw new Error('Plugin "memory-core" cannot delete session because it did not create it');
-      }
-    });
-    const logger = createMockLogger();
-
-    const outcome = await runDreamNarrative({
-      agentId: "blockdigest",
-      subagent,
-      workspaceDir,
-      data: { phase: "rem", snippets: ["A digest session needs one lifecycle owner."] },
-      logger,
-    });
-
-    expect(mockObjectArg(subagent.run, "subagent run").sessionKey).toBe(ownedKey);
-    expect(
-      subagent.deleteSession.mock.calls.map(
-        (call: unknown[]) => (call[0] as { sessionKey: string }).sessionKey,
-      ),
-    ).toEqual([ownedKey, ownedKey]);
-    expect(outcome).toEqual({ status: "completed" });
-    expectLogExcludes(logger.warn, "did not create it");
-  });
-
-  // Regression: unscoped narrative session keys cannot be resolved to a per-agent SQLite
-  // store, so every subagent call failed with "Cannot resolve SQLite session scope without
-  // an agent id" and the whole dreaming pipeline produced nothing.
-  it("scopes narrative sessions to the workspace's owning agent", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("The night shift agent kept its own notebook.");
-    const logger = createMockLogger();
-    const nowMs = Date.parse("2026-04-05T03:00:00Z");
-    const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const sessionSuffix = `dreaming-narrative-memory-core-v2-rem-${workspaceHash}`;
-
-    await runDreamNarrative({
       agentId: "researcher",
-      subagent,
-      workspaceDir,
-      data: { phase: "rem", snippets: ["The index remembered a second agent."] },
-      nowMs,
-      timezone: "UTC",
-      logger,
-    });
-
-    expect(mockObjectArg(subagent.run, "subagent run").sessionKey).toBe(
-      `agent:researcher:${sessionSuffix}`,
-    );
-    expect(mockObjectArg(subagent.deleteSession, "delete session")).toEqual({
-      sessionKey: `agent:researcher:${sessionSuffix}`,
-    });
-    // The runId names its owning agent too, so two agents sharing a workspace cannot collide
-    // on one run; the scrub marker still matches because the agent scope follows the prefix.
-    expect(mockObjectArg(subagent.run, "subagent run").idempotencyKey).toBe(
-      `dreaming-narrative-researcher-rem-${workspaceHash}-${nowMs}`,
-    );
-    expectLogExcludes(logger.warn, "narrative generation failed");
-  });
-
-  it("waits for persisted assistant text before falling back", async () => {
-    vi.useFakeTimers();
-    try {
-      const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-      const subagent = createMockSubagent("");
-      subagent.getSessionMessages
-        .mockResolvedValueOnce({
-          messages: [{ role: "user", content: "prompt" }],
-        })
-        .mockResolvedValueOnce({
-          messages: [
-            { role: "user", content: "prompt" },
-            {
-              role: "assistant",
-              content: [{ type: "text", text: "The delayed diary text finally settled." }],
-            },
-          ],
-        });
-      const logger = createMockLogger();
-
-      const operation = runDreamNarrative({
-        agentId: "main",
-        subagent,
-        workspaceDir,
-        data: {
-          phase: "light",
-          snippets: ["The narrative assistant persisted after the run completed."],
-        },
-        nowMs: Date.parse("2026-04-05T03:00:00Z"),
-        timezone: "UTC",
-        logger,
-      });
-      await flushNarrativeSettleTimers(operation);
-
-      expect(subagent.getSessionMessages).toHaveBeenCalledTimes(2);
-      expect(subagent.getSessionMessages).toHaveBeenNthCalledWith(1, {
-        sessionKey: expect.stringContaining("dreaming-narrative-memory-core-v2-light-"),
-        limit: expect.any(Number),
-      });
-      expect(subagent.getSessionMessages).toHaveBeenNthCalledWith(2, {
-        sessionKey: expect.stringContaining("dreaming-narrative-memory-core-v2-light-"),
-        limit: expect.any(Number),
-      });
-      const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-      expect(content).toContain("The delayed diary text finally settled.");
-      expect(content).not.toContain("A memory trace surfaced");
-      expectLogExcludes(logger.warn, "produced no text");
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("writes the terminal reply text without polling the session store", async () => {
-    vi.useFakeTimers();
-    try {
-      const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-      const subagent = createMockSubagent("");
-      subagent.waitForRun.mockResolvedValue({
-        status: "ok",
-        terminalReply: {
-          disposition: "visible",
-          text: "The terminal reply carried the diary safely.",
-        },
-      });
-      // Simulate the sibling-cleanup race from #123360: the store never shows the
-      // completed run's text within the settle window.
-      subagent.getSessionMessages.mockResolvedValue({ messages: [] });
-      const logger = createMockLogger();
-
-      const operation = runDreamNarrative({
-        agentId: "main",
-        subagent,
-        workspaceDir,
-        data: {
-          phase: "light",
-          snippets: ["The narrative raced a sibling phase's cleanup."],
-        },
-        nowMs: Date.parse("2026-04-05T03:00:00Z"),
-        timezone: "UTC",
-        logger,
-      });
-      await flushNarrativeSettleTimers(operation);
-
-      expect(subagent.getSessionMessages).not.toHaveBeenCalled();
-      const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-      expect(content).toContain("The terminal reply carried the diary safely.");
-      expect(content).not.toContain("A memory trace surfaced");
-      expectLogExcludes(logger.warn, "produced no text");
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it.each([
-    { label: "empty", reply: { disposition: "empty" } },
-    { label: "silent", reply: { disposition: "silent" } },
-    // `message-tool-not-called` is an explicit no-text fact too; history must
-    // not resurface a transcript for it.
-    {
-      label: "empty (message-tool-not-called)",
-      reply: { disposition: "empty", code: "message-tool-not-called" },
-    },
-  ] as const)(
-    "treats an explicit $label terminal reply as authoritative no-text and never reads history",
-    async ({ reply }) => {
-      vi.useFakeTimers();
-      try {
-        const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-        const subagent = createMockSubagent("");
-        subagent.waitForRun.mockResolvedValue({
-          status: "ok",
-          // Any `text` beside a non-visible disposition must be ignored.
-          terminalReply: { ...reply, text: "text that must be ignored" },
-        });
-        // The store holds an OLD narrative from a previous run; reading it would
-        // resurface stale text over the authoritative no-text result.
-        subagent.getSessionMessages.mockResolvedValue({
-          messages: [
-            { role: "user", content: "prompt" },
-            { role: "assistant", content: "A stale narrative from a previous run." },
-          ],
-        });
-        const logger = createMockLogger();
-
-        const operation = runDreamNarrative({
-          agentId: "main",
-          subagent,
-          workspaceDir,
-          data: {
-            phase: "rem",
-            snippets: ["The run was silent, so history must not speak for it."],
-          },
-          nowMs: Date.parse("2026-04-05T03:00:00Z"),
-          timezone: "UTC",
-          logger,
-        });
-        await flushNarrativeSettleTimers(operation);
-
-        expect(subagent.getSessionMessages).not.toHaveBeenCalled();
-        const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-        expect(content).toContain("A memory trace surfaced");
-        expect(content).not.toContain("A stale narrative from a previous run.");
-        expect(content).not.toContain("text that must be ignored");
-        expectLogIncludes(logger.warn, "produced no text");
-      } finally {
-        vi.useRealTimers();
-      }
-    },
-  );
-
-  it("treats a visible terminal reply with only whitespace as no-text", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("");
-    subagent.waitForRun.mockResolvedValue({
-      status: "ok",
-      terminalReply: { disposition: "visible", text: "   \n  " },
-    });
-    subagent.getSessionMessages.mockResolvedValue({
-      messages: [
-        { role: "user", content: "prompt" },
-        { role: "assistant", content: "A stale narrative from a previous run." },
-      ],
-    });
-    const logger = createMockLogger();
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: {
-        phase: "light",
-        snippets: ["A blank diary page must not borrow yesterday's words."],
-      },
-      nowMs: Date.parse("2026-04-05T03:00:00Z"),
-      timezone: "UTC",
-      logger,
-    });
-
-    expect(subagent.getSessionMessages).not.toHaveBeenCalled();
-    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    expect(content).toContain("A memory trace surfaced");
-    expect(content).not.toContain("A stale narrative from a previous run.");
-    expectLogIncludes(logger.warn, "produced no text");
-  });
-
-  it("falls back after settled assistant text never appears", async () => {
-    vi.useFakeTimers();
-    try {
-      const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-      const subagent = createMockSubagent("");
-      const logger = createMockLogger();
-
-      const operation = runDreamNarrative({
-        agentId: "main",
-        subagent,
-        workspaceDir,
-        data: {
-          phase: "light",
-          snippets: ["The narrative assistant never persisted text."],
-        },
-        nowMs: Date.parse("2026-04-05T03:00:00Z"),
-        timezone: "UTC",
-        logger,
-      });
-      await flushNarrativeSettleTimers(operation);
-
-      expect(subagent.getSessionMessages).toHaveBeenCalledTimes(5);
-      const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-      expect(content).toContain(
-        "A memory trace surfaced, but details were unavailable in this run.",
-      );
-      expectLogIncludes(logger.warn, "produced no text");
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("retries with the session default when the configured model cannot start", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("The default model carried the diary home.");
-    subagent.run.mockRejectedValueOnce(new Error("model unavailable"));
-    const logger = createMockLogger();
-    const nowMs = Date.parse("2026-04-05T03:00:00Z");
-    const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `agent:main:dreaming-narrative-memory-core-v2-light-${workspaceHash}`;
-    const retrySessionKey = `${expectedSessionKey}-retry-1`;
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: {
-        phase: "light",
-        snippets: ["API endpoints need authentication"],
-      },
-      nowMs,
-      timezone: "UTC",
-      model: "ollama/missing-model",
-      logger,
-    });
-
-    expect(subagent.run).toHaveBeenCalledTimes(2);
-    const configuredRunOptions = mockObjectArg(subagent.run, "subagent run");
-    expect(configuredRunOptions.sessionKey).toBe(expectedSessionKey);
-    expect(configuredRunOptions.model).toBe("ollama/missing-model");
-    const retryRunOptions = mockObjectArg(subagent.run, "subagent run", 1);
-    expect(retryRunOptions.sessionKey).toBe(retrySessionKey);
-    expect(retryRunOptions).not.toHaveProperty("model");
-    expect(subagent.getSessionMessages).toHaveBeenCalledWith({
-      sessionKey: retrySessionKey,
-      limit: 5,
-    });
-    expect(subagent.deleteSession).toHaveBeenCalledTimes(3);
-    expect(mockObjectArg(subagent.deleteSession, "delete session")).toEqual({
-      sessionKey: expectedSessionKey,
-    });
-    expect(mockObjectArg(subagent.deleteSession, "delete session", 1)).toEqual({
-      sessionKey: retrySessionKey,
-    });
-    expect(mockObjectArg(subagent.deleteSession, "delete session", 2)).toEqual({
-      sessionKey: retrySessionKey,
-    });
-    expectLogIncludes(logger.warn, "session default");
-  });
-
-  it("retries with the session default when the configured model run ends unavailable", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("The default model carried the diary home.");
-    subagent.run
-      .mockResolvedValueOnce({ runId: "run-configured" })
-      .mockResolvedValueOnce({ runId: "run-default" });
-    subagent.waitForRun
-      .mockResolvedValueOnce({ status: "error", error: "unknown model: ollama/missing-model" })
-      .mockResolvedValueOnce({ status: "ok" });
-    const logger = createMockLogger();
-    const nowMs = Date.parse("2026-04-05T03:00:00Z");
-    const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `agent:main:dreaming-narrative-memory-core-v2-rem-${workspaceHash}`;
-    const retrySessionKey = `${expectedSessionKey}-retry-1`;
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: {
-        phase: "rem",
-        snippets: ["The index remembered a missing provider."],
-      },
-      nowMs,
-      timezone: "UTC",
-      model: "ollama/missing-model",
-      logger,
-    });
-
-    expect(subagent.waitForRun).toHaveBeenCalledTimes(2);
-    expect(subagent.getSessionMessages).toHaveBeenCalledWith({
-      sessionKey: retrySessionKey,
-      limit: 5,
-    });
-    expect(subagent.deleteSession).toHaveBeenCalledTimes(4);
-    expect(mockObjectArg(subagent.deleteSession, "delete session")).toEqual({
-      sessionKey: expectedSessionKey,
-    });
-    expect(mockObjectArg(subagent.deleteSession, "delete session", 1)).toEqual({
-      sessionKey: retrySessionKey,
-    });
-    expect(mockObjectArg(subagent.deleteSession, "delete session", 2)).toEqual({
-      sessionKey: expectedSessionKey,
-    });
-    expect(mockObjectArg(subagent.deleteSession, "delete session", 3)).toEqual({
-      sessionKey: retrySessionKey,
-    });
-    expectLogIncludes(logger.warn, "unknown model");
-  });
-
-  it("does not hide configured model authorization failures by retrying", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("");
-    subagent.run.mockRejectedValue(
-      new Error("provider/model override is not authorized for this plugin subagent run."),
-    );
-    const logger = createMockLogger();
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: {
-        phase: "light",
-        snippets: ["API endpoints need authentication"],
-      },
-      model: "ollama/missing-model",
-      logger,
-    });
-
-    expect(subagent.run).toHaveBeenCalledOnce();
-    expect(subagent.waitForRun).not.toHaveBeenCalled();
-    expect(subagent.deleteSession).toHaveBeenCalledOnce();
-    expectLogIncludes(logger.warn, "narrative generation failed");
-  });
-
-  it("skips narrative when no snippets are available", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("Should not appear.");
-    const logger = createMockLogger();
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: { phase: "light", snippets: [] },
-      logger,
-    });
-
-    expect(subagent.run).not.toHaveBeenCalled();
-    const exists = await fs
-      .access(path.join(workspaceDir, "DREAMS.md"))
-      .then(() => true)
-      .catch(() => false);
-    expect(exists).toBe(false);
-  });
-
-  it("writes a fallback diary entry when the subagent times out", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("");
-    subagent.waitForRun.mockResolvedValue({ status: "timeout" });
-    const logger = createMockLogger();
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: { phase: "deep", snippets: ["some memory"] },
-      logger,
-    });
-
-    // Should not throw, should warn.
-    expect(logger.warn).toHaveBeenCalled();
-    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    // Raw staging snippets must never leak into the diary; only the generic
-    // placeholder is written on fallback.
-    expect(content).not.toContain("some memory");
-    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
-    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("status=timeout"));
-  });
-
-  it("does not leak sensitive raw staging fragments into the diary on fallback", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("");
-    subagent.waitForRun.mockResolvedValue({ status: "timeout" });
-    const logger = createMockLogger();
-
-    // Realistic staging fragments as described in issue #88391: session
-    // metadata, conversation summaries, and operational logs that must never
-    // be persisted to the human-readable dream diary.
-    const sensitiveSnippets = [
-      "Conversation Summary: 343 files copied, 30 MB on B2 so far",
-      "Session: 2026-05-22 00:02:16 GMT+1: Session Key: agent:main:dashboard:secret",
-    ];
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: { phase: "deep", snippets: sensitiveSnippets },
-      logger,
-    });
-
-    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    for (const fragment of sensitiveSnippets) {
-      expect(content).not.toContain(fragment);
-    }
-    expect(content).not.toContain("Session Key:");
-    expect(content).not.toContain("agent:main:dashboard");
-    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
-  });
-
-  it("skips extra settle waits after timeout and still attempts cleanup", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("");
-    subagent.waitForRun.mockResolvedValueOnce({ status: "timeout" });
-    subagent.deleteSession.mockRejectedValue(new Error("still active"));
-    const logger = createMockLogger();
-
-    const outcome = await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: { phase: "rem", snippets: ["some memory"] },
-      logger,
-    });
-
-    expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(60_000);
-    expectLogIncludes(logger.warn, "narrative session cleanup failed for rem phase");
-    expect(outcome).toEqual({ status: "degraded", error: "still active" });
-  });
-
-  it("handles subagent error gracefully", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("");
-    subagent.run.mockRejectedValue(
-      new Error("connection failed", {
-        cause: new RequestScopedSubagentRuntimeError(),
-      }),
-    );
-    const logger = createMockLogger();
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: { phase: "rem", snippets: ["pattern surfaced"] },
-      logger,
-    });
-
-    // Should not throw, and an unexpected failure still leaves a dated diary trace
-    // instead of silently skipping the entry.
-    expectLogIncludes(logger.warn, "narrative generation failed");
-    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    expect(content).not.toContain("pattern surfaced");
-    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
-  });
-
-  it("falls back to a local narrative when subagent runtime is request-scoped", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("");
-    subagent.deleteSession.mockRejectedValueOnce(new RequestScopedSubagentRuntimeError());
-    subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
-    const logger = createMockLogger();
-
-    await runDreamNarrative({
-      agentId: "main",
       subagent,
       workspaceDir,
       data: { phase: "light", snippets: ["API endpoints need authentication"] },
       nowMs: Date.parse("2026-04-05T03:00:00Z"),
       timezone: "UTC",
-      logger,
+      model: "anthropic/claude-sonnet-4-6",
+      logger: createLogger(),
     });
 
-    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    // Raw staging snippets must never leak into the diary on fallback.
-    expect(content).not.toContain("API endpoints need authentication");
-    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
-    expectLogIncludes(logger.info, "request-scoped");
-    expectLogExcludes(logger.warn, "request-scoped");
-    expectLogExcludes(logger.warn, workspaceDir);
-    expectLogExcludes(logger.warn, "narrative pre-cleanup");
-    expectLogExcludes(logger.warn, "narrative session cleanup failed");
-    expect(subagent.deleteSession).toHaveBeenCalledOnce();
-  });
-
-  it("falls back when the request-scoped runtime error is detected by stable code", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("");
-    const crossBoundaryError = new Error("different wrapper text");
-    crossBoundaryError.name = "RequestScopedSubagentRuntimeError";
-    Object.assign(crossBoundaryError, {
-      code: SUBAGENT_RUNTIME_REQUEST_SCOPE_ERROR_CODE,
+    expect(subagent.complete).toHaveBeenCalledOnce();
+    expect(subagent.complete.mock.calls[0]?.[0]).toMatchObject({
+      agentId: "researcher",
+      model: "anthropic/claude-sonnet-4-6",
+      timeoutMs: 60_000,
+      message: expect.stringContaining("API endpoints need authentication"),
+      extraSystemPrompt: expect.stringContaining("Output ONLY the diary entry"),
     });
-    subagent.run.mockRejectedValue(crossBoundaryError);
-    const logger = createMockLogger();
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: { phase: "deep", snippets: [], promotions: ["A durable candidate surfaced."] },
-      nowMs: Date.parse("2026-04-05T03:00:00Z"),
-      timezone: "UTC",
-      logger,
-    });
-
-    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    // Raw staging promotions must never leak into the diary on fallback.
-    expect(content).not.toContain("A durable candidate surfaced.");
-    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
-    expectLogIncludes(logger.info, "request-scoped");
-    expectLogExcludes(logger.warn, "request-scoped");
-    expect(subagent.deleteSession).toHaveBeenCalledOnce();
-  });
-
-  it("does not fall back for non-Error objects that only spoof the stable code", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("");
-    subagent.run.mockRejectedValue({
-      code: SUBAGENT_RUNTIME_REQUEST_SCOPE_ERROR_CODE,
-      name: "RequestScopedSubagentRuntimeError",
-      message: "spoofed",
-    });
-    const logger = createMockLogger();
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: { phase: "deep", snippets: ["should not persist"] },
-      logger,
-    });
-
-    // A spoofed code must not be treated as the request-scoped runtime, so this stays on the
-    // unexpected-failure path: warn plus a generic fallback entry, never the request-scoped info.
-    expectLogIncludes(logger.warn, "narrative generation failed");
-    expectLogExcludes(logger.info, "request-scoped");
-    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    expect(content).not.toContain("should not persist");
-    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
-  });
-
-  it("cleans up session even on failure", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("");
-    subagent.getSessionMessages.mockRejectedValue(new Error("fetch failed"));
-    const logger = createMockLogger();
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: { phase: "light", snippets: ["memory fragment"] },
-      logger,
-    });
-
-    expect(subagent.deleteSession).toHaveBeenCalled();
-  });
-
-  it("scrubs stale dreaming entries and orphan transcripts after cleanup", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const stateDir = await createTempWorkspace("openclaw-dreaming-state-");
-    const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
-    await fs.mkdir(sessionsDir, { recursive: true });
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const orphanPath = path.join(sessionsDir, "orphan.jsonl");
-    const livePath = path.join(sessionsDir, "still-live.jsonl");
-    const normalTranscriptPath = path.join(sessionsDir, "normal-user-session.jsonl");
-    const updatedAt = Date.now();
-    await seedSessionStore(storePath, {
-      "agent:main:dreaming-narrative-light-1": {
-        sessionId: "orphan",
-        sessionFile: orphanPath,
-        updatedAt: updatedAt - 600_000,
-      },
-      "agent:main:kept-session": {
-        sessionId: "still-live",
-        sessionFile: livePath,
-        updatedAt,
-      },
-      "agent:main:telegram:group:dreaming-narrative-room": {
-        sessionId: "still-missing-non-dreaming",
-        updatedAt,
-      },
-      "agent:main:dreaming-narrative-corrupt-normal": {
-        sessionId: "normal-user-session",
-        sessionFile: normalTranscriptPath,
-        updatedAt,
-      },
-    });
-    await seedDreamingTranscriptEvent({
-      sessionId: "orphan",
-      sessionKey: "agent:main:dreaming-narrative-light-1",
-      storePath,
-      timestampMs: Date.now() - 600_000,
-      runId: "dreaming-narrative-light-123",
-    });
-    await seedDreamingTranscriptEvent({
-      sessionId: "still-live",
-      sessionKey: "agent:main:kept-session",
-      storePath,
-      timestampMs: Date.now(),
-      runId: "dreaming-narrative-light-keep",
-    });
-    await fs.writeFile(orphanPath, '{"runId":"dreaming-narrative-light-123"}\n', "utf-8");
-    await fs.writeFile(livePath, '{"runId":"dreaming-narrative-light-keep"}\n', "utf-8");
-    await fs.writeFile(normalTranscriptPath, '{"runId":"ordinary-user-session"}\n', "utf-8");
-    const oldDate = new Date(Date.now() - 600_000);
-    await fs.utimes(orphanPath, oldDate, oldDate);
-    await fs.utimes(livePath, oldDate, oldDate);
-    await fs.utimes(normalTranscriptPath, oldDate, oldDate);
-
-    vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfig").mockReturnValue({
-      session: {},
-    } as never);
-    setNarrativeTestEnv(stateDir);
-    vi.mocked(resolveStateDir).mockReturnValue(stateDir);
-
-    const subagent = createMockSubagent("The repository whispered of forgotten endpoints.");
-    const logger = createMockLogger();
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir,
-      data: { phase: "light", snippets: ["memory fragment"] },
-      logger,
-    });
-
-    const updatedStore = readSessionStoreEntries(storePath) as Record<string, unknown>;
-    expect(updatedStore).not.toHaveProperty("agent:main:dreaming-narrative-light-1");
-    expect(updatedStore).toHaveProperty("agent:main:dreaming-narrative-corrupt-normal");
-    expect(updatedStore).toHaveProperty("agent:main:kept-session");
-    expect(updatedStore).toHaveProperty("agent:main:telegram:group:dreaming-narrative-room");
-    expect(loadTranscriptEventsSync({ agentId: "main", sessionId: "orphan", storePath })).toEqual(
-      [],
+    expect(outcome).toEqual({ status: "completed" });
+    expect(await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf8")).toContain(
+      "The repository whispered of forgotten endpoints.",
     );
-    expect(
-      loadTranscriptEventsSync({ agentId: "main", sessionId: "still-live", storePath }),
-    ).not.toEqual([]);
-    const sessionFiles = await fs.readdir(sessionsDir);
-    expect(sessionFiles).toContain("still-live.jsonl");
-    expect(sessionFiles).toContain("normal-user-session.jsonl");
-    expectLogIncludes(logger.info, "dreaming cleanup scrubbed");
   });
 
-  it("reclaims an aged dreaming row whose transcript still exists (failed deleteSession)", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const stateDir = await createTempWorkspace("openclaw-dreaming-state-");
-    const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
-    await fs.mkdir(sessionsDir, { recursive: true });
-    const storePath = path.join(sessionsDir, "sessions.json");
-    // Orphan: a completed dreaming row whose deleteSession previously threw, so
-    // BOTH the store row and its transcript still exist (issue #88322).
-    const orphanTranscript = path.join(sessionsDir, "orphan-dreaming.jsonl");
-    // A second dreaming row whose transcript is fresh (a live/just-started run)
-    // must be preserved.
-    const liveTranscript = path.join(sessionsDir, "live-dreaming.jsonl");
-    const updatedAt = Date.now();
-    await seedSessionStore(storePath, {
-      "agent:main:dreaming-narrative-deep-orphan": {
-        sessionId: "orphan-dreaming",
-        sessionFile: orphanTranscript,
-        updatedAt: updatedAt - 600_000,
-      },
-      "agent:main:dreaming-narrative-deep-live": {
-        sessionId: "live-dreaming",
-        sessionFile: liveTranscript,
-        updatedAt,
-      },
-      "agent:main:kept-session": {
-        sessionId: "still-live",
-        sessionFile: path.join(sessionsDir, "still-live.jsonl"),
-        updatedAt,
-      },
-    });
-    await seedDreamingTranscriptEvent({
-      sessionId: "orphan-dreaming",
-      sessionKey: "agent:main:dreaming-narrative-deep-orphan",
-      storePath,
-      timestampMs: Date.now() - 600_000,
-      runId: "dreaming-narrative-deep-orphan",
-    });
-    await seedDreamingTranscriptEvent({
-      sessionId: "live-dreaming",
-      sessionKey: "agent:main:dreaming-narrative-deep-live",
-      storePath,
-      timestampMs: Date.now(),
-      runId: "dreaming-narrative-deep-live",
-    });
-    await fs.writeFile(orphanTranscript, '{"runId":"dreaming-narrative-deep-orphan"}\n', "utf-8");
-    await fs.writeFile(liveTranscript, '{"runId":"dreaming-narrative-deep-live"}\n', "utf-8");
-    await fs.writeFile(path.join(sessionsDir, "still-live.jsonl"), "{}\n", "utf-8");
-    // Age the orphan transcript past the 5-minute orphan threshold; keep the
-    // live transcript fresh.
-    const aged = new Date(Date.now() - 600_000);
-    await fs.utimes(orphanTranscript, aged, aged);
-
-    vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfig").mockReturnValue({
-      session: {},
-    } as never);
-    setNarrativeTestEnv(stateDir);
-    vi.mocked(resolveStateDir).mockReturnValue(stateDir);
-
-    const subagent = createMockSubagent("A forgotten endpoint hummed in the dark.");
-    const logger = createMockLogger();
-
+  it.each([
+    new Error("model unavailable"),
+    new Error("Completion failed", { cause: new Error("unknown model: ollama/missing-model") }),
+  ])("retries an unavailable configured model with the default (%s)", async (error) => {
+    const workspaceDir = await createTempWorkspace("dreaming-model-retry-");
+    const subagent = createCompletion("The default model carried the diary home.");
+    subagent.complete.mockRejectedValueOnce(error);
     await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
-      data: { phase: "light", snippets: ["memory fragment"] },
-      logger,
+      data: { phase: "rem", snippets: ["A configured endpoint was absent."] },
+      model: "ollama/missing-model",
+      logger: createLogger(),
     });
 
-    const updatedStore = readSessionStoreEntries(storePath) as Record<string, unknown>;
-    // The aged orphan dreaming row is reclaimed even though its transcript existed.
-    expect(updatedStore).not.toHaveProperty("agent:main:dreaming-narrative-deep-orphan");
-    // The fresh dreaming row and the non-dreaming row survive.
-    expect(updatedStore).toHaveProperty("agent:main:dreaming-narrative-deep-live");
-    expect(updatedStore).toHaveProperty("agent:main:kept-session");
-    expect(
-      loadTranscriptEventsSync({ agentId: "main", sessionId: "orphan-dreaming", storePath }),
-    ).toEqual([]);
-    expect(
-      loadTranscriptEventsSync({ agentId: "main", sessionId: "live-dreaming", storePath }),
-    ).not.toEqual([]);
-
-    const sessionFiles = await fs.readdir(sessionsDir);
-    // SQLite transcript state is archived while legacy JSONL support files are left alone.
-    expect(sessionFiles).toContain("orphan-dreaming.jsonl");
-    expect(sessionFiles).toContain("live-dreaming.jsonl");
-    expectLogIncludes(logger.info, "dreaming cleanup scrubbed");
-  });
-
-  it("isolates narrative sessions across workspaces even at the same timestamp", async () => {
-    const firstWorkspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const secondWorkspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = createMockSubagent("A quiet memory took shape.");
-    const logger = createMockLogger();
-    const nowMs = Date.parse("2026-04-05T03:00:00Z");
-
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir: firstWorkspaceDir,
-      data: { phase: "light", snippets: ["first workspace fragment"] },
-      nowMs,
-      logger,
-    });
-    await runDreamNarrative({
-      agentId: "main",
-      subagent,
-      workspaceDir: secondWorkspaceDir,
-      data: { phase: "light", snippets: ["second workspace fragment"] },
-      nowMs,
-      logger,
-    });
-
-    const firstSessionKey = mockObjectArg(subagent.run, "subagent run").sessionKey;
-    const secondSessionKey = mockObjectArg(subagent.run, "subagent run", 1).sessionKey;
-    expect(firstSessionKey).toBeTypeOf("string");
-    expect(secondSessionKey).toBeTypeOf("string");
-    expect(firstSessionKey).not.toBe(secondSessionKey);
-    expect(firstSessionKey).toContain("dreaming-narrative-memory-core-v2-light-");
-    expect(secondSessionKey).toContain("dreaming-narrative-memory-core-v2-light-");
-    const deleteKeys = subagent.deleteSession.mock.calls.map(
-      (call: unknown[]) => (call[0] as { sessionKey: string })?.sessionKey,
+    expect(subagent.complete).toHaveBeenCalledTimes(2);
+    expect(subagent.complete.mock.calls[0]?.[0].model).toBe("ollama/missing-model");
+    expect(subagent.complete.mock.calls[1]?.[0]).not.toHaveProperty("model");
+    expect(await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf8")).toContain(
+      "The default model carried the diary home.",
     );
-    expect(deleteKeys.filter((key: string) => key === firstSessionKey)).toHaveLength(2);
-    expect(deleteKeys.filter((key: string) => key === secondSessionKey)).toHaveLength(2);
   });
+
+  it("does not retry unauthorized model selection even when its cause names an unavailable model", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-model-denied-");
+    const subagent = createCompletion();
+    subagent.complete.mockRejectedValue(
+      Object.assign(
+        new Error("model override is not authorized", {
+          cause: new Error("unknown model: ollama/missing-model"),
+        }),
+        { code: "LLM_COMPLETION_NOT_AUTHORIZED" },
+      ),
+    );
+    const logger = createLogger();
+    await runDreamNarrative({
+      agentId: "main",
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["A private raw staging fragment."] },
+      model: "ollama/missing-model",
+      logger,
+    });
+
+    expect(subagent.complete).toHaveBeenCalledOnce();
+    expectLogIncludes(logger.warn, "not authorized");
+    const diary = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf8");
+    expect(diary).not.toContain("A private raw staging fragment.");
+    expect(diary).toContain("A memory trace surfaced");
+  });
+
+  it.each([
+    { name: "empty completion", failure: undefined },
+    { name: "timeout", failure: new Error("completion timed out") },
+    { name: "request-scoped runtime", failure: new RequestScopedSubagentRuntimeError() },
+  ])("writes only a generic trace after $name", async ({ failure }) => {
+    const workspaceDir = await createTempWorkspace("dreaming-fallback-");
+    const subagent = createCompletion("   \n  ");
+    if (failure) {
+      subagent.complete.mockRejectedValue(failure);
+    }
+    const outcome = await runDreamNarrative({
+      agentId: "main",
+      subagent,
+      workspaceDir,
+      data: { phase: "deep", snippets: ["A private raw staging fragment."] },
+      logger: createLogger(),
+    });
+
+    expect(outcome).toMatchObject({ status: "degraded" });
+    const diary = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf8");
+    expect(diary).toContain("A memory trace surfaced, but details were unavailable in this run.");
+    expect(diary).not.toContain("A private raw staging fragment.");
+  });
+
+  it.each(["main", undefined])("skips empty data for owner %s", async (agentId) => {
+    const workspaceDir = await createTempWorkspace("dreaming-empty-");
+    const subagent = createCompletion();
+    await expect(
+      runDreamNarrative({
+        agentId,
+        subagent,
+        workspaceDir,
+        data: { phase: "light", snippets: [] },
+        logger: createLogger(),
+      }),
+    ).resolves.toEqual({ status: "skipped" });
+    expect(subagent.complete).not.toHaveBeenCalled();
+    await expect(fs.access(path.join(workspaceDir, "DREAMS.md"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("keeps ownerless sweeps alive with a local trace", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-ownerless-");
+    const subagent = createCompletion();
+    await runDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["An ownerless memory fragment."] },
+      logger: createLogger(),
+    });
+    expect(subagent.complete).not.toHaveBeenCalled();
+    expect(await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf8")).toContain(
+      "A memory trace surfaced",
+    );
+  });
+
+  it.each([false, true])(
+    "detaches publication without an unhandled failure (reject=%s)",
+    async (reject) => {
+      const workspaceDir = await createTempWorkspace("dreaming-detached-");
+      const completion = createDeferred<{ text: string }>();
+      const subagent = createCompletion();
+      subagent.complete.mockReturnValue(completion.promise);
+      const unhandled = vi.fn();
+      process.on("unhandledRejection", unhandled);
+      try {
+        await expect(
+          runDreamNarrative({
+            agentId: "main",
+            subagent,
+            workspaceDir,
+            data: { phase: "rem", snippets: ["A detached fragment."] },
+            logger: createLogger(),
+            detached: true,
+          }),
+        ).resolves.toEqual({ status: "pending" });
+        expect(subagent.complete).toHaveBeenCalledOnce();
+        if (reject) {
+          completion.reject(new Error("completion failed"));
+        } else {
+          completion.resolve({ text: "A detached memory found its page." });
+        }
+        await vi.waitFor(async () => {
+          const diary = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf8");
+          expect(diary).toContain(
+            reject ? "A memory trace surfaced" : "A detached memory found its page.",
+          );
+        });
+        expect(unhandled).not.toHaveBeenCalled();
+      } finally {
+        completion.resolve({ text: "settled" });
+        process.off("unhandledRejection", unhandled);
+      }
+    },
+  );
 });
 
 describe("runDreamNarrative deletion boundary", () => {
@@ -1409,22 +267,13 @@ describe("runDreamNarrative deletion boundary", () => {
         });
       }
       const waiting = createDeferred<void>();
-      const terminal = createDeferred<{
-        status: string;
-        terminalReply: { disposition: "visible"; text: string };
-      }>();
-      const reply = {
-        status: "ok",
-        terminalReply: { disposition: "visible" as const, text: `I remembered: ${claim}` },
-      };
+      const terminal = createDeferred<{ text: string }>();
+      const reply = { text: `I remembered: ${claim}` };
       const subagent = {
-        run: vi.fn().mockResolvedValue({ runId: "generated-after-forget" }),
-        waitForRun: vi.fn(async () => {
+        complete: vi.fn(async (_params: { message: string }) => {
           waiting.resolve();
           return await terminal.promise;
         }),
-        getSessionMessages: vi.fn().mockResolvedValue({ messages: [] }),
-        deleteSession: vi.fn().mockResolvedValue(undefined),
       };
       const data = {
         phase: "light" as const,
@@ -1445,7 +294,7 @@ describe("runDreamNarrative deletion boundary", () => {
       });
       try {
         await waiting.promise;
-        expect(mockObjectArg(subagent.run, "subagent run").message).toContain(claim);
+        expect(subagent.complete.mock.calls[0]?.[0].message).toContain(claim);
         if (mutation === "forget") {
           const forgotten = await forgetMemoryEntries({
             cfg: { agents: { entries: { main: { workspace: workspaceDir } } } },
@@ -1475,7 +324,7 @@ describe("runDreamNarrative deletion boundary", () => {
           expect(outcome).toEqual({ status: "skipped" });
           expectLogIncludes(logger.info, "narrative publication skipped");
         } else {
-          expect(content).toContain(reply.terminalReply.text);
+          expect(content).toContain(reply.text);
           expect(outcome).toEqual({ status: "completed" });
         }
       } finally {
@@ -1485,278 +334,3 @@ describe("runDreamNarrative deletion boundary", () => {
     },
   );
 });
-
-describe("runDreamNarrative ownership gate", () => {
-  it("keeps the sweep alive with a local fallback when no owning agent is known", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = {
-      run: vi.fn(),
-      waitForRun: vi.fn(),
-      getSessionMessages: vi.fn(),
-      deleteSession: vi.fn(),
-    };
-    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-
-    await runDreamNarrative({
-      subagent,
-      workspaceDir,
-      data: { phase: "light", snippets: ["An ownerless sweep still leaves a trace."] },
-      nowMs: Date.parse("2026-04-05T03:00:00Z"),
-      timezone: "UTC",
-      logger,
-    });
-
-    // No agent means no resolvable session store, so the subagent is never called.
-    expect(subagent.run).not.toHaveBeenCalled();
-    expect(subagent.deleteSession).not.toHaveBeenCalled();
-    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    expect(content).not.toContain("An ownerless sweep still leaves a trace.");
-    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
-    expectLogIncludes(logger.info, "no owning agent id");
-  });
-
-  it("queues the ownerless fallback through detached dispatch", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = {
-      run: vi.fn(),
-      waitForRun: vi.fn(),
-      getSessionMessages: vi.fn(),
-      deleteSession: vi.fn(),
-    };
-    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-
-    // A detached cron sweep must not await the diary write, so the ownerless fallback rides
-    // the same limiter as the subagent path instead of blocking inline.
-    await runDreamNarrative({
-      subagent,
-      workspaceDir,
-      data: { phase: "light", snippets: ["A detached ownerless sweep still leaves a trace."] },
-      nowMs: Date.parse("2026-04-05T03:00:00Z"),
-      timezone: "UTC",
-      logger,
-      detached: true,
-    });
-
-    expect(subagent.run).not.toHaveBeenCalled();
-    await vi.waitFor(async () => {
-      expect(await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).toContain(
-        "A memory trace surfaced, but details were unavailable in this run.",
-      );
-    });
-  });
-
-  it("stays a no-op for an ownerless sweep with nothing to narrate", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-    const subagent = {
-      run: vi.fn(),
-      waitForRun: vi.fn(),
-      getSessionMessages: vi.fn(),
-      deleteSession: vi.fn(),
-    };
-    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-
-    await runDreamNarrative({
-      subagent,
-      workspaceDir,
-      data: { phase: "light", snippets: [] },
-      nowMs: Date.parse("2026-04-05T03:00:00Z"),
-      timezone: "UTC",
-      logger,
-    });
-
-    // Empty narrative data is a no-op with or without an owner; the ownership fallback must
-    // not invent a diary entry for material that never existed.
-    expect(subagent.run).not.toHaveBeenCalled();
-    await expectPathMissing(path.join(workspaceDir, "DREAMS.md"));
-  });
-});
-
-describe("runDreamNarrative detached dispatch", () => {
-  type Deferred<T> = { promise: Promise<T>; resolve: (v: T) => void };
-  function deferred<T>(): Deferred<T> {
-    let resolve: ((v: T) => void) | undefined;
-    const promise = new Promise<T>((r) => {
-      resolve = r;
-    });
-    if (!resolve) {
-      throw new Error("Expected dream narrative deferred resolver to be initialized");
-    }
-    return { promise, resolve };
-  }
-
-  function createBlockingSubagent() {
-    const runDeferreds: Array<Deferred<{ runId: string }>> = [];
-    const subagent = {
-      run: vi.fn(() => {
-        const d = deferred<{ runId: string }>();
-        runDeferreds.push(d);
-        return d.promise;
-      }),
-      // Resolve the rest of the pipeline as a no-op so a single resolve()
-      // on a deferred unblocks the slot for the queued task.
-      waitForRun: vi.fn().mockResolvedValue({ status: "timeout" }),
-      getSessionMessages: vi.fn().mockResolvedValue({ messages: [] }),
-      deleteSession: vi.fn().mockResolvedValue(undefined),
-    };
-    return { subagent, runDeferreds };
-  }
-
-  function createMockLogger() {
-    return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-  }
-
-  async function drainMicrotasks(rounds = 30): Promise<void> {
-    for (let i = 0; i < rounds; i += 1) {
-      await Promise.resolve();
-    }
-  }
-
-  it("caps the number of in-flight detached narratives at 3", async () => {
-    const { subagent, runDeferreds } = createBlockingSubagent();
-    const workspaceDirs = await Promise.all(
-      Array.from({ length: 5 }, () => createTempWorkspace("openclaw-dreaming-detach-")),
-    );
-    const logger = createMockLogger();
-
-    for (const [i, workspaceDir] of workspaceDirs.entries()) {
-      void runDreamNarrative({
-        agentId: "main",
-        subagent,
-        workspaceDir,
-        data: { phase: "light", snippets: [`fragment-${i}`] },
-        nowMs: Date.parse("2026-04-28T03:00:00Z"),
-        logger,
-        detached: true,
-      });
-    }
-
-    await drainMicrotasks();
-
-    // Only the first 3 should have reached subagent.run; the rest are queued.
-    expect(subagent.run).toHaveBeenCalledTimes(3);
-
-    // Drain the rest so module-level concurrency state does not leak into
-    // subsequent tests. The mock subagent creates a new deferred every time
-    // queued tasks acquire a slot, so loop until no new deferreds appear.
-    for (let iter = 0; iter < 10; iter += 1) {
-      const before = runDeferreds.length;
-      for (const d of runDeferreds) {
-        d.resolve({ runId: "drain" });
-      }
-      if (before >= 5) {
-        break;
-      }
-      await vi.waitFor(() => {
-        expect(runDeferreds.length).toBeGreaterThan(before);
-      });
-    }
-    for (const d of runDeferreds) {
-      d.resolve({ runId: "drain" });
-    }
-    await vi.waitFor(() => {
-      expect(subagent.deleteSession).toHaveBeenCalledTimes(10);
-    });
-    expect(subagent.run).toHaveBeenCalledTimes(5);
-    expect(subagent.waitForRun).toHaveBeenCalledTimes(5);
-  });
-
-  it("serializes detached narratives that reuse a workspace and phase session", async () => {
-    let nextRunId = 0;
-    const waitDeferreds: Array<Deferred<{ status: string }>> = [];
-    const subagent = {
-      run: vi.fn(() => {
-        nextRunId += 1;
-        return Promise.resolve({ runId: `run-${nextRunId}` });
-      }),
-      waitForRun: vi.fn(() => {
-        const d = deferred<{ status: string }>();
-        waitDeferreds.push(d);
-        return d.promise;
-      }),
-      getSessionMessages: vi.fn().mockResolvedValue({ messages: [] }),
-      deleteSession: vi.fn().mockResolvedValue(undefined),
-    };
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-detach-");
-    const logger = createMockLogger();
-
-    for (let i = 0; i < 5; i += 1) {
-      void runDreamNarrative({
-        agentId: "main",
-        subagent,
-        workspaceDir,
-        data: { phase: "light", snippets: [`fragment-${i}`] },
-        nowMs: Date.parse("2026-04-28T03:00:00Z"),
-        logger,
-        detached: true,
-      });
-    }
-
-    await vi.waitFor(() => {
-      expect(waitDeferreds.length).toBe(1);
-    });
-
-    expect(subagent.run).toHaveBeenCalledTimes(1);
-    expect(subagent.waitForRun).toHaveBeenCalledTimes(1);
-    // The first run is still active, so later same-key jobs must not pre-delete its session.
-    expect(subagent.deleteSession).toHaveBeenCalledTimes(1);
-
-    for (let i = 0; i < 5; i += 1) {
-      const currentDeferred = waitDeferreds[i];
-      if (!currentDeferred) {
-        throw new Error(`Expected wait deferred ${i} to exist`);
-      }
-      currentDeferred.resolve({ status: "timeout" });
-      if (i < 4) {
-        await vi.waitFor(() => {
-          expect(waitDeferreds.length).toBeGreaterThan(i + 1);
-        });
-      }
-    }
-
-    await vi.waitFor(() => {
-      expect(subagent.deleteSession).toHaveBeenCalledTimes(10);
-    });
-    expect(subagent.run).toHaveBeenCalledTimes(5);
-    expect(subagent.waitForRun).toHaveBeenCalledTimes(5);
-  });
-
-  it("swallows underlying narrative errors instead of leaving an unhandled rejection", async () => {
-    const error = new Error("boom");
-    const subagent = {
-      run: vi.fn().mockRejectedValue(error),
-      waitForRun: vi.fn().mockResolvedValue({ status: "ok" }),
-      getSessionMessages: vi.fn().mockResolvedValue({ messages: [] }),
-      deleteSession: vi.fn().mockResolvedValue(undefined),
-    };
-    const logger = createMockLogger();
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-detach-");
-    const unhandled = vi.fn();
-    process.on("unhandledRejection", unhandled);
-
-    try {
-      void runDreamNarrative({
-        agentId: "main",
-        subagent,
-        workspaceDir,
-        data: { phase: "light", snippets: ["fragment"] },
-        nowMs: Date.parse("2026-04-28T03:00:00Z"),
-        logger,
-        detached: true,
-      });
-
-      await drainMicrotasks();
-
-      expect(subagent.run).toHaveBeenCalledOnce();
-      expect(unhandled).not.toHaveBeenCalled();
-      // Settle the detached fallback write before the fixture workspace is torn down.
-      await vi.waitFor(async () => {
-        expect(await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).toContain(
-          "A memory trace surfaced, but details were unavailable in this run.",
-        );
-      });
-    } finally {
-      process.off("unhandledRejection", unhandled);
-    }
-  });
-});
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -1,6 +1,4 @@
 // Memory Core plugin module implements dreaming narrative behavior.
-import { createHash } from "node:crypto";
-import { createAsyncLock } from "openclaw/plugin-sdk/async-lock-runtime";
 import {
   extractErrorCode,
   formatErrorMessage,
@@ -8,45 +6,12 @@ import {
   readErrorName,
   SUBAGENT_RUNTIME_REQUEST_SCOPE_ERROR_CODE,
 } from "openclaw/plugin-sdk/error-runtime";
-import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
-import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import pLimit from "p-limit";
-import { readDreamsFile, resolveDreamsPath, updateDreamsFile } from "./dreaming-dreams-file.js";
-import {
-  DREAMING_SESSION_KEY_PREFIX,
-  scrubDreamingNarrativeArtifacts,
-} from "./dreaming-session-cleanup.js";
-import { extractAssistantText } from "./dreaming-shared.js";
-import { readStore } from "./short-term-promotion-store.js";
+import { appendNarrativeEntry, clampDreamDiaryContextEntry } from "./dreaming-dreams-file.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
-type SubagentRunParams = Parameters<PluginRuntime["subagent"]["run"]>[0];
-
-export type SubagentSurface = {
-  run: (params: SubagentRunParams) => Promise<{ runId: string }>;
-  waitForRun: (params: { runId: string; timeoutMs?: number }) => Promise<{
-    status: string;
-    error?: string;
-    /**
-     * Authoritative final assistant text captured by the run registry while the
-     * raw text was still available. Preferred over polling the session store,
-     * which lags a completed run (see readSettledNarrativeText) and can stay
-     * empty past the settle budget when a sibling phase's cleanup races it (#123360).
-     */
-    terminalReply?: {
-      disposition: "visible" | "silent" | "empty";
-      text?: string;
-    };
-  }>;
-  getSessionMessages: (params: {
-    sessionKey: string;
-    limit?: number;
-  }) => Promise<{ messages: unknown[] }>;
-  deleteSession: (params: { sessionKey: string }) => Promise<void>;
-};
+export type DreamingCompletion = Pick<PluginRuntime["subagent"], "complete">;
 
 export type NarrativePhaseData = {
   phase: "light" | "deep" | "rem";
@@ -96,38 +61,9 @@ const NARRATIVE_SYSTEM_PROMPT = [
   "- Output ONLY the diary entry. No preamble, no sign-off, no commentary.",
 ].join("\n");
 
-// Narrative generation is best-effort. Keep the timeout bounded so a stalled
-// diary subagent does not leave the parent dreaming cron job "running" for
-// many minutes after the reports have already been written. The previous 15 s
-// limit was empirically too tight for warm-gateway runs across light, REM, and
-// deep phases — even unblocked LLM calls hit it on the first sweep after a
-// restart. 60 s gives realistic latency headroom while still capping the
-// worst case at one minute, well below the multi-minute stall the original
-// comment warned against.
+// Bound best-effort diary inference independently from the parent sweep.
 const NARRATIVE_TIMEOUT_MS = 60_000;
-const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
-// A completed run can reach the session reader before the final assistant text
-// is visible, so retry briefly before falling back to synthetic diary text.
-const NARRATIVE_MESSAGE_SETTLE_DELAYS_MS = [50, 150, 300, 750] as const;
-const DREAMING_SESSION_OWNER_KEY = "memory-core-v2";
-const DIARY_START_MARKER = "<!-- openclaw:dreaming:diary:start -->";
-const DIARY_END_MARKER = "<!-- openclaw:dreaming:diary:end -->";
-const BACKFILL_ENTRY_MARKER = "openclaw:dreaming:backfill-entry";
 const RECENT_DIARY_CONTEXT_LIMIT = 3;
-const RECENT_DIARY_CONTEXT_MAX_CHARS = 360;
-const NARRATIVE_SESSION_LOCKS_KEY = Symbol.for(
-  "openclaw.memoryCore.dreamingNarrative.sessionLocks",
-);
-
-type NarrativeSessionLockEntry = {
-  withLock: ReturnType<typeof createAsyncLock>;
-  refs: number;
-};
-
-const narrativeSessionLocks = resolveGlobalMap<string, NarrativeSessionLockEntry>(
-  NARRATIVE_SESSION_LOCKS_KEY,
-);
-
 function isRequestScopedSubagentRuntimeError(err: unknown): boolean {
   return (
     err instanceof RequestScopedSubagentRuntimeError ||
@@ -182,11 +118,24 @@ export async function appendFallbackNarrativeEntry(params: {
   }
 }
 
-function buildNarrativeAttemptKey(baseKey: string, attempt: number): string {
-  return attempt === 0 ? baseKey : `${baseKey}-retry-${attempt}`;
+function isConfiguredModelUnavailableNarrativeError(error: unknown): boolean {
+  const errors: Error[] = [];
+  for (
+    let current = error;
+    current instanceof Error && !errors.includes(current);
+    current = current.cause
+  ) {
+    errors.push(current);
+  }
+  // Runtime wrappers retain provider causes, but denied authority never authorizes
+  // a retry through the default model even if a nested cause names a missing model.
+  if (errors.some((entry) => extractErrorCode(entry) === "LLM_COMPLETION_NOT_AUTHORIZED")) {
+    return false;
+  }
+  return errors.some((entry) => isModelUnavailableMessage(entry.message));
 }
 
-function isConfiguredModelUnavailableNarrativeError(raw: string): boolean {
+function isModelUnavailableMessage(raw: string): boolean {
   const message = raw.trim();
   if (!message) {
     return false;
@@ -227,86 +176,6 @@ function isConfiguredModelUnavailableNarrativeError(raw: string): boolean {
   return false;
 }
 
-function formatNarrativeTerminalStatus(params: { status: string; error?: string }): string {
-  const detail = params.error?.trim();
-  return detail ? `status=${params.status} (${detail})` : `status=${params.status}`;
-}
-
-async function startNarrativeRunOrFallback(params: {
-  subagent: SubagentSurface;
-  sessionKey: string;
-  runKey: string;
-  message: string;
-  data: NarrativePhaseData;
-  workspaceDir: string;
-  nowMs: number;
-  timezone?: string;
-  model?: string;
-  logger: Logger;
-}): Promise<string | null> {
-  try {
-    const run = await params.subagent.run({
-      // The gateway uses the idempotency key as the runId, and the orphan-transcript
-      // scrub matches runIds by DREAMING_TRANSCRIPT_RUN_MARKER — keep it unscoped.
-      idempotencyKey: `${params.runKey}-${params.nowMs}`,
-      sessionKey: params.sessionKey,
-      message: params.message,
-      disableTools: true,
-      ...(params.model ? { model: params.model } : {}),
-      extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
-      promptMode: "minimal",
-      lane: `dreaming-narrative:${params.sessionKey}`,
-      lightContext: true,
-      deliver: false,
-    });
-    return run.runId;
-  } catch (runErr) {
-    if (!isRequestScopedSubagentRuntimeError(runErr)) {
-      throw runErr;
-    }
-    await appendFallbackNarrativeEntry({
-      ...params,
-      reason: "subagent runtime is request-scoped",
-    });
-    return null;
-  }
-}
-
-function buildNarrativeWorkspaceHash(workspaceDir: string): string {
-  return createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-}
-
-/**
- * Deterministic run identity, which the gateway also uses as the runId.
- * The agent scope goes after `DREAMING_SESSION_KEY_PREFIX` so the orphan-transcript scrub
- * keeps matching DREAMING_TRANSCRIPT_RUN_MARKER, while two agents that share one workspace
- * cannot collide on a run they own through different agent-scoped sessions.
- */
-function buildNarrativeRunKey(params: {
-  agentId: string;
-  workspaceDir: string;
-  phase: NarrativePhaseData["phase"];
-}): string {
-  const workspaceHash = buildNarrativeWorkspaceHash(params.workspaceDir);
-  return `${DREAMING_SESSION_KEY_PREFIX}${params.agentId}-${params.phase}-${workspaceHash}`;
-}
-
-/**
- * Build the deterministic subagent session key used for dream narratives.
- * Sessions live in per-agent SQLite stores, so the key must name its owning agent;
- * an unscoped key cannot be resolved to a store and the whole run fails.
- */
-function buildNarrativeSessionKey(params: {
-  agentId: string;
-  workspaceDir: string;
-  phase: NarrativePhaseData["phase"];
-}): string {
-  const workspaceHash = buildNarrativeWorkspaceHash(params.workspaceDir);
-  // Keep the plugin owner in the stable key so rows created before plugin ownership was
-  // persisted cannot be reused by a memory-core run that is then forbidden to delete them.
-  return `agent:${params.agentId}:${DREAMING_SESSION_KEY_PREFIX}${DREAMING_SESSION_OWNER_KEY}-${params.phase}-${workspaceHash}`;
-}
-
 // ── Prompt building ────────────────────────────────────────────────────
 
 function buildNarrativePrompt(data: NarrativePhaseData): string {
@@ -333,7 +202,7 @@ function buildNarrativePrompt(data: NarrativePhaseData): string {
 
   const currentDate = data.currentDate?.trim();
   const recentDiaryEntries = (data.recentDiaryEntries ?? [])
-    .map(clampDiaryContextEntry)
+    .map(clampDreamDiaryContextEntry)
     .filter((entry) => entry.length > 0)
     .slice(0, RECENT_DIARY_CONTEXT_LIMIT);
   if (currentDate || recentDiaryEntries.length > 0) {
@@ -355,476 +224,12 @@ function buildNarrativePrompt(data: NarrativePhaseData): string {
   return lines.join("\n");
 }
 
-function waitForNarrativeMessagesToSettle(delayMs: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, delayMs);
-  });
-}
-
-async function readNarrativeText(params: {
-  subagent: SubagentSurface;
-  sessionKey: string;
-}): Promise<string | null> {
-  const { messages } = await params.subagent.getSessionMessages({
-    sessionKey: params.sessionKey,
-    limit: NARRATIVE_MESSAGE_FETCH_LIMIT,
-  });
-  return extractAssistantText(messages);
-}
-
-async function readSettledNarrativeText(params: {
-  subagent: SubagentSurface;
-  sessionKey: string;
-}): Promise<string | null> {
-  const immediateNarrative = await readNarrativeText(params);
-  if (immediateNarrative) {
-    return immediateNarrative;
-  }
-
-  for (const delayMs of NARRATIVE_MESSAGE_SETTLE_DELAYS_MS) {
-    await waitForNarrativeMessagesToSettle(delayMs);
-    const narrative = await readNarrativeText(params);
-    if (narrative) {
-      return narrative;
-    }
-  }
-  return null;
-}
-
-/**
- * Classifies the run result's terminal reply for diary use. The terminal
- * reply is the authoritative completion-time fact, so an explicit
- * non-visible disposition (silent/empty) means "this run produced no diary
- * text" — the transcript must not be read for it, or an older narrative from
- * a previous run could resurface (#127184 review). Only an absent terminal
- * reply (legacy runtime) falls back to the transcript.
- */
-type TerminalReplyNarrative =
-  | { kind: "visible"; text: string }
-  | { kind: "non-visible" }
-  | { kind: "absent" };
-
-function classifyTerminalReplyNarrative(
-  result: Awaited<ReturnType<SubagentSurface["waitForRun"]>>,
-): TerminalReplyNarrative {
-  const reply = result.terminalReply;
-  if (!reply) {
-    return { kind: "absent" };
-  }
-  const text =
-    reply.disposition === "visible" && typeof reply.text === "string" ? reply.text.trim() : "";
-  return text ? { kind: "visible", text } : { kind: "non-visible" };
-}
-
-// ── Date formatting ────────────────────────────────────────────────────
-
-function formatNarrativeDate(epochMs: number, timezone?: string): string {
-  const opts: Intl.DateTimeFormatOptions = {
-    timeZone: timezone ?? process.env.TZ,
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-    // Always include the timezone abbreviation so the reader knows which
-    // timezone the timestamp refers to.  Without this, users who haven't
-    // configured a timezone see bare times that look local but are actually
-    // UTC, causing confusion (see #65027).
-    timeZoneName: "short",
-  };
-  return new Intl.DateTimeFormat("en-US", opts).format(new Date(epochMs));
-}
-
-// ── DREAMS.md file I/O ─────────────────────────────────────────────────
-
-function ensureDiarySection(existing: string): string {
-  if (existing.includes(DIARY_START_MARKER) && existing.includes(DIARY_END_MARKER)) {
-    return existing;
-  }
-  const diarySection = `# Dream Diary\n\n${DIARY_START_MARKER}\n${DIARY_END_MARKER}\n`;
-  if (existing.trim().length === 0) {
-    return diarySection;
-  }
-  return diarySection + "\n" + existing;
-}
-
-function replaceDiaryContent(existing: string, diaryContent: string): string {
-  const ensured = ensureDiarySection(existing);
-  const startIdx = ensured.indexOf(DIARY_START_MARKER);
-  const endIdx = ensured.indexOf(DIARY_END_MARKER);
-  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
-    return ensured;
-  }
-  const before = ensured.slice(0, startIdx + DIARY_START_MARKER.length);
-  const after = ensured.slice(endIdx);
-  const normalized = diaryContent.trim().length > 0 ? `\n${diaryContent.trim()}\n` : "\n";
-  return before + normalized + after;
-}
-
-function splitDiaryBlocks(diaryContent: string): string[] {
-  return diaryContent
-    .split(/\n---\n/)
-    .map((block) => block.trim())
-    .filter((block) => block.length > 0);
-}
-
-function clampDiaryContextEntry(entry: string): string {
-  const normalized = entry.replace(/\s+/g, " ").trim();
-  if (normalized.length <= RECENT_DIARY_CONTEXT_MAX_CHARS) {
-    return normalized;
-  }
-  return `${truncateUtf16Safe(normalized, RECENT_DIARY_CONTEXT_MAX_CHARS).trimEnd()}...`;
-}
-
-function normalizeDiaryBlockBody(block: string): string {
-  const bodyLines: string[] = [];
-  for (const line of block.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("<!--") || trimmed.startsWith("#")) {
-      continue;
-    }
-    if (trimmed.startsWith("*") && trimmed.endsWith("*") && trimmed.length > 2) {
-      continue;
-    }
-    bodyLines.push(trimmed);
-  }
-  return clampDiaryContextEntry(bodyLines.join(" "));
-}
-
-function isOptionalDiaryContextReadError(err: unknown): boolean {
-  const code = extractErrorCode(err);
-  if (
-    code === "EACCES" ||
-    code === "EPERM" ||
-    code === "ENOENT" ||
-    code === "ENOTDIR" ||
-    code === "not-found" ||
-    code === "not-file" ||
-    code === "path-alias" ||
-    code === "path-mismatch" ||
-    code === "symlink"
-  ) {
-    return true;
-  }
-  return err instanceof Error && err.message === "path must be a regular file";
-}
-
-function getDiaryContextEntries(existing: string): string[] {
-  const startIdx = existing.indexOf(DIARY_START_MARKER);
-  const endIdx = existing.indexOf(DIARY_END_MARKER);
-  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
-    return [];
-  }
-  const inner = existing.slice(startIdx + DIARY_START_MARKER.length, endIdx);
-  return splitDiaryBlocks(inner)
-    .map(normalizeDiaryBlockBody)
-    .filter((entry) => entry.length > 0);
-}
-
-export async function readRecentDreamDiaryEntries(params: {
-  workspaceDir: string;
-  limit?: number;
-}): Promise<string[]> {
-  const limit = Math.max(0, Math.floor(params.limit ?? RECENT_DIARY_CONTEXT_LIMIT));
-  if (limit === 0) {
-    return [];
-  }
-  let existing: string;
-  try {
-    const dreamsPath = await resolveDreamsPath(params.workspaceDir);
-    existing = await readDreamsFile(dreamsPath);
-  } catch (err) {
-    if (isOptionalDiaryContextReadError(err)) {
-      return [];
-    }
-    throw err;
-  }
-  return getDiaryContextEntries(existing).slice(-limit).toReversed();
-}
-
-function normalizeDiaryBlockFingerprint(block: string): string {
-  const lines = block
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-  let dateLine = "";
-  const bodyLines: string[] = [];
-  for (const line of lines) {
-    if (!dateLine && line.startsWith("*") && line.endsWith("*") && line.length > 2) {
-      dateLine = line.slice(1, -1).trim();
-      continue;
-    }
-    if (line.startsWith("<!--") || line.startsWith("#")) {
-      continue;
-    }
-    bodyLines.push(line);
-  }
-  const normalizedDate = dateLine.replace(/\s+/g, " ").trim();
-  const normalizedBody = bodyLines
-    .join("\n")
-    .replace(/[ \t]+\n/g, "\n")
-    .trim();
-  return `${normalizedDate}\n${normalizedBody}`;
-}
-
-function joinDiaryBlocks(blocks: string[]): string {
-  if (blocks.length === 0) {
-    return "";
-  }
-  return blocks.map((block) => `---\n\n${block.trim()}\n`).join("\n");
-}
-
-function stripBackfillDiaryBlocks(existing: string): { updated: string; removed: number } {
-  const ensured = ensureDiarySection(existing);
-  const startIdx = ensured.indexOf(DIARY_START_MARKER);
-  const endIdx = ensured.indexOf(DIARY_END_MARKER);
-  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
-    return { updated: ensured, removed: 0 };
-  }
-  const inner = ensured.slice(startIdx + DIARY_START_MARKER.length, endIdx);
-  const kept: string[] = [];
-  let removed = 0;
-  for (const block of splitDiaryBlocks(inner)) {
-    if (block.includes(BACKFILL_ENTRY_MARKER)) {
-      removed += 1;
-      continue;
-    }
-    kept.push(block);
-  }
-  return {
-    updated: replaceDiaryContent(ensured, joinDiaryBlocks(kept)),
-    removed,
-  };
-}
-
-function formatBackfillDiaryDate(isoDay: string, _timezone?: string): string {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDay);
-  if (!match) {
-    return isoDay;
-  }
-  const [, year, month, day] = match;
-  const opts: Intl.DateTimeFormatOptions = {
-    // Preserve the source iso day exactly; backfill labels should not drift by timezone.
-    timeZone: "UTC",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  };
-  const epochMs = Date.UTC(Number(year), Number(month) - 1, Number(day), 12);
-  return new Intl.DateTimeFormat("en-US", opts).format(new Date(epochMs));
-}
-
-async function withNarrativeSessionLock<T>(sessionKey: string, fn: () => Promise<T>): Promise<T> {
-  let lockEntry = narrativeSessionLocks.get(sessionKey);
-  if (!lockEntry) {
-    lockEntry = { withLock: createAsyncLock(), refs: 0 };
-    narrativeSessionLocks.set(sessionKey, lockEntry);
-  }
-  lockEntry.refs += 1;
-  try {
-    return await lockEntry.withLock(fn);
-  } finally {
-    lockEntry.refs -= 1;
-    if (lockEntry.refs <= 0 && narrativeSessionLocks.get(sessionKey) === lockEntry) {
-      narrativeSessionLocks.delete(sessionKey);
-    }
-  }
-}
-
-function buildBackfillDiaryEntry(params: {
-  isoDay: string;
-  bodyLines: string[];
-  sourcePath?: string;
-  timezone?: string;
-}): string {
-  const dateStr = formatBackfillDiaryDate(params.isoDay, params.timezone);
-  const marker = `<!-- ${BACKFILL_ENTRY_MARKER} day=${params.isoDay}${params.sourcePath ? ` source=${params.sourcePath}` : ""} -->`;
-  const body = params.bodyLines
-    .map((line) => line.trimEnd())
-    .join("\n")
-    .trim();
-  return [`*${dateStr}*`, marker, body].filter((part) => part.length > 0).join("\n\n");
-}
-
-export async function writeBackfillDiaryEntries(params: {
-  workspaceDir: string;
-  entries: Array<{
-    isoDay: string;
-    bodyLines: string[];
-    sourcePath?: string;
-  }>;
-  preserveExisting?: boolean;
-  timezone?: string;
-}): Promise<{ dreamsPath: string; written: number; replaced: number }> {
-  return await updateDreamsFile({
-    workspaceDir: params.workspaceDir,
-    updater: (existing, dreamsPath) => {
-      const stripped = params.preserveExisting
-        ? { updated: existing, removed: 0 }
-        : stripBackfillDiaryBlocks(existing);
-      const startIdx = stripped.updated.indexOf(DIARY_START_MARKER);
-      const endIdx = stripped.updated.indexOf(DIARY_END_MARKER);
-      const inner =
-        startIdx >= 0 && endIdx > startIdx
-          ? stripped.updated.slice(startIdx + DIARY_START_MARKER.length, endIdx)
-          : "";
-      const preservedBlocks = splitDiaryBlocks(inner);
-      const additions = params.entries.map((entry) =>
-        buildBackfillDiaryEntry({
-          isoDay: entry.isoDay,
-          bodyLines: entry.bodyLines,
-          sourcePath: entry.sourcePath,
-          timezone: params.timezone,
-        }),
-      );
-      const existingFingerprints = new Set(
-        preservedBlocks.map((block) => normalizeDiaryBlockFingerprint(block)),
-      );
-      const appended = params.preserveExisting
-        ? additions.filter((block) => {
-            const fingerprint = normalizeDiaryBlockFingerprint(block);
-            if (existingFingerprints.has(fingerprint)) {
-              return false;
-            }
-            existingFingerprints.add(fingerprint);
-            return true;
-          })
-        : additions;
-      const nextBlocks = [...preservedBlocks, ...appended];
-      return {
-        content: replaceDiaryContent(stripped.updated, joinDiaryBlocks(nextBlocks)),
-        result: {
-          dreamsPath,
-          written: appended.length,
-          replaced: stripped.removed,
-        },
-      };
-    },
-  });
-}
-
-export async function removeBackfillDiaryEntries(params: {
-  workspaceDir: string;
-}): Promise<{ dreamsPath: string; removed: number }> {
-  return await updateDreamsFile({
-    workspaceDir: params.workspaceDir,
-    updater: (existing, dreamsPath) => {
-      const stripped = stripBackfillDiaryBlocks(existing);
-      return {
-        content: stripped.updated,
-        result: {
-          dreamsPath,
-          removed: stripped.removed,
-        },
-        shouldWrite: stripped.removed > 0 || existing.length > 0,
-      };
-    },
-  });
-}
-
-export async function dedupeDreamDiaryEntries(params: {
-  workspaceDir: string;
-}): Promise<{ dreamsPath: string; removed: number; kept: number }> {
-  return await updateDreamsFile({
-    workspaceDir: params.workspaceDir,
-    updater: (existing, dreamsPath) => {
-      const ensured = ensureDiarySection(existing);
-      const startIdx = ensured.indexOf(DIARY_START_MARKER);
-      const endIdx = ensured.indexOf(DIARY_END_MARKER);
-      if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
-        return {
-          content: ensured,
-          result: { dreamsPath, removed: 0, kept: 0 },
-          shouldWrite: false,
-        };
-      }
-      const inner = ensured.slice(startIdx + DIARY_START_MARKER.length, endIdx);
-      const blocks = splitDiaryBlocks(inner);
-      const seen = new Set<string>();
-      const keptBlocks: string[] = [];
-      let removed = 0;
-      for (const block of blocks) {
-        const fingerprint = normalizeDiaryBlockFingerprint(block);
-        if (seen.has(fingerprint)) {
-          removed += 1;
-          continue;
-        }
-        seen.add(fingerprint);
-        keptBlocks.push(block);
-      }
-      return {
-        content: replaceDiaryContent(ensured, joinDiaryBlocks(keptBlocks)),
-        result: {
-          dreamsPath,
-          removed,
-          kept: keptBlocks.length,
-        },
-        shouldWrite: removed > 0,
-      };
-    },
-  });
-}
-
-function buildDiaryEntry(narrative: string, dateStr: string): string {
-  return `\n---\n\n*${dateStr}*\n\n${narrative}\n`;
-}
-
-async function appendNarrativeEntry(params: {
-  workspaceDir: string;
-  narrative: string;
-  nowMs: number;
-  timezone?: string;
-  sourceEntryKeys?: readonly string[];
-  recentDiaryEntries?: readonly string[];
-}): Promise<string | undefined> {
-  const dateStr = formatNarrativeDate(params.nowMs, params.timezone);
-  const entry = buildDiaryEntry(params.narrative, dateStr);
-  return await updateDreamsFile<string | undefined>({
-    workspaceDir: params.workspaceDir,
-    updater: async (existing, dreamsPath) => {
-      const sourceKeys = params.sourceEntryKeys ?? [];
-      const currentSources =
-        sourceKeys.length > 0
-          ? (await readStore(params.workspaceDir, new Date(params.nowMs).toISOString())).entries
-          : undefined;
-      const currentDiary = new Set(getDiaryContextEntries(existing));
-      // The updater holds the purge lock. Model work ran outside it, so both
-      // staged inputs and prior diary quotes must survive until this commit.
-      if (
-        sourceKeys.some((key) => !currentSources?.[key]) ||
-        params.recentDiaryEntries?.some((block) => !currentDiary.has(clampDiaryContextEntry(block)))
-      ) {
-        return { content: existing, result: undefined, shouldWrite: false };
-      }
-      let updated: string;
-      if (existing.includes(DIARY_START_MARKER) && existing.includes(DIARY_END_MARKER)) {
-        const endIdx = existing.lastIndexOf(DIARY_END_MARKER);
-        updated = existing.slice(0, endIdx) + entry + "\n" + existing.slice(endIdx);
-      } else if (existing.includes(DIARY_START_MARKER)) {
-        const startIdx = existing.indexOf(DIARY_START_MARKER) + DIARY_START_MARKER.length;
-        updated =
-          existing.slice(0, startIdx) +
-          entry +
-          "\n" +
-          DIARY_END_MARKER +
-          "\n" +
-          existing.slice(startIdx);
-      } else {
-        const diarySection = `# Dream Diary\n\n${DIARY_START_MARKER}${entry}\n${DIARY_END_MARKER}\n`;
-        updated = existing.trim().length === 0 ? diarySection : `${diarySection}\n${existing}`;
-      }
-      return { content: updated, result: dreamsPath };
-    },
-  });
-}
-
 // ── Orchestrator ───────────────────────────────────────────────────────
 
 export type DreamNarrativeRequest = {
-  /** Agent that owns this workspace; the narrative session lives in its SQLite store. */
+  /** Agent whose configured model and credentials own the completion. */
   agentId: string;
-  subagent: SubagentSurface;
+  subagent: DreamingCompletion;
   workspaceDir: string;
   data: NarrativePhaseData;
   nowMs?: number;
@@ -840,239 +245,77 @@ export type DreamNarrativeOutcome =
 async function generateAndAppendDreamNarrative(
   params: DreamNarrativeRequest,
 ): Promise<DreamNarrativeOutcome> {
-  // `runDreamNarrative` is the only entry point and already dropped empty narrative data.
   const nowMs =
     typeof params.nowMs === "number" && Number.isFinite(params.nowMs) ? params.nowMs : Date.now();
-  const runKey = buildNarrativeRunKey({
-    agentId: params.agentId,
-    workspaceDir: params.workspaceDir,
-    phase: params.data.phase,
-  });
-  const sessionKey = buildNarrativeSessionKey({
-    agentId: params.agentId,
-    workspaceDir: params.workspaceDir,
-    phase: params.data.phase,
-  });
   const message = buildNarrativePrompt(params.data);
-  let cleanupFailure: string | undefined;
-  let outcome: DreamNarrativeOutcome = { status: "completed" };
-  await withNarrativeSessionLock(sessionKey, async () => {
-    const attempts: Array<{ sessionKey: string; runId: string | null }> = [];
-    let successfulSessionKey: string | null = null;
-    let terminalReply: TerminalReplyNarrative | null = null;
-    try {
-      const attemptModels = params.model ? [params.model, undefined] : [undefined];
-
-      for (const [attemptIndex, attemptModel] of attemptModels.entries()) {
-        const attemptSessionKey = buildNarrativeAttemptKey(sessionKey, attemptIndex);
-        const attemptRunKey = buildNarrativeAttemptKey(runKey, attemptIndex);
-        const attempt = { sessionKey: attemptSessionKey, runId: null as string | null };
-        attempts.push(attempt);
-
-        try {
-          // Clear stale context from a previous failed cleanup before reusing any stable attempt key.
-          try {
-            await params.subagent.deleteSession({ sessionKey: attemptSessionKey });
-          } catch (preCleanupErr) {
-            if (!isRequestScopedSubagentRuntimeError(preCleanupErr)) {
-              cleanupFailure = formatErrorMessage(preCleanupErr);
-              params.logger.warn(
-                `memory-core: narrative pre-cleanup failed for ${params.data.phase} phase: ${cleanupFailure}`,
-              );
-            }
-          }
-
-          const runId = await startNarrativeRunOrFallback({
-            ...params,
-            sessionKey: attemptSessionKey,
-            runKey: attemptRunKey,
-            message,
-            nowMs,
-            model: attemptModel,
-          });
-          if (!runId) {
-            return;
-          }
-          attempt.runId = runId;
-
-          const result = await params.subagent.waitForRun({
-            runId,
-            timeoutMs: NARRATIVE_TIMEOUT_MS,
-          });
-
-          if (result.status === "ok") {
-            successfulSessionKey = attemptSessionKey;
-            terminalReply = classifyTerminalReplyNarrative(result);
-            break;
-          }
-
-          if (
-            attemptModel &&
-            result.status === "error" &&
-            isConfiguredModelUnavailableNarrativeError(result.error ?? "")
-          ) {
-            params.logger.warn(
-              `memory-core: narrative generation ended with ${formatNarrativeTerminalStatus({
-                status: result.status,
-                error: result.error,
-              })} for ${params.data.phase} phase using configured model "${attemptModel}"; retrying with the session default.`,
-            );
-            continue;
-          }
-
-          params.logger.warn(
-            `memory-core: narrative generation ended with ${formatNarrativeTerminalStatus({
-              status: result.status,
-              error: result.error,
-            })} for ${params.data.phase} phase; writing fallback diary entry.`,
-          );
-          await appendFallbackNarrativeEntry({
-            ...params,
-            nowMs,
-            reason: `the narrative run ended with ${formatNarrativeTerminalStatus({
-              status: result.status,
-              error: result.error,
-            })}`,
-          });
-          return;
-        } catch (err) {
-          if (attemptModel && isConfiguredModelUnavailableNarrativeError(formatErrorMessage(err))) {
-            params.logger.warn(
-              `memory-core: narrative generation could not start with configured model "${attemptModel}" for ${params.data.phase} phase; retrying with the session default (${formatErrorMessage(err)}).`,
-            );
-            continue;
-          }
-          throw err;
-        }
-      }
-
-      if (!successfulSessionKey) {
-        return;
-      }
-
-      // Prefer the terminal reply the run registry captured at completion time.
-      // A visible reply is immune to the sibling-cleanup race (#123360); an
-      // explicit non-visible reply is authoritative no-text and must not read
-      // history (an older narrative could resurface); only an absent reply
-      // (legacy runtime) falls back to polling the session store.
-      const narrative =
-        terminalReply?.kind === "visible"
-          ? terminalReply.text
-          : terminalReply?.kind === "absent"
-            ? await readSettledNarrativeText({
-                subagent: params.subagent,
-                sessionKey: successfulSessionKey,
-              })
-            : null;
-      if (!narrative) {
-        params.logger.warn(
-          `memory-core: narrative generation produced no text for ${params.data.phase} phase; writing fallback diary entry.`,
-        );
-        await appendFallbackNarrativeEntry({
-          ...params,
-          nowMs,
-          reason: "the narrative run produced no text",
+  try {
+    const attemptModels = params.model ? [params.model, undefined] : [undefined];
+    let narrative = "";
+    for (const model of attemptModels) {
+      try {
+        const result = await params.subagent.complete({
+          agentId: params.agentId,
+          message,
+          extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
+          ...(model ? { model } : {}),
+          timeoutMs: NARRATIVE_TIMEOUT_MS,
         });
-        return;
-      }
-
-      const dreamsPath = await appendNarrativeEntry({
-        workspaceDir: params.workspaceDir,
-        narrative,
-        nowMs,
-        timezone: params.timezone,
-        sourceEntryKeys: params.data.sourceEntryKeys,
-        recentDiaryEntries: params.data.recentDiaryEntries,
-      });
-      if (dreamsPath === undefined) {
-        outcome = { status: "skipped" };
-        params.logger.info(
-          `memory-core: narrative publication skipped for ${params.data.phase} phase because source memory or diary context changed.`,
+        narrative = result.text.trim();
+        break;
+      } catch (error) {
+        if (!model || !isConfiguredModelUnavailableNarrativeError(error)) {
+          throw error;
+        }
+        params.logger.warn(
+          `memory-core: narrative generation could not use configured model "${model}" for ${params.data.phase} phase; retrying with the agent default (${formatErrorMessage(error)}).`,
         );
-        return;
       }
-
-      params.logger.info(
-        `memory-core: dream diary entry written for ${params.data.phase} phase [workspace=${params.workspaceDir}].`,
-      );
-    } catch (err) {
-      // Narrative generation is best-effort — never fail the parent phase. Still write the
-      // fallback entry the terminal-status and empty-text branches write, so an unexpected
-      // failure leaves a visible diary trace instead of an untouched DREAMS.md.
+    }
+    if (!narrative) {
       params.logger.warn(
-        `memory-core: narrative generation failed for ${params.data.phase} phase: ${formatErrorMessage(err)}`,
+        `memory-core: narrative generation produced no text for ${params.data.phase} phase; writing fallback diary entry.`,
       );
       await appendFallbackNarrativeEntry({
         ...params,
         nowMs,
-        reason: `the narrative run failed (${formatErrorMessage(err)})`,
+        reason: "the narrative run produced no text",
       });
-    } finally {
-      // Only cleanup after a run was accepted. Request-scoped fallback writes a
-      // local diary entry without creating a subagent session.
-      const cleanedSessionKeys = new Set<string>();
-      for (const attempt of attempts) {
-        if (!attempt.runId || cleanedSessionKeys.has(attempt.sessionKey)) {
-          continue;
-        }
-        cleanedSessionKeys.add(attempt.sessionKey);
-        try {
-          await params.subagent.deleteSession({ sessionKey: attempt.sessionKey });
-        } catch (cleanupErr) {
-          cleanupFailure = formatErrorMessage(cleanupErr);
-          params.logger.warn(
-            `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${cleanupFailure}`,
-          );
-        }
-      }
-
-      await scrubDreamingNarrativeArtifacts({
-        agentId: params.agentId,
-        config: getRuntimeConfig(),
-        logger: params.logger,
-      }).catch((scrubErr: unknown) => {
-        cleanupFailure = formatErrorMessage(scrubErr);
-        params.logger.warn(
-          `memory-core: dreaming cleanup scrub failed for ${params.data.phase} phase: ${cleanupFailure}`,
-        );
-      });
+      return { status: "degraded", error: "the narrative run produced no text" };
     }
-  });
-  return cleanupFailure ? { status: "degraded", error: cleanupFailure } : outcome;
-}
-
-// ── Detached narrative concurrency limit ───────────────────────────────
-//
-// Cron-driven dreaming detaches narrative generation across light, REM, and
-// deep phases for every workspace, so a 10-workspace cron sweep used to fire
-// 30 concurrent narrative subagents at once. Each one holds the session
-// write-lock while it runs and burns a model slot, which caused lock
-// contention (>30 s) and cascading narrative timeouts (#73198).
-//
-// `runDetachedNarrativeJob` caps total in-flight detached narratives across
-// phases/workspaces so cron sweeps cannot exhaust model and session-lock slots.
-const DETACHED_NARRATIVE_CONCURRENCY = 3;
-const detachedNarrativeLimit = pLimit(DETACHED_NARRATIVE_CONCURRENCY);
-
-function runDetachedNarrativeJob(params: {
-  job: () => Promise<DreamNarrativeOutcome>;
-  logger: Logger;
-  phase: NarrativePhaseData["phase"];
-  workspaceDir: string;
-}): void {
-  queueMicrotask(() => {
-    void detachedNarrativeLimit(params.job)
-      .then((outcome) => {
-        if (outcome.status === "degraded") {
-          params.logger.warn(
-            `memory-core: detached dreaming narrative degraded for ${params.phase} phase [workspace=${params.workspaceDir}]: ${outcome.error}`,
-          );
-        }
-      })
-      .catch(() => {
-        // Unexpected failures are logged by the narrative job before reaching this boundary.
-      });
-  });
+    const dreamsPath = await appendNarrativeEntry({
+      workspaceDir: params.workspaceDir,
+      narrative,
+      nowMs,
+      timezone: params.timezone,
+      sourceEntryKeys: params.data.sourceEntryKeys,
+      recentDiaryEntries: params.data.recentDiaryEntries,
+    });
+    if (dreamsPath === undefined) {
+      params.logger.info(
+        `memory-core: narrative publication skipped for ${params.data.phase} phase because source memory or diary context changed.`,
+      );
+      return { status: "skipped" };
+    }
+    params.logger.info(
+      `memory-core: dream diary entry written for ${params.data.phase} phase [workspace=${params.workspaceDir}].`,
+    );
+  } catch (error) {
+    const requestScoped = isRequestScopedSubagentRuntimeError(error);
+    if (!requestScoped) {
+      params.logger.warn(
+        `memory-core: narrative generation failed for ${params.data.phase} phase: ${formatErrorMessage(error)}`,
+      );
+    }
+    await appendFallbackNarrativeEntry({
+      ...params,
+      nowMs,
+      reason: requestScoped
+        ? "subagent runtime is request-scoped"
+        : `the narrative run failed (${formatErrorMessage(error)})`,
+    });
+    return { status: "degraded", error: formatErrorMessage(error) };
+  }
+  return { status: "completed" };
 }
 
 /**
@@ -1089,7 +332,7 @@ export async function runDreamNarrative(
   if (rest.data.snippets.length === 0 && !rest.data.promotions?.length) {
     return { status: "skipped" };
   }
-  // Narrative sessions are stored per agent, so an ownerless sweep cannot start one.
+  // Model and credential selection requires the workspace's owning agent.
   // Write the local diary fallback instead of skipping the entry without a trace, and
   // keep it on the same dispatch so a detached cron sweep never awaits a diary write.
   const job = agentId
@@ -1104,14 +347,15 @@ export async function runDreamNarrative(
         return { status: "completed" as const };
       };
   if (detached) {
-    runDetachedNarrativeJob({
-      job,
-      logger: rest.logger,
-      phase: rest.data.phase,
-      workspaceDir: rest.workspaceDir,
+    // The shared runtime queue bounds inference; the sweep never waits for diary publication.
+    queueMicrotask(() => {
+      void job().catch((error: unknown) => {
+        rest.logger.warn(
+          `memory-core: detached dreaming narrative failed for ${rest.data.phase} phase: ${formatErrorMessage(error)}`,
+        );
+      });
     });
     return { status: "pending" };
   }
   return await job();
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -333,24 +333,15 @@ function createHarness(
 }
 
 function createMockNarrativeSubagent(response = "The archive hummed softly.") {
-  const run = vi.fn(async (_params: { sessionKey: string; message: string; model?: string }) => ({
-    runId: "dream-run-1",
-  }));
-  const waitForRun = vi.fn(async () => ({ status: "ok" }));
-  const getSessionMessages = vi.fn(async () => ({
-    messages: [{ role: "assistant", content: response }],
-  }));
-  const deleteSession = vi.fn(async () => {});
   return {
-    run,
-    waitForRun,
-    getSessionMessages,
-    deleteSession,
+    complete: vi.fn(async (_params: { agentId: string; message: string; model?: string }) => ({
+      text: response,
+    })),
   };
 }
 
 function firstNarrativeRun(subagent: ReturnType<typeof createMockNarrativeSubagent>) {
-  const firstRun = subagent.run.mock.calls[0]?.[0];
+  const firstRun = subagent.complete.mock.calls[0]?.[0];
   if (!firstRun) {
     throw new Error("expected narrative subagent run");
   }
@@ -557,41 +548,7 @@ describe("memory-core dreaming phases", () => {
     expect(Object.keys(phaseSignals.entries)).toEqual(["valid"]);
   });
 
-  it("uses the hashed narrative session key for sweep-level fallback cleanup", async () => {
-    const workspaceDir = await createDreamingWorkspace();
-    await writeDailyNote(workspaceDir, [
-      `# ${DREAMING_TEST_DAY}`,
-      "",
-      "- Move backups to S3 Glacier.",
-      "- Keep retention at 365 days.",
-    ]);
-    const testConfig = createNarrativeDreamingSweepConfig(workspaceDir);
-    const subagent = createMockNarrativeSubagent("The archive hummed softly.");
-    const logger = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
-    const nowMs = Date.parse("2026-04-05T10:05:00.000Z");
-    const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `agent:main:dreaming-narrative-memory-core-v2-light-${workspaceHash}`;
-
-    await runDreamingSweepPhases({
-      agentId: "main",
-      workspaceDir,
-      cfg: testConfig,
-      pluginConfig: resolveMemoryDreamingPluginConfig(testConfig),
-      logger,
-      subagent,
-      nowMs,
-    });
-
-    expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
-    expect(subagent.deleteSession).toHaveBeenNthCalledWith(1, { sessionKey: expectedSessionKey });
-    expect(subagent.deleteSession).toHaveBeenNthCalledWith(2, { sessionKey: expectedSessionKey });
-  });
-
-  it("suppresses cleanup warnings during request-scoped narrative fallback", async () => {
+  it("leaves a generic diary trace when completion is unavailable", async () => {
     const workspaceDir = await createDreamingWorkspace();
     await writeDailyNote(workspaceDir, [
       `# ${DREAMING_TEST_DAY}`,
@@ -601,10 +558,7 @@ describe("memory-core dreaming phases", () => {
     ]);
     const testConfig = createNarrativeDreamingSweepConfig(workspaceDir);
     const subagent = createMockNarrativeSubagent();
-    subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
-    subagent.deleteSession.mockImplementation(() => {
-      throw new RequestScopedSubagentRuntimeError();
-    });
+    subagent.complete.mockRejectedValue(new RequestScopedSubagentRuntimeError());
     const logger = {
       info: vi.fn(),
       warn: vi.fn(),
@@ -621,7 +575,7 @@ describe("memory-core dreaming phases", () => {
         subagent,
         nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
       }),
-    ).resolves.toEqual({ degradedPhases: 0, pendingNarratives: 0 });
+    ).resolves.toEqual({ degradedPhases: 1, pendingNarratives: 0 });
 
     const dreams = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(dreams).toContain("A memory trace surfaced, but details were unavailable in this run.");
@@ -629,9 +583,6 @@ describe("memory-core dreaming phases", () => {
     expect(logger.error).not.toHaveBeenCalled();
     expectIncludesSubstring(mockStringMessages(logger.info), "request-scoped");
     expectNotIncludesSubstring(mockStringMessages(logger.warn), "request-scoped");
-    expectNotIncludesSubstring(mockStringMessages(logger.warn), "narrative pre-cleanup");
-    expectNotIncludesSubstring(mockStringMessages(logger.warn), "narrative session cleanup failed");
-    expect(subagent.deleteSession).toHaveBeenCalledOnce();
   });
 
   it("does not re-ingest managed light dreaming blocks from daily notes", async () => {
@@ -2891,7 +2842,7 @@ describe("memory-core dreaming phases", () => {
       await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
     });
 
-    expect(subagent.run).toHaveBeenCalledTimes(1);
+    expect(subagent.complete).toHaveBeenCalledTimes(1);
     const firstRun = firstNarrativeRun(subagent);
     expect(firstRun.message).toContain("Move backups to S3 Glacier.");
     expect(firstRun.message).toContain("Keep retention at 365 days.");
@@ -2950,8 +2901,8 @@ describe("memory-core dreaming phases", () => {
       );
     });
 
-    expect(subagent.run).toHaveBeenCalledTimes(2);
-    for (const [run] of subagent.run.mock.calls) {
+    expect(subagent.complete).toHaveBeenCalledTimes(2);
+    for (const [run] of subagent.complete.mock.calls) {
       expect(run.message).toContain("Keep the owner-approved backup plan.");
       expect(run.message).not.toContain("Run the restricted stored instruction.");
     }
@@ -3010,7 +2961,7 @@ describe("memory-core dreaming phases", () => {
       );
     });
 
-    expect(subagent.run).toHaveBeenCalledTimes(1);
+    expect(subagent.complete).toHaveBeenCalledTimes(1);
     const firstRun = firstNarrativeRun(subagent);
     expect(firstRun.message).toContain("Move backups to S3 Glacier.");
     expect(firstRun.message).toContain("Keep retention at 365 days.");

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -19,6 +19,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeConceptToken } from "./concept-vocabulary.js";
 import { isPromotionOriginBlocked } from "./dreaming-consolidation-candidates.js";
+import { readRecentDreamDiaryEntries } from "./dreaming-dreams-file.js";
 import { appendFailedDreamingEvent } from "./dreaming-events.js";
 import {
   normalizeDailyIngestionState,
@@ -30,7 +31,6 @@ import { writeDailyDreamingPhaseBlock } from "./dreaming-markdown.js";
 import {
   type DreamNarrativeRequest,
   type DreamNarrativeOutcome,
-  readRecentDreamDiaryEntries,
   type NarrativePhaseData,
   runDreamNarrative,
 } from "./dreaming-narrative.js";
@@ -1545,7 +1545,7 @@ type DreamingSweepPhaseResult = {
 
 export async function runDreamingSweepPhases(params: {
   /**
-   * Agent that owns this workspace; narrative subagent sessions are stored under it.
+   * Agent whose model and credentials own this workspace's narrative completions.
    * Absent only when no roster or triggering agent can be attributed, which downgrades
    * narratives to the local diary fallback without stopping the sweep.
    */
@@ -1558,7 +1558,7 @@ export async function runDreamingSweepPhases(params: {
   detachNarratives?: boolean;
   nowMs?: number;
 }): Promise<DreamingSweepPhaseResult> {
-  // Normalize nowMs once so all phase timestamps and narrative session keys are consistent.
+  // All phases in one sweep share the same observation and report timestamp.
   const sweepNowMs =
     typeof params.nowMs === "number" && Number.isFinite(params.nowMs) ? params.nowMs : Date.now();
   const admissionPolicy = resolveAdmissionPolicy(params.pluginConfig);

--- a/extensions/memory-core/src/dreaming-session-cleanup.ts
+++ b/extensions/memory-core/src/dreaming-session-cleanup.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { cleanupSessionLifecycleArtifacts } from "openclaw/plugin-sdk/session-store-runtime";
 
-export const DREAMING_SESSION_KEY_PREFIX = "dreaming-narrative-";
+const DREAMING_SESSION_KEY_PREFIX = "dreaming-narrative-";
 export const DREAMING_ORPHAN_MIN_AGE_MS = 300_000;
 const DREAMING_TRANSCRIPT_RUN_MARKER = '"runId":"dreaming-narrative-';
 

--- a/extensions/memory-core/src/dreaming-shared.ts
+++ b/extensions/memory-core/src/dreaming-shared.ts
@@ -1,38 +1,7 @@
 // Memory Core plugin module implements dreaming shared behavior.
-import {
-  asNullableRecord,
-  normalizeOptionalString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 export { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-
-export function extractAssistantText(messages: unknown[]): string | null {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = asNullableRecord(messages[index]);
-    if (message?.role !== "assistant") {
-      continue;
-    }
-    if (typeof message.content === "string" && message.content.trim()) {
-      return message.content.trim();
-    }
-    if (Array.isArray(message.content)) {
-      const text = message.content
-        .flatMap((part) => {
-          const item = asNullableRecord(part);
-          return (item?.type === "text" || item?.type === "output_text") &&
-            typeof item.text === "string"
-            ? [item.text]
-            : [];
-        })
-        .join("\n")
-        .trim();
-      if (text) {
-        return text;
-      }
-    }
-  }
-  return null;
-}
 
 export function includesSystemEventToken(cleanedBody: string, eventText: string): boolean {
   const normalizedBody = normalizeOptionalString(cleanedBody);

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -570,8 +570,8 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
   const recencyHalfLifeDays =
     params.config.recencyHalfLifeDays ?? DEFAULT_MEMORY_DREAMING_RECENCY_HALF_LIFE_DAYS;
   const fallbackWorkspaceDir = normalizeOptionalString(params.workspaceDir);
-  // Narrative subagent sessions live in per-agent SQLite stores, so every swept workspace
-  // carries its owning agent. The triggering agent owns whatever the roster cannot attribute.
+  // Each completion uses its workspace owner's model and credentials. The triggering
+  // agent owns whatever the roster cannot attribute.
   const triggerAgentId = normalizeLowercaseStringOrEmpty(params.agentId);
   const seenWorkspaces = new Set<string>();
   const workspaces: Array<{ agentId?: string; agentIds: readonly string[]; workspaceDir: string }> =
@@ -1036,6 +1036,8 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
     generation: number,
     startupStartedAtMs: number,
   ): Promise<void> => {
+    // Previous releases persisted narrative sessions. Reclaim those historical artifacts
+    // at startup; new prompt-only completions create no sessions to scrub.
     const { DREAMING_ORPHAN_MIN_AGE_MS, scrubDreamingNarrativeArtifacts } =
       await import("./dreaming-session-cleanup.js");
     if (disposed || generation !== gatewayLifecycleGeneration) {

--- a/extensions/memory-core/src/memory-forget-consolidation.test.ts
+++ b/extensions/memory-core/src/memory-forget-consolidation.test.ts
@@ -157,12 +157,7 @@ describe("memory forget", () => {
         ],
       });
       const subagent = {
-        run: vi.fn(async () => ({ runId: "shared-consolidation" })),
-        waitForRun: vi.fn(async () => ({ status: "ok" })),
-        getSessionMessages: vi.fn(async () => ({
-          messages: [{ role: "assistant", content: output }],
-        })),
-        deleteSession: vi.fn(async () => undefined),
+        complete: vi.fn(async () => ({ text: output })),
       };
 
       if (failOrigins) {

--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -14,7 +14,7 @@ import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/se
 import { openOpenClawAgentDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { writeBackfillDiaryEntries } from "./dreaming-narrative.js";
+import { writeBackfillDiaryEntries } from "./dreaming-dreams-file.js";
 import {
   clearMemoryCoreWorkspaceNamespace,
   SESSION_BACKFILL_REWIND_NAMESPACE,

--- a/extensions/memory-core/src/session-backfill.ts
+++ b/extensions/memory-core/src/session-backfill.ts
@@ -1,8 +1,8 @@
 import path from "node:path";
 import { listSessionTranscriptCorpusEntriesForAgent } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+import { removeBackfillDiaryEntries, writeBackfillDiaryEntries } from "./dreaming-dreams-file.js";
 import type { SessionIngestionFileState } from "./dreaming-ingestion-state.js";
-import { removeBackfillDiaryEntries, writeBackfillDiaryEntries } from "./dreaming-narrative.js";
 import {
   listMemorySessionTombstones,
   recordMemoryEntryOrigins,

--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -389,7 +389,6 @@ export async function applyShortTermPromotions(
       ? await consolidateMemory({
           agentId: options.agentId,
           subagent: options.consolidation.subagent,
-          workspaceDir,
           existingMemory,
           candidates: toAppend,
           ...(options.consolidation.model ? { model: options.consolidation.model } : {}),

--- a/extensions/memory-core/src/short-term-promotion-owner.test.ts
+++ b/extensions/memory-core/src/short-term-promotion-owner.test.ts
@@ -17,17 +17,6 @@ function resultEntryFor(promoted: PromotionCandidate): string {
   return `- ${promoted.snippet} Source: ${promoted.path}#L${promoted.startLine}-L${promoted.endLine} ${buildPromotionRecallAnnotations(promoted)}`;
 }
 
-function createSubagent(output: string) {
-  return {
-    run: vi.fn(async (_options: unknown) => ({ runId: "run-1" })),
-    waitForRun: vi.fn(async () => ({ status: "ok" })),
-    getSessionMessages: vi.fn(async () => ({
-      messages: [{ role: "assistant", content: output }],
-    })),
-    deleteSession: vi.fn(async (_options: unknown) => undefined),
-  };
-}
-
 async function recordConsolidationRecall(workspaceDir: string) {
   await recordShortTermRecalls({
     workspaceDir,
@@ -59,7 +48,7 @@ async function recordConsolidationRecall(workspaceDir: string) {
 }
 
 describe("short-term promotion consolidation ownership", () => {
-  it("uses the promotion owner for the consolidation session lifecycle", async () => {
+  it("uses the promotion owner for consolidation inference", async () => {
     const workspaceDir = await createTempWorkspace("memory-consolidation-owner-");
     const notePath = path.join(workspaceDir, "memory", "2026-07-01.md");
     await fs.mkdir(path.dirname(notePath), { recursive: true });
@@ -74,7 +63,7 @@ describe("short-term promotion consolidation ownership", () => {
       memory: `# Memory\n\n${resultEntry}\n`,
       operations: [{ candidateKey: promoted.key, action: "added", resultEntry, priorEntries: [] }],
     });
-    const subagent = createSubagent(output);
+    const subagent = { complete: vi.fn(async () => ({ text: output })) };
 
     const applied = await applyShortTermPromotions({
       agentId: "researcher",
@@ -88,14 +77,9 @@ describe("short-term promotion consolidation ownership", () => {
     });
 
     expect(applied).toMatchObject({ applied: 1, appended: 1 });
-    const runOptions = subagent.run.mock.calls[0]?.[0] as { sessionKey?: string } | undefined;
-    const sessionKey = runOptions?.sessionKey;
-    if (!sessionKey) {
-      throw new Error("expected consolidation session key");
-    }
-    expect(sessionKey).toMatch(/^agent:researcher:/u);
-    expect(subagent.getSessionMessages).toHaveBeenCalledWith({ sessionKey, limit: 5 });
-    expect(subagent.deleteSession).toHaveBeenCalledWith({ sessionKey });
+    expect(subagent.complete).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "researcher" }),
+    );
     const memory = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf8");
     expect(memory).toContain("## Consolidated Memory");
     expect(memory).not.toContain("## Promoted From Short-Term Memory");

--- a/extensions/memory-core/src/short-term-promotion-types.ts
+++ b/extensions/memory-core/src/short-term-promotion-types.ts
@@ -189,7 +189,7 @@ export type ApplyShortTermPromotionsOptions = {
   maxPromotedSnippetTokens?: number;
   maxPriorEntryLossFraction?: number;
   consolidation?: {
-    subagent?: import("./dreaming-narrative.js").SubagentSurface;
+    subagent?: import("./dreaming-narrative.js").DreamingCompletion;
     model?: string;
     logger: {
       info: (message: string) => void;

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -529,6 +529,8 @@ export async function executePluginOwnedProcess(params: {
         claimResources: params.context.preparedBackend.claimLiveSessionResources,
       });
     }
+    run.assertCurrent?.();
+    signal.throwIfAborted();
     const execution = params.execute({
       command,
       args: params.executionArgs,

--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -179,6 +179,7 @@ export async function executeCliProcess(params: {
   const pluginTimeout: { error?: FailoverError } = {};
   let terminalInterruption: CliTerminalInterruption | undefined;
   let result: RunExit;
+  runParams.assertCurrent?.();
   params.diagnostics?.observeRequestPayload(params.stdin ?? params.argsPrompt ?? "");
   if (params.nodePlacement) {
     const nodeRun = await executeNodeClaudeRun({
@@ -265,6 +266,7 @@ export async function executeCliProcess(params: {
     try {
       const managedRun = await supervisor.spawn({
         runId: runParams.runId,
+        assertCurrent: runParams.assertCurrent,
         sessionId: runParams.sessionId,
         backendId: context.backendResolved.id,
         scopeKey,

--- a/src/agents/cli-runner/execute.pending-cancellation.test.ts
+++ b/src/agents/cli-runner/execute.pending-cancellation.test.ts
@@ -122,6 +122,89 @@ describe("local CLI pending process cancellation", () => {
     vi.restoreAllMocks();
   });
 
+  it.each(["process", "plugin"] as const)(
+    "rejects expired authority after CLI preparation before %s execution",
+    async (target) => {
+      const entered = createDeferred();
+      const prepared = createDeferred();
+      const context = createRunContext({
+        runId: `expired-${target}`,
+        beforeExecution: async () => {
+          entered.resolve();
+          await prepared.promise;
+        },
+      });
+      let current = true;
+      context.params.assertCurrent = () => {
+        if (!current) {
+          throw new Error("Completion authority expired");
+        }
+      };
+      const pluginExecute = vi.fn(async function* () {
+        yield { type: "result", result: "unexpected" };
+      });
+      if (target === "plugin") {
+        context.preparedBackend.backend.command = process.execPath;
+        context.executionTarget = { kind: "plugin", execute: pluginExecute };
+      }
+      const adapter = createTestAdapter();
+      adapter.settle(0);
+      createChildAdapterMock.mockResolvedValueOnce(adapter);
+
+      const run = executePreparedCliRun(context);
+      const rejected = expect(run).rejects.toThrow("Completion authority expired");
+      await entered.promise;
+      current = false;
+      prepared.resolve();
+
+      await rejected;
+      expect(createChildAdapterMock).not.toHaveBeenCalled();
+      expect(pluginExecute).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects expired authority behind a supervisor scope fence without replacing its process", async () => {
+    const context = createRunContext({ runId: "expired-replacement" });
+    let current = true;
+    context.params.assertCurrent = () => {
+      if (!current) {
+        throw new Error("Completion authority expired");
+      }
+    };
+    const scopeKey = buildCliSupervisorScopeKey({
+      backend: context.preparedBackend.backend,
+      backendId: context.backendResolved.id,
+      cliSessionId: "resume-1",
+    });
+    const startup = createDeferred<ChildAdapter>();
+    const adapter = createTestAdapter();
+    createChildAdapterMock.mockReturnValueOnce(startup.promise);
+    const spawn = vi.spyOn(supervisor, "spawn");
+    const first = supervisor.spawn({
+      runId: "surviving-process",
+      sessionId: context.params.sessionId,
+      backendId: context.backendResolved.id,
+      scopeKey,
+      mode: "child",
+      argv: ["agent-cli"],
+    });
+    const replacement = executePreparedCliRun(context, "resume-1");
+    const rejected = expect(replacement).rejects.toThrow("Completion authority expired");
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2));
+    current = false;
+    startup.resolve(adapter);
+
+    const firstRun = await first;
+    try {
+      await rejected;
+      expect(createChildAdapterMock).toHaveBeenCalledOnce();
+      expect(adapter.kill).not.toHaveBeenCalled();
+    } finally {
+      firstRun.cancel();
+      await firstRun.wait();
+    }
+  });
+
   it("preserves the caller run id and cleans up cancellation after normal completion", async () => {
     const controller = new AbortController();
     const adapter = createTestAdapter();

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -277,6 +277,8 @@ export type RunCliAgentParams = {
   };
   disableTools?: boolean;
   abortSignal?: AbortSignal;
+  /** Revalidate the exact caller authority immediately before external execution. */
+  assertCurrent?: () => void;
   onPartialReply?: (payload: PartialReplyPayload) => boolean | void | Promise<boolean | void>;
   onBlockReply?: (payload: BlockReplyPayload, context?: BlockReplyContext) => void | Promise<void>;
   onExecutionStarted?: () => void;

--- a/src/agents/embedded-agent-runner/lanes.test.ts
+++ b/src/agents/embedded-agent-runner/lanes.test.ts
@@ -25,7 +25,7 @@ describe("resolveGlobalLane", () => {
       ["main", CommandLane.Main],
       ["subagent", CommandLane.Subagent],
       ["cron-nested", CommandLane.CronNested],
-      ["skill-workshop-review", CommandLane.SkillWorkshopReview],
+      ["background:core:review", "background:core:review"],
       ["nested", CommandLane.Nested],
       ["custom-lane", "custom-lane"],
       [" custom ", "custom"],

--- a/src/agents/embedded-agent-runner/run/lane-controller.queue-liveness.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.queue-liveness.test.ts
@@ -312,11 +312,10 @@ describe("queued embedded run context liveness", () => {
 
         abort.abort(new Error("queued run canceled"));
         expect(isAgentRunWaitingForCapacity(params.runId)).toBe(false);
-        expect(getCommandLaneSnapshot(blockedLane).queuedCount).toBe(1);
+        expect(getCommandLaneSnapshot(blockedLane).queuedCount).toBe(0);
         expect(sweepStaleRunContexts()).toBe(1);
         expect(getAgentRunContext(params.runId)).toBeUndefined();
 
-        setCommandLaneConcurrency(blockedLane, 1);
         await expect(run).rejects.toThrow("queued run canceled");
       } finally {
         setCommandLaneConcurrency(blockedLane, 1);

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -11,6 +11,7 @@ import {
   getAgentRunContext,
   retainQueuedAgentRunContext,
 } from "../../../infra/agent-run-registry.js";
+import { isBackgroundWorkLane } from "../../../process/background-work.js";
 import {
   enqueueCommandInLane,
   getCommandLaneSnapshot,
@@ -204,6 +205,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     withEmbeddedRunLaneTimeout(
       {
         ...opts,
+        abortSignal,
         taskTimeoutProgressAtMs: () => laneTaskProgressAtMs,
         taskTimeoutSubscribe: (onDeadline) => {
           notifyLaneTaskDeadline = onDeadline;
@@ -256,7 +258,9 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     options.getParams().replyOperation?.markWaitingForGlobalLane();
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
-      priority: sessionLanePolicy.priority,
+      priority: isBackgroundWorkLane(options.globalLane)
+        ? "background"
+        : sessionLanePolicy.priority,
       onQueued: noteCapacityWait,
     };
     const taskWithCurrentLifecycle = async () => {
@@ -354,6 +358,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
   const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
     const sessionOpts: CommandQueueEnqueueOptions = {
       ...opts,
+      abortSignal,
       priority: sessionLanePolicy.priority,
       onQueued: noteCapacityWait,
     };

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -169,6 +169,8 @@ type AgentHarnessIsolatedCompletionParams = {
   prompt: string;
   timeoutMs: number;
   abortSignal?: AbortSignal;
+  /** Revalidate the captured caller immediately before inference I/O, including retries. */
+  assertCurrent?: () => void;
   thinkLevel?: import("../../auto-reply/thinking.js").ThinkLevel;
   /** Do not recover ambiguous reasoning as visible text; an empty visible result is valid. */
   outputTextPolicy?: "strict-visible";

--- a/src/agents/host-prepared-isolated-completion.ts
+++ b/src/agents/host-prepared-isolated-completion.ts
@@ -16,6 +16,7 @@ export async function runHostPreparedIsolatedCompletion(
     ? AbortSignal.any([params.abortSignal, timeoutSignal])
     : timeoutSignal;
   const assistant = await completeWithPreparedSimpleCompletionModel({
+    assertCurrent: params.assertCurrent,
     model: params.authorization.model,
     auth: params.authorization.auth,
     cfg: params.config,

--- a/src/agents/isolated-completion.test.ts
+++ b/src/agents/isolated-completion.test.ts
@@ -204,6 +204,51 @@ function registerHarness(overrides: Partial<AgentHarness>): void {
 }
 
 describe("runIsolatedCompletion", () => {
+  it.each(["legacy", "v2"])(
+    "rejects expired authority after %s host authorization before harness egress",
+    async (version) => {
+      const preparing = createDeferred();
+      const finishPreparation = createDeferred();
+      const expired = new Error("completion owner retired");
+      let active = true;
+      mocks.prepareSimpleCompletionModel.mockImplementationOnce(async () => {
+        preparing.resolve();
+        await finishPreparation.promise;
+        return {
+          model: { provider: "test-provider", id: "test-model", api: "openai-responses" },
+          auth: { apiKey: "test-key", source: "test-profile", mode: "api-key" },
+        };
+      });
+      const run = vi.fn(async () => ({
+        assistant: assistant([{ type: "text", text: "must not be generated" }]),
+      }));
+      registerHarness({
+        id: "test-runtime",
+        ...(version === "legacy"
+          ? { runIsolatedCompletion: run }
+          : { runIsolatedCompletionV2: run }),
+      });
+      const result = runIsolatedCompletion({
+        ...request(),
+        agentHarnessRuntimeOverride: "test-runtime",
+        assertCurrent: () => {
+          if (!active) {
+            throw expired;
+          }
+        },
+      }).then(
+        (value) => ({ value }),
+        (error: unknown) => ({ error }),
+      );
+      await preparing.promise;
+      active = false;
+      finishPreparation.resolve();
+      expect(await result).toEqual({ error: expired });
+      expect(run).not.toHaveBeenCalled();
+      expect(releaseRuntimeLease).toHaveBeenCalledOnce();
+    },
+  );
+
   it.each(["claude-cli", "anthropic"])(
     "keeps the CLI execution owner for a %s utility model without resolving HTTP credentials",
     async (provider) => {
@@ -299,76 +344,98 @@ describe("runIsolatedCompletion", () => {
     );
   });
 
-  it("keeps automatic harness fallback core-owned and scopes one profile per call", async () => {
-    const firstPlan = {
-      ...nativeAuthPlan,
-      forwardedAuthProfileId: "openai:first",
-      forwardedAuthProfileSource: "auto" as const,
-      forwardedAuthProfileCandidateIds: ["openai:first", "openai:backup"],
-    };
-    const backupPlan = {
-      ...firstPlan,
-      forwardedAuthProfileId: "openai:backup",
-      forwardedAuthProfileCandidateIds: ["openai:backup"],
-    };
-    mocks.ensureAuthProfileStore.mockReturnValueOnce({
-      version: 1,
-      profiles: {
-        "openai:first": { type: "token", provider: "openai", token: "first" },
-        "openai:backup": { type: "token", provider: "openai", token: "backup" },
-      },
-    });
-    mocks.prepareAgentRuntimeAuth.mockReturnValueOnce({
-      plan: firstPlan,
-      attempts: [
-        { kind: "profile", plan: firstPlan, profileId: "openai:first" },
-        { kind: "profile", plan: backupPlan, profileId: "openai:backup" },
-      ],
-    });
-    const runIsolatedCompletionV2 = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("first profile unavailable"))
-      .mockResolvedValueOnce({
-        assistant: assistant([{ type: "text", text: "backup result" }]),
+  it.each([false, true])(
+    "keeps profile fallback within live authority (retired: %s)",
+    async (retired) => {
+      let active = true;
+      const expired = new Error("completion owner retired");
+      const firstPlan = {
+        ...nativeAuthPlan,
+        forwardedAuthProfileId: "openai:first",
+        forwardedAuthProfileSource: "auto" as const,
+        forwardedAuthProfileCandidateIds: ["openai:first", "openai:backup"],
+      };
+      const backupPlan = {
+        ...firstPlan,
+        forwardedAuthProfileId: "openai:backup",
+        forwardedAuthProfileCandidateIds: ["openai:backup"],
+      };
+      mocks.ensureAuthProfileStore.mockReturnValueOnce({
+        version: 1,
+        profiles: {
+          "openai:first": { type: "token", provider: "openai", token: "first" },
+          "openai:backup": { type: "token", provider: "openai", token: "backup" },
+        },
       });
-    registerHarness({
-      authBootstrap: "harness",
-      runIsolatedCompletionV2,
-    });
+      mocks.prepareAgentRuntimeAuth.mockReturnValueOnce({
+        plan: firstPlan,
+        attempts: [
+          { kind: "profile", plan: firstPlan, profileId: "openai:first" },
+          { kind: "profile", plan: backupPlan, profileId: "openai:backup" },
+        ],
+      });
+      const runIsolatedCompletionV2 = vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          active = !retired;
+          throw new Error("first profile unavailable");
+        })
+        .mockResolvedValueOnce({
+          assistant: assistant([{ type: "text", text: "backup result" }]),
+        });
+      registerHarness({
+        authBootstrap: "harness",
+        runIsolatedCompletionV2,
+      });
 
-    await expect(runIsolatedCompletion(request())).resolves.toMatchObject({
-      text: "backup result",
-    });
-    expect(runIsolatedCompletionV2).toHaveBeenCalledTimes(2);
-    expect(
-      runIsolatedCompletionV2.mock.calls.map(([params]) => ({
-        profileId:
-          params.authorization.owner === "harness"
-            ? params.authorization.plan.forwardedAuthProfileId
-            : undefined,
-        candidateIds:
-          params.authorization.owner === "harness"
-            ? params.authorization.plan.forwardedAuthProfileCandidateIds
-            : undefined,
-        profiles:
-          params.authorization.owner === "harness"
-            ? Object.keys(params.authorization.authProfileStore.profiles)
-            : [],
-      })),
-    ).toEqual([
-      {
-        profileId: "openai:first",
-        candidateIds: ["openai:first"],
-        profiles: ["openai:first"],
-      },
-      {
-        profileId: "openai:backup",
-        candidateIds: ["openai:backup"],
-        profiles: ["openai:backup"],
-      },
-    ]);
-    expect(mocks.prepareSimpleCompletionModel).not.toHaveBeenCalled();
-  });
+      const result = runIsolatedCompletion({
+        ...request(),
+        assertCurrent: () => {
+          if (!active) {
+            throw expired;
+          }
+        },
+      });
+      if (retired) {
+        await expect(result).rejects.toThrow(expired);
+        expect(runIsolatedCompletionV2).toHaveBeenCalledOnce();
+        expect(releaseRuntimeLease).toHaveBeenCalledOnce();
+        return;
+      }
+      await expect(result).resolves.toMatchObject({
+        text: "backup result",
+      });
+      expect(runIsolatedCompletionV2).toHaveBeenCalledTimes(2);
+      expect(
+        runIsolatedCompletionV2.mock.calls.map(([params]) => ({
+          profileId:
+            params.authorization.owner === "harness"
+              ? params.authorization.plan.forwardedAuthProfileId
+              : undefined,
+          candidateIds:
+            params.authorization.owner === "harness"
+              ? params.authorization.plan.forwardedAuthProfileCandidateIds
+              : undefined,
+          profiles:
+            params.authorization.owner === "harness"
+              ? Object.keys(params.authorization.authProfileStore.profiles)
+              : [],
+        })),
+      ).toEqual([
+        {
+          profileId: "openai:first",
+          candidateIds: ["openai:first"],
+          profiles: ["openai:first"],
+        },
+        {
+          profileId: "openai:backup",
+          candidateIds: ["openai:backup"],
+          profiles: ["openai:backup"],
+        },
+      ]);
+      expect(mocks.prepareSimpleCompletionModel).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([true, false])(
     "requires actual profile dispatch before direct auth (cooled: %s)",
@@ -511,9 +578,13 @@ describe("runIsolatedCompletion", () => {
   });
 
   it("passes one prepared route to the selected harness and returns text", async () => {
-    const runIsolatedCompletionHarness = vi.fn(async () => ({
-      assistant: assistant([{ type: "text", text: '{"ok":true}' }]),
-    }));
+    let retainedAssertCurrent: (() => void) | undefined;
+    const runIsolatedCompletionHarness = vi.fn(
+      async (params: Parameters<NonNullable<AgentHarness["runIsolatedCompletion"]>>[0]) => {
+        retainedAssertCurrent = params.assertCurrent;
+        return { assistant: assistant([{ type: "text", text: '{"ok":true}' }]) };
+      },
+    );
     registerHarness({
       runIsolatedCompletion: runIsolatedCompletionHarness,
     });
@@ -535,6 +606,8 @@ describe("runIsolatedCompletion", () => {
     );
     expect(mocks.acquireAgentRunPreparedModelRuntime).toHaveBeenCalledOnce();
     expect(releaseRuntimeLease).toHaveBeenCalledOnce();
+    expect(retainedAssertCurrent).toBeTypeOf("function");
+    expect(() => retainedAssertCurrent?.()).toThrow("Isolated completion has ended");
     expect(runIsolatedCompletionHarness).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "openai",

--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -67,6 +67,7 @@ type RunIsolatedCompletionParams = {
   prompt: string;
   timeoutMs: number;
   abortSignal?: AbortSignal;
+  assertCurrent?: () => void;
   thinkLevel?: ThinkLevel;
   outputTextPolicy?: AgentHarnessIsolatedCompletionParamsV2["outputTextPolicy"];
   streamParams?: AgentHarnessIsolatedCompletionParamsV2["streamParams"];
@@ -191,6 +192,7 @@ async function runCliIsolatedCompletion(params: {
         "isolated-completion",
       );
       try {
+        params.request.assertCurrent?.();
         const result = await runCliAgent({
           preparedRunAdmission,
           sessionId,
@@ -213,6 +215,7 @@ async function runCliIsolatedCompletion(params: {
           thinkLevel: params.request.thinkLevel,
           streamParams: params.request.streamParams,
           abortSignal: params.request.abortSignal,
+          assertCurrent: params.request.assertCurrent,
           executionMode: "side-question",
           cliToolAvailability: { native: [], openClaw: [] },
           disableTools: true,
@@ -419,6 +422,15 @@ async function prepareHostAuthorization(params: {
 export async function runIsolatedCompletion(
   request: RunIsolatedCompletionParams,
 ): Promise<IsolatedCompletionResult> {
+  let active = true;
+  const assertCurrent = () => {
+    if (!active) {
+      throw new IsolatedCompletionError("runtime-unavailable", "Isolated completion has ended.");
+    }
+    request.abortSignal?.throwIfAborted();
+    request.assertCurrent?.();
+  };
+  assertCurrent();
   const config = request.config ?? {};
   const agentId = request.agentId ?? resolveDefaultAgentId(config);
   const agentDir = request.agentDir ?? resolveAgentDir(config, agentId);
@@ -451,6 +463,7 @@ export async function runIsolatedCompletion(
   );
   const pluginRegistry = lease.snapshot.pluginRegistry;
   try {
+    assertCurrent();
     const run = async (): Promise<IsolatedCompletionResult> => {
       await ensureSelectedAgentHarnessPlugin({
         provider,
@@ -475,7 +488,7 @@ export async function runIsolatedCompletion(
       });
       if (cliOwner) {
         const completion = await runCliIsolatedCompletion({
-          request,
+          request: { ...request, assertCurrent },
           provider: cliOwner,
           modelProvider: provider,
           agentId,
@@ -492,6 +505,7 @@ export async function runIsolatedCompletion(
       }
 
       const harness = await resolveHarness(runtime);
+      assertCurrent();
       if (!harness.runIsolatedCompletionV2 && !harness.runIsolatedCompletion) {
         throw new IsolatedCompletionError(
           "unsupported",
@@ -509,6 +523,7 @@ export async function runIsolatedCompletion(
         prompt: request.prompt,
         timeoutMs: request.timeoutMs,
         abortSignal: request.abortSignal,
+        assertCurrent,
         thinkLevel: request.thinkLevel,
         outputTextPolicy: request.outputTextPolicy,
       };
@@ -557,6 +572,7 @@ export async function runIsolatedCompletion(
         let firstError: unknown;
         let priorProfileAttempted = false;
         for (const preparedAttempt of authAttempts?.length ? authAttempts : [undefined]) {
+          assertCurrent();
           const attempt: PreparedAgentRuntimeAuthAttempt | undefined =
             preparedAttempt?.kind === "profile"
               ? { ...preparedAttempt, plan: selectIsolatedHarnessAuthPlan(preparedAttempt) }
@@ -620,6 +636,7 @@ export async function runIsolatedCompletion(
             ) {
               throw new Error("Prepared runtime auth candidates are temporarily unavailable.");
             }
+            assertCurrent();
             const pending = harness.runIsolatedCompletionV2(
               prepareIsolatedHarnessParamsV2(harness, {
                 ...commonParams,
@@ -631,9 +648,8 @@ export async function runIsolatedCompletion(
             result = await pending;
             break;
           } catch (error) {
-            if (request.abortSignal?.aborted) {
-              throw error;
-            }
+            // Retired authority is terminal, not a reason to try another credential.
+            assertCurrent();
             firstError ??= error;
           }
         }
@@ -666,6 +682,7 @@ export async function runIsolatedCompletion(
             ? { sourceAuthFingerprint: authorization.sourceAuthFingerprint }
             : {}),
         };
+        assertCurrent();
         result = await harness.runIsolatedCompletion!(
           prepareIsolatedHarnessParams(harness, harnessParams),
         );
@@ -682,6 +699,7 @@ export async function runIsolatedCompletion(
       };
     };
     const result = await withPluginRuntimeGenerationScope(lease.snapshot, run);
+    assertCurrent();
     if (!result.text && request.outputTextPolicy !== "strict-visible") {
       throw new IsolatedCompletionError(
         "output-rejected",
@@ -690,6 +708,7 @@ export async function runIsolatedCompletion(
     }
     return result;
   } finally {
+    active = false;
     lease.release();
   }
 }

--- a/src/agents/simple-completion-execution.test.ts
+++ b/src/agents/simple-completion-execution.test.ts
@@ -68,9 +68,12 @@ describe("completeWithPreparedSimpleCompletionModel", () => {
       model,
       cfg,
     });
-    expect(mocks.complete).toHaveBeenCalledWith(preparedModel, context, {
-      apiKey: "ollama-local",
-    });
+    expect(mocks.complete).toHaveBeenCalledWith(
+      preparedModel,
+      context,
+      { apiKey: "ollama-local" },
+      undefined,
+    );
   });
 
   it.each([
@@ -97,10 +100,12 @@ describe("completeWithPreparedSimpleCompletionModel", () => {
       context,
       options: { reasoning },
     });
-    expect(mocks.complete).toHaveBeenCalledWith(model, context, {
-      ...(expected ? { reasoning: expected } : {}),
-      apiKey: "sk-test",
-    });
+    expect(mocks.complete).toHaveBeenCalledWith(
+      model,
+      context,
+      { ...(expected ? { reasoning: expected } : {}), apiKey: "sk-test" },
+      undefined,
+    );
   });
 
   it("carries strict visibility internally without adding a wire option", async () => {
@@ -142,9 +147,11 @@ describe("completeWithPreparedSimpleCompletionModel", () => {
       options: { reasoning: "off" },
     });
 
-    expect(mocks.complete).toHaveBeenCalledWith(preparedModel, context, {
-      reasoning: "off",
-      apiKey: "sk-test",
-    });
+    expect(mocks.complete).toHaveBeenCalledWith(
+      preparedModel,
+      context,
+      { reasoning: "off", apiKey: "sk-test" },
+      undefined,
+    );
   });
 });

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -647,6 +647,7 @@ export async function prepareSimpleCompletionModelForAgent(params: {
 }
 
 export async function completeWithPreparedSimpleCompletionModel(params: {
+  assertCurrent?: () => void;
   model: Model;
   auth: ResolvedProviderAuth;
   context: Parameters<typeof completeSimple>[1];
@@ -676,7 +677,12 @@ export async function completeWithPreparedSimpleCompletionModel(params: {
   if (strictReasoningTags) {
     reasoningTagTextPolicy.markStrict(completionOptions);
   }
-  return await completeSimple(completionModel, params.context, completionOptions);
+  return await completeSimple(
+    completionModel,
+    params.context,
+    completionOptions,
+    params.assertCurrent,
+  );
 }
 
 function normalizeSimpleCompletionReasoning(

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -5,6 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../config/cron-limits.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  createBackgroundWorkOwner,
+  getBackgroundWorkSnapshot,
+} from "../process/background-work.js";
 import { enqueueCommandInLane, setCommandLaneConcurrency } from "../process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../process/command-queue.test-support.js";
 import { CommandLane } from "../process/lanes.js";
@@ -125,5 +129,25 @@ describe("applyGatewayLaneConcurrency", () => {
     setCommandLaneConcurrency(CommandLane.Nested, 1);
     await nestedRun;
     expect(started).toBe(true);
+  });
+
+  it("preserves shared background capacity across gateway lane publication", async () => {
+    const owner = createBackgroundWorkOwner({ owner: "plugin:reload-test", maxConcurrent: 3 });
+    const gates = Array.from({ length: 3 }, () => createDeferred());
+    const active = gates.map((gate) => owner.enqueue(async () => await gate.promise));
+    let nextStarted = false;
+    const next = owner.enqueue(async () => {
+      nextStarted = true;
+    });
+    try {
+      applyConfigLaneConcurrency({ hooks: { enabled: true } });
+      applyConfigLaneConcurrency({ hooks: { enabled: false } });
+      expect(getBackgroundWorkSnapshot()).toMatchObject({ activeCount: 3, queuedCount: 1 });
+      expect(nextStarted).toBe(false);
+    } finally {
+      gates.forEach((gate) => gate.resolve());
+      await Promise.all([...active, next]);
+    }
+    expect(nextStarted).toBe(true);
   });
 });

--- a/src/gateway/server-methods/diagnostics.test.ts
+++ b/src/gateway/server-methods/diagnostics.test.ts
@@ -4,6 +4,7 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   emitDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -13,6 +14,7 @@ import {
   startDiagnosticStabilityRecorder,
   stopDiagnosticStabilityRecorder,
 } from "../../logging/diagnostic-stability.js";
+import { createBackgroundWorkOwner } from "../../process/background-work.js";
 import { getCommandLaneDiagnostics } from "../../process/command-lane-diagnostics.js";
 import {
   enqueueCommandInLane,
@@ -191,12 +193,12 @@ describe("diagnostics gateway methods", () => {
       const payload = await requestLaneDiagnostics();
       expect(payload.ts).toBeGreaterThan(0);
       expect(payload.lanes.map((snapshot) => snapshot.lane)).toEqual([
+        CommandLane.Background,
         CommandLane.Cron,
         CommandLane.CronNested,
         CommandLane.HookDispatch,
         CommandLane.Main,
         CommandLane.Nested,
-        CommandLane.SkillWorkshopReview,
         CommandLane.Subagent,
         CommandLane.SystemAgent,
       ]);
@@ -238,6 +240,30 @@ describe("diagnostics gateway methods", () => {
       setCommandLaneConcurrency(lane, 1);
       await Promise.all([active, queued]);
       setCommandLaneConcurrency(lane, originalConcurrency);
+    }
+  });
+
+  it("reports background owners once in the aggregate without duplicating dynamic lanes", async () => {
+    const before = await requestLaneDiagnostics();
+    const owner = createBackgroundWorkOwner({ owner: "core:diagnostics-test", maxConcurrent: 1 });
+    const gate = createDeferred();
+    const active = owner.enqueue(async () => await gate.promise);
+    const queued = owner.enqueue(async () => undefined);
+    try {
+      const payload = await requestLaneDiagnostics();
+      expect(
+        payload.lanes.find((snapshot) => snapshot.lane === CommandLane.Background),
+      ).toMatchObject({
+        activeCount: 1,
+        queuedCount: 1,
+        maxConcurrent: 3,
+        blockedBy: "lane",
+      });
+      expect(payload.lanes.some((snapshot) => snapshot.lane === owner.lane)).toBe(false);
+      expect(payload.dynamic).toEqual(before.dynamic);
+    } finally {
+      gate.resolve();
+      await Promise.all([active, queued]);
     }
   });
 

--- a/src/gateway/server-methods/diagnostics.test.ts
+++ b/src/gateway/server-methods/diagnostics.test.ts
@@ -251,9 +251,7 @@ describe("diagnostics gateway methods", () => {
     const queued = owner.enqueue(async () => undefined);
     try {
       const payload = await requestLaneDiagnostics();
-      expect(
-        payload.lanes.find((snapshot) => snapshot.lane === CommandLane.Background),
-      ).toMatchObject({
+      expect(payload.lanes.find((snapshot) => snapshot.lane === "background")).toMatchObject({
         activeCount: 1,
         queuedCount: 1,
         maxConcurrent: 3,

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -39,21 +39,21 @@ type OperatorToolGatewayAuthority = {
   >;
   scopes: readonly string[];
   operatorRoleActor?: GatewayOperatorRoleActor;
-  active: boolean;
+  signal: AbortSignal;
 };
 
 const operatorToolGatewayAuthority = new AsyncLocalStorage<OperatorToolGatewayAuthority>();
 
 /** Retains operator attribution and authority only for the awaited tool invocation. */
 export async function withOperatorToolGatewayAuthority<T>(
-  authority: Omit<OperatorToolGatewayAuthority, "active">,
+  authority: Omit<OperatorToolGatewayAuthority, "signal">,
   run: () => Promise<T>,
 ): Promise<T> {
-  const activeAuthority = { ...authority, active: true };
+  const lifetime = new AbortController();
   try {
-    return await operatorToolGatewayAuthority.run(activeAuthority, run);
+    return await operatorToolGatewayAuthority.run({ ...authority, signal: lifetime.signal }, run);
   } finally {
-    activeAuthority.active = false;
+    lifetime.abort(new Error("operator tool invocation authority expired"));
   }
 }
 
@@ -101,9 +101,7 @@ function resolveInProcessGatewayDispatch(
   options?: DispatchGatewayMethodInProcessOptions,
 ): ResolvedInProcessGatewayDispatch {
   const inheritedOperatorAuthority = operatorToolGatewayAuthority.getStore();
-  if (inheritedOperatorAuthority && !inheritedOperatorAuthority.active) {
-    throw new Error("operator tool invocation authority expired");
-  }
+  inheritedOperatorAuthority?.signal.throwIfAborted();
   const scope = getPluginRuntimeGatewayRequestScope();
   const scopedOperatorProfile = scope?.client?.authenticatedUserProfile;
   const scopedRoleActor = scope?.client?.internal?.operatorRoleActor;
@@ -295,9 +293,7 @@ export function prepareInProcessAgentExecution(params: {
   const client = getPluginRuntimeGatewayRequestScope()?.client ?? resolved.client;
   const assertLifetime = () => {
     resolved.assertContextCurrent();
-    if (inheritedAuthority && !inheritedAuthority.active) {
-      throw new Error("operator tool invocation authority expired");
-    }
+    inheritedAuthority?.signal.throwIfAborted();
   };
   const assertCurrent = () => {
     assertLifetime();
@@ -312,6 +308,7 @@ export function prepareInProcessAgentExecution(params: {
   };
   return {
     context: resolved.context,
+    signal: inheritedAuthority?.signal,
     assertCurrent,
     async authorize() {
       assertLifetime();

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -6,6 +6,7 @@ import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-
 import type { PluginSubagentRequesterContext } from "../plugins/runtime/subagent-requester-context.js";
 import type { RuntimePluginToolGrant } from "../plugins/runtime/tool-grant.js";
 import { readInProcessAgentRuntimeIdentity } from "./in-process-agent-runtime-identity.js";
+import { authorizeGatewaySessionCreation } from "./operator-role-policy.js";
 import { ADMIN_SCOPE, WRITE_SCOPE } from "./operator-scopes.js";
 import {
   dispatchGatewayRequestInProcessRaw,
@@ -274,6 +275,67 @@ function resolveInProcessGatewayDispatch(
     context,
     delegatedToolPolicyHandoffId,
     isWebchatConnect,
+  };
+}
+
+/** Authorizes a sessionless agent execution against its captured Gateway and caller. */
+export function prepareInProcessAgentExecution(params: {
+  agentId: string;
+  pluginRuntimeOwnerId: string;
+  resolveGatewayContext?: GatewayContextResolver;
+}) {
+  const inheritedAuthority = operatorToolGatewayAuthority.getStore();
+  const resolved = resolveInProcessGatewayDispatch("agent", {
+    agentRunTracking: "plugin_subagent",
+    pluginRuntimeOwnerId: params.pluginRuntimeOwnerId,
+    resolveGatewayContext: params.resolveGatewayContext,
+  });
+  // Profile verification updates the original connection. Sessionless work needs
+  // that live principal, not the dispatch copy carrying session tracking metadata.
+  const client = getPluginRuntimeGatewayRequestScope()?.client ?? resolved.client;
+  const assertLifetime = () => {
+    resolved.assertContextCurrent();
+    if (inheritedAuthority && !inheritedAuthority.active) {
+      throw new Error("operator tool invocation authority expired");
+    }
+  };
+  const assertCurrent = () => {
+    assertLifetime();
+    const error = authorizeGatewaySessionCreation({
+      cfg: resolved.context.getRuntimeConfig(),
+      agentId: params.agentId,
+      client,
+    });
+    if (error) {
+      unwrapGatewayMethodDispatchResponse("agent", { ok: false, error });
+    }
+  };
+  return {
+    context: resolved.context,
+    assertCurrent,
+    async authorize() {
+      assertLifetime();
+      const { authorizeGatewayRequestPreDispatch, createRequestGatewayMethodRegistry } =
+        await import("./server-methods.js");
+      assertLifetime();
+      const { error } = await authorizeGatewayRequestPreDispatch({
+        method: "agent",
+        requestParams: { agentId: params.agentId },
+        client,
+        context: resolved.context,
+        methodRegistry:
+          resolved.context.getGatewayMethodRegistry?.() ?? createRequestGatewayMethodRegistry(),
+      });
+      assertLifetime();
+      if (error) {
+        unwrapGatewayMethodDispatchResponse("agent", { ok: false, error });
+      }
+      assertCurrent();
+    },
+    run<T>(run: () => Promise<T>): Promise<T> {
+      assertCurrent();
+      return operatorToolGatewayAuthority.exit(run);
+    },
   };
 }
 

--- a/src/gateway/server-plugin-subagent-runtime.test.ts
+++ b/src/gateway/server-plugin-subagent-runtime.test.ts
@@ -1,0 +1,474 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { runIsolatedCompletion } from "../agents/isolated-completion.js";
+import {
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "../config/config.js";
+import {
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import { markTrustedOtelDiagnosticListener } from "../infra/diagnostic-otel-listener-provenance.js";
+import {
+  withPluginRuntimeGatewayRequestScope,
+  withPluginRuntimePluginIdScope,
+} from "../plugins/runtime/gateway-request-scope.js";
+import type { PluginRuntime } from "../plugins/runtime/types.js";
+import {
+  createBackgroundWorkOwner,
+  getBackgroundWorkSnapshot,
+} from "../process/background-work.js";
+import { resetCommandQueueStateForTest } from "../process/command-queue.test-support.js";
+import { ensureProfileForEmail } from "../state/user-profiles.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import type { GatewayRequestContext, GatewayRequestOptions } from "./server-methods/types.js";
+import * as inProcessDispatch from "./server-plugin-in-process-dispatch.js";
+import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
+import {
+  createGatewaySubagentRuntime,
+  resolvePluginSubagentOverridePolicies,
+} from "./server-plugin-subagent-runtime.js";
+
+const isolated = vi.hoisted(() => vi.fn<typeof runIsolatedCompletion>());
+vi.mock("../agents/isolated-completion.js", () => ({ runIsolatedCompletion: isolated }));
+vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: () => undefined,
+}));
+
+const PLUGIN_ID = "test-completion";
+type CompleteParams = Parameters<PluginRuntime["subagent"]["complete"]>[0];
+let config: OpenClawConfig;
+let context: GatewayRequestContext | undefined;
+let lifetime: AbortController;
+
+function createRuntime() {
+  return createGatewaySubagentRuntime(
+    () => context,
+    resolvePluginSubagentOverridePolicies(config),
+    lifetime.signal,
+  );
+}
+
+function complete(runtime: PluginRuntime["subagent"], params: Partial<CompleteParams> = {}) {
+  return withPluginRuntimePluginIdScope(PLUGIN_ID, () =>
+    runtime.complete({ agentId: "research", message: "Review these notes", ...params }),
+  );
+}
+
+function completeScoped(
+  client: GatewayRequestOptions["client"],
+  params: Partial<CompleteParams> = {},
+) {
+  const runtime = createRuntime();
+  return withPluginRuntimeGatewayRequestScope(
+    { pluginId: PLUGIN_ID, client, isWebchatConnect: () => false },
+    () => runtime.complete({ agentId: "research", message: "Review these notes", ...params }),
+  );
+}
+
+const operatorProfile = {
+  profileId: "completion-operator",
+  displayName: "Completion operator",
+  hasAvatar: false,
+  updatedAt: 1,
+};
+
+function restrictOperatorAgents() {
+  config.gateway = {
+    roles: {
+      default: "limited",
+      definitions: {
+        limited: { agents: ["main"], scopes: ["operator.write"], sessions: { others: "none" } },
+      },
+    },
+  };
+}
+
+function blockBackgroundSlots(count: number) {
+  const owner = createBackgroundWorkOwner({ owner: "core:completion-test", maxConcurrent: 3 });
+  const gate = createDeferred();
+  const work = Array.from({ length: count }, () => owner.enqueue(async () => await gate.promise));
+  return { release: () => gate.resolve(), settled: () => Promise.all(work) };
+}
+
+beforeEach(() => {
+  resetCommandQueueStateForTest();
+  isolated.mockReset().mockImplementation(async (params) => ({
+    text: `${params.agentId}:${params.provider}/${params.model}`,
+    provider: params.provider,
+    model: params.model,
+    owner: { kind: "harness", id: "test-runtime" },
+  }));
+  config = {
+    agents: {
+      defaults: { model: "test-provider/global-model" },
+      entries: {
+        main: { model: "test-provider/main-model" },
+        research: { model: "test-provider/research-model@research-profile" },
+      },
+    },
+  };
+  setRuntimeConfigSnapshot(config);
+  context = { getRuntimeConfig: () => config } as GatewayRequestContext;
+  lifetime = new AbortController();
+});
+
+afterEach(() => {
+  lifetime.abort();
+  resetCommandQueueStateForTest();
+  resetConfigRuntimeState();
+  vi.restoreAllMocks();
+});
+
+describe("plugin background completions", () => {
+  it("uses the selected agent's model and credential owner without creating a session", async () => {
+    const dispatch = vi.spyOn(inProcessDispatch, "dispatchGatewayMethodInProcess");
+    await expect(
+      complete(createRuntime(), { extraSystemPrompt: "Summarize only" }),
+    ).resolves.toEqual({
+      text: "research:test-provider/research-model",
+    });
+    expect(isolated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "research",
+        provider: "test-provider",
+        model: "research-model",
+        authProfileId: "research-profile",
+        systemPrompt: "Summarize only",
+        prompt: "Review these notes",
+        timeoutMs: 30_000,
+        abortSignal: expect.any(AbortSignal),
+      }),
+    );
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("records one trusted usage event attributed to the host plugin and selected agent without a session", async () => {
+    resetDiagnosticEventsForTest();
+    const events: Array<{
+      event: Extract<DiagnosticEventPayload, { type: "model.usage" }>;
+      hostPluginId?: string;
+      trusted: boolean;
+      internal?: boolean;
+    }> = [];
+    const stop = onTrustedInternalDiagnosticEvent(
+      markTrustedOtelDiagnosticListener((event, metadata, privateData) => {
+        if (event.type === "model.usage") {
+          events.push({
+            event,
+            hostPluginId: (privateData as { hostPluginId?: string }).hostPluginId,
+            trusted: metadata.trusted,
+            internal: metadata.internal,
+          });
+        }
+      }),
+    );
+    isolated.mockResolvedValueOnce({
+      text: "summary",
+      provider: "test-provider",
+      model: "research-model",
+      owner: { kind: "harness", id: "test-runtime" },
+      usage: {
+        input: 11,
+        output: 7,
+        cacheRead: 5,
+        cacheWrite: 2,
+        total: 25,
+        cost: { total: 0.0042 },
+      },
+    });
+    const request = {
+      message: "Summarize",
+      pluginId: "spoofed-plugin",
+      sessionKey: "spoofed-session",
+    };
+    try {
+      await expect(complete(createRuntime(), request)).resolves.toEqual({ text: "summary" });
+    } finally {
+      stop();
+      resetDiagnosticEventsForTest();
+    }
+    expect(events).toEqual([
+      {
+        trusted: true,
+        internal: true,
+        hostPluginId: PLUGIN_ID,
+        event: expect.objectContaining({
+          type: "model.usage",
+          agentId: "research",
+          provider: "test-provider",
+          model: "research-model",
+          usage: { input: 11, output: 7, cacheRead: 5, cacheWrite: 2, promptTokens: 18, total: 25 },
+          costUsd: 0.0042,
+        }),
+      },
+    ]);
+    expect(events[0]?.event).not.toHaveProperty("sessionKey");
+    expect(events[0]?.event).not.toHaveProperty("sessionId");
+  });
+
+  it.each([
+    {
+      name: "untrusted plugin",
+      subagent: undefined,
+      model: "test-provider/override",
+      allowed: false,
+    },
+    {
+      name: "allowlisted model",
+      subagent: { allowModelOverride: true, allowedModels: ["test-provider/override"] },
+      model: "test-provider/override",
+      allowed: true,
+    },
+    {
+      name: "model outside allowlist",
+      subagent: { allowModelOverride: true, allowedModels: ["test-provider/other"] },
+      model: "test-provider/override",
+      allowed: false,
+    },
+    {
+      name: "invalid allowlist",
+      subagent: { allowModelOverride: true, allowedModels: ["not-a-model-ref"] },
+      model: "test-provider/override",
+      allowed: false,
+    },
+  ])(
+    "applies existing subagent override policy for $name",
+    async ({ subagent, model, allowed }) => {
+      config.plugins = { entries: { [PLUGIN_ID]: { subagent } } };
+      const result = complete(createRuntime(), { model });
+      if (allowed) {
+        await expect(result).resolves.toEqual({ text: "research:test-provider/override" });
+        expect(isolated).toHaveBeenCalledOnce();
+      } else {
+        await expect(result).rejects.toThrow(/not trusted|not allowlisted|none of the entries/u);
+        expect(isolated).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each(["operator.write", "operator.admin"])(
+    "retains request-scoped %s model override authority",
+    async (scope) => {
+      const result = completeScoped(createSyntheticPluginRuntimeClient({ scopes: [scope] }), {
+        model: "test-provider/override",
+      });
+      if (scope === "operator.admin") {
+        await expect(result).resolves.toEqual({ text: "research:test-provider/override" });
+      } else {
+        await expect(result).rejects.toThrow("override is not authorized");
+        expect(isolated).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each(["operator.read", "operator.write"])(
+    "enforces %s scope even when using the agent's default model",
+    async (scope) => {
+      const result = completeScoped(createSyntheticPluginRuntimeClient({ scopes: [scope] }));
+      if (scope === "operator.read") {
+        await expect(result).rejects.toThrow("missing scope: operator.write");
+        expect(isolated).not.toHaveBeenCalled();
+      } else {
+        await expect(result).resolves.toEqual({ text: "research:test-provider/research-model" });
+      }
+    },
+  );
+
+  it("keeps operator agent ceilings while admitting genuine background work", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      restrictOperatorAgents();
+      const profile = ensureProfileForEmail("completion-ceiling@example.com");
+      const client = createSyntheticPluginRuntimeClient({
+        scopes: ["operator.write"],
+        authenticatedUserProfile: { ...operatorProfile, profileId: profile.id },
+      });
+      await expect(completeScoped(client)).rejects.toThrow(
+        'Your operator role cannot create sessions for agent "research"',
+      );
+      expect(isolated).not.toHaveBeenCalled();
+      await expect(completeScoped(client, { agentId: "main" })).resolves.toEqual({
+        text: "main:test-provider/main-model",
+      });
+      await expect(complete(createRuntime())).resolves.toEqual({
+        text: "research:test-provider/research-model",
+      });
+    });
+  });
+
+  it("snapshots the authorized agent and credentials before queued request mutation", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      restrictOperatorAgents();
+      const profile = ensureProfileForEmail("completion-mutation@example.com");
+      config.agents!.entries!.main!.model = "test-provider/main-model@main-profile";
+      const blockers = blockBackgroundSlots(3);
+      const runtime = createRuntime();
+      const request = { agentId: "main", message: "Review these notes" };
+      const result = withPluginRuntimeGatewayRequestScope(
+        {
+          pluginId: PLUGIN_ID,
+          client: createSyntheticPluginRuntimeClient({
+            scopes: ["operator.write"],
+            authenticatedUserProfile: { ...operatorProfile, profileId: profile.id },
+          }),
+          isWebchatConnect: () => false,
+        },
+        () => runtime.complete(request),
+      ).then(
+        (value) => ({ value }),
+        (error: unknown) => ({ error }),
+      );
+      await vi.dynamicImportSettled();
+      await vi.waitFor(() => expect(getBackgroundWorkSnapshot().queuedCount).toBe(1));
+      request.agentId = "research";
+      blockers.release();
+      await blockers.settled();
+      await expect(result).resolves.toEqual({ value: { text: "main:test-provider/main-model" } });
+      expect(isolated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "main",
+          model: "main-model",
+          authProfileId: "main-profile",
+        }),
+      );
+    });
+  });
+
+  it.each(["runtime retirement", "binding replacement"])(
+    "rechecks the host after profile verification awaits during %s",
+    async (reason) => {
+      const entered = createDeferred();
+      const verification = createDeferred();
+      const client = createSyntheticPluginRuntimeClient({ scopes: ["operator.write"] });
+      client.authenticatedGitHubIdentitySync = async () => {
+        entered.resolve();
+        await verification.promise;
+        client.authenticatedUserProfile = operatorProfile;
+        return { profileId: operatorProfile.profileId, updatedAt: Date.now() };
+      };
+      const result = completeScoped(client, { agentId: "main" });
+      const rejected = expect(result).rejects.toThrow(/retired|current gateway instance binding/u);
+      await entered.promise;
+      if (reason === "runtime retirement") {
+        lifetime.abort(new Error("runtime retired"));
+      } else {
+        context = { getRuntimeConfig: () => config } as GatewayRequestContext;
+      }
+      verification.resolve();
+      await rejected;
+      expect(isolated).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["queued", "running"])(
+    "rejects %s work after inherited operator tool authority closes",
+    async (phase) => {
+      const blockers = blockBackgroundSlots(phase === "queued" ? 3 : 0);
+      const started = createDeferred();
+      const cleanup = createDeferred();
+      if (phase === "running") {
+        isolated.mockImplementationOnce(async (params) => {
+          started.resolve();
+          await cleanup.promise;
+          return {
+            text: "late output",
+            provider: params.provider,
+            model: params.model,
+            owner: { kind: "harness", id: "test-runtime" },
+          };
+        });
+      }
+      let rejected: Promise<void> | undefined;
+      await inProcessDispatch.withOperatorToolGatewayAuthority(
+        { authenticatedUserProfile: operatorProfile, scopes: ["operator.write"] },
+        async () => {
+          const result = complete(createRuntime());
+          rejected = expect(result).rejects.toThrow("operator tool invocation authority expired");
+          if (phase === "queued") {
+            await vi.waitFor(() => expect(getBackgroundWorkSnapshot().queuedCount).toBe(1));
+          } else {
+            await started.promise;
+          }
+        },
+      );
+      blockers.release();
+      cleanup.resolve();
+      await rejected;
+      await blockers.settled();
+      expect(isolated).toHaveBeenCalledTimes(phase === "queued" ? 0 : 1);
+    },
+  );
+
+  it.each(["caller cancellation", "runtime retirement", "binding replacement"])(
+    "never starts queued inference after %s",
+    async (reason) => {
+      const blockers = blockBackgroundSlots(3);
+      const controller = new AbortController();
+      const result = complete(createRuntime(), { signal: controller.signal });
+      const rejected = expect(result).rejects.toThrow(
+        /cancelled|retired|current gateway instance binding/u,
+      );
+      await vi.waitFor(() => expect(getBackgroundWorkSnapshot().queuedCount).toBe(1));
+      if (reason === "caller cancellation") {
+        controller.abort(new Error("caller cancelled"));
+      } else if (reason === "runtime retirement") {
+        lifetime.abort(new Error("runtime retired"));
+      } else {
+        context = {} as GatewayRequestContext;
+      }
+      blockers.release();
+      await Promise.all([rejected, blockers.settled()]);
+      expect(isolated).not.toHaveBeenCalled();
+      expect(getBackgroundWorkSnapshot()).toMatchObject({ activeCount: 0, queuedCount: 0 });
+    },
+  );
+
+  it.each(["caller cancellation", "timeout"])(
+    "holds capacity through cleanup after %s and rejects late output",
+    async (reason) => {
+      const blockers = blockBackgroundSlots(2);
+      const started = createDeferred();
+      const aborted = createDeferred();
+      const cleanup = createDeferred();
+      let runningSignal: AbortSignal | undefined;
+      isolated.mockImplementationOnce(async (params) => {
+        runningSignal = params.abortSignal;
+        runningSignal?.addEventListener("abort", () => aborted.resolve(), { once: true });
+        started.resolve();
+        await cleanup.promise;
+        return {
+          text: "late output",
+          provider: params.provider,
+          model: params.model,
+          owner: { kind: "harness", id: "test-runtime" },
+        };
+      });
+      const controller = new AbortController();
+      const runtime = createRuntime();
+      const first = complete(runtime, {
+        signal: controller.signal,
+        ...(reason === "timeout" ? { timeoutMs: 10 } : {}),
+      });
+      await started.promise;
+      const second = complete(runtime);
+      await vi.waitFor(() => expect(getBackgroundWorkSnapshot().queuedCount).toBe(1));
+      const rejected = expect(first).rejects.toThrow(/caller cancelled|timeout/u);
+      if (reason === "caller cancellation") {
+        controller.abort(new Error("caller cancelled"));
+      }
+      await aborted.promise;
+      expect(runningSignal?.aborted).toBe(true);
+      expect(isolated).toHaveBeenCalledOnce();
+      expect(getBackgroundWorkSnapshot()).toMatchObject({ activeCount: 3, queuedCount: 1 });
+      cleanup.resolve();
+      await rejected;
+      await expect(second).resolves.toEqual({ text: "research:test-provider/research-model" });
+      expect(isolated).toHaveBeenCalledTimes(2);
+      blockers.release();
+      await blockers.settled();
+    },
+  );
+});

--- a/src/gateway/server-plugin-subagent-runtime.test.ts
+++ b/src/gateway/server-plugin-subagent-runtime.test.ts
@@ -369,8 +369,10 @@ describe("plugin background completions", () => {
       const blockers = blockBackgroundSlots(phase === "queued" ? 3 : 0);
       const started = createDeferred();
       const cleanup = createDeferred();
+      let runningSignal: AbortSignal | undefined;
       if (phase === "running") {
         isolated.mockImplementationOnce(async (params) => {
+          runningSignal = params.abortSignal;
           started.resolve();
           await cleanup.promise;
           return {
@@ -394,6 +396,9 @@ describe("plugin background completions", () => {
           }
         },
       );
+      if (phase === "running") {
+        expect(runningSignal?.aborted).toBe(true);
+      }
       blockers.release();
       cleanup.resolve();
       await rejected;
@@ -401,6 +406,31 @@ describe("plugin background completions", () => {
       expect(isolated).toHaveBeenCalledTimes(phase === "queued" ? 0 : 1);
     },
   );
+
+  it("revalidates the captured Gateway before inference after isolated preparation", async () => {
+    const preparing = createDeferred();
+    const finishPreparation = createDeferred();
+    const inference = vi.fn();
+    isolated.mockImplementationOnce(async (params) => {
+      preparing.resolve();
+      await finishPreparation.promise;
+      params.assertCurrent?.();
+      inference();
+      return {
+        text: "must not be generated",
+        provider: params.provider,
+        model: params.model,
+        owner: { kind: "harness", id: "test-runtime" },
+      };
+    });
+    const result = complete(createRuntime());
+    const rejected = expect(result).rejects.toThrow("current gateway instance binding");
+    await preparing.promise;
+    context = { getRuntimeConfig: () => config } as GatewayRequestContext;
+    finishPreparation.resolve();
+    await rejected;
+    expect(inference).not.toHaveBeenCalled();
+  });
 
   it.each(["caller cancellation", "runtime retirement", "binding replacement"])(
     "never starts queued inference after %s",

--- a/src/gateway/server-plugin-subagent-runtime.ts
+++ b/src/gateway/server-plugin-subagent-runtime.ts
@@ -27,7 +27,7 @@ import {
 } from "./server-plugin-in-process-dispatch.js";
 import { resolvePluginSubagentToolsAlsoAllow } from "./server-plugin-runtime-client.js";
 
-export function normalizePluginSubagentAllowedModelRef(raw: string): string | null {
+function normalizePluginSubagentAllowedModelRef(raw: string): string | null {
   const trimmed = raw.trim();
   if (!trimmed) {
     return null;
@@ -48,7 +48,7 @@ export function normalizePluginSubagentAllowedModelRef(raw: string): string | nu
   return `${parsed.provider}/${modelId}`;
 }
 
-export function resolvePluginSubagentRequestedModelRef(params: {
+function resolvePluginSubagentRequestedModelRef(params: {
   provider?: string;
   model?: string;
 }): string | null {
@@ -67,7 +67,7 @@ export function resolvePluginSubagentRequestedModelRef(params: {
   return `${parsed.provider}/${parsed.model}`;
 }
 
-export function normalizePluginSubagentRunRuntime(
+function normalizePluginSubagentRunRuntime(
   value: unknown,
 ): Awaited<ReturnType<PluginRuntime["subagent"]["run"]>>["runtime"] {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -264,9 +264,9 @@ export function createGatewaySubagentRuntime(
   };
 
   const subagentRuntime: PluginRuntime["subagent"] = {
-    async complete(params) {
+    async complete(request) {
       // Authorization and credential selection must use the same request across queue waits.
-      params = { ...params };
+      const params = { ...request };
       const scope = getPluginRuntimeGatewayRequestScope();
       const pluginId = scope?.pluginId?.trim();
       if (!pluginId) {
@@ -287,7 +287,7 @@ export function createGatewaySubagentRuntime(
       await execution.authorize();
       assertCurrent();
       authorizeModelOverride(params);
-      const signals = [params.signal, runtimeLifetime].filter(
+      const signals = [params.signal, runtimeLifetime, execution.signal].filter(
         (signal): signal is AbortSignal => signal !== undefined,
       );
       // Preserve subagent authority while sharing the sessionless inference owner.
@@ -338,6 +338,7 @@ export function createGatewaySubagentRuntime(
               prompt: params.message,
               timeoutMs,
               abortSignal: runSignal,
+              assertCurrent,
             }),
           );
           runSignal.throwIfAborted();

--- a/src/gateway/server-plugin-subagent-runtime.ts
+++ b/src/gateway/server-plugin-subagent-runtime.ts
@@ -1,11 +1,31 @@
+import { randomUUID } from "node:crypto";
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import {
   normalizeBuiltInProviderModelId,
   stripSelfProviderModelPrefix,
 } from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeModelRef } from "../agents/model-ref-shared.js";
 import { parseModelRef } from "../agents/model-selection-normalize.js";
+import type { AgentWaitResult } from "../agents/run-wait.types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizePluginsConfig } from "../plugins/config-state.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  bindGatewayContextResolver,
+  getPluginRuntimeGatewayRequestScope,
+} from "../plugins/runtime/gateway-request-scope.js";
+import { resolvePluginSubagentCompletionRequester } from "../plugins/runtime/subagent-requester-context.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
+import type { PluginOrigin } from "../plugins/types.js";
+import { createBackgroundWorkOwner } from "../process/background-work.js";
+import { ADMIN_SCOPE } from "./operator-scopes.js";
+import type { GatewayContextResolver, GatewayRequestOptions } from "./server-methods/types.js";
+import {
+  dispatchGatewayMethodInProcess,
+  prepareInProcessAgentExecution,
+} from "./server-plugin-in-process-dispatch.js";
+import { resolvePluginSubagentToolsAlsoAllow } from "./server-plugin-runtime-client.js";
 
 export function normalizePluginSubagentAllowedModelRef(raw: string): string | null {
   const trimmed = raw.trim();
@@ -58,4 +78,411 @@ export function normalizePluginSubagentRunRuntime(
   const provider = typeof record.provider === "string" ? record.provider.trim() : "";
   const model = typeof record.model === "string" ? record.model.trim() : "";
   return harness && provider && model ? { harness, provider, model } : undefined;
+}
+
+type PluginSubagentOverridePolicy = {
+  allowModelOverride: boolean;
+
+  allowAnyModel: boolean;
+  hasConfiguredAllowlist: boolean;
+  allowedModels: Set<string>;
+};
+
+export type PluginSubagentOverridePolicies = Record<string, PluginSubagentOverridePolicy>;
+
+export function resolvePluginSubagentOverridePolicies(
+  cfg: OpenClawConfig,
+): PluginSubagentOverridePolicies {
+  const normalized = normalizePluginsConfig(cfg.plugins);
+  const policies: PluginSubagentOverridePolicies = {};
+  for (const [pluginId, entry] of Object.entries(normalized.entries)) {
+    const allowModelOverride = entry.subagent?.allowModelOverride === true;
+    const hasConfiguredAllowlist = entry.subagent?.hasAllowedModelsConfig === true;
+    const configuredAllowedModels = entry.subagent?.allowedModels ?? [];
+    const allowedModels = new Set<string>();
+    let allowAnyModel = false;
+    for (const modelRef of configuredAllowedModels) {
+      const normalizedModelRef = normalizePluginSubagentAllowedModelRef(modelRef);
+      if (!normalizedModelRef) {
+        continue;
+      }
+      if (normalizedModelRef === "*") {
+        allowAnyModel = true;
+        continue;
+      }
+      allowedModels.add(normalizedModelRef);
+    }
+    if (
+      !allowModelOverride &&
+      !hasConfiguredAllowlist &&
+      allowedModels.size === 0 &&
+      !allowAnyModel
+    ) {
+      continue;
+    }
+    policies[pluginId] = {
+      allowModelOverride,
+      allowAnyModel,
+      hasConfiguredAllowlist,
+      allowedModels,
+    };
+  }
+  return policies;
+}
+
+function authorizeFallbackModelOverride(params: {
+  policies: PluginSubagentOverridePolicies;
+  pluginId?: string;
+  provider?: string;
+  model?: string;
+}): { allowed: true } | { allowed: false; reason: string } {
+  const pluginId = params.pluginId?.trim();
+  if (!pluginId) {
+    return {
+      allowed: false,
+      reason: "provider/model override requires plugin identity in fallback subagent runs.",
+    };
+  }
+  const policy = params.policies[pluginId];
+  if (!policy?.allowModelOverride) {
+    return {
+      allowed: false,
+      reason:
+        `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
+        "See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent and search for: " +
+        "plugins.entries.<id>.subagent.allowModelOverride",
+    };
+  }
+  if (policy.allowAnyModel) {
+    return { allowed: true };
+  }
+  if (policy.hasConfiguredAllowlist && policy.allowedModels.size === 0) {
+    return {
+      allowed: false,
+      reason: `plugin "${pluginId}" configured subagent.allowedModels, but none of the entries normalized to a valid provider/model target.`,
+    };
+  }
+  if (policy.allowedModels.size === 0) {
+    return { allowed: true };
+  }
+  const requestedModelRef = resolvePluginSubagentRequestedModelRef(params);
+  if (!requestedModelRef) {
+    return {
+      allowed: false,
+      reason:
+        "fallback provider/model overrides that use an allowlist must resolve to a canonical provider/model target.",
+    };
+  }
+  if (policy.allowedModels.has(requestedModelRef)) {
+    return { allowed: true };
+  }
+  return {
+    allowed: false,
+    reason: `model override "${requestedModelRef}" is not allowlisted for plugin "${pluginId}".`,
+  };
+}
+
+function hasAdminScope(client: GatewayRequestOptions["client"] | undefined): boolean {
+  const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+  return scopes.includes(ADMIN_SCOPE);
+}
+
+function canClientUseModelOverride(client: GatewayRequestOptions["client"]): boolean {
+  return hasAdminScope(client) || client?.internal?.allowModelOverride === true;
+}
+
+export function canTrustedOfficialPluginRequestScopes(params: {
+  pluginId?: string;
+  pluginOrigin?: PluginOrigin;
+  pluginTrustedOfficialInstall?: boolean;
+}): boolean {
+  if (!params.pluginId) {
+    return false;
+  }
+  if (params.pluginOrigin === "bundled" || params.pluginTrustedOfficialInstall === true) {
+    return true;
+  }
+  const registry = getActivePluginRegistry();
+  const record = registry?.plugins.find((entry) => entry.id === params.pluginId);
+  return record?.origin === "bundled" || record?.trustedOfficialInstall === true;
+}
+
+const PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT = 1_000;
+
+export function createGatewaySubagentRuntime(
+  resolveGatewayContext?: GatewayContextResolver,
+  overridePolicies: PluginSubagentOverridePolicies = {},
+  runtimeLifetime?: AbortSignal,
+): PluginRuntime["subagent"] {
+  const authorizeModelOverride = (params: { provider?: string; model?: string }) => {
+    const scope = getPluginRuntimeGatewayRequestScope();
+    const overrideRequested = Boolean(params.provider || params.model);
+    const hasRequestScopeClient = Boolean(scope?.client);
+    let allowOverride = hasRequestScopeClient && canClientUseModelOverride(scope?.client ?? null);
+    let allowSyntheticModelOverride = false;
+    if (overrideRequested && !allowOverride && !hasRequestScopeClient) {
+      const fallbackAuth = authorizeFallbackModelOverride({
+        policies: overridePolicies,
+        pluginId: scope?.pluginId,
+        provider: params.provider,
+        model: params.model,
+      });
+      if (!fallbackAuth.allowed) {
+        throw new Error(fallbackAuth.reason);
+      }
+      allowOverride = true;
+      allowSyntheticModelOverride = true;
+    }
+    if (overrideRequested && !allowOverride) {
+      throw new Error("provider/model override is not authorized for this plugin subagent run.");
+    }
+    return { allowOverride, allowSyntheticModelOverride };
+  };
+  const getSessionMessages: PluginRuntime["subagent"]["getSessionMessages"] = async (params) => {
+    const scope = getPluginRuntimeGatewayRequestScope();
+    const limit =
+      params.limit == null || !Number.isFinite(params.limit)
+        ? undefined
+        : Math.min(
+            PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT,
+            Math.max(1, Math.floor(params.limit)),
+          );
+    const payload = await dispatchGatewayMethodInProcess<{ messages?: unknown[] }>(
+      "sessions.get",
+      {
+        key: params.sessionKey,
+        ...(limit != null && { limit }),
+      },
+      {
+        resolveGatewayContext,
+        ...(!scope?.client && canTrustedOfficialPluginRequestScopes(scope ?? {})
+          ? { operatorRoleActor: { kind: "system" as const } }
+          : {}),
+      },
+    );
+    return { messages: Array.isArray(payload?.messages) ? payload.messages : [] };
+  };
+
+  const subagentRuntime: PluginRuntime["subagent"] = {
+    async complete(params) {
+      // Authorization and credential selection must use the same request across queue waits.
+      params = { ...params };
+      const scope = getPluginRuntimeGatewayRequestScope();
+      const pluginId = scope?.pluginId?.trim();
+      if (!pluginId) {
+        throw new Error(
+          "Plugin background completion requires a plugin identity and Gateway binding.",
+        );
+      }
+      const execution = prepareInProcessAgentExecution({
+        agentId: params.agentId,
+        pluginRuntimeOwnerId: pluginId,
+        resolveGatewayContext,
+      });
+      const assertCurrent = () => {
+        runtimeLifetime?.throwIfAborted();
+        execution.assertCurrent();
+      };
+      runtimeLifetime?.throwIfAborted();
+      await execution.authorize();
+      assertCurrent();
+      authorizeModelOverride(params);
+      const signals = [params.signal, runtimeLifetime].filter(
+        (signal): signal is AbortSignal => signal !== undefined,
+      );
+      // Preserve subagent authority while sharing the sessionless inference owner.
+      // Queueing must not outlive the Gateway instance that admitted the plugin.
+      return await createBackgroundWorkOwner({
+        owner: `plugin:${pluginId}`,
+        maxConcurrent: 3,
+      }).enqueue(
+        async (signal) => {
+          assertCurrent();
+          const [
+            { resolveConfiguredAgentId },
+            { resolveSimpleCompletionSelectionForAgent },
+            { runIsolatedCompletion },
+            { finalizePluginLlmCompletion },
+          ] = await Promise.all([
+            import("../agents/agent-scope.js"),
+            import("../agents/simple-completion-runtime.js"),
+            import("../agents/isolated-completion.js"),
+            import("../plugins/runtime/runtime-llm.runtime.js"),
+          ]);
+          await execution.authorize();
+          assertCurrent();
+          signal.throwIfAborted();
+          authorizeModelOverride(params);
+          const cfg = execution.context.getRuntimeConfig();
+          const agentId = resolveConfiguredAgentId(cfg, params.agentId);
+          const selection = resolveSimpleCompletionSelectionForAgent({
+            cfg,
+            agentId,
+            modelRef: params.model,
+          });
+          if (!selection) {
+            throw new Error(`No model configured for agent ${agentId}.`);
+          }
+          const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 30_000);
+          const runSignal = AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]);
+          // Hold capacity through runtime cleanup; a response-only abort race would
+          // admit another completion while the previous model still unwinds.
+          const result = await execution.run(() =>
+            runIsolatedCompletion({
+              config: cfg,
+              agentId,
+              provider: selection.provider,
+              model: selection.modelId,
+              authProfileId: selection.profileId,
+              systemPrompt: params.extraSystemPrompt ?? "",
+              prompt: params.message,
+              timeoutMs,
+              abortSignal: runSignal,
+            }),
+          );
+          runSignal.throwIfAborted();
+          assertCurrent();
+          signal.throwIfAborted();
+          finalizePluginLlmCompletion({
+            cfg,
+            hostPluginId: pluginId,
+            rawUsage: result.usage,
+            result: {
+              text: result.text,
+              provider: result.provider,
+              model: result.model,
+              agentId,
+              execution: { mode: "isolated-agent-runtime", owner: result.owner },
+              audit: { caller: { kind: "plugin", id: pluginId } },
+            },
+          });
+          return { text: result.text };
+        },
+        { abortSignal: signals.length ? AbortSignal.any(signals) : undefined },
+      );
+    },
+    async run(params) {
+      if (params.disableTools === true && (params.toolsAlsoAllow?.length ?? 0) > 0) {
+        throw new Error("Tool-free plugin subagent runs cannot request additive tools.");
+      }
+      const pluginSubagentRequester = resolvePluginSubagentCompletionRequester(
+        params.completionDelivery,
+      );
+      const scope = getPluginRuntimeGatewayRequestScope();
+      const pluginId =
+        typeof scope?.pluginId === "string" && scope.pluginId.trim()
+          ? scope.pluginId.trim()
+          : undefined;
+      const runtimePluginToolGrant = resolvePluginSubagentToolsAlsoAllow({
+        pluginId,
+        toolsAlsoAllow: params.toolsAlsoAllow,
+      });
+      const { allowOverride, allowSyntheticModelOverride } = authorizeModelOverride(params);
+      const payload = await dispatchGatewayMethodInProcess<{
+        runId?: string;
+        sessionKey?: string;
+        runtime?: unknown;
+      }>(
+        "agent",
+        {
+          sessionKey: params.sessionKey,
+          message: params.message,
+          deliver: params.deliver ?? false,
+          ...(allowOverride && params.provider && { provider: params.provider }),
+          ...(allowOverride && params.model && { model: params.model }),
+          ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
+          ...(params.promptMode === "minimal" && { promptMode: params.promptMode }),
+          ...(params.lane && { lane: params.lane }),
+          ...(params.cwd && { cwd: params.cwd }),
+          ...(params.lightContext === true && { bootstrapContextMode: "lightweight" }),
+          // The gateway `agent` schema requires `idempotencyKey: NonEmptyString`,
+          // so fall back to a generated UUID when the caller omits it. Without
+          // this, plugin subagent runs (for example memory-core dreaming
+          // narrative) silently fail schema validation at the gateway.
+          idempotencyKey: params.idempotencyKey || randomUUID(),
+        },
+        {
+          allowSyntheticModelOverride,
+          agentRunTracking: "plugin_subagent",
+          ...(!scope?.client ? { operatorRoleActor: { kind: "system" as const } } : {}),
+          ...(pluginId ? { pluginRuntimeOwnerId: pluginId } : {}),
+          ...(pluginSubagentRequester ? { pluginSubagentRequester } : {}),
+          ...(runtimePluginToolGrant ? { runtimePluginToolGrant } : {}),
+          ...(params.disableTools === true ? { pluginSubagentToolsAllow: [] } : {}),
+          resolveGatewayContext,
+        },
+      );
+      const runId = payload?.runId;
+      if (typeof runId !== "string" || !runId) {
+        throw new Error("Gateway agent method returned an invalid runId.");
+      }
+      const sessionKey = payload?.sessionKey?.trim() || params.sessionKey;
+      const runtime = normalizePluginSubagentRunRuntime(payload?.runtime);
+      return { runId, sessionKey, ...(runtime ? { runtime } : {}) };
+    },
+    async waitForRun(params) {
+      const payload = await dispatchGatewayMethodInProcess<
+        Omit<AgentWaitResult, "status"> & { status?: string }
+      >(
+        "agent.wait",
+        {
+          runId: params.runId,
+          ...(params.timeoutMs != null && { timeoutMs: params.timeoutMs }),
+        },
+        { resolveGatewayContext },
+      );
+      const { status: rawStatus, error, ...metadata } = payload;
+      let status = rawStatus;
+      if (status === "completed" || status === "succeeded") {
+        status = "ok";
+      } else if (status === "error" && error?.trim().toLowerCase() === "completed") {
+        status = "ok";
+      }
+      if (status !== "ok" && status !== "error" && status !== "timeout" && status !== "pending") {
+        throw new Error(`Gateway agent.wait returned unexpected status: ${rawStatus}`);
+      }
+      return {
+        ...metadata,
+        status,
+        ...(status !== "ok" && error ? { error } : {}),
+      };
+    },
+    getSessionMessages,
+    async deleteSession(params) {
+      const scope = getPluginRuntimeGatewayRequestScope();
+      const pluginId =
+        typeof scope?.pluginId === "string" && scope.pluginId.trim()
+          ? scope.pluginId.trim()
+          : undefined;
+      const pluginOwnedCleanupOptions = pluginId
+        ? {
+            pluginRuntimeOwnerId: pluginId,
+            ...(!hasAdminScope(scope?.client)
+              ? {
+                  forceSyntheticClient: true,
+                  syntheticScopes: [ADMIN_SCOPE],
+                }
+              : {}),
+          }
+        : undefined;
+      await dispatchGatewayMethodInProcess(
+        "sessions.delete",
+        {
+          key: params.sessionKey,
+          deleteTranscript: params.deleteTranscript ?? true,
+        },
+        {
+          ...pluginOwnedCleanupOptions,
+          resolveGatewayContext,
+          ...(!scope?.client && canTrustedOfficialPluginRequestScopes(scope ?? {})
+            ? { operatorRoleActor: { kind: "system" as const } }
+            : {}),
+        },
+      );
+    },
+  };
+  if (resolveGatewayContext) {
+    bindGatewayContextResolver(subagentRuntime, resolveGatewayContext);
+  }
+  return subagentRuntime;
 }

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -3,12 +3,10 @@
 import { randomUUID } from "node:crypto";
 import { performance } from "node:perf_hooks";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import type { AgentWaitResult } from "../agents/run-wait.types.js";
 import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import { allowsProcessHomeSessionScan } from "../config/paths.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
 import { activatePluginRegistry } from "../plugins/loader-shared.js";
@@ -19,9 +17,7 @@ import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot
 import { getPluginModuleLoaderStats } from "../plugins/plugin-module-loader-cache.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import type { PluginRegistryParams } from "../plugins/registry-types.js";
-import { getActivePluginRegistry } from "../plugins/runtime.js";
 import {
-  bindGatewayContextResolver,
   getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeGatewayContextResolver,
 } from "../plugins/runtime/gateway-request-scope.js";
@@ -31,31 +27,26 @@ import {
   setPluginRuntimeLoadContext,
   type PluginRuntimeLoadContext,
 } from "../plugins/runtime/load-context.js";
-import { resolvePluginSubagentCompletionRequester } from "../plugins/runtime/subagent-requester-context.js";
 import type {
   CreatePluginRuntimeOptions,
   PluginRuntime,
   RuntimeGatewayRequestOptions,
 } from "../plugins/runtime/types.js";
 import type { PluginLogger, PluginOrigin } from "../plugins/types.js";
-import { ADMIN_SCOPE, authorizeOperatorScopesForRequiredScope } from "./method-scopes.js";
+import { authorizeOperatorScopesForRequiredScope } from "./method-scopes.js";
 import { normalizeOperatorScopeList, type OperatorScope } from "./operator-scopes.js";
 import type { GatewayNodeInvokeStream } from "./server-methods/shared-types.js";
-import type {
-  GatewayContextResolver,
-  GatewayRequestHandler,
-  GatewayRequestOptions,
-} from "./server-methods/types.js";
+import type { GatewayContextResolver, GatewayRequestHandler } from "./server-methods/types.js";
 import {
   dispatchGatewayMethodInProcess,
   dispatchGatewayMethodInProcessRaw,
   getInProcessGatewayRequestContext,
 } from "./server-plugin-in-process-dispatch.js";
-import { resolvePluginSubagentToolsAlsoAllow } from "./server-plugin-runtime-client.js";
 import {
-  normalizePluginSubagentAllowedModelRef,
-  normalizePluginSubagentRunRuntime,
-  resolvePluginSubagentRequestedModelRef,
+  canTrustedOfficialPluginRequestScopes,
+  createGatewaySubagentRuntime,
+  resolvePluginSubagentOverridePolicies,
+  type PluginSubagentOverridePolicies,
 } from "./server-plugin-subagent-runtime.js";
 import {
   createGatewayHooksRuntime,
@@ -71,135 +62,9 @@ export {
 };
 export type { GatewayMethodDispatchResponse } from "./server-plugin-in-process-dispatch.js";
 export { hasInProcessGatewayContext } from "./server-plugins-node-runtime.js";
-
-type PluginSubagentOverridePolicy = {
-  allowModelOverride: boolean;
-
-  allowAnyModel: boolean;
-  hasConfiguredAllowlist: boolean;
-  allowedModels: Set<string>;
-};
-
-type PluginSubagentOverridePolicies = Record<string, PluginSubagentOverridePolicy>;
-
-function resolvePluginSubagentOverridePolicies(
-  cfg: OpenClawConfig,
-): PluginSubagentOverridePolicies {
-  const normalized = normalizePluginsConfig(cfg.plugins);
-  const policies: PluginSubagentOverridePolicies = {};
-  for (const [pluginId, entry] of Object.entries(normalized.entries)) {
-    const allowModelOverride = entry.subagent?.allowModelOverride === true;
-    const hasConfiguredAllowlist = entry.subagent?.hasAllowedModelsConfig === true;
-    const configuredAllowedModels = entry.subagent?.allowedModels ?? [];
-    const allowedModels = new Set<string>();
-    let allowAnyModel = false;
-    for (const modelRef of configuredAllowedModels) {
-      const normalizedModelRef = normalizePluginSubagentAllowedModelRef(modelRef);
-      if (!normalizedModelRef) {
-        continue;
-      }
-      if (normalizedModelRef === "*") {
-        allowAnyModel = true;
-        continue;
-      }
-      allowedModels.add(normalizedModelRef);
-    }
-    if (
-      !allowModelOverride &&
-      !hasConfiguredAllowlist &&
-      allowedModels.size === 0 &&
-      !allowAnyModel
-    ) {
-      continue;
-    }
-    policies[pluginId] = {
-      allowModelOverride,
-      allowAnyModel,
-      hasConfiguredAllowlist,
-      allowedModels,
-    };
-  }
-  return policies;
-}
-
-function authorizeFallbackModelOverride(params: {
-  policies: PluginSubagentOverridePolicies;
-  pluginId?: string;
-  provider?: string;
-  model?: string;
-}): { allowed: true } | { allowed: false; reason: string } {
-  const pluginId = params.pluginId?.trim();
-  if (!pluginId) {
-    return {
-      allowed: false,
-      reason: "provider/model override requires plugin identity in fallback subagent runs.",
-    };
-  }
-  const policy = params.policies[pluginId];
-  if (!policy?.allowModelOverride) {
-    return {
-      allowed: false,
-      reason:
-        `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
-        "See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent and search for: " +
-        "plugins.entries.<id>.subagent.allowModelOverride",
-    };
-  }
-  if (policy.allowAnyModel) {
-    return { allowed: true };
-  }
-  if (policy.hasConfiguredAllowlist && policy.allowedModels.size === 0) {
-    return {
-      allowed: false,
-      reason: `plugin "${pluginId}" configured subagent.allowedModels, but none of the entries normalized to a valid provider/model target.`,
-    };
-  }
-  if (policy.allowedModels.size === 0) {
-    return { allowed: true };
-  }
-  const requestedModelRef = resolvePluginSubagentRequestedModelRef(params);
-  if (!requestedModelRef) {
-    return {
-      allowed: false,
-      reason:
-        "fallback provider/model overrides that use an allowlist must resolve to a canonical provider/model target.",
-    };
-  }
-  if (policy.allowedModels.has(requestedModelRef)) {
-    return { allowed: true };
-  }
-  return {
-    allowed: false,
-    reason: `model override "${requestedModelRef}" is not allowlisted for plugin "${pluginId}".`,
-  };
-}
+export { createGatewaySubagentRuntime } from "./server-plugin-subagent-runtime.js";
 
 // ── Internal gateway dispatch for plugin runtime ────────────────────
-
-function hasAdminScope(client: GatewayRequestOptions["client"] | undefined): boolean {
-  const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
-  return scopes.includes(ADMIN_SCOPE);
-}
-
-function canClientUseModelOverride(client: GatewayRequestOptions["client"]): boolean {
-  return hasAdminScope(client) || client?.internal?.allowModelOverride === true;
-}
-
-function canTrustedOfficialPluginRequestScopes(params: {
-  pluginId?: string;
-  pluginOrigin?: PluginOrigin;
-  pluginTrustedOfficialInstall?: boolean;
-}): boolean {
-  if (!params.pluginId) {
-    return false;
-  }
-  if (params.pluginOrigin === "bundled" || params.pluginTrustedOfficialInstall === true) {
-    return true;
-  }
-  const registry = getActivePluginRegistry();
-  const record = registry?.plugins.find((entry) => entry.id === params.pluginId);
-  return record?.origin === "bundled" || record?.trustedOfficialInstall === true;
-}
 
 function resolveRuntimeNodeInvokeSyntheticScopes(params: {
   pluginId?: string;
@@ -231,183 +96,6 @@ export async function dispatchTrustedPluginGatewayMethod<T>(
     ...(syntheticScopes ? { syntheticScopes } : {}),
     ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
   });
-}
-
-const PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT = 1_000;
-
-export function createGatewaySubagentRuntime(
-  resolveGatewayContext?: GatewayContextResolver,
-  overridePolicies: PluginSubagentOverridePolicies = {},
-): PluginRuntime["subagent"] {
-  const getSessionMessages: PluginRuntime["subagent"]["getSessionMessages"] = async (params) => {
-    const scope = getPluginRuntimeGatewayRequestScope();
-    const limit =
-      params.limit == null || !Number.isFinite(params.limit)
-        ? undefined
-        : Math.min(
-            PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT,
-            Math.max(1, Math.floor(params.limit)),
-          );
-    const payload = await dispatchGatewayMethodInProcess<{ messages?: unknown[] }>(
-      "sessions.get",
-      {
-        key: params.sessionKey,
-        ...(limit != null && { limit }),
-      },
-      {
-        resolveGatewayContext,
-        ...(!scope?.client && canTrustedOfficialPluginRequestScopes(scope ?? {})
-          ? { operatorRoleActor: { kind: "system" as const } }
-          : {}),
-      },
-    );
-    return { messages: Array.isArray(payload?.messages) ? payload.messages : [] };
-  };
-
-  const subagentRuntime: PluginRuntime["subagent"] = {
-    async run(params) {
-      if (params.disableTools === true && (params.toolsAlsoAllow?.length ?? 0) > 0) {
-        throw new Error("Tool-free plugin subagent runs cannot request additive tools.");
-      }
-      const pluginSubagentRequester = resolvePluginSubagentCompletionRequester(
-        params.completionDelivery,
-      );
-      const scope = getPluginRuntimeGatewayRequestScope();
-      const pluginId =
-        typeof scope?.pluginId === "string" && scope.pluginId.trim()
-          ? scope.pluginId.trim()
-          : undefined;
-      const runtimePluginToolGrant = resolvePluginSubagentToolsAlsoAllow({
-        pluginId,
-        toolsAlsoAllow: params.toolsAlsoAllow,
-      });
-      const overrideRequested = Boolean(params.provider || params.model);
-      const hasRequestScopeClient = Boolean(scope?.client);
-      let allowOverride = hasRequestScopeClient && canClientUseModelOverride(scope?.client ?? null);
-      let allowSyntheticModelOverride = false;
-      if (overrideRequested && !allowOverride && !hasRequestScopeClient) {
-        const fallbackAuth = authorizeFallbackModelOverride({
-          policies: overridePolicies,
-          pluginId: scope?.pluginId,
-          provider: params.provider,
-          model: params.model,
-        });
-        if (!fallbackAuth.allowed) {
-          throw new Error(fallbackAuth.reason);
-        }
-        allowOverride = true;
-        allowSyntheticModelOverride = true;
-      }
-      if (overrideRequested && !allowOverride) {
-        throw new Error("provider/model override is not authorized for this plugin subagent run.");
-      }
-      const payload = await dispatchGatewayMethodInProcess<{
-        runId?: string;
-        sessionKey?: string;
-        runtime?: unknown;
-      }>(
-        "agent",
-        {
-          sessionKey: params.sessionKey,
-          message: params.message,
-          deliver: params.deliver ?? false,
-          ...(allowOverride && params.provider && { provider: params.provider }),
-          ...(allowOverride && params.model && { model: params.model }),
-          ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
-          ...(params.promptMode === "minimal" && { promptMode: params.promptMode }),
-          ...(params.lane && { lane: params.lane }),
-          ...(params.cwd && { cwd: params.cwd }),
-          ...(params.lightContext === true && { bootstrapContextMode: "lightweight" }),
-          // The gateway `agent` schema requires `idempotencyKey: NonEmptyString`,
-          // so fall back to a generated UUID when the caller omits it. Without
-          // this, plugin subagent runs (for example memory-core dreaming
-          // narrative) silently fail schema validation at the gateway.
-          idempotencyKey: params.idempotencyKey || randomUUID(),
-        },
-        {
-          allowSyntheticModelOverride,
-          agentRunTracking: "plugin_subagent",
-          ...(!scope?.client ? { operatorRoleActor: { kind: "system" as const } } : {}),
-          ...(pluginId ? { pluginRuntimeOwnerId: pluginId } : {}),
-          ...(pluginSubagentRequester ? { pluginSubagentRequester } : {}),
-          ...(runtimePluginToolGrant ? { runtimePluginToolGrant } : {}),
-          ...(params.disableTools === true ? { pluginSubagentToolsAllow: [] } : {}),
-          resolveGatewayContext,
-        },
-      );
-      const runId = payload?.runId;
-      if (typeof runId !== "string" || !runId) {
-        throw new Error("Gateway agent method returned an invalid runId.");
-      }
-      const sessionKey = payload?.sessionKey?.trim() || params.sessionKey;
-      const runtime = normalizePluginSubagentRunRuntime(payload?.runtime);
-      return { runId, sessionKey, ...(runtime ? { runtime } : {}) };
-    },
-    async waitForRun(params) {
-      const payload = await dispatchGatewayMethodInProcess<
-        Omit<AgentWaitResult, "status"> & { status?: string }
-      >(
-        "agent.wait",
-        {
-          runId: params.runId,
-          ...(params.timeoutMs != null && { timeoutMs: params.timeoutMs }),
-        },
-        { resolveGatewayContext },
-      );
-      const { status: rawStatus, error, ...metadata } = payload;
-      let status = rawStatus;
-      if (status === "completed" || status === "succeeded") {
-        status = "ok";
-      } else if (status === "error" && error?.trim().toLowerCase() === "completed") {
-        status = "ok";
-      }
-      if (status !== "ok" && status !== "error" && status !== "timeout" && status !== "pending") {
-        throw new Error(`Gateway agent.wait returned unexpected status: ${rawStatus}`);
-      }
-      return {
-        ...metadata,
-        status,
-        ...(status !== "ok" && error ? { error } : {}),
-      };
-    },
-    getSessionMessages,
-    async deleteSession(params) {
-      const scope = getPluginRuntimeGatewayRequestScope();
-      const pluginId =
-        typeof scope?.pluginId === "string" && scope.pluginId.trim()
-          ? scope.pluginId.trim()
-          : undefined;
-      const pluginOwnedCleanupOptions = pluginId
-        ? {
-            pluginRuntimeOwnerId: pluginId,
-            ...(!hasAdminScope(scope?.client)
-              ? {
-                  forceSyntheticClient: true,
-                  syntheticScopes: [ADMIN_SCOPE],
-                }
-              : {}),
-          }
-        : undefined;
-      await dispatchGatewayMethodInProcess(
-        "sessions.delete",
-        {
-          key: params.sessionKey,
-          deleteTranscript: params.deleteTranscript ?? true,
-        },
-        {
-          ...pluginOwnedCleanupOptions,
-          resolveGatewayContext,
-          ...(!scope?.client && canTrustedOfficialPluginRequestScopes(scope ?? {})
-            ? { operatorRoleActor: { kind: "system" as const } }
-            : {}),
-        },
-      );
-    },
-  };
-  if (resolveGatewayContext) {
-    bindGatewayContextResolver(subagentRuntime, resolveGatewayContext);
-  }
-  return subagentRuntime;
 }
 
 type GatewayRuntimeNodes = Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"];
@@ -534,7 +222,11 @@ function createGatewayPluginRuntimeBindings(
       },
       hooks: createGatewayHooksRuntime(resolveBoundGatewayContext),
       nodes: createGatewayNodesRuntime(resolveBoundGatewayContext, lifetime.signal),
-      subagent: createGatewaySubagentRuntime(resolveBoundGatewayContext, overridePolicies),
+      subagent: createGatewaySubagentRuntime(
+        resolveBoundGatewayContext,
+        overridePolicies,
+        lifetime.signal,
+      ),
     },
   };
 }

--- a/src/llm/stream.complete-host.test.ts
+++ b/src/llm/stream.complete-host.test.ts
@@ -5,7 +5,7 @@ import type {
   Context,
   Model,
 } from "@openclaw/llm-core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { bindModelLlmRuntime } from "./model-runtime-binding.js";
 import { completeSimple } from "./stream.js";
 import { createAssistantMessageEventStream } from "./utils/event-stream.js";
@@ -77,4 +77,73 @@ describe("LLM completion transport host", () => {
       completeSimple(bindModelLlmRuntime(model, runtime), { messages: [] }),
     ).resolves.toEqual(message);
   });
+
+  it.each(["expired authority", "aborted caller"] as const)(
+    "rejects an isolated completion with %s during transport setup before provider admission",
+    async (reason) => {
+      const { runHostPreparedIsolatedCompletion } =
+        await import("../agents/host-prepared-isolated-completion.js");
+      const registry = createApiRegistry();
+      const runtime = createLlmRuntime(registry);
+      const model = bindModelLlmRuntime(
+        {
+          api: "test-isolated-host-api",
+          provider: "test-isolated-host",
+          id: "test-isolated-host-model",
+          name: "Test Isolated Host Model",
+          baseUrl: "https://example.test",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 1024,
+          maxTokens: 512,
+        } satisfies Model,
+        runtime,
+      );
+      const providerStream = vi.fn((): AssistantMessageEventStreamContract => {
+        throw new Error("Unexpected provider admission");
+      });
+      registry.registerApiProvider({
+        api: model.api,
+        stream: providerStream,
+        streamSimple: providerStream,
+      });
+      let current = true;
+      const controller = new AbortController();
+      const run = runHostPreparedIsolatedCompletion({
+        authorization: {
+          owner: "host",
+          model,
+          auth: { apiKey: "test", source: "test", mode: "api-key" },
+        },
+        provider: model.provider,
+        modelId: model.id,
+        agentId: "main",
+        agentDir: "/tmp/isolated-host-agent",
+        workspaceDir: "/tmp/isolated-host-workspace",
+        config: {},
+        systemPrompt: "system",
+        prompt: "user",
+        timeoutMs: 1_000,
+        abortSignal: controller.signal,
+        assertCurrent: () => {
+          if (!current) {
+            throw new Error("Completion authority expired");
+          }
+        },
+      });
+      if (reason === "expired authority") {
+        current = false;
+      } else {
+        controller.abort(new Error("Completion caller aborted"));
+      }
+
+      await expect(run).rejects.toThrow(
+        reason === "expired authority"
+          ? "Completion authority expired"
+          : "Completion caller aborted",
+      );
+      expect(providerStream).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/llm/stream.ts
+++ b/src/llm/stream.ts
@@ -109,7 +109,11 @@ export async function completeSimple<TApi extends Api>(
   model: Model<TApi>,
   context: Context,
   options?: SimpleStreamOptions,
+  assertCurrent?: () => void,
 ): Promise<AssistantMessage> {
   await ensureTransportRuntimeHost();
+  // Runtime setup can outlive its caller. Admit only a current request to the provider.
+  assertCurrent?.();
+  options?.signal?.throwIfAborted();
   return await resolveRuntime(model).completeSimple(model, context, options);
 }

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -1013,6 +1013,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       resolveApiKeyForProvider: vi.fn<PluginRuntime["modelAuth"]["resolveApiKeyForProvider"]>(),
     },
     subagent: {
+      complete: vi.fn(),
       run: vi.fn(),
       waitForRun: vi.fn(),
       getSessionMessages: vi.fn(),

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -45,6 +45,7 @@ type InternalPluginLoadOverrides = {
 
 function createDeferredGatewaySubagentRuntime(runtime: PluginRuntime): PluginRuntime["subagent"] {
   return {
+    complete: (...args) => runtime.subagent.complete(...args),
     run: (...args) => runtime.subagent.run(...args),
     waitForRun: (...args) => runtime.subagent.waitForRun(...args),
     getSessionMessages: (...args) => runtime.subagent.getSessionMessages(...args),

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -585,6 +585,8 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
         }
         const subagent = getRuntimeProperty();
         return {
+          complete: (params) =>
+            withPluginRuntimePluginIdScope(pluginId, () => subagent.complete(params)),
           run: async (params) => {
             const { assertSessionIdentitiesOwned } = await loadSessionOwnership();
             return await withPluginRuntimePluginIdScope(pluginId, async () => {

--- a/src/plugins/registry.runtime-config.sqlite.test.ts
+++ b/src/plugins/registry.runtime-config.sqlite.test.ts
@@ -35,6 +35,7 @@ describe("plugin registry SQLite session ownership", () => {
         agents: { list: [{ id: "researcher", default: true }] },
       } as OpenClawConfig;
       const subagent = {
+        complete: vi.fn(async () => ({ text: "completed" })),
         run: vi.fn(async () => ({ runId: "workboard-run" })),
         waitForRun: vi.fn(async () => ({ status: "ok" as const })),
         getSessionMessages: vi.fn(async () => ({ messages: [] })),

--- a/src/plugins/registry.runtime-session-ownership.test.ts
+++ b/src/plugins/registry.runtime-session-ownership.test.ts
@@ -184,6 +184,7 @@ describe("plugin registry runtime session ownership", () => {
     };
     const typedEntries = entries as unknown as Record<string, SessionEntry>;
     const subagent = {
+      complete: vi.fn(async () => ({ text: "completed" })),
       run: vi.fn(async () => ({ runId: "subagent-run" })),
       waitForRun: vi.fn(async () => ({ status: "ok" as const })),
       getSessionMessages: vi.fn(async () => ({ messages: [] })),

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -51,6 +51,7 @@ function createCommandResult() {
 
 function createGatewaySubagentRuntime() {
   return {
+    complete: vi.fn(),
     run: vi.fn(),
     waitForRun: vi.fn(),
     getSessionMessages: vi.fn(),

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -176,6 +176,7 @@ function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
     throw new RequestScopedSubagentRuntimeError();
   };
   return {
+    complete: unavailable,
     run: unavailable,
     waitForRun: unavailable,
     getSessionMessages: unavailable,

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -223,12 +223,12 @@ function readExplicitCostUsd(raw: unknown): number | undefined {
   );
 }
 
-function finalizeCompletion(params: {
+export function finalizePluginLlmCompletion(params: {
   cfg: OpenClawConfig;
   hostPluginId?: string;
   suppressUsage?: boolean;
   rawUsage: unknown;
-  logger: RuntimeLogger;
+  logger?: RuntimeLogger;
   result: Omit<LlmCompleteResult, "usage">;
 }): LlmCompleteResult {
   const normalized = normalizeUsage(params.rawUsage as UsageLike | undefined);
@@ -252,7 +252,8 @@ function finalizeCompletion(params: {
     ...(normalized?.total !== undefined ? { totalTokens: normalized.total } : {}),
     ...(costUsd !== undefined ? { costUsd } : {}),
   };
-  params.logger.info("plugin llm completion", {
+  const logger = params.logger ?? toRuntimeLogger(defaultLogger);
+  logger.info("plugin llm completion", {
     caller: params.result.audit.caller,
     purpose: params.result.audit.purpose,
     sessionKey: params.result.audit.sessionKey,
@@ -641,7 +642,7 @@ export function createRuntimeLlm(
           authProfileId:
             executionProfile ?? requestedModelProfile ?? preferredProfile ?? modelProfile,
         });
-        return finalizeCompletion({
+        return finalizePluginLlmCompletion({
           cfg,
           hostPluginId: pluginPolicyId,
           rawUsage: result.usage,
@@ -698,7 +699,7 @@ export function createRuntimeLlm(
         .filter((c): c is { type: "text"; text: string } => c.type === "text")
         .map((c) => c.text)
         .join("");
-      return finalizeCompletion({
+      return finalizePluginLlmCompletion({
         cfg,
         hostPluginId: pluginPolicyId,
         // Provider failures resolve as messages; only visible successful output owns usage.

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -34,6 +34,15 @@ type SubagentRunParams = {
   cwd?: string;
 };
 
+type SubagentCompleteParams = {
+  agentId: string;
+  message: string;
+  extraSystemPrompt?: string;
+  model?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
+
 type PluginManagedWorktree = {
   id: string;
   path: string;
@@ -134,6 +143,8 @@ export type PluginRuntime = PluginRuntimeCore & {
     ) => Promise<T>;
   };
   subagent: {
+    /** Fresh, tool-free background inference under the existing subagent model policy. */
+    complete: (params: SubagentCompleteParams) => Promise<{ text: string }>;
     run: (params: SubagentRunParams) => Promise<SubagentRunResult>;
     waitForRun: (params: SubagentWaitParams) => Promise<AgentWaitResult>;
     getSessionMessages: (

--- a/src/process/background-work.test.ts
+++ b/src/process/background-work.test.ts
@@ -89,9 +89,9 @@ describe("background work admission", () => {
       const started = createDeferred();
       const active = owner.enqueue(async (signal) => {
         started.resolve();
-        await new Promise<void>((resolve) =>
-          signal.addEventListener("abort", () => resolve(), { once: true }),
-        );
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
         signal.throwIfAborted();
       });
       await started.promise;

--- a/src/process/background-work.test.ts
+++ b/src/process/background-work.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createBackgroundWorkOwner, getBackgroundWorkSnapshot } from "./background-work.js";
+import {
+  enqueueCommandInLane,
+  getCommandLaneSnapshot,
+  markGatewayDraining,
+  resetAllLanes,
+} from "./command-queue.js";
+import { resetCommandQueueStateForTest } from "./command-queue.test-support.js";
+import { getGatewayRestartDrainSignal } from "./gateway-work-admission.js";
+import { CommandLane } from "./lanes.js";
+
+vi.mock("../logging/diagnostic-runtime.js", () => ({
+  logLaneEnqueue: vi.fn(),
+  logLaneDequeue: vi.fn(),
+  diagnosticLogger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe("background work admission", () => {
+  beforeEach(resetCommandQueueStateForTest);
+  afterEach(resetCommandQueueStateForTest);
+
+  it("shares three slots, preserves owner widths and FIFO, and leaves foreground capacity free", async () => {
+    const parallel = createBackgroundWorkOwner({ owner: "plugin:parallel", maxConcurrent: 3 });
+    const serial = createBackgroundWorkOwner({ owner: "core:serial", maxConcurrent: 1 });
+    const gates = Array.from({ length: 3 }, () => createDeferred());
+    const parallelRuns = gates.map((gate) => parallel.enqueue(async () => await gate.promise));
+    const serialGate = createDeferred();
+    const order: number[] = [];
+    const first = serial.enqueue(async () => {
+      order.push(1);
+      await serialGate.promise;
+    });
+    const second = serial.enqueue(async () => {
+      order.push(2);
+    });
+    try {
+      expect(getBackgroundWorkSnapshot()).toMatchObject({ activeCount: 3, queuedCount: 2 });
+      await expect(enqueueCommandInLane(CommandLane.Main, async () => "foreground")).resolves.toBe(
+        "foreground",
+      );
+      gates[0]!.resolve();
+      await parallelRuns[0];
+      expect(order).toEqual([1]);
+      expect(getBackgroundWorkSnapshot()).toMatchObject({ activeCount: 3, queuedCount: 1 });
+      gates[1]!.resolve();
+      gates[2]!.resolve();
+      await Promise.all(parallelRuns);
+      expect(getCommandLaneSnapshot(serial.lane)).toMatchObject({ activeCount: 1, queuedCount: 1 });
+      serialGate.resolve();
+      await Promise.all([first, second]);
+      expect(order).toEqual([1, 2]);
+    } finally {
+      gates.forEach((gate) => gate.resolve());
+      serialGate.resolve();
+      await Promise.all([...parallelRuns, first, second]);
+    }
+  });
+
+  it("removes cancelled work immediately without invoking it or reordering its successors", async () => {
+    const owner = createBackgroundWorkOwner({ owner: "core:cancel", maxConcurrent: 1 });
+    const gate = createDeferred();
+    const active = owner.enqueue(async () => await gate.promise);
+    const controller = new AbortController();
+    const cancelledTask = vi.fn(async () => undefined);
+    const order: number[] = [];
+    const first = owner.enqueue(async () => {
+      order.push(1);
+    });
+    const cancelled = owner.enqueue(cancelledTask, { abortSignal: controller.signal });
+    const last = owner.enqueue(async () => {
+      order.push(2);
+    });
+    const rejection = expect(cancelled).rejects.toThrow("cancel background work");
+    controller.abort(new Error("cancel background work"));
+    await rejection;
+    expect(getBackgroundWorkSnapshot()).toMatchObject({ activeCount: 1, queuedCount: 2 });
+    gate.resolve();
+    await Promise.all([active, first, last]);
+    expect(cancelledTask).not.toHaveBeenCalled();
+    expect(order).toEqual([1, 2]);
+  });
+
+  it.each(["drain", "reset"])(
+    "cancels old work on restart %s and admits fresh work",
+    async (restart) => {
+      const owner = createBackgroundWorkOwner({ owner: "core:restart", maxConcurrent: 1 });
+      const started = createDeferred();
+      const active = owner.enqueue(async (signal) => {
+        started.resolve();
+        await new Promise<void>((resolve) =>
+          signal.addEventListener("abort", () => resolve(), { once: true }),
+        );
+        signal.throwIfAborted();
+      });
+      await started.promise;
+      const staleTask = vi.fn(async () => undefined);
+      const stale = owner.enqueue(staleTask);
+      const oldSignal = getGatewayRestartDrainSignal();
+      const activeRejected = expect(active).rejects.toThrow(/draining for restart|runtime reset/u);
+      const staleRejected = expect(stale).rejects.toThrow(/draining for restart|runtime reset/u);
+      if (restart === "drain") {
+        markGatewayDraining();
+      } else {
+        resetAllLanes();
+      }
+      await Promise.all([activeRejected, staleRejected]);
+      resetAllLanes();
+      expect(oldSignal.aborted).toBe(true);
+      expect(getGatewayRestartDrainSignal().aborted).toBe(false);
+      await expect(owner.enqueue(async () => "fresh")).resolves.toBe("fresh");
+      expect(staleTask).not.toHaveBeenCalled();
+      expect(getBackgroundWorkSnapshot()).toMatchObject({ activeCount: 0, queuedCount: 0 });
+    },
+  );
+});

--- a/src/process/background-work.ts
+++ b/src/process/background-work.ts
@@ -1,0 +1,99 @@
+import { getGroupRegistry, getLaneGroup } from "./command-queue.capacity-groups.js";
+import {
+  enqueueCommandInLane,
+  getCommandLaneSnapshot,
+  publishLaneConfiguration,
+} from "./command-queue.js";
+import type { CommandLaneSnapshot, CommandQueueEnqueueOptions } from "./command-queue.types.js";
+import { getGatewayRestartDrainSignal } from "./gateway-work-admission.js";
+import { CommandLane } from "./lanes.js";
+
+const BACKGROUND_WORK_GROUP = "background-work";
+const BACKGROUND_WORK_MAX_CONCURRENT = 3;
+
+/** Register a stable core/plugin owner key, never a session or run identifier.
+ * Only leaf work belongs here: a coordinator holding capacity must not await
+ * another background task, which could need the same occupied capacity. */
+export function createBackgroundWorkOwner(params: { owner: string; maxConcurrent: number }) {
+  const owner = params.owner.trim();
+  if (!owner) {
+    throw new Error("Background work requires a stable owner key");
+  }
+  if (
+    !Number.isInteger(params.maxConcurrent) ||
+    params.maxConcurrent < 1 ||
+    params.maxConcurrent > BACKGROUND_WORK_MAX_CONCURRENT
+  ) {
+    throw new Error(
+      `Background owner concurrency must be between 1 and ${BACKGROUND_WORK_MAX_CONCURRENT}`,
+    );
+  }
+  const lane = `${CommandLane.Background}:${owner}`;
+  const register = () => {
+    if (getLaneGroup(lane)) {
+      if (getCommandLaneSnapshot(lane).maxConcurrent !== params.maxConcurrent) {
+        throw new Error(
+          `Background owner ${owner} is already registered with different concurrency`,
+        );
+      }
+    } else {
+      const group = getGroupRegistry().groups.get(BACKGROUND_WORK_GROUP);
+      publishLaneConfiguration({
+        lanes: { [lane]: params.maxConcurrent },
+        groups: {
+          [BACKGROUND_WORK_GROUP]: {
+            budget: BACKGROUND_WORK_MAX_CONCURRENT,
+            members: [...(group?.members ?? []), lane],
+          },
+        },
+      });
+    }
+    return lane;
+  };
+  return {
+    get lane() {
+      return register();
+    },
+    enqueue<T>(
+      task: (signal: AbortSignal) => Promise<T>,
+      options?: CommandQueueEnqueueOptions,
+    ): Promise<T> {
+      const restartSignal = getGatewayRestartDrainSignal();
+      const signal = options?.abortSignal
+        ? AbortSignal.any([restartSignal, options.abortSignal])
+        : restartSignal;
+      return enqueueCommandInLane(
+        register(),
+        () => {
+          signal.throwIfAborted();
+          return task(signal);
+        },
+        { ...options, priority: "background", abortSignal: signal },
+      );
+    },
+  };
+}
+
+export function isBackgroundWorkLane(lane: string): boolean {
+  return getLaneGroup(lane)?.group === BACKGROUND_WORK_GROUP;
+}
+
+export function getBackgroundWorkSnapshot(): CommandLaneSnapshot {
+  const group = getGroupRegistry().groups.get(BACKGROUND_WORK_GROUP);
+  const members = [...(group?.members ?? [])].map((lane) => getCommandLaneSnapshot(lane));
+  const activeCount = members.reduce((sum, member) => sum + member.activeCount, 0);
+  return {
+    lane: CommandLane.Background,
+    activeCount,
+    queuedCount: members.reduce((sum, member) => sum + member.queuedCount, 0),
+    maxConcurrent: BACKGROUND_WORK_MAX_CONCURRENT,
+    draining: members.some((member) => member.draining),
+    generation: Math.max(0, ...members.map((member) => member.generation)),
+    blockedBy:
+      activeCount >= BACKGROUND_WORK_MAX_CONCURRENT
+        ? "group-budget"
+        : members.some((member) => member.queuedCount > 0 && member.blockedBy === "lane")
+          ? "lane"
+          : null,
+  };
+}

--- a/src/process/command-lane-diagnostics.ts
+++ b/src/process/command-lane-diagnostics.ts
@@ -1,3 +1,4 @@
+import { getBackgroundWorkSnapshot, isBackgroundWorkLane } from "./background-work.js";
 // Bounded diagnostics composition over the command queue's lane totals.
 // Static lanes get full snapshots; per-session (dynamic) lanes collapse into
 // one aggregate so a saturation snapshot can never become an unbounded payload.
@@ -6,7 +7,7 @@ import {
   getCommandLaneSnapshot,
   listCommandLaneTotals,
 } from "./command-queue.js";
-import { STATIC_COMMAND_LANES } from "./lanes.js";
+import { CommandLane, STATIC_COMMAND_LANES } from "./lanes.js";
 
 type DynamicCommandLaneSummary = {
   laneCount: number;
@@ -23,7 +24,9 @@ export function getCommandLaneDiagnostics(): {
 } {
   const lanes = [...STATIC_COMMAND_LANES]
     .toSorted()
-    .map((lane) => getCommandLaneSnapshot(lane))
+    .map((lane) =>
+      lane === CommandLane.Background ? getBackgroundWorkSnapshot() : getCommandLaneSnapshot(lane),
+    )
     // Disabled lanes disappear only once their outstanding work has cleared.
     .filter((lane) => lane.maxConcurrent > 0 || lane.activeCount > 0 || lane.queuedCount > 0);
   const dynamic: DynamicCommandLaneSummary = {
@@ -33,7 +36,7 @@ export function getCommandLaneDiagnostics(): {
     queuedLaneCount: 0,
   };
   for (const totals of listCommandLaneTotals()) {
-    if (STATIC_COMMAND_LANE_SET.has(totals.lane)) {
+    if (STATIC_COMMAND_LANE_SET.has(totals.lane) || isBackgroundWorkLane(totals.lane)) {
       continue;
     }
     dynamic.laneCount += 1;

--- a/src/process/command-queue.scoped-lanes.test.ts
+++ b/src/process/command-queue.scoped-lanes.test.ts
@@ -182,7 +182,6 @@ describe("scoped command lane lifecycle", () => {
       CommandLane.SystemAgent,
       CommandLane.Cron,
       CommandLane.CronNested,
-      CommandLane.SkillWorkshopReview,
       CommandLane.Subagent,
       CommandLane.Nested,
     ];

--- a/src/process/command-queue.state.ts
+++ b/src/process/command-queue.state.ts
@@ -30,6 +30,7 @@ export type QueueEntry = {
   taskTimeoutAbortGraceMs?: number;
   taskTimeoutReleaseSignal?: AbortSignal;
   onWait?: (waitMs: number, queuedAhead: number) => void;
+  releaseQueuedAbort?: () => void;
 };
 
 type QueueRing = {
@@ -147,8 +148,28 @@ export function dequeueLaneQueue(queue: LaneQueue): QueueEntry | undefined {
   if (entry) {
     delete entry.queued;
     queue.length -= 1;
+    entry.releaseQueuedAbort?.();
   }
   return entry;
+}
+
+/** Cancellation is infrequent; compact only its priority ring while keeping FIFO order. */
+export function removeLaneQueueEntry(queue: LaneQueue, entry: QueueEntry): boolean {
+  if (!entry.queued) {
+    return false;
+  }
+  const ring = getPriorityRing(queue, entry.priority);
+  const count = ring.length;
+  for (let index = 0; index < count; index += 1) {
+    const candidate = dequeueQueueRing(ring)!;
+    if (candidate !== entry) {
+      appendQueueRing(ring, candidate);
+    }
+  }
+  delete entry.queued;
+  queue.length -= 1;
+  entry.releaseQueuedAbort?.();
+  return true;
 }
 
 /**

--- a/src/process/command-queue.test-support.ts
+++ b/src/process/command-queue.test-support.ts
@@ -4,6 +4,8 @@ type CommandQueueStateShape = {
   lanes: Map<unknown, unknown>;
   nextTaskId: number;
   nextQueueSequence?: number;
+  laneGroups?: Map<unknown, unknown>;
+  laneGroupByLane?: Map<unknown, unknown>;
 };
 
 /** Hard-reset the process-global command queue between isolated tests. */
@@ -18,6 +20,8 @@ export function resetCommandQueueStateForTest(): void {
   }
 
   state.lanes.clear();
+  state.laneGroups?.clear();
+  state.laneGroupByLane?.clear();
   state.nextTaskId = 1;
   state.nextQueueSequence = 1;
 }

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -1,7 +1,7 @@
 // Command queue serializes and limits process execution for shared command lanes.
 import { AsyncLocalStorage } from "node:async_hooks";
 import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
-import { formatErrorMessage, readErrorName } from "../infra/errors.js";
+import { formatErrorMessage, readErrorName, toErrorObject } from "../infra/errors.js";
 import {
   diagnosticLogger as diag,
   logLaneDequeue,
@@ -548,7 +548,7 @@ export function enqueueCommandInLane<T>(
   opts?: CommandQueueEnqueueOptions,
 ): Promise<T> {
   if (opts?.abortSignal?.aborted) {
-    return Promise.reject(opts.abortSignal.reason);
+    return Promise.reject(toErrorObject(opts.abortSignal.reason, "Queued command aborted"));
   }
   const queueState = getQueueState();
   if (isGatewaySubordinateWorkAdmissionClosed()) {
@@ -582,7 +582,7 @@ export function enqueueCommandInLane<T>(
     if (signal) {
       const onAbort = () => {
         if (removeLaneQueueEntry(state.queue, entry)) {
-          entry.reject(signal.reason);
+          entry.reject(toErrorObject(signal.reason, "Queued command aborted"));
           retireIdleScopedCommandLane(state);
         }
       };

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -26,6 +26,7 @@ import {
   getQueueState,
   type LaneState,
   normalizeLane,
+  removeLaneQueueEntry,
   type QueueEntry,
   type QueuePriority,
 } from "./command-queue.state.js";
@@ -546,6 +547,9 @@ export function enqueueCommandInLane<T>(
   task: (marker: CommandLaneTaskMarker) => Promise<T>,
   opts?: CommandQueueEnqueueOptions,
 ): Promise<T> {
+  if (opts?.abortSignal?.aborted) {
+    return Promise.reject(opts.abortSignal.reason);
+  }
   const queueState = getQueueState();
   if (isGatewaySubordinateWorkAdmissionClosed()) {
     return Promise.reject(new GatewayDrainingError());
@@ -574,6 +578,17 @@ export function enqueueCommandInLane<T>(
       onWait: opts?.onWait,
     };
     enqueueLaneEntry(state, entry);
+    const signal = opts?.abortSignal;
+    if (signal) {
+      const onAbort = () => {
+        if (removeLaneQueueEntry(state.queue, entry)) {
+          entry.reject(signal.reason);
+          retireIdleScopedCommandLane(state);
+        }
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      entry.releaseQueuedAbort = () => signal.removeEventListener("abort", onAbort);
+    }
     logLaneEnqueue(cleaned, getLaneDepth(state));
     drainReadyCommandLane(cleaned);
     if (entry.queued) {

--- a/src/process/command-queue.types.ts
+++ b/src/process/command-queue.types.ts
@@ -33,6 +33,8 @@ export type CommandQueueTaskDeadline =
   | { kind: "unlimited" };
 
 export type CommandQueueEnqueueOptions = {
+  /** Cancels queued admission; the task owns cancellation after it starts. */
+  abortSignal?: AbortSignal;
   /** Called only when this entry remains queued after immediate lane admission. */
   onQueued?: () => void;
   warnAfterMs?: number;

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -578,6 +578,9 @@ export function tryBeginGatewaySuspendAdmission(
 export function resetGatewayWorkAdmission(): void {
   // SIGUSR1 can abandon old async chains before their finally blocks run.
   // Retire their ALS records so surviving chains must re-enter admission.
+  GATEWAY_WORK_ADMISSION_STATE.restartDrainController.abort(
+    new GatewayDrainingError("gateway runtime reset"),
+  );
   for (const admission of GATEWAY_WORK_ADMISSION_STATE.activeRootWork) {
     admission.references = 0;
     admission.retiredByReset = true;

--- a/src/process/lanes.ts
+++ b/src/process/lanes.ts
@@ -10,7 +10,7 @@ export const enum CommandLane {
    * group rather than by adding a slot outside the cron budget.
    */
   HookDispatch = "hook-dispatch",
-  SkillWorkshopReview = "skill-workshop-review",
+  Background = "background",
   Subagent = "subagent",
   Nested = "nested",
 }
@@ -23,7 +23,7 @@ export const STATIC_COMMAND_LANES = [
   CommandLane.Cron,
   CommandLane.CronNested,
   CommandLane.HookDispatch,
-  CommandLane.SkillWorkshopReview,
+  CommandLane.Background,
   CommandLane.Subagent,
   CommandLane.Nested,
 ] as const;

--- a/src/process/spawn-utils.test.ts
+++ b/src/process/spawn-utils.test.ts
@@ -35,6 +35,29 @@ function spawnOptionsAt(
 }
 
 describe("spawnWithFallback", () => {
+  it("does not retry a failed spawn after its caller authority expires", async () => {
+    const child = new EventEmitter() as ChildProcess;
+    const spawnMock = vi.fn(() => child);
+    let current = true;
+    const pending = spawnWithFallback({
+      argv: ["agent-cli"],
+      options: {},
+      fallbacks: [{ label: "no-detach", options: { detached: false } }],
+      spawnImpl: spawnMock,
+      assertCurrent: () => {
+        if (!current) {
+          throw new Error("Completion authority expired");
+        }
+      },
+    });
+    const rejected = expect(pending).rejects.toThrow("Completion authority expired");
+    current = false;
+    child.emit("error", Object.assign(new Error("spawn EBADF"), { code: "EBADF" }));
+
+    await rejected;
+    expect(spawnMock).toHaveBeenCalledOnce();
+  });
+
   it("retries on EBADF using fallback options", async () => {
     const spawnMock = vi
       .fn()

--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -16,10 +16,11 @@ type SpawnWithFallbackResult = {
 };
 
 type SpawnWithFallbackParams = {
+  assertCurrent?: () => void;
   argv: string[];
   options: SpawnOptions;
   fallbacks?: SpawnFallback[];
-  spawnImpl?: typeof spawn;
+  spawnImpl?: (command: string, args: string[], options: SpawnOptions) => ChildProcess;
   retryCodes?: string[];
   onFallback?: (err: unknown, fallback: SpawnFallback) => void;
 };
@@ -41,7 +42,7 @@ function shouldRetry(err: unknown, codes: string[]): boolean {
 }
 
 async function spawnAndWaitForSpawn(
-  spawnImpl: typeof spawn,
+  spawnImpl: NonNullable<SpawnWithFallbackParams["spawnImpl"]>,
   argv: string[],
   options: SpawnOptions,
 ): Promise<ChildProcess> {
@@ -100,6 +101,7 @@ export async function spawnWithFallback(
 
   let lastError: unknown;
   for (const [index, attempt] of attempts.entries()) {
+    params.assertCurrent?.();
     try {
       const child = await spawnAndWaitForSpawn(spawnImpl, params.argv, attempt.options);
       return {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -82,6 +82,7 @@ function isServiceManagedRuntime(): boolean {
 }
 
 type ChildAdapterInput = {
+  assertCurrent?: () => void;
   /** Own a separately signalable tree whose private IPC channel gates worker startup. */
   ownedWorker?: true;
   /** Preserve the supplied environment exactly by skipping environment-mutating spawn wrappers. */
@@ -102,6 +103,7 @@ type ChildAdapterInput = {
 export async function createChildAdapter(params: ChildAdapterInput): Promise<WorkerChildAdapter> {
   if (params.anchoredShellCommand !== undefined) {
     return await createServiceChildRelayAdapter({
+      assertCurrent: params.assertCurrent,
       command: process.platform === "win32" ? params.anchoredShellCommand : "/bin/sh",
       args: process.platform === "win32" ? [] : ["-c", params.anchoredShellCommand],
       windowsShellCommand: process.platform === "win32" ? params.anchoredShellCommand : undefined,
@@ -131,6 +133,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     isServiceManagedRuntime()
   ) {
     return await createServiceChildRelayAdapter({
+      assertCurrent: params.assertCurrent,
       command: preparedSpawn.command,
       args: preparedSpawn.args,
       argv0: preparedSpawn.argv0,
@@ -166,6 +169,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   };
 
   const spawned = await spawnWithFallback({
+    assertCurrent: params.assertCurrent,
     argv: [preparedSpawn.command, ...preparedSpawn.args],
     options,
     fallbacks:

--- a/src/process/supervisor/adapters/pty.ts
+++ b/src/process/supervisor/adapters/pty.ts
@@ -17,6 +17,7 @@ declare const WORKER_DEPLOY_BUILD: boolean;
 type PtyAdapter = SpawnProcessAdapter;
 
 export async function createPtyAdapter(params: {
+  assertCurrent?: () => void;
   shell: string;
   args: string[];
   cwd?: string;
@@ -47,6 +48,7 @@ export async function createPtyAdapter(params: {
   if (spawnEnv) {
     setPtyTerminalName({ env: spawnEnv, name: terminalName, platform: process.platform });
   }
+  params.assertCurrent?.();
   const pty = spawn(preparedSpawn.command, preparedSpawn.args, {
     cwd: params.cwd,
     env: spawnEnv,

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -123,6 +123,7 @@ function createOutputRelay(stream?: Readable) {
 }
 
 export async function createServiceChildRelayAdapter(params: {
+  assertCurrent?: () => void;
   command: string;
   args: string[];
   argv0?: string;
@@ -152,6 +153,7 @@ export async function createServiceChildRelayAdapter(params: {
   const controlFd = useWindowsJobAnchor ? undefined : reserveStdioEntry(stdio, "pipe");
   reserveStdioEntry(stdio, "ipc");
 
+  params.assertCurrent?.();
   const child = spawn(process.execPath, resolveRuntimeWorkerArgv(workerUrl), {
     stdio,
     // A detached Windows Job owner survives host loss long enough to clean up.

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -168,6 +168,8 @@ export function createProcessSupervisor(): ProcessSupervisor & {
   const waitForScope = (scopeKey: string): Promise<void> => waitForRuns(scopeKey);
 
   const startRun = async (input: SpawnInput, owner: OwnedRun): Promise<ManagedRun> => {
+    // A scope fence can outlive its caller; reject before replacing the surviving process.
+    input.assertCurrent?.();
     const { runId, scopeKey } = owner;
     const startedAtMs = Date.now();
     const startingTerminationReason = owner.terminationReason;
@@ -293,6 +295,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       const adapter =
         input.mode === "pty"
           ? await createPtyAdapter({
+              assertCurrent: input.assertCurrent,
               shell: expectDefined(input.argv[0], "spawn executable"),
               args: input.argv.slice(1),
               cwd: input.cwd,
@@ -300,11 +303,13 @@ export function createProcessSupervisor(): ProcessSupervisor & {
             })
           : input.mode === "anchored-shell"
             ? await createChildAdapter({
+                assertCurrent: input.assertCurrent,
                 anchoredShellCommand: input.command,
                 cwd: input.cwd,
                 env: input.env,
               })
             : await createChildAdapter({
+                assertCurrent: input.assertCurrent,
                 argv: input.argv,
                 argv0: input.argv0,
                 cwd: input.cwd,

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -82,6 +82,8 @@ export type SpawnProcessAdapter<WaitSignal = NodeJS.Signals | number | null> = {
 
 type SpawnBaseInput = {
   runId?: string;
+  /** Revalidate caller authority after queued startup and before each process launch. */
+  assertCurrent?: () => void;
   sessionId: string;
   backendId: string;
   scopeKey?: string;

--- a/src/skills/workshop/collection-review.ts
+++ b/src/skills/workshop/collection-review.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import { stableStringify } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { prepareSystemAgentRunAdmission } from "../../agents/admitted-run-context.js";
 import {
   listAgentIds,
   resolveAgentDir,
@@ -17,7 +16,6 @@ import { SessionManager } from "../../agents/sessions/index.js";
 import { canonicalizePath } from "../../agents/utils/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
-import { CommandLane } from "../../process/lanes.js";
 import {
   MAX_RECONCILED_SKILLS,
   MAX_RECONCILED_SKILL_BYTES,
@@ -31,6 +29,7 @@ import {
 } from "./collection-review-state.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
 import { readSkillUsageByFile } from "./curator.js";
+import { runSkillWorkshopReview } from "./review-run.js";
 
 const COLLECTION_REVIEW_SESSION_SEGMENT = "skill-collection-review";
 const COLLECTION_REVIEW_TIMEOUT_MS = 10 * 60_000;
@@ -86,53 +85,32 @@ async function runSkillCollectionReview(params: {
     ),
     assertCurrent: params.assertCurrent,
   };
-  const { runEmbeddedAgent } = await import("../../agents/embedded-agent.js");
-  const preparedRunAdmission = prepareSystemAgentRunAdmission(
-    params.config,
+  await runSkillWorkshopReview({
+    reviewKind: "collection-review",
+    sessionId,
+    sessionKey,
+    sandboxSessionKey: sessionKey,
+    sessionManager: SessionManager.inMemory(params.workspaceDir),
+    agentId: params.agentId,
+    trigger: "cron",
+    workspaceDir: params.workspaceDir,
+    config: params.config,
+    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+    prompt: buildCollectionReviewPrompt(skills, params.env),
+    provider: model.provider,
+    model: model.model,
+    ...(model.authProfileId
+      ? { authProfileId: model.authProfileId, authProfileIdSource: "user" as const }
+      : {}),
+    timeoutMs: COLLECTION_REVIEW_TIMEOUT_MS,
     runId,
-    params.agentId,
-    "skill-workshop.collection-review",
-  );
-  try {
-    await runEmbeddedAgent({
-      preparedRunAdmission,
-      sessionId,
-      sessionKey,
-      sandboxSessionKey: sessionKey,
-      sessionManager: SessionManager.inMemory(params.workspaceDir),
-      agentId: params.agentId,
-      trigger: "cron",
-      lane: CommandLane.SkillWorkshopReview,
-      agentHarnessId: "openclaw",
-      agentHarnessRuntimeOverride: "openclaw",
-      workspaceDir: params.workspaceDir,
-      config: params.config,
-      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
-      prompt: buildCollectionReviewPrompt(skills, params.env),
-      provider: model.provider,
-      model: model.model,
-      ...(model.authProfileId
-        ? { authProfileId: model.authProfileId, authProfileIdSource: "user" as const }
-        : {}),
-      modelSelectionLocked: true,
-      modelFallbacksOverride: [],
-      timeoutMs: COLLECTION_REVIEW_TIMEOUT_MS,
-      runId,
-      toolsAllow: ["skill_workshop"],
-      skillWorkshopProposalOnly: true,
-      disableTrajectory: true,
-      skillWorkshopCollectionReconcile: collectionReconcile,
-      skillWorkshopProposalEnv: params.env,
-      cleanupBundleMcpOnRunEnd: true,
-      bootstrapContextMode: "lightweight",
-      skillsSnapshot: { prompt: "", skills: [] },
-      verboseLevel: "off",
-      reasoningLevel: "off",
-      suppressToolErrorWarnings: true,
-    });
-  } finally {
-    preparedRunAdmission.close();
-  }
+    toolsAllow: ["skill_workshop"],
+    skillWorkshopCollectionReconcile: collectionReconcile,
+    skillWorkshopProposalEnv: params.env,
+    bootstrapContextMode: "lightweight",
+    skillsSnapshot: { prompt: "", skills: [] },
+    reasoningLevel: "off",
+  });
   if (!collectionReconcile.result) {
     throw new Error("Skill collection review ended without reconciling the collection.");
   }

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { prepareSystemAgentRunAdmission } from "../../agents/admitted-run-context.js";
 import {
   createCronCreatorAuthorityCapability,
   runWithCronCreatorAuthorityCapability,
@@ -15,7 +14,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-run-registry.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runWithGatewayIndependentRootWorkAdmission } from "../../process/gateway-work-admission.js";
-import { CommandLane } from "../../process/lanes.js";
 import type { RunSkillUsage } from "../runtime/run-usage.js";
 import { applyAutonomousSkillProposal } from "./autonomous-apply.js";
 import { recordSkillExperienceReviewOutcome } from "./collection-review-state.js";
@@ -26,6 +24,7 @@ import {
   selectCurrentSkillTurnMessages,
 } from "./experience-review-prompt.js";
 import { assertSkillReviewRunSucceeded } from "./review-outcome.js";
+import { runSkillWorkshopReview } from "./review-run.js";
 import type { SkillWorkshopProposalMutationBudget } from "./types.js";
 
 const EXPERIENCE_REVIEW_MIN_MODEL_ITERATIONS = 10;
@@ -443,66 +442,43 @@ async function runSkillExperienceReviewInner(
       config,
       agentId: foregroundPromptContext.agentId,
     });
-    const { runEmbeddedAgent } = await import("../../agents/embedded-agent.js");
-    const preparedRunAdmission = prepareSystemAgentRunAdmission(
-      config,
-      runId,
-      foregroundPromptContext.agentId,
-      "skill-workshop.experience",
-    );
-    let embeddedResult: Awaited<ReturnType<typeof runEmbeddedAgent>>;
-    try {
-      const run = () =>
-        runEmbeddedAgent({
-          ...foregroundPromptContext,
-          preparedRunAdmission,
-          sessionId: reviewSession.sessionId,
-          sessionKey: reviewSession.sessionKey,
-          // Delivery authority closes with the foreground turn and cannot be reused by this fork.
-          messageActionTurnCapability: undefined,
-          sessionManager: detachedSession,
-          sessionPersistence: "detached",
-          // Never occupy the foreground agent lane after the idle gate opens.
-          lane: CommandLane.SkillWorkshopReview,
-          agentHarnessId: "openclaw",
-          agentHarnessRuntimeOverride: "openclaw",
-          workspaceDir,
-          config,
-          prompt: buildSkillExperienceReviewPrompt({ ...candidate, existingSkills }),
-          provider: modelProviderId,
-          model: modelId,
-          modelSelectionLocked: true,
-          modelFallbacksOverride: [],
-          ...(candidate.ctx.authProfileId
-            ? { authProfileId: candidate.ctx.authProfileId, authProfileIdSource: "user" as const }
-            : {}),
-          timeoutMs: EXPERIENCE_REVIEW_TIMEOUT_MS,
-          runId,
-          silentExpected: true,
-          allowEmptyAssistantReplyAsSilent: true,
-          terminalReplyExpectation: "optional",
-          toolExecutionAllow: ["skill_workshop"],
-          cleanupBundleMcpOnRunEnd: true,
-          disableTrajectory: true,
-          skillWorkshopProposalOnly: true,
-          skillWorkshopUpdateProposals: true,
-          skillWorkshopAutonomousCapture: true,
-          skillWorkshopProposalMutationBudget: proposalMutationBudget,
-          skillWorkshopOrigin: {
-            agentId: foregroundPromptContext.agentId,
-            sessionKey: foregroundSessionKey,
-            ...(candidate.ctx.runId ? { runId: candidate.ctx.runId } : {}),
-          },
-          verboseLevel: "off",
-          suppressToolErrorWarnings: true,
-          ...(capability ? { cronCreatorAuthorityCapability: capability } : {}),
-        });
-      embeddedResult = capability
-        ? await runWithCronCreatorAuthorityCapability(capability, run)
-        : await run();
-    } finally {
-      preparedRunAdmission.close();
-    }
+    const run = () =>
+      runSkillWorkshopReview({
+        reviewKind: "experience",
+        ...foregroundPromptContext,
+        sessionId: reviewSession.sessionId,
+        sessionKey: reviewSession.sessionKey,
+        // Delivery authority closes with the foreground turn and cannot be reused by this fork.
+        messageActionTurnCapability: undefined,
+        sessionManager: detachedSession,
+        sessionPersistence: "detached",
+        workspaceDir,
+        config,
+        prompt: buildSkillExperienceReviewPrompt({ ...candidate, existingSkills }),
+        provider: modelProviderId,
+        model: modelId,
+        ...(candidate.ctx.authProfileId
+          ? { authProfileId: candidate.ctx.authProfileId, authProfileIdSource: "user" as const }
+          : {}),
+        timeoutMs: EXPERIENCE_REVIEW_TIMEOUT_MS,
+        runId,
+        silentExpected: true,
+        allowEmptyAssistantReplyAsSilent: true,
+        terminalReplyExpectation: "optional",
+        toolExecutionAllow: ["skill_workshop"],
+        skillWorkshopUpdateProposals: true,
+        skillWorkshopAutonomousCapture: true,
+        skillWorkshopProposalMutationBudget: proposalMutationBudget,
+        skillWorkshopOrigin: {
+          agentId: foregroundPromptContext.agentId,
+          sessionKey: foregroundSessionKey,
+          ...(candidate.ctx.runId ? { runId: candidate.ctx.runId } : {}),
+        },
+        ...(capability ? { cronCreatorAuthorityCapability: capability } : {}),
+      });
+    const embeddedResult = capability
+      ? await runWithCronCreatorAuthorityCapability(capability, run)
+      : await run();
 
     // A failed review can leave a pending proposal; never auto-apply it.
     assertSkillReviewRunSucceeded(embeddedResult);

--- a/src/skills/workshop/history-scan-review.ts
+++ b/src/skills/workshop/history-scan-review.ts
@@ -1,9 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { prepareSystemAgentRunAdmission } from "../../agents/admitted-run-context.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection-config.js";
 import { SessionManager } from "../../agents/sessions/index.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { CommandLane } from "../../process/lanes.js";
 import {
   buildSkillHistoryScanPrompt,
   type SkillHistoryScanPromptSession,
@@ -13,6 +11,7 @@ import {
   resolveSkillHistoryScanReviewOutcome,
   assertSkillReviewRunSucceeded,
 } from "./review-outcome.js";
+import { runSkillWorkshopReview } from "./review-run.js";
 import type { SkillWorkshopProposalReviewProgress } from "./types.js";
 
 export const HISTORY_SCAN_SESSION_SEGMENT = "skill-workshop-history-scan";
@@ -58,28 +57,18 @@ export async function runSkillHistoryScanReview(params: {
       }
     : undefined;
   const runId = params.runId ?? `${HISTORY_SCAN_SESSION_SEGMENT}:${randomUUID()}`;
-  const preparedRunAdmission = prepareSystemAgentRunAdmission(
-    params.config,
-    runId,
-    params.agentId,
-    "skill-workshop.history-scan",
-  );
   let runError: unknown;
   try {
     const sessionId = randomUUID();
     const sessionKey = `agent:${params.agentId}:${HISTORY_SCAN_SESSION_SEGMENT}:incognito-${sessionId}`;
-    const { runEmbeddedAgent } = await import("../../agents/embedded-agent.js");
-    const result = await runEmbeddedAgent({
-      preparedRunAdmission,
+    const result = await runSkillWorkshopReview({
+      reviewKind: "history-scan",
       sessionId,
       sessionKey,
       sandboxSessionKey: sessionKey,
       sessionManager: SessionManager.inMemory(params.workspaceDir),
       agentId: params.agentId,
       trigger: "manual",
-      lane: CommandLane.SkillWorkshopReview,
-      agentHarnessId: "openclaw",
-      agentHarnessRuntimeOverride: "openclaw",
       workspaceDir: params.workspaceDir,
       config: params.config,
       prompt: buildSkillHistoryScanPrompt({
@@ -88,30 +77,20 @@ export async function runSkillHistoryScanReview(params: {
       }),
       provider: modelRef.provider,
       model: modelRef.model,
-      // A smaller configured fallback must not receive a prompt sized for the primary model.
-      modelSelectionLocked: true,
-      modelFallbacksOverride: [],
       timeoutMs: HISTORY_SCAN_TIMEOUT_MS,
       runId,
       toolsAllow: ["skill_workshop"],
-      disableTrajectory: true,
-      skillWorkshopProposalOnly: true,
       skillWorkshopProposalEnv: params.env,
       skillWorkshopProposalMutationBudget: proposalMutationBudget,
       skillWorkshopProposalReviewCompletion: proposalReviewCompletion,
       skillWorkshopOrigin: { agentId: params.agentId, runId },
-      cleanupBundleMcpOnRunEnd: true,
       bootstrapContextMode: "lightweight",
       skillsSnapshot: { prompt: "", skills: [] },
-      verboseLevel: "off",
       reasoningLevel: "off",
-      suppressToolErrorWarnings: true,
     });
     assertSkillReviewRunSucceeded(result);
   } catch (error) {
     runError = error;
-  } finally {
-    preparedRunAdmission.close();
   }
   if (proposalReviewCompletion?.completed) {
     return proposalMutationBudget.completed;

--- a/src/skills/workshop/review-run.ts
+++ b/src/skills/workshop/review-run.ts
@@ -1,0 +1,50 @@
+import { prepareSystemAgentRunAdmission } from "../../agents/admitted-run-context.js";
+import type { RunEmbeddedAgentParams } from "../../agents/embedded-agent-runner/run/params.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createBackgroundWorkOwner } from "../../process/background-work.js";
+import { getGatewayRestartDrainSignal } from "../../process/gateway-work-admission.js";
+
+const reviews = createBackgroundWorkOwner({ owner: "core:skill-workshop", maxConcurrent: 1 });
+
+/** All Workshop reviewers share admission, model locking, and background capacity. */
+export async function runSkillWorkshopReview(
+  params: RunEmbeddedAgentParams & {
+    agentId: string;
+    config: OpenClawConfig;
+    reviewKind: "experience" | "history-scan" | "collection-review";
+  },
+) {
+  const { reviewKind, ...runParams } = params;
+  const restartSignal = getGatewayRestartDrainSignal();
+  const abortSignal = params.abortSignal
+    ? AbortSignal.any([restartSignal, params.abortSignal])
+    : restartSignal;
+  abortSignal.throwIfAborted();
+  const preparedRunAdmission = prepareSystemAgentRunAdmission(
+    params.config,
+    params.runId,
+    params.agentId,
+    `skill-workshop.${reviewKind}`,
+  );
+  try {
+    const { runEmbeddedAgent } = await import("../../agents/embedded-agent.js");
+    return await runEmbeddedAgent({
+      ...runParams,
+      preparedRunAdmission,
+      abortSignal,
+      lane: reviews.lane,
+      agentHarnessId: "openclaw",
+      agentHarnessRuntimeOverride: "openclaw",
+      // Review prompts and cloned prefixes are sized for this exact model.
+      modelSelectionLocked: true,
+      modelFallbacksOverride: [],
+      disableTrajectory: true,
+      skillWorkshopProposalOnly: true,
+      cleanupBundleMcpOnRunEnd: true,
+      verboseLevel: "off",
+      suppressToolErrorWarnings: true,
+    });
+  } finally {
+    preparedRunAdmission.close();
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Workshop reviews and dreaming used separate scheduling and execution plumbing, making background load hard to see and leaving dreaming to manage temporary agent sessions just to obtain text. Operators saw a dedicated workshop lane without a shared limit for this class of work.

## Why This Change Was Made

Use the existing command queue and capacity groups as the single background execution owner: three shared slots, stable owner keys, and a serial workshop owner. Queued cancellation removes work immediately; active completion holds capacity through runtime cleanup. Coordinating cron and foreground chat retain their independent lanes.

Dreaming uses an additive `runtime.subagent.complete` operation backed by the existing tool-free isolated inference owner. It preserves agent/profile selection, Gateway scopes and agent ceilings, subagent model-override policy, and trusted usage attribution. All workshop review entry points share the same admission/model-locking helper. Remove dreaming's private limiter and run/wait/read/delete session plumbing; keep startup cleanup for previously persisted sessions. Existing field-specific cron reconciliation remains the owner of operator customization.

## User Impact

System busyness shows one `background` row for shared load. Workshop remains serial and proposal-only. Dreaming keeps its source/purge revalidation and memory provenance boundaries; failed or empty diary inference reports a degraded outcome with its existing generic diary trace. No new settings, SQLite schema, or Gateway protocol version.

## Evidence

Exact-head CI is green: [run 33718007385, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33718007385) at `cbab4f2b7c88ee65ebf479ea8523f1d2aa1ef9ad`.

Production LOC: +1407/−1455 (net -48). Tests and test support: +1622/−1832 (net -210). Pure moves between the runtime owner modules and diary artifact modules cancel out in these net totals.

- Real isolated Gateway with actual WebSocket `diagnostics.lanes`: background 3/3 active, two waiting, workshop maximum one; foreground completed while background remained full; all active/queued counts returned to zero.
- Full production build, SDK exports, and Control UI asset checks passed. The complete rebased `check:changed` gate passed, including core/plugin types, lint, dead-code, schema, and boundary checks.
- Follow-up validation: 487 tests across 20 files and eight shards passed, covering Gateway authorization, queue cancellation, CLI process ownership, builtin completion, Codex/Copilot setup races, and memory deletion lineage. Earlier focused queue/workshop/dreaming suites also passed.
- End-to-end runtime proof: five workshop scenarios and two child-Gateway memory scenarios passed with deterministic mock model responses, including restricted-memory handling and explicit-agent consolidation.
- Independent review caught mutable input after queued authorization; admission now snapshots the request. ClawSweeper identified an authority expiry during asynchronous model setup; the canonical isolated owner now carries a live assertion through runtime/provider admission, CLI launch and retries, native Codex RPC writes, and Copilot SDK calls. Parent-tool closure also aborts queued or active completion. Both bugs have failing-before/passing-after regression evidence; cleanup remains available after expiry.
- Reconciled current main while preserving disabled-lane visibility, operator-role attribution, moved session-ownership tests, and shared Codex fixtures; the seven-file integration rerun passed.
- CI retry: the unchanged `chat-pane-placement-restart` test hit its lazy-dialog readiness timeout in the full UI shard. It passed in isolation and all 3,759 tests in its UI shard passed on the same-commit retry; the full retry job and aggregate CI gate are green. Named follow-up: synchronize that test’s lazy imports before the DOM wait; the recent placement-dialog teardown repair is #136354. No runtime/test code was changed for the retry.
- The complete rebased independent review is clean through P2. The implementation reuses each runtime’s cancellation contract after admission; it does not claim control of opaque SDK transport internals.

## SDK Support and Compatibility

`runtime.subagent.complete` is an intentional supported host-provided capability for this generic background-work refactor. Core owns admission, capacity, cancellation, and lifecycle. Existing subagent methods remain unchanged; plugins adopting the new method require the release that first contains it and must declare that minimum host version once assigned. Code constructing a complete `PluginRuntime` against the new SDK must add this member or use `createPluginRuntimeMock` with partial overrides; the canonical helper and in-tree constructors are updated. There is no session-based fallback for older hosts. The scheduling default intentionally becomes three shared slots with Workshop capped at one; existing configuration keys and cron customization remain unchanged.

## Memory Compatibility

This changes inference scheduling and lifecycle, not persisted memory data. The 19 moved diary/backfill helpers retain their markers, formatting, fingerprints, date bucketing, atomic writes, purge locking, and public exports. SQLite schemas, indexes, retention, origin records, staging stores, and backfill cursors are unchanged. Existing startup cleanup retains its age guard and cutoff for historical temporary sessions; new prompt-only completions create no temporary sessions. Artifact round-trip, purge races, backfill rollback, and reopened-store forget/lineage coverage preserve those contracts. No migration is needed.

Before is a synthetic reconstruction of the previous diagnostics row. After is the running Control UI replaying snapshots recorded from the real Gateway probe. Both images contain synthetic data only.

| Before | After |
| --- | --- |
| ![Previous workshop lane](https://github.com/user-attachments/assets/d7947064-0bd5-4953-a3ee-8ee34158040a) | ![Shared background queue saturated](https://github.com/user-attachments/assets/5614752e-fcb5-4a2c-9262-88319d2d1f9e) |

Video of the same running-UI replay (synthetic previous row, then real Gateway peak/foreground/drained snapshots):

https://github.com/user-attachments/assets/6be5ed81-a344-4c1b-be8d-c42552bbb547
