### PR TITLE
fix: memories never promote when the daily pass records a claim first

### DIFF
--- a/extensions/memory-core/src/short-term-promotion-record.ts
+++ b/extensions/memory-core/src/short-term-promotion-record.ts
@@ -242,8 +242,8 @@ export async function recordShortTermRecalls(params: {
                 entry.claimHash === claimHash,
             )
           : undefined;
-      // Interactive/grounded writers retain their path-qualified identity.
-      // Daily recurrence reinforces that candidate instead of creating a rival.
+      // Non-daily writers retain their path-qualified identity unless daily
+      // ingestion has already established the canonical claim entry.
       const claimKey =
         signalType === "daily"
           ? buildDailyClaimEntryKey(claimHash)
@@ -254,12 +254,8 @@ export async function recordShortTermRecalls(params: {
               source: "memory",
               claimHash,
             });
-      // The reverse arrival order needs the same treatment: a daily claim
-      // recorded before its first interactive recall must be reinforced by that
-      // recall, or the recall opens the rival entry this pairing avoids and
-      // neither side alone reaches the promotion thresholds.
       const dailyClaimEntry =
-        signalType === "recall" ? store.entries[buildDailyClaimEntryKey(claimHash)] : undefined;
+        signalType === "daily" ? undefined : store.entries[buildDailyClaimEntryKey(claimHash)];
       const key =
         nonDailyEntry?.key ??
         dailyClaimEntry?.key ??
@@ -319,8 +315,8 @@ export async function recordShortTermRecalls(params: {
         : nowIso;
       // Daily claim keys omit the file path; retain the first source citation
       // while observations from distinct days accumulate on the same claim. A
-      // recall reinforcing such a claim cites it the same way, so the claim
-      // never adopts the path of whichever file the search happened to hit.
+      // A later non-daily signal cites it the same way, so the claim never
+      // adopts the path of whichever file the search or backfill happened to hit.
       const preserveFirstDailySource =
         existing !== undefined && (signalType === "daily" || dailyClaimEntry !== undefined);
       store.entries[key] = {

--- a/extensions/memory-core/src/short-term-promotion-record.ts
+++ b/extensions/memory-core/src/short-term-promotion-record.ts
@@ -254,8 +254,15 @@ export async function recordShortTermRecalls(params: {
               source: "memory",
               claimHash,
             });
+      // The reverse arrival order needs the same treatment: a daily claim
+      // recorded before its first interactive recall must be reinforced by that
+      // recall, or the recall opens the rival entry this pairing avoids and
+      // neither side alone reaches the promotion thresholds.
+      const dailyClaimEntry =
+        signalType === "recall" ? store.entries[buildDailyClaimEntryKey(claimHash)] : undefined;
       const key =
         nonDailyEntry?.key ??
+        dailyClaimEntry?.key ??
         (signalType !== "recall" || store.entries[claimKey] ? claimKey : buildEntryKey(result));
       const existing = store.entries[key];
       const score = clampScore(result.score);
@@ -311,8 +318,11 @@ export async function recordShortTermRecalls(params: {
         ? (existing?.lastRecalledAt ?? nowIso)
         : nowIso;
       // Daily claim keys omit the file path; retain the first source citation
-      // while observations from distinct days accumulate on the same claim.
-      const preserveFirstDailySource = signalType === "daily" && existing !== undefined;
+      // while observations from distinct days accumulate on the same claim. A
+      // recall reinforcing such a claim cites it the same way, so the claim
+      // never adopts the path of whichever file the search happened to hit.
+      const preserveFirstDailySource =
+        existing !== undefined && (signalType === "daily" || dailyClaimEntry !== undefined);
       store.entries[key] = {
         key,
         path: preserveFirstDailySource ? existing.path : normalizedPath,

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -857,6 +857,27 @@ describe("short-term promotion", () => {
     expect(ranked[0]?.key).not.toMatch(/^memory:claim:/u);
   });
 
+  it("reinforces an existing daily claim when the recall arrives second", async (workspaceDir) => {
+    const claim = "Deploy scripts live in infra/deploy and need the staging profile.";
+    await recordMemoryRecalls(
+      workspaceDir,
+      "__dreaming_daily__:2026-04-01",
+      [memoryRecallResult("memory/2026-04-01.md", 3, 3, 0.62, claim)],
+      { signalType: "daily", dayBucket: "2026-04-01" },
+    );
+    await recordMemoryRecalls(workspaceDir, "deploy scripts", [
+      memoryRecallResult("memory/2026-04-02.md", 7, 9, 0.9, claim),
+    ]);
+
+    const ranked = await rankAllCandidates(workspaceDir);
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0]).toMatchObject({ recallCount: 1, dailyCount: 1, signalCount: 2 });
+    expect(ranked[0]?.key).toMatch(/^memory:claim:/u);
+    // The claim keeps its first citation rather than the recalled file's.
+    expect(ranked[0]?.path).toBe("memory/2026-04-01.md");
+    expect(ranked[0]?.startLine).toBe(3);
+  });
+
   it("reads only light-staged keys that have not already gone through REM", async (workspaceDir) => {
     const nowMs = Date.parse("2026-04-05T10:00:00.000Z");
     await recordMemoryRecalls(

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -857,26 +857,47 @@ describe("short-term promotion", () => {
     expect(ranked[0]?.key).not.toMatch(/^memory:claim:/u);
   });
 
-  it("reinforces an existing daily claim when the recall arrives second", async (workspaceDir) => {
-    const claim = "Deploy scripts live in infra/deploy and need the staging profile.";
-    await recordMemoryRecalls(
-      workspaceDir,
-      "__dreaming_daily__:2026-04-01",
-      [memoryRecallResult("memory/2026-04-01.md", 3, 3, 0.62, claim)],
-      { signalType: "daily", dayBucket: "2026-04-01" },
-    );
-    await recordMemoryRecalls(workspaceDir, "deploy scripts", [
-      memoryRecallResult("memory/2026-04-02.md", 7, 9, 0.9, claim),
-    ]);
+  for (const signalType of ["recall", "grounded"] as const) {
+    it(`reinforces an existing daily claim when ${signalType} arrives second`, async (workspaceDir) => {
+      const claim = "Deploy scripts live in infra/deploy and need the staging profile.";
+      await recordMemoryRecalls(
+        workspaceDir,
+        "__dreaming_daily__:2026-04-01",
+        [memoryRecallResult("memory/2026-04-01.md", 3, 3, 0.62, claim)],
+        { signalType: "daily", dayBucket: "2026-04-01" },
+      );
+      await recordMemoryRecalls(
+        workspaceDir,
+        signalType === "grounded" ? "__dreaming_grounded_backfill__" : "deploy scripts",
+        [
+          memoryRecallResult(
+            "memory/2026-04-02.md",
+            7,
+            9,
+            0.9,
+            claim,
+            signalType === "grounded"
+              ? { query: "__dreaming_grounded_backfill__:deploy", signalCount: 1 }
+              : {},
+          ),
+        ],
+        { signalType, dayBucket: "2026-04-02" },
+      );
 
-    const ranked = await rankAllCandidates(workspaceDir);
-    expect(ranked).toHaveLength(1);
-    expect(ranked[0]).toMatchObject({ recallCount: 1, dailyCount: 1, signalCount: 2 });
-    expect(ranked[0]?.key).toMatch(/^memory:claim:/u);
-    // The claim keeps its first citation rather than the recalled file's.
-    expect(ranked[0]?.path).toBe("memory/2026-04-01.md");
-    expect(ranked[0]?.startLine).toBe(3);
-  });
+      const ranked = await rankAllCandidates(workspaceDir);
+      expect(ranked).toHaveLength(1);
+      expect(ranked[0]).toMatchObject({
+        recallCount: signalType === "recall" ? 1 : 0,
+        dailyCount: 1,
+        groundedCount: signalType === "grounded" ? 1 : 0,
+        signalCount: 2,
+      });
+      expect(ranked[0]?.key).toMatch(/^memory:claim:/u);
+      // The claim keeps its first citation rather than the later signal's file.
+      expect(ranked[0]?.path).toBe("memory/2026-04-01.md");
+      expect(ranked[0]?.startLine).toBe(3);
+    });
+  }
 
   it("reads only light-staged keys that have not already gone through REM", async (workspaceDir) => {
     const nowMs = Date.parse("2026-04-05T10:00:00.000Z");


### PR DESCRIPTION
Closes #136963

## What Problem This Solves

Fixes an issue where users with dreaming enabled would see `Promoted 0 candidate(s)` on every deep-sleep run — indefinitely — even though their memories were being recalled regularly. `MEMORY.md` never received durable promotions, and `openclaw memory promote` reported no candidates at all, giving no indication of why.

The trigger is ordering: when the dreaming daily pass records a claim **before** that claim's first interactive recall. That is the normal case, because the daily pass runs on a schedule and seeds claims before anything queries them.

## Why This Change Was Made

A claim's signals were being split across two store keys. The daily pass writes `memory:claim:<hash>`; a later recall of the same text could not land on that key, so it opened a rival path-qualified entry. Since `signalCount` is read per entry, both keys stayed permanently under `minRecallCount`/`minUniqueQueries`, and no amount of genuine use could move either one.

The opposite order — recall first, then daily — was already reconciled by the `nonDailyEntry` lookup, whose comment states the intent: "Daily recurrence reinforces that candidate instead of creating a rival." This change makes that intent hold in both directions for recall and grounded staging by applying one mirrored daily-claim lookup to every non-daily signal.

It also extends the citation-preservation rule to both paths. A daily claim key omits the file path, so later signals keep the original source citation rather than adopting whichever file the search or backfill happened to hit.

Thresholds and scoring are untouched — this only stops equivalent signals from being split.

## User Impact

Workspaces whose claims are seeded by the daily pass before being recalled or grounded now accumulate signals on a single entry, so genuine use reaches the promotion gate as designed. No configuration change or threshold tuning is needed.

## Evidence

- Current `main` at `53066564532e4ce55eca937c406cab85eee850e6` reproduced the daily-first recall split: two rival entries and zero candidates at two signals and two unique queries.
- The untouched PR head reproduced the same daily-first grounded split: two rival entries and zero candidates at the same thresholds.
- `node scripts/run-vitest.mjs extensions/memory-core/src/short-term-promotion.test.ts` — 93 passed.
- `node scripts/run-vitest.mjs extensions/memory-core/src/` — 1,331 passed, 3 skipped.
- `node scripts/run-oxlint.mjs --tsconfig extensions/tsconfig.json extensions/memory-core/src/short-term-promotion-record.ts extensions/memory-core/src/short-term-promotion.test.ts` — clean.
- `git diff --check` — clean.
- Real workspace promotion trace through the production recorder, ranker, and apply path: daily-first plus three recalls produced one entry with `dailyCount=1`, `recallCount=3`, `signalCount=4`, and four unique queries; ranking returned one candidate; apply wrote one promotion to `MEMORY.md` with the original `memory/2026-04-01.md:3-3` citation.
- Real grounded staging trace: daily-first plus two grounded observations produced one entry with `dailyCount=1`, `groundedCount=2`, three signals, and three unique queries; ranking and apply each returned one result with the original daily citation.
