### PR TITLE
fix(gateway): stop late request failures after shutdown

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2836,7 +2836,7 @@ src/gateway/server-instance-runtime.ts	3
 src/gateway/server-lifecycle.ts	1
 src/gateway/server-maintenance.ts	4
 src/gateway/server-methods-list.ts	1
-src/gateway/server-methods.ts	4
+src/gateway/server-methods.ts	3
 src/gateway/server-methods/agent-run-handler.ts	1
 src/gateway/server-methods/agent-session-patch.ts	1
 src/gateway/server-methods/agent-session-reset.ts	2

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -67,6 +67,13 @@ When waiting capacity is exhausted, the Gateway returns retryable `UNAVAILABLE`
 before the method runs; retry within the request's budget. Started requests
 complete concurrently, so responses can arrive out of order.
 
+Ordinary UI/SDK requests may outlive a socket disconnect, but cannot start a
+handler in a retiring Gateway instance. Shutdown fences new request entry and
+joins pending handler loading and authorization before releasing their runtime.
+Already-started methods retain their own shutdown behavior; shutdown does not
+wait for every RPC to finish. Exact pending node progress and result replies
+remain available during node cleanup, until transport shutdown seals entry.
+
 Clients should branch on `code` and `details.code`; `message` remains human-readable
 and can change except where a compatibility note says otherwise. Method-level
 authorization failures use top-level `code: "FORBIDDEN"` with structured

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -16,10 +16,7 @@ import { OPENAI_CODEX_DEFAULT_PROFILE_ID } from "./auth-profiles/constants.js";
 import { getRuntimeExternalCliProfileIds } from "./auth-profiles/runtime-external-profile-references.js";
 import { saveAuthProfileStore } from "./auth-profiles/store.js";
 import { preparePublishedModelCatalogOwnerIdentity } from "./prepared-model-catalog-owner.js";
-import {
-  createPreparedModelCatalogWorker,
-  createPreparedModelCatalogWorkerInput,
-} from "./prepared-model-catalog-worker.js";
+import { createPreparedModelCatalogWorker } from "./prepared-model-catalog-worker.js";
 import {
   DISCOVERED_HARNESS_ID,
   PROVIDER_ID,
@@ -962,7 +959,7 @@ describe("prepared model catalog worker boundary", () => {
         },
       },
     };
