### PR TITLE
fix(imessage): recover stalled private bridge

### DIFF
--- a/extensions/imessage/src/bridge-recovery.ts
+++ b/extensions/imessage/src/bridge-recovery.ts
@@ -1,0 +1,53 @@
+import { spawn } from "node:child_process";
+
+const BRIDGE_RECOVERY_TIMEOUT_MS = 30_000;
+const recoveries = new Map<string, Promise<void>>();
+
+/**
+ * Re-inject the private bridge after imsg has positively identified it as
+ * unresponsive. This deliberately does not retry the failed mutation: imsg may
+ * still reconcile a published send, so replaying it could duplicate a message.
+ */
+export function recoverIMessageBridge(cliPath: string): Promise<void> {
+  const existing = recoveries.get(cliPath);
+  if (existing) {
+    return existing;
+  }
+
+  const recovery = new Promise<void>((resolve, reject) => {
+    const child = spawn(cliPath, ["launch", "--json"], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => {
+      if (stderr.length < 4096) {
+        stderr += String(chunk).slice(0, 4096 - stderr.length);
+      }
+    });
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error("imsg launch timed out while recovering the private API bridge"));
+    }, BRIDGE_RECOVERY_TIMEOUT_MS);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const detail = stderr.trim();
+      reject(
+        new Error(
+          `imsg launch failed (${signal ? `signal ${signal}` : `exit ${code ?? "unknown"}`})${detail ? `: ${detail}` : ""}`,
+        ),
+      );
+    });
+  }).finally(() => {
+    recoveries.delete(cliPath);
+  });
+  recoveries.set(cliPath, recovery);
+  return recovery;
+}

--- a/extensions/imessage/src/bridge-recovery.ts
+++ b/extensions/imessage/src/bridge-recovery.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { runIMessageCliJsonCommand } from "./cli-output.js";
 
 const BRIDGE_RECOVERY_TIMEOUT_MS = 30_000;
 const recoveries = new Map<string, Promise<void>>();
@@ -14,40 +14,15 @@ export function recoverIMessageBridge(cliPath: string): Promise<void> {
     return existing;
   }
 
-  const recovery = new Promise<void>((resolve, reject) => {
-    const child = spawn(cliPath, ["launch", "--json"], {
-      stdio: ["ignore", "ignore", "pipe"],
+  const recovery = runIMessageCliJsonCommand({
+    cliPath,
+    args: ["launch"],
+    timeoutMs: BRIDGE_RECOVERY_TIMEOUT_MS,
+  })
+    .then(() => undefined)
+    .finally(() => {
+      recoveries.delete(cliPath);
     });
-    let stderr = "";
-    child.stderr?.on("data", (chunk) => {
-      if (stderr.length < 4096) {
-        stderr += String(chunk).slice(0, 4096 - stderr.length);
-      }
-    });
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error("imsg launch timed out while recovering the private API bridge"));
-    }, BRIDGE_RECOVERY_TIMEOUT_MS);
-    child.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-    child.once("close", (code, signal) => {
-      clearTimeout(timer);
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      const detail = stderr.trim();
-      reject(
-        new Error(
-          `imsg launch failed (${signal ? `signal ${signal}` : `exit ${code ?? "unknown"}`})${detail ? `: ${detail}` : ""}`,
-        ),
-      );
-    });
-  }).finally(() => {
-    recoveries.delete(cliPath);
-  });
   recoveries.set(cliPath, recovery);
   return recovery;
 }

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -478,7 +478,7 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
     runIMessageCliJsonCommandMock.mockRejectedValueOnce(recoveryError);
     const client = new IMessageRpcClient({
       cliPath: "/tmp/imsg-stall-recovery-failure",
-      runtime: { error: runtimeError },
+      runtime: { error: runtimeError, exit: vi.fn(), log: vi.fn() },
     });
     await client.start();
     const pending = client.request("send", {}, { timeoutMs: 0 });
@@ -498,7 +498,11 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
       ),
     );
 
