### PR TITLE
fix(release): accept a per-version owner-approved Telegram waiver

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -34,7 +34,7 @@ on:
         default: false
         type: boolean
       telegram_waiver:
-        description: Explicit owner-approved Telegram integration waiver for stable 2026.8.1 only
+        description: Telegram waiver <target-version>-owner-approved for stable/full; requires release-owner approval
         required: false
         default: ""
         type: string

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -72,7 +72,7 @@ on:
         default: false
         type: boolean
       telegram_waiver:
-        description: Explicit owner-approved Telegram integration waiver for stable 2026.8.1 only
+        description: Telegram waiver <target-version>-owner-approved for stable/full; requires release-owner approval
         required: false
         default: ""
         type: string

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -318,10 +318,13 @@ keep Telegram selected by default. The existing
 deferral; it is rejected for `stable` and `full` and does not disable the focused
 `rerun_group=npm-telegram` workflow.
 
-Best effort is separate from an explicit omission. For the release owner's
-2026.8.1 exception, pass
-`-f telegram_waiver=2026.8.1-owner-approved`. This is accepted only when the
-actual target package is `2026.8.1` and the profile is `stable` or `full`.
+Best effort is separate from an explicit omission. With release-owner approval
+for the exact release, pass `-f telegram_waiver=<target-version>-owner-approved`
+(for example, `-f telegram_waiver=2026.9.1-owner-approved`). The value must name
+the validated target's actual `package.json` version in `YYYY.M.PATCH` form,
+the sealed candidate version must match, and the profile must be `stable` or
+`full`. Beta and other prerelease targets are rejected. Package-spec overrides
+must be exactly `openclaw@<target-version>`; blank specs select the sealed candidate.
 It omits source Telegram QA, Package Acceptance Telegram E2E, and the
 published-package Telegram E2E; their evidence states **waived / not run**,
 never passed. Telegram unit tests and every other selected gate remain active,

--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -337,8 +337,7 @@ export function validateReleaseCoveragePolicyBinding(plan, validationInputs = {}
   }
 }
 
