### PR TITLE
fix(release): preserve legacy gh log reads

### DIFF
--- a/scripts/frv.mjs
+++ b/scripts/frv.mjs
@@ -140,6 +140,16 @@ function verifierEvidenceNeedsRefresh(error) {
   }
 }
 
+function isUnknownAllowEscapeSequencesFlag(error) {
+  return (
+    typeof error?.stderr === "string" &&
+    error.stderr
+      .replace(/\r\n?/gu, "\n")
+      .split("\n")
+      .includes("unknown flag: --allow-escape-sequences")
+  );
+}
+
 async function sleep(milliseconds) {
   await new Promise((resolvePromise) => {
     setTimeout(resolvePromise, milliseconds);
@@ -524,10 +534,19 @@ export function createClient(repository, dependencies = {}) {
             .map((line) => JSON.parse(line))
         : [];
     },
-    getJobLog(jobId) {
+    async getJobLog(jobId) {
       // Octopool's gh shim refuses log bodies with terminal escape sequences even off a TTY;
       // real gh ignores the flag off-TTY, so the controller works with either binary.
-      return apiText(`actions/jobs/${jobId}/logs`, undefined, ["--allow-escape-sequences"]);
+      const path = `actions/jobs/${jobId}/logs`;
+      try {
+        return await apiText(path, undefined, ["--allow-escape-sequences"]);
+      } catch (error) {
+        // gh before 2.97 rejects this flag before issuing the protected request.
+        if (!isUnknownAllowEscapeSequencesFlag(error)) {
+          throw error;
+        }
+        return apiText(path);
+      }
     },
     rerunFailed: (runId) => rerun(runId, "rerun-failed-jobs"),
     rerunParent: (runId) => rerun(runId, "rerun"),

--- a/test/scripts/frv.test.ts
+++ b/test/scripts/frv.test.ts
@@ -1146,6 +1146,13 @@ describe("FRV strict verifier", () => {
 });
 
 describe("FRV protected gh evidence reads", () => {
+  const jobLogArgs = [
+    "api",
+    `repos/${REPOSITORY}/actions/jobs/1/logs`,
+    "-H",
+    "Cache-Control: max-age=0",
+  ];
+
   it.each([
     ["getRun", ["101"], "actions/runs/101", { run_attempt: 2 }],
     ["getRunAttempt", ["101", 2], "actions/runs/101/attempts/2", { run_attempt: 2 }],
@@ -1169,8 +1176,22 @@ describe("FRV protected gh evidence reads", () => {
     expect(result.calls).toHaveLength(1);
   });
 
+  it("falls back once when gh does not support the escape-sequence flag", () => {
+    const result = runProtectedFrv("getJobLog", [1], "actions/jobs/1/logs", "legacy-flag");
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toBe("job evidence");
+    expect(result.calls).toEqual([[...jobLogArgs, "--allow-escape-sequences"], jobLogArgs]);
+  });
+
+  it("does not fall back after an unrelated job-log error", () => {
+    const result = runProtectedFrv("getJobLog", [1], "actions/jobs/1/logs", "unrelated");
+    expect(result.status).toBe(23);
+    expect(result.stderr).toContain("unrelated log failure");
+    expect(result.calls).toEqual([[...jobLogArgs, "--allow-escape-sequences"]]);
+  });
+
   it("preserves protected refusal status without retry or alternate execution", () => {
-    const result = runProtectedFrv("getRun", ["101"], "actions/runs/101", true);
+    const result = runProtectedFrv("getRun", ["101"], "actions/runs/101", "protected");
     expect(result.status).toBe(19);
     expect(result.stderr).toContain("protected refusal");
     expect(result.calls).toHaveLength(1);
@@ -1181,7 +1202,7 @@ function runProtectedFrv(
   method: string,
   args: Array<string | number>,
   endpoint: string,
-  denied = false,
+  failure: "none" | "legacy-flag" | "protected" | "unrelated" = "none",
 ) {
   const root = mkdtempSync(join(tmpdir(), "frv-protected-"));
   const gh = join(root, "gh");
@@ -1192,9 +1213,13 @@ const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync("calls.jsonl", JSON.stringify(args) + "\\n");
 const fail = (message, code) => { console.error(message); process.exit(code); };
-if (${denied}) fail("protected refusal", 19);
+const failure = ${JSON.stringify(failure)};
+if (failure === "protected") fail("protected refusal", 19);
 if (args[0] !== "api" || !args.includes(${JSON.stringify(`repos/${REPOSITORY}/${endpoint}`)})) fail("unexpected request", 17);
 if (!args.some((arg, i) => ["-H", "--header"].includes(arg) && args[i+1] === "Cache-Control: max-age=0")) fail("missing live header", 18);
+if (${endpoint.endsWith("/logs")} && failure === "legacy-flag" && args.includes("--allow-escape-sequences")) fail("unknown flag: --allow-escape-sequences", 1);
+if (${endpoint.endsWith("/logs")} && failure === "unrelated") fail("unrelated log failure", 23);
+if (${endpoint.endsWith("/logs")} && failure === "none" && !args.includes("--allow-escape-sequences")) fail("missing escape-sequence flag", 20);
 if (${endpoint.includes("/jobs?")}) {
   if (!args.includes("--paginate") || !args.includes(".jobs[] | @json")) fail("missing pagination", 17);
   console.log('{"id":1}\\n{"id":2}');
@@ -1222,7 +1247,13 @@ if (${endpoint.includes("/jobs?")}) {
         env: { HOME: root, PATH: `${root}${delimiter}${process.env.PATH ?? ""}` },
       },
     );
-    return { ...result, calls: readFileSync(join(root, "calls.jsonl"), "utf8").trim().split("\n") };
+    return {
+      ...result,
+      calls: readFileSync(join(root, "calls.jsonl"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    };
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Related: #136856

## What Problem This Solves

Fixes an issue where maintainers using `gh` 2.96 or older could not run `pnpm frv continue --failed` after #136856 because the job-log preflight passed an unsupported `--allow-escape-sequences` flag and aborted before any recovery mutation.

## Why This Change Was Made

The FRV client keeps the flagged, protected no-cache request as the primary path. It retries once without the flag only when stderr contains the exact standalone legacy-client line `unknown flag: --allow-escape-sequences`; every other error is propagated unchanged.

The fallback stays local to `scripts/frv.mjs`. The protected PATH route, `Cache-Control: max-age=0`, transport classifier, workflows, timeouts, and rerun policy are unchanged. Remove this compatibility branch once maintainer environments require `gh >= 2.97`.

## User Impact

Maintainers can recover failed FRV children with both ANSI-capable current `gh` clients and legacy clients that predate the flag. No runtime product behavior changes.

## Evidence

- Official `cli/cli` source: v2.96.0 has no `--allow-escape-sequences` API flag; v2.97.0 adds the flag and permits raw non-JSON response bodies to bypass escape-sequence refusal.
- Direct official-binary proof: checksum-verified `gh` 2.96.0 (`f23a0c37...`) exits 1 with the exact standalone line `unknown flag: --allow-escape-sequences`; checksum-verified 2.97.0 (`a58b8fd7...`) accepts the same `gh api` arguments and proceeds to authentication (exit 4 with no unknown-flag error). Releases were published July 2 and July 31, 2026, respectively.
- Before production fix: `test/scripts/frv.test.ts` had 45 passing cases and one expected failure. The legacy-client case stopped on `unknown flag: --allow-escape-sequences`, proving recovery aborted in preflight.
- After fix, exact rebased head `24db7f902f0fc49fa2a3acdeee4e5892df8875f0`: `node scripts/run-vitest.mjs run test/scripts/frv.test.ts` passes 46/46.
- `node --check scripts/frv.mjs`, focused Oxfmt, both changed-file Oxlint targets, test-root tsgo, coercion-helper guard, Docker E2E boundary guard, raw HTTP/2 guard, and `git diff --check` pass.
- `check-changed` initially stopped because the GWT lacked nested workspace dependency links. After enabling the full checkout and linking the canonical workspace dependencies, the failed test-root typecheck and every remaining planned check passed.
- Test audit: the added cases protect observable command ordering and error propagation at the real process boundary, reuse the existing harness, fail on the demonstrated regression, and add no test-only production seam.
- Deslop: no behavior-neutral cleanup remained.
- Autoreview: P1 scoped-clean, confidence 0.98.
- Production/tooling LOC: +21/-2, net +19. Tests/test-support: +35/-4, net +31.
- Stable patch ID across the final main rebase: `9c2000becddd95bf6637e25b43543c4d054ef772`.
- No FRV campaign, rerun, release, publish, tag, registry, workflow, or timeout mutation.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
source: [LOCAL_SESSION]
redaction: local paths, credentials, raw tool output, system/developer prompts, and unrelated session turns omitted

[user]
Implement only the independently reviewed repair for landed #136856 in a fresh GWT. Prove the legacy test fails before the production change, keep the fallback local and exact, run focused verification and review, then open a draft PR without merging.

[assistant]
Refreshed origin/main, created and verified the isolated full-history GWT, inspected the merged regression and official gh v2.96/v2.97 source, and added process-boundary regression coverage.

[assistant]
Captured the required pre-fix failure: 45 tests passed and only the legacy unknown-flag case failed. Added the exact standalone-line fallback while preserving the protected no-cache route and unrelated-error propagation.

[user]
Compress the production delta to net +20 or less without changing semantics.

[assistant]
Compressed and verified the production delta at +21/-2, net +19. Final focused tests pass 46/46; changed-surface checks, test audit, deslop, privacy scan, and P1 autoreview are clean.

[tool summary]
Repository reads, two scoped file edits, focused tests/checks, one commit, and one branch push. Raw command output omitted.
```

</details>
<!-- agent-transcript:end -->
