### PR TITLE
feat(android): report node host memory and disk stats

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -11,6 +11,7 @@ OpenClaw Android is the officially released Google Play app. It connects to an O
 - Configure foreground on-device Voice Wake and Gateway-synced wake words in **Settings → Voice**.
 - Use **Settings → OpenClaw** for guided Gateway setup and repair. New replies stay visible at the end of the conversation; scrolling back preserves your reading position until you return or tap **Jump to latest**.
 - Enable camera, location, and other phone capabilities through onboarding or Settings. Biometric locking, Gateway/chat notifications, and authenticated background presence are supported.
+- View the phone's memory and disk meters on the Control UI Devices page. Connected Android nodes report host resource stats immediately and every 60 seconds; disk meters require an available storage sample and a Gateway that supports host stats.
 - Manage installed skills and Gateway-verified ClawHub releases, review Skill Workshop proposals, and inspect or edit automations with the required Gateway access.
 - Use the Wear OS companion for sessions, replies, aborts, and realtime Talk through the paired phone without storing Gateway credentials on the watch.
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -83,6 +83,7 @@ import ai.openclaw.app.node.LocationCaptureManager
 import ai.openclaw.app.node.LocationHandler
 import ai.openclaw.app.node.MobileUiHandler
 import ai.openclaw.app.node.MotionHandler
+import ai.openclaw.app.node.NodeHostStatsReporter
 import ai.openclaw.app.node.NodePresenceAliveBeacon
 import ai.openclaw.app.node.NotificationsHandler
 import ai.openclaw.app.node.PhotosHandler
