### PR TITLE
fix(ui): preserve immediate New Session to Chat navigation

### DIFF
--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -475,7 +475,7 @@ export function bootstrapApplication(): ApplicationRuntime {
       void navigateWithMode(routeId, options, "replace");
     },
     revalidate: (routeId) => router.revalidate(context, routeId),
-    preload: (routeId, options) => router.preloadLocation(routeLocation(routeId, options), context),
+    preload: (routeId) => router.preloadLocation(locationForRoute(routeId, basePath), context),
   };
   return {
     context,

--- a/ui/src/app/context.ts
+++ b/ui/src/app/context.ts
@@ -122,7 +122,8 @@ export type ApplicationContext<TRouteId extends string = string> = {
   ) => Promise<void>;
   readonly replace: (routeId: TRouteId, options?: ApplicationNavigationOptions) => void;
   readonly revalidate: (routeId?: TRouteId) => Promise<void>;
-  readonly preload: (routeId: TRouteId, options?: ApplicationNavigationOptions) => Promise<void>;
+  /** Warms a named route; dynamic locations load as part of navigation. */
+  readonly preload: (routeId: TRouteId) => Promise<void>;
 };
 
 export const applicationContext =

--- a/ui/src/app/route-transition.test.ts
+++ b/ui/src/app/route-transition.test.ts
@@ -23,37 +23,6 @@ function testDocumentWithOutlet(animate = vi.fn()) {
 afterEach(() => document.body.replaceChildren());
 
 describe("navigateWithRouteTransition", () => {
-  it("keeps the outgoing view live until the destination is prepared", async () => {
-    let finishPreparation!: () => void;
-    const prepare = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          finishPreparation = resolve;
-        }),
-    );
-    const navigate = vi.fn(async () => undefined);
-    const test = testDocumentWithOutlet();
-    const transition = navigateWithRouteTransition({
-      document: test.document,
-      from: "new-session",
-      to: "chat",
-      navigate,
-      prepare,
-      prefersReducedMotion: false,
-    });
-    await Promise.resolve();
-
-    expect(prepare).toHaveBeenCalledOnce();
-    expect(navigate).not.toHaveBeenCalled();
-
-    finishPreparation();
-    await vi.waitFor(() => expect(navigate).toHaveBeenCalledOnce());
-    document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT));
-    await transition;
-
-    expect(navigate).toHaveBeenCalledOnce();
-  });
-
   it("animates the rendered chat pane without freezing the outgoing document", async () => {
     const finished = Promise.resolve({} as Animation);
     const animate = vi.fn(() => ({ finished }) as Animation);
@@ -73,7 +42,7 @@ describe("navigateWithRouteTransition", () => {
       navigate,
       prefersReducedMotion: false,
     });
-    await vi.waitFor(() => expect(navigate).toHaveBeenCalledOnce());
+    expect(navigate).toHaveBeenCalledOnce();
     expect(animate).not.toHaveBeenCalled();
     finishNavigation();
     document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT));
@@ -86,20 +55,22 @@ describe("navigateWithRouteTransition", () => {
     );
   });
 
-  it("navigates directly when destination preparation fails", async () => {
+  it("propagates navigation failure without animating", async () => {
     const test = testDocumentWithOutlet();
-    const navigate = vi.fn(async () => undefined);
-
-    await navigateWithRouteTransition({
-      document: test.document,
-      from: "new-session",
-      to: "chat",
-      navigate,
-      prepare: async () => {
-        throw new Error("preload failed");
-      },
-      prefersReducedMotion: false,
+    const failure = new Error("Chat route failed to load");
+    const navigate = vi.fn(async () => {
+      throw failure;
     });
+
+    await expect(
+      navigateWithRouteTransition({
+        document: test.document,
+        from: "new-session",
+        to: "chat",
+        navigate,
+        prefersReducedMotion: false,
+      }),
+    ).rejects.toBe(failure);
 
     expect(navigate).toHaveBeenCalledOnce();
     expect(test.animate).not.toHaveBeenCalled();

--- a/ui/src/app/route-transition.ts
+++ b/ui/src/app/route-transition.ts
@@ -4,7 +4,6 @@ type RouteTransitionOptions = {
   document: Document;
   from: RouteId | undefined;
   navigate: () => Promise<void>;
-  prepare?: () => Promise<void>;
   prefersReducedMotion: boolean;
   to: RouteId;
 };
@@ -59,18 +58,12 @@ async function navigateAndAnimate(
 }
 
 export async function navigateWithRouteTransition(options: RouteTransitionOptions): Promise<void> {
-  const { document, from, navigate, prepare, prefersReducedMotion, to } = options;
+  const { document, from, navigate, prefersReducedMotion, to } = options;
   if (from !== "new-session" || to !== "chat") {
     return navigate();
   }
 
-  try {
-    await prepare?.();
-  } catch {
-    // Preparation is an enhancement. Preserve direct navigation so its normal
-    // route error handling remains authoritative when preloading fails.
-    return navigate();
-  }
-
+  // Navigation commits the URL while the outlet keeps the submitted prompt live.
+  // Only the entrance animation waits for the rendered chat composer.
   return navigateAndAnimate(document, navigate, prefersReducedMotion);
 }

--- a/ui/src/e2e/new-session-page.transition.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.transition.e2e.test.ts
@@ -234,7 +234,7 @@ suite.define(() => {
     }
   });
 
-  it("opens the confirmed session before roster or reference lookup completes and preserves effort", async () => {
+  it("commits the confirmed session URL before Chat loads and animates only the ready composer", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -341,6 +341,9 @@ suite.define(() => {
       await gateway.waitForRequest("sessions.list", { after: listRequestsBeforeSubmit });
       await expect.poll(() => chatModuleRequested).toBe(true);
 
+      expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(SESSION_KEY));
+      expect(await gateway.getRequests("chat.startup")).toHaveLength(0);
+      expect(await gateway.getRequests("sessions.resolve")).toHaveLength(0);
       expect(await submittedPrompt.isVisible()).toBe(true);
       expect(await submittedPrompt.count()).toBe(1);
       await captureProof(page, "01-chat-route-preparing.png");

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -637,10 +637,6 @@ describe("DraftSubmissionFlow", () => {
         });
       },
     );
-    const preload = vi.fn(
-      async (_routeId: string, _options?: Parameters<ApplicationContext["preload"]>[1]) =>
-        undefined,
-    );
     const setSessionKey = vi.fn((sessionKey: string) => {
       context.gateway.snapshot.sessionKey = sessionKey;
     });
@@ -712,7 +708,6 @@ describe("DraftSubmissionFlow", () => {
       },
       config: { current: {} },
       navigateAndWait,
-      preload,
     } as unknown as ApplicationContext;
     const host = new TestReactiveControllerHost();
     const gateway = new DraftGatewayState(
@@ -819,11 +814,9 @@ describe("DraftSubmissionFlow", () => {
     if (background) {
       await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
       expect(navigateAndWait).not.toHaveBeenCalled();
-      expect(preload).not.toHaveBeenCalled();
     } else {
       await vi.waitFor(() => expect(navigateAndWait).toHaveBeenCalledOnce());
-      expect(preload).toHaveBeenCalledWith("chat", navigateAndWait.mock.calls[0]?.[1]);
-      expect(preload.mock.invocationCallOrder[0]).toBeLessThan(
+      expect(setSessionKey.mock.invocationCallOrder[0]).toBeLessThan(
         navigateAndWait.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
       );
     }
@@ -873,7 +866,6 @@ describe("DraftSubmissionFlow", () => {
     } else {
       expect(setSessionKey).toHaveBeenCalledWith(start.mock.calls[0]?.[0].recovery.sessionKey);
       expect(selectAgent).toHaveBeenCalledWith("cloud");
-      expect(preload).toHaveBeenCalledOnce();
     }
 
     if (navigationError) {

--- a/ui/src/pages/new-session/started-session-navigation.test.ts
+++ b/ui/src/pages/new-session/started-session-navigation.test.ts
@@ -10,6 +10,39 @@ afterEach(() => {
 });
 
 describe("confirmed session navigation", () => {
+  it("hands off the confirmed session without waiting for speculative preloading", async () => {
+    const { context, flow } = createDraftFixture();
+    const sessionKey = "agent:main:dashboard:0f403cb8-3920-4cf1-8eb7-79f2f00ce488";
+    vi.mocked(context.sessions.createResult).mockResolvedValue({
+      key: sessionKey,
+      initialRun: { status: "idle" },
+    });
+    let releasePreload!: () => void;
+    vi.mocked(context.preload).mockReturnValue(
+      new Promise<void>((resolve) => {
+        releasePreload = resolve;
+      }),
+    );
+    vi.mocked(context.navigateAndWait).mockImplementation(async (_routeId, options) => {
+      expect(options?.pathname).toBe("/chat/main/0f403cb8");
+      expect(consumeSessionNavigationHandoff(context.gateway, "/chat/main/0f403cb8")).toBe(
+        sessionKey,
+      );
+      queueMicrotask(() => document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT)));
+    });
+    flow.setMessage("start this task");
+    const submission = flow.submit();
+    try {
+      await vi.waitFor(() => expect(context.navigateAndWait).toHaveBeenCalledOnce());
+      await submission;
+      expect(context.sessions.createResult).toHaveBeenCalledOnce();
+      expect(flow.error).toBeNull();
+    } finally {
+      releasePreload();
+      await submission;
+    }
+  });
+
   it("surfaces navigation failure after a session has already been created", async () => {
     const { context, flow } = createDraftFixture();
     vi.mocked(context.sessions.createResult).mockResolvedValue({
@@ -71,7 +104,7 @@ describe("confirmed session navigation", () => {
       retire: ({ flow }: ReturnType<typeof createDraftFixture>) => flow.invalidate(),
     },
   ])(
-    "retires a confirmed session handoff when $scenario during route preparation",
+    "retires a confirmed session handoff when $scenario during session selection",
     async ({ retire }) => {
       const fixture = createDraftFixture();
       const { context, flow } = fixture;
@@ -80,42 +113,21 @@ describe("confirmed session navigation", () => {
         key: sessionKey,
         initialRun: { status: "idle" },
       });
-      let releasePreload!: () => void;
-      vi.mocked(context.preload).mockReturnValueOnce(
-        new Promise<void>((resolve) => {
-          releasePreload = resolve;
-        }),
-      );
-      vi.mocked(context.navigateAndWait).mockImplementation(async () => {
-        queueMicrotask(() => document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT)));
+      // Selection publishes synchronously; a subscriber may retire the flow
+      // before navigation has claimed the confirmed key.
+      vi.mocked(context.gateway.setSessionKey).mockImplementation((key) => {
+        context.gateway.snapshot.sessionKey = key;
+        retire(fixture);
       });
       flow.setMessage("keep this task on its original connection");
-      let settled = false;
-      const submission = flow.submit().finally(() => {
-        settled = true;
-      });
-      let pathname: string | undefined;
-      try {
-        await vi.waitFor(() => expect(context.preload).toHaveBeenCalledOnce());
-        pathname = vi.mocked(context.preload).mock.calls[0]?.[1]?.pathname;
-        if (!pathname) {
-          throw new Error("The created session did not prepare a route");
-        }
-        retire(fixture);
-        releasePreload();
 
-        await vi.waitFor(() => expect(settled).toBe(true));
-        expect(consumeSessionNavigationHandoff(context.gateway, pathname)).toBeUndefined();
-        expect(context.navigateAndWait).not.toHaveBeenCalled();
-        expect(context.sessions.createResult).toHaveBeenCalledOnce();
-      } finally {
-        releasePreload();
-        document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT));
-        await submission;
-        if (pathname) {
-          consumeSessionNavigationHandoff(context.gateway, pathname);
-        }
-      }
+      await flow.submit();
+
+      expect(
+        consumeSessionNavigationHandoff(context.gateway, "/chat/main/0f403cb8"),
+      ).toBeUndefined();
+      expect(context.navigateAndWait).not.toHaveBeenCalled();
+      expect(context.sessions.createResult).toHaveBeenCalledOnce();
     },
   );
 

--- a/ui/src/pages/new-session/started-session-navigation.ts
+++ b/ui/src/pages/new-session/started-session-navigation.ts
@@ -55,7 +55,6 @@ export class StartedSessionNavigation {
       to: "chat",
       prefersReducedMotion:
         globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false,
-      prepare: () => context.preload("chat", options),
       navigate: () => {
         if (this.current !== current || !this.isCurrent(context, started.agentId)) {
           throw new DOMException("Session navigation interrupted", "AbortError");


### PR DESCRIPTION
Related: #136862 (the New Session preload follow-up; compression and transcript warming remain in that PR).

## What Problem This Solves

Resolves the contradictory New Session → Chat loading contract: the UI appeared to prepare a session route before navigating, but dynamic session paths never matched the router's exact-path preloader. Making that call work would delay the Chat URL and run its loader before the confirmed-session handoff existed.

## Why This Change Was Made

Choose **navigate first** (option b): commit the Chat URL as soon as creation is confirmed, keep the submitted prompt visible while Chat loads, and animate only after the composer is rendered. Remove the ineffective transition `prepare` hook and its failure fallback, and narrow `context.preload` to named routes. The existing guarded handoff stays immediately before navigation; sidebar route warming retains its base-path-aware behavior.

This preserves the ordering already shipped in v2026.8.2. Real preloading would be a separate behavior change involving handoff lifetime, cancellation, module/data readiness, and URL timing. No configuration, persistence, protocol, or dependency changes.

## User Impact

Starting a session retains immediate navigation, visible progress, the selected thinking level, and retry without a second session creation. Developers can no longer request a dynamic preload that silently loads nothing.

## Evidence

- New `started-session-navigation.test.ts` regression failed on the original code: navigation was never called while speculative preload remained pending. It passes after the deletion and verifies that the confirmed key is handed to navigation.
- 95 distinct focused tests passed across `started-session-navigation.test.ts`, `route-transition.test.ts`, `bootstrap.test.ts`, `pages/chat/route.test.ts`, and `draft-submission-flow.test.ts`. Retirement coverage now uses synchronous selection notifications; error/retry and reduced-motion behavior remain covered.
- The production-bundle Chromium transition scenario passed before and after. The updated e2e explicitly asserts the Chat URL while the Chat module is blocked, zero `sessions.resolve`, continuous prompt visibility, and animation after the composer appears.
- All 26 browser cases passed across the transition and GitHub-project suites, including desktop/mobile, light/dark, reduced motion, creation failure/retry, background starts, and project/worktree preparation.
- Initial CI/typechecking found an additional placement test coupled to preload; it now asserts selection before navigation and passes.
- Independent Codex autoreview: no actionable P0–P2 findings.
- Direct inspection/execution of pinned `@openclaw/uirouter` 0.1.1 confirmed exact-path matching and no loader/component invocation for dynamic Chat, agents, workboard, memory, or plugins paths. New Session was the only production preload-options caller.
- Production: +6/-13 (net **-7**). Tests: +66/-88 (net **-22**).

Commands:

```sh
node scripts/run-vitest.mjs ui/src/pages/new-session/started-session-navigation.test.ts ui/src/app/route-transition.test.ts ui/src/app/bootstrap.test.ts ui/src/pages/chat/route.test.ts
node scripts/run-vitest.mjs ui/src/pages/new-session/draft-submission-flow.test.ts ui/src/pages/new-session/started-session-navigation.test.ts ui/src/app/route-transition.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.transition.e2e.test.ts ui/src/e2e/new-session-page.github-projects.e2e.test.ts
OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.transition.e2e.test.ts -t 'commits the confirmed session URL'
```

The attached screenshots are synthetic mocked-Gateway browser captures, inspected for unrelated/private content. Before and after deliberately preserve the same visible behavior: pending Chat module, then ready Chat composer. They do not claim authenticated live-Gateway proof.

![Before: Chat module pending](https://github.com/user-attachments/assets/2171be07-9282-4623-9a70-2377dad3597e)

![Before: Chat composer ready](https://github.com/user-attachments/assets/27fc53b5-2068-4566-96fe-367c36909f85)

![After: Chat module pending](https://github.com/user-attachments/assets/9f5419eb-af7c-4c71-ada1-265886c8224b)

![After: Chat composer ready](https://github.com/user-attachments/assets/356d9bb9-472c-406c-9b5b-9a31b7d24659)
