### PR TITLE
refactor: consolidate background work policy and scheduling

### DIFF
--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -1,6 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Memory Core plugin module implements dreaming behavior.
-import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { resolveMemoryDreamingPluginConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import {
   DEFAULT_MEMORY_DEEP_DREAMING_MAX_PROMOTED_SNIPPET_TOKENS as DEFAULT_MEMORY_DREAMING_MAX_PROMOTED_SNIPPET_TOKENS,
@@ -55,18 +54,7 @@ type ManagedCronJobCreate = {
   };
 };
 
-type ManagedCronJobPatch = {
-  name?: string;
-  description?: string;
-  enabled?: boolean;
-  schedule?: CronSchedule;
-  sessionTarget?: "main" | "isolated";
-  wakeMode?: "now";
-  payload?: CronPayload;
-  delivery?: {
-    mode: "none";
-  };
-};
+type ManagedCronJobPatch = Partial<Omit<ManagedCronJobCreate, "declarationKey">>;
 
 type ManagedCronJobLike = {
   id: string;
@@ -127,12 +115,10 @@ type ShortTermPromotionDreamingConfig = {
   };
 };
 
-type ReconcileResult =
-  | { status: "unavailable"; removed: number }
-  | { status: "disabled"; removed: number }
-  | { status: "added"; removed: number }
-  | { status: "updated"; removed: number }
-  | { status: "noop"; removed: number };
+type ReconcileResult = {
+  status: "unavailable" | "disabled" | "added" | "updated" | "noop";
+  removed: number;
+};
 
 type LegacyPhaseMigrationMode = "enabled" | "disabled";
 
@@ -252,10 +238,6 @@ async function removeStaleManagedDreamingRows(cron: CronServiceLike): Promise<nu
   );
 }
 
