### PR TITLE
fix(ui): avoid duplicate settings loads with warm route modules

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -59,6 +59,8 @@ Reference for **LLM/model providers** (not chat channels like WhatsApp/Telegram)
 
 Open **Settings → Models** in the Control UI to add, replace, or remove provider API keys stored in `models.providers.<id>.apiKey`. The page identifies whether each API key comes from OpenClaw config or an environment variable without displaying the credential. Environment-provided keys remain managed by the gateway process environment.
 
+Provider controls appear as soon as credentials, the model catalog, and configuration are ready. Usage and local costs load independently afterward, so a slow usage response does not block provider settings.
+
 Open **Model Setup** from the page header to inspect detected AI access. When available, it shows the authentication method (API key or account sign-in) and the actual email address reported by the provider or local runtime. API keys and tokens stay hidden.
 
 Use **Test connection** to run a live provider probe and see latency or a categorized authentication, rate-limit, billing, timeout, or response error. A probe makes a real provider request and may consume a small number of tokens. OAuth and token profiles can also be logged out from the provider card.

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -61,7 +61,7 @@ import { page as workboardPage } from "./pages/workboard/route.ts";
 import { page as worktreesPage } from "./pages/worktrees/route.ts";
 
 type AppRouteModule = {
-  render: (data: unknown) => unknown;
+  render: (data: unknown, loaderPending: boolean) => unknown;
   renderOwnerKey?: (
     match: Pick<RouteMatch, "data" | "location">,
     settled: Pick<RouteMatch, "data" | "location"> | undefined,
@@ -115,6 +115,20 @@ const APP_ROUTE_TREE = [
 ] as const;
 
 const appRoutes = APP_ROUTE_TREE as readonly AppRoute[];
+
+/** Starts route chunk downloads without running the route's loader. */
+export function warmApplicationRouteModule(
+  router: ApplicationRouter,
+  location: RouteLocation,
+  basePath: string,
+): void {
+  const routeId = routeIdFromPath(location.pathname, basePath);
+  const route = routeId ? router.getRoute(routeId) : null;
+  if (route) {
+    // Navigation owns chunk errors; its import reuses the browser's module cache.
+    void Promise.resolve(route.component()).catch(() => undefined);
+  }
+}
 
 export function createApplicationRouter(): ApplicationRouter {
   const router = createRouter<RouteId, ApplicationContext<RouteId>, AppRouteModule>({

--- a/ui/src/app/bootstrap.test.ts
+++ b/ui/src/app/bootstrap.test.ts
@@ -61,6 +61,49 @@ describe("normalizeLegacyTerminalViewLocation", () => {
 });
 
 describe("bootstrapApplication", () => {
+  it.each([
+    { pathname: "/settings/model-providers", routeId: "model-providers", warmed: true },
+    { pathname: "/operator/settings/model-providers", routeId: "model-providers", warmed: true },
+    { pathname: "/chat/main/example-deadbeef", routeId: "chat", warmed: true },
+    { pathname: "/", routeId: "chat", warmed: false },
+    { pathname: "/chat", routeId: "chat", warmed: false },
+    { pathname: "/focus/terminal", routeId: "chat", warmed: false },
+    { pathname: "/approve/exec%3A1", routeId: "chat", warmed: false },
+  ] as const)(
+    "warms only explicit application routes at startup: $pathname",
+    async ({ pathname, routeId, warmed }) => {
+      const previousUrl = window.location.href;
+      const previousSettings = loadSettings();
+      window.history.replaceState({}, "", pathname);
+      const runtime = bootstrapApplication();
+      const route = runtime.router.getRoute(routeId);
+      if (!route) {
+        throw new Error(`Missing route ${routeId}`);
+      }
+      const component = vi.spyOn(route, "component").mockResolvedValue({ render: () => null });
+      const loader = vi.spyOn(route, "loader");
+      const startGateway = vi.spyOn(runtime.context.gateway, "start").mockImplementation(() => {});
+      try {
+        expect(component).not.toHaveBeenCalled();
+        const starting = runtime.start();
+        expect(component).toHaveBeenCalledTimes(warmed ? 1 : 0);
+        expect(loader).not.toHaveBeenCalled();
+        runtime.stop();
+        await starting;
+        component.mockClear();
+        await runtime.start();
+        expect(component).not.toHaveBeenCalled();
+      } finally {
+        runtime.stop();
+        component.mockRestore();
+        loader.mockRestore();
+        startGateway.mockRestore();
+        window.history.replaceState({}, "", previousUrl);
+        saveSettings(previousSettings);
+      }
+    },
+  );
+
   it("replaces a released dashboard query bookmark before router start", async () => {
     const initialLocation = {
       pathname: "/chat",

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -11,6 +11,7 @@ import {
   routeIdFromPath,
   sameRouteLocation,
   startApplicationRouter,
+  warmApplicationRouteModule,
   type ApplicationRouter,
   type RouteId,
 } from "../app-routes.ts";
@@ -499,6 +500,11 @@ export function bootstrapApplication(): ApplicationRuntime {
         },
         () => startGatewayPageActivation(gateway, document, window),
       ];
+      if (startsApplicationRouter && !firstRunDefaultLanding) {
+        // Download explicit-route chunks alongside startup. Default landing must
+        // wait for setup's decision before fetching the Chat workspace graph.
+        steps.unshift(() => warmApplicationRouteModule(router, applicationLocation, basePath));
+      }
       // Resolve first-run setup before routing: the default Chat route owns the
       // workspace graph, which setup users would otherwise fetch and discard.
       steps.push(() =>

--- a/ui/src/app/router-outlet.test.ts
+++ b/ui/src/app/router-outlet.test.ts
@@ -106,7 +106,7 @@ describe("openclaw-router-outlet", () => {
 
     const navigation = router.navigate("next", context);
     await settleOutlet(outlet);
-    expect(renderOwnedRoute).toHaveBeenCalledWith(undefined);
+    expect(renderOwnedRoute).toHaveBeenCalledWith(undefined, true);
     expect(outlet.querySelector("mcp-app-view")).toBe(appView);
     expect(outlet.querySelector('[data-testid="owned-route"]')?.textContent).toBe("page");
     expect(teardownView).not.toHaveBeenCalled();

--- a/ui/src/app/router-outlet.ts
+++ b/ui/src/app/router-outlet.ts
@@ -21,7 +21,7 @@ import {
 export { selectRenderedRouteMatch } from "./router-outlet-controller.ts";
 
 type RenderableModule<TData> = {
-  render: (data: TData | undefined) => unknown;
+  render: (data: TData | undefined, loaderPending: boolean) => unknown;
   renderOwnerKey?: (
     match: Pick<RouteMatch<string, unknown, TData>, "data" | "location">,
     settled: Pick<RouteMatch<string, unknown, TData>, "data" | "location"> | undefined,
@@ -156,7 +156,9 @@ function renderRouterOutlet<TRouteId extends string, TLoadContext, TModule, TDat
       : null;
   }
   const renderedPage = () =>
-    measureRoutedRender(routeId, () => routeModule.render(renderedMatch.data));
+    measureRoutedRender(routeId, () =>
+      routeModule.render(renderedMatch.data, renderedMatch.isFetching === "loader"),
+    );
   return renderedMatch.error
     ? renderError<TRouteId, TLoadContext, TModule, TData>(
         router,

--- a/ui/src/e2e/model-providers-progressive.e2e.test.ts
+++ b/ui/src/e2e/model-providers-progressive.e2e.test.ts
@@ -1,12 +1,14 @@
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
 import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ApplicationRouter } from "../app-routes.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
+  waitForControlUiRoute,
   type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
 
@@ -42,88 +44,171 @@ describeControlUiE2e("Control UI progressive Model Providers loading", () => {
     await server?.close();
   });
 
-  it("renders provider controls before usage and cost settle", async () => {
-    const context = await browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 1_000, width: 1_280 },
-      ...(recordVisuals
-        ? { recordVideo: { dir: artifactDir, size: { height: 1_000, width: 1_280 } } }
-        : {}),
-    });
-    const page = await context.newPage();
-    const now = Date.now();
-    const gateway = await installMockGateway(page, {
-      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true }],
-      heldMethods: ["usage.status", "sessions.usage"],
-      methodResponses: {
-        "config.get": {
-          config: { agents: { defaults: { model: "openai/gpt-5.5" } } },
-          sourceConfig: {},
-          hash: "progressive-model-providers",
-          issues: [],
-          raw: "{}",
-          valid: true,
-        },
-        "models.authStatus": {
-          ts: now,
-          providers: [
-            {
-              provider: "openai",
-              displayName: "OpenAI",
-              status: "static",
-              profiles: [],
-              apiKey: { source: "env", envVar: "OPENAI_API_KEY" },
-            },
-          ],
-        },
-        "usage.status": {
-          updatedAt: now,
-          providers: [{ provider: "openai", displayName: "OpenAI", plan: "Pro", windows: [] }],
-        },
-        "sessions.usage": {
-          aggregates: {
-            byProvider: [
+  it.each(["cold", "prewarmed", "cached"] as const)(
+    "renders provider controls before usage and cost settle (%s module)",
+    async (moduleState) => {
+      const context = await browser.newContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1_000, width: 1_280 },
+        ...(recordVisuals
+          ? { recordVideo: { dir: artifactDir, size: { height: 1_000, width: 1_280 } } }
+          : {}),
+      });
+      const page = await context.newPage();
+      const now = Date.now();
+      const gateway = await installMockGateway(page, {
+        models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true }],
+        heldMethods:
+          moduleState === "cached"
+            ? []
+            : [
+                "usage.status",
+                "sessions.usage",
+                ...(moduleState === "cold" ? ["models.authStatus"] : []),
+              ],
+        methodResponses: {
+          "config.get": {
+            config: { agents: { defaults: { model: "openai/gpt-5.5" } } },
+            sourceConfig: {},
+            hash: "progressive-model-providers",
+            issues: [],
+            raw: "{}",
+            valid: true,
+          },
+          "models.authStatus": {
+            ts: now,
+            providers: [
               {
                 provider: "openai",
-                count: 1,
-                totals: { totalTokens: 100, totalCost: 1.25 },
+                displayName: "OpenAI",
+                status: "static",
+                profiles: [],
+                apiKey: { source: "env", envVar: "OPENAI_API_KEY" },
               },
             ],
           },
+          "usage.status": {
+            updatedAt: now,
+            providers: [{ provider: "openai", displayName: "OpenAI", plan: "Pro", windows: [] }],
+          },
+          "sessions.usage": {
+            aggregates: {
+              byProvider: [
+                {
+                  provider: "openai",
+                  count: 1,
+                  totals: { totalTokens: 100, totalCost: 1.25 },
+                },
+              ],
+            },
+          },
         },
-      },
-    });
+      });
 
-    try {
-      expect((await page.goto(`${server.baseUrl}settings/model-providers`))?.status()).toBe(200);
-      await gateway.waitForRequest("usage.status");
-      await gateway.waitForRequest("sessions.usage");
-      const provider = page.locator('[data-provider-id="openai"]');
-      await provider.waitFor();
-      await expect.poll(async () => provider.textContent()).toContain("Credentials configured");
-      await expect.poll(async () => provider.textContent()).toContain("Loading");
-      expect(await gateway.getRequests("usage.status")).toHaveLength(1);
-      expect(await gateway.getRequests("sessions.usage")).toHaveLength(1);
-      if (recordVisuals) {
-        await page.screenshot({ path: path.join(artifactDir, "before.png"), fullPage: true });
-      }
+      try {
+        const previousLoads = moduleState === "cached" ? 1 : 0;
+        let previousConfigLoads = 0;
+        if (moduleState === "cached") {
+          await page.goto(`${server.baseUrl}settings/appearance`);
+          await waitForControlUiRoute(page, { routeId: "appearance" });
+          await page.locator('a[href="/settings/model-providers"]').first().click();
+          await waitForControlUiRoute(page, { routeId: "model-providers" });
+          await expect
+            .poll(() => page.locator('[data-provider-id="openai"]').textContent())
+            .toContain("$1.25");
+          await page.locator('a[href="/settings/appearance"]').first().click();
+          await waitForControlUiRoute(page, { routeId: "appearance" });
+          await gateway.deferNext("usage.status");
+          await gateway.deferNext("sessions.usage");
+        }
+        if (moduleState !== "cold") {
+          if (moduleState === "prewarmed") {
+            await page.goto(`${server.baseUrl}settings/appearance`);
+          }
+          await waitForControlUiRoute(page, { routeId: "appearance" });
+          // Hold only the route's core request: a competing page load must not
+          // share this gate and conceal the duplicate work.
+          await gateway.deferNext("config.get");
+          previousConfigLoads = (await gateway.getRequests("config.get")).length;
+          await page.evaluate(async () => {
+            const app = document.querySelector<
+              HTMLElement & { runtime: { router: ApplicationRouter } }
+            >("openclaw-app");
+            const route = app?.runtime.router.getRoute("model-providers");
+            if (!route) {
+              throw new Error("Models route is unavailable");
+            }
+            await route.component();
+          });
+          await page.locator('a[href="/settings/model-providers"]').first().click();
+        } else {
+          expect((await page.goto(`${server.baseUrl}settings/model-providers`))?.status()).toBe(
+            200,
+          );
+        }
+        if (moduleState === "cold") {
+          await gateway.waitForRequest("models.authStatus");
+        } else {
+          await expect
+            .poll(async () => (await gateway.getRequests("config.get")).length)
+            .toBeGreaterThan(previousConfigLoads);
+        }
+        await page.locator("openclaw-model-providers-page").waitFor();
+        if (moduleState === "cached") {
+          await expect
+            .poll(() => page.locator('[data-provider-id="openai"]').textContent())
+            .toContain("Credentials configured");
+          await expect
+            .poll(() => page.locator('[data-provider-id="openai"]').textContent())
+            .toContain("Loading");
+        }
+        if (recordVisuals) {
+          await page.screenshot({
+            path: path.join(artifactDir, "route-pending.png"),
+            fullPage: true,
+          });
+        }
+        expect(await gateway.getRequests("usage.status")).toHaveLength(previousLoads);
+        expect(await gateway.getRequests("sessions.usage")).toHaveLength(previousLoads);
+        await gateway.resolveDeferred(moduleState === "cold" ? "models.authStatus" : "config.get");
+        await waitForControlUiRoute(page, { routeId: "model-providers" });
+        await gateway.waitForRequest("usage.status");
+        await gateway.waitForRequest("sessions.usage");
+        const provider = page.locator('[data-provider-id="openai"]');
+        await provider.waitFor();
+        await expect.poll(async () => provider.textContent()).toContain("Credentials configured");
+        await expect.poll(async () => provider.textContent()).toContain("Loading");
+        expect(await gateway.getRequests("usage.status")).toHaveLength(previousLoads + 1);
+        expect(await gateway.getRequests("sessions.usage")).toHaveLength(previousLoads + 1);
+        if (recordVisuals) {
+          await page.screenshot({ path: path.join(artifactDir, "before.png"), fullPage: true });
+        }
 
-      await gateway.resolveDeferred("usage.status");
-      await expect.poll(async () => provider.textContent()).toContain("Pro");
-      expect(await provider.textContent()).not.toContain("$1.25");
-      if (recordVisuals) {
-        await page.screenshot({ path: path.join(artifactDir, "usage-ready.png"), fullPage: true });
-      }
+        await gateway.resolveDeferred("usage.status");
+        await expect.poll(async () => provider.textContent()).toContain("Pro");
+        expect(await provider.textContent()).not.toContain("$1.25");
+        if (recordVisuals) {
+          await page.screenshot({
+            path: path.join(artifactDir, "usage-ready.png"),
+            fullPage: true,
+          });
+        }
 
-      await gateway.resolveDeferred("sessions.usage");
-      await expect.poll(async () => provider.textContent()).toContain("$1.25");
-      expect(await page.locator('[data-provider-id="unknown-provider"]').count()).toBe(0);
-      if (recordVisuals) {
-        await page.screenshot({ path: path.join(artifactDir, "after.png"), fullPage: true });
+        await gateway.resolveDeferred("sessions.usage");
+        await expect.poll(async () => provider.textContent()).toContain("$1.25");
+        expect(await gateway.getRequests("usage.status")).toHaveLength(previousLoads + 1);
+        expect(await gateway.getRequests("sessions.usage")).toHaveLength(previousLoads + 1);
+        expect(await page.locator('[data-provider-id="unknown-provider"]').count()).toBe(0);
+        if (recordVisuals) {
+          await page.screenshot({ path: path.join(artifactDir, "after.png"), fullPage: true });
+        }
+      } finally {
+        if (recordVisuals) {
+          await page.screenshot({ path: path.join(artifactDir, "final.png"), fullPage: true });
+        }
+        await context.close();
       }
-    } finally {
-      await context.close();
-    }
-  });
+    },
+  );
 });

--- a/ui/src/pages/gateway-source-replacement.test.ts
+++ b/ui/src/pages/gateway-source-replacement.test.ts
@@ -9,6 +9,7 @@ import type { ApplicationContext, ApplicationGatewaySnapshot } from "../app/cont
 import { clawhubVerdictKey } from "../lib/skills/index.ts";
 import { waitForFast } from "../test-helpers/wait-for.ts";
 import type { ModelProvidersData } from "./model-providers/load.ts";
+import { createEmptyModelProvidersRouteData } from "./model-providers/model-providers-page.test-support.ts";
 import type { ModelProvidersRouteData } from "./model-providers/route.ts";
 import type { SkillsRouteData } from "./skills/skills-page.ts";
 import { createSkill } from "./skills/view.test-support.ts";
@@ -473,7 +474,11 @@ describe("gateway source replacement across reconnect with a reused client", () 
     const page = createPage(
       "openclaw-model-providers-page",
       contextWithClient(client, { connected: true, agentsList, selectedAgentId: "main" }),
-    ) as TestPage & { data: ModelProvidersData | null };
+    ) as TestPage & {
+      data: ModelProvidersData | null;
+      routeData: ModelProvidersRouteData;
+    };
+    page.routeData = createEmptyModelProvidersRouteData(page.context);
     document.body.append(page);
     await waitForFast(() => expect(authCalls).toBe(1));
 

--- a/ui/src/pages/model-providers/model-providers-page.test-support.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test-support.ts
@@ -3,7 +3,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ModelsProbeResult } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { DefaultModelSelection, ModelProviderLogoutTarget } from "./data.ts";
-import type { ModelProvidersData } from "./load.ts";
+import { EMPTY_MODEL_PROVIDERS_DATA, type ModelProvidersData } from "./load.ts";
 import type { ModelBehaviorConfig } from "./model-behavior.ts";
 import type { ModelProvidersRouteData } from "./route.ts";
 import "./model-providers-page.ts";
@@ -228,11 +228,25 @@ export function focusDocument(): void {
   vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
 }
 
+export function createEmptyModelProvidersRouteData(
+  context: ApplicationContext,
+): ModelProvidersRouteData {
+  // A loader completed before connection; the connected page now owns recovery.
+  return {
+    gateway: context.gateway,
+    gatewaySnapshot: { ...context.gateway.snapshot, phase: "stopped", client: null },
+    data: EMPTY_MODEL_PROVIDERS_DATA,
+    client: null,
+    agentId: context.agentSelection.state.selectedId,
+  };
+}
+
 export function appendPage(context: ApplicationContext) {
   const page = document.createElement(
     "openclaw-model-providers-page",
   ) as ModelProvidersPageTestElement;
   page.context = context;
+  page.routeData = createEmptyModelProvidersRouteData(context);
   document.body.append(page);
   return page;
 }

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -7,6 +7,7 @@ import type { DefaultModelSelection } from "./data.ts";
 import { EMPTY_MODEL_PROVIDERS_DATA } from "./load.ts";
 import {
   appendPage,
+  createEmptyModelProvidersRouteData,
   createHarness,
   deferred,
   publishableGateway,
@@ -40,6 +41,7 @@ describe("ModelProvidersPage agent scope", () => {
         "openclaw-model-providers-page",
       ) as ModelProvidersPageTestElement;
       page.context = context;
+      page.routeData = createEmptyModelProvidersRouteData(context);
       if (loadSource === "preload") {
         const routeData = {
           gateway: context.gateway,
@@ -84,6 +86,7 @@ describe("ModelProvidersPage agent scope", () => {
         "openclaw-model-providers-page",
       ) as ModelProvidersPageTestElement;
       page.context = context;
+      page.routeData = createEmptyModelProvidersRouteData(context);
       if (loadSource === "preload") {
         page.routeData = {
           gateway: context.gateway,

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -59,6 +59,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
   private context!: ApplicationContext;
 
   @property({ attribute: false }) routeData: ModelProvidersRouteData | undefined;
+  @property({ attribute: false }) loaderPending = false;
 
   @state() private data: ModelProvidersData | null = null;
   @state() private busy: Record<string, boolean> = {};
@@ -98,19 +99,24 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     },
     onComplete: ({ client, data }) => {
       this.loadClient = null;
-      this.adoptLoadedData(client, data);
+      this.supplemental.adoptCoreData(client, data);
     },
     onError: () => {
       this.loadClient = null;
     },
   });
   private readonly refreshPolicy = new UsageRefreshPolicy({
-    isLoading: () => this.loadClient !== null || this.supplemental.usageLoading,
+    isLoading: () =>
+      this.loaderPending ||
+      !this.routeDataObserved ||
+      this.loadClient !== null ||
+      this.supplemental.usageLoading,
     // Usage convergence must not restart the independent local-cost request.
     reload: () => this.supplemental.loadUsage(),
     onIncompleteUsageExhausted: () => this.requestUpdate(),
   });
   private readonly supplemental = new ModelProviderSupplementalLoader(this, {
+    isCoreLoading: () => this.loaderPending,
     getGateway: () => this.gateway,
     getData: () => this.data,
     getDataClient: () => this.dataClient,
@@ -130,7 +136,12 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
         // Keep the last snapshot visible while the canonical reconnect load replaces it.
         this.resetConnectionState({ preserveVisibleData: true });
       }
-      if (change.becameConnected && !change.initial) {
+      if (
+        change.becameConnected &&
+        !change.initial &&
+        this.routeDataObserved &&
+        !this.loaderPending
+      ) {
         void this.refresh({ force: false });
       }
     },
@@ -167,7 +178,10 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
   }
 
   override willUpdate(changed: PropertyValues) {
-    if (changed.has("routeData") && this.routeData !== undefined) {
+    if (
+      (changed.has("routeData") || changed.has("loaderPending")) &&
+      this.routeData !== undefined
+    ) {
       this.routeDataObserved = true;
       const selectedAgentId = this.resolveSelectedAgentId();
       this.setSelectedAgent(selectedAgentId);
@@ -175,7 +189,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
         (this.routeData.agentId ?? "") === selectedAgentId &&
         this.gateway.isRouteDataCurrent(this.routeData)
       ) {
-        this.adoptLoadedData(this.routeData.client, this.routeData.data);
+        this.supplemental.adoptCoreData(this.routeData.client, this.routeData.data);
       } else {
         this.data = null;
         this.dataClient = null;
@@ -193,11 +207,11 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     ) {
       void this.context.agents.ensureList();
     }
-    if (!this.routeDataObserved && this.routeData !== undefined) {
-      return;
-    }
+    // The route owns initial loading, even when its page module is already cached.
     const client = this.gateway.client;
     if (
+      !this.routeDataObserved ||
+      this.loaderPending ||
       !this.gateway.connected ||
       !client ||
       !this.selectedAgentId ||
@@ -207,10 +221,6 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       return;
     }
     void this.refresh({ force: false });
-  }
-
-  private adoptLoadedData(client: GatewayBrowserClient | null, data: ModelProvidersData) {
-    this.supplemental.adoptCoreData(client, data);
   }
 
   private invalidateRequests() {
@@ -615,11 +625,9 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     };
     const defaults = this.defaultsDraft ?? configuredDefaults;
     const stageDefaults = (patch: Partial<DefaultsDraft>) => {
-      const current = this.defaultsDraft ?? configuredDefaults;
-      const next = { ...current, ...patch };
-      this.defaultsDraft = next;
+      this.defaultsDraft = { ...(this.defaultsDraft ?? configuredDefaults), ...patch };
       this.setMessage("defaults", null);
-      void this.saveDefaults(next);
+      void this.saveDefaults(this.defaultsDraft);
     };
     // This keeps the pre-move General busy gate sourced from the same update state.
     const cards = buildModelProviderCards({
@@ -642,7 +650,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       refreshing: this.loadClient !== null,
       error: rosterError ?? data.error ?? data.catalogError,
       providerUsageFailed: data.providerUsage?.ok === false,
-      supplementalLoading: this.supplemental.loading,
+      supplementalLoading: this.loaderPending || this.supplemental.loading,
       updatedAt: data.updatedAt,
       costDays: MODEL_PROVIDERS_COST_DAYS,
       credentialAgentLabel: selectedAgentLabel,

--- a/ui/src/pages/model-providers/model-providers-page.usage.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.usage.test.ts
@@ -9,6 +9,7 @@ import {
   deferred,
   focusDocument,
   requestCount,
+  type ModelProvidersPageTestElement,
 } from "./model-providers-page.test-support.ts";
 
 afterEach(() => {
@@ -18,6 +19,34 @@ afterEach(() => {
 });
 
 describe("ModelProvidersPage usage convergence", () => {
+  it("waits for the route loader before starting provider requests, including after reconnect", async () => {
+    const harness = createHarness("main");
+    const page = document.createElement(
+      "openclaw-model-providers-page",
+    ) as ModelProvidersPageTestElement;
+    page.context = harness.context;
+    document.body.append(page);
+    await page.updateComplete;
+    expect(harness.request).not.toHaveBeenCalled();
+
+    harness.publishPhase("offline");
+    harness.publishPhase("connected");
+    await page.updateComplete;
+    expect(harness.request).not.toHaveBeenCalled();
+
+    page.routeData = {
+      gateway: harness.context.gateway,
+      gatewaySnapshot: harness.context.gateway.snapshot,
+      client: harness.context.gateway.snapshot.client,
+      agentId: "main",
+      data: { ...EMPTY_MODEL_PROVIDERS_DATA, config: {}, updatedAt: Date.now() },
+    };
+    await vi.waitFor(() => expect(page.data?.costByProvider).toEqual([]));
+    expect(requestCount(harness.request, "models.authStatus")).toBe(0);
+    expect(requestCount(harness.request, "usage.status")).toBe(1);
+    expect(requestCount(harness.request, "sessions.usage")).toBe(1);
+  });
+
   it("restarts an exhausted retry cycle on same-client reconnect", async () => {
     vi.useFakeTimers();
     focusDocument();

--- a/ui/src/pages/model-providers/route.ts
+++ b/ui/src/pages/model-providers/route.ts
@@ -64,7 +64,10 @@ export const page = definePage({
   component: () =>
     import("./model-providers-page.ts").then(() => ({
       header: true,
-      render: (data: ModelProvidersRouteData | undefined) =>
-        html`<openclaw-model-providers-page .routeData=${data}></openclaw-model-providers-page>`,
+      render: (data: ModelProvidersRouteData | undefined, loaderPending = false) =>
+        html`<openclaw-model-providers-page
+          .routeData=${data}
+          .loaderPending=${loaderPending}
+        ></openclaw-model-providers-page>`,
     })),
 });

--- a/ui/src/pages/model-providers/supplemental-load.ts
+++ b/ui/src/pages/model-providers/supplemental-load.ts
@@ -12,6 +12,7 @@ type SupplementalGateway = {
 };
 
 type SupplementalOptions = {
+  isCoreLoading: () => boolean;
   getGateway: () => SupplementalGateway;
   getData: () => ModelProvidersData | null;
   getDataClient: () => GatewayBrowserClient | null;
@@ -76,9 +77,15 @@ export class ModelProviderSupplementalLoader {
         this.options.getGateway().epoch,
       );
     }
-    // The same route data can be adopted more than once. Core refresh cancels
-    // the prior generation before its replacement reaches this boundary.
-    if (client && !this.loading && data.providerUsage === null && data.costByProvider === null) {
+    // Cached core data stays visible during route reloads; only the settled
+    // loader starts supplemental work, so adopting its result cannot duplicate it.
+    if (
+      client &&
+      !this.options.isCoreLoading() &&
+      !this.loading &&
+      data.providerUsage === null &&
+      data.costByProvider === null
+    ) {
       void this.load(client);
     }
   }

--- a/ui/src/pages/plugins/plugins-page.test.ts
+++ b/ui/src/pages/plugins/plugins-page.test.ts
@@ -48,26 +48,44 @@ describe("PluginsPage", () => {
 
   afterEach(resetPluginsPageTestState);
 
-  it("accepts matching route data without issuing a duplicate list request", async () => {
+  it.each([false, true])(
+    "adopts matching route data without duplicate requests (delayed: %s)",
+    async (delayed) => {
+      const { client, request } = createClient(async () => createResult());
+      const harness = createGateway(client);
+      const result = createResult();
+      const routeData: PluginsRouteData = createPluginsRouteData(harness.gateway, result);
+
+      const { page } = await mountPage(
+        createContext(harness.gateway),
+        delayed ? undefined : routeData,
+      );
+
+      if (delayed) {
+        expect(page.querySelector("h1")?.textContent).toBe("Plugins");
+        expect(request).not.toHaveBeenCalled();
+        harness.emit(client, false);
+        harness.emit(client, true);
+        await page.updateComplete;
+        expect(request).not.toHaveBeenCalled();
+        page.routeData = createPluginsRouteData(harness.gateway, result);
+        await page.updateComplete;
+      }
+
+      expect(page.result).toBe(result);
+      expect(request).not.toHaveBeenCalled();
+      expect(page.querySelectorAll("h1")).toHaveLength(1);
+      expect(page.querySelector("h1")?.textContent).toBe("Plugins");
+    },
+  );
+
+  it("surfaces a route catalog load failure without retrying it", async () => {
     const { client, request } = createClient(async () => createResult());
     const harness = createGateway(client);
-    const result = createResult();
-    const routeData: PluginsRouteData = createPluginsRouteData(harness.gateway, result);
-
-    const { page } = await mountPage(createContext(harness.gateway), routeData);
-
-    expect(page.result).toBe(result);
-    expect(request).not.toHaveBeenCalled();
-    expect(page.querySelectorAll("h1")).toHaveLength(1);
-    expect(page.querySelector("h1")?.textContent).toBe("Plugins");
-  });
-
-  it("surfaces an initial catalog load failure", async () => {
-    const { client } = createClient(async () => {
-      throw new Error("catalog unavailable");
+    const { page } = await mountPage(createContext(harness.gateway), {
+      ...createPluginsRouteData(harness.gateway, null),
+      error: "catalog unavailable",
     });
-    const harness = createGateway(client);
-    const { page } = await mountPage(createContext(harness.gateway));
 
     await waitForFast(() =>
       expect(page.querySelector(".plugins-page-error")?.textContent).toContain(
@@ -77,6 +95,7 @@ describe("PluginsPage", () => {
     expect(
       page.querySelector(".plugins-page-error")?.textContent?.match(/catalog unavailable/gu),
     ).toHaveLength(1);
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("refreshes the authoritative catalog after a same-client reconnect", async () => {

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -266,11 +266,10 @@ class PluginsPage extends OpenClawLightDomElement {
 
   private applyRouteData() {
     const data = this.routeData;
-    this.routeDataConsumed = true;
     if (!data) {
-      this.ensureInitialData();
       return;
     }
+    this.routeDataConsumed = true;
     const urlTab = pluginsHubTabForRoute(data.location, this.context.basePath);
     if (urlTab !== this.activeTab) {
       this.changeTab(urlTab);
@@ -463,7 +462,10 @@ class PluginsPage extends OpenClawLightDomElement {
   }
 
   private get loading(): boolean {
-    return this.gateway.connected && this.catalogTask.status === TaskStatus.PENDING;
+    return (
+      this.gateway.connected &&
+      (!this.routeDataConsumed || this.catalogTask.status === TaskStatus.PENDING)
+    );
   }
 
   private get searchResults(): PluginSearchResult[] | null {
@@ -489,16 +491,15 @@ class PluginsPage extends OpenClawLightDomElement {
   }
 
   private ensureInitialData() {
+    // The route owns initial loading; a warm page module can render before its data arrives.
     if (
+      !this.routeDataConsumed ||
       !this.gateway.connected ||
       !this.gateway.client ||
       this.loading ||
       this.result ||
       this.error
     ) {
-      return;
-    }
-    if (this.routeData && !this.routeDataConsumed) {
       return;
     }
     void this.refreshCatalog();


### PR DESCRIPTION
Related: #136862 (deferred route-module warm-up follow-up).

## What Problem This Solves

Fixes an issue where opening Models or Plugins could start a second page load when the page module arrived before its route loader. Models could then request usage and cost again when the loader result arrived. The same ownership gap affected cached revisits while fresh route data was still loading.

## Why This Change Was Made

The outlet now passes the rendered match's loader-pending state to page renderers. `pendingMatches` alone cannot represent this: `@openclaw/uirouter` 0.1.1 promotes a module-ready match into `matches` and clears `pendingMatches` before its loader completes. Models preserves cached controls while deferring supplemental requests until the route loader settles. Models and Plugins also require initial loader adoption before starting their own refreshes, including an early reconnect.

Restores `warmApplicationRouteModule` from the follow-up identified in #136862. Explicit routes start downloading their page chunks at the beginning of the startup lifecycle, alongside Gateway startup. Default landing waits for the first-run decision, and stopped runtimes do not start warm-ups.

The sibling audit found Agents, Devices, and Usage already gate initial loader adoption; Skills additionally withholds its page until data arrives. Channels and Workboard use shared stores with loading-state deduplication. Other self-loading pages have no route loader, synchronous query-only loaders, or separately owned requests.

## User Impact

Settings remain progressive: provider controls appear before usage and cost settle, and each supplemental request runs once per navigation even when the page module or prior route data is cached. Explicit-route chunk downloads start one wave earlier on cold startup. Configuration and storage contracts are unchanged.

## Evidence

- Before the fix, a mounted Models page with pending route data sent three premature core requests; Plugins sent a premature `plugins.list`. The new delayed-adoption regressions fail on the previous code.
- Chromium production-bundle reproduction prewarms the page module and defers only the route's `config.get`, so a competing page load cannot hide behind the same held auth request. The pre-fix prewarmed case starts usage before the route loader is released. An initial-adoption-only repair still fails the cached revisit, which is covered by the outlet marker.
- Progressive E2E covers cold, prewarmed, and cached routes; credentials remain visible while usage/cost are held, usage then appears before cost, and `usage.status` / `sessions.usage` each run once per navigation.
- Focused Models, route admission, outlet presentation/MCP ownership, Plugins lifecycle/routing/consent/icons, and startup tests pass. Startup cases cover an explicit settings route, a mount prefix, a session deep link, default landing, focused/approval documents, and starting after stop.
- Screenshots below use the deterministic mock Gateway. Request-order assertions provide the network evidence; screenshots show the progressively rendered states.

Production delta: +72/-31 (net +41); tests/test support: +291/-93 (net +198); docs: +2/-0. The growth adds the explicit rendered-loader contract and restores early module warming; it removes the two undefined-data self-loading paths. Tests/test support are separate. 

Validation completed: 191 focused unit tests and 38 browser scenarios across the Models, Plugins, model setup, and New Session surfaces. The broad run initially caught the new cached-test precondition; after seeding a connected route, all three progressive cases passed. Visual inspection also caught and fixed the pending usage label; its new assertion fails without the presentation fix. Codex autoreview is scoped-clean through P2.

Focused commands:

```sh
node scripts/run-vitest.mjs ui/src/pages/model-providers/model-providers-page.test.ts ui/src/pages/model-providers/model-providers-page.usage.test.ts ui/src/pages/model-providers/route.test.ts ui/src/app/router-outlet.test.ts ui/src/app/router-outlet-chat.test.ts ui/src/app/router-outlet-controller.test.ts
node scripts/run-vitest.mjs ui/src/app/bootstrap.test.ts
node scripts/run-vitest.mjs ui/src/pages/plugins/plugins-page.test.ts ui/src/pages/plugins/plugins-page.lifecycle.test.ts ui/src/pages/plugins/plugins-page.routing.test.ts ui/src/pages/plugins/plugins-page.consent.test.ts ui/src/pages/plugins/plugins-page.icons.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/model-providers-progressive.e2e.test.ts ui/src/e2e/model-provider-usage-outcomes.e2e.test.ts ui/src/e2e/plugins-hub-navigation.e2e.test.ts ui/src/e2e/model-setup.e2e.test.ts ui/src/e2e/new-session-page.transition.e2e.test.ts
```

`pnpm build` passed, including the production UI bundle and startup request/size budgets (8 requests, 348,703 gzip bytes). The changed-file gate passed its structural checks, core-test/UI type checks, i18n verification, and dead-export scans; its initial page-size lint failure was fixed by removing redundant code, and targeted lint plus UI type checking passed afterward. The final Models unit rerun passed all 41 tests.

![Before: prewarmed page self-loads while its route loader is still held](https://github.com/user-attachments/assets/2e086541-c38e-4de6-b44b-c2233bd6d196)

![After: cached controls remain visible while route loading owns the refresh](https://github.com/user-attachments/assets/d631f794-fe00-4f00-8171-4c19a429372d)

![After: usage and cost settle once each](https://github.com/user-attachments/assets/50c61be9-4bd1-4039-99c4-920b5c0b1499)

CI caught one additional Models fixture in `ui/src/pages/gateway-source-replacement.test.ts` that mounted without any route result. Updated it to use the existing completed-disconnected-loader fixture so it still proves stale same-client source work is rejected without relying on the removed undefined-data self-load. The original assertion failed locally before the fixture update; all 21 source-replacement cases and 8 Models usage cases pass afterward.
