### PR TITLE
fix(macos): reduce idle CPU while animating the menu bar icon

### DIFF
--- a/apps/macos/Sources/OpenClaw/CritterStatusImage.swift
+++ b/apps/macos/Sources/OpenClaw/CritterStatusImage.swift
@@ -1,0 +1,133 @@
+import AppKit
+import QuartzCore
+import SwiftUI
+
+struct CritterMotionTarget {
+    var value: CGFloat = 0
+    var curve: CritterMotionCurve?
+}
+
+enum CritterMotionCurve {
+    case wiggle, scurryOut, scurryBack
+
+    static let scurryOutDuration = 0.12
+    static let scurryBackDuration = 0.16
+
+    func animation(keyPath: String) -> CABasicAnimation {
+        if self == .wiggle {
+            let spring = CASpringAnimation(keyPath: keyPath)
+            spring.mass = 1
+            spring.stiffness = 220
+            spring.damping = 18
+            spring.duration = spring.settlingDuration
+            spring.timingFunction = CAMediaTimingFunction(name: .linear)
+            return spring
+        }
+        let animation = CABasicAnimation(keyPath: keyPath)
+        animation.duration = self == .scurryOut ? Self.scurryOutDuration : Self.scurryBackDuration
+        animation.timingFunction = CAMediaTimingFunction(name: self == .scurryOut ? .easeInEaseOut : .easeOut)
+        return animation
+    }
+}
+
+struct CritterStatusImage: NSViewRepresentable {
+    var image: NSImage
+    var rotation: CritterMotionTarget
+    var translation: CritterMotionTarget
+    var motionEnabled: Bool
+
+    func makeNSView(context: Context) -> CritterMotionView {
+        CritterMotionView()
+    }
+
+    func updateNSView(_ view: CritterMotionView, context: Context) {
+        view.imageView.image = self.image
+        view.updateMotion(rotation: self.rotation, translation: self.translation, enabled: self.motionEnabled)
+    }
+
+    static func dismantleNSView(_ view: CritterMotionView, coordinator: ()) {
+        view.updateMotion(rotation: .init(), translation: .init(), enabled: false)
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: CritterMotionView, context: Context) -> CGSize? {
+        CGSize(width: 18, height: 18)
+    }
+}
+
+@MainActor
+final class CritterMotionView: NSView {
+    let imageView = NSImageView(frame: NSRect(x: -9, y: -9, width: 18, height: 18))
+    private let rotationView = NSView(frame: NSRect(x: 9, y: 9, width: 0, height: 0))
+    private static let animationPrefix = "openclaw.critter.motion."
+    private var animationSequence: UInt64 = 0
+    private var targetAngle: CGFloat = 0
+    private var targetOffset: CGFloat = 0
+
+    init() {
+        super.init(frame: NSRect(x: 0, y: 0, width: 18, height: 18))
+        self.wantsLayer = true
+        self.rotationView.wantsLayer = true
+        self.imageView.wantsLayer = true
+        // AppKit owns layer anchors. A zero-size, non-clipping parent fixes the pivot at the image center.
+        self.rotationView.clipsToBounds = false
+        self.imageView.imageScaling = .scaleNone
+        self.addSubview(self.rotationView)
+        self.rotationView.addSubview(self.imageView)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func updateMotion(rotation: CritterMotionTarget, translation: CritterMotionTarget, enabled: Bool) {
+        guard let translationLayer = self.layer, let rotationLayer = self.rotationView.layer else { return }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        defer { CATransaction.commit() }
+
+        // Only child transforms move. AppKit retains its frames, anchors, template tint, and backing scale.
+        // The centered pivot stays independent while scurry retargets translation.
+        self.targetAngle = self.update(
+            layer: rotationLayer,
+            keyPath: "sublayerTransform.rotation.z",
+            from: self.targetAngle,
+            to: enabled ? -rotation.value * .pi / 180 : 0,
+            curve: enabled ? rotation.curve : nil)
+        self.targetOffset = self.update(
+            layer: translationLayer,
+            keyPath: "sublayerTransform.translation.x",
+            from: self.targetOffset,
+            to: enabled ? translation.value : 0,
+            curve: enabled ? translation.curve : nil)
+    }
+
+    private func update(
+        layer: CALayer,
+        keyPath: String,
+        from previous: CGFloat,
+        to value: CGFloat,
+        curve: CritterMotionCurve?) -> CGFloat
+    {
+        // A reset also retires a return animation whose model target is already zero.
+        guard let curve else {
+            for key in layer.animationKeys() ?? [] where key.hasPrefix(Self.animationPrefix) {
+                layer.removeAnimation(forKey: key)
+            }
+            layer.setValue(value, forKeyPath: keyPath)
+            return value
+        }
+        guard previous != value else { return previous }
+
+        let animation = curve.animation(keyPath: keyPath)
+        // Both interpolating springs and interrupted timing curves compose additively in SwiftUI.
+        // Retain old tails and compensate from the old model target, not the presentation value.
+        animation.fromValue = previous - value
+        animation.toValue = 0
+        animation.isAdditive = true
+        layer.setValue(value, forKeyPath: keyPath)
+        self.animationSequence &+= 1
+        layer.add(animation, forKey: Self.animationPrefix + String(self.animationSequence))
+        return value
+    }
+}

--- a/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
+++ b/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
@@ -12,10 +12,12 @@ extension CritterStatusLabel {
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            self.iconImage
+            CritterStatusImage(
+                image: self.iconImage,
+                rotation: self.iconRotation,
+                translation: self.iconTranslation,
+                motionEnabled: self.effectiveAnimationsEnabled && !self.earBoostActive)
                 .frame(width: 18, height: 18)
-                .rotationEffect(.degrees(self.wiggleAngle), anchor: .center)
-                .offset(x: self.wiggleOffset)
                 // Avoid Combine's TimerPublisher here: on macOS 26.2 we've seen crashes inside executor checks
                 // triggered by its callbacks. Drive periodic updates via a Swift-concurrency task instead.
                 .task(id: self.tickTaskID) {
@@ -211,7 +213,7 @@ extension CritterStatusLabel {
         }
     }
 
-    private var iconImage: Image {
+    private var iconImage: NSImage {
         let badge: CritterIconRenderer.Badge? = if let prominence = self.iconState.badgeProminence, !self.isPaused {
             CritterIconRenderer.Badge(
                 symbolName: self.iconState.badgeSymbolName,
@@ -223,31 +225,31 @@ extension CritterStatusLabel {
         if self.isPaused {
             // Paused reads as "off duty": awake but with drooped antennae, distinct
             // from idle (perked) and sleeping (drooped + closed eyes).
-            return Image(nsImage: CritterIconRenderer.makeIcon(blink: 0, antennaDroop: 1, badge: nil))
+            return CritterIconRenderer.makeIcon(blink: 0, antennaDroop: 1, badge: nil)
         }
 
         if self.isSleeping {
-            return Image(nsImage: CritterIconRenderer.makeIcon(
+            return CritterIconRenderer.makeIcon(
                 blink: 1,
                 antennaDroop: 1,
                 eyesClosedLines: true,
-                badge: nil))
+                badge: nil)
         }
 
-        return Image(nsImage: CritterIconRenderer.makeIcon(
+        return CritterIconRenderer.makeIcon(
             blink: self.blinkAmount,
             legWiggle: max(self.legWiggle, self.isWorkingNow ? 0.6 : 0),
             earWiggle: self.earWiggle,
             earScale: self.earBoostActive ? 1.9 : 1.0,
             happyEyes: self.celebrating,
-            badge: badge))
+            badge: badge)
     }
 
     private func resetMotion() {
         self.blinkAmount = 0
         self.celebrating = false
-        self.wiggleAngle = 0
-        self.wiggleOffset = 0
+        self.iconRotation = .init()
+        self.iconTranslation = .init()
         self.legWiggle = 0
         self.earWiggle = 0
     }
@@ -277,18 +279,14 @@ extension CritterStatusLabel {
     }
 
     private func wiggle() {
-        let targetAngle = Double.random(in: -4.5...4.5)
+        let targetAngle = CGFloat.random(in: -4.5...4.5)
         let targetOffset = CGFloat.random(in: -0.5...0.5)
-        withAnimation(.interpolatingSpring(stiffness: 220, damping: 18)) {
-            self.wiggleAngle = targetAngle
-            self.wiggleOffset = targetOffset
-        }
+        self.iconRotation = .init(value: targetAngle, curve: .wiggle)
+        self.iconTranslation = .init(value: targetOffset, curve: .wiggle)
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 360_000_000)
-            withAnimation(.interpolatingSpring(stiffness: 220, damping: 18)) {
-                self.wiggleAngle = 0
-                self.wiggleOffset = 0
-            }
+            self.iconRotation = .init(value: 0, curve: .wiggle)
+            self.iconTranslation = .init(value: 0, curve: .wiggle)
         }
     }
 
@@ -305,15 +303,15 @@ extension CritterStatusLabel {
 
     private func scurry() {
         let target = CGFloat.random(in: 0.7...1.0)
-        withAnimation(.easeInOut(duration: 0.12)) {
+        withAnimation(.easeInOut(duration: CritterMotionCurve.scurryOutDuration)) {
             self.legWiggle = target
-            self.wiggleOffset = CGFloat.random(in: -0.6...0.6)
+            self.iconTranslation = .init(value: CGFloat.random(in: -0.6...0.6), curve: .scurryOut)
         }
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 180_000_000)
-            withAnimation(.easeOut(duration: 0.16)) {
+            withAnimation(.easeOut(duration: CritterMotionCurve.scurryBackDuration)) {
                 self.legWiggle = 0.25
-                self.wiggleOffset = 0
+                self.iconTranslation = .init(value: 0, curve: .scurryBack)
             }
         }
     }

--- a/apps/macos/Sources/OpenClaw/CritterStatusLabel.swift
+++ b/apps/macos/Sources/OpenClaw/CritterStatusLabel.swift
@@ -18,8 +18,8 @@ struct CritterStatusLabel: View {
     @State var celebrating = false
     @State var celebrationGeneration = 0
     @State var nextBlink = Date().addingTimeInterval(Double.random(in: 3.5...8.5))
-    @State var wiggleAngle: Double = 0
-    @State var wiggleOffset: CGFloat = 0
+    @State var iconRotation = CritterMotionTarget()
+    @State var iconTranslation = CritterMotionTarget()
     @State var nextWiggle = Date().addingTimeInterval(Double.random(in: 6.5...14))
     @State var legWiggle: CGFloat = 0
     @State var nextLegWiggle = Date().addingTimeInterval(Double.random(in: 5.0...11.0))

--- a/apps/macos/Tests/OpenClawIPCTests/CritterIconRendererTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CritterIconRendererTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import QuartzCore
 import Testing
 @testable import OpenClaw
 
@@ -39,6 +40,109 @@ struct CritterIconRendererTests {
         #expect(celebrating.tiffRepresentation != nil)
     }
 
+    @Test func `icon motion keeps native frames fixed around the image center`() throws {
+        let view = CritterMotionView()
+        let rotation = try #require(view.imageView.superview)
+        let rotationLayer = try #require(rotation.layer)
+        let translationLayer = try #require(view.layer)
+        let imageFrame = view.imageView.frame
+        let rotationFrame = rotation.frame
+        let imageCenter = NSPoint(x: view.imageView.bounds.midX, y: view.imageView.bounds.midY)
+        let pivot = view.imageView.convert(imageCenter, to: rotation)
+        #expect(pivot == .zero)
+        #expect(rotationLayer.bounds.size == .zero)
+
+        for (angle, offset) in [(CGFloat(4), CGFloat(0.5)), (-3, -0.4)] {
+            view.updateMotion(rotation: .init(value: angle), translation: .init(value: offset), enabled: true)
+            #expect(view.frame == NSRect(x: 0, y: 0, width: 18, height: 18))
+            #expect(view.imageView.frame == imageFrame)
+            #expect(rotation.frame == rotationFrame)
+            // Detached AppKit backing layers are unlinked; combine their model transforms in view coordinates.
+            let rotated = pivot.applying(CATransform3DGetAffineTransform(rotationLayer.sublayerTransform))
+            let center = rotation.convert(rotated, to: view)
+                .applying(CATransform3DGetAffineTransform(translationLayer.sublayerTransform))
+            #expect(abs(center.x - (9 + offset)) < 0.001)
+            #expect(abs(center.y - 9) < 0.001)
+        }
+    }
+
+    @Test func `icon motion retargets independent channels from their model targets`() throws {
+        let view = CritterMotionView()
+        let translation = SampledPresentationLayer()
+        translation.sampledPresentation = SampledPresentationLayer()
+        // Sampling a presentation with an active tail would count that tail twice when retargeting.
+        translation.sampledPresentation?.setValue(8, forKeyPath: "sublayerTransform.translation.x")
+        view.layer = translation
+        let rotation = try #require(view.imageView.superview?.layer)
+
+        view.updateMotion(
+            rotation: .init(value: 4, curve: .wiggle), translation: .init(value: 0.5, curve: .wiggle), enabled: true)
+        let rotationKeys = Set(rotation.animationKeys() ?? [])
+        let translationKeys = Set(translation.animationKeys() ?? [])
+        #expect(rotationKeys.count == 1)
+        #expect(translationKeys.count == 1)
+
+        view.updateMotion(
+            rotation: .init(value: 4, curve: .wiggle), translation: .init(value: 0.5, curve: .scurryOut), enabled: true)
+        #expect(Set(rotation.animationKeys() ?? []) == rotationKeys)
+        #expect(Set(translation.animationKeys() ?? []) == translationKeys)
+
+        view.updateMotion(
+            rotation: .init(value: 4, curve: .wiggle),
+            translation: .init(value: -0.4, curve: .scurryOut),
+            enabled: true)
+        let retargetedTranslationKeys = Set(translation.animationKeys() ?? [])
+        #expect(Set(rotation.animationKeys() ?? []) == rotationKeys)
+        #expect(retargetedTranslationKeys.isSuperset(of: translationKeys))
+        #expect(retargetedTranslationKeys.count == translationKeys.count + 1)
+        let translationKey = try #require(retargetedTranslationKeys.subtracting(translationKeys).first)
+        let translationAnimation = try #require(translation.animation(forKey: translationKey) as? CABasicAnimation)
+        let translationResidual = try #require(translationAnimation.fromValue as? CGFloat)
+        #expect(abs(translationResidual - 0.9) < 0.001)
+        #expect(translationAnimation.toValue as? CGFloat == 0)
+        #expect(translationAnimation.isAdditive)
+        #expect(translation.value(forKeyPath: "sublayerTransform.translation.x") as? CGFloat == -0.4)
+
+        view.updateMotion(
+            rotation: .init(value: -3, curve: .wiggle),
+            translation: .init(value: -0.4, curve: .scurryBack),
+            enabled: true)
+        let retargetedRotationKeys = Set(rotation.animationKeys() ?? [])
+        #expect(Set(translation.animationKeys() ?? []) == retargetedTranslationKeys)
+        #expect(retargetedRotationKeys.isSuperset(of: rotationKeys))
+        #expect(retargetedRotationKeys.count == rotationKeys.count + 1)
+        let rotationKey = try #require(retargetedRotationKeys.subtracting(rotationKeys).first)
+        let rotationAnimation = try #require(rotation.animation(forKey: rotationKey) as? CABasicAnimation)
+        let rotationResidual = try #require(rotationAnimation.fromValue as? CGFloat)
+        #expect(abs(rotationResidual + 7 * .pi / 180) < 0.001)
+        #expect(rotationAnimation.toValue as? CGFloat == 0)
+        #expect(rotationAnimation.isAdditive)
+    }
+
+    @Test(arguments: [false, true])
+    func `icon motion reset retires only owned animations even at a zero target`(disabled: Bool) throws {
+        let view = CritterMotionView()
+        let layers = try [#require(view.layer), #require(view.imageView.superview?.layer)]
+        view.updateMotion(
+            rotation: .init(value: 4, curve: .wiggle), translation: .init(value: 0.5, curve: .scurryOut), enabled: true)
+        view.updateMotion(
+            rotation: .init(value: 0, curve: .wiggle), translation: .init(value: 0, curve: .scurryBack), enabled: true)
+        for layer in layers {
+            #expect(layer.animationKeys()?.count == 2)
+            let foreign = CABasicAnimation(keyPath: "opacity")
+            foreign.duration = 10
+            layer.add(foreign, forKey: "foreign.animation")
+        }
+
+        let reset = disabled ? CritterMotionTarget(value: 9, curve: .wiggle) : .init()
+        view.updateMotion(rotation: reset, translation: reset, enabled: !disabled)
+        for layer in layers {
+            #expect(layer.animationKeys() == ["foreign.animation"])
+        }
+        #expect(layers[0].value(forKeyPath: "sublayerTransform.translation.x") as? CGFloat == 0)
+        #expect(layers[1].value(forKeyPath: "sublayerTransform.rotation.z") as? CGFloat == 0)
+    }
+
     @Test func `idle critter sleeps until its next animation`() {
         let now = Date(timeIntervalSinceReferenceDate: 100)
         let delay = CritterStatusLabel.nextAnimationTickDelay(
@@ -62,5 +166,13 @@ struct CritterIconRendererTests {
             deadlines: [now.addingTimeInterval(8)])
 
         #expect(delay == 0.35)
+    }
+}
+
+private final class SampledPresentationLayer: CALayer {
+    var sampledPresentation: SampledPresentationLayer?
+
+    override func presentation() -> Self? {
+        self.sampledPresentation as? Self
     }
 }


### PR DESCRIPTION
Related: #136572, #136741

## What Problem This Solves

Fixes an issue where leaving the macOS menu-bar icon animated consumed about 3% of one CPU core even with every app window closed. Turning animation off reduced the same Release-optimized binary to 0.03%, isolating the remaining cost to the icon rather than Gateway polling.

## Why This Change Was Made

Move whole-icon rotation and translation from SwiftUI layout into explicit Core Animation on a fixed-size native image view. The native leaf owns motion; SwiftUI still owns the existing blink, leg, antenna, work, celebration, attention, and voice-meter state. AppKit retains image/template rendering and its own layer geometry. Independent additive animations preserve overlapping spring and scurry targets, with owner-scoped cancellation on reset or dismantle.

The rotation pivot is a non-clipping zero-size parent centered on the image; this avoids assuming or changing AppKit's layer anchor. The old whole-image `rotationEffect`/`offset` path is removed. No animation cadence, settings, Gateway behavior, dependency, schema, or protocol changes.

## User Impact

The icon stays animated without paying for repeated hosting-view layout. Fresh-launch idle fell from **3.033% to 0.158% CPU (95% lower)**. After dashboard/settings interaction, a matched two-minute run fell from **3.175% to 0.908% (71% lower)**. Animations remain enabled in both comparisons. This is not a claim that all post-window idle energy costs are eliminated.

## Evidence

- Real Foundation-signed arm64 app, Release `-O` build, matching dSYM, strict/deep signature verification. Baseline native source: `008d9d2c42d68e3f3a356b38d467c979b7cf1f9a`. Same isolated profile and unchanged Gateway process; General → Connection → General, then all windows closed and a quiet warmup. No builds, profiler, capture, or UI interaction during the CPU windows.
- Unprofiled 120-second cumulative CPU: baseline **3.17487%**, candidate **0.90830%**; Gateway **0.35832%** in both windows. Separate same-baseline fresh-launch ON/OFF control: **3.03332% / 0.03333%**.
- Fresh-launch control, with no activation or window interaction: **0.15833% CPU over 120 seconds**, Gateway **0.35832%**. Separate fresh-candidate Time Profiler + Activity Monitor: **0.17327% CPU**, **2.39 wakeups/s** over 56.98 seconds, 110 complete sampled milliseconds; no App Nap. Startup can preload WebKit, so this is a no-UI-interaction control, not a claim that WebKit is absent.
- Post-window candidate Time Profiler + Activity Monitor: **0.826% CPU over 56.02 seconds**, 485 complete sampled milliseconds, hosting-view layout **6 ms inclusive**. Residual **263.8 wakeups/s** include WebKit display-link/scavenger work after dashboard interaction. The earlier baseline wakeup trace was collected before the same UI history, so it is **not a valid wakeup A/B comparison**.
- Live Settings toggle **ON → OFF → ON** verified through native Accessibility state. Icon-only captured frames show retained pose changes; two OFF stills 12 seconds apart remain unchanged. Captures prove sampled visible behavior, not frame-perfect interpolation or FPS.
- Four focused regression cases passed in a signed, source-audited sandbox: fixed native geometry/centered pivot, independent additive retargeting from model targets, and reset cleanup even when a return animation already targets zero. The same test declarations fail the incorrect pre-pivot implementation. Full-project macOS coverage also passed in the hosted Swift test phase; no full GUI test suite was run on the operator desktop.
- Final committed-head independent Codex autoreview: no actionable P0–P2 findings. Both hosted macOS release and complete shared/app Swift-test phases passed in [CI run33718361532](https://github.com/openclaw/openclaw/actions/runs/33718361532), and `openclaw/ci-gate` is green for `70a3d475d8a5bec7055634372d363dd48c607a46`. SwiftFormat, strict SwiftLint, and diff-check pass. The final source differs from the measured binary only in whitespace required by SwiftLint.

Both native binaries used the same older auxiliary payload (`1623683f478b1e4a2e3d5632585f006ea142e08c`) and preserved proof bundle identifier. These are optimized native profiling bundles, not a distributable/notarized release. Measurements are from macOS 27 beta / Xcode 27 beta; animation is randomized, so repeated windows can vary.

Production delta: **+131 lines net**; tests: **+112 lines**. Growth introduces the native rendering owner, explicit curve mapping, fixed centered geometry, and lifecycle-scoped animation cleanup. The former SwiftUI whole-icon motion path is deleted; no second rendering path or fallback is retained.

### Before / after sampled icon motion

These inspected, synthetic-only crops exclude neighboring menu items and unrelated desktop content. Requested and actual source timestamps are printed to avoid counting repeated video frames as new animation samples.

Before:
![Baseline icon motion](https://github.com/user-attachments/assets/77cbbe07-6a40-4422-a042-4dbd9cf0d5b4)

After:
![Native compositor icon motion](https://github.com/user-attachments/assets/249aac08-47aa-4da9-8211-752a49974be7)

### Named follow-up

Investigate hidden-dashboard WebKit display-link wakeups. The dashboard retains its main controller/web view after close and also owns background notification behavior; destroying it merely to improve an idle counter would change that contract. This PR leaves that separate lifecycle boundary unchanged.

At landing preparation, ClawSweeper had posted only its review-start placeholder, with no published findings or Rank-up moves. Independent review and exact-head CI are complete. The isolated profiling app, Gateway service, state, and preferences have been cleaned up; signed builds and private traces are retained locally.
