### PR TITLE
perf: release parent inputs while workers execute

### DIFF
--- a/src/infra/worker-task-pool.retention.test-support.ts
+++ b/src/infra/worker-task-pool.retention.test-support.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { setImmediate, setTimeout } from "node:timers/promises";
+import { WorkerTaskPool } from "./worker-task-pool.js";
+import type { PoolFixtureInput, PoolFixtureResult } from "./worker-task-pool.test-support.js";
+
+const pool = new WorkerTaskPool<PoolFixtureInput, PoolFixtureResult>({
+  workerUrl: new URL("./worker-task-pool.test-support.ts", import.meta.url),
+  maxWorkers: 1,
+});
+
+try {
+  for (const factory of [false, true]) {
+    const counters = new SharedArrayBuffer(8);
+    const view = new Int32Array(counters);
+    let reference!: WeakRef<ArrayBuffer>;
+    const completion = (() => {
+      const buffer = new ArrayBuffer(1024 * 1024);
+      new Uint8Array(buffer)[0] = 37;
+      reference = new WeakRef(buffer);
+      const input = { label: "retention", counters, wait: true, buffer };
+      return pool.run(factory ? () => input : input, { timeoutMs: 10_000 });
+    })();
+    void completion.catch(() => {});
+    try {
+      const deadline = Date.now() + 10_000;
+      while (Atomics.load(view, 0) !== 1) {
+        assert.ok(Date.now() < deadline, "worker must receive input");
+        await setTimeout(5);
+      }
+      for (let index = 0; index < 4; index++) {
+        await setImmediate();
+        global.gc!();
+      }
+      assert.equal(
+        reference.deref() === undefined,
+        true,
+        `parent retained ${factory ? "factory" : "direct"} input`,
+      );
+      Atomics.store(view, 1, 1);
+      Atomics.notify(view, 1);
+      const result = await completion;
+      assert.equal(result.label, "retention");
+      assert.equal(new Uint8Array(result.buffer!)[0], 37);
+    } finally {
+      Atomics.store(view, 1, 1);
+      Atomics.notify(view, 1);
+      await Promise.allSettled([completion]);
+    }
+  }
+} finally {
+  await pool.close();
+}

--- a/src/infra/worker-task-pool.test.ts
+++ b/src/infra/worker-task-pool.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { channel } from "node:diagnostics_channel";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -196,4 +197,17 @@ describe("worker task pool", () => {
     );
     expect(stdout.trim()).toBe("finished");
   }, 20_000);
+
+  it("releases parent inputs while their worker copies are still executing", async () => {
+    await promisify(execFile)(
+      process.execPath,
+      [
+        "--expose-gc",
+        "--import",
+        "tsx",
+        fileURLToPath(new URL("./worker-task-pool.retention.test-support.ts", import.meta.url)),
+      ],
+      { timeout: 20_000 },
+    );
+  }, 25_000);
 });

