### PR TITLE
refactor(github): simplify preview requests and hovercard lifecycle

### DIFF
--- a/src/gateway/control-ui-github-api.test.ts
+++ b/src/gateway/control-ui-github-api.test.ts
@@ -106,6 +106,23 @@ describe("Control UI GitHub failures", () => {
     expect(display.retryable).toBe(true);
   });
 
+  it("dispatches an admitted request before its caller can retire", async () => {
+    let active = true;
+    let activeAtDispatch: boolean | undefined;
+    const pending = fetchGitHubApi(
+      "https://api.github.com/repos/owner/repo/actions/runs",
+      async () => {
+        activeAtDispatch = active;
+        return new Response("{}");
+      },
+      "synthetic-token",
+    );
+    active = false;
+    await pending;
+
+    expect(activeAtDispatch).toBe(true);
+  });
+
   it("shows configured credential recovery instructions but hides unknown errors", () => {
     const unavailable = new SecretSurfaceUnavailableError({
       ownerKind: "capability",

--- a/src/gateway/control-ui-github-api.ts
+++ b/src/gateway/control-ui-github-api.ts
@@ -1,12 +1,5 @@
-// Shared api.github.com plumbing for Control UI GitHub surfaces (link
-// previews, session pull request chips): pinned origin, manual redirects,
-// bounded bodies, and normalized upstream error statuses.
 import { createHash } from "node:crypto";
-import {
-  asFiniteNumber,
-  parseStrictNonNegativeInteger,
-} from "@openclaw/normalization-core/number-coercion";
-import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
+import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { getRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
@@ -16,7 +9,6 @@ import {
   isTrustedSecretSurfaceUnavailableError,
   SecretSurfaceUnavailableError,
 } from "../secrets/runtime-degraded-state.js";
-export { isRecord } from "@openclaw/normalization-core/record-coerce";
 
 export const GITHUB_API_ORIGIN = "https://api.github.com";
 export const CONTROL_UI_GITHUB_CREDENTIAL_UNAVAILABLE_MESSAGE =
@@ -110,25 +102,6 @@ export function formatControlUiGitHubPreviewError(error: unknown): {
   };
 }
 
-export function requiredString(record: Record<string, unknown>, key: string): string {
-  const value = readNonBlankString(record[key]);
-  if (value === undefined) {
-    throw new ControlUiGitHubError(502, `GitHub response omitted ${key}`);
-  }
-  return value;
-}
-
-export function readOptionalGitHubString(
-  record: Record<string, unknown>,
-  key: string,
-): string | undefined {
-  return readNonBlankString(record[key]);
-}
-
-export function optionalNumber(record: Record<string, unknown>, key: string): number | undefined {
-  return asFiniteNumber(record[key]);
-}
-
 export function githubApiToken(
   env: NodeJS.ProcessEnv = process.env,
   config: OpenClawConfig | null = getRuntimeConfigSnapshot(),
@@ -220,8 +193,10 @@ export async function fetchGitHubApi(
   for (let redirects = 0; ; redirects += 1) {
     // Recheck every dispatch, including redirects and auxiliary metadata reads.
     // Selection must still be current after the asynchronous credential read.
-    await identity?.revalidate();
-    identity?.assertSelected();
+    if (identity) {
+      await identity.revalidate();
+      identity.assertSelected();
+    }
     let response: Response;
     try {
       response = await fetchImpl(url.href, {

--- a/src/gateway/control-ui-github-preview.test.ts
+++ b/src/gateway/control-ui-github-preview.test.ts
@@ -55,24 +55,26 @@ function previewPayload(overrides: Record<string, unknown> = {}): Record<string,
   };
 }
 
+function managedIdentity(cacheScope: string, assertSelected: () => void = vi.fn()) {
+  return {
+    token: `token-${cacheScope}`,
+    cacheScope,
+    assertSelected,
+    revalidate: vi.fn(async () => assertSelected()),
+  };
+}
+
 describe("parseControlUiGitHubPreviewTarget", () => {
+  const target = { kind: "issue", number: 1, owner: "openclaw", repo: "openclaw" };
+
   it("accepts bounded GitHub issue and pull request targets", () => {
-    const target = parseControlUiGitHubPreviewTarget({
+    expect(parseControlUiGitHubPreviewTarget({ ...target, kind: "pull" })).toEqual({
+      ...target,
       kind: "pull",
-      number: 99816,
-      owner: "openclaw",
-      repo: "openclaw",
     });
-    expect(target).toEqual({ kind: "pull", number: 99816, owner: "openclaw", repo: "openclaw" });
-    expect(
-      parseControlUiGitHubPreviewTarget({
-        kind: "issue",
-        number: 1,
-        owner: "github",
-        repo: ".github",
-      }),
-    ).toEqual({ kind: "issue", number: 1, owner: "github", repo: ".github" });
     for (const repo of [
+      "openclaw",
+      ".github",
       ".whitesource",
       ".emacs.d",
       "-edge",
@@ -81,44 +83,25 @@ describe("parseControlUiGitHubPreviewTarget", () => {
       "repo.",
       "foo..bar",
     ]) {
-      expect(
-        parseControlUiGitHubPreviewTarget({
-          kind: "issue",
-          number: 1,
-          owner: "openclaw",
-          repo,
-        }),
-      ).toEqual({ kind: "issue", number: 1, owner: "openclaw", repo });
+      expect(parseControlUiGitHubPreviewTarget({ ...target, repo })).toEqual({ ...target, repo });
     }
   });
 
-  it("rejects invalid repository paths and item numbers", () => {
-    expect(
-      parseControlUiGitHubPreviewTarget({
-        kind: "issue",
-        number: 1,
-        owner: "openclaw/evil",
-        repo: "openclaw",
-      }),
-    ).toBeNull();
-    expect(
-      parseControlUiGitHubPreviewTarget({
-        kind: "issue",
-        number: 0,
-        owner: "openclaw",
-        repo: "..",
-      }),
-    ).toBeNull();
-    for (const repo of [".", "..", "repo.git", "repo.atom"]) {
-      expect(
-        parseControlUiGitHubPreviewTarget({
-          kind: "issue",
-          number: 1,
-          owner: "openclaw",
-          repo,
-        }),
-      ).toBeNull();
-    }
+  it.each([
+    { field: "kind", value: "comment" },
+    { field: "owner", value: "openclaw/evil" },
+    { field: "repo", value: "." },
+    { field: "repo", value: ".." },
+    { field: "repo", value: "repo.git" },
+    { field: "repo", value: "repo.atom" },
+    { field: "number", value: 0 },
+    { field: "number", value: 1.5 },
+    { field: "number", value: 10_000_000_000 },
+    { field: "number", value: "1" },
+    { field: "agentId", value: " " },
+    { field: "agentId", value: 1 },
+  ])("rejects invalid $field: $value", ({ field, value }) => {
+    expect(parseControlUiGitHubPreviewTarget({ ...target, [field]: value })).toBeNull();
   });
 });
 
@@ -138,14 +121,8 @@ describe("loadControlUiGitHubPreview", () => {
 
   it("keeps selected identity caches separate and revalidates cached delivery", async () => {
     const target = { kind: "issue" as const, number: 88122, owner: "openclaw", repo: "openclaw" };
-    const makeIdentity = (token: string) => ({
-      token,
-      cacheScope: token,
-      assertSelected: vi.fn(),
-      revalidate: vi.fn().mockResolvedValue(undefined),
-    });
-    const firstIdentity = makeIdentity("first-preview-identity");
-    const secondIdentity = makeIdentity("second-preview-identity");
+    const firstIdentity = managedIdentity("first-preview-identity");
+    const secondIdentity = managedIdentity("second-preview-identity");
     const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input, init) =>
       requestUrl(input).includes("/issues/")
         ? githubJson(
@@ -191,12 +168,7 @@ describe("loadControlUiGitHubPreview", () => {
           throw new GitHubIdentityError("changed");
         }
       };
-      const identity = {
-        token: "inflight-preview-identity",
-        cacheScope: `inflight-preview-identity-${stage}`,
-        assertSelected,
-        revalidate: async () => assertSelected(),
-      };
+      const identity = managedIdentity(`inflight-preview-identity-${stage}`, assertSelected);
       const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
         const url = requestUrl(input);
         if (fetchMock.mock.calls.length === stopAfter) {
@@ -231,22 +203,12 @@ describe("loadControlUiGitHubPreview", () => {
     const started = createDeferred();
     const repository = createDeferred<Response>();
     let connected = true;
-    const identity = {
-      token: "shared-preview-identity",
-      cacheScope: "shared-preview-identity",
-      assertSelected() {
-        if (!connected) {
-          throw new GitHubIdentityError("changed");
-        }
-      },
-      async revalidate() {
-        this.assertSelected();
-      },
-    };
-    const follower = {
-      ...identity,
-      assertSelected() {},
-    };
+    const identity = managedIdentity("shared-preview-identity", () => {
+      if (!connected) {
+        throw new GitHubIdentityError("changed");
+      }
+    });
+    const follower = managedIdentity("shared-preview-identity");
     const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
       if (fetchMock.mock.calls.length === 1) {
         started.resolve();
@@ -277,12 +239,7 @@ describe("loadControlUiGitHubPreview", () => {
   it.each([401, 403, 429])(
     "does not retry a selected identity failure anonymously (HTTP %s)",
     async (httpStatus) => {
-      const identity = {
-        token: "selected-preview-identity",
-        cacheScope: `selected-preview-identity-${httpStatus}`,
-        assertSelected: vi.fn(),
-        revalidate: vi.fn().mockResolvedValue(undefined),
-      };
+      const identity = managedIdentity(`selected-preview-identity-${httpStatus}`);
       const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(githubJson({}, httpStatus));
 
       await expect(
@@ -332,25 +289,18 @@ describe("loadControlUiGitHubPreview", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
       "https://api.github.com/repos/openclaw/openclaw/pulls/99816",
     );
-    const avatarRequest = fetchMock.mock.calls
-      .map(([input]) => input)
-      .find((input) => {
-        return input instanceof URL && input.href.includes("avatars.githubusercontent.com");
-      });
-    expect(avatarRequest).toBeInstanceOf(URL);
-    expect(avatarRequest instanceof URL ? avatarRequest.href : "").toContain(
-      "avatars.githubusercontent.com/u/58493",
-    );
-    expect(avatarRequest instanceof URL ? avatarRequest.hash : "").toBe("");
-    expect(avatarRequest instanceof URL ? avatarRequest.search : "").toBe("?s=64");
-    expect(avatarRequest instanceof URL ? avatarRequest.searchParams.get("s") : null).toBe("64");
+    const avatarUrl = fetchMock.mock.calls
+      .map(([input]) => requestUrl(input))
+      .find((url) => url.startsWith("https://avatars.githubusercontent.com/"));
+    expect(avatarUrl).toBe("https://avatars.githubusercontent.com/u/58493?s=64");
   });
 
   it("resolves co-authors from noreply trailers without a lookup per person", async () => {
     const commits = [
       {
         commit: {
-          message: "feat: one\n\nCo-authored-by: Ada King <20+ada@users.noreply.github.com>",
+          // A commits page can exceed the shared 256 KiB JSON default.
+          message: `${"x".repeat(300 * 1024)}\n\nCo-authored-by: Ada King <20+ada@users.noreply.github.com>`,
         },
       },
       // Repeat plus a different case: the same person must fold into one face.
@@ -367,6 +317,14 @@ describe("loadControlUiGitHubPreview", () => {
       },
       // A plain address carries no account id, so it cannot resolve to a face.
       { commit: { message: "fix: five\n\nCo-authored-by: Someone <someone@example.com>" } },
+      {
+        commit: { message: "fix: six\n\nCo-authored-by: Alan <31+alan@users.noreply.github.com>" },
+      },
+      {
+        commit: {
+          message: "fix: seven\n\nCo-authored-by: Grace <99+grace@users.noreply.github.com>",
+        },
+      },
     ];
     const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
       const url = requestUrl(input);
@@ -387,20 +345,24 @@ describe("loadControlUiGitHubPreview", () => {
       fetchMock,
     );
 
-    expect(preview.coAuthorCount).toBe(2);
+    expect(preview.coAuthorCount).toBe(4);
     expect(preview.coAuthors).toEqual([
       { login: "ada", avatarDataUrl: "data:image/png;base64,iVBORw==" },
       { login: "mira", avatarDataUrl: "data:image/png;base64,iVBORw==" },
+      { login: "alan", avatarDataUrl: "data:image/png;base64,iVBORw==" },
     ]);
     // The account id in the trailer is the avatar, so no per-person API lookup.
-    const avatarUrls = fetchMock.mock.calls
-      .map(([input]) => requestUrl(input))
-      .filter((url) => url.includes("avatars.githubusercontent.com"));
-    expect(avatarUrls).toEqual([
+    const urls = fetchMock.mock.calls.map(([input]) => requestUrl(input));
+    expect(urls.filter((url) => url.startsWith("https://api.github.com/"))).toEqual([
+      "https://api.github.com/repos/openclaw/openclaw/pulls/88101",
+      "https://api.github.com/repos/openclaw/openclaw/pulls/88101/commits?per_page=100",
+    ]);
+    expect(urls.filter((url) => url.startsWith("https://avatars.githubusercontent.com/"))).toEqual([
       "https://avatars.githubusercontent.com/u/58493?s=64",
       // Co-author avatars go through the same bounded ?s=64 normalization.
       "https://avatars.githubusercontent.com/u/20?s=64",
       "https://avatars.githubusercontent.com/u/7?s=64",
+      "https://avatars.githubusercontent.com/u/31?s=64",
     ]);
   });
 
@@ -556,7 +518,7 @@ describe("loadControlUiGitHubPreview", () => {
       .mockResolvedValueOnce(avatarResponse);
 
     const preview = await loadControlUiGitHubPreview(
-      { kind: "pull", number: 70009, owner: "openclaw", repo: "bad-avatar" },
+      { kind: "issue", number: 70009, owner: "openclaw", repo: "bad-avatar" },
       undefined,
       fetchMock,
     );

--- a/src/gateway/control-ui-github-preview.ts
+++ b/src/gateway/control-ui-github-preview.ts
@@ -1,23 +1,21 @@
+import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import {
   GitHubIdentityError,
   type prepareGitHubReadIdentity,
 } from "../agents/github-tool-identity.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import type { ControlUiGitHubPreview } from "./control-ui-contract.js";
-// Same-origin GitHub metadata adapter for Control UI link previews.
 import {
   ControlUiGitHubError,
   discardResponse,
   fetchGitHubApi,
   GITHUB_API_ORIGIN,
   GITHUB_REQUEST_TIMEOUT_MS,
-  isRecord,
-  optionalNumber,
-  readOptionalGitHubString,
   readBoundedResponse,
   readGitHubJsonResponse,
   resolveGitHubApiCredentialScope,
-  requiredString,
   withOptionalGitHubAuth,
 } from "./control-ui-github-api.js";
 
@@ -97,39 +95,12 @@ export function parseControlUiGitHubPreviewTarget(
   return { kind, number, owner, repo };
 }
 
-function commitsApiUrl(target: ControlUiGitHubPreviewTarget): string {
-  const owner = encodeURIComponent(target.owner);
-  const repo = encodeURIComponent(target.repo);
-  return `${GITHUB_API_ORIGIN}/repos/${owner}/${repo}/pulls/${target.number}/commits?per_page=${GITHUB_COMMITS_PAGE_SIZE}`;
-}
-
-function previewApiUrl(target: ControlUiGitHubPreviewTarget): string {
-  const collection = target.kind === "pull" ? "pulls" : "issues";
-  const owner = encodeURIComponent(target.owner);
-  const repo = encodeURIComponent(target.repo);
-  return `${GITHUB_API_ORIGIN}/repos/${owner}/${repo}/${collection}/${target.number}`;
-}
-
-function repositoryApiUrl(target: ControlUiGitHubPreviewTarget): string {
-  const owner = encodeURIComponent(target.owner);
-  const repo = encodeURIComponent(target.repo);
-  return `${GITHUB_API_ORIGIN}/repos/${owner}/${repo}`;
-}
-
-async function assertPublicRepositoryUrl(
-  repositoryUrl: string,
-  fetchImpl: typeof fetch,
-  token: string,
-  identity?: ControlUiGitHubPreviewIdentity,
-): Promise<void> {
-  // Private and missing repositories stop at this same request boundary before
-  // any item fetch, so operator.read callers cannot probe private item numbers.
-  const parsed = await readGitHubJsonResponse(
-    await fetchGitHubApi(repositoryUrl, fetchImpl, token, undefined, identity),
-  );
-  if (!isRecord(parsed) || parsed.private !== false) {
-    throw new ControlUiGitHubError(404, "GitHub repository is not public");
+function requiredString(record: Record<string, unknown>, key: string): string {
+  const value = readNonBlankString(record[key]);
+  if (value === undefined) {
+    throw new ControlUiGitHubError(502, `GitHub response omitted ${key}`);
   }
+  return value;
 }
 
 function redirectedRepositoryApiUrl(target: ControlUiGitHubPreviewTarget, url: URL): string | null {
@@ -173,30 +144,27 @@ function previewRepositoryApiUrl(
 
 function parseGitHubResponse(
   target: ControlUiGitHubPreviewTarget,
-  value: unknown,
+  value: Record<string, unknown>,
 ): { preview: ControlUiGitHubPreview; avatarUrl?: string } {
-  if (!isRecord(value)) {
-    throw new ControlUiGitHubError(502, "GitHub response was not an object");
-  }
   const user = isRecord(value.user) ? value.user : {};
   return {
     preview: {
       ...target,
-      additions: optionalNumber(value, "additions"),
-      changedFiles: optionalNumber(value, "changed_files"),
-      closedAt: readOptionalGitHubString(value, "closed_at"),
-      comments: optionalNumber(value, "comments"),
+      additions: asFiniteNumber(value.additions),
+      changedFiles: asFiniteNumber(value.changed_files),
+      closedAt: readNonBlankString(value.closed_at),
+      comments: asFiniteNumber(value.comments),
       createdAt: requiredString(value, "created_at"),
-      deletions: optionalNumber(value, "deletions"),
+      deletions: asFiniteNumber(value.deletions),
       draft: typeof value.draft === "boolean" ? value.draft : undefined,
-      login: readOptionalGitHubString(user, "login") ?? "ghost",
-      mergedAt: readOptionalGitHubString(value, "merged_at"),
+      login: readNonBlankString(user.login) ?? "ghost",
+      mergedAt: readNonBlankString(value.merged_at),
       state: requiredString(value, "state"),
-      stateReason: readOptionalGitHubString(value, "state_reason"),
+      stateReason: readNonBlankString(value.state_reason),
       title: requiredString(value, "title"),
       updatedAt: requiredString(value, "updated_at"),
     },
-    avatarUrl: readOptionalGitHubString(user, "avatar_url"),
+    avatarUrl: readNonBlankString(user.avatar_url),
   };
 }
 
@@ -230,36 +198,15 @@ function safeAvatarUrl(raw: string | undefined): URL | null {
   }
 }
 
-/**
- * Distinct co-author logins from a PR's commit trailers, author excluded, in
- * first-seen order. Returns the true total alongside the bounded face list so
- * the card can render "+N" without another request.
- */
 async function fetchCoAuthors(
-  target: ControlUiGitHubPreviewTarget,
   authorLogin: string,
+  loadCommits: () => Promise<unknown>,
   fetchImpl: typeof fetch,
-  token: string | undefined,
-  beforeRedirect: ((url: URL) => Promise<void>) | undefined,
-  identity?: ControlUiGitHubPreviewIdentity,
 ): Promise<{ coAuthors: { login: string; avatarDataUrl?: string }[]; coAuthorCount: number }> {
   const empty = { coAuthors: [], coAuthorCount: 0 };
   let commits: unknown;
   try {
-    const response = await fetchGitHubApi(
-      commitsApiUrl(target),
-      fetchImpl,
-      token,
-      beforeRedirect,
-      identity,
-    );
-    if (!response.ok) {
-      await discardResponse(response);
-      return empty;
-    }
-    commits = JSON.parse(
-      (await readBoundedResponse(response, GITHUB_COMMITS_MAX_BYTES)).toString("utf8"),
-    );
+    commits = await loadCommits();
   } catch {
     // Co-authors are decoration on an already-useful card, so a failed or
     // oversized commits page degrades to no faces instead of failing the card.
@@ -271,7 +218,7 @@ async function fetchCoAuthors(
   const byLogin = new Map<string, { login: string; accountId: string }>();
   for (const entry of commits) {
     const commit = isRecord(entry) && isRecord(entry.commit) ? entry.commit : undefined;
-    const message = commit ? readOptionalGitHubString(commit, "message") : undefined;
+    const message = readNonBlankString(commit?.message);
     if (!message) {
       continue;
     }
@@ -336,8 +283,20 @@ async function fetchPreview(
   token?: string,
   identity?: ControlUiGitHubPreviewIdentity,
 ): Promise<ControlUiGitHubPreview> {
+  const request = (url: string, beforeRedirect?: (url: URL) => Promise<void>) =>
+    fetchGitHubApi(url, fetchImpl, token, beforeRedirect, identity);
+  const assertPublicRepository = async (url: string) => {
+    // Private and missing repositories stop before any item fetch, so
+    // operator.read callers cannot probe private item numbers.
+    const repository = await readGitHubJsonResponse(await request(url));
+    if (!isRecord(repository) || repository.private !== false) {
+      throw new ControlUiGitHubError(404, "GitHub repository is not public");
+    }
+  };
+  const repositoryUrl = `${GITHUB_API_ORIGIN}/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}`;
+  const itemUrl = `${repositoryUrl}/${target.kind === "pull" ? "pulls" : "issues"}/${target.number}`;
   if (token) {
-    await assertPublicRepositoryUrl(repositoryApiUrl(target), fetchImpl, token, identity);
+    await assertPublicRepository(repositoryUrl);
   }
   // Every credentialed fetch below shares this guard: a rename or transfer can
   // redirect into a repository the token can read but the viewer may not see.
@@ -347,22 +306,17 @@ async function fetchPreview(
         if (!repositoryUrl) {
           throw new ControlUiGitHubError(502, "GitHub item returned an unsafe redirect");
         }
-        await assertPublicRepositoryUrl(repositoryUrl, fetchImpl, token, identity);
+        await assertPublicRepository(repositoryUrl);
       }
     : undefined;
-  const parsed = await readGitHubJsonResponse(
-    await fetchGitHubApi(previewApiUrl(target), fetchImpl, token, beforeRedirect, identity),
-  );
+  const readItem = async (url: string, maxBytes?: number) =>
+    readGitHubJsonResponse(await request(url, beforeRedirect), maxBytes);
+  const parsed = await readItem(itemUrl);
   if (!isRecord(parsed)) {
     throw new ControlUiGitHubError(502, "GitHub response was not an object");
   }
   if (token) {
-    await assertPublicRepositoryUrl(
-      previewRepositoryApiUrl(target, parsed),
-      fetchImpl,
-      token,
-      identity,
-    );
+    await assertPublicRepository(previewRepositoryApiUrl(target, parsed));
   }
   const { preview, avatarUrl } = parseGitHubResponse(target, parsed);
   // Both extra fetches run only after the public-repository assertions above,
@@ -370,7 +324,15 @@ async function fetchPreview(
   const [avatarDataUrl, coAuthorFacts] = await Promise.all([
     fetchAvatarDataUrl(avatarUrl, fetchImpl),
     target.kind === "pull"
-      ? fetchCoAuthors(target, preview.login, fetchImpl, token, beforeRedirect, identity)
+      ? fetchCoAuthors(
+          preview.login,
+          () =>
+            readItem(
+              `${itemUrl}/commits?per_page=${GITHUB_COMMITS_PAGE_SIZE}`,
+              GITHUB_COMMITS_MAX_BYTES,
+            ),
+          fetchImpl,
+        )
       : Promise.resolve({ coAuthors: [], coAuthorCount: 0 }),
   ]);
   return {

--- a/src/gateway/control-ui-github-preview.ts
+++ b/src/gateway/control-ui-github-preview.ts
@@ -302,11 +302,11 @@ async function fetchPreview(
   // redirect into a repository the token can read but the viewer may not see.
   const beforeRedirect = token
     ? async (url: URL) => {
-        const repositoryUrl = redirectedRepositoryApiUrl(target, url);
-        if (!repositoryUrl) {
+        const redirectedRepositoryUrl = redirectedRepositoryApiUrl(target, url);
+        if (!redirectedRepositoryUrl) {
           throw new ControlUiGitHubError(502, "GitHub item returned an unsafe redirect");
         }
-        await assertPublicRepository(repositoryUrl);
+        await assertPublicRepository(redirectedRepositoryUrl);
       }
     : undefined;
   const readItem = async (url: string, maxBytes?: number) =>

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -2,7 +2,12 @@
 // UI chat view can pin PR status chips above the composer.
 import fs from "node:fs/promises";
 import nodePath from "node:path";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  normalizeOptionalString,
+  readNonBlankString,
+} from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { runGit } from "../agents/worktrees/git.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
@@ -16,9 +21,6 @@ import {
   ControlUiGitHubError,
   fetchGitHubJson,
   GITHUB_API_ORIGIN,
-  isRecord,
-  optionalNumber,
-  readOptionalGitHubString,
   resolveGitHubApiCredentialScope,
 } from "./control-ui-github-api.js";
 import {
@@ -327,7 +329,7 @@ async function resolveSessionBranch(
 }
 
 function derivePullState(value: Record<string, unknown>): ControlUiSessionPullRequest["state"] {
-  if (readOptionalGitHubString(value, "merged_at")) {
+  if (readNonBlankString(value.merged_at)) {
     return "merged";
   }
   if (value.state !== "open") {
@@ -340,20 +342,20 @@ function parsePullListItem(value: unknown): PullListItem | null {
   if (!isRecord(value)) {
     return null;
   }
-  const number = optionalNumber(value, "number");
-  const title = readOptionalGitHubString(value, "title");
-  const url = readOptionalGitHubString(value, "html_url");
+  const number = asFiniteNumber(value.number);
+  const title = readNonBlankString(value.title);
+  const url = readNonBlankString(value.html_url);
   const base = isRecord(value.base) ? value.base : {};
   const baseRepo = isRecord(base.repo) ? base.repo : {};
   const baseOwner = isRecord(baseRepo.owner) ? baseRepo.owner : {};
-  const owner = readOptionalGitHubString(baseOwner, "login");
-  const repo = readOptionalGitHubString(baseRepo, "name");
+  const owner = readNonBlankString(baseOwner.login);
+  const repo = readNonBlankString(baseRepo.name);
   const head = isRecord(value.head) ? value.head : {};
   if (!number || !Number.isSafeInteger(number) || number < 1 || !title || !url || !owner || !repo) {
     return null;
   }
   const user = isRecord(value.user) ? value.user : {};
-  const authorLogin = readOptionalGitHubString(user, "login");
+  const authorLogin = readNonBlankString(user.login);
   return {
     number,
     title,
@@ -362,9 +364,9 @@ function parsePullListItem(value: unknown): PullListItem | null {
     repo,
     state: derivePullState(value),
     ...(authorLogin ? { author: { login: authorLogin } } : {}),
-    headSha: readOptionalGitHubString(head, "sha"),
-    baseRef: readOptionalGitHubString(base, "ref"),
-    mergeCommitSha: readOptionalGitHubString(value, "merge_commit_sha"),
+    headSha: readNonBlankString(head.sha),
+    baseRef: readNonBlankString(base.ref),
+    mergeCommitSha: readNonBlankString(value.merge_commit_sha),
   };
 }
 
@@ -414,9 +416,9 @@ async function fetchDiffCounts(
       return {};
     }
     return {
-      additions: optionalNumber(value, "additions"),
-      deletions: optionalNumber(value, "deletions"),
-      changedFiles: optionalNumber(value, "changed_files"),
+      additions: asFiniteNumber(value.additions),
+      deletions: asFiniteNumber(value.deletions),
+      changedFiles: asFiniteNumber(value.changed_files),
     };
   } catch (error) {
     rethrowRateLimit(error);
@@ -442,7 +444,7 @@ function rollupCheckRuns(value: unknown): ControlUiSessionPullRequest["checks"] 
   let running = 0;
   for (const runValue of value.check_runs) {
     const run = isRecord(runValue) ? runValue : {};
-    const conclusion = readOptionalGitHubString(run, "conclusion");
+    const conclusion = readNonBlankString(run.conclusion);
     if (conclusion && FAILING_CHECK_CONCLUSIONS.has(conclusion)) {
       failed += 1;
       continue;

--- a/src/gateway/github-user-identity.ts
+++ b/src/gateway/github-user-identity.ts
@@ -1,7 +1,11 @@
 import type { IncomingHttpHeaders } from "node:http";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeLowercaseStringOrEmpty,
+  readNonBlankString,
+} from "@openclaw/normalization-core/string-coerce";
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
+import { createLazyPromise } from "../shared/lazy-promise.js";
 import { resolveCachedGitHubIdentity } from "../state/user-profile-github-identity.js";
 import { classifyTailscaleLogin } from "../state/user-profiles-tailscale-login.js";
 import { syncGitHubIdentity } from "../state/user-profiles.js";
@@ -16,7 +20,6 @@ import {
   githubApiToken,
   readBoundedResponse,
   readGitHubJsonResponse,
-  readOptionalGitHubString,
   withOptionalGitHubAuth,
 } from "./control-ui-github-api.js";
 
@@ -153,36 +156,7 @@ function parseGitHubUserIdentity(accountId: number, payload: unknown): ResolvedG
   if (!login) {
     throw new ControlUiGitHubError(502, "GitHub response omitted a valid login");
   }
-  return { accountId, login, name: readOptionalGitHubString(payload, "name") };
-}
-
-function retryableConnectionSync(
-  sync: () => Promise<AuthenticatedGitHubIdentitySyncResult>,
-): AuthenticatedGitHubIdentitySync {
-  let inFlight: Promise<AuthenticatedGitHubIdentitySyncResult> | undefined;
-  let completed: AuthenticatedGitHubIdentitySyncResult | undefined;
-  return () => {
-    if (completed) {
-      return Promise.resolve(completed);
-    }
-    if (inFlight) {
-      return inFlight;
-    }
-    const current = sync().then((result) => {
-      completed = result;
-      return result;
-    });
-    inFlight = current;
-    void current.then(
-      () => {
-        inFlight = undefined;
-      },
-      () => {
-        inFlight = undefined;
-      },
-    );
-    return current;
-  };
+  return { accountId, login, name: readNonBlankString(payload.name) };
 }
 
 function cloudflareAccessAssertion(params: {
@@ -220,7 +194,7 @@ export function createAuthenticatedGitHubIdentitySync(params: {
     ? classifyTailscaleLogin(params.authResult.tailscaleIdentity.login)
     : undefined;
   if (tailscaleLogin?.kind === "provider" && tailscaleLogin.provider === "github") {
-    return retryableConnectionSync(async () => {
+    return createLazyPromise(async () => {
       const identity = await resolveGitHubUserIdentityByLogin(tailscaleLogin.subject);
       const profile = syncGitHubIdentity({
         identity,
@@ -235,7 +209,7 @@ export function createAuthenticatedGitHubIdentitySync(params: {
   if (!access) {
     return undefined;
   }
-  return retryableConnectionSync(async () => {
+  return createLazyPromise(async () => {
     const accessIdentity = await resolveCloudflareAccessIdentity(
       access.assertion,
       access.principal,

--- a/src/gateway/project-github-search.ts
+++ b/src/gateway/project-github-search.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import type {
   RemoteProject,
   ProjectsSearchRemoteResult,
@@ -8,11 +10,8 @@ import {
   fetchGitHubApi,
   fetchGitHubJson,
   GITHUB_API_ORIGIN,
-  isRecord,
-  readOptionalGitHubString,
   readGitHubJsonResponse,
   resolveGitHubApiCredentialScope,
-  requiredString,
 } from "./control-ui-github-api.js";
 
 const SEARCH_CACHE_MS = 60_000;
@@ -39,20 +38,17 @@ function parseRepository(value: unknown): RemoteProject | null {
   if (!isRecord(value)) {
     return null;
   }
-  let fullName: string;
-  let name: string;
-  try {
-    fullName = requiredString(value, "full_name");
-    name = requiredString(value, "name");
-  } catch {
+  const fullName = readNonBlankString(value.full_name);
+  const name = readNonBlankString(value.name);
+  if (!fullName || !name) {
     return null;
   }
-  const clone = parseProjectGitUrl(readOptionalGitHubString(value, "clone_url") ?? "");
-  const webUrl = boundedString(readOptionalGitHubString(value, "html_url"), 2048);
+  const clone = parseProjectGitUrl(readNonBlankString(value.clone_url) ?? "");
+  const webUrl = boundedString(readNonBlankString(value.html_url), 2048);
   if (!clone || !webUrl) {
     return null;
   }
-  const description = boundedString(readOptionalGitHubString(value, "description"), 500);
+  const description = boundedString(readNonBlankString(value.description), 500);
   return {
     name: name.slice(0, 100),
     fullName: fullName.slice(0, 200),

--- a/src/gateway/server-methods/control-ui.test.ts
+++ b/src/gateway/server-methods/control-ui.test.ts
@@ -270,52 +270,50 @@ describe("controlUi.githubPreview", () => {
     });
   });
 
-  it("returns a retryable unavailable error for GitHub quota failures", async () => {
-    const handlers = createControlUiHandlers(
-      vi.fn().mockRejectedValue(new ControlUiGitHubError(429, "rate limited")),
-    );
-    const respond = vi.fn<RespondFn>();
-
-    await expectDefined(
-      handlers["controlUi.githubPreview"],
-      'handlers["controlUi.githubPreview"] test invariant',
-    )(
-      requestOptions({ kind: "pull", number: 99816, owner: "openclaw", repo: "openclaw" }, respond),
-    );
-
-    expect(respond).toHaveBeenCalledWith(false, undefined, {
-      code: "UNAVAILABLE",
+  it.each([
+    {
+      failure: "GitHub quota",
+      error: new ControlUiGitHubError(429, "rate limited"),
       message: "GitHub API rate limit exceeded (HTTP 429). Wait and retry.",
       retryable: true,
-    });
-  });
-
-  it("preserves a configured-unavailable preview credential diagnostic", async () => {
-    const error = new SecretSurfaceUnavailableError({
-      ownerKind: "capability",
-      ownerId: "control-ui-github",
-      state: "unavailable",
-      paths: ["gateway.controlUi.github.token"],
-      refKeys: [],
-      reason: "secret reference was not found",
-    });
-    const handlers = createControlUiHandlers(vi.fn().mockRejectedValue(error));
-    const respond = vi.fn<RespondFn>();
-
-    await expectDefined(
-      handlers["controlUi.githubPreview"],
-      'handlers["controlUi.githubPreview"] test invariant',
-    )(
-      requestOptions({ kind: "pull", number: 99816, owner: "openclaw", repo: "openclaw" }, respond),
-    );
-
-    expect(respond).toHaveBeenCalledWith(false, undefined, {
-      code: "UNAVAILABLE",
+    },
+    {
+      failure: "configured-unavailable preview credential",
+      error: new SecretSurfaceUnavailableError({
+        ownerKind: "capability",
+        ownerId: "control-ui-github",
+        state: "unavailable",
+        paths: ["gateway.controlUi.github.token"],
+        refKeys: [],
+        reason: "secret reference was not found",
+      }),
       message:
         "The configured Control UI GitHub credential is unavailable. Resolve gateway.controlUi.github.token and retry.",
       retryable: false,
-    });
-  });
+    },
+  ])(
+    "preserves the $failure diagnostic in the RPC response",
+    async ({ error, message, retryable }) => {
+      const handlers = createControlUiHandlers(vi.fn().mockRejectedValue(error));
+      const respond = vi.fn<RespondFn>();
+
+      await expectDefined(
+        handlers["controlUi.githubPreview"],
+        'handlers["controlUi.githubPreview"] test invariant',
+      )(
+        requestOptions(
+          { kind: "pull", number: 99816, owner: "openclaw", repo: "openclaw" },
+          respond,
+        ),
+      );
+
+      expect(respond).toHaveBeenCalledWith(false, undefined, {
+        code: "UNAVAILABLE",
+        message,
+        retryable,
+      });
+    },
+  );
 });
 
 describe("controlUi.sessionPreview", () => {

--- a/ui/src/components/github-link-hovercard-registration.ts
+++ b/ui/src/components/github-link-hovercard-registration.ts
@@ -1,4 +1,3 @@
-import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { GitHubLinkHovercardProvider } from "./github-link-hovercard.runtime.ts";
 import {
   GITHUB_HOVERCARD_OPEN_DELAY_MS,
@@ -14,20 +13,10 @@ import {
 
 const HOVERCARD_TAG = "openclaw-github-link-hovercard-provider";
 
-type HovercardProviderElement = GitHubLinkHovercardProvider;
-
-const bootstrap = new LazyHovercardBootstrap<
-  HovercardProviderElement,
-  { client: GatewayBrowserClient | null; agentId: string | undefined }
->({
+const bootstrap = new LazyHovercardBootstrap<GitHubLinkHovercardProvider>({
   tag: HOVERCARD_TAG,
   load: async () =>
     (await import("./github-link-hovercard.runtime.ts")).GitHubLinkHovercardProvider,
-  snapshot: (provider) => ({ client: provider.client, agentId: provider.agentId }),
-  restore: (provider, properties) => {
-    provider.client = properties.client;
-    provider.agentId = properties.agentId;
-  },
 });
 
 async function activateHovercard(event: Event, trigger: HovercardBootstrapTrigger): Promise<void> {

--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -3,7 +3,7 @@ import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { ReactiveElement } from "lit";
+import { html, nothing, ReactiveElement, render, type TemplateResult } from "lit";
 import type { ControlUiGitHubPreview } from "../../../src/gateway/control-ui-contract.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { i18n, t } from "../i18n/index.ts";
@@ -129,192 +129,147 @@ function previewState(preview: GitHubPreview): PreviewState {
     : { label: t("githubPreview.states.closed"), tone: "purple" };
 }
 
-function appendTextElement(
-  parent: HTMLElement,
-  tagName: keyof HTMLElementTagNameMap,
-  className: string,
-  text: string,
-): HTMLElement {
-  const element = document.createElement(tagName);
-  element.className = className;
-  element.textContent = text;
-  parent.append(element);
-  return element;
+function renderAvatar(dataUrl: string | undefined) {
+  return dataUrl
+    ? html`<img
+        class="github-link-hovercard__avatar"
+        alt=""
+        decoding="async"
+        referrerpolicy="no-referrer"
+        src=${dataUrl}
+      />`
+    : nothing;
 }
 
-function coAuthorAvatarElement(dataUrl: string): HTMLImageElement {
-  const avatar = document.createElement("img");
-  avatar.className = "github-link-hovercard__avatar";
-  avatar.alt = "";
-  avatar.decoding = "async";
-  avatar.referrerPolicy = "no-referrer";
-  avatar.src = dataUrl;
-  return avatar;
-}
-
-/**
- * Overlapping faces after the author, plus "+N" for anyone past the fetched
- * three. The group is one labelled image: names reach assistive tech through
- * its accessible name instead of competing with the metrics for row width.
- */
-function appendCoAuthors(author: HTMLElement, preview: GitHubPreview): void {
+function renderCoAuthors(preview: GitHubPreview) {
   const coAuthors = preview.coAuthors ?? [];
   const total = preview.coAuthorCount ?? coAuthors.length;
   if (coAuthors.length === 0) {
-    return;
-  }
-  const stack = document.createElement("span");
-  stack.className = "github-link-hovercard__coauthors";
-  let faces = 0;
-  for (const coAuthor of coAuthors) {
-    if (coAuthor.avatarDataUrl) {
-      stack.append(coAuthorAvatarElement(coAuthor.avatarDataUrl));
-      faces += 1;
-    }
+    return nothing;
   }
   // Counted from rendered faces, not fetched people: avatar inlining is optional,
   // and a co-author with no face must fall into "+N" rather than disappear.
+  const faces = coAuthors.filter((coAuthor) => coAuthor.avatarDataUrl).length;
   const hidden = Math.max(0, total - faces);
-  if (hidden > 0) {
-    const more = document.createElement("span");
-    more.className = "github-link-hovercard__coauthors-more";
-    more.textContent = `+${hidden}`;
-    stack.append(more);
+  if (faces === 0 && hidden === 0) {
+    return nothing;
   }
-  if (stack.childElementCount === 0) {
-    return;
-  }
-  // The faces are decorative images, so the group carries the only accessible
-  // name; a title alone is never announced.
   const label = t("githubPreview.coAuthors", {
     logins: coAuthors.map((coAuthor) => coAuthor.login).join(", "),
   });
-  stack.title = label;
-  stack.role = "img";
-  stack.ariaLabel = label;
-  author.after(stack);
+  return html`<span
+    class="github-link-hovercard__coauthors"
+    title=${label}
+    role="img"
+    aria-label=${label}
+    >${coAuthors.map((coAuthor) => renderAvatar(coAuthor.avatarDataUrl))}${hidden > 0
+      ? html`<span class="github-link-hovercard__coauthors-more">+${hidden}</span>`
+      : nothing}</span
+  >`;
 }
 
-function appendMetric(parent: HTMLElement, className: string, text: string): void {
-  appendTextElement(parent, "span", `github-link-hovercard__metric ${className}`, text);
-}
-
-function appendCardLink(
-  parent: HTMLElement,
-  className: string,
-  href: string,
-  text: string,
-): HTMLAnchorElement {
-  const link = document.createElement("a");
-  link.className = className;
-  link.href = href;
-  link.target = EXTERNAL_LINK_TARGET;
-  link.rel = buildExternalLinkRel();
-  link.textContent = text;
-  parent.append(link);
-  return link;
+function renderCardLink(className: string, href: string, content: string | TemplateResult) {
+  return html`<a
+    class=${className}
+    href=${href}
+    target=${EXTERNAL_LINK_TARGET}
+    rel=${buildExternalLinkRel()}
+    >${content}</a
+  >`;
 }
 
 function renderLoading(card: HTMLDivElement): void {
-  card.replaceChildren();
   card.dataset.loading = "true";
   card.removeAttribute("data-state");
-  const label = t("githubPreview.loading");
-  // The card is a dialog, so every render state has to leave it with a name.
-  card.setAttribute("aria-label", label);
-  const skeleton = appendTextElement(card, "div", "github-link-hovercard__skeleton", "");
-  skeleton.setAttribute("aria-hidden", "true");
-  for (const [rowClass, parts] of [
+  card.setAttribute("aria-label", t("githubPreview.loading"));
+  const rows = [
     ["header", ["badge", "repo", "time"]],
     ["title", ["title"]],
     ["footer", ["author", "metrics"]],
-  ] as const) {
-    const row = appendTextElement(skeleton, "div", `github-link-hovercard__${rowClass}`, "");
-    for (const part of parts) {
-      appendTextElement(row, "span", `skeleton github-link-hovercard__placeholder--${part}`, "");
-    }
-  }
+  ] as const;
+  render(
+    html`<div class="github-link-hovercard__skeleton" aria-hidden="true">
+      ${rows.map(
+        ([rowClass, parts]) =>
+          html`<div class=${`github-link-hovercard__${rowClass}`}>
+            ${parts.map(
+              (part) =>
+                html`<span class=${`skeleton github-link-hovercard__placeholder--${part}`}></span>`,
+            )}
+          </div>`,
+      )}
+    </div>`,
+    card,
+  );
 }
 
 function renderUnavailable(card: HTMLDivElement, error: string): void {
-  card.replaceChildren();
   card.dataset.loading = "false";
   card.dataset.state = "unavailable";
   const label = t("githubPreview.unavailable");
   card.setAttribute("aria-label", label);
-  const content = appendTextElement(card, "div", "github-link-hovercard__unavailable", "");
-  appendTextElement(content, "div", "", label);
-  if (error && error !== label) {
-    const detail = appendTextElement(content, "div", "github-link-hovercard__error", error);
-    detail.id = `${card.id}-error`;
-    card.setAttribute("aria-describedby", detail.id);
+  const showError = error && error !== label;
+  const errorId = `${card.id}-error`;
+  if (showError) {
+    card.setAttribute("aria-describedby", errorId);
   }
+  render(
+    html`<div class="github-link-hovercard__unavailable">
+      <div>${label}</div>
+      ${showError
+        ? html`<div class="github-link-hovercard__error" id=${errorId}>${error}</div>`
+        : nothing}
+    </div>`,
+    card,
+  );
 }
 
 function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
-  card.replaceChildren();
   card.dataset.loading = "false";
   const state = previewState(preview);
   card.dataset.state = state.tone;
-
-  const header = document.createElement("div");
-  header.className = "github-link-hovercard__header";
-  const badge = document.createElement("span");
-  badge.className = "github-link-hovercard__state";
-  badge.dataset.tone = state.tone;
-  const stateDot = document.createElement("span");
-  stateDot.className = "github-link-hovercard__state-dot";
-  stateDot.setAttribute("aria-hidden", "true");
-  badge.append(stateDot, document.createTextNode(state.label));
-  header.append(badge);
-  // Every link on the card reuses the href it was activated with; that target is
-  // already resolved and validated by parseGitHubLinkTarget, so no reparsing here.
-  appendCardLink(
-    header,
-    "github-link-hovercard__repo",
-    preview.href,
-    `${preview.owner}/${preview.repo} #${preview.number}`,
+  const comments = preview.comments ?? 0;
+  render(
+    html`<div class="github-link-hovercard__header">
+        <span class="github-link-hovercard__state" data-tone=${state.tone}
+          ><span class="github-link-hovercard__state-dot" aria-hidden="true"></span
+          >${state.label}</span
+        >
+        ${renderCardLink(
+          "github-link-hovercard__repo",
+          preview.href,
+          `${preview.owner}/${preview.repo} #${preview.number}`,
+        )}
+        <time class="github-link-hovercard__time"
+          >${formatRelativeTimestamp(Date.parse(preview.updatedAt))}</time
+        >
+      </div>
+      ${renderCardLink("github-link-hovercard__title", preview.href, preview.title)}
+      <div class="github-link-hovercard__footer">
+        ${renderCardLink(
+          "github-link-hovercard__author",
+          gitHubProfileUrl(preview.login),
+          html`${renderAvatar(preview.avatarDataUrl)}${preview.login}`,
+        )}${renderCoAuthors(preview)}
+        ${preview.kind === "pull"
+          ? html`<span class="github-link-hovercard__metrics github-link-hovercard__metrics--diff">
+              <span class="github-link-hovercard__metric github-link-hovercard__metric--additions"
+                >+${preview.additions ?? 0}</span
+              >
+              <span class="github-link-hovercard__metric github-link-hovercard__metric--deletions"
+                >−${preview.deletions ?? 0}</span
+              >
+            </span>`
+          : html`<span class="github-link-hovercard__metrics">
+              <span class="github-link-hovercard__metric"
+                >${t(comments === 1 ? "githubPreview.comment" : "githubPreview.comments", {
+                  count: String(comments),
+                })}</span
+              >
+            </span>`}
+      </div>`,
+    card,
   );
-  appendTextElement(
-    header,
-    "time",
-    "github-link-hovercard__time",
-    formatRelativeTimestamp(Date.parse(preview.updatedAt)),
-  );
-
-  const footer = document.createElement("div");
-  footer.className = "github-link-hovercard__footer";
-  const author = appendCardLink(
-    footer,
-    "github-link-hovercard__author",
-    gitHubProfileUrl(preview.login),
-    preview.login,
-  );
-  if (preview.avatarDataUrl) {
-    author.prepend(coAuthorAvatarElement(preview.avatarDataUrl));
-  }
-  appendCoAuthors(author, preview);
-
-  const metrics = document.createElement("span");
-  metrics.className = "github-link-hovercard__metrics";
-  if (preview.kind === "pull") {
-    metrics.classList.add("github-link-hovercard__metrics--diff");
-    appendMetric(metrics, "github-link-hovercard__metric--additions", `+${preview.additions ?? 0}`);
-    appendMetric(metrics, "github-link-hovercard__metric--deletions", `−${preview.deletions ?? 0}`);
-  } else {
-    const comments = preview.comments ?? 0;
-    appendMetric(
-      metrics,
-      "",
-      t(comments === 1 ? "githubPreview.comment" : "githubPreview.comments", {
-        count: String(comments),
-      }),
-    );
-  }
-  footer.append(metrics);
-  card.append(header);
-  appendCardLink(card, "github-link-hovercard__title", preview.href, preview.title);
-  card.append(footer);
   card.setAttribute(
     "aria-label",
     t("githubPreview.ariaLabel", {
@@ -373,8 +328,6 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
   // pointer-driven open still fully releases on mouse-out (see handleCardPointerLeave).
   private activeTrigger: "focus" | "pointer" | null = null;
   private readonly hovercard = new PortaledHovercardController(() => this.close());
-  private renderedPreview: GitHubPreview | null = null;
-  private renderedError: string | null = null;
   private stopI18n: (() => void) | null = null;
   // Spans the synchronous focus() that hands focus back to the trigger, so the
   // card the user just dismissed cannot reopen under them (handleCardKeyDown).
@@ -385,24 +338,6 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     // Share metadata, not navigation: each activation owns its full validated URL.
     task: async ([target], { signal }) =>
       target ? { ...(await this.loadPreview(target, signal)), ...target } : initialState,
-    onComplete: (preview) => {
-      const card = this.hovercard.card;
-      if (!card) {
-        return;
-      }
-      this.renderedPreview = preview;
-      renderPreview(card, preview);
-      this.hovercard.position();
-    },
-    onError: (error) => {
-      const card = this.hovercard.card;
-      if (!card) {
-        return;
-      }
-      this.renderedError = truncateUtf16Safe(formatUiError(error), 320);
-      renderUnavailable(card, this.renderedError);
-      this.hovercard.position();
-    },
   });
   private readonly activeAnchorObserver = new MutationObserver(() => {
     const anchor = this.activeAnchor;
@@ -426,7 +361,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.addEventListener("focusout", this.handleFocusOut);
     this.addEventListener("keydown", this.handleKeyDown);
     this.addEventListener("click", this.handleClick);
-    this.stopI18n ??= i18n.subscribe(this.handleLocaleChange);
+    this.stopI18n ??= i18n.subscribe(() => this.requestUpdate());
   }
 
   override disconnectedCallback(): void {
@@ -442,20 +377,20 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     super.disconnectedCallback();
   }
 
-  private readonly handleLocaleChange = () => {
+  protected override updated(): void {
     const card = this.hovercard.card;
     if (!card) {
       return;
     }
-    if (this.renderedPreview) {
-      renderPreview(card, this.renderedPreview);
-    } else if (this.renderedError !== null) {
-      renderUnavailable(card, this.renderedError);
-    } else {
-      renderLoading(card);
-    }
+    card.removeAttribute("aria-describedby");
+    this.previewTask.render({
+      initial: () => renderLoading(card),
+      pending: () => renderLoading(card),
+      complete: (preview) => renderPreview(card, preview),
+      error: (error) => renderUnavailable(card, truncateUtf16Safe(formatUiError(error), 320)),
+    });
     this.hovercard.position();
-  };
+  }
 
   private readonly handlePointerOver = (event: Event) => {
     const pointer = event as PointerEvent;
@@ -548,7 +483,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     if (event.key !== "Tab" || event.shiftKey || event.target !== this.activeAnchor) {
       return;
     }
-    const [first] = this.cardFocusables();
+    const [first] = this.hovercard.focusables();
     if (!first) {
       return;
     }
@@ -563,7 +498,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     // Tab moves between the card's own links normally and only exits at the edge
     // of that run: the card has no tab-sequence neighbour, so leaving it lands on
     // the trigger like Escape does instead of dropping focus to the document.
-    const focusables = this.cardFocusables();
+    const focusables = this.hovercard.focusables();
     const edge = event.shiftKey ? focusables[0] : focusables.at(-1);
     if (event.key === "Tab" && document.activeElement !== edge) {
       return;
@@ -575,10 +510,6 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     anchor?.focus({ preventScroll: true });
     this.suppressFocusOpen = false;
   };
-
-  private cardFocusables(): HTMLElement[] {
-    return [...(this.hovercard.card?.querySelectorAll<HTMLElement>("a[href]") ?? [])];
-  }
 
   private readonly handleClick = () => {
     this.close();
@@ -622,10 +553,6 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
       `openclaw-github-hovercard-${nextHovercardId}`,
       "github-link-hovercard",
     );
-    // A tooltip may not own controls: its content is flattened and unreachable.
-    // The card is a non-modal dialog instead, named by the render functions.
-    this.renderedPreview = null;
-    this.renderedError = null;
     renderLoading(card);
     // The card is portaled to document.body, so the provider's delegated pointer
     // listeners never see it; it reports its own hover to keep intent shared.
@@ -634,7 +561,7 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     card.addEventListener("focusin", this.handleCardFocusIn);
     card.addEventListener("focusout", this.handleCardFocusOut);
     card.addEventListener("keydown", this.handleCardKeyDown);
-    this.hovercard.mount(anchor, card, "vertical");
+    this.hovercard.mount(anchor, card, "vertical", true, () => render(nothing, card));
 
     void this.previewTask.run([target]);
   }
@@ -696,8 +623,6 @@ export class GitHubLinkHovercardProvider extends ReactiveElement {
     this.hovercard.reset();
     this.activeAnchorObserver.disconnect();
     void this.previewTask.run([null]);
-    this.renderedPreview = null;
-    this.renderedError = null;
     this.activeAnchor = null;
     this.activeTarget = null;
     this.activeTrigger = null;

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -5,6 +5,7 @@ import { createDeferred } from "../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { i18n } from "../i18n/index.ts";
 import { GitHubLinkHovercardProvider } from "./github-link-hovercard.runtime.ts";
+import { LazyHovercardBootstrap } from "./lazy-hovercard-registration.ts";
 
 // Mirrors CLOSE_DELAY_MS in the runtime, like the 250ms open delay used below.
 const GITHUB_HOVERCARD_CLOSE_DELAY_MS = 120;
@@ -572,6 +573,40 @@ describe("openclaw-github-link-hovercard-provider", () => {
     resolvePending(issuePreviewResponse());
     await vi.advanceTimersByTimeAsync(0);
     expect(hovercard()).toBeNull();
+  });
+
+  it("uses the latest dependencies assigned before its lazy definition finishes", async () => {
+    const tag = `test-github-lazy-upgrade-${crypto.randomUUID()}`;
+    const loaded = createDeferred<CustomElementConstructor>();
+    const bootstrap = new LazyHovercardBootstrap<GitHubLinkHovercardProvider>({
+      tag,
+      load: () => loaded.promise,
+    });
+    const provider = document.createElement(tag) as GitHubLinkHovercardProvider;
+    const anchor = document.createElement("a");
+    anchor.href = ISSUE_HREF;
+    provider.append(anchor);
+    document.body.append(provider);
+    const staleRequest = vi.fn();
+    provider.client = { request: staleRequest } as unknown as GatewayBrowserClient;
+    provider.agentId = "first-agent";
+
+    const definition = bootstrap.define();
+    const request = vi.fn().mockResolvedValue(issuePreviewResponse());
+    provider.client = { request } as unknown as GatewayBrowserClient;
+    provider.agentId = "second-agent";
+    loaded.resolve(class extends GitHubLinkHovercardProvider {});
+    await definition;
+    await provider.updateComplete;
+    await hover(anchor);
+
+    expect(staleRequest).not.toHaveBeenCalled();
+    expect(request.mock.calls[0]?.[1]).toMatchObject({ agentId: "second-agent" });
+    expect(hovercard()?.textContent).toContain("Keep hover previews reachable");
+    provider.agentId = "third-agent";
+    expect(hovercard()).toBeNull();
+    await hover(anchor);
+    expect(request.mock.calls[1]?.[1]).toMatchObject({ agentId: "third-agent" });
   });
 
   it.each([

--- a/ui/src/components/lazy-hovercard-registration.ts
+++ b/ui/src/components/lazy-hovercard-registration.ts
@@ -2,15 +2,13 @@ import { ensureCustomElementDefined } from "../app/lazy-custom-element.ts";
 
 export type HovercardBootstrapTrigger = "focus" | "pointer";
 
-export class LazyHovercardBootstrap<TElement extends HTMLElement, TProperties> {
+export class LazyHovercardBootstrap<TElement extends HTMLElement> {
   private stopListeners: (() => void) | null = null;
 
   constructor(
     private readonly params: {
       tag: string;
       load: () => Promise<CustomElementConstructor>;
-      snapshot: (element: TElement) => TProperties;
-      restore: (element: TElement, properties: TProperties) => void;
       onDefined?: () => void;
     },
   ) {}
@@ -26,20 +24,11 @@ export class LazyHovercardBootstrap<TElement extends HTMLElement, TProperties> {
   }
 
   async define(): Promise<void> {
-    const pending = new Map(
-      [...document.querySelectorAll<TElement>(this.params.tag)].map((element) => [
-        element,
-        this.params.snapshot(element),
-      ]),
-    );
     await ensureCustomElementDefined(this.params.tag, async () => {
       const provider = await this.params.load();
-      // Non-isolated test modules can share one document and element registry.
+      // Another loader may register the tag while this import is pending.
       if (!customElements.get(this.params.tag)) {
         customElements.define(this.params.tag, provider);
-      }
-      for (const [element, properties] of pending) {
-        this.params.restore(element, properties);
       }
     });
     this.stopListeners?.();

--- a/ui/src/components/session-progress-hovercard-registration.ts
+++ b/ui/src/components/session-progress-hovercard-registration.ts
@@ -1,6 +1,3 @@
-import type { GatewayBrowserClient } from "../api/gateway.ts";
-import type { ApplicationContext } from "../app/context.ts";
-import type { ApplicationGateway } from "../app/gateway.ts";
 import {
   hovercardBootstrapIntentActive,
   LazyHovercardBootstrap,
@@ -10,43 +7,16 @@ import {
   SESSION_PROGRESS_HOVER_LINK_SELECTOR,
   sessionProgressHoverTargetFromEvent,
 } from "./session-progress-hovercard-target.ts";
+import type { SessionProgressHovercardProvider } from "./session-progress-hovercard.runtime.ts";
 
 const HOVERCARD_TAG = "openclaw-session-progress-hovercard-provider";
 
 let bootstrapObserver: MutationObserver | null = null;
 
-type HovercardProviderElement = HTMLElement & {
-  client?: GatewayBrowserClient | null;
-  context?: ApplicationContext | null;
-  gateway?: ApplicationGateway | null;
-};
-
-const bootstrap = new LazyHovercardBootstrap<
-  HovercardProviderElement,
-  {
-    client: GatewayBrowserClient | null;
-    context: ApplicationContext | null;
-    gateway: ApplicationGateway | null;
-  }
->({
+const bootstrap = new LazyHovercardBootstrap<SessionProgressHovercardProvider>({
   tag: HOVERCARD_TAG,
   load: async () =>
     (await import("./session-progress-hovercard.runtime.ts")).SessionProgressHovercardProvider,
-  snapshot: (provider) => ({
-    client: provider.client ?? null,
-    context: provider.context ?? null,
-    gateway: provider.gateway ?? null,
-  }),
-  restore: (provider, properties) => {
-    // Lit assigns .gateway before upgrade. Remove the expando so the runtime
-    // accessors can own the restored dependencies after definition.
-    delete provider.client;
-    delete provider.context;
-    delete provider.gateway;
-    provider.client = properties.client;
-    provider.context = properties.context;
-    provider.gateway = properties.gateway;
-  },
   onDefined: () => {
     bootstrapObserver?.disconnect();
     bootstrapObserver = null;

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -42,6 +42,13 @@ function sessionHovercardMenuOpen(owner: ParentNode): boolean {
 }
 
 export class SessionProgressHovercardProvider extends ReactiveElement {
+  // Let Lit replay dependencies assigned before the lazy element upgrades.
+  static override properties = {
+    client: { attribute: false, noAccessor: true },
+    context: { attribute: false, noAccessor: true },
+    gateway: { attribute: false, noAccessor: true },
+  };
+
   private applicationClient: GatewayBrowserClient | null = null;
   private applicationContext: ApplicationContext | null = null;
   private applicationGateway: ApplicationGateway | null = null;

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -189,7 +189,7 @@ describeControlUiE2e("GitHub link hover cards", () => {
       const skeleton = card.locator('[aria-hidden="true"]');
       await skeleton.waitFor({ state: "visible" });
       expect(await card.locator("a").count()).toBe(0);
-      expect(await card.textContent()).toBe("");
+      expect((await card.textContent())?.trim()).toBe("");
       const placeholder = skeleton.locator(".skeleton").first();
       await placeholder.waitFor({ state: "visible" });
       const animating = () =>


### PR DESCRIPTION
Related: #136917

## What Problem This Solves

GitHub previews had several owners for the same request and rendering state: credentials and redirect checks were threaded through auxiliary reads, hovercards mirrored their Task result into extra fields, and lazy registration replayed properties that Lit already owns. This maintainer-requested cleanup removes those duplicate paths while preserving the preview, error subtext, and selected GitHub identity behavior.

It also fixes a dispatch-ordering defect: an unconditional optional `await` deferred an already-admitted GitHub Actions request even when no asynchronous identity validator existed, allowing its caller to retire before dispatch.

## Why This Change Was Made

Preview loading now captures transport credentials and lifecycle checks once and shares its guarded JSON reader with the bounded commits request. The metadata consumers use canonical normalization helpers, and authenticated viewer synchronization reuses the existing retryable lazy-promise owner.

GitHub hovercards render from Task state with Lit templates. Both GitHub and session providers declare their pre-upgrade properties, so Lit owns dependency replay and registration only loads the element and resumes user intent. This removes the manual DOM builder stack, mirrored preview/error fields, custom synchronization cache, generic field wrappers, and bootstrap snapshot/restore plumbing.

The distinct managed-preview, shared Actions, project-search, and stale PR-chip cache policies remain intact. Managed identity selection never falls back anonymously; the documented optional service/environment credential recovery remains available. No settings, storage, protocol, or dependency changes.

## User Impact

The card appearance, error subtext, keyboard navigation, exact links, and lazy styles stay the same. The code has fewer places where credentials, lifecycle checks, or UI state can drift apart. Production changes: 220 added / 431 removed (**−211**); tests: 157 added / 145 removed (**+12**).

## Evidence

- 235 focused gateway tests passed across previews, identity, project search, PR chips, RPC handlers, and Actions boards; the final API/preview rerun passed all 56 tests.
- 67 UI unit tests and 17 Chromium GitHub/session-hovercard scenarios passed, including cancellation, cold upgrade, identity changes, keyboard focus, and cached permalink navigation.
- The dispatch regression fails on the original code and passes after repair. Coauthor coverage now also proves the 1 MiB commits limit, three-face cap, and absence of per-person API lookups.
- Actual candidate handler with real GitHub: selected managed identity loads public PR metadata; missing item returns safe HTTP 404 subtext; removed/changed identity blocks cached delivery and subsequent dispatch. Disposable credential state was removed.
- Production UI build passed. Independent Codex review: scoped-clean, no actionable P0–P2 findings.

The full changed-file gate passed, including core/UI/test typechecks, lint, dead-export scans, and repository guards. The built Control UI was exercised in the existing Chrome profile against a disposable real Gateway and real GitHub; both the successful card and 404 explanation rendered correctly. The test browser tab and temporary managed credentials were cleaned up.

### Visual parity

Before cleanup (the live error state from #136917):

![Before cleanup: safe GitHub error subtext](https://github.com/user-attachments/assets/3d8bf5ac-ab59-4013-ab07-1319684dcf77)

After cleanup, through the candidate production build and real GitHub:

![After cleanup: safe GitHub error subtext](https://github.com/user-attachments/assets/b16fdfca-4b25-4ae8-b8f6-3fae835fc185)

![After cleanup: successful public pull request preview](https://github.com/user-attachments/assets/f19dc4d4-6375-46d1-aae3-59288ac2f69b)

### Separate follow-ups observed during proof

- Source-checkout cold session-catalog initialization: the disposable Gateway temporarily delayed session subscriptions for about 198 seconds, then recovered; subsequent preview reads and rendering succeeded. This was outside the preview request path.
- The Control UI precompression plugin does not follow a bare Vite CLI `--outDir` override. The supported config factory's `outDir` option built successfully; no build behavior was changed here.

Final exact-head CI: [run 33722554847](https://github.com/openclaw/openclaw/actions/runs/33722554847) succeeded on `9783d6090e61998da889dc5a10406a967b93416e` (159 passed, 13 skipped, zero failures). The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/137075#issuecomment-5521685006) found no code/security defects or Rank-up moves. Its maintainer-acceptance and restricted-environment proof items were [resolved before landing](https://github.com/openclaw/openclaw/pull/137075#issuecomment-5521699903). Both independent Codex review passes were scoped-clean.
