### PR TITLE
fix: artifact transfer tests fail under a restrictive umask

### DIFF
--- a/test/scripts/repo-e2e-artifacts.test.ts
+++ b/test/scripts/repo-e2e-artifacts.test.ts
@@ -104,7 +104,9 @@ describe("repo E2E artifact transfer", () => {
         fs.statSync(path.join(root, "package.json")).mtimeMs,
       );
       expect(fs.readlinkSync(path.join(root, "dist-runtime/index.js"))).toBe("../dist/index.js");
-      expect(fs.statSync(path.join(root, "dist/index.js")).mode & 0o777).toBe(0o755);
+      expect(execFileSync(path.join(root, "dist/index.js"), { encoding: "utf8" })).toBe(
+        "artifact\n",
+      );
       expect(fs.readFileSync(path.join(root, "dist/private-qa.js"), "utf8")).toBe("private QA\n");
       expect(fs.readFileSync(path.join(root, "packages/demo/dist/index.d.ts"), "utf8")).toContain(
         "ready",


### PR DESCRIPTION
Related: #136830, whose isolated profiler verification exposed these artifact-test failures.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled. This will use a maintainer-owned upstream branch.

</details>

## What Problem This Solves

Fixes an issue where contributors running the repository E2E artifact-transfer tests with `umask 077` would receive two false failures even though the restored executable works. The test required exact `0755`; normal non-root archive extraction can legitimately produce `0700` while preserving execution by the current user.

## Why This Change Was Made

Replace the permission-metadata assertion with direct execution of the restored synthetic shebang script and exact stdout verification. This tests the consumer-visible contract without changing archive extraction, overriding the caller's umask, or weakening protection against lost executable permission.

## User Impact

No production or configuration behavior changes. The existing full and CI-artifact test cases now accept usable restored executables under restrictive permissions, while still failing when the executable cannot run. Every other assertion, including archive identity/digest rejection, hidden artifacts, links, and refreshed build stamps, remains unchanged.

## Evidence

- **Fail first:** the unchanged nine-case suite under `077` had exactly two failures at the `0755` assertion and seven passing cases (`448`/`0700` received versus `493`/`0755` expected).
- **After:** the same nine cases pass under both `077` and `022`. These are nine distinct cases run twice, not 18 newly added tests.
- **Negative control:** native archive extraction restored `0700` under `077` and `0755` under `022`; direct execution printed exactly `artifact\n` in both. Removing execute bits from each restored fixture produced `EACCES`, demonstrating that the new assertion still detects lost execution permission.
- **All 15 selected checks passed**, including formatting, test-root typechecking and lint. The initial private-PATH run stopped at missing Corepack; adding the already-installed Corepack directory after pinned Node resolved the prerequisite without changing `CI`, source, dependencies, or check policy. The original failure is preserved.
- **Independent Codex autoreview:** `scoped-clean`, no findings at the configured P0 threshold.

Verification used Node 24.15.0, pnpm 12.1.0, and private HOME/TMP/XDG directories. Production LOC: **0**. Tests: **+3/-1**, one existing assertion replaced, no new test-only production seam, skip, fallback, or dependency change.

The suite is owned by Linux `core-tooling` CI. Both explicit Windows CI inventories omit this file; no Windows execution claim or new platform exclusion is made. Native local proof ran on macOS. The installed `bsdtar` manual and the actual extraction controls confirm the non-root permission behavior; forcing `tar -p` would instead introduce a broader permission/metadata policy that this change deliberately avoids.

Completed suite command, separately under each launcher umask:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/repo-e2e-artifacts.test.ts --reporter=verbose --maxWorkers=1
```

Completed selected checks:

```bash
node scripts/check-changed.mjs --base 2fffd4e8ba116813222b28b89179fd911784aeae --timed -- test/scripts/repo-e2e-artifacts.test.ts
```

```bash
git diff --check
```

The exact-mode assertion and plain `tar -xzf` owner were introduced together in [0e6848e36751e5974971571b4f966d90c2921685](https://github.com/openclaw/openclaw/commit/0e6848e36751e5974971571b4f966d90c2921685), the [E2E critical-path optimization, #134746](https://github.com/openclaw/openclaw/pull/134746). Raw-parent and unreplaced patch inspection confirmed this is not an older independent promise to restore all mode bits regardless of umask. Code author: Peter Steinberger; PR author and merger: @steipete; raw Git committer: GitHub. The change merged September 1, 2026. Current `main` still has the same owner and pre-fix test. No browser proof or product build is needed for this test-only change.

### Final validation and maintainer disposition

[Exact-head CI33722535488, attempt1](https://github.com/openclaw/openclaw/actions/runs/33722535488) completed successfully for `28354980dea28cc8bab575923754ebbf2726dbf6`. The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/137076#issuecomment-5521832383) found no correctness or security issue and recommends merging after checks. Maintainer decision: merge this scoped behavioral-test repair under the requested QA repair workflow; preserve production extraction policy and all existing integrity assertions. Independent review and native preparation passed on the unchanged head.
