### PR TITLE
fix(ci): authenticate the Kova source fetch in performance runs

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -98,7 +98,7 @@ jobs:
       cache_write_allowed: ${{ steps.candidate_trust.outputs.cache_write_allowed }}
     steps:
       - name: Prepare Git owner
-        uses: openclaw/openclaw/.github/actions/git-owner@dd4528b6393e7d00063067a080ca7241b48ce475
+        uses: openclaw/openclaw/.github/actions/git-owner@a379bbd73e30b84a89aca4d54744ab9ca19082e7
 
       - name: Checkout target metadata
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -214,6 +214,8 @@ jobs:
   kova:
     name: ${{ matrix.title }}
     needs: resolve_target
+    permissions:
+      contents: read
     runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'ubuntu-24.04' || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 240
     strategy:
@@ -300,7 +302,7 @@ jobs:
 
       - name: Prepare Git owner
         if: steps.lane.outputs.run == 'true'
-        uses: openclaw/openclaw/.github/actions/git-owner@dd4528b6393e7d00063067a080ca7241b48ce475
+        uses: openclaw/openclaw/.github/actions/git-owner@a379bbd73e30b84a89aca4d54744ab9ca19082e7
 
       - name: Checkout OpenClaw
         if: steps.lane.outputs.run == 'true'
@@ -400,6 +402,8 @@ jobs:
 
       - name: Install OCM and Kova
         if: steps.lane.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -419,12 +423,27 @@ jobs:
           tar -xzf "$ocm_archive" -C "${RUNNER_TEMP}/ocm-install"
           install -m 0755 "${RUNNER_TEMP}/ocm-install/ocm" "$HOME/.local/bin/ocm"
 
-          python3 -I -S "$CI_GIT_OWNER" --git 0 init -b main "$KOVA_SRC"
-          python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" remote add origin "https://github.com/${KOVA_REPOSITORY}.git"
-          # The complete worktree is consumed next; do not defer its blobs to a
-          # second unauthenticated promisor fetch during checkout.
-          python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" fetch --depth 1 origin "$KOVA_REF"
-          python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" checkout --detach FETCH_HEAD
+          python3 -I -S "$CI_GIT_OWNER" --policy - "$KOVA_SRC" <<'PYTHON'
+          import base64
+          import os
+          import sys
+          from ci_git_owner import checkout_environment, fetch, fetch_timeout_seconds, git_auth_environment, run_git
+
+          remote = f"https://github.com/{os.environ['KOVA_REPOSITORY']}.git"
+          token = os.environ.pop("GH_TOKEN")
+          print("::add-mask::" + base64.b64encode(f"x-access-token:{token}".encode()).decode(), flush=True)
+          checkout_environment.update(git_auth_environment(remote, token))
+          del token
+          source = sys.argv[3]
+          os.makedirs(source, exist_ok=True)
+          run_git(source, "init", "-b", "main")
+          run_git(source, "remote", "add", "origin", remote)
+          fetch(source, os.environ["KOVA_REF"], blobless=True, max_attempts=3, retry_failures=True)
+          # Filtered checkout can fetch promised blobs; retain process-only auth
+          # and the network deadline until the complete worktree is available.
+          run_git(source, "checkout", "--detach", "FETCH_HEAD", timeout=fetch_timeout_seconds)
+          PYTHON
+          unset GH_TOKEN
           npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund
           node - "$KOVA_SRC" <<'NODE'
           const fs = require("node:fs");
@@ -706,7 +725,7 @@ jobs:
       REQUESTED_REPEAT: ${{ inputs.repeat || '3' }}
     steps:
       - name: Prepare Git owner
-        uses: openclaw/openclaw/.github/actions/git-owner@dd4528b6393e7d00063067a080ca7241b48ce475
+        uses: openclaw/openclaw/.github/actions/git-owner@a379bbd73e30b84a89aca4d54744ab9ca19082e7
 
       - name: Checkout OpenClaw source target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -750,28 +769,36 @@ jobs:
           install-bun: "false"
 
       - name: Fetch previous source performance baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
           exec python3 -I -S "$CI_GIT_OWNER" --policy - <<'PYTHON'
