### PR TITLE
fix(qa): run Telegram RTT marker in direct messages

### DIFF
--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
@@ -126,15 +126,22 @@ describe("Telegram QA transport adapter", () => {
   });
 
   it("targets the SUT DM for direct-message-only scenarios", async () => {
-    mocks.userbotStart.mockResolvedValueOnce({
-      assertHealthy: mocks.userbotAssertHealthy,
-      chatId: 200,
-      close: mocks.userbotClose,
-      send: mocks.userbotSend,
+    let onUpdate: ((update: unknown) => Promise<void>) | undefined;
+    mocks.userbotStart.mockImplementationOnce(async (params) => {
+      onUpdate = params.onUpdate;
+      return {
+        assertHealthy: mocks.userbotAssertHealthy,
+        chatId: 200,
+        close: mocks.userbotClose,
+        send: mocks.userbotSend,
+      };
     });
+    mocks.userbotSend.mockResolvedValueOnce({ messageId: 10 });
+    const addInboundMessage = vi.fn().mockResolvedValue({ id: "in-1" });
+    const addOutboundMessage = vi.fn().mockResolvedValue({ id: "out-1" });
     const adapter = await createTelegramQaTransportAdapter({
       adapterOptions: { transportPolicy: { directMessageOnly: true } },
-      messages: {},
+      messages: { addInboundMessage, addOutboundMessage },
     } as never);
 
     expect(mocks.userbotStart).toHaveBeenCalledWith(
@@ -155,6 +162,24 @@ describe("Telegram QA transport adapter", () => {
       replyChannel: "telegram",
       replyTo: "100",
     });
+
+    await adapter.sendInbound?.({
+      conversation: { id: "logical-dm", kind: "direct" },
+      senderId: "driver",
+      text: "ping",
+    });
+    await onUpdate?.({
+      kind: "message",
+      chatId: 200,
+      messageId: 11,
+      senderId: 200,
+      timestamp: 100_000,
+      text: "pong",
+      entities: [],
+    });
+    expect(addOutboundMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "dm:logical-dm", text: "pong" }),
+    );
 
     await adapter.cleanup?.();
     await adapter.cleanupAfterGatewayStop?.();

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
@@ -138,7 +138,7 @@ export async function createTelegramQaTransportAdapter(
     }
     const outbound = await context.messages.addOutboundMessage({
       accountId,
-      to: `${logicalConversationKind}:${logicalConversationId}`,
+      to: `${logicalConversationKind === "direct" ? "dm" : logicalConversationKind}:${logicalConversationId}`,
       senderId: String(update.senderId),
       senderName: update.senderUsername,
       text: update.text,

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -70,6 +70,25 @@ function runTelegramStreamingFinalScenario(params: {
 describe("qa scenario catalog channel contracts", () => {
   const agentRuntime = "agent-runtime";
 
+  it("runs the Telegram RTT exact-marker scenario through an isolated direct message", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("telegram-reply-chain-exact-marker"));
+    expect(scenario.execution.transportPolicy).toEqual({ directMessageOnly: true });
+    expect(scenario.execution.flow?.steps[0]?.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sendInbound: expect.objectContaining({
+            conversation: { id: "telegram-reply-chain-dm", kind: "direct" },
+          }),
+        }),
+        expect.objectContaining({
+          waitForOutbound: expect.objectContaining({
+            conversation: { id: "telegram-reply-chain-dm", kind: "direct" },
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("routes native command session targeting through Crabline Telegram", () => {
     const scenario = readQaScenarioById("native-command-session-target");
     const config = readQaScenarioExecutionConfig("native-command-session-target") as

--- a/qa/scenarios/channels/telegram-reply-chain-exact-marker.yaml
+++ b/qa/scenarios/channels/telegram-reply-chain-exact-marker.yaml
@@ -17,6 +17,8 @@ scenario:
   execution:
     kind: flow
     channel: telegram
+    transportPolicy:
+      directMessageOnly: true
     summary: Request one exact Telegram marker and verify single-message delivery.
     config:
       requiredProviderMode: mock-openai
@@ -31,13 +33,13 @@ flow:
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - sendInbound:
-            conversation: { id: telegram-command-room, kind: channel }
+            conversation: { id: telegram-reply-chain-dm, kind: direct }
             senderId: qa-command-operator
             senderName: QA Command Operator
             text:
-              expr: "`@openclaw Telegram reply-chain marker QA. Reply exactly: ${config.marker}`"
+              expr: "`Telegram reply-chain marker QA. Reply exactly: ${config.marker}`"
         - waitForOutbound:
-            conversation: { id: telegram-command-room, kind: channel }
+            conversation: { id: telegram-reply-chain-dm, kind: direct }
             sinceIndex: { ref: startIndex }
             textIncludes: { ref: config.marker }
             timeoutMs: 90000


### PR DESCRIPTION
## Summary

- move the Telegram reply-chain RTT scenario from the shared QA group to an isolated direct message
- encode QA bus direct-message targets with the canonical `dm:` prefix
- cover the direct-message scenario plan and observed reply mapping

## Problem

The scheduled OpenClaw main RTT test sent its marker into the shared Telegram Test Server group. The leased SUT bot did not have write access there, so Telegram rejected the send with `Have no write access to the chat`.

The first direct-message proof then exposed a second bug: the Telegram adapter recorded direct replies as `direct:<id>`, while the QA bus accepts `dm:<id>`. The reply reached Telegram but the scenario wait could not match its logical conversation.

## Product path

Telegram Test Server user message -> OpenClaw Telegram gateway -> exact bot reply -> TDLib user observer.

## Fix

- declare this RTT scenario as direct-message-only
- send and wait in the same logical direct conversation
- map observed direct replies to the QA bus `dm:` target spelling

## Proof

- Red on current main `289f1406a4b128dfa2b45234002bc990586e9f39`: [RTT run 33716369097](https://github.com/openclaw/openclaw-rtt/actions/runs/33716369097)
- Green on exact head `b9442d40d625e611670400d54ef614b4a26cb613`: [RTT run 33720712119](https://github.com/openclaw/openclaw-rtt/actions/runs/33720712119) — the real Telegram producer passed, delivered `QA-TELEGRAM-REPLY-CHAIN-OK` exactly once, and completed 20/20 round-trip checks. The later RTT-repository import step failed only because the temporary proof branch needed a Git committer identity during rebase.
- Focused tests: 90 passed across Telegram adapter, Telegram API, scenario catalog, and suite planning.
