### PR TITLE
docs: embed dashboard demo video

### DIFF
--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -44,6 +44,18 @@ state, so each browser can keep its own working layout.
 
 ## Build a dashboard by asking
 
+Watch Patrick Erichsen build an OpenClaw 2.0 release dashboard from one prompt:
+
+<iframe
+  className="w-full aspect-video rounded-lg"
+  src="https://www.youtube-nocookie.com/embed/gHyBueWideg"
+  title="Build an OpenClaw Dashboard with One Prompt"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
+></iframe>
+
 Ask your agent for what you want to see:
 
 > Create a widget named revenue-graph: an interactive bar chart of monthly


### PR DESCRIPTION
## What Problem This Solves

The session dashboards guide explains how to build a dashboard by asking, but it does not show the workflow in action.

## Why This Change Was Made

Embeds the official two-minute OpenClaw 2.0 dashboard demo directly in the canonical “Build a dashboard by asking” section. The responsive Mintlify iframe uses YouTube’s privacy-enhanced embed host.

## User Impact

Readers can watch Patrick Erichsen create a release dashboard from one prompt without leaving the dashboard guide.

## Evidence

- Public source video: https://youtu.be/gHyBueWideg
- `node scripts/check-docs-mdx.mjs docs/web/dashboards.md`
- `git diff --check`
- Production desktop and mobile verification will follow after merge and docs deployment.