### PR TITLE
fix: preserve catalog metadata and provider failure outcomes

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -268,6 +268,8 @@ Provider-busy signals such as `ModelNotReadyException` land in the overloaded bu
 
 The embedded failover controller owns transient retries, including overloads and server errors. `retry.provider.maxRetries` sets the retry budget (default: 3), with jittered backoff, provider retry pacing, and a fixed 90-second retry window. Once that budget or window is exhausted, recovery proceeds to profile rotation, configured model fallback, or a visible error. Provider SDKs and the reply runner do not add separate replay loops. Retry and any fallback winner remain turn-local, and replay-unsafe attempts are not retried.
 
+Visible failure messages preserve the provider's HTTP status independently of retry classification. A provider HTTP 500 remains a server error in the final reply, even when recovery groups it with timeout-shaped failures. Raw provider response details stay out of that reply.
+
 When a run starts from the configured default primary, a cron job primary, an agent primary with explicit fallbacks, or an auto-selected fallback override, OpenClaw can walk the matching configured fallback chain. Agent primaries without explicit fallbacks and explicit user selections (for example `/model ollama/qwen3.5:27b`, the model picker, `sessions.patch`, or one-off CLI provider/model overrides) are strict: if that provider/model is unreachable or fails before producing a reply, OpenClaw reports the failure instead of answering from an unrelated fallback.
 
 ### Candidate chain rules

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -2767,10 +2767,12 @@ export async function startQaMockOpenAiServer(params?: {
       ...(QA_FINAL_ONLY_MARKER_STREAMING_PROMPT_RE.test(allInputText)
         ? { previewPauseMs: finalOnlyMarkerPauseMs }
         : {}),
-      ...(repeatedRequestRecovery
+      // Stall one request; later failures let the normal retry budget settle the turn.
+      ...(repeatedRequestRecovery &&
+      scenarioState.repeatedRequestRecoveryAttempts <= QA_REPEATED_REQUEST_STALL_ATTEMPT
         ? {
             responsePauseMs:
-              scenarioState.repeatedRequestRecoveryAttempts >= QA_REPEATED_REQUEST_STALL_ATTEMPT
+              scenarioState.repeatedRequestRecoveryAttempts === QA_REPEATED_REQUEST_STALL_ATTEMPT
                 ? QA_REPEATED_REQUEST_STALLED_RESPONSE_PAUSE_MS
                 : QA_REPEATED_REQUEST_RESPONSE_PAUSE_MS,
           }

--- a/src/agents/clawrouter-catalog-discovery.e2e.test.ts
+++ b/src/agents/clawrouter-catalog-discovery.e2e.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   buildModelsListResult,
@@ -22,27 +22,41 @@ vi.mock("node:worker_threads", async (importOriginal) => ({
 describe("ClawRouter cold prepared catalog", () => {
   let state: OpenClawTestState;
 
-  beforeEach(async () => {
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await state.cleanup();
+  });
+
+  it.each([
+    {
+      label: "publishes metadata with a sibling catalog=false",
+      sibling: false,
+      refreshedAuth: false,
+    },
+    {
+      label: "publishes metadata with a sibling catalog=true",
+      sibling: true,
+      refreshedAuth: false,
+    },
+    {
+      label: "discovers a provider introduced by refreshed auth",
+      sibling: true,
+      refreshedAuth: true,
+    },
+  ])("$label", async ({ sibling, refreshedAuth }) => {
     state = await createOpenClawTestState({
       label: "clawrouter-catalog",
       env: {
-        CLAWROUTER_API_KEY: "catalog-test-key",
+        CLAWROUTER_API_KEY: refreshedAuth ? undefined : "catalog-test-key",
         OPENAI_API_KEY: undefined,
         CODEX_API_KEY: undefined,
         CODEX_HOME: undefined,
         OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
       },
     });
-  });
-
-  afterEach(async () => {
-    vi.unstubAllGlobals();
-    await state.cleanup();
-  });
-
-  it.each([false, true])("publishes metadata with a sibling catalog=%s", async (sibling) => {
     // Distinct catalog URLs keep each scenario cold across plugin module loaders.
-    const baseUrl = `https://${sibling ? "mixed" : "single"}.example.test/private`;
+    const scope = refreshedAuth ? "refreshed" : sibling ? "mixed" : "single";
+    const baseUrl = `https://${scope}.example.test/private`;
     const agentId = "private-openclaw";
     const config: OpenClawConfig = {
       plugins: {
@@ -57,7 +71,15 @@ describe("ClawRouter cold prepared catalog", () => {
         providers: {
           clawrouter: {
             baseUrl,
-            apiKey: { source: "env", provider: "default", id: "CLAWROUTER_API_KEY" },
+            ...(refreshedAuth
+              ? {}
+              : {
+                  apiKey: {
+                    source: "env" as const,
+                    provider: "default",
+                    id: "CLAWROUTER_API_KEY",
+                  },
+                }),
             agentRuntime: { id: "openclaw" },
             models: [],
           },
@@ -68,12 +90,19 @@ describe("ClawRouter cold prepared catalog", () => {
           workspace: state.workspaceDir,
           model: { primary: sibling ? "openai/codex-latest" : "clawrouter/codex-latest" },
           models: {
-            "clawrouter/codex-latest": { agentRuntime: { id: "openclaw" } },
+            ...(refreshedAuth
+              ? {}
+              : { "clawrouter/codex-latest": { agentRuntime: { id: "openclaw" } } }),
             ...(sibling ? { "openai/codex-latest": { agentRuntime: { id: "openclaw" } } } : {}),
           },
           modelPolicy: { allow: ["clawrouter/codex-latest"] },
         },
-        list: [{ id: agentId, model: { primary: "clawrouter/codex-latest" } }],
+        list: [
+          {
+            id: agentId,
+            model: { primary: refreshedAuth ? "openai/codex-latest" : "clawrouter/codex-latest" },
+          },
+        ],
       },
     };
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
@@ -117,6 +146,24 @@ describe("ClawRouter cold prepared catalog", () => {
       agentFacts: prepared.agentFacts[0]!,
       pluginMetadataSnapshot: prepared.pluginGeneration.pluginMetadataSnapshot,
     });
+    if (refreshedAuth) {
+      // The new credential must enter through the worker's durable auth refresh,
+      // without a configured model preloading its provider into the startup scope.
+      expect(value.providerIds).not.toContain("clawrouter");
+      await state.writeAuthProfiles(
+        {
+          version: 1,
+          profiles: {
+            "clawrouter:default": {
+              type: "api_key",
+              provider: "clawrouter",
+              key: "catalog-test-key",
+            },
+          },
+        },
+        agentId,
+      );
+    }
     const result = await runPreparedModelCatalogWorkerRequest(value, {
       kind: "catalog",
     });
@@ -135,7 +182,7 @@ describe("ClawRouter cold prepared catalog", () => {
     const catalog = await buildModelsListResult({
       context: { getRuntimeConfig: () => config } as GatewayRequestContext,
       agentId,
-      params: { view: "configured", preparedOnly: true },
+      params: { view: refreshedAuth ? "all" : "configured", preparedOnly: true },
       preloadedCatalog: { agentId, config, snapshot: result.snapshot },
       preloadedOnly: true,
       catalogProjector: projector,

--- a/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
@@ -49,13 +49,7 @@ type ScenarioOutcome =
   | { kind: "error"; error: Error & { attempts?: unknown[] } };
 
 const runEmbeddedAttemptMock = vi.fn<(params: unknown) => Promise<EmbeddedRunAttemptResult>>();
-const { computeBackoffMock, sleepWithAbortMock } = vi.hoisted(() => ({
-  computeBackoffMock: vi.fn(
-    (
-      _policy: { initialMs: number; maxMs: number; factor: number; jitter: number },
-      _attempt: number,
-    ) => 0,
-  ),
+const { sleepWithAbortMock } = vi.hoisted(() => ({
   sleepWithAbortMock: vi.fn(async (_ms: number, _abortSignal?: AbortSignal) => undefined),
 }));
 
@@ -79,7 +73,7 @@ beforeAll(async () => {
     runEmbeddedAttempt: (params) => runEmbeddedAttemptMock(params),
   });
   installEmbeddedRunnerBackoffE2eMocks({
-    computeBackoff: (policy, attempt) => computeBackoffMock(policy, attempt),
+    computeBackoff: () => 0,
     sleepWithAbort: (ms, abortSignal) => sleepWithAbortMock(ms, abortSignal),
   });
   vi.doMock("./embedded-agent-runner/model.js", () => ({
@@ -97,7 +91,6 @@ beforeAll(async () => {
 
 beforeEach(() => {
   runEmbeddedAttemptMock.mockReset();
-  computeBackoffMock.mockClear();
   sleepWithAbortMock.mockClear();
 });
 
@@ -141,9 +134,11 @@ async function withScenarioWorkspace<T>(
     fs.mkdir(agentDir, { recursive: true }),
     fs.mkdir(workspaceDir, { recursive: true }),
   ]);
+  const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
   try {
     return await run({ agentDir, workspaceDir });
   } finally {
+    random.mockRestore();
     const { waitForSessionTranscriptIndexReconcile } =
       await import("../config/sessions/session-transcript-reconcile.js");
     const { closeOpenClawAgentDatabaseByPath } = await import("../state/openclaw-agent-db.js");
@@ -486,7 +481,7 @@ describe("runEmbeddedAgent provider fault sequences", () => {
       ).toEqual(
         faults.map(() => ({ provider: "openai", model: "mock-1", profileId: "openai:p1" })),
       );
-      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([10_000, 20_000]);
+      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([1_000, 2_000]);
       expect(outcome.provider).toBe("openai");
       expect(outcome.model).toBe("mock-1");
       expect(outcome.attempts).toEqual([]);
@@ -497,7 +492,7 @@ describe("runEmbeddedAgent provider fault sequences", () => {
     });
   });
 
-  it("walks 429 -> 401 -> 500 -> 200 across profile rotation and model fallback", async () => {
+  it("walks 429 -> 401 -> persistent 500 -> 200 across profile rotation and model fallback", async () => {
     await withScenarioWorkspace(async ({ agentDir, workspaceDir }) => {
       writeProfiles(agentDir, { openai: 2, groq: true });
       const observations: AttemptObservation[] = [];
@@ -505,7 +500,8 @@ describe("runEmbeddedAgent provider fault sequences", () => {
         [
           { status: 429, window: "long" },
           { status: 401 },
-          { status: 500 },
+          // Exhaust the default three transient retries before advancing the model.
+          ...Array.from({ length: 4 }, () => ({ status: 500 as const })),
           { status: 200, text: "fallback chain ok" },
         ],
         observations,
@@ -525,10 +521,10 @@ describe("runEmbeddedAgent provider fault sequences", () => {
       ).toEqual([
         ["openai", "mock-1", "openai:p1"],
         ["openai", "mock-1", "openai:p2"],
-        ["groq", "mock-2", "groq:p1"],
+        ...Array.from({ length: 4 }, () => ["groq", "mock-2", "groq:p1"]),
         ["groq", "mock-3", "groq:p1"],
       ]);
-      expect(sleepWithAbortMock).not.toHaveBeenCalled();
+      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([1_000, 2_000, 4_000]);
       expect(outcome.provider).toBe("groq");
       expect(outcome.model).toBe("mock-3");
       expect(outcome.attempts).toMatchObject([
@@ -646,7 +642,12 @@ describe("runEmbeddedAgent provider fault sequences", () => {
       writeProfiles(agentDir, { openai: 2, groq: true });
       const observations: AttemptObservation[] = [];
       installFaultScript(
-        [{ status: 429, window: "long" }, { status: 401 }, { status: 500 }, { status: 402 }],
+        [
+          { status: 429, window: "long" },
+          { status: 401 },
+          ...Array.from({ length: 4 }, () => ({ status: 500 as const })),
+          { status: 402 },
+        ],
         observations,
       );
 
@@ -664,10 +665,11 @@ describe("runEmbeddedAgent provider fault sequences", () => {
       ).toEqual([
         ["openai", "mock-1", "openai:p1"],
         ["openai", "mock-1", "openai:p2"],
-        ["groq", "mock-2", "groq:p1"],
+        ...Array.from({ length: 4 }, () => ["groq", "mock-2", "groq:p1"]),
         ["groq", "mock-3", "groq:p1"],
       ]);
       // FIXED(refactor-02): the shared concrete reason propagates through exhaustion prose and attempts.
+      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([1_000, 2_000, 4_000]);
       expect(error.message).toMatch(/^All models failed \(3\): /);
       expect(error.message).toMatch(
         /openai\/mock-1: .* \(auth(?:_permanent)?\) \| groq\/mock-2: .* \(server_error\) \| groq\/mock-3: .* \(billing\)/,

--- a/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test-support.ts
@@ -1,5 +1,5 @@
 // Full-entry coverage for current-attempt error context across model fallback.
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
@@ -320,5 +320,80 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
       provider: "deepseek",
       model: "deepseek-chat",
     });
+  });
+
+  it("does not present stale successful-assistant errors as the current timeout", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        terminal: { kind: "timeout", phase: "prompt", source: "runtime" },
+        currentAttemptAssistant: makeAssistantMessageFixture({
+          stopReason: "stop",
+          errorMessage: "500 stale provider diagnostic",
+          provider: "deepseek",
+          model: "deepseek-chat",
+          content: [],
+        }),
+      }),
+    );
+
+    const promise = runEmbeddedAgent({
+      ...createOverflowRunParams(state),
+      runId: "run-successful-assistant-stale-error-timeout",
+      config: makeCrossProviderFallbackConfig(),
+      agentHarnessRuntimeOverride: "openclaw",
+      provider: "deepseek",
+      model: "deepseek-chat",
+      authProfileId: "deepseek:test",
+      authProfileIdSource: "user",
+      modelFallbacksOverride: ["deepseek/deepseek-chat"],
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
+    await expect(promise).rejects.toThrow("LLM request timed out.");
+    await expect(promise).rejects.not.toThrow("500");
+    await expect(promise).rejects.not.toThrow("stale provider diagnostic");
+  });
+
+  it("does not retry successful replies for stale unsupported-thinking errors", async () => {
+    const helpers = await import("../embedded-agent-helpers.js");
+    const thinking = await import("../embedded-agent-helpers/thinking.js");
+    const thinkingMock = vi.mocked(helpers.pickFallbackThinkingLevel);
+    const previousThinking = thinkingMock.getMockImplementation();
+    thinkingMock.mockImplementation(thinking.pickFallbackThinkingLevel);
+    try {
+      mockedRunEmbeddedAttempt.mockResolvedValue(
+        makeAttemptResult({
+          assistantTexts: ["Successful reply"],
+          currentAttemptAssistant: makeAssistantMessageFixture({
+            stopReason: "stop",
+            errorMessage: 'think value "high" is not supported for this model',
+            provider: "deepseek",
+            model: "deepseek-chat",
+            content: [{ type: "text", text: "Successful reply" }],
+          }),
+        }),
+      );
+
+      const result = await runEmbeddedAgent({
+        ...createOverflowRunParams(state),
+        runId: "run-successful-assistant-stale-thinking",
+        config: makeCrossProviderFallbackConfig(),
+        agentHarnessRuntimeOverride: "openclaw",
+        provider: "deepseek",
+        model: "deepseek-chat",
+        thinkLevel: "high",
+        authProfileId: "deepseek:test",
+        authProfileIdSource: "user",
+      });
+
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
+      expect(result.meta.finalAssistantVisibleText).toBe("Successful reply");
+    } finally {
+      thinkingMock.mockReset();
+      if (previousThinking) {
+        thinkingMock.mockImplementation(previousThinking);
+      }
+    }
   });
 });

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -665,25 +665,46 @@ describe("handleAssistantFailover", () => {
       expect(err.rawError).toBe(rawError);
     });
 
-    it("preserves the raw provider error on surfaced failures", async () => {
-      const rawError = '  400 {"error":{"message":"credit balance is too low"}}  ';
-      const outcome = await handleAssistantFailover(
-        makeParams({
-          initialDecision: { action: "surface_error", reason: "billing" },
-          failoverReason: "billing",
-          billingFailure: true,
-          lastAssistant: {
-            errorMessage: rawError,
-            model: "claude-haiku-4-5-20251001",
-            provider: "Anthropic",
-          } as Params["lastAssistant"],
-        }),
-      );
+    it.each([
+      [
+        "surface_error",
+        "billing",
+        '  400 {"error":{"message":"credit balance is too low"}}  ',
+        400,
+      ],
+      ["surface_error", "timeout", "500 provider returned HTTP 500", 500],
+      ["surface_error", "timeout", "503 service unavailable", 503],
+      ["surface_error", "timeout", "request timed out", 408],
+      ["fallback_model", "timeout", "500 provider returned HTTP 500", 500],
+      ["fallback_model", "timeout", "503 service unavailable", 503],
+      ["fallback_model", "timeout", "request timed out", 408],
+      ["rotate_profile", "overloaded", "529 overloaded", 529],
+      ["rotate_profile", "overloaded", "503 overloaded", 503],
+    ] as const)(
+      "preserves provider status and raw error through %s: %s / %s",
+      async (action, reason, rawError, status) => {
+        const outcome = await handleAssistantFailover(
+          makeParams({
+            initialDecision: { action, reason },
+            failoverReason: reason,
+            fallbackConfigured: action !== "surface_error",
+            overloadProfileRotations: 3,
+            billingFailure: reason === "billing",
+            lastAssistant: {
+              stopReason: "error",
+              errorMessage: rawError,
+              model: "claude-haiku-4-5-20251001",
+              provider: "Anthropic",
+            } as Params["lastAssistant"],
+          }),
+        );
 
-      const err = expectThrownFailoverError(outcome);
-      expect(err.reason).toBe("billing");
-      expect(err.rawError).toBe(rawError.trim());
-    });
+        const err = expectThrownFailoverError(outcome);
+        expect(err.reason).toBe(reason);
+        expect(err.status).toBe(status);
+        expect(err.rawError).toBe(rawError.trim());
+      },
+    );
 
     it("coerces a null decision reason onto the most specific non-timeout failure signal", async () => {
       const outcome = await handleAssistantFailover(

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -16,6 +16,7 @@ import {
   isTimeoutErrorMessage,
   type FailoverReason,
 } from "../../embedded-agent-helpers.js";
+import { buildAssistantFailoverSignal } from "../../embedded-agent-helpers/assistant-message-failures.js";
 import { FailoverError, resolveFailoverStatus } from "../../failover-error.js";
 import type { PreparedProviderFailoverOwner } from "../../failover/provider-patterns.js";
 import { classifyRateLimitWindow, resolveRetryAfterMs } from "../../failover/retry-evidence.js";
@@ -111,6 +112,11 @@ export async function handleAssistantFailover(params: {
   }) => Promise<boolean>;
 }): Promise<AssistantFailoverOutcome> {
   const terminal = projectAgentRunAttemptTerminal(params.terminal);
+  // Routing reasons group several HTTP failures; retain the provider's status
+  // when constructing the error so fallback summaries do not invent a timeout.
+  const assistantStatus = params.lastAssistant
+    ? buildAssistantFailoverSignal(params.lastAssistant).status
+    : undefined;
   const externalAbort = terminal.externalAbort || params.signalOwnedInterruption;
   let overloadProfileRotations = params.overloadProfileRotations;
   let decision = params.initialDecision;
@@ -178,7 +184,7 @@ export async function handleAssistantFailover(params: {
         overloadProfileRotations > params.overloadProfileRotationLimit &&
         params.fallbackConfigured
       ) {
-        const status = resolveFailoverStatus("overloaded");
+        const status = assistantStatus ?? resolveFailoverStatus("overloaded");
         params.warn(
           `overload profile rotation cap reached for ${sanitizeForLog(params.provider)}/${sanitizeForLog(params.modelId)} after ${overloadProfileRotations} rotations; escalating to model fallback`,
         );
@@ -273,7 +279,9 @@ export async function handleAssistantFailover(params: {
   if (decision.action === "fallback_model") {
     const message = resolveAssistantFailoverErrorMessage(params);
     const status =
-      resolveFailoverStatus(decision.reason) ?? (isTimeoutErrorMessage(message) ? 408 : undefined);
+      assistantStatus ??
+      resolveFailoverStatus(decision.reason) ??
+      (isTimeoutErrorMessage(message) ? 408 : undefined);
     params.logAssistantFailoverDecision("fallback_model", {
       status,
       retryCount: params.getTransientRetryCount(),
@@ -311,7 +319,9 @@ export async function handleAssistantFailover(params: {
       const message = resolveAssistantFailoverErrorMessage(params);
       const reason = resolveSurfaceErrorReason(decision.reason, params);
       const status =
-        resolveFailoverStatus(reason) ?? (isTimeoutErrorMessage(message) ? 408 : undefined);
+        assistantStatus ??
+        resolveFailoverStatus(reason) ??
+        (isTimeoutErrorMessage(message) ? 408 : undefined);
       const shouldSuspend =
         Boolean(params.sessionKey) && (reason === "rate_limit" || reason === "billing");
 

--- a/src/agents/embedded-agent-runner/run/assistant-failure.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.ts
@@ -91,20 +91,24 @@ export async function handleEmbeddedAssistantFailure(input: {
   agentDir: string;
   isProbeSession: boolean;
 }): Promise<EmbeddedRunAssistantFailureOutcome> {
+  // Successful responses can retain stale error fields. Only current failures
+  // may drive retries, profile health, or failure copy.
+  const failedAssistant =
+    input.attemptAssistant?.stopReason === "error" ? input.attemptAssistant : undefined;
   const { aborted, idleTimedOut, promptError, timedOut } = projectAgentRunAttemptTerminal(
     input.attempt.terminal,
   );
   const terminalInterrupted = isEmbeddedRunTerminalInterrupted(input.terminalState.outcome);
   const { signalOwnedInterruption } = input.terminalState;
   const fallbackThinking = pickFallbackThinkingLevel({
-    message: input.attemptAssistant?.errorMessage,
+    message: failedAssistant?.errorMessage,
     attempted: input.attemptedThinking,
   });
-  const authFailure = isAuthAssistantError(input.attemptAssistant);
-  const rateLimitFailure = isRateLimitAssistantError(input.attemptAssistant);
-  const billingFailure = isBillingAssistantError(input.attemptAssistant);
-  const failoverFailure = isFailoverAssistantError(input.attemptAssistant);
-  const assistantFailoverReason = classifyAssistantFailoverReason(input.attemptAssistant, {
+  const authFailure = isAuthAssistantError(failedAssistant);
+  const rateLimitFailure = isRateLimitAssistantError(failedAssistant);
+  const billingFailure = isBillingAssistantError(failedAssistant);
+  const failoverFailure = isFailoverAssistantError(failedAssistant);
+  const assistantFailoverReason = classifyAssistantFailoverReason(failedAssistant, {
     providerOwner: input.providerOwner,
   });
   const assistantProviderStarted =
@@ -119,7 +123,7 @@ export async function handleEmbeddedAssistantFailure(input: {
       providerStarted: assistantProviderStarted,
       transientRateLimit:
         assistantProfileFailoverReason === "rate_limit" &&
-        isShortWindowRateLimitMessage(input.attemptAssistant?.errorMessage),
+        isShortWindowRateLimitMessage(failedAssistant?.errorMessage),
     },
   );
   const terminalAssistantError = isTerminalAssistantError(input.attemptAssistant);
@@ -140,7 +144,7 @@ export async function handleEmbeddedAssistantFailure(input: {
     });
   }
   const cloudCodeAssistFormatError = input.attempt.cloudCodeAssistFormatError;
-  const imageDimensionError = parseImageDimensionError(input.attemptAssistant?.errorMessage ?? "");
+  const imageDimensionError = parseImageDimensionError(failedAssistant?.errorMessage ?? "");
   // Classified reasons consult the failover retry controller so a zero-output
   // failure draws from the single transient budget instead of stacking silent
   // retries on top of it; only reasons the controller cannot classify use the
@@ -161,7 +165,7 @@ export async function handleEmbeddedAssistantFailure(input: {
     !promptError &&
     shouldRetrySilentErrorAssistantTurn({
       attempt: input.attempt,
-      assistant: input.attemptAssistant,
+      assistant: failedAssistant,
     });
   if (replaySafeSilentErrorFailure) {
     if (silentControllerConsultReason === null) {
@@ -170,8 +174,8 @@ export async function handleEmbeddedAssistantFailure(input: {
         log.warn(
           `[empty-error-retry] stopReason=error non-visible-output; resubmitting ` +
             `attempt=${emptyErrorRetries}/${MAX_EMPTY_ERROR_RETRIES} ` +
-            `provider=${input.attemptAssistant?.provider ?? input.provider} ` +
-            `model=${input.attemptAssistant?.model ?? input.model} ` +
+            `provider=${failedAssistant?.provider ?? input.provider} ` +
+            `model=${failedAssistant?.model ?? input.model} ` +
             `sessionKey=${input.runParams.sessionKey ?? input.runParams.sessionId}`,
         );
         return buildOutcome(input, {
@@ -183,14 +187,14 @@ export async function handleEmbeddedAssistantFailure(input: {
     } else if (
       await input.maybeRetryTransient({
         reason: silentControllerConsultReason,
-        retryAfterMs: resolveRetryAfterMs(input.attemptAssistant?.errorMessage),
+        retryAfterMs: resolveRetryAfterMs(failedAssistant?.errorMessage),
       })
     ) {
       log.warn(
         `[empty-error-retry] stopReason=error non-visible-output; transient ` +
           `reason=${silentControllerConsultReason} retrying same model ` +
-          `provider=${input.attemptAssistant?.provider ?? input.provider} ` +
-          `model=${input.attemptAssistant?.model ?? input.model} ` +
+          `provider=${failedAssistant?.provider ?? input.provider} ` +
+          `model=${failedAssistant?.model ?? input.model} ` +
           `sessionKey=${input.runParams.sessionKey ?? input.runParams.sessionId}`,
       );
       return buildOutcome(input, {
@@ -216,13 +220,13 @@ export async function handleEmbeddedAssistantFailure(input: {
   const logFailoverDecision = createFailoverDecisionLogger({
     stage: "assistant",
     runId: input.runParams.runId,
-    rawError: input.attemptAssistant?.errorMessage?.trim(),
+    rawError: failedAssistant?.errorMessage?.trim(),
     failoverReason: effectiveFailoverReason,
     profileFailureReason: assistantProfileFailureReason,
     provider: input.activeErrorContext.provider,
     model: input.activeErrorContext.model,
-    sourceProvider: input.attemptAssistant?.provider ?? input.provider,
-    sourceModel: input.attemptAssistant?.model ?? input.modelId,
+    sourceProvider: failedAssistant?.provider ?? input.provider,
+    sourceModel: failedAssistant?.model ?? input.modelId,
     profileId: failedProfileId,
     fallbackConfigured: input.fallbackConfigured,
     timedOut,
@@ -235,7 +239,7 @@ export async function handleEmbeddedAssistantFailure(input: {
     !signalOwnedInterruption &&
     authFailure &&
     (await input.maybeRefreshRuntimeAuthForAuthError(
-      input.attemptAssistant?.errorMessage ?? "",
+      failedAssistant?.errorMessage ?? "",
       input.runtimeAuthRetry,
     ))
   ) {
@@ -291,7 +295,7 @@ export async function handleEmbeddedAssistantFailure(input: {
     provider: input.provider,
     providerOwner: input.providerOwner,
     activeErrorContext: input.activeErrorContext,
-    lastAssistant: input.attemptAssistant,
+    lastAssistant: failedAssistant,
     config: input.runParams.config,
     sessionKey: input.runParams.sessionKey ?? input.runParams.sessionId,
     agentId: input.runParams.agentId,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -92,7 +92,7 @@ async function* observeModelCallIterator<T>(
       // the agent loop returns on the terminal event after awaiting result().
       // Close the underlying iterator for provider cleanup (idle-timeout abort
       // listeners, SSE readers) even when result() already emitted the terminal
-      // event; emitModelCallCompleted self-dedupes via state.terminalEventEmitted.
+      // event; lifecycle completion self-dedupes via state.terminalEventEmitted.
       await safeReturnIterator(iterator);
       lifecycle.emitCompleted();
     }

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.test.ts
@@ -121,61 +121,67 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents lifecycle", () => {
     vi.useRealTimers();
   });
 
-  it("emits one successful provider timeline event for result and iterator completion", async () => {
-    let now = Date.parse("2026-07-09T18:30:00.000Z");
-    vi.spyOn(Date, "now").mockImplementation(() => now);
-    async function* stream() {
-      yield { type: "text", text: "ok" };
-    }
-    const originalStream = stream() as unknown as AsyncIterable<unknown> & {
-      result: () => Promise<string>;
-    };
-    originalStream.result = async () => {
-      now += 125;
-      return "kept";
-    };
-    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
-      (() => originalStream) as unknown as StreamFn,
-      {
+  it.each(["stop", "error"])(
+    "emits one %s provider timeline event for result and iterator completion",
+    async (stopReason) => {
+      let now = Date.parse("2026-07-09T18:30:00.000Z");
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+      const assistant = { role: "assistant", stopReason, errorMessage: "request timed out" };
+      async function* stream() {
+        yield stopReason === "error"
+          ? { type: "error", error: assistant }
+          : { type: "done", message: assistant };
+      }
+      const originalStream = stream() as unknown as AsyncIterable<unknown> & {
+        result: () => Promise<typeof assistant>;
+      };
+      originalStream.result = async () => {
+        now += 125;
+        return assistant;
+      };
+      const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+        (() => originalStream) as unknown as StreamFn,
+        {
+          runId: "run-timeline-success",
+          provider: "openai",
+          model: "gpt-5.5",
+          api: "openai-responses",
+          transport: "http",
+          trace: createDiagnosticTraceContext(),
+          nextCallId: () => "call-timeline-success",
+        },
+      );
+
+      const events = await collectProviderTimelineEvents(async () => {
+        const returned = wrapped(
+          {} as never,
+          {} as never,
+          {} as never,
+        ) as unknown as typeof originalStream;
+        await returned.result();
+        await drain(returned);
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: "provider.request",
+        name: "provider.request",
+        timestamp: "2026-07-09T18:30:00.000Z",
         runId: "run-timeline-success",
+        spanId: "call-timeline-success",
+        durationMs: 125,
         provider: "openai",
-        model: "gpt-5.5",
-        api: "openai-responses",
-        transport: "http",
-        trace: createDiagnosticTraceContext(),
-        nextCallId: () => "call-timeline-success",
-      },
-    );
-
-    const events = await collectProviderTimelineEvents(async () => {
-      const returned = wrapped(
-        {} as never,
-        {} as never,
-        {} as never,
-      ) as unknown as typeof originalStream;
-      await returned.result();
-      await drain(returned);
-    });
-
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
-      type: "provider.request",
-      name: "provider.request",
-      timestamp: "2026-07-09T18:30:00.000Z",
-      runId: "run-timeline-success",
-      spanId: "call-timeline-success",
-      durationMs: 125,
-      provider: "openai",
-      operation: "openai-responses",
-      ok: true,
-      attributes: {
-        model: "gpt-5.5",
-        api: "openai-responses",
-        transport: "http",
-      },
-    });
-    expect(events[0]?.status).toBeUndefined();
-  });
+        operation: "openai-responses",
+        ok: stopReason === "stop",
+        attributes: {
+          model: "gpt-5.5",
+          api: "openai-responses",
+          transport: "http",
+        },
+      });
+      expect(events[0]?.status).toBeUndefined();
+    },
+  );
 
   it("records legacy response status without inferring provider acceptance", async () => {
     const originalOnResponse = vi.fn(async () => undefined);
@@ -530,86 +536,96 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents lifecycle", () => {
     expectNumberField(memory, "arrayBuffersBytes");
   });
 
-  it("fires frozen sanitized model-call plugin hooks", async () => {
-    const started = vi.fn();
-    const ended = vi.fn();
-    const { registry } = createHookRunnerWithRegistry([
-      { hookName: "model_call_started", handler: started },
-      { hookName: "model_call_ended", handler: ended },
-    ]);
-    initializeGlobalHookRunner(registry);
-    const secretChunk = "secret response with Bearer sk-test-secret-value";
+  it.each(["stop", "error"])(
+    "fires frozen sanitized model-call plugin hooks for %s",
+    async (stopReason) => {
+      const started = vi.fn();
+      const ended = vi.fn();
+      const { registry } = createHookRunnerWithRegistry([
+        { hookName: "model_call_started", handler: started },
+        { hookName: "model_call_ended", handler: ended },
+      ]);
+      initializeGlobalHookRunner(registry);
+      const secretChunk = "secret response with Bearer sk-test-secret-value";
 
-    async function* stream() {
-      yield { type: "text", text: secretChunk };
-    }
-    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
-      (() => stream()) as unknown as StreamFn,
-      {
-        runId: "run-1",
-        sessionKey: "session-key",
-        sessionId: "session-id",
-        provider: "openai",
-        model: "gpt-5.4",
-        api: "openai-responses",
-        transport: "http",
-        contextTokenBudget: 150_000,
-        contextWindowSource: "modelsConfig",
-        contextWindowReferenceTokens: 200_000,
-        trace: createDiagnosticTraceContext(),
-        nextCallId: () => "call-hook",
-      },
-    );
+      async function* stream() {
+        yield { type: "text", text: secretChunk };
+        if (stopReason === "error") {
+          yield {
+            type: "error",
+            error: { role: "assistant", stopReason, errorMessage: secretChunk },
+          };
+        }
+      }
+      const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+        (() => stream()) as unknown as StreamFn,
+        {
+          runId: "run-1",
+          sessionKey: "session-key",
+          sessionId: "session-id",
+          provider: "openai",
+          model: "gpt-5.4",
+          api: "openai-responses",
+          transport: "http",
+          contextTokenBudget: 150_000,
+          contextWindowSource: "modelsConfig",
+          contextWindowReferenceTokens: 200_000,
+          trace: createDiagnosticTraceContext(),
+          nextCallId: () => "call-hook",
+        },
+      );
 
-    const events = await collectModelCallEvents(async () => {
-      await drain(wrapped({} as never, {} as never, {} as never) as AsyncIterable<unknown>);
-    });
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
+      const events = await collectModelCallEvents(async () => {
+        await drain(wrapped({} as never, {} as never, {} as never) as AsyncIterable<unknown>);
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
 
-    expect(events.map((event) => event.type)).toEqual([
-      "model.call.started",
-      "model.call.completed",
-    ]);
-    const startedEvent = requireMockRecordArg(started, 0, 0, "started hook event");
-    expect(startedEvent.runId).toBe("run-1");
-    expect(startedEvent.callId).toBe("call-hook");
-    expect(startedEvent.sessionKey).toBe("session-key");
-    expect(startedEvent.sessionId).toBe("session-id");
-    expect(startedEvent.provider).toBe("openai");
-    expect(startedEvent.model).toBe("gpt-5.4");
-    expect(startedEvent.api).toBe("openai-responses");
-    expect(startedEvent.transport).toBe("http");
-    expect(startedEvent.contextTokenBudget).toBe(150_000);
-    expect(startedEvent.contextWindowSource).toBe("modelsConfig");
-    expect(startedEvent.contextWindowReferenceTokens).toBe(200_000);
-    const startedCtx = requireMockRecordArg(started, 0, 1, "started hook context");
-    expect(startedCtx.runId).toBe("run-1");
-    expect(startedCtx.sessionKey).toBe("session-key");
-    expect(startedCtx.sessionId).toBe("session-id");
-    expect(startedCtx.modelProviderId).toBe("openai");
-    expect(startedCtx.modelId).toBe("gpt-5.4");
-    expect(startedCtx.contextTokenBudget).toBe(150_000);
-    expect(startedCtx.contextWindowSource).toBe("modelsConfig");
-    expect(startedCtx.contextWindowReferenceTokens).toBe(200_000);
-    const endedEvent = requireMockRecordArg(ended, 0, 0, "ended hook event");
-    expect(endedEvent.runId).toBe("run-1");
-    expect(endedEvent.callId).toBe("call-hook");
-    expect(endedEvent.outcome).toBe("completed");
-    expect(endedEvent.contextTokenBudget).toBe(150_000);
-    expect(endedEvent.contextWindowSource).toBe("modelsConfig");
-    expect(endedEvent.contextWindowReferenceTokens).toBe(200_000);
-    expectNumberField(endedEvent, "durationMs");
-    expectNumberField(endedEvent, "responseStreamBytes");
-    expectNumberField(endedEvent, "timeToFirstByteMs");
-    const endedCtx = requireMockRecordArg(ended, 0, 1, "ended hook context");
-    expect(endedCtx.runId).toBe("run-1");
-    expect(Object.isFrozen(startedEvent)).toBe(true);
-    expect(Object.isFrozen(startedCtx)).toBe(true);
-    expect(Object.isFrozen(startedCtx.trace)).toBe(true);
-    expect(JSON.stringify([started.mock.calls, ended.mock.calls])).not.toContain(secretChunk);
-  });
+      expect(events.map((event) => event.type)).toEqual([
+        "model.call.started",
+        stopReason === "error" ? "model.call.error" : "model.call.completed",
+      ]);
+      const startedEvent = requireMockRecordArg(started, 0, 0, "started hook event");
+      expect(startedEvent.runId).toBe("run-1");
+      expect(startedEvent.callId).toBe("call-hook");
+      expect(startedEvent.sessionKey).toBe("session-key");
+      expect(startedEvent.sessionId).toBe("session-id");
+      expect(startedEvent.provider).toBe("openai");
+      expect(startedEvent.model).toBe("gpt-5.4");
+      expect(startedEvent.api).toBe("openai-responses");
+      expect(startedEvent.transport).toBe("http");
+      expect(startedEvent.contextTokenBudget).toBe(150_000);
+      expect(startedEvent.contextWindowSource).toBe("modelsConfig");
+      expect(startedEvent.contextWindowReferenceTokens).toBe(200_000);
+      const startedCtx = requireMockRecordArg(started, 0, 1, "started hook context");
+      expect(startedCtx.runId).toBe("run-1");
+      expect(startedCtx.sessionKey).toBe("session-key");
+      expect(startedCtx.sessionId).toBe("session-id");
+      expect(startedCtx.modelProviderId).toBe("openai");
+      expect(startedCtx.modelId).toBe("gpt-5.4");
+      expect(startedCtx.contextTokenBudget).toBe(150_000);
+      expect(startedCtx.contextWindowSource).toBe("modelsConfig");
+      expect(startedCtx.contextWindowReferenceTokens).toBe(200_000);
+      const endedEvent = requireMockRecordArg(ended, 0, 0, "ended hook event");
+      expect(endedEvent.runId).toBe("run-1");
+      expect(endedEvent.callId).toBe("call-hook");
+      expect(endedEvent.outcome).toBe(stopReason === "error" ? "error" : "completed");
+      expect(ended).toHaveBeenCalledOnce();
+      expect(endedEvent.contextTokenBudget).toBe(150_000);
+      expect(endedEvent.contextWindowSource).toBe("modelsConfig");
+      expect(endedEvent.contextWindowReferenceTokens).toBe(200_000);
+      expectNumberField(endedEvent, "durationMs");
+      expectNumberField(endedEvent, "responseStreamBytes");
+      expectNumberField(endedEvent, "timeToFirstByteMs");
+      const endedCtx = requireMockRecordArg(ended, 0, 1, "ended hook context");
+      expect(endedCtx.runId).toBe("run-1");
+      expect(Object.isFrozen(startedEvent)).toBe(true);
+      expect(Object.isFrozen(startedCtx)).toBe(true);
+      expect(Object.isFrozen(startedCtx.trace)).toBe(true);
+      expect(JSON.stringify([started.mock.calls, ended.mock.calls])).not.toContain(secretChunk);
+    },
+  );
 
   it("keeps core model-call diagnostics while suppressing finalization plugin hooks", async () => {
     const started = vi.fn();

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-lifecycle.ts
@@ -98,6 +98,7 @@ export type ModelCallObservationState = {
   lastStreamProgressAt?: number;
   semanticProgressEmitted?: boolean;
   terminalEventEmitted?: boolean;
+  terminalError?: Error;
   suppressPluginHooks?: boolean;
 };
 export type ModelCallObserver = {
@@ -279,10 +280,11 @@ function dispatchModelCallEndedHook(
   );
 }
 
-function emitModelCallCompleted(
+function emitModelCallEnded(
   eventBase: ModelCallEventBase,
   startedAt: number,
   observer: ModelCallObserver,
+  failure: { error: unknown } | undefined,
   ownerGeneration: CoreModelRequestOwnerGeneration | undefined,
 ): void {
   if (observer.state.terminalEventEmitted) {
@@ -291,66 +293,27 @@ function emitModelCallCompleted(
   observer.state.terminalEventEmitted = true;
   const durationMs = Date.now() - startedAt;
   const sizeTimingFields = observer.sizeTimingFields();
-  emitProviderRequestTimelineEvent(
-    eventBase,
-    startedAt,
-    durationMs,
-    true,
-    observer.state.responseStatus,
-    observer.state.providerAcceptanceKind,
-  );
-  emitCoreModelRequestEndedDiagnosticEvent(
-    {
-      type: "model.call.completed",
-      ...eventBase,
-      durationMs,
-      ...sizeTimingFields,
-      ...observer.usageField(),
-    },
-    ownerGeneration,
-    modelContentPrivateData(observer.completedContent()),
-  );
-  if (!observer.state.suppressPluginHooks) {
-    dispatchModelCallEndedHook(eventBase, {
-      durationMs,
-      outcome: "completed",
-      ...sizeTimingFields,
-    });
-  }
-}
-
-function emitModelCallError(
-  eventBase: ModelCallEventBase,
-  startedAt: number,
-  observer: ModelCallObserver,
-  err: unknown,
-  ownerGeneration: CoreModelRequestOwnerGeneration | undefined,
-): void {
-  if (observer.state.terminalEventEmitted) {
-    return;
-  }
-  observer.state.terminalEventEmitted = true;
-  const durationMs = Date.now() - startedAt;
-  const sizeTimingFields = observer.sizeTimingFields();
-  const fields = modelCallErrorFields(err);
-  const errorStatus = diagnosticHttpStatusCode(err);
+  const fields = failure ? modelCallErrorFields(failure.error) : undefined;
+  const terminal = fields
+    ? { type: "model.call.error" as const, ...fields }
+    : { type: "model.call.completed" as const };
+  const errorStatus = failure ? diagnosticHttpStatusCode(failure.error) : undefined;
   const responseStatus =
     observer.state.responseStatus ?? (errorStatus === undefined ? undefined : Number(errorStatus));
   emitProviderRequestTimelineEvent(
     eventBase,
     startedAt,
     durationMs,
-    false,
+    failure === undefined,
     responseStatus,
     observer.state.providerAcceptanceKind,
   );
   emitCoreModelRequestEndedDiagnosticEvent(
     {
-      type: "model.call.error",
+      ...terminal,
       ...eventBase,
       durationMs,
       ...sizeTimingFields,
-      ...fields,
       ...observer.usageField(),
     },
     ownerGeneration,
@@ -359,7 +322,7 @@ function emitModelCallError(
   if (!observer.state.suppressPluginHooks) {
     dispatchModelCallEndedHook(eventBase, {
       durationMs,
-      outcome: "error",
+      outcome: failure ? "error" : "completed",
       ...sizeTimingFields,
       ...fields,
     });
@@ -450,10 +413,22 @@ export function createModelLifecycle(params: {
     propagatedOptions,
     startedAt,
     emitCompleted() {
-      emitModelCallCompleted(eventBase, startedAt, observer, params.ctx.ownerGeneration);
+      emitModelCallEnded(
+        eventBase,
+        startedAt,
+        observer,
+        observer.state.terminalError ? { error: observer.state.terminalError } : undefined,
+        params.ctx.ownerGeneration,
+      );
     },
     emitError(err: unknown) {
-      emitModelCallError(eventBase, startedAt, observer, err, params.ctx.ownerGeneration);
+      emitModelCallEnded(
+        eventBase,
+        startedAt,
+        observer,
+        { error: err },
+        params.ctx.ownerGeneration,
+      );
     },
   };
 }

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-observation.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-observation.test.ts
@@ -643,57 +643,100 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents observation", () => {
     expect(JSON.stringify(events)).not.toContain("private tool description");
   });
 
-  it("captures per-call usage from terminal error events", async () => {
-    // Aborted/error streams terminate with an `error` event carrying the final
-    // AssistantMessage and its usage. Iterating to completion without awaiting
-    // result() must still surface per-call usage, matching the `done` path and
-    // the usage field already emitted on model.call.error and its OTel span.
-    const assistant = {
-      role: "assistant",
-      content: [{ type: "text", text: "partial reply" }],
-      usage: {
+  it.each(
+    [
+      {
+        stopReason: "aborted",
+        errorMessage: undefined,
+        errorCode: undefined,
+        failureKind: "aborted",
+      },
+      {
+        stopReason: "error",
+        errorMessage: "request timed out",
+        errorCode: undefined,
+        failureKind: "timeout",
+      },
+      {
+        stopReason: "error",
+        errorMessage: "provider unavailable",
+        errorCode: "ETIMEDOUT",
+        failureKind: "timeout",
+      },
+    ].flatMap((failure) =>
+      ["iterator", "result", "result-then-iterator", "iterator-then-result"].map((consumption) =>
+        Object.assign({}, failure, { consumption }),
+      ),
+    ),
+  )(
+    "records $stopReason/$failureKind via $consumption with usage and no duplicate terminal event",
+    async ({ stopReason, errorMessage, errorCode, failureKind, consumption }) => {
+      const assistant = {
+        role: "assistant",
+        content: [{ type: "text", text: "partial reply" }],
+        usage: {
+          input: 11,
+          output: 7,
+          cacheRead: 3,
+          cacheWrite: 2,
+          reasoningTokens: 5,
+          totalTokens: 28,
+        },
+        stopReason,
+        errorMessage,
+        errorCode,
+        timestamp: 1,
+      };
+      async function* stream() {
+        yield { type: "error", reason: stopReason, error: assistant };
+      }
+      const originalStream = Object.assign(stream(), { result: async () => assistant });
+      const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+        (() => originalStream) as unknown as StreamFn,
+        {
+          runId: "run-1",
+          provider: "openrouter",
+          model: "openrouter/auto",
+          trace: createDiagnosticTraceContext(),
+          nextCallId: () => "call-error-usage",
+        },
+      );
+
+      const events = await collectModelCallEvents(async () => {
+        const response = wrapped(
+          {} as never,
+          {} as never,
+          {} as never,
+        ) as unknown as typeof originalStream;
+        if (consumption === "result" || consumption === "result-then-iterator") {
+          expect(await response.result()).toBe(assistant);
+        }
+        if (consumption !== "result") {
+          for await (const event of response) {
+            expect(event.error).toBe(assistant);
+            if (consumption === "iterator-then-result") {
+              expect(await response.result()).toBe(assistant);
+              break;
+            }
+          }
+        }
+      });
+
+      expect(events.map((event) => event.type)).toEqual(["model.call.started", "model.call.error"]);
+      const errorEvent = getEvent(events, 1);
+      expect(errorEvent.failureKind).toBe(failureKind);
+      expect(errorEvent.responseStreamBytes).toBeGreaterThan(0);
+      expect(errorEvent.usage).toEqual({
         input: 11,
         output: 7,
         cacheRead: 3,
         cacheWrite: 2,
         reasoningTokens: 5,
-        totalTokens: 28,
-      },
-      stopReason: "aborted",
-      timestamp: 1,
-    };
-    async function* stream() {
-      yield { type: "error", reason: "aborted", error: assistant };
-    }
-    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
-      (() => stream()) as unknown as StreamFn,
-      {
-        runId: "run-1",
-        provider: "openrouter",
-        model: "openrouter/auto",
-        trace: createDiagnosticTraceContext(),
-        nextCallId: () => "call-error-usage",
-      },
-    );
-
-    const events = await collectModelCallEvents(async () => {
-      await drain(wrapped({} as never, {} as never, {} as never) as AsyncIterable<unknown>);
-    });
-
-    // An in-band error event is data, not a throw, so iteration completes
-    // normally; the per-call usage rides on the terminal completion event.
-    const completedEvent = getEvent(events, 1);
-    expect(completedEvent.type).toBe("model.call.completed");
-    expect(completedEvent.usage).toEqual({
-      input: 11,
-      output: 7,
-      cacheRead: 3,
-      cacheWrite: 2,
-      reasoningTokens: 5,
-      total: 28,
-      promptTokens: 16,
-    });
-  });
+        total: 28,
+        promptTokens: 16,
+      });
+    },
+  );
 
   it("skips prompt stat computation when diagnostics are disabled", async () => {
     // Prompt stats are only attached to diagnostic events; when diagnostics are

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-observation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-observation.ts
@@ -155,13 +155,24 @@ function normalizedModelCallUsage(rawUsage: unknown): ModelCallUsage | undefined
   };
 }
 
-function observeModelCallUsage(state: ModelCallObservationState, value: unknown): void {
+function observeModelCallTerminalMessage(state: ModelCallObservationState, value: unknown): void {
   if (!isRecord(value)) {
     return;
   }
   let rawUsage: unknown;
   try {
     rawUsage = value.usage;
+    // The stream contract returns failed assistant messages without throwing.
+    // Keep their terminal fact for both iterator and result-only completion.
+    if (
+      value.role === "assistant" &&
+      (value.stopReason === "error" || value.stopReason === "aborted")
+    ) {
+      state.terminalError ??= Object.assign(
+        new Error(typeof value.errorMessage === "string" ? value.errorMessage : value.stopReason),
+        { code: value.errorCode },
+      );
+    }
   } catch {
     return;
   }
@@ -188,7 +199,7 @@ function observeOutputMessageContent(state: ModelCallObservationState, chunk: un
   // iterated error-terminated calls still report the per-call usage that the
   // model.call.error event and its OTel span already expose.
   if (message !== undefined) {
-    observeModelCallUsage(state, message);
+    observeModelCallTerminalMessage(state, message);
     if (state.contentCapture?.outputMessages) {
       state.outputMessages = [cloneDiagnosticContentValue(message)];
     }
@@ -201,7 +212,7 @@ function observeResultMessageContent(
   result: unknown,
 ): void {
   state.timeToFirstByteMs ??= Math.max(0, Date.now() - startedAt);
-  observeModelCallUsage(state, result);
+  observeModelCallTerminalMessage(state, result);
   if (state.contentCapture?.outputMessages && state.outputMessages === undefined) {
     state.outputMessages = [cloneDiagnosticContentValue(result)];
   }

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -251,6 +251,23 @@ function appendNormalizedPluginMetadataOwners(
   }
 }
 
+export function resolveImplicitProviderDiscoveryScope(
+  params: Pick<
+    ImplicitProviderParams,
+    "config" | "workspaceDir" | "env" | "pluginMetadataSnapshot" | "providerDiscoveryProviderIds"
+  >,
+): ProviderDiscoveryScope | undefined {
+  return resolveProviderDiscoveryScope({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env ?? process.env,
+    resolveOwners: params.pluginMetadataSnapshot
+      ? (provider) => resolvePluginMetadataProviderOwners(params.pluginMetadataSnapshot, provider)
+      : undefined,
+    providerIds: params.providerDiscoveryProviderIds,
+  });
+}
+
 function mergeImplicitProviderSet(
   target: Record<string, ProviderConfig>,
   additions: Record<string, ProviderConfig> | undefined,
@@ -573,15 +590,7 @@ export async function prepareImplicitProviderStaticCatalog(
   >,
 ): Promise<PreparedProviderStaticCatalog> {
   const env = params.env ?? process.env;
-  const discoveryScope = resolveProviderDiscoveryScope({
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env,
-    resolveOwners: params.pluginMetadataSnapshot
-      ? (provider) => resolvePluginMetadataProviderOwners(params.pluginMetadataSnapshot, provider)
-      : undefined,
-    providerIds: params.providerDiscoveryProviderIds,
-  });
+  const discoveryScope = resolveImplicitProviderDiscoveryScope(params);
   const providers = await resolveRuntimePluginDiscoveryProviders({
     config: params.config,
     workspaceDir: params.workspaceDir,
@@ -635,15 +644,7 @@ export async function resolveImplicitProviders(
       allowKeychainPrompt: false,
       externalCliProviderIds: params.providerDiscoveryProviderIds,
     }));
-  const discoveryScope = resolveProviderDiscoveryScope({
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env,
-    resolveOwners: params.pluginMetadataSnapshot
-      ? (provider) => resolvePluginMetadataProviderOwners(params.pluginMetadataSnapshot, provider)
-      : undefined,
-    providerIds: params.providerDiscoveryProviderIds,
-  });
+  const discoveryScope = resolveImplicitProviderDiscoveryScope(params);
   const discoveryPluginIds = discoveryScope ? [...discoveryScope.keys()] : undefined;
   // The runtime config has already resolved SecretRefs at its owning boundary.
   // Re-resolving source refs here would execute unrelated file/exec providers on catalog reads.

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -8,9 +8,11 @@ import {
 } from "../config/resolution-facts.js";
 import { setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import { serveWorkerTasks } from "../infra/worker-task-pool.js";
+import { listRuntimePluginIdsFromRegistry } from "../plugins/active-runtime-registry.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { isManifestPluginAvailableForControlPlane } from "../plugins/manifest-contract-eligibility.js";
 import { restorePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { planRuntimePluginDiscovery } from "../plugins/provider-discovery.js";
 import { manifestPluginResolvesRuntimeModelCatalogAugment } from "../plugins/providers.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
@@ -27,13 +29,16 @@ import {
   loadAuthProfileStoreWithoutExternalProfiles,
   preserveResolvedSecretBackedCredentials,
 } from "./auth-profiles/store.js";
+import { resolveImplicitProviderDiscoveryScope } from "./models-config.providers.implicit.js";
 import {
   fingerprintPreparedModelCatalogGeneration,
   type PreparedModelCatalogWorkerInput,
   type PreparedModelWorkerRequest,
   type PreparedModelWorkerResult,
 } from "./prepared-model-catalog-worker.js";
+import { prepareOwnedPluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
 import { scopeSyntheticAuthProviderRefs } from "./prepared-model-runtime.synthetic-auth.js";
+import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
 
 function refreshAuthStore(params: {
@@ -223,19 +228,56 @@ export async function runPreparedModelCatalogWorkerRequest(
         (left, right) => left.localeCompare(right),
       ),
     };
+    const { pluginMetadataSnapshot, pluginRegistry } = prepared.pluginGeneration;
+    const discoveryScope = resolveImplicitProviderDiscoveryScope({
+      config: value.input.config,
+      env: value.input.env,
+      workspaceDir: value.input.workspaceDir,
+      pluginMetadataSnapshot,
+      providerDiscoveryProviderIds: exactAgentFacts.providerIds,
+    });
+    const discoveryPluginIds = [...(discoveryScope?.keys() ?? [])];
+    const discoveryPlan = await withPluginRuntimeGenerationScope(pluginGenerationScope, () =>
+      planRuntimePluginDiscovery({
+        config: value.input.config,
+        env: value.input.env,
+        workspaceDir: value.input.workspaceDir,
+        pluginMetadataSnapshot,
+        onlyPluginIds: discoveryPluginIds,
+      }),
+    );
+    let catalogGeneration = prepared.pluginGeneration;
+    if (discoveryPlan.kind === "runtime") {
+      // Refresh can reveal credential-only providers absent at startup. Materialize their
+      // catalog owners from the captured metadata before binding the authoritative registry.
+      const catalogRegistry = loadAgentRuntimePluginRegistryHandle({
+        ...value.input,
+        metadataSnapshot: pluginMetadataSnapshot,
+        preferBuiltPluginArtifacts: value.preferBuiltPluginArtifacts,
+        reusableRegistry: pluginRegistry,
+        basePluginIds: [
+          ...(pluginRegistry ? listRuntimePluginIdsFromRegistry(pluginRegistry) : []),
+          ...(discoveryPlan.pluginIds ?? discoveryPluginIds),
+        ],
+      });
+      prepareOwnedPluginLoadContext(
+        value.input,
+        value.input.env ?? process.env,
+        catalogRegistry,
+        pluginMetadataSnapshot,
+        value.preferBuiltPluginArtifacts,
+      );
+      pluginGenerationScope.pluginRegistry = catalogRegistry;
+      catalogGeneration = Object.freeze({ ...catalogGeneration, pluginRegistry: catalogRegistry });
+    }
     const source = await prepareAgentCatalogSource(
       exactAgentFacts,
-      prepared.pluginGeneration,
+      catalogGeneration,
       "live",
       false,
       { authStore },
     );
-    const facts = await prepareFullCatalogFacts(
-      exactAgentFacts,
-      prepared.pluginGeneration,
-      "live",
-      source,
-    );
+    const facts = await prepareFullCatalogFacts(exactAgentFacts, catalogGeneration, "live", source);
     // Full discovery can publish routes absent from startup config. Pair those exact rows with
     // provider-owned synthetic auth before the catalog and auth modes cross the worker boundary.
     const catalogCredentials = resolveSyntheticCredentials(

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -15,6 +15,10 @@ import {
   resolvePluginRuntimeArtifactPreference,
 } from "./plugin-runtime-artifact-selection.js";
 import { buildEffectiveManifestProviderConfig } from "./provider-catalog.js";
+import type {
+  ProviderDiscoveryPlan,
+  ResolveRuntimePluginDiscoveryProvidersParams,
+} from "./provider-discovery.js";
 import { resolveDiscoveredProviderPluginIds } from "./providers.js";
 import { resolvePluginProvidersCore } from "./providers.runtime.js";
 import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-scope.js";
@@ -281,18 +285,9 @@ function resolveRuntimeEntryProviders(entryResult: ProviderDiscoveryEntryResult)
   });
 }
 
-export function resolvePluginDiscoveryProvidersRuntime(params: {
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  onlyPluginIds?: string[];
-  includeUntrustedWorkspacePlugins?: boolean;
-  requireCompleteDiscoveryEntryCoverage?: boolean;
-  discoveryEntriesOnly?: boolean;
-  includeManifestModelCatalogProviders?: boolean;
-  includeSyntheticAuthProviders?: boolean;
-  pluginMetadataSnapshot?: PluginMetadataRegistryView;
-}): ProviderPlugin[] {
+export function planPluginDiscoveryRuntime(
+  params: ResolveRuntimePluginDiscoveryProvidersParams,
+): ProviderDiscoveryPlan {
   const env = params.env ?? process.env;
   const entryResult = resolveProviderDiscoveryEntryPlugins({ ...params, env });
   const entryProviders = entryResult.providers.filter(
@@ -303,7 +298,7 @@ export function resolvePluginDiscoveryProvidersRuntime(params: {
   );
   const runtimeEntryProviders = resolveRuntimeEntryProviders(entryResult);
   if (params.discoveryEntriesOnly === true) {
-    return entryProviders;
+    return { kind: "entries", providers: entryProviders };
   }
   if (
     entryResult.providers.length > 0 &&
@@ -311,7 +306,7 @@ export function resolvePluginDiscoveryProvidersRuntime(params: {
     runtimeEntryProviders.length === entryResult.providers.length &&
     entryResult.runtimeManifestCatalogPluginIds.size === 0
   ) {
-    return runtimeEntryProviders;
+    return { kind: "entries", providers: runtimeEntryProviders };
   }
   let fullPluginIds = params.onlyPluginIds;
   let retainedProviders: ProviderPlugin[] | undefined;
@@ -329,7 +324,7 @@ export function resolvePluginDiscoveryProvidersRuntime(params: {
       ...entryResult.runtimeManifestCatalogPluginIds,
     ]);
     if (fullPluginIds.length === 0) {
-      return [...runtimeEntryProviders];
+      return { kind: "entries", providers: runtimeEntryProviders };
     }
     const fullPluginIdSet = new Set(fullPluginIds);
     retainedProviders = runtimeEntryProviders.filter(
@@ -345,10 +340,20 @@ export function resolvePluginDiscoveryProvidersRuntime(params: {
       fullPluginIds = entryPluginIds;
     }
   }
+  return { kind: "runtime", providers: retainedProviders ?? [], pluginIds: fullPluginIds };
+}
+
+export function resolvePluginDiscoveryProvidersRuntime(
+  params: ResolveRuntimePluginDiscoveryProvidersParams,
+): ProviderPlugin[] {
+  const plan = planPluginDiscoveryRuntime(params);
+  if (plan.kind === "entries") {
+    return plan.providers;
+  }
   const fullProviders = resolvePluginProvidersCore({
     ...params,
-    env,
-    ...(fullPluginIds ? { onlyPluginIds: fullPluginIds } : {}),
+    env: params.env ?? process.env,
+    ...(plan.pluginIds ? { onlyPluginIds: plan.pluginIds } : {}),
   });
-  return retainedProviders ? [...retainedProviders, ...fullProviders] : fullProviders;
+  return [...plan.providers, ...fullProviders];
 }

--- a/src/plugins/provider-discovery.ts
+++ b/src/plugins/provider-discovery.ts
@@ -49,7 +49,7 @@ export type PreparedProviderStaticCatalog = Readonly<{
 }>;
 
 /** Options for resolving plugin providers that can contribute model catalog entries. */
-type ResolveRuntimePluginDiscoveryProvidersParams = {
+export type ResolveRuntimePluginDiscoveryProvidersParams = {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
@@ -61,6 +61,16 @@ type ResolveRuntimePluginDiscoveryProvidersParams = {
   includeSyntheticAuthProviders?: boolean;
   pluginMetadataSnapshot?: PluginMetadataRegistryView;
 };
+
+export type ProviderDiscoveryPlan =
+  | { kind: "entries"; providers: ProviderPlugin[] }
+  | { kind: "runtime"; providers: ProviderPlugin[]; pluginIds: string[] | undefined };
+
+export async function planRuntimePluginDiscovery(
+  params: ResolveRuntimePluginDiscoveryProvidersParams,
+): Promise<ProviderDiscoveryPlan> {
+  return (await loadProviderRuntime()).planPluginDiscoveryRuntime(params);
+}
 
 /** Loads provider runtime discovery and filters to providers that can produce catalog order entries. */
 export async function resolveRuntimePluginDiscoveryProviders(

--- a/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
@@ -10,7 +10,9 @@ type JsonObject = Record<string, unknown>;
 const BOT_TOKEN = `424242:${"A".repeat(35)}`;
 const CHAT_ID = -1001234;
 const SENDER_ID = 777;
-const FAILURE_TEXT = "Something went wrong while processing your request. Please try again.";
+const FAILURE_TEXT =
+  "⚠️ mock-openai/gpt-5.6-luna-alt request failed (provider internal error, HTTP 500). This is usually temporary — try again shortly.";
+const RAW_ERROR_CANARY = "untrusted-provider-detail-qa-canary";
 
 async function readRequest(req: IncomingMessage): Promise<JsonObject> {
   let text = "";
@@ -45,7 +47,7 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
     const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
     if (pathname.startsWith("/v1/")) {
       providerRequests += 1;
-      writeJson(res, 500, { error: { message: "provider returned HTTP 500" } });
+      writeJson(res, 500, { error: { message: `provider returned HTTP 500 ${RAW_ERROR_CANARY}` } });
       return;
     }
 
@@ -168,6 +170,7 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
               sends: [{ chatId: String(CHAT_ID), silent: true, text: FAILURE_TEXT }],
             });
           expect(providerRequests).toBeGreaterThan(0);
+          expect(telegramSends.map((send) => send.text).join("\n")).not.toContain(RAW_ERROR_CANARY);
         } finally {
           await stopQaGatewayFixture(gatewayOwner);
           for (const poll of pendingPolls) {

--- a/test/gateway-cold-agent-abort.e2e.test.ts
+++ b/test/gateway-cold-agent-abort.e2e.test.ts
@@ -125,15 +125,18 @@ it(
       const aborted = await client.request("chat.abort", { sessionKey, runId });
       expect(aborted).toMatchObject({ aborted: true, runIds: [runId] });
       const terminal = await final;
-      // resolveRunLivenessState persists a stop before any output as blocked.
-      expect(terminal).toMatchObject({
+      // The agent RPC retains its cancellation wire status; the task records the outcome.
+      expect(terminal).toEqual({
         runId,
-        status: "error",
-        summary: "failed",
-        stopReason: "aborted",
-        result: { meta: { aborted: true, stopReason: "aborted", livenessState: "blocked" } },
+        status: "timeout",
+        summary: "aborted",
+        stopReason: "rpc",
       });
-      expect(terminal).not.toHaveProperty("result.meta.error");
+      expect(await client.request("tasks.list", { sessionKey })).toEqual({
+        tasks: [
+          expect.objectContaining({ runId, childSessionKey: sessionKey, status: "cancelled" }),
+        ],
+      });
       await vi.waitFor(() => expect(providerAborted).toBe(true), { timeout: 5_000 });
       expect(providerRequests).toBe(1);
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cold model inventories lose provider display names and reasoning metadata, provider HTTP 500 failures are presented as HTTP 408 timeouts, and diagnostic streams report failed model calls as completed. These defects and stale retry/cancellation fixtures broke Gateway E2E in [2026.9.1 Full Release Validation #4](https://github.com/openclaw/openclaw/actions/runs/33714427358), child run [33715186698](https://github.com/openclaw/openclaw/actions/runs/33715186698).

All five reported failures reproduce on both release Code SHA `730dc392a5bc198774971f2ec61ee28ba46aba36` and main `eea96a33d8912a737e24920baddb56a02e6a467e`. They are pre-existing main failures, not missing companions to the run #3→#4 cherry-picks. The PR is based on `401ad5b14b485813b53c590801cf6394191168e2`; its affected source is identical to the tested main baseline.

## Why This Change Was Made

The catalog worker now shares canonical discovery planning and materializes the required catalog owners after auth refresh, using the captured metadata and a separate catalog generation. Failure handling keeps the provider's actual HTTP status and selects error fields only from failed assistants. Model diagnostics record terminal stream failures through one deduplicated emitter for events, timelines, and sanitized hooks.

The fixtures now exercise the existing contracts: persistent faults exhaust the shared retry budget; Stop produces its established cancellation wire response and a cancelled task; the recovery mock stalls exactly the fifth request, then lets subsequent failures settle through the normal retry budget. The recovery test and its timing/assertions remain unchanged.

## User Impact

Cold catalog listings retain their names and reasoning capabilities, including providers discovered through newly persisted credentials. Operators receive accurate failure copy and timeout diagnostics. Stale error text on a successful reply cannot trigger an unnecessary thinking retry or replace a later timeout. Telegram failure settlement continues to produce one visible error reply with notifications disabled without leaking raw provider details.

Production code is **+58 lines net**: +58 for the catalog ownership phase and shared planning, +14 for error provenance, and −14 from consolidating diagnostic termination. Tests/support are +212 net; docs are +2. There are no runtime retry, timeout, configuration, protocol, or storage changes.

## Evidence

| Failure | Before, on release and main | Repair / after |
| --- | --- | --- |
| A — cold ClawRouter catalog | Both original cases lose name/reasoning metadata | Three cases pass, including auth introduced after worker input; 116 owner/sibling tests pass |
| B — fault sequences | The same three of eight cases fail | Eight cases pass with exact delays, profile order, fallback winner, and exhaustion text |
| C — cold Gateway abort | Expects obsolete failed/blocked result | Exact cancellation payload, cancelled task, provider closure, and one request pass |
| D — Telegram failure settlement | 17 provider requests; final copy incorrectly says HTTP 408 | Exact HTTP 500 reply and raw-error privacy assertion pass; status matrix fails six cases before and 82 owner tests pass after |
| E — repeated-request recovery | Times out at 510 seconds | Unchanged test passes on patched main (420.3s) and release (425.5s): real 90s timeout, one stall, no recovery takeover, exactly one queued success |

Two additional full-entry regressions demonstrate stale successful-assistant error text causing misleading timeout copy and an unnecessary second attempt. Both fail before; six context cases and 21 failure-owner tests pass after. For diagnostics, all 12 new consumption/error cases plus two hook/timeline cases fail before; 52 owner tests pass after. The diagnostic-only Gateway run reaches the timeout predicate and exposes the separate repeated-stall fixture defect.

The integrated main run passes all five E2E files (14 tests); patched release passes A–D together (13 tests) and E separately (1 test). `pnpm build`, private QA runtime builds, and `pnpm check:changed --base 401ad5b14b485813b53c590801cf6394191168e2` pass. One test-matrix lint issue was corrected before the final clean check. The refreshed local Codex P2 review is clean.

The requested `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P2` review is scoped-clean with no findings. All seven exact commits cherry-pick cleanly onto release Code SHA `730dc392a5bc198774971f2ec61ee28ba46aba36`; the verification checkout is clean.

Backport order: A, B, C, D stale error fields, D HTTP status, E diagnostics, E fixture. All are new PR commits; there are no existing main-only prerequisite picks.

```sh
git cherry-pick \
  608583cf2efef4a5af70493ce4b124918d62cbd0 \
  3ca630b53ca981bc10713e1fe4644ea52bcadddb \
  897187f81ba65c78c8bc2c496b30e816bf3a7b8f \
  d330e36df62b255e52da3871a7f8d4ba74d00a73 \
  32e2a90f2ebc6634e9a06327acfd6031d4246710 \
  c5bb7a682c1696c76c36b3954dbf5d996e778881 \
  141e1458be09f5c92e65a0446d1c624fc67053bc
```

Contract audit: terminal errors are returned stream data in `packages/llm-core/src/types.ts:198–206` and `packages/ai/src/transports/transport-stream-shared.ts:445–456`. Direct upstream Codex inspection covered [model metadata](https://github.com/openai/codex/blob/94cbbddafc1776d5e377bca1b05932c697e82238/codex-rs/app-server/src/models.rs#L27-L66) and [interrupted turns](https://github.com/openai/codex/blob/94cbbddafc1776d5e377bca1b05932c697e82238/codex-rs/app-server/src/bespoke_event_handling.rs#L1565-L1588); the repaired owners remain in OpenClaw.

History: A's worker narrowing (`cf59ce401fee`), B's retry contract (`4a1cc226964a`), C's Stop repair (`03e4bc05af66`), D's safe failure-copy contract (`ee8657a02329`), and E's observer/fixture history (`0e7250f37bf3`, `c8c6e5a990b2`) all predate run #3's `37a5c5bd3d88`. No existing main-only fix replaces these repairs. Why run #3 did not expose the failures remains unproven; its logs were not refetched. The full Linux release workflow was not rerun; the before/after Gateway proofs here run locally on macOS with Node 26.8.1.
