### PR TITLE
refactor(logging): simplify diagnostic event assertions

### DIFF
--- a/src/logging/diagnostic-log-events.test.ts
+++ b/src/logging/diagnostic-log-events.test.ts
@@ -146,21 +146,15 @@ describe("diagnostic log events", () => {
     unsubscribe();
 
     expect(received).toHaveLength(1);
-    const [event] = received;
-    expect(expectDefined(event, "event test invariant").message).not.toContain(secret);
-    expect(expectDefined(event, "event test invariant").message.length).toBeLessThanOrEqual(4200);
-    expect(expectDefined(event, "event test invariant").attributes?.token).not.toBe(secret);
-    expect(String(expectDefined(event, "event test invariant").attributes?.token)).toContain("…");
-    expect(
-      String(expectDefined(event, "event test invariant").attributes?.longValue).length,
-    ).toBeLessThanOrEqual(2100);
-    expect(
-      Object.hasOwn(expectDefined(event, "event test invariant").attributes ?? {}, "nested"),
-    ).toBe(false);
-    expect(
-      Object.hasOwn(expectDefined(event, "event test invariant").attributes ?? {}, "bad key"),
-    ).toBe(false);
-    expect(Object.hasOwn(expectDefined(event, "event test invariant"), "argsJson")).toBe(false);
+    const event = expectDefined(received[0], "event test invariant");
+    expect(event.message).not.toContain(secret);
+    expect(event.message.length).toBeLessThanOrEqual(4200);
+    expect(event.attributes?.token).not.toBe(secret);
+    expect(String(event.attributes?.token)).toContain("…");
+    expect(String(event.attributes?.longValue).length).toBeLessThanOrEqual(2100);
+    expect(Object.hasOwn(event.attributes ?? {}, "nested")).toBe(false);
+    expect(Object.hasOwn(event.attributes ?? {}, "bad key")).toBe(false);
+    expect(Object.hasOwn(event, "argsJson")).toBe(false);
   });
 
   it("keeps bounded diagnostic messages UTF-16 safe", async () => {
@@ -207,11 +201,9 @@ describe("diagnostic log events", () => {
     unsubscribe();
 
     expect(received).toHaveLength(1);
-    expect(expectDefined(received[0], "received[0] test invariant").attributes?.safe).toBe("ok");
-    expect(
-      Object.keys(expectDefined(received[0], "received[0] test invariant").attributes ?? {}),
-    ).toHaveLength(32);
     const attributes = expectDefined(received[0], "received[0] test invariant").attributes ?? {};
+    expect(attributes.safe).toBe("ok");
+    expect(Object.keys(attributes)).toHaveLength(32);
     expect(Object.hasOwn(attributes, PROTO_KEY)).toBe(false);
     expect(Object.hasOwn(attributes, "constructor")).toBe(false);
     expect(Object.hasOwn(attributes, "prototype")).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

Repeated checks of the same captured diagnostic event make the redaction and bounds tests harder to read.

## Why This Change Was Made

Reuse one guarded event or attributes binding in two existing cases. All six scenarios and 31 assertions retain their inputs, expected values, delivery waits and cleanup order. Test code decreases eight lines; production code is unchanged.

## User Impact

No runtime or user-visible behavior changes. Privacy, trace provenance, UTF-16 truncation, attribute limits and diagnostic delivery coverage remain intact.

## Evidence

- The same four suites passed on the unchanged baseline and candidate: **27 tests across four files**, including the six diagnostic event cases, file-log redaction, multi-batch capture and canonical guard helpers.
- The full normal changed gate passed for `src/logging/diagnostic-log-events.test.ts`, including services test typechecking, formatting, lint, repository guards and all three dead-export scans.
- Independent Codex review through P2: scoped-clean, no actionable findings.
- Tested locally with Node 26.8.1 and pnpm 12.1.0 against the frozen dependency lock. Hosted CI is pending first publication; no live runtime claim is made for this test-only cleanup.
