### PR TITLE
test(infra): reuse the shared dotenv warning guard

### DIFF
--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { describe, expect, it, vi } from "vitest";
 import { loadCliDotEnv } from "../cli/dotenv.js";
 import { captureFullEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
@@ -15,14 +16,6 @@ const loggerMocks = vi.hoisted(() => ({
 vi.mock("../logging/subsystem.js", () => ({
   createSubsystemLogger: vi.fn(() => loggerMocks),
 }));
-
-function requireFirstWarnCall(): [unknown, unknown] {
-  const [call] = loggerMocks.warn.mock.calls;
-  if (!call) {
-    throw new Error("expected logger warning");
-  }
-  return call as [unknown, unknown];
-}
 
 const CREDENTIAL_AND_GATEWAY_ENV_KEYS = [
   "ANTHROPIC_API_KEY",
@@ -244,7 +237,10 @@ describe("loadDotEnv", () => {
         expect(process.env.FOO).toBe("from-global");
         expect(process.env.BAR).toBe("from-gateway");
         expect(loggerMocks.warn).toHaveBeenCalledOnce();
-        const [message, metadata] = requireFirstWarnCall();
+        const [message, metadata] = expectDefined(
+          loggerMocks.warn.mock.calls[0],
+          "logger warning call",
+        );
         expect(String(message)).toContain("Conflicting values in");
         expect(String((metadata as { ignoredPath?: unknown } | undefined)?.ignoredPath)).toContain(
           "gateway.env",


### PR DESCRIPTION
## What Problem This Solves

The dotenv conflict-warning test has a one-use helper solely to unwrap its first logged call, duplicating existing assertion support.

## Why This Change Was Made

Use the shared `expectDefined` helper through its narrow entrypoint at the assertion site. Keep the one-warning count, `String` conversions, message and `ignoredPath` assertions, and existing fixture lifecycle unchanged.

## User Impact

No runtime behavior changes. All existing dotenv precedence, credential and workspace denial, CLI, and cleanup coverage remains. Production: 0 lines changed; tests: +5/-9 (net -4).

## Evidence

- The same dotenv, global-reader, workspace-blocklist, and canonical assertion-helper suites passed all 45 cases before and after, with identical inventories and suite order.
- `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- src/infra/dotenv.test.ts`: all 20 selected canonical local stages passed, including test types, dead-export scans, and type-aware lint.
- Formatting and independent Codex review passed with no actionable P0-P2 findings. Node 26.8.1 was pinned; the signed commit preserves the tested bytes.
