### PR TITLE
fix(codex): accept native empty tool catalogs

### DIFF
--- a/extensions/codex/src/app-server/native-tool-catalog.test.ts
+++ b/extensions/codex/src/app-server/native-tool-catalog.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseCodexNativeToolCatalog } from "./native-tool-catalog.js";
+import { codexDynamicToolsFingerprint } from "./thread-fingerprints.js";
+
+const threadId = "native-thread";
+const tool = {
+  type: "function" as const,
+  name: "example",
+  description: "Synthetic tool",
+  inputSchema: { type: "object" },
+};
+
+describe("parseCodexNativeToolCatalog", () => {
+  it.each([{}, { dynamic_tools: null }, { dynamic_tools: [] }])(
+    "restores the native empty representation %j without accepting a missing nonempty catalog",
+    (catalog) => {
+      const metadata = { id: threadId, ...catalog };
+      expect(
+        parseCodexNativeToolCatalog(metadata, threadId, codexDynamicToolsFingerprint([])),
+      ).toEqual([]);
+      expect(() =>
+        parseCodexNativeToolCatalog(metadata, threadId, codexDynamicToolsFingerprint([tool])),
+      ).toThrow("native tool catalog is missing, corrupt, or changed");
+    },
+  );
+
+  it.each([
+    null,
+    {},
+    { id: "other" },
+    ...[false, 0, "", {}, [null]].map((dynamic_tools) => ({ id: threadId, dynamic_tools })),
+  ])("rejects invalid metadata %j", (metadata) => {
+    expect(() => parseCodexNativeToolCatalog(metadata, threadId)).toThrow(
+      "native tool catalog is missing, corrupt, or changed",
+    );
+  });
+
+  it("retains nonempty declarations and the pinned false-defer omission", () => {
+    expect(
+      parseCodexNativeToolCatalog(
+        { id: threadId, dynamic_tools: [{ ...tool, deferLoading: false }] },
+        threadId,
+        codexDynamicToolsFingerprint([tool]),
+      ),
+    ).toEqual([tool]);
+  });
+});

--- a/extensions/codex/src/app-server/native-tool-catalog.ts
+++ b/extensions/codex/src/app-server/native-tool-catalog.ts
@@ -18,7 +18,7 @@ export function hasCodexNativeToolCatalog(
   return binding?.connectionScope === "supervision" && !binding.pendingSupervisionBranch;
 }
 
