### PR TITLE
perf: avoid redundant config directory existence probes

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -134,7 +134,7 @@ describe("normalizeE164", () => {
 });
 
 describe("resolveConfigDir", () => {
-  it("prefers ~/.openclaw when legacy dir is missing", async () => {
+  it("resolves the default config directory", async () => {
     await withTestDir({ prefix: "openclaw-config-dir-" }, async (root) => {
       const newDir = path.join(root, ".openclaw");
       await fs.promises.mkdir(newDir, { recursive: true });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,16 +73,7 @@ export function resolveConfigDir(
   if (configPath) {
     return path.dirname(resolveUserPath(configPath, env, homedir));
   }
-  const newDir = path.join(resolveRequiredHomeDir(env, homedir), ".openclaw");
-  try {
-    const hasNew = fs.existsSync(newDir);
-    if (hasNew) {
-      return newDir;
-    }
-  } catch {
-    // best-effort
-  }
-  return newDir;
+  return path.join(resolveRequiredHomeDir(env, homedir), ".openclaw");
 }
 
 /** Resolves the effective OpenClaw home directory, if one can be determined. */


### PR DESCRIPTION
## What Problem This Solves

Repeated default configuration-directory resolution performs a filesystem existence probe whose result cannot change the returned path. This adds avoidable synchronous work to callers, including plugin install-root preparation.

## Why This Change Was Made

Return the resolved `.openclaw` path directly. The old branch returned that same path whether `existsSync` returned true, returned false, or threw. Remove the branch and its obsolete catch; keep the `fs` import used by other utilities. Rename one stale test title without changing assertions.

`resolveConfigDir` owns lexical config-root computation. The separate `resolveStateDir` still performs its meaningful current-versus-legacy directory selection. Environment override precedence, tilde expansion, home resolution, cwd fallback and frozen plugin-root results are unchanged. No cache, new configuration, storage/schema change, dependency, or compatibility path is introduced. Production: **1 added / 10 deleted (net −9)**. Tests: **1 added / 1 deleted (title only)**.

## User Impact

Less filesystem work when resolving the default config directory, with the same returned paths. The measurements below concern complete public resolver operations on one macOS host with Node 26.8.1; they do not establish a Gateway-startup or model-turn speedup. No user documentation changes are needed because the public behavior is unchanged.

## Evidence

The actual installed source modules were imported normally. Real temporary directories represented existing and missing default locations; there were no filesystem mocks, syscall spies, cache flushes, or forced slow storage. Each sample contains eight complete public calls, including return collection and any supported home callback. Import/setup time was recorded separately and excluded from API timings.

Frozen order: **B0 → C0 → C1 → B1**, six rows per host, one first batch, two warm batches, then sixteen measured batches. Two additional proof hosts cover sixteen cases each. **3,680 total public calls; 384 measured means; 24 first and 48 warm means; 614 home callbacks.** Exact strings, frozen object descriptors/identity, full callback errors, inputs and filesystem effects were retained and compared. Controls include state-over-config precedence, path trimming/expansion, HOME/USERPROFILE/OPENCLAW_HOME priority, missing home values, callback error/cwd fallback, a regular-file default leaf, and legacy-only state selection. Legacy state remains `.clawdbot` while installation paths remain under `.openclaw`.

Preset gates: both default-path medians must improve at least 3% in each run order; a protected row fails only when it is slower by both >3% and >1 μs/op in both orders; kernel child maximum RSS must not rise >10% in both orders. Every gate passed without changing the workload or rerunning a failed numerical result.

| Whole operation | B0 → C0 median, μs/op | B1 → C1 median, μs/op | Candidate change, forward / reverse |
|---|---:|---:|---:|
| Default config path, directory exists | 6.945 → 3.698 | 6.474 → 3.609 | -46.76% / -44.25% |
| Default config path, directory missing | 5.964 → 3.068 | 5.951 → 2.844 | -48.56% / -52.21% |
| Plugin install roots, including state discovery | 15.039 → 14.526 | 15.437 → 13.917 | -3.41% / -9.85% |
| State-directory override | 1.583 → 1.859 | 2.021 → 1.841 | +17.44% / -8.89% |
| Config-file override | 2.109 → 2.200 | 2.258 → 2.440 | +4.32% / +8.07% |
| Throwing home callback with cwd fallback | 7.469 → 4.932 | 6.990 → 4.706 | -33.96% / -32.68% |

The slower controls remain visible: the state override was 0.276 μs/op slower forward and 0.180 μs/op faster reverse; the config-file override was 0.091/0.182 μs/op slower. Plugin-root p95 was slower in both orders (19.927 → 25.261 and 19.073 → 32.318 μs/op), despite its faster medians. These short-path samples do not establish a universal regression bound. Kernel peak RSS rose 0.92%/0.74%; sampled aggregate-tree RSS and all first/warm/tail measurements are retained below.

Canonical verification ran `node scripts/run-vitest.mjs src/utils.test.ts src/infra/home-dir.test.ts src/media/local-roots.test.ts` on both variants: **69 passes and 3 pre-existing platform skips per variant, identical 72 statuses**. The full changed-check passed (278.5765 s); independent source review and fresh managed review found no actionable findings. No new implementation-coupled filesystem-spy test was added. The native proof exercises the removed probe's actual filesystem states and the unchanged public contracts.

The raw-first numerical audit reproduced every timing field and all 3,680 outputs before comparing the reducer result. Its reviewer had authored the harness error-reporting repair, but not the product change, fixtures, or numerical reducer. Final closure rechecked 1,894 selected source/runtime pins, 70 aliases, all 23 observed PIDs and 15 process groups absent, and the complete retained evidence (26,487,001 bytes). No subject was rerun. Commit `e35b27a1451c05365a4206b271837135b0b1d03e` preserves the measured source bytes exactly.

Measured source: base `239beea173a085d15530ca6fa0098cf6106a29eb`; before `src/utils.ts` SHA-256 `22d670bf9d0915fd2a19e593565fed836e4b4a8fc32b2d14c2f960221200cbd0`; candidate `d95cf3a63bb818edd5341b753019cb68002e219f59b1b0e468f886f67955a8a3`. The owner, test, home resolver, state-path owner and install-root caller remained unchanged on main through `d1774564e68` before publication.

Best-fix judgment: remove the redundant probe at its owner. A caller cache would retain unnecessary work and add lifecycle policy; changing state-directory discovery would alter a real contract. Relevant source review covered utils, home resolution, state/config paths, media roots, plugin installation roots, skills paths, cron storage and the SDK export. [Node's implementation](https://github.com/nodejs/node/blob/v26.8.1/src/node_file.cc#L994-L1022) confirms this is an existence probe (`uv_fs_access` on this platform), not a claim about eliminating a macOS stat syscall.

<details>
<summary>Complete timing vectors and resource measurements</summary>

Nanoseconds per complete public call; each mean contains eight calls. Values are unfiltered and remain in execution order. This is API timing, not the duration of the surrounding proof/recording harness.

```json
{
  "rowNames": {
    "H01": "Default config path, directory exists",
    "H02": "Default config path, directory missing",
    "H03": "Plugin install roots, including state discovery",
    "H04": "State-directory override",
    "H05": "Config-file override",
    "H06": "Throwing home callback with cwd fallback"
  },
  "vectors": {
    "B0": {
      "H01": {
        "first": [
          9229.125
        ],
        "warm": [
          11057.25,
          6734.375
        ],
        "measured": [
          9614.625,
          12958.375,
          8203.125,
          9078.125,
          7093.75,
          6786.5,
          6890.625,
          4390.625,
          6005.25,
          5932.375,
          7187.5,
          7505.25,
          5692.75,
          4291.625,
          7000.0,
          5338.625
        ]
      },
      "H02": {
        "first": [
          5916.75
        ],
        "warm": [
          4578.125,
          5192.625
        ],
        "measured": [
          4125.0,
          5911.5,
          6645.875,
          5994.875,
          13776.0,
          5864.625,
          5932.375,
          5375.0,
          8260.375,
          6458.375,
          8692.625,
          6718.75,
          10323.0,
          5614.5,
          4458.375,
          5463.5
        ]
      },
      "H03": {
        "first": [
          26708.25
        ],
        "warm": [
          18854.125,
          17020.875
        ],
        "measured": [
          14713.5,
          14083.375,
          14458.375,
          16531.25,
          15567.75,
          19927.125,
          17099.0,
          15505.25,
          13989.625,
          18901.0,
          16468.75,
          14849.0,
          14599.0,
          11802.125,
          15229.125,
          12302.125
        ]
      },
      "H04": {
        "first": [
          12229.125
        ],
        "warm": [
          3562.5,
          2197.875
        ],
        "measured": [
          1447.875,
          1963.5,
          1401.0,
          1494.875,
          2104.25,
          1755.125,
          1562.5,
          1739.625,
          1473.875,
          1604.125,
          1255.125,
          1322.875,
          1562.5,
          1895.875,
          2640.625,
          1812.5
        ]
      },
      "H05": {
        "first": [
          2989.625
        ],
        "warm": [
          2229.25,
          2057.25
        ],
        "measured": [
          2671.875,
          2906.25,
          1984.375,
          2442.625,
          1911.5,
          1864.5,
          3109.375,
          1822.875,
          4687.5,
          2687.5,
          1734.375,
          1880.125,
          2510.375,
          1812.5,
          1682.25,
          2234.375
        ]
      },
      "H06": {
        "first": [
          27562.5
        ],
        "warm": [
          9885.5,
          7635.5
        ],
        "measured": [
          6760.375,
          8906.25,
          5937.5,
          7104.125,
          7099.0,
          6000.0,
          7833.25,
          6645.75,
          5666.625,
          13500.0,
          6682.375,
          8421.875,
          9223.875,
          8578.125,
          9609.375,
          7901.0
        ]
      }
    },
    "C0": {
      "H01": {
        "first": [
          5380.25
        ],
        "warm": [
          4760.375,
          4739.625
        ],
        "measured": [
          4119.75,
          5500.0,
          5078.125,
          3724.0,
          3697.875,
          3703.125,
          3911.5,
          3619.875,
          3656.25,
          3697.875,
          4390.625,
          3442.75,
          3348.875,
          3536.5,
          3104.125,
          2875.0
        ]
      },
      "H02": {
        "first": [
          3656.25
        ],
        "warm": [
          3140.625,
          3177.125
        ],
        "measured": [
          3099.0,
          3187.5,
          2989.625,
          4828.125,
          4156.25,
          2880.25,
          3036.5,
          3036.5,
          2994.75,
          3255.25,
          4875.0,
          2989.625,
          2698.0,
          3703.125,
          2953.125,
          3390.625
        ]
      },
      "H03": {
        "first": [
          26083.375
        ],
        "warm": [
          18302.125,
          13755.125
        ],
        "measured": [
          16286.5,
          17067.75,
          14359.375,
          15197.875,
          13750.0,
          25260.5,
          14651.125,
          14312.5,
          11187.5,
          14864.625,
          14880.25,
          15781.25,
          13432.25,
          14401.0,
          12645.875,
          13239.5
        ]
      },
      "H04": {
        "first": [
          12052.0
        ],
        "warm": [
          3453.125,
          1625.0
        ],
        "measured": [
          1937.5,
          1927.125,
          1406.25,
          1890.625,
          1697.875,
          1442.75,
          1203.125,
          1718.75,
          1661.375,
          1828.125,
          1916.625,
          2265.625,
          2145.875,
          1578.125,
          1916.625,
          2171.875
        ]
      },
      "H05": {
        "first": [
          3323.0
        ],
        "warm": [
          2093.75,
          2609.375
        ],
        "measured": [
          2557.25,
          2359.375,
          1921.875,
          2489.5,
          2171.875,
          2052.125,
          1869.75,
          2661.5,
          2166.625,
          3666.75,
          1854.25,
          2703.125,
          1697.875,
          2125.0,
          2515.625,
          2229.125
        ]
      },
      "H06": {
        "first": [
          22890.625
        ],
        "warm": [
          5322.875,
          4713.625
        ],
        "measured": [
          4302.125,
          3734.375,
          4494.75,
          5125.0,
          5072.875,
          4822.875,
          5078.125,
          5041.625,
          5198.0,
          5765.625,
          4724.0,
          4510.375,
          4520.875,
          5489.5,
          4796.875,
          5312.5
        ]
      }
    },
    "C1": {
      "H01": {
        "first": [
          5432.25
        ],
        "warm": [
          4671.875,
          3786.375
        ],
        "measured": [
          4552.125,
          5161.375,
          3036.375,
          3666.75,
          4817.75,
          5114.5,
          5828.125,
          3276.0,
          3723.875,
          3208.375,
          3166.625,
          3395.75,
          3817.75,
          3395.75,
          3552.125,
          3416.625
        ]
      },
      "H02": {
        "first": [
          3505.25
        ],
        "warm": [
          3744.75,
          3010.375
        ],
        "measured": [
          3463.625,
          3031.25,
          2750.0,
          2911.375,
          2604.125,
          2562.5,
          3145.875,
          2661.375,
          2932.375,
          2635.375,
          4921.875,
          2776.125,
          2750.0,
          2645.875,
          3166.625,
          2958.375
        ]
      },
      "H03": {
        "first": [
          31349.0
        ],
        "warm": [
          20317.625,
          11161.375
        ],
        "measured": [
          12812.5,
          32317.625,
          12843.75,
          12573.0,
          13859.375,
          16671.875,
          13322.875,
          31744.875,
          13974.0,
          15838.5,
          15807.25,
          16276.0,
          13770.875,
          15640.625,
          12213.5,
          12380.25
        ]
      },
      "H04": {
        "first": [
          11385.375
        ],
        "warm": [
          3583.25,
          2203.125
        ],
        "measured": [
          1958.25,
          1849.0,
          1546.875,
          1765.625,
          1864.625,
          1573.0,
          1833.375,
          1541.75,
          1880.125,
          1812.5,
          1333.375,
          2218.75,
          2302.125,
          1604.25,
          2161.375,
          1948.0
        ]
      },
      "H05": {
        "first": [
          3099.0
        ],
        "warm": [
          3099.0,
          2510.375
        ],
        "measured": [
          2088.5,
          2343.75,
          2661.5,
          2208.375,
          2583.25,
          2697.875,
          2437.5,
          2619.75,
          4119.875,
          2453.125,
          2666.625,
          2213.5,
          2442.625,
          1645.875,
          1833.25,
          2213.625
        ]
      },
      "H06": {
        "first": [
          22005.125
        ],
        "warm": [
          6265.625,
          5203.125
        ],
        "measured": [
          5031.25,
          4843.75,
          5250.0,
          4578.125,
          5562.5,
          4213.5,
          4156.25,
          4364.5,
          4916.625,
          4692.625,
          4906.25,
          5333.25,
          4718.75,
          4046.875,
          4291.625,
          3942.75
        ]
      }
    },
    "B1": {
      "H01": {
        "first": [
          12432.25
        ],
        "warm": [
          12645.75,
          11125.0
        ],
        "measured": [
          7463.5,
          10067.75,
          6427.125,
          7557.25,
          7447.875,
          6932.375,
          5291.625,
          6520.875,
          6573.0,
          5869.75,
          5947.875,
          5661.5,
          6000.0,
          4791.625,
          7119.75,
          4989.625
        ]
      },
      "H02": {
        "first": [
          23156.25
        ],
        "warm": [
          6052.0,
          7447.875
        ],
        "measured": [
          5010.375,
          6515.625,
          4510.375,
          5093.75,
          8239.625,
          5073.0,
          7614.625,
          6343.75,
          4515.625,
          5880.25,
          8895.875,
          6671.875,
          6020.875,
          8031.25,
          4791.75,
          5427.125
        ]
      },
      "H03": {
        "first": [
          25359.375
        ],
        "warm": [
          17385.375,
          18765.625
        ],
        "measured": [
          16234.375,
          13135.375,
          15812.5,
          13791.625,
          17041.625,
          19072.875,
          13583.375,
          15302.0,
          15572.875,
          16781.25,
          15781.25,
          15770.875,
          13010.375,
          14036.5,
          13781.25,
          13349.0
        ]
      },
      "H04": {
        "first": [
          11411.5
        ],
        "warm": [
          4109.375,
          3416.625
        ],
        "measured": [
          1708.375,
          6979.125,
          2255.25,
          2041.625,
          1843.75,
          2125.0,
          2270.75,
          2072.875,
          1994.75,
          2000.0,
          1776.0,
          2130.25,
          1859.375,
          2250.0,
          1760.375,
          1520.75
        ]
      },
      "H05": {
        "first": [
          3031.25
        ],
        "warm": [
          2276.0,
          2760.5
        ],
        "measured": [
          3145.875,
          2630.125,
          2312.5,
          2203.125,
          2036.5,
          1869.75,
          2984.375,
          2489.625,
          5015.625,
          1812.5,
          2145.875,
          2161.5,
          2541.625,
          2041.625,
          1942.75,
          2510.375
        ]
      },
      "H06": {
        "first": [
          24911.375
        ],
        "warm": [
          9125.0,
          8192.75
        ],
        "measured": [
          9088.5,
          6406.25,
          8130.25,
          6708.25,
          6776.0,
          7755.125,
          6182.25,
          6447.875,
          7515.625,
          8703.125,
          8770.75,
          6421.875,
          7453.125,
          7203.125,
          5885.375,
          6234.375
        ]
      }
    }
  },
  "resources": {
    "B0": {
      "nativeWallNs": 1176803125,
      "chargedNs": 6701576125,
      "kernelRss": 143933440,
      "sampledRss": 167329792,
      "imports": [
        {
          "relative": "src/utils.ts",
          "sha256": "22d670bf9d0915fd2a19e593565fed836e4b4a8fc32b2d14c2f960221200cbd0",
          "wallNs": "79037875"
        },
        {
          "relative": "src/plugins/install-root-context.ts",
          "sha256": "c940508132ab58c6628aeed0e7d8f4ce69c55e0ab3b20fef6b430901fdcbf977",
          "wallNs": "12004167"
        },
        {
          "relative": "src/config/paths.ts",
          "sha256": "517445e75cf4e0817b2cc2f31081874478f9375d432697197e6257e0eab7c399",
          "wallNs": "163375"
        }
      ]
    },
    "C0": {
      "nativeWallNs": 1246764375,
      "chargedNs": 6742636333,
      "kernelRss": 145260544,
      "sampledRss": 169230336,
      "imports": [
        {
          "relative": "src/utils.ts",
          "sha256": "d95cf3a63bb818edd5341b753019cb68002e219f59b1b0e468f886f67955a8a3",
          "wallNs": "78704792"
        },
        {
          "relative": "src/plugins/install-root-context.ts",
          "sha256": "c940508132ab58c6628aeed0e7d8f4ce69c55e0ab3b20fef6b430901fdcbf977",
          "wallNs": "12842459"
        },
        {
          "relative": "src/config/paths.ts",
          "sha256": "517445e75cf4e0817b2cc2f31081874478f9375d432697197e6257e0eab7c399",
          "wallNs": "189167"
        }
      ]
    },
    "C1": {
      "nativeWallNs": 1331413875,
      "chargedNs": 6843945916,
      "kernelRss": 144736256,
      "sampledRss": 168099840,
      "imports": [
        {
          "relative": "src/utils.ts",
          "sha256": "d95cf3a63bb818edd5341b753019cb68002e219f59b1b0e468f886f67955a8a3",
          "wallNs": "78163709"
        },
        {
          "relative": "src/plugins/install-root-context.ts",
          "sha256": "c940508132ab58c6628aeed0e7d8f4ce69c55e0ab3b20fef6b430901fdcbf977",
          "wallNs": "12778167"
        },
        {
          "relative": "src/config/paths.ts",
          "sha256": "517445e75cf4e0817b2cc2f31081874478f9375d432697197e6257e0eab7c399",
          "wallNs": "167708"
        }
      ]
    },
    "B1": {
      "nativeWallNs": 1419648333,
      "chargedNs": 6906499625,
      "kernelRss": 143671296,
      "sampledRss": 166739968,
      "imports": [
        {
          "relative": "src/utils.ts",
          "sha256": "22d670bf9d0915fd2a19e593565fed836e4b4a8fc32b2d14c2f960221200cbd0",
          "wallNs": "80365666"
        },
        {
          "relative": "src/plugins/install-root-context.ts",
          "sha256": "c940508132ab58c6628aeed0e7d8f4ce69c55e0ab3b20fef6b430901fdcbf977",
          "wallNs": "12833209"
        },
        {
          "relative": "src/config/paths.ts",
          "sha256": "517445e75cf4e0817b2cc2f31081874478f9375d432697197e6257e0eab7c399",
          "wallNs": "184791"
        }
      ]
    }
  },
  "failures": []
}
```

</details>
