### PR TITLE
chore(doctor): simplify browser warning assertion

### DIFF
--- a/src/commands/doctor-browser.facade.test.ts
+++ b/src/commands/doctor-browser.facade.test.ts
@@ -14,14 +14,6 @@ vi.mock("../plugin-sdk/facade-loader.js", () => ({
   loadBundledPluginPublicSurfaceModuleSyncCore,
 }));
 
-function requireFirstNoteCall(noteFn: ReturnType<typeof vi.fn>): unknown[] {
-  const call = noteFn.mock.calls[0];
-  if (!call) {
-    throw new Error("expected browser doctor note");
-  }
-  return call;
-}
-
 describe("doctor browser facade", () => {
   beforeEach(() => {
     loadBundledPluginPublicSurfaceModuleSyncCore.mockReset();
@@ -178,10 +170,9 @@ describe("doctor browser facade", () => {
     const noteFn = vi.fn();
 
     await expect(noteChromeMcpBrowserReadiness({}, { noteFn })).resolves.toBeUndefined();
-    expect(noteFn).toHaveBeenCalledTimes(1);
-    expect(requireFirstNoteCall(noteFn)).toEqual([
+    expect(noteFn).toHaveBeenCalledExactlyOnceWith(
       "- Browser health check is unavailable: missing browser doctor facade",
       "Browser",
-    ]);
+    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The browser Doctor warning test repeats mock-call extraction and cardinality checks around one existing warning assertion.

## Why This Change Was Made

Use Vitest’s existing exact-once matcher and remove the one-use wrapper. Preserve the resolved result, exactly one call, exactly two arguments, and the full warning message and title.

## User Impact

No runtime or user-visible change. All eight browser facade cases remain in their original order; production LOC is unchanged and test LOC is reduced by nine lines.

## Evidence

- Unchanged browser facade baseline: 8 tests passed.
- Updated facade, browser-residue, and sandbox suites: 20 tests passed across 3 files through the normal runner.
- Full one-path changed gate: all 20 configured stages passed, including command test types, all three dead-export scans, and typed lint.
- Scoped formatting, diff check, and independent Codex review passed with no actionable findings through P2.
- Direct inspection of installed Vitest 4.1.11 confirmed that the matcher preserves call count, argument count, and equality checks.
