### PR TITLE
refactor: reuse shared guards in image tests

### DIFF
--- a/src/media-understanding/image.runtime-profile.test.ts
+++ b/src/media-understanding/image.runtime-profile.test.ts
@@ -1,6 +1,7 @@
 // Image runtime tests cover model-backed image routing, auth/profile handling,
 // provider payload transforms, and MiniMax/Copilot special paths.
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -79,27 +80,6 @@ type AuthRequestCall = {
   preferredProfile?: string;
   store?: unknown;
 };
-
-function requireMockCallAt<const Calls extends readonly unknown[][]>(
-  mock: { mock: { calls: Calls } },
-  index: number,
-  label: string,
-): Calls[number] {
-  // Tests inspect exact dependency calls because image runtime behavior is
-  // mostly provider/auth orchestration.
-  const call = mock.mock.calls[index];
-  if (!call) {
-    throw new Error(`Expected ${label} call ${index}`);
-  }
-  return call as Calls[number];
-}
-
-function requireFirstMockCall<const Calls extends readonly unknown[][]>(
-  mock: { mock: { calls: Calls } },
-  label: string,
-): Calls[number] {
-  return requireMockCallAt(mock, 0, label);
-}
 
 vi.mock("../llm/stream.js", async () => {
   const actual = await vi.importActual<typeof import("../llm/stream.js")>("../llm/stream.js");
@@ -435,7 +415,7 @@ describe("describeImageWithModelCore", () => {
         authProfileId: "github-copilot:backup",
       }),
     );
-    const [completionModel] = requireFirstMockCall(completeMock, "complete");
+    const [completionModel] = expectDefined(completeMock.mock.calls[0], "complete call 0");
     expect(completionModel).toEqual(
       expect.objectContaining({
         contextWindow: 1_050_000,
@@ -687,7 +667,7 @@ describe("describeImageWithModelCore", () => {
       timeoutMs: 1000,
     });
 
-    const options = requireFirstMockCall(completeMock, "image completion")[2];
+    const options = expectDefined(completeMock.mock.calls[0], "image completion call 0")[2];
     expect(options.maxTokens).toBe(4096);
   });
 
@@ -724,7 +704,7 @@ describe("describeImageWithModelCore", () => {
       timeoutMs: 1000,
     });
 
-    const options = requireFirstMockCall(completeMock, "image completion")[2];
+    const options = expectDefined(completeMock.mock.calls[0], "image completion call 0")[2];
     expect(options.maxTokens).toBe(1024);
   });
 

--- a/src/media-understanding/image.runtime-timeout.test.ts
+++ b/src/media-understanding/image.runtime-timeout.test.ts
@@ -1,6 +1,7 @@
 // Image runtime tests cover model-backed image routing, auth/profile handling,
 // provider payload transforms, and MiniMax/Copilot special paths.
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -68,27 +69,6 @@ type ResolveModelWithRegistryTestParams = {
   provider: string;
   modelId: string;
 };
