### PR TITLE
perf: short-circuit plugin shape classification

### DIFF
--- a/src/plugins/inspect-shape.ts
+++ b/src/plugins/inspect-shape.ts
@@ -22,6 +22,14 @@ type PluginShapeSummary = {
   capabilities: PluginCapabilityEntry[];
 };
 
+type PluginShapeParams = {
+  plugin: PluginRegistry["plugins"][number];
+  report: Pick<
+    PluginRegistry,
+    "hooks" | "typedHooks" | "tools" | "gatewayMethodDescriptors" | "sessionCatalogs"
+  >;
+};
+
 function buildPluginCapabilityEntries(
   plugin: PluginRegistry["plugins"][number],
   report: Pick<PluginRegistry, "sessionCatalogs">,
@@ -63,70 +71,37 @@ function buildPluginCapabilityEntries(
   ].filter((entry) => entry.ids.length > 0);
 }
 
-function derivePluginInspectShape(params: {
-  capabilityCount: number;
-  typedHookCount: number;
-  customHookCount: number;
-  toolCount: number;
-  commandCount: number;
-  cliCount: number;
-  serviceCount: number;
-  gatewayMethodCount: number;
-  httpRouteCount: number;
-}): PluginInspectShape {
-  if (params.capabilityCount > 1) {
+function derivePluginInspectShape(
+  { plugin, report }: PluginShapeParams,
+  capabilityCount: number,
+): PluginInspectShape {
+  if (capabilityCount > 1) {
     return "hybrid-capability";
   }
-  if (params.capabilityCount === 1) {
+  if (capabilityCount === 1) {
     return "plain-capability";
   }
   const hasOnlyHooks =
-    params.typedHookCount + params.customHookCount > 0 &&
-    params.toolCount === 0 &&
-    params.commandCount === 0 &&
-    params.cliCount === 0 &&
-    params.serviceCount === 0 &&
-    params.gatewayMethodCount === 0 &&
-    params.httpRouteCount === 0;
+    plugin.commands.length === 0 &&
+    plugin.cliCommands.length === 0 &&
+    plugin.services.length === 0 &&
+    plugin.httpRoutes === 0 &&
+    (report.typedHooks.some((entry) => entry.pluginId === plugin.id) ||
+      report.hooks.some((entry) => entry.pluginId === plugin.id)) &&
+    !report.tools.some((entry) => entry.pluginId === plugin.id) &&
+    !(report.gatewayMethodDescriptors ?? []).some(
+      (descriptor) => descriptor.owner.kind === "plugin" && descriptor.owner.pluginId === plugin.id,
+    );
   if (hasOnlyHooks) {
     return "hook-only";
   }
   return "non-capability";
 }
 
-export function buildPluginShapeSummary(params: {
-  plugin: PluginRegistry["plugins"][number];
-  report: Pick<
-    PluginRegistry,
-    "hooks" | "typedHooks" | "tools" | "gatewayMethodDescriptors" | "sessionCatalogs"
-  >;
-}): PluginShapeSummary {
+export function buildPluginShapeSummary(params: PluginShapeParams): PluginShapeSummary {
   const capabilities = buildPluginCapabilityEntries(params.plugin, params.report);
-  const typedHookCount = params.report.typedHooks.filter(
-    (entry) => entry.pluginId === params.plugin.id,
-  ).length;
-  const customHookCount = params.report.hooks.filter(
-    (entry) => entry.pluginId === params.plugin.id,
-  ).length;
-  const toolCount = params.report.tools.filter(
-    (entry) => entry.pluginId === params.plugin.id,
-  ).length;
-  const gatewayMethodCount = (params.report.gatewayMethodDescriptors ?? []).filter(
-    (descriptor) =>
-      descriptor.owner.kind === "plugin" && descriptor.owner.pluginId === params.plugin.id,
-  ).length;
   const capabilityCount = capabilities.length;
-  const shape = derivePluginInspectShape({
-    capabilityCount,
-    typedHookCount,
-    customHookCount,
-    toolCount,
-    commandCount: params.plugin.commands.length,
-    cliCount: params.plugin.cliCommands.length,
-    serviceCount: params.plugin.services.length,
-    gatewayMethodCount,
-    httpRouteCount: params.plugin.httpRoutes,
-  });
+  const shape = derivePluginInspectShape(params, capabilityCount);
 
   return {
     shape,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers with write access can edit it.

</details>

## What Problem This Solves

Plugin shape summaries scan and allocate filtered hook, tool and gateway arrays even when the capability list already determines the answer. Those counts exist only to answer existence questions.

## Why This Change Was Made

Keep classification inside `buildPluginShapeSummary`'s owner. Return the capability classification immediately; for plugins without capabilities, reject ordinary commands/services/routes first and use short-circuit existence checks for hooks, tools and plugin-owned gateway descriptors. Remove the intermediate count object and four filtered arrays. Capability order, borrowed ID arrays and the fresh result objects remain unchanged.

Production LOC: +26/-51 (net −25). Tests unchanged. No configuration, persistence, plugin SDK, model/provider, or gateway protocol change.

## User Impact

Less work per plugin shape summary. The complete summary call was 52–61% faster on the three primary capability fixtures, saving about 0.484–0.596µs per call. The surrounding inspect report still does its detailed scans; this does not establish a whole CLI startup or host CPU improvement.

## Evidence

Actual source-owner functions, synthetic registry records, two proof hosts, then B0/C0/C1/B1. Eight timed rows and sixteen proof controls; 32 calls per batch; one first, two warm and sixteen measured batches per row/host. All 19,504 calls passed full input/result/order/alias checks, with 512 measured means. A separate reviewer reconstructed the raw graphs and arithmetic before opening the aggregate. That audit was raw-first, but not blind to the lead's earlier acceptance disclosure.

Median time change, negative faster:

| Complete summary | B0 → C0 | B1 → C1 |
| --- | ---: | ---: |
| Channel capability | −53.875% | −61.122% |
| Provider capability | −54.440% | −60.233% |
| Mixed capabilities | −52.505% | −59.400% |
| Hook owner | −15.966% | −31.829% |
| Later hook owner | +40.941% | −25.204% |
| Disqualifying tool | +21.828% | −27.875% |
| Commands | −32.276% | −60.983% |
| Empty plugin | +13.343% | −23.929% |

The original gates passed: each primary at least 3% faster in both orders; protected regression rejects only when both >3% and >1µs in both orders; kernel peak RSS rejects above 10% in both orders. The three adverse forward protected medians were +378ns, +201ns and +57ns.

Tails were not uniformly faster. Channel-summary p95 worsened in both orders (+37.084%/+81.887%, +0.579/+3.038µs). Later-hook and command forward p95 rose +4.238/+6.802µs, then improved in reverse. Hook-owner, later-hook and disqualifying-tool first observations worsened in both orders; the largest was +44.957µs forward for the disqualifying-tool row. Six forward warm medians were adverse. All exact first/warm/p95 vectors remain in the retained raw audit; none was discarded or presented as passing a tail gate.

Kernel peak RSS was +1.150%/−0.287%; sampled group RSS +0.811%/+0.395%. Whole-host user CPU was +11.119%/+5.871%, so no broad CPU reduction is demonstrated. Whole-host wall includes imports, fixture construction, checking and graph I/O; only the complete public summary loop is the operation timer.

Correctness: the same 86 existing cases pass before and after across eight complete files covering registry status, compatibility/runtime inspection, bundled inspection, installed health, config validation and the shape contract. Repository changed-check passed (308.924s). Fresh managed Codex P2 review is scoped-clean, no findings; the reviewer did not rerun tests. Current main's reviewed owner/caller/test files are unchanged from the frozen base. No implementation-mirroring test was added.

Frozen base: `63974421ae54abc47f8c0c5905c35978c20f48a7`. Candidate owner SHA-256: `a9facf1444656e356e4e0e375db71ec8807ff013688348283d5741457b15a4bc`. Independent numeric audit seal: `0576176048926fb49559dbd6bf8a68e8023a95fc7c880da3adb708ddfed54489`. Final immutable experiment SHA-256: `6ef94c9c9a6e57f2603bdb5c1fcb3eccfde9a0458b9ddaef1cdd565f20038344`.

All nine native phases and terminal publication joins exited zero; 566 selected pins and final process/group absence were checked. Complete retained evidence is 24,783,009 bytes. Recorded phase charge is 53.942s; late external-actuals publication lacks an exact duration, so the final accounting conservatively charges an 82.071s enclosing interval plus audit/final reserves (142.879s total bound within the original 360s). Preparation/source reading is separately recorded. No rerun, workload adjustment, gate widening, or live provider/network timing claim.
