### PR TITLE
fix(release): keep plugin scan evidence bound to the requested candidate

### DIFF
--- a/.github/workflows/plugin-prerelease.yml
+++ b/.github/workflows/plugin-prerelease.yml
@@ -61,12 +61,43 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  resolve_target:
+    name: Resolve target ref
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      checkout_revision: ${{ steps.resolve.outputs.sha }}
+    steps:
+      # Candidate planning executes repository code; admission must own a separate runner.
+      - name: Checkout trusted ref resolver
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          path: workflow
+          sparse-checkout: scripts/github/resolve-openclaw-ref.sh
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: false
+
+      - name: Resolve target SHA
+        id: resolve
+        env:
+          TARGET_REF: ${{ inputs.target_ref }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          OPENCLAW_REF_REMOTE: ${{ github.server_url }}/${{ github.repository }}.git
+        run: |
+          bash workflow/scripts/github/resolve-openclaw-ref.sh \
+            --ref "$TARGET_REF" \
+            --expected-sha "$EXPECTED_SHA" \
+            --github-output "$GITHUB_OUTPUT"
+
   preflight:
     name: Build plugin prerelease plan
+    needs: [resolve_target]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
-      checkout_revision: ${{ steps.manifest.outputs.checkout_revision }}
       run_plugin_prerelease_suite: ${{ steps.manifest.outputs.run_plugin_prerelease_suite }}
       run_plugin_prerelease_static: ${{ steps.manifest.outputs.run_plugin_prerelease_static }}
       plugin_prerelease_static_matrix: ${{ steps.manifest.outputs.plugin_prerelease_static_matrix }}
@@ -190,7 +221,7 @@ jobs:
       - name: Checkout target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.target_ref }}
+          ref: ${{ needs.resolve_target.outputs.checkout_revision }}
           fetch-depth: 1
           fetch-tags: false
           persist-credentials: false
@@ -213,29 +244,17 @@ jobs:
       - name: Build plugin prerelease manifest
         id: manifest
         env:
-          EXPECTED_SHA: ${{ inputs.expected_sha }}
           FULL_RELEASE_VALIDATION: ${{ inputs.full_release_validation && 'true' || 'false' }}
           PHASE: ${{ inputs.phase }}
         run: |
           node --import tsx --input-type=module <<'EOF'
           import { appendFileSync, existsSync, globSync } from "node:fs";
-          import { execFileSync } from "node:child_process";
           import path from "node:path";
 
           const createMatrix = (include) => ({ include });
           const outputPath = process.env.GITHUB_OUTPUT;
-          const checkoutRevision = execFileSync("git", ["rev-parse", "HEAD"], {
-            encoding: "utf8",
-          }).trim();
-          const expectedSha = (process.env.EXPECTED_SHA ?? "").trim();
           const fullReleaseValidation = process.env.FULL_RELEASE_VALIDATION === "true";
           const phase = process.env.PHASE ?? "all";
-          if (expectedSha && expectedSha !== checkoutRevision) {
-            console.error(
-              `target_ref resolved to ${checkoutRevision}, expected ${expectedSha}`,
-            );
-            process.exit(1);
-          }
 
           let pluginPrereleasePlan = { staticChecks: [], dockerLanes: [] };
           let extensionShards = [];
@@ -419,7 +438,6 @@ jobs:
           const runSuite = runStatic || runNode || runExtensions || runInspector || runDocker;
 
           const manifest = {
-            checkout_revision: checkoutRevision,
             run_plugin_prerelease_suite: runSuite,
             run_plugin_prerelease_static: runStatic,
             plugin_prerelease_static_matrix: createMatrix(staticChecks),
@@ -445,7 +463,7 @@ jobs:
     permissions:
       contents: read
     name: Plan plugin npm security artifacts
-    needs: [preflight]
+    needs: [resolve_target]
     if: inputs.phase != 'candidate'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -478,7 +496,7 @@ jobs:
       - name: Checkout candidate as inert data
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ needs.preflight.outputs.checkout_revision }}
+          ref: ${{ needs.resolve_target.outputs.checkout_revision }}
           path: .release-candidate
           fetch-depth: 1
           fetch-tags: false
@@ -496,8 +514,8 @@ jobs:
     permissions:
       contents: read
     name: plugin-npm-security-scan
-    needs: [preflight, plugin-npm-security-plan]
-    if: ${{ !cancelled() && always() && needs.preflight.result == 'success' && needs.plugin-npm-security-plan.result == 'success' }}
+    needs: [resolve_target, plugin-npm-security-plan]
+    if: ${{ !cancelled() && always() && needs.resolve_target.result == 'success' && needs.plugin-npm-security-plan.result == 'success' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
@@ -527,7 +545,7 @@ jobs:
       - name: Checkout candidate as inert package input
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ needs.preflight.outputs.checkout_revision }}
+          ref: ${{ needs.resolve_target.outputs.checkout_revision }}
           path: .release-candidate
           fetch-depth: 1
           fetch-tags: false
@@ -536,7 +554,7 @@ jobs:
 
       - name: Pack supplemental inert plugin inputs
         env:
-          CANDIDATE_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CANDIDATE_SHA: ${{ needs.resolve_target.outputs.checkout_revision }}
           EXPECTED_PACKAGES_JSON: ${{ needs.plugin-npm-security-plan.outputs.packages_json }}
           TOOLING_SHA: ${{ github.sha }}
         shell: bash
@@ -560,7 +578,7 @@ jobs:
 
       - name: Scan supplemental inert plugin inputs
         env:
-          CANDIDATE_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          CANDIDATE_SHA: ${{ needs.resolve_target.outputs.checkout_revision }}
           EXPECTED_PACKAGES_JSON: ${{ needs.plugin-npm-security-plan.outputs.packages_json }}
           TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           TOOLING_SHA: ${{ github.sha }}
@@ -592,7 +610,7 @@ jobs:
       contents: read
     # Job-level skips happen before matrix expansion; retain a unique owner name.
     name: ${{ matrix.check_name || 'plugin-prerelease-static-shard' }}
-    needs: [preflight]
+    needs: [resolve_target, preflight]
     if: needs.preflight.outputs.run_plugin_prerelease_static == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 45
@@ -603,7 +621,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.preflight.outputs.checkout_revision }}
+          ref: ${{ needs.resolve_target.outputs.checkout_revision }}
           fetch-depth: 1
           fetch-tags: false
           persist-credentials: false
@@ -629,7 +647,7 @@ jobs:
     permissions:
       contents: read
     name: ${{ matrix.check_name || 'plugin-prerelease-node-shard' }}
-    needs: [preflight]
+    needs: [resolve_target, preflight]
     if: needs.preflight.outputs.run_plugin_prerelease_node == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (matrix.runner || 'ubuntu-24.04') }}
     timeout-minutes: 60
@@ -640,7 +658,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.preflight.outputs.checkout_revision }}
+          ref: ${{ needs.resolve_target.outputs.checkout_revision }}
           fetch-depth: 1
           fetch-tags: false
           persist-credentials: false
@@ -713,7 +731,7 @@ jobs:
     permissions:
       contents: read
     name: ${{ matrix.check_name || 'plugin-prerelease-extension-shard' }}
-    needs: [preflight]
+    needs: [resolve_target, preflight]
     if: needs.preflight.outputs.run_plugin_prerelease_extensions == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || matrix.runner }}
     timeout-minutes: 60
@@ -725,7 +743,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.preflight.outputs.checkout_revision }}
+          ref: ${{ needs.resolve_target.outputs.checkout_revision }}
           fetch-depth: 1
           fetch-tags: false
           persist-credentials: false
@@ -781,7 +799,7 @@ jobs:
     permissions:
       contents: read
     name: plugin-prerelease-inspector
-    needs: [preflight]
+    needs: [resolve_target, preflight]
     if: needs.preflight.outputs.run_plugin_prerelease_inspector == 'true'
     continue-on-error: true
     runs-on: ubuntu-24.04
@@ -790,7 +808,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.preflight.outputs.checkout_revision }}
+          ref: ${{ needs.resolve_target.outputs.checkout_revision }}
           fetch-depth: 1
           fetch-tags: false
           persist-credentials: false
@@ -959,7 +977,7 @@ jobs:
 
   plugin-prerelease-docker-suite:
     name: plugin-prerelease-docker-suite
-    needs: [preflight]
+    needs: [resolve_target, preflight]
     if: ${{ inputs.full_release_validation && needs.preflight.outputs.run_plugin_prerelease_docker == 'true' }}
     permissions:
       actions: read
@@ -968,7 +986,7 @@ jobs:
       pull-requests: read
     uses: ./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
     with:
-      ref: ${{ needs.preflight.outputs.checkout_revision }}
+      ref: ${{ needs.resolve_target.outputs.checkout_revision }}
       include_repo_e2e: false
       include_release_path_suites: false
       include_openwebui: false

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -1,7 +1,14 @@
 // Plugin Prerelease Test Plan tests cover plugin prerelease test plan script behavior.
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
 import { runInNewContext } from "node:vm";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -134,11 +141,9 @@ function runPluginManifest(phase: "all" | "candidate" | "independent") {
   }
   const root = tempDirs.make("openclaw-plugin-prerelease-phase-");
   const outputPath = join(root, "github-output");
