### PR TITLE
fix(ui): unblock Cloud Worker and MCP deletions with array settings

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -682,12 +682,16 @@ newer config is applied. If that work needs restart recovery, the RPC returns
 the active revision.
 
 `config.patch` also accepts `replacePaths`, an array of config paths whose array
-replacement is intentional. If a patch would replace or delete an existing array
-with fewer entries, the Gateway rejects the write unless that exact path appears
-in `replacePaths`; nested arrays under array entries use `[]`, such as
-`agents.entries.*.skills`. This prevents truncated `config.get` snapshots from
-silently clobbering routing or allowlist arrays. Use `config.apply` when you
-intend to replace the full config.
+replacement or deletion is intentional. If a patch removes existing array entries
+or deletes an array, the Gateway rejects the write unless that exact array path
+appears in `replacePaths`. Deleting a containing object requires its contained
+array paths, including empty arrays. Deleting a whole array requires only its own
+path, not paths to arrays nested inside its entries. Use exact record keys, such
+as `agents.entries.main.skills`. For ID-merged entry updates, nested array paths
+use `[]`, such as `models.providers.custom.models[].input`. Parent paths and `*`
+wildcards do not authorize descendant arrays. This prevents truncated
+`config.get` snapshots from silently clobbering routing or allowlist arrays. Use
+`config.apply` when you intend to replace the full config.
 
 Arrays of objects with stable `id` fields merge by ID unless their path appears
 in `replacePaths`. These updates preserve authored fields in untouched entries;

--- a/src/config/merge-patch.proto-pollution.test.ts
+++ b/src/config/merge-patch.proto-pollution.test.ts
@@ -1,6 +1,7 @@
 // Verifies config merge patches reject prototype pollution inputs.
 import { describe, it, expect } from "vitest";
 import { applyMergePatch } from "./merge-patch.js";
+import { collectBaseArrayPaths } from "./patch-replace-paths.js";
 
 describe("applyMergePatch prototype pollution guard", () => {
   it("ignores __proto__ keys in patch", () => {
@@ -109,5 +110,49 @@ describe("applyMergePatch prototype pollution guard", () => {
     }) as { browser?: { profiles?: Record<string, unknown> } };
     expect(Object.keys(removed.browser?.profiles ?? {})).toEqual([]);
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});
+
+describe("merge-patch array deletion intent", () => {
+  it("collects exact paths in property order, including empty arrays, without descending into entries", () => {
+    const base = { nested: { values: [{ inner: [1] }], empty: [] }, last: [2] };
+    expect(collectBaseArrayPaths(base, "settings")).toEqual([
+      "settings.nested.values",
+      "settings.nested.empty",
+      "settings.last",
+    ]);
+    expect(collectBaseArrayPaths(base.nested.values, "settings.nested.values")).toEqual([
+      "settings.nested.values",
+    ]);
+  });
+
+  it.each([null, undefined, "value", 1, new Date(0), new Map([["values", []]])])(
+    "ignores non-object config values (%s)",
+    (value) => expect(collectBaseArrayPaths(value, "settings")).toEqual([]),
+  );
+
+  it("uses own properties of object-tagged records, not their prototype", () => {
+    const base = Object.assign(Object.create({ inherited: [1] }), { values: [] });
+    expect(collectBaseArrayPaths(base, "")).toEqual(["values"]);
+  });
+
+  it("shares the exact browser-profile reserved-key exception with merge patches", () => {
+    const base = JSON.parse(`{
+      "__proto__": [], "constructor": [], "prototype": [],
+      "browser": {
+        "constructor": [],
+        "profiles": {
+          "__proto__": [],
+          "constructor": { "values": [], "constructor": [], "prototype": [], "__proto__": [] },
+          "prototype": { "values": [] },
+          "regular": { "nested": { "constructor": [], "values": [] } }
+        }
+      }
+    }`);
+    expect(collectBaseArrayPaths(base, "")).toEqual([
+      "browser.profiles.constructor.values",
+      "browser.profiles.prototype.values",
+      "browser.profiles.regular.nested.values",
+    ]);
   });
 });

--- a/src/config/merge-patch.ts
+++ b/src/config/merge-patch.ts
@@ -1,8 +1,8 @@
 // Creates and applies JSON merge-patch updates to config-like objects.
 import { isDeepStrictEqual } from "node:util";
 import { isPlainObject } from "../infra/plain-object.js";
-import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { isRecord } from "../utils.js";
+import { formatConfigPatchPath, isMergePatchObjectKeyAllowed } from "./patch-replace-paths.js";
 
 type PlainObject = Record<string, unknown>;
 
@@ -59,22 +59,8 @@ function isObjectWithStringId(value: unknown): value is Record<string, unknown> 
   return typeof value.id === "string" && value.id.length > 0;
 }
 
-function formatMergePatchPath(parentPath: string | undefined, key: string): string {
-  return parentPath ? `${parentPath}.${key}` : key;
-}
-
 function formatMergePatchArrayEntryPath(arrayPath: string): string {
   return `${arrayPath}[]`;
-}
-
-/** Whether a merge-patch key is safe at its exact config path. */
-export function isMergePatchObjectKeyAllowed(key: string, parentPath?: string): boolean {
-  if (!isBlockedObjectKey(key)) {
-    return true;
-  }
-  // Browser profile names are schema-validated map ids. Their values still
-  // recurse through this guard, so nested prototype-related keys stay blocked.
-  return parentPath === "browser.profiles" && (key === "constructor" || key === "prototype");
 }
 
 /**
@@ -145,7 +131,7 @@ export function applyMergePatch(
   const result: PlainObject = isPlainObject(base) ? { ...base } : {};
 
   for (const [key, value] of Object.entries(patch)) {
-    const path = formatMergePatchPath(options.path, key);
+    const path = formatConfigPatchPath(options.path, key);
     if (!isMergePatchObjectKeyAllowed(key, options.path)) {
       continue;
     }

--- a/src/config/patch-replace-paths.ts
+++ b/src/config/patch-replace-paths.ts
@@ -1,4 +1,40 @@
-// Normalizes config.patch replacePaths shared by Gateway and agent preflight checks.
+// Browser-safe path/key rules shared by merge patches and explicit array-deletion intent.
+import { isPlainObject } from "../infra/plain-object.js";
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
+
+export function formatConfigPatchPath(parentPath: string | undefined, key: string): string {
+  return parentPath ? `${parentPath}.${key}` : key;
+}
+
+/** Whether a merge-patch key is safe at its exact config path. */
+export function isMergePatchObjectKeyAllowed(key: string, parentPath?: string): boolean {
+  if (!isBlockedObjectKey(key)) {
+    return true;
+  }
+  // Browser profile names are schema-validated map ids. Their values still
+  // recurse through this guard, so nested prototype-related keys stay blocked.
+  return parentPath === "browser.profiles" && (key === "constructor" || key === "prototype");
+}
+
+/** Collect only beneath a subtree the caller explicitly intends to delete. */
+export function collectBaseArrayPaths(base: unknown, path: string): string[] {
+  if (Array.isArray(base)) {
+    return [path];
+  }
+  if (!isPlainObject(base)) {
+    return [];
+  }
+  const paths: string[] = [];
+  for (const [key, value] of Object.entries(base)) {
+    const childPath = formatConfigPatchPath(path, key);
+    if (!isMergePatchObjectKeyAllowed(key, path)) {
+      continue;
+    }
+    paths.push(...collectBaseArrayPaths(value, childPath));
+  }
+  return paths;
+}
+
 function normalizeConfigPatchReplacePath(value: string): string {
   const trimmed = value.trim();
   if (trimmed.endsWith("[]")) {

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -23,14 +23,15 @@ import {
   resolveConfigSnapshotHash,
 } from "../../config/io.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
-import {
-  applyMergePatch,
-  createMergePatch,
-  isMergePatchObjectKeyAllowed,
-} from "../../config/merge-patch.js";
+import { applyMergePatch, createMergePatch } from "../../config/merge-patch.js";
 import { normalizeSubmittedConfigModelRefs } from "../../config/model-input-normalization.js";
 import { ConfigMutationConflictError } from "../../config/mutation-conflict.js";
-import { normalizeConfigPatchReplacePaths } from "../../config/patch-replace-paths.js";
+import {
+  collectBaseArrayPaths,
+  formatConfigPatchPath,
+  isMergePatchObjectKeyAllowed,
+  normalizeConfigPatchReplacePaths,
+} from "../../config/patch-replace-paths.js";
 import { redactConfigObject, restoreRedactedValues } from "../../config/redact-snapshot.js";
 import { loadGatewayRuntimeConfigSchema } from "../../config/runtime-schema.js";
 import { projectSourceOntoRuntimeShape } from "../../config/runtime-source-projection.js";
@@ -147,10 +148,6 @@ function requireConfigBaseHash(
   return true;
 }
 
-function formatConfigPatchPath(parentPath: string, key: string): string {
-  return parentPath ? `${parentPath}.${key}` : key;
-}
-
 function readConfigPatchReplacePaths(params: unknown): Set<string> {
   const rawPaths = (params as { replacePaths?: unknown }).replacePaths;
   return normalizeConfigPatchReplacePaths(Array.isArray(rawPaths) ? rawPaths : undefined);
@@ -215,24 +212,6 @@ function collectDestructiveArrayPatchPaths(params: {
         }),
       );
     }
-  }
-  return paths;
-}
-
-function collectBaseArrayPaths(base: unknown, path: string): string[] {
-  if (Array.isArray(base)) {
-    return [path];
-  }
-  if (!isPlainObject(base)) {
-    return [];
-  }
-  const paths: string[] = [];
-  for (const [key, value] of Object.entries(base)) {
-    const childPath = formatConfigPatchPath(path, key);
-    if (!isMergePatchObjectKeyAllowed(key, path)) {
-      continue;
-    }
-    paths.push(...collectBaseArrayPaths(value, childPath));
   }
   return paths;
 }

