### PR TITLE
fix(ci): authenticate frozen source checkouts

### DIFF
--- a/.github/actions/ensure-base-commit/action.yml
+++ b/.github/actions/ensure-base-commit/action.yml
@@ -15,6 +15,8 @@ runs:
       env:
         BASE_SHA: ${{ inputs.base-sha }}
         FETCH_REF: ${{ inputs.fetch-ref }}
+        CHECKOUT_REPO: ${{ github.repository }}
+        CHECKOUT_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
 
@@ -39,8 +41,12 @@ runs:
         fi
 
         fetch_base_ref() {
+          local auth_header
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           timeout --signal=TERM --kill-after=10s 30s git \
             -c protocol.version=2 \
+            -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
             fetch "$@"
         }
 

--- a/.github/workflows/ci-build-artifacts-testbox.yml
+++ b/.github/workflows/ci-build-artifacts-testbox.yml
@@ -62,7 +62,7 @@ jobs:
             reset_checkout_dir
             git init "$workdir" >/dev/null
             git config --global --add safe.directory "$workdir"
-            git -C "$workdir" remote add origin "https://github.com/${CHECKOUT_REPO}"
+            git -C "$workdir" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
             git -C "$workdir" config gc.auto 0
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
@@ -189,11 +189,17 @@ jobs:
 
       - name: Prepare Testbox shell
         shell: bash
