### PR TITLE
fix(gateway): let operators abandon a worker placement whose paired device is offline

### DIFF
--- a/docs/gateway/cloud-sessions.md
+++ b/docs/gateway/cloud-sessions.md
@@ -94,7 +94,7 @@ Suspension never interrupts work: sessions with an active turn, queued messages,
 
 ## What stays with the Gateway
 
-Placement is disposable; the session is not. The transcript, the last-reconciled workspace files, placement history, and every provider credential live with the Gateway in all placements. After a clean reclaim or idle suspension, the next message provisions a replacement — warm when an image exists, cold otherwise. Failed placements keep their diagnostic visible; resolve pending cleanup, then redispatch and retry. An offline paired device is different by design: the placement stays active and waits for the device to reconnect, and **Continue on Gateway…** is an explicit action that can lose unsynced device files. Workspace changes made after the last reconciliation are the only loss window, and clean stops (including auto-suspension) reconcile before releasing the machine.
+Placement is disposable; the session is not. The transcript, the last-reconciled workspace files, placement history, and every provider credential live with the Gateway in all placements. After a clean reclaim or idle suspension, the next message provisions a replacement — warm when an image exists, cold otherwise. Failed placements keep their diagnostic visible; resolve pending cleanup, then redispatch and retry. An offline paired device is different by design: the placement stays active and waits for the device to reconnect, and **Continue on Gateway…** works while the device is offline, resuming from the last Gateway-synced workspace and discarding unsynced device changes. Workspace changes made after the last reconciliation are the only loss window, and clean stops (including auto-suspension) reconcile before releasing the machine.
 
 ## Related
 

--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -412,7 +412,7 @@ To stop a running turn in the Control UI, use chat **Stop** or `/stop` first. On
 
 Archiving or deleting a non-main cloud-worker session with an active placement first interrupts and drains its current work, then safely reclaims the worker. The Gateway records the archive or deletion only after final reconciliation and safe teardown succeed. If reclaim is unavailable, fails, or the placement is transitioning or failed without proof that its environment is gone, the operation reports an error and retains the session and recovery state; it never force-discards unsynced work. Restoring an archived session retains reclaimed placement metadata so the next turn can dispatch a fresh worker with the same workspace profile.
 
-For a broken or runaway cloud environment, an administrator can call the admin-only `environments.destroy` method with `{ "force": true }` as a last resort. Forced teardown durably marks the placement failed and abandons any unreconciled remote result before destroying the environment.
+For a broken or runaway cloud environment, an administrator can call the admin-only `environments.destroy` method with `{ "force": true }` as a last resort. Forced teardown durably marks the placement failed and abandons any unreconciled remote result before destroying the environment. For an unreachable paired device, forced destroy succeeds without waiting for reconnection and discards unsynced device changes.
 
 The equivalent write-scoped session RPC is:
 

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -16,12 +16,16 @@ import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from 
 import { SessionMutationAuthorizationChangedError } from "../session-sharing.js";
 import { resolveDevicePlacementEligibility } from "../worker-environments/device-placement-eligibility.js";
 import { selectDevicePlacementCandidates } from "../worker-environments/device-placement-selector.js";
+import { DEVICE_WORKER_PROVIDER_ID } from "../worker-environments/device-provider-identity.js";
 import { resolveWorkerPlacementDestination } from "../worker-environments/placement-destination.js";
 import {
   projectWorkerSessionPlacement,
   readWorkerPlacementIdentity,
 } from "../worker-environments/placement-projector.js";
-import type { WorkerSessionPlacementRecord } from "../worker-environments/placement-record.js";
+import {
+  isForceAbandonedWorkerPlacement,
+  type WorkerSessionPlacementRecord,
+} from "../worker-environments/placement-record.js";
 import {
   resolveWorkerPlacementCapabilities,
   resolveWorkerPlacementSessionRuntime,
@@ -354,9 +358,21 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
         placement: existingPlacement,
       })
     ) {
+      let providerId: string | undefined;
+      try {
+        const identity = readWorkerPlacementIdentity(
+          existingPlacement,
+          context.workerEnvironmentService,
+        );
+        providerId = identity?.providerId;
+      } catch {
+        // Missing inventory proof must retain the refusal even when its label is unknown.
+      }
       respondInvalidWorkerSession(
         respond,
-        "cloud worker environment must be stopped before redispatch; use Stop cloud worker",
+        providerId === DEVICE_WORKER_PROVIDER_ID
+          ? "device worker placement must be abandoned before redispatch; use Continue on Gateway"
+          : "cloud worker environment must be stopped before redispatch; use Stop cloud worker",
       );
       return;
     }
@@ -528,7 +544,13 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
       return;
     }
     const existingPlacement = placementReader.getMany([sessionId]).get(sessionId);