--- a/src/infra/worker-task-pool.ts
+++ b/src/infra/worker-task-pool.ts
@@ -3,6 +3,7 @@ import { parentPort, Worker, type Transferable, type WorkerOptions } from "node:
 import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { createDeferredCore, type Deferred } from "../shared/deferred.js";
 
 type WorkerTaskInput<Input> = Input | (() => Input | Promise<Input>);
 type WorkerTaskOptions<Input> = {
@@ -11,11 +12,9 @@ type WorkerTaskOptions<Input> = {
   transferList?: (input: Input) => readonly Transferable[];
 };
 type WorkerReply<Output> = { status: "ok"; value: Output } | { status: "failed"; error: string };
-type Task<Input, Output> = {
-  input: WorkerTaskInput<Input>;
+type Task<Input, Output> = Deferred<Output> & {
+  input?: WorkerTaskInput<Input>;
   options: WorkerTaskOptions<Input>;
-  resolve: (value: Output) => void;
-  reject: (error: Error) => void;
   timer: NodeJS.Timeout;
   abort: () => void;
   done: boolean;
@@ -62,30 +61,27 @@ export class WorkerTaskPool<Input, Output> {
     if (this.closedError) {
       return Promise.reject(this.closedError);
     }
-    return new Promise<Output>((resolve, reject) => {
-      const abort = () =>
-        this.cancel(task, toErrorObject(options.signal?.reason, "worker task aborted"));
-      const task: Task<Input, Output> = {
-        input,
-        options,
-        resolve,
-        reject,
-        abort,
-        done: false,
-        // Queueing and asynchronous preparation consume the same budget as execution.
-        timer: setTimeout(
-          () => this.cancel(task, new WorkerTaskError("worker task timed out", "timeout")),
-          resolveTimerTimeoutMs(options.timeoutMs, 60_000),
-        ),
-      };
-      options.signal?.addEventListener("abort", abort, { once: true });
-      this.queue.push(task);
-      if (options.signal?.aborted) {
-        abort();
-      } else {
-        this.dispatch();
-      }
-    });
+    // A Promise executor would let the task's timer/abort closures retain input too.
+    const task: Task<Input, Output> = {
+      ...createDeferredCore<Output>(),
+      input,
+      options,
+      abort: () => this.cancel(task, toErrorObject(options.signal?.reason, "worker task aborted")),
+      done: false,
+      // Queueing and asynchronous preparation consume the same budget as execution.
+      timer: setTimeout(
+        () => this.cancel(task, new WorkerTaskError("worker task timed out", "timeout")),
+        resolveTimerTimeoutMs(options.timeoutMs, 60_000),
+      ),
+    };
+    options.signal?.addEventListener("abort", task.abort, { once: true });
+    this.queue.push(task);
+    if (options.signal?.aborted) {
+      task.abort();
+    } else {
+      this.dispatch();
+    }
+    return task.promise;
   }
 
   close(
@@ -123,12 +119,15 @@ export class WorkerTaskPool<Input, Output> {
   }
 
   private async start(slot: Slot<Input, Output>, task: Task<Input, Output>): Promise<void> {
+    // Execution owns the input now; retaining it on task duplicates the worker's clone.
+    const taskInput = task.input!;
+    delete task.input;
     let input: Input;
     try {
       input =
-        typeof task.input === "function"
-          ? await (task.input as () => Input | Promise<Input>)() // SAFETY: Callable inputs are factories.
-          : task.input;
+        typeof taskInput === "function"
+          ? await (taskInput as () => Input | Promise<Input>)() // SAFETY: Callable inputs are factories.
+          : taskInput;
     } catch (error) {
       this.fail(slot, toErrorObject(error, "worker task preparation failed"));
       return;


### PR DESCRIPTION
## What Problem This Solves

Busy compute workers kept an unnecessary copy of each request alive in the Gateway until execution finished. Large Code Mode and compaction inputs could therefore occupy both the worker and parent heaps.

## Why This Change Was Made

The shared worker pool now consumes its queued input when execution starts and uses the existing deferred-promise helper. Both changes matter: removing the task field alone still leaves the original input captured by the Promise executor through timer and abort callbacks. Queueing, cancellation, timeouts, transferred buffers and worker retirement retain their existing owners.

## User Impact

Compute work can release the parent copy once the worker owns its input. There are no configuration, protocol, persistence or output changes. Production LOC: **−1**.

## Evidence

- A real blocked worker received a 32 MiB buffer. Before the repair, both direct inputs and input factories retained the parent buffer; after the repair both parent buffers were collected while the worker still returned intact data. Main-isolate external memory fell by exactly 32 MiB in this scoped witness. This is not a whole-Gateway RSS claim.
- The checked-in collection regression fails against the original owner and passes after the repair. The worker pool, compaction planning and Code Mode lifecycle suites pass: 58 tests.
- The canonical changed-file checks pass, including core and test typechecks, formatting, lint and architecture guards.
- Independent source review and fresh managed Codex autoreview through P2 found no actionable findings.
- Node documents that [worker messages are cloned immediately](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist); no parent mutation or retry path needs to retain the input after dispatch.
