### PR TITLE
perf: avoid idle-key predecessor promises in FIFO leases

### DIFF
--- a/src/shared/keyed-fifo-lease.test.ts
+++ b/src/shared/keyed-fifo-lease.test.ts
@@ -100,6 +100,28 @@ describe("keyed FIFO leases", () => {
     third.release();
   });
 
+  it("releases an idle key independently when a mixed lease exits before its predecessor", async () => {
+    const registry = createRegistry();
+    const older = registry.reserve(["busy"])!;
+    const mixed = registry.reserve(["idle", "busy"])!;
+    const idle = registry.reserve(["idle"])!;
+    const busy = registry.reserve(["busy"])!;
+    let busyReady = false;
+    const busyWait = busy.wait().then((ready) => {
+      busyReady = ready;
+    });
+
+    mixed.release();
+    await expect(idle.wait()).resolves.toBe(true);
+    expect(busyReady).toBe(false);
+    idle.release();
+
+    older.release();
+    await busyWait;
+    expect(busyReady).toBe(true);
+    busy.release();
+  });
+
   it("shares reservations across duplicate runtime chunks", async () => {
     const key = TEST_KEY;
     keysToDelete.add(key);

--- a/src/shared/keyed-fifo-lease.ts
+++ b/src/shared/keyed-fifo-lease.ts
@@ -38,20 +38,21 @@ export function createKeyedFifoLeaseRegistry(globalKey: symbol): KeyedFifoLeaseR
       }
 
       const { promise: completed, resolve: complete } = createDeferredCore();
-      const predecessors = keys.map((key) => state.tails.get(key) ?? Promise.resolve());
-      const owned = keys.map((key, index) => {
-        const tail = predecessors[index]!.then(() => completed);
+      const predecessors: Promise<void>[] = [];
+      const owned = keys.map((key) => {
+        const predecessor = state.tails.get(key);
+        if (predecessor) {
+          predecessors.push(predecessor);
+        }
+        // Early release must not couple an idle key to another key's busy predecessor.
+        const tail = predecessor?.then(() => completed) ?? completed;
         state.tails.set(key, tail);
         return { key, tail };
       });
-      let released = false;
-
       const release = () => {
-        if (released) {
+        if (!state.releases.delete(release)) {
           return;
         }
-        released = true;
-        state.releases.delete(release);
         complete();
         for (const { key, tail } of owned) {
           void tail.then(() => state.tails.get(key) === tail && state.tails.delete(key));


### PR DESCRIPTION
## What Problem This Solves

Reply ordering and persistence leases create resolved predecessor promises and forwarding chains even for idle keys. That work is repeated across reserve, wait and cleanup, although an idle key already has the lease's completion promise.

## Why This Change Was Made

Keep only existing predecessor promises in the prepared wait list. Idle keys use the existing completion promise directly; busy keys retain their own predecessor chain. The active-release set also owns release idempotence, removing the duplicate boolean state.

Each key retains independent ordering: releasing a mixed idle/busy lease early must not block the idle key behind the busy predecessor. Abort still cancels waiting without releasing the reserved slot, and full close still releases every live lease.

## User Impact

Ordering, cancellation, duplicate-chunk sharing, cleanup and close/restart behavior remain unchanged. Idle leases create fewer promises. Readiness can settle three microtasks earlier; exact relative timing against unrelated microtasks is not claimed to be unchanged.

Production LOC: +9/−8 (net +1); tests +22. The extra line keeps the predecessor list explicitly promise-only while removing redundant release state. No configuration, dependency, persistence or public API change.

## Evidence

All 38 focused tests pass across the lease owner, lifecycle and delivery/persistence callers. The added test protects independent idle-key release when a mixed lease exits before its busy predecessor. The complete changed-file gate passes, and fresh independent managed Codex review through P2 is clean.

The same actual-owner probe before and after exercises empty reservations, mixed ordering, early release, abort-before/during wait, idempotent release, full close and restart. Complete promise-init counts, including equal probe overhead, fall from 13 to 9 for one idle key, 18 to 10 for two, and 168 to 40 for 32 synthetic idle keys. Fully busy counts are unchanged; a mixed two-key lease falls from 18 to 14. These are scoped allocation counts, not retained-heap, RSS or latency measurements.

An initial candidate failed the promise-only `Promise.all` lint rule. The final owner collects only present predecessors during reservation; it adds no suppression, cast or per-wait filtering. The failed attempt remains preserved, and both the full gate and independent review were repeated on the corrected patch.
