### PR TITLE
test(heartbeat): reuse canonical mock call guards

### DIFF
--- a/src/infra/heartbeat-runner.response-prefix-template.test.ts
+++ b/src/infra/heartbeat-runner.response-prefix-template.test.ts
@@ -1,4 +1,5 @@
 // Tests heartbeat runner response prefix template handling.
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { runHeartbeatOnce, type HeartbeatDeps } from "./heartbeat-runner.js";
@@ -52,14 +53,6 @@ describe("runHeartbeatOnce responsePrefix templates", () => {
     });
   }
 
-  function requireFirstMockCall<T>(mock: { mock: { calls: T[][] } }, label: string): T[] {
-    const call = mock.mock.calls[0];
-    if (!call) {
-      throw new Error(`expected ${label} call`);
-    }
-    return call;
-  }
-
   async function runTemplatedHeartbeat(params: { responsePrefix: string; replyText: string }) {
     return withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createTelegramHeartbeatConfig({
@@ -102,7 +95,10 @@ describe("runHeartbeatOnce responsePrefix templates", () => {
     });
 
     expect(sendTelegram).toHaveBeenCalledTimes(1);
-    const [target, message, options] = requireFirstMockCall(sendTelegram, "telegram send");
+    const [target, message, options] = expectDefined(
+      sendTelegram.mock.calls[0],
+      "telegram send call",
+    );
     expect(target).toBe(TELEGRAM_GROUP);
     expect(message).toBe("[openai/gpt-5.4|think:high] Heartbeat alert");
     expect(typeof options).toBe("object");

--- a/src/infra/heartbeat-runner.subagent-session-guard.test.ts
+++ b/src/infra/heartbeat-runner.subagent-session-guard.test.ts
@@ -1,5 +1,6 @@
 // Tests heartbeat runner guardrails for subagent sessions.
 import fs from "node:fs/promises";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
@@ -17,14 +18,6 @@ installHeartbeatRunnerTestRuntime();
 afterEach(() => {
   resetSystemEventsForTest();
 });
-
-function requireFirstMockCall<T>(mock: { mock: { calls: T[][] } }, label: string): T[] {
-  const call = mock.mock.calls[0];
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call;
-}
 
 describe("runHeartbeatOnce", () => {
   it("falls back to the main session when a subagent session key is forced", async () => {
@@ -86,10 +79,10 @@ describe("runHeartbeatOnce", () => {
       });
 
       expect(replySpy).toHaveBeenCalledTimes(1);
-      const [replyParams, _replyRuntime, replyConfig] = requireFirstMockCall(
-        replySpy,
-        "reply",
-      ) as Parameters<typeof replySpy>;
+      const [replyParams, _replyRuntime, replyConfig] = expectDefined(
+        replySpy.mock.calls[0],
+        "reply call",
+      );
       expect(replyParams?.SessionKey).toBe(mainSessionKey);
       expect(replyParams?.OriginatingChannel).toBeUndefined();
       expect(replyParams?.OriginatingTo).toBeUndefined();
@@ -155,7 +148,7 @@ describe("runHeartbeatOnce", () => {
       });
 
       expect(replySpy).toHaveBeenCalledTimes(1);
-      const [replyParams] = requireFirstMockCall(replySpy, "reply") as Parameters<typeof replySpy>;
+      const [replyParams] = expectDefined(replySpy.mock.calls[0], "reply call");
       expect(replyParams?.SessionKey).toBe(mainSessionKey);
       expect(replyParams?.Body).toContain("async command completion event");
       expect(peekSystemEventEntries(mainSessionKey)).toStrictEqual([]);


### PR DESCRIPTION
## What Problem This Solves

Two heartbeat test files duplicate the same first-mock-call guard. The local helpers widen argument tuples, forcing the subagent tests to cast the rows back to their original types.

## Why This Change Was Made

Use the existing `expectDefined` helper on each `mock.calls[0]` row. This preserves the missing-call failure while retaining the actual tuple type, removing both helper copies and two casts.

## User Impact

Test maintenance only: production code is unchanged and the test diff is 11 lines smaller. All four heartbeat cases keep their exact prefix, ACK suppression, session routing, originating-context, config identity, prompt, and event-consumption assertions.

## Evidence

The same five-file canonical invocation passed all 10 cases before and after the change:

```sh
node scripts/run-vitest.mjs \
  src/infra/heartbeat-runner.response-prefix-template.test.ts \
  src/infra/heartbeat-runner.subagent-session-guard.test.ts \
  src/infra/heartbeat-runner.sender-prefers-delivery-target.test.ts \
  src/infra/heartbeat-runner.session-state.test.ts \
  packages/normalization-core/src/expect.test.ts
```

The full configured two-path changed gate passed all 20 stages, including infra typechecking, typed lint, and the three dead-export scans. Independent Codex review was clean through P2. Direct Vitest source and type inspection confirmed that mock-call rows retain their argument tuples and are absent before any call.

Named follow-up: audit the subagent test's existing JSON session fixtures against the canonical SQLite seeder. This cleanup preserves those fixtures and their lifecycle.