+        env:
+          CHECKOUT_REPO: ${{ github.repository }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           timeout --signal=TERM --kill-after=10s 120s git \
             -c protocol.version=2 \
+            -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
             fetch --no-tags --prune --no-recurse-submodules --depth=50 origin \
             "+refs/heads/main:refs/remotes/origin/main"
 

--- a/.github/workflows/ci-build-artifacts-testbox.yml
+++ b/.github/workflows/ci-build-artifacts-testbox.yml
@@ -95,11 +95,15 @@ jobs:
       - name: Resolve release dist cache seeds
         id: dist-cache-seeds
         shell: bash
+        env:
+          CHECKOUT_REPO: ${{ github.repository }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
           cache_prefix="${RUNNER_OS}-dist-build-"
           declare -A seen=()
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
 
           resolve_tag_sha() {
             local tag="$1"
@@ -112,7 +116,11 @@ jobs:
               elif [[ "$ref" == "refs/tags/${tag}" ]]; then
                 direct="$sha"
               fi
-            done < <(git ls-remote --tags origin "refs/tags/${tag}" "refs/tags/${tag}^{}")
+            done < <(git \
+              -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
+              ls-remote --tags origin "refs/tags/${tag}" "refs/tags/${tag}^{}")
 
             printf '%s\n' "${peeled:-$direct}"
           }

--- a/.github/workflows/ci-check-arm-testbox.yml
+++ b/.github/workflows/ci-check-arm-testbox.yml
@@ -77,7 +77,7 @@ jobs:
             reset_checkout_dir
             git init "$workdir" >/dev/null
             git config --global --add safe.directory "$workdir"
-            git -C "$workdir" remote add origin "https://github.com/${CHECKOUT_REPO}"
+            git -C "$workdir" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
             git -C "$workdir" config gc.auto 0
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
@@ -107,11 +107,17 @@ jobs:
           install-bun: "false"
       - name: Prepare Testbox shell
         shell: bash
+        env:
+          CHECKOUT_REPO: ${{ github.repository }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           timeout --signal=TERM --kill-after=10s 120s git \
             -c protocol.version=2 \
+            -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
             fetch --no-tags --prune --no-recurse-submodules --depth=50 origin \
             "+refs/heads/main:refs/remotes/origin/main"
 

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -66,7 +66,7 @@ jobs:
             reset_checkout_dir
             git init "$workdir" >/dev/null
             git config --global --add safe.directory "$workdir"
-            git -C "$workdir" remote add origin "https://github.com/${CHECKOUT_REPO}"
+            git -C "$workdir" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
             git -C "$workdir" config gc.auto 0
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
@@ -96,11 +96,17 @@ jobs:
           install-bun: "false"
       - name: Prepare Testbox shell
         shell: bash
+        env:
+          CHECKOUT_REPO: ${{ github.repository }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           timeout --signal=TERM --kill-after=10s 120s git \
             -c protocol.version=2 \
+            -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
             fetch --no-tags --prune --no-recurse-submodules --depth=50 origin \
             "+refs/heads/main:refs/remotes/origin/main"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,12 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_REF: ${{ inputs.target_ref || github.sha }}
+          CHECKOUT_TOKEN: ${{ github.token }}
           CHECKOUT_FALLBACK_REF: ${{ github.sha }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           git init "$GITHUB_WORKSPACE"
           git -C "$GITHUB_WORKSPACE" config gc.auto 0
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
@@ -152,8 +154,10 @@ jobs:
             local fetch_status
             for attempt in 1 2 3; do
               timeout --signal=TERM --kill-after=10s 120s git -C "$GITHUB_WORKSPACE" \
-                -c protocol.version=2 \
-                fetch --no-tags --prune --no-recurse-submodules --depth=2 origin \
+              -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
+              fetch --no-tags --prune --no-recurse-submodules --depth=2 origin \
                 "+${ref}:refs/remotes/origin/checkout" && return 0
               fetch_status="$?"
               if [ "$fetch_status" != "124" ] && [ "$fetch_status" != "137" ]; then
@@ -190,6 +194,7 @@ jobs:
         if: inputs.historical_target_tag != ''
         env:
           EXPECTED_SHA: ${{ steps.checkout_ref.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
           HISTORICAL_TARGET_TAG: ${{ inputs.historical_target_tag }}
         run: |
           set -euo pipefail
@@ -197,12 +202,8 @@ jobs:
             echo "historical_target_tag must be a canonical OpenClaw release tag." >&2
             exit 1
           fi
-          tag_ref="refs/tags/${HISTORICAL_TARGET_TAG}"
-          remote="$(git remote get-url origin)"
-          tag_sha="$(git ls-remote --tags "$remote" "${tag_ref}^{}" | awk 'NR == 1 { print $1 }')"
-          if [[ -z "$tag_sha" ]]; then
-            tag_sha="$(git ls-remote --tags "$remote" "$tag_ref" | awk 'NR == 1 { print $1 }')"
-          fi
+          encoded_ref="$(jq -rn --arg value "refs/tags/${HISTORICAL_TARGET_TAG}" '$value | @uri')"
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}" --jq .sha)"
           if [[ "$tag_sha" != "$EXPECTED_SHA" ]]; then
             echo "Historical release tag ${HISTORICAL_TARGET_TAG} does not resolve to ${EXPECTED_SHA}." >&2
             exit 1
@@ -212,6 +213,7 @@ jobs:
         if: inputs.release_candidate_ref != ''
         env:
           EXPECTED_SHA: ${{ steps.checkout_ref.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
           RELEASE_CANDIDATE_REF: ${{ inputs.release_candidate_ref }}
         run: |
           set -euo pipefail
@@ -219,8 +221,8 @@ jobs:
             echo "release_candidate_ref must be a canonical OpenClaw release branch." >&2
             exit 1
           fi
-          remote="$(git remote get-url origin)"
-          branch_sha="$(git ls-remote --heads "$remote" "refs/heads/${RELEASE_CANDIDATE_REF}" | awk 'NR == 1 { print $1 }')"
+          encoded_ref="$(jq -rn --arg value "refs/heads/${RELEASE_CANDIDATE_REF}" '$value | @uri')"
+          branch_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}" --jq .sha)"
           if [[ "$branch_sha" != "$EXPECTED_SHA" ]]; then
             echo "Release candidate branch ${RELEASE_CANDIDATE_REF} does not resolve to ${EXPECTED_SHA}." >&2
             exit 1
@@ -458,10 +460,12 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_REF: ${{ inputs.target_ref || github.sha }}
+          CHECKOUT_TOKEN: ${{ github.token }}
           CHECKOUT_FALLBACK_REF: ${{ github.sha }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           git init "$GITHUB_WORKSPACE"
           git -C "$GITHUB_WORKSPACE" config gc.auto 0
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
@@ -470,8 +474,10 @@ jobs:
             local fetch_status
             for attempt in 1 2 3; do
               timeout --signal=TERM --kill-after=10s 120s git -C "$GITHUB_WORKSPACE" \
-                -c protocol.version=2 \
-                fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
+              -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
+              fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
                 "+${ref}:refs/remotes/origin/checkout" && return 0
               fetch_status="$?"
               if [ "$fetch_status" != "124" ] && [ "$fetch_status" != "137" ]; then
@@ -507,44 +513,43 @@ jobs:
           base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
 
-      - name: Prepare trusted pre-commit config
-        if: github.event_name == 'pull_request'
+      - name: Prepare trusted scanner config
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
-          trusted_config="$RUNNER_TEMP/pre-commit-base.yaml"
-          if git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null &&
-            git cat-file -e "${BASE_SHA}:.pre-commit-config.yaml" 2>/dev/null; then
-            git show "${BASE_SHA}:.pre-commit-config.yaml" > "$trusted_config"
-          elif git show "refs/remotes/origin/${BASE_REF}:.pre-commit-config.yaml" \
-            > "$trusted_config" 2>/dev/null; then
-            echo "Base SHA ${BASE_SHA} does not expose .pre-commit-config.yaml; using origin/${BASE_REF} instead."
+          trusted_policy="$RUNNER_TEMP/zizmor.yml"
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            if ! git show "${BASE_SHA}:.github/zizmor.yml" > "$trusted_policy" 2>/dev/null; then
+              echo "::error title=trusted zizmor policy unavailable::Could not read .github/zizmor.yml from exact base ${BASE_SHA}."
+              exit 1
+            fi
           else
-            echo "::warning title=trusted pre-commit config unavailable::Could not read .pre-commit-config.yaml from ${BASE_SHA} or origin/${BASE_REF}; falling back to the checked-out config."
-            rm -f "$trusted_config"
-            exit 0
+            cp .github/zizmor.yml "$trusted_policy"
           fi
-          echo "PRE_COMMIT_CONFIG_PATH=$trusted_config" >> "$GITHUB_ENV"
 
-      - name: Resolve Python runtime
-        id: setup-python
-        run: |
-          set -euo pipefail
-          python3 --version
-          version="$(python3 - <<'PY'
-          import platform
-          print(platform.python_version())
-          PY
-          )"
-          echo "python-version=${version}" >> "$GITHUB_OUTPUT"
+          cat > "$RUNNER_TEMP/security-fast-pre-commit.yaml" <<EOF
+          repos:
+            - repo: local
+              hooks:
+                - { id: detect-private-key, name: detect private key, entry: detect-private-key, language: system, types: [text], exclude: '(^|/)(\.pre-commit-config\.yaml$|apps/ios/fastlane/Fastfile$|.*\.test\.ts$)' }
+                - id: zizmor
+                  name: zizmor
+                  entry: zizmor
+                  language: system
+                  types: [yaml]
+                  files: '(\.github/(workflows/.*|dependabot.ya?ml))|(action\.ya?ml)$'
+                  require_serial: true
+                  args: [--config, "$trusted_policy", --persona=regular, --min-severity=medium, --min-confidence=medium]
+                  exclude: '^(vendor/|apps/swabble/)'
+          EOF
+          echo "PRE_COMMIT_CONFIG_PATH=$RUNNER_TEMP/security-fast-pre-commit.yaml" >> "$GITHUB_ENV"
 
-      - name: Install pre-commit
-        run: python3 -m pip install --disable-pip-version-check pre-commit==4.2.0
+      - name: Install security scanners
+        run: python3 --version && python3 -m pip install --disable-pip-version-check pre-commit==4.2.0 pre-commit-hooks==6.0.0 zizmor==1.22.0
 
       - name: Detect committed private keys
-        run: pre-commit run --config "${PRE_COMMIT_CONFIG_PATH:-.pre-commit-config.yaml}" --all-files detect-private-key
+        run: GIT_ALLOW_PROTOCOL=file GIT_CONFIG_COUNT=0 pre-commit run --config "$PRE_COMMIT_CONFIG_PATH" --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
         env:
@@ -571,7 +576,8 @@ jobs:
           fi
 
           printf 'Auditing workflow files:\n%s\n' "${workflow_files[@]}"
-          pre-commit run --config "${PRE_COMMIT_CONFIG_PATH:-.pre-commit-config.yaml}" zizmor --files "${workflow_files[@]}"
+          GIT_ALLOW_PROTOCOL=file GIT_CONFIG_COUNT=0 \
+            pre-commit run --config "$PRE_COMMIT_CONFIG_PATH" zizmor --files "${workflow_files[@]}"
 
       - name: Setup Node.js
         env:
@@ -599,9 +605,11 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           workdir="$GITHUB_WORKSPACE"
           reset_checkout_dir() {
             mkdir -p "$workdir"
@@ -619,6 +627,8 @@ jobs:
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
 
@@ -664,9 +674,11 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           workdir="$GITHUB_WORKSPACE"
           reset_checkout_dir() {
             mkdir -p "$workdir"
@@ -684,6 +696,8 @@ jobs:
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
 
@@ -921,9 +935,11 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           workdir="$GITHUB_WORKSPACE"
           reset_checkout_dir() {
             mkdir -p "$workdir"
@@ -941,6 +957,8 @@ jobs:
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
 
@@ -1011,9 +1029,11 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           workdir="$GITHUB_WORKSPACE"
           reset_checkout_dir() {
             mkdir -p "$workdir"
@@ -1031,6 +1051,8 @@ jobs:
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
 
@@ -1092,9 +1114,11 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           workdir="$GITHUB_WORKSPACE"
           reset_checkout_dir() {
             mkdir -p "$workdir"
@@ -1112,6 +1136,8 @@ jobs:
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
 
@@ -1169,9 +1195,11 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           workdir="$GITHUB_WORKSPACE"
           reset_checkout_dir() {
             mkdir -p "$workdir"
@@ -1189,6 +1217,8 @@ jobs:
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
 
@@ -1247,9 +1277,11 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           workdir="$GITHUB_WORKSPACE"
           reset_checkout_dir() {
             mkdir -p "$workdir"
@@ -1267,6 +1299,8 @@ jobs:
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
 
@@ -1404,9 +1438,11 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           workdir="$GITHUB_WORKSPACE"
           reset_checkout_dir() {
             mkdir -p "$workdir"
@@ -1424,6 +1460,8 @@ jobs:
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
 
@@ -1453,6 +1491,8 @@ jobs:
           OPENCLAW_LOCAL_CHECK: "0"
           TASK: ${{ matrix.task }}
           PR_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+          CHECKOUT_REPO: ${{ github.repository }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1463,7 +1503,11 @@ jobs:
               pnpm check:host-env-policy:swift
               pnpm dup:check:coverage
               if [ -n "$PR_BASE_SHA" ]; then
-                git fetch --no-tags --depth=1 origin "+${PR_BASE_SHA}:refs/remotes/origin/pr-base"
+                auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
+                git \
+                  -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+                  -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
+                  fetch --no-tags --depth=1 origin "+${PR_BASE_SHA}:refs/remotes/origin/pr-base"
                 node scripts/report-test-temp-creations.mjs --base refs/remotes/origin/pr-base --head HEAD --no-merge-base
               fi
               pnpm deps:patches:check
@@ -1554,9 +1598,11 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           workdir="$GITHUB_WORKSPACE"
           reset_checkout_dir() {
             mkdir -p "$workdir"
@@ -1574,6 +1620,8 @@ jobs:
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
 
@@ -1739,9 +1787,11 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           workdir="$GITHUB_WORKSPACE"
           reset_checkout_dir() {
             mkdir -p "$workdir"
@@ -1759,6 +1809,8 @@ jobs:
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
 
@@ -1842,8 +1894,10 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           git init "$GITHUB_WORKSPACE"
           git -C "$GITHUB_WORKSPACE" config gc.auto 0
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
@@ -1851,8 +1905,10 @@ jobs:
             local fetch_status
             for attempt in 1 2 3; do
               timeout --signal=TERM --kill-after=10s 120s git -C "$GITHUB_WORKSPACE" \
-                -c protocol.version=2 \
-                fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
+              -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
+              fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
                 "+${CHECKOUT_SHA}:refs/remotes/origin/checkout" && return 0
               fetch_status="$?"
               if [ "$fetch_status" != "124" ] && [ "$fetch_status" != "137" ]; then
@@ -1909,8 +1965,10 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           git init "$GITHUB_WORKSPACE"
           git -C "$GITHUB_WORKSPACE" config gc.auto 0
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
@@ -1918,6 +1976,8 @@ jobs:
           fetch_checkout_ref() {
             git -C "$GITHUB_WORKSPACE" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/checkout" &
             local fetch_pid="$!"
@@ -2030,8 +2090,10 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           git init "$GITHUB_WORKSPACE"
           git -C "$GITHUB_WORKSPACE" config gc.auto 0
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
@@ -2039,6 +2101,8 @@ jobs:
           fetch_checkout_ref() {
             git -C "$GITHUB_WORKSPACE" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/checkout" &
             local fetch_pid="$!"
@@ -2097,8 +2161,10 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           git init "$GITHUB_WORKSPACE"
           git -C "$GITHUB_WORKSPACE" config gc.auto 0
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
@@ -2106,6 +2172,8 @@ jobs:
           fetch_checkout_ref() {
             git -C "$GITHUB_WORKSPACE" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/checkout" &
             local fetch_pid="$!"
@@ -2255,8 +2323,10 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           git init "$GITHUB_WORKSPACE"
           git -C "$GITHUB_WORKSPACE" config gc.auto 0
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
@@ -2264,6 +2334,8 @@ jobs:
           fetch_checkout_ref() {
             git -C "$GITHUB_WORKSPACE" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/checkout" &
             local fetch_pid="$!"
@@ -2355,9 +2427,11 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
+          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
           workdir="$GITHUB_WORKSPACE"
           reset_checkout_dir() {
             mkdir -p "$workdir"
@@ -2375,6 +2449,8 @@ jobs:
 
             timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
               -c protocol.version=2 \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
               fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
               "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
 

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ github.sha }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git init "$GITHUB_WORKSPACE"
@@ -36,9 +37,13 @@ jobs:
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
           fetch_checkout_ref() {
             local fetch_status
+            local auth_header
+            auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
             for attempt in 1 2 3; do
               timeout --signal=TERM --kill-after=10s 30s git -C "$GITHUB_WORKSPACE" \
                 -c protocol.version=2 \
+                -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+                -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
                 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
                 "+${CHECKOUT_SHA}:refs/remotes/origin/checkout" && return 0
               fetch_status="$?"
@@ -88,6 +93,7 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ github.sha }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git init "$GITHUB_WORKSPACE"
@@ -95,9 +101,13 @@ jobs:
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
           fetch_checkout_ref() {
             local fetch_status
+            local auth_header
+            auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
             for attempt in 1 2 3; do
               timeout --signal=TERM --kill-after=10s 30s git -C "$GITHUB_WORKSPACE" \
                 -c protocol.version=2 \
+                -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+                -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
                 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
                 "+${CHECKOUT_SHA}:refs/remotes/origin/checkout" && return 0
               fetch_status="$?"
@@ -124,6 +134,8 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CHECKOUT_REPO: ${{ github.repository }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           trusted_config="$RUNNER_TEMP/pre-commit-base.yaml"
@@ -133,8 +145,13 @@ jobs:
             local ref="$1"
             local target="$2"
             local fetch_status
+            local auth_header
+            auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
             for attempt in 1 2 3; do
-              timeout --signal=TERM --kill-after=10s 30s git fetch --no-tags --depth=1 origin \
+              timeout --signal=TERM --kill-after=10s 30s git \
+                -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+                -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
+                fetch --no-tags --depth=1 origin \
                 "+${ref}:${target}" && return 0
               fetch_status="$?"
               if [ "$fetch_status" != "124" ] && [ "$fetch_status" != "137" ]; then
@@ -232,6 +249,7 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ github.sha }}
+          CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git init "$GITHUB_WORKSPACE"
@@ -239,9 +257,13 @@ jobs:
           git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
           fetch_checkout_ref() {
             local fetch_status
+            local auth_header
+            auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
             for attempt in 1 2 3; do
               timeout --signal=TERM --kill-after=10s 30s git -C "$GITHUB_WORKSPACE" \
                 -c protocol.version=2 \
+                -c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}" \
+                -c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false" \
                 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
                 "+${CHECKOUT_SHA}:refs/remotes/origin/checkout" && return 0
               fetch_status="$?"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -129,12 +129,22 @@ describe("ci workflow guards", () => {
     expect(historicalTargetStep.run).toContain(
       "Historical release tag ${HISTORICAL_TARGET_TAG} does not resolve to ${EXPECTED_SHA}.",
     );
+    expect(historicalTargetStep.env.GH_TOKEN).toBe("${{ github.token }}");
+    expect(historicalTargetStep.run).toContain(
+      'gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}" --jq .sha',
+    );
+    expect(historicalTargetStep.run).not.toContain("git ls-remote");
     const releaseCandidateStep = preflightSteps.find(
       (step) => step.name === "Validate release candidate target",
     );
     expect(releaseCandidateStep.run).toContain(
       "Release candidate branch ${RELEASE_CANDIDATE_REF} does not resolve to ${EXPECTED_SHA}.",
     );
+    expect(releaseCandidateStep.env.GH_TOKEN).toBe("${{ github.token }}");
+    expect(releaseCandidateStep.run).toContain(
+      'gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}" --jq .sha',
+    );
+    expect(releaseCandidateStep.run).not.toContain("git ls-remote");
     expect(readFileSync(".github/workflows/ci.yml", "utf8")).toContain(
       "OPENCLAW_CI_RUN_ANDROID: ${{ github.event_name == 'workflow_dispatch' && (inputs.release_gate || inputs.include_android) && 'true' || steps.changed_scope.outputs.run_android || 'false' }}",
     );
@@ -358,8 +368,88 @@ describe("ci workflow guards", () => {
     expect(action).not.toContain("if ! git fetch --no-tags");
   });
 
-  it("bounds early unauthenticated checkout fetches", () => {
+  it("keeps manual source checkouts authenticated, scoped, and bounded", () => {
     const workflow = readCiWorkflow();
+
+    const sourceCheckouts = Object.entries(workflow.jobs)
+      .map(([jobName, job]) => [jobName, job.steps.find((step) => step.name === "Checkout")])
+      .filter(([, step]) => step?.env?.CHECKOUT_REPO);
+    expect(sourceCheckouts).toHaveLength(18);
+
+    for (const [jobName, checkoutStep] of sourceCheckouts) {
+      expect(checkoutStep.env.CHECKOUT_TOKEN, jobName).toBe("${{ github.token }}");
+      expect(checkoutStep.run, jobName).toContain(
+        "auth_header=\"$(printf 'x-access-token:%s' \"$CHECKOUT_TOKEN\" | base64 | tr -d '\\n')\"",
+      );
+      expect(checkoutStep.run, jobName).toContain(
+        '-c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}"',
+      );
+      expect(checkoutStep.run, jobName).toContain(
+        '-c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false"',
+      );
+    }
+
+    const guardsStep = workflow.jobs["check-shard"].steps.find(
+      (step) => step.name === "Run check shard",
+    );
+    expect(guardsStep.env.CHECKOUT_TOKEN).toBe("${{ github.token }}");
+    expect(guardsStep.run).toContain(
+      '-c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}"',
+    );
+
+    for (const [workflowPath, jobName] of [
+      [".github/workflows/ci-check-testbox.yml", "check"],
+      [".github/workflows/ci-check-arm-testbox.yml", "check-arm"],
+      [".github/workflows/ci-build-artifacts-testbox.yml", "build-artifacts"],
+    ]) {
+      const testboxWorkflow = parse(readFileSync(workflowPath, "utf8"));
+      const prepareStep = testboxWorkflow.jobs[jobName].steps.find(
+        (step) => step.name === "Prepare Testbox shell",
+      );
+      const checkoutStep = testboxWorkflow.jobs[jobName].steps.find(
+        (step) => step.name === "Checkout",
+      );
+
+      expect(prepareStep.env.CHECKOUT_TOKEN, workflowPath).toBe("${{ github.token }}");
+      expect(checkoutStep.run, workflowPath).toContain(
+        'remote add origin "https://github.com/${CHECKOUT_REPO}.git"',
+      );
+      expect(prepareStep.run, workflowPath).toContain(
+        '-c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}"',
+      );
+    }
+
+    const workflowSanity = readWorkflowSanityWorkflow();
+    for (const jobName of ["no-tabs", "actionlint", "generated-doc-baselines"]) {
+      const checkoutStep = workflowSanity.jobs[jobName].steps.find(
+        (step) => step.name === "Checkout",
+      );
+
+      expect(checkoutStep.env.CHECKOUT_TOKEN, jobName).toBe("${{ github.token }}");
+      expect(checkoutStep.run, jobName).toContain(
+        '-c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}"',
+      );
+      expect(checkoutStep.run, jobName).toContain(
+        '-c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false"',
+      );
+    }
+
+    const workflowAuditStep = workflowSanity.jobs.actionlint.steps.find(
+      (step) => step.name === "Prepare trusted workflow audit configs",
+    );
+    expect(workflowAuditStep.env.CHECKOUT_TOKEN).toBe("${{ github.token }}");
+    expect(workflowAuditStep.run).toContain(
+      '-c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}"',
+    );
+
+    const ensureBaseAction = readFileSync(".github/actions/ensure-base-commit/action.yml", "utf8");
+    expect(ensureBaseAction).toContain("CHECKOUT_TOKEN: ${{ github.token }}");
+    expect(ensureBaseAction).toContain(
+      '-c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}"',
+    );
+    expect(ensureBaseAction).toContain(
+      '-c "http.https://github.com/${CHECKOUT_REPO}.git.followRedirects=false"',
+    );
 
     for (const jobName of ["preflight", "security-fast", "skills-python"]) {
       const checkoutStep = workflow.jobs[jobName].steps.find((step) => step.name === "Checkout");
@@ -383,6 +473,27 @@ describe("ci workflow guards", () => {
         'git -C "$GITHUB_WORKSPACE" fetch --no-tags --depth=1',
       );
     }
+  });
+
+  it("keeps security-fast scanner hooks local and its PR policy immutable", () => {
+    const workflow = readCiWorkflow();
+    const steps = workflow.jobs["security-fast"].steps;
+    const prepareStep = steps.find((step) => step.name === "Prepare trusted scanner config");
+    const installStep = steps.find((step) => step.name === "Install security scanners");
+    const privateKeyStep = steps.find((step) => step.name === "Detect committed private keys");
+    const zizmorStep = steps.find(
+      (step) => step.name === "Audit changed GitHub workflows with zizmor",
+    );
+
+    expect(prepareStep.run).toContain('git show "${BASE_SHA}:.github/zizmor.yml"');
+    expect(prepareStep.run).toContain("::error title=trusted zizmor policy unavailable::");
+    expect(prepareStep.run).toContain("repo: local");
+    expect(prepareStep.run).toContain("entry: detect-private-key");
+    expect(prepareStep.run).toContain("entry: zizmor");
+    expect(prepareStep.run).not.toContain(".pre-commit-config.yaml");
+    expect(installStep.run).toContain("pre-commit==4.2.0 pre-commit-hooks==6.0.0 zizmor==1.22.0");
+    expect(privateKeyStep.run).toContain("GIT_ALLOW_PROTOCOL=file GIT_CONFIG_COUNT=0");
+    expect(zizmorStep.run).toContain("GIT_ALLOW_PROTOCOL=file GIT_CONFIG_COUNT=0");
   });
 
   it("retries workflow sanity checkout fetch timeouts", () => {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -419,6 +419,18 @@ describe("ci workflow guards", () => {
       );
     }
 
+    const artifactWorkflow = parse(
+      readFileSync(".github/workflows/ci-build-artifacts-testbox.yml", "utf8"),
+    );
+    const cacheSeedStep = artifactWorkflow.jobs["build-artifacts"].steps.find(
+      (step) => step.name === "Resolve release dist cache seeds",
+    );
+    expect(cacheSeedStep.env.CHECKOUT_TOKEN).toBe("${{ github.token }}");
+    expect(cacheSeedStep.run).toContain(
+      '-c "http.https://github.com/${CHECKOUT_REPO}.git.extraheader=AUTHORIZATION: basic ${auth_header}"',
+    );
+    expect(cacheSeedStep.run).toContain('ls-remote --tags origin "refs/tags/${tag}"');
+
     const workflowSanity = readWorkflowSanityWorkflow();
     for (const jobName of ["no-tabs", "actionlint", "generated-doc-baselines"]) {
       const checkoutStep = workflowSanity.jobs[jobName].steps.find(


### PR DESCRIPTION
## Summary

Repairs the frozen 2026.6.35 candidate CI checkout boundary after anonymous Git reads began failing. Every manual checkout/fetch of `github.repository` now passes the job token as a process-only, repository-scoped HTTP header; no credentials are saved to `origin` or Git config, and redirects are disabled. This also covers the shared shallow-base recovery action, so a distant PR base cannot reintroduce the unauthenticated transport.

The three frozen Testbox preparation workflows fetch trusted `main` after their candidate checkout. Their `origin` URLs now end in `.git`, exactly matching the URL-scoped header. Workflow Sanity's three manual source checkouts and its later trusted-base fetch use the same boundary. Release-target verification now uses the authenticated GitHub commit API for its historical tag and candidate branch identity, rather than anonymous `git ls-remote`.

`security-fast` now preserves the candidate's exact scanner versions (`pre-commit` 4.2.0, `pre-commit-hooks` 6.0.0, `zizmor` 1.22.0) while using local system hooks built from immutable base `zizmor` policy. This removes its remote Git-hook initialization and forces hook Git transport to `file` only. The external ClawHub checkout remains untouched: the candidate token is intentionally not lent to another repository. `actions/checkout` paths remain untouched.

## Evidence

- Frozen `659df810` preflight and security-fast jobs have `contents: read` but no authenticated Git transport at `.github/workflows/ci.yml:139` and `:457`.
- Candidate PR runs #136721, #136903, #136924, and #136935 consistently exit 128 before source checkout: `fatal: could not read Username for https://github.com`.
- This PR's first ARM Testbox run exposed the same second-hop path: job `100514638783` failed at the uncredentialed `refs/heads/main` fetch in `ci-check-arm-testbox.yml`.
- Exact-head replay job `100518016507` proves source checkout and shared base recovery now pass, then separately fails only when pre-commit tries to clone `https://github.com/pre-commit/pre-commit-hooks`.
- Candidate `zizmor-pre-commit` v1.22.0 declares its `zizmor==1.22.0` package dependency, and `pre-commit-hooks` 6.0.0 exports the `detect-private-key` executable. The candidate-native local hooks preserve their file filters, exclusions, policy arguments, and pins.
- Release target validation follows established main repair `ea947e7891a` using `GH_TOKEN` + the same-repository commit API; security-fast follows established main network-free scanner repair `1b535dd2f4f` without pulling unrelated CI machinery.
- Git URL matching is exact: the guard asserts each Testbox `origin` URL and authentication header use `https://github.com/${CHECKOUT_REPO}.git`.

## Validation

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` (33 passed)
- `actionlint` on `ci.yml`, `workflow-sanity.yml`, and all three Testbox workflows
- `./node_modules/.bin/oxfmt --check` on changed workflow/action/test files
- Git URL-match assertion with the exact `.git` origin key
- `git diff --check`
- `autoreview --mode local --base origin/extended-stable/2026.6.33` (no accepted finding output)

The replacement exact-head CI re-exercises security-fast without relying on a third-party Git clone or forwarding the repository token beyond `openclaw/openclaw`.

## Follow-up: release cache tag authentication

Commit `f95d46e649c` closes the remaining same-repository read identified by ClawSweeper. `Resolve release dist cache seeds` now receives the ephemeral GitHub token and applies the established process-only, repository-scoped Git header plus redirect policy to its `git ls-remote --tags` invocation. It never persists credentials on `origin`; private frozen candidates can resolve beta/latest tag cache keys rather than silently skipping them. The workflow guard now makes that cache lookup part of the authenticated-read contract.

Verification: `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts --reporter=dot` (33 passed), `actionlint .github/workflows/ci-build-artifacts-testbox.yml`, formatting, and `git diff --check` passed. `check-changed --dry-run` selected tooling; its actual Testbox delegation is unavailable locally because pnpm attempts a non-TTY modules purge before dispatch. Commit autoreview was invoked for `f95d46e649c`.

Follow-up delta: workflow +9/-1; test +12/-0. The test fails on the prior head because the cache-seed step has neither its token environment nor the scoped `ls-remote` header.

## Current merge gate

Exact-head CI now reaches the repaired manual checkout and base-recovery paths. Its remaining `security-fast` failure is solely the candidate's four `fast-uri@4.1.2` high advisories; #136721 supplies the targeted `4.1.4` lockfile/shrinkwrap repair. Merge #136949 first, then rerun #136721 and dependent candidate heads.
