### PR TITLE
fix(release): validate worker artifacts against target declarations

### DIFF
--- a/scripts/check-cli-bootstrap-imports.mts
+++ b/scripts/check-cli-bootstrap-imports.mts
@@ -38,6 +38,7 @@ const STATIC_IMPORT_RE =
 type CliBootstrapCheckParams = {
   rootDir?: string;
   entrypoints?: string[];
+  workerDeployEntrypoints?: readonly string[];
   distDir?: string;
   gatewayRunChunkMaxBytes?: number;
   fs?: typeof fs;
@@ -354,8 +355,8 @@ export function collectGatewayRunChunkBudgetErrors(params: CliBootstrapCheckPara
 export function collectWorkerDeployArtifactErrors(params: CliBootstrapCheckParams = {}) {
   const rootDir = params.rootDir ?? process.cwd();
   const fsImpl = params.fs ?? fs;
-  const entrypoints = WORKER_DEPLOY_ENTRYPOINTS.map((entrypoint) =>
-    path.resolve(rootDir, entrypoint),
+  const entrypoints = (params.workerDeployEntrypoints ?? WORKER_DEPLOY_ENTRYPOINTS).map(
+    (entrypoint) => path.resolve(rootDir, entrypoint),
   );
   const artifactDir = path.dirname(entrypoints[0]!);
   const artifactNames = new Set(

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -20,6 +20,7 @@ import { basename, dirname, join, resolve, win32 } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 import { extract } from "tar";
+import { tsImport } from "tsx/esm/api";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { COMPLETION_SKIP_PLUGIN_COMMANDS_ENV } from "../src/cli/completion-runtime.ts";
 import { escapeRegExp } from "../src/shared/regexp.js";
@@ -1385,7 +1386,7 @@ async function main() {
     if (packedPackage.name !== "openclaw" || packedPackage.version !== rootPackage.version) {
       throw new Error("release-check: prepared tarball does not match the target package version.");
     }
-    verifyPackedContents(results, packedRoot);
+    await verifyPackedContents(results, packedRoot);
     runPackedBundledChannelEntrySmoke(tarballPath, packedRoot);
     console.log("release-check: final npm tarball contents and installed runtime look OK.");
   } finally {
@@ -1393,9 +1394,24 @@ async function main() {
   }
 }
 
-function verifyPackedContents(results: NpmPackResult[], packedRoot: string): void {
+async function verifyPackedContents(results: NpmPackResult[], packedRoot: string): Promise<void> {
+  // WORKER_BUNDLE_*_PATH exports declare the target's sealed deploy artifacts.
+  // Trusted tooling may be newer than the frozen target in the working directory.
+  const workerBundle = await tsImport(
+    pathToFileURL(resolve("src/shared/worker-bundle-hash.ts")).href,
+    import.meta.url,
+  );
+  const workerDeployEntrypoints = Object.entries(workerBundle)
+    .filter(([name]) => /^WORKER_BUNDLE_.*_PATH$/u.test(name))
+    .map(([name, value]) => {
+      if (typeof value !== "string") {
+        throw new Error(`release-check: target worker artifact ${name} must be a path string.`);
+      }
+      return `dist/worker/${value}`;
+    });
   checkCliBootstrapExternalImports({
     rootDir: packedRoot,
+    workerDeployEntrypoints,
     logger: {
       error: (message: string) => console.error(`release-check: ${message}`),
     },

--- a/test/scripts/check-cli-bootstrap-imports.test.ts
+++ b/test/scripts/check-cli-bootstrap-imports.test.ts
@@ -183,4 +183,33 @@ describe("check-cli-bootstrap-imports", () => {
       "Worker deploy artifact must not contain a dependency manifest or lifecycle scripts.",
     ]);
   });
+
+  it.each(["two", "three", "default"] as const)(
+    "requires the %s-artifact worker deployment contract",
+    (contract) => {
+      const root = makeTempRoot();
+      const workerDeployEntrypoints = [
+        "dist/worker/worker.mjs",
+        "dist/worker/workspace-rsync-receiver.mjs",
+      ];
+      for (const entrypoint of workerDeployEntrypoints) {
+        writeFixture(root, entrypoint, "export {};\n");
+      }
+      if (contract === "three") {
+        workerDeployEntrypoints.push("dist/worker/github-exec-launcher.mjs");
+      }
+      expect(
+        collectWorkerDeployArtifactErrors({
+          rootDir: root,
+          workerDeployEntrypoints: contract === "default" ? undefined : workerDeployEntrypoints,
+        }),
+      ).toEqual(
+        contract === "two"
+          ? []
+          : [
+              "Worker deploy artifact dist/worker/github-exec-launcher.mjs is missing. Run pnpm build first.",
+            ],
+      );
+    },
+  );
 });

--- a/test/scripts/release-check.test.ts
+++ b/test/scripts/release-check.test.ts
@@ -1,5 +1,5 @@
 // Release Check tests cover release check script behavior.
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
   copyFileSync,
   mkdtempSync,
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { create } from "tar";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import {
@@ -35,7 +36,7 @@ function requirePluginEntries(config: { plugins?: { entries?: Record<string, unk
 }
 
 describe("release-check", () => {
-  it("loads sparse release tooling and checks the separate target SDK inventory", () => {
+  it("loads sparse release tooling and checks the separate target SDK and worker inventories", () => {
     const root = mkdtempSync(join(tmpdir(), "openclaw-release-check-target-"));
     try {
       const toolingRoot = join(root, "tooling");
@@ -59,7 +60,12 @@ describe("release-check", () => {
       symlinkSync(resolve("node_modules"), join(toolingRoot, "node_modules"), "junction");
       mkdirSync(join(root, "scripts", "lib"), { recursive: true });
       mkdirSync(join(root, "extensions"));
-      writeFileSync(join(root, "package.json"), JSON.stringify({ files: ["dist"] }));
+      const packageJson = JSON.stringify({
+        name: "openclaw",
+        version: "2026.9.1",
+        files: ["dist"],
+      });
+      writeFileSync(join(root, "package.json"), packageJson);
       writeFileSync(
         join(root, "scripts/lib/plugin-sdk-entrypoints.json"),
         JSON.stringify(["target-private", "target-public"]),
@@ -104,6 +110,57 @@ describe("release-check", () => {
           "dist/plugin-sdk/target-public.js",
         ],
       });
+
+      copyFileSync("appcast.xml", join(root, "appcast.xml"));
+      mkdirSync(join(root, "src/shared"), { recursive: true });
+      const packedRoot = join(root, "package");
+      const packedFiles = {
+        "package.json": packageJson,
+        "dist/entry.js": 'import "./cli/run-main.js";',
+        "dist/cli/run-main.js": "export {};",
+        "dist/run-gateway.js": "const GATEWAY_AUTH_MODES = []; function addGatewayRunCommand() {}",
+        "dist/worker/worker.mjs": "export {};",
+        "dist/worker/workspace-rsync-receiver.mjs": "export {};",
+      };
+      for (const [relativePath, source] of Object.entries(packedFiles)) {
+        const destination = join(packedRoot, relativePath);
+        mkdirSync(dirname(destination), { recursive: true });
+        writeFileSync(destination, source);
+      }
+      const tarball = join(root, "target.tgz");
+      create({ cwd: root, file: tarball, gzip: true, sync: true }, ["package"]);
+      for (const declaresLauncher of [false, true]) {
+        writeFileSync(
+          join(root, "src/shared/worker-bundle-hash.ts"),
+          'export const WORKER_BUNDLE_ENTRY_PATH = "worker.mjs";\n' +
+            'export const WORKER_BUNDLE_RSYNC_RECEIVER_PATH = "workspace-rsync-receiver.mjs";\n' +
+            (declaresLauncher
+              ? 'export const WORKER_BUNDLE_GITHUB_EXEC_LAUNCHER_PATH = "github-exec-launcher.mjs";\n'
+              : ""),
+        );
+        const result = spawnSync(
+          process.execPath,
+          [
+            "--import",
+            join(toolingRoot, "scripts/tsx.mjs"),
+            join(toolingRoot, "scripts/release-check.ts"),
+            "--tarball",
+            tarball,
+          ],
+          {
+            cwd: root,
+            encoding: "utf8",
+            env: { ...process.env, TSX_TSCONFIG_PATH: join(toolingRoot, "tsconfig.json") },
+          },
+        );
+        expect(result.status).toBe(1);
+        // The two-artifact target reaches the next check; the fixture omits SDK output.
+        expect(result.stderr).toContain(
+          declaresLauncher
+            ? "Worker deploy artifact dist/worker/github-exec-launcher.mjs is missing."
+            : "release-check: packed dist/plugin-sdk directory not found.",
+        );
+      }
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where maintainers validating the frozen 2026.9.1 release with newer trusted tooling hit a missing worker artifact that the release never declared or built. [Full Release Validation run 33714427358](https://github.com/openclaw/openclaw/actions/runs/33714427358) failed npm qualification in [child job 100524208290](https://github.com/openclaw/openclaw/actions/runs/33714659595/job/100524208290).

Related: #136583, which added the third sealed worker artifact, `github-exec-launcher.mjs`, after the release cut.

## Why This Change Was Made

The target checkout owns its worker deployment inventory. Release qualification now loads its `src/shared/worker-bundle-hash.ts` with `tsx/esm/api` and passes the `WORKER_BUNDLE_*_PATH` exports to the existing guard through a narrow parameter. These exports match the target's staging/bootstrap lists; the module imports only `node:crypto`, so deriving requirements does not initialize the build configuration. `tsImport` also preserves the existing regression guard against tsx's source-lexer failure on literal dynamic imports in this script.

Local guard calls still default to the tooling's current constants. Missing files, unexpected runtime assets, non-regular files, and external runtime imports retain the same checks. Non-string target path declarations fail explicitly. There is no config/env surface, dist-byte inference, runtime refactor, or release-target edit. The net change is **+17 tooling lines** for the target ownership boundary and **+86 test lines**; no new production test seam.

## User Impact

Maintainers can qualify the unchanged frozen release using repaired tooling. A target declaring two deploy artifacts does not require the launcher; a target declaring three still fails if the launcher is missing.

## Evidence

- `pnpm test test/scripts/check-cli-bootstrap-imports.test.ts test/scripts/release-check.test.ts test/release-check.test.ts`: **85 tests passed**, including after the final rebase. Both new regression paths failed on the original tooling with the reported missing-launcher error. Coverage includes the unchanged local default and the workflow's separate sparse tooling/target checkout arrangement.
- `pnpm check:changed`: **passed**, including after the final rebase. The initial lint finding at the dynamic module boundary was fixed with explicit path-string validation, then tests and checks were rerun.
- Full `pnpm install && pnpm build` succeeded in separate isolated worktrees for frozen target `21616f1a5cac00c236a363a3f404f5f166f74855` and main build target `eea96a33d8912a737e24920baddb56a02e6a467e`. Builds took 8m19s and 8m29s respectively and included the normal bootstrap guard and Control UI build.
- Fresh pre-commit P2 autoreview: **scoped-clean**, no accepted/actionable findings.
- Requested post-PR `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P2`: **scoped-clean** on head `81bd383855f088f539591542a2c832624d0febbe`, no accepted/actionable P0–P2 findings.

The tarball checks below used Node 26.8.1 and pnpm 12.1.0 on macOS. `FIX` names the fix worktree, `TARGET` the detached frozen release worktree, and `UNFIXED` an exact `git archive` of the original main tooling at `eea96a33d8912a737e24920baddb56a02e6a467e`, with the same installed tooling dependencies. The two unfixed script blobs were verified against that Git revision.

```sh
# Pack the already-built targets through the normal prepack/postpack lifecycle.
(cd "$TARGET" && OPENCLAW_PREPACK_PREPARED=1 pnpm pack --pack-destination .artifacts/worker-guard-pack)
(cd "$FIX" && OPENCLAW_PREPACK_PREPARED=1 OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG=1 pnpm pack --pack-destination .artifacts/worker-guard-pack)

# Original tooling + unchanged frozen release tarball: exit 1, missing launcher.
(cd "$TARGET" && TSX_TSCONFIG_PATH="$UNFIXED/tsconfig.json" node --import "$UNFIXED/scripts/tsx.mjs" "$UNFIXED/scripts/release-check.ts" --tarball .artifacts/worker-guard-pack/openclaw-2026.9.1.tgz)

# Fixed tooling + that identical frozen release tarball: exit 0.
(cd "$TARGET" && TSX_TSCONFIG_PATH="$FIX/tsconfig.json" node --import "$FIX/scripts/tsx.mjs" "$FIX/scripts/release-check.ts" --tarball .artifacts/worker-guard-pack/openclaw-2026.9.1.tgz)

# Fixed tooling + complete main tarball: exit 0.
(cd "$FIX" && TSX_TSCONFIG_PATH="$FIX/tsconfig.json" node --import "$FIX/scripts/tsx.mjs" "$FIX/scripts/release-check.ts" --tarball .artifacts/worker-guard-pack/openclaw-2026.8.1.tgz)

# Remove only the launcher from a copy of the main archive.
(cd "$FIX" && mkdir -p .artifacts/worker-guard-missing-launcher && tar -xzf .artifacts/worker-guard-pack/openclaw-2026.8.1.tgz -C .artifacts/worker-guard-missing-launcher && rm .artifacts/worker-guard-missing-launcher/package/dist/worker/github-exec-launcher.mjs && tar -czf .artifacts/worker-guard-pack/openclaw-2026.8.1-missing-launcher.tgz -C .artifacts/worker-guard-missing-launcher package)

# Fixed tooling + incomplete main tarball: exit 1, missing launcher.
(cd "$FIX" && TSX_TSCONFIG_PATH="$FIX/tsconfig.json" node --import "$FIX/scripts/tsx.mjs" "$FIX/scripts/release-check.ts" --tarball .artifacts/worker-guard-pack/openclaw-2026.8.1-missing-launcher.tgz)
```

Both successful full checks ended with `release-check: final npm tarball contents and installed runtime look OK.`, including isolated install, CLI, plugin activation, SDK consumer, bundled-channel, completion, and workspace bootstrap smoke. The two negative checks both reported `Worker deploy artifact dist/worker/github-exec-launcher.mjs is missing. Run pnpm build first.`

Tarball SHA-256: frozen release `9afbf8848812f9ed5d8b2a69c503606372bef6743357872b58bc32a74b3bdc54`; complete main `c7ca11a0907d1170d2682572ca895ebe94acbbfae69ea97557184b83c2991092`.

[Hosted CI run 33718947038](https://github.com/openclaw/openclaw/actions/runs/33718947038) is attached to the exact PR head; its completion is not part of the local proof above. Full Release Validation has not been redispatched, and nothing has been merged or published by this change.
