### PR TITLE
fix(cron): keep current-session media in Control UI history

### DIFF
--- a/src/cron/isolated-agent/current-session-completion.ts
+++ b/src/cron/isolated-agent/current-session-completion.ts
@@ -4,11 +4,13 @@ import {
   projectOutboundPayloadPlanForMirror,
 } from "../../infra/outbound/payloads.js";
 import { commitBackgroundResultToSession } from "../../sessions/background-session-result.js";
+import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { createCronExecutionId } from "../run-id.js";
 import {
   buildDirectCronTranscriptMirrorPayloads,
   resolveDirectCronTranscriptMirrorText,
 } from "./delivery-dispatch-awareness.js";
+import { logCronDeliveryWarn } from "./delivery-dispatch-policy.js";
 import type { DispatchCronDeliveryParams } from "./delivery-dispatch-types.js";
 import { resolvedDeliveryTargetsExternalChannel } from "./delivery-target.js";
 
@@ -16,8 +18,28 @@ type CurrentSessionCompletionResult =
   | { ok: false; reason: string }
   | { ok: true; requiresExternalDelivery: boolean; deliveryError?: string };
 
+const currentSessionCompletionMediaRuntimeLoader = createLazyImportLoader(async () => {
+  const [assistantContent, assistantDisplay, managedMedia, localRoots] = await Promise.all([
+    import("../../gateway/server-methods/chat-assistant-content.js"),
+    import("../../shared/assistant-display-content.js"),
+    import("../../gateway/managed-image-attachments.js"),
+    import("../../media/local-roots.js"),
+  ]);
+  return {
+    attachManagedOutgoingMediaToMessage: managedMedia.attachManagedOutgoingMediaToMessage,
+    buildAssistantDisplayContentFromReplyPayloads:
+      assistantContent.buildAssistantDisplayContentFromReplyPayloads,
+    getAgentScopedMediaLocalRootsForSources: localRoots.getAgentScopedMediaLocalRootsForSources,
+    hasAssistantDisplayMediaContent: assistantContent.hasAssistantDisplayMediaContent,
+    hasManagedOutgoingAssistantContent: assistantContent.hasManagedOutgoingAssistantContent,
+    readAssistantDisplayContent: assistantDisplay.readAssistantDisplayContent,
+    removeManagedOutgoingMediaBlocks: managedMedia.removeManagedOutgoingMediaBlocks,
+  };
+});
+
 export async function commitCurrentSessionCronCompletion(
   params: DispatchCronDeliveryParams,
+  deliveryPayloads: DispatchCronDeliveryParams["deliveryPayloads"],
   text?: string,
 ): Promise<CurrentSessionCompletionResult> {
   const sourceSessionKey = params.sourceSessionKey?.trim();
@@ -30,26 +52,93 @@ export async function commitCurrentSessionCronCompletion(
   const completionText =
     resolveDirectCronTranscriptMirrorText(
       projectOutboundPayloadPlanForMirror(
-        createOutboundPayloadPlan(buildDirectCronTranscriptMirrorPayloads(params.deliveryPayloads)),
+        createOutboundPayloadPlan(buildDirectCronTranscriptMirrorPayloads(deliveryPayloads)),
       ),
     ) ?? normalizeOptionalString(text);
   if (!completionText) {
     return { ok: false, reason: "current cron completion has no durable transcript projection" };
   }
+
+  const mediaSources = deliveryPayloads.flatMap((payload) => [
+    ...(payload.mediaUrls ?? []),
+    ...(payload.mediaUrl ? [payload.mediaUrl] : []),
+  ]);
+  const mediaRuntime =
+    mediaSources.length > 0 ? await currentSessionCompletionMediaRuntimeLoader.load() : undefined;
+  const assistantContent = mediaRuntime
+    ? await mediaRuntime.buildAssistantDisplayContentFromReplyPayloads({
+        sessionKey: sourceSessionKey,
+        agentId: params.agentId,
+        payloads: deliveryPayloads,
+        managedMediaLocalRoots: mediaRuntime.getAgentScopedMediaLocalRootsForSources({
+          cfg: params.cfgWithAgentDefaults,
+          agentId: params.agentId,
+          mediaSources,
+        }),
+        includeSensitiveMedia: false,
+        onManagedMediaPrepareError: (message) => {
+          void logCronDeliveryWarn(
+            `[cron:${params.job.id}] current-session media embedding skipped attachment: ${message}`,
+          );
+        },
+      })
+    : undefined;
+  const hasDisplayMedia = mediaRuntime?.hasAssistantDisplayMediaContent(assistantContent) ?? false;
+  const hasManagedMedia =
+    mediaRuntime?.hasManagedOutgoingAssistantContent(assistantContent) ?? false;
+  const displayContent = hasDisplayMedia ? assistantContent : undefined;
+  const cleanupPreparedMedia = async () => {
+    if (mediaRuntime && displayContent) {
+      await mediaRuntime.removeManagedOutgoingMediaBlocks({
+        blocks: displayContent,
+        messageId: null,
+      });
+    }
+  };
+
+  let preparedMediaCommitted = false;
   const runId = createCronExecutionId(params.job.id, params.runStartedAt);
   const committed = await commitBackgroundResultToSession({
     agentId: params.agentId,
     sessionKey: sourceSessionKey,
     expectedGeneration: params.sourceSessionGeneration,
     text: completionText,
+    ...(displayContent ? { displayContent } : {}),
+    ...(hasManagedMedia && mediaRuntime
+      ? {
+          onMessageCommitted: (result) => {
+            // The committed row owns either these prepared blocks or the original
+            // bytes from an idempotent retry; bind exactly that durable content.
+            preparedMediaCommitted = result.appended;
+            if (
+              !mediaRuntime.attachManagedOutgoingMediaToMessage({
+                messageId: result.messageId,
+                blocks: mediaRuntime.readAssistantDisplayContent(result.message),
+              })
+            ) {
+              throw new Error("current-session media ownership could not be persisted");
+            }
+          },
+        }
+      : {}),
     idempotencyKey: `cron-current-completion:${runId}`,
     provenance: { kind: "cron", jobId: params.job.id, runId },
     config: params.cfgWithAgentDefaults,
     signal: params.abortSignal,
+  }).catch(async (error: unknown) => {
+    if (!preparedMediaCommitted) {
+      await cleanupPreparedMedia();
+    }
+    throw error;
   });
   if (!committed.ok) {
+    await cleanupPreparedMedia();
     return committed;
   }
+  if (!committed.appended) {
+    await cleanupPreparedMedia();
+  }
+
   if (params.sourceDeliveryOutcome.satisfiesSourceDelivery) {
     return { ok: true, requiresExternalDelivery: false };
   }

--- a/src/cron/isolated-agent/current-session-completion.ts
+++ b/src/cron/isolated-agent/current-session-completion.ts
@@ -84,8 +84,6 @@ export async function commitCurrentSessionCronCompletion(
       })
     : undefined;
   const hasDisplayMedia = mediaRuntime?.hasAssistantDisplayMediaContent(assistantContent) ?? false;
-  const hasManagedMedia =
-    mediaRuntime?.hasManagedOutgoingAssistantContent(assistantContent) ?? false;
   const displayContent = hasDisplayMedia ? assistantContent : undefined;
   const cleanupPreparedMedia = async () => {
     if (mediaRuntime && displayContent) {
@@ -104,16 +102,22 @@ export async function commitCurrentSessionCronCompletion(
     expectedGeneration: params.sourceSessionGeneration,
     text: completionText,
     ...(displayContent ? { displayContent } : {}),
-    ...(hasManagedMedia && mediaRuntime
+    ...(mediaRuntime
       ? {
           onMessageCommitted: (result) => {
             // The committed row owns either these prepared blocks or the original
             // bytes from an idempotent retry; bind exactly that durable content.
             preparedMediaCommitted = result.appended;
+            const committedDisplayContent = mediaRuntime.readAssistantDisplayContent(
+              result.message,
+            );
+            if (!mediaRuntime.hasManagedOutgoingAssistantContent(committedDisplayContent)) {
+              return;
+            }
             if (
               !mediaRuntime.attachManagedOutgoingMediaToMessage({
                 messageId: result.messageId,
-                blocks: mediaRuntime.readAssistantDisplayContent(result.message),
+                blocks: committedDisplayContent,
               })
             ) {
               throw new Error("current-session media ownership could not be persisted");

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -3781,6 +3781,104 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     });
   });
 
+  it("skips ownership attachment when the canonical retry row has no managed media", async () => {
+    const displayContent = [
+      {
+        type: "image",
+        url: "/api/chat/media/outgoing/source-session-id/attachment/retry.png",
+      },
+    ];
+    const committedDisplayContent = [
+      { type: "text", text: "Report attached." },
+      {
+        type: "attachment_error",
+        attachment: { code: "delivery-failed", kind: "image", label: "report.png" },
+      },
+    ];
+    buildAssistantDisplayContentFromReplyPayloadsMock.mockResolvedValueOnce(displayContent);
+    commitBackgroundResultToSessionMock.mockImplementationOnce(
+      async (params: {
+        onMessageCommitted?: (result: {
+          appended: boolean;
+          message: Record<string, unknown>;
+          messageId: string;
+        }) => void;
+      }) => {
+        const messageId = "existing-current-completion-message";
+        params.onMessageCommitted?.({
+          appended: false,
+          message: { [ASSISTANT_DISPLAY_CONTENT_FIELD]: committedDisplayContent },
+          messageId,
+        });
+        return { ok: true, messageId, appended: false };
+      },
+    );
+    const params = makeCurrentSessionMediaParams({
+      text: "Report attached.",
+      mediaUrl: "https://example.com/retry.png?token=redacted",
+      runStartedAt: 2_575,
+    });
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state).toMatchObject({ delivered: true, deliveryAttempted: true });
+    expect(attachManagedOutgoingMediaToMessageMock).not.toHaveBeenCalled();
+    expect(removeManagedOutgoingMediaBlocksMock).toHaveBeenCalledWith({
+      blocks: displayContent,
+      messageId: null,
+    });
+  });
+
+  it("repairs canonical managed ownership when retry media preparation fails", async () => {
+    const displayContent = [
+      { type: "text", text: "Report attached." },
+      {
+        type: "attachment_error",
+        attachment: { code: "delivery-failed", kind: "image", label: "report.png" },
+      },
+    ];
+    const committedDisplayContent = [
+      {
+        type: "image",
+        url: "/api/chat/media/outgoing/source-session-id/attachment/original.png",
+      },
+    ];
+    buildAssistantDisplayContentFromReplyPayloadsMock.mockResolvedValueOnce(displayContent);
+    commitBackgroundResultToSessionMock.mockImplementationOnce(
+      async (params: {
+        onMessageCommitted?: (result: {
+          appended: boolean;
+          message: Record<string, unknown>;
+          messageId: string;
+        }) => void;
+      }) => {
+        const messageId = "existing-current-completion-message";
+        params.onMessageCommitted?.({
+          appended: false,
+          message: { [ASSISTANT_DISPLAY_CONTENT_FIELD]: committedDisplayContent },
+          messageId,
+        });
+        return { ok: true, messageId, appended: false };
+      },
+    );
+    const params = makeCurrentSessionMediaParams({
+      text: "Report attached.",
+      runStartedAt: 2_590,
+    });
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state).toMatchObject({ delivered: true, deliveryAttempted: true });
+    expect(attachManagedOutgoingMediaToMessageMock).toHaveBeenCalledWith({
+      messageId: "existing-current-completion-message",
+      blocks: committedDisplayContent,
+    });
+    expect(removeManagedOutgoingMediaBlocksMock).toHaveBeenCalledWith({
+      blocks: displayContent,
+      messageId: null,
+    });
+  });
+
   it("commits text and media from the finalized current-target payload", async () => {
     const displayContent = [
       { type: "text", text: "Report attached." },

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -15,6 +15,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ChannelMessagingAdapter } from "../../channels/plugins/types.public.js";
 import * as deliveryQueueSqlite from "../../infra/delivery-queue-sqlite.js";
+import { ASSISTANT_DISPLAY_CONTENT_FIELD } from "../../shared/assistant-display-content.js";
 
 const directCronCompletionRetention = {
   idPrefix: "cron-direct-delivery:v1:",
@@ -26,12 +27,15 @@ const directCronCompletionRetention = {
 
 const {
   appendAssistantMessageToSessionTranscriptMock,
+  attachManagedOutgoingMediaToMessageMock,
+  buildAssistantDisplayContentFromReplyPayloadsMock,
   commitBackgroundResultToSessionMock,
   countActiveDescendantRunsMock,
   deliverOutboundPayloadsMock,
   ensureOutboundSessionEntryMock,
   loadCronSessionEntryLatestMock,
   maybeApplyTtsToPayloadMock,
+  removeManagedOutgoingMediaBlocksMock,
   retireSessionMcpRuntimeMock,
   resolveOutboundSessionRouteMock,
 } = vi.hoisted(() => ({
@@ -40,15 +44,19 @@ const {
     sessionFile: "session.jsonl",
     messageId: "mirror-message",
   }),
+  attachManagedOutgoingMediaToMessageMock: vi.fn().mockReturnValue(true),
+  buildAssistantDisplayContentFromReplyPayloadsMock: vi.fn(),
   commitBackgroundResultToSessionMock: vi.fn().mockResolvedValue({
     ok: true,
     messageId: "current-completion-message",
+    appended: true,
   }),
   countActiveDescendantRunsMock: vi.fn().mockReturnValue(0),
   deliverOutboundPayloadsMock: vi.fn().mockResolvedValue([{ ok: true }]),
   ensureOutboundSessionEntryMock: vi.fn().mockResolvedValue(undefined),
   loadCronSessionEntryLatestMock: vi.fn(),
   maybeApplyTtsToPayloadMock: vi.fn(async (params: { payload: unknown }) => params.payload),
+  removeManagedOutgoingMediaBlocksMock: vi.fn().mockResolvedValue(undefined),
   retireSessionMcpRuntimeMock: vi.fn().mockResolvedValue(true),
   resolveOutboundSessionRouteMock: vi.fn().mockResolvedValue(null),
 }));
@@ -138,6 +146,27 @@ vi.mock("../../config/sessions/transcript.runtime.js", () => ({
 
 vi.mock("../../sessions/background-session-result.js", () => ({
   commitBackgroundResultToSession: commitBackgroundResultToSessionMock,
+}));
+
+vi.mock("../../gateway/server-methods/chat-assistant-content.js", () => ({
+  buildAssistantDisplayContentFromReplyPayloads: buildAssistantDisplayContentFromReplyPayloadsMock,
+  hasAssistantDisplayMediaContent: (content: Array<Record<string, unknown>> | undefined) =>
+    Boolean(content?.some((block) => block.type !== "text")),
+  hasManagedOutgoingAssistantContent: (content: Array<Record<string, unknown>> | undefined) =>
+    Boolean(
+      content?.some(
+        (block) =>
+          block.type === "image" ||
+          block.type === "audio" ||
+          block.type === "video" ||
+          block.type === "attachment",
+      ),
+    ),
+}));
+
+vi.mock("../../gateway/managed-image-attachments.js", () => ({
+  attachManagedOutgoingMediaToMessage: attachManagedOutgoingMediaToMessageMock,
+  removeManagedOutgoingMediaBlocks: removeManagedOutgoingMediaBlocksMock,
 }));
 
 vi.mock("./session.js", () => ({
@@ -306,6 +335,31 @@ function makeBaseParams(overrides: {
   };
 }
 
+function makeCurrentSessionMediaParams(options: {
+  text?: string;
+  mediaUrl?: string;
+  runStartedAt?: number;
+}) {
+  const params = makeBaseParams({
+    ...(options.text !== undefined ? { synthesizedText: options.text } : {}),
+    ...(options.runStartedAt !== undefined ? { runStartedAt: options.runStartedAt } : {}),
+    sessionTarget: "current",
+  });
+  if (options.text === undefined) {
+    params.synthesizedText = undefined;
+    params.summary = undefined;
+    params.outputText = undefined;
+  }
+  params.deliveryPayloadHasStructuredContent = true;
+  params.deliveryPayloads = [
+    {
+      ...(options.text !== undefined ? { text: options.text } : {}),
+      mediaUrl: options.mediaUrl ?? "https://example.com/report.png?token=redacted",
+    },
+  ];
+  return params;
+}
+
 const requireRecord = createRequireRecord("object", "expected-label");
 
 function outboundDeliveryCall(callIndex = 0) {
@@ -373,10 +427,29 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       },
       messageId: "mirror-message",
     });
-    commitBackgroundResultToSessionMock.mockResolvedValue({
-      ok: true,
-      messageId: "current-completion-message",
-    });
+    commitBackgroundResultToSessionMock.mockImplementation(
+      async (params: {
+        displayContent?: readonly Record<string, unknown>[];
+        onMessageCommitted?: (result: {
+          appended: boolean;
+          message: Record<string, unknown>;
+          messageId: string;
+        }) => void;
+      }) => {
+        const messageId = "current-completion-message";
+        params.onMessageCommitted?.({
+          appended: true,
+          message: params.displayContent
+            ? { [ASSISTANT_DISPLAY_CONTENT_FIELD]: params.displayContent }
+            : {},
+          messageId,
+        });
+        return { ok: true, messageId, appended: true };
+      },
+    );
+    buildAssistantDisplayContentFromReplyPayloadsMock.mockResolvedValue(undefined);
+    attachManagedOutgoingMediaToMessageMock.mockReturnValue(true);
+    removeManagedOutgoingMediaBlocksMock.mockResolvedValue(undefined);
     loadCronSessionEntryLatestMock.mockReturnValue({
       sessionId: "test-session-id",
       lifecycleRevision: "test-lifecycle-revision",
@@ -3601,35 +3674,203 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 
-  it("commits a safe media projection and still sends the current-target payload once", async () => {
-    const params = makeBaseParams({ sessionTarget: "current", runStartedAt: 2_500 });
-    params.synthesizedText = undefined;
-    params.summary = undefined;
-    params.outputText = undefined;
-    params.deliveryPayloadHasStructuredContent = true;
-    params.deliveryPayloads = [{ mediaUrl: "https://example.com/report.png?token=redacted" }];
+  it("commits a media-only current-target completion with managed display content", async () => {
+    const displayContent = [
+      {
+        type: "image",
+        url: "/api/chat/media/outgoing/source-session-id/attachment/report.png",
+      },
+    ];
+    buildAssistantDisplayContentFromReplyPayloadsMock.mockResolvedValueOnce(displayContent);
+    const params = makeCurrentSessionMediaParams({ runStartedAt: 2_500 });
 
     const state = await dispatchCronDelivery(params);
 
     expect(state).toMatchObject({ delivered: true, deliveryAttempted: true });
-    expect(commitBackgroundResultToSessionMock).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "report.png" }),
+    expect(buildAssistantDisplayContentFromReplyPayloadsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:webchat:direct:owner",
+        agentId: "main",
+        payloads: [{ mediaUrl: "https://example.com/report.png?token=redacted" }],
+        includeSensitiveMedia: false,
+      }),
     );
+    expect(commitBackgroundResultToSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "report.png", displayContent }),
+    );
+    expect(attachManagedOutgoingMediaToMessageMock).toHaveBeenCalledWith({
+      messageId: "current-completion-message",
+      blocks: displayContent,
+    });
+    expect(removeManagedOutgoingMediaBlocksMock).not.toHaveBeenCalled();
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expectDeliveryCall(0, {
       payloads: [{ mediaUrl: "https://example.com/report.png?token=redacted" }],
     });
   });
 
-  it("does not mark or send a current-target delivery when its session commit fails", async () => {
+  it("fails before external delivery when committed media ownership cannot be attached", async () => {
+    const displayContent = [
+      {
+        type: "image",
+        url: "/api/chat/media/outgoing/source-session-id/attachment/report.png",
+      },
+    ];
+    buildAssistantDisplayContentFromReplyPayloadsMock.mockResolvedValueOnce(displayContent);
+    attachManagedOutgoingMediaToMessageMock.mockReturnValueOnce(false);
+    const params = makeCurrentSessionMediaParams({ runStartedAt: 2_525 });
+
+    await expect(dispatchCronDelivery(params)).rejects.toThrow(
+      "current-session media ownership could not be persisted",
+    );
+
+    expect(attachManagedOutgoingMediaToMessageMock).toHaveBeenCalledWith({
+      messageId: "current-completion-message",
+      blocks: displayContent,
+    });
+    expect(removeManagedOutgoingMediaBlocksMock).not.toHaveBeenCalled();
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("repairs committed media ownership and cleans new media when the commit deduplicates", async () => {
+    const displayContent = [
+      {
+        type: "image",
+        url: "/api/chat/media/outgoing/source-session-id/attachment/retry.png",
+      },
+    ];
+    const committedDisplayContent = [
+      {
+        type: "image",
+        url: "/api/chat/media/outgoing/source-session-id/attachment/original.png",
+      },
+    ];
+    buildAssistantDisplayContentFromReplyPayloadsMock.mockResolvedValueOnce(displayContent);
+    commitBackgroundResultToSessionMock.mockImplementationOnce(
+      async (params: {
+        onMessageCommitted?: (result: {
+          appended: boolean;
+          message: Record<string, unknown>;
+          messageId: string;
+        }) => void;
+      }) => {
+        const messageId = "existing-current-completion-message";
+        params.onMessageCommitted?.({
+          appended: false,
+          message: { [ASSISTANT_DISPLAY_CONTENT_FIELD]: committedDisplayContent },
+          messageId,
+        });
+        return { ok: true, messageId, appended: false };
+      },
+    );
+    const params = makeCurrentSessionMediaParams({
+      mediaUrl: "https://example.com/retry.png?token=redacted",
+      runStartedAt: 2_550,
+    });
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state).toMatchObject({ delivered: true, deliveryAttempted: true });
+    expect(attachManagedOutgoingMediaToMessageMock).toHaveBeenCalledWith({
+      messageId: "existing-current-completion-message",
+      blocks: committedDisplayContent,
+    });
+    expect(removeManagedOutgoingMediaBlocksMock).toHaveBeenCalledWith({
+      blocks: displayContent,
+      messageId: null,
+    });
+  });
+
+  it("commits text and media from the finalized current-target payload", async () => {
+    const displayContent = [
+      { type: "text", text: "Report attached." },
+      {
+        type: "image",
+        url: "/api/chat/media/outgoing/source-session-id/attachment/report.png",
+      },
+    ];
+    buildAssistantDisplayContentFromReplyPayloadsMock.mockResolvedValueOnce(displayContent);
+    const params = makeCurrentSessionMediaParams({
+      text: "Report attached.",
+      runStartedAt: 2_600,
+    });
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state).toMatchObject({ delivered: true, deliveryAttempted: true });
+    expect(commitBackgroundResultToSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Report attached.\nreport.png", displayContent }),
+    );
+    expect(attachManagedOutgoingMediaToMessageMock).toHaveBeenCalledWith({
+      messageId: "current-completion-message",
+      blocks: displayContent,
+    });
+    expectDeliveryCall(0, { payloads: params.deliveryPayloads });
+  });
+
+  it("persists a visible failure block when current-target media cannot be prepared", async () => {
+    const displayContent = [
+      { type: "text", text: "Report attached." },
+      {
+        type: "attachment_error",
+        attachment: { code: "delivery-failed", kind: "image", label: "report.png" },
+      },
+    ];
+    buildAssistantDisplayContentFromReplyPayloadsMock.mockResolvedValueOnce(displayContent);
+    const params = makeCurrentSessionMediaParams({
+      text: "Report attached.",
+      runStartedAt: 2_650,
+    });
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state).toMatchObject({ delivered: true, deliveryAttempted: true });
+    expect(commitBackgroundResultToSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ displayContent }),
+    );
+    expect(attachManagedOutgoingMediaToMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("drops preliminary media when a descendant final reply replaces the payload", async () => {
+    const finalReply = "The descendant finished without an attachment.";
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(true);
+    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(finalReply);
+    const params = makeCurrentSessionMediaParams({
+      text: "on it",
+      mediaUrl: "https://example.com/preliminary.png?token=redacted",
+      runStartedAt: 2_700,
+    });
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state).toMatchObject({ delivered: true, deliveryAttempted: true });
+    expect(buildAssistantDisplayContentFromReplyPayloadsMock).not.toHaveBeenCalled();
+    expect(commitBackgroundResultToSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: finalReply }),
+    );
+    expect(commitBackgroundResultToSessionMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ displayContent: expect.anything() }),
+    );
+    expect(attachManagedOutgoingMediaToMessageMock).not.toHaveBeenCalled();
+    expectDeliveryCall(0, { payloads: [{ text: finalReply }] });
+  });
+
+  it("cleans managed media when a current-target session commit fails", async () => {
     const queueSourceAwareness = vi.fn().mockResolvedValue(undefined);
+    const displayContent = [
+      { type: "text", text: "must not escape before commit" },
+      {
+        type: "image",
+        url: "/api/chat/media/outgoing/source-session-id/attachment/report.png",
+      },
+    ];
+    buildAssistantDisplayContentFromReplyPayloadsMock.mockResolvedValueOnce(displayContent);
     commitBackgroundResultToSessionMock.mockResolvedValueOnce({
       ok: false,
       reason: "source session was archived",
     });
-    const params = makeBaseParams({
-      synthesizedText: "must not escape before commit",
-      sessionTarget: "current",
+    const params = makeCurrentSessionMediaParams({
+      text: "must not escape before commit",
     });
     params.queueSourceSessionMessageToolAwareness = queueSourceAwareness;
 
@@ -3640,7 +3881,33 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       deliveryAttempted: true,
       deliveryError: "source session was archived",
     });
+    expect(removeManagedOutgoingMediaBlocksMock).toHaveBeenCalledWith({
+      blocks: displayContent,
+      messageId: null,
+    });
+    expect(attachManagedOutgoingMediaToMessageMock).not.toHaveBeenCalled();
     expect(queueSourceAwareness).toHaveBeenCalledOnce();
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("cleans managed media when a current-target session commit throws", async () => {
+    const displayContent = [
+      {
+        type: "image",
+        url: "/api/chat/media/outgoing/source-session-id/attachment/report.png",
+      },
+    ];
+    buildAssistantDisplayContentFromReplyPayloadsMock.mockResolvedValueOnce(displayContent);
+    commitBackgroundResultToSessionMock.mockRejectedValueOnce(new Error("transcript write failed"));
+    const params = makeCurrentSessionMediaParams({});
+
+    await expect(dispatchCronDelivery(params)).rejects.toThrow("transcript write failed");
+
+    expect(removeManagedOutgoingMediaBlocksMock).toHaveBeenCalledWith({
+      blocks: displayContent,
+      messageId: null,
+    });
+    expect(attachManagedOutgoingMediaToMessageMock).not.toHaveBeenCalled();
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 
@@ -3648,7 +3915,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     const queueSourceAwareness = vi.fn().mockResolvedValue(undefined);
     commitBackgroundResultToSessionMock.mockImplementationOnce(async () => {
       expect(queueSourceAwareness).not.toHaveBeenCalled();
-      return { ok: true, messageId: "current-completion-message" };
+      return { ok: true, messageId: "current-completion-message", appended: true };
     });
     const params = makeBaseParams({
       synthesizedText: "message-tool completion",

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -700,7 +700,13 @@ export async function dispatchCronDelivery(
     }
     if (requiresCurrentSessionCompletion) {
       deliveryAttempted = true;
-      const completion = await commitCurrentSessionCronCompletion(params, synthesizedText);
+      // Descendant finalization can replace the initial payload set; persist
+      // exactly the payloads this dispatch will deliver.
+      const completion = await commitCurrentSessionCronCompletion(
+        params,
+        deliveryPayloads,
+        synthesizedText,
+      );
       if (!completion.ok) {
         recordDelivery("not-delivered", completion.reason);
         return failDeliveryTarget(completion.reason);

--- a/src/sessions/background-session-result.test.ts
+++ b/src/sessions/background-session-result.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { loadTranscriptEvents, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import { ASSISTANT_DISPLAY_CONTENT_FIELD } from "../shared/assistant-display-content.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { commitBackgroundResultToSession } from "./background-session-result.js";
 import {
@@ -75,7 +76,7 @@ describe("commitBackgroundResultToSession", () => {
     admission.release();
 
     const first = await commit;
-    expect(first).toMatchObject({ ok: true });
+    expect(first).toMatchObject({ ok: true, appended: true });
     (await laterAdmission).release();
     const retry = await commitBackgroundResultToSession({
       agentId: "main",
@@ -86,7 +87,11 @@ describe("commitBackgroundResultToSession", () => {
       provenance: { kind: "cron", jobId: "job-1", runId: "cron:job-1:1000" },
       config: target.config,
     });
-    expect(retry).toEqual(first);
+    expect(retry).toMatchObject({
+      ok: true,
+      messageId: first.ok ? first.messageId : undefined,
+      appended: false,
+    });
 
     const events = await loadTranscriptEvents({
       agentId: "main",
@@ -113,6 +118,74 @@ describe("commitBackgroundResultToSession", () => {
     ]);
     expect(updates).toHaveLength(1);
     unsubscribe();
+  });
+
+  it("stores model-safe text separately from rich display content", async () => {
+    const target = await createTarget();
+    const displayContent = [
+      { type: "text", text: "Automation finished with an image." },
+      {
+        type: "image",
+        url: "/api/chat/media/outgoing/source-session/attachment/report.png",
+      },
+    ];
+    const committed: Array<{ appended: boolean; displayContent: unknown }> = [];
+    const recordCommitted = (result: { appended: boolean; message: unknown }) => {
+      committed.push({
+        appended: result.appended,
+        displayContent: (result.message as Record<string, unknown>)[
+          ASSISTANT_DISPLAY_CONTENT_FIELD
+        ],
+      });
+    };
+    const commitParams = {
+      agentId: "main",
+      sessionKey: target.sessionKey,
+      expectedGeneration: target.generation,
+      text: "Automation finished with an image.",
+      displayContent,
+      idempotencyKey: "cron-current-completion:cron:job-media:1500",
+      provenance: { kind: "cron" as const, jobId: "job-media", runId: "cron:job-media:1500" },
+      config: target.config,
+      onMessageCommitted: recordCommitted,
+    };
+
+    await expect(commitBackgroundResultToSession(commitParams)).resolves.toMatchObject({
+      ok: true,
+      appended: true,
+    });
+    await expect(
+      commitBackgroundResultToSession({
+        ...commitParams,
+        displayContent: [
+          {
+            type: "image",
+            url: "/api/chat/media/outgoing/source-session/attachment/retry.png",
+          },
+        ],
+      }),
+    ).resolves.toMatchObject({ ok: true, appended: false });
+
+    expect(committed).toEqual([
+      { appended: true, displayContent },
+      { appended: false, displayContent },
+    ]);
+    const events = await loadTranscriptEvents({
+      agentId: "main",
+      sessionId: target.sessionId,
+      sessionKey: target.sessionKey,
+      storePath: target.storePath,
+    });
+    expect(events).toEqual([
+      expect.objectContaining({ type: "session" }),
+      expect.objectContaining({
+        type: "message",
+        message: expect.objectContaining({
+          content: [{ type: "text", text: "Automation finished with an image." }],
+          [ASSISTANT_DISPLAY_CONTENT_FIELD]: displayContent,
+        }),
+      }),
+    ]);
   });
 
   it("refuses an archived target conversation", async () => {
@@ -168,6 +241,13 @@ describe("commitBackgroundResultToSession", () => {
         sessionKey: target.sessionKey,
         expectedGeneration: target.generation,
         text: "Do not append this stale cron result.",
+        displayContent: [
+          { type: "text", text: "Do not append this stale cron result." },
+          {
+            type: "image",
+            url: "/api/chat/media/outgoing/source-session/attachment/stale.png",
+          },
+        ],
         idempotencyKey: "cron-current-completion:cron:job-stale:3000",
         provenance: { kind: "cron", jobId: "job-stale", runId: "cron:job-stale:3000" },
         config: target.config,

--- a/src/sessions/background-session-result.ts
+++ b/src/sessions/background-session-result.ts
@@ -9,6 +9,10 @@ import {
 } from "../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  ASSISTANT_DISPLAY_CONTENT_FIELD,
+  retainAssistantModelContent,
+} from "../shared/assistant-display-content.js";
+import {
   OPENCLAW_TRANSCRIPT_ARTIFACT_API,
   OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER,
 } from "../shared/transcript-only-openclaw-assistant.js";
@@ -22,7 +26,7 @@ import {
 const AUTOMATION_RESULT_MODEL = "automation-result" as const;
 
 type BackgroundSessionResultCommit =
-  | { ok: true; messageId: string }
+  | { ok: true; messageId: string; appended: boolean }
   | { ok: false; reason: string };
 
 type BackgroundSessionResultProvenance = {
@@ -38,6 +42,10 @@ export async function commitBackgroundResultToSession(params: {
   /** Pins output to the conversation generation that admitted the background run. */
   expectedGeneration: { sessionId: string; lifecycleRevision: string | undefined };
   text: string;
+  displayContent?: readonly Record<string, unknown>[];
+  onMessageCommitted?: Parameters<
+    typeof appendExactAssistantMessageToSessionTranscript
+  >[0]["onMessageCommitted"];
   idempotencyKey: string;
   provenance: BackgroundSessionResultProvenance;
   config: OpenClawConfig;
@@ -49,6 +57,8 @@ export async function commitBackgroundResultToSession(params: {
   if (!sessionKey || !text || !idempotencyKey) {
     return { ok: false, reason: "background session result is missing required data" };
   }
+  const displayContent = params.displayContent?.map((block) => Object.assign({}, block));
+  const modelContent = displayContent ? retainAssistantModelContent(displayContent) : [];
 
   const storePath = resolveSessionStorePathCore(params.config.session?.store, {
     agentId: params.agentId,
@@ -90,7 +100,8 @@ export async function commitBackgroundResultToSession(params: {
       }
       const message = {
         role: "assistant",
-        content: [{ type: "text", text }],
+        content: modelContent.length > 0 ? modelContent : [{ type: "text", text }],
+        ...(displayContent?.length ? { [ASSISTANT_DISPLAY_CONTENT_FIELD]: displayContent } : {}),
         api: OPENCLAW_TRANSCRIPT_ARTIFACT_API,
         provider: OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER,
         model: AUTOMATION_RESULT_MODEL,
@@ -114,6 +125,7 @@ export async function commitBackgroundResultToSession(params: {
       } satisfies SessionTranscriptAssistantMessage & {
         openclawAutomation: BackgroundSessionResultProvenance;
       };
+      let appendedMessage = false;
       const appended = await appendExactAssistantMessageToSessionTranscript({
         agentId: params.agentId,
         sessionKey,
@@ -124,9 +136,16 @@ export async function commitBackgroundResultToSession(params: {
         storePath,
         updateMode: "inline",
         config: params.config,
+        // Managed display blocks get fresh attachment ids on retry. Preserve the
+        // first committed bytes once this idempotency key owns a transcript row.
+        ...(displayContent ? { beforeMessageWrite: ({ message: candidate }) => candidate } : {}),
+        onMessageCommitted: (result) => {
+          appendedMessage = result.appended;
+          params.onMessageCommitted?.(result);
+        },
       });
       return appended.ok
-        ? { ok: true, messageId: appended.messageId }
+        ? { ok: true, messageId: appended.messageId, appended: appendedMessage }
         : { ok: false, reason: appended.reason };
     },
   });


### PR DESCRIPTION
Closes #136525

## What Problem This Solves

Fixes an issue where a `sessionTarget: "current"` cron completion containing text plus a `MEDIA:` attachment was delivered externally but persisted only text in the bound Control UI conversation. This left durable history incomplete even though the automation reported successful delivery.

## Why This Change Was Made

Current-session transcript persistence now consumes the same finalized delivery payloads used by dispatch. If descendant finalization replaces an interim reply, the durable message records only the final payload instead of retaining preliminary media.

The source-session commit boundary stores model-safe assistant content separately from rich `openclawDisplayContent`. Managed media ownership is attached inside the exact commit callback using the canonical message actually persisted or replayed by idempotency; newly prepared media is cleaned up on rejection, exceptions, or deduplicated retries without deleting media already owned by a committed transcript row.

This reuses the existing assistant display-content, local-media-root, managed-media, exact-generation, and idempotent transcript owners. It does not change external channel delivery, isolated-session cron behavior, Control UI rendering, sensitive-media policy, configuration, schema, protocol, or public APIs.

Production delta is +123/-5 lines; test delta is +464/-19 lines. The production growth establishes the previously missing current-session structured completion and managed-media ownership boundary.

## User Impact

Current-session cron results now remain complete in durable Control UI history: users can reopen the bound conversation and see both completion text and images. Descendant final replies do not leave stale preliminary media, and idempotent retries repair the original durable row rather than adopting newly generated attachment identifiers.

## Evidence

### Before / after

Before: the bound source conversation contains the source-ready message but no cron completion media.

![Before: source conversation without cron media](https://github.com/user-attachments/assets/3674ac2f-65a4-4663-bac8-0f2a27116614)

https://github.com/user-attachments/assets/c72b836e-477f-4b51-b540-8f96a32de1c6

After: the same conversation reloads the finalized cron text and image from durable managed media.

![After: finalized cron text and image in Control UI history](https://github.com/user-attachments/assets/20f563a9-1d52-470e-be1c-8925eb350829)

https://github.com/user-attachments/assets/588fdd66-e60a-412a-af4d-ac2dc83220ae

The proof used an isolated state directory, dedicated dev Gateway port, mock model provider, and a non-main source session. A real cron agent turn completed through `cron.run`; durable `chat.history` was then reloaded in Chromium.

```text
cron status:              ok
completionStatus:         succeeded
deliveryStatus:           delivered
durable content types:    text, image
image metadata:           image/png, 640x360, 18,099 bytes
Control UI image loaded:  300x169 natural dimensions
model requests:           2 (source bootstrap + cron agent turn)
```

The managed media endpoint returned HTTP 200, and the served PNG matched the source bytes (`sha256: 6b39477e8a226da5022afb5f815cb69dd8fad7b871e546be788d54110d3f9db3`).

### TDD and owner-boundary tests

The initial regressions failed before implementation for the intended missing behavior:

- `background-session-result.test.ts`: 1 failed, 5 passed because rich display content could not be persisted separately from model-safe text.
- `delivery-dispatch.double-announce.test.ts`: 3 failed, 163 passed because current-session persistence used preliminary payloads and did not own the managed-media commit lifecycle.

A fresh P1 review then exposed retry preparation drift. Two additional tests failed before the final fix: one retry incorrectly attempted ownership against a canonical row with no managed media, while another failed to repair canonical managed ownership after retry preparation degraded to `attachment_error`.

Final focused results:

- `node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` — 172 passed.
- `node scripts/run-vitest.mjs src/sessions/background-session-result.test.ts src/gateway/server-methods/chat-reply-media.test.ts` — 29 passed.

Coverage includes media-only and text-plus-media completions, descendant final-reply replacement, exact durable-message ownership, idempotent retry repair and cleanup, rejected commits, thrown commits, archived/replaced source sessions, and visible attachment-preparation failures.

### Repository checks

- `node scripts/check-changed.mjs -- src/cron/isolated-agent/current-session-completion.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` — passed core production/test typechecks, lint, formatting, import-cycle, persistence, and media guards.
- `pnpm build` — passed; no ineffective dynamic-import warning.
- Fresh isolated P1 autoreview — scoped-clean with no accepted/actionable P0 or P1 findings.

### Known proof gap

Telegram Test Server userbot proof could not run because the authenticated Convex CLI account cannot access the OpenClaw QA broker project. No live Telegram claim is made. The dispatch owner-boundary suite verifies that external delivery receives the finalized media payload once and does not run after transcript media ownership fails.
