### PR TITLE
fix(ui): direct dashboard links bypass automatic browser login

### DIFF
--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -60,6 +60,31 @@ The Control UI is an **admin surface** (chat, config, exec approvals). Do not ex
 - **Identity-bearing modes**: Tailscale Serve satisfies Control UI/WebSocket auth via identity headers when `gateway.auth.allowTailscale: true`; a non-loopback identity-aware reverse proxy satisfies `gateway.auth.mode: "trusted-proxy"`. Neither needs a pasted shared secret for the WebSocket.
 - **Not localhost**: use Tailscale Serve, a non-loopback shared-secret bind, a non-loopback identity-aware reverse proxy with `gateway.auth.mode: "trusted-proxy"`, or an SSH tunnel. HTTP APIs still use shared-secret auth unless you intentionally run private-ingress `gateway.auth.mode: "none"` or trusted-proxy HTTP auth. See [Web surfaces](/web).
 
+## Automatic browser handoff
+
+An identity-aware HTTPS host can provide automatic login for direct dashboard links while
+keeping the Gateway's existing token and device authentication. After an initial connection
+fails because authentication is missing, the Control UI makes one same-origin request to
+`GET /.well-known/openclaw/browser-bootstrap` (under the Control UI base path, if configured).
+Existing credentials are tried first. Explicit credentials, remote Gateway selections,
+pairing failures, and rejected credentials do not trigger this recovery.
+
+This endpoint belongs to the deployment's authenticated proxy or handoff service. OpenClaw
+does not expose an unauthenticated credential issuer. The service must independently verify
+the browser's identity and authorization before using the host's `openclaw dashboard --json`
+handoff. Return only its single-use browser credential:
+
+```json
+{ "bootstrapToken": "<single-use-browser-bootstrap>", "bootstrapProfile": "owner" }
+```
+
+Use `Content-Type: application/json` and `Cache-Control: no-store`, reject cross-origin
+requests, and never return the shared Gateway token. The UI rejects redirects, responses
+larger than 8 KiB, and tokens longer than 4096 printable ASCII characters. The request has
+a 45-second deadline and is cancelled if the connection changes or the page stops.
+Successful recovery preserves the current dashboard route. If no endpoint is configured or
+the host declines the request, the existing login instructions remain available.
+
 ## Open in Telegram
 
 Telegram bots can open the dashboard as a Telegram Mini App with `/dashboard`.

--- a/ui/src/app/bootstrap.gateway-credentials.test.ts
+++ b/ui/src/app/bootstrap.gateway-credentials.test.ts
@@ -1,8 +1,12 @@
 /* @vitest-environment jsdom */
+/* @vitest-environment-options {"url":"https://gateway.example/"} */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import { bootstrapApplication, type ApplicationRuntime } from "./bootstrap.ts";
+import { createGatewayStoreTestStore } from "./gateway-store.test-support.ts";
+import * as gatewayStore from "./gateway-store.ts";
 import { persistSessionToken } from "./settings.ts";
 
 const NATIVE_AUTH_KEY = "__OPENCLAW_NATIVE_CONTROL_AUTH__";
