### PR TITLE
fix(windows): keep managed Gateway startup alive and stoppable

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -218,10 +218,10 @@ Suggested `.gitignore` starter:
     Clone the repo to the desired path (default `~/.openclaw/workspace`).
   </Step>
   <Step title="Update config">
-    Set `agents.defaults.workspace` to that path in `~/.openclaw/openclaw.json`.
+    Set `agents.entries.<agentId>.workspace` to the cloned path in `~/.openclaw/openclaw.json` for the agent that should use it. A sole agent without a per-agent override can use `agents.defaults.workspace` instead; in a multi-agent roster, that setting only changes the base directory for unpinned entries.
   </Step>
-  <Step title="Seed missing files">
-    Run `openclaw setup --workspace <path>` to seed any missing files.
+  <Step title="Verify the workspace">
+    Run `openclaw agents list` and confirm that the intended agent points to the cloned path before starting the Gateway. Moving an existing workspace does not require rerunning onboarding.
   </Step>
   <Step title="Copy sessions (optional)">
     If you need sessions, copy `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite`

--- a/src/daemon/schtasks-process.ts
+++ b/src/daemon/schtasks-process.ts
@@ -16,6 +16,7 @@ import { resolveGatewayServiceProbeHosts } from "./gateway-service-probe-hosts.j
 import { readScheduledTaskCommand } from "./schtasks-layout.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 import type { GatewayServiceCommandConfig, GatewayServiceEnv } from "./service-types.js";