@@ -159,6 +160,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -1537,6 +1539,7 @@ class NodeRuntime private constructor(
   private val voiceCapturePreparationMutex = Mutex()
 
   @Volatile private var nodePresenceAliveLastSuccessAtMs: Long? = null
+  private var nodeHostStatsJob: Job? = null
   private var operatorConnected = false
   private var operatorStatusText: String = "Offline"
   private var nodeStatusText: String = "Offline"
@@ -1958,6 +1961,7 @@ class NodeRuntime private constructor(
         }
         notificationOutbox.onConnected()
         publishNodePresenceAliveBeacon(NodePresenceAliveBeacon.Trigger.Connect)
+        startNodeHostStatsReporting()
         refreshNodesDevices()
         val endpoint = connectedEndpoint
         if (!operatorConnected && endpoint != null && connection != null) {
@@ -1966,6 +1970,8 @@ class NodeRuntime private constructor(
       },
       onDisconnected = { message ->
         invalidateNodeCapabilityApprovalState()
+        nodeHostStatsJob?.cancel()
+        nodeHostStatsJob = null
         updateStatus {
           _nodeConnected.value = false
           nodeStatusText = message
@@ -3255,6 +3261,37 @@ class NodeRuntime private constructor(
       stopActiveVoiceSession()
       publishNodePresenceAliveBeacon(NodePresenceAliveBeacon.Trigger.Background, throttleRecentSuccess = true)
     }
+  }
+
+  private fun startNodeHostStatsReporting() {
+    nodeHostStatsJob?.cancel()
+    nodeHostStatsJob = null
+    val gatewayId = nodeSession.currentEndpointStableId() ?: return
+    nodeHostStatsJob =
+      scope.launch {
+        var loggedFailure = false
+        while (isActive && _nodeConnected.value) {
+          val sent =
+            try {
+              nodeSession.sendNodeEventForEndpoint(
+                expectedEndpointStableId = gatewayId,
+                event = NodeHostStatsReporter.EVENT_NAME,
+                payloadJson = NodeHostStatsReporter.makePayloadJson(NodeHostStatsReporter.sample(appContext)),
+                // This job owns the shared limit for sampling and transport warnings.
+                logFailure = false,
+              )
+            } catch (err: CancellationException) {
+              throw err
+            } catch (_: Exception) {
+              false
+            }
+          if (!sent && !loggedFailure) {
+            Log.w("OpenClawNode", "node.host.stats could not be published")
+            loggedFailure = true
+          }
+          delay(NodeHostStatsReporter.INTERVAL_MS)
+        }
+      }
   }
 
   private fun publishNodePresenceAliveBeacon(

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -631,8 +631,9 @@ class GatewaySession(
     expectedEndpointStableId: String?,
     event: String,
     payloadJson: String?,
+    logFailure: Boolean = true,
   ): Boolean =
-    sendNodeEventWithOutcomeForEndpoint(expectedEndpointStableId, event, payloadJson) ==
+    sendNodeEventWithOutcomeForEndpoint(expectedEndpointStableId, event, payloadJson, logFailure) ==
       NodeEventSendOutcome.COMPLETED
 
   internal suspend fun sendNodeEventWithOutcome(
@@ -644,6 +645,7 @@ class GatewaySession(
     expectedEndpointStableId: String?,
     event: String,
     payloadJson: String?,
+    logFailure: Boolean = true,
   ): NodeEventSendOutcome {
     val conn = readyConnection(expectedEndpointStableId) ?: return NodeEventSendOutcome.DISCONNECTED
     return try {
@@ -659,7 +661,7 @@ class GatewaySession(
       // Voice/audio ownership takeover must cancel before a stale node event dispatches.
       throw err
     } catch (err: Throwable) {
-      Log.w("OpenClawGateway", "node.event failed: ${err::class.java.simpleName}")
+      if (logFailure) Log.w("OpenClawGateway", "node.event failed: ${err::class.java.simpleName}")
       NodeEventSendOutcome.FAILED
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/NodeHostStatsReporter.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/NodeHostStatsReporter.kt
@@ -1,0 +1,52 @@
+package ai.openclaw.app.node
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Environment
+import android.os.StatFs
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+internal object NodeHostStatsReporter {
+  const val EVENT_NAME: String = "node.host.stats"
+  const val INTERVAL_MS: Long = 60_000
+
+  data class Sample(
+    val cpuCount: Int,
+    val memoryTotalBytes: Long,
+    val memoryFreeBytes: Long,
+    val diskTotalBytes: Long? = null,
+    val diskAvailableBytes: Long? = null,
+  )
+
+  fun sample(context: Context): Sample {
+    val memory = ActivityManager.MemoryInfo()
+    checkNotNull(context.getSystemService(ActivityManager::class.java)).getMemoryInfo(memory)
+    val disk =
+      runCatching {
+        val stats = StatFs(Environment.getDataDirectory().path)
+        stats.totalBytes to stats.availableBytes
+      }.getOrNull()
+    return Sample(
+      cpuCount = Runtime.getRuntime().availableProcessors(),
+      memoryTotalBytes = memory.totalMem,
+      memoryFreeBytes = memory.availMem,
+      diskTotalBytes = disk?.first,
+      diskAvailableBytes = disk?.second,
+    )
+  }
+
+  fun makePayloadJson(sample: Sample): String =
+    buildJsonObject {
+      val memoryTotal = sample.memoryTotalBytes.coerceAtLeast(0L)
+      put("cpuCount", JsonPrimitive(sample.cpuCount.coerceIn(1, 4096)))
+      put("memoryTotalBytes", JsonPrimitive(memoryTotal))
+      put("memoryFreeBytes", JsonPrimitive(sample.memoryFreeBytes.coerceIn(0L, memoryTotal)))
+      // Disk fields are a pair in the Gateway contract; failed sampling omits both.
+      if (sample.diskTotalBytes != null && sample.diskAvailableBytes != null) {
+        val diskTotal = sample.diskTotalBytes.coerceAtLeast(0L)
+        put("diskTotalBytes", JsonPrimitive(diskTotal))
+        put("diskAvailableBytes", JsonPrimitive(sample.diskAvailableBytes.coerceIn(0L, diskTotal)))
+      }
+    }.toString()
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -1,6 +1,8 @@
 package ai.openclaw.app.gateway
 
 import ai.openclaw.app.chat.ChatWidgetUrlResolver
+import ai.openclaw.app.node.NodeHostStatsReporter
+import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -40,6 +42,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -1484,6 +1487,106 @@ class GatewaySessionInvokeTest {
         assertEquals("persisted", response["reason"]?.jsonPrimitive?.content)
       } finally {
         shutdownHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun sendNodeEventForEndpoint_sendsHostStatsAndAcceptsUnhandledAck() =
+    runBlocking {
+      val json = testJson()
+      val connected = CompletableDeferred<Unit>()
+      val nodeEventParams = CompletableDeferred<JsonObject>()
+      val lastDisconnect = AtomicReference("")
+      val server =
+        startGatewayServer(json) { webSocket, id, method, frame ->
+          when (method) {
+            "connect" -> {
+              webSocket.send(connectResponseFrame(id))
+            }
+
+            "node.event" -> {
+              nodeEventParams.complete(frame["params"]!!.jsonObject)
+              webSocket.send(
+                """{"type":"res","id":"$id","ok":true,"payload":{"ok":true,"event":"node.host.stats","handled":false}}""",
+              )
+            }
+          }
+        }
+      val harness =
+        createNodeHarness(connected, lastDisconnect) { GatewaySession.InvokeResult.ok("{}") }
+      val payloadJson =
+        NodeHostStatsReporter.makePayloadJson(
+          NodeHostStatsReporter.Sample(8, 8_000_000_000, 3_000_000_000, 128_000_000_000, 64_000_000_000),
+        )
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        awaitConnectedOrThrow(connected, lastDisconnect, server)
+        assertFalse(
+          harness.session.sendNodeEventForEndpoint("another-gateway", NodeHostStatsReporter.EVENT_NAME, payloadJson),
+        )
+        assertTrue(
+          harness.session.sendNodeEventForEndpoint(
+            gatewayIdForPort(server.port),
+            NodeHostStatsReporter.EVENT_NAME,
+            payloadJson,
+          ),
+        )
+        val params = withTimeout(TEST_TIMEOUT_MS) { nodeEventParams.await() }
+        assertEquals("node.host.stats", params["event"]?.jsonPrimitive?.content)
+        assertEquals(payloadJson, params["payloadJSON"]?.jsonPrimitive?.content)
+      } finally {
+        shutdownHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun sendNodeEventForEndpoint_canDelegateFailureLoggingToCaller() =
+    runBlocking {
+      for (suppressLog in listOf(false, true)) {
+        val connected = CompletableDeferred<Unit>()
+        val nodeEventSeen = CompletableDeferred<Unit>()
+        val sent = CompletableDeferred<Boolean>()
+        val lastDisconnect = AtomicReference("")
+        val server =
+          startGatewayServer(testJson()) { webSocket, id, method, _ ->
+            when (method) {
+              "connect" -> webSocket.send(connectResponseFrame(id))
+              "node.event" -> nodeEventSeen.complete(Unit)
+            }
+          }
+        val harness =
+          createNodeHarness(connected, lastDisconnect) { GatewaySession.InvokeResult.ok("{}") }
+
+        fun failureLogs(): Int =
+          ShadowLog.getLogsForTag("OpenClawGateway").count {
+            it.type == Log.WARN && it.msg.startsWith("node.event failed:")
+          }
+        var sendJob: Job? = null
+
+        try {
+          connectNodeSession(harness.session, server.port)
+          awaitConnectedOrThrow(connected, lastDisconnect, server)
+          val logsBefore = failureLogs()
+          val gatewayId = gatewayIdForPort(server.port)
+          sendJob =
+            launch {
+              sent.complete(
+                if (suppressLog) {
+                  harness.session.sendNodeEventForEndpoint(gatewayId, NodeHostStatsReporter.EVENT_NAME, "{}", logFailure = false)
+                } else {
+                  harness.session.sendNodeEventForEndpoint(gatewayId, NodeHostStatsReporter.EVENT_NAME, "{}")
+                },
+              )
+            }
+          withTimeout(TEST_TIMEOUT_MS) { nodeEventSeen.await() }
+          harness.session.disconnect()
+          assertFalse(withTimeout(TEST_TIMEOUT_MS) { sent.await() })
+          assertEquals(if (suppressLog) 0 else 1, failureLogs() - logsBefore)
+        } finally {
+          sendJob?.cancelAndJoin()
+          shutdownHarness(harness, server)
+        }
       }
     }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/NodeHostStatsReporterTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/NodeHostStatsReporterTest.kt
@@ -1,0 +1,63 @@
+package ai.openclaw.app.node
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NodeHostStatsReporterTest {
+  private val sample =
+    NodeHostStatsReporter.Sample(
+      cpuCount = 8,
+      memoryTotalBytes = 8_000_000_000,
+      memoryFreeBytes = 3_000_000_000,
+      diskTotalBytes = 128_000_000_000,
+      diskAvailableBytes = 64_000_000_000,
+    )
+
+  @Test
+  fun makePayloadJson_includesHostStatsWithoutLoadAverage() {
+    assertPayload(
+      sample,
+      """{"cpuCount":8,"memoryTotalBytes":8000000000,"memoryFreeBytes":3000000000,"diskTotalBytes":128000000000,"diskAvailableBytes":64000000000}""",
+    )
+  }
+
+  @Test
+  fun makePayloadJson_omitsUnavailableDiskPair() {
+    for (disk in listOf(null to null, null to 10L, 10L to null)) {
+      assertPayload(
+        sample.copy(diskTotalBytes = disk.first, diskAvailableBytes = disk.second),
+        """{"cpuCount":8,"memoryTotalBytes":8000000000,"memoryFreeBytes":3000000000}""",
+      )
+    }
+  }
+
+  @Test
+  fun makePayloadJson_clampsFreeBytesToTotal() {
+    assertPayload(
+      sample.copy(memoryFreeBytes = 9_000_000_000, diskAvailableBytes = 256_000_000_000),
+      """{"cpuCount":8,"memoryTotalBytes":8000000000,"memoryFreeBytes":8000000000,"diskTotalBytes":128000000000,"diskAvailableBytes":128000000000}""",
+    )
+  }
+
+  @Test
+  fun makePayloadJson_enforcesNonNegativeBytesAndCpuBounds() {
+    for ((cpuCount, expectedCpuCount) in listOf(0 to 1, 4097 to 4096)) {
+      assertPayload(
+        NodeHostStatsReporter.Sample(cpuCount, -1, -2, -3, -4),
+        """{"cpuCount":$expectedCpuCount,"memoryTotalBytes":0,"memoryFreeBytes":0,"diskTotalBytes":0,"diskAvailableBytes":0}""",
+      )
+    }
+  }
+
+  private fun assertPayload(
+    sample: NodeHostStatsReporter.Sample,
+    expected: String,
+  ) {
+    assertEquals(
+      Json.parseToJsonElement(expected).jsonObject,
+      Json.parseToJsonElement(NodeHostStatsReporter.makePayloadJson(sample)).jsonObject,
+    )
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Paired Android devices showed no resource meters on the Control UI Devices page because only CLI and macOS node hosts published the `node.host.stats` snapshot introduced in #136859.

## Why This Change Was Made

`NodeRuntime` starts one stats job when the node session connects: it publishes `node.host.stats` immediately and every 60 seconds through the fire-and-forget `sendNodeEventForEndpoint` path, bound to the connected endpoint, and cancels it on disconnect or replacement. `NodeHostStatsReporter` samples `availableProcessors`, `ActivityManager.MemoryInfo` (total/available), and `StatFs` on the data directory, clamps values to the Gateway bounds, and omits both disk fields when storage sampling fails. Only the first failure per connection is logged; the session's generic `node.event failed` warning is suppressed for this periodic event so logs do not fill up on an older Gateway.

## User Impact

Connected Android nodes show memory and disk meters on the Devices page; older Gateways answer `handled: false` and the app keeps its cadence.

## Evidence

- `cd apps/android && ./gradlew :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.node.NodeHostStatsReporterTest' --tests 'ai.openclaw.app.node.NodePresenceAliveBeaconTest' --tests 'ai.openclaw.app.gateway.GatewaySessionInvokeTest.sendNodeEventForEndpoint_*'`: 13 tests passed.
- `pnpm android:format` and `pnpm android:assemble` (1m 13s) green; Codex autoreview (branch vs `origin/main`): scoped-clean.
- No device was attached, so on-device verification was not performed; the payload builder and session send path are unit-tested.

Production LOC +93/−2 (reporter plus connection lifecycle) / tests +166 / docs +1.