-/** Pinned serde omits false deferLoading; every other declaration byte remains native-owned. */
+/** Pinned serde omits empty catalogs and false deferLoading; declarations remain native-owned. */
 export function parseCodexNativeToolCatalog(
   metadata: unknown,
   threadId: string,
@@ -28,12 +28,11 @@ export function parseCodexNativeToolCatalog(
     new Error(
       "The canonical Codex native tool catalog is missing, corrupt, or changed; the thread is preserved. Reconnect and inspect its native metadata before retrying.",
     );
-  if (
-    !isJsonObject(metadata) ||
-    metadata.id !== threadId ||
-    !Array.isArray(metadata.dynamic_tools) ||
-    Buffer.byteLength(JSON.stringify(metadata.dynamic_tools)) > 1024 * 1024
-  ) {
+  if (!isJsonObject(metadata) || metadata.id !== threadId) {
+    throw fail();
+  }
+  const catalog = metadata.dynamic_tools ?? [];
+  if (!Array.isArray(catalog) || Buffer.byteLength(JSON.stringify(catalog)) > 1024 * 1024) {
     throw fail();
   }
   const names = new Set<string>();
@@ -65,7 +64,7 @@ export function parseCodexNativeToolCatalog(
       ...(value.deferLoading === true ? { deferLoading: true } : {}),
     };
   };
-  const tools = metadata.dynamic_tools.map((value): CodexDynamicToolSpec => {
+  const tools = catalog.map((value): CodexDynamicToolSpec => {
     if (!isJsonObject(value) || value.type !== "namespace") {
       return readFunction(value);
     }

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -7412,7 +7412,7 @@ describe("runCodexAppServerAttempt", () => {
         rolloutPath,
         JSON.stringify({
           type: "session_meta",
-          payload: { id: "thread-existing", model_provider: "openai", dynamic_tools: [] },
+          payload: { id: "thread-existing", model_provider: "openai" },
         }) + "\n",
       );
       const pluginConfig = {


### PR DESCRIPTION
Closes #137079

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users continuing a supervised Codex conversation could not start its next turn or create a canonical message fork when that conversation had no registered dynamic tools. OpenClaw reported a corrupt native catalog even though the native thread was valid and preserved.

## Why This Change Was Made

Codex 0.153.0 (also verified with 0.152.1) omits empty catalogs in native metadata and restores absent/null values as an empty vector. Normalize that representation once in the canonical catalog reader, keeping the existing thread-identity, size, declaration and fingerprint checks. The ordinary adoption sibling already follows this contract; changing native metadata, rotating the conversation or adding a retry would repair the wrong owner.

The fix is net-negative production code: **production +7/−8 (net −1); tests +48/−1 (net +47)**. No config/default, API, protocol, schema or dependency changes.

## User Impact

Supervised conversations created with no dynamic tools can resume and retain their native history. Their canonical forks can validate the same empty catalog. Invalid present catalog values and an omitted catalog that conflicts with a nonempty bound fingerprint still fail closed.

## Evidence

- Pre-fix: omitted/null parser cases failed while explicit empty passed; the existing supported stdio/proxy supervised-attempt cases failed before `turn/start` after their fixture was corrected to match native serialization.
- Post-fix: **379 tests passed** across `native-tool-catalog.test.ts`, `run-attempt.test.ts`, and `thread-lifecycle.binding.test.ts`.
- `node scripts/check-changed.mjs -- extensions/codex/src/app-server/native-tool-catalog.ts extensions/codex/src/app-server/native-tool-catalog.test.ts extensions/codex/src/app-server/run-attempt.test.ts` passed, including plugin production/test typechecks, doctor and boundary guards, zero-unused-export scans, lint, and zero runtime import cycles. `git diff --check` passed.
- Actual pinned native binary, not mocked transport: fresh temporary HOME/CODEX_HOME, child-only environment and blocked external endpoints; `thread/start` → synthetic `thread/inject_items` → unsubscribe → native catalog read → resume → read → fork → child read. Before patch, OpenClaw's actual loader rejected omitted-empty source/resumed/forked metadata. After patch, all three reads succeeded, resume preserved the original ID, fork lineage matched, and the process exited cleanly. The coordinator independently reran this proof successfully.
- Fresh autoreview and a separate frozen-patch independent review both found no actionable P0–P2 issues.
- Exact dependency contract personally read in pinned [Codex commit 41e22fee981a63b3698df7ed36bad393cda24715](https://github.com/openai/codex/commit/41e22fee981a63b3698df7ed36bad393cda24715): `codex-rs/rollout/src/recorder.rs:892–896`, `codex-rs/protocol/src/protocol.rs:3072–3077`, `codex-rs/protocol/src/dynamic_tools.rs:165–175`, `codex-rs/history/src/lib.rs:325–337`, and `codex-rs/core/src/session/mod.rs:705–709`. Source inspected at `rust-v0.153.0`; the same native before/after proof also passed on 0.152.1 before integration.

Proof scope: no inference, credentials, real operator state, or Gateway UI gesture. This parser-only change has no visual output, import/lazy-boundary, packaging, or generated-artifact change; no full runtime build was run. Rebased on current main `a828190b2953483a4a181ff5d23c283e92713d47`, retaining its model/auth ownership fences; all proof and both reviews repeated on candidate `8dc40afcba6d5ddc92e4f341418546aa62dfd74d`. Exact-head CI and native landing checks are pending publication.
