### PR TITLE
fix: prevent macOS crashes when cookie sync is enabled

### DIFF
--- a/apps/macos/Sources/OpenClaw/CookieSyncManager.swift
+++ b/apps/macos/Sources/OpenClaw/CookieSyncManager.swift
@@ -29,7 +29,6 @@ final class CookieSyncManager: NSObject {
     private(set) var lastSummary: String?
 
     @ObservationIgnored private let logger = Logger(subsystem: "ai.openclaw", category: "cookie-sync")
-    @ObservationIgnored private let queue = DispatchQueue(label: "ai.openclaw.cookie-sync")
     @ObservationIgnored private weak var appState: AppState?
     @ObservationIgnored private var endpointState: GatewayEndpointState?
     @ObservationIgnored private var endpointTask: Task<Void, Never>?
@@ -273,17 +272,15 @@ final class CookieSyncManager: NSObject {
     }
 
     private func installStartupWatchdog(generation: UUID) {
-        let timer = DispatchSource.makeTimerSource(queue: self.queue)
+        let timer = DispatchSource.makeTimerSource(queue: .main)
         timer.schedule(deadline: .now() + 5)
         timer.setEventHandler { [weak self] in
-            Task { @MainActor [weak self] in
-                guard let self, self.processGeneration == generation else { return }
-                self.startupWatchdog?.cancel()
-                self.startupWatchdog = nil
-                if self.process?.isRunning == true {
-                    self.retryAttempt = 0
-                    self.logger.debug("cookie sync startup watchdog passed")
-                }
+            guard let self, self.processGeneration == generation else { return }
+            self.startupWatchdog?.cancel()
+            self.startupWatchdog = nil
+            if self.process?.isRunning == true {
+                self.retryAttempt = 0
+                self.logger.debug("cookie sync startup watchdog passed")
             }
         }
         self.startupWatchdog = timer

--- a/apps/macos/Tests/OpenClawIPCTests/CookieSyncManagerWatchdogGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CookieSyncManagerWatchdogGuardTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Testing
+
+struct CookieSyncManagerWatchdogGuardTests {
+    @Test func `startup watchdog runs on the main actor queue`() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let packageRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let managerFile = packageRoot
+            .appendingPathComponent("Sources/OpenClaw/CookieSyncManager.swift")
+        let source = try String(contentsOf: managerFile, encoding: .utf8)
+        let start = try #require(source.range(of: "    private func installStartupWatchdog"))
+        let following = source[start.upperBound...]
+        let end = try #require(following.range(of: "\n    private func "))
+        let watchdog = source[start.lowerBound..<end.lowerBound]
+
+        #expect(watchdog.contains("DispatchSource.makeTimerSource(queue: .main)"))
+    }
+}


### PR DESCRIPTION
Closes #134430

## What Problem This Solves

Fixes an issue where users running the macOS app in remote mode with Cookie Sync enabled could hit a Swift MainActor isolation trap several seconds after the watcher started, causing the app to crash-loop.

## Why This Change Was Made

The startup watchdog was created on a private dispatch queue inside a `@MainActor` manager. Its event handler inherited main-actor isolation, so Swift could trap at closure entry before the nested `Task { @MainActor ... }` had a chance to run. The watchdog now runs directly on the main queue and updates actor-owned state without the unreachable extra hop.

The stdout/stderr readers and `Process.terminationHandler` remain unchanged: focused runtime probes and their existing lifecycle tests show those sibling callback paths already deliver correctly.

## User Impact

Cookie Sync can remain enabled in remote mode without crashing the macOS app when the five-second startup watchdog fires. This does not change configuration, schema, protocol, credentials, retry policy, or cookie-sync CLI arguments.

## Evidence

### Maintainer continuation (September 16)

The contributor watchdog correction is composed with current main, preserving the original PR head as an ancestor. The only product delta is the main-queue watchdog and removal of its redundant actor hop/private queue (production **-3 lines**, focused guard **+21 lines**). Current `isAvailable`, stop/generation checks, retry policy, reader callbacks and cookie policy remain unchanged.

The complete baseline manager and reader on main `b5eb58956fa1557eb2ddd456dfe405c2878590fc` exactly match the retained native-proof inputs; the integrated manager and guard exactly match the retained passing candidate. Six native Swift/Foundation lifecycle cases (46 assertions) and the Swift Testing guard are **historical retained evidence**, not current-head CI. Their inspectable results and bindings are in [the maintainer proof comment](https://github.com/openclaw/openclaw/pull/137052#issuecomment-5705374334).

Current-toolchain check: Apple Command Line Tools Swift 6.4, explicit macOS SDK and macOS 14 deployment target, `-swift-version 6 -strict-concurrency=complete -enable-actor-data-race-checks -D DEBUG -typecheck` on the complete integrated manager and real `PipeReadStream`, with synthetic app/endpoint support: **exit 0**. The only warning comes from the synthetic endpoint stub's synchronous `subscribe` implementation. No operator cookies, real remote endpoint, Xcode-license change, or app deployment was used.

Native SDK inspection closes the prior review's declaration gap: `DispatchSourceHandler = @convention(block) () -> Void` is not `@Sendable`, while `NSTask.terminationHandler` is declared `NS_SWIFT_SENDABLE`. The unchanged reader callback is explicitly `@Sendable` and invoked on its supplied `.main` queue. This supports repairing the remaining timer at its owner without changing the working siblings.

Published integration: `bfb5bc69a235bfeed280cc39e8ddb82558677553`. Fresh independent review completed with no actionable source findings; its rejected baseline/candidate-hash identification is documented in the [proof comment](https://github.com/openclaw/openclaw/pull/137052#issuecomment-5705374334). Exact-head [CI35156971253](https://github.com/openclaw/openclaw/actions/runs/35156971253) (including macOS Swift tests) and [Workflow Sanity35156971330](https://github.com/openclaw/openclaw/actions/runs/35156971330) completed successfully. The refreshed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/137052#issuecomment-5521253122) accepts the native proof and reports no actionable findings. Historical proof was not replayed or relabeled as current-head CI.

### Original contributor evidence (historical)

### Before

A Swift 6 strict-concurrency reproduction using the original callback shape on a private serial queue consistently terminated with `Trace/BPT trap: 5` and exit code 133. The same inherited MainActor callback on `DispatchQueue.main` printed:

```text
watchdog delivered: true
survived
```

The unchanged `Process.terminationHandler` sibling independently printed:

```text
termination delivered: true, status: 0
survived
```

### Real macOS app path

A real OpenClaw macOS process was launched with an isolated profile, remote mode, Cookie Sync enabled for `x.com`, a synthetic direct endpoint, and an executable CLI fixture. The fixture received the production command, emitted both output streams, stayed alive beyond the five-second watchdog, and exited normally after eight seconds:

```text
PASS: real OpenClaw process survived the five-second watchdog boundary and child termination (child_lifetime=8s)
cookie sync started for 1 domain(s)
cookie sync: cookie-sync-proof-stdout
cookie sync stderr: <private>
child-start argv=browser cookie-sync --watch --domains x.com --into proof
child-exit status=0
cookie sync started for 1 domain(s)
```

The app was still alive at 11 seconds and had started the retry child. A sanitized real settings-window screenshot was also inspected after the same isolated app remained alive for more than two minutes; the local GitHub CLI does not support attachment upload, so no local-only path is included here.

### Automated checks

- Focused Swift tests: 4 tests in 2 suites passed (`CookieSyncManagerWatchdogGuardTests` and `PipeReadStreamTests`).
- Changed-file gate passed, including Swift formatting/lint, all three macOS CI test groups, and repository guards.

