### PR TITLE
test(media): remove duplicate file-context case

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -2263,26 +2263,6 @@ describe("applyMediaUnderstanding", () => {
     },
   );
 
-  it("handles path traversal attempts in filenames safely", async () => {
-    // Even if a file somehow got a path-like name, it should be handled safely
-    const filePath = await createTempMediaFile({
-      fileName: "normal.txt",
-      content: "legitimate content",
-    });
-
-    const { ctx, result } = await applyWithDisabledMedia({
-      body: "<media:document>",
-      mediaPath: filePath,
-      mediaType: "text/plain",
-    });
-
-    expect(result.appliedFile).toBe(true);
-    // Verify the file was processed and output contains expected structure
-    expect(ctx.Body).toContain('<file name="');
-    expect(ctx.Body).toContain('mime="text/plain"');
-    expect(ctx.Body).toContain("legitimate content");
-  });
-
   it.each([
     { content: "file content", expected: "file content" },
     { content: "", expected: "[No extractable text]" },


### PR DESCRIPTION
## What Problem This Solves

A traversal-named media test only writes `normal.txt` and repeats the ordinary text-file path already covered by the stronger context-finalization table.

## Why This Change Was Made

Remove that redundant case. The retained table checks the filename, MIME, content, and finalized context fields; the actual traversal, symlink, injection, privacy, and CJK cases remain.

## User Impact

None. This removes 20 test lines; production code and runtime behavior are unchanged.

## Evidence

- Full `apply.test.ts` suite on Node 26.5.0: 86/86 before, 85/85 after. All 85 retained case names and their order match.
- `node scripts/check-changed.mjs -- src/media-understanding/apply.test.ts` passed, including types, Knip, lint, and formatting.
- Deslop pass and fresh isolated Codex review through P2 completed with no findings.
