### PR TITLE
fix(routing): keep returned routes independent of cached state

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -1418,6 +1418,23 @@ describe("wildcard peer bindings (peer.id=*)", () => {
 });
 
 describe("resolved route cache keys", () => {
+  test("keeps cached routes independent of returned route mutations", () => {
+    const input: Parameters<typeof resolveAgentRoute>[0] = {
+      cfg: { agents: { entries: { main: {} } } },
+      channel: "discord",
+      peer: { kind: "direct", id: "user-1" },
+    };
+    let route = resolveAgentRoute(input);
+    const expected = { ...route };
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      route.agentId = "caller-owned-agent";
+      route.sessionKey = "caller-owned-session";
+      route = resolveAgentRoute(input);
+      expect(route).toEqual(expected);
+    }
+  });
+
   test("does not reuse a cached route when peer and guild fields contain cache separators", () => {
     const cfg: OpenClawConfig = {
       agents: { list: [{ id: "whole-peer" }, { id: "guild-room" }] },

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -345,39 +345,16 @@ function pushToIndexMap(
   map.set(key, [binding]);
 }
 
-function peerLookupKeys(kind: ChatType, id: string): string[] {
-  if (kind === "group") {
-    return [`group:${id}`, `channel:${id}`];
-  }
-  if (kind === "channel") {
-    return [`channel:${id}`, `group:${id}`];
-  }
-  return [`${kind}:${id}`];
+function peerLookupKey(kind: ChatType, id: string): string {
+  // Group/channel matching is interchangeable; share one source-ordered bucket.
+  return `${kind === "channel" ? "group" : kind}:${id}`;
 }
 
-function collectPeerIndexedBindings(
+function getPeerIndexedBindings(
   index: EvaluatedBindingsIndex,
   peer: RoutePeer | null,
 ): EvaluatedBinding[] {
-  if (!peer) {
-    return [];
-  }
-  const out: EvaluatedBinding[] = [];
-  const seen = new Set<EvaluatedBinding>();
-  for (const key of peerLookupKeys(peer.kind, peer.id)) {
-    const matches = index.byPeer.get(key);
-    if (!matches) {
-      continue;
-    }
-    for (const match of matches) {
-      if (seen.has(match)) {
-        continue;
-      }
-      seen.add(match);
-      out.push(match);
-    }
-  }
-  return out;
+  return peer ? (index.byPeer.get(peerLookupKey(peer.kind, peer.id)) ?? []) : [];
 }
 
 function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBindingsIndex {
@@ -391,9 +368,11 @@ function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBin
 
   for (const binding of bindings) {
     if (binding.match.peer.state === "valid") {
-      for (const key of peerLookupKeys(binding.match.peer.kind, binding.match.peer.id)) {
-        pushToIndexMap(byPeer, key, binding);
-      }
+      pushToIndexMap(
+        byPeer,
+        peerLookupKey(binding.match.peer.kind, binding.match.peer.id),
+        binding,
+      );
       continue;
     }
     if (binding.match.peer.state === "wildcard-kind") {
@@ -717,6 +696,8 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
         routeCache.clear();
         routeCache.set(routeCacheKey, route);
       }
+      // Cold and warm returns are caller-owned; edits must not poison the cache.
+      return { ...route };
     }
     return route;
   };
@@ -763,13 +744,13 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       matchedBy: "binding.peer",
       enabled: Boolean(peer),
       scopePeer: peer,
-      candidates: collectPeerIndexedBindings(bindingsIndex, peer),
+      candidates: getPeerIndexedBindings(bindingsIndex, peer),
     },
     {
       matchedBy: "binding.peer.parent",
       enabled: Boolean(parentPeer && parentPeer.id),
       scopePeer: parentPeer && parentPeer.id ? parentPeer : null,
-      candidates: collectPeerIndexedBindings(bindingsIndex, parentPeer),
+      candidates: getPeerIndexedBindings(bindingsIndex, parentPeer),
     },
     {
       matchedBy: "binding.peer.wildcard",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a caller editing its first resolved route could change the agent or session returned by later routing calls. Warm cache hits already returned independent objects, but a cold miss exposed the cache's own object.

## Why This Change Was Made

Keep cached routes privately owned and return a mutable copy on cold misses, matching the existing warm path. The same resolver now stores group/channel bindings in one source-ordered peer bucket, removing duplicate buckets and the collector that reconstructed their identical contents. Concrete peer kinds remain intact in match records, session keys and route-cache keys.

## User Impact

Editing one returned route no longer changes later routing decisions. Direct, wildcard, parent, guild, role, team and account precedence remain unchanged. The route index retains fewer duplicate arrays and references.

Production LOC: +14/−33 (net −19); tests +17. The ownership fix requires one additional flat route copy per cache miss. No configuration, persistence, dependency, protocol or routing-policy change.

## Evidence

The actual exported-function reproduction and the new regression both failed before the repair: changing the first result's `agentId` and `sessionKey` polluted the next result. Both pass afterward, and the regression also checks mutation of a warm result.

All 97 tests across the routing owner, bound-account, route-target and inbound-envelope suites pass. The complete changed-file gate passes, and independent managed Codex review through P2 is clean. The reviewed patch is byte-identical after rebasing onto repaired main.

A fixed actual-owner workload of 250 rooms, three mixed-kind bindings per room and 1,000 route-cache misses produced identical complete routes, 20 independently asserted routing cases, projections, sibling selections and core inbound envelopes. Peer bucket arrays fell from 500 to 250, stored binding references from 1,500 to 750, and peer-map reads from 4,000 to 2,000. The 2,000 temporary collector sets and 2,000 collector arrays are removed. These are logical container and operation counts, not retained-heap, RSS or latency measurements. The inbound-envelope proof uses synthetic inputs and the documented no-history-read option; it does not claim an external channel send.
