### PR TITLE
fix(macos): prevent local node auth reuse across gateways

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -600,6 +600,9 @@ final class MacNodeModeCoordinator: NSObject {
                 completedRouteAuthorityGeneration: self.completedRouteAuthorityGeneration,
                 isPaused: false)
         else { return nil }
+        // Node credentials belong to the selected endpoint, matching the operator route.
+        // A missing owner must not unlock legacy role-global token storage.
+        let deviceAuth = Self.nodeDeviceAuthBinding(for: endpoint)
         let options = GatewayConnectOptions(
             role: "node",
             scopes: [],
@@ -614,7 +617,9 @@ final class MacNodeModeCoordinator: NSObject {
             clientId: "openclaw-macos",
             clientMode: "node",
             clientDisplayName: InstanceIdentity.displayName,
-            deviceIdentityProfile: Self.nodeIdentityProfile)
+            deviceIdentityProfile: Self.nodeIdentityProfile,
+            allowStoredDeviceAuth: deviceAuth.allowStoredDeviceAuth,
+            deviceAuthGatewayID: deviceAuth.gatewayID)
         let sessionBox = self.buildSessionBox(url: config.url, tls: endpoint.tls)
 
         // Resolve compatibility fallback before node admission. Operator recovery
@@ -1102,6 +1107,12 @@ extension MacNodeModeCoordinator {
 }
 
 extension MacNodeModeCoordinator {
+    nonisolated static func nodeDeviceAuthBinding(
+        for endpoint: GatewayConnection.EndpointSnapshot) -> (allowStoredDeviceAuth: Bool, gatewayID: String?)
+    {
+        (endpoint.deviceAuthGatewayID != nil, endpoint.deviceAuthGatewayID)
+    }
+
     static func endpointTransitionRequiresDisconnect(
         from previous: GatewayEndpointState,
         to next: GatewayEndpointState) -> Bool

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -550,7 +550,7 @@ final class MacNodeModeCoordinator: NSObject {
                     continue
                 }
                 self.logger.error("mac node gateway connect failed: \(error.localizedDescription, privacy: .public)")
-                let failure = Self.nodeHostWorkerFailure(error)
+                let failure = Self.nodeGatewayConnectionFailure(error)
                 self.channelStatus.record(.unavailable(reason: failure.reason, diagnostic: failure.diagnostic))
                 try? await Task.sleep(nanoseconds: min(retryDelay, 10_000_000_000))
                 retryDelay = min(retryDelay * 2, 10_000_000_000)
@@ -1033,6 +1033,14 @@ extension MacNodeModeCoordinator {
             return (reason, diagnostic)
         }
         return (error.localizedDescription, nil)
+    }
+
+    static func nodeGatewayConnectionFailure(_ error: Error) -> (reason: String, diagnostic: String?) {
+        guard let problem = GatewayConnectionProblemMapper.map(error: error),
+              problem.needsPairingApproval
+        else { return self.nodeHostWorkerFailure(error) }
+        let reason = problem.actionLabel.map { "\(problem.statusText) — \($0)" } ?? problem.statusText
+        return (reason, problem.message)
     }
 
     private func handleNodeHostWorkerFailure(configurationGeneration: UInt64) {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -184,6 +184,26 @@ private struct CoordinatorWaitTimeout: Error, CustomStringConvertible {
     }
 }
 