-    const error = (await pending.catch((cause: unknown) => cause)) as IMessageRpcRequestError;
+    const error = await pending.catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(IMessageRpcRequestError);
+    if (!(error instanceof IMessageRpcRequestError)) {
+      throw new Error("expected an IMessageRpcRequestError");
+    }
     expect(error).toMatchObject({
       code: -32603,
       data: { disposition: "may_have_completed", retry_safe: false },

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -48,6 +48,12 @@ function createMockChild(): MockChild {
   return child;
 }
 
+function createCompletedMockChild(exitCode = 0): MockChild {
+  const child = createMockChild();
+  queueMicrotask(() => child.emit("close", exitCode, null));
+  return child;
+}
+
 let IMessageRpcClient: typeof import("./client.js").IMessageRpcClient;
 let IMessageRpcRequestError: typeof import("./client.js").IMessageRpcRequestError;
 let privateApiStatus: typeof import("./private-api-status.js");
@@ -75,7 +81,11 @@ describe("IMessageRpcClient child stream error handling", () => {
     vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("VITEST", "");
     child = createMockChild();
-    spawnMock.mockReset().mockReturnValue(child);
+    spawnMock
+      .mockReset()
+      .mockImplementation((_command, args: string[]) =>
+        args[0] === "launch" ? createCompletedMockChild() : child,
+      );
   });
 
   afterEach(async () => {
@@ -413,7 +423,11 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
     vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("VITEST", "");
     child = createMockChild();
-    spawnMock.mockReset().mockReturnValue(child);
+    spawnMock
+      .mockReset()
+      .mockImplementation((_command, args: string[]) =>
+        args[0] === "launch" ? createCompletedMockChild() : child,
+      );
   });
 
   afterEach(() => {
@@ -454,6 +468,12 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
     const error = await pending.catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(IMessageRpcRequestError);
     expect(privateApiStatus.getCachedIMessagePrivateApiStatus(cliPath)).toBeUndefined();
+    expect(spawnMock).toHaveBeenNthCalledWith(
+      2,
+      cliPath,
+      ["launch", "--json"],
+      expect.objectContaining({ stdio: ["ignore", "ignore", "pipe"] }),
+    );
 
     child.emit("close", 0, null);
     await client.stop();

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -6,9 +6,14 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import type { IMessagePrivateApiStatus } from "./private-api-status.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const runIMessageCliJsonCommandMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
   spawn: spawnMock,
+}));
+
+vi.mock("./cli-output.js", () => ({
+  runIMessageCliJsonCommand: runIMessageCliJsonCommandMock,
 }));
 
 // A dead imsg helper can emit an async `error` on any of its stdio streams. On
@@ -48,12 +53,6 @@ function createMockChild(): MockChild {
   return child;
 }
 
-function createCompletedMockChild(exitCode = 0): MockChild {
-  const child = createMockChild();
-  queueMicrotask(() => child.emit("close", exitCode, null));
-  return child;
-}
-
 let IMessageRpcClient: typeof import("./client.js").IMessageRpcClient;
 let IMessageRpcRequestError: typeof import("./client.js").IMessageRpcRequestError;
 let privateApiStatus: typeof import("./private-api-status.js");
@@ -68,6 +67,7 @@ beforeAll(async () => {
 
 afterAll(() => {
   vi.doUnmock("node:child_process");
+  vi.doUnmock("./cli-output.js");
   vi.resetModules();
 });
 
@@ -81,11 +81,8 @@ describe("IMessageRpcClient child stream error handling", () => {
     vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("VITEST", "");
     child = createMockChild();
-    spawnMock
-      .mockReset()
-      .mockImplementation((_command, args: string[]) =>
-        args[0] === "launch" ? createCompletedMockChild() : child,
-      );
+    spawnMock.mockReset().mockReturnValue(child);
+    runIMessageCliJsonCommandMock.mockReset().mockResolvedValue({ status: "launched" });
   });
 
   afterEach(async () => {
@@ -423,11 +420,8 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
     vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("VITEST", "");
     child = createMockChild();
-    spawnMock
-      .mockReset()
-      .mockImplementation((_command, args: string[]) =>
-        args[0] === "launch" ? createCompletedMockChild() : child,
-      );
+    spawnMock.mockReset().mockReturnValue(child);
+    runIMessageCliJsonCommandMock.mockReset().mockResolvedValue({ status: "launched" });
   });
 
   afterEach(() => {
@@ -468,11 +462,50 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
     const error = await pending.catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(IMessageRpcRequestError);
     expect(privateApiStatus.getCachedIMessagePrivateApiStatus(cliPath)).toBeUndefined();
-    expect(spawnMock).toHaveBeenNthCalledWith(
-      2,
+    expect(runIMessageCliJsonCommandMock).toHaveBeenCalledWith({
       cliPath,
-      ["launch", "--json"],
-      expect.objectContaining({ stdio: ["ignore", "ignore", "pipe"] }),
+      args: ["launch"],
+      timeoutMs: 30_000,
+    });
+
+    child.emit("close", 0, null);
+    await client.stop();
+  });
+
+  it("logs recovery failure while preserving the original structured error", async () => {
+    const recoveryError = new Error("launch stderr stream failed");
+    const runtimeError = vi.fn();
+    runIMessageCliJsonCommandMock.mockRejectedValueOnce(recoveryError);
+    const client = new IMessageRpcClient({
+      cliPath: "/tmp/imsg-stall-recovery-failure",
+      runtime: { error: runtimeError },
+    });
+    await client.start();
+    const pending = client.request("send", {}, { timeoutMs: 0 });
+    pending.catch(() => {});
+    child.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          error: {
+            code: -32603,
+            message: "Timed out waiting for response to 'send-message'",
+            data: { disposition: "may_have_completed", retry_safe: false },
+          },
+        })}\n`,
+      ),
+    );
+
+    const error = (await pending.catch((cause: unknown) => cause)) as IMessageRpcRequestError;
+    expect(error).toMatchObject({
+      code: -32603,
+      data: { disposition: "may_have_completed", retry_safe: false },
+    });
+    expect(error.message).toContain("Timed out waiting for response to 'send-message'");
+    expect(runtimeError).toHaveBeenCalledWith(
+      "imessage: automatic bridge recovery failed: launch stderr stream failed",
     );
 
     child.emit("close", 0, null);

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -5,6 +5,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
+import { recoverIMessageBridge } from "./bridge-recovery.js";
 import { expandIMessageUserPath } from "./cli-path.js";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
 import { invalidateCachedIMessagePrivateApiStatus } from "./private-api-status.js";
@@ -292,6 +293,13 @@ export class IMessageRpcClient {
       // re-probe and report the real state.
       if (isIMessageBridgeStall(err)) {
         invalidateCachedIMessagePrivateApiStatus(this.configuredCliPath);
+        try {
+          await recoverIMessageBridge(this.cliPath);
+        } catch (recoveryError) {
+          this.runtime?.error?.(
+            `imessage: automatic bridge recovery failed: ${formatErrorMessage(recoveryError)}`,
+          );
+        }
         throw describeIMessageBridgeStall(err);
       }
       throw err;

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -294,7 +294,7 @@ export class IMessageRpcClient {
       if (isIMessageBridgeStall(err)) {
         invalidateCachedIMessagePrivateApiStatus(this.configuredCliPath);
         try {
-          await recoverIMessageBridge(this.cliPath);
+          await recoverIMessageBridge(this.configuredCliPath);
         } catch (recoveryError) {
           this.runtime?.error?.(
             `imessage: automatic bridge recovery failed: ${formatErrorMessage(recoveryError)}`,


### PR DESCRIPTION
## Summary

- automatically run one coalesced `imsg launch --json` recovery after imsg positively identifies its injected Messages.app helper as unresponsive
- preserve the original structured delivery error and never replay the failed mutation, avoiding duplicate-message risk
- keep client-side RPC deadlines and ordinary request errors outside the recovery path

Closes #137026. Follows #134572. `openclaw/imsg#253` is complementary and is not a dependency.

## Redacted production proof

A retained local trace from OpenClaw 2026.8.2 shows:

| Relative time | Event |
|---|---|
| `T+00:00` | inbound group message entered the expected agent session |
| `T+00:19` | agent completed its response and invoked outbound delivery |
| `T+02:49` | imsg returned `code=-32603 Timed out waiting for response to 'send-message'` |\n| `T+03:04` | agent attempted one shorter response |\n| `T+05:34` | the second send returned the same structured timeout |\n| `T+05:38` | run ended without a visible reply |\n\nPhone numbers, participants, chat/message GUIDs, content, and local paths are omitted. The trace establishes that model execution completed before both transport failures.\n\n## Safety contract\n\nThe trigger is imsg's structured post-publication bridge timeout, not OpenClaw's local `imsg rpc timeout (...)`. Recovery is single-flight per configured CLI path. The timed-out mutation is not retried because it may have completed late.\n\n## Validation\n\n- `node --import ./scripts/tsx.mjs scripts/test-extension.mts imessage`: 56 files and 1,211 tests passed\n- focused `client.test.ts`: 18 tests passed\n- `git diff --check`\n- local autoreview at P0/P1: scoped clean\n\n## Proof gap\n\nThe deterministic regression covers the exact structured production error, recovery invocation, cache invalidation, and no-replay behavior. Deliberate bridge fault injection has not been run because it interrupts Messages.app; that live proof should use the isolated development gateway before this leaves draft.