### PR TITLE
perf: reuse progress formatter character preparation

### DIFF
--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -969,10 +969,6 @@ export function resolveChannelProgressDraftMaxLineChars(
   return configured && configured > 0 ? configured : defaultValue;
 }
 
-function sliceCodePoints(value: string, start: number, end?: number): string {
-  return Array.from(value).slice(start, end).join("");
-}
-
 function compactProgressLineDetail(detail: string, maxChars: number): string {
   const chars = Array.from(detail);
   if (chars.length <= maxChars) {
@@ -990,7 +986,7 @@ function compactProgressLineDetail(detail: string, maxChars: number): string {
 }
 
 function removeUnbalancedInlineBackticks(value: string): string {
-  const backtickCount = Array.from(value).filter((char) => char === "`").length;
+  const backtickCount = value.match(/`/g)?.length ?? 0;
   if (backtickCount % 2 === 0) {
     return value;
   }
@@ -1003,7 +999,7 @@ function repairCompactedProgressMarkdown(value: string): string {
   if (!trimmedStart.startsWith("_") || trimmedStart.endsWith("_")) {
     return withoutDanglingBackticks;
   }
-  const underscoreCount = Array.from(trimmedStart).filter((char) => char === "_").length;
+  const underscoreCount = trimmedStart.match(/_/g)?.length ?? 0;
   if (underscoreCount % 2 === 0) {
     return withoutDanglingBackticks;
   }
@@ -1016,14 +1012,18 @@ function repairCompactedProgressMarkdown(value: string): string {
 
 function compactChannelProgressDraftNarration(text: string): string {
   const normalized = text.replace(/\s+/g, " ").trim();
-  if (Array.from(normalized).length <= PROGRESS_DRAFT_NARRATION_MAX_CHARS) {
+  const chars = Array.from(normalized);
+  if (chars.length <= PROGRESS_DRAFT_NARRATION_MAX_CHARS) {
     return normalized;
   }
-  return compactPlainProgressLine(normalized, PROGRESS_DRAFT_NARRATION_MAX_CHARS);
+  return compactPlainProgressLine(chars, PROGRESS_DRAFT_NARRATION_MAX_CHARS);
 }
 
-function compactPlainProgressLine(line: string, maxChars: number): string {
-  const head = sliceCodePoints(line, 0, maxChars - 1).trimEnd();
+function compactPlainProgressLine(chars: readonly string[], maxChars: number): string {
+  const head = chars
+    .slice(0, maxChars - 1)
+    .join("")
+    .trimEnd();
   const boundary = head.search(/\s+\S*$/u);
   if (boundary > Math.floor(maxChars * 0.6)) {
     return `${head.slice(0, boundary).trimEnd()}…`;
@@ -1075,7 +1075,7 @@ function compactChannelProgressDraftLine(line: string, maxChars: number): string
     }
   }
 
-  return repairCompactedProgressMarkdown(compactPlainProgressLine(normalized, maxChars));
+  return repairCompactedProgressMarkdown(compactPlainProgressLine(chars, maxChars));
 }
 
 export function formatPlanChecklistLines(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers with write access can edit it.

</details>

## What Problem This Solves

Progress formatting repeatedly expands the same text into Unicode code points. It also expands every character just to count ASCII backticks and underscores during Markdown repair.

## Why This Change Was Made

Carry the already-prepared code-point array into the private compaction helper, remove the duplicate slicing helper, and count literal ASCII markers directly. Unicode truncation, word boundaries, Markdown parity, callback order and error propagation retain their existing owners and behavior.

Production LOC: +11/-11 (net 0). Tests unchanged. No new cache, dependency, configuration, persistence or public API.

## User Impact

The complete progress formatter improved 19–36% on the three primary workloads, saving roughly 2.1–6.8µs per call. This measures generic/Matrix-style progress text and explicit summary narration, not complete channel delivery, model latency, or Discord's default quiet presentation.

## Evidence

Actual public `formatChannelProgressDraftText` and `formatPlanChecklistLines` calls with synthetic inputs. Two proof hosts, then B0/C0/C1/B1; ten timed rows and twenty proof controls; eight calls per batch; one first, two warm and sixteen measured batches per row/host. All 6,140 calls passed full result/input/alias/lifecycle checks, with 640 measured batch means. The independent raw-first audit checked all 2,462 callbacks, both expected sentinel-error throws, callback-driven input mutation and repeated nested input references, then exactly matched the aggregate.

Median time change, negative faster:

| Whole formatter workload | B0 → C0 | B1 → C1 |
| --- | ---: | ---: |
| Long structured read paths | −18.934% | −26.616% |
| Long ordinary prose | −35.912% | −24.012% |
| Longer summary narration | −20.541% | −24.319% |
| W04 control | −9.018% | −7.021% |
| W05 control | −24.647% | −40.548% |
| W06 control | −10.291% | +6.456% |
| W07 control | +16.425% | +1.967% |
| W08 control | −16.302% | −32.643% |
| Public recording callback | −11.616% | −5.920% |
| W10 control | −5.479% | −18.614% |

The preset gates passed without reruns: each primary at least 3% faster in both orders; a protected row rejects only when both orders exceed 3% and 1µs regression; kernel RSS rejects above 10% in both orders. W06 reverse worsened 440ns; W07 worsened 555ns/83ns. These remain in the result.

First/warm/tail observations were not uniformly better. The W01 reverse first batch worsened 79.896µs (+86.750%); W03 reverse p95 worsened 5.411µs (+43.417%). W06 p95 worsened in both orders (+0.229/+1.672µs). W07 forward p95 worsened 2.177µs; additional first/warm adverses include W08 forward +7.956µs, W09 reverse +6.125µs and W10 both warm batches +2.141/+2.255µs. All 25 slower descriptive comparisons and every raw vector are retained in the audit. With sixteen measured batches, nearest-rank p95 is the maximum, not a stable tail-latency estimate.

Kernel peak RSS increased +1.042%/+2.570%; sampled group RSS +0.955%/+2.634%. No memory improvement is claimed. The operation clock includes the complete formatter, callbacks and result collection; fixture preparation and graph serialization are outside it but inside host/resource accounting. First batches are first per row in a shared host, not independent cold starts.

Correctness: the same 126 existing cases pass before and after across the five complete streaming, lifecycle, compositor, visibility and tool-metadata test files. Repository changed-check passed (328.392s). Fresh managed Codex P2 review is scoped-clean with no findings; it did not rerun tests. Current main's reviewed owner/caller/test files are unchanged from the frozen base. Existing Unicode, Markdown, callback and lifecycle coverage is preferable to a new implementation-mirroring test.

Frozen base: `63974421ae54abc47f8c0c5905c35978c20f48a7`. Candidate owner SHA-256: `10002dcd840944c8864f9c029bd9b54fff453e868f31998d9de63eca8ff347dd`. Independent numeric audit seal: `1616d38f865dcc59575c2b732718c90c76c51d5994e58b0081799249b5e23dde`. Final immutable experiment SHA-256: `decaa54811bd7df57497bb03b2e9cdb2cf9843b497745760253cba69b9a838f3`.

All nine phases and terminal accounting tools exited zero; 444 selected pins, 137 history members and all 21 recorded PIDs/15 groups were checked. Complete evidence is 21,702,169 bytes. Recorded phase charge is 54.024s. A late external-actuals publication lacks an exact duration; conservatively charging its enclosing 155.834s interval plus audit and final reserves gives a 216.825s bound within the original 360s. Preparation/source reading is separate. The auditor knew the parent-reported pass but froze its independent numbers before reading the aggregate. No data filtering, retries, retuned gates or network/provider performance claim.
