### PR TITLE
fix(worker): preserve turn outcomes when skill cleanup fails

### DIFF
--- a/docs/cli/worker.md
+++ b/docs/cli/worker.md
@@ -80,18 +80,19 @@ and scrubbed when that directory is removed. The sealed worker launcher binds it
 to each `exec` child. GitHub CLI must be installed on the worker host; the bundle
 includes the launcher, not `gh`.
 
-Materialized skill files are temporary turn inputs. A failed per-turn deletion logs
-`Materialized skill cleanup failed`; failed removal of the enclosing temporary
-state directory logs `Worker environment cleanup failed`. Node Claude skill sessions
-use `Node Claude skill session cleanup failed` for their enclosing directory. These
+Materialized skill files are temporary turn inputs in a private directory separate
+from worker state and its GitHub credentials. A failed per-turn deletion logs
+`Materialized skill cleanup failed`. Node Claude skill sessions separately report
+`Node Claude skill session cleanup failed` for temporary Workshop configuration. These
 bounded, redacted warnings identify files that may remain. Wait until the worker or
 session and its owned processes have stopped before checking permissions and manually
 removing the reported directory. A completed turn alone does not mean a managed worker
 has stopped. These filesystem deletion failures preserve the original success, error,
 cancellation, or timeout without replaying work or claiming deletion succeeded.
-Process draining, authority revocation, database close, and transport close retain
-their existing failure behavior. Invalid skill integrity or delivery limits still
-reject the turn.
+Worker state deletion, including GitHub credential cleanup, still rejects on failure.
+Process draining, authority revocation, database close, and transport or MCP close
+retain their existing failure behavior. Invalid skill integrity or delivery limits
+still reject the turn.
 
 The worker loads workspace `AGENTS.md` through the bounded bootstrap loader and
 appends Gateway-supplied system instructions as literal text. It does not discover

--- a/docs/cli/worker.md
+++ b/docs/cli/worker.md
@@ -80,6 +80,19 @@ and scrubbed when that directory is removed. The sealed worker launcher binds it
 to each `exec` child. GitHub CLI must be installed on the worker host; the bundle
 includes the launcher, not `gh`.
 
+Materialized skill files are temporary turn inputs. A failed per-turn deletion logs
+`Materialized skill cleanup failed`; failed removal of the enclosing temporary
+state directory logs `Worker environment cleanup failed`. Node Claude skill sessions
+use `Node Claude skill session cleanup failed` for their enclosing directory. These
+bounded, redacted warnings identify files that may remain. Wait until the worker or
+session and its owned processes have stopped before checking permissions and manually
+removing the reported directory. A completed turn alone does not mean a managed worker
+has stopped. These filesystem deletion failures preserve the original success, error,
+cancellation, or timeout without replaying work or claiming deletion succeeded.
+Process draining, authority revocation, database close, and transport close retain
+their existing failure behavior. Invalid skill integrity or delivery limits still
+reject the turn.
+
 The worker loads workspace `AGENTS.md` through the bounded bootstrap loader and
 appends Gateway-supplied system instructions as literal text. It does not discover
 `SYSTEM.md` or `APPEND_SYSTEM.md` from the workspace or agent state directory.

--- a/src/infra/temp-artifact-cleanup.ts
+++ b/src/infra/temp-artifact-cleanup.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs/promises";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { formatErrorMessage } from "./errors.js";
+import { runBestEffortCleanup } from "./non-fatal-cleanup.js";
+
+const log = createSubsystemLogger("infra:temp-artifacts");
+
+// Only disposable filesystem artifacts are advisory. Call after resource release;
+// failed deletion must preserve the primary result, including cancellation/timeouts.
+export function removeTemporaryArtifacts(directory: string, owner: string): Promise<void> {
+  return runBestEffortCleanup({
+    cleanup: () => fs.rm(directory, { recursive: true, force: true }),
+    onError: (error) =>
+      log.warn(
+        truncateUtf16Safe(
+          formatErrorMessage(
+            `${owner} cleanup failed; files may remain in ${directory}. After the worker or session stops, check permissions and remove the retained directory: ${formatErrorMessage(error)}`,
+          ),
+          1_024,
+        ),
+      ),
+  });
+}

--- a/src/node-host/claude-skill-session.test.ts
+++ b/src/node-host/claude-skill-session.test.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { loggingState } from "../logging/state.js";
+import { loadWorkspaceSkills } from "../skills/loading/workspace-skill-loader.js";
+import { buildSkillSnapshot } from "../skills/loading/workspace-skill-prompt.js";
+import { prepareSkillResourceDelivery } from "../skills/runtime/resources.js";
+import { prepareNodeClaudeSkillSession } from "./claude-skill-session.js";
+
+const temps = useAutoCleanupTempDirTracker(afterEach);
+
+describe("node Claude skill artifact cleanup", () => {
+  it("preserves the exact frozen setup error when enclosing skill cleanup fails", async () => {
+    const workspace = temps.make("node-skill-rollback-");
+    const skillDir = path.join(workspace, "skills", "partial");
+    await fs.mkdir(skillDir, { recursive: true });
+    const markdown = "---\ndescription: Partial materialization proof\n---\n# Instructions\n";
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), markdown);
+    await fs.writeFile(path.join(skillDir, "reference.md"), "supporting resource");
+    const resources = await prepareSkillResourceDelivery(
+      buildSkillSnapshot(workspace, {
+        entries: loadWorkspaceSkills(workspace, { workspaceOnly: true }),
+      }),
+      () => {},
+    );
+    const primary = new Error("Node skill setup cancelled");
+    primary.name = "AbortError";
+    Object.freeze(primary);
+    const controller = new AbortController();
+    let directory: string | undefined;
+    let retainedFile: string | undefined;
+    const originalWriteFile = fs.writeFile;
+    const writeFile = vi
+      .spyOn(fs, "writeFile")
+      .mockImplementation(async (target, data, options) => {
+        await originalWriteFile(target, data, options);
+        if (typeof target === "string" && path.basename(target) === "SKILL.md") {
+          retainedFile = target;
+          directory = path.resolve(path.dirname(target), "../../..");
+          controller.abort(primary);
+        }
+      });
+    const originalRm = fs.rm;
+    const deletionError = new Error("EACCES: retained node skill artifact");
+    const rm = vi.spyOn(fs, "rm").mockImplementation((target, options) => {
+      if (
+        directory &&
+        (String(target) === directory || String(target).startsWith(`${directory}${path.sep}`))
+      ) {
+        return Promise.reject(deletionError);
+      }
+      return originalRm(target, options);
+    });
+    const warn = vi.fn();
+    const previousConsole = loggingState.rawConsole;
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    loggingState.rawConsole = { log: vi.fn(), info: vi.fn(), warn, error: vi.fn() };
+    const unsubscribe = vi.fn();
+    try {
+      const result = await prepareNodeClaudeSkillSession({
+        signal: controller.signal,
+        emitChunk: vi.fn(),
+        onInput: vi.fn(),
+        frames: {
+          send: vi.fn(),
+          onMessage: (listener) => {
+            void listener(Buffer.from(JSON.stringify({ type: "init", resources })));
+            return unsubscribe;
+          },
+        },
+      }).catch((error: unknown) => error);
+      expect.soft(result).toBe(primary);
+      expect(unsubscribe).toHaveBeenCalledOnce();
+      expect(retainedFile).toBeDefined();
+      expect(await fs.readFile(retainedFile!, "utf8")).toBe(markdown);
+      await expect(
+        fs.stat(path.join(path.dirname(retainedFile!), "reference.md")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      const warning = warn.mock.calls.flat().map(String).join("\n");
+      expect(warning).toContain("Materialized skill cleanup failed");
+      expect.soft(warning).toContain("Node Claude skill session cleanup failed");
+      expect(warning).toContain(directory);
+      expect(warning).toContain("EACCES");
+      expect(warning).not.toContain(markdown);
+    } finally {
+      writeFile.mockRestore();
+      rm.mockRestore();
+      loggingState.rawConsole = previousConsole;
+      setLoggerOverride(null);
+      resetLogger();
+      if (directory) {
+        await fs.rm(directory, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/src/node-host/claude-skill-session.test.ts
+++ b/src/node-host/claude-skill-session.test.ts
@@ -12,7 +12,82 @@ import { prepareNodeClaudeSkillSession } from "./claude-skill-session.js";
 const temps = useAutoCleanupTempDirTracker(afterEach);
 
 describe("node Claude skill artifact cleanup", () => {
-  it("preserves the exact frozen setup error when enclosing skill cleanup fails", async () => {
+  it.skipIf(process.platform === "win32" || process.getuid?.() === 0).each([false, true])(
+    "grants only the artifact root and cleans independent inputs after close (Workshop: %s)",
+    async (workshop) => {
+      const workspace = temps.make("node-skill-session-");
+      const skillDir = path.join(workspace, "skills", "guide");
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillDir, "SKILL.md"),
+        "---\ndescription: Guide\n---\n# Guide\n",
+      );
+      const resources = await prepareSkillResourceDelivery(
+        buildSkillSnapshot(workspace, {
+          entries: loadWorkspaceSkills(workspace, { workspaceOnly: true }),
+        }),
+        () => {},
+      );
+      const session = await prepareNodeClaudeSkillSession({
+        signal: new AbortController().signal,
+        emitChunk: vi.fn(),
+        onInput: vi.fn(),
+        frames: {
+          send: vi.fn(),
+          onMessage: (listener) => {
+            void listener(
+              Buffer.from(
+                JSON.stringify({
+                  type: "init",
+                  resources,
+                  ...(workshop ? { workshop: { description: "Fixture", inputSchema: {} } } : {}),
+                }),
+              ),
+            );
+            return vi.fn();
+          },
+        },
+      });
+      const artifactRoot = session.argv[session.argv.indexOf("--add-dir") + 1]!;
+      const skillPath = session.rewriteReferences(path.join(skillDir, "SKILL.md"));
+      const configPath = workshop
+        ? session.argv[session.argv.indexOf("--mcp-config") + 1]!
+        : undefined;
+      const warn = vi.fn();
+      const previousConsole = loggingState.rawConsole;
+      setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+      loggingState.rawConsole = { log: vi.fn(), info: vi.fn(), warn, error: vi.fn() };
+      try {
+        expect(session.argv.filter((arg) => arg === "--add-dir")).toHaveLength(1);
+        expect(path.dirname(path.dirname(skillPath))).toBe(artifactRoot);
+        expect((await fs.stat(artifactRoot)).mode & 0o777).toBe(0o700);
+        expect(session.catalog).toContain(skillPath);
+        if (configPath) {
+          expect(path.relative(artifactRoot, configPath).startsWith(`..${path.sep}`)).toBe(true);
+          expect((await fs.stat(path.dirname(configPath))).mode & 0o777).toBe(0o700);
+        }
+        await fs.chmod(path.dirname(skillPath), 0o500);
+        await session.close();
+        await expect(session.writeStdout("late output")).rejects.toThrow("invocation closed");
+        await expect(session.cleanup()).resolves.toBeUndefined();
+        expect(await fs.readFile(skillPath, "utf8")).toContain("# Guide");
+        if (configPath) {
+          await expect(fs.stat(path.dirname(configPath))).rejects.toMatchObject({ code: "ENOENT" });
+        }
+        expect(warn).toHaveBeenCalledOnce();
+        expect(warn.mock.calls.flat().join("\n")).toContain(artifactRoot);
+      } finally {
+        await session.close();
+        await fs.chmod(path.dirname(skillPath), 0o700);
+        await session.cleanup();
+        loggingState.rawConsole = previousConsole;
+        setLoggerOverride(null);
+        resetLogger();
+      }
+    },
+  );
+
+  it("preserves the exact frozen setup error when partial skill cleanup fails", async () => {
     const workspace = temps.make("node-skill-rollback-");
     const skillDir = path.join(workspace, "skills", "partial");
     await fs.mkdir(skillDir, { recursive: true });
@@ -38,7 +113,7 @@ describe("node Claude skill artifact cleanup", () => {
         await originalWriteFile(target, data, options);
         if (typeof target === "string" && path.basename(target) === "SKILL.md") {
           retainedFile = target;
-          directory = path.resolve(path.dirname(target), "../../..");
+          directory = path.dirname(path.dirname(target));
           controller.abort(primary);
         }
       });
@@ -80,7 +155,7 @@ describe("node Claude skill artifact cleanup", () => {
       ).rejects.toMatchObject({ code: "ENOENT" });
       const warning = warn.mock.calls.flat().map(String).join("\n");
       expect(warning).toContain("Materialized skill cleanup failed");
-      expect.soft(warning).toContain("Node Claude skill session cleanup failed");
+      expect(warn).toHaveBeenCalledOnce();
       expect(warning).toContain(directory);
       expect(warning).toContain("EACCES");
       expect(warning).not.toContain(markdown);

--- a/src/node-host/claude-skill-session.ts
+++ b/src/node-host/claude-skill-session.ts
@@ -21,6 +21,7 @@ import {
   NodeClaudeSkillResultSchema,
   type NodeClaudeSkillInit,
 } from "../infra/node-claude-skill-protocol.js";
+import { removeTemporaryArtifacts } from "../infra/temp-artifact-cleanup.js";
 import type { OpenClawPluginNodeHostCommandIo } from "../plugins/types.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { materializeSkillResources } from "../skills/runtime/resources.js";
@@ -72,12 +73,8 @@ export async function prepareNodeClaudeSkillSession(io: OpenClawPluginNodeHostCo
     }
   };
   const cleanup = async () => {
-    try {
-      await artifacts?.cleanup();
-    } finally {
-      if (directory) {
-        await fs.rm(directory, { recursive: true, force: true });
-      }
+    if (directory) {
+      await removeTemporaryArtifacts(directory, "Node Claude skill session");
     }
   };
   try {

--- a/src/node-host/claude-skill-session.ts
+++ b/src/node-host/claude-skill-session.ts
@@ -73,6 +73,7 @@ export async function prepareNodeClaudeSkillSession(io: OpenClawPluginNodeHostCo
     }
   };
   const cleanup = async () => {
+    await artifacts?.cleanup();
     if (directory) {
       await removeTemporaryArtifacts(directory, "Node Claude skill session");
     }
@@ -103,17 +104,17 @@ export async function prepareNodeClaudeSkillSession(io: OpenClawPluginNodeHostCo
     });
     const init = await initialized.promise;
     assertCurrent();
-    directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-node-claude-skills-"));
-    assertCurrent();
     if (init.resources) {
-      artifacts = await materializeSkillResources(init.resources, directory, assertCurrent);
+      artifacts = await materializeSkillResources(init.resources, assertCurrent);
       assertCurrent();
     }
     // Claude's native Read permission covers the project plus --add-dir roots.
     // Expose only verified resources, never the separate MCP configuration file.
-    const argv: string[] = artifacts ? ["--add-dir", path.join(directory, "skill-resources")] : [];
+    const argv: string[] = artifacts ? ["--add-dir", artifacts.directory] : [];
     const workshop = init.workshop;
     if (workshop) {
+      directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-node-claude-skills-"));
+      assertCurrent();
       // An unguessable local route prevents unrelated browser traffic; the
       // Gateway's exact pending invocation remains the privileged effect owner.
       const route = `/mcp/${randomUUID()}`;

--- a/src/skills/library/service.test.ts
+++ b/src/skills/library/service.test.ts
@@ -347,11 +347,7 @@ describe("profile-owned skill publication and selection", () => {
       prepareSkillResourceDelivery(snapshot, () => {}),
     );
     expect(delivery).toBeDefined();
-    const materialized = await materializeSkillResources(
-      delivery!,
-      path.join(stateDir, "worker"),
-      () => {},
-    );
+    const materialized = await materializeSkillResources(delivery!, () => {});
     try {
       const skill = materialized.snapshot.resolvedSkills![0]!;
       expect(await fs.readFile(skill.filePath, "utf8")).toBe(content);

--- a/src/skills/runtime/resources.test.ts
+++ b/src/skills/runtime/resources.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -30,8 +30,18 @@ describe("prepared workspace skill resources", () => {
       const directory = await writeSkill(workspace, "partial");
       await fs.writeFile(path.join(directory, "reference.md"), "supporting resource");
       const delivery = await prepareSkillResourceDelivery(loadSnapshot(workspace), () => {});
-      const stateDir = temps.make("skill-rollback-worker-");
-      const parent = path.join(stateDir, "skill-resources");
+      let artifactRoot: string | undefined;
+      let retainedFile: string | undefined;
+      const originalWriteFile = fs.writeFile;
+      const writeFile = vi
+        .spyOn(fs, "writeFile")
+        .mockImplementation(async (target, data, options) => {
+          await originalWriteFile(target, data, options);
+          if (typeof target === "string" && path.basename(target) === "SKILL.md") {
+            retainedFile = target;
+            artifactRoot = path.dirname(path.dirname(target));
+          }
+        });
       const primary = new Error("Prepared turn closed");
       primary.name = name;
       Object.freeze(primary);
@@ -39,7 +49,7 @@ describe("prepared workspace skill resources", () => {
       const deletionError = new Error(`EACCES: token=${secret} ${"🦞".repeat(2_000)}`);
       const originalRm = fs.rm;
       const rm = vi.spyOn(fs, "rm").mockImplementation((target, options) => {
-        if (String(target).startsWith(`${parent}${path.sep}`)) {
+        if (target === artifactRoot) {
           return Promise.reject(deletionError);
         }
         return originalRm(target, options);
@@ -48,16 +58,9 @@ describe("prepared workspace skill resources", () => {
       const previousConsole = loggingState.rawConsole;
       setLoggerOverride({ level: "silent", consoleLevel: "warn" });
       loggingState.rawConsole = { log: vi.fn(), info: vi.fn(), warn, error: vi.fn() };
-      let retainedFile: string | undefined;
       try {
-        const result = await materializeSkillResources(delivery!, stateDir, () => {
-          if (!existsSync(parent)) {
-            return;
-          }
-          const turn = readdirSync(parent)[0];
-          const candidate = turn && path.join(parent, turn, "0", "SKILL.md");
-          if (candidate && existsSync(candidate)) {
-            retainedFile = candidate;
+        const result = await materializeSkillResources(delivery!, () => {
+          if (retainedFile) {
             throw primary;
           }
         }).catch((error: unknown) => error);
@@ -74,10 +77,14 @@ describe("prepared workspace skill resources", () => {
         expect.soft(warning.length).toBeLessThanOrEqual(1_200);
         expect.soft(Buffer.from(warning, "utf8").toString("utf8")).toBe(warning);
       } finally {
+        writeFile.mockRestore();
         rm.mockRestore();
         loggingState.rawConsole = previousConsole;
         setLoggerOverride(null);
         resetLogger();
+        if (artifactRoot) {
+          await fs.rm(artifactRoot, { recursive: true, force: true });
+        }
       }
     },
   );
@@ -101,7 +108,7 @@ describe("prepared workspace skill resources", () => {
         reuse === "rehydrated" ? structuredClone(snapshot) : snapshot,
         () => {},
       );
-      const worker = await materializeSkillResources(next!, temps.make("fresh-worker-"), () => {});
+      const worker = await materializeSkillResources(next!, () => {});
       try {
         const skill = worker.snapshot.resolvedSkills![0]!;
         expect(await fs.readFile(path.join(skill.baseDir, "scripts/check.sh"), "utf8")).toBe(
@@ -157,7 +164,7 @@ describe("prepared workspace skill resources", () => {
     ]);
     const delivery = await prepareSkillResourceDelivery(snapshot, () => {});
     expect(delivery?.skills).toMatchObject([{ name: "directory-name" }]);
-    const materialized = await materializeSkillResources(delivery!, workspace, () => {});
+    const materialized = await materializeSkillResources(delivery!, () => {});
     try {
       const skill = materialized.snapshot.resolvedSkills![0]!;
       expect(skill.name).toBe("directory-name");
@@ -165,6 +172,8 @@ describe("prepared workspace skill resources", () => {
       expect(await fs.readFile(skill.filePath, "utf8")).toBe(markdown);
       expect(await fs.readFile(path.join(skill.baseDir, "scripts/check.sh"), "utf8")).toBe(script);
       if (process.platform !== "win32") {
+        expect((await fs.stat(materialized.directory)).mode & 0o777).toBe(0o700);
+        expect((await fs.stat(skill.filePath)).mode & 0o777).toBe(0o400);
         expect((await fs.stat(path.join(skill.baseDir, "scripts/check.sh"))).mode & 0o777).toBe(
           0o500,
         );
@@ -203,7 +212,7 @@ describe("prepared workspace skill resources", () => {
     expect(snapshot.prompt.match(/<name>/g)).toHaveLength(65);
     const delivery = await prepareSkillResourceDelivery(snapshot, () => {});
     expect(delivery?.skills).toHaveLength(65);
-    const materialized = await materializeSkillResources(delivery!, workspace, () => {});
+    const materialized = await materializeSkillResources(delivery!, () => {});
     try {
       expect(materialized.snapshot.skills.map((skill) => skill.name)).toEqual(
         snapshot.resolvedSkills!.map((skill) => skill.name),

--- a/src/skills/runtime/resources.test.ts
+++ b/src/skills/runtime/resources.test.ts
@@ -1,7 +1,10 @@
+import { existsSync, readdirSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resetLogger, setLoggerOverride } from "../../logging/logger.js";
+import { loggingState } from "../../logging/state.js";
 import { loadWorkspaceSkills } from "../loading/workspace-skill-loader.js";
 import { buildSkillSnapshot } from "../loading/workspace-skill-prompt.js";
 import { materializeSkillResources, prepareSkillResourceDelivery } from "./resources.js";
@@ -20,6 +23,65 @@ function loadSnapshot(workspace: string) {
 }
 
 describe("prepared workspace skill resources", () => {
+  it.each(["AbortError", "TimeoutError"])(
+    "preserves the exact frozen %s after partial materialization and failed cleanup",
+    async (name) => {
+      const workspace = temps.make("skill-rollback-");
+      const directory = await writeSkill(workspace, "partial");
+      await fs.writeFile(path.join(directory, "reference.md"), "supporting resource");
+      const delivery = await prepareSkillResourceDelivery(loadSnapshot(workspace), () => {});
+      const stateDir = temps.make("skill-rollback-worker-");
+      const parent = path.join(stateDir, "skill-resources");
+      const primary = new Error("Prepared turn closed");
+      primary.name = name;
+      Object.freeze(primary);
+      const secret = "synthetic-cleanup-secret";
+      const deletionError = new Error(`EACCES: token=${secret} ${"🦞".repeat(2_000)}`);
+      const originalRm = fs.rm;
+      const rm = vi.spyOn(fs, "rm").mockImplementation((target, options) => {
+        if (String(target).startsWith(`${parent}${path.sep}`)) {
+          return Promise.reject(deletionError);
+        }
+        return originalRm(target, options);
+      });
+      const warn = vi.fn();
+      const previousConsole = loggingState.rawConsole;
+      setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+      loggingState.rawConsole = { log: vi.fn(), info: vi.fn(), warn, error: vi.fn() };
+      let retainedFile: string | undefined;
+      try {
+        const result = await materializeSkillResources(delivery!, stateDir, () => {
+          if (!existsSync(parent)) {
+            return;
+          }
+          const turn = readdirSync(parent)[0];
+          const candidate = turn && path.join(parent, turn, "0", "SKILL.md");
+          if (candidate && existsSync(candidate)) {
+            retainedFile = candidate;
+            throw primary;
+          }
+        }).catch((error: unknown) => error);
+        expect.soft(result).toBe(primary);
+        expect(retainedFile).toBeDefined();
+        expect(await fs.readFile(retainedFile!, "utf8")).toBe(markdown);
+        expect(existsSync(path.join(path.dirname(retainedFile!), "reference.md"))).toBe(false);
+        const warning = warn.mock.calls.flat().map(String).join("\n");
+        expect.soft(warning).toContain("Materialized skill cleanup failed");
+        expect.soft(warning).toContain(path.basename(path.dirname(path.dirname(retainedFile!))));
+        expect.soft(warning).toContain("EACCES");
+        expect.soft(warning).not.toContain(secret);
+        expect.soft(warning).not.toContain(markdown);
+        expect.soft(warning.length).toBeLessThanOrEqual(1_200);
+        expect.soft(Buffer.from(warning, "utf8").toString("utf8")).toBe(warning);
+      } finally {
+        rm.mockRestore();
+        loggingState.rawConsole = previousConsole;
+        setLoggerOverride(null);
+        resetLogger();
+      }
+    },
+  );
+
   it.each(["same", "rehydrated"] as const)(
     "delivers current supporting bytes to a fresh worker with the %s catalog snapshot",
     async (reuse) => {

--- a/src/skills/runtime/resources.ts
+++ b/src/skills/runtime/resources.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { Value } from "typebox/value";
 import {
@@ -9,7 +10,6 @@ import {
   SkillResourceDeliverySchema,
   type SkillResourceDelivery,
 } from "../../../packages/gateway-protocol/src/schema/skill-resources.js";
-import { ensureAbsoluteDirectory } from "../../infra/fs-safe.js";
 import { removeTemporaryArtifacts } from "../../infra/temp-artifact-cleanup.js";
 import { prepareSkillBundle, readSkillBundleTree } from "../library/bundle.js";
 import { loadSkillLibrarySelection, readSelectedSkillLibraryFiles } from "../library/selection.js";
@@ -113,12 +113,12 @@ export async function prepareSkillResourceDelivery(
   return delivery;
 }
 
-/** Worker owns both the directory and cleanup; resource bytes never enter project reconciliation. */
+/** Owns private turn inputs independently of credential-bearing worker state. */
 export async function materializeSkillResources(
   delivery: SkillResourceDelivery,
-  stateDir: string,
   assertCurrent: () => void,
 ): Promise<{
+  directory: string;
   snapshot: SkillSnapshot;
   rewriteReferences: (text: string) => string;
   cleanup: () => Promise<void>;
@@ -140,13 +140,7 @@ export async function materializeSkillResources(
     throw new Error("Skill resource integrity or delivery limit check failed.");
   }
   assertCurrent();
-  const parent = path.join(stateDir, "skill-resources");
-  const ensured = await ensureAbsoluteDirectory(parent, { mode: 0o700 });
-  if (!ensured.ok) {
-    throw ensured.error;
-  }
-  assertCurrent();
-  const directory = await fs.mkdtemp(path.join(parent, "turn-"));
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-resources-"));
   const cleanup = () => removeTemporaryArtifacts(directory, "Materialized skill");
   try {
     const pathMappings: Array<[string, string]> = [];
@@ -182,6 +176,7 @@ export async function materializeSkillResources(
     }
     assertCurrent();
     return {
+      directory,
       snapshot: {
         skills: resolvedSkills.map((skill) => ({ name: skill.name, skillKey: skill.name })),
         resolvedSkills,

--- a/src/skills/runtime/resources.ts
+++ b/src/skills/runtime/resources.ts
@@ -10,6 +10,7 @@ import {
   type SkillResourceDelivery,
 } from "../../../packages/gateway-protocol/src/schema/skill-resources.js";
 import { ensureAbsoluteDirectory } from "../../infra/fs-safe.js";
+import { removeTemporaryArtifacts } from "../../infra/temp-artifact-cleanup.js";
 import { prepareSkillBundle, readSkillBundleTree } from "../library/bundle.js";
 import { loadSkillLibrarySelection, readSelectedSkillLibraryFiles } from "../library/selection.js";
 import { loadSingleSkillDirectory } from "../loading/local-loader.js";
@@ -146,7 +147,7 @@ export async function materializeSkillResources(
   }
   assertCurrent();
   const directory = await fs.mkdtemp(path.join(parent, "turn-"));
-  const cleanup = () => fs.rm(directory, { recursive: true, force: true });
+  const cleanup = () => removeTemporaryArtifacts(directory, "Materialized skill");
   try {
     const pathMappings: Array<[string, string]> = [];
     const resolvedSkills: NonNullable<SkillSnapshot["resolvedSkills"]> = [];

--- a/src/worker/embedded-agent.runtime.ts
+++ b/src/worker/embedded-agent.runtime.ts
@@ -111,9 +111,7 @@ const WORKER_TOOL_CONFIG = { plugins: { enabled: false } } satisfies OpenClawCon
 
 export async function runWorkerEmbeddedTurn(params: RunWorkerEmbeddedTurnParams): Promise<void> {
   const resources = params.skillResources
-    ? await materializeSkillResources(params.skillResources, params.stateDir, () =>
-        params.signal?.throwIfAborted(),
-      )
+    ? await materializeSkillResources(params.skillResources, () => params.signal?.throwIfAborted())
     : undefined;
   try {
     await runWorkerEmbeddedTurnWithResources(

--- a/src/worker/worker.fault-injection.test.ts
+++ b/src/worker/worker.fault-injection.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkerLiveEventParams } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type {
@@ -14,6 +17,12 @@ import {
   clearAgentRunContext,
   getAgentRunContext,
 } from "../infra/agent-run-registry.js";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { loggingState } from "../logging/state.js";
+import { loadWorkspaceSkills } from "../skills/loading/workspace-skill-loader.js";
+import { buildSkillSnapshot } from "../skills/loading/workspace-skill-prompt.js";
+import { prepareSkillResourceDelivery } from "../skills/runtime/resources.js";
+import { runWorkerCommand } from "./worker-command.runtime.js";
 import {
   WorkerAdmissionError,
   WorkerConnectionStoppedError,
@@ -82,6 +91,179 @@ describe("cloud worker milestone 2 fault injection", () => {
     }
     await harness.close();
   });
+
+  it.skipIf(process.platform === "win32" || process.getuid?.() === 0).each([
+    ["success", "standalone", "completed", "stop"],
+    ["success", "managed", "completed", "stop"],
+    ["provider failure", "managed", "failed", "error"],
+    ["cancellation", "managed", "failed", "aborted"],
+  ] as const)(
+    "preserves %s through the %s command when materialized skill cleanup gets real EACCES",
+    async (outcome, mode, expectedStatus, stopReason) => {
+      const skillDir = path.join(harness.root, "skills", "cleanup");
+      await fs.mkdir(skillDir, { recursive: true });
+      const markdown = "---\nname: cleanup\ndescription: Cleanup proof\n---\n# Instructions\n";
+      await fs.writeFile(path.join(skillDir, "SKILL.md"), markdown);
+      const descriptor = harness.createDescriptor();
+      descriptor.assignment.skillResources = await prepareSkillResourceDelivery(
+        buildSkillSnapshot(harness.root, {
+          entries: loadWorkspaceSkills(harness.root, { workspaceOnly: true }),
+        }),
+        () => {},
+      );
+      const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+      let environmentStateDir: string | undefined;
+      const providerRelease = createDeferred<WorkerInferenceTerminalOutcome>();
+      const providerStarted = createDeferred();
+      harness.providerPlan = {
+        kind: "pending",
+        release: providerRelease,
+        started: providerStarted,
+      };
+      const finishingGate = harness.addLiveEventGate("after-service", "finishing");
+      const controller = new AbortController();
+      const warn = vi.fn();
+      const previousConsole = loggingState.rawConsole;
+      setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+      loggingState.rawConsole = { log: vi.fn(), info: vi.fn(), warn, error: vi.fn() };
+      const input = new PassThrough();
+      const output = new PassThrough();
+      let stdout = "";
+      output.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString("utf8");
+      });
+      const lifetime = {
+        signal: controller.signal,
+        started: Promise.resolve(true),
+        dispose: vi.fn(),
+        reportConnectionFailure: vi.fn(),
+        terminateOwnedTree: vi.fn(),
+      };
+      const managed = mode === "managed";
+      const command = runWorkerCommand({ input, output, managed, lifetime });
+      void command.catch(() => undefined);
+      if (managed) {
+        input.write(
+          `${JSON.stringify({ type: "turn", turnId: descriptor.assignment.turnId, descriptor })}\n`,
+        );
+      } else {
+        input.end(JSON.stringify(descriptor));
+      }
+      let protectedDirectory: string | undefined;
+      try {
+        await providerStarted.promise;
+        environmentStateDir = process.env.OPENCLAW_STATE_DIR;
+        expect(environmentStateDir).toBeDefined();
+        expect(environmentStateDir).not.toBe(previousStateDir);
+        const parent = path.join(environmentStateDir!, "skill-resources");
+        const turns = await fs.readdir(parent);
+        expect(turns).toHaveLength(1);
+        const turnDirectory = path.join(parent, turns[0]!);
+        protectedDirectory = path.join(turnDirectory, "0");
+        const retainedFile = path.join(protectedDirectory, "SKILL.md");
+        expect(await fs.readFile(retainedFile, "utf8")).toBe(markdown);
+        await fs.chmod(protectedDirectory, 0o500);
+        if (outcome === "cancellation") {
+          input.write(
+            `${JSON.stringify({ type: "cancel", turnId: descriptor.assignment.turnId })}\n`,
+          );
+        } else {
+          providerRelease.resolve(
+            outcome === "provider failure"
+              ? { type: "error", reason: "provider-error", message: "fixture provider failed" }
+              : doneOutcome("paid reply"),
+          );
+        }
+        await finishingGate.entered.promise;
+        if (outcome === "cancellation") {
+          expect(harness.requestParams("worker.inference.cancel")).toHaveLength(1);
+        }
+        const finishing = harness
+          .requestParams("worker.live-event")
+          .map((params) => params as WorkerLiveEventParams)
+          .filter(({ event }) => event.kind === "lifecycle" && event.payload.phase === "finishing");
+        expect(finishing).toHaveLength(1);
+        expect(finishing[0]?.event).toMatchObject({
+          kind: "lifecycle",
+          payload: { phase: "finishing", stopReason },
+        });
+        const payload = finishing[0]!.event.payload;
+        if (outcome === "provider failure") {
+          expect(payload).toHaveProperty("error", "fixture provider failed");
+        } else {
+          expect(payload).not.toHaveProperty("error");
+        }
+        if (outcome === "cancellation") {
+          expect(payload).toHaveProperty("aborted", true);
+        }
+        expect(harness.placementStore.listPendingWorkspaceResults()).toMatchObject([
+          { sessionId: SESSION_ID, environmentId: ENVIRONMENT_ID, runId: RUN_ID },
+        ]);
+        expect(harness.placementStore.get(SESSION_ID)?.lastLiveEventAckCursor).toBe(
+          finishing[0]!.seq,
+        );
+        finishingGate.release.resolve();
+        await expect.soft(command).resolves.toBeUndefined();
+        const settled: unknown = JSON.parse(stdout || "null");
+        const transcript = SessionManager.open(harness.sessionTarget);
+        const messages = transcript
+          .getEntries()
+          .flatMap((entry) => (entry.type === "message" ? [entry.message] : []));
+        expect(messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+        expect(messages[1]).toMatchObject({ stopReason });
+        if (outcome === "success") {
+          expect(messages[1]).toMatchObject({ content: [{ type: "text", text: "paid reply" }] });
+        } else if (outcome === "provider failure") {
+          expect(messages[1]).toHaveProperty("errorMessage", "fixture provider failed");
+        }
+        const expectedResult = { status: expectedStatus, transcriptLeafId: transcript.getLeafId() };
+        expect.soft(settled).toMatchObject(
+          managed
+            ? {
+                type: "result",
+                turnId: descriptor.assignment.turnId,
+                retainWorker: false,
+                result: expectedResult,
+              }
+            : expectedResult,
+        );
+        expect(lifetime.dispose).toHaveBeenCalledOnce();
+        expect(lifetime.terminateOwnedTree).not.toHaveBeenCalled();
+        expect(process.env.OPENCLAW_STATE_DIR).toBe(previousStateDir);
+        expect(harness.providerCalls).toBe(1);
+        expect(harness.requestParams("worker.inference.start")).toHaveLength(1);
+        expect(harness.requestParams("worker.live-event")).toHaveLength(finishing[0]!.seq);
+        expect(await fs.readFile(retainedFile, "utf8")).toBe(markdown);
+        const warning = warn.mock.calls.flat().map(String).join("\n");
+        expect.soft(warning).toContain("Materialized skill cleanup failed");
+        expect.soft(warning).toContain(turnDirectory);
+        expect.soft(warning).toContain("Worker environment cleanup failed");
+        expect.soft(warning).toContain(environmentStateDir);
+        expect.soft(warning).toContain("EACCES");
+        expect.soft(warning).not.toContain(markdown);
+      } finally {
+        providerRelease.resolve(doneOutcome("fixture teardown"));
+        finishingGate.release.resolve();
+        controller.abort(new Error("fixture teardown"));
+        input.end();
+        await Promise.allSettled([command]);
+        try {
+          // Keep deletion blocked until the command's enclosing teardown has settled.
+          if (protectedDirectory) {
+            await fs.chmod(protectedDirectory, 0o700);
+          }
+          if (environmentStateDir) {
+            await fs.rm(environmentStateDir, { recursive: true, force: true });
+          }
+        } finally {
+          output.destroy();
+          loggingState.rawConsole = previousConsole;
+          setLoggerOverride(null);
+          resetLogger();
+        }
+      }
+    },
+  );
 
   it("replays captured compaction exactly after worker commit and canonical reopen", async () => {
     await runWorkerProviderReplayRoundTrip({

--- a/src/worker/worker.fault-injection.test.ts
+++ b/src/worker/worker.fault-injection.test.ts
@@ -93,18 +93,25 @@ describe("cloud worker milestone 2 fault injection", () => {
   });
 
   it.skipIf(process.platform === "win32" || process.getuid?.() === 0).each([
-    ["success", "standalone", "completed", "stop"],
-    ["success", "managed", "completed", "stop"],
-    ["provider failure", "managed", "failed", "error"],
-    ["cancellation", "managed", "failed", "aborted"],
+    ["success", "standalone", "skill", "completed", "stop"],
+    ["success", "managed", "skill", "completed", "stop"],
+    ["provider failure", "managed", "skill", "failed", "error"],
+    ["cancellation", "managed", "skill", "failed", "aborted"],
+    ["success", "standalone", "credential", "completed", "stop"],
+    ["success", "managed", "credential", "completed", "stop"],
   ] as const)(
-    "preserves %s through the %s command when materialized skill cleanup gets real EACCES",
-    async (outcome, mode, expectedStatus, stopReason) => {
+    "settles %s through the %s command with real EACCES deleting %s files",
+    async (outcome, mode, deniedOwner, expectedStatus, stopReason) => {
       const skillDir = path.join(harness.root, "skills", "cleanup");
       await fs.mkdir(skillDir, { recursive: true });
       const markdown = "---\nname: cleanup\ndescription: Cleanup proof\n---\n# Instructions\n";
       await fs.writeFile(path.join(skillDir, "SKILL.md"), markdown);
       const descriptor = harness.createDescriptor();
+      descriptor.assignment.github = {
+        login: "worker-cleanup-fixture",
+        token: "synthetic-worker-cleanup-token",
+        branch: "openclaw/cleanup-fixture",
+      };
       descriptor.assignment.skillResources = await prepareSkillResourceDelivery(
         buildSkillSnapshot(harness.root, {
           entries: loadWorkspaceSkills(harness.root, { workspaceOnly: true }),
@@ -150,18 +157,28 @@ describe("cloud worker milestone 2 fault injection", () => {
         input.end(JSON.stringify(descriptor));
       }
       let protectedDirectory: string | undefined;
+      let turnDirectory: string | undefined;
       try {
         await providerStarted.promise;
         environmentStateDir = process.env.OPENCLAW_STATE_DIR;
         expect(environmentStateDir).toBeDefined();
         expect(environmentStateDir).not.toBe(previousStateDir);
-        const parent = path.join(environmentStateDir!, "skill-resources");
-        const turns = await fs.readdir(parent);
-        expect(turns).toHaveLength(1);
-        const turnDirectory = path.join(parent, turns[0]!);
-        protectedDirectory = path.join(turnDirectory, "0");
-        const retainedFile = path.join(protectedDirectory, "SKILL.md");
-        expect(await fs.readFile(retainedFile, "utf8")).toBe(markdown);
+        const request = harness.requestParams(
+          "worker.inference.start",
+        )[0] as WorkerInferenceStartParams;
+        const retainedFile = request.context.systemPrompt?.match(
+          /<location>([^<]+)<\/location>/u,
+        )?.[1];
+        expect(retainedFile).toBeDefined();
+        turnDirectory = path.dirname(path.dirname(retainedFile!));
+        const profilesRoot = path.join(environmentStateDir!, "github-profiles");
+        const profiles = await fs.readdir(profilesRoot);
+        expect(profiles).toHaveLength(1);
+        const profileDir = path.join(profilesRoot, profiles[0]!);
+        const hostsPath = path.join(profileDir, "hosts.yml");
+        expect(await fs.readFile(hostsPath, "utf8")).toContain(descriptor.assignment.github.token);
+        protectedDirectory = deniedOwner === "skill" ? path.dirname(retainedFile!) : profileDir;
+        expect(await fs.readFile(retainedFile!, "utf8")).toBe(markdown);
         await fs.chmod(protectedDirectory, 0o500);
         if (outcome === "cancellation") {
           input.write(
@@ -203,7 +220,11 @@ describe("cloud worker milestone 2 fault injection", () => {
           finishing[0]!.seq,
         );
         finishingGate.release.resolve();
-        await expect.soft(command).resolves.toBeUndefined();
+        if (deniedOwner === "credential") {
+          await expect.soft(command).rejects.toMatchObject({ code: "EACCES" });
+        } else {
+          await expect.soft(command).resolves.toBeUndefined();
+        }
         const settled: unknown = JSON.parse(stdout || "null");
         const transcript = SessionManager.open(harness.sessionTarget);
         const messages = transcript
@@ -217,29 +238,44 @@ describe("cloud worker milestone 2 fault injection", () => {
           expect(messages[1]).toHaveProperty("errorMessage", "fixture provider failed");
         }
         const expectedResult = { status: expectedStatus, transcriptLeafId: transcript.getLeafId() };
-        expect.soft(settled).toMatchObject(
-          managed
-            ? {
-                type: "result",
-                turnId: descriptor.assignment.turnId,
-                retainWorker: false,
-                result: expectedResult,
-              }
-            : expectedResult,
-        );
+        if (deniedOwner === "credential" && !managed) {
+          expect.soft(stdout).toBe("");
+        } else {
+          expect.soft(settled).toMatchObject(
+            managed
+              ? {
+                  type: "result",
+                  turnId: descriptor.assignment.turnId,
+                  retainWorker: false,
+                  result: expectedResult,
+                }
+              : expectedResult,
+          );
+        }
         expect(lifetime.dispose).toHaveBeenCalledOnce();
         expect(lifetime.terminateOwnedTree).not.toHaveBeenCalled();
         expect(process.env.OPENCLAW_STATE_DIR).toBe(previousStateDir);
         expect(harness.providerCalls).toBe(1);
         expect(harness.requestParams("worker.inference.start")).toHaveLength(1);
         expect(harness.requestParams("worker.live-event")).toHaveLength(finishing[0]!.seq);
-        expect(await fs.readFile(retainedFile, "utf8")).toBe(markdown);
         const warning = warn.mock.calls.flat().map(String).join("\n");
-        expect.soft(warning).toContain("Materialized skill cleanup failed");
-        expect.soft(warning).toContain(turnDirectory);
-        expect.soft(warning).toContain("Worker environment cleanup failed");
-        expect.soft(warning).toContain(environmentStateDir);
-        expect.soft(warning).toContain("EACCES");
+        if (deniedOwner === "skill") {
+          expect(await fs.readFile(retainedFile!, "utf8")).toBe(markdown);
+          await expect
+            .soft(fs.stat(environmentStateDir!))
+            .rejects.toMatchObject({ code: "ENOENT" });
+          await expect.soft(fs.stat(hostsPath)).rejects.toMatchObject({ code: "ENOENT" });
+          expect.soft(warning).toContain("Materialized skill cleanup failed");
+          expect.soft(warning).toContain(turnDirectory);
+          expect.soft(warning).toContain("EACCES");
+        } else {
+          expect(await fs.readFile(hostsPath, "utf8")).toContain(
+            descriptor.assignment.github.token,
+          );
+          await expect(fs.stat(turnDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+        }
+        expect.soft(warning).not.toContain("Worker environment cleanup failed");
+        expect.soft(warning).not.toContain(descriptor.assignment.github.token);
         expect.soft(warning).not.toContain(markdown);
       } finally {
         providerRelease.resolve(doneOutcome("fixture teardown"));
@@ -251,6 +287,9 @@ describe("cloud worker milestone 2 fault injection", () => {
           // Keep deletion blocked until the command's enclosing teardown has settled.
           if (protectedDirectory) {
             await fs.chmod(protectedDirectory, 0o700);
+          }
+          if (turnDirectory) {
+            await fs.rm(turnDirectory, { recursive: true, force: true });
           }
           if (environmentStateDir) {
             await fs.rm(environmentStateDir, { recursive: true, force: true });

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, realpath, rm, stat } from "node:fs/promises";
+import { chmod, mkdtemp, realpath, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -8,6 +8,7 @@ import {
 import { waitForExecScope } from "../agents/bash-process-registry.js";
 import type { ComputerContextEpoch } from "../agents/tools/computer-tool.js";
 import { isPathInside } from "../infra/path-guards.js";
+import { removeTemporaryArtifacts } from "../infra/temp-artifact-cleanup.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db-cache.js";
@@ -97,7 +98,7 @@ export async function createWorkerRuntimeEnvironment(sessionId: string) {
         } else {
           process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
         }
-        await rm(stateDir, { recursive: true, force: true });
+        await removeTemporaryArtifacts(stateDir, "Worker environment");
       })()),
   };
 }

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, realpath, stat } from "node:fs/promises";
+import { chmod, mkdtemp, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -8,7 +8,6 @@ import {
 import { waitForExecScope } from "../agents/bash-process-registry.js";
 import type { ComputerContextEpoch } from "../agents/tools/computer-tool.js";
 import { isPathInside } from "../infra/path-guards.js";
-import { removeTemporaryArtifacts } from "../infra/temp-artifact-cleanup.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db-cache.js";
@@ -98,7 +97,7 @@ export async function createWorkerRuntimeEnvironment(sessionId: string) {
         } else {
           process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
         }
-        await removeTemporaryArtifacts(stateDir, "Worker environment");
+        await rm(stateDir, { recursive: true, force: true });
       })()),
   };
 }


### PR DESCRIPTION
Closes #136957

<details>
<summary>Additional instructions</summary>

This is a maintainer-owned upstream branch; maintainers can update it.

</details>

## What Problem This Solves

Fixes an issue where users running worker turns with materialized skills could receive a failed result after their answer was committed and finishing was acknowledged when temporary skill-file deletion failed. Setup rollback could also lose its original cancellation or timeout error behind a secondary deletion error.

## Why This Change Was Made

Copied skill inputs now own a private per-turn artifact directory, independent of worker state. Failed deletion is advisory: report a bounded/redacted warning and retained-directory guidance, then preserve the existing result or original error. The node CLI receives exactly that artifact directory as its additional read root; temporary Workshop configuration stays in a separate private directory allocated only when needed.

This isolation matters after #136583 introduced per-turn GitHub profiles inside worker state. The original version of this PR made enclosing state-directory deletion advisory; integration testing caught that this would weaken the new credential-bearing lifecycle. **Worker state and GitHub credential cleanup are now byte-for-byte unchanged from the reviewed main baseline and still reject on deletion failure.** A denied skill-file deletion cannot obstruct removal of credential-bearing state because the trees are independent.

Process draining, database/transport or MCP closure, authority revocation, privileged desktop cleanup, worker finishing/ACK, interruption precedence, and retry/fallback classification retain their existing behavior. No wire result field, configuration, dependency, store, retry, or timeout was added. The internal materializer directory result serves a real CLI read-permission caller; it is not a protocol change.

## User Impact

Completed worker work remains completed when disposable skill-file cleanup is denied, and failed or interrupted work retains its original reason. Operators receive a warning identifying potentially retained skill files. Wait until the worker/session and its owned processes stop before manually checking permissions and removing the reported artifact directory. Integrity and resource-delivery validation still fail closed.

The maintainer explicitly selected advisory cleanup for these disposable skill inputs, not for credential state or privileged resources.

## Evidence

The original reproduction used real filesystem `EACCES` and showed a committed answer plus successful finishing ACK followed by failed worker status. Portable partial-write rollback cases showed the exact frozen primary error being replaced by deletion failure.

After rebasing onto main `df4628e68f13dc10a159e7beabf32a14c454db42`, **six integration regressions failed before the isolation repair**: four standalone/managed success, provider-failure and cancellation cases retained worker state when skill deletion was denied; two standalone/managed credential-deletion cases incorrectly resolved. All six now pass: skill deletion warns while credential-bearing state disappears, and denied credential deletion still rejects.

These cases use the actual worker command, embedded loop, WebSocket/RPC owners, transcript store, finishing receiver/result fence, real materializer, actual GitHub-profile writer with synthetic credentials, and real POSIX deletion. Permissions remain blocked through command settlement. They also assert one provider execution and no extra inference or terminal replay. No production test seam was introduced.

**220 tests passed across 12 files**, in the following focused runs, with no skipped tests on the non-root macOS proof host:

```bash
node scripts/run-vitest.mjs src/worker/worker.fault-injection.test.ts src/skills/runtime/resources.test.ts src/node-host/claude-skill-session.test.ts
```

```bash
node scripts/run-vitest.mjs src/skills/library/service.test.ts src/worker/worker-command.runtime.test.ts src/worker/worker-runtime-environment.test.ts src/worker/worker.runtime.test.ts src/worker/embedded-agent-live.runtime.test.ts src/node-host/invoke-agent-cli-claude.test.ts src/node-host/worker-runtime.test.ts src/node-host/runtime.test.ts
```

```bash
node scripts/run-vitest.mjs src/gateway/node-claude-skill-runtime.test.ts --maxWorkers=1
```

Coverage includes exact frozen cancellation/timeout identity; private artifact and file modes; the exact node read root excluding Workshop config; independent artifact cleanup; actual synthetic CLI execution of supporting files; current-main GitHub identity binding and retained-process isolation; stale-transcript no-replay; background-process/finalizer ordering; desktop cleanup; and MCP close failures. POSIX permission cases explicitly skip Windows/root. There is no additional combined command-timeout/EACCES or typed transcript-error/EACCES case.

Targeted formatting, core/test types, typed lint, dead-export scans, import-cycle and applicable boundary guards passed through the scoped changed gate:

```bash
node scripts/check-changed.mjs -- docs/cli/worker.md src/infra/temp-artifact-cleanup.ts src/node-host/claude-skill-session.ts src/node-host/claude-skill-session.test.ts src/skills/library/service.test.ts src/skills/runtime/resources.ts src/skills/runtime/resources.test.ts src/worker/embedded-agent.runtime.ts src/worker/worker.fault-injection.test.ts src/worker/worker.runtime.ts
```

`git diff --check` passed. Fresh isolated Codex autoreview covered the complete candidate against the pinned main baseline and is clean at its default P0-only threshold. No full local build, live-model or UI run was performed: this repair is exercised at actual filesystem, command/RPC and synthetic CLI boundaries, without changing an external provider/API, package entrypoint or lazy boundary. Live-model/UI proof was outside the original task's authorization.

Production LOC: **+40/-24 (net +16)**. Tests: **+470/-9 (net +461)**. Docs: **+14**. Growth supplies the shared bounded/redacted artifact-deletion boundary and exact internal read-root ownership, while removing nested staging and unnecessary Workshop-directory allocation. The ClawSweeper merge-risk item about broadening cleanup policy is addressed: the helper is used only for materialized skill inputs and temporary node Workshop configuration, never worker credential state or privileged cleanup.

Guidance is updated in [the worker documentation](https://docs.openclaw.ai/cli/worker). Original defect provenance was verified at `1842ab774cd60155803b55248aaf0417b6e2bbd1`, with the implicated owners unchanged from `b394488146f52b5bc807855ebb64057d7d3c1d3f`; the exact introducing commit and shipped-release reachability remain unverified. Generic node CLI prompt-file deletion and non-filesystem close-error precedence remain separate-policy follow-ups. The separate paired-node computer/provider repair is not included.
