### PR TITLE
fix: diagnose and reduce slow reply preparation

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2176,7 +2176,7 @@ src/auto-reply/reply/reply-operation-run-state.ts	1
 src/auto-reply/reply/reply-payload-sending-hook.ts	1
 src/auto-reply/reply/reply-run-registry.registry.ts	1
 src/auto-reply/reply/reply-threading.ts	2
-src/auto-reply/reply/reply-timing-tracker.ts	3
+src/auto-reply/reply/reply-timing-tracker.ts	2
 src/auto-reply/reply/reply-turn-admission.ts	1
 src/auto-reply/reply/restart-recovery-claim.ts	3
 src/auto-reply/reply/session-delivery.ts	1
@@ -2654,7 +2654,7 @@ src/config/sessions/session-accessor.sqlite-parent-fork.ts	1
 src/config/sessions/session-accessor.sqlite-read.ts	12
 src/config/sessions/session-accessor.sqlite-recovery.ts	1
 src/config/sessions/session-accessor.sqlite-reset-window.ts	2
-src/config/sessions/session-accessor.sqlite-title-probes.ts	2
+src/config/sessions/session-accessor.sqlite-title-probes.ts	1
 src/config/sessions/session-accessor.sqlite-transcript-message-append.ts	1
 src/config/sessions/session-accessor.sqlite-transcript-mirror.ts	1
 src/config/sessions/session-accessor.sqlite-transcript-store.ts	2

--- a/docs/diagnostics/flags.md
+++ b/docs/diagnostics/flags.md
@@ -72,7 +72,11 @@ without editing the file.
 
 ## Profiler flags
 
-Profiler flags gate lightweight timing spans; they add no overhead when off.
+Slow reply preparation and Codex startup are logged at the default log level
+without profiler flags: a stage taking at least 5 seconds or a tracked total
+taking at least 10 seconds emits a warning. Fast paths remain quiet. Profiler
+flags lower the timing thresholds to 500 milliseconds per stage and 1 second
+total, and enable additional detail.
 
 Enable all profiler-gated spans for one gateway run:
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -278,6 +278,36 @@ OpenTelemetry log export is enabled, using the same bounded attributes as file
 logs. Configure `diagnostics.otel.logsExporter` to choose OTLP, stdout JSONL, or
 both sinks.
 
+### Slow reply preparation
+
+When a reply spends a long time preparing, inspect the normal Gateway logs:
+
+```bash
+openclaw logs --follow --plain | rg 'timings|agent turn milestone|liveness warning'
+```
+
+Reply resolver, dispatch, and agent-turn preparation milestones include stage
+durations, elapsed time, and available run/session identifiers. Without profiler
+flags, they warn at 10 seconds elapsed or 5 seconds in one preparation stage. Codex preparation also
+logs each completed slow stage immediately, including failures, and emits a
+`native-turn-handoff` summary before submitting the native turn. Timing records
+contain stage names and identifiers, not prompts or tool arguments.
+
+Use the first `turn_accepted`, `model_call_started`, `tool_execution_started`, and
+`assistant_output_started` milestones to separate startup from later activity.
+Delayed first assistant/tool activity is logged once at `info` by default,
+because provider and tool latency is not itself a preparation warning.
+These are runtime observations: native turn acceptance does not prove that a
+provider request has started. Whole-turn summaries remain profiler-only because
+their totals include model and tool time. Compare the individual preparation
+stages before attributing a long turn to Gateway startup. A simultaneous
+`liveness warning` with high event-loop delay
+can explain delays across several sessions.
+
+For shorter delays, [profiler flags](/diagnostics/flags#profiler-flags) lower the
+warning thresholds. They are not required to diagnose a multi-second startup
+stall.
+
 ### Model call size and timing
 
 Model-call diagnostics record bounded request/response measurements without

--- a/extensions/codex/src/app-server/attempt-preparation-timing.test.ts
+++ b/extensions/codex/src/app-server/attempt-preparation-timing.test.ts
@@ -1,0 +1,92 @@
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCodexAttemptPreparationTiming } from "./attempt-preparation-timing.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Codex attempt preparation timing", () => {
+  it.each([
+    { flags: [], stageMs: 5_000, totalMs: 11_000 },
+    { flags: ["codex.profiler"], stageMs: 500, totalMs: 1_100 },
+  ])(
+    "reports slow stages and the native handoff with flags=$flags",
+    async ({ flags, stageMs, totalMs }) => {
+      let nowMs = 0;
+      vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+      const params = {
+        runId: "run-1",
+        sessionId: "session-1",
+        sessionKey: "agent:main:test",
+        prompt: "private prompt",
+        config: { diagnostics: { flags } },
+      };
+      const preparation = createCodexAttemptPreparationTiming(params);
+
+      await preparation.measure("connection", async () => {
+        nowMs += stageMs;
+      });
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0]?.[1]).toEqual({
+        runId: "run-1",
+        sessionId: "session-1",
+        sessionKey: "agent:main:test",
+        stage: "connection",
+        outcome: "completed",
+        totalMs: stageMs,
+        stages: [{ name: "connection", durationMs: stageMs, elapsedMs: stageMs }],
+      });
+
+      for (const stage of ["tools", "prompt"]) {
+        await preparation.measure(stage, async () => {
+          nowMs += (totalMs - stageMs) / 2;
+        });
+      }
+      expect(warn).toHaveBeenCalledOnce();
+      preparation.ready();
+      expect(warn).toHaveBeenCalledTimes(2);
+      expect(warn.mock.calls[1]?.[1]).toMatchObject({
+        stage: "native-turn-handoff",
+        outcome: "ready",
+        totalMs,
+      });
+      expect(JSON.stringify(warn.mock.calls)).not.toContain(params.prompt);
+    },
+  );
+
+  it.each([
+    { precedingMs: 0, failingMs: 7_000 },
+    { precedingMs: 4_000, failingMs: 4_000 },
+  ])(
+    "retains slow failed preparation ($precedingMs/$failingMs) without replacing its error",
+    async ({ precedingMs, failingMs }) => {
+      let nowMs = 0;
+      vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+      const preparation = createCodexAttemptPreparationTiming({
+        runId: "run-1",
+        sessionId: "session-1",
+      });
+      const failure = new Error("private failure detail");
+      for (const stage of ["connection", "runtime"]) {
+        await preparation.measure(stage, () => {
+          nowMs += precedingMs;
+        });
+      }
+
+      await expect(
+        preparation.measure("tools", async () => {
+          nowMs += failingMs;
+          throw failure;
+        }),
+      ).rejects.toBe(failure);
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0]?.[1]).toMatchObject({
+        stage: "tools",
+        outcome: "error",
+        totalMs: precedingMs * 2 + failingMs,
+      });
+      expect(JSON.stringify(warn.mock.calls)).not.toContain(failure.message);
+    },
+  );
+});

