### PR TITLE
feat(ios): report node host memory and CPU stats

### DIFF
--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -302,7 +302,7 @@ gateway can only send pushes for iOS devices that paired with that gateway.
 - One Chat surface for text, realtime voice, dictation, and voice notes through the operator gateway session.
 - iOS node commands in foreground: camera snap/clip, screen record, location, contacts, calendar, reminders, photos, motion, local notifications.
 - Authenticated background `node.presence.alive` beacons that update gateway last-seen metadata when the app moves between foreground and background, without treating suspended sockets as connected.
-- Connected nodes publish CPU count, memory, and available home-volume disk capacity immediately and every 60 seconds through `node.host.stats`, supplying the Control UI Devices meters. Disk fields are omitted when unavailable; iOS does not report load averages. Reporting stops when the node route disconnects or changes, and iOS suspension can pause updates.
+- Connected nodes publish CPU count and memory immediately and every 60 seconds through `node.host.stats`, supplying the Control UI Devices meters. iOS reports neither load averages nor disk capacity (Apple's required-reason API policy does not allow sending disk-space values off-device). Reporting stops when the node route disconnects or changes, and iOS suspension can pause updates.
 - Share extension deep-link forwarding into the connected gateway session.
 
 ## Computer Use Relationship
@@ -342,7 +342,6 @@ Pass criteria:
 
 ## Known Issues / Limitations / Problems
 
-- App Store follow-up: resolve the required-reason API policy for disk-capacity reporting before distribution. Apple's [disk-space API reasons](https://developer.apple.com/documentation/bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/nsprivacyaccessedapitype) permit display on another device only over the local network, with explicit user permission; they do not cover automatic reporting to an Internet Gateway.
 - Foreground-first: iOS can suspend sockets in background; reconnect recovery is still being tuned.
 - Background command limits are strict: `camera.*`, `screen.*`, and `talk.*` are blocked when backgrounded.
 - Background location requires `Always` location permission.

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -302,6 +302,7 @@ gateway can only send pushes for iOS devices that paired with that gateway.
 - One Chat surface for text, realtime voice, dictation, and voice notes through the operator gateway session.
 - iOS node commands in foreground: camera snap/clip, screen record, location, contacts, calendar, reminders, photos, motion, local notifications.
 - Authenticated background `node.presence.alive` beacons that update gateway last-seen metadata when the app moves between foreground and background, without treating suspended sockets as connected.
+- Connected nodes publish CPU count, memory, and available home-volume disk capacity immediately and every 60 seconds through `node.host.stats`, supplying the Control UI Devices meters. Disk fields are omitted when unavailable; iOS does not report load averages. Reporting stops when the node route disconnects or changes, and iOS suspension can pause updates.
 - Share extension deep-link forwarding into the connected gateway session.
 
 ## Computer Use Relationship
@@ -341,6 +342,7 @@ Pass criteria:
 
 ## Known Issues / Limitations / Problems
 
+- App Store follow-up: resolve the required-reason API policy for disk-capacity reporting before distribution. Apple's [disk-space API reasons](https://developer.apple.com/documentation/bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/nsprivacyaccessedapitype) permit display on another device only over the local network, with explicit user permission; they do not cover automatic reporting to an Internet Gateway.
 - Foreground-first: iOS can suspend sockets in background; reconnect recovery is still being tuned.
 - Background command limits are strict: `camera.*`, `screen.*`, and `talk.*` are blocked when backgrounded.
 - Background location requires `Always` location permission.

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -471,6 +471,7 @@ final class NodeAppModel {
     // Secondary "operator" connection: used for chat/talk/config/voicewake requests.
     private let operatorGateway = GatewayNodeSession()
     private var nodeGatewayTask: Task<Void, Never>?
+    @ObservationIgnored private var nodeHostStatsTask: Task<Void, Never>?
     private var operatorGatewayTask: Task<Void, Never>?
     @ObservationIgnored private var gatewaySessionResetTask: Task<Void, Never>?
     @ObservationIgnored private var gatewaySessionResetGeneration: UInt64 = 0
@@ -3587,6 +3588,7 @@ extension NodeAppModel {
         }
 
         self.gatewayRouteGeneration &+= 1
+        self.stopNodeHostStatsPublisher()
         self.activeGatewayConnectConfig = nextConfig
         prepareForGatewayConnect(
             stableID: effectiveStableID,
@@ -3679,6 +3681,7 @@ extension NodeAppModel {
         self.talkMode.updateGatewayConnected(false)
         self.voiceWake.invalidatePendingCommand()
         self.gatewayRouteGeneration &+= 1
+        self.stopNodeHostStatsPublisher()
         nodeGatewayTask?.cancel()
         self.nodeGatewayTask = nil
         operatorGatewayTask?.cancel()
@@ -4416,6 +4419,8 @@ extension NodeAppModel {
         let shouldContinue = self.gatewayRouteCheck(
             generation: routeGeneration,
             stableID: stableID)
+        await self.startNodeHostStatsPublisher(shouldContinue: shouldContinue)
+        guard shouldContinue() else { return }
         await onNodeGatewayConnected(shouldContinue: shouldContinue)
         guard shouldContinue() else { return }
         SignificantLocationMonitor.startIfNeeded(
@@ -4604,7 +4609,50 @@ extension NodeAppModel {
 
     private func handleNodeGatewayRouteInvalidated(routeGeneration: UInt64, stableID: String) {
         guard self.isCurrentGatewayRoute(generation: routeGeneration, stableID: stableID) else { return }
+        self.stopNodeHostStatsPublisher()
         self.invalidateNodePushToTalkRoute()
+    }
+
+    private func stopNodeHostStatsPublisher() {
+        self.nodeHostStatsTask?.cancel()
+        self.nodeHostStatsTask = nil
+    }
+
+    private func startNodeHostStatsPublisher(
+        shouldContinue: @escaping @MainActor @Sendable () -> Bool) async
+    {
+        self.stopNodeHostStatsPublisher()
+        guard let route = await self.nodeGateway.currentRoute(), shouldContinue(), self.gatewayConnected else { return }
+        let gateway = self.nodeGateway
+        self.nodeHostStatsTask = Task {
+            var failureLogged = false
+            let logger = Logger(subsystem: "ai.openclawfoundation.app", category: "NodeHostStats")
+            // App route generations survive socket reconnects; the captured route fences both.
+            while !Task.isCancelled, shouldContinue(), await gateway.currentRoute() == route {
+                guard !Task.isCancelled, shouldContinue() else { return }
+                let sent: Bool
+                do {
+                    let payload = try NodeHostStatsReporter.makePayload()
+                    let payloadJSON = try Self.encodePayload(payload)
+                    sent = await gateway.sendEvent(
+                        event: NodeHostStatsReporter.eventName,
+                        payloadJSON: payloadJSON,
+                        ifCurrentRoute: route)
+                } catch {
+                    sent = false
+                }
+                guard !Task.isCancelled, shouldContinue() else { return }
+                if !sent, !failureLogged {
+                    logger.debug("Node host stats publish failed")
+                    failureLogged = true
+                }
+                do {
+                    try await Task.sleep(for: .seconds(NodeHostStatsReporter.intervalSeconds))
+                } catch {
+                    return
+                }
+            }
+        }
     }
 
     func invalidateNodePushToTalkRoute() {

--- a/apps/ios/Sources/Node/NodeHostStatsReporter.swift
+++ b/apps/ios/Sources/Node/NodeHostStatsReporter.swift
@@ -1,0 +1,93 @@
+import Darwin
+import Foundation
+
+enum NodeHostStatsReporter {
+    static let eventName = "node.host.stats"
+    static let intervalSeconds: TimeInterval = 60
+
+    struct Payload: Encodable {
+        let cpuCount: Int
+        let memoryTotalBytes: UInt64
+        let memoryFreeBytes: UInt64
+        let diskTotalBytes: Int64?
+        let diskAvailableBytes: Int64?
+    }
+
+    struct Sampler {
+        var cpuCount: () -> Int = { ProcessInfo.processInfo.activeProcessorCount }
+        var memoryTotalBytes: () -> UInt64 = { ProcessInfo.processInfo.physicalMemory }
+        var memoryFreeBytes: () throws -> UInt64 = { try NodeHostStatsReporter.sampleFreeMemory() }
+        var diskCapacity: () throws -> (totalBytes: Int64?, availableBytes: Int64?) = {
+            let values = try URL(fileURLWithPath: NSHomeDirectory()).resourceValues(forKeys: [
+                .volumeTotalCapacityKey,
+                .volumeAvailableCapacityForImportantUsageKey,
+            ])
+            return (values.volumeTotalCapacity.map(Int64.init), values.volumeAvailableCapacityForImportantUsage)
+        }
+    }
+
+    private struct NodeEventRequestPayload: Encodable {
+        let event = NodeHostStatsReporter.eventName
+        let payloadJSON: String
+    }
+
+    static func makePayload(sampler: Sampler = Sampler()) throws -> Payload {
+        let memoryTotalBytes = sampler.memoryTotalBytes()
+        let memoryFreeBytes = try min(sampler.memoryFreeBytes(), memoryTotalBytes)
+        let disk = try? sampler.diskCapacity()
+        let diskTotalBytes: Int64?
+        let diskAvailableBytes: Int64?
+        if let total = disk?.totalBytes, let available = disk?.availableBytes {
+            diskTotalBytes = max(0, total)
+            diskAvailableBytes = max(0, min(available, total))
+        } else {
+            diskTotalBytes = nil
+            diskAvailableBytes = nil
+        }
+        return Payload(
+            cpuCount: max(1, min(4096, sampler.cpuCount())),
+            memoryTotalBytes: memoryTotalBytes,
+            memoryFreeBytes: memoryFreeBytes,
+            diskTotalBytes: diskTotalBytes,
+            diskAvailableBytes: diskAvailableBytes)
+    }
+
+    static func makeNodeEventRequestPayloadJSON(
+        payload: Payload,
+        encoder: JSONEncoder = JSONEncoder()) throws -> String
+    {
+        guard let payloadJSON = try String(data: encoder.encode(payload), encoding: .utf8),
+              let requestJSON = try String(
+                  data: encoder.encode(NodeEventRequestPayload(payloadJSON: payloadJSON)),
+                  encoding: .utf8)
+        else {
+            throw EncodingError.invalidValue(payload, EncodingError.Context(
+                codingPath: [],
+                debugDescription: "Failed to encode node.event payload as UTF-8"))
+        }
+        return requestJSON
+    }
+
+    private static func sampleFreeMemory() throws -> UInt64 {
+        let host = mach_host_self()
+        defer { mach_port_deallocate(mach_task_self_, host) }
+        var statistics = vm_statistics64_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64_data_t>.size / MemoryLayout<integer_t>.size)
+        let result = withUnsafeMutablePointer(to: &statistics) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(host, HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            throw NSError(domain: NSMachErrorDomain, code: Int(result))
+        }
+        var pageSize: vm_size_t = 0
+        let pageSizeResult = host_page_size(host, &pageSize)
+        guard pageSizeResult == KERN_SUCCESS else {
+            throw NSError(domain: NSMachErrorDomain, code: Int(pageSizeResult))
+        }
+        // Inactive pages are reclaimable; cap the estimate at physical memory in makePayload.
+        return (UInt64(statistics.free_count) + UInt64(statistics.inactive_count)) * UInt64(pageSize)
+    }
+}

--- a/apps/ios/Sources/Node/NodeHostStatsReporter.swift
+++ b/apps/ios/Sources/Node/NodeHostStatsReporter.swift
@@ -5,25 +5,19 @@ enum NodeHostStatsReporter {
     static let eventName = "node.host.stats"
     static let intervalSeconds: TimeInterval = 60
 
+    // Disk capacity is deliberately not sampled: Apple's required-reason API policy
+    // does not permit sending disk-space values off-device, and the Gateway treats
+    // the disk fields as optional.
     struct Payload: Encodable {
         let cpuCount: Int
         let memoryTotalBytes: UInt64
         let memoryFreeBytes: UInt64
-        let diskTotalBytes: Int64?
-        let diskAvailableBytes: Int64?
     }
 
     struct Sampler {
         var cpuCount: () -> Int = { ProcessInfo.processInfo.activeProcessorCount }
         var memoryTotalBytes: () -> UInt64 = { ProcessInfo.processInfo.physicalMemory }
         var memoryFreeBytes: () throws -> UInt64 = { try NodeHostStatsReporter.sampleFreeMemory() }
-        var diskCapacity: () throws -> (totalBytes: Int64?, availableBytes: Int64?) = {
-            let values = try URL(fileURLWithPath: NSHomeDirectory()).resourceValues(forKeys: [
-                .volumeTotalCapacityKey,
-                .volumeAvailableCapacityForImportantUsageKey,
-            ])
-            return (values.volumeTotalCapacity.map(Int64.init), values.volumeAvailableCapacityForImportantUsage)
-        }
     }
 
     private struct NodeEventRequestPayload: Encodable {
@@ -34,22 +28,10 @@ enum NodeHostStatsReporter {
     static func makePayload(sampler: Sampler = Sampler()) throws -> Payload {
         let memoryTotalBytes = sampler.memoryTotalBytes()
         let memoryFreeBytes = try min(sampler.memoryFreeBytes(), memoryTotalBytes)
-        let disk = try? sampler.diskCapacity()
-        let diskTotalBytes: Int64?
-        let diskAvailableBytes: Int64?
-        if let total = disk?.totalBytes, let available = disk?.availableBytes {
-            diskTotalBytes = max(0, total)
-            diskAvailableBytes = max(0, min(available, total))
-        } else {
-            diskTotalBytes = nil
-            diskAvailableBytes = nil
-        }
         return Payload(
             cpuCount: max(1, min(4096, sampler.cpuCount())),
             memoryTotalBytes: memoryTotalBytes,
-            memoryFreeBytes: memoryFreeBytes,
-            diskTotalBytes: diskTotalBytes,
-            diskAvailableBytes: diskAvailableBytes)
+            memoryFreeBytes: memoryFreeBytes)
     }
 
     static func makeNodeEventRequestPayloadJSON(

--- a/apps/ios/Sources/Node/NodeHostStatsReporter.swift
+++ b/apps/ios/Sources/Node/NodeHostStatsReporter.swift
@@ -5,9 +5,9 @@ enum NodeHostStatsReporter {
     static let eventName = "node.host.stats"
     static let intervalSeconds: TimeInterval = 60
 
-    // Disk capacity is deliberately not sampled: Apple's required-reason API policy
-    // does not permit sending disk-space values off-device, and the Gateway treats
-    // the disk fields as optional.
+    /// Wire payload for `node.host.stats`. Disk capacity is deliberately not sampled:
+    /// Apple's required-reason API policy does not permit sending disk-space values
+    /// off-device, and the Gateway treats the disk fields as optional.
     struct Payload: Encodable {
         let cpuCount: Int
         let memoryTotalBytes: UInt64

--- a/apps/ios/Tests/NodeHostStatsReporterTests.swift
+++ b/apps/ios/Tests/NodeHostStatsReporterTests.swift
@@ -12,32 +12,13 @@ struct NodeHostStatsReporterTests {
         #expect(request["event"] == "node.host.stats")
         let payloadJSON = try #require(request["payloadJSON"])
         let values = try JSONDecoder().decode([String: UInt64].self, from: Data(payloadJSON.utf8))
+        // Disk fields stay absent by design (Apple required-reason API policy).
         #expect(values == [
             "cpuCount": 6,
             "memoryTotalBytes": 8_000_000_000,
             "memoryFreeBytes": 2_000_000_000,
-            "diskTotalBytes": 256_000_000_000,
-            "diskAvailableBytes": 100_000_000_000,
         ])
         #expect(payloadJSON.utf8.count < 200)
-    }
-
-    @Test(arguments: [(nil, nil), (Int64(256), nil), (nil, Int64(100))])
-    func `disk fields are omitted together`(capacity: (Int64?, Int64?)) throws {
-        var sampler = Self.sampler()
-        sampler.diskCapacity = { capacity }
-        let payload = try NodeHostStatsReporter.makePayload(sampler: sampler)
-        let values = try JSONDecoder().decode([String: UInt64].self, from: JSONEncoder().encode(payload))
-        #expect(Set(values.keys) == ["cpuCount", "memoryTotalBytes", "memoryFreeBytes"])
-    }
-
-    @Test func `failed disk sampling still reports memory`() throws {
-        var sampler = Self.sampler()
-        sampler.diskCapacity = { throw CocoaError(.fileReadUnknown) }
-        let payload = try NodeHostStatsReporter.makePayload(sampler: sampler)
-        #expect(payload.diskTotalBytes == nil)
-        #expect(payload.diskAvailableBytes == nil)
-        #expect(payload.memoryFreeBytes == 2_000_000_000)
     }
 
     @Test(arguments: [0, 8192])
@@ -45,19 +26,17 @@ struct NodeHostStatsReporterTests {
         var sampler = Self.sampler()
         sampler.cpuCount = { cpuCount }
         sampler.memoryFreeBytes = { UInt64.max }
-        sampler.diskCapacity = { (100, 200) }
         let payload = try NodeHostStatsReporter.makePayload(sampler: sampler)
         #expect(payload.cpuCount == (cpuCount == 0 ? 1 : 4096))
         #expect(payload.memoryFreeBytes == payload.memoryTotalBytes)
-        #expect(payload.diskAvailableBytes == payload.diskTotalBytes)
     }
 
-    @Test func `negative disk values are clamped to zero`() throws {
+    @Test func `failed memory sampling surfaces as an error`() {
         var sampler = Self.sampler()
-        sampler.diskCapacity = { (-1, -2) }
-        let payload = try NodeHostStatsReporter.makePayload(sampler: sampler)
-        #expect(payload.diskTotalBytes == 0)
-        #expect(payload.diskAvailableBytes == 0)
+        sampler.memoryFreeBytes = { throw CocoaError(.fileReadUnknown) }
+        #expect(throws: CocoaError.self) {
+            try NodeHostStatsReporter.makePayload(sampler: sampler)
+        }
     }
 
     @Test func `older gateway unhandled response is accepted`() throws {
@@ -73,11 +52,6 @@ struct NodeHostStatsReporterTests {
         #expect((1...4096).contains(payload.cpuCount))
         #expect(payload.memoryTotalBytes == ProcessInfo.processInfo.physicalMemory)
         #expect(payload.memoryFreeBytes <= payload.memoryTotalBytes)
-        #expect((payload.diskTotalBytes == nil) == (payload.diskAvailableBytes == nil))
-        if let total = payload.diskTotalBytes, let available = payload.diskAvailableBytes {
-            #expect(total >= 0)
-            #expect((0...total).contains(available))
-        }
         #expect(try JSONEncoder().encode(payload).count < 200)
     }
 
@@ -85,7 +59,6 @@ struct NodeHostStatsReporterTests {
         NodeHostStatsReporter.Sampler(
             cpuCount: { 6 },
             memoryTotalBytes: { 8_000_000_000 },
-            memoryFreeBytes: { 2_000_000_000 },
-            diskCapacity: { (256_000_000_000, 100_000_000_000) })
+            memoryFreeBytes: { 2_000_000_000 })
     }
 }

--- a/apps/ios/Tests/NodeHostStatsReporterTests.swift
+++ b/apps/ios/Tests/NodeHostStatsReporterTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import OpenClawProtocol
+import Testing
+@testable import OpenClaw
+
+struct NodeHostStatsReporterTests {
+    @Test func `snapshot and node event envelope match the wire contract`() throws {
+        let payload = try NodeHostStatsReporter.makePayload(sampler: Self.sampler())
+        let requestJSON = try NodeHostStatsReporter.makeNodeEventRequestPayloadJSON(payload: payload)
+        let request = try #require(JSONSerialization.jsonObject(with: Data(requestJSON.utf8)) as? [String: String])
+        #expect(Set(request.keys) == ["event", "payloadJSON"])
+        #expect(request["event"] == "node.host.stats")
+        let payloadJSON = try #require(request["payloadJSON"])
+        let values = try JSONDecoder().decode([String: UInt64].self, from: Data(payloadJSON.utf8))
+        #expect(values == [
+            "cpuCount": 6,
+            "memoryTotalBytes": 8_000_000_000,
+            "memoryFreeBytes": 2_000_000_000,
+            "diskTotalBytes": 256_000_000_000,
+            "diskAvailableBytes": 100_000_000_000,
+        ])
+        #expect(payloadJSON.utf8.count < 200)
+    }
+
+    @Test(arguments: [(nil, nil), (Int64(256), nil), (nil, Int64(100))])
+    func `disk fields are omitted together`(capacity: (Int64?, Int64?)) throws {
+        var sampler = Self.sampler()
+        sampler.diskCapacity = { capacity }
+        let payload = try NodeHostStatsReporter.makePayload(sampler: sampler)
+        let values = try JSONDecoder().decode([String: UInt64].self, from: JSONEncoder().encode(payload))
+        #expect(Set(values.keys) == ["cpuCount", "memoryTotalBytes", "memoryFreeBytes"])
+    }
+
+    @Test func `failed disk sampling still reports memory`() throws {
+        var sampler = Self.sampler()
+        sampler.diskCapacity = { throw CocoaError(.fileReadUnknown) }
+        let payload = try NodeHostStatsReporter.makePayload(sampler: sampler)
+        #expect(payload.diskTotalBytes == nil)
+        #expect(payload.diskAvailableBytes == nil)
+        #expect(payload.memoryFreeBytes == 2_000_000_000)
+    }
+
+    @Test(arguments: [0, 8192])
+    func `samples are clamped to gateway bounds`(cpuCount: Int) throws {
+        var sampler = Self.sampler()
+        sampler.cpuCount = { cpuCount }
+        sampler.memoryFreeBytes = { UInt64.max }
+        sampler.diskCapacity = { (100, 200) }
+        let payload = try NodeHostStatsReporter.makePayload(sampler: sampler)
+        #expect(payload.cpuCount == (cpuCount == 0 ? 1 : 4096))
+        #expect(payload.memoryFreeBytes == payload.memoryTotalBytes)
+        #expect(payload.diskAvailableBytes == payload.diskTotalBytes)
+    }
+
+    @Test func `negative disk values are clamped to zero`() throws {
+        var sampler = Self.sampler()
+        sampler.diskCapacity = { (-1, -2) }
+        let payload = try NodeHostStatsReporter.makePayload(sampler: sampler)
+        #expect(payload.diskTotalBytes == 0)
+        #expect(payload.diskAvailableBytes == 0)
+    }
+
+    @Test func `older gateway unhandled response is accepted`() throws {
+        let response = try JSONDecoder().decode(
+            NodeEventResult.self,
+            from: Data(#"{"ok":true,"event":"node.host.stats","handled":false,"reason":"unsupported"}"#.utf8))
+        #expect(response.ok)
+        #expect(!response.handled)
+    }
+
+    @Test func `live sampler produces a bounded snapshot`() throws {
+        let payload = try NodeHostStatsReporter.makePayload()
+        #expect((1...4096).contains(payload.cpuCount))
+        #expect(payload.memoryTotalBytes == ProcessInfo.processInfo.physicalMemory)
+        #expect(payload.memoryFreeBytes <= payload.memoryTotalBytes)
+        #expect((payload.diskTotalBytes == nil) == (payload.diskAvailableBytes == nil))
+        if let total = payload.diskTotalBytes, let available = payload.diskAvailableBytes {
+            #expect(total >= 0)
+            #expect((0...total).contains(available))
+        }
+        #expect(try JSONEncoder().encode(payload).count < 200)
+    }
+
+    private static func sampler() -> NodeHostStatsReporter.Sampler {
+        NodeHostStatsReporter.Sampler(
+            cpuCount: { 6 },
+            memoryTotalBytes: { 8_000_000_000 },
+            memoryFreeBytes: { 2_000_000_000 },
+            diskCapacity: { (256_000_000_000, 100_000_000_000) })
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Paired iPhones and iPads showed no resource meters on the Control UI Devices page because only CLI and macOS node hosts published the `node.host.stats` snapshot introduced in #136859.

## Why This Change Was Made

The iOS node now publishes CPU count and memory (total plus free-and-inactive pages from `host_statistics64`) through the existing `node.event` channel right after the node route connects and every 60 seconds, with the publisher task bound to the current route so it stops on disconnect, reset, or target replacement. Disk capacity is deliberately not reported: Apple's required-reason API policy does not allow sending disk-space values off-device, and the Gateway contract treats the disk fields as optional. iOS reports no load average either. Payloads stay under 200 bytes.

## User Impact

Connected iPhones and iPads show a memory meter on the Devices page; older Gateways answer `handled: false` and the app keeps its cadence without errors.

## Evidence

- `pnpm ios:gen` then `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,id=<iPhone 17 Pro, iOS 26.5>' -only-testing:OpenClawTests/NodeHostStatsReporterTests test`: 5 tests passed (wire envelope, clamping, sampler failure, older-Gateway response, live bounded sampling).
- Codex autoreview (branch vs `origin/main`): scoped-clean.
- No new settings or UI; `apps/ios/README.md` documents the behavior and the disk-reporting policy.

Production LOC about +120 (reporter and route-bound publisher) / tests +70 / docs +2.
