### PR TITLE
fix(qa): Slack RTT results omit measurements

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/scenario-runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/scenario-runtime.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { runSlackScenario } from "./scenario-runtime.js";
+import type { SlackQaScenarioImplementation, SlackQaScenarioRun } from "./slack-live.contracts.js";
 import { slackQaMpimAppMentionDedupeScenario } from "./slack-live.scenario-implementations.js";
+
+const { runSlackApprovalScenario, runSlackCodexApprovalScenario } = vi.hoisted(() => ({
+  runSlackApprovalScenario: vi.fn(),
+  runSlackCodexApprovalScenario: vi.fn(),
+}));
+
+vi.mock("./slack-live.approvals.js", () => ({ runSlackApprovalScenario }));
+vi.mock("./slack-live.codex-approval-runner.js", () => ({ runSlackCodexApprovalScenario }));
 
 function createMpimRuntime(
   capturedMessages: Array<{ channelId: string; text: string; ts: string }>,
@@ -54,10 +63,132 @@ function createMpimRuntime(
     },
     sutIdentity: { botId: "B_SUT", userId: "U_SUT" },
   };
-  return { env: environment as never, marker: markerText, writes: environment.readMessageWrites };
+  return {
+    env: environment as never,
+    marker: markerText,
+    postMessage,
+    writes: environment.readMessageWrites,
+  };
+}
+
+function createScenarioRuntime(run: SlackQaScenarioRun) {
+  const implementation = {
+    buildRun: () => run,
+  } satisfies SlackQaScenarioImplementation;
+  const environment = {
+    channelId: "C_QA",
+    configureScenario: vi.fn().mockResolvedValue({
+      cfg: {},
+      primaryModel: "openai/gpt-5.6-luna",
+      run,
+    }),
+    context: {},
+    observedMessages: [],
+    scenario: {
+      id: "slack-rtt",
+      timeoutMs: 30_000,
+      title: "Slack RTT",
+    },
+    stopGateway: vi.fn(),
+    sutAccountId: "sut",
+    sutIdentity: { userId: "U_SUT" },
+  };
+  return { environment: environment as never, implementation };
+}
+
+function expectRttEvidence(params: {
+  requestStartedAt: string;
+  responseObservedAt: string;
+  result: unknown;
+  rttMs: number;
+  source: "approval-request-to-resolution" | "request-to-observed-message";
+}) {
+  expect(params.result).toEqual(
+    expect.objectContaining({
+      requestStartedAt: params.requestStartedAt,
+      responseObservedAt: params.responseObservedAt,
+      rttMs: params.rttMs,
+      rttMeasurement: {
+        finalMatchedReplyRttMs: params.rttMs,
+        requestStartedAt: params.requestStartedAt,
+        responseObservedAt: params.responseObservedAt,
+        source: params.source,
+      },
+    }),
+  );
 }
 
 describe("Slack scenario runtime capture merge", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("returns structured RTT evidence for a matched reply", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-09-03T12:00:00.000Z");
+    const runtime = createMpimRuntime([]);
+    runtime.postMessage.mockImplementationOnce(async () => {
+      vi.advanceTimersByTime(1_750);
+      return { channel: "C_MPIM", ts: "1.000000" };
+    });
+
+    expectRttEvidence({
+      requestStartedAt: "2026-09-03T12:00:00.000Z",
+      responseObservedAt: "2026-09-03T12:00:01.750Z",
+      result: await runSlackScenario(runtime.env, slackQaMpimAppMentionDedupeScenario),
+      rttMs: 1_750,
+      source: "request-to-observed-message",
+    });
+  });
+
+  it("returns structured RTT evidence for a native approval", async () => {
+    const runtime = createScenarioRuntime({
+      approvalKind: "exec",
+      decision: "allow-once",
+      kind: "approval",
+      token: "SLACK_QA_APPROVAL",
+    });
+    runSlackApprovalScenario.mockResolvedValueOnce({
+      artifact: { approvalId: "approval-1" },
+      requestStartedAt: new Date("2026-09-03T12:00:00.000Z"),
+      responseObservedAt: new Date("2026-09-03T12:00:01.250Z"),
+      rttMs: 1_250,
+    });
+
+    expectRttEvidence({
+      requestStartedAt: "2026-09-03T12:00:00.000Z",
+      responseObservedAt: "2026-09-03T12:00:01.250Z",
+      result: await runSlackScenario(runtime.environment, runtime.implementation),
+      rttMs: 1_250,
+      source: "approval-request-to-resolution",
+    });
+  });
+
+  it("returns structured RTT evidence for a Codex approval", async () => {
+    const runtime = createScenarioRuntime({
+      approvalKind: "plugin",
+      appServerMethod: "item/commandExecution/requestApproval",
+      decision: "allow-once",
+      kind: "codex-approval",
+      token: "SLACK_QA_CODEX_APPROVAL",
+    });
+    runSlackCodexApprovalScenario.mockResolvedValueOnce({
+      artifact: { approvalId: "approval-2" },
+      requestStartedAt: new Date("2026-09-03T12:00:00.000Z"),
+      responseObservedAt: new Date("2026-09-03T12:00:02.500Z"),
+      rttMs: 2_500,
+    });
+
+    expectRttEvidence({
+      requestStartedAt: "2026-09-03T12:00:00.000Z",
+      responseObservedAt: "2026-09-03T12:00:02.500Z",
+      result: await runSlackScenario(runtime.environment, runtime.implementation),
+      rttMs: 2_500,
+      source: "approval-request-to-resolution",
+    });
+  });
+
   it.each([
     ["ignores off-channel captured commentary", "C_OTHER", "commentary", "1.500000", undefined],
     [

--- a/extensions/qa-lab/src/live-transports/slack/scenario-runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/scenario-runtime.ts
@@ -127,10 +127,21 @@ async function runSlackMessageScenario(params: {
     });
     const responseObservedAt = new Date(reply.observedAt);
     const rttMs = responseObservedAt.getTime() - requestStartedAt.getTime();
+    const requestStartedAtIso = requestStartedAt.toISOString();
+    const responseObservedAtIso = responseObservedAt.toISOString();
     return {
       details: [`reply matched in ${rttMs}ms`, beforeRunDetails, observedDetails, afterReplyDetails]
         .filter(Boolean)
         .join("; "),
+      requestStartedAt: requestStartedAtIso,
+      responseObservedAt: responseObservedAtIso,
+      rttMs,
+      rttMeasurement: {
+        finalMatchedReplyRttMs: rttMs,
+        requestStartedAt: requestStartedAtIso,
+        responseObservedAt: responseObservedAtIso,
+        source: "request-to-observed-message" as const,
+      },
     };
   } finally {
     await params.run.cleanup?.(scenarioContext);
@@ -184,6 +195,15 @@ export async function runSlackScenario(
     return {
       details: `${run.approvalKind} approval resolved ${run.decision} in ${approval.rttMs}ms`,
       artifacts: { approval: approval.artifact },
+      requestStartedAt: approval.requestStartedAt.toISOString(),
+      responseObservedAt: approval.responseObservedAt.toISOString(),
+      rttMs: approval.rttMs,
+      rttMeasurement: {
+        finalMatchedReplyRttMs: approval.rttMs,
+        requestStartedAt: approval.requestStartedAt.toISOString(),
+        responseObservedAt: approval.responseObservedAt.toISOString(),
+        source: "approval-request-to-resolution" as const,
+      },
     };
   }
   if (run.kind === "codex-approval") {
@@ -200,6 +220,15 @@ export async function runSlackScenario(
     return {
       details: `Codex ${run.appServerMethod} approval resolved ${run.decision} in ${approval.rttMs}ms`,
       artifacts: { approval: approval.artifact },
+      requestStartedAt: approval.requestStartedAt.toISOString(),
+      responseObservedAt: approval.responseObservedAt.toISOString(),
+      rttMs: approval.rttMs,
+      rttMeasurement: {
+        finalMatchedReplyRttMs: approval.rttMs,
+        requestStartedAt: approval.requestStartedAt.toISOString(),
+        responseObservedAt: approval.responseObservedAt.toISOString(),
+        source: "approval-request-to-resolution" as const,
+      },
     };
   }
   return await runSlackMessageScenario({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack live QA scenarios completed successfully but omitted structured RTT evidence for normal replies, native approvals, and Codex approvals. Downstream RTT importers therefore had no canonical measurement to ingest.

## Why This Change Was Made

The Slack scenario runtime now projects the timing facts already measured by each owning producer: `rttMs`, ISO `requestStartedAt` and `responseObservedAt`, and canonical `rttMeasurement`. No-reply and direct-transport result behavior is unchanged.

The Codex approval projection was checked against `openai/codex@36984da4424cb91b6bc88c6af8d73207930ac729`:

- `codex-rs/app-server-protocol/src/protocol/common.rs:1696-1710` defines the command and file approval server-request methods.
- `codex-rs/app-server-protocol/src/protocol/v2/item.rs:1530-1636` defines request start timestamps and typed approval responses.
- `codex-rs/app-server-protocol/src/protocol/v2/notification.rs:71-77` defines the resolved-request notification.
- `codex-rs/app-server/src/bespoke_event_handling.rs:2012-2136` resolves requests after client responses and maps approval decisions.
- `codex-rs/app-server/src/thread_state.rs:78-83,206-225` preserves request/resolution ordering on the thread listener.

## User Impact

Slack QA results can again feed RTT evidence and dashboards for successful message and approval flows.

## Evidence

- Pre-fix reproduction: focused runtime suite had 3 intended failures and 4 passes because all three successful result projections omitted RTT fields.
- Exact-head focused test: `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/slack/scenario-runtime.test.ts` -> 7 passed.
- Formatting and diff checks passed.
- Changed classification: `extensions`, `extensionTests`.
- Local changed gate passed all lightweight checks, then reached unrelated stale shared-dependency type errors. The remote retry reached the gate but lacked hydrated `tsx`; its one-shot lease cleaned up.
- Mandatory autoreview: scoped-clean through P2, no findings.
- Production LOC: +29/-0. Test LOC: +133/-2. No dependency or lockfile changes.
- Exact head: `450bd0ae1d15a3e1d041b06654f991ca56deaefd`.
- Live Slack exact-head proof: Actions run [33718645882](https://github.com/openclaw/openclaw/actions/runs/33718645882) passed both requested scenarios against `450bd0ae1d15a3e1d041b06654f991ca56deaefd`.
- Ref validation: `fix/qa-slack-rtt-evidence-20260903` resolved exactly to the expected head before the secret-bearing lane started.
- Redacted QA evidence: `slack-approval-exec-native` passed with `result.timing.rttMs: 2910`; `slack-canary` passed with `result.timing.rttMs: 6260`. Both entries identify the live Slack channel and source-checkout revision.
- ClawSweeper rank-up move satisfied: exact-head live Slack canary and approval evidence are attached above.
- Production LOC rationale: the accepted `+29/-0` directly projects three producer-owned timing results with distinct source semantics; a helper would not reduce branch ownership or preserve the result shape more clearly.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
[user]
Execute phase 1 only from a fresh current-main worktree. Reproduce the Slack RTT projection defect, preserve measured RTT and canonical timestamps for normal replies and approvals, test it, review it, and open a draft PR without merging.

[assistant]
Created the requested shared worktree and branch, verified the dependency symlink, read repository policy, inspected Slack producer/consumer boundaries, and directly checked the canonical Codex app-server approval contract.

[assistant]
Reproduced the defect before editing: three focused assertions failed because successful Slack message, native approval, and Codex approval results omitted the canonical RTT fields.

[user]
Remove unintended pnpm-lock.yaml churn, rebase onto current origin/main, keep a helper only if it is the leanest owner expression, and report production/test LOC separately.

[assistant]
Removed the lockfile churn and the helper. The final owner fix directly projects each producer's authoritative measured RTT and ISO timestamps. Rebased onto current main and reran focused tests, formatting, diff checks, changed classification, and mandatory autoreview.

[assistant]
Final local proof: 7/7 focused tests pass; autoreview is scoped-clean; production LOC is +29/-0 and test LOC is +133/-2. The branch was pushed for a draft PR and independent exact-head review.
```

</details>
<!-- agent-transcript:end -->