--- a/extensions/codex/src/app-server/attempt-preparation-timing.ts
+++ b/extensions/codex/src/app-server/attempt-preparation-timing.ts
@@ -1,0 +1,58 @@
+import {
+  embeddedAgentLog,
+  type EmbeddedRunAttemptParamsV2,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  createCodexDynamicToolBuildStageTracker,
+  formatCodexDynamicToolBuildStageSummary,
+} from "./dynamic-tool-build.js";
+import { isCodexAppServerProfilerEnabled } from "./profiler-flag.js";
+
+/** Records startup before the native turn owns inference and tool execution. */
+export function createCodexAttemptPreparationTiming(
+  params: Pick<EmbeddedRunAttemptParamsV2, "runId" | "sessionId" | "sessionKey" | "config">,
+) {
+  const tracker = createCodexDynamicToolBuildStageTracker();
+  const profilerEnabled = isCodexAppServerProfilerEnabled(params.config);
+  const totalWarnMs = profilerEnabled ? 1_000 : 10_000;
+  const stageWarnMs = profilerEnabled ? 500 : 5_000;
+  const log = (stage: string, outcome: "completed" | "error" | "ready") => {
+    const summary = tracker.snapshot();
+    const lastStage = summary.stages.at(-1);
+    const slowTotal = outcome !== "completed" && summary.totalMs >= totalWarnMs;
+    const slowStage = outcome !== "ready" && (lastStage?.durationMs ?? 0) >= stageWarnMs;
+    if (!slowTotal && !slowStage) {
+      return;
+    }
+    embeddedAgentLog.warn(
+      `codex app-server preparation timings runId=${params.runId} sessionId=${params.sessionId} stage=${stage} outcome=${outcome} totalMs=${summary.totalMs} stages=${formatCodexDynamicToolBuildStageSummary(summary)}`,
+      {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        stage,
+        outcome,
+        totalMs: summary.totalMs,
+        stages: summary.stages,
+      },
+    );
+  };
+  return {
+    async measure<T>(stage: string, run: () => Promise<T> | T): Promise<T> {
+      let outcome: "completed" | "error" = "error";
+      try {
+        const result = await run();
+        outcome = "completed";
+        return result;
+      } finally {
+        tracker.mark(stage);
+        // Emit completed slow stages immediately: a later stalled stage must
+        // not erase the work already spent before the native turn starts.
+        log(stage, outcome);
+      }
+    },
+    ready() {
+      log("native-turn-handoff", "ready");
+    },
+  };
+}

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -200,19 +200,11 @@ type CodexDynamicToolBuildStageSummary = {
 };
 const CODEX_DYNAMIC_TOOL_BUILD_WARN_TOTAL_MS = 1_000;
 const CODEX_DYNAMIC_TOOL_BUILD_WARN_STAGE_MS = 500;