@@ -21,11 +25,103 @@ beforeEach(() => {
 afterEach(() => {
   runtime?.stop();
   runtime = undefined;
+  delete window[NATIVE_AUTH_KEY];
   window.history.replaceState({}, "", originalUrl);
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("pending Gateway credentials", () => {
+  it("recovers a bare dashboard login through its same-origin handoff without changing the route", async () => {
+    window.history.replaceState({}, "", "/settings/appearance?keep=yes#section");
+    const initialUrl = window.location.href;
+    const store = createGatewayStoreTestStore();
+    vi.spyOn(gatewayStore, "createApplicationGateway").mockReturnValue(store.gateway);
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({ bootstrapToken: "owner-bootstrap", bootstrapProfile: "owner" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    runtime = bootstrapApplication();
+    vi.spyOn(runtime.router, "start").mockResolvedValue(undefined);
+    await runtime.start();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    store.current().opts.onClose?.({
+      code: 4008,
+      reason: "connect failed",
+      error: {
+        code: "INVALID_REQUEST",
+        message: "token missing",
+        details: { code: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING },
+      },
+      willRetry: false,
+    });
+
+    await vi.waitFor(() => expect(store.gateway.connection.bootstrapToken).toBe("owner-bootstrap"));
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/.well-known/openclaw/browser-bootstrap",
+      expect.objectContaining({
+        method: "GET",
+        credentials: "same-origin",
+        cache: "no-store",
+        redirect: "error",
+      }),
+    );
+    expect(store.current().opts.bootstrapProfile).toBe("owner");
+    expect(window.location.href).toBe(initialUrl);
+  });
+
+  it.each(["native client", "unconfirmed Gateway"])(
+    "does not replace the %s authentication flow with a browser handoff",
+    async (flow) => {
+      window.history.replaceState({}, "", "/settings/appearance");
+      const store = createGatewayStoreTestStore();
+      vi.spyOn(gatewayStore, "createApplicationGateway").mockReturnValue(store.gateway);
+      if (flow === "native client") {
+        window[NATIVE_AUTH_KEY] = {
+          gatewayUrl: store.gateway.connection.gatewayUrl,
+          client: {
+            id: "openclaw-ios",
+            mode: "ui",
+            platform: "iOS 27.0.0",
+            deviceFamily: "iPhone",
+            scopes: ["operator.read"],
+          },
+        };
+      } else {
+        window.history.replaceState(
+          {},
+          "",
+          "/settings/appearance?gatewayUrl=wss%3A%2F%2Fother-gateway.example",
+        );
+      }
+      const fetchMock = vi.fn<typeof fetch>(async () =>
+        Response.json({ bootstrapToken: "owner-bootstrap", bootstrapProfile: "owner" }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      runtime = bootstrapApplication();
+      vi.spyOn(runtime.router, "start").mockResolvedValue(undefined);
+      await runtime.start();
+      store.current().opts.onClose?.({
+        code: 4008,
+        reason: "connect failed",
+        error: {
+          code: "INVALID_REQUEST",
+          message: "token missing",
+          details: { code: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING },
+        },
+        willRetry: false,
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(store.clients).toHaveLength(1);
+    },
+  );
+
   it("re-scopes credentials before confirming a changed Gateway URL", () => {
     const currentGatewayUrl = "wss://gateway.example/openclaw";
     const nextGatewayUrl = "wss://other-gateway.example/openclaw";

--- a/ui/src/app/bootstrap.gateway-credentials.test.ts
+++ b/ui/src/app/bootstrap.gateway-credentials.test.ts
@@ -32,45 +32,84 @@ afterEach(() => {
 });
 
 describe("pending Gateway credentials", () => {
-  it("recovers a bare dashboard login through its same-origin handoff without changing the route", async () => {
-    window.history.replaceState({}, "", "/settings/appearance?keep=yes#section");
-    const initialUrl = window.location.href;
-    const store = createGatewayStoreTestStore();
-    vi.spyOn(gatewayStore, "createApplicationGateway").mockReturnValue(store.gateway);
-    const fetchMock = vi.fn<typeof fetch>(async () =>
-      Response.json({ bootstrapToken: "owner-bootstrap", bootstrapProfile: "owner" }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
-    runtime = bootstrapApplication();
-    vi.spyOn(runtime.router, "start").mockResolvedValue(undefined);
-    await runtime.start();
-    expect(fetchMock).not.toHaveBeenCalled();
+  it.each([
+    {
+      name: "an initial missing token",
+      authCode: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING,
+      retryUnavailable: false,
+    },
+    {
+      name: "a missing token after retrying an unavailable Gateway",
+      authCode: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING,
+      retryUnavailable: true,
+    },
+    {
+      name: "a missing password after retrying an unavailable Gateway",
+      authCode: ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING,
+      retryUnavailable: true,
+    },
+  ])(
+    "recovers $name through its same-origin handoff without changing the route",
+    async ({ authCode, retryUnavailable }) => {
+      window.history.replaceState({}, "", "/settings/appearance?keep=yes#section");
+      const initialUrl = window.location.href;
+      const store = createGatewayStoreTestStore();
+      vi.spyOn(gatewayStore, "createApplicationGateway").mockReturnValue(store.gateway);
+      const fetchMock = vi.fn<typeof fetch>(async () =>
+        Response.json({ bootstrapToken: "owner-bootstrap", bootstrapProfile: "owner" }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      runtime = bootstrapApplication();
+      vi.spyOn(runtime.router, "start").mockResolvedValue(undefined);
+      await runtime.start();
+      expect(fetchMock).not.toHaveBeenCalled();
 
-    store.current().opts.onClose?.({
-      code: 4008,
-      reason: "connect failed",
-      error: {
-        code: "INVALID_REQUEST",
-        message: "token missing",
-        details: { code: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING },
-      },
-      willRetry: false,
-    });
+      if (retryUnavailable) {
+        const revision = store.gateway.connectionRevision;
+        store.current().opts.onClose?.({
+          code: 4008,
+          reason: "connect failed",
+          error: { code: "UNAVAILABLE", message: "Gateway temporarily unavailable" },
+          willRetry: false,
+        });
+        expect(store.gateway.snapshot).toMatchObject({
+          phase: "stopped",
+          lastErrorCode: "UNAVAILABLE",
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
 
-    await vi.waitFor(() => expect(store.gateway.connection.bootstrapToken).toBe("owner-bootstrap"));
-    expect(fetchMock).toHaveBeenCalledOnce();
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/.well-known/openclaw/browser-bootstrap",
-      expect.objectContaining({
-        method: "GET",
-        credentials: "same-origin",
-        cache: "no-store",
-        redirect: "error",
-      }),
-    );
-    expect(store.current().opts.bootstrapProfile).toBe("owner");
-    expect(window.location.href).toBe(initialUrl);
-  });
+        store.gateway.connect();
+        expect(store.gateway.connectionRevision).toBe(revision);
+      }
+
+      store.current().opts.onClose?.({
+        code: 4008,
+        reason: "connect failed",
+        error: {
+          code: "INVALID_REQUEST",
+          message: "authentication missing",
+          details: { code: authCode },
+        },
+        willRetry: false,
+      });
+
+      await vi.waitFor(() =>
+        expect(store.gateway.connection.bootstrapToken).toBe("owner-bootstrap"),
+      );
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/.well-known/openclaw/browser-bootstrap",
+        expect.objectContaining({
+          method: "GET",
+          credentials: "same-origin",
+          cache: "no-store",
+          redirect: "error",
+        }),
+      );
+      expect(store.current().opts.bootstrapProfile).toBe("owner");
+      expect(window.location.href).toBe(initialUrl);
+    },
+  );
 
   it.each(["native client", "unconfirmed Gateway"])(
     "does not replace the %s authentication flow with a browser handoff",

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -344,11 +344,32 @@ export function bootstrapApplication(): ApplicationRuntime {
       : null;
   let lastPostConnectClient: GatewayBrowserClient | null = null;
   let lastRecoveryClient: GatewayBrowserClient | null = null;
+  let browserBootstrapAttempted = Boolean(
+    hasPendingGateway || startup.nativeClient || startup.pendingBootstrapToken,
+  );
+  const initialConnectionRevision = gateway.connectionRevision;
   const stopPostConnect = gateway.subscribe((snapshot) => {
     connectionBootstrap.synchronize({
       client: snapshot.client,
       connected: snapshot.phase === "connected",
     });
+    if (snapshot.phase === "connected") {
+      browserBootstrapAttempted = true;
+    }
+    if (!browserBootstrapAttempted && snapshot.phase === "stopped" && snapshot.lastErrorCode) {
+      browserBootstrapAttempted = true;
+      // Recovery stays off the startup path; loading it cannot revive a replaced connection.
+      startupLifecycle.trackDisposer(
+        import("./browser-bootstrap.runtime.ts").then(({ startBrowserBootstrapRecovery }) =>
+          gateway.snapshot.client === snapshot.client &&
+          gateway.connectionRevision === initialConnectionRevision &&
+          !startupLifecycle.signal.aborted
+            ? startBrowserBootstrapRecovery(gateway, basePath)
+            : () => {},
+        ),
+        () => {},
+      );
+    }
     if (snapshot.phase !== "connected" || !snapshot.client) {
       lastPostConnectClient = null;
       lastRecoveryClient = null;

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -4,6 +4,7 @@ import {
   type ControlUiFocusLocation,
 } from "@openclaw/session-url-contract";
 import type { RouteLocation } from "@openclaw/uirouter";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import {
   createApplicationRouter,
@@ -356,7 +357,12 @@ export function bootstrapApplication(): ApplicationRuntime {
     if (snapshot.phase === "connected") {
       browserBootstrapAttempted = true;
     }
-    if (!browserBootstrapAttempted && snapshot.phase === "stopped" && snapshot.lastErrorCode) {
+    if (
+      !browserBootstrapAttempted &&
+      snapshot.phase === "stopped" &&
+      (snapshot.lastErrorCode === ConnectErrorDetailCodes.AUTH_TOKEN_MISSING ||
+        snapshot.lastErrorCode === ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING)
+    ) {
       browserBootstrapAttempted = true;
       // Recovery stays off the startup path; loading it cannot revive a replaced connection.
       startupLifecycle.trackDisposer(

--- a/ui/src/app/browser-bootstrap.runtime.ts
+++ b/ui/src/app/browser-bootstrap.runtime.ts
@@ -1,0 +1,114 @@
+import { gatewayCredentialScope } from "@openclaw/gateway-client/browser";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import { readResponseTextWithLimit } from "../lib/response-body.ts";
+import type { ApplicationGateway, ApplicationGatewaySnapshot } from "./gateway.ts";
+
+const BROWSER_BOOTSTRAP_PATH = "/.well-known/openclaw/browser-bootstrap";
+// A host handoff may verify identity and mint a credential in separate bounded operations.
+const BROWSER_BOOTSTRAP_TIMEOUT_MS = 45_000;
+
+/** Recover initial browser authentication through an identity-aware same-origin host. */
+export function startBrowserBootstrapRecovery(
+  gateway: ApplicationGateway,
+  basePath: string,
+): () => void {
+  const location = globalThis.location;
+  const revision = gateway.connectionRevision;
+  const connection = gateway.connection;
+  if (
+    location?.protocol !== "https:" ||
+    gatewayCredentialScope(connection.gatewayUrl) !==
+      gatewayCredentialScope(`wss://${location.host}${basePath}`) ||
+    connection.token ||
+    connection.password ||
+    connection.bootstrapToken
+  ) {
+    return () => {};
+  }
+  const gatewayUrl = new URL(connection.gatewayUrl);
+  if (gatewayUrl.username || gatewayUrl.password || gatewayUrl.hash) {
+    return () => {};
+  }
+
+  const abort = new AbortController();
+  let attempted = false;
+  let initialClient = gateway.snapshot.client;
+  const recover = async () => {
+    const timeout = globalThis.setTimeout(() => abort.abort(), BROWSER_BOOTSTRAP_TIMEOUT_MS);
+    try {
+      const response = await fetch(`${basePath}${BROWSER_BOOTSTRAP_PATH}`, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        credentials: "same-origin",
+        cache: "no-store",
+        redirect: "error",
+        signal: abort.signal,
+      });
+      const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
+      if (!response.ok || contentType !== "application/json") {
+        void response.body?.cancel().catch(() => undefined);
+        return;
+      }
+      const body = await readResponseTextWithLimit(response, {
+        maxBytes: 8192,
+        tooLargeMessage: "Browser bootstrap response exceeded its limit",
+      });
+      const bootstrap = asOptionalRecord(JSON.parse(body));
+      if (
+        !bootstrap ||
+        Object.keys(bootstrap).length !== 2 ||
+        typeof bootstrap.bootstrapToken !== "string" ||
+        !/^[\x21-\x7e]{1,4096}$/u.test(bootstrap.bootstrapToken) ||
+        bootstrap.bootstrapProfile !== "owner"
+      ) {
+        return;
+      }
+      // A user edit, stop, or replacement connection revokes this pending handoff.
+      // Never send the host's credential to a subsequently selected Gateway.
+      if (
+        !abort.signal.aborted &&
+        gateway.connectionRevision === revision &&
+        gateway.snapshot.client === initialClient &&
+        gateway.snapshot.phase === "stopped"
+      ) {
+        gateway.connect({
+          bootstrapToken: bootstrap.bootstrapToken,
+          bootstrapProfile: bootstrap.bootstrapProfile,
+        });
+      }
+    } catch {
+      // Ordinary Gateways have no issuer here. Keep the existing actionable auth error.
+    } finally {
+      globalThis.clearTimeout(timeout);
+    }
+  };
+  const onSnapshot = (snapshot: ApplicationGatewaySnapshot) => {
+    initialClient ??= snapshot.client;
+    if (
+      gateway.connectionRevision !== revision ||
+      snapshot.client !== initialClient ||
+      snapshot.phase === "connected"
+    ) {
+      abort.abort();
+    }
+    if (
+      attempted ||
+      abort.signal.aborted ||
+      !snapshot.client ||
+      snapshot.phase !== "stopped" ||
+      (snapshot.lastErrorCode !== ConnectErrorDetailCodes.AUTH_TOKEN_MISSING &&
+        snapshot.lastErrorCode !== ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING)
+    ) {
+      return;
+    }
+    attempted = true;
+    void recover();
+  };
+  const unsubscribe = gateway.subscribe(onSnapshot);
+  onSnapshot(gateway.snapshot);
+  return () => {
+    abort.abort();
+    unsubscribe();
+  };
+}

--- a/ui/src/app/browser-bootstrap.test.ts
+++ b/ui/src/app/browser-bootstrap.test.ts
@@ -1,0 +1,272 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import { setAvatarGatewayOrigin } from "../lib/identity-avatar-context.ts";
+import { startBrowserBootstrapRecovery } from "./browser-bootstrap.runtime.ts";
+import {
+  createGatewayStoreTestStore as createStore,
+  stubGatewayStoreTestGlobals,
+} from "./gateway-store.test-support.ts";
+import { loadSettings } from "./settings.ts";
+
+const OWNER_BOOTSTRAP = { bootstrapToken: "owner-bootstrap", bootstrapProfile: "owner" };
+const PAGE_URL = "https://gateway.example/operator/chat/research?draft=hello#section";
+let store: ReturnType<typeof createStore>;
+let dispose: (() => void) | undefined;
+let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+
+function startRecovery(gatewayUrl = "wss://gateway.example/operator", basePath = "/operator") {
+  store = createStore({ settings: { ...loadSettings(), gatewayUrl } });
+  dispose = startBrowserBootstrapRecovery(store.gateway, basePath);
+  store.gateway.start();
+}
+
+function rejectConnect(
+  code: string = ConnectErrorDetailCodes.AUTH_TOKEN_MISSING,
+  willRetry = false,
+) {
+  store.current().opts.onClose?.({
+    code: 4008,
+    reason: "connect failed",
+    error: { code: "INVALID_REQUEST", message: "auth failed", details: { code } },
+    willRetry,
+  });
+}
+
+async function settleFetch() {
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+beforeEach(() => {
+  stubGatewayStoreTestGlobals();
+  const location = new URL(PAGE_URL);
+  vi.stubGlobal("location", location);
+  vi.stubGlobal("window", { location });
+  fetchMock = vi.fn<typeof fetch>(async () => Response.json(OWNER_BOOTSTRAP));
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  dispose?.();
+  dispose = undefined;
+  store?.gateway.stop();
+  setAvatarGatewayOrigin(null);
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("same-origin browser bootstrap recovery", () => {
+  it("recovers a missing password for the exact mount without publishing credentials in the URL", async () => {
+    startRecovery("wss://gateway.example/operator/");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    rejectConnect(ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING);
+    await vi.waitFor(() => expect(store.clients).toHaveLength(2));
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/operator/.well-known/openclaw/browser-bootstrap",
+      expect.objectContaining({
+        method: "GET",
+        credentials: "same-origin",
+        redirect: "error",
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(store.current().opts).toMatchObject(OWNER_BOOTSTRAP);
+    expect(store.gateway.connection.token).toBe("");
+    expect(globalThis.location.href).toBe(PAGE_URL);
+  });
+
+  it.each([
+    "wss://other.example/operator",
+    "wss://gateway.example/different-mount",
+    "ws://gateway.example/operator",
+    "wss://user@gateway.example/operator",
+    "wss://gateway.example/operator?target=another",
+    "wss://gateway.example/operator#target",
+  ])("does not mint credentials for the non-default endpoint %s", async (gatewayUrl) => {
+    startRecovery(gatewayUrl);
+    rejectConnect();
+    await settleFetch();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(store.clients).toHaveLength(1);
+  });
+
+  it("does not request a handoff from a plain HTTP page", async () => {
+    const location = new URL("http://gateway.example/operator/chat");
+    vi.stubGlobal("location", location);
+    vi.stubGlobal("window", { location });
+    startRecovery("ws://gateway.example/operator");
+    rejectConnect();
+    await settleFetch();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { token: "explicit-token" },
+    { password: "explicit-password" },
+    { bootstrapToken: "explicit-bootstrap" },
+  ])("preserves explicit connection credentials %j", async (credentials) => {
+    store = createStore({
+      settings: { ...loadSettings(), gatewayUrl: "wss://gateway.example/operator" },
+    });
+    store.gateway.connect(credentials);
+    dispose = startBrowserBootstrapRecovery(store.gateway, "/operator");
+    rejectConnect();
+    await settleFetch();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(store.gateway.connection).toMatchObject(credentials);
+  });
+
+  it.each([
+    ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
+    ConnectErrorDetailCodes.PAIRING_REQUIRED,
+    ConnectErrorDetailCodes.AUTH_SCOPE_MISMATCH,
+  ])("does not replace a credential after %s", async (errorCode) => {
+    startRecovery();
+    rejectConnect(errorCode);
+    await settleFetch();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("waits for the actual terminal auth failure before considering a handoff", async () => {
+    startRecovery();
+    rejectConnect(ConnectErrorDetailCodes.AUTH_TOKEN_MISSING, true);
+    await settleFetch();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    rejectConnect();
+    await vi.waitFor(() => expect(store.clients).toHaveLength(2));
+  });
+
+  it.each([
+    { name: "missing endpoint", response: () => new Response(null, { status: 404 }) },
+    { name: "denied identity", response: () => new Response(null, { status: 403 }) },
+    {
+      name: "invalid JSON",
+      response: () => new Response("not-json", { headers: { "Content-Type": "application/json" } }),
+    },
+    {
+      name: "extra fields",
+      response: () => Response.json({ ...OWNER_BOOTSTRAP, token: "shared" }),
+    },
+    {
+      name: "wrong profile",
+      response: () => Response.json({ ...OWNER_BOOTSTRAP, bootstrapProfile: "node" }),
+    },
+    {
+      name: "empty credential",
+      response: () => Response.json({ ...OWNER_BOOTSTRAP, bootstrapToken: "" }),
+    },
+    {
+      name: "whitespace credential",
+      response: () => Response.json({ ...OWNER_BOOTSTRAP, bootstrapToken: "two words" }),
+    },
+    {
+      name: "control character",
+      response: () => Response.json({ ...OWNER_BOOTSTRAP, bootstrapToken: "bad\u0001token" }),
+    },
+    {
+      name: "oversized credential",
+      response: () => Response.json({ ...OWNER_BOOTSTRAP, bootstrapToken: "a".repeat(4097) }),
+    },
+  ])("leaves failed login actionable without a retry loop on $name", async ({ response }) => {
+    fetchMock.mockImplementation(async () => response());
+    startRecovery();
+    rejectConnect();
+    await settleFetch();
+    rejectConnect();
+    await settleFetch();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(store.clients).toHaveLength(1);
+    expect(store.gateway.snapshot.lastErrorCode).toBe(ConnectErrorDetailCodes.AUTH_TOKEN_MISSING);
+    expect(store.gateway.connection.bootstrapToken).toBe("");
+  });
+
+  it("cancels a streamed response once the envelope exceeds its byte bound", async () => {
+    const cancel = vi.fn();
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode(" ".repeat(8193)));
+            },
+            cancel,
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    startRecovery();
+    rejectConnect();
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+    expect(store.clients).toHaveLength(1);
+  });
+
+  it.each(["manual retry", "changed credentials", "stopped gateway", "disposed recovery"])(
+    "discards an awaited handoff after %s",
+    async (action) => {
+      let deliver!: (response: Response) => void;
+      fetchMock.mockReturnValue(
+        new Promise((resolve) => {
+          deliver = resolve;
+        }),
+      );
+      startRecovery();
+      rejectConnect();
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const signal = fetchMock.mock.calls[0]?.[1]?.signal;
+
+      if (action === "manual retry") {
+        store.gateway.connect();
+      } else if (action === "changed credentials") {
+        store.gateway.connect({ token: "user-token" });
+      } else if (action === "stopped gateway") {
+        store.gateway.stop();
+      } else {
+        dispose?.();
+      }
+      const clientCount = store.clients.length;
+      deliver(Response.json(OWNER_BOOTSTRAP));
+      await settleFetch();
+
+      expect(signal?.aborted).toBe(true);
+      expect(store.clients).toHaveLength(clientCount);
+      expect(store.gateway.connection.bootstrapToken).toBe("");
+      if (action === "changed credentials") {
+        expect(store.gateway.connection.token).toBe("user-token");
+      }
+    },
+  );
+
+  it("bounds a stalled handoff without retrying or hiding the auth error", async () => {
+    vi.useFakeTimers();
+    fetchMock.mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    startRecovery();
+    rejectConnect();
+    const signal = fetchMock.mock.calls[0]?.[1]?.signal;
+    await vi.advanceTimersByTimeAsync(45_000);
+
+    expect(signal?.aborted).toBe(true);
+    expect(store.clients).toHaveLength(1);
+    expect(store.gateway.snapshot.lastErrorCode).toBe(ConnectErrorDetailCodes.AUTH_TOKEN_MISSING);
+    rejectConnect();
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/e2e/browser-bootstrap.e2e.test.ts
+++ b/ui/src/e2e/browser-bootstrap.e2e.test.ts
@@ -1,0 +1,113 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Control UI browser bootstrap" });
+
+suite.define(() => {
+  it("recovers a bare HTTPS deep link and reuses the paired browser credential on reload", async () => {
+    const artifactDir = suite.artifactDir;
+    const video = await suite.withPage(
+      {
+        viewport: { width: 1440, height: 1000 },
+        locale: "en-US",
+        serviceWorkers: "block",
+        recordVideo: { dir: artifactDir, size: { width: 1440, height: 1000 } },
+      },
+      async ({ page }) => {
+        const origin = "https://gateway.example";
+        const sessionKey = "agent:main:browser-bootstrap-proof";
+        const deepLink = `${controlUiSessionUrl(`${origin}/`, sessionKey)}?keep=yes#section`;
+        const bootstrapToken = "synthetic-owner-bootstrap";
+        const deviceToken = "synthetic-paired-browser";
+        let helperCalls = 0;
+        let releaseHandoff!: () => void;
+        const handoffReady = new Promise<void>((resolve) => {
+          releaseHandoff = resolve;
+        });
+
+        // Exercise secure-origin browser behavior while serving only this test's local bundle.
+        await page.route(`${origin}/**`, async (route) => {
+          const requested = new URL(route.request().url());
+          const upstream = new URL(
+            `${requested.pathname}${requested.search}`,
+            suite.server.baseUrl,
+          );
+          const response = await route.fetch({ url: upstream.href });
+          await route.fulfill({ response });
+        });
+        const gateway = await installMockGateway(page, {
+          sessionKey,
+          deviceToken,
+          heldMethods: ["connect"],
+          historyMessages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "text", text: "Your browser is connected. This is synthetic proof data." },
+              ],
+            },
+          ],
+        });
+        await page.route(`${origin}/.well-known/openclaw/browser-bootstrap`, async (route) => {
+          helperCalls += 1;
+          expect(route.request().method()).toBe("GET");
+          expect(route.request().headers().authorization).toBeUndefined();
+          await handoffReady;
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            headers: { "Cache-Control": "no-store" },
+            body: JSON.stringify({ bootstrapToken, bootstrapProfile: "owner" }),
+          });
+        });
+
+        await page.goto(deepLink);
+        const initialConnect = await gateway.waitForRequest("connect");
+        expect(initialConnect.params).not.toHaveProperty("auth.bootstrapToken");
+        expect(initialConnect.params).not.toHaveProperty("auth.deviceToken");
+        await gateway.rejectDeferred("connect", {
+          code: "INVALID_REQUEST",
+          message: "The Gateway needs a matching token or password.",
+          details: { code: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING },
+        });
+        await page.getByText("Auth required", { exact: true }).waitFor();
+        await expect.poll(() => helperCalls).toBe(1);
+        await page.screenshot({ path: path.join(artifactDir, "1-auth-required.png") });
+
+        await gateway.deferNext("connect");
+        releaseHandoff();
+        const recoveredConnect = await gateway.waitForRequest("connect", { after: 1 });
+        expect(recoveredConnect.params).toMatchObject({
+          auth: { bootstrapToken },
+          device: { id: expect.any(String), signature: expect.any(String) },
+        });
+        await gateway.resolveDeferred("connect");
+        await waitForControlUiGatewayReady(page);
+        await page
+          .getByText("Your browser is connected. This is synthetic proof data.", { exact: true })
+          .waitFor();
+        expect(page.url()).toBe(deepLink);
+        await page.screenshot({ path: path.join(artifactDir, "2-connected.png") });
+
+        await page.reload();
+        const reloadConnect = await gateway.waitForRequest("connect");
+        expect(reloadConnect.params).toMatchObject({ auth: { deviceToken } });
+        expect(reloadConnect.params).not.toHaveProperty("auth.bootstrapToken");
+        await gateway.resolveDeferred("connect");
+        await waitForControlUiGatewayReady(page);
+        await page
+          .getByText("Your browser is connected. This is synthetic proof data.", { exact: true })
+          .waitFor();
+        expect(helperCalls).toBe(1);
+        expect(page.url()).toBe(deepLink);
+        await page.screenshot({ path: path.join(artifactDir, "3-reloaded.png") });
+        return page.video();
+      },
+    );
+    await video?.saveAs(path.join(artifactDir, "browser-bootstrap.webm"));
+  });
+});

--- a/ui/src/lib/connection-hints.node.test.ts
+++ b/ui/src/lib/connection-hints.node.test.ts
@@ -135,13 +135,16 @@ describe("resolveAuthHintKind", () => {
     ).toBe("required");
   });
 
-  it("returns failed for structured auth mismatch codes", () => {
+  it.each([
+    { lastErrorCode: ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH, hasToken: true },
+    { lastErrorCode: ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID, hasToken: false },
+  ])("returns failed for structured auth code $lastErrorCode", ({ lastErrorCode, hasToken }) => {
     expect(
       resolveAuthHintKind({
         connected: false,
         lastError: "disconnected (4008): connect failed",
-        lastErrorCode: ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
-        hasToken: true,
+        lastErrorCode,
+        hasToken,
         hasPassword: false,
       }),
     ).toBe("failed");

--- a/ui/src/lib/connection-hints.ts
+++ b/ui/src/lib/connection-hints.ts
@@ -20,6 +20,7 @@ const AUTH_FAILURE_CODES = new Set<string>([
   ConnectErrorDetailCodes.AUTH_UNAUTHORIZED,
   ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
   ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH,
+  ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID,
   ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH,
   ConnectErrorDetailCodes.AUTH_RATE_LIMITED,
   ConnectErrorDetailCodes.AUTH_TAILSCALE_IDENTITY_MISSING,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a direct dashboard link would reach the manual login form even when their HTTPS host already provided an identity-verified browser handoff. Entering through the host's launcher worked, but bookmarks and deep links skipped that handoff.

## Why This Change Was Made

After the initial same-origin connection fails because authentication is missing, the Control UI makes one bounded request to the host-owned `/.well-known/openclaw/browser-bootstrap` endpoint and uses the existing single-use owner bootstrap flow. The host remains responsible for verifying identity and authorization. An HTTP redirect cannot inspect browser credentials or URL fragments, so recovery belongs after the browser's first authentication attempt.

The helper loads lazily. Explicit credentials, remote Gateway selections, native-client startup, pairing failures, rejected credentials, manually stopped connections, and replaced connections do not trigger or accept a handoff. The response is size-bounded, cannot redirect, and has a deadline; the shared Gateway token is never requested or returned.

## User Impact

Direct dashboard links can sign in automatically on hosts providing the documented endpoint, preserving the route, query, and fragment. Reloads reuse the paired browser credential. Ordinary deployments retain their existing actionable login instructions. Invalid or spent bootstrap credentials use the existing authentication-failure guidance rather than a network-error hint. There are no new configuration keys, database changes, or Gateway protocol changes.

## Evidence

- Captured the failing startup regression before the fix: the connection never received a browser bootstrap credential. Also captured two failing sequences where terminal `UNAVAILABLE` followed by unchanged-credential retry and missing token/password consumed recovery too early; both pass after restricting the startup trigger to missing-auth errors.
- 98 focused recovery, startup, credential-classifier, and login-gate tests pass, covering credential scope, malformed/denied/oversized responses, deadline, cancellation, manual retry, and native/pending-Gateway boundaries.
- Bundled Chromium proof passes: fresh HTTPS deep link, missing-auth response, one handoff, signed bootstrap connection, unchanged URL, then reload using the device credential without another handoff.
- Full package build and UI production build pass, including startup-size and lazy-module checks. Scoped formatting, lint/stylelint, core/UI typechecks, ownership/graph guards, and Knip pass.
- Independent review found no actionable P0–P2 findings, including the adjacent bootstrap-error classification and startup retry repairs.
- Real Gateway proof passed in isolated state with actual HTTPS/WebSocket transport and CLI-issued single-use bootstraps: automatic login, paired reload, denied helper, invalid token, and replay rejection. The identity verifier in that fixture was synthetic; Gateway authorization was real.
- After rebasing to include the existing WhatsApp selector-race repair from #136810, all five WhatsApp scenarios and the bootstrap browser scenario pass together. The rebuilt UI passes its startup-size checks. The original CI attempt also hit a transient Matrix dependency-download failure before one check ran; the rebased head passed all 134 CI jobs. The final missing-auth trigger correction also passed exact-head [CI33718492856](https://github.com/openclaw/openclaw/actions/runs/33718492856).

Production LOC: +142/-0; tests: +526/-3; docs: +25/-0. The production addition provides the optional host identity handoff and reuses the existing connection lifecycle, credential scope, bounded response reader, and startup disposer. No existing authentication path is replaced.

The screenshots below contain synthetic test data only. The screenshots illustrate the bundled mocked scenario; the separate real-Gateway proof above used isolated runtime state and a synthetic identity verifier. Production rollout and verification against the deployment identity service follow landing.

Before: direct link stops at missing authentication.

![Direct link requires authentication](https://github.com/user-attachments/assets/e8aa1fef-cbf5-4d8a-b3a8-80b1e95da337)

After: the verified browser handoff connects without changing the deep link.

![Direct link connects automatically](https://github.com/user-attachments/assets/f56eac9b-e1b7-4e19-bc5c-03bf61f46331)
