### PR TITLE
fix(ci): route changed-scope updates through Windows CI

### DIFF
--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -253,6 +253,7 @@ export function detectChangedScope(changedPaths) {
     }
 
     if (
+      path === "scripts/ci-changed-scope.mjs" ||
       windowsCiTests.has(path) ||
       WINDOWS_LAN_ADVERTISEMENT_SCOPE_RE.test(path) ||
       WINDOWS_FILE_URL_SCOPE_RE.test(path) ||

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -594,7 +594,10 @@ export function detectNodeFastScope(changedPaths) {
     runPluginContracts ||= NODE_FAST_PLUGIN_CONTRACT_SCOPE_RE.test(path);
     runCiRouting ||= NODE_FAST_CI_ROUTING_SCOPE_RE.test(path);
 
-    if (!NODE_FAST_SCOPE_RE.test(path)) {
+    // The scope router owns native-lane selection; its edits must exercise that lane.
+    const isScopeOwnerPath =
+      path === "scripts/ci-changed-scope.mjs" || path === "src/scripts/ci-changed-scope.test.ts";
+    if (!NODE_FAST_SCOPE_RE.test(path) || isScopeOwnerPath) {
       return { runFastOnly: false, runPluginContracts: false, runCiRouting: false };
     }
   }

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -832,13 +832,11 @@ describe("detectChangedScope", () => {
     expect(
       detectNodeFastScope([
         "scripts/check-changed.mjs",
-        "scripts/ci-changed-scope.mjs",
         "scripts/run-vitest.mts",
         "scripts/test-projects.test-support.mts",
         "src/commands/status.scan-result.test.ts",
         "src/scripts/ci-changed-scope.control-ui.test.ts",
         "src/scripts/ci-changed-scope.native-i18n.test.ts",
-        "src/scripts/ci-changed-scope.test.ts",
         "src/scripts/ci-changed-scope.windows.test.ts",
         "test/scripts/changed-lanes.test.ts",
         "test/scripts/run-vitest.test.ts",
@@ -849,6 +847,16 @@ describe("detectChangedScope", () => {
       runFastOnly: true,
       runPluginContracts: false,
       runCiRouting: true,
+    });
+  });
+
+  it("routes scope-owner edits out of fast-only CI so Windows coverage runs", () => {
+    expect(
+      detectNodeFastScope(["scripts/ci-changed-scope.mjs", "src/scripts/ci-changed-scope.test.ts"]),
+    ).toEqual({
+      runFastOnly: false,
+      runPluginContracts: false,
+      runCiRouting: false,
     });
   });
 

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -620,7 +620,7 @@ describe("detectChangedScope", () => {
       runMacosNode: false,
       runIosBuild: false,
       runAndroid: false,
-      runWindows: false,
+      runWindows: true,
       runSkillsPython: false,
       runChangedSmoke: true,
       runControlUiI18n: false,

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -10363,6 +10363,34 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     },
   );
 
+  it("routes changed-scope owner edits through the Windows manifest matrix", () => {
+    const changedPaths = ["scripts/ci-changed-scope.mjs", "src/scripts/ci-changed-scope.test.ts"];
+    const scopeEnv = Object.fromEntries(
+      Object.entries(runCiChangedScopeFixture(changedPaths)).map(([key, value]) => [
+        "OPENCLAW_CI_" + key.toUpperCase(),
+        value,
+      ]),
+    );
+    const manifest = runCiManifestFixture({
+      bundledPlanner: true,
+      eventName: "pull_request",
+      historicalCompatibility: false,
+      changedPaths,
+      scopeEnv: { ...scopeEnv, OPENCLAW_CI_DOCS_CHANGED: "false" },
+    });
+
+    expect(manifest.status, manifest.output).toBe(0);
+    expect(scopeEnv.OPENCLAW_CI_RUN_WINDOWS).toBe("true");
+    expect(scopeEnv.OPENCLAW_CI_RUN_NODE_FAST_ONLY).toBe("false");
+    expect(manifest.outputs.run_checks_windows).toBe("true");
+    expect(
+      JSON.parse(expectDefined(manifest.outputs.checks_windows_matrix, "Windows matrix")).include,
+    ).toEqual([
+      { check_name: "checks-windows-node-test-1", runtime: "node", task: "test-1" },
+      { check_name: "checks-windows-node-test-2", runtime: "node", task: "test-2" },
+    ]);
+  });
+
   it.each<{
     label: string;
     changedPath: string;


### PR DESCRIPTION
<!-- Source-first CI bug fix; no public issue is linked. -->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where changes to the CI changed-scope router could alter Windows CI selection without running the Windows lane itself, allowing a Windows routing regression to merge without platform coverage.

## Why This Change Was Made

The changed-scope router now routes its own changes through Windows CI. Scope-owner edits are excluded from the fast-only Node classification so the downstream CI manifest preserves the Windows matrix. The fix stays at the scope owner and does not broaden unrelated Windows path rules or change any Windows test commands.

## User Impact

CI changes that affect Windows lane selection now receive Windows-specific validation before merge.

## Evidence

- After-fix real behavior proof at the current head: `detectChangedScope(["scripts/ci-changed-scope.mjs", "src/scripts/ci-changed-scope.test.ts"])` reports `runWindows: true`, `runNode: true`, and `detectNodeFastScope(...)` reports `runFastOnly: false`. Inspectable output: `{"runWindows":true,"runNodeFastOnly":false,"runNode":true}`.
- Manifest-level regression proof: `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t "routes changed-scope owner edits through the Windows manifest matrix"` - `1 passed`.
- Focused scope-router tests: `node scripts/run-vitest.mjs src/scripts/ci-changed-scope.test.ts` - `96 passed`.
- `oxfmt --check scripts/ci-changed-scope.mjs src/scripts/ci-changed-scope.test.ts test/scripts/ci-workflow-guards.test.ts` passed.
- `git diff --check` passed.
- Proof boundary: this verifies the changed-scope producer, fast-only classification, and CI manifest Windows matrix selection; it does not claim that a hosted Windows runner was executed locally.
- Exact head: `652ed6140dbea29b433c8a639fbdd5f2e86179c3`.