### PR TITLE
fix(ui): restore startup CSS hard gate

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -124,17 +124,18 @@ remains the explicit operator override for attempting a different budget.
 
 ## Control UI size budgets
 
-`pnpm ui:build` produces and verifies the bundle, then reports its compressed
-sizes. Budget violations do not prevent artifact generation. The separate
-`control-ui-performance` job enforces the budgets without blocking other jobs
-from building or testing the same source.
+`pnpm ui:build` produces and verifies the bundle, then enforces its compressed
+size budgets. A violation fails the build after artifact generation. The separate
+`control-ui-performance` job compares the exact candidate and base revisions
+without blocking other jobs from building or testing the same source.
 
-Startup CSS has a 45 KiB advisory target and a 50 KiB hard ceiling. Growth below
-1 KiB passes; an increase of 1 KiB or more in either startup CSS or the largest
-CSS file fails the comparison. The existing largest-file, JavaScript, request-count,
-and isolated-renderer ceilings still apply independently. Reports include exact
-bytes, base deltas, and remaining headroom, with an early warning when the largest
-CSS file has less than 1 KiB of headroom.
+Startup CSS has a 45 KiB hard ceiling. As a secondary exact-base guard, growth
+below 1 KiB passes; an increase of 1 KiB or more in either startup CSS or the
+largest CSS file fails the comparison even below the absolute ceilings. The
+existing largest-file, JavaScript, request-count, and isolated-renderer ceilings
+still apply independently. Reports include exact bytes, base deltas, and remaining
+headroom, with an early warning when the largest CSS file has less than 1 KiB of
+headroom.
 
 CI builds the selected checkout and the exact preflight base with the same
 installed Node, Vite, and dependencies. The temporary base's CSS sidecars are
@@ -149,9 +150,9 @@ pnpm ui:check-performance:base <base-commit-sha>
 ```
 
 To enforce absolute budgets on an existing build, run `pnpm ui:check-performance`.
-Use `--base-dist <directory>` to compare with an already-built base, or
-`--report-only` to report violations without failing. Missing or malformed build
-artifacts remain errors in report-only mode.
+Use `--base-dist <directory>` to compare with an already-built base. Run
+`pnpm ui:check-performance --report-only` for an explicit non-blocking
+diagnostic. Missing or malformed build artifacts remain errors in report-only mode.
 
 ## Watching pull request CI
 

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -209,10 +209,11 @@ existing temporary directories, Node or Vitest caches, or other global caches. S
 validators; it does not require `TSX_DISABLE_CACHE` in the invoking shell. Raw
 external `tsx` and `node --import tsx` invocations outside these launchers are unchanged.
 
-Control UI builds report size budgets without enforcing them. Run
-`pnpm ui:check-performance` after a build to enforce absolute budgets, or
-`pnpm ui:check-performance:base <base-commit-sha>` to build and compare both
-revisions with the same toolchain. See [Control UI size budgets](/ci#control-ui-size-budgets).
+Control UI builds enforce absolute size budgets. Run
+`pnpm ui:check-performance --report-only` for an explicit non-blocking diagnostic,
+or `pnpm ui:check-performance:base <base-commit-sha>` for the secondary exact-base
+comparison with the same toolchain. See
+[Control UI size budgets](/ci#control-ui-size-budgets).
 
 ### Source tests and subprocess builds
 

--- a/scripts/check-control-ui-performance.mts
+++ b/scripts/check-control-ui-performance.mts
@@ -21,7 +21,6 @@ const DEFAULT_STARTUP_BUDGET_BASELINE_PATH = path.resolve(
 // may accumulate. The fixed startup JS ceiling bounds that cumulative creep.
 const CONTROL_UI_STARTUP_JS_GZIP_TOLERANCE_BYTES = 512;
 const CONTROL_UI_STARTUP_JS_GZIP_BUILD_VARIANCE_BYTES = 64;
-const CONTROL_UI_STARTUP_CSS_GZIP_TARGET_BYTES = 45 * KIB;
 const CONTROL_UI_CSS_GZIP_GROWTH_BYTES = KIB;
 // The opaque Mermaid sandbox loads one self-contained classic script only when
 // a diagram is viewed. Keep its size visible without relaxing ordinary chunks.
@@ -36,9 +35,13 @@ const controlUiPerformanceBudgets = {
   // 350 KiB maintainer-approved by Vyctor 2026-08-11 for #121686;
   // #121734 left main 6 B below the prior 319 KiB hard ceiling.
   startupJsGzipBytes: 350 * KIB,
-  // Keep 45 KiB advisory: tiny integrated changes must not exhaust the budget.
-  // The fixed 50 KiB ceiling bounds accumulation of sub-KiB changes.
-  startupCssGzipBytes: 50 * KIB,
+  // 45 KiB CSS ceilings maintainer-approved 2026-07 alongside the interleaved
+  // sidebar zone styling; headroom over the ~36.5 KiB post-diet baseline.
+  // Briefly 47 KiB for the Tide/Beacon/Phosphor palettes, restored to 45 KiB
+  // once those palettes moved out of the startup sheet into public/themes and
+  // measured 42.2 KiB — below where they started. Adding a built-in theme no
+  // longer costs the default path anything, so this ceiling should stay put.
+  startupCssGzipBytes: 45 * KIB,
   largestJsGzipBytes: 215 * KIB,
   // Composer multiline surface (stack #124301) legitimately grew boot CSS;
   // operator decision 2026-08-25 rejected boot splitting due to precedence risk.
@@ -260,11 +263,6 @@ function controlUiPerformanceWarnings(
   budgets: Readonly<typeof CONTROL_UI_PERFORMANCE_BUDGETS>,
 ): string[] {
   const warnings: string[] = [];
-  if (metrics.startup.css.gzipBytes > CONTROL_UI_STARTUP_CSS_GZIP_TARGET_BYTES) {
-    warnings.push(
-      `startup CSS gzip is above the ${CONTROL_UI_STARTUP_CSS_GZIP_TARGET_BYTES} B advisory target; remaining hard-ceiling headroom: ${budgets.startupCssGzipBytes - metrics.startup.css.gzipBytes} B`,
-    );
-  }
   const largestCssHeadroom = budgets.largestCssGzipBytes - metrics.largest.css.gzipBytes;
   if (largestCssHeadroom < CONTROL_UI_CSS_GZIP_GROWTH_BYTES) {
     warnings.push(`largest CSS gzip has ${largestCssHeadroom} B of hard-ceiling headroom`);
@@ -318,7 +316,7 @@ export function formatControlUiPerformanceReport(
     );
   }
   lines.push(
-    `  startup CSS: ${formatAssetSummary(metrics.startup.css)} (limits: ${formatRequestCount(budgets.startupCssRequests)}, advisory target ${CONTROL_UI_STARTUP_CSS_GZIP_TARGET_BYTES} B, hard ceiling ${budgets.startupCssGzipBytes} B; headroom ${budgets.startupCssGzipBytes - metrics.startup.css.gzipBytes} B)`,
+    `  startup CSS: ${formatAssetSummary(metrics.startup.css)} (limits: ${formatRequestCount(budgets.startupCssRequests)}, hard ceiling ${budgets.startupCssGzipBytes} B; headroom ${budgets.startupCssGzipBytes - metrics.startup.css.gzipBytes} B)`,
     `  largest ordinary JS: ${metrics.largest.js.file}, ${formatControlUiPerformanceBytes(metrics.largest.js.gzipBytes)} gzip (limit: ${formatControlUiPerformanceBytes(budgets.largestJsGzipBytes)})`,
     `  largest CSS: ${metrics.largest.css.file}, ${metrics.largest.css.gzipBytes} B gzip (hard ceiling ${budgets.largestCssGzipBytes} B; headroom ${budgets.largestCssGzipBytes - metrics.largest.css.gzipBytes} B)`,
     `  all JS: ${formatAssetSummary(metrics.total.js)}`,
@@ -328,7 +326,7 @@ export function formatControlUiPerformanceReport(
     for (const area of ["startup", "largest"] as const) {
       const growth = metrics[area].css.gzipBytes - baseMetrics[area].css.gzipBytes;
       lines.push(
-        `  ${area} CSS gzip vs base: ${baseMetrics[area].css.gzipBytes} B -> ${metrics[area].css.gzipBytes} B (${growth >= 0 ? "+" : ""}${growth} B; growth below ${CONTROL_UI_CSS_GZIP_GROWTH_BYTES} B allowed)`,
+        `  ${area} CSS gzip vs base: ${baseMetrics[area].css.gzipBytes} B -> ${metrics[area].css.gzipBytes} B (${growth >= 0 ? "+" : ""}${growth} B; secondary guard allows growth below ${CONTROL_UI_CSS_GZIP_GROWTH_BYTES} B)`,
       );
     }
   }

--- a/scripts/ui.mts
+++ b/scripts/ui.mts
@@ -441,19 +441,14 @@ export function runUiCli(argv: string[] = process.argv.slice(2)): void {
     if (rest.some((arg) => arg === "--help" || arg === "-h")) {
       return;
     }
-    for (const [validator, ...validatorArgs] of [
-      ["check-control-ui-precompressed-assets.mts"],
-      ["check-control-ui-performance.mts", "--report-only"],
-    ] as const) {
+    for (const validator of [
+      "check-control-ui-precompressed-assets.mts",
+      "check-control-ui-performance.mts",
+    ]) {
       runSpawnCallSync(
         resolveSpawnCall(
           process.execPath,
-          [
-            "--import",
-            new URL("./tsx.mjs", import.meta.url).href,
-            path.join(here, validator),
-            ...validatorArgs,
-          ],
+          ["--import", new URL("./tsx.mjs", import.meta.url).href, path.join(here, validator)],
           env,
           { cwd: repoRoot },
         ),

--- a/test/scripts/control-ui-performance.test.ts
+++ b/test/scripts/control-ui-performance.test.ts
@@ -285,16 +285,27 @@ describe("Control UI performance budgets", () => {
     );
   });
 
-  it("reports a 17-byte startup CSS target excess without failing the check", () => {
-    const { rootDir, scriptPath } = createCliFixture(46_097);
+  it.each([
+    ["accepts startup CSS exactly at 45 KiB", 45 * 1024, 0],
+    ["rejects startup CSS one byte above 45 KiB", 45 * 1024 + 1, 1],
+  ])("%s", (_name, startupCssGzipBytes, expectedStatus) => {
+    const { rootDir, scriptPath } = createCliFixture(startupCssGzipBytes);
     const result = runControlUiPerformanceCli(scriptPath, ["--json"], rootDir);
 
-    expect(result.status, result.stderr).toBe(0);
+    expect(result.status, result.stderr).toBe(expectedStatus);
     const report = JSON.parse(result.stdout);
-    expect(report.violations).toEqual([]);
-    expect(report.warnings).toEqual([expect.stringContaining("CSS")]);
-    expect(report.report).toContain("46097 B");
-    expect(report.report).toContain("5103 B");
+    expect(report.violations).toEqual(
+      expectedStatus
+        ? [
+            expect.objectContaining({
+              metric: "startup CSS gzip",
+              actual: 45 * 1024 + 1,
+              limit: 45 * 1024,
+            }),
+          ]
+        : [],
+    );
+    expect(report.report).toContain(`hard ceiling ${45 * 1024} B`);
   });
 
   it.each<
@@ -307,14 +318,12 @@ describe("Control UI performance budgets", () => {
       metric: string | null,
     ]
   >([
-    ["startup growth below 1 KiB", 47_103, 46_080, 50_000, 50_000, null],
-    ["startup growth at 1 KiB", 47_104, 46_080, 50_000, 50_000, "startup CSS"],
-    ["deferred growth below 1 KiB", 46_080, 46_080, 52_000, 50_977, null],
-    ["deferred growth at 1 KiB", 46_080, 46_080, 52_000, 50_976, "largest CSS"],
-    ["startup at the hard cap", 51_200, 51_200, 50_000, 50_000, null],
-    ["startup above the hard cap", 51_201, 51_201, 50_000, 50_000, "startup CSS"],
-    ["deferred at the hard cap", 46_080, 46_080, 53_400, 53_400, null],
-    ["deferred above the hard cap", 46_080, 46_080, 53_401, 53_401, "largest CSS"],
+    ["startup growth below 1 KiB", 45_000, 43_977, 45_000, 45_000, null],
+    ["startup growth at 1 KiB", 45_000, 43_976, 45_000, 45_000, "startup CSS"],
+    ["deferred growth below 1 KiB", 45_000, 45_000, 52_000, 50_977, null],
+    ["deferred growth at 1 KiB", 45_000, 45_000, 52_000, 50_976, "largest CSS"],
+    ["deferred at the hard cap", 45_000, 45_000, 53_400, 53_400, null],
+    ["deferred above the hard cap", 45_000, 45_000, 53_401, 53_401, "largest CSS"],
   ])("checks %s against built base assets", (_name, css, baseCss, lazy, baseLazy, metric) => {
     const current = createCliFixture(css, lazy);
     const base = createCliFixture(baseCss, baseLazy);
@@ -335,7 +344,7 @@ describe("Control UI performance budgets", () => {
   });
 
   it("keeps budget violations visible in report-only mode without rejecting artifacts", () => {
-    const { rootDir, scriptPath } = createCliFixture(51_201);
+    const { rootDir, scriptPath } = createCliFixture(46_081);
     const enforced = runControlUiPerformanceCli(scriptPath, ["--json"], rootDir);
     const reported = runControlUiPerformanceCli(scriptPath, ["--json", "--report-only"], rootDir);
 
@@ -344,7 +353,7 @@ describe("Control UI performance budgets", () => {
     const report = JSON.parse(reported.stdout);
     expect(report.violations).toEqual(JSON.parse(enforced.stdout).violations);
     expect(report.violations).toEqual([
-      expect.objectContaining({ metric: "startup CSS gzip", actual: 51_201, limit: 51_200 }),
+      expect.objectContaining({ metric: "startup CSS gzip", actual: 46_081, limit: 46_080 }),
     ]);
   });
 
@@ -378,7 +387,9 @@ describe("Control UI performance budgets", () => {
       const baselinePath = path.join(configDir, "control-ui-startup-budget-baseline.json");
       const before = fs.readFileSync(baselinePath, "utf8");
       const args = ["--update-baseline", option];
-      if (option === "--base-dist") args.push(distDir);
+      if (option === "--base-dist") {
+        args.push(distDir);
+      }
 
       const result = runControlUiPerformanceCli(scriptPath, args, rootDir);
       expect(result.status).toBe(1);

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -401,7 +401,7 @@ process.exitCode = ${expectedExit};\n`,
     { noPnpm: false, failValidator: "check-control-ui-precompressed-assets.mts" },
     { noPnpm: true, failValidator: "check-control-ui-performance.mts" },
   ])(
-    "reports budgets and enforces asset validity off disk caches (noPnpm=$noPnpm, failure=$failValidator)",
+    "enforces asset and performance budgets off disk caches (noPnpm=$noPnpm, failure=$failValidator)",
     ({ noPnpm, failValidator }) => {
       const tempDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ui-cache-")));
       const tempRoot = path.join(tempDir, "temp");
@@ -463,8 +463,7 @@ enum Transformed { Value = "transformed" }
 const validator = process.argv[2];
 const reportOnly = process.argv.includes("--report-only");
 console.log(JSON.stringify({ validator, transformed: Transformed.Value, reportOnly }));
-process.exitCode = validator === ${JSON.stringify(failValidator)} ? 17
-  : validator === "check-control-ui-performance.mts" && !reportOnly ? 1 : 0;
+process.exitCode = validator === ${JSON.stringify(failValidator)} ? 17 : 0;
 `,
         );
         // Run the native launcher, intercept only the build, then replay each real
@@ -486,7 +485,7 @@ childProcess.spawnSync = function(command, args, options) {
   }
   const validator = path.basename(args[2]);
   if (!validators.includes(validator)) throw new Error("Unexpected UI subprocess");
-  assert.deepEqual(args.slice(3), validator === "check-control-ui-performance.mts" ? ["--report-only"] : []);
+  assert.deepEqual(args.slice(3), []);
   assert.equal(options.env.TSX_DISABLE_CACHE, undefined);
   return spawnSync(command, [...args.slice(0, 2), ${JSON.stringify(fixture)}, validator, ...args.slice(3)], options);
 };
@@ -550,7 +549,7 @@ require("node:module").syncBuiltinESMExports();
           expectedValidators.map((validator) => ({
             validator,
             transformed: "transformed",
-            reportOnly: validator === "check-control-ui-performance.mts",
+            reportOnly: false,
           })),
         );
         for (const cacheRoot of cacheRoots) {


### PR DESCRIPTION
## What Problem This Solves

Fixes the Control UI performance regression introduced by PR #136972, where the 45 KiB startup CSS ceiling became advisory with a 50 KiB hard limit and `ui:build` ran the performance check in report-only mode.

## Why This Change Was Made

The canonical fix restores the 45 KiB startup CSS hard owner and makes ordinary `ui:build` enforce performance violations. The exact-base comparison remains a separate 1 KiB growth guard, while `--report-only` remains available as an explicit diagnostic.

The branch was rebased once onto frozen `origin/main` base `6b97bae2e1578bf946984a766270a820df0d6aca`. Conflict resolution preserved current-main direct Vite launcher behavior and changed only the validator enforcement policy.

No configuration, schema, baseline, or workflow changes are included.

## User Impact

Control UI builds once again fail when startup CSS exceeds 45 KiB, preventing cumulative performance regressions from passing the normal build path.

## Evidence

- Exact head: `9940885b10c981b558bd0663d8d6953e4281a7b8`
- Frozen base: `6b97bae2e1578bf946984a766270a820df0d6aca`
- Scope: 6 files
- Production/tooling: +14/-21, net -7
- Tests: +33/-23, net +10
- Docs: +20/-18, net +2
- Total: +67/-62, net +5
- Focused local Vitest: 2 files, 69/69 passed
- `pnpm ui:build`: passed
- Startup CSS: 43,899 B gzip, with 2,181 B headroom below the 46,080 B ceiling
- Changed-file verification: formatting, script erasability, script/root-test type checks, coercion declarations, dependency guards, temp-path checks, Docker E2E boundaries, raw HTTP/2 boundary, and scoped oxlint all passed
- Trusted Testbox command proof: provider `blacksmith-testbox`; leases `tbx_01m1n2wpb8gy9d48j6669m1ejh` and `tbx_01m1n39ypnmmybn43t897fe9rf`; Actions runs `33828513722` and `33828974121`. Both wrapper timing summaries reported `exitCode: 0`; the exact focused command completed 69/69 tests. The linked Actions hosting runs concluded `cancelled` during external lease cleanup. Under the repository’s delegated Testbox contract, that hosting status is a cleanup artifact, not the command verdict. This does not claim terminal-success GitHub Actions proof.
- Sol/high P1 autoreview: scoped clean, no P0/P1 findings, 0.98 confidence

## Owner Decision

Restore the 45 KiB absolute startup CSS gate and ordinary `ui:build` enforcement. Keep the exact-base 1 KiB comparison as a secondary guard and retain explicit report-only diagnostics.

Release and artifact validity must not depend on PR-only CI. The fixed ceiling prevents cumulative sub-threshold growth, and #136972 is main-only and unshipped, so it carries no shipped compatibility obligation.

The PR remains draft while the active release hold blocks landing.