-// The release owner approved only these Telegram integration omissions for
-// 2026.8.1. This declaration never turns a failed or unrun test into a pass.
+// Owner declarations bind omissions to one release; waived or unrun never means passed.
 export function normalizeReleaseTelegramWaiver({
   telegramWaiver,
   targetVersion,
@@ -354,11 +353,11 @@ export function normalizeReleaseTelegramWaiver({
     return "";
   }
   if (
-    telegramWaiver !== "2026.8.1-owner-approved" ||
-    targetVersion !== "2026.8.1" ||
+    telegramWaiver !== `${targetVersion}-owner-approved` ||
+    parseReleaseVersion(stringValue(targetVersion))?.baseVersion !== stringValue(targetVersion) ||
     !["stable", "full"].includes(releaseProfile)
   ) {
-    throw new Error("Telegram waiver requires owner-approved 2026.8.1 stable/full validation");
+    throw new Error("Telegram waiver requires an exact stable/full owner declaration");
   }
   if (candidateVersion !== undefined && candidateVersion !== targetVersion) {
     throw new Error("Telegram waiver target version differs from the release candidate");
@@ -390,10 +389,10 @@ export function normalizeReleaseTelegramWaiver({
   // the waived release exactly; a moving dist-tag does not establish version.
   if (
     [releasePackageSpec, packageAcceptancePackageSpec, npmTelegramPackageSpec].some(
-      (spec) => spec !== "" && spec !== "openclaw@2026.8.1",
+      (spec) => spec !== "" && spec !== `openclaw@${targetVersion}`,
     )
   ) {
-    throw new Error("Telegram waiver package overrides must be openclaw@2026.8.1");
+    throw new Error(`Telegram waiver package overrides must be openclaw@${targetVersion}`);
   }
   return telegramWaiver;
 }

--- a/scripts/lib/release-publish-children.sh
+++ b/scripts/lib/release-publish-children.sh
@@ -1163,8 +1163,8 @@ append_release_proof_to_github_release() {
   tarball="$(jq -er '.openclawNpmTarball | select(type == "string" and length > 0)' "${evidence_path}")"
   integrity="$(jq -er '.openclawNpmIntegrity | select(type == "string" and length > 0)' "${evidence_path}")"
 
-  if [[ "$(jq -r '.telegramWaiver // ""' "${evidence_path}")" == "2026.8.1-owner-approved" ]]; then
-    telegram_line="- Telegram integration checks: waived by the release owner for 2026.8.1 (source QA, Package Acceptance, published-package E2E); not run."
+  if [[ "$(jq -r '.telegramWaiver // ""' "${evidence_path}")" == "${release_version}-owner-approved" ]]; then
+    telegram_line="- Telegram integration checks: waived by the release owner for ${release_version} (source QA, Package Acceptance, published-package E2E); not run."
   elif [[ -n "${NPM_TELEGRAM_RUN_ID// }" ]]; then
     telegram_line="- npm Telegram beta E2E: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${NPM_TELEGRAM_RUN_ID}"
   else

--- a/test/scripts/find-reusable-release-validation.test.ts
+++ b/test/scripts/find-reusable-release-validation.test.ts
@@ -672,9 +672,9 @@ describe("scripts/github/find-reusable-release-validation.sh", () => {
     });
   });
 
-  it.each(["", "2026.8.1-owner-approved"])(
+  it.each(["", "2026.8.1", "2026.9.1"])(
     "reuses strict protected-tag evidence with Telegram waiver %j",
-    (telegramWaiver) => {
+    (version) => {
       const { clone, priorSha } = getSharedRepo();
       const trustedWorkflowRef = `release-publish/${VERIFIER_SHA.slice(0, 12)}-456`;
       const producerRef = `release-ci/${VERIFIER_SHA.slice(0, 12)}-122`;
@@ -683,12 +683,12 @@ describe("scripts/github/find-reusable-release-validation.sh", () => {
         targetSha: priorSha,
         trustedWorkflowRef,
         workflowRef: producerRef,
-        validationInputs: telegramWaiver
+        validationInputs: version
           ? {
               ...DEFAULT_INPUTS,
-              telegramWaiver,
-              targetVersion: "2026.8.1",
-              releasePackageSpec: "openclaw@2026.8.1",
+              telegramWaiver: `${version}-owner-approved`,
+              targetVersion: version,
+              releasePackageSpec: `openclaw@${version}`,
             }
           : DEFAULT_INPUTS,
       });

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -495,38 +495,49 @@ describe("full release execution plan", () => {
     },
   );
 
-  it("omits only the owner-waived Telegram child from stable package validation", () => {
-    const input = {
-      releaseProfile: "stable",
-      releasePackageSpec: "openclaw@2026.8.1",
-      targetVersion: "2026.8.1",
-      telegramWaiver: "2026.8.1-owner-approved",
-      children: {},
-    };
-    const ordinary = plan({ ...input, telegramWaiver: "" });
-    const waived = plan(input);
-    expect(
-      waived.children
-        .filter((plannedChild) => plannedChild.required)
-        .map((plannedChild) => plannedChild.key),
-    ).toEqual(
-      ordinary.children
-        .filter((plannedChild) => plannedChild.required && plannedChild.key !== "npmTelegram")
-        .map((plannedChild) => plannedChild.key),
-    );
-    expect(waived.gates).toEqual(ordinary.gates);
-    expect(
-      waived.children.find((plannedChild) => plannedChild.key === "npmTelegram"),
-    ).toMatchObject({
-      required: false,
-      selected: false,
-      result: "skipped",
-      runId: "",
-    });
-  });
+  it.each(["2026.8.1", "2026.9.1"])(
+    "omits only the owner-waived Telegram child for %s",
+    (version) => {
+      const input = {
+        releaseProfile: "stable",
+        releasePackageSpec: `openclaw@${version}`,
+        packageAcceptancePackageSpec: `openclaw@${version}`,
+        npmTelegramPackageSpec: `openclaw@${version}`,
+        targetVersion: version,
+        telegramWaiver: `${version}-owner-approved`,
+        children: {},
+      };
+      const ordinary = plan({ ...input, telegramWaiver: "" });
+      const waived = plan(input);
+      expect(
+        waived.children
+          .filter((plannedChild) => plannedChild.required)
+          .map((plannedChild) => plannedChild.key),
+      ).toEqual(
+        ordinary.children
+          .filter((plannedChild) => plannedChild.required && plannedChild.key !== "npmTelegram")
+          .map((plannedChild) => plannedChild.key),
+      );
+      expect(waived.gates).toEqual(ordinary.gates);
+      expect(
+        waived.children.find((plannedChild) => plannedChild.key === "npmTelegram"),
+      ).toMatchObject({
+        required: false,
+        selected: false,
+        result: "skipped",
+        runId: "",
+      });
+    },
+  );
 
   it.each([
     { telegramWaiver: "unknown" },
+    { telegramWaiver: "2026.9.1-owner-approved" },
+    { telegramWaiver: "2026.8.1-owner-approval" },
+    { targetVersion: "2026.9.1-beta.1", telegramWaiver: "2026.9.1-beta.1-owner-approved" },
+    { targetVersion: "2026.9.1-1", telegramWaiver: "2026.9.1-1-owner-approved" },
+    { targetVersion: "2026.13.1", telegramWaiver: "2026.13.1-owner-approved" },
+    { targetVersion: "2026.8.1 ", telegramWaiver: "2026.8.1 -owner-approved" },
     { targetVersion: "2026.8.2" },
     { targetVersion: "2026.8.1-beta.3" },
     { releaseProfile: "beta" },
@@ -555,45 +566,62 @@ describe("full release execution plan", () => {
     ).toThrow(/Telegram waiver/u);
   });
 
-  it("seals the Telegram waiver and exact version into the immutable plan", () => {
-    const waiver = { telegramWaiver: "2026.8.1-owner-approved", targetVersion: "2026.8.1" };
-    const artifact = executionPlan({ ...waiver, releaseProfile: "stable", children: {} }, waiver);
-    expect(validateReleaseExecutionPlanArtifact(artifact)).toMatchObject(waiver);
-    const changed = { ...artifact, targetVersion: "2026.8.2" };
-    expect(() => validateReleaseExecutionPlanArtifact(changed)).toThrow(/digest/u);
-    expect(() =>
-      validateReleaseExecutionPlanArtifact({
-        ...changed,
-        sha256: releaseExecutionPlanSha256(changed),
-      }),
-    ).toThrow(/Telegram waiver/u);
-    expect(() => validateReleaseExecutionPlanArtifact(artifact, { telegramWaiver: "" })).toThrow(
-      /Telegram waiver/u,
-    );
-    const candidate = candidateBinding();
-    expect(() =>
-      executionPlan(
+  it.each(["2026.8.1", "2026.9.1"])(
+    "seals the Telegram waiver and exact version %s into the immutable plan",
+    (version) => {
+      const waiver = { telegramWaiver: `${version}-owner-approved`, targetVersion: version };
+      const artifact = executionPlan({ ...waiver, releaseProfile: "stable", children: {} }, waiver);
+      expect(validateReleaseExecutionPlanArtifact(artifact)).toMatchObject(waiver);
+      for (const result of ["success", "failure"]) {
+        const claimed = {
+          ...artifact,
+          children: artifact.children.map((plannedChild) =>
+            plannedChild.key === "npmTelegram" ? { ...plannedChild, result } : plannedChild,
+          ),
+        };
+        expect(() =>
+          validateReleaseExecutionPlanArtifact({
+            ...claimed,
+            sha256: releaseExecutionPlanSha256(claimed),
+          }),
+        ).toThrow("Telegram waiver requires an unrun Telegram child");
+      }
+      const changed = { ...artifact, targetVersion: "2026.8.2" };
+      expect(() => validateReleaseExecutionPlanArtifact(changed)).toThrow(/digest/u);
+      expect(() =>
+        validateReleaseExecutionPlanArtifact({
+          ...changed,
+          sha256: releaseExecutionPlanSha256(changed),
+        }),
+      ).toThrow(/Telegram waiver/u);
+      expect(() => validateReleaseExecutionPlanArtifact(artifact, { telegramWaiver: "" })).toThrow(
+        /Telegram waiver/u,
+      );
+      const candidate = candidateBinding();
+      expect(() =>
+        executionPlan(
+          { ...waiver, releaseProfile: "stable", children: {} },
+          { ...waiver, attemptEvidenceVersion: 2, candidate, candidateRequest: candidate.request },
+        ),
+      ).toThrow("Telegram waiver target version differs from the release candidate");
+      const manifest = fullReleaseCandidateManifestFixture(candidateRequestInput());
+      manifest.package.version = version;
+      const matchingCandidate = buildFullReleaseCandidateBinding({
+        manifest,
+        artifact: candidate.evidenceArtifact,
+      });
+      const sealedCandidatePlan = executionPlan(
         { ...waiver, releaseProfile: "stable", children: {} },
-        { ...waiver, attemptEvidenceVersion: 2, candidate, candidateRequest: candidate.request },
-      ),
-    ).toThrow("Telegram waiver target version differs from the release candidate");
-    const manifest = fullReleaseCandidateManifestFixture(candidateRequestInput());
-    manifest.package.version = "2026.8.1";
-    const matchingCandidate = buildFullReleaseCandidateBinding({
-      manifest,
-      artifact: candidate.evidenceArtifact,
-    });
-    const sealedCandidatePlan = executionPlan(
-      { ...waiver, releaseProfile: "stable", children: {} },
-      {
-        ...waiver,
-        attemptEvidenceVersion: 2,
-        candidate: matchingCandidate,
-        candidateRequest: matchingCandidate.request,
-      },
-    );
-    expect(validateReleaseExecutionPlanArtifact(sealedCandidatePlan)).toMatchObject(waiver);
-  });
+        {
+          ...waiver,
+          attemptEvidenceVersion: 2,
+          candidate: matchingCandidate,
+          candidateRequest: matchingCandidate.request,
+        },
+      );
+      expect(validateReleaseExecutionPlanArtifact(sealedCandidatePlan)).toMatchObject(waiver);
+    },
+  );
 
   it("seals complete candidate producer evidence into attempt-aware plans", () => {
     const candidate = candidateBinding();

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2731,9 +2731,24 @@ describe("package acceptance workflow", () => {
   );
 
   it.each([
-    { name: "standalone FRV", fullReleasePreflight: true, independentProducer: true },
-    { name: "direct FRV", fullReleasePreflight: true, independentProducer: false },
-    { name: "historical NPM", fullReleasePreflight: false, independentProducer: false },
+    {
+      name: "standalone FRV",
+      fullReleasePreflight: true,
+      independentProducer: true,
+      version: "2026.8.1",
+    },
+    {
+      name: "direct FRV",
+      fullReleasePreflight: true,
+      independentProducer: false,
+      version: "2026.9.1",
+    },
+    {
+      name: "historical NPM",
+      fullReleasePreflight: false,
+      independentProducer: false,
+      version: "2026.8.1-beta.3",
+    },
   ])("carries the $name artifact owner without replacing publication authority", async (mode) => {
     const producerRunId = mode.independentProducer ? "333" : "111";
     const fullReleaseRunId = mode.fullReleasePreflight ? "111" : "222";
@@ -2772,7 +2787,7 @@ describe("package acceptance workflow", () => {
     const fixture = createReleasePublishFixture(
       {
         EXPECTED_PRODUCER_RUN_ID: producerRunId,
-        RELEASE_TAG: "v2026.8.1-beta.3",
+        RELEASE_TAG: `v${mode.version}`,
         TARGET_SHA: "d".repeat(40),
         OPENCLAW_NPM_RESUME_RUN_ID: "777",
         NPM_TELEGRAM_RUN_ID: "",
@@ -2832,6 +2847,7 @@ render_github_release_notes() { cp "$2" "$1"; printf '%s\\n' '{"verificationIncl
       JSON.stringify({
         openclawNpmTarball: "https://example.invalid/openclaw.tgz",
         openclawNpmIntegrity: "sha512-fixture",
+        ...(mode.fullReleasePreflight ? { telegramWaiver: `${mode.version}-owner-approved` } : {}),
       }),
     );
     const resume = fixture.run(
@@ -2868,6 +2884,11 @@ render_github_release_notes() { cp "$2" "$1"; printf '%s\\n' '{"verificationIncl
     );
     expect(proof.status, proof.stderr).toBe(0);
     const proofText = readFileSync(join(fixture.root, "release-verification.md"), "utf8");
+    expect(proofText).toContain(
+      mode.fullReleasePreflight
+        ? `Telegram integration checks: waived by the release owner for ${mode.version} (source QA, Package Acceptance, published-package E2E); not run.`
+        : "npm Telegram beta E2E: not supplied",
+    );
     expect
       .soft(proofText)
       .toContain(
@@ -7023,26 +7044,31 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     },
   );
 
-  it.each(["stable", "full"])(
-    "waives only Telegram integration lanes for approved %s 2026.8.1",
-    (profile) => {
-      const options = { telegramWaiver: "2026.8.1-owner-approved" };
-      const direct = runReleaseChecksInputValidation(profile, "false", "all", "false", "", options);
-      const umbrella = runFullReleaseInputValidation(profile, "false", options);
-      expect(direct.result.status, direct.result.stderr).toBe(0);
-      expect(umbrella.status, umbrella.stderr).toBe(0);
-      const output = readFileSync(direct.outputPath, "utf8");
-      expect(output).toContain("telegram_waiver=2026.8.1-owner-approved");
-      expect(output).toContain("qa_live_telegram_enabled=false");
-      expect(output).toContain("run_release_soak=true");
-      expect(output).toContain("skip_package_telegram_e2e=false");
-    },
-  );
+  it.each([
+    ["stable", "2026.8.1"],
+    ["full", "2026.8.1"],
+    ["stable", "2026.9.1"],
+    ["full", "2026.9.1"],
+  ])("waives only Telegram integration lanes for approved %s %s", (profile, version) => {
+    const options = { telegramWaiver: `${version}-owner-approved`, version };
+    const direct = runReleaseChecksInputValidation(profile, "false", "all", "false", "", options);
+    const umbrella = runFullReleaseInputValidation(profile, "false", options);
+    expect(direct.result.status, direct.result.stderr).toBe(0);
+    expect(umbrella.status, umbrella.stderr).toBe(0);
+    const output = readFileSync(direct.outputPath, "utf8");
+    expect(output).toContain(`telegram_waiver=${version}-owner-approved`);
+    expect(output).toContain("qa_live_telegram_enabled=false");
+    expect(output).toContain("run_release_soak=true");
+    expect(output).toContain("skip_package_telegram_e2e=false");
+  });
 
   it.each([
     { version: "2026.8.2" },
     { version: "2026.8.1-beta.3" },
     { telegramWaiver: "true" },
+    { telegramWaiver: "2026.9.1-owner-approved" },
+    { telegramWaiver: "2026.8.1-owner-approval" },
+    { version: "2026.9.1-beta.1", telegramWaiver: "2026.9.1-beta.1-owner-approved" },
     { rerunGroup: "npm-telegram" },
     { liveSuiteFilter: "qa-telegram" },
     { rerunGroup: "qa-live", liveSuiteFilter: "qa-live" },

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -1774,9 +1774,9 @@ describe("release CI summary child correlation", () => {
     },
   );
 
-  it.each(["", "2026.8.1-owner-approved"])(
+  it.each(["", "2026.8.1", "2026.9.1"])(
     "recomputes mixed-attempt evidence with Telegram waiver %j",
-    async (telegramWaiver) => {
+    async (version) => {
       const fixture = trustedMainPackageFixture({
         manifestVersion: 3,
         workflowSha: "a".repeat(40),
@@ -1808,7 +1808,9 @@ describe("release CI summary child correlation", () => {
         getRunAttemptJobs: (runId: string, runAttempt: number) => Array<Record<string, unknown>>;
         loadExecutionPlan: () => Record<string, unknown>;
       };
-      const waiver = telegramWaiver ? { telegramWaiver, targetVersion: "2026.8.1" } : {};
+      const waiver = version
+        ? { telegramWaiver: `${version}-owner-approved`, targetVersion: version }
+        : {};
       Object.assign(manifest.validationInputs, waiver);
       const plannedChild = {
         dispatchName: "Dispatch release checks",
@@ -1957,7 +1959,7 @@ describe("release CI summary child correlation", () => {
           runAttempt: 2,
         }),
       ]);
-      if (telegramWaiver) {
+      if (version) {
         delete manifest.validationInputs.telegramWaiver;
         await expect(validate()).rejects.toThrow(/Telegram waiver/u);
         Object.assign(manifest.validationInputs, waiver);
@@ -2999,22 +3001,25 @@ describe("release CI summary child correlation", () => {
     ).toThrow("selected child is missing from manifest: NPM Telegram Beta E2E");
   });
 
-  it("validates the release-specific Telegram waiver before changing package child coverage", () => {
-    const raw = rawManifest({});
-    raw.releaseProfile = "stable";
-    Object.assign(raw.validationInputs, {
-      telegramWaiver: "2026.8.1-owner-approved",
-      targetVersion: "2026.8.1",
-      releasePackageSpec: "openclaw@2026.8.1",
-    });
-    const expected = { runAttempt: 2, runId: "29090000000" };
-    const manifest = validateParentManifest(raw, expected);
-    expect(
-      requiredChildKeysForRerunGroup(manifest.rerunGroup, manifest.validationInputs),
-    ).not.toContain("npmTelegram");
-    raw.validationInputs.targetVersion = "2026.8.2";
-    expect(() => validateParentManifest(raw, expected)).toThrow(/Telegram waiver/u);
-  });
+  it.each(["2026.8.1", "2026.9.1"])(
+    "validates the Telegram waiver for %s before changing package child coverage",
+    (version) => {
+      const raw = rawManifest({});
+      raw.releaseProfile = "stable";
+      Object.assign(raw.validationInputs, {
+        telegramWaiver: `${version}-owner-approved`,
+        targetVersion: version,
+        releasePackageSpec: `openclaw@${version}`,
+      });
+      const expected = { runAttempt: 2, runId: "29090000000" };
+      const manifest = validateParentManifest(raw, expected);
+      expect(
+        requiredChildKeysForRerunGroup(manifest.rerunGroup, manifest.validationInputs),
+      ).not.toContain("npmTelegram");
+      raw.validationInputs.targetVersion = "2026.8.2";
+      expect(() => validateParentManifest(raw, expected)).toThrow(/Telegram waiver/u);
+    },
+  );
 
   it.each([
     { label: "legacy manifest", version: 3 },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Full Release Validation rejects the release owner's approved Telegram omission for stable 2026.9.1 because the existing declaration is hardcoded to 2026.8.1.

The release owner, Peter, explicitly approved waiving Telegram integration lanes for 2026.9.1 because the Telegram Test Server QA credential pool is broken: the tester lost group write access. Related: #136986 (credential readiness/writeability failure), #136988 (readiness repair), and #133321 (the original 2026.8.1 waiver).

## Why This Change Was Made

The existing `telegram_waiver` input now accepts exactly `<target-version>-owner-approved`, bound to the validated target's `package.json` version in `YYYY.M.PATCH` form and to any sealed candidate. Only stable/full profiles qualify; prereleases, version mismatches, wrong suffixes, conflicting Telegram selectors, and package overrides other than `openclaw@<target-version>` are rejected. Each declaration requires release-owner approval for that exact release.

The shared policy remains the single normalization owner. State, summary, and reusable-validation consumers already use it and retain exact input/plan binding; their regression coverage now includes both 2026.8.1 and 2026.9.1. Publication compares the verified release version and renders that version in waiver notes. Both workflow input descriptions and the release-validation docs explain the declaration. No additional config or environment surface is introduced.

## User Impact

For the approved 2026.9.1 validation, pass `-f telegram_waiver=2026.9.1-owner-approved` with `release_profile=stable` (or `full`) and the exact 2026.9.1 target. Leave package overrides blank for the sealed candidate, or pin them to `openclaw@2026.9.1`. Keep `skip_package_telegram_e2e=false`; that separate input remains beta-only.

Source Telegram QA, Package Acceptance Telegram E2E, and published-package Telegram E2E are recorded as **waived / not run**, never passed. Telegram unit tests, other selected gates, stable soak, performance, and publication identity checks remain unchanged. No release is dispatched or published by this PR.

## Evidence

Four new 2026.9.1 regression cases failed against the old policy and passed after the change. The six affected suites passed all 995 tests; after the lint-only callback rename, the state suite passed all 283 tests. A clean rebase preserved the patch byte-for-byte, and the complete six-file run passed all 995 tests again on head `195f18eea09da96b4b799753ccef5dd393a8b718`.

```sh
pnpm test test/scripts/full-release-validation-state.test.ts test/scripts/find-reusable-release-validation.test.ts test/scripts/package-acceptance-workflow.test.ts test/scripts/release-ci-summary.test.ts test/scripts/package-source-preflight.test.ts test/scripts/release-no-push-workflow.test.ts
pnpm check:changed
git diff --check
```

- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P2`: scoped-clean, no accepted/actionable P0–P2 findings.
- `pnpm check:changed`: passed after correcting a shadowed callback name in the new test.
- SHA-pinned helper parser + shared-policy probe: passed; forwards the exact 2026.9.1 declaration and accepts a matching stable candidate without dispatching.
- Policy tests also reject tampered waived children claiming success or failure; workflow tests execute the actual input-validation shell and publication-note renderer.
- `pnpm check:workflows`: actionlint passed; the command then stopped because its Python bootstrap could not obtain `pre-commit==4.6.2`. Zizmor remains unproven. The CI git-owner, composite-input-interpolation, and conflict-marker guards passed separately.
- `shellcheck scripts/lib/release-publish-children.sh`: reports nine pre-existing sourced-library diagnostics (SC2034/SC2153/SC2154), identical to the base revision; no new diagnostics.
- Production scripts: +8/-9, net **-1**. Workflow descriptions: +2/-2. Tests: +171/-112. Docs: +7/-4.

Hosted Full Release Validation and live Telegram were not run. The broken external credential pool still needs repair; this change records the approved omission and does not repair or certify that pool.

Separate existing follow-up found during publication inspection: the postpublish verifier rejects a correction tag whose source package retains the base version (`scripts/lib/release-beta-verifier.ts`, `verifyBetaRelease`), despite earlier same-source correction identity handling. That path stops before waiver notes and is outside this stable-version policy change.