-function compareOptionalStrings(a: string | undefined, b: string | undefined): boolean {
-  return a === b;
-}
-
 async function migrateLegacyPhaseDreamingCronJobs(params: {
   cron: CronServiceLike;
   legacyJobs: ManagedCronJobLike[];
@@ -295,10 +277,10 @@ function buildManagedDreamingPatch(
 ): ManagedCronJobPatch | null {
   const patch: ManagedCronJobPatch = {};
 
-  if (!compareOptionalStrings(normalizeOptionalString(job.name), desired.name)) {
+  if (normalizeOptionalString(job.name) !== desired.name) {
     patch.name = desired.name;
   }
-  if (!compareOptionalStrings(normalizeOptionalString(job.description), desired.description)) {
+  if (normalizeOptionalString(job.description) !== desired.description) {
     patch.description = desired.description;
   }
   if (job.enabled !== true) {
@@ -310,8 +292,8 @@ function buildManagedDreamingPatch(
   const scheduleTz = normalizeOptionalString(job.schedule?.tz);
   if (
     scheduleKind !== "cron" ||
-    !compareOptionalStrings(scheduleExpr, desired.schedule.expr) ||
-    !compareOptionalStrings(scheduleTz, desired.schedule.tz)
+    scheduleExpr !== desired.schedule.expr ||
+    scheduleTz !== desired.schedule.tz
   ) {
     patch.schedule = desired.schedule;
   }
@@ -331,7 +313,7 @@ function buildManagedDreamingPatch(
     desired.payload.kind === "systemEvent" ? desired.payload.text : desired.payload.message;
   const payloadNeedsUpdate =
     payloadKind !== normalizeLowercaseStringOrEmpty(desired.payload.kind) ||
-    !compareOptionalStrings(payloadToken, desiredPayloadToken) ||
+    payloadToken !== desiredPayloadToken ||
     (desired.payload.kind === "agentTurn" &&
       job.payload?.lightContext !== desired.payload.lightContext);
   if (payloadNeedsUpdate) {
@@ -475,20 +457,8 @@ async function reconcileShortTermDreamingCronJob(params: {
   }
 
   const desired = buildManagedDreamingCronJob(params.config);
-  if (managed.length === 0) {
-    await cron.add(desired);
-    const migratedLegacy = await migrateLegacyPhaseDreamingCronJobs({
-      cron,
-      legacyJobs: legacyPhaseJobs,
-      logger: params.logger,
-      mode: "enabled",
-    });
-    const removedStale = await removeStaleManagedDreamingRows(cron);
-    params.logger.info("memory-core: created managed dreaming cron job.");
-    return { status: "added", removed: migratedLegacy + removedStale };
-  }
-
-  if (!managed.some((job) => job.declarationKey === MANAGED_DREAMING_DECLARATION_KEY)) {
+  const primary = managed.find((job) => job.declarationKey === MANAGED_DREAMING_DECLARATION_KEY);
+  if (!primary) {
     await cron.add(desired);
     let removed = await migrateLegacyPhaseDreamingCronJobs({
       cron,
@@ -504,14 +474,14 @@ async function reconcileShortTermDreamingCronJob(params: {
       removed += 1;
     }
     removed += await removeStaleManagedDreamingRows(cron);
-    params.logger.info("memory-core: replaced legacy managed dreaming cron job identity.");
+    params.logger.info(
+      managed.length === 0
+        ? "memory-core: created managed dreaming cron job."
+        : "memory-core: replaced legacy managed dreaming cron job identity.",
+    );
     return { status: "added", removed };
   }
 
-  const primary = expectDefined(
-    managed.find((job) => job.declarationKey === MANAGED_DREAMING_DECLARATION_KEY),
-    "declaration-keyed managed dreaming job",
-  );
   const duplicates = sortManagedJobs(managed.filter((job) => job.id !== primary.id));
   let removed = await migrateLegacyPhaseDreamingCronJobs({
     cron,

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -37,7 +37,7 @@ let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatch
 let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acpx.js").tryDispatchAcpReplyHook;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 let replyRunRegistry: typeof import("./reply-run-registry.js").replyRunRegistry;
-let getActiveReplyRunCount: typeof import("./reply-run-registry.js").getActiveReplyRunCount;
+let getActiveReplyRunCount: typeof import("./reply-run-registry.registry.js").getActiveReplyRunCount;
 let createReplyOperation: typeof import("./reply-run-registry.js").createReplyOperation;
 let replyRunTesting: typeof import("./reply-run-registry.test-support.js").testing;
 
@@ -171,8 +171,8 @@ describe("dispatchReplyFromConfig ACP abort", () => {
     ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
     ({ tryDispatchAcpReplyHook } = await import("../../plugin-sdk/acpx.js"));
     ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
-    ({ replyRunRegistry, getActiveReplyRunCount, createReplyOperation } =
-      await import("./reply-run-registry.js"));
+    ({ replyRunRegistry, createReplyOperation } = await import("./reply-run-registry.js"));
+    ({ getActiveReplyRunCount } = await import("./reply-run-registry.registry.js"));
     ({ testing: replyRunTesting } = await import("./reply-run-registry.test-support.js"));
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.owner-settlement.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.owner-settlement.test.ts
@@ -33,15 +33,15 @@ import {
 import { createReplyDispatcher } from "./reply-dispatcher.js";
 import { buildTestCtx } from "./test-ctx.js";
 
-let getActiveReplyRunCount: typeof import("./reply-run-registry.js").getActiveReplyRunCount;
+let getActiveReplyRunCount: typeof import("./reply-run-registry.registry.js").getActiveReplyRunCount;
 let runAfterReplyOperationClear: typeof import("./reply-run-registry.js").runAfterReplyOperationClear;
 let resetReplyRunRegistry: typeof import("./reply-run-registry.test-support.js").testing.resetReplyRunRegistry;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 
 beforeAll(async () => {
   await globalBeforeAll0();
-  ({ getActiveReplyRunCount, runAfterReplyOperationClear } =
-    await import("./reply-run-registry.js"));
+  ({ getActiveReplyRunCount } = await import("./reply-run-registry.registry.js"));
+  ({ runAfterReplyOperationClear } = await import("./reply-run-registry.js"));
   ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
   const { testing } = await import("./reply-run-registry.test-support.js");
   resetReplyRunRegistry = () => testing.resetReplyRunRegistry();

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -35,7 +35,7 @@ import { createReplyDispatcher } from "./reply-dispatcher.js";
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 let createReplyOperation: typeof import("./reply-run-registry.js").createReplyOperation;
-let getActiveReplyRunCount: typeof import("./reply-run-registry.js").getActiveReplyRunCount;
+let getActiveReplyRunCount: typeof import("./reply-run-registry.registry.js").getActiveReplyRunCount;
 let replyRunRegistry: typeof import("./reply-run-registry.js").replyRunRegistry;
 let runAfterReplyOperationClear: typeof import("./reply-run-registry.js").runAfterReplyOperationClear;
 let resetReplyRunRegistry: typeof import("./reply-run-registry.test-support.js").testing.resetReplyRunRegistry;
@@ -105,7 +105,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
     const replyRunRegistryModule = await import("./reply-run-registry.js");
     createReplyOperation = replyRunRegistryModule.createReplyOperation;
-    getActiveReplyRunCount = replyRunRegistryModule.getActiveReplyRunCount;
+    ({ getActiveReplyRunCount } = await import("./reply-run-registry.registry.js"));
     replyRunRegistry = replyRunRegistryModule.replyRunRegistry;
     runAfterReplyOperationClear = replyRunRegistryModule.runAfterReplyOperationClear;
     const { testing } = await import("./reply-run-registry.test-support.js");

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -28,11 +28,8 @@ import {
   buildInboundUserContextPrefix,
   resolveInboundUserContextPromptJoiner,
 } from "./inbound-meta.js";
-import {
-  REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
-  createReplyOperation,
-  getActiveReplyRunCount,
-} from "./reply-run-registry.js";
+import { REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS, createReplyOperation } from "./reply-run-registry.js";
+import { getActiveReplyRunCount } from "./reply-run-registry.registry.js";
 import { testing as replyRunTesting } from "./reply-run-registry.test-support.js";
 import { routeReply } from "./route-reply.runtime.js";
 import { drainFormattedSystemEvents } from "./session-system-events.js";

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -28,7 +28,6 @@ export {
   clearReplyRunForResetBySessionId,
   expireStaleReplyRunBySessionId,
   forceClearReplyRunBySessionId,
-  getActiveReplyRunCount,
   isReplyRunAbortableForCompaction,
   isReplyRunActiveForSessionId,
   isReplyRunEvidenceStaleBySessionId,

--- a/src/gateway/server-plugin-subagent-runtime.test.ts
+++ b/src/gateway/server-plugin-subagent-runtime.test.ts
@@ -222,6 +222,14 @@ describe("plugin background completions", () => {
       subagent: { allowModelOverride: true, allowedModels: ["test-provider/override"] },
       model: "test-provider/override",
       allowed: true,
+      expectedText: "research:test-provider/override",
+    },
+    {
+      name: "provider-qualified model id",
+      subagent: { allowModelOverride: true, allowedModels: ["openrouter/test-model"] },
+      model: "openrouter/test-model",
+      allowed: true,
+      expectedText: "research:openrouter/openrouter/test-model",
     },
     {
       name: "model outside allowlist",
@@ -237,11 +245,11 @@ describe("plugin background completions", () => {
     },
   ])(
     "applies existing subagent override policy for $name",
-    async ({ subagent, model, allowed }) => {
+    async ({ subagent, model, allowed, expectedText }) => {
       config.plugins = { entries: { [PLUGIN_ID]: { subagent } } };
       const result = complete(createRuntime(), { model });
       if (allowed) {
-        await expect(result).resolves.toEqual({ text: "research:test-provider/override" });
+        await expect(result).resolves.toEqual({ text: expectedText });
         expect(isolated).toHaveBeenCalledOnce();
       } else {
         await expect(result).rejects.toThrow(/not trusted|not allowlisted|none of the entries/u);

--- a/src/gateway/server-plugin-subagent-runtime.ts
+++ b/src/gateway/server-plugin-subagent-runtime.ts
@@ -1,15 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
-import {
-  normalizeBuiltInProviderModelId,
-  stripSelfProviderModelPrefix,
-} from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeModelRef } from "../agents/model-ref-shared.js";
 import { parseModelRef } from "../agents/model-selection-normalize.js";
 import type { AgentWaitResult } from "../agents/run-wait.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
+import { compileModelAllowlist, type CompiledModelAllowlist } from "../plugins/model-allowlist.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import {
   bindGatewayContextResolver,
@@ -26,27 +22,6 @@ import {
   prepareInProcessAgentExecution,
 } from "./server-plugin-in-process-dispatch.js";
 import { resolvePluginSubagentToolsAlsoAllow } from "./server-plugin-runtime-client.js";
-
-function normalizePluginSubagentAllowedModelRef(raw: string): string | null {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return null;
-  }
-  if (trimmed === "*") {
-    return "*";
-  }
-  const parsed = parseModelCatalogRef(trimmed);
-  if (!parsed) {
-    return null;
-  }
-  // Operator allowlists already name canonical targets; keep policy setup independent
-  // of plugin metadata and provider-runtime discovery.
-  const modelId = normalizeBuiltInProviderModelId(
-    parsed.provider,
-    stripSelfProviderModelPrefix(parsed.provider, parsed.modelId),
-  );
-  return `${parsed.provider}/${modelId}`;
-}
 
 function resolvePluginSubagentRequestedModelRef(params: {
   provider?: string;
@@ -80,12 +55,8 @@ function normalizePluginSubagentRunRuntime(
   return harness && provider && model ? { harness, provider, model } : undefined;
 }
 
-type PluginSubagentOverridePolicy = {
+type PluginSubagentOverridePolicy = CompiledModelAllowlist & {
   allowModelOverride: boolean;
-
-  allowAnyModel: boolean;
-  hasConfiguredAllowlist: boolean;
-  allowedModels: Set<string>;
 };
 
 export type PluginSubagentOverridePolicies = Record<string, PluginSubagentOverridePolicy>;
@@ -97,34 +68,22 @@ export function resolvePluginSubagentOverridePolicies(
   const policies: PluginSubagentOverridePolicies = {};
   for (const [pluginId, entry] of Object.entries(normalized.entries)) {
     const allowModelOverride = entry.subagent?.allowModelOverride === true;
-    const hasConfiguredAllowlist = entry.subagent?.hasAllowedModelsConfig === true;
-    const configuredAllowedModels = entry.subagent?.allowedModels ?? [];
-    const allowedModels = new Set<string>();
-    let allowAnyModel = false;
-    for (const modelRef of configuredAllowedModels) {
-      const normalizedModelRef = normalizePluginSubagentAllowedModelRef(modelRef);
-      if (!normalizedModelRef) {
-        continue;
-      }
-      if (normalizedModelRef === "*") {
-        allowAnyModel = true;
-        continue;
-      }
-      allowedModels.add(normalizedModelRef);
-    }
+    const allowlist = compileModelAllowlist({
+      configured: entry.subagent?.hasAllowedModelsConfig === true,
+      values: entry.subagent?.allowedModels,
+      formatKey: (provider, model) => `${provider}/${model}`,
+    });
     if (
       !allowModelOverride &&
-      !hasConfiguredAllowlist &&
-      allowedModels.size === 0 &&
-      !allowAnyModel
+      !allowlist.configured &&
+      !allowlist.models.size &&
+      !allowlist.allowAny
     ) {
       continue;
     }
     policies[pluginId] = {
       allowModelOverride,
-      allowAnyModel,
-      hasConfiguredAllowlist,
-      allowedModels,
+      ...allowlist,
     };
   }
   return policies;
@@ -153,16 +112,16 @@ function authorizeFallbackModelOverride(params: {
         "plugins.entries.<id>.subagent.allowModelOverride",
     };
   }
-  if (policy.allowAnyModel) {
+  if (policy.allowAny) {
     return { allowed: true };
   }
-  if (policy.hasConfiguredAllowlist && policy.allowedModels.size === 0) {
+  if (policy.configured && policy.models.size === 0) {
     return {
       allowed: false,
       reason: `plugin "${pluginId}" configured subagent.allowedModels, but none of the entries normalized to a valid provider/model target.`,
     };
   }
-  if (policy.allowedModels.size === 0) {
+  if (policy.models.size === 0) {
     return { allowed: true };
   }
   const requestedModelRef = resolvePluginSubagentRequestedModelRef(params);
@@ -173,7 +132,7 @@ function authorizeFallbackModelOverride(params: {
         "fallback provider/model overrides that use an allowlist must resolve to a canonical provider/model target.",
     };
   }
-  if (policy.allowedModels.has(requestedModelRef)) {
+  if (policy.models.has(requestedModelRef)) {
     return { allowed: true };
   }
   return {
@@ -396,10 +355,7 @@ export function createGatewaySubagentRuntime(
           ...(params.lane && { lane: params.lane }),
           ...(params.cwd && { cwd: params.cwd }),
           ...(params.lightContext === true && { bootstrapContextMode: "lightweight" }),
-          // The gateway `agent` schema requires `idempotencyKey: NonEmptyString`,
-          // so fall back to a generated UUID when the caller omits it. Without
-          // this, plugin subagent runs (for example memory-core dreaming
-          // narrative) silently fail schema validation at the gateway.
+          // The Gateway agent schema requires a nonempty idempotency key.
           idempotencyKey: params.idempotencyKey || randomUUID(),
         },
         {

--- a/src/plugins/model-allowlist.ts
+++ b/src/plugins/model-allowlist.ts
@@ -1,0 +1,40 @@
+import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
+import {
+  normalizeBuiltInProviderModelId,
+  stripSelfProviderModelPrefix,
+} from "@openclaw/model-catalog-core/provider-model-id-normalization";
+
+export type CompiledModelAllowlist = {
+  configured: boolean;
+  allowAny: boolean;
+  models: Set<string>;
+};
+
+export function compileModelAllowlist(params: {
+  configured: boolean;
+  values?: readonly string[];
+  // Match the caller's resolved-target representation, including provider-qualified model IDs.
+  formatKey: (provider: string, model: string) => string;
+}): CompiledModelAllowlist {
+  const models = new Set<string>();
+  let allowAny = false;
+  for (const raw of params.values ?? []) {
+    const trimmed = raw.trim();
+    if (trimmed === "*") {
+      allowAny = true;
+      continue;
+    }
+    const parsed = parseModelCatalogRef(trimmed);
+    if (!parsed) {
+      continue;
+    }
+    // Operator allowlists already name canonical targets; keep policy setup independent
+    // of plugin metadata and provider-runtime discovery.
+    const modelId = normalizeBuiltInProviderModelId(
+      parsed.provider,
+      stripSelfProviderModelPrefix(parsed.provider, parsed.modelId),
+    );
+    models.add(params.formatKey(parsed.provider, modelId));
+  }
+  return { configured: params.configured, allowAny, models };
+}

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -1,9 +1,4 @@
 // Runtime LLM helpers adapt plugin provider hooks into the core model runtime.
-import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
-import {
-  normalizeBuiltInProviderModelId,
-  stripSelfProviderModelPrefix,
-} from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { asFiniteNumber, asFiniteNumberInRange } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { splitTrailingAuthProfile } from "../../agents/model-ref-profile.js";
@@ -23,6 +18,7 @@ import {
   resolveModelCostConfig,
 } from "../../utils/usage-format.js";
 import { normalizePluginsConfig } from "../config-state.js";
+import { compileModelAllowlist, type CompiledModelAllowlist } from "../model-allowlist.js";
 import { getPluginRuntimeGatewayRequestScope } from "./gateway-request-scope.js";
 import { createLlmCompleteError as completionError } from "./runtime-llm-error.js";
 import {
@@ -62,18 +58,12 @@ export type CreateRuntimeLlmOptions = {
   logger?: RuntimeLogger;
 };
 
-type RuntimeModelAllowlist = {
-  configured: boolean;
-  allowAny: boolean;
-  models: Set<string>;
-};
-
 type RuntimeLlmPolicy = {
   allowAgentIdOverride: boolean;
   allowModelOverride: boolean;
   allowAuthProfileOverride: boolean;
-  overrideModels: RuntimeModelAllowlist;
-  completionModels: RuntimeModelAllowlist;
+  overrideModels: CompiledModelAllowlist;
+  completionModels: CompiledModelAllowlist;
 };
 
 const defaultLogger = getChildLogger({ capability: "runtime.llm" });
@@ -299,47 +289,6 @@ export function finalizePluginLlmCompletion(params: {
   return { ...params.result, usage };
 }
 
-function normalizeAllowedModelRef(raw: string): string | null {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return null;
-  }
-  if (trimmed === "*") {
-    return "*";
-  }
-  const parsed = parseModelCatalogRef(trimmed);
-  if (!parsed) {
-    return null;
-  }
-  // Operator allowlists already name canonical targets; keep policy checks independent
-  // of plugin metadata and provider-runtime discovery.
-  const modelId = normalizeBuiltInProviderModelId(
-    parsed.provider,
-    stripSelfProviderModelPrefix(parsed.provider, parsed.modelId),
-  );
-  return modelKey(parsed.provider, modelId);
-}
-
-function normalizeModelAllowlist(params: {
-  configured: boolean;
-  values?: readonly string[];
-}): RuntimeModelAllowlist {
-  const models = new Set<string>();
-  let allowAny = false;
-  for (const modelRef of params.values ?? []) {
-    const normalizedModelRef = normalizeAllowedModelRef(modelRef);
-    if (!normalizedModelRef) {
-      continue;
-    }
-    if (normalizedModelRef === "*") {
-      allowAny = true;
-      continue;
-    }
-    models.add(normalizedModelRef);
-  }
-  return { configured: params.configured, allowAny, models };
-}
-
 function buildPolicyFromEntry(entry: {
   allowAgentIdOverride?: boolean;
   allowModelOverride?: boolean;
@@ -353,13 +302,15 @@ function buildPolicyFromEntry(entry: {
     allowAgentIdOverride: entry.allowAgentIdOverride === true,
     allowModelOverride: entry.allowModelOverride === true,
     allowAuthProfileOverride: entry.allowAuthProfileOverride === true,
-    overrideModels: normalizeModelAllowlist({
+    overrideModels: compileModelAllowlist({
       configured: entry.hasAllowedModelsConfig === true,
       values: entry.allowedModels,
+      formatKey: modelKey,
     }),
-    completionModels: normalizeModelAllowlist({
+    completionModels: compileModelAllowlist({
       configured: entry.hasAllowedCompletionModelsConfig === true,
       values: entry.allowedCompletionModels,
+      formatKey: modelKey,
     }),
   };
 }
@@ -433,35 +384,36 @@ function assertAllowedAuthProfileOverride(params: {
   );
 }
 
-function assertOverrideModelAllowed(params: {
+function assertModelAllowed(params: {
+  kind: "override" | "completion";
   resolvedModelRef: string | null;
   policy: RuntimeLlmPolicy | undefined;
   policyOwnerPluginId?: string;
 }): void {
-  const allowlist = params.policy?.overrideModels;
-  if (!allowlist?.configured) {
+  const allowlist =
+    params.kind === "override" ? params.policy?.overrideModels : params.policy?.completionModels;
+  if (!allowlist?.configured || allowlist.allowAny) {
     return;
   }
-  if (allowlist.allowAny) {
-    return;
-  }
+  const target = params.kind === "override" ? "model override" : "model";
   if (allowlist.models.size === 0) {
     throw completionError(
       "LLM_COMPLETION_NOT_AUTHORIZED",
-      "Plugin LLM completion model override allowlist has no valid models.",
+      `Plugin LLM completion ${target} allowlist has no valid models.`,
     );
   }
   if (!params.resolvedModelRef) {
     throw completionError(
       "LLM_COMPLETION_NOT_AUTHORIZED",
-      "Plugin LLM completion model override allowlist requires a resolvable provider/model target.",
+      `Plugin LLM completion ${target} allowlist requires a resolvable provider/model target.`,
     );
   }
   if (!allowlist.models.has(params.resolvedModelRef)) {
     const owner = params.policyOwnerPluginId ? ` for plugin "${params.policyOwnerPluginId}"` : "";
+    const usage = params.kind === "completion" ? " for completions" : "";
     throw completionError(
       "LLM_COMPLETION_NOT_AUTHORIZED",
-      `Plugin LLM completion model override "${params.resolvedModelRef}" is not allowlisted${owner}.`,
+      `Plugin LLM completion ${target} "${params.resolvedModelRef}" is not allowlisted${usage}${owner}.`,
     );
   }
 }
@@ -483,49 +435,17 @@ function assertAllowedModelOverride(params: {
   }
   // Host and operator policy are independent trust boundaries. When both
   // configure a restriction, an override must satisfy their intersection.
-  assertOverrideModelAllowed({
+  assertModelAllowed({
+    kind: "override",
     resolvedModelRef: params.resolvedModelRef,
     policy: params.authorityPolicy,
   });
-  assertOverrideModelAllowed({
+  assertModelAllowed({
+    kind: "override",
     resolvedModelRef: params.resolvedModelRef,
     policy: params.pluginPolicy,
     policyOwnerPluginId: params.pluginPolicyId,
   });
-}
-
-function assertCompletionModelAllowed(params: {
-  resolvedModelRef: string | null;
-  policy: RuntimeLlmPolicy | undefined;
-  policyOwnerPluginId?: string;
-}): void {
-  const policy = params.policy;
-  const allowlist = policy?.completionModels;
-  if (!allowlist?.configured) {
-    return;
-  }
-  if (allowlist.allowAny) {
-    return;
-  }
-  if (allowlist.models.size === 0) {
-    throw completionError(
-      "LLM_COMPLETION_NOT_AUTHORIZED",
-      "Plugin LLM completion model allowlist has no valid models.",
-    );
-  }
-  if (!params.resolvedModelRef) {
-    throw completionError(
-      "LLM_COMPLETION_NOT_AUTHORIZED",
-      "Plugin LLM completion model allowlist requires a resolvable provider/model target.",
-    );
-  }
-  if (!allowlist.models.has(params.resolvedModelRef)) {
-    const owner = params.policyOwnerPluginId ? ` for plugin "${params.policyOwnerPluginId}"` : "";
-    throw completionError(
-      "LLM_COMPLETION_NOT_AUTHORIZED",
-      `Plugin LLM completion model "${params.resolvedModelRef}" is not allowlisted for completions${owner}.`,
-    );
-  }
 }
 
 /**
@@ -596,8 +516,9 @@ export function createRuntimeLlm(
       }
       const normalizedSelection = normalizeModelRef(selection.provider, selection.modelId);
       const resolvedModelRef = modelKey(normalizedSelection.provider, normalizedSelection.model);
-      assertCompletionModelAllowed({ resolvedModelRef, policy: authorityPolicy });
-      assertCompletionModelAllowed({
+      assertModelAllowed({ kind: "completion", resolvedModelRef, policy: authorityPolicy });
+      assertModelAllowed({
+        kind: "completion",
         resolvedModelRef,
         policy: pluginPolicy,
         policyOwnerPluginId: pluginPolicyId,

--- a/src/process/command-queue.capacity-groups.ts
+++ b/src/process/command-queue.capacity-groups.ts
@@ -7,9 +7,6 @@ import { getQueueState, normalizeLane, peekLaneQueue } from "./command-queue.sta
 import type { CommandLaneBlockReason, CommandLaneSnapshot } from "./command-queue.types.js";
 import { CommandLane } from "./lanes.js";
 
-/** Drains a single lane. Supplied by command-queue.ts to avoid a cycle. */
-type DrainLaneFn = (lane: string) => void;
-
 /** Internal bounded drain contract used by the group arbiter. */
 type BoundedDrainLaneFn = (lane: string, maxStarts?: number) => number | void;
 
@@ -111,29 +108,10 @@ function getMemberActiveCount(lane: string): number {
   return getQueueState().lanes.get(lane)?.activeTaskIds.size ?? 0;
 }
 
-/**
- * Why `lane` cannot admit another task, or null if it can.
- *
- * Group capacity is always DERIVED from members' `activeTaskIds`, never tracked
- * in a separate counter. That is what makes timeout, abort, clear, reset and
- * stale-generation completion release capacity for free: they all remove the
- * task id, so the next admission decision simply sees a smaller number. The
- * only remaining obligation is that those paths re-drain the group.
- */
-function resolveLaneBlockReason(lane: string): CommandLaneBlockReason {
-  const state = getQueueState().lanes.get(lane);
-  if (state && state.activeTaskIds.size >= state.maxConcurrent) {
-    return "lane";
-  }
-  const group = getLaneGroup(lane);
-  if (!group) {
-    return null;
-  }
-  return resolveGroupBlockReason(group, lane, readGroupCapacity(group));
-}
-
 type GroupCapacity = { active: number; reserved: number };
 
+// Derive capacity from active task IDs so timeout, reset, and stale completion
+// handling share the queue's existing ownership accounting.
 function readGroupCapacity(group: LaneGroupState): GroupCapacity {
   let active = 0;
   let reserved = 0;
@@ -180,8 +158,8 @@ export function applyCommandLaneCapacity(snapshot: CommandLaneSnapshot): void {
 }
 
 export function canAdmitInGroup(lane: string): boolean {
-  const reason = resolveLaneBlockReason(lane);
-  return reason === null || reason === "lane";
+  const group = getLaneGroup(lane);
+  return !group || resolveGroupBlockReason(group, lane, readGroupCapacity(group)) === null;
 }
 
 /**
@@ -290,7 +268,7 @@ function resolveNextGroupLane(group: LaneGroupState): string | undefined {
  * group applies the same order across member queue heads so a completing lane
  * cannot synchronously reclaim shared capacity ahead of an older sibling.
  */
-function drainCommandLaneGroup(lane: string, drainLane: BoundedDrainLaneFn): void {
+export function drainCommandLaneGroup(lane: string, drainLane: BoundedDrainLaneFn): void {
   const group = getLaneGroup(lane);
   if (!group || DRAINING_GROUPS.has(group)) {
     return;
@@ -306,14 +284,4 @@ function drainCommandLaneGroup(lane: string, drainLane: BoundedDrainLaneFn): voi
   } finally {
     DRAINING_GROUPS.delete(group);
   }
-}
-
-/**
- * Re-drain the owning capacity group after a member changes state.
- *
- * The legacy exported name and callback surface stay stable for internal SDK
- * consumers; the supplied queue drain also supports the private bounded call.
- */
-export function drainGroupSiblings(lane: string, drainLane: DrainLaneFn): void {
-  drainCommandLaneGroup(lane, drainLane);
 }

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -11,7 +11,7 @@ import {
   applyCommandLaneCapacity,
   canAdmitInGroup,
   type CommandLaneGroupSpec,
-  drainGroupSiblings,
+  drainCommandLaneGroup,
   getGroupRegistry,
   getLaneGroup,
   installCommandLaneGroup,
@@ -435,7 +435,7 @@ function drainLane(
 
 function drainReadyCommandLane(lane: string, completedState?: LaneState): void {
   if (getLaneGroup(lane)) {
-    drainGroupSiblings(lane, drainLane);
+    drainCommandLaneGroup(lane, drainLane);
     return;
   }
   // An idle scoped lane may have been retired and recreated while an older

--- a/src/skills/workshop/experience-review-default.ts
+++ b/src/skills/workshop/experience-review-default.ts
@@ -8,13 +8,9 @@ import {
 
 const defaultScheduler = createSkillExperienceReviewScheduler({
   isSystemActive: async () => {
-    const [{ getActiveEmbeddedRunCount }, { getActiveReplyRunCount }] = await Promise.all([
-      import("../../agents/embedded-agent-runner/active-run-projections.js"),
-      import("../../auto-reply/reply/reply-run-registry.js"),
-    ]);
-    // The embedded count already folds in reply-backed runs. Keep the direct
-    // reply check explicit so this idle gate cannot regress if that contract changes.
-    return getActiveEmbeddedRunCount() > 0 || getActiveReplyRunCount() > 0;
+    const { getActiveEmbeddedRunCount } =
+      await import("../../agents/embedded-agent-runner/active-run-projections.js");
+    return getActiveEmbeddedRunCount() > 0;
   },
   prepareReview: async (candidate: ExperienceReviewCandidate) => {
     const { getRuntimeConfig } = await import("../../config/config.js");


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #136938: background work shares one queue now, but the surrounding plugin completion policy and maintenance scheduling still repeated the same decisions. This requested refactor removes 150 production lines while preserving existing behavior.

## Why This Change Was Made

Compile static model allowlists once for plugin subagents and LLM completions, and use one LLM membership check for override and completion restrictions. Each caller retains its existing model-key representation, error messages, and authorization policy; host and operator restrictions still intersect.

Call the queue's capacity-group arbiter directly and leave lane-width checks with the lane owner. Merge dreaming's missing-job creation paths while retaining sparse updates, operator-owned fields, add-before-delete ordering, and strict legacy replacement failures. Workshop now relies on the canonical active-run projection, which already includes reply-only runs.

## User Impact

No public API, config, persistence, concurrency limit, or visible UI change. Workshop and dreaming keep the three-run shared background budget and their existing cancellation and cleanup behavior. The deslop pass removes a redundant activity check, an obsolete wrapper, duplicated types and comparisons, and a stale dreaming-specific comment.

## Evidence

- 477 focused tests passed across 15 files: capacity groups, transactional queue publication, background owners, Gateway diagnostics, Workshop scheduling, plugin subagent and LLM authorization, isolated completions, dreaming reconciliation and startup cleanup, and reply lifecycle/dispatch.
- Existing policy tests retain empty/invalid/wildcard allowlists, host/operator intersection, and denial cases. One added case protects the subagent's provider-qualified model representation alongside existing LLM coverage.
- Independent Codex review: no actionable P0–P2 findings. Formatting and diff checks pass.
- Production: +107/-257 = **−150 lines**. Tests: +20/-15 = **+5 lines**. No dependency or SDK surface changes.
- CI artifact build passed. The changed-file gate exposed an unused reply-count re-export after Workshop stopped using it; the export was removed and four test files now import the registry owner. The complete final changed-file gate passed, including typecheck, lint, dead-export scans, plugin boundaries and runtime-cycle guards; [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33723650563) completed successfully on its first attempt, including Windows and the required `openclaw/ci-gate`. This is behavior-preserving refactoring; validation does not claim paid-provider live inference.

Merged through the native guarded workflow as [8ffa76c2803](https://github.com/openclaw/openclaw/commit/8ffa76c28032077e56301b5b9c69dc31e0c47065). ClawSweeper found no code/security defects; its generic data-model compatibility flag is [addressed with unchanged-contract evidence](https://github.com/openclaw/openclaw/pull/137086#issuecomment-5521749839).