+struct MacNodeModeCoordinatorDeviceAuthTests {
+    @Test
+    @MainActor
+    func `unproven legacy token failure exposes gateway re-pair action`() throws {
+        let failure = MacNodeModeCoordinator.nodeGatewayConnectionFailure(
+            GatewayConnectAuthError(
+                message: "pairing required",
+                detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue,
+                canRetryWithDeviceToken: false))
+
+        #expect(failure.reason == "This device is not approved yet — Approve on gateway")
+        let status = try #require(MacNodeChannelState.unavailable(
+            reason: failure.reason,
+            diagnostic: failure.diagnostic).operatorStatusLine)
+        #expect(status.label == "Mac node unavailable — This device is not approved yet — Approve on gateway")
+        #expect(status.diagnostic == "The gateway received the connection request, "
+            + "but this device must be approved first.")
+    }
+}
+
 struct MacNodeModeCoordinatorTests {
     private func nodeDeviceAuthBinding(
         deviceAuthGatewayID: String?) throws -> (allowStoredDeviceAuth: Bool, gatewayID: String?)

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -185,6 +185,19 @@ private struct CoordinatorWaitTimeout: Error, CustomStringConvertible {
 }
 
 struct MacNodeModeCoordinatorTests {
+    private func nodeDeviceAuthBinding(
+        deviceAuthGatewayID: String?) throws -> (allowStoredDeviceAuth: Bool, gatewayID: String?)
+    {
+        let endpoint = try GatewayConnection.EndpointSnapshot(
+            config: (
+                url: #require(URL(string: "wss://gateway.example.invalid")),
+                token: nil,
+                password: nil),
+            routeAuthority: nil,
+            deviceAuthGatewayID: deviceAuthGatewayID)
+        return MacNodeModeCoordinator.nodeDeviceAuthBinding(for: endpoint)
+    }
+
     private func waitUntil(
         _ description: String,
         timeout: Duration = .seconds(2),
@@ -496,6 +509,27 @@ struct MacNodeModeCoordinatorTests {
             routeRevision: 2)
 
         #expect(!MacNodeModeCoordinator.endpointState(replacement, matches: first))
+    }
+
+    @Test func `node device auth binding uses the endpoint owner`() throws {
+        let binding = try self.nodeDeviceAuthBinding(deviceAuthGatewayID: "gateway-a")
+
+        #expect(binding.allowStoredDeviceAuth)
+        #expect(binding.gatewayID == "gateway-a")
+    }
+
+    @Test func `node device auth binding rejects unscoped storage`() throws {
+        let binding = try self.nodeDeviceAuthBinding(deviceAuthGatewayID: nil)
+
+        #expect(!binding.allowStoredDeviceAuth)
+        #expect(binding.gatewayID == nil)
+    }
+
+    @Test func `node device auth binding keeps gateway owners distinct`() throws {
+        let first = try self.nodeDeviceAuthBinding(deviceAuthGatewayID: "gateway-a")
+        let second = try self.nodeDeviceAuthBinding(deviceAuthGatewayID: "gateway-b")
+
+        #expect(first.gatewayID != second.gatewayID)
     }
 
     @Test func `stop pause and endpoint changes revoke final connect admission`() throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -560,9 +560,7 @@ public actor GatewayChannelActor {
                 response,
                 identity: identity,
                 selectedAuth: selectedAuth,
-                role: role,
-                deviceAuthGatewayID: deviceAuthGatewayID,
-                deviceIdentityProfile: deviceIdentityProfile,
+                options: options,
                 connectionGeneration: connectionGeneration)
             self.receivedDeviceAuthRoles.formUnion(outcome.receivedRoles)
             self.persistedDeviceAuthRoles.formUnion(outcome.persistedRoles)
@@ -902,12 +900,14 @@ extension GatewayChannelActor {
         _ res: ResponseFrame,
         identity: DeviceIdentity?,
         selectedAuth: SelectedConnectAuth,
-        role: String,
-        deviceAuthGatewayID: String?,
-        deviceIdentityProfile: GatewayDeviceIdentityProfile,
+        options: GatewayConnectOptions,
         connectionGeneration: UInt64) async throws
         -> (receivedRoles: Set<String>, persistedRoles: Set<String>, hello: HelloOk)
     {
+        let role = options.role
+        let allowStoredDeviceAuth = options.allowStoredDeviceAuth
+        let deviceAuthGatewayID = options.deviceAuthGatewayID
+        let deviceIdentityProfile = options.deviceIdentityProfile
         if res.ok == false {
             let error = res.error
             let msg = error?.message ?? "gateway connect failed"
@@ -970,7 +970,7 @@ extension GatewayChannelActor {
             let sameStoredToken = authRole == role && deviceToken == selectedAuth.storedToken
             // Hello scopes describe this socket. Reissuing the stored token must not narrow its reusable grant.
             let scopes = sameStoredToken ? (selectedAuth.storedScopes ?? helloScopes) : helloScopes
-            if let identity, self.persistIssuedDeviceToken(
+            if let identity, allowStoredDeviceAuth, self.persistIssuedDeviceToken(
                 authSource: self.lastAuthSource,
                 deviceId: identity.deviceId,
                 role: authRole,
@@ -992,13 +992,14 @@ extension GatewayChannelActor {
                 }
                 let scopes = rawEntry["scopes"]?.arrayValue?.compactMap(\.stringValue) ?? []
                 receivedRoles.insert(authRole)
-                if let identity, self.shouldPersistBootstrapHandoffTokens(), self.persistBootstrapHandoffToken(
-                    deviceId: identity.deviceId,
-                    role: authRole,
-                    token: deviceToken,
-                    scopes: scopes,
-                    deviceAuthGatewayID: deviceAuthGatewayID,
-                    deviceIdentityProfile: deviceIdentityProfile)
+                if let identity, allowStoredDeviceAuth, self.shouldPersistBootstrapHandoffTokens(),
+                   self.persistBootstrapHandoffToken(
+                       deviceId: identity.deviceId,
+                       role: authRole,
+                       token: deviceToken,
+                       scopes: scopes,
+                       deviceAuthGatewayID: deviceAuthGatewayID,
+                       deviceIdentityProfile: deviceIdentityProfile)
                 {
                     persistedRoles.insert(authRole)
                 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -905,7 +905,6 @@ extension GatewayChannelActor {
         -> (receivedRoles: Set<String>, persistedRoles: Set<String>, hello: HelloOk)
     {
         let role = options.role
-        let allowStoredDeviceAuth = options.allowStoredDeviceAuth
         let deviceAuthGatewayID = options.deviceAuthGatewayID
         let deviceIdentityProfile = options.deviceIdentityProfile
         if res.ok == false {
@@ -970,7 +969,9 @@ extension GatewayChannelActor {
             let sameStoredToken = authRole == role && deviceToken == selectedAuth.storedToken
             // Hello scopes describe this socket. Reissuing the stored token must not narrow its reusable grant.
             let scopes = sameStoredToken ? (selectedAuth.storedScopes ?? helloScopes) : helloScopes
-            if let identity, allowStoredDeviceAuth, self.persistIssuedDeviceToken(
+            // Fresh pairing can suppress stored-token lookup. Stable Gateway ownership,
+            // not lookup permission, authorizes persisting newly issued credentials.
+            if let identity, let deviceAuthGatewayID, self.persistIssuedDeviceToken(
                 authSource: self.lastAuthSource,
                 deviceId: identity.deviceId,
                 role: authRole,
@@ -992,7 +993,7 @@ extension GatewayChannelActor {
                 }
                 let scopes = rawEntry["scopes"]?.arrayValue?.compactMap(\.stringValue) ?? []
                 receivedRoles.insert(authRole)
-                if let identity, allowStoredDeviceAuth, self.shouldPersistBootstrapHandoffTokens(),
+                if let identity, let deviceAuthGatewayID, self.shouldPersistBootstrapHandoffTokens(),
                    self.persistBootstrapHandoffToken(
                        deviceId: identity.deviceId,
                        role: authRole,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -969,9 +969,7 @@ extension GatewayChannelActor {
             let sameStoredToken = authRole == role && deviceToken == selectedAuth.storedToken
             // Hello scopes describe this socket. Reissuing the stored token must not narrow its reusable grant.
             let scopes = sameStoredToken ? (selectedAuth.storedScopes ?? helloScopes) : helloScopes
-            // Fresh pairing can suppress stored-token lookup. Stable Gateway ownership,
-            // not lookup permission, authorizes persisting newly issued credentials.
-            if let identity, let deviceAuthGatewayID, self.persistIssuedDeviceToken(
+            if let identity, options.allowsDeviceAuthPersistence, self.persistIssuedDeviceToken(
                 authSource: self.lastAuthSource,
                 deviceId: identity.deviceId,
                 role: authRole,
@@ -993,7 +991,7 @@ extension GatewayChannelActor {
                 }
                 let scopes = rawEntry["scopes"]?.arrayValue?.compactMap(\.stringValue) ?? []
                 receivedRoles.insert(authRole)
-                if let identity, let deviceAuthGatewayID, self.shouldPersistBootstrapHandoffTokens(),
+                if let identity, options.allowsDeviceAuthPersistence, self.shouldPersistBootstrapHandoffTokens(),
                    self.persistBootstrapHandoffToken(
                        deviceId: identity.deviceId,
                        role: authRole,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectOptions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectOptions.swift
@@ -26,8 +26,8 @@ public struct GatewayConnectOptions: Sendable {
     /// Set false for an endpoint handoff whose explicit credentials (including none) must be
     /// tried without loading a previously stored device token.
     public var allowStoredDeviceAuth: Bool
-    /// Stable Gateway owner for device tokens. Newly issued tokens are persisted only when set.
-    /// Nil can still read legacy unscoped storage when `allowStoredDeviceAuth` is true.
+    /// Stable Gateway owner for device tokens. Nil preserves legacy unscoped storage only when
+    /// `allowStoredDeviceAuth` is true; false plus nil disables both lookup and persistence.
     public var deviceAuthGatewayID: String?
 
     public init(
@@ -97,6 +97,12 @@ public struct GatewayAuthBinding: Equatable, Sendable {
 }
 
 extension GatewayConnectOptions {
+    var allowsDeviceAuthPersistence: Bool {
+        // Legacy callers must rotate credentials in the same unscoped namespace they read.
+        // Fresh pairing instead supplies an owner; explicit ownerless handoffs set false/nil.
+        self.allowStoredDeviceAuth || self.deviceAuthGatewayID != nil
+    }
+
     /// Additive connect-frame fields, sent only when this node declares them.
     /// Lives here so `GatewayChannel.sendConnect` stays within its body budget.
     func applyOptionalConnectParams(to params: inout [String: OpenClawProtocol.AnyCodable]) {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectOptions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectOptions.swift
@@ -24,10 +24,10 @@ public struct GatewayConnectOptions: Sendable {
     /// role/scoped sessions such as operator UI clients.
     public var includeDeviceIdentity: Bool
     /// Set false for an endpoint handoff whose explicit credentials (including none) must be
-    /// tried without loading or persisting a device token for an unverified gateway owner.
+    /// tried without loading a previously stored device token.
     public var allowStoredDeviceAuth: Bool
-    /// Stable gateway owner for device tokens. Nil preserves legacy unscoped storage for clients
-    /// that have not adopted endpoint ownership yet.
+    /// Stable Gateway owner for device tokens. Newly issued tokens are persisted only when set.
+    /// Nil can still read legacy unscoped storage when `allowStoredDeviceAuth` is true.
     public var deviceAuthGatewayID: String?
 
     public init(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectOptions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectOptions.swift
@@ -24,7 +24,7 @@ public struct GatewayConnectOptions: Sendable {
     /// role/scoped sessions such as operator UI clients.
     public var includeDeviceIdentity: Bool
     /// Set false for an endpoint handoff whose explicit credentials (including none) must be
-    /// tried without reusing a device token issued by a different gateway.
+    /// tried without loading or persisting a device token for an unverified gateway owner.
     public var allowStoredDeviceAuth: Bool
     /// Stable gateway owner for device tokens. Nil preserves legacy unscoped storage for clients
     /// that have not adopted endpoint ownership yet.

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNativeTransportDeviceAuthTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNativeTransportDeviceAuthTests.swift
@@ -1,0 +1,123 @@
+#if os(macOS)
+import Foundation
+import OpenClawProtocol
+import Testing
+@testable import OpenClawKit
+
+private func nativeNodeConnectOptions(
+    allowStoredDeviceAuth: Bool,
+    deviceAuthGatewayID: String? = nil) -> GatewayConnectOptions
+{
+    GatewayConnectOptions(
+        role: "node",
+        scopes: [],
+        caps: [],
+        commands: [],
+        permissions: [:],
+        clientId: "openclaw-native-transport-test",
+        clientMode: "node",
+        clientDisplayName: "Native Transport Test",
+        includeDeviceIdentity: true,
+        allowStoredDeviceAuth: allowStoredDeviceAuth,
+        deviceAuthGatewayID: deviceAuthGatewayID)
+}
+
+extension GatewayNodeSession {
+    fileprivate func connectThroughURLSessionForTest(
+        _ url: URL,
+        options: GatewayConnectOptions) async throws
+    {
+        try await self.connect(
+            url: url,
+            credentials: .init(),
+            connectOptions: options,
+            sessionBox: nil,
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { BridgeInvokeResponse(id: $0.id, ok: true) })
+    }
+}
+
+@Suite(.serialized)
+struct GatewayNativeTransportDeviceAuthTests {
+    @Test(.stateDirectoryIsolated)
+    @MainActor
+    func `owner-bound issuance persists scoped token and sends it on reconnect`() async throws {
+        let gatewayID = "native-owner"
+        let issuedToken = "native-owner-issued-token"
+        let fixture = try await NativeGatewayWebSocketFixture.start(
+            issuedDeviceTokens: [issuedToken, nil])
+        defer { fixture.stop() }
+
+        let identity = DeviceIdentityStore.loadOrCreate()
+        let gateway = GatewayNodeSession()
+        let options = nativeNodeConnectOptions(
+            allowStoredDeviceAuth: false,
+            deviceAuthGatewayID: gatewayID)
+
+        try await gateway.connectThroughURLSessionForTest(fixture.url(), options: options)
+
+        #expect(fixture.capturedAuth(at: 0) == .init(
+            token: nil,
+            bootstrapToken: nil,
+            deviceToken: nil))
+        let stored = try #require(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node",
+            gatewayID: gatewayID))
+        #expect(stored.token == issuedToken)
+        #expect(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node") == nil)
+
+        fixture.closeConnection(at: 0)
+        try await waitUntil("native owner-bound reconnect") {
+            await fixture.capturedAuth(at: 1) != nil
+        }
+        #expect(fixture.capturedAuth(at: 1) == .init(
+            token: issuedToken,
+            bootstrapToken: nil,
+            deviceToken: nil))
+
+        await gateway.disconnect()
+    }
+
+    @Test(.stateDirectoryIsolated)
+    @MainActor
+    func `ownerless issuance is not persisted and reconnect sends no credential`() async throws {
+        let previousToken = "previous-ownerless-token"
+        let fixture = try await NativeGatewayWebSocketFixture.start(
+            issuedDeviceTokens: ["ownerless-issued-token", nil])
+        defer { fixture.stop() }
+
+        let identity = DeviceIdentityStore.loadOrCreate()
+        _ = DeviceAuthStore.storeToken(
+            deviceId: identity.deviceId,
+            role: "node",
+            token: previousToken)
+        let gateway = GatewayNodeSession()
+        let options = nativeNodeConnectOptions(allowStoredDeviceAuth: false)
+
+        try await gateway.connectThroughURLSessionForTest(fixture.url(), options: options)
+
+        #expect(fixture.capturedAuth(at: 0) == .init(
+            token: nil,
+            bootstrapToken: nil,
+            deviceToken: nil))
+        let roles = await gateway.currentDeviceAuthRoles()
+        #expect(roles.received == ["node"])
+        #expect(roles.persisted.isEmpty)
+        #expect(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node")?
+            .token == previousToken)
+
+        fixture.closeConnection(at: 0)
+        try await waitUntil("native ownerless reconnect") {
+            await fixture.capturedAuth(at: 1) != nil
+        }
+        #expect(fixture.capturedAuth(at: 1) == .init(
+            token: nil,
+            bootstrapToken: nil,
+            deviceToken: nil))
+
+        await gateway.disconnect()
+    }
+}
+#endif

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNativeTransportDeviceAuthTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNativeTransportDeviceAuthTests.swift
@@ -25,11 +25,12 @@ private func nativeNodeConnectOptions(
 extension GatewayNodeSession {
     fileprivate func connectThroughURLSessionForTest(
         _ url: URL,
+        credentials: GatewayNodeSessionCredentials = .init(),
         options: GatewayConnectOptions) async throws
     {
         try await self.connect(
             url: url,
-            credentials: .init(),
+            credentials: credentials,
             connectOptions: options,
             sessionBox: nil,
             onConnected: {},
@@ -40,6 +41,45 @@ extension GatewayNodeSession {
 
 @Suite(.serialized)
 struct GatewayNativeTransportDeviceAuthTests {
+    @Test(.stateDirectoryIsolated)
+    @MainActor
+    func `legacy unscoped token rotation persists and reconnects with replacement`() async throws {
+        let previousToken = "native-legacy-previous-token"
+        let rotatedToken = "native-legacy-rotated-token"
+        let fixture = try await NativeGatewayWebSocketFixture.start(
+            issuedDeviceTokens: [rotatedToken, nil])
+        defer { fixture.stop() }
+
+        let identity = DeviceIdentityStore.loadOrCreate()
+        _ = DeviceAuthStore.storeToken(
+            deviceId: identity.deviceId,
+            role: "node",
+            token: previousToken)
+        let gateway = GatewayNodeSession()
+        let options = nativeNodeConnectOptions(allowStoredDeviceAuth: true)
+
+        try await gateway.connectThroughURLSessionForTest(fixture.url(), options: options)
+
+        #expect(fixture.capturedAuth(at: 0) == .init(
+            token: previousToken,
+            bootstrapToken: nil,
+            deviceToken: nil))
+        #expect(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node")?.token == rotatedToken)
+
+        fixture.closeConnection(at: 0)
+        try await waitUntil("native legacy token rotation reconnect") {
+            await fixture.capturedAuth(at: 1) != nil
+        }
+        #expect(fixture.capturedAuth(at: 1) == .init(
+            token: rotatedToken,
+            bootstrapToken: nil,
+            deviceToken: nil))
+
+        await gateway.disconnect()
+    }
+
     @Test(.stateDirectoryIsolated)
     @MainActor
     func `owner-bound issuance persists scoped token and sends it on reconnect`() async throws {
@@ -76,6 +116,114 @@ struct GatewayNativeTransportDeviceAuthTests {
             token: issuedToken,
             bootstrapToken: nil,
             deviceToken: nil))
+
+        await gateway.disconnect()
+    }
+
+    @Test(.stateDirectoryIsolated)
+    @MainActor
+    func `gateway A reconnect never claims gateway B legacy token`() async throws {
+        let gatewayAID = "native-gateway-a"
+        let gatewayBLegacyToken = "native-gateway-b-legacy-token"
+        let gatewayASharedToken = "native-gateway-a-shared-token"
+        let gatewayAScopedToken = "native-gateway-a-device-token"
+        let fixture = try await NativeGatewayWebSocketFixture.start(
+            issuedDeviceTokens: [gatewayAScopedToken, nil, nil])
+        defer { fixture.stop() }
+
+        let identity = DeviceIdentityStore.loadOrCreate()
+        _ = DeviceAuthStore.storeToken(
+            deviceId: identity.deviceId,
+            role: "node",
+            token: gatewayBLegacyToken)
+
+        let authenticatedGateway = GatewayNodeSession()
+        let options = nativeNodeConnectOptions(
+            allowStoredDeviceAuth: true,
+            deviceAuthGatewayID: gatewayAID)
+        try await authenticatedGateway.connectThroughURLSessionForTest(
+            fixture.url(),
+            credentials: .init(token: gatewayASharedToken),
+            options: options)
+        #expect(fixture.capturedAuth(at: 0) == .init(
+            token: gatewayASharedToken,
+            bootstrapToken: nil,
+            deviceToken: nil))
+        #expect(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node",
+            gatewayID: gatewayAID)?.token == gatewayAScopedToken)
+        #expect(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node")?.token == gatewayBLegacyToken)
+        await authenticatedGateway.disconnect()
+
+        let gateway = GatewayNodeSession()
+        try await gateway.connectThroughURLSessionForTest(fixture.url(), options: options)
+
+        #expect(fixture.capturedAuth(at: 1) == .init(
+            token: gatewayAScopedToken,
+            bootstrapToken: nil,
+            deviceToken: nil))
+        #expect(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node")?.token == gatewayBLegacyToken)
+
+        fixture.closeConnection(at: 1)
+        try await waitUntil("native gateway-scoped token reconnect") {
+            await fixture.capturedAuth(at: 2) != nil
+        }
+        #expect(fixture.capturedAuth(at: 2) == .init(
+            token: gatewayAScopedToken,
+            bootstrapToken: nil,
+            deviceToken: nil))
+        #expect(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node")?.token == gatewayBLegacyToken)
+
+        await gateway.disconnect()
+    }
+
+    @Test(.stateDirectoryIsolated)
+    @MainActor
+    func `unproven legacy token enters visible native re-pair recovery`() async throws {
+        let gatewayID = "native-unproven-owner"
+        let fixture = try await NativeGatewayWebSocketFixture.start(
+            issuedDeviceTokens: [nil],
+            connectFailures: [0: .pairingRequired])
+        defer { fixture.stop() }
+
+        let identity = DeviceIdentityStore.loadOrCreate()
+        _ = DeviceAuthStore.storeToken(
+            deviceId: identity.deviceId,
+            role: "node",
+            token: "unproven-legacy-token")
+        let gateway = GatewayNodeSession()
+        let options = nativeNodeConnectOptions(
+            allowStoredDeviceAuth: true,
+            deviceAuthGatewayID: gatewayID)
+
+        do {
+            try await gateway.connectThroughURLSessionForTest(fixture.url(), options: options)
+            Issue.record("expected pairing-required recovery")
+        } catch let error as GatewayConnectAuthError {
+            #expect(error.detail == .pairingRequired)
+            let problem = try #require(GatewayConnectionProblemMapper.map(error: error))
+            #expect(problem.needsPairingApproval)
+            #expect(problem.actionLabel == "Approve on gateway")
+        }
+
+        #expect(fixture.capturedAuth(at: 0) == .init(
+            token: nil,
+            bootstrapToken: nil,
+            deviceToken: nil))
+        #expect(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node")?.token == "unproven-legacy-token")
+        #expect(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node",
+            gatewayID: gatewayID) == nil)
 
         await gateway.disconnect()
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -2834,14 +2834,18 @@ struct GatewayNodeSessionTests {
     }
 
     @Test(.stateDirectoryIsolated)
-    func `credentialless setup handoff does not send a stored device token`() async throws {
+    func `ownerless handoff does not persist or reuse an issued device token`() async throws {
         let identity = DeviceIdentityStore.loadOrCreate()
         _ = DeviceAuthStore.storeToken(
             deviceId: identity.deviceId,
             role: "node",
             token: "previous-gateway-device-token")
 
-        let session = FakeGatewayWebSocketSession()
+        let session = FakeGatewayWebSocketSession(helloAuth: [
+            "deviceToken": "ownerless-issued-device-token",
+            "role": "node",
+            "scopes": [],
+        ])
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(includeDeviceIdentity: true, allowStoredDeviceAuth: false)
 
@@ -2856,8 +2860,23 @@ struct GatewayNodeSessionTests {
         #expect(auth["bootstrapToken"] == nil)
         #expect(auth["deviceToken"] == nil)
         #expect(task.latestConnectDevice() != nil)
-        #expect(await gateway.currentDeviceAuthRoles().persisted == [])
+        let initialRoles = await gateway.currentDeviceAuthRoles()
+        #expect(initialRoles.received == ["node"])
+        #expect(initialRoles.persisted.isEmpty)
+        #expect(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node")?
+            .token == "previous-gateway-device-token")
 
+        try await waitUntil("ownerless socket receiving before reconnect") {
+            task.hasPendingReceiveHandler()
+        }
+        task.emitReceiveFailure()
+        try await waitUntil("ownerless reconnect socket created") {
+            session.snapshotMakeCount() == 2
+        }
+        let reconnectAuth = try #require(session.latestTask()?.latestConnectAuth())
+        #expect(reconnectAuth["token"] == nil)
+        #expect(reconnectAuth["bootstrapToken"] == nil)
+        #expect(reconnectAuth["deviceToken"] == nil)
         await gateway.disconnect()
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -740,7 +740,8 @@ private func operatorConnectOptions(
     caps: [String] = [],
     clientId: String = "openclaw-ios-test",
     clientMode: String = "ui",
-    includeDeviceIdentity: Bool = false) -> GatewayConnectOptions
+    includeDeviceIdentity: Bool = false,
+    deviceAuthGatewayID: String? = nil) -> GatewayConnectOptions
 {
     GatewayConnectOptions(
         role: "operator",
@@ -751,7 +752,8 @@ private func operatorConnectOptions(
         clientId: clientId,
         clientMode: clientMode,
         clientDisplayName: "iOS Test",
-        includeDeviceIdentity: includeDeviceIdentity)
+        includeDeviceIdentity: includeDeviceIdentity,
+        deviceAuthGatewayID: deviceAuthGatewayID)
 }
 
 private func testURL(_ value: String) throws -> URL {
@@ -2911,6 +2913,7 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `share extension identity profile uses separate node identity and token store`() async throws {
+        let gatewayID = "share-gateway"
         let primaryIdentity = DeviceIdentityStore.loadOrCreate()
         _ = DeviceAuthStore.storeToken(
             deviceId: primaryIdentity.deviceId,
@@ -2927,7 +2930,8 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-ios",
             clientDisplayName: "OpenClaw Share",
             deviceIdentityProfile: .shareExtension,
-            includeDeviceIdentity: true)
+            includeDeviceIdentity: true,
+            deviceAuthGatewayID: gatewayID)
 
         try await gateway.connectForTest(
             testURL("ws://example.invalid"),
@@ -2940,14 +2944,20 @@ struct GatewayNodeSessionTests {
         #expect(shareDeviceId != primaryIdentity.deviceId)
         #expect(DeviceAuthStore.loadToken(deviceId: primaryIdentity.deviceId, role: "node")?
             .token == "primary-node-token")
-        // Profile selects identity resolution, not a token namespace; (device_id, role) is the canonical key.
-        // Per-profile identities keep caches disjoint in practice, and Node reads the same table by that key.
-        #expect(DeviceAuthStore.loadToken(deviceId: shareDeviceId, role: "node")?.token == "share-node-token")
-        #expect(DeviceAuthStore.loadToken(deviceId: shareDeviceId, role: "node")?.scopes == ["node.exec"])
+        // Profile selects identity resolution; the stable Gateway owner scopes the token within that identity.
+        #expect(DeviceAuthStore.loadToken(
+            deviceId: shareDeviceId,
+            role: "node",
+            gatewayID: gatewayID)?.token == "share-node-token")
         #expect(
             DeviceAuthStore
-                .loadToken(deviceId: shareDeviceId, role: "node", profile: .shareExtension)?.token ==
+                .loadToken(
+                    deviceId: shareDeviceId,
+                    role: "node",
+                    gatewayID: gatewayID,
+                    profile: .shareExtension)?.token ==
                 "share-node-token")
+        #expect(DeviceAuthStore.loadToken(deviceId: shareDeviceId, role: "node") == nil)
 
         await gateway.disconnect()
     }
@@ -3045,6 +3055,7 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `bootstrap hello stores additional device tokens`() async throws {
+        let gatewayID = "bootstrap-gateway"
         let identity = DeviceIdentityStore.loadOrCreate()
         let session = FakeGatewayWebSocketSession(helloAuth: [
             "deviceToken": "node-device-token",
@@ -3069,7 +3080,9 @@ struct GatewayNodeSessionTests {
             ],
         ])
         let gateway = GatewayNodeSession()
-        let options = nodeConnectOptions(includeDeviceIdentity: true)
+        let options = nodeConnectOptions(
+            includeDeviceIdentity: true,
+            deviceAuthGatewayID: gatewayID)
 
         try await gateway.connectForTest(
             testURL("wss://example.invalid"),
@@ -3077,8 +3090,14 @@ struct GatewayNodeSessionTests {
             options: options,
             session: session)
 
-        let nodeEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node"))
-        let operatorEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator"))
+        let nodeEntry = try #require(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node",
+            gatewayID: gatewayID))
+        let operatorEntry = try #require(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "operator",
+            gatewayID: gatewayID))
         #expect(nodeEntry.token == "node-device-token")
         #expect(nodeEntry.scopes == [])
         #expect(operatorEntry.token == "operator-device-token")
@@ -3098,6 +3117,7 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `failed device token write retains issuance without claiming persistence`() async throws {
+        let gatewayID = "blocked-storage-gateway"
         let stateDir = try #require(ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"])
         let blocker = URL(fileURLWithPath: stateDir, isDirectory: true)
             .appendingPathComponent("identity", isDirectory: false)
@@ -3112,7 +3132,9 @@ struct GatewayNodeSessionTests {
             "scopes": [],
         ])
         let gateway = GatewayNodeSession()
-        let options = nodeConnectOptions(includeDeviceIdentity: true)
+        let options = nodeConnectOptions(
+            includeDeviceIdentity: true,
+            deviceAuthGatewayID: gatewayID)
 
         try await gateway.connectForTest(
             testURL("wss://example.invalid"),
@@ -3128,19 +3150,23 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `same primary device token preserves stored scopes`() async throws {
+        let gatewayID = "operator-gateway"
         let identity = DeviceIdentityStore.loadOrCreate()
         _ = DeviceAuthStore.storeToken(
             deviceId: identity.deviceId,
             role: "operator",
             token: "server-operator-token",
-            scopes: ["operator.admin", "operator.read"])
+            scopes: ["operator.admin", "operator.read"],
+            gatewayID: gatewayID)
         let session = FakeGatewayWebSocketSession(helloAuth: [
             "deviceToken": "server-operator-token",
             "role": "operator",
             "scopes": ["operator.read"],
         ])
         let gateway = GatewayNodeSession()
-        let options = operatorConnectOptions(includeDeviceIdentity: true)
+        let options = operatorConnectOptions(
+            includeDeviceIdentity: true,
+            deviceAuthGatewayID: gatewayID)
 
         try await gateway.connectForTest(
             testURL("wss://example.invalid"),
@@ -3148,7 +3174,10 @@ struct GatewayNodeSessionTests {
             options: options,
             session: session)
 
-        let operatorEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator"))
+        let operatorEntry = try #require(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "operator",
+            gatewayID: gatewayID))
         #expect(operatorEntry.token == "server-operator-token")
         #expect(operatorEntry.scopes == ["operator.admin", "operator.read"])
 
@@ -3157,12 +3186,14 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `rotated primary device token uses hello scopes and ignores additional handoff tokens`() async throws {
+        let gatewayID = "rotating-operator-gateway"
         let identity = DeviceIdentityStore.loadOrCreate()
         _ = DeviceAuthStore.storeToken(
             deviceId: identity.deviceId,
             role: "operator",
             token: "old-operator-token",
-            scopes: ["operator.admin", "operator.read"])
+            scopes: ["operator.admin", "operator.read"],
+            gatewayID: gatewayID)
         let session = FakeGatewayWebSocketSession(helloAuth: [
             "deviceToken": "rotated-operator-token",
             "role": "operator",
@@ -3176,7 +3207,9 @@ struct GatewayNodeSessionTests {
             ],
         ])
         let gateway = GatewayNodeSession()
-        let options = operatorConnectOptions(includeDeviceIdentity: true)
+        let options = operatorConnectOptions(
+            includeDeviceIdentity: true,
+            deviceAuthGatewayID: gatewayID)
 
         try await gateway.connectForTest(
             testURL("wss://example.invalid"),
@@ -3184,7 +3217,10 @@ struct GatewayNodeSessionTests {
             options: options,
             session: session)
 
-        let operatorEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator"))
+        let operatorEntry = try #require(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "operator",
+            gatewayID: gatewayID))
         #expect(operatorEntry.token == "rotated-operator-token")
         #expect(operatorEntry.scopes == ["operator.read"])
         #expect(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node") == nil)
@@ -3194,6 +3230,7 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `untrusted bootstrap hello does not persist bootstrap handoff tokens`() async throws {
+        let gatewayID = "untrusted-bootstrap-gateway"
         let identity = DeviceIdentityStore.loadOrCreate()
         let session = FakeGatewayWebSocketSession(helloAuth: [
             "deviceToken": "untrusted-node-token",
@@ -3211,7 +3248,9 @@ struct GatewayNodeSessionTests {
             ],
         ])
         let gateway = GatewayNodeSession()
-        let options = nodeConnectOptions(includeDeviceIdentity: true)
+        let options = nodeConnectOptions(
+            includeDeviceIdentity: true,
+            deviceAuthGatewayID: gatewayID)
 
         try await gateway.connectForTest(
             testURL("ws://example.invalid"),
@@ -3219,14 +3258,21 @@ struct GatewayNodeSessionTests {
             options: options,
             session: session)
 
-        #expect(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node") == nil)
-        #expect(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator") == nil)
+        #expect(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node",
+            gatewayID: gatewayID) == nil)
+        #expect(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "operator",
+            gatewayID: gatewayID) == nil)
 
         await gateway.disconnect()
     }
 
     @Test(.stateDirectoryIsolated)
