### PR TITLE
fix(node-host): report the hardware model so CLI nodes get real device icons

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -53,6 +53,8 @@ Pending pairing requests expire 5 minutes after the device's last retry — a de
   - non-exec node commands: `operator.pairing` + `operator.write`
   - `system.run` / `system.run.prepare` / `system.which`: `operator.pairing` + `operator.admin`
 
+Headless node hosts report the hardware model on macOS and Linux.
+
 Connected CLI node hosts and the macOS app report CPU count, load averages,
 memory, and home-volume disk capacity every 60 seconds, starting on connection.
 The Gateway exposes the latest snapshot as `hostStats` in `node.list` and

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -266,6 +266,7 @@ export type GatewayClientOptions = {
   clientBuildId?: string;
   platform?: string;
   deviceFamily?: string;
+  modelIdentifier?: string;
   mode?: GatewayClientMode;
   role?: string;
   scopes?: string[];
@@ -808,6 +809,7 @@ export class GatewayClient {
           buildId: this.opts.clientBuildId,
           platform,
           deviceFamily,
+          modelIdentifier: useLegacyNodeProtocolEnvelope ? undefined : this.opts.modelIdentifier,
           mode: clientMode,
           instanceId: this.opts.instanceId,
         },

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -1393,12 +1393,14 @@ describe("GatewayClient connect auth payload", () => {
     async ({ canonical, legacy, protocolBounds }) => {
       const signDevicePayload = vi.fn((_privateKeyPem: string, _payload: string) => "signature");
       const deviceFamily = canonical === "macos" ? "Mac" : "Windows";
+      const modelIdentifier = "TestMachine1,1";
       const client = createClientWithIdentity(`device-${legacy}`, vi.fn(), {
         role: "node",
         mode: GATEWAY_CLIENT_MODES.NODE,
         clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
         platform: canonical,
         deviceFamily,
+        modelIdentifier,
         hostDeps: { signDevicePayload },
         ...protocolBounds,
       });
@@ -1407,8 +1409,12 @@ describe("GatewayClient connect auth payload", () => {
       expect(currentConnect.params).toMatchObject({
         minProtocol: PROTOCOL_VERSION,
         maxProtocol: PROTOCOL_VERSION,
-        client: { platform: canonical, deviceFamily },
+        client: { platform: canonical, deviceFamily, modelIdentifier },
       });
+      expect(signDevicePayload.mock.calls[0]?.[1]?.split("|").slice(9)).toEqual([
+        canonical,
+        deviceFamily.toLowerCase(),
+      ]);
 
       emitConnectFailure(
         currentWs,
@@ -1427,6 +1433,7 @@ describe("GatewayClient connect auth payload", () => {
         client: { platform: legacy },
       });
       expect(legacyConnect.params?.client).not.toHaveProperty("deviceFamily");
+      expect(legacyConnect.params?.client).not.toHaveProperty("modelIdentifier");
       expect(signDevicePayload.mock.calls.at(-1)?.[1]?.split("|").slice(9)).toEqual([legacy, ""]);
       client.stop();
     },

--- a/src/infra/machine-model.test.ts
+++ b/src/infra/machine-model.test.ts
@@ -1,0 +1,91 @@
+import os from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let resolveMachineModelIdentifier: typeof import("./machine-model.js").resolveMachineModelIdentifier;
+type ModelDeps = NonNullable<Parameters<typeof resolveMachineModelIdentifier>[1]>;
+const spawn = vi.fn<NonNullable<ModelDeps["spawnSync"]>>();
+const read = vi.fn<NonNullable<ModelDeps["readFileSync"]>>();
+const deps = { spawnSync: spawn, readFileSync: read };
+
+describe("resolveMachineModelIdentifier", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ resolveMachineModelIdentifier } = await import("./machine-model.js"));
+    spawn.mockReset();
+    read.mockReset();
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each([
+    { name: "success", stdout: " Mac16,1\n", expected: "Mac16,1" },
+    { name: "empty", stdout: " \n", expected: undefined },
+    { name: "timeout", stdout: "", expected: undefined },
+  ])("resolves darwin $name with a bounded probe", ({ name, stdout, expected }) => {
+    spawn.mockReturnValue({
+      stdout,
+      stderr: "",
+      pid: 1,
+      output: [],
+      status: name === "timeout" ? null : 0,
+      signal: name === "timeout" ? "SIGKILL" : null,
+      ...(name === "timeout" ? { error: new Error("spawnSync sysctl ETIMEDOUT") } : {}),
+    });
+
+    expect(resolveMachineModelIdentifier("darwin", deps)).toBe(expected);
+    expect(spawn).toHaveBeenCalledExactlyOnceWith("sysctl", ["-n", "hw.model"], {
+      encoding: "utf-8",
+      timeout: 5_000,
+      killSignal: "SIGKILL",
+    });
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "DMI", product: " Test Laptop \n", tree: "Other model", expected: "Test Laptop" },
+    { name: "missing DMI", product: null, tree: " Test Board\0\0", expected: "Test Board" },
+    { name: "empty DMI", product: " \n", tree: "Test Board\0\n", expected: "Test Board" },
+    { name: "missing files", product: null, tree: null, expected: undefined },
+    { name: "empty files", product: "\0", tree: " \0\0", expected: undefined },
+    { name: "bounded DMI", product: "x".repeat(80), tree: null, expected: "x".repeat(64) },
+    { name: "bounded tree", product: null, tree: "x".repeat(63) + "🚀", expected: "x".repeat(63) },
+  ])("resolves linux $name", ({ product, tree, expected }) => {
+    read.mockImplementation((file) => {
+      const value =
+        file === "/sys/devices/virtual/dmi/id/product_name"
+          ? product
+          : file === "/proc/device-tree/model"
+            ? tree
+            : null;
+      if (value === null) {
+        throw new Error("ENOENT");
+      }
+      return value;
+    });
+
+    expect(resolveMachineModelIdentifier("linux", deps)).toBe(expected);
+    expect(read).toHaveBeenNthCalledWith(1, "/sys/devices/virtual/dmi/id/product_name", "utf-8");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it.each(["win32", "freebsd"] as const)("leaves %s unknown without probing", (platform) => {
+    expect(resolveMachineModelIdentifier(platform, deps)).toBeUndefined();
+    expect(spawn).not.toHaveBeenCalled();
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it.each(["Test Laptop", ""])(
+    "memoizes the first result, including missing models (%j)",
+    (value) => {
+      vi.spyOn(os, "platform").mockReturnValue("linux");
+      read.mockReturnValue(value);
+      const first = resolveMachineModelIdentifier(undefined, deps);
+      const reads = read.mock.calls.length;
+      read.mockReturnValue("Changed Laptop");
+
+      expect(first).toBe(value || undefined);
+      expect(resolveMachineModelIdentifier("linux", deps)).toBe(first);
+      expect(read).toHaveBeenCalledTimes(reads);
+    },
+  );
+});

--- a/src/infra/machine-model.ts
+++ b/src/infra/machine-model.ts
@@ -1,0 +1,53 @@
+import {
+  spawnSync,
+  type SpawnSyncOptionsWithStringEncoding,
+  type SpawnSyncReturns,
+} from "node:child_process";
+import { readFileSync } from "node:fs";
+import os from "node:os";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { DARWIN_SYSTEM_PROBE_TIMEOUT_MS } from "./os-summary.js";
+
+const models = new Map<NodeJS.Platform, string | undefined>();
+
+export function resolveMachineModelIdentifier(
+  platform = os.platform(),
+  deps: {
+    spawnSync?: (
+      command: string,
+      args: string[],
+      options: SpawnSyncOptionsWithStringEncoding,
+    ) => SpawnSyncReturns<string>;
+    readFileSync?: (file: string, encoding: "utf-8") => string;
+  } = {},
+): string | undefined {
+  // Hardware is process-stable; cache missing results too so reconnects never reprobe.
+  if (models.has(platform)) {
+    return models.get(platform);
+  }
+  let model: string | undefined;
+  if (platform === "darwin") {
+    const res = (deps.spawnSync ?? spawnSync)("sysctl", ["-n", "hw.model"], {
+      encoding: "utf-8",
+      timeout: DARWIN_SYSTEM_PROBE_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+    });
+    model = normalizeOptionalString(res.stdout);
+  } else if (platform === "linux") {
+    for (const file of ["/sys/devices/virtual/dmi/id/product_name", "/proc/device-tree/model"]) {
+      try {
+        const value = (deps.readFileSync ?? readFileSync)(file, "utf-8");
+        model = normalizeOptionalString(value.trim().replace(/\0+$/, ""));
+        if (model) {
+          model = truncateUtf16Safe(model, 64);
+          break;
+        }
+      } catch {
+        // DMI is absent on many ARM hosts; device-tree is absent on many x86 hosts.
+      }
+    }
+  }
+  models.set(platform, model);
+  return model;
+}

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -1,5 +1,4 @@
 // Detects system command availability for setup and diagnostics.
-import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import os from "node:os";
 import {
@@ -10,8 +9,9 @@ import {
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { PresenceEntry } from "../../packages/gateway-protocol/src/schema/snapshot.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
+import { resolveMachineModelIdentifier } from "./machine-model.js";
 import { pickBestEffortPrimaryLanIPv4 } from "./network-discovery-display.js";
-import { DARWIN_SYSTEM_PROBE_TIMEOUT_MS, resolveDarwinProductVersion } from "./os-summary.js";
+import { resolveDarwinProductVersion } from "./os-summary.js";
 
 export type SystemPresence = {
   host?: string;
@@ -91,19 +91,7 @@ function initSelfPresence() {
   const host = os.hostname();
   const ip = resolvePrimaryIPv4() ?? undefined;
   const version = resolveRuntimeServiceVersion(process.env);
-  const modelIdentifier = (() => {
-    const p = os.platform();
-    if (p === "darwin") {
-      const res = spawnSync("sysctl", ["-n", "hw.model"], {
-        encoding: "utf-8",
-        timeout: DARWIN_SYSTEM_PROBE_TIMEOUT_MS,
-        killSignal: "SIGKILL",
-      });
-      const out = normalizeOptionalString(res.stdout) ?? "";
-      return out.length > 0 ? out : undefined;
-    }
-    return os.arch();
-  })();
+  const modelIdentifier = resolveMachineModelIdentifier();
   const platform = (() => {
     const p = os.platform();
     const rel = os.release();

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -38,6 +38,7 @@ async function withPresenceModule<T>(
 
 describe("system-presence version fallback", () => {
   beforeEach(() => {
+    vi.resetModules();
     spawnSyncMock.mockReturnValue({
       stdout: "",
       stderr: "",

--- a/src/node-host/gateway-platform-identity.test.ts
+++ b/src/node-host/gateway-platform-identity.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveNodeHostGatewayPlatformIdentity } from "./gateway-platform-identity.js";
+
+describe("resolveNodeHostGatewayPlatformIdentity", () => {
+  it.each([
+    { runtime: "darwin", platform: "macos", deviceFamily: "Mac", modelIdentifier: "Mac16,1" },
+    { runtime: "linux", platform: "linux", deviceFamily: "Linux", modelIdentifier: "Test Board" },
+    { runtime: "win32", platform: "windows", deviceFamily: "Windows", modelIdentifier: undefined },
+    {
+      runtime: "freebsd",
+      platform: "unknown",
+      deviceFamily: undefined,
+      modelIdentifier: undefined,
+    },
+  ] as const)(
+    "reports $runtime hardware identity",
+    ({ runtime, platform, deviceFamily, modelIdentifier }) => {
+      const resolveModel = vi.fn(() => modelIdentifier);
+      expect(resolveNodeHostGatewayPlatformIdentity(runtime, resolveModel)).toEqual({
+        platform,
+        ...(deviceFamily ? { deviceFamily, modelIdentifier } : {}),
+      });
+      expect(resolveModel).toHaveBeenCalledExactlyOnceWith(runtime);
+    },
+  );
+});

--- a/src/node-host/gateway-platform-identity.ts
+++ b/src/node-host/gateway-platform-identity.ts
@@ -1,14 +1,21 @@
-export function resolveNodeHostGatewayPlatformIdentity(platform: NodeJS.Platform): {
+import { resolveMachineModelIdentifier } from "../infra/machine-model.js";
+
+export function resolveNodeHostGatewayPlatformIdentity(
+  platform: NodeJS.Platform,
+  resolveModel = resolveMachineModelIdentifier,
+): {
   platform: string;
   deviceFamily?: string;
+  modelIdentifier?: string;
 } {
+  const modelIdentifier = resolveModel(platform);
   switch (platform) {
     case "darwin":
-      return { platform: "macos", deviceFamily: "Mac" };
+      return { platform: "macos", deviceFamily: "Mac", modelIdentifier };
     case "win32":
-      return { platform: "windows", deviceFamily: "Windows" };
+      return { platform: "windows", deviceFamily: "Windows", modelIdentifier };
     case "linux":
-      return { platform: "linux", deviceFamily: "Linux" };
+      return { platform: "linux", deviceFamily: "Linux", modelIdentifier };
     default:
       return { platform: "unknown" };
   }

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -114,6 +114,10 @@ vi.mock("../infra/machine-name.js", () => ({
   getMachineDisplayName: vi.fn(async () => "test-node"),
 }));
 
+vi.mock("../infra/machine-model.js", () => ({
+  resolveMachineModelIdentifier: vi.fn(() => "TestMachine1,1"),
+}));
+
 vi.mock("../infra/executable-path.js", () => ({
   resolveExecutableFromPathEnv: vi.fn((bin: string) => mocks.resolvedExecutables.get(bin) ?? null),
 }));
@@ -277,6 +281,9 @@ describe("runNodeHost", () => {
 
       expect(lastCapturedOptions()?.platform).toBe(platform);
       expect(lastCapturedOptions()?.deviceFamily).toBe(deviceFamily);
+      expect(lastCapturedOptions()?.modelIdentifier).toBe(
+        runtime === "freebsd" ? undefined : "TestMachine1,1",
+      );
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Headless `openclaw node run` hosts (including the node-host worker embedded by the macOS app) connect with `platform` and `deviceFamily` but no hardware model, so the Control UI Devices page cannot pick a form-factor icon or family label for them and shows a generic monitor glyph, while the Gateway's own presence entry reported a CPU architecture string as its "model" on Linux.

## Why This Change Was Made

Hardware model discovery moves into one process-stable owner, `src/infra/machine-model.ts` (`sysctl -n hw.model` on macOS, DMI `product_name` or the device-tree model on Linux, undefined on Windows, memoized per process), shared by Gateway self-presence and the node host's platform identity. The gateway client gains a `modelIdentifier` option that rides the modern connect envelope next to `deviceFamily`; legacy node envelopes and the signed device payload are unchanged. The Gateway already stores and projects `connect.client.modelIdentifier`, so `node.list` now carries it for CLI nodes.

## User Impact

CLI node hosts on macOS and Linux show the right device icon and family label (Mac Studio, MacBook Pro, Mac mini, …) on the Devices page and report `hw: <model>` in `openclaw nodes status`. Linux Gateway presence stops reporting `x64`/`arm64` as a model.

## Evidence

- `pnpm test src/infra/machine-model.test.ts src/node-host/gateway-platform-identity.test.ts src/node-host/runner.test.ts src/gateway/client.test.ts src/infra/system-presence.version.test.ts` and related files: 183 tests passing (darwin/linux/win32 probes, timeout and missing-file paths, memoization, node-host propagation, modern vs legacy connect metadata).
- `node scripts/check-changed.mjs` green; Codex autoreview (branch vs `origin/main`): scoped-clean.
- Docs: `docs/nodes/index.md` notes the hardware model reporting.

Production LOC +50 (new owner module, identity plumbing) / tests +132 / docs +2. Companion to the Devices page structure pass PR.
