### PR TITLE
test(infra): reuse the canonical restart test assertion

### DIFF
--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -61,14 +61,6 @@ function decodeCmdPathArg(value: string): string {
   return withoutQuotes.replace(/\^!/g, "!").replace(/%%/g, "%");
 }
 
-function requireFirstMockCall<T>(mock: { mock: { calls: T[][] } }, label: string): T[] {
-  const call = mock.mock.calls[0];
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call;
-}
-
 afterEach(() => {
   envSnapshot.restore();
   for (const scriptPath of createdScriptPaths) {
@@ -123,7 +115,7 @@ describe("relaunchGatewayScheduledTask", () => {
     expect(result.method).toBe("schtasks");
     expect(result.tried).toContain('schtasks /Run /TN "OpenClaw Gateway (work)"');
     expect(result.tried).toContain(`${cmdExePath} /d /s /c ${seenCommandArg}`);
-    const spawnCall = requireFirstMockCall(spawnMock, "restart helper spawn");
+    const spawnCall = expectDefined(spawnMock.mock.calls[0], "restart helper spawn call");
     expect(spawnCall[0]).toBe(cmdExePath);
     expect(spawnCall[1]).toStrictEqual(["/d", "/s", "/c", seenCommandArg]);
     expect(spawnCall[2]).toStrictEqual({
@@ -219,7 +211,7 @@ describe("relaunchGatewayScheduledTask", () => {
     relaunchGatewayScheduledTask({ OPENCLAW_PROFILE: "work" });
 
     expect(spawnMock).toHaveBeenCalledOnce();
-    const spawnCall = requireFirstMockCall(spawnMock, "restart helper spawn");
+    const spawnCall = expectDefined(spawnMock.mock.calls[0], "restart helper spawn call");
     const commandArgs = spawnCall[1];
     if (!Array.isArray(commandArgs)) {
       throw new Error("expected cmd.exe argument array");


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested test-audit cleanup: the Windows Scheduled Task restart tests duplicate a missing-spawn-call assertion already provided by the canonical helper.

## Why This Change Was Made

Use the already-imported `expectDefined` at the two call sites and remove the local wrapper. All eight owner cases, strict command arguments/options, generated-script readback, CJK encoding checks, and fixture cleanup remain unchanged.

## User Impact

No user-visible behavior change. Production changes: **0 lines**. Tests: **+2 / −10 lines**. No configuration, API, persistence, or dependency change.

## Evidence

The same normal command passed before and after:

```sh
pnpm test src/infra/windows-task-restart.test.ts src/infra/windows-launcher-encoding.test.ts packages/normalization-core/src/expect.test.ts
```

```text
Before: 3 files passed, 32 tests passed (unit 4 + infra 28)
After:  3 files passed, 32 tests passed (unit 4 + infra 28)
```

All 46 `expect(...)` source lines and all eight owner cases are retained. Formatting, the configured changed gate (including infra test types, lint and unused-export scans), and independent Codex review passed. The gate used `pnpm check:changed -- src/infra/windows-task-restart.test.ts` on the trusted local route.

The script/encoding checks use synthetic files and a mocked spawn; this does not claim a live Windows Scheduled Task restart. Stable release source and the helper's original introduction were inspected. The canonical helper's existing tests retain missing-value rejection and defined-value behavior.
