### PR TITLE
fix: Tailscale Control UI image previews stay available

### DIFF
--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -62,7 +62,11 @@ type ConnectAuth = {
   password?: string;
 };
 
-type GatewayAuthSurface = "http" | "http-user-profile-avatar" | "ws-control-ui";
+type GatewayAuthSurface =
+  | "http"
+  | "http-control-ui-read"
+  | "http-user-profile-avatar"
+  | "ws-control-ui";
 
 /** Inputs needed to authorize one HTTP or websocket gateway connection. */
 type AuthorizeGatewayConnectParams = {
@@ -254,7 +258,11 @@ function authorizeTrustedProxy(params: {
 }
 
 function shouldAllowTailscaleHeaderAuth(authSurface: GatewayAuthSurface): boolean {
-  return authSurface === "ws-control-ui" || authSurface === "http-user-profile-avatar";
+  return (
+    authSurface === "ws-control-ui" ||
+    authSurface === "http-control-ui-read" ||
+    authSurface === "http-user-profile-avatar"
+  );
 }
 
 function authorizeHttpBrowserOrigin(params: {
@@ -449,12 +457,12 @@ async function authorizeGatewayConnectCore(
   const explicitSharedSecretAuth = hasExplicitSharedSecretAuth(connectAuth);
 
   if (
-    authSurface === "http-user-profile-avatar" &&
+    (authSurface === "http-control-ui-read" || authSurface === "http-user-profile-avatar") &&
     auth.allowTailscale &&
     !localDirect &&
     !explicitSharedSecretAuth
   ) {
-    // Reject cross-origin ambient avatar requests before the Tailscale WhoIs
+    // Reject cross-origin ambient Control UI requests before the Tailscale WhoIs
     // lookup. Explicit shared-secret auth is not subject to this browser gate.
     const originResult = authorizeHttpBrowserOrigin({
       authSurface,
@@ -589,6 +597,16 @@ export async function authorizeHttpGatewayConnect(
   return authorizeGatewayConnect({
     ...params,
     authSurface: "http",
+  });
+}
+
+/** Authorize a read-only Control UI HTTP request, including verified Tailscale identity. */
+export async function authorizeControlUiReadHttpGatewayConnect(
+  params: Omit<AuthorizeGatewayConnectParams, "authSurface">,
+): Promise<GatewayAuthResult> {
+  return authorizeGatewayConnect({
+    ...params,
+    authSurface: "http-control-ui-read",
   });
 }
 

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -19,6 +19,7 @@ import {
   AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
 } from "./auth-rate-limit.js";
 import {
+  authorizeControlUiReadHttpGatewayConnect,
   authorizeHttpGatewayConnect,
   authorizeUserProfileAvatarHttpGatewayConnect,
   type GatewayAuthResult,
@@ -251,7 +252,7 @@ export async function authorizeControlUiReadRequestOrReply(
   const canUseDeviceTokenFallback =
     Boolean(token) && auth.mode !== "trusted-proxy" && auth.mode !== "none";
   const run = async (): Promise<AuthorizedControlUiReadRequest | null> => {
-    const authResult = await authorizeHttpGatewayConnect({
+    const authResult = await authorizeControlUiReadHttpGatewayConnect({
       auth,
       connectAuth: token ? { token, password: token } : null,
       req: params.req,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -18,6 +18,7 @@ import {
   runWithDiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
 import { runHttpConnectionRequest } from "../infra/http-request-lifecycle.js";
+import { readTailscaleWhoisIdentity } from "../infra/tailscale.js";
 import { parseDevicePairingJoinRequestPath } from "../pairing/join-code.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveAssistantAgentId } from "./assistant-identity.js";
@@ -306,6 +307,10 @@ export function createGatewayHttpServer(opts: {
         req,
         trustedProxies,
         allowRealIpFallback,
+        // HTTP authorization must observe Tailnet revocation on the next request.
+        // WebSocket upgrades retain the ordinary cache because they authenticate once.
+        tailscaleWhois: (ip) =>
+          readTailscaleWhoisIdentity(ip, undefined, { cacheTtlMs: 0, errorTtlMs: 0 }),
       });
       const scopedNodeCapability = normalizePluginNodeCapabilityScopedUrl(req.url ?? "/");
       if (scopedNodeCapability.malformedScopedPath) {

--- a/src/gateway/server.auth.modes.suite.ts
+++ b/src/gateway/server.auth.modes.suite.ts
@@ -1,5 +1,7 @@
 // Auth modes suite covers password, token, none, Tailscale, and control-UI
 // origin behavior across gateway WebSocket authentication modes.
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 import {
   connectReq,
@@ -275,7 +277,9 @@ export function registerAuthModesSuite(): void {
         },
         afterWrite: { mode: "auto" },
       });
-      server = await startTestGatewayServer(await getGatewayTestPort());
+      server = await startTestGatewayServer(await getGatewayTestPort(), {
+        controlUiEnabled: true,
+      });
       const endpoint = server.getTailscaleIngressEndpoint();
       if (!endpoint) {
         throw new Error("expected managed Tailscale listener");
@@ -305,7 +309,7 @@ export function registerAuthModesSuite(): void {
       ws.close();
     });
 
-    test("skips pairing for tailscale-authenticated control ui with device identity", async () => {
+    test("authorizes assistant media through the live Tailscale identity", async () => {
       const ws = await openTailscaleWs(tailscaleEndpoint, { origin: tailscaleOrigin });
       const res = await connectReq(ws, {
         skipDefaultAuth: true,
@@ -314,6 +318,62 @@ export function registerAuthModesSuite(): void {
         },
       });
       expect(res.ok, JSON.stringify(res)).toBe(true);
+      // SAFETY: a successful connect response carries the hello-ok payload shape.
+      const payload = res.payload as { auth?: { deviceToken?: string } } | undefined;
+      expect(payload?.auth?.deviceToken).toBe(undefined);
+      testTailscaleWhois.calls.length = 0;
+
+      const stateDir = process.env.OPENCLAW_STATE_DIR;
+      if (!stateDir) {
+        throw new Error("expected Tailscale Control UI media fixture");
+      }
+      const mediaDir = path.join(stateDir, "media", "tailscale-control-ui");
+      await fs.mkdir(mediaDir, { recursive: true });
+      const mediaPath = path.join(mediaDir, "preview.png");
+      await fs.writeFile(mediaPath, Buffer.from("not-a-real-png"));
+      const mediaUrl = new URL(
+        "/__openclaw__/assistant-media",
+        `http://${tailscaleEndpoint.host}:${tailscaleEndpoint.port}`,
+      );
+      mediaUrl.searchParams.set("meta", "1");
+      mediaUrl.searchParams.set("source", mediaPath);
+      const headers = {
+        origin: tailscaleOrigin,
+        "sec-fetch-site": "same-origin",
+        "x-forwarded-for": "100.64.0.1",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "gateway.tailnet.ts.net",
+        "tailscale-user-login": "peter",
+        "tailscale-user-name": "Peter",
+      };
+
+      const media = await fetch(mediaUrl, { headers });
+      const mediaBody = await media.json();
+      expect(media.status, JSON.stringify(mediaBody)).toBe(200);
+      expect(mediaBody).toMatchObject({ available: true, mimeType: "image/png" });
+
+      testTailscaleWhois.value = null;
+      const revokedMedia = await fetch(mediaUrl, { headers });
+      expect(revokedMedia.status).toBe(401);
+      const revokedBytesUrl = new URL(mediaUrl);
+      revokedBytesUrl.searchParams.delete("meta");
+      const revokedBytes = await fetch(revokedBytesUrl, { headers });
+      expect(revokedBytes.status).toBe(401);
+      expect(testTailscaleWhois.calls).toEqual([
+        {
+          ip: "100.64.0.1",
+          opts: { cacheTtlMs: 0, errorTtlMs: 0 },
+        },
+        {
+          ip: "100.64.0.1",
+          opts: { cacheTtlMs: 0, errorTtlMs: 0 },
+        },
+        {
+          ip: "100.64.0.1",
+          opts: { cacheTtlMs: 0, errorTtlMs: 0 },
+        },
+      ]);
+
       const status = await rpcReq(ws, "status");
       expect(status.ok).toBe(true);
       ws.close();

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -188,7 +188,14 @@ vi.mock("../infra/tailscale.js", async () => {
     await vi.importActual<typeof import("../infra/tailscale.js")>("../infra/tailscale.js");
   return {
     ...actual,
-    readTailscaleWhoisIdentity: async () => testTailscaleWhois.value,
+    readTailscaleWhoisIdentity: async (
+      ip: string,
+      _exec: unknown,
+      opts?: { timeoutMs?: number; cacheTtlMs?: number; errorTtlMs?: number },
+    ) => {
+      testTailscaleWhois.calls.push({ ip, opts });
+      return testTailscaleWhois.value;
+    },
   };
 });
 

--- a/src/gateway/test-helpers.runtime-state.ts
+++ b/src/gateway/test-helpers.runtime-state.ts
@@ -63,7 +63,13 @@ type GatewayTestHoistedState = {
     resolveEndBeforeTimeoutIds: Set<string>;
     compactEmbeddedAgentSession: Mock<CompactEmbeddedAgentSessionFn>;
   };
-  testTailscaleWhois: { value: TailscaleWhoisIdentity | null };
+  testTailscaleWhois: {
+    value: TailscaleWhoisIdentity | null;
+    calls: Array<{
+      ip: string;
+      opts?: { timeoutMs?: number; cacheTtlMs?: number; errorTtlMs?: number };
+    }>;
+  };
   getReplyFromConfig: Mock<GetReplyFromConfigFn>;
   sendWhatsAppMock: Mock<SendWhatsAppFn>;
   testState: {
@@ -125,7 +131,7 @@ const gatewayTestHoisted = vi.hoisted(() => {
         },
       }),
     },
-    testTailscaleWhois: { value: null },
+    testTailscaleWhois: { value: null, calls: [] },
     getReplyFromConfig: vi.fn<GetReplyFromConfigFn>().mockResolvedValue(undefined),
     sendWhatsAppMock: vi.fn().mockResolvedValue({ messageId: "msg-1", toJid: "jid-1" }),
     testState: {

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -362,6 +362,7 @@ function resetGatewayLifecycleTestState(options: { preserveRuntimeBindings: bool
 function resetGatewayMutableTestFixtures(): void {
   testTailnetIPv4.value = undefined;
   testTailscaleWhois.value = null;
+  testTailscaleWhois.calls.length = 0;
   agentDiscoveryMock.enabled = false;
   agentDiscoveryMock.discoverCalls = 0;
   agentDiscoveryMock.models = [];

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -200,6 +200,24 @@ describe("tailscale helpers", () => {
     expect(exec).toHaveBeenCalledTimes(2);
   });
 
+  it("bypasses existing whois results when the cache TTL is zero", async () => {
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ UserProfile: { LoginName: "before@example.com" } }),
+      })
+      .mockRejectedValueOnce(new Error("no longer authorized"));
+
+    await expect(readTailscaleWhoisIdentity("100.64.0.13", exec)).resolves.toEqual({
+      login: "before@example.com",
+    });
+    await expect(
+      readTailscaleWhoisIdentity("100.64.0.13", exec, { cacheTtlMs: 0, errorTtlMs: 0 }),
+    ).resolves.toBeNull();
+
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
   it("does not cache whois results when the cache expiry would exceed Date range", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(8_640_000_000_000_000));

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -646,14 +646,16 @@ export async function readTailscaleWhoisIdentity(
   if (!normalized) {
     return null;
   }
-  const now = Date.now();
-  const cached = readCachedWhois(normalized, now);
-  if (cached !== undefined) {
-    return cached;
-  }
-
   const cacheTtlMs = opts?.cacheTtlMs ?? 60_000;
   const errorTtlMs = opts?.errorTtlMs ?? 5_000;
+  const now = Date.now();
+  if (cacheTtlMs > 0) {
+    const cached = readCachedWhois(normalized, now);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
+
   try {
     const tailscaleBin = await getTailscaleBinary();
     const result = await exec(tailscaleBin, ["whois", "--json", normalized], {
@@ -662,10 +664,14 @@ export async function readTailscaleWhoisIdentity(
     });
     const parsed = result.stdout ? parsePossiblyNoisyJsonObject(result.stdout) : {};
     const identity = parseWhoisIdentity(parsed);
-    writeCachedWhois(normalized, identity, cacheTtlMs);
+    if (cacheTtlMs > 0) {
+      writeCachedWhois(normalized, identity, cacheTtlMs);
+    }
     return identity;
   } catch {
-    writeCachedWhois(normalized, null, errorTtlMs);
+    if (errorTtlMs > 0) {
+      writeCachedWhois(normalized, null, errorTtlMs);
+    }
     return null;
   }
 }


### PR DESCRIPTION
Fixes #136707

## What Problem This Solves

Fixes an issue where Control UI image uploads appeared as “Unavailable” when the gateway was accessed through Tailscale Serve with token authentication. The upload succeeded, but the follow-up `assistant-media` request returned 401.

## Why This Change Was Made

Read-only, same-origin Control UI HTTP requests now use the existing managed-Tailscale authorization path. The Gateway installs uncached Tailscale WhoIs verification when it first attributes each HTTP request; no durable device token or pairing grant is created.

## User Impact

Tailscale Serve users can view uploaded image previews in the Control UI without supplying a second credential. Removing the user’s Tailscale authorization blocks the next authenticated metadata or unticketed byte request.

## Evidence

- Added an end-to-end gateway regression proving no device token is issued, live WhoIs returns 200 from `assistant-media?meta=1`, the initial ingress boundary receives zero-TTL verification, and revocation makes the next metadata and unticketed byte requests return 401.
- Added a Tailscale helper regression proving zero-TTL WhoIs requests bypass existing cached authorization.
- Focused gateway auth tests: 128 passed.
- Focused Tailscale helper tests: 34 passed.
- `pnpm check:changed`: passed.
- Final independent auth/security review: no P0/P1 findings (0.90 confidence).
