### PR TITLE
feat(ui): add readable person activity URLs

### DIFF
--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -134,6 +134,35 @@ keeps their panes and drafts separate, including in split view. Continuing a
 thread navigates to the adopted OpenClaw session link. The same catalog query
 also works under `/dashboard/<agentId>`.
 
+## Person activity URLs
+
+Open a person's recent sessions with a readable Activity link:
+
+```text
+/activity/ada-12345678abcd
+/activity/ada-12345678abcd?time=30d&q=release
+```
+
+New links use the person's display-name slug and the first 12 lowercase
+hexadecimal characters of their profile UUID, with UUID dashes omitted. The
+name is decorative: renamed people and stale names still resolve by the id
+prefix. A missing name produces a bare-prefix link.
+
+Prefixes from 8 through 32 hexadecimal characters are accepted. If a prefix
+matches several profiles, Activity shows an error instead of choosing a person.
+Recorded profile identities in retained sessions still resolve if their profile
+row is missing; they also participate in ambiguity checks before session filters.
+Use a longer prefix, the full 32-character compact UUID, or the full dashed
+UUID to select the exact profile. Names never break a tie.
+
+Existing `/activity?person=<profile-id>` links remain accepted and are replaced
+with the person path after resolution, without adding browser history. Search
+and time filters remain query parameters. Exact UUID bookmarks retain all 32
+hexadecimal characters, and unresolved IDs never redirect to a shorter prefix.
+Clearing the person filter returns
+to `/activity` while retaining those filters. Normal Gateway authentication
+and session visibility rules apply to every form.
+
 ## Focus presentation routes
 
 A focus route renders one supported content surface without the normal Control
@@ -237,52 +266,53 @@ With `gateway.controlUi.basePath: "/openclaw"`, use
 This table lists every Control UI application route. A dash means the route has
 no route-specific URL parameters.
 
-| Page                | Canonical path              | Aliases                   | Parameters or dynamic forms                                       |
-| ------------------- | --------------------------- | ------------------------- | ----------------------------------------------------------------- |
-| Chat                | `/chat`                     | -                         | Key-backed session forms above; `?draft=<text>`                   |
-| Dashboard           | `/dashboard`                | -                         | Key-backed session forms above; `?draft=<text>`                   |
-| Beam transcript     | `/beam/<title>-<beam-id>`   | `/beam/<beam-id>`         | Optional title slug and 12-32 lowercase hexadecimal id characters |
-| Dashboards          | `/dashboards`               | -                         | -                                                                 |
-| Ask OpenClaw        | `/custodian`                | -                         | `?intent=new-agent`, `?onboarding=1`                              |
-| New session         | `/new`                      | -                         | `?agent=<agentId>`, `?catalog=<catalogId>`                        |
-| Activity            | `/activity`                 | -                         | `?view=run&run=<run-id>`, `?view=run&execution=<execution-id>`    |
-| Apps                | `/apps`                     | -                         | -                                                                 |
-| Portals             | `/portals`                  | -                         | -                                                                 |
-| Agents              | `/settings/agents`          | `/agents`                 | `/settings/agents/<agentId>[/<panel>]`                            |
-| Channels            | `/settings/channels`        | `/channels`               | Shared settings parameters below                                  |
-| Connection          | `/settings/connection`      | -                         | Shared settings parameters below                                  |
-| Legacy General      | `/settings/general`         | `/config`                 | Redirects to Appearance → Language                                |
-| Profile             | `/settings/profile`         | `/profile`                | Shared settings parameters below                                  |
-| Communications      | `/settings/communications`  | `/communications`         | Shared settings parameters below                                  |
-| Appearance          | `/settings/appearance`      | `/appearance`             | Shared settings parameters below                                  |
-| Notifications       | `/settings/notifications`   | -                         | Shared settings parameters below                                  |
-| Security            | `/settings/security`        | -                         | Shared settings parameters below                                  |
-| Secrets             | `/settings/secrets`         | -                         | Shared settings parameters below                                  |
-| Advanced            | `/settings/advanced`        | -                         | Shared settings parameters below                                  |
-| Approvals           | `/settings/approvals`       | -                         | Shared settings parameters below                                  |
-| Automation settings | `/settings/automation`      | `/automation`             | Shared settings parameters below                                  |
-| MCP                 | `/settings/mcp`             | `/mcp`                    | Shared settings parameters below                                  |
-| Memory              | `/settings/memory`          | -                         | `/settings/memory/memories\|dreams\|settings`                     |
-| Infrastructure      | `/settings/infrastructure`  | `/infrastructure`         | Shared settings parameters below                                  |
-| Labs                | `/settings/labs`            | -                         | Shared settings parameters below                                  |
-| About               | `/settings/about`           | -                         | Shared settings parameters below                                  |
-| AI and agents       | `/settings/ai-agents`       | `/ai-agents`              | Shared settings parameters below                                  |
-| Model setup         | `/settings/model-setup`     | `/model-setup`            | `?firstRun=1`                                                     |
-| Model providers     | `/settings/model-providers` | `/model-providers`        | Shared settings parameters below                                  |
-| Import memory       | `/memory-import`            | `/settings/memory-import` | -                                                                 |
-| Workboard           | `/workboard`                | -                         | `/workboard/<boardId>`                                            |
-| Worktrees           | `/worktrees`                | `/settings/worktrees`     | -                                                                 |
-| Sessions            | `/sessions`                 | `/settings/sessions`      | `?session=<sessionKey>`, `?status=archived\|all`                  |
-| Usage               | `/usage`                    | -                         | -                                                                 |
-| Debug               | `/debug`                    | -                         | -                                                                 |
-| Logs                | `/logs`                     | -                         | -                                                                 |
-| Skill Workshop      | `/skills/workshop`          | -                         | -                                                                 |
-| Skills              | `/skills`                   | -                         | -                                                                 |
-| Plugins             | `/settings/plugins`         | -                         | `/settings/plugins/discover`                                      |
-| Automations         | `/cron`                     | -                         | `?job=<jobId>`, `?job=<jobId>&run=<runId>`                        |
-| Tasks               | `/tasks`                    | -                         | -                                                                 |
-| Devices             | `/settings/devices`         | `/nodes`                  | Shared settings parameters below                                  |
-| Plugin tab host     | `/plugin`                   | -                         | `?plugin=<pluginId>&id=<tabId>`                                   |
+| Page                | Canonical path                  | Aliases                   | Parameters or dynamic forms                                       |
+| ------------------- | ------------------------------- | ------------------------- | ----------------------------------------------------------------- |
+| Chat                | `/chat`                         | -                         | Key-backed session forms above; `?draft=<text>`                   |
+| Dashboard           | `/dashboard`                    | -                         | Key-backed session forms above; `?draft=<text>`                   |
+| Beam transcript     | `/beam/<title>-<beam-id>`       | `/beam/<beam-id>`         | Optional title slug and 12-32 lowercase hexadecimal id characters |
+| Dashboards          | `/dashboards`                   | -                         | -                                                                 |
+| Ask OpenClaw        | `/custodian`                    | -                         | `?intent=new-agent`, `?onboarding=1`                              |
+| New session         | `/new`                          | -                         | `?agent=<agentId>`, `?catalog=<catalogId>`                        |
+| Activity            | `/activity`                     | -                         | `?view=run&run=<run-id>`, `?view=run&execution=<execution-id>`    |
+| Person activity     | `/activity/<name>-<profile-id>` | -                         | Optional name slug and 8-32 lowercase hexadecimal id characters   |
+| Apps                | `/apps`                         | -                         | -                                                                 |
+| Portals             | `/portals`                      | -                         | -                                                                 |
+| Agents              | `/settings/agents`              | `/agents`                 | `/settings/agents/<agentId>[/<panel>]`                            |
+| Channels            | `/settings/channels`            | `/channels`               | Shared settings parameters below                                  |
+| Connection          | `/settings/connection`          | -                         | Shared settings parameters below                                  |
+| Legacy General      | `/settings/general`             | `/config`                 | Redirects to Appearance → Language                                |
+| Profile             | `/settings/profile`             | `/profile`                | Shared settings parameters below                                  |
+| Communications      | `/settings/communications`      | `/communications`         | Shared settings parameters below                                  |
+| Appearance          | `/settings/appearance`          | `/appearance`             | Shared settings parameters below                                  |
+| Notifications       | `/settings/notifications`       | -                         | Shared settings parameters below                                  |
+| Security            | `/settings/security`            | -                         | Shared settings parameters below                                  |
+| Secrets             | `/settings/secrets`             | -                         | Shared settings parameters below                                  |
+| Advanced            | `/settings/advanced`            | -                         | Shared settings parameters below                                  |
+| Approvals           | `/settings/approvals`           | -                         | Shared settings parameters below                                  |
+| Automation settings | `/settings/automation`          | `/automation`             | Shared settings parameters below                                  |
+| MCP                 | `/settings/mcp`                 | `/mcp`                    | Shared settings parameters below                                  |
+| Memory              | `/settings/memory`              | -                         | `/settings/memory/memories\|dreams\|settings`                     |
+| Infrastructure      | `/settings/infrastructure`      | `/infrastructure`         | Shared settings parameters below                                  |
+| Labs                | `/settings/labs`                | -                         | Shared settings parameters below                                  |
+| About               | `/settings/about`               | -                         | Shared settings parameters below                                  |
+| AI and agents       | `/settings/ai-agents`           | `/ai-agents`              | Shared settings parameters below                                  |
+| Model setup         | `/settings/model-setup`         | `/model-setup`            | `?firstRun=1`                                                     |
+| Model providers     | `/settings/model-providers`     | `/model-providers`        | Shared settings parameters below                                  |
+| Import memory       | `/memory-import`                | `/settings/memory-import` | -                                                                 |
+| Workboard           | `/workboard`                    | -                         | `/workboard/<boardId>`                                            |
+| Worktrees           | `/worktrees`                    | `/settings/worktrees`     | -                                                                 |
+| Sessions            | `/sessions`                     | `/settings/sessions`      | `?session=<sessionKey>`, `?status=archived\|all`                  |
+| Usage               | `/usage`                        | -                         | -                                                                 |
+| Debug               | `/debug`                        | -                         | -                                                                 |
+| Logs                | `/logs`                         | -                         | -                                                                 |
+| Skill Workshop      | `/skills/workshop`              | -                         | -                                                                 |
+| Skills              | `/skills`                       | -                         | -                                                                 |
+| Plugins             | `/settings/plugins`             | -                         | `/settings/plugins/discover`                                      |
+| Automations         | `/automations`                  | `/cron`                   | `?job=<jobId>`, `?job=<jobId>&run=<runId>`                        |
+| Tasks               | `/tasks`                        | -                         | -                                                                 |
+| Devices             | `/settings/devices`             | `/nodes`                  | Shared settings parameters below                                  |
+| Plugin tab host     | `/plugin`                       | -                         | `?plugin=<pluginId>&id=<tabId>`                                   |
 
 Automation links open the exact job independently of the current list filters or
 loaded page. Adding `run` opens its run history and highlights the matching loaded

--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -152,6 +152,9 @@ Prefixes from 8 through 32 hexadecimal characters are accepted. If a prefix
 matches several profiles, Activity shows an error instead of choosing a person.
 Recorded profile identities in retained sessions still resolve if their profile
 row is missing; they also participate in ambiguity checks before session filters.
+For restricted readers, lookup uses only caller-visible session associations;
+hidden draft and incognito sessions cannot affect resolution or ambiguity.
+Search, time windows, and pagination do not narrow that visibility scope.
 Use a longer prefix, the full 32-character compact UUID, or the full dashed
 UUID to select the exact profile. Names never break a tie.
 

