### PR TITLE
fix(ui): prevent blank retained auth proof screenshots

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -484,7 +484,12 @@ JSON report together. Mantis allocates an invocation directory for setup logs,
 capture attempts, and its report; the builder preserves each attempt's relative
 paths and refuses to overwrite an existing report.
 
-Separate output owners remain: real-Gateway suites, `chat-outbox-*`, and
+The real-Gateway auth transport suite also allocates one fresh directory per
+suite invocation. Its screenshots wait for meaningful content and the presentation
+owner's finite entrance or resize animations, while perpetual descendant activity
+continues.
+
+Separate output owners remain: other real-Gateway suites, `chat-outbox-*`, and
 `chat-attachment-read-lifecycle`. Do not assume those owners have the ordinary
 mocked proof retention guarantee.
 

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -740,11 +740,14 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
       gatewayPortClosed: gateway ? await isPortClosed("127.0.0.1", gateway.port) : true,
       proxyPortClosed: proxy ? await isPortClosed("127.0.0.1", proxy.port) : true,
     };
-    await writeFile(
-      path.join(artifactDir, "cleanup-summary.json"),
-      `${JSON.stringify(cleanup, null, 2)}\n`,
-      "utf8",
-    );
+    // Setup can reject before this invocation allocates retained evidence.
+    if (artifactDir) {
+      await writeFile(
+        path.join(artifactDir, "cleanup-summary.json"),
+        `${JSON.stringify(cleanup, null, 2)}\n`,
+        "utf8",
+      );
+    }
     expect(cleanup).toEqual({
       gatewayPortClosed: true,
       proxyPortClosed: true,

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -1,12 +1,12 @@
 // Control UI tests prove trusted-proxy and browser-origin auth through real transports.
 import { createHash } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage } from "node:http";
 import net from "node:net";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
@@ -17,6 +17,8 @@ import {
 } from "../../../src/test-utils/openclaw-test-state.js";
 import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.js";
 import type { ApplicationRuntime } from "../app/bootstrap.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   controlUiE2eWaitTimeoutMs,
@@ -31,11 +33,7 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.resolve(
-  process.cwd(),
-  process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() ||
-    ".artifacts/control-ui-e2e/control-ui-auth-transports",
-);
+let artifactDir: string;
 const viewport = { height: 900, width: 1280 };
 const trustedProxyUser = "qa-operator";
 const configProofIdentifier = "9223372036854775807";
@@ -495,7 +493,6 @@ async function createBrowserPage(
   errors: string[];
   page: Page;
 }> {
-  await mkdir(artifactDir, { recursive: true });
   const context = await browser.newContext({
     locale: "en-US",
     recordVideo: captureUiProofEnabled ? { dir: artifactDir, size: viewport } : undefined,
@@ -544,23 +541,30 @@ async function closeOpenContexts(): Promise<void> {
   );
 }
 
-async function captureChromiumScreenshot(page: Page, fileName: string): Promise<void> {
+async function captureChromiumScreenshot(
+  fileName: string,
+  surface: Locator,
+  content: readonly Locator[],
+): Promise<void> {
   if (!captureUiProofEnabled) {
     return;
   }
-  const session = await page.context().newCDPSession(page);
-  try {
-    // The live dashboard keeps rendering while RPCs settle. Capture the current
-    // Chromium surface directly so proof does not wait on unrelated UI activity.
-    const result = await session.send("Page.captureScreenshot", {
-      captureBeyondViewport: false,
-      format: "png",
-      fromSurface: true,
-    });
-    await writeFile(path.join(artifactDir, fileName), Buffer.from(result.data, "base64"));
-  } finally {
-    await session.detach();
-  }
+  const image = await takeControlUiViewportScreenshot(surface.page(), surface, content);
+  await writeFile(path.join(artifactDir, fileName), image);
+}
+
+async function captureConnectedAuth(fileName: string, page: Page): Promise<void> {
+  await captureChromiumScreenshot(fileName, page.locator(".shell"), [
+    page.getByRole("textbox", { name: "WebSocket URL", exact: true }),
+    page.getByText("Authenticated via trusted proxy.", { exact: true }),
+  ]);
+}
+
+async function captureRejectedAuth(fileName: string, failure: Locator): Promise<void> {
+  await captureChromiumScreenshot(fileName, failure.page().locator(".login-gate__card"), [
+    failure.locator(".login-gate__failure-title"),
+    failure.locator(".login-gate__failure-steps"),
+  ]);
 }
 
 async function verifyGatewayServedControlUiBundle(httpUrl: string): Promise<{
@@ -707,7 +711,11 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
         `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}.`,
       );
     }
-    await mkdir(artifactDir, { recursive: true });
+    artifactDir = createControlUiE2eArtifactDir(
+      "control-ui-auth-transports",
+      process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() ||
+        ".artifacts/control-ui-e2e/control-ui-auth-transports",
+    );
     allowedUi = await startControlUiE2eServer();
     // A lightweight proxy supplies the distinct rejected Origin without starting
     // a second Vite compiler in the already resource-intensive browser shard.
@@ -769,7 +777,11 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     await expect.poll(() => rawEditorBefore.inputValue()).toContain(`"${configProofIdentifier}"`);
     await expect.poll(() => rawEditorBefore.inputValue()).toContain(configProofPrefixBefore);
     await rawEditorBefore.scrollIntoViewIfNeeded();
-    await captureChromiumScreenshot(connected.page, "01-real-config-id-before.png");
+    await captureChromiumScreenshot(
+      "01-real-config-id-before.png",
+      connected.page.locator(".shell"),
+      [rawEditorBefore],
+    );
 
     const settingsUrl = new URL("settings/communications", gateway.httpUrl);
     settingsUrl.searchParams.set("section", "messages");
@@ -830,7 +842,11 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
       "utf8",
     );
     console.info(`[real-config-id-proof] ${JSON.stringify(proof)}`);
-    await captureChromiumScreenshot(connected.page, "02-real-config-id-after.png");
+    await captureChromiumScreenshot(
+      "02-real-config-id-after.png",
+      connected.page.locator(".shell"),
+      [rawEditor],
+    );
     expect(connected.errors).toEqual([]);
     await closeContext(connected.context);
   });
