### PR TITLE
fix: skip managed gateway stop on no-op openclaw update

### DIFF
--- a/src/cli/update-cli/update-command-dry-run.ts
+++ b/src/cli/update-cli/update-command-dry-run.ts
@@ -139,9 +139,11 @@ export function printUpdateDryRun(params: {
   actions.push("Run plugin update sync after core update");
   actions.push("Refresh shell completion cache (if needed)");
   actions.push(
-    params.shouldRestart
+    params.shouldRestart && !params.packageAlreadyCurrent
       ? "Restart gateway service and run doctor checks"
-      : "Skip restart (because --no-restart is set)",
+      : params.shouldRestart
+        ? "Leave managed gateway running (already at target version)"
+        : "Skip restart (because --no-restart is set)",
   );
 
   const notes: string[] = [...(params.preflightNotes ?? [])];
@@ -179,7 +181,7 @@ export function printUpdateDryRun(params: {
       updateInstallKind: params.updateInstallKind,
       switchToGit: params.switchToGit,
       switchToPackage: params.switchToPackage,
-      restart: params.shouldRestart,
+      restart: params.shouldRestart && !params.packageAlreadyCurrent,
       requestedChannel: params.requestedChannel,
       storedChannel: params.storedChannel,
       effectiveChannel: params.channel,

--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -180,6 +180,7 @@ export async function executeMutableUpdate(
           root: mutationRoot,
           shouldRestart: params.shouldRestart,
           jsonMode: Boolean(opts.json),
+          packageAlreadyCurrent: params.packageAlreadyCurrent,
           timeoutMs: updateStepTimeoutMs,
           phase,
           expectedService: admission?.services.get(mutationRoot),

--- a/src/cli/update-cli/update-command-execution.types.ts
+++ b/src/cli/update-cli/update-command-execution.types.ts
@@ -21,6 +21,7 @@ export type MutableUpdateExecutionParams = {
   tag: string;
   opts: UpdateCommandOptions;
   shouldRestart: boolean;
+  packageAlreadyCurrent?: boolean;
   devTarget?: DevUpdateTarget;
   packageInstallSpec: string | null;
   packageInstallEnv?: NodeJS.ProcessEnv;

--- a/src/cli/update-cli/update-command-finish-types.ts
+++ b/src/cli/update-cli/update-command-finish-types.ts
@@ -10,6 +10,8 @@ import type { UpdateRestartParams } from "./update-command-service-context-types
 import type { UpdateServiceLoadBoundary } from "./update-command-service-load.js";
 export type FinishUpdateParams = UpdateRestartParams & {
   coreAlreadyCurrent?: boolean;
+  /** Alias retained for callers; prefer coreAlreadyCurrent for restart gating. */
+  packageAlreadyCurrent?: boolean;
   serviceLoadBoundary?: UpdateServiceLoadBoundary;
   failure?: { cause: unknown; detail: string };
   mutationStarted: boolean;

--- a/src/cli/update-cli/update-command-noop.ts
+++ b/src/cli/update-cli/update-command-noop.ts
@@ -110,6 +110,7 @@ export async function finishAlreadyCurrentUpdate(
         ...inspection,
         root: params.root,
         phase: "inspect",
+        packageAlreadyCurrent: true,
         expectedService: admission.services.get(params.root),
         updateRun: params.opts.run,
         handoffFromGateway: (state) =>

--- a/src/cli/update-cli/update-command-post-update-windows.ts
+++ b/src/cli/update-cli/update-command-post-update-windows.ts
@@ -1,0 +1,26 @@
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { createWindowsTaskAutoStartGuard } from "./update-command-service-maintenance.js";
+import {
+  maybeResumeWindowsTaskAutoStartAfterPackageUpdate,
+  type PreManagedServiceStop,
+} from "./update-command-service.js";
+
+export async function resumeWindowsAutoStartForUpdate(params: {
+  result: UpdateRunResult;
+  root: string;
+  updateStepTimeoutMs: number;
+  currentServiceStop: () => PreManagedServiceStop | undefined;
+}): Promise<void> {
+  const stopped = params.currentServiceStop();
+  await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(
+    stopped,
+    true,
+    stopped
+      ? createWindowsTaskAutoStartGuard({
+          root: params.result.root ?? params.root,
+          before: stopped,
+          timeoutMs: params.updateStepTimeoutMs,
+        })
+      : undefined,
+  );
+}

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -15,6 +15,7 @@ import { tryWriteCompletionCache } from "./shared.js";
 import { convergeUpdatePlugins } from "./update-command-convergence.js";
 import type { FinishUpdateParams } from "./update-command-finish-types.js";
 import { retireStandaloneGitWrapper } from "./update-command-git.js";
+import { resumeWindowsAutoStartForUpdate } from "./update-command-post-update-windows.js";
 import {
   assertUpdateCommandPackageFinalization,
   createUpdateCommandFinalizationFence,
@@ -31,13 +32,11 @@ import {
 import { rollbackFailedUpdate } from "./update-command-rollback.js";
 import { withOwnedManagedUpdateEnv } from "./update-command-service-env.js";
 import { UpdateServiceLoadBoundaryError } from "./update-command-service-load.js";
-import { createWindowsTaskAutoStartGuard } from "./update-command-service-maintenance.js";
 import { GatewayServiceUpdateOwnershipError } from "./update-command-service-plan.js";
 import {
   recordFailedUpdateGatewayState,
   maybeRestartService,
   maybeRestartServiceAfterFailedMutableUpdate,
-  maybeResumeWindowsTaskAutoStartAfterPackageUpdate,
   maybeStopManagedServiceBeforeMutableUpdate,
   tryInstallShellCompletion,
   type PreManagedServiceStop,
@@ -82,20 +81,13 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
   let rollbackStopState: PreManagedServiceStop | undefined;
   // Rollback can replace the suspension owner.
   const currentServiceStop = () => rollbackStopState ?? params.preManagedServiceStop;
-  const resumeWindowsAutoStart = async (result: UpdateRunResult) => {
-    const stopped = currentServiceStop();
-    await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(
-      stopped,
-      true,
-      stopped
-        ? createWindowsTaskAutoStartGuard({
-            root: result.root ?? params.root,
-            before: stopped,
-            timeoutMs: params.updateStepTimeoutMs,
-          })
-        : undefined,
-    );
-  };
+  const resumeWindowsAutoStart = async (result: UpdateRunResult) =>
+    resumeWindowsAutoStartForUpdate({
+      result,
+      root: params.root,
+      updateStepTimeoutMs: params.updateStepTimeoutMs,
+      currentServiceStop,
+    });
   let rolledBack = false;
   let completedDowntimeMs: number | undefined = params.coreAlreadyCurrent ? 0 : undefined;
   let pendingRestartAtMs =

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -61,6 +61,7 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
   assertCurrent();
   const shouldRestart =
     params.shouldRestart &&
+    !params.packageAlreadyCurrent &&
     (!params.coreAlreadyCurrent || params.preManagedServiceStop?.running === true);
   let gateway: TriageFailureContext["gateway"] = "preserve";
   let triageAllowed = true;
@@ -508,6 +509,7 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
       const restarted = await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () =>
         maybeRestartService({
           shouldRestart: shouldRestart && restartContext.serviceMutationAllowed,
+          packageAlreadyCurrent: params.packageAlreadyCurrent,
           result: resultWithPostUpdate,
           opts: params.opts,
           refreshServiceEnv: restartContext.refreshGatewayServiceEnv,

--- a/src/cli/update-cli/update-command-service-maintenance.test.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.test.ts
@@ -154,6 +154,77 @@ const nativeOfflineCases: NativeOfflineCase[] = [
   })),
 ];
 
+it.each([
+  {
+    packageAlreadyCurrent: true,
+    expectStop: false,
+    label: "already current",
+  },
+  {
+    packageAlreadyCurrent: false,
+    expectStop: true,
+    label: "version differs",
+  },
+] as const)(
+  "stops a running owned gateway before package update only when the version differs ($label)",
+  async ({ packageAlreadyCurrent, expectStop }) => {
+    const home = await makeTempWorkspace("openclaw-update-already-current-stop-");
+    try {
+      await withEnvAsync(
+        {
+          HOME: home,
+          USERPROFILE: home,
+          APPDATA: path.join(home, "AppData"),
+          OPENCLAW_GATEWAY_PORT: undefined,
+          OPENCLAW_HOME: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_PROFILE: undefined,
+          OPENCLAW_SUPERVISOR_MODE: undefined,
+          OPENCLAW_SERVICE_MARKER: undefined,
+          OPENCLAW_SERVICE_KIND: undefined,
+        },
+        async () => {
+          mockProcessPlatform("linux");
+          const service = createMockGatewayService({
+            readCommand: async () => ({
+              programArguments: [
+                process.execPath,
+                path.join(process.cwd(), "openclaw.mjs"),
+                "gateway",
+              ],
+              environment: { HOME: home },
+            }),
+            readRuntime: async () => ({ status: "running", pid: process.pid + 1 }),
+            isLoaded: async () => true,
+            isEnabled: async () => true,
+          });
+          mocks.service.mockReturnValue(service);
+          const inspected = await maybeStopManagedServiceBeforeMutableUpdate({
+            root: process.cwd(),
+            updateInstallKind: "package",
+            shouldRestart: true,
+            jsonMode: true,
+            packageAlreadyCurrent,
+          });
+          expect(inspected.serviceUpdateVerdict?.kind).toBe("owned");
+          expect(inspected.running).toBe(true);
+          expect(inspected.stopped).toBe(expectStop);
+          if (expectStop) {
+            expect(service.stop).toHaveBeenCalledOnce();
+          } else {
+            expect(service.stop).not.toHaveBeenCalled();
+          }
+          expect(service.start).not.toHaveBeenCalled();
+          expect(service.restart).not.toHaveBeenCalled();
+        },
+      );
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  },
+);
+
 it.each(nativeOfflineCases)(
   "requires affirmative native offline proof for owned $platform service ($label)",
   (scenario) =>

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -333,6 +333,8 @@ type ManagedServiceStopParams = {
   root: string;
   shouldRestart: boolean;
   jsonMode: boolean;
+  /** When true, leave a running managed gateway up (no-op version match). */
+  packageAlreadyCurrent?: boolean;
   phase?: "inspect" | "prepare";
   handoffFromGateway?: (state: GatewayServiceState) => Promise<boolean>;
   expectedService?: Pick<
@@ -509,7 +511,13 @@ async function stopManagedServiceBeforeMutableUpdate(
   }
   // Pure inventory inspection supplies no handoff callback. Execution supplies it
   // only after complete target admission, before online candidate validation.
-  if (params.shouldRestart && serviceState.running && params.handoffFromGateway) {
+  // A no-op version match must not hand off or SIGTERM the live gateway.
+  if (
+    params.shouldRestart &&
+    !params.packageAlreadyCurrent &&
+    serviceState.running &&
+    params.handoffFromGateway
+  ) {
     const blockMessage = gatewayMaintenanceBlockMessage(serviceState, params.root, "handoff");
     if (blockMessage) {
       return { ...inspected, blockMessage };
@@ -549,18 +557,24 @@ async function stopManagedServiceBeforeMutableUpdate(
   // need the handoff marker to distinguish that transition from operator-stopped state.
   const supervisorMayRespawn =
     params.shouldRestart &&
+    !params.packageAlreadyCurrent &&
     serviceState.loadState.status === "loaded" &&
     (process.platform === "darwin"
       ? (await service.isEnabled?.({ env: serviceState.env, timeoutMs: params.timeoutMs })) === true
       : process.env.OPENCLAW_UPDATE_RUN_HANDOFF === "1");
   assertCurrent();
-  if (!params.shouldRestart || (!serviceState.running && !supervisorMayRespawn)) {
-    if (!params.shouldRestart && !params.jsonMode && serviceState.running) {
-      const warning = `--no-restart is set while the managed gateway service is running; the ${params.updateInstallKind} update will not stop or restart that process.`;
+  const leaveManagedGatewayRunning = !params.shouldRestart || Boolean(params.packageAlreadyCurrent);
+  if (leaveManagedGatewayRunning || (!serviceState.running && !supervisorMayRespawn)) {
+    if (leaveManagedGatewayRunning && !params.jsonMode && serviceState.running) {
+      const warning = params.packageAlreadyCurrent
+        ? "Package already matches the target version; leaving the managed gateway running."
+        : `--no-restart is set while the managed gateway service is running; the ${params.updateInstallKind} update will not stop or restart that process.`;
       defaultRuntime.log(theme.warn(warning));
     }
     const windowsTaskAutoStartRecovery =
-      !params.shouldRestart && isGatewayServiceEnv(process.env) ? undefined : await suspendTask();
+      leaveManagedGatewayRunning && isGatewayServiceEnv(process.env)
+        ? undefined
+        : await suspendTask();
     return {
       ...inspected,
       ...(windowsTaskAutoStartRecovery ? { windowsTaskAutoStartRecovery } : {}),

--- a/src/cli/update-cli/update-command-service.test.ts
+++ b/src/cli/update-cli/update-command-service.test.ts
@@ -368,6 +368,35 @@ describe("maybeRestartService", () => {
     },
   );
 
+  
+  it("leaves a current gateway running without the --no-restart tip", async () => {
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+
+    await expect(
+      maybeRestartService({
+        shouldRestart: false,
+        result: {
+          status: "ok",
+          mode: "npm",
+          steps: [],
+          durationMs: 0,
+        },
+        opts: {},
+        refreshServiceEnv: false,
+        gatewayPort: 18789,
+        timeoutMs: 1_000,
+        packageAlreadyCurrent: true,
+      }),
+    ).resolves.toBe("ok");
+
+    const logs = logSpy.mock.calls.map((call) => String(call[0]));
+    expect(logs.some((line) => line.includes("already at target version; left running"))).toBe(
+      true,
+    );
+    expect(logs.some((line) => line.includes("restart skipped (--no-restart)"))).toBe(false);
+    logSpy.mockRestore();
+  });
+
   it("rejects channel failures even when a Git target has no build identity", async () => {
     mocks.waitForGatewayHealthyRestart.mockResolvedValue({
       runtime: { status: "running", pid: 8000 },

--- a/src/cli/update-cli/update-command-service.test.ts
+++ b/src/cli/update-cli/update-command-service.test.ts
@@ -368,7 +368,6 @@ describe("maybeRestartService", () => {
     },
   );
 
-  
   it("leaves a current gateway running without the --no-restart tip", async () => {
     const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
 

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -216,6 +216,7 @@ export async function maybeRestartService(params: {
   requireRunningServiceAfterRestart?: boolean;
   serviceMutationSkipMessage?: string;
   timeoutMs: number;
+  packageAlreadyCurrent?: boolean;
   onVerificationFailure?: (reason: string) => void;
   onVerified?: (verifiedAtMs: number) => void;
 }): Promise<"ok" | "failed" | "restart-health-failed"> {
@@ -586,6 +587,14 @@ export async function maybeRestartService(params: {
         return await failed("restart-health-failed");
       }
       return await failed();
+    }
+    return "ok";
+  }
+
+  if (activation.packageAlreadyCurrent) {
+    if (!activation.opts.json) {
+      defaultRuntime.log("");
+      defaultRuntime.log(theme.muted("Gateway: already at target version; left running."));
     }
     return "ok";
   }

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -543,6 +543,7 @@ async function updateCommandInternal(
     // service; otherwise the unchanged unit could still restart on the stale Node.
     const canRefreshManagedServiceNode =
       shouldRestart &&
+      !packageAlreadyCurrent &&
       managedServiceNodeRunner !== undefined &&
       (await gatewayServiceCommandUsesRoot({ root })) === true;
     const runtimePreflight = await resolvePackageRuntimePreflight({
@@ -629,6 +630,7 @@ async function updateCommandInternal(
     tag,
     opts,
     shouldRestart,
+    packageAlreadyCurrent,
     devTarget,
     packageInstallSpec,
     packageInstallEnv,
@@ -684,6 +686,7 @@ async function updateCommandInternal(
     channel,
     downgradeRisk,
     shouldRestart,
+    packageAlreadyCurrent,
     opts,
     ownedManagedUpdateEnv: ownedManagedUpdateContext?.env,
     controlPlaneUpdateSentinelMeta,


### PR DESCRIPTION
Closes #136997.

## What Problem This Solves

Fixes an issue where operators running `openclaw update` on an already-current install would have their running managed gateway stopped and restarted for nothing. The no-op path (`currentVersion === targetVersion`) still went through the stop-replace-restart service maintenance sequence, so an "already current" update dropped live gateway connections and paused channel ingress for the duration of the restart.

## Why This Change Was Made

`openclaw update` resolved the managed-gateway verdict and always executed the stop step before the package update, regardless of whether a package update was actually going to happen. The fix gates the managed gateway stop on a real version change: when the resolved target equals the installed version, the gateway keeps running. Plugin and shell-completion refresh still run on the no-op path, so nothing else about `update` changes. Real upgrades keep the existing stop-replace-restart behavior, and `--no-restart` semantics are untouched.

A follow-up commit on this branch moves the `ManagedGatewayUpdateVerdict` type from `update-command-service-maintenance.ts` into `update-command-service-plan.ts` (where the other managed-service plan types already live) so the maintenance module returns under the 700-line `max-lines` budget. No suppression was added and no baseline entry was introduced.

## User Impact

Operators who run `openclaw update` on a current install no longer lose their gateway session: no dropped WebSocket clients, no channel ingress gap, no restart latency. Upgrades behave exactly as before.

## Evidence

Focused tests on the changed modules, run on this branch:

```
$ ./node_modules/.bin/vitest run src/cli/update-cli/update-command-service-maintenance.test.ts src/cli/update-cli/update-command-service.test.ts

 ✓ |cli| src/cli/update-cli/update-command-service-maintenance.test.ts > stops a running owned gateway before package update only when the version differs ('already current') 95ms
 ✓ |cli| src/cli/update-cli/update-command-service-maintenance.test.ts > stops a running owned gateway before package update only when the version differs ('version differs') 15ms
 ✓ |cli| src/cli/update-cli/update-command-service.test.ts > maybeRestartService > leaves a current gateway running without the --no-restart tip 3ms
 ...
 Test Files  2 passed (2)
      Tests  21 passed (21)
```

The `already current` / `version differs` pair is the direct regression lock for this fix: same fixture, only the resolved target version differs, and the stop call is asserted absent in the first case and present in the second.

Lint gate (`check-lint-core-1`, `eslint(max-lines)`) verified locally before and after the split commit:

```
# before
$ ./node_modules/.bin/oxlint --config .oxlintrc.json src/cli/update-cli/update-command-service-maintenance.ts
src/cli/update-cli/update-command-service-maintenance.ts:759:2: error eslint(max-lines): File has too many lines (702). help: Maximum allowed is 700.
exit=1

# after
$ ./node_modules/.bin/oxlint --config .oxlintrc.json src/cli/update-cli/update-command-service-maintenance.ts
exit=0
```
