### PR TITLE
improve(gateway): verify persisted mobile reconnects

### DIFF
--- a/src/gateway/server.auth.control-ui.mobile-reconnect.suite.ts
+++ b/src/gateway/server.auth.control-ui.mobile-reconnect.suite.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect, test } from "vitest";
 import type { WebSocket } from "ws";
 import {
@@ -27,10 +28,6 @@ const IOS_OPERATOR_SCOPES = [
   "operator.talk.secrets",
   "operator.write",
 ];
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 export function registerControlUiMobileReconnectSuite(): void {
   test("reconnects persisted iOS node and operator role tokens after password-mode restart", async () => {

--- a/src/gateway/server.auth.control-ui.mobile-reconnect.suite.ts
+++ b/src/gateway/server.auth.control-ui.mobile-reconnect.suite.ts
@@ -1,6 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect, test } from "vitest";
-import type { WebSocket } from "ws";
+import { WebSocket } from "ws";
 import {
   closeOpenClawStateDatabaseForTest,
   isOpenClawStateDatabaseOpen,
@@ -29,8 +29,18 @@ const IOS_OPERATOR_SCOPES = [
   "operator.write",
 ];
 
+async function closeWs(ws: WebSocket | undefined): Promise<void> {
+  if (!ws || ws.readyState === WebSocket.CLOSED) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    ws.once("close", () => resolve());
+    ws.close();
+  });
+}
+
 export function registerControlUiMobileReconnectSuite(): void {
-  test("reconnects persisted iOS node and operator role tokens after password-mode restart", async () => {
+  test("reconnects persisted mobile role tokens through shared and explicit fields after restart", async () => {
     type GatewayServer = Awaited<ReturnType<typeof startTestGatewayServer>>;
     const previousAuth = testState.gatewayAuth;
     const previousToken = process.env.OPENCLAW_GATEWAY_TOKEN;
@@ -38,8 +48,6 @@ export function registerControlUiMobileReconnectSuite(): void {
     let bootstrapServer: GatewayServer | undefined;
     let restartedServer: GatewayServer | undefined;
     let bootstrapWs: WebSocket | undefined;
-    let nodeWs: WebSocket | undefined;
-    let operatorWs: WebSocket | undefined;
     let unauthenticatedWs: WebSocket | undefined;
 
     try {
@@ -128,41 +136,64 @@ export function registerControlUiMobileReconnectSuite(): void {
       unauthenticatedWs.close();
       unauthenticatedWs = undefined;
 
-      nodeWs = await openWs(port);
-      const nodeReconnect = await connectReq(nodeWs, {
-        deviceToken: nodeToken,
-        skipDefaultAuth: true,
-        role: "node",
-        scopes: [],
-        client: nodeClient,
-        deviceIdentityPath: identityPath,
-      });
-      expect(nodeReconnect.ok, JSON.stringify(nodeReconnect.error)).toBe(true);
-      expect(nodeReconnect.payload?.type).toBe("hello-ok");
+      const reconnectRoles = async (
+        pathName: string,
+        credentialField: "token" | "deviceToken",
+      ): Promise<void> => {
+        let nodeWs: WebSocket | undefined;
+        let operatorWs: WebSocket | undefined;
+        try {
+          nodeWs = await openWs(port);
+          const nodeReconnect = await connectReq(nodeWs, {
+            ...(credentialField === "token" ? { token: nodeToken } : { deviceToken: nodeToken }),
+            skipDefaultAuth: true,
+            role: "node",
+            scopes: [],
+            client: nodeClient,
+            deviceIdentityPath: identityPath,
+          });
+          expect(nodeReconnect.ok, `${pathName}: ${JSON.stringify(nodeReconnect.error)}`).toBe(
+            true,
+          );
+          expect(nodeReconnect.payload?.type).toBe("hello-ok");
 
-      operatorWs = await openWs(port);
-      const operatorReconnect = await connectReq(operatorWs, {
-        deviceToken: operatorToken,
-        skipDefaultAuth: true,
-        role: "operator",
-        scopes: IOS_OPERATOR_SCOPES,
-        client: { ...nodeClient, mode: "ui" as const },
-        deviceIdentityPath: identityPath,
-      });
-      expect(operatorReconnect.ok, JSON.stringify(operatorReconnect.error)).toBe(true);
-      expect(operatorReconnect.payload?.type).toBe("hello-ok");
+          operatorWs = await openWs(port);
+          const operatorReconnect = await connectReq(operatorWs, {
+            ...(credentialField === "token"
+              ? { token: operatorToken }
+              : { deviceToken: operatorToken }),
+            skipDefaultAuth: true,
+            role: "operator",
+            scopes: IOS_OPERATOR_SCOPES,
+            client: { ...nodeClient, mode: "ui" as const },
+            deviceIdentityPath: identityPath,
+          });
+          expect(
+            operatorReconnect.ok,
+            `${pathName}: ${JSON.stringify(operatorReconnect.error)}`,
+          ).toBe(true);
+          expect(operatorReconnect.payload?.type).toBe("hello-ok");
 
-      expect((await rpcReq(operatorWs, "health")).ok).toBe(true);
-      const nodes = await rpcReq<{
-        nodes?: Array<{ connected?: boolean; nodeId?: string }>;
-      }>(operatorWs, "node.list", {});
-      expect(nodes.ok).toBe(true);
-      expect(nodes.payload?.nodes).toContainEqual(
-        expect.objectContaining({
-          connected: true,
-          nodeId: identity.deviceId,
-        }),
-      );
+          expect((await rpcReq(operatorWs, "health")).ok).toBe(true);
+          const nodes = await rpcReq<{
+            nodes?: Array<{ connected?: boolean; nodeId?: string }>;
+          }>(operatorWs, "node.list", {});
+          expect(nodes.ok).toBe(true);
+          expect(nodes.payload?.nodes).toContainEqual(
+            expect.objectContaining({
+              connected: true,
+              nodeId: identity.deviceId,
+            }),
+          );
+        } finally {
+          await Promise.all([closeWs(operatorWs), closeWs(nodeWs)]);
+        }
+      };
+
+      // iPhone and Android normal stored-token reconnects use auth.token; Watch/direct
+      // and trusted retry paths use auth.deviceToken. Keep both mobile contracts covered.
+      await reconnectRoles("normal stored-token fallback", "token");
+      await reconnectRoles("explicit device-token path", "deviceToken");
 
       const pairingAfterReconnect = await listDevicePairing();
       expect(
@@ -173,8 +204,6 @@ export function registerControlUiMobileReconnectSuite(): void {
       expect(pairedAfterReconnect?.tokens?.operator?.token).toBe(operatorToken);
     } finally {
       unauthenticatedWs?.close();
-      operatorWs?.close();
-      nodeWs?.close();
       bootstrapWs?.close();
       await restartedServer?.close();
       await bootstrapServer?.close();

--- a/src/gateway/server.auth.control-ui.mobile-reconnect.suite.ts
+++ b/src/gateway/server.auth.control-ui.mobile-reconnect.suite.ts
@@ -1,0 +1,194 @@
+import { expect, test } from "vitest";
+import type { WebSocket } from "ws";
+import {
+  closeOpenClawStateDatabaseForTest,
+  isOpenClawStateDatabaseOpen,
+} from "../state/openclaw-state-db.js";
+import {
+  createOperatorIdentityFixture,
+  REMOTE_BOOTSTRAP_HEADERS,
+  startProxiedControlUiServer,
+} from "./server.auth.control-ui.fixtures.test-support.js";
+import {
+  connectReq,
+  ConnectErrorDetailCodes,
+  openWs,
+  restoreGatewayToken,
+  rpcReq,
+  startTestGatewayServer,
+  testState,
+} from "./server.auth.test-helpers.js";
+
+const IOS_OPERATOR_SCOPES = [
+  "operator.admin",
+  "operator.approvals",
+  "operator.questions",
+  "operator.read",
+  "operator.talk.secrets",
+  "operator.write",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function registerControlUiMobileReconnectSuite(): void {
+  test("reconnects persisted iOS node and operator role tokens after password-mode restart", async () => {
+    type GatewayServer = Awaited<ReturnType<typeof startTestGatewayServer>>;
+    const previousAuth = testState.gatewayAuth;
+    const previousToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    const previousPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    let bootstrapServer: GatewayServer | undefined;
+    let restartedServer: GatewayServer | undefined;
+    let bootstrapWs: WebSocket | undefined;
+    let nodeWs: WebSocket | undefined;
+    let operatorWs: WebSocket | undefined;
+    let unauthenticatedWs: WebSocket | undefined;
+
+    try {
+      testState.gatewayAuth = { mode: "password", password: "secret" };
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+
+      const started = await startProxiedControlUiServer();
+      bootstrapServer = started.server;
+      const { port } = started;
+      const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+      const { FULL_ACCESS_PAIRING_SETUP_BOOTSTRAP_PROFILE } =
+        await import("../shared/device-bootstrap-profile.js");
+      const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
+      const { identityPath, identity } = await createOperatorIdentityFixture(
+        "openclaw-mobile-reconnect-",
+      );
+      const nodeClient = {
+        id: "openclaw-ios",
+        version: "2026.8.10",
+        platform: "iOS 26.6.1",
+        mode: "node" as const,
+        deviceFamily: "iPhone",
+      };
+
+      const bootstrap = await issueDeviceBootstrapToken({
+        profile: FULL_ACCESS_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+      });
+      bootstrapWs = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      const initial = await connectReq(bootstrapWs, {
+        skipDefaultAuth: true,
+        bootstrapToken: bootstrap.token,
+        role: "node",
+        scopes: [],
+        client: nodeClient,
+        deviceIdentityPath: identityPath,
+      });
+      expect(initial.ok, JSON.stringify(initial.error)).toBe(true);
+      expect(initial.payload?.type).toBe("hello-ok");
+
+      const initialAuth = initial.payload?.auth;
+      const nodeToken =
+        isRecord(initialAuth) && typeof initialAuth.deviceToken === "string"
+          ? initialAuth.deviceToken
+          : undefined;
+      const operatorHandoff =
+        isRecord(initialAuth) && Array.isArray(initialAuth.deviceTokens)
+          ? initialAuth.deviceTokens.find((entry) => isRecord(entry) && entry.role === "operator")
+          : undefined;
+      const operatorToken =
+        isRecord(operatorHandoff) && typeof operatorHandoff.deviceToken === "string"
+          ? operatorHandoff.deviceToken
+          : undefined;
+      if (!nodeToken || !operatorToken) {
+        throw new Error("expected bootstrap to issue node and operator device tokens");
+      }
+      expect(isRecord(operatorHandoff) ? operatorHandoff.scopes : undefined).toEqual(
+        IOS_OPERATOR_SCOPES,
+      );
+
+      const pairedBeforeRestart = await getPairedDevice(identity.deviceId);
+      expect(pairedBeforeRestart?.tokens?.node?.token).toBe(nodeToken);
+      expect(pairedBeforeRestart?.tokens?.operator?.token).toBe(operatorToken);
+
+      bootstrapWs.close();
+      bootstrapWs = undefined;
+      await bootstrapServer.close();
+      bootstrapServer = undefined;
+      closeOpenClawStateDatabaseForTest();
+      expect(isOpenClawStateDatabaseOpen()).toBe(false);
+
+      restartedServer = await startTestGatewayServer(port, { controlUiEnabled: true });
+
+      unauthenticatedWs = await openWs(port);
+      const unauthenticated = await connectReq(unauthenticatedWs, {
+        skipDefaultAuth: true,
+        role: "operator",
+        scopes: IOS_OPERATOR_SCOPES,
+        client: { ...nodeClient, mode: "ui" as const },
+        deviceIdentityPath: identityPath,
+      });
+      expect(unauthenticated.ok).toBe(false);
+      const unauthenticatedDetails = unauthenticated.error?.details;
+      expect(isRecord(unauthenticatedDetails) ? unauthenticatedDetails.code : undefined).toBe(
+        ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING,
+      );
+      unauthenticatedWs.close();
+      unauthenticatedWs = undefined;
+
+      nodeWs = await openWs(port);
+      const nodeReconnect = await connectReq(nodeWs, {
+        token: nodeToken,
+        skipDefaultAuth: true,
+        role: "node",
+        scopes: [],
+        client: nodeClient,
+        deviceIdentityPath: identityPath,
+      });
+      expect(nodeReconnect.ok, JSON.stringify(nodeReconnect.error)).toBe(true);
+      expect(nodeReconnect.payload?.type).toBe("hello-ok");
+
+      operatorWs = await openWs(port);
+      const operatorReconnect = await connectReq(operatorWs, {
+        token: operatorToken,
+        skipDefaultAuth: true,
+        role: "operator",
+        scopes: IOS_OPERATOR_SCOPES,
+        client: { ...nodeClient, mode: "ui" as const },
+        deviceIdentityPath: identityPath,
+      });
+      expect(operatorReconnect.ok, JSON.stringify(operatorReconnect.error)).toBe(true);
+      expect(operatorReconnect.payload?.type).toBe("hello-ok");
+
+      expect((await rpcReq(operatorWs, "health")).ok).toBe(true);
+      const nodes = await rpcReq<{
+        nodes?: Array<{ connected?: boolean; nodeId?: string }>;
+      }>(operatorWs, "node.list", {});
+      expect(nodes.ok).toBe(true);
+      expect(nodes.payload?.nodes).toContainEqual(
+        expect.objectContaining({
+          connected: true,
+          nodeId: identity.deviceId,
+        }),
+      );
+
+      const pairingAfterReconnect = await listDevicePairing();
+      expect(
+        pairingAfterReconnect.pending.filter((entry) => entry.deviceId === identity.deviceId),
+      ).toEqual([]);
+      const pairedAfterReconnect = await getPairedDevice(identity.deviceId);
+      expect(pairedAfterReconnect?.tokens?.node?.token).toBe(nodeToken);
+      expect(pairedAfterReconnect?.tokens?.operator?.token).toBe(operatorToken);
+    } finally {
+      unauthenticatedWs?.close();
+      operatorWs?.close();
+      nodeWs?.close();
+      bootstrapWs?.close();
+      await restartedServer?.close();
+      await bootstrapServer?.close();
+      closeOpenClawStateDatabaseForTest();
+      testState.gatewayAuth = previousAuth;
+      restoreGatewayToken(previousToken);
+      if (previousPassword === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+      } else {
+        process.env.OPENCLAW_GATEWAY_PASSWORD = previousPassword;
+      }
+    }
+  });
+}

--- a/src/gateway/server.auth.control-ui.mobile-reconnect.suite.ts
+++ b/src/gateway/server.auth.control-ui.mobile-reconnect.suite.ts
@@ -130,7 +130,7 @@ export function registerControlUiMobileReconnectSuite(): void {
 
       nodeWs = await openWs(port);
       const nodeReconnect = await connectReq(nodeWs, {
-        token: nodeToken,
+        deviceToken: nodeToken,
         skipDefaultAuth: true,
         role: "node",
         scopes: [],
@@ -142,7 +142,7 @@ export function registerControlUiMobileReconnectSuite(): void {
 
       operatorWs = await openWs(port);
       const operatorReconnect = await connectReq(operatorWs, {
-        token: operatorToken,
+        deviceToken: operatorToken,
         skipDefaultAuth: true,
         role: "operator",
         scopes: IOS_OPERATOR_SCOPES,

--- a/src/gateway/server.auth.control-ui.test.ts
+++ b/src/gateway/server.auth.control-ui.test.ts
@@ -5,6 +5,7 @@ import { describe } from "vitest";
 import { registerControlUiBootstrapLifecycleSuite } from "./server.auth.control-ui.bootstrap-lifecycle.suite.js";
 import { registerControlUiDeviceTokenSuite } from "./server.auth.control-ui.device-token.suite.js";
 import { registerControlUiMobileBootstrapSuite } from "./server.auth.control-ui.mobile-bootstrap.suite.js";
+import { registerControlUiMobileReconnectSuite } from "./server.auth.control-ui.mobile-reconnect.suite.js";
 import { registerControlUiOwnerBootstrapSuite } from "./server.auth.control-ui.owner-bootstrap.suite.js";
 import { registerControlUiPairingSuite } from "./server.auth.control-ui.pairing.suite.js";
 import { registerControlUiTrustedProxySuite } from "./server.auth.control-ui.trusted-proxy.suite.js";
@@ -24,6 +25,7 @@ describe("gateway server auth/connect", () => {
   registerControlUiDeviceTokenSuite();
   registerControlUiPairingSuite();
   registerControlUiMobileBootstrapSuite();
+  registerControlUiMobileReconnectSuite();
   registerControlUiBootstrapLifecycleSuite();
   registerControlUiOwnerBootstrapSuite();
 });


### PR DESCRIPTION
Related: #134142

## What Problem This Solves

Gateway coverage did not deterministically verify that a previously bootstrapped mobile identity can reconnect both its node and operator sessions after a password-mode Gateway restart using persisted role tokens.

This is a Gateway-side regression guard. It does not claim to reproduce or fix the reported iOS credential-storage failure in #134142.

## Why This Change Was Made

The integration test bootstraps a signed `openclaw-ios` identity, captures its node and operator tokens, closes the Gateway and state database, then restarts against the same state. One shared fixture reconnects both roles through both current mobile credential contracts:

- normal iPhone/OpenClawKit and Android stored-token reconnects via `auth.token`;
- Watch/direct and trusted retry reconnects via explicit `auth.deviceToken`.

The test waits for both role sockets to close between paths. It also verifies password mode remains active, operator RPCs work, the node is connected, no new pairing is pending, and the persisted tokens are unchanged. No runtime code or user behavior changes.

## User Impact

No user-visible behavior changes. Maintainers gain deterministic coverage for persisted mobile role reconnects across Gateway restarts.

## Evidence

- Focused both-fields test on the current code: 1 passed, 40 skipped.
- Full owning `src/gateway/server.auth.control-ui.test.ts` suite: 41/41 passed.
- Focused test passed five consecutive runs before publication.
- Formatting, targeted oxlint, and whitespace checks passed.
- Fresh autoreview after deterministic socket shutdown: scoped-clean for P0-P2 findings, confidence 0.97.
- ClawSweeper reviewer-environment limitation: `ws` source was unavailable in its environment. Direct inspection of installed `ws` 8.21.1 confirms `close()` enters the closing handshake and emits `close` only after socket and receiver cleanup; the test awaits both role sockets before exercising the next credential field.
- Hosted exact-head CI is green on head `fe9cf1f8cbb2249c42b7719800a060a6d74c0eae`; run `33719247380` passed after its sole stale queued `report-plugin-sdk-api-diff` job was recovered by cancelling the stuck run and rerunning only that job.
- ClawSweeper data-model classification is a test-only false positive: there are no schema, state shape, migration, or persistence writer changes. The test closes and reopens the existing state DB and confirms node/operator tokens remain byte-for-byte unchanged; version-to-version package migration proof is deliberately owned by the separate Upgrade Survivor PR.




