### PR TITLE
fix(ui): show registered teammates in session assignment

### DIFF
--- a/docs/concepts/multi-user.md
+++ b/docs/concepts/multi-user.md
@@ -30,7 +30,7 @@ Gateway profile display names and avatars are resolved from the current profile 
 In the Control UI, the session context menu (kebab or right-click on a sidebar row, and the same menu on the chat header) offers:
 
 - **Assign to me**: take responsibility for the session yourself.
-- **Assign to…**: pick from a submenu of known people and configured agents.
+- **Assign to…**: pick any registered person or configured agent, including offline teammates and people who have not owned a session. Choices refresh when you open the menu and do not depend on session filters or archive status.
 
 Agents can reassign ownership with the [`sessions` tool](/concepts/session-tool#managing-session-settings-and-groups) using `action: "assign_owner"` with `ownerType` (`"human"` or `"agent"`) and `ownerId`, targeting the current session by default or another visible session via `sessionKey`.
 

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -42,7 +42,7 @@ import {
 import type { SidebarWorkboardBoard } from "./app-sidebar-workboard.ts";
 import { resolveCloudWorkerStopAction } from "./cloud-worker-stop.ts";
 import type { SessionAttentionController } from "./session-attention-controller.ts";
-import { listAssignableSessionOwners, type SessionOwnerOption } from "./session-owner-chip.ts";
+import { sessionSelfOwner, type SessionOwnerOption } from "./session-owner-chip.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
 
@@ -569,11 +569,10 @@ export function applySidebarSessionOwnerFilter(input: {
 } {
   const facetOwners = input.ownerFacet ?? [];
   const selfId = input.self?.id;
-  const selfOwner = selfId
-    ? listAssignableSessionOwners({ facet: facetOwners, self: input.self }).find(
-        (owner) => owner.type === "human" && owner.id === selfId,
-      )
-    : undefined;
+  const selfOwner =
+    facetOwners.find((owner) => owner.id === selfId)?.type === "agent"
+      ? null
+      : sessionSelfOwner(input.self);
   const ownerOptions = selfOwner
     ? [selfOwner, ...facetOwners.filter((owner) => owner.id !== selfOwner.id)]
     : facetOwners;

--- a/ui/src/components/session-menu-actions.ts
+++ b/ui/src/components/session-menu-actions.ts
@@ -13,6 +13,7 @@ import {
 import { renderSessionEditorOptions, renderSessionGroupOptions } from "./session-menu-options.ts";
 import type { SessionCreatedActor, SessionOwnerOption } from "./session-owner-chip.ts";
 import { SessionOwnerMenu } from "./session-owner-menu.ts";
+import "../styles/sidebar-menus.css";
 
 export type SessionMenuData = {
   label: string;

--- a/ui/src/components/session-menu-actions.ts
+++ b/ui/src/components/session-menu-actions.ts
@@ -11,12 +11,8 @@ import {
   type CompactSessionMenuView,
 } from "./session-menu-compact.ts";
 import { renderSessionEditorOptions, renderSessionGroupOptions } from "./session-menu-options.ts";
-import type { SessionOwnerOption } from "./session-owner-chip.ts";
-import {
-  renderSessionOwnerAssignmentMenu,
-  renderSessionOwnerAssignmentOptions,
-  sessionOwnerAssignmentFromMenuValue,
-} from "./session-owner-menu.ts";
+import type { SessionCreatedActor, SessionOwnerOption } from "./session-owner-chip.ts";
+import { SessionOwnerMenu } from "./session-owner-menu.ts";
 
 export type SessionMenuData = {
   label: string;
@@ -81,9 +77,7 @@ type SessionMenuActionsState = {
   archiveAllowed: boolean;
   deleteAllowed: boolean;
   groups: readonly string[];
-  ownerOptions: readonly SessionOwnerOption[];
-  selfOwner: SessionOwnerOption | null;
-  currentOwnerId: string | null;
+  currentOwner: SessionCreatedActor | null;
   worktreePath: string | null;
   navigationAllowed: boolean;
   copyMarkdownAllowed: boolean;
@@ -95,6 +89,7 @@ const SESSION_ICON_GRID_COLUMNS = 6;
 
 /** Canonical single-session actions shared by sidebar and chat-header menus. */
 export class SessionMenuActions {
+  private readonly ownerMenu: SessionOwnerMenu;
   private iconPickerMode: "grid" | "custom" = "grid";
   private customIconValue = "";
 
@@ -103,7 +98,15 @@ export class SessionMenuActions {
     private readonly readState: () => SessionMenuActionsState,
     private readonly onAction: (action: SessionManagementAction) => void,
     private readonly onClose: () => void,
-  ) {}
+  ) {
+    this.ownerMenu = new SessionOwnerMenu(host);
+  }
+
+  readonly loadOwners = () => {
+    if (this.readState().selectionCount === 1) {
+      this.ownerMenu.load();
+    }
+  };
 
   private actionDisabled(kind: SessionManagementActionKind, extra = false): boolean {
     const state = this.readState();
@@ -173,6 +176,10 @@ export class SessionMenuActions {
   }
 
   handleSelect(value: string): boolean {
+    if (value === "reload-owners") {
+      this.ownerMenu.load();
+      return true;
+    }
     if (
       value === "copy-session-id" ||
       value === "copy-session-link" ||
@@ -209,9 +216,9 @@ export class SessionMenuActions {
       });
       return true;
     }
-    const owner = sessionOwnerAssignmentFromMenuValue(value);
-    if (owner) {
-      this.runAction({ kind: "assign-owner", owner });
+    const [action, type, encodedId] = value.split(":");
+    if (action === "assign-owner" && (type === "human" || type === "agent") && encodedId) {
+      this.runAction({ kind: "assign-owner", owner: { type, id: decodeURIComponent(encodedId) } });
       return true;
     }
     return false;
@@ -397,25 +404,15 @@ export class SessionMenuActions {
             this.actionDisabled("set-icon") && this.actionDisabled("set-color"),
           )}
       ${this.renderGroupAction()}
-      ${batch
-        ? nothing
-        : state.compact
-          ? state.selfOwner || state.ownerOptions.length > 0
-            ? renderCompactSessionMenuNavigationItem({
-                value: "compact:open-assign-owner",
-                label: t("sessionsView.assignTo"),
-                icon: icons.users,
-                disabled: this.actionDisabled("assign-owner"),
-                title: state.actionDisabledReasons["assign-owner"],
-              })
-            : nothing
-          : renderSessionOwnerAssignmentMenu({
-              ownerOptions: state.ownerOptions,
-              selfOwner: state.selfOwner,
-              currentOwnerId: state.currentOwnerId,
-              disabled: this.actionDisabled("assign-owner"),
-              disabledReason: state.actionDisabledReasons["assign-owner"],
-            })}
+      ${!batch
+        ? this.renderSubmenu(
+            "assign-owner",
+            t("sessionsView.assignTo"),
+            icons.users,
+            this.actionDisabled("assign-owner"),
+            state.actionDisabledReasons["assign-owner"],
+          )
+        : nothing}
     `;
   }
 
@@ -482,11 +479,9 @@ export class SessionMenuActions {
       case "group":
         return this.renderGroupSubmenu(inline);
       case "assign-owner":
-        return renderSessionOwnerAssignmentOptions(
+        return this.ownerMenu.render(
           {
-            ownerOptions: state.ownerOptions,
-            selfOwner: state.selfOwner,
-            currentOwnerId: state.currentOwnerId,
+            currentOwner: state.currentOwner,
             disabled: this.actionDisabled("assign-owner"),
             disabledReason: state.actionDisabledReasons["assign-owner"],
           },

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -2,6 +2,18 @@
 
 import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RouteId } from "../app-route-paths.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import { deferred } from "../test-helpers/app-sidebar.ts";
+import {
+  createApplicationContextProvider,
+  type ApplicationContextProvider,
+} from "../test-helpers/application-context.ts";
+import {
+  createSessionOwnerMenuHarness,
+  sessionOwnerProfiles,
+} from "../test-helpers/session-owner-menu.ts";
+import { waitForFast } from "../test-helpers/wait-for.ts";
 import "./session-menu.ts";
 import type { SessionMenuData } from "./session-menu-actions.ts";
 import type { SessionMenuAction, SessionMenuActionKind, SessionMenuWork } from "./session-menu.ts";
@@ -11,7 +23,6 @@ type SessionMenuElement = HTMLElement & {
   compact: boolean;
   lastActive: string;
   session: SessionMenuData;
-  ownerOptions: readonly SessionOwnerOption[];
   updateComplete: Promise<boolean>;
 };
 type SessionMenuItem = HTMLElement & { disabled: boolean; updateComplete: Promise<unknown> };
@@ -39,9 +50,8 @@ async function mountMenu(
     selectionCount?: number;
     lastActive?: string;
     groups?: readonly string[];
-    ownerOptions?: readonly SessionOwnerOption[];
-    selfOwner?: SessionOwnerOption | null;
-    currentOwnerId?: string | null;
+    context?: ApplicationContext<RouteId>;
+    currentOwner?: SessionOwnerOption | null;
     trigger?: HTMLElement | null;
     onAction?: (action: SessionMenuAction) => void;
     onClose?: () => void;
@@ -49,7 +59,9 @@ async function mountMenu(
     forkFromLastCompleted?: boolean;
   } = {},
 ): Promise<SessionMenuElement> {
-  const container = document.createElement("div");
+  const container = options.context
+    ? createApplicationContextProvider(options.context)
+    : document.createElement("div");
   containers.push(container);
   document.body.append(container);
   const session: SessionMenuData = {
@@ -85,9 +97,7 @@ async function mountMenu(
       (session.archived || (options.archiveAllowed ?? true))}
       .cloudWorkerStopAllowed=${options.cloudWorkerStopAllowed ?? false}
       .groups=${options.groups ?? []}
-      .ownerOptions=${options.ownerOptions ?? []}
-      .selfOwner=${options.selfOwner ?? null}
-      .currentOwnerId=${options.currentOwnerId ?? null}
+      .currentOwner=${options.currentOwner ?? null}
       .work=${options.work ?? null}
       .workboard=${options.workboard === undefined
         ? { captured: false, busy: false }
@@ -142,57 +152,147 @@ function selectMenuValue(menu: SessionMenuElement, value: string) {
 }
 
 describe("session menu", () => {
-  it("puts the self shortcut first in the owner submenu and dispatches canonical owners", async () => {
-    const onAction = vi.fn<(action: SessionMenuAction) => void>();
-    const onClose = vi.fn();
-    const selfOwner = { type: "human", id: "profile-ada", label: "Ada" } as const;
-    const menu = await mountMenu({
-      ownerOptions: [selfOwner, { type: "agent", id: "research:one", label: "Research" }],
-      selfOwner,
-      currentOwnerId: "research:one",
-      onAction,
-      onClose,
-    });
-    const selected = menuItem(menu, "Research");
-    const submenu = menuItem(menu, "Assign to…");
-    expect(menuItemLabels(menu).filter((label) => label.startsWith("Assign to"))).toEqual([
-      "Assign to…",
-    ]);
-    expect(menuItemLabels(submenu)).toEqual(["Me", "Research"]);
-    expect(selected.getAttribute("role")).toBe("menuitemradio");
-    expect(selected.getAttribute("aria-checked")).toBe("true");
-    expect(selected.disabled).toBe(true);
-    expect(selected.querySelector("[slot='details']")).not.toBeNull();
+  it("keeps self and agents available while the directory loads, then retries a visible failure", async () => {
+    const pending = deferred<ReturnType<typeof sessionOwnerProfiles>>();
+    const { context, request } = createSessionOwnerMenuHarness(() => pending.promise);
+    const menu = await mountMenu({ context });
+    await waitForFast(() => expect(request).toHaveBeenCalledWith("users.list", {}));
+    expect(menuItemLabels(menuItem(menu, "Assign to…")).slice(0, 2)).toEqual(["Me", "Research"]);
+    expect(menu.textContent).toContain("Loading");
 
-    for (const label of ["Me", "Research"]) {
-      const value = menuItem(menu, label).getAttribute("value");
-      menu.querySelector("wa-dropdown")?.dispatchEvent(
-        new CustomEvent("wa-select", {
-          bubbles: true,
-          composed: true,
-          detail: { item: { value } },
-        }),
-      );
-    }
-    expect(onAction.mock.calls).toEqual([
-      [{ kind: "assign-owner", owner: { type: "human", id: "profile-ada" } }],
-      [{ kind: "assign-owner", owner: { type: "agent", id: "research:one" } }],
-    ]);
-    expect(onClose).toHaveBeenCalledTimes(2);
-    const closeOrder = onClose.mock.invocationCallOrder[0];
-    const actionOrder = onAction.mock.invocationCallOrder[0];
-    if (closeOrder === undefined || actionOrder === undefined) {
-      throw new Error("Expected close and action call order");
-    }
-    expect(closeOrder).toBeLessThan(actionOrder);
-
-    const batch = await mountMenu({
-      selectionCount: 2,
-      ownerOptions: [selfOwner],
-      selfOwner,
-    });
-    expect(batch.textContent).not.toContain("Assign to");
+    pending.reject(new Error("Directory is temporarily unavailable."));
+    await waitForFast(() =>
+      expect(menu.querySelector('[role="alert"]')?.textContent).toContain(
+        "Directory is temporarily unavailable.",
+      ),
+    );
+    expect(menuItemLabels(menuItem(menu, "Assign to…")).slice(0, 2)).toEqual(["Me", "Research"]);
+    request.mockImplementation(() => sessionOwnerProfiles("Ada", "Carol"));
+    selectMenuValue(menu, "reload-owners");
+    await waitForFast(() =>
+      expect(menuItemLabels(menuItem(menu, "Assign to…"))).toEqual(["Me", "Research", "Carol"]),
+    );
+    expect(menu.querySelector('[role="alert"]')).toBeNull();
+    expect(request).toHaveBeenCalledTimes(2);
   });
+
+  it.each(["reconnect", "replace gateway"] as const)(
+    "retires an in-flight directory on %s",
+    async (transition) => {
+      const pending = deferred<ReturnType<typeof sessionOwnerProfiles>>();
+      const first = createSessionOwnerMenuHarness(() => pending.promise);
+      const menu = await mountMenu({ context: first.context });
+      await waitForFast(() => expect(first.request).toHaveBeenCalledWith("users.list", {}));
+      if (transition === "reconnect") {
+        first.request.mockImplementation(() => sessionOwnerProfiles("Carol"));
+        first.publish({ phase: "reconnecting" });
+        first.publish({ phase: "connected" });
+      } else {
+        const next = createSessionOwnerMenuHarness(() => sessionOwnerProfiles("Carol"));
+        (menu.parentElement as ApplicationContextProvider).setContext(next.context);
+      }
+      await waitForFast(() =>
+        expect(menuItemLabels(menuItem(menu, "Assign to…"))).toEqual(["Me", "Research", "Carol"]),
+      );
+      pending.resolve(sessionOwnerProfiles("Bob"));
+      await pending.promise;
+      await menu.updateComplete;
+      expect(menuItemLabels(menuItem(menu, "Assign to…"))).toEqual(["Me", "Research", "Carol"]);
+    },
+  );
+
+  it.each([
+    {
+      name: "agent",
+      currentOwner: { type: "agent", id: "research:one" },
+      selectedLabel: "Research",
+      otherLabel: "Colleague",
+      otherType: "human",
+    },
+    {
+      name: "merged profile",
+      currentOwner: {
+        type: "human",
+        id: "profile-merged-colleague",
+        identity: { type: "profile", id: "research:one" },
+      },
+      selectedLabel: "Colleague",
+      otherLabel: "Research",
+      otherType: "agent",
+    },
+  ] as const)(
+    "selects the canonical $name while distinguishing people and naming blank profiles",
+    async ({ currentOwner, selectedLabel, otherLabel, otherType }) => {
+      const onAction = vi.fn<(action: SessionMenuAction) => void>();
+      const onClose = vi.fn();
+      const profiles = sessionOwnerProfiles("Colleague", "Zed", "Merged colleague").profiles.map(
+        (profile, index) =>
+          Object.assign(
+            profile,
+            index === 0
+              ? { id: "research:one" }
+              : index === 1
+                ? { displayName: "  ", emails: ["zed@example.test"] }
+                : { mergedInto: "research:one" },
+          ),
+      );
+      const { context } = createSessionOwnerMenuHarness(() => ({ profiles }));
+      const menu = await mountMenu({
+        context,
+        currentOwner,
+        onAction,
+        onClose,
+      });
+      const submenu = menuItem(menu, "Assign to…");
+      expect(menuItemLabels(menu).filter((label) => label.startsWith("Assign to"))).toEqual([
+        "Assign to…",
+      ]);
+      await waitForFast(() =>
+        expect(menuItemLabels(submenu)).toEqual([
+          "Me",
+          "Research",
+          "Colleague",
+          "zed@example.test",
+        ]),
+      );
+      const selected = menuItem(menu, selectedLabel);
+      expect(selected.getAttribute("role")).toBe("menuitemradio");
+      expect(selected.getAttribute("aria-checked")).toBe("true");
+      expect(selected.disabled).toBe(true);
+      expect(selected.querySelector("[slot='details']")).not.toBeNull();
+      const other = menuItem(menu, otherLabel);
+      expect(other.getAttribute("aria-checked")).toBe("false");
+      expect(other.disabled).toBe(false);
+
+      for (const label of ["Me", otherLabel]) {
+        const value = menuItem(menu, label).getAttribute("value");
+        menu.querySelector("wa-dropdown")?.dispatchEvent(
+          new CustomEvent("wa-select", {
+            bubbles: true,
+            composed: true,
+            detail: { item: { value } },
+          }),
+        );
+      }
+      expect(onAction.mock.calls).toEqual([
+        [{ kind: "assign-owner", owner: { type: "human", id: "profile-ada" } }],
+        [{ kind: "assign-owner", owner: { type: otherType, id: "research:one" } }],
+      ]);
+      expect(onClose).toHaveBeenCalledTimes(2);
+      const closeOrder = onClose.mock.invocationCallOrder[0];
+      const actionOrder = onAction.mock.invocationCallOrder[0];
+      if (closeOrder === undefined || actionOrder === undefined) {
+        throw new Error("Expected close and action call order");
+      }
+      expect(closeOrder).toBeLessThan(actionOrder);
+
+      const batch = await mountMenu({
+        selectionCount: 2,
+        context,
+      });
+      expect(batch.textContent).not.toContain("Assign to");
+    },
+  );
 
   it("disables only denied mutation actions and ignores forced selection", async () => {
     const onAction = vi.fn<(action: SessionMenuAction) => void>();
@@ -235,6 +335,7 @@ describe("session menu", () => {
       "Archive session",
       "Icon & color",
       "Move to group",
+      "Assign to…",
       "Add to Workboard",
       "Fork conversation",
       "Copy",
@@ -244,14 +345,12 @@ describe("session menu", () => {
   });
 
   it("drills into compact menu groups without rendering side flyouts", async () => {
-    const ada = { type: "human", id: "profile-ada", label: "Ada" } as const;
-    const research = { type: "agent", id: "research:one", label: "Research owner" } as const;
+    const { context } = createSessionOwnerMenuHarness(undefined, "Research owner");
     const menu = await mountMenu({
       compact: true,
       groups: ["Research", "Operations"],
-      ownerOptions: [ada, research],
-      selfOwner: ada,
-      currentOwnerId: research.id,
+      context,
+      currentOwner: { type: "agent", id: "research:one" },
       work: {
         loading: false,
         pullRequestUrl: "https://example.test/pr",
@@ -321,6 +420,7 @@ describe("session menu", () => {
       "Mark as unread",
       "Archive session",
       "Icon & color",
+      "Assign to…",
       "Fork conversation",
       "Copy",
       "Open in",

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -152,13 +152,29 @@ function selectMenuValue(menu: SessionMenuElement, value: string) {
 }
 
 describe("session menu", () => {
-  it("keeps self and agents available while the directory loads, then retries a visible failure", async () => {
+  it("keeps self, agents, and the current owner while the directory loads, then retries a visible failure", async () => {
     const pending = deferred<ReturnType<typeof sessionOwnerProfiles>>();
     const { context, request } = createSessionOwnerMenuHarness(() => pending.promise);
-    const menu = await mountMenu({ context });
+    const menu = await mountMenu({
+      context,
+      currentOwner: {
+        type: "human",
+        id: "profile-old-bob",
+        identity: { type: "profile", id: "profile-bob" },
+        label: "Bob",
+      },
+    });
+    const expectCurrentOwner = () => {
+      expect
+        .soft(menuItemLabels(menuItem(menu, "Assign to…")).slice(0, 3))
+        .toEqual(["Me", "Research", "Bob"]);
+      const selected = menu.querySelector<SessionMenuItem>('wa-dropdown-item[aria-checked="true"]');
+      expect.soft(selected?.getAttribute("value")).toBe("assign-owner:human:profile-bob");
+      expect.soft(selected?.disabled).toBe(true);
+    };
     await waitForFast(() => expect(request).toHaveBeenCalledWith("users.list", {}));
-    expect(menuItemLabels(menuItem(menu, "Assign to…")).slice(0, 2)).toEqual(["Me", "Research"]);
     expect(menu.textContent).toContain("Loading");
+    expectCurrentOwner();
 
     pending.reject(new Error("Directory is temporarily unavailable."));
     await waitForFast(() =>
@@ -166,11 +182,16 @@ describe("session menu", () => {
         "Directory is temporarily unavailable.",
       ),
     );
-    expect(menuItemLabels(menuItem(menu, "Assign to…")).slice(0, 2)).toEqual(["Me", "Research"]);
-    request.mockImplementation(() => sessionOwnerProfiles("Ada", "Carol"));
+    expectCurrentOwner();
+    request.mockImplementation(() => sessionOwnerProfiles("Ada", "Bob", "Carol"));
     selectMenuValue(menu, "reload-owners");
     await waitForFast(() =>
-      expect(menuItemLabels(menuItem(menu, "Assign to…"))).toEqual(["Me", "Research", "Carol"]),
+      expect(menuItemLabels(menuItem(menu, "Assign to…"))).toEqual([
+        "Me",
+        "Research",
+        "Bob",
+        "Carol",
+      ]),
     );
     expect(menu.querySelector('[role="alert"]')).toBeNull();
     expect(request).toHaveBeenCalledTimes(2);

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -17,7 +17,7 @@ import {
   compactSessionMenuViewForValue,
   type CompactSessionMenuView,
 } from "./session-menu-compact.ts";
-import type { SessionOwnerOption } from "./session-owner-chip.ts";
+import type { SessionCreatedActor } from "./session-owner-chip.ts";
 
 /**
  * Worktree-session extras resolved lazily by the menu host after open.
@@ -62,9 +62,7 @@ class SessionMenu extends OpenClawLightDomElement {
   @property({ attribute: false }) deleteAllowed = false;
   @property({ attribute: false }) cloudWorkerStopAllowed = false;
   @property({ attribute: false }) groups: readonly string[] = [];
-  @property({ attribute: false }) ownerOptions: readonly SessionOwnerOption[] = [];
-  @property({ attribute: false }) selfOwner: SessionOwnerOption | null = null;
-  @property({ attribute: false }) currentOwnerId: string | null = null;
+  @property({ attribute: false }) currentOwner: SessionCreatedActor | null = null;
   @property({ attribute: false }) work: SessionMenuWork | null = null;
   @property({ attribute: false }) workboard: { captured: boolean; busy: boolean } | null = null;
   @property({ attribute: false }) onAction: (action: SessionMenuAction) => void = () => {};
@@ -86,9 +84,7 @@ class SessionMenu extends OpenClawLightDomElement {
       archiveAllowed: this.archiveAllowed,
       deleteAllowed: this.deleteAllowed,
       groups: this.groups,
-      ownerOptions: this.ownerOptions,
-      selfOwner: this.selfOwner,
-      currentOwnerId: this.currentOwnerId,
+      currentOwner: this.currentOwner,
       worktreePath: this.work?.worktreePath ?? null,
     }),
     (action) => this.onAction(action),
@@ -203,6 +199,7 @@ class SessionMenu extends OpenClawLightDomElement {
         placement="bottom-start"
         .distance=${0}
         aria-label=${menuLabel}
+        @wa-show=${this.managementActions.loadOwners}
         @wa-select=${this.handleSelect}
         @wa-after-hide=${this.handleAfterHide}
       >

--- a/ui/src/components/session-owner-chip.test.ts
+++ b/ui/src/components/session-owner-chip.test.ts
@@ -3,7 +3,7 @@
 import { afterEach, expect, it, vi } from "vitest";
 import type { SessionParticipant } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar-context.ts";
-import { listAssignableSessionOwners } from "./session-owner-chip.ts";
+import "./session-owner-chip.ts";
 
 afterEach(() => {
   document.body.replaceChildren();
@@ -93,65 +93,4 @@ it("renders the total participant count in the back slot for three identities", 
   expect(chip.querySelector(".session-owner-stack")?.getAttribute("aria-label")).toBe(
     "Owned by Ada · +2 more",
   );
-});
-
-it("treats a present owner facet as authoritative before adding self and configured agents", () => {
-  const facet = [
-    { type: "human" as const, id: "profile:channel:opaque", label: "Opaque Person" },
-    {
-      type: "agent" as const,
-      id: "facet-agent",
-      label: "Facet Agent",
-      avatarUrl: "/avatar/facet-agent",
-    },
-    { type: "agent" as const, id: "avatar-only", avatarUrl: "/avatar/avatar-only" },
-  ];
-
-  expect(
-    listAssignableSessionOwners({
-      facet,
-      agents: [
-        { id: "configured-agent", name: "Configured Agent" },
-        { id: "facet-agent", name: "Configured name" },
-        { id: "avatar-only", name: "Avatar Only" },
-      ],
-      self: { id: "profile-self", name: "Self" },
-    }),
-  ).toEqual([
-    {
-      type: "agent",
-      id: "avatar-only",
-      identity: { type: "agent", id: "avatar-only" },
-      label: "Avatar Only",
-      avatarUrl: "/avatar/avatar-only",
-    },
-    {
-      type: "agent",
-      id: "configured-agent",
-      identity: { type: "agent", id: "configured-agent" },
-      label: "Configured Agent",
-    },
-    {
-      type: "agent",
-      id: "facet-agent",
-      identity: { type: "agent", id: "facet-agent" },
-      label: "Facet Agent",
-      avatarUrl: "/avatar/facet-agent",
-    },
-    { type: "human", id: "profile:channel:opaque", label: "Opaque Person" },
-    {
-      type: "human",
-      id: "profile-self",
-      identity: { type: "profile", id: "profile-self" },
-      label: "Self",
-    },
-  ]);
-});
-
-it("does not reconstruct assignment candidates when the owner facet is absent", () => {
-  expect(
-    listAssignableSessionOwners({
-      facet: undefined,
-    }),
-  ).toEqual([]);
 });

--- a/ui/src/components/session-owner-chip.ts
+++ b/ui/src/components/session-owner-chip.ts
@@ -3,6 +3,7 @@ import { property } from "lit/decorators.js";
 import type { SessionParticipant } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
 import type { SessionCreatedActor as ProtocolSessionCreatedActor } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import type { SessionsListResult } from "../api/types.ts";
+import type { AuthenticatedUser } from "../app/user-profile.ts";
 import { t } from "../i18n/index.ts";
 import { takeGraphemes } from "../lib/graphemes.ts";
 import { resolveAvatar } from "../lib/identity-avatar.ts";
@@ -12,38 +13,18 @@ import "./viewer-facepile.ts";
 export type SessionCreatedActor = ProtocolSessionCreatedActor;
 export type SessionOwnerOption = NonNullable<SessionsListResult["owners"]>[number];
 
-export function listAssignableSessionOwners(params: {
-  facet?: SessionsListResult["owners"];
-  agents?: readonly { id: string; name?: string }[];
-  self?: { id: string; name?: string; avatarUrl?: string } | null;
-}): SessionOwnerOption[] {
-  const owners = new Map((params.facet ?? []).map((owner) => [owner.id, owner]));
-  if (params.self?.id && owners.get(params.self.id)?.type !== "agent") {
-    owners.set(params.self.id, {
-      type: "human",
-      id: params.self.id,
-      identity: { type: "profile", id: params.self.id },
-      ...(params.self.name ? { label: params.self.name } : {}),
-      ...(params.self.avatarUrl ? { avatarUrl: params.self.avatarUrl } : {}),
-    });
-  }
-  for (const agent of params.agents ?? []) {
-    const owner = owners.get(agent.id);
-    owners.set(agent.id, {
-      type: "agent",
-      id: agent.id,
-      identity: { type: "agent", id: agent.id },
-      ...(agent.name ? { label: agent.name } : {}),
-      // Keep the enriched identity, with the roster name when no identity name is configured.
-      ...(owner?.type === "agent" ? owner : {}),
-    });
-  }
-  return [...owners.values()].toSorted(
-    (left, right) =>
-      left.type.localeCompare(right.type) ||
-      (left.label ?? left.id).localeCompare(right.label ?? right.id) ||
-      left.id.localeCompare(right.id),
-  );
+export function sessionSelfOwner(
+  self: AuthenticatedUser | null | undefined,
+): SessionOwnerOption | null {
+  return self
+    ? {
+        type: "human",
+        id: self.id,
+        identity: { type: "profile", id: self.id },
+        label: self.name,
+        avatarUrl: self.avatarUrl,
+      }
+    : null;
 }
 
 export function renderSessionOwnerChip(

--- a/ui/src/components/session-owner-menu.ts
+++ b/ui/src/components/session-owner-menu.ts
@@ -1,96 +1,133 @@
-import { html, nothing } from "lit";
+import { ContextConsumer } from "@lit/context";
+import { initialState, Task, TaskStatus } from "@lit/task";
+import { html, nothing, type ReactiveControllerHost } from "lit";
 import { ref } from "lit/directives/ref.js";
+import type { UsersListResult } from "../../../packages/gateway-protocol/src/schema/users.js";
+import { buildControlUiUserAvatarPath } from "../../../src/gateway/control-ui-user-avatar-route.js";
+import { applicationContext } from "../app/context.ts";
 import { t } from "../i18n/index.ts";
+import { normalizeAgentTargetLabel } from "../lib/agents/display.ts";
+import { resolveAgentAvatarUrl } from "../lib/avatar.ts";
+import { formatUiError } from "../lib/format-error.ts";
+import { GatewayPageController } from "../lit/gateway-page-controller.ts";
 import { icons } from "./icons.ts";
-import { renderSessionOwnerAvatar, type SessionOwnerOption } from "./session-owner-chip.ts";
+import {
+  renderSessionOwnerAvatar,
+  sessionSelfOwner,
+  type SessionCreatedActor,
+  type SessionOwnerOption,
+} from "./session-owner-chip.ts";
 import { syncDropdownItemRadio } from "./web-awesome.ts";
 
-type SessionOwnerAssignment = Pick<SessionOwnerOption, "type" | "id">;
-
 type SessionOwnerMenuParams = {
-  ownerOptions: readonly SessionOwnerOption[];
-  selfOwner: SessionOwnerOption | null;
-  currentOwnerId: string | null;
+  currentOwner: SessionCreatedActor | null;
   disabled: boolean;
   disabledReason?: string;
 };
 
-export function sessionOwnerAssignmentFromMenuValue(value: string): SessionOwnerAssignment | null {
-  if (!value.startsWith("assign-owner:")) {
-    return null;
-  }
-  const [, type, encodedId] = value.split(":");
-  const id = encodedId ? decodeURIComponent(encodedId) : "";
-  return (type === "human" || type === "agent") && id ? { type, id } : null;
-}
+/** Assignment uses the Gateway directory, independently of session filters and presence. */
+export class SessionOwnerMenu {
+  private readonly context;
+  private readonly profiles;
+  private opened = false;
 
-export function renderSessionOwnerAssignmentOptions(
-  params: SessionOwnerMenuParams,
-  inline = false,
-) {
-  const title = params.disabledReason ?? nothing;
-  const selfChecked = params.selfOwner?.id === params.currentOwnerId;
-  const ownerOptions = params.ownerOptions.filter(
-    (owner) => owner.type !== params.selfOwner?.type || owner.id !== params.selfOwner.id,
-  );
-  return html`
-    ${params.selfOwner
-      ? html`<wa-dropdown-item
-          slot=${inline ? nothing : "submenu"}
-          class="session-menu__item"
-          value=${`assign-owner:${params.selfOwner.type}:${encodeURIComponent(params.selfOwner.id)}`}
-          role="menuitemradio"
-          aria-checked=${String(selfChecked)}
-          ${ref((element) => syncDropdownItemRadio(element, selfChecked))}
-          ?disabled=${params.disabled || selfChecked}
-          title=${title}
-        >
-          <span slot="icon" class="session-menu__icon" aria-hidden="true"
-            >${renderSessionOwnerAvatar(params.selfOwner)}</span
-          >
-          <span class="session-menu__text">${t("sessionsView.assignToMe")}</span>
-          ${selfChecked
-            ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
-                >${icons.check}</span
-              >`
-            : nothing}
-        </wa-dropdown-item>`
-      : nothing}
-    ${ownerOptions.map((owner) => {
-      const checked = owner.id === params.currentOwnerId;
-      return html`
-        <wa-dropdown-item
-          slot=${inline ? nothing : "submenu"}
+  constructor(host: ReactiveControllerHost & HTMLElement) {
+    this.context = new ContextConsumer(host, { context: applicationContext, subscribe: true });
+    // Bind the Gateway before Task reads its epoch, so reconnects and source replacements
+    // retire stale directory replies before the menu renders.
+    const connection = new GatewayPageController(host, {
+      getGateway: () => this.context.value?.gateway,
+    });
+    this.profiles = new Task(host, {
+      args: () => [connection.epoch, this.opened, connection.capture()?.client] as const,
+      task: ([, opened, client]) =>
+        opened && client ? client.request<UsersListResult>("users.list", {}) : initialState,
+    });
+  }
+
+  readonly load = () => {
+    this.opened = true;
+    void this.profiles.run();
+  };
+
+  render(params: SessionOwnerMenuParams, inline = false) {
+    const context = this.context.value;
+    const self = sessionSelfOwner(context?.gateway.snapshot.selfUser);
+    const profiles =
+      this.profiles.status === TaskStatus.COMPLETE ? (this.profiles.value?.profiles ?? []) : [];
+    const owners: SessionOwnerOption[] = profiles
+      .filter((profile) => !profile.mergedInto && profile.id !== self?.id)
+      .map((profile) => ({
+        type: "human",
+        id: profile.id,
+        identity: { type: "profile", id: profile.id },
+        label:
+          profile.displayName?.trim() ||
+          profile.githubIdentity?.login ||
+          profile.emails[0] ||
+          profile.id,
+        avatarUrl: buildControlUiUserAvatarPath(profile.id, profile.updatedAt),
+      }));
+    for (const agent of context?.agents.state.agentsList?.agents ?? []) {
+      const identity = context?.agentIdentity.get(agent.id);
+      owners.push({
+        type: "agent",
+        id: agent.id,
+        identity: { type: "agent", id: agent.id },
+        label: normalizeAgentTargetLabel(agent, identity),
+        avatarUrl: resolveAgentAvatarUrl(agent, identity) ?? undefined,
+      });
+    }
+    owners.sort(
+      (left, right) =>
+        left.type.localeCompare(right.type) ||
+        (left.label ?? left.id).localeCompare(right.label ?? right.id) ||
+        left.id.localeCompare(right.id),
+    );
+    if (self) {
+      owners.unshift(self);
+    }
+    const slot = inline ? nothing : "submenu";
+    return html`
+      ${owners.map((owner) => {
+        const checked =
+          owner.type === params.currentOwner?.type &&
+          owner.id === (params.currentOwner.identity?.id ?? params.currentOwner.id);
+        return html`<wa-dropdown-item
+          slot=${slot}
           class="session-menu__item"
           value=${`assign-owner:${owner.type}:${encodeURIComponent(owner.id)}`}
           role="menuitemradio"
           aria-checked=${String(checked)}
           ${ref((element) => syncDropdownItemRadio(element, checked))}
           ?disabled=${params.disabled || checked}
-          title=${title}
+          title=${params.disabledReason ?? nothing}
         >
           <span slot="icon" class="session-menu__icon" aria-hidden="true"
             >${renderSessionOwnerAvatar(owner)}</span
           >
-          <span class="session-menu__text">${owner.label ?? owner.id}</span>
+          <span class="session-menu__text"
+            >${owner === self ? t("sessionsView.assignToMe") : (owner.label ?? owner.id)}</span
+          >
           ${checked
             ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
                 >${icons.check}</span
               >`
             : nothing}
-        </wa-dropdown-item>
-      `;
-    })}
-  `;
-}
-
-export function renderSessionOwnerAssignmentMenu(params: SessionOwnerMenuParams) {
-  const title = params.disabledReason ?? nothing;
-  return params.selfOwner || params.ownerOptions.length > 0
-    ? html`<wa-dropdown-item class="session-menu__item" ?disabled=${params.disabled} title=${title}>
-        <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.users}</span>
-        <span class="session-menu__text">${t("sessionsView.assignTo")}</span>
-        ${renderSessionOwnerAssignmentOptions(params)}
-      </wa-dropdown-item>`
-    : nothing;
+        </wa-dropdown-item>`;
+      })}
+      ${this.profiles.render({
+        pending: () =>
+          html`<wa-dropdown-item slot=${slot} disabled>${t("common.loading")}</wa-dropdown-item>`,
+        error: (error) => html`
+          <div slot=${slot} class="session-menu__info" role="alert">
+            ${formatUiError(error, t("common.failed"))}
+          </div>
+          <wa-dropdown-item slot=${slot} class="session-menu__item" value="reload-owners"
+            >${t("common.retry")}</wa-dropdown-item
+          >
+        `,
+      })}
+    `;
+  }
 }

--- a/ui/src/components/session-owner-menu.ts
+++ b/ui/src/components/session-owner-menu.ts
@@ -53,21 +53,27 @@ export class SessionOwnerMenu {
   render(params: SessionOwnerMenuParams, inline = false) {
     const context = this.context.value;
     const self = sessionSelfOwner(context?.gateway.snapshot.selfUser);
-    const profiles =
-      this.profiles.status === TaskStatus.COMPLETE ? (this.profiles.value?.profiles ?? []) : [];
-    const owners: SessionOwnerOption[] = profiles
-      .filter((profile) => !profile.mergedInto && profile.id !== self?.id)
-      .map((profile) => ({
-        type: "human",
-        id: profile.id,
-        identity: { type: "profile", id: profile.id },
-        label:
-          profile.displayName?.trim() ||
-          profile.githubIdentity?.login ||
-          profile.emails[0] ||
-          profile.id,
-        avatarUrl: buildControlUiUserAvatarPath(profile.id, profile.updatedAt),
-      }));
+    const currentOwner = params.currentOwner;
+    const currentOwnerId = currentOwner?.identity?.id ?? currentOwner?.id;
+    // The session already records its owner; directory availability must not erase the checked row.
+    const owners: SessionOwnerOption[] =
+      this.profiles.status === TaskStatus.COMPLETE
+        ? (this.profiles.value?.profiles ?? [])
+            .filter((profile) => !profile.mergedInto && profile.id !== self?.id)
+            .map((profile) => ({
+              type: "human",
+              id: profile.id,
+              identity: { type: "profile", id: profile.id },
+              label:
+                profile.displayName?.trim() ||
+                profile.githubIdentity?.login ||
+                profile.emails[0] ||
+                profile.id,
+              avatarUrl: buildControlUiUserAvatarPath(profile.id, profile.updatedAt),
+            }))
+        : currentOwner?.type === "human" && currentOwnerId && currentOwnerId !== self?.id
+          ? [{ ...currentOwner, type: currentOwner.type, id: currentOwnerId }]
+          : [];
     for (const agent of context?.agents.state.agentsList?.agents ?? []) {
       const identity = context?.agentIdentity.get(agent.id);
       owners.push({
@@ -90,9 +96,7 @@ export class SessionOwnerMenu {
     const slot = inline ? nothing : "submenu";
     return html`
       ${owners.map((owner) => {
-        const checked =
-          owner.type === params.currentOwner?.type &&
-          owner.id === (params.currentOwner.identity?.id ?? params.currentOwner.id);
+        const checked = owner.type === currentOwner?.type && owner.id === currentOwnerId;
         return html`<wa-dropdown-item
           slot=${slot}
           class="session-menu__item"

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -32,7 +32,6 @@ import {
 import "../styles/sidebar-menus.css";
 import { sessionMenuReasons } from "./session-menu-access.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
-import { listAssignableSessionOwners } from "./session-owner-chip.ts";
 import {
   isSidebarAttentionDismissed,
   isUpdateAttentionForced,
@@ -222,18 +221,6 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
     isGatewayMethodAdvertised(context.gateway.snapshot, cloudWorkerStopAction.method) === true,
   );
   const selfUser = context?.gateway.snapshot.selfUser ?? null;
-  const sessionsResult = [
-    host.sessionData.sessionsResult,
-    ...Object.values(host.sessionData.sessionResultsByAgent),
-  ].find((result) => result?.sessions.some((row) => row.key === session.key));
-  const ownerOptions = listAssignableSessionOwners({
-    facet: sessionsResult?.owners,
-    agents: context?.agents.state.agentsList?.agents,
-    self: selfUser,
-  });
-  const selfOwner = selfUser
-    ? (ownerOptions.find((owner) => owner.type === "human" && owner.id === selfUser.id) ?? null)
-    : null;
   const assignmentAccess = host.readSessionMutationAccess({
     method: "sessions.assignOwner",
     params: { key: session.key, owner: { type: "human", id: selfUser?.id ?? "profile" } },
@@ -282,9 +269,7 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
         .deleteAllowed=${deleteAllowed}
         .cloudWorkerStopAllowed=${cloudWorkerStopAllowed}
         .groups=${host.knownSessionGroups()}
-        .ownerOptions=${ownerOptions}
-        .selfOwner=${selfOwner}
-        .currentOwnerId=${session.owner?.actor.id ?? null}
+        .currentOwner=${session.owner?.actor ?? null}
         .work=${batchRows ? null : controller.sessionMenuWork}
         .workboard=${null}
         .onClose=${() => {

--- a/ui/src/e2e/session-owner-assignment.e2e.test.ts
+++ b/ui/src/e2e/session-owner-assignment.e2e.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { Page } from "playwright";
 import { expect as expectBrowser } from "playwright/test";
 import { beforeEach, expect, it } from "vitest";
+import type { UsersListResult } from "../../../packages/gateway-protocol/src/schema/users.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiBundledGatewayUrl,
@@ -17,7 +18,7 @@ const suite = createControlUiE2eSuite({
   name: "Control UI session owner assignment mocked Gateway E2E",
   startServerBeforeBrowser: true,
 });
-const sessionKey = "agent:main:owner-outcome";
+const sessionKey = "agent:main:dashboard:owner-outcome";
 const proofPhase = process.env.OPENCLAW_OWNER_ASSIGNMENT_PROOF_PHASE;
 let proofDir: string;
 beforeEach(() => {
@@ -26,13 +27,12 @@ beforeEach(() => {
   }
 });
 
-function sessionsListResponse() {
+function sessionsListResponse(archived = false) {
   return {
     count: 2,
     owners: [
       { type: "human" as const, id: "profile-ada", label: "Ada" },
       { type: "human" as const, id: "profile-bob", label: "Bob" },
-      { type: "human" as const, id: "profile-carol", label: "Carol" },
     ],
     defaults: { contextTokens: null, model: null, modelProvider: null },
     path: "",
@@ -49,6 +49,7 @@ function sessionsListResponse() {
         key: sessionKey,
         kind: "direct",
         label: "Owner outcome",
+        archived,
         createdActor: { type: "human", id: "profile-bob", label: "Bob" },
         owner: { actor: { type: "human", id: "profile-bob", label: "Bob" } },
         updatedAt: 1,
@@ -58,12 +59,34 @@ function sessionsListResponse() {
   };
 }
 
-async function installOwnerGateway(page: Page) {
+function directoryResponse(extraNames: string[]): UsersListResult {
+  return {
+    profiles: ["Ada", "Bob", "Carol", ...extraNames].map((displayName) => ({
+      id: `profile-${displayName.toLowerCase().replaceAll(" ", "-")}`,
+      displayName,
+      avatarMime: displayName === "Ada" ? "image/png" : null,
+      mergedInto: null,
+      createdAt: 1,
+      updatedAt: 1,
+      emails: [],
+      githubIdentity: null,
+      hasAvatar: displayName === "Ada",
+    })),
+  };
+}
+
+async function installOwnerGateway(page: Page, archived = false, extraNames: string[] = []) {
   await routeAvatarFixtures(page, [{ id: "profile-ada", background: "#7c3aed", label: "A" }]);
+  const result = sessionsListResponse(archived);
   const gateway = await installMockGateway(page, {
-    featureMethods: ["chat.startup", "sessions.assignOwner"],
+    featureMethods: ["chat.startup", "sessions.assignOwner", "users.list"],
     historyMessages: [{ role: "assistant", content: "Owner assignment outcome proof." }],
-    methodResponses: { "sessions.list": sessionsListResponse() },
+    methodResponses: {
+      "sessions.list": archived
+        ? { ...result, count: 1, sessions: result.sessions.filter((row) => row.key !== sessionKey) }
+        : result,
+      "users.list": directoryResponse(extraNames),
+    },
     operatorScopes: ["operator.read", "operator.write"],
     presenceUsers: [
       {
@@ -73,9 +96,15 @@ async function installOwnerGateway(page: Page) {
         avatarUrl: "/api/users/profile-ada/avatar?v=1",
       },
     ],
+    sessions: result.sessions,
+    sessionArchiveFiltering: true,
     sessionKey,
   });
-  await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+  await page.goto(
+    archived
+      ? `${suite.server.baseUrl}chat?session=${encodeURIComponent(sessionKey)}`
+      : controlUiSessionUrl(suite.server.baseUrl, sessionKey),
+  );
   await page.getByText("Owner assignment outcome proof.", { exact: true }).waitFor();
   await gateway.deferNext("sessions.assignOwner");
   return gateway;
@@ -174,8 +203,8 @@ suite.define(() => {
         const ownerItems = assignTo.locator(
           ':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text',
         );
-        await expectBrowser(ownerItems).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);
         await captureProof(page, "assignment-submenu");
+        await expectBrowser(ownerItems).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);
         const selfAvatar = assignTo
           .getByRole("menuitemradio", { name: "Me", exact: true })
           .locator("openclaw-viewer-avatar img");
@@ -237,6 +266,67 @@ suite.define(() => {
     );
   });
 
+  it.each([
+    { surface: "sidebar", width: 1280 },
+    { surface: "header", width: 1280 },
+    { surface: "compact header", width: 390 },
+  ])(
+    "assigns an archived session to an offline teammate from the $surface",
+    async ({ surface, width }) => {
+      await suite.withPage(
+        {
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 900, width },
+        },
+        async ({ page }) => {
+          const extraNames =
+            surface === "sidebar"
+              ? Array.from(
+                  { length: 30 },
+                  (_, index) => `Teammate ${String(index + 1).padStart(2, "0")}`,
+                )
+              : [];
+          const gateway = await installOwnerGateway(page, true, extraNames);
+          const activePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--active");
+          await expectBrowser(activePane.locator(".agent-chat__disabled-banner")).toContainText(
+            "This session is archived.",
+          );
+          if (surface === "sidebar") {
+            const row = page.locator(`[data-session-key="${sessionKey}"]`);
+            await row.hover();
+            await row
+              .getByRole("button", { name: "Open session menu: Owner outcome", exact: true })
+              .click();
+          } else {
+            await activePane.getByRole("button", { name: "Actions for Owner outcome" }).click();
+          }
+          const assignTo = page.getByRole("menuitem", { name: "Assign to…", exact: true });
+          if (surface === "compact header") {
+            await assignTo.click();
+          } else {
+            await assignTo.hover();
+          }
+          await page.getByRole("menuitemradio", { name: "Me", exact: true }).waitFor();
+          await captureProof(page, `archived-${surface.replaceAll(" ", "-")}`);
+          await expectBrowser(
+            page.getByRole("menuitemradio").locator(":scope > .session-menu__text"),
+          ).toHaveText(["Me", "OpenClaw", "Bob", "Carol", ...extraNames]);
+          const target = extraNames.at(-1) ?? "Carol";
+          const owner = page.getByRole("menuitemradio", { name: target, exact: true });
+          await owner.scrollIntoViewIfNeeded();
+          await expectBrowser(owner).toBeInViewport();
+          await captureProof(page, `archived-${surface.replaceAll(" ", "-")}-selected`);
+          await owner.click();
+          await expectAssignmentRequest(
+            gateway,
+            `profile-${target.toLowerCase().replaceAll(" ", "-")}`,
+          );
+        },
+      );
+    },
+  );
+
   it("themes the assignee submenu with the active palette", async () => {
     await suite.withPage(
       {
@@ -274,7 +364,7 @@ suite.define(() => {
     );
   });
 
-  it("keeps a rejected header owner assignment visible", async () => {
+  it("retries the header directory in place and keeps a rejected assignment visible", async () => {
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -286,7 +376,22 @@ suite.define(() => {
         const gateway = await installOwnerGateway(page);
         const activePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--active");
         const menuTrigger = activePane.getByRole("button", { name: "Actions for Owner outcome" });
+        await gateway.deferNext("users.list");
         await menuTrigger.press("Enter");
+        const assignTo = page.getByRole("menuitem", { name: "Assign to…", exact: true });
+        await assignTo.hover();
+        await gateway.waitForRequest("users.list");
+        const directoryError = "The team directory is temporarily unavailable.";
+        await gateway.rejectDeferred("users.list", {
+          code: "UNAVAILABLE",
+          message: directoryError,
+        });
+        await expectBrowser(assignTo.getByRole("alert")).toContainText(directoryError);
+        await assignTo.getByRole("menuitem", { name: "Retry", exact: true }).click();
+        await expectBrowser(menuTrigger).toHaveAttribute("aria-expanded", "true");
+        await expectBrowser(
+          assignTo.getByRole("menuitemradio", { name: "Carol", exact: true }),
+        ).toBeVisible();
         await chooseMe(page);
         await expectAssignmentRequest(gateway);
 

--- a/ui/src/e2e/session-owner-assignment.e2e.test.ts
+++ b/ui/src/e2e/session-owner-assignment.e2e.test.ts
@@ -381,17 +381,38 @@ suite.define(() => {
         const assignTo = page.getByRole("menuitem", { name: "Assign to…", exact: true });
         await assignTo.hover();
         await gateway.waitForRequest("users.list");
+        const expectCurrentOwner = async (phase: string) => {
+          await captureProof(page, `header-directory-${phase}`);
+          expect
+            .soft(
+              await assignTo.getByRole("menuitemradio", { name: "Bob", exact: true }).isVisible(),
+            )
+            .toBe(true);
+          const selectedOwners = await assignTo
+            .getByRole("menuitemradio", { checked: true })
+            .evaluateAll((owners) =>
+              owners.map((owner) => ({
+                label: owner.querySelector(".session-menu__text")?.textContent?.trim(),
+                disabled: owner.hasAttribute("disabled"),
+              })),
+            );
+          expect.soft(selectedOwners).toEqual([{ label: "Bob", disabled: true }]);
+        };
+        await expectBrowser(assignTo).toContainText("Loading");
+        await expectCurrentOwner("pending");
         const directoryError = "The team directory is temporarily unavailable.";
         await gateway.rejectDeferred("users.list", {
           code: "UNAVAILABLE",
           message: directoryError,
         });
         await expectBrowser(assignTo.getByRole("alert")).toContainText(directoryError);
+        await expectCurrentOwner("failed");
         await assignTo.getByRole("menuitem", { name: "Retry", exact: true }).click();
         await expectBrowser(menuTrigger).toHaveAttribute("aria-expanded", "true");
         await expectBrowser(
           assignTo.getByRole("menuitemradio", { name: "Carol", exact: true }),
         ).toBeVisible();
+        await expectBrowser(assignTo.getByRole("menuitemradio")).toHaveCount(4);
         await chooseMe(page);
         await expectAssignmentRequest(gateway);
 

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -14,7 +14,6 @@ import {
   type PersonActivityRouting,
 } from "../../components/person-activity-link.ts";
 import { sessionMenuReasons } from "../../components/session-menu-access.ts";
-import { listAssignableSessionOwners } from "../../components/session-owner-chip.ts";
 import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
 import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
@@ -427,16 +426,6 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       (user) =>
         presenceMatchesProfile(user, renderedOwnerIdentity) && user.watchedSessions.includes(key),
     );
-    const ownerOptions = listAssignableSessionOwners({
-      facet: result?.owners,
-      agents: this.context.agents.state.agentsList?.agents,
-      self: sharingSnapshot.selfUser ?? null,
-    });
-    const selfOwner = sharingSnapshot.selfUser
-      ? (ownerOptions.find(
-          (owner) => owner.type === "human" && owner.id === sharingSnapshot.selfUser?.id,
-        ) ?? null)
-      : null;
     const header = renderChatPaneHeader({
       paneId: this.paneId,
       narrow: this.narrow,
@@ -560,9 +549,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
               .statusActions=${this.compactHeaderStatusActions()}
               .sharing=${sharing}
               .groups=${knownGroups}
-              .ownerOptions=${ownerOptions}
-              .selfOwner=${selfOwner}
-              .currentOwnerId=${row.owner?.actor.id ?? null}
+              .currentOwner=${row.owner?.actor ?? null}
               .actionDisabledReasons=${actionDisabledReasons}
               .forkDisabled=${this.state.sessionsLoading || row.modelSelectionLocked === true}
               .forkFromLastCompleted=${row.hasActiveRun === true}

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -3,15 +3,19 @@
 import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../../api/gateway.ts";
+import type { RouteId } from "../../../app-route-paths.ts";
+import type { ApplicationContext } from "../../../app/context.ts";
 import type { UiSettings } from "../../../app/settings.ts";
 import { icons } from "../../../components/icons.ts";
 import type { SessionMenuData } from "../../../components/session-menu-actions.ts";
 import type { SessionOwnerOption } from "../../../components/session-owner-chip.ts";
 import type { SessionCapability } from "../../../lib/sessions/index.ts";
+import { createApplicationContextProvider } from "../../../test-helpers/application-context.ts";
 import {
   clearNativeGatewayTestState,
   setNativeGatewayTestState,
 } from "../../../test-helpers/native-gateways.ts";
+import { createSessionOwnerMenuHarness } from "../../../test-helpers/session-owner-menu.ts";
 import {
   createGatewayBrowserClientFixture,
   createSessionCapabilityFixture,
@@ -74,9 +78,8 @@ async function mountMenu(
     layoutActions?: HeaderMenuQuickAction[];
     statusActions?: HeaderMenuStatusAction[];
     sharing?: ChatSessionSharingProps | null;
-    ownerOptions?: SessionOwnerOption[];
-    selfOwner?: SessionOwnerOption | null;
-    currentOwnerId?: string | null;
+    context?: ApplicationContext<RouteId>;
+    currentOwner?: SessionOwnerOption | null;
     actionDisabledReasons?: Partial<Record<HeaderMenuActionKind, string>>;
     forkDisabled?: boolean;
     forkFromLastCompleted?: boolean;
@@ -88,7 +91,9 @@ async function mountMenu(
     onAction?: (action: HeaderMenuAction) => void;
   } = {},
 ): Promise<HeaderMenuElement> {
-  const container = document.createElement("div");
+  const container = options.context
+    ? createApplicationContextProvider(options.context)
+    : document.createElement("div");
   containers.push(container);
   document.body.append(container);
   render(
@@ -118,9 +123,7 @@ async function mountMenu(
       .statusActions=${options.statusActions ?? []}
       .sharing=${options.sharing ?? null}
       .groups=${["Projects"]}
-      .ownerOptions=${options.ownerOptions ?? []}
-      .selfOwner=${options.selfOwner ?? null}
-      .currentOwnerId=${options.currentOwnerId ?? null}
+      .currentOwner=${options.currentOwner ?? null}
       .actionDisabledReasons=${options.actionDisabledReasons ?? {}}
       .forkDisabled=${options.forkDisabled ?? false}
       .forkFromLastCompleted=${options.forkFromLastCompleted ?? false}
@@ -238,6 +241,7 @@ describe("chat header session menu", () => {
       "Archive session",
       "Icon & color",
       "Move to group",
+      "Assign to…",
       "Fork conversation",
       "Copy",
       "Open in",
@@ -458,12 +462,10 @@ describe("chat header session menu", () => {
 
   it("offers self and named owner assignment in one submenu", async () => {
     const onAction = vi.fn<(action: HeaderMenuAction) => void>();
-    const ada = { type: "human", id: "profile-ada", label: "Ada" } as const;
-    const research = { type: "agent", id: "research:one", label: "Research" } as const;
+    const { context } = createSessionOwnerMenuHarness();
     const menu = await mountMenu({
-      ownerOptions: [ada, research],
-      selfOwner: ada,
-      currentOwnerId: research.id,
+      context,
+      currentOwner: { type: "agent", id: "research:one" },
       onAction,
     });
 
@@ -496,8 +498,7 @@ describe("chat header session menu", () => {
     const onOpenCommandPalette = vi.fn();
     const onSettingsChange = vi.fn<(patch: Partial<UiSettings>) => void>();
     const onAction = vi.fn<(action: HeaderMenuAction) => void>();
-    const ada = { type: "human", id: "profile-ada", label: "Ada" } as const;
-    const research = { type: "agent", id: "research:one", label: "Research" } as const;
+    const { context } = createSessionOwnerMenuHarness();
     const menu = await mountMenu({
       compact: true,
       worktreePath: "/work/openclaw",
@@ -527,9 +528,8 @@ describe("chat header session menu", () => {
           onActivate: showAccess,
         },
       ],
-      ownerOptions: [ada, research],
-      selfOwner: ada,
-      currentOwnerId: research.id,
+      context,
+      currentOwner: { type: "agent", id: "research:one" },
       onOpenCommandPalette,
       onSettingsChange,
       onAction,

--- a/ui/src/pages/chat/components/chat-header-session-menu.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.ts
@@ -14,7 +14,7 @@ import {
   renderCompactSessionMenuFrame,
   type CompactSessionMenuView,
 } from "../../../components/session-menu-compact.ts";
-import type { SessionOwnerOption } from "../../../components/session-owner-chip.ts";
+import type { SessionCreatedActor } from "../../../components/session-owner-chip.ts";
 import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import {
@@ -73,9 +73,7 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
   @property({ attribute: false }) statusActions: HeaderMenuStatusAction[] = [];
   @property({ attribute: false }) sharing: ChatSessionSharingProps | null = null;
   @property({ attribute: false }) groups: readonly string[] = [];
-  @property({ attribute: false }) ownerOptions: readonly SessionOwnerOption[] = [];
-  @property({ attribute: false }) selfOwner: SessionOwnerOption | null = null;
-  @property({ attribute: false }) currentOwnerId: string | null = null;
+  @property({ attribute: false }) currentOwner: SessionCreatedActor | null = null;
   @property({ attribute: false }) actionDisabledReasons: Partial<
     Record<HeaderMenuActionKind, string>
   > = {};
@@ -105,9 +103,7 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
       archiveAllowed: this.archiveAllowed,
       deleteAllowed: this.deleteAllowed,
       groups: this.groups,
-      ownerOptions: this.ownerOptions,
-      selfOwner: this.selfOwner,
-      currentOwnerId: this.currentOwnerId,
+      currentOwner: this.currentOwner,
       worktreePath: this.worktreePath,
     }),
     (action) => this.onAction(action),
@@ -198,6 +194,7 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
       return;
     }
     if (this.managementActions.handleSelect(value)) {
+      event.preventDefault();
       return;
     }
     if (value === "continue-in-terminal" && !this.actionDisabled(value)) {
@@ -392,6 +389,7 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
 
   private readonly handleShow = () => {
     this.compactView = "root";
+    this.managementActions.loadOwners();
     this.onOpen();
   };
 

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -930,10 +930,6 @@ openclaw-chat-pane {
   background: var(--wa-color-surface-raised);
 }
 
-.chat-header-session-menu--compact .session-menu__chevron {
-  display: inline-flex;
-}
-
 .chat-header-session-menu--compact::part(menu) {
   max-height: calc(100dvh - 16px);
   overflow-y: auto;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2661,6 +2661,11 @@ wa-dropdown-item.session-menu__item {
   gap: 0;
 }
 
+.session-menu__item::part(submenu) {
+  max-height: calc(100dvh - 16px);
+  overflow: auto;
+}
+
 /* The icon slot wrapper is a block-level flex item, so its inline child sits on
    the row's text baseline ~2px above the label's optical centre. */
 wa-dropdown-item.session-menu__item::part(icon) {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2567,10 +2567,6 @@ wa-dropdown.session-menu::part(menu) {
   background: var(--wa-color-surface-raised);
 }
 
-.session-menu--compact .session-menu__chevron {
-  display: inline-flex;
-}
-
 html[dir="rtl"] .session-menu__chevron,
 html[dir="rtl"] .session-menu__back > .session-menu__icon {
   transform: scaleX(-1);
@@ -2659,11 +2655,6 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
    that margin as the icon column instead of stacking into a ~17px gutter. */
 wa-dropdown-item.session-menu__item {
   gap: 0;
-}
-
-.session-menu__item::part(submenu) {
-  max-height: calc(100dvh - 16px);
-  overflow: auto;
 }
 
 /* The icon slot wrapper is a block-level flex item, so its inline child sits on

--- a/ui/src/styles/sidebar-menus.css
+++ b/ui/src/styles/sidebar-menus.css
@@ -28,6 +28,10 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
 wa-dropdown-item.sidebar-session-owner-submenu::part(submenu) {
   width: min(220px, calc(100dvw - 16px));
   max-width: calc(100dvw - 16px);
+}
+
+wa-dropdown-item.sidebar-session-owner-submenu::part(submenu),
+.session-menu__item::part(submenu) {
   max-height: calc(100dvh - 16px);
   overflow: auto;
 }

--- a/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
@@ -20,6 +20,7 @@ import {
   installDialogPolyfill,
   waitForConfirmDialogActions,
 } from "../modal-dialog.ts";
+import { sessionOwnerProfiles } from "../session-owner-menu.ts";
 import { waitForFast } from "../wait-for.ts";
 
 describe("AppSidebar session mutation feedback", () => {
@@ -33,7 +34,10 @@ describe("AppSidebar session mutation feedback", () => {
     restoreDialogPolyfill();
   });
 
-  async function mountMutationHarness(client: GatewayBrowserClient = {} as GatewayBrowserClient) {
+  async function mountMutationHarness(
+    client: GatewayBrowserClient = {} as GatewayBrowserClient,
+    directory = sessionOwnerProfiles(),
+  ) {
     const harness = createSessionsHarness("main", [
       "agent:main:main",
       "agent:main:a",
@@ -46,6 +50,9 @@ describe("AppSidebar session mutation feedback", () => {
       ...args: Parameters<GatewayBrowserClient["request"]>
     ): Promise<T> => {
       const [method, params] = args;
+      if (method === "users.list") {
+        return Promise.resolve(directory as T);
+      }
       if (method === "sessions.patchMany") {
         const request = params as {
           targets: Array<{ key: string; agentId?: string }>;
@@ -175,9 +182,10 @@ describe("AppSidebar session mutation feedback", () => {
         },
       };
     });
-    const { gateway, harness, sidebar } = await mountMutationHarness({
-      request,
-    } as unknown as GatewayBrowserClient);
+    const { gateway, harness, sidebar } = await mountMutationHarness(
+      { request } as unknown as GatewayBrowserClient,
+      sessionOwnerProfiles("Ada", "Bob"),
+    );
     gateway.publish({
       selfUser: { id: "profile-ada", name: "Ada" },
       hello: gatewayHelloForMethods(["sessions.assignOwner"], ["operator.write"]),
@@ -197,6 +205,7 @@ describe("AppSidebar session mutation feedback", () => {
     await sidebar.updateComplete;
 
     const menu = await openSessionMenu(sidebar, row.key);
+    await waitForFast(() => expect(menu.textContent).toContain("Bob"));
     expect(
       Array.from(menu.querySelectorAll<HTMLElement>(":scope > wa-dropdown > wa-dropdown-item"))
         .map((item) => item.querySelector(".session-menu__text")?.textContent?.trim())

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1913,6 +1913,8 @@ function installControlUiMockGateway(
           shared: { source: "system-configured", accountId: 1, login: "system-bot" },
           pendingPersonal: null,
         };
+      case "users.list":
+        return { profiles: [] };
       case "users.github.status":
       case "tools.github.status": {
         const system = {

--- a/ui/src/test-helpers/session-owner-menu.ts
+++ b/ui/src/test-helpers/session-owner-menu.ts
@@ -1,0 +1,39 @@
+import type { UsersListResult } from "../../../packages/gateway-protocol/src/schema/users.js";
+import { createContext, createGatewayHarness, createSessions } from "./app-sidebar.ts";
+import {
+  createGatewayRequestMock,
+  createTestGatewayClient,
+  type GatewayRequestHandler,
+} from "./gateway-client.ts";
+
+export function sessionOwnerProfiles(...names: string[]): UsersListResult {
+  return {
+    profiles: names.map((displayName) => ({
+      id: `profile-${displayName.toLowerCase().replaceAll(" ", "-")}`,
+      displayName,
+      avatarMime: null,
+      mergedInto: null,
+      createdAt: 1,
+      updatedAt: 1,
+      emails: [],
+      githubIdentity: null,
+      hasAvatar: false,
+    })),
+  };
+}
+
+export function createSessionOwnerMenuHarness(
+  requestHandler: GatewayRequestHandler = () => sessionOwnerProfiles("Ada"),
+  agentName = "Research",
+) {
+  const request = createGatewayRequestMock(requestHandler);
+  const gateway = createGatewayHarness(createTestGatewayClient(request));
+  gateway.publish({ selfUser: { id: "profile-ada", name: "Ada" } });
+  const context = createContext(gateway.gateway, createSessions("main", []), {
+    defaultId: "main",
+    mainKey: "main",
+    scope: "per-sender",
+    agents: [{ id: "research:one", name: agentName }],
+  });
+  return { context, request, publish: gateway.publish };
+}

--- a/ui/src/test-helpers/session-owner-menu.ts
+++ b/ui/src/test-helpers/session-owner-menu.ts
@@ -35,5 +35,5 @@ export function createSessionOwnerMenuHarness(
     scope: "per-sender",
     agents: [{ id: "research:one", name: agentName }],
   });
-  return { context, request, publish: gateway.publish };
+  return { context, request, publish: gateway.publish.bind(gateway) };
 }


### PR DESCRIPTION
Closes #136821

## What Problem This Solves

Fixes an issue where users assigning a conversation could not choose registered teammates who were offline or had never owned a session. An archived conversation selected outside the active session list could reduce the sidebar submenu to just Me and configured agents.

## Why This Change Was Made

Both sidebar and chat-header menus now share a directory-backed owner menu using the existing `users.list` API. Session-owner facets remain session filters; they no longer define who can receive an assignment. The refactor removes the duplicate caller projections and sole-use assignment parser, and uses the existing Gateway lifecycle and Lit Task arguments to retire stale responses. Shared menu scrolling lives with the menu stylesheet, and redundant compact-chevron styles are removed.

Production code is net **−20 lines** (+174/−194); tests/test support are counted separately. No Gateway API, persistence schema, permissions, or configuration changes.

## User Impact

Registered people are available regardless of presence, session filters, or archive status. Me, configured agents, and the current owner remain available while people load; directory failures show an in-place Retry action. Long submenus scroll, blank display names use readable fallbacks, and current-owner selection preserves namespaces and canonical identities after account merges.

## Evidence

The regression failed before the change because Carol existed only in the user directory and was missing from the menu. The revised tests cover active and archived conversations across sidebar, header, and compact menus, including the last person in a long roster, keyboard assignment, Retry, reconnects, Gateway replacement, merged profiles, and person/agent ID collisions.

- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33716159743) passed: 122 successful jobs, 12 skips, zero failures.
- 399 focused unit tests passed; 21 browser E2E scenarios passed across assignment and owner-filter flows.
- The changed-scope checks, UI and core-test typechecks, i18n, unused-export checks, targeted lint, and production UI build passed, including existing JavaScript/CSS and asset-integrity budgets.
- Live proof used Chrome against a normally started isolated Gateway with real WebSocket handlers and SQLite. An offline synthetic profile with no sessions appeared in an archived conversation's menu; assignment succeeded; after reload the header showed the new owner selected. Production SQLite readback confirmed ownership and preserved creator/archive metadata. No real team conversation was reassigned.
- Independent Codex review found a merged-profile selection edge case; it was repaired and the subsequent review was clean. Both ClawSweeper rank-up requests are also addressed: the canonical current owner stays selected and disabled during directory loading and failure, with sidebar and header regressions that failed before the repair and pass after it. Retry replaces the pending row without duplicates.

Synthetic before/after evidence (Carol is registered but has no sessions):

| Before | After |
| --- | --- |
| ![Before: Carol is missing](https://github.com/user-attachments/assets/45422b1c-b7d8-4e6d-8026-e4b36bf317c4) | ![After: Carol is available](https://github.com/user-attachments/assets/6d601ded-3fef-47af-8e65-9c4e4ca223bc) |

Follow-up observation: the isolated source Gateway emitted repeated `sessions.list` refreshes and bundled-plugin loader warnings. The final directory evidence recorded three successful directory calls and one successful assignment, and its real RPC/persistence proof passed; the separate source-startup/roster behavior remains to be triaged.
