### PR TITLE
fix(macos): preserve Gateway URL text during onboarding

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -740,12 +740,10 @@ extension AppState {
             }
 
             if draft.dirtyFields.contains(.remoteUrl) {
-                let trimmedUrl = draft.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmedUrl.isEmpty {
-                    changed = Self.updateGatewayString(&remote, key: "url", value: nil) || changed
-                } else if let normalizedUrl = GatewayRemoteConfig.normalizeGatewayUrlString(trimmedUrl) {
-                    changed = Self.updateGatewayString(&remote, key: "url", value: normalizedUrl) || changed
-                }
+                // Reconciliation needs the incomplete draft too, or it mistakes the
+                // unchanged disk URL for a saved edit. gatewayDraftCanPersist gates writes.
+                let url = GatewayRemoteConfig.normalizeGatewayUrlString(draft.remoteUrl) ?? draft.remoteUrl
+                changed = Self.updateGatewayString(&remote, key: "url", value: url) || changed
             }
 
         case .ssh:

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -226,6 +226,67 @@ struct AppStateRemoteConfigTests {
         }
     }
 
+    @Test(arguments: [nil, "wss://previous.example.test"] as [String?])
+    func `incomplete direct URL edits survive sync until completed`(savedURL: String?) async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            var remote: [String: Any] = ["transport": "direct"]
+            remote["url"] = savedURL
+            #expect(OpenClawConfigFile.saveDict(["gateway": ["mode": "remote", "remote": remote]]))
+            let state = AppState(preview: true)
+            state._testEnableGatewayConfigSync()
+
+            for draft in ["w", "ws", "wss", "wss:", "wss:/", "wss://"] {
+                state.remoteUrl = draft
+                await state._testAwaitGatewayConfigSync()
+
+                #expect(state.remoteUrl == draft)
+                #expect(state._testDirtyGatewayConfigFields == ["gateway.remote.url"])
+                #expect(!state.gatewayConfigIsCurrentForRouting)
+                #expect(GatewayRemoteConfig.resolveUrlString(root: OpenClawConfigFile.loadDict()) == savedURL)
+            }
+
+            state.remoteUrl += "gateway.example.test"
+            await state._testAwaitGatewayConfigSync()
+            #expect(state.remoteUrl == "wss://gateway.example.test")
+            #expect(state._testDirtyGatewayConfigFields.isEmpty)
+            #expect(state.gatewayConfigIsCurrentForRouting)
+            #expect(GatewayRemoteConfig.resolveUrlString(root: OpenClawConfigFile.loadDict()) == state.remoteUrl)
+        }
+    }
+
+    @Test
+    func `incomplete direct URL retains ownership across external config edits`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            var remote = ["transport": "direct", "url": "wss://previous.example.test", "token": "old-token"]
+            #expect(OpenClawConfigFile.saveDict(["gateway": ["mode": "remote", "remote": remote]]))
+            let state = AppState(preview: true)
+            state._testEnableGatewayConfigSync()
+            state.remoteUrl = "wss://"
+            await state._testAwaitGatewayConfigSync()
+
+            remote["token"] = "new-token"
+            #expect(OpenClawConfigFile.saveDict(["gateway": ["mode": "remote", "remote": remote]]))
+            state._testApplyConfigFromDisk()
+            #expect(state.remoteUrl == "wss://")
+            #expect(state.remoteToken == "new-token")
+            #expect(state.gatewayConfigConflict == nil)
+
+            remote["url"] = "wss://external.example.test"
+            #expect(OpenClawConfigFile.saveDict(["gateway": ["mode": "remote", "remote": remote]]))
+            state._testApplyConfigFromDisk()
+            #expect(state.remoteUrl == "wss://")
+            #expect(state._testConflictedGatewayConfigFields == ["gateway.remote.url"])
+            #expect(!state.keepGatewayConfigEdits())
+            #expect(GatewayRemoteConfig.resolveUrlString(root: OpenClawConfigFile.loadDict()) == remote["url"])
+            #expect(state.useFileGatewayConfigConflict())
+            #expect(state.remoteUrl == remote["url"])
+            #expect(state._testDirtyGatewayConfigFields.isEmpty)
+            #expect(state.gatewayConfigIsCurrentForRouting)
+        }
+    }
+
     @Test
     func `successful gateway config sync clears dirty fields`() async {
         let configPath = TestIsolation.tempConfigPath()
@@ -413,8 +474,8 @@ struct AppStateRemoteConfigTests {
             #expect(state.gatewayConfigConflict?.fieldNames == ["Identity file", "Gateway token"])
             #expect(state.gatewayConfigConflict?.message ==
                 "These settings changed outside the app while you were editing: " +
-                    "Identity file and Gateway token. " +
-                    "Choose which version to keep.")
+                "Identity file and Gateway token. " +
+                "Choose which version to keep.")
             #expect(!state._testGatewayConfigIsCurrentForRouting)
 
             state._testEnableGatewayConfigSync()


### PR DESCRIPTION
Closes #136863. Thanks @hannesrudolph for the report and recording.

## What Problem This Solves

Fixes an issue where macOS users entering a remote Gateway URL during onboarding would see every incomplete edit disappear despite the field retaining focus. The same AppState owner also serves the Direct URL field in Settings → General.

## Why This Change Was Made

Config reconciliation compared disk state with a projected draft. The direct-URL projection silently retained the disk URL when the draft was incomplete, so reconciliation mistook the unchanged disk value for a successfully saved edit and reloaded it into the text field.

Project the normalized URL when available and otherwise preserve the actual draft. The existing `gatewayDraftCanPersist` check still runs before any save; incomplete routes remain unavailable and never reach the saver. External same-field edits still produce a conflict, and unrelated token changes are still adopted. No new config, schema, protocol, or dependency surface.

This removes the silent projection branch rather than compensating in the onboarding binding. Production LOC: +4/-6 (net -2). Tests: +63/-2, including two pre-existing indentation corrections from the pinned formatter.

Provenance: the ownership reconciliation added in 033531767957 (#118046), present in v2026.8.1 and v2026.8.2, ran before route validation while reusing the older skip-invalid projection. Verified against its raw parent 1f7e2f0dc673db3862e709e6890cd508858eb425.

## User Impact

Users can type a `ws://` or `wss://` Gateway URL normally, including partial schemes, then check the completed connection. Existing valid config remains intact while the new URL is incomplete. The documented connection flow is unchanged.

## Evidence

- Live native proof on macOS 27.0: fresh isolated profile, Welcome → On another computer → Advanced options → Direct. The signed v2026.8.2 app erases a native `w` keystroke. The candidate retains every typed character through `wss://` and `wss://gateway.example.test`.
- Candidate: current-source Swift executable placed in a private copy of the release bundle, framework search path set, and signed with the matching Developer ID. Screenshots are cropped to the synthetic connection form; no discovered hosts or credentials are included. This verifies editing and validation, not authentication to a real Gateway.
- Regression tests were run against unchanged production code first: both new tests failed, reproducing erased drafts and lost conflict ownership. After the repair, 98 tests pass across `AppStateRemoteConfigTests` and `GatewayEndpointStoreTests`.
- Coverage includes fresh and existing URLs, incomplete prefixes, completing and persisting the URL, routing remaining unavailable during incomplete edits, adopting external token changes, detecting external URL conflicts, rejecting incomplete “Keep my edits,” and “Use file” recovery. Existing SSH, token, and endpoint tests pass.
- Commands: `node scripts/prepare-apple-mermaid.mjs`; `swift build --package-path apps/macos --product OpenClaw`; `swift build --package-path apps/macos --build-system native --build-tests`; signed-test `swift test --package-path apps/macos --build-system native --skip-build --filter 'AppStateRemoteConfigTests|GatewayEndpointStoreTests'` under an isolated named profile; pinned SwiftFormat; `git diff --check`.
- A broader local run had three default-profile installation ownership assertions fail under that isolated named profile; the normal macOS CI lane exercises those with its intended default profile. All local changed checks passed, including pinned SwiftLint and 1,074 macOS tooling test instances. [Exact-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33714911770/attempts/2) passed, including the default-profile native app tests and release build. The two unassigned Blacksmith Swift jobs in attempt 1 were cancelled only after all active jobs finished, then retried on the supported hosted macOS fallback; successful jobs were retained.
- Independent Codex autoreview: no actionable P0–P2 findings.

Before, after a native `w` keystroke (placeholder remains):

![Released app erases typed Gateway URL](https://github.com/user-attachments/assets/d3146d5c-c267-4423-85ad-40cb83cd0dc6)

After, partial URL remains editable:

![Candidate retains partial Gateway URL](https://github.com/user-attachments/assets/d37cb463-ec17-451f-832b-f81a05669c3f)

After, completed URL remains visible:

![Candidate retains completed Gateway URL](https://github.com/user-attachments/assets/901205c9-7289-42fe-9673-9bf60cbd5899)