@@ -857,7 +873,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     expect(await failure.locator(".login-gate__command").count()).toBe(0);
     expect(untrustedEvidence.identityInjected).toBe(false);
     expect(untrustedEvidence.requiredHeaderInjected).toBe(false);
-    await captureChromiumScreenshot(rejected.page, "02-untrusted-proxy-rejected.png");
+    await captureRejectedAuth("02-untrusted-proxy-rejected.png", failure);
     expect(rejected.errors).toEqual([]);
     await closeContext(rejected.context);
 
@@ -882,7 +898,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     expect(trustedEvidence.requiredHeaderInjected).toBe(true);
     expect(trustedEvidence.gatewayResult?.recoveryScope).toMatch(/^[A-Za-z0-9_-]+$/u);
     expect(trustedEvidence.gatewayResult?.recoveryScope).not.toContain(trustedProxyUser);
-    await captureChromiumScreenshot(connected.page, "01-trusted-proxy-connected.png");
+    await captureConnectedAuth("01-trusted-proxy-connected.png", connected.page);
     expect(connected.errors).toEqual([]);
     await closeContext(connected.context);
 
@@ -1006,7 +1022,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
           entry.upstreamHandshakeStatus === 403),
       rejected.evidenceStartIndex,
     );
-    await captureChromiumScreenshot(rejected.page, "04-rejected-origin-recovery.png");
+    await captureRejectedAuth("04-rejected-origin-recovery.png", originFailure);
     expect(rejected.errors).toEqual([]);
     await closeContext(rejected.context);
 
@@ -1020,7 +1036,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
         entry.gatewayResult?.ok === true,
       allowed.evidenceStartIndex,
     );
-    await captureChromiumScreenshot(allowed.page, "03-allowed-origin-connected.png");
+    await captureConnectedAuth("03-allowed-origin-connected.png", allowed.page);
     expect(allowed.errors).toEqual([]);
     await closeContext(allowed.context);
 

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -1,10 +1,15 @@
 // Control UI tests cover the initial-connect splash shown instead of the
 // login gate while the Gateway resolves its first connection attempt.
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
 import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import {
+  takeControlUiViewportScreenshot,
+  waitForControlUiProofSurface,
+} from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
   canRunPlaywrightChromium,
   controlUiE2eWaitTimeoutMs,