-    const input = createPreparedModelCatalogWorkerInput({
+    const worker = createPreparedModelCatalogWorker({
       agentFacts: {
         input: {
           agentId: "main",
@@ -982,12 +979,9 @@ describe("prepared model catalog worker boundary", () => {
         templateAuthStorage: AuthStorage.inMemory({}),
       } satisfies PreparedModelRuntimeAgentFacts,
       pluginMetadataSnapshot: fixture.pluginMetadataSnapshot,
-    });
-
-    const catalog = await createPreparedModelCatalogWorker({
-      input,
       isCurrent: fixture.isCurrent,
-    }).loadCatalog();
+    });
+    const catalog = await worker.loadCatalog();
 
     expect(catalog.entries).toContainEqual(
       expect.objectContaining({

--- a/src/agents/prepared-model-catalog-worker.metadata.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.metadata.integration.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPluginCache,
+  getPluginMetadataSnapshotCache,
+  withPluginCache,
+} from "../plugins/plugin-cache.js";
+import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import { preparePublishedModelCatalogOwnerIdentity } from "./prepared-model-catalog-owner.js";
+import { createCatalogFixture, PROVIDER_ID } from "./prepared-model-catalog-worker.test-support.js";
+import { usePreparedCatalogWorkerFixtures } from "./test-helpers/prepared-model-catalog-worker-fixture.js";
+
+const { makeTempDir, retireAfterTest, waitForWorkers } = usePreparedCatalogWorkerFixtures();
+
+describe("prepared catalog parent metadata ownership", () => {
+  it("retains canonical metadata across module evaluation and clones only for the worker", async () => {
+    const fixture = createCatalogFixture(makeTempDir, 0);
+    const { agentDir, config, env, workspaceDir } = fixture;
+    const cache = createPluginCache();
+    const metadata = withPluginCache(cache, () =>
+      loadPluginMetadataSnapshot({ config, env, workspaceDir, allowCurrent: false }),
+    );
+    const input = {
+      agentId: "main",
+      agentDir,
+      inheritedAuthDir: agentDir,
+      config,
+      env,
+      workspaceDir,
+    };
+    let current = true;
+    retireAfterTest(() => {
+      current = false;
+    });
+
+    // The operation owns this frozen graph across module evaluation, as retained
+    // Gateway generations do. A new module must not reinstall its Map mutators.
+    vi.resetModules();
+    const [runtimeBuild, providerRuntime, metadataRuntime, generationScope] = await Promise.all([
+      import("./prepared-model-runtime.build.js"),
+      import("../plugins/provider-runtime.js"),
+      import("../plugins/current-plugin-metadata-snapshot.js"),
+      import("../plugins/runtime/generation-scope.js"),
+    ]);
+    let registry: PluginRegistry | undefined;
+    const capture = providerRuntime.captureProviderSyntheticAuthFacts;
+    const captureSpy = vi
+      .spyOn(providerRuntime, "captureProviderSyntheticAuthFacts")
+      .mockImplementation((params) => {
+        expect(metadataRuntime.getCurrentPluginMetadataSnapshot()).toBe(metadata);
+        expect(generationScope.getPluginRuntimeGenerationRegistry()).toBe(registry);
+        expect(getPluginMetadataSnapshotCache(metadata)).toBe(cache);
+        return capture(params);
+      });
+    try {
+      await withPluginCache(cache, async () => {
+        const build = runtimeBuild.startSerializedSnapshotBuildBatch(
+          [
+            {
+              input,
+              catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
+              isGenerationCurrent: () => current,
+              isBuildCurrent: () => current,
+            },
+          ],
+          new Map(),
+          30_000,
+          "static",
+          undefined,
+          metadata,
+        );
+        let prepared: Awaited<typeof build.pending>[number] | undefined;
+        try {
+          [prepared] = await build.pending;
+        } finally {
+          await build.completion;
+        }
+        if (!prepared) {
+          throw new Error("prepared runtime produced no snapshot");
+        }
+        registry = prepared.pluginGeneration.pluginRegistry;
+        expect(registry).toBeDefined();
+        expect(prepared.snapshot.metadataSnapshot).toBe(metadata);
+        expect(prepared.snapshot.metadataSnapshot.index).toBe(metadata.index);
+        expect(metadata.normalizePluginId(` ${PROVIDER_ID.toUpperCase()} `)).toBe(PROVIDER_ID);
+        expect(fs.existsSync(fixture.marker)).toBe(false);
+        expect(captureSpy).not.toHaveBeenCalled();
+        await waitForWorkers();
+
+        const catalog = await prepared.snapshot.loadFullModelCatalog!();
+        expect(captureSpy).toHaveBeenCalledOnce();
+        expect(catalog.entries).toContainEqual(
+          expect.objectContaining({ provider: PROVIDER_ID, id: "plugin-generation-v1" }),
+        );
+        expect(fs.readFileSync(fixture.marker, "utf8")).toBe("start\ndone\n");
+        expect(Object.isFrozen(metadata.byPluginId)).toBe(true);
+      });
+    } finally {
+      current = false;
+      try {
+        await waitForWorkers();
+      } finally {
+        captureSpy.mockRestore();
+        cache.disposeModules?.();
+      }
+    }
+  });
+});

--- a/src/agents/prepared-model-catalog-worker.mismatch.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.mismatch.integration.test.ts
@@ -27,6 +27,30 @@ const { makeTempDir, retireAfterTest, waitForWorkers } = usePreparedCatalogWorke
 
 const DRIFTED_OWNER_FINGERPRINT = "owner-generation-drifted";
 
+const workerBoundary = vi.hoisted(() => ({ fingerprint: undefined as string | undefined }));
+
+vi.mock("node:worker_threads", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:worker_threads")>();
+  return {
+    ...actual,
+    Worker: class extends actual.Worker {
+      constructor(...[filename, options]: ConstructorParameters<typeof actual.Worker>) {
+        const data: unknown = options?.workerData;
+        // Inject only at structured cloning; parent facts and the real worker stay intact.
+        super(
+          filename,
+          workerBoundary.fingerprint && isRecord(data) && data.kind === "catalog"
+            ? {
+                ...options,
+                workerData: { ...data, generationFingerprint: workerBoundary.fingerprint },
+              }
+            : options,
+        );
+      }
+    },
+  };
+});
+
 /** A prepared generation whose owner hands its worker a real lifecycle plan. */
 async function createMismatchFixture() {
   const root = makeTempDir("openclaw-model-catalog-mismatch-");
@@ -89,7 +113,7 @@ async function createMismatchFixture() {
       undefined,
     ).pending
   )[0]!;
-  const workerInput = createPreparedModelCatalogWorkerInput({
+  const workerParams = {
     agentFacts: {
       input: { agentId: "main", agentDir, workspaceDir, config, env },
       env,
@@ -104,8 +128,9 @@ async function createMismatchFixture() {
     } satisfies PreparedModelRuntimeAgentFacts,
     pluginMetadataSnapshot: build.pluginGeneration.pluginMetadataSnapshot,
     preferBuiltPluginArtifacts: build.pluginGeneration.preferBuiltPluginArtifacts,
-  });
-  return { agentDir, marker, isCurrent, workerInput };
+  };
+  const fingerprint = createPreparedModelCatalogWorkerInput(workerParams).generationFingerprint;
+  return { agentDir, marker, isCurrent, workerParams, fingerprint };
 }
 
 function trackSpawnedWorkers(
@@ -126,14 +151,16 @@ function trackSpawnedWorkers(
 
 describe("prepared model catalog worker generation mismatch", () => {
   beforeEach(() => {
+    workerBoundary.fingerprint = undefined;
     vi.stubEnv("CODEX_HOME", makeTempDir("openclaw-worker-empty-codex-"));
   });
 
   it("retires a worker that reconstructs another generation instead of publishing its facts", async () => {
     const fixture = await createMismatchFixture();
+    workerBoundary.fingerprint = DRIFTED_OWNER_FINGERPRINT;
     await trackSpawnedWorkers(async (spawned) => {
       const worker = createPreparedModelCatalogWorker({
-        input: { ...fixture.workerInput, generationFingerprint: DRIFTED_OWNER_FINGERPRINT },
+        ...fixture.workerParams,
         isCurrent: fixture.isCurrent,
       });
 
@@ -145,7 +172,7 @@ describe("prepared model catalog worker generation mismatch", () => {
         name: "PreparedModelCatalogGenerationMismatchError",
         agentDir: fixture.agentDir,
         generationFingerprint: DRIFTED_OWNER_FINGERPRINT,
-        reconstructedFingerprint: fixture.workerInput.generationFingerprint,
+        reconstructedFingerprint: fixture.fingerprint,
       });
       expect(spawned).toHaveLength(1);
 
@@ -163,15 +190,10 @@ describe("prepared model catalog worker generation mismatch", () => {
     const fixture = await createMismatchFixture();
     // Inject a mismatch only at the first worker clone boundary. This drives the real owner,
     // pool, and worker without depending on the production-only environmental trigger.
-    let drifted = true;
-    const transientInput = { ...fixture.workerInput };
-    Object.defineProperty(transientInput, "generationFingerprint", {
-      enumerable: true,
-      get: () => (drifted ? DRIFTED_OWNER_FINGERPRINT : fixture.workerInput.generationFingerprint),
-    });
+    workerBoundary.fingerprint = DRIFTED_OWNER_FINGERPRINT;
     await trackSpawnedWorkers(async (spawned) => {
       const worker = createPreparedModelCatalogWorker({
-        input: transientInput,
+        ...fixture.workerParams,
         isCurrent: fixture.isCurrent,
       });
 
@@ -186,7 +208,7 @@ describe("prepared model catalog worker generation mismatch", () => {
       expect(catalog).toMatchObject({
         agentDir: fixture.agentDir,
         generationFingerprint: DRIFTED_OWNER_FINGERPRINT,
-        reconstructedFingerprint: fixture.workerInput.generationFingerprint,
+        reconstructedFingerprint: fixture.fingerprint,
       });
       expect(spawned).toHaveLength(1);
       // The queued catalog request never ran on the retired worker: no catalog hook executed.
@@ -195,7 +217,7 @@ describe("prepared model catalog worker generation mismatch", () => {
 
       // Not latched: once the injection clears, the same owner rebuilds from its prepared facts
       // and publishes the full catalog.
-      drifted = false;
+      workerBoundary.fingerprint = undefined;
       const recovered = await worker.loadCatalog();
       expect(spawned).toHaveLength(2);
       expect(recovered.entries).toContainEqual(
@@ -215,16 +237,11 @@ describe("prepared model catalog worker generation mismatch", () => {
     const releaseTermination = createDeferredCore();
     const replacementStarted = createDeferredCore();
     let restoreTermination: (() => void) | undefined;
-    let drifted = true;
-    const transientInput = { ...fixture.workerInput };
-    Object.defineProperty(transientInput, "generationFingerprint", {
-      enumerable: true,
-      get: () => (drifted ? DRIFTED_OWNER_FINGERPRINT : fixture.workerInput.generationFingerprint),
-    });
+    workerBoundary.fingerprint = DRIFTED_OWNER_FINGERPRINT;
     await trackSpawnedWorkers(
       async (spawned) => {
         const worker = createPreparedModelCatalogWorker({
-          input: transientInput,
+          ...fixture.workerParams,
           isCurrent: fixture.isCurrent,
         });
         const auth = worker
@@ -241,7 +258,7 @@ describe("prepared model catalog worker generation mismatch", () => {
               throw new Error("Expected the old worker's held termination");
             }),
           ]);
-          drifted = false;
+          workerBoundary.fingerprint = undefined;
           replacement = worker.loadCatalog();
           const outcome = replacement.catch((error: unknown) => error);
           await Promise.race([

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -7,7 +7,6 @@ import { projectConfigOntoRuntimeSourceSnapshot } from "../config/runtime-source
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import { WorkerTaskError, WorkerTaskPool } from "../infra/worker-task-pool.js";
 import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
-import { restorePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { captureProviderSyntheticAuthFacts } from "../plugins/provider-runtime.js";
 import type { PreparedSyntheticAuthFacts } from "../plugins/provider-synthetic-auth.js";
@@ -194,20 +193,23 @@ type PreparedModelCatalogWorker = Readonly<{
   loadCatalog: () => Promise<ModelCatalogSnapshot>;
 }>;
 
-export function createPreparedModelCatalogWorker(params: {
-  input: PreparedModelCatalogWorkerInput;
-  isCurrent: () => boolean;
-  pluginRegistry?: PluginRegistry;
-}): PreparedModelCatalogWorker {
+export function createPreparedModelCatalogWorker(
+  params: Parameters<typeof createPreparedModelCatalogWorkerInput>[0] & {
+    isCurrent: () => boolean;
+    pluginRegistry?: PluginRegistry;
+  },
+): PreparedModelCatalogWorker {
+  const workerInput = createPreparedModelCatalogWorkerInput(params);
+  // Parent probes retain the canonical generation; only the worker restores a cloned payload.
+  const metadataSnapshot = params.pluginMetadataSnapshot;
   const superseded = () =>
     new PreparedModelRuntimePublicationSupersededError(
-      `prepared model runtime catalog generation was superseded for ${params.input.input.agentDir}`,
+      `prepared model runtime catalog generation was superseded for ${workerInput.input.agentDir}`,
     );
   let generationPoll: NodeJS.Timeout | undefined;
   let stoppedError: Error | undefined;
   let expectedFingerprint: string | undefined;
   const captures = new Map<AbortController, Promise<PreparedSyntheticAuthFacts>>();
-  const metadataSnapshot = restorePluginMetadataSnapshot(params.input.pluginMetadataSnapshot);
   const assertCurrent = () => {
     if (stoppedError) {
       throw stoppedError;
@@ -221,7 +223,7 @@ export function createPreparedModelCatalogWorker(params: {
     message: Extract<PreparedModelWorkerResult, { status: "generation-mismatch" }>,
   ) =>
     new PreparedModelCatalogGenerationMismatchError(
-      params.input.input.agentDir,
+      workerInput.input.agentDir,
       message.generationFingerprint,
       message.reconstructedFingerprint,
     );
@@ -238,9 +240,9 @@ export function createPreparedModelCatalogWorker(params: {
       idleTimeoutMs: 0,
       restartOnError: false,
       workerOptions: {
-        workerData: params.input,
+        workerData: workerInput,
         // Establish state/config environment before worker module initialization reads process.env.
-        env: params.input.input.env,
+        env: workerInput.input.env,
       },
       validateResult: (message) => {
         assertCurrent();
@@ -284,7 +286,7 @@ export function createPreparedModelCatalogWorker(params: {
         }
       }, PREPARED_MODEL_CATALOG_WORKER_GENERATION_POLL_MS);
       generationPoll.unref();
-      const { input } = params.input;
+      const { input } = workerInput;
       const capture = withPluginRuntimeGenerationScope(
         { metadataSnapshot, pluginRegistry: params.pluginRegistry },
         () =>
@@ -296,9 +298,9 @@ export function createPreparedModelCatalogWorker(params: {
               command.kind === "catalog"
                 ? [
                     ...listManifestSyntheticAuthProviderRefs(metadataSnapshot.index),
-                    ...params.input.providerIds,
+                    ...workerInput.providerIds,
                   ]
-                : [...params.input.providerIds, ...command.providerIds],
+                : [...workerInput.providerIds, ...command.providerIds],
             signal: controller.signal,
           }),
       );
@@ -315,7 +317,7 @@ export function createPreparedModelCatalogWorker(params: {
       message = await requestPool.run(
         () => {
           assertCurrent();
-          expectedFingerprint = fingerprintPreparedModelWorkerRequest(params.input, value);
+          expectedFingerprint = fingerprintPreparedModelWorkerRequest(workerInput, value);
           return value;
         },
         { timeoutMs: PREPARED_MODEL_CATALOG_WORKER_TIMEOUT_MS, signal: controller.signal },

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -12,10 +12,7 @@ import { getPreparedRuntimeAuthMaterializations } from "./auth-profiles/runtime-
 import { collectConfiguredAgentHarnessRuntimes } from "./harness-runtimes.js";
 import { augmentPreparedModelCatalogWithAgentHarness } from "./harness/model-catalog.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
-import {
-  createPreparedModelCatalogWorker,
-  createPreparedModelCatalogWorkerInput,
-} from "./prepared-model-catalog-worker.js";
+import { createPreparedModelCatalogWorker } from "./prepared-model-catalog-worker.js";
 import {
   getPreparedModelFullCatalogAuth,
   setPreparedModelFullCatalogAuth,
@@ -189,11 +186,9 @@ function createFullModelCatalogAccess(params: {
   // request initializes one registry and reuses that exact plugin generation until retirement.
   const worker = createPreparedModelCatalogWorker({
     pluginRegistry: params.pluginGeneration.pluginRegistry,
-    input: createPreparedModelCatalogWorkerInput({
-      agentFacts: params.agentFacts,
-      pluginMetadataSnapshot: params.pluginGeneration.pluginMetadataSnapshot,
-      preferBuiltPluginArtifacts: params.pluginGeneration.preferBuiltPluginArtifacts,
-    }),
+    agentFacts: params.agentFacts,
+    pluginMetadataSnapshot: params.pluginGeneration.pluginMetadataSnapshot,
+    preferBuiltPluginArtifacts: params.pluginGeneration.preferBuiltPluginArtifacts,
     isCurrent: params.isCurrent,
   });
   return {

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -60,7 +60,7 @@ describe("prepared model runtime reload auth adoption", () => {
       catalogMode: "static",
     });
     mocks.buildPreparedModelCatalogSnapshot.mockClear();
-    mocks.createPreparedModelCatalogWorkerInput.mockClear();
+    mocks.createPreparedModelCatalogWorker.mockClear();
     expect((await prepareModelRuntimeSnapshot(input)).modelCatalog.entries).toEqual([]);
 
     mocks.mutationListener?.({
@@ -74,7 +74,7 @@ describe("prepared model runtime reload auth adoption", () => {
       modelCatalog: { entries: [] },
     });
     expect(
-      mocks.createPreparedModelCatalogWorkerInput.mock.calls.at(-1)?.[0].agentFacts.providerIds,
+      mocks.createPreparedModelCatalogWorker.mock.calls.at(-1)?.[0].agentFacts.providerIds,
     ).toContain("custom");
     expect(mocks.buildPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
     expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
@@ -147,7 +147,7 @@ describe("prepared model runtime reload auth adoption", () => {
       catalogMode: "static",
     });
     mocks.runPreparedModelCatalogWorker.mockClear();
-    mocks.createPreparedModelCatalogWorkerInput.mockClear();
+    mocks.createPreparedModelCatalogWorker.mockClear();
     mocks.mutationListener?.({
       agentDir: input.agentDir,
       affectsInheritedStores: false,
@@ -157,7 +157,7 @@ describe("prepared model runtime reload auth adoption", () => {
     await prepareModelRuntimeSnapshot(input);
     expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
     expect(
-      mocks.createPreparedModelCatalogWorkerInput.mock.calls.at(-1)?.[0].agentFacts.providerIds,
+      mocks.createPreparedModelCatalogWorker.mock.calls.at(-1)?.[0].agentFacts.providerIds,
     ).toEqual([]);
   });
 

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -131,10 +131,6 @@ vi.mock("../plugins/provider-public-artifacts.js", () => ({
 }));
 
 vi.mock("./prepared-model-catalog-worker.js", () => ({
-  createPreparedModelCatalogWorkerInput: ({ agentFacts }: { agentFacts: unknown }) => ({
-    generationFingerprint: "test-generation",
-    input: (agentFacts as { input: unknown }).input,
-  }),
   createPreparedModelCatalogWorker: () => ({
     loadCatalog: async () => {
       const catalog = await mocks.runPreparedModelCatalogWorker();

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -53,19 +53,8 @@ const preparedModelRuntimeMocks = vi.hoisted(() => ({
     entries: [],
     routeVariants: [],
   })),
-  createPreparedModelCatalogWorkerInput: vi.fn(
-    ({
-      agentFacts,
-    }: {
-      agentFacts: { input: unknown; authStore: unknown; providerIds: unknown };
-    }) => ({
-      kind: "catalog",
-      generationFingerprint: "test-generation",
-      input: agentFacts.input,
-      authStore: agentFacts.authStore,
-      providerIds: agentFacts.providerIds,
-    }),
-  ),
+  createPreparedModelCatalogWorker:
+    vi.fn<typeof import("./prepared-model-catalog-worker.js").createPreparedModelCatalogWorker>(),
   configuredAgentIds: [] as string[],
   configuredAgentIdsError: undefined as Error | undefined,
   configuredAgentDirs: new Map<string, string>(),
@@ -121,28 +110,30 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
 }));
 
 vi.mock("./prepared-model-catalog-worker.js", () => ({
-  createPreparedModelCatalogWorkerInput: (
-    ...args: Parameters<typeof preparedModelRuntimeMocks.createPreparedModelCatalogWorkerInput>
-  ) => preparedModelRuntimeMocks.createPreparedModelCatalogWorkerInput(...args),
-  createPreparedModelCatalogWorker: () => ({
-    loadCatalog: async (...args: unknown[]) => {
-      const catalog = await preparedModelRuntimeMocks.runPreparedModelCatalogWorker(...args);
-      // Real worker replies always pair inventory with the observed auth generation.
-      setPreparedModelFullCatalogAuth(
-        catalog,
-        getPreparedModelFullCatalogAuth(catalog) ?? {
+  createPreparedModelCatalogWorker: (
+    ...factoryArgs: Parameters<typeof preparedModelRuntimeMocks.createPreparedModelCatalogWorker>
+  ) => {
+    preparedModelRuntimeMocks.createPreparedModelCatalogWorker(...factoryArgs);
+    return {
+      loadCatalog: async (...args: unknown[]) => {
+        const catalog = await preparedModelRuntimeMocks.runPreparedModelCatalogWorker(...args);
+        // Real worker replies always pair inventory with the observed auth generation.
+        setPreparedModelFullCatalogAuth(
+          catalog,
+          getPreparedModelFullCatalogAuth(catalog) ?? {
+            authStore: preparedModelRuntimeMocks.preparedAuthStore ?? { version: 1, profiles: {} },
+            authModes: {},
+          },
+        );
+        return catalog;
+      },
+      loadAuth: () =>
+        Promise.resolve({
           authStore: preparedModelRuntimeMocks.preparedAuthStore ?? { version: 1, profiles: {} },
           authModes: {},
-        },
-      );
-      return catalog;
-    },
-    loadAuth: () =>
-      Promise.resolve({
-        authStore: preparedModelRuntimeMocks.preparedAuthStore ?? { version: 1, profiles: {} },
-        authModes: {},
-      }),
-  }),
+        }),
+    };
+  },
 }));
 
 vi.mock("./model-catalog.js", async () => ({
@@ -417,7 +408,7 @@ export function resetPreparedModelRuntimeHarness(state: OpenClawTestState): void
   preparedModelRuntimeMocks.buildPreparedModelCatalogSnapshot
     .mockReset()
     .mockResolvedValue({ entries: [], routeVariants: [] });
-  preparedModelRuntimeMocks.createPreparedModelCatalogWorkerInput.mockClear();
+  preparedModelRuntimeMocks.createPreparedModelCatalogWorker.mockClear();
   preparedModelRuntimeMocks.discoverAuthStorage
     .mockReset()
     .mockImplementation(() => preparedModelRuntimeMocks.authStorage);

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -57,177 +57,191 @@ export function createInternalAgentTurnFacade(
     throwIfGatewayDispatchAborted(method, dispatchOptions.signal);
     options.assertContextCurrent?.();
     const context = options.getContext();
-    const methodRegistry = getMethodRegistry();
-    const authorization = await authorizeGatewayRequestPreDispatch({
-      method,
-      requestParams: request,
+    const entry = context.requestEntryLifetime?.enter({
+      req: { method, params: request },
       client: options.client,
       context,
-      methodRegistry,
     });
-    if (authorization.error) {
-      return { ok: false, error: authorization.error };
-    }
-    const validationError = validateGatewayMethodParams(request, validateAgentParams, method);
-    if (validationError) {
-      return { ok: false, error: validationError };
-    }
-    options.assertContextCurrent?.();
-    let acceptance: GatewayMethodDispatchResponse | undefined;
-    let final: GatewayMethodDispatchResponse | undefined;
-    let resolveAcceptance: ((response: GatewayMethodDispatchResponse) => void) | undefined;
-    let rejectAcceptance: ((error: Error) => void) | undefined;
-    let resolveFinal: ((response: GatewayMethodDispatchResponse) => void) | undefined;
-    let rejectFinal: ((error: Error) => void) | undefined;
-    let postAcceptanceError: Error | undefined;
-    // Acceptance publishes the abort owner before this callback runs. Retain that exact
-    // entry so a late deadline cannot cancel a same-run-id successor.
-    let acceptedAbortOwner: { entry: ChatAbortControllerEntry; runId: string } | undefined;
-    let pendingCancelReason: "rpc" | "timeout" | undefined;
-    const cancelAcceptedRun = (reason: "rpc" | "timeout") => {
-      pendingCancelReason ??= reason;
-      const owner = acceptedAbortOwner;
-      if (!owner || context.chatAbortControllers.get(owner.runId) !== owner.entry) {
-        return;
-      }
-      abortChatRunById(context, {
-        runId: owner.runId,
-        sessionKey: owner.entry.sessionKey,
-        stopReason: pendingCancelReason,
-      });
-    };
-    const acceptancePromise = new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
-      resolveAcceptance = resolve;
-      rejectAcceptance = reject;
-    });
-    const createFinalPromise = () =>
-      new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
-        resolveFinal = resolve;
-        rejectFinal = reject;
-        if (final) {
-          resolve(final);
-        }
-      });
-    const io: AgentTurnIo = {
-      emitAcceptance: (frame, meta) => {
-        if (!acceptance) {
-          acceptance = {
-            ok: frame[0],
-            payload: frame[1],
-            error: frame[2],
-            ...(meta ? { meta } : {}),
-          };
-          resolveAcceptance?.(acceptance);
-          const acceptedRunId =
-            typeof meta?.runId === "string" && meta.runId.trim() ? meta.runId.trim() : undefined;
-          const acceptedEntry = acceptedRunId
-            ? context.chatAbortControllers.get(acceptedRunId)
-            : undefined;
-          if (acceptedRunId && acceptedEntry) {
-            acceptedAbortOwner = { entry: acceptedEntry, runId: acceptedRunId };
-            if (pendingCancelReason) {
-              cancelAcceptedRun(pendingCancelReason);
-            }
-          }
-          if (
-            meta?.cached === true &&
-            acceptedRunId &&
-            context.chatAbortControllers.get(acceptedRunId)?.executionStarted === true
-          ) {
-            dispatchOptions.onExecutionStarted?.();
-          }
-        }
-      },
-      emitFinal: (frame, meta) => {
-        if (!final) {
-          final = {
-            ok: frame[0],
-            payload: frame[1],
-            error: frame[2],
-            ...(meta ? { meta } : {}),
-          };
-          resolveFinal?.(final);
-        }
-      },
-      ...(dispatchOptions.onExecutionStarted
-        ? { emitExecutionStarted: dispatchOptions.onExecutionStarted }
-        : {}),
-    };
-    const operation = runWithGatewayRequestEnvelope(
-      method,
-      options.client,
-      async () => {
-        const principal = captureAgentTurnPrincipal(options.client);
-        const preflight = prepareAgentRequestPreflight({
-          request,
-          context,
-          client: principal,
-          io,
-        });
-        if (!preflight) {
-          return;
-        }
-        const onRunObserved = resolveAgentTurnRunObserver({
-          principal,
-          registerToolEventRecipient: context.registerToolEventRecipient,
-        });
-        await createAgentTurnService(
-          { context, isWebchatConnect },
-          options.assertContextCurrent,
-        ).startTurn({ preflight, principal, io, onRunObserved });
-      },
-      {
+    try {
+      const methodRegistry = getMethodRegistry();
+      const authorization = await authorizeGatewayRequestPreDispatch({
+        method,
+        requestParams: request,
+        client: options.client,
         context,
-        isWebchatConnect,
         methodRegistry,
-        reject: (error) => io.emitAcceptance([false, undefined, error]),
-      },
-    );
-    void operation.then(
-      () => {
-        if (!acceptance) {
-          rejectAcceptance?.(new Error(`Gateway method "${method}" completed without a response.`));
-        }
-      },
-      (error: unknown) => {
-        const dispatchError = error instanceof Error ? error : new Error(String(error));
-        if (acceptance) {
-          postAcceptanceError = dispatchError;
-          rejectFinal?.(dispatchError);
+      });
+      entry?.assertOpen();
+      if (authorization.error) {
+        return { ok: false, error: authorization.error };
+      }
+      const validationError = validateGatewayMethodParams(request, validateAgentParams, method);
+      if (validationError) {
+        return { ok: false, error: validationError };
+      }
+      options.assertContextCurrent?.();
+      let acceptance: GatewayMethodDispatchResponse | undefined;
+      let final: GatewayMethodDispatchResponse | undefined;
+      let resolveAcceptance: ((response: GatewayMethodDispatchResponse) => void) | undefined;
+      let rejectAcceptance: ((error: Error) => void) | undefined;
+      let resolveFinal: ((response: GatewayMethodDispatchResponse) => void) | undefined;
+      let rejectFinal: ((error: Error) => void) | undefined;
+      let postAcceptanceError: Error | undefined;
+      // Acceptance publishes the abort owner before this callback runs. Retain that exact
+      // entry so a late deadline cannot cancel a same-run-id successor.
+      let acceptedAbortOwner: { entry: ChatAbortControllerEntry; runId: string } | undefined;
+      let pendingCancelReason: "rpc" | "timeout" | undefined;
+      const cancelAcceptedRun = (reason: "rpc" | "timeout") => {
+        pendingCancelReason ??= reason;
+        const owner = acceptedAbortOwner;
+        if (!owner || context.chatAbortControllers.get(owner.runId) !== owner.entry) {
           return;
         }
-        rejectAcceptance?.(dispatchError);
-      },
-    );
-    const response = (async () => {
-      const first = acceptance ?? (await acceptancePromise);
-      if (
-        dispatchOptions.expectFinal !== true ||
-        (first.payload as { status?: unknown } | undefined)?.status !== "accepted"
-      ) {
-        return first;
-      }
-      dispatchOptions.onAccepted?.(first.payload);
-      if (postAcceptanceError) {
-        throw postAcceptanceError;
-      }
-      return final ?? (await createFinalPromise());
-    })();
-    return await waitForGatewayDispatch(
-      method,
-      response,
-      dispatchOptions.timeoutMs,
-      dispatchOptions.signal,
-      dispatchOptions.cancelOnDeadline || dispatchOptions.onSignalAbort
-        ? async () => {
-            if (dispatchOptions.cancelOnDeadline) {
-              cancelAcceptedRun("rpc");
-            }
-            await dispatchOptions.onSignalAbort?.();
+        abortChatRunById(context, {
+          runId: owner.runId,
+          sessionKey: owner.entry.sessionKey,
+          stopReason: pendingCancelReason,
+        });
+      };
+      const acceptancePromise = new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
+        resolveAcceptance = resolve;
+        rejectAcceptance = reject;
+      });
+      const createFinalPromise = () =>
+        new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
+          resolveFinal = resolve;
+          rejectFinal = reject;
+          if (final) {
+            resolve(final);
           }
-        : undefined,
-      dispatchOptions.cancelOnDeadline ? () => cancelAcceptedRun("timeout") : undefined,
-    );
+        });
+      const io: AgentTurnIo = {
+        emitAcceptance: (frame, meta) => {
+          if (!acceptance) {
+            acceptance = {
+              ok: frame[0],
+              payload: frame[1],
+              error: frame[2],
+              ...(meta ? { meta } : {}),
+            };
+            resolveAcceptance?.(acceptance);
+            const acceptedRunId =
+              typeof meta?.runId === "string" && meta.runId.trim() ? meta.runId.trim() : undefined;
+            const acceptedEntry = acceptedRunId
+              ? context.chatAbortControllers.get(acceptedRunId)
+              : undefined;
+            if (acceptedRunId && acceptedEntry) {
+              acceptedAbortOwner = { entry: acceptedEntry, runId: acceptedRunId };
+              if (pendingCancelReason) {
+                cancelAcceptedRun(pendingCancelReason);
+              }
+            }
+            if (
+              meta?.cached === true &&
+              acceptedRunId &&
+              context.chatAbortControllers.get(acceptedRunId)?.executionStarted === true
+            ) {
+              dispatchOptions.onExecutionStarted?.();
+            }
+          }
+        },
+        emitFinal: (frame, meta) => {
+          if (!final) {
+            final = {
+              ok: frame[0],
+              payload: frame[1],
+              error: frame[2],
+              ...(meta ? { meta } : {}),
+            };
+            resolveFinal?.(final);
+          }
+        },
+        ...(dispatchOptions.onExecutionStarted
+          ? { emitExecutionStarted: dispatchOptions.onExecutionStarted }
+          : {}),
+      };
+      const operation = runWithGatewayRequestEnvelope(
+        method,
+        options.client,
+        async () => {
+          entry?.assertOpen();
+          entry?.release();
+          const principal = captureAgentTurnPrincipal(options.client);
+          const preflight = prepareAgentRequestPreflight({
+            request,
+            context,
+            client: principal,
+            io,
+          });
+          if (!preflight) {
+            return;
+          }
+          const onRunObserved = resolveAgentTurnRunObserver({
+            principal,
+            registerToolEventRecipient: context.registerToolEventRecipient,
+          });
+          await createAgentTurnService(
+            { context, isWebchatConnect },
+            options.assertContextCurrent,
+          ).startTurn({ preflight, principal, io, onRunObserved });
+        },
+        {
+          context,
+          isWebchatConnect,
+          methodRegistry,
+          reject: (error) => io.emitAcceptance([false, undefined, error]),
+        },
+      );
+      void operation.then(
+        () => {
+          if (!acceptance) {
+            rejectAcceptance?.(
+              new Error(`Gateway method "${method}" completed without a response.`),
+            );
+          }
+        },
+        (error: unknown) => {
+          const dispatchError = error instanceof Error ? error : new Error(String(error));
+          if (acceptance) {
+            postAcceptanceError = dispatchError;
+            rejectFinal?.(dispatchError);
+            return;
+          }
+          rejectAcceptance?.(dispatchError);
+        },
+      );
+      const response = (async () => {
+        const first = acceptance ?? (await acceptancePromise);
+        if (
+          dispatchOptions.expectFinal !== true ||
+          (first.payload as { status?: unknown } | undefined)?.status !== "accepted"
+        ) {
+          return first;
+        }
+        dispatchOptions.onAccepted?.(first.payload);
+        if (postAcceptanceError) {
+          throw postAcceptanceError;
+        }
+        return final ?? (await createFinalPromise());
+      })();
+      return await waitForGatewayDispatch(
+        method,
+        response,
+        dispatchOptions.timeoutMs,
+        dispatchOptions.signal,
+        dispatchOptions.cancelOnDeadline || dispatchOptions.onSignalAbort
+          ? async () => {
+              if (dispatchOptions.cancelOnDeadline) {
+                cancelAcceptedRun("rpc");
+              }
+              await dispatchOptions.onSignalAbort?.();
+            }
+          : undefined,
+        dispatchOptions.cancelOnDeadline ? () => cancelAcceptedRun("timeout") : undefined,
+      );
+    } finally {
+      entry?.release();
+    }
   };
 
   const dispatch = async <T = unknown>(
@@ -252,34 +266,48 @@ export function createInternalAgentTurnFacade(
     throwIfGatewayDispatchAborted(method, signal);
     options.assertContextCurrent?.();
     const context = options.getContext();
-    const methodRegistry = getMethodRegistry();
-    const authorization = await authorizeGatewayRequestPreDispatch({
-      method,
-      requestParams: params,
+    const entry = context.requestEntryLifetime?.enter({
+      req: { method, params },
       client: options.client,
       context,
-      methodRegistry,
     });
-    if (authorization.error) {
-      return throwEnvelopeRejection(method, authorization.error);
-    }
-    const validationError = validateGatewayMethodParams(params, validateAgentWaitParams, method);
-    if (validationError) {
-      return throwEnvelopeRejection(method, validationError);
-    }
-    options.assertContextCurrent?.();
-    const result = runWithGatewayRequestEnvelope(
-      method,
-      options.client,
-      () => createAgentTurnService({ context, isWebchatConnect }).waitForTurn(params),
-      {
+    try {
+      const methodRegistry = getMethodRegistry();
+      const authorization = await authorizeGatewayRequestPreDispatch({
+        method,
+        requestParams: params,
+        client: options.client,
         context,
-        isWebchatConnect,
         methodRegistry,
-        reject: (error) => throwEnvelopeRejection(method, error),
-      },
-    );
-    return (await waitForGatewayDispatch(method, result, timeoutMs, signal, onSignalAbort)) as T;
+      });
+      entry?.assertOpen();
+      if (authorization.error) {
+        return throwEnvelopeRejection(method, authorization.error);
+      }
+      const validationError = validateGatewayMethodParams(params, validateAgentWaitParams, method);
+      if (validationError) {
+        return throwEnvelopeRejection(method, validationError);
+      }
+      options.assertContextCurrent?.();
+      const result = runWithGatewayRequestEnvelope(
+        method,
+        options.client,
+        () => {
+          entry?.assertOpen();
+          entry?.release();
+          return createAgentTurnService({ context, isWebchatConnect }).waitForTurn(params);
+        },
+        {
+          context,
+          isWebchatConnect,
+          methodRegistry,
+          reject: (error) => throwEnvelopeRejection(method, error),
+        },
+      );
+      return (await waitForGatewayDispatch(method, result, timeoutMs, signal, onSignalAbort)) as T;
+    } finally {
+      entry?.release();
+    }
   };
 
   return { dispatch, dispatchRaw, wait };

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -698,6 +698,7 @@ export function createGatewayCloseHandler(
       socket: { close: (code: number, reason: string) => void };
     }>;
     configReloader: { stop: () => Promise<void> };
+    finishRequestEntries?: () => Promise<void>;
     wss?: WebSocketServer;
     httpServer?: HttpServer;
     httpServers?: HttpServer[];
@@ -1010,6 +1011,9 @@ export function createGatewayCloseHandler(
           }
         });
       }
+      // Node cleanup replies remain admissible until sockets close. Join their
+      // uncancellable preparation before releasing the remaining process state.
+      await params.finishRequestEntries?.();
       clearSessionTypingState();
       const transportServers =
         params.httpServers && params.httpServers.length > 0
@@ -1051,6 +1055,7 @@ export function createGatewayCloseHandler(
         warnings,
       });
     } finally {
+      await params.finishRequestEntries?.();
       await shutdownStep("plugin-host-registry", clearActivePluginRegistry, warnings);
       // Channel and plugin teardown still resolve account credentials. Keep the
       // active snapshot until every teardown owner is done, then always scrub it.

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -161,49 +161,63 @@ export async function dispatchGatewayRequestInProcessRaw(
     rejectFirstResponse = reject;
   });
   const deadlineMs = resolveDispatchDeadlineMs(options.timeoutMs);
-  const { handleGatewayRequest } = await import("./server-methods.js");
-  void handleGatewayRequest({
-    req: {
-      type: "req",
-      id: `${options.requestIdPrefix ?? "in-process"}-${randomUUID()}`,
-      method,
-      params,
-    },
+  const req = {
+    type: "req" as const,
+    id: `${options.requestIdPrefix ?? "in-process"}-${randomUUID()}`,
+    method,
+    params,
+  };
+  const entry = options.context.requestEntryLifetime?.enter({
+    req,
     client: options.client,
-    isWebchatConnect: options.isWebchatConnect ?? (() => false),
-    respond: (ok, payload, error, meta) => {
-      const response = { ok, payload, error, ...(meta ? { meta } : {}) };
-      if (!firstResponse) {
-        firstResponse = response;
-        resolveFirstResponse?.(response);
-        return;
-      }
-      if (!finalResponse) {
-        finalResponse = response;
-        resolveFinalResponse?.(response);
-      }
-    },
     context: options.context,
-    methodRegistry: options.methodRegistry,
-    sessionMutationCommitGuard: options.sessionMutationCommitGuard,
-    ...(options.signal ? { signal: options.signal } : {}),
-  })
-    .then(() => {
-      if (!firstResponse) {
-        rejectFirstResponse?.(
-          new Error(`Gateway method "${method}" completed without a response.`),
-        );
-      }
+  });
+  try {
+    const { handleGatewayRequest } = await import("./server-methods.js");
+    entry?.assertOpen();
+    void handleGatewayRequest({
+      req,
+      requestEntry: entry,
+      client: options.client,
+      isWebchatConnect: options.isWebchatConnect ?? (() => false),
+      respond: (ok, payload, error, meta) => {
+        const response = { ok, payload, error, ...(meta ? { meta } : {}) };
+        if (!firstResponse) {
+          firstResponse = response;
+          resolveFirstResponse?.(response);
+          return;
+        }
+        if (!finalResponse) {
+          finalResponse = response;
+          resolveFinalResponse?.(response);
+        }
+      },
+      context: options.context,
+      methodRegistry: options.methodRegistry,
+      sessionMutationCommitGuard: options.sessionMutationCommitGuard,
+      ...(options.signal ? { signal: options.signal } : {}),
     })
-    .catch((err: unknown) => {
-      const error = err instanceof Error ? err : new Error(String(err));
-      if (!firstResponse) {
-        rejectFirstResponse?.(error);
-        return;
-      }
-      postFirstResponseError = error;
-      rejectFinalResponse?.(error);
-    });
+      .then(() => {
+        if (!firstResponse) {
+          rejectFirstResponse?.(
+            new Error(`Gateway method "${method}" completed without a response.`),
+          );
+        }
+      })
+      .catch((err: unknown) => {
+        const error = err instanceof Error ? err : new Error(String(err));
+        if (!firstResponse) {
+          rejectFirstResponse?.(error);
+          return;
+        }
+        postFirstResponseError = error;
+        rejectFinalResponse?.(error);
+      })
+      .finally(() => entry?.release());
+  } catch (error) {
+    entry?.release();
+    throw error;
+  }
 
   firstResponse = await waitForDispatch(
     method,

--- a/src/gateway/server-kernel-request-runtime.ts
+++ b/src/gateway/server-kernel-request-runtime.ts
@@ -236,6 +236,7 @@ export async function prepareGatewayKernelRequestRuntime(params: {
       getConfigReloaderHotReloadStatus: kernel.getConfigReloaderHotReloadStatus,
     });
   });
+  gatewayRequestContext.requestEntryLifetime = runtime.requestEntryLifetime;
   bindApprovalPublicationContext(gatewayRequestContext);
   await attachInitialGatewayLifetimeSidecars({
     chatMetadataLifecycle,

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -28,6 +28,7 @@ import {
   type GatewayPluginRuntimeClaim,
 } from "./server-plugin-runtime-generation.js";
 import type { GatewayCloseOptions } from "./server-public.js";
+import { GatewayRequestEntryLifetime } from "./server-request-entry.js";
 import type { prepareGatewayKernelState } from "./server-runtime-state-prepare.js";
 import { runGatewayShutdownSteps } from "./server-shutdown.js";
 import type { GatewayShutdownRuntime } from "./server-shutdown.runtime.js";
@@ -53,6 +54,7 @@ export async function prepareGatewayLifecycle(params: {
   shutdownRuntime: GatewayShutdownRuntime;
 }) {
   const { runtime, port, log, logCron, diagnosticsEnabled, shutdownRuntime } = params;
+  const requestEntryLifetime = new GatewayRequestEntryLifetime();
   const {
     minimalTestGateway,
     transportBridge,
@@ -385,6 +387,7 @@ export async function prepareGatewayLifecycle(params: {
       return;
     }
     lifecycle.closePreludeStarted = true;
+    requestEntryLifetime.beginClose();
     mentionInbox.dispose();
     postReadySidecarStopOwner.beginClose();
     gatewayLifetimeSidecarStopOwner.beginClose();
@@ -413,6 +416,7 @@ export async function prepareGatewayLifecycle(params: {
     // Owners are fenced synchronously above. Join them before any runtime they
     // can publish into is torn down.
     await Promise.all([
+      requestEntryLifetime.waitForPendingEntries(),
       stopDeliveryRecoveryForClose(),
       stopMediaCleanupForClose(),
       runtimeState.stopGatewayUpdateCheck(),
@@ -486,7 +490,7 @@ export async function prepareGatewayLifecycle(params: {
   };
   const createCloseHandler = () => async (optsValue?: GatewayCloseOptions) => {
     try {
-      markClosePreludeStarted();
+      await beginClosePrelude();
       const channelIds = listLoadedChannelPlugins().map((plugin) => plugin.id as ChannelId);
       const transport = transportBridge.current();
       await transport?.portalService.closeAll();
@@ -526,6 +530,7 @@ export async function prepareGatewayLifecycle(params: {
         },
         getPendingReplyCount: getTotalPendingReplies,
         clients,
+        finishRequestEntries: () => requestEntryLifetime.sealAndJoin(),
         configReloader: { stop: stopConfigReloaderForClose },
         ...(transport
           ? {
@@ -543,6 +548,7 @@ export async function prepareGatewayLifecycle(params: {
         closeProviderTransportDispatcherPool: shutdownRuntime.closeProviderTransportDispatcherPool,
       })(optsValue);
     } finally {
+      await requestEntryLifetime.sealAndJoin();
       params.releasePluginMetadata();
     }
   };
@@ -589,6 +595,7 @@ export async function prepareGatewayLifecycle(params: {
 
   return {
     ...runtime,
+    requestEntryLifetime,
     subscribeSessionMessageEvents,
     unsubscribeSessionMessageEvents,
     restartRecoveryCandidates,

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -38,10 +38,6 @@ import {
   resolveLeastPrivilegeOperatorScopesForMethod,
 } from "./method-scopes.js";
 import {
-  listCoreGatewayHandlerMethodNames,
-  type CoreGatewayHandlerFamily,
-} from "./methods/core-descriptors.js";
-import {
   createCoreGatewayMethodDescriptors,
   createGatewayMethodDescriptorsFromHandlers,
   createGatewayMethodRegistry,
@@ -51,8 +47,9 @@ import {
 } from "./methods/registry.js";
 import { isOperatorScope } from "./operator-scopes.js";
 import { isRoleAuthorizedForMethod, parseGatewayRole } from "./role-policy.js";
+import { coreGatewayHandlers } from "./server-methods/core-handlers.js";
 import { authenticatedProfileUnavailableError } from "./server-methods/gateway-client-identity.js";
-import { createLazyCoreHandlers, lazyHandlerModule } from "./server-methods/lazy-core-handlers.js";
+import { prepareGatewayRequestHandler } from "./server-methods/lazy-core-handlers.js";
 import { isTargetedNonSafeGatewayRestartRequest } from "./server-methods/restart-request.js";
 import { withSessionMutationCommitGuard } from "./server-methods/session-mutation-guards.js";
 import type {
@@ -62,6 +59,7 @@ import type {
   GatewayRequestOptions,
   SessionMutationAuthorization,
 } from "./server-methods/types.js";
+import type { GatewayRequestEntry } from "./server-request-entry.js";
 import { sessionMutationTargetFields } from "./session-method-policy.js";
 import { resolveDirectIncognitoTargets } from "./session-sharing-target-input.js";
 import {
@@ -70,200 +68,7 @@ import {
 } from "./session-sharing.js";
 import { classifyGatewayStaleInstall } from "./stale-install.js";
 
-type CoreGatewayHandlerModuleLoader = () => Promise<GatewayRequestHandlers>;
-
-const CORE_GATEWAY_HANDLER_MODULES = {
-  agent: () => import("./server-methods/agent.js").then((module) => module.agentHandlers),
-  "agent-identity": () =>
-    import("./server-methods/agent-identity.js").then((module) => module.agentIdentityHandlers),
-  agents: () => import("./server-methods/agents.js").then((module) => module.agentsHandlers),
-  "agents-workspace": () =>
-    import("./server-methods/agents-workspace.js").then((module) => module.agentsWorkspaceHandlers),
-  artifacts: () =>
-    import("./server-methods/artifacts.js").then((module) => module.artifactsHandlers),
-  board: () => import("./server-methods/board.js").then((module) => module.boardHandlers),
-  audit: () => import("./server-methods/audit.js").then((module) => module.auditHandlers),
-  users: () => import("./server-methods/users.js").then((module) => module.usersHandlers),
-  "users-mentionable": () =>
-    import("./server-methods/users-mentionable.js").then(
-      (module) => module.usersMentionableHandlers,
-    ),
-  attach: () => import("./server-methods/attach.js").then((module) => module.attachHandlers),
-  channels: () => import("./server-methods/channels.js").then((module) => module.channelsHandlers),
-  "channel-pairing": () =>
-    import("./server-methods/channel-pairing.js").then((module) => module.channelPairingHandlers),
-  chat: () => import("./server-methods/chat.js").then((module) => module.chatHandlers),
-  // Cancellation must not wait for unrelated chat history and send workflows to load.
-  "chat-abort": () =>
-    import("./server-methods/chat-abort-handler.js").then((module) => ({
-      "chat.abort": module.handleChatAbortRequest,
-    })),
-  commands: () => import("./server-methods/commands.js").then((module) => module.commandsHandlers),
-  config: () => import("./server-methods/config.js").then((module) => module.configHandlers),
-  conversations: () =>
-    import("./server-methods/conversations.js").then((module) => module.conversationHandlers),
-  connect: () => import("./server-methods/connect.js").then((module) => module.connectHandlers),
-  "control-ui": () =>
-    import("./server-methods/control-ui.js").then((module) => module.controlUiHandlers),
-  cron: () => import("./server-methods/cron.js").then((module) => module.cronHandlers),
-  devices: () => import("./server-methods/devices.js").then((module) => module.deviceHandlers),
-  "device-pair-setup": () =>
-    import("./server-methods/device-pair-setup.js").then(
-      (module) => module.devicePairSetupHandlers,
-    ),
-  diagnostics: () =>
-    import("./server-methods/diagnostics.js").then((module) => module.diagnosticsHandlers),
-  doctor: () =>
-    import("./server-methods/doctor.js").then((module) => module.createDoctorHandlers()),
-  environments: () =>
-    import("./server-methods/environments.js").then((module) => module.environmentsHandlers),
-  worktrees: () =>
-    import("./server-methods/worktrees.js").then((module) => module.worktreesHandlers),
-  "exec-approvals": () =>
-    import("./server-methods/exec-approvals.js").then((module) => module.execApprovalsHandlers),
-  fs: () => import("./server-methods/fs.js").then((module) => module.fsHandlers),
-  health: () => import("./server-methods/health.js").then((module) => module.healthHandlers),
-  logs: () => import("./server-methods/logs.js").then((module) => module.logsHandlers),
-  "memory-search": () =>
-    import("./server-methods/memory-search.js").then((module) => module.memorySearchHandlers),
-  mentions: () => import("./server-methods/mentions.js").then((module) => module.mentionHandlers),
-  terminal: () => import("./server-methods/terminal.js").then((module) => module.terminalHandlers),
-  transcripts: () =>
-    import("./server-methods/transcripts.js").then((module) => module.transcriptsHandlers),
-  "ui-command": () =>
-    import("./server-methods/ui-command.js").then((module) => module.uiCommandHandlers),
-  "models-auth-status": () =>
-    import("./server-methods/models-auth-status.js").then(
-      (module) => module.modelsAuthStatusHandlers,
-    ),
-  "models-auth-order": () =>
-    import("./server-methods/models-auth-order.js").then(
-      (module) => module.modelsAuthOrderHandlers,
-    ),
-  models: () => import("./server-methods/models.js").then((module) => module.modelsHandlers),
-  "models-probe": () =>
-    import("./server-methods/models-probe.js").then((module) => module.modelsProbeHandlers),
-  "native-hook-relay": () =>
-    import("./server-methods/native-hook-relay.js").then(
-      (module) => module.nativeHookRelayHandlers,
-    ),
-  "nodes-pending": () =>
-    import("./server-methods/nodes.pending-work.js").then(
-      (module) => module.nodePendingWorkHandlers,
-    ),
-  nodes: () => import("./server-methods/nodes.js").then((module) => module.nodeHandlers),
-  "plugin-host-hooks": () =>
-    import("./server-methods/plugin-host-hooks.js").then((module) => module.pluginHostHookHandlers),
-  plugins: () => import("./server-methods/plugins.js").then((module) => module.pluginsHandlers),
-  projects: () => import("./server-methods/projects.js").then((module) => module.projectsHandlers),
-  portals: () => import("./server-methods/portals.js").then((module) => module.portalHandlers),
-  "progress-card": () =>
-    import("./server-methods/progress-card.js").then((module) => module.progressCardHandlers),
-  migrations: () =>
-    import("./server-methods/migrations.js").then((module) => module.migrationsHandlers),
-  push: () => import("./server-methods/push.js").then((module) => module.pushHandlers),
-  restart: () => import("./server-methods/restart.js").then((module) => module.restartHandlers),
-  suspend: () => import("./server-methods/suspend.js").then((module) => module.suspendHandlers),
-  send: () => import("./server-methods/send.js").then((module) => module.sendHandlers),
-  "sessions-files": () =>
-    import("./server-methods/sessions-files.js").then((module) => module.sessionsFilesHandlers),
-  "sessions-github": () =>
-    import("./server-methods/sessions-github.js").then((module) => module.sessionsGitHubHandlers),
-  "sessions-diff": () =>
-    import("./server-methods/sessions-diff.js").then((module) => module.sessionsDiffHandlers),
-  "sessions-abort": () =>
-    import("./server-methods/sessions-abort.js").then((module) => module.sessionAbortHandlers),
-  "sessions-compact": () =>
-    import("./server-methods/sessions-compact.js").then((module) => module.sessionCompactHandlers),
-  "sessions-compaction-checkpoints": () =>
-    import("./server-methods/sessions-compaction-checkpoints.js").then(
-      (module) => module.sessionCheckpointHandlers,
-    ),
-  "sessions-compaction-queries": () =>
-    import("./server-methods/sessions-compaction-queries.js").then(
-      (module) => module.sessionCheckpointQueryHandlers,
-    ),
-  "sessions-create": () =>
-    import("./server-methods/sessions-create.js").then((module) => module.sessionCreateHandlers),
-  "sessions-title": () =>
-    import("./server-methods/sessions-title.js").then((module) => module.sessionTitleHandlers),
-  "sessions-recover": () =>
-    import("./server-methods/sessions-recover.js").then((module) => module.sessionRecoverHandlers),
-  "sessions-delete": () =>
-    import("./server-methods/sessions-delete.js").then((module) => module.sessionDeleteHandlers),
-  "sessions-dispatch": () =>
-    import("./server-methods/sessions-dispatch.js").then(
-      (module) => module.sessionDispatchHandlers,
-    ),
-  "sessions-groups": () =>
-    import("./server-methods/sessions-groups.js").then((module) => module.sessionGroupHandlers),
-  "sessions-goal": () =>
-    import("./server-methods/sessions-goal.js").then((module) => module.sessionGoalHandlers),
-  "sessions-messaging": () =>
-    import("./server-methods/sessions-messaging.js").then(
-      (module) => module.sessionMessagingHandlers,
-    ),
-  "sessions-mutations": () =>
-    import("./server-methods/sessions-mutations.js").then(
-      (module) => module.sessionMutationHandlers,
-    ),
-  "sessions-read": () =>
-    import("./server-methods/sessions-read.js").then((module) => module.sessionReadHandlers),
-  "sessions-rewind": () =>
-    import("./server-methods/sessions-rewind.js").then((module) => module.sessionRewindHandlers),
-  "sessions-sharing": () =>
-    import("./server-methods/sessions-sharing.js").then((module) => module.sessionSharingHandlers),
-  "sessions-subscriptions": () =>
-    import("./server-methods/sessions-subscriptions.js").then(
-      (module) => module.sessionSubscriptionHandlers,
-    ),
-  "sessions-suggestions": () =>
-    import("./server-methods/sessions-suggestions.js").then(
-      (module) => module.sessionSuggestionHandlers,
-    ),
-  "session-catalog": () =>
-    import("./server-methods/session-catalog.js").then((module) => module.sessionCatalogHandlers),
-  "session-discussion": () =>
-    import("./server-methods/session-discussion.js").then(
-      (module) => module.sessionDiscussionHandlers,
-    ),
-  "session-observer-rpc": () =>
-    import("./session-observer-rpc.js").then((module) => module.sessionObserverHandlers),
-  "session-companion-rpc": () =>
-    import("./session-companion-rpc.js").then((module) => module.sessionCompanionHandlers),
-  "hooks-status": () =>
-    import("./server-methods/hooks-status.js").then((module) => module.hooksStatusHandlers),
-  skills: () => import("./server-methods/skills.js").then((module) => module.skillsHandlers),
-  system: () => import("./server-methods/system.js").then((module) => module.systemHandlers),
-  talk: () => import("./server-methods/talk.js").then((module) => module.talkHandlers),
-  tasks: () => import("./server-methods/tasks.js").then((module) => module.tasksHandlers),
-  "task-suggestions": () =>
-    import("./server-methods/task-suggestions.js").then((module) => module.taskSuggestionsHandlers),
-  "tools-catalog": () =>
-    import("./server-methods/tools-catalog.js").then((module) => module.toolsCatalogHandlers),
-  "tools-github": () =>
-    import("./server-methods/tools-github.js").then((module) => module.toolsGitHubHandlers),
-  "tools-effective": () =>
-    import("./server-methods/tools-effective.js").then((module) => module.toolsEffectiveHandlers),
-  "tools-invoke": () =>
-    import("./server-methods/tools-invoke.js").then((module) => module.toolsInvokeHandlers),
-  "mcp-app": () => import("./server-methods/mcp-app.js").then((module) => module.mcpAppHandlers),
-  tts: () => import("./server-methods/tts.js").then((module) => module.ttsHandlers),
-  update: () => import("./server-methods/update.js").then((module) => module.updateHandlers),
-  usage: () => import("./server-methods/usage.js").then((module) => module.usageHandlers),
-  "voicewake-routing": () =>
-    import("./server-methods/voicewake-routing.js").then(
-      (module) => module.voicewakeRoutingHandlers,
-    ),
-  voicewake: () =>
-    import("./server-methods/voicewake.js").then((module) => module.voicewakeHandlers),
-  web: () => import("./server-methods/web.js").then((module) => module.webHandlers),
-  "system-agent": () =>
-    import("./server-methods/system-agent.js").then((module) => module.systemAgentHandlers),
-  "system-changes": () =>
-    import("./server-methods/system-changes.js").then((module) => module.systemChangesHandlers),
-  wizard: () => import("./server-methods/wizard.js").then((module) => module.wizardHandlers),
-} satisfies Record<CoreGatewayHandlerFamily, CoreGatewayHandlerModuleLoader>;
+export { coreGatewayHandlers };
 
 function authorizeGatewayMethod(
   method: string,
@@ -405,22 +210,6 @@ async function authorizeAuthenticatedProfileForMethod(params: {
     ? null
     : authenticatedProfileUnavailableError();
 }
-
-const coreGatewayHandlerMethodNames = listCoreGatewayHandlerMethodNames();
-const coreGatewayHandlerModules = Object.entries(CORE_GATEWAY_HANDLER_MODULES) as Array<
-  [CoreGatewayHandlerFamily, CoreGatewayHandlerModuleLoader]
->;
-
-export const coreGatewayHandlers: GatewayRequestHandlers = Object.fromEntries(
-  coreGatewayHandlerModules.flatMap(([family, loadModule]) =>
-    Object.entries(
-      createLazyCoreHandlers({
-        methods: coreGatewayHandlerMethodNames.get(family) ?? [],
-        loadHandlers: lazyHandlerModule(loadModule, (handlers) => handlers),
-      }),
-    ),
-  ),
-);
 
 /** Builds the per-request method registry from core, plugin, and explicit extra handlers. */
 export function createRequestGatewayMethodRegistry(
@@ -681,59 +470,81 @@ export async function runWithGatewayRequestEnvelope<T>(
 
 /** Authorizes and dispatches one gateway JSON-RPC-style request. */
 export async function handleGatewayRequest(
-  opts: GatewayRequestOptions & { extraHandlers?: GatewayRequestHandlers },
+  opts: GatewayRequestOptions & {
+    extraHandlers?: GatewayRequestHandlers;
+    requestEntry?: GatewayRequestEntry;
+  },
 ): Promise<void> {
   const { req, respond, client, isWebchatConnect, context, signal } = opts;
-  // Prefer the caller-attached registry when it owns the requested method so plugin dispatch
-  // metadata newer than global runtime state still authorizes and dispatches correctly. When the
-  // attached snapshot does not own the method, rebuild from the process-root registry so late
-  // methods remain reachable (#94127).
-  const methodRegistry =
-    opts.methodRegistry?.getHandler(req.method) !== undefined
-      ? opts.methodRegistry
-      : createRequestGatewayMethodRegistry(opts.extraHandlers);
-  const authorization = await authorizeGatewayRequestPreDispatch({
-    method: req.method,
-    requestParams: req.params,
-    client,
-    context,
-    methodRegistry,
-  });
-  if (authorization.error) {
-    respond(false, undefined, authorization.error);
-    return;
-  }
-  const handler = methodRegistry.getHandler(req.method) as GatewayRequestHandler | undefined;
-  if (!handler) {
-    const error = errorShape(ErrorCodes.INVALID_REQUEST, `unknown method: ${req.method}`);
-    respond(false, undefined, error);
-    return;
-  }
-  // Every session mutation owner uses these pre-commit assertions. Compose the
-  // host lifetime here so individual handlers cannot lose it across an await.
-  const sessionMutationAuthorization = withSessionMutationCommitGuard(
-    authorization.sessionMutationAuthorization,
-    opts.sessionMutationCommitGuard,
-  );
-  const invokeHandler = () => {
-    opts.sessionMutationCommitGuard?.();
-    return handler({
-      req,
-      params: (req.params ?? {}) as Record<string, unknown>,
+  const entry = opts.requestEntry ?? context.requestEntryLifetime?.enter(opts);
+  try {
+    entry?.assertOpen();
+    // Prefer the caller-attached registry when it owns the requested method so plugin dispatch
+    // metadata newer than global runtime state still authorizes and dispatches correctly. When the
+    // attached snapshot does not own the method, rebuild from the process-root registry so late
+    // methods remain reachable (#94127).
+    const methodRegistry =
+      opts.methodRegistry?.getHandler(req.method) !== undefined
+        ? opts.methodRegistry
+        : createRequestGatewayMethodRegistry(opts.extraHandlers);
+    const authorization = await authorizeGatewayRequestPreDispatch({
+      method: req.method,
+      requestParams: req.params,
       client,
-      isWebchatConnect,
-      respond,
       context,
-      signal,
-      sessionMutationCommitGuard: opts.sessionMutationCommitGuard,
-      sessionMutationAuthorization,
+      methodRegistry,
     });
-  };
-  await runWithGatewayRequestEnvelope(req.method, client, invokeHandler, {
-    context,
-    isWebchatConnect,
-    methodRegistry,
-    requestParams: req.params,
-    reject: (error) => respond(false, undefined, error),
-  });
+    entry?.assertOpen();
+    if (authorization.error) {
+      respond(false, undefined, authorization.error);
+      return;
+    }
+    const handler = methodRegistry.getHandler(req.method) as GatewayRequestHandler | undefined;
+    if (!handler) {
+      const error = errorShape(ErrorCodes.INVALID_REQUEST, `unknown method: ${req.method}`);
+      respond(false, undefined, error);
+      return;
+    }
+    // Every session mutation owner uses these pre-commit assertions. Compose the
+    // host lifetime here so individual handlers cannot lose it across an await.
+    const sessionMutationAuthorization = withSessionMutationCommitGuard(
+      authorization.sessionMutationAuthorization,
+      opts.sessionMutationCommitGuard,
+    );
+    const invokeHandler = async () => {
+      const preparedHandler = await prepareGatewayRequestHandler(handler, entry);
+      const handlerOptions = {
+        req,
+        params: (req.params ?? {}) as Record<string, unknown>,
+        client,
+        isWebchatConnect,
+        respond,
+        context,
+        signal,
+        sessionMutationCommitGuard: opts.sessionMutationCommitGuard,
+        sessionMutationAuthorization,
+      };
+      opts.sessionMutationCommitGuard?.();
+      entry?.assertOpen();
+      if (signal?.aborted) {
+        return;
+      }
+      // No await between the final fence, ownership handoff, and actual invocation.
+      // Long polls and shutdown initiators must never remain preparation leases.
+      entry?.release();
+      return preparedHandler(handlerOptions);
+    };
+    await runWithGatewayRequestEnvelope(req.method, client, invokeHandler, {
+      context,
+      isWebchatConnect,
+      methodRegistry,
+      requestParams: req.params,
+      reject: (error) => respond(false, undefined, error),
+    });
+  } finally {
+    // Transport/import owners retain failures through their response and logging paths.
+    if (!opts.requestEntry) {
+      entry?.release();
+    }
+  }
 }

--- a/src/gateway/server-methods/core-handlers.ts
+++ b/src/gateway/server-methods/core-handlers.ts
@@ -1,0 +1,169 @@
+// Lazy core handler families keep gateway startup metadata-only until first use.
+import { createLazyPromise } from "../../shared/lazy-promise.js";
+import {
+  listCoreGatewayHandlerMethodNames,
+  type CoreGatewayHandlerFamily,
+} from "../methods/core-descriptors.js";
+import { createLazyCoreHandlers } from "./lazy-core-handlers.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+type CoreGatewayHandlerModuleLoader = () => Promise<GatewayRequestHandlers>;
+
+const CORE_GATEWAY_HANDLER_MODULES = {
+  agent: () => import("./agent.js").then((module) => module.agentHandlers),
+  "agent-identity": () =>
+    import("./agent-identity.js").then((module) => module.agentIdentityHandlers),
+  agents: () => import("./agents.js").then((module) => module.agentsHandlers),
+  "agents-workspace": () =>
+    import("./agents-workspace.js").then((module) => module.agentsWorkspaceHandlers),
+  artifacts: () => import("./artifacts.js").then((module) => module.artifactsHandlers),
+  board: () => import("./board.js").then((module) => module.boardHandlers),
+  audit: () => import("./audit.js").then((module) => module.auditHandlers),
+  users: () => import("./users.js").then((module) => module.usersHandlers),
+  "users-mentionable": () =>
+    import("./users-mentionable.js").then((module) => module.usersMentionableHandlers),
+  attach: () => import("./attach.js").then((module) => module.attachHandlers),
+  channels: () => import("./channels.js").then((module) => module.channelsHandlers),
+  "channel-pairing": () =>
+    import("./channel-pairing.js").then((module) => module.channelPairingHandlers),
+  chat: () => import("./chat.js").then((module) => module.chatHandlers),
+  // Cancellation must not wait for unrelated chat history and send workflows to load.
+  "chat-abort": () =>
+    import("./chat-abort-handler.js").then((module) => ({
+      "chat.abort": module.handleChatAbortRequest,
+    })),
+  commands: () => import("./commands.js").then((module) => module.commandsHandlers),
+  config: () => import("./config.js").then((module) => module.configHandlers),
+  conversations: () => import("./conversations.js").then((module) => module.conversationHandlers),
+  connect: () => import("./connect.js").then((module) => module.connectHandlers),
+  "control-ui": () => import("./control-ui.js").then((module) => module.controlUiHandlers),
+  cron: () => import("./cron.js").then((module) => module.cronHandlers),
+  devices: () => import("./devices.js").then((module) => module.deviceHandlers),
+  "device-pair-setup": () =>
+    import("./device-pair-setup.js").then((module) => module.devicePairSetupHandlers),
+  diagnostics: () => import("./diagnostics.js").then((module) => module.diagnosticsHandlers),
+  doctor: () => import("./doctor.js").then((module) => module.createDoctorHandlers()),
+  environments: () => import("./environments.js").then((module) => module.environmentsHandlers),
+  worktrees: () => import("./worktrees.js").then((module) => module.worktreesHandlers),
+  "exec-approvals": () =>
+    import("./exec-approvals.js").then((module) => module.execApprovalsHandlers),
+  fs: () => import("./fs.js").then((module) => module.fsHandlers),
+  health: () => import("./health.js").then((module) => module.healthHandlers),
+  logs: () => import("./logs.js").then((module) => module.logsHandlers),
+  "memory-search": () => import("./memory-search.js").then((module) => module.memorySearchHandlers),
+  mentions: () => import("./mentions.js").then((module) => module.mentionHandlers),
+  terminal: () => import("./terminal.js").then((module) => module.terminalHandlers),
+  transcripts: () => import("./transcripts.js").then((module) => module.transcriptsHandlers),
+  "ui-command": () => import("./ui-command.js").then((module) => module.uiCommandHandlers),
+  "models-auth-status": () =>
+    import("./models-auth-status.js").then((module) => module.modelsAuthStatusHandlers),
+  "models-auth-order": () =>
+    import("./models-auth-order.js").then((module) => module.modelsAuthOrderHandlers),
+  models: () => import("./models.js").then((module) => module.modelsHandlers),
+  "models-probe": () => import("./models-probe.js").then((module) => module.modelsProbeHandlers),
+  "native-hook-relay": () =>
+    import("./native-hook-relay.js").then((module) => module.nativeHookRelayHandlers),
+  "nodes-pending": () =>
+    import("./nodes.pending-work.js").then((module) => module.nodePendingWorkHandlers),
+  nodes: () => import("./nodes.js").then((module) => module.nodeHandlers),
+  "plugin-host-hooks": () =>
+    import("./plugin-host-hooks.js").then((module) => module.pluginHostHookHandlers),
+  plugins: () => import("./plugins.js").then((module) => module.pluginsHandlers),
+  projects: () => import("./projects.js").then((module) => module.projectsHandlers),
+  portals: () => import("./portals.js").then((module) => module.portalHandlers),
+  "progress-card": () => import("./progress-card.js").then((module) => module.progressCardHandlers),
+  migrations: () => import("./migrations.js").then((module) => module.migrationsHandlers),
+  push: () => import("./push.js").then((module) => module.pushHandlers),
+  restart: () => import("./restart.js").then((module) => module.restartHandlers),
+  suspend: () => import("./suspend.js").then((module) => module.suspendHandlers),
+  send: () => import("./send.js").then((module) => module.sendHandlers),
+  "sessions-files": () =>
+    import("./sessions-files.js").then((module) => module.sessionsFilesHandlers),
+  "sessions-github": () =>
+    import("./sessions-github.js").then((module) => module.sessionsGitHubHandlers),
+  "sessions-diff": () => import("./sessions-diff.js").then((module) => module.sessionsDiffHandlers),
+  "sessions-abort": () =>
+    import("./sessions-abort.js").then((module) => module.sessionAbortHandlers),
+  "sessions-compact": () =>
+    import("./sessions-compact.js").then((module) => module.sessionCompactHandlers),
+  "sessions-compaction-checkpoints": () =>
+    import("./sessions-compaction-checkpoints.js").then(
+      (module) => module.sessionCheckpointHandlers,
+    ),
+  "sessions-compaction-queries": () =>
+    import("./sessions-compaction-queries.js").then(
+      (module) => module.sessionCheckpointQueryHandlers,
+    ),
+  "sessions-create": () =>
+    import("./sessions-create.js").then((module) => module.sessionCreateHandlers),
+  "sessions-title": () =>
+    import("./sessions-title.js").then((module) => module.sessionTitleHandlers),
+  "sessions-recover": () =>
+    import("./sessions-recover.js").then((module) => module.sessionRecoverHandlers),
+  "sessions-delete": () =>
+    import("./sessions-delete.js").then((module) => module.sessionDeleteHandlers),
+  "sessions-dispatch": () =>
+    import("./sessions-dispatch.js").then((module) => module.sessionDispatchHandlers),
+  "sessions-groups": () =>
+    import("./sessions-groups.js").then((module) => module.sessionGroupHandlers),
+  "sessions-goal": () => import("./sessions-goal.js").then((module) => module.sessionGoalHandlers),
+  "sessions-messaging": () =>
+    import("./sessions-messaging.js").then((module) => module.sessionMessagingHandlers),
+  "sessions-mutations": () =>
+    import("./sessions-mutations.js").then((module) => module.sessionMutationHandlers),
+  "sessions-read": () => import("./sessions-read.js").then((module) => module.sessionReadHandlers),
+  "sessions-rewind": () =>
+    import("./sessions-rewind.js").then((module) => module.sessionRewindHandlers),
+  "sessions-sharing": () =>
+    import("./sessions-sharing.js").then((module) => module.sessionSharingHandlers),
+  "sessions-subscriptions": () =>
+    import("./sessions-subscriptions.js").then((module) => module.sessionSubscriptionHandlers),
+  "sessions-suggestions": () =>
+    import("./sessions-suggestions.js").then((module) => module.sessionSuggestionHandlers),
+  "session-catalog": () =>
+    import("./session-catalog.js").then((module) => module.sessionCatalogHandlers),
+  "session-discussion": () =>
+    import("./session-discussion.js").then((module) => module.sessionDiscussionHandlers),
+  "session-observer-rpc": () =>
+    import("../session-observer-rpc.js").then((module) => module.sessionObserverHandlers),
+  "session-companion-rpc": () =>
+    import("../session-companion-rpc.js").then((module) => module.sessionCompanionHandlers),
+  "hooks-status": () => import("./hooks-status.js").then((module) => module.hooksStatusHandlers),
+  skills: () => import("./skills.js").then((module) => module.skillsHandlers),
+  system: () => import("./system.js").then((module) => module.systemHandlers),
+  talk: () => import("./talk.js").then((module) => module.talkHandlers),
+  tasks: () => import("./tasks.js").then((module) => module.tasksHandlers),
+  "task-suggestions": () =>
+    import("./task-suggestions.js").then((module) => module.taskSuggestionsHandlers),
+  "tools-catalog": () => import("./tools-catalog.js").then((module) => module.toolsCatalogHandlers),
+  "tools-github": () => import("./tools-github.js").then((module) => module.toolsGitHubHandlers),
+  "tools-effective": () =>
+    import("./tools-effective.js").then((module) => module.toolsEffectiveHandlers),
+  "tools-invoke": () => import("./tools-invoke.js").then((module) => module.toolsInvokeHandlers),
+  "mcp-app": () => import("./mcp-app.js").then((module) => module.mcpAppHandlers),
+  tts: () => import("./tts.js").then((module) => module.ttsHandlers),
+  update: () => import("./update.js").then((module) => module.updateHandlers),
+  usage: () => import("./usage.js").then((module) => module.usageHandlers),
+  "voicewake-routing": () =>
+    import("./voicewake-routing.js").then((module) => module.voicewakeRoutingHandlers),
+  voicewake: () => import("./voicewake.js").then((module) => module.voicewakeHandlers),
+  web: () => import("./web.js").then((module) => module.webHandlers),
+  "system-agent": () => import("./system-agent.js").then((module) => module.systemAgentHandlers),
+  "system-changes": () =>
+    import("./system-changes.js").then((module) => module.systemChangesHandlers),
+  wizard: () => import("./wizard.js").then((module) => module.wizardHandlers),
+} satisfies Record<CoreGatewayHandlerFamily, CoreGatewayHandlerModuleLoader>;
+
+export const coreGatewayHandlers: GatewayRequestHandlers = Object.fromEntries(
+  Array.from(listCoreGatewayHandlerMethodNames()).flatMap(([family, methods]) =>
+    Object.entries(
+      createLazyCoreHandlers({
+        methods,
+        // Failed family imports stay cached until restart, just like successful loads.
+        loadHandlers: createLazyPromise(CORE_GATEWAY_HANDLER_MODULES[family], {
+          cacheRejections: true,
+        }),
+      }),
+    ),
+  ),
+);

--- a/src/gateway/server-methods/lazy-core-handlers.ts
+++ b/src/gateway/server-methods/lazy-core-handlers.ts
@@ -1,13 +1,21 @@
-// Lazy core handler families keep gateway startup metadata-only until first use.
-import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
+import type { GatewayRequestEntry } from "../server-request-entry.js";
+import type { GatewayRequestHandler, GatewayRequestHandlers } from "./types.js";
 
-export function lazyHandlerModule<T>(
-  loadModule: () => Promise<T>,
-  selectHandlers: (module: T) => GatewayRequestHandlers,
-): () => Promise<GatewayRequestHandlers> {
-  let handlersPromise: Promise<GatewayRequestHandlers> | null = null;
-  // Cache the first import so concurrent calls to one family share its load.
-  return () => (handlersPromise ??= loadModule().then(selectHandlers));
+const preparations = new WeakMap<GatewayRequestHandler, () => Promise<GatewayRequestHandler>>();
+
+/** Resolve forwarding wrappers without mistaking them for actual handler entry. */
+export async function prepareGatewayRequestHandler(
+  handler: GatewayRequestHandler,
+  entry?: GatewayRequestEntry,
+): Promise<GatewayRequestHandler> {
+  let preparedHandler = handler;
+  let prepare = preparations.get(preparedHandler);
+  while (prepare) {
+    entry?.assertOpen();
+    preparedHandler = await prepare();
+    prepare = preparations.get(preparedHandler);
+  }
+  return preparedHandler;
 }
 
 export function createLazyCoreHandlers(params: {
@@ -15,17 +23,28 @@ export function createLazyCoreHandlers(params: {
   loadHandlers: () => Promise<GatewayRequestHandlers>;
 }): GatewayRequestHandlers {
   return Object.fromEntries(
-    params.methods.map((method) => [
-      method,
-      async (opts: GatewayRequestHandlerOptions) => {
+    params.methods.map((method) => {
+      const forwarding: GatewayRequestHandler = async (opts) => {
+        const entry = opts.context.requestEntryLifetime?.enter(opts);
+        try {
+          const handler = await prepareGatewayRequestHandler(forwarding, entry);
+          entry?.assertOpen();
+          entry?.release();
+          await handler(opts);
+        } finally {
+          entry?.release();
+        }
+      };
+      preparations.set(forwarding, async () => {
         const handlers = await params.loadHandlers();
         const handler = handlers[method];
         if (!handler) {
           // Advertised core methods must exist once their family resolves.
           throw new Error(`lazy gateway handler not found: ${method}`);
         }
-        await handler(opts);
-      },
-    ]),
+        return handler;
+      });
+      return [method, forwarding];
+    }),
   );
 }

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -401,6 +401,11 @@ export type GatewayRequestContext = GatewayKernelContext &
     /** Live instance routing only; never authorization or wire state. */
     resolveGatewayContext?: GatewayContextResolver;
     hostLifecycle?: import("../server-public.js").GatewayHostLifecycle;
+    /** Entry-only access; the kernel owns closure. Absent in embedded-only contexts. */
+    requestEntryLifetime?: Pick<
+      import("../server-request-entry.js").GatewayRequestEntryLifetime,
+      "enter" | "signal"
+    >;
   };
 
 /** Full dispatch context for raw request frames before params are normalized. */

--- a/src/gateway/server-request-entry.test.ts
+++ b/src/gateway/server-request-entry.test.ts
@@ -1,0 +1,443 @@
+import { EventEmitter } from "node:events";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+} from "../process/gateway-work-admission.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { getFreePort } from "../test-utils/ports.js";
+import { createInternalAgentTurnFacade } from "./agent-turn/internal-facade.js";
+import { createGatewayMethodRegistry } from "./methods/registry.js";
+import { NodeRegistry } from "./node-registry.js";
+import { dispatchGatewayRequestInProcessRaw } from "./server-in-process-dispatch.js";
+import { createGatewayKernel } from "./server-kernel.js";
+import { createLazyCoreHandlers } from "./server-methods/lazy-core-handlers.js";
+import type { GatewayRequestHandler } from "./server-methods/types.js";
+import {
+  createDispatchTestHarness,
+  createOperatorWsClient,
+} from "./server/ws-connection/authenticated-request-dispatch.test-support.js";
+
+const boundaries = vi.hoisted(() => ({
+  router: vi.fn<() => Promise<void>>(),
+  start: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock(
+  "./server/ws-connection/authenticated-request-dispatch.server-methods.runtime.js",
+  async () => {
+    await boundaries.router();
+    return await import("./server-methods.js");
+  },
+);
+vi.mock("./server/ws-connection/request-start.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./server/ws-connection/request-start.js")>();
+  return {
+    ...actual,
+    scheduleGatewayRequestStart: (bytes: number) => {
+      const started = actual.scheduleGatewayRequestStart(bytes);
+      return started?.then(() => boundaries.start()) ?? null;
+    },
+  };
+});
+
+describe.sequential("Gateway request entry lifetime", () => {
+  let state: Awaited<ReturnType<typeof createOpenClawTestState>>;
+  let kernel: Awaited<ReturnType<typeof createGatewayKernel>>;
+  let port: number;
+
+  beforeAll(async () => {
+    state = await createOpenClawTestState({
+      label: "gateway-request-entry",
+      layout: "home",
+      env: {
+        OPENCLAW_GATEWAY_PASSWORD: undefined,
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        VITEST: "1",
+      },
+    });
+    port = await getFreePort();
+    await state.writeConfig({
+      gateway: {
+        auth: { mode: "token", token: "request-entry-test" },
+        controlUi: { enabled: false },
+        port,
+      },
+    });
+    state.applyEnv();
+  });
+  beforeEach(async () => {
+    boundaries.router.mockReset();
+    boundaries.start.mockReset();
+    kernel = await createGatewayKernel(port, {
+      auth: { mode: "token", token: "request-entry-test" },
+      bind: "loopback",
+      controlUiEnabled: false,
+      sidecarStartup: "defer",
+    });
+    kernel.kernel.setDispatchReady(true);
+  });
+  afterEach(async () => {
+    await kernel?.closeOnStartupFailure();
+  });
+  afterAll(async () => {
+    await state?.cleanup();
+  });
+
+  it.each(["router", "start", "profile", "family", "family rejection", "nested family"] as const)(
+    "joins %s preparation and rejects handler entry before close returns",
+    async (boundary) => {
+      const held = createDeferredCore();
+      const reached = createDeferredCore();
+      const pause = async () => {
+        reached.resolve();
+        await held.promise;
+      };
+      const handler = vi.fn<GatewayRequestHandler>(({ respond }) =>
+        respond(true, { entered: true }),
+      );
+      const client = createOperatorWsClient();
+      const lazy = createLazyCoreHandlers({
+        methods: ["test.entry"],
+        loadHandlers: async () => {
+          if (boundary === "nested family") {
+            return createLazyCoreHandlers({
+              methods: ["test.entry"],
+              loadHandlers: async () => {
+                await pause();
+                return { "test.entry": handler };
+              },
+            });
+          }
+          if (boundary.startsWith("family")) {
+            await pause();
+          }
+          if (boundary === "family rejection") {
+            throw new Error("expected family preparation failure");
+          }
+          return { "test.entry": handler };
+        },
+      });
+      if (boundary === "router" || boundary === "start") {
+        boundaries[boundary].mockImplementation(pause);
+      } else if (boundary === "profile") {
+        client.authenticatedGitHubIdentitySync = async () => {
+          await pause();
+          client.authenticatedUserProfile = {
+            profileId: "entry-profile",
+            displayName: "Entry",
+            avatarRevision: "entry-avatar",
+            hasAvatar: false,
+            updatedAt: 1,
+          };
+          return { profileId: "entry-profile", updatedAt: 1 };
+        };
+      }
+      const harness = createDispatchTestHarness({
+        buildRequestContext: () => kernel.gatewayRequestContext,
+        extraHandlers: lazy,
+      });
+      let closeSettled = false;
+      let closing: Promise<void> | undefined;
+      const lateResponses: unknown[] = [];
+      harness.send.mockImplementation((frame) => {
+        if (closeSettled) {
+          lateResponses.push(frame);
+        }
+        return { kind: "sent" };
+      });
+      const lateErrors: string[] = [];
+      harness.logGateway.error.mockImplementation((message) => {
+        if (closeSettled) {
+          lateErrors.push(message);
+        }
+      });
+      try {
+        await harness.dispatcher.dispatch(
+          { type: "req", id: "held", method: "test.entry", params: {} },
+          client,
+        );
+        await reached.promise;
+        closing = kernel.beginClosePrelude().then(() => {
+          closeSettled = true;
+        });
+        await nextTurn();
+        expect.soft(closeSettled).toBe(false);
+        held.resolve();
+        await harness.awaitResponseFrame("held");
+        await closing;
+        expect.soft(handler).not.toHaveBeenCalled();
+        expect.soft(lateResponses).toEqual([]);
+        expect.soft(lateErrors).toEqual([]);
+      } finally {
+        held.resolve();
+        await harness.awaitResponseFrame("held");
+        await closing;
+      }
+    },
+  );
+
+  it.each(["test.entry", "device.token.rotate"])(
+    "refuses credential-barrier waiter %s before joining close without draining its predecessor",
+    async (method) => {
+      const held = createDeferredCore();
+      const reached = createDeferredCore();
+      const finished = createDeferredCore();
+      let mutationFinished = false;
+      const mutation = vi.fn<GatewayRequestHandler>(async ({ respond }) => {
+        reached.resolve();
+        try {
+          await held.promise;
+          respond(true, { mutated: true });
+        } finally {
+          mutationFinished = true;
+          finished.resolve();
+        }
+      });
+      const waiter = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true));
+      const client = createOperatorWsClient();
+      const harness = createDispatchTestHarness({
+        buildRequestContext: () => kernel.gatewayRequestContext,
+        extraHandlers: { "device.token.revoke": mutation, [method]: waiter },
+      });
+      const events: string[] = [];
+      harness.send.mockImplementation(() => {
+        events.push("response");
+        return { kind: "sent" };
+      });
+      let queued: Promise<void> | undefined;
+      let closing: Promise<void> | undefined;
+      try {
+        await harness.dispatcher.dispatch(
+          { type: "req", id: "mutation", method: "device.token.revoke", params: {} },
+          client,
+        );
+        await reached.promise;
+        queued = harness.dispatcher.dispatch({ type: "req", id: "waiting", method }, client);
+        await nextTurn();
+        expect(waiter).not.toHaveBeenCalled();
+        expect(harness.send).not.toHaveBeenCalled();
+        closing = kernel.beginClosePrelude().then(() => {
+          events.push("closed");
+        });
+        await vi.waitFor(() => expect(events).toContain("closed"));
+        expect.soft(events).toEqual(["response", "closed"]);
+        expect(harness.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: "waiting",
+            ok: false,
+            error: expect.objectContaining({ code: "UNAVAILABLE", retryable: true }),
+          }),
+        );
+        expect(harness.close).not.toHaveBeenCalled();
+        expect(waiter).not.toHaveBeenCalled();
+        expect(mutationFinished).toBe(false);
+        expect(mutation.mock.calls[0]?.[0].signal).toBeUndefined();
+      } finally {
+        held.resolve();
+        await finished.promise;
+        await queued;
+        await closing;
+        await harness.awaitResponseFrame("mutation");
+        await nextTurn();
+      }
+    },
+  );
+
+  it("permits ordinary entry after disconnect while its Gateway is live", async () => {
+    const held = createDeferredCore();
+    const reached = createDeferredCore();
+    boundaries.start.mockImplementation(async () => {
+      reached.resolve();
+      await held.promise;
+    });
+    const socket = new EventEmitter();
+    const client = createOperatorWsClient({ socket });
+    let disconnected = false;
+    const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { entered: true }));
+    const harness = createDispatchTestHarness({
+      buildRequestContext: () => kernel.gatewayRequestContext,
+      extraHandlers: { "test.entry": handler },
+      isClosed: () => disconnected,
+    });
+    try {
+      await harness.dispatcher.dispatch(
+        { type: "req", id: "disconnected", method: "test.entry" },
+        client,
+      );
+      await reached.promise;
+      disconnected = true;
+      socket.emit("close");
+      held.resolve();
+      expect(await harness.awaitResponseFrame("disconnected")).toMatchObject({ ok: true });
+      expect(handler).toHaveBeenCalledOnce();
+    } finally {
+      held.resolve();
+      await harness.awaitResponseFrame("disconnected");
+    }
+  });
+
+  it("hands execution off before a handler initiates close", async () => {
+    const result = await dispatchGatewayRequestInProcessRaw(
+      "test.close",
+      {},
+      {
+        context: kernel.gatewayRequestContext,
+        client: createOperatorWsClient(),
+        methodRegistry: createGatewayMethodRegistry([
+          {
+            name: "test.close",
+            owner: { kind: "aux", area: "entry-test" },
+            scope: "operator.admin",
+            handler: async ({ respond }: Parameters<GatewayRequestHandler>[0]) => {
+              await kernel.beginClosePrelude();
+              respond(true, { closed: true });
+            },
+          },
+        ]),
+      },
+    );
+    expect(result).toMatchObject({ ok: true, payload: { closed: true } });
+  });
+
+  it("admits exact pending node cleanup replies while close drains", async () => {
+    const node = createOperatorWsClient({ socket: { readyState: 1, send: vi.fn() } });
+    node.connect.role = "node";
+    node.connect.client.id = "node-host";
+    node.connect.client.mode = "node";
+    node.connect.device = {
+      id: "entry-node",
+      publicKey: "key",
+      signature: "sig",
+      signedAt: 1,
+      nonce: "nonce",
+    };
+    node.connect.commands = ["debug.ping"];
+    const registry = new NodeRegistry({
+      resolveCurrentPairingState: async () => ({ identity: "paired", generation: "current" }),
+    });
+    registry.register(node, { pairingIdentity: "paired", pairingGeneration: "current" });
+    const context = { ...kernel.gatewayRequestContext, nodeRegistry: registry };
+    const ready = createDeferredCore<string>();
+    await kernel.beginClosePrelude();
+    markGatewayRestartDraining();
+    const invoked = registry.invokeLifecycle({
+      nodeId: "entry-node",
+      command: "debug.ping",
+      timeoutMs: 10_000,
+      isDispatchAuthorized: () => true,
+      onDispatchReady: ready.resolve,
+    });
+    const settled = invoked.then(
+      (value) => ({ value }),
+      (error: unknown) => ({ error }),
+    );
+    try {
+      const id = await Promise.race([
+        ready.promise,
+        settled.then(() => {
+          throw new Error("invoke did not dispatch");
+        }),
+      ]);
+      const response = await dispatchGatewayRequestInProcessRaw(
+        "node.invoke.result",
+        { id, nodeId: "entry-node", ok: true },
+        { context, client: node },
+      );
+      expect(response).toMatchObject({ ok: true });
+      expect(await settled).toMatchObject({ value: { ok: true } });
+    } finally {
+      registry.unregister(node.connId);
+      await settled;
+      resetGatewayWorkAdmission();
+    }
+  });
+
+  it("keeps a retired context closed when a replacement Gateway starts", async () => {
+    const retired = kernel.gatewayRequestContext;
+    await kernel.closeOnStartupFailure();
+    kernel = await createGatewayKernel(port, {
+      auth: { mode: "token", token: "request-entry-test" },
+      bind: "loopback",
+      controlUiEnabled: false,
+      sidecarStartup: "defer",
+    });
+    const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { entered: true }));
+    const methodRegistry = createGatewayMethodRegistry([
+      {
+        name: "test.entry",
+        owner: { kind: "aux", area: "entry-test" },
+        scope: "operator.admin",
+        handler,
+      },
+    ]);
+    const options = { client: createOperatorWsClient(), methodRegistry };
+    await expect(
+      dispatchGatewayRequestInProcessRaw("test.entry", {}, { ...options, context: retired }),
+    ).rejects.toThrow(/closed|closing/);
+    expect(handler).not.toHaveBeenCalled();
+    await expect(
+      dispatchGatewayRequestInProcessRaw(
+        "test.entry",
+        {},
+        { ...options, context: kernel.gatewayRequestContext },
+      ),
+    ).resolves.toMatchObject({ ok: true });
+  });
+
+  it("joins typed authorization before allowing its service to start", async () => {
+    const held = createDeferredCore();
+    const reached = createDeferredCore();
+    const client = createOperatorWsClient();
+    client.authenticatedGitHubIdentitySync = async () => {
+      reached.resolve();
+      await held.promise;
+      client.authenticatedUserProfile = {
+        profileId: "typed-profile",
+        displayName: "Typed",
+        avatarRevision: "typed-avatar",
+        hasAvatar: false,
+        updatedAt: 1,
+      };
+      return { profileId: "typed-profile", updatedAt: 1 };
+    };
+    const facade = createInternalAgentTurnFacade({
+      client,
+      getContext: () => kernel.gatewayRequestContext,
+    });
+    kernel.dedupe.set("agent:entry-typed", { ts: Date.now(), ok: true, payload: { cached: true } });
+    const result = facade.dispatchRaw({ message: "cached", idempotencyKey: "entry-typed" });
+    const settled = result.then(
+      (value) => ({ value }),
+      (error: unknown) => ({ error }),
+    );
+    let closeSettled = false;
+    let closing: Promise<void> | undefined;
+    try {
+      await reached.promise;
+      closing = kernel.beginClosePrelude().then(() => {
+        closeSettled = true;
+      });
+      await nextTurn();
+      expect.soft(closeSettled).toBe(false);
+      held.resolve();
+      expect(await settled).toMatchObject({
+        error: expect.objectContaining({ message: expect.stringMatching(/closed|closing/) }),
+      });
+      await closing;
+    } finally {
+      held.resolve();
+      await settled;
+      await closing;
+    }
+  });
+});

--- a/src/gateway/server-request-entry.ts
+++ b/src/gateway/server-request-entry.ts
@@ -1,0 +1,75 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { createDeferredCore } from "../shared/deferred.js";
+import type { GatewayRequestOptions } from "./server-methods/types.js";
+
+type RequestEntryOptions = Pick<GatewayRequestOptions, "client" | "context"> & {
+  req: Pick<GatewayRequestOptions["req"], "method" | "params">;
+};
+
+export type GatewayRequestEntry = {
+  assertOpen: () => void;
+  release: () => void;
+};
+
+function isPendingNodeCompletion({ req, client, context }: RequestEntryOptions): boolean {
+  if (client?.connect.role !== "node" || !client.connId || !isRecord(req.params)) {
+    return false;
+  }
+  const invokeId =
+    req.method === "node.invoke.progress"
+      ? req.params.invokeId
+      : req.method === "node.invoke.result"
+        ? req.params.id
+        : undefined;
+  return (
+    typeof invokeId === "string" &&
+    typeof req.params.nodeId === "string" &&
+    context.nodeRegistry.isInvokeCurrent(invokeId, req.params.nodeId, client.connId)
+  );
+}
+
+/** One Gateway's preparation leases; handler execution belongs to its existing runtime owner. */
+export class GatewayRequestEntryLifetime {
+  private readonly stopping = new AbortController();
+  private readonly active = new Set<Promise<void>>();
+  private sealed = false;
+  readonly signal = this.stopping.signal;
+
+  enter(options: RequestEntryOptions): GatewayRequestEntry {
+    let released = false;
+    const assertOpen = () => {
+      // Shutdown may still issue node cleanup commands. Only their exact pending
+      // invoke can enter until transports close; pairing and settlement still revalidate.
+      if (released || this.sealed || (this.signal.aborted && !isPendingNodeCompletion(options))) {
+        throw new Error("Gateway request entry is closed");
+      }
+    };
+    assertOpen();
+    const settled = createDeferredCore();
+    this.active.add(settled.promise);
+    return {
+      assertOpen,
+      release: () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        this.active.delete(settled.promise);
+        settled.resolve();
+      },
+    };
+  }
+
+  beginClose(): void {
+    this.stopping.abort();
+  }
+
+  async waitForPendingEntries(): Promise<void> {
+    await Promise.all(this.active);
+  }
+
+  async sealAndJoin(): Promise<void> {
+    this.sealed = true;
+    await this.waitForPendingEntries();
+  }
+}

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -9,6 +9,7 @@ import {
   formatValidationErrors,
   validateRequestFrame,
 } from "../../../../packages/gateway-protocol/src/index.js";
+import { racePromiseWithAbortSignal } from "../../../infra/abort-signal.js";
 import {
   createChildDiagnosticTraceContext,
   parseDiagnosticTraceparent,
@@ -16,6 +17,7 @@ import {
 } from "../../../infra/diagnostic-trace-context.js";
 import { runOutsideGatewayRootWorkAdmission } from "../../../process/gateway-work-admission.js";
 import { createLazyPromise } from "../../../shared/lazy-runtime.js";
+import type { GatewayRequestEntry } from "../../server-request-entry.js";
 import { classifyGatewayStaleInstall } from "../../stale-install.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import {
@@ -95,16 +97,7 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
     }
     const req = parsed;
     logWs("in", "req", { connId, id: req.id, method: req.method });
-    for (;;) {
-      const barrier = deviceCredentialMutationBarrier;
-      if (!barrier) {
-        break;
-      }
-      await barrier.catch(() => undefined);
-      if (isClosed()) {
-        return;
-      }
-    }
+    const context = buildRequestContext();
     const hasCurrentClientAuthority = () => {
       if (closeInvalidatedClient(client, req.method)) {
         return false;
@@ -127,9 +120,6 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       }
       return true;
     };
-    if (!hasCurrentClientAuthority()) {
-      return;
-    }
     const respond = (
       ok: boolean,
       payload?: unknown,
@@ -192,7 +182,6 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       }
     };
 
-    const context = buildRequestContext();
     const agentRuntimeIdentity = client.internal?.agentRuntimeIdentity;
     const hasCurrentRuntimeAuthority = () => {
       if (
@@ -216,11 +205,12 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       }
     };
     const policyResponse = registerGatewayPolicyResponse(req.method, client, respondWithAuthority);
-    if (!hasCurrentRuntimeAuthority()) {
-      return;
-    }
 
     const executeRequest = async () => {
+      let entry: GatewayRequestEntry | undefined;
+      // Capture the predecessor before this request publishes its own mutation tail.
+      // Later frames wait on that tail, preserving credential mutation order.
+      const credentialMutationBarrier = deviceCredentialMutationBarrier;
       // Most UI/SDK RPCs outlive a reconnect. Companion asks are the exception:
       // without their requester there is no safe recipient for a late answer.
       const cancelOnDisconnect =
@@ -234,7 +224,33 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
         client.socket.once("close", cancelRequest);
       }
       try {
+        entry = context.requestEntryLifetime?.enter({ req, client, context });
+        if (credentialMutationBarrier) {
+          await racePromiseWithAbortSignal(
+            credentialMutationBarrier,
+            context.requestEntryLifetime?.signal,
+          ).catch(() => undefined);
+          // Refuse within the preparation lease; closing neither cancels nor joins
+          // the mutating handler, and must observe this response before entry settles.
+          if (context.requestEntryLifetime?.signal.aborted) {
+            respondWithAuthority(
+              false,
+              undefined,
+              errorShape(ErrorCodes.UNAVAILABLE, "gateway closing before request dispatch", {
+                retryable: true,
+              }),
+            );
+            return;
+          }
+          if (isClosed()) {
+            return;
+          }
+        }
+        if (!hasCurrentClientAuthority() || !hasCurrentRuntimeAuthority()) {
+          return;
+        }
         const { handleGatewayRequest } = await loadGatewayServerMethods();
+        entry?.assertOpen();
         // Node completion traffic retains its native yielding and existing close-drain
         // deadline. Operator requests share bounded starts without serializing completion.
         if (client.connect.role === "operator") {
@@ -251,6 +267,7 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
           }
           await start;
         }
+        entry?.assertOpen();
         // Waiting never grants authority. Ordinary requests may outlive their socket;
         // only request-owned cancellation and current authority fence their start.
         if (
@@ -269,6 +286,7 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
             extraHandlers,
             methodRegistry: getMethodRegistry?.(),
             context,
+            requestEntry: entry,
             ...(requestController ? { signal: requestController.signal } : {}),
           }),
         );
@@ -283,6 +301,7 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
         );
       } finally {
         policyResponse?.finish();
+        entry?.release();
         if (requestController) {
           client.socket.off("close", cancelRequest);
         }


### PR DESCRIPTION
Related: #127256 (Gateway-generation admission), #136145 (received-work/fixture lifetime), and #136036 (separate Full Access and metadata repair).

## What Problem This Solves

Closing or restarting a Gateway while the Control UI was loading could leave asynchronous request preparation running after shutdown completed. In the observed cold-browser case, `update.status`, `taskSuggestions.list`, `chat.startup`, and `talk.catalog` imports continued into torn-down dependencies after the UI assertion passed.

This repairs the generic **pre-handler request-entry** boundary. The historical cold case did not reach `chat.metadata`; the separate Full Access/metadata repair is not claimed to fix this broader entry gap. Stable-tag inspection found the structural gap in `v2026.8.2`; no introducing commit is attributed.

## Why This Change Was Made

One Gateway-instance owner retains credential-mutation waits, router loading, bounded start scheduling, authorization, and nested lazy-handler preparation. Shutdown fences ordinary entry and joins pending preparation before teardown. The final liveness check, ownership release, and actual handler invocation are synchronous. WebSocket, raw in-process, typed-agent, and directly callable lazy-handler paths share this boundary.

Already-started handlers retain their existing lifecycle owners: this is **not an all-RPC drain**. Ordinary UI/SDK requests remain reconnect-safe, existing disconnect-cancelled operations remain cancelled, and exact pending node progress/results remain available until transport shutdown seals entry. A credential waiter interrupted by shutdown receives retryable `UNAVAILABLE` before its lease releases, without cancelling or joining its running predecessor.

The handler registry uses the existing rejection-caching lazy-promise helper; the duplicate cache implementation and unsafe family-key assertion are removed. All 97 handler-family mappings and 108 runtime import targets are preserved. Reconciliation retains main's policy-response close ordering, host/caller fences, session-mutation commit guards, combined delivery-recovery shutdown, discovery ownership, and mention/update-check cleanup.

Validation also exposed a separate catalog composition defect: the parent factory restored an untransferred shallow projection of an already-frozen metadata graph. Across module evaluation, replacing its nonconfigurable collection mutators threw `Cannot redefine property: clear` before a worker could start. The factory now receives canonical parent facts and builds its own transfer input, retaining the original snapshot/cache/normalizer/registry for parent capture. Restoration remains only at the actual cloned child boundary. This removes three production lines and adds a fail-first real-worker regression; it is a functional validation repair, not cosmetic deslop.

**Production LOC: +693/-543, net +150. Tests/support: +624/-74, net +550. Docs: +7.** The positive production delta supplies the missing shared preparation/execution ownership boundary, while removing duplicate preparation/reconstruction paths. The assertion allowance only shrinks. No new configuration/env option, dependency, database schema, protocol version, timeout, logger suppression, or Vitest patch.

## User Impact

A retiring Gateway cannot start an ordinary handler when delayed preparation resumes. Normal reconnect and node-cleanup behavior are preserved. Catalog preparation retains its authoritative parent metadata instead of reconstructing a second graph. The entry contract is documented in [Gateway protocol](https://docs.openclaw.ai/gateway/protocol).

The separately coordinated #136146 owns broader received/cooperative execution, startup/disconnect, post-response, and fixture lifetimes. This PR does not claim those guarantees or close the broader linked issues. The source-only cold Talk/plugin-discovery stall is also separate.

## Evidence

Current head: **`1b34bf0a6367ffd86124db5cefa34145dae40520`**, based on `3b710e4b75c94675a0e1f1b1c31754635c08a1a6`. Both commits' final tree matches the verified 22-path candidate and all 52 recorded source inputs.

- **340 tests across 23 files passed:** 232 Gateway cases in the original recorded per-project failure order, 94 catalog/metadata cases, and 14 delivery-recovery cases. Original assertions and timeouts are unchanged. The Gateway replay used a temporary sequencer only to restore recorded order rather than Vitest's updated failed-first cache order.
- The original entry regressions produced eight pre-fix failures; two credential-waiter regressions separately failed for missing responses. The new outer-build catalog regression failed on original production with the exact `clear` error, then passed through a real Worker while preserving parent identity and child cloning.
- Complete `node scripts/check-changed.mjs --base 3b710e4b75c94675a0e1f1b1c31754635c08a1a6` passed, including core/test types, formatting, lint, dead exports, architecture and ownership guards.
- Full local `pnpm build` and `pnpm plugin-sdk:surface:check` passed in an exact-source normal checkout with copied dependencies. The first worktree build detected an ancestor dependency input changing during compilation; the isolated build passed with the consistency guard unchanged. Startup JS was 348,749 B gzip against the unchanged 350,141 B enforcement limit; all 149 public SDK subpaths passed.
- Full 22-path deslop found no worthwhile behavior-neutral edits. Fresh independent Codex autoreview completed both evidence batches with zero findings at the requested P0 threshold; this is not a broader-priority audit.
- [Final-source AWS run `run_7533a481fa76`](https://crabbox.openclaw.ai/portal/runs/run_7533a481fa76) passed runtime/UI builds and real built-browser/wire flows. All 52 inputs matched nine checkpoints. The catalog card and startup RPCs worked, ordinary TCP loss reconnected, shutdown resolved in **78.00 ms**, and the child remained quiet for **20 seconds** before natural exit 0. The wire probe observed retryable refusal before close, zero follower handler entries, and a predecessor held until explicit release. Five screenshots and the **25.16-second recording** were inspected; the lease is released.

Live fixtures are fresh synthetic loopback auth-none environments, with no hydration, instance role, Tailnet, operator state or operator service. This is not real credential rotation/provider authentication, native hosted-service proof, a green source-only cold Vitest run, or proof of the original warmed metadata path. Broker heartbeat/event warnings were retained; complete downloaded logs and source receipts were verified. Two prior proof-assembly errors stopped before product execution and were repaired only in ignored harness scripts.

The earlier grouped run's timeout/root-count failures are not all attributed to the metadata repair: their exact historical causal chain remains unobserved. The final unchanged-assertion original-order replay passed every case. An isolated base/candidate diagnostic also passed and observed slow startup imports near the baseline deadline, not a proven pairing-read deadlock.

[Exact proof, inspected media, and retained earlier-head history](https://github.com/openclaw/openclaw/pull/136998#issuecomment-5534272044). Current main deliberately restored fail-closed audits in #137989 (audit retry hardening). The refreshed head's first CI attempt passed the code/test checks but exhausted four npm advisory attempts and returned incomplete coverage. After a public readiness probe returned valid JSON, only the failed security job and aggregate gate were retried. [CI run 33850254675, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33850254675/attempts/2) completed successfully on this exact head. No rebase, audit exception or gate bypass was applied; the strict audit completed rather than being downgraded to a warning. The verified candidate is ready for native prepare/merge.
