### PR TITLE
fix(plugin-sdk): strip undeclared __exportAll from published dts

### DIFF
--- a/scripts/check-plugin-sdk-exports.mts
+++ b/scripts/check-plugin-sdk-exports.mts
@@ -143,6 +143,10 @@ export default defineChannelPluginEntry({
 `,
     );
     writeFileSync(join(consumerRoot, "package.json"), '{"private":true,"type":"module"}\n');
+    // Keep skipLibCheck on for this in-tree consumer: workspace @openclaw/ai
+    // declaration caches can omit .d.mts while still shipping .mjs, which makes
+    // skipLibCheck:false fail with TS7016 before the helper scan below. Packed
+    // release-check still uses skipLibCheck:false against a complete tarball.
     writeFileSync(
       join(consumerRoot, "tsconfig.json"),
       `{

--- a/scripts/check-plugin-sdk-exports.mts
+++ b/scripts/check-plugin-sdk-exports.mts
@@ -13,6 +13,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -29,6 +30,7 @@ import {
   isPrivateQaPluginSdkBuild,
 } from "./lib/plugin-sdk-declaration-budget.mts";
 import { publicPluginSdkEntrypoints, publicPluginSdkSubpaths } from "./lib/plugin-sdk-entries.mts";
+import { findUndeclaredBundlerHelperDtsExports } from "./lib/sanitize-bundler-helper-dts-exports.mts";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
@@ -71,6 +73,7 @@ let missing = 0;
       join(consumerRoot, "index.ts"),
       `import { buildChannelConfigSchema, DmPolicySchema } from "openclaw/plugin-sdk/channel-config-schema";
 import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
+import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
 import { identityEntryAuthenticationClassifier, meetsIdentifierAuthentication } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import type {
   ChannelIngressIdentitySubjectInput,
@@ -105,6 +108,7 @@ void preparedCatalog;
 // @ts-expect-error Prepared selections require their typed catalog metadata.
 const incompletePrepared: typeof preparedModelsData = legacyModelsData;
 void incompletePrepared;
+void defineToolPlugin;
 
 const identifierAuthentication: IdentifierAuthentication = "verified";
 const meetsMinimum: boolean = meetsIdentifierAuthentication(identifierAuthentication, "asserted");
@@ -147,7 +151,7 @@ export default defineChannelPluginEntry({
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noEmit": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "strict": true,
     "types": []
   },
@@ -296,6 +300,41 @@ if (declarationBudget.shouldFail) {
   console.log(
     `Public plugin SDK declaration graph: ${declarationBytes}/${declarationBudget.budgetBytes} bytes (${MAX_PUBLIC_PLUGIN_SDK_DECLARATION_BYTES}-byte ratchet + ${PLUGIN_SDK_DECLARATION_OUTPUT_VARIANCE_BYTES}-byte output variance).`,
   );
+}
+
+{
+  const rootDist = resolve(scriptDir, "..", "dist");
+  if (!existsSync(rootDist)) {
+    console.error("UNDECLARED BUNDLER HELPER DTS EXPORT: missing dist/ for helper export scan");
+    missing += 1;
+  } else {
+    const queue = [rootDist];
+    const visitedDirs = new Set<string>();
+    while (queue.length > 0) {
+      const dir = queue.pop()!;
+      if (visitedDirs.has(dir)) {
+        continue;
+      }
+      visitedDirs.add(dir);
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          queue.push(fullPath);
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith(".d.ts")) {
+          continue;
+        }
+        const sourceText = readFileSync(fullPath, "utf8");
+        for (const finding of findUndeclaredBundlerHelperDtsExports(sourceText, fullPath)) {
+          console.error(
+            `UNDECLARED BUNDLER HELPER DTS EXPORT: ${relative(resolve(scriptDir, ".."), fullPath)}:${finding.line} exports ${finding.name} without a local declaration`,
+          );
+          missing += 1;
+        }
+      }
+    }
+  }
 }
 
 if (missing > 0) {

--- a/scripts/check-plugin-sdk-exports.mts
+++ b/scripts/check-plugin-sdk-exports.mts
@@ -322,7 +322,7 @@ if (declarationBudget.shouldFail) {
           queue.push(fullPath);
           continue;
         }
-        if (!entry.isFile() || !entry.name.endsWith(".d.ts")) {
+        if (!entry.isFile() || !/\.d\.(?:ts|mts|cts)$/u.test(entry.name)) {
           continue;
         }
         const sourceText = readFileSync(fullPath, "utf8");

--- a/scripts/check-plugin-sdk-exports.mts
+++ b/scripts/check-plugin-sdk-exports.mts
@@ -151,7 +151,7 @@ export default defineChannelPluginEntry({
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noEmit": true,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "strict": true,
     "types": []
   },

--- a/scripts/fixtures/packed-plugin-sdk-type-smoke.ts
+++ b/scripts/fixtures/packed-plugin-sdk-type-smoke.ts
@@ -1,11 +1,13 @@
 // Packed Plugin Sdk Type Smoke script supports OpenClaw repository automation.
 import type { ChannelMessagingAdapter } from "openclaw/plugin-sdk/core";
+import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
 type PublicPluginSdkModules = [
   typeof import("openclaw/plugin-sdk/core"),
   typeof import("openclaw/plugin-sdk/channel-entry-contract"),
   typeof import("openclaw/plugin-sdk/config-contracts"),
   typeof import("openclaw/plugin-sdk/plugin-entry"),
   typeof import("openclaw/plugin-sdk/runtime-env"),
+  typeof import("openclaw/plugin-sdk/tool-plugin"),
 ];
 
 const resolvedModules = null as unknown as PublicPluginSdkModules;
@@ -15,3 +17,4 @@ const routeOwnerResolver: NonNullable<
 
 void resolvedModules;
 void routeOwnerResolver;
+void defineToolPlugin;

--- a/scripts/lib/declaration-stage.mts
+++ b/scripts/lib/declaration-stage.mts
@@ -158,4 +158,48 @@ export async function publishStagedDeclarations(
   }
   sealInputs?.();
   publishArtifactFiles(staging, dist, ordered, previous);
+  // Main tsdown also emits hashed root/extension .d.ts into dist/ without
+  // passing through the staging sanitizer above. Sweep the live tree so
+  // undeclared bundler helpers cannot reach the published package.
+  sanitizePublishedDeclarationTree(dist);
+}
+
+function sanitizePublishedDeclarationTree(root: string) {
+  const queue = [root];
+  const seen = new Set<string>();
+  while (queue.length > 0) {
+    const dir = queue.pop()!;
+    if (seen.has(dir)) {
+      continue;
+    }
+    seen.add(dir);
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(fullPath);
+        continue;
+      }
+      if (
+        !entry.isFile() ||
+        !(
+          entry.name.endsWith(".d.ts") ||
+          entry.name.endsWith(".d.mts") ||
+          entry.name.endsWith(".d.cts")
+        )
+      ) {
+        continue;
+      }
+      const current = fs.readFileSync(fullPath, "utf8");
+      const sanitized = sanitizeBundlerHelperDtsExports(current).sourceText;
+      if (sanitized !== current) {
+        fs.writeFileSync(fullPath, sanitized);
+      }
+    }
+  }
 }

--- a/scripts/lib/declaration-stage.mts
+++ b/scripts/lib/declaration-stage.mts
@@ -84,7 +84,9 @@ export async function publishStagedDeclarations(
       const raw = fs.readFileSync(file);
       // Strip undeclared bundler helpers (for example __exportAll) before the
       // staged bytes become the published declaration identity.
-      const sanitizedText = relative.endsWith(".d.ts")
+      const isDeclaration =
+        relative.endsWith(".d.ts") || relative.endsWith(".d.mts") || relative.endsWith(".d.cts");
+      const sanitizedText = isDeclaration
         ? sanitizeBundlerHelperDtsExports(raw.toString("utf8")).sourceText
         : raw.toString("utf8");
       const bytes = Buffer.from(sanitizedText, "utf8");

--- a/scripts/lib/declaration-stage.mts
+++ b/scripts/lib/declaration-stage.mts
@@ -166,19 +166,9 @@ export async function publishStagedDeclarations(
 
 function sanitizePublishedDeclarationTree(root: string) {
   const queue = [root];
-  const seen = new Set<string>();
   while (queue.length > 0) {
     const dir = queue.pop()!;
-    if (seen.has(dir)) {
-      continue;
-    }
-    seen.add(dir);
-    let entries;
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {

--- a/scripts/lib/declaration-stage.mts
+++ b/scripts/lib/declaration-stage.mts
@@ -81,15 +81,10 @@ export async function publishStagedDeclarations(
     for (const file of files) {
       const relative = portableRelativePath(source.output, file);
       const target = path.join(staging, relative);
-      const raw = fs.readFileSync(file);
-      // Strip undeclared bundler helpers (for example __exportAll) before the
-      // staged bytes become the published declaration identity.
-      const isDeclaration =
-        relative.endsWith(".d.ts") || relative.endsWith(".d.mts") || relative.endsWith(".d.cts");
-      const sanitizedText = isDeclaration
-        ? sanitizeBundlerHelperDtsExports(raw.toString("utf8")).sourceText
-        : raw.toString("utf8");
-      const bytes = Buffer.from(sanitizedText, "utf8");
+      const raw = fs.readFileSync(file, "utf8");
+      // Strip generated bundler helpers before staged bytes become the published
+      // declaration identity.
+      const bytes = Buffer.from(sanitizeBundlerHelperDtsExports(raw).sourceText, "utf8");
       // Shared chunks may be identical across groups. A differing owner must
       // fail before publication; last-writer-wins can corrupt nominal identity.
       if (fs.existsSync(target)) {

--- a/scripts/lib/declaration-stage.mts
+++ b/scripts/lib/declaration-stage.mts
@@ -7,6 +7,7 @@ import {
   portableRelativePath,
   publishArtifactFiles,
 } from "./build-artifact-cache.mts";
+import { sanitizeBundlerHelperDtsExports } from "./sanitize-bundler-helper-dts-exports.mts";
 
 function declarationReferences(file: string, contents: string) {
   const source = ts.createSourceFile(file, contents, ts.ScriptTarget.Latest);
@@ -80,7 +81,13 @@ export async function publishStagedDeclarations(
     for (const file of files) {
       const relative = portableRelativePath(source.output, file);
       const target = path.join(staging, relative);
-      const bytes = fs.readFileSync(file);
+      const raw = fs.readFileSync(file);
+      // Strip undeclared bundler helpers (for example __exportAll) before the
+      // staged bytes become the published declaration identity.
+      const sanitizedText = relative.endsWith(".d.ts")
+        ? sanitizeBundlerHelperDtsExports(raw.toString("utf8")).sourceText
+        : raw.toString("utf8");
+      const bytes = Buffer.from(sanitizedText, "utf8");
       // Shared chunks may be identical across groups. A differing owner must
       // fail before publication; last-writer-wins can corrupt nominal identity.
       if (fs.existsSync(target)) {
@@ -98,6 +105,19 @@ export async function publishStagedDeclarations(
     [{ path: ".", extensions: [".d.ts", ".d.mts", ".d.cts"] }],
     fs,
   ).map((file) => portableRelativePath(staging, file));
+  // Invocation-written stages never pass through the source-copy sanitizer above.
+  // Normalize every staged declaration before closure checks and publication.
+  for (const file of files) {
+    if (!file.endsWith(".d.ts") && !file.endsWith(".d.mts") && !file.endsWith(".d.cts")) {
+      continue;
+    }
+    const absolute = path.join(staging, file);
+    const current = fs.readFileSync(absolute, "utf8");
+    const sanitized = sanitizeBundlerHelperDtsExports(current).sourceText;
+    if (sanitized !== current) {
+      fs.writeFileSync(absolute, sanitized);
+    }
+  }
   const emitted = new Set(files);
   for (const entry of required) {
     if (!emitted.has(entry)) {

--- a/scripts/lib/sanitize-bundler-helper-dts-exports.mts
+++ b/scripts/lib/sanitize-bundler-helper-dts-exports.mts
@@ -105,11 +105,11 @@ function scanDts(sourceText: string, fileName: string): DtsSanitization {
   const edits: Array<{ start: number; end: number }> = [];
 
   for (const statement of sourceFile.statements) {
-    if (
-      ts.isImportDeclaration(statement) &&
-      ts.isNamedImports(statement.importClause?.namedBindings)
-    ) {
-      const { namedBindings } = statement.importClause;
+    const importBindings = ts.isImportDeclaration(statement)
+      ? statement.importClause?.namedBindings
+      : undefined;
+    if (importBindings && ts.isNamedImports(importBindings)) {
+      const namedBindings = importBindings;
       const helpers = namedBindings.elements.filter(
         (specifier): specifier is ts.ImportSpecifier =>
           ts.isImportSpecifier(specifier) &&
@@ -127,14 +127,14 @@ function scanDts(sourceText: string, fileName: string): DtsSanitization {
         }
       }
     }
-    if (
-      !ts.isExportDeclaration(statement) ||
-      statement.moduleSpecifier ||
-      !ts.isNamedExports(statement.exportClause)
-    ) {
+    if (!ts.isExportDeclaration(statement) || statement.moduleSpecifier) {
       continue;
     }
-    for (const element of statement.exportClause.elements) {
+    const exportClause = statement.exportClause;
+    if (!ts.isNamedExports(exportClause)) {
+      continue;
+    }
+    for (const element of exportClause.elements) {
       const localName = exportElementLocalName(element);
       if (!isBundlerHelperName(localName) || helperIsDeclared) {
         continue;

--- a/scripts/lib/sanitize-bundler-helper-dts-exports.mts
+++ b/scripts/lib/sanitize-bundler-helper-dts-exports.mts
@@ -132,9 +132,7 @@ export function sanitizeBundlerHelperDtsExports(sourceText: string): {
       node.exportClause &&
       ts.isNamedExports(node.exportClause)
     ) {
-      const elements = node.exportClause.elements;
-      for (let index = 0; index < elements.length; index += 1) {
-        const element = elements[index]!;
+      for (const element of node.exportClause.elements) {
         const localName = exportElementLocalName(element);
         if (!isBundlerHelperName(localName)) {
           continue;
@@ -164,7 +162,7 @@ export function sanitizeBundlerHelperDtsExports(sourceText: string): {
   ts.forEachChild(sourceFile, visit);
 
   let next = sourceText;
-  for (const edit of edits.sort((left, right) => right.start - left.start)) {
+  for (const edit of edits.toSorted((left, right) => right.start - left.start)) {
     next = `${next.slice(0, edit.start)}${next.slice(edit.end)}`;
   }
   return { sourceText: next, removed };

--- a/scripts/lib/sanitize-bundler-helper-dts-exports.mts
+++ b/scripts/lib/sanitize-bundler-helper-dts-exports.mts
@@ -9,9 +9,9 @@
 import ts from "typescript";
 
 /** Runtime helpers that must never appear as undeclared declaration exports. */
-export const BUNDLER_RUNTIME_HELPER_EXPORT_NAMES = ["__exportAll"] as const;
+const BUNDLER_RUNTIME_HELPER_EXPORT_NAMES = ["__exportAll"] as const;
 
-export type BundlerRuntimeHelperExportName = (typeof BUNDLER_RUNTIME_HELPER_EXPORT_NAMES)[number];
+type BundlerRuntimeHelperExportName = (typeof BUNDLER_RUNTIME_HELPER_EXPORT_NAMES)[number];
 
 const HELPER_NAME_SET = new Set<string>(BUNDLER_RUNTIME_HELPER_EXPORT_NAMES);
 

--- a/scripts/lib/sanitize-bundler-helper-dts-exports.mts
+++ b/scripts/lib/sanitize-bundler-helper-dts-exports.mts
@@ -131,7 +131,7 @@ function scanDts(sourceText: string, fileName: string): DtsSanitization {
       continue;
     }
     const exportClause = statement.exportClause;
-    if (!ts.isNamedExports(exportClause)) {
+    if (!exportClause || !ts.isNamedExports(exportClause)) {
       continue;
     }
     for (const element of exportClause.elements) {

--- a/scripts/lib/sanitize-bundler-helper-dts-exports.mts
+++ b/scripts/lib/sanitize-bundler-helper-dts-exports.mts
@@ -1,0 +1,171 @@
+/**
+ * Removes undeclared bundler runtime helpers from emitted `.d.ts` export lists.
+ *
+ * Rolldown/tsdown can mirror JS helpers such as `__exportAll` into declaration
+ * `export { ... }` clauses without emitting a matching type declaration. Strict
+ * consumers then fail with TS2304 when they import public SDK entrypoints that
+ * resolve through those chunks (for example `openclaw/plugin-sdk/tool-plugin`).
+ */
+import ts from "typescript";
+
+/** Runtime helpers that must never appear as undeclared declaration exports. */
+export const BUNDLER_RUNTIME_HELPER_EXPORT_NAMES = ["__exportAll"] as const;
+
+export type BundlerRuntimeHelperExportName = (typeof BUNDLER_RUNTIME_HELPER_EXPORT_NAMES)[number];
+
+const HELPER_NAME_SET = new Set<string>(BUNDLER_RUNTIME_HELPER_EXPORT_NAMES);
+
+export type UndeclaredBundlerHelperDtsExport = {
+  /** Helper local name as it appears in the export clause. */
+  name: BundlerRuntimeHelperExportName;
+  /** 1-based line of the export clause. */
+  line: number;
+};
+
+function isBundlerHelperName(name: string | undefined): name is BundlerRuntimeHelperExportName {
+  return Boolean(name && HELPER_NAME_SET.has(name));
+}
+
+function hasLocalHelperDeclaration(sourceFile: ts.SourceFile, name: string): boolean {
+  let found = false;
+  const visit = (node: ts.Node) => {
+    if (found) {
+      return;
+    }
+    if (ts.isFunctionDeclaration(node) && node.name?.text === name) {
+      found = true;
+      return;
+    }
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === name) {
+      found = true;
+      return;
+    }
+    if (
+      (ts.isClassDeclaration(node) ||
+        ts.isInterfaceDeclaration(node) ||
+        ts.isTypeAliasDeclaration(node) ||
+        ts.isEnumDeclaration(node) ||
+        ts.isModuleDeclaration(node)) &&
+      node.name &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return found;
+}
+
+function exportElementLocalName(element: ts.ExportSpecifier): string | undefined {
+  return element.propertyName?.text ?? element.name.text;
+}
+
+/**
+ * Finds bundler helpers that are re-exported from a declaration file without a
+ * local declaration the TypeScript checker can resolve.
+ */
+export function findUndeclaredBundlerHelperDtsExports(
+  sourceText: string,
+  fileName = "chunk.d.ts",
+): UndeclaredBundlerHelperDtsExport[] {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    ts.ScriptKind.TS,
+  );
+  const findings: UndeclaredBundlerHelperDtsExport[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isExportDeclaration(node) &&
+      !node.moduleSpecifier &&
+      node.exportClause &&
+      ts.isNamedExports(node.exportClause)
+    ) {
+      for (const element of node.exportClause.elements) {
+        const localName = exportElementLocalName(element);
+        if (!isBundlerHelperName(localName)) {
+          continue;
+        }
+        if (hasLocalHelperDeclaration(sourceFile, localName)) {
+          continue;
+        }
+        const { line } = sourceFile.getLineAndCharacterOfPosition(element.getStart(sourceFile));
+        findings.push({ name: localName, line: line + 1 });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return findings;
+}
+
+/**
+ * Drops undeclared bundler helper export specifiers from declaration text.
+ * Preserves surrounding formatting where practical.
+ */
+export function sanitizeBundlerHelperDtsExports(sourceText: string): {
+  sourceText: string;
+  removed: UndeclaredBundlerHelperDtsExport[];
+} {
+  const removed = findUndeclaredBundlerHelperDtsExports(sourceText);
+  if (removed.length === 0) {
+    return { sourceText, removed };
+  }
+
+  const sourceFile = ts.createSourceFile(
+    "chunk.d.ts",
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    ts.ScriptKind.TS,
+  );
+  const edits: Array<{ start: number; end: number }> = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isExportDeclaration(node) &&
+      !node.moduleSpecifier &&
+      node.exportClause &&
+      ts.isNamedExports(node.exportClause)
+    ) {
+      const elements = node.exportClause.elements;
+      for (let index = 0; index < elements.length; index += 1) {
+        const element = elements[index]!;
+        const localName = exportElementLocalName(element);
+        if (!isBundlerHelperName(localName)) {
+          continue;
+        }
+        if (hasLocalHelperDeclaration(sourceFile, localName)) {
+          continue;
+        }
+        const start = element.getFullStart();
+        let end = element.getEnd();
+        // Consume a following comma when present so we do not leave `a, , b`.
+        const after = sourceText.slice(end).match(/^\s*,/u);
+        if (after) {
+          end += after[0].length;
+        } else {
+          // Or a preceding comma when this is the final specifier.
+          const before = sourceText.slice(0, start).match(/,\s*$/u);
+          if (before) {
+            edits.push({ start: start - before[0].length, end });
+            continue;
+          }
+        }
+        edits.push({ start, end });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+
+  let next = sourceText;
+  for (const edit of edits.sort((left, right) => right.start - left.start)) {
+    next = `${next.slice(0, edit.start)}${next.slice(edit.end)}`;
+  }
+  return { sourceText: next, removed };
+}

--- a/scripts/lib/sanitize-bundler-helper-dts-exports.mts
+++ b/scripts/lib/sanitize-bundler-helper-dts-exports.mts
@@ -22,55 +22,77 @@ export type UndeclaredBundlerHelperDtsExport = {
   line: number;
 };
 
+type DtsSanitization = {
+  edits: Array<{ start: number; end: number }>;
+  removed: UndeclaredBundlerHelperDtsExport[];
+};
+
 function isBundlerHelperName(name: string | undefined): name is BundlerRuntimeHelperExportName {
   return Boolean(name && HELPER_NAME_SET.has(name));
 }
 
-function hasLocalHelperDeclaration(sourceFile: ts.SourceFile, name: string): boolean {
-  let found = false;
-  const visit = (node: ts.Node) => {
-    if (found) {
-      return;
+function hasLocalHelperBinding(sourceFile: ts.SourceFile, name: string): boolean {
+  return sourceFile.statements.some((statement) => {
+    if (ts.isImportDeclaration(statement) && statement.importClause) {
+      const { importClause } = statement;
+      if (importClause.name?.text === name) {
+        return true;
+      }
+      const bindings = importClause.namedBindings;
+      if (!bindings) {
+        return false;
+      }
+      if (ts.isNamespaceImport(bindings)) {
+        return bindings.name.text === name;
+      }
+      return bindings.elements.some(
+        (specifier) =>
+          ts.isImportSpecifier(specifier) &&
+          specifier.name.text === name &&
+          (specifier.propertyName?.text ?? name) === name,
+      );
     }
-    if (ts.isFunctionDeclaration(node) && node.name?.text === name) {
-      found = true;
-      return;
-    }
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === name) {
-      found = true;
-      return;
+    if (ts.isVariableStatement(statement)) {
+      return statement.declarationList.declarations.some(
+        (declaration) => ts.isIdentifier(declaration.name) && declaration.name.text === name,
+      );
     }
     if (
-      (ts.isClassDeclaration(node) ||
-        ts.isInterfaceDeclaration(node) ||
-        ts.isTypeAliasDeclaration(node) ||
-        ts.isEnumDeclaration(node) ||
-        ts.isModuleDeclaration(node)) &&
-      node.name &&
-      ts.isIdentifier(node.name) &&
-      node.name.text === name
+      ts.isClassDeclaration(statement) ||
+      ts.isFunctionDeclaration(statement) ||
+      ts.isInterfaceDeclaration(statement) ||
+      ts.isTypeAliasDeclaration(statement) ||
+      ts.isEnumDeclaration(statement) ||
+      ts.isModuleDeclaration(statement)
     ) {
-      found = true;
-      return;
+      return statement.name?.text === name;
     }
-    ts.forEachChild(node, visit);
-  };
-  ts.forEachChild(sourceFile, visit);
-  return found;
+    return false;
+  });
 }
 
 function exportElementLocalName(element: ts.ExportSpecifier): string | undefined {
   return element.propertyName?.text ?? element.name.text;
 }
 
-/**
- * Finds bundler helpers that are re-exported from a declaration file without a
- * local declaration the TypeScript checker can resolve.
- */
-export function findUndeclaredBundlerHelperDtsExports(
+function removeListElement(
   sourceText: string,
-  fileName = "chunk.d.ts",
-): UndeclaredBundlerHelperDtsExport[] {
+  element: ts.Node,
+  edits: Array<{ start: number; end: number }>,
+) {
+  const start = element.getFullStart();
+  let end = element.getEnd();
+  const after = sourceText.slice(end).match(/^\s*,/u);
+  if (after) {
+    end += after[0].length;
+    edits.push({ start, end });
+    return;
+  }
+  const before = sourceText.slice(0, start).match(/,\s*$/u);
+  edits.push({ start: before ? start - before[0].length : start, end });
+}
+
+function scanDts(sourceText: string, fileName: string): DtsSanitization {
   const sourceFile = ts.createSourceFile(
     fileName,
     sourceText,
@@ -78,89 +100,67 @@ export function findUndeclaredBundlerHelperDtsExports(
     /*setParentNodes*/ true,
     ts.ScriptKind.TS,
   );
-  const findings: UndeclaredBundlerHelperDtsExport[] = [];
-  const visit = (node: ts.Node) => {
+  const helperIsDeclared = hasLocalHelperBinding(sourceFile, "__exportAll");
+  const removed: UndeclaredBundlerHelperDtsExport[] = [];
+  const edits: Array<{ start: number; end: number }> = [];
+
+  for (const statement of sourceFile.statements) {
     if (
-      ts.isExportDeclaration(node) &&
-      !node.moduleSpecifier &&
-      node.exportClause &&
-      ts.isNamedExports(node.exportClause)
+      ts.isImportDeclaration(statement) &&
+      ts.isNamedImports(statement.importClause?.namedBindings)
     ) {
-      for (const element of node.exportClause.elements) {
-        const localName = exportElementLocalName(element);
-        if (!isBundlerHelperName(localName)) {
-          continue;
+      const { namedBindings } = statement.importClause;
+      const helpers = namedBindings.elements.filter(
+        (specifier): specifier is ts.ImportSpecifier =>
+          ts.isImportSpecifier(specifier) &&
+          specifier.name.text === "__exportAll" &&
+          specifier.propertyName !== undefined &&
+          specifier.propertyName.text !== "__exportAll",
+      );
+      if (helpers.length > 0) {
+        if (helpers.length === namedBindings.elements.length) {
+          edits.push({ start: statement.getFullStart(), end: statement.getEnd() });
+        } else {
+          for (const helper of helpers) {
+            removeListElement(sourceText, helper, edits);
+          }
         }
-        if (hasLocalHelperDeclaration(sourceFile, localName)) {
-          continue;
-        }
-        const { line } = sourceFile.getLineAndCharacterOfPosition(element.getStart(sourceFile));
-        findings.push({ name: localName, line: line + 1 });
       }
     }
-    ts.forEachChild(node, visit);
-  };
-  ts.forEachChild(sourceFile, visit);
-  return findings;
+    if (
+      !ts.isExportDeclaration(statement) ||
+      statement.moduleSpecifier ||
+      !ts.isNamedExports(statement.exportClause)
+    ) {
+      continue;
+    }
+    for (const element of statement.exportClause.elements) {
+      const localName = exportElementLocalName(element);
+      if (!isBundlerHelperName(localName) || helperIsDeclared) {
+        continue;
+      }
+      const { line } = sourceFile.getLineAndCharacterOfPosition(element.getStart(sourceFile));
+      removed.push({ name: localName, line: line + 1 });
+      removeListElement(sourceText, element, edits);
+    }
+  }
+  return { edits, removed };
 }
 
-/**
- * Drops undeclared bundler helper export specifiers from declaration text.
- * Preserves surrounding formatting where practical.
- */
+/** Finds undeclared bundler helpers re-exported from a declaration file. */
+export function findUndeclaredBundlerHelperDtsExports(
+  sourceText: string,
+  fileName = "chunk.d.ts",
+): UndeclaredBundlerHelperDtsExport[] {
+  return scanDts(sourceText, fileName).removed;
+}
+
+/** Drops undeclared bundler helper specifiers from declaration text. */
 export function sanitizeBundlerHelperDtsExports(sourceText: string): {
   sourceText: string;
   removed: UndeclaredBundlerHelperDtsExport[];
 } {
-  const removed = findUndeclaredBundlerHelperDtsExports(sourceText);
-  if (removed.length === 0) {
-    return { sourceText, removed };
-  }
-
-  const sourceFile = ts.createSourceFile(
-    "chunk.d.ts",
-    sourceText,
-    ts.ScriptTarget.Latest,
-    /*setParentNodes*/ true,
-    ts.ScriptKind.TS,
-  );
-  const edits: Array<{ start: number; end: number }> = [];
-  const visit = (node: ts.Node) => {
-    if (
-      ts.isExportDeclaration(node) &&
-      !node.moduleSpecifier &&
-      node.exportClause &&
-      ts.isNamedExports(node.exportClause)
-    ) {
-      for (const element of node.exportClause.elements) {
-        const localName = exportElementLocalName(element);
-        if (!isBundlerHelperName(localName)) {
-          continue;
-        }
-        if (hasLocalHelperDeclaration(sourceFile, localName)) {
-          continue;
-        }
-        const start = element.getFullStart();
-        let end = element.getEnd();
-        // Consume a following comma when present so we do not leave `a, , b`.
-        const after = sourceText.slice(end).match(/^\s*,/u);
-        if (after) {
-          end += after[0].length;
-        } else {
-          // Or a preceding comma when this is the final specifier.
-          const before = sourceText.slice(0, start).match(/,\s*$/u);
-          if (before) {
-            edits.push({ start: start - before[0].length, end });
-            continue;
-          }
-        }
-        edits.push({ start, end });
-      }
-    }
-    ts.forEachChild(node, visit);
-  };
-  ts.forEachChild(sourceFile, visit);
-
+  const { edits, removed } = scanDts(sourceText, "chunk.d.ts");
   let next = sourceText;
   for (const edit of edits.toSorted((left, right) => right.start - left.start)) {
     next = `${next.slice(0, edit.start)}${next.slice(edit.end)}`;

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -766,6 +766,10 @@ export function createPackedPluginSdkTypescriptSmokeProject(params: {
 }): void {
   const dependencies: Record<string, string> = {
     openclaw: params.packageSpec,
+    // Strict declaration checking needs the release-declared ws types; without
+    // them skipLibCheck:false reports TS7016 before the __exportAll TS2304.
+    "@types/ws": "8.18.1",
+    typescript: "6.0.3",
   };
   if (params.aiPackageSpec) {
     dependencies["@openclaw/ai"] = params.aiPackageSpec;
@@ -794,7 +798,7 @@ export function createPackedPluginSdkTypescriptSmokeProject(params: {
           moduleResolution: "NodeNext",
           noEmit: true,
           strict: true,
-          skipLibCheck: true,
+          skipLibCheck: false,
           target: "ES2022",
         },
         include: ["src/index.ts"],

--- a/test/fixtures/published-2026.8.2-undeclared-exportall.d.ts
+++ b/test/fixtures/published-2026.8.2-undeclared-exportall.d.ts
@@ -1,0 +1,5 @@
+// Compact excerpt of the published openclaw@2026.8.2 agent-harness-runtime chunk
+// export clause that incorrectly re-exported an undeclared bundler helper (issue #136881).
+export declare const SessionDiscussionProvider: unknown;
+export declare const DispatchReplyWithDispatcher: unknown;
+export { SessionDiscussionProvider as uc, __exportAll as ud, DispatchReplyWithDispatcher as ui };

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -878,13 +878,15 @@ describe("createPackedPluginSdkTypescriptSmokeProject", () => {
 
       expect(packageJson.dependencies?.openclaw).toBe(`file:${packageRoot}`);
       expect(packageJson.dependencies?.["@openclaw/ai"]).toBe("file:/tmp/openclaw-ai.tgz");
-      expect(tsconfig.compilerOptions?.skipLibCheck).toBe(true);
+      expect(tsconfig.compilerOptions?.skipLibCheck).toBe(false);
       expect(source).toBe(fixtureSource);
       expect(source).toContain('"openclaw/plugin-sdk/core"');
       expect(source).toContain('"openclaw/plugin-sdk/plugin-entry"');
       expect(source).toContain('"openclaw/plugin-sdk/channel-entry-contract"');
       expect(source).toContain('"openclaw/plugin-sdk/config-contracts"');
       expect(source).toContain('"openclaw/plugin-sdk/runtime-env"');
+      expect(source).toContain('"openclaw/plugin-sdk/tool-plugin"');
+      expect(source).toContain("defineToolPlugin");
       expect(source).toContain("type PublicPluginSdkModules = [");
       expect(source).not.toContain("TelegramAccountConfig");
       expect(source).not.toContain("openclaw/plugin-sdk/channel-contract-testing");

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -877,6 +877,8 @@ describe("createPackedPluginSdkTypescriptSmokeProject", () => {
       );
 
       expect(packageJson.dependencies?.openclaw).toBe(`file:${packageRoot}`);
+      expect(packageJson.dependencies?.["@types/ws"]).toBe("8.18.1");
+      expect(packageJson.dependencies?.typescript).toBe("6.0.3");
       expect(packageJson.dependencies?.["@openclaw/ai"]).toBe("file:/tmp/openclaw-ai.tgz");
       expect(tsconfig.compilerOptions?.skipLibCheck).toBe(false);
       expect(source).toBe(fixtureSource);

--- a/test/scripts/declaration-stage.test.ts
+++ b/test/scripts/declaration-stage.test.ts
@@ -31,6 +31,31 @@ function fixture() {
 }
 
 describe("canonical declaration stage", () => {
+  it("strips undeclared __exportAll from staged declaration exports", async () => {
+    const { staging, dist, invocation } = fixture();
+    await publishStagedDeclarations(
+      {
+        env: process.env,
+        maxOldSpaceMb: 8192,
+        heapShortfall: null,
+        invocations: [
+          invocation({
+            "plugin-sdk/core.d.ts":
+              "export declare const keep: number;\nexport { keep as k, __exportAll as ud };\n",
+          }),
+        ],
+      },
+      [],
+      staging,
+      dist,
+      ["plugin-sdk/core.d.ts"],
+      ["plugin-sdk/obsolete.d.ts"],
+    );
+    const published = fs.readFileSync(path.join(dist, "plugin-sdk/core.d.ts"), "utf8");
+    expect(published).toContain("keep as k");
+    expect(published).not.toContain("__exportAll");
+  });
+
   it("rejects absolute reference paths even when a staged relative namesake exists", async () => {
     const { staging, dist, invocation } = fixture();
     await expect(

--- a/test/scripts/declaration-stage.test.ts
+++ b/test/scripts/declaration-stage.test.ts
@@ -59,6 +59,34 @@ describe("canonical declaration stage", () => {
     },
   );
 
+  it("also strips undeclared __exportAll left in live dist outside staging", async () => {
+    const { staging, dist, invocation } = fixture();
+    fs.writeFileSync(
+      path.join(dist, "leftover-chunk.d.ts"),
+      "export declare const keep: number;\nexport { keep as k, __exportAll as ud };\n",
+    );
+    await publishStagedDeclarations(
+      {
+        env: process.env,
+        maxOldSpaceMb: 8192,
+        heapShortfall: null,
+        invocations: [
+          invocation({
+            "plugin-sdk/core.d.ts": "export declare const ok: true;\n",
+          }),
+        ],
+      },
+      [],
+      staging,
+      dist,
+      ["plugin-sdk/core.d.ts"],
+      ["plugin-sdk/obsolete.d.ts"],
+    );
+    const leftover = fs.readFileSync(path.join(dist, "leftover-chunk.d.ts"), "utf8");
+    expect(leftover).toContain("keep as k");
+    expect(leftover).not.toContain("__exportAll");
+  });
+
   it("rejects absolute reference paths even when a staged relative namesake exists", async () => {
     const { staging, dist, invocation } = fixture();
     await expect(

--- a/test/scripts/declaration-stage.test.ts
+++ b/test/scripts/declaration-stage.test.ts
@@ -31,30 +31,33 @@ function fixture() {
 }
 
 describe("canonical declaration stage", () => {
-  it("strips undeclared __exportAll from staged declaration exports", async () => {
-    const { staging, dist, invocation } = fixture();
-    await publishStagedDeclarations(
-      {
-        env: process.env,
-        maxOldSpaceMb: 8192,
-        heapShortfall: null,
-        invocations: [
-          invocation({
-            "plugin-sdk/core.d.ts":
-              "export declare const keep: number;\nexport { keep as k, __exportAll as ud };\n",
-          }),
-        ],
-      },
-      [],
-      staging,
-      dist,
-      ["plugin-sdk/core.d.ts"],
-      ["plugin-sdk/obsolete.d.ts"],
-    );
-    const published = fs.readFileSync(path.join(dist, "plugin-sdk/core.d.ts"), "utf8");
-    expect(published).toContain("keep as k");
-    expect(published).not.toContain("__exportAll");
-  });
+  it.each([".d.ts", ".d.mts", ".d.cts"])(
+    "strips undeclared __exportAll from staged %s declaration exports",
+    async (extension) => {
+      const { staging, dist, invocation } = fixture();
+      await publishStagedDeclarations(
+        {
+          env: process.env,
+          maxOldSpaceMb: 8192,
+          heapShortfall: null,
+          invocations: [
+            invocation({
+              [`plugin-sdk/core${extension}`]:
+                "export declare const keep: number;\nexport { keep as k, __exportAll as ud };\n",
+            }),
+          ],
+        },
+        [],
+        staging,
+        dist,
+        [`plugin-sdk/core${extension}`],
+        ["plugin-sdk/obsolete.d.ts"],
+      );
+      const published = fs.readFileSync(path.join(dist, `plugin-sdk/core${extension}`), "utf8");
+      expect(published).toContain("keep as k");
+      expect(published).not.toContain("__exportAll");
+    },
+  );
 
   it("rejects absolute reference paths even when a staged relative namesake exists", async () => {
     const { staging, dist, invocation } = fixture();

--- a/test/scripts/declaration-stage.test.ts
+++ b/test/scripts/declaration-stage.test.ts
@@ -59,33 +59,36 @@ describe("canonical declaration stage", () => {
     },
   );
 
-  it("also strips undeclared __exportAll left in live dist outside staging", async () => {
-    const { staging, dist, invocation } = fixture();
-    fs.writeFileSync(
-      path.join(dist, "leftover-chunk.d.ts"),
-      "export declare const keep: number;\nexport { keep as k, __exportAll as ud };\n",
-    );
-    await publishStagedDeclarations(
-      {
-        env: process.env,
-        maxOldSpaceMb: 8192,
-        heapShortfall: null,
-        invocations: [
-          invocation({
-            "plugin-sdk/core.d.ts": "export declare const ok: true;\n",
-          }),
-        ],
-      },
-      [],
-      staging,
-      dist,
-      ["plugin-sdk/core.d.ts"],
-      ["plugin-sdk/obsolete.d.ts"],
-    );
-    const leftover = fs.readFileSync(path.join(dist, "leftover-chunk.d.ts"), "utf8");
-    expect(leftover).toContain("keep as k");
-    expect(leftover).not.toContain("__exportAll");
-  });
+  it.each([".d.ts", ".d.mts", ".d.cts"])(
+    "also strips undeclared __exportAll left in live dist outside staging (%s)",
+    async (extension) => {
+      const { staging, dist, invocation } = fixture();
+      fs.writeFileSync(
+        path.join(dist, `leftover-chunk${extension}`),
+        "export declare const keep: number;\nexport { keep as k, __exportAll as ud };\n",
+      );
+      await publishStagedDeclarations(
+        {
+          env: process.env,
+          maxOldSpaceMb: 8192,
+          heapShortfall: null,
+          invocations: [
+            invocation({
+              "plugin-sdk/core.d.ts": "export declare const ok: true;\n",
+            }),
+          ],
+        },
+        [],
+        staging,
+        dist,
+        ["plugin-sdk/core.d.ts"],
+        ["plugin-sdk/obsolete.d.ts"],
+      );
+      const leftover = fs.readFileSync(path.join(dist, `leftover-chunk${extension}`), "utf8");
+      expect(leftover).toContain("keep as k");
+      expect(leftover).not.toContain("__exportAll");
+    },
+  );
 
   it("rejects absolute reference paths even when a staged relative namesake exists", async () => {
     const { staging, dist, invocation } = fixture();

--- a/test/scripts/sanitize-bundler-helper-dts-exports.test.ts
+++ b/test/scripts/sanitize-bundler-helper-dts-exports.test.ts
@@ -1,16 +1,9 @@
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   findUndeclaredBundlerHelperDtsExports,
   sanitizeBundlerHelperDtsExports,
 } from "../../scripts/lib/sanitize-bundler-helper-dts-exports.mts";
-
-const fixturePath = join(
-  dirname(fileURLToPath(import.meta.url)),
-  "../fixtures/published-2026.8.2-undeclared-exportall.d.ts",
-);
 
 describe("sanitizeBundlerHelperDtsExports", () => {
   it("flags and removes an undeclared __exportAll named export", () => {
@@ -70,9 +63,12 @@ describe("sanitizeBundlerHelperDtsExports", () => {
   });
 
   it("clears the published 2026.8.2 undeclared __exportAll export shape", () => {
-    const source = readFileSync(fixturePath, "utf8");
+    const source = readFileSync(
+      new URL("../fixtures/published-2026.8.2-undeclared-exportall.d.ts", import.meta.url),
+      "utf8",
+    );
     expect(source).toContain("__exportAll as ud");
-    expect(findUndeclaredBundlerHelperDtsExports(source, fixturePath)).toEqual([
+    expect(findUndeclaredBundlerHelperDtsExports(source)).toEqual([
       { name: "__exportAll", line: 5 },
     ]);
     const sanitized = sanitizeBundlerHelperDtsExports(source);
@@ -80,6 +76,6 @@ describe("sanitizeBundlerHelperDtsExports", () => {
     expect(sanitized.sourceText).toContain("SessionDiscussionProvider as uc");
     expect(sanitized.sourceText).toContain("DispatchReplyWithDispatcher as ui");
     expect(sanitized.sourceText).not.toContain("__exportAll");
-    expect(findUndeclaredBundlerHelperDtsExports(sanitized.sourceText, fixturePath)).toEqual([]);
+    expect(findUndeclaredBundlerHelperDtsExports(sanitized.sourceText)).toEqual([]);
   });
 });

--- a/test/scripts/sanitize-bundler-helper-dts-exports.test.ts
+++ b/test/scripts/sanitize-bundler-helper-dts-exports.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  findUndeclaredBundlerHelperDtsExports,
+  sanitizeBundlerHelperDtsExports,
+} from "../../scripts/lib/sanitize-bundler-helper-dts-exports.mts";
+
+const fixturePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../fixtures/published-2026.8.2-undeclared-exportall.d.ts",
+);
+
+describe("sanitizeBundlerHelperDtsExports", () => {
+  it("flags and removes an undeclared __exportAll named export", () => {
+    const source = [
+      "export declare const keepMe: number;",
+      "export { keepMe as km, __exportAll as ud, alsoKeep as ak };",
+      "export declare const alsoKeep: string;",
+      "",
+    ].join("\n");
+
+    expect(findUndeclaredBundlerHelperDtsExports(source)).toEqual([
+      { name: "__exportAll", line: 2 },
+    ]);
+
+    const sanitized = sanitizeBundlerHelperDtsExports(source);
+    expect(sanitized.removed).toEqual([{ name: "__exportAll", line: 2 }]);
+    expect(sanitized.sourceText).toContain("keepMe as km");
+    expect(sanitized.sourceText).toContain("alsoKeep as ak");
+    expect(sanitized.sourceText).not.toContain("__exportAll");
+    expect(findUndeclaredBundlerHelperDtsExports(sanitized.sourceText)).toEqual([]);
+  });
+
+  it("keeps __exportAll when the declaration file declares it", () => {
+    const source = [
+      "declare function __exportAll(target: object, all: object): void;",
+      "export { __exportAll as ud };",
+      "",
+    ].join("\n");
+    expect(findUndeclaredBundlerHelperDtsExports(source)).toEqual([]);
+    expect(sanitizeBundlerHelperDtsExports(source).sourceText).toBe(source);
+  });
+
+  it("clears the published 2026.8.2 undeclared __exportAll export shape", () => {
+    const source = readFileSync(fixturePath, "utf8");
+    expect(source).toContain("__exportAll as ud");
+    expect(findUndeclaredBundlerHelperDtsExports(source, fixturePath)).toEqual([
+      { name: "__exportAll", line: 5 },
+    ]);
+    const sanitized = sanitizeBundlerHelperDtsExports(source);
+    expect(sanitized.removed).toEqual([{ name: "__exportAll", line: 5 }]);
+    expect(sanitized.sourceText).toContain("SessionDiscussionProvider as uc");
+    expect(sanitized.sourceText).toContain("DispatchReplyWithDispatcher as ui");
+    expect(sanitized.sourceText).not.toContain("__exportAll");
+    expect(findUndeclaredBundlerHelperDtsExports(sanitized.sourceText, fixturePath)).toEqual([]);
+  });
+});

--- a/test/scripts/sanitize-bundler-helper-dts-exports.test.ts
+++ b/test/scripts/sanitize-bundler-helper-dts-exports.test.ts
@@ -43,6 +43,32 @@ describe("sanitizeBundlerHelperDtsExports", () => {
     expect(sanitizeBundlerHelperDtsExports(source).sourceText).toBe(source);
   });
 
+  it("keeps a directly imported __exportAll binding", () => {
+    const source = [
+      'import { __exportAll } from "./helper.js";',
+      "export { __exportAll as ud };",
+      "",
+    ].join("\n");
+    expect(findUndeclaredBundlerHelperDtsExports(source)).toEqual([]);
+    expect(sanitizeBundlerHelperDtsExports(source).sourceText).toBe(source);
+  });
+
+  it("removes generated helper aliases from mixed imports", () => {
+    const source = [
+      'import { keep as k, ud as __exportAll } from "./helper.js";',
+      "export { keep as k };",
+      "",
+    ].join("\n");
+    const sanitized = sanitizeBundlerHelperDtsExports(source);
+    expect(sanitized.sourceText).toContain('import { keep as k } from "./helper.js";');
+    expect(sanitized.sourceText).not.toContain("__exportAll");
+
+    const onlyHelper = sanitizeBundlerHelperDtsExports(
+      'import { ud as __exportAll } from "./helper.js";\nexport {};\n',
+    );
+    expect(onlyHelper.sourceText).not.toContain("__exportAll");
+  });
+
   it("clears the published 2026.8.2 undeclared __exportAll export shape", () => {
     const source = readFileSync(fixturePath, "utf8");
     expect(source).toContain("__exportAll as ud");


### PR DESCRIPTION
Closes #136881

## Problem

Strict external TypeScript consumers of `openclaw/plugin-sdk/tool-plugin` failed because the published declaration graph re-exported an undeclared bundler helper.

## Fix

Normalize generated declaration imports and exports at the canonical declaration staging owner. Remove only mangled `__exportAll` helper aliases, preserve declared and directly imported bindings, and check every published declaration extension for leaks.

The packed Plugin SDK smoke now imports `tool-plugin` with `strict: true` and `skipLibCheck: false`, using the release-declared TypeScript and `@types/ws` versions. The declaration staging owner also normalizes hashed root and extension declaration chunks that are outside the staged SDK subset.

## Verification

- Current `main` red: the shipped `2026.8.2` package contains the undeclared helper export and the strict consumer reports `TS2304`.
- Repaired head: 86 focused declaration-stage and release-check tests pass, and the generated package declaration replay removes all helper imports and exports.
- Exact-head Blacksmith CI run `33726488515` passed.
- The exact-head build artifact passed a packed strict consumer compile for `tool-plugin` with `skipLibCheck: false`, plus a second public SDK import.
