### PR TITLE
refactor(cron): remove the core execution test proxy

### DIFF
--- a/src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts
+++ b/src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts
@@ -7,7 +7,7 @@ import {
   withCronServiceForTest,
 } from "./service.test-harness.js";
 import { createCronServiceState } from "./service/state.js";
-import { executeJobCore } from "./service/timer.test-support.js";
+import { executeJobCore } from "./service/timer-execution.js";
 import type { CronJob } from "./types.js";
 
 const noopLogger = createNoopLogger();

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -45,8 +45,9 @@ import { computeJobNextRunAtMs, recomputeNextRunsForMaintenance } from "./jobs-s
 import { stop } from "./ops-lifecycle.js";
 import { run as runManualCronJob } from "./ops-run.js";
 import { createCronServiceState as createBaseCronServiceState, type CronEvent } from "./state.js";
+import { executeJobCore } from "./timer-execution.js";
 import { applyJobResult, executeJobCoreWithTimeout, runMissedJobs } from "./timer.js";
-import { executeJobCore, onTimer } from "./timer.test-support.js";
+import { onTimer } from "./timer.test-support.js";
 
 const FAST_TIMEOUT_SECONDS = 1;
 const timerRegressionFixtures = setupCronRegressionFixtures({

--- a/src/cron/service/timer.test-support.ts
+++ b/src/cron/service/timer.test-support.ts
@@ -1,23 +1,7 @@
-import type { CronDeliveryTrace, CronJob, CronRunOutcome, CronRunTelemetry } from "../types.js";
 import type { CronServiceState } from "./state.js";
-import type { CronTriggerEvalOutcome } from "./timer.js";
 import "./timer.js";
 
-type ExecuteJobCoreResult = CronRunOutcome &
-  CronRunTelemetry & {
-    delivered?: boolean;
-    deliveryAttempted?: boolean;
-    deliveryError?: string;
-    delivery?: CronDeliveryTrace;
-    triggerEval?: CronTriggerEvalOutcome;
-  };
-
 type CronTimerTestApi = {
-  executeJobCore(
-    state: CronServiceState,
-    job: CronJob,
-    abortSignal?: AbortSignal,
-  ): Promise<ExecuteJobCoreResult>;
   onTimer(state: CronServiceState): Promise<void>;
 };
 
@@ -25,14 +9,6 @@ function getTestApi(): CronTimerTestApi {
   return (globalThis as Record<PropertyKey, unknown>)[
     Symbol.for("openclaw.cronTimerTestApi")
   ] as CronTimerTestApi;
-}
-
-export function executeJobCore(
-  state: CronServiceState,
-  job: CronJob,
-  abortSignal?: AbortSignal,
-): Promise<ExecuteJobCoreResult> {
-  return getTestApi().executeJobCore(state, job, abortSignal);
 }
 
 export function onTimer(state: CronServiceState): Promise<void> {

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -5,7 +5,7 @@ import { createDeferred } from "../../../test/helpers/promise.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "../../cron/service.test-harness.js";
 import { createCronServiceState as createCronServiceStateBase } from "../../cron/service/state.js";
-import { executeJobCore, onTimer } from "../../cron/service/timer.test-support.js";
+import { onTimer } from "../../cron/service/timer.test-support.js";
 import { loadCronStore } from "../../cron/store.js";
 import type { CronJob } from "../../cron/types.js";
 import { getActiveGatewayRootWorkCount } from "../../process/gateway-work-admission.js";
@@ -17,6 +17,7 @@ import { formatTaskStatusDetail } from "../../tasks/task-status.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { getSuspensionVisibleCronTaskRunCount } from "./active-run-cancellation.js";
 import { stop } from "./ops-lifecycle.js";
+import { executeJobCore } from "./timer-execution.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({
   prefix: "cron-service-timer-seam",

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,4 +1,3 @@
-import { executeJobCore } from "./timer-execution.js";
 import { onTimer } from "./timer-scheduler.js";
 
 export type { CronTriggerEvalOutcome } from "./timer-execution-timeout.js";
@@ -15,7 +14,6 @@ export { stopTimer } from "./timer-execution.js";
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.cronTimerTestApi")] = {
-    executeJobCore,
     onTimer,
   };
 }


### PR DESCRIPTION
## What problem does this solve?

`executeJobCore` already has a production owner, but three cron test suites still call it through a global test proxy. That keeps an unnecessary runtime import/object member and a second, reduced copy of its result type.

## Why this change?

Import the existing execution owner directly in those suites and delete its forwarding path. Keep the `onTimer` proxy and global publication: those tests still need the awaited scheduler error boundary. No new production export or replacement helper is added.

## User impact

Internal test cleanup only. Every test case, assertion and fixture body is preserved, including cancellation and teardown coverage. Production decreases by 2 lines, test support by 24, with 2 added test import lines: 24 fewer lines overall. No configuration, storage, protocol or SDK contract changes.

## Evidence

The same eight complete suites passed 131 tests before and after the change, covering the three migrated consumers, core tool policy and script wake behavior, database mocking, escaping scheduler errors, and native runner cleanup. All non-import statement bytes in the three modified test files are identical; retained `getTestApi` and `onTimer` functions are also unchanged. Formatting and `git diff --check` passed.

The initial normal baseline stopped before any tests because Vitest could not write a temporary module-cache file. A subsequent baseline added only native cache debug logging and passed; the candidate passed with the ordinary command. No manual application cache clearing, relocation, cache bypass, timeout change or dependency patch was used. The original cache deletion event was not observed, so this change makes no claim to repair that separate failure.

The full changed gate passed on the final source after a private workspace dependency installation repair. Its first attempt had stopped at missing UI package declarations because borrowed workspace dependency links still pointed outside the task checkout; those task-owned links were replaced through a frozen install, with source and lockfiles unchanged. The 131-test runs preceded that installation repair and are retained as their original proof. The independent Codex review found no actionable P0–P2 findings; it completed before the final gate and did not independently verify that gate result.
