### PR TITLE
fix(browser): prevent false node navigation proxy timeouts

### DIFF
--- a/extensions/browser/src/browser-tool-dispatch.ts
+++ b/extensions/browser/src/browser-tool-dispatch.ts
@@ -39,7 +39,10 @@ import {
   type BrowserScreenshotOptions,
 } from "./browser-tool.screenshot.js";
 import { appendNavigatedPageState, executeSnapshotAction } from "./browser-tool.snapshot.js";
-import { resolveBrowserNavigationTimeoutMs } from "./browser/act-policy.js";
+import {
+  BROWSER_ACTION_TRANSPORT_SLACK_MS,
+  resolveBrowserNavigationTimeoutMs,
+} from "./browser/act-policy.js";
 import { parseBrowserNavigationUrl } from "./browser/navigation-guard.js";
 
 function readOptionalTargetAndTimeout(params: Record<string, unknown>) {
@@ -235,10 +238,7 @@ export async function executeBrowserTabAction(context: {
     case "navigate": {
       const targetUrl = readTargetUrlParam(params);
       const targetId = readStringParam(params, "targetId");
-      const timeoutMs =
-        requestedTimeoutMs === undefined
-          ? undefined
-          : resolveBrowserNavigationTimeoutMs(requestedTimeoutMs);
+      const timeoutMs = resolveBrowserNavigationTimeoutMs(requestedTimeoutMs);
       const result = proxyRequest
         ? await proxyRequest({
             method: "POST",
@@ -249,7 +249,7 @@ export async function executeBrowserTabAction(context: {
               targetId,
               timeoutMs,
             },
-            timeoutMs,
+            timeoutMs: timeoutMs + BROWSER_ACTION_TRANSPORT_SLACK_MS,
           })
         : await browserNavigate(baseUrl, {
             url: targetUrl,

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -3056,54 +3056,18 @@ describe("browser tool url alias support", () => {
     },
   );
 
-  it("preserves an explicit navigation timeout across node and Gateway watchdogs", async () => {
-    mockSingleBrowserProxyNode();
-    gatewayMocks.callGatewayTool
-      .mockResolvedValueOnce({
-        ok: true,
-        payload: {
-          result: { ok: true, targetId: "tab-1", url: "https://example.com/slow" },
-        },
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        payload: {
-          result: {
-            ok: true,
-            format: "ai",
-            targetId: "tab-1",
-            url: "https://example.com/slow",
-            snapshot: "slow page",
-          },
-        },
-      });
-    const tool = createBrowserTool();
-
-    await tool.execute?.("call-1", {
-      action: "navigate",
-      target: "node",
-      url: "https://example.com/slow",
-      targetId: "tab-1",
-      timeoutMs: 45_000,
-    });
-
-    const { options, request } = nodeInvokeCall(0);
-    expect(options.timeoutMs).toBe(55_000);
-    expect(request.timeoutMs).toBe(50_000);
-    expect(request.params?.timeoutMs).toBe(45_000);
-    expect(request.params?.body).toEqual({
-      url: "https://example.com/slow",
-      targetId: "tab-1",
-      timeoutMs: 45_000,
-    });
-  });
-
   it.each([
-    { requestedTimeoutMs: 10, expectedTimeoutMs: 1_000 },
-    { requestedTimeoutMs: 180_000, expectedTimeoutMs: 120_000 },
-    { requestedTimeoutMs: Number.MAX_SAFE_INTEGER, expectedTimeoutMs: 120_000 },
+    { label: "default", requestedTimeoutMs: undefined, expectedTimeoutMs: 20_000 },
+    { label: "explicit", requestedTimeoutMs: 45_000, expectedTimeoutMs: 45_000 },
+    { label: "minimum", requestedTimeoutMs: 10, expectedTimeoutMs: 1_000 },
+    { label: "maximum", requestedTimeoutMs: 180_000, expectedTimeoutMs: 120_000 },
+    {
+      label: "safe integer maximum",
+      requestedTimeoutMs: Number.MAX_SAFE_INTEGER,
+      expectedTimeoutMs: 120_000,
+    },
   ])(
-    "keeps normalized node navigation timeout $requestedTimeoutMs inside nested watchdogs",
+    "keeps the $label node navigation timeout inside nested watchdogs",
     async ({ requestedTimeoutMs, expectedTimeoutMs }) => {
       mockSingleBrowserProxyNode();
       gatewayMocks.callGatewayTool
@@ -3131,13 +3095,13 @@ describe("browser tool url alias support", () => {
         target: "node",
         url: "https://example.com/slow",
         targetId: "tab-1",
-        timeoutMs: requestedTimeoutMs,
+        ...(requestedTimeoutMs === undefined ? {} : { timeoutMs: requestedTimeoutMs }),
       });
 
       const { options, request } = nodeInvokeCall(0);
-      expect(options.timeoutMs).toBe(expectedTimeoutMs + 10_000);
-      expect(request.timeoutMs).toBe(expectedTimeoutMs + 5_000);
-      expect(request.params?.timeoutMs).toBe(expectedTimeoutMs);
+      expect(options.timeoutMs).toBe(expectedTimeoutMs + 15_000);
+      expect(request.timeoutMs).toBe(expectedTimeoutMs + 10_000);
+      expect(request.params?.timeoutMs).toBe(expectedTimeoutMs + 5_000);
       expect(request.params?.body).toEqual({
         url: "https://example.com/slow",
         targetId: "tab-1",

--- a/extensions/browser/src/browser/client-actions-core.navigation.test.ts
+++ b/extensions/browser/src/browser/client-actions-core.navigation.test.ts
@@ -68,11 +68,14 @@ describe("browser navigation client actions", () => {
     },
   );
 
-  it("preserves the existing navigation watchdog when no timeout is requested", async () => {
+  it("keeps the default navigation timeout inside its transport watchdog", async () => {
     await browserNavigate(undefined, { url: "https://example.com" });
 
     const request = lastNavigationRequest();
-    expect(request.options.timeoutMs).toBe(20_000);
-    expect(JSON.parse(request.options.body ?? "{}")).toEqual({ url: "https://example.com" });
+    expect(request.options.timeoutMs).toBe(25_000);
+    expect(JSON.parse(request.options.body ?? "{}")).toEqual({
+      url: "https://example.com",
+      timeoutMs: 20_000,
+    });
   });
 });

--- a/extensions/browser/src/browser/client-actions-core.ts
+++ b/extensions/browser/src/browser/client-actions-core.ts
@@ -88,14 +88,12 @@ export async function browserNavigate(
   },
 ): Promise<BrowserActionTabResult> {
   const q = buildProfileQuery(opts.profile);
-  const timeoutMs =
-    opts.timeoutMs === undefined ? undefined : resolveBrowserNavigationTimeoutMs(opts.timeoutMs);
+  const timeoutMs = resolveBrowserNavigationTimeoutMs(opts.timeoutMs);
   return await fetchBrowserJson<BrowserActionTabResult>(withBaseUrl(baseUrl, `/navigate${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ url: opts.url, targetId: opts.targetId, timeoutMs }),
-    timeoutMs:
-      timeoutMs === undefined ? 20_000 : resolveBrowserOperationRequestTimeoutMs(timeoutMs),
+    timeoutMs: resolveBrowserOperationRequestTimeoutMs(timeoutMs),
     signal: opts.signal,
   });
 }


### PR DESCRIPTION
Closes #136769

Thanks @CloudDevops for the detailed report and same-target controls.

## What Problem This Solves

Fixes an issue where node-hosted browser navigation could report a generic 20-second proxy timeout while Chrome was healthy and the selected tab still supported snapshots and evaluation.

## Why This Change Was Made

Navigation now keeps its 20-second browser operation limit inside a separate 25-second transport window. The node and Gateway watchdogs remain outside that window, so the browser action settles before an outer proxy timer can replace its result.

The repair applies the same operation-versus-transport boundary to local browser navigation. It does not add a retry, stale-target refresh, setting, or compatibility path.

## User Impact

Operators now receive the browser-owned navigation result or error instead of a misleading healthy-CDP proxy timeout. Snapshot, evaluate, and later navigation remain available on the same target.

## Evidence

- Baseline: `5ecfe38102ce72e723b743b0f2b2a2ef45d479d5`.
- Candidate: `1427129b1fa8c2af52a4c6f97e0911a08da83a17`.
- Real Chromium/CDP red: a delayed no-content navigation reached the endpoint once, then baseline returned `browser proxy timed out ... after 20000ms` at 20.119 seconds with `cdpReady=true`.
- Real Chromium/CDP green: the same scenario returned the browser-owned `page.goto: net::ERR_ABORTED` result at 20.114 seconds with no proxy timeout.
- Same-target controls: tabs, snapshot, evaluate, and a later fast navigation passed before and after the repair.
- Regression: the default nested-watchdog assertion failed on baseline and passes on the candidate.
- Focused tests: `node scripts/run-vitest.mjs extensions/browser/src/browser-tool.test.ts extensions/browser/src/browser/client-actions-core.navigation.test.ts` — 257 passed.
- Focused gates: formatting, Oxlint, conflict markers, max-lines ratchet, assertion-safety ratchet, and extension import-boundary checks passed.
- Line count: production `8 added, 10 removed`; tests `20 added, 53 removed`.