-/** Creates cheap optional timing instrumentation for the dynamic-tool hot path. */
-export function createCodexDynamicToolBuildStageTracker(options: { enabled?: boolean } = {}): {
+/** Captures bounded preparation stages before a slow turn needs diagnosis. */
+export function createCodexDynamicToolBuildStageTracker(): {
   mark: (name: string) => void;
   snapshot: () => CodexDynamicToolBuildStageSummary;
 } {
-  if (!options.enabled) {
-    return {
-      mark() {},
-      snapshot() {
-        return { totalMs: 0, stages: [] };
-      },
-    };
-  }
   const startedAt = Date.now();
   let previousAt = startedAt;
   const stages: CodexDynamicToolBuildStageTiming[] = [];
@@ -238,10 +230,13 @@ export function createCodexDynamicToolBuildStageTracker(options: { enabled?: boo
 /** Returns true when dynamic-tool construction is slow enough to warrant a warning log. */
 export function shouldWarnCodexDynamicToolBuildStageSummary(
   summary: CodexDynamicToolBuildStageSummary,
+  profilerEnabled = false,
 ): boolean {
+  const totalWarnMs = profilerEnabled ? CODEX_DYNAMIC_TOOL_BUILD_WARN_TOTAL_MS : 10_000;
+  const stageWarnMs = profilerEnabled ? CODEX_DYNAMIC_TOOL_BUILD_WARN_STAGE_MS : 5_000;
   return (
-    summary.totalMs >= CODEX_DYNAMIC_TOOL_BUILD_WARN_TOTAL_MS ||
-    summary.stages.some((stage) => stage.durationMs >= CODEX_DYNAMIC_TOOL_BUILD_WARN_STAGE_MS)
+    summary.totalMs >= totalWarnMs ||
+    summary.stages.some((stage) => stage.durationMs >= stageWarnMs)
   );
 }
 /** Formats per-stage timings into the compact form used by Codex app-server logs. */
@@ -275,11 +270,7 @@ export async function buildDynamicTools(
     input.onWebSearchPolicyResolved?.(false);
     return [];
   }
-  // Dynamic tool construction is on the reply hot path, so per-stage
-  // Date.now/span bookkeeping runs only when the Codex profiler flag is set.
-  const toolBuildStages = createCodexDynamicToolBuildStageTracker({
-    enabled: input.profilerEnabled,
-  });
+  const toolBuildStages = createCodexDynamicToolBuildStageTracker();
   const modelHasVision = params.model.input?.includes("image") ?? false;
   const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, input.sessionAgentId);
   const injectedOpenClawCodingToolsFactory = dynamicToolBuildState.openClawCodingToolsFactory;
@@ -583,7 +574,7 @@ export async function buildDynamicTools(
     );
   }
   const summary = toolBuildStages.snapshot();
-  if (shouldWarnCodexDynamicToolBuildStageSummary(summary)) {
+  if (shouldWarnCodexDynamicToolBuildStageSummary(summary, input.profilerEnabled)) {
     const phase = input.forceHeartbeatTool ? "registered-tools" : "runtime-tools";
     embeddedAgentLog.warn(
       `codex app-server dynamic tool build timings runId=${params.runId} sessionId=${params.sessionId} phase=${phase} totalMs=${summary.totalMs} stages=${formatCodexDynamicToolBuildStageSummary(summary)}`,

--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -72,9 +72,7 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
     offAnnounced: false,
     resetAnnounced: false,
   };
-  const preDynamicStartupStages = createCodexDynamicToolBuildStageTracker({
-    enabled: profilerEnabled,
-  });
+  const preDynamicStartupStages = createCodexDynamicToolBuildStageTracker();
   const runtimeArtifactRequest =
     params.captureRuntimeArtifact || params.expectedRuntimeArtifact
       ? params.expectedRuntimeArtifact

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -65,7 +65,6 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     params,
     preDynamicStartupStages,
     mutable,
-    startupAuthProfileId,
     resolvedWorkspace,
     effectiveWorkspace,
     effectiveCwd,
@@ -81,7 +80,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     agentDir,
   } = connection;
   const preDynamicSummary = preDynamicStartupStages.snapshot();
-  if (shouldWarnCodexDynamicToolBuildStageSummary(preDynamicSummary)) {
+  if (shouldWarnCodexDynamicToolBuildStageSummary(preDynamicSummary, profilerEnabled)) {
     embeddedAgentLog.warn(
       `codex app-server pre-dynamic startup timings runId=${params.runId} sessionId=${params.sessionId} totalMs=${preDynamicSummary.totalMs} stages=${formatCodexDynamicToolBuildStageSummary(preDynamicSummary)}`,
       {
@@ -90,7 +89,6 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         totalMs: preDynamicSummary.totalMs,
         stages: preDynamicSummary.stages,
         hasStartupBinding: Boolean(mutable.startupBinding?.threadId),
-        startupAuthProfileId: startupAuthProfileId ?? null,
         bundleMcpDiagnosticCount: bundleMcpThreadConfig.diagnostics.length,
         nativeToolSurfaceEnabled,
       },

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1,4 +1,5 @@
 import type { EmbeddedRunAttemptParamsV2 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createCodexAttemptPreparationTiming } from "./attempt-preparation-timing.js";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import { activateCodexAttemptTurn } from "./run-attempt-active-turn.js";
 import { cleanupCodexAttempt } from "./run-attempt-cleanup.js";
@@ -23,15 +24,24 @@ export async function runCodexAppServerAttempt(
   params: EmbeddedRunAttemptParamsV2,
   options: CodexRunAttemptOptions,
 ): Promise<EmbeddedRunAttemptResult> {
-  const connection = await prepareCodexAttemptConnection({ params, options });
-  const runtime = await prepareCodexAttemptRuntime(connection);
-  const attemptTools = await prepareCodexAttemptTools(runtime);
-  const attemptContext = await prepareCodexAttemptContext(runtime, attemptTools);
-  const attemptPrompt = await prepareCodexAttemptPrompt(attemptContext);
+  const preparation = createCodexAttemptPreparationTiming(params);
+  const connection = await preparation.measure("connection", () =>
+    prepareCodexAttemptConnection({ params, options }),
+  );
+  const runtime = await preparation.measure("runtime", () =>
+    prepareCodexAttemptRuntime(connection),
+  );
+  const attemptTools = await preparation.measure("tools", () => prepareCodexAttemptTools(runtime));
+  const attemptContext = await preparation.measure("context", () =>
+    prepareCodexAttemptContext(runtime, attemptTools),
+  );
+  const attemptPrompt = await preparation.measure("prompt", () =>
+    prepareCodexAttemptPrompt(attemptContext),
+  );
   const resources = prepareCodexAttemptResources(attemptPrompt);
   attemptTools.runtimeYieldCompletionClaim.current = () =>
     resources.state.nativeHookRelay?.hasClaimedDirectChild() ?? false;
-  await startCodexAttemptRuntime(resources);
+  await preparation.measure("runtime-start", () => startCodexAttemptRuntime(resources));
 
   const turnRuntime = createCodexAttemptTurnState(resources);
   try {
@@ -46,18 +56,23 @@ export async function runCodexAppServerAttempt(
       turnRuntime,
       lifecycle,
     );
-    const { ensureCurrentThreadRoute } = await prepareCodexAttemptRoute(
-      resources,
-      turnRuntime,
-      notifications,
-      serverRequests.handleServerRequest,
+    const { ensureCurrentThreadRoute } = await preparation.measure("thread-route", () =>
+      prepareCodexAttemptRoute(
+        resources,
+        turnRuntime,
+        notifications,
+        serverRequests.handleServerRequest,
+      ),
     );
-    const turnRequest = await prepareCodexAttemptTurnRequest(
-      resources,
-      turnRuntime,
-      ensureCurrentThreadRoute,
-      notifications.waitForActiveNativeTurnCompletion,
+    const turnRequest = await preparation.measure("turn-request", () =>
+      prepareCodexAttemptTurnRequest(
+        resources,
+        turnRuntime,
+        ensureCurrentThreadRoute,
+        notifications.waitForActiveNativeTurnCompletion,
+      ),
     );
+    preparation.ready();
     const turnStart = await startCodexAttemptTurn(
       resources,
       turnRuntime,

--- a/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
@@ -59,8 +59,7 @@ export async function prepareCodexThreadLifecyclePreflight(params: CodexStartOrR
   if (params.nativeHookRelayRequired) {
     await assertCodexNativeHookRelayAllowed(params.client, params.signal);
   }
-  // Thread lifecycle spans are useful when profiling startup churn, but normal
-  // turns should not pay Date.now/span-array overhead while resuming threads.
+  // Slow resumes must be diagnosable without enabling a profiler beforehand.
   const lifecycleTiming = createCodexThreadLifecycleTimingTracker({
     ...params.timing,
     enabled: params.timing?.enabled ?? isCodexAppServerProfilerEnabled(params.params.config),

--- a/extensions/codex/src/app-server/thread-lifecycle-timing.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-timing.ts
@@ -47,8 +47,11 @@ function shouldWarnCodexThreadLifecycleTimingSummary(
   summary: CodexThreadLifecycleTimingSummary,
   options: CodexThreadLifecycleTimingOptions = {},
 ): boolean {
-  const totalThresholdMs = options.totalThresholdMs ?? CODEX_THREAD_LIFECYCLE_TIMING_WARN_TOTAL_MS;
-  const stageThresholdMs = options.stageThresholdMs ?? CODEX_THREAD_LIFECYCLE_TIMING_WARN_STAGE_MS;
+  const detailed = options.enabled || options.log?.isEnabled?.("trace");
+  const totalThresholdMs =
+    options.totalThresholdMs ?? (detailed ? CODEX_THREAD_LIFECYCLE_TIMING_WARN_TOTAL_MS : 10_000);
+  const stageThresholdMs =
+    options.stageThresholdMs ?? (detailed ? CODEX_THREAD_LIFECYCLE_TIMING_WARN_STAGE_MS : 5_000);
   return (
     summary.totalMs >= totalThresholdMs ||
     summary.spans.some((span) => span.durationMs >= stageThresholdMs)
@@ -79,18 +82,6 @@ export function createCodexThreadLifecycleTimingTracker(
   options: CodexThreadLifecycleTimingOptions = {},
 ): CodexThreadLifecycleTimingTracker {
   const log = options.log ?? embeddedAgentLog;
-  if (!options.enabled && log.isEnabled?.("trace") !== true) {
-    return {
-      async measure(_name, run) {
-        return await run();
-      },
-      measureSync(_name, run) {
-        return run();
-      },
-      mark() {},
-      logSummary() {},
-    };
-  }
 
   const now = options.now ?? Date.now;
   const startedAt = now();
@@ -134,7 +125,7 @@ export function createCodexThreadLifecycleTimingTracker(
         return;
       }
       const summary = snapshot();
-      const shouldWarn = shouldWarnCodexThreadLifecycleTimingSummary(summary, options);
+      const shouldWarn = shouldWarnCodexThreadLifecycleTimingSummary(summary, { ...options, log });
       if (!shouldWarn && !log.isEnabled?.("trace")) {
         return;
       }

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -5899,7 +5899,7 @@ describe("Codex app-server thread lifecycle timing", () => {
     expect(message).toContain("thread-resume-request:9ms@9ms");
   });
 
-  it("warns on slow start even when trace logging is disabled", async () => {
+  it("warns on slow start even when profiling and trace logging are disabled", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     let nowMs = 0;
@@ -5919,7 +5919,7 @@ describe("Codex app-server thread lifecycle timing", () => {
       dynamicTools: [],
       appServer: createThreadLifecycleAppServerOptions(),
       timing: {
-        enabled: true,
+        enabled: false,
         now: () => nowMs,
         log,
         totalThresholdMs: 10,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -258,6 +258,12 @@ async function executeAgentTurnInternalLoop(
   const signalExecutionPhaseForTyping = (
     info: Parameters<NonNullable<RunEmbeddedAgentParams["onExecutionPhase"]>>[0],
   ) => {
+    agentTurnTiming.logExecutionPhaseIfSlow({
+      runId,
+      sessionId: params.followupRun.run.sessionId,
+      sessionKey: params.sessionKey,
+      phase: info.phase,
+    });
     const startupPhase = resolveRunStartupPhase(info.phase);
     if (startupPhase && startupPhase !== lastRunStartupPhase) {
       lastRunStartupPhase = startupPhase;

--- a/src/auto-reply/reply/agent-runner-turn-timing.ts
+++ b/src/auto-reply/reply/agent-runner-turn-timing.ts
@@ -1,3 +1,4 @@
+import type { EmbeddedAgentExecutionPhase } from "../../agents/embedded-agent-runner/execution-phase.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createReplyTimingTracker } from "./reply-timing-tracker.js";
 
@@ -16,8 +17,21 @@ type AgentTurnLogParams = AgentTurnTerminalLogParams | AgentTurnMilestoneLogPara
 const agentTurnTimingLog = createSubsystemLogger("auto-reply/agent-turn-timing");
 
 export function createAgentTurnTimingTracker(options: { profilerEnabled?: boolean } = {}) {
+  const observedExecutionPhases = new Set<EmbeddedAgentExecutionPhase>();
   const timing = createReplyTimingTracker<AgentTurnLogParams>({
-    log: agentTurnTimingLog,
+    log: {
+      warn(message, details) {
+        const isOutputMilestone =
+          details?.milestone === "assistant_output_started" ||
+          details?.milestone === "tool_execution_started";
+        // Provider and tool latency is useful context, not a startup warning.
+        if (isOutputMilestone && !options.profilerEnabled) {
+          agentTurnTimingLog.info(message, details);
+        } else {
+          agentTurnTimingLog.warn(message, details);
+        }
+      },
+    },
     enabled: options.profilerEnabled === true,
     formatMessage: (params, summary, stages) => {
       const identity = `runId=${params.runId} sessionId=${params.sessionId ?? "unknown"} sessionKey=${params.sessionKey ?? "unknown"}`;
@@ -34,11 +48,26 @@ export function createAgentTurnTimingTracker(options: { profilerEnabled?: boolea
     measure: timing.measure,
     measureSync: timing.measureSync,
     logIfSlow(params: AgentTurnTerminalLogParams) {
+      // The terminal duration includes inference and tools; default warnings
+      // belong to the preparation and first-activity milestones below.
+      if (!options.profilerEnabled) {
+        return;
+      }
       const { runId, sessionId, sessionKey, outcome, error } = params;
       timing.logIfSlow({ runId, sessionId, sessionKey, outcome, error });
     },
     logMilestoneIfSlow(params: AgentTurnMilestoneLogParams) {
       const { runId, sessionId, sessionKey, milestone } = params;
+      timing.logIfSlow({ runId, sessionId, sessionKey, milestone }, { repeat: true });
+    },
+    logExecutionPhaseIfSlow(params: AgentTurnLogContext & { phase: EmbeddedAgentExecutionPhase }) {
+      // Each phase is a first-observation boundary, not a log for every tool
+      // or retry. The fixed phase vocabulary bounds this per-turn state.
+      if (observedExecutionPhases.has(params.phase)) {
+        return;
+      }
+      observedExecutionPhases.add(params.phase);
+      const { runId, sessionId, sessionKey, phase: milestone } = params;
       timing.logIfSlow({ runId, sessionId, sessionKey, milestone }, { repeat: true });
     },
   };

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -192,6 +192,7 @@ export async function gatherDispatchRequest(
       return;
     }
     agentDispatchStartedAt = Date.now();
+    replyHotPathTiming.logPreparationIfSlow({ channel, messageId, sessionKey });
     logMessageDispatchStarted({
       channel,
       sessionKey: acpDispatchSessionKey,

--- a/src/auto-reply/reply/dispatch-from-config.timing.ts
+++ b/src/auto-reply/reply/dispatch-from-config.timing.ts
@@ -1,10 +1,12 @@
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createReplyTimingTracker } from "./reply-timing-tracker.js";
 
-type ReplyHotPathLogParams = {
+type ReplyHotPathLogContext = {
   channel: string;
   messageId?: number | string;
   sessionKey?: string;
+};
+type ReplyHotPathLogParams = ReplyHotPathLogContext & {
   outcome: "completed" | "skipped" | "error";
   reason?: string;
 };
@@ -12,7 +14,9 @@ type ReplyHotPathLogParams = {
 const replyHotPathTimingLog = createSubsystemLogger("auto-reply/reply-timing");
 
 export function createReplyHotPathTimingTracker(options: { profilerEnabled?: boolean } = {}) {
-  const timing = createReplyTimingTracker<ReplyHotPathLogParams>({
+  const timing = createReplyTimingTracker<
+    ReplyHotPathLogParams | (ReplyHotPathLogContext & { outcome: "milestone"; reason: string })
+  >({
     log: replyHotPathTimingLog,
     enabled: options.profilerEnabled === true,
     formatMessage: (params, summary, stages) =>
@@ -22,7 +26,17 @@ export function createReplyHotPathTimingTracker(options: { profilerEnabled?: boo
   return {
     measure: timing.measure,
     logIfSlow(params: ReplyHotPathLogParams) {
+      if (!options.profilerEnabled) {
+        return;
+      }
       timing.logIfSlow(params);
+    },
+    logPreparationIfSlow(params: ReplyHotPathLogContext) {
+      const { channel, messageId, sessionKey } = params;
+      timing.logIfSlow(
+        { channel, messageId, sessionKey, outcome: "milestone", reason: "before_reply_resolver" },
+        { repeat: true },
+      );
     },
   };
 }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -87,7 +87,7 @@ import {
 } from "./pending-final-delivery.js";
 import { getPreparedReplyDispatchRuntime } from "./prepared-reply-dispatch-context.js";
 import { attachProgressNarratorToReplyOptions } from "./progress-narrator.js";
-import { createReplyTimingTracker } from "./reply-timing-tracker.js";
+import { createReplyTimingTracker, isReplyProfilerEnabled } from "./reply-timing-tracker.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import { initSessionState, resolveReplySessionPreprocessingState } from "./session.js";
 import { mergeSkillFilters } from "./skill-filter.js";
@@ -327,10 +327,13 @@ export async function getReplyFromConfig(
       isFastTestEnv,
       configOverride,
     });
-  // Profiler spans stay inert unless diagnostics enable `profiler` or
-  // `reply.profiler`, so normal replies do not pay per-stage Date.now/array
-  // bookkeeping while we can still split resolver costs on demand.
-  const resolverTiming = createReplyTimingTracker({ log: replyResolverTimingLog, config: cfg });
+  // Retain preparation timings before a stall happens. Whole-turn summaries
+  // include inference and tools, so only profiling warns on their duration.
+  const profilerEnabled = isReplyProfilerEnabled({ config: cfg });
+  const resolverTiming = createReplyTimingTracker({
+    log: replyResolverTimingLog,
+    enabled: profilerEnabled,
+  });
   const useFastTestBootstrap = resolverTiming.measureSync("reply.resolve_fast_test_bootstrap", () =>
     shouldUseReplyFastTestBootstrap({
       isFastTestEnv,
@@ -1007,7 +1010,9 @@ export async function getReplyFromConfig(
         autoFallbackPrimaryProbe,
       }),
     );
-    logResolverTiming("completed", "fast_directive_prepared_reply");
+    if (profilerEnabled) {
+      logResolverTiming("completed", "fast_directive_prepared_reply");
+    }
     return fastReplyResult;
   }
 
@@ -1358,7 +1363,9 @@ export async function getReplyFromConfig(
       autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
     }),
   );
-  logResolverTiming("completed", "prepared_reply");
+  if (profilerEnabled) {
+    logResolverTiming("completed", "prepared_reply");
+  }
   return replyResult;
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/reply-timing-tracker.test.ts
+++ b/src/auto-reply/reply/reply-timing-tracker.test.ts
@@ -6,11 +6,15 @@ import { createReplyHotPathTimingTracker } from "./dispatch-from-config.timing.j
 import { createReplyTimingTracker, isReplyProfilerEnabled } from "./reply-timing-tracker.js";
 
 const subsystemWarn = vi.hoisted(() => vi.fn());
+const subsystemInfo = vi.hoisted(() => vi.fn());
 vi.mock("../../logging/subsystem.js", () => ({
-  createSubsystemLogger: () => ({ warn: subsystemWarn }),
+  createSubsystemLogger: () => ({ warn: subsystemWarn, info: subsystemInfo }),
 }));
 
-beforeEach(() => subsystemWarn.mockReset());
+beforeEach(() => {
+  subsystemWarn.mockReset();
+  subsystemInfo.mockReset();
+});
 afterEach(() => vi.restoreAllMocks());
 
 describe("isReplyProfilerEnabled", () => {
@@ -26,17 +30,26 @@ describe("isReplyProfilerEnabled", () => {
 });
 
 describe("createReplyTimingTracker", () => {
-  it("is a pass-through tracker unless the profiler flag is enabled", async () => {
+  it("reports slow preparation without profiling while keeping fast replies quiet", async () => {
     const warn = vi.fn();
-    const now = vi.spyOn(Date, "now");
+    let nowMs = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => nowMs);
     const tracker = createReplyTimingTracker({ log: { warn }, enabled: false });
 
     expect(tracker.measureSync("sync", () => 42)).toBe(42);
     await expect(tracker.measure("async", async () => "ok")).resolves.toBe("ok");
     tracker.logIfSlow({ message: "reply timings" });
-
-    expect(now).not.toHaveBeenCalled();
     expect(warn).not.toHaveBeenCalled();
+
+    await tracker.measure("prepare", async () => {
+      nowMs += 5_000;
+    });
+    tracker.logIfSlow({ message: "reply timings", details: { runId: "run-1" } });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[1]).toMatchObject({
+      runId: "run-1",
+      spans: expect.arrayContaining([{ name: "prepare", durationMs: 5_000, elapsedMs: 5_000 }]),
+    });
   });
 
   it("records and logs spans when the profiler flag is enabled", () => {
@@ -60,9 +73,8 @@ describe("createReplyTimingTracker", () => {
     });
   });
 
-  it("records sync throws and async rejections through the shared clock path", async () => {
+  it("retains failed-stage timings and propagates the original failures", async () => {
     const warn = vi.fn();
-    const now = vi.spyOn(Date, "now");
     const tracker = createReplyTimingTracker({ log: { warn }, enabled: true, totalWarnMs: 0 });
 
     expect(() =>
@@ -77,7 +89,6 @@ describe("createReplyTimingTracker", () => {
     ).rejects.toThrow("async failed");
     tracker.logIfSlow({ message: "reply timings" });
 
-    expect(now).toHaveBeenCalledTimes(8);
     expect(warn.mock.calls[0]?.[1]).toMatchObject({
       spans: [{ name: "sync_failure" }, { name: "async_failure" }],
     });
@@ -160,5 +171,74 @@ describe("createReplyTimingTracker", () => {
         spans: [],
       },
     );
+  });
+
+  it("keeps ordinary model and tool execution out of default terminal warnings", async () => {
+    let nowMs = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    const agentTiming = createAgentTurnTimingTracker();
+    const dispatchTiming = createReplyHotPathTimingTracker();
+    const identity = { runId: "run-1", sessionId: "session-1", sessionKey: "agent:main" };
+
+    agentTiming.logMilestoneIfSlow({ ...identity, milestone: "before_embedded_run" });
+    agentTiming.logExecutionPhaseIfSlow({ ...identity, phase: "turn_accepted" });
+    agentTiming.logExecutionPhaseIfSlow({ ...identity, phase: "model_call_started" });
+    await dispatchTiming.measure("reply.run_reply_resolver", () =>
+      agentTiming.measure("embedded_run", async () => {
+        nowMs += 20_000;
+        agentTiming.logExecutionPhaseIfSlow({ ...identity, phase: "assistant_output_started" });
+        agentTiming.logExecutionPhaseIfSlow({ ...identity, phase: "tool_execution_started" });
+      }),
+    );
+    agentTiming.logIfSlow({ ...identity, outcome: "completed" });
+    dispatchTiming.logIfSlow({ channel: "webchat", outcome: "completed" });
+
+    expect(subsystemWarn).not.toHaveBeenCalled();
+    expect(subsystemInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports slow dispatch preparation before model execution without profiling", async () => {
+    let nowMs = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    const tracker = createReplyHotPathTimingTracker();
+    await tracker.measure("reply.load_reply_resolver", async () => {
+      nowMs += 5_000;
+    });
+    tracker.logPreparationIfSlow({ channel: "webchat", sessionKey: "agent:main" });
+
+    expect(subsystemWarn).toHaveBeenCalledOnce();
+    expect(subsystemWarn.mock.calls[0]?.[1]).toMatchObject({
+      channel: "webchat",
+      sessionKey: "agent:main",
+      outcome: "milestone",
+      reason: "before_reply_resolver",
+      totalMs: 5_000,
+      spans: [{ name: "reply.load_reply_resolver", durationMs: 5_000, elapsedMs: 5_000 }],
+    });
+  });
+
+  it("records the first slow execution phases without profiling or repeated tool logs", () => {
+    let nowMs = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    const tracker = createAgentTurnTimingTracker();
+    const identity = { runId: "run-1", sessionId: "session-1", sessionKey: "agent:main" };
+
+    tracker.logExecutionPhaseIfSlow({ ...identity, phase: "runner_entered" });
+    expect(subsystemWarn).not.toHaveBeenCalled();
+    nowMs = 21_000;
+    tracker.logExecutionPhaseIfSlow({ ...identity, phase: "turn_accepted" });
+    nowMs = 24_000;
+    tracker.logExecutionPhaseIfSlow({ ...identity, phase: "assistant_output_started" });
+    tracker.logExecutionPhaseIfSlow({ ...identity, phase: "tool_execution_started" });
+    nowMs = 30_000;
+    tracker.logExecutionPhaseIfSlow({ ...identity, phase: "tool_execution_started" });
+
+    expect(subsystemWarn.mock.calls.map((call) => call[1])).toEqual([
+      { ...identity, milestone: "turn_accepted", totalMs: 21_000, spans: [] },
+    ]);
+    expect(subsystemInfo.mock.calls.map((call) => call[1])).toEqual([
+      { ...identity, milestone: "assistant_output_started", totalMs: 24_000, spans: [] },
+      { ...identity, milestone: "tool_execution_started", totalMs: 24_000, spans: [] },
+    ]);
   });
 });

--- a/src/auto-reply/reply/reply-timing-tracker.ts
+++ b/src/auto-reply/reply/reply-timing-tracker.ts
@@ -21,16 +21,6 @@ type ReplyTimingTracker<TLogParams extends object = ReplyTimingLogParams> = {
   logIfSlow: (params: TLogParams, options?: { repeat?: boolean }) => void;
 };
 
-const disabledTimingTracker: ReplyTimingTracker<object> = {
-  async measure(_name, run) {
-    return await run();
-  },
-  measureSync(_name, run) {
-    return run();
-  },
-  logIfSlow() {},
-};
-
 /** Checks config/env diagnostic flags for reply profiling. */
 export function isReplyProfilerEnabled(params?: {
   config?: OpenClawConfig;
@@ -44,7 +34,7 @@ export function isReplyProfilerEnabled(params?: {
   );
 }
 
-/** Creates a no-timer pass-through unless reply profiling is enabled. */
+/** Keeps slow replies diagnosable; profiling lowers the warning thresholds. */
 export function createReplyTimingTracker<TLogParams extends object = ReplyTimingLogParams>(params: {
   log: { warn: (message: string, details?: Record<string, unknown>) => void };
   config?: OpenClawConfig;
@@ -59,24 +49,20 @@ export function createReplyTimingTracker<TLogParams extends object = ReplyTiming
   ) => string;
   detailKeys?: (params: TLogParams) => readonly string[];
 }): ReplyTimingTracker<TLogParams> {
-  const enabled =
+  const profilerEnabled =
     params.enabled ?? isReplyProfilerEnabled({ config: params.config, env: params.env });
-  if (!enabled) {
-    // Normal turns share this pass-through, avoiding Date.now and span arrays.
-    return disabledTimingTracker as ReplyTimingTracker<TLogParams>;
-  }
-
   const startedAt = Date.now();
   const spans: ReplyTimingSummary["spans"] = [];
   let didLog = false;
-  const totalWarnMs = params.totalWarnMs ?? 1_000;
-  const stageWarnMs = params.stageWarnMs ?? 500;
+  const totalWarnMs = params.totalWarnMs ?? (profilerEnabled ? 1_000 : 10_000);
+  const stageWarnMs = params.stageWarnMs ?? (profilerEnabled ? 500 : 5_000);
   const toMs = (value: number) => Math.max(0, Math.round(value));
   const record = (name: string, spanStartedAt: number) => {
+    const currentAt = Date.now();
     spans.push({
       name,
-      durationMs: toMs(Date.now() - spanStartedAt),
-      elapsedMs: toMs(Date.now() - startedAt),
+      durationMs: toMs(currentAt - spanStartedAt),
+      elapsedMs: toMs(currentAt - startedAt),
     });
   };
 

--- a/src/config/sessions/session-accessor.sqlite-title-probes.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-title-probes.test.ts
@@ -12,81 +12,112 @@ import {
   readSessionTranscriptTitleProbeBatch,
   replaceTranscriptEvents,
 } from "./session-accessor.js";
+import { importSqliteSessionRows } from "./session-accessor.sqlite-import.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-test.each([false, true])("bounds transcript boundary work (compacted: %s)", async (compacted) => {
-  const env = captureEnv(["OPENCLAW_STATE_DIR"]);
-  const tempDir = tempDirs.make("openclaw-title-probe-work-");
-  setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
-  const scope = {
-    agentId: "main",
-    sessionId: "bounded-title-probe",
-    sessionKey: "agent:main:bounded-title-probe",
-    storePath: path.join(tempDir, "sessions.json"),
-  };
-  const messages = Array.from({ length: 60 }, (_, index) => ({
-    type: "message",
-    id: `message-${index}`,
-    parentId: index === 0 ? null : `message-${index - 1}`,
-    message: { role: index === 0 ? "user" : "assistant", content: `Message ${index}` },
-  }));
-  const metadata = Array.from({ length: 20 }, (_, index) => ({
-    type: "custom",
-    id: `metadata-${index}`,
-    parentId: index === 0 ? "message-59" : `metadata-${index - 1}`,
-    customType: "synthetic-title-probe",
-    data: { text: "Synthetic non-message metadata" },
-  }));
-  const nativeJson = new DatabaseSync(":memory:");
-  const extractJson = nativeJson.prepare("SELECT json_extract(?, ?) AS value");
-  try {
-    await replaceTranscriptEvents(scope, [
-      ...messages,
-      ...metadata,
-      ...(compacted
-        ? [
-            {
-              type: "compaction",
-              id: "compaction",
-              parentId: "metadata-19",
-              firstKeptEntryId: "message-0",
-              summary: "Synthetic compaction summary ".repeat(4096),
-            },
-          ]
-        : []),
-    ]);
-    const database = openOpenClawAgentDatabase({
-      agentId: scope.agentId,
-      path: path.join(tempDir, "openclaw-agent.sqlite"),
-    });
-    let boundaryInspections = 0;
-    database.db.function("json_extract", { deterministic: true }, (value, jsonPath) => {
-      if (jsonPath === "$.type") {
-        boundaryInspections += 1;
+test.each([
+  { boundaryType: undefined, source: "canonical" },
+  { boundaryType: "reset", source: "canonical" },
+  { boundaryType: "compaction", source: "canonical" },
+  { boundaryType: "reset", source: "exact-import" },
+  { boundaryType: "compaction", source: "exact-import" },
+] as const)(
+  "reads title edges after $boundaryType from $source without inspecting indexed payloads",
+  async ({ boundaryType, source }) => {
+    const env = captureEnv(["OPENCLAW_STATE_DIR"]);
+    const tempDir = tempDirs.make("openclaw-title-probe-work-");
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
+    const scope = {
+      agentId: "main",
+      sessionId: "bounded-title-probe",
+      sessionKey: "agent:main:bounded-title-probe",
+      storePath: path.join(tempDir, "sessions.json"),
+    };
+    const messages = Array.from({ length: 60 }, (_, index) => ({
+      type: "message",
+      id: `message-${index}`,
+      parentId: index === 0 ? null : `message-${index - 1}`,
+      message: { role: index === 0 ? "user" : "assistant", content: `Message ${index}` },
+    }));
+    const boundaries = boundaryType
+      ? [
+          {
+            type: boundaryType,
+            id: "boundary",
+            parentId: "message-59",
+            ...(boundaryType === "compaction"
+              ? {
+                  firstKeptEntryId: "message-0",
+                  summary: "Synthetic compaction summary ".repeat(4096),
+                }
+              : {}),
+          },
+        ]
+      : [];
+    const metadata = Array.from({ length: 20 }, (_, index) => ({
+      type: "custom",
+      id: `metadata-${index}`,
+      parentId: index === 0 ? (boundaryType ? "boundary" : "message-59") : `metadata-${index - 1}`,
+      customType: "synthetic-title-probe",
+      data: { text: "Synthetic non-message metadata" },
+    }));
+    const nativeJson = new DatabaseSync(":memory:");
+    const extractJson = nativeJson.prepare("SELECT json_extract(?, ?) AS value");
+    try {
+      const events = [...messages, ...boundaries, ...metadata];
+      if (source === "exact-import") {
+        await importSqliteSessionRows({
+          ...scope,
+          entry: { sessionId: scope.sessionId, updatedAt: 1 },
+          readExactTranscriptRows: (append) => {
+            for (const event of events) {
+              append({ createdAt: 1, eventJson: JSON.stringify(event) });
+            }
+          },
+        });
+      } else {
+        await replaceTranscriptEvents(scope, events);
       }
-      return extractJson.get(value, jsonPath)?.value ?? null;
-    });
+      const database = openOpenClawAgentDatabase({
+        agentId: scope.agentId,
+        path: path.join(tempDir, "openclaw-agent.sqlite"),
+      });
+      let boundaryInspections = 0;
+      database.db.function("json_extract", { deterministic: true }, (value, jsonPath) => {
+        if (jsonPath === "$.type") {
+          boundaryInspections += 1;
+        }
+        return extractJson.get(value, jsonPath)?.value ?? null;
+      });
 
-    const parse = vi.spyOn(JSON, "parse");
-    const [probe] = readSessionTranscriptTitleProbeBatch([scope]);
-    const boundaryParses = parse.mock.calls.filter(([value]) =>
-      value.includes("Synthetic compaction summary"),
-    ).length;
-    parse.mockRestore();
-    expect(probe?.totalMessages).toBe(messages.length);
-    expect(probe?.head).toHaveLength(20);
-    expect(probe?.tail).toHaveLength(20);
-    expect(probe?.head[0]?.event).toMatchObject({ id: "message-0" });
-    expect(probe?.tail.at(-1)?.event).toMatchObject({ id: "message-59" });
-    expect(boundaryInspections).toBeGreaterThan(0);
-    expect(boundaryInspections).toBeLessThanOrEqual(metadata.length * 2);
-    expect(boundaryParses).toBe(compacted ? 1 : 0);
-  } finally {
-    vi.restoreAllMocks();
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-    nativeJson.close();
-    env.restore();
-  }
-});
+      const parse = vi.spyOn(JSON, "parse");
+      const [probe] = readSessionTranscriptTitleProbeBatch([scope]);
+      const boundaryParses = parse.mock.calls.filter(([value]) =>
+        value.includes("Synthetic compaction summary"),
+      ).length;
+      parse.mockRestore();
+      expect(boundaryParses).toBe(0);
+      if (boundaryType === "reset") {
+        expect(probe).toBeUndefined();
+      } else {
+        expect(probe?.totalMessages).toBe(messages.length);
+        expect(probe?.head).toHaveLength(20);
+        expect(probe?.tail).toHaveLength(20);
+        expect(probe?.head[0]?.event).toMatchObject({ id: "message-0" });
+        expect(probe?.tail.at(-1)?.event).toMatchObject({ id: "message-59" });
+      }
+      if (source === "exact-import") {
+        expect(boundaryInspections).toBeGreaterThan(0);
+      } else {
+        expect(boundaryInspections).toBe(0);
+      }
+    } finally {
+      vi.restoreAllMocks();
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      nativeJson.close();
+      env.restore();
+    }
+  },
+);

--- a/src/config/sessions/session-accessor.sqlite-title-probes.ts
+++ b/src/config/sessions/session-accessor.sqlite-title-probes.ts
@@ -16,7 +16,11 @@ type TitleProbeDatabase = Pick<
   | "session_windows"
   | "transcript_events"
   | "transcript_rewrite_watermarks"
->;
+> & {
+  transcript_event_identities: OpenClawAgentKyselyDatabase["transcript_event_identities"] & {
+    rowid: number;
+  };
+};
 
 export type SessionTranscriptTitleProbe = {
   generation: string | null;
@@ -28,20 +32,10 @@ export type SessionTranscriptTitleProbe = {
 
 const SESSION_TITLE_PROBE_MESSAGES = 20;
 
-function parseEventType(eventJson: string | null): string | undefined {
-  if (!eventJson) {
-    return undefined;
-  }
-  try {
-    const event = JSON.parse(eventJson) as { type?: unknown };
-    return typeof event.type === "string" ? event.type : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function sqliteTranscriptBoundaryEventType() {
-  return /* kysely-allow-raw: boundary type lives inside canonical transcript JSON. */ sql<string>`json_extract(boundary_event.event_json, '$.type')`;
+function sqliteTitleBoundaryType() {
+  // Exact SQLite handoffs can omit identities. Only those rows need their raw JSON;
+  // ordinary transcript metadata already has its type in the identity projection.
+  return /* kysely-allow-raw: exact imports retain raw events without identity rows. */ sql<string>`coalesce(identity.event_type, json_extract(boundary_event.event_json, '$.type'))`;
 }
 
 function readTitleProbeChunk(
@@ -83,19 +77,32 @@ function readTitleProbeChunk(
               .as("latest_seq"),
             eb
               .selectFrom("session_transcript_active_events as boundary")
-              .innerJoin("transcript_events as boundary_event", (join) =>
+              .leftJoin("transcript_event_identities as identity", (join) =>
+                // Resolve a covered sequence key first: directly joining while selecting type
+                // can make SQLite scan its type index once per metadata row.
+                join.on("identity.rowid", "=", (lookup) =>
+                  lookup
+                    .selectFrom("transcript_event_identities as identity_key")
+                    .select("identity_key.rowid")
+                    .whereRef("identity_key.session_id", "=", "boundary.session_id")
+                    .whereRef("identity_key.seq", "=", "boundary.event_seq")
+                    .limit(1),
+                ),
+              )
+              .leftJoin("transcript_events as boundary_event", (join) =>
                 join
                   .onRef("boundary_event.session_id", "=", "boundary.session_id")
-                  .onRef("boundary_event.seq", "=", "boundary.event_seq"),
+                  .onRef("boundary_event.seq", "=", "boundary.event_seq")
+                  .on("identity.event_type", "is", null),
               )
-              .select("boundary_event.event_json")
+              .select(sqliteTitleBoundaryType().as("event_type"))
               .whereRef("boundary.session_id", "=", "window.session_id")
               .where("boundary.message_position", "is", null)
               // Excluding latest-reset sessions prevents pre-reset text from leaking.
-              .where(sqliteTranscriptBoundaryEventType(), "in", ["reset", "compaction"])
+              .where(sqliteTitleBoundaryType(), "in", ["reset", "compaction"])
               .orderBy("boundary.active_position", "desc")
               .limit(1)
-              .as("latest_boundary_json"),
+              .as("latest_boundary_type"),
           ])
           .where("window.session_id", "in", sessionIds),
       ).rows;
@@ -103,10 +110,7 @@ function readTitleProbeChunk(
       for (const row of windows) {
         const emptyTranscript = row.latest_seq === null;
         const projectionCurrent = row.needs_rebuild === 0 && row.indexed_seq === row.latest_seq;
-        if (
-          (!emptyTranscript && !projectionCurrent) ||
-          parseEventType(row.latest_boundary_json) === "reset"
-        ) {
+        if ((!emptyTranscript && !projectionCurrent) || row.latest_boundary_type === "reset") {
           continue;
         }
         probes.set(row.session_id, {

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -8,6 +8,7 @@ export function createExtensionCodexAppServerAttemptLightVitestConfig(
     [
       "extensions/codex/src/app-server/attempt-client-cleanup.test.ts",
       "extensions/codex/src/app-server/attempt-diagnostics.test.ts",
+      "extensions/codex/src/app-server/attempt-preparation-timing.test.ts",
       "extensions/codex/src/app-server/attempt-steering.test.ts",
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",


### PR DESCRIPTION
Related: #136762, #136916

## What Problem This Solves

Resolves a problem where busy session lists repeatedly scan transcript metadata while replies wait to start, and operators cannot distinguish slow reply preparation from ordinary model or tool execution without enabling detailed profiling.

## Why This Change Was Made

Use the existing transcript identity projection for title-boundary types, with an indexed sequence lookup that avoids SQLite scanning the type index for every metadata row. Exact SQLite handoffs intentionally lack identity rows, so those rows continue reading their raw type. Retain the metadata-first read and shared snapshot transaction landed in #136916, including skipping preview reads for excluded sessions. Active-branch ordering, reset exclusion, stale projections, and bounded preview windows remain unchanged.

Record slow reply and Codex preparation stages by default at the existing owner boundaries. Default thresholds are 10 seconds total or 5 seconds per stage; the existing profiler flag retains its finer thresholds. Preparation warnings and first-activity observations are distinct from whole-turn summaries, which remain profiler-only. Logs omit prompt/tool contents and do not claim native turn acceptance is provider-request start. No configuration, schema, persistence, or protocol change.

## User Impact

Session lists spend less time reading metadata, reducing one source of Gateway contention. Operators get actionable timing records for slow dispatch, context/tool preparation, native thread setup, and turn handoff without enabling verbose profiling.

Production LOC: +209/-112 (net +97); tests/test support: +288/-84 (net +204); docs: +35/-1 (net +34). The title-query repair adds 4 production lines; the remaining growth supplies default, bounded preparation diagnostics and replaces disabled collectors. Existing timing helpers and thresholds are reused.

## Evidence

- Final integrated synthetic title accessor: **63.7 ms baseline median → 13.0 ms candidate median**, five warm samples. Baseline samples were noisy (53–294 ms); candidate samples were 12.7–13.7 ms. Fixture: 10 sessions, each with 60 messages and 1,000 metadata events carrying 8 KiB payloads. The baseline includes #136916. This is a component benchmark, not an end-to-end reply-latency claim.
- Canonical boundary regression cases fail before the fix with 20/21 JSON type inspections and pass with zero. Real exact-import cases preserve reset/compaction behavior. Independent selector comparison covered 5,184 ordering/identity combinations.
- **54 focused tests passed after integration** with #136916, covering title probes, read-only access, title rendering, and session-list materialization. Before integration, 102 tests covered exact imports, active projections, and concurrent list-cache behavior as well. Earlier focused timing and Codex preparation suites also passed, including tests that reject ordinary execution-time warning noise.
- Changed-file checks passed, including core/test/plugin types, lint, assertion safety, boundaries, dead-code scans, and import cycles. Fresh independent Codex autoreview is scoped-clean through P2; final-head CI passed with 144 successful jobs, 15 skipped, and no failures.

Focused performance verification:

```sh
node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-title-probes.test.ts src/config/sessions/session-accessor.sqlite-import.test.ts src/config/sessions/session-accessor.sqlite-active-events.test.ts src/gateway/session-transcript-title-reader.test.ts src/gateway/session-utils.perf.test.ts src/gateway/server-methods/sessions-read-cache.test.ts
```

Known separate follow-up: exact SQLite handoffs intentionally omit identity rows. The canonical reset-window page reader can therefore miss reset/compaction boundaries, and a subsequent public `chat.inject` can append with `parentId: null`, losing the prior branch title. The live fixture captured this append defect; baseline and candidate title probes return identical results on that state. The importer, append-parent owner, and write path are unchanged here. Repair needs retained-anchor, append-lineage, and context/history coverage. The changed batched title probe retains its existing reset exclusion.

## Maintainer review follow-through

Default preparation diagnostics are the requested capability, and the bounded always-on measurement cost is accepted. Most of the +97 production lines supply that capability; the title-query optimization itself is +4. Both independent pre-landing Codex reviews were scoped-clean through P2, including the final integrated head.

The stored-data detector is a false positive for this read-only query change: schemas, stored event representations, migration code, retention, and write paths are unchanged. Canonical and exact-import regression cases exercise both supported stored forms, including reset/compaction boundaries. No migration is needed. The maintainer has explicitly directed this PR to be landed after its normal gates pass.

CI caught one missing full-suite ownership entry for the new preparation timing test. Added it to the existing attempt-light suite; the exact ownership regression and all four timing tests pass. A fresh P2 review of that one-line test-registration fix is scoped-clean. Runtime files are byte-identical between `518d2857` and final head `82080e95`; final CI is [run 33716286941](https://github.com/openclaw/openclaw/actions/runs/33716286941).

## Real Gateway verification

An isolated Linux Testbox ran a real child Gateway and authenticated `sessions.list` / `chat.inject` RPCs against synthetic state, using Node 24.19.0 and the candidate's frozen dependency graph. Runtime source matched `518d2857`, which is byte-identical to final head `82080e95` except for the test-suite registration line.

The flow passed title/preview checks for a 603-event, approximately 9.6 MB transcript; read-only exact-import compaction; indexed reset visibility; and public append refresh on both indexed transcripts. The exact-import append defect described above was separately captured and baseline-compared, rather than counted as passing. Actual list RPC round trips were 91.14 ms initially, 5.64 ms after the canonical appends, and 0.77 ms warm. These are single synthetic observations, not a production reply benchmark. The child Gateway and temporary state were removed; the Testbox lease was stopped. [Testbox backing run](https://github.com/openclaw/openclaw/actions/runs/33714922891) (the wrapper completed with exit 0; lease cleanup can cancel the backing workflow).

The latest ClawSweeper review at final head found no introduced defect. Its two remaining checklist items are addressed above: the requested bounded diagnostics overhead is accepted, and the read-only query has no stored-data or migration change.
