### PR TITLE
fix(gateway): stop repeating the stale-build disk-space warning every minute

### DIFF
--- a/src/gateway/worker-environments/placement-disk-space.test.ts
+++ b/src/gateway/worker-environments/placement-disk-space.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { SpawnResult } from "../../process/exec.js";
 import { onSessionLifecycleEvent } from "../../sessions/session-lifecycle-events.js";
 import { createDeferredCore } from "../../shared/deferred.js";
+import { StaleWorkerBuildError } from "./admission.js";
 import { createWorkerPlacementDiskSpaceMonitor } from "./placement-disk-space.js";
 import type { WorkerSessionPlacementRecord } from "./placement-store.js";
 import type { WorkerWorkspaceCommand } from "./tunnel-contract.js";
@@ -188,7 +189,26 @@ describe("active worker placement disk-space monitoring", () => {
     expect(harness.monitor.version()).toBe(2);
   });
 
-  it("keeps the last exact-binding sample when a later advisory probe fails", async () => {
+  it("probes and warns once per stale worker build binding", async () => {
+    const harness = createHarness(async () => result(6 * GIB, 10 * GIB));
+    harness.startTunnel.mockRejectedValue(new StaleWorkerBuildError());
+
+    await harness.monitor.sweep();
+    await harness.monitor.sweep();
+    await harness.monitor.sweep();
+
+    expect(harness.warn).toHaveBeenCalledTimes(1);
+    expect(harness.startTunnel).toHaveBeenCalledTimes(1);
+
+    harness.setPlacement(activePlacement({ generation: 4, activeOwnerEpoch: 8 }));
+    await harness.monitor.sweep();
+    await harness.monitor.sweep();
+
+    expect(harness.warn).toHaveBeenCalledTimes(2);
+    expect(harness.startTunnel).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the last exact-binding sample and warns on every failed advisory probe", async () => {
     let fail = false;
     const harness = createHarness(async () =>
       fail
@@ -202,9 +222,11 @@ describe("active worker placement disk-space monitoring", () => {
     fail = true;
 
     await harness.monitor.sweep();
+    await harness.monitor.sweep();
 
     expect(harness.monitor.read(harness.placement)?.status).toBe("warning");
     expect(harness.monitor.version()).toBe(1);
+    expect(harness.warn).toHaveBeenCalledTimes(2);
     expect(harness.warn).toHaveBeenCalledWith(
       expect.stringContaining("Worker disk-space probe command failed"),
     );

--- a/src/gateway/worker-environments/placement-disk-space.ts
+++ b/src/gateway/worker-environments/placement-disk-space.ts
@@ -3,6 +3,7 @@ import type { SessionPlacementDiskSpace } from "../../../packages/gateway-protoc
 import { formatErrorMessage } from "../../infra/errors.js";
 import { emitSessionLifecycleEvent } from "../../sessions/session-lifecycle-events.js";
 import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
+import { StaleWorkerBuildError } from "./admission.js";
 import type { WorkerPlacementDiskSpaceReader } from "./placement-projector.js";
 import type {
   WorkerSessionPlacementRecord,
@@ -36,8 +37,10 @@ type DiskSpaceObservation = {
   snapshot: SessionPlacementDiskSpace;
 };
 
+type PlacementBinding = Omit<DiskSpaceObservation, "snapshot">;
+
 function hasExactBinding(
-  observation: DiskSpaceObservation,
+  observation: PlacementBinding,
   placement: WorkerSessionPlacementRecord | undefined,
 ): placement is ActivePlacement {
   return (
@@ -109,6 +112,7 @@ export function createWorkerPlacementDiskSpaceMonitor(params: {
   now?: () => number;
 }) {
   const observations = new Map<string, DiskSpaceObservation>();
+  const staleBindings = new Map<string, PlacementBinding>();
   const now = params.now ?? Date.now;
   let observationVersion = 0;
 
@@ -120,6 +124,11 @@ export function createWorkerPlacementDiskSpaceMonitor(params: {
   };
 
   const probe = async (placement: ActivePlacement): Promise<void> => {
+    // A stale worker build cannot recover until its placement binding changes.
+    const stale = staleBindings.get(placement.sessionId);
+    if (stale && hasExactBinding(stale, placement)) {
+      return;
+    }
     const tunnel = await params.environments.startTunnel({
       environmentId: placement.environmentId,
       ownerEpoch: placement.activeOwnerEpoch,
@@ -179,12 +188,20 @@ export function createWorkerPlacementDiskSpaceMonitor(params: {
         observationVersion += 1;
       }
     }
+    for (const [sessionId, binding] of staleBindings) {
+      if (!hasExactBinding(binding, params.placements.get(sessionId))) {
+        staleBindings.delete(sessionId);
+      }
+    }
     const tasks = active.map((placement) => () => probe(placement));
     await runTasksWithConcurrency({
       tasks,
       limit: DISK_SPACE_PROBE_CONCURRENCY,
       onTaskError: (error, index) => {
         const placement = active[index];
+        if (placement && error instanceof StaleWorkerBuildError) {
+          staleBindings.set(placement.sessionId, { ...placement });
+        }
         params.warn(
           `Worker disk-space probe failed${placement ? ` (${placement.sessionId})` : ""}: ${formatErrorMessage(error)}`,
         );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Gateway that was upgraded while a session was still placed on a worker enrolled under the previous build logged the same warning every minute, indefinitely:

```
Worker disk-space probe failed (<session>): Worker build does not match the current Gateway build; redispatch the session so its worker can bootstrap the current build before retrying.
```

## Why This Change Was Made

The placement disk-space monitor sweeps every active placement each minute and opens a tunnel to probe free space. For a stale-build placement the tunnel is refused with `StaleWorkerBuildError`, and that condition cannot change until the placement binding (environment, owner epoch, generation) changes. The monitor now remembers the exact stale binding, warns once, and skips it on later sweeps; the memory is dropped when the binding changes, so a redispatched worker is probed again. Every other probe failure keeps warning per sweep as before.

## User Impact

After a Gateway upgrade, operators see one warning per stale placement instead of one per minute, and the Gateway stops opening a doomed tunnel every sweep for those placements. No behavior change for healthy placements.

## Evidence

After-fix Gateway capture (same state directory, fix build): one stale-build warning at the first sweep and none in the following 17 sweeps, while a freshly rebound placement was probed within a minute (`diskSpace.status: ok`). Pre-fix on the same directory: one warning per minute across four Gateway runs (66 total). Full excerpt and commands in the PR comment.

Observed live today on a dev Gateway with a paired-device placement from the previous build (one warning every 60 s for over an hour). New test: a placement whose `startTunnel` rejects with `StaleWorkerBuildError` yields one warning and one `startTunnel` call across three sweeps, probes again after its binding changes, and a generic failure still warns on every sweep; the first assertion fails on the pre-fix code (3 warnings). File suite: 12 tests passed. Production delta +17 lines.
