### PR TITLE
fix: keep delegated approvals alive until their outcome

### DIFF
--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -123,6 +123,12 @@ that the requesting run and verified inference route remain valid. Interactive
 setup and agent handoffs still require a direct operator session; delegated chat
 cannot start a wizard, even when a model proposes it.
 
+While a human reviews the proposal, the requesting tool stays open. **Allow once**
+applies the exact proposal and returns its application outcome; **Deny** or expiry
+returns a non-applied outcome instead of leaving the agent reporting a pending
+change. Stopping the requesting run cancels its approval. A late approval cannot
+restart a closed run: request the change again from an active run if still needed.
+
 Configured agents can ask OpenClaw to create another agent through their
 `openclaw` tool. The request enters the same typed create-agent operation and
 host authorization flow; any approval summary names the requesting agent.

--- a/docs/gateway/permission-modes.md
+++ b/docs/gateway/permission-modes.md
@@ -40,6 +40,8 @@ proposed operation. Full Access applies it automatically without an approval
 prompt, including when Full Access comes from the configured default rather than
 an explicit session mode. Restricted runs still require human approval in the
 OpenClaw operator UI; conversational claims of approval never authorize the change.
+The requesting tool waits for the human decision and application outcome. Stopping
+the run cancels its pending approval; approving later cannot revive that run.
 
 Independent filesystem and sandbox boundaries, tool policy, and system-agent
 operation restrictions still apply. The host also checks that the requesting run

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -710,13 +710,15 @@ Codex runtime, so `Promise.all` does not submit them concurrently; use a
 bounded sequential launch loop when starting collector children.
 
 Tools marked `catalogMode: "direct-only"`, including the OpenClaw `computer`
-tool, are grouped under `openclaw_direct`. OpenClaw adds that namespace to
-Codex's `code_mode.direct_only_tool_namespaces` list without replacing
+tool and regular-agent `openclaw` delegation, are grouped under `openclaw_direct`.
+OpenClaw adds that namespace to Codex's
+`features.code_mode.direct_only_tool_namespaces` list without replacing
 operator-supplied entries. Codex therefore exposes those tools as
 `DirectModelOnly` in normal and code-mode-only threads instead of routing them
-through nested Code Mode `tools.*` calls. This boundary is required for
-image-bearing results: nested Code Mode serialization flattens image output to
-text, which would discard the screenshot needed for the next computer action.
+through nested Code Mode `tools.*` calls. This preserves image-bearing results,
+which nested Code Mode otherwise flattens to text. It also keeps delegated human
+approval on the direct model call: a yielded script cell must not let the model
+finish its turn while that approval is still waiting.
 
 Set `codexDynamicToolsLoading: "direct"` only when connecting to a custom
 Codex app-server that cannot search deferred dynamic tools or when debugging
@@ -725,7 +727,7 @@ the full tool payload.
 ## Timeouts
 
 OpenClaw-owned dynamic tool calls are bounded independently from
-`appServer.requestTimeoutMs`. Each Codex `item/tool/call` request uses the
+`appServer.requestTimeoutMs`. Ordinary Codex `item/tool/call` requests use the
 first available timeout in this order:
 
 - A positive per-call `timeoutMs` argument.
@@ -741,11 +743,19 @@ first available timeout in this order:
 
 This watchdog is the outer dynamic `item/tool/call` budget. Provider-specific
 request timeouts run inside that call and keep their own timeout semantics.
-Dynamic tool budgets are capped at 600000 ms. `agents_wait` adds 30000 ms of
-outer completion grace, and the app-server client allows 660000 ms so that
-structured wait result can reach Codex. On timeout, OpenClaw aborts the tool
-signal where supported and returns a failed dynamic-tool response to Codex so
-the turn can continue instead of leaving the session in `processing`.
+Ordinary dynamic tool budgets are capped at 600000 ms. `agents_wait` adds 30000 ms
+of outer completion grace. Human-interaction tools use the validated question
+wait plus 30000 ms: `ask_user` and `secrets` credential requests honor their question
+timeout, while delegated `openclaw` calls use the fixed 930000 ms default. That
+budget covers the ten-minute approval window plus staging and application;
+model-authored arguments cannot override it. The app-server request watchdog
+leaves another 30000 ms beyond the applicable tool budget for the result to reach
+Codex.
+
+On timeout, OpenClaw aborts the tool signal where supported and returns a failed
+dynamic-tool response to Codex so the turn can continue instead of leaving the
+session in `processing`. These wait budgets never preserve approval authority
+after the requesting run or tool closes.
 
 ### Turn execution and settlement
 

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -52,6 +52,7 @@ import {
   CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
   flattenCodexDynamicToolFunctions,
 } from "./protocol.js";
+import { resolveCodexDynamicToolDirectNames } from "./run-attempt-tools.js";
 import { createCodexTestModel } from "./test-support.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -1020,6 +1021,77 @@ describe("Codex app-server dynamic tool build", () => {
         expect.any(AbortSignal),
         undefined,
       );
+    },
+  );
+
+  it.each(["searchable", "direct"] as const)(
+    "keeps regular delegation model-only with %s loading while ordinary tools stay scriptable",
+    async (loading) => {
+      const workspaceDir = path.join(tempDir, "workspace");
+      const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+      params.disableTools = false;
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      params.config = { tools: { exec: { mode: "ask" } } };
+      setOpenClawCodingToolsFactoryForTests((options) =>
+        createOpenClawCodingTools(options).filter((tool) =>
+          ["openclaw", "message"].includes(tool.name),
+        ),
+      );
+
+      const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+        sandbox: null,
+        isHostScopedToolActive: () => false,
+      });
+      expect(tools.map((tool) => tool.name).toSorted()).toEqual(["message", "openclaw"]);
+      const bridge = createCodexDynamicToolBridge({
+        tools,
+        signal: new AbortController().signal,
+        loading,
+        directToolNames: resolveCodexDynamicToolDirectNames(params, false),
+      });
+
+      expect(bridge.specs).toContainEqual({
+        type: "namespace",
+        name: CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
+        description: "",
+        tools: [expect.objectContaining({ type: "function", name: "openclaw" })],
+      });
+      const ordinarySpec = expect.objectContaining({ type: "function", name: "message" });
+      expect(bridge.specs).toContainEqual(
+        loading === "direct"
+          ? ordinarySpec
+          : {
+              type: "namespace",
+              name: "openclaw",
+              description: "",
+              tools: [expect.objectContaining({ name: "message", deferLoading: true })],
+            },
+      );
+    },
+  );
+
+  it.each(["core policy", "Codex excludes", "turn allowlist"])(
+    "filters the real regular delegate when denied by %s",
+    async (policy) => {
+      const workspaceDir = path.join(tempDir, "workspace");
+      const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+      params.disableTools = false;
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      params.config = policy === "core policy" ? { tools: { deny: ["openclaw"] } } : {};
+      params.toolsAllow = policy === "turn allowlist" ? ["message"] : ["openclaw", "message"];
+      setOpenClawCodingToolsFactoryForTests((options) =>
+        createOpenClawCodingTools(options).filter((tool) =>
+          ["openclaw", "message"].includes(tool.name),
+        ),
+      );
+
+      const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+        sandbox: null,
+        isHostScopedToolActive: () => false,
+        pluginConfig: policy === "Codex excludes" ? { codexDynamicToolsExclude: ["openclaw"] } : {},
+      });
+
+      expect(tools.map((tool) => tool.name)).toEqual(["message"]);
     },
   );
 

--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   handleDynamicToolCallWithTimeout,
   resolveDynamicToolCallTimeoutMs,
+  resolveDynamicToolServerRequestTimeoutMs,
   resolveTerminalDynamicToolBatchAction,
   shouldBlockTerminalReleaseForNonTerminalDynamicToolResult,
   shouldReleaseTurnAfterTerminalDynamicTool,