-    func `private lan bootstrap persists handoff tokens for reconnect`() async throws {
+    func `owner-bound bootstrap persists handoff tokens when lookup is disabled`() async throws {
+        let gatewayID = "private-lan-gateway"
         let identity = DeviceIdentityStore.loadOrCreate()
         let url = try #require(URL(string: "ws://192.168.50.164:18889"))
         let bootstrapSession = FakeGatewayWebSocketSession(helloAuth: [
@@ -3245,7 +3291,10 @@ struct GatewayNodeSessionTests {
             ],
         ])
         let gateway = GatewayNodeSession()
-        let options = nodeConnectOptions(includeDeviceIdentity: true)
+        let options = nodeConnectOptions(
+            includeDeviceIdentity: true,
+            allowStoredDeviceAuth: false,
+            deviceAuthGatewayID: gatewayID)
 
         try await gateway.connectForTest(
             url,
@@ -3254,8 +3303,14 @@ struct GatewayNodeSessionTests {
             session: bootstrapSession)
         await gateway.disconnect()
 
-        let nodeEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node"))
-        let operatorEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator"))
+        let nodeEntry = try #require(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node",
+            gatewayID: gatewayID))
+        let operatorEntry = try #require(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "operator",
+            gatewayID: gatewayID))
         #expect(nodeEntry.token == "lan-node-token")
         #expect(nodeEntry.scopes == [])
         #expect(operatorEntry.token == "lan-operator-token")
@@ -3265,7 +3320,9 @@ struct GatewayNodeSessionTests {
         ])
 
         let reconnectSession = FakeGatewayWebSocketSession()
-        try await gateway.connectForTest(url, options: options, session: reconnectSession)
+        var reconnectOptions = options
+        reconnectOptions.allowStoredDeviceAuth = true
+        try await gateway.connectForTest(url, options: reconnectOptions, session: reconnectSession)
 
         let reconnectAuth = try #require(reconnectSession.latestTask()?.latestConnectAuth())
         #expect(reconnectAuth["token"] as? String == "lan-node-token")

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -3055,7 +3055,6 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `bootstrap hello stores additional device tokens`() async throws {
-        let gatewayID = "bootstrap-gateway"
         let identity = DeviceIdentityStore.loadOrCreate()
         let session = FakeGatewayWebSocketSession(helloAuth: [
             "deviceToken": "node-device-token",
@@ -3080,9 +3079,7 @@ struct GatewayNodeSessionTests {
             ],
         ])
         let gateway = GatewayNodeSession()
-        let options = nodeConnectOptions(
-            includeDeviceIdentity: true,
-            deviceAuthGatewayID: gatewayID)
+        let options = nodeConnectOptions(includeDeviceIdentity: true)
 
         try await gateway.connectForTest(
             testURL("wss://example.invalid"),
@@ -3090,14 +3087,8 @@ struct GatewayNodeSessionTests {
             options: options,
             session: session)
 
-        let nodeEntry = try #require(DeviceAuthStore.loadToken(
-            deviceId: identity.deviceId,
-            role: "node",
-            gatewayID: gatewayID))
-        let operatorEntry = try #require(DeviceAuthStore.loadToken(
-            deviceId: identity.deviceId,
-            role: "operator",
-            gatewayID: gatewayID))
+        let nodeEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node"))
+        let operatorEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator"))
         #expect(nodeEntry.token == "node-device-token")
         #expect(nodeEntry.scopes == [])
         #expect(operatorEntry.token == "operator-device-token")
@@ -3272,9 +3263,9 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `owner-bound bootstrap persists handoff tokens when lookup is disabled`() async throws {
-        let gatewayID = "private-lan-gateway"
+        let gatewayID = "loopback-gateway"
         let identity = DeviceIdentityStore.loadOrCreate()
-        let url = try #require(URL(string: "ws://192.168.50.164:18889"))
+        let url = try #require(URL(string: "ws://127.0.0.1:18889"))
         let bootstrapSession = FakeGatewayWebSocketSession(helloAuth: [
             "deviceToken": "lan-node-token",
             "role": "node",

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/NativeGatewayWebSocketFixture.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/NativeGatewayWebSocketFixture.swift
@@ -1,0 +1,380 @@
+#if os(macOS)
+import CryptoKit
+import Foundation
+import Network
+
+@MainActor
+final class NativeGatewayWebSocketFixture {
+    struct ConnectAuth: Equatable, Sendable {
+        let token: String?
+        let bootstrapToken: String?
+        let deviceToken: String?
+    }
+
+    private struct Client {
+        enum Phase {
+            case handshake
+            case connect
+            case open
+        }
+
+        let connection: NWConnection
+        var buffer = Data()
+        var phase = Phase.handshake
+    }
+
+    private static let websocketGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+    private let listener: NWListener
+    private let issuedDeviceTokens: [String?]
+    private var clients: [Int: Client] = [:]
+    private var connectAuth: [ConnectAuth] = []
+    private var nextConnectionIndex = 0
+    private var stopped = false
+    nonisolated let port: UInt16
+
+    private init(listener: NWListener, port: UInt16, issuedDeviceTokens: [String?]) {
+        self.listener = listener
+        self.port = port
+        self.issuedDeviceTokens = issuedDeviceTokens
+        self.listener.newConnectionHandler = { [weak self] connection in
+            MainActor.assumeIsolated {
+                guard let self else {
+                    connection.cancel()
+                    return
+                }
+                self.accept(connection)
+            }
+        }
+    }
+
+    static func start(issuedDeviceTokens: [String?]) async throws -> NativeGatewayWebSocketFixture {
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
+        let listener = try NWListener(using: parameters, on: .any)
+        listener.newConnectionHandler = { $0.cancel() }
+        listener.start(queue: .main)
+        do {
+            let deadline = ContinuousClock.now + .seconds(5)
+            while ContinuousClock.now < deadline {
+                try Task.checkCancellation()
+                switch listener.state {
+                case .ready:
+                    guard let port = listener.port, port.rawValue != 0 else {
+                        throw URLError(.cannotFindHost)
+                    }
+                    return NativeGatewayWebSocketFixture(
+                        listener: listener,
+                        port: port.rawValue,
+                        issuedDeviceTokens: issuedDeviceTokens)
+                case let .failed(error):
+                    throw error
+                case .cancelled:
+                    throw CancellationError()
+                default:
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+            }
+            throw URLError(.timedOut)
+        } catch {
+            listener.cancel()
+            throw error
+        }
+    }
+
+    nonisolated func url() -> URL {
+        URL(string: "ws://127.0.0.1:\(self.port)")!
+    }
+
+    func capturedAuth(at index: Int) -> ConnectAuth? {
+        guard self.connectAuth.indices.contains(index) else { return nil }
+        return self.connectAuth[index]
+    }
+
+    func closeConnection(at index: Int) {
+        self.close(index)
+    }
+
+    func stop() {
+        guard !self.stopped else { return }
+        self.stopped = true
+        self.listener.cancel()
+        for index in Array(self.clients.keys) {
+            self.close(index)
+        }
+    }
+
+    private func accept(_ connection: NWConnection) {
+        guard !self.stopped else {
+            connection.cancel()
+            return
+        }
+        let index = self.nextConnectionIndex
+        self.nextConnectionIndex += 1
+        self.clients[index] = Client(connection: connection)
+        connection.stateUpdateHandler = { [weak self] state in
+            MainActor.assumeIsolated {
+                guard let self else {
+                    connection.cancel()
+                    return
+                }
+                switch state {
+                case .ready:
+                    self.receive(index)
+                case .cancelled, .failed:
+                    self.clients[index] = nil
+                default:
+                    break
+                }
+            }
+        }
+        connection.start(queue: .main)
+    }
+
+    private func receive(_ index: Int) {
+        guard let client = self.clients[index] else { return }
+        client.connection.receive(
+            minimumIncompleteLength: 1,
+            maximumLength: 65536)
+        { [weak self] data, _, complete, error in
+            MainActor.assumeIsolated {
+                guard let self, var client = self.clients[index] else { return }
+                if let data {
+                    client.buffer.append(data)
+                    self.clients[index] = client
+                    self.process(index)
+                }
+                if error != nil || complete {
+                    self.close(index)
+                } else if self.clients[index] != nil {
+                    self.receive(index)
+                }
+            }
+        }
+    }
+
+    private func process(_ index: Int) {
+        guard let client = self.clients[index] else { return }
+        switch client.phase {
+        case .handshake:
+            self.processHandshake(index)
+        case .connect, .open:
+            self.processFrames(index)
+        }
+    }
+
+    private func processHandshake(_ index: Int) {
+        guard var client = self.clients[index],
+              let headerEnd = client.buffer.range(of: Data("\r\n\r\n".utf8))
+        else { return }
+        let headerData = client.buffer[..<headerEnd.upperBound]
+        client.buffer.removeSubrange(..<headerEnd.upperBound)
+        guard let headers = String(data: headerData, encoding: .utf8),
+              let key = headers
+                  .components(separatedBy: "\r\n")
+                  .first(where: { $0.lowercased().hasPrefix("sec-websocket-key:") })?
+                  .split(separator: ":", maxSplits: 1)
+                  .last?
+                  .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !key.isEmpty
+        else {
+            self.close(index)
+            return
+        }
+
+        let digest = Insecure.SHA1.hash(data: Data((key + Self.websocketGUID).utf8))
+        let accept = Data(digest).base64EncodedString()
+        let response = [
+            "HTTP/1.1 101 Switching Protocols",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            "Sec-WebSocket-Accept: \(accept)",
+            "",
+            "",
+        ].joined(separator: "\r\n")
+        client.phase = .connect
+        self.clients[index] = client
+        client.connection.send(content: Data(response.utf8), completion: .contentProcessed { [weak self] error in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                guard error == nil else {
+                    self.close(index)
+                    return
+                }
+                self.sendChallenge(index)
+                self.processFrames(index)
+            }
+        })
+    }
+
+    private func processFrames(_ index: Int) {
+        while var client = self.clients[index],
+              let frame = Self.takeFrame(from: &client.buffer)
+        {
+            self.clients[index] = client
+            switch frame.opcode {
+            case 0x1, 0x2:
+                self.handleText(frame.payload, index: index)
+            case 0x8:
+                self.close(index)
+                return
+            case 0x9:
+                self.sendFrame(opcode: 0xA, payload: frame.payload, index: index)
+            default:
+                break
+            }
+        }
+    }
+
+    private func handleText(_ data: Data, index: Int) {
+        guard var client = self.clients[index], client.phase == .connect,
+              let request = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              request["type"] as? String == "req",
+              request["method"] as? String == "connect",
+              let id = request["id"] as? String
+        else { return }
+
+        let params = request["params"] as? [String: Any]
+        let auth = params?["auth"] as? [String: Any]
+        self.connectAuth.append(ConnectAuth(
+            token: auth?["token"] as? String,
+            bootstrapToken: auth?["bootstrapToken"] as? String,
+            deviceToken: auth?["deviceToken"] as? String))
+        client.phase = .open
+        self.clients[index] = client
+        self.sendConnectOK(id: id, index: index)
+    }
+
+    private func sendChallenge(_ index: Int) {
+        let frame: [String: Any] = [
+            "type": "event",
+            "event": "connect.challenge",
+            "payload": [
+                "nonce": "native-transport-\(index)",
+                "ts": 1_800_000_000_000,
+            ],
+        ]
+        self.sendJSON(frame, index: index)
+    }
+
+    private func sendConnectOK(id: String, index: Int) {
+        var auth: [String: Any] = [
+            "role": "node",
+            "scopes": [],
+        ]
+        if self.issuedDeviceTokens.indices.contains(index),
+           let token = self.issuedDeviceTokens[index]
+        {
+            auth["deviceToken"] = token
+        }
+        let frame: [String: Any] = [
+            "type": "res",
+            "id": id,
+            "ok": true,
+            "payload": [
+                "type": "hello-ok",
+                "protocol": 2,
+                "server": [
+                    "version": "test",
+                    "connId": "native-\(index)",
+                ],
+                "features": [
+                    "methods": [],
+                    "events": [],
+                    "capabilities": [],
+                ],
+                "snapshot": [
+                    "presence": [["ts": 1]],
+                    "health": [:],
+                    "stateVersion": [
+                        "presence": 0,
+                        "health": 0,
+                    ],
+                    "uptimeMs": 0,
+                ],
+                "policy": [
+                    "maxPayload": 1,
+                    "maxBufferedBytes": 1,
+                    "tickIntervalMs": 30000,
+                ],
+                "auth": auth,
+            ],
+        ]
+        self.sendJSON(frame, index: index)
+    }
+
+    private func sendJSON(_ frame: [String: Any], index: Int) {
+        guard let data = try? JSONSerialization.data(withJSONObject: frame) else {
+            self.close(index)
+            return
+        }
+        self.sendFrame(opcode: 0x1, payload: data, index: index)
+    }
+
+    private func sendFrame(opcode: UInt8, payload: Data, index: Int) {
+        guard let client = self.clients[index] else { return }
+        var frame = Data([0x80 | opcode])
+        switch payload.count {
+        case 0...125:
+            frame.append(UInt8(payload.count))
+        case 126...65535:
+            frame.append(126)
+            frame.append(UInt8((payload.count >> 8) & 0xFF))
+            frame.append(UInt8(payload.count & 0xFF))
+        default:
+            self.close(index)
+            return
+        }
+        frame.append(payload)
+        client.connection.send(content: frame, completion: .contentProcessed { [weak self] error in
+            guard error != nil else { return }
+            MainActor.assumeIsolated {
+                self?.close(index)
+            }
+        })
+    }
+
+    private func close(_ index: Int) {
+        self.clients.removeValue(forKey: index)?.connection.cancel()
+    }
+
+    private static func takeFrame(from buffer: inout Data) -> (opcode: UInt8, payload: Data)? {
+        guard buffer.count >= 2 else { return nil }
+        let first = buffer[buffer.startIndex]
+        let second = buffer[buffer.index(after: buffer.startIndex)]
+        var payloadLength = Int(second & 0x7F)
+        var cursor = 2
+
+        if payloadLength == 126 {
+            guard buffer.count >= 4 else { return nil }
+            payloadLength = Int(buffer[2]) << 8 | Int(buffer[3])
+            cursor = 4
+        } else if payloadLength == 127 {
+            guard buffer.count >= 10 else { return nil }
+            let length = buffer[2..<10].reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+            guard length <= UInt64(Int.max) else { return nil }
+            payloadLength = Int(length)
+            cursor = 10
+        }
+
+        let masked = second & 0x80 != 0
+        let mask: [UInt8]
+        if masked {
+            guard buffer.count >= cursor + 4 else { return nil }
+            mask = Array(buffer[cursor..<(cursor + 4)])
+            cursor += 4
+        } else {
+            mask = []
+        }
+        guard buffer.count >= cursor + payloadLength else { return nil }
+
+        var payload = Data(buffer[cursor..<(cursor + payloadLength)])
+        if masked {
+            for offset in payload.indices {
+                payload[offset] ^= mask[(offset - payload.startIndex) % 4]
+            }
+        }
+        buffer.removeSubrange(..<(cursor + payloadLength))
+        return (first & 0x0F, payload)
+    }
+}
+#endif

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/NativeGatewayWebSocketFixture.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/NativeGatewayWebSocketFixture.swift
@@ -2,6 +2,7 @@
 import CryptoKit
 import Foundation
 import Network
+@testable import OpenClawKit
 
 @MainActor
 final class NativeGatewayWebSocketFixture {
@@ -9,6 +10,17 @@ final class NativeGatewayWebSocketFixture {
         let token: String?
         let bootstrapToken: String?
         let deviceToken: String?
+    }
+
+    struct ConnectFailure: Sendable {
+        let message: String
+        let detailCode: String
+        let requestId: String
+
+        static let pairingRequired = ConnectFailure(
+            message: "pairing required",
+            detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue,
+            requestId: "native-pairing-request")
     }
 
     private struct Client {
@@ -26,16 +38,23 @@ final class NativeGatewayWebSocketFixture {
     private static let websocketGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
     private let listener: NWListener
     private let issuedDeviceTokens: [String?]
+    private let connectFailures: [Int: ConnectFailure]
     private var clients: [Int: Client] = [:]
     private var connectAuth: [ConnectAuth] = []
     private var nextConnectionIndex = 0
     private var stopped = false
     nonisolated let port: UInt16
 
-    private init(listener: NWListener, port: UInt16, issuedDeviceTokens: [String?]) {
+    private init(
+        listener: NWListener,
+        port: UInt16,
+        issuedDeviceTokens: [String?],
+        connectFailures: [Int: ConnectFailure])
+    {
         self.listener = listener
         self.port = port
         self.issuedDeviceTokens = issuedDeviceTokens
+        self.connectFailures = connectFailures
         self.listener.newConnectionHandler = { [weak self] connection in
             MainActor.assumeIsolated {
                 guard let self else {
@@ -47,7 +66,10 @@ final class NativeGatewayWebSocketFixture {
         }
     }
 
-    static func start(issuedDeviceTokens: [String?]) async throws -> NativeGatewayWebSocketFixture {
+    static func start(
+        issuedDeviceTokens: [String?],
+        connectFailures: [Int: ConnectFailure] = [:]) async throws -> NativeGatewayWebSocketFixture
+    {
         let parameters = NWParameters.tcp
         parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
         let listener = try NWListener(using: parameters, on: .any)
@@ -65,7 +87,8 @@ final class NativeGatewayWebSocketFixture {
                     return NativeGatewayWebSocketFixture(
                         listener: listener,
                         port: port.rawValue,
-                        issuedDeviceTokens: issuedDeviceTokens)
+                        issuedDeviceTokens: issuedDeviceTokens,
+                        connectFailures: connectFailures)
                 case let .failed(error):
                     throw error
                 case .cancelled:
@@ -241,7 +264,11 @@ final class NativeGatewayWebSocketFixture {
             deviceToken: auth?["deviceToken"] as? String))
         client.phase = .open
         self.clients[index] = client
-        self.sendConnectOK(id: id, index: index)
+        if let failure = self.connectFailures[index] {
+            self.sendConnectFailure(id: id, failure: failure, index: index)
+        } else {
+            self.sendConnectOK(id: id, index: index)
+        }
     }
 
     private func sendChallenge(_ index: Int) {
@@ -297,6 +324,23 @@ final class NativeGatewayWebSocketFixture {
                     "tickIntervalMs": 30000,
                 ],
                 "auth": auth,
+            ],
+        ]
+        self.sendJSON(frame, index: index)
+    }
+
+    private func sendConnectFailure(id: String, failure: ConnectFailure, index: Int) {
+        let frame: [String: Any] = [
+            "type": "res",
+            "id": id,
+            "ok": false,
+            "error": [
+                "code": "AUTH_UNAUTHORIZED",
+                "message": failure.message,
+                "details": [
+                    "code": failure.detailCode,
+                    "requestId": failure.requestId,
+                ],
             ],
         ]
         self.sendJSON(frame, index: index)


### PR DESCRIPTION
Related: #134142

## What Problem This Solves

Fixes an issue where the macOS local node could load a legacy role-global device token, or a token associated with another Gateway, when connecting to the selected Gateway. It also prevents an explicit ownerless handoff from persisting a newly issued token into the legacy namespace and reusing it on reconnect.

## Why This Change Was Made

The selected endpoint already carries a stable device-auth Gateway owner, and the macOS operator connection uses it. This change applies the same owner binding to the local-node connection and disables stored device-auth lookup when no stable owner exists.

Device-auth writes preserve two valid contracts:

- legacy/default callers with `allowStoredDeviceAuth=true` and no owner continue rotating credentials in the same unscoped namespace they read;
- modern pairing with a stable `deviceAuthGatewayID` persists only in that Gateway's scope, even when prior-token lookup is disabled.

The explicit `allowStoredDeviceAuth=false, deviceAuthGatewayID=nil` combination disables both lookup and persistence. Tagged releases `v2026.7.1`, `v2026.8.1`, and `v2026.8.2` could store the macOS node token under the legacy unscoped role key; those provenance-free tokens are not migrated or relabeled to a Gateway. No storage schema or Gateway protocol changes are involved.

## User Impact

The macOS local node now reuses only credentials issued for its selected Gateway. Switching Gateways cannot silently reuse a node token from another route, while legacy clients that intentionally use the unscoped namespace still persist Gateway token rotation and reconnect with the replacement.

Upgraded macOS installations with only a provenance-free legacy node token must re-pair for an owner-bound endpoint. The Mac node exposes the existing `Approve on gateway` recovery action instead of silently assigning that token to a Gateway whose authority cannot be proven.

## Maintainer Decision

Accept fail-closed visible re-pairing for provenance-free legacy macOS node tokens rather than silently assigning them to an unproven Gateway. This is the intended compatibility boundary for this fix.

## Evidence

- Focused `MacNodeModeCoordinatorTests` cover:
  - propagation of the selected Gateway owner;
  - disabling stored auth when the owner is absent;
  - keeping different Gateway owners distinct;
  - surfacing `Approve on gateway` for the fail-closed re-pair path.
- `GatewayNodeSessionTests` cover:
  - legacy/default bootstrap handoff persisting node and operator credentials unscoped;
  - explicit ownerless issuance being observed but not persisted;
  - automatic explicit-ownerless reconnect sending no token, bootstrap token, or device token;
  - owner-bound bootstrap handoff persistence and reconnect behavior used by iOS setup.
- macOS-only native transport coverage uses the production `URLSessionWebSocketTask` path and a loopback Gateway/WebSocket fixture:
  - legacy/default unscoped rotation: the old credential is sent, the returned replacement overwrites the unscoped entry, and forced automatic reconnect sends only the replacement;
  - owner-bound fresh pairing: the first connection sends no stored credential, issuance persists only in the stable owner's scope, and reconnect sends that scoped credential;
  - explicit ownerless handoff: issuance is not persisted and reconnect remains credentialless;
  - unproven legacy recovery: the legacy credential is not sent, remains unscoped, and `PAIRING_REQUIRED` maps to `Approve on gateway`;
  - two-Gateway authority regression: a legacy unscoped token representing Gateway B remains dormant after Gateway A accepts its explicit shared credential and issues an A-scoped token; a fresh connection and forced automatic reconnect send only A's scoped credential. Endpoints and credential values are redacted, and the fixture emits no token artifacts.
- Pinned SwiftFormat 0.63.0: clean on all touched Swift files.
- Pinned SwiftLint 0.65.1: changed production and native transport test files are clean. Existing size/style violations in the large legacy test files reproduce at the branch base.
- `git diff --check`: passed.
- P0-P2 autoreview: scoped clean on the final staged tree, 0.97 confidence.
- Exact-head hosted proof for `e6054461e28fd79165f302b32269ae3009224f44`: CI run `33737299073` passed. `macos-swift (tests)` passed the production `URLSessionWebSocketTask` fixture, observing that Gateway B's legacy unscoped credential was never sent to Gateway A, remained dormant, and Gateway A's newly issued scoped credential was the only device credential sent on fresh connection and forced reconnect. The same run passed legacy unscoped token rotation/reconnect, explicit ownerless credentialless reconnect, owner-bound fresh pairing persistence/reconnect, `macos-swift (release)`, `ios-build (tests)`, `ios-build (release)`, and the aggregate `openclaw/ci-gate`. The unrelated Android third-party timeout passed on its single-job rerun.

Native Swift tests were not run locally: this host has Xcode 16.3 / Swift 6.1, while the packages require Swift tools 6.3. The scoped changed-check classifier also cannot run its mobile protocol scan from this sparse worktree because `apps/ios/Sources` is absent. Exact-head hosted macOS and iOS CI owns compile and runtime proof.

Installed-app and multi-Gateway Keychain/container proof remains for the dedicated Apple fleet lane; this PR does not claim that proof.
