### PR TITLE
codex/dashboard visibility owner

### DIFF
--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -705,8 +705,7 @@ suite.define(() => {
     await currentPage.getByRole("button", { name: "Session sharing" }).click();
     const dropdown = currentPage.locator(".chat-pane__sharing-menu");
     await expect.poll(() => dropdown.getAttribute("open")).not.toBeNull();
-    await dropdown.locator(".chat-pane__sharing-visibility-title").waitFor();
-    await dropdown.locator(".chat-pane__sharing-owner-title").waitFor();
+    await expectBrowser(dropdown.locator(".chat-pane__sharing-title")).toHaveCount(2);
     await currentPage.getByText("Publish draft", { exact: true }).click();
     await gateway.waitForRequest("session.visibility.set");
     await expect.poll(() => dropdown.getAttribute("open")).toBeNull();

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -205,14 +205,14 @@ suite.define(() => {
       const slotBounds = slot.getBoundingClientRect();
       const textBounds = text.getBoundingClientRect();
       return {
-        backSize: [backBounds.width, backBounds.height],
+        backSize: [Math.round(backBounds.width), Math.round(backBounds.height)],
         centerDelta:
           stackBounds.left + stackBounds.width / 2 - (slotBounds.left + slotBounds.width / 2),
-        frontSize: [frontBounds.width, frontBounds.height],
+        frontSize: [Math.round(frontBounds.width), Math.round(frontBounds.height)],
         overlap: backBounds.right - frontBounds.left,
         reveal: frontBounds.left - backBounds.left,
         slotWidth: slotBounds.width,
-        stackSize: [stackBounds.width, stackBounds.height],
+        stackSize: [Math.round(stackBounds.width), Math.round(stackBounds.height)],
         textGap: textBounds.left - stackBounds.right,
       };
     });

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -705,7 +705,8 @@ suite.define(() => {
     await currentPage.getByRole("button", { name: "Session sharing" }).click();
     const dropdown = currentPage.locator(".chat-pane__sharing-menu");
     await expect.poll(() => dropdown.getAttribute("open")).not.toBeNull();
-    expect(await dropdown.locator(".chat-pane__sharing-title").count()).toBe(1);
+    await dropdown.locator(".chat-pane__sharing-visibility-title").waitFor();
+    await dropdown.locator(".chat-pane__sharing-owner-title").waitFor();
     await currentPage.getByText("Publish draft", { exact: true }).click();
     await gateway.waitForRequest("session.visibility.set");
     await expect.poll(() => dropdown.getAttribute("open")).toBeNull();

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5204,6 +5204,7 @@ export const en: TranslationMap & {
       suggest: "Suggest",
       draft: "Draft",
       publishDraft: "Publish draft",
+      owner: "Owner",
       members: "Members",
       selected: "Member",
       noPeople: "No paired people found.",

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -191,30 +191,6 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       sharingReadAccess.allowed || sharingVisibilityAccess.allowed
         ? undefined
         : sharingReadAccess.reason;
-    const sharing =
-      sharingMethodsSupported && row
-        ? {
-            session: row,
-            state: this.sessionSharingStates.get(this.sessionSharingCacheKey(row.key)),
-            allowedVisibilities: sharingSnapshot.hello?.policy?.allowedSessionVisibilities,
-            membersAvailable: sharingReadAccess.allowed,
-            openDisabledReason: sharingOpenDisabledReason,
-            visibilityDisabledReason: sharingVisibilityAccess.allowed
-              ? undefined
-              : sharingVisibilityAccess.reason,
-            memberAddDisabledReason: sharingMemberAddAccess.allowed
-              ? undefined
-              : sharingMemberAddAccess.reason,
-            memberRemoveDisabledReason: sharingMemberRemoveAccess.allowed
-              ? undefined
-              : sharingMemberRemoveAccess.reason,
-            onOpen: () => void this.loadSessionSharing(row),
-            onVisibilityChange: (visibility: SessionVisibility) =>
-              void this.setSessionVisibility(row, visibility),
-            onMemberChange: (identityId: string, member: boolean) =>
-              void this.setSessionMember(row, identityId, member),
-          }
-        : null;
     const renameAccess = row
       ? readSessionMethodAccess(this.context.gateway.snapshot, {
           method: "sessions.patch",
@@ -426,6 +402,33 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       (user) =>
         presenceMatchesProfile(user, renderedOwnerIdentity) && user.watchedSessions.includes(key),
     );
+    const sharing =
+      sharingMethodsSupported && row
+        ? {
+            session: row,
+            state: this.sessionSharingStates.get(this.sessionSharingCacheKey(row.key)),
+            allowedVisibilities: sharingSnapshot.hello?.policy?.allowedSessionVisibilities,
+            membersAvailable: sharingReadAccess.allowed,
+            openDisabledReason: sharingOpenDisabledReason,
+            visibilityDisabledReason: sharingVisibilityAccess.allowed
+              ? undefined
+              : sharingVisibilityAccess.reason,
+            memberAddDisabledReason: sharingMemberAddAccess.allowed
+              ? undefined
+              : sharingMemberAddAccess.reason,
+            memberRemoveDisabledReason: sharingMemberRemoveAccess.allowed
+              ? undefined
+              : sharingMemberRemoveAccess.reason,
+            ownerViewing,
+            personActivity,
+            showOwner: showOwnerChip,
+            onOpen: () => void this.loadSessionSharing(row),
+            onVisibilityChange: (visibility: SessionVisibility) =>
+              void this.setSessionVisibility(row, visibility),
+            onMemberChange: (identityId: string, member: boolean) =>
+              void this.setSessionMember(row, identityId, member),
+          }
+        : null;
     const header = renderChatPaneHeader({
       paneId: this.paneId,
       narrow: this.narrow,
@@ -502,7 +505,9 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
         onDockSideChange: (dock) => this.handleBoardDockChange(dock),
       }),
       sharingControl:
-        sharing && (!this.narrow || !canManageChatSessionSharing(sharing.session))
+        sharing &&
+        (!canManageChatSessionSharing(sharing.session) || !sharing.openDisabledReason) &&
+        (!this.narrow || !canManageChatSessionSharing(sharing.session))
           ? renderChatSessionSharing(sharing)
           : nothing,
       placementControl: renderChatPanePlacement({

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -405,7 +405,7 @@ describe("chat pane header", () => {
     expect(crumbs?.nextElementSibling?.getAttribute("data-slot")).toBe("placement");
   });
 
-  it("groups visibility with the face switch inside the centered header region", () => {
+  it("places visibility in the owner slot while the face switch stays centered", () => {
     const { container } = mountHeader({
       placementControl: html`<span data-slot="placement"></span>`,
       presence: html`<span data-slot="presence"></span>`,
@@ -420,20 +420,39 @@ describe("chat pane header", () => {
       "chat-pane__header-center",
     );
     expect(container.querySelector('[data-slot="sharing"]')?.parentElement?.className).toBe(
-      "chat-pane__header-center",
+      "chat-pane__header-leading",
     );
   });
 
-  it("keeps visibility with trailing actions when the session has no face switch", () => {
+  it("keeps visibility in the owner slot when the session has no face switch", () => {
     const { container } = mountHeader({
       faceControl: nothing,
       sharingControl: html`<span data-slot="sharing"></span>`,
     });
 
     expect(container.querySelector('[data-slot="sharing"]')?.parentElement?.className).toBe(
-      "chat-pane__header-trailing",
+      "chat-pane__header-leading",
     );
     expect(container.querySelector(".chat-pane__header--centered")).toBeNull();
+  });
+
+  it("replaces the header owner avatar when visibility is available", () => {
+    const actor = {
+      type: "human" as const,
+      id: "profile-ada",
+      identity: { type: "profile" as const, id: "profile-ada" },
+      label: "Ada",
+    };
+    const { container } = mountHeader({
+      session: row({ owner: { actor } }),
+      showOwnerChip: true,
+      sharingControl: html`<span data-slot="sharing"></span>`,
+    });
+
+    expect(container.querySelector("openclaw-session-owner-chip")).toBeNull();
+    expect(container.querySelector('[data-slot="sharing"]')?.parentElement?.className).toBe(
+      "chat-pane__header-leading",
+    );
   });
 
   it("uses the full header width when no face switch needs centering", () => {

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -386,6 +386,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
   const drawerLabel = props.navDrawerOpen ? t("nav.collapse") : t("nav.expand");
   const compactSessionActions = props.narrow && props.sessionMenuAction !== nothing;
   const hasFaceControl = props.faceControl !== undefined && props.faceControl !== nothing;
+  const hasSharingControl = props.sharingControl !== undefined && props.sharingControl !== nothing;
 
   return html`
     <div
@@ -422,23 +423,25 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
             >`
           : nothing}
         ${renderIdentityCrumbs(props, copied, copyPathLabel, copyBranchLabel)}
-        ${renderStandalonePersonLink(
-          renderSessionOwnerChip(
-            props.showOwnerChip ? props.session?.owner?.actor : undefined,
-            "header",
-            props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
-            props.ownerViewing,
-          ),
-          props.showOwnerChip
-            ? personActivityLink(
-                props.session?.owner?.actor.identity?.type === "profile"
-                  ? props.session.owner.actor.identity.id
-                  : undefined,
-                props.personActivity,
-                props.session?.owner?.actor.label,
-              )
-            : null,
-        )}
+        ${hasSharingControl
+          ? props.sharingControl
+          : renderStandalonePersonLink(
+              renderSessionOwnerChip(
+                props.showOwnerChip ? props.session?.owner?.actor : undefined,
+                "header",
+                props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
+                props.ownerViewing,
+              ),
+              props.showOwnerChip
+                ? personActivityLink(
+                    props.session?.owner?.actor.identity?.type === "profile"
+                      ? props.session.owner.actor.identity.id
+                      : undefined,
+                    props.personActivity,
+                    props.session?.owner?.actor.label,
+                  )
+                : null,
+            )}
         ${props.showOwnerChip && props.session?.participants?.length
           ? html`<openclaw-viewer-facepile
               class="chat-pane__participants"
@@ -452,12 +455,9 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
         ${props.placementControl ?? nothing} ${props.presence ?? nothing}
       </div>
       ${hasFaceControl
-        ? html`<div class="chat-pane__header-center">
-            ${props.faceControl} ${props.sharingControl ?? nothing}
-          </div>`
+        ? html`<div class="chat-pane__header-center">${props.faceControl}</div>`
         : nothing}
       <div class="chat-pane__header-trailing">
-        ${hasFaceControl ? nothing : (props.sharingControl ?? nothing)}
         ${!props.catalog && props.branches.length > 1
           ? html`
               <wa-dropdown

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -100,6 +100,9 @@ describe("chat session sharing menu", () => {
     const items = [...root.querySelectorAll<HTMLElement>(".chat-pane__sharing-visibility-item")];
     expect(items).toHaveLength(4);
     expect(items.every((item) => item.querySelector('[slot="icon"]') !== null)).toBe(true);
+    const draftIcon = root.querySelector('[value="visibility:draft"] [slot="icon"]');
+    expect(draftIcon?.querySelector("svg")).not.toBeNull();
+    expect(draftIcon?.textContent?.trim()).toBe("");
     expect(items.map((item) => item.getAttribute("role"))).toEqual(
       items.map(() => "menuitemradio"),
     );
@@ -214,7 +217,9 @@ describe("chat session sharing menu", () => {
       }),
     );
     expect(root.querySelector("wa-dropdown")).toBeNull();
-    expect(root.querySelector(".chat-pane__draft-indicator")?.textContent).toContain("👻");
+    const indicator = root.querySelector(".chat-pane__draft-indicator");
+    expect(indicator?.querySelector("svg")).not.toBeNull();
+    expect(indicator?.textContent?.trim()).toBe("");
   });
 
   it("publishes a manageable draft through the shared visibility callback", () => {

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -73,11 +73,11 @@ describe("chat session sharing menu", () => {
     const ownerLink = root.querySelector<HTMLAnchorElement>(
       ".chat-pane__sharing-owner a.person-activity-link",
     );
-    expect(ownerLink?.getAttribute("href")).toBe("/activity?person=owner");
+    expect(ownerLink?.getAttribute("href")).toBe("/activity/owner");
     expect(root.querySelector(".session-menu__separator")).toBeNull();
 
     ownerLink?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-    expect(navigate).toHaveBeenCalledWith("owner");
+    expect(navigate).toHaveBeenCalledWith("owner", "Owner");
 
     dropdown?.dispatchEvent(
       new CustomEvent("wa-select", {
@@ -257,7 +257,7 @@ describe("chat session sharing menu", () => {
       root
         .querySelector("a.person-activity-avatar-link:has(openclaw-session-owner-chip)")
         ?.getAttribute("href"),
-    ).toBe("/activity?person=owner");
+    ).toBe("/activity/owner");
   });
 
   it("publishes a manageable draft through the shared visibility callback", () => {

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -20,6 +20,7 @@ describe("chat session sharing menu", () => {
   it("shows the owner picker with policy-gated modes and known identities", () => {
     const onVisibilityChange = vi.fn();
     const onMemberChange = vi.fn();
+    const navigate = vi.fn();
     const root = mount(
       renderChatSessionSharing({
         session: {
@@ -33,7 +34,12 @@ describe("chat session sharing menu", () => {
           loading: false,
           result: {
             sessionKey: "agent:main:main",
-            owner: { type: "human", id: "owner", label: "Owner" },
+            owner: {
+              type: "human",
+              id: "owner",
+              identity: { type: "profile", id: "owner" },
+              label: "Owner",
+            },
             members: [],
             identities: [
               { type: "human", id: "owner", label: "Owner" },
@@ -43,6 +49,8 @@ describe("chat session sharing menu", () => {
             allowedVisibilities: ["shared", "read-only"],
           },
         },
+        ownerViewing: false,
+        personActivity: { basePath: "", navigate },
         onOpen: vi.fn(),
         onVisibilityChange,
         onMemberChange,
@@ -55,7 +63,21 @@ describe("chat session sharing menu", () => {
     expect(root.textContent).not.toContain("Suggest");
     expect(root.textContent).toContain("Alice");
     expect(root.querySelector('wa-dropdown-item[value="member:owner"]')).toBeNull();
+    expect(root.querySelector(".chat-pane__sharing-owner-title")?.textContent?.trim()).toBe(
+      "Owner",
+    );
+    expect(root.querySelector(".chat-pane__sharing-owner")?.textContent?.trim()).toBe("Owner");
+    expect(
+      root.querySelector(".chat-pane__sharing-owner openclaw-session-owner-chip"),
+    ).not.toBeNull();
+    const ownerLink = root.querySelector<HTMLAnchorElement>(
+      ".chat-pane__sharing-owner a.person-activity-link",
+    );
+    expect(ownerLink?.getAttribute("href")).toBe("/activity?person=owner");
     expect(root.querySelector(".session-menu__separator")).toBeNull();
+
+    ownerLink?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(navigate).toHaveBeenCalledWith("owner");
 
     dropdown?.dispatchEvent(
       new CustomEvent("wa-select", {
@@ -200,7 +222,7 @@ describe("chat session sharing menu", () => {
     expect(root.querySelectorAll(".chat-pane__sharing-member-skeleton .skeleton")).toHaveLength(6);
   });
 
-  it("shows only the draft marker to a non-manager", () => {
+  it("keeps the linked owner beside the draft marker for a non-manager", () => {
     const root = mount(
       renderChatSessionSharing({
         session: {
@@ -209,8 +231,19 @@ describe("chat session sharing menu", () => {
           updatedAt: 1,
           visibility: "draft",
           sharingRole: "member",
+          owner: {
+            actor: {
+              type: "human",
+              id: "owner",
+              identity: { type: "profile", id: "owner" },
+              label: "Owner",
+            },
+          },
         },
         state: undefined,
+        ownerViewing: false,
+        personActivity: { basePath: "", navigate: vi.fn() },
+        showOwner: true,
         onOpen: vi.fn(),
         onVisibilityChange: vi.fn(),
         onMemberChange: vi.fn(),
@@ -220,6 +253,11 @@ describe("chat session sharing menu", () => {
     const indicator = root.querySelector(".chat-pane__draft-indicator");
     expect(indicator?.querySelector("svg")).not.toBeNull();
     expect(indicator?.textContent?.trim()).toBe("");
+    expect(
+      root
+        .querySelector("a.person-activity-avatar-link:has(openclaw-session-owner-chip)")
+        ?.getAttribute("href"),
+    ).toBe("/activity?person=owner");
   });
 
   it("publishes a manageable draft through the shared visibility callback", () => {

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -39,7 +39,7 @@ const VISIBILITY_LABEL_KEYS: Record<SessionVisibility, string> = {
 
 function sharingIcon(visibility: SessionVisibility): TemplateResult {
   if (visibility === "draft") {
-    return html`<span aria-hidden="true">👻</span>`;
+    return icons.pencil;
   }
   return visibility === "shared" ? icons.users : icons.lock;
 }
@@ -104,7 +104,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
   if (!canManage) {
     return visibility === "draft"
       ? html`<span class="chat-pane__draft-indicator" title=${t("chat.sessionSharing.draft")}
-          >👻</span
+          >${sharingIcon("draft")}</span
         >`
       : nothing;
   }

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -116,6 +116,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
   const ownerActivity = personActivityLink(
     owner?.identity?.type === "profile" ? owner.identity.id : undefined,
     props.personActivity,
+    owner?.label,
   );
   if (!canManage) {
     return visibility === "draft"

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -6,6 +6,13 @@ import type {
   SessionVisibility,
 } from "../../../api/types.ts";
 import { icons } from "../../../components/icons.ts";
+import {
+  personActivityLink,
+  renderPersonAvatarLink,
+  renderPersonName,
+  renderStandalonePersonLink,
+  type PersonActivityRouting,
+} from "../../../components/person-activity-link.ts";
 import { renderSessionOwnerChip } from "../../../components/session-owner-chip.ts";
 import { syncDropdownItemRadio } from "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
@@ -25,6 +32,9 @@ export type ChatSessionSharingProps = {
   visibilityDisabledReason?: string;
   memberAddDisabledReason?: string;
   memberRemoveDisabledReason?: string;
+  ownerViewing?: boolean;
+  personActivity?: PersonActivityRouting;
+  showOwner?: boolean;
   onOpen: () => void;
   onVisibilityChange: (visibility: SessionVisibility) => void;
   onMemberChange: (identityId: string, member: boolean) => void;
@@ -101,16 +111,28 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
   }
   const visibility = session.visibility ?? "shared";
   const canManage = canManageChatSessionSharing(session);
+  const result = props.state?.result;
+  const owner = result?.owner ?? session.owner?.actor;
+  const ownerActivity = personActivityLink(
+    owner?.identity?.type === "profile" ? owner.identity.id : undefined,
+    props.personActivity,
+  );
   if (!canManage) {
     return visibility === "draft"
-      ? html`<span class="chat-pane__draft-indicator" title=${t("chat.sessionSharing.draft")}
-          >${sharingIcon("draft")}</span
-        >`
+      ? html`${props.showOwner && owner
+            ? renderStandalonePersonLink(
+                renderSessionOwnerChip(owner, "header", "owned", props.ownerViewing),
+                ownerActivity,
+              )
+            : nothing}<span
+            class="chat-pane__draft-indicator"
+            title=${t("chat.sessionSharing.draft")}
+            >${sharingIcon("draft")}</span
+          >`
       : nothing;
   }
-  const result = props.state?.result;
   const members = new Set(result?.members.map((member) => member.identityId) ?? []);
-  // The shared header owner chip presents effective ownership; this picker manages mutable members.
+  // The owner row presents effective ownership; selectable rows below manage mutable members.
   const identities =
     result?.identities.filter((identity) => identity.id !== result.owner?.id) ?? [];
   const allowed = result?.allowedVisibilities ?? props.allowedVisibilities ?? [visibility];
@@ -118,7 +140,8 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
   const membersAvailable = props.membersAvailable !== false;
   const visibilityOptions = allowed.filter((option) => !canPublish || option !== "shared");
   const shouldCapMembers =
-    membersAvailable && visibilityOptions.length + identities.length + (canPublish ? 1 : 0) > 12;
+    membersAvailable &&
+    visibilityOptions.length + identities.length + (canPublish ? 1 : 0) + (owner ? 1 : 0) > 12;
   const content = html`
     ${canPublish
       ? html`<wa-dropdown-item
@@ -159,6 +182,28 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
         </wa-dropdown-item>
       `;
     })}
+    ${owner
+      ? html`
+          <div class="chat-pane__sharing-title chat-pane__sharing-owner-title">
+            ${t("chat.sessionSharing.owner")}
+          </div>
+          <div class="chat-pane__sharing-owner">
+            <span class="chat-pane__sharing-member-icon" aria-hidden="true">
+              ${owner.type === "human"
+                ? renderPersonAvatarLink(
+                    renderSessionOwnerChip(owner, "header", "owned", props.ownerViewing),
+                    ownerActivity,
+                  )
+                : icons.bot}
+            </span>
+            ${renderPersonName(
+              owner.label ?? owner.id ?? t("chat.sessionSharing.owner"),
+              ownerActivity,
+              "session-menu__text",
+            )}
+          </div>
+        `
+      : nothing}
     ${membersAvailable
       ? html`
           <div class="chat-pane__sharing-title chat-pane__sharing-members-title">

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -830,6 +830,11 @@ openclaw-chat-pane {
   font-size: 13px;
 }
 
+.chat-pane__draft-indicator svg {
+  width: 15px;
+  height: 15px;
+}
+
 .chat-pane__header-center .chat-pane__draft-indicator {
   width: 28px;
   height: 28px;

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -767,6 +767,20 @@ openclaw-chat-pane {
   margin-top: 8px;
 }
 
+.chat-pane__sharing-owner-title {
+  margin-top: 8px;
+}
+
+.chat-pane__sharing-owner {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  min-height: 36px;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  font-size: 12px;
+}
+
 .chat-pane__sharing-member-skeleton {
   display: grid;
   grid-template-columns: 20px minmax(0, 1fr);


### PR DESCRIPTION
## Summary

- Replace the owner chip with the compact visibility trigger in the same leading header slot.
- Move Owner into the visibility menu while preserving readable person Activity links.
- Use the shared Lucide icon for Draft instead of an emoji.
- Preserve the standard visibility icons, selected checkmarks, and member skeleton.

## Visual proof

| Change | Before | After |
| --- | --- | --- |
| Draft icon | ![Draft before](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/02-draft-before.png) | ![Draft after](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/02-draft-after.png) |
| Visibility trigger | ![Visibility trigger before](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/03-visibility-trigger-before.png) | ![Visibility trigger after](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/03-visibility-trigger-after.png) |
| Owner placement | ![Owner before](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/04-owner-before.png) | ![Owner after](https://gist.githubusercontent.com/Patrick-Erichsen/20029f1ee5f5478a2f47005ef869b8ee/raw/04-owner-after.png) |

## Validation

- 61 focused header, identity-link, and sharing tests passed.
- Rejected visibility-change browser flow passed with both Visibility and Owner sections present.
- `pnpm tsgo:ui`
- Production LOC: +124 / -53. Test and test-support LOC: +73 / -11. Growth is the visibility-menu owner row and shared header wiring.

## Stack

1. This PR
2. #137068 — dashboard side-panel presentation
3. #137069 — dashboard gallery