-
-function requireMockCallAt<const Calls extends readonly unknown[][]>(
-  mock: { mock: { calls: Calls } },
-  index: number,
-  label: string,
-): Calls[number] {
-  // Tests inspect exact dependency calls because image runtime behavior is
-  // mostly provider/auth orchestration.
-  const call = mock.mock.calls[index];
-  if (!call) {
-    throw new Error(`Expected ${label} call ${index}`);
-  }
-  return call as Calls[number];
-}
-
-function requireFirstMockCall<const Calls extends readonly unknown[][]>(
-  mock: { mock: { calls: Calls } },
-  label: string,
-): Calls[number] {
-  return requireMockCallAt(mock, 0, label);
-}
 
 vi.mock("../llm/stream.js", async () => {
   const actual = await vi.importActual<typeof import("../llm/stream.js")>("../llm/stream.js");
@@ -322,7 +302,7 @@ describe("describeImageWithModelCore", () => {
       model: "gpt-5.4",
     });
     expect(completeMock).toHaveBeenCalledOnce();
-    const firstCall = requireFirstMockCall(completeMock, "image completion");
+    const firstCall = expectDefined(completeMock.mock.calls[0], "image completion call 0");
     const [completionModel, context, options] = firstCall;
     expect(completionModel).toEqual({
       provider: "openai",
@@ -388,7 +368,7 @@ describe("describeImageWithModelCore", () => {
       model: "gpt-5.4",
     });
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
-    const firstCall = requireFirstMockCall(completeMock, "image completion");
+    const firstCall = expectDefined(completeMock.mock.calls[0], "image completion call 0");
     expect(firstCall[2].timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
   });
 
@@ -428,7 +408,10 @@ describe("describeImageWithModelCore", () => {
       text: "openrouter ok",
       model: "google/gemini-2.5-flash",
     });
-    const firstCall = requireFirstMockCall(completeMock, "OpenRouter image completion");
+    const firstCall = expectDefined(
+      completeMock.mock.calls[0],
+      "OpenRouter image completion call 0",
+    );
     const [, context] = firstCall;
     expect(context.systemPrompt).toBeUndefined();
     const userMessage = context.messages[0];
@@ -481,7 +464,10 @@ describe("describeImageWithModelCore", () => {
       text: "dashscope ok",
       model: "qwen3.6-plus",
     });
-    const firstCall = requireFirstMockCall(completeMock, "DashScope image completion");
+    const firstCall = expectDefined(
+      completeMock.mock.calls[0],
+      "DashScope image completion call 0",
+    );
     const [, context] = firstCall;
     expect(context.systemPrompt).toBeUndefined();
     const userMessage = context.messages[0];
@@ -601,7 +587,7 @@ describe("describeImageWithModelCore", () => {
         model: model.id,
       });
       expect(completeMock).toHaveBeenCalledTimes(2);
-      const retryCall = requireMockCallAt(completeMock, 1, "retry image completion");
+      const retryCall = expectDefined(completeMock.mock.calls[1], "retry image completion call 1");
       const [retryModel, , retryOptions] = retryCall;
       if (!retryOptions?.onPayload) {
         throw new Error("expected retry payload mapper");
@@ -658,7 +644,10 @@ describe("describeImageWithModelCore", () => {
     ).rejects.toThrow("caller cancelled image description");
 
     expect(completeMock).toHaveBeenCalledOnce();
-    const options = requireFirstMockCall(completeMock, "cancelled image completion")[2];
+    const options = expectDefined(
+      completeMock.mock.calls[0],
+      "cancelled image completion call 0",
+    )[2];
     expect(options?.signal?.aborted).toBe(true);
   });
 
@@ -692,7 +681,7 @@ describe("describeImageWithModelCore", () => {
     );
     await vi.advanceTimersByTimeAsync(25);
     await assertion;
-    const firstCall = requireFirstMockCall(completeMock, "timed image completion");
+    const firstCall = expectDefined(completeMock.mock.calls[0], "timed image completion call 0");
     const options = firstCall[2];
     if (!options?.signal) {
       throw new Error("Expected image completion abort signal");
@@ -782,7 +771,10 @@ describe("describeImageWithModelCore", () => {
     await vi.advanceTimersByTimeAsync(slowSetupMs);
     await Promise.resolve();
     expect(completeMock).toHaveBeenCalledTimes(1);
-    const firstCall = requireFirstMockCall(completeMock, "slow setup image completion");
+    const firstCall = expectDefined(
+      completeMock.mock.calls[0],
+      "slow setup image completion call 0",
+    );
     const options = firstCall[2];
     if (!options?.signal) {
       throw new Error("Expected image completion abort signal");

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 // Image runtime tests cover model-backed image routing, auth/profile handling,
 // provider payload transforms, and MiniMax/Copilot special paths.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
@@ -76,27 +77,6 @@ type AuthRequestCall = {
   preferredProfile?: string;
   store?: unknown;
 };
-
-function requireMockCallAt<const Calls extends readonly unknown[][]>(
-  mock: { mock: { calls: Calls } },
-  index: number,
-  label: string,
-): Calls[number] {
-  // Tests inspect exact dependency calls because image runtime behavior is
-  // mostly provider/auth orchestration.
-  const call = mock.mock.calls[index];
-  if (!call) {
-    throw new Error(`Expected ${label} call ${index}`);
-  }
-  return call as Calls[number];
-}
-
-function requireFirstMockCall<const Calls extends readonly unknown[][]>(
-  mock: { mock: { calls: Calls } },
-  label: string,
-): Calls[number] {
-  return requireMockCallAt(mock, 0, label);
-}
 
 const requireRecord = createRequireRecord("record", "expected-label-capitalized");
 
@@ -300,7 +280,7 @@ describe("describeImageWithModelCore", () => {
     expect(authRequest?.store).toBe(authStore);
     expect(requireApiKeyMock).toHaveBeenCalled();
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("minimax-portal", "test-api-key");
-    const [fetchUrl, fetchOptionsValue] = requireFirstMockCall(fetchMock, "fetch");
+    const [fetchUrl, fetchOptionsValue] = expectDefined(fetchMock.mock.calls[0], "fetch call 0");
     const fetchOptions = requireRecord(fetchOptionsValue, "fetch options");
     expect(fetchUrl).toBe("https://api.minimax.io/v1/coding_plan/vlm");
     expect(fetchOptions).toEqual({
@@ -380,7 +360,7 @@ describe("describeImageWithModelCore", () => {
     });
 
     const guardedOptions = requireRecord(
-      requireFirstMockCall(imageTestFetchWithSsrFGuardMock, "guarded fetch")[0],
+      expectDefined(imageTestFetchWithSsrFGuardMock.mock.calls[0], "guarded fetch call 0")[0],
       "guarded fetch options",
     );
     expect(guardedOptions.dispatcherPolicy).toEqual({
@@ -413,7 +393,7 @@ describe("describeImageWithModelCore", () => {
       sentinelValue,
       "MiniMax VLM request",
     );
-    const [, fetchOptionsValue] = requireFirstMockCall(fetchMock, "fetch");
+    const [, fetchOptionsValue] = expectDefined(fetchMock.mock.calls[0], "fetch call 0");
     const fetchOptions = requireRecord(fetchOptionsValue, "fetch options");
     expect(new Headers(fetchOptions.headers as HeadersInit).get("Authorization")).toBe(
       ["Bearer", "test-token"].join(" "),
@@ -455,9 +435,9 @@ describe("describeImageWithModelCore", () => {
       text: "generic ok",
       model: "custom-vision",
     });
-    const [streamRequest] = requireFirstMockCall(
-      registerProviderStreamForModelMock,
-      "provider stream registration",
+    const [streamRequest] = expectDefined(
+      registerProviderStreamForModelMock.mock.calls[0],
+      "provider stream registration call 0",
     );
     expect(streamRequest).toEqual({
       model: {
@@ -529,7 +509,7 @@ describe("describeImageWithModelCore", () => {
     // empty-string secret; the empty key flows through to the model runtime.
     expect(requireApiKeyMock).not.toHaveBeenCalled();
     expect(setRuntimeApiKeyMock).not.toHaveBeenCalled();
-    const completeCall = requireFirstMockCall(completeMock, "complete");
+    const completeCall = expectDefined(completeMock.mock.calls[0], "complete call 0");
     expect(requireRecord(completeCall[2], "stream options").apiKey).toBe("");
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -614,7 +594,7 @@ describe("describeImageWithModelCore", () => {
         provider: "minimax",
       }),
     );
-    const [fetchUrl] = requireFirstMockCall(fetchMock, "fetch");
+    const [fetchUrl] = expectDefined(fetchMock.mock.calls[0], "fetch call 0");
     expect(fetchUrl).toBe("https://api.minimaxi.com/v1/coding_plan/vlm");
   });
 
@@ -664,7 +644,7 @@ describe("describeImageWithModelCore", () => {
         provider: "minimax-cn",
       }),
     );
-    const [fetchUrl] = requireFirstMockCall(fetchMock, "fetch");
+    const [fetchUrl] = expectDefined(fetchMock.mock.calls[0], "fetch call 0");
     expect(fetchUrl).toBe("https://api.minimaxi.com/v1/coding_plan/vlm");
   });
 
@@ -701,7 +681,7 @@ describe("describeImageWithModelCore", () => {
       model: "MiniMax-VL-01",
     });
 
-    const [fetchUrl] = requireFirstMockCall(fetchMock, "fetch");
+    const [fetchUrl] = expectDefined(fetchMock.mock.calls[0], "fetch call 0");
     expect(fetchUrl).toBe("https://api.minimaxi.com/v1/coding_plan/vlm");
   });
 
@@ -834,7 +814,7 @@ describe("describeImageWithModelCore", () => {
         skipAgentDiscovery: true,
       },
     );
-    const [completeModel] = requireFirstMockCall(completeMock, "complete");
+    const [completeModel] = expectDefined(completeMock.mock.calls[0], "complete call 0");
     expect(requireRecord(completeModel, "complete model").api).toBe("openai-responses");
   });
 
@@ -950,9 +930,9 @@ describe("describeImageWithModelCore", () => {
       model: "google/gemma-4-e2b",
     });
     expect(registryFind).not.toHaveBeenCalled();
-    const [resolveRequestValue] = requireFirstMockCall(
-      resolveModelWithRegistryMock,
-      "model registry resolution",
+    const [resolveRequestValue] = expectDefined(
+      resolveModelWithRegistryMock.mock.calls[0],
+      "model registry resolution call 0",
     );
     const resolveRequest = requireRecord(resolveRequestValue, "model registry request");
     expect(resolveRequest.provider).toBe("lmstudio");


### PR DESCRIPTION
## What Problem This Solves

Three image test suites duplicate mock-call guards already provided by the shared normalization package, adding test scaffolding without additional coverage.

## Why This Change Was Made

Use `expectDefined` at all 21 call sites and remove the six local helpers. Call indices, descriptive labels, inferred argument types, all 165 assertions, and all existing cases remain intact. Production LOC: **0**. Test/test-support LOC: **+40/-88 (net -48)**.

## User Impact

No user-visible behavior change. Existing provider, authentication, prompt-placement, profile, cancellation, timeout, retry, and generation-release checks remain unchanged.

## Evidence

- Baseline and candidate each passed **46/46 tests on the first attempt** through the normal test wrapper: the three changed image suites plus the canonical `expect` helper suite. The expanded case inventory and order within every file match; ordinary parallel file-completion order differed. These are mocked owner tests, not live provider proof.
- The complete three-path `check-changed` gate passed locally with Node 26.8.1 and pnpm 12.1.0, including the core/test type graphs, all guards, dead-export scans, formatting, and lint. Only the inherited `OPENCLAW_TESTBOX` flag was unset for the documented trusted-local route.
- Fresh Codex review through P2 found no actionable issues. Post-hook verification preserves the exact reviewed patch and all three file hashes.

Tooling follow-up, shared with #136994: the initial configured Testbox attempt failed during Git bootstrap with a GitHub username credential challenge, before any changed checks ran. Its temporary failure capture was discarded with the sync checkout. The lease stopped and local sync worktree/process cleanup was verified; no remote test result or runtime equivalence is claimed.
