### PR TITLE
fix(agents): keep cache-TTL pruning sticky and use Anthropic server-side clearing

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -36,7 +36,7 @@ extensions/anthropic/session-catalog-listing.ts	1
 extensions/anthropic/session-catalog-parsing.ts	7
 extensions/anthropic/session-catalog-registration.ts	3
 extensions/anthropic/session-catalog-runtime.ts	1
-extensions/anthropic/stream-wrappers.ts	6
+extensions/anthropic/stream-wrappers.ts	5
 extensions/baseten/models.ts	3
 extensions/beam/src/mirror.ts	3
 extensions/beam/src/types.ts	2
@@ -1831,7 +1831,7 @@ src/agents/embedded-agent-runner/thinking.ts	25
 src/agents/embedded-agent-runner/tool-call-argument-decoding.ts	5
 src/agents/embedded-agent-runner/tool-result-char-estimator.ts	9
 src/agents/embedded-agent-runner/tool-result-context-guard.ts	13
-src/agents/embedded-agent-runner/tool-result-truncation.ts	22
+src/agents/embedded-agent-runner/tool-result-truncation.ts	20
 src/agents/embedded-agent-runner/tool-schema-runtime.ts	1
 src/agents/embedded-agent-runner/transcript-rewrite.ts	2
 src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts	2

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -124,8 +124,9 @@ Pruning is off by default for non-Anthropic providers. To enable:
 }
 ```
 
-To stop new pruning, set `mode: "off"`. Existing client-side projections remain
-stable until compaction removes their results or the session is reset.
+To stop new pruning, set `mode: "off"`. Existing client-side projections keep
+replaying, including after a Gateway restart, until compaction removes their
+results or the session is reset.
 
 ## Pruning vs compaction
 

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -34,8 +34,10 @@ The request's provider, endpoint, and authentication determine where it runs.
 For provider `anthropic` with the `anthropic-messages` API, API-key authentication,
 and the default endpoint or `api.anthropic.com`, OpenClaw delegates pruning to
 Anthropic's [server-side tool-result clearing](https://platform.claude.com/docs/en/build-with-claude/context-editing).
-OpenClaw skips new client-side cache-TTL pruning, and the server clears old
-results before the model sees them. Full local history is retained. `ttl` does
+OpenClaw opens no new client-side pruning rounds, and the server clears old
+results before the model sees them. Projections made earlier in the same session
+(for example on a proxy route, or restored from the transcript marker) still
+replay unchanged. Full local history is retained. `ttl` does
 not gate this path.
 
 OpenClaw derives the request parameters without adding config options:

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -6,31 +6,83 @@ read_when:
   - You want to understand Anthropic prompt cache optimization
 ---
 
-Session pruning trims **old tool results** from the context before each LLM call. It reduces context bloat from accumulated tool outputs (exec results, file reads, search results) without rewriting normal conversation text.
+Session pruning trims **old tool results** from the model's context. It reduces context bloat from accumulated tool outputs (exec results, file reads, search results) without rewriting normal conversation text.
 
 <Info>
-Pruning is in-memory only -- it does not modify the on-disk session transcript. Your full history is always preserved.
+Your full history is preserved. Client-side pruning keeps a stable projected view
+in memory and records it in the hidden `openclaw.cache-ttl` transcript marker so
+the same view can be restored after a Gateway restart. Original tool-result
+entries are not rewritten.
 </Info>
 
 ## Why it matters
 
 Long sessions accumulate tool output that inflates the context window. This increases cost and can force [compaction](/concepts/compaction) sooner than necessary.
 
-Pruning is especially valuable for **Anthropic prompt caching**. After the cache TTL expires, the next request re-caches the full prompt. Pruning reduces the cache-write size, directly lowering cost.
+Pruning is especially valuable for **Anthropic prompt caching**. It reduces the
+tool content that must be cached and keeps later requests on the reduced prefix.
+Direct Anthropic API-key requests use server-side clearing; other eligible routes
+prune locally after the cache TTL expires.
 
 ## How it works
 
-Pruning runs in `cache-ttl` mode, gated on both a time check and a context-size check:
+Set `agents.defaults.contextPruning.mode` to `"cache-ttl"` to enable pruning.
+The request's provider, endpoint, and authentication determine where it runs.
 
-1. Wait for the cache TTL to expire (default 5 minutes when set manually; see [Smart defaults](#smart-defaults) for the Anthropic auto-default). Before the TTL elapses, pruning is skipped entirely to preserve prompt-cache reuse for nearby turns.
+### Direct Anthropic API-key requests
+
+For provider `anthropic` with the `anthropic-messages` API, API-key authentication,
+and the default endpoint or `api.anthropic.com`, OpenClaw delegates pruning to
+Anthropic's [server-side tool-result clearing](https://platform.claude.com/docs/en/build-with-claude/context-editing).
+OpenClaw skips new client-side cache-TTL pruning, and the server clears old
+results before the model sees them. Full local history is retained. `ttl` does
+not gate this path.
+
+OpenClaw derives the request parameters without adding config options:
+
+| Parameter           | Value                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| `trigger`           | Input tokens: `max(50000, floor(contextWindow * 0.3))`                                   |
+| `keep`              | The 3 most recent tool uses and their results                                            |
+| `clear_at_least`    | Input tokens: `max(12500, floor(contextWindow * 0.05))`                                  |
+| `exclude_tools`     | Names excluded by `tools.deny`, plus exposed tools outside `tools.allow` when configured |
+| `clear_tool_inputs` | `false`, preserving tool-call arguments                                                  |
+
+The request includes the `clear_tool_uses_20250919` edit and
+`context-management-2025-06-27` beta header. If server-side compaction is enabled,
+the clearing edit comes before the compaction edit. Explicit caller-provided
+`context_management` remains unchanged. Client-side soft-trim and `hardClear`
+settings do not change the server's clearing policy.
+
+Clearing invalidates the prompt cache from the first cleared result;
+`clear_at_least` prevents a clearing event that would remove too few tokens to
+justify the new cache write. When clearing occurs, OpenClaw logs this info line:
+
+```text
+[anthropic] server-side context edit: cleared N tool results (M input tokens)
+```
+
+### Client-side pruning
+
+Amazon Bedrock, Google, Microsoft Foundry, OAuth, proxies, Vertex, and other
+cache-TTL-eligible routes keep client-side pruning. New pruning rounds are gated
+on both a time check and a context-size check:
+
+1. Wait for the cache TTL to expire (default 5 minutes when set manually; see [Smart defaults](#smart-defaults) for the Anthropic auto-default). Before the TTL elapses, no new pruning occurs; existing projections still replay unchanged.
 2. Once the TTL has elapsed, estimate total context size against the model's context window. Below roughly 30% usage, pruning is skipped and the TTL clock keeps running.
 3. **Soft-trim** oversized tool results: results over 4,000 characters keep their first and last 1,500 characters with `...` in between.
 4. If context usage is still at or above roughly 50% and at least 50,000 characters of prunable tool content remain, **hard-clear** those results: replace their content with a placeholder (default `[Old tool result content cleared]`, configurable via `agents.defaults.contextPruning.hardClear.placeholder`; set `hardClear.enabled: false` to skip this step).
-5. Reset the TTL clock only when pruning actually changed the context, so follow-up requests reuse the fresh cache.
+5. Record each changed result as a session projection and reset the pruning TTL clock. Follow-up requests reuse the same projected bytes, including tool-loop continuations and later turns.
+
+The TTL gates new pruning rounds, not replay of previous projections. Projections
+survive Gateway restarts through the transcript marker. Compaction drops
+projections for results no longer in the active history; `/new` and session reset
+start without the old session's projections. Cache-TTL marker timestamps still
+support the existing cache and heartbeat bookkeeping.
 
 Two safety rules apply regardless of thresholds: the last three assistant turns are never pruned, and nothing before the session's first user message is ever pruned (protects bootstrap reads like `SOUL.md`/`USER.md`). The size thresholds and trim windows above are built-in behavior, not config keys; the configurable surface is `agents.defaults.contextPruning` (`mode`, `ttl`, `tools`, `hardClear`).
 
-Only `toolResult` messages are eligible; normal conversation text is left alone. Use `agents.defaults.contextPruning.tools.{allow,deny}` to scope which tool names are prunable.
+Only `toolResult` messages are eligible; normal conversation text is left alone. Use `agents.defaults.contextPruning.tools.{allow,deny}` to scope which tool names are prunable on either path.
 
 ## Legacy image cleanup
 
@@ -53,6 +105,9 @@ The bundled Anthropic plugin auto-configures pruning and heartbeat cadence the f
 
 If you set `agents.defaults.contextPruning.mode` or `agents.defaults.heartbeat.every` yourself, OpenClaw does not override them. This auto-default only fires for Anthropic-family auth; other providers get pruning `off` unless you configure it.
 
+The seeded `ttl` applies to client-side pruning. Direct Anthropic API-key requests
+use the token thresholds above while retaining the same heartbeat defaults.
+
 ## Enable or disable
 
 Pruning is off by default for non-Anthropic providers. To enable:
@@ -67,15 +122,16 @@ Pruning is off by default for non-Anthropic providers. To enable:
 }
 ```
 
-To disable: set `mode: "off"`.
+To stop new pruning, set `mode: "off"`. Existing client-side projections remain
+stable until compaction removes their results or the session is reset.
 
 ## Pruning vs compaction
 
-|            | Pruning            | Compaction              |
-| ---------- | ------------------ | ----------------------- |
-| **What**   | Trims tool results | Summarizes conversation |
-| **Saved?** | No (per-request)   | Yes (in transcript)     |
-| **Scope**  | Tool results only  | Entire conversation     |
+|            | Pruning                                                              | Compaction                                              |
+| ---------- | -------------------------------------------------------------------- | ------------------------------------------------------- |
+| **What**   | Trims tool results                                                   | Summarizes conversation                                 |
+| **Saved?** | Client projections persist; server clearing keeps full local history | Summary persists in transcript or provider replay state |
+| **Scope**  | Tool results only                                                    | Entire conversation                                     |
 
 They complement each other -- pruning keeps tool output lean between compaction cycles.
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -259,6 +259,12 @@ reports dropping invalidated thinking from replay. It includes the mismatch
 reasons and up to five affected message paths, not the thinking content. No
 debug flag is required.
 
