### PR TITLE
fix(update): make owner refusals and restart recovery actionable

### DIFF
--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -65,6 +65,10 @@ such as `telegram:123456789`. This gives first-time setups an explicit owner for
 privileged commands and exec approval prompts. After an owner exists, later
 pairing approvals only grant DM access; they do not add more owners.
 
+Manually allowlisted senders are not automatically command owners. If an
+authorized sender has no owner access, owner-only commands reply with the exact
+`openclaw config set commands.ownerAllowFrom` command for the operator to run.
+
 <Note>
 WhatsApp's login QR links a WhatsApp account to OpenClaw. DM access requests
 approve people who message that account. These are separate flows.

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -134,6 +134,16 @@ Doctor result leaves the Gateway stopped, including when a detached managed
 update helper is still running. Re-enabling Windows task autostart cannot
 bypass that decision.
 
+On macOS, a terminated update helper can leave the selected Gateway LaunchAgent
+installed but unloaded and disabled across logins. `openclaw doctor` and
+`openclaw doctor --fix` diagnose this state; `--fix` leaves an already-stopped
+Gateway stopped. If the update was interrupted or installation safety is
+uncertain, rerun `openclaw update` or use Doctor and triage before starting it.
+Once verified, run `openclaw gateway start` (or
+`openclaw --profile <profile> gateway start`) to re-enable and start that service.
+Keep the same state/config and custom-label overrides; Doctor prints the selected
+label and recovery command. Interactive Doctor can offer bootstrap repair.
+
 A cancellation before package mutation can restore the original service under
 its existing handoff ownership. Recovery succeeds only after the Gateway passes
 the normal restart health checks and reports the verified installation version

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -141,6 +141,12 @@ recovery stops and reports the error without retrying with weaker options. Repai
 the reported failure, rerun `openclaw update`, and check `openclaw gateway status --deep`.
 See [Failed update recovery](/gateway/restart-recovery#recovery-after-a-failed-update).
 
+On macOS, if Doctor reports an installed but unloaded and disabled Gateway
+LaunchAgent after an interrupted update, finish update verification or Doctor and
+triage first. Then use the printed `openclaw gateway start` command, preserving
+its profile and state/config or custom-label overrides. `doctor --fix` diagnoses
+the disabled label but leaves an already-stopped Gateway stopped.
+
 Use channels to change the install type. The updater keeps your state, config,
 credentials, and workspace in `~/.openclaw`; it only changes which OpenClaw
 code install the CLI and gateway use.

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -135,7 +135,10 @@ command handling is enabled for the surface.
 
 <ParamField path="commands.ownerAllowFrom" type="string[]">
   Explicit owner allowlist for owner-only command surfaces. Separate from
-  `commands.allowFrom` and DM pairing access.
+  `commands.allowFrom` and DM pairing access. CLI pairing approval records the
+  first owner; Control UI pairing has an explicit owner checkbox. Authorized
+  non-owners receive a refusal with the exact configuration command for their
+  sender ID when using an owner-only command such as `/restart` or `/update`.
 </ParamField>
 
 Channel plugins can enforce owner-only command access through their

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -78,14 +78,24 @@ describe("gateway update action", () => {
   });
 
   it.each([false, undefined])("requires an explicit owner identity (%s)", async (senderIsOwner) => {
-    const result = await createGatewayTool({ senderIsOwner }).execute("update", {
-      action: "update.run",
-    });
+    const result = await withGatewayToolCallerIdentity(
+      {
+        agentId: "main",
+        sessionKey: "agent:main:telegram:direct:123456789",
+        turnSourceChannel: "telegram",
+      },
+      () =>
+        createGatewayTool({ senderIsOwner, requesterSenderId: "123456789" }).execute("update", {
+          action: "update.run",
+          requesterSenderId: "spoofed",
+          channel: "discord",
+        }),
+    );
     expect(result.details).toEqual({
       ok: false,
       code: "owner_required",
       message:
-        "Only the OpenClaw owner can start an update from chat. Tell the user to run `openclaw update` in a terminal or use the Control UI.",
+        "Only the OpenClaw owner can start an update from chat. Ask the operator to run `openclaw config set commands.ownerAllowFrom '[\"telegram:123456789\"]'` in a terminal to make this sender a command owner.",
     });
     expect(callGatewayToolMock).not.toHaveBeenCalled();
     expect(dispatchMock).not.toHaveBeenCalled();
@@ -242,7 +252,7 @@ describe("gateway update action", () => {
     });
     expect(result.details).toMatchObject({ handoff: { command, message } });
     expect(JSON.stringify(result.details, null, 2).length).toBeLessThan(4000);
-    expect(JSON.stringify(result.details)).toContain("exact manual instructions in handoff");
+    expect(JSON.stringify(result.details)).toContain("exact manual instructions");
   });
 
   it("preserves oversized manual instructions without throwing or truncating", async () => {

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -95,7 +95,7 @@ describe("gateway update action", () => {
       ok: false,
       code: "owner_required",
       message:
-        "Only the OpenClaw owner can start an update from chat. Ask the operator to run `openclaw config set commands.ownerAllowFrom '[\"telegram:123456789\"]'` in a terminal to make this sender a command owner.",
+        "Only the OpenClaw owner can start an update from chat. Ask the operator to add `telegram:123456789` to `commands.ownerAllowFrom`.",
     });
     expect(callGatewayToolMock).not.toHaveBeenCalled();
     expect(dispatchMock).not.toHaveBeenCalled();

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -1,6 +1,7 @@
 /** Gateway config reads and owner-requested self-updates. */
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import { Type } from "typebox";
+import { formatCommandOwnerHint } from "../../commands/doctor-command-owner.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
 import {
   DEFAULT_UPDATE_TIMEOUT_MS,
@@ -132,16 +133,19 @@ export function createGatewayTool(options?: {
       const params = args as Record<string, unknown>;
       const action = readToolStringParam(params, "action", { required: true });
       if (action === "update.run") {
+        const caller = getGatewayToolCallerIdentity();
         if (options?.senderIsOwner !== true) {
+          const hint = formatCommandOwnerHint({
+            channel: caller?.turnSourceChannel,
+            id: options?.requesterSenderId,
+          });
           return jsonResult({
             ok: false,
             code: "owner_required",
-            message:
-              "Only the OpenClaw owner can start an update from chat. Tell the user to run `openclaw update` in a terminal or use the Control UI.",
+            message: `Only the OpenClaw owner can start an update from chat. ${hint}`,
           });
         }
         // Routing comes from the admitted caller, never model-authored destinations or credentials.
-        const caller = getGatewayToolCallerIdentity();
         const deliveryContext = caller
           ? {
               channel: caller.turnSourceChannel,

--- a/src/auto-reply/reply/command-gates.ts
+++ b/src/auto-reply/reply/command-gates.ts
@@ -1,4 +1,5 @@
 // Applies command feature gates before command handlers execute.
+import { formatCommandOwnerHint } from "../../commands/doctor-command-owner.js";
 import {
   isCommandFlagEnabled,
   isRestartEnabled,
@@ -112,10 +113,14 @@ export function rejectNonOwnerCommand(
   logVerbose(
     `Ignoring ${commandLabel} from non-owner sender: ${redactIdentifier(params.command.senderId)}`,
   );
-  if (isNativeCommandTurn(resolveCommandTurnContext(params.ctx))) {
-    return commandReply("You are not authorized to use this command.");
+  if (!params.command.isAuthorizedSender) {
+    return rejectUnauthorizedCommand(params, commandLabel);
   }
-  return { shouldContinue: false };
+  const hint = formatCommandOwnerHint({
+    channel: params.command.channel,
+    id: params.command.senderId,
+  });
+  return commandReply(`You are not authorized to use this owner-only command. ${hint}`);
 }
 
 export function requireGatewayClientScope(

--- a/src/auto-reply/reply/command-gates.ts
+++ b/src/auto-reply/reply/command-gates.ts
@@ -117,6 +117,7 @@ export function rejectNonOwnerCommand(
     return rejectUnauthorizedCommand(params, commandLabel);
   }
   const hint = formatCommandOwnerHint({
+    cfg: params.cfg,
     channel: params.command.channel,
     id: params.command.senderId,
   });

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1162,7 +1162,10 @@ describe("/acp command", () => {
 
     const result = await handleAcpCommand(params, true);
 
-    expect(result).toEqual({ shouldContinue: false });
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: expect.stringContaining("commands.ownerAllowFrom") },
+    });
   });
 
   it("keeps read-only /acp actions available to authorized non-owners", async () => {

--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -617,7 +617,7 @@ describe("handleAllowlistCommand", () => {
     const result = await handleAllowlistCommand(params, true);
 
     expect(result?.shouldContinue).toBe(false);
-    expect(result?.reply).toBeUndefined();
+    expect(result?.reply?.text).toContain("commands.ownerAllowFrom");
     expect(replaceConfigFileMock).not.toHaveBeenCalled();
     expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
   });
@@ -640,7 +640,7 @@ describe("handleAllowlistCommand", () => {
     const result = await handleAllowlistCommand(params, true);
 
     expect(result?.shouldContinue).toBe(false);
-    expect(result?.reply).toBeUndefined();
+    expect(result?.reply?.text).toContain("commands.ownerAllowFrom");
     expect(replaceConfigFileMock).not.toHaveBeenCalled();
     expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/commands-diagnostics.test.ts
+++ b/src/auto-reply/reply/commands-diagnostics.test.ts
@@ -682,7 +682,10 @@ describe("diagnostics command", () => {
       true,
     );
 
-    expect(result).toEqual({ shouldContinue: false });
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: expect.stringContaining("commands.ownerAllowFrom") },
+    });
     expect(execCalls).toHaveLength(0);
   });
 

--- a/src/auto-reply/reply/commands-gating.test.ts
+++ b/src/auto-reply/reply/commands-gating.test.ts
@@ -346,14 +346,20 @@ describe("command gating", () => {
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as OpenClawConfig);
     const configResult = await handleConfigCommand(configParams, true);
-    expect(configResult).toEqual({ shouldContinue: false });
+    expect(configResult).toEqual({
+      shouldContinue: false,
+      reply: { text: expect.stringContaining("commands.ownerAllowFrom") },
+    });
 
     const debugParams = buildParams("/debug show", {
       commands: { debug: true, text: true },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as OpenClawConfig);
     const debugResult = await handleDebugCommand(debugParams, true);
-    expect(debugResult).toEqual({ shouldContinue: false });
+    expect(debugResult).toEqual({
+      shouldContinue: false,
+      reply: { text: expect.stringContaining("commands.ownerAllowFrom") },
+    });
   });
 
   it("keeps /config show and /debug show available for owners", async () => {
@@ -604,7 +610,7 @@ describe("command gating", () => {
     const configResult = await handleConfigCommand(configParams, true);
     expect(configResult).toEqual({
       shouldContinue: false,
-      reply: { text: "You are not authorized to use this command." },
+      reply: { text: expect.stringContaining("commands.ownerAllowFrom") },
     });
 
     const debugParams = buildParams("/debug show", {
@@ -618,7 +624,7 @@ describe("command gating", () => {
     const debugResult = await handleDebugCommand(debugParams, true);
     expect(debugResult).toEqual({
       shouldContinue: false,
-      reply: { text: "You are not authorized to use this command." },
+      reply: { text: expect.stringContaining("commands.ownerAllowFrom") },
     });
   });
 

--- a/src/auto-reply/reply/commands-info.test.ts
+++ b/src/auto-reply/reply/commands-info.test.ts
@@ -152,7 +152,12 @@ describe("info command handlers", () => {
 
     const result = await handleExportSessionCommand(params, true);
 
-    expect(result).toEqual({ shouldContinue: false });
+    expect(result).toEqual({
+      shouldContinue: false,
+      ...(isAuthorizedSender
+        ? { reply: { text: expect.stringContaining("commands.ownerAllowFrom") } }
+        : {}),
+    });
     expect(buildExportSessionReplyMock).not.toHaveBeenCalled();
   });
 
@@ -190,7 +195,10 @@ describe("info command handlers", () => {
 
     const result = await handleExportTrajectoryCommand(params, true);
 
-    expect(result).toEqual({ shouldContinue: false });
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: expect.stringContaining("commands.ownerAllowFrom") },
+    });
     expect(buildExportTrajectoryCommandReplyMock).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/commands-loop.test.ts
+++ b/src/auto-reply/reply/commands-loop.test.ts
@@ -130,7 +130,10 @@ describe("loop command", () => {
     const params = buildLoopParams("/loop 5m check ci");
     params.command.senderIsOwner = false;
 
-    expect(await handleLoopCommand(params, true)).toEqual({ shouldContinue: false });
+    expect(await handleLoopCommand(params, true)).toEqual({
+      shouldContinue: false,
+      reply: { text: expect.stringContaining("operator.admin") },
+    });
     expect(rewrittenBody(params)).toBe("/loop 5m check ci");
   });
 

--- a/src/auto-reply/reply/commands-mcp.test.ts
+++ b/src/auto-reply/reply/commands-mcp.test.ts
@@ -118,7 +118,10 @@ describe("handleCommands /mcp", () => {
       setParams.command.senderIsOwner = false;
 
       const setResult = expectMcpResult(await handleMcpCommand(setParams, true));
-      expect(setResult).toEqual({ shouldContinue: false });
+      expect(setResult).toEqual({
+        shouldContinue: false,
+        reply: { text: expect.stringContaining("commands.ownerAllowFrom") },
+      });
       expect(mcpServers.has("evil")).toBe(false);
 
       const unsetParams = buildCommandTestParams("/mcp unset existing", buildCfg(), undefined, {
@@ -126,7 +129,10 @@ describe("handleCommands /mcp", () => {
       });
       unsetParams.command.senderIsOwner = false;
       const unsetResult = expectMcpResult(await handleMcpCommand(unsetParams, true));
-      expect(unsetResult).toEqual({ shouldContinue: false });
+      expect(unsetResult).toEqual({
+        shouldContinue: false,
+        reply: { text: expect.stringContaining("commands.ownerAllowFrom") },
+      });
       expect(mcpServers.has("existing")).toBe(true);
     });
   });
@@ -141,7 +147,10 @@ describe("handleCommands /mcp", () => {
       showParams.command.senderIsOwner = false;
 
       const showResult = expectMcpResult(await handleMcpCommand(showParams, true));
-      expect(showResult).toEqual({ shouldContinue: false });
+      expect(showResult).toEqual({
+        shouldContinue: false,
+        reply: { text: expect.stringContaining("commands.ownerAllowFrom") },
+      });
       const replyText = showResult.reply?.text ?? "";
       expect(replyText).not.toContain('MCP server "context7"');
       expect(replyText).not.toContain('"command": "uvx"');

--- a/src/auto-reply/reply/commands-session-restart.test.ts
+++ b/src/auto-reply/reply/commands-session-restart.test.ts
@@ -259,22 +259,31 @@ describe("handleRestartCommand", () => {
     expect(mocks.scheduleGatewaySigusr1Restart).not.toHaveBeenCalled();
   });
 
-  it("rejects authorized non-owner restart commands", async () => {
-    const result = await handleRestartCommand(
-      restartCommandParams({
-        command: {
-          ...restartCommandParams().command,
-          senderIsOwner: false,
-          isAuthorizedSender: true,
-        },
-      }),
-      true,
-    );
+  it.each(["text", "native"] as const)(
+    "gives authorized non-owner %s restart commands the owner setup hint",
+    async (source) => {
+      const result = await handleRestartCommand(
+        restartCommandParams({
+          ctx: { CommandSource: source },
+          command: {
+            ...restartCommandParams().command,
+            senderIsOwner: false,
+            isAuthorizedSender: true,
+          },
+        }),
+        true,
+      );
 
-    expect(result).toEqual({ shouldContinue: false });
-    expect(mocks.writeRestartSentinel).not.toHaveBeenCalled();
-    expect(mocks.triggerOpenClawRestart).not.toHaveBeenCalled();
-  });
+      expect(result).toEqual({
+        shouldContinue: false,
+        reply: {
+          text: "You are not authorized to use this owner-only command. Ask the operator to run `openclaw config set commands.ownerAllowFrom '[\"telegram:user-1\"]'` in a terminal to make this sender a command owner.",
+        },
+      });
+      expect(mocks.writeRestartSentinel).not.toHaveBeenCalled();
+      expect(mocks.triggerOpenClawRestart).not.toHaveBeenCalled();
+    },
+  );
 
   it("does not restart when the sentinel cannot be written", async () => {
     mocks.writeRestartSentinel.mockRejectedValueOnce(new Error("disk full"));

--- a/src/auto-reply/reply/commands-session.activation.test.ts
+++ b/src/auto-reply/reply/commands-session.activation.test.ts
@@ -78,7 +78,10 @@ describe("handleActivationCommand", () => {
 
     const result = await handleActivationCommand(params, true);
 
-    expect(result).toEqual({ shouldContinue: false });
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: expect.stringContaining("commands.ownerAllowFrom") },
+    });
     expect(params.sessionEntry?.groupActivation).toBe("mention");
     expect(params.sessionEntry?.groupActivationNeedsSystemIntro).toBeUndefined();
     expect(persistSessionEntryMock).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/commands-update.test.ts
+++ b/src/auto-reply/reply/commands-update.test.ts
@@ -75,28 +75,46 @@ describe("handleUpdateCommand", () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it.each(["unauthorized", "non-owner"])(
-    "rejects an %s sender before calling the gateway",
-    async (gate) => {
+  it.each([true, false])(
+    "silently rejects unauthorized senders (owner=%s)",
+    async (senderIsOwner) => {
       const params = updateCommandParams();
-      params.command.isAuthorizedSender = gate !== "unauthorized";
-      params.command.senderIsOwner = gate !== "non-owner";
+      params.command.isAuthorizedSender = false;
+      params.command.senderIsOwner = senderIsOwner;
 
       expect(await handleUpdateCommand(params, true)).toEqual({ shouldContinue: false });
       expect(dispatch).not.toHaveBeenCalled();
     },
   );
 
-  it("returns the native owner-gate reply", async () => {
-    const params = updateCommandParams();
-    params.ctx.CommandSource = "native";
-    params.command.senderIsOwner = false;
+  it.each(["text", "native"] as const)(
+    "returns an owner setup hint for an authorized %s sender",
+    async (source) => {
+      const params = updateCommandParams();
+      params.ctx.CommandSource = source;
+      params.command.senderIsOwner = false;
+      params.command.senderId = "123456789";
 
-    expect(await handleUpdateCommand(params, true)).toEqual({
-      shouldContinue: false,
-      reply: { text: "You are not authorized to use this command." },
+      expect(await handleUpdateCommand(params, true)).toEqual({
+        shouldContinue: false,
+        reply: {
+          text: "You are not authorized to use this owner-only command. Ask the operator to run `openclaw config set commands.ownerAllowFrom '[\"telegram:123456789\"]'` in a terminal to make this sender a command owner.",
+        },
+      });
+      expect(dispatch).not.toHaveBeenCalled();
+    },
+  );
+
+  it("relays owner recovery instructions when the gateway revokes an admitted owner", async () => {
+    const message =
+      "Ask the operator to run `openclaw config set commands.ownerAllowFrom '[\"telegram:owner\"]'` in a terminal.";
+    dispatch.mockResolvedValueOnce({
+      ok: false,
+      message,
+      result: { status: "error", reason: "owner_required" },
     });
-    expect(dispatch).not.toHaveBeenCalled();
+    const result = await handleUpdateCommand(updateCommandParams(), true);
+    expect(result?.reply?.text).toContain(message);
   });
 
   it("honors commands.restart=false without starting an update", async () => {

--- a/src/auto-reply/reply/commands-update.ts
+++ b/src/auto-reply/reply/commands-update.ts
@@ -43,7 +43,7 @@ export const handleUpdateCommand: CommandHandler = defineGatewayControlCommand(
           `⬆️ Updating OpenClaw${versions}. Back in a few minutes; I'll confirm here.`,
         );
       }
-      const message = summary.handoff?.message?.replaceAll("\n", " ");
+      const message = (summary.message ?? summary.handoff?.message)?.replaceAll("\n", " ");
       const command = summary.handoff?.command;
       const manualCommand =
         command && !message?.includes(command) ? `Run manually: ${command}` : "";

--- a/src/cli/daemon-cli/restart-health-client.test.ts
+++ b/src/cli/daemon-cli/restart-health-client.test.ts
@@ -1,0 +1,187 @@
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import type { ConnectParams } from "../../../packages/gateway-protocol/src/index.js";
+import type { GatewayAuthConfig } from "../../config/types.gateway.js";
+import { createMockGatewayService } from "../../daemon/service.test-helpers.js";
+import {
+  buildMinimalGatewayHelloOkPayload,
+  closeMinimalGatewayServer,
+  parseMinimalGatewayRequestFrame,
+  sendMinimalGatewayConnectChallenge,
+  sendMinimalGatewayResponse,
+} from "../../gateway/minimal-gateway.test-helpers.js";
+import {
+  evaluateMissingDeviceIdentity,
+  shouldClearUnboundScopesForMissingDeviceIdentity,
+} from "../../gateway/server/ws-connection/connect-policy.js";
+import {
+  shouldPreserveLocalCliSharedAuthScopes,
+  shouldSkipLocalBackendSelfPairing,
+} from "../../gateway/server/ws-connection/handshake-auth-helpers.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { waitForGatewayHealthyRestart } from "./restart-health.js";
+
+// Exercise the real client over a socket and apply the Gateway's actual identity
+// predicates, so a diagnostic client cannot accidentally stand in for local control.
+describe("restart verifier local control identity", () => {
+  it.each(["token", "password", "none"] as const)(
+    "reads health and served identity with %s auth without creating device state",
+    async (mode) => {
+      await withOpenClawTestState(
+        {
+          env: {
+            OPENCLAW_GATEWAY_TOKEN: undefined,
+            OPENCLAW_GATEWAY_PASSWORD: undefined,
+            OPENCLAW_GATEWAY_URL: "wss://remote.example.invalid",
+          },
+        },
+        async (state) => {
+          const auth: GatewayAuthConfig =
+            mode === "none" ? { mode } : { mode, [mode]: "fixture-restart-secret" };
+          const gateway = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+          await once(gateway, "listening");
+          const port = (gateway.address() as AddressInfo).port;
+          const requests: string[] = [];
+          const failures: string[] = [];
+          const connections: ConnectParams[] = [];
+          gateway.on("connection", (socket) => {
+            let scopes: string[] = [];
+            sendMinimalGatewayConnectChallenge(socket);
+            socket.on("message", (data) => {
+              const request = parseMinimalGatewayRequestFrame(data);
+              if (request.type !== "req" || !request.id || !request.method) {
+                return;
+              }
+              requests.push(request.method);
+              const reject = (message: string) => {
+                failures.push(message);
+                socket.send(
+                  JSON.stringify({
+                    type: "res",
+                    id: request.id,
+                    ok: false,
+                    error: { code: "FORBIDDEN", message },
+                  }),
+                );
+              };
+              if (request.method === "connect") {
+                const connect = request.params as ConnectParams;
+                connections.push(connect);
+                const sharedAuthOk =
+                  mode !== "none" && connect.auth?.[mode] === "fixture-restart-secret";
+                const policy = {
+                  connectParams: connect,
+                  locality: "direct_local" as const,
+                  hasBrowserOriginHeader: false,
+                  sharedAuthOk,
+                  authMethod: mode,
+                };
+                const backend = shouldSkipLocalBackendSelfPairing(policy);
+                const decision = evaluateMissingDeviceIdentity({
+                  hasDeviceIdentity: Boolean(connect.device),
+                  role: "operator",
+                  isControlUi: false,
+                  localBackendSelfPairingOk: backend,
+                  sharedAuthOk,
+                  authOk: mode === "none" || sharedAuthOk,
+                  hasSharedAuth: mode !== "none",
+                  isLocalClient: true,
+                });
+                if (decision.kind !== "allow") {
+                  reject("device identity required");
+                  socket.close(1008, "device identity required");
+                  return;
+                }
+                const clearScopes =
+                  !backend &&
+                  !shouldPreserveLocalCliSharedAuthScopes(policy) &&
+                  shouldClearUnboundScopesForMissingDeviceIdentity({ decision, authMethod: mode });
+                scopes = clearScopes ? [] : (connect.scopes ?? []);
+                const hello = buildMinimalGatewayHelloOkPayload({
+                  auth: { role: "operator", scopes },
+                });
+                sendMinimalGatewayResponse(socket, request.id, {
+                  ...hello,
+                  server: { ...hello.server, version: "2026.8.1", buildId: "fixture-build" },
+                });
+                return;
+              }
+              if (request.method !== "health" && !scopes.includes("operator.read")) {
+                reject("missing scope: operator.read");
+                return;
+              }
+              sendMinimalGatewayResponse(socket, request.id, {
+                ok: true,
+                plugins: {
+                  errors: [
+                    {
+                      id: "fixture-plugin",
+                      origin: "bundled",
+                      activated: true,
+                      error: "fixture load failure",
+                    },
+                  ],
+                },
+                channels: { fixture: { probe: { ok: false, error: "fixture channel failure" } } },
+              });
+            });
+          });
+          await state.writeConfig({
+            gateway: {
+              mode: "remote",
+              remote: {
+                url: "wss://remote.example.invalid",
+                token: "fixture-peer-token",
+                password: "fixture-peer-password",
+              },
+              auth,
+            },
+          });
+          const service = createMockGatewayService({
+            readRuntime: async () => ({ status: "running", pid: process.pid }),
+          });
+          const before = await fs.readdir(state.stateDir, { recursive: true });
+          try {
+            const result = await waitForGatewayHealthyRestart({
+              service,
+              port,
+              env: state.env,
+              probeHosts: ["127.0.0.1"],
+              expectedVersion: "2026.8.1",
+              expectedBuildId: "fixture-build",
+              attempts: 0,
+              delayMs: 1,
+            });
+            expect(result).toMatchObject({
+              healthy: false,
+              waitOutcome: "plugin-errors",
+              gatewayVersion: "2026.8.1",
+              gatewayBuildId: "fixture-build",
+              activatedPluginErrors: [{ id: "fixture-plugin", error: "fixture load failure" }],
+              channelProbeErrors: [{ id: "fixture", error: "fixture channel failure" }],
+            });
+            expect(failures).toEqual([]);
+            expect(requests).toEqual(["connect", "health"]);
+            expect(connections).toHaveLength(1);
+            expect(connections[0]?.device).toBeUndefined();
+            expect(connections[0]?.auth).toEqual(
+              mode === "none" ? undefined : { [mode]: "fixture-restart-secret" },
+            );
+            expect(connections[0]?.client).toMatchObject(
+              mode === "none"
+                ? { id: "gateway-client", mode: "backend" }
+                : { id: "cli", mode: "cli" },
+            );
+            expect(connections[0]?.scopes).toEqual(["operator.read"]);
+            expect(await fs.readdir(state.stateDir, { recursive: true })).toEqual(before);
+          } finally {
+            await closeMinimalGatewayServer(gateway);
+          }
+        },
+      );
+    },
+  );
+});

--- a/src/cli/daemon-cli/restart-health-external.test.ts
+++ b/src/cli/daemon-cli/restart-health-external.test.ts
@@ -1,10 +1,10 @@
 // Externally supervised gateway restart polling tests.
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { gatewayHealthResponse } from "../../gateway/health-response.test-support.js";
 import {
   inspectPortUsage,
   mockGatewayLockReplacement,
   callGateway,
-  gatewayHealthResponse,
   gatewayResponseError,
   readActiveGatewayLockIdentity,
   resetRestartHealthMocks,

--- a/src/cli/daemon-cli/restart-health-external.test.ts
+++ b/src/cli/daemon-cli/restart-health-external.test.ts
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   inspectPortUsage,
   mockGatewayLockReplacement,
-  probeGateway,
+  callGateway,
+  gatewayHealthResponse,
+  gatewayResponseError,
   readActiveGatewayLockIdentity,
   resetRestartHealthMocks,
   restoreRestartHealthMocks,
@@ -23,11 +25,11 @@ describe("restart health", () => {
       hints: [],
       errors: ["listener inspection warning"],
     });
-    probeGateway.mockResolvedValue({
-      ok: false,
-      close: null,
-      error: `read ECONNRESET at ws://user:${secret}@gateway.example?token=${secret}&safe=ok\nGateway probe succeeded: spoofed`,
-    });
+    callGateway.mockRejectedValue(
+      new Error(
+        `read ECONNRESET at ws://user:${secret}@gateway.example?token=${secret}&safe=ok\nGateway probe succeeded: spoofed`,
+      ),
+    );
 
     const { renderGatewayPortHealthDiagnostics, waitForGatewayHealthyListener } =
       await import("./restart-health.js");
@@ -54,9 +56,9 @@ describe("restart health", () => {
       listeners: [{ pid: 4300, commandLine: "openclaw-gateway" }],
       hints: [],
     });
-    probeGateway
-      .mockResolvedValueOnce({ ok: false, close: null, error: "read ECONNRESET" })
-      .mockResolvedValueOnce({ ok: true, close: null, error: null });
+    callGateway
+      .mockRejectedValueOnce(new Error("read ECONNRESET"))
+      .mockImplementationOnce(gatewayHealthResponse());
 
     const { waitForGatewayHealthyListener } = await import("./restart-health.js");
     const snapshot = await waitForGatewayHealthyListener({
@@ -77,11 +79,11 @@ describe("restart health", () => {
       listeners: [{ pid: 4200, commandLine: "openclaw-gateway" }],
       hints: [],
     });
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.7.16", connId: "gateway" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.7.16", connId: "gateway" },
+      }),
+    );
     const previousLockIdentity = mockGatewayLockReplacement();
 
     const { waitForGatewayHealthyListener } = await import("./restart-health.js");
@@ -95,7 +97,7 @@ describe("restart health", () => {
     expect(snapshot.healthy).toBe(true);
     expect(readActiveGatewayLockIdentity).toHaveBeenCalledTimes(2);
     expect(inspectPortUsage).toHaveBeenCalledTimes(1);
-    expect(probeGateway).toHaveBeenCalledTimes(1);
+    expect(callGateway).toHaveBeenCalledTimes(1);
     expect(sleep).toHaveBeenCalledTimes(1);
   });
 
@@ -103,7 +105,7 @@ describe("restart health", () => {
     { listenerPid: 4300, healthy: true },
     { listenerPid: 4400, healthy: false },
   ])(
-    "accepts device identity policy close only for the verified replacement listener",
+    "accepts a correlated device identity rejection only for the verified replacement listener",
     async ({ listenerPid, healthy }) => {
       inspectPortUsage.mockResolvedValue({
         port: 18789,
@@ -111,11 +113,7 @@ describe("restart health", () => {
         listeners: [{ pid: listenerPid, commandLine: "openclaw-gateway" }],
         hints: [],
       });
-      probeGateway.mockResolvedValue({
-        ok: false,
-        gatewayReached: true,
-        close: { code: 1008, reason: "device identity required" },
-      });
+      callGateway.mockRejectedValue(gatewayResponseError("device identity required"));
       const previousLockIdentity = mockGatewayLockReplacement({ pid: 4300 });
 
       const { waitForGatewayHealthyListener } = await import("./restart-health.js");
@@ -131,7 +129,7 @@ describe("restart health", () => {
         expect(snapshot.probeError).toBeUndefined();
       }
       expect(inspectPortUsage).toHaveBeenCalledTimes(1);
-      expect(probeGateway).toHaveBeenCalledTimes(1);
+      expect(callGateway).toHaveBeenCalledTimes(1);
     },
   );
 

--- a/src/cli/daemon-cli/restart-health-probe.test.ts
+++ b/src/cli/daemon-cli/restart-health-probe.test.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
+import { gatewayHealthResponse } from "../../gateway/health-response.test-support.js";
 import {
   buildMinimalGatewayHelloOkPayload,
   closeMinimalGatewayServer,
@@ -17,7 +18,6 @@ import {
   inspectPortUsage,
   makeGatewayService,
   callGateway,
-  gatewayHealthResponse,
   gatewayResponseError,
   resetRestartHealthMocks,
   restoreRestartHealthMocks,

--- a/src/cli/daemon-cli/restart-health-probe.test.ts
+++ b/src/cli/daemon-cli/restart-health-probe.test.ts
@@ -16,15 +16,17 @@ import {
   inspectGatewayRestartWithSnapshot,
   inspectPortUsage,
   makeGatewayService,
-  probeGateway,
+  callGateway,
+  gatewayHealthResponse,
+  gatewayResponseError,
   resetRestartHealthMocks,
   restoreRestartHealthMocks,
   sleep,
 } from "./restart-health.test-helpers.js";
 
 // Load the real client's dependency graph before timing its socket/probe behavior.
-const actualProbe =
-  await vi.importActual<typeof import("../../gateway/probe.js")>("../../gateway/probe.js");
+const actualCall =
+  await vi.importActual<typeof import("../../gateway/call.js")>("../../gateway/call.js");
 
 describe("restart health", () => {
   beforeEach(resetRestartHealthMocks);
@@ -76,21 +78,25 @@ describe("restart health", () => {
         tlsFingerprint: "ab".repeat(32),
       })),
     };
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      error: null,
-      server: { version: "2026.8.1", connId: "tls-ready" },
-      health: null,
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.8.1", connId: "tls-ready" },
+        health: null,
+      }),
+    );
 
     const { confirmGatewayReachable } = await import("./restart-health-probe.js");
-    await expect(confirmGatewayReachable({ port: 18_789, configuredProbe })).resolves.toMatchObject(
-      { reachable: true, gatewayVersion: "2026.8.1" },
-    );
-    expect(probeGateway).toHaveBeenCalledWith(
+    await expect(
+      confirmGatewayReachable({
+        port: 18_789,
+        configuredProbe,
+        config: { gateway: { tls: { enabled: true } } },
+      }),
+    ).resolves.toMatchObject({ reachable: true, gatewayVersion: "2026.8.1" });
+    expect(callGateway).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "wss://127.0.0.1:18789",
+        localPortOverride: 18789,
+        config: { gateway: { tls: { enabled: true } } },
         tlsFingerprint: "ab".repeat(32),
       }),
     );
@@ -131,7 +137,7 @@ describe("restart health", () => {
     }
   });
 
-  it.each(["timeout", "read ECONNRESET"])(
+  it.each(["timeout", "read ECONNRESET", "auth required"])(
     "preserves the real matching-version detail probe failure: %s",
     async (failure) => {
       const gateway = new WebSocketServer({ host: "127.0.0.1", port: 0 });
@@ -167,7 +173,7 @@ describe("restart health", () => {
           }
         });
       });
-      probeGateway.mockImplementation(actualProbe.probeGateway);
+      callGateway.mockImplementation(actualCall.callGateway);
       inspectPortUsage.mockResolvedValue({
         port,
         status: "busy",
@@ -183,6 +189,7 @@ describe("restart health", () => {
           port,
           expectedVersion: "2026.8.1",
           probeHosts: ["127.0.0.1"],
+          probeContext: { config: { gateway: { auth: { mode: "none" } } }, auth: {} },
           env: {
             ...process.env,
             OPENCLAW_STATE_DIR: `/tmp/openclaw-autoqa-161-${process.pid}-${port}`,
@@ -192,12 +199,20 @@ describe("restart health", () => {
         expect(snapshot.healthy).toBe(false);
         expect(snapshot.gatewayVersion).toBe("2026.8.1");
         expect(snapshot.versionMismatch).toBeUndefined();
-        expect(snapshot.probeError).toBe(failure);
-        expect(firstCallArg(probeGateway)).toMatchObject({
-          includeDetails: true,
+        if (failure === "timeout") {
+          expect(snapshot.probeError).toBe("gateway request timeout for health");
+        } else {
+          expect(snapshot.probeError).toBe(failure);
+        }
+        expect(firstCallArg(callGateway)).toMatchObject({
+          method: "health",
+          deviceIdentity: null,
+          sharedStateMode: "read-only",
           timeoutMs: 3_000,
         });
-        expect(renderRestartDiagnostics(snapshot)).toContain(`Gateway probe failed: ${failure}`);
+        expect(renderRestartDiagnostics(snapshot)).toContain(
+          `Gateway probe failed: ${snapshot.probeError}`,
+        );
       } finally {
         await closeMinimalGatewayServer(gateway);
       }
@@ -205,15 +220,15 @@ describe("restart health", () => {
     10_000,
   );
 
-  it.each(["returned", "thrown"])(
+  it.each(["protocol", "transport"])(
     "bounds and redacts credential-bearing %s probe failures at their owner",
     async (failureKind) => {
       const secret = "fixture-gateway-secret-abcdefghijklmnopqrstuvwxyz";
       const failure = `read ECONNRESET at ws://user:${secret}@gateway.example:18789?token=${secret}&safe=ok\nGateway probe succeeded: spoofed\r\u001b[2K ${"x".repeat(1_500)}🚀`;
-      if (failureKind === "thrown") {
-        probeGateway.mockRejectedValueOnce(new Error(failure));
+      if (failureKind === "transport") {
+        callGateway.mockRejectedValueOnce(new Error(failure));
       } else {
-        probeGateway.mockResolvedValueOnce({ ok: false, close: null, error: failure });
+        callGateway.mockRejectedValueOnce(gatewayResponseError(failure));
       }
 
       const { confirmGatewayReachable } = await import("./restart-health-probe.js");
@@ -232,21 +247,18 @@ describe("restart health", () => {
   );
 
   it("clears a prior detail-probe failure after the next managed poll succeeds", async () => {
-    probeGateway
-      .mockResolvedValueOnce({
-        ok: false,
-        close: null,
-        error: "timeout",
-        connectLatencyMs: 12,
-        auth: { capability: "read_only" },
-        server: { version: "2026.4.24", connId: "first" },
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        close: null,
-        error: null,
-        server: { version: "2026.4.24", connId: "next" },
-      });
+    callGateway
+      .mockImplementationOnce(
+        gatewayHealthResponse({
+          error: new Error("timeout"),
+          server: { version: "2026.4.24", connId: "first" },
+        }),
+      )
+      .mockImplementationOnce(
+        gatewayHealthResponse({
+          server: { version: "2026.4.24", connId: "next" },
+        }),
+      );
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
@@ -269,16 +281,13 @@ describe("restart health", () => {
     expect(sleep).toHaveBeenCalledTimes(1);
   });
 
-  it("accepts matching-version restart liveness when the probe lacks operator scope", async () => {
-    probeGateway.mockResolvedValue({
-      ok: false,
-      close: null,
-      connectLatencyMs: 12,
-      error: "missing scope: operator.read",
-      gatewayReached: true,
-      auth: { capability: "connected_no_operator_scope" },
-      server: { version: "2026.4.24", connId: "new" },
-    });
+  it("rejects matching-version restart readiness when health lacks operator scope", async () => {
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        error: gatewayResponseError("missing scope: operator.read"),
+        server: { version: "2026.4.24", connId: "new" },
+      }),
+    );
 
     const snapshot = await inspectGatewayRestartWithSnapshot({
       runtime: { status: "running", pid: 8000 },
@@ -291,19 +300,19 @@ describe("restart health", () => {
       },
     });
 
-    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.healthy).toBe(false);
     expect(snapshot.gatewayVersion).toBe("2026.4.24");
     expect(snapshot.expectedVersion).toBe("2026.4.24");
     expect(snapshot.versionMismatch).toBeUndefined();
-    expect(snapshot.probeError).toBeUndefined();
+    expect(snapshot.probeError).toBe("missing scope: operator.read");
   });
 
   it("stops waiting once the restarted gateway reports the wrong version", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.23", connId: "old" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.23", connId: "old" },
+      }),
+    );
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
@@ -327,11 +336,11 @@ describe("restart health", () => {
   });
 
   it("stops waiting once the restarted gateway reports the wrong build identity", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.24", buildId: "old-build", connId: "old" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.24", buildId: "old-build", connId: "old" },
+      }),
+    );
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
@@ -354,30 +363,30 @@ describe("restart health", () => {
   });
 
   it("marks matching-version restarts unhealthy when activated plugins failed to load", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.24", connId: "new" },
-      health: {
-        ok: true,
-        plugins: {
-          errors: [
-            {
-              id: "telegram",
-              origin: "bundled",
-              activated: true,
-              error: "failed to load plugin dependency: ENOSPC",
-            },
-            {
-              id: "optional",
-              origin: "workspace",
-              activated: false,
-              error: "disabled plugin ignored",
-            },
-          ],
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.24", connId: "new" },
+        health: {
+          ok: true,
+          plugins: {
+            errors: [
+              {
+                id: "telegram",
+                origin: "bundled",
+                activated: true,
+                error: "failed to load plugin dependency: ENOSPC",
+              },
+              {
+                id: "optional",
+                origin: "workspace",
+                activated: false,
+                error: "disabled plugin ignored",
+              },
+            ],
+          },
         },
-      },
-    });
+      }),
+    );
 
     const snapshot = await inspectGatewayRestartWithSnapshot({
       runtime: { status: "running", pid: 8000 },
@@ -402,7 +411,10 @@ describe("restart health", () => {
       },
     ]);
     expect(snapshot.versionMismatch).toBeUndefined();
-    expect((firstCallArg(probeGateway) as { includeDetails?: boolean }).includeDetails).toBe(true);
+    expect(firstCallArg(callGateway)).toMatchObject({
+      method: "health",
+      scopes: ["operator.read"],
+    });
 
     const { renderRestartDiagnostics } = await import("./restart-health.js");
     expect(renderRestartDiagnostics(snapshot).join("\n")).toContain(
@@ -411,24 +423,24 @@ describe("restart health", () => {
   });
 
   it("stops waiting once the expected-version gateway reports activated plugin errors", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.24", connId: "new" },
-      health: {
-        ok: true,
-        plugins: {
-          errors: [
-            {
-              id: "telegram",
-              origin: "bundled",
-              activated: true,
-              error: "failed to load plugin dependency: ENOSPC",
-            },
-          ],
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.24", connId: "new" },
+        health: {
+          ok: true,
+          plugins: {
+            errors: [
+              {
+                id: "telegram",
+                origin: "bundled",
+                activated: true,
+                error: "failed to load plugin dependency: ENOSPC",
+              },
+            ],
+          },
         },
-      },
-    });
+      }),
+    );
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
@@ -451,20 +463,20 @@ describe("restart health", () => {
   });
 
   it("stops waiting once the expected-version gateway reports channel probe errors", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.24", connId: "new" },
-      health: {
-        ok: true,
-        channels: {
-          telegram: {
-            configured: true,
-            probe: { ok: false, error: "This operation was aborted" },
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.24", connId: "new" },
+        health: {
+          ok: true,
+          channels: {
+            telegram: {
+              configured: true,
+              probe: { ok: false, error: "This operation was aborted" },
+            },
           },
         },
-      },
-    });
+      }),
+    );
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",

--- a/src/cli/daemon-cli/restart-health-probe.ts
+++ b/src/cli/daemon-cli/restart-health-probe.ts
@@ -1,20 +1,23 @@
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../../packages/gateway-protocol/src/client-info.js";
 import { classifyGatewayConnectFailure } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { createConfigIO } from "../../config/io.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { callGateway } from "../../gateway/call.js";
+import { isGatewayProtocolResponseError } from "../../gateway/client.js";
 import type { PluginHealthErrorSummary } from "../../gateway/health/types.js";
 import {
   createConfiguredGatewayLocalProbe,
   type ConfiguredGatewayLocalProbe,
 } from "../../gateway/local-http-probe.js";
+import { READ_SCOPE } from "../../gateway/method-scopes.js";
 import { resolveGatewayProbeAuthSafeWithSecretInputs } from "../../gateway/probe-auth.js";
-import { probeGateway } from "../../gateway/probe.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { inspectPortUsage } from "../../infra/ports-inspect.js";
 import { LOOPBACK_PORT_PROBE_HOSTS } from "../../infra/ports-probe.js";
@@ -97,14 +100,8 @@ function formatGatewayRestartProbeError(error: unknown): string {
   );
 }
 
-function looksLikeAuthClose(code: number | undefined, reason: string | undefined): boolean {
-  if (code !== 1008) {
-    return false;
-  }
+function isGatewayAuthRejection(reason: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(reason);
-  if (!normalized) {
-    return false;
-  }
   const pairingFailure = classifyGatewayConnectFailure({ reason: normalized });
   if (
     pairingFailure.kind === "pairing-required" &&
@@ -213,74 +210,72 @@ function readChannelProbeErrors(health: unknown): Array<{ id: string; error: str
 
 export async function confirmGatewayReachable(params: {
   port: number;
-  includeHealthDetails?: boolean;
   auth?: GatewayRestartProbeAuth;
   config?: OpenClawConfig;
   configuredProbe?: ConfiguredGatewayLocalProbe;
   env?: NodeJS.ProcessEnv;
   allowDeviceIdentityRequired?: boolean;
 }): Promise<GatewayReachability> {
-  const token = normalizeOptionalString(params.auth?.token ?? process.env.OPENCLAW_GATEWAY_TOKEN);
-  const password = normalizeOptionalString(
-    params.auth?.password ?? process.env.OPENCLAW_GATEWAY_PASSWORD,
-  );
+  const result: GatewayReachability = {
+    reachable: false,
+    gatewayVersion: null,
+    gatewayBuildId: undefined,
+    activatedPluginErrors: [],
+    channelProbeErrors: [],
+  };
   try {
+    const context = params.config
+      ? { config: params.config, auth: params.auth }
+      : await resolveGatewayRestartProbeContext(params.env);
+    const auth = params.auth ?? context.auth;
     const configuredProbe =
-      params.configuredProbe ?? createConfiguredGatewayLocalProbe(params.config ?? {});
+      params.configuredProbe ?? createConfiguredGatewayLocalProbe(context.config);
     const target = await configuredProbe.resolveWebSocketTarget(params.port);
     if (!target) {
-      return {
-        reachable: false,
-        gatewayVersion: null,
-        gatewayBuildId: null,
-        activatedPluginErrors: [],
-        channelProbeErrors: [],
-        probeError: "gateway TLS certificate unavailable",
-      };
+      return { ...result, gatewayBuildId: null, probeError: "gateway TLS certificate unavailable" };
     }
-    const probe = await probeGateway({
-      url: target.url,
-      auth: token || password ? { token, password } : undefined,
-      ...(target.tlsFingerprint ? { tlsFingerprint: target.tlsFingerprint } : {}),
-      ...(params.config ? { config: params.config } : {}),
+    const authNone = context.config.gateway?.auth?.mode === "none";
+    // Readiness is first-party local control. CLI shared auth preserves read scopes;
+    // auth-none uses the existing loopback backend contract without pairing a device.
+    const health = await callGateway({
+      config: context.config,
+      localPortOverride: params.port,
+      token: auth?.token,
+      password: auth?.password,
+      skipImplicitAuth: true,
+      tlsFingerprint: target.tlsFingerprint,
+      method: "health",
+      scopes: [READ_SCOPE],
+      clientName: authNone ? GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT : GATEWAY_CLIENT_NAMES.CLI,
+      mode: authNone ? GATEWAY_CLIENT_MODES.BACKEND : GATEWAY_CLIENT_MODES.CLI,
+      requireLocalBackendSharedAuth: authNone,
+      deviceIdentity: null,
+      sharedStateMode: "read-only",
       timeoutMs: 3_000,
-      includeDetails: params.includeHealthDetails === true,
-      env: params.env,
+      onHelloOk: (hello) => {
+        result.gatewayVersion = hello.server.version;
+        result.gatewayBuildId = hello.server.buildId ?? null;
+      },
     });
-    const reachedGateway =
-      probe.ok ||
-      (probe.gatewayReached === true &&
-        (looksLikeAuthClose(probe.close?.code, probe.close?.reason) ||
-          (params.allowDeviceIdentityRequired === true &&
-            probe.close?.code === 1008 &&
-            normalizeLowercaseStringOrEmpty(probe.close.reason) === "device identity required") ||
-          (probe.connectLatencyMs != null &&
-            probe.server?.version != null &&
-            probe.auth.capability === "connected_no_operator_scope")));
-    return {
-      reachable: reachedGateway,
-      gatewayVersion: probe.server?.version ?? null,
-      gatewayBuildId:
-        probe.server?.buildId ??
-        (reachedGateway || probe.server?.version != null || probe.server?.connId != null
-          ? null
-          : undefined),
-      activatedPluginErrors: readActivatedPluginErrors(probe.health),
-      channelProbeErrors: readChannelProbeErrors(probe.health),
-      ...(!reachedGateway && probe.error
-        ? { probeError: formatGatewayRestartProbeError(probe.error) }
-        : {}),
-    };
+    result.reachable = true;
+    result.activatedPluginErrors = readActivatedPluginErrors(health);
+    result.channelProbeErrors = readChannelProbeErrors(health);
   } catch (error) {
-    return {
-      reachable: false,
-      gatewayVersion: null,
-      gatewayBuildId: undefined,
-      activatedPluginErrors: [],
-      channelProbeErrors: [],
-      probeError: formatGatewayRestartProbeError(error),
-    };
+    // Only a correlated Gateway rejection proves protocol reachability. Bare socket
+    // closes (including foreign listeners) must never satisfy restart health.
+    result.reachable =
+      result.gatewayVersion === null &&
+      isGatewayProtocolResponseError(error) &&
+      (isGatewayAuthRejection(error.message) ||
+        (params.allowDeviceIdentityRequired === true &&
+          error.message === "device identity required"));
+    if (result.reachable) {
+      result.gatewayBuildId ??= null;
+    } else {
+      result.probeError = formatGatewayRestartProbeError(error);
+    }
   }
+  return result;
 }
 
 export type GatewayRestartProbeContext = {

--- a/src/cli/daemon-cli/restart-health-wait.test.ts
+++ b/src/cli/daemon-cli/restart-health-wait.test.ts
@@ -5,7 +5,8 @@ import {
   inspectPortUsage,
   makeGatewayService,
   monotonicClock,
-  probeGateway,
+  callGateway,
+  gatewayHealthResponse,
   resetRestartHealthMocks,
   restoreRestartHealthMocks,
   sleep,
@@ -84,11 +85,13 @@ describe("restart health", () => {
       vi.mocked(service.readRuntime).mockResolvedValueOnce({ status: "running", pid });
     }
     for (const ok of reachable) {
-      probeGateway.mockResolvedValueOnce({
-        ok,
-        close: null,
-        ...(ok ? { server: { version: "2026.8.1", connId: "settling" } } : {}),
-      });
+      if (ok) {
+        callGateway.mockImplementationOnce(
+          gatewayHealthResponse({ server: { version: "2026.8.1" } }),
+        );
+      } else {
+        callGateway.mockRejectedValueOnce(new Error("connect ECONNREFUSED"));
+      }
     }
     inspectPortUsage.mockResolvedValue({
       port: 18789,
@@ -112,15 +115,15 @@ describe("restart health", () => {
     expect(snapshot.healthy).toBe(outcome === "healthy");
     expect(snapshot.runtime.pid).toBe(pids.at(-1));
     expect(snapshot.elapsedMs).toBe(elapsedMs);
-    expect(probeGateway).toHaveBeenCalledTimes(reachable.length);
+    expect(callGateway).toHaveBeenCalledTimes(reachable.length);
   });
 
   it("waits for the managed service when running service proof is required", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.24", connId: "new" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.24", connId: "new" },
+      }),
+    );
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
@@ -150,11 +153,11 @@ describe("restart health", () => {
   });
 
   it("times out when running service proof never arrives", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.24", connId: "stale" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.24", connId: "stale" },
+      }),
+    );
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
@@ -395,7 +398,7 @@ describe("restart health", () => {
           }
         : { port: 18789, status: "free", listeners: [], hints: [] },
     );
-    probeGateway.mockResolvedValue({ ok: true, close: null });
+    callGateway.mockImplementation(gatewayHealthResponse({}));
 
     const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
     const snapshot = await waitForGatewayHealthyRestart({
@@ -439,11 +442,11 @@ describe("restart health", () => {
         listeners: [{ pid: 8000, commandLine: "openclaw-gateway" }],
         hints: [],
       });
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.26", connId: "new" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.26", connId: "new" },
+      }),
+    );
 
     const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
     const snapshot = await waitForGatewayHealthyRestart({
@@ -478,11 +481,11 @@ describe("restart health", () => {
         listeners: [{ pid: 8000, commandLine: "openclaw-gateway" }],
         hints: [],
       });
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.26", buildId: "new-build", connId: "new" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.26", buildId: "new-build", connId: "new" },
+      }),
+    );
 
     const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
     const snapshot = await waitForGatewayHealthyRestart({
@@ -509,13 +512,11 @@ describe("restart health", () => {
       listeners: [{ pid: 8000, commandLine: "openclaw-gateway" }],
       hints: [],
     });
-    probeGateway
-      .mockResolvedValueOnce({ ok: false, close: null, error: "connect ECONNREFUSED" })
-      .mockResolvedValueOnce({
-        ok: true,
-        close: null,
+    callGateway.mockRejectedValueOnce(new Error("connect ECONNREFUSED")).mockImplementationOnce(
+      gatewayHealthResponse({
         server: { version: "2026.4.26", buildId: "new-build", connId: "new" },
-      });
+      }),
+    );
 
     const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
     const snapshot = await waitForGatewayHealthyRestart({
@@ -566,11 +567,11 @@ describe("restart health", () => {
       listeners: [{ pid: 8000, commandLine: "openclaw-gateway" }],
       hints: [],
     });
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.26", connId: "legacy" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.26", connId: "legacy" },
+      }),
+    );
 
     const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
     const snapshot = await waitForGatewayHealthyRestart({

--- a/src/cli/daemon-cli/restart-health-wait.test.ts
+++ b/src/cli/daemon-cli/restart-health-wait.test.ts
@@ -1,12 +1,12 @@
 // Managed gateway restart polling tests.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayService } from "../../daemon/service.js";
+import { gatewayHealthResponse } from "../../gateway/health-response.test-support.js";
 import {
   inspectPortUsage,
   makeGatewayService,
   monotonicClock,
   callGateway,
-  gatewayHealthResponse,
   resetRestartHealthMocks,
   restoreRestartHealthMocks,
   sleep,

--- a/src/cli/daemon-cli/restart-health.test-helpers.ts
+++ b/src/cli/daemon-cli/restart-health.test-helpers.ts
@@ -1,5 +1,11 @@
 import { vi } from "vitest";
+import {
+  GatewayProtocolRequestError,
+  retainGatewayResponsePayload,
+} from "../../../packages/gateway-client/src/protocol-request.js";
 import type { GatewayService } from "../../daemon/service.js";
+import type { CallGatewayOptions } from "../../gateway/call.js";
+import { buildMinimalGatewayHelloOkPayload } from "../../gateway/minimal-gateway.test-helpers.js";
 import type { GatewayLockIdentity } from "../../infra/gateway-lock.js";
 import type { PortUsage } from "../../infra/ports-types.js";
 
@@ -16,7 +22,36 @@ export const sleep = vi.fn(async (ms: number) => {
 export const classifyPortListener = vi.fn<(_listener: unknown, _port: number) => PortListenerKind>(
   () => "gateway",
 );
-export const probeGateway = vi.fn();
+export const callGateway = vi.fn<(opts: CallGatewayOptions) => Promise<unknown>>();
+
+export function gatewayHealthResponse(
+  params: {
+    server?: Partial<Parameters<NonNullable<CallGatewayOptions["onHelloOk"]>>[0]["server"]>;
+    health?: unknown;
+    error?: Error;
+  } = {},
+) {
+  return async (opts: CallGatewayOptions): Promise<unknown> => {
+    const hello = buildMinimalGatewayHelloOkPayload();
+    opts.onHelloOk?.({
+      ...hello,
+      type: "hello-ok",
+      server: { ...hello.server, ...params.server },
+      auth: { role: "operator", scopes: ["operator.read"] },
+      snapshot: { presence: [], health: {}, stateVersion: { presence: 0, health: 0 }, uptimeMs: 0 },
+    });
+    if (params.error) {
+      throw params.error;
+    }
+    return params.health ?? { ok: true };
+  };
+}
+
+export function gatewayResponseError(message: string): GatewayProtocolRequestError {
+  const error = new GatewayProtocolRequestError({ code: "UNAVAILABLE", message });
+  retainGatewayResponsePayload(error, undefined);
+  return error;
+}
 export const createConfigIO = vi.fn();
 export const readBestEffortConfig = vi.fn(async () => ({}));
 export const resolveGatewayProbeAuthSafeWithSecretInputs = vi.fn<
@@ -42,8 +77,9 @@ vi.mock("../../infra/ports-probe.js", () => ({
   LOOPBACK_PORT_PROBE_HOSTS: ["127.0.0.1"],
 }));
 
-vi.mock("../../gateway/probe.js", () => ({
-  probeGateway: (opts: unknown) => probeGateway(opts),
+vi.mock("../../gateway/call.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../gateway/call.js")>()),
+  callGateway: (opts: CallGatewayOptions) => callGateway(opts),
 }));
 
 vi.mock("../../config/io.js", () => ({
@@ -162,11 +198,13 @@ export async function inspectUnknownListenerFallback(params: {
   });
 }
 
-export async function inspectAmbiguousOwnershipWithProbe(
-  probeResult: Awaited<ReturnType<typeof probeGateway>>,
-) {
+export async function inspectAmbiguousOwnershipWithProbe(error?: Error) {
   classifyPortListener.mockReturnValue("unknown");
-  probeGateway.mockResolvedValue(probeResult);
+  if (error) {
+    callGateway.mockRejectedValue(error);
+  } else {
+    callGateway.mockImplementation(gatewayHealthResponse());
+  }
   return inspectGatewayRestartWithSnapshot({
     runtime: { status: "running", pid: 8000 },
     portUsage: {
@@ -226,11 +264,8 @@ export function resetRestartHealthMocks() {
   });
   classifyPortListener.mockReset();
   classifyPortListener.mockReturnValue("gateway");
-  probeGateway.mockReset();
-  probeGateway.mockResolvedValue({
-    ok: false,
-    close: null,
-  });
+  callGateway.mockReset();
+  callGateway.mockRejectedValue(new Error("connect ECONNREFUSED"));
   hasActiveStartupMigrationLease.mockReset();
   hasActiveStartupMigrationLease.mockReturnValue(false);
   readActiveGatewayLockIdentity.mockReset();

--- a/src/cli/daemon-cli/restart-health.test-helpers.ts
+++ b/src/cli/daemon-cli/restart-health.test-helpers.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../packages/gateway-client/src/protocol-request.js";
 import type { GatewayService } from "../../daemon/service.js";
 import type { CallGatewayOptions } from "../../gateway/call.js";
-import { buildMinimalGatewayHelloOkPayload } from "../../gateway/minimal-gateway.test-helpers.js";
+import { gatewayHealthResponse } from "../../gateway/health-response.test-support.js";
 import type { GatewayLockIdentity } from "../../infra/gateway-lock.js";
 import type { PortUsage } from "../../infra/ports-types.js";
 
@@ -23,29 +23,6 @@ export const classifyPortListener = vi.fn<(_listener: unknown, _port: number) =>
   () => "gateway",
 );
 export const callGateway = vi.fn<(opts: CallGatewayOptions) => Promise<unknown>>();
-
-export function gatewayHealthResponse(
-  params: {
-    server?: Partial<Parameters<NonNullable<CallGatewayOptions["onHelloOk"]>>[0]["server"]>;
-    health?: unknown;
-    error?: Error;
-  } = {},
-) {
-  return async (opts: CallGatewayOptions): Promise<unknown> => {
-    const hello = buildMinimalGatewayHelloOkPayload();
-    opts.onHelloOk?.({
-      ...hello,
-      type: "hello-ok",
-      server: { ...hello.server, ...params.server },
-      auth: { role: "operator", scopes: ["operator.read"] },
-      snapshot: { presence: [], health: {}, stateVersion: { presence: 0, health: 0 }, uptimeMs: 0 },
-    });
-    if (params.error) {
-      throw params.error;
-    }
-    return params.health ?? { ok: true };
-  };
-}
 
 export function gatewayResponseError(message: string): GatewayProtocolRequestError {
   const error = new GatewayProtocolRequestError({ code: "UNAVAILABLE", message });

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -1,6 +1,7 @@
 // Managed gateway restart inspection tests.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayService } from "../../daemon/service.js";
+import { gatewayHealthResponse } from "../../gateway/health-response.test-support.js";
 import {
   classifyPortListener,
   createConfigIO,
@@ -11,7 +12,6 @@ import {
   inspectUnknownListenerFallback,
   makeGatewayService,
   callGateway,
-  gatewayHealthResponse,
   gatewayResponseError,
   readBestEffortConfig,
   resetRestartHealthMocks,

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -10,7 +10,9 @@ import {
   inspectPortUsage,
   inspectUnknownListenerFallback,
   makeGatewayService,
-  probeGateway,
+  callGateway,
+  gatewayHealthResponse,
+  gatewayResponseError,
   readBestEffortConfig,
   resetRestartHealthMocks,
   resolveGatewayServiceProbeHosts,
@@ -119,22 +121,16 @@ describe("restart health", () => {
   });
 
   it("uses a local gateway probe when ownership is ambiguous", async () => {
-    const snapshot = await inspectAmbiguousOwnershipWithProbe({
-      ok: true,
-      close: null,
-    });
+    const snapshot = await inspectAmbiguousOwnershipWithProbe();
 
     expect(snapshot.healthy).toBe(true);
-    expect((firstCallArg(probeGateway) as { url?: string }).url).toBe("ws://127.0.0.1:18789");
+    expect(firstCallArg(callGateway)).toMatchObject({ localPortOverride: 18789, method: "health" });
   });
 
   it("treats a busy port as healthy when runtime status lags but the probe succeeds", async () => {
     Object.defineProperty(process, "platform", { value: "win32", configurable: true });
     classifyPortListener.mockReturnValue("gateway");
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-    });
+    callGateway.mockImplementation(gatewayHealthResponse({}));
 
     const snapshot = await inspectGatewayRestartWithSnapshot({
       runtime: { status: "stopped" },
@@ -163,12 +159,7 @@ describe("restart health", () => {
   ])(
     "treats a correlated Gateway rejection with reason %s as healthy gateway reachability",
     async (reason) => {
-      const snapshot = await inspectAmbiguousOwnershipWithProbe({
-        ok: false,
-        gatewayReached: true,
-        error: reason,
-        close: { code: 1008, reason },
-      });
+      const snapshot = await inspectAmbiguousOwnershipWithProbe(gatewayResponseError(reason));
 
       expect(snapshot.healthy).toBe(true);
       expect(snapshot.probeError).toBeUndefined();
@@ -191,21 +182,20 @@ describe("restart health", () => {
   ])(
     "does not treat ambiguous 1008 close reason %s as healthy gateway reachability",
     async (reason) => {
-      const snapshot = await inspectAmbiguousOwnershipWithProbe({
-        ok: false,
-        close: { code: 1008, reason },
-      });
+      const snapshot = await inspectAmbiguousOwnershipWithProbe(
+        new Error(`gateway closed (1008): ${reason}`),
+      );
 
       expect(snapshot.healthy).toBe(false);
     },
   );
 
   it("requires the expected gateway version when provided", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.23", connId: "old" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.23", connId: "old" },
+      }),
+    );
 
     const snapshot = await inspectGatewayRestartWithSnapshot({
       runtime: { status: "running", pid: 8000 },
@@ -226,11 +216,11 @@ describe("restart health", () => {
   });
 
   it("accepts the restarted gateway when the expected version matches", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.24", connId: "new" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.24", connId: "new" },
+      }),
+    );
 
     const snapshot = await inspectGatewayRestartWithSnapshot({
       runtime: { status: "running", pid: 8000 },
@@ -250,11 +240,11 @@ describe("restart health", () => {
   });
 
   it("requires the expected gateway build identity when provided", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.24", buildId: "old-build", connId: "old" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.24", buildId: "old-build", connId: "old" },
+      }),
+    );
 
     const snapshot = await inspectGatewayRestartWithSnapshot({
       runtime: { status: "running", pid: 8000 },
@@ -279,11 +269,11 @@ describe("restart health", () => {
   });
 
   it("accepts the restarted gateway when the expected build identity matches", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.24", buildId: "new-build", connId: "new" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.24", buildId: "new-build", connId: "new" },
+      }),
+    );
 
     const snapshot = await inspectGatewayRestartWithSnapshot({
       runtime: { status: "running", pid: 8000 },
@@ -303,16 +293,16 @@ describe("restart health", () => {
   });
 
   it("requires Gateway runtime build identity for a configured Control UI root", async () => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: {
-        version: "2026.4.24",
-        buildId: "old-build",
-        controlUiBuildSource: "configured",
-        connId: "new",
-      },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: {
+          version: "2026.4.24",
+          buildId: "old-build",
+          controlUiBuildSource: "configured",
+          connId: "new",
+        },
+      }),
+    );
 
     const snapshot = await inspectGatewayRestartWithSnapshot({
       runtime: { status: "running", pid: 8000 },
@@ -338,11 +328,11 @@ describe("restart health", () => {
     resolveGatewayProbeAuthSafeWithSecretInputs.mockResolvedValue({
       auth: { token: "probe-token" },
     });
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version: "2026.4.24", connId: "new" },
-    });
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.24", connId: "new" },
+      }),
+    );
     const service = makeGatewayService({ status: "running", pid: 8000 });
     const serviceEnv = {
       ...process.env,
@@ -382,13 +372,16 @@ describe("restart health", () => {
         suppressFutureVersionWarning: true,
       }),
     );
-    const probeInput = firstCallArg(probeGateway) as {
-      auth?: { token?: string; password?: string };
-      env?: NodeJS.ProcessEnv;
+    const probeInput = firstCallArg(callGateway) as {
+      token?: string;
+      password?: string;
+      config?: unknown;
     };
-    expect(probeInput.auth?.token).toBe("probe-token");
-    expect(probeInput.auth?.password).toBeUndefined();
-    expect(probeInput.env).toBe(serviceEnv);
+    expect(probeInput.token).toBe("probe-token");
+    expect(probeInput.password).toBeUndefined();
+    expect(probeInput.config).toEqual({
+      gateway: { auth: { mode: "token", token: "probe-token" } },
+    });
   });
 
   it("treats busy ports with unavailable listener details as healthy when runtime is running", async () => {
@@ -410,7 +403,7 @@ describe("restart health", () => {
     const snapshot = await inspectGatewayRestart({ service, port: 18789 });
 
     expect(snapshot.healthy).toBe(true);
-    expect(probeGateway).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
     expect(resolveGatewayServiceProbeHosts).toHaveBeenCalledWith({
       env: process.env,
       command: null,

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -20,7 +20,7 @@ import {
   confirmGatewayReachable,
   resolveGatewayRestartProbeContext,
   type GatewayReachability,
-  type GatewayRestartProbeAuth,
+  type GatewayRestartProbeContext,
 } from "./restart-health-probe.js";
 import {
   DEFAULT_RESTART_HEALTH_ATTEMPTS,
@@ -129,7 +129,7 @@ export async function inspectGatewayRestart(params: {
   expectedVersion?: string | null;
   expectedBuildId?: string | null;
   includeUnknownListenersAsStale?: boolean;
-  probeAuth?: GatewayRestartProbeAuth;
+  probeContext?: GatewayRestartProbeContext;
   configuredProbe?: ConfiguredGatewayLocalProbe;
   probeHosts?: readonly string[];
 }): Promise<GatewayRestartSnapshot> {
@@ -151,8 +151,7 @@ export async function inspectGatewayRestart(params: {
     if (!reachability) {
       reachability = await confirmGatewayReachable({
         port: params.port,
-        includeHealthDetails: requiresGatewayProbe,
-        auth: params.probeAuth,
+        ...params.probeContext,
         ...(params.configuredProbe ? { configuredProbe: params.configuredProbe } : {}),
         env,
       });
@@ -365,7 +364,7 @@ export async function waitForGatewayHealthyRestart(params: {
     expectedVersion: params.expectedVersion,
     expectedBuildId: params.expectedBuildId,
     includeUnknownListenersAsStale: params.includeUnknownListenersAsStale,
-    probeAuth: probeContext.auth,
+    probeContext,
     configuredProbe,
     probeHosts,
   });
@@ -478,7 +477,7 @@ export async function waitForGatewayHealthyRestart(params: {
       expectedVersion: params.expectedVersion,
       expectedBuildId: params.expectedBuildId,
       includeUnknownListenersAsStale: params.includeUnknownListenersAsStale,
-      probeAuth: probeContext.auth,
+      probeContext,
       configuredProbe,
       probeHosts,
     });

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -21,6 +21,8 @@ import {
   GATEWAY_SERVICE_SELECTOR_ENV_KEYS,
 } from "../daemon/constants.js";
 import { mockSystemAccountHome } from "../daemon/service.test-helpers.js";
+import type { CallGatewayOptions } from "../gateway/call.js";
+import { gatewayHealthResponse } from "../gateway/health-response.test-support.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "../infra/supervisor-markers.js";
 import { isBetaTag } from "../infra/update-channels.js";
@@ -74,9 +76,10 @@ const serviceReadRuntime = vi.fn();
 const mockGetSelfAndAncestorPidsSync = vi.fn(() => new Set<number>([process.pid]));
 const terminateStaleGatewayPids = vi.fn();
 const inspectPortUsage = vi.fn();
+const probePortUsage = vi.fn();
 const classifyPortListener = vi.fn();
 const formatPortDiagnostics = vi.fn();
-const probeGateway = vi.fn();
+const callGateway = vi.fn<(opts: CallGatewayOptions) => Promise<unknown>>();
 const pathExists = vi.fn();
 const syncPluginsForUpdateChannel = vi.fn();
 const updateNpmInstalledPlugins = vi.fn();
@@ -483,13 +486,19 @@ vi.mock("../infra/ports-inspect.js", () => ({
   inspectPortUsage: (...args: unknown[]) => inspectPortUsage(...args),
 }));
 
+vi.mock("../infra/ports-probe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/ports-probe.js")>()),
+  probePortUsage: (...args: unknown[]) => probePortUsage(...args),
+}));
+
 vi.mock("../infra/ports-format.js", () => ({
   classifyPortListener: (...args: unknown[]) => classifyPortListener(...args),
   formatPortDiagnostics: (...args: unknown[]) => formatPortDiagnostics(...args),
 }));
 
-vi.mock("../gateway/probe.js", () => ({
-  probeGateway: (...args: unknown[]) => probeGateway(...args),
+vi.mock("../gateway/call.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../gateway/call.js")>()),
+  callGateway: (opts: CallGatewayOptions) => callGateway(opts),
 }));
 
 vi.mock("./update-cli/restart-helper.js", () => ({
@@ -894,7 +903,7 @@ describe("update-cli", () => {
     }
   };
 
-  const probeGatewayCall = (index = 0) => probeGateway.mock.calls[index]?.[0];
+  const gatewayHealthCall = (index = 0) => callGateway.mock.calls[index]?.[0];
 
   const pluginWarning = (result?: UpdateRunResult) => result?.postUpdate?.plugins?.warnings?.[0];
   const pluginOutcome = (result?: UpdateRunResult) => result?.postUpdate?.plugins?.npm.outcomes[0];
@@ -1477,7 +1486,7 @@ describe("update-cli", () => {
         pid: gatewayFixturePid,
         state: "running",
       });
-      mockGatewayProbe(manifest.version, "updated-gateway");
+      mockGatewayHealth(manifest.version, "updated-gateway");
     };
   };
 
@@ -1563,20 +1572,8 @@ describe("update-cli", () => {
     expect(logs).not.toContain("Update Result: OK");
   };
 
-  const mockGatewayProbe = (version: string, connId: string, buildId?: string) => {
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: { version, connId, buildId },
-      auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
-      health: null,
-      status: null,
-      presence: null,
-      configSnapshot: null,
-      connectLatencyMs: 1,
-      error: null,
-      url: "ws://127.0.0.1:18789",
-    });
+  const mockGatewayHealth = (version: string, connId: string, buildId?: string) => {
+    callGateway.mockImplementation(gatewayHealthResponse({ server: { version, connId, buildId } }));
   };
 
   const completeChangedPostCorePluginUpdate = (
@@ -1666,7 +1663,7 @@ describe("update-cli", () => {
         pid: gatewayFixturePid,
         state: "running",
       });
-      mockGatewayProbe("2026.4.27", "updated-work");
+      mockGatewayHealth("2026.4.27", "updated-work");
     });
     return updatedEntrypoint;
   };
@@ -1768,6 +1765,7 @@ describe("update-cli", () => {
     }
     restartHealthTestControl.snapshot = undefined;
     vi.resetAllMocks();
+    probePortUsage.mockResolvedValue("free");
     serviceEnabled.mockResolvedValue(true);
     serviceDefinitionMutationCapability.mockResolvedValue(undefined);
     readPersistedInstalledPluginIndex.mockResolvedValue(null);
@@ -1888,7 +1886,7 @@ describe("update-cli", () => {
     });
     classifyPortListener.mockReturnValue("gateway");
     formatPortDiagnostics.mockReturnValue(["Port 18789 is already in use."]);
-    mockGatewayProbe("1.0.0", "conn-test");
+    mockGatewayHealth("1.0.0", "conn-test");
     pathExists.mockResolvedValue(false);
     syncPluginsForUpdateChannel.mockResolvedValue(pluginSyncResult(baseConfig));
     updateNpmInstalledPlugins.mockResolvedValue(npmPluginUpdateResult(baseConfig));
@@ -2129,7 +2127,7 @@ describe("update-cli", () => {
           : path.join(root, "dist", "index.js");
       if (kind === "package") {
         mockPackageInstallStatus(root);
-        mockGatewayProbe("9999.0.0", "updated-service");
+        mockGatewayHealth("9999.0.0", "updated-service");
       } else {
         mockGitUpdateAfterMutation(makeOkUpdateResult({ mode: "git", root }));
       }
@@ -3260,7 +3258,7 @@ describe("update-cli", () => {
         expect(syncPluginsForUpdateChannel).toHaveBeenCalledOnce();
         expect(updateNpmInstalledPlugins).toHaveBeenCalledOnce();
       }
-      expectNoSideEffects(runDaemonInstall, probeGateway);
+      expectNoSideEffects(runDaemonInstall, callGateway);
       expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
     },
   );
@@ -4984,7 +4982,7 @@ describe("update-cli", () => {
     vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
     vi.mocked(runCommandWithTimeout).mockResolvedValue(commandResult({ stdout: sha }));
     mockOwnedGitService(root);
-    mockGatewayProbe("1.0.0", "restored", "fixture-original-build");
+    mockGatewayHealth("1.0.0", "restored", "fixture-original-build");
     const entrypoint = path.join(root, "dist", "index.js");
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValue(entrypoint);
 
@@ -7616,7 +7614,7 @@ describe("update-cli", () => {
     mockFileBackedPathExists();
     mockNpmGlobalCommands(nodeModules, undefined, canonicalGitRoot);
     mockRunningManagedGateway(["node", packageEntrypoint, "gateway", "run"]);
-    mockGatewayProbe("2026.4.21", "updated-checkout");
+    mockGatewayHealth("2026.4.21", "updated-checkout");
     serviceReadCommand.mockImplementation(async () => ({
       programArguments: [
         "node",
@@ -9330,7 +9328,7 @@ describe("update-cli", () => {
           });
         });
       }
-      mockGatewayProbe("2026.4.24", "updated-gateway");
+      mockGatewayHealth("2026.4.24", "updated-gateway");
 
       await updateCommand({ yes: true, json });
 
@@ -9374,7 +9372,7 @@ describe("update-cli", () => {
     serviceLoaded.mockResolvedValue(true);
     primeServiceCommand(["node", updatedEntrypoint, "gateway", "run"]);
     mockGatewayInstallFailure(updatedEntrypoint);
-    mockGatewayProbe("2026.4.24", "matching-old-gateway");
+    mockGatewayHealth("2026.4.24", "matching-old-gateway");
 
     await updateCommand({ yes: true });
 
@@ -9407,7 +9405,7 @@ describe("update-cli", () => {
     serviceLoaded.mockResolvedValue(true);
     primeServiceCommand(["node", oldEntrypoint, "gateway", "run"]);
     mockGatewayInstallFailure(updatedEntrypoint);
-    mockGatewayProbe("2026.4.24", "matching-old-service");
+    mockGatewayHealth("2026.4.24", "matching-old-service");
 
     await updateCommand({ yes: true });
 
@@ -9428,7 +9426,7 @@ describe("update-cli", () => {
     const { updatedRoot, updatedEntrypoint } = setupNpmUpdatedRootRefresh();
     prepareRestartScript.mockResolvedValue(null);
     serviceLoaded.mockResolvedValue(true);
-    mockGatewayProbe("2026.4.23", "old-gateway");
+    mockGatewayHealth("2026.4.23", "old-gateway");
 
     await expect(updateCommand({ yes: true, json: true, timeout: "123" })).rejects.toEqual(
       new ExitError(1),
@@ -9440,8 +9438,7 @@ describe("update-cli", () => {
     expect(restartCall?.[0].slice(1)).toEqual([updatedEntrypoint, "gateway", "restart", "--json"]);
     expect(restartCall?.[1].cwd).toBe(updatedRoot);
     expect(restartCall?.[1].timeoutMs).toBe(123_000);
-    const probeCall = probeGatewayCall() as { includeDetails?: boolean } | undefined;
-    expect(probeCall?.includeDetails).toBe(true);
+    expect(gatewayHealthCall()).toMatchObject({ method: "health", scopes: ["operator.read"] });
     expect(defaultRuntime.exit).not.toHaveBeenCalled();
     expect(lastWriteJsonCall()).toMatchObject({ status: "error", reason: "restart-unhealthy" });
     expect(getErrorOutput()).toContain(
@@ -9485,7 +9482,7 @@ describe("update-cli", () => {
   it("skips the post-refresh restart script when LaunchAgent already serves the expected package version", async () => {
     const { updatedRoot, updatedEntrypoint } = setupNpmUpdatedRootRefresh();
     serviceLoaded.mockResolvedValue(true);
-    mockGatewayProbe("2026.4.24", "updated-gateway");
+    mockGatewayHealth("2026.4.24", "updated-gateway");
 
     await updateCommand({ yes: true });
 
@@ -9496,8 +9493,7 @@ describe("update-cli", () => {
     expect(installCall?.[1].timeoutMs).toBe(60_000);
     expect(gatewayCommandCall(updatedEntrypoint, "restart")).toBeUndefined();
     expect(runRestartScript).not.toHaveBeenCalled();
-    const probeCall = probeGatewayCall() as { includeDetails?: boolean } | undefined;
-    expect(probeCall?.includeDetails).toBe(true);
+    expect(gatewayHealthCall()).toMatchObject({ method: "health", scopes: ["operator.read"] });
     expect(getLogOutput()).toContain("Gateway: restarted and verified.");
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
   });
@@ -9514,7 +9510,7 @@ describe("update-cli", () => {
       beforeUpdate: () => {
         setupNpmUpdatedRootRefresh();
         serviceLoaded.mockResolvedValue(true);
-        mockGatewayProbe("2026.4.24", "updated-gateway");
+        mockGatewayHealth("2026.4.24", "updated-gateway");
       },
     });
     expect(sentinel?.payload.status).toBe("ok");
@@ -9604,12 +9600,12 @@ describe("update-cli", () => {
           setupNpmUpdatedRootRefresh();
           prepareRestartScript.mockResolvedValue(null);
           serviceLoaded.mockResolvedValue(true);
-          mockGatewayProbe("2026.4.23", "old-gateway");
+          mockGatewayHealth("2026.4.23", "old-gateway");
           if (consumed) {
-            const probeResult = await probeGateway();
-            probeGateway.mockImplementation(async () => {
+            const respond = expectDefined(callGateway.getMockImplementation(), "health response");
+            callGateway.mockImplementation(async (opts) => {
               sentinelConsumed = (await clearRestartSentinel()) || sentinelConsumed;
-              return probeResult;
+              return respond(opts);
             });
           }
         },
@@ -9631,40 +9627,29 @@ describe("update-cli", () => {
     setupNpmUpdatedRootRefresh();
     readPackageVersion.mockResolvedValue("2026.4.24");
     serviceLoaded.mockResolvedValue(true);
-    probeGateway.mockResolvedValue({
-      ok: true,
-      close: null,
-      server: {
-        version: "2026.4.24",
-        connId: "updated-gateway",
-      },
-      auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
-      health: {
-        ok: true,
-        plugins: {
-          errors: [
-            {
-              id: "telegram",
-              origin: "bundled",
-              activated: true,
-              error: "failed to load plugin dependency: ENOSPC",
-            },
-          ],
+    callGateway.mockImplementation(
+      gatewayHealthResponse({
+        server: { version: "2026.4.24", connId: "updated-gateway" },
+        health: {
+          ok: true,
+          plugins: {
+            errors: [
+              {
+                id: "telegram",
+                origin: "bundled",
+                activated: true,
+                error: "failed to load plugin dependency: ENOSPC",
+              },
+            ],
+          },
         },
-      },
-      status: null,
-      presence: null,
-      configSnapshot: null,
-      connectLatencyMs: 1,
-      error: null,
-      url: "ws://127.0.0.1:18789",
-    });
+      }),
+    );
 
     await expect(updateCommand({ yes: true })).rejects.toEqual(new ExitError(1));
 
     expect(runRestartScript).toHaveBeenCalledTimes(1);
-    const probeCall = probeGatewayCall() as { includeDetails?: boolean } | undefined;
-    expect(probeCall?.includeDetails).toBe(true);
+    expect(gatewayHealthCall()).toMatchObject({ method: "health", scopes: ["operator.read"] });
     expect(defaultRuntime.exit).not.toHaveBeenCalled();
     expect(getLogOutput()).toContain("- telegram: failed to load plugin dependency: ENOSPC");
   });

--- a/src/cli/update-cli/update-command-service.integration.test.ts
+++ b/src/cli/update-cli/update-command-service.integration.test.ts
@@ -12,6 +12,7 @@ import {
   resolveLaunchAgentEnvWrapperPath,
 } from "../../daemon/launchd-service-files.js";
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
+import { gatewayHealthResponse } from "../../gateway/health-response.test-support.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
 import * as runtimeUtils from "../../utils.js";
@@ -44,7 +45,7 @@ const mocks = vi.hoisted(() => ({
   loaded: true,
   listenerPids: vi.fn(() => [4242]),
   ports: vi.fn<typeof import("../../infra/ports-inspect.js").inspectPortUsage>(),
-  probe: vi.fn<typeof import("../../gateway/probe.js").probeGateway>(),
+  call: vi.fn<(opts: import("../../gateway/call.js").CallGatewayOptions) => Promise<unknown>>(),
   signal: vi.fn(),
   events: [] as string[],
   command: vi.fn<typeof import("../../daemon/systemd.js").readSystemdServiceExecStart>(),
@@ -102,7 +103,10 @@ vi.mock("../../infra/ports-inspect.js", () => ({
   inspectPortUsage: mocks.ports,
 }));
 
-vi.mock("../../gateway/probe.js", () => ({ probeGateway: mocks.probe }));
+vi.mock("../../gateway/call.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../gateway/call.js")>()),
+  callGateway: mocks.call,
+}));
 
 vi.mock("../../daemon/systemd.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../daemon/systemd.js")>()),
@@ -202,7 +206,7 @@ beforeEach(async () => {
     listeners: [],
     hints: [],
   }));
-  mocks.probe.mockReset();
+  mocks.call.mockReset();
   mocks.running = true;
   mocks.loaded = true;
   mocks.inLaunchd = false;
@@ -363,25 +367,17 @@ describe("preserved update activation with real version guards", () => {
         listeners: [{ pid: 4242, command: "openclaw-gateway" }],
         hints: [],
       }));
-      mocks.probe.mockImplementation(async ({ url }) => ({
-        ok: true,
-        url,
-        connectLatencyMs: 1,
-        error: null,
-        close: null,
-        auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
-        server: {
-          version: VERSION,
-          connId: "fixture",
-          ...(outcome === "missing build"
-            ? {}
-            : { buildId: outcome === "stale build" ? "old-build" : "new-build" }),
-        },
-        health: {},
-        status: {},
-        presence: [],
-        configSnapshot: null,
-      }));
+      mocks.call.mockImplementation(
+        gatewayHealthResponse({
+          server: {
+            version: VERSION,
+            connId: "fixture",
+            ...(outcome === "missing build"
+              ? {}
+              : { buildId: outcome === "stale build" ? "old-build" : "new-build" }),
+          },
+        }),
+      );
       const { waitForGatewayHealthyRestart } = await vi.importActual<
         typeof import("../daemon-cli/restart-health.js")
       >("../daemon-cli/restart-health.js");
@@ -453,9 +449,12 @@ describe("preserved update activation with real version guards", () => {
             ([args]) => args.expectedBuildId === (channel === "dev" ? "new-build" : undefined),
           ),
         ).toBe(true);
-        expect(mocks.probe.mock.calls.every(([args]) => args.url === "ws://127.0.0.1:19305")).toBe(
-          true,
-        );
+        expect(mocks.call).toHaveBeenCalled();
+        expect(
+          mocks.call.mock.calls.every(
+            ([args]) => args.localPortOverride === 19305 && args.method === "health",
+          ),
+        ).toBe(true);
       }
       if (buildMismatch) {
         expect(

--- a/src/commands/doctor-command-owner.test.ts
+++ b/src/commands/doctor-command-owner.test.ts
@@ -1,7 +1,9 @@
 // Doctor command-owner tests cover channel sender formatting and configured owner detection.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   formatCommandOwnerFromChannelSender,
+  formatCommandOwnerHint,
   hasConfiguredCommandOwners,
   noteCommandOwnerHealth,
 } from "./doctor-command-owner.js";
@@ -13,6 +15,7 @@ vi.mock("../../packages/terminal-core/src/note.js", () => ({
 }));
 
 describe("command owner health", () => {
+  afterEach(() => vi.unstubAllEnvs());
   beforeEach(() => {
     note.mockClear();
   });
@@ -45,13 +48,40 @@ describe("command owner health", () => {
       [
         "No command owner is configured.",
         "A command owner is the human operator account allowed to run owner-only commands and approve dangerous actions, including /diagnostics, /export-session, /export-trajectory, /config, and exec approvals.",
-        "DM pairing only lets someone talk to the bot; it does not make that sender the owner for privileged commands.",
+        "CLI pairing approval records the first command owner. Control UI approval has an owner checkbox; otherwise set commands.ownerAllowFrom.",
         "Fix: set commands.ownerAllowFrom to your channel user id, for example openclaw config set commands.ownerAllowFrom '[\"telegram:123456789\"]'",
         "Restart the gateway after changing this if it is already running.",
       ].join("\n"),
       "Command owner",
     );
   });
+
+  it.skipIf(process.platform === "win32")(
+    "quotes a sender id without overriding the selected profile",
+    () => {
+      vi.stubEnv("OPENCLAW_PROFILE", "owner-proof");
+      const id = "@o'brien$(printf injected) --profile decoy:example.org";
+      const hint = formatCommandOwnerHint({ channel: "matrix", id });
+      const command = hint.slice(hint.indexOf("`") + 1, hint.lastIndexOf("`"));
+      const args = execFileSync(
+        "/bin/sh",
+        ["-c", command.replace(/^openclaw /, "printf '%s\\n' ")],
+        {
+          encoding: "utf8",
+        },
+      )
+        .trim()
+        .split("\n");
+      expect(args).toEqual([
+        "--profile",
+        "owner-proof",
+        "config",
+        "set",
+        "commands.ownerAllowFrom",
+        JSON.stringify([`matrix:${id}`]),
+      ]);
+    },
+  );
 
   it("does not warn when command owners are configured", () => {
     noteCommandOwnerHealth({ commands: { ownerAllowFrom: ["telegram:123"] } });

--- a/src/commands/doctor-command-owner.test.ts
+++ b/src/commands/doctor-command-owner.test.ts
@@ -61,7 +61,7 @@ describe("command owner health", () => {
     () => {
       vi.stubEnv("OPENCLAW_PROFILE", "owner-proof");
       const id = "@o'brien$(printf injected) --profile decoy:example.org";
-      const hint = formatCommandOwnerHint({ channel: "matrix", id });
+      const hint = formatCommandOwnerHint({ cfg: {}, channel: "matrix", id });
       const command = hint.slice(hint.indexOf("`") + 1, hint.lastIndexOf("`"));
       const args = execFileSync(
         "/bin/sh",
@@ -82,6 +82,42 @@ describe("command owner health", () => {
       ]);
     },
   );
+
+  it.each([
+    { name: "no owners", owners: [], expected: ["telegram:123"] },
+    {
+      name: "existing owners and duplicates",
+      owners: ["slack:owner", "telegram:123", "slack:owner", "*", "telegram:*"],
+      expected: ["slack:owner", "telegram:123"],
+    },
+    {
+      name: "a new owner alongside existing owners",
+      owners: ["slack:owner"],
+      expected: ["slack:owner", "telegram:123"],
+    },
+  ])("preserves command owners in the hint with $name", ({ owners, expected }) => {
+    expect(
+      formatCommandOwnerHint({
+        cfg: { commands: { ownerAllowFrom: owners } },
+        channel: "telegram",
+        id: "123",
+      }),
+    ).toBe(
+      `Ask the operator to run \`openclaw config set commands.ownerAllowFrom '${JSON.stringify(expected)}'\` in a terminal to make this sender a command owner.`,
+    );
+  });
+
+  it("asks the operator to add the sender when config is unavailable", () => {
+    expect(formatCommandOwnerHint({ channel: "telegram", id: "123" })).toBe(
+      "Ask the operator to add `telegram:123` to `commands.ownerAllowFrom`.",
+    );
+  });
+
+  it("keeps internal Gateway ownership guidance", () => {
+    expect(formatCommandOwnerHint({ cfg: {}, channel: "webchat", id: "123" })).toBe(
+      "Ask the operator to grant this Gateway client operator.admin access.",
+    );
+  });
 
   it("does not warn when command owners are configured", () => {
     noteCommandOwnerHealth({ commands: { ownerAllowFrom: ["telegram:123"] } });

--- a/src/commands/doctor-command-owner.ts
+++ b/src/commands/doctor-command-owner.ts
@@ -5,6 +5,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PairingChannel } from "../pairing/pairing-store.types.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 
 function resolveConfiguredCommandOwners(cfg: OpenClawConfig): string[] {
   const owners = cfg.commands?.ownerAllowFrom;
@@ -40,6 +41,29 @@ export function formatCommandOwnerFromChannelSender(params: {
   return `${params.channel}:${id}`;
 }
 
+/** Gives admitted senders an operator-run command without granting owner authority. */
+export function formatCommandOwnerHint(params: {
+  channel?: string | null;
+  id?: string | null;
+}): string {
+  if (params.channel === INTERNAL_MESSAGE_CHANNEL) {
+    return "Ask the operator to grant this Gateway client operator.admin access.";
+  }
+  const owner =
+    params.channel && params.id
+      ? formatCommandOwnerFromChannelSender({ channel: params.channel, id: params.id })
+      : null;
+  if (!owner) {
+    return "Ask the operator to set commands.ownerAllowFrom to your channel user id.";
+  }
+  const owners = JSON.stringify([owner]).replaceAll(
+    "'",
+    process.platform === "win32" ? "''" : "'\\''",
+  );
+  const command = formatCliCommand("openclaw config set commands.ownerAllowFrom");
+  return `Ask the operator to run \`${command} '${owners}'\` in a terminal to make this sender a command owner.`;
+}
+
 /** Emits setup guidance when privileged command ownership is not configured. */
 export function noteCommandOwnerHealth(cfg: OpenClawConfig): void {
   if (hasConfiguredCommandOwners(cfg)) {
@@ -49,7 +73,7 @@ export function noteCommandOwnerHealth(cfg: OpenClawConfig): void {
     [
       "No command owner is configured.",
       "A command owner is the human operator account allowed to run owner-only commands and approve dangerous actions, including /diagnostics, /export-session, /export-trajectory, /config, and exec approvals.",
-      "DM pairing only lets someone talk to the bot; it does not make that sender the owner for privileged commands.",
+      "CLI pairing approval records the first command owner. Control UI approval has an owner checkbox; otherwise set commands.ownerAllowFrom.",
       `Fix: set commands.ownerAllowFrom to your channel user id, for example ${formatCliCommand("openclaw config set commands.ownerAllowFrom '[\"telegram:123456789\"]'")}`,
       "Restart the gateway after changing this if it is already running.",
     ].join("\n"),

--- a/src/commands/doctor-command-owner.ts
+++ b/src/commands/doctor-command-owner.ts
@@ -43,6 +43,7 @@ export function formatCommandOwnerFromChannelSender(params: {
 
 /** Gives admitted senders an operator-run command without granting owner authority. */
 export function formatCommandOwnerHint(params: {
+  cfg?: OpenClawConfig;
   channel?: string | null;
   id?: string | null;
 }): string {
@@ -56,10 +57,12 @@ export function formatCommandOwnerHint(params: {
   if (!owner) {
     return "Ask the operator to set commands.ownerAllowFrom to your channel user id.";
   }
-  const owners = JSON.stringify([owner]).replaceAll(
-    "'",
-    process.platform === "win32" ? "''" : "'\\''",
-  );
+  if (!params.cfg) {
+    return `Ask the operator to add \`${owner}\` to \`commands.ownerAllowFrom\`.`;
+  }
+  const owners = JSON.stringify([
+    ...new Set([...resolveConfiguredCommandOwners(params.cfg), owner]),
+  ]).replaceAll("'", process.platform === "win32" ? "''" : "'\\''");
   const command = formatCliCommand("openclaw config set commands.ownerAllowFrom");
   return `Ask the operator to run \`${command} '${owners}'\` in a terminal to make this sender a command owner.`;
 }

--- a/src/commands/doctor-platform-notes.disabled-launchagent.test.ts
+++ b/src/commands/doctor-platform-notes.disabled-launchagent.test.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execLaunchctl } from "../daemon/launchd-exec.js";
+import { runGatewayDaemonHealth } from "../flows/doctor-health-contribution-runners.gateway.js";
+import { createDoctorHealthFlowContext } from "../flows/doctor-health-contributions.test-support.js";
+
+const { note, maybeRepairGatewayDaemon } = vi.hoisted(() => ({
+  note: vi.fn(),
+  maybeRepairGatewayDaemon: vi.fn(),
+}));
+
+vi.mock("../../packages/terminal-core/src/note.js", () => ({ note }));
+vi.mock("./doctor-gateway-daemon-flow.js", () => ({ maybeRepairGatewayDaemon }));
+vi.mock("../config/paths.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/paths.js")>()),
+  isDefaultInstallIdentity: () => true,
+}));
+vi.mock("../daemon/launchd-exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../daemon/launchd-exec.js")>()),
+  execLaunchctl: vi.fn(),
+}));
+
+describe("Doctor disabled LaunchAgent diagnosis", () => {
+  let home: string;
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-launchagent-"));
+    Object.defineProperty(process, "platform", { ...platformDescriptor, value: "darwin" });
+  });
+
+  afterEach(async () => {
+    if (platformDescriptor) {
+      Object.defineProperty(process, "platform", platformDescriptor);
+    }
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  it.each([
+    {
+      profile: undefined,
+      label: "ai.openclaw.gateway",
+      override: undefined,
+      command: "openclaw gateway start",
+    },
+    {
+      profile: "staging",
+      label: "ai.openclaw.staging",
+      override: undefined,
+      command: "openclaw --profile staging gateway start",
+    },
+    {
+      profile: undefined,
+      label: "dev.openclaw.custom",
+      override: "dev.openclaw.custom",
+      command: "OPENCLAW_LAUNCHD_LABEL=dev.openclaw.custom openclaw gateway start",
+    },
+  ])(
+    "diagnoses $label during offline repair without activating it",
+    async ({ profile, label, override, command }) => {
+      const env = {
+        HOME: home,
+        OPENCLAW_STATE_DIR: path.join(home, "state"),
+        OPENCLAW_CONFIG_PATH: path.join(home, "state", "openclaw.json"),
+        OPENCLAW_PROFILE: profile,
+        OPENCLAW_LAUNCHD_LABEL: override,
+      };
+      await fs.mkdir(path.join(home, "Library", "LaunchAgents"), { recursive: true });
+      await fs.writeFile(path.join(home, "Library", "LaunchAgents", `${label}.plist`), "fixture");
+      vi.mocked(execLaunchctl).mockImplementation(async ([action, target]) => {
+        if (action === "print" && target?.endsWith(`/${label}`)) {
+          return { code: 113, stdout: "", stderr: "Could not find service", termination: "exit" };
+        }
+        if (action === "print-disabled") {
+          return { code: 0, stdout: `"${label}" => disabled`, stderr: "", termination: "exit" };
+        }
+        throw new Error(`Unexpected launchctl action: ${action}`);
+      });
+      const ctx = createDoctorHealthFlowContext({
+        env,
+        options: { repair: true, nonInteractive: true },
+        gatewayMaintenanceActive: true,
+      });
+
+      await runGatewayDaemonHealth(ctx);
+
+      expect(note).toHaveBeenCalledOnce();
+      const message = note.mock.calls[0]?.[0];
+      expect(message).toContain(
+        `Gateway LaunchAgent ${label} is installed but unloaded and disabled`,
+      );
+      expect(message).toContain(command);
+      expect(message).toContain("update");
+      expect(message).toContain("doctor");
+      expect(message).toContain("triage");
+      expect(maybeRepairGatewayDaemon).not.toHaveBeenCalled();
+      expect(execLaunchctl).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each([
+    { installed: true, loaded: false, enabled: true },
+    { installed: true, loaded: true, enabled: false },
+    { installed: false, loaded: false, enabled: false },
+  ])("leaves other service states unchanged: %j", async ({ installed, loaded, enabled }) => {
+    const label = "dev.openclaw.other-state";
+    const env = { HOME: home, OPENCLAW_LAUNCHD_LABEL: label };
+    if (installed) {
+      await fs.mkdir(path.join(home, "Library", "LaunchAgents"), { recursive: true });
+      await fs.writeFile(path.join(home, "Library", "LaunchAgents", `${label}.plist`), "fixture");
+    }
+    vi.mocked(execLaunchctl).mockImplementation(async ([action]) => {
+      if (action === "print") {
+        return {
+          code: loaded ? 0 : 113,
+          stdout: loaded ? "state = running" : "",
+          stderr: loaded ? "" : "Could not find service",
+          termination: "exit",
+        };
+      }
+      if (action === "print-disabled") {
+        return {
+          code: 0,
+          stdout: `"${label}" => ${enabled ? "enabled" : "disabled"}`,
+          stderr: "",
+          termination: "exit",
+        };
+      }
+      throw new Error(`Unexpected launchctl action: ${action}`);
+    });
+    const ctx = createDoctorHealthFlowContext({ env, healthOk: true });
+
+    await runGatewayDaemonHealth(ctx);
+
+    expect(note).not.toHaveBeenCalled();
+    expect(maybeRepairGatewayDaemon).toHaveBeenCalledOnce();
+  });
+});

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -7,7 +7,13 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasConfiguredSecretInput } from "../config/types.secrets.js";
-import { findStaleOpenClawUpdateLaunchdJobs } from "../daemon/launchd.js";
+import {
+  findStaleOpenClawUpdateLaunchdJobs,
+  isLaunchAgentEnabled,
+  isLaunchAgentLoaded,
+  launchAgentPlistExists,
+  resolveLaunchAgentLabel,
+} from "../daemon/launchd.js";
 import { resolveGatewayService, type GatewayService } from "../daemon/service.js";
 import { runExec } from "../process/exec.js";
 import { shortenHomePath } from "../utils.js";
@@ -49,6 +55,29 @@ export async function noteMacLaunchAgentOverrides() {
   if (warning) {
     note(warning, "Gateway (macOS)");
   }
+}
+
+/** Diagnose persistent disablement without taking activation authority from update or Doctor. */
+export async function noteMacDisabledGatewayLaunchAgent(env: NodeJS.ProcessEnv = process.env) {
+  if (
+    process.platform !== "darwin" ||
+    !(await launchAgentPlistExists(env)) ||
+    (await isLaunchAgentLoaded({ env })) ||
+    (await isLaunchAgentEnabled({ env }))
+  ) {
+    return;
+  }
+  const label = resolveLaunchAgentLabel(env);
+  const labelEnv = env.OPENCLAW_LAUNCHD_LABEL?.trim() ? `OPENCLAW_LAUNCHD_LABEL=${label} ` : "";
+  note(
+    [
+      `Gateway LaunchAgent ${label} is installed but unloaded and disabled in launchd.`,
+      "A terminated update helper can leave it disabled across logins. Doctor does not automatically re-enable it.",
+      `After verifying the installation is safe to run, use ${labelEnv}${formatCliCommand("openclaw gateway start", env)} to re-enable and start it. Keep the same state/config overrides.`,
+      `If an update was interrupted or installation safety is uncertain, run ${formatCliCommand("openclaw update", env)} or ${formatCliCommand("openclaw doctor", env)} and ${formatCliCommand("openclaw triage", env)} before starting it.`,
+    ].join("\n"),
+    "Gateway (macOS)",
+  );
 }
 
 /** Returns a warning for stale OpenClaw updater launchd jobs left after interrupted updates. */

--- a/src/flows/doctor-health-contribution-runners.gateway.ts
+++ b/src/flows/doctor-health-contribution-runners.gateway.ts
@@ -134,7 +134,15 @@ export async function runDevicePairingHealth(ctx: DoctorHealthFlowContext): Prom
 }
 
 export async function runGatewayDaemonHealth(ctx: DoctorHealthFlowContext): Promise<void> {
-  if (ctx.gatewayMaintenanceActive || !isDefaultInstallIdentity(ctx.env ?? process.env)) {
+  if (!isDefaultInstallIdentity(ctx.env ?? process.env)) {
+    return;
+  }
+  if (ctx.cfg.gateway?.mode !== "remote") {
+    const { noteMacDisabledGatewayLaunchAgent } =
+      await import("../commands/doctor-platform-notes.js");
+    await noteMacDisabledGatewayLaunchAgent(ctx.env ?? process.env);
+  }
+  if (ctx.gatewayMaintenanceActive) {
     return;
   }
   const { maybeRepairGatewayDaemon } = await import("../commands/doctor-gateway-daemon-flow.js");

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -95,6 +95,7 @@ const mocks = vi.hoisted(() => ({
   maybeScanExtraGatewayServices: vi.fn().mockResolvedValue(undefined),
   maybeResolveDuelingSystemdGatewayScopes: vi.fn().mockResolvedValue(undefined),
   noteMacLaunchAgentOverrides: vi.fn(),
+  noteMacDisabledGatewayLaunchAgent: vi.fn(),
   noteMacLaunchctlGatewayEnvOverrides: vi.fn(),
   noteMacStaleOpenClawUpdateLaunchdJobs: vi.fn(),
   gatewaySecretInputPathCanWin: vi.fn(),
@@ -387,6 +388,7 @@ vi.mock("../gateway/call.js", () => ({
 
 vi.mock("../commands/doctor-platform-notes.js", () => ({
   noteMacLaunchAgentOverrides: mocks.noteMacLaunchAgentOverrides,
+  noteMacDisabledGatewayLaunchAgent: mocks.noteMacDisabledGatewayLaunchAgent,
   noteMacLaunchctlGatewayEnvOverrides: mocks.noteMacLaunchctlGatewayEnvOverrides,
   noteMacStaleOpenClawUpdateLaunchdJobs: mocks.noteMacStaleOpenClawUpdateLaunchdJobs,
 }));

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -138,6 +138,8 @@ type CallGatewayBaseOptions = {
   requiredStoredDeviceAuthScopes?: OperatorScope[];
   requireLocalBackendSharedAuth?: boolean;
   sharedStateMode?: "read-only";
+  /** Keep caller-resolved token/password authoritative, including an empty result. */
+  skipImplicitAuth?: boolean;
   onHelloOk?: GatewayClientOptions["onHelloOk"];
   deviceIdentity?: DeviceIdentity | null;
   instanceId?: string;
@@ -1129,7 +1131,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
       opts.localPortOverride !== undefined || opts.ignoreEnvUrlOverride === true,
     localPortOverride: opts.localPortOverride,
     explicitTlsFingerprint: opts.tlsFingerprint,
-    skipImplicitAuth: useStoredDeviceAuth,
+    skipImplicitAuth: useStoredDeviceAuth || opts.skipImplicitAuth === true,
     ...(useStoredDeviceAuth
       ? {}
       : {

--- a/src/gateway/health-response.test-support.ts
+++ b/src/gateway/health-response.test-support.ts
@@ -1,0 +1,25 @@
+import type { CallGatewayOptions } from "./call.js";
+import { buildMinimalGatewayHelloOkPayload } from "./minimal-gateway.test-helpers.js";
+
+export function gatewayHealthResponse(
+  params: {
+    server?: Partial<Parameters<NonNullable<CallGatewayOptions["onHelloOk"]>>[0]["server"]>;
+    health?: unknown;
+    error?: Error;
+  } = {},
+) {
+  return async (opts: CallGatewayOptions): Promise<unknown> => {
+    const hello = buildMinimalGatewayHelloOkPayload();
+    opts.onHelloOk?.({
+      ...hello,
+      type: "hello-ok",
+      server: { ...hello.server, ...params.server },
+      auth: { role: "operator", scopes: ["operator.read"] },
+      snapshot: { presence: [], health: {}, stateVersion: { presence: 0, health: 0 }, uptimeMs: 0 },
+    });
+    if (params.error) {
+      throw params.error;
+    }
+    return params.health ?? { ok: true };
+  };
+}

--- a/src/gateway/server-methods/update-owner.test.ts
+++ b/src/gateway/server-methods/update-owner.test.ts
@@ -82,7 +82,7 @@ describe("update.run current owner authority", () => {
           reason: "owner_required",
           ackDelivered: false,
           message: expect.stringContaining(
-            "openclaw config set commands.ownerAllowFrom '[\"slack:owner\"]'",
+            `openclaw config set commands.ownerAllowFrom '${JSON.stringify(change === "revoked" ? ["slack:owner"] : ["replacement", "slack:owner"])}'`,
           ),
         });
         expect(adoptUpdateCampaignMock).not.toHaveBeenCalled();
@@ -109,7 +109,7 @@ describe("update.run current owner authority", () => {
       reason: "owner_required",
       ackDelivered: true,
       message: expect.stringContaining(
-        "openclaw config set commands.ownerAllowFrom '[\"slack:owner\"]'",
+        'openclaw config set commands.ownerAllowFrom \'["replacement","slack:owner"]\'',
       ),
     });
     expect(runGatewayUpdateMock).not.toHaveBeenCalled();
@@ -119,7 +119,7 @@ describe("update.run current owner authority", () => {
     expect(sendGatewayLifecycleNoticeMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
         message: expect.stringContaining(
-          "openclaw config set commands.ownerAllowFrom '[\"slack:owner\"]'",
+          'openclaw config set commands.ownerAllowFrom \'["replacement","slack:owner"]\'',
         ),
       }),
     );

--- a/src/gateway/server-methods/update-owner.test.ts
+++ b/src/gateway/server-methods/update-owner.test.ts
@@ -78,7 +78,13 @@ describe("update.run current owner authority", () => {
       if (allowed) {
         expect(runGatewayUpdateMock).toHaveBeenCalledOnce();
       } else {
-        expect(result.details).toMatchObject({ reason: "owner_required", ackDelivered: false });
+        expect(result.details).toMatchObject({
+          reason: "owner_required",
+          ackDelivered: false,
+          message: expect.stringContaining(
+            "openclaw config set commands.ownerAllowFrom '[\"slack:owner\"]'",
+          ),
+        });
         expect(adoptUpdateCampaignMock).not.toHaveBeenCalled();
         expect(sendGatewayLifecycleNoticeMock).not.toHaveBeenCalled();
         expect(runGatewayUpdateMock).not.toHaveBeenCalled();
@@ -102,6 +108,9 @@ describe("update.run current owner authority", () => {
       ok: false,
       reason: "owner_required",
       ackDelivered: true,
+      message: expect.stringContaining(
+        "openclaw config set commands.ownerAllowFrom '[\"slack:owner\"]'",
+      ),
     });
     expect(runGatewayUpdateMock).not.toHaveBeenCalled();
     expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
@@ -109,7 +118,9 @@ describe("update.run current owner authority", () => {
     expect(sentinelState.capturedPayload).toBeUndefined();
     expect(sendGatewayLifecycleNoticeMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        message: "⚠️ Update did not start: owner_required.",
+        message: expect.stringContaining(
+          "openclaw config set commands.ownerAllowFrom '[\"slack:owner\"]'",
+        ),
       }),
     );
   });

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -10,6 +10,7 @@ import {
   validateUpdateStatusResult,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { isConfiguredCommandOwner } from "../../auto-reply/command-auth.js";
+import { formatCommandOwnerHint } from "../../commands/doctor-command-owner.js";
 import { isRestartEnabled } from "../../config/commands.flags.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
@@ -237,6 +238,7 @@ export const updateHandlers: GatewayRequestHandlers = {
     const noticeAttemptId = randomUUID();
     let ownsUpdateOutcome = false;
     let adoptedCampaignId: string | undefined;
+    const ownerRequiredMessage = `Only the OpenClaw owner can start an update from chat. ${formatCommandOwnerHint({ channel: params.requester?.channel, id: params.requester?.senderId })}`;
     const refuseNonOwner = () => {
       const requester = params.requester;
       // Only external chat identities are revocable here; internal or channel-less
@@ -254,6 +256,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       respond(true, {
         ok: false,
         code: "owner_required",
+        message: ownerRequiredMessage,
         ackDelivered,
         result: { status: "error", reason: "owner_required" },
       });
@@ -442,7 +445,7 @@ export const updateHandlers: GatewayRequestHandlers = {
             // Recheck after the awaited acknowledgement, immediately before the effect.
             if (refuseNonOwner()) {
               if (ackDelivered) {
-                await notify("failed", "⚠️ Update did not start: owner_required.");
+                await notify("failed", ownerRequiredMessage);
               }
               return;
             }
@@ -548,7 +551,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         // Recheck after the awaited acknowledgement, immediately before the effect.
         if (refuseNonOwner()) {
           if (ackDelivered) {
-            await notify("failed", "⚠️ Update did not start: owner_required.");
+            await notify("failed", ownerRequiredMessage);
           }
           return;
         }

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -238,7 +238,8 @@ export const updateHandlers: GatewayRequestHandlers = {
     const noticeAttemptId = randomUUID();
     let ownsUpdateOutcome = false;
     let adoptedCampaignId: string | undefined;
-    const ownerRequiredMessage = `Only the OpenClaw owner can start an update from chat. ${formatCommandOwnerHint({ channel: params.requester?.channel, id: params.requester?.senderId })}`;
+    const ownerRequiredMessage = () =>
+      `Only the OpenClaw owner can start an update from chat. ${formatCommandOwnerHint({ cfg: context.getRuntimeConfig(), channel: params.requester?.channel, id: params.requester?.senderId })}`;
     const refuseNonOwner = () => {
       const requester = params.requester;
       // Only external chat identities are revocable here; internal or channel-less
@@ -256,7 +257,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       respond(true, {
         ok: false,
         code: "owner_required",
-        message: ownerRequiredMessage,
+        message: ownerRequiredMessage(),
         ackDelivered,
         result: { status: "error", reason: "owner_required" },
       });
@@ -445,7 +446,7 @@ export const updateHandlers: GatewayRequestHandlers = {
             // Recheck after the awaited acknowledgement, immediately before the effect.
             if (refuseNonOwner()) {
               if (ackDelivered) {
-                await notify("failed", ownerRequiredMessage);
+                await notify("failed", ownerRequiredMessage());
               }
               return;
             }
@@ -551,7 +552,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         // Recheck after the awaited acknowledgement, immediately before the effect.
         if (refuseNonOwner()) {
           if (ackDelivered) {
-            await notify("failed", ownerRequiredMessage);
+            await notify("failed", ownerRequiredMessage());
           }
           return;
         }

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -985,6 +985,11 @@ describe("scheduleRestartSentinelWake", () => {
     { kind: "update", status: "ok", notice: "✅ OpenClaw updated and restarted." },
     {
       kind: "update",
+      status: "skipped",
+      notice: "ℹ️ OpenClaw update skipped: already-current.",
+    },
+    {
+      kind: "update",
       status: "error",
       notice:
         "⚠️ OpenClaw update failed: verification failed. The gateway is running the previous version.",
@@ -1003,7 +1008,10 @@ describe("scheduleRestartSentinelWake", () => {
         ts: 123,
         sessionKey: "agent:main:main",
         message: kind === "restart" ? "/restart" : "/update",
-        stats: { mode: "npm", reason: "verification failed" },
+        stats: {
+          mode: "npm",
+          reason: status === "skipped" ? "already-current" : "verification failed",
+        },
       };
       const { formatRestartSentinelMessage } = await vi.importActual<
         typeof import("../infra/restart-sentinel.js")

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -238,7 +238,8 @@ vi.mock("../agents/agent-scope.js", async () => {
   };
 });
 
-vi.mock("../infra/restart-sentinel.js", () => ({
+vi.mock("../infra/restart-sentinel.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/restart-sentinel.js")>()),
   finalizeUpdateRestartSentinelRunningVersion: mocks.finalizeUpdateRestartSentinelRunningVersion,
   readRestartSentinel: mocks.readRestartSentinel,
   clearRestartSentinelIfRevision: mocks.clearRestartSentinelIfRevision,
@@ -900,7 +901,7 @@ describe("scheduleRestartSentinelWake", () => {
             expectedSessionId: sessionId,
             expectedLifecycleRevision: entry.lifecycleRevision,
             storePath,
-            text: "restart message",
+            text: "✅ OpenClaw updated and restarted.",
             idempotencyKey: `restart-sentinel-notice:${sessionKey}:123`,
           }),
         );
@@ -920,7 +921,7 @@ describe("scheduleRestartSentinelWake", () => {
             sessionKey,
             message: expect.objectContaining({
               role: "assistant",
-              content: [{ type: "text", text: "restart message" }],
+              content: [{ type: "text", text: "✅ OpenClaw updated and restarted." }],
             }),
           }),
           subscribers,
@@ -980,33 +981,61 @@ describe("scheduleRestartSentinelWake", () => {
     },
   );
 
-  it("keeps durable notice delivery and the wake for Telegram update outcomes", async () => {
-    mocks.deliveryContextFromSession.mockReturnValue({ channel: "telegram", to: "chat-123" });
-    mocks.readRestartSentinel.mockResolvedValue({
-      version: 1,
-      revision: 123,
-      payload: { kind: "update", status: "ok", ts: 123, sessionKey: "agent:main:main" },
-    });
-    mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "chat-123" });
+  it.each([
+    { kind: "update", status: "ok", notice: "✅ OpenClaw updated and restarted." },
+    {
+      kind: "update",
+      status: "error",
+      notice:
+        "⚠️ OpenClaw update failed: verification failed. The gateway is running the previous version.",
+    },
+    {
+      kind: "restart",
+      status: "ok",
+      notice: "Gateway restart ok (npm)\n/restart\nReason: verification failed",
+    },
+  ] as const)(
+    "keeps durable $kind/$status notice delivery separate from the wake",
+    async ({ kind, status, notice }) => {
+      const payload: RestartSentinelPayload = {
+        kind,
+        status,
+        ts: 123,
+        sessionKey: "agent:main:main",
+        message: kind === "restart" ? "/restart" : "/update",
+        stats: { mode: "npm", reason: "verification failed" },
+      };
+      const { formatRestartSentinelMessage } = await vi.importActual<
+        typeof import("../infra/restart-sentinel.js")
+      >("../infra/restart-sentinel.js");
+      const wake = formatRestartSentinelMessage(payload);
+      mocks.formatRestartSentinelMessage.mockReturnValueOnce(wake);
+      mocks.deliveryContextFromSession.mockReturnValue({ channel: "telegram", to: "chat-123" });
+      mocks.readRestartSentinel.mockResolvedValue({ version: 1, revision: 123, payload });
+      mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "chat-123" });
 
-    await scheduleRestartSentinelWake({ deps: {} as never });
+      await scheduleRestartSentinelWake({ deps: {} as never });
 
-    expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
-    expect(mocks.enqueueDeliveryOnce).toHaveBeenCalledWith(
-      expect.objectContaining({
-        channel: "telegram",
-        to: "chat-123",
-        payloads: [{ text: "restart message" }],
-      }),
-      "restart-sentinel-notice:agent:main:main:123",
-    );
-    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledOnce();
-    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
-      "restart message",
-      expect.objectContaining({ sessionKey: "agent:main:main" }),
-    );
-    expect(mocks.requestHeartbeat).toHaveBeenCalledOnce();
-  });
+      expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
+      expect(mocks.enqueueDeliveryOnce).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: "telegram",
+          to: "chat-123",
+          payloads: [{ text: notice }],
+        }),
+        "restart-sentinel-notice:agent:main:main:123",
+      );
+      expect(mocks.deliverOutboundPayloads).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ payloads: [{ text: notice }] }),
+      );
+      expect(mocks.formatRestartSentinelMessage).toHaveBeenCalledWith(payload);
+      expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+        wake,
+        expect.objectContaining({ sessionKey: "agent:main:main" }),
+      );
+      expect(mocks.requestHeartbeat).toHaveBeenCalledOnce();
+    },
+  );
 
   it("persists every downstream intent before consuming the loaded revision", async () => {
     await scheduleRestartSentinelWake({ deps: {} as never });
@@ -3211,7 +3240,7 @@ describe("scheduleRestartSentinelWake", () => {
         to: "123",
         accountId: "bot",
         threadId: "7",
-        payloads: [{ text: "restart message" }],
+        payloads: [{ text: "✅ OpenClaw updated and restarted." }],
       }),
     );
     const eventOptions = mocks.enqueueSystemEvent.mock.calls[0]?.[1];

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -19,6 +19,7 @@ import {
   clearRestartSentinelIfRevision,
   finalizeUpdateRestartSentinelRunningVersion,
   formatRestartSentinelMessage,
+  formatUpdateOutcomeNotice,
   readRestartSentinel,
   type RestartSentinelContinuation,
   type RestartSentinelPayload,
@@ -429,6 +430,7 @@ async function loadRestartSentinelStartupTask(params: {
   }
   const sessionKey = payload.sessionKey?.trim();
   const message = formatRestartSentinelMessage(payload);
+  const noticeMessage = payload.kind === "update" ? formatUpdateOutcomeNotice(payload) : message;
   const summary = summarizeRestartSentinel(payload);
   const wakeDeliveryContext = mergeDeliveryContext(
     payload.threadId != null
@@ -535,7 +537,7 @@ async function loadRestartSentinelStartupTask(params: {
         expectedSessionId: entry.sessionId,
         expectedLifecycleRevision: entry.lifecycleRevision ?? null,
         storePath,
-        text: message,
+        text: noticeMessage,
         idempotencyKey: `restart-sentinel-notice:${canonicalKey}:${sentinelRevision}`,
       }).catch((error: unknown) => ({ ok: false as const, reason: formatErrorMessage(error) }));
       internalNoticeWritten = notice.ok;
@@ -593,7 +595,7 @@ async function loadRestartSentinelStartupTask(params: {
       const queuedNotice = await enqueueRestartSentinelNotice({
         cfg,
         ...route,
-        message,
+        message: noticeMessage,
         sessionKey: canonicalKey,
         revision: sentinelRevision,
       });
@@ -620,7 +622,7 @@ async function loadRestartSentinelStartupTask(params: {
         cfg,
         sessionKey: canonicalKey,
         summary,
-        message,
+        message: noticeMessage,
         ...route,
         queueId: noticeQueueId,
       });

--- a/src/gateway/update-run-summary.ts
+++ b/src/gateway/update-run-summary.ts
@@ -32,6 +32,7 @@ export function summarizeUpdateRunResponse(response: unknown) {
     ok,
     status,
     reason: text(result.reason, 240),
+    message: readStringField(raw, "message"),
     mode: text(result.mode, 40),
     before: before ? { version: before } : undefined,
     after: after ? { version: after } : undefined,
@@ -55,7 +56,7 @@ export function summarizeUpdateRunResponse(response: unknown) {
     failedSteps,
     next: ok
       ? "Update handed off. Reply briefly and wait for the automatic completion or failure notice; do not run shell commands or restart anything."
-      : "Tell the user the update did not start and why; relay any exact manual instructions in handoff.",
+      : "Tell the user the update did not start and why; relay any exact manual instructions.",
   };
   if (JSON.stringify(summary, null, 2).length >= 4000) {
     for (const step of failedSteps) {

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -525,10 +525,14 @@ describe("restart sentinel", () => {
       expected: "⚠️ OpenClaw update failed: install. The gateway is running the previous version.",
     },
     {
-      name: "other non-success status",
+      name: "skipped with a recorded reason",
+      payload: { status: "skipped", stats: { reason: "already-current" } },
+      expected: "ℹ️ OpenClaw update skipped: already-current.",
+    },
+    {
+      name: "skipped without a reason",
       payload: { status: "skipped" },
-      expected:
-        "⚠️ OpenClaw update failed: unknown reason. The gateway is running the previous version.",
+      expected: "ℹ️ OpenClaw update skipped: unknown reason.",
     },
     {
       name: "a sentence note",

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -55,6 +55,7 @@ import {
   finalizeUpdateRestartSentinelRunningVersion,
   formatDoctorNonInteractiveHint,
   formatRestartSentinelMessage,
+  formatUpdateOutcomeNotice,
   hasRestartSentinel,
   markUpdateRestartSentinelFailure,
   readRestartSentinel,
@@ -473,6 +474,70 @@ describe("restart sentinel", () => {
         "Reason: validation failed",
         "Run openclaw doctor",
       ].join("\n"),
+    );
+  });
+
+  it.each<{
+    name: string;
+    payload: Partial<import("./restart-sentinel.js").RestartSentinelPayload>;
+    expected: string;
+  }>([
+    {
+      name: "success with both versions",
+      payload: {
+        stats: { before: { version: "2026.8.1" }, after: { version: "2026.8.2" } },
+        message: "/update",
+      },
+      expected: "✅ OpenClaw updated to 2026.8.2 (from 2026.8.1).",
+    },
+    {
+      name: "success without the previous version",
+      payload: { stats: { after: { version: "2026.8.2" } }, doctorHint: "Run openclaw doctor." },
+      expected: "✅ OpenClaw updated to 2026.8.2.\nRun openclaw doctor.",
+    },
+    {
+      name: "success without versions",
+      payload: { message: "tool note" },
+      expected: "✅ OpenClaw updated and restarted.",
+    },
+    {
+      name: "failure with a reason",
+      payload: {
+        status: "error",
+        stats: { reason: "verification failed", before: { version: "2026.8.1" } },
+        doctorHint: "Run openclaw doctor.",
+      },
+      expected:
+        "⚠️ OpenClaw update failed: verification failed. The gateway is running 2026.8.1.\nRun openclaw doctor.",
+    },
+    {
+      name: "failure with the first failed step",
+      payload: {
+        status: "error",
+        stats: {
+          steps: [
+            { name: "download", command: "download", log: { exitCode: 0 } },
+            { name: "install", command: "install", log: { exitCode: 1 } },
+            { name: "verify", command: "verify", log: { exitCode: 1 } },
+          ],
+        },
+      },
+      expected: "⚠️ OpenClaw update failed: install. The gateway is running the previous version.",
+    },
+    {
+      name: "other non-success status",
+      payload: { status: "skipped" },
+      expected:
+        "⚠️ OpenClaw update failed: unknown reason. The gateway is running the previous version.",
+    },
+    {
+      name: "a sentence note",
+      payload: { message: "  The requested update is complete.  " },
+      expected: "✅ OpenClaw updated and restarted.\nThe requested update is complete.",
+    },
+  ])("formats a human update outcome for $name", ({ payload, expected }) => {
+    expect(formatUpdateOutcomeNotice({ kind: "update", status: "ok", ts: 1, ...payload })).toBe(
+      expected,
     );
   });
 

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -380,7 +380,9 @@ export function formatUpdateOutcomeNotice(payload: RestartSentinelPayload): stri
   let outcome = "✅ OpenClaw updated and restarted.";
   if (payload.status === "ok" && current) {
     outcome = `✅ OpenClaw updated to ${current}${previous ? ` (from ${previous})` : ""}.`;
-  } else if (payload.status !== "ok") {
+  } else if (payload.status === "skipped") {
+    outcome = `ℹ️ OpenClaw update skipped: ${payload.stats?.reason?.trim() || "unknown reason"}.`;
+  } else if (payload.status === "error") {
     const reason =
       payload.stats?.reason?.trim() ||
       payload.stats?.steps?.find((step) => step.log?.exitCode != null && step.log.exitCode !== 0)

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -372,6 +372,27 @@ export async function hasRestartSentinel(env: NodeJS.ProcessEnv = process.env): 
   }
 }
 
+export function formatUpdateOutcomeNotice(payload: RestartSentinelPayload): string {
+  const before = payload.stats?.before?.version;
+  const after = payload.stats?.after?.version;
+  const previous = typeof before === "string" ? before.trim() : "";
+  const current = typeof after === "string" ? after.trim() : "";
+  let outcome = "✅ OpenClaw updated and restarted.";
+  if (payload.status === "ok" && current) {
+    outcome = `✅ OpenClaw updated to ${current}${previous ? ` (from ${previous})` : ""}.`;
+  } else if (payload.status !== "ok") {
+    const reason =
+      payload.stats?.reason?.trim() ||
+      payload.stats?.steps?.find((step) => step.log?.exitCode != null && step.log.exitCode !== 0)
+        ?.name ||
+      "unknown reason";
+    outcome = `⚠️ OpenClaw update failed: ${reason}. The gateway is running ${previous || "the previous version"}.`;
+  }
+  const note = payload.message?.trim() ?? "";
+  const sentence = !note.startsWith("/") && /\s/.test(note) && /[.!?]$/.test(note) ? note : "";
+  return [outcome, sentence, payload.doctorHint?.trim()].filter(Boolean).join("\n");
+}
+
 export function formatRestartSentinelMessage(payload: RestartSentinelPayload): string {
   const message = payload.message?.trim();
   if (message && (!payload.stats || payload.kind === "config-auto-recovery")) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where authorized chat users receive no actionable response to owner-only commands on an ownerless install, a healthy local Gateway can fail updater readiness checks, and Doctor overlooks a LaunchAgent left disabled by an interrupted update helper.

Follow-up to merged #136588. This branch includes the owner-refusal, local restart-verification, disabled-service diagnosis, and human-readable update-notice repairs.

## Why This Change Was Made

Owner refusals now share one sender-specific recovery hint across command replies, tool results, and Gateway requester revalidation. Restart verification reuses the existing local control client and its established CLI/shared-secret and loopback backend/auth-none contracts. Doctor reports persistent LaunchAgent disablement through its existing Gateway health contribution without taking activation authority from the operator.

## User Impact

Authorized non-owners get an operator-run command that preserves existing configured owners, removes duplicates and wildcard entries, and adds the requesting sender; tools without config ask the operator to add the sender instead of replacing the owner list; unauthorized senders retain their existing behavior. CLI pairing and Control UI ownership guidance now matches the implemented setup paths. Local restart checks retain plugin/channel failures and served version/build information without creating a device identity or changing Gateway authentication rules. Doctor names the selected profile or custom LaunchAgent label and gives its exact start command, with update/triage advice when installation safety is uncertain.

Skipped update outcomes now read `ℹ️ OpenClaw update skipped: <recorded reason>.`; a missing reason reads `unknown reason`. Error outcomes retain their failure line and running-version detail. No configuration, environment-variable, SQLite, or protocol surface changes. The general remote diagnostic probe is unchanged.

## Evidence

W15c resolves both P1 findings from the 08:17 UTC revision of [the ClawSweeper review](https://github.com/openclaw/openclaw/pull/136995#issuecomment-5520570499):

- Owner recovery uses the current runtime config, including after awaited acknowledgement. Existing owners are preserved and de-duplicated, wildcards are excluded, ownerless config retains a one-entry command, and config-unavailable tools use add wording. For existing `slack:owner` and new `telegram:123`, the command is `openclaw config set commands.ownerAllowFrom '["slack:owner","telegram:123"]'`.
- Skipped results are distinct from errors in the shared notice formatter and durable delivery. `already-current` remains the recorded reason: no canonical reason constant exists for translating it to a latest-version phrase.
- Test alignment repairs main's red gateway-tool/commands-update assertions after #136952 added the in-process system actor; method, requester, session/delivery routing, timeout, scopes, and resolver assertions remain explicit.
- Before the fixes, the dispatch reproduction failed in all four selected cases; the new owner regressions failed in three cases and the skipped-notice regressions failed in two cases. The requested seven-file run then passed all 203 tests across five Vitest shards.
- Command: `node scripts/run-vitest.mjs src/agents/tools/gateway-tool.test.ts src/auto-reply/reply/commands-update.test.ts src/commands/doctor-command-owner.test.ts src/auto-reply/reply/commands-session-restart.test.ts src/gateway/server-methods/update-owner.test.ts src/infra/restart-sentinel.test.ts src/gateway/server-restart-sentinel.test.ts`.
- `pnpm check:changed`: exit 0 on final W15c tree `81d6ed0c0bdacb4c293f342bc8aa792df100fb92`, including typechecks, lint, formatting, and selected runtime guards.
- Fresh Codex branch autoreview against `origin/main`: exit 0, scoped-clean at the requested helper's default P0 threshold. No accepted/actionable findings.
- Rank-up compatibility request: no schema, stored representation, migration, or authorization rule changes. Existing multi-owner configuration and current-config revocation after acknowledgement are covered; no migration is needed. Existing typed sentinel round-trip cases passed. This work order uses focused owner/delivery proof; it does not add live Telegram Test Server proof or repeat a package-staging update roundtrip.

Latest-review disposition (08:45 UTC, reviewed head 80c3b52e24f): the full-array command exposes configured owner IDs to an authorized non-owner. This is the explicitly requested maintainer design for preserving existing owners; it is retained intentionally. The new redaction/non-disclosure suggestion is not applied because it would replace the specified full-array guidance with a different recovery contract. Owner authority still requires the existing sender check and an operator-run config change. Treat this as an acknowledged visibility tradeoff, not a claim that the reply conceals owner membership. Requester controls are documented as defense in depth within a trusted Gateway domain, not hostile multi-user isolation. The optional Telegram Test Server rank-up remains unperformed under this work order's focused proof scope; the compatibility request is addressed above.

CI follow-up: [run 33734359177](https://github.com/openclaw/openclaw/actions/runs/33734359177) exposed 66 updater-owned failures in `checks-node-compact-small-20`. The production readiness path already used `callGateway`, but two CLI fixtures still mocked the retired `probeGateway` call. The repair moves the existing pure hello/health fixture into shared test support and aligns the transport mocks and health-request assertions. Real service ownership, version/build rejection, sentinel consumption, and plugin-error guards remain exercised. A local rerun also found an unmocked port-availability check in the absent-service fixture; that I/O is now fixture-owned. No production changes were needed. The repaired six-file CLI/restart suite passed all 531 tests in 34.94 seconds.

Landing stopped on the next exact-head CI run: [checks-node-compact-small-5, job 100600155339](https://github.com/openclaw/openclaw/actions/runs/33740164492/job/100600155339) failed `src/commands/agent-exec.test.ts` / “bounds blocked service-relay construction through the shipped CLI command”. The one-second command deadline elapsed before the fake CLI wrote its PID. This test is absent from the PR head and was added to main by [693c16dbccc / #136507](https://github.com/openclaw/openclaw/commit/693c16dbccce1144badd66d9afd7929b456506f7); it remains unchanged on fetched main `5a9168fea34a6b62b5a97673fb5416e7504ced09`. It is outside the updater stack, so the requested unrelated-main-failure stop rule applies. The four W15c commits are pushed; native prepare/merge has not run.

Earlier stack proof (retained for context):

- Focused coverage: 29 test files across owner-command siblings, update tool/RPC refusals, restart waits, generic Gateway call/probe behavior, Doctor flows, and docs. The final per-file runs passed. The dedicated restored regression run passed all 64 tests; the restart suite passed all 87 tests after cleanup.
- Regression proof used a temporary WIP commit and `git revert --no-commit`, retaining the new tests while reverting production fixes. All five lanes failed for the intended old behavior: 19 failing assertions, with 45 controls passing. Restoring the fixes made the same behavior cases pass.
- `pnpm check:changed`: exit 0, including the inherited parent stack's macOS validation. `pnpm prompt:snapshots:check`: current, 7 files. `pnpm build`: exit 0. All OpenClaw commands used temporary state/config paths.
- Requested Codex branch review against the parent branch: exit 0, `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority` (P0 threshold).
- Live macOS proof: a built CLI served an isolated token-auth LaunchAgent on a temporary port. After a real launchd restart, the verifier confirmed a changed PID, the same served version/build, and sustained health; the restart log had **zero** `missing scope: operator.read` lines. The temporary LaunchAgent was removed. The socket tests cover token, password, and auth-none, preserve plugin/channel errors, reject remote credential leakage, and verify that no device files are created.

Full PR LOC against main: production +188 / -88 (net +100), tests/support +1036 / -424 (net +612), docs +24 / -1 (net +23). W15c including the CI fixture repair adds only +7 net production lines and +36 net test/support lines: current-config owner preservation and explicit skipped status require the small additional decision surface. The restart-client change is net -4 production lines. The two positive production deltas add the shared executable ownership hint and the selected-service diagnosis; no duplicate probe path or handshake exception was added.

The live proof exercises a real managed restart and readiness verification; it does not repeat the full package-staging update roundtrip or send live channel messages. No configuration, baseline, changelog, workflow, protocol, or SQLite changes are included. The changed-check temp-directory warning names an earlier Doctor test with explicit afterEach removal; it is advisory, not an unclean test or gate failure. Landing is authorized after exact-head CI and native prepare/merge gates pass.