+import { WINDOWS_TASK_SUPERVISOR_FLAG } from "./windows-task-supervisor-contract.js";
 
 type WindowsProcessSnapshotEntry = {
   ProcessId?: number;
@@ -173,10 +174,16 @@ export async function resolveScheduledTaskOwnedGatewayPids(
     if (!snapshot) {
       return [];
     }
-    const pid = findInstalledProcessPid(snapshot, port, installedArguments, () => true);
-    if (pid) {
-      // The task is single-instance; persisted argv identifies its process before it starts listening.
-      return [pid];
+    // Prefer the Gateway PID; before admission its exact supervisor still owns startup.
+    // /End can leave that supervisor alive, so stop must find it before a Gateway exists.
+    for (const argv of [
+      installedArguments,
+      [...installedArguments, WINDOWS_TASK_SUPERVISOR_FLAG],
+    ]) {
+      const pid = findInstalledProcessPid(snapshot, port, argv, () => true);
+      if (pid) {
+        return [pid];
+      }
     }
     // A listener can be dual-stack or belong to another task; Windows control requires CIM argv proof.
     return [];

--- a/src/daemon/schtasks.integration.e2e.test.ts
+++ b/src/daemon/schtasks.integration.e2e.test.ts
@@ -20,8 +20,10 @@ import {
   createGatewayTaskSupervisorProbe,
   expectGatewayTaskSupervisorProcessAlive,
   expectScheduledTaskProbeOrigin,
+  isProcessAlive,
   waitForGatewayTaskSupervisorExit,
   waitForGatewayTaskSupervisorProcesses,
+  waitForProcessExit,
   writeGatewayTaskSupervisorProbe,
 } from "./schtasks.task-supervisor.native-test-support.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
@@ -30,11 +32,12 @@ import { resolveGatewayService } from "./service.js";
 
 const WAIT_INTERVAL_MS = 200;
 const WAIT_TIMEOUT_MS = 30_000;
-const RESTART_ON_FAILURE_WAIT_TIMEOUT_MS = 120_000;
 const DIAGNOSTIC_TEXT_LIMIT = 16_384;
 const DIAGNOSTIC_PROCESS_LIMIT = 32;
 const TASK_LOGON_INTERACTIVE_TOKEN = 3;
 const TASK_RUNLEVEL_LEAST_PRIVILEGE = 0;
+const TASK_STATE_READY = 3;
+const TASK_STATE_RUNNING = 4;
 
 type ScheduledTaskPrincipal = {
   lastRunTime: string;
@@ -102,17 +105,6 @@ async function waitForRuntimeStatus(
   );
 }
 
-async function waitForProcessExit(pid: number): Promise<void> {
-  const deadline = Date.now() + WAIT_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    if (!isProcessAlive(pid)) {
-      return;
-    }
-    await sleep();
-  }
-  throw new Error(`Timed out waiting for Scheduled Task process ${pid} to exit`);
-}
-
 async function reserveLoopbackPort(): Promise<number> {
   const server = createServer();
   await new Promise<void>((resolve, reject) => {
@@ -150,15 +142,6 @@ async function waitForLoopbackPortRelease(port: number): Promise<void> {
     await sleep();
   }
   throw new Error(`Timed out waiting for Scheduled Task loopback port ${port} to be reusable`);
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ESRCH";
-  }
 }
 
 async function readTaskXml(taskName: string): Promise<string | null> {
@@ -382,18 +365,16 @@ function assertInteractiveLeastPrivilegeTask(params: {
   expect(exportedRunLevel === undefined || exportedRunLevel === "LeastPrivilege").toBe(true);
 }
 
-async function waitForSuccessfulScheduledTaskRun(
-  taskName: string,
-  timeoutMs = WAIT_TIMEOUT_MS,
-): Promise<ScheduledTaskPrincipal> {
-  const deadline = Date.now() + timeoutMs;
+async function waitForFailedScheduledTaskRun(taskName: string): Promise<ScheduledTaskPrincipal> {
+  const deadline = Date.now() + WAIT_TIMEOUT_MS;
   let lastPrincipal: ScheduledTaskPrincipal | null = null;
   let lastError: unknown;
   while (Date.now() < deadline) {
     try {
       lastPrincipal = readTaskPrincipal(taskName);
       if (
-        lastPrincipal.lastTaskResult === 0 &&
+        lastPrincipal.taskState === TASK_STATE_READY &&
+        lastPrincipal.lastTaskResult === 23 &&
         !Number.isNaN(Date.parse(lastPrincipal.lastRunTime)) &&
         Date.parse(lastPrincipal.lastRunTime) > 0
       ) {
@@ -405,7 +386,7 @@ async function waitForSuccessfulScheduledTaskRun(
     await sleep();
   }
   throw new Error(
-    `Timed out waiting for Scheduled Task ${taskName} to record a successful run; ${
+    `Timed out waiting for Scheduled Task ${taskName} to finish the intentional exit 23; ${
       lastPrincipal
         ? `observed state=${lastPrincipal.taskState} result=${lastPrincipal.lastTaskResult}`
         : `last inspection failed: ${lastError instanceof Error ? lastError.message : String(lastError)}`
@@ -799,6 +780,8 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
     const scriptPath = resolveTaskScriptPath(env);
     const launcherPath = resolveTaskLauncherScriptPath(env, scriptPath);
 
+    // Source workers resolve tsx from the task cwd; give the isolated fixture its dependencies.
+    await fs.symlink(path.resolve("node_modules"), path.join(rootDir, "node_modules"), "junction");
     await writeGatewayTaskSupervisorProbe({ activePidPath, eventsPath, probe });
 
     let testFailed = false;
@@ -830,9 +813,18 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
           environment: {
             OPENCLAW_GATEWAY_PORT: String(gatewayPort),
             OPENCLAW_SERVICE_KIND: "gateway",
+            // Source aliases belong to the checkout, even when the task runs outside it.
+            TSX_TSCONFIG_PATH: path.resolve("tsconfig.json"),
           },
           description: `OpenClaw CI Scheduled Task integration ${id}`,
         });
+
+        const failedProcesses = await waitForGatewayTaskSupervisorProcesses({
+          probe,
+          failedAttempt: true,
+        });
+        installedPrincipal = await waitForFailedScheduledTaskRun(taskName);
+        await waitForGatewayTaskSupervisorExit(failedProcesses);
 
         expect((await execSchtasks(["/Query", "/TN", taskName])).code).toBe(0);
         const taskXml = await readTaskXml(taskName);
@@ -843,10 +835,7 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         expect(taskXml.replaceAll("/", "\\").toLowerCase()).toContain(
           launcherPath.replaceAll("/", "\\").toLowerCase(),
         );
-        installedPrincipal = await waitForSuccessfulScheduledTaskRun(
-          taskName,
-          RESTART_ON_FAILURE_WAIT_TIMEOUT_MS,
-        );
+        expect(taskXml).toContain("<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>");
         assertInteractiveLeastPrivilegeTask({
           taskXml,
           principal: installedPrincipal,
@@ -858,24 +847,33 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         expect(command?.programArguments).toEqual(programArguments);
         expect(command?.environment?.OPENCLAW_GATEWAY_PORT).toBe(String(gatewayPort));
         expect(command?.environment?.OPENCLAW_SERVICE_KIND).toBe("gateway");
-        const installedRun = await proof.waitForExactProbeRun(eventsPath, 1);
-        const installedPid = installedRun.pid;
-        const installedProcesses = await waitForGatewayTaskSupervisorProcesses({
-          probe,
-          requireFailedAttempt: true,
+        // An executed exit 23 need not trigger Scheduler retry. Request recovery only
+        // after failure cleanup; IgnoreNew prevents overlap if Scheduler also retries.
+        const recoveryMutations: string[] = [];
+        await service.start({
+          env,
+          stdout,
+          onMutation: (mutation) => recoveryMutations.push(mutation.mode),
         });
-        expectProbeProcessAlive(installedPid);
-        expectProbeProcessAlive(installedProcesses.childPid);
-        expectGatewayTaskSupervisorProcessAlive(installedProcesses.supervisorPid, probe.probePath);
+        expect(recoveryMutations).toEqual(["schtasks-start"]);
+        const recoveredRun = await proof.waitForExactProbeRun(eventsPath, 1);
+        const recoveredPid = recoveredRun.pid;
+        const recoveredProcesses = await waitForGatewayTaskSupervisorProcesses({ probe });
+        expect(recoveredPid).not.toBe(failedProcesses.childPid);
+        expect(recoveredProcesses.supervisorPid).not.toBe(failedProcesses.supervisorPid);
+        expectProbeProcessAlive(recoveredPid);
+        expectProbeProcessAlive(recoveredProcesses.childPid);
+        expectGatewayTaskSupervisorProcessAlive(recoveredProcesses.supervisorPid, probe.probePath);
         expectScheduledTaskProbeOrigin({
           eventsPath,
           probePath: probe.probePath,
-          run: installedRun,
+          run: recoveredRun,
           scriptPath,
           readRelatedProcessDiagnostics,
         });
         expect(await canBindLoopbackPort(gatewayPort)).toBe(false);
-        await waitForRuntimeStatus(readRuntime, "running", installedPid);
+        await waitForRuntimeStatus(readRuntime, "running", recoveredPid);
+        expect(readTaskPrincipal(taskName).taskState).toBe(TASK_STATE_RUNNING);
 
         const stopMutations: string[] = [];
         await service.stop({
@@ -884,9 +882,9 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
           onMutation: (mutation) => stopMutations.push(mutation.mode),
         });
         expect(stopMutations).toEqual(["schtasks-stop"]);
-        await waitForProcessExit(installedPid);
-        await waitForGatewayTaskSupervisorExit(installedProcesses);
-        await clearActivePid(activePidPath, installedPid);
+        await waitForProcessExit(recoveredPid);
+        await waitForGatewayTaskSupervisorExit(recoveredProcesses);
+        await clearActivePid(activePidPath, recoveredPid);
         await waitForLoopbackPortRelease(gatewayPort);
         await waitForRuntimeStatus(readRuntime, "stopped");
         expect((await execSchtasks(["/Query", "/TN", taskName])).code).toBe(0);
@@ -901,7 +899,7 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         const startedRun = await proof.waitForExactProbeRun(eventsPath, 2);
         const startedPid = startedRun.pid;
         const startedProcesses = await waitForGatewayTaskSupervisorProcesses({ probe });
-        expect(startedPid).not.toBe(installedPid);
+        expect(startedPid).not.toBe(recoveredPid);
         expectProbeProcessAlive(startedPid);
         expectProbeProcessAlive(startedProcesses.childPid);
         expectGatewayTaskSupervisorProcessAlive(startedProcesses.supervisorPid, probe.probePath);
@@ -914,6 +912,7 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         });
         expect(await canBindLoopbackPort(gatewayPort)).toBe(false);
         await waitForRuntimeStatus(readRuntime, "running", startedPid);
+        expect(readTaskPrincipal(taskName).taskState).toBe(TASK_STATE_RUNNING);
         await service.start({ env, stdout });
         await proof.waitForExactProbeRun(eventsPath, 2);
 
@@ -928,8 +927,8 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         const restartedRun = await proof.waitForExactProbeRun(eventsPath, 3);
         const restartedPid = restartedRun.pid;
         const restartedProcesses = await waitForGatewayTaskSupervisorProcesses({ probe });
-        lifecyclePids = [installedPid, startedPid, restartedPid];
-        expect(restartedPid).not.toBe(startedPid);
+        lifecyclePids = [recoveredPid, startedPid, restartedPid];
+        expect(new Set(lifecyclePids).size).toBe(lifecyclePids.length);
         expectProbeProcessAlive(restartedPid);
         expectProbeProcessAlive(restartedProcesses.childPid);
         expectGatewayTaskSupervisorProcessAlive(restartedProcesses.supervisorPid, probe.probePath);
@@ -945,6 +944,7 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         await clearActivePid(activePidPath, startedPid);
         expect(await canBindLoopbackPort(gatewayPort)).toBe(false);
         await waitForRuntimeStatus(readRuntime, "running", restartedPid);
+        expect(readTaskPrincipal(taskName).taskState).toBe(TASK_STATE_RUNNING);
 
         await service.stop({ env, stdout });
         await waitForProcessExit(restartedPid);
@@ -976,7 +976,21 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
                 head: proofHead,
                 profile,
                 taskName,
-                lifecycle: ["install", "stop", "start", "restart", "stop", "uninstall"],
+                lifecycle: [
+                  "install",
+                  "failed-run",
+                  "recovery-start",
+                  "stop",
+                  "start",
+                  "restart",
+                  "stop",
+                  "uninstall",
+                ],
+                failedRun: {
+                  taskState: installedPrincipal?.taskState,
+                  lastTaskResult: installedPrincipal?.lastTaskResult,
+                  ...failedProcesses,
+                },
                 pids: lifecyclePids,
                 gatewayPort,
                 portReleaseRebind: true,

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -493,76 +493,90 @@ describe("Scheduled Task stop/restart cleanup", () => {
     });
   });
 
-  it("adopts exact persisted Windows argv and escalates through taskkill tree cleanup", async () => {
-    await withPreparedGatewayTask(async ({ env, stdout }) => {
-      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-      pushSuccessfulSchtasksResponses(3);
-      inspectPortUsageMock.mockResolvedValue(freePortUsage());
-      let forced = false;
-      spawnSync.mockImplementation((command, args) => {
-        const executable = command.toLowerCase();
-        if (executable.endsWith("taskkill.exe")) {
-          const argv = Array.isArray(args) ? args.map(String) : [];
-          if (argv.includes("/F")) {
-            forced = true;
+  it.each(["gateway", "task-supervisor", "gateway-with-supervisor"])(
+    "stops the exact installed Windows %s even before its port is bound",
+    async (owner) => {
+      await withPreparedGatewayTask(async ({ env, stdout }) => {
+        vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+        pushSuccessfulSchtasksResponses(3);
+        inspectPortUsageMock.mockResolvedValue(freePortUsage());
+        let forced = false;
+        spawnSync.mockImplementation((command, args) => {
+          const executable = command.toLowerCase();
+          if (executable.endsWith("taskkill.exe")) {
+            const argv = Array.isArray(args) ? args.map(String) : [];
+            if (argv.includes("/F")) {
+              forced = true;
+              return {
+                pid: 0,
+                output: [null, "", ""],
+                stdout: "",
+                stderr: "",
+                status: 0,
+                signal: null,
+              };
+            }
             return {
               pid: 0,
               output: [null, "", ""],
               stdout: "",
               stderr: "",
-              status: 0,
+              status: 1,
               signal: null,
             };
           }
+          const processes = [
+            ...(owner === "gateway-with-supervisor"
+              ? [
+                  {
+                    ProcessId: 4141,
+                    CommandLine: `${INSTALLED_GATEWAY_COMMAND_LINE} --task-supervisor`,
+                  },
+                ]
+              : []),
+            {
+              ProcessId: 3131,
+              CommandLine:
+                '"C:\\Program Files\\nodejs\\node.exe" "C:\\other-openclaw.cjs" gateway --port 18789',
+            },
+            ...(!forced
+              ? [
+                  {
+                    ProcessId: 4242,
+                    CommandLine:
+                      INSTALLED_GATEWAY_COMMAND_LINE +
+                      (owner === "task-supervisor" ? " --task-supervisor" : ""),
+                  },
+                ]
+              : []),
+            { ProcessId: 9999, CommandLine: "powershell.exe" },
+          ];
+          const output = JSON.stringify(processes);
           return {
             pid: 0,
-            output: [null, "", ""],
-            stdout: "",
+            output: [null, output, ""],
+            stdout: output,
             stderr: "",
-            status: 1,
+            status: 0,
             signal: null,
           };
-        }
-        const processes = [
-          {
-            ProcessId: 3131,
-            CommandLine:
-              '"C:\\Program Files\\nodejs\\node.exe" "C:\\other-openclaw.cjs" gateway --port 18789',
-          },
-          ...(!forced
-            ? [
-                {
-                  ProcessId: 4242,
-                  CommandLine: INSTALLED_GATEWAY_COMMAND_LINE,
-                },
-              ]
-            : []),
-          { ProcessId: 9999, CommandLine: "powershell.exe" },
-        ];
-        const output = JSON.stringify(processes);
-        return {
-          pid: 0,
-          output: [null, output, ""],
-          stdout: output,
-          stderr: "",
-          status: 0,
-          signal: null,
-        };
+        });
+
+        await stopScheduledTask({ env, stdout });
+
+        const taskkillCalls = spawnSync.mock.calls
+          .filter(([command]) => command.toLowerCase().endsWith("taskkill.exe"))
+          .map(([, args]) => args);
+        expect(taskkillCalls).toEqual([
+          ["/T", "/PID", "4242"],
+          ["/F", "/T", "/PID", "4242"],
+        ]);
+        expect(taskkillCalls.flat()).not.toContain("3131");
+        expect(taskkillCalls.flat()).not.toContain("4141");
+        expect(killProcessTreeMock).not.toHaveBeenCalled();
       });
-
-      await stopScheduledTask({ env, stdout });
-
-      const taskkillCalls = spawnSync.mock.calls
-        .filter(([command]) => command.toLowerCase().endsWith("taskkill.exe"))
-        .map(([, args]) => args);
-      expect(taskkillCalls).toEqual([
-        ["/T", "/PID", "4242"],
-        ["/F", "/T", "/PID", "4242"],
-      ]);
-      expect(taskkillCalls.flat()).not.toContain("3131");
-      expect(killProcessTreeMock).not.toHaveBeenCalled();
-    });
-  });
+    },
+  );
 
   it("starts a registered task and ignores audit observer failures", async () => {
     await withPreparedGatewayTask(async ({ env }) => {

--- a/src/daemon/schtasks.task-supervisor.native-test-support.ts
+++ b/src/daemon/schtasks.task-supervisor.native-test-support.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { expect } from "vitest";
@@ -16,6 +17,7 @@ type WindowsProcessDiagnostic = {
 export type GatewayTaskSupervisorProbe = {
   childPidPath: string;
   failedAttemptPidPath: string;
+  failedSupervisorPidPath: string;
   probePath: string;
   supervisorPidPath: string;
 };
@@ -39,15 +41,20 @@ async function waitForRecordedPid(pidPath: string, label: string): Promise<numbe
   throw new Error(`Timed out waiting for Scheduled Task ${label} process id`);
 }
 
-async function waitForProcessExit(pid: number): Promise<void> {
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+export async function waitForProcessExit(pid: number): Promise<void> {
   const deadline = Date.now() + WAIT_TIMEOUT_MS;
   while (Date.now() < deadline) {
-    try {
-      process.kill(pid, 0);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ESRCH") {
-        return;
-      }
+    if (!isProcessAlive(pid)) {
+      return;
     }
     await sleep();
   }
@@ -58,6 +65,7 @@ export function createGatewayTaskSupervisorProbe(rootDir: string): GatewayTaskSu
   return {
     childPidPath: path.join(rootDir, "child-pid.txt"),
     failedAttemptPidPath: path.join(rootDir, "failed-attempt-pid.txt"),
+    failedSupervisorPidPath: path.join(rootDir, "failed-supervisor-pid.txt"),
     probePath: path.join(rootDir, "probe.mts"),
     supervisorPidPath: path.join(rootDir, "supervisor-pid.txt"),
   };
@@ -83,11 +91,14 @@ export async function writeGatewayTaskSupervisorProbe(params: {
       "const childPidPath = process.argv[7];",
       "const supervisorPidPath = process.argv[8];",
       "const failedAttemptPidPath = process.argv[9];",
+      "const failedSupervisorPidPath = process.argv[10];",
       "const appendEvent = (phase) => fs.appendFileSync(eventsPath, `${JSON.stringify({ phase, pid: process.pid, ppid: process.ppid })}\\n`);",
       "if (process.argv.includes('--task-supervisor')) {",
       "  fs.writeFileSync(supervisorPidPath, String(process.pid));",
       "  await runWindowsGatewayTaskSupervisor();",
       "} else if (!fs.existsSync(failedAttemptPidPath)) {",
+      // Preserve this run's supervisor before a recovery launch overwrites its live PID file.
+      "  fs.copyFileSync(supervisorPidPath, failedSupervisorPidPath);",
       "  fs.writeFileSync(failedAttemptPidPath, String(process.pid));",
       "  process.exit(23);",
       "} else {",
@@ -119,10 +130,12 @@ export function buildGatewayTaskSupervisorProgramArguments(params: {
   gatewayPort: number;
   probe: GatewayTaskSupervisorProbe;
 }): string[] {
+  // The task runs from a temporary workspace, not the checkout that owns tsx.
+  const tsxImportUrl = pathToFileURL(createRequire(import.meta.url).resolve("tsx")).href;
   return [
     process.execPath,
     "--import",
-    "tsx",
+    tsxImportUrl,
     params.probe.probePath,
     "gateway",
     "--port",
@@ -132,22 +145,24 @@ export function buildGatewayTaskSupervisorProgramArguments(params: {
     params.probe.childPidPath,
     params.probe.supervisorPidPath,
     params.probe.failedAttemptPidPath,
+    params.probe.failedSupervisorPidPath,
   ];
 }
 
 export async function waitForGatewayTaskSupervisorProcesses(params: {
   probe: GatewayTaskSupervisorProbe;
-  requireFailedAttempt?: boolean;
+  failedAttempt?: boolean;
 }): Promise<{ childPid: number; supervisorPid: number }> {
+  const childPidPath = params.failedAttempt
+    ? params.probe.failedAttemptPidPath
+    : params.probe.childPidPath;
+  const supervisorPidPath = params.failedAttempt
+    ? params.probe.failedSupervisorPidPath
+    : params.probe.supervisorPidPath;
   const [childPid, supervisorPid] = await Promise.all([
-    waitForRecordedPid(params.probe.childPidPath, "child"),
-    waitForRecordedPid(params.probe.supervisorPidPath, "supervisor"),
+    waitForRecordedPid(childPidPath, "child"),
+    waitForRecordedPid(supervisorPidPath, "supervisor"),
   ]);
-  if (params.requireFailedAttempt) {
-    await waitForProcessExit(
-      await waitForRecordedPid(params.probe.failedAttemptPidPath, "failed child"),
-    );
-  }
   return { childPid, supervisorPid };
 }
 

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import type { Duplex, Readable } from "node:stream";
 import { toErrorObject } from "../../infra/errors.js";
@@ -27,7 +27,6 @@ type ServiceChildRelayAdapter = SpawnProcessAdapter<NodeJS.Signals | null> & {
 type AuthorityState = "starting" | "active" | "closing" | "closed" | "identity-lost";
 type StdioEntry = "ignore" | "inherit" | "ipc" | "pipe" | number;
 
-const retainedChildren = new Map<string, ChildProcess>();
 const PUSHED_OUTPUT_BUFFER_LIMIT_BYTES = 256 * 1024;
 
 function readChildMessage(raw: unknown): ServiceChildRelayMessage | ServiceChildAnchorMessage {
@@ -155,19 +154,17 @@ export async function createServiceChildRelayAdapter(params: {
 
   const child = spawn(process.execPath, resolveRuntimeWorkerArgv(workerUrl), {
     stdio,
-    // Windows must keep its exact Job owner alive long enough to observe host IPC loss.
+    // A detached Windows Job owner survives host loss long enough to clean up.
+    // Keep its child handle referenced so an idle host can finish admission and lineage cleanup.
     detached: useWindowsJobAnchor,
     windowsHide: true,
     env: process.env,
   });
-  retainedChildren.set(generation, child);
-  child.unref();
 
   // SAFETY: a defined controlFd was reserved as a pipe in this exact spawn stdio array.
   const control = controlFd === undefined ? null : (child.stdio[controlFd] as Duplex | null);
   if (!child.connected || (!useWindowsJobAnchor && (!control || !child.stdout || !child.stderr))) {
     child.kill("SIGKILL");
-    retainedChildren.delete(generation);
     throw new Error("service child lifecycle channels were not created");
   }
   const stdoutRelay = createOutputRelay(child.stdout ?? undefined);
@@ -401,7 +398,6 @@ export async function createServiceChildRelayAdapter(params: {
     finishAuthorityClose(
       childError?.message ?? "Windows service child anchor exited without a closing receipt",
     );
-    retainedChildren.delete(generation);
   };
   child.once("disconnect", () => {
     childDisconnected = true;
@@ -411,8 +407,6 @@ export async function createServiceChildRelayAdapter(params: {
     childExited = true;
     if (useWindowsJobAnchor) {
       finishWindowsAuthority();
-    } else {
-      retainedChildren.delete(generation);
     }
   });
 
@@ -433,7 +427,6 @@ export async function createServiceChildRelayAdapter(params: {
     await sendChildMessage(start);
   } catch (error) {
     child.kill("SIGKILL");
-    retainedChildren.delete(generation);
     throw error;
   }
 
@@ -450,7 +443,6 @@ export async function createServiceChildRelayAdapter(params: {
       await extinctionCompletion.promise;
     } else {
       child.kill("SIGKILL");
-      retainedChildren.delete(generation);
     }
     // Startup owns command admission, so its exact failure wins over a concurrent
     // backpressured secret pipe closing as a consequence of that failed admission.

--- a/src/process/supervisor/service-child-windows-job-anchor.ts
+++ b/src/process/supervisor/service-child-windows-job-anchor.ts
@@ -483,7 +483,8 @@ export function runServiceChildWindowsJobAnchor(): void {
             null,
             1,
             CREATE_NEW_PROCESS_GROUP | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT,
-            buildWindowsJobEnvironmentBlock(next.env),
+            // NULL inherits; an explicitly empty environment must remain an empty block.
+            next.env === undefined ? null : buildWindowsJobEnvironmentBlock(next.env),
             next.cwd ?? null,
             {
               StartupInfo: {

--- a/src/process/supervisor/service-child-windows-job-start.ts
+++ b/src/process/supervisor/service-child-windows-job-start.ts
@@ -2,7 +2,7 @@ import { asOptionalRecord, isStringRecord } from "@openclaw/normalization-core/r
 import { mergeProcessEnv } from "../../infra/process-env.js";
 import type { ServiceChildStart } from "./service-child-protocol.js";
 
-export function buildWindowsJobEnvironmentBlock(env: Record<string, string> | undefined): Buffer {
+export function buildWindowsJobEnvironmentBlock(env: Record<string, string>): Buffer {
   const merged = mergeProcessEnv([env], "win32");
   for (const [key, value] of Object.entries(merged)) {
     if (key.includes("\0") || value.includes("\0")) {

--- a/src/process/supervisor/supervisor.anchored-shell.real.test.ts
+++ b/src/process/supervisor/supervisor.anchored-shell.real.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -151,6 +152,73 @@ async function expectPending(promise: Promise<void>) {
 }
 
 describe("supervisor anchored shell real process ownership", () => {
+  it.each(["inherited", "replacement", "empty"] as const)(
+    "completes an otherwise idle host with %s command environment",
+    async (environment) => {
+      const cwd = tempDirs.make("openclaw-anchored-shell-idle-");
+      const hostPath = path.join(cwd, "host.mts");
+      const supervisorUrl = new URL("./supervisor.ts", import.meta.url).href;
+      let command =
+        'printf "%s\\n" "${OPENCLAW_TEST_PARENT_ENV-absent}" "${OPENCLAW_TEST_CHILD_ENV-absent}"';
+      if (process.platform === "win32") {
+        const commandPath = path.join(cwd, "environment.cmd");
+        await writeFile(
+          commandPath,
+          "@echo off\r\nif defined OPENCLAW_TEST_PARENT_ENV (echo parent) else (echo absent)\r\nif defined OPENCLAW_TEST_CHILD_ENV (echo child) else (echo absent)\r\n",
+        );
+        command = `"${commandPath}"`;
+      }
+      await writeFile(
+        hostPath,
+        `
+          const { createProcessSupervisor } = await import(${JSON.stringify(supervisorUrl)});
+          const supervisor = createProcessSupervisor();
+          const environment = ${JSON.stringify(environment)};
+          const run = await supervisor.spawn({
+            mode: "anchored-shell",
+            command: ${JSON.stringify(command)},
+            sessionId: "idle-host",
+            backendId: "idle-host",
+            ...(environment === "inherited" ? {} : {
+              env: environment === "empty" ? {} : { OPENCLAW_TEST_CHILD_ENV: "child" },
+            }),
+          });
+          try {
+            const result = await run.wait();
+            await run.waitForExtinction();
+            console.log(JSON.stringify(result));
+          } finally {
+            await supervisor.shutdown();
+          }
+        `,
+        "utf8",
+      );
+      // A separate host has no Vitest timers or IPC keeping admission alive.
+      const host = spawnSync(process.execPath, ["--import", "tsx", hostPath], {
+        env: {
+          ...process.env,
+          OPENCLAW_TEST_PARENT_ENV: "parent",
+          OPENCLAW_TEST_CHILD_ENV: undefined,
+        },
+        encoding: "utf8",
+        timeout: 10_000,
+      });
+      expect(host.error).toBeUndefined();
+      expect(host.status, host.stderr).toBe(0);
+      const result = JSON.parse(host.stdout);
+      expect({ ...result, stdout: result.stdout.replaceAll("\r\n", "\n") }).toMatchObject({
+        reason: "exit",
+        exitCode: 0,
+        stdout:
+          environment === "inherited"
+            ? "parent\nabsent\n"
+            : environment === "replacement"
+              ? "absent\nchild\n"
+              : "absent\nabsent\n",
+      });
+    },
+  );
+
   it.each(["exit", "cancel"] as const)(
     "keeps a replacement's status independent of an older live child's %s",
     async (completion) => {


### PR DESCRIPTION
Related: #136203 — Windows upgrade maintenance, workspace and stale-Codex reports.

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where starting a managed Gateway on native Windows could exit before the Gateway started, and stopping it immediately could report success while its supervisor later launched a Gateway. These are reproduced current-main startup/lifecycle defects discovered while investigating the Windows upgrade report.

## Why This Change Was Made

Keep the service relay's real child handle referenced through admission and lineage completion, removing the premature `unref()` and redundant retention map. Pass `NULL` to `CreateProcessW` when the command environment is omitted, preserving native inheritance; explicitly supplied environments, including `{}`, remain replacements. For pre-admission stop, recognize the exact installed supervisor argv while preferring the actual Gateway PID and preserving the full-argv, port and identity fences.

The native fixture now proves deliberate exit 23 and extinction of that exact child and supervisor, requests recovery explicitly, and reads current numeric Running state rather than treating historical LastTaskResult as liveness. It retains the complete service lifecycle and ownership assertions. Its external temporary cwd receives test-owned dependency resolution through the public tsx export and checkout tsconfig. No production retry or keepalive was added. Workspace migration instructions now identify the intended per-agent workspace and verify it without rerunning onboarding.

## User Impact

Native Windows operators can start, restart and stop the managed Gateway, including stopping before its child is admitted. Omitted child environments inherit normally; intentional sanitized environments and explicit Codex overrides retain their meaning. Production is **+17/-17 (net 0)**; tests/support **+232/-121 (net +111)**; docs **+3/-3**. There are no configuration, dependency, SQLite-schema or protocol changes.

Thanks to @hermannmetzker-ai and @DasX for the reports that prompted the investigation.

## Evidence

**266 distinct local passes and 63 distinct native Windows passes**; repeated subsets are not added. Local coverage includes POSIX cancellation, parent loss and descendant extinction. Final changed checks and formatting passed. A fresh, secret-scanned, isolated Codex review before commit found no actionable P0 findings; this is a P0-scoped result.

Native proof used **Azure Windows Server 2022, amd64, en-US, Node 24.15.0 and pnpm 12.1.0**, with the same interactive user and **InteractiveToken/Limited** Scheduled Tasks. It used Crabbox's documented connect workflow after a run-transport ownership failure was safely resolved; these are **not signed Crabbox run receipts**. No operator state, provider credentials or inference were used.

| Boundary | Before / after evidence |
| --- | --- |
| Idle caller and environment | Independent idle-host regressions failed before repair; inherited, replacement and empty environments pass afterward without diagnostic keepalive/ref interventions. |
| Managed service | Actual built CLI install/start/status/stop/restart passed, with PID-generation replacement and descendant cleanup. Immediate stop before admission left no supervisor or late Gateway and the port remained free. |
| Scheduled Task fixture | **5/5 passed** with the default external temp root: Ready=3/result=23 and exact failed identities extinct, explicit recovery, directly observed Running=4, three distinct successful PIDs, stop/start/restart/stop/uninstall, task-origin/argv/port checks, default-task preservation and cleanup. Main lifecycle used no Startup fallback. |
| Workspace | Four actual Doctor cases independently verified SQLite imports and synthetic corpus preservation. Live managed-write rejection preserved the last-good runtime; post-Doctor explicit pin activation and normal restart passed. |
| Codex | Actual Gateway `/codex status` selected/rejected env-specified 0.144.5, then initialized managed 0.152.1 in a fresh PID after User/Process `OPENCLAW_CODEX_APP_SERVER_BIN` removal and normal managed restart. Separate launcher, state.env and config.env overrides remained effective; config command won. Exact official launcher contracts were inspected for 0.144.5, 0.151.0 and 0.152.1. |

Proof base: `d1bf55e3176cfd4afbac27f134996f1d5762c72e` plus intentional patch. Native five-case source-patch SHA256: `e1bcece65140b347b777f2df2f765eaccc3b1f8ea7251b009c2bbea77f35bb62`. Final source-patch SHA256 excluding docs: `f23017c5a4bb0f2baa0c15b69143e8571017866d29b54ed87b842e4bf46b7073`. Full candidate including docs: `5a357bfa857dc1451549096e15d96aba7dd57f57a9779edc3f6a0c38be7453cb`.

All production postimages are native-tested. After native 5/5, a max-lines check required moving two byte-identical process-liveness/wait helper bodies into their already-imported test-support owner. The 30-second/200ms behavior and assertions are unchanged; final local tests, checks and fresh review passed. The lease expired after cleanup, so the final test-helper layout is **not claimed as identical native-executed bytes**.

<details>
<summary>Exact focused commands and prior failures</summary>

```sh
node scripts/run-vitest.mjs src/process/supervisor/supervisor.anchored-shell.real.test.ts src/process/supervisor/service-child-relay-host.test.ts src/process/supervisor/supervisor.scope-extinction.test.ts src/process/supervisor/supervisor.cancellation-reason.test.ts src/process/supervisor/adapters/child.service-lifecycle.test.ts src/infra/process-env.test.ts
# Local: 78 passed. Native, excluding POSIX-only adapters/child.service-lifecycle.test.ts: 55 passed.
node scripts/run-vitest.mjs src/daemon/schtasks.stop.test.ts src/daemon/schtasks.test.ts src/daemon/schtasks.install.test.ts src/daemon/schtasks.startup-fallback.test.ts
# Local: 184 passed.
node scripts/run-vitest.mjs src/daemon/schtasks.stop.test.ts -t 'stops the exact installed Windows'
# Native: 3 passed; 29 excluded by the explicit filter.
OPENCLAW_E2E_USE_PREBUILT_DIST=1 OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/daemon/schtasks.integration.e2e.test.ts
# Final local: 4 passed, 1 native-only skip.
pnpm test:windows:schtasks:integration
# Native: 5 passed; CI_WINDOWS_SCHTASKS_ROOT unset; prebuilt QA runtime.
pnpm build
# Full native build: passed.
node scripts/check-changed.mjs -- src/daemon/schtasks.integration.e2e.test.ts src/daemon/schtasks.task-supervisor.native-test-support.ts
# Final changed gate: passed; prior producer changed gates also passed.
git diff --check
```

Before-results remain preserved: idle native host exit 13; omitted-env failure isolated separately; successful immediate stop followed by a late Gateway; the old unsupported automatic-retry expectation; external-root loader/alias resolution failures; one local check process killed with 137; and max-lines 1010 > 1000. Fixture dependency ownership and duplicate-helper consolidation corrected the test failures. No assertions, timeouts or lint limits were suppressed.

</details>

**Limits and follow-up:** #136578 already addressed locale/Doctor/retained-root/admission behavior. This repair does not establish the reporter's historical Windows 11/de-DE stale-Codex cause or reconstruct lost intent in an already-keyed workspace roster; #136203 remains open. A separate refusal during overlapping live config rewrite, automatic handoff and manual restart remains a follow-up. The current native matrix used credential-free diagnostics, not authenticated model inference. Main comparison found no changes in the repaired daemon/supervisor paths; additive cloud-worker resolver and unrelated dependency/CI drift do not alter the repaired owner contracts.