--- a/src/gateway/session-identity-projection.ts
+++ b/src/gateway/session-identity-projection.ts
@@ -1,3 +1,4 @@
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type {
   SessionCreatedActor,
@@ -18,9 +19,11 @@ import { normalizeAgentId } from "../routing/session-key.js";
 import { looksLikeAvatarPath } from "../shared/avatar-policy.js";
 import { SESSIONS_LIST_OWNER_LIMIT } from "../shared/session-list-limits.js";
 import type { SessionOwnerFacetIdentity } from "../shared/session-types.js";
+import { resolveUserProfileReference } from "../state/user-profile-list.js";
 import { buildControlUiResourcePath } from "./control-ui-contract.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
+import type { SessionEntryPair } from "./session-list-order.js";
 import type { SessionActorProfileIdentity } from "./session-utils-contracts.js";
 
 export function projectSessionParticipant(
@@ -183,6 +186,53 @@ export function projectSessionPeople(
     }
   }
   return [...people.values()];
+}
+
+/** Resolve navigation references within the caller-prepared visibility scope. */
+export function resolveSessionListProfileReference(
+  reference: string,
+  entries: readonly SessionEntryPair[],
+  identities: Map<string, SessionActorProfileIdentity | undefined>,
+  allowedProfileIds: ReadonlySet<string> | undefined,
+): Result<string | undefined, "ambiguous"> {
+  const exact = projectSessionParticipant({ type: "profile", id: reference }, identities);
+  if (
+    identities.get(reference) &&
+    (!allowedProfileIds || allowedProfileIds.has(exact.identity.id))
+  ) {
+    return ok(exact.identity.id);
+  }
+  const prefix = /^[0-9a-f]{8,32}$/.test(reference);
+  const matches = new Set<string>();
+  // Qualified associations outlive profile rows. Resolve over caller-visible identities
+  // before time/search filters so hidden associations cannot affect the result.
+  for (const [, entry] of entries) {
+    const ids = [
+      sessionCreatorProfileId(entry.createdActor),
+      ...(entry.participants ?? []).flatMap(({ identity }) =>
+        identity.type === "profile" ? [identity.id] : [],
+      ),
+    ];
+    for (const id of ids) {
+      if (id === reference) {
+        return ok(exact.identity.id);
+      }
+      if (id && prefix && id.replaceAll("-", "").toLowerCase().startsWith(reference)) {
+        matches.add(projectSessionParticipant({ type: "profile", id }, identities).identity.id);
+      }
+    }
+  }
+  const durable = resolveUserProfileReference(
+    reference,
+    allowedProfileIds ? { allowedProfileIds } : {},
+  );
+  if (!durable.ok) {
+    return durable;
+  }
+  if (durable.value) {
+    matches.add(durable.value);
+  }
+  return matches.size > 1 ? err("ambiguous") : ok(matches.values().next().value);
 }
 
 export function projectSessionPeopleFacet(

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -1,5 +1,6 @@
 import { performance } from "node:perf_hooks";
 import { expectDefined } from "@openclaw/normalization-core";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -15,7 +16,10 @@ import {
 import { shouldKeepSubagentRunChildLink } from "../agents/subagents/registry/subagent-run-liveness.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import type { SessionEntry } from "../config/sessions.js";
-import { MAX_SESSION_PARTICIPANTS } from "../config/sessions/session-entry-provenance.js";
+import {
+  MAX_SESSION_PARTICIPANTS,
+  sessionCreatorProfileId,
+} from "../config/sessions/session-entry-provenance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withPinnedActivePluginRegistryWorkspaceDir } from "../plugins/runtime-workspace-state.js";
 import {
@@ -27,6 +31,7 @@ import {
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { SESSIONS_LIST_OWNER_LIMIT } from "../shared/session-list-limits.js";
 import type { SessionOwnerFacetIdentity } from "../shared/session-types.js";
+import { resolveUserProfileReference } from "../state/user-profile-list.js";
 import {
   projectSessionOwner,
   addSessionOwnerFacetIdentity,
@@ -34,7 +39,7 @@ import {
   projectSessionParticipants,
   projectSessionPeople,
   projectSessionPeopleFacet,
-  projectSessionActor,
+  projectSessionParticipant,
 } from "./session-identity-projection.js";
 import { type SessionEntryPair, sortAndLimitSessionEntries } from "./session-list-order.js";
 import {
@@ -160,6 +165,45 @@ function resolveSessionsListWindowLimit(limit: number | undefined, offset: numbe
   return Number.isFinite(windowLimit) ? Math.min(windowLimit, Number.MAX_SAFE_INTEGER) : undefined;
 }
 
+function resolveSessionListProfileReference(
+  reference: string,
+  store: Record<string, SessionEntry>,
+  identities: Map<string, SessionActorProfileIdentity | undefined>,
+): Result<string | undefined, "ambiguous"> {
+  const exact = projectSessionParticipant({ type: "profile", id: reference }, identities);
+  if (identities.get(reference)) {
+    return ok(exact.identity.id);
+  }
+  const prefix = /^[0-9a-f]{8,32}$/.test(reference);
+  const matches = new Set<string>();
+  // Qualified associations outlive profile rows. Resolve over retained identities
+  // before filters so an orphan cannot disappear or borrow another person's prefix.
+  for (const entry of Object.values(store)) {
+    const ids = [
+      sessionCreatorProfileId(entry.createdActor),
+      ...(entry.participants ?? []).flatMap(({ identity }) =>
+        identity.type === "profile" ? [identity.id] : [],
+      ),
+    ];
+    for (const id of ids) {
+      if (id === reference) {
+        return ok(exact.identity.id);
+      }
+      if (id && prefix && id.replaceAll("-", "").toLowerCase().startsWith(reference)) {
+        matches.add(projectSessionParticipant({ type: "profile", id }, identities).identity.id);
+      }
+    }
+  }
+  const durable = resolveUserProfileReference(reference);
+  if (!durable.ok) {
+    return durable;
+  }
+  if (durable.value) {
+    matches.add(durable.value);
+  }
+  return matches.size > 1 ? err("ambiguous") : ok(matches.values().next().value);
+}
+
 function filterSessionEntries(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
@@ -203,10 +247,16 @@ function filterSessionEntries(params: {
   const people = new Map<string, NonNullable<SessionsListResult["people"]>[number]>();
   let peopleSessionCount = 0;
   let peopleIncomplete = false;
-  let selectedProfileId: string | undefined;
   const configuredAgentIds = params.configuredAgentIds ?? new Set(listAgentIds(cfg));
   const identities =
     params.userProfileIdentityById ?? new Map<string, SessionActorProfileIdentity | undefined>();
+  const profileReference = opts.involvingProfileId
+    ? resolveSessionListProfileReference(opts.involvingProfileId, store, identities)
+    : undefined;
+  if (profileReference && !profileReference.ok) {
+    throw new Error("Person link is ambiguous. Use a longer profile ID in the Activity URL.");
+  }
+  const selectedProfileId = profileReference?.value;
 
   for (const [key, entry] of Object.entries(store)) {
     if (params.entryFilter && !params.entryFilter(key, entry)) {
@@ -346,11 +396,6 @@ function filterSessionEntries(params: {
         });
       }
       if (opts.involvingProfileId) {
-        selectedProfileId ??= projectSessionActor(
-          { type: "human", id: opts.involvingProfileId },
-          identities,
-          cfg,
-        )?.identity?.id;
         if (!associated.some((person) => person.identity.id === selectedProfileId)) {
           continue;
         }
@@ -365,16 +410,16 @@ function filterSessionEntries(params: {
     entries.push([key, entry]);
   }
 
-  const {
-    people: visiblePeople,
-    selected,
-    overflow,
-  } = projectSessionPeopleFacet(people.values(), selectedProfileId);
+  const { people: visiblePeople, overflow } = projectSessionPeopleFacet(
+    people.values(),
+    selectedProfileId,
+  );
   return {
     entries,
     ownerEntries,
     ownerFacet: sortSessionOwnerFacet(ownerFacet),
-    involvingProfileId: selected?.identity.id,
+    // Empty time/search windows do not invalidate a resolved person link.
+    involvingProfileId: selectedProfileId,
     ...(opts.includePeople
       ? {
           people: visiblePeople,

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -1,6 +1,5 @@
 import { performance } from "node:perf_hooks";
 import { expectDefined } from "@openclaw/normalization-core";
-import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -16,10 +15,7 @@ import {
 import { shouldKeepSubagentRunChildLink } from "../agents/subagents/registry/subagent-run-liveness.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import type { SessionEntry } from "../config/sessions.js";
-import {
-  MAX_SESSION_PARTICIPANTS,
-  sessionCreatorProfileId,
-} from "../config/sessions/session-entry-provenance.js";
+import { MAX_SESSION_PARTICIPANTS } from "../config/sessions/session-entry-provenance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withPinnedActivePluginRegistryWorkspaceDir } from "../plugins/runtime-workspace-state.js";
 import {
@@ -31,7 +27,6 @@ import {
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { SESSIONS_LIST_OWNER_LIMIT } from "../shared/session-list-limits.js";
 import type { SessionOwnerFacetIdentity } from "../shared/session-types.js";
-import { resolveUserProfileReference } from "../state/user-profile-list.js";
 import {
   projectSessionOwner,
   addSessionOwnerFacetIdentity,
@@ -39,7 +34,7 @@ import {
   projectSessionParticipants,
   projectSessionPeople,
   projectSessionPeopleFacet,
-  projectSessionParticipant,
+  resolveSessionListProfileReference,
 } from "./session-identity-projection.js";
 import { type SessionEntryPair, sortAndLimitSessionEntries } from "./session-list-order.js";
 import {
@@ -165,45 +160,6 @@ function resolveSessionsListWindowLimit(limit: number | undefined, offset: numbe
   return Number.isFinite(windowLimit) ? Math.min(windowLimit, Number.MAX_SAFE_INTEGER) : undefined;
 }
 
-function resolveSessionListProfileReference(
-  reference: string,
-  store: Record<string, SessionEntry>,
-  identities: Map<string, SessionActorProfileIdentity | undefined>,
-): Result<string | undefined, "ambiguous"> {
-  const exact = projectSessionParticipant({ type: "profile", id: reference }, identities);
-  if (identities.get(reference)) {
-    return ok(exact.identity.id);
-  }
-  const prefix = /^[0-9a-f]{8,32}$/.test(reference);
-  const matches = new Set<string>();
-  // Qualified associations outlive profile rows. Resolve over retained identities
-  // before filters so an orphan cannot disappear or borrow another person's prefix.
-  for (const entry of Object.values(store)) {
-    const ids = [
-      sessionCreatorProfileId(entry.createdActor),
-      ...(entry.participants ?? []).flatMap(({ identity }) =>
-        identity.type === "profile" ? [identity.id] : [],
-      ),
-    ];
-    for (const id of ids) {
-      if (id === reference) {
-        return ok(exact.identity.id);
-      }
-      if (id && prefix && id.replaceAll("-", "").toLowerCase().startsWith(reference)) {
-        matches.add(projectSessionParticipant({ type: "profile", id }, identities).identity.id);
-      }
-    }
-  }
-  const durable = resolveUserProfileReference(reference);
-  if (!durable.ok) {
-    return durable;
-  }
-  if (durable.value) {
-    matches.add(durable.value);
-  }
-  return matches.size > 1 ? err("ambiguous") : ok(matches.values().next().value);
-}
-
 function filterSessionEntries(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
@@ -213,6 +169,7 @@ function filterSessionEntries(params: {
   configuredAgentIds?: ReadonlySet<string>;
   getRowContext?: SessionListRowContextProvider;
   entryFilter?: (key: string, entry: SessionEntry) => boolean;
+  restrictProfileReferences?: boolean;
   involvingActorId?: string;
   ownerFirstActorId?: string;
 }): Pick<
@@ -250,18 +207,34 @@ function filterSessionEntries(params: {
   const configuredAgentIds = params.configuredAgentIds ?? new Set(listAgentIds(cfg));
   const identities =
     params.userProfileIdentityById ?? new Map<string, SessionActorProfileIdentity | undefined>();
+  const visibleEntries = Object.entries(store).filter(
+    ([key, entry]) => params.entryFilter?.(key, entry) ?? true,
+  );
+  const allowedProfileIds =
+    opts.involvingProfileId && params.restrictProfileReferences
+      ? new Set(
+          visibleEntries.flatMap(([, entry]) => {
+            const owner = projectSessionOwner(entry, identities, cfg, configuredAgentIds)?.actor;
+            return projectSessionPeople(entry, identities, cfg, owner).map(
+              (person) => person.identity.id,
+            );
+          }),
+        )
+      : undefined;
   const profileReference = opts.involvingProfileId
-    ? resolveSessionListProfileReference(opts.involvingProfileId, store, identities)
+    ? resolveSessionListProfileReference(
+        opts.involvingProfileId,
+        visibleEntries,
+        identities,
+        allowedProfileIds,
+      )
     : undefined;
   if (profileReference && !profileReference.ok) {
     throw new Error("Person link is ambiguous. Use a longer profile ID in the Activity URL.");
   }
   const selectedProfileId = profileReference?.value;
 
-  for (const [key, entry] of Object.entries(store)) {
-    if (params.entryFilter && !params.entryFilter(key, entry)) {
-      continue;
-    }
+  for (const [key, entry] of visibleEntries) {
     if (
       isCronRunSessionKey(key) ||
       (!includeGlobal && key === "global") ||
@@ -449,6 +422,7 @@ function selectSessionEntries(params: {
   userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
   configuredAgentIds?: ReadonlySet<string>;
   entryFilter?: (key: string, entry: SessionEntry) => boolean;
+  restrictProfileReferences?: boolean;
   involvingActorId?: string;
   ownerFirstActorId?: string;
 }): SessionEntrySelection {
@@ -512,6 +486,8 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
     opts,
     now,
     entryFilter,
+    // This wrapper also tracks incognito for unrestricted callers; preserve the original scope.
+    restrictProfileReferences: params.entryFilter !== undefined,
     defaultLimit: SESSIONS_LIST_DEFAULT_LIMIT,
     getRowContext:
       hasSpawnedByFilter || Boolean(normalizeOptionalString(opts.search))
@@ -621,7 +597,10 @@ export function filterAndSortSessionEntries(params: {
   getRowContext?: SessionListRowContextProvider;
   involvingActorId?: string;
 }): [string, SessionEntry][] {
-  return selectSessionEntries(params).entries;
+  return selectSessionEntries({
+    ...params,
+    restrictProfileReferences: params.entryFilter !== undefined,
+  }).entries;
 }
 
 /** Projects lightweight list rows while sharing the event loop with other requests. */

--- a/src/gateway/session-utils-profile-reference.test.ts
+++ b/src/gateway/session-utils-profile-reference.test.ts
@@ -3,11 +3,14 @@ import path from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { SessionEntry } from "../config/sessions.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { ensureProfileForEmail, linkEmail, resolveUserProfileId } from "../state/user-profiles.js";
+import type { GatewayClient } from "./server-methods/types.js";
+import { createSessionListEntryFilter } from "./session-sharing.js";
 import { listSessionsFromStoreAsync } from "./session-utils.js";
 
 const roots = createTempDirTracker();
@@ -186,4 +189,94 @@ it("leaves missing and invalid person references unresolved without creating pro
     expect(result.sessions).toEqual([]);
   }
   expect(fs.existsSync(path.join(stateRoot, "state", "openclaw.sqlite"))).toBe(false);
+});
+
+it.each([
+  { hidden: "draft", durable: false },
+  { hidden: "incognito", durable: false },
+  { hidden: "draft", durable: true },
+  { hidden: "incognito", durable: true },
+])("does not resolve hidden $hidden identities (durable=$durable)", async ({ hidden, durable }) => {
+  const visibleId = "12345678-a123-4123-8123-123456789abc";
+  const hiddenId = "12345678-a123-4123-8123-123456789def";
+  createProfile(visibleId);
+  if (durable) {
+    createProfile(hiddenId);
+  }
+  const visibility = createSessionListEntryFilter({
+    client: {
+      connect: { scopes: ["operator.read"] },
+      authenticatedUserProfile: { profileId: visibleId },
+    } as GatewayClient,
+  });
+  const entryFilter = vi.fn(visibility);
+  const store: Record<string, SessionEntry> = {
+    "agent:main:visible": {
+      sessionId: "visible",
+      updatedAt: Date.now(),
+      visibility: "shared",
+      participants: [{ identity: { type: "profile", id: visibleId } }],
+    },
+    "agent:main:hidden": {
+      sessionId: "hidden",
+      updatedAt: Date.now(),
+      visibility: hidden === "draft" ? "draft" : "shared",
+      incognito: hidden === "incognito" ? true : undefined,
+      participants: [{ identity: { type: "profile", id: hiddenId } }],
+    },
+  };
+  for (const reference of ["12345678a123", hiddenId, hiddenId.replaceAll("-", "")]) {
+    entryFilter.mockClear();
+    const result = await listSessionsFromStoreAsync({
+      cfg: {},
+      storePath: stateRoot,
+      store,
+      entryFilter,
+      opts: { includePeople: true, involvingProfileId: reference, search: "no-matching-session" },
+    });
+    expect(result.involvingProfileId, reference).toBe(
+      reference === "12345678a123" ? visibleId : undefined,
+    );
+    expect(result.sessions).toEqual([]);
+    expect(result.people).toEqual([]);
+    expect(entryFilter).toHaveBeenCalledTimes(2);
+  }
+});
+
+it("resolves merge aliases for visible owners without considering hidden profiles", async () => {
+  const source = "12345678-a123-4123-8123-123456789abc";
+  const hidden = "12345678-a123-4123-8123-123456789def";
+  const target = "87654321-a123-4123-8123-123456789abc";
+  for (const id of [source, hidden, target]) {
+    createProfile(id);
+  }
+  linkEmail(`${source}@activity.test`, target);
+  const entryFilter = createSessionListEntryFilter({
+    client: {
+      connect: { scopes: ["operator.read"] },
+      authenticatedUserProfile: { profileId: target },
+    } as GatewayClient,
+  });
+  const result = await listSessionsFromStoreAsync({
+    cfg: {},
+    storePath: stateRoot,
+    entryFilter,
+    store: {
+      "agent:main:owned": {
+        sessionId: "owned",
+        updatedAt: Date.now(),
+        visibility: "shared",
+        owner: { actor: { type: "human", id: target } },
+      },
+      "agent:main:hidden": {
+        sessionId: "hidden",
+        updatedAt: Date.now(),
+        visibility: "draft",
+        participants: [{ identity: { type: "profile", id: hidden } }],
+      },
+    },
+    opts: { includePeople: true, involvingProfileId: "12345678a123" },
+  });
+  expect(result.involvingProfileId).toBe(target);
+  expect(result.sessions.map((row) => row.key)).toEqual(["agent:main:owned"]);
 });

--- a/src/gateway/session-utils-profile-reference.test.ts
+++ b/src/gateway/session-utils-profile-reference.test.ts
@@ -1,0 +1,189 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { ensureProfileForEmail, linkEmail, resolveUserProfileId } from "../state/user-profiles.js";
+import { listSessionsFromStoreAsync } from "./session-utils.js";
+
+const roots = createTempDirTracker();
+let stateRoot: string;
+beforeEach(() => {
+  stateRoot = roots.make("activity-profile-reference-");
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateRoot);
+});
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+  roots.cleanup();
+});
+
+function createProfile(id: string): void {
+  const profile = ensureProfileForEmail(`${id}@activity.test`);
+  const { db } = openOpenClawStateDatabase();
+  // Deterministic IDs exercise real prefix collisions without weakening the UUID producer.
+  db.prepare("UPDATE user_profiles SET id = ? WHERE id = ?").run(id, profile.id);
+  db.prepare("UPDATE user_profile_emails SET profile_id = ? WHERE profile_id = ?").run(
+    id,
+    profile.id,
+  );
+}
+
+function listActivity(
+  profileIds: string[],
+  involvingProfileId: string,
+  options: Partial<SessionsListParams> = {},
+) {
+  return listSessionsFromStoreAsync({
+    cfg: {},
+    storePath: stateRoot,
+    store: Object.fromEntries(
+      profileIds.map((id, index) => [
+        `agent:main:activity-${index}`,
+        {
+          sessionId: `activity-${index}`,
+          updatedAt: Date.now(),
+          participants: [{ identity: { type: "profile" as const, id } }],
+        },
+      ]),
+    ),
+    opts: { includePeople: true, involvingProfileId, ...options },
+  });
+}
+
+it("resolves short person references across UUID boundaries before session pagination", async () => {
+  const selected = "12345678-a123-4123-8123-123456789abc";
+  const other = "87654321-b123-4123-8123-123456789abc";
+  createProfile(selected);
+  createProfile(other);
+  for (const length of [8, 9, 12, 13, 16, 17, 20, 21, 32]) {
+    const reference = selected.replaceAll("-", "").slice(0, length);
+    const result = await listActivity([other, selected, selected], reference, { limit: 1 });
+    expect(result.involvingProfileId, reference).toBe(selected);
+    expect(result.totalCount, reference).toBe(2);
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]?.participants?.[0]?.identity.id).toBe(selected);
+  }
+  expect(resolveUserProfileId("12345678")).toBeUndefined();
+});
+
+it("rejects an ambiguous person reference even when only one matching profile has visible sessions", async () => {
+  const first = "12345678-a123-4123-8123-123456789abc";
+  const second = "12345678-b123-4123-8123-123456789abc";
+  createProfile(first);
+  createProfile(second);
+  await expect(listActivity([first], "12345678")).rejects.toThrow(
+    "Person link is ambiguous. Use a longer profile ID in the Activity URL.",
+  );
+  expect((await listActivity([first, second], "12345678a")).involvingProfileId).toBe(first);
+});
+
+it("keeps old person references working after profile merges and counts merge aliases once", async () => {
+  const first = "12345678-a123-4123-8123-123456789abc";
+  const second = "12345678-b123-4123-8123-123456789abc";
+  const target = "87654321-c123-4123-8123-123456789abc";
+  for (const id of [first, second, target]) {
+    createProfile(id);
+  }
+  linkEmail(`${first}@activity.test`, target);
+  linkEmail(`${second}@activity.test`, target);
+  for (const reference of ["12345678", first, second]) {
+    const result = await listActivity([first, second, target], reference);
+    expect(result.involvingProfileId, reference).toBe(target);
+    expect(result.sessions).toHaveLength(3);
+    expect(result.people).toHaveLength(1);
+  }
+});
+
+it("prefers an exact profile identifier over a UUID prefix", async () => {
+  const exact = "deadbeef";
+  const longer = "deadbeef-a123-4123-8123-123456789abc";
+  createProfile(exact);
+  createProfile(longer);
+  const result = await listActivity([longer, exact], exact);
+  expect(result.involvingProfileId).toBe(exact);
+  expect(result.sessions).toHaveLength(1);
+  expect(result.sessions[0]?.participants?.[0]?.identity.id).toBe(exact);
+});
+
+it("retains a resolved person when search matches no sessions without resolving missing people", async () => {
+  const selected = "12345678-a123-4123-8123-123456789abc";
+  createProfile(selected);
+  for (const reference of [selected, "12345678a123", "missing-person"]) {
+    const result = await listActivity([selected], reference, { search: "no-matching-session" });
+    expect(result.involvingProfileId, reference).toBe(
+      reference === "missing-person" ? undefined : selected,
+    );
+    expect(result.sessions).toEqual([]);
+    expect(result.people).toEqual([]);
+  }
+});
+
+it.each(["12345678-a123-4123-8123-123456789abc", "12345678-A123-4123-8123-123456789ABC"])(
+  "resolves retained profile %s without a durable row",
+  async (retained) => {
+    for (const reference of [
+      retained,
+      "12345678a123",
+      retained.replaceAll("-", "").toLowerCase(),
+    ]) {
+      const result = await listActivity([retained], reference);
+      expect(result.involvingProfileId, reference).toBe(retained);
+      expect(result.sessions, reference).toHaveLength(1);
+      const empty = await listActivity([retained], reference, { search: "no-matching-session" });
+      expect(empty.involvingProfileId, reference).toBe(retained);
+      expect(empty.sessions, reference).toEqual([]);
+    }
+    expect(fs.existsSync(path.join(stateRoot, "state", "openclaw.sqlite"))).toBe(false);
+    createProfile("12345678-a123-4123-8123-123456789def");
+    await expect(
+      listActivity([retained], "12345678a123", { search: "no-matching-session" }),
+    ).rejects.toThrow("Person link is ambiguous");
+  },
+);
+
+it("resolves qualified retained creators without treating legacy human IDs as profiles", async () => {
+  const retained = "12345678-a123-4123-8123-123456789abc";
+  const result = await listSessionsFromStoreAsync({
+    cfg: {},
+    storePath: stateRoot,
+    store: {
+      "agent:main:qualified": {
+        sessionId: "qualified",
+        updatedAt: Date.now(),
+        createdActor: { type: "human", id: retained, source: "profile" },
+      },
+      "agent:main:legacy": {
+        sessionId: "legacy",
+        updatedAt: Date.now(),
+        createdActor: {
+          type: "human",
+          id: "12345678-a123-4123-8123-123456789def",
+          source: "channel",
+        },
+      },
+    },
+    opts: { includePeople: true, involvingProfileId: "12345678a123" },
+  });
+  expect(result.involvingProfileId).toBe(retained);
+  expect(result.sessions.map((row) => row.key)).toEqual(["agent:main:qualified"]);
+});
+
+it("leaves missing and invalid person references unresolved without creating profile storage", async () => {
+  for (const reference of [
+    "12345678",
+    "1234567",
+    "ABCDEF12",
+    "123456789abcdef0123456789abcdef012",
+    "unknown-person",
+  ]) {
+    const result = await listActivity([], reference);
+    expect(result.involvingProfileId).toBeUndefined();
+    expect(result.sessions).toEqual([]);
+  }
+  expect(fs.existsSync(path.join(stateRoot, "state", "openclaw.sqlite"))).toBe(false);
+});

--- a/src/state/user-profile-list.ts
+++ b/src/state/user-profile-list.ts
@@ -216,14 +216,23 @@ export function getUserProfileDisplay(
 /** Activity references are display navigation, never authentication identifiers. */
 export function resolveUserProfileReference(
   reference: string,
-  options: OpenClawStateDatabaseOptions = {},
+  options: OpenClawStateDatabaseOptions & { allowedProfileIds?: ReadonlySet<string> } = {},
 ): Result<string | undefined, "ambiguous"> {
+  const { allowedProfileIds } = options;
+  if (allowedProfileIds?.size === 0) {
+    return ok(undefined);
+  }
   return (
     withExistingOpenClawStateDatabaseReadOnly(({ db }): Result<string | undefined, "ambiguous"> => {
       if (!tableExists(db, "user_profiles")) {
         return ok(undefined);
       }
-      const profiles = userProfilesDb(db).selectFrom("user_profiles");
+      let profiles = userProfilesDb(db).selectFrom("user_profiles");
+      if (allowedProfileIds) {
+        profiles = profiles.where((eb) =>
+          eb(eb.fn.coalesce("merged_into", "id"), "in", [...allowedProfileIds]),
+        );
+      }
       const exact = selectResolvedUserProfile(
         db,
         reference,
@@ -244,8 +253,8 @@ export function resolveUserProfileReference(
       ]
         .filter(Boolean)
         .join("-");
-      // Tombstones retain old links; aliases of one merge head are one match.
-      // Resolve over durable profiles so time, search, and facet caps cannot choose a person.
+      // Tombstones retain old links; aliases of one allowed merge head are one match.
+      // Time, search, and facet caps must not choose a person within that visibility scope.
       const matches = executeSqliteQuerySync(
         db,
         profiles

--- a/src/state/user-profile-list.ts
+++ b/src/state/user-profile-list.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { executeSqliteQuerySync } from "../infra/kysely-sync.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
@@ -210,4 +211,50 @@ export function getUserProfileDisplay(
     avatarRevision,
     hasAvatar: profile.has_avatar === 1,
   };
+}
+
+/** Activity references are display navigation, never authentication identifiers. */
+export function resolveUserProfileReference(
+  reference: string,
+  options: OpenClawStateDatabaseOptions = {},
+): Result<string | undefined, "ambiguous"> {
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(({ db }): Result<string | undefined, "ambiguous"> => {
+      if (!tableExists(db, "user_profiles")) {
+        return ok(undefined);
+      }
+      const profiles = userProfilesDb(db).selectFrom("user_profiles");
+      const exact = selectResolvedUserProfile(
+        db,
+        reference,
+        profiles.select(["id", "merged_into"]),
+      );
+      if (exact) {
+        return ok(exact.id);
+      }
+      if (!/^[0-9a-f]{8,32}$/.test(reference)) {
+        return ok(undefined);
+      }
+      const uuidPrefix = [
+        reference.slice(0, 8),
+        reference.slice(8, 12),
+        reference.slice(12, 16),
+        reference.slice(16, 20),
+        reference.slice(20),
+      ]
+        .filter(Boolean)
+        .join("-");
+      // Tombstones retain old links; aliases of one merge head are one match.
+      // Resolve over durable profiles so time, search, and facet caps cannot choose a person.
+      const matches = executeSqliteQuerySync(
+        db,
+        profiles
+          .select((eb) => eb.fn.coalesce("merged_into", "id").as("id"))
+          .where("id", "like", `${uuidPrefix}%`)
+          .distinct()
+          .limit(2),
+      ).rows;
+      return matches.length > 1 ? err("ambiguous") : ok(matches[0]?.id);
+    }, options) ?? ok(undefined)
+  );
 }

--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -12,6 +12,8 @@ import {
   visibleSettingsNavigationGroups,
 } from "./app-navigation.ts";
 import {
+  activityPersonFromPath,
+  activityPersonLocation,
   inferBasePathFromPathname,
   normalizeBasePath,
   pathForRoute,
@@ -373,6 +375,91 @@ describe("routeIdFromPath", () => {
     expect(inferBasePathFromPathname("/ui/workboard/ops")).toBe("/ui");
   });
 
+  it.each([
+    {
+      personId: "12345678-abcd-4ef0-8123-456789abcdef",
+      label: "Josh Roberts",
+      segment: "josh-roberts-12345678abcd",
+      reference: "12345678abcd",
+    },
+    {
+      personId: "12345678-ABCD-4EF0-8123-456789ABCDEF",
+      label: undefined,
+      segment: "12345678abcd",
+      reference: "12345678abcd",
+    },
+    {
+      personId: "12345678-abcd-4ef0-8123-456789abcdef",
+      label: "Ada",
+      segment: "ada-12345678abcd",
+      reference: "12345678abcd",
+    },
+    {
+      personId: "12345678-abcd-4ef0-8123-456789abcdef",
+      label: "李 明",
+      segment: "%E6%9D%8E-%E6%98%8E-12345678abcd",
+      reference: "12345678abcd",
+    },
+    { personId: "alice", label: "Alice", segment: "alice", reference: "alice" },
+    {
+      personId: "profile-deadbeef",
+      label: "Alice",
+      segment: "profile%2Ddeadbeef",
+      reference: "profile-deadbeef",
+    },
+    {
+      personId: "profile/a",
+      label: "Alice",
+      segment: "profile%2Fa",
+      reference: "profile/a",
+    },
+    {
+      personId: "release.js",
+      label: "Alice",
+      segment: "release%2Ejs",
+      reference: "release.js",
+    },
+  ])("round-trips Activity links for $personId", ({ personId, label, segment, reference }) => {
+    const pathname = `/ui/activity/${segment}`;
+    expect(activityPersonLocation(personId, "/ui", label)).toEqual({
+      pathname,
+      search: "",
+      href: pathname,
+    });
+    expect(activityPersonFromPath(pathname, "/ui")).toBe(reference);
+    expect(routeIdFromPath(pathname, "/ui")).toBe("activity");
+    expect(createApplicationRouter().routeIdFromPath(pathname, "/ui")).toBe("activity");
+    expect(inferBasePathFromPathname(pathname)).toBe("/ui");
+  });
+
+  it("preserves full Activity UUIDs and accepts longer collision-disambiguating prefixes", () => {
+    const personId = "12345678-abcd-4ef0-8123-456789abcdef";
+    const uuidShapedName = activityPersonLocation(personId, "", "deadbeef-cafe-4dad-8bad");
+    expect(activityPersonFromPath(uuidShapedName.pathname)).toBe("12345678abcd");
+    expect(activityPersonFromPath(`/activity/${personId}`)).toBe(personId);
+    expect(activityPersonFromPath("/activity/josh-12345678abcd")).toBe("12345678abcd");
+    expect(activityPersonLocation(personId, "", "Josh", 16).pathname).toBe(
+      "/activity/josh-12345678abcd4ef0",
+    );
+    expect(activityPersonFromPath("/activity/renamed-josh-12345678/")).toBe("12345678");
+    expect(inferBasePathFromPathname("/activity/josh-12345678")).toBe("");
+    expect(inferBasePathFromPathname("/apps/openclaw/activity/josh-12345678")).toBe(
+      "/apps/openclaw",
+    );
+  });
+
+  it.each([
+    "/activity",
+    "/activity/",
+    "/activity/%",
+    "/activity/%20",
+    "/activity/%2E",
+    "/activity/%2E%2E",
+    "/activity/alice/extra",
+  ])("rejects an invalid Activity person path %s", (pathname) => {
+    expect(activityPersonFromPath(pathname)).toBeNull();
+  });
+
   it("round-trips session navigation through the lazy contract seam", () => {
     const pathname = sessionNavigationTarget({
       face: "chat",
@@ -403,6 +490,7 @@ describe("routeIdFromPath", () => {
 
   it("rejects route-shaped paths outside the configured base path", () => {
     expect(routeIdFromPath("/xx/chat", "/ui")).toBeNull();
+    expect(routeIdFromPath("/xx/activity/josh-12345678", "/ui")).toBeNull();
     expect(routeIdFromPath("/other/sessions", "/apps/openclaw")).toBeNull();
   });
 

--- a/ui/src/app-route-paths.test.ts
+++ b/ui/src/app-route-paths.test.ts
@@ -39,6 +39,25 @@ const AGENT_PANEL_CASES = [
 
 const DYNAMIC_STARTUP_CASES = [
   {
+    label: "person Activity",
+    routeId: "activity",
+    location: {
+      pathname: "/activity/josh-12345678",
+      search: "?time=30d&q=release",
+      hash: "#sessions",
+    },
+  },
+  {
+    label: "mounted person Activity",
+    routeId: "activity",
+    basePath: "/ui",
+    location: {
+      pathname: "/ui/activity/josh-12345678",
+      search: "?time=30d&q=release",
+      hash: "#sessions",
+    },
+  },
+  {
     label: "agent panel",
     routeId: "agents",
     location: {
@@ -104,6 +123,7 @@ const DYNAMIC_STARTUP_CASES = [
 ] as const satisfies readonly {
   label: string;
   routeId: RouteId;
+  basePath?: string;
   location: RouteLocation;
 }[];
 
@@ -189,7 +209,9 @@ describe("Dynamic route startup bridge", () => {
 
   it.each(DYNAMIC_STARTUP_CASES)(
     "loads the $label once while publishing its real location",
-    async ({ routeId, location: initialLocation }) => {
+    async (testCase) => {
+      const { routeId, location: initialLocation } = testCase;
+      const basePath = "basePath" in testCase ? testCase.basePath : "";
       let location: RouteLocation = { ...initialLocation };
       const push = vi.fn((next: RouteLocation) => {
         location = next;
@@ -215,8 +237,8 @@ describe("Dynamic route startup bridge", () => {
         route.loader = loader;
         route.component = async () => ({ render: () => null });
 
-        await startApplicationRouter(router, history, "", {
-          basePath: "",
+        await startApplicationRouter(router, history, basePath, {
+          basePath,
         } as unknown as ApplicationContext);
 
         expect(loader).toHaveBeenCalledOnce();
@@ -231,62 +253,72 @@ describe("Dynamic route startup bridge", () => {
     },
   );
 
-  it("loads a later dynamic history destination exactly once", async () => {
-    let location: RouteLocation = {
-      pathname: "/chat/main/01JSESSIONA",
-      search: "",
-      hash: "#first",
-    };
-    let historyListener: ((next: RouteLocation) => void) | undefined;
-    const history: RouterHistory = {
-      location: () => location,
-      push: vi.fn((next: RouteLocation) => {
-        location = next;
-      }),
-      replace: vi.fn((next: RouteLocation) => {
-        location = next;
-      }),
-      listen: (listener) => {
-        historyListener = listener;
-        return () => {
-          historyListener = undefined;
-        };
-      },
-    };
-    const router = createApplicationRouter();
-    const route = router.getRoute("chat");
-    if (!route) {
-      throw new Error("Chat route missing");
-    }
-    const loader = vi.fn<NonNullable<typeof route.loader>>(async () => ({}));
-    const originalLoader = route.loader;
-    const originalComponent = route.component;
-    try {
-      route.loader = loader;
-      route.component = async () => ({ render: () => null });
-
-      await startApplicationRouter(router, history, "", {
-        basePath: "",
-      } as unknown as ApplicationContext);
-      expect(loader).toHaveBeenCalledOnce();
-
-      location = {
-        pathname: "/chat/main/01JSESSIONB",
-        search: "?probe=1",
-        hash: "#second",
+  it.each([
+    { routeId: "chat", firstPath: "/chat/main/01JSESSIONA", nextPath: "/chat/main/01JSESSIONB" },
+    {
+      routeId: "activity",
+      firstPath: "/activity/josh-12345678",
+      nextPath: "/activity/mira-2ab34567",
+    },
+  ] as const)(
+    "loads a later $routeId history destination exactly once",
+    async ({ routeId, firstPath, nextPath }) => {
+      let location: RouteLocation = {
+        pathname: firstPath,
+        search: "",
+        hash: "#first",
       };
-      historyListener?.(location);
+      let historyListener: ((next: RouteLocation) => void) | undefined;
+      const history: RouterHistory = {
+        location: () => location,
+        push: vi.fn((next: RouteLocation) => {
+          location = next;
+        }),
+        replace: vi.fn((next: RouteLocation) => {
+          location = next;
+        }),
+        listen: (listener) => {
+          historyListener = listener;
+          return () => {
+            historyListener = undefined;
+          };
+        },
+      };
+      const router = createApplicationRouter();
+      const route = router.getRoute(routeId);
+      if (!route) {
+        throw new Error(`Route missing: ${routeId}`);
+      }
+      const loader = vi.fn<NonNullable<typeof route.loader>>(async () => ({}));
+      const originalLoader = route.loader;
+      const originalComponent = route.component;
+      try {
+        route.loader = loader;
+        route.component = async () => ({ render: () => null });
 
-      await vi.waitFor(() => {
-        expect(loader).toHaveBeenCalledTimes(2);
-        expect(loader.mock.calls[1]?.[1].location).toEqual(location);
-      });
-    } finally {
-      router.stop();
-      route.loader = originalLoader;
-      route.component = originalComponent;
-    }
-  });
+        await startApplicationRouter(router, history, "", {
+          basePath: "",
+        } as unknown as ApplicationContext);
+        expect(loader).toHaveBeenCalledOnce();
+
+        location = {
+          pathname: nextPath,
+          search: "",
+          hash: "#second",
+        };
+        historyListener?.(location);
+
+        await vi.waitFor(() => {
+          expect(loader).toHaveBeenCalledTimes(2);
+          expect(loader.mock.calls[1]?.[1].location).toEqual(location);
+        });
+      } finally {
+        router.stop();
+        route.loader = originalLoader;
+        route.component = originalComponent;
+      }
+    },
+  );
 
   it("keeps a loader not-found state without rejecting startup", async () => {
     let location: RouteLocation = { pathname: "/", search: "", hash: "" };
@@ -523,6 +555,7 @@ describe("Memory tab route paths", () => {
   );
 
   it("rejects unknown and nested Memory tab segments", () => {
+    expect(memoryTabFromPath("/settings/memory//")).toBeNull();
     expect(memoryTabFromPath("/settings/memory/unknown")).toBeNull();
     expect(memoryTabFromPath("/settings/memory/dreams/extra")).toBeNull();
     expect(routeIdFromPath("/settings/memory/unknown")).toBeNull();
@@ -551,6 +584,7 @@ describe("Plugins hub tab route paths", () => {
   );
 
   it("rejects unknown and nested Plugins hub tab segments", () => {
+    expect(pluginsHubTabFromPath("/settings/plugins//")).toBeNull();
     expect(pluginsHubTabFromPath("/settings/plugins/unknown")).toBeNull();
     expect(pluginsHubTabFromPath("/settings/plugins/discover/extra")).toBeNull();
     expect(routeIdFromPath("/settings/plugins/unknown")).toBeNull();

--- a/ui/src/app-route-paths.ts
+++ b/ui/src/app-route-paths.ts
@@ -1,13 +1,20 @@
+import { normalizeAtHashSlug } from "@openclaw/normalization-core/string-normalization";
 import {
   inferControlUiFocusBasePath,
   matchControlUiCatalogSharePath,
+  SESSION_UUID_SUFFIX_RE,
 } from "@openclaw/session-url-contract";
-import { normalizeRouteBasePath, normalizeRoutePath as normalizePath } from "@openclaw/uirouter";
+import {
+  normalizeRouteBasePath as normalizeBasePath,
+  normalizeRoutePath as normalizePath,
+} from "@openclaw/uirouter";
 import type { RouteLocation } from "@openclaw/uirouter";
 import { isValidWorkboardBoardId } from "@openclaw/workboard-contract";
 import { DEFAULT_AGENT_PANEL, isAgentsPanel, type AgentsPanel } from "./lib/agents/panels.ts";
 import type { BoardFace } from "./lib/board/settings.ts";
+import { takeGraphemes } from "./lib/graphemes.ts";
 export const INTERNAL_AGENT_PATH_PARAM = "__openclawAgentPath";
+export const INTERNAL_ACTIVITY_PATH_PARAM = "__openclawActivityPath";
 export const INTERNAL_SESSION_PATH_PARAM = "__openclawSessionPath";
 export const INTERNAL_MEMORY_PATH_PARAM = "__openclawMemoryPath";
 export const INTERNAL_PLUGINS_PATH_PARAM = "__openclawPluginsPath";
@@ -84,7 +91,6 @@ const APP_ROUTE_DEFINITIONS = {
 
 export type RouteId = keyof typeof APP_ROUTE_DEFINITIONS;
 export const APP_ROUTE_IDS = Object.keys(APP_ROUTE_DEFINITIONS) as RouteId[];
-
 const APP_ROUTE_PATHS: string[] = [];
 const ROUTE_ID_BY_PATH = new Map<string, RouteId>();
 // Static paths and aliases share one prepared index; earlier declarations keep priority.
@@ -114,27 +120,71 @@ export function routePageSpec<Id extends RouteId>(
   return { id: routeId, ...APP_ROUTE_DEFINITIONS[routeId] };
 }
 
-export function normalizeBasePath(basePath: string): string {
-  return normalizeRouteBasePath(basePath);
-}
+export { normalizeBasePath };
 
 export function pathForRoute(routeId: RouteId, basePath = ""): string {
-  const normalizedBasePath = normalizeBasePath(basePath);
-  const path = APP_ROUTE_DEFINITIONS[routeId].path;
-  return normalizedBasePath ? `${normalizedBasePath}${path}` : path;
+  return `${normalizeBasePath(basePath)}${APP_ROUTE_DEFINITIONS[routeId].path}`;
 }
 
-/** Query key the Activity feed reads to scope its session list to one person. */
+function routePathSuffix(pathname: string, routeId: RouteId, basePath: string): string | null {
+  const normalizedPath = normalizePath(pathname);
+  const routePath = pathForRoute(routeId, basePath);
+  if (normalizedPath === routePath) {
+    return "";
+  }
+  const prefix = `${routePath}/`;
+  return normalizedPath.startsWith(prefix) ? normalizedPath.slice(prefix.length) || null : null;
+}
+
+/** Legacy person query accepted by existing Activity links. */
 export const ACTIVITY_PERSON_PARAM = "person";
+const ACTIVITY_PERSON_SHORT_REF_RE = /(?:^|-)([0-9a-f]{8,32})$/u;
+
+function isProfileUuid(id: string): boolean {
+  return id.length === 36 && SESSION_UUID_SUFFIX_RE.test(id);
+}
 
 /** Activity feed scoped to one person, for every surface that shows an identity. */
 export function activityPersonLocation(
   personId: string,
   basePath = "",
+  label?: string,
+  minimumRefLength = 12,
 ): { pathname: string; search: string; href: string } {
-  const pathname = pathForRoute("activity", basePath);
-  const search = `?${new URLSearchParams({ [ACTIVITY_PERSON_PARAM]: personId }).toString()}`;
-  return { pathname, search, href: `${pathname}${search}` };
+  const uuid = isProfileUuid(personId);
+  const slug = takeGraphemes(normalizeAtHashSlug(label), 48).replace(/-+$/u, "");
+  const reference = uuid
+    ? `${slug ? `${slug}-` : ""}${personId.replaceAll("-", "").slice(0, minimumRefLength).toLowerCase()}`
+    : personId;
+  // A decorative name must not turn its short reference into another exact UUID.
+  let encodedReference = encodeURIComponent(
+    isProfileUuid(reference) ? `person-${reference}` : reference,
+  ).replaceAll(".", "%2E");
+  // Retained protocol identities can be literal strings; escape their short-ref delimiter.
+  if (!uuid) {
+    encodedReference = encodedReference.replace(/-(?=[0-9a-f]{8,32}$)/u, "%2D");
+  }
+  const pathname = `${pathForRoute("activity", basePath)}/${encodedReference}`;
+  return { pathname, search: "", href: pathname };
+}
+
+export function activityPersonFromPath(pathname: string, basePath = ""): string | null {
+  const reference = routePathSuffix(pathname, "activity", basePath);
+  if (!reference || reference.includes("/")) {
+    return null;
+  }
+  try {
+    const personId = decodeURIComponent(reference);
+    if (!personId.trim() || personId === "." || personId === "..") {
+      return null;
+    }
+    // A full UUID is an exact identifier; its final group is not a short prefix.
+    return isProfileUuid(personId)
+      ? personId
+      : (reference.match(ACTIVITY_PERSON_SHORT_REF_RE)?.[1] ?? personId);
+  } catch {
+    return null;
+  }
 }
 
 export function pathForWorkboardBoard(boardId: string, basePath = ""): string {
@@ -159,13 +209,11 @@ export function pathForAgentPanel(
 }
 
 export function agentRouteFromPath(pathname: string, basePath = ""): AgentRoutePath | null {
-  const normalizedPath = normalizePath(pathname);
-  const agentsPath = pathForRoute("agents", basePath);
-  const prefix = `${agentsPath}/`;
-  if (!normalizedPath.startsWith(prefix)) {
+  const suffix = routePathSuffix(pathname, "agents", basePath);
+  if (!suffix) {
     return null;
   }
-  const segments = normalizedPath.slice(prefix.length).split("/");
+  const segments = suffix.split("/");
   if (segments.length > 2 || !segments[0]) {
     return null;
   }
@@ -194,16 +242,10 @@ export function pathForMemoryTab(tab: MemoryRouteTab, basePath = ""): string {
 }
 
 export function memoryTabFromPath(pathname: string, basePath = ""): MemoryRouteTab | null {
-  const normalizedPath = normalizePath(pathname);
-  const memoryPath = pathForRoute("memory", basePath);
-  if (normalizedPath === memoryPath) {
+  const segment = routePathSuffix(pathname, "memory", basePath);
+  if (segment === "") {
     return "overview";
   }
-  const prefix = `${memoryPath}/`;
-  if (!normalizedPath.startsWith(prefix)) {
-    return null;
-  }
-  const segment = normalizedPath.slice(prefix.length);
   return segment === "memories" || segment === "dreams" || segment === "settings" ? segment : null;
 }
 
@@ -213,12 +255,8 @@ export function pathForPluginsHubTab(tab: PluginsHubRouteTab, basePath = ""): st
 }
 
 export function pluginsHubTabFromPath(pathname: string, basePath = ""): PluginsHubRouteTab | null {
-  const normalizedPath = normalizePath(pathname);
-  const pluginsPath = pathForRoute("plugins", basePath);
-  if (normalizedPath === pluginsPath) {
-    return "installed";
-  }
-  return normalizedPath === `${pluginsPath}/discover` ? "discover" : null;
+  const segment = routePathSuffix(pathname, "plugins", basePath);
+  return segment === "" ? "installed" : segment === "discover" ? "discover" : null;
 }
 
 export function isSessionRouteId(routeId: string | null | undefined): routeId is BoardFace {
@@ -251,13 +289,7 @@ export function sessionRouteNamespaceFromPath(pathname: string, basePath = ""): 
 }
 
 export function workboardBoardIdFromPath(pathname: string, basePath = ""): string | null {
-  const normalizedPath = normalizePath(pathname);
-  const workboardPath = pathForRoute("workboard", basePath);
-  const prefix = `${workboardPath}/`;
-  if (!normalizedPath.startsWith(prefix)) {
-    return null;
-  }
-  const encodedBoardId = normalizedPath.slice(prefix.length);
+  const encodedBoardId = routePathSuffix(pathname, "workboard", basePath);
   if (!encodedBoardId || encodedBoardId.includes("/")) {
     return null;
   }
@@ -267,6 +299,25 @@ export function workboardBoardIdFromPath(pathname: string, basePath = ""): strin
   } catch {
     return null;
   }
+}
+
+function dynamicRouteIdFromPath(pathname: string, basePath = ""): RouteId | null {
+  if (agentRouteFromPath(pathname, basePath)) {
+    return "agents";
+  }
+  if (activityPersonFromPath(pathname, basePath)) {
+    return "activity";
+  }
+  if (workboardBoardIdFromPath(pathname, basePath)) {
+    return "workboard";
+  }
+  if (memoryTabFromPath(pathname, basePath)) {
+    return "memory";
+  }
+  if (pluginsHubTabFromPath(pathname, basePath)) {
+    return "plugins";
+  }
+  return sessionRouteNamespaceFromPath(pathname, basePath);
 }
 
 export function routeIdFromPath(pathname: string, basePath = ""): RouteId | null {
@@ -282,26 +333,13 @@ export function routeIdFromPath(pathname: string, basePath = ""): RouteId | null
   const routePath = normalizedBasePath
     ? normalizedPath.slice(normalizedBasePath.length) || "/"
     : normalizedPath;
-  if (agentRouteFromPath(normalizedPath, normalizedBasePath)) {
-    return "agents";
-  }
-  if (workboardBoardIdFromPath(normalizedPath, normalizedBasePath)) {
-    return "workboard";
-  }
-  if (memoryTabFromPath(normalizedPath, normalizedBasePath)) {
-    return "memory";
-  }
-  if (pluginsHubTabFromPath(normalizedPath, normalizedBasePath)) {
-    return "plugins";
-  }
   // uirouter matches static paths case-insensitively (pathKey lowercases), so
   // this pre-gate must too — otherwise /Usage is rewritten to /chat before the
   // router, which would have matched it, ever starts.
-  const exactRouteId = ROUTE_ID_BY_PATH.get(routePath.toLowerCase());
-  if (exactRouteId) {
-    return exactRouteId;
-  }
-  return sessionRouteNamespaceFromPath(normalizedPath, normalizedBasePath);
+  return (
+    ROUTE_ID_BY_PATH.get(routePath.toLowerCase()) ??
+    dynamicRouteIdFromPath(normalizedPath, normalizedBasePath)
+  );
 }
 
 // A candidate mount base that is a registered route ("/custodian"), or that
@@ -342,46 +380,19 @@ export function inferBasePathFromPathname(pathname: string): string {
   const segments = normalizedPath.split("/").filter(Boolean);
   for (let index = 0; index < segments.length; index += 1) {
     const candidate = `/${segments.slice(index).join("/")}`;
-    const routePath = APP_ROUTE_PATHS.find((path) => path === candidate);
+    const routePath = ROUTE_ID_BY_PATH.has(candidate) ? candidate : undefined;
     const documentRoutePath = Object.values(CONTROL_UI_DOCUMENT_ROUTE_PATHS).find(
       (path) => candidate === path || candidate.startsWith(`${path}/`),
     );
-    const dynamicAgentRoute = agentRouteFromPath(candidate) !== null;
-    const dynamicWorkboardRoute = workboardBoardIdFromPath(candidate) !== null;
-    const dynamicMemoryRoute = memoryTabFromPath(candidate) !== null;
-    const dynamicPluginsRoute = pluginsHubTabFromPath(candidate) !== null;
-    const sessionNamespace = sessionRouteNamespaceFromPath(candidate);
-    const dynamicSessionRoute = sessionNamespace !== null;
-    if (
-      !routePath &&
-      !documentRoutePath &&
-      !dynamicAgentRoute &&
-      !dynamicWorkboardRoute &&
-      !dynamicMemoryRoute &&
-      !dynamicPluginsRoute &&
-      !dynamicSessionRoute
-    ) {
+    const dynamicRouteId = dynamicRouteIdFromPath(candidate);
+    if (!routePath && !documentRoutePath && !dynamicRouteId) {
       continue;
     }
     const previousSegment = segments[index - 1];
-    const dynamicRoutePath = documentRoutePath
-      ? documentRoutePath
-      : dynamicAgentRoute
-        ? APP_ROUTE_DEFINITIONS.agents.path
-        : dynamicWorkboardRoute
-          ? APP_ROUTE_DEFINITIONS.workboard.path
-          : dynamicMemoryRoute
-            ? APP_ROUTE_DEFINITIONS.memory.path
-            : dynamicPluginsRoute
-              ? APP_ROUTE_DEFINITIONS.plugins.path
-              : sessionNamespace
-                ? APP_ROUTE_DEFINITIONS[sessionNamespace].path
-                : null;
-    const firstRouteSegment = (routePath ?? dynamicRoutePath ?? "").split("/").find(Boolean);
-    if (index > 0 && previousSegment === firstRouteSegment) {
-      return "";
-    }
-    if (index === 0) {
+    const dynamicRoutePath =
+      documentRoutePath ?? (dynamicRouteId ? APP_ROUTE_DEFINITIONS[dynamicRouteId].path : null);
+    const firstRouteSegment = (routePath ?? dynamicRoutePath ?? "").split("/")[1];
+    if (index === 0 || previousSegment === firstRouteSegment) {
       return "";
     }
     const basePath = `/${segments.slice(0, index).join("/")}`;

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -8,7 +8,9 @@ import type {
   RouterHistory,
 } from "@openclaw/uirouter";
 import {
+  activityPersonFromPath,
   agentRouteFromPath,
+  INTERNAL_ACTIVITY_PATH_PARAM,
   INTERNAL_AGENT_PATH_PARAM,
   INTERNAL_MEMORY_PATH_PARAM,
   INTERNAL_PLUGINS_PATH_PARAM,
@@ -120,8 +122,8 @@ export function createApplicationRouter(): ApplicationRouter {
   const router = createRouter<RouteId, ApplicationContext<RouteId>, AppRouteModule>({
     routes: appRoutes,
   });
-  // The shared router intentionally matches exact paths only. Workboard ids,
-  // hub tabs, and session refs are runtime data, so the app owns those paths.
+  // The shared router intentionally matches exact paths only. People, Workboard
+  // ids, hub tabs, and session refs are runtime data, so the app owns those paths.
   return {
     ...router,
     routeIdFromPath,
@@ -131,6 +133,9 @@ export function createApplicationRouter(): ApplicationRouter {
 type DynamicRoute = readonly [routeId: RouteId, searchKey: string, searchValue: string];
 
 function dynamicRouteFromPath(pathname: string, basePath: string): DynamicRoute | null {
+  if (activityPersonFromPath(pathname, basePath)) {
+    return ["activity", INTERNAL_ACTIVITY_PATH_PARAM, pathname];
+  }
   const agentRoute = agentRouteFromPath(pathname, basePath);
   if (agentRoute) {
     return ["agents", INTERNAL_AGENT_PATH_PARAM, pathname];

--- a/ui/src/components/person-activity-card.ts
+++ b/ui/src/components/person-activity-card.ts
@@ -254,7 +254,7 @@ export function renderPersonActivityCard(input: PersonCardInput) {
         presenceMatchesProfile(user, actor?.identity),
       ),
   );
-  const activity = personActivityLink(user.identity?.id, input.routing);
+  const activity = personActivityLink(user.identity?.id, input.routing, user.name);
   return html`<div class="person-activity-card">
     <header class="person-activity-card__header">
       <openclaw-viewer-avatar

--- a/ui/src/components/person-activity-link.ts
+++ b/ui/src/components/person-activity-link.ts
@@ -9,7 +9,7 @@ import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
  */
 export type PersonActivityRouting = {
   basePath: string;
-  navigate: (personId: string) => void;
+  navigate: (personId: string, label?: string) => void;
 };
 
 type PersonActivityLink = { href: string; open: (event: MouseEvent) => void };
@@ -27,9 +27,9 @@ export function personActivityRouting(
 ): PersonActivityRouting {
   return {
     basePath: context.basePath,
-    navigate: (personId: string) => {
+    navigate: (personId: string, label?: string) => {
       beforeNavigate?.();
-      context.navigate("activity", activityPersonLocation(personId, context.basePath));
+      context.navigate("activity", activityPersonLocation(personId, context.basePath, label));
     },
   };
 }
@@ -38,19 +38,20 @@ export function personActivityRouting(
 export function personActivityLink(
   personId: string | null | undefined,
   routing: PersonActivityRouting | undefined,
+  label?: string,
 ): PersonActivityLink | null {
   const id = personId?.trim();
   if (!id || !routing) {
     return null;
   }
   return {
-    href: activityPersonLocation(id, routing.basePath).href,
+    href: activityPersonLocation(id, routing.basePath, label).href,
     open: (event: MouseEvent) => {
       if (!shouldHandleNavigationClick(event)) {
         return;
       }
       event.preventDefault();
-      routing.navigate(id);
+      routing.navigate(id, label);
     },
   };
 }

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -548,14 +548,14 @@ describe("renderSessionHovercard", () => {
     );
 
     const name = container.querySelector<HTMLAnchorElement>(".session-hovercard__attribution-name");
-    expect(name?.getAttribute("href")).toBe("/ui/activity?person=alice");
+    expect(name?.getAttribute("href")).toBe("/ui/activity/alice");
     expect(
       container.querySelector(".person-activity-avatar-link")?.getAttribute("aria-hidden"),
     ).toBe("true");
 
     const click = new MouseEvent("click", { bubbles: true, cancelable: true });
     name?.dispatchEvent(click);
-    expect(navigate).toHaveBeenCalledWith("alice");
+    expect(navigate).toHaveBeenCalledWith("alice", "Alice Baker");
     expect(click.defaultPrevented).toBe(true);
   });
 
@@ -595,10 +595,10 @@ describe("renderSessionHovercard", () => {
       ...container.querySelectorAll<HTMLAnchorElement>("openclaw-viewer-facepile a"),
     ];
     expect(participantLinks.map((link) => link.getAttribute("href"))).toEqual([
-      "/activity?person=mira",
-      "/activity?person=riley",
-      "/activity?person=sam",
-      "/activity?person=lee",
+      "/activity/mira",
+      "/activity/riley",
+      "/activity/sam",
+      "/activity/lee",
     ]);
 
     const participantsTooltip = container.querySelector<
@@ -622,22 +622,17 @@ describe("renderSessionHovercard", () => {
           ".session-hovercard__participant-link",
         ) ?? []),
       ].map((link) => link.getAttribute("href")),
-    ).toEqual([
-      "/activity?person=mira",
-      "/activity?person=riley",
-      "/activity?person=sam",
-      "/activity?person=lee",
-    ]);
+    ).toEqual(["/activity/mira", "/activity/riley", "/activity/sam", "/activity/lee"]);
 
     participantLinks[1]?.dispatchEvent(
       new MouseEvent("click", { bubbles: true, cancelable: true }),
     );
-    expect(navigate).toHaveBeenCalledWith("riley");
+    expect(navigate).toHaveBeenCalledWith("riley", "Riley");
 
     participantsTooltip
       ?.querySelector<HTMLAnchorElement>('.session-hovercard__participant-link[href$="lee"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-    expect(navigate).toHaveBeenLastCalledWith("lee");
+    expect(navigate).toHaveBeenLastCalledWith("lee", "Lee");
   });
 
   it("uses the first participant as the attribution when the creator is unknown", () => {

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -236,7 +236,7 @@ function renderParticipantMenu(
       const label = participantLabel(participant);
       const activity =
         participant.identity.type === "profile"
-          ? personActivityLink(participant.identity.id, personActivity)
+          ? personActivityLink(participant.identity.id, personActivity, label)
           : null;
       return html`<div role="listitem">
         ${renderPersonName(
@@ -271,7 +271,7 @@ function renderSessionAttribution({
   const primaryParticipant = creator ? undefined : participants[0];
   const primaryActivity =
     primaryIdentity?.type === "profile"
-      ? personActivityLink(primaryIdentity.id, personActivity)
+      ? personActivityLink(primaryIdentity.id, personActivity, primaryLabel)
       : null;
   const creatorInitials = creator ? sessionOwnerInitials(creator) : "";
   const avatarFallback = creatorInitials

--- a/ui/src/components/viewer-facepile.test.ts
+++ b/ui/src/components/viewer-facepile.test.ts
@@ -150,7 +150,7 @@ it.each(
         provenance !== "unqualified" ? `/api/users/${id}/avatar` : undefined,
       );
       expect(facepile.querySelector("a")?.getAttribute("href")).toBe(
-        provenance !== "unqualified" ? `/activity?person=${id}` : undefined,
+        provenance !== "unqualified" ? "/activity/ada-lovelace-c3e324520467" : undefined,
       );
       expect(facepile.querySelector(".viewer-facepile")?.getAttribute("data-viewer-count")).toBe(
         provenance === "mixed" ? "2" : "1",
@@ -419,7 +419,7 @@ it("links faces only when the host opts in, so nested facepiles stay plain", asy
     [...linked.querySelectorAll<HTMLAnchorElement>("a.person-activity-avatar-link")].map((link) =>
       link.getAttribute("href"),
     ),
-  ).toEqual(["/activity?person=profile-ada", "/activity?person=profile-mira"]);
+  ).toEqual(["/activity/profile-ada", "/activity/profile-mira"]);
 
   // Sidebar rows and collapsed group headers render facepiles inside an anchor or button;
   // a nested link there would break the parent's click target.

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -131,7 +131,7 @@ class ViewerFacepile extends OpenClawLightDomContentsElement {
                 variant="session"
               ></openclaw-viewer-avatar>`,
               user.identity?.type === "profile"
-                ? personActivityLink(user.identity.id, this.personActivity)
+                ? personActivityLink(user.identity.id, this.personActivity, user.name)
                 : null,
             )}
           </span>

--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -453,9 +453,7 @@ suite.define(() => {
         const personCard = page.getByRole("dialog", { name: "Activity for Alice Chen" });
         await personCard.waitFor({ state: "visible" });
         await personCard.getByRole("link", { name: "View activity", exact: true }).click();
-        await expect
-          .poll(() => new URL(page.url()).searchParams.get("person"))
-          .toBe("profile-alice");
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/activity/profile-alice");
         await expect
           .poll(() => activityPage.locator('[data-activity-identity="profile-alice"]').isVisible())
           .toBe(true);
@@ -473,12 +471,10 @@ suite.define(() => {
         });
 
         await activityPage.locator(".activity-feed__people-clear").click();
-        await expect.poll(() => new URL(page.url()).searchParams.get("person")).toBeNull();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/activity");
         await activityPage.locator(".activity-feed__people-trigger").click();
         await activityPage.locator('[data-activity-person="profile-carol"]').click();
-        await expect
-          .poll(() => new URL(page.url()).searchParams.get("person"))
-          .toBe("profile-carol");
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/activity/profile-carol");
         await expect.poll(() => activitySession(nightlyMaintenanceKey).count()).toBe(1);
         await expect
           .poll(() =>
@@ -493,7 +489,7 @@ suite.define(() => {
         });
 
         await activityPage.locator(".activity-feed__people-clear").click();
-        await expect.poll(() => new URL(page.url()).searchParams.get("person")).toBeNull();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/activity");
         await page.setViewportSize({ height: 844, width: 390 });
 
         const peopleControl = activityPage.locator(".activity-feed__people-control");
@@ -534,9 +530,7 @@ suite.define(() => {
         ).toEqual({ backgroundColor: "rgba(0, 0, 0, 0)", borderTopWidth: "0px" });
         await activityPage.locator(".activity-feed__people-trigger").click();
         await activityPage.locator('[data-activity-person="profile-carol"]').click();
-        await expect
-          .poll(() => new URL(page.url()).searchParams.get("person"))
-          .toBe("profile-carol");
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/activity/profile-carol");
         await expect.poll(() => activitySession(nightlyMaintenanceKey).count()).toBe(1);
         await expect
           .poll(() => activityFeed.locator('[data-activity-created-via="cron"]').count())

--- a/ui/src/e2e/identity-activity-links.e2e.test.ts
+++ b/ui/src/e2e/identity-activity-links.e2e.test.ts
@@ -32,10 +32,14 @@ async function captureProof(page: Page, fileName: string): Promise<void> {
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
-  it("opens each identity's activity feed from the hovercard", async () => {
+  it("opens identity activity links and preserves pretty URLs through filters and reloads", async () => {
     const now = Date.now();
     const selectedSessionKey = "agent:main:identity-selected";
     const sessionKey = "agent:main:identity-hovered";
+    const adaId = "a1b2c3d4-1234-4567-89ab-0123456789ab";
+    const adaPath = "/activity/ada-king-a1b2c3d41234";
+    const exactAdaPath = "/activity/ada-king-a1b2c3d41234456789ab0123456789ab";
+    const missingId = "a1b2c3d4-1234-4567-89ab-0123456789ac";
 
     await suite.withPage(
       {
@@ -56,8 +60,8 @@ suite.define(() => {
             {
               createdActor: {
                 type: "human",
-                id: "profile-ada",
-                identity: { type: "profile", id: "profile-ada" },
+                id: adaId,
+                identity: { type: "profile", id: adaId },
                 label: "Ada King",
               },
               createdAt: now - 3 * 60 * 60_000,
@@ -68,13 +72,13 @@ suite.define(() => {
               owner: {
                 actor: {
                   type: "human",
-                  id: "profile-ada",
-                  identity: { type: "profile", id: "profile-ada" },
+                  id: adaId,
+                  identity: { type: "profile", id: adaId },
                   label: "Ada King",
                 },
               },
               participants: [
-                { identity: { type: "profile", id: "profile-ada" }, label: "Ada King" },
+                { identity: { type: "profile", id: adaId }, label: "Ada King" },
                 { identity: { type: "profile", id: "profile-mira" }, label: "Mira" },
               ],
               participantCount: 2,
@@ -83,7 +87,7 @@ suite.define(() => {
           ]),
           people: [
             {
-              identity: { type: "profile", id: "profile-ada" },
+              identity: { type: "profile", id: adaId },
               label: "Ada King",
               sessionCount: 1,
             },
@@ -93,7 +97,7 @@ suite.define(() => {
           peopleIncomplete: false,
         };
         const associatedSessions = sessionList.sessions.slice(1);
-        await installMockGateway(page, {
+        const gateway = await installMockGateway(page, {
           featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
           hasMultipleSessionSharingIdentities: true,
           presenceUsers: [
@@ -103,21 +107,44 @@ suite.define(() => {
               identity: { type: "profile", id: "profile-self" },
               name: "You",
             },
+            {
+              id: adaId,
+              identity: { type: "profile", id: adaId },
+              name: "Ada King",
+            },
           ],
           methodResponses: {
             "progressCard.get": { card: null },
             "sessions.list": {
               cases: [
-                ...["profile-ada", "profile-mira"].map((involvingProfileId) => ({
-                  match: { involvingProfileId },
+                {
+                  match: { involvingProfileId: "a1b2c3d41234", search: "no-matching-sessions" },
                   response: {
                     ...sessionList,
-                    involvingProfileId,
-                    sessions: associatedSessions,
-                    count: 1,
-                    totalCount: 1,
+                    involvingProfileId: adaId,
+                    people: [],
+                    sessions: [],
+                    count: 0,
+                    totalCount: 0,
                   },
+                },
+                ...[missingId, missingId.replaceAll("-", "")].map((involvingProfileId) => ({
+                  match: { involvingProfileId },
+                  response: { ...sessionList, people: [], sessions: [], count: 0, totalCount: 0 },
                 })),
+                ...[adaId, adaId.replaceAll("-", ""), "a1b2c3d41234", "profile-mira"].map(
+                  (involvingProfileId) => ({
+                    match: { involvingProfileId },
+                    response: {
+                      ...sessionList,
+                      involvingProfileId:
+                        involvingProfileId === "profile-mira" ? "profile-mira" : adaId,
+                      sessions: associatedSessions,
+                      count: 1,
+                      totalCount: 1,
+                    },
+                  }),
+                ),
                 { response: sessionList },
               ],
             },
@@ -137,7 +164,7 @@ suite.define(() => {
         const identity = card.locator("a.session-hovercard__attribution-name");
         const participant = card.locator("openclaw-viewer-facepile a.person-activity-avatar-link");
         await expect.poll(() => identity.textContent()).toBe("Ada King");
-        expect(await identity.getAttribute("href")).toBe("/activity?person=profile-ada");
+        expect(await identity.getAttribute("href")).toBe(adaPath);
         await expect
           .poll(async () =>
             (
@@ -155,7 +182,7 @@ suite.define(() => {
         await expect
           .poll(() => participant.locator(".viewer-avatar").getAttribute("aria-label"))
           .toBe("Mira");
-        expect(await participant.getAttribute("href")).toBe("/activity?person=profile-mira");
+        expect(await participant.getAttribute("href")).toBe("/activity/profile-mira");
         await identity.hover();
         expect(
           await identity.evaluate((element) => getComputedStyle(element).textDecorationLine),
@@ -170,12 +197,11 @@ suite.define(() => {
         expect(await identity.evaluate((element) => document.activeElement === element)).toBe(true);
         await identity.click();
 
-        await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
-        expect(new URL(page.url()).searchParams.get("person")).toBe("profile-ada");
+        await waitForControlUiRoute(page, { pathname: adaPath, routeId: "activity", search: "" });
         await expect.poll(() => card.count()).toBe(0);
         const activityPage = page.locator("openclaw-activity-page");
         await expect
-          .poll(() => activityPage.locator('[data-activity-identity="profile-ada"]').count())
+          .poll(() => activityPage.locator(`[data-activity-identity="${adaId}"]`).count())
           .toBe(1);
         await expect
           .poll(() => activityPage.locator(`[data-activity-session="${sessionKey}"]`).count())
@@ -195,12 +221,115 @@ suite.define(() => {
         await row.hover();
         await card.waitFor({ state: "visible" });
         await participant.click();
-        await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
-        expect(new URL(page.url()).searchParams.get("person")).toBe("profile-mira");
+        await waitForControlUiRoute(page, {
+          pathname: "/activity/profile-mira",
+          routeId: "activity",
+          search: "",
+        });
         await expect
           .poll(() => activityPage.locator('[data-activity-identity="profile-mira"]').count())
           .toBe(1);
         await captureProof(page, "hovercard-participant-activity.png");
+
+        await page.goto(new URL(adaPath, suite.server.baseUrl).href);
+        await waitForControlUiRoute(page, { pathname: adaPath, routeId: "activity", search: "" });
+        await expect
+          .poll(() => activityPage.locator(`[data-activity-identity="${adaId}"]`).isVisible())
+          .toBe(true);
+        expect(await gateway.getRequests("sessions.list")).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              params: expect.objectContaining({ involvingProfileId: "a1b2c3d41234" }),
+            }),
+          ]),
+        );
+
+        await activityPage.getByRole("button", { name: "Last 30 days", exact: true }).click();
+        await waitForControlUiRoute(page, {
+          pathname: adaPath,
+          routeId: "activity",
+          search: "?time=30d",
+        });
+        await activityPage.getByRole("searchbox").fill("Ada");
+        const filterSearch = "?time=30d&q=Ada";
+        await waitForControlUiRoute(page, {
+          pathname: adaPath,
+          routeId: "activity",
+          search: filterSearch,
+        });
+        await page.reload();
+        await waitForControlUiRoute(page, {
+          pathname: adaPath,
+          routeId: "activity",
+          search: filterSearch,
+        });
+        await expect.poll(() => activityPage.getByRole("searchbox").inputValue()).toBe("Ada");
+        await expect
+          .poll(() => activityPage.locator(`[data-activity-identity="${adaId}"]`).isVisible())
+          .toBe(true);
+        expect(await gateway.getRequests("sessions.list")).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              params: expect.objectContaining({
+                involvingProfileId: "a1b2c3d41234",
+                search: "Ada",
+                activeMinutes: 43200,
+              }),
+            }),
+          ]),
+        );
+        await captureProof(page, "pretty-person-activity-filters.png");
+
+        await activityPage.getByRole("searchbox").fill("no-matching-sessions");
+        await expect
+          .poll(() => activityPage.locator(".activity-feed__empty").isVisible())
+          .toBe(true);
+        await page.reload();
+        await expect
+          .poll(() => activityPage.locator(".activity-feed__empty").isVisible())
+          .toBe(true);
+        await expect
+          .poll(() => activityPage.locator(`[data-activity-identity="${adaId}"]`).isVisible())
+          .toBe(true);
+        expect(await activityPage.locator(".activity-feed__people-clear").isVisible()).toBe(true);
+        expect(new URL(page.url()).pathname).toBe(adaPath);
+
+        const legacyUrl = new URL(`/activity?person=${adaId}&time=30d&q=Ada`, suite.server.baseUrl);
+        await page.goto(legacyUrl.href);
+        await waitForControlUiRoute(page, {
+          pathname: exactAdaPath,
+          routeId: "activity",
+          search: filterSearch,
+        });
+        await expect
+          .poll(() => activityPage.locator(`[data-activity-session="${sessionKey}"]`).isVisible())
+          .toBe(true);
+        await activityPage.locator(".activity-feed__people-clear").click();
+        await waitForControlUiRoute(page, {
+          pathname: "/activity",
+          routeId: "activity",
+          search: filterSearch,
+        });
+        await expect.poll(() => activityPage.locator("[data-activity-identity]").count()).toBe(0);
+
+        // An exact missing bookmark must never broaden into another person's shared prefix.
+        const missingUrl = new URL(`/activity?person=${missingId}`, suite.server.baseUrl);
+        await page.goto(missingUrl.href);
+        await expect
+          .poll(() => activityPage.getByText("Person not found", { exact: true }).isVisible())
+          .toBe(true);
+        expect(page.url()).toBe(missingUrl.href);
+        await activityPage.getByRole("button", { name: "Last 30 days", exact: true }).click();
+        await waitForControlUiRoute(page, {
+          pathname: `/activity/${missingId.replaceAll("-", "")}`,
+          routeId: "activity",
+          search: "?time=30d",
+        });
+        await page.reload();
+        await expect
+          .poll(() => activityPage.getByText("Person not found", { exact: true }).isVisible())
+          .toBe(true);
+        expect(await activityPage.locator(`[data-activity-identity="${adaId}"]`).count()).toBe(0);
       },
     );
   });
@@ -324,28 +453,31 @@ suite.define(() => {
           ".chat-pane__header a.person-activity-avatar-link:has(openclaw-session-owner-chip)",
         );
         await ownerLink.waitFor({ state: "visible" });
-        expect(await ownerLink.getAttribute("href")).toBe("/activity?person=profile-ada");
+        expect(await ownerLink.getAttribute("href")).toBe("/activity/profile-ada");
         const participantLink = page.locator(
           ".chat-pane__participants a.person-activity-avatar-link",
         );
-        expect(await participantLink.getAttribute("href")).toBe("/activity?person=profile-mira");
+        expect(await participantLink.getAttribute("href")).toBe("/activity/profile-mira");
 
         const authorGroup = page.locator(".chat-group.user", { hasText: "Handing this over." });
         const author = authorGroup.locator("a.chat-sender-name");
         await author.waitFor({ state: "visible" });
         await expect.poll(() => author.textContent()).toBe("Ada King");
-        expect(await author.getAttribute("href")).toBe("/activity?person=profile-ada");
+        expect(await author.getAttribute("href")).toBe("/activity/profile-ada");
         const legacyGroup = page.locator(".chat-group.user", {
           hasText: "Historical attribution stays display-only.",
         });
         await legacyGroup.locator(".chat-sender-name").waitFor({ state: "visible" });
         expect(await legacyGroup.locator(".chat-sender-name").textContent()).toBe("Historical Ada");
-        expect(await legacyGroup.locator('a[href*="/activity?person="]').count()).toBe(0);
+        expect(await legacyGroup.locator('a[href*="/activity/"]').count()).toBe(0);
         await captureProof(page, "chat-identity-links.png");
 
         await participantLink.click();
-        await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
-        expect(new URL(page.url()).searchParams.get("person")).toBe("profile-mira");
+        await waitForControlUiRoute(page, {
+          pathname: "/activity/profile-mira",
+          routeId: "activity",
+          search: "",
+        });
         await expect
           .poll(() =>
             page
@@ -362,8 +494,11 @@ suite.define(() => {
         // which is what reaching for the name does anyway.
         await authorGroup.hover();
         await author.click();
-        await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
-        expect(new URL(page.url()).searchParams.get("person")).toBe("profile-ada");
+        await waitForControlUiRoute(page, {
+          pathname: "/activity/profile-ada",
+          routeId: "activity",
+          search: "",
+        });
         await captureProof(page, "chat-author-activity.png");
       },
     );

--- a/ui/src/e2e/people-activity-card.e2e.test.ts
+++ b/ui/src/e2e/people-activity-card.e2e.test.ts
@@ -284,7 +284,7 @@ suite.define(() => {
         await person.click();
         await card.waitFor({ state: "visible" });
         await card.getByRole("link", { name: "View activity", exact: true }).click();
-        await expect.poll(() => page.url()).toContain("/activity?person=alice");
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/activity/alice");
         await expect.poll(() => card.count()).toBe(0);
       },
     );
@@ -451,7 +451,7 @@ suite.define(() => {
         await profileCard.waitFor({ state: "visible" });
         expect(await profileCard.getByRole("link", { name: /^Raw watch(?:\s|$)/ }).count()).toBe(0);
         const activity = profileCard.getByRole("link", { name: "View activity", exact: true });
-        expect(await activity.getAttribute("href")).toBe(`/activity?person=${id}`);
+        expect(await activity.getAttribute("href")).toBe(`/activity/${id}`);
         if (captureUiProofEnabled) {
           await page.screenshot({
             path: path.join(proofDirectory, "profile-card.png"),

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -340,7 +340,7 @@ suite.define(() => {
           .toBe("Ada King & 4 others");
         const attribution = card.locator(".session-hovercard__attribution");
         const attributionName = attribution.locator("a.session-hovercard__attribution-name");
-        expect(await attributionName.getAttribute("href")).toBe("/activity?person=profile-ada");
+        expect(await attributionName.getAttribute("href")).toBe("/activity/profile-ada");
         const linkedAvatars = attribution.locator(".person-activity-avatar-link .viewer-avatar");
         await expect.poll(() => linkedAvatars.count()).toBe(5);
         const collapsedSpread = await linkedAvatars.evaluateAll((avatars) => {

--- a/ui/src/pages/activity/activity-page.ts
+++ b/ui/src/pages/activity/activity-page.ts
@@ -1,5 +1,6 @@
 import { consume } from "@lit/context";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import type { RouteLocation } from "@openclaw/uirouter";
 import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { AuditRunInspectResult } from "../../../../packages/gateway-protocol/src/schema/audit-run.js";
@@ -10,7 +11,7 @@ import {
   type GatewayEventFrame,
 } from "../../api/gateway.ts";
 import { titleForRoute } from "../../app-navigation.ts";
-import { pathForRoute } from "../../app-route-paths.ts";
+import { activityPersonFromPath, pathForRoute } from "../../app-route-paths.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -42,7 +43,6 @@ import {
 import { renderRunInspector } from "./run-inspector-view.ts";
 import { SessionActivityController } from "./session-activity-controller.ts";
 import { renderSessionActivityView } from "./session-activity-view.ts";
-import { sessionActivitySearch } from "./session-activity.ts";
 import {
   parseActivityEvent,
   updateToolActivity,
@@ -76,7 +76,11 @@ class ActivityPage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   private context!: ApplicationContext;
 
-  @property({ attribute: false }) routeSearch = "";
+  @property({ attribute: false }) routeLocation: RouteLocation = {
+    pathname: "/activity",
+    search: "",
+    hash: "",
+  };
   private routeData: ActivityRouteData = {
     mode: "sessions",
     filters: { personId: null, query: "", time: "7d" },
@@ -126,15 +130,26 @@ class ActivityPage extends OpenClawLightDomElement {
   );
 
   override willUpdate(changed: PropertyValues) {
-    if (changed.has("routeSearch")) {
-      this.routeData = resolveActivityRouteData(this.routeSearch);
+    if (changed.has("routeLocation")) {
+      this.routeData = resolveActivityRouteData(
+        this.routeLocation.search,
+        activityPersonFromPath(this.routeLocation.pathname, this.context?.basePath),
+      );
     }
   }
 
   override updated(changed: PropertyValues) {
-    if (changed.has("routeSearch")) {
+    if (changed.has("routeLocation")) {
       this.bindInspectorRoute();
       this.syncSessionActivity();
+    }
+    const canonical = this.sessionActivity.canonicalLocation(
+      this.routeLocation,
+      this.context.basePath,
+      projectPresencePayload(this.presencePayload).users,
+    );
+    if (canonical) {
+      this.context.replace("activity", canonical);
     }
     const autoFollowEnabled = this.autoFollow && changed.has("autoFollow");
     if (
@@ -550,6 +565,7 @@ class ActivityPage extends OpenClawLightDomElement {
   private renderMode() {
     const route = this.routeData;
     if (route.mode === "sessions") {
+      const presenceViewers = projectPresencePayload(this.presencePayload).users;
       return renderSessionActivityView({
         context: this.context,
         expandedAutomationDays: this.expandedAutomationDays,
@@ -557,7 +573,7 @@ class ActivityPage extends OpenClawLightDomElement {
           ...route.filters,
           personId: this.sessionActivity.result?.involvingProfileId ?? route.filters.personId,
         },
-        presenceViewers: projectPresencePayload(this.presencePayload).users,
+        presenceViewers,
         result: this.sessionActivity.result,
         loading: this.sessionActivity.loading,
         error: this.sessionActivity.error,
@@ -572,7 +588,15 @@ class ActivityPage extends OpenClawLightDomElement {
           this.expandedAutomationDays = next;
         },
         onFiltersChange: (next) =>
-          this.context.navigate("activity", { search: sessionActivitySearch(next) }),
+          this.context.navigate(
+            "activity",
+            this.sessionActivity.locationForFilters(
+              next,
+              this.routeLocation,
+              this.context.basePath,
+              presenceViewers,
+            ),
+          ),
       });
     }
     if (route.mode === "run") {
@@ -671,9 +695,8 @@ class ActivityPage extends OpenClawLightDomElement {
 
 export const activityPageComponent = {
   header: true,
-  render: (search: unknown) => html`<openclaw-activity-page
-    .routeSearch=${typeof search === "string" ? search : ""}
-  ></openclaw-activity-page>`,
+  render: (location: RouteLocation = { pathname: "/activity", search: "", hash: "" }) =>
+    html`<openclaw-activity-page .routeLocation=${location}></openclaw-activity-page>`,
 };
 
 if (!customElements.get("openclaw-activity-page")) {

--- a/ui/src/pages/activity/route.test.ts
+++ b/ui/src/pages/activity/route.test.ts
@@ -1,15 +1,16 @@
 // @vitest-environment node
 import type { RouteLoaderOptions, RouteLocation } from "@openclaw/uirouter";
 import { describe, expect, it } from "vitest";
+import { activityPersonFromPath } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { page } from "./route.ts";
 import { resolveActivityRouteData, type ActivityRouteData } from "./run-inspector-model.ts";
 
-function loadRoute(search: string): ActivityRouteData {
+function loadRoute(search: string, pathname = "/activity", basePath = ""): ActivityRouteData {
   if (!page.loader) {
     throw new Error("activity route has no loader");
   }
-  const location: RouteLocation = { pathname: "/activity", search, hash: "" };
+  const location: RouteLocation = { pathname, search, hash: "" };
   const loaded = page.loader({} as ApplicationContext, {
     signal: new AbortController().signal,
     shouldRun: () => true,
@@ -18,7 +19,10 @@ function loadRoute(search: string): ActivityRouteData {
     deps: search,
     cause: "navigation",
   } satisfies RouteLoaderOptions);
-  return resolveActivityRouteData(typeof loaded === "string" ? loaded : "");
+  if (!("pathname" in loaded)) {
+    throw new Error("activity route did not return a location");
+  }
+  return resolveActivityRouteData(loaded.search, activityPersonFromPath(loaded.pathname, basePath));
 }
 
 describe("resolveActivityRouteData", () => {
@@ -42,6 +46,20 @@ describe("resolveActivityRouteData", () => {
 
   it("keeps the browser-local tool feed behind its explicit mode", () => {
     expect(loadRoute("?view=live")).toEqual({ mode: "live", selector: null });
+  });
+
+  it("scopes readable person paths independently of query filters and mounted prefixes", () => {
+    expect(
+      loadRoute("?person=ignored&time=30d&q=release", "/ui/activity/ada-12345678", "/ui"),
+    ).toEqual({
+      mode: "sessions",
+      filters: { personId: "12345678", time: "30d", query: "release" },
+      selector: null,
+    });
+    expect(loadRoute("?view=live", "/activity/ada-12345678")).toEqual({
+      mode: "live",
+      selector: null,
+    });
   });
 
   it("decodes one run-inspector query reference without narrowing it", () => {

--- a/ui/src/pages/activity/route.ts
+++ b/ui/src/pages/activity/route.ts
@@ -1,9 +1,20 @@
-import { definePage } from "@openclaw/uirouter";
-import { routePageSpec } from "../../app-route-paths.ts";
+import { definePage, type RouteLocation } from "@openclaw/uirouter";
+import { INTERNAL_ACTIVITY_PATH_PARAM, routePageSpec } from "../../app-route-paths.ts";
+
+function sessionActivityRouteLocation(location: RouteLocation): RouteLocation {
+  const params = new URLSearchParams(location.search);
+  const pathname = params.get(INTERNAL_ACTIVITY_PATH_PARAM) ?? location.pathname;
+  params.delete(INTERNAL_ACTIVITY_PATH_PARAM);
+  const search = params.toString();
+  return { pathname, search: search ? `?${search}` : "", hash: location.hash };
+}
 
 export const page = definePage({
   ...routePageSpec("activity"),
-  loaderDeps: (_context, { search }) => search,
-  loader: (_context, { deps }) => deps,
+  loaderDeps: (_context, source) => {
+    const { pathname, search, hash } = sessionActivityRouteLocation(source);
+    return `${pathname}\u0000${search}\u0000${hash}`;
+  },
+  loader: (_context, { location }) => sessionActivityRouteLocation(location),
   component: () => import("./activity-page.ts").then((module) => module.activityPageComponent),
 });

--- a/ui/src/pages/activity/run-inspector-model.ts
+++ b/ui/src/pages/activity/run-inspector-model.ts
@@ -43,13 +43,20 @@ export function activityRunInspectorHref(runId: string, basePath: string): strin
   return activityRunInspectorSelectorHref({ kind: "run", id: runId }, basePath);
 }
 
-export function resolveActivityRouteData(search: string): ActivityRouteData {
+export function resolveActivityRouteData(
+  search: string,
+  pathPersonId?: string | null,
+): ActivityRouteData {
   const params = new URLSearchParams(search);
   if (params.get("view") === "live") {
     return { mode: "live", selector: null };
   }
   if (params.get("view") !== "run") {
-    return { mode: "sessions", filters: parseSessionActivityFilters(search), selector: null };
+    return {
+      mode: "sessions",
+      filters: parseSessionActivityFilters(search, pathPersonId),
+      selector: null,
+    };
   }
   const executionId = params.get("execution");
   const selectorId = params.get("receipt")?.trim() || null;

--- a/ui/src/pages/activity/session-activity-controller.ts
+++ b/ui/src/pages/activity/session-activity-controller.ts
@@ -1,8 +1,15 @@
+import type { RouteLocation } from "@openclaw/uirouter";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
+import { activityPersonFromPath, activityPersonLocation } from "../../app-route-paths.ts";
+import type { PresenceViewer } from "../../lib/presence-users.ts";
 import { createSessionEventRefreshCoordinator } from "../../lib/sessions/event-refresh-coordinator.ts";
-import type { SessionActivityFilters } from "./session-activity.ts";
+import {
+  canonicalSessionActivityLocation,
+  sessionActivityLocation,
+  type SessionActivityFilters,
+} from "./session-activity.ts";
 
 /** The Activity query owns its page; selecting a person must not replace the sidebar roster. */
 export class SessionActivityController implements ReactiveController {
@@ -14,6 +21,7 @@ export class SessionActivityController implements ReactiveController {
   private pending?: AbortController;
   private refreshPending = false;
   private filters: SessionActivityFilters | null = null;
+  private normalizedLocation = "";
   private readonly observesPageLifecycle =
     typeof document !== "undefined" && typeof globalThis.addEventListener === "function";
   private pageActive = !this.observesPageLifecycle || document.visibilityState !== "hidden";
@@ -47,6 +55,68 @@ export class SessionActivityController implements ReactiveController {
     this.result = undefined;
     this.refreshPending = false;
     this.filters = null;
+    this.normalizedLocation = "";
+  }
+
+  private personLabel(id: string, presence: readonly PresenceViewer[]): string | undefined {
+    return (
+      this.result?.people?.find((person) => person.identity.id === id)?.label ??
+      presence.find((person) => person.identity?.id === id)?.name
+    );
+  }
+
+  canonicalLocation(
+    location: RouteLocation,
+    basePath: string,
+    presence: readonly PresenceViewer[],
+  ): RouteLocation | null {
+    if (!this.filters?.personId || !this.result?.involvingProfileId || this.loading) {
+      return null;
+    }
+    const personId = this.result.involvingProfileId;
+    const canonical = canonicalSessionActivityLocation(
+      location,
+      personId,
+      this.personLabel(personId, presence),
+      basePath,
+    );
+    if (!canonical) {
+      this.normalizedLocation = "";
+      return null;
+    }
+    const source = `${location.pathname}${location.search}${location.hash}`;
+    if (this.normalizedLocation === source) {
+      return null;
+    }
+    // The resolved ID owns the link; replace each stale name once without adding history.
+    this.normalizedLocation = source;
+    return canonical;
+  }
+
+  locationForFilters(
+    filters: SessionActivityFilters,
+    current: RouteLocation,
+    basePath: string,
+    presence: readonly PresenceViewer[],
+  ) {
+    const location = sessionActivityLocation(
+      filters,
+      basePath,
+      filters.personId ? this.personLabel(filters.personId, presence) : undefined,
+    );
+    const currentId = this.result?.involvingProfileId ?? this.filters?.personId;
+    if (filters.personId && filters.personId === currentId) {
+      // Filter changes must not broaden an exact legacy bookmark into a shared prefix.
+      location.pathname = activityPersonFromPath(current.pathname, basePath)
+        ? current.pathname
+        : activityPersonLocation(
+            filters.personId,
+            basePath,
+            this.personLabel(filters.personId, presence),
+            32,
+          ).pathname;
+    }
+    return location;
   }
 
   private readonly handlePageLifecycle = (event: Event): void => {

--- a/ui/src/pages/activity/session-activity.test.ts
+++ b/ui/src/pages/activity/session-activity.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { activityPersonFromPath } from "../../app-route-paths.ts";
 import {
   parseSessionActivityFilters,
+  canonicalSessionActivityLocation,
   projectSessionActivity,
-  sessionActivitySearch,
+  sessionActivityLocation,
 } from "./session-activity.ts";
 
 const people: NonNullable<SessionsListResult["people"]> = [
@@ -24,6 +26,37 @@ function result(sessions: GatewaySessionRow[]): SessionsListResult {
 }
 
 describe("session activity projection", () => {
+  it("refreshes decorative names while retaining exact references, longer prefixes, filters and anchors", () => {
+    const personId = "12345678-abcd-4123-8123-123456789abc";
+    const legacy = {
+      pathname: "/ui/activity",
+      search: `?person=${personId}&time=30d&q=release`,
+      hash: "#sessions",
+    };
+    expect(canonicalSessionActivityLocation(legacy, personId, "Ada Lovelace", "/ui")).toEqual({
+      pathname: "/ui/activity/ada-lovelace-12345678abcd41238123123456789abc",
+      search: "?time=30d&q=release",
+      hash: "#sessions",
+    });
+    for (const reference of [
+      "12345678",
+      "12345678abcd4123",
+      personId,
+      personId.replaceAll("-", ""),
+    ]) {
+      const location = { ...legacy, pathname: `/ui/activity/${reference}`, search: "?q=none" };
+      expect(canonicalSessionActivityLocation(location, personId, "Ada", "/ui")?.pathname).toBe(
+        `/ui/activity/ada-${reference.replaceAll("-", "")}`,
+      );
+    }
+    const empty = { pathname: "/ui/activity/ada-12345678abcd", search: "?q=none", hash: "" };
+    expect(canonicalSessionActivityLocation(empty, "12345678abcd", undefined, "/ui")).toBeNull();
+    expect(
+      canonicalSessionActivityLocation(legacy, "abcdef12-1234-4123-8123-123456789abc", "Ada", "/ui")
+        ?.pathname,
+    ).toBe("/ui/activity/ada-abcdef12123441238123123456789abc");
+  });
+
   it("groups the server page without treating its preview or session clock as personal history", () => {
     const now = new Date(2026, 7, 17, 12).getTime();
     const rows: GatewaySessionRow[] = [
@@ -66,10 +99,16 @@ describe("session activity projection", () => {
     expect(projectSessionActivity(undefined).sessions).toEqual([]);
   });
 
-  it("round-trips linkable filters in a stable query order", () => {
+  it("round-trips person paths and query filters under a mounted base path", () => {
     const filters = { personId: "profile/a", query: "release notes", time: "30d" as const };
-    const search = sessionActivitySearch(filters);
-    expect(search).toBe("?time=30d&person=profile%2Fa&q=release+notes");
-    expect(parseSessionActivityFilters(search)).toEqual(filters);
+    const { pathname, search } = sessionActivityLocation(filters, "/ui");
+    expect(pathname).toBe("/ui/activity/profile%2Fa");
+    expect(search).toBe("?time=30d&q=release+notes");
+    expect(parseSessionActivityFilters(search, activityPersonFromPath(pathname, "/ui"))).toEqual(
+      filters,
+    );
+    expect(sessionActivityLocation({ ...filters, personId: null }, "/ui").pathname).toBe(
+      "/ui/activity",
+    );
   });
 });

--- a/ui/src/pages/activity/session-activity.ts
+++ b/ui/src/pages/activity/session-activity.ts
@@ -1,6 +1,12 @@
+import type { RouteLocation } from "@openclaw/uirouter";
 import { buildControlUiResourcePath } from "../../../../src/gateway/control-ui-resource-routes.js";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
-import { ACTIVITY_PERSON_PARAM } from "../../app-route-paths.ts";
+import {
+  ACTIVITY_PERSON_PARAM,
+  activityPersonFromPath,
+  activityPersonLocation,
+  pathForRoute,
+} from "../../app-route-paths.ts";
 import { readAvatarGatewayContext } from "../../lib/identity-avatar-context.ts";
 import type { PresenceViewer } from "../../lib/presence-users.ts";
 
@@ -40,29 +46,68 @@ function normalized(value: string | null | undefined): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
-export function parseSessionActivityFilters(search: string): SessionActivityFilters {
+export function parseSessionActivityFilters(
+  search: string,
+  pathPersonId?: string | null,
+): SessionActivityFilters {
   const params = new URLSearchParams(search);
   const rawTime = params.get("time");
   return {
-    personId: normalized(params.get(ACTIVITY_PERSON_PARAM)) ?? null,
+    personId: pathPersonId ?? normalized(params.get(ACTIVITY_PERSON_PARAM)) ?? null,
     query: params.get("q")?.trim() ?? "",
     time: isActivityTimeFilter(rawTime) ? rawTime : DEFAULT_ACTIVITY_TIME_FILTER,
   };
 }
 
-export function sessionActivitySearch(filters: SessionActivityFilters): string {
+export function sessionActivityLocation(
+  filters: SessionActivityFilters,
+  basePath = "",
+  personLabel?: string,
+): { pathname: string; search: string } {
   const params = new URLSearchParams();
   if (filters.time !== DEFAULT_ACTIVITY_TIME_FILTER) {
     params.set("time", filters.time);
-  }
-  if (filters.personId) {
-    params.set(ACTIVITY_PERSON_PARAM, filters.personId);
   }
   if (filters.query) {
     params.set("q", filters.query);
   }
   const serialized = params.toString();
-  return serialized ? `?${serialized}` : "";
+  const search = serialized ? `?${serialized}` : "";
+  const pathname = filters.personId
+    ? activityPersonLocation(filters.personId, basePath, personLabel).pathname
+    : pathForRoute("activity", basePath);
+  return { pathname, search };
+}
+
+export function canonicalSessionActivityLocation(
+  location: RouteLocation,
+  personId: string,
+  label: string | undefined,
+  basePath: string,
+): RouteLocation | null {
+  const params = new URLSearchParams(location.search);
+  const pathReference = activityPersonFromPath(location.pathname, basePath);
+  const compactReference = (pathReference ?? params.get(ACTIVITY_PERSON_PARAM))?.replaceAll(
+    "-",
+    "",
+  );
+  const prefixLength =
+    compactReference &&
+    /^[0-9a-f]{8,32}$/.test(compactReference) &&
+    personId.replaceAll("-", "").startsWith(compactReference)
+      ? compactReference.length
+      : 32;
+  // Empty filtered pages carry no profile metadata; retain the readable incoming link.
+  const pathname =
+    pathReference && !label
+      ? location.pathname
+      : activityPersonLocation(personId, basePath, label, prefixLength).pathname;
+  params.delete(ACTIVITY_PERSON_PARAM);
+  const query = params.toString();
+  const search = query ? `?${query}` : "";
+  return pathname === location.pathname && search === location.search
+    ? null
+    : { pathname, search, hash: location.hash };
 }
 
 export function sessionActivityTimestamp(row: GatewaySessionRow): number {

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -520,7 +520,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
                     who,
                     // Only other people's messages: your own name links nowhere useful.
                     isPeerGroup && group.sender?.identity?.type === "profile"
-                      ? personActivityLink(group.sender.identity.id, opts.personActivity)
+                      ? personActivityLink(group.sender.identity.id, opts.personActivity, who)
                       : null,
                     "chat-sender-name",
                   )}

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2053,9 +2053,9 @@ describe("grouped chat rendering", () => {
     const peer = renderSender("profile-alice");
     const link = peer.querySelector<HTMLAnchorElement>("a.chat-sender-name");
     expect(link?.textContent).toBe("Alice Example");
-    expect(link?.getAttribute("href")).toBe("/activity?person=profile-alice");
+    expect(link?.getAttribute("href")).toBe("/activity/profile-alice");
     link?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-    expect(navigate).toHaveBeenCalledWith("profile-alice");
+    expect(navigate).toHaveBeenCalledWith("profile-alice", "Alice Example");
 
     const own = renderSender("me");
     expect(own.querySelector("a.chat-sender-name")).toBeNull();

--- a/ui/src/pages/chat/components/chat-pane-header-identity.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header-identity.test.ts
@@ -47,19 +47,19 @@ describe("chat pane header identity links", () => {
     const ownerLink = container.querySelector<HTMLAnchorElement>(
       "a.person-activity-avatar-link:has(openclaw-session-owner-chip)",
     );
-    expect(ownerLink?.getAttribute("href")).toBe("/activity?person=ada");
+    expect(ownerLink?.getAttribute("href")).toBe("/activity/ada");
     const participantLinks = [
       ...container.querySelectorAll<HTMLAnchorElement>(
         ".chat-pane__participants a.person-activity-avatar-link",
       ),
     ];
     expect(participantLinks.map((link) => link.getAttribute("href"))).toEqual([
-      "/activity?person=mira",
-      "/activity?person=riley",
+      "/activity/mira",
+      "/activity/riley",
     ]);
 
     ownerLink?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-    expect(navigate).toHaveBeenCalledWith("ada");
+    expect(navigate).toHaveBeenCalledWith("ada", "Ada King");
   });
 
   it("leaves identities unlinked when the header has no activity routing", () => {

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -435,6 +435,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
                   ? props.session.owner.actor.identity.id
                   : undefined,
                 props.personActivity,
+                props.session?.owner?.actor.label,
               )
             : null,
         )}

--- a/ui/src/test-helpers/app-sidebar-cases/presence.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/presence.ts
@@ -107,9 +107,9 @@ describe("AppSidebar viewer presence", () => {
       .querySelector<HTMLAnchorElement>(".person-activity-card footer a")!
       .dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
     expect(onNavigate).toHaveBeenCalledWith("activity", {
-      href: "/activity?person=alice",
-      pathname: "/activity",
-      search: "?person=alice",
+      href: "/activity/alice",
+      pathname: "/activity/alice",
+      search: "",
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Person links in the Control UI currently produce opaque addresses such as `/activity?person=12345678-abcd-4ef0-8123-456789abcdef`. Names, avatars, and participant links now open `/activity/ada-12345678abcd`, making copied links recognizable.

Fixes #136945.

## Why This Change Was Made

The shared person-link builder owns the readable path. The Gateway resolves the UUID reference against durable profiles and qualified identities in retained sessions before time/search filtering or pagination. Names are decorative; renamed and merged profiles keep working, and ambiguous references produce an explicit error.

Restricted readers resolve references only within caller-visible owner, participant, and creator associations. Visibility runs once, and the same visible entries feed lookup and listing. Hidden draft/incognito identities cannot change canonical-ID or ambiguity results. Administrator lookup remains global.

Existing query bookmarks retain all identity characters, including through filter changes, so an unresolved exact ID cannot broaden into another person's prefix. Shared route parsing removes duplicate checks and keeps the startup bundle within its existing budget. The integration preserves #136916's Activity rendering and auto-follow improvements, #136866's lazy hovercard styles and shared route index, and #136433's route-ID validation.

## User Impact

Person links work from chat authors, headers, avatars, presence, Activity cards, and session hovercards. Direct loads, reloads, browser history, mounted paths, and search/time filters preserve the selected person. Clearing the person returns to Activity with the remaining filters.

No database schema, migration, persisted preference, protocol-field, configuration, or dependency changes. Profile queries are read-only. The serialization change is the browser URL; old query bookmarks remain accepted.

## Evidence

- 174 routing/navigation/native-route/hovercard tests after the final rebase, existing focused Activity tests, and 33 Gateway tests across routing, identity, ownership, search, UUID boundaries, exact-ID priority, merged/retained identities, empty filtered results, and missing storage.
- Hidden draft/incognito regressions cover durable and missing profile rows, exact/compact references, hidden collisions, visible owner-only merge aliases, and one visibility-predicate call per entry. These failed before the repair and pass afterward.
- All 10 mocked-Gateway identity/hovercard browser scenarios passed again after the final rebase. Actual anonymous-browser person-menu clicks produced the screenshots below.
- Core/core-test/UI type checks, lint/format, schema/storage, import-cycle and authorization guards pass. The final rebased production UI build passed at 349109 B gzip against its unchanged 350141 B startup budget. Full changed-file gates passed before integration; after the visibility repair, the module-length lint issue was repaired and the affected checks were rerun successfully.
- Independent Codex reviews of the complete feature, main integration, visibility repair, and final conflict rebase are scoped-clean at P0–P2.
- [CI for the current head](https://github.com/openclaw/openclaw/actions/runs/33720735553) passed for `480fbc567a4e25490294c0eae6a5cd770af44cac`, including the required `openclaw/ci-gate`. The previous head passed all 184 checks; concurrent main changes required the final rebase before merge.

Production growth adds shared URL handling and scoped identity resolution, including the visibility boundary; common route parsing removes duplicated logic. LOC: production +449/-145 (net +304); tests/support +717/-132 (net +585); docs +79/-46 (net +33).

Screenshots contain only synthetic people and sessions.

| Before | After |
| --- | --- |
| ![Person Activity URL before](https://github.com/user-attachments/assets/112e123f-665e-43b8-9a16-78f500dea8ef) | ![Person Activity URL after](https://github.com/user-attachments/assets/2a167590-813a-47bc-9d5e-4cef17ee0657) |