+          import base64
           import os
           import re
           import subprocess
           from pathlib import Path
-          from ci_git_owner import run_git, git_output, GitFailure, check_cancelled
+          from ci_git_owner import run_git, git_output, GitFailure, FetchTimeout, check_cancelled, checkout_environment, fetch, git_auth_environment
 
           reports = ".artifacts/clawgrit-baseline"
           Path(reports).mkdir(parents=True, exist_ok=True)
+          remote = "https://github.com/openclaw/clawgrit-reports.git"
+          token = os.environ.pop("GH_TOKEN")
+          print("::add-mask::" + base64.b64encode(f"x-access-token:{token}".encode()).decode(), flush=True)
+          checkout_environment.update(git_auth_environment(remote, token))
+          del token
           def summary(message):
               check_cancelled()
               with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as output:
                   output.write(message + "\n")
 
           run_git(reports, "init", "-b", "main")
-          run_git(reports, "remote", "add", "origin", "https://github.com/openclaw/clawgrit-reports.git")
+          run_git(reports, "remote", "add", "origin", remote)
           try:
-              run_git(reports, "fetch", "--filter=blob:none", "--depth=1", "origin", "main", reclaim_locks=True)
-          except GitFailure:
+              fetch(reports, "main", blobless=True, max_attempts=3, retry_failures=True)
+          except (GitFailure, FetchTimeout):
               summary("No previous source performance baseline could be fetched.")
               raise SystemExit(0)
           ref_slug = re.sub(rb"[^A-Za-z0-9._-]", b"-", os.environ["TESTED_REF"].encode()).decode()
@@ -1061,7 +1088,7 @@ jobs:
 
       - name: Prepare Git owner
         if: steps.lane.outputs.run == 'true'
-        uses: openclaw/openclaw/.github/actions/git-owner@dd4528b6393e7d00063067a080ca7241b48ce475
+        uses: openclaw/openclaw/.github/actions/git-owner@a379bbd73e30b84a89aca4d54744ab9ca19082e7
 
       - name: Checkout performance publisher helper
         if: steps.lane.outputs.run == 'true'
@@ -1161,6 +1188,7 @@ jobs:
         if: steps.download.outcome == 'success'
         continue-on-error: ${{ env.REPORT_PUBLISH_REQUIRED != 'true' }}
         env:
+          GH_TOKEN: ${{ github.token }}
           ARTIFACT_ID: ${{ steps.artifact.outputs.id }}
           INPUT_ROOT: ${{ steps.paths.outputs.input_root }}
           REPORTS_ROOT: ${{ steps.paths.outputs.reports_root }}
@@ -1259,14 +1287,21 @@ jobs:
           python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$reports_root" config core.hooksPath /dev/null
           python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$reports_root" remote add origin "https://github.com/openclaw/clawgrit-reports.git"
           python3 -I -S "$CI_GIT_OWNER" --policy - "$reports_root" "$annotation" <<'PYTHON'
+          import base64
+          import os
           import sys
-          from ci_git_owner import run_git, GitFailure, FetchTimeout
+          from ci_git_owner import checkout_environment, fetch, git_auth_environment, GitFailure, FetchTimeout
+          token = os.environ.pop("GH_TOKEN")
+          print("::add-mask::" + base64.b64encode(f"x-access-token:{token}".encode()).decode(), flush=True)
+          checkout_environment.update(git_auth_environment("https://github.com/openclaw/clawgrit-reports.git", token))
+          del token
           try:
-              run_git(sys.argv[3], "fetch", "--depth=1", "origin", "main", timeout=120, reclaim_locks=True)
+              fetch(sys.argv[3], "main", max_attempts=3, retry_failures=True)
           except (GitFailure, FetchTimeout):
               print(f"::{sys.argv[4]}::Unable to fetch openclaw/clawgrit-reports before publishing.")
               raise SystemExit(1)
           PYTHON
