### PR TITLE
improve(android): verify gateway auth recovery

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -52,12 +53,14 @@ private const val LIFECYCLE_TEST_TIMEOUT_MS = 8_000L
 private const val LIFECYCLE_CONNECT_CHALLENGE_FRAME =
   """{"type":"event","event":"connect.challenge","payload":{"nonce":"android-test-nonce","ts":1700000000123}}"""
 
-private class ReconnectDeviceAuthStore : DeviceAuthTokenStore {
+private class ReconnectDeviceAuthStore(
+  private val entry: DeviceAuthEntry? = null,
+) : DeviceAuthTokenStore {
   override fun loadEntry(
     gatewayId: String,
     deviceId: String,
     role: String,
-  ): DeviceAuthEntry? = null
+  ): DeviceAuthEntry? = entry
 
   override fun saveToken(
     gatewayId: String,
@@ -143,6 +146,7 @@ private data class TerminalCallbackObservation(
 private data class ReconnectServer(
   val server: MockWebServer,
   val sockets: ConcurrentLinkedQueue<WebSocket>,
+  val requestFrames: ConcurrentLinkedQueue<JsonObject>,
 ) {
   val port: Int
     get() = server.port
@@ -1037,6 +1041,98 @@ class GatewaySessionReconnectTest {
     }
 
   @Test
+  fun passwordMissingFromStoredDeviceTokenPausesAndExplicitReconnectSucceeds() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val connectFailure = CompletableDeferred<Pair<GatewaySession.ErrorShape, Boolean>>()
+      val secondAttempt = CompletableDeferred<Unit>()
+      val reconnected = CompletableDeferred<Unit>()
+      val connectAttempts = AtomicInteger()
+      val storedToken = "stored-device-token"
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method != "connect") return@startGatewayServer
+          when (connectAttempts.incrementAndGet()) {
+            1 -> {
+              webSocket.send(
+                """{"type":"res","id":"$id","ok":false,"error":{"code":"INVALID_REQUEST","message":"gateway password required","details":{"code":"AUTH_PASSWORD_MISSING"}}}""",
+              )
+            }
+
+            else -> {
+              secondAttempt.complete(Unit)
+              webSocket.send(connectResponseFrame(id))
+            }
+          }
+        }
+      val authStore =
+        ReconnectDeviceAuthStore(
+          DeviceAuthEntry(
+            token = storedToken,
+            role = "node",
+            scopes = listOf("node:invoke"),
+            updatedAtMs = 1,
+          ),
+        )
+      val harness =
+        createReconnectHarness(
+          onConnected = { reconnected.complete(Unit) },
+          deviceAuthStore = authStore,
+          onConnectFailure = { error, pauseReconnect ->
+            connectFailure.complete(error to pauseReconnect)
+          },
+        )
+
+      try {
+        connectNodeSession(harness.session, server.port, token = null)
+        val (error, pauseReconnect) =
+          withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connectFailure.await() }
+        val desiredConnection = readField<Any>(harness.session, "desired")
+
+        assertEquals("AUTH_PASSWORD_MISSING", error.details?.code)
+        assertTrue(pauseReconnect)
+        assertTrue(readField<Boolean>(desiredConnection, "reconnectPausedForAuthFailure"))
+        val firstAuth =
+          server.requestFrames
+            .first { it["method"]?.jsonPrimitive?.content == "connect" }
+            .getValue("params")
+            .jsonObject
+            .getValue("auth")
+            .jsonObject
+        assertEquals(storedToken, firstAuth.getValue("token").jsonPrimitive.content)
+        assertNull(firstAuth["deviceToken"])
+        assertNull(firstAuth["password"])
+
+        assertNull(
+          "Terminal authentication failure must suppress automatic reconnects",
+          withTimeoutOrNull(LIFECYCLE_TEST_TIMEOUT_MS) { secondAttempt.await() },
+        )
+        assertTrue(readField<Boolean>(desiredConnection, "reconnectPausedForAuthFailure"))
+        assertEquals(1, connectAttempts.get())
+
+        harness.session.reconnect()
+        assertFalse(readField<Boolean>(desiredConnection, "reconnectPausedForAuthFailure"))
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { secondAttempt.await() }
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { reconnected.await() }
+
+        assertEquals(2, connectAttempts.get())
+        val reconnectAuth =
+          server.requestFrames
+            .filter { it["method"]?.jsonPrimitive?.content == "connect" }
+            .last()
+            .getValue("params")
+            .jsonObject
+            .getValue("auth")
+            .jsonObject
+        assertEquals(storedToken, reconnectAuth.getValue("token").jsonPrimitive.content)
+        assertNull(reconnectAuth["deviceToken"])
+        assertNull(reconnectAuth["password"])
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
   fun failureOrdersDisconnectAfterInFlightHandlerAndAcceptedConnectResponse() =
     runBlocking {
       val json = Json { ignoreUnknownKeys = true }
@@ -1411,6 +1507,7 @@ class GatewaySessionReconnectTest {
         Triple("AUTH_TOKEN_MISMATCH", true, false),
         Triple("AUTH_DEVICE_TOKEN_MISMATCH", false, true),
         Triple("AUTH_TOKEN_NOT_CONFIGURED", false, true),
+        Triple("AUTH_PASSWORD_MISSING", false, true),
         Triple("AUTH_PASSWORD_NOT_CONFIGURED", false, true),
         Triple("AUTH_SCOPE_MISMATCH", false, true),
         Triple("AUTH_VERIFIED_USER_REQUIRED", false, true),
@@ -1731,6 +1828,7 @@ class GatewaySessionReconnectTest {
   private fun connectNodeSession(
     session: GatewaySession,
     port: Int,
+    token: String? = "test-token",
   ) {
     session.connect(
       endpoint =
@@ -1741,7 +1839,7 @@ class GatewaySessionReconnectTest {
           port = port,
           tlsEnabled = false,
         ),
-      token = "test-token",
+      token = token,
       bootstrapToken = null,
       password = null,
       options =
@@ -1802,6 +1900,7 @@ class GatewaySessionReconnectTest {
     onRequestFrame: (webSocket: WebSocket, id: String, method: String) -> Unit,
   ): ReconnectServer {
     val sockets = ConcurrentLinkedQueue<WebSocket>()
+    val requestFrames = ConcurrentLinkedQueue<JsonObject>()
     val server =
       MockWebServer().apply {
         dispatcher =
@@ -1822,6 +1921,7 @@ class GatewaySessionReconnectTest {
                     text: String,
                   ) {
                     val frame = json.parseToJsonElement(text).jsonObject
+                    requestFrames += frame
                     if (frame["type"]?.jsonPrimitive?.content != "req") return
                     val id = frame["id"]?.jsonPrimitive?.content ?: return
                     val method = frame["method"]?.jsonPrimitive?.content ?: return
@@ -1857,7 +1957,11 @@ class GatewaySessionReconnectTest {
           }
         start()
       }
-    return ReconnectServer(server = server, sockets = sockets)
+    return ReconnectServer(
+      server = server,
+      sockets = sockets,
+      requestFrames = requestFrames,
+    )
   }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/NodeRuntimeWearProxyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/NodeRuntimeWearProxyTest.kt
@@ -1,0 +1,246 @@
+package ai.openclaw.app.wear
+
+import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.closeNodeRuntimeTestFixture
+import ai.openclaw.app.gateway.GatewayEndpoint
+import ai.openclaw.app.gateway.GatewayRegistryEntry
+import ai.openclaw.app.gateway.GatewayRegistryEntryKind
+import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.wear.shared.WearMessage
+import ai.openclaw.wear.shared.WearRpcMethod
+import android.content.Context
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.net.InetAddress
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+private const val WEAR_GATEWAY_READY_TIMEOUT_MS = 15_000L
+private const val WEAR_SESSIONS_SEARCH = "wear-runtime-proof"
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NodeRuntimeWearProxyTest {
+  @Test
+  fun wearRequestsRecoverOnlyAfterThePhoneOperatorSessionIsReady() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication<android.app.Application>()
+      val gateway = NodeRuntimeWearGateway()
+      val prefs =
+        SecurePrefs(
+          app,
+          app.getSharedPreferences("wear-runtime-${UUID.randomUUID()}", Context.MODE_PRIVATE),
+        )
+      prefs.setManualEnabled(true)
+      prefs.setManualHost(gateway.endpoint.host)
+      prefs.setManualPort(gateway.endpoint.port)
+      prefs.setManualTls(false)
+      prefs.gatewayRegistry.upsert(
+        GatewayRegistryEntry(
+          stableId = gateway.endpoint.stableId,
+          kind = GatewayRegistryEntryKind.MANUAL,
+          name = gateway.endpoint.name,
+          host = gateway.endpoint.host,
+          port = gateway.endpoint.port,
+          tls = false,
+        ),
+      )
+      prefs.gatewayRegistry.setActive(gateway.endpoint.stableId)
+      prefs.saveGatewayCredentials(gateway.endpoint.stableId, token = "synthetic-wear-runtime-token")
+      val runtime = NodeRuntime.forGatewayAuthReset(app, prefs)
+
+      try {
+        runtime.connect(gateway.endpoint)
+        awaitOperatorReady(runtime, gateway.endpoint)
+        assertTrue(runtime.handleWearProxyRequest("watch-1", sessionsRequest()).ok)
+
+        gateway.holdNextOperatorHello()
+        val disconnected = runtime.handleWearProxyRequest("watch-1", request(WearRpcMethod.GatewayDisconnect))
+        assertFalse(checkNotNull(disconnected.result).jsonObject.getValue("connected").jsonPrimitive.content.toBoolean())
+        assertUnavailable(runtime.handleWearProxyRequest("watch-1", sessionsRequest()))
+
+        val reconnecting = runtime.handleWearProxyRequest("watch-1", request(WearRpcMethod.GatewayConnect))
+        assertFalse(checkNotNull(reconnecting.result).jsonObject.getValue("connected").jsonPrimitive.content.toBoolean())
+        gateway.awaitHeldOperatorHello()
+        assertUnavailable(runtime.handleWearProxyRequest("watch-1", sessionsRequest()))
+
+        gateway.releaseOperatorHello()
+        awaitOperatorReady(runtime, gateway.endpoint)
+        val recovered = runtime.handleWearProxyRequest("watch-1", sessionsRequest())
+
+        assertTrue(recovered.ok)
+        assertEquals(
+          0,
+          checkNotNull(recovered.result)
+            .jsonObject
+            .getValue("sessions")
+            .jsonArray.size,
+        )
+        assertEquals(2, gateway.wearSessionsRequests.get())
+      } finally {
+        gateway.releaseOperatorHello()
+        closeNodeRuntimeTestFixture(runtime)
+        gateway.close()
+      }
+    }
+
+  private suspend fun awaitOperatorReady(
+    runtime: NodeRuntime,
+    endpoint: GatewayEndpoint,
+  ) {
+    val session =
+      NodeRuntime::class.java
+        .getDeclaredField("operatorSession")
+        .apply { isAccessible = true }
+        .get(runtime) as GatewaySession
+    withTimeout(WEAR_GATEWAY_READY_TIMEOUT_MS) {
+      while (session.captureRequestLease(endpoint.stableId)?.isCurrent() != true) {
+        delay(10)
+      }
+    }
+  }
+
+  private fun assertUnavailable(response: WearMessage.Response) {
+    assertFalse(response.ok)
+    assertEquals("unavailable", response.error?.code)
+  }
+
+  private fun request(method: WearRpcMethod): WearMessage.Request =
+    WearMessage.Request(
+      requestId = UUID.randomUUID().toString(),
+      method = method,
+      params = buildJsonObject {},
+    )
+
+  private fun sessionsRequest(): WearMessage.Request =
+    WearMessage.Request(
+      requestId = UUID.randomUUID().toString(),
+      method = WearRpcMethod.SessionsList,
+      params = buildJsonObject { put("search", WEAR_SESSIONS_SEARCH) },
+    )
+}
+
+private class NodeRuntimeWearGateway : AutoCloseable {
+  private val json = Json { ignoreUnknownKeys = true }
+  private val server = MockWebServer()
+  private val holdOperatorHello = AtomicBoolean()
+  private val heldOperatorHello = AtomicReference<Pair<WebSocket, String>?>()
+  private val heldOperatorHelloObserved = CompletableDeferred<Unit>()
+  val wearSessionsRequests = AtomicInteger()
+  val endpoint: GatewayEndpoint
+
+  init {
+    server.dispatcher =
+      object : Dispatcher() {
+        override fun dispatch(request: RecordedRequest): MockResponse =
+          if (request.getHeader("Upgrade").equals("websocket", ignoreCase = true)) {
+            MockResponse().withWebSocketUpgrade(listener())
+          } else {
+            MockResponse().setResponseCode(404)
+          }
+      }
+    server.start(InetAddress.getByName("127.0.0.1"), 0)
+    endpoint = GatewayEndpoint.manual("127.0.0.1", server.port)
+  }
+
+  fun holdNextOperatorHello() {
+    holdOperatorHello.set(true)
+  }
+
+  suspend fun awaitHeldOperatorHello() {
+    withTimeout(WEAR_GATEWAY_READY_TIMEOUT_MS) {
+      heldOperatorHelloObserved.await()
+    }
+  }
+
+  fun releaseOperatorHello() {
+    heldOperatorHello.getAndSet(null)?.let { (socket, id) ->
+      sendHello(socket, id, role = "operator")
+    }
+  }
+
+  private fun listener() =
+    object : WebSocketListener() {
+      override fun onOpen(
+        webSocket: WebSocket,
+        response: Response,
+      ) {
+        webSocket.send(
+          """{"type":"event","event":"connect.challenge","payload":{"nonce":"wear-runtime-proof","ts":1700000000123}}""",
+        )
+      }
+
+      override fun onMessage(
+        webSocket: WebSocket,
+        text: String,
+      ) {
+        val frame = json.parseToJsonElement(text).jsonObject
+        if (frame["type"]?.jsonPrimitive?.content != "req") return
+        val id = checkNotNull(frame["id"]?.jsonPrimitive?.content)
+        val method = frame["method"]?.jsonPrimitive?.content
+        val params = frame["params"] as? JsonObject ?: JsonObject(emptyMap())
+        if (method == "connect") {
+          val role = checkNotNull(params["role"]?.jsonPrimitive?.content)
+          if (role == "operator" && holdOperatorHello.compareAndSet(true, false)) {
+            heldOperatorHello.set(webSocket to id)
+            heldOperatorHelloObserved.complete(Unit)
+          } else {
+            sendHello(webSocket, id, role)
+          }
+          return
+        }
+        val payload =
+          if (method == "sessions.list") {
+            if (params["search"]?.jsonPrimitive?.content == WEAR_SESSIONS_SEARCH) {
+              wearSessionsRequests.incrementAndGet()
+            }
+            """{"sessions":[]}"""
+          } else {
+            "{}"
+          }
+        webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":$payload}""")
+      }
+    }
+
+  private fun sendHello(
+    webSocket: WebSocket,
+    id: String,
+    role: String,
+  ) {
+    val scopes = if (role == "operator") """["operator.read","operator.write"]""" else "[]"
+    webSocket.send(
+      """{"type":"res","id":"$id","ok":true,"payload":{"type":"hello-ok","protocol":3,"server":{"host":"wear-runtime","version":"proof"},"features":{"methods":["sessions.list"],"events":[]},"auth":{"role":"$role","scopes":$scopes},"snapshot":{"sessionDefaults":{"mainSessionKey":"agent:main:main"}}}}""",
+    )
+  }
+
+  override fun close() {
+    server.shutdown()
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/NodeRuntimeWearProxyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/NodeRuntimeWearProxyTest.kt
@@ -86,11 +86,23 @@ class NodeRuntimeWearProxyTest {
         gateway.holdOperatorHellos()
         gateway.holdNodeHellos()
         val disconnected = runtime.handleWearProxyRequest("watch-1", request(WearRpcMethod.GatewayDisconnect))
-        assertFalse(checkNotNull(disconnected.result).jsonObject.getValue("connected").jsonPrimitive.content.toBoolean())
+        assertFalse(
+          checkNotNull(disconnected.result)
+            .jsonObject
+            .getValue("connected")
+            .jsonPrimitive.content
+            .toBoolean(),
+        )
         assertUnavailable(runtime.handleWearProxyRequest("watch-1", sessionsRequest()))
 
         val reconnecting = runtime.handleWearProxyRequest("watch-1", request(WearRpcMethod.GatewayConnect))
-        assertFalse(checkNotNull(reconnecting.result).jsonObject.getValue("connected").jsonPrimitive.content.toBoolean())
+        assertFalse(
+          checkNotNull(reconnecting.result)
+            .jsonObject
+            .getValue("connected")
+            .jsonPrimitive.content
+            .toBoolean(),
+        )
         gateway.awaitHeldOperatorHello()
         assertUnavailable(runtime.handleWearProxyRequest("watch-1", sessionsRequest()))
 
@@ -124,9 +136,9 @@ class NodeRuntimeWearProxyTest {
     withTimeout(WEAR_GATEWAY_READY_TIMEOUT_MS) {
       while (
         session.captureRequestLease(endpoint.stableId)?.isCurrent() != true ||
-          !synchronized(statusLock) {
-            ReflectionHelpers.getField<Boolean>(runtime, "operatorConnected")
-          }
+        !synchronized(statusLock) {
+          ReflectionHelpers.getField<Boolean>(runtime, "operatorConnected")
+        }
       ) {
         delay(10)
       }

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/NodeRuntimeWearProxyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/NodeRuntimeWearProxyTest.kt
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
 import java.net.InetAddress
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
@@ -75,11 +76,15 @@ class NodeRuntimeWearProxyTest {
       val runtime = NodeRuntime.forGatewayAuthReset(app, prefs)
 
       try {
+        gateway.holdNodeHellos()
         runtime.connect(gateway.endpoint)
         awaitOperatorReady(runtime, gateway.endpoint)
         assertTrue(runtime.handleWearProxyRequest("watch-1", sessionsRequest()).ok)
+        gateway.releaseNodeHellos()
+        awaitPhoneSessionsReady(runtime, gateway.endpoint)
 
         gateway.holdOperatorHellos()
+        gateway.holdNodeHellos()
         val disconnected = runtime.handleWearProxyRequest("watch-1", request(WearRpcMethod.GatewayDisconnect))
         assertFalse(checkNotNull(disconnected.result).jsonObject.getValue("connected").jsonPrimitive.content.toBoolean())
         assertUnavailable(runtime.handleWearProxyRequest("watch-1", sessionsRequest()))
@@ -104,6 +109,7 @@ class NodeRuntimeWearProxyTest {
         assertEquals(2, gateway.wearSessionsRequests.get())
       } finally {
         gateway.releaseOperatorHellos()
+        gateway.releaseNodeHellos()
         closeNodeRuntimeTestFixture(runtime)
         gateway.close()
       }
@@ -113,17 +119,45 @@ class NodeRuntimeWearProxyTest {
     runtime: NodeRuntime,
     endpoint: GatewayEndpoint,
   ) {
-    val session =
-      NodeRuntime::class.java
-        .getDeclaredField("operatorSession")
-        .apply { isAccessible = true }
-        .get(runtime) as GatewaySession
+    val session = readGatewaySession(runtime, "operatorSession")
+    val statusLock = ReflectionHelpers.getField<Any>(runtime, "gatewayStatusLock")
+    withTimeout(WEAR_GATEWAY_READY_TIMEOUT_MS) {
+      while (
+        session.captureRequestLease(endpoint.stableId)?.isCurrent() != true ||
+          !synchronized(statusLock) {
+            ReflectionHelpers.getField<Boolean>(runtime, "operatorConnected")
+          }
+      ) {
+        delay(10)
+      }
+    }
+  }
+
+  private suspend fun awaitPhoneSessionsReady(
+    runtime: NodeRuntime,
+    endpoint: GatewayEndpoint,
+  ) {
+    awaitSessionReady(runtime, endpoint, "nodeSession")
+    awaitOperatorReady(runtime, endpoint)
+  }
+
+  private suspend fun awaitSessionReady(
+    runtime: NodeRuntime,
+    endpoint: GatewayEndpoint,
+    fieldName: String,
+  ) {
+    val session = readGatewaySession(runtime, fieldName)
     withTimeout(WEAR_GATEWAY_READY_TIMEOUT_MS) {
       while (session.captureRequestLease(endpoint.stableId)?.isCurrent() != true) {
         delay(10)
       }
     }
   }
+
+  private fun readGatewaySession(
+    runtime: NodeRuntime,
+    fieldName: String,
+  ): GatewaySession = ReflectionHelpers.getField(runtime, fieldName)
 
   private fun assertUnavailable(response: WearMessage.Response) {
     assertFalse(response.ok)
@@ -148,10 +182,8 @@ class NodeRuntimeWearProxyTest {
 private class NodeRuntimeWearGateway : AutoCloseable {
   private val json = Json { ignoreUnknownKeys = true }
   private val server = MockWebServer()
-  private val operatorHelloGateLock = Any()
-  private var operatorHellosHeld = false
-  private val heldOperatorHellos = mutableListOf<Pair<WebSocket, String>>()
-  private val heldOperatorHelloObserved = CompletableDeferred<Unit>()
+  private val operatorHelloGate = GatewayHelloGate()
+  private val nodeHelloGate = GatewayHelloGate()
   val wearSessionsRequests = AtomicInteger()
   val endpoint: GatewayEndpoint
 
@@ -170,38 +202,24 @@ private class NodeRuntimeWearGateway : AutoCloseable {
   }
 
   fun holdOperatorHellos() {
-    synchronized(operatorHelloGateLock) {
-      operatorHellosHeld = true
-    }
+    operatorHelloGate.hold()
+  }
+
+  fun holdNodeHellos() {
+    nodeHelloGate.hold()
   }
 
   suspend fun awaitHeldOperatorHello() {
-    withTimeout(WEAR_GATEWAY_READY_TIMEOUT_MS) {
-      heldOperatorHelloObserved.await()
-    }
+    operatorHelloGate.awaitHeld()
   }
 
   fun releaseOperatorHellos() {
-    val pending =
-      synchronized(operatorHelloGateLock) {
-        operatorHellosHeld = false
-        heldOperatorHellos.toList().also { heldOperatorHellos.clear() }
-      }
-    pending.forEach { (socket, id) ->
-      sendHello(socket, id, role = "operator")
-    }
+    operatorHelloGate.release { socket, id -> sendHello(socket, id, role = "operator") }
   }
 
-  private fun holdOperatorHello(
-    webSocket: WebSocket,
-    id: String,
-  ): Boolean =
-    synchronized(operatorHelloGateLock) {
-      if (!operatorHellosHeld) return@synchronized false
-      heldOperatorHellos += webSocket to id
-      heldOperatorHelloObserved.complete(Unit)
-      true
-    }
+  fun releaseNodeHellos() {
+    nodeHelloGate.release { socket, id -> sendHello(socket, id, role = "node") }
+  }
 
   private fun listener() =
     object : WebSocketListener() {
@@ -225,7 +243,8 @@ private class NodeRuntimeWearGateway : AutoCloseable {
         val params = frame["params"] as? JsonObject ?: JsonObject(emptyMap())
         if (method == "connect") {
           val role = checkNotNull(params["role"]?.jsonPrimitive?.content)
-          if (role == "operator" && holdOperatorHello(webSocket, id)) return
+          val gate = if (role == "operator") operatorHelloGate else nodeHelloGate
+          if (gate.capture(webSocket, id)) return
           sendHello(webSocket, id, role)
           return
         }
@@ -255,5 +274,48 @@ private class NodeRuntimeWearGateway : AutoCloseable {
 
   override fun close() {
     server.shutdown()
+  }
+}
+
+private class GatewayHelloGate {
+  private val lock = Any()
+  private var held = false
+  private var observed = CompletableDeferred<Unit>()
+  private val pending = mutableListOf<Pair<WebSocket, String>>()
+
+  fun hold() {
+    synchronized(lock) {
+      check(!held)
+      check(pending.isEmpty())
+      observed = CompletableDeferred()
+      held = true
+    }
+  }
+
+  suspend fun awaitHeld() {
+    val signal = synchronized(lock) { observed }
+    withTimeout(WEAR_GATEWAY_READY_TIMEOUT_MS) {
+      signal.await()
+    }
+  }
+
+  fun capture(
+    webSocket: WebSocket,
+    id: String,
+  ): Boolean =
+    synchronized(lock) {
+      if (!held) return@synchronized false
+      pending += webSocket to id
+      observed.complete(Unit)
+      true
+    }
+
+  fun release(sendHello: (WebSocket, String) -> Unit) {
+    val captured =
+      synchronized(lock) {
+        held = false
+        pending.toList().also { pending.clear() }
+      }
+    captured.forEach { (socket, id) -> sendHello(socket, id) }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/NodeRuntimeWearProxyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/NodeRuntimeWearProxyTest.kt
@@ -38,9 +38,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.net.InetAddress
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
 
 private const val WEAR_GATEWAY_READY_TIMEOUT_MS = 15_000L
 private const val WEAR_SESSIONS_SEARCH = "wear-runtime-proof"
@@ -51,7 +49,7 @@ class NodeRuntimeWearProxyTest {
   @Test
   fun wearRequestsRecoverOnlyAfterThePhoneOperatorSessionIsReady() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication<android.app.Application>()
+      val app = RuntimeEnvironment.getApplication()
       val gateway = NodeRuntimeWearGateway()
       val prefs =
         SecurePrefs(
@@ -81,7 +79,7 @@ class NodeRuntimeWearProxyTest {
         awaitOperatorReady(runtime, gateway.endpoint)
         assertTrue(runtime.handleWearProxyRequest("watch-1", sessionsRequest()).ok)
 
-        gateway.holdNextOperatorHello()
+        gateway.holdOperatorHellos()
         val disconnected = runtime.handleWearProxyRequest("watch-1", request(WearRpcMethod.GatewayDisconnect))
         assertFalse(checkNotNull(disconnected.result).jsonObject.getValue("connected").jsonPrimitive.content.toBoolean())
         assertUnavailable(runtime.handleWearProxyRequest("watch-1", sessionsRequest()))
@@ -91,7 +89,7 @@ class NodeRuntimeWearProxyTest {
         gateway.awaitHeldOperatorHello()
         assertUnavailable(runtime.handleWearProxyRequest("watch-1", sessionsRequest()))
 
-        gateway.releaseOperatorHello()
+        gateway.releaseOperatorHellos()
         awaitOperatorReady(runtime, gateway.endpoint)
         val recovered = runtime.handleWearProxyRequest("watch-1", sessionsRequest())
 
@@ -105,7 +103,7 @@ class NodeRuntimeWearProxyTest {
         )
         assertEquals(2, gateway.wearSessionsRequests.get())
       } finally {
-        gateway.releaseOperatorHello()
+        gateway.releaseOperatorHellos()
         closeNodeRuntimeTestFixture(runtime)
         gateway.close()
       }
@@ -150,8 +148,9 @@ class NodeRuntimeWearProxyTest {
 private class NodeRuntimeWearGateway : AutoCloseable {
   private val json = Json { ignoreUnknownKeys = true }
   private val server = MockWebServer()
-  private val holdOperatorHello = AtomicBoolean()
-  private val heldOperatorHello = AtomicReference<Pair<WebSocket, String>?>()
+  private val operatorHelloGateLock = Any()
+  private var operatorHellosHeld = false
+  private val heldOperatorHellos = mutableListOf<Pair<WebSocket, String>>()
   private val heldOperatorHelloObserved = CompletableDeferred<Unit>()
   val wearSessionsRequests = AtomicInteger()
   val endpoint: GatewayEndpoint
@@ -170,8 +169,10 @@ private class NodeRuntimeWearGateway : AutoCloseable {
     endpoint = GatewayEndpoint.manual("127.0.0.1", server.port)
   }
 
-  fun holdNextOperatorHello() {
-    holdOperatorHello.set(true)
+  fun holdOperatorHellos() {
+    synchronized(operatorHelloGateLock) {
+      operatorHellosHeld = true
+    }
   }
 
   suspend fun awaitHeldOperatorHello() {
@@ -180,11 +181,27 @@ private class NodeRuntimeWearGateway : AutoCloseable {
     }
   }
 
-  fun releaseOperatorHello() {
-    heldOperatorHello.getAndSet(null)?.let { (socket, id) ->
+  fun releaseOperatorHellos() {
+    val pending =
+      synchronized(operatorHelloGateLock) {
+        operatorHellosHeld = false
+        heldOperatorHellos.toList().also { heldOperatorHellos.clear() }
+      }
+    pending.forEach { (socket, id) ->
       sendHello(socket, id, role = "operator")
     }
   }
+
+  private fun holdOperatorHello(
+    webSocket: WebSocket,
+    id: String,
+  ): Boolean =
+    synchronized(operatorHelloGateLock) {
+      if (!operatorHellosHeld) return@synchronized false
+      heldOperatorHellos += webSocket to id
+      heldOperatorHelloObserved.complete(Unit)
+      true
+    }
 
   private fun listener() =
     object : WebSocketListener() {
@@ -208,12 +225,8 @@ private class NodeRuntimeWearGateway : AutoCloseable {
         val params = frame["params"] as? JsonObject ?: JsonObject(emptyMap())
         if (method == "connect") {
           val role = checkNotNull(params["role"]?.jsonPrimitive?.content)
-          if (role == "operator" && holdOperatorHello.compareAndSet(true, false)) {
-            heldOperatorHello.set(webSocket to id)
-            heldOperatorHelloObserved.complete(Unit)
-          } else {
-            sendHello(webSocket, id, role)
-          }
+          if (role == "operator" && holdOperatorHello(webSocket, id)) return
+          sendHello(webSocket, id, role)
           return
         }
         val payload =

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearProxyControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearProxyControllerTest.kt
@@ -148,9 +148,10 @@ class WearProxyControllerTest {
     }
 
   @Test
-  fun phoneGatewayReconnectRestoresWearStatusAndRequests() =
+  fun gatewayCommandsStayOnPhoneRelayWithoutInventingReadiness() =
     runTest {
       var gatewayRequests = 0
+      var gatewayConnects = 0
       val requestedMethods = mutableListOf<String>()
       var connected = true
       var selectedAgent = "main"
@@ -179,7 +180,7 @@ class WearProxyControllerTest {
             selectedAgent = agentId
             true
           },
-          connectGateway = { connected = true },
+          connectGateway = { gatewayConnects += 1 },
           disconnectGateway = { connected = false },
         )
 
@@ -197,7 +198,6 @@ class WearProxyControllerTest {
       assertEquals(0, gatewayRequests)
       val offlineSessions = controller.handle(request(WearRpcMethod.SessionsList))
       val reconnected = controller.handle(request(WearRpcMethod.GatewayConnect))
-      val recoveredSessions = controller.handle(request(WearRpcMethod.SessionsList))
 
       val statusResult = checkNotNull(status.result).jsonObject
       val agentsResult = checkNotNull(agents.result).jsonObject
@@ -220,7 +220,7 @@ class WearProxyControllerTest {
           .jsonPrimitive.content
           .toBoolean(),
       )
-      assertTrue(
+      assertFalse(
         reconnectedResult
           .getValue("connected")
           .jsonPrimitive.content
@@ -228,16 +228,9 @@ class WearProxyControllerTest {
       )
       assertFalse(offlineSessions.ok)
       assertEquals("unavailable", offlineSessions.error?.code)
-      assertTrue(recoveredSessions.ok)
-      assertEquals(
-        0,
-        checkNotNull(recoveredSessions.result)
-          .jsonObject
-          .getValue("sessions")
-          .jsonArray.size,
-      )
-      assertEquals(2, gatewayRequests)
-      assertEquals(listOf("sessions.list", "sessions.list"), requestedMethods)
+      assertEquals(1, gatewayConnects)
+      assertEquals(1, gatewayRequests)
+      assertEquals(listOf("sessions.list"), requestedMethods)
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearProxyControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearProxyControllerTest.kt
@@ -148,15 +148,20 @@ class WearProxyControllerTest {
     }
 
   @Test
-  fun agentsAndGatewayControlsStayOnThePhoneRuntimeBoundary() =
+  fun phoneGatewayReconnectRestoresWearStatusAndRequests() =
     runTest {
       var gatewayRequests = 0
+      val requestedMethods = mutableListOf<String>()
       var connected = true
       var selectedAgent = "main"
       val controller =
         WearProxyController(
-          requestGateway = { _, _ ->
+          requestGateway = { method, _ ->
             gatewayRequests += 1
+            requestedMethods += method
+            if (!connected) {
+              throw WearProxyGatewayException("unavailable", "Phone gateway is offline")
+            }
             buildJsonObject {}
           },
           isGatewayConnected = { connected },
@@ -189,7 +194,10 @@ class WearProxyControllerTest {
         )
       val selectedStatus = controller.handle(request(WearRpcMethod.ProxyStatus))
       val disconnected = controller.handle(request(WearRpcMethod.GatewayDisconnect))
+      assertEquals(0, gatewayRequests)
+      val offlineSessions = controller.handle(request(WearRpcMethod.SessionsList))
       val reconnected = controller.handle(request(WearRpcMethod.GatewayConnect))
+      val recoveredSessions = controller.handle(request(WearRpcMethod.SessionsList))
 
       val statusResult = checkNotNull(status.result).jsonObject
       val agentsResult = checkNotNull(agents.result).jsonObject
@@ -218,7 +226,18 @@ class WearProxyControllerTest {
           .jsonPrimitive.content
           .toBoolean(),
       )
-      assertEquals(0, gatewayRequests)
+      assertFalse(offlineSessions.ok)
+      assertEquals("unavailable", offlineSessions.error?.code)
+      assertTrue(recoveredSessions.ok)
+      assertEquals(
+        0,
+        checkNotNull(recoveredSessions.result)
+          .jsonObject
+          .getValue("sessions")
+          .jsonArray.size,
+      )
+      assertEquals(2, gatewayRequests)
+      assertEquals(listOf("sessions.list", "sessions.list"), requestedMethods)
     }
 
   @Test


### PR DESCRIPTION
Related: #134142

## What Problem This Solves

Android had no lifecycle regression coverage for a paired client reconnecting with its stored device token when a Gateway rejects that token with `AUTH_PASSWORD_MISSING`. Wear coverage also did not prove that phone-relayed requests remain unavailable until the phone's asynchronous operator session is actually ready after reconnect.

## Why This Change Was Made

This adds test-only JVM/Robolectric coverage at the existing ownership boundaries:

- `GatewaySession` sends the stored credential through `auth.token`, treats `AUTH_PASSWORD_MISSING` as terminal, pauses automatic reconnect, and recovers after an explicit reconnect.
- `WearProxyController` keeps Gateway commands on the phone relay without inventing synchronous readiness.
- `NodeRuntime` is exercised against a local WebSocket Gateway fixture that gates replacement operator and node handshakes. The test waits for both a current operator request lease and the synchronized `operatorConnected` state before expecting a relayed Wear request to succeed.

No production behavior, direct Wear pairing, protocol, configuration, or persistence surface changes.

## User Impact

No runtime behavior changes. Future Android or Gateway changes that break terminal auth pause/recovery or phone-owned Wear relay readiness will fail deterministic JVM coverage.

## Evidence

- Exact head `bdd5994feb2e68214d93f9748a2493ff1e63bbd5`: `android-test-play`, `android-test-third-party`, `android-test-wear`, `android-build-play`, `android-build-wear`, `android-ktlint`, and the aggregate `openclaw/ci-gate` passed.
- CI run: https://github.com/openclaw/openclaw/actions/runs/33729515878
- Current-head ClawSweeper: 4/6, no correctness findings, no rank-up moves; recommends accepting the deterministic coverage after exact-head Android checks.
- Android owner decision: accept and merge after exact-head checks.
- Fresh branch-wide P0-P2 autoreview: scoped clean.
- `git diff --check`: clean.

Remaining proof gap: no Android phone/Wear emulator or physical-device E2E in this PR. Direct Wear pairing remains out of scope because Wear is phone-relay-only.
