### PR TITLE
fix(acpx): complete interrupted fixture turns

### DIFF
--- a/extensions/acpx/test/fixtures/codex-app-server.mjs
+++ b/extensions/acpx/test/fixtures/codex-app-server.mjs
@@ -6,11 +6,17 @@ let nextRequestId = 1;
 let nextThreadId = 1;
 let nextTurnId = 1;
 const pending = new Map();
+const activeTurns = new Map();
 const tracePath = process.env.OPENCLAW_ACPX_PROCESS_FIXTURE_TRACE;
+const afterResponseCallback = Symbol("afterResponseCallback");
 
-function trace(method) {
+function trace(method, params = {}) {
   if (tracePath) {
-    fs.appendFileSync(tracePath, `${JSON.stringify({ method })}\n`, "utf8");
+    fs.appendFileSync(
+      tracePath,
+      `${JSON.stringify({ method, threadId: params.threadId, turnId: params.turnId })}\n`,
+      "utf8",
+    );
   }
 }
 
@@ -25,9 +31,28 @@ function notify(method, params) {
 function request(method, params) {
   const id = `fixture-${nextRequestId++}`;
   write({ id, method, params });
-  return new Promise((resolve, reject) => {
+  const response = new Promise((resolve, reject) => {
     pending.set(id, { resolve, reject });
   });
+  return { id, response };
+}
+
+function invalidRequest(message) {
+  const error = new Error(message);
+  error.code = -32600;
+  return error;
+}
+
+function deferUntilAfterResponse(result, callback) {
+  let pendingCallback = callback;
+  return {
+    result,
+    [afterResponseCallback]() {
+      const consume = pendingCallback;
+      pendingCallback = null;
+      consume?.();
+    },
+  };
 }
 
 const model = {
@@ -43,7 +68,9 @@ const model = {
 };
 
 async function handle(method, params) {
-  trace(method);
+  if (method !== "turn/start") {
+    trace(method, params);
+  }
   if (method === "initialize") {
     return { userAgent: "openclaw-acpx-process-fixture", codexHome: process.cwd() };
   }
@@ -74,12 +101,23 @@ async function handle(method, params) {
     };
   }
   if (method === "turn/start") {
+    if (activeTurns.has(params.threadId)) {
+      throw invalidRequest("a turn is already active for this thread");
+    }
     const turnId = `turn-process-${nextTurnId++}`;
+    trace(method, { threadId: params.threadId, turnId });
     const turn = { id: turnId, items: [], status: "inProgress", error: null };
+    const state = {
+      threadId: params.threadId,
+      turn,
+      terminalStatus: null,
+      pendingElicitationRequestId: null,
+    };
+    activeTurns.set(params.threadId, state);
     queueMicrotask(() => {
       void (async () => {
         notify("turn/started", { threadId: params.threadId, turn });
-        const answers = await request("item/tool/requestUserInput", {
+        const elicitation = request("item/tool/requestUserInput", {
           threadId: params.threadId,
           turnId,
           itemId: "request_user_input",
@@ -96,8 +134,16 @@ async function handle(method, params) {
           isBlocking: true,
           autoResolutionMs: null,
         });
+        state.pendingElicitationRequestId = elicitation.id;
+        const answers = await elicitation.response;
+        if (activeTurns.get(params.threadId) !== state || state.terminalStatus !== null) {
+          return;
+        }
+        state.pendingElicitationRequestId = null;
         const text = JSON.stringify(answers);
         const item = { type: "agentMessage", id: "message-process", text };
+        state.turn = { ...turn, items: [item], status: "completed" };
+        state.terminalStatus = "completed";
         notify("item/agentMessage/delta", {
           threadId: params.threadId,
           turnId,
@@ -107,15 +153,41 @@ async function handle(method, params) {
         notify("item/completed", { threadId: params.threadId, turnId, item });
         notify("turn/completed", {
           threadId: params.threadId,
-          turn: { ...turn, items: [item], status: "completed" },
+          turn: state.turn,
         });
+        activeTurns.delete(params.threadId);
       })().catch(() => {
         process.stderr.write("codex app-server fixture turn failed\n");
       });
     });
     return { turn };
   }
-  if (["turn/interrupt", "thread/unsubscribe", "thread/archive"].includes(method)) {
+  if (method === "turn/interrupt") {
+    const state = activeTurns.get(params.threadId);
+    if (!state || state.terminalStatus !== null || state.turn.id !== params.turnId) {
+      throw invalidRequest("no matching active turn to interrupt");
+    }
+    const pendingElicitationRequestId = state.pendingElicitationRequestId;
+    const interruptedTurn = { ...state.turn, items: [], status: "interrupted" };
+
+    // Fence the elicitation continuation before settling it or admitting a successor turn.
+    state.terminalStatus = "interrupted";
+    state.turn = interruptedTurn;
+    state.pendingElicitationRequestId = null;
+    if (pendingElicitationRequestId) {
+      const waiter = pending.get(pendingElicitationRequestId);
+      pending.delete(pendingElicitationRequestId);
+      waiter?.resolve(undefined);
+    }
+    return deferUntilAfterResponse({}, () => {
+      notify("turn/completed", {
+        threadId: state.threadId,
+        turn: interruptedTurn,
+      });
+      activeTurns.delete(state.threadId);
+    });
+  }
+  if (["thread/unsubscribe", "thread/archive"].includes(method)) {
     return {};
   }
   throw new Error(`unsupported fixture method: ${method}`);
@@ -142,11 +214,19 @@ readline.createInterface({ input: process.stdin }).on("line", async (line) => {
     return;
   }
   try {
-    write({ id: message.id, result: await handle(message.method, message.params ?? {}) });
+    const handled = await handle(message.method, message.params ?? {});
+    const afterResponse = handled?.[afterResponseCallback];
+    const result = afterResponse ? handled.result : handled;
+    write({ id: message.id, result });
+    afterResponse?.();
   } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error && Number.isInteger(error.code)
+        ? error.code
+        : -32601;
     write({
       id: message.id,
-      error: { code: -32601, message: error instanceof Error ? error.message : String(error) },
+      error: { code, message: error instanceof Error ? error.message : String(error) },
     });
   }
 });

--- a/test/e2e/qa-lab/runtime/webhooks-taskflow-cancellation-authz.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/webhooks-taskflow-cancellation-authz.e2e.test.ts
@@ -1,6 +1,7 @@
 // Webhooks TaskFlow E2E covers route-bound child cancellation on a real Gateway listener.
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { AcpRuntimeEvent } from "@openclaw/acp-core/runtime/types";
 import type { OpenClawPluginService } from "openclaw/plugin-sdk/core";
 import {
   createPluginStateKeyedStoreForTests,
@@ -173,12 +174,18 @@ async function projectChild(params: {
   expect(response).toMatchObject({ status: 200, body: { ok: true } });
 }
 
-async function readAcpTraceMethods(tracePath: string): Promise<string[]> {
+type AcpFixtureTraceEntry = {
+  method: string;
+  threadId?: string;
+  turnId?: string;
+};
+
+async function readAcpTrace(tracePath: string): Promise<AcpFixtureTraceEntry[]> {
   return (await fs.readFile(tracePath, "utf8"))
     .trim()
     .split("\n")
     .filter(Boolean)
-    .map((line) => (JSON.parse(line) as { method: string }).method);
+    .map((line) => JSON.parse(line) as AcpFixtureTraceEntry);
 }
 
 describe("webhooks TaskFlow child cancellation authority", () => {
@@ -548,7 +555,9 @@ describe("webhooks TaskFlow child cancellation authority", () => {
             });
             expect(getTaskFlowById(acpReplacementFlowId)).toMatchObject({ status: "queued" });
             expect(getTaskFlowById(acpReplacementFlowId)?.cancelRequestedAt).toBeUndefined();
-            acpxMethodsBeforeRelease = await readAcpTraceMethods(acpxTracePath);
+            acpxMethodsBeforeRelease = (await readAcpTrace(acpxTracePath)).map(
+              (entry) => entry.method,
+            );
             expect(acpxMethodsBeforeRelease).toContain("turn/start");
             expect(acpxMethodsBeforeRelease).not.toContain("turn/interrupt");
           } finally {
@@ -581,7 +590,8 @@ describe("webhooks TaskFlow child cancellation authority", () => {
             backendId: "acpx",
           });
           const queuedTargetEntered = createDeferred();
-          const releaseQueuedTarget = createDeferred();
+          const queuedTurnOrder: string[] = [];
+          const queuedTargetEvents: AcpRuntimeEvent[] = [];
           const queuedTargetTurn = acpManager.runTurn({
             admittedRunContext: createTestAdmittedRunContext(queuedAcpRunId),
             cfg: config,
@@ -590,13 +600,32 @@ describe("webhooks TaskFlow child cancellation authority", () => {
             text: "Keep the target active while its same-id successor queues.",
             mode: "prompt",
             requestId: queuedAcpRunId,
-            onElicitation: async () => {
+            onElicitation: async (_request, context) => {
               queuedTargetEntered.resolve();
-              await releaseQueuedTarget.promise;
-              return { action: "accept", content: { question: "cancel target" } };
+              await new Promise<void>((resolve) => {
+                if (context.signal.aborted) {
+                  resolve();
+                  return;
+                }
+                context.signal.addEventListener("abort", () => resolve(), { once: true });
+              });
+              return { action: "cancel" };
+            },
+            onEvent: (event) => {
+              queuedTargetEvents.push(event);
+              if (event.type === "done" && event.status === "cancelled") {
+                queuedTurnOrder.push("target-cancelled");
+              }
             },
           });
           await queuedTargetEntered.promise;
+          const targetTurnStart = (await readAcpTrace(acpxTracePath)).findLast(
+            (entry) => entry.method === "turn/start",
+          );
+          expect(targetTurnStart).toMatchObject({
+            threadId: expect.any(String),
+            turnId: expect.any(String),
+          });
           const queuedFlowId = await createFlow(origin, "Cancel target before queued successor");
           await projectChild({
             origin,
@@ -605,11 +634,12 @@ describe("webhooks TaskFlow child cancellation authority", () => {
             childSessionKey: queuedAcpChild,
             runId: queuedAcpRunId,
           });
-          const interruptsBeforeQueuedCancel = (await readAcpTraceMethods(acpxTracePath)).filter(
-            (method) => method === "turn/interrupt",
+          const interruptsBeforeQueuedCancel = (await readAcpTrace(acpxTracePath)).filter(
+            (entry) => entry.method === "turn/interrupt",
           ).length;
           const queuedSuccessorEntered = createDeferred();
           const releaseQueuedSuccessor = createDeferred();
+          const queuedSuccessorEvents: AcpRuntimeEvent[] = [];
           const queuedSuccessorTurn = acpManager.runTurn({
             admittedRunContext: createTestAdmittedRunContext(queuedAcpRunId),
             cfg: config,
@@ -619,9 +649,13 @@ describe("webhooks TaskFlow child cancellation authority", () => {
             mode: "prompt",
             requestId: queuedAcpRunId,
             onElicitation: async () => {
+              queuedTurnOrder.push("successor-entered");
               queuedSuccessorEntered.resolve();
               await releaseQueuedSuccessor.promise;
               return { action: "accept", content: { question: "complete successor" } };
+            },
+            onEvent: (event) => {
+              queuedSuccessorEvents.push(event);
             },
           });
           const queuedCancelPromise = postWebhook(origin, {
@@ -630,28 +664,61 @@ describe("webhooks TaskFlow child cancellation authority", () => {
           });
           await vi.waitFor(
             async () => {
-              const interruptCount = (await readAcpTraceMethods(acpxTracePath)).filter(
-                (method) => method === "turn/interrupt",
+              const interruptCount = (await readAcpTrace(acpxTracePath)).filter(
+                (entry) => entry.method === "turn/interrupt",
               ).length;
               expect(interruptCount - interruptsBeforeQueuedCancel).toBeGreaterThan(0);
             },
             { interval: 10, timeout: 10_000 },
           );
-          releaseQueuedTarget.resolve();
           const queuedCancel = await queuedCancelPromise;
           expect(queuedCancel).toMatchObject({ status: 200, body: { ok: true } });
-          const interruptsAfterTargetCancel = (await readAcpTraceMethods(acpxTracePath)).filter(
-            (method) => method === "turn/interrupt",
-          ).length;
-          expect(interruptsAfterTargetCancel - interruptsBeforeQueuedCancel).toBeGreaterThan(0);
+          const interruptsAfterTargetCancel = (await readAcpTrace(acpxTracePath)).filter(
+            (entry) => entry.method === "turn/interrupt",
+          );
+          const targetInterrupts = interruptsAfterTargetCancel.slice(interruptsBeforeQueuedCancel);
+          expect(targetInterrupts).toEqual([
+            expect.objectContaining({
+              threadId: targetTurnStart?.threadId,
+              turnId: targetTurnStart?.turnId,
+            }),
+          ]);
           await queuedTargetTurn;
+          expect(queuedTargetEvents.at(-1)).toEqual({
+            type: "done",
+            status: "cancelled",
+            stopReason: "cancelled",
+          });
           await queuedSuccessorEntered.promise;
-          const interruptsWhileSuccessorActive = (await readAcpTraceMethods(acpxTracePath)).filter(
-            (method) => method === "turn/interrupt",
-          ).length;
-          expect(interruptsWhileSuccessorActive - interruptsAfterTargetCancel).toBe(0);
+          expect(queuedTurnOrder).toEqual(["target-cancelled", "successor-entered"]);
+          const successorTurnStart = (await readAcpTrace(acpxTracePath)).findLast(
+            (entry) => entry.method === "turn/start",
+          );
+          expect(successorTurnStart?.threadId).toBe(targetTurnStart?.threadId);
+          expect(successorTurnStart?.turnId).toEqual(expect.any(String));
+          expect(successorTurnStart?.turnId).not.toBe(targetTurnStart?.turnId);
           releaseQueuedSuccessor.resolve();
           await queuedSuccessorTurn;
+          expect(queuedSuccessorEvents.at(-1)).toEqual({
+            type: "done",
+            status: "completed",
+            stopReason: "end_turn",
+          });
+          expect(
+            queuedSuccessorEvents.filter(
+              (event) =>
+                event.type === "done" &&
+                (event.status === "cancelled" ||
+                  event.stopReason === "cancel" ||
+                  event.stopReason === "cancelled"),
+            ),
+          ).toHaveLength(0);
+          const interruptsAfterSuccessor = (await readAcpTrace(acpxTracePath)).filter(
+            (entry) => entry.method === "turn/interrupt",
+          );
+          expect(
+            interruptsAfterSuccessor.filter((entry) => entry.turnId === successorTurnStart?.turnId),
+          ).toHaveLength(0);
 
           console.info(
             "webhooks-taskflow-authority-proof",
@@ -690,9 +757,10 @@ describe("webhooks TaskFlow child cancellation authority", () => {
               acpQueuedSuccessor: {
                 transport: "process",
                 httpStatus: queuedCancel.status,
-                targetInterruptRequests: interruptsAfterTargetCancel - interruptsBeforeQueuedCancel,
-                successorInterruptRequests:
-                  interruptsWhileSuccessorActive - interruptsAfterTargetCancel,
+                targetInterruptRequests: targetInterrupts.length,
+                successorInterruptRequests: interruptsAfterSuccessor.filter(
+                  (entry) => entry.turnId === successorTurnStart?.turnId,
+                ).length,
                 successorStatus: "completed",
               },
             }),


### PR DESCRIPTION
Related: #136915

## What Problem This Solves

Closes the remaining cancellation-oracle blind spot from #136915. The process
fixture previously acknowledged `turn/interrupt` without faithfully settling
the target turn in Codex app-server protocol order.

This is test-support only. No production behavior changes.

## Why This Change Was Made

The fixture now terminalizes the exact active turn, fences its pending
elicitation continuation, and rejects mismatched, stale, or duplicate
interrupts. The line dispatcher writes the successful interrupt JSON-RPC
response before emitting exactly one interrupted `turn/completed`.

The existing process E2E records generated turn IDs and verifies the cancelled
target and queued successor through successor completion, so a stale target
request cannot silently affect the successor.

## User Impact

No production or user-visible behavior changes. Release validation now models
Codex interrupt ordering accurately and retains target/successor isolation
coverage.

## Evidence

### Scope

- Exact head: `bec49a6d417f073202781f9f09cf5e7e4eb77eca`
- Native refresh base: `8f9b0105143c3d0fba859ad1f843555ab17e19df`
- Previous reviewed head: `72fff896b0c16eb2d753746ec1fd06c46810097f`
- Stable patch ID: `ba8d0a9502ecc15b3756d0a51049737f6e1f6d7b`
- Signed refresh commit preserves both previous-head and current-main ancestry.
- Files:
  - `extensions/acpx/test/fixtures/codex-app-server.mjs`
  - `test/e2e/qa-lab/runtime/webhooks-taskflow-cancellation-authz.e2e.test.ts`
- Whole-PR LOC: production `+0/-0`; tests/test support `+180/-32` (net `+148`).
- No Code Mode or Talk files, strings, or behavior are present in the delta.

### Exact-Head Proof

Direct-wire JSON-RPC proof:

```json
{"verdict":"GREEN","threadsUnique":true,"turnsUnique":true,"mismatchError":-32600,"duplicateError":-32600,"interruptResponseIndex":9,"interruptedCompletionIndex":10,"targetCompletionStatuses":["interrupted"],"independentStatus":"completed","successorStatus":"completed"}
```

- Successful interrupt response precedes exactly one interrupted terminal.
- Mismatched and duplicate interrupts return `-32600`.
- Independent and queued successor turns complete normally.
- `git diff --check` passed.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/34760188939
  - passed with no failed jobs
- Exact-head ClawSweeper: https://github.com/openclaw/openclaw/pull/137049#issuecomment-5521230825
  - reviewed head `bec49a6d417f073202781f9f09cf5e7e4eb77eca`
  - ready for maintainer review
  - no findings

The patch-identical prior head passed ACPX `303/303`, focused process
elicitation `1/1`, manager cancellation `3/3`, private-QA build, and the
private-QA process E2E `1/1`.

Exact-head local dependency-backed reruns were attempted without installation.
The approved shared `node_modules` donor lacks declared links including
`@agentclientprotocol/codex-acp`, `import-meta-resolve`, and `smol-toml`.
ACPX reached 176 passing tests before dependency resolution stopped 16 suites;
the manager suite could not load. No install or donor mutation was performed;
exact-head hosted CI provides the complete dependency-backed proof.

### Dependency Contract

Personally inspected OpenAI Codex source at
`85c2d4d921688324334f2d91a62529c08d17d617`:

- `codex-rs/app-server/src/request_processors/turn_processor.rs:1581-1625`
  validates the exact active turn and defers ordinary interrupt responses until
  cancellation is observed.
- `codex-rs/app-server/src/bespoke_event_handling.rs:1224-1240` responds to
  pending interrupt requests before interrupted terminal handling.
- `codex-rs/app-server/src/bespoke_event_handling.rs:1406-1431` and
  `:1613-1635` emit terminal `turn/completed` with interrupted status.
- `codex-rs/app-server/src/bespoke_event_handling.rs:1674-1687` awaits the
  response send; there is no artificial response/completion delay.
- Contract tests:
  `codex-rs/app-server/tests/suite/v2/turn_interrupt.rs:104-122` and
  `codex-rs/app-server/tests/suite/v2/thread_queue.rs:898-921`.

### Review

Test-audit passed: response-before-terminal ordering, exact target validation,
and full-lifetime successor isolation are observable at the real fixture
process boundary.

Diff-scoped autoreview raised two P2 claims; both were rejected after source
verification:

1. Late elicitation responses cannot fall through into request handling:
   `codex-app-server.mjs:203-211` unconditionally consumes every id-only
   response and returns even when its waiter no longer exists.
2. Adding an artificial post-response delay would diverge from Codex. Codex
   awaits the response send and then immediately handles the interrupted
   terminal event; the fixture preserves that order, and the E2E asserts the
   target terminal before successor admission through successor completion.

No Testbox or Full Release Validation was used.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, credentials, auth details, raw tool output, system/developer prompts
scope: this two-file ACPX cancellation-oracle repair only

[assistant]
verified the exact worktree/base, read the required policies and complete touched files, and inspected the sibling OpenAI Codex app-server contract.

[assistant]
test-audit passed: the observable invariant is one interrupted target terminal before successor admission; the credible regression is the fixture acknowledging interruption while leaving input pending; existing trace-only coverage missed it; no production seam was needed.

[assistant]
implemented authoritative active-turn state, unique turn IDs, pending elicitation settlement, duplicate/stale rejection, continuation fencing, response-before-terminal ordering, and target/successor event assertions in only the two authorized test-support files.

[assistant]
direct-wire proof was green: the successful response preceded exactly one interrupted terminal, duplicate and mismatched interrupts returned `-32600`, and independent and queued successor turns completed normally.

[assistant]
the exact-head refresh preserved the reviewed patch and ancestry. hosted CI and ClawSweeper provide exact-head proof; local dependency-backed reruns were limited by missing links in the approved shared dependency donor, with no install performed.
````

</details>
<!-- agent-transcript:end -->