+          unset GH_TOKEN
           python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$reports_root" checkout -B main FETCH_HEAD
 
           ref_slug="$(printf '%s' "$TESTED_REF" | tr -c 'A-Za-z0-9._-' '-')"
@@ -1388,7 +1423,7 @@ jobs:
           import os
           import re
           from pathlib import Path
-          from ci_git_owner import run_git, git_output, GitFailure, FetchTimeout, backoff, check_cancelled
+          from ci_git_owner import run_git, git_output, GitFailure, FetchTimeout, backoff, check_cancelled, checkout_environment, git_auth_environment
 
           annotation = "error" if os.environ["REPORT_PUBLISH_REQUIRED"] == "true" else "warning"
           def summary(text):
@@ -1408,6 +1443,7 @@ jobs:
               summary("### Clawgrit report publish unavailable\n\nThe repository-scoped ClawSweeper GitHub App token could not be created.")
               fail("ClawSweeper GitHub App token is unavailable; Kova artifacts were uploaded, but the report cannot be published.")
           auth_header = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+          auth_environment = git_auth_environment("https://github.com/openclaw/clawgrit-reports.git", token)
           del token
           print(f"::add-mask::{auth_header}", flush=True)
           reports = str(Path(os.environ["REPORTS_ROOT"]).resolve(strict=True))
@@ -1421,14 +1457,10 @@ jobs:
           if git_output(reports, *local, "config", "--local", "--get", "core.hooksPath").rstrip("\n") != "/dev/null" or git_output(reports, *local, "remote", "get-url", "origin").rstrip("\n") != "https://github.com/openclaw/clawgrit-reports.git":
               fail("Prepared reports checkout failed integrity validation.")
           run_git(reports, *local, "cat-file", "-e", f"{report_commit}^{{commit}}")
+          checkout_environment.update(auth_environment)
           for attempt in range(1, 6):
               try:
-                  run_git(reports, "push", "origin", "HEAD:main", timeout=120, reclaim_locks=True, env={
-                      "GIT_TERMINAL_PROMPT": "0", "GIT_CONFIG_COUNT": "2",
-                      "GIT_CONFIG_KEY_0": "core.hooksPath", "GIT_CONFIG_VALUE_0": "/dev/null",
-                      "GIT_CONFIG_KEY_1": "http.https://github.com/.extraheader",
-                      "GIT_CONFIG_VALUE_1": f"AUTHORIZATION: basic {auth_header}",
-                  })
+                  run_git(reports, *local, "push", "origin", "HEAD:main", timeout=120, reclaim_locks=True)
               except (GitFailure, FetchTimeout):
                   # Only ordinary failures after verified extinction authorize reconciliation.
                   # The fifth ambiguous push still gets its backoff, fetch and duplicate check.
@@ -1436,6 +1468,8 @@ jobs:
               else:
                   success()
               try:
+                  # The outer publish loop already retries reconciliation within
+                  # this job's deadline; do not multiply its network budget.
                   run_git(reports, *local, "fetch", "--depth=1", "origin", "main", timeout=120, reclaim_locks=True)
               except (GitFailure, FetchTimeout):
                   check_cancelled()

