### PR TITLE
chore(node-host): cover password-missing supervisor exit

### DIFF
--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -959,12 +959,28 @@ describe("runNodeHost", () => {
 
   it.each([
     ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
+    ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING,
     ConnectErrorDetailCodes.CLIENT_VERSION_MISMATCH,
     ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED,
   ])("closes MCP clients before exiting on terminal reconnect pause %s", async (detailCode) => {
-    await expect(runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 })).rejects.toThrow(
-      "event loop readiness timeout",
+    let resolveReadiness:
+      | ((value: { ready: false; aborted: false; elapsedMs: number }) => void)
+      | undefined;
+    mocks.startGatewayClientWhenEventLoopReady.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveReadiness = resolve;
+      }),
     );
+    let resolveMcpClose: (() => void) | undefined;
+    mocks.closeMcpManager.mockImplementationOnce(
+      () =>
+        new Promise<undefined>((resolve) => {
+          resolveMcpClose = () => resolve(undefined);
+        }),
+    );
+    const running = runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 });
+    const stopped = expect(running).rejects.toThrow("event loop readiness timeout");
+    await vi.waitFor(() => expect(startNodeHostMcpManager).toHaveBeenCalled());
     const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
     try {
       lastCapturedOptions()?.onReconnectPaused?.({
@@ -974,10 +990,18 @@ describe("runNodeHost", () => {
       });
       await vi.waitFor(() => {
         expect(mocks.closeMcpManager).toHaveBeenCalledOnce();
-        expect(exit).toHaveBeenCalledWith(1);
       });
       expect(mocks.capturedGatewayClients[0]?.stop).toHaveBeenCalled();
+      expect(exit).not.toHaveBeenCalled();
+
+      resolveMcpClose?.();
+      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1));
+
+      resolveReadiness?.({ ready: false, aborted: false, elapsedMs: 0 });
+      await stopped;
     } finally {
+      resolveMcpClose?.();
+      resolveReadiness?.({ ready: false, aborted: false, elapsedMs: 0 });
       exit.mockRestore();
     }
   });


### PR DESCRIPTION
Related: #134142

## What Problem This Solves

The CLI node host intentionally exits when the Gateway reports a terminal
token, password, bootstrap, or client-version reconnect pause so its supervisor
can restart it with refreshed credentials. The existing runner regression
coverage omitted the exact `AUTH_PASSWORD_MISSING` detail reported by the
Gateway upgrade incident.

## Why This Change Was Made

This adds the missing password-auth case to the existing terminal-pause table.
The test keeps Gateway readiness pending, blocks MCP shutdown, and proves the
process cannot exit until MCP cleanup completes. Runtime behavior is unchanged.

## User Impact

No user-visible behavior changes. The test protects the documented supervisor
restart policy and cleanup ordering for CLI nodes when a Gateway rejects a
reconnect because a password is missing.

## Evidence

- `PATH="$HOME/.nodenv/versions/24.15.0/bin:$PATH" node scripts/run-vitest.mjs src/node-host/runner.test.ts` (41 passed)
- `./node_modules/.bin/oxfmt --write --threads=1 src/node-host/runner.test.ts`
- `./node_modules/.bin/oxlint --deny-warnings src/node-host/runner.test.ts`
- `git diff --check`
- fresh Codex autoreview after the cleanup-order correction: clean, no accepted/actionable findings (0.99)

The prior ClawSweeper finding about pre-callback cleanup is addressed: the
runner remains live until `onReconnectPaused`, `process.exit` is asserted absent
while MCP close is pending, and exit status 1 is observed only after cleanup is
released.
