### PR TITLE
fix(media): show usable byte limits in rejection errors

### DIFF
--- a/docs/nodes/images.md
+++ b/docs/nodes/images.md
@@ -87,7 +87,7 @@ image destinations retain their URL punctuation.
 - Images: up to `channels.whatsapp.mediaMaxMb` (default 50MB) after optimization.
 - Audio/video: 16MB cap (shared default; overridden by `mediaMaxMb` when sending through WhatsApp).
 - Documents: 100MB cap (shared default; overridden by `mediaMaxMb` when sending through WhatsApp).
-- Oversize or unreadable media produces a clear error in logs, and the reply is skipped.
+- Oversize or unreadable media produces a clear error in logs, and the reply is skipped. Size errors use readable byte units rather than rounding fractional caps to a whole MB.
 
 **Media understanding caps (transcription/description)**
 

--- a/src/agents/tool-images.log.test.ts
+++ b/src/agents/tool-images.log.test.ts
@@ -1,7 +1,11 @@
 // Tool image logging tests cover diagnostic context emitted while sanitizing
 // oversized or transformed image payloads.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { imageResultFromFile } from "../plugin-sdk/channel-actions.js";
 
 const { infoMock, resizeToJpegMock, warnMock } = vi.hoisted(() => ({
   infoMock: vi.fn(),
@@ -42,6 +46,7 @@ async function createLargePng(): Promise<Buffer> {
 }
 
 describe("tool-images log context", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   let png: Buffer;
 
   beforeAll(async () => {
@@ -54,6 +59,44 @@ describe("tool-images log context", () => {
     resizeToJpegMock.mockResolvedValue(Buffer.alloc(100, 2));
     warnMock.mockClear();
   });
+
+  it.each([
+    { maxBytes: 512, outputBytes: 768, limit: "512B", actual: "768B" },
+    { maxBytes: 256 * 1024, outputBytes: 512 * 1024, limit: "256.0KB", actual: "512.0KB" },
+    {
+      maxBytes: 1.5 * 1024 * 1024,
+      outputBytes: 2 * 1024 * 1024,
+      limit: "1.50MB",
+      actual: "2.00MB",
+    },
+  ])(
+    "reports the effective SDK image cap of $limit",
+    async ({ maxBytes, outputBytes, limit, actual }) => {
+      const filePath = path.join(tempDirs.make("tool-image-cap-"), "sample.png");
+      await writeFile(filePath, png);
+      resizeToJpegMock.mockResolvedValue(Buffer.alloc(outputBytes, 2));
+
+      const result = await imageResultFromFile({
+        label: "sdk:image",
+        path: filePath,
+        extraText: "image caption",
+        details: { media: { outbound: false } },
+        imageSanitization: { maxBytes },
+      });
+
+      expect(result.content).toEqual([
+        { type: "text", text: "image caption" },
+        {
+          type: "text",
+          text: `[sdk:image] omitted image payload: Error: Image could not be reduced below ${limit} (got ${actual})`,
+        },
+      ]);
+      expect(result.details).toMatchObject({
+        path: filePath,
+        media: { outbound: false, mediaUrl: filePath },
+      });
+    },
+  );
 
   it("includes filename from read label", async () => {
     const blocks = [

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -99,14 +99,11 @@ function imageWithinLimits(
 }
 
 function formatBytesShort(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes < 1024) {
-    return `${Math.max(0, Math.round(bytes))}B`;
-  }
   return formatByteSize(bytes, {
     style: "legacy-binary",
     maxUnit: "mega",
     separator: "",
-    fractionDigits: (_value, unit) => (unit === "kilo" ? 1 : 2),
+    fractionDigits: (_value, unit) => (unit === "mega" ? 2 : unit === "kilo" ? 1 : 0),
   });
 }
 
@@ -287,8 +284,6 @@ async function resizeImageBase64IfNeeded(params: {
   }
 
   const best = smallest?.buffer ?? buf;
-  const maxMb = (params.maxBytes / (1024 * 1024)).toFixed(0);
-  const gotMb = (best.byteLength / (1024 * 1024)).toFixed(2);
   const sourcePixels =
     typeof width === "number" && typeof height === "number" ? `${width}x${height}px` : "unknown";
   const sourceWithFile = params.fileName ? `${params.fileName} ${sourcePixels}` : sourcePixels;
@@ -308,7 +303,9 @@ async function resizeImageBase64IfNeeded(params: {
       triggerOverDimensions: overDimensions,
     },
   );
-  throw new Error(`Image could not be reduced below ${maxMb}MB (got ${gotMb}MB)`);
+  throw new Error(
+    `Image could not be reduced below ${formatBytesShort(params.maxBytes)} (got ${formatBytesShort(best.byteLength)})`,
+  );
 }
 
 export async function sanitizeContentBlocksImages(

--- a/src/media/store.shared.ts
+++ b/src/media/store.shared.ts
@@ -4,6 +4,15 @@ import { formatByteSize } from "@openclaw/normalization-core";
 // directory is the trust boundary. Temp and final writes must use one mode.
 export const MEDIA_FILE_MODE = 0o644;
 
+export function formatMediaSize(bytes: number): string {
+  return formatByteSize(bytes, {
+    style: "legacy-binary",
+    maxUnit: "mega",
+    separator: "",
+    fractionDigits: (value) => (Number.isInteger(value) ? 0 : 2),
+  });
+}
+
 /** Stable error categories for unsafe or failed source-file ingestion. */
 type SaveMediaSourceErrorCode =
   | "invalid-path"
@@ -23,12 +32,7 @@ export class SaveMediaSourceError extends Error {
   }
 
   static tooLarge(maxBytes: number, options?: ErrorOptions): SaveMediaSourceError {
-    const limit = formatByteSize(maxBytes, {
-      style: "legacy-binary",
-      maxUnit: "mega",
-      separator: "",
-      fractionDigits: (value) => (Number.isInteger(value) ? 0 : 2),
-    });
+    const limit = formatMediaSize(maxBytes);
     return new SaveMediaSourceError("too-large", `Media exceeds ${limit} limit`, options);
   }
 }

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -562,7 +562,13 @@ describe("loadWebMedia", () => {
           models: [{ maxBytes: 8 }],
         },
       }),
-    ).rejects.toThrow(/exceeds/i);
+    ).rejects.toThrow("Media exceeds 8B limit");
+  });
+
+  it("reports the configured byte cap when image optimization cannot meet it", async () => {
+    await expect(
+      loadWebMedia(tinyPngFile, { maxBytes: 8, localRoots: [fixtureRoot] }),
+    ).rejects.toThrow(/^Media could not be reduced below 8B \(got /);
   });
 
   it("uses the strictest model image maxBytes across fallback candidates", () => {
@@ -641,31 +647,37 @@ describe("loadWebMedia", () => {
     expect(result.buffer.length).toBeGreaterThan(0);
   });
 
-  it("rejects oversized local media before an unbounded file-handle read", async () => {
-    const maxBytes = 1024 * 1024;
-    const oversizedFile = path.join(fixtureRoot, "oversized.bin");
-    await fs.writeFile(oversizedFile, Buffer.alloc(maxBytes + 1));
-    let unboundedReadCalled = false;
-    __setFsSafeTestHooksForTest({
-      afterOpen: (filePath, handle) => {
-        if (filePath !== oversizedFile) {
-          return;
-        }
-        vi.spyOn(handle, "readFile").mockImplementation(async () => {
-          unboundedReadCalled = true;
-          throw new Error("unbounded read invoked");
-        });
-      },
-    });
+  it.each([
+    { maxBytes: 1024 * 1024, expectedLimit: "1MB" },
+    { maxBytes: 256 * 1024, expectedLimit: "256KB" },
+    { maxBytes: 1.5 * 1024 * 1024, expectedLimit: "1.50MB" },
+  ])(
+    "rejects oversized local media before an unbounded file-handle read ($expectedLimit)",
+    async ({ maxBytes, expectedLimit }) => {
+      const oversizedFile = path.join(fixtureRoot, "oversized.bin");
+      await fs.writeFile(oversizedFile, Buffer.alloc(maxBytes + 1));
+      let unboundedReadCalled = false;
+      __setFsSafeTestHooksForTest({
+        afterOpen: (filePath, handle) => {
+          if (filePath !== oversizedFile) {
+            return;
+          }
+          vi.spyOn(handle, "readFile").mockImplementation(async () => {
+            unboundedReadCalled = true;
+            throw new Error("unbounded read invoked");
+          });
+        },
+      });
 
-    await expect(
-      loadWebMediaRaw(oversizedFile, {
-        maxBytes,
-        localRoots: [fixtureRoot],
-      }),
-    ).rejects.toThrow("Media exceeds 1MB limit");
-    expect(unboundedReadCalled).toBe(false);
-  });
+      await expect(
+        loadWebMediaRaw(oversizedFile, {
+          maxBytes,
+          localRoots: [fixtureRoot],
+        }),
+      ).rejects.toThrow(`Media exceeds ${expectedLimit} limit`);
+      expect(unboundedReadCalled).toBe(false);
+    },
+  );
 
   it.runIf(process.platform !== "win32")(
     "rejects local media when an allowed ancestor symlink retargets before open",

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -53,6 +53,7 @@ import {
   readImageProbeFromHeader,
 } from "./media-services.js";
 import { extractOriginalFilename, getMediaDir } from "./store.js";
+import { formatMediaSize } from "./store.shared.js";
 
 export { getDefaultLocalRootsCore, LocalMediaAccessError };
 export type { LocalMediaAccessErrorCode };
@@ -207,7 +208,6 @@ const HOST_READ_DECLARED_TEXT_ERROR =
 const HOST_READ_TEXT_PLAIN_EXTENSION_BY_MIME: Record<string, readonly string[]> = {
   "text/plain": [".txt"],
 };
-const MB = 1024 * 1024;
 
 function stripLegacyMediaDirectivePrefix(mediaUrl: string): string {
   if (/^\s*media:\/\//i.test(mediaUrl)) {
@@ -499,16 +499,12 @@ function isAllowedHostReadTextAlias(mime: string | undefined, filePath?: string)
   return ext !== undefined && allowedExtensions.includes(ext);
 }
 
-function formatMb(bytes: number, digits = 2): string {
-  return (bytes / MB).toFixed(digits);
-}
-
 function formatCapLimit(label: string, cap: number, size: number): string {
-  return `${label} exceeds ${formatMb(cap, 0)}MB limit (got ${formatMb(size)}MB)`;
+  return `${label} exceeds ${formatMediaSize(cap)} limit (got ${formatMediaSize(size)})`;
 }
 
 function formatCapReduce(label: string, cap: number, size: number): string {
-  return `${label} could not be reduced below ${formatMb(cap, 0)}MB (got ${formatMb(size)}MB)`;
+  return `${label} could not be reduced below ${formatMediaSize(cap)} (got ${formatMediaSize(size)})`;
 }
 
 function isHeicSource(opts: { contentType?: string; fileName?: string }): boolean {
@@ -897,12 +893,12 @@ function logOptimizedImage(params: { originalSize: number; optimized: OptimizedI
   }
   if (params.optimized.format === "png") {
     logVerbose(
-      `Optimized PNG (preserving alpha) from ${formatMb(params.originalSize)}MB to ${formatMb(params.optimized.optimizedSize)}MB (side<=${params.optimized.resizeSide}px)`,
+      `Optimized PNG (preserving alpha) from ${formatMediaSize(params.originalSize)} to ${formatMediaSize(params.optimized.optimizedSize)} (side<=${params.optimized.resizeSide}px)`,
     );
     return;
   }
   logVerbose(
-    `Optimized media from ${formatMb(params.originalSize)}MB to ${formatMb(params.optimized.optimizedSize)}MB (side<=${params.optimized.resizeSide}px, q=${params.optimized.quality})`,
+    `Optimized media from ${formatMediaSize(params.originalSize)} to ${formatMediaSize(params.optimized.optimizedSize)} (side<=${params.optimized.resizeSide}px, q=${params.optimized.quality})`,
   );
 }
 
@@ -926,7 +922,7 @@ async function optimizeImageWithFallback(params: {
     transparency: "auto",
   });
   if (optimized.chosen.transparency === "flattened" && shouldLogVerbose()) {
-    logVerbose(`Image transparency flattened to fit ${formatMb(cap, 0)}MB optimization budget`);
+    logVerbose(`Image transparency flattened to fit ${formatMediaSize(cap)} optimization budget`);
   }
   return {
     buffer: optimized.data,
@@ -1212,7 +1208,7 @@ async function loadWebMediaInternal(
     } catch (err) {
       if (err instanceof FsSafeError) {
         if (err.code === "too-large") {
-          throw new Error(`Media exceeds ${formatMb(sourceReadCap, 0)}MB limit`, {
+          throw new Error(`Media exceeds ${formatMediaSize(sourceReadCap)} limit`, {
             cause: err,
           });
         }


### PR DESCRIPTION
Related: #136685 (the earlier storage-cap repair; this fixes its separate loader and tool-result follow-up).

## What Problem This Solves

Fixes an issue where operators reading rejected-media errors would see misleading whole-megabyte limits for fractional or small byte caps. A tool image that cannot fit an 8-byte limit currently reports a `0MB` limit. Local media ingestion and optimization diagnostics have the same rounding problem.

## Why This Change Was Made

Media loading now shares the existing storage error formatter, and tool image omissions use the formatter already used by their resize logs. This removes the duplicate whole-MB conversion paths without changing file access, image processing, acceptance thresholds, or public interfaces.

## User Impact

Size failures identify the effective cap in readable byte units. The image-result path still preserves captions and attachment metadata, and images that fit remain usable. No configuration, dependency, SDK export, persistence, or protocol change is introduced.

## Evidence

The same unmocked public `imageResultFromFile` probe was run before and after on base `0894af43024c4eccce603b794c8a0008d26e49ae`, using the normal repository loader and Rastermill 0.3.2. With an 8-byte cap, the real encoder reached 611 bytes. Before: the assertion failed because the result said `below 0MB (got 0.00MB)`. After: it passed with `below 8B (got 611B)`. The accepted control remained a byte-identical 613-byte JPEG, with captions and attachment metadata preserved. Both runs cleaned up their isolated fixtures and completed process closure.

Fresh affected-owner tests passed: **263 cases in seven files**, covering web media (100), tool images (23), and storage/download handling (140), with no failures or skipped cases. The six-file formatter made no further changes. All 29 checks selected by the maintained changed-file plan passed. Two independent Codex source reviews returned no actionable P0–P2 findings across six complete review passes. [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33715295783) and the required `openclaw/ci-gate` passed on `4090d4029817a5eb67b34d26d14713ab29ef5468`. The probe exercises the source SDK helper and actual encoder, not a packaged CLI, Gateway, provider or channel send.

Regression introduction is unknown; the defective behavior was reproduced directly on the current-main baseline.

Production: +21/-24 (net -3). Tests: +81/-26 (net +55). Documentation: +1/-1.

The repair is extracted from a broader local media investigation. Telegram and Feishu changes are excluded and retain their separate channel-verification requirements.

Validated head: `4090d4029817a5eb67b34d26d14713ab29ef5468`.

Maintainer disposition: accepted this diagnostic-only repair under the authorized maintainer repair workflow. The refreshed ClawSweeper review found no correctness or security issues; its remaining items were the maintainer landing decision. Merged as `30066c6164a346d3defb3b55636520752f7e1d32`, with ancestry verified on `main`.