--- a/test/scripts/ci-git-owner-auth.test.ts
+++ b/test/scripts/ci-git-owner-auth.test.ts
@@ -88,23 +88,29 @@ it.skipIf(process.platform === "win32").each([
   50_000,
 );
 
-it.skipIf(process.platform === "win32")(
-  "Kova checkout is complete after its initial public fetch closes",
-  async () => {
+it.skipIf(process.platform === "win32").each([
+  { mode: "kova", failures: 0, succeeds: true },
+  { mode: "kova-retry", failures: 2, succeeds: true },
+  { mode: "kova-exhausted", failures: 3, succeeds: false },
+])(
+  "Kova authenticates source fetch and checkout with bounded retries ($mode)",
+  async ({ mode, failures, succeeds }) => {
     const report = await runAuthFixture(
-      "kova",
+      mode,
       workflowScript("openclaw-performance.yml", "kova", "Install OCM and Kova"),
     );
-    expect(report.exitCode, report.stderr).toBe(0);
+    expect(report.exitCode === 0, report.stderr).toBe(succeeds);
     expect(report).toMatchObject({
-      checkoutComplete: true,
-      sessions: 1,
+      checkoutComplete: succeeds,
+      sessions: failures + (succeeds ? 2 : 0),
+      transientFailures: failures,
+      filteredFetch: succeeds,
+      shallowCheckout: succeeds,
       credentialPersisted: false,
     });
+    expect(report.requests.length).toBeGreaterThan(0);
     expect(
-      report.requests.every(
-        (request: { authorizationPresent: boolean }) => !request.authorizationPresent,
-      ),
+      report.requests.every((request: { authenticated: boolean }) => request.authenticated),
     ).toBe(true);
   },
   50_000,

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -15306,13 +15306,13 @@ it("pins every Performance Git owner before checkout and preserves Git deadlines
     }
     expect(steps[index]).toEqual({
       name: "Prepare Git owner",
-      uses: "openclaw/openclaw/.github/actions/git-owner@dd4528b6393e7d00063067a080ca7241b48ce475",
+      uses: "openclaw/openclaw/.github/actions/git-owner@a379bbd73e30b84a89aca4d54744ab9ca19082e7",
       ...(decision ? { if: "steps.lane.outputs.run == 'true'" } : {}),
     });
     expect(job["timeout-minutes"]).toBe(timeout);
     const bodies = steps.map(({ run }) => run ?? "").join("\n");
     expect(bodies).not.toMatch(/(?:^|[\s(])git\s/mu);
-    expect(bodies).not.toMatch(/timeout[^\n]*git/u);
+    expect(bodies).not.toMatch(/(?:^|[\s(])timeout\s+[^\n]*\bgit\b/u);
     const ownerDeadlines = [...bodies.matchAll(/--(?:checkout-)?git (\d+)/gu)].map((match) =>
       Number(match[1]),
     );
@@ -15320,14 +15320,15 @@ it("pins every Performance Git owner before checkout and preserves Git deadlines
     if (jobId !== "publish") {
       expect(bodies).not.toMatch(/timeout=\d+/u);
     } else {
-      expect(bodies.match(/timeout=120/g)).toHaveLength(3);
+      expect(bodies.match(/timeout=120/g)).toHaveLength(2);
       expect(bodies).not.toMatch(/timeout=(?!120)\d+/u);
       expect(bodies.match(/for attempt in range\(1, 6\)/gu)).toHaveLength(1);
       expect(bodies.match(/backoff\(attempt \* 2\)/gu)).toHaveLength(1);
       expect(bodies).toContain('"push", "origin", "HEAD:main", timeout=120, reclaim_locks=True');
       expect(
         bodies.match(/"fetch", "--depth=1", "origin", "main", timeout=120, reclaim_locks=True/gu),
-      ).toHaveLength(2);
+      ).toHaveLength(1);
+      expect(bodies).toContain('fetch(sys.argv[3], "main", max_attempts=3, retry_failures=True)');
       expect(bodies).toContain("if error.code != 1:");
       expect(bodies).toContain(
         '"ls-tree", "--name-only", "FETCH_HEAD", "--", f"{dest}/report.json"',

--- a/test/scripts/fixtures/ci-checkout-auth.py
+++ b/test/scripts/fixtures/ci-checkout-auth.py
@@ -14,6 +14,7 @@ from urllib.parse import urlsplit
 
 owner = str(Path(sys.argv[1]).resolve())
 mode = sys.argv[2]
+kova = mode in ("kova", "kova-retry", "kova-exhausted")
 git = shutil.which("git")
 assert git, "Git is required for checkout authentication proof"
 
@@ -82,6 +83,9 @@ with tempfile.TemporaryDirectory(prefix="checkout-auth-") as directory:
     authorization = f"Basic {encoded}"
     requests = []
     kova_methods = []
+    transient_failures = 0
+    filtered_fetch = False
+    planned_failures = {"kova-retry": 2, "kova-exhausted": 3}.get(mode, 0)
     post_checkout_requests = []
     checkout_complete = root / "checkout-complete"
     redirect = False
@@ -97,6 +101,7 @@ with tempfile.TemporaryDirectory(prefix="checkout-auth-") as directory:
             self.serve_git()
 
         def serve_git(self):
+            global transient_failures, filtered_fetch
             parsed = urlsplit(self.path)
             headers = self.headers.get_all("Authorization") or []
             authenticated = len(headers) == 1 and headers[0].lower().startswith("basic ") and headers[0][6:] == encoded
@@ -113,16 +118,23 @@ with tempfile.TemporaryDirectory(prefix="checkout-auth-") as directory:
                 self.send_header("Content-Length", "0")
                 self.end_headers()
                 return
-            if mode == "kova":
+            if kova:
                 kova_methods.append(self.command)
-            public_fetch = mode == "kova" and kova_methods.count("GET") == 1
-            if not authenticated and not public_fetch:
+            if not authenticated:
                 self.send_response(401)
                 self.send_header("WWW-Authenticate", 'Basic realm="checkout fixture"')
                 self.send_header("Content-Length", "0")
                 self.end_headers()
                 return
+            if kova and self.command == "GET" and transient_failures < planned_failures:
+                transient_failures += 1
+                self.send_response(503)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
             body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            if kova and b"filter blob:none" in body:
+                filtered_fetch = True
             backend = subprocess.run(
                 [git, "http-backend"], input=body, capture_output=True, timeout=15,
                 env={**env, "GIT_PROJECT_ROOT": str(root), "GIT_HTTP_EXPORT_ALL": "1",
@@ -153,7 +165,7 @@ with tempfile.TemporaryDirectory(prefix="checkout-auth-") as directory:
     try:
         remote = f"http://127.0.0.1:{server.server_port}/{bare.name}"
         workspace = root / "workspace"
-        if mode == "kova":
+        if kova:
             # Keep the whole workflow body intact. Only unrelated OCM/npm tools
             # are stubbed; Git talks to the real server for every object it needs.
             workspace = root / "kova-src"
@@ -164,22 +176,26 @@ sha256sum() { cat >/dev/null; }
 tar() { :; }
 npm() { test -s "$KOVA_SRC/payload.txt"; }
 node() { :; }
-''' + sys.argv[3]
-            config = home / ".gitconfig"
-            checked(git, "config", "--file", str(config), f"url.{remote}.insteadOf",
-                    "https://github.com/fixture/kova.git")
+''' + sys.argv[3].replace('"https://github.com/${KOVA_REPOSITORY}.git"', json.dumps(remote)).replace(
+                'f"https://github.com/{os.environ[\'KOVA_REPOSITORY\']}.git"', repr(remote))
             result = command("bash", "-e", "-o", "pipefail", "-c", script, extra={
-                "GIT_CONFIG_GLOBAL": str(config), "CI_GIT_OWNER": owner,
+                "CI_GIT_OWNER": owner, "GH_TOKEN": token,
                 "RUNNER_TEMP": str(root), "KOVA_HOME": str(home / "kova"),
                 "GITHUB_ENV": str(root / "environment"), "GITHUB_PATH": str(root / "path"),
                 "OCM_VERSION": "fixture", "OCM_LINUX_X64_SHA256": "fixture",
                 "KOVA_REPOSITORY": "fixture/kova", "KOVA_REF": revision})
             complete = result.returncode == 0 and (workspace / "payload.txt").read_text() == (source / "payload.txt").read_text()
             local_config = (workspace / ".git/config").read_text()
-            assert token not in result.stdout + result.stderr + local_config
-            assert encoded not in result.stdout + result.stderr + local_config
+            # Actions consumes mask registration without rendering the secret.
+            # Every other output line and persisted config must remain secretless.
+            visible_stdout = "\n".join(line for line in result.stdout.splitlines()
+                                       if line != f"::add-mask::{encoded}")
+            published = visible_stdout + result.stderr + local_config
+            assert token not in published and encoded not in published
             print(json.dumps({"mode": mode, "exitCode": result.returncode, "stderr": result.stderr,
                               "checkoutComplete": complete, "sessions": kova_methods.count("GET"),
+                              "transientFailures": transient_failures, "filteredFetch": filtered_fetch,
+                              "shallowCheckout": complete and checked(git, "rev-parse", "--is-shallow-repository", cwd=workspace) == "true",
                               "credentialPersisted": "extraheader" in local_config.lower(), "requests": requests}))
             raise SystemExit(0)
         checked(git, "init", str(workspace))

--- a/test/scripts/openclaw-performance-git-lifecycle.test.ts
+++ b/test/scripts/openclaw-performance-git-lifecycle.test.ts
@@ -45,7 +45,9 @@ posixIt.each(Object.keys(steps) as PerformanceFixtureOptions["mode"][])(
     const report = await performanceRun(mode);
     expect(report.code, report.output).toBe(0);
     expect(report.readyAttempts.length).toBeGreaterThan(0);
-    if (mode === "prepare") expect(report.githubOutput).toContain("ready=true\n");
+    if (mode === "prepare") {
+      expect(report.githubOutput).toContain("ready=true\n");
+    }
     if (mode === "publish") {
       expect(report.pushes).toHaveLength(1);
       expect(report.fetches).toHaveLength(0);
@@ -58,7 +60,7 @@ posixIt.each(Object.keys(steps) as PerformanceFixtureOptions["mode"][])(
 posixIt.each([23, 124, 125, 143])(
   "baseline ordinary fetch %s is advisory after extinction",
   async (code) => {
-    const report = await performanceRun("baseline", { fetchResults: [code] });
+    const report = await performanceRun("baseline", { fetchResults: [code, code, code] });
     expect(report.code, report.output).toBe(0);
     expect(report.githubSummary).toBe(
       "No previous source performance baseline could be fetched.\n",
@@ -124,7 +126,11 @@ const terminalCases = [
 // Every injected lifecycle failure must stop at its command, before later policy actions.
 posixIt.each(
   terminalCases.flatMap((entry) =>
-    (["cleanup-failure", "cancel"] as const).map((code) => ({ ...entry, code })),
+    (["cleanup-failure", "cancel"] as const).map((code) => ({
+      mode: entry.mode,
+      operation: entry.operation,
+      code,
+    })),
   ),
 )(
   "$mode $operation $code fences every later action",
@@ -158,11 +164,10 @@ posixIt.each(
 posixIt.each(["hang", 23, 124, 125, 143] as const)(
   "prepare initial fetch %s cannot reach checkout, commit or token readiness",
   async (failure) => {
-    const report = await performanceRun("prepare", { fetchResults: [failure] });
+    const report = await performanceRun("prepare", { fetchResults: [failure, failure, failure] });
     expect(report.code, report.output).toBe(1);
-    expect(report.fetches.map(({ args }) => args)).toEqual([
-      ["fetch", "--depth=1", "origin", "main"],
-    ]);
+    expect(report.fetches).toHaveLength(3);
+    expect(report.fetches.every(({ args }) => args.includes("--depth=1"))).toBe(true);
     expect(report.checkouts).toHaveLength(0);
     expect(report.commands.at(-1)?.args[0]).toBe("fetch");
     expect(report.githubOutput).toBe("ready=false\n");
@@ -186,7 +191,8 @@ posixIt(
     expect(report.commands.some(({ args }) => args[0] === "commit")).toBe(false);
     expect(
       report.commands.every(
-        ({ envProbe }) => !JSON.parse(envProbe!).token && !JSON.parse(envProbe!).auth,
+        ({ envProbe, args }) =>
+          !JSON.parse(envProbe!).token && JSON.parse(envProbe!).auth === (args[0] === "fetch"),
       ),
     ).toBe(true);
   },
@@ -233,8 +239,21 @@ posixIt.each([124, 125, 143, "hang"] as const)(
     for (const command of report.commands) {
       const scope = JSON.parse(command.envProbe!);
       expect(scope.token).toBe(false);
-      expect(scope.auth).toBe(command.args[0] === "push");
-      if (scope.auth) expect(scope).toMatchObject({ count: "2", hooks: "/dev/null", prompt: "0" });
+      const authenticated = [
+        "push",
+        "fetch",
+        "ls-tree",
+        "checkout",
+        "cherry-pick",
+        "rev-parse",
+      ].includes(command.args[0]!);
+      expect(scope.auth).toBe(authenticated);
+      if (scope.auth) {
+        expect(scope).toMatchObject({ count: "3", prompt: "0" });
+      }
+      if (command.args[0] === "push") {
+        expect(command.configuration).toContain("core.hooksPath=/dev/null");
+      }
     }
     expect(JSON.stringify(report)).not.toContain("fixture-performance-token");
     expect(JSON.stringify(report)).not.toContain(

--- a/test/scripts/openclaw-performance-workflow.test-support.ts
+++ b/test/scripts/openclaw-performance-workflow.test-support.ts
@@ -157,6 +157,7 @@ export function preparePerformanceFixture(root: string, options: PerformanceFixt
     GITHUB_SHA: target,
     GITHUB_WORKFLOW: "OpenClaw Performance",
     GITHUB_REPOSITORY: "fixture/performance",
+    GH_TOKEN: "fixture-performance-read-token",
     GITHUB_RUN_ID: "123",
     GITHUB_RUN_ATTEMPT: "1",
     ARTIFACT_ID: "42",

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -525,10 +525,11 @@ describe("OpenClaw performance workflow", () => {
 
     expect(baseline.if).toBeUndefined();
     expect(baseline.env?.CLAWGRIT_REPORTS_TOKEN).toBeUndefined();
+    expect(baseline.env?.GH_TOKEN).toBe("${{ github.token }}");
+    expect(run).toContain('remote = "https://github.com/openclaw/clawgrit-reports.git"');
     expect(run).toContain(
-      '"remote", "add", "origin", "https://github.com/openclaw/clawgrit-reports.git"',
+      'fetch(reports, "main", blobless=True, max_attempts=3, retry_failures=True)',
     );
-    expect(run).toContain('"fetch", "--filter=blob:none", "--depth=1", "origin", "main"');
     expect(run).toContain('"ls-tree", "--name-only", "FETCH_HEAD", "--", pointer');
     expect(run).toContain('"show", f"FETCH_HEAD:{pointer}"');
     expect(run).toContain('"sparse-checkout", "init", "--no-cone"');
@@ -761,7 +762,7 @@ describe("OpenClaw performance workflow", () => {
     );
   });
 
-  it("keeps app credentials out of artifact processing and scopes them to Git push", () => {
+  it("keeps app credentials out of artifact processing and scopes them to report Git operations", () => {
     const workflow = readWorkflow();
     const kovaJob = workflow.jobs?.kova;
     const artifact = findStep("Resolve Kova artifact", "publish");
@@ -813,10 +814,10 @@ describe("OpenClaw performance workflow", () => {
     expect(publish.if).toContain("steps.prepare.outputs.already_published != 'true'");
     expect(publish.run).not.toContain("${{ steps.kova.outputs.");
     expect(publish.run).toContain('os.environ.pop("CLAWGRIT_REPORTS_APP_TOKEN", "")');
-    expect(publish.run).toContain('"GIT_CONFIG_KEY_0": "core.hooksPath"');
-    expect(publish.run).toContain('"GIT_CONFIG_VALUE_0": "/dev/null"');
-    expect(publish.run).toContain('"GIT_CONFIG_KEY_1": "http.https://github.com/.extraheader"');
-    expect(publish.run).toContain('"GIT_CONFIG_VALUE_1": f"AUTHORIZATION: basic {auth_header}"');
+    expect(publish.run).toContain('local = ("-c", "core.hooksPath=/dev/null")');
+    expect(publish.run).toContain(
+      'git_auth_environment("https://github.com/openclaw/clawgrit-reports.git", token)',
+    );
     expect(publish.run).not.toContain("export GIT_CONFIG_");
     expect(readFileSync(WORKFLOW, "utf8")).not.toContain("https://x-access-token:");
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves intermittent product-performance validation failures while fetching public Kova source. Runs [33704895299](https://github.com/openclaw/openclaw/actions/runs/33704895299) and [33710883601](https://github.com/openclaw/openclaw/actions/runs/33710883601) failed on the same pinned ref that [33697210168](https://github.com/openclaw/openclaw/actions/runs/33697210168) fetched successfully. The inspected failing log reports `could not read Username` and `expected flush after ref listing`.

## Why This Change Was Made

The Kova fetch was anonymous and single-attempt. Use the job's read-only token through the existing trusted Git owner, with three fetch attempts and five-second backoff. Keep depth one and blob filtering; authentication also covers checkout's promised-blob requests. The refreshed immutable owner pin supplies the existing repository-scoped credential helper, which keeps credentials in the Git process environment, blocks redirects, and preserves cancellation/cleanup fencing. Encoded credentials are masked, and the raw token is removed before Kova dependencies run.

Apply the same authentication and three-attempt fetch policy to source-baseline and initial report reads. Report publication reuses its existing repository-scoped app token and bounded outer reconciliation loop; adding nested retries there would exceed its job budget. OCM is a checksum-verified release-asset download with existing bounded retries, not another Git fetch.

## User Impact

Release operators can run performance validation without relying on anonymous GitHub Git access. No OpenClaw runtime or configuration behavior changes.

## Evidence

- Real smart-HTTP Git fixture reproduced the pre-fix username error. The changed workflow authenticates both filtered fetch and checkout, recovers after two HTTP 503s, and stops after three failed attempts. The fixture checks shallow/filtered behavior and credential absence from config and visible logs.
- The extracted Kova Git policy fetched and checked out `81919463ef9620722373c813192c688573f2b533` from GitHub using local maintainer authentication; no persisted credentials. This is not an Actions job-token test.
- Workflow-sanity local equivalent passed: pinned actionlint (including ShellCheck), zizmor 1.29.0 with repository configuration, generated Git-owner check, composite-input guard, and conflict-marker check. Direct ShellCheck passed Kova/baseline/publish bodies; the report-preparation body passes with actionlint's existing SC2153/SC2129 exclusions.
- `node scripts/check-changed.mjs -- <workflow and performance/auth test paths>` passed, including formatting, test-root type checking, script/test lint, and repository guards. Independent Codex autoreview found no actionable P0/P1 findings.
- Workflow/tooling delta: +57/-23 (net +34); tests/support: +86/-42 (net +44). The added workflow lines establish transient credential scopes and reuse existing retry/cleanup ownership; no new runtime helper or product setting.
- Ran `node scripts/run-vitest.mjs test/scripts/ci-git-owner-auth.test.ts test/scripts/openclaw-performance-workflow.test.ts test/scripts/openclaw-performance-git-lifecycle.test.ts`: 148 passed; 10 hit local fixture watchdogs and one hit a managed-process cleanup error. All 11 passed when rerun individually with unchanged assertions/timeouts. The updated `ci-workflow-guards` Performance pin/deadline case also passed, as did its focused lint. Several captured watchdog reports stopped before the changed fetch policy; exact local scheduling cause remains unproven.
- `pnpm check:workflows` itself could not bootstrap because the configured package index does not provide its pinned `pre-commit==4.6.2`; the equivalent audit tools above were run directly.

Hosted product-performance validation cannot be run from this worker. GitHub's server-side reason for rejecting the anonymous requests is not proven by the log; throttling/transient rejection is consistent with the intermittent failures.
