### PR TITLE
test(infra): reuse canonical approval test assertions

### DIFF
--- a/src/infra/approval-gateway-resolver.test.ts
+++ b/src/infra/approval-gateway-resolver.test.ts
@@ -1,3 +1,4 @@
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 // Covers approval resolution over the gateway client.
 import type { ApprovalResolveResult } from "../../packages/gateway-protocol/src/index.js";
@@ -29,14 +30,6 @@ const recordedApproval = {
 vi.mock("../gateway/operator-approvals-client.js", () => ({
   withOperatorApprovalsGatewayClient: hoisted.withOperatorApprovalsGatewayClient,
 }));
-
-function requireFirstMockCall<T>(mock: { mock: { calls: T[][] } }): T[] {
-  const call = mock.mock.calls[0];
-  if (!call) {
-    throw new Error("expected gateway client call");
-  }
-  return call;
-}
 
 function withApprovalAccountContext<T>(run: () => T): T {
   return withGatewayNativeApprovalRuntime(
@@ -73,8 +66,9 @@ describe("resolveApprovalOverGateway", () => {
     });
 
     expect(hoisted.withOperatorApprovalsGatewayClient).toHaveBeenCalledTimes(1);
-    const [gatewayClientOptions, gatewayClientRunner] = requireFirstMockCall(
-      hoisted.withOperatorApprovalsGatewayClient,
+    const [gatewayClientOptions, gatewayClientRunner] = expectDefined(
+      hoisted.withOperatorApprovalsGatewayClient.mock.calls[0],
+      "gateway client call",
     );
     expect(gatewayClientOptions).toEqual({
       config: { gateway: { auth: { token: "cfg-token" } } },
@@ -155,8 +149,9 @@ describe("resolveApprovalOverGateway", () => {
         senderId: "owner",
       });
 
-      const [gatewayClientOptions] = requireFirstMockCall(
-        hoisted.withOperatorApprovalsGatewayClient,
+      const [gatewayClientOptions] = expectDefined(
+        hoisted.withOperatorApprovalsGatewayClient.mock.calls[0],
+        "gateway client call",
       );
       expect(gatewayClientOptions).toMatchObject({
         clientDisplayName: `${label} approval (owner)`,
@@ -175,7 +170,10 @@ describe("resolveApprovalOverGateway", () => {
       senderId: "owner",
     });
 
-    const [gatewayClientOptions] = requireFirstMockCall(hoisted.withOperatorApprovalsGatewayClient);
+    const [gatewayClientOptions] = expectDefined(
+      hoisted.withOperatorApprovalsGatewayClient.mock.calls[0],
+      "gateway client call",
+    );
     expect(gatewayClientOptions).toMatchObject({
       clientDisplayName: "external-chat approval (owner)",
     });


### PR DESCRIPTION
## What Problem This Solves

The approval resolver tests maintained a separate missing-call assertion that duplicates the existing shared assertion helper. This maintainer-requested test audit consolidates that ownership without removing coverage.

## Why This Change Was Made

Use `expectDefined` for the three recorded Gateway client calls and remove the local helper. Recorded argument arrays still pass through unchanged, and a missing call still fails before destructuring. Every existing assertion and test table remains intact.

## User Impact

No user-visible behavior change. Approval routing, reviewer identity, custody, legacy fallback, and malformed-input contracts are unchanged. Production: **0 lines**; tests: **+11 / −13**.

## Evidence

The same normal test command passed before and after:

```sh
pnpm test src/infra/approval-gateway-resolver.test.ts packages/normalization-core/src/expect.test.ts
```

```text
Tests  4 passed (4)
Tests  42 passed (42)
```

All 46 case names and all 41 resolver assertion lines match before/after. The canonical helper tests retain missing-value rejection coverage.

`node scripts/check-changed.mjs -- src/infra/approval-gateway-resolver.test.ts` passed, including the infrastructure test type graph, formatting, lint, guards, and dead-export scans. A fresh isolated Codex review through P2 found no actionable findings.

This is synthetic, mocked-client test proof; no live approval operation was performed.