@@ -412,6 +413,7 @@ describe("dynamic tool execution helpers", () => {
   it.each([
     { tool: "session_status", deadlineMs: 600_000 },
     { tool: "agents_wait", deadlineMs: 630_000 },
+    { tool: "openclaw", deadlineMs: 930_000 },
   ])("enforces the resolved $tool cap at $deadlineMs ms", async ({ tool, deadlineMs }) => {
     vi.useFakeTimers();
     const call = {
@@ -420,6 +422,7 @@ describe("dynamic tool execution helpers", () => {
       tool,
       arguments: { timeoutSeconds: 1_000 },
     };
+    expect(resolveDynamicToolServerRequestTimeoutMs(call)).toBeGreaterThan(deadlineMs);
     const onTimeout = vi.fn();
     const response = handleDynamicToolCallWithTimeout({
       call,
@@ -561,6 +564,7 @@ describe("dynamic tool execution helpers", () => {
     { tool: "sessions_send", timeoutSeconds: 1, completionMs: 6_000 },
     { tool: "agents_wait", timeoutSeconds: 600, completionMs: 600_000 },
     { tool: "agents_wait", timeoutSeconds: 600, completionMs: 605_000 },
+    { tool: "openclaw", timeoutSeconds: 1, completionMs: 600_000 },
   ])(
     "preserves the $tool result after $completionMs ms",
     async ({ tool, timeoutSeconds, completionMs }) => {
@@ -694,26 +698,29 @@ describe("dynamic tool execution helpers", () => {
     expect(result.diagnosticTerminalReason).toBe("failed");
   });
 
-  it("preserves enclosing timeout provenance for active tool aborts", async () => {
-    const controller = new AbortController();
-    const resultPromise = handleDynamicToolCallWithTimeout({
-      call: {
-        ...dynamicCallContext,
-        callId: "call-active-timeout-abort",
-        tool: "memory_search",
-        arguments: {},
-      },
-      toolBridge: { handleToolCall: vi.fn(() => new Promise<never>(() => {})) },
-      signal: controller.signal,
-      timeoutMs: 1_000,
-    });
-    controller.abort(Object.assign(new Error("gateway timeout"), { name: "TimeoutError" }));
+  it.each(["memory_search", "openclaw"])(
+    "preserves enclosing timeout provenance for active %s aborts",
+    async (tool) => {
+      const controller = new AbortController();
+      const resultPromise = handleDynamicToolCallWithTimeout({
+        call: {
+          ...dynamicCallContext,
+          callId: "call-active-timeout-abort",
+          tool,
+          arguments: {},
+        },
+        toolBridge: { handleToolCall: vi.fn(() => new Promise<never>(() => {})) },
+        signal: controller.signal,
+        timeoutMs: 1_000,
+      });
+      controller.abort(Object.assign(new Error("gateway timeout"), { name: "TimeoutError" }));
 
-    await expect(resultPromise).resolves.toMatchObject({
-      success: false,
-      diagnosticTerminalReason: "timed_out",
-    });
-  });
+      await expect(resultPromise).resolves.toMatchObject({
+        success: false,
+        diagnosticTerminalReason: "timed_out",
+      });
+    },
+  );
 
   it("preserves timeout provenance when the dynamic tool bridge rejects", async () => {
     const timeoutError = Object.assign(new Error("tool deadline elapsed"), {

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -507,14 +507,17 @@ export function resolveDynamicToolCallTimeoutMs(params: {
 }): number {
   const args = isJsonObject(params.call.arguments) ? params.call.arguments : undefined;
   if (
+    params.call.tool === "openclaw" ||
     params.call.tool === "ask_user" ||
     (params.call.tool === "secrets" && args?.action === "request")
   ) {
     try {
       // Human entry owns a validated wait longer than ordinary tool execution.
-      // Leave grace for registration, cancellation, and the structured no_answer result.
+      // OpenClaw delegation uses that default for its ten-minute approval plus
+      // staging/application; it has no model-authored timeout override.
+      const timeoutSeconds = params.call.tool === "openclaw" ? undefined : args?.timeoutSeconds;
       return (
-        normalizeQuestionTimeoutSeconds(args?.timeoutSeconds) * 1_000 +
+        normalizeQuestionTimeoutSeconds(timeoutSeconds) * 1_000 +
         CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS
       );
     } catch {

--- a/src/agents/tools/openclaw-delegate-tool.test.ts
+++ b/src/agents/tools/openclaw-delegate-tool.test.ts
@@ -2,7 +2,10 @@ import { Value } from "typebox/value";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_OWNER_ONLY_CORE_TOOLS } from "../../security/dangerous-tools.js";
 import { compactToolOutputHint } from "../tool-schema-hints.js";
-import { getGatewayToolCallerIdentity } from "./gateway-caller-context.js";
+import {
+  getGatewayToolCallerIdentity,
+  withGatewayToolCallerIdentity,
+} from "./gateway-caller-context.js";
 import { callInProcessGatewayTool } from "./in-process-gateway.js";
 import { createOpenClawDelegateToolsForRun } from "./openclaw-delegate-tool.js";
 
@@ -17,13 +20,11 @@ beforeEach(() => {
 });
 
 describe("openclaw delegation tool", () => {
-  it("relays context and surfaces pending approval", async () => {
+  it("relays context and the completed approval outcome", async () => {
     callGateway.mockResolvedValue({
       sessionId: "ignored-by-client",
-      reply: "Approval pending.",
+      reply: "Applied.",
       action: "none",
-      needsApproval: true,
-      proposalId: "system-agent:proposal-1",
     });
     const tool = createOpenClawDelegateToolsForRun({
       sessionAgentId: "main",
@@ -49,16 +50,11 @@ describe("openclaw delegation tool", () => {
       },
     });
     expect(result.details).toEqual({
-      reply: "Approval pending.",
-      needsApproval: true,
-      proposalId: "system-agent:proposal-1",
+      reply: "Applied.",
     });
     expect(tool.outputSchema).toBeDefined();
     expect(Value.Check(tool.outputSchema!, result.details)).toBe(true);
-    expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      "{ reply: string; action?: string; needsApproval?: true; proposalId?: string }",
-    );
-    expect(tool.catalogMode).toBeUndefined();
+    expect(compactToolOutputHint(tool.outputSchema)).toBe("{ reply: string; action?: string }");
   });
 
   it.each([
@@ -94,8 +90,14 @@ describe("openclaw delegation tool", () => {
     options: Omit<Parameters<typeof createOpenClawDelegateToolsForRun>[0], "sessionAgentId">;
     full: boolean;
   }>)("carries $name authority privately, not in RPC data", async ({ options, full }) => {
+    const runController = new AbortController();
+    const toolController = new AbortController();
     callGateway.mockImplementation(async () => {
       expect(getGatewayToolCallerIdentity()?.fullPermission).toBe(full);
+      expect(getGatewayToolCallerIdentity()?.approvalSignals).toEqual([
+        runController.signal,
+        toolController.signal,
+      ]);
       return { sessionId: "delegate", reply: "Done." };
     });
     const [tool] = createOpenClawDelegateToolsForRun({
@@ -107,7 +109,16 @@ describe("openclaw delegation tool", () => {
       throw new Error("expected OpenClaw delegation tool");
     }
 
-    await tool.execute("call-policy", { message: "Change logging.", fullPermission: !full });
+    expect(tool.catalogMode).toBe("direct-only");
+    await withGatewayToolCallerIdentity(
+      { agentId: "main", sessionKey: "agent:main:main", approvalSignals: [runController.signal] },
+      () =>
+        tool.execute(
+          "call-policy",
+          { message: "Change logging.", fullPermission: !full },
+          toolController.signal,
+        ),
+    );
 
     expect(tool.description).toContain(full ? "without asking for approval" : "human approval");
     expect(callGateway.mock.calls[0]?.[1]).not.toHaveProperty("fullPermission");

--- a/src/agents/tools/openclaw-delegate-tool.ts
+++ b/src/agents/tools/openclaw-delegate-tool.ts
@@ -5,7 +5,7 @@ import { SYSTEM_AGENT_ID } from "../../system-agent/agent-id.js";
 import { resolveExecDefaults } from "../exec-defaults.js";
 import type { OpenClawToolsOptions } from "../openclaw-tools.types.js";
 import { jsonResult, readToolStringParam, type AnyAgentTool } from "./common.js";
-import { wrapToolWithGatewayCallerIdentity } from "./gateway-caller-context.js";
+import { withGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 import { callInProcessGatewayTool } from "./in-process-gateway.js";
 
 const OpenClawDelegateSchema = Type.Object({
@@ -17,8 +17,6 @@ const OpenClawDelegateOutputSchema = Type.Object(
   {
     reply: Type.String(),
     action: Type.Optional(Type.String()),
-    needsApproval: Type.Optional(Type.Literal(true)),
-    proposalId: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
@@ -27,8 +25,6 @@ type OpenClawDelegateResult = {
   sessionId: string;
   reply: string;
   action?: string;
-  needsApproval?: boolean;
-  proposalId?: string;
 };
 
 function stableDelegationSessionId(sessionKey: string | undefined, agentId: string): string {
@@ -82,42 +78,48 @@ export function createOpenClawDelegateToolsForRun(
   const tool: AnyAgentTool = {
     name: "openclaw",
     label: "OpenClaw",
+    // Keep human approval in one model tool call; a yielded cell can outlive its turn.
+    catalogMode: "direct-only",
     description:
       "Ask system expert. Gateway restart, config, channels, plugins, agents, models/providers, updates. " +
       (fullPermission
         ? "Full Access applies permitted changes without asking for approval."
-        : "Changes need human approval."),
+        : "Changes wait for human approval and return the final outcome."),
     parameters: OpenClawDelegateSchema,
     outputSchema: OpenClawDelegateOutputSchema,
-    execute: async (_toolCallId, args) => {
+    execute: async (_toolCallId, args, signal) => {
       const params = (args ?? {}) as Record<string, unknown>;
       const message = readToolStringParam(params, "message", { required: true });
       const sessionId = readToolStringParam(params, "sessionId") ?? defaultSessionId;
-      const result = await callInProcessGatewayTool<OpenClawDelegateResult>("openclaw.chat", {
-        sessionId,
-        message,
-        delegation: {
-          agentId: options.sessionAgentId,
-          ...(sessionKey ? { sessionKey } : {}),
-          ...(options.agentChannel ? { turnSourceChannel: options.agentChannel } : {}),
-          ...(turnSourceTo ? { turnSourceTo } : {}),
-          ...(options.agentAccountId ? { turnSourceAccountId: options.agentAccountId } : {}),
-          ...(turnSourceThreadId !== undefined ? { turnSourceThreadId } : {}),
-        },
-      });
+      // Bind permissions and this call's cancellation privately: a stopped tool
+      // must retire its proposal even while the requesting run remains live.
+      const caller = sessionKey
+        ? {
+            agentId: options.sessionAgentId,
+            sessionKey,
+            fullPermission,
+            approvalSignals: signal ? [signal] : [],
+          }
+        : undefined;
+      const result = await withGatewayToolCallerIdentity(caller, () =>
+        callInProcessGatewayTool<OpenClawDelegateResult>("openclaw.chat", {
+          sessionId,
+          message,
+          delegation: {
+            agentId: options.sessionAgentId,
+            ...(sessionKey ? { sessionKey } : {}),
+            ...(options.agentChannel ? { turnSourceChannel: options.agentChannel } : {}),
+            ...(turnSourceTo ? { turnSourceTo } : {}),
+            ...(options.agentAccountId ? { turnSourceAccountId: options.agentAccountId } : {}),
+            ...(turnSourceThreadId !== undefined ? { turnSourceThreadId } : {}),
+          },
+        }),
+      );
       return jsonResult({
         reply: result.reply,
         ...(result.action && result.action !== "none" ? { action: result.action } : {}),
-        ...(result.needsApproval ? { needsApproval: true } : {}),
-        ...(result.proposalId ? { proposalId: result.proposalId } : {}),
       });
     },
   };
-  // Keep permission authority out of model-authored RPC data and scoped to this tool call.
-  return [
-    wrapToolWithGatewayCallerIdentity(
-      tool,
-      sessionKey ? { agentId: options.sessionAgentId, sessionKey, fullPermission } : undefined,
-    ),
-  ];
+  return [tool];
 }

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -141,6 +141,7 @@ export type GatewaySystemAgentSession = {
       question?: SystemAgentChatQuestion;
       step?: import("../../wizard/session.js").WizardStep;
     };
+    noteAssistantMessage: (text: string) => void;
     seedHistory: (turns: readonly SystemAgentHistoryTurn[]) => void;
     historyLength: () => number;
     historySince: (index: number) => SystemAgentHistoryTurn[];
@@ -149,6 +150,7 @@ export type GatewaySystemAgentSession = {
       decision: "allow-once" | "allow-always" | "deny" | null,
       proposalHash: string,
       beforePersistentApply?: () => void,
+      terminalStatus?: "expired" | "cancelled",
     ) => Promise<{
       text: string;
       action: "none" | "exit" | "open-tui" | "open-setup";
@@ -162,7 +164,15 @@ export type GatewaySystemAgentSession = {
   welcomeAuditSequence?: number;
   lastUsedAt: number;
   ownerKey: string;
-  pendingApproval?: { id: string; proposalHash: string };
+  pendingApproval?: {
+    id: string;
+    proposalHash: string;
+    completion: Promise<
+      NonNullable<
+        Awaited<ReturnType<GatewaySystemAgentSession["engine"]["resolveOperatorApproval"]>>
+      >
+    >;
+  };
 };
 
 /** Kernel-owned services and state that can be constructed without binding sockets. */

--- a/src/gateway/server-methods/system-agent-approval-authority.test.ts
+++ b/src/gateway/server-methods/system-agent-approval-authority.test.ts
@@ -1,0 +1,507 @@
+// Covers exact delegated approval authority and closure fences.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createOperationalRunInstanceRef } from "../../agents/admitted-run-context.js";
+import { withGatewayToolCallerIdentity } from "../../agents/tools/gateway-caller-context.js";
+import {
+  claimAgentRunDelegatedAuthority,
+  releaseAgentRunDelegatedAuthority,
+  resetAgentRunRegistryForTest,
+  validateAgentRunDelegatedAuthority,
+} from "../../infra/agent-run-registry.js";
+import type { ExecApprovalDecision } from "../../infra/exec-approvals.js";
+import type { SystemAgentApprovalRequestPayload } from "../../infra/system-agent-approvals.js";
+import { ExecApprovalManager } from "../exec-approval-manager.js";
+import type { WorkerSessionTurnClaim } from "../worker-environments/placement-record.js";
+import { prepareDelegatedSystemAgentApproval } from "./system-agent-approval.js";
+import type { SystemAgentChatSession } from "./system-agent.js";
+import type { GatewayRequestContext } from "./types.js";
+
+afterEach(() => {
+  resetAgentRunRegistryForTest();
+});
+
+async function resolveTestProposal(
+  params: Parameters<typeof prepareDelegatedSystemAgentApproval>[0] & {
+    proposal: NonNullable<
+      ReturnType<SystemAgentChatSession["engine"]["getPendingOperatorProposal"]>
+    >;
+  },
+) {
+  const resolveProposal = await prepareDelegatedSystemAgentApproval(params);
+  return await resolveProposal(params.proposal);
+}
+
+async function queueDelegatedApproval(
+  params: Parameters<typeof resolveTestProposal>[0],
+): Promise<string> {
+  const resolution = await resolveTestProposal(params);
+  if (resolution.kind !== "approval") {
+    throw new Error("expected a human approval request");
+  }
+  return resolution.id;
+}
+
+describe("prepareDelegatedSystemAgentApproval", () => {
+  const workerTurnClaim = (claimId: string): WorkerSessionTurnClaim => ({
+    sessionId: "delegate-worker",
+    claimId,
+    runId: "delegated-worker-run",
+    placementGeneration: 1,
+    owner: { kind: "worker", environmentId: "worker-1", ownerEpoch: 1 },
+  });
+
+  it("refuses to apply a delegated change after its run authority closes", async () => {
+    const proposal = {
+      operation: { kind: "gateway-restart" as const },
+      hash: "a".repeat(64),
+    };
+    const resolveOperatorApproval = vi.fn().mockResolvedValue(null);
+    const session = {
+      engine: {
+        historyLength: () => 0,
+        historySince: () => [],
+        noteAssistantMessage: vi.fn(),
+        getPendingOperatorProposal: () => proposal,
+        resolveOperatorApproval,
+      },
+      lastUsedAt: 1,
+      ownerKey: "agent:main:main",
+    } as unknown as SystemAgentChatSession;
+    const sessions = new Map([["delegate-closed", session]]);
+    const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
+      approvalKind: "system-agent",
+      resolveAllowedDecisions: (request) => request.allowedDecisions,
+      validateAgentRuntimeDelegatedAuthority: validateAgentRunDelegatedAuthority,
+    });
+    const context = {
+      systemAgentApprovalManager: manager,
+      broadcast: vi.fn(),
+    } as unknown as GatewayRequestContext;
+    const operationalRunInstance = createOperationalRunInstanceRef("delegated-run-closed");
+    const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
+
+    let approvalId: string | undefined;
+    await withGatewayToolCallerIdentity(
+      {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        operationalRunInstance,
+      },
+      async () => {
+        approvalId = await queueDelegatedApproval({
+          context,
+          sessions,
+          session,
+          sessionId: "delegate-closed",
+          delegation: { agentId: "main", sessionKey: "agent:main:main" },
+          proposal,
+        });
+      },
+    );
+    expect(releaseAgentRunDelegatedAuthority(authority)).toBe(true);
+    expect(validateAgentRunDelegatedAuthority(authority)).toBe(false);
+
+    expect(approvalId).toBeTruthy();
+    expect(manager.resolve(approvalId!, "allow-once", "operator-ui")).toBe(false);
+    expect(manager.getSnapshot(approvalId!)?.status).toBe("cancelled");
+    await vi.waitFor(() =>
+      expect(resolveOperatorApproval).toHaveBeenCalledWith(
+        null,
+        proposal.hash,
+        expect.any(Function),
+        "cancelled",
+      ),
+    );
+  });
+
+  it("rechecks authority after queued approval work before the final effect", async () => {
+    const proposal = {
+      operation: { kind: "gateway-restart" as const },
+      hash: "b".repeat(64),
+    };
+    const applyStarted = createDeferred();
+    const releaseApply = createDeferred();
+    const applyEffect = vi.fn();
+    const resolveOperatorApproval = vi.fn(
+      async (
+        _decision: "allow-once" | "allow-always" | "deny" | null,
+        _proposalHash: string,
+        beforePersistentApply?: () => void,
+      ) => {
+        if (_decision === null) {
+          return null;
+        }
+        applyStarted.resolve();
+        await releaseApply.promise;
+        beforePersistentApply?.();
+        applyEffect();
+        return null;
+      },
+    );
+    const session = {
+      engine: {
+        historyLength: () => 0,
+        historySince: () => [],
+        noteAssistantMessage: vi.fn(),
+        getPendingOperatorProposal: () => proposal,
+        resolveOperatorApproval,
+      },
+      lastUsedAt: 1,
+      ownerKey: "agent:main:main",
+    } as unknown as SystemAgentChatSession;
+    const sessions = new Map([["delegate-race", session]]);
+    const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
+      approvalKind: "system-agent",
+      resolveAllowedDecisions: (request) => request.allowedDecisions,
+      validateAgentRuntimeDelegatedAuthority: validateAgentRunDelegatedAuthority,
+    });
+    const publishResolved = vi.fn();
+    const context = {
+      systemAgentApprovalManager: manager,
+      broadcast: vi.fn(),
+      approvalEvents: { publishRequested: vi.fn(), publishResolved },
+    } as unknown as GatewayRequestContext;
+    const operationalRunInstance = createOperationalRunInstanceRef("delegated-run-race");
+    const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
+
+    let approvalId: string | undefined;
+    await withGatewayToolCallerIdentity(
+      {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        operationalRunInstance,
+      },
+      async () => {
+        approvalId = await queueDelegatedApproval({
+          context,
+          sessions,
+          session,
+          sessionId: "delegate-race",
+          delegation: { agentId: "main", sessionKey: "agent:main:main" },
+          proposal,
+        });
+      },
+    );
+
+    expect(manager.resolve(approvalId!, "allow-once", "operator-ui")).toBe(true);
+    await applyStarted.promise;
+    expect(releaseAgentRunDelegatedAuthority(authority)).toBe(true);
+    releaseApply.resolve();
+    const result = resolveOperatorApproval.mock.results[0]?.value;
+    await expect(result).rejects.toThrow("system-agent approval authority is no longer active");
+    expect(applyEffect).not.toHaveBeenCalled();
+    await vi.waitFor(() =>
+      expect(publishResolved).toHaveBeenCalledWith(
+        "system-agent",
+        expect.objectContaining({ applicationStatus: "not-applied" }),
+      ),
+    );
+  });
+
+  it.each(["run", "tool", "gateway", "worker", "session"] as const)(
+    "fences Full Access when its %s closes during apply preparation",
+    async (owner) => {
+      const started = createDeferred();
+      const release = createDeferred();
+      const effect = vi.fn();
+      const proposal = { operation: { kind: "gateway-restart" as const }, hash: "f".repeat(64) };
+      const session = {
+        engine: {
+          resolveOperatorApproval: async (
+            decision: ExecApprovalDecision | null,
+            _hash: string,
+            assertCurrent?: () => void,
+          ) => {
+            if (decision === null) {
+              return null;
+            }
+            started.resolve();
+            await release.promise;
+            assertCurrent?.();
+            effect();
+            return { text: "Applied", action: "none" as const, applied: true };
+          },
+        },
+        ownerKey: "agent:main:main",
+        lastUsedAt: 1,
+      } as unknown as SystemAgentChatSession;
+      const sessions = new Map([["delegate-full", session]]);
+      let workerActive = true;
+      const context = {
+        systemAgentSessions: sessions,
+        validateAgentRuntimeApprovalAuthority: () => workerActive,
+      } as unknown as GatewayRequestContext;
+      let liveContext = context;
+      const operationalRunInstance = createOperationalRunInstanceRef("full-access-run");
+      const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
+      const controller = new AbortController();
+      const pending = withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          operationalRunInstance,
+          approvalAuthority: authority,
+          fullPermission: true,
+          gatewayContextResolver: () => liveContext,
+          approvalSignals: [controller.signal],
+          ...(owner === "worker" ? { workerTurnClaim: workerTurnClaim("full-turn") } : {}),
+        },
+        () =>
+          resolveTestProposal({
+            context,
+            sessions,
+            session,
+            sessionId: "delegate-full",
+            delegation: { agentId: "main", sessionKey: "agent:main:main" },
+            proposal,
+          }),
+      );
+      await started.promise;
+      if (owner === "run") {
+        releaseAgentRunDelegatedAuthority(authority);
+      } else if (owner === "tool") {
+        controller.abort();
+      } else if (owner === "gateway") {
+        liveContext = { ...context };
+      } else if (owner === "worker") {
+        workerActive = false;
+      } else {
+        sessions.set("delegate-full", { ...session });
+      }
+      release.resolve();
+
+      await expect(pending).rejects.toThrow("system-agent approval authority is no longer active");
+      expect(effect).not.toHaveBeenCalled();
+    },
+  );
+
+  it("publishes the channel completion after the delegated change is applied", async () => {
+    const proposal = {
+      operation: { kind: "gateway-restart" as const },
+      hash: "c".repeat(64),
+    };
+    const resolveOperatorApproval = vi.fn().mockResolvedValue({
+      text: "Applied",
+      action: "none" as const,
+      applied: true,
+    });
+    const session = {
+      engine: {
+        historyLength: () => 0,
+        historySince: () => [],
+        noteAssistantMessage: vi.fn(),
+        getPendingOperatorProposal: () => proposal,
+        resolveOperatorApproval,
+      },
+      lastUsedAt: 1,
+      ownerKey: "agent:main:main",
+    } as unknown as SystemAgentChatSession;
+    const sessions = new Map([["delegate-applied", session]]);
+    const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
+      approvalKind: "system-agent",
+      resolveAllowedDecisions: (request) => request.allowedDecisions,
+      validateAgentRuntimeDelegatedAuthority: validateAgentRunDelegatedAuthority,
+    });
+    const publishResolved = vi.fn();
+    const context = {
+      systemAgentApprovalManager: manager,
+      broadcast: vi.fn(),
+      approvalEvents: { publishRequested: vi.fn(), publishResolved },
+    } as unknown as GatewayRequestContext;
+    const operationalRunInstance = createOperationalRunInstanceRef("delegated-run-applied");
+    claimAgentRunDelegatedAuthority(operationalRunInstance);
+
+    let approvalId: string | undefined;
+    await withGatewayToolCallerIdentity(
+      {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        operationalRunInstance,
+      },
+      async () => {
+        approvalId = await queueDelegatedApproval({
+          context,
+          sessions,
+          session,
+          sessionId: "delegate-applied",
+          delegation: { agentId: "main", sessionKey: "agent:main:main" },
+          proposal,
+        });
+      },
+    );
+
+    expect(manager.resolve(approvalId!, "allow-once", "operator-ui")).toBe(true);
+    await vi.waitFor(() =>
+      expect(publishResolved).toHaveBeenCalledWith(
+        "system-agent",
+        expect.objectContaining({ applicationStatus: "applied" }),
+      ),
+    );
+  });
+
+  it("fences a delegated worker turn before the persistent effect", async () => {
+    const proposal = {
+      operation: { kind: "gateway-restart" as const },
+      hash: "d".repeat(64),
+    };
+    const applyStarted = createDeferred();
+    const releaseApply = createDeferred();
+    let workerTurnActive = true;
+    const applyEffect = vi.fn();
+    const resolveOperatorApproval = vi.fn(
+      async (
+        _decision: "allow-once" | "allow-always" | "deny" | null,
+        _proposalHash: string,
+        beforePersistentApply?: () => void,
+      ) => {
+        if (_decision === null) {
+          return null;
+        }
+        applyStarted.resolve();
+        await releaseApply.promise;
+        beforePersistentApply?.();
+        applyEffect();
+        return null;
+      },
+    );
+    const session = {
+      engine: {
+        historyLength: () => 0,
+        historySince: () => [],
+        noteAssistantMessage: vi.fn(),
+        getPendingOperatorProposal: () => proposal,
+        resolveOperatorApproval,
+      },
+      lastUsedAt: 1,
+      ownerKey: "agent:main:main",
+    } as unknown as SystemAgentChatSession;
+    const sessions = new Map([["delegate-worker", session]]);
+    const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
+      approvalKind: "system-agent",
+      resolveAllowedDecisions: (request) => request.allowedDecisions,
+      validateAgentRuntimeDelegatedAuthority: (authority) =>
+        validateAgentRunDelegatedAuthority(authority) && workerTurnActive,
+    });
+    const context = {
+      systemAgentApprovalManager: manager,
+      broadcast: vi.fn(),
+      approvalEvents: { publishRequested: vi.fn(), publishResolved: vi.fn() },
+      validateAgentRuntimeApprovalAuthority: () => workerTurnActive,
+    } as unknown as GatewayRequestContext;
+    const operationalRunInstance = createOperationalRunInstanceRef("delegated-worker-run");
+    claimAgentRunDelegatedAuthority(operationalRunInstance);
+    const turnClaim = workerTurnClaim("turn-1");
+
+    let approvalId: string | undefined;
+    await withGatewayToolCallerIdentity(
+      {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        operationalRunInstance,
+        workerTurnClaim: turnClaim,
+      },
+      async () => {
+        approvalId = await queueDelegatedApproval({
+          context,
+          sessions,
+          session,
+          sessionId: "delegate-worker",
+          delegation: { agentId: "main", sessionKey: "agent:main:main" },
+          proposal,
+        });
+      },
+    );
+
+    expect(manager.resolve(approvalId!, "allow-once", "operator-ui")).toBe(true);
+    await applyStarted.promise;
+    workerTurnActive = false;
+    releaseApply.resolve();
+    const result = resolveOperatorApproval.mock.results[0]?.value;
+    await expect(result).rejects.toThrow("system-agent approval authority is no longer active");
+    expect(applyEffect).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    "reuses the exact worker approval with Full Access=%s",
+    async (fullPermission) => {
+      const proposal = {
+        operation: { kind: "gateway-restart" as const },
+        hash: "e".repeat(64),
+      };
+      const session = {
+        engine: {
+          historyLength: () => 0,
+          historySince: () => [],
+          noteAssistantMessage: vi.fn(),
+          getPendingOperatorProposal: () => proposal,
+          resolveOperatorApproval: vi.fn().mockResolvedValue(null),
+        },
+        lastUsedAt: 1,
+        ownerKey: "agent:main:main",
+      } as unknown as SystemAgentChatSession;
+      const sessions = new Map([["delegate-worker", session]]);
+      const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
+        approvalKind: "system-agent",
+        resolveAllowedDecisions: (request) => request.allowedDecisions,
+        validateAgentRuntimeDelegatedAuthority: validateAgentRunDelegatedAuthority,
+      });
+      const context = {
+        systemAgentApprovalManager: manager,
+        broadcast: vi.fn(),
+        validateAgentRuntimeApprovalAuthority: () => true,
+      } as unknown as GatewayRequestContext;
+      const operationalRunInstance = createOperationalRunInstanceRef("delegated-worker-run");
+      claimAgentRunDelegatedAuthority(operationalRunInstance);
+
+      const firstClaim = workerTurnClaim("turn-2");
+      let firstApprovalId: string | undefined;
+      await withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          operationalRunInstance,
+          workerTurnClaim: firstClaim,
+        },
+        async () => {
+          firstApprovalId = await queueDelegatedApproval({
+            context,
+            sessions,
+            session,
+            sessionId: "delegate-worker",
+            delegation: { agentId: "main", sessionKey: "agent:main:main" },
+            proposal,
+          });
+        },
+      );
+      const secondClaim = workerTurnClaim("turn-2");
+      let secondApprovalId: string | undefined;
+      await withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          operationalRunInstance,
+          workerTurnClaim: secondClaim,
+          fullPermission,
+        },
+        async () => {
+          secondApprovalId = await queueDelegatedApproval({
+            context,
+            sessions,
+            session,
+            sessionId: "delegate-worker",
+            delegation: { agentId: "main", sessionKey: "agent:main:main" },
+            proposal,
+          });
+        },
+      );
+
+      expect(secondApprovalId).toBe(firstApprovalId);
+      expect(manager.listPendingRecords()).toHaveLength(1);
+      expect(session.engine.resolveOperatorApproval).not.toHaveBeenCalled();
+      const completion = session.pendingApproval?.completion;
+      manager.expire(firstApprovalId!);
+      await completion;
+    },
+  );
+});

--- a/src/gateway/server-methods/system-agent-approval.test.ts
+++ b/src/gateway/server-methods/system-agent-approval.test.ts
@@ -16,8 +16,10 @@ import {
   resetAgentRunRegistryForTest,
   validateAgentRunDelegatedAuthority,
 } from "../../infra/agent-run-registry.js";
-import type { ExecApprovalDecision } from "../../infra/exec-approvals.js";
-import type { SystemAgentApprovalRequestPayload } from "../../infra/system-agent-approvals.js";
+import {
+  SYSTEM_AGENT_APPROVAL_TIMEOUT_MS,
+  type SystemAgentApprovalRequestPayload,
+} from "../../infra/system-agent-approvals.js";
 import { resetPluginStateStoreForTests } from "../../plugin-state/plugin-state-store.js";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
 import { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
@@ -28,8 +30,8 @@ import {
   type SystemAgentPluginMetadataTestSnapshot,
 } from "../../system-agent/system-agent.test-helpers.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
-import type { WorkerSessionTurnClaim } from "../worker-environments/placement-record.js";
-import { prepareDelegatedSystemAgentApproval } from "./system-agent-approval.js";
+import { getOperatorApprovalDetailed } from "../operator-approval-store.js";
+import { runSystemAgentGatewayTask } from "./system-agent-execution.js";
 import { systemAgentHandlers, type SystemAgentChatSession } from "./system-agent.js";
 import type { GatewayClient, GatewayRequestContext } from "./types.js";
 
@@ -47,472 +49,6 @@ vi.mock("../../system-agent/transcript-store.js", () => transcriptStoreMocks);
 
 afterEach(() => {
   resetAgentRunRegistryForTest();
-});
-
-async function resolveTestProposal(
-  params: Parameters<typeof prepareDelegatedSystemAgentApproval>[0] & {
-    proposal: NonNullable<
-      ReturnType<SystemAgentChatSession["engine"]["getPendingOperatorProposal"]>
-    >;
-  },
-) {
-  const resolveProposal = await prepareDelegatedSystemAgentApproval(params);
-  return await resolveProposal(params.proposal);
-}
-
-async function queueDelegatedApproval(
-  params: Parameters<typeof resolveTestProposal>[0],
-): Promise<string> {
-  const resolution = await resolveTestProposal(params);
-  if (resolution.kind !== "approval") {
-    throw new Error("expected a human approval request");
-  }
-  return resolution.id;
-}
-
-describe("prepareDelegatedSystemAgentApproval", () => {
-  const workerTurnClaim = (claimId: string): WorkerSessionTurnClaim => ({
-    sessionId: "delegate-worker",
-    claimId,
-    runId: "delegated-worker-run",
-    placementGeneration: 1,
-    owner: { kind: "worker", environmentId: "worker-1", ownerEpoch: 1 },
-  });
-
-  it("refuses to apply a delegated change after its run authority closes", async () => {
-    const proposal = {
-      operation: { kind: "gateway-restart" as const },
-      hash: "a".repeat(64),
-    };
-    const resolveOperatorApproval = vi.fn().mockResolvedValue(null);
-    const session = {
-      engine: {
-        getPendingOperatorProposal: () => proposal,
-        resolveOperatorApproval,
-      },
-      lastUsedAt: 1,
-      ownerKey: "agent:main:main",
-    } as unknown as SystemAgentChatSession;
-    const sessions = new Map([["delegate-closed", session]]);
-    const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
-      approvalKind: "system-agent",
-      resolveAllowedDecisions: (request) => request.allowedDecisions,
-      validateAgentRuntimeDelegatedAuthority: validateAgentRunDelegatedAuthority,
-    });
-    const context = {
-      systemAgentApprovalManager: manager,
-      broadcast: vi.fn(),
-    } as unknown as GatewayRequestContext;
-    const operationalRunInstance = createOperationalRunInstanceRef("delegated-run-closed");
-    const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
-
-    let approvalId: string | undefined;
-    await withGatewayToolCallerIdentity(
-      {
-        agentId: "main",
-        sessionKey: "agent:main:main",
-        operationalRunInstance,
-      },
-      async () => {
-        approvalId = await queueDelegatedApproval({
-          context,
-          sessions,
-          session,
-          sessionId: "delegate-closed",
-          delegation: { agentId: "main", sessionKey: "agent:main:main" },
-          proposal,
-        });
-      },
-    );
-    expect(releaseAgentRunDelegatedAuthority(authority)).toBe(true);
-    expect(validateAgentRunDelegatedAuthority(authority)).toBe(false);
-
-    expect(approvalId).toBeTruthy();
-    expect(manager.resolve(approvalId!, "allow-once", "operator-ui")).toBe(false);
-    expect(manager.getSnapshot(approvalId!)?.status).toBe("cancelled");
-    await vi.waitFor(() =>
-      expect(resolveOperatorApproval).toHaveBeenCalledWith(
-        null,
-        proposal.hash,
-        expect.any(Function),
-      ),
-    );
-  });
-
-  it("rechecks authority after queued approval work before the final effect", async () => {
-    const proposal = {
-      operation: { kind: "gateway-restart" as const },
-      hash: "b".repeat(64),
-    };
-    const applyStarted = createDeferred();
-    const releaseApply = createDeferred();
-    const applyEffect = vi.fn();
-    const resolveOperatorApproval = vi.fn(
-      async (
-        _decision: "allow-once" | "allow-always" | "deny" | null,
-        _proposalHash: string,
-        beforePersistentApply?: () => void,
-      ) => {
-        if (_decision === null) {
-          return null;
-        }
-        applyStarted.resolve();
-        await releaseApply.promise;
-        beforePersistentApply?.();
-        applyEffect();
-        return null;
-      },
-    );
-    const session = {
-      engine: {
-        getPendingOperatorProposal: () => proposal,
-        resolveOperatorApproval,
-      },
-      lastUsedAt: 1,
-      ownerKey: "agent:main:main",
-    } as unknown as SystemAgentChatSession;
-    const sessions = new Map([["delegate-race", session]]);
-    const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
-      approvalKind: "system-agent",
-      resolveAllowedDecisions: (request) => request.allowedDecisions,
-      validateAgentRuntimeDelegatedAuthority: validateAgentRunDelegatedAuthority,
-    });
-    const publishResolved = vi.fn();
-    const context = {
-      systemAgentApprovalManager: manager,
-      broadcast: vi.fn(),
-      approvalEvents: { publishRequested: vi.fn(), publishResolved },
-    } as unknown as GatewayRequestContext;
-    const operationalRunInstance = createOperationalRunInstanceRef("delegated-run-race");
-    const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
-
-    let approvalId: string | undefined;
-    await withGatewayToolCallerIdentity(
-      {
-        agentId: "main",
-        sessionKey: "agent:main:main",
-        operationalRunInstance,
-      },
-      async () => {
-        approvalId = await queueDelegatedApproval({
-          context,
-          sessions,
-          session,
-          sessionId: "delegate-race",
-          delegation: { agentId: "main", sessionKey: "agent:main:main" },
-          proposal,
-        });
-      },
-    );
-
-    expect(manager.resolve(approvalId!, "allow-once", "operator-ui")).toBe(true);
-    await applyStarted.promise;
-    expect(releaseAgentRunDelegatedAuthority(authority)).toBe(true);
-    releaseApply.resolve();
-    const result = resolveOperatorApproval.mock.results[0]?.value;
-    await expect(result).rejects.toThrow("system-agent approval authority is no longer active");
-    expect(applyEffect).not.toHaveBeenCalled();
-    await vi.waitFor(() =>
-      expect(publishResolved).toHaveBeenCalledWith(
-        "system-agent",
-        expect.objectContaining({ applicationStatus: "not-applied" }),
-      ),
-    );
-  });
-
-  it.each(["run", "tool", "gateway", "worker", "session"] as const)(
-    "fences Full Access when its %s closes during apply preparation",
-    async (owner) => {
-      const started = createDeferred();
-      const release = createDeferred();
-      const effect = vi.fn();
-      const proposal = { operation: { kind: "gateway-restart" as const }, hash: "f".repeat(64) };
-      const session = {
-        engine: {
-          resolveOperatorApproval: async (
-            decision: ExecApprovalDecision | null,
-            _hash: string,
-            assertCurrent?: () => void,
-          ) => {
-            if (decision === null) {
-              return null;
-            }
-            started.resolve();
-            await release.promise;
-            assertCurrent?.();
-            effect();
-            return { text: "Applied", action: "none" as const, applied: true };
-          },
-        },
-        ownerKey: "agent:main:main",
-        lastUsedAt: 1,
-      } as unknown as SystemAgentChatSession;
-      const sessions = new Map([["delegate-full", session]]);
-      let workerActive = true;
-      const context = {
-        systemAgentSessions: sessions,
-        validateAgentRuntimeApprovalAuthority: () => workerActive,
-      } as unknown as GatewayRequestContext;
-      let liveContext = context;
-      const operationalRunInstance = createOperationalRunInstanceRef("full-access-run");
-      const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
-      const controller = new AbortController();
-      const pending = withGatewayToolCallerIdentity(
-        {
-          agentId: "main",
-          sessionKey: "agent:main:main",
-          operationalRunInstance,
-          approvalAuthority: authority,
-          fullPermission: true,
-          gatewayContextResolver: () => liveContext,
-          approvalSignals: [controller.signal],
-          ...(owner === "worker" ? { workerTurnClaim: workerTurnClaim("full-turn") } : {}),
-        },
-        () =>
-          resolveTestProposal({
-            context,
-            sessions,
-            session,
-            sessionId: "delegate-full",
-            delegation: { agentId: "main", sessionKey: "agent:main:main" },
-            proposal,
-          }),
-      );
-      await started.promise;
-      if (owner === "run") {
-        releaseAgentRunDelegatedAuthority(authority);
-      } else if (owner === "tool") {
-        controller.abort();
-      } else if (owner === "gateway") {
-        liveContext = { ...context };
-      } else if (owner === "worker") {
-        workerActive = false;
-      } else {
-        sessions.set("delegate-full", { ...session });
-      }
-      release.resolve();
-
-      await expect(pending).rejects.toThrow("system-agent approval authority is no longer active");
-      expect(effect).not.toHaveBeenCalled();
-    },
-  );
-
-  it("publishes the channel completion after the delegated change is applied", async () => {
-    const proposal = {
-      operation: { kind: "gateway-restart" as const },
-      hash: "c".repeat(64),
-    };
-    const resolveOperatorApproval = vi.fn().mockResolvedValue({
-      text: "Applied",
-      action: "none" as const,
-      applied: true,
-    });
-    const session = {
-      engine: {
-        getPendingOperatorProposal: () => proposal,
-        resolveOperatorApproval,
-      },
-      lastUsedAt: 1,
-      ownerKey: "agent:main:main",
-    } as unknown as SystemAgentChatSession;
-    const sessions = new Map([["delegate-applied", session]]);
-    const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
-      approvalKind: "system-agent",
-      resolveAllowedDecisions: (request) => request.allowedDecisions,
-      validateAgentRuntimeDelegatedAuthority: validateAgentRunDelegatedAuthority,
-    });
-    const publishResolved = vi.fn();
-    const context = {
-      systemAgentApprovalManager: manager,
-      broadcast: vi.fn(),
-      approvalEvents: { publishRequested: vi.fn(), publishResolved },
-    } as unknown as GatewayRequestContext;
-    const operationalRunInstance = createOperationalRunInstanceRef("delegated-run-applied");
-    claimAgentRunDelegatedAuthority(operationalRunInstance);
-
-    let approvalId: string | undefined;
-    await withGatewayToolCallerIdentity(
-      {
-        agentId: "main",
-        sessionKey: "agent:main:main",
-        operationalRunInstance,
-      },
-      async () => {
-        approvalId = await queueDelegatedApproval({
-          context,
-          sessions,
-          session,
-          sessionId: "delegate-applied",
-          delegation: { agentId: "main", sessionKey: "agent:main:main" },
-          proposal,
-        });
-      },
-    );
-
-    expect(manager.resolve(approvalId!, "allow-once", "operator-ui")).toBe(true);
-    await vi.waitFor(() =>
-      expect(publishResolved).toHaveBeenCalledWith(
-        "system-agent",
-        expect.objectContaining({ applicationStatus: "applied" }),
-      ),
-    );
-  });
-
-  it("fences a delegated worker turn before the persistent effect", async () => {
-    const proposal = {
-      operation: { kind: "gateway-restart" as const },
-      hash: "d".repeat(64),
-    };
-    const applyStarted = createDeferred();
-    const releaseApply = createDeferred();
-    let workerTurnActive = true;
-    const applyEffect = vi.fn();
-    const resolveOperatorApproval = vi.fn(
-      async (
-        _decision: "allow-once" | "allow-always" | "deny" | null,
-        _proposalHash: string,
-        beforePersistentApply?: () => void,
-      ) => {
-        if (_decision === null) {
-          return null;
-        }
-        applyStarted.resolve();
-        await releaseApply.promise;
-        beforePersistentApply?.();
-        applyEffect();
-        return null;
-      },
-    );
-    const session = {
-      engine: {
-        getPendingOperatorProposal: () => proposal,
-        resolveOperatorApproval,
-      },
-      lastUsedAt: 1,
-      ownerKey: "agent:main:main",
-    } as unknown as SystemAgentChatSession;
-    const sessions = new Map([["delegate-worker", session]]);
-    const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
-      approvalKind: "system-agent",
-      resolveAllowedDecisions: (request) => request.allowedDecisions,
-      validateAgentRuntimeDelegatedAuthority: (authority) =>
-        validateAgentRunDelegatedAuthority(authority) && workerTurnActive,
-    });
-    const context = {
-      systemAgentApprovalManager: manager,
-      broadcast: vi.fn(),
-      approvalEvents: { publishRequested: vi.fn(), publishResolved: vi.fn() },
-      validateAgentRuntimeApprovalAuthority: () => workerTurnActive,
-    } as unknown as GatewayRequestContext;
-    const operationalRunInstance = createOperationalRunInstanceRef("delegated-worker-run");
-    claimAgentRunDelegatedAuthority(operationalRunInstance);
-    const turnClaim = workerTurnClaim("turn-1");
-
-    let approvalId: string | undefined;
-    await withGatewayToolCallerIdentity(
-      {
-        agentId: "main",
-        sessionKey: "agent:main:main",
-        operationalRunInstance,
-        workerTurnClaim: turnClaim,
-      },
-      async () => {
-        approvalId = await queueDelegatedApproval({
-          context,
-          sessions,
-          session,
-          sessionId: "delegate-worker",
-          delegation: { agentId: "main", sessionKey: "agent:main:main" },
-          proposal,
-        });
-      },
-    );
-
-    expect(manager.resolve(approvalId!, "allow-once", "operator-ui")).toBe(true);
-    await applyStarted.promise;
-    workerTurnActive = false;
-    releaseApply.resolve();
-    const result = resolveOperatorApproval.mock.results[0]?.value;
-    await expect(result).rejects.toThrow("system-agent approval authority is no longer active");
-    expect(applyEffect).not.toHaveBeenCalled();
-  });
-
-  it.each([false, true])(
-    "reuses the exact worker approval with Full Access=%s",
-    async (fullPermission) => {
-      const proposal = {
-        operation: { kind: "gateway-restart" as const },
-        hash: "e".repeat(64),
-      };
-      const session = {
-        engine: {
-          getPendingOperatorProposal: () => proposal,
-          resolveOperatorApproval: vi.fn().mockResolvedValue(null),
-        },
-        lastUsedAt: 1,
-        ownerKey: "agent:main:main",
-      } as unknown as SystemAgentChatSession;
-      const sessions = new Map([["delegate-worker", session]]);
-      const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
-        approvalKind: "system-agent",
-        resolveAllowedDecisions: (request) => request.allowedDecisions,
-        validateAgentRuntimeDelegatedAuthority: validateAgentRunDelegatedAuthority,
-      });
-      const context = {
-        systemAgentApprovalManager: manager,
-        broadcast: vi.fn(),
-        validateAgentRuntimeApprovalAuthority: () => true,
-      } as unknown as GatewayRequestContext;
-      const operationalRunInstance = createOperationalRunInstanceRef("delegated-worker-run");
-      claimAgentRunDelegatedAuthority(operationalRunInstance);
-
-      const firstClaim = workerTurnClaim("turn-2");
-      let firstApprovalId: string | undefined;
-      await withGatewayToolCallerIdentity(
-        {
-          agentId: "main",
-          sessionKey: "agent:main:main",
-          operationalRunInstance,
-          workerTurnClaim: firstClaim,
-        },
-        async () => {
-          firstApprovalId = await queueDelegatedApproval({
-            context,
-            sessions,
-            session,
-            sessionId: "delegate-worker",
-            delegation: { agentId: "main", sessionKey: "agent:main:main" },
-            proposal,
-          });
-        },
-      );
-      const secondClaim = workerTurnClaim("turn-2");
-      let secondApprovalId: string | undefined;
-      await withGatewayToolCallerIdentity(
-        {
-          agentId: "main",
-          sessionKey: "agent:main:main",
-          operationalRunInstance,
-          workerTurnClaim: secondClaim,
-          fullPermission,
-        },
-        async () => {
-          secondApprovalId = await queueDelegatedApproval({
-            context,
-            sessions,
-            session,
-            sessionId: "delegate-worker",
-            delegation: { agentId: "main", sessionKey: "agent:main:main" },
-            proposal,
-          });
-        },
-      );
-
-      expect(secondApprovalId).toBe(firstApprovalId);
-      expect(manager.listPendingRecords()).toHaveLength(1);
-      expect(session.engine.resolveOperatorApproval).not.toHaveBeenCalled();
-    },
-  );
 });
 
 describe("Full Access delegated chat", () => {
@@ -540,6 +76,320 @@ describe("Full Access delegated chat", () => {
     pluginMetadataSnapshot?.rebindForCurrentEnv();
   });
 
+  async function createDelegatedChatFixture(
+    source: "typed" | "model tool" | "planner" = "typed",
+    previousRun = "live",
+  ) {
+    const stateDir = systemAgentTempDirs.make("openclaw-full-access-change-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
+    fs.writeFileSync(path.join(stateDir, "openclaw.json"), JSON.stringify(verifiedConfig));
+    pluginMetadataSnapshot?.rebindForCurrentEnv();
+    const fixture = await createSystemAgentVerifiedInferenceTestFixture(verifiedConfig);
+    setupInferenceMocks.resolvePersistentApplyInference.mockResolvedValue(
+      fixture.binding.execution,
+    );
+    const runConfigSet = vi.fn(async () => {});
+    let proposed = false;
+    const engine = new SystemAgentChatEngine({
+      operatorApprovalOnly: true,
+      surface: "gateway",
+      verifiedInference: fixture.binding,
+      deps: {
+        ...fixture.deps,
+        readConfigFileSnapshot: async () =>
+          ({
+            exists: true,
+            valid: true,
+            path: "/tmp/openclaw.json",
+            hash: "verified-config",
+            config: verifiedConfig,
+            runtimeConfig: verifiedConfig,
+            sourceConfig: verifiedConfig,
+            issues: [],
+          }) as never,
+        runConfigSet,
+      },
+      runAgentTurn: async (params) => {
+        if (source === "typed" || proposed) {
+          return { text: "Config verified." };
+        }
+        if (source === "planner") {
+          return null;
+        }
+        proposed = true;
+        const tool = createSystemAgentTool({
+          surface: params.surface,
+          approvalArmed: params.approvalArmed,
+          operatorApprovalOnly: params.operatorApprovalOnly,
+          proposalRef: params.session.proposalRef,
+        });
+        await tool.execute("propose-config", {
+          action: "config_set",
+          path: "logging.level",
+          value: "debug",
+        });
+        return { text: "Change proposed." };
+      },
+      planWithAssistant: async () => {
+        proposed = true;
+        return { reply: "Change proposed.", command: "config set logging.level debug" };
+      },
+    });
+    vi.spyOn(engine, "loadOverview").mockResolvedValue({
+      config: { path: "/tmp/openclaw.json", exists: true, valid: true, issues: [], hash: null },
+      agents: [],
+      defaultAgentId: "main",
+      defaultModel: "openai/gpt-5.5",
+      tools: {
+        codex: { available: false },
+        claude: { available: false },
+        gemini: { available: false },
+        apiKeys: { openai: false, anthropic: false },
+      },
+      gateway: { url: "ws://127.0.0.1:18789", source: "test", reachable: true },
+      references: {
+        docsUrl: "https://docs.openclaw.ai",
+        sourceUrl: "https://github.com/openclaw/openclaw",
+      },
+    } as never);
+    const delegatedSession: SystemAgentChatSession = {
+      engine,
+      welcome: "welcome text",
+      lastUsedAt: 1,
+      ownerKey: JSON.stringify(["main", "agent:main:main"]),
+    };
+    const sessions = new Map<string, SystemAgentChatSession>([["delegate-full", delegatedSession]]);
+    const approvalDatabasePath = path.join(stateDir, "approvals.sqlite");
+    if (previousRun === "registration-failure") {
+      fs.mkdirSync(approvalDatabasePath);
+    }
+    const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
+      approvalKind: "system-agent",
+      resolveAllowedDecisions: (request) => request.allowedDecisions,
+      validateAgentRuntimeDelegatedAuthority: validateAgentRunDelegatedAuthority,
+      ...(["registration-failure", "durable"].includes(previousRun)
+        ? {
+            persistence: {
+              runtimeEpoch: "delegated-approval-test",
+              databaseOptions: { path: approvalDatabasePath },
+            },
+          }
+        : {}),
+    });
+    const operationalRunInstance = createOperationalRunInstanceRef("delegated-full-run");
+    const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
+    const requested = createDeferred();
+    const broadcast = vi.fn((event: string) => {
+      if (event === "openclaw.approval.requested") {
+        requested.resolve();
+      }
+    });
+    const context = {
+      systemAgentSessions: sessions,
+      systemAgentApprovalManager: manager,
+      broadcast,
+      broadcastToConnIds: vi.fn(),
+      hasExecApprovalClients: () => true,
+    } as unknown as GatewayRequestContext;
+    const callChat = async (params: Record<string, unknown>) => {
+      const respond = vi.fn<(ok: boolean, payload?: unknown, error?: unknown) => void>();
+      const handler = expectDefined(systemAgentHandlers["openclaw.chat"], "chat handler");
+      await handler({
+        params,
+        respond,
+        context,
+        client: {
+          connId: "conn-test",
+          connect: { device: { id: "device-test" } },
+        } as GatewayClient,
+      } as never);
+      const [ok, payload, error] = expectDefined(respond.mock.calls[0], "chat response");
+      return { ok, payload, error };
+    };
+    return {
+      engine,
+      manager,
+      authority,
+      operationalRunInstance,
+      sessions,
+      delegatedSession,
+      context,
+      runConfigSet,
+      broadcast,
+      callChat,
+      requested,
+      approvalDatabasePath,
+    };
+  }
+
+  it.each([
+    "allow",
+    "deny",
+    "expired",
+    "run-cancelled",
+    "tool-cancelled",
+    "apply-failed",
+    "queued-cancelled",
+    "precommit-cancelled",
+    "afterDecision-failed",
+  ] as const)(
+    "keeps delegated chat pending without blocking other work until %s settles",
+    async (outcome) => {
+      const {
+        engine,
+        manager,
+        authority,
+        operationalRunInstance,
+        runConfigSet,
+        callChat,
+        requested,
+        approvalDatabasePath,
+      } = await createDelegatedChatFixture("typed", "durable");
+      const controller = new AbortController();
+      if (outcome === "expired") {
+        vi.useFakeTimers();
+      }
+      const applyStarted = createDeferred();
+      const releaseApply = createDeferred();
+      const execution = await setupInferenceMocks.resolvePersistentApplyInference();
+      if (outcome === "precommit-cancelled" || outcome === "afterDecision-failed") {
+        setupInferenceMocks.resolvePersistentApplyInference.mockImplementationOnce(async () => {
+          applyStarted.resolve();
+          await releaseApply.promise;
+          if (outcome === "afterDecision-failed") {
+            throw new Error("inference unavailable");
+          }
+          return execution;
+        });
+      }
+      if (outcome === "apply-failed") {
+        runConfigSet.mockRejectedValueOnce(new Error("write failed"));
+      }
+      let sameOwner: Promise<Awaited<ReturnType<typeof callChat>>> | undefined;
+      let settled = false;
+      const pending = withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          operationalRunInstance,
+          approvalSignals: [controller.signal],
+        },
+        () =>
+          callChat({
+            sessionId: "delegate-full",
+            message: "config set logging.level debug",
+            delegation: { agentId: "main", sessionKey: "agent:main:main" },
+          }),
+      ).then((result) => {
+        settled = true;
+        return result;
+      });
+      try {
+        await requested.promise;
+        const record = expectDefined(manager.listPendingRecords()[0], "pending approval");
+        await runSystemAgentGatewayTask(async () => undefined);
+        expect.soft(settled).toBe(false);
+        expect(runConfigSet).not.toHaveBeenCalled();
+        if (outcome === "allow") {
+          sameOwner = withGatewayToolCallerIdentity(
+            { agentId: "main", sessionKey: "agent:main:main", operationalRunInstance },
+            () =>
+              callChat({
+                sessionId: "delegate-full",
+                message: "Has it finished?",
+                delegation: { agentId: "main", sessionKey: "agent:main:main" },
+              }),
+          );
+          await runSystemAgentGatewayTask(async () => undefined);
+          expect(manager.listPendingRecords()).toHaveLength(1);
+        }
+        if (outcome === "expired") {
+          await vi.advanceTimersByTimeAsync(SYSTEM_AGENT_APPROVAL_TIMEOUT_MS);
+        } else if (outcome === "run-cancelled") {
+          releaseAgentRunDelegatedAuthority(authority);
+          manager.forceDenyIfRuntimeAuthorityClosed(record.id);
+        } else if (outcome === "tool-cancelled") {
+          controller.abort();
+        } else {
+          const queued =
+            outcome === "queued-cancelled"
+              ? runSystemAgentGatewayTask(async () => {
+                  applyStarted.resolve();
+                  await releaseApply.promise;
+                })
+              : undefined;
+          if (queued) {
+            await applyStarted.promise;
+          }
+          expect(
+            manager.resolve(record.id, outcome === "deny" ? "deny" : "allow-once", "operator-ui"),
+          ).toBe(true);
+          if (queued || outcome === "precommit-cancelled" || outcome === "afterDecision-failed") {
+            await applyStarted.promise;
+            if (outcome !== "afterDecision-failed") {
+              controller.abort();
+            }
+            releaseApply.resolve();
+            await queued;
+          }
+        }
+        const result = await pending;
+        if (sameOwner) {
+          expect((await sameOwner).payload).toEqual(result.payload);
+        }
+        if (outcome === "queued-cancelled" || outcome === "precommit-cancelled") {
+          expect(
+            getOperatorApprovalDetailed({
+              id: record.id,
+              databaseOptions: { path: approvalDatabasePath },
+            }),
+          ).toMatchObject({
+            outcome: "found",
+            record: { decision: "allow-once", status: "allowed" },
+          });
+          expect(manager.resolve(record.id, "allow-once", "late-operator")).toBe(false);
+        }
+        const expected =
+          outcome === "allow"
+            ? "[openclaw] done: config.set"
+            : outcome === "deny"
+              ? "Denied"
+              : outcome === "expired"
+                ? "expired"
+                : outcome === "apply-failed" || outcome === "afterDecision-failed"
+                  ? "failed"
+                  : "cancelled";
+        expect.soft(result.payload).toMatchObject({ reply: expect.stringContaining(expected) });
+        expect.soft(result.payload).not.toHaveProperty("needsApproval");
+        expect.soft(result.payload).not.toHaveProperty("proposalId");
+        await vi.waitFor(() => expect(engine.getPendingOperatorProposal()).toBeNull());
+        expect(runConfigSet).toHaveBeenCalledTimes(
+          outcome === "allow" || outcome === "apply-failed" ? 1 : 0,
+        );
+        if (outcome === "allow" || outcome === "afterDecision-failed") {
+          expect(
+            transcriptStoreMocks.appendTranscriptTurn.mock.calls.filter(([turn]) =>
+              turn.text.includes(
+                outcome === "allow" ? "[openclaw] done: config.set" : "failed to complete",
+              ),
+            ),
+          ).toHaveLength(1);
+        }
+      } finally {
+        releaseApply.resolve();
+        controller.abort();
+        for (const record of manager.listPendingRecords()) {
+          manager.expire(record.id);
+        }
+        await pending;
+        await sameOwner;
+        await engine.dispose();
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it.each([
     ...(["typed", "model tool", "planner"] as const).flatMap((source) =>
       (["closed", "live", "live-restricted"] as const).map((previousRun) => ({
@@ -553,130 +403,17 @@ describe("Full Access delegated chat", () => {
   ])(
     "applies Full Access via $source without inheriting a $previousRun proposal",
     async ({ source, previousRun }) => {
-      const stateDir = systemAgentTempDirs.make("openclaw-full-access-change-");
-      vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-      vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
-      fs.writeFileSync(path.join(stateDir, "openclaw.json"), JSON.stringify(verifiedConfig));
-      pluginMetadataSnapshot?.rebindForCurrentEnv();
-      const fixture = await createSystemAgentVerifiedInferenceTestFixture(verifiedConfig);
-      setupInferenceMocks.resolvePersistentApplyInference.mockResolvedValue(
-        fixture.binding.execution,
-      );
-      const runConfigSet = vi.fn(async () => {});
-      let proposed = false;
-      const engine = new SystemAgentChatEngine({
-        operatorApprovalOnly: true,
-        surface: "gateway",
-        verifiedInference: fixture.binding,
-        deps: {
-          ...fixture.deps,
-          readConfigFileSnapshot: async () =>
-            ({
-              exists: true,
-              valid: true,
-              path: "/tmp/openclaw.json",
-              hash: "verified-config",
-              config: verifiedConfig,
-              runtimeConfig: verifiedConfig,
-              sourceConfig: verifiedConfig,
-              issues: [],
-            }) as never,
-          runConfigSet,
-        },
-        runAgentTurn: async (params) => {
-          if (source === "typed" || proposed) {
-            return { text: "Config verified." };
-          }
-          if (source === "planner") {
-            return null;
-          }
-          proposed = true;
-          const tool = createSystemAgentTool({
-            surface: params.surface,
-            approvalArmed: params.approvalArmed,
-            operatorApprovalOnly: params.operatorApprovalOnly,
-            proposalRef: params.session.proposalRef,
-          });
-          await tool.execute("propose-config", {
-            action: "config_set",
-            path: "logging.level",
-            value: "debug",
-          });
-          return { text: "Change proposed." };
-        },
-        planWithAssistant: async () => {
-          proposed = true;
-          return { reply: "Change proposed.", command: "config set logging.level debug" };
-        },
-      });
-      vi.spyOn(engine, "loadOverview").mockResolvedValue({
-        config: { path: "/tmp/openclaw.json", exists: true, valid: true, issues: [], hash: null },
-        agents: [],
-        defaultAgentId: "main",
-        defaultModel: "openai/gpt-5.5",
-        tools: {
-          codex: { available: false },
-          claude: { available: false },
-          gemini: { available: false },
-          apiKeys: { openai: false, anthropic: false },
-        },
-        gateway: { url: "ws://127.0.0.1:18789", source: "test", reachable: true },
-        references: {
-          docsUrl: "https://docs.openclaw.ai",
-          sourceUrl: "https://github.com/openclaw/openclaw",
-        },
-      } as never);
-      const delegatedSession: SystemAgentChatSession = {
+      const {
         engine,
-        welcome: "welcome text",
-        lastUsedAt: 1,
-        ownerKey: JSON.stringify(["main", "agent:main:main"]),
-      };
-      const sessions = new Map<string, SystemAgentChatSession>([
-        ["delegate-full", delegatedSession],
-      ]);
-      const approvalDatabasePath = path.join(stateDir, "approvals.sqlite");
-      if (previousRun === "registration-failure") {
-        fs.mkdirSync(approvalDatabasePath);
-      }
-      const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
-        approvalKind: "system-agent",
-        resolveAllowedDecisions: (request) => request.allowedDecisions,
-        validateAgentRuntimeDelegatedAuthority: validateAgentRunDelegatedAuthority,
-        ...(previousRun === "registration-failure"
-          ? {
-              persistence: {
-                runtimeEpoch: "registration-failure",
-                databaseOptions: { path: approvalDatabasePath },
-              },
-            }
-          : {}),
-      });
-      const operationalRunInstance = createOperationalRunInstanceRef("delegated-full-run");
-      const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
-      const broadcast = vi.fn();
-      const context = {
-        systemAgentSessions: sessions,
-        systemAgentApprovalManager: manager,
+        manager,
+        authority,
+        operationalRunInstance,
+        delegatedSession,
+        runConfigSet,
         broadcast,
-        broadcastToConnIds: vi.fn(),
-        hasExecApprovalClients: () => true,
-      } as unknown as GatewayRequestContext;
-      const callChat = async (params: Record<string, unknown>) => {
-        const respond = vi.fn<(ok: boolean, payload?: unknown, error?: unknown) => void>();
-        const handler = expectDefined(systemAgentHandlers["openclaw.chat"], "chat handler");
-        await handler({
-          params,
-          respond,
-          context,
-          client: {
-            connId: "conn-test",
-            connect: { device: { id: "device-test" } },
-          } as GatewayClient,
-        } as never);
-        const [ok, payload, error] = expectDefined(respond.mock.calls[0], "chat response");
-        return { ok, payload, error };
-      };
+        callChat,
+        requested,
+      } = await createDelegatedChatFixture(source, previousRun);
 
       const call = await withGatewayToolCallerIdentity(
         {
@@ -754,7 +491,7 @@ describe("Full Access delegated chat", () => {
         expect(manager.listPendingRecords()).toEqual([]);
         expect.soft(engine.getPendingOperatorProposal()).toBeNull();
       } else {
-        expect((await proposalCall).payload).toMatchObject({ needsApproval: true });
+        await requested.promise;
         expect(manager.listPendingRecords()).toHaveLength(1);
       }
       expect(runConfigSet).toHaveBeenCalledOnce();
@@ -812,6 +549,9 @@ describe("Full Access delegated chat", () => {
       expect(manager.listPendingRecords()).toEqual([]);
       if (pending) {
         expect(manager.resolve(pending.id, "allow-once", "late-operator")).toBe(false);
+        expect((await proposalCall).payload).toMatchObject({
+          reply: expect.stringContaining("cancelled"),
+        });
       }
       expect(validateAgentRunDelegatedAuthority(authority)).toBe(previousAuthorityActive);
     },

--- a/src/gateway/server-methods/system-agent-approval.ts
+++ b/src/gateway/server-methods/system-agent-approval.ts
@@ -13,8 +13,8 @@ import {
   type SystemAgentApprovalResolved,
   type SystemAgentApprovalRequestPayload,
 } from "../../infra/system-agent-approvals.js";
-import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../../process/gateway-work-admission.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { describeSystemAgentPersistentOperation } from "../../system-agent/operations.js";
 import type { AgentRuntimeDelegatedAuthority } from "../agent-runtime-identity-token.js";
 import { sameWorkerSessionTurnClaim } from "../worker-environments/placement-record.js";
@@ -24,6 +24,7 @@ import {
   handlePendingApprovalRequest,
 } from "./approval-shared.js";
 import type { GatewaySystemAgentSession } from "./shared-types.js";
+import { persistSystemAgentEngineHistory } from "./system-agent-chat-turn.js";
 import { runSystemAgentGatewayTask } from "./system-agent-execution.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -58,7 +59,7 @@ async function retireSystemAgentProposal(
       manager?.forceDenyIfRuntimeAuthorityClosed(pending.id);
     }
   } finally {
-    await session.engine.resolveOperatorApproval(null, proposalHash);
+    await session.engine.resolveOperatorApproval(null, proposalHash, undefined, "cancelled");
   }
 }
 
@@ -94,7 +95,7 @@ type DelegatedProposalResolver = (
     ReturnType<GatewaySystemAgentSession["engine"]["getPendingOperatorProposal"]>
   >,
 ) => Promise<
-  | { kind: "approval"; id: string }
+  | ({ kind: "approval" } & NonNullable<GatewaySystemAgentSession["pendingApproval"]>)
   | {
       kind: "completed";
       reply: NonNullable<
@@ -153,7 +154,9 @@ export async function prepareDelegatedSystemAgentApproval(params: {
   };
   const assertLiveApprovalAuthority = () => {
     if (!isAuthorityActive() || params.sessions.get(params.sessionId) !== params.session) {
-      throw new Error("system-agent approval authority is no longer active");
+      throw new Error(
+        "OpenClaw change cancelled: system-agent approval authority is no longer active. Retry the request if it is still needed.",
+      );
     }
   };
   const manager = params.context.systemAgentApprovalManager;
@@ -183,11 +186,14 @@ export async function prepareDelegatedSystemAgentApproval(params: {
           runtimeApprovalAuthority,
         );
         if (pending?.proposalHash === proposal.hash) {
-          return { kind: "approval", id: pending.id };
+          return { kind: "approval", ...pending };
         }
         throw new Error("OpenClaw change is no longer pending. Retry the request.");
       }
-      const applyDecision = async (decision: ExecApprovalDecision | null) => {
+      const applyDecision = async (
+        decision: ExecApprovalDecision | null,
+        terminalStatus?: "expired" | "cancelled",
+      ) => {
         if (decision && decision !== "deny") {
           assertLiveApprovalAuthority();
         }
@@ -195,6 +201,7 @@ export async function prepareDelegatedSystemAgentApproval(params: {
           decision,
           proposal.hash,
           assertLiveApprovalAuthority,
+          terminalStatus,
         );
       };
       // Only a fresh proposal belongs to this input. An existing operator request
@@ -230,7 +237,23 @@ export async function prepareDelegatedSystemAgentApproval(params: {
         SYSTEM_AGENT_APPROVAL_TIMEOUT_MS,
         `system-agent:${randomUUID()}`,
       );
-      const pendingApproval = { id: record.id, proposalHash: proposal.hash };
+      const completion =
+        createDeferredCore<NonNullable<Awaited<ReturnType<typeof applyDecision>>>>();
+      const pendingApproval = {
+        id: record.id,
+        proposalHash: proposal.hash,
+        completion: completion.promise,
+      };
+      const cancelledReply = {
+        text: "OpenClaw change cancelled. No change. Retry the request if it is still needed.",
+        action: "none" as const,
+        applied: false,
+      };
+      const failedReply = {
+        text: "OpenClaw change failed to complete. Check the current settings and OpenClaw status before retrying.",
+        action: "none" as const,
+        applied: false,
+      };
       params.session.pendingApproval = pendingApproval;
       record.agentRuntimeDelegatedAuthority = runtimeApprovalAuthority;
       // The request loses authority when replaced, even while its source run lives.
@@ -285,19 +308,41 @@ export async function prepareDelegatedSystemAgentApproval(params: {
                     params.sessions.get(params.sessionId) !== params.session ||
                     params.session.pendingApproval !== pendingApproval
                   ) {
-                    return null;
+                    return cancelledReply;
                   }
+                  let historyStart = params.session.engine.historyLength();
+                  const terminalStatus =
+                    record.status === "expired"
+                      ? "expired"
+                      : !isAuthorityActive() || record.status === "cancelled"
+                        ? "cancelled"
+                        : undefined;
                   params.session.pendingApproval = undefined;
-                  // Retire failures before releasing this task; a later run may propose the same hash.
-                  return await withProposalFailureCleanup(() => applyDecision(decision));
+                  try {
+                    // Retire failures before releasing this task; a later run may propose the same hash.
+                    return (
+                      (await withProposalFailureCleanup(() =>
+                        applyDecision(terminalStatus ? null : decision, terminalStatus),
+                      )) ?? cancelledReply
+                    );
+                  } catch {
+                    // Inference loss clears engine history; persist the failure from its new cursor.
+                    historyStart = params.session.engine.historyLength();
+                    params.session.engine.noteAssistantMessage(failedReply.text);
+                    return failedReply;
+                  } finally {
+                    persistSystemAgentEngineHistory(params.session.engine, historyStart);
+                  }
                 }),
               "system-agent:task",
             );
+            completion.resolve(reply);
             if (decision) {
               const applicationStatus = reply?.applied === true ? "applied" : "not-applied";
               publishApplicationResult(decision, applicationStatus);
             }
           } catch (error) {
+            completion.resolve(failedReply);
             if (decision) {
               publishApplicationResult(decision, "not-applied");
             }
@@ -305,24 +350,8 @@ export async function prepareDelegatedSystemAgentApproval(params: {
           }
         },
         afterDecisionErrorLabel: "OpenClaw approval apply failed",
-      });
-      return { kind: "approval", id: record.id };
+      }).catch(() => completion.resolve(failedReply));
+      return { kind: "approval", ...pendingApproval };
     });
   };
-}
-
-const systemAgentSessionQueues = new WeakMap<
-  Map<string, GatewaySystemAgentSession>,
-  KeyedAsyncQueue
->();
-
-export function getSystemAgentSessionQueue(
-  sessions: Map<string, GatewaySystemAgentSession>,
-): KeyedAsyncQueue {
-  let queue = systemAgentSessionQueues.get(sessions);
-  if (!queue) {
-    queue = new KeyedAsyncQueue();
-    systemAgentSessionQueues.set(sessions, queue);
-  }
-  return queue;
 }

--- a/src/gateway/server-methods/system-agent-chat-turn.test.ts
+++ b/src/gateway/server-methods/system-agent-chat-turn.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { SystemAgentApprovalRequestPayload } from "../../infra/system-agent-approvals.js";
-import { ExecApprovalManager } from "../exec-approval-manager.js";
 import {
-  buildDelegatedApprovalPendingReply,
   buildSystemAgentChatResult,
   getSystemAgentChatInputError,
   runSystemAgentChatInput,
@@ -140,55 +137,5 @@ describe("system-agent chat input", () => {
       action: "none",
       step: { id: "channel", type: "select" },
     });
-  });
-
-  it("omits the delegated approval link when the Control UI is disabled", async () => {
-    const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
-      approvalKind: "system-agent",
-      resolveAllowedDecisions: (request) => request.allowedDecisions,
-    });
-    const record = manager.create(
-      {
-        title: "OpenClaw change",
-        description: "restart the Gateway",
-        command: "restart the Gateway",
-        proposalHash: "a".repeat(64),
-        allowedDecisions: ["allow-once", "deny"],
-        sessionId: "delegation-disabled-ui",
-      },
-      60_000,
-      "system-agent:disabled-ui",
-    );
-    const decisionPromise = manager.register(record, 60_000);
-    try {
-      const snapshot = manager.getSnapshot(record.id);
-      expect(snapshot).not.toBeNull();
-      expect(snapshot?.resolvedAtMs).toBeUndefined();
-
-      const replyParams = {
-        cfg: {
-          gateway: {
-            publicOrigin: "https://control.example.com",
-            controlUi: { enabled: false },
-          },
-        },
-        manager,
-        approvalId: record.id,
-        nowMs: record.createdAtMs,
-      };
-      const reply = buildDelegatedApprovalPendingReply(replyParams);
-      expect(reply).toContain("OpenClaw change pending approval: restart the Gateway.");
-      expect(reply).toContain("No change has been made.");
-      expect(reply).toContain("Expires in 1m.");
-      expect(reply).not.toContain("Review:");
-
-      replyParams.cfg.gateway.controlUi.enabled = true;
-      expect(buildDelegatedApprovalPendingReply(replyParams)).toContain(
-        "Review: https://control.example.com/approve/system-agent%3Adisabled-ui.",
-      );
-    } finally {
-      manager.expire(record.id);
-      await decisionPromise;
-    }
   });
 });

--- a/src/gateway/server-methods/system-agent-chat-turn.ts
+++ b/src/gateway/server-methods/system-agent-chat-turn.ts
@@ -2,13 +2,9 @@ import type {
   SystemAgentChatParams,
   SystemAgentChatResult,
 } from "../../../packages/gateway-protocol/src/index.js";
-import { resolveGatewayPublicOrigin } from "../../config/gateway-public-origin.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { formatExecApprovalExpiresIn } from "../../infra/exec-approval-reply.js";
-import type { SystemAgentApprovalRequestPayload } from "../../infra/system-agent-approvals.js";
 import type { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
-import { normalizeControlUiBasePath } from "../control-ui-shared.js";
-import type { ExecApprovalManager } from "../exec-approval-manager.js";
+import { appendTranscriptTurn } from "../../system-agent/transcript-store.js";
+import type { GatewaySystemAgentSession } from "./shared-types.js";
 
 type SystemAgentChatReply = Awaited<ReturnType<SystemAgentChatEngine["handle"]>>;
 type SystemAgentChatEngineInput = Pick<
@@ -98,7 +94,6 @@ export async function runSystemAgentChatInput(params: {
 export function buildSystemAgentChatResult(params: {
   sessionId: string;
   reply: SystemAgentChatReply;
-  proposalId?: string;
 }): SystemAgentChatResult {
   const action =
     params.reply.action === "open-tui"
@@ -126,29 +121,16 @@ export function buildSystemAgentChatResult(params: {
     ...(params.reply.wizardInputPending === true ? { wizardInputPending: true } : {}),
     ...(params.reply.question ? { question: params.reply.question } : {}),
     ...(params.reply.step ? { step: params.reply.step } : {}),
-    ...(params.proposalId ? { needsApproval: true, proposalId: params.proposalId } : {}),
   };
 }
 
-export function buildDelegatedApprovalPendingReply(params: {
-  cfg: OpenClawConfig;
-  manager: ExecApprovalManager<SystemAgentApprovalRequestPayload>;
-  approvalId: string;
-  nowMs?: number;
-}): string {
-  const snapshot = params.manager.getSnapshot(params.approvalId);
-  if (!snapshot) {
-    throw new Error("system-agent approval snapshot unavailable after registration");
+export function persistSystemAgentEngineHistory(
+  engine: GatewaySystemAgentSession["engine"],
+  startIndex: number,
+): void {
+  const at = Date.now();
+  for (const turn of engine.historySince(startIndex)) {
+    // Engine history has already masked sensitive user input.
+    appendTranscriptTurn({ ...turn, at });
   }
-  const origin = resolveGatewayPublicOrigin(params.cfg);
-  const reviewUrl =
-    origin && params.cfg.gateway?.controlUi?.enabled !== false
-      ? `${origin}${normalizeControlUiBasePath(params.cfg.gateway?.controlUi?.basePath)}/approve/${encodeURIComponent(params.approvalId)}`
-      : undefined;
-  return [
-    `OpenClaw change pending approval: ${snapshot.request.description}.`,
-    ...(reviewUrl ? [`Review: ${reviewUrl}.`] : []),
-    "No change has been made.",
-    `Expires in ${formatExecApprovalExpiresIn(snapshot.expiresAtMs, params.nowMs ?? Date.now())}.`,
-  ].join(" ");
 }

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -254,7 +254,11 @@ describe("openclaw.chat session ownership", () => {
   it("preserves the live session and pending approval when reset persistence fails", async () => {
     const engine = makeEngine();
     const session = seededSession({ engine });
-    session.pendingApproval = { id: "approval-1", proposalHash: "proposal-1" };
+    session.pendingApproval = {
+      id: "approval-1",
+      proposalHash: "proposal-1",
+      completion: Promise.resolve({ text: "Denied", action: "none" }),
+    };
     const sessions = new Map<string, SystemAgentChatSession>([["owned-session", session]]);
     const expire = vi.fn();
     const context = {
@@ -274,6 +278,7 @@ describe("openclaw.chat session ownership", () => {
     expect(session.pendingApproval).toEqual({
       id: "approval-1",
       proposalHash: "proposal-1",
+      completion: expect.any(Promise),
     });
     expect(expire).not.toHaveBeenCalled();
     expect(engine.dispose).not.toHaveBeenCalled();

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -938,7 +938,7 @@ describe("openclaw.chat", () => {
     } as unknown as GatewayRequestContext;
 
     const requestResponses = makeRespond();
-    await withGatewayToolCallerIdentity(
+    const pendingChat = withGatewayToolCallerIdentity(
       {
         agentId: "main",
         sessionKey: "agent:main:main",
@@ -967,17 +967,14 @@ describe("openclaw.chat", () => {
           extraHandlers: { "openclaw.chat": systemAgentHandlers["openclaw.chat"]! },
         }),
     );
-    const first = expectDefined(requestResponses.calls[0], "delegated Gateway response invariant");
-    expect(getActiveGatewayRootWorkCount()).toBe(0);
-    const proposalId = (first.payload as { proposalId?: string }).proposalId;
-
-    expect(first.payload).toMatchObject({
-      reply:
-        "OpenClaw change pending approval: restart the Gateway. No change has been made. Expires in 10m.",
-      needsApproval: true,
-      proposalId: expect.stringMatching(/^system-agent:/),
-    });
-    expect(proposalId).toBeTruthy();
+    await vi.waitFor(() => expect(manager.listPendingRecords()).toHaveLength(1));
+    expect(requestResponses.calls).toHaveLength(0);
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+    expect(systemAgentLane()).toMatchObject({ activeCount: 0, queuedCount: 0 });
+    const proposalId = expectDefined(
+      manager.listPendingRecords()[0],
+      "pending restart approval",
+    ).id;
     expect(manager.getSnapshot(proposalId!)).toMatchObject({
       request: { proposalHash, agentId: "main", sessionKey: "agent:main:main" },
     });
@@ -991,7 +988,7 @@ describe("openclaw.chat", () => {
     expect(handle).toHaveBeenNthCalledWith(1, "Restart Gateway.");
 
     // The follow-up chat rides the same live run authority the delegate tool carries.
-    await withGatewayToolCallerIdentity(
+    const sameOwnerChat = withGatewayToolCallerIdentity(
       { agentId: "main", sessionKey: "agent:main:main", operationalRunInstance },
       () =>
         callChat(context, {
@@ -1013,6 +1010,7 @@ describe("openclaw.chat", () => {
       "allow-once",
       proposalHash,
       expect.any(Function),
+      undefined,
     );
     expect(runGatewayRestart).toHaveBeenCalledOnce();
     await expect(resolveOperatorApproval.mock.results[0]?.value).resolves.toMatchObject({
@@ -1022,6 +1020,15 @@ describe("openclaw.chat", () => {
     expect(readLastSystemAgentAuditEntry()).toMatchObject({
       operation: "gateway.restart",
       summary: "Scheduled Gateway restart",
+    });
+    await pendingChat;
+    const sameOwnerResult = await sameOwnerChat;
+    expect(requestResponses.calls).toHaveLength(1);
+    expect(requestResponses.calls[0]?.payload).toMatchObject({
+      reply: expect.stringContaining("[openclaw] done: gateway.restart"),
+    });
+    expect(sameOwnerResult.payload).toMatchObject({
+      reply: expect.stringContaining("[openclaw] done: gateway.restart"),
     });
     expect(getActiveGatewayRootWorkCount()).toBe(0);
   });

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -27,11 +27,7 @@ import {
 import { isSystemAgentInferenceUnavailableError } from "../../system-agent/inference-error.js";
 import { buildNewAgentWelcome } from "../../system-agent/new-agent-welcome.js";
 import { buildOnboardingWelcome } from "../../system-agent/onboarding-welcome.js";
-import {
-  appendTranscriptReset,
-  appendTranscriptTurn,
-  readTranscriptTail,
-} from "../../system-agent/transcript-store.js";
+import { appendTranscriptReset, readTranscriptTail } from "../../system-agent/transcript-store.js";
 import { resolveUserPath } from "../../utils.js";
 import { WizardSession } from "../../wizard/session.js";
 import { listVisiblePendingApprovalRequests } from "./approval-shared.js";
@@ -46,16 +42,13 @@ import {
   SetupAdmissionBusyError,
 } from "./setup-admission.js";
 import type { GatewaySystemAgentSession as SystemAgentChatSession } from "./shared-types.js";
-import {
-  getSystemAgentSessionQueue,
-  prepareDelegatedSystemAgentApproval,
-} from "./system-agent-approval.js";
+import { prepareDelegatedSystemAgentApproval } from "./system-agent-approval.js";
 import { sanitizeSystemAgentChatParams } from "./system-agent-chat-params.js";
 import {
-  buildDelegatedApprovalPendingReply,
   buildSystemAgentChatResult,
   buildSystemAgentRejoinResult,
   getSystemAgentChatInputError,
+  persistSystemAgentEngineHistory,
   runSystemAgentChatInput,
 } from "./system-agent-chat-turn.js";
 import {
@@ -120,15 +113,6 @@ async function evictOldestSession(
     }
     await oldest?.engine.dispose();
     sessions.delete(oldestKey);
-  }
-}
-
-function persistEngineHistory(engine: SystemAgentChatSession["engine"], startIndex: number): void {
-  const at = Date.now();
-  for (const turn of engine.historySince(startIndex)) {
-    // Engine history is authoritative here: sensitive user text has already
-    // been replaced by the mask marker before it crosses this boundary.
-    appendTranscriptTurn({ ...turn, at });
   }
 }
 
@@ -387,288 +371,276 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, inputError));
       return;
     }
-    await runSystemAgentGatewayTask(async () => {
+    const pending = await runSystemAgentGatewayTask(async () => {
       const sessions = context.systemAgentSessions;
       const sessionId = params.sessionId;
-      // Initialization, resets, and turns share one per-session queue. Without
-      // it, concurrent first messages can create competing engines and lose
-      // conversation state when the later initializer replaces the first.
-      await getSystemAgentSessionQueue(sessions).enqueue(sessionId, async () => {
-        const ownerKey = resolveSystemAgentSessionOwnerKey({
-          delegation: params.delegation,
-          client,
+      // Initialization, resets, turns, and approval application share this task owner.
+      const ownerKey = resolveSystemAgentSessionOwnerKey({
+        delegation: params.delegation,
+        client,
+      });
+      if (!ownerKey) {
+        if (isGatewayClientProfilePending(client)) {
+          respond(false, undefined, authenticatedProfileUnavailableError());
+          return undefined;
+        }
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "OpenClaw caller identity unavailable."),
+        );
+        return undefined;
+      }
+      const boundSession = sessions.get(sessionId);
+      if (boundSession && boundSession.ownerKey !== ownerKey) {
+        // Structured invalidation details let clients with a persisted id mint a
+        // fresh one instead of retry-looping against the foreign live session.
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "OpenClaw session belongs to another caller.", {
+            details: buildSystemAgentSessionInvalidatedErrorDetails(),
+          }),
+        );
+        return undefined;
+      }
+      if (params.reset) {
+        const existing = sessions.get(sessionId);
+        // Persist the reset first; a failed write must leave the live session intact.
+        appendTranscriptReset();
+        sessions.delete(sessionId);
+        if (existing?.pendingApproval) {
+          context.systemAgentApprovalManager?.expire(existing.pendingApproval.id, "session-reset");
+        }
+        await existing?.engine.dispose();
+      }
+      let session = sessions.get(sessionId);
+      if ((params.wizardAnswer !== undefined || params.wizardCancel !== undefined) && !session) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            params.wizardCancel !== undefined
+              ? "No active OpenClaw chat session is awaiting that wizard cancel."
+              : "No active OpenClaw chat session is awaiting that wizard answer.",
+            { details: buildSystemAgentSessionInvalidatedErrorDetails() },
+          ),
+        );
+        return undefined;
+      }
+      let greetingAuditSequence: number | undefined;
+      const welcomeOnly =
+        params.wizardAnswer === undefined &&
+        params.wizardCancel === undefined &&
+        (params.message === undefined || !params.message.trim());
+      if (!session) {
+        const { verifySystemAgentInferenceWithFallback } =
+          await import("../../system-agent/inference-fallback.js");
+        const inference = await verifySystemAgentInferenceWithFallback({
+          ...(params.delegation ? { requestingAgentId: params.delegation.agentId } : {}),
+          runtime: defaultRuntime,
         });
-        if (!ownerKey) {
-          if (isGatewayClientProfilePending(client)) {
-            respond(false, undefined, authenticatedProfileUnavailableError());
-            return;
-          }
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, "OpenClaw caller identity unavailable."),
-          );
-          return;
-        }
-        const boundSession = sessions.get(sessionId);
-        if (boundSession && boundSession.ownerKey !== ownerKey) {
-          // Structured invalidation details let clients with a persisted id mint a
-          // fresh one instead of retry-looping against the foreign live session.
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.INVALID_REQUEST, "OpenClaw session belongs to another caller.", {
-              details: buildSystemAgentSessionInvalidatedErrorDetails(),
-            }),
-          );
-          return;
-        }
-        if (params.reset) {
-          const existing = sessions.get(sessionId);
-          // Persist the reset first; a failed write must leave the live session intact.
-          appendTranscriptReset();
-          sessions.delete(sessionId);
-          if (existing?.pendingApproval) {
-            context.systemAgentApprovalManager?.expire(
-              existing.pendingApproval.id,
-              "session-reset",
-            );
-          }
-          await existing?.engine.dispose();
-        }
-        let session = sessions.get(sessionId);
-        if ((params.wizardAnswer !== undefined || params.wizardCancel !== undefined) && !session) {
+        if (!inference.ok) {
           respond(
             false,
             undefined,
             errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              params.wizardCancel !== undefined
-                ? "No active OpenClaw chat session is awaiting that wizard cancel."
-                : "No active OpenClaw chat session is awaiting that wizard answer.",
-              { details: buildSystemAgentSessionInvalidatedErrorDetails() },
+              ErrorCodes.UNAVAILABLE,
+              `OpenClaw requires working inference: ${inference.error}`,
+              {
+                details: buildSystemAgentInferenceUnavailableErrorDetails(),
+              },
             ),
           );
-          return;
+          return undefined;
         }
-        let greetingAuditSequence: number | undefined;
-        const welcomeOnly =
-          params.wizardAnswer === undefined &&
-          params.wizardCancel === undefined &&
-          (params.message === undefined || !params.message.trim());
-        if (!session) {
-          const { verifySystemAgentInferenceWithFallback } =
-            await import("../../system-agent/inference-fallback.js");
-          const inference = await verifySystemAgentInferenceWithFallback({
-            ...(params.delegation ? { requestingAgentId: params.delegation.agentId } : {}),
-            runtime: defaultRuntime,
-          });
-          if (!inference.ok) {
-            respond(
-              false,
-              undefined,
-              errorShape(
-                ErrorCodes.UNAVAILABLE,
-                `OpenClaw requires working inference: ${inference.error}`,
-                {
-                  details: buildSystemAgentInferenceUnavailableErrorDetails(),
-                },
-              ),
-            );
-            return;
-          }
-          // The gateway surface must never install/restart its own daemon; the
-          // engine's setup path honors this via surface: "gateway".
-          const engine = new SystemAgentChatEngine({
-            surface: "gateway",
-            verifiedInference: inference.binding,
-            operatorApprovalOnly: params.delegation !== undefined,
-            ...(params.delegation?.agentId ? { requesterAgentId: params.delegation.agentId } : {}),
-          });
-          // `reset: true` keeps the durable logbook but deliberately starts
-          // model context clean; only ordinary fresh sessions receive its tail.
-          if (!params.reset) {
-            engine.seedHistory(
-              readTranscriptTail(SYSTEM_AGENT_SEED_HISTORY_LIMIT, { afterLastReset: true }).map(
-                ({ role, text }) => ({ role, text }),
-              ),
-            );
-          }
-          const welcomeHistoryStart = engine.historyLength();
-          let persistWelcome = !welcomeOnly;
-          let welcome: string;
-          let welcomeQuestion: SystemAgentChatQuestion | undefined;
-          try {
-            if (params.welcomeVariant === "onboarding") {
-              const onboardingWelcome = await buildOnboardingWelcome({ engine });
-              welcome = onboardingWelcome.text;
-              welcomeQuestion = onboardingWelcome.question;
-            } else if (params.welcomeVariant === "new-agent") {
-              welcome = buildNewAgentWelcome({ engine });
-            } else {
-              const overview = await engine.loadOverview();
-              const facts = loadSystemAgentGreetingFacts();
-              greetingAuditSequence = facts.auditSequence;
-              persistWelcome ||= facts.recentExternalEdit;
-              welcome = (
-                await resolveSystemAgentGreeting({
-                  overview,
-                  facts,
-                  planner: (plannerParams) => engine.planGreeting(plannerParams),
-                  allowInference: welcomeOnly,
-                })
-              ).text;
-              welcomeQuestion = buildSystemAgentGreetingQuestion(overview, facts);
-              engine.noteAssistantMessage(welcome);
-            }
-          } catch (error) {
-            await engine.dispose().catch(() => undefined);
-            if (!isSystemAgentInferenceUnavailableError(error)) {
-              throw error;
-            }
-            respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, error.message));
-            return;
-          }
-          // Passive welcomes are ephemeral; an external-edit alert must survive
-          // before delivery acknowledges the audit cursor that would hide it.
-          if (persistWelcome) {
-            persistEngineHistory(engine, welcomeHistoryStart);
-          }
-          await evictOldestSession(sessions, context);
-          session = {
-            engine,
-            welcome,
-            ...(welcomeQuestion ? { welcomeQuestion } : {}),
-            ...(greetingAuditSequence !== undefined
-              ? { welcomeAuditSequence: greetingAuditSequence }
-              : {}),
-            lastUsedAt: Date.now(),
-            ownerKey,
-          };
-          sessions.set(sessionId, session);
-          if (welcomeOnly) {
-            respond(
-              true,
-              {
-                sessionId,
-                reply: session.welcome,
-                action: "none",
-                ...(session.welcomeQuestion ? { question: session.welcomeQuestion } : {}),
-              },
-              undefined,
-            );
-            acknowledgeDeliveredSystemAgentWelcome(session);
-            return;
-          }
-        }
-        session.lastUsedAt = Date.now();
-        // Inline check (not `welcomeOnly`) so TS narrows params.message below.
-        if (
-          params.wizardAnswer === undefined &&
-          params.wizardCancel === undefined &&
-          (params.message === undefined || !params.message.trim())
-        ) {
-          respond(
-            true,
-            buildSystemAgentRejoinResult({
-              sessionId,
-              welcome: session.welcome,
-              ...(session.welcomeQuestion ? { welcomeQuestion: session.welcomeQuestion } : {}),
-              engine: session.engine,
-            }),
-            undefined,
+        // The gateway surface must never install/restart its own daemon; the
+        // engine's setup path honors this via surface: "gateway".
+        const engine = new SystemAgentChatEngine({
+          surface: "gateway",
+          verifiedInference: inference.binding,
+          operatorApprovalOnly: params.delegation !== undefined,
+          ...(params.delegation?.agentId ? { requesterAgentId: params.delegation.agentId } : {}),
+        });
+        // `reset: true` keeps the durable logbook but deliberately starts
+        // model context clean; only ordinary fresh sessions receive its tail.
+        if (!params.reset) {
+          engine.seedHistory(
+            readTranscriptTail(SYSTEM_AGENT_SEED_HISTORY_LIMIT, { afterLastReset: true }).map(
+              ({ role, text }) => ({ role, text }),
+            ),
           );
-          acknowledgeDeliveredSystemAgentWelcome(session);
-          return;
         }
-        const historyStart = session.engine.historyLength();
-        let reply: Awaited<ReturnType<SystemAgentChatEngine["handle"]>>;
-        let resolveProposal:
-          | Awaited<ReturnType<typeof prepareDelegatedSystemAgentApproval>>
-          | undefined;
+        const welcomeHistoryStart = engine.historyLength();
+        let persistWelcome = !welcomeOnly;
+        let welcome: string;
+        let welcomeQuestion: SystemAgentChatQuestion | undefined;
         try {
-          if (params.delegation) {
-            resolveProposal = await prepareDelegatedSystemAgentApproval({
-              context,
-              sessions,
-              session,
-              sessionId,
-              delegation: params.delegation,
-            });
+          if (params.welcomeVariant === "onboarding") {
+            const onboardingWelcome = await buildOnboardingWelcome({ engine });
+            welcome = onboardingWelcome.text;
+            welcomeQuestion = onboardingWelcome.question;
+          } else if (params.welcomeVariant === "new-agent") {
+            welcome = buildNewAgentWelcome({ engine });
+          } else {
+            const overview = await engine.loadOverview();
+            const facts = loadSystemAgentGreetingFacts();
+            greetingAuditSequence = facts.auditSequence;
+            persistWelcome ||= facts.recentExternalEdit;
+            welcome = (
+              await resolveSystemAgentGreeting({
+                overview,
+                facts,
+                planner: (plannerParams) => engine.planGreeting(plannerParams),
+                allowInference: welcomeOnly,
+              })
+            ).text;
+            welcomeQuestion = buildSystemAgentGreetingQuestion(overview, facts);
+            engine.noteAssistantMessage(welcome);
           }
-          const turnReply = await runSystemAgentChatInput({
-            engine: session.engine,
-            input: params,
-          });
-          if (!turnReply) {
-            respond(
-              false,
-              undefined,
-              errorShape(ErrorCodes.INVALID_REQUEST, "OpenClaw chat input is missing."),
-            );
-            return;
-          }
-          reply = turnReply;
         } catch (error) {
-          persistEngineHistory(session.engine, historyStart);
-          if (error instanceof SystemAgentWizardAnswerError) {
-            respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, error.message));
-            return;
-          }
+          await engine.dispose().catch(() => undefined);
           if (!isSystemAgentInferenceUnavailableError(error)) {
             throw error;
           }
-          // A failed inference turn invalidates this conversation. Remove the
-          // exact engine before cleanup so a retry must pass the live gate and
-          // cannot resume partial proposal or CLI-session state.
-          // Initialization failures stay unmarked because no live session existed.
-          if (sessions.get(sessionId)?.engine === session.engine) {
-            sessions.delete(sessionId);
-          }
-          try {
-            await session.engine.dispose();
-          } catch {
-            // The inference error is authoritative; cleanup stays best-effort.
-          }
+          respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, error.message));
+          return undefined;
+        }
+        // Passive welcomes are ephemeral; an external-edit alert must survive
+        // before delivery acknowledges the audit cursor that would hide it.
+        if (persistWelcome) {
+          persistSystemAgentEngineHistory(engine, welcomeHistoryStart);
+        }
+        await evictOldestSession(sessions, context);
+        session = {
+          engine,
+          welcome,
+          ...(welcomeQuestion ? { welcomeQuestion } : {}),
+          ...(greetingAuditSequence !== undefined
+            ? { welcomeAuditSequence: greetingAuditSequence }
+            : {}),
+          lastUsedAt: Date.now(),
+          ownerKey,
+        };
+        sessions.set(sessionId, session);
+        if (welcomeOnly) {
           respond(
-            false,
+            true,
+            {
+              sessionId,
+              reply: session.welcome,
+              action: "none",
+              ...(session.welcomeQuestion ? { question: session.welcomeQuestion } : {}),
+            },
             undefined,
-            errorShape(ErrorCodes.UNAVAILABLE, error.message, {
-              details: buildSystemAgentSessionInvalidatedErrorDetails(),
-            }),
           );
-          return;
+          acknowledgeDeliveredSystemAgentWelcome(session);
+          return undefined;
         }
-        let proposalId: string | undefined;
-        if (resolveProposal) {
-          const proposal = session.engine.getPendingOperatorProposal();
-          if (proposal) {
-            const resolution = await resolveProposal(proposal);
-            if (resolution.kind === "completed") {
-              reply = resolution.reply;
-            } else {
-              proposalId = resolution.id;
-            }
-          }
-        }
-        persistEngineHistory(session.engine, historyStart);
-        const pendingReply = proposalId
-          ? buildDelegatedApprovalPendingReply({
-              cfg: context.getRuntimeConfig?.() ?? {},
-              manager: context.systemAgentApprovalManager!,
-              approvalId: proposalId,
-            })
-          : undefined;
+      }
+      session.lastUsedAt = Date.now();
+      // Inline check (not `welcomeOnly`) so TS narrows params.message below.
+      if (
+        params.wizardAnswer === undefined &&
+        params.wizardCancel === undefined &&
+        (params.message === undefined || !params.message.trim())
+      ) {
         respond(
           true,
-          buildSystemAgentChatResult({
+          buildSystemAgentRejoinResult({
             sessionId,
-            reply: pendingReply ? { ...reply, text: pendingReply } : reply,
-            proposalId,
+            welcome: session.welcome,
+            ...(session.welcomeQuestion ? { welcomeQuestion: session.welcomeQuestion } : {}),
+            engine: session.engine,
           }),
           undefined,
         );
-      });
+        acknowledgeDeliveredSystemAgentWelcome(session);
+        return undefined;
+      }
+      const historyStart = session.engine.historyLength();
+      let reply: Awaited<ReturnType<SystemAgentChatEngine["handle"]>>;
+      let resolveProposal:
+        | Awaited<ReturnType<typeof prepareDelegatedSystemAgentApproval>>
+        | undefined;
+      try {
+        if (params.delegation) {
+          resolveProposal = await prepareDelegatedSystemAgentApproval({
+            context,
+            sessions,
+            session,
+            sessionId,
+            delegation: params.delegation,
+          });
+        }
+        const turnReply = await runSystemAgentChatInput({
+          engine: session.engine,
+          input: params,
+        });
+        if (!turnReply) {
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, "OpenClaw chat input is missing."),
+          );
+          return undefined;
+        }
+        reply = turnReply;
+      } catch (error) {
+        persistSystemAgentEngineHistory(session.engine, historyStart);
+        if (error instanceof SystemAgentWizardAnswerError) {
+          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, error.message));
+          return undefined;
+        }
+        if (!isSystemAgentInferenceUnavailableError(error)) {
+          throw error;
+        }
+        // A failed inference turn invalidates this conversation. Remove the
+        // exact engine before cleanup so a retry must pass the live gate and
+        // cannot resume partial proposal or CLI-session state.
+        // Initialization failures stay unmarked because no live session existed.
+        if (sessions.get(sessionId)?.engine === session.engine) {
+          sessions.delete(sessionId);
+        }
+        try {
+          await session.engine.dispose();
+        } catch {
+          // The inference error is authoritative; cleanup stays best-effort.
+        }
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, error.message, {
+            details: buildSystemAgentSessionInvalidatedErrorDetails(),
+          }),
+        );
+        return undefined;
+      }
+      let pendingApproval: SystemAgentChatSession["pendingApproval"];
+      if (resolveProposal) {
+        const proposal = session.engine.getPendingOperatorProposal();
+        if (proposal) {
+          const resolution = await resolveProposal(proposal);
+          if (resolution.kind === "completed") {
+            reply = resolution.reply;
+          } else {
+            pendingApproval = resolution;
+          }
+        }
+      }
+      persistSystemAgentEngineHistory(session.engine, historyStart);
+      if (pendingApproval) {
+        return pendingApproval;
+      }
+      respond(true, buildSystemAgentChatResult({ sessionId, reply }), undefined);
+      return undefined;
     });
+    // Human waiting must retain the requesting tool, but release the task queue:
+    // the approval owner reenters it to apply the exact proposal.
+    if (pending) {
+      const reply = await pending.completion;
+      respond(true, buildSystemAgentChatResult({ sessionId: params.sessionId, reply }), undefined);
+    }
   },
 };

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -120,6 +120,7 @@ export class SystemAgentChatEngine {
     decision: "allow-once" | "allow-always" | "deny" | null,
     proposalHash: string,
     beforePersistentApply?: () => void,
+    terminalStatus?: "expired" | "cancelled",
   ): Promise<SystemAgentChatReply | null> {
     const turn = this.turnQueue.then(async () => {
       const reply = await this.router.resolveOperatorApproval(
@@ -127,6 +128,12 @@ export class SystemAgentChatEngine {
         proposalHash,
         beforePersistentApply,
       );
+      if (reply && terminalStatus && !reply.applied) {
+        reply.text = `OpenClaw change ${terminalStatus}. No change. Retry the request if it is still needed.`;
+      }
+      if (reply && decision === "allow-once" && !reply.applied) {
+        reply.text += " Check the current settings and OpenClaw status before retrying.";
+      }
       if (reply?.text) {
         this.history.push({ role: "assistant", text: reply.text });
       }


### PR DESCRIPTION
Related: #134557 — delegated system-agent approvals can be consumed without applying the requested configuration change.

## What Problem This Solves

Fixes an issue where users approving a delegated OpenClaw configuration change in Guarded mode could lose the approval card when the requesting turn finished, while the final answer incorrectly said the proposal was still pending for ten minutes. Even a quick Allow could record the human decision without applying the change.

Fresh authenticated baseline proof captured the full resolution payload: `deny`, `terminalStatus: cancelled`, durable reason `run-aborted`. A separate actual Allow recorded `allow-once`, followed by a false-pending final and `applicationStatus: not-applied`. This behavior already exists in baseline `04bad80b953d493882d5ecf8b095275eaf5826fd`; this PR does not attribute it to #136036, the Full Access delegation repair.

## Why This Change Was Made

The existing pending-proposal owner now carries completion, and the requesting tool waits for the actual application or terminal non-application result. Human waiting happens **outside** system-agent serialization so the single decision executor can reenter that queue without deadlocking. Final history and failure/cancellation/expiry replies come from that owner; the redundant per-session queue and immediate pending-response plumbing are removed.

Long real waits also exposed a native Code Mode ownership mismatch: a yielded cell could let the model finish its turn while the nested delegation call remained pending. The delegate now uses the existing direct-only tool surface, preserving one direct model call through the human decision. Other tools retain Code Mode, and ordinary tool policy, Codex exclusions, and turn allowlists still apply. Direct placement grants no ring-zero authority.

**Authorization is unchanged:** the exact run, tool, worker claim, Gateway, and session must remain live, including after awaited work and immediately before persistent effects. The caller now carries its individual AbortSignal privately instead of relying on an outer Promise race. A closed run cannot approve or revive the proposal. The approval still expires after 600 seconds; the dynamic tool uses the existing human-interaction execution budget and transport grace, not a new configuration option.

## User Impact

Operators can take time to review a delegated change, click Allow or Deny, and receive the actual outcome. Stop cancels the proposal. Expiry produces a truthful final response instead of a disappearing card followed by a stale pending claim. Late Allow preserves the terminal decision and performs no write.

No new configuration keys, SQLite changes, protocol version, dependency changes, or compatibility fallback. Documentation is updated for [OpenClaw delegation](https://docs.openclaw.ai/cli/openclaw), [permission modes](https://docs.openclaw.ai/gateway/permission-modes), and the [Codex harness reference](https://docs.openclaw.ai/plugins/codex-harness-reference).

## Evidence

### Real authenticated browser proof

Real isolated Gateway and Chromium, stock Codex 0.152.1, public `openai/gpt-5.6-luna`, Guarded sessions. No provider mock, shortened expiry, clock manipulation, approval-manager injection, or operator Gateway/state access.

| Scenario | Observed result |
| --- | --- |
| Baseline, no human decision | Approval cancelled about 1.8 seconds after registration; final falsely said pending for ten minutes. |
| Baseline, actual Allow | Allow at +193 ms; false-pending final at +2,249 ms; not-applied at +15,338 ms; saved/live configuration unchanged. |
| Fixed, Allow after 95 seconds | Card remained usable; Allow at +95,296 ms, application at +119,480 ms, accurate final at +120,842 ms. Saved/live `logging.level` changed `debug` → `info`. |
| Fixed, Deny | Actual GUI Deny; no write; final “Denied. No change.” |
| Fixed, Stop | Actual GUI Stop / `chat.abort`; durable cancelled record, aborted chat, visible “Interrupted”; no write. |
| Fixed, natural expiry | Card still visible at +300,157 and +590,103 ms. Expired at +600,001 ms; accurate final at +600,675 ms: “The request expired. No configuration change was made.” |

Deny and Stop completed while another session continued its full expiry wait. Late Allow after Deny, Stop, and expiry returned `applied: false` with the exact unchanged terminal snapshot; saved/live configuration remained unchanged. This is the existing terminal replay contract, not an exception-based API.

Before/after screenshots and recordings attached below were inspected and contain synthetic data only. Full resolution payloads, config readbacks, source hashes, build identity, and verification logs are retained locally. The live proof build is `2026.8.1-2d23e7276db1-2026-09-03T03-33-24.827Z`; source/build hashes were unchanged throughout. The approval-owner modules are unchanged on the refreshed main baseline. Exact-head integration CI is tracked on this PR.

### Regression and contract proof

- Pre-fix owner regressions failed on early completion, missing terminal history, and stale pending results; the per-tool cancellation table failed 8/8 before signal propagation was repaired.
- Direct-only regression failed eight delegate metadata cases and both real-descriptor Codex namespace cases before the marker was added. Post-fix: 11 delegate tests, 114 Codex build tests, and 11 Code Mode/Pi/headless/start/resume sibling contracts passed.
- Owner/sibling validation included a 272-test run and a later 71-test split-owner run. These overlap; counts are not additive.
- Core, core-test, plugin, and plugin-test typechecks; scoped formatting/lint/architecture checks; max-lines ratchet; `pnpm build qaRuntime`; and `git diff --check` passed. Documentation link audit: 7,290 links, zero broken.
- Fresh independent Codex autoreview completed scoped-clean at the configured P0-only threshold before commit; exact-head CI and native landing guards remain required.

Focused owner command:

```bash
node scripts/run-vitest.mjs src/agents/tools/openclaw-delegate-tool.test.ts src/gateway/server-methods/system-agent-approval.test.ts src/gateway/server-methods/system-agent-approval-authority.test.ts src/gateway/server-methods/system-agent.test.ts
```

Native dependency source was inspected personally at Codex `rust-v0.152.1` / `5adb68a49933ae446bf11935662c83dba55a0804`: [direct-only exposure](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/tools/src/tool_executor.rs#L68-L96), [namespace override](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/core/src/tools/spec_plan.rs#L496-L525), dynamic handler awaiting lines 139–151/174–250, and active-turn waiter cleanup. No custom Codex runtime or protocol is required.

### Scope and remaining distinctions

Production **+361/−356, net +5**; tests **+975/−679, net +296**, including moved authority coverage; docs **+29/−11, net +18**. Handler churn is largely dedentation after deleting duplicate serialization. Remaining production growth supplies the completion/ownership boundary and truthful terminal outcomes rather than a second execution path.

The baseline UI startup gzip guard failed by 143 bytes before any UI edits; the shared main repair #136817 has since merged. This PR changes no UI budget. The `ask_user` / `secrets` Code Mode exposure audit is a separate follow-up, not silently included here. The issue's distinct `agents.entries` deletion/whole-object examples have not been reproduced by this proof, so the mutation-specific follow-up on #134557 remains for separate verification.

### Exact-head integration proof

Refreshed all four authenticated real-browser flows on PR head `72c297aee646c33d300808981628679ae6526d24`, build `2026.8.1-72c297aee646-2026-09-03T05-13-22.910Z`, after integrating current main. Source/build hashes stayed unchanged throughout.

- **Allow after 95 seconds:** human decision at +95,201 ms, actual application at +108,128 ms, accurate final at +109,480 ms. Saved and live `logging.level` changed from `debug` to `info`.
- **Deny:** no write; final “Request denied. No change was made.”
- **Stop:** cancelled approval and aborted chat at +201 ms; visible “Interrupted”; no write.
- **Natural expiry:** approval stayed visible through the full wait, expired at +600,011 ms, and produced the truthful final at +601,516 ms: “The request expired before approval. No configuration change was made.”

Late Allow after Deny, Stop, and expiry returned `applied: false` with the exact unchanged terminal snapshot. Deny/Stop completed while the other session remained waiting. No model/provider mocks, clock shortcuts, or post-closure execution. Test Gateway/state and temporary credentials were cleaned up; the operator Gateway was untouched.

The exact-head conversation-only recordings appended last show Allow and natural expiry, in that order. They were cropped to exclude operator identity chrome, then inspected across the full duration and final frames; the approval controls, countdown, final response and permission posture remain visible.

[CI run 33717961345, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33717961345) completed successfully for the exact head; required `openclaw/ci-gate` is **SUCCESS**, with no failed or pending checks. Local integration: **239 tests passed** across three shards; `pnpm build qaRuntime` passed in 3m38.4s after the frozen-lockfile install. Fresh pre-commit Codex autoreview was scoped-clean at P0-only threshold, and `git range-diff` confirms the rebase preserved the reviewed patch.

Exact local test command:

```bash
node scripts/run-vitest.mjs src/agents/tools/openclaw-delegate-tool.test.ts src/gateway/server-methods/system-agent-approval.test.ts src/gateway/server-methods/system-agent-approval-authority.test.ts src/gateway/server-methods/system-agent.test.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/dynamic-tool-execution.test.ts
```

### ClawSweeper evidence-gap resolution

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/137017#issuecomment-5521307008) found no correctness or security defects and rated the patch/proof diamond. Its P1 pre-merge item was a verification-access gap in its DNS-disabled environment. I verified each missing item before proceeding:

- **Current main:** fetched `13799ec4f8380c14f7ce1836ce611291254bdda2` and reopened all seven affected production modules. Each is byte-identical to the reviewed pre-fix baseline at `c7f353d7274f130603d3af24f454218832025d66`; the repair is not already present on main.
- **Official Codex provenance:** a fresh `git ls-remote` against `https://github.com/openai/codex.git` returned tag object `3c6cfbab81e44218c729dc8c6b304cb760d1b8a1` for `rust-v0.152.1` and peeled commit `5adb68a49933ae446bf11935662c83dba55a0804`, exactly matching the locally inspected source. The direct-call, waiter-cleanup and DirectModelOnly contracts cited above are from that commit.
- **Published media:** downloaded all eight linked GitHub attachments successfully. Every SHA-256 matches the original inspected source media. I also decoded and inspected the remotely fetched exact-head expiry recording's final frame; it visibly reports expiry and no configuration change. The latest Allow recording SHA-256 is `b978384507c1a484ed4c33c2d049d0786d1599303c5bbd13ba417e619112c48f`; expiry is `f39ac722d38beaf4faa11f0dce814eb879f39d69861f5bf343a6e0398ce49a3e`.

This resolves the published evidence-access concern through maintainer verification; it does not claim the review worker had network access. No code, authorization policy, or gate was weakened. Head remains `72c297aee646c33d300808981628679ae6526d24`; exact-head CI, the required gate, independent review, and the four authenticated live flows remain green. No additional Rank-up moves or source findings were published.

![Before: closed run still claims approval is pending](https://github.com/user-attachments/assets/ba703ded-2681-4ba4-8ad5-af87a88bf4f8)

![After: approval stays usable during human review](https://github.com/user-attachments/assets/ef7d60be-4fa5-43a9-b31f-6fc2c48353c7)

![After: Allow applies the setting before the final answer](https://github.com/user-attachments/assets/f67be5f0-ac36-4d62-9307-9c6a1f5a8057)

![After: expiry is reported truthfully without a write](https://github.com/user-attachments/assets/80787662-5ca2-44b2-a6f6-f3d4cfc8a1e4)

https://github.com/user-attachments/assets/9768e2fe-e4a9-463c-97fb-cc1666d92017

https://github.com/user-attachments/assets/7416ba94-dacf-4e2f-8721-b6aed10e7a4a

https://github.com/user-attachments/assets/0ce5c4c6-4eb6-47ef-98ed-c1d8f610bda9

https://github.com/user-attachments/assets/5d3ed115-81fc-4b67-9089-5cfce8fe59f1