### PR TITLE
perf(agents): skip unused BTW reasoning collection

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -423,8 +423,6 @@ function createSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry
 }
 
 function createAssistantDoneEvent(content: unknown[]) {
-  // Done events include usage/provider metadata because BTW persists the reply
-  // as a normal assistant turn.
   return {
     type: "done",
     reason: "stop",
@@ -497,8 +495,10 @@ function supportsPreparedOpenAIAuth(ctx: Parameters<AgentHarness["supports"]>[0]
   return { supported: true as const, priority: 100 };
 }
 
-function runSideQuestion(overrides: Partial<RunBtwSideQuestionParams> = {}) {
-  return runBtwSideQuestion({
+function createSideQuestionParams(
+  overrides: Partial<RunBtwSideQuestionParams> = {},
+): RunBtwSideQuestionParams {
+  return {
     cfg: { agents: { entries: { main: { default: true } } } } as never,
     agentId: "main",
     agentDir: DEFAULT_AGENT_DIR,
@@ -512,7 +512,11 @@ function runSideQuestion(overrides: Partial<RunBtwSideQuestionParams> = {}) {
     opts: {},
     isNewSession: false,
     ...overrides,
-  });
+  };
+}
+
+function runSideQuestion(overrides: Partial<RunBtwSideQuestionParams> = {}) {
+  return runBtwSideQuestion(createSideQuestionParams(overrides));
 }
 
 function runMathSideQuestion(overrides: Partial<RunBtwSideQuestionParams> = {}) {
@@ -903,20 +907,70 @@ describe("runBtwSideQuestion", () => {
     });
   });
 
-  it("returns a final payload when block streaming is unavailable", async () => {
-    mockDoneAnswer("Final answer.");
+  it.each([false, true])(
+    "returns only final text when block streaming is unavailable (thinking: %s)",
+    async (withThinking) => {
+      const onReasoningStream = vi.fn();
+      const onReasoningEnd = vi.fn();
+      streamSimpleMock.mockReturnValue(
+        makeAsyncEvents([
+          createAssistantDoneEvent([
+            ...(withThinking ? [{ type: "thinking", thinking: "Hidden reasoning." }] : []),
+            { type: "text", text: "Final answer." },
+          ]),
+        ]),
+      );
 
-    const result = await runSideQuestion();
+      const result = await runSideQuestion({ opts: { onReasoningStream, onReasoningEnd } });
 
-    expect(result).toEqual({ text: "Final answer." });
-    const ensureArgs = mockCall(ensureOpenClawModelsJsonMock);
-    expect(ensureArgs?.[1]).toBe(DEFAULT_AGENT_DIR);
-    expect(ensureArgs?.[2]).toEqual({ workspaceDir: "/tmp/workspace" });
-    expect(discoverModelsMock).toHaveBeenCalledWith(undefined, DEFAULT_AGENT_DIR, {
-      config: ensureArgs?.[0],
-      workspaceDir: "/tmp/workspace",
-    });
-  });
+      expect(result).toEqual({ text: "Final answer." });
+      expect(onReasoningStream).not.toHaveBeenCalled();
+      expect(onReasoningEnd).not.toHaveBeenCalled();
+      const ensureArgs = mockCall(ensureOpenClawModelsJsonMock);
+      expect(ensureArgs?.[1]).toBe(DEFAULT_AGENT_DIR);
+      expect(ensureArgs?.[2]).toEqual({ workspaceDir: "/tmp/workspace" });
+      expect(discoverModelsMock).toHaveBeenCalledWith(undefined, DEFAULT_AGENT_DIR, {
+        config: ensureArgs?.[0],
+        workspaceDir: "/tmp/workspace",
+      });
+    },
+  );
+
+  it.each(["off", "on", "stream"] as const)(
+    "keeps admitted %s reasoning visibility when caller input changes",
+    async (mode) => {
+      const onReasoningStream = vi.fn();
+      const onReasoningEnd = vi.fn();
+      const input = createSideQuestionParams({
+        resolvedReasoningLevel: mode,
+        opts: {
+          onAssistantMessageStart: async () => {
+            input.resolvedReasoningLevel = mode === "off" ? "on" : "off";
+          },
+          onReasoningStream,
+          onReasoningEnd,
+        },
+      });
+      const done = createDoneEvent("Final answer.");
+      streamSimpleMock.mockReturnValue(
+        makeAsyncEvents([
+          { type: "start", partial: done.message },
+          { type: "thinking_delta", delta: "One " },
+          { type: "thinking_delta", delta: "two" },
+          { type: "thinking_end" },
+          done,
+        ]),
+      );
+
+      await expect(runBtwSideQuestion(input)).resolves.toEqual({ text: "Final answer." });
+      expect(onReasoningStream.mock.calls).toEqual(
+        mode === "off"
+          ? []
+          : [[{ text: "One ", isReasoning: true }], [{ text: "One two", isReasoning: true }]],
+      );
+      expect(onReasoningEnd).toHaveBeenCalledTimes(mode === "off" ? 0 : 1);
+    },
+  );
 
   it.each([
     { harness: "openclaw", sandboxSessionKey: undefined },

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -100,13 +100,6 @@ function collectTextContent(content: Array<{ type?: string; text?: string }>): s
     .join("");
 }
 
-function collectThinkingContent(content: Array<{ type?: string; thinking?: string }>): string {
-  return content
-    .filter((part): part is { type: "thinking"; thinking: string } => part.type === "thinking")
-    .map((part) => part.thinking)
-    .join("");
-}
-
 function buildBtwSystemPrompt(): string {
   return [
     "You are answering an ephemeral /btw side question about the current conversation.",
@@ -1376,8 +1369,8 @@ export async function runBtwSideQuestion(
       }
 
       if (event.type === "thinking_delta") {
-        reasoningText += event.delta;
         if (params.resolvedReasoningLevel !== "off") {
+          reasoningText += event.delta;
           await params.opts?.onReasoningStream?.({ text: reasoningText, isReasoning: true });
         }
         continue;
@@ -1399,13 +1392,8 @@ export async function runBtwSideQuestion(
     }
 
     const finalMessage = finalEvent?.type === "done" ? finalEvent.message : undefined;
-    if (finalMessage) {
-      if (!sawTextEvent) {
-        answerText = collectTextContent(finalMessage.content);
-      }
-      if (!reasoningText) {
-        collectThinkingContent(finalMessage.content);
-      }
+    if (finalMessage && !sawTextEvent) {
+      answerText = collectTextContent(finalMessage.content);
     }
 
     const answer = answerText.trim();


### PR DESCRIPTION
BTW now prepares reasoning text only when the stream can expose it. The direct-provider owner already copies its input before asynchronous work; the reasoning visibility field stays private. Hidden thinking deltas therefore need no accumulated string. Visible reasoning still uses the existing cumulative callbacks and mode checks.

The same change removes the terminal thinking collector whose result was discarded. A previous lint cleanup removed its unused assignment but left its filter/map/join work running. Terminal answer fallback, text-delta precedence, error selection, awaited block delivery and alternative CLI/harness routes keep their existing behavior.

The actual owner passed a paired 19-case synthetic stream corpus: final-only and streamed text, off/on/stream reasoning, input-mode mutation after start, terminal errors, empty answers, block completion and callback failures. All result, callback, event-yield and iterator-cleanup traces matched. Precise coverage observed nine terminal collector calls before and zero after; text collection was unchanged. Skipped hidden accumulation follows from the exercised branches and private input ownership. A supplemental V8 range counter was inconclusive and is not used as allocation evidence. No Gateway RSS, retained-memory or speedup claim is made.

The existing terminal fallback test now covers mixed thinking/text content, and direct-input tests preserve admitted visibility across caller mutation for all three modes. All existing cases remain. Focused coverage passed 76 permanent tests plus the 19 artifact scenarios. Production is −12 lines; tests are +54 lines. The complete canonical changed gate and managed P0–P2 review passed. All proof/review processes joined, their private runtimes were removed, and final source hashes stayed unchanged.

The fixture’s obsolete claim that BTW persists a normal assistant turn was also removed; BTW remains ephemeral. The final two-comment deletion is bound to unchanged executable code and the passing full gate, with targeted formatting and a fresh managed review.

The published branch was refreshed onto main `239beea173a085d15530ca6fa0098cf6106a29eb`; both touched source preimages and the complete reviewed patch are byte-identical. Exact-head hosted CI is green.

Focused before/after measurement used the same unchanged 19-case owner fixture, including Inspector precise coverage, on Node 26.8.1/Vitest 4.1.11. Only the BTW owner was switched between its baseline and this exact PR head; the surrounding source, fixture, arguments and cache policy stayed fixed. The two pilot runs are excluded, followed by three paired runs in final/baseline, baseline/final, final/baseline order. No sample was retried or discarded.

| Pair | Baseline seconds | Final seconds | Paired change | Baseline peak RSS MiB | Final peak RSS MiB | Paired change |
|---|---:|---:|---:|---:|---:|---:|
| 1 | 13.87 | 13.86 | −0.01 | 1777.141 | 1749.625 | −27.516 |
| 2 | 14.30 | 15.39 | +1.09 | 1772.703 | 1785.594 | +12.891 |
| 3 | 13.86 | 13.81 | −0.05 | 1767.953 | 1782.375 | +14.422 |

The median paired elapsed change is −0.010 seconds (range −0.050…+1.090), and median paired peak RSS change is **+12.891 MiB** (range −27.516…+14.422). This instrumented process comparison does not demonstrate a memory or general speed improvement. It includes wrapper startup, transforms/imports, mock setup, coverage and teardown; three pairs cannot isolate the removed collector's cost or establish a Gateway result. The justification remains deletion of discarded computation, simpler reasoning ownership and 12 fewer production lines.

The command was `/usr/bin/time -l node scripts/run-vitest.mjs src/agents/btw-terminal-collection.proof.test.ts --configLoader=runner --no-cache`; the temporary fixture was byte-identical in both arms (SHA-256 `e1248d942b0df0603bc02ab82292245d1040c67fc157d680d85b9eab594379e2`). Runner-based config loading and disabled result caching keep the known cache writers out of dependency donors; the existing filesystem-module cache was directed to a fresh private runtime for each leg. The donor-cache metadata checks were unchanged, but are not an OS-level write trace. macOS time reports maximum RSS in bytes, converted to MiB by 1,048,576; it is not retained heap or summed concurrent process-tree RSS.

All eight commands exited zero and all 152 case traces matched. Observed process identities were absent, private runtimes were removed, donor-cache metadata stayed unchanged, and the final source/permanent tests were restored. Pilot values, retained separately: baseline 15.35 seconds / 1,884,487,680 peak-RSS bytes; final 13.67 seconds / 1,833,385,984 bytes. No provider or Gateway calls were part of this focused fixture.