-    if (existingPlacement?.state !== "active" && existingPlacement?.state !== "draining") {
+    const retryAbandonment =
+      "abandonSource" in params && isForceAbandonedWorkerPlacement(existingPlacement);
+    if (
+      existingPlacement?.state !== "active" &&
+      existingPlacement?.state !== "draining" &&
+      !retryAbandonment
+    ) {
       respondInvalidWorkerSession(
         respond,
         `session cannot move from placement ${existingPlacement?.state ?? "local"}`,

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -8,6 +8,7 @@ import {
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "../../plugins/runtime.js";
+import { FORCED_WORKER_ABANDONMENT_ERROR } from "../worker-environments/placement-record.js";
 import type { WorkerSessionPlacementRecord } from "../worker-environments/placement-store.js";
 import type { WorkerPlacementDispatchRequest } from "../worker-environments/service-contract.js";
 import { readSessionsMutationVersion } from "./session-change-event.js";
@@ -546,53 +547,68 @@ describe("sessions.dispatch", () => {
     );
   });
 
-  it("moves an active session back to the Gateway with exact-source CAS", async () => {
-    mocks.resolveTarget.mockReturnValue(
-      targetWithEntry({
-        sessionId,
-        worktree: { id: "worktree-1", branch: "openclaw/cloud-test", repoRoot: "/repo" },
-      }),
-    );
-    mocks.findLiveByOwner.mockReturnValue({
-      id: "worktree-1",
-      ownerKind: "session",
-      ownerId: sessionKey,
-    });
-    const move = vi.fn().mockResolvedValue({ state: "local", generation: 7 });
-    const source = { generation: 4, environmentId: "environment-previous", ownerEpoch: 1 };
+  it.each(["active", "abandoned"] as const)(
+    "moves an %s session back to the Gateway with exact-source CAS",
+    async (sourceState) => {
+      mocks.resolveTarget.mockReturnValue(
+        targetWithEntry({
+          sessionId,
+          worktree: { id: "worktree-1", branch: "openclaw/cloud-test", repoRoot: "/repo" },
+        }),
+      );
+      mocks.findLiveByOwner.mockReturnValue({
+        id: "worktree-1",
+        ownerKind: "session",
+        ownerId: sessionKey,
+      });
+      const move = vi.fn().mockResolvedValue({ state: "local", generation: 7 });
+      const source = { generation: 4, environmentId: "environment-previous", ownerEpoch: 1 };
+      const placement =
+        sourceState === "active"
+          ? activePlacementRecord()
+          : {
+              ...failedPlacementRecord(),
+              recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+            };
 
-    const respond = await invokeSessionMove(
-      makeContext({
-        workerPlacementDispatchService: { dispatch: vi.fn(), move } as never,
-        workerSessionPlacementService: {
-          getMany: () => new Map([[sessionId, activePlacementRecord()]]),
+      const respond = await invokeSessionMove(
+        makeContext({
+          workerPlacementDispatchService: { dispatch: vi.fn(), move } as never,
+          workerSessionPlacementService: {
+            getMany: () => new Map([[sessionId, placement]]),
+          },
+        }),
+        {
+          expected: source,
+          target: { kind: "gateway" },
+          ...(sourceState === "abandoned" ? { abandonSource: true } : {}),
         },
-      }),
-      { expected: source, target: { kind: "gateway" } },
-    );
+      );
 
-    expect(move).toHaveBeenCalledWith(
-      {
-        sessionId,
-        sessionKey,
-        agentId: "main",
-        source,
-        target: { kind: "gateway" },
-      },
-      expect.any(Function),
-      undefined,
-    );
-    expect(respond).toHaveBeenCalledWith(
-      true,
-      {
-        ok: true,
-        key: sessionKey,
-        sessionId,
-        placement: { state: "local", generation: 7 },
-      },
-      undefined,
-    );
-  });
+      expect(move).toHaveBeenCalledWith(
+        {
+          sessionId,
+          sessionKey,
+          agentId: "main",
+          source,
+          target: { kind: "gateway" },
+          ...(sourceState === "abandoned" ? { abandonSource: true } : {}),
+        },
+        expect.any(Function),
+        undefined,
+      );
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        {
+          ok: true,
+          key: sessionKey,
+          sessionId,
+          placement: { state: "local", generation: 7 },
+        },
+        undefined,
+      );
+    },
+  );
 
   it("resolves a worker move through the canonical destination owner", async () => {
     mocks.resolveTarget.mockReturnValue(
@@ -630,33 +646,42 @@ describe("sessions.dispatch", () => {
     );
   });
 
-  it("rejects a move when the session is no longer worker-owned", async () => {
-    mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
-    const move = vi.fn();
+  it.each([
+    { state: "local", recoveryError: null, abandonSource: undefined },
+    { state: "failed", recoveryError: "worker failed", abandonSource: true },
+    { state: "failed", recoveryError: FORCED_WORKER_ABANDONMENT_ERROR, abandonSource: undefined },
+  ] as const)(
+    "rejects a $state move without an explicit forced-abandonment retry",
+    async (source) => {
+      mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
+      const move = vi.fn();
 
-    const respond = await invokeSessionMove(
-      makeContext({
-        workerPlacementDispatchService: { dispatch: vi.fn(), move } as never,
-        workerSessionPlacementService: {
-          getMany: () => new Map([[sessionId, { state: "local" } as never]]),
+      const respond = await invokeSessionMove(
+        makeContext({
+          workerPlacementDispatchService: { dispatch: vi.fn(), move } as never,
+          workerSessionPlacementService: {
+            getMany: () =>
+              new Map([[sessionId, { ...failedPlacementRecord(), ...source } as never]]),
+          },
+        }),
+        {
+          expected: { generation: 4, environmentId: "environment-previous", ownerEpoch: 1 },
+          target: { kind: "gateway" },
+          ...(source.abandonSource ? { abandonSource: true } : {}),
         },
-      }),
-      {
-        expected: { generation: 4, environmentId: "environment-previous", ownerEpoch: 1 },
-        target: { kind: "gateway" },
-      },
-    );
+      );
 
-    expect(move).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({
-        code: ErrorCodes.INVALID_REQUEST,
-        message: "session cannot move from placement local",
-      }),
-    );
-  });
+      expect(move).not.toHaveBeenCalled();
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          code: ErrorCodes.INVALID_REQUEST,
+          message: `session cannot move from placement ${source.state}`,
+        }),
+      );
+    },
+  );
 
   it.each([undefined, 2, 3])(
     "redispatches a reclaimed session with correlated identity (environment epoch: %s)",
@@ -780,68 +805,57 @@ describe("sessions.dispatch", () => {
     );
   });
 
-  it("rejects failed-placement redispatch while its environment remains live", async () => {
-    mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
-    const dispatch = vi.fn();
+  it.each([
+    [
+      "fake",
+      "failed",
+      "cloud worker environment must be stopped before redispatch; use Stop cloud worker",
+    ],
+    [
+      "device",
+      "attached",
+      "device worker placement must be abandoned before redispatch; use Continue on Gateway",
+    ],
+    [
+      "unknown",
+      "unavailable",
+      "cloud worker environment must be stopped before redispatch; use Stop cloud worker",
+    ],
+  ])(
+    "rejects failed-placement redispatch while its %s environment remains live",
+    async (providerId, state, message) => {
+      mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
+      const dispatch = vi.fn();
 
-    const respond = await invoke(
-      makeContext({
-        workerEnvironmentService: {
-          get: vi.fn(() => ({ state: "failed", leaseId: "lease-previous" })),
-          supportsExecutionMode: () => true,
-        } as never,
-        workerPlacementDispatchService: { dispatch },
-        workerSessionPlacementService: {
-          getMany: () => new Map([[sessionId, failedPlacementRecord()]]),
-        },
-      }),
-    );
+      const respond = await invoke(
+        makeContext({
+          workerEnvironmentService: {
+            get: vi.fn(() => {
+              if (state === "unavailable") {
+                throw new Error("environment inventory unavailable");
+              }
+              return { state, leaseId: "lease-previous", ownerEpoch: 1, providerId };
+            }),
+            supportsExecutionMode: () => true,
+          } as never,
+          workerPlacementDispatchService: { dispatch },
+          workerSessionPlacementService: {
+            getMany: () => new Map([[sessionId, failedPlacementRecord()]]),
+          },
+        }),
+      );
 
-    expect(dispatch).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({
-        code: ErrorCodes.INVALID_REQUEST,
-        message:
-          "cloud worker environment must be stopped before redispatch; use Stop cloud worker",
-      }),
-    );
-  });
-
-  it("rejects failed-placement redispatch when environment proof is unavailable", async () => {
-    mocks.resolveTarget.mockReturnValue(targetWithEntry({ sessionId }));
-    const dispatch = vi.fn();
-
-    const respond = await invoke(
-      makeContext({
-        // Proof unavailable = the inventory cannot answer, not "row absent";
-        // an absent row proves the environment is gone and permits redispatch.
-        workerEnvironmentService: {
-          get: vi.fn(() => {
-            throw new Error("environment inventory unavailable");
-          }),
-          supportsExecutionMode: () => true,
-        } as never,
-        workerPlacementDispatchService: { dispatch },
-        workerSessionPlacementService: {
-          getMany: () => new Map([[sessionId, failedPlacementRecord()]]),
-        },
-      }),
-    );
-
-    expect(failedPlacementRecord().environmentId).not.toBeNull();
-    expect(dispatch).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({
-        code: ErrorCodes.INVALID_REQUEST,
-        message:
-          "cloud worker environment must be stopped before redispatch; use Stop cloud worker",
-      }),
-    );
-  });
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          code: ErrorCodes.INVALID_REQUEST,
+          message,
+        }),
+      );
+    },
+  );
 
   it.each([
     ["CLI", "claude-cli"],

--- a/src/gateway/server-worker-placement-workspace-recovery.ts
+++ b/src/gateway/server-worker-placement-workspace-recovery.ts
@@ -1,6 +1,6 @@
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { FORCED_WORKER_ABANDONMENT_ERROR } from "./worker-environments/placement-force-abandon.js";
+import { FORCED_WORKER_ABANDONMENT_ERROR } from "./worker-environments/placement-record.js";
 import type { WorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 import { recoverWorkerWorkspaceReconciliation } from "./worker-environments/workspace-reconcile.js";
 

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -421,9 +421,11 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
           });
           const result = await raceNodeWorkerOperation(operation, signal);
           if (!result.ok) {
-            throw new Error(
-              `node worker environment stop failed (${result.error?.code ?? "UNAVAILABLE"})`,
-            );
+            const code = result.error?.code ?? "UNAVAILABLE";
+            const message = `node worker environment stop failed (${code})`;
+            throw RETRYABLE_TRANSPORT_CODES.has(code)
+              ? new WorkerTunnelOwnerDisconnectedError(message)
+              : new Error(message);
           }
         }
       } catch (error) {

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -393,7 +393,10 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       try {
         // Remote-exec runtimes own their processes separately; this is only the embedded
         // worker's environment lifetime, not a new requirement on the workspace transport.
-        if (entry.executionMode === "worker-turn" && reason === undefined) {
+        if (
+          entry.executionMode === "worker-turn" &&
+          (reason === undefined || reason === "operator-abandon")
+        ) {
           const signal = AbortSignal.timeout(DEFAULT_COMMAND_TIMEOUT_MS);
           const { transport, node } = await findNode(entry, signal);
           if (node.workerHost.environmentSession !== NODE_WORKER_ENVIRONMENT_SESSION_VERSION) {
@@ -423,6 +426,15 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
             );
           }
         }
+      } catch (error) {
+        if (
+          reason !== "operator-abandon" ||
+          !(error instanceof WorkerTunnelOwnerDisconnectedError)
+        ) {
+          throw error;
+        }
+        // Forced abandonment already fenced the placement; draining rotates its owner epoch.
+        // An offline node keeps the stale epoch and cannot publish results after reconnecting.
       } finally {
         stopping = false;
         await options.workspaceTransfer.close(entry.environmentId);
@@ -431,8 +443,8 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
         retiredEntries.delete(entry);
       }
     })().finally(() => {
-      // Failed or unconfirmed provider teardown keeps the exact owner retryable. Only
-      // physical-stop proof may release it and make subsequent stops idempotent.
+      // Failed teardown keeps the exact owner retryable; confirmed stop or explicit
+      // abandonment releases it and makes subsequent stops idempotent.
       if (retiredEntries.has(entry)) {
         entry.stopPromise = undefined;
       }
@@ -459,7 +471,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       // source of the retired scope; bundle metadata is not cleanup authority.
       const record = options.getEnvironment(environmentId);
       if (record?.nodeDeviceId && (ownerEpoch === undefined || record.ownerEpoch === ownerEpoch)) {
-        if (reason) {
+        if (reason === "provider-destroying" || reason === "provider-destroyed") {
           // Provider teardown owns the whole dedicated machine. No remote session tuple is
           // needed for local transfer cleanup; durable ownership remains until its proof.
           operations.push(options.workspaceTransfer.close(environmentId));
@@ -470,16 +482,19 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
           const sessionId = record.attachedSessionIds[0];
           if (sessionId) {
             operations.push(
-              stopEnvironmentOwner({
-                deviceId: record.nodeDeviceId,
-                environmentId,
-                ownerEpoch: record.ownerEpoch,
-                sessionId,
-                executionMode:
-                  record.profileSnapshot.executionMode === "remote-exec"
-                    ? "remote-exec"
-                    : "worker-turn",
-              }),
+              stopEnvironmentOwner(
+                {
+                  deviceId: record.nodeDeviceId,
+                  environmentId,
+                  ownerEpoch: record.ownerEpoch,
+                  sessionId,
+                  executionMode:
+                    record.profileSnapshot.executionMode === "remote-exec"
+                      ? "remote-exec"
+                      : "worker-turn",
+                },
+                reason,
+              ),
             );
           }
         }

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -1,5 +1,5 @@
 import type { WorkerDispatchPlacementStore } from "./placement-dispatch-failure.js";
-import { placementTurnOwner } from "./placement-record.js";
+import { FORCED_WORKER_ABANDONMENT_ERROR, placementTurnOwner } from "./placement-record.js";
 import { isCurrentWorkerWorkspacePendingResultOwner } from "./placement-workspace-result.js";
 import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
@@ -9,29 +9,7 @@ import {
   workerWorkspaceResultRef,
 } from "./workspace-result-staging.js";
 
-export const FORCED_WORKER_ABANDONMENT_ERROR =
-  "Worker result abandoned by forced operator teardown";
-
-async function tryResolveWorkspacePath(
-  resolveWorkspacePath: (placement: {
-    sessionId: string;
-    sessionKey: string;
-    agentId: string;
-  }) => Promise<string>,
-  placement: { sessionId: string; sessionKey: string; agentId: string },
-  onCleanupError?: (error: unknown) => void,
-): Promise<string | undefined> {
-  try {
-    return await resolveWorkspacePath(placement);
-  } catch (error) {
-    // Forced teardown is the last-resort state owner. If the session/worktree is
-    // already gone, skip local repair/ref cleanup and still release the claim.
-    reportCleanupError(onCleanupError, error);
-    return undefined;
-  }
-}
-
-function reportCleanupError(
+export function reportWorkerAbandonmentCleanupError(
   onCleanupError: ((error: unknown) => void) | undefined,
   error: unknown,
 ): void {
@@ -87,7 +65,7 @@ export async function forceAbandonWorkerEnvironment(params: {
           journalCleanups.push({ owner, placement, journal });
         }
       } catch (error) {
-        reportCleanupError(params.onCleanupError, error);
+        reportWorkerAbandonmentCleanupError(params.onCleanupError, error);
         retainedJournalSessions.add(owner.sessionId);
       }
     }
@@ -171,7 +149,7 @@ export async function forceAbandonWorkerEnvironment(params: {
       const root = await params.resolveWorkspacePath(cleanup.placement);
       await recoverWorkerWorkspaceReconciliation({ root, journal: cleanup.journal });
     } catch (error) {
-      reportCleanupError(params.onCleanupError, error);
+      reportWorkerAbandonmentCleanupError(params.onCleanupError, error);
       retainedJournalSessions.add(cleanup.owner.sessionId);
     }
   }
@@ -185,21 +163,14 @@ export async function forceAbandonWorkerEnvironment(params: {
   }
   for (const cleanup of stagedResultCleanups) {
     try {
-      const root = await tryResolveWorkspacePath(
-        params.resolveWorkspacePath,
-        cleanup.placement,
-        params.onCleanupError,
-      );
-      if (!root) {
-        continue;
-      }
+      const root = await params.resolveWorkspacePath(cleanup.placement);
       for (const stagedResultRef of cleanup.refs) {
         if (await hasWorkerWorkspaceResultRef({ root, stagedResultRef })) {
           await deleteStagedWorkerWorkspaceResult({ root, stagedResultRef });
         }
       }
     } catch (error) {
-      reportCleanupError(params.onCleanupError, error);
+      reportWorkerAbandonmentCleanupError(params.onCleanupError, error);
     }
   }
 }

--- a/src/gateway/worker-environments/placement-move-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-move-abandon.test.ts
@@ -178,6 +178,25 @@ describe("offline device placement abandonment", () => {
     },
   );
 
+  it("abandons a device whose supervisor proof disappears after discovery", async () => {
+    const { harness, active, environments, reconnect, invoke } = await deviceTeardown(false);
+    reconnect();
+    invoke.mockResolvedValueOnce({
+      ok: false,
+      error: { code: "PRIVATE_DIALECT_UNAVAILABLE" },
+    });
+
+    await expect(harness.service.move(requestFor(active))).resolves.toMatchObject({
+      state: "local",
+    });
+    expect(invoke).toHaveBeenCalledOnce();
+    expect(environments.get(active.environmentId)).toMatchObject({
+      state: "failed",
+      leaseId: null,
+      lastError: FORCED_WORKER_ABANDONMENT_ERROR,
+    });
+  });
+
   it("force destroys an unreachable device and accepts its already fenced placement for abandonment", async () => {
     const { harness, active, environments } = await deviceTeardown(false);
     const respond = vi.fn();

--- a/src/gateway/worker-environments/placement-move-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-move-abandon.test.ts
@@ -1,17 +1,26 @@
 import fs from "node:fs/promises";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import { environmentsHandlers } from "../server-methods/environments.js";
+import { createNodeWorkerTunnelManager } from "./node-worker-tunnel.js";
+import { BUILD, transport, workspaceTransfer } from "./node-worker-tunnel.test-support.js";
+import { isUnavailableEnvironment } from "./placement-dispatch-failure.js";
 import { REQUEST } from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
+import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-record.js";
 import {
   createWorkerSessionPlacementStore,
   type WorkerSessionPlacementStore,
 } from "./placement-store.js";
+import { createWorkerEnvironmentService } from "./service.js";
+import { BUNDLE_ARTIFACT, createProvider } from "./service.test-support.js";
+import { isFailedWorkerPlacementEnvironmentGone } from "./session-placement-lifecycle.js";
+import { createWorkerEnvironmentStore } from "./store.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -71,6 +80,192 @@ describe("offline device placement abandonment", () => {
       ...(abandonSource ? { abandonSource: true as const } : {}),
     };
   }
+
+  async function deviceTeardown(liveTunnel: boolean, providerId = "device", sharedHost = true) {
+    const harness = createHarness(placements);
+    const active = await harness.service.dispatch(REQUEST);
+    harness.markEnvironmentNodeDeviceId("device-1");
+    seedEnvironment(active, providerId);
+    database.db
+      .prepare(
+        "UPDATE worker_environments SET profile_snapshot_json = ?, shared_host = ?, node_device_id = 'device-1' WHERE environment_id = ?",
+      )
+      .run(
+        JSON.stringify({ settings: {}, executionMode: "worker-turn" }),
+        Number(sharedHost),
+        active.environmentId,
+      );
+    const store = createWorkerEnvironmentStore({ database, now: () => 1_000 });
+    let connected = false;
+    const nodeTransport = transport();
+    const nodes = await nodeTransport.listCurrentNodes();
+    for (const node of nodes) {
+      node.nodeId = "device-1";
+    }
+    nodeTransport.listCurrentNodes = async () => (connected ? nodes : []);
+    const invoke = vi.spyOn(nodeTransport, "invoke");
+    const transfer = { ...workspaceTransfer(), closeAll: vi.fn(async () => {}) };
+    const manager = createNodeWorkerTunnelManager({
+      gatewayDeviceId: "gateway-device-1",
+      getEnvironment: (id) => store.get(id),
+      listEnvironments: () => store.list(),
+      getTransport: () => nodeTransport,
+      launchNodeWorker: vi.fn(),
+      validateWorkerTurn: (claim) => placements.validateTurnClaim(claim),
+      workspaceTransfer: transfer,
+    });
+    if (liveTunnel) {
+      await manager.start({
+        executionMode: "worker-turn",
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+        deviceId: "device-1",
+        sessionId: active.sessionId,
+        expectedBuild: BUILD,
+      });
+    }
+    const provider = createProvider({ id: providerId, destroy: vi.fn(async () => {}) });
+    const environments = createWorkerEnvironmentService({
+      store,
+      getConfig: () => ({}),
+      resolveProvider: () => provider,
+      prepareInstallation: async () => BUNDLE_ARTIFACT,
+      bootstrapWorker: async () => BUILD,
+      executeInference: vi.fn(),
+      nodeTunnelManager: manager,
+      now: () => 1_000,
+    });
+    vi.mocked(harness.environments.get).mockImplementation(environments.get);
+    vi.mocked(harness.environments.destroy).mockImplementation(environments.destroy);
+    onTestFinished(async () => {
+      connected = true;
+      await environments.stop();
+    });
+    return {
+      harness,
+      active,
+      environments,
+      manager,
+      transfer,
+      invoke,
+      provider,
+      reconnect: () => {
+        connected = true;
+      },
+    };
+  }
+
+  it.each([false, true])(
+    "abandons an unreachable device through real teardown (live tunnel: %s)",
+    async (liveTunnel) => {
+      const { harness, active, environments, transfer, invoke } = await deviceTeardown(liveTunnel);
+      const fail = vi.spyOn(placements, "fail");
+      await expect(harness.service.move(requestFor(active))).resolves.toMatchObject({
+        state: "local",
+      });
+      expect(isUnavailableEnvironment(environments.get(active.environmentId)!)).toBe(true);
+      expect(environments.get(active.environmentId)).toMatchObject({
+        state: "failed",
+        leaseId: null,
+        lastError: FORCED_WORKER_ABANDONMENT_ERROR,
+      });
+      expect(fail).toHaveBeenCalledWith(
+        expect.objectContaining({ recoveryError: FORCED_WORKER_ABANDONMENT_ERROR }),
+      );
+      expect(transfer.close).toHaveBeenCalledWith(active.environmentId);
+      expect(invoke).not.toHaveBeenCalled();
+      expect(placements.getPlacementMove(active.sessionId)).toBeUndefined();
+    },
+  );
+
+  it("force destroys an unreachable device and accepts its already fenced placement for abandonment", async () => {
+    const { harness, active, environments } = await deviceTeardown(false);
+    const respond = vi.fn();
+    await environmentsHandlers["environments.destroy"]!({
+      params: { environmentId: active.environmentId, force: true },
+      respond,
+      context: {
+        workerEnvironmentService: environments,
+        workerPlacementDispatchService: harness.service,
+        logGateway: { warn: vi.fn() },
+      },
+    } as never);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ worker: expect.objectContaining({ state: "failed" }) }),
+      undefined,
+    );
+    const failed = placements.get(active.sessionId);
+    expect(failed).toMatchObject({
+      state: "failed",
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+    });
+    if (failed?.state !== "failed") {
+      throw new Error("placement was not fenced");
+    }
+    expect(
+      isFailedWorkerPlacementEnvironmentGone({
+        environmentService: environments,
+        placement: failed,
+      }),
+    ).toBe(true);
+    await expect(
+      harness.service.move({
+        ...requestFor(active),
+        source: { ...requestFor(active).source, generation: failed.generation },
+      }),
+    ).resolves.toMatchObject({ state: "local" });
+  });
+
+  it("retries abandonment after an earlier forced attempt fenced the placement but failed to stop", async () => {
+    const { harness, active } = await deviceTeardown(false);
+    const destroy = vi.mocked(harness.environments.destroy);
+    destroy.mockRejectedValueOnce(
+      new Error("device worker node is not connected with the supervisor dialect"),
+    );
+    const request = requestFor(active);
+    await expect(harness.service.move(request)).rejects.toThrow("not connected");
+    expect(placements.get(active.sessionId)).toMatchObject({
+      state: "failed",
+      recoveryError: FORCED_WORKER_ABANDONMENT_ERROR,
+    });
+    await expect(harness.service.move(request)).resolves.toMatchObject({ state: "local" });
+  });
+
+  it.each([false, true])(
+    "still remotely stops a connected device during forced destruction (live tunnel: %s)",
+    async (liveTunnel) => {
+      const { harness, active, reconnect, invoke, provider } = await deviceTeardown(liveTunnel);
+      reconnect();
+      await expect(
+        harness.service.forceDestroyEnvironment(active.environmentId),
+      ).resolves.toMatchObject({ state: "failed", leaseId: null });
+      expect(invoke).toHaveBeenCalledOnce();
+      expect(provider.destroy).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("keeps ordinary device destruction waiting for its remote stop", async () => {
+    const { active, environments, provider } = await deviceTeardown(false);
+    await expect(environments.destroy(active.environmentId)).rejects.toThrow(
+      "not connected with the supervisor dialect",
+    );
+    expect(environments.get(active.environmentId)).toMatchObject({
+      state: "attached",
+      ownerEpoch: active.activeOwnerEpoch,
+    });
+    expect(placements.get(active.sessionId)).toMatchObject({ state: "active" });
+    expect(provider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("keeps forced cloud destruction owned by the dedicated provider", async () => {
+    const { harness, active, invoke, provider } = await deviceTeardown(false, "crabbox", false);
+    await expect(
+      harness.service.forceDestroyEnvironment(active.environmentId),
+    ).resolves.toMatchObject({ state: "destroyed" });
+    expect(invoke).not.toHaveBeenCalled();
+    expect(provider.destroy).toHaveBeenCalledOnce();
+  });
 
   it("forces the exact offline device local and closes its stale turn claim", async () => {
     let afterMoveBegin = () => {};

--- a/src/gateway/worker-environments/placement-move-abandon.ts
+++ b/src/gateway/worker-environments/placement-move-abandon.ts
@@ -5,11 +5,15 @@ import {
   type WorkerDispatchPlacementStore,
 } from "./placement-dispatch-failure.js";
 import {
-  FORCED_WORKER_ABANDONMENT_ERROR,
   forceAbandonWorkerEnvironment,
+  reportWorkerAbandonmentCleanupError,
 } from "./placement-force-abandon.js";
 import type { WorkerPlacementMoveIntent } from "./placement-move-intent.js";
 import type { WorkerPlacementRunnerAvailabilityReader } from "./placement-projector.js";
+import {
+  FORCED_WORKER_ABANDONMENT_ERROR,
+  isForceAbandonedWorkerPlacement,
+} from "./placement-record.js";
 import type {
   WorkerPlacementAuthorization,
   WorkerPlacementMoveRequest,
@@ -42,17 +46,13 @@ export function createWorkerPlacementMoveAbandonment(options: {
         onCleanupError,
       });
       try {
-        return await environments.destroy(environmentId);
+        return await environments.destroy(environmentId, "operator-abandon");
       } catch (error) {
         const current = environments.get(environmentId);
         if (!current || !isUnavailableEnvironment(current)) {
           throw error;
         }
-        try {
-          onCleanupError?.(error);
-        } catch {
-          // Reporting cannot overturn the durable placement/environment fences.
-        }
+        reportWorkerAbandonmentCleanupError(onCleanupError, error);
         return current;
       }
     });
@@ -60,12 +60,15 @@ export function createWorkerPlacementMoveAbandonment(options: {
   const validateAbandonSource = (request: WorkerPlacementMoveRequest): void => {
     const current = placements.get(request.sessionId);
     if (
-      current?.state !== "active" ||
+      (current?.state !== "active" && !isForceAbandonedWorkerPlacement(current)) ||
       current.generation !== request.source.generation ||
       current.environmentId !== request.source.environmentId ||
       current.activeOwnerEpoch !== request.source.ownerEpoch
     ) {
       throw new Error(`Cannot abandon stale worker placement for session ${request.sessionKey}`);
+    }
+    if (isForceAbandonedWorkerPlacement(current)) {
+      return;
     }
     const runner = options.runnerAvailability.read(current);
     if (!runner) {

--- a/src/gateway/worker-environments/placement-move-intent.ts
+++ b/src/gateway/worker-environments/placement-move-intent.ts
@@ -16,7 +16,12 @@ import type {
 } from "../../state/openclaw-state-db.generated.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../../state/openclaw-state-schema.js";
 import { drainWorkerSessionPlacement } from "./placement-drain.js";
-import { normalizeEpoch, required, type WorkerSessionPlacementRecord } from "./placement-record.js";
+import {
+  isForceAbandonedWorkerPlacement,
+  normalizeEpoch,
+  required,
+  type WorkerSessionPlacementRecord,
+} from "./placement-record.js";
 import { getRequired, query, transitionValues } from "./placement-row-codec.js";
 import type { PlacementStoreRuntime } from "./placement-runtime.js";
 import { boundedWorkerError } from "./worker-error.js";
@@ -420,14 +425,17 @@ export function createPlacementMoveOps(runtime: PlacementStoreRuntime) {
         }
         const current = getRequired(db, sessionId);
         if (
-          current.state !== "active" ||
+          (current.state !== "active" &&
+            !(abandonSource && isForceAbandonedWorkerPlacement(current))) ||
           current.generation !== source.generation ||
           current.environmentId !== source.environmentId ||
           current.activeOwnerEpoch !== source.ownerEpoch
         ) {
           throw new Error(`Cannot move stale worker placement for session ${sessionId}`);
         }
-        requireExactAttachedEnvironment(db, { sessionId, ...source });
+        if (current.state === "active") {
+          requireExactAttachedEnvironment(db, { sessionId, ...source });
+        }
         ensureWorkerPlacementMoveSchema(db);
         const timestamp = now();
         const row: MoveRow = {
@@ -446,16 +454,18 @@ export function createPlacementMoveOps(runtime: PlacementStoreRuntime) {
           db,
           moveQuery(db).insertInto("worker_session_placement_moves").values(row),
         );
-        const placement = drainWorkerSessionPlacement(
-          db,
-          {
-            sessionId,
-            environmentId: source.environmentId,
-            ownerEpoch: source.ownerEpoch,
-            expectedGeneration: source.generation,
-          },
-          timestamp,
-        );
+        const placement =
+          current.state === "failed"
+            ? current
+            : drainWorkerSessionPlacement(
+                db,
+                {
+                  sessionId,
+                  ...source,
+                  expectedGeneration: source.generation,
+                },
+                timestamp,
+              );
         return { intent: fromRow(row), placement, joined: false };
       });
     },

--- a/src/gateway/worker-environments/placement-move-service.ts
+++ b/src/gateway/worker-environments/placement-move-service.ts
@@ -14,6 +14,7 @@ import {
 } from "./placement-reclaim-contract.js";
 import {
   isCurrentPlacementTurnClaim,
+  isForceAbandonedWorkerPlacement,
   projectWorkerSessionTurnClaim,
   reportPlacementTransition,
 } from "./placement-record.js";
@@ -26,7 +27,11 @@ import type {
 } from "./service-contract.js";
 import { isFailedWorkerPlacementEnvironmentGone } from "./session-placement-lifecycle.js";
 
-type WorkerDrainingDispatchPlacement = Extract<WorkerDispatchPlacement, { state: "draining" }>;
+type WorkerMoveBeginResult = {
+  intent: WorkerPlacementMoveIntent;
+  placement: Extract<WorkerDispatchPlacement, { state: "draining" | "failed" }>;
+  joined: boolean;
+};
 type WorkerMovePlacement = Extract<WorkerDispatchPlacement, { state: "local" | "active" }>;
 type WorkerPlacementMoveSourceDisposition = "reconcile" | "abandon";
 const RESTART_AUTHORITY_EXPIRED =
@@ -37,17 +42,9 @@ export type WorkerPlacementMoveBarrier = (
     authorize?: WorkerPlacementAuthorization;
     signal?: AbortSignal;
     sourceDisposition: WorkerPlacementMoveSourceDisposition;
-    begin: (prepareNew?: (runId: string) => Promise<void>) => Promise<{
-      intent: WorkerPlacementMoveIntent;
-      placement: WorkerDrainingDispatchPlacement;
-      joined: boolean;
-    }>;
+    begin: (prepareNew?: (runId: string) => Promise<void>) => Promise<WorkerMoveBeginResult>;
   },
-) => Promise<{
-  intent: WorkerPlacementMoveIntent;
-  placement: WorkerDrainingDispatchPlacement;
-  joined: boolean;
-}>;
+) => Promise<WorkerMoveBeginResult>;
 
 type MoveSessionIdentity = Pick<WorkerPlacementMoveRequest, "sessionId" | "sessionKey" | "agentId">;
 
@@ -144,7 +141,10 @@ export function createWorkerPlacementMoveService(options: {
             }
           }
           const started = options.placements.beginPlacementMove(moveRequest);
-          if (started.placement.state !== "draining") {
+          if (
+            started.placement.state !== "draining" &&
+            !(request.abandonSource && isForceAbandonedWorkerPlacement(started.placement))
+          ) {
             throw new Error(
               `Session ${request.sessionKey} placement move is already in ${started.placement.state}`,
             );
@@ -236,16 +236,6 @@ export function createWorkerPlacementMoveService(options: {
             sessionId: intent.sessionId,
           });
           return;
-        }
-        if (
-          placement.state !== "active" &&
-          placement.state !== "draining" &&
-          placement.state !== "reconciling" &&
-          placement.state !== "failed"
-        ) {
-          throw new Error(
-            `Session ${identity.sessionKey} abandonment recovery is waiting in ${placement.state}`,
-          );
         }
         await options.abandonSource(identity, intent);
         return;

--- a/src/gateway/worker-environments/placement-record.ts
+++ b/src/gateway/worker-environments/placement-record.ts
@@ -1,5 +1,16 @@
 import type { WorkerSessionPlacementState } from "./placement-state.js";
 
+export const FORCED_WORKER_ABANDONMENT_ERROR =
+  "Worker result abandoned by forced operator teardown";
+
+export function isForceAbandonedWorkerPlacement(
+  placement: WorkerSessionPlacementRecord | undefined,
+): placement is Extract<WorkerSessionPlacementRecord, { state: "failed" }> {
+  return (
+    placement?.state === "failed" && placement.recoveryError === FORCED_WORKER_ABANDONMENT_ERROR
+  );
+}
+
 export type WorkerSessionPlacementIdentity = {
   sessionId: string;
   agentId: string;

--- a/src/gateway/worker-environments/placement-workspace-journal.test.ts
+++ b/src/gateway/worker-environments/placement-workspace-journal.test.ts
@@ -7,7 +7,7 @@ import {
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
 import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
-import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-force-abandon.js";
+import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-record.js";
 import {
   createWorkerSessionPlacementStore,
   type WorkerSessionPlacementStore,

--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -11,6 +11,8 @@ import {
 } from "../../plugins/types.js";
 import { verifyWorkerAdmissionHandshake } from "./admission.js";
 import type { WorkerInstallationArtifact } from "./bundle.js";
+import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider-identity.js";
+import { FORCED_WORKER_ABANDONMENT_ERROR } from "./placement-record.js";
 import {
   createWorkerProjectPreparation,
   readWorkerProjectSnapshot,
@@ -434,14 +436,18 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
   const cancelRequested = (record: WorkerEnvironmentRecord) =>
     move(record, "failed", { lastError: "Provisioning canceled before provider allocation" });
 
-  const finishDestroy = async (record: WorkerEnvironmentRecord, provider?: WorkerProvider) => {
+  const finishDestroy = async (
+    record: WorkerEnvironmentRecord,
+    provider?: WorkerProvider,
+    reason?: "operator-abandon",
+  ) => {
     let r = record;
     if (r.state === "requested") {
       return cancelRequested(requireCurrentOwner(r));
     }
     // Fence local authority even when the provider is unavailable. stopOwner preserves
     // shared/unknown-host stop acknowledgements before releasing their attachments.
-    r = await stopOwner(r, "provider-destroying");
+    r = await stopOwner(r, reason ?? "provider-destroying");
     r = r.nodeDeviceId !== null && r.sharedHost === false ? r : beginDrain(r);
     const owningProvider = provider ?? providerFor(r.providerId);
     let leaseId = r.leaseId;
@@ -695,7 +701,7 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
 
   const destroy = async (
     environmentId: string,
-    destroyOptions: { requireUnattached?: boolean } = {},
+    destroyOptions: { requireUnattached?: boolean; reason?: "operator-abandon" } = {},
   ) => {
     const stopping = options.isStopping();
     if (stopping) {
@@ -715,8 +721,14 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
           "Attached cloud workers must be stopped through sessions.reclaim",
         );
       }
-      record = store.requestDestroy({ environmentId, state: record.state });
-      return finishDestroy(record);
+      const reason =
+        record.providerId === DEVICE_WORKER_PROVIDER_ID ? destroyOptions.reason : undefined;
+      record = store.requestDestroy({
+        environmentId,
+        state: record.state,
+        ...(reason ? { terminalState: "failed", lastError: FORCED_WORKER_ABANDONMENT_ERROR } : {}),
+      });
+      return finishDestroy(record, undefined, reason);
     });
   };
 

--- a/src/gateway/worker-environments/provider-owner-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-owner-lifecycle.ts
@@ -1,5 +1,6 @@
 import { isDeepStrictEqual } from "node:util";
 import type { WorkerProvider } from "../../plugins/types.js";
+import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider-identity.js";
 import type { WorkerProviderLifecycleOptions } from "./provider-lifecycle.types.js";
 import { requireProviderOperationTimeoutMs } from "./service-validation.js";
 import type { WorkerEnvironmentRecord } from "./store.js";
@@ -55,12 +56,14 @@ export function createWorkerProviderOwnerLifecycle(
     // Fence admission without erasing the attachment needed to stop a retained node worker.
     // A crash or failed stop leaves the exact scope available for teardown replay.
     store.revokeEnvironmentCredential(record.environmentId);
-    // Only a dedicated node lease makes provider teardown proof of worker termination.
-    // Shared or unknown host isolation still requires the exact worker's stop acknowledgement.
+    // Shared hosts require an exact stop acknowledgement unless the operator explicitly
+    // abandons a paired device; only dedicated leases have provider-owned physical teardown.
+    const abandon =
+      reason === "operator-abandon" && record.providerId === DEVICE_WORKER_PROVIDER_ID;
     await tunnels?.stop(
       record.environmentId,
       record.ownerEpoch,
-      record.nodeDeviceId !== null && record.sharedHost === false ? reason : undefined,
+      abandon || (record.nodeDeviceId !== null && record.sharedHost === false) ? reason : undefined,
     );
     return requireCurrentOwner(record);
   };

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -650,8 +650,8 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
         }),
       );
     },
-    destroy: async (environmentId: string) =>
-      environmentAccess.project(await providerLifecycle.destroy(environmentId)),
+    destroy: async (environmentId: string, reason?: "operator-abandon") =>
+      environmentAccess.project(await providerLifecycle.destroy(environmentId, { reason })),
     destroyUnattached: async (environmentId: string) =>
       environmentAccess.project(
         await providerLifecycle.destroy(environmentId, { requireUnattached: true }),

--- a/src/gateway/worker-environments/tunnel-contract.ts
+++ b/src/gateway/worker-environments/tunnel-contract.ts
@@ -45,7 +45,10 @@ export type WorkerTunnelRequest = {
 };
 
 /** Provider teardown fences local work first; only its confirmed result releases physical ownership. */
-export type WorkerTunnelStopReason = "provider-destroying" | "provider-destroyed";
+export type WorkerTunnelStopReason =
+  | "provider-destroying"
+  | "provider-destroyed"
+  | "operator-abandon";
 
 export type WorkerWorkspaceCommand = {
   argv: readonly string[];


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a session placed on a paired device whose node went away for good could not be recovered by any documented operator action. **Continue on Gateway…** (`sessions.move` to the Gateway with `abandonSource`) failed with `device worker node is not connected with the supervisor dialect`, left the placement `failed` with the forced-teardown fence recorded, and then refused to run again because the placement was no longer `active`. The admin last resort, `environments.destroy` with `force`, failed the same way, and `sessions.dispatch` refused with "cloud worker environment must be stopped before redispatch; use Stop cloud worker" for what was a device placement. The docs promised the opposite for all three.

## Why This Change Was Made

Forced teardown of a worker-turn environment stopped the tunnel with the ordinary reason, which must find the node and run the remote stop command; an offline node throws, the device environment never reads as unavailable, and the abandon path rethrows. The repair carries an explicit `operator-abandon` stop reason from the forced paths through the provider lifecycle to the tunnel. Under that reason, and only for the device provider, an unreachable node is tolerated after the durable placement fence: local transfer state is closed, the environment finishes as `failed` with the forced-abandonment error and its lease cleared, and the move completes to `local`. The existing owner-epoch fencing rejects the stale node if it ever reconnects. A placement already fenced by a previous forced attempt can now be retried at the RPC, the source validator, the durable move begin, and the move barrier. Ordinary reclaim still waits for the device and reconciles; connected devices still receive the remote stop; cloud providers keep their physical teardown. The dispatch refusal now names the device placement and "Continue on Gateway". Duplicated cleanup handling and a redundant recovery guard were removed; the forced-abandonment constant moved next to the placement record it describes.

Follow-up (not in this PR): the Control UI offers Continue on Gateway only for active placements; a historical failed placement can be retried through the RPC but not yet from the UI.

## User Impact

Operators can free a session from a dead paired device with **Continue on Gateway…** (or the admin forced destroy) and redispatch it, instead of being stuck with an unrecoverable placement. Unsynced device files are lost exactly as the docs already state.

## Evidence

Live replay on a dev Gateway against the exact stuck placement: on the pre-fix build every recovery path failed as described above; after restarting the same state directory on this build, startup recovery completed the recorded abandonment (placement `local`, environment `unavailable/destroyed`, no stale-build warnings) and `sessions.dispatch` was accepted again. Exact RPC transcript in the PR comment.

Boundary tests in `placement-move-abandon.test.ts` (real SQLite store, placement service, environment lifecycle, node tunnel, forced-destroy RPC, synthetic node transport): abandon with the tunnel stop throwing the disconnected-owner error completes to `local` and marks the environment unavailable; a second abandon after a fenced first attempt is accepted; forced `environments.destroy` succeeds on the same offline environment; connected devices and cloud providers keep their existing teardown. Four of these fail on `origin/main`. Focused run: 17 files, 362 tests passed; full changed-file gate green; Codex autoreview scoped-clean. Production +147/−107 (net +40), tests +339/−130, docs +2/−2.
