### PR TITLE
perf(plugins): remove redundant auto-enable fingerprints

### DIFF
--- a/src/config/plugin-auto-enable.apply.ts
+++ b/src/config/plugin-auto-enable.apply.ts
@@ -12,13 +12,10 @@ import type {
   PluginAutoEnableCandidate,
   PluginAutoEnableResult,
 } from "./plugin-auto-enable.types.js";
-import { hashRuntimeConfigValue } from "./runtime-snapshot.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
 type PluginAutoEnableCacheEntry = {
-  configFingerprint: string;
   discoveryFingerprint: string;
-  envFingerprint: string;
   registryFingerprint: string;
   ambientEnvTriggers: AmbientEnvTriggerPolicy;
   result: PluginAutoEnableResult;
@@ -31,13 +28,11 @@ type PluginAutoEnableConfigCache = WeakMap<object, PluginAutoEnableEnvCache>;
 let sameTurnApplyCache: PluginAutoEnableConfigCache | undefined;
 let sameTurnApplyCacheClearScheduled = false;
 let stableFingerprintMemo = new WeakMap<object, string>();
-let configFingerprintMemo = new WeakMap<object, string>();
 
-// Gateway metadata/config use replacement snapshots, and process.env selection is generation-fixed.
-// The plugin metadata lifecycle clear is the freshness boundary for these identity memos.
+// Metadata arrays use replacement snapshots; lifecycle clear refreshes their identity memo.
+// Config/env identity is already enforced by the nested same-turn cache.
 registerPluginMetadataProcessMemoLifecycleClear(() => {
   stableFingerprintMemo = new WeakMap();
-  configFingerprintMemo = new WeakMap();
   sameTurnApplyCache = undefined;
 });
 
@@ -89,34 +84,14 @@ function stableFingerprintValue(value: unknown): string {
   return fingerprint;
 }
 
-/** Fingerprints config snapshots used by plugin auto-enable detection. */
-function fingerprintPluginAutoEnableConfig(config: OpenClawConfig): string {
-  const cached = configFingerprintMemo.get(config);
-  if (cached !== undefined) {
-    return cached;
-  }
-  const fingerprint = hashRuntimeConfigValue(config);
-  configFingerprintMemo.set(config, fingerprint);
-  return fingerprint;
-}
-
-/** Fingerprints environment snapshots used by plugin auto-enable detection. */
-function fingerprintPluginAutoEnableEnv(env: NodeJS.ProcessEnv): string {
-  return stableFingerprintValue(env);
-}
-
 function createPluginAutoEnableCacheEntry(params: {
-  config: OpenClawConfig;
   discovery: PluginDiscoveryResult;
-  env: NodeJS.ProcessEnv;
   manifestRegistry: PluginManifestRegistry;
   result: PluginAutoEnableResult;
   ambientEnvTriggers: AmbientEnvTriggerPolicy;
 }): PluginAutoEnableCacheEntry {
   return {
-    configFingerprint: fingerprintPluginAutoEnableConfig(params.config),
     discoveryFingerprint: stableFingerprintValue(params.discovery.candidates),
-    envFingerprint: fingerprintPluginAutoEnableEnv(params.env),
     registryFingerprint: stableFingerprintValue(params.manifestRegistry.plugins),
     ambientEnvTriggers: params.ambientEnvTriggers,
     result: params.result,
@@ -125,16 +100,12 @@ function createPluginAutoEnableCacheEntry(params: {
 
 function isPluginAutoEnableCacheEntryFresh(params: {
   entry: PluginAutoEnableCacheEntry;
-  config: OpenClawConfig;
   discovery: PluginDiscoveryResult;
-  env: NodeJS.ProcessEnv;
   manifestRegistry: PluginManifestRegistry;
   ambientEnvTriggers: AmbientEnvTriggerPolicy;
 }): boolean {
   return (
-    params.entry.configFingerprint === fingerprintPluginAutoEnableConfig(params.config) &&
     params.entry.discoveryFingerprint === stableFingerprintValue(params.discovery.candidates) &&
-    params.entry.envFingerprint === fingerprintPluginAutoEnableEnv(params.env) &&
     params.entry.registryFingerprint === stableFingerprintValue(params.manifestRegistry.plugins) &&
     params.entry.ambientEnvTriggers === params.ambientEnvTriggers
   );
@@ -202,9 +173,7 @@ export function applyPluginAutoEnable(params: {
       cached &&
       isPluginAutoEnableCacheEntryFresh({
         entry: cached,
-        config,
         discovery: params.discovery,
-        env,
         manifestRegistry: params.manifestRegistry,
         ambientEnvTriggers,
       })
@@ -221,9 +190,7 @@ export function applyPluginAutoEnable(params: {
     discoveryCache.set(
       params.discovery,
       createPluginAutoEnableCacheEntry({
-        config,
         discovery: params.discovery,
-        env,
         manifestRegistry: params.manifestRegistry,
         result,
         ambientEnvTriggers,

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -1106,23 +1106,10 @@ describe("applyPluginAutoEnable core", () => {
     expect(setupRegistryMock.resolvePluginSetupAutoEnableReasons).toHaveBeenCalledTimes(2);
   });
 
-  it("fingerprints identical snapshots once per plugin metadata lifecycle", () => {
-    const traversals = { candidates: 0, config: 0, env: 0, plugins: 0 };
-    const config = new Proxy<OpenClawConfig>(
-      {},
-      {
-        ownKeys: (target) => {
-          traversals.config += 1;
-          return Reflect.ownKeys(target);
-        },
-      },
-    );
-    const envSnapshot = new Proxy(makeIsolatedEnv(), {
-      ownKeys: (target) => {
-        traversals.env += 1;
-        return Reflect.ownKeys(target);
-      },
-    });
+  it("fingerprints identical metadata snapshots once per plugin metadata lifecycle", () => {
+    const traversals = { candidates: 0, plugins: 0 };
+    const config: OpenClawConfig = {};
+    const envSnapshot = makeIsolatedEnv();
     const discovery: PluginDiscoveryResult = {
       candidates: new Proxy([], {
         get: (target, property, receiver) => {
@@ -1162,8 +1149,6 @@ describe("applyPluginAutoEnable core", () => {
     clearPluginMetadataLifecycleCaches();
     applyPluginAutoEnable({ config, discovery, env: envSnapshot, manifestRegistry });
 
-    expect(traversals.config).toBeGreaterThan(firstTraversalCounts.config);
-    expect(traversals.env).toBeGreaterThan(firstTraversalCounts.env);
     expect(traversals.candidates).toBeGreaterThan(firstTraversalCounts.candidates);
     expect(traversals.plugins).toBeGreaterThan(firstTraversalCounts.plugins);
   });


### PR DESCRIPTION
## What Problem This Solves

Plugin auto-enable processing serializes the complete config and environment into cached fingerprints even though its result cache already requires those exact objects. The fingerprints are themselves memoized by the same object identities, so comparing them on a hit cannot detect a change.

## Why This Change Was Made

Remove the redundant config/environment fingerprints, their private helpers and the config fingerprint map. Keep the existing result-cache identity keys, one-turn expiry and lifecycle clearing. Discovery and registry array fingerprints remain because those nested arrays can be replaced inside the same container; ambient trigger policy also remains part of freshness checking.

## User Impact

Auto-enable makes the same decisions while avoiding redundant config hashing and environment serialization. Startup and reload retain their existing activation behavior. There are no changed defaults, options, freshness policies, stored data or public APIs.

Production LOC: −33; tests −15. The removed test setup asserted traversal by the deleted serializers. Adjacent behavioral tests still cover result identity, next-turn recomputation, distinct inputs and lifecycle mutations; metadata-fingerprint coverage remains.

## Evidence

All 102 tests across five owner, provider, channel, model-support and Gateway activation-helper suites pass. The complete changed-file gate passes, and independent managed Codex review through P2 is clean.

The same actual-owner probe produces identical complete results for 12 cases, including activation, distinct config/environment/metadata objects, lifecycle mutation, nested metadata-array replacement, ambient policy, explicit disable, and actual startup/reload activation helpers preserving runtime-owned fields. Those helpers receive synthetic prepared inputs; this is not a live Gateway claim.

A fixed synthetic workload with 256 configured origins and 512 irrelevant environment entries previously retained a 43-byte config digest and a 50,579-byte UTF-8 environment serialization in their identity memos. Both memo writes are removed. Normal environment detection still runs. These are logical memo values and operation counts, not V8 retained-heap bytes, RSS or a latency benchmark.