-  const head = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
   const result = spawnSync("bash", ["-c", step.run], {
     encoding: "utf8",
     env: {
-      EXPECTED_SHA: head,
       FULL_RELEASE_VALIDATION: "true",
       GITHUB_OUTPUT: outputPath,
       PATH: process.env.PATH,
@@ -446,11 +451,26 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
 
   it("keeps the trusted security scanner outside the candidate test process", () => {
     const workflow = readPluginPrereleaseWorkflow();
+    const admission = workflow.jobs.resolve_target;
     const securityPlan = workflow.jobs["plugin-npm-security-plan"];
     const securityScan = workflow.jobs["plugin-npm-security-scan"];
     const source = readFileSync(".github/workflows/plugin-prerelease.yml", "utf8");
 
-    expect(securityPlan.needs).toEqual(["preflight"]);
+    expect(admission.steps).toEqual([
+      expect.objectContaining({
+        uses: CHECKOUT_V6,
+        with: expect.objectContaining({ ref: "${{ github.sha }}", path: "workflow" }),
+      }),
+      expect.objectContaining({
+        env: {
+          EXPECTED_SHA: "${{ inputs.expected_sha }}",
+          OPENCLAW_REF_REMOTE: "${{ github.server_url }}/${{ github.repository }}.git",
+          TARGET_REF: "${{ inputs.target_ref }}",
+        },
+        run: expect.stringContaining("bash workflow/scripts/github/resolve-openclaw-ref.sh"),
+      }),
+    ]);
+    expect(securityPlan.needs).toEqual(["resolve_target"]);
     expect(securityPlan.if).toBe("inputs.phase != 'candidate'");
     expect(workflow.jobs["plugin-npm-security-package"]).toBeUndefined();
     const securityPlanStepNames = securityPlan.steps.map((step: WorkflowStep) => step.name);
@@ -459,7 +479,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     );
     expect(securityScan).toMatchObject({
       name: "plugin-npm-security-scan",
-      needs: ["preflight", "plugin-npm-security-plan"],
+      needs: ["resolve_target", "plugin-npm-security-plan"],
       permissions: { contents: "read" },
       "runs-on": "ubuntu-24.04",
       "timeout-minutes": 45,
@@ -496,6 +516,101 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       required: false,
       type: "string",
     });
+  });
+
+  it("binds scanner identity independently of candidate-owned outputs", () => {
+    const workflow = readPluginPrereleaseWorkflow();
+    const root = tempDirs.make("openclaw-plugin-prerelease-identity-");
+    const admittedSha = "a".repeat(40);
+    const substitutedSha = "b".repeat(40);
+    mkdirSync(join(root, "scripts/lib"), { recursive: true });
+    mkdirSync(join(root, "workflow/scripts/github"), { recursive: true });
+    mkdirSync(join(root, "bin"));
+    symlinkSync(resolve("node_modules"), join(root, "node_modules"), "dir");
+    writeFileSync(
+      join(root, "workflow/scripts/github/resolve-openclaw-ref.sh"),
+      readFileSync("scripts/github/resolve-openclaw-ref.sh"),
+    );
+    writeFileSync(
+      join(root, "bin/git"),
+      `#!/bin/sh\n[ "$1" = rev-parse ] && [ "$2" = HEAD ] || exit 2\nprintf '%s\\n' '${admittedSha}'\n`,
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      join(root, "scripts/lib/plugin-prerelease-test-plan.mts"),
+      `import { appendFileSync } from "node:fs";
+       process.once("exit", () => appendFileSync(process.env.GITHUB_OUTPUT,
+         "checkout_revision=${substitutedSha}\\n"));
+       export function assertPluginPrereleaseTestPlanComplete() {
+         return { staticChecks: [{ checkName: "fixture", command: "true", check: "fixture" }], dockerLanes: [] };
+       }`,
+    );
+    writeFileSync(
+      join(root, "scripts/lib/extension-test-plan.mts"),
+      "export const DEFAULT_EXTENSION_TEST_SHARD_COUNT = 1; export function createExtensionTestShards() { return []; }",
+    );
+    writeFileSync(
+      join(root, "scripts/lib/ci-node-test-plan.mts"),
+      "export function createNodeTestShards() { return []; }",
+    );
+    const needs: Record<string, { outputs: Record<string, string> }> = {};
+    for (const [jobId, stepName] of [
+      ["resolve_target", "Resolve target SHA"],
+      ["preflight", "Build plugin prerelease manifest"],
+    ] as const) {
+      const job = workflow.jobs[jobId];
+      if (!job) {
+        continue;
+      }
+      const step = job.steps.find((entry: WorkflowStep) => entry.name === stepName);
+      const outputPath = join(root, `${jobId}-output`);
+      const result = spawnSync("bash", ["-c", step.run], {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          EXPECTED_SHA: admittedSha,
+          FULL_RELEASE_VALIDATION: "true",
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${join(root, "bin")}:${process.env.PATH}`,
+          PHASE: "independent",
+          TARGET_REF: admittedSha,
+        },
+      });
+      expect(result.status, result.stderr).toBe(0);
+      // Actions assigns each output in file order; the last duplicate wins.
+      const outputs = Object.fromEntries(
+        readFileSync(outputPath, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => [line.slice(0, line.indexOf("=")), line.slice(line.indexOf("=") + 1)]),
+      );
+      if (jobId === "preflight") {
+        expect(outputs.checkout_revision).toBe(substitutedSha);
+      }
+      needs[jobId] = {
+        outputs: Object.fromEntries(
+          Object.entries(job.outputs).map(([key, expression]) => [
+            key,
+            runInNewContext(String(expression).slice(3, -2), {
+              steps: { [step.id]: { outputs }, node_test_exclusions: { outputs: {} } },
+            }),
+          ]),
+        ),
+      };
+    }
+    for (const jobId of ["plugin-npm-security-plan", "plugin-npm-security-scan"]) {
+      for (const step of workflow.jobs[jobId].steps as WorkflowStep[]) {
+        const candidateRef = step.with?.path === ".release-candidate" ? step.with.ref : undefined;
+        for (const expression of [candidateRef, step.env?.CANDIDATE_SHA]) {
+          if (expression !== undefined) {
+            if (typeof expression !== "string") {
+              throw new Error("Candidate identity must be a workflow expression");
+            }
+            expect(runInNewContext(expression.slice(3, -2), { needs })).toBe(admittedSha);
+          }
+        }
+      }
+    }
   });
 
   it("wires the full plugin prerelease plan into its release workflow", () => {
@@ -552,7 +667,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     expect(staticShard).toEqual({
       if: "needs.preflight.outputs.run_plugin_prerelease_static == 'true'",
       name: "${{ matrix.check_name || 'plugin-prerelease-static-shard' }}",
-      needs: ["preflight"],
+      needs: ["resolve_target", "preflight"],
       permissions: {
         contents: "read",
       },
@@ -566,7 +681,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
             "fetch-depth": 1,
             "fetch-tags": false,
             "persist-credentials": false,
-            ref: "${{ needs.preflight.outputs.checkout_revision }}",
+            ref: "${{ needs.resolve_target.outputs.checkout_revision }}",
             submodules: false,
           },
         },
@@ -751,7 +866,6 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       type: "string",
     });
     expect(pluginManifestEnv).toEqual({
-      EXPECTED_SHA: "${{ inputs.expected_sha }}",
       FULL_RELEASE_VALIDATION: "${{ inputs.full_release_validation && 'true' || 'false' }}",
       PHASE: "${{ inputs.phase }}",
     });
@@ -764,7 +878,6 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       "const runDocker = runCandidate && fullReleaseValidation && dockerLanes.length > 0;",
     );
     expect(pluginPreflight.outputs).toEqual({
-      checkout_revision: "${{ steps.manifest.outputs.checkout_revision }}",
       plugin_prerelease_docker_lanes:
         "${{ steps.manifest.outputs.plugin_prerelease_docker_lanes }}",
       plugin_prerelease_extension_matrix:
@@ -785,7 +898,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     expect(staticShard.strategy.matrix).toBe(
       "${{ fromJson(needs.preflight.outputs.plugin_prerelease_static_matrix) }}",
     );
-    expect(securityScan.needs).toEqual(["preflight", "plugin-npm-security-plan"]);
+    expect(securityScan.needs).toEqual(["resolve_target", "plugin-npm-security-plan"]);
     expect(nodeShard.strategy.matrix).toBe(
       "${{ fromJson(needs.preflight.outputs.plugin_prerelease_node_matrix) }}",
     );
@@ -799,7 +912,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       extensionShard.steps.find((step: WorkflowStep) => step.name === "Run extension shard").run,
     ).toContain("--retry=1");
     expect(inspector.name).toBe("plugin-prerelease-inspector");
-    expect(inspector.needs).toEqual(["preflight"]);
+    expect(inspector.needs).toEqual(["resolve_target", "preflight"]);
     expect(inspector.if).toBe("needs.preflight.outputs.run_plugin_prerelease_inspector == 'true'");
     expect(inspector["continue-on-error"]).toBe(true);
     expect(inspector["runs-on"]).toBe("ubuntu-24.04");
@@ -844,7 +957,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     expect(dockerSuite).toMatchObject({
       if: "${{ inputs.full_release_validation && needs.preflight.outputs.run_plugin_prerelease_docker == 'true' }}",
       name: "plugin-prerelease-docker-suite",
-      needs: ["preflight"],
+      needs: ["resolve_target", "preflight"],
       permissions: {
         actions: "read",
         contents: "read",
@@ -860,7 +973,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
         include_repo_e2e: false,
         live_models_only: false,
         allow_unreleased_changelog: true,
-        ref: "${{ needs.preflight.outputs.checkout_revision }}",
+        ref: "${{ needs.resolve_target.outputs.checkout_revision }}",
         shared_image_artifact_namespace: "plugin-prerelease",
         shared_image_policy: "no-push-artifact",
         targeted_docker_lane_group_size: 2,


### PR DESCRIPTION
Closes #136999

## What Problem This Solves

Resolves a problem where release operators could receive independent plugin scan evidence for a different commit when candidate-owned prerelease planning overwrote its checkout output after SHA validation.

## Why This Change Was Made

Resolve the target in a separate trusted-only job using the existing release ref resolver. Candidate planning no longer produces commit identity; every later candidate checkout and scanner metadata argument reads the immutable admission output directly. A same-job validation step cannot provide this boundary because candidate code runs on that job's runner.

This remains a supplemental scan of checked-in package inputs, not a guarantee that published artifacts have identical bytes. No Gateway runtime, package dependency, configuration, schema, or protocol changes.

## User Impact

Release validation stays bound to the requested candidate. Branch, tag, and full-SHA inputs remain supported, including standalone fork workflows. The existing resolver rejects ambiguous short names shared by a branch and tag; qualify those as `refs/heads/...` or `refs/tags/...`.

## Evidence

- The added actual workflow-shell regression fails before the repair with the substituted SHA, then passes after it. It exercises a candidate exit hook, ordered output replacement, and the scanner's checkout/metadata expressions.
- `node scripts/run-vitest.mjs test/scripts/plugin-prerelease-test-plan.test.ts test/scripts/resolve-openclaw-ref.test.ts`: 26 tests passed.
- `node scripts/check-changed.mjs -- .github/workflows/plugin-prerelease.yml test/scripts/plugin-prerelease-test-plan.test.ts`: passed, including typecheck and changed-test lint.
- `node --import ./scripts/tsx.mjs scripts/check-workflows.mts`: actionlint, zizmor, generated CI ownership, composite interpolation, and conflict-marker checks passed with task-local Python 3.12 / pinned pre-commit 4.6.2 tooling.
- The actual new admission shell resolved live public `main` and stable-tag refs, retained an exact frozen SHA, and rejected a mismatched expected SHA before emitting output.
- Fresh Codex autoreview and a separate frozen-head independent source review: no blocking findings through P2.

Production/tooling LOC: +50/-32, net +18, entirely workflow YAML. Runtime production LOC: unchanged. Tests: +127/-14, net +113. The workflow growth buys the separate trusted runner boundary; the old candidate-side identity producer and validation are removed, and no new implementation helper is introduced.

### Actual Actions boundary proof

[Substitution run 33716906692](https://github.com/openclaw/openclaw/actions/runs/33716906692) passed using this exact PR head as trusted workflow/tooling. A reviewed, temporary synthetic candidate at `f7d48a1567bb44c67d9ece59039660a275c4c5d5` attempted to replace the checkout output with `0e844d050bb8950b5864700aa990103561bb762e`. Both physical scanner checkouts and the downloaded report retained the distinct candidate SHA. The report matched all 90 expected packages, passed with zero errors and zero unexpected critical findings, and recorded the exact tooling SHA. Admission, candidate planning, trusted package planning, and scanning ran on four distinct GitHub-hosted runners.

[Mismatch run 33716909143](https://github.com/openclaw/openclaw/actions/runs/33716909143) intentionally requested the stable tag with a different expected SHA. Admission rejected that precise mismatch, and all nine downstream jobs were skipped.

[Required CI run 33716366805](https://github.com/openclaw/openclaw/actions/runs/33716366805) passed on `0e844d050bb8950b5864700aa990103561bb762e`. The latest exact-head ClawSweeper review has no findings or pre-merge actions; fresh autoreview and the separate frozen-head independent review are also clear. Native prepare/merge gates still apply.

The synthetic candidate deliberately disabled broad product test lanes; independent scanning used the unchanged checked-in plugin inventory. This is real Actions/scanner execution, not package publication or a claim that the current publisher scans identical final bytes.
