### PR TITLE
test(install): reuse the shared warning presence guard

### DIFF
--- a/test/scripts/preinstall-package-manager-warning.test.ts
+++ b/test/scripts/preinstall-package-manager-warning.test.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { copyFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createPackageManagerWarningMessage,
@@ -19,18 +20,6 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const EXPECTED_NODE_ENGINE_RANGE = ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
-function requireFirstWarning(warn: ReturnType<typeof vi.fn>): unknown {
-  const [call] = warn.mock.calls;
-  if (!call) {
-    throw new Error("expected package manager warning");
-  }
-  const [message] = call;
-  if (message === undefined) {
-    throw new Error("expected package manager warning");
-  }
-  return message;
-}
 
 describe("install runtime enforcement", () => {
   it("reads the canonical package engine range", () => {
@@ -514,7 +503,8 @@ describe("warnIfNonPnpmLifecycle", () => {
       ),
     ).toBe(true);
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(requireFirstWarning(warn)).toContain("detected npm");
+    const [message] = expectDefined(warn.mock.calls[0], "package manager warning call");
+    expect(message).toContain("detected npm");
   });
 
   it("stays quiet for pnpm", () => {


### PR DESCRIPTION
## What Problem This Solves

The npm lifecycle warning test has a one-use helper that duplicates existing assertion support just to read the first warning.

## Why This Change Was Made

Use the shared `expectDefined` helper at the assertion site. Keep the exact warning-count and first-message content assertions, including failure when a call or message is missing, without imposing a new argument-count contract on the variadic warning callback.

## User Impact

No runtime behavior changes. All existing installer, Node/Bun, PATH, legacy-marker and package-manager cases remain. Production: 0 lines changed; tests: +3/-13 (net -10).

## Evidence

- The installer warning and canonical assertion-helper suites passed all 66 cases before and after, with identical case inventories.
- `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- test/scripts/preinstall-package-manager-warning.test.ts`: all 15 canonical local stages passed, including test types and type-aware lint.
- Formatting and independent Codex review passed with no actionable P0-P2 findings; signed commit preserves the tested bytes.

An earlier delegated attempt exited 2 during its Git bootstrap before checks ran; its lease and temporary checkout were cleaned up. Separate tooling follow-ups: **remote changed-gate Git bootstrap credential challenge** (HTTP cause unknown) and **temporary delegated failure capture not preserved**. The documented trusted-local gate above passed independently; no remote success is claimed.