--- a/ui/src/components/mcp-servers-card.test.ts
+++ b/ui/src/components/mcp-servers-card.test.ts
@@ -2,8 +2,15 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ApplicationContext, ApplicationGateway } from "../app/context.ts";
 import { i18n } from "../i18n/index.ts";
+import type {
+  ConfigPatchBuilder,
+  ConfigPatchOptions,
+} from "../lib/config/config-gateway-operations.ts";
+import { createConfigCapabilityHarness, deferred } from "../lib/config/config-test-harness.ts";
+import { buildRemoveMcpServerPatch, patchMcpServers } from "../lib/config/mcp-servers.ts";
 import {
   createApplicationContextProvider,
   type ApplicationContextProvider,
@@ -16,9 +23,7 @@ type McpServersCard = HTMLElementTagNameMap["openclaw-mcp-servers-card"];
 type RuntimeConfigHarness = {
   runtimeConfig: ApplicationContext["runtimeConfig"];
   ensureLoaded: ReturnType<typeof vi.fn<() => Promise<void>>>;
-  patch: ReturnType<
-    typeof vi.fn<(options: { raw: Record<string, unknown>; note: string }) => Promise<boolean>>
-  >;
+  patch: ReturnType<typeof vi.fn<(options: ConfigPatchOptions) => Promise<boolean>>>;
 };
 
 function createGateway(options: { connected?: boolean; admin?: boolean } = {}): ApplicationGateway {
@@ -56,28 +61,20 @@ function createGateway(options: { connected?: boolean; admin?: boolean } = {}): 
 
 function createRuntimeConfig(config: Record<string, unknown>): RuntimeConfigHarness {
   const ensureLoaded = vi.fn(async () => undefined);
-  const patch = vi.fn<
-    (options: { raw: Record<string, unknown>; note: string }) => Promise<boolean>
-  >(async () => true);
+  const patch = vi.fn<(options: ConfigPatchOptions) => Promise<boolean>>(async () => true);
   const listeners = new Set<() => void>();
   const state = {
     configSnapshot: { sourceConfig: config, hash: "base" },
     lastError: null as string | null,
   };
-  const patchFromSnapshot = vi.fn(
-    async (
-      build: (
-        config: Readonly<Record<string, unknown>>,
-      ) => { options: { raw: Record<string, unknown>; note: string } } | { error: string },
-    ) => {
-      const built = build(config);
-      if ("error" in built) {
-        state.lastError = built.error;
-        return false;
-      }
-      return patch(built.options);
-    },
-  );
+  const patchFromSnapshot = vi.fn(async (build: ConfigPatchBuilder) => {
+    const built = build(config);
+    if ("error" in built) {
+      state.lastError = built.error;
+      return false;
+    }
+    return patch(built.options);
+  });
   const runtimeConfig = {
     state,
     ensureLoaded,
@@ -387,9 +384,25 @@ describe("openclaw-mcp-servers-card", () => {
     });
   });
 
-  it("removes a server with an explicit merge-patch null", async () => {
+  it.each([
+    { name: "HTTP", server: { url: "https://mcp.example.test/mcp" }, replacePaths: [] },
+    {
+      name: "stdio with nested filters",
+      server: {
+        command: "node",
+        args: ["synthetic-server.mjs"],
+        toolFilter: { include: ["search"], exclude: ["admin_*"] },
+      },
+      replacePaths: [
+        "mcp.servers.docs.args",
+        "mcp.servers.docs.toolFilter.include",
+        "mcp.servers.docs.toolFilter.exclude",
+      ],
+    },
+  ])("removes a $name server with exact array intent", async ({ server, replacePaths }) => {
+    const retained = { command: "node", args: ["retained.mjs"] };
     const { card, harness } = await mountCard({
-      config: { mcp: { servers: { docs: { url: "https://mcp.example.com/mcp" } } } },
+      config: { mcp: { servers: { docs: server, retained } } },
     });
 
     actionButton(card, "Remove docs").click();
@@ -398,7 +411,85 @@ describe("openclaw-mcp-servers-card", () => {
     expect(firstPatchCall(harness)).toEqual({
       raw: { mcp: { servers: { docs: null } } },
       note: "mcp settings: remove server docs",
+      ...(replacePaths.length ? { replacePaths } : {}),
     });
+  });
+
+  it("builds removal intent from the snapshot after queued writes settle", async () => {
+    const retained = { command: "node", args: ["retained.mjs"], opaque: null };
+    let config: Record<string, unknown> = {
+      mcp: { servers: { docs: { command: "node", args: ["initial.mjs"] }, retained } },
+    };
+    let hash = "before";
+    const gate = deferred<void>();
+    const patches: unknown[] = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        return {
+          config,
+          sourceConfig: config,
+          raw: JSON.stringify(config),
+          hash,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method !== "config.patch") {
+        throw new Error(`Unexpected request ${method}`);
+      }
+      patches.push(params);
+      if (patches.length === 1) {
+        await gate.promise;
+        config = {
+          mcp: {
+            servers: {
+              docs: { command: "node", args: ["updated.mjs"], toolFilter: { include: ["search"] } },
+              retained,
+            },
+          },
+        };
+        hash = "queued-write";
+      } else {
+        config = { mcp: { servers: { retained } } };
+        hash = "removed";
+      }
+      return { ok: true, config, hash };
+    });
+    const { runtimeConfig } = createConfigCapabilityHarness(
+      request as GatewayBrowserClient["request"],
+    );
+    try {
+      await runtimeConfig.ensureLoaded();
+      const priorWrite = runtimeConfig.patch({
+        raw: {
+          mcp: {
+            servers: { docs: { args: ["updated.mjs"], toolFilter: { include: ["search"] } } },
+          },
+        },
+        note: "update server",
+        replacePaths: ["mcp.servers.docs.args"],
+      });
+      const removal = patchMcpServers(runtimeConfig, {
+        buildPatch: (servers) => buildRemoveMcpServerPatch(servers, "docs"),
+        note: "remove server",
+      });
+      await waitForFast(() => expect(patches).toHaveLength(1));
+      gate.resolve();
+      await expect(priorWrite).resolves.toBe(true);
+      await expect(removal).resolves.toEqual({ ok: true });
+      expect(patches).toHaveLength(2);
+      expect(patches[1]).toMatchObject({
+        baseHash: "queued-write",
+        raw: JSON.stringify({ mcp: { servers: { docs: null } } }),
+        replacePaths: ["mcp.servers.docs.args", "mcp.servers.docs.toolFilter.include"],
+      });
+      expect(runtimeConfig.state.configSnapshot?.sourceConfig).toEqual({
+        mcp: { servers: { retained } },
+      });
+    } finally {
+      gate.resolve();
+      runtimeConfig.dispose();
+    }
   });
 
   it("disables mutation controls without operator.admin access", async () => {

--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -158,7 +158,7 @@ suite.define(() => {
       const buildFleet = {
         provider: "crabbox",
         install: "bundle",
-        label: "Build fleet",
+        suspendAfter: "30m",
         settings: {
           provider: "hetzner",
           class: "standard",
@@ -244,9 +244,9 @@ suite.define(() => {
         cloudWorkers: {
           profiles: {
             "build-fleet": {
-              ...buildFleet,
+              provider: "crabbox",
+              install: "bundle",
               settings: {
-                ...buildFleet.settings,
                 provider: "daytona",
                 class: "batch/ARM64.v2",
                 ttl: "12h",
@@ -309,14 +309,21 @@ suite.define(() => {
       const pendingRequestCount = (await gateway.getRequests("config.patch")).length;
       await page.getByRole("button", { name: "Save" }).click();
       const pendingPatch = await waitForConfigPatch(gateway, pendingRequestCount);
-      expect(pendingPatch).toMatchObject({
+      expect(pendingPatch).toEqual({
         cloudWorkers: {
           profiles: {
-            "build-fleet": editedFleet,
             pending: {
               provider: "crabbox",
               install: "bundle",
-              settings: { provider: "aws", class: "custom" },
+              settings: {
+                provider: "aws",
+                class: "custom",
+                ttl: "8h",
+                idleTimeout: "45m",
+                setup: null,
+                desktop: null,
+                binary: null,
+              },
             },
           },
         },
@@ -482,6 +489,7 @@ suite.define(() => {
         },
       },
       description: "Provider: static-ssh",
+      replacePaths: undefined,
     },
     {
       name: "class removal",
@@ -498,10 +506,11 @@ suite.define(() => {
         },
       },
       description: "Class: Unknown",
+      replacePaths: ["cloudWorkers.profiles.pending.settings.setupEnv"],
     },
   ])(
     "preserves Advanced edits after $name and deletes project defaults",
-    async ({ replacement, description }) => {
+    async ({ replacement, description, replacePaths }) => {
       const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
       const page = await context.newPage();
       const pending = configuredCloudWorkerProfile();
@@ -602,7 +611,7 @@ suite.define(() => {
         const savedConfig = {
           cloudWorkers: {
             ...replacedConfig.cloudWorkers,
-            profiles: { pending: { ...replacement, label: "Advanced saved" }, retained },
+            profiles: { pending: { ...replacement, suspendAfter: "1h" }, retained },
           },
         };
         await rawEditor.fill(JSON.stringify(savedConfig, null, 2));
@@ -639,10 +648,13 @@ suite.define(() => {
         }
         expect(requestRaw(deleteRequest)).toEqual({
           cloudWorkers: {
-            profiles: { pending: null, retained },
+            profiles: { pending: null },
             projectProfiles: { "github.com/acme/app": null, "github.com/acme/docs": null },
           },
         });
+        expect(isRecord(deleteRequest.params) && deleteRequest.params.replacePaths).toEqual(
+          replacePaths,
+        );
         await expect.poll(() => pendingRow.count()).toBe(0);
         await page.locator(".settings-row code", { hasText: /^retained$/ }).waitFor();
       } finally {

--- a/ui/src/lib/config/mcp-servers.ts
+++ b/ui/src/lib/config/mcp-servers.ts
@@ -1,5 +1,6 @@
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import { collectBaseArrayPaths } from "../../../../src/config/patch-replace-paths.js";
 import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../format-error.ts";
 import type { RuntimeConfigCapability } from "./runtime-config-capability.ts";
@@ -19,7 +20,9 @@ export type McpServerSummary = {
   tls: "verify-off" | "mtls" | null;
 };
 
-export type McpServersPatchBuildResult = { patch: Record<string, unknown> } | { error: string };
+export type McpServersPatchBuildResult =
+  | { patch: Record<string, unknown>; replacePaths?: string[] }
+  | { error: string };
 
 function splitMcpCommandLine(value: string): string[] | null {
   const parts: string[] = [];
@@ -188,7 +191,10 @@ export function buildRemoveMcpServerPatch(
   name: string,
 ): McpServersPatchBuildResult {
   return Object.hasOwn(servers, name)
-    ? { patch: { [name]: null } }
+    ? {
+        patch: { [name]: null },
+        replacePaths: collectBaseArrayPaths(servers[name], `mcp.servers.${name}`),
+      }
     : { error: t("mcpServers.missing", { name }) };
 }
 
@@ -216,6 +222,7 @@ export async function patchMcpServers(
             options: {
               raw: { mcp: { servers: built.patch } },
               note: options.note,
+              ...(built.replacePaths?.length ? { replacePaths: built.replacePaths } : {}),
             },
           };
     });

--- a/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { applyMergePatch } from "../../../../src/config/merge-patch.js";
 import {
   buildCloudWorkerDeletePatch,
   buildCloudWorkerUpsertPatch,
@@ -11,19 +12,26 @@ import {
 const configuredProfile = {
   provider: "crabbox",
   install: "npm",
-  label: "preserved",
+  suspendAfter: "30m",
   settings: {
     provider: "aws",
     class: "beast",
     ttl: "24h",
     idleTimeout: "60m",
     setup: "install-node",
-    setupEnv: ["OPENCLAW_WORKER_ARTIFACT_TOKEN"],
+    setupEnv: ["QA_WORKER_FLAG"],
     desktop: true,
     binary: "/opt/crabbox",
-    region: "eu-west-1",
+    opaque: { nullable: null, flags: ["kept"] },
   },
 };
+
+function requirePatch(result: ReturnType<typeof buildCloudWorkerUpsertPatch>) {
+  if ("error" in result) {
+    throw new Error(`Unexpected profile patch error: ${result.error}`);
+  }
+  return result;
+}
 
 describe("cloud worker settings state", () => {
   it.each([undefined, ""])("requires an explicit class for an empty draft (%j)", (machineClass) => {
@@ -89,7 +97,7 @@ describe("cloud worker settings state", () => {
     expect(validateCloudWorkerDraft(draft, { production: configuredProfile }, null)).toBe(expected);
   });
 
-  it("builds a full edit patch with tombstones while preserving unknown fields", () => {
+  it("clears setup with exact array intent while preserving opaque fields", () => {
     const config = { cloudWorkers: { profiles: { production: configuredProfile } } };
     const draft = {
       ...createCloudWorkerDraft(readCloudWorkerProfiles(config)[0]),
@@ -101,15 +109,14 @@ describe("cloud worker settings state", () => {
       desktop: false,
       binary: "",
     };
-
-    expect(buildCloudWorkerUpsertPatch(config, draft, "production")).toEqual({
+    const built = requirePatch(buildCloudWorkerUpsertPatch(config, draft, "production"));
+    expect(built).toEqual({
       patch: {
         cloudWorkers: {
           profiles: {
             production: {
               provider: "crabbox",
               install: "npm",
-              label: "preserved",
               settings: {
                 provider: "hetzner",
                 class: "large",
@@ -119,8 +126,26 @@ describe("cloud worker settings state", () => {
                 setupEnv: null,
                 desktop: null,
                 binary: null,
-                region: "eu-west-1",
               },
+            },
+          },
+        },
+      },
+      replacePaths: ["cloudWorkers.profiles.production.settings.setupEnv"],
+    });
+    expect(applyMergePatch(config, built.patch)).toEqual({
+      cloudWorkers: {
+        profiles: {
+          production: {
+            provider: "crabbox",
+            install: "npm",
+            suspendAfter: "30m",
+            settings: {
+              provider: "hetzner",
+              class: "large",
+              ttl: "8h",
+              idleTimeout: "45m",
+              opaque: configuredProfile.settings.opaque,
             },
           },
         },
@@ -141,49 +166,43 @@ describe("cloud worker settings state", () => {
         backend: "hetzner",
         binary: "/opt/crabbox-next",
       };
-
-      expect(buildCloudWorkerUpsertPatch(config, draft, "production")).toEqual({
-        patch: {
-          cloudWorkers: {
-            profiles: {
-              production: {
-                ...profile,
-                settings: {
-                  ...profile.settings,
-                  provider: "hetzner",
-                  binary: "/opt/crabbox-next",
-                },
+      const built = requirePatch(buildCloudWorkerUpsertPatch(config, draft, "production"));
+      expect(applyMergePatch(config, built.patch)).toEqual({
+        cloudWorkers: {
+          profiles: {
+            production: {
+              ...profile,
+              settings: {
+                ...profile.settings,
+                provider: "hetzner",
+                binary: "/opt/crabbox-next",
               },
             },
           },
         },
       });
+      expect(built.replacePaths).toEqual([]);
     },
   );
 
-  it.each([undefined, []])("keeps empty setup environment unchanged (%j)", (setupEnv) => {
-    const existingSettings = Object.fromEntries(
-      Object.entries(configuredProfile.settings).filter(
-        ([key]) => key !== "setupEnv" || setupEnv !== undefined,
-      ),
-    );
-    if (setupEnv) {
-      existingSettings.setupEnv = setupEnv;
-    }
-    const profile = { ...configuredProfile, settings: existingSettings };
-    const config = { cloudWorkers: { profiles: { production: profile } } };
-    const draft = { ...createCloudWorkerDraft(readCloudWorkerProfiles(config)[0]), setup: "" };
-
-    expect(buildCloudWorkerUpsertPatch(config, draft, "production")).toEqual({
-      patch: {
+  it.each([{ setupEnv: undefined }, { setupEnv: [] }])(
+    "keeps empty setup environment unchanged ($setupEnv)",
+    ({ setupEnv }) => {
+      const { setupEnv: _setupEnv, ...settings } = configuredProfile.settings;
+      const existingSettings = { ...settings, ...(setupEnv ? { setupEnv } : {}) };
+      const profile = { ...configuredProfile, settings: existingSettings };
+      const config = { cloudWorkers: { profiles: { production: profile } } };
+      const draft = { ...createCloudWorkerDraft(readCloudWorkerProfiles(config)[0]), setup: "" };
+      const built = requirePatch(buildCloudWorkerUpsertPatch(config, draft, "production"));
+      const { setup: _setup, ...retainedSettings } = existingSettings;
+      expect(applyMergePatch(config, built.patch)).toEqual({
         cloudWorkers: {
-          profiles: {
-            production: { ...profile, settings: { ...existingSettings, setup: null } },
-          },
+          profiles: { production: { ...profile, settings: retainedSettings } },
         },
-      },
-    });
-  });
+      });
+      expect(built.replacePaths).toEqual([]);
+    },
+  );
 
   it.each([
     {
@@ -214,13 +233,12 @@ describe("cloud worker settings state", () => {
       desktop: false,
       binary: "",
     });
-
     expect(buildCloudWorkerUpsertPatch(config, draft, "production")).toEqual({
       error: "profileMissing",
     });
   });
 
-  it("builds add and delete payloads against the complete profile record", () => {
+  it("adds only the new profile without resending existing profiles", () => {
     const config = { cloudWorkers: { profiles: { production: configuredProfile } } };
     const draft = {
       ...createCloudWorkerDraft(),
@@ -228,12 +246,11 @@ describe("cloud worker settings state", () => {
       backend: "hetzner",
       machineClass: "standard",
     };
-    const added = buildCloudWorkerUpsertPatch(config, draft, null);
-    expect(added).toMatchObject({
+    const built = requirePatch(buildCloudWorkerUpsertPatch(config, draft, null));
+    expect(built).toEqual({
       patch: {
         cloudWorkers: {
           profiles: {
-            production: configuredProfile,
             "build-fleet": {
               provider: "crabbox",
               install: "bundle",
@@ -242,25 +259,27 @@ describe("cloud worker settings state", () => {
                 class: "standard",
                 ttl: "8h",
                 idleTimeout: "45m",
+                setup: null,
+                desktop: null,
+                binary: null,
               },
             },
           },
         },
       },
+      replacePaths: [],
     });
-    expect(buildCloudWorkerDeletePatch(config, "production")).toEqual({
-      patch: {
-        cloudWorkers: {
-          profiles: { production: null },
-        },
-      },
-    });
+    expect(applyMergePatch(config, built.patch)).toMatchObject(config);
   });
 
-  it("removes only project defaults that reference a deleted profile", () => {
+  it("deletes only the target and its project defaults with exact array intent", () => {
+    const deleted = {
+      ...configuredProfile,
+      settings: { ...configuredProfile.settings, empty: [] },
+    };
     const config = {
       cloudWorkers: {
-        profiles: { production: configuredProfile, retained: configuredProfile },
+        profiles: { production: deleted, retained: configuredProfile },
         projectProfiles: {
           "github.com/acme/app": "production",
           "github.com/acme/docs": "production",
@@ -268,16 +287,27 @@ describe("cloud worker settings state", () => {
         },
       },
     };
-
-    expect(buildCloudWorkerDeletePatch(config, "production")).toEqual({
+    const built = requirePatch(buildCloudWorkerDeletePatch(config, "production"));
+    expect(built).toEqual({
       patch: {
         cloudWorkers: {
-          profiles: { production: null, retained: configuredProfile },
+          profiles: { production: null },
           projectProfiles: {
             "github.com/acme/app": null,
             "github.com/acme/docs": null,
           },
         },
+      },
+      replacePaths: [
+        "cloudWorkers.profiles.production.settings.setupEnv",
+        "cloudWorkers.profiles.production.settings.opaque.flags",
+        "cloudWorkers.profiles.production.settings.empty",
+      ],
+    });
+    expect(applyMergePatch(config, built.patch)).toEqual({
+      cloudWorkers: {
+        profiles: { retained: configuredProfile },
+        projectProfiles: { "github.com/acme/retained": "retained" },
       },
     });
   });

--- a/ui/src/pages/cloud-workers/cloud-worker-config.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.ts
@@ -1,5 +1,8 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { collectBaseArrayPaths } from "../../../../src/config/patch-replace-paths.js";
+
+type CloudWorkerConfigPatch = { patch: Record<string, unknown>; replacePaths: string[] };
 
 export type CloudWorkerProfileDraft = {
   id: string;
@@ -139,7 +142,7 @@ export function buildCloudWorkerUpsertPatch(
   config: Readonly<Record<string, unknown>>,
   draft: CloudWorkerProfileDraft,
   editingId: string | null,
-): { patch: Record<string, unknown> } | { error: CloudWorkerDraftError } {
+): CloudWorkerConfigPatch | { error: CloudWorkerDraftError } {
   const profiles = profileRecords(config);
   const error = validateCloudWorkerDraft(draft, profiles, editingId);
   if (error) {
@@ -156,40 +159,40 @@ export function buildCloudWorkerUpsertPatch(
   ) {
     return { error: "profileMissing" };
   }
+  const setup = draft.setup.trim();
+  const clearSetupEnv =
+    !setup && Array.isArray(existingSettings.setupEnv) && existingSettings.setupEnv.length > 0;
+  // Omitted settings merge in place; resending opaque nulls would delete them.
   const settings = {
-    ...existingSettings,
     provider: draft.backend.trim(),
     class: draft.machineClass.trim(),
     ttl: draft.ttl.trim(),
     idleTimeout: draft.idleTimeout.trim(),
-    setup: draft.setup.trim() || null,
-    ...(draft.setup.trim() ||
-    !Array.isArray(existingSettings.setupEnv) ||
-    existingSettings.setupEnv.length === 0
-      ? {}
-      : { setupEnv: null }),
+    setup: setup || null,
+    ...(clearSetupEnv ? { setupEnv: null } : {}),
     desktop: draft.desktop ? true : null,
     binary: draft.binary.trim() || null,
   };
   const profile = {
-    ...existing,
     provider: normalizeOptionalString(existing.provider) ?? "crabbox",
     install: existing.install === "npm" ? "npm" : "bundle",
     settings,
   };
   return {
-    patch: {
-      cloudWorkers: {
-        profiles: { ...profiles, [id]: profile },
-      },
-    },
+    patch: { cloudWorkers: { profiles: { [id]: profile } } },
+    replacePaths: clearSetupEnv
+      ? collectBaseArrayPaths(
+          existingSettings.setupEnv,
+          `cloudWorkers.profiles.${id}.settings.setupEnv`,
+        )
+      : [],
   };
 }
 
 export function buildCloudWorkerDeletePatch(
   config: Readonly<Record<string, unknown>>,
   profileId: string,
-): { patch: Record<string, unknown> } | { error: "profileMissing" } {
+): CloudWorkerConfigPatch | { error: "profileMissing" } {
   const profiles = profileRecords(config);
   if (!Object.hasOwn(profiles, profileId)) {
     return { error: "profileMissing" };
@@ -206,12 +209,13 @@ export function buildCloudWorkerDeletePatch(
   return {
     patch: {
       cloudWorkers: {
-        profiles: { ...profiles, [profileId]: null },
+        profiles: { [profileId]: null },
         ...(Object.keys(removedProjectProfiles).length > 0
           ? { projectProfiles: removedProjectProfiles }
           : {}),
       },
     },
+    replacePaths: collectBaseArrayPaths(profiles[profileId], `cloudWorkers.profiles.${profileId}`),
   };
 }
 

--- a/ui/src/pages/cloud-workers/cloud-workers-page.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.test.ts
@@ -1,0 +1,161 @@
+/* @vitest-environment jsdom */
+import { expectDefined } from "@openclaw/normalization-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  validateConfigPatchParams,
+  type ConfigPatchParams,
+} from "../../../../packages/gateway-protocol/src/index.js";
+import { applyMergePatch } from "../../../../src/config/merge-patch.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
+import { i18n } from "../../i18n/index.ts";
+import { createGatewayHarness } from "../../lib/config/config-test-harness.ts";
+import { createRuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
+import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import "./cloud-workers-page.ts";
+
+vi.mock("../../components/confirm-dialog.ts", () => ({ showConfirmDialog: vi.fn() }));
+
+function actionButton(container: Element, label: string): HTMLButtonElement {
+  return expectDefined(
+    [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent?.trim() === label,
+    ),
+    `${label} button`,
+  );
+}
+
+beforeEach(async () => {
+  await i18n.setLocale("en");
+  vi.mocked(showConfirmDialog).mockReset().mockResolvedValue(true);
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("Cloud Workers mutation requests", () => {
+  it.each(["delete", "setup-clear"] as const)(
+    "forwards exact array intent for %s and retains unrelated data",
+    async (action) => {
+      const settings = { provider: "aws", class: "standard", ttl: "8h", idleTimeout: "45m" };
+      const retained = { provider: "crabbox", settings: { ...settings, opaque: null } };
+      const pending = {
+        provider: "crabbox",
+        settings: { ...settings, setup: "true", setupEnv: ["QA_WORKER_FLAG"], opaque: null },
+      };
+      const projectProfiles = {
+        "github.com/acme/pending": "pending",
+        "github.com/acme/retained": "retained",
+      };
+      let config: Record<string, unknown> = {
+        cloudWorkers: { profiles: { pending, retained }, projectProfiles },
+      };
+      let hash = "before";
+      const patches: ConfigPatchParams[] = [];
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        if (method === "config.get") {
+          return {
+            config,
+            sourceConfig: config,
+            raw: JSON.stringify(config),
+            hash,
+            valid: true,
+            issues: [],
+          };
+        }
+        if (method === "environments.list") {
+          return { environments: [], profiles: [] };
+        }
+        if (method !== "config.patch" || !validateConfigPatchParams(params)) {
+          throw new Error(`Unexpected request ${method}`);
+        }
+        patches.push(params);
+        const merged = applyMergePatch(config, JSON.parse(params.raw), {
+          mergeObjectArraysById: true,
+        });
+        if (!isRecord(merged)) {
+          throw new Error("Expected a merged configuration object");
+        }
+        config = merged;
+        hash = "after";
+        return { ok: true, config, hash };
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      const gatewayHarness = createGatewayHarness(client);
+      gatewayHarness.publish(
+        true,
+        client,
+        gatewayHelloForMethods(["config.patch", "environments.list"]),
+      );
+      const gateway = Object.assign(gatewayHarness.gateway, {
+        connection: { gatewayUrl: "ws://gateway.example.test", token: "", password: "" },
+      });
+      const runtimeConfig = createRuntimeConfigCapability(gateway);
+      const context = {
+        gateway,
+        runtimeConfig,
+        navigate: vi.fn(),
+      } as unknown as ApplicationContext;
+      const provider = createApplicationContextProvider(context);
+      const page = document.createElement("openclaw-cloud-workers-page");
+      provider.append(page);
+      document.body.append(provider);
+      try {
+        await waitForFast(() =>
+          expect(page.querySelectorAll(".settings-row code")).toHaveLength(2),
+        );
+        const row = expectDefined(
+          [...page.querySelectorAll(".settings-row")].find(
+            (entry) => entry.querySelector("code")?.textContent === "pending",
+          ),
+          "pending profile row",
+        );
+        if (action === "delete") {
+          await waitForFast(() => expect(actionButton(row, "Delete").disabled).toBe(false));
+          actionButton(row, "Delete").click();
+        } else {
+          actionButton(row, "Edit").click();
+          await waitForFast(() => expect(page.querySelector("textarea")).not.toBeNull());
+          const setup = expectDefined(page.querySelector("textarea"), "Setup editor");
+          setup.value = "";
+          setup.dispatchEvent(new Event("input", { bubbles: true }));
+          await waitForFast(() => expect(actionButton(page, "Save").disabled).toBe(false));
+          actionButton(page, "Save").click();
+        }
+        await waitForFast(() => expect(patches).toHaveLength(1));
+        expect(patches[0]).toMatchObject({
+          baseHash: "before",
+          replacePaths: ["cloudWorkers.profiles.pending.settings.setupEnv"],
+        });
+        const raw = JSON.parse(expectDefined(patches[0], "mutation request").raw);
+        expect(Object.keys(raw.cloudWorkers.profiles)).toEqual(["pending"]);
+        expect(config).toEqual({
+          cloudWorkers: {
+            profiles:
+              action === "delete"
+                ? { retained }
+                : {
+                    pending: {
+                      provider: "crabbox",
+                      install: "bundle",
+                      settings: { ...settings, opaque: null },
+                    },
+                    retained,
+                  },
+            projectProfiles:
+              action === "delete" ? { "github.com/acme/retained": "retained" } : projectProfiles,
+          },
+        });
+      } finally {
+        provider.remove();
+        runtimeConfig.dispose();
+      }
+    },
+  );
+});

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -219,6 +219,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
           : {
               options: {
                 raw: built.patch,
+                replacePaths: built.replacePaths,
                 note: `cloud workers: ${editingId ? "update" : "add"} ${profileId}`,
                 canDispatch: isCurrent,
               },
@@ -285,6 +286,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
           : {
               options: {
                 raw: built.patch,
+                replacePaths: built.replacePaths,
                 note: `cloud workers: delete ${profile.id}`,
                 canDispatch: isCurrent,
               },


### PR DESCRIPTION
Closes #136954: Control UI deletions omit required array-replacement intent.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled. This is a maintainer-owned branch in the upstream repository.

</details>

## What Problem This Solves

Fixes an issue where users deleting Cloud Worker profiles or MCP servers would receive a configuration error when those records contained arrays. Clearing a Cloud Worker's Setup field also failed when setup environment variables were configured. Cloud Worker edits could additionally remove opaque null-valued settings that the editor did not own.

## Why This Change Was Made

The destructive UI producers now derive exact array-deletion intent from the same authoritative snapshot used for dispatch, reusing the existing Gateway collector through a browser-safe shared module. Target-only merge patches preserve untouched records and settings; the Gateway's array guard, compare-and-swap checks, and UI lifecycle/access fences remain unchanged.

## User Impact

Operators can delete array-bearing profiles and servers, or clear Setup, without bypassing configuration protections. Profile deletion still removes only project defaults referencing that profile. Retained records and provider-owned settings, including opaque nulls, remain intact. Existing Gateway restart requirements still apply; no new configuration option, dependency, protocol, schema, or performance budget is introduced.

## Evidence

**Reviewed and locally verified head:** `0fcec488c37678d460916b96eea1305e0fabca3d`, based on `52907070417495b59596f3efc0d4403a66ce29c2`. The prerequisite rebase preserved the complete binary diff and all 12 changed file blobs. Product build identity: `2026.8.1-0fcec488c376-2026-09-03T04-41-37.548Z`.

### Regression and sibling coverage

Before production changes, the permanent UI suite had 16 failing cases and 33 passing cases. All 49 pass after the repair. Separate real-handler probes established exact-path acceptance, rejection of missing or parent-only intent, and preserved stale-hash rejection. These were distinct contract assertions, not 16 separate bugs.

**204 distinct automated cases passed:** 49 UI producer/DOM cases, 38 Gateway handler cases, 23 merge/collector cases, 86 coordinator/lifecycle/sibling cases, and 8 Chromium cases with a mock Gateway. Repeated pre/post-rebase runs are not counted again. Coverage includes queued-write snapshot freshness, nested and empty arrays, stop-at-array traversal, safe-key behavior, reconnect/confirmation races, access controls, and retained null-valued data.

Canonical changed-file gates and `pnpm build:ci-artifacts` passed. Startup JS was 348,495 gzip bytes against 350,141; startup CSS was 44,680 bytes against 46,080. All 798 finalized precompression sidecars were verified. The mock-Gateway browser suite builds its own UI bundle; it is not represented as byte-identical product-dist proof.

Isolated Codex autoreview returned `scoped-clean` with no findings at its configured P0 threshold across two complete evidence passes. The first oversized-dataset refusal was preserved; all 25 complete evidence records were then supplied through supported split inputs without dropping material or changing scanner limits.

<details>
<summary>Completed local commands</summary>

Commands ran under a private HOME/TMP/XDG environment, Node 24.15.0, repository-pinned pnpm 12.1.0, and one test worker. The browser suite used the already-installed Chromium executable through `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`.

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/pages/cloud-workers/cloud-worker-config.test.ts ui/src/pages/cloud-workers/cloud-workers-page.test.ts ui/src/components/mcp-servers-card.test.ts --maxWorkers 1
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-methods.config.ts --configLoader runner src/gateway/server-methods/config.test.ts --maxWorkers 1
```

```bash
node scripts/run-vitest.mjs src/config/merge-patch.test.ts src/config/merge-patch.proto-pollution.test.ts --maxWorkers 1
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/lib/config/config-write-coordinator.test.ts ui/src/lib/config/runtime-config-capability.test.ts ui/src/pages/plugins/plugins-page.test.ts --maxWorkers 1
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/cloud-workers-settings.e2e.test.ts --maxWorkers 1
```

```bash
node scripts/check-changed.mjs --base 52907070417495b59596f3efc0d4403a66ce29c2 -- docs/gateway/configuration.md src/config/merge-patch.proto-pollution.test.ts src/config/merge-patch.ts src/config/patch-replace-paths.ts src/gateway/server-methods/config.ts ui/src/components/mcp-servers-card.test.ts ui/src/e2e/cloud-workers-settings.e2e.test.ts ui/src/lib/config/mcp-servers.ts ui/src/pages/cloud-workers/cloud-worker-config.test.ts ui/src/pages/cloud-workers/cloud-worker-config.ts ui/src/pages/cloud-workers/cloud-workers-page.test.ts ui/src/pages/cloud-workers/cloud-workers-page.ts
```

```bash
pnpm build:ci-artifacts
```

```bash
git diff --check 52907070417495b59596f3efc0d4403a66ce29c2 HEAD
```

</details>

### Real Control UI and Gateway proof

Normal single-use owner pairing connected an isolated Chromium browser to real task-owned Gateways with synthetic configuration. The BEFORE build reproduced all three array-intent rejections. The AFTER build asserted exact target-only requests, singleton `replacePaths`, actual RPC responses, rendered results, and persisted/runtime state. No cloud machine, MCP transport, channel, or provider was enabled.

The Cloud-delete then MCP-remove sequence preserved the original execution order. Cloud deletion was accepted and rendered with a restart-required notice. MCP removal persisted and updated configuration, but its RPC returned the documented `UNAVAILABLE` restart-required receipt. That original result remains **partial**, not a clean RPC success; neither deletion was replayed.

An operator-assisted restart of the same saved target state, with only private logging instrumentation added, completed that observation. One read-only CLI response and two normal browser `config.get` responses confirmed non-null `appliedConfigHash === configRevisionHash`, both deleted targets and the deleted profile's project reference absent, and complete retained records, including opaque nulls, unchanged. This proves the new logging-instrumented revision, not automatic completion of the original restart. Outstanding prior restart debt is a source-supported explanation for the partial receipt, not a proven diagnosis of that original event. This PR does not alter reload settlement or restart notifications.

A separate fresh Setup-clear fixture passed with a successful non-noop RPC and the exact `setupEnv` replacement path. The saved editor reopened with empty Setup. A fresh `config.get` confirmed the revision active **without an operator-assisted restart**, complete Cloud records equal to the seed minus only the selected `setup`/`setupEnv`, both opaque nulls preserved, unchanged project defaults, and complete disabled MCP records unchanged. All task-owned Gateways and browser processes were stopped and their absence verified.

Targeted internal notification wakes remain possible when recurring schedules are disabled. An unavailable-harness guard blocked the observed internal attempt; no runtime was enabled to bypass it. Original shared logs were not inspected, so original-event chronology and automatic-restart completion remain explicit gaps, not claimed passes.

All six captures below were inspected in full and contain synthetic data only.

| Flow | Before | After |
| --- | --- | --- |
| Delete array-bearing Cloud profile | ![Profile deletion rejected before the repair](https://github.com/user-attachments/assets/3bc4d08e-2747-48c2-a244-2d0c30f92bb2) | ![Only the retained profile remains after operator-assisted restart](https://github.com/user-attachments/assets/67a09b23-be93-4e5c-b51e-2f81a72d6b68) |
| Clear Setup with environment array | ![Setup clear rejected before the repair](https://github.com/user-attachments/assets/c3141861-1cbe-4371-a4ba-1cd528632c82) | ![Saved Setup is empty after reopening; the textarea displays its placeholder](https://github.com/user-attachments/assets/d7fbb4cc-feac-40c1-8bca-c7378165a180) |
| Remove array-bearing MCP server | ![MCP removal rejected before the repair](https://github.com/user-attachments/assets/e7358779-9acd-4e61-8846-f958ec517ff5) | ![Only the retained disabled server remains after operator-assisted restart](https://github.com/user-attachments/assets/f1c612cc-dd36-419f-a270-2373cdd88c5b) |

### Ownership, provenance, and scope

The producer is the correct owner: making the Gateway permissive or automatically authorizing all destructive patches in the generic coordinator would erase the existing protection. The shared collector is moved, not replaced by parallel recursion; duplicate formatters and whole-record resends are removed. CLI MCP mutations use their existing full-config/CAS path and are unaffected.

Raw source/history and live metadata trace missing MCP removal intent to [Control UI plugin management, #103176](https://github.com/openclaw/openclaw/pull/103176), Cloud deletion/broad resends to [Cloud Worker profiles, #124864](https://github.com/openclaw/openclaw/pull/124864), and explicit `setupEnv: null` on Setup clear to [provider-owned Cloud settings preservation, #129846](https://github.com/openclaw/openclaw/pull/129846). Code author: Peter Steinberger; PR author and merger: @steipete; raw Git committer: GitHub. Those merged on July 10, August 17, and August 26, 2026, respectively. The exact-array guard predates those UI paths. No first affected stable release is claimed.

Production LOC: **+77/-63 (net +14)**. Tests/support: **+428/-89 (net +339)**. Documentation: **+10/-6 (net +4)**. The production increase carries explicit intent across existing boundaries after deleting redundant formatting and broad resends. No fallback, compatibility alias, new queue, or generic auto-authorization path was added.

Named follow-up: the existing `isPlainObject` comment overstates its object-tag predicate by claiming class instances are excluded. This repair preserves the actual predicate behavior; correcting that comment must not silently change its contract. The separately tracked after-submit disconnect/lost-acknowledgment concern is not treated as fixed here.
