### PR TITLE
fix(macos): preserve partial direct Gateway URL input

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -159,6 +159,36 @@ struct AppStateRemoteConfigTests {
     }
 
     @Test
+    func `partial direct URL remains editable after config sync`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(
+            env: ["OPENCLAW_CONFIG_PATH": configPath],
+            defaults: [connectionModeKey: AppState.ConnectionMode.remote.rawValue])
+        {
+            #expect(OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "transport": "direct",
+                    ],
+                ],
+            ]))
+            let state = AppState(preview: true)
+            state._testEnableGatewayConfigSync()
+
+            state.remoteUrl = "w"
+            await state._testAwaitGatewayConfigSync()
+
+            #expect(state.remoteUrl == "w")
+            #expect(state._testDirtyGatewayConfigFields == ["gateway.remote.url"])
+            #expect(!state._testGatewayConfigIsCurrentForRouting)
+            let remote = (OpenClawConfigFile.loadDict()["gateway"] as? [String: Any])?["remote"]
+                as? [String: Any]
+            #expect(remote?["url"] == nil)
+        }
+    }
+
+    @Test
     func `invalid remote edit retires the prior canonical gateway route`() async {
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withIsolatedState(


### PR DESCRIPTION
Related: #136863

Superseded by #136983 (`f06d6f4913ffa7ba8db3bed1bf84d3cf4cfd0bec`).

## What Problem This Solves

This PR added a regression test for the macOS Direct Gateway URL field clearing incomplete keyboard input during onboarding.

## Why This Change Was Made

Current `main` now contains the complete owner-boundary repair from #136983. That change projects the actual incomplete URL draft during config reconciliation while retaining the existing persistence gate, and it includes broader coverage for consecutive partial inputs, existing saved URLs, unrelated external edits, same-field conflicts, and conflict recovery.

The test in this PR is therefore redundant and no production change should be added here.

## User Impact

No additional user impact beyond #136983. Users on current `main` can type partial `ws://` and `wss://` Gateway URLs without config sync erasing the field.

## Evidence

- Canonical fix: #136983, merged as `f06d6f4913ffa7ba8db3bed1bf84d3cf4cfd0bec` and linked to close #136863.
- Current-main source replaces the skip-invalid projection with the normalized URL when available and otherwise the actual draft; `gatewayDraftCanPersist` still prevents incomplete URLs from reaching the config saver.
- Current-main tests cover partial prefixes with and without a previously saved URL, completion and persistence, routing remaining unavailable while incomplete, unrelated external token adoption, external URL conflict detection, rejected “Keep my edits,” and “Use file” recovery.
- This PR's exact-head CI merge ref collected `partial direct URL remains editable after config sync` and passed after including the canonical fix: https://github.com/openclaw/openclaw/actions/runs/33721094911/job/100540424297
- The canonical PR includes inspected native macOS before/after evidence and exact-head CI proof: https://github.com/openclaw/openclaw/pull/136983