+`[anthropic] server-side context edit: cleared N tool results (M input tokens)`
+is an info-level line when Anthropic reports applying server-side tool-result
+clearing. It contains counts only, without tool arguments or result content, and
+requires no debug flag. See [Session pruning](/concepts/session-pruning#direct-anthropic-api-key-requests)
+for the routes and thresholds that enable clearing.
+
 ### Trace correlation
 
 File logs are JSONL. When a log call carries a valid diagnostic trace context,

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -281,6 +281,17 @@ persist the successful repair. Adaptive mode remains enabled,
 but a response may contain no thinking block. Integrations that build Messages API
 requests directly should follow Anthropic's [preserved-thinking rules](https://platform.claude.com/docs/en/build-with-claude/thinking#preserved-thinking).
 
+With `contextPruning.mode: "cache-ttl"`, direct Anthropic API-key requests use
+[server-side tool-result clearing](/concepts/session-pruning#direct-anthropic-api-key-requests).
+Anthropic's server-side clearing and compaction never invalidate Fable 5.1
+thinking: the prefix check uses the history sent by the client, before those
+server edits. See Anthropic's [context-editing contract](https://platform.claude.com/docs/en/build-with-claude/context-editing).
+On other eligible routes, a client-side prune is a one-time prefix edit. OpenClaw
+retains that projection for later requests, so pruning does not flip back to the
+original bytes and invalidate newly created thinking. Earlier thinking affected
+by a client-side edit is handled by `drop_block` where the binding controls above
+apply, or by the existing rejection-and-repair path elsewhere.
+
 Fable 5.1 thinking is also bound to the model that produced it. Switching a
 session from Fable 5.1 to any other model (Opus 5, Sonnet 5, Fable 5, or
 older) continues the visible conversation without Fable's earlier reasoning;

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -53,9 +53,11 @@ function runWrapper(apiKey: string | undefined): Record<string, string> | undefi
 function createPayloadCapturingBaseStream(captured: {
   headers?: Record<string, string>;
   payload?: Record<string, unknown>;
+  options?: Parameters<StreamFn>[2];
 }): StreamFn {
   return (model, _context, options) => {
     captured.headers = options?.headers;
+    captured.options = options;
     const payload = {} as Record<string, unknown>;
     options?.onPayload?.(payload as never, model as never);
     captured.payload = payload;
@@ -151,12 +153,18 @@ function runCompactionProviderWrapper(params?: {
   extraParams?: Record<string, unknown>;
   headers?: Record<string, string>;
   payload?: Record<string, unknown>;
+  config?: Parameters<typeof wrapAnthropicProviderStream>[0]["config"];
 }) {
-  const captured: { headers?: Record<string, string>; payload?: Record<string, unknown> } = {};
+  const captured: {
+    headers?: Record<string, string>;
+    payload?: Record<string, unknown>;
+    options?: Parameters<StreamFn>[2];
+  } = {};
   const wrapped = wrapAnthropicProviderStream({
     streamFn: createPayloadCapturingBaseStream(captured),
     modelId: "claude-sonnet-4-6",
     extraParams: params?.extraParams ?? { anthropicServerCompaction: true },
+    config: params?.config,
   } as never);
   const payload = params?.payload ?? {};
   void wrapped?.(
@@ -218,21 +226,34 @@ describe("anthropic stream wrappers", () => {
     expect(captured.payload).toMatchObject({ service_tier: "auto" });
   });
 
-  it("injects opt-in server compaction for direct API-key requests", () => {
+  it("passes opt-in server compaction to the direct API-key transport", () => {
     const captured = runCompactionProviderWrapper({
       headers: { "Anthropic-Beta": "files-api-2025-04-14" },
     });
 
     expect(captured.headers?.["Anthropic-Beta"]).toBe("files-api-2025-04-14,compact-2026-01-12");
-    expect(captured.payload?.context_management).toEqual({
-      edits: [
-        {
-          type: "compact_20260112",
-          trigger: { type: "input_tokens", value: 140_000 },
-        },
-      ],
+    expect(captured.options).toMatchObject({
+      anthropicServerCompaction: true,
+      anthropicCompactThreshold: 140_000,
     });
   });
+
+  it.each(["off", "cache-ttl"] satisfies Array<"off" | "cache-ttl">)(
+    "derives context management from context pruning mode %s",
+    (mode) => {
+      const tools = { allow: ["read*"], deny: ["read_secret"] };
+      const captured = runCompactionProviderWrapper({
+        extraParams: {},
+        config: { agents: { defaults: { contextPruning: { mode, tools } } } },
+      });
+
+      if (mode === "cache-ttl") {
+        expect(captured.options).toMatchObject({ cacheTtlPruning: { tools } });
+      } else {
+        expect(captured.options).not.toHaveProperty("cacheTtlPruning");
+      }
+    },
+  );
 
   it("preserves existing context management under the compaction wrapper", () => {
     const existing = { edits: [{ type: "clear_tool_uses_20250919" }] };

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -153,7 +153,6 @@ function runCompactionProviderWrapper(params?: {
   extraParams?: Record<string, unknown>;
   headers?: Record<string, string>;
   payload?: Record<string, unknown>;
-  config?: Parameters<typeof wrapAnthropicProviderStream>[0]["config"];
 }) {
   const captured: {
     headers?: Record<string, string>;
@@ -164,7 +163,6 @@ function runCompactionProviderWrapper(params?: {
     streamFn: createPayloadCapturingBaseStream(captured),
     modelId: "claude-sonnet-4-6",
     extraParams: params?.extraParams ?? { anthropicServerCompaction: true },
-    config: params?.config,
   } as never);
   const payload = params?.payload ?? {};
   void wrapped?.(
@@ -237,23 +235,6 @@ describe("anthropic stream wrappers", () => {
       anthropicCompactThreshold: 140_000,
     });
   });
-
-  it.each(["off", "cache-ttl"] satisfies Array<"off" | "cache-ttl">)(
-    "derives context management from context pruning mode %s",
-    (mode) => {
-      const tools = { allow: ["read*"], deny: ["read_secret"] };
-      const captured = runCompactionProviderWrapper({
-        extraParams: {},
-        config: { agents: { defaults: { contextPruning: { mode, tools } } } },
-      });
-
-      if (mode === "cache-ttl") {
-        expect(captured.options).toMatchObject({ cacheTtlPruning: { tools } });
-      } else {
-        expect(captured.options).not.toHaveProperty("cacheTtlPruning");
-      }
-    },
-  );
 
   it("preserves existing context management under the compaction wrapper", () => {
     const existing = { edits: [{ type: "clear_tool_uses_20250919" }] };

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -212,25 +212,22 @@ export function createAnthropicFastModeWrapper(
   };
 }
 
-/** Pass context-management settings to the shared request payload policy. */
-function createAnthropicContextManagementWrapper(
+/** Pass opt-in server compaction to the shared request payload policy. */
+function createAnthropicCompactionWrapper(
   baseStreamFn: StreamFn | undefined,
   extraParams: Record<string, unknown> | undefined,
-  cacheTtlPruning?: { tools?: { allow?: string[]; deny?: string[] } },
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     const compaction = resolveAnthropicServerCompactionPlan(model, extraParams, options?.apiKey);
+    if (!compaction.enabled) {
+      return underlying(model, context, options);
+    }
     const requestOptions = {
       ...options,
-      ...(cacheTtlPruning ? { cacheTtlPruning } : {}),
-      ...(compaction.enabled
-        ? {
-            anthropicServerCompaction: true,
-            anthropicCompactThreshold: compaction.threshold,
-            headers: mergeAnthropicBetaHeader(options?.headers, [ANTHROPIC_COMPACTION_BETA]),
-          }
-        : {}),
+      anthropicServerCompaction: true,
+      anthropicCompactThreshold: compaction.threshold,
+      headers: mergeAnthropicBetaHeader(options?.headers, [ANTHROPIC_COMPACTION_BETA]),
     };
     return underlying(model, context, requestOptions);
   };
@@ -311,7 +308,6 @@ export function resolveAnthropicServiceTier(
 export function wrapAnthropicProviderStream(
   ctx: ProviderWrapStreamFnContext,
 ): StreamFn | undefined {
-  const contextPruning = ctx.config?.agents?.defaults?.contextPruning;
   const anthropicBetas = resolveAnthropicBetas(ctx.extraParams, ctx.modelId);
   const needsAnthropicBetaWrapper =
     anthropicBetas !== undefined ||
@@ -333,13 +329,8 @@ export function wrapAnthropicProviderStream(
       ? (streamFn) =>
           createAnthropicFastModeWrapper(streamFn, () => resolveAnthropicFastMode(ctx.extraParams))
       : undefined,
-    ctx.extraParams?.anthropicServerCompaction === true || contextPruning?.mode === "cache-ttl"
-      ? (streamFn) =>
-          createAnthropicContextManagementWrapper(
-            streamFn,
-            ctx.extraParams,
-            contextPruning?.mode === "cache-ttl" ? { tools: contextPruning.tools } : undefined,
-          )
+    ctx.extraParams?.anthropicServerCompaction === true
+      ? (streamFn) => createAnthropicCompactionWrapper(streamFn, ctx.extraParams)
       : undefined,
     (streamFn) => createAnthropicThinkingPrefillWrapper(streamFn),
   );

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -212,32 +212,27 @@ export function createAnthropicFastModeWrapper(
   };
 }
 
-/** Wrap a direct Anthropic API stream with opt-in server-side compaction. */
-function createAnthropicCompactionWrapper(
+/** Pass context-management settings to the shared request payload policy. */
+function createAnthropicContextManagementWrapper(
   baseStreamFn: StreamFn | undefined,
   extraParams: Record<string, unknown> | undefined,
+  cacheTtlPruning?: { tools?: { allow?: string[]; deny?: string[] } },
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
-  const payloadWrapper = createPayloadPatchStreamWrapper(underlying, ({ payload, model }) => {
-    const payloadPolicy = resolveAnthropicPayloadPolicy({
-      provider: readStringValue(model.provider),
-      api: readStringValue(model.api),
-      baseUrl: readStringValue(model.baseUrl),
-      contextWindow: model.contextWindow,
-      enableServerCompaction: true,
-      extraParams,
-    });
-    applyAnthropicPayloadPolicyToParams(payload, payloadPolicy, new Set());
-  });
   return (model, context, options) => {
-    if (!resolveAnthropicServerCompactionPlan(model, extraParams, options?.apiKey).enabled) {
-      return underlying(model, context, options);
-    }
-    return payloadWrapper(model, context, {
+    const compaction = resolveAnthropicServerCompactionPlan(model, extraParams, options?.apiKey);
+    const requestOptions = {
       ...options,
-      anthropicServerCompaction: true,
-      headers: mergeAnthropicBetaHeader(options?.headers, [ANTHROPIC_COMPACTION_BETA]),
-    } as Parameters<StreamFn>[2]);
+      ...(cacheTtlPruning ? { cacheTtlPruning } : {}),
+      ...(compaction.enabled
+        ? {
+            anthropicServerCompaction: true,
+            anthropicCompactThreshold: compaction.threshold,
+            headers: mergeAnthropicBetaHeader(options?.headers, [ANTHROPIC_COMPACTION_BETA]),
+          }
+        : {}),
+    };
+    return underlying(model, context, requestOptions);
   };
 }
 
@@ -316,6 +311,7 @@ export function resolveAnthropicServiceTier(
 export function wrapAnthropicProviderStream(
   ctx: ProviderWrapStreamFnContext,
 ): StreamFn | undefined {
+  const contextPruning = ctx.config?.agents?.defaults?.contextPruning;
   const anthropicBetas = resolveAnthropicBetas(ctx.extraParams, ctx.modelId);
   const needsAnthropicBetaWrapper =
     anthropicBetas !== undefined ||
@@ -337,8 +333,13 @@ export function wrapAnthropicProviderStream(
       ? (streamFn) =>
           createAnthropicFastModeWrapper(streamFn, () => resolveAnthropicFastMode(ctx.extraParams))
       : undefined,
-    ctx.extraParams?.anthropicServerCompaction === true
-      ? (streamFn) => createAnthropicCompactionWrapper(streamFn, ctx.extraParams)
+    ctx.extraParams?.anthropicServerCompaction === true || contextPruning?.mode === "cache-ttl"
+      ? (streamFn) =>
+          createAnthropicContextManagementWrapper(
+            streamFn,
+            ctx.extraParams,
+            contextPruning?.mode === "cache-ttl" ? { tools: contextPruning.tools } : undefined,
+          )
       : undefined,
     (streamFn) => createAnthropicThinkingPrefillWrapper(streamFn),
   );

--- a/packages/ai/src/anthropic-binding-transport-parity.test.ts
+++ b/packages/ai/src/anthropic-binding-transport-parity.test.ts
@@ -1,82 +1,12 @@
-import type { Context, Model } from "@openclaw/llm-core";
+import type { Context } from "@openclaw/llm-core";
 import { describe, expect, it, vi } from "vitest";
-import { configureAiTransportHost, getAiTransportHost } from "./host.js";
 import {
   anthropicModel,
   context,
   anthropicEvents,
-  createAnthropicResponse,
+  captureAnthropicRequest,
   registerParityHostLifecycle,
 } from "./provider-transport-parity.test-support.js";
-
-async function captureAnthropicRequest(
-  implementation: "provider" | "transport",
-  options: {
-    model?: Partial<Model<"anthropic-messages">>;
-    apiKey?: string;
-    reasoning?: "low" | "off";
-    events?: readonly Record<string, unknown>[];
-    context?: Context;
-    thinkingOverride?: { type: "disabled" } | { type: "enabled"; budget_tokens: number };
-    headers?: Record<string, string>;
-  } = {},
-) {
-  const requests: Array<{ payload: Record<string, unknown>; headers: Headers }> = [];
-  const warnings: string[] = [];
-  const capabilities = getAiTransportHost().resolveProviderRequestCapabilities({});
-  const fetchMock: typeof fetch = async (_input, init) => {
-    if (typeof init?.body !== "string") {
-      throw new Error("Expected a JSON Anthropic request body");
-    }
-    requests.push({
-      payload: JSON.parse(init.body) as Record<string, unknown>,
-      headers: new Headers(init?.headers),
-    });
-    return createAnthropicResponse(options.events ?? anthropicEvents);
-  };
-  configureAiTransportHost({
-    ...getAiTransportHost(),
-    buildModelFetch: () => fetchMock,
-    logWarn: (_subsystem, message) => warnings.push(message),
-    resolveProviderRequestCapabilities: (input) => ({
-      ...capabilities,
-      endpointClass:
-        new URL(input.baseUrl ?? "https://api.anthropic.com").hostname === "api.anthropic.com"
-          ? "anthropic-public"
-          : "custom",
-    }),
-  });
-  const model = { ...anthropicModel, ...options.model };
-  const streamOptions = {
-    apiKey: options.apiKey ?? "sk-test",
-    reasoning: options.reasoning ?? "low",
-    headers: options.headers,
-    onPayload: (payload: unknown) =>
-      options.thinkingOverride
-        ? { ...(payload as Record<string, unknown>), thinking: options.thinkingOverride }
-        : undefined,
-  } as const;
-  const [{ streamSimpleAnthropic }, { createAnthropicMessagesTransportStreamFn }] =
-    await Promise.all([
-      import("./providers/anthropic.js"),
-      import("./transports/anthropic-transport-stream.js"),
-    ]);
-  const requestContext = options.context ?? context;
-  const stream =
-    implementation === "provider"
-      ? streamSimpleAnthropic(model, requestContext, streamOptions)
-      : await Promise.resolve(
-          createAnthropicMessagesTransportStreamFn()(model, requestContext, streamOptions),
-        );
-  const result = await stream.result();
-  expect(result.stopReason).toBe("stop");
-  expect(requests).toHaveLength(1);
-  const [request] = requests;
-  if (!request) {
-    throw new Error("Expected one Anthropic request");
-  }
-  return { ...request, warnings };
-}
 
 describe("Anthropic thinking-binding transport parity", () => {
   registerParityHostLifecycle();

--- a/packages/ai/src/anthropic-context-management-parity.test.ts
+++ b/packages/ai/src/anthropic-context-management-parity.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  anthropicEvents,
+  captureAnthropicRequest,
+  context,
+  registerParityHostLifecycle,
+} from "./provider-transport-parity.test-support.js";
+
+describe("Anthropic server context management parity", () => {
+  registerParityHostLifecycle();
+
+  it.each([
+    { name: "direct API key", enabled: true },
+    { name: "default endpoint", model: { baseUrl: undefined }, enabled: true },
+    { name: "OAuth", apiKey: "sk-ant-oat01-synthetic", enabled: false },
+    { name: "proxy", model: { baseUrl: "https://proxy.example/v1" }, enabled: false },
+    { name: "Bedrock", model: { provider: "amazon-bedrock" }, enabled: false },
+    { name: "Vertex", model: { provider: "google-vertex" }, enabled: false },
+    { name: "Foundry", model: { provider: "microsoft-foundry" }, enabled: false },
+  ])("gates tool clearing for $name in both request paths", async ({ enabled, ...options }) => {
+    for (const implementation of ["provider", "transport"] as const) {
+      const { payload, headers } = await captureAnthropicRequest(implementation, {
+        ...options,
+        cacheTtlPruning: {},
+      });
+      expect(payload.context_management).toEqual(
+        enabled
+          ? {
+              edits: [
+                {
+                  type: "clear_tool_uses_20250919",
+                  trigger: { type: "input_tokens", value: 60_000 },
+                  keep: { type: "tool_uses", value: 3 },
+                  clear_at_least: { type: "input_tokens", value: 12_500 },
+                  exclude_tools: [],
+                  clear_tool_inputs: false,
+                },
+              ],
+            }
+          : undefined,
+      );
+      expect(
+        headers.get("anthropic-beta")?.includes("context-management-2025-06-27") ?? false,
+      ).toBe(enabled);
+    }
+  });
+
+  it("keeps clearing enabled after simple dispatch selects the Anthropic transport alias", async () => {
+    const { payload, headers } = await captureAnthropicRequest("transport", {
+      transportApi: "openclaw-anthropic-messages-transport",
+      cacheTtlPruning: {},
+    });
+    expect(payload.context_management).toEqual({
+      edits: [expect.objectContaining({ type: "clear_tool_uses_20250919" })],
+    });
+    expect(headers.get("anthropic-beta")).toContain("context-management-2025-06-27");
+  });
+
+  it("clamps small-window thresholds and enables clearing without thinking", async () => {
+    for (const implementation of ["provider", "transport"] as const) {
+      const { payload, headers } = await captureAnthropicRequest(implementation, {
+        model: { contextWindow: 100_000 },
+        reasoning: "off",
+        cacheTtlPruning: {},
+      });
+      expect(payload.context_management).toEqual({
+        edits: [
+          expect.objectContaining({
+            trigger: { type: "input_tokens", value: 50_000 },
+            clear_at_least: { type: "input_tokens", value: 12_500 },
+          }),
+        ],
+      });
+      expect(headers.get("anthropic-beta")).toContain("context-management-2025-06-27");
+      expect(headers.get("anthropic-beta") ?? "").not.toContain("thinking-binding-controls");
+    }
+  });
+
+  it("derives thresholds, tool exclusions, and clearing-before-compaction order", async () => {
+    const tools = context.tools.flatMap((tool) =>
+      ["lookup", "read", "write", "exec", "search", "special+tool"].map((name) =>
+        Object.assign({}, tool, { name }),
+      ),
+    );
+    for (const implementation of ["provider", "transport"] as const) {
+      const { payload, headers } = await captureAnthropicRequest(implementation, {
+        model: { contextWindow: 1_000_000 },
+        context: { ...context, tools },
+        cacheTtlPruning: {
+          tools: {
+            allow: ["READ", "look*", "write", "special+*"],
+            deny: ["write", "ex*", "retired_tool"],
+          },
+        },
+        anthropicServerCompaction: true,
+        anthropicCompactThreshold: 650_000,
+        headers: { "Anthropic-Beta": "synthetic-beta" },
+      });
+      expect(payload.context_management).toEqual({
+        edits: [
+          {
+            type: "clear_tool_uses_20250919",
+            trigger: { type: "input_tokens", value: 300_000 },
+            keep: { type: "tool_uses", value: 3 },
+            clear_at_least: { type: "input_tokens", value: 50_000 },
+            exclude_tools: ["exec", "retired_tool", "search", "write"],
+            clear_tool_inputs: false,
+          },
+          { type: "compact_20260112", trigger: { type: "input_tokens", value: 650_000 } },
+        ],
+      });
+      expect(headers.get("anthropic-beta")).toContain("synthetic-beta");
+      expect(headers.get("anthropic-beta")).toContain("context-management-2025-06-27");
+    }
+  });
+
+  it("keeps explicit context management and omits clearing without cache-TTL pruning", async () => {
+    for (const implementation of ["provider", "transport"] as const) {
+      for (const options of [{}, { cacheTtlPruning: {}, contextManagement: { edits: [] } }]) {
+        const { payload, headers } = await captureAnthropicRequest(implementation, options);
+        expect(payload.context_management).toEqual(options.contextManagement);
+        expect(headers.get("anthropic-beta") ?? "").not.toContain("context-management-2025-06-27");
+      }
+    }
+  });
+
+  it("respects the effective environment endpoint", async () => {
+    vi.stubEnv("ANTHROPIC_BASE_URL", "https://proxy.example/v1");
+    for (const implementation of ["provider", "transport"] as const) {
+      const { payload, headers } = await captureAnthropicRequest(implementation, {
+        model: { baseUrl: undefined },
+        cacheTtlPruning: {},
+      });
+      expect(payload.context_management).toBeUndefined();
+      expect(headers.get("anthropic-beta") ?? "").not.toContain("context-management-2025-06-27");
+    }
+  });
+
+  it("logs bounded aggregate clearing counts from the final message delta", async () => {
+    const events = anthropicEvents.map((event) =>
+      event.type === "message_delta"
+        ? Object.assign({}, event, {
+            context_management: {
+              applied_edits: [
+                {
+                  type: "clear_tool_uses_20250919",
+                  cleared_tool_uses: 8,
+                  cleared_input_tokens: 50_000,
+                },
+                {
+                  type: "clear_tool_uses_20250919",
+                  cleared_tool_uses: 2,
+                  cleared_input_tokens: 5_000,
+                },
+                { type: "future", content: "must not log" },
+              ],
+            },
+          })
+        : event,
+    );
+    for (const implementation of ["provider", "transport"] as const) {
+      const { info } = await captureAnthropicRequest(implementation, { events });
+      expect(info).toEqual([
+        "server-side context edit: cleared 10 tool results (55000 input tokens)",
+      ]);
+      const empty = await captureAnthropicRequest(implementation);
+      expect(empty.info).toEqual([]);
+    }
+  });
+});

--- a/packages/ai/src/provider-options.ts
+++ b/packages/ai/src/provider-options.ts
@@ -68,8 +68,14 @@ export type AnthropicEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
 export type AnthropicThinkingDisplay = "summarized" | "omitted";
 
+export type AnthropicContextManagementOptions = {
+  anthropicServerCompaction?: boolean;
+  anthropicCompactThreshold?: number;
+  cacheTtlPruning?: { tools?: { allow?: string[]; deny?: string[] } };
+};
+
 /** Provider options shared by the Anthropic provider and canonical transport. */
-export interface AnthropicOptions extends StreamOptions {
+export interface AnthropicOptions extends StreamOptions, AnthropicContextManagementOptions {
   /**
    * Enable extended thinking.
    * For Opus 4.6+ and Sonnet 4.6: uses adaptive thinking (model decides when/how much to think).

--- a/packages/ai/src/provider-transport-parity.test-support.ts
+++ b/packages/ai/src/provider-transport-parity.test-support.ts
@@ -1,5 +1,6 @@
 import type { Context, Model } from "@openclaw/llm-core";
-import { afterAll, afterEach, beforeAll, vi } from "vitest";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterAll, afterEach, beforeAll, expect, vi } from "vitest";
 import { configureAiTransportHost, getAiTransportHost } from "./host.js";
 
 export const anthropicModel = {
@@ -100,4 +101,98 @@ export function registerParityHostLifecycle() {
   afterAll(() => {
     configureAiTransportHost(initialHost);
   });
+}
+
+export async function captureAnthropicRequest(
+  implementation: "provider" | "transport",
+  options: {
+    model?: Partial<Model<"anthropic-messages">>;
+    apiKey?: string;
+    transportApi?: Model["api"];
+    reasoning?: "low" | "off";
+    events?: readonly Record<string, unknown>[];
+    context?: Context;
+    thinkingOverride?: { type: "disabled" } | { type: "enabled"; budget_tokens: number };
+    headers?: Record<string, string>;
+    cacheTtlPruning?: { tools?: { allow?: string[]; deny?: string[] } };
+    anthropicServerCompaction?: boolean;
+    anthropicCompactThreshold?: number;
+    contextManagement?: unknown;
+  } = {},
+) {
+  const requests: Array<{ payload: Record<string, unknown>; headers: Headers }> = [];
+  const warnings: string[] = [];
+  const info: string[] = [];
+  const capabilities = getAiTransportHost().resolveProviderRequestCapabilities({});
+  const fetchMock: typeof fetch = async (_input, init) => {
+    if (typeof init?.body !== "string") {
+      throw new Error("Expected a JSON Anthropic request body");
+    }
+    const payload: unknown = JSON.parse(init.body);
+    if (!isRecord(payload)) {
+      throw new Error("Expected an Anthropic request object");
+    }
+    requests.push({
+      payload,
+      headers: new Headers(init?.headers),
+    });
+    return createAnthropicResponse(options.events ?? anthropicEvents);
+  };
+  configureAiTransportHost({
+    ...getAiTransportHost(),
+    buildModelFetch: () => fetchMock,
+    logInfo: (_subsystem, message) => info.push(message),
+    logWarn: (_subsystem, message) => warnings.push(message),
+    resolveProviderRequestCapabilities: (input) => ({
+      ...capabilities,
+      endpointClass:
+        new URL(input.baseUrl ?? "https://api.anthropic.com").hostname === "api.anthropic.com"
+          ? "anthropic-public"
+          : "custom",
+    }),
+  });
+  const model = { ...anthropicModel, ...options.model };
+  const streamOptions = {
+    apiKey: options.apiKey ?? "sk-test",
+    reasoning: options.reasoning ?? "low",
+    headers: options.headers,
+    cacheTtlPruning: options.cacheTtlPruning,
+    anthropicServerCompaction: options.anthropicServerCompaction,
+    anthropicCompactThreshold: options.anthropicCompactThreshold,
+    onPayload: (payload: unknown) => {
+      if (!isRecord(payload)) {
+        throw new Error("Expected an Anthropic request object");
+      }
+      if (options.thinkingOverride) {
+        payload.thinking = options.thinkingOverride;
+      }
+      if (options.contextManagement !== undefined) {
+        payload.context_management = options.contextManagement;
+      }
+    },
+  } as const;
+  const [{ streamSimpleAnthropic }, { createAnthropicMessagesTransportStreamFn }] =
+    await Promise.all([
+      import("./providers/anthropic.js"),
+      import("./transports/anthropic-transport-stream.js"),
+    ]);
+  const requestContext = options.context ?? context;
+  const stream =
+    implementation === "provider"
+      ? streamSimpleAnthropic(model, requestContext, streamOptions)
+      : await Promise.resolve(
+          createAnthropicMessagesTransportStreamFn()(
+            { ...model, api: options.transportApi ?? model.api },
+            requestContext,
+            streamOptions,
+          ),
+        );
+  const result = await stream.result();
+  expect(result.stopReason).toBe("stop");
+  expect(requests).toHaveLength(1);
+  const [request] = requests;
+  if (!request) {
+    throw new Error("Expected one Anthropic request");
+  }
+  return { ...request, warnings, info };
 }

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -19,7 +19,11 @@ import {
   type AnthropicInlineImageBudget,
 } from "../internal/anthropic-inline-images.js";
 import { calculateCost } from "../model-utils.js";
-import type { AnthropicOptions, AnthropicThinkingDisplay } from "../provider-options.js";
+import type {
+  AnthropicContextManagementOptions,
+  AnthropicOptions,
+  AnthropicThinkingDisplay,
+} from "../provider-options.js";
 import { transformProviderMessages as transformMessages } from "../provider-transcript-transform.js";
 import {
   buildAnthropicReplayPlan,
@@ -28,7 +32,13 @@ import {
   suppressAnthropicCompaction,
   type AnthropicCompactionBlock,
 } from "../transports/anthropic-compaction-replay.js";
-import { applyAnthropicCacheControlToMessages } from "../transports/anthropic-payload-policy.js";
+import {
+  applyAnthropicCacheControlToMessages,
+  applyAnthropicContextManagementToRequest,
+  isDirectAnthropicModel,
+  logAnthropicContextEdits,
+  resolveAnthropicContextManagementBetaHeader,
+} from "../transports/anthropic-payload-policy.js";
 import {
   assignTransportErrorDetails,
   finalizeTerminalToolCallArguments,
@@ -134,7 +144,6 @@ const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
 const EMPTY_ERROR_TOOL_RESULT_TEXT = "[tool error with no output]";
 
 type AnthropicCompactionOptions = AnthropicOptions & {
-  anthropicServerCompaction?: boolean;
   authProfileId?: string;
 };
 
@@ -421,16 +430,28 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicComp
       usedCompactionReplay = builtParams.usedCompactionReplay;
       let params = builtParams.params;
       const toolProjection = builtParams.toolProjection;
+      applyAnthropicContextManagementToRequest(
+        params,
+        model,
+        requestOptions,
+        directApiKeyBetaHeader,
+      );
       const nextParams = await requestOptions?.onPayload?.(params, model);
       if (nextParams !== undefined) {
         params = nextParams as MessageCreateParamsStreaming;
       }
       applyClaudeRequestContract(params, model);
+      const betaHeader = resolveAnthropicContextManagementBetaHeader(
+        params,
+        directApiKeyBetaHeader,
+      );
       const sdkRequestOptions = {
         ...(requestOptions?.signal ? { signal: requestOptions.signal } : {}),
         ...(requestOptions?.timeoutMs !== undefined ? { timeout: requestOptions.timeoutMs } : {}),
         maxRetries: 0,
-        headers: applyAnthropicThinkingBindingControls(params, directApiKeyBetaHeader),
+        headers:
+          applyAnthropicThinkingBindingControls(params, betaHeader) ??
+          (betaHeader !== undefined ? { "anthropic-beta": betaHeader } : undefined),
       };
       const response = await client.messages
         .create({ ...params, stream: true }, sdkRequestOptions)
@@ -452,9 +473,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicComp
         contentIndex: number;
       }> = [];
       const compactionCapture = createCompactionCapture(output, model, requestOptions);
-      const requireMessageStop =
-        refusalBuffer !== undefined ||
-        (model.provider === "anthropic" && isAnthropicPublicEndpoint(model.baseUrl));
+      const requireMessageStop = refusalBuffer !== undefined || isDirectAnthropicModel(model);
 
       for await (const event of iterateAnthropicEvents(response, requireMessageStop)) {
         // A serving-model fallback replaces the initial snapshot; report only once at completion.
@@ -673,6 +692,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicComp
             }
           }
         } else if (event.type === "message_delta") {
+          logAnthropicContextEdits(event);
           if (event.delta.stop_reason) {
             if (event.delta.stop_reason === "refusal") {
               applyAnthropicRefusal(output, event.delta.stop_details, model.provider);
@@ -757,11 +777,11 @@ function normalizeAnthropicThinkingOptions(
   return { ...options, thinkingEnabled: false, thinkingBudgetTokens: undefined };
 }
 
-type AnthropicSimpleStreamOptions = SimpleStreamOptions & {
-  anthropicServerCompaction?: boolean;
-  authProfileId?: string;
-  toolChoice?: AnthropicCompactionOptions["toolChoice"];
-};
+type AnthropicSimpleStreamOptions = SimpleStreamOptions &
+  AnthropicContextManagementOptions & {
+    authProfileId?: string;
+    toolChoice?: AnthropicCompactionOptions["toolChoice"];
+  };
 
 export const streamSimpleAnthropic: StreamFunction<
   "anthropic-messages",
@@ -779,6 +799,8 @@ export const streamSimpleAnthropic: StreamFunction<
   const base = {
     ...buildBaseOptions(model, options, apiKey),
     anthropicServerCompaction: options?.anthropicServerCompaction,
+    anthropicCompactThreshold: options?.anthropicCompactThreshold,
+    cacheTtlPruning: options?.cacheTtlPruning,
     authProfileId: options?.authProfileId,
     maxTokens: clampMaxTokensToModel(model, options?.maxTokens ?? model.maxTokens),
     toolChoice: options?.toolChoice,
@@ -846,17 +868,6 @@ export const streamSimpleAnthropic: StreamFunction<
   } satisfies AnthropicCompactionOptions);
 };
 
-function isAnthropicPublicEndpoint(baseUrl: string | undefined): boolean {
-  if (!baseUrl) {
-    return true;
-  }
-  try {
-    return new URL(baseUrl).hostname.toLowerCase() === "api.anthropic.com";
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Server-side refusal fallback is a first-party Claude API beta: proxies and
  * Bedrock/Vertex/Foundry reject the `fallbacks` param, and OAuth (Claude Code
@@ -870,7 +881,7 @@ function supportsAnthropicServerSideFallback(model: Model<"anthropic-messages">)
   ) {
     return false;
   }
-  return isAnthropicPublicEndpoint(model.baseUrl);
+  return isDirectAnthropicModel(model);
 }
 
 function createClient(
@@ -1039,13 +1050,11 @@ function createClient(
     isOAuthToken: false,
     serverSideFallback,
     // Binding controls are verified only on direct API-key requests, not OAuth or proxies.
-    directApiKeyBetaHeader:
-      model.provider === "anthropic" &&
-      isAnthropicPublicEndpoint(model.baseUrl ?? process.env.ANTHROPIC_BASE_URL)
-        ? (Object.entries(defaultHeaders).findLast(
-            ([name]) => name.toLowerCase() === "anthropic-beta",
-          )?.[1] ?? "")
-        : undefined,
+    directApiKeyBetaHeader: isDirectAnthropicModel(model)
+      ? (Object.entries(defaultHeaders).findLast(
+          ([name]) => name.toLowerCase() === "anthropic-beta",
+        )?.[1] ?? "")
+      : undefined,
   };
 }
 

--- a/packages/ai/src/transports/anthropic-payload-policy.test.ts
+++ b/packages/ai/src/transports/anthropic-payload-policy.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost, getAiTransportHost } from "../host.js";
 import {
+  applyAnthropicPayloadPolicyToParams,
+  isAnthropicServerToolClearingEnabled,
+  resolveAnthropicPayloadPolicy,
   resolveAnthropicEphemeralCacheControl,
   resolveAnthropicServerCompactionPlan,
 } from "./anthropic-payload-policy.js";
@@ -67,5 +70,44 @@ describe("Anthropic compaction authentication eligibility", () => {
     } finally {
       configureAiTransportHost(host);
     }
+  });
+});
+
+describe("Anthropic tool-clearing policy", () => {
+  const model = { provider: "anthropic", api: "anthropic-messages", contextWindow: 200_000 };
+
+  it.each([undefined, "", "  "])(
+    "requires resolved authentication before disabling client pruning: %j",
+    (apiKey) => {
+      expect(isAnthropicServerToolClearingEnabled(model, apiKey)).toBe(false);
+    },
+  );
+
+  it("expands deny globs over historical tools while the allow complement covers exposed tools", () => {
+    const payload: Record<string, unknown> = {
+      tools: [{ name: "lookup" }, { name: "search" }],
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "old_exec", name: "exec_retired", input: {} },
+            { type: "tool_use", id: "old_other", name: "other_retired", input: {} },
+          ],
+        },
+      ],
+    };
+    const policy = resolveAnthropicPayloadPolicy({
+      ...model,
+      cacheTtlPruning: { tools: { allow: ["lookup"], deny: ["exec*"] } },
+    });
+    applyAnthropicPayloadPolicyToParams(payload, policy, new Set());
+    expect(payload.context_management).toEqual({
+      edits: [
+        expect.objectContaining({
+          type: "clear_tool_uses_20250919",
+          exclude_tools: ["exec_retired", "search"],
+        }),
+      ],
+    });
   });
 });

--- a/packages/ai/src/transports/anthropic-payload-policy.ts
+++ b/packages/ai/src/transports/anthropic-payload-policy.ts
@@ -1,5 +1,9 @@
+import type { BetaContextManagementConfig } from "@anthropic-ai/sdk/resources/beta/messages/messages.js";
 import type { Model } from "@openclaw/llm-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { getAiTransportHost } from "../host.js";
+import type { AnthropicContextManagementOptions } from "../provider-options.js";
 import { isAnthropicOAuthApiKey } from "../providers/anthropic-auth-headers.js";
 import { resolveCacheRetention } from "../providers/cache-retention.js";
 import {
@@ -27,6 +31,7 @@ type AnthropicPayloadPolicyInput = {
   api?: string;
   baseUrl?: string;
   cacheRetention?: "short" | "long" | "none";
+  cacheTtlPruning?: AnthropicContextManagementOptions["cacheTtlPruning"];
   contextWindow?: unknown;
   enableCacheControl?: boolean;
   enableServerCompaction?: boolean;
@@ -45,6 +50,11 @@ type AnthropicPayloadPolicy = {
   compactThreshold: number;
   serviceTier: AnthropicServiceTier | undefined;
   useServerCompaction: boolean;
+  toolClearing?: {
+    trigger: number;
+    clearAtLeast: number;
+    tools: NonNullable<AnthropicContextManagementOptions["cacheTtlPruning"]>["tools"];
+  };
 };
 
 /** Resolve the Anthropic input-token trigger, including the API's minimum. */
@@ -73,15 +83,11 @@ export function resolveAnthropicServerCompactionPlan(
   extraParams?: Record<string, unknown>,
   apiKey?: string,
 ): { enabled: boolean; threshold?: number } {
-  const provider = normalizeOptionalLowercaseString(model.provider);
-  const api = normalizeOptionalLowercaseString(model.api);
-  const endpointClass = resolveProviderEndpoint(model).endpointClass;
   const enabled =
     extraParams?.anthropicServerCompaction === true &&
     !isAnthropicOAuthApiKey(apiKey) &&
-    provider === "anthropic" &&
-    api === "anthropic-messages" &&
-    (endpointClass === "default" || endpointClass === "anthropic-public");
+    normalizeOptionalLowercaseString(model.api) === "anthropic-messages" &&
+    isDirectAnthropicModel(model);
   return {
     enabled,
     ...(enabled
@@ -93,6 +99,32 @@ export function resolveAnthropicServerCompactionPlan(
         }
       : {}),
   };
+}
+
+export function isDirectAnthropicModel(model: { provider?: unknown; baseUrl?: string }): boolean {
+  const baseUrl = model.baseUrl?.trim() || process.env.ANTHROPIC_BASE_URL?.trim();
+  const endpointModel = baseUrl === model.baseUrl ? model : { ...model, baseUrl };
+  const endpointClass = resolveProviderEndpoint(endpointModel).endpointClass;
+  return (
+    normalizeOptionalLowercaseString(model.provider) === "anthropic" &&
+    (endpointClass === "anthropic-public" ||
+      (endpointClass === "default" &&
+        (!baseUrl || resolveBaseUrlHostname(baseUrl) === "api.anthropic.com")))
+  );
+}
+
+export function isAnthropicServerToolClearingEnabled(
+  model: { provider?: unknown; api?: unknown; baseUrl?: string },
+  apiKey?: string,
+): boolean {
+  const resolvedApiKey = apiKey && getAiTransportHost().resolveSecretSentinel(apiKey);
+  // Only a prepared direct API-key request can take ownership away from client pruning.
+  return (
+    Boolean(resolvedApiKey?.trim()) &&
+    !isAnthropicOAuthApiKey(resolvedApiKey) &&
+    normalizeOptionalLowercaseString(model.api) === "anthropic-messages" &&
+    isDirectAnthropicModel(model)
+  );
 }
 
 function resolveBaseUrlHostname(baseUrl: string): string | undefined {
@@ -322,7 +354,195 @@ export function resolveAnthropicPayloadPolicy(
       ),
     serviceTier: input.serviceTier,
     useServerCompaction: input.enableServerCompaction === true && serverCompactionPlan.enabled,
+    ...(input.cacheTtlPruning &&
+    normalizeOptionalLowercaseString(input.api) === "anthropic-messages" &&
+    isDirectAnthropicModel(input)
+      ? {
+          toolClearing: {
+            trigger: Math.max(
+              50_000,
+              Math.floor((parsePositiveInteger(input.contextWindow) ?? 0) * 0.3),
+            ),
+            clearAtLeast: Math.max(
+              12_500,
+              Math.floor((parsePositiveInteger(input.contextWindow) ?? 0) * 0.05),
+            ),
+            tools: input.cacheTtlPruning.tools,
+          },
+        }
+      : {}),
   };
+}
+
+type AnthropicContextManagementPayload = {
+  context_management?: unknown;
+  tools?: unknown;
+  messages?: unknown;
+};
+
+function resolveToolClearingExclusions(
+  payload: AnthropicContextManagementPayload,
+  filter: NonNullable<AnthropicPayloadPolicy["toolClearing"]>["tools"],
+): string[] {
+  const compile = (patterns: string[] | undefined) =>
+    (patterns ?? [])
+      .map((pattern) => pattern.trim().toLowerCase())
+      .filter(Boolean)
+      .map(
+        (pattern) =>
+          new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replaceAll("\\*", ".*")}$`),
+      );
+  const allow = compile(filter?.allow);
+  const deny = compile(filter?.deny);
+  if (allow.length === 0 && deny.length === 0) {
+    return [];
+  }
+  const excluded = new Set(
+    filter?.deny?.map((name) => name.trim()).filter((name) => name && !name.includes("*")),
+  );
+  const exposed = new Set<string>();
+  for (const tool of Array.isArray(payload.tools) ? payload.tools : []) {
+    if (isRecord(tool) && typeof tool.name === "string") {
+      exposed.add(tool.name);
+    }
+  }
+  const candidates = new Set(exposed);
+  // Denied historical tools stay protected even after disappearing from the exposed tool set.
+  for (const message of deny.length > 0 && Array.isArray(payload.messages)
+    ? payload.messages
+    : []) {
+    if (!isRecord(message) || !Array.isArray(message.content)) {
+      continue;
+    }
+    for (const block of message.content) {
+      if (isRecord(block) && block.type === "tool_use" && typeof block.name === "string") {
+        candidates.add(block.name);
+      }
+    }
+  }
+  for (const toolName of candidates) {
+    const name = toolName.trim().toLowerCase();
+    if (
+      deny.some((pattern) => pattern.test(name)) ||
+      (exposed.has(toolName) && allow.length > 0 && !allow.some((pattern) => pattern.test(name)))
+    ) {
+      excluded.add(toolName);
+    }
+  }
+  return [...excluded].toSorted();
+}
+
+function applyAnthropicContextManagementEdits(
+  payload: AnthropicContextManagementPayload,
+  policy: AnthropicPayloadPolicy,
+): void {
+  if (payload.context_management !== undefined) {
+    return;
+  }
+  const edits: NonNullable<BetaContextManagementConfig["edits"]> = [];
+  if (policy.toolClearing) {
+    edits.push({
+      type: "clear_tool_uses_20250919",
+      trigger: { type: "input_tokens", value: policy.toolClearing.trigger },
+      keep: { type: "tool_uses", value: 3 },
+      clear_at_least: { type: "input_tokens", value: policy.toolClearing.clearAtLeast },
+      exclude_tools: resolveToolClearingExclusions(payload, policy.toolClearing.tools),
+      clear_tool_inputs: false,
+    });
+  }
+  // Clear cheap-to-discard tool results before asking the server to summarize the remaining context.
+  if (policy.useServerCompaction) {
+    edits.push({
+      type: "compact_20260112",
+      trigger: { type: "input_tokens", value: policy.compactThreshold },
+    });
+  }
+  if (edits.length > 0) {
+    payload.context_management = { edits };
+  }
+}
+
+export function applyAnthropicContextManagementToRequest(
+  payload: AnthropicContextManagementPayload,
+  model: Model,
+  options: AnthropicContextManagementOptions | undefined,
+  directApiKeyBetaHeader: string | undefined,
+): void {
+  if (
+    directApiKeyBetaHeader === undefined ||
+    (!options?.cacheTtlPruning && !options?.anthropicServerCompaction)
+  ) {
+    return;
+  }
+  applyAnthropicContextManagementEdits(
+    payload,
+    resolveAnthropicPayloadPolicy({
+      ...model,
+      // This adapter owns the wire API; simple-dispatch aliases remain on the replay identity.
+      api: "anthropic-messages",
+      enableServerCompaction: true,
+      extraParams: { ...options },
+      cacheTtlPruning: options?.cacheTtlPruning,
+    }),
+  );
+}
+
+export function resolveAnthropicContextManagementBetaHeader(
+  payload: AnthropicContextManagementPayload,
+  directApiKeyBetaHeader: string | undefined,
+): string | undefined {
+  if (directApiKeyBetaHeader === undefined || !isRecord(payload.context_management)) {
+    return directApiKeyBetaHeader;
+  }
+  const edits = payload.context_management.edits;
+  const betas = new Set(
+    directApiKeyBetaHeader
+      .split(",")
+      .map((beta) => beta.trim())
+      .filter(Boolean),
+  );
+  for (const edit of Array.isArray(edits) ? edits : []) {
+    if (!isRecord(edit)) {
+      continue;
+    }
+    if (edit.type === "clear_tool_uses_20250919") {
+      betas.add("context-management-2025-06-27");
+    } else if (edit.type === "compact_20260112") {
+      betas.add("compact-2026-01-12");
+    }
+  }
+  return [...betas].join(",");
+}
+
+export function logAnthropicContextEdits(event: unknown): void {
+  if (!isRecord(event) || !isRecord(event.context_management)) {
+    return;
+  }
+  const edits = event.context_management.applied_edits;
+  let clearedTools = 0;
+  let clearedTokens = 0;
+  for (const edit of Array.isArray(edits) ? edits : []) {
+    if (
+      !isRecord(edit) ||
+      edit.type !== "clear_tool_uses_20250919" ||
+      typeof edit.cleared_tool_uses !== "number" ||
+      !Number.isSafeInteger(edit.cleared_tool_uses) ||
+      edit.cleared_tool_uses < 0 ||
+      typeof edit.cleared_input_tokens !== "number" ||
+      !Number.isSafeInteger(edit.cleared_input_tokens) ||
+      edit.cleared_input_tokens < 0
+    ) {
+      continue;
+    }
+    clearedTools = Math.min(Number.MAX_SAFE_INTEGER, clearedTools + edit.cleared_tool_uses);
+    clearedTokens = Math.min(Number.MAX_SAFE_INTEGER, clearedTokens + edit.cleared_input_tokens);
+  }
+  if (clearedTools > 0 || clearedTokens > 0) {
+    getAiTransportHost().logInfo(
+      "anthropic",
+      `server-side context edit: cleared ${clearedTools} tool results (${clearedTokens} input tokens)`,
+    );
+  }
 }
 
 /** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
@@ -345,16 +565,7 @@ export function applyAnthropicPayloadPolicyToParams(
     stripAnthropicSystemPromptBoundary(payloadObj.system);
   }
 
-  if (policy.useServerCompaction && payloadObj.context_management === undefined) {
-    payloadObj.context_management = {
-      edits: [
-        {
-          type: "compact_20260112",
-          trigger: { type: "input_tokens", value: policy.compactThreshold },
-        },
-      ],
-    };
-  }
+  applyAnthropicContextManagementEdits(payloadObj, policy);
 
   if (!policy.cacheControl) {
     return;

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -100,6 +100,10 @@ import {
 } from "./anthropic-compaction-replay.js";
 import {
   applyAnthropicPayloadPolicyToParams,
+  applyAnthropicContextManagementToRequest,
+  isDirectAnthropicModel,
+  logAnthropicContextEdits,
+  resolveAnthropicContextManagementBetaHeader,
   resolveAnthropicPayloadPolicy,
 } from "./anthropic-payload-policy.js";
 import {
@@ -145,7 +149,6 @@ type AnthropicTransportModel = Model<"anthropic-messages"> & {
 
 type AnthropicTransportOptions = AnthropicOptions &
   Pick<SimpleStreamOptions, "reasoning" | "thinkingBudgets" | "stop"> & {
-    anthropicServerCompaction?: boolean;
     authProfileId?: string;
   };
 type AnthropicMessagesClient = {
@@ -229,14 +232,6 @@ function resolveAnthropicMessagesMaxTokens(params: {
           Math.floor(contextWindow / ANTHROPIC_MESSAGES_FALLBACK_CONTEXT_DIVISOR),
         ),
       );
-}
-
-function isDirectAnthropicModel(model: Pick<AnthropicTransportModel, "provider" | "baseUrl">) {
-  if (normalizeLowercaseStringOrEmpty(model.provider) !== "anthropic") {
-    return false;
-  }
-  const endpointClass = resolveProviderEndpoint(model).endpointClass;
-  return endpointClass === "default" || endpointClass === "anthropic-public";
 }
 
 function isKimiAnthropicProvider(provider: string | undefined): boolean {
@@ -1106,7 +1101,9 @@ function resolveAnthropicTransportOptions(
     toolChoice: options?.toolChoice,
     thinkingBudgets: options?.thinkingBudgets,
     reasoning,
-    ...(options?.anthropicServerCompaction === true ? { anthropicServerCompaction: true } : {}),
+    anthropicServerCompaction: options?.anthropicServerCompaction,
+    anthropicCompactThreshold: options?.anthropicCompactThreshold,
+    cacheTtlPruning: options?.cacheTtlPruning,
     ...(options?.authProfileId ? { authProfileId: options.authProfileId } : {}),
   });
   if (reasoning === "off") {
@@ -1193,15 +1190,24 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
         usedCompactionReplay = builtParams.usedCompactionReplay;
         let params = builtParams.params;
         const toolProjection = builtParams.toolProjection;
+        applyAnthropicContextManagementToRequest(
+          params,
+          model,
+          transportOptions,
+          directApiKeyBetaHeader,
+        );
         const nextParams = await transportOptions.onPayload?.(params, model);
         if (nextParams !== undefined) {
           params = nextParams as Record<string, unknown>;
         }
         applyClaudeRequestContract(params, model);
-        const bindingHeaders = applyAnthropicThinkingBindingControls(
+        const betaHeader = resolveAnthropicContextManagementBetaHeader(
           params,
           directApiKeyBetaHeader,
         );
+        const bindingHeaders =
+          applyAnthropicThinkingBindingControls(params, betaHeader) ??
+          (betaHeader !== undefined ? { "anthropic-beta": betaHeader } : undefined);
         const { response, stream: anthropicStream } = await client.messages.stream(
           { ...params, stream: true },
           { signal: transportOptions.signal, headers: bindingHeaders },
@@ -1718,6 +1724,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             continue;
           }
           if (event.type === "message_delta") {
+            logAnthropicContextEdits(event);
             const delta = event.delta as
               | { stop_reason?: string; stop_details?: unknown }
               | undefined;

--- a/packages/ai/src/transports/provider-compaction-replay.test.ts
+++ b/packages/ai/src/transports/provider-compaction-replay.test.ts
@@ -359,6 +359,7 @@ describe("prepared compaction replay eligibility", () => {
     api: "anthropic-messages",
     provider: "anthropic",
     id: "claude-sonnet-4-6",
+    baseUrl: "https://api.anthropic.com",
   };
 
   it.each([

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -21,7 +21,6 @@ const ANTHROPIC_DEFAULT_BETAS = [
   "interleaved-thinking-2025-05-14",
 ];
 const ANTHROPIC_CONTEXT_1M_BETA = "context-1m-2025-08-07";
-const ANTHROPIC_COMPACTION_BETA = "compact-2026-01-12";
 const ANTHROPIC_OAUTH_BETAS = ["oauth-2025-04-20", "claude-code-20250219"];
 
 const XAI_FAST_MODEL_IDS = new Map<string, string>([
@@ -221,54 +220,6 @@ function createAnthropicFastModeWrapper(baseStreamFn: StreamFn | undefined, fast
   return createAnthropicServiceTierWrapper(baseStreamFn, fastMode ? "auto" : "standard_only");
 }
 
-function createAnthropicCompactionWrapper(
-  baseStreamFn: StreamFn | undefined,
-  extraParams: Record<string, unknown> | undefined,
-) {
-  const underlying = baseStreamFn ?? (() => ({}) as ReturnType<StreamFn>);
-  return ((model, context, options) => {
-    if (
-      extraParams?.anthropicServerCompaction !== true ||
-      isAnthropicOauthApiKey(options?.apiKey) ||
-      !isDirectAnthropicModel(model)
-    ) {
-      return underlying(model, context, options);
-    }
-    const originalOnPayload = options?.onPayload;
-    const configuredThreshold =
-      typeof extraParams.anthropicCompactThreshold === "number"
-        ? Math.floor(extraParams.anthropicCompactThreshold)
-        : undefined;
-    const threshold = Math.max(
-      50_000,
-      configuredThreshold ?? Math.floor((model.contextWindow ?? 0) * 0.7),
-    );
-    return underlying(model, context, {
-      ...options,
-      headers: {
-        ...options?.headers,
-        "anthropic-beta": [options?.headers?.["anthropic-beta"], ANTHROPIC_COMPACTION_BETA]
-          .filter(Boolean)
-          .join(","),
-      },
-      onPayload: (payload) => {
-        if (payload && typeof payload === "object") {
-          const payloadObj = payload as Record<string, unknown>;
-          payloadObj.context_management ??= {
-            edits: [
-              {
-                type: "compact_20260112",
-                trigger: { type: "input_tokens", value: threshold },
-              },
-            ],
-          };
-        }
-        return originalOnPayload?.(payload, model);
-      },
-    });
-  }) as StreamFn;
-}
-
 import { isAnthropicFamilyCacheTtlEligible } from "../llm/providers/stream-wrappers/anthropic-family-cache-semantics.js";
 import { createAnthropicToolPayloadCompatibilityWrapper } from "../llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.js";
 import { createGoogleThinkingPayloadWrapper } from "../llm/providers/stream-wrappers/google.js";
@@ -385,9 +336,6 @@ function installFullProviderRuntimeDepsForTest() {
         const fastMode = resolveAnthropicFastMode(params.context.extraParams);
         if (fastMode !== undefined) {
           streamFn = createAnthropicFastModeWrapper(streamFn, fastMode);
-        }
-        if (params.context.extraParams?.anthropicServerCompaction === true) {
-          streamFn = createAnthropicCompactionWrapper(streamFn, params.context.extraParams);
         }
         return streamFn;
       }
@@ -3257,50 +3205,6 @@ describe("applyExtraParamsToAgent", () => {
     });
 
     expect(payload.service_tier).toBe(expected);
-  });
-
-  it("injects configured Anthropic server compaction through the provider runtime", () => {
-    const cfg = buildModelConfig("anthropic/claude-sonnet-4-5", {
-      anthropicServerCompaction: true,
-      anthropicCompactThreshold: 120_000,
-    });
-    const payload = runAnthropicServiceTierCase({ cfg });
-    const headers = runAnthropicHeaderCase({
-      cfg,
-      modelId: "claude-sonnet-4-5",
-      options: { apiKey: "sk-ant-api03-test-key" },
-    });
-
-    expect(payload.context_management).toEqual({
-      edits: [
-        {
-          type: "compact_20260112",
-          trigger: { type: "input_tokens", value: 120_000 },
-        },
-      ],
-    });
-    expect(headers?.["anthropic-beta"]).toContain(ANTHROPIC_COMPACTION_BETA);
-  });
-
-  it.each([
-    {
-      name: "is omitted",
-      extraParamsOverride: {},
-    },
-    {
-      name: "uses OAuth auth",
-      extraParamsOverride: { anthropicServerCompaction: true },
-      options: { apiKey: "sk-ant-oat-test-token" },
-    },
-    {
-      name: "uses a proxy endpoint",
-      extraParamsOverride: { anthropicServerCompaction: true },
-      baseUrl: "https://proxy.example.test/v1",
-    },
-  ])("does not inject Anthropic server compaction when the opt-in $name", (params) => {
-    const payload = runAnthropicServiceTierCase(params);
-
-    expect(payload).not.toHaveProperty("context_management");
   });
 
   it.each([

--- a/src/agents/embedded-agent-runner/cache-ttl.test.ts
+++ b/src/agents/embedded-agent-runner/cache-ttl.test.ts
@@ -91,7 +91,7 @@ describe("isCacheTtlEligibleProvider", () => {
 });
 
 describe("readLastCacheTtlTimestamp", () => {
-  it("returns the latest matching timestamp for the active provider/model", () => {
+  it("returns the latest matching timestamp while ignoring projection metadata", () => {
     // Replay only reuses cache TTL entries scoped to the current model target;
     // stale entries for other providers must not reset pruning clocks.
     const sessionManager = {
@@ -103,6 +103,8 @@ describe("readLastCacheTtlTimestamp", () => {
             timestamp: 1_700_000_000_000,
             provider: "anthropic",
             modelId: "claude-sonnet-4-5",
+            prunedToolResults: [{ key: "tool:old:42", mode: "hard" }],
+            ambiguousToolResultBaseKeys: [],
           },
         },
         {

--- a/src/agents/embedded-agent-runner/cache-ttl.ts
+++ b/src/agents/embedded-agent-runner/cache-ttl.ts
@@ -79,17 +79,19 @@ function matchesCacheTtlContext(
   return true;
 }
 
+/** Transcript entries visible to cache-TTL marker readers; stores without entries read as empty. */
+export function readCacheTtlEntries(sessionManager: unknown): CustomEntryLike[] {
+  const sm = sessionManager as { getEntries?: () => CustomEntryLike[] };
+  return sm?.getEntries ? sm.getEntries() : [];
+}
+
 /** Reads the most recent cache-TTL marker that matches the optional provider/model context. */
 export function readLastCacheTtlTimestamp(
   sessionManager: unknown,
   context?: CacheTtlContext,
 ): number | null {
-  const sm = sessionManager as { getEntries?: () => CustomEntryLike[] };
-  if (!sm?.getEntries) {
-    return null;
-  }
   try {
-    const entries = sm.getEntries();
+    const entries = readCacheTtlEntries(sessionManager);
     let last: number | null = null;
     for (let i = entries.length - 1; i >= 0; i--) {
       const entry = entries[i];

--- a/src/agents/embedded-agent-runner/run.compaction-runtime.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.compaction-runtime.test-support.ts
@@ -319,6 +319,7 @@ async function createRecoveryFixture(state: OpenClawTestState, options: FixtureO
         replacements: new Map(),
         frozen: new Set(),
         ambiguousBaseKeys: new Set(),
+        restoredCacheTtl: new Map(),
         sourceTextByKey: new Map(),
       };
       return recoverEmbeddedRunOverflow({

--- a/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
@@ -181,6 +181,7 @@ function makeInput(overrides: RecoveryInputOverrides = {}): RecoveryInput {
       replacements: new Map(),
       frozen: new Set(),
       ambiguousBaseKeys: new Set(),
+      restoredCacheTtl: new Map(),
       sourceTextByKey: new Map(),
     },
     attemptCompactionCount: 0,
@@ -371,6 +372,7 @@ describe("recoverEmbeddedRunOverflow", () => {
       replacements: new Map(),
       frozen: new Set(["tool:call_1:1"]),
       ambiguousBaseKeys: new Set(),
+      restoredCacheTtl: new Map(),
       sourceTextByKey: new Map(),
     };
     const messagesSnapshot = [

--- a/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../tools/computer-tool.js", () => ({
   invalidateComputerFrameIfMissing: hoisted.invalidateComputerFrameIfMissing,
 }));
 vi.mock("../cache-ttl.js", () => ({
+  readCacheTtlEntries: () => [],
   isCacheTtlEligibleProvider: hoisted.isCacheTtlEligibleProvider,
   readLastCacheTtlTimestamp: hoisted.readLastCacheTtlTimestamp,
 }));
@@ -218,6 +219,24 @@ describe("installEmbeddedAttemptContextGuards", () => {
         activeContextEngine: { info: { id: "test-engine", ownsCompaction: true } },
         getServerToolClearingEnabled: () => serverClearing,
       });
+      const earlierProjection = "[trimmed by an earlier client-side prune]";
+      if (serverClearing) {
+        // A projection made before this route took over (proxy/OAuth turn, or restored
+        // from the transcript marker) must keep replaying under server clearing.
+        const key = "tool:old-tool:1";
+        input.toolResultPromptProjectionState.replacements.set(key, {
+          message: {
+            role: "toolResult",
+            toolCallId: "old-tool",
+            toolName: "read",
+            content: [{ type: "text", text: earlierProjection }],
+            timestamp: 1,
+          } as AgentMessage,
+          cacheTtl: "soft",
+        });
+        input.toolResultPromptProjectionState.sourceTextByKey.set(key, ["x".repeat(5_000)]);
+        input.toolResultPromptProjectionState.frozen.add(key);
+      }
       input.attempt = {
         ...input.attempt,
         config: { agents: { defaults: { contextPruning: { mode: "cache-ttl" } } } } as never,
@@ -271,7 +290,7 @@ describe("installEmbeddedAttemptContextGuards", () => {
       const firstTool = engineMessages?.find((message) => message.role === "toolResult");
       expect(firstTool?.content[0]).toMatchObject({
         type: "text",
-        text: serverClearing ? "x".repeat(5_000) : expect.stringContaining("[Tool result trimmed:"),
+        text: serverClearing ? earlierProjection : expect.stringContaining("[Tool result trimmed:"),
       });
 
       await input.activeSession.agent.transformContext?.(messages, new AbortController().signal);

--- a/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { AgentSession } from "../../sessions/index.js";
+import { createToolResultPromptProjectionState } from "../session-prompt-state.js";
 import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -58,6 +59,8 @@ function createInput(overrides: Record<string, unknown> = {}) {
     getPromptCache: () => undefined,
     getPromptCacheRetention: () => "short" as const,
     getCompactionReplayEnabled: () => false,
+    getServerToolClearingEnabled: () => false,
+    toolResultPromptProjectionState: createToolResultPromptProjectionState(),
     getSystemPrompt: () => "system prompt",
     isOpenAIResponsesApi: false,
     repairToolUseResultPairing: false,
@@ -205,74 +208,78 @@ describe("installEmbeddedAttemptContextGuards", () => {
     expect(input.activeSession.agent.transformContext).toBe(originalTransform);
   });
 
-  it("projects expired cache-TTL history before context-engine assembly once per attempt", async () => {
-    const now = Date.now();
-    hoisted.isCacheTtlEligibleProvider.mockReturnValue(true);
-    hoisted.readLastCacheTtlTimestamp.mockReturnValue(now - 300_000);
-    const input = createInput({
-      activeContextEngine: { info: { id: "test-engine", ownsCompaction: true } },
-    });
-    input.attempt = {
-      ...input.attempt,
-      config: { agents: { defaults: { contextPruning: { mode: "cache-ttl" } } } } as never,
-      model: { api: "anthropic-messages", contextWindow: 2_048 },
-      modelId: "claude-sonnet-4-6",
-      provider: "anthropic",
-    };
-    const originalTransform = vi.fn(async (messages: AgentMessage[]) => messages);
-    input.activeSession.agent.transformContext = originalTransform;
-    let engineMessages: AgentMessage[] | undefined;
-    hoisted.installContextEngineLoopHook.mockImplementation(({ agent }) => {
-      const previous = agent.transformContext;
-      agent.transformContext = async (messages: AgentMessage[], signal: AbortSignal) => {
-        const projected = await previous(messages, signal);
-        engineMessages = projected;
-        return projected;
-      };
-      return vi.fn(() => {
-        agent.transformContext = previous;
+  it.each([false, true])(
+    "keeps cache-TTL tool-loop bytes stable with server clearing=%s",
+    async (serverClearing) => {
+      const now = Date.now();
+      hoisted.isCacheTtlEligibleProvider.mockReturnValue(true);
+      hoisted.readLastCacheTtlTimestamp.mockReturnValue(now - 300_000);
+      const input = createInput({
+        activeContextEngine: { info: { id: "test-engine", ownsCompaction: true } },
+        getServerToolClearingEnabled: () => serverClearing,
       });
-    });
-    const messages = [
-      { role: "user", content: "first", timestamp: 1 },
-      { role: "assistant", content: [{ type: "text", text: "a1" }], timestamp: 1 },
-      {
-        role: "toolResult",
-        toolCallId: "old-tool",
-        toolName: "read",
-        content: [{ type: "text", text: "x".repeat(5_000) }],
-        timestamp: 1,
-      },
-      { role: "assistant", content: [{ type: "text", text: "a2" }], timestamp: 1 },
-      { role: "assistant", content: [{ type: "text", text: "a3" }], timestamp: 1 },
-      { role: "assistant", content: [{ type: "text", text: "a4" }], timestamp: 1 },
-    ] as AgentMessage[];
-
-    const guards = installEmbeddedAttemptContextGuards(input as never);
-    expect(hoisted.isCacheTtlEligibleProvider).toHaveBeenCalledExactlyOnceWith(
-      "anthropic",
-      "claude-sonnet-4-6",
-      "anthropic-messages",
-    );
-    expect(hoisted.readLastCacheTtlTimestamp).toHaveBeenCalledExactlyOnceWith(
-      input.sessionManager,
-      {
-        provider: "anthropic",
+      input.attempt = {
+        ...input.attempt,
+        config: { agents: { defaults: { contextPruning: { mode: "cache-ttl" } } } } as never,
+        model: { api: "anthropic-messages", contextWindow: 2_048 },
         modelId: "claude-sonnet-4-6",
-      },
-    );
-    await input.activeSession.agent.transformContext?.(messages, new AbortController().signal);
-    const firstTool = engineMessages?.find((message) => message.role === "toolResult");
-    expect(firstTool?.content[0]).toMatchObject({
-      type: "text",
-      text: expect.stringContaining("[Tool result trimmed:"),
-    });
+        provider: "anthropic",
+      };
+      const originalTransform = vi.fn(async (messages: AgentMessage[]) => messages);
+      input.activeSession.agent.transformContext = originalTransform;
+      let engineMessages: AgentMessage[] | undefined;
+      hoisted.installContextEngineLoopHook.mockImplementation(({ agent }) => {
+        const previous = agent.transformContext;
+        agent.transformContext = async (messages: AgentMessage[], signal: AbortSignal) => {
+          const projected = await previous(messages, signal);
+          engineMessages = projected;
+          return projected;
+        };
+        return vi.fn(() => {
+          agent.transformContext = previous;
+        });
+      });
+      const messages = [
+        { role: "user", content: "first", timestamp: 1 },
+        { role: "assistant", content: [{ type: "text", text: "a1" }], timestamp: 1 },
+        {
+          role: "toolResult",
+          toolCallId: "old-tool",
+          toolName: "read",
+          content: [{ type: "text", text: "x".repeat(5_000) }],
+          timestamp: 1,
+        },
+        { role: "assistant", content: [{ type: "text", text: "a2" }], timestamp: 1 },
+        { role: "assistant", content: [{ type: "text", text: "a3" }], timestamp: 1 },
+        { role: "assistant", content: [{ type: "text", text: "a4" }], timestamp: 1 },
+      ] as AgentMessage[];
 
-    await input.activeSession.agent.transformContext?.(messages, new AbortController().signal);
-    const secondTool = engineMessages?.find((message) => message.role === "toolResult");
-    expect(secondTool?.content[0]).toMatchObject({ type: "text", text: "x".repeat(5_000) });
+      const guards = installEmbeddedAttemptContextGuards(input as never);
+      expect(hoisted.isCacheTtlEligibleProvider).toHaveBeenCalledExactlyOnceWith(
+        "anthropic",
+        "claude-sonnet-4-6",
+        "anthropic-messages",
+      );
+      expect(hoisted.readLastCacheTtlTimestamp).toHaveBeenCalledExactlyOnceWith(
+        input.sessionManager,
+        {
+          provider: "anthropic",
+          modelId: "claude-sonnet-4-6",
+        },
+      );
+      await input.activeSession.agent.transformContext?.(messages, new AbortController().signal);
+      const firstTool = engineMessages?.find((message) => message.role === "toolResult");
+      expect(firstTool?.content[0]).toMatchObject({
+        type: "text",
+        text: serverClearing ? "x".repeat(5_000) : expect.stringContaining("[Tool result trimmed:"),
+      });
 
-    guards.remove();
-    expect(input.activeSession.agent.transformContext).toBe(originalTransform);
-  });
+      await input.activeSession.agent.transformContext?.(messages, new AbortController().signal);
+      const secondTool = engineMessages?.find((message) => message.role === "toolResult");
+      expect(secondTool?.content).toEqual(firstTool?.content);
+
+      guards.remove();
+      expect(input.activeSession.agent.transformContext).toBe(originalTransform);
+    },
+  );
 });

--- a/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
@@ -11,6 +11,7 @@ import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-tr
 import { closeOpenClawAgentDatabasesForTest } from "../../../state/openclaw-agent-db.js";
 import { FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE } from "../../bootstrap-files.js";
 import { SessionManager } from "../../sessions/session-manager.js";
+import { createToolResultPromptProjectionState } from "../session-prompt-state.js";
 
 const hoisted = vi.hoisted(() => ({
   runAgentEndSideEffects: vi.fn(),
@@ -76,6 +77,7 @@ describe("embedded attempt phase lifecycle state", () => {
       } as never,
       activeSession: activeSession as never,
       sessionManager: sessionManager as never,
+      toolResultPromptProjectionState: createToolResultPromptProjectionState(),
       withOwnedTranscriptWrite: async (operation) => await operation(),
       subscription: {
         toolMetas: [],
@@ -157,6 +159,7 @@ describe("embedded attempt phase lifecycle state", () => {
       } as never,
       activeSession: activeSession as never,
       sessionManager: sessionManager as never,
+      toolResultPromptProjectionState: createToolResultPromptProjectionState(),
       withOwnedTranscriptWrite: async (operation) => await operation(),
       subscription: {
         toolMetas: [{ toolName: "exec", asyncStarted: true }],
@@ -243,6 +246,7 @@ describe("embedded attempt phase lifecycle state", () => {
       } as never,
       activeSession: activeSession as never,
       sessionManager: sessionManager as never,
+      toolResultPromptProjectionState: createToolResultPromptProjectionState(),
       withOwnedTranscriptWrite: async (operation) => await operation(),
       subscription: {
         toolMetas: [

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
@@ -50,6 +50,7 @@ const projectionState: ToolResultPromptProjectionState = {
   replacements: new Map(),
   frozen: new Set(),
   ambiguousBaseKeys: new Set(),
+  restoredCacheTtl: new Map(),
   sourceTextByKey: new Map(),
 };
 

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -171,6 +171,7 @@ export async function runEmbeddedAttemptPromptPhase(input: {
       request,
       sessionAgentId: input.context.sessionAgentId,
       sessionManager,
+      toolResultPromptProjectionState: input.context.toolResultPromptProjectionState,
       prePromptMessageCount: input.lifecycle.getPrePromptMessageCount(),
       replaceSessionMessages: (messages) => {
         activeSession.agent.state.messages = messages;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
@@ -5,6 +5,7 @@ import { testing } from "../../openai-transport-stream.test-support.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { SessionManager } from "../../sessions/index.js";
 import { makeAgentAssistantMessage } from "../../test-helpers/agent-message-fixtures.js";
+import { createToolResultPromptProjectionState } from "../session-prompt-state.js";
 import {
   handleEmbeddedAttemptMidTurnPrecheck,
   prepareEmbeddedAttemptPromptPreflight,
@@ -200,6 +201,7 @@ describe("attempt prompt preflight", () => {
 
   it("routes a mid-turn compaction request with its measured budget", () => {
     const outcome = handleEmbeddedAttemptMidTurnPrecheck({
+      toolResultPromptProjectionState: createToolResultPromptProjectionState(),
       attempt,
       request,
       sessionAgentId: "test",
@@ -226,6 +228,7 @@ describe("attempt prompt preflight", () => {
     const messagesBefore = sessionManager.buildSessionContext().messages;
     const replaceSessionMessages = vi.fn();
     const outcome = handleEmbeddedAttemptMidTurnPrecheck({
+      toolResultPromptProjectionState: createToolResultPromptProjectionState(),
       attempt,
       request: { ...request, route: "truncate_tool_results_only" },
       sessionAgentId: "test",
@@ -249,6 +252,7 @@ describe("attempt prompt preflight", () => {
 
   it("keeps the compaction fallback when persisted truncation cannot inspect history", () => {
     const outcome = handleEmbeddedAttemptMidTurnPrecheck({
+      toolResultPromptProjectionState: createToolResultPromptProjectionState(),
       attempt,
       request: { ...request, route: "truncate_tool_results_only" },
       sessionAgentId: "test",
@@ -267,6 +271,7 @@ describe("attempt prompt preflight", () => {
     );
     const replaceSessionMessages = vi.fn();
     const outcome = handleEmbeddedAttemptMidTurnPrecheck({
+      toolResultPromptProjectionState: createToolResultPromptProjectionState(),
       attempt: { ...attempt, contextTokenBudget: 100 },
       request: { ...request, route: "truncate_tool_results_only" },
       sessionAgentId: "test",

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
@@ -9,6 +9,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { SessionManager } from "../../sessions/index.js";
 import { log } from "../logger.js";
+import type { ToolResultPromptProjectionState } from "../session-prompt-state.js";
 import {
   resolveLiveToolResultMaxChars,
   truncateOversizedToolResultsInSessionManager,
@@ -59,6 +60,7 @@ export function handleEmbeddedAttemptMidTurnPrecheck(input: {
   request: MidTurnPrecheckRequest;
   sessionAgentId: string;
   sessionManager: SessionManager;
+  toolResultPromptProjectionState: ToolResultPromptProjectionState;
   prePromptMessageCount: number;
   replaceSessionMessages: (messages: AgentMessage[]) => void;
 }): {
@@ -88,6 +90,7 @@ export function handleEmbeddedAttemptMidTurnPrecheck(input: {
     });
     const truncationResult = truncateOversizedToolResultsInSessionManager({
       sessionManager: input.sessionManager,
+      projectionState: input.toolResultPromptProjectionState,
       contextWindowTokens: contextTokenBudget,
       maxCharsOverride: toolResultMaxChars,
       sessionFile: attempt.sessionFile,

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   prepareSessionManager: vi.fn(),
   prepareTrajectory: vi.fn(),
   prepareTransport: vi.fn(),
+  restoreProjections: vi.fn(),
 }));
 
 vi.mock("../../anthropic-payload-log.js", () => ({
@@ -19,6 +20,9 @@ vi.mock("../../anthropic-payload-log.js", () => ({
 vi.mock("../../cache-trace.js", () => ({ createCacheTrace: mocks.createCacheTrace }));
 vi.mock("../session-prompt-state.js", () => ({
   getEmbeddedSessionPromptState: mocks.getSessionPromptState,
+}));
+vi.mock("../tool-result-truncation.js", () => ({
+  restoreCacheTtlToolResultProjections: mocks.restoreProjections,
 }));
 vi.mock("./attempt-setup.js", () => ({
   installEmbeddedAttemptContextGuards: mocks.installContextGuards,
@@ -44,7 +48,7 @@ type PrepareInput = Parameters<typeof prepareEmbeddedAttemptSessionRuntime>[0];
 
 function createFixture() {
   const order: string[] = [];
-  const sessionManager = { kind: "manager" };
+  const sessionManager = { kind: "manager", getBranch: () => [] };
   const activeSession = {
     messages: [{ role: "user" }, { role: "assistant" }],
     sessionId: "active-session",

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
@@ -4,6 +4,7 @@ import { createCacheTrace } from "../../cache-trace.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import type { AgentSession } from "../../sessions/index.js";
+import { readCacheTtlEntries } from "../cache-ttl.js";
 import { getProviderPromptState } from "../provider-prompt-state.js";
 import { getEmbeddedSessionPromptState } from "../session-prompt-state.js";
 import { restoreCacheTtlToolResultProjections } from "../tool-result-truncation.js";
@@ -167,7 +168,7 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
   if (!input.isRawModelRun) {
     restoreCacheTtlToolResultProjections(
       toolResultPromptProjectionState,
-      sessionManager.getBranch(),
+      readCacheTtlEntries(sessionManager),
     );
   }
   const settleTracker = createEmbeddedAttemptSessionSettleTracker(activeSession);

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
@@ -6,6 +6,7 @@ import type { guardSessionManager } from "../../session-tool-result-guard-wrappe
 import type { AgentSession } from "../../sessions/index.js";
 import { getProviderPromptState } from "../provider-prompt-state.js";
 import { getEmbeddedSessionPromptState } from "../session-prompt-state.js";
+import { restoreCacheTtlToolResultProjections } from "../tool-result-truncation.js";
 import type { createEmbeddedAttemptExternalAbortController } from "./attempt-finalize.js";
 import {
   prepareEmbeddedAttemptAgentSession,
@@ -163,6 +164,12 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
   // cannot rewrite the provider prompt-cache tail between turns (#99495).
   const sessionPromptState = getEmbeddedSessionPromptState(attempt.sessionId);
   const toolResultPromptProjectionState = sessionPromptState.toolResults;
+  if (!input.isRawModelRun) {
+    restoreCacheTtlToolResultProjections(
+      toolResultPromptProjectionState,
+      sessionManager.getBranch(),
+    );
+  }
   const settleTracker = createEmbeddedAttemptSessionSettleTracker(activeSession);
   input.externalAbortController.setActiveSessionAbort(settleTracker.abortActiveSession);
   input.lifecycle.onSessionSettleTrackerReady(settleTracker.buildAbortSettlePromise);
@@ -187,6 +194,8 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
     onCurrentTurnImageFailure: recordCurrentTurnImageFailure,
     getPromptCacheRetention: () => transport.effectivePromptCacheRetention,
     getCompactionReplayEnabled: () => transport.compactionReplayEnabled,
+    getServerToolClearingEnabled: () => transport.serverToolClearingEnabled,
+    toolResultPromptProjectionState,
     getSystemPrompt: () => state.systemPromptText,
     isOpenAIResponsesApi,
     repairToolUseResultPairing: transcriptPolicy.repairToolUseResultPairing,

--- a/src/agents/embedded-agent-runner/run/attempt-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-settle.ts
@@ -436,6 +436,7 @@ export async function runEmbeddedAttemptSettledPhase(
           attempt,
           activeSession,
           sessionManager,
+          toolResultPromptProjectionState,
           withOwnedTranscriptWrite: input.sessionLock.withOwnedTranscriptWrite,
           state: streamSettleState,
           getRunAbortDeadlineAtMs,

--- a/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
@@ -7,6 +7,7 @@ import { attachRuntimePromptMediaFacts } from "../../../media/media-facts.js";
 import type { ProviderRuntimePluginHandle } from "../../../plugins/provider-hook-runtime.js";
 import { resolveSandboxContext as resolveRealSandboxContext } from "../../sandbox/context.js";
 import { castAgentMessage } from "../../test-helpers/agent-message-fixtures.js";
+import { createToolResultPromptProjectionState } from "../session-prompt-state.js";
 import { buildEmbeddedForegroundPromptContext } from "./agent-end-context.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
@@ -142,6 +143,8 @@ describe("prepareEmbeddedAttemptSetup", () => {
       getPromptCache: () => undefined,
       getPromptCacheRetention: () => undefined,
       getCompactionReplayEnabled: () => false,
+      getServerToolClearingEnabled: () => false,
+      toolResultPromptProjectionState: createToolResultPromptProjectionState(),
       getSystemPrompt: () => "",
       isOpenAIResponsesApi: false,
       repairToolUseResultPairing: false,

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -353,9 +353,6 @@ export function installEmbeddedAttemptContextGuards(input: {
         ? await previousCacheTtlTransform.call(activeSession.agent, messages, signal)
         : messages;
       const sourceMessages = Array.isArray(transformed) ? transformed : messages;
-      if (input.getServerToolClearingEnabled()) {
-        return sourceMessages;
-      }
       const projected = pruneExpiredCacheTtlToolResults({
         messages: sourceMessages,
         settings: cacheTtlSettings,
@@ -364,6 +361,9 @@ export function installEmbeddedAttemptContextGuards(input: {
         dropThinkingBlocksForEstimate: input.dropThinkingBlocksForEstimate,
         now: Date.now(),
         projectionState: input.toolResultPromptProjectionState,
+        // Server-side clearing owns new rounds; earlier client projections still
+        // replay so the prefix already sent for this session does not change.
+        pruneNewRounds: !input.getServerToolClearingEnabled(),
         onPruned: () => {
           lastCacheTouchAt = Date.now();
         },

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -55,6 +55,7 @@ import {
   mapSandboxSkillUsagePaths,
   resolveSandboxSkillRuntimeInputs,
 } from "../sandbox-skills.js";
+import type { ToolResultPromptProjectionState } from "../session-prompt-state.js";
 import {
   installContextEngineLoopHook,
   installToolResultContextGuard,
@@ -279,6 +280,8 @@ export function installEmbeddedAttemptContextGuards(input: {
   getPromptCache: () => EmbeddedRunAttemptResult["promptCache"];
   getPromptCacheRetention: () => PromptCacheRetention;
   getCompactionReplayEnabled: () => boolean;
+  getServerToolClearingEnabled: () => boolean;
+  toolResultPromptProjectionState: ToolResultPromptProjectionState;
   getSystemPrompt: () => string;
   onCurrentTurnImageFailure?: (count: number) => void;
   isOpenAIResponsesApi: boolean;
@@ -350,6 +353,9 @@ export function installEmbeddedAttemptContextGuards(input: {
         ? await previousCacheTtlTransform.call(activeSession.agent, messages, signal)
         : messages;
       const sourceMessages = Array.isArray(transformed) ? transformed : messages;
+      if (input.getServerToolClearingEnabled()) {
+        return sourceMessages;
+      }
       const projected = pruneExpiredCacheTtlToolResults({
         messages: sourceMessages,
         settings: cacheTtlSettings,
@@ -357,10 +363,11 @@ export function installEmbeddedAttemptContextGuards(input: {
         lastCacheTouchAt,
         dropThinkingBlocksForEstimate: input.dropThinkingBlocksForEstimate,
         now: Date.now(),
+        projectionState: input.toolResultPromptProjectionState,
+        onPruned: () => {
+          lastCacheTouchAt = Date.now();
+        },
       });
-      if (projected !== sourceMessages) {
-        lastCacheTouchAt = Date.now();
-      }
       return projected;
     };
   }

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -814,6 +814,7 @@ vi.mock("../../transcript-policy.js", () => ({
 }));
 
 vi.mock("../cache-ttl.js", () => ({
+  readCacheTtlEntries: () => [],
   appendCacheTtlTimestamp: (
     sessionManager: { appendCustomEntry?: (customType: string, data: unknown) => void },
     data: unknown,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
@@ -12,6 +12,11 @@ import { attachRuntimePromptMediaFacts } from "../../../media/media-facts.js";
 import { SessionManager } from "../../sessions/index.js";
 import { castAgentMessage } from "../../test-helpers/agent-message-fixtures.js";
 import { testing as extraParamsTesting } from "../extra-params.test-support.js";
+import {
+  clearEmbeddedSessionPromptStates,
+  createToolResultPromptProjectionState,
+  getEmbeddedSessionPromptState,
+} from "../session-prompt-state.js";
 import { RUN_LIVENESS_JOIN_TIMEOUT_MS } from "./abortable.js";
 import {
   prepareEmbeddedAttemptTransport,
@@ -50,6 +55,7 @@ function createSettleFixture(overrides?: Partial<SettleInput>): SettleInput {
       messages: [],
     },
     sessionManager,
+    toolResultPromptProjectionState: createToolResultPromptProjectionState(),
     withOwnedTranscriptWrite: async (operation: () => unknown) => await operation(),
     subscription: {
       toolMetas: [],
@@ -122,6 +128,58 @@ describe("settleEmbeddedAttemptStream liveness", () => {
     expect(flushed).toHaveBeenCalledWith({ reason: "pre_compaction", attemptAccepted: false });
     expect(result.sessionIdUsed).toBe("sess-settle-1");
   });
+
+  it("persists the active projection after session-state eviction", async () => {
+    const sessionId = "cache-ttl-settle-evicted";
+    const otherSessionIds = Array.from({ length: 65 }, (_, index) => `cache-ttl-other-${index}`);
+    const state = getEmbeddedSessionPromptState(sessionId).toolResults;
+    const key = "tool:old-read:42";
+    state.replacements.set(key, {
+      message: {
+        role: "toolResult",
+        toolCallId: "old-read",
+        toolName: "read",
+        content: [{ type: "text", text: "kept prefix\n...\nkept suffix" }],
+        isError: false,
+        timestamp: 42,
+      },
+      cacheTtl: "soft",
+    });
+    state.sourceTextByKey.set(key, ["original full output"]);
+    state.frozen.add(key);
+    const input = {
+      ...createSettleFixture(),
+      toolResultPromptProjectionState: state,
+    };
+    input.attempt = {
+      ...input.attempt,
+      sessionId,
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      model: { ...input.attempt.model, api: "anthropic-messages" },
+      config: { agents: { defaults: { contextPruning: { mode: "cache-ttl" } } } },
+    };
+    try {
+      for (const otherSessionId of otherSessionIds) {
+        getEmbeddedSessionPromptState(otherSessionId);
+      }
+      expect(getEmbeddedSessionPromptState(sessionId).toolResults).not.toBe(state);
+
+      await settleEmbeddedAttemptStream(input);
+
+      expect(input.sessionManager.getEntries()).toContainEqual(
+        expect.objectContaining({
+          type: "custom",
+          customType: "openclaw.cache-ttl",
+          data: expect.objectContaining({
+            prunedToolResults: [{ key, mode: "soft" }],
+          }),
+        }),
+      );
+    } finally {
+      clearEmbeddedSessionPromptStates([sessionId, ...otherSessionIds]);
+    }
+  });
 });
 
 describe("prepareEmbeddedAttemptTransport", () => {
@@ -135,9 +193,42 @@ describe("prepareEmbeddedAttemptTransport", () => {
   });
 
   it.each([
-    { compaction: true, apiKey: "test-api-key", replayEnabled: true },
-    { compaction: true, apiKey: "test-sk-ant-oat-oauth", replayEnabled: false },
-    { compaction: false, apiKey: "test-api-key", replayEnabled: false },
+    {
+      compaction: true,
+      apiKey: "test-api-key",
+      replayEnabled: true,
+      pruning: false,
+      clearing: false,
+    },
+    {
+      compaction: true,
+      apiKey: "test-sk-ant-oat-oauth",
+      replayEnabled: false,
+      pruning: true,
+      clearing: false,
+    },
+    {
+      compaction: false,
+      apiKey: "test-api-key",
+      replayEnabled: false,
+      pruning: true,
+      clearing: true,
+    },
+    {
+      compaction: true,
+      apiKey: "test-api-key",
+      replayEnabled: true,
+      pruning: true,
+      clearing: true,
+    },
+    {
+      compaction: false,
+      apiKey: "test-api-key",
+      replayEnabled: false,
+      pruning: true,
+      clearing: false,
+      baseUrl: "https://proxy.example.test/anthropic",
+    },
   ])("prepares transport and replay from resolved auth/config: %j", async (testCase) => {
     const streamFn = vi.fn();
     bindStreamLlmRuntime(streamFn, {
@@ -152,12 +243,16 @@ describe("prepareEmbeddedAttemptTransport", () => {
     };
     const input = {
       attempt: {
-        config: {},
+        config: {
+          agents: {
+            defaults: { contextPruning: { mode: testCase.pruning ? "cache-ttl" : "off" } },
+          },
+        },
         model: {
           api: "anthropic-messages",
           provider: "anthropic",
           id: "claude-sonnet-4-6",
-          baseUrl: "https://api.anthropic.com",
+          baseUrl: testCase.baseUrl ?? "https://api.anthropic.com",
         },
         modelId: "claude-sonnet-4-6",
         provider: "anthropic",
@@ -204,6 +299,7 @@ describe("prepareEmbeddedAttemptTransport", () => {
     expect(result.effectiveAgentTransport).toBe("sse");
     expect(session.agent.transport).toBe("sse");
     expect(result.compactionReplayEnabled).toBe(testCase.replayEnabled);
+    expect(result.serverToolClearingEnabled).toBe(testCase.clearing);
   });
 
   it("materializes native video from the prepared session agent workspace", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -625,10 +625,21 @@ export async function prepareEmbeddedAttemptTransport(input: {
     );
   }
   session.agent.transport = effectiveAgentTransport;
+  const contextPruning = attempt.config?.agents?.defaults?.contextPruning;
+  const serverToolClearingEnabled =
+    contextPruning?.mode === "cache-ttl" &&
+    isAnthropicServerToolClearingEnabled(attempt.model, transportApiKey);
+  if (serverToolClearingEnabled) {
+    // One owner: the decision that suspends client-side pruning also hands the
+    // clearing request to the transport, so neither can happen without the other.
+    const baseStreamFn = session.agent.streamFn;
+    session.agent.streamFn = (model, context, options) => {
+      const requestOptions = { ...options, cacheTtlPruning: { tools: contextPruning?.tools } };
+      return baseStreamFn(model, context, requestOptions);
+    };
+  }
   return {
-    serverToolClearingEnabled:
-      attempt.config?.agents?.defaults?.contextPruning?.mode === "cache-ttl" &&
-      isAnthropicServerToolClearingEnabled(attempt.model, transportApiKey),
+    serverToolClearingEnabled,
     compactionReplayEnabled: resolveCompactionReplayEligibility(attempt.model, {
       extraParams: effectiveExtraParams,
       apiKey: transportApiKey,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -2,7 +2,10 @@
  * Prepares transport before streaming and settles the completed stream afterward.
  * It may assume session runtime ownership and provider inputs are established.
  */
-import { resolveCompactionReplayEligibility } from "@openclaw/ai/transports";
+import {
+  isAnthropicServerToolClearingEnabled,
+  resolveCompactionReplayEligibility,
+} from "@openclaw/ai/transports";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import type { AssistantMessage } from "../../../llm/types.js";
@@ -37,6 +40,7 @@ import {
   type ProviderPromptState,
   wrapStreamFnWithProviderPromptState,
 } from "../provider-prompt-state.js";
+import type { ToolResultPromptProjectionState } from "../session-prompt-state.js";
 import {
   resolveEmbeddedAgentApiKey,
   resolveEmbeddedAgentBaseStreamFn,
@@ -101,6 +105,7 @@ export async function settleEmbeddedAttemptStream(input: {
   attempt: EmbeddedRunAttemptParams;
   activeSession: AgentSession;
   sessionManager: SessionManager;
+  toolResultPromptProjectionState: ToolResultPromptProjectionState;
   withOwnedTranscriptWrite: WithOwnedTranscriptWrite;
   subscription: EmbeddedAttemptSubscription;
   state: {
@@ -293,6 +298,7 @@ export async function settleEmbeddedAttemptStream(input: {
       modelId: attempt.modelId,
       modelApi: attempt.model.api,
       isCacheTtlEligibleProvider,
+      toolResultPromptProjectionState: input.toolResultPromptProjectionState,
     });
 
     if (timedOutDuringCompaction) {
@@ -620,6 +626,9 @@ export async function prepareEmbeddedAttemptTransport(input: {
   }
   session.agent.transport = effectiveAgentTransport;
   return {
+    serverToolClearingEnabled:
+      attempt.config?.agents?.defaults?.contextPruning?.mode === "cache-ttl" &&
+      isAnthropicServerToolClearingEnabled(attempt.model, transportApiKey),
     compactionReplayEnabled: resolveCompactionReplayEligibility(attempt.model, {
       extraParams: effectiveExtraParams,
       apiKey: transportApiKey,

--- a/src/agents/embedded-agent-runner/run/attempt-thread-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-thread-helpers.ts
@@ -4,6 +4,10 @@ import { normalizeStructuredPromptSection } from "@openclaw/ai/internal/shared";
  */
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
+import {
+  serializeCacheTtlToolResultProjections,
+  type ToolResultPromptProjectionState,
+} from "../session-prompt-state.js";
 
 /** Custom transcript marker used to preserve cache-TTL pruning state across attempts. */
 const ATTEMPT_CACHE_TTL_CUSTOM_TYPE = "openclaw.cache-ttl";
@@ -91,6 +95,7 @@ export function appendAttemptCacheTtlIfNeeded(params: {
   modelApi?: string;
   isCacheTtlEligibleProvider: (provider: string, modelId: string, modelApi?: string) => boolean;
   now?: number;
+  toolResultPromptProjectionState: ToolResultPromptProjectionState;
 }): boolean {
   if (!shouldAppendAttemptCacheTtl(params)) {
     return false;
@@ -99,6 +104,7 @@ export function appendAttemptCacheTtlIfNeeded(params: {
     timestamp: params.now ?? Date.now(),
     provider: params.provider,
     modelId: params.modelId,
+    ...serializeCacheTtlToolResultProjections(params.toolResultPromptProjectionState),
   });
   return true;
 }

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.cache-ttl.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.cache-ttl.test.ts
@@ -1,5 +1,6 @@
 // Coverage for cache-TTL session entries after embedded attempts.
 import { describe, expect, it, vi } from "vitest";
+import { createToolResultPromptProjectionState } from "../session-prompt-state.js";
 import { appendAttemptCacheTtlIfNeeded } from "./attempt-thread-helpers.js";
 
 const ATTEMPT_CACHE_TTL_CUSTOM_TYPE = "openclaw.cache-ttl";
@@ -13,6 +14,7 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
     };
     const appended = appendAttemptCacheTtlIfNeeded({
       sessionManager,
+      toolResultPromptProjectionState: createToolResultPromptProjectionState(),
       timedOutDuringCompaction: false,
       compactionOccurredThisAttempt: true,
       config: {
@@ -41,6 +43,7 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
     };
     const appended = appendAttemptCacheTtlIfNeeded({
       sessionManager,
+      toolResultPromptProjectionState: createToolResultPromptProjectionState(),
       timedOutDuringCompaction: false,
       compactionOccurredThisAttempt: false,
       config: {
@@ -64,6 +67,8 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
       timestamp: 123,
       provider: "anthropic",
       modelId: "claude-sonnet-4-20250514",
+      prunedToolResults: [],
+      ambiguousToolResultBaseKeys: [],
     });
   });
 });

--- a/src/agents/embedded-agent-runner/run/overflow-context-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/overflow-context-recovery.test.ts
@@ -107,6 +107,7 @@ describe("recoverEmbeddedRunOverflow transcript ownership", () => {
             replacements: new Map(),
             frozen: new Set(),
             ambiguousBaseKeys: new Set(),
+            restoredCacheTtl: new Map(),
             sourceTextByKey: new Map(),
           },
           attemptCompactionCount: 0,

--- a/src/agents/embedded-agent-runner/session-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/session-prompt-state.ts
@@ -8,9 +8,11 @@ export type ToolResultPromptProjectionState = {
   frozen: Set<string>;
   ambiguousBaseKeys: Set<string>;
   sourceTextByKey: Map<string, string[]>;
-  /** Cache-TTL prune modes read from the transcript marker; the next pruning pass materializes them. */
-  restoredCacheTtl: Map<string, "soft" | "hard">;
+  /** Cache-TTL marks read from the transcript marker; the projection owner materializes them on the next replay. */
+  restoredCacheTtl: Map<string, RestoredCacheTtlMark>;
 };
+
+type RestoredCacheTtlMark = { mode: "soft" } | { mode: "hard"; placeholder: string };
 
 type EmbeddedSessionPromptState = {
   activeProjectKeys: string[];
@@ -56,16 +58,21 @@ export function cloneToolResultPromptProjectionState(
   };
 }
 
-/** Marker payload stays key-sized: pruned bytes are recomputed from canonical history on restore. */
+/** Marker payload stays key-sized: soft trims are recomputed from canonical history, hard clears keep only their placeholder. */
 export function serializeCacheTtlToolResultProjections(state: ToolResultPromptProjectionState) {
-  const modes = new Map(state.restoredCacheTtl);
+  const marks = new Map(state.restoredCacheTtl);
   for (const [key, projection] of state.replacements) {
-    if (projection.cacheTtl) {
-      modes.set(key, projection.cacheTtl);
+    if (projection.cacheTtl === "soft") {
+      marks.set(key, { mode: "soft" });
+    } else if (projection.cacheTtl === "hard" && projection.message.role === "toolResult") {
+      const placeholder = projection.message.content
+        .flatMap((block) => (block.type === "text" ? [block.text] : []))
+        .join("\n");
+      marks.set(key, { mode: "hard", placeholder });
     }
   }
   return {
-    prunedToolResults: [...modes].map(([key, mode]) => ({ key, mode })),
+    prunedToolResults: [...marks].map(([key, mark]) => Object.assign({ key }, mark)),
     ambiguousToolResultBaseKeys: [...state.ambiguousBaseKeys],
   };
 }

--- a/src/agents/embedded-agent-runner/session-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/session-prompt-state.ts
@@ -4,10 +4,12 @@ import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import type { AgentMessage } from "../runtime/index.js";
 
 export type ToolResultPromptProjectionState = {
-  replacements: Map<string, AgentMessage>;
+  replacements: Map<string, { message: AgentMessage; cacheTtl?: "soft" | "hard" }>;
   frozen: Set<string>;
   ambiguousBaseKeys: Set<string>;
   sourceTextByKey: Map<string, string[]>;
+  /** Cache-TTL prune modes read from the transcript marker; the next pruning pass materializes them. */
+  restoredCacheTtl: Map<string, "soft" | "hard">;
 };
 
 type EmbeddedSessionPromptState = {
@@ -26,10 +28,11 @@ const sessionPromptStates = resolveGlobalSingleton(
 
 export function createToolResultPromptProjectionState(): ToolResultPromptProjectionState {
   return {
-    replacements: new Map<string, AgentMessage>(),
+    replacements: new Map(),
     frozen: new Set<string>(),
     ambiguousBaseKeys: new Set<string>(),
     sourceTextByKey: new Map<string, string[]>(),
+    restoredCacheTtl: new Map(),
   };
 }
 
@@ -49,6 +52,21 @@ export function cloneToolResultPromptProjectionState(
     frozen: new Set(state.frozen),
     ambiguousBaseKeys: new Set(state.ambiguousBaseKeys),
     sourceTextByKey: new Map(state.sourceTextByKey),
+    restoredCacheTtl: new Map(state.restoredCacheTtl),
+  };
+}
+
+/** Marker payload stays key-sized: pruned bytes are recomputed from canonical history on restore. */
+export function serializeCacheTtlToolResultProjections(state: ToolResultPromptProjectionState) {
+  const modes = new Map(state.restoredCacheTtl);
+  for (const [key, projection] of state.replacements) {
+    if (projection.cacheTtl) {
+      modes.set(key, projection.cacheTtl);
+    }
+  }
+  return {
+    prunedToolResults: [...modes].map(([key, mode]) => ({ key, mode })),
+    ambiguousToolResultBaseKeys: [...state.ambiguousBaseKeys],
   };
 }
 

--- a/src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts
@@ -86,6 +86,7 @@ function project(
     lastCacheTouchAt?: number | null;
     now?: number;
     projectionState?: ToolResultPromptProjectionState;
+    pruneNewRounds?: boolean;
     onPruned?: () => void;
   } = {},
 ): AgentMessage[] {
@@ -98,6 +99,7 @@ function project(
     dropThinkingBlocksForEstimate: options.dropThinkingBlocksForEstimate ?? false,
     now: options.now ?? NOW,
     projectionState: options.projectionState ?? createToolResultPromptProjectionState(),
+    pruneNewRounds: options.pruneNewRounds ?? true,
     onPruned: options.onPruned,
   });
 }
@@ -247,6 +249,37 @@ describe("cache-TTL tool-result projection", () => {
     restoreCacheTtlToolResultProjections(restarted, entries);
     const restored = project(expanded, { projectionState: restarted, lastCacheTouchAt: NOW });
     expect(JSON.stringify(restored)).toBe(JSON.stringify(continued));
+  });
+
+  it("replays existing and restored projections when another owner prunes new rounds", () => {
+    const state = createToolResultPromptProjectionState();
+    const history = prunableHistory([tool({ id: "old", text: "a".repeat(5_000) })]);
+    const first = project(history, { projectionState: state });
+    const entries = [
+      {
+        type: "custom",
+        customType: "openclaw.cache-ttl",
+        data: serializeCacheTtlToolResultProjections(state),
+      },
+    ];
+    const expanded = [
+      ...history,
+      assistant(),
+      tool({ id: "new", text: "b".repeat(5_000) }),
+      assistant(),
+      assistant(),
+      assistant(),
+    ];
+    // Live state: the earlier projection replays, the new result is left to the server.
+    const live = project(expanded, { projectionState: state, pruneNewRounds: false });
+    expect(toolText(live, "old")).toBe(toolText(first, "old"));
+    expect(toolText(live, "new")).toBe("b".repeat(5_000));
+    // Restarted state: marker keys re-derive the same bytes without opening a new round.
+    const restarted = createToolResultPromptProjectionState();
+    restoreCacheTtlToolResultProjections(restarted, entries);
+    const restored = project(expanded, { projectionState: restarted, pruneNewRounds: false });
+    expect(toolText(restored, "old")).toBe(toolText(first, "old"));
+    expect(toolText(restored, "new")).toBe("b".repeat(5_000));
   });
 
   it("gates new pruning rounds without undoing earlier projections", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts
@@ -173,7 +173,7 @@ describe("cache-TTL tool-result projection", () => {
         expect(entries.at(-1)?.data).toMatchObject({
           timestamp: NOW,
           prunedToolResults: expect.arrayContaining([
-            { key: expect.stringContaining("tool-0"), mode },
+            expect.objectContaining({ key: expect.stringContaining("tool-0"), mode }),
           ]),
         });
         // The marker carries keys only; pruned bytes never enter the transcript.
@@ -249,6 +249,39 @@ describe("cache-TTL tool-result projection", () => {
     restoreCacheTtlToolResultProjections(restarted, entries);
     const restored = project(expanded, { projectionState: restarted, lastCacheTouchAt: NOW });
     expect(JSON.stringify(restored)).toBe(JSON.stringify(continued));
+  });
+
+  it("replays restored projections through the history transform when pruning is off", () => {
+    const state = createToolResultPromptProjectionState();
+    const history = prunableHistory(
+      Array.from({ length: 18 }, (_, index) =>
+        tool({ id: `tool-${index}`, text: `${index}:` + "x".repeat(6_000) }),
+      ),
+    );
+    const first = project(history, { projectionState: state });
+    const sent = truncateOversizedToolResultsInMessages(
+      first,
+      1_000,
+      2_500,
+      100_000,
+      state,
+    ).messages;
+    expect(toolText(sent, "tool-0")).toContain("content cleared");
+    const entries = [
+      {
+        type: "custom",
+        customType: "openclaw.cache-ttl",
+        data: structuredClone(serializeCacheTtlToolResultProjections(state)),
+      },
+    ];
+    expect(JSON.stringify(entries[0]?.data)).not.toContain("x".repeat(20));
+    // Pruning is off after the restart: no prune pass runs, only the per-request history transform.
+    const restarted = createToolResultPromptProjectionState();
+    restoreCacheTtlToolResultProjections(restarted, entries);
+    expect(
+      truncateOversizedToolResultsInMessages(history, 1_000, 2_500, 100_000, restarted).messages,
+    ).toEqual(sent);
+    expect(restarted.restoredCacheTtl.size).toBe(0);
   });
 
   it("replays existing and restored projections when another owner prunes new rounds", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts
@@ -1,9 +1,20 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
 import type { AgentContextPruningConfig } from "../../config/types.agent-defaults.js";
+import { appendAttemptCacheTtlIfNeeded } from "./run/attempt-thread-helpers.js";
+import {
+  clearEmbeddedSessionPromptStates,
+  createToolResultPromptProjectionState,
+  getEmbeddedSessionPromptState,
+  serializeCacheTtlToolResultProjections,
+  type ToolResultPromptProjectionState,
+} from "./session-prompt-state.js";
 import {
   pruneExpiredCacheTtlToolResults,
+  reconcileToolResultPromptProjectionState,
   resolveCacheTtlPruningSettings,
+  restoreCacheTtlToolResultProjections,
+  truncateOversizedToolResultsInMessages,
 } from "./tool-result-truncation.js";
 
 const NOW = 1_000_000;
@@ -74,6 +85,8 @@ function project(
     dropThinkingBlocksForEstimate?: boolean;
     lastCacheTouchAt?: number | null;
     now?: number;
+    projectionState?: ToolResultPromptProjectionState;
+    onPruned?: () => void;
   } = {},
 ): AgentMessage[] {
   return pruneExpiredCacheTtlToolResults({
@@ -84,6 +97,8 @@ function project(
       options.lastCacheTouchAt === undefined ? NOW - 300_000 : options.lastCacheTouchAt,
     dropThinkingBlocksForEstimate: options.dropThinkingBlocksForEstimate ?? false,
     now: options.now ?? NOW,
+    projectionState: options.projectionState ?? createToolResultPromptProjectionState(),
+    onPruned: options.onPruned,
   });
 }
 
@@ -102,6 +117,162 @@ function toolText(messages: AgentMessage[], id: string): string {
 }
 
 describe("cache-TTL tool-result projection", () => {
+  it.each(["soft", "hard"] as const)(
+    "replays %s pruning after TTL refresh and restart, until compaction/reset",
+    (mode) => {
+      const sessionId = `cache-ttl-${mode}`;
+      clearEmbeddedSessionPromptStates([sessionId]);
+      try {
+        const messages = prunableHistory(
+          Array.from({ length: mode === "hard" ? 18 : 1 }, (_, index) =>
+            tool({ id: `tool-${index}`, text: `${index}:` + "x".repeat(6_000), image: true }),
+          ),
+        );
+        const state = getEmbeddedSessionPromptState(sessionId).toolResults;
+        truncateOversizedToolResultsInMessages(messages, 1_000, 5_500, 100_000, state);
+        let pruningRounds = 0;
+        const options = { projectionState: state, onPruned: () => pruningRounds++ };
+        const first = project(messages, options);
+        expect(toolText(first, "tool-0")).toContain(
+          mode === "hard" ? "content cleared" : "Tool result trimmed",
+        );
+        const second = project(messages, { ...options, lastCacheTouchAt: NOW });
+        expect(second).toEqual(first);
+        expect(pruningRounds).toBe(1);
+        const sent = truncateOversizedToolResultsInMessages(
+          second,
+          1_000,
+          2_500,
+          100_000,
+          state,
+        ).messages;
+        expect(
+          truncateOversizedToolResultsInMessages(messages, 1_000, 2_500, 100_000, state).messages,
+        ).toEqual(sent);
+        const entries: { type: string; customType: string; data: unknown }[] = [];
+        const sessionManager = {
+          getEntries: () => entries,
+          appendCustomEntry: (customType: string, data: unknown) => {
+            const serialized = JSON.stringify(data);
+            entries.push({ type: "custom", customType, data: JSON.parse(serialized) });
+          },
+        };
+        appendAttemptCacheTtlIfNeeded({
+          sessionManager,
+          config: { agents: { defaults: { contextPruning: { mode: "cache-ttl" } } } },
+          provider: "anthropic",
+          modelId: "claude-sonnet-4-6",
+          timedOutDuringCompaction: false,
+          compactionOccurredThisAttempt: false,
+          isCacheTtlEligibleProvider: () => true,
+          toolResultPromptProjectionState: state,
+          now: NOW,
+        });
+        expect(entries.at(-1)?.data).toMatchObject({
+          timestamp: NOW,
+          prunedToolResults: expect.arrayContaining([
+            { key: expect.stringContaining("tool-0"), mode },
+          ]),
+        });
+        // The marker carries keys only; pruned bytes never enter the transcript.
+        expect(JSON.stringify(entries.at(-1)?.data)).not.toContain("x".repeat(20));
+        clearEmbeddedSessionPromptStates([sessionId]);
+        const restarted = getEmbeddedSessionPromptState(sessionId).toolResults;
+        restoreCacheTtlToolResultProjections(restarted, entries);
+        const restored = project(messages, {
+          projectionState: restarted,
+          lastCacheTouchAt: NOW,
+          onPruned: () => pruningRounds++,
+        });
+        expect(restored).toEqual(first);
+        expect(pruningRounds).toBe(1);
+        expect(
+          truncateOversizedToolResultsInMessages(restored, 1_000, 2_500, 100_000, restarted)
+            .messages,
+        ).toEqual(sent);
+        const compacted = [user("summary"), ...messages.slice(-4)];
+        reconcileToolResultPromptProjectionState(compacted, restarted);
+        expect(restarted.replacements.size).toBe(0);
+        restoreCacheTtlToolResultProjections(restarted, entries);
+        project(compacted, { projectionState: restarted, lastCacheTouchAt: NOW });
+        expect(restarted.replacements.size).toBe(0);
+        expect(restarted.restoredCacheTtl.size).toBe(0);
+        clearEmbeddedSessionPromptStates([sessionId]);
+        expect(getEmbeddedSessionPromptState(sessionId).toolResults.replacements.size).toBe(0);
+      } finally {
+        clearEmbeddedSessionPromptStates([sessionId]);
+      }
+    },
+  );
+
+  it("keeps ambiguous tool identities stable when pruning composes with oversized projection", () => {
+    const messages = prunableHistory([
+      tool({ id: "duplicate", text: "a".repeat(5_000) }),
+      tool({ id: "duplicate", text: "b".repeat(5_000) }),
+    ]);
+    const state = createToolResultPromptProjectionState();
+    const first = project(messages, { projectionState: state });
+    const sent = truncateOversizedToolResultsInMessages(
+      first,
+      1_000,
+      2_000,
+      100_000,
+      state,
+    ).messages;
+    const replay = project(messages, { projectionState: state, lastCacheTouchAt: NOW });
+    expect(
+      truncateOversizedToolResultsInMessages(replay, 1_000, 2_000, 100_000, state).messages,
+    ).toEqual(sent);
+    expect(state.replacements.size).toBe(2);
+  });
+
+  it("keeps pruned bytes when a later result makes a tool identity ambiguous", () => {
+    const messages = prunableHistory([tool({ id: "reused", text: "a".repeat(5_000) })]);
+    const state = createToolResultPromptProjectionState();
+    const sent = project(messages, { projectionState: state });
+    const entries = [
+      {
+        type: "custom",
+        customType: "openclaw.cache-ttl",
+        data: serializeCacheTtlToolResultProjections(state),
+      },
+    ];
+    const expanded = [...messages, tool({ id: "reused", text: "b".repeat(5_000) })];
+    const continued = project(expanded, {
+      projectionState: state,
+      lastCacheTouchAt: NOW,
+    });
+    expect(JSON.stringify(continued.slice(0, messages.length))).toBe(JSON.stringify(sent));
+    const restarted = createToolResultPromptProjectionState();
+    restoreCacheTtlToolResultProjections(restarted, entries);
+    const restored = project(expanded, { projectionState: restarted, lastCacheTouchAt: NOW });
+    expect(JSON.stringify(restored)).toBe(JSON.stringify(continued));
+  });
+
+  it("gates new pruning rounds without undoing earlier projections", () => {
+    const state = createToolResultPromptProjectionState();
+    const history = prunableHistory([tool({ id: "old", text: "a".repeat(5_000) })]);
+    const first = project(history, { projectionState: state });
+    const expanded = [
+      ...history,
+      assistant(),
+      tool({ id: "new", text: "b".repeat(5_000) }),
+      assistant(),
+      assistant(),
+      assistant(),
+    ];
+    const retained = project(expanded, { projectionState: state, lastCacheTouchAt: NOW });
+    expect(toolText(retained, "old")).toBe(toolText(first, "old"));
+    expect(toolText(retained, "new")).toBe("b".repeat(5_000));
+    const expired = project(expanded, {
+      projectionState: state,
+      lastCacheTouchAt: NOW,
+      now: NOW + 300_000,
+    });
+    expect(toolText(expired, "old")).toBe(toolText(first, "old"));
+    expect(toolText(expired, "new")).toContain("[Tool result trimmed:");
+  });
+
   it("normalizes TTL, hard-clear, and deny-first tool matching once", () => {
     expect(resolveCacheTtlPruningSettings(undefined)).toBeUndefined();
     expect(resolveCacheTtlPruningSettings({ mode: "off" })).toBeUndefined();

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -68,6 +68,7 @@ function createPromptProjectionStateForTest(): ToolResultPromptProjectionState {
     replacements: new Map(),
     frozen: new Set(),
     ambiguousBaseKeys: new Set(),
+    restoredCacheTtl: new Map(),
     sourceTextByKey: new Map(),
   };
 }
@@ -1767,6 +1768,7 @@ describe("truncateOversizedToolResultsInSession", () => {
       48_000,
       projectionState,
     ).messages[0];
+    const staleProjectionState = cloneToolResultPromptProjectionState(projectionState);
 
     const result = truncateOversizedToolResultsInSessionManager({
       sessionManager: SessionManager.open(scope),
@@ -1778,6 +1780,17 @@ describe("truncateOversizedToolResultsInSession", () => {
     });
 
     expect(result.truncated).toBe(true);
+    expect(projectionState.sourceTextByKey.size).toBe(0);
+    expect(projectionState.replacements.size).toBe(0);
+    expect(projectionState.frozen.size).toBe(0);
+    preparePromptProjectionStateForTest({
+      sessionId,
+      messages: SessionManager.open(scope).buildSessionContext().messages,
+      state: staleProjectionState,
+    });
+    expect(staleProjectionState.sourceTextByKey.size).toBe(0);
+    expect(staleProjectionState.replacements.size).toBe(0);
+    expect(staleProjectionState.frozen.size).toBe(0);
     const activeToolResult = SessionManager.open(scope)
       .getBranch()
       .find((entry) => entry.type === "message" && entry.message.role === "toolResult");

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -210,36 +210,6 @@ export function pruneExpiredCacheTtlToolResults(params: {
     ...message,
     content: [{ type: "text" as const, text: settings.placeholder }],
   });
-  const restoredMode = (candidate: string | undefined) =>
-    candidate === undefined ? undefined : projectionState.restoredCacheTtl.get(candidate);
-  if (projectionState.restoredCacheTtl.size > 0) {
-    // Marker keys re-derive the same bytes from canonical history; keys whose
-    // source left the branch (compaction, reset) are dropped with this pass.
-    for (const [index, source] of params.messages.entries()) {
-      const key = projection.keys[index];
-      const baseKey = getToolResultProjectionBaseKey(source);
-      const exactMode = restoredMode(key);
-      const mode = exactMode ?? restoredMode(baseKey);
-      if (
-        !key ||
-        !mode ||
-        source.role !== "toolResult" ||
-        projectionState.replacements.get(key)?.cacheTtl
-      ) {
-        continue;
-      }
-      if (!exactMode && baseKey) {
-        // A key persisted before its tool id became ambiguous belongs to the earliest occurrence.
-        projectionState.restoredCacheTtl.delete(baseKey);
-      }
-      recordProjection(
-        index,
-        mode === "hard" ? clearCacheTtlToolResult(source) : softPruneCacheTtlToolResult(source),
-        mode,
-      );
-    }
-    projectionState.restoredCacheTtl.clear();
-  }
   if (
     !params.pruneNewRounds ||
     !params.lastCacheTouchAt ||
@@ -914,7 +884,12 @@ function getToolResultProjectionKeys(
 }
 
 const cacheTtlProjectionSnapshotSchema = z.object({
-  prunedToolResults: z.array(z.object({ key: z.string(), mode: z.enum(["soft", "hard"]) })),
+  prunedToolResults: z.array(
+    z.union([
+      z.object({ key: z.string(), mode: z.literal("soft") }),
+      z.object({ key: z.string(), mode: z.literal("hard"), placeholder: z.string() }),
+    ]),
+  ),
   ambiguousToolResultBaseKeys: z.array(z.string()).optional(),
 });
 
@@ -938,9 +913,9 @@ export function restoreCacheTtlToolResultProjections(
     for (const key of parsed.data.ambiguousToolResultBaseKeys ?? []) {
       projectionState.ambiguousBaseKeys.add(key);
     }
-    for (const item of parsed.data.prunedToolResults) {
-      if (!projectionState.replacements.get(item.key)?.cacheTtl) {
-        projectionState.restoredCacheTtl.set(item.key, item.mode);
+    for (const { key, ...mark } of parsed.data.prunedToolResults) {
+      if (!projectionState.replacements.get(key)?.cacheTtl) {
+        projectionState.restoredCacheTtl.set(key, mark);
       }
     }
     return;
@@ -1028,10 +1003,9 @@ function projectToolResultBranch(params: {
     (entry): entry is ToolResultBranchEntry & { message: AgentMessage } =>
       entry.type === "message" && entry.message !== undefined,
   );
-  const keys = getToolResultProjectionKeys(
-    messageEntries.map((entry) => entry.message),
-    params.projectionState,
-  );
+  const messages = messageEntries.map((entry) => entry.message);
+  const keys = getToolResultProjectionKeys(messages, params.projectionState);
+  materializeRestoredCacheTtl(messages, keys, params.projectionState);
   let messageIndex = 0;
   return {
     keys,
@@ -1071,6 +1045,50 @@ function projectToolResultBranch(params: {
       };
     }),
   };
+}
+
+/**
+ * Restored marker keys become replacements here, at the owner every replay path
+ * uses, so the pruned bytes are sent whether or not cache-TTL pruning is still on.
+ */
+function materializeRestoredCacheTtl(
+  messages: AgentMessage[],
+  keys: Array<string | undefined>,
+  state: ToolResultPromptProjectionState,
+): void {
+  if (state.restoredCacheTtl.size === 0) {
+    return;
+  }
+  for (const [index, message] of messages.entries()) {
+    const key = keys[index];
+    if (!key || message.role !== "toolResult" || state.replacements.get(key)?.cacheTtl) {
+      continue;
+    }
+    const baseKey = getToolResultProjectionBaseKey(message);
+    const exact = state.restoredCacheTtl.get(key);
+    const mark = exact ?? (baseKey ? state.restoredCacheTtl.get(baseKey) : undefined);
+    if (!mark) {
+      continue;
+    }
+    if (!exact && baseKey) {
+      // A key persisted before its tool id became ambiguous belongs to the earliest occurrence.
+      state.restoredCacheTtl.delete(baseKey);
+    }
+    const projected =
+      mark.mode === "hard"
+        ? { ...message, content: [{ type: "text" as const, text: mark.placeholder }] }
+        : softPruneCacheTtlToolResult(message);
+    state.replacements.set(key, {
+      message: Object.assign({}, projected, { [TOOL_RESULT_PROJECTION_KEY]: key }),
+      cacheTtl: mark.mode,
+    });
+    state.frozen.add(key);
+    if (!state.sourceTextByKey.has(key)) {
+      state.sourceTextByKey.set(key, getToolResultTextBlocks(message));
+    }
+  }
+  // Marks whose source left the branch (compaction, reset) are dropped with this pass.
+  state.restoredCacheTtl.clear();
 }
 
 function getToolResultTextBlocks(message: AgentMessage): string[] {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -173,6 +173,8 @@ export function pruneExpiredCacheTtlToolResults(params: {
   dropThinkingBlocksForEstimate: boolean;
   now: number;
   projectionState: ToolResultPromptProjectionState;
+  /** False replays existing projections only, when another owner (server clearing) prunes. */
+  pruneNewRounds: boolean;
   onPruned?: () => void;
 }): AgentMessage[] {
   const { settings, projectionState } = params;
@@ -239,6 +241,7 @@ export function pruneExpiredCacheTtlToolResults(params: {
     projectionState.restoredCacheTtl.clear();
   }
   if (
+    !params.pruneNewRounds ||
     !params.lastCacheTouchAt ||
     settings.ttlMs <= 0 ||
     params.now - params.lastCacheTouchAt < settings.ttlMs
@@ -918,7 +921,7 @@ const cacheTtlProjectionSnapshotSchema = z.object({
 /** Reads pruned keys from the active transcript branch, never from a sibling branch. */
 export function restoreCacheTtlToolResultProjections(
   projectionState: ToolResultPromptProjectionState,
-  entries: readonly { type: string; customType?: string; data?: unknown }[],
+  entries: readonly { type?: unknown; customType?: unknown; data?: unknown }[],
 ): void {
   for (let index = entries.length - 1; index >= 0; index--) {
     const entry = entries[index];

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -4,6 +4,7 @@ import { estimateStringChars } from "@openclaw/normalization-core/cjk-chars";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { z } from "zod";
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import type { AgentContextPruningConfig } from "../../config/types.agent-defaults.js";
 import { createDedupeCache } from "../../infra/dedupe.js";
@@ -47,6 +48,7 @@ type CacheTtlPruningSettings = {
   isToolPrunable: (toolName: string) => boolean;
 };
 type CacheTtlToolResultMessage = Extract<AgentMessage, { role: "toolResult" }>;
+const TOOL_RESULT_PROJECTION_KEY = Symbol("toolResultProjectionKey");
 
 export function resolveCacheTtlPruningSettings(
   config: AgentContextPruningConfig | undefined,
@@ -170,29 +172,93 @@ export function pruneExpiredCacheTtlToolResults(params: {
   lastCacheTouchAt: number | null;
   dropThinkingBlocksForEstimate: boolean;
   now: number;
+  projectionState: ToolResultPromptProjectionState;
+  onPruned?: () => void;
 }): AgentMessage[] {
-  const { messages, settings } = params;
+  const { settings, projectionState } = params;
+  const projection = projectToolResultBranch({
+    branch: buildToolResultPlanningBranch(params.messages),
+    projectionState,
+    recordSources: true,
+  });
+  const messages = params.messages.map(
+    (message, index) => projection.branch[index]?.message ?? message,
+  );
+  const unchanged = messages.some((message, index) => message !== params.messages[index])
+    ? messages
+    : params.messages;
+  let next: AgentMessage[] | undefined;
+  const recordProjection = (
+    index: number,
+    message: CacheTtlToolResultMessage,
+    mode: "soft" | "hard",
+  ) => {
+    const key = projection.keys[index];
+    const replacement = key
+      ? Object.assign({}, message, { [TOOL_RESULT_PROJECTION_KEY]: key })
+      : message;
+    if (key) {
+      // TTL gates new edits only: replay these bytes until their source leaves the session.
+      projectionState.replacements.set(key, { message: replacement, cacheTtl: mode });
+      projectionState.frozen.add(key);
+    }
+    (next ??= messages.slice())[index] = replacement;
+  };
+  const clearCacheTtlToolResult = (message: CacheTtlToolResultMessage) => ({
+    ...message,
+    content: [{ type: "text" as const, text: settings.placeholder }],
+  });
+  const restoredMode = (candidate: string | undefined) =>
+    candidate === undefined ? undefined : projectionState.restoredCacheTtl.get(candidate);
+  if (projectionState.restoredCacheTtl.size > 0) {
+    // Marker keys re-derive the same bytes from canonical history; keys whose
+    // source left the branch (compaction, reset) are dropped with this pass.
+    for (const [index, source] of params.messages.entries()) {
+      const key = projection.keys[index];
+      const baseKey = getToolResultProjectionBaseKey(source);
+      const exactMode = restoredMode(key);
+      const mode = exactMode ?? restoredMode(baseKey);
+      if (
+        !key ||
+        !mode ||
+        source.role !== "toolResult" ||
+        projectionState.replacements.get(key)?.cacheTtl
+      ) {
+        continue;
+      }
+      if (!exactMode && baseKey) {
+        // A key persisted before its tool id became ambiguous belongs to the earliest occurrence.
+        projectionState.restoredCacheTtl.delete(baseKey);
+      }
+      recordProjection(
+        index,
+        mode === "hard" ? clearCacheTtlToolResult(source) : softPruneCacheTtlToolResult(source),
+        mode,
+      );
+    }
+    projectionState.restoredCacheTtl.clear();
+  }
   if (
     !params.lastCacheTouchAt ||
     settings.ttlMs <= 0 ||
     params.now - params.lastCacheTouchAt < settings.ttlMs
   ) {
-    return messages;
+    return next ?? unchanged;
   }
   const cutoff =
     messages.flatMap((message, index) => (message.role === "assistant" ? [index] : [])).at(-3) ??
     -1;
   const start = messages.findIndex((message) => message.role === "user");
   if (cutoff < 0 || start < 0) {
-    return messages;
+    return next ?? unchanged;
   }
   const estimate = params.dropThinkingBlocksForEstimate ? dropThinkingBlocks(messages) : messages;
   let totalChars = estimate.reduce((sum, message) => sum + cacheTtlMessageChars(message), 0);
   const charWindow = params.contextWindowTokens * 4;
   if (totalChars / charWindow < 0.3) {
-    return messages;
+    return next ?? unchanged;
   }
-  let next: AgentMessage[] | undefined;
+  let pruned = false;
   const eligible: number[] = [];
   for (let index = start; index < cutoff; index++) {
     const message = messages[index];
@@ -202,34 +268,48 @@ export function pruneExpiredCacheTtlToolResults(params: {
     ) {
       continue;
     }
+    const key = projection.keys[index];
+    const previousMode = key ? projectionState.replacements.get(key)?.cacheTtl : undefined;
+    if (previousMode === "hard") {
+      continue;
+    }
     eligible.push(index);
-    const projected = softPruneCacheTtlToolResult(message);
-    if (projected !== message) {
+    if (previousMode === "soft") {
+      continue;
+    }
+    // Trim the canonical source, not the oversized projection, so a restart re-derives identical bytes.
+    const source = params.messages[index];
+    const projected = source?.role === "toolResult" ? softPruneCacheTtlToolResult(source) : source;
+    if (projected && projected !== source && projected.role === "toolResult") {
       totalChars += cacheTtlMessageChars(projected) - cacheTtlMessageChars(message);
-      (next ??= messages.slice())[index] = projected;
+      recordProjection(index, projected, "soft");
+      pruned = true;
     }
   }
-  const output = next ?? messages;
+  const output = next ?? unchanged;
   if (
-    totalChars / charWindow < 0.5 ||
-    !settings.hardClear ||
-    eligible.reduce((sum, index) => sum + cacheTtlMessageChars(output[index]!), 0) < 50_000
+    totalChars / charWindow >= 0.5 &&
+    settings.hardClear &&
+    eligible.reduce((sum, index) => sum + cacheTtlMessageChars(output[index]!), 0) >= 50_000
   ) {
-    return output;
-  }
-  for (const index of eligible) {
-    if (totalChars / charWindow < 0.5) {
-      break;
+    for (const index of eligible) {
+      if (totalChars / charWindow < 0.5) {
+        break;
+      }
+      const message = (next ?? messages)[index];
+      if (message?.role !== "toolResult") {
+        continue;
+      }
+      const cleared = clearCacheTtlToolResult(message);
+      totalChars += cacheTtlMessageChars(cleared) - cacheTtlMessageChars(message);
+      recordProjection(index, cleared, "hard");
+      pruned = true;
     }
-    const message = (next ?? messages)[index] as AgentMessage;
-    const cleared = {
-      ...message,
-      content: [{ type: "text", text: settings.placeholder }],
-    } as AgentMessage;
-    totalChars += cacheTtlMessageChars(cleared) - cacheTtlMessageChars(message);
-    (next ??= messages.slice())[index] = cleared;
   }
-  return next ?? messages;
+  if (pruned) {
+    params.onPruned?.();
+  }
+  return next ?? unchanged;
 }
 
 const MIN_KEEP_CHARS = 2_000;
@@ -678,7 +758,10 @@ export function truncateOversizedToolResultsInMessages(
           projectedMessage &&
           projectedMessage !== originalMessage
         ) {
-          projectionState.replacements.set(projectionKey, projectedMessage);
+          projectionState.replacements.set(projectionKey, {
+            ...projectionState.replacements.get(projectionKey),
+            message: projectedMessage,
+          });
         }
       }
     }
@@ -779,10 +862,17 @@ function getToolResultProjectionKeys(
   }
   const occurrences = new Map<string, number>();
   return baseKeys.map((baseKey, index) => {
+    const message = messages[index];
+    if (
+      message &&
+      TOOL_RESULT_PROJECTION_KEY in message &&
+      typeof message[TOOL_RESULT_PROJECTION_KEY] === "string"
+    ) {
+      return message[TOOL_RESULT_PROJECTION_KEY];
+    }
     if (baseKey && !projectionState.ambiguousBaseKeys.has(baseKey)) {
       return baseKey;
     }
-    const message = messages[index];
     if (!message || message.role !== "toolResult") {
       return undefined;
     }
@@ -797,16 +887,78 @@ function getToolResultProjectionKeys(
     const fallbackBase = `fallback:${baseKey ?? "tool"}:${sourceIdentity}`;
     const occurrence = occurrences.get(fallbackBase) ?? 0;
     occurrences.set(fallbackBase, occurrence + 1);
-    return `${fallbackBase}:${occurrence}`;
+    const key = `${fallbackBase}:${occurrence}`;
+    const previousSource = baseKey ? projectionState.sourceTextByKey.get(baseKey) : undefined;
+    if (
+      baseKey &&
+      previousSource &&
+      toolResultTextMatches(previousSource, getToolResultTextBlocks(message))
+    ) {
+      // A later duplicate must move the original projection, not make its sent bytes disappear.
+      const replacement = projectionState.replacements.get(baseKey);
+      if (replacement) {
+        projectionState.replacements.set(key, replacement);
+        projectionState.replacements.delete(baseKey);
+      }
+      projectionState.sourceTextByKey.set(key, previousSource);
+      projectionState.sourceTextByKey.delete(baseKey);
+      if (projectionState.frozen.delete(baseKey)) {
+        projectionState.frozen.add(key);
+      }
+    }
+    return key;
   });
 }
 
-/** Drops projections whose source messages no longer exist in canonical session history. */
+const cacheTtlProjectionSnapshotSchema = z.object({
+  prunedToolResults: z.array(z.object({ key: z.string(), mode: z.enum(["soft", "hard"]) })),
+  ambiguousToolResultBaseKeys: z.array(z.string()).optional(),
+});
+
+/** Reads pruned keys from the active transcript branch, never from a sibling branch. */
+export function restoreCacheTtlToolResultProjections(
+  projectionState: ToolResultPromptProjectionState,
+  entries: readonly { type: string; customType?: string; data?: unknown }[],
+): void {
+  for (let index = entries.length - 1; index >= 0; index--) {
+    const entry = entries[index];
+    if (entry?.type === "reset") {
+      return;
+    }
+    if (entry?.type !== "custom" || entry.customType !== "openclaw.cache-ttl") {
+      continue;
+    }
+    const parsed = cacheTtlProjectionSnapshotSchema.safeParse(entry.data);
+    if (!parsed.success) {
+      continue;
+    }
+    for (const key of parsed.data.ambiguousToolResultBaseKeys ?? []) {
+      projectionState.ambiguousBaseKeys.add(key);
+    }
+    for (const item of parsed.data.prunedToolResults) {
+      if (!projectionState.replacements.get(item.key)?.cacheTtl) {
+        projectionState.restoredCacheTtl.set(item.key, item.mode);
+      }
+    }
+    return;
+  }
+}
+
+/** Drops projections whose source messages were removed or rewritten in canonical history. */
 export function reconcileToolResultPromptProjectionState(
   messages: AgentMessage[],
   projectionState: ToolResultPromptProjectionState,
 ): void {
-  const canonicalKeys = new Set(getToolResultProjectionKeys(messages, projectionState));
+  const keys = getToolResultProjectionKeys(messages, projectionState);
+  const canonicalKeys = new Set(
+    messages.flatMap((message, index) => {
+      const key = keys[index];
+      const source = key ? projectionState.sourceTextByKey.get(key) : undefined;
+      return key && (!source || toolResultTextMatches(source, getToolResultTextBlocks(message)))
+        ? [key]
+        : [];
+    }),
+  );
   for (const key of [
     ...projectionState.frozen,
     ...projectionState.replacements.keys(),
@@ -830,6 +982,7 @@ function mergeProjectedToolResultMessage(
   message: AgentMessage,
   projectedMessage: AgentMessage,
   sourceText: string[] | undefined,
+  cacheTtl?: "soft" | "hard",
 ): AgentMessage {
   if (message.role !== "toolResult" || projectedMessage.role !== "toolResult") {
     return projectedMessage;
@@ -843,10 +996,13 @@ function mergeProjectedToolResultMessage(
     isRecord(block) && block.type === "text" && typeof block.text === "string" ? [block.text] : [],
   );
   const currentText = getToolResultTextBlocks(message);
-  if (
-    (sourceText && currentText.some((text, index) => text !== sourceText[index])) ||
-    currentText.length !== projectedText.length
-  ) {
+  if (sourceText && !toolResultTextMatches(currentText, sourceText)) {
+    return message;
+  }
+  if (cacheTtl) {
+    return { ...message, content: projectedMessage.content };
+  }
+  if (currentText.length !== projectedText.length) {
     return message;
   }
   let textIndex = 0;
@@ -889,13 +1045,18 @@ function projectToolResultBranch(params: {
       if (key && params.recordSources && !params.projectionState.sourceTextByKey.has(key)) {
         params.projectionState.sourceTextByKey.set(key, getToolResultTextBlocks(entry.message));
       }
-      const message = projected
+      let message = projected
         ? mergeProjectedToolResultMessage(
             entry.message,
-            projected,
+            projected.message,
             key ? params.projectionState.sourceTextByKey.get(key) : undefined,
+            projected.cacheTtl,
           )
         : entry.message;
+      if (key && projected?.cacheTtl && message !== entry.message) {
+        // Carry canonical identity through content edits, including duplicate or absent tool ids.
+        message = Object.assign({}, message, { [TOOL_RESULT_PROJECTION_KEY]: key });
+      }
       return {
         ...entry,
         message,
@@ -918,6 +1079,10 @@ function getToolResultTextBlocks(message: AgentMessage): string[] {
           : [],
       )
     : [];
+}
+
+function toolResultTextMatches(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((text, index) => text === right[index]);
 }
 
 function buildAggregateToolResultReplacements(params: {
@@ -1298,6 +1463,13 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
     sessionManager,
     replacements: plan.replacements,
   });
+  if (rewriteResult.changed && params.projectionState) {
+    // Recovery changed canonical bytes; keeping their former source would undo the next TTL edit.
+    reconcileToolResultPromptProjectionState(
+      sessionManager.buildSessionContext().messages,
+      params.projectionState,
+    );
+  }
   const hasRuntimeTarget = Boolean(
     params.sessionId && params.sessionKey && params.agentId && params.storePath,
   );


### PR DESCRIPTION
## What Problem This Solves

`agents.defaults.contextPruning.mode: "cache-ttl"` projects old tool results (soft trim, then hard clear) once the prompt-cache TTL has expired, but the projection lived only inside that one request. The next request of the same turn (tool-loop continuation) and the next turn sent the unpruned history again, so the prompt cache diverged at the first pruned result: pruning never saved a cache write and instead added one uncached request. On Claude Fable 5.1, whose thinking is bound to the exact request prefix, the flip is a history edit: reasoning produced during the pruned request is bound to the pruned bytes and is dropped one request later (documented and live-verified in #136782). The session-pruning docs already promised "follow-up requests reuse the fresh cache"; the code did not deliver it.

## Why This Change Was Made

- **Sticky projections (every cache-TTL-eligible route).** Cache-TTL soft trims and hard clears are recorded in the session's existing tool-result projection state and frozen, so the per-request projection pass replays the identical bytes on every later request. The TTL gates new pruning rounds only. Soft trims are derived from the canonical source rather than the oversized projection so the bytes are reproducible. The pruned keys and modes ride on the existing `openclaw.cache-ttl` transcript marker (key-sized, no result text) and the projection is re-derived from canonical history on the first request after a Gateway restart; compaction and `/new` drop projections whose source left the branch, canonical recovery rewrites invalidate stale sources, and a later duplicate tool id migrates the original projection instead of losing it.
- **Server-side clearing on the direct Anthropic API-key route.** Anthropic's context editing is the documented way to trim history for preserved-thinking models: server-side edits are applied after the prefix check and do not invalidate thinking (probe in the evidence). With cache-TTL mode on a direct API-key request, OpenClaw now skips client-side pruning and sends a `clear_tool_uses_20250919` edit through the shared payload policy in both Anthropic request paths (provider adapter and canonical transport), ordered before optional server compaction, adding the `context-management-2025-06-27` beta only when the edit is present. Parameters are derived from the existing config, no new options: trigger `max(50000, 30% of the context window)`, keep 3 tool uses, `clear_at_least` `max(12500, 5% of the window)` so a clearing event is worth its cache write, `exclude_tools` from `tools.deny` (plus the complement of `tools.allow`, since the server has no allow list), tool inputs kept. Applied edits from the final `message_delta` log one info line with counts only.
- OAuth (Claude Code identity), proxies, Bedrock, Vertex, Foundry and every other provider keep the sticky client-side pruning.
- **One owner for the hand-off.** The runner decision that suspends client-side pruning also wraps the session stream with the clearing request, so the transport cannot be asked to clear without client pruning being suspended, and vice versa. Projections made earlier in the session (another route, or restored from the marker) keep replaying under server clearing; only new pruning rounds are delegated.

Production delta: +463 net (the server-side clearing path is most of it: derivation, exclusions, header/telemetry, parity across both adapters; the sticky projection reshapes the existing replacement/frozen/source maps). Tests +459 net.

## User Impact

- Cache-TTL pruning now keeps the pruned view stable across tool loops, turns and Gateway restarts, so it saves the cache write it was designed to save and no longer invalidates Fable 5.1 thinking one request after a prune.
- Direct Anthropic API-key sessions with `cache-ttl` delegate to server-side tool-result clearing; `ttl` does not apply on that route. Operators see `[anthropic] server-side context edit: cleared N tool results (M input tokens)` when it fires.
- No config, schema or protocol changes. The transcript marker gains two small fields that older readers ignore.

Docs: `docs/concepts/session-pruning.md`, `docs/providers/anthropic.md`, `docs/logging.md`.

## Evidence

Unit and contract coverage, each failing on pre-fix code for the intended reason: the next-request flip (`attempt-context-guards`), sticky replay across TTL refresh plus a fresh session state re-derived from the marker and dropped again after compaction, ambiguous tool ids after a later duplicate, TTL gating of new rounds without undoing earlier projections, projection persistence after session-state LRU eviction, stale sources after real SQLite recovery, and the clearing edit/beta/telemetry parity across both Anthropic adapters (direct key, default endpoint, OAuth, proxy, Bedrock, Vertex, Foundry, simple-dispatch alias, environment base URL, explicit `context_management`, exclusions with allow/deny patterns, clearing-before-compaction order). `node scripts/check-changed.mjs` green, including the assertion-safety ratchet, which shrinks by three.

Live, against `api.anthropic.com`:

- **Proxy route (client-side pruning, `ttl: "1m"`, Haiku 4.5 so the 200k window keeps the 30% gate reachable).** After three big-file reads and a 75 s wait, the first request of the next turn soft-trimmed the four oldest tool results (51,182/44,859 chars each → 3,087) and left the last two intact. The trimmed bytes then stayed identical on the same turn's tool-loop continuation and on the two following turns (proxy captures 140–144); on pre-fix code the continuation re-sent the full text. The `openclaw.cache-ttl` marker carried the four keys with `mode: "soft"` in 430 bytes.
- **Direct API-key route (server-side clearing, `cache-ttl` mode, Haiku 4.5).** Four full-file read turns plus a follow-up: every response was 200 and the Gateway logged `[anthropic] server-side context edit: cleared 2 tool results (22500 input tokens)` growing to `cleared 7 tool results (64357 input tokens)` as history grew, with no client-side projection on that route.
- **Clearing does not invalidate Fable 5.1 thinking (API probe).** Replaying a captured Fable 5.1 request carrying three signed thinking blocks and three tool results with `prefix_mismatch_behavior: "error"`: control 200 with `input_transformations: []`; with `clear_tool_uses_20250919` (trigger 1000) the response reported `applied_edits: [{cleared_tool_uses: 3, cleared_input_tokens: 24}]` and still `input_transformations: []`; the repeat request hit the cache (`cache_read_input_tokens` 55,897, `cache_creation_input_tokens` 0). Anthropic's context-editing docs state the same; this confirms it for the binding controls.

Re-proof after the single-owner change (fresh dist from the rebased head, plugin wrapper no longer involved in clearing): the direct-route Haiku 4.5 run again returned 200 on all ten requests and logged `[anthropic] server-side context edit: cleared 2 tool results (23114 input tokens)` once the history crossed the 60k-token trigger; the proxy-route Haiku 4.5 control (client-side pruning) is recorded below.

Proxy-route control on the same rebuilt dist (Haiku 4.5, five distinct big-file reads, `ttl: "1m"`): after the TTL the first request of the next turn soft-trimmed the four oldest results (51,150 chars → 3,087 each) and left the newest intact; the trimmed bytes stayed identical on the tool-loop continuation and the two following turns (proxy captures 167–171), so client-side sticky pruning is unchanged by the single-owner hand-off.

Pruning-off restart proof (after the projection-owner change): the Gateway was restarted with `contextPruning.mode: "off"` on the same proxy-route session that had soft-trimmed four results while pruning was on; its next request still sent the four trimmed results (3,087 chars each) with no prune pass installed — claude-haiku-4-5 msgs=33 tool_results=[3087,3087,3087,3087,51150,65,65,65] status=200.

CI note: the `check-lint-core-4` failure on the current head is `src/node-host/runner.test.ts` exceeding the max-lines limit on `main` (1,103 lines, untouched by this PR); the in-flight fix is #137149. This PR is rebased onto it once it lands.

Rig note for reviewers: Sonnet 4.6, Opus 4.6+, Sonnet 5 and Fable 5 run with a 1M-token window in OpenClaw (`supportsClaude1MContext`), so on those models the 30% pruning gate and the derived 300k-token clearing trigger sit far higher than on Haiku 4.5; the thresholds are unchanged by this PR.