@@ -42,32 +47,35 @@ async function createPage(): Promise<Page> {
   return page;
 }
 
-async function waitForSettledSurface(page: Page): Promise<void> {
-  // Playwright visibility ignores opacity. Let entrance/resize motion finish;
-  // do not fast-forward animations or wait for perpetual descendant motion.
-  const surface = page.locator(".connect-splash, .shell");
-  await expect
-    .poll(() =>
-      surface.evaluate(
-        (element) =>
-          getComputedStyle(element).opacity === "1" &&
-          element
-            .getAnimations()
-            .filter((animation) => Number.isFinite(animation.effect?.getComputedTiming().endTime))
-            .every((animation) => animation.playState === "finished"),
-      ),
-    )
-    .toBe(true);
-}
-
 async function takeProofScreenshot(page: Page, name: string, content: Locator[]): Promise<Buffer> {
-  // Lazy hosts can have boxes before their definitions or children have loaded.
-  await Promise.all(content.map((locator) => locator.waitFor()));
-  await waitForSettledSurface(page);
+  await waitForControlUiProofSurface(page.locator(".connect-splash, .shell"), content);
   return page.screenshot({
     fullPage: true,
     ...(artifactDir ? { path: path.join(artifactDir, `${name}.png`) } : {}),
   });
+}
+
+async function proofContentPainted(page: Page, proof: Buffer, content: Locator): Promise<boolean> {
+  const contentBounds = await content.boundingBox();
+  expect(contentBounds).not.toBeNull();
+  return page.evaluate(
+    async ({ png, bounds }) => {
+      const image = new Image();
+      image.src = `data:image/png;base64,${png}`;
+      await image.decode();
+      const crop = document.createElement("canvas");
+      crop.width = bounds.width;
+      crop.height = bounds.height;
+      const context = crop.getContext("2d")!;
+      context.drawImage(image, -bounds.x, -bounds.y);
+      const pixels = context.getImageData(0, 0, crop.width, crop.height).data;
+      // Reject a flat (or effectively invisible) crop without fixing the pose or palette.
+      return pixels.some(
+        (value, index) => index % 4 !== 3 && Math.abs(value - pixels[index % 4]!) > 10,
+      );
+    },
+    { png: proof.toString("base64"), bounds: contentBounds! },
+  );
 }
 
 async function captureProof(page: Page, name: string, content: Locator[]): Promise<void> {
@@ -163,24 +171,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     const proof = await takeProofScreenshot(page, "01-centered-connecting-mascot", [
       mascot.locator("canvas"),
     ]);
-    const painted = await page.evaluate(
-      async ({ png, bounds }) => {
-        const image = new Image();
-        image.src = `data:image/png;base64,${png}`;
-        await image.decode();
-        const crop = document.createElement("canvas");
-        crop.width = bounds.width;
-        crop.height = bounds.height;
-        const context = crop.getContext("2d")!;
-        context.drawImage(image, -bounds.x, -bounds.y);
-        const pixels = context.getImageData(0, 0, crop.width, crop.height).data;
-        // Reject a flat (or effectively invisible) crop without fixing the pose or palette.
-        return pixels.some(
-          (value, index) => index % 4 !== 3 && Math.abs(value - pixels[index % 4]!) > 10,
-        );
-      },
-      { png: proof.toString("base64"), bounds: mascotBounds! },
-    );
+    const painted = await proofContentPainted(page, proof, mascot);
     expect(painted, "connecting proof must contain the centered mascot").toBe(true);
 
     await gateway.resolveDeferred("connect");
@@ -328,7 +319,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     expect(await loadingSections.locator("button, input, wa-dropdown").count()).toBe(0);
     await page.evaluate(() => document.fonts.ready);
     // Compare section layouts at rest, not the shell's translated entrance frame.
-    await waitForSettledSurface(page);
+    await waitForControlUiProofSurface(page.locator(".shell"), [loadingSections]);
     const sectionTitles = [
       "Found on this Gateway",
       "Run a model locally",
@@ -389,7 +380,9 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     await page.getByRole("heading", { name: "Connect a verified AI model" }).waitFor();
     // Restoring desktop starts a grid-row transition after the responsive Lit update.
     await page.locator(".shell:not(.shell--mobile-nav)").waitFor();
-    await waitForSettledSurface(page);
+    await waitForControlUiProofSurface(page.locator(".shell"), [
+      page.getByRole("heading", { name: "Connect a verified AI model" }),
+    ]);
     const readySectionTops = await Promise.all(
       sectionTitles.map(
         async (name) => (await page.getByRole("heading", { name }).boundingBox())!.y,
@@ -411,6 +404,101 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
       .toBe(true);
     await captureProof(page, "07b-first-run-model-setup-ready-mobile", [setupHeading]);
   });
+
+  it.each(["entrance", "lazy content"] as const)(
+    "captures recovery pixels after %s readiness despite perpetual descendant animation",
+    async (pending) => {
+      const page = await createPage();
+      const pageErrors: string[] = [];
+      page.on("pageerror", (error) => pageErrors.push(error.message));
+      // The endpoint rejects every attempt, including automatic reconnects.
+      await installMockGateway(page, {
+        methodResponses: {
+          connect: {
+            __mockError: {
+              code: "INVALID_REQUEST",
+              message: "origin not allowed",
+              details: { code: ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED },
+            },
+          },
+        },
+      });
+      await page.goto(server.baseUrl);
+      const surface = page.locator(".login-gate__card");
+      const recoveryTitle = page.locator(".login-gate__failure-title");
+      const recovery = page.getByText("Browser origin not allowed", { exact: true });
+      await waitForControlUiProofSurface(surface, [recovery]);
+
+      await page.evaluate((pendingPresentation) => {
+        const card = document.querySelector<HTMLElement>(".login-gate__card")!;
+        const title = document.querySelector<HTMLElement>(".login-gate__failure-title")!;
+        const activity = document.createElement("span");
+        activity.dataset.proofActivity = "";
+        activity.textContent = "•";
+        card.append(activity);
+        activity.animate([{ opacity: 0.4 }, { opacity: 1 }], {
+          duration: 100,
+          iterations: Infinity,
+        });
+        // Explicit scheduling perturbations widen the unsafe capture window;
+        // they do not change the application's wait budgets or capture policy.
+        if (pendingPresentation === "entrance") {
+          card.style.animationName = "none";
+          void getComputedStyle(card).animationName;
+          card.style.animationDelay = "1s";
+          card.style.animationFillMode = "backwards";
+          card.style.animationName = "scale-in";
+          return;
+        }
+        const text = title.textContent!;
+        const height = title.getBoundingClientRect().height;
+        const lazyHost = document.createElement("openclaw-proof-recovery-title");
+        lazyHost.style.display = "block";
+        lazyHost.style.minHeight = `${height}px`;
+        // Keep Lit's marker and text nodes intact for reconnect-driven renders.
+        for (const child of title.childNodes) {
+          if (child.nodeType === Node.TEXT_NODE) {
+            child.textContent = "";
+          }
+        }
+        title.append(lazyHost);
+        // A boxed lazy host is not meaningful content. An independent finite
+        // descendant completes registration while the activity above stays live.
+        const loading = lazyHost.animate([{ opacity: 1 }, { opacity: 1 }], { duration: 1_000 });
+        void loading.finished.then(() => {
+          customElements.define(
+            "openclaw-proof-recovery-title",
+            class extends HTMLElement {
+              connectedCallback() {
+                const label = document.createElement("span");
+                label.textContent = text;
+                this.replaceChildren(label);
+              }
+            },
+          );
+        });
+      }, pending);
+
+      const proof = await takeControlUiViewportScreenshot(page, surface, [recovery]);
+      if (artifactDir) {
+        await writeFile(
+          path.join(artifactDir, `capture-readiness-${pending.replaceAll(" ", "-")}.png`),
+          proof,
+        );
+      }
+      // The crop contains recovery words, not the card border or animated dot.
+      expect(
+        await proofContentPainted(page, proof, recoveryTitle),
+        "capture must paint recovery guidance",
+      ).toBe(true);
+      expect(
+        await page
+          .locator("[data-proof-activity]")
+          .evaluate((element) => element.getAnimations()[0]?.playState),
+      ).toBe("running");
+      expect(pageErrors).toEqual([]);
+    },
+  );
 
   it("falls back to the login gate when stored credentials are rejected", async () => {
     const page = await createPage();

--- a/ui/src/test-helpers/control-ui-e2e-screenshot.ts
+++ b/ui/src/test-helpers/control-ui-e2e-screenshot.ts
@@ -1,0 +1,46 @@
+import type { Locator, Page } from "playwright";
+import { expect } from "vitest";
+
+export async function waitForControlUiProofSurface(
+  surface: Locator,
+  content: readonly Locator[],
+): Promise<void> {
+  // Lazy hosts can have boxes before their meaningful children have loaded.
+  await Promise.all(content.map((locator) => locator.waitFor()));
+  // Visibility ignores opacity. Settle only the owner's finite entrance/resize
+  // motion; perpetual descendant activity must not hold up retained proof.
+  await expect
+    .poll(() =>
+      surface.evaluate(
+        (element) =>
+          element.checkVisibility({ checkOpacity: true }) &&
+          getComputedStyle(element).opacity === "1" &&
+          element
+            .getAnimations()
+            .filter((animation) => Number.isFinite(animation.effect?.getComputedTiming().endTime))
+            .every((animation) => animation.playState === "finished"),
+      ),
+    )
+    .toBe(true);
+}
+
+export async function takeControlUiViewportScreenshot(
+  page: Page,
+  surface: Locator,
+  content: readonly Locator[],
+): Promise<Buffer> {
+  await waitForControlUiProofSurface(surface, content);
+  // CDP repaints the current viewport but does not settle semantic presentation.
+  // Keep capture independent of unrelated dashboard RPCs and descendant motion.
+  const session = await page.context().newCDPSession(page);
+  try {
+    const result = await session.send("Page.captureScreenshot", {
+      captureBeyondViewport: false,
+      format: "png",
+      fromSurface: true,
+    });
+    return Buffer.from(result.data, "base64");
+  } finally {
+    await session.detach();
+  }
+}


### PR DESCRIPTION
Related: #134274 (separate real-Gateway evidence-retention work).

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where retained Control UI auth screenshots could be blank or visibly mid-entrance even though the real transport and DOM assertions passed. This is a maintainer-requested, confirmed evidence-capture bug.

## Why This Change Was Made

Playwright's layout visibility does not establish painted content: the login card's real `scale-in` animation starts at opacity zero. Raw CDP screenshot capture can repaint that valid transparent state before the context closes. The capture owner now waits for its meaningful children, opacity, and finite entrance/resize animations before using the same viewport capture options.

The existing splash readiness and PNG-crop checks are shared instead of duplicated. Connected and rejected auth stages name their presentation owner explicitly; perpetual descendant motion remains active. Auth allocates a fresh evidence directory beneath its existing parent. Main's Gateway/context cleanup flow remains intact; the related retention PR's other owners are not included.

## User Impact

Developers get readable retained auth proof. Runtime authentication, Gateway behavior, configuration, dependencies, schemas, and protocols do not change. Production LOC is zero; all code changes are tests or test support.

## Evidence

Exact-head CI for `46ec22dbed97ae76ac4150c23983a6654ec5684b`: [run 33720986568](https://github.com/openclaw/openclaw/actions/runs/33720986568) succeeded, including `openclaw/ci-gate`. The repository watcher finished GREEN with zero pending checks.

Validation before the setup-failure follow-up at `ad4f19e` (macOS arm64, Node 24.20.0, Playwright 1.62.1/Chromium 151.0.7922.34):

- Both new PNG-crop regressions fail with the original raw-capture behavior, then pass with readiness. The entrance control is blank; the lazy-content control lacks its recovery title. Fixed captures show the title and recovery instructions while perpetual descendant animation continues.
- The lazy-content fixture preserves Lit's marker/text nodes during reconnect, and both regression cases require no browser page errors.
- Complete splash/auth suites: **13/13 passed**, zero skipped (264.27s). All six retained auth PNGs were inspected and show meaningful content. Gateway and proxy ports closed after cleanup.
- Exact original order A (MCP, auth, agent-file, logs, usage): **10/10 passed**, zero skipped (345.66s). Order B (MCP, logs, auth, usage, agent-file): **10/10 passed**, zero skipped (199.41s).
- Canonical UI build, explicit-path format/diff checks, and the required changed-file gate passed. The final frozen-source run included core/UI types, all three dead-export scans, and changed-file lint/styles.
- Fresh independent Codex autoreview: no findings at its requested P0 threshold. This is a scoped review, not an all-severity claim.

The setup-failure follow-up in `46ec22d` guards only the cleanup report write when setup rejects before allocating an invocation directory. Every cleanup phase and the original port assertions still run. A missing-Chromium replay now exits **1 with only the intended startup diagnostic**, zero passed tests, no TypeError, no media allocation, and no changes to the three existing cleanup reports. Fresh capture-enabled auth proof after this guard: **4/4 passed**, zero skipped (117.28s), one new retained directory, six inspected PNGs, and both ports closed. The splash/helper bytes are unchanged; the 13/13 and A/B results above predate this setup-only guard. Fresh independent Codex autoreview of the full candidate is scoped-clean at P0, and the complete explicit-path changed gate against the same base passed again after the guard.

Dependency proof for [ClawSweeper’s sole inspection gap](https://github.com/openclaw/openclaw/pull/137031#issuecomment-5521298356): directly inspected installed Playwright **1.62.1**. `playwright-core/lib/coreBundle.js:58013-58015` implements `Locator.page()` by returning `this._frame.page()`; `:59916-59918` returns the frame’s owning page. The public `Locator` interface in `playwright-core/types/types.d.ts:15984-15987` declares `page(): Page`. The fresh four-test capture run exercised this call for all six auth screenshots, and both core/UI typechecks passed. This supplies the source/type/runtime evidence unavailable in the reviewer’s environment; no code change was needed.

The two owner suites were run with a fresh capture root:

```sh
OPENCLAW_CAPTURE_UI_PROOF=1 \
OPENCLAW_UI_E2E_ARTIFACT_DIR="$PWD/.artifacts/retained-proof-readiness-landing/final-owners" \
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/initial-connect-splash.e2e.test.ts \
  ui/src/e2e/control-ui-auth-transports.e2e.test.ts
```

The red control removed only the viewport helper's readiness call and used the same command with the splash file and `-t 'captures recovery pixels'`: both selected cases failed the pixel oracle. Restoring readiness passed both. The order runs used the same runner with artifact-only sequencers over the unchanged main E2E config; assertions, project isolation, and budgets were unchanged.

```sh
OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build --configLoader runner
node scripts/check-changed.mjs --timed \
  --base 1311ba9b473542c063d0312c43bbd74ebe6fd88a -- \
  ui/src/e2e/control-ui-auth-transports.e2e.test.ts \
  ui/src/e2e/initial-connect-splash.e2e.test.ts \
  ui/src/test-helpers/control-ui-e2e-screenshot.ts docs/reference/test.md
```

An initial cold order-A attempt hit the repository's 120-second no-output watchdog during MCP collection, before any tests. One bounded rerun completed after focused startup proof; no budgets or watchdog settings changed. Production delta: **0**. Tests/test support: +228/-75; docs: +6/-1.

Contract inspection covered installed Playwright screenshot preparation, visibility and `Locator.page()`, plus Chromium151 screenshot/surface-copy code. [Playwright visibility](https://playwright.dev/docs/actionability#visible) explicitly includes opacity-zero elements. [CDP captureScreenshot](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot) defines capture options, not application readiness; the [Chromium screenshot owner](https://chromium.googlesource.com/chromium/src/+/refs/tags/151.0.7922.34/content/browser/devtools/protocol/page_handler.cc) drives rendering without waiting for semantic content.

Historical evidence established causal sufficiency by holding the actual entrance animation at time zero and obtaining a PNG identical to the retained blank. The exact original Linux scheduling trigger remains unknown; fresh macOS validation does not claim Linux parity. Inspected public before/after assets are in [the retained-proof comment](https://github.com/openclaw/openclaw/pull/137031#issuecomment-5520991281); connected real-Gateway captures include local host diagnostics and are not attached here.

Follow-up: record auth-video case provenance before interpreting an uncaptured scenario's blank terminal video. Intentional MCP teardown blanks are separate from screenshot readiness.
