### PR TITLE
fix(qa): fail before unwritable Telegram test chats

### DIFF
--- a/.agents/skills/telegram-e2e-userbot/scripts/telegram-test-doctor.mjs
+++ b/.agents/skills/telegram-e2e-userbot/scripts/telegram-test-doctor.mjs
@@ -24,19 +24,32 @@ export async function runTelegramTestDoctor({
   let proxy;
   try {
     const driverEnv = { ...sanitizeChildEnvironment(), ...credential.driverEnv };
-    const status = await runCommandImpl("uv", ["run", USER_DRIVER_PATH, "status", "--json"], {
-      cwd: process.cwd(),
-      env: driverEnv,
-      leaseFailure,
-      timeoutMs: 30_000,
-    });
-    if (status.status !== 0 || status.timedOut) {
+    const status = await runCommandImpl(
+      "uv",
+      ["run", USER_DRIVER_PATH, "status", "--json", "--chat", credential.groupId],
+      {
+        cwd: process.cwd(),
+        env: driverEnv,
+        leaseFailure,
+        timeoutMs: 30_000,
+      },
+    );
+    if (status.timedOut) {
       throw new Error("TDLib Test Server user session is not authorized.");
     }
-    const driver = JSON.parse(status.stdout);
+    let driver;
+    try {
+      driver = JSON.parse(status.stdout);
+    } catch {
+      throw new Error(status.stderr.trim() || "TDLib Test Server user status failed.");
+    }
+    if (status.status !== 0 && driver.ok !== false) {
+      throw new Error(status.stderr.trim() || "TDLib Test Server user status failed.");
+    }
+    if (driver.authorized !== true) {
+      throw new Error("TDLib Test Server user session is not authorized.");
+    }
     if (
-      driver.ok !== true ||
-      driver.authorized !== true ||
       driver.testDc !== true ||
       driver.tdlibVersion !== credential.tdlibVersion ||
       String(driver.user?.id) !== credential.testerUserId
@@ -96,8 +109,10 @@ export async function runTelegramTestDoctor({
     ) {
       throw new Error("Telegram Test Server bot is not an active member of the test group.");
     }
+    const testerGroupMembership = driver.testerGroupMembership === true;
+    const testerCanSendBasicMessages = driver.testerCanSendBasicMessages === true;
     return {
-      ok: true,
+      ok: testerGroupMembership && testerCanSendBasicMessages,
       credentialSource: "convex",
       credentialLoaded: true,
       isolatedTdlibState: true,
@@ -107,6 +122,8 @@ export async function runTelegramTestDoctor({
       sutBot: true,
       groupPrivacyDisabled: true,
       groupMembership: true,
+      testerGroupMembership,
+      testerCanSendBasicMessages,
     };
   } finally {
     await proxy?.close();
@@ -116,7 +133,12 @@ export async function runTelegramTestDoctor({
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   runTelegramTestDoctor()
-    .then((result) => console.log(JSON.stringify(result)))
+    .then((result) => {
+      console.log(JSON.stringify(result));
+      if (!result.ok) {
+        process.exitCode = 1;
+      }
+    })
     .catch((error) => {
       console.error(
         JSON.stringify({

--- a/.agents/skills/telegram-e2e-userbot/scripts/telegram-test-doctor.test.mjs
+++ b/.agents/skills/telegram-e2e-userbot/scripts/telegram-test-doctor.test.mjs
@@ -2,6 +2,62 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { runTelegramTestDoctor } from "./telegram-test-doctor.mjs";
 
+function credentialFixture(overrides = {}) {
+  return {
+    driverEnv: {},
+    groupId: "-1001",
+    sutBotId: "42",
+    sutToken: "sut-token",
+    sutUsername: "sut_bot",
+    tdlibVersion: "1.8.67",
+    testerUserId: "123",
+    whenLeaseUnhealthy: new Promise(() => {}),
+    assertLeaseHealthy() {},
+    async release() {},
+    ...overrides,
+  };
+}
+
+function statusFixture(overrides = {}, resultOverrides = {}) {
+  return {
+    status: 0,
+    stdout: JSON.stringify({
+      ok: true,
+      authorized: true,
+      testDc: true,
+      tdlibVersion: "1.8.67",
+      user: { id: 123 },
+      testerGroupMembership: true,
+      testerCanSendBasicMessages: true,
+      ...overrides,
+    }),
+    stderr: "",
+    timedOut: false,
+    ...resultOverrides,
+  };
+}
+
+function botApiFixture({ membershipStatus = "member", onGetMe } = {}) {
+  const methods = [];
+  const fetchImpl = async (url) => {
+    const method = new URL(url).pathname.split("/").at(-1);
+    methods.push(method);
+    if (method === "getMe") {
+      onGetMe?.();
+      return Response.json({
+        ok: true,
+        result: {
+          id: 42,
+          username: "sut_bot",
+          can_read_all_group_messages: true,
+        },
+      });
+    }
+    return Response.json({ ok: true, result: { status: membershipStatus } });
+  };
+  return { fetchImpl, methods };
+}
+
 test("doctor revocation after getMe prevents later Bot API calls and releases", async () => {
   const leaseError = new Error("doctor lease revoked");
   let healthy = true;
@@ -15,14 +71,7 @@ test("doctor revocation after getMe prevents later Bot API calls and releases", 
       resolve(leaseError);
     };
   });
-  const credential = {
-    driverEnv: {},
-    groupId: "-1001",
-    sutBotId: "42",
-    sutToken: "sut-token",
-    sutUsername: "sut_bot",
-    tdlibVersion: "1.8.56",
-    testerUserId: "123",
+  const credential = credentialFixture({
     whenLeaseUnhealthy,
     assertLeaseHealthy: () => {
       if (!healthy) throw leaseError;
@@ -30,7 +79,7 @@ test("doctor revocation after getMe prevents later Bot API calls and releases", 
     release: async () => {
       released = true;
     },
-  };
+  });
   const fetchImpl = async (url) => {
     methods.push(new URL(url).pathname.split("/").at(-1));
     return {
@@ -54,18 +103,7 @@ test("doctor revocation after getMe prevents later Bot API calls and releases", 
     runTelegramTestDoctor({
       acquireCredential: async () => credential,
       fetchImpl,
-      runCommandImpl: async () => ({
-        status: 0,
-        stdout: JSON.stringify({
-          ok: true,
-          authorized: true,
-          testDc: true,
-          tdlibVersion: "1.8.56",
-          user: { id: 123 },
-        }),
-        stderr: "",
-        timedOut: false,
-      }),
+      runCommandImpl: async () => statusFixture(),
       startProxy: async () => ({
         apiRoot: "http://127.0.0.1:19881",
         close: async () => {
@@ -77,5 +115,78 @@ test("doctor revocation after getMe prevents later Bot API calls and releases", 
   );
   assert.deepEqual(methods, ["getMe"]);
   assert.equal(proxyClosed, true);
+  assert.equal(released, true);
+});
+
+test("doctor preserves tester writability diagnostics and releases", async () => {
+  let released = false;
+  let proxyClosed = false;
+  const { fetchImpl, methods } = botApiFixture();
+  const result = await runTelegramTestDoctor({
+    acquireCredential: async () =>
+      credentialFixture({
+        release: async () => {
+          released = true;
+        },
+      }),
+    fetchImpl,
+    runCommandImpl: async (_command, args) => {
+      assert.deepEqual(args.slice(-4), ["status", "--json", "--chat", "-1001"]);
+      return statusFixture(
+        {
+          ok: false,
+          testerGroupMembership: true,
+          testerCanSendBasicMessages: false,
+        },
+        { status: 1 },
+      );
+    },
+    startProxy: async () => ({
+      apiRoot: "http://127.0.0.1:19881",
+      close: async () => {
+        proxyClosed = true;
+      },
+    }),
+  });
+
+  assert.deepEqual(methods, ["getMe", "getChatMember"]);
+  assert.deepEqual(result, {
+    ok: false,
+    credentialSource: "convex",
+    credentialLoaded: true,
+    isolatedTdlibState: true,
+    testDc: true,
+    tdlibAuthorized: true,
+    botApiProxy: true,
+    sutBot: true,
+    groupPrivacyDisabled: true,
+    groupMembership: true,
+    testerGroupMembership: true,
+    testerCanSendBasicMessages: false,
+  });
+  assert.equal(proxyClosed, true);
+  assert.equal(released, true);
+});
+
+test("doctor preserves operational user status failures and releases", async () => {
+  let released = false;
+  await assert.rejects(
+    runTelegramTestDoctor({
+      acquireCredential: async () =>
+        credentialFixture({
+          release: async () => {
+            released = true;
+          },
+        }),
+      runCommandImpl: async () => ({
+        status: 1,
+        stdout: "",
+        stderr: "searchPublicChat failed (500): unavailable",
+        timedOut: false,
+      }),
+      startProxy: async () => assert.fail("proxy must not start"),
+    }),
+    /searchPublicChat failed \(500\): unavailable/u,
+  );
   assert.equal(released, true);
 });

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
@@ -546,8 +546,7 @@ class UserDriver:
             return chat_writability(
                 member=True,
                 writable=(
-                    default_can_send
-                    and isinstance(can_message, dict)
+                    isinstance(can_message, dict)
                     and can_message.get("@type") == "canSendMessageToUserResultOk"
                 ),
             )

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
@@ -46,6 +46,13 @@ class DriverError(RuntimeError):
     pass
 
 
+def chat_writability(member=False, writable=False):
+    return {
+        "testerGroupMembership": member,
+        "testerCanSendBasicMessages": writable,
+    }
+
+
 def read_json(path):
     try:
         return json.loads(path.read_text())
@@ -514,6 +521,109 @@ class UserDriver:
                     f"Chat not found for tester account: {chat}. Add the QA user to the group, or configure the TDLib chat id from `user-driver.py chats --json`."
                 ) from error
 
+    def inspect_chat_writability(self, chat_id):
+        chat = self.client.request({"@type": "getChat", "chat_id": chat_id}, timeout=10)
+        chat_type = chat.get("type") if isinstance(chat, dict) else None
+        chat_type_name = chat_type.get("@type") if isinstance(chat_type, dict) else ""
+        default_permissions = chat.get("permissions") if isinstance(chat, dict) else None
+        default_can_send = (
+            isinstance(default_permissions, dict)
+            and default_permissions.get("can_send_basic_messages") is True
+        )
+
+        if chat_type_name == "chatTypePrivate":
+            user_id = chat_type.get("user_id")
+            if type(user_id) is not int or user_id <= 0:
+                return chat_writability()
+            can_message = self.client.request(
+                {
+                    "@type": "canSendMessageToUser",
+                    "user_id": user_id,
+                    "only_local": False,
+                },
+                timeout=10,
+            )
+            return chat_writability(
+                member=True,
+                writable=(
+                    default_can_send
+                    and isinstance(can_message, dict)
+                    and can_message.get("@type") == "canSendMessageToUserResultOk"
+                ),
+            )
+
+        if chat_type_name == "chatTypeBasicGroup":
+            group_id = chat_type.get("basic_group_id")
+            method = "getBasicGroup"
+            id_field = "basic_group_id"
+        elif (
+            chat_type_name == "chatTypeSupergroup"
+            and chat_type.get("is_channel") is False
+        ):
+            group_id = chat_type.get("supergroup_id")
+            method = "getSupergroup"
+            id_field = "supergroup_id"
+        else:
+            return chat_writability()
+        if type(group_id) is not int or group_id == 0:
+            return chat_writability()
+
+        group = self.client.request({"@type": method, id_field: group_id}, timeout=10)
+        status = group.get("status") if isinstance(group, dict) else None
+        if not isinstance(status, dict):
+            return chat_writability()
+
+        status_type = status.get("@type")
+        if status_type == "chatMemberStatusCreator":
+            member = status.get("is_member") is True
+            return chat_writability(member=member, writable=member)
+        if status_type == "chatMemberStatusAdministrator":
+            return chat_writability(member=True, writable=True)
+        if status_type == "chatMemberStatusMember":
+            member = True
+            personal_can_send = True
+        elif status_type == "chatMemberStatusRestricted":
+            personal_permissions = status.get("permissions")
+            personal_can_send = (
+                isinstance(personal_permissions, dict)
+                and personal_permissions.get("can_send_basic_messages") is True
+            )
+            member = status.get("is_member") is True
+        else:
+            return chat_writability()
+
+        writable = member and personal_can_send and default_can_send
+        if member and personal_can_send and chat_type_name == "chatTypeSupergroup":
+            full_info = self.client.request(
+                {"@type": "getSupergroupFullInfo", "supergroup_id": group_id},
+                timeout=10,
+            )
+            paid_message_star_count = full_info.get(
+                "outgoing_paid_message_star_count"
+            )
+            my_boost_count = full_info.get("my_boost_count")
+            unrestrict_boost_count = full_info.get("unrestrict_boost_count")
+            bypasses_default_permissions = (
+                type(my_boost_count) is int
+                and type(unrestrict_boost_count) is int
+                and unrestrict_boost_count > 0
+                and my_boost_count >= unrestrict_boost_count
+            )
+            writable = (
+                type(paid_message_star_count) is int
+                and paid_message_star_count == 0
+                and (default_can_send or bypasses_default_permissions)
+            )
+        return chat_writability(member=member, writable=writable)
+
+    def require_chat_writable(self, chat_id):
+        writability = self.inspect_chat_writability(chat_id)
+        if not writability["testerCanSendBasicMessages"]:
+            raise DriverError(
+                "Telegram tester cannot send basic messages to the selected chat."
+            )
+        return writability
+
     def formatted_text(self, text):
         sut = resolve_sut(self.config, self.bot_config)
         username = sut.get("username") or ""
@@ -805,17 +915,25 @@ def command_status(args):
     me = driver.client.request({"@type": "getMe"})
     version = driver.client.request({"@type": "getOption", "name": "version"})
     save_tester_identity(config, me)
+    writability = None
+    if args.chat:
+        chat_id = driver.resolve_chat(args.chat)
+        writability = driver.inspect_chat_writability(chat_id)
+    ok = writability is None or writability["testerCanSendBasicMessages"]
     print_result(
         {
-            "ok": True,
+            "ok": ok,
             "authorized": True,
             "testDc": config.get("testDc") is True,
             "tdlibVersion": version.get("value", ""),
             "user": public_user(me),
+            **(writability or {}),
         },
         args.json,
         getattr(args, "output", ""),
     )
+    if not ok:
+        sys.exit(1)
 
 
 def command_confirm_qr(args):
@@ -1036,6 +1154,7 @@ def command_serve(args):
     driver = UserDriver(config, bot_config)
     driver.authorize(argparse.Namespace(timeout_ms=args.timeout_ms))
     chat_id = driver.resolve_chat(args.chat)
+    driver.require_chat_writable(chat_id)
     tester = driver.client.request({"@type": "getMe"})
     write_ndjson(
         {
@@ -1127,6 +1246,7 @@ def main():
 
     status = sub.add_parser("status")
     add_common(status)
+    status.add_argument("--chat", default="")
     status.set_defaults(func=command_status)
 
     confirm_qr = sub.add_parser("confirm-qr")

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
@@ -171,17 +171,43 @@ class PhotoContentTest(unittest.TestCase):
                 )
 
     def test_private_writability_uses_can_send_result(self):
-        chat = {
-            "type": {"@type": "chatTypePrivate", "user_id": 77},
-            "permissions": {"can_send_basic_messages": True},
-        }
-        for result_type, writable in [
-            ("canSendMessageToUserResultOk", True),
-            ("canSendMessageToUserResultUserHasPaidMessages", False),
-            ("canSendMessageToUserResultUserIsDeleted", False),
-            ("canSendMessageToUserResultUserRestrictsNewChats", False),
+        for name, permissions, result_type, writable in [
+            (
+                "allowed with group-style permission",
+                {"can_send_basic_messages": True},
+                "canSendMessageToUserResultOk",
+                True,
+            ),
+            ("allowed without permissions", None, "canSendMessageToUserResultOk", True),
+            (
+                "allowed despite denied group-style permission",
+                {"can_send_basic_messages": False},
+                "canSendMessageToUserResultOk",
+                True,
+            ),
+            (
+                "paid messages",
+                {"can_send_basic_messages": True},
+                "canSendMessageToUserResultUserHasPaidMessages",
+                False,
+            ),
+            (
+                "deleted user",
+                {"can_send_basic_messages": True},
+                "canSendMessageToUserResultUserIsDeleted",
+                False,
+            ),
+            (
+                "restricted new chats",
+                {"can_send_basic_messages": True},
+                "canSendMessageToUserResultUserRestrictsNewChats",
+                False,
+            ),
         ]:
-            with self.subTest(result_type=result_type):
+            with self.subTest(name=name):
+                chat = {"type": {"@type": "chatTypePrivate", "user_id": 77}}
+                if permissions is not None:
+                    chat["permissions"] = permissions
                 result, requests = self.inspect_chat(
                     chat,
                     {"canSendMessageToUser": {"@type": result_type}},

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
@@ -1,8 +1,12 @@
 import importlib.util
+import io
+import json
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
+from unittest import mock
 
 
 DRIVER_PATH = Path(__file__).with_name("user-driver.py")
@@ -12,7 +16,26 @@ sys.modules["tg_user_driver_test_target"] = driver
 SPEC.loader.exec_module(driver)
 
 
+class FakeTdlibClient:
+    def __init__(self, responses):
+        self.responses = responses
+        self.requests = []
+
+    def request(self, payload, timeout=20):
+        self.requests.append((payload, timeout))
+        response = self.responses.get(payload["@type"])
+        if response is None:
+            raise AssertionError(payload)
+        return response(payload) if callable(response) else response
+
+
 class PhotoContentTest(unittest.TestCase):
+    def inspect_chat(self, chat, responses, chat_id=-1001):
+        client = FakeTdlibClient({"getChat": chat, **responses})
+        instance = driver.UserDriver.__new__(driver.UserDriver)
+        instance.client = client
+        return instance.inspect_chat_writability(chat_id), client.requests
+
     def test_rejects_unsafe_prebuilt_archive_members(self):
         class FakeTar:
             extracted = False
@@ -79,6 +102,248 @@ class PhotoContentTest(unittest.TestCase):
             [payload["@type"] for payload, _timeout in instance.client.requests],
             ["getChat", "loadChats", "getChat"],
         )
+
+    def test_effective_group_writability(self):
+        chat = {
+            "type": {
+                "@type": "chatTypeSupergroup",
+                "supergroup_id": 7,
+                "is_channel": False,
+            },
+            "permissions": {"can_send_basic_messages": True},
+        }
+        cases = [
+            ("creator", {"@type": "chatMemberStatusCreator", "is_member": True}, True, None, True, True),
+            ("detached creator", {"@type": "chatMemberStatusCreator", "is_member": False}, True, None, False, False),
+            ("administrator", {"@type": "chatMemberStatusAdministrator"}, False, None, True, True),
+            ("member", {"@type": "chatMemberStatusMember"}, True, None, True, True),
+            (
+                "paid member",
+                {"@type": "chatMemberStatusMember"},
+                True,
+                {"outgoing_paid_message_star_count": 5},
+                True,
+                False,
+            ),
+            (
+                "default restricted",
+                {"@type": "chatMemberStatusMember"},
+                False,
+                {"my_boost_count": 0, "unrestrict_boost_count": 2},
+                True,
+                False,
+            ),
+            (
+                "booster",
+                {"@type": "chatMemberStatusMember"},
+                False,
+                {"my_boost_count": 2, "unrestrict_boost_count": 2},
+                True,
+                True,
+            ),
+            (
+                "personally restricted",
+                {
+                    "@type": "chatMemberStatusRestricted",
+                    "is_member": True,
+                    "permissions": {"can_send_basic_messages": False},
+                },
+                True,
+                None,
+                True,
+                False,
+            ),
+            ("left", {"@type": "chatMemberStatusLeft"}, True, None, False, False),
+        ]
+
+        for name, status, default_allowed, full_info, member, writable in cases:
+            with self.subTest(name=name):
+                chat["permissions"]["can_send_basic_messages"] = default_allowed
+                responses = {"getSupergroup": {"status": status}}
+                responses["getSupergroupFullInfo"] = {
+                    "outgoing_paid_message_star_count": 0,
+                    **(full_info or {}),
+                }
+                result, _requests = self.inspect_chat(chat, responses)
+                self.assertEqual(
+                    result,
+                    driver.chat_writability(member=member, writable=writable),
+                )
+
+    def test_private_writability_uses_can_send_result(self):
+        chat = {
+            "type": {"@type": "chatTypePrivate", "user_id": 77},
+            "permissions": {"can_send_basic_messages": True},
+        }
+        for result_type, writable in [
+            ("canSendMessageToUserResultOk", True),
+            ("canSendMessageToUserResultUserHasPaidMessages", False),
+            ("canSendMessageToUserResultUserIsDeleted", False),
+            ("canSendMessageToUserResultUserRestrictsNewChats", False),
+        ]:
+            with self.subTest(result_type=result_type):
+                result, requests = self.inspect_chat(
+                    chat,
+                    {"canSendMessageToUser": {"@type": result_type}},
+                    chat_id=42,
+                )
+                self.assertEqual(
+                    result,
+                    driver.chat_writability(member=True, writable=writable),
+                )
+                self.assertEqual(
+                    [payload["@type"] for payload, _timeout in requests],
+                    ["getChat", "canSendMessageToUser"],
+                )
+
+    def test_basic_group_and_channel_boundaries(self):
+        basic, requests = self.inspect_chat(
+            {
+                "type": {"@type": "chatTypeBasicGroup", "basic_group_id": 7},
+                "permissions": {"can_send_basic_messages": True},
+            },
+            {"getBasicGroup": {"status": {"@type": "chatMemberStatusMember"}}},
+            chat_id=-7,
+        )
+        channel, channel_requests = self.inspect_chat(
+            {
+                "type": {
+                    "@type": "chatTypeSupergroup",
+                    "supergroup_id": 7,
+                    "is_channel": True,
+                },
+                "permissions": {"can_send_basic_messages": True},
+            },
+            {},
+        )
+        self.assertEqual(basic, driver.chat_writability(member=True, writable=True))
+        self.assertEqual(
+            [payload["@type"] for payload, _timeout in requests],
+            ["getChat", "getBasicGroup"],
+        )
+        self.assertEqual(channel, driver.chat_writability())
+        self.assertEqual(len(channel_requests), 1)
+
+    def test_status_preserves_chat_resolution_errors(self):
+        class FakeClient:
+            def request(self, payload, timeout=20):
+                if payload["@type"] == "getMe":
+                    return {"id": 123, "type": {"@type": "userTypeRegular"}}
+                return {"value": "1.8.67"}
+
+        class FakeDriver:
+            client = FakeClient()
+
+            def authorize(self, _args, need_ready=True):
+                return True
+
+            def resolve_chat(self, _chat):
+                raise driver.DriverError("searchPublicChat failed (500): unavailable")
+
+            def inspect_chat_writability(self, _chat_id):
+                raise AssertionError("resolution must succeed before capability inspection")
+
+        stdout = io.StringIO()
+        with (
+            mock.patch.object(driver, "load_config", return_value=({"testDc": True}, {})),
+            mock.patch.object(driver, "UserDriver", return_value=FakeDriver()),
+            mock.patch.object(driver, "save_tester_identity"),
+            redirect_stdout(stdout),
+            self.assertRaisesRegex(driver.DriverError, "unavailable"),
+        ):
+            driver.command_status(
+                driver.argparse.Namespace(
+                    timeout_ms=30_000,
+                    chat="@unavailable",
+                    json=True,
+                    output="",
+                )
+            )
+        self.assertEqual(stdout.getvalue(), "")
+
+    def test_status_reports_resolved_unwritable_chat(self):
+        class FakeClient:
+            def request(self, payload, timeout=20):
+                if payload["@type"] == "getMe":
+                    return {"id": 123, "type": {"@type": "userTypeRegular"}}
+                return {"value": "1.8.67"}
+
+        class FakeDriver:
+            client = FakeClient()
+
+            def authorize(self, _args, need_ready=True):
+                return True
+
+            def resolve_chat(self, _chat):
+                return -1001
+
+            def inspect_chat_writability(self, chat_id):
+                self.inspected = chat_id
+                return driver.chat_writability(member=True)
+
+        fake_driver = FakeDriver()
+        stdout = io.StringIO()
+        with (
+            mock.patch.object(driver, "load_config", return_value=({"testDc": True}, {})),
+            mock.patch.object(driver, "UserDriver", return_value=fake_driver),
+            mock.patch.object(driver, "save_tester_identity"),
+            redirect_stdout(stdout),
+            self.assertRaises(SystemExit) as exit_context,
+        ):
+            driver.command_status(
+                driver.argparse.Namespace(
+                    timeout_ms=30_000,
+                    chat="-1001",
+                    json=True,
+                    output="",
+                )
+            )
+        self.assertEqual(exit_context.exception.code, 1)
+        self.assertEqual(fake_driver.inspected, -1001)
+        result = json.loads(stdout.getvalue())
+        self.assertEqual(result["testerGroupMembership"], True)
+        self.assertEqual(result["testerCanSendBasicMessages"], False)
+
+    def test_command_serve_preflights_before_ready(self):
+        events = []
+
+        class FakeClient:
+            users = {}
+
+            def request(self, payload, timeout=20):
+                return {"id": 123, "type": {"@type": "userTypeRegular"}}
+
+            def next_update(self, timeout=0.1):
+                return None
+
+        class FakeDriver:
+            client = FakeClient()
+
+            def authorize(self, _args):
+                events.append("authorize")
+
+            def resolve_chat(self, _chat):
+                events.append("resolve")
+                return -1001
+
+            def require_chat_writable(self, chat_id):
+                events.append(("preflight", chat_id))
+                raise driver.DriverError("tester chat is unwritable")
+
+        with (
+            mock.patch.object(driver, "load_config", return_value=({}, {})),
+            mock.patch.object(driver, "UserDriver", return_value=FakeDriver()),
+            mock.patch.object(driver, "write_ndjson") as write_ndjson,
+            mock.patch.object(driver.select, "select", return_value=([sys.stdin], [], [])),
+            mock.patch.object(driver.sys, "stdin", io.StringIO("")),
+            self.assertRaisesRegex(driver.DriverError, "unwritable"),
+        ):
+            driver.command_serve(
+                driver.argparse.Namespace(timeout_ms=30_000, chat="-1001")
+            )
+
+        self.assertEqual(events, ["authorize", "resolve", ("preflight", -1001)])
+        write_ndjson.assert_not_called()
 
     def test_marks_sut_mentions_and_commands_with_utf16_entities(self):
         instance = driver.UserDriver.__new__(driver.UserDriver)

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-record.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-record.py
@@ -521,6 +521,7 @@ def main():
     # One resolution path for every chat form the driver accepts: numeric id,
     # @username (the DM lane passes the SUT's username), or an invite link.
     chat_id = driver_obj.resolve_chat(args.chat)
+    driver_obj.require_chat_writable(chat_id)
     sut = driver.resolve_sut(config, bot_config)
     sut_user_id = args.sut_user_id or sut.get("id") or ""
 

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-record.test.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-record.test.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 RECORD_PATH = Path(__file__).with_name("user-record.py")
@@ -48,6 +49,58 @@ class CallbackScenarioTest(unittest.TestCase):
                 },
             )
             self.assertEqual(list(target.parent.glob(".*.tmp")), [])
+
+    def test_checks_chat_writability_before_publishing_ready(self):
+        events = []
+
+        class FakeDriver:
+            client = object()
+
+            def resolve_chat(self, _chat):
+                return -1001
+
+            def require_chat_writable(self, chat_id):
+                events.append(("preflight", chat_id))
+
+        class FakeRecorder:
+            def __init__(self, _client, chat_id, _record, _sut_user_id):
+                self.chat_id = chat_id
+                self.started_at = 1
+
+            def close(self):
+                pass
+
+            def summary(self):
+                return {"timeline": []}
+
+        fake_driver = FakeDriver()
+        with tempfile.TemporaryDirectory() as directory:
+            scenario_path = Path(directory) / "scenario.json"
+            scenario_path.write_text('{"actions":[]}\n')
+            argv = [
+                "user-record.py",
+                "--scenario",
+                str(scenario_path),
+                "--ready-file",
+                str(Path(directory) / "ready.json"),
+                "--seconds",
+                "0",
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(record, "build_driver", return_value=({}, {}, fake_driver)),
+                mock.patch.object(record, "EventRecorder", FakeRecorder),
+                mock.patch.object(record.driver, "resolve_sut", return_value={}),
+                mock.patch.object(
+                    record,
+                    "publish_recorder_ready",
+                    side_effect=lambda *_args: events.append(("ready", -1001)),
+                ),
+                mock.patch("builtins.print"),
+            ):
+                record.main()
+
+        self.assertEqual(events, [("preflight", -1001), ("ready", -1001)])
 
     def test_ignores_cached_messages_from_before_recording_window(self):
         recorder = record.EventRecorder(FakeClient(), -1001, "", 42)


### PR DESCRIPTION
Closes #136986

## What Problem This Solves

Telegram Test Server QA could report a leased tester session as ready even when
the tester could not send basic messages to the selected chat. The first
scenario action then failed late with `Have no write access to the chat`.

## Repair

- A single TDLib-backed helper evaluates tester membership and effective basic
  message writability for private chats, basic groups, and non-channel
  supergroups.
- Private-chat writability depends only on TDLib returning
  `canSendMessageToUserResultOk`; group default permissions do not apply to DMs.
- Chat lookup and other operational `DriverError` failures remain operational
  failures. Writability is inspected only after chat resolution succeeds.
- `command_serve` and the recorder require writability before publishing any
  ready output.
- The doctor reports resolved-but-unwritable capability fields while preserving
  operational failures. Proxy and credential lease cleanup remains in `finally`.
- Broadcast channels remain outside this QA skill's documented group/DM scope.

## Dependency Contract

Direct TDLib source was inspected at
`d1085f9cebc5a62379991ae1652673954f229c1f`:

- `chat.permissions` provides default non-administrator permissions for groups.
- creator/administrator status bypasses group defaults; restricted members
  retain personal restrictions.
- qualifying supergroup boosts can bypass default restrictions.
- `supergroupFullInfo.outgoing_paid_message_star_count` independently requires
  paid-message consent, so a non-zero value is not ready for this unpaid QA path.
- `canSendMessageToUserResultOk` means the private user can be messaged, so it is
  the sole DM writability predicate.

## Evidence

Repaired head: `1fcc70d0319b7e99c4704030edf84e578146e9b7`

Focused validation on that exact tree:

- `uv run --python 3.12 python .agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py`:
  15 passed
- `uv run --python 3.12 python .agents/skills/telegram-e2e-userbot/scripts/user-record.test.py`:
  5 passed
- `node --test .agents/skills/telegram-e2e-userbot/scripts/telegram-test-doctor.test.mjs`:
  3 passed
- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts`:
  9 passed
- `node scripts/check-changed.mjs -- .agents/skills/telegram-e2e-userbot/scripts/user-driver.py .agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py`:
  all selected repository lanes passed, including typecheck, lint, and import-cycle checks
- `git diff --check`: passed
- P1 autoreview against pinned merge base
  `3ed226a746a8efd223a35a81790014c41ff044a3`: scoped clean, no actionable
  findings (0.96 confidence)

The DM regression now covers a successful direct capability result when
`chat.permissions` is absent, when group-style basic-message permission is true,
and when it is false. Existing negative TDLib result coverage remains.

Full PR delta:

- production/tooling: `+155/-13`, net `+142`
- tests: `+476/-21`, net `+455`

The focused repair itself is production/tooling `+1/-2`, net `-1`, and tests
`+36/-10`, net `+26`. No rebase was performed.

## Mandatory Live Proof

Still pending:

- [ ] writable group reaches ready and sends successfully
- [ ] unwritable group is rejected before ready output
- [ ] DM reaches ready and sends successfully
- [ ] every attempt releases its Convex lease and removes task-owned runtime
      processes, listeners, and scratch state
- [ ] exact-head required CI is green

Authenticated Telegram Test Server proof is unavailable from this checkout
because the local authenticated Convex broker client and non-interactive broker
credentials are absent. No credential lease was acquired.

Exact-head CI for `1fcc70d0319b7e99c4704030edf84e578146e9b7` is currently queued or
running.

Do not merge until all three live cases and exact-head CI are green.
