### PR TITLE
fix(macos): keep gateway windows on their selected connections

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppNavigationActions.swift
+++ b/apps/macos/Sources/OpenClaw/AppNavigationActions.swift
@@ -20,14 +20,7 @@ enum AppNavigationActions {
 
     static func openChat(sessionKey: String? = nil, agentID: String? = nil, draft: String? = nil) {
         NSApp.activate(ignoringOtherApps: true)
-        Task { @MainActor in
-            let resolvedSessionKey = if let sessionKey {
-                sessionKey
-            } else {
-                await WebChatManager.shared.preferredSessionKey()
-            }
-            WebChatManager.shared.show(sessionKey: resolvedSessionKey, agentID: agentID, draft: draft)
-        }
+        WebChatManager.shared.show(sessionKey: sessionKey, agentID: agentID, draft: draft)
     }
 
     static func openSettings(tab: SettingsTab = .general) {

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -5,11 +5,6 @@ import OpenClawKit
 import ServiceManagement
 import SwiftUI
 
-private enum RemoteTLSFingerprintUpdate {
-    case preserve
-    case replace(String?)
-}
-
 @MainActor
 final class VoiceWakeGlobalSyncScheduler {
     private let delay: @Sendable () async throws -> Void
@@ -1170,10 +1165,16 @@ extension AppState {
 }
 
 extension AppState {
+    struct PrimaryGatewayConfiguration: Equatable, Sendable {
+        let url: URL
+        let token: String?
+        let tlsFingerprint: String?
+    }
+
     private static func syncedGatewayRoot(
         currentRoot: [String: Any],
         draft: GatewayConfigSyncDraft,
-        remoteTLSFingerprintUpdate: RemoteTLSFingerprintUpdate = .preserve)
+        primaryGateway: PrimaryGatewayConfiguration? = nil)
         -> (root: [String: Any], changed: Bool)
     {
         var root = currentRoot
@@ -1219,11 +1220,14 @@ extension AppState {
             remote = updated.remote
             remoteChanged = updated.changed
         }
-        if case let .replace(fingerprint) = remoteTLSFingerprintUpdate {
+        if let primaryGateway {
+            // An explicit Gateway replacement owns the complete auth bundle;
+            // an old password must never reach the new Gateway's native dashboard.
+            remoteChanged = Self.updateGatewayString(&remote, key: "password", value: nil) || remoteChanged
             remoteChanged = Self.updateGatewayString(
                 &remote,
                 key: "tlsFingerprint",
-                value: fingerprint) || remoteChanged
+                value: primaryGateway.tlsFingerprint) || remoteChanged
         }
         if remoteChanged {
             if remote.isEmpty {
@@ -1302,25 +1306,33 @@ extension AppState {
 
     @discardableResult
     func syncGatewayConfigNow() -> Bool {
-        self.syncGatewayConfigNow(remoteTLSFingerprintUpdate: .preserve)
+        self.syncGatewayConfigNow(primaryGateway: nil)
     }
 
     @discardableResult
-    func syncGatewayConfigNow(remoteTLSFingerprint: String?) -> Bool {
-        self.syncGatewayConfigNow(remoteTLSFingerprintUpdate: .replace(remoteTLSFingerprint))
+    func replacePrimaryGateway(_ configuration: PrimaryGatewayConfiguration) -> Bool {
+        self.syncGatewayConfigNow(primaryGateway: configuration)
     }
 
-    private func syncGatewayConfigNow(remoteTLSFingerprintUpdate: RemoteTLSFingerprintUpdate) -> Bool {
+    private func syncGatewayConfigNow(primaryGateway: PrimaryGatewayConfiguration?) -> Bool {
         guard self.gatewayConfigSyncIsEnabled, !self.isInitializing else { return true }
+        let previousSyncState = self.gatewayConfigSyncState
         self.setGatewayConfigSyncState(.pending)
 
         let currentRoot = OpenClawConfigFile.loadDict()
         self.applyConfigOverrides(currentRoot)
         guard self.conflictedGatewayConfigFields.isEmpty else { return false }
 
-        let draft = self.gatewayConfigDraft()
+        var draft = self.gatewayConfigDraft()
+        if let primaryGateway {
+            draft.connectionMode = .remote
+            draft.remoteTransport = .direct
+            draft.remoteUrl = primaryGateway.url.absoluteString
+            draft.remoteToken = primaryGateway.token ?? ""
+            draft.dirtyFields.formUnion([.mode, .remoteTransport, .remoteUrl, .remoteToken])
+        }
         guard Self.gatewayDraftCanPersist(draft) else {
-            self.setGatewayConfigSyncState(.failed)
+            self.setGatewayConfigSyncState(primaryGateway == nil ? .failed : previousSyncState)
             return false
         }
 
@@ -1328,30 +1340,33 @@ extension AppState {
         let synced = Self.syncedGatewayRoot(
             currentRoot: currentRoot,
             draft: draft,
-            remoteTLSFingerprintUpdate: remoteTLSFingerprintUpdate)
-        guard synced.changed else {
-            self.acknowledgeGatewayConfigPersistence(draft.dirtyFields, root: currentRoot)
-            self.setGatewayConfigSyncState(.current)
-            return true
-        }
-        guard self.gatewayConfigSaver(synced.root) else {
-            self.setGatewayConfigSyncState(.failed)
+            primaryGateway: primaryGateway)
+        guard !synced.changed || self.gatewayConfigSaver(synced.root) else {
+            self.setGatewayConfigSyncState(primaryGateway == nil ? .failed : previousSyncState)
             Self.logger.warning("gateway config sync rejected to protect persisted gateway auth/mode")
             return false
         }
-        self.acknowledgeGatewayConfigPersistence(draft.dirtyFields, root: synced.root)
+        self.acknowledgeGatewayConfigPersistence(draft, root: synced.root)
+        if primaryGateway != nil {
+            // Publish the selection only after its endpoint and credentials commit.
+            if synced.changed, !self.isPreview {
+                WebChatManager.shared.resetPrimaryConnections()
+            }
+            self.applyGatewayConfigView(synced.root, forcing: Self.gatewayConfigFieldsPersisted(by: draft))
+        }
         self.lastConfigFingerprint = Self.configFingerprint(synced.root)
         self.setGatewayConfigSyncState(.current)
-        NotificationCenter.default.post(name: .openclawConfigDidChange, object: nil)
+        if synced.changed {
+            NotificationCenter.default.post(name: .openclawConfigDidChange, object: nil)
+        }
         return true
     }
 
     private func acknowledgeGatewayConfigPersistence(
-        _ fields: Set<GatewayConfigField>,
+        _ draft: GatewayConfigSyncDraft,
         root: [String: Any])
     {
-        let persistedFields = Self.gatewayConfigFieldsPersisted(by: self.gatewayConfigDraft())
-            .intersection(fields)
+        let persistedFields = Self.gatewayConfigFieldsPersisted(by: draft)
         self.dirtyGatewayConfigFields.subtract(persistedFields)
         self.conflictedGatewayConfigFields.subtract(persistedFields)
         self.lastObservedGatewayConfig = Self.gatewayConfigSnapshot(root)

--- a/apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift
@@ -26,7 +26,8 @@ extension ChannelsStore {
         self.startCount += 1
         guard self.startCount == 1 else { return }
         guard self.pollTask == nil else { return }
-        GatewayPushSubscription.restartTask(task: &self.gatewayPushTask) { [weak self] push in
+        GatewayPushSubscription.restartTask(task: &self.gatewayPushTask) { [weak self] delivery in
+            guard let push = delivery.push else { return }
             self?.handleGatewayPush(push)
         }
         self.pollTask = Task.detached { [weak self] in

--- a/apps/macos/Sources/OpenClaw/ConnectionModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/ConnectionModeCoordinator.swift
@@ -40,7 +40,7 @@ final class ConnectionModeCoordinator {
             NodesStore.shared.lastError = nil
             await RemoteTunnelManager.shared.stopAll()
             guard self.transition.isCurrent(applyGeneration, mode: mode) else { return }
-            WebChatManager.shared.resetTunnels()
+            WebChatManager.shared.resetPrimaryConnections()
         }
 
         switch mode {
@@ -56,7 +56,7 @@ final class ConnectionModeCoordinator {
         case .remote:
             // Never run a local gateway in remote mode.
             GatewayProcessManager.shared.stop()
-            WebChatManager.shared.resetTunnels()
+            WebChatManager.shared.resetPrimaryConnections()
 
             do {
                 NodesStore.shared.lastError = nil

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -174,16 +174,20 @@ final class ControlChannel {
     private(set) var authSourceLabel: String?
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "control")
+    private let gateway: GatewayConnection
+    private let endpointRevision: @Sendable () -> UInt64
 
     private var eventTask: Task<Void, Never>?
     private var recoveryTask: Task<Void, Never>?
     private var lastRecoveryAt: Date?
     private var compatibilityAlerts = ControlChannelCompatibilityAlerts()
+    private var activityServerLease: GatewayConnection.ServerLease?
 
     private func synchronizeRouteGeneration() -> UInt64 {
         // Endpoint stream delivery can lag source adoption; fence UI publication directly.
-        if self.compatibilityAlerts.observeEndpoint(revision: GatewayEndpointStore.shared.routeRevision) {
+        if self.compatibilityAlerts.observeEndpoint(revision: self.endpointRevision()) {
             self.cancelPendingStateTask()
+            self.retireActivity()
         }
         return self.compatibilityAlerts.routeGeneration
     }
@@ -192,7 +196,7 @@ final class ControlChannel {
     private func reconcileCurrentConnection(generation: UInt64) -> Bool {
         guard generation == self.synchronizeRouteGeneration(),
               let state = self.compatibilityAlerts.observeConnection(
-                  revision: GatewayConnection.shared.connectedEndpointRevision)
+                  revision: self.gateway.connectedEndpointRevision)
         else { return false }
         // Admission can precede its snapshot; publish success and cancel stale deferred status together.
         self.setStateThrottled(state, generation: generation)
@@ -244,8 +248,19 @@ final class ControlChannel {
         UInt64(max(0, interval) * 1_000_000_000)
     }
 
-    private init() {
+    init(
+        gateway: GatewayConnection = .shared,
+        endpointRevision: @escaping @Sendable () -> UInt64 = { GatewayEndpointStore.shared.routeRevision })
+    {
+        self.gateway = gateway
+        self.endpointRevision = endpointRevision
         self.startEventStream()
+    }
+
+    isolated deinit {
+        self.eventTask?.cancel()
+        self.recoveryTask?.cancel()
+        self.pendingStateTask?.cancel()
     }
 
     func configure() async {
@@ -275,7 +290,8 @@ final class ControlChannel {
     }
 
     func endpointDidChange(_ state: GatewayEndpointState) {
-        guard state.routeRevision == GatewayEndpointStore.shared.routeRevision else { return }
+        guard state.routeRevision == self.endpointRevision() else { return }
+        _ = self.synchronizeRouteGeneration()
         switch state {
         case .ready:
             Task { await self.refreshEndpoint(reason: "endpoint changed") }
@@ -301,8 +317,9 @@ final class ControlChannel {
 
     func disconnect() async {
         self.compatibilityAlerts.routeChanged()
+        self.retireActivity()
         self.setStateThrottled(.disconnected)
-        await GatewayConnection.shared.shutdown()
+        await self.gateway.shutdown()
     }
 
     func health(timeout: TimeInterval? = nil) async throws -> Data {
@@ -335,7 +352,7 @@ final class ControlChannel {
             let rawParams = params?.reduce(into: [String: OpenClawKit.AnyCodable]()) {
                 $0[$1.key] = OpenClawKit.AnyCodable($1.value.base)
             }
-            return try await GatewayConnection.shared.request(
+            return try await self.gateway.request(
                 method: method,
                 params: rawParams,
                 timeoutMs: timeoutMs,
@@ -348,7 +365,7 @@ final class ControlChannel {
         retryTransportFailures: Bool = true) async throws -> Data
     {
         try await self.performRequest {
-            try await GatewayConnection.shared.request(request, retryTransportFailures: retryTransportFailures)
+            try await self.gateway.request(request, retryTransportFailures: retryTransportFailures)
         }
     }
 
@@ -560,8 +577,8 @@ final class ControlChannel {
     }
 
     private func establishGatewayConnection(timeoutMs: Int = 5000) async throws {
-        try await GatewayConnection.shared.refresh()
-        let ok = try await GatewayConnection.shared.healthOK(timeoutMs: timeoutMs)
+        try await self.gateway.refresh()
+        let ok = try await self.gateway.healthOK(timeoutMs: timeoutMs)
         if ok == false {
             throw NSError(
                 domain: "Gateway",
@@ -573,7 +590,7 @@ final class ControlChannel {
 
     private func refreshAuthSourceLabel() async {
         let isRemote = CommandResolver.connectionModeIsRemote()
-        let authSource = await GatewayConnection.shared.authSource()
+        let authSource = await self.gateway.authSource()
         self.authSourceLabel = Self.formatAuthSource(authSource, isRemote: isRemote)
     }
 
@@ -600,12 +617,36 @@ final class ControlChannel {
     }
 
     private func startEventStream() {
-        GatewayPushSubscription.restartTask(task: &self.eventTask) { [weak self] push in
-            self?.handle(push: push)
+        GatewayPushSubscription.restartTask(task: &self.eventTask, connection: self.gateway) { [weak self] delivery in
+            self?.handle(delivery: delivery)
         }
     }
 
-    private func handle(push: GatewayPush) {
+    private func retireActivity() {
+        self.activityServerLease = nil
+        // Keep the last known main key until a current hello replaces it.
+        // Retired deliveries cannot use that metadata to recreate old work.
+        WorkActivityStore.shared.reset()
+    }
+
+    private func handle(delivery: GatewayConnection.PushDelivery) {
+        let generation = self.synchronizeRouteGeneration()
+        guard delivery.isCurrent, delivery.serverLease.endpointRevision == self.endpointRevision() else { return }
+        guard let push = delivery.push else {
+            guard case let .disconnected(reason) = delivery.event else { return }
+            self.retireActivity()
+            self.setStateThrottled(reason.map(ConnectionState.degraded) ?? .disconnected, generation: generation)
+            return
+        }
+        // Agent events may precede the ordinary hello notification. Adopt the
+        // admitted handshake once, before any current work can be projected.
+        if self.activityServerLease != delivery.serverLease {
+            WorkActivityStore.shared.reset()
+            if let mainSessionKey = delivery.mainSessionKey {
+                WorkActivityStore.shared.setMainSessionKey(mainSessionKey)
+            }
+            self.activityServerLease = delivery.serverLease
+        }
         switch push {
         case let .event(evt) where evt.event == "agent":
             if let payload = evt.payload,
@@ -627,18 +668,22 @@ final class ControlChannel {
             // The gateway targets this event at connections bound to the
             // caller's own profile; receipt means our profile appearance
             // changed on another device.
-            self.refreshProfileAccent()
+            self.refreshProfileAccent(delivery: delivery)
         case .snapshot:
             self.reconcileCurrentConnection(generation: self.synchronizeRouteGeneration())
-            self.refreshProfileAccent()
+            self.refreshProfileAccent(delivery: delivery)
         default:
             break
         }
     }
 
-    private func refreshProfileAccent() {
+    private func refreshProfileAccent(delivery: GatewayConnection.PushDelivery) {
         Task {
-            let accent = await Self.fetchProfileAccentHex()
+            guard delivery.isCurrent else { return }
+            let accent = await self.fetchProfileAccentHex(serverLease: delivery.serverLease)
+            // A replaced request can fail as well as succeed; neither outcome
+            // may repaint the newly selected Gateway's profile appearance.
+            guard delivery.isCurrent else { return }
             AppStateStore.shared.profileAccentHex = accent
         }
     }
@@ -649,12 +694,13 @@ final class ControlChannel {
     /// fallback. Goes straight through GatewayConnection: routing this through
     /// ControlChannel.request would mark the channel degraded on the expected
     /// older-gateway failure.
-    private static func fetchProfileAccentHex() async -> String? {
+    private func fetchProfileAccentHex(serverLease: GatewayConnection.ServerLease) async -> String? {
         do {
-            let data = try await GatewayConnection.shared.requestRaw(
+            let data = try await self.gateway.request(
                 method: "users.prefs.get",
                 params: ["keys": OpenClawKit.AnyCodable(["ui.accent"])],
-                timeoutMs: 8000)
+                timeoutMs: 8000,
+                ifCurrentServerLease: serverLease)
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                   json["status"] as? String == "ok"
             else { return nil }

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -161,7 +161,6 @@ final class ControlChannel {
                 self.logger.info("control channel state -> connecting")
             case .disconnected:
                 self.logger.info("control channel state -> disconnected")
-                self.scheduleRecovery(reason: "disconnected")
             case let .degraded(message):
                 let detail = message.isEmpty ? "degraded" : "degraded: \(message)"
                 self.logger.info("control channel state -> \(detail, privacy: .public)")
@@ -187,6 +186,7 @@ final class ControlChannel {
         // Endpoint stream delivery can lag source adoption; fence UI publication directly.
         if self.compatibilityAlerts.observeEndpoint(revision: self.endpointRevision()) {
             self.cancelPendingStateTask()
+            self.cancelRecovery()
             self.retireActivity()
         }
         return self.compatibilityAlerts.routeGeneration
@@ -273,6 +273,7 @@ final class ControlChannel {
         case .local:
             await self.configure()
         case let .remote(target, identity):
+            let generation = self.synchronizeRouteGeneration()
             do {
                 _ = (target, identity)
                 let idSet = !identity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -281,9 +282,10 @@ final class ControlChannel {
                         "target=\(target, privacy: .public) identitySet=\(idSet, privacy: .public)")
                 self.setStateThrottled(.connecting)
                 _ = try await GatewayEndpointStore.shared.ensureRemoteControlTunnel()
-                await self.refreshEndpoint(reason: "configure")
+                await self.refreshEndpoint(reason: "configure", generation: generation)
             } catch {
-                self.setStateThrottled(.degraded(error.localizedDescription))
+                guard !Task.isCancelled, generation == self.synchronizeRouteGeneration() else { return }
+                self.setStateThrottled(.degraded(error.localizedDescription), generation: generation)
                 throw error
             }
         }
@@ -291,10 +293,10 @@ final class ControlChannel {
 
     func endpointDidChange(_ state: GatewayEndpointState) {
         guard state.routeRevision == self.endpointRevision() else { return }
-        _ = self.synchronizeRouteGeneration()
+        let generation = self.synchronizeRouteGeneration()
         switch state {
         case .ready:
-            Task { await self.refreshEndpoint(reason: "endpoint changed") }
+            Task { await self.refreshEndpoint(reason: "endpoint changed", generation: generation) }
         case .connecting:
             self.setStateThrottled(.connecting)
         case let .unavailable(_, reason, _):
@@ -302,21 +304,27 @@ final class ControlChannel {
         }
     }
 
-    func refreshEndpoint(reason: String) async {
+    func refreshEndpoint(reason: String, generation: UInt64? = nil) async {
+        let generation = generation ?? self.synchronizeRouteGeneration()
+        guard !Task.isCancelled, generation == self.synchronizeRouteGeneration() else { return }
         self.logger.info("control channel refresh endpoint reason=\(reason, privacy: .public)")
-        let generation = self.synchronizeRouteGeneration()
+        if self.eventTask == nil { self.startEventStream() }
         self.setStateThrottled(.connecting)
         do {
             try await self.establishGatewayConnection()
             guard self.reconcileCurrentConnection(generation: generation) else { return }
             PresenceReporter.shared.sendImmediate(reason: "connect")
         } catch {
+            guard !Task.isCancelled else { return }
             self.reportFailure(error, generation: generation)
         }
     }
 
     func disconnect() async {
         self.compatibilityAlerts.routeChanged()
+        self.cancelRecovery()
+        self.eventTask?.cancel()
+        self.eventTask = nil
         self.retireActivity()
         self.setStateThrottled(.disconnected)
         await self.gateway.shutdown()
@@ -372,6 +380,7 @@ final class ControlChannel {
     private func performRequest(_ operation: () async throws -> Data) async throws -> Data {
         try Task.checkCancellation()
         let generation = self.synchronizeRouteGeneration()
+        if self.eventTask == nil { self.startEventStream() }
         do {
             let data = try await operation()
             try Task.checkCancellation()
@@ -532,7 +541,16 @@ final class ControlChannel {
         return true
     }
 
+    private func cancelRecovery() {
+        self.recoveryTask?.cancel()
+        self.recoveryTask = nil
+        self.lastRecoveryAt = nil
+    }
+
     private func scheduleRecovery(reason: String) {
+        let generation = self.synchronizeRouteGeneration()
+        let mode = AppStateStore.shared.connectionMode
+        guard mode != .unconfigured else { return }
         let now = Date()
         if let last = self.lastRecoveryAt, now.timeIntervalSince(last) < 10 { return }
         guard self.recoveryTask == nil else { return }
@@ -540,11 +558,12 @@ final class ControlChannel {
 
         self.recoveryTask = Task { [weak self] in
             guard let self else { return }
-            let mode = await MainActor.run { AppStateStore.shared.connectionMode }
-            guard mode != .unconfigured else {
-                self.recoveryTask = nil
-                return
+            defer {
+                if generation == self.synchronizeRouteGeneration() { self.recoveryTask = nil }
             }
+            // Explicit disconnect and route replacement retire recovery before it can manage a process or tunnel.
+            guard !Task.isCancelled, generation == self.synchronizeRouteGeneration(),
+                  AppStateStore.shared.connectionMode == mode, self.state != .connected else { return }
 
             let trimmedReason = reason.trimmingCharacters(in: .whitespacesAndNewlines)
             let reasonText = trimmedReason.isEmpty ? "unknown" : trimmedReason
@@ -565,14 +584,15 @@ final class ControlChannel {
                 }
             }
 
-            await self.refreshEndpoint(reason: "recovery:\(reasonText)")
+            guard !Task.isCancelled, generation == self.synchronizeRouteGeneration(),
+                  AppStateStore.shared.connectionMode == mode else { return }
+            await self.refreshEndpoint(reason: "recovery:\(reasonText)", generation: generation)
+            guard !Task.isCancelled, generation == self.synchronizeRouteGeneration() else { return }
             if case .connected = self.state {
                 self.logger.info("control channel recovery finished")
             } else if case let .degraded(message) = self.state {
                 self.logger.error("control channel recovery failed \(message, privacy: .public)")
             }
-
-            self.recoveryTask = nil
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/CronJobsStore.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobsStore.swift
@@ -52,8 +52,9 @@ final class CronJobsStore {
             return
         }
         self.eventTask = Task { [weak self, gateway] in
-            for await push in await gateway.subscribe() {
+            for await delivery in await gateway.subscribe() {
                 guard !Task.isCancelled, let self else { return }
+                guard delivery.isCurrent, let push = delivery.push else { continue }
                 self.handle(push: push)
             }
         }

--- a/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
@@ -148,12 +148,8 @@ struct DashboardPrimaryGatewayAdapter {
         try await MacGatewayProfileStore.shared.endpoint(profileID: profileID)
     }
 
-    var currentTLSFingerprint: @MainActor () -> String? = {
-        GatewayRemoteConfig.resolveTLSFingerprint(root: OpenClawConfigFile.loadDict())
-    }
-
-    var persist: @MainActor (AppState, String?) -> Bool = {
-        $0.syncGatewayConfigNow(remoteTLSFingerprint: $1)
+    var persist: @MainActor (AppState, AppState.PrimaryGatewayConfiguration) -> Bool = {
+        $0.replacePrimaryGateway($1)
     }
 
     func apply(profileID: String) async throws {
@@ -185,24 +181,8 @@ struct DashboardPrimaryGatewayAdapter {
     }
 
     private func apply(url: URL, token: String?, tlsFingerprint: String?) throws {
-        let previous = (
-            transport: self.state.remoteTransport,
-            url: self.state.remoteUrl,
-            token: self.state.remoteToken,
-            mode: self.state.connectionMode,
-            tlsFingerprint: self.currentTLSFingerprint())
-        self.state.remoteTransport = .direct
-        self.state.remoteUrl = url.absoluteString
-        // Promotion intentionally moves the saved token into gateway.remote.token,
-        // matching the existing Settings connection flow.
-        self.state.remoteToken = token ?? ""
-        self.state.connectionMode = .remote
-        guard self.persist(self.state, tlsFingerprint) else {
-            self.state.remoteTransport = previous.transport
-            self.state.remoteUrl = previous.url
-            self.state.remoteToken = previous.token
-            self.state.connectionMode = previous.mode
-            _ = self.persist(self.state, previous.tlsFingerprint)
+        let configuration = AppState.PrimaryGatewayConfiguration(url: url, token: token, tlsFingerprint: tlsFingerprint)
+        guard self.persist(self.state, configuration) else {
             throw DashboardPrimaryGatewayError.notPromotable
         }
     }

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -45,11 +45,13 @@ final class DashboardManager {
     @ObservationIgnored private var openForCommandTask: Task<Void, Never>?
     @ObservationIgnored private var navigationIntents: [DashboardGatewayTarget: NavigationIntent] = [:]
     @ObservationIgnored private var updater: UpdaterProviding?
-    @ObservationIgnored private var displayedRouteRevision: UInt64?
-    @ObservationIgnored private var displayedRouteAuthority: UInt64?
+    @ObservationIgnored private var displayedPrimaryRoutes:
+        [ObjectIdentifier: (revision: UInt64?, authority: UInt64?)] = [:]
     @ObservationIgnored private var endpointGeneration: UInt64 = 0
     @ObservationIgnored private var presentationGeneration: UInt64 = 0
-    @ObservationIgnored private var switchGenerations: [ObjectIdentifier: UInt64] = [:]
+    @ObservationIgnored private var windowLifetime: UInt64 = 0
+    @ObservationIgnored private var gatewaySnapshotGeneration: UInt64 = 0
+    @ObservationIgnored private var profileCredentialsNeedRefresh = false
     @ObservationIgnored private let authTokenProvider: @Sendable (GatewayConnection.Config) async -> String?
     @ObservationIgnored private let routeProbe: @Sendable (DashboardRouteProbePurpose) async -> Void
     @ObservationIgnored private let endpointStateProvider: @Sendable () async -> GatewayEndpointState
@@ -118,6 +120,10 @@ final class DashboardManager {
                         if name == .controlChannelStateDidChange {
                             await self.handleControlChannelStateChange(ControlChannel.shared.state)
                         }
+                        if name == MacGatewayProfileStore.didChangeNotification {
+                            // Retain the invalidation until the latest catalog refresh finishes.
+                            self.profileCredentialsNeedRefresh = true
+                        }
                         await self.refreshGatewaySnapshots()
                     }
                 }
@@ -175,29 +181,27 @@ final class DashboardManager {
     }
 
     func handleEndpointState(_ state: GatewayEndpointState) async {
-        // The shared endpoint stream owns only the main window's primary route.
-        // Profile-targeted documents keep their saved endpoint and credentials.
-        guard self.mainTarget == .primary else { return }
+        // Primary is a route role, independent of which native window displays it.
+        // Saved-profile documents keep their own endpoint and credentials.
         self.endpointGeneration &+= 1
         let generation = self.endpointGeneration
-        guard let controller, controller.isWindowOpen else { return }
+        let controllers = self.dashboardControllers().filter { $0.target == .primary }.map(\.controller)
+        guard !controllers.isEmpty else { return }
         guard case let .ready(mode, url, token, password, routeRevision) = state else {
-            if controller.currentURL != Self.failureURL || controller.auth.hasCredential {
+            for controller in controllers {
                 self.replaceWithRouteFailure(controller)
             }
-            self.displayedRouteRevision = nil
-            self.displayedRouteAuthority = nil
             return
         }
         let config: GatewayConnection.Config = (url, token, password)
         let tlsParams = Self.primaryTLSParams(for: config, mode: mode)
         var authToken = await self.authTokenProvider(config)
-        guard self.endpointTransitionIsCurrent(generation, controller: controller) else { return }
+        guard self.endpointGeneration == generation else { return }
         if authToken == nil, password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty == nil {
             await self.routeProbe(.authentication)
-            guard self.endpointTransitionIsCurrent(generation, controller: controller) else { return }
+            guard self.endpointGeneration == generation else { return }
             authToken = await self.authTokenProvider(config)
-            guard self.endpointTransitionIsCurrent(generation, controller: controller) else { return }
+            guard self.endpointGeneration == generation else { return }
         }
         guard let dashboardURL = try? GatewayEndpointStore.dashboardURL(
             for: config,
@@ -210,53 +214,57 @@ final class DashboardManager {
             gatewayUrl: Self.websocketURLString(for: dashboardURL),
             token: authToken,
             password: password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
-        let routeChanged = self.displayedRouteRevision.map { $0 != routeRevision }
-            ?? (routeRevision > 0) || !controller.hasTLSParams(tlsParams)
-        let credentialChanged = controller.auth.token != auth.token || controller.auth.password != auth.password
-        if routeChanged || credentialChanged {
-            if routeChanged {
-                self.displayedRouteAuthority = nil
+        for controller in controllers where self.target(for: controller) == .primary && controller.isWindowOpen {
+            let key = ObjectIdentifier(controller)
+            let previousRoute = self.displayedPrimaryRoutes[key]
+            let revisionChanged = (previousRoute?.revision).map { $0 != routeRevision } ?? (routeRevision > 0)
+            let routeChanged = revisionChanged || !controller.hasTLSParams(tlsParams) ||
+                controller.auth.gatewayUrl != auth.gatewayUrl
+            let credentialChanged = controller.auth.token != auth.token || controller.auth.password != auth.password
+            if routeChanged || credentialChanged {
+                guard auth.hasCredential else {
+                    self.replaceWithRouteFailure(controller)
+                    continue
+                }
+                if let replacement = self.replaceWindowController(
+                    controller,
+                    configuration: WindowConfiguration(
+                        url: dashboardURL, auth: auth, tlsParams: tlsParams, mode: mode, displayName: "OpenClaw"),
+                    target: .primary,
+                    present: false)
+                {
+                    self.displayedPrimaryRoutes[ObjectIdentifier(replacement)] = (routeRevision, nil)
+                }
+            } else {
+                let updateBridgeEnabled = controller === self.controller && Self.updateBridgeEnabled(mode: mode)
+                if dashboardURL == controller.currentURL {
+                    controller.setUpdateBridgeEnabled(updateBridgeEnabled)
+                } else if auth.hasCredential {
+                    controller.update(url: dashboardURL, auth: auth, updateBridgeEnabled: updateBridgeEnabled)
+                }
+                self.displayedPrimaryRoutes[key] = (routeRevision, previousRoute?.authority)
             }
-            self.displayedRouteRevision = routeRevision
-            guard auth.hasCredential else {
-                self.replaceWithRouteFailure(controller)
-                return
-            }
-            self.replaceWindowController(
-                controller,
-                configuration: WindowConfiguration(
-                    url: dashboardURL, auth: auth, tlsParams: tlsParams, mode: mode, displayName: "OpenClaw"),
-                target: .primary,
-                present: false)
-            return
         }
-        if dashboardURL == controller.currentURL {
-            self.displayedRouteRevision = routeRevision
-            controller.setUpdateBridgeEnabled(Self.updateBridgeEnabled(mode: mode))
-            return
-        }
-        guard auth.hasCredential, controller.isWindowOpen else { return }
-        dashboardManagerLogger.info(
-            "dashboard endpoint changed; reloading url=\(dashboardLogString(for: dashboardURL), privacy: .public)")
-        controller.update(url: dashboardURL, auth: auth, updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode))
-        self.displayedRouteRevision = routeRevision
     }
 
     private func replaceWithRouteFailure(_ current: DashboardWindowController) {
-        guard self.controller === current else { return }
-        self.switchGenerations[ObjectIdentifier(current)] = nil
-        let window = current.detachWindowForReplacement()
-        let replacement = self.makePrimaryController(
-            url: Self.failureURL,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
-            mode: .unconfigured,
-            reusingWindow: window)
-        self.controller = replacement
-        replacement.showFailure(
+        guard current.currentURL != Self.failureURL || current.auth.hasCredential else { return }
+        let replacement = self.replaceWindowController(
+            current,
+            configuration: WindowConfiguration(
+                url: Self.failureURL,
+                auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+                tlsParams: nil,
+                mode: .unconfigured,
+                displayName: "OpenClaw"),
+            target: .primary,
+            present: false)
+        replacement?.showFailure(
             title: "Dashboard reconnecting",
             message: "The selected Gateway changed.",
             detail: "Waiting for a fresh authenticated connection.",
-            present: false)
+            present: false,
+            preservingPendingCommands: true)
     }
 
     func presentDashboard() {
@@ -278,7 +286,7 @@ final class DashboardManager {
 
     @discardableResult
     func showConfiguredWindowIfPossible() -> Bool {
-        guard self.mainTarget == .primary else { return false }
+        guard self.mainTarget == .primary, self.controller?.pendingGatewaySwitch == nil else { return false }
         let mode = AppStateStore.shared.connectionMode
         guard let endpoint = Self.immediateDashboardEndpoint(mode: mode),
               let url = try? GatewayEndpointStore.dashboardURL(
@@ -327,44 +335,29 @@ final class DashboardManager {
             auth: auth,
             mode: mode,
             tlsParams: tlsParams)
-        self.controller = controller
+        self.installMainController(controller)
         controller.loadInBackground(url: url, auth: auth)
     }
 
     private func showResolvedPrimaryDashboard() async throws {
-        let mode = AppStateStore.shared.connectionMode
-        let generation = self.endpointGeneration
         let originalController = self.controller
-        dashboardManagerLogger.info("dashboard show requested mode=\(String(describing: mode), privacy: .public)")
-        let endpoint: GatewayConnection.EndpointSnapshot
+        let resolved: (configuration: WindowConfiguration, endpoint: GatewayConnection.EndpointSnapshot)
         do {
-            endpoint = try await self.primaryEndpoint(mode: mode)
+            resolved = try await self.windowConfiguration(for: .primary)
         } catch {
-            guard self.presentationIsCurrent(generation, controller: originalController) else {
+            guard self.presentationIsCurrent(controller: originalController) else {
                 throw SupersededDashboardPresentation()
             }
             throw error
         }
-        guard self.presentationIsCurrent(generation, controller: originalController) else {
+        guard self.presentationIsCurrent(controller: originalController) else {
             throw SupersededDashboardPresentation()
         }
-        let config = endpoint.config
-        dashboardManagerLogger.info("dashboard config url=\(config.url.absoluteString, privacy: .public)")
-        let token = await self.authTokenProvider(config)
-        guard self.presentationIsCurrent(generation, controller: originalController) else {
-            throw SupersededDashboardPresentation()
-        }
-        let url = try GatewayEndpointStore.dashboardURL(for: config, mode: mode, authToken: token)
-        let auth = DashboardWindowAuth(
-            gatewayUrl: Self.websocketURLString(for: url),
-            token: token,
-            password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
 
         let creatingWindow = self.controller == nil
         self.presentDashboard(
-            configuration: WindowConfiguration(
-                url: url, auth: auth, tlsParams: endpoint.tls?.params, mode: mode, displayName: "OpenClaw"),
-            endpoint: endpoint,
+            configuration: resolved.configuration,
+            endpoint: resolved.endpoint,
             target: .primary,
             source: self.controller)
         await self.refreshGatewaySnapshots()
@@ -380,7 +373,8 @@ final class DashboardManager {
         // Pending lookup intent is target-owned even before a native window exists.
         let intent = NavigationIntent(windowID: source?.window.map(ObjectIdentifier.init))
         self.navigationIntents[target] = intent
-        if target == self.mainTarget {
+        source?.retirePendingSessionCommands()
+        if target == self.mainTarget, source == nil {
             self.pendingOpenCommands.removeAll(where: \.supersedesPendingNavigation)
         }
         return intent.id
@@ -398,6 +392,7 @@ final class DashboardManager {
     {
         if let source, let sourceTarget = self.target(for: source) {
             self.navigationIntents[sourceTarget] = nil
+            _ = source.takePendingNativeActions()
         }
         self.navigationIntents[target] = nil
     }
@@ -432,7 +427,8 @@ final class DashboardManager {
             url: Self.failureURL,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
             mode: .unconfigured)
-        self.controller = controller
+        self.pendingOpenCommands.removeAll()
+        self.installMainController(controller)
         // Keep observing while the failure page is up so a recovered tunnel
         // swaps the window back to the live dashboard.
         self.observeEndpointChanges()
@@ -443,15 +439,15 @@ final class DashboardManager {
     }
 
     func close() {
+        self.windowLifetime &+= 1
+        self.gatewaySnapshotGeneration &+= 1
         self.endpointGeneration &+= 1
-        self.presentationGeneration &+= 1
-        self.presentationTask?.cancel()
-        self.presentationTask = nil
+        self.retirePresentation()
         self.navigationIntents.removeAll()
         self.openForCommandTask?.cancel()
         self.openForCommandTask = nil
         self.pendingOpenCommands.removeAll()
-        self.switchGenerations.removeAll()
+        self.displayedPrimaryRoutes.removeAll()
         self.controller?.closeDashboard()
         let controllers = self.auxiliaryWindows.values.map(\.controller)
         self.auxiliaryWindows.removeAll()
@@ -463,39 +459,49 @@ final class DashboardManager {
     }
 
     func dispatchNativeCommand(_ command: DashboardNativeCommand) {
+        let frontmost = self.frontmostDashboard()
+        let source = frontmost?.controller ?? self.controller
+        let target = source?.pendingGatewaySwitch?.target ?? frontmost?.target ?? self.mainTarget
         if command.supersedesPendingNavigation {
             // This also invalidates a handoff still suspended in show(atPath:).
-            self.retireNavigation(for: self.mainTarget)
+            self.retireNavigation(for: target)
         }
         NSApp.activate(ignoringOtherApps: true)
-        if let controller, controller.isWindowOpen, controller.canDeliverNativeCommands {
-            controller.show()
-            controller.dispatchNativeCommand(command)
+        if let source {
+            // Admit once to the native window; replacements transfer its ordered queue before loading.
+            let needsRecovery = !source.isWindowOpen || !source.canDeliverNativeCommands
+            source.dispatchNativeCommand(command)
+            source.show()
+            guard needsRecovery, source.pendingGatewaySwitch == nil else { return }
+            if source === self.controller, target == .primary, self.showConfiguredWindowIfPossible() { return }
+            self.switchTarget(target, in: source, forceReload: true)
             return
         }
-        // One coalesced open drains the queue in press order; a Task per key
-        // press would race window creation and reorder ⌘N/⌘K delivery.
         self.pendingOpenCommands.append(command)
+        if self.showConfiguredWindowIfPossible() { return }
         guard self.openForCommandTask == nil else { return }
+        let lifetime = self.windowLifetime
         self.openForCommandTask = Task { @MainActor in
-            defer { self.openForCommandTask = nil }
-            guard !self.pendingOpenCommands.isEmpty else { return }
-            if !self.showConfiguredWindowIfPossible() {
-                do {
-                    try await self.show()
-                } catch {
-                    guard !Task.isCancelled else { return }
-                    // Commands are moment-bound; drop them with the failed open.
-                    self.pendingOpenCommands = []
-                    self.showFailure(error)
-                    return
-                }
+            defer {
+                if self.windowLifetime == lifetime { self.openForCommandTask = nil }
             }
-            let commands = self.pendingOpenCommands
-            self.pendingOpenCommands = []
-            for command in commands {
-                self.controller?.dispatchNativeCommand(command)
+            guard !Task.isCancelled, self.windowLifetime == lifetime else { return }
+            do {
+                try await self.show()
+            } catch {
+                guard !Task.isCancelled, self.windowLifetime == lifetime else { return }
+                self.showFailure(error)
             }
+        }
+    }
+
+    private func installMainController(_ controller: DashboardWindowController) {
+        self.controller = controller
+        // The manager owns commands only until the first native window exists, including preload races.
+        let commands = self.pendingOpenCommands
+        self.pendingOpenCommands.removeAll()
+        for command in commands {
+            controller.dispatchNativeCommand(command)
         }
     }
 
@@ -505,18 +511,55 @@ final class DashboardManager {
     }
 
     private func refreshGatewaySnapshots() async {
-        guard let entries = try? await self.loadGatewayEntries() else { return }
+        self.gatewaySnapshotGeneration &+= 1
+        let generation = self.gatewaySnapshotGeneration
+        guard var entries = try? await self.loadGatewayEntries(),
+              self.gatewaySnapshotGeneration == generation else { return }
+        let previousEntries = self.gatewayEntries
+        let profileTargets = Set(self.dashboardControllers().map(\.target).filter { $0 != .primary })
+        for target in profileTargets.sorted(by: { $0.bridgeID < $1.bridgeID }) {
+            let hasEntry = entries.contains { $0.id == target.bridgeID }
+            guard self.profileCredentialsNeedRefresh || !hasEntry else { continue }
+            let resolved: (configuration: WindowConfiguration, endpoint: GatewayConnection.EndpointSnapshot)
+            do {
+                resolved = try await self.windowConfiguration(for: target)
+            } catch {
+                guard self.gatewaySnapshotGeneration == generation else { return }
+                if error as? MacGatewayProfileError == .profileNotFound,
+                   let current = self.dashboardControllers().first(where: { $0.target == target })
+                {
+                    await self.switchTarget(.primary, in: current.controller)?.value
+                    return
+                }
+                continue
+            }
+            guard self.gatewaySnapshotGeneration == generation else { return }
+            let (configuration, endpoint) = resolved
+            if !hasEntry {
+                // Primary-row deduplication is display policy, not profile removal.
+                // A saved window keeps its fixed route until the profile owner removes it.
+                entries.append(DashboardGatewayEntry(
+                    id: target.bridgeID,
+                    name: previousEntries.first { $0.id == target.bridgeID }?.name ?? configuration.displayName,
+                    kind: "remote",
+                    isPrimary: false,
+                    canPromote: endpoint.config.token?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty != nil,
+                    health: .unknown))
+            }
+            for (_, controller) in self.dashboardControllers().filter({ $0.target == target }) {
+                if self.profileCredentialsNeedRefresh, self.requiresIsolatedDashboardDocument(
+                    controller, auth: configuration.auth, endpoint: endpoint, comparePrimaryRoute: false)
+                {
+                    self.replaceWindowController(
+                        controller,
+                        configuration: configuration,
+                        target: target,
+                        present: false)
+                }
+            }
+        }
         self.gatewayEntries = entries
-        if let controller, !Self.targetIsAvailable(self.mainTarget, in: entries) {
-            await self.switchTarget(.primary, in: controller)
-            return
-        }
-        if let invalid = self.auxiliaryWindows.values.first(where: {
-            !Self.targetIsAvailable($0.target, in: entries)
-        }) {
-            await self.switchTarget(.primary, in: invalid.controller)
-            return
-        }
+        self.profileCredentialsNeedRefresh = false
         if let controller, let snapshot = self.snapshot(for: self.mainTarget) {
             controller.updateGatewaySnapshot(snapshot)
         }
@@ -532,58 +575,54 @@ final class DashboardManager {
         return self.auxiliaryWindows.values.first { $0.controller === source }?.target
     }
 
-    private static func targetIsAvailable(
-        _ target: DashboardGatewayTarget,
-        in entries: [DashboardGatewayEntry]) -> Bool
-    {
-        entries.contains { $0.id == target.bridgeID }
+    private func controller(in window: NSWindow, for target: DashboardGatewayTarget) -> DashboardWindowController? {
+        guard let controller = window.windowController as? DashboardWindowController,
+              self.target(for: controller) == target else { return nil }
+        return controller
     }
 
-    private func beginSwitch(for source: DashboardWindowController) -> UInt64 {
-        let key = ObjectIdentifier(source)
-        let generation = (self.switchGenerations[key] ?? 0) &+ 1
-        self.switchGenerations[key] = generation
-        return generation
-    }
-
-    private func switchIsCurrent(_ generation: UInt64, for source: DashboardWindowController) -> Bool {
-        self.switchGenerations[ObjectIdentifier(source)] == generation && self.target(for: source) != nil
-    }
-
-    private func finishSwitch(_ generation: UInt64, for source: DashboardWindowController) {
-        let key = ObjectIdentifier(source)
-        if self.switchGenerations[key] == generation {
-            self.switchGenerations[key] = nil
-        }
-    }
-
+    @discardableResult
     private func switchTarget(
         _ target: DashboardGatewayTarget,
         in source: DashboardWindowController,
         forceReload: Bool = false,
-        present: Bool? = nil) async
+        present: Bool? = nil) -> Task<Void, Never>?
     {
-        guard let currentTarget = self.target(for: source) else { return }
-        // Each source window has its own generation so the latest selection wins
-        // without serializing unrelated dashboard windows.
-        let generation = self.beginSwitch(for: source)
-        guard forceReload || currentTarget != target else {
-            self.finishSwitch(generation, for: source)
-            return
+        guard let currentTarget = self.target(for: source), let window = source.window else { return nil }
+        guard !forceReload || source.pendingGatewaySwitch == nil else { return nil }
+        if !forceReload {
+            self.retireNavigation(for: target, from: source)
+            if source === self.controller { self.retirePresentation() }
         }
-        do {
-            let (configuration, _) = try await self.windowConfiguration(for: target)
-            guard self.switchIsCurrent(generation, for: source), self.target(for: source) == currentTarget else {
-                return
+        // User intent belongs to the native shell and survives background document replacement.
+        let intent = DashboardGatewaySwitchIntent(target: target)
+        let needsReplacement = forceReload || currentTarget != target || !source.canDeliverNativeCommands
+        source.pendingGatewaySwitch = needsReplacement ? intent : nil
+        guard source.pendingGatewaySwitch != nil else { return nil }
+        return Task { @MainActor in
+            guard self.controller(in: window, for: currentTarget)?.pendingGatewaySwitch == intent else { return }
+            do {
+                let (configuration, endpoint) = try await self.windowConfiguration(for: target)
+                guard !Task.isCancelled, let current = self.controller(in: window, for: currentTarget),
+                      current.pendingGatewaySwitch == intent else { return }
+                current.pendingGatewaySwitch = nil
+                if let replacement = self.replaceWindowController(
+                    current,
+                    configuration: configuration,
+                    target: target,
+                    present: present), target == .primary
+                {
+                    self.rememberPresentedEndpoint(endpoint, controller: replacement)
+                }
+                await self.refreshGatewaySnapshots()
+                self.updateFrontmostDashboardTarget()
+            } catch {
+                guard !Task.isCancelled, let current = self.controller(in: window, for: currentTarget),
+                      current.pendingGatewaySwitch == intent else { return }
+                current.pendingGatewaySwitch = nil
+                _ = current.takePendingNativeActions()
+                Self.showGatewayError(error, message: "Could Not Switch Gateway")
             }
-            self.replaceWindowController(source, configuration: configuration, target: target, present: present)
-            self.finishSwitch(generation, for: source)
-            await self.refreshGatewaySnapshots()
-            self.updateFrontmostDashboardTarget()
-        } catch {
-            guard self.switchIsCurrent(generation, for: source) else { return }
-            self.finishSwitch(generation, for: source)
-            Self.showGatewayError(error, message: "Could Not Switch Gateway")
         }
     }
 
@@ -597,7 +636,10 @@ final class DashboardManager {
         let isMainWindow = self.controller === source
         let windowID = self.auxiliaryWindows.first { $0.value.controller === source }?.key
         guard isMainWindow || windowID != nil else { return nil }
-        self.switchGenerations[ObjectIdentifier(source)] = nil
+        let preserveNavigation = self.target(for: source) == target &&
+            Self.notificationRoute(source.currentURL) == Self.notificationRoute(configuration.url)
+        let pendingActions = source.takePendingNativeActions()
+        self.displayedPrimaryRoutes[ObjectIdentifier(source)] = nil
         // Background reconciliation must not resurrect a window the user closed;
         // explicit show/open callers opt back into presentation.
         let shouldPresent = present ?? source.isWindowOpen
@@ -609,13 +651,12 @@ final class DashboardManager {
             windowAutosaveName: autosaveName,
             auxiliary: !isMainWindow,
             reusingWindow: window)
+        // Picker admission already retired older actions. Later commands follow this window's successor;
+        // session navigation remains bound to its original gateway selection, origin, and mount.
+        replacement.restorePendingNativeActions(pendingActions, preservingNavigation: preserveNavigation)
         if isMainWindow {
-            if self.mainTarget == .primary, target != .primary {
-                self.displayedRouteRevision = nil
-                self.displayedRouteAuthority = nil
-            }
             self.mainTarget = target
-            self.controller = replacement
+            self.installMainController(replacement)
         } else if let windowID {
             self.auxiliaryWindows[windowID] = AuxiliaryWindowInstance(target: target, controller: replacement)
         }
@@ -626,14 +667,39 @@ final class DashboardManager {
         return replacement
     }
 
-    private func openWindow(for target: DashboardGatewayTarget) async {
-        do {
-            let (configuration, _) = try await self.windowConfiguration(for: target)
-            self.openWindow(for: target, configuration: configuration)
-            await self.refreshGatewaySnapshots()
-            self.updateFrontmostDashboardTarget()
-        } catch {
-            Self.showGatewayError(error, message: "Could Not Open Gateway Window")
+    @discardableResult
+    private func openWindow(for target: DashboardGatewayTarget, reuseExisting: Bool = false) -> Task<Void, Never> {
+        // Capture authority at the synchronous request boundary, before any menu/bridge task can outlive close().
+        let lifetime = self.windowLifetime
+        return Task { @MainActor in
+            guard !Task.isCancelled, self.windowLifetime == lifetime else { return }
+            if reuseExisting, let controller = self.dashboardController(for: target) {
+                controller.show()
+                self.updateFrontmostDashboardTarget()
+                return
+            }
+            let opensMain = reuseExisting && self.mainTarget == target
+            do {
+                if opensMain {
+                    try await self.show()
+                } else {
+                    let (configuration, endpoint) = try await self.windowConfiguration(for: target)
+                    guard !Task.isCancelled, self.windowLifetime == lifetime else { return }
+                    let controller = self.openWindow(for: target, configuration: configuration)
+                    if target == .primary {
+                        self.rememberPresentedEndpoint(endpoint, controller: controller)
+                    }
+                    await self.refreshGatewaySnapshots()
+                }
+                self.updateFrontmostDashboardTarget()
+            } catch {
+                guard !Task.isCancelled, self.windowLifetime == lifetime else { return }
+                if opensMain {
+                    self.showFailure(error)
+                } else {
+                    Self.showGatewayError(error, message: "Could Not Open Gateway Window")
+                }
+            }
         }
     }
 
@@ -660,46 +726,6 @@ final class DashboardManager {
         }
         controller.show(url: configuration.url, auth: configuration.auth)
         return controller
-    }
-
-    private func windowConfiguration(for target: DashboardGatewayTarget) async throws
-        -> (configuration: WindowConfiguration, endpoint: GatewayConnection.EndpointSnapshot)
-    {
-        switch target {
-        case .primary:
-            let mode = AppStateStore.shared.connectionMode
-            let endpoint = try await self.primaryEndpoint(mode: mode)
-            let config = endpoint.config
-            let token = await self.authTokenProvider(config)
-            let url = try GatewayEndpointStore.dashboardURL(for: config, mode: mode, authToken: token)
-            let auth = DashboardWindowAuth(
-                gatewayUrl: Self.websocketURLString(for: url),
-                token: token,
-                password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
-            return (WindowConfiguration(
-                url: url,
-                auth: auth,
-                tlsParams: endpoint.tls?.params,
-                mode: mode,
-                displayName: "OpenClaw"), endpoint)
-        case let .profile(profileID):
-            let endpoint = try await self.profileEndpoint(profileID: profileID)
-            let url = try GatewayEndpointStore.dashboardURL(
-                for: endpoint.config,
-                mode: .remote,
-                authToken: endpoint.config.token)
-            let auth = DashboardWindowAuth(
-                gatewayUrl: Self.websocketURLString(for: url),
-                token: endpoint.config.token,
-                password: endpoint.config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
-            let name = self.gatewayEntries.first { $0.id == target.bridgeID }?.name ?? url.host ?? "Gateway"
-            return (WindowConfiguration(
-                url: url,
-                auth: auth,
-                tlsParams: endpoint.tls?.params,
-                mode: .remote,
-                displayName: name), endpoint)
-        }
     }
 
     private func makePrimaryController(
@@ -767,7 +793,7 @@ final class DashboardManager {
                 source,
                 auth: configuration.auth,
                 endpoint: endpoint,
-                comparePrimaryRoute: source === self.controller && target == .primary)
+                comparePrimaryRoute: target == .primary)
             {
                 presented = self.replaceWindowController(
                     source, configuration: configuration, target: target, present: true)
@@ -786,15 +812,14 @@ final class DashboardManager {
                 target: target,
                 windowAutosaveName: self.mainWindowAutosaveName,
                 auxiliary: false)
-            self.controller = controller
+            self.installMainController(controller)
             controller.show(url: configuration.url, auth: configuration.auth)
             presented = controller
         } else {
             presented = self.openWindow(for: target, configuration: configuration)
         }
-        if target == .primary, presented === self.controller {
-            self.rememberPresentedEndpoint(endpoint)
-            self.observeEndpointChanges()
+        if target == .primary, let presented {
+            self.rememberPresentedEndpoint(endpoint, controller: presented)
         }
         self.updateFrontmostDashboardTarget()
         return presented
@@ -845,6 +870,54 @@ final class DashboardManager {
 }
 
 extension DashboardManager {
+    private func windowConfiguration(for target: DashboardGatewayTarget) async throws
+        -> (configuration: WindowConfiguration, endpoint: GatewayConnection.EndpointSnapshot)
+    {
+        switch target {
+        case .primary:
+            while true {
+                try Task.checkCancellation()
+                let generation = self.endpointGeneration
+                let mode = AppStateStore.shared.connectionMode
+                do {
+                    let endpoint = try await self.primaryEndpoint(mode: mode)
+                    let config = endpoint.config
+                    let token = await self.authTokenProvider(config)
+                    guard self.endpointGeneration == generation else { continue }
+                    let url = try GatewayEndpointStore.dashboardURL(for: config, mode: mode, authToken: token)
+                    let auth = DashboardWindowAuth(
+                        gatewayUrl: Self.websocketURLString(for: url),
+                        token: token,
+                        password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
+                    return (
+                        WindowConfiguration(
+                            url: url, auth: auth, tlsParams: endpoint.tls?.params, mode: mode, displayName: "OpenClaw"),
+                        endpoint)
+                } catch {
+                    guard self.endpointGeneration == generation else { continue }
+                    throw error
+                }
+            }
+        case let .profile(profileID):
+            let endpoint = try await self.profileEndpoint(profileID: profileID)
+            let url = try GatewayEndpointStore.dashboardURL(
+                for: endpoint.config,
+                mode: .remote,
+                authToken: endpoint.config.token)
+            let auth = DashboardWindowAuth(
+                gatewayUrl: Self.websocketURLString(for: url),
+                token: endpoint.config.token,
+                password: endpoint.config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
+            let name = self.gatewayEntries.first { $0.id == target.bridgeID }?.name ?? url.host ?? "Gateway"
+            return (WindowConfiguration(
+                url: url,
+                auth: auth,
+                tlsParams: endpoint.tls?.params,
+                mode: .remote,
+                displayName: name), endpoint)
+        }
+    }
+
     private func primaryEndpoint(
         mode: AppState.ConnectionMode) async throws -> GatewayConnection.EndpointSnapshot
     {
@@ -1003,12 +1076,17 @@ extension DashboardManager {
         {
             self.navigationIntents[target] = nil
         }
-        self.switchGenerations[ObjectIdentifier(controller)] = nil
+        controller.pendingGatewaySwitch = nil
+        _ = controller.takePendingNativeActions()
+        self.displayedPrimaryRoutes[ObjectIdentifier(controller)] = nil
         if let windowID = self.auxiliaryWindows.first(where: { $0.value.controller === controller })?.key {
             self.auxiliaryWindows.removeValue(forKey: windowID)
             self.auxiliaryWindowOrder.removeAll { $0 == windowID }
         }
         self.updateFrontmostDashboardTarget()
+        if target != .primary {
+            Task { await self.refreshGatewaySnapshots() }
+        }
     }
 
     func show() async throws {
@@ -1022,7 +1100,7 @@ extension DashboardManager {
                 await self.refreshGatewaySnapshots()
                 return
             }
-            await self.switchTarget(self.mainTarget, in: controller, forceReload: true, present: true)
+            await self.switchTarget(self.mainTarget, in: controller, forceReload: true, present: true)?.value
             return
         }
         self.observeEndpointChanges()
@@ -1032,7 +1110,8 @@ extension DashboardManager {
                 return
             } catch is SupersededDashboardPresentation {
                 guard !Task.isCancelled, self.mainTarget == .primary else {
-                    throw CancellationError()
+                    // Selection or close already retired this presentation; callers have no setup error to show.
+                    return
                 }
                 if let controller, controller.isWindowOpen {
                     controller.show()
@@ -1061,9 +1140,10 @@ extension DashboardManager {
         return presentationTask
     }
 
-    private func endpointTransitionIsCurrent(_ generation: UInt64, controller: DashboardWindowController) -> Bool {
-        self.endpointGeneration == generation && self.controller === controller &&
-            self.mainTarget == .primary && controller.isWindowOpen
+    private func retirePresentation() {
+        self.presentationGeneration &+= 1
+        self.presentationTask?.cancel()
+        self.presentationTask = nil
     }
 
     private static func primaryTLSParams(
@@ -1097,15 +1177,11 @@ extension DashboardManager {
         return auth.hasCredential ? (mode, url, auth, endpoint.tls?.params) : nil
     }
 
-    private func presentationIsCurrent(
-        _ generation: UInt64,
-        controller originalController: DashboardWindowController?) -> Bool
-    {
+    private func presentationIsCurrent(controller originalController: DashboardWindowController?) -> Bool {
         guard !Task.isCancelled, self.mainTarget == .primary else {
             return false
         }
-        let originalControllerIsCurrent = originalController.map { self.controller === $0 } ?? (self.controller == nil)
-        return self.endpointGeneration == generation && originalControllerIsCurrent
+        return originalController.map { self.controller === $0 } ?? (self.controller == nil)
     }
 
     private func requiresIsolatedDashboardDocument(
@@ -1114,19 +1190,24 @@ extension DashboardManager {
         endpoint: GatewayConnection.EndpointSnapshot,
         comparePrimaryRoute: Bool = true) -> Bool
     {
-        !controller.hasTLSParams(endpoint.tls?.params) ||
+        let displayedRoute = self.displayedPrimaryRoutes[ObjectIdentifier(controller)]
+        return !controller.hasTLSParams(endpoint.tls?.params) ||
             controller.auth.gatewayUrl != auth.gatewayUrl ||
             controller.auth.token != auth.token ||
             controller.auth.password != auth.password ||
-            (comparePrimaryRoute && (endpoint.routeAuthority != self.displayedRouteAuthority ||
-                    endpoint.revision.map { $0 != self.displayedRouteRevision } == true))
+            (comparePrimaryRoute && (endpoint.routeAuthority != displayedRoute?.authority ||
+                    endpoint.revision.map { $0 != displayedRoute?.revision } == true))
     }
 
-    private func rememberPresentedEndpoint(_ endpoint: GatewayConnection.EndpointSnapshot) {
-        if let revision = endpoint.revision {
-            self.displayedRouteRevision = revision
-        }
-        self.displayedRouteAuthority = endpoint.routeAuthority
+    private func rememberPresentedEndpoint(
+        _ endpoint: GatewayConnection.EndpointSnapshot,
+        controller: DashboardWindowController)
+    {
+        let key = ObjectIdentifier(controller)
+        self.displayedPrimaryRoutes[key] = (
+            endpoint.revision ?? self.displayedPrimaryRoutes[key]?.revision,
+            endpoint.routeAuthority)
+        self.observeEndpointChanges()
     }
 
     func handleOnboardingCompletion() {
@@ -1134,23 +1215,26 @@ extension DashboardManager {
     }
 
     func navigateBack() {
-        guard self.controller?.window?.isKeyWindow == true else { return }
-        self.controller?.navigateBack()
+        guard let controller = self.frontmostDashboard()?.controller,
+              controller.window?.isKeyWindow == true else { return }
+        controller.navigateBack()
     }
 
     func navigateForward() {
-        guard self.controller?.window?.isKeyWindow == true else { return }
-        self.controller?.navigateForward()
+        guard let controller = self.frontmostDashboard()?.controller,
+              controller.window?.isKeyWindow == true else { return }
+        controller.navigateForward()
     }
 
     func handleGatewayRequest(_ request: DashboardGatewaysRequest, from source: DashboardWindowController) {
+        // Retained WebViews may still emit callbacks after their window closes or document is replaced.
+        guard self.target(for: source) != nil, source.isWindowOpen else { return }
         switch request {
         case let .select(target):
-            self.retireNavigation(for: target, from: source)
-            Task { await self.switchTarget(target, in: source) }
+            self.switchTarget(target, in: source)
         case let .openWindow(target):
             self.retireNavigation(for: target)
-            Task { await self.openWindow(for: target) }
+            self.openWindow(for: target)
         case let .setPrimary(target):
             guard self.target(for: source) == target else { return }
             self.presentSetPrimaryConfirmation(target, source: source)
@@ -1182,12 +1266,11 @@ extension DashboardManager {
 
     func openOrFocusDashboard(for target: DashboardGatewayTarget) {
         self.retireNavigation(for: target)
-        Task { await self.performOpenOrFocusDashboard(for: target) }
+        self.openWindow(for: target, reuseExisting: true)
     }
 
     func switchFrontmostDashboard(to target: DashboardGatewayTarget) {
-        self.retireNavigation(for: target, from: self.frontmostDashboard()?.controller)
-        Task { await self.performSwitchFrontmostDashboard(to: target) }
+        self.performSwitchFrontmostDashboard(to: target)
     }
 
     func confirmSetPrimary(_ target: DashboardGatewayTarget) {
@@ -1238,32 +1321,13 @@ extension DashboardManager {
             .controller
     }
 
-    private func performOpenOrFocusDashboard(for target: DashboardGatewayTarget) async {
-        if let controller = self.dashboardController(for: target) {
-            NSApp.activate(ignoringOtherApps: true)
-            controller.show()
-            self.updateFrontmostDashboardTarget()
-            return
-        }
-        if self.mainTarget == target || (target == .primary && self.controller == nil) {
-            do {
-                try await self.show()
-            } catch {
-                self.showFailure(error)
-            }
-        } else {
-            await self.openWindow(for: target)
-        }
-        self.updateFrontmostDashboardTarget()
-    }
-
-    private func performSwitchFrontmostDashboard(to target: DashboardGatewayTarget) async {
+    @discardableResult
+    private func performSwitchFrontmostDashboard(to target: DashboardGatewayTarget) -> Task<Void, Never>? {
         guard let frontmost = self.frontmostDashboard() else {
-            await self.performOpenOrFocusDashboard(for: target)
-            return
+            self.retireNavigation(for: target)
+            return self.openWindow(for: target, reuseExisting: true)
         }
-        await self.switchTarget(target, in: frontmost.controller, present: true)
-        self.updateFrontmostDashboardTarget()
+        return self.switchTarget(target, in: frontmost.controller, present: true)
     }
 
     private func presentSetPrimaryConfirmation(
@@ -1283,7 +1347,7 @@ extension DashboardManager {
                 do {
                     try await DashboardPrimaryGatewayAdapter(state: AppStateStore.shared).apply(profileID: profileID)
                     if let source, self.target(for: source) != nil {
-                        await self.switchTarget(.primary, in: source)
+                        await self.switchTarget(.primary, in: source)?.value
                     } else {
                         await self.refreshGatewaySnapshots()
                     }
@@ -1356,8 +1420,8 @@ extension DashboardManager {
         return manager
     }
 
-    func _testSetController(_ controller: DashboardWindowController?) {
-        self.controller = controller
+    func _testSetController(_ controller: DashboardWindowController) {
+        self.installMainController(controller)
     }
 
     func _testController() -> DashboardWindowController? {
@@ -1373,15 +1437,15 @@ extension DashboardManager {
     }
 
     func _testOpenWindow(for target: DashboardGatewayTarget) async {
-        await self.openWindow(for: target)
+        await self.openWindow(for: target).value
     }
 
     func _testSwitchTarget(_ target: DashboardGatewayTarget, in source: DashboardWindowController) async {
-        await self.switchTarget(target, in: source)
+        await self.switchTarget(target, in: source)?.value
     }
 
     func _testSwitchFrontmostDashboard(to target: DashboardGatewayTarget) async {
-        await self.performSwitchFrontmostDashboard(to: target)
+        await self.performSwitchFrontmostDashboard(to: target)?.value
     }
 
     func _testHandleControlChannelStateChange(_ state: ControlChannel.ConnectionState) async {
@@ -1398,17 +1462,9 @@ extension DashboardManager {
 
     func _testSetMainTarget(_ target: DashboardGatewayTarget) {
         self.mainTarget = target
-        if target != .primary {
-            self.displayedRouteRevision = nil
-            self.displayedRouteAuthority = nil
+        if target != .primary, let controller {
+            self.displayedPrimaryRoutes[ObjectIdentifier(controller)] = nil
         }
-    }
-
-    static func _testTargetIsAvailable(
-        _ target: DashboardGatewayTarget,
-        in entries: [DashboardGatewayEntry]) -> Bool
-    {
-        self.targetIsAvailable(target, in: entries)
     }
 }
 #endif

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -600,11 +600,11 @@ final class DashboardManager {
         source.pendingGatewaySwitch = needsReplacement ? intent : nil
         guard source.pendingGatewaySwitch != nil else { return nil }
         return Task { @MainActor in
-            guard self.controller(in: window, for: currentTarget)?.pendingGatewaySwitch == intent else { return }
+            guard self.controller(in: window, for: currentTarget)?.pendingGatewaySwitch === intent else { return }
             do {
                 let (configuration, endpoint) = try await self.windowConfiguration(for: target)
                 guard !Task.isCancelled, let current = self.controller(in: window, for: currentTarget),
-                      current.pendingGatewaySwitch == intent else { return }
+                      current.pendingGatewaySwitch === intent else { return }
                 current.pendingGatewaySwitch = nil
                 if let replacement = self.replaceWindowController(
                     current,
@@ -618,7 +618,7 @@ final class DashboardManager {
                 self.updateFrontmostDashboardTarget()
             } catch {
                 guard !Task.isCancelled, let current = self.controller(in: window, for: currentTarget),
-                      current.pendingGatewaySwitch == intent else { return }
+                      current.pendingGatewaySwitch === intent else { return }
                 current.pendingGatewaySwitch = nil
                 _ = current.takePendingNativeActions()
                 Self.showGatewayError(error, message: "Could Not Switch Gateway")

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+Gateways.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+Gateways.swift
@@ -143,7 +143,9 @@ extension DashboardWindowController {
         let alert = NSAlert()
         alert.messageText = "Set \(gatewayName) as primary?"
         alert.informativeText =
-            "This changes the Mac app's primary Gateway and resets Talk Mode, canvas, and chat connections."
+            "This changes the Mac app's primary Gateway and resets its Talk Mode, canvas, " +
+            "and native chat connection. " +
+            "Other saved Gateway windows stay open."
         alert.addButton(withTitle: "Set as Primary")
         alert.addButton(withTitle: "Cancel")
         return alert

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -18,6 +18,7 @@ private final class DashboardWindowContentView: NSView {
 private final class DashboardWindow: NSWindow {
     /// User intent belongs to the native window, not the privileged document it hosts.
     var userIntentGeneration: UInt64 = 0
+    var pendingGatewaySwitch: DashboardGatewaySwitchIntent?
 
     override func toggleToolbarShown(_: Any?) {}
 
@@ -25,6 +26,11 @@ private final class DashboardWindow: NSWindow {
         if item.action == #selector(NSWindow.toggleToolbarShown(_:)) { return false }
         return super.validateUserInterfaceItem(item)
     }
+}
+
+struct DashboardGatewaySwitchIntent: Equatable {
+    let id = UUID()
+    let target: DashboardGatewayTarget
 }
 
 private final class DashboardLinkSplitView: NSSplitView {
@@ -423,27 +429,6 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         self.windowFrameAutosaveName = ""
         self.window = nil
         return window
-    }
-
-    func showFailure(title: String, message: String, detail: String? = nil, present: Bool = true) {
-        self.hasLiveContent = false
-        self.isShowingFailurePage = true
-        self.advanceNavigationGeneration()
-        // Queued commands are moment-bound user intent; replaying them after a
-        // later recovery reload would toggle or navigate unexpectedly.
-        self.pendingNativeCommands = []
-        self.pendingNativeNavigation = nil
-        self.currentURL = URL(string: "about:blank")!
-        self.auth = DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil)
-        self.setUpdateBridgeEnabled(false)
-        self.refreshNativeAuthScript(url: self.currentURL, auth: self.auth)
-        self.webView.stopLoading()
-        self.webView.loadHTMLString(
-            DashboardFailurePage.html(title: title, message: message, detail: detail, url: nil),
-            baseURL: nil)
-        if present {
-            self.show()
-        }
     }
 
     private func load(_ url: URL) {
@@ -1005,10 +990,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         self.hasLiveContent = false
         self.isShowingFailurePage = true
         self.advanceNavigationGeneration()
-        // Same moment-bound rule as showFailure: a terminal load failure
-        // invalidates commands queued for the document that never arrived.
-        self.pendingNativeCommands = []
-        self.pendingNativeNavigation = nil
+        // A failed document retires its actions. A pending picker already owns its successor's commands.
+        if self.pendingGatewaySwitch == nil {
+            self.pendingNativeCommands = []
+            self.pendingNativeNavigation = nil
+        }
         dashboardWindowLogger.error(
             """
             dashboard load failed url=\(dashboardLogString(for: self.currentURL), privacy: .public) \
@@ -1024,6 +1010,59 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
 }
 
 extension DashboardWindowController {
+    func showFailure(
+        title: String,
+        message: String,
+        detail: String? = nil,
+        present: Bool = true,
+        preservingPendingCommands: Bool = false)
+    {
+        self.hasLiveContent = false
+        self.isShowingFailurePage = true
+        self.advanceNavigationGeneration()
+        // Terminal failure drops moment-bound actions. A transient reconnect keeps generic commands
+        // for its successor document; route-specific session navigation always expires here.
+        if !preservingPendingCommands { self.pendingNativeCommands = [] }
+        self.pendingNativeNavigation = nil
+        self.currentURL = URL(string: "about:blank")!
+        self.auth = DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil)
+        self.setUpdateBridgeEnabled(false)
+        self.refreshNativeAuthScript(url: self.currentURL, auth: self.auth)
+        self.webView.stopLoading()
+        self.webView.loadHTMLString(
+            DashboardFailurePage.html(title: title, message: message, detail: detail, url: nil),
+            baseURL: nil)
+        if present {
+            self.show()
+        }
+    }
+
+    typealias PendingNativeActions = (commands: [DashboardNativeCommand], navigation: DashboardNativeNavigation?)
+
+    func takePendingNativeActions() -> PendingNativeActions {
+        defer {
+            self.pendingNativeCommands = []
+            self.pendingNativeNavigation = nil
+            self.advanceNavigationGeneration()
+        }
+        return (self.pendingNativeCommands, self.pendingNativeNavigation)
+    }
+
+    func restorePendingNativeActions(_ actions: PendingNativeActions, preservingNavigation: Bool) {
+        // Transfer already admitted intent without advancing the native window's generation again.
+        self.pendingNativeCommands = actions.commands
+        self.pendingNativeNavigation = preservingNavigation ? actions.navigation : nil
+    }
+
+    func retirePendingSessionCommands() {
+        self.pendingNativeCommands.removeAll(where: \.supersedesPendingNavigation)
+    }
+
+    var pendingGatewaySwitch: DashboardGatewaySwitchIntent? {
+        get { (self.window as? DashboardWindow)?.pendingGatewaySwitch }
+        set { (self.window as? DashboardWindow)?.pendingGatewaySwitch = newValue }
+    }
+
     func navigateBack() {
         self.activeNavigationWebView.goBack()
     }
@@ -1075,8 +1114,10 @@ extension DashboardWindowController {
     func windowWillClose(_: Notification) {
         self.advanceWindowIntent()
         self.advanceNavigationGeneration()
+        self.hasLiveContent = false
         self.pendingNativeCommands = []
         self.pendingNativeNavigation = nil
+        self.pendingGatewaySwitch = nil
         self.webView.stopLoading()
         self.closeLinkBrowser(focusDashboard: false)
         self.onClosed?()
@@ -1164,7 +1205,7 @@ extension DashboardWindowController {
             self.advanceWindowIntent()
             self.advanceNavigationGeneration()
         }
-        guard self.hasLiveContent else {
+        guard self.hasLiveContent, self.isWindowOpen, self.pendingGatewaySwitch == nil else {
             // Ordered queue, duplicates included: two ⌘K presses while loading
             // must toggle twice, and ⌘N followed by ⌘K must deliver both.
             if command.supersedesPendingNavigation {
@@ -1389,6 +1430,8 @@ extension DashboardWindowController {
             guard !self.isShowingFailurePage else { return }
             self.hasLiveContent = true
             self.publishNativeHistoryState()
+            // Commands admitted after picker selection belong to its successor document.
+            guard self.pendingGatewaySwitch == nil else { return }
             // History state must reach the shell before a queued command can navigate it.
             self.flushPendingNativeCommands()
             self.flushPendingNativeNavigation()

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -28,9 +28,12 @@ private final class DashboardWindow: NSWindow {
     }
 }
 
-struct DashboardGatewaySwitchIntent: Equatable {
-    let id = UUID()
+final class DashboardGatewaySwitchIntent {
     let target: DashboardGatewayTarget
+
+    init(target: DashboardGatewayTarget) {
+        self.target = target
+    }
 }
 
 private final class DashboardLinkSplitView: NSSplitView {

--- a/apps/macos/Sources/OpenClaw/DevicePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/DevicePairingApprovalPrompter.swift
@@ -11,9 +11,10 @@ final class DevicePairingApprovalPrompter {
     static let shared = DevicePairingApprovalPrompter()
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "device-pairing")
+    private let gateway: GatewayConnection
+    private let center: PairingApprovalCenter
+    private var source: PairingPromptSupport.Source?
     private var task: Task<Void, Never>?
-    private var isStopping = false
-    private var listFetchGeneration = 0
     private var queue: [PendingRequest] = []
     var pendingCount: Int = 0
     var pendingRepairCount: Int = 0
@@ -63,49 +64,57 @@ final class DevicePairingApprovalPrompter {
 
     private typealias PairingResolvedEvent = PairingPromptSupport.PairingResolvedEvent
 
-    func start() {
-        PairingApprovalCenter.shared.register(kind: .device) { [weak self] card, decision in
-            await self?.handleDecision(card: card, decision: decision)
-        }
-        self.startPushTask()
+    init(gateway: GatewayConnection = .shared, center: PairingApprovalCenter = .shared) {
+        self.gateway = gateway
+        self.center = center
     }
 
-    private func startPushTask() {
+    func start() {
+        self.center.register(kind: .device) { [weak self] card, decision in
+            await self?.handleDecision(card: card, decision: decision)
+        }
         PairingPromptSupport.startPairingPushTask(
             task: &self.task,
-            isStopping: &self.isStopping,
-            loadPending: self.loadPendingRequestsFromGateway,
-            handlePush: self.handle(push:))
+            gateway: self.gateway,
+            handlePush: self.handle(delivery:))
     }
 
     func stop() {
-        PairingPromptSupport.stopPairingPrompter(
-            isStopping: &self.isStopping,
-            task: &self.task,
-            queue: &self.queue)
-        PairingApprovalCenter.shared.unregister(kind: .device)
-        self.pendingLocalDecisionRequestIds.removeAll(keepingCapacity: false)
-        self.updatePendingCounts()
+        self.task?.cancel()
+        self.task = nil
+        self.replaceSource(nil)
+        self.center.unregister(kind: .device)
     }
 
-    private func loadPendingRequestsFromGateway() async {
-        // Push-triggered refreshes can overlap; only the newest snapshot may
-        // replace the queue or an older read would drop just-arrived requests.
-        self.listFetchGeneration += 1
-        let generation = self.listFetchGeneration
+    private func replaceSource(_ source: PairingPromptSupport.Source?) {
+        self.source?.retire()
+        self.source = source
+        self.queue.removeAll()
+        self.pairedDeviceIds.removeAll()
+        self.trustUnknownRequestIds.removeAll()
+        self.pendingLocalDecisionRequestIds.removeAll(keepingCapacity: false)
+        self.updatePendingCounts()
+        self.syncCards()
+    }
+
+    private func owns(_ source: PairingPromptSupport.Source) -> Bool {
+        self.source === source && source.isCurrent
+    }
+
+    private func loadPendingRequestsFromGateway(source: PairingPromptSupport.Source) async {
+        guard self.owns(source) else { return }
         do {
-            let list: PairingList = try await GatewayConnection.shared.requestDecoded(method: .devicePairList)
-            guard generation == self.listFetchGeneration else { return }
-            self.apply(list: list)
+            try await source.refreshList(method: GatewayConnection.Method.devicePairList.rawValue) { data in
+                let list = try JSONDecoder().decode(PairingList.self, from: data)
+                self.apply(list: list)
+            }
         } catch {
+            guard self.owns(source) else { return }
             self.logger.error("failed to load device pairing requests: \(error.localizedDescription, privacy: .public)")
         }
     }
 
     private func apply(list: PairingList) {
-        if self.isStopping {
-            return
-        }
         self.pairedDeviceIds = Set((list.paired ?? []).map(\.deviceId))
         self.queue = list.pending.sorted(by: { $0.ts < $1.ts })
         // This snapshot is authoritative for every pending request in it.
@@ -120,13 +129,12 @@ final class DevicePairingApprovalPrompter {
     }
 
     private func syncCards() {
-        guard !self.isStopping else { return }
         // A pending local decision hides the card immediately (the decision is
         // optimistic); the failure path re-syncs so the card can come back.
         let cards = self.queue
             .filter { !self.pendingLocalDecisionRequestIds.contains($0.requestId) }
             .map { self.card(for: $0) }
-        PairingApprovalCenter.shared.sync(kind: .device, cards: cards)
+        self.center.sync(kind: .device, cards: cards)
     }
 
     private func card(for req: PendingRequest) -> PairingApprovalCenter.Card {
@@ -149,23 +157,26 @@ final class DevicePairingApprovalPrompter {
             previouslyPaired: self.trustUnknownRequestIds.contains(req.requestId)
                 ? nil
                 : self.pairedDeviceIds.contains(req.deviceId),
-            requestedAt: Date(timeIntervalSince1970: req.ts / 1000))
+            requestedAt: Date(timeIntervalSince1970: req.ts / 1000),
+            source: self.source)
     }
 
     private func handleDecision(card: PairingApprovalCenter.Card, decision: PairingApprovalCenter.Decision) async {
-        guard !self.isStopping else { return }
-        guard let request = self.queue.first(where: { $0.requestId == card.requestId }) else { return }
+        guard let source = card.source, self.owns(source),
+              let request = self.queue.first(where: { $0.requestId == card.requestId })
+        else {
+            self.logger.info("pairing decision discarded because its request or Gateway connection changed")
+            return
+        }
 
         self.pendingLocalDecisionRequestIds.insert(request.requestId)
         // Optimistic dismiss: the card leaves the panel before the RPC
         // round-trip.
         self.syncCards()
-        let rpcOk: Bool = switch decision {
-        case .approve:
-            await self.approve(requestId: request.requestId)
-        case .reject:
-            await self.reject(requestId: request.requestId)
-        }
+        let rpcOk = await PairingPromptSupport.decide(
+            requestId: request.requestId, kind: .device, decision: decision, source: source, logger: self.logger)
+        guard self.owns(source) else { return }
+        source.invalidateList()
         self.pendingLocalDecisionRequestIds.remove(request.requestId)
 
         if !rpcOk {
@@ -173,12 +184,14 @@ final class DevicePairingApprovalPrompter {
             // failure: re-sync with gateway truth so stale cards collapse. A
             // request that is genuinely still pending comes back, and the
             // notification explains why the optimistic dismiss did not stick.
-            await self.loadPendingRequestsFromGateway()
+            await self.loadPendingRequestsFromGateway(source: source)
+            guard self.owns(source) else { return }
             self.syncCards()
             if self.queue.contains(where: { $0.requestId == request.requestId }) {
                 await PairingPromptSupport.notifyDecisionFailed(
                     kind: .device,
                     decision: decision,
+                    source: source,
                     subject: PairingPromptSupport.subjectLabel(
                         displayName: request.displayName,
                         fallback: request.deviceId))
@@ -186,41 +199,27 @@ final class DevicePairingApprovalPrompter {
             return
         }
 
-        // Discard any in-flight list snapshot: it predates this resolution
-        // and applying it would resurrect the just-resolved card.
-        self.listFetchGeneration += 1
         self.queue.removeAll { $0.requestId == request.requestId }
         self.updatePendingCounts()
         self.syncCards()
     }
 
-    private func approve(requestId: String) async -> Bool {
-        await PairingPromptSupport.approveRequest(
-            requestId: requestId,
-            kind: "device",
-            logger: self.logger)
-        {
-            try await GatewayConnection.shared.devicePairApprove(requestId: requestId)
+    private func handle(delivery: GatewayConnection.PushDelivery) {
+        guard let push = delivery.push else {
+            if self.source?.lease == delivery.serverLease { self.replaceSource(nil) }
+            return
         }
-    }
-
-    private func reject(requestId: String) async -> Bool {
-        await PairingPromptSupport.rejectRequest(
-            requestId: requestId,
-            kind: "device",
-            logger: self.logger)
-        {
-            try await GatewayConnection.shared.devicePairReject(requestId: requestId)
+        guard delivery.isCurrent else { return }
+        if self.source?.lease != delivery.serverLease {
+            self.replaceSource(.init(lease: delivery.serverLease, gateway: self.gateway))
         }
-    }
-
-    private func handle(push: GatewayPush) {
+        guard let source = self.source else { return }
         switch push {
         case let .event(evt) where evt.event == "device.pair.requested":
             guard let payload = evt.payload else { return }
             do {
                 let req = try GatewayPayloadDecoding.decode(payload, as: PendingRequest.self)
-                self.enqueue(req)
+                self.enqueue(req, source: source)
             } catch {
                 self.logger
                     .error("failed to decode device pairing request: \(error.localizedDescription, privacy: .public)")
@@ -229,12 +228,17 @@ final class DevicePairingApprovalPrompter {
             guard let payload = evt.payload else { return }
             do {
                 let resolved = try GatewayPayloadDecoding.decode(payload, as: PairingResolvedEvent.self)
-                self.handleResolved(resolved)
+                self.handleResolved(resolved, source: source)
             } catch {
                 self.logger
                     .error(
                         "failed to decode device pairing resolution: \(error.localizedDescription, privacy: .public)")
             }
+        case .snapshot:
+            Task { await self.loadPendingRequestsFromGateway(source: source) }
+        case .seqGap:
+            source.invalidateList()
+            Task { await self.loadPendingRequestsFromGateway(source: source) }
         default:
             break
         }
@@ -249,8 +253,9 @@ final class DevicePairingApprovalPrompter {
         return queue.filter { $0.deviceId != req.deviceId } + [req]
     }
 
-    private func enqueue(_ req: PendingRequest) {
+    private func enqueue(_ req: PendingRequest, source: PairingPromptSupport.Source) {
         guard let next = Self.coalescedQueue(self.queue, adding: req) else { return }
+        source.invalidateList()
         self.queue = next
         self.trustUnknownRequestIds.insert(req.requestId)
         self.updatePendingCounts()
@@ -258,14 +263,14 @@ final class DevicePairingApprovalPrompter {
         // The "previously paired" trust signal must not come from a stale
         // startup snapshot; re-fetch gateway truth for each new request.
         Task { @MainActor [weak self] in
-            await self?.loadPendingRequestsFromGateway()
+            await self?.loadPendingRequestsFromGateway(source: source)
         }
     }
 
-    private func handleResolved(_ resolved: PairingResolvedEvent) {
+    private func handleResolved(_ resolved: PairingResolvedEvent, source: PairingPromptSupport.Source) {
         // Discard any in-flight list snapshot taken before this resolution
         // so it cannot resurrect the resolved card.
-        self.listFetchGeneration += 1
+        source.invalidateList()
         self.queue.removeAll { $0.requestId == resolved.requestId }
         self.updatePendingCounts()
         self.syncCards()

--- a/apps/macos/Sources/OpenClaw/ExecApprovalQueueStore.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalQueueStore.swift
@@ -10,12 +10,14 @@ struct ExecApprovalQueueItem: Decodable, Identifiable {
         case systemAgent
     }
 
+    // The Gateway's durable operator_approvals registry shares IDs across kinds.
     let id: String
     let request: ExecApprovalPromptRequest
     let createdAtMs: Int
     let expiresAtMs: Int
     let kind: ApprovalKind
     let allowedDecisions: [ExecApprovalDecision]
+    fileprivate var serverLease: GatewayConnection.ServerLease?
 
     init(
         id: String,
@@ -50,15 +52,21 @@ struct ExecApprovalQueueItem: Decodable, Identifiable {
             policyPresent: requestContainer.contains(.allowedDecisions))
     }
 
-    func assigningKind(_ kind: ApprovalKind) -> Self {
+    fileprivate func owned(by lease: GatewayConnection.ServerLease, kind: ApprovalKind = .exec) -> Self {
         var request = self.request
         request.allowedDecisions = self.allowedDecisions
-        return Self(
+        var owned = Self(
             id: self.id,
             request: request,
             createdAtMs: self.createdAtMs,
             expiresAtMs: self.expiresAtMs,
             kind: kind)
+        owned.serverLease = lease
+        return owned
+    }
+
+    fileprivate func hasSameSource(as other: Self) -> Bool {
+        self.id == other.id && self.kind == other.kind && self.serverLease == other.serverLease
     }
 
     private static func inlineDecisions(
@@ -91,6 +99,10 @@ final class ExecApprovalQueueStore {
     @ObservationIgnored private let logger = Logger(subsystem: "ai.openclaw", category: "exec-approvals.queue")
     @ObservationIgnored private let gateway: GatewayConnection
     @ObservationIgnored private var eventTask: Task<Void, Never>?
+    @ObservationIgnored private var admittedLease: GatewayConnection.ServerLease?
+    @ObservationIgnored private var pendingRefresh: (
+        lease: GatewayConnection.ServerLease,
+        task: Task<Void, Never>)?
     @ObservationIgnored private var expiryTasks: [String: Task<Void, Never>] = [:]
     @ObservationIgnored private var refreshGeneration: UInt64 = 0
 
@@ -101,9 +113,9 @@ final class ExecApprovalQueueStore {
     func start() {
         guard self.eventTask == nil else { return }
         self.eventTask = Task { [weak self, gateway] in
-            for await push in await gateway.subscribe(bufferingNewest: 200) {
+            for await delivery in await gateway.subscribe(bufferingNewest: 200) {
                 guard !Task.isCancelled, let self else { return }
-                self.handle(push: push)
+                self.handle(delivery: delivery)
             }
         }
     }
@@ -111,6 +123,9 @@ final class ExecApprovalQueueStore {
     func stop() {
         self.eventTask?.cancel()
         self.eventTask = nil
+        self.pendingRefresh?.task.cancel()
+        self.pendingRefresh = nil
+        self.admittedLease = nil
         for task in self.expiryTasks.values {
             task.cancel()
         }
@@ -121,26 +136,87 @@ final class ExecApprovalQueueStore {
     func refresh() async {
         let generation = self.refreshGeneration
         do {
-            let listed: [ExecApprovalQueueItem] = try await self.gateway.requestDecoded(
-                method: .execApprovalList,
-                timeoutMs: 10000)
-            // A resolution received during the request owns newer state; an old
-            // list must never resurrect its already-dismissed approval card.
-            guard generation == self.refreshGeneration, !Task.isCancelled else { return }
-            let nowMs = Self.currentTimeMs()
-            let systemApprovals = self.requests.filter { $0.kind == .systemAgent && $0.expiresAtMs > nowMs }
-            self.replaceRequests(listed.filter { $0.expiresAtMs > nowMs } + systemApprovals)
+            let lease = try await self.gateway.acquireServerLease()
+            guard generation == self.refreshGeneration, !Task.isCancelled,
+                  self.gateway.serverLeaseMatchesCurrentState(lease)
+            else { return }
+            self.admit(lease)
+            await self.reconcile(lease).value
         } catch {
             guard !Task.isCancelled else { return }
             self.logger.error("exec approval listing failed \(error.localizedDescription, privacy: .public)")
         }
     }
 
+    @discardableResult
+    private func admit(_ lease: GatewayConnection.ServerLease) -> Bool {
+        guard self.admittedLease != lease else { return false }
+        self.admittedLease = lease
+        self.replaceRequests(self.requests.filter { $0.serverLease == lease })
+        return true
+    }
+
+    private func reconcile(_ lease: GatewayConnection.ServerLease) -> Task<Void, Never> {
+        if let pending = self.pendingRefresh, pending.lease == lease {
+            return pending.task
+        }
+        self.pendingRefresh?.task.cancel()
+        let task = Task { [weak self] in
+            guard !Task.isCancelled, let self else { return }
+            defer {
+                // A replacement cancels its predecessor before installing its own task.
+                if !Task.isCancelled { self.pendingRefresh = nil }
+            }
+            do {
+                while !Task.isCancelled, self.gateway.serverLeaseMatchesCurrentState(lease) {
+                    let generation = self.refreshGeneration
+                    async let exec = self.listRequests(kind: .exec, lease: lease)
+                    async let system = self.listRequests(kind: .systemAgent, lease: lease)
+                    let listed = try await exec + system
+                    guard !Task.isCancelled, self.gateway.serverLeaseMatchesCurrentState(lease) else { return }
+                    // Reconcile again after newer events so untouched pending rows are still recovered.
+                    guard generation == self.refreshGeneration else { continue }
+                    self.replaceRequests(listed.filter { $0.expiresAtMs > Self.currentTimeMs() })
+                    return
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.logger.error("exec approval listing failed \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        self.pendingRefresh = (lease, task)
+        return task
+    }
+
+    private func listRequests(
+        kind: ExecApprovalQueueItem.ApprovalKind,
+        lease: GatewayConnection.ServerLease) async throws -> [ExecApprovalQueueItem]
+    {
+        let method = kind == .exec ? "exec.approval.list" : "openclaw.approval.list"
+        if kind == .systemAgent,
+           await self.gateway.supportsServerMethod(method, ifCurrentServerLease: lease) != true
+        {
+            return []
+        }
+        let data = try await self.gateway.request(
+            method: method,
+            params: nil,
+            timeoutMs: 10000,
+            ifCurrentServerLease: lease)
+        return try JSONDecoder().decode([ExecApprovalQueueItem].self, from: data)
+            .map { $0.owned(by: lease, kind: kind) }
+    }
+
     func resolve(request: ExecApprovalQueueItem, decision: ExecApprovalDecision) async {
         guard request.allowedDecisions.contains(decision),
               decision != .allowAlways,
-              self.requests.contains(where: { $0.id == request.id })
-        else { return }
+              request.expiresAtMs > Self.currentTimeMs(),
+              let lease = request.serverLease,
+              self.requests.contains(where: { $0.hasSameSource(as: request) })
+        else {
+            self.logger.info("exec approval decision ignored; request or available decisions changed")
+            return
+        }
 
         var params: [String: AnyCodable] = [
             "id": AnyCodable(request.id),
@@ -156,10 +232,17 @@ final class ExecApprovalQueueStore {
         }
 
         do {
-            try await self.gateway.requestVoid(method: method, params: params, timeoutMs: 10000)
-            self.removeRequest(id: request.id)
+            _ = try await self.gateway.request(
+                method: method.rawValue,
+                params: params,
+                timeoutMs: 10000,
+                ifCurrentServerLease: lease)
+            self.removeRequest(request)
         } catch {
             self.logger.error("exec approval resolution failed \(error.localizedDescription, privacy: .public)")
+            if !self.gateway.serverLeaseMatchesCurrentState(lease) {
+                self.removeRequest(request)
+            }
             // A losing race (the modal prompter or another client resolved first)
             // surfaces here as a gateway rejection. Re-list instead of parsing
             // error text so the card converges to the authoritative queue.
@@ -167,7 +250,23 @@ final class ExecApprovalQueueStore {
         }
     }
 
-    private func handle(push: GatewayPush) {
+    private func handle(delivery: GatewayConnection.PushDelivery) {
+        let serverLease = delivery.serverLease
+        guard let push = delivery.push else {
+            // Retirement still clears A's rows while replacement B is unavailable.
+            if self.pendingRefresh?.lease == serverLease {
+                self.pendingRefresh?.task.cancel()
+                self.pendingRefresh = nil
+            }
+            if self.admittedLease == serverLease { self.admittedLease = nil }
+            self.replaceRequests(self.requests.filter { $0.serverLease != serverLease })
+            return
+        }
+        guard delivery.isCurrent else { return }
+        // The short hello admission can let current events precede the ordinary snapshot.
+        if self.admit(serverLease) {
+            _ = self.reconcile(serverLease)
+        }
         guard case let .event(event) = push, let payload = event.payload else { return }
         switch event.event {
         case "exec.approval.requested", "openclaw.approval.requested":
@@ -176,7 +275,7 @@ final class ExecApprovalQueueStore {
                 let kind: ExecApprovalQueueItem.ApprovalKind = event.event == "openclaw.approval.requested"
                     ? .systemAgent
                     : .exec
-                self.insertRequest(request.assigningKind(kind))
+                self.insertRequest(request.owned(by: serverLease, kind: kind))
             } catch {
                 self.logger.error("exec approval event decode failed \(error.localizedDescription, privacy: .public)")
             }
@@ -184,7 +283,15 @@ final class ExecApprovalQueueStore {
             guard let resolved = try? GatewayPayloadDecoding.decode(payload, as: ResolvedApproval.self) else {
                 return
             }
-            self.removeRequest(id: resolved.id)
+            self.refreshGeneration &+= 1
+            let kind: ExecApprovalQueueItem.ApprovalKind = event.event == "openclaw.approval.resolved"
+                ? .systemAgent
+                : .exec
+            if let request = self.requests.first(where: {
+                $0.id == resolved.id && $0.kind == kind && $0.serverLease == serverLease
+            }) {
+                self.removeRequest(request)
+            }
         default:
             break
         }
@@ -199,10 +306,13 @@ final class ExecApprovalQueueStore {
         self.scheduleExpiry(for: request)
     }
 
-    private func removeRequest(id: String) {
+    private func removeRequest(_ request: ExecApprovalQueueItem) {
+        // A retained menu action, timer, or reply must not retire the same id
+        // admitted later from another Gateway or physical connection.
+        guard let index = self.requests.firstIndex(where: { $0.hasSameSource(as: request) }) else { return }
         self.refreshGeneration &+= 1
-        self.requests.removeAll { $0.id == id }
-        self.expiryTasks.removeValue(forKey: id)?.cancel()
+        self.requests.remove(at: index)
+        self.expiryTasks.removeValue(forKey: request.id)?.cancel()
     }
 
     private func replaceRequests(_ requests: [ExecApprovalQueueItem]) {
@@ -220,7 +330,7 @@ final class ExecApprovalQueueStore {
         self.expiryTasks.removeValue(forKey: request.id)?.cancel()
         let (remainingMs, overflow) = request.expiresAtMs.subtractingReportingOverflow(Self.currentTimeMs())
         guard !overflow, remainingMs > 0 else {
-            self.removeRequest(id: request.id)
+            self.removeRequest(request)
             return
         }
         // Task startup may be delayed; keep the Gateway's expiry deadline.
@@ -228,7 +338,7 @@ final class ExecApprovalQueueStore {
         self.expiryTasks[request.id] = Task { [weak self] in
             try? await Task.sleep(until: deadline, clock: .continuous)
             guard !Task.isCancelled else { return }
-            self?.removeRequest(id: request.id)
+            self?.removeRequest(request)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
@@ -9,7 +9,12 @@ final class ExecApprovalsGatewayPrompter {
     static let shared = ExecApprovalsGatewayPrompter()
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "exec-approvals.gateway")
+    private let gateway: GatewayConnection
     private var task: Task<Void, Never>?
+
+    init(gateway: GatewayConnection = .shared) {
+        self.gateway = gateway
+    }
 
     struct GatewayApprovalRequest: Codable {
         var id: String
@@ -29,17 +34,17 @@ final class ExecApprovalsGatewayPrompter {
     }
 
     private func run() async {
-        let stream = await GatewayConnection.shared.subscribe(bufferingNewest: 200)
-        for await push in stream {
+        let stream = await self.gateway.subscribe(bufferingNewest: 200)
+        for await delivery in stream {
             if Task.isCancelled {
                 return
             }
-            await self.handle(push: push)
+            await self.handle(delivery: delivery)
         }
     }
 
-    private func handle(push: GatewayPush) async {
-        guard case let .event(evt) = push else { return }
+    private func handle(delivery: GatewayConnection.PushDelivery) async {
+        guard delivery.isCurrent, let push = delivery.push, case let .event(evt) = push else { return }
         guard evt.event == "exec.approval.requested" || evt.event == "openclaw.approval.requested" else { return }
         guard let payload = evt.payload else { return }
         do {
@@ -58,24 +63,19 @@ final class ExecApprovalsGatewayPrompter {
             else {
                 return
             }
-            if evt.event == "openclaw.approval.requested" {
-                try await GatewayConnection.shared.requestVoid(
-                    method: .approvalResolve,
-                    params: [
-                        "id": AnyCodable(request.id),
-                        "kind": AnyCodable("system-agent"),
-                        "decision": AnyCodable(decision.rawValue),
-                    ],
-                    timeoutMs: 10000)
-            } else {
-                try await GatewayConnection.shared.requestVoid(
-                    method: .execApprovalResolve,
-                    params: [
-                        "id": AnyCodable(request.id),
-                        "decision": AnyCodable(decision.rawValue),
-                    ],
-                    timeoutMs: 10000)
+            guard delivery.isCurrent else {
+                self.logger.info("exec approval decision discarded after the Gateway connection changed")
+                return
             }
+            let isSystemAgent = evt.event == "openclaw.approval.requested"
+            var params = ["id": AnyCodable(request.id), "decision": AnyCodable(decision.rawValue)]
+            if isSystemAgent { params["kind"] = AnyCodable("system-agent") }
+            let method: GatewayConnection.Method = isSystemAgent ? .approvalResolve : .execApprovalResolve
+            _ = try await self.gateway.request(
+                method: method.rawValue,
+                params: params,
+                timeoutMs: 10000,
+                ifCurrentServerLease: delivery.serverLease)
         } catch {
             self.logger.error("exec approval handling failed \(error.localizedDescription, privacy: .public)")
         }

--- a/apps/macos/Sources/OpenClaw/GatewayConnection+Cron.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection+Cron.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import OSLog
 
 private let gatewayCronLogger = Logger(subsystem: "ai.openclaw", category: "gateway.connection")
@@ -60,5 +61,57 @@ extension GatewayConnection {
             gatewayCronLogger.warning("cron.runs skipped \(skipped, privacy: .public) malformed entries")
         }
         return entries
+    }
+
+    // MARK: - Cron
+
+    struct CronSchedulerStatus: Decodable {
+        let enabled: Bool
+        let storePath: String
+        let sqlitePath: String?
+        let jobs: Int
+        let nextWakeAtMs: Int?
+    }
+
+    func cronStatus() async throws -> CronSchedulerStatus {
+        try await self.requestDecoded(method: .cronStatus)
+    }
+
+    func cronList(includeDisabled: Bool = true) async throws -> [CronJob] {
+        let data = try await requestRaw(
+            method: .cronList,
+            params: ["includeDisabled": AnyCodable(includeDisabled)])
+        return try Self.decodeCronListResponse(data)
+    }
+
+    func cronRuns(jobId: String, limit: Int = 200) async throws -> [CronRunLogEntry] {
+        let data = try await requestRaw(
+            method: .cronRuns,
+            params: ["id": AnyCodable(jobId), "limit": AnyCodable(limit)])
+        return try Self.decodeCronRunsResponse(data)
+    }
+
+    func cronRun(jobId: String, force: Bool = true) async throws {
+        try await self.requestVoid(
+            method: .cronRun,
+            params: [
+                "id": AnyCodable(jobId),
+                "mode": AnyCodable(force ? "force" : "due"),
+            ],
+            timeoutMs: 20000)
+    }
+
+    func cronRemove(jobId: String) async throws {
+        try await self.requestVoid(method: .cronRemove, params: ["id": AnyCodable(jobId)])
+    }
+
+    func cronUpdate(jobId: String, patch: [String: AnyCodable]) async throws {
+        try await self.requestVoid(
+            method: .cronUpdate,
+            params: ["id": AnyCodable(jobId), "patch": AnyCodable(patch)])
+    }
+
+    func cronAdd(payload: [String: AnyCodable]) async throws {
+        try await self.requestVoid(method: .cronAdd, params: payload)
     }
 }

--- a/apps/macos/Sources/OpenClaw/GatewayConnection+RealtimeTalk.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection+RealtimeTalk.swift
@@ -53,7 +53,8 @@ extension GatewayConnection {
                     ifCurrentServerLease: lease)
                 return AsyncStream(bufferingPolicy: .bufferingNewest(bufferingNewest)) { continuation in
                     let task = Task {
-                        for await push in pushes {
+                        for await delivery in pushes {
+                            guard delivery.isCurrent, let push = delivery.push else { continue }
                             guard case let .event(event) = push else { continue }
                             switch continuation.yield(event) {
                             case .enqueued:
@@ -87,7 +88,7 @@ extension GatewayConnection {
 
     func subscribe(
         bufferingNewest: Int,
-        ifCurrentServerLease lease: ServerLease) -> AsyncStream<GatewayPush>
+        ifCurrentServerLease lease: ServerLease) -> AsyncStream<PushDelivery>
     {
         let id = UUID()
         let connection = self
@@ -96,8 +97,8 @@ extension GatewayConnection {
                 continuation.finish()
                 return
             }
-            if let snapshot = self.lastSnapshot {
-                switch continuation.yield(.snapshot(snapshot)) {
+            if let snapshot = self.lastSnapshot, let delivery = self.makePushDelivery(.snapshot(snapshot)) {
+                switch continuation.yield(delivery) {
                 case .enqueued:
                     break
                 case .dropped, .terminated:
@@ -127,7 +128,7 @@ extension GatewayConnection {
     }
 
     func finishRealtimeTalkSubscribers(socketGeneration: UInt64? = nil) {
-        let subscribers: [AsyncStream<GatewayPush>.Continuation]
+        let subscribers: [AsyncStream<PushDelivery>.Continuation]
         if let socketGeneration {
             if let removed = self.realtimeTalkSubscribers.removeValue(forKey: socketGeneration) {
                 subscribers = Array(removed.values)

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -8,10 +8,8 @@ import OSLog
 
 private let gatewayConnectionLogger = Logger(subsystem: "ai.openclaw", category: "gateway.connection")
 
-/// Single, shared Gateway websocket connection for the whole app.
-///
-/// This owns exactly one `GatewayChannelActor` and reuses it across all callers
-/// (ControlChannel, debug actions, SwiftUI WebChat, etc.).
+/// Owns one Gateway websocket shared by its callers. The primary app runtime
+/// uses `.shared`; saved-profile windows use independent connections.
 actor GatewayConnection {
     static let shared: GatewayConnection = {
         #if DEBUG
@@ -21,7 +19,9 @@ actor GatewayConnection {
             return GatewayConnection(testEndpointProvider: { throw URLError(.notConnectedToInternet) })
         }
         #endif
-        return GatewayConnection(endpointProvider: GatewayConnection.defaultEndpointProvider)
+        return GatewayConnection(
+            endpointProvider: GatewayConnection.defaultEndpointProvider,
+            currentEndpointRevision: { GatewayEndpointStore.shared.routeRevision })
     }()
 
     nonisolated static let operatorClientCaps = [
@@ -79,12 +79,58 @@ actor GatewayConnection {
 
     /// One connected Gateway server, not merely an endpoint configuration.
     /// A reconnect at the same URL creates a different lease.
-    struct ServerLease: Sendable {
+    struct ServerLease: Sendable, Hashable {
         // Managed-image HTTP reuses this captured route from its focused extension file.
         // Carrying the snapshot forward prevents endpoint or TLS rediscovery after suspension.
         let route: Route
         let socketGeneration: UInt64
+        let endpointRevision: UInt64?
         fileprivate let client: GatewayChannelActor
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.client === rhs.client && lhs.route.generation == rhs.route.generation &&
+                lhs.socketGeneration == rhs.socketGeneration && lhs.endpointRevision == rhs.endpointRevision
+        }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(ObjectIdentifier(self.client))
+            hasher.combine(self.route.generation)
+            hasher.combine(self.socketGeneration)
+            hasher.combine(self.endpointRevision)
+        }
+    }
+
+    struct PushDelivery: Sendable {
+        enum Event: Sendable {
+            case push(GatewayPush)
+            /// Retirement is also an exact-source cleanup receipt. It grants no
+            /// action or current-status authority when isCurrent is false.
+            case disconnected(String?)
+        }
+
+        let event: Event
+        let serverLease: ServerLease
+        let mainSessionKey: String?
+        fileprivate let currentOwner: @Sendable () -> Bool
+
+        var isCurrent: Bool {
+            self.currentOwner()
+        }
+
+        var push: GatewayPush? {
+            guard case let .push(push) = self.event else { return nil }
+            return push
+        }
+    }
+
+    private struct AdmittedConnection: Sendable {
+        let lease: ServerLease
+        let mainSessionKey: String?
+    }
+
+    private enum ConnectionPublication: Sendable {
+        case connected(AdmittedConnection)
+        case disconnected(ServerLease)
     }
 
     enum Method: String {
@@ -140,6 +186,7 @@ actor GatewayConnection {
     }
 
     private let endpointProvider: EndpointProvider
+    private nonisolated let currentEndpointRevision: (@Sendable () -> UInt64)?
     private let supportsSharedEndpointRecovery: Bool
     private let activationBindingKeyProvider: @Sendable () -> SymmetricKey?
     private let includeDeviceIdentity: Bool
@@ -169,9 +216,9 @@ actor GatewayConnection {
         }
     }
 
-    private nonisolated let connectedRevision = LockIsolated<UInt64?>(nil)
+    private nonisolated let connectionPublication = LockIsolated<ConnectionPublication?>(nil)
     private var configuredConnection: ConfiguredConnection? {
-        didSet { self.publishConnectedEndpointRevision() }
+        didSet { self.publishConnectedServerLease() }
     }
 
     private var highestEndpointRevision: UInt64?
@@ -184,23 +231,42 @@ actor GatewayConnection {
     var activeSocketGeneration: UInt64?
     private var lastRetiredSocketGeneration: UInt64?
 
-    private var subscribers: [UUID: AsyncStream<GatewayPush>.Continuation] = [:]
+    private var subscribers: [UUID: AsyncStream<PushDelivery>.Continuation] = [:]
     var realtimeTalkSubscribers: [
-        UInt64: [UUID: AsyncStream<GatewayPush>.Continuation]
+        UInt64: [UUID: AsyncStream<PushDelivery>.Continuation]
     ] = [:]
     var lastSnapshot: HelloOk? {
-        didSet { self.publishConnectedEndpointRevision() }
+        didSet { self.publishConnectedServerLease() }
     }
 
     nonisolated var connectedEndpointRevision: UInt64? {
-        self.connectedRevision.value
+        guard case let .connected(connection) = self.connectionPublication.value else { return nil }
+        return connection.lease.endpointRevision
     }
 
-    private func publishConnectedEndpointRevision() {
-        // Publish the admitted handshake's owner, not an untagged queued snapshot.
-        // Clearing either connection state also retires this synchronous UI fact.
-        let revision = self.lastSnapshot == nil ? nil : self.configuredConnection?.endpoint.revision
-        self.connectedRevision.withValue { $0 = revision }
+    private func publishConnectedServerLease() {
+        // Retirement clears authority before changing any other actor state.
+        // Only a fully admitted handshake may replace that terminal publication.
+        guard self.lastSnapshot != nil, let connection = self.configuredConnection,
+              let socketGeneration = self.activeSocketGeneration
+        else { return }
+        let endpoint = connection.endpoint
+        let lease = ServerLease(
+            route: Route(
+                generation: self.routeGeneration,
+                authority: endpoint.routeAuthority,
+                url: endpoint.config.url,
+                token: endpoint.config.token,
+                password: endpoint.config.password,
+                tls: endpoint.tls,
+                deviceAuthGatewayID: endpoint.deviceAuthGatewayID,
+                activationOwnershipFingerprint: Self.activationOwnershipFingerprint(
+                    config: endpoint.config, key: connection.activationBindingKey)),
+            socketGeneration: socketGeneration,
+            endpointRevision: endpoint.revision,
+            client: connection.client)
+        let admitted = AdmittedConnection(lease: lease, mainSessionKey: self.cachedMainSessionKey())
+        self.connectionPublication.withValue { $0 = .connected(admitted) }
     }
 
     var canvasPluginSurfaceURL: String?
@@ -214,6 +280,7 @@ actor GatewayConnection {
 
     init(
         endpointProvider: @escaping EndpointProvider = GatewayConnection.defaultEndpointProvider,
+        currentEndpointRevision: (@Sendable () -> UInt64)? = nil,
         supportsSharedEndpointRecovery: Bool = true,
         activationBindingKeyProvider: @escaping @Sendable () -> SymmetricKey? =
             GatewayConnection.defaultActivationBindingKey,
@@ -224,6 +291,7 @@ actor GatewayConnection {
         })
     {
         self.endpointProvider = endpointProvider
+        self.currentEndpointRevision = currentEndpointRevision
         self.supportsSharedEndpointRecovery = supportsSharedEndpointRecovery
         self.activationBindingKeyProvider = activationBindingKeyProvider
         self.includeDeviceIdentity = true
@@ -250,6 +318,7 @@ actor GatewayConnection {
         self.endpointProvider = {
             try await EndpointSnapshot(config: configProvider(), routeAuthority: nil)
         }
+        self.currentEndpointRevision = nil
         self.supportsSharedEndpointRecovery = false
         self.activationBindingKeyProvider = activationBindingKeyProvider
         // Mock WebSocket routes do not exercise device authentication and must not
@@ -263,9 +332,11 @@ actor GatewayConnection {
 
     init(
         testEndpointProvider: @escaping EndpointProvider,
+        currentEndpointRevision: (@Sendable () -> UInt64)? = nil,
         sessionBox: WebSocketSessionBox? = nil)
     {
         self.endpointProvider = testEndpointProvider
+        self.currentEndpointRevision = currentEndpointRevision
         self.supportsSharedEndpointRecovery = false
         self.activationBindingKeyProvider = { GatewayConnection.testingActivationBindingKey }
         // Mock WebSocket routes do not exercise device authentication and must not
@@ -680,7 +751,11 @@ extension GatewayConnection {
               let client = self.configuredConnection?.client,
               let socketGeneration = self.activeSocketGeneration
         else { return nil }
-        let lease = ServerLease(route: route, socketGeneration: socketGeneration, client: client)
+        let lease = ServerLease(
+            route: route,
+            socketGeneration: socketGeneration,
+            endpointRevision: self.configuredConnection?.endpoint.revision,
+            client: client)
         guard await self.isCurrentServerLease(lease) else { return nil }
         return lease
     }
@@ -726,6 +801,7 @@ extension GatewayConnection {
                     authBinding: authBinding,
                     key: self.configuredConnection?.activationBindingKey)),
             socketGeneration: socketGeneration,
+            endpointRevision: endpoint.revision,
             client: client)
         guard await self.isCurrentServerLease(lease) else {
             throw OpenClawChatTransportSendError.notDispatched
@@ -814,11 +890,18 @@ extension GatewayConnection {
         return lease.route.activationOwnershipFingerprint
     }
 
-    func serverLeaseMatchesCurrentState(_ lease: ServerLease) -> Bool {
-        self.routeMatchesConfiguredConnection(lease.route) &&
-            self.configuredConnection?.client === lease.client &&
-            self.activeSocketGeneration == lease.socketGeneration &&
-            self.lastSnapshot != nil
+    nonisolated func serverLeaseMatchesCurrentState(_ lease: ServerLease) -> Bool {
+        self.publicationIsCurrent(lease, connected: true)
+    }
+
+    private nonisolated func publicationIsCurrent(_ lease: ServerLease, connected: Bool) -> Bool {
+        let current: ServerLease? = switch (self.connectionPublication.value, connected) {
+        case let (.connected(connection), true): connection.lease
+        case let (.disconnected(lease), false): lease
+        default: nil
+        }
+        guard current == lease else { return false }
+        return self.currentEndpointRevision.map { $0() == lease.endpointRevision } ?? true
     }
 
     private func routeMatchesCurrentState(_ route: Route, endpoint: EndpointSnapshot) -> Bool {
@@ -853,8 +936,8 @@ extension GatewayConnection {
     }
 
     func shutdown() async {
+        let client = self.retireConfiguredConnection(disconnection: .disconnected(nil))
         self.shutdownGeneration &+= 1
-        let client = self.retireConfiguredConnection()
         if let client {
             await self.clientShutdown(client)
         }
@@ -919,10 +1002,11 @@ extension GatewayConnection {
                 includeDeviceIdentity: self.includeDeviceIdentity,
                 allowStoredDeviceAuth: endpoint.deviceAuthGatewayID != nil,
                 deviceAuthGatewayID: endpoint.deviceAuthGatewayID),
-            disconnectHandler: { [weak self] _, socketGeneration in
+            disconnectHandler: { [weak self] reason, socketGeneration in
                 await self?.handleDisconnect(
                     routeGeneration: configuredRouteGeneration,
-                    socketGeneration: socketGeneration)
+                    socketGeneration: socketGeneration,
+                    reason: reason)
             })
         self.configuredConnection = ConfiguredConnection(
             client: client,
@@ -952,7 +1036,8 @@ extension GatewayConnection {
 
     /// Invalidate every route-owned fact before shutdown can suspend; otherwise
     /// reentrant work could continue on a client whose replacement is in flight.
-    private func retireConfiguredConnection() -> GatewayChannelActor? {
+    private func retireConfiguredConnection(disconnection: PushDelivery.Event? = nil) -> GatewayChannelActor? {
+        self.retirePublication(disconnection: disconnection)
         self.routeGeneration &+= 1
         self.finishRealtimeTalkSubscribers()
         self.resetSocketGeneration()
@@ -994,9 +1079,13 @@ extension GatewayConnection {
         self.installCanvasPluginSurfaceURL(from: snapshot)
     }
 
-    private func handleDisconnect(routeGeneration: UInt64, socketGeneration: UInt64) {
+    private func handleDisconnect(
+        routeGeneration: UInt64,
+        socketGeneration: UInt64,
+        reason: String = "gateway disconnected")
+    {
         guard routeGeneration == self.routeGeneration,
-              retireSocketGeneration(socketGeneration)
+              retireSocketGeneration(socketGeneration, reason: reason)
         else { return }
         self.finishRealtimeTalkSubscribers(socketGeneration: socketGeneration)
         self.lastSnapshot = nil
@@ -1018,7 +1107,7 @@ extension GatewayConnection {
         return true
     }
 
-    private func retireSocketGeneration(_ socketGeneration: UInt64) -> Bool {
+    private func retireSocketGeneration(_ socketGeneration: UInt64, reason: String) -> Bool {
         if let lastRetiredSocketGeneration,
            socketGeneration <= lastRetiredSocketGeneration
         {
@@ -1029,6 +1118,7 @@ extension GatewayConnection {
         {
             return false
         }
+        self.retirePublication(disconnection: .disconnected(reason))
         activeSocketGeneration = nil
         lastRetiredSocketGeneration = socketGeneration
         return true
@@ -1217,13 +1307,13 @@ extension GatewayConnection {
             stateDir?.isEmpty == false ? stateDir : nil)
     }
 
-    func subscribe(bufferingNewest: Int = 100) -> AsyncStream<GatewayPush> {
+    func subscribe(bufferingNewest: Int = 100) -> AsyncStream<PushDelivery> {
         let id = UUID()
         let snapshot = self.lastSnapshot
         let connection = self
         return AsyncStream(bufferingPolicy: .bufferingNewest(bufferingNewest)) { continuation in
-            if let snapshot {
-                continuation.yield(.snapshot(snapshot))
+            if let snapshot, let delivery = self.makePushDelivery(.snapshot(snapshot)) {
+                continuation.yield(delivery)
             }
             self.subscribers[id] = continuation
             continuation.onTermination = { @Sendable _ in
@@ -1236,25 +1326,58 @@ extension GatewayConnection {
         self.subscribers[id] = nil
     }
 
+    func makePushDelivery(_ push: GatewayPush) -> PushDelivery? {
+        guard case let .connected(connection) = self.connectionPublication.value else { return nil }
+        let lease = connection.lease
+        return PushDelivery(
+            event: .push(push),
+            serverLease: lease,
+            mainSessionKey: connection.mainSessionKey,
+            currentOwner: { [weak self] in
+                self?.serverLeaseMatchesCurrentState(lease) == true
+            })
+    }
+
+    private func retirePublication(disconnection: PushDelivery.Event?) {
+        let lease = self.connectionPublication.withValue { publication -> ServerLease? in
+            let lease: ServerLease? = switch publication {
+            case let .connected(connection): connection.lease
+            case let .disconnected(lease): lease
+            case nil: nil
+            }
+            publication = disconnection == nil ? nil : lease.map(ConnectionPublication.disconnected)
+            return lease
+        }
+        guard let lease else { return }
+        // The terminal outcome survives its socket, but a replacement owner
+        // invalidates it before it can degrade the newly selected Gateway.
+        let delivery = PushDelivery(
+            event: disconnection ?? .disconnected(nil),
+            serverLease: lease,
+            mainSessionKey: nil,
+            currentOwner: { [weak self] in
+                self?.publicationIsCurrent(lease, connected: false) == true
+            })
+        for continuation in self.subscribers.values {
+            continuation.yield(delivery)
+        }
+    }
+
     private func broadcast(_ push: GatewayPush) {
         if case let .snapshot(snapshot) = push {
             self.lastSnapshot = snapshot
             if self.canvasPluginSurfaceURL == nil {
                 self.installCanvasPluginSurfaceURL(from: snapshot)
             }
-            if let mainSessionKey = cachedMainSessionKey() {
-                Task { @MainActor in
-                    WorkActivityStore.shared.setMainSessionKey(mainSessionKey)
-                }
-            }
         }
+        guard let delivery = self.makePushDelivery(push) else { return }
         for (_, continuation) in self.subscribers {
-            continuation.yield(push)
+            continuation.yield(delivery)
         }
         if let socketGeneration = self.activeSocketGeneration {
             var terminatedSubscriberIDs: [UUID] = []
             for (id, continuation) in self.realtimeTalkSubscribers[socketGeneration] ?? [:] {
-                switch continuation.yield(push) {
+                switch continuation.yield(delivery) {
                 case .enqueued:
                     break
                 case .dropped, .terminated:
@@ -1562,12 +1685,6 @@ extension GatewayConnection {
 
     // MARK: - VoiceWake
 
-    func voiceWakeGetTriggers() async throws -> [String] {
-        struct VoiceWakePayload: Decodable { let triggers: [String] }
-        let payload: VoiceWakePayload = try await requestDecoded(method: .voicewakeGet)
-        return payload.triggers
-    }
-
     func voiceWakeSetTriggers(_ triggers: [String]) async {
         do {
             try await self.requestVoid(
@@ -1577,89 +1694,5 @@ extension GatewayConnection {
         } catch {
             // Best-effort only.
         }
-    }
-
-    // MARK: - Node pairing
-
-    func nodePairApprove(requestId: String) async throws {
-        try await self.requestVoid(
-            method: .nodePairApprove,
-            params: ["requestId": AnyCodable(requestId)],
-            timeoutMs: 10000)
-    }
-
-    func nodePairReject(requestId: String) async throws {
-        try await self.requestVoid(
-            method: .nodePairReject,
-            params: ["requestId": AnyCodable(requestId)],
-            timeoutMs: 10000)
-    }
-
-    // MARK: - Device pairing
-
-    func devicePairApprove(requestId: String) async throws {
-        try await self.requestVoid(
-            method: .devicePairApprove,
-            params: ["requestId": AnyCodable(requestId)],
-            timeoutMs: 10000)
-    }
-
-    func devicePairReject(requestId: String) async throws {
-        try await self.requestVoid(
-            method: .devicePairReject,
-            params: ["requestId": AnyCodable(requestId)],
-            timeoutMs: 10000)
-    }
-
-    // MARK: - Cron
-
-    struct CronSchedulerStatus: Decodable {
-        let enabled: Bool
-        let storePath: String
-        let sqlitePath: String?
-        let jobs: Int
-        let nextWakeAtMs: Int?
-    }
-
-    func cronStatus() async throws -> CronSchedulerStatus {
-        try await self.requestDecoded(method: .cronStatus)
-    }
-
-    func cronList(includeDisabled: Bool = true) async throws -> [CronJob] {
-        let data = try await requestRaw(
-            method: .cronList,
-            params: ["includeDisabled": AnyCodable(includeDisabled)])
-        return try Self.decodeCronListResponse(data)
-    }
-
-    func cronRuns(jobId: String, limit: Int = 200) async throws -> [CronRunLogEntry] {
-        let data = try await requestRaw(
-            method: .cronRuns,
-            params: ["id": AnyCodable(jobId), "limit": AnyCodable(limit)])
-        return try Self.decodeCronRunsResponse(data)
-    }
-
-    func cronRun(jobId: String, force: Bool = true) async throws {
-        try await self.requestVoid(
-            method: .cronRun,
-            params: [
-                "id": AnyCodable(jobId),
-                "mode": AnyCodable(force ? "force" : "due"),
-            ],
-            timeoutMs: 20000)
-    }
-
-    func cronRemove(jobId: String) async throws {
-        try await self.requestVoid(method: .cronRemove, params: ["id": AnyCodable(jobId)])
-    }
-
-    func cronUpdate(jobId: String, patch: [String: AnyCodable]) async throws {
-        try await self.requestVoid(
-            method: .cronUpdate,
-            params: ["id": AnyCodable(jobId), "patch": AnyCodable(patch)])
-    }
-
-    func cronAdd(payload: [String: AnyCodable]) async throws {
-        try await self.requestVoid(method: .cronAdd, params: payload)
     }
 }

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -74,6 +74,20 @@ enum GatewayDiscoveryPreferences {
     /// This intentionally ignores discovery ids: manual direct/SSH selections
     /// must still isolate device tokens before discovery has identified them.
     static func deviceAuthGatewayID(
+        root: [String: Any],
+        connectionMode: AppState.ConnectionMode? = nil) -> String?
+    {
+        let mode = connectionMode ?? ConnectionModeResolver.resolve(root: root).mode
+        let resolution = GatewayRemoteConfig.resolveTransportResolution(root: root)
+        return self.deviceAuthGatewayID(
+            connectionMode: mode,
+            remoteTransport: resolution.transport,
+            remoteURL: resolution.directURL?.absoluteString ?? GatewayRemoteConfig.resolveUrlString(root: root) ?? "",
+            remoteTarget: resolution.transport == .ssh ? CommandResolver.connectionSettings(configRoot: root)
+                .target : "")
+    }
+
+    static func deviceAuthGatewayID(
         connectionMode: AppState.ConnectionMode,
         remoteTransport: AppState.RemoteTransport,
         remoteURL: String,

--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -369,7 +369,7 @@ actor GatewayEndpointStore {
 
     private var state: GatewayEndpointState
     private var subscribers: [UUID: AsyncStream<GatewayEndpointState>.Continuation] = [:]
-    private var remoteEnsure: (token: UUID, task: Task<RemoteTunnelManager.Route, Error>)?
+    private var remoteEnsure: (token: UUID, task: Task<GatewayConnection.EndpointSnapshot, Error>)?
     private var resolvedEndpoint: GatewayConnection.EndpointSnapshot?
     private nonisolated let endpointRevision = LockIsolated<UInt64>(1)
     private var resolutionGeneration: UInt64 = 0
@@ -551,15 +551,19 @@ actor GatewayEndpointStore {
                 self.publishReadyEndpoint(source: source, url: url)
                 return
             }
+            let endpointBeforeLookup = self.resolvedEndpoint
             let route = await deps.remoteRouteIfRunning()
+            guard await self.sourceIsCurrent(source, generation: generation) else { return }
+            // An overlapping ensure owns completion. Its new endpoint also wins
+            // over a lookup that captured the previous tunnel before suspending.
+            guard self.remoteEnsure == nil,
+                  self.resolvedEndpoint?.revision == endpointBeforeLookup?.revision,
+                  self.resolvedEndpoint?.routeAuthority == endpointBeforeLookup?.routeAuthority
+            else { return }
             guard let route else {
-                guard await self.sourceIsCurrent(source, generation: generation) else { return }
-                self.setState(.connecting(mode: .remote, detail: Self.remoteConnectingDetail))
-                self.kickRemoteEnsureIfNeeded(detail: Self.remoteConnectingDetail)
+                self.kickRemoteEnsureIfNeeded(source: source, generation: generation)
                 return
             }
-            guard await self.sourceIsCurrent(source, generation: generation) else { return }
-            self.cancelRemoteEnsure()
             let url = URL(string: "\(source.scheme)://127.0.0.1:\(Int(route.localPort))")!
             self.publishReadyEndpoint(source: source, url: url, routeAuthority: route.generation)
         case .unconfigured:
@@ -608,8 +612,7 @@ actor GatewayEndpointStore {
         } else {
             try await self.ensureRemoteEndpoint(
                 source: context.source,
-                generation: context.generation,
-                detail: Self.remoteConnectingDetail)
+                generation: context.generation)
         }
         guard let portInt = endpoint.config.url.port, let port = UInt16(exactly: portInt) else {
             throw NSError(
@@ -650,8 +653,7 @@ actor GatewayEndpointStore {
             }
             return try await self.ensureRemoteEndpoint(
                 source: context.source,
-                generation: context.generation,
-                detail: Self.remoteConnectingDetail)
+                generation: context.generation)
         case let .unavailable(mode, reason, _):
             guard mode == .remote else {
                 throw NSError(domain: "GatewayEndpoint", code: 1, userInfo: [NSLocalizedDescriptionKey: reason])
@@ -663,8 +665,7 @@ actor GatewayEndpointStore {
                 "endpoint unavailable; ensuring remote control tunnel reason=\(reason, privacy: .public)")
             return try await self.ensureRemoteEndpoint(
                 source: context.source,
-                generation: context.generation,
-                detail: Self.remoteConnectingDetail)
+                generation: context.generation)
         }
     }
 
@@ -674,28 +675,27 @@ actor GatewayEndpointStore {
     }
 
     @discardableResult
-    private func kickRemoteEnsureIfNeeded(detail: String) -> Bool {
-        guard self.deps.canStartRemoteTunnel() else {
-            self.setState(.connecting(mode: .remote, detail: detail))
-            return false
-        }
-        if self.remoteEnsure != nil {
-            self.setState(.connecting(mode: .remote, detail: detail))
-            return true
-        }
+    private func kickRemoteEnsureIfNeeded(
+        source: SourceSnapshot,
+        generation: UInt64) -> Task<GatewayConnection.EndpointSnapshot, Error>?
+    {
+        if let ensure = self.remoteEnsure { return ensure.task }
+        self.setState(.connecting(mode: .remote, detail: Self.remoteConnectingDetail))
+        guard self.deps.canStartRemoteTunnel() else { return nil }
 
-        let deps = deps
         let token = UUID()
-        let task = Task.detached(priority: .utility) { try await deps.ensureRemoteTunnel() }
+        // The endpoint owner publishes completion even if every requester leaves.
+        // Canceling a waiter must not strand a successfully recreated SSH tunnel.
+        let task = Task(priority: .utility) {
+            try await self.runRemoteEnsure(source: source, generation: generation, token: token)
+        }
         self.remoteEnsure = (token: token, task: task)
-        self.setState(.connecting(mode: .remote, detail: detail))
-        return true
+        return task
     }
 
     private func ensureRemoteEndpoint(
         source: SourceSnapshot,
-        generation: UInt64,
-        detail: String) async throws -> GatewayConnection.EndpointSnapshot
+        generation: UInt64) async throws -> GatewayConnection.EndpointSnapshot
     {
         try Task.checkCancellation()
         guard source.mode == .remote,
@@ -717,88 +717,55 @@ actor GatewayEndpointStore {
             return self.publishReadyEndpoint(source: source, url: url)
         }
 
-        guard self.kickRemoteEnsureIfNeeded(detail: detail) else {
+        guard let task = self.kickRemoteEnsureIfNeeded(source: source, generation: generation) else {
             throw CancellationError()
         }
-        guard let ensure = remoteEnsure else {
-            throw NSError(domain: "GatewayEndpoint", code: 1, userInfo: [NSLocalizedDescriptionKey: "Connecting…"])
-        }
-
-        let route: RemoteTunnelManager.Route
         do {
-            route = try await ensure.task.value
-        } catch {
-            if Task.isCancelled {
-                throw CancellationError()
-            }
-            guard self.remoteEnsure?.token == ensure.token,
-                  await self.sourceIsCurrent(source, generation: generation),
-                  self.remoteEnsure?.token == ensure.token
+            let endpoint = try await task.value
+            guard await self.sourceIsCurrent(source, generation: generation),
+                  self.resolvedEndpoint?.revision == endpoint.revision
             else { throw CancellationError() }
-            self.remoteEnsure = nil
-            if error is CancellationError {
-                self.setState(.connecting(mode: .remote, detail: detail))
-                throw error
-            }
-            let msg = "Remote control tunnel failed (\(error.localizedDescription))"
-            self.setState(.unavailable(mode: .remote, reason: msg))
-            self.logger.error("remote control tunnel ensure failed \(msg, privacy: .public)")
-            throw NSError(domain: "GatewayEndpoint", code: 1, userInfo: [NSLocalizedDescriptionKey: msg])
+            return endpoint
+        } catch {
+            guard await self.sourceIsCurrent(source, generation: generation) else { throw CancellationError() }
+            throw error
         }
-
-        try Task.checkCancellation()
-        let routeIsCurrent = await deps.remoteRouteIsCurrent(route)
-        try Task.checkCancellation()
-        guard await self.sourceIsCurrent(source, generation: generation) else {
-            throw CancellationError()
-        }
-        guard routeIsCurrent else {
-            if self.remoteEnsure?.token == ensure.token {
-                self.remoteEnsure = nil
-            }
-            return try await self.ensureRemoteEndpoint(
-                source: source,
-                generation: generation,
-                detail: detail)
-        }
-        guard self.remoteEnsure?.token == ensure.token else {
-            if let endpoint = matchingReadyRemoteEndpoint(
-                route: route,
-                source: source,
-                generation: generation)
-            {
-                return endpoint
-            }
-            throw CancellationError()
-        }
-        self.remoteEnsure = nil
-
-        let url = URL(string: "\(source.scheme)://127.0.0.1:\(Int(route.localPort))")!
-        return self.publishReadyEndpoint(source: source, url: url, routeAuthority: route.generation)
     }
 
-    private func matchingReadyRemoteEndpoint(
-        route: RemoteTunnelManager.Route,
+    private func runRemoteEnsure(
         source: SourceSnapshot,
-        generation: UInt64) -> GatewayConnection.EndpointSnapshot?
+        generation: UInt64,
+        token: UUID) async throws -> GatewayConnection.EndpointSnapshot
     {
-        let url = URL(string: "\(source.scheme)://127.0.0.1:\(Int(route.localPort))")!
-        guard generation == self.resolutionGeneration,
-              self.activeSource == source,
-              let endpoint = resolvedEndpoint,
-              endpoint.config.url == url,
-              endpoint.config.token == source.token,
-              endpoint.config.password == source.password,
-              endpoint.deviceAuthGatewayID == source.deviceAuthGatewayID,
-              endpoint.routeAuthority == route.generation,
-              state == .ready(
-                  mode: .remote,
-                  url: url,
-                  token: source.token,
-                  password: source.password,
-                  routeRevision: endpoint.revision ?? 0)
-        else { return nil }
-        return endpoint
+        defer {
+            if self.remoteEnsure?.token == token { self.remoteEnsure = nil }
+        }
+        do {
+            while true {
+                guard self.remoteEnsure?.token == token,
+                      await self.sourceIsCurrent(source, generation: generation)
+                else { throw CancellationError() }
+                let route = try await self.deps.ensureRemoteTunnel()
+                try Task.checkCancellation()
+                let routeIsCurrent = await self.deps.remoteRouteIsCurrent(route)
+                guard await self.sourceIsCurrent(source, generation: generation),
+                      self.remoteEnsure?.token == token
+                else { throw CancellationError() }
+                guard routeIsCurrent else { continue }
+
+                let url = URL(string: "\(source.scheme)://127.0.0.1:\(Int(route.localPort))")!
+                return self.publishReadyEndpoint(source: source, url: url, routeAuthority: route.generation)
+            }
+        } catch {
+            guard await self.sourceIsCurrent(source, generation: generation),
+                  self.remoteEnsure?.token == token
+            else { throw CancellationError() }
+            if error is CancellationError { throw error }
+            let message = "Remote control tunnel failed (\(error.localizedDescription))"
+            self.setState(.unavailable(mode: .remote, reason: message))
+            self.logger.error("remote control tunnel ensure failed \(message, privacy: .public)")
+            throw NSError(domain: "GatewayEndpoint", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+        }
     }
 
     private func removeSubscriber(_ id: UUID) {

--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -992,8 +992,12 @@ extension GatewayEndpointStore {
                     generation: AppStateStore.shared.gatewayRoutingGeneration,
                     tailscaleIP: TailscaleService.shared.tailscaleIP)
             },
-            generationIsCurrent: { generation in
-                AppStateStore.shared.gatewayRoutingGeneration == generation
+            acceptSource: { source in
+                guard AppStateStore.shared.gatewayRoutingGeneration == source.routingGeneration else { return false }
+                // Close the old native transcript owner before a new route can reach
+                // RPC, including disk edits that beat the config watcher.
+                WebChatManager.shared.preparePrimaryGateway(gatewayID: source.deviceAuthGatewayID)
+                return true
             },
             profile: .current,
             beforeConfigRead: {})
@@ -1014,7 +1018,7 @@ extension GatewayEndpointStore {
 
     private static func liveSourceSnapshot(
         appSnapshot: @escaping @MainActor @Sendable () -> LiveAppSnapshot,
-        generationIsCurrent: @escaping @MainActor @Sendable (UInt64) -> Bool,
+        acceptSource: @escaping @MainActor @Sendable (SourceSnapshot) -> Bool,
         profile: AppProfile,
         beforeConfigRead: @escaping @Sendable () async -> Void) async throws -> SourceSnapshot
     {
@@ -1051,13 +1055,7 @@ extension GatewayEndpointStore {
         } else {
             sshRouteIdentity = nil
         }
-        let deviceAuthGatewayID = GatewayDiscoveryPreferences.deviceAuthGatewayID(
-            connectionMode: mode,
-            remoteTransport: remoteResolution.transport,
-            remoteURL: remoteResolution.directURL?.absoluteString
-                ?? GatewayRemoteConfig.resolveUrlString(root: root)
-                ?? "",
-            remoteTarget: sshRouteIdentity?.target ?? "")
+        let deviceAuthGatewayID = GatewayDiscoveryPreferences.deviceAuthGatewayID(root: root, connectionMode: mode)
 
         let source = SourceSnapshot(
             routingGeneration: app.generation,
@@ -1088,7 +1086,7 @@ extension GatewayEndpointStore {
             directRemoteURL: remoteResolution.directURL,
             remoteTLSFingerprint: isRemote ? GatewayRemoteConfig.resolveTLSFingerprint(root: root) : nil,
             sshRouteIdentity: sshRouteIdentity)
-        let selectionIsCurrent = await generationIsCurrent(app.generation)
+        let selectionIsCurrent = await acceptSource(source)
         guard selectionIsCurrent, !Task.isCancelled else {
             // An obsolete read is not an unconfigured selection. Do not publish
             // a fabricated route that can retire the newer selection's authority.
@@ -1327,8 +1325,8 @@ extension GatewayEndpointStore {
                     generation: state.gatewayRoutingGeneration,
                     tailscaleIP: nil)
             },
-            generationIsCurrent: { generation in
-                state.gatewayRoutingGeneration == generation
+            acceptSource: { source in
+                state.gatewayRoutingGeneration == source.routingGeneration
             },
             profile: profile,
             beforeConfigRead: beforeConfigRead)

--- a/apps/macos/Sources/OpenClaw/GatewayPushSubscription.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayPushSubscription.swift
@@ -3,32 +3,35 @@ import OpenClawKit
 enum GatewayPushSubscription {
     @MainActor
     static func consume(
+        connection: GatewayConnection = .shared,
         bufferingNewest: Int? = nil,
-        onPush: @escaping @MainActor (GatewayPush) -> Void) async
+        onPush: @escaping @MainActor (GatewayConnection.PushDelivery) -> Void) async
     {
-        let stream: AsyncStream<GatewayPush> = if let bufferingNewest {
-            await GatewayConnection.shared.subscribe(bufferingNewest: bufferingNewest)
+        let stream: AsyncStream<GatewayConnection.PushDelivery> = if let bufferingNewest {
+            await connection.subscribe(bufferingNewest: bufferingNewest)
         } else {
-            await GatewayConnection.shared.subscribe()
+            await connection.subscribe()
         }
 
-        for await push in stream {
+        for await delivery in stream {
             if Task.isCancelled { return }
-            await MainActor.run {
-                onPush(push)
-            }
+            // Validate payloads on the consumer executor. Retirement receipts
+            // also reach exact-source cleanup; status/action users must recheck.
+            if delivery.push != nil, !delivery.isCurrent { continue }
+            onPush(delivery)
         }
     }
 
     @MainActor
     static func restartTask(
         task: inout Task<Void, Never>?,
+        connection: GatewayConnection = .shared,
         bufferingNewest: Int? = nil,
-        onPush: @escaping @MainActor (GatewayPush) -> Void)
+        onPush: @escaping @MainActor (GatewayConnection.PushDelivery) -> Void)
     {
         task?.cancel()
         task = Task {
-            await self.consume(bufferingNewest: bufferingNewest, onPush: onPush)
+            await self.consume(connection: connection, bufferingNewest: bufferingNewest, onPush: onPush)
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/InstancesStore.swift
+++ b/apps/macos/Sources/OpenClaw/InstancesStore.swift
@@ -60,7 +60,8 @@ final class InstancesStore {
         self.startCount += 1
         guard self.startCount == 1 else { return }
         guard self.task == nil else { return }
-        GatewayPushSubscription.restartTask(task: &self.eventTask) { [weak self] push in
+        GatewayPushSubscription.restartTask(task: &self.eventTask) { [weak self] delivery in
+            guard let push = delivery.push else { return }
             self?.handle(push: push)
         }
         SimpleTaskSupport.startDetachedLoop(task: &self.task, interval: self.interval) { [weak self] in

--- a/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
@@ -343,16 +343,18 @@ actor MacGatewayConnectionFleet {
         return connection
     }
 
-    func remove(profileID: String) async {
-        guard let connection = self.connections.removeValue(forKey: profileID) else { return }
+    func remove(profileID: String) async -> GatewayConnection? {
+        guard let connection = self.connections.removeValue(forKey: profileID) else { return nil }
         await connection.shutdown()
+        return connection
     }
 
-    func shutdown() async {
-        let connections = self.connections.values
+    func shutdown() async -> [GatewayConnection] {
+        let connections = Array(self.connections.values)
         self.connections.removeAll()
         for connection in connections {
             await connection.shutdown()
         }
+        return connections
     }
 }

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -159,7 +159,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Start tunnel retirement before helper drains can consume the quit deadline.
         async let tunnelCleanup: Void = RemoteTunnelManager.shared.shutdown()
         async let gatewayCleanup: Void = GatewayConnection.shared.shutdown()
-        async let profileCleanup: Void = MacGatewayConnectionFleet.shared.shutdown()
+        async let profileCleanup = MacGatewayConnectionFleet.shared.shutdown()
         // CUA must drain its worker before the node closes the daemon socket.
         if AppLaunchRuntimePlan.current.allowsCuaComputerControl {
             await CuaDriverHostCoordinator.shared.shutdown()
@@ -388,10 +388,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Developer/testing helper: auto-open chat when launched with --chat (or legacy --webchat).
         if launchPlan.shouldAutoOpenChat(arguments: CommandLine.arguments) {
             self.webChatAutoLogger.debug("Auto-opening chat via CLI flag")
-            Task { @MainActor in
-                let sessionKey = await WebChatManager.shared.preferredSessionKey()
-                WebChatManager.shared.show(sessionKey: sessionKey)
-            }
+            WebChatManager.shared.show()
         }
         if launchPlan.shouldAutoOpenDashboard(arguments: CommandLine.arguments) {
             self.webChatAutoLogger.info("Auto-opening dashboard via CLI flag")

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -316,10 +316,6 @@ final class MacNodeModeCoordinator: NSObject {
             computerControlProvider: ComputerControlProvider.current())
     }
 
-    func currentCanvasPluginSurfaceRoute() async -> GatewayCanvasHostRoute? {
-        await self.session.currentCanvasHostRoute()
-    }
-
     func setPresenceActivityReportingEnabled(_ enabled: Bool) async {
         await self.presenceReporter.setReportingEnabled(enabled)
     }
@@ -343,10 +339,6 @@ final class MacNodeModeCoordinator: NSObject {
                 "mac node presence clear failed: \(error.localizedDescription, privacy: .public)")
             return .retry
         }
-    }
-
-    func refreshCanvasPluginSurfaceRoute(replacing observedURL: String?) async -> GatewayCanvasHostRoute? {
-        await self.session.refreshCanvasHostRoute(replacing: observedURL)
     }
 
     private func refresh(

--- a/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
@@ -35,11 +35,12 @@ final class NodePairingApprovalPrompter {
     static let shared = NodePairingApprovalPrompter()
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "node-pairing")
+    private let gateway: GatewayConnection
+    private let center: PairingApprovalCenter
+    private var source: PairingPromptSupport.Source?
     private var task: Task<Void, Never>?
     private var reconcileTask: Task<Void, Never>?
     private var reconcileOnceTask: Task<Void, Never>?
-    private var reconcileInFlight = false
-    private var isStopping = false
     private var queue: [PendingRequest] = []
     var pendingCount: Int = 0
     /// Node ids already paired on the gateway (from the last list fetch);
@@ -98,29 +99,35 @@ final class NodePairingApprovalPrompter {
     private typealias PairingResolvedEvent = PairingPromptSupport.PairingResolvedEvent
     private typealias PairingResolution = PairingPromptSupport.PairingResolution
 
+    init(gateway: GatewayConnection = .shared, center: PairingApprovalCenter = .shared) {
+        self.gateway = gateway
+        self.center = center
+    }
+
     func start() {
         self.reconcileTask?.cancel()
         self.reconcileTask = nil
-        PairingApprovalCenter.shared.register(kind: .node) { [weak self] card, decision in
+        self.center.register(kind: .node) { [weak self] card, decision in
             await self?.handleDecision(card: card, decision: decision)
         }
-        self.startPushTask()
-    }
-
-    private func startPushTask() {
         PairingPromptSupport.startPairingPushTask(
             task: &self.task,
-            isStopping: &self.isStopping,
-            loadPending: self.loadPendingRequestsFromGateway,
-            handlePush: self.handle(push:))
+            gateway: self.gateway,
+            handlePush: self.handle(delivery:))
     }
 
     func stop() {
-        PairingPromptSupport.stopPairingPrompter(
-            isStopping: &self.isStopping,
-            task: &self.task,
-            queue: &self.queue)
-        PairingApprovalCenter.shared.unregister(kind: .node)
+        self.task?.cancel()
+        self.task = nil
+        self.replaceSource(nil)
+        self.center.unregister(kind: .node)
+    }
+
+    private func replaceSource(_ source: PairingPromptSupport.Source?) {
+        self.source?.retire()
+        self.source = source
+        self.queue.removeAll()
+        self.pairedNodeIds.removeAll()
         self.reconcileTask?.cancel()
         self.reconcileTask = nil
         self.reconcileOnceTask?.cancel()
@@ -131,28 +138,29 @@ final class NodePairingApprovalPrompter {
         self.pendingLocalDecisionRequestIds.removeAll(keepingCapacity: false)
         self.echoedResolutionsByRequestId.removeAll(keepingCapacity: false)
         self.trustUnknownRequestIds.removeAll(keepingCapacity: false)
+        self.syncCards()
     }
 
-    private func loadPendingRequestsFromGateway() async {
+    private func owns(_ source: PairingPromptSupport.Source) -> Bool {
+        self.source === source && source.isCurrent
+    }
+
+    private func loadPendingRequestsFromGateway(source: PairingPromptSupport.Source) async {
         // The gateway process may start slightly after the app. Retry a bit so
         // pending pairing prompts are still shown on launch.
         var delayMs: UInt64 = 200
         for attempt in 1...8 {
-            if Task.isCancelled { return }
+            guard !Task.isCancelled, self.owns(source) else { return }
             do {
-                let data = try await GatewayConnection.shared.request(
-                    method: "node.pair.list",
-                    params: nil,
-                    timeoutMs: 6000)
-                guard !data.isEmpty else { return }
-                let list = try JSONDecoder().decode(PairingList.self, from: data)
-                let pendingCount = list.pending.count
+                try await self.refreshPairingList(timeoutMs: 6000, source: source)
+                guard self.owns(source) else { return }
+                let pendingCount = self.queue.count
                 guard pendingCount > 0 else { return }
                 self.logger.info(
                     "loaded \(pendingCount, privacy: .public) pending node pairing request(s) on startup")
-                self.apply(list: list)
                 return
             } catch {
+                guard !Task.isCancelled, self.owns(source) else { return }
                 if attempt == 8 {
                     self.logger
                         .error(
@@ -165,36 +173,26 @@ final class NodePairingApprovalPrompter {
         }
     }
 
-    private func reconcileLoop() async {
+    private func reconcileLoop(source: PairingPromptSupport.Source) async {
         // Reconcile requests periodically so multiple running apps stay in sync
         // (e.g. close cards + notify if another machine approves/rejects via app or CLI).
-        while !Task.isCancelled {
-            if self.isStopping {
-                break
-            }
-            if !self.shouldPoll {
-                self.reconcileTask = nil
-                return
-            }
-            await self.reconcileOnce(timeoutMs: 2500)
+        // Queue mutations own the task slot; an exiting loop cannot clear its replacement.
+        while !Task.isCancelled, self.owns(source), self.shouldPoll {
+            await self.reconcileOnce(timeoutMs: 2500, source: source)
             try? await Task.sleep(
                 nanoseconds: NodePairingReconcilePolicy.activeIntervalMs * 1_000_000)
         }
-        self.reconcileTask = nil
     }
 
-    private func fetchPairingList(timeoutMs: Double) async throws -> PairingList {
-        let data = try await GatewayConnection.shared.request(
-            method: "node.pair.list",
-            params: nil,
-            timeoutMs: timeoutMs)
-        return try JSONDecoder().decode(PairingList.self, from: data)
-    }
-
-    private func apply(list: PairingList) {
-        if self.isStopping {
-            return
+    private func refreshPairingList(timeoutMs: Double, source: PairingPromptSupport.Source) async throws {
+        try await source.refreshList(method: "node.pair.list", timeoutMs: timeoutMs) { data in
+            let list = try JSONDecoder().decode(PairingList.self, from: data)
+            self.apply(list: list, source: source)
         }
+    }
+
+    private func apply(list: PairingList, source: PairingPromptSupport.Source) {
+        guard self.owns(source) else { return }
 
         self.pairedNodeIds = Set((list.paired ?? []).map(\.nodeId))
         // This snapshot is authoritative for every pending request in it.
@@ -205,7 +203,7 @@ final class NodePairingApprovalPrompter {
 
         // Enqueue any missing requests (covers missed pushes while reconnecting).
         for req in list.pending.sorted(by: { $0.ts < $1.ts }) {
-            self.enqueue(req)
+            self.enqueue(req, source: source)
         }
 
         // Detect resolved requests (approved/rejected elsewhere).
@@ -223,7 +221,7 @@ final class NodePairingApprovalPrompter {
                 self.echoedResolutionsByRequestId[req.requestId] = resolution
             } else {
                 Task { @MainActor in
-                    await self.notify(resolution: resolution, request: req, via: "remote")
+                    await self.notify(resolution: resolution, request: req, via: "remote", source: source)
                 }
             }
         }
@@ -246,19 +244,29 @@ final class NodePairingApprovalPrompter {
         return .approved
     }
 
-    private func handle(push: GatewayPush) {
+    private func handle(delivery: GatewayConnection.PushDelivery) {
+        guard let push = delivery.push else {
+            if self.source?.lease == delivery.serverLease { self.replaceSource(nil) }
+            return
+        }
+        guard delivery.isCurrent else { return }
+        if self.source?.lease != delivery.serverLease {
+            self.replaceSource(.init(lease: delivery.serverLease, gateway: self.gateway))
+        }
+        guard let source = self.source else { return }
         switch push {
         case let .event(evt) where evt.event == "node.pair.requested":
             guard let payload = evt.payload else { return }
             do {
                 let req = try GatewayPayloadDecoding.decode(payload, as: PendingRequest.self)
+                source.invalidateList()
                 self.trustUnknownRequestIds.insert(req.requestId)
-                self.enqueue(req)
+                self.enqueue(req, source: source)
                 self.syncCards()
                 self.updateReconcileLoop()
                 // Refresh the paired list now so the card's "previously
                 // paired" trust signal reflects current gateway truth.
-                self.scheduleReconcileOnce(delayMs: 0)
+                self.scheduleReconcileOnce(delayMs: 0, source: source)
             } catch {
                 self.logger
                     .error("failed to decode pairing request: \(error.localizedDescription, privacy: .public)")
@@ -267,22 +275,23 @@ final class NodePairingApprovalPrompter {
             guard let payload = evt.payload else { return }
             do {
                 let resolved = try GatewayPayloadDecoding.decode(payload, as: PairingResolvedEvent.self)
-                self.handleResolved(resolved)
+                self.handleResolved(resolved, source: source)
             } catch {
                 self.logger
                     .error(
                         "failed to decode pairing resolution: \(error.localizedDescription, privacy: .public)")
             }
         case .snapshot:
-            self.scheduleReconcileOnce(delayMs: 0)
+            Task { await self.loadPendingRequestsFromGateway(source: source) }
         case .seqGap:
-            self.scheduleReconcileOnce()
+            source.invalidateList()
+            self.scheduleReconcileOnce(source: source)
         default:
             return
         }
     }
 
-    private func enqueue(_ req: PendingRequest) {
+    private func enqueue(_ req: PendingRequest, source: PairingPromptSupport.Source) {
         if self.queue.contains(where: { $0.requestId == req.requestId }) {
             return
         }
@@ -292,19 +301,20 @@ final class NodePairingApprovalPrompter {
         self.queue.removeAll { $0.nodeId == req.nodeId }
         self.queue.append(req)
         self.updatePendingCounts()
-        self.beginAutoApproveIfEligible(req)
+        self.beginAutoApproveIfEligible(req, source: source)
     }
 
     /// Auto-approve runs before the request surfaces in the panel: the app's
     /// own local node pairs silently, and `silent` requests are approved after
     /// an SSH trust probe. Only failed attempts fall through to the UI.
-    private func beginAutoApproveIfEligible(_ req: PendingRequest) {
+    private func beginAutoApproveIfEligible(_ req: PendingRequest, source: PairingPromptSupport.Source) {
         guard !self.autoApproveAttempts.contains(req.requestId) else { return }
         guard self.isAutoApproveCandidate(req) else { return }
         self.autoApproveInFlight.insert(req.requestId)
         Task { @MainActor [weak self] in
-            guard let self else { return }
-            let approved = await self.tryAutomaticApproveIfPossible(req)
+            guard let self, self.owns(source) else { return }
+            let approved = await self.tryAutomaticApproveIfPossible(req, source: source)
+            guard self.owns(source) else { return }
             self.autoApproveInFlight.remove(req.requestId)
             if approved {
                 self.queue.removeAll { $0.requestId == req.requestId }
@@ -329,7 +339,6 @@ final class NodePairingApprovalPrompter {
     }
 
     private func syncCards() {
-        guard !self.isStopping else { return }
         // A pending local decision hides the card immediately (the decision is
         // optimistic); the failure path re-syncs so the card can come back.
         let cards = self.queue
@@ -338,7 +347,7 @@ final class NodePairingApprovalPrompter {
                     !self.pendingLocalDecisionRequestIds.contains($0.requestId)
             }
             .map { self.card(for: $0) }
-        PairingApprovalCenter.shared.sync(kind: .node, cards: cards)
+        self.center.sync(kind: .node, cards: cards)
     }
 
     private func card(for req: PendingRequest) -> PairingApprovalCenter.Card {
@@ -361,24 +370,27 @@ final class NodePairingApprovalPrompter {
             previouslyPaired: self.trustUnknownRequestIds.contains(req.requestId)
                 ? nil
                 : self.pairedNodeIds.contains(req.nodeId),
-            requestedAt: Date(timeIntervalSince1970: req.ts / 1000))
+            requestedAt: Date(timeIntervalSince1970: req.ts / 1000),
+            source: self.source)
     }
 
     private func handleDecision(card: PairingApprovalCenter.Card, decision: PairingApprovalCenter.Decision) async {
-        guard !self.isStopping else { return }
-        guard let request = self.queue.first(where: { $0.requestId == card.requestId }) else { return }
+        guard let source = card.source, self.owns(source),
+              let request = self.queue.first(where: { $0.requestId == card.requestId })
+        else {
+            self.logger.info("pairing decision discarded because its request or Gateway connection changed")
+            return
+        }
 
         self.pendingLocalDecisionRequestIds.insert(request.requestId)
         // Optimistic dismiss: the card leaves the panel before the RPC
         // round-trip; the outcome arrives as a notification instead.
         self.syncCards()
         let expected: PairingResolution = decision == .approve ? .approved : .rejected
-        let rpcOk: Bool = switch decision {
-        case .approve:
-            await self.approve(requestId: request.requestId)
-        case .reject:
-            await self.reject(requestId: request.requestId)
-        }
+        let rpcOk = await PairingPromptSupport.decide(
+            requestId: request.requestId, kind: .node, decision: decision, source: source, logger: self.logger)
+        guard self.owns(source) else { return }
+        source.invalidateList()
         self.pendingLocalDecisionRequestIds.remove(request.requestId)
 
         if let echoed = self.echoedResolutionsByRequestId.removeValue(forKey: request.requestId) {
@@ -386,9 +398,9 @@ final class NodePairingApprovalPrompter {
             // (possibly another operator with the opposite decision); report
             // the authoritative outcome, not what the user asked for.
             let via = rpcOk && echoed == expected ? "local" : "remote"
-            await self.notify(resolution: echoed, request: request, via: via)
+            await self.notify(resolution: echoed, request: request, via: via, source: source)
         } else if rpcOk {
-            await self.notify(resolution: expected, request: request, via: "local")
+            await self.notify(resolution: expected, request: request, via: "local", source: source)
         } else {
             // RPC failed and nothing resolved it elsewhere: bring the card
             // back, tell the user the optimistic dismiss did not stick, and
@@ -397,41 +409,29 @@ final class NodePairingApprovalPrompter {
             await PairingPromptSupport.notifyDecisionFailed(
                 kind: .node,
                 decision: decision,
+                source: source,
                 subject: PairingPromptSupport.subjectLabel(
                     displayName: request.displayName,
                     fallback: request.nodeId))
-            self.scheduleReconcileOnce(delayMs: 0)
+            guard self.owns(source) else { return }
+            self.scheduleReconcileOnce(delayMs: 0, source: source)
             return
         }
 
+        guard self.owns(source) else { return }
         self.queue.removeAll { $0.requestId == request.requestId }
         self.updatePendingCounts()
         self.syncCards()
         self.updateReconcileLoop()
     }
 
-    private func approve(requestId: String) async -> Bool {
-        await PairingPromptSupport.approveRequest(
-            requestId: requestId,
-            kind: "node",
-            logger: self.logger)
-        {
-            try await GatewayConnection.shared.nodePairApprove(requestId: requestId)
-        }
-    }
-
-    private func reject(requestId: String) async -> Bool {
-        await PairingPromptSupport.rejectRequest(
-            requestId: requestId,
-            kind: "node",
-            logger: self.logger)
-        {
-            try await GatewayConnection.shared.nodePairReject(requestId: requestId)
-        }
-    }
-
-    private func notify(resolution: PairingResolution, request: PendingRequest, via: String) async {
-        guard await PairingPromptSupport.notificationsAuthorized() else { return }
+    private func notify(
+        resolution: PairingResolution,
+        request: PendingRequest,
+        via: String,
+        source: PairingPromptSupport.Source) async
+    {
+        guard self.owns(source) else { return }
 
         let title = resolution == .approved ? "Node pairing approved" : "Node pairing rejected"
         let device = PairingPromptSupport.subjectLabel(
@@ -443,15 +443,21 @@ final class NodePairingApprovalPrompter {
             title: title,
             body: body,
             sound: nil,
-            priority: .active)
+            priority: .active,
+            requestPermission: false,
+            isCurrent: { self.owns(source) })
     }
 
-    private struct SSHTarget {
+    struct SSHTarget: Equatable {
         let host: String
         let port: Int
     }
 
-    private func tryAutomaticApproveIfPossible(_ req: PendingRequest) async -> Bool {
+    private func tryAutomaticApproveIfPossible(
+        _ req: PendingRequest,
+        source: PairingPromptSupport.Source) async -> Bool
+    {
+        guard self.owns(source) else { return false }
         guard let localNodeId = DeviceIdentityStore.loadOrCreatePersisted(
             profile: MacNodeModeCoordinator.nodeIdentityProfile)?.deviceId
         else {
@@ -465,13 +471,13 @@ final class NodePairingApprovalPrompter {
             localNodeId: localNodeId)
         {
             guard self.beginAutoApproveAttempt(requestId: req.requestId) else { return false }
-            return await self.approveAutomatically(req, via: "local-node", notify: false)
+            return await self.approveAutomatically(req, via: "local-node", notify: false, source: source)
         }
 
         guard req.silent == true else { return false }
         guard self.beginAutoApproveAttempt(requestId: req.requestId) else { return false }
 
-        guard let target = await self.resolveSSHTarget() else {
+        guard let target = await self.resolveSSHTarget(source: source), self.owns(source) else {
             self.logger.info("silent pairing skipped (no ssh target) requestId=\(req.requestId, privacy: .public)")
             return false
         }
@@ -483,21 +489,34 @@ final class NodePairingApprovalPrompter {
         }
 
         let ok = await Self.probeSSH(user: user, host: target.host, port: target.port)
+        guard self.owns(source) else {
+            self.logger.info("silent pairing probe result ignored after the Gateway connection changed")
+            return false
+        }
         if !ok {
             self.logger.info("silent pairing probe failed requestId=\(req.requestId, privacy: .public)")
             return false
         }
 
-        return await self.approveAutomatically(req, via: "silent-ssh", notify: true)
+        return await self.approveAutomatically(req, via: "silent-ssh", notify: true, source: source)
     }
 
-    private func approveAutomatically(_ req: PendingRequest, via: String, notify: Bool) async -> Bool {
+    private func approveAutomatically(
+        _ req: PendingRequest, via: String, notify: Bool, source: PairingPromptSupport.Source) async -> Bool
+    {
+        guard self.owns(source) else { return false }
         self.pendingLocalDecisionRequestIds.insert(req.requestId)
         defer {
-            self.pendingLocalDecisionRequestIds.remove(req.requestId)
-            self.echoedResolutionsByRequestId.removeValue(forKey: req.requestId)
+            if self.source === source {
+                self.pendingLocalDecisionRequestIds.remove(req.requestId)
+                self.echoedResolutionsByRequestId.removeValue(forKey: req.requestId)
+            }
         }
-        guard await self.approve(requestId: req.requestId) else {
+        let approved = await PairingPromptSupport.decide(
+            requestId: req.requestId, kind: .node, decision: .approve, source: source, logger: self.logger)
+        guard self.owns(source) else { return false }
+        source.invalidateList()
+        guard approved else {
             self.logger.info("automatic pairing approve failed requestId=\(req.requestId, privacy: .public)")
             return false
         }
@@ -508,7 +527,7 @@ final class NodePairingApprovalPrompter {
             via=\(via, privacy: .public)
             """)
         if notify {
-            await self.notify(resolution: .approved, request: req, via: via)
+            await self.notify(resolution: .approved, request: req, via: via, source: source)
         }
         return true
     }
@@ -527,21 +546,13 @@ final class NodePairingApprovalPrompter {
         connectionMode == .local && requestNodeId == localNodeId
     }
 
-    private func resolveSSHTarget() async -> SSHTarget? {
+    private func resolveSSHTarget(source: PairingPromptSupport.Source) async -> SSHTarget? {
         let settings = CommandResolver.connectionSettings()
-        if !settings.target.isEmpty, let parsed = CommandResolver.parseSSHTarget(settings.target) {
-            let user = NSUserName().trimmingCharacters(in: .whitespacesAndNewlines)
-            if let targetUser = parsed.user,
-               !targetUser.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-               targetUser != user
-            {
-                self.logger.info("silent pairing skipped (ssh user mismatch)")
-                return nil
-            }
-            let host = parsed.host.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !host.isEmpty else { return nil }
-            let port = parsed.port > 0 ? parsed.port : 22
-            return SSHTarget(host: host, port: port)
+        let gatewayURL = source.lease.route.url
+        let user = NSUserName().trimmingCharacters(in: .whitespacesAndNewlines)
+        if settings.mode == .remote, settings.transport == .ssh {
+            return Self.silentPairingSSHTarget(
+                settings: settings, gatewayURL: gatewayURL, gateways: [], preferredStableID: nil, user: user)
         }
 
         let model = GatewayDiscoveryModel(localDisplayName: InstanceIdentity.displayName)
@@ -549,12 +560,48 @@ final class NodePairingApprovalPrompter {
         defer { model.stop() }
 
         let deadline = Date().addingTimeInterval(5.0)
-        while model.gateways.isEmpty, Date() < deadline {
+        while self.owns(source), Date() < deadline {
+            if let target = Self.silentPairingSSHTarget(
+                settings: settings,
+                gatewayURL: gatewayURL,
+                gateways: model.gateways,
+                preferredStableID: GatewayDiscoveryPreferences.preferredStableID(),
+                user: user)
+            {
+                return target
+            }
             try? await Task.sleep(nanoseconds: 200_000_000)
         }
+        return nil
+    }
 
-        let preferred = GatewayDiscoveryPreferences.preferredStableID()
-        let gateway = model.gateways.first { $0.stableID == preferred } ?? model.gateways.first
+    static func silentPairingSSHTarget(
+        settings: CommandResolver.RemoteSettings,
+        gatewayURL: URL,
+        gateways: [GatewayDiscoveryModel.DiscoveredGateway],
+        preferredStableID: String?,
+        user: String) -> SSHTarget?
+    {
+        if settings.mode == .remote, settings.transport == .ssh {
+            guard let parsed = CommandResolver.parseSSHTarget(settings.target) else { return nil }
+            if let targetUser = parsed.user,
+               !targetUser.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               targetUser != user
+            {
+                return nil
+            }
+            let host = parsed.host.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !host.isEmpty else { return nil }
+            return SSHTarget(host: host, port: parsed.port > 0 ? parsed.port : 22)
+        }
+        // SSH proves ownership only of the server behind this captured route.
+        // Dormant SSH settings and unrelated Bonjour entries cannot authorize it.
+        guard let owner = try? MacGatewayProfileStore.canonicalURL(gatewayURL) else { return nil }
+        let matches = gateways.filter {
+            guard let raw = GatewayDiscoveryHelpers.directUrl(for: $0), let url = URL(string: raw) else { return false }
+            return (try? MacGatewayProfileStore.canonicalURL(url)) == owner
+        }
+        let gateway = matches.first { $0.stableID == preferredStableID } ?? matches.first
         guard let gateway else { return nil }
         guard let target = GatewayDiscoveryHelpers.sshTarget(for: gateway),
               let parsed = CommandResolver.parseSSHTarget(target)
@@ -589,11 +636,11 @@ final class NodePairingApprovalPrompter {
     }
 
     private func updateReconcileLoop() {
-        guard !self.isStopping else { return }
+        guard let source = self.source else { return }
         if self.shouldPoll {
             if self.reconcileTask == nil {
                 self.reconcileTask = Task { [weak self] in
-                    await self?.reconcileLoop()
+                    await self?.reconcileLoop(source: source)
                 }
             }
         } else {
@@ -607,35 +654,30 @@ final class NodePairingApprovalPrompter {
         self.pendingCount = self.queue.count
     }
 
-    private func reconcileOnce(timeoutMs: Double) async {
-        if self.isStopping {
-            return
-        }
-        if self.reconcileInFlight {
-            return
-        }
-        self.reconcileInFlight = true
-        defer { self.reconcileInFlight = false }
+    private func reconcileOnce(timeoutMs: Double, source: PairingPromptSupport.Source) async {
         do {
-            let list = try await self.fetchPairingList(timeoutMs: timeoutMs)
-            self.apply(list: list)
+            try await self.refreshPairingList(timeoutMs: timeoutMs, source: source)
         } catch {
             // best effort: ignore transient connectivity failures
         }
     }
 
-    private func scheduleReconcileOnce(delayMs: UInt64 = NodePairingReconcilePolicy.resyncDelayMs) {
+    private func scheduleReconcileOnce(
+        delayMs: UInt64 = NodePairingReconcilePolicy.resyncDelayMs, source: PairingPromptSupport.Source)
+    {
         self.reconcileOnceTask?.cancel()
         self.reconcileOnceTask = Task { [weak self] in
             guard let self else { return }
             if delayMs > 0 {
                 try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
             }
-            await self.reconcileOnce(timeoutMs: 2500)
+            guard !Task.isCancelled else { return }
+            await self.reconcileOnce(timeoutMs: 2500, source: source)
         }
     }
 
-    private func handleResolved(_ resolved: PairingResolvedEvent) {
+    private func handleResolved(_ resolved: PairingResolvedEvent, source: PairingPromptSupport.Source) {
+        source.invalidateList()
         let resolution: PairingResolution =
             resolved.decision == PairingResolution.approved.rawValue ? .approved : .rejected
 
@@ -651,7 +693,7 @@ final class NodePairingApprovalPrompter {
             self.echoedResolutionsByRequestId[resolved.requestId] = resolution
         } else {
             Task { @MainActor in
-                await self.notify(resolution: resolution, request: request, via: "remote")
+                await self.notify(resolution: resolution, request: request, via: "remote", source: source)
             }
         }
         self.updateReconcileLoop()

--- a/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingConfiguredGatewayProbe.swift
@@ -164,9 +164,9 @@ final class OnboardingConfiguredGatewayProbe {
             self.reconnectPending = false
         }
         let stream = await gateway.subscribe(bufferingNewest: 1)
-        for await push in stream {
+        for await delivery in stream {
             guard !Task.isCancelled else { return }
-            guard case .snapshot = push else { continue }
+            guard delivery.isCurrent, case .snapshot = delivery.push else { continue }
             // captureRoute can create the socket whose hello produced this
             // snapshot. Coalesce it until that route-bound check finishes so a
             // real reconnect is never lost behind the in-flight request.

--- a/apps/macos/Sources/OpenClaw/PairingApprovalCenter.swift
+++ b/apps/macos/Sources/OpenClaw/PairingApprovalCenter.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import Observation
+import OSLog
 import SwiftUI
 
 /// Unified store + window owner for node/device pairing approvals. Both
@@ -22,6 +23,12 @@ final class PairingApprovalCenter {
     }
 
     struct Card: Identifiable, Equatable {
+        struct ID: Hashable {
+            let kind: Kind
+            let requestId: String
+            let source: ObjectIdentifier?
+        }
+
         let kind: Kind
         let requestId: String
         /// nodeId or deviceId.
@@ -46,24 +53,26 @@ final class PairingApprovalCenter {
         /// trust claim must never come from a stale snapshot.
         let previouslyPaired: Bool?
         let requestedAt: Date
+        var source: PairingPromptSupport.Source?
 
-        var id: String {
-            self.requestId
+        var id: ID {
+            ID(kind: self.kind, requestId: self.requestId, source: self.source.map(ObjectIdentifier.init))
         }
     }
 
     typealias DecisionHandler = @MainActor (Card, Decision) async -> Void
 
     private(set) var cards: [Card] = []
-    private(set) var decisionsInFlight: Set<String> = []
+    private(set) var decisionsInFlight: Set<Card.ID> = []
     private var handlersByKind: [Kind: DecisionHandler] = [:]
+    private let logger = Logger(subsystem: "ai.openclaw", category: "pairing-decisions")
     private var panel: PairingApprovalPanelController?
     /// Request ids visible when the user chose "Not Now"; the panel reopens
     /// automatically only when a request they have not seen yet arrives.
-    private var snoozedRequestIds: Set<String> = []
+    private var snoozedRequestIds: Set<Card.ID> = []
     /// Request ids the visible panel has already presented. Periodic queue
     /// syncs must not re-activate the app; only genuinely new requests may.
-    private var presentedRequestIds: Set<String> = []
+    private var presentedRequestIds: Set<Card.ID> = []
 
     func register(kind: Kind, handler: @escaping DecisionHandler) {
         self.handlersByKind[kind] = handler
@@ -79,12 +88,11 @@ final class PairingApprovalCenter {
     func sync(kind: Kind, cards: [Card]) {
         var others = self.cards.filter { $0.kind != kind }
         #if DEBUG
-        others += self.cards.filter { $0.kind == kind && self.demoRequestIds.contains($0.requestId) }
+        others += self.cards.filter { $0.kind == kind && self.demoRequestIds.contains($0.id) }
         #endif
-        // requestId tiebreaker: Swift sort is not stable and equal timestamps
-        // would let cards swap positions between syncs.
+        // Wire ids can repeat across kinds; keep equal-time cards deterministic.
         self.cards = (others + cards).sorted {
-            ($0.requestedAt, $0.requestId) < ($1.requestedAt, $1.requestId)
+            ($0.requestedAt, $0.requestId, $0.kind.rawValue) < ($1.requestedAt, $1.requestId, $1.kind.rawValue)
         }
         self.snoozedRequestIds.formIntersection(self.cards.map(\.id))
         self.updatePanel()
@@ -92,19 +100,31 @@ final class PairingApprovalCenter {
 
     func decide(_ card: Card, _ decision: Decision) {
         #if DEBUG
-        if self.demoRequestIds.contains(card.requestId) {
-            self.demoRequestIds.remove(card.requestId)
-            self.cards.removeAll { $0.requestId == card.requestId }
+        if self.demoRequestIds.contains(card.id) {
+            self.demoRequestIds.remove(card.id)
+            self.cards.removeAll { $0.id == card.id }
             self.updatePanel()
             return
         }
         #endif
-        guard let handler = self.handlersByKind[card.kind] else { return }
-        guard self.decisionsInFlight.insert(card.requestId).inserted else { return }
+        guard let handler = self.currentDecisionHandler(for: card) else { return }
+        guard self.decisionsInFlight.insert(card.id).inserted else { return }
         Task { @MainActor in
+            defer { self.decisionsInFlight.remove(card.id) }
+            // The rendered action may outlive its source or wait behind a switch.
+            guard self.currentDecisionHandler(for: card) != nil else { return }
             await handler(card, decision)
-            self.decisionsInFlight.remove(card.requestId)
         }
+    }
+
+    private func currentDecisionHandler(for card: Card) -> DecisionHandler? {
+        guard let handler = self.handlersByKind[card.kind],
+              self.cards.contains(where: { $0.id == card.id }), card.source?.isCurrent != false
+        else {
+            self.logger.info("pairing decision discarded because its request or Gateway connection changed")
+            return nil
+        }
+        return handler
     }
 
     /// Resolve a batch of cards with one decision. Takes the caller's
@@ -131,7 +151,7 @@ final class PairingApprovalCenter {
         self.ensurePanel().show()
     }
 
-    static func shouldAutoPresent(cardIds: [String], snoozedIds: Set<String>) -> Bool {
+    static func shouldAutoPresent<ID: Hashable>(cardIds: [ID], snoozedIds: Set<ID>) -> Bool {
         !cardIds.isEmpty && !cardIds.allSatisfy { snoozedIds.contains($0) }
     }
 
@@ -179,7 +199,7 @@ final class PairingApprovalCenter {
 
     /// Demo/screenshot hook: decisions on injected cards resolve locally
     /// instead of routing to a prompter.
-    private var demoRequestIds: Set<String> = []
+    private var demoRequestIds: Set<Card.ID> = []
 
     func injectDemoCards(_ cards: [Card]) {
         self.demoRequestIds.formUnion(cards.map(\.id))

--- a/apps/macos/Sources/OpenClaw/PairingPromptSupport.swift
+++ b/apps/macos/Sources/OpenClaw/PairingPromptSupport.swift
@@ -1,12 +1,75 @@
 import Foundation
 import OpenClawKit
+import OpenClawProtocol
 import OSLog
-import UserNotifications
 
 /// Shared plumbing for the node/device pairing prompters: gateway push
 /// subscription lifecycle and approve/reject RPC logging.
 @MainActor
 enum PairingPromptSupport {
+    /// A pairing queue belongs to one subscription lifetime and physical server.
+    /// Retained cards and probes keep this owner, never a newly selected Gateway.
+    @MainActor
+    final class Source: Equatable {
+        let lease: GatewayConnection.ServerLease
+        let gateway: GatewayConnection
+        private var active = true
+        private var listRevision = 0
+        private var listTask: Task<Void, Error>?
+
+        init(lease: GatewayConnection.ServerLease, gateway: GatewayConnection) {
+            self.lease = lease
+            self.gateway = gateway
+        }
+
+        var isCurrent: Bool {
+            self.active && self.gateway.serverLeaseMatchesCurrentState(self.lease)
+        }
+
+        func retire() {
+            self.active = false
+            self.listTask?.cancel()
+            self.listTask = nil
+        }
+
+        func invalidateList() {
+            self.listRevision += 1
+        }
+
+        func refreshList(
+            method: String,
+            timeoutMs: Double? = nil,
+            apply: @escaping @MainActor (Data) throws -> Void) async throws
+        {
+            guard !Task.isCancelled, self.isCurrent else { return }
+            // Each prompter owns its Source and one list task. Queue mutations
+            // invalidate snapshots; overlapping readers join without invalidating
+            // one another, and an invalidated initial read still converges.
+            if self.listTask == nil {
+                self.listTask = Task { @MainActor in
+                    defer { self.listTask = nil }
+                    while !Task.isCancelled, self.isCurrent {
+                        let revision = self.listRevision
+                        let data = try await self.gateway.request(
+                            method: method,
+                            params: nil,
+                            timeoutMs: timeoutMs,
+                            ifCurrentServerLease: self.lease)
+                        guard !Task.isCancelled, self.isCurrent else { return }
+                        guard revision == self.listRevision else { continue }
+                        try apply(data)
+                        return
+                    }
+                }
+            }
+            try await self.listTask?.value
+        }
+
+        nonisolated static func == (lhs: Source, rhs: Source) -> Bool {
+            lhs === rhs
+        }
+    }
+
     enum PairingResolution: String {
         case approved
         case rejected
@@ -18,57 +81,57 @@ enum PairingPromptSupport {
         let ts: Double
     }
 
-    static func runPairingPushTask(
-        bufferingNewest: Int = 200,
-        loadPending: @escaping @MainActor () async -> Void,
-        handlePush: @escaping @MainActor (GatewayPush) -> Void) async
-    {
-        _ = try? await GatewayConnection.shared.refresh()
-        await loadPending()
-        await GatewayPushSubscription.consume(bufferingNewest: bufferingNewest, onPush: handlePush)
-    }
-
     static func startPairingPushTask(
         task: inout Task<Void, Never>?,
-        isStopping: inout Bool,
+        gateway: GatewayConnection,
         bufferingNewest: Int = 200,
-        loadPending: @escaping @MainActor () async -> Void,
-        handlePush: @escaping @MainActor (GatewayPush) -> Void)
+        handlePush: @escaping @MainActor (GatewayConnection.PushDelivery) -> Void)
     {
         guard task == nil else { return }
-        isStopping = false
         task = Task {
-            await self.runPairingPushTask(
-                bufferingNewest: bufferingNewest,
-                loadPending: loadPending,
-                handlePush: handlePush)
+            _ = try? await gateway.acquireServerLease()
+            await GatewayPushSubscription.consume(
+                connection: gateway, bufferingNewest: bufferingNewest, onPush: handlePush)
         }
     }
 
-    static func stopPairingPrompter(
-        isStopping: inout Bool,
-        task: inout Task<Void, Never>?,
-        queue: inout [some Any])
-    {
-        isStopping = true
-        task?.cancel()
-        task = nil
-        queue.removeAll(keepingCapacity: false)
-    }
-
-    static func approveRequest(
+    static func decide(
         requestId: String,
-        kind: String,
-        logger: Logger,
-        action: @escaping () async throws -> Void) async -> Bool
+        kind: PairingApprovalCenter.Kind,
+        decision: PairingApprovalCenter.Decision,
+        source: Source,
+        logger: Logger) async -> Bool
     {
+        guard source.isCurrent else {
+            logger.info("pairing decision discarded after the Gateway connection changed")
+            return false
+        }
+        defer {
+            if !source.isCurrent {
+                logger.info("pairing decision result ignored after the Gateway connection changed")
+            }
+        }
+        let method: GatewayConnection.Method = switch (kind, decision) {
+        case (.node, .approve): .nodePairApprove
+        case (.node, .reject): .nodePairReject
+        case (.device, .approve): .devicePairApprove
+        case (.device, .reject): .devicePairReject
+        }
         do {
-            try await action()
-            logger.info("approved \(kind, privacy: .public) pairing requestId=\(requestId, privacy: .public)")
+            _ = try await source.gateway.request(
+                method: method.rawValue,
+                params: ["requestId": AnyCodable(requestId)],
+                timeoutMs: 10000,
+                ifCurrentServerLease: source.lease)
+            guard source.isCurrent else { return false }
+            logger.info("""
+            pairing decision confirmed method=\(method.rawValue, privacy: .public) \
+            requestId=\(requestId, privacy: .public)
+            """)
             return true
         } catch {
-            logger.error("approve failed requestId=\(requestId, privacy: .public)")
-            logger.error("approve failed: \(error.localizedDescription, privacy: .public)")
+            guard source.isCurrent else { return false }
+            logger.error("pairing decision failed: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }
@@ -80,13 +143,6 @@ enum PairingPromptSupport {
         return name?.isEmpty == false ? name! : fallback
     }
 
-    static func notificationsAuthorized() async -> Bool {
-        guard PermissionManager.notificationCenterAvailable else { return false }
-        let settings = await UNUserNotificationCenter.current().notificationSettings()
-        let status = settings.authorizationStatus
-        return PermissionManager.isNotificationAuthorized(status: status)
-    }
-
     /// Decisions resolve the card optimistically before the RPC returns; when
     /// the RPC then fails the card comes back and this explains why. A failed
     /// RPC does not prove the gateway rejected the decision (it may have
@@ -95,32 +151,17 @@ enum PairingPromptSupport {
     static func notifyDecisionFailed(
         kind: PairingApprovalCenter.Kind,
         decision: PairingApprovalCenter.Decision,
+        source: Source,
         subject: String) async
     {
-        guard await self.notificationsAuthorized() else { return }
+        guard source.isCurrent else { return }
         let action = decision == .approve ? "approval" : "rejection"
         _ = await NotificationManager().send(
             title: "\(kind == .node ? "Node" : "Device") pairing \(action) not confirmed",
             body: "\(subject)\nThe gateway did not confirm the \(action); the request may still be pending.",
             sound: nil,
-            priority: .active)
-    }
-
-    @discardableResult
-    static func rejectRequest(
-        requestId: String,
-        kind: String,
-        logger: Logger,
-        action: @escaping () async throws -> Void) async -> Bool
-    {
-        do {
-            try await action()
-            logger.info("rejected \(kind, privacy: .public) pairing requestId=\(requestId, privacy: .public)")
-            return true
-        } catch {
-            logger.error("reject failed requestId=\(requestId, privacy: .public)")
-            logger.error("reject failed: \(error.localizedDescription, privacy: .public)")
-            return false
-        }
+            priority: .active,
+            requestPermission: false,
+            isCurrent: { source.isCurrent })
     }
 }

--- a/apps/macos/Sources/OpenClaw/SkillsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SkillsSettings.swift
@@ -44,8 +44,9 @@ struct SkillsSettings: View {
             let pushes = await GatewayConnection.shared.subscribe()
             let initialRefresh = Task { await self.model.refreshIfNeeded() }
             defer { initialRefresh.cancel() }
-            for await push in pushes {
+            for await delivery in pushes {
                 if Task.isCancelled { return }
+                guard delivery.isCurrent, let push = delivery.push else { continue }
                 self.model.handleGatewayPush(push)
             }
         }

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -725,11 +725,11 @@ extension TalkModeRuntime {
         return await withTaskGroup(of: String?.self) { group in
             group.addTask { [runId, sessionKey] in
                 var latestText: String?
-                for await push in stream {
+                for await delivery in stream {
                     if Task.isCancelled {
                         return latestText
                     }
-                    guard case let .event(evt) = push else { continue }
+                    guard delivery.isCurrent, case let .event(evt) = delivery.push else { continue }
                     guard evt.event == "chat", let payload = evt.payload else { continue }
                     guard let chatEvent = try? GatewayPayloadDecoding.decode(
                         payload,

--- a/apps/macos/Sources/OpenClaw/VoiceWakeGlobalSettingsSync.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeGlobalSettingsSync.swift
@@ -7,55 +7,65 @@ final class VoiceWakeGlobalSettingsSync {
     static let shared = VoiceWakeGlobalSettingsSync()
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.sync")
+    private let gateway: GatewayConnection
     private var task: Task<Void, Never>?
+    private var refreshTask: Task<Void, Never>?
 
     private struct VoiceWakePayload: Codable, Equatable {
         let triggers: [String]
     }
 
+    init(gateway: GatewayConnection = .shared) {
+        self.gateway = gateway
+    }
+
     func start() {
-        SimpleTaskSupport.start(task: &self.task) { [weak self] in
+        SimpleTaskSupport.start(task: &self.task) { @MainActor [weak self] in
             guard let self else { return }
-            while !Task.isCancelled {
-                do {
-                    try await GatewayConnection.shared.refresh()
-                } catch {
-                    // Not configured / not reachable yet.
+            _ = try? await self.gateway.acquireServerLease()
+            await GatewayPushSubscription
+                .consume(connection: self.gateway, bufferingNewest: 200) { [weak self] delivery in
+                    guard let self, delivery.isCurrent, let push = delivery.push else { return }
+                    switch push {
+                    case .snapshot, .seqGap:
+                        self.refreshTask?.cancel()
+                        self.refreshTask = Task { await self.refreshFromGateway(delivery: delivery) }
+                    case let .event(event) where event.event == "voicewake.changed":
+                        self.handle(push: push)
+                    default:
+                        break
+                    }
                 }
-
-                await self.refreshFromGateway()
-
-                let stream = await GatewayConnection.shared.subscribe(bufferingNewest: 200)
-                for await push in stream {
-                    if Task.isCancelled { return }
-                    await self.handle(push: push)
-                }
-
-                // If the stream finishes (gateway shutdown / reconnect), loop and resubscribe.
-                try? await Task.sleep(nanoseconds: 600_000_000)
-            }
         }
     }
 
     func stop() {
         SimpleTaskSupport.stop(task: &self.task)
+        SimpleTaskSupport.stop(task: &self.refreshTask)
     }
 
-    private func refreshFromGateway() async {
+    private func refreshFromGateway(delivery: GatewayConnection.PushDelivery) async {
         do {
-            let triggers = try await GatewayConnection.shared.voiceWakeGetTriggers()
-            AppStateStore.shared.applyGlobalVoiceWakeTriggers(triggers)
+            let data = try await self.gateway.request(
+                method: GatewayConnection.Method.voicewakeGet.rawValue,
+                params: nil,
+                ifCurrentServerLease: delivery.serverLease)
+            guard !Task.isCancelled, delivery.isCurrent else { return }
+            let payload = try JSONDecoder().decode(VoiceWakePayload.self, from: data)
+            AppStateStore.shared.applyGlobalVoiceWakeTriggers(payload.triggers)
         } catch {
             // Best-effort only.
         }
     }
 
-    func handle(push: GatewayPush) async {
+    func handle(push: GatewayPush) {
         guard case let .event(evt) = push else { return }
         guard evt.event == "voicewake.changed" else { return }
         guard let payload = evt.payload else { return }
         do {
             let decoded = try GatewayPayloadDecoding.decode(payload, as: VoiceWakePayload.self)
+            // A valid live update is newer than any snapshot read already in flight.
+            self.refreshTask?.cancel()
             AppStateStore.shared.applyGlobalVoiceWakeTriggers(decoded.triggers)
         } catch {
             self.logger.error("failed to decode voicewake.changed: \(error.localizedDescription, privacy: .public)")

--- a/apps/macos/Sources/OpenClaw/WebChatManager.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatManager.swift
@@ -60,6 +60,11 @@ final class WebChatManager {
     private var windowRoute: WebChatRoute?
     private var currentChatRoute: WebChatRoute?
     private var cachedPreferredSessionKey: String?
+    private var primaryGatewayID: String?
+    private var primaryGeneration: UInt64 = 0
+    private var primaryOpenTask: Task<Void, Never>?
+    private var windowGeneration: UInt64 = 0
+    private var fleetShutdownTask: Task<Void, Never>?
     private var profileWindows: [UUID: ProfileWindowInstance] = [:]
     private var profileWindowOrder: [UUID] = []
     private var unavailableProfileIDs: Set<String> = []
@@ -77,7 +82,29 @@ final class WebChatManager {
         self.currentChatRoute?.sessionKey ?? self.windowRoute?.sessionKey
     }
 
-    func show(sessionKey: String, agentID: String? = nil, draft: String? = nil) {
+    func show(sessionKey: String? = nil, agentID: String? = nil, draft: String? = nil) {
+        self.primaryOpenTask?.cancel()
+        self.preparePrimaryGateway(gatewayID: GatewayDiscoveryPreferences.deviceAuthGatewayID(
+            root: OpenClawConfigFile.loadDict()))
+        if let sessionKey = sessionKey ?? self.cachedPreferredSessionKey {
+            self.presentChat(sessionKey: sessionKey, agentID: agentID, draft: draft)
+            return
+        }
+
+        let generation = self.primaryGeneration
+        self.primaryOpenTask = Task { @MainActor [weak self] in
+            guard !Task.isCancelled else { return }
+            let sessionKey = await GatewayConnection.shared.mainSessionKey()
+            guard !Task.isCancelled, let self else { return }
+            self.preparePrimaryGateway(gatewayID: GatewayDiscoveryPreferences.deviceAuthGatewayID(
+                root: OpenClawConfigFile.loadDict()))
+            guard generation == self.primaryGeneration else { return }
+            self.cachedPreferredSessionKey = sessionKey
+            self.presentChat(sessionKey: sessionKey, agentID: agentID, draft: draft)
+        }
+    }
+
+    private func presentChat(sessionKey: String, agentID: String?, draft: String?) {
         let route = WebChatRoute(sessionKey: sessionKey, agentID: agentID)
         if let controller = windowController {
             // The window shell switches sessions in place (sidebar, /new);
@@ -146,10 +173,12 @@ final class WebChatManager {
     #endif
 
     func newGatewayWindow() {
+        let generation = self.windowGeneration
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
                 let profiles = try await MacGatewayProfileStore.shared.profiles()
+                guard generation == self.windowGeneration else { return }
                 guard !profiles.isEmpty else {
                     AppNavigationActions.openSettings(tab: .gateways)
                     return
@@ -157,6 +186,7 @@ final class WebChatManager {
                 let preferredID = AppDefaults.standard.string(forKey: Self.lastGatewayProfileIDKey)
                 switch Self.promptForGatewayProfile(profiles: profiles, preferredID: preferredID) {
                 case let .profile(profile):
+                    guard generation == self.windowGeneration else { return }
                     AppDefaults.standard.set(profile.id, forKey: Self.lastGatewayProfileIDKey)
                     try await self.show(profile: profile)
                 case .manage:
@@ -164,6 +194,7 @@ final class WebChatManager {
                 case nil:
                     break
                 }
+            } catch is CancellationError {
             } catch {
                 Self.showProfileError(error, message: "Could Not Open Gateway Window")
             }
@@ -171,10 +202,13 @@ final class WebChatManager {
     }
 
     func openGatewayWindow(profile: MacGatewayProfile) {
+        let generation = self.windowGeneration
         Task { @MainActor [weak self] in
+            guard let self, generation == self.windowGeneration else { return }
             do {
                 AppDefaults.standard.set(profile.id, forKey: Self.lastGatewayProfileIDKey)
-                try await self?.show(profile: profile)
+                try await self.show(profile: profile)
+            } catch is CancellationError {
             } catch {
                 Self.showProfileError(error, message: "Could Not Open Gateway Window")
             }
@@ -182,17 +216,14 @@ final class WebChatManager {
     }
 
     func show(profile: MacGatewayProfile) async throws {
-        guard !self.unavailableProfileIDs.contains(profile.id) else {
-            throw MacGatewayProfileError.profileNotFound
-        }
+        let generation = self.windowGeneration
+        // An older close must finish retiring the fleet before this open can acquire its successor.
+        await self.fleetShutdownTask?.value
+        try self.requireCurrentWindowRequest(generation, profileID: profile.id)
         let connection = await MacGatewayConnectionFleet.shared.connection(profileID: profile.id)
-        guard !self.unavailableProfileIDs.contains(profile.id) else {
-            throw MacGatewayProfileError.profileNotFound
-        }
+        try self.requireCurrentWindowRequest(generation, profileID: profile.id)
         let sessionKey = await connection.mainSessionKey()
-        guard !self.unavailableProfileIDs.contains(profile.id) else {
-            throw MacGatewayProfileError.profileNotFound
-        }
+        try self.requireCurrentWindowRequest(generation, profileID: profile.id)
         let windowID = UUID()
         let route = WebChatRoute(sessionKey: sessionKey, agentID: nil)
         let previousController = self.profileWindowOrder.reversed().lazy
@@ -223,8 +254,13 @@ final class WebChatManager {
         self.profileWindowOrder.append(windowID)
         controller.cascade(from: previousController)
         controller.show()
-        Task {
-            try? await connection.refresh()
+    }
+
+    private func requireCurrentWindowRequest(_ generation: UInt64, profileID: String) throws {
+        try Task.checkCancellation()
+        guard generation == self.windowGeneration else { throw CancellationError() }
+        guard !self.unavailableProfileIDs.contains(profileID) else {
+            throw MacGatewayProfileError.profileNotFound
         }
     }
 
@@ -239,7 +275,9 @@ final class WebChatManager {
         for controller in controllers {
             controller.close()
         }
-        await MacGatewayConnectionFleet.shared.remove(profileID: profileID)
+        if let connection = await MacGatewayConnectionFleet.shared.remove(profileID: profileID) {
+            self.retireSessionObserver(connection: connection)
+        }
     }
 
     func gatewayProfileDidSave(profileID: String) {
@@ -254,33 +292,49 @@ final class WebChatManager {
             ?? WebChatRoute(sessionKey: trimmed, agentID: nil)
     }
 
-    func preferredSessionKey() async -> String {
-        if let cachedPreferredSessionKey {
-            return cachedPreferredSessionKey
-        }
-        let key = await GatewayConnection.shared.mainSessionKey()
-        cachedPreferredSessionKey = key
-        return key
-    }
-
-    func resetTunnels() {
+    func resetPrimaryConnections() {
+        self.primaryGeneration &+= 1
+        self.primaryOpenTask?.cancel()
+        self.primaryOpenTask = nil
         self.windowController?.close()
         self.windowController = nil
         self.windowRoute = nil
         self.currentChatRoute = nil
         self.cachedPreferredSessionKey = nil
-        let profileControllers = self.profileWindows.values.map(\.controller)
-        self.profileWindows.removeAll()
-        self.profileWindowOrder.removeAll()
-        self.unavailableProfileIDs.removeAll()
-        for controller in profileControllers {
-            controller.close()
-        }
-        Task { await MacGatewayConnectionFleet.shared.shutdown() }
+    }
+
+    func preparePrimaryGateway(gatewayID: String?) {
+        guard self.primaryGatewayID != gatewayID else { return }
+        self.resetPrimaryConnections()
+        self.primaryGatewayID = gatewayID
     }
 
     func close() {
-        self.resetTunnels()
+        // Invalidate admitted opens before closing windows or awaiting fleet retirement.
+        self.windowGeneration &+= 1
+        self.resetPrimaryConnections()
+        let profileControllers = self.profileWindows.values.map(\.controller)
+        self.profileWindows.removeAll()
+        self.profileWindowOrder.removeAll()
+        for controller in profileControllers {
+            controller.close()
+        }
+        let previousShutdown = self.fleetShutdownTask
+        self.fleetShutdownTask = Task {
+            await previousShutdown?.value
+            for connection in await MacGatewayConnectionFleet.shared.shutdown() {
+                self.retireSessionObserver(connection: connection)
+            }
+        }
+    }
+
+    private func retireSessionObserver(connection: GatewayConnection) {
+        let connectionID = ObjectIdentifier(connection)
+        // A retired profile has no future socket on which to declare hidden.
+        // Its subscription must end even when the final hide cannot acquire a lease.
+        self.sessionObserverMonitors.removeValue(forKey: connectionID)?.cancel()
+        self.sessionObserverRequests.removeValue(forKey: connectionID)?.task.cancel()
+        self.sessionObserverDeclarations.removeValue(forKey: connectionID)
     }
 
     private func setSessionObserverVisible(
@@ -300,9 +354,9 @@ final class WebChatManager {
             // must redeclare both while any window on that connection remains open.
             self.sessionObserverMonitors[connectionID] = Task { @MainActor [weak self] in
                 let pushes = await connection.subscribe(bufferingNewest: 1)
-                for await push in pushes {
+                for await delivery in pushes {
                     guard !Task.isCancelled else { return }
-                    guard case .snapshot = push else { continue }
+                    guard delivery.isCurrent, case .snapshot = delivery.push else { continue }
                     guard let self else { return }
                     self.scheduleSessionObserverVisibility(
                         self.sessionObserverOwners.isVisible(connection: connectionID),
@@ -323,22 +377,18 @@ final class WebChatManager {
         let requestID = UUID()
         let task = Task { @MainActor [weak self] in
             await previous?.value
-            guard let self,
+            defer { self?.finishSessionObserverRequest(connection: connectionID, id: requestID) }
+            guard !Task.isCancelled, let self,
                   self.sessionObserverOwners.isVisible(connection: connectionID) == visible,
                   let lease = await connection.captureServerLease(),
+                  !Task.isCancelled,
                   self.sessionObserverOwners.isVisible(connection: connectionID) == visible
-            else {
-                self?.finishSessionObserverRequest(connection: connectionID, id: requestID)
-                return
-            }
+            else { return }
 
             if let declaration = self.sessionObserverDeclarations[connectionID],
                declaration.visible == visible,
                await connection.isCurrentServerLease(declaration.lease)
-            {
-                self.finishSessionObserverRequest(connection: connectionID, id: requestID)
-                return
-            }
+            { return }
 
             // A timed-out mutation may already have changed the Gateway. Clear
             // the old confirmation before dispatch so reopening retries truthfully.
@@ -352,16 +402,16 @@ final class WebChatManager {
                         timeoutMs: subscribe.timeoutMs,
                         ifCurrentServerLease: lease)
                 }
-                guard self.sessionObserverOwners.isVisible(connection: connectionID) == visible else {
-                    self.finishSessionObserverRequest(connection: connectionID, id: requestID)
-                    return
-                }
+                guard !Task.isCancelled,
+                      self.sessionObserverOwners.isVisible(connection: connectionID) == visible
+                else { return }
                 let request = OpenClawChatGatewayRequests.setSessionObserverVisibility(visible)
                 _ = try await connection.request(
                     method: request.method,
                     params: request.params,
                     timeoutMs: request.timeoutMs,
                     ifCurrentServerLease: lease)
+                guard !Task.isCancelled else { return }
                 if visible {
                     self.sessionObserverDeclarations[connectionID] = (lease: lease, visible: true)
                 } else {
@@ -374,6 +424,7 @@ final class WebChatManager {
                 // A hidden mutation can time out after dispatch. Retry once on its
                 // original socket; keep the snapshot monitor for a replaced socket.
                 if !visible,
+                   !Task.isCancelled,
                    remainingHiddenRetries > 0,
                    await connection.isCurrentServerLease(lease),
                    !self.sessionObserverOwners.isVisible(connection: connectionID)
@@ -384,7 +435,6 @@ final class WebChatManager {
                         remainingHiddenRetries: remainingHiddenRetries - 1)
                 }
             }
-            self.finishSessionObserverRequest(connection: connectionID, id: requestID)
         }
         self.sessionObserverRequests[connectionID] = (id: requestID, task: task)
     }

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -193,19 +193,14 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         path: String,
         replacing failedResource: OpenClawChatWidgetResource?) async -> OpenClawChatWidgetResource?
     {
+        // Node mode may still own a different Gateway; widgets follow this chat connection.
         await OpenClawChatWidgetURLResolver.resolveResource(
             target: path,
             replacing: failedResource,
             currentSurfaceRoutes: {
-                let node = await MacNodeModeCoordinator.shared.currentCanvasPluginSurfaceRoute()
-                let operatorSurface = await self.connection.canvasPluginSurfaceRoute()
-                return (node: node, operatorSurface: operatorSurface)
+                await (node: nil, operatorSurface: self.connection.canvasPluginSurfaceRoute())
             },
-            // Prefer the local node route; operator rotation keeps chat usable
-            // while macOS node mode is disabled or reconnecting.
-            refreshNodeSurfaceRoute: { observed in
-                await MacNodeModeCoordinator.shared.refreshCanvasPluginSurfaceRoute(replacing: observed?.url)
-            },
+            refreshNodeSurfaceRoute: { _ in nil },
             refreshOperatorSurfaceRoute: { observed in
                 await self.connection.refreshCanvasPluginSurfaceRoute(replacing: observed?.url)
             })
@@ -777,9 +772,6 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     }
 
     func setActiveSessionKey(_ sessionKey: String) async throws {
-        await MainActor.run {
-            WebChatManager.shared.recordActiveSessionKey(sessionKey)
-        }
         let target = self.sessionTarget(for: sessionKey)
         let request = OpenClawChatGatewayRequests.subscribeSessionMessages(
             sessionKey: target.sessionKey,
@@ -798,10 +790,11 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
 
                 let stream = await self.connection.subscribe()
                 var hasSeenSnapshot = false
-                for await push in stream {
+                for await delivery in stream {
                     if Task.isCancelled {
                         return
                     }
+                    guard delivery.isCurrent, let push = delivery.push else { continue }
                     if case .snapshot = push {
                         if hasSeenSnapshot {
                             continuation.yield(.routeChanged)
@@ -1027,6 +1020,7 @@ final class WebChatSwiftUIWindowController: NSObject, NSWindowDelegate {
     private let sessionKeyRelay: WebChatSessionKeyRelay
     private let speech: OpenClawChatSpeechController
     private let voiceNoteRecorder: OpenClawVoiceNoteRecorder
+    private var routingIdentityTask: Task<Void, Never>?
     private var window: NSWindow?
     var onClosed: (() -> Void)?
     var onVisibilityChanged: ((Bool) -> Void)?
@@ -1043,7 +1037,7 @@ final class WebChatSwiftUIWindowController: NSObject, NSWindowDelegate {
         windowTitle: String = "OpenClaw Chat",
         windowAutosaveName: String = WebChatSwiftUILayout.windowFrameAutosaveName)
     {
-        // Connection-mode changes tear chat windows down via resetTunnels(),
+        // Primary route changes retire the owning window synchronously,
         // so binding the cache identity at construction stays correct. One
         // store instance backs both the transcript cache and the offline
         // command outbox.
@@ -1156,18 +1150,15 @@ final class WebChatSwiftUIWindowController: NSObject, NSWindowDelegate {
         // Custom transports have no Gateway owner; never attach them to the primary connection.
         if let gatewayTransport {
             let chatConnection = gatewayTransport.connection
-            Task { @MainActor [weak vm] in
+            self.routingIdentityTask = Task { @MainActor [weak vm] in
                 let pushes = await chatConnection.subscribe()
-                for await push in pushes {
-                    guard let vm else { return }
-                    guard case .snapshot = push else { continue }
-                    let route = await chatConnection.captureRoute()
-                    let routingIdentity: OpenClawChatSessionRoutingIdentity? = if let route {
-                        try? await chatConnection.sessionRoutingIdentity(
-                            ifCurrentRoute: route)
-                    } else {
-                        nil
-                    }
+                for await delivery in pushes {
+                    guard !Task.isCancelled, let vm else { return }
+                    guard delivery.isCurrent, case .snapshot = delivery.push else { continue }
+                    let routingIdentity = try? await chatConnection.sessionRoutingIdentity(
+                        ifCurrentRoute: delivery.serverLease.route)
+                    guard !Task.isCancelled else { return }
+                    guard delivery.isCurrent else { continue }
                     if let routingIdentity {
                         // An explicit navigation agent owns this window; gateway
                         // default refreshes only supply the fallback route.
@@ -1243,6 +1234,9 @@ final class WebChatSwiftUIWindowController: NSObject, NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         guard notification.object as? NSWindow === self.window else { return }
+        self.routingIdentityTask?.cancel()
+        self.routingIdentityTask = nil
+        self.viewModel.detachTransport()
         self.onVisibilityChanged?(false)
         let onClosed = self.onClosed
         self.onClosed = nil

--- a/apps/macos/Sources/OpenClaw/WorkActivityStore.swift
+++ b/apps/macos/Sources/OpenClaw/WorkActivityStore.swift
@@ -25,13 +25,22 @@ final class WorkActivityStore {
     private var jobs: [String: Activity] = [:]
     private var tools: [String: Activity] = [:]
     private var currentSessionKey: String?
-    private var toolSeqBySession: [String: Int] = [:]
+    private var toolCleanupOwners: [String: UUID] = [:]
 
     private var mainSessionKeyStorage = "main"
     private let toolResultGrace: TimeInterval = 2.0
 
     var mainSessionKey: String {
         self.mainSessionKeyStorage
+    }
+
+    func reset() {
+        self.jobs.removeAll()
+        self.tools.removeAll()
+        self.toolCleanupOwners.removeAll()
+        self.currentSessionKey = nil
+        self.lastToolUpdatedAt = nil
+        self.refreshDerivedState()
     }
 
     func handleJob(sessionKey: String, state: String) {
@@ -63,7 +72,8 @@ final class WorkActivityStore {
         let label = Self.buildLabel(name: name, meta: meta, args: args)
         if phase.lowercased() == "start" {
             self.lastToolUpdatedAt = Date()
-            self.toolSeqBySession[sessionKey, default: 0] += 1
+            // Session keys can recur after reset; old grace tasks must never regain ownership.
+            self.toolCleanupOwners[sessionKey] = UUID()
             let activity = Activity(
                 sessionKey: sessionKey,
                 role: self.role(for: sessionKey),
@@ -75,13 +85,13 @@ final class WorkActivityStore {
         } else {
             // Delay removal slightly to avoid flicker on rapid result/start bursts.
             let key = sessionKey
-            let seq = self.toolSeqBySession[key, default: 0]
+            guard let owner = self.toolCleanupOwners[key] else { return }
             Task { [weak self] in
                 let nsDelay = UInt64((self?.toolResultGrace ?? 0) * 1_000_000_000)
                 try? await Task.sleep(nanoseconds: nsDelay)
                 await MainActor.run {
                     guard let self else { return }
-                    guard self.toolSeqBySession[key, default: 0] == seq else { return }
+                    guard self.toolCleanupOwners[key] == owner else { return }
                     self.lastToolUpdatedAt = Date()
                     self.clearTool(sessionKey: key)
                 }
@@ -153,6 +163,7 @@ final class WorkActivityStore {
     private func clearTool(sessionKey: String) {
         guard self.tools[sessionKey] != nil else { return }
         self.tools.removeValue(forKey: sessionKey)
+        self.toolCleanupOwners.removeValue(forKey: sessionKey)
 
         if self.currentSessionKey == sessionKey, !self.isActive(sessionKey: sessionKey) {
             self.pickNextSession()

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import Testing
 @testable import OpenClaw
 
@@ -315,6 +316,123 @@ struct AppStateRemoteConfigTests {
             #expect(state.remoteTokenDirty)
             await state._testAwaitGatewayConfigSync()
             #expect(!state.remoteTokenDirty)
+        }
+    }
+
+    @Test(arguments: [false, true], [false, true])
+    func `primary replacement retires the previous gateway credentials`(
+        promoteProfile: Bool,
+        storedTokenIsReference: Bool) async throws
+    {
+        let configPath = TestIsolation.tempConfigPath()
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+        try await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            let priorToken: Any = storedTokenIsReference
+                ? ["$secretRef": "gateway-a-token"]
+                : "gateway-a-token"
+            #expect(OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "transport": "direct",
+                        "url": "wss://gateway-a.example.test",
+                        "token": priorToken,
+                        "password": "gateway-a-password",
+                        "tlsFingerprint": String(repeating: "b", count: 64),
+                    ],
+                ],
+            ]))
+            let state = AppState(preview: true)
+            state._testEnableGatewayConfigSync()
+            let nextURL = try #require(URL(string: "wss://gateway-b.example.test:443"))
+            let adapter = DashboardPrimaryGatewayAdapter(
+                state: state,
+                endpoint: { _ in
+                    GatewayConnection.EndpointSnapshot(
+                        config: (url: nextURL, token: "gateway-b-token", password: nil),
+                        routeAuthority: nil)
+                })
+
+            if promoteProfile {
+                try await adapter.apply(profileID: "gateway-b")
+            } else {
+                try adapter.apply(link: GatewayConnectDeepLink(
+                    host: "gateway-b.example.test",
+                    port: 443,
+                    tls: true,
+                    bootstrapToken: nil,
+                    token: nil,
+                    password: nil))
+            }
+            await state._testAwaitGatewayConfigSync()
+
+            let persisted = OpenClawConfigFile.loadDict()
+            #expect(GatewayRemoteConfig.resolveGatewayUrl(root: persisted) == nextURL)
+            #expect(GatewayRemoteConfig.resolveTokenString(root: persisted) ==
+                (promoteProfile ? "gateway-b-token" : nil))
+            if !promoteProfile {
+                let remote = (persisted["gateway"] as? [String: Any])?["remote"] as? [String: Any]
+                #expect(remote?["token"] == nil)
+            }
+            #expect(GatewayRemoteConfig.resolvePasswordString(root: persisted) == nil)
+            #expect(GatewayEndpointStore._testResolveGatewayPassword(
+                isRemote: true,
+                root: persisted,
+                env: [:]) == nil)
+            #expect(GatewayRemoteConfig.resolveTLSFingerprint(root: persisted) == nil)
+            #expect(state.connectionMode == .remote)
+            #expect(state.remoteTransport == .direct)
+            #expect(state.remoteUrl == nextURL.absoluteString)
+            #expect(state.remoteToken == (promoteProfile ? "gateway-b-token" : ""))
+            #expect(!state.remoteTokenUnsupported)
+            #expect(state._testGatewayConfigIsCurrentForRouting)
+        }
+    }
+
+    @Test
+    func `rejected primary replacement preserves the canonical connection without a rollback write`() async throws {
+        let configPath = TestIsolation.tempConfigPath()
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+        try await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            #expect(OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "transport": "direct",
+                        "url": "wss://gateway-a.example.test",
+                        "token": ["$secretRef": "gateway-a-token"],
+                        "password": "gateway-a-password",
+                    ],
+                ],
+            ]))
+            let original = OpenClawConfigFile.loadDict()
+            var saveAttempts = 0
+            let state = AppState(preview: true, gatewayConfigSaver: { _ in
+                saveAttempts += 1
+                return false
+            })
+            state._testEnableGatewayConfigSync()
+            let adapter = DashboardPrimaryGatewayAdapter(state: state)
+            let link = GatewayConnectDeepLink(
+                host: "gateway-b.example.test",
+                port: 443,
+                tls: true,
+                bootstrapToken: nil,
+                token: "gateway-b-token",
+                password: nil)
+
+            #expect(throws: DashboardPrimaryGatewayError.notPromotable) {
+                try adapter.apply(link: link)
+            }
+            await state._testAwaitGatewayConfigSync()
+
+            #expect(saveAttempts == 1)
+            #expect(NSDictionary(dictionary: OpenClawConfigFile.loadDict()).isEqual(to: original))
+            #expect(state.remoteUrl == "wss://gateway-a.example.test")
+            #expect(state.remoteToken.isEmpty)
+            #expect(state.remoteTokenUnsupported)
+            #expect(state._testDirtyGatewayConfigFields.isEmpty)
+            #expect(state._testGatewayConfigIsCurrentForRouting)
         }
     }
 
@@ -726,7 +844,10 @@ struct AppStateRemoteConfigTests {
             #expect(GatewayDiscoveryPreferences.preferredRouteBinding() == nil)
         }
     }
+}
 
+@MainActor
+extension AppStateRemoteConfigTests {
     @Test
     func `cold SSH config replacement overrides stale defaults and clears their owner`() async {
         let configPath = TestIsolation.tempConfigPath()

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -281,19 +281,6 @@ struct DashboardManagerGatewayTargetTests {
         #expect(!manager.showConfiguredWindowIfPossible())
     }
 
-    @Test func `removed current profile requires target reconciliation`() {
-        let primary = DashboardGatewayEntry(
-            id: "primary",
-            name: "Local Gateway",
-            kind: "local",
-            isPrimary: true,
-            canPromote: false,
-            health: .ok)
-
-        #expect(DashboardManager._testTargetIsAvailable(.primary, in: [primary]))
-        #expect(!DashboardManager._testTargetIsAvailable(.profile("removed"), in: [primary]))
-    }
-
     @Test func `opening primary creates isolated auxiliary window`() async throws {
         let server = try await DashboardHTTPFixture.start()
         defer { server.stop() }
@@ -362,7 +349,26 @@ struct DashboardManagerGatewayTargetTests {
         #expect(auxiliary.controller._testLinkBrowserDataStore === dataStore)
 
         let auxiliaryWindow = auxiliary.controller.window
-        await manager._testSwitchTarget(.profile(studio), in: auxiliary.controller)
+        await manager.handleEndpointState(.connecting(mode: .remote, detail: "Switching Gateway"))
+        let reconnecting = try #require(manager._testAuxiliaryWindows().first?.controller)
+        #expect(reconnecting.currentURL == URL(string: "about:blank"))
+        #expect(!reconnecting.auth.hasCredential)
+        #expect(reconnecting.window === auxiliaryWindow)
+        #expect(manager._testController() === controller)
+
+        await manager.handleEndpointState(.ready(
+            mode: .remote,
+            url: replacementServer.websocketURL(),
+            token: "rotated-primary-token",
+            password: nil,
+            routeRevision: 2))
+        let recovered = try #require(manager._testAuxiliaryWindows().first?.controller)
+        #expect(recovered.auth.token == "rotated-primary-token")
+        #expect(recovered.window === auxiliaryWindow)
+        #expect(!recovered._testUpdateBridgeAvailable)
+        #expect(manager._testController() === controller)
+
+        await manager._testSwitchTarget(.profile(studio), in: recovered)
         let replacement = try #require(manager._testAuxiliaryWindows().first?.controller)
         #expect(replacement !== auxiliary.controller)
         #expect(replacement.window === auxiliaryWindow)
@@ -421,6 +427,425 @@ struct DashboardManagerGatewayTargetTests {
         #expect(manager._testMainTarget() == .profile(secondID))
         #expect(manager._testController()?.currentURL.port == Int(currentServer.port))
         #expect(manager._testController()?.window === originalWindow)
+    }
+
+    @Test func `promotion keeps other saved profile windows on their physical gateway`() async throws {
+        let savedServer = try await DashboardHTTPFixture.start()
+        let primaryServer = try await DashboardHTTPFixture.start(
+            html: """
+            <html><body><script>
+            window.commandEvents = [];
+            window.addEventListener('openclaw:native-toggle-search', event => {
+              event.preventDefault(); window.commandEvents.push('palette');
+            });
+            </script></body></html>
+            """,
+            contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'")
+        defer {
+            savedServer.stop()
+            primaryServer.stop()
+        }
+        let saved = GatewayConnectionEndpointSource(url: savedServer.websocketURL(), token: "saved-b")
+        let primary = GatewayConnectionEndpointSource(url: primaryServer.websocketURL(), token: "primary-a")
+        let profileGate = DashboardWindowOwnershipPresentationGate()
+        let profile = MacGatewayCatalogProfile(
+            profile: MacGatewayProfile(id: "saved-b", name: "Saved B", url: savedServer.websocketURL()),
+            canPromote: true)
+        let manager = DashboardManager._testMake(
+            primaryEndpointProvider: { _ in primary.snapshot() },
+            profileEndpointProvider: { _ in
+                let endpoint = saved.snapshot()
+                guard endpoint.config.token != "removed" else { throw MacGatewayProfileError.profileNotFound }
+                if endpoint.config.password != nil { await profileGate.waitForRelease() }
+                return endpoint
+            },
+            gatewayEntriesProvider: {
+                DashboardGatewayCatalog.entries(
+                    mode: .remote,
+                    primaryRemoteURL: primary.snapshot().config.url,
+                    resolvedRemoteURL: nil,
+                    resolvedRemoteHostLabel: nil,
+                    profiles: saved.snapshot().config.token == "removed" ? [] : [MacGatewayCatalogProfile(
+                        profile: profile.profile,
+                        canPromote: saved.snapshot().config.token != nil)],
+                    primaryHealth: .ok)
+            })
+        defer { manager.close() }
+        await manager._testOpenWindow(for: .profile("saved-b"))
+        await manager._testOpenWindow(for: .profile("saved-b"))
+        let originals = manager._testAuxiliaryWindows()
+        let promoted = try #require(originals.first?.controller)
+        let promotedWindow = try #require(promoted.window)
+        let fixedWindow = try #require(originals.last?.controller.window)
+        #expect(promotedWindow !== fixedWindow)
+
+        primary.setEndpoint(saved.snapshot())
+        await manager._testSwitchTarget(.primary, in: promoted)
+        #expect(manager.gatewayEntries.contains { $0.id == "profile:saved-b" })
+        saved.setEndpoint(GatewayConnection.EndpointSnapshot(
+            config: (url: savedServer.websocketURL(), token: nil, password: "password-only"), routeAuthority: nil))
+        manager.configure(updater: DashboardGatewayTestUpdater())
+        await profileGate.waitUntilRequested()
+        #expect(manager.gatewayEntries.contains { $0.id == "profile:saved-b" })
+        await profileGate.release()
+        let credentialDeadline = ContinuousClock.now + .seconds(5)
+        while manager.gatewayEntries.first(where: { $0.id == "profile:saved-b" })?.canPromote != false,
+              ContinuousClock.now < credentialDeadline
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(manager.gatewayEntries.first { $0.id == "profile:saved-b" }?.canPromote == false)
+        saved.setEndpoint(GatewayConnection.EndpointSnapshot(
+            config: (url: savedServer.websocketURL(), token: "saved-b", password: nil), routeAuthority: nil))
+        primary.setEndpoint(GatewayConnection.EndpointSnapshot(
+            config: (url: primaryServer.websocketURL(), token: "primary-c", password: nil), routeAuthority: nil))
+        await manager.handleEndpointState(.ready(
+            mode: .remote, url: primaryServer.websocketURL(), token: "primary-c", password: nil, routeRevision: 2))
+
+        let windows = manager._testAuxiliaryWindows()
+        let following = try #require(windows.first { $0.controller.window === promotedWindow })
+        let fixed = try #require(windows.first { $0.controller.window === fixedWindow })
+        #expect(following.target == .primary)
+        #expect(following.controller.auth.token == "primary-c")
+        #expect(fixed.target == .profile("saved-b"))
+        #expect(fixed.controller.auth.token == "saved-b")
+        #expect(fixed.controller.currentURL.port == Int(savedServer.port))
+
+        fixed.controller.webView(fixed.controller.webView, didCommit: nil)
+        fixed.controller.dispatchNativeCommand(.commandPalette)
+        #expect(fixed.controller._testPendingNativeCommands == [.commandPalette])
+        saved.setEndpoint(GatewayConnection.EndpointSnapshot(
+            config: (url: savedServer.websocketURL(), token: "removed", password: nil), routeAuthority: nil))
+        manager.configure(updater: DashboardGatewayTestUpdater())
+        let deadline = ContinuousClock.now + .seconds(5)
+        while manager._testAuxiliaryWindows().contains(where: { $0.target == .profile("saved-b") }),
+              ContinuousClock.now < deadline
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(!manager.gatewayEntries.contains { $0.id == "profile:saved-b" })
+        #expect(manager._testAuxiliaryWindows().allSatisfy { $0.target == .primary })
+        let replacement = try #require(fixedWindow.windowController as? DashboardWindowController)
+        while replacement.webView.isLoading, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let commands = try await replacement.webView.evaluateJavaScript("window.commandEvents") as? [String]
+        #expect(commands == [])
+    }
+
+    @Test func `picker selection survives primary document replacement`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let gate = DashboardWindowOwnershipPresentationGate()
+        let manager = DashboardManager._testMake(
+            primaryEndpointProvider: { _ in
+                GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: "primary", password: nil), routeAuthority: nil)
+            },
+            profileEndpointProvider: { profileID in
+                await gate.waitForRelease()
+                return GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: profileID, password: nil), routeAuthority: nil)
+            },
+            gatewayEntriesProvider: { DashboardGatewayTestEntries.withProfiles(["secondary"]) })
+        defer { manager.close() }
+        try await manager.show()
+        let source = try #require(manager._testController())
+        let window = try #require(source.window)
+        let selection = Task { await manager._testSwitchTarget(.profile("secondary"), in: source) }
+        await gate.waitUntilRequested()
+
+        await manager.handleEndpointState(.connecting(mode: .remote, detail: "Reconnecting"))
+        #expect(manager._testController() !== source)
+        await gate.release()
+        await selection.value
+
+        #expect(manager._testMainTarget() == .profile("secondary"))
+        #expect(manager._testController()?.auth.token == "secondary")
+        #expect(manager._testController()?.window === window)
+    }
+
+    @Test func `picker resolves the current primary after suspended authentication`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let gate = DashboardWindowOwnershipPresentationGate(released: true)
+        let source = GatewayConnectionEndpointSource(url: server.websocketURL(), token: "before")
+        let manager = DashboardManager._testMake(
+            authTokenProvider: { config in
+                if config.token == "before" { await gate.waitForRelease() }
+                return config.token
+            },
+            primaryEndpointProvider: { _ in source.snapshot() },
+            profileEndpointProvider: { _ in
+                GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: "secondary", password: nil), routeAuthority: nil)
+            },
+            gatewayEntriesProvider: { DashboardGatewayTestEntries.withProfiles(["secondary"]) })
+        defer { manager.close() }
+        try await manager.show()
+        await manager._testOpenWindow(for: .profile("secondary"))
+        let secondary = try #require(manager._testAuxiliaryWindows().first?.controller)
+        let window = try #require(secondary.window)
+        await gate.hold()
+        let selection = Task { await manager._testSwitchTarget(.primary, in: secondary) }
+        await gate.waitUntilRequested()
+        source.setEndpoint(GatewayConnection.EndpointSnapshot(
+            config: (url: server.websocketURL(), token: "after", password: nil), routeAuthority: nil))
+        await manager.handleEndpointState(.ready(
+            mode: .remote, url: server.websocketURL(), token: "after", password: nil, routeRevision: 2))
+        await gate.release()
+        await selection.value
+
+        let selected = try #require(manager._testAuxiliaryWindows().first)
+        #expect(selected.target == .primary)
+        #expect(selected.controller.auth.token == "after")
+        #expect(selected.controller.window === window)
+    }
+
+    @Test func `saved credential changes refresh every existing profile document`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let source = GatewayConnectionEndpointSource(url: server.websocketURL(), token: "before")
+        let manager = DashboardManager._testMake(
+            observeGatewayChanges: true,
+            profileEndpointProvider: { _ in source.snapshot() },
+            gatewayEntriesProvider: { DashboardGatewayTestEntries.withProfiles(["secondary"]) })
+        defer { manager.close() }
+        await manager._testOpenWindow(for: .profile("secondary"))
+        await manager._testOpenWindow(for: .profile("secondary"))
+        let windows = manager._testAuxiliaryWindows().compactMap(\.controller.window)
+        #expect(windows.count == 2)
+        source.setEndpoint(GatewayConnection.EndpointSnapshot(
+            config: (url: server.websocketURL(), token: "after", password: nil), routeAuthority: nil))
+
+        NotificationCenter.default.post(name: MacGatewayProfileStore.didChangeNotification, object: nil)
+        let deadline = ContinuousClock.now + .seconds(5)
+        while manager._testAuxiliaryWindows().contains(where: { $0.controller.auth.token != "after" }),
+              ContinuousClock.now < deadline
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        let refreshed = manager._testAuxiliaryWindows()
+        #expect(refreshed.count == 2)
+        #expect(refreshed.allSatisfy { $0.controller.auth.token == "after" })
+        #expect(refreshed.allSatisfy { instance in windows.contains { $0 === instance.controller.window } })
+        for instance in refreshed {
+            let scripts = instance.controller._testUserScripts.map(\.source).joined()
+            #expect(scripts.contains("after"))
+            #expect(!scripts.contains("before"))
+        }
+    }
+
+    @Test(arguments: ["recover", "switch-away-and-back", "command-during-refresh", "reselect-current"])
+    func `failed secondary command recovery retains its window and command order`(_ scenario: String) async throws {
+        let server = try await DashboardHTTPFixture.start(
+            html: """
+            <html><body><script>
+            window.commandEvents = [];
+            window.addEventListener('openclaw:native-new-session', () => window.commandEvents.push('new-session'));
+            window.addEventListener('openclaw:native-toggle-search', event => {
+              event.preventDefault(); window.commandEvents.push('palette');
+            });
+            </script></body></html>
+            """,
+            contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'")
+        defer { server.stop() }
+        let gate = DashboardWindowOwnershipPresentationGate()
+        let catalogGate = DashboardWindowOwnershipPresentationGate(released: true)
+        let saved = GatewayConnectionEndpointSource(url: server.websocketURL(), token: "secondary")
+        let manager = DashboardManager._testMake(
+            primaryEndpointProvider: { _ in
+                GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: "primary", password: nil), routeAuthority: nil)
+            },
+            profileEndpointProvider: { _ in
+                let endpoint = saved.snapshot()
+                if endpoint.config.token == "suspended" { await gate.waitForRelease() }
+                return endpoint
+            },
+            gatewayEntriesProvider: {
+                await catalogGate.waitForRelease()
+                return DashboardGatewayTestEntries.withProfiles(["secondary"])
+            })
+        defer { manager.close() }
+        try await manager.show()
+        let primary = try #require(manager._testController())
+        await manager._testOpenWindow(for: .profile("secondary"))
+        let secondary = try #require(manager._testAuxiliaryWindows().first?.controller)
+        let window = try #require(secondary.window)
+        secondary.showFailure(title: "Unavailable", message: "Synthetic connection failure")
+        if scenario == "command-during-refresh" { await catalogGate.hold() }
+        saved.setEndpoint(GatewayConnection.EndpointSnapshot(
+            config: (url: server.websocketURL(), token: "suspended", password: nil), routeAuthority: nil))
+        manager.dispatchNativeCommand(.newSession)
+        manager.dispatchNativeCommand(.commandPalette)
+        manager.dispatchNativeCommand(.commandPalette)
+        await gate.waitUntilRequested()
+        saved.setEndpoint(GatewayConnection.EndpointSnapshot(
+            config: (url: server.websocketURL(), token: "secondary", password: nil), routeAuthority: nil))
+        if scenario == "switch-away-and-back" {
+            for target in [DashboardGatewayTarget.primary, .profile("secondary")] {
+                let current = try #require(window.windowController as? DashboardWindowController)
+                manager.handleGatewayRequest(.select(target), from: current)
+                let deadline = ContinuousClock.now + .seconds(5)
+                while manager._testAuxiliaryWindows().first?.target != target, ContinuousClock.now < deadline {
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+                #expect(manager._testAuxiliaryWindows().first?.target == target)
+            }
+        } else if scenario == "reselect-current" {
+            manager.switchFrontmostDashboard(to: .profile("secondary"))
+        }
+        await gate.release()
+        if scenario == "command-during-refresh" {
+            await catalogGate.waitUntilRequested()
+            let recovered = try #require(window.windowController as? DashboardWindowController)
+            let deadline = ContinuousClock.now + .seconds(5)
+            while !recovered.canDeliverNativeCommands || recovered.webView.isLoading,
+                  ContinuousClock.now < deadline
+            {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(recovered.canDeliverNativeCommands)
+            manager.dispatchNativeCommand(.commandPalette)
+            await catalogGate.release()
+        }
+
+        var primaryCommands: [String] = []
+        var secondaryCommands: [String] = []
+        let deadline = ContinuousClock.now + .seconds(5)
+        let expectedCount = scenario == "command-during-refresh" ? 4 : 3
+        while primaryCommands.count + secondaryCommands.count < expectedCount, ContinuousClock.now < deadline {
+            primaryCommands = await (try? primary.webView.evaluateJavaScript("window.commandEvents") as? [String]) ?? []
+            if let recovered = window.windowController as? DashboardWindowController {
+                await secondaryCommands =
+                    (try? recovered.webView.evaluateJavaScript("window.commandEvents") as? [String]) ?? []
+            }
+            if primaryCommands.count + secondaryCommands.count < expectedCount {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+
+        let expected: [String] = switch scenario {
+        case "switch-away-and-back", "reselect-current": []
+        case "command-during-refresh": ["new-session", "palette", "palette", "palette"]
+        default: ["new-session", "palette", "palette"]
+        }
+        #expect(primaryCommands.isEmpty)
+        #expect(secondaryCommands == expected)
+        #expect(manager._testController() === primary)
+        #expect(manager._testAuxiliaryWindows().first?.controller.window === window)
+        #expect((window.windowController as? DashboardWindowController)?.canDeliverNativeCommands == true)
+    }
+
+    @Test func `native commands stay in the frontmost gateway window`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let entries = DashboardGatewayTestEntries.withProfiles(["secondary"])
+        let manager = DashboardManager._testMake(
+            primaryEndpointProvider: { _ in
+                GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: "primary", password: nil),
+                    routeAuthority: nil)
+            },
+            profileEndpointProvider: { profileID in
+                GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: profileID, password: nil),
+                    routeAuthority: nil)
+            },
+            gatewayEntriesProvider: { entries })
+        defer { manager.close() }
+        try await manager.show()
+        let primary = try #require(manager._testController())
+        await manager._testOpenWindow(for: .profile("secondary"))
+        let secondary = try #require(manager._testAuxiliaryWindows().first?.controller)
+        for controller in [primary, secondary] {
+            let deadline = ContinuousClock.now + .seconds(5)
+            while controller.webView.isLoading, ContinuousClock.now < deadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(controller.canDeliverNativeCommands)
+            _ = try await controller.webView.evaluateJavaScript("""
+            window.commandEvents = [];
+            window.addEventListener('openclaw:native-new-session', () => window.commandEvents.push('new-session'));
+            window.addEventListener('openclaw:native-toggle-search', event => {
+              event.preventDefault(); window.commandEvents.push('palette');
+            });
+            """)
+        }
+        secondary.show()
+        #expect(manager.frontmostDashboardTarget == .profile("secondary"))
+        manager.dispatchNativeCommand(.newSession)
+        manager.dispatchNativeCommand(.commandPalette)
+        let primaryCommands = try await primary.webView.evaluateJavaScript("window.commandEvents") as? [String]
+        let secondaryCommands = try await secondary.webView.evaluateJavaScript("window.commandEvents") as? [String]
+        #expect(primaryCommands == [])
+        #expect(secondaryCommands == ["new-session", "palette"])
+    }
+
+    @Test func `closing the manager retires a pending gateway window open`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let gate = DashboardWindowOwnershipPresentationGate()
+        let entries = DashboardGatewayTestEntries.withProfiles(["secondary"])
+        let manager = DashboardManager._testMake(
+            profileEndpointProvider: { profileID in
+                await gate.waitForRelease()
+                return GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: profileID, password: nil),
+                    routeAuthority: nil)
+            },
+            gatewayEntriesProvider: { entries })
+        defer { manager.close() }
+        let open = Task { await manager._testOpenWindow(for: .profile("secondary")) }
+        await gate.waitUntilRequested()
+        manager.close()
+        await gate.release()
+        await open.value
+        #expect(manager._testAuxiliaryWindows().isEmpty)
+        #expect(manager.frontmostDashboardTarget == nil)
+    }
+
+    @Test(arguments: ["bridge", "open-menu", "switch-menu", "closed-source", "replaced-source"])
+    func `window requests cannot outlive their admitting owner`(_ entry: String) async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let manager = DashboardManager._testMake(
+            primaryEndpointProvider: { _ in
+                GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: "primary", password: nil), routeAuthority: nil)
+            },
+            profileEndpointProvider: { _ in
+                GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: "secondary", password: nil), routeAuthority: nil)
+            },
+            gatewayEntriesProvider: { DashboardGatewayTestEntries.withProfiles(["secondary"]) })
+        defer { manager.close() }
+        try await manager.show()
+        let source = try #require(manager._testController())
+        let target = DashboardGatewayTarget.profile("secondary")
+        switch entry {
+        case "bridge": manager.handleGatewayRequest(.openWindow(target), from: source)
+        case "open-menu": manager.openOrFocusDashboard(for: target)
+        case "closed-source":
+            source.closeDashboard()
+            manager.handleGatewayRequest(.openWindow(target), from: source)
+        case "replaced-source":
+            await manager._testSwitchTarget(.profile("replacement"), in: source)
+            manager.handleGatewayRequest(.openWindow(target), from: source)
+        default:
+            source.closeDashboard()
+            manager.switchFrontmostDashboard(to: target)
+        }
+        if entry != "closed-source", entry != "replaced-source" { manager.close() }
+        let deadline = ContinuousClock.now + .seconds(1)
+        while manager._testAuxiliaryWindows().isEmpty, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(manager._testAuxiliaryWindows().isEmpty)
+        #expect(manager._testController()?.isWindowOpen == (entry == "replaced-source"))
+        if entry == "replaced-source" { #expect(manager._testMainTarget() == .profile("replacement")) }
     }
 
     @Test func `main menu switch replaces the frontmost dashboard in place`() async throws {
@@ -510,6 +935,278 @@ struct DashboardManagerGatewayTargetTests {
     }
 }
 
+@MainActor
+extension DashboardManagerGatewayTargetTests {
+    @Test(arguments: ["present", "initial-command"])
+    func `superseded primary presentation preserves the selected profile`(_ entry: String) async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let configPath = TestIsolation.tempConfigPath()
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+        try Data("{}".utf8).write(to: URL(fileURLWithPath: configPath))
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_CONFIG_PATH": configPath,
+            "OPENCLAW_GATEWAY_TOKEN": nil,
+            "OPENCLAW_GATEWAY_PASSWORD": nil,
+        ]) {
+            let state = AppStateStore.shared
+            let previousMode = state.connectionMode
+            state.connectionMode = .remote
+            defer { state.connectionMode = previousMode }
+            let gate = DashboardWindowOwnershipPresentationGate(released: true)
+            let manager = DashboardManager._testMake(
+                primaryEndpointProvider: { _ in
+                    await gate.waitForRelease()
+                    return GatewayConnection.EndpointSnapshot(
+                        config: (url: server.websocketURL(), token: "primary", password: nil), routeAuthority: nil)
+                },
+                profileEndpointProvider: { _ in
+                    GatewayConnection.EndpointSnapshot(
+                        config: (url: server.websocketURL(), token: "secondary", password: nil), routeAuthority: nil)
+                },
+                gatewayEntriesProvider: { DashboardGatewayTestEntries.withProfiles(["secondary"]) })
+            defer { manager.close() }
+            if entry == "present" { try await manager.show() }
+            await gate.hold()
+            if entry == "present" {
+                manager.presentDashboard()
+            } else {
+                manager.dispatchNativeCommand(.commandPalette)
+            }
+            await gate.waitUntilRequested()
+            let presentation = Task { try await manager.show() }
+            if entry == "initial-command" {
+                let config = """
+                {"gateway":{"remote":{"transport":"direct","url":"\(server.websocketURL())","token":"primary"}}}
+                """
+                try Data(config.utf8).write(to: URL(fileURLWithPath: configPath))
+                #expect(manager.showConfiguredWindowIfPossible())
+            }
+            let source = try #require(manager._testController())
+            await manager._testSwitchTarget(.profile("secondary"), in: source)
+            let selected = try #require(manager._testController())
+            #expect(manager._testMainTarget() == .profile("secondary"))
+            await gate.release()
+            do {
+                try await presentation.value
+            } catch {
+                Issue.record("A superseded presentation reported failure: \(error)")
+            }
+            let deadline = ContinuousClock.now + .seconds(5)
+            while selected.webView.isLoading, ContinuousClock.now < deadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(manager._testController() === selected)
+            #expect(selected.auth.token == "secondary")
+            #expect(selected.canDeliverNativeCommands)
+            #expect(selected.isWindowOpen)
+        }
+    }
+
+    @Test(arguments: ["reconnect-during-recovery", "command-during-picker"])
+    func `window commands survive the current gateway transition`(_ scenario: String) async throws {
+        let responseGate = DashboardWindowOwnershipPresentationGate(released: true)
+        let primaryGate = DashboardWindowOwnershipPresentationGate(released: true)
+        let profileGate = DashboardWindowOwnershipPresentationGate(released: true)
+        let catalogGate = DashboardWindowOwnershipPresentationGate(released: true)
+        let server = try await DashboardHTTPFixture.start(
+            html: """
+            <html><body><script>
+            window.commandEvents = [];
+            window.addEventListener('openclaw:native-toggle-search', event => {
+              event.preventDefault(); window.commandEvents.push('palette');
+            });
+            </script></body></html>
+            """,
+            contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'",
+            beforeResponse: { await responseGate.waitForRelease() })
+        defer {
+            server.stop()
+            Task {
+                await responseGate.release()
+                await primaryGate.release()
+                await catalogGate.release()
+            }
+        }
+        let manager = DashboardManager._testMake(
+            primaryEndpointProvider: { _ in
+                await primaryGate.waitForRelease()
+                return GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: "primary", password: nil), routeAuthority: nil)
+            },
+            profileEndpointProvider: { _ in
+                await profileGate.waitForRelease()
+                return GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: "secondary", password: nil), routeAuthority: nil)
+            },
+            gatewayEntriesProvider: {
+                let read = await catalogGate.waitForRelease()
+                var entries = DashboardGatewayTestEntries.withProfiles(["secondary"])
+                entries[0] = DashboardGatewayEntry(
+                    id: "primary",
+                    name: "Catalog \(read)",
+                    kind: "local",
+                    isPrimary: true,
+                    canPromote: false,
+                    health: .ok)
+                return entries
+            })
+        defer { manager.close() }
+        let reconnect = scenario == "reconnect-during-recovery"
+        await manager._testOpenWindow(for: reconnect ? .primary : .profile("secondary"))
+        let original = try #require(manager._testAuxiliaryWindows().first?.controller)
+        let window = try #require(original.window)
+        original.showFailure(title: "Unavailable", message: "Synthetic connection failure")
+        if reconnect {
+            await responseGate.hold()
+            await catalogGate.hold()
+        } else {
+            await primaryGate.hold()
+            manager.handleGatewayRequest(.select(.primary), from: original)
+            await primaryGate.waitUntilRequested()
+        }
+        manager.dispatchNativeCommand(.commandPalette)
+        manager.dispatchNativeCommand(.commandPalette)
+        if reconnect {
+            await catalogGate.waitUntilRequested()
+            await manager.handleEndpointState(.connecting(mode: .remote, detail: "Reconnecting"))
+            await catalogGate.release()
+            let deadline = ContinuousClock.now + .seconds(5)
+            while manager.gatewayEntries.first?.name != "Catalog 2", ContinuousClock.now < deadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(manager.gatewayEntries.first?.name == "Catalog 2")
+            await manager.handleEndpointState(.ready(
+                mode: .remote, url: server.websocketURL(), token: "reconnected", password: nil, routeRevision: 2))
+            await responseGate.release()
+        } else {
+            // Wait until the command has entered either the current window or an endpoint recovery.
+            let deadline = ContinuousClock.now + .seconds(5)
+            while original._testPendingNativeCommands.isEmpty,
+                  await profileGate.numberOfRequests() == 1, ContinuousClock.now < deadline
+            {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            await primaryGate.release()
+        }
+        let deadline = ContinuousClock.now + .seconds(5)
+        var events: [String] = []
+        repeat {
+            if let current = window.windowController as? DashboardWindowController {
+                events = await (try? current.webView.evaluateJavaScript("window.commandEvents") as? [String]) ?? []
+                if !current.webView.isLoading, events == ["palette", "palette"],
+                   manager._testAuxiliaryWindows().first?.target == .primary
+                {
+                    break
+                }
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        } while ContinuousClock.now < deadline
+        #expect(manager._testAuxiliaryWindows().first?.target == .primary)
+        #expect(events == ["palette", "palette"])
+        #expect((window.windowController as? DashboardWindowController)?.auth.token ==
+            (reconnect ? "reconnected" : "primary"))
+    }
+
+    @Test(arguments: ["primary-endpoint", "primary-reconnect", "profile-credentials", "picker", "close"])
+    func `loading document actions follow only the surviving window selection`(_ scenario: String) async throws {
+        let responseGate = DashboardWindowOwnershipPresentationGate()
+        let html = """
+        <html><body><script>
+        window.commandEvents = [];
+        window.addEventListener('openclaw:native-new-session', () => window.commandEvents.push('new-session'));
+        window.addEventListener('openclaw:native-toggle-search', event => {
+          event.preventDefault(); window.commandEvents.push('palette');
+        });
+        window.addEventListener('openclaw:native-navigate', event => {
+          event.preventDefault(); history.pushState({}, '', event.detail.path);
+          window.commandEvents.push('navigation');
+        });
+        </script></body></html>
+        """
+        let server = try await DashboardHTTPFixture.start(
+            html: html,
+            contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'",
+            beforeResponse: { await responseGate.waitForRelease() })
+        let replacementServer = try await DashboardHTTPFixture.start(
+            html: html, contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'")
+        defer {
+            server.stop()
+            replacementServer.stop()
+            Task { await responseGate.release() }
+        }
+        let source = GatewayConnectionEndpointSource(url: server.websocketURL(), token: "before")
+        let profile = scenario == "profile-credentials" || scenario == "picker" || scenario == "close"
+        let manager = DashboardManager._testMake(
+            observeGatewayChanges: scenario == "profile-credentials",
+            primaryEndpointProvider: { _ in
+                scenario == "picker"
+                    ? GatewayConnection.EndpointSnapshot(
+                        config: (url: replacementServer.websocketURL(), token: "after", password: nil),
+                        routeAuthority: nil)
+                    : source.snapshot()
+            },
+            profileEndpointProvider: { _ in source.snapshot() },
+            gatewayEntriesProvider: { DashboardGatewayTestEntries.withProfiles(["secondary"]) })
+        defer { manager.close() }
+        await manager._testOpenWindow(for: profile ? .profile("secondary") : .primary)
+        await responseGate.waitUntilRequested()
+        let original = try #require(manager._testAuxiliaryWindows().first?.controller)
+        let window = try #require(original.window)
+        #expect(original.webView.isLoading)
+        #expect(original.canDeliverNativeCommands)
+        manager.dispatchNativeCommand(.newSession)
+        manager.dispatchNativeCommand(.commandPalette)
+        manager.dispatchNativeCommand(.commandPalette)
+        #expect(original._testPendingNativeCommands == [.newSession, .commandPalette, .commandPalette])
+        let path = "/chat/main/dashboard/preserved"
+        original.dispatchNativeNavigation(DashboardNativeNavigation(
+            path: path, search: nil, fallbackURL: server.url(path)))
+        let intent = original.windowIntentGeneration
+
+        switch scenario {
+        case "close":
+            window.performClose(nil)
+            #expect(original._testPendingNativeCommands.isEmpty)
+            #expect(original._testPendingNativeNavigation == nil)
+            #expect(manager._testAuxiliaryWindows().isEmpty)
+            return
+        case "picker":
+            manager.handleGatewayRequest(.select(.primary), from: original)
+        case "profile-credentials":
+            source.setEndpoint(GatewayConnection.EndpointSnapshot(
+                config: (url: server.websocketURL(), token: "after", password: nil), routeAuthority: nil))
+            NotificationCenter.default.post(name: MacGatewayProfileStore.didChangeNotification, object: nil)
+        default:
+            if scenario == "primary-reconnect" {
+                await manager.handleEndpointState(.connecting(mode: .remote, detail: "Reconnecting"))
+            }
+            await manager.handleEndpointState(.ready(
+                mode: .remote, url: replacementServer.websocketURL(), token: "after", password: nil, routeRevision: 2))
+        }
+        let replacementDeadline = ContinuousClock.now + .seconds(5)
+        while window.windowController === original, ContinuousClock.now < replacementDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let replacement = try #require(window.windowController as? DashboardWindowController)
+        #expect(replacement !== original)
+        #expect(replacement.window === window)
+        if scenario != "picker" { #expect(replacement.windowIntentGeneration == intent) }
+        await responseGate.release()
+        let deadline = ContinuousClock.now + .seconds(5)
+        let expected = scenario == "picker" ? [] :
+            ["new-session", "palette", "palette"] + (scenario == "profile-credentials" ? ["navigation"] : [])
+        var events: [String] = []
+        repeat {
+            events = await (try? replacement.webView.evaluateJavaScript("window.commandEvents") as? [String]) ?? []
+            if !replacement.webView.isLoading, replacement.canDeliverNativeCommands, events == expected { break }
+            try await Task.sleep(for: .milliseconds(10))
+        } while ContinuousClock.now < deadline
+        #expect(events == expected)
+        #expect(replacement.webView.url?.path == (scenario == "profile-credentials" ? path : "/"))
+    }
+}
+
 private enum DashboardGatewayTestEntries {
     static func withProfiles(_ profileIDs: [String]) -> [DashboardGatewayEntry] {
         [
@@ -583,11 +1280,11 @@ private final class DashboardGatewayTestUpdater: UpdaterProviding {
 
 @MainActor
 struct DashboardPrimaryGatewayAdapterTests {
-    @Test func `token profile promotion carries its TLS pin`() async throws {
+    @Test(arguments: [nil, String(repeating: "a", count: 64)] as [String?])
+    func `token profile promotion carries its authentication and TLS policy`(fingerprint: String?) async throws {
         let state = AppState(preview: true)
         let url = try #require(URL(string: "wss://studio.example:443/"))
-        let fingerprint = String(repeating: "a", count: 64)
-        var persistedFingerprints: [String?] = []
+        var configurations: [AppState.PrimaryGatewayConfiguration] = []
         let adapter = DashboardPrimaryGatewayAdapter(
             state: state,
             endpoint: { _ in
@@ -596,43 +1293,14 @@ struct DashboardPrimaryGatewayAdapterTests {
                     tls: DashboardGatewayTestTLS.route(fingerprint: fingerprint),
                     routeAuthority: nil)
             },
-            currentTLSFingerprint: { nil },
-            persist: { _, fingerprint in
-                persistedFingerprints.append(fingerprint)
+            persist: { _, configuration in
+                configurations.append(configuration)
                 return true
             })
 
         try await adapter.apply(profileID: "studio")
 
-        #expect(state.remoteTransport == .direct)
-        #expect(state.remoteUrl == url.absoluteString)
-        #expect(state.remoteToken == "profile-token")
-        #expect(state.connectionMode == .remote)
-        #expect(persistedFingerprints == [fingerprint])
-    }
-
-    @Test func `token profile without a pin clears the previous primary pin`() async throws {
-        let state = AppState(preview: true)
-        let url = try #require(URL(string: "wss://studio.example:443/"))
-        var persistedFingerprints: [String?] = []
-        let adapter = DashboardPrimaryGatewayAdapter(
-            state: state,
-            endpoint: { _ in
-                GatewayConnection.EndpointSnapshot(
-                    config: (url: url, token: "profile-token", password: nil),
-                    tls: DashboardGatewayTestTLS.route(fingerprint: nil),
-                    routeAuthority: nil)
-            },
-            currentTLSFingerprint: { String(repeating: "b", count: 64) },
-            persist: { _, fingerprint in
-                persistedFingerprints.append(fingerprint)
-                return true
-            })
-
-        try await adapter.apply(profileID: "studio")
-
-        #expect(persistedFingerprints.count == 1)
-        #expect(persistedFingerprints[0] == nil)
+        #expect(configurations == [.init(url: url, token: "profile-token", tlsFingerprint: fingerprint)])
     }
 
     @Test func `password only profile cannot be promoted`() async throws {
@@ -650,52 +1318,17 @@ struct DashboardPrimaryGatewayAdapterTests {
         }
     }
 
-    @Test func `failed promotion restores previous AppState fields`() async throws {
-        let state = AppState(preview: true)
-        state.remoteTransport = .ssh
-        state.remoteUrl = "ws://127.0.0.1:18789"
-        state.remoteToken = "previous-token"
-        state.connectionMode = .local
-        let url = try #require(URL(string: "wss://studio.example:443/"))
-        let previousFingerprint = String(repeating: "b", count: 64)
-        let profileFingerprint = String(repeating: "a", count: 64)
-        var persistedFingerprints: [String?] = []
-        let adapter = DashboardPrimaryGatewayAdapter(
-            state: state,
-            endpoint: { _ in
-                GatewayConnection.EndpointSnapshot(
-                    config: (url: url, token: "profile-token", password: nil),
-                    tls: DashboardGatewayTestTLS.route(fingerprint: profileFingerprint),
-                    routeAuthority: nil)
-            },
-            currentTLSFingerprint: { previousFingerprint },
-            persist: { _, fingerprint in
-                persistedFingerprints.append(fingerprint)
-                return persistedFingerprints.count > 1
-            })
-
-        await #expect(throws: DashboardPrimaryGatewayError.notPromotable) {
-            try await adapter.apply(profileID: "studio")
-        }
-        #expect(state.remoteTransport == .ssh)
-        #expect(state.remoteUrl == "ws://127.0.0.1:18789")
-        #expect(state.remoteToken == "previous-token")
-        #expect(state.connectionMode == .local)
-        #expect(persistedFingerprints == [profileFingerprint, previousFingerprint])
-    }
-
-    @Test func `deep link applies direct endpoint and clears omitted token and pin`() throws {
+    @Test func `deep link submits its direct endpoint without inherited authentication`() throws {
         let state = AppState(preview: true)
         state.remoteTransport = .ssh
         state.remoteUrl = "ws://127.0.0.1:18789"
         state.remoteToken = "stale-token"
         state.connectionMode = .local
-        var persistedFingerprints: [String?] = []
+        var configurations: [AppState.PrimaryGatewayConfiguration] = []
         let adapter = DashboardPrimaryGatewayAdapter(
             state: state,
-            currentTLSFingerprint: { String(repeating: "b", count: 64) },
-            persist: { _, fingerprint in
-                persistedFingerprints.append(fingerprint)
+            persist: { _, configuration in
+                configurations.append(configuration)
                 return true
             })
         let link = GatewayConnectDeepLink(
@@ -708,11 +1341,10 @@ struct DashboardPrimaryGatewayAdapterTests {
 
         try adapter.apply(link: link)
 
-        #expect(state.remoteTransport == .direct)
-        #expect(state.remoteUrl == "wss://gateway.example:8443")
-        #expect(state.remoteToken.isEmpty)
-        #expect(state.connectionMode == .remote)
-        #expect(persistedFingerprints == [nil])
+        #expect(try configurations == [.init(
+            url: #require(link.websocketURL),
+            token: nil,
+            tlsFingerprint: nil)])
     }
 
     @Test func `deep link password is rejected without mutation`() throws {
@@ -760,7 +1392,6 @@ struct DashboardGatewaySetupCoordinatorTests {
         let coordinator = DashboardGatewaySetupCoordinator(
             adapter: DashboardPrimaryGatewayAdapter(
                 state: state,
-                currentTLSFingerprint: { String(repeating: "a", count: 64) },
                 persist: { _, _ in
                     persistCount += 1
                     return true
@@ -787,15 +1418,14 @@ struct DashboardGatewaySetupCoordinatorTests {
         #expect(openedSettings == 0)
     }
 
-    @Test func `accept applies primary and opens connection settings`() {
+    @Test func `accept persists primary and opens connection settings`() throws {
         let state = AppState(preview: true)
-        var persistedFingerprints: [String?] = []
+        var configurations: [AppState.PrimaryGatewayConfiguration] = []
         var openedSettings = 0
         let adapter = DashboardPrimaryGatewayAdapter(
             state: state,
-            currentTLSFingerprint: { nil },
-            persist: { _, fingerprint in
-                persistedFingerprints.append(fingerprint)
+            persist: { _, configuration in
+                configurations.append(configuration)
                 return true
             })
         let coordinator = DashboardGatewaySetupCoordinator(
@@ -813,9 +1443,10 @@ struct DashboardGatewaySetupCoordinatorTests {
 
         coordinator.handle(link)
 
-        #expect(state.remoteUrl == "wss://gateway.example:443")
-        #expect(state.remoteToken == "fixture-token")
-        #expect(persistedFingerprints == [nil])
+        #expect(try configurations == [.init(
+            url: #require(link.websocketURL),
+            token: "fixture-token",
+            tlsFingerprint: nil)])
         #expect(openedSettings == 1)
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixture.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixture.swift
@@ -15,13 +15,21 @@ final class DashboardHTTPFixture {
     private let listener: NWListener
     private let responseHTML: String
     private let contentSecurityPolicy: String
+    private let beforeResponse: (@MainActor () async -> Void)?
     private var clients: [UUID: Client] = [:]
     private var stopped = false
     nonisolated let port: UInt16
 
-    private init(listener: NWListener, port: UInt16, html: String, contentSecurityPolicy: String) {
+    private init(
+        listener: NWListener,
+        port: UInt16,
+        html: String,
+        contentSecurityPolicy: String,
+        beforeResponse: (@MainActor () async -> Void)?)
+    {
         self.responseHTML = html
         self.contentSecurityPolicy = contentSecurityPolicy
+        self.beforeResponse = beforeResponse
         self.listener = listener
         self.port = port
         self.listener.newConnectionHandler = { [weak self] connection in
@@ -37,7 +45,8 @@ final class DashboardHTTPFixture {
 
     static func start(
         html: String = DashboardHTTPFixture.html,
-        contentSecurityPolicy: String = "default-src 'none'") async throws -> DashboardHTTPFixture
+        contentSecurityPolicy: String = "default-src 'none'",
+        beforeResponse: (@MainActor () async -> Void)? = nil) async throws -> DashboardHTTPFixture
     {
         let parameters = NWParameters.tcp
         parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
@@ -57,7 +66,8 @@ final class DashboardHTTPFixture {
                         listener: listener,
                         port: port.rawValue,
                         html: html,
-                        contentSecurityPolicy: contentSecurityPolicy)
+                        contentSecurityPolicy: contentSecurityPolicy,
+                        beforeResponse: beforeResponse)
                 case let .failed(error):
                     throw error
                 case .cancelled:
@@ -66,7 +76,9 @@ final class DashboardHTTPFixture {
                     try await Task.sleep(for: .milliseconds(10))
                 }
             }
-            throw URLError(.timedOut)
+            throw URLError(.timedOut, userInfo: [
+                NSLocalizedDescriptionKey: "Dashboard HTTP fixture listener timed out: \(listener.state)",
+            ])
         } catch {
             listener.cancel()
             throw error
@@ -109,14 +121,23 @@ final class DashboardHTTPFixture {
         guard let client = self.clients[id] else { return }
         // One bounded request per connection; neither slow clients nor a partial
         // header can leave a receive alive beyond the connection's deadline.
-        client.connection.receive(minimumIncompleteLength: 1, maximumLength: 8192 - client.request.count) {
-            [weak self] data, _, complete, error in
+        client.connection.receive(
+            minimumIncompleteLength: 1,
+            maximumLength: 8192 - client.request.count)
+        { [weak self] data, _, complete, error in
             MainActor.assumeIsolated {
                 guard let self, var client = self.clients[id] else { return }
                 if let data { client.request.append(data) }
                 self.clients[id] = client
                 if client.request.range(of: Data("\r\n\r\n".utf8)) != nil {
-                    self.respond(id)
+                    if let beforeResponse = self.beforeResponse {
+                        Task { @MainActor [weak self] in
+                            await beforeResponse()
+                            self?.respond(id)
+                        }
+                    } else {
+                        self.respond(id)
+                    }
                 } else if error != nil || complete || client.request.count >= 8192 {
                     self.close(id)
                 } else {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
@@ -137,134 +137,142 @@ extension DashboardWindowOwnershipTests {
 
     @Test(arguments: ["same", "refreshed", "refreshed-close", "new-window-close"])
     func `older manager command replay does not cancel a newer notification click`(_ scenario: String) async throws {
-        let server = try await DashboardHTTPFixture.start(
-            html: """
-            <html><body><script>
-            window.commandEvents = [];
-            window.addEventListener('openclaw:native-new-session', () => window.commandEvents.push('new-session'));
-            window.addEventListener('openclaw:native-toggle-search', event => {
-              event.preventDefault(); window.commandEvents.push('toggle');
-            });
-            window.addEventListener('openclaw:native-navigate', event => {
-              event.preventDefault(); history.pushState({}, '', event.detail.path);
-            });
-            </script></body></html>
-            """,
-            contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'")
-        defer { server.stop() }
-        let state = AppStateStore.shared
-        let previousMode = state.connectionMode
-        state.connectionMode = .remote
-        defer { state.connectionMode = previousMode }
-        let primaryGate = DashboardWindowOwnershipPresentationGate(released: true)
-        let notificationGate = DashboardWindowOwnershipPresentationGate()
-        let endpointURL = server.websocketURL()
-        let manager = DashboardManager._testMake(
-            primaryEndpointProvider: { _ in
-                let request = await primaryGate.waitForRelease()
-                if request == (scenario == "new-window-close" ? 2 : 3) {
-                    await notificationGate.waitForRelease()
-                }
-                return GatewayConnection.EndpointSnapshot(
-                    config: (
-                        url: endpointURL,
-                        token: request == 1 || scenario == "same" ? "before" : "after",
-                        password: nil),
-                    routeAuthority: nil)
-            },
-            gatewayEntriesProvider: { [Self.primaryGateway] })
-        defer { manager.close() }
-        if scenario != "new-window-close" {
-            try await manager.show()
-            let controller = try #require(manager._testController())
-            try await self.waitForDashboard(controller, path: "/")
-            controller.window?.performClose(nil)
-        }
-        let originalWindow = manager._testController()?.window
-        await primaryGate.hold()
-        manager.dispatchNativeCommand(.newSession)
-        manager.dispatchNativeCommand(.commandPalette)
-        manager.dispatchNativeCommand(.commandPalette)
-        await primaryGate.waitUntilRequested()
+        try await TestIsolation.withIsolatedState {
+            let server = try await DashboardHTTPFixture.start(
+                html: """
+                <html><body><script>
+                window.commandEvents = [];
+                window.addEventListener('openclaw:native-new-session', () => window.commandEvents.push('new-session'));
+                window.addEventListener('openclaw:native-toggle-search', event => {
+                  event.preventDefault(); window.commandEvents.push('toggle');
+                });
+                window.addEventListener('openclaw:native-navigate', event => {
+                  event.preventDefault(); history.pushState({}, '', event.detail.path);
+                });
+                </script></body></html>
+                """,
+                contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'")
+            defer { server.stop() }
+            let state = AppStateStore.shared
+            let previousMode = state.connectionMode
+            state.connectionMode = .remote
+            defer { state.connectionMode = previousMode }
+            let primaryGate = DashboardWindowOwnershipPresentationGate(released: true)
+            let notificationGate = DashboardWindowOwnershipPresentationGate()
+            let endpointURL = server.websocketURL()
+            let manager = DashboardManager._testMake(
+                primaryEndpointProvider: { _ in
+                    let request = await primaryGate.waitForRelease()
+                    if request == (scenario == "new-window-close" ? 2 : 3) {
+                        await notificationGate.waitForRelease()
+                    }
+                    return GatewayConnection.EndpointSnapshot(
+                        config: (
+                            url: endpointURL,
+                            token: request == 1 || scenario == "same" ? "before" : "after",
+                            password: nil),
+                        routeAuthority: nil)
+                },
+                gatewayEntriesProvider: { [Self.primaryGateway] })
+            defer { manager.close() }
+            if scenario != "new-window-close" {
+                try await manager.show()
+                let controller = try #require(manager._testController())
+                try await self.waitForDashboard(controller, path: "/")
+                controller.window?.performClose(nil)
+            }
+            let originalWindow = manager._testController()?.window
+            await primaryGate.hold()
+            manager.dispatchNativeCommand(.newSession)
+            manager.dispatchNativeCommand(.commandPalette)
+            manager.dispatchNativeCommand(.commandPalette)
+            await primaryGate.waitUntilRequested()
 
-        let click = Task { @MainActor in
-            try await manager.openBackgroundSession(
-                self.completion(), target: .primary, sourceURL: server.url())
-        }
-        while await primaryGate.numberOfRequests() < (scenario == "new-window-close" ? 2 : 3) {
-            await Task.yield()
-        }
-        await primaryGate.release()
-        await notificationGate.waitUntilRequested()
-        let reopened = try await self.waitForQueuedToggles(manager)
-        let window = try #require(reopened.window)
-        if let originalWindow { #expect(window === originalWindow) }
-        let commands = try await reopened.webView.evaluateJavaScript("window.commandEvents") as? [String]
-        #expect(commands == ["toggle", "toggle"])
-        if scenario.hasSuffix("-close") {
-            window.performClose(nil)
-        }
-        await notificationGate.release()
-        try await click.value
+            let click = Task { @MainActor in
+                try await manager.openBackgroundSession(
+                    self.completion(), target: .primary, sourceURL: server.url())
+            }
+            while await primaryGate.numberOfRequests() < (scenario == "new-window-close" ? 2 : 3) {
+                await Task.yield()
+            }
+            await primaryGate.release()
+            await notificationGate.waitUntilRequested()
+            let reopened = try await self.waitForQueuedToggles(manager)
+            let window = try #require(reopened.window)
+            if let originalWindow { #expect(window === originalWindow) }
+            let commands = try await reopened.webView.evaluateJavaScript("window.commandEvents") as? [String]
+            #expect(commands == ["toggle", "toggle"])
+            if scenario.hasSuffix("-close") {
+                window.performClose(nil)
+            }
+            await notificationGate.release()
+            try await click.value
 
-        let current = try #require(manager._testController())
-        #expect(current.window === window)
-        if scenario.hasSuffix("-close") {
-            #expect(!current.isWindowOpen)
-            #expect(current.webView.url?.path == "/")
-        } else {
-            try await self.waitForDashboard(current, path: "/chat/main/dashboard/completed")
+            let current = try #require(manager._testController())
+            #expect(current.window === window)
+            if scenario.hasSuffix("-close") {
+                #expect(!current.isWindowOpen)
+                #expect(current.webView.url?.path == "/")
+            } else {
+                try await self.waitForDashboard(current, path: "/chat/main/dashboard/completed")
+            }
         }
     }
 
     @Test(arguments: ["same-close", "other-open"])
     func `manual window admission retires only its target notification`(_ action: String) async throws {
-        let server = try await DashboardHTTPFixture.start()
-        defer { server.stop() }
-        let state = AppStateStore.shared
-        let previousMode = state.connectionMode
-        state.connectionMode = .remote
-        defer { state.connectionMode = previousMode }
-        let gate = DashboardWindowOwnershipPresentationGate()
-        let endpointURL = server.websocketURL()
-        let endpoint = GatewayConnection.EndpointSnapshot(
-            config: (url: endpointURL, token: "synthetic", password: nil), routeAuthority: nil)
-        let manager = DashboardManager._testMake(
-            primaryEndpointProvider: { _ in endpoint },
-            profileEndpointProvider: { _ in
-                if await gate.numberOfRequests() == 0 { await gate.waitForRelease() }
-                return endpoint
-            },
-            gatewayEntriesProvider: {
-                [Self.primaryGateway, DashboardGatewayEntry(
-                    id: "profile:background", name: "Background", kind: "remote",
-                    isPrimary: false, canPromote: false, health: .ok)]
-            })
-        defer { manager.close() }
-        let target = DashboardGatewayTarget.profile("background")
-        let click = Task { @MainActor in
-            try await manager.openBackgroundSession(self.completion(), target: target, sourceURL: server.url())
-        }
-        await gate.waitUntilRequested()
-        manager.openOrFocusDashboard(for: action == "other-open" ? .primary : target)
-        let deadline = ContinuousClock.now + .seconds(5)
-        while manager._testController() == nil, manager._testAuxiliaryWindows().isEmpty,
-              ContinuousClock.now < deadline
-        {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        let opened = try #require(manager._testController() ?? manager._testAuxiliaryWindows().first?.controller)
-        try await self.waitForDashboard(opened, path: "/")
-        if action == "same-close" { opened.window?.performClose(nil) }
-        await gate.release()
-        try await click.value
+        try await TestIsolation.withIsolatedState {
+            let server = try await DashboardHTTPFixture.start()
+            defer { server.stop() }
+            let state = AppStateStore.shared
+            let previousMode = state.connectionMode
+            state.connectionMode = .remote
+            defer { state.connectionMode = previousMode }
+            let gate = DashboardWindowOwnershipPresentationGate()
+            let endpointURL = server.websocketURL()
+            let endpoint = GatewayConnection.EndpointSnapshot(
+                config: (url: endpointURL, token: "synthetic", password: nil), routeAuthority: nil)
+            let manager = DashboardManager._testMake(
+                primaryEndpointProvider: { _ in endpoint },
+                profileEndpointProvider: { _ in
+                    if await gate.numberOfRequests() == 0 { await gate.waitForRelease() }
+                    return endpoint
+                },
+                gatewayEntriesProvider: {
+                    [Self.primaryGateway, DashboardGatewayEntry(
+                        id: "profile:background",
+                        name: "Background",
+                        kind: "remote",
+                        isPrimary: false,
+                        canPromote: false,
+                        health: .ok)]
+                })
+            defer { manager.close() }
+            let target = DashboardGatewayTarget.profile("background")
+            let click = Task { @MainActor in
+                try await manager.openBackgroundSession(self.completion(), target: target, sourceURL: server.url())
+            }
+            await gate.waitUntilRequested()
+            manager.openOrFocusDashboard(for: action == "other-open" ? .primary : target)
+            let deadline = ContinuousClock.now + .seconds(5)
+            while manager._testController() == nil, manager._testAuxiliaryWindows().isEmpty,
+                  ContinuousClock.now < deadline
+            {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            let opened = try #require(manager._testController() ?? manager._testAuxiliaryWindows().first?.controller)
+            try await self.waitForDashboard(opened, path: "/")
+            if action == "same-close" { opened.window?.performClose(nil) }
+            await gate.release()
+            try await click.value
 
-        if action == "same-close" {
-            #expect(manager._testAuxiliaryWindows().isEmpty)
-        } else {
-            let completed = try #require(manager._testAuxiliaryWindows().first?.controller)
-            try await self.waitForDashboard(completed, path: "/chat/main/dashboard/completed")
-            #expect(opened.webView.url?.path == "/")
+            if action == "same-close" {
+                #expect(manager._testAuxiliaryWindows().isEmpty)
+            } else {
+                let completed = try #require(manager._testAuxiliaryWindows().first?.controller)
+                try await self.waitForDashboard(completed, path: "/chat/main/dashboard/completed")
+                #expect(opened.webView.url?.path == "/")
+            }
         }
     }
 
@@ -453,8 +461,12 @@ extension DashboardWindowOwnershipTests {
             },
             gatewayEntriesProvider: {
                 [Self.primaryGateway, DashboardGatewayEntry(
-                    id: "profile:background", name: "Background", kind: "remote",
-                    isPrimary: false, canPromote: false, health: .ok)]
+                    id: "profile:background",
+                    name: "Background",
+                    kind: "remote",
+                    isPrimary: false,
+                    canPromote: false,
+                    health: .ok)]
             })
     }
 
@@ -490,6 +502,11 @@ extension DashboardWindowOwnershipTests {
         }
         #expect(controller.canDeliverNativeCommands)
         #expect(controller.webView.url?.path == path)
-        throw URLError(.timedOut)
+        throw URLError(.timedOut, userInfo: [
+            NSLocalizedDescriptionKey: "Dashboard document timed out: expected path=\(path), " +
+                "actual path=\(controller.webView.url?.path ?? "nil"), " +
+                "canDeliverNativeCommands=\(controller.canDeliverNativeCommands), " +
+                "isLoading=\(controller.webView.isLoading)",
+        ])
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
@@ -341,11 +341,13 @@ extension DashboardWindowOwnershipTests {
         try await self.waitForDashboard(clicked, path: "/")
         try await self.waitForDashboard(other, path: "/")
         let windows = [main, clicked, other].compactMap(\.window)
-        clicked.show()
-        try #require(NSApp.orderedWindows.first(where: { windows.contains($0) }) === clicked.window)
-        try #require(windows.first(where: \.isKeyWindow).map { $0 === clicked.window } ?? true)
         await gate.hold()
         let click = Task { @MainActor in
+            // Focus and admission are one UI action; yielding between them lets
+            // unrelated AppKit tests choose the window before this click starts.
+            clicked.show()
+            #expect(NSApp.orderedWindows.first(where: { windows.contains($0) }) === clicked.window)
+            #expect(windows.first(where: \.isKeyWindow).map { $0 === clicked.window } ?? true)
             try await manager.openBackgroundSession(self.completion(), target: .primary, sourceURL: server.url())
         }
         await gate.waitUntilRequested()

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -1094,9 +1094,10 @@ extension DashboardWindowSmokeTests {
         let replacementServer = try await DashboardHTTPFixture.start()
         defer { replacementServer.stop() }
         let controller = self.makeShownController(server: server)
-        defer { controller.closeDashboard() }
+        let window = try #require(controller.window)
         let manager = DashboardManager._testMake()
         manager._testSetController(controller)
+        defer { manager.close() }
 
         await manager.handleEndpointState(.ready(
             mode: .remote,
@@ -1104,8 +1105,12 @@ extension DashboardWindowSmokeTests {
             token: "device-token",
             password: nil))
 
-        #expect(controller.currentURL.absoluteString == replacementServer.url("/#token=device-token").absoluteString)
-        let authScripts = controller._testUserScripts
+        let replacement = try #require(manager._testController())
+        #expect(replacement !== controller)
+        #expect(replacement.window === window)
+        #expect(window.isVisible)
+        #expect(replacement.currentURL.absoluteString == replacementServer.url("/#token=device-token").absoluteString)
+        let authScripts = replacement._testUserScripts
             .filter { $0.source.contains("__OPENCLAW_NATIVE_CONTROL_AUTH__") }
         #expect(authScripts.count == 1)
         // JSONSerialization escapes "/" so match on host:port, not the full origin.

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalQueueStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalQueueStoreTests.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import Foundation
 import OpenClawProtocol
 import Testing
@@ -18,7 +19,7 @@ private struct ApprovalFixtureRequest: Encodable, Sendable {
 
     init(
         id: String,
-        sessionKey: String = "main",
+        sessionKey: String? = "main",
         command: String = "echo safe",
         createdOffsetMs: Int = 0,
         expiresOffsetMs: Int = 60000,
@@ -39,6 +40,7 @@ private struct ApprovalFixtureRequest: Encodable, Sendable {
 }
 
 private struct ApprovalGatewayRequest: Sendable {
+    let gatewayURL: URL
     let id: String
     let method: String
     let approvalId: String?
@@ -48,12 +50,18 @@ private struct ApprovalGatewayRequest: Sendable {
 
 private actor ApprovalGatewayRequestLog {
     private var makeListedRequests: @Sendable () -> [ApprovalFixtureRequest]
+    private var makeListedSystemRequests: @Sendable () -> [ApprovalFixtureRequest]
     private var requests: [ApprovalGatewayRequest] = []
     private var nextSequence = 0
     private var resolveRejection: String?
+    private var unavailableMethods: Set<String> = []
 
-    init(initialRequests: @escaping @Sendable () -> [ApprovalFixtureRequest]) {
+    init(
+        initialRequests: @escaping @Sendable () -> [ApprovalFixtureRequest],
+        systemRequests: @escaping @Sendable () -> [ApprovalFixtureRequest])
+    {
         self.makeListedRequests = initialRequests
+        self.makeListedSystemRequests = systemRequests
     }
 
     func append(_ request: ApprovalGatewayRequest) {
@@ -64,9 +72,14 @@ private actor ApprovalGatewayRequestLog {
         self.requests.filter { $0.method == method }
     }
 
-    func listResponse() throws -> String {
+    func listResponse(method: String) throws -> String {
         // Start fixture lifetimes at the Gateway response, after cold connection work.
-        try #require(String(data: JSONEncoder().encode(self.makeListedRequests()), encoding: .utf8))
+        let requests = method == "openclaw.approval.list" ? self.makeListedSystemRequests() : self.makeListedRequests()
+        return try #require(String(data: JSONEncoder().encode(requests), encoding: .utf8))
+    }
+
+    func setListedRequests(_ requests: @escaping @Sendable () -> [ApprovalFixtureRequest]) {
+        self.makeListedRequests = requests
     }
 
     /// Simulates another client (the modal prompter) winning the resolution
@@ -78,6 +91,14 @@ private actor ApprovalGatewayRequestLog {
 
     func resolveRejectionReason() -> String? {
         self.resolveRejection
+    }
+
+    func rejectTemporarily(methods: Set<String>) {
+        self.unavailableMethods = methods
+    }
+
+    func isUnavailable(method: String) -> Bool {
+        self.unavailableMethods.contains(method)
     }
 
     func nextEventSequence() -> Int {
@@ -93,14 +114,30 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
 
     init(
         initialRequests: @escaping @Sendable () -> [ApprovalFixtureRequest] = { [] },
-        listResponseDelay: Duration = .zero)
+        systemRequests: @escaping @Sendable () -> [ApprovalFixtureRequest] = { [] },
+        advertisedMethods: [String] = [],
+        listResponseDelay: Duration = .zero,
+        beforeListResponse: (@Sendable () async -> Void)? = nil,
+        gatewayURL: @escaping @Sendable () -> URL = { URL(string: "ws://127.0.0.1:1")! })
     {
-        let requestLog = ApprovalGatewayRequestLog(initialRequests: initialRequests)
+        let requestLog = ApprovalGatewayRequestLog(initialRequests: initialRequests, systemRequests: systemRequests)
         self.requestLog = requestLog
         self.session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
-                guard sendIndex > 0, let request = Self.decodeRequest(message) else { return }
+            let connectionURL = gatewayURL()
+            return GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                guard sendIndex > 0,
+                      let request = Self.decodeRequest(message, gatewayURL: connectionURL)
+                else { return }
                 await requestLog.append(request)
+                if await requestLog.isUnavailable(method: request.method) {
+                    let response = ResponseFrame(
+                        type: "res",
+                        id: request.id,
+                        ok: false,
+                        error: ErrorShape(code: "UNAVAILABLE", message: "temporary fixture failure"))
+                    try socket.emitReceiveSuccess(.data(JSONEncoder().encode(response)))
+                    return
+                }
                 if request.method.hasSuffix("approval.resolve"),
                    let reason = await requestLog.resolveRejectionReason()
                 {
@@ -118,23 +155,33 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
                 if request.method == "exec.approval.list", listResponseDelay > .zero {
                     try await Task.sleep(for: listResponseDelay)
                 }
-                let payload = if request.method == "exec.approval.list" {
-                    try await requestLog.listResponse()
+                let payload = if request.method.hasSuffix(".approval.list") {
+                    try await requestLog.listResponse(method: request.method)
                 } else {
                     #"{"ok":true}"#
                 }
+                if request.method.hasSuffix(".approval.list") {
+                    await beforeListResponse?()
+                }
                 let response = #"{"type":"res","id":"\#(request.id)","ok":true,"payload":\#(payload)}"#
                 socket.emitReceiveSuccess(.data(Data(response.utf8)))
+            }, receiveHook: { socket, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: socket.snapshotConnectRequestID() ?? "connect",
+                    methods: advertisedMethods))
             })
         })
         self.gateway = GatewayConnection(
-            configProvider: { (url: URL(string: "ws://127.0.0.1:1")!, token: nil, password: nil) },
+            configProvider: { (url: gatewayURL(), token: nil, password: nil) },
             sessionBox: WebSocketSessionBox(session: self.session))
     }
 
     @MainActor
     func withStore(_ body: @MainActor (ExecApprovalQueueStore) async throws -> Void) async rethrows {
-        let store = ExecApprovalQueueStore(gateway: self.gateway)
+        let store = ExecApprovalQueueStore(gateway: gateway)
         do {
             try await body(store)
         } catch {
@@ -147,8 +194,8 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
     }
 
     func sendEvent(name: String, payload: String) async throws {
-        let socket = try await self.readySocket()
-        let sequence = await self.requestLog.nextEventSequence()
+        let socket = try await readySocket()
+        let sequence = await requestLog.nextEventSequence()
         let event = #"{"type":"event","event":"\#(name)","seq":\#(sequence),"payload":\#(payload)}"#
         socket.emitReceiveSuccessOnce(.data(Data(event.utf8)))
     }
@@ -156,7 +203,7 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
     private func readySocket() async throws -> GatewayTestWebSocketTask {
         let deadline = ContinuousClock.now + .seconds(2)
         while ContinuousClock.now < deadline {
-            if let socket = self.session.latestTask(), socket.hasPendingReceiveHandler() {
+            if let socket = session.latestTask(), socket.hasPendingReceiveHandler() {
                 return socket
             }
             try await Task.sleep(for: .milliseconds(2))
@@ -164,7 +211,10 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
         return try #require(self.session.latestTask())
     }
 
-    private static func decodeRequest(_ message: URLSessionWebSocketTask.Message) -> ApprovalGatewayRequest? {
+    private static func decodeRequest(
+        _ message: URLSessionWebSocketTask.Message,
+        gatewayURL: URL) -> ApprovalGatewayRequest?
+    {
         let data: Data? = switch message {
         case let .data(data): data
         case let .string(value): value.data(using: .utf8)
@@ -177,6 +227,7 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
         else { return nil }
         let parameters = frame["params"] as? [String: Any]
         return ApprovalGatewayRequest(
+            gatewayURL: gatewayURL,
             id: id,
             method: method,
             approvalId: parameters?["id"] as? String,
@@ -188,6 +239,47 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
 @Suite(.serialized)
 @MainActor
 struct ExecApprovalQueueStoreTests {
+    @Test(arguments: [false, true])
+    func `captured approval cannot resolve through another gateway`(refreshReplacement: Bool) async throws {
+        let urlA = try #require(URL(string: "ws://127.0.0.1:49240/"))
+        let urlB = try #require(URL(string: "ws://127.0.0.1:49241/"))
+        let source = LockIsolated(urlA)
+        let fixture = ApprovalGatewayFixture(
+            initialRequests: { [ApprovalFixtureRequest(id: "shared-id", command: "echo gateway-a")] },
+            gatewayURL: { source.value })
+        try await fixture.withStore { store in
+            await store.refresh()
+            let capturedA = try #require(store.requests.first)
+            #expect(capturedA.request.command == "echo gateway-a")
+
+            source.withValue { $0 = urlB }
+            try await fixture.gateway.refresh()
+            await fixture.requestLog.setListedRequests {
+                [ApprovalFixtureRequest(id: "shared-id", command: "echo gateway-b")]
+            }
+            if refreshReplacement {
+                await store.refresh()
+                #expect(store.requests.first?.request.command == "echo gateway-b")
+            }
+
+            // A menu button retains the displayed item before its Task starts.
+            // The same server-local id may now describe a different command on B.
+            await store.resolve(request: capturedA, decision: .deny)
+            #expect(await fixture.requestLog.requests(method: "exec.approval.resolve").isEmpty)
+            if refreshReplacement {
+                #expect(store.requests.first?.request.command == "echo gateway-b")
+            }
+
+            await store.refresh()
+            let currentB = try #require(store.requests.first)
+            await store.resolve(request: currentB, decision: .allowOnce)
+            let resolutions = await fixture.requestLog.requests(method: "exec.approval.resolve")
+            #expect(resolutions.count == 1)
+            #expect(resolutions.first?.gatewayURL == urlB)
+            #expect(resolutions.first?.decision == "allow-once")
+        }
+    }
+
     @Test func `refresh seeds direct gateway list and excludes expired approvals`() async {
         let fixture = ApprovalGatewayFixture(initialRequests: {
             [
@@ -231,6 +323,28 @@ struct ExecApprovalQueueStoreTests {
 
             #expect(store.requests.isEmpty)
             #expect(await fixture.requestLog.requests(method: "exec.approval.list").count == 2)
+        }
+    }
+
+    @Test func `temporary resolve and list failures preserve the current gateway approval`() async throws {
+        let fixture = ApprovalGatewayFixture(initialRequests: {
+            [ApprovalFixtureRequest(id: "pending")]
+        })
+        try await fixture.withStore { store in
+            await store.refresh()
+            let request = try #require(store.requests.first)
+            await fixture.requestLog.rejectTemporarily(methods: ["exec.approval.resolve", "exec.approval.list"])
+
+            await store.resolve(request: request, decision: .deny)
+
+            #expect(store.requests.map(\.id) == ["pending"])
+            #expect(await fixture.requestLog.requests(method: "exec.approval.resolve").count == 1)
+            #expect(await fixture.requestLog.requests(method: "exec.approval.list").count == 2)
+
+            await fixture.requestLog.rejectTemporarily(methods: [])
+            await store.resolve(request: request, decision: .allowOnce)
+            #expect(store.requests.isEmpty)
+            #expect(await fixture.requestLog.requests(method: "exec.approval.resolve").count == 2)
         }
     }
 
@@ -311,7 +425,7 @@ struct ExecApprovalQueueStoreTests {
     }
 
     @Test func `system agent approvals resolve through the unified kind-aware gateway method`() async throws {
-        let fixture = ApprovalGatewayFixture()
+        let fixture = ApprovalGatewayFixture(advertisedMethods: ["openclaw.approval.list"])
         try await fixture.withStore { store in
             store.start()
             await store.refresh()
@@ -329,6 +443,137 @@ struct ExecApprovalQueueStoreTests {
             #expect(resolution.first?.decision == "allow-once")
             #expect(resolution.first?.kind == "system-agent")
             #expect(store.requests.isEmpty)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `reconnect reloads advertised system approvals with current authority`(supportsSystemList: Bool) async throws {
+        let fixture = ApprovalGatewayFixture(
+            initialRequests: { [ApprovalFixtureRequest(id: "exec-pending")] },
+            systemRequests: { [ApprovalFixtureRequest(id: "system-pending", command: "echo recovered")] },
+            advertisedMethods: supportsSystemList ? ["openclaw.approval.list"] : [])
+        try await fixture.withStore { store in
+            store.start()
+            await store.refresh()
+            var captured: ExecApprovalQueueItem?
+            if supportsSystemList {
+                let event = ApprovalFixtureRequest(id: "system-pending", command: "echo before-reconnect")
+                try await fixture.sendEvent(name: "openclaw.approval.requested", payload: event.json)
+                try #require(await self.waitUntil {
+                    store.requests.contains { $0.request.command == "echo before-reconnect" }
+                })
+                await store.refresh()
+                captured = try #require(store.requests.first { $0.kind == .systemAgent })
+            }
+
+            await fixture.gateway.shutdown()
+            await store.refresh()
+            #expect(fixture.session.snapshotMakeCount() == 2)
+            if let captured {
+                await store.resolve(request: captured, decision: .deny)
+            }
+            #expect(await fixture.requestLog.requests(method: "approval.resolve").isEmpty)
+            #expect(await fixture.requestLog.requests(method: "openclaw.approval.list").count ==
+                (supportsSystemList ? 3 : 0))
+
+            if supportsSystemList {
+                let recovered = try #require(store.requests.first { $0.kind == .systemAgent })
+                #expect(recovered.request.command == "echo recovered")
+                await store.resolve(request: recovered, decision: .allowOnce)
+                #expect(await fixture.requestLog.requests(method: "approval.resolve").count == 1)
+            } else {
+                #expect(store.requests.allSatisfy { $0.kind == .exec })
+            }
+            let exec = try #require(store.requests.first { $0.kind == .exec })
+            await store.resolve(request: exec, decision: .allowOnce)
+            #expect(store.requests.isEmpty)
+        }
+    }
+
+    @Test func `a replacement hello reloads both approval kinds without reopening the menu`() async throws {
+        let phase = LockIsolated("before")
+        let fixture = ApprovalGatewayFixture(
+            initialRequests: { [ApprovalFixtureRequest(id: "exec-pending", command: "exec-\(phase.value)")] },
+            systemRequests: { [ApprovalFixtureRequest(id: "system-pending", command: "system-\(phase.value)")] },
+            advertisedMethods: ["openclaw.approval.list"])
+        try await fixture.withStore { store in
+            store.start()
+            await store.refresh()
+            #expect(Set(store.requests.map(\.request.command)) == ["exec-before", "system-before"])
+
+            phase.withValue { $0 = "after" }
+            await fixture.gateway.shutdown()
+            _ = try await fixture.gateway.acquireServerLease()
+
+            try #require(await self.waitUntil {
+                Set(store.requests.map(\.request.command)) == ["exec-after", "system-after"]
+            })
+        }
+    }
+
+    @Test func `overlapping refreshes cannot replace a newer approval event`() async throws {
+        let holdResponse = LockIsolated(false)
+        let responseCaptured = LockIsolated(false)
+        let releaseResponse = AsyncTestGate()
+        let fixture = ApprovalGatewayFixture(
+            initialRequests: { [ApprovalFixtureRequest(id: "resolved-during-list")] },
+            beforeListResponse: {
+                guard holdResponse.value else { return }
+                responseCaptured.withValue { $0 = true }
+                await releaseResponse.wait()
+            })
+        try await fixture.withStore { store in
+            store.start()
+            await store.refresh()
+            try #require(store.requests.count == 1)
+            holdResponse.withValue { $0 = true }
+            let first = Task { await store.refresh() }
+            let second = Task { await store.refresh() }
+            defer {
+                first.cancel()
+                second.cancel()
+                releaseResponse.open()
+            }
+            try #require(await self.waitUntil { responseCaptured.value })
+
+            await fixture.requestLog.setListedRequests { [] }
+            try await fixture.sendEvent(
+                name: "exec.approval.resolved",
+                payload: #"{"id":"resolved-during-list"}"#)
+            try #require(await self.waitUntil { store.requests.isEmpty })
+            releaseResponse.open()
+            await first.value
+            await second.value
+            #expect(store.requests.isEmpty)
+        }
+    }
+
+    @Test func `initial reconciliation converges after a newer approval event`() async throws {
+        let responseCaptured = LockIsolated(false)
+        let releaseResponse = AsyncTestGate()
+        let fixture = ApprovalGatewayFixture(
+            initialRequests: {
+                [ApprovalFixtureRequest(id: "resolved-during-list"), ApprovalFixtureRequest(id: "still-pending")]
+            },
+            beforeListResponse: {
+                responseCaptured.withValue { $0 = true }
+                await releaseResponse.wait()
+            })
+        defer { releaseResponse.open() }
+        try await fixture.withStore { store in
+            store.start()
+            _ = try await fixture.gateway.acquireServerLease()
+            try #require(await self.waitUntil { responseCaptured.value })
+
+            let request = ApprovalFixtureRequest(id: "resolved-during-list")
+            try await fixture.sendEvent(name: "exec.approval.requested", payload: request.json)
+            try #require(await self.waitUntil { store.requests.map(\.id) == [request.id] })
+            await fixture.requestLog.setListedRequests { [ApprovalFixtureRequest(id: "still-pending")] }
+            try await fixture.sendEvent(name: "exec.approval.resolved", payload: #"{"id":"resolved-during-list"}"#)
+            try #require(await self.waitUntil { store.requests.isEmpty })
+
+            releaseResponse.open()
+            try #require(await self.waitUntil { store.requests.map(\.id) == ["still-pending"] })
         }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -68,10 +68,8 @@ struct ExecApprovalsSocketPathGuardTests {
 
     @Test
     func `harden parent accepts current directory components`() throws {
-        let root = FileManager().temporaryDirectory
-            .appendingPathComponent("openclaw-socket-dot-\(UUID().uuidString)", isDirectory: true)
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager().removeItem(at: root) }
-        try FileManager().createDirectory(at: root, withIntermediateDirectories: true)
 
         try ExecApprovalsSocketPathGuard.hardenParentDirectory(
             for: "\(root.path)/./approvals.sock")
@@ -79,14 +77,16 @@ struct ExecApprovalsSocketPathGuardTests {
 
     @Test
     func `harden parent validates directories hidden behind nested symlinks`() throws {
-        let root = FileManager().temporaryDirectory
-            .appendingPathComponent("openclaw-socket-nested-link-\(UUID().uuidString)", isDirectory: true)
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         let victim = root.appendingPathComponent("victim", isDirectory: true)
         let unsafe = root.appendingPathComponent("unsafe", isDirectory: true)
         let redirect = unsafe.appendingPathComponent("redirect", isDirectory: true)
         let outer = root.appendingPathComponent("outer", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
-        try FileManager().createDirectory(at: victim, withIntermediateDirectories: true)
+        try FileManager().createDirectory(
+            at: victim,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700])
         try FileManager().createDirectory(at: unsafe, withIntermediateDirectories: true)
         try FileManager().setAttributes([.posixPermissions: 0o777], ofItemAtPath: unsafe.path)
         try FileManager().createSymbolicLink(at: redirect, withDestinationURL: victim)

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
@@ -293,7 +293,7 @@ struct GatewayConnectionTests {
         var iterator = stream.makeAsyncIterator()
         let first = await iterator.next()
 
-        guard case let .snapshot(snap) = first else {
+        guard first?.isCurrent == true, case let .snapshot(snap) = first?.push else {
             Issue.record("expected snapshot, got \(String(describing: first))")
             return
         }
@@ -317,7 +317,7 @@ struct GatewayConnectionTests {
         session.latestTask()?.emitReceiveSuccess(.data(evt1))
 
         let firstEvent = await iterator.next()
-        guard case let .event(firstFrame) = firstEvent else {
+        guard firstEvent?.isCurrent == true, case let .event(firstFrame) = firstEvent?.push else {
             Issue.record("expected event, got \(String(describing: firstEvent))")
             return
         }
@@ -330,7 +330,7 @@ struct GatewayConnectionTests {
         session.latestTask()?.emitReceiveSuccess(.data(evt3))
 
         let gap = await iterator.next()
-        guard case let .seqGap(expected, received) = gap else {
+        guard gap?.isCurrent == true, case let .seqGap(expected, received) = gap?.push else {
             Issue.record("expected seqGap, got \(String(describing: gap))")
             return
         }
@@ -338,7 +338,7 @@ struct GatewayConnectionTests {
         #expect(received == 3)
 
         let secondEvent = await iterator.next()
-        guard case let .event(secondFrame) = secondEvent else {
+        guard secondEvent?.isCurrent == true, case let .event(secondFrame) = secondEvent?.push else {
             Issue.record("expected event, got \(String(describing: secondEvent))")
             return
         }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -383,6 +383,60 @@ private func assertConfigLookupCannotRecreateRoute(
         }
     }
 
+    @Test(arguments: [false, true]) @MainActor
+    func `intentional disconnect retires queued recovery`(pendingFailure: Bool) async throws {
+        let shutdown = GatewayConnectionSuspensionGate()
+        let retireClient: @Sendable (GatewayChannelActor) async -> Void = { client in
+            await shutdown.suspend()
+            await client.shutdown()
+        }
+        try await self.withIsolatedRecoveryFixture(clientShutdown: retireClient) { socket, message, sendIndex in
+            guard sendIndex > 0, let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
+            socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+        } operation: { connection, session in
+            _ = try await connection.request(method: "health", params: nil, retryTransportFailures: false)
+            let control = ControlChannel(gateway: connection, endpointRevision: { 1 })
+            if pendingFailure {
+                control.endpointDidChange(.unavailable(mode: .local, reason: "offline", routeRevision: 1))
+            } else {
+                _ = try await control.health()
+                #expect(control.state == .connected)
+            }
+
+            let proof = Task {
+                await shutdown.waitUntilStarted()
+                // Hold transport retirement open while any previously queued recovery gets its turn.
+                let deadline = ContinuousClock.now + .milliseconds(200)
+                while GatewayProcessManager.shared.status == .stopped, ContinuousClock.now < deadline {
+                    try? await Task.sleep(for: .milliseconds(2))
+                }
+                #expect(GatewayProcessManager.shared.status == .stopped)
+                #expect(control.state == .disconnected)
+                #expect(session.snapshotMakeCount() == 1)
+                await shutdown.open()
+            }
+            await control.disconnect()
+            await proof.value
+        }
+    }
+
+    @Test @MainActor
+    func `current endpoint failure still starts control recovery`() async throws {
+        try await self.withIsolatedRecoveryFixture { socket, message, sendIndex in
+            guard sendIndex > 0, let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
+            socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+        } operation: { connection, _ in
+            let control = ControlChannel(gateway: connection, endpointRevision: { 1 })
+            control.endpointDidChange(.unavailable(mode: .local, reason: "offline", routeRevision: 1))
+            let deadline = ContinuousClock.now + .seconds(2)
+            while GatewayProcessManager.shared.status == .stopped, ContinuousClock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(2))
+            }
+            #expect(GatewayProcessManager.shared.status != .stopped)
+            await control.disconnect()
+        }
+    }
+
     @Test @MainActor
     func `genuine transport failure still activates and retries local gateway recovery`() async throws {
         try await self.assertUncancelledFailureRecovers(URLError(.networkConnectionLost))
@@ -1280,6 +1334,7 @@ extension GatewayConnectionControlTests {
     @MainActor
     private func withIsolatedRecoveryFixture<T>(
         mode: AppState.ConnectionMode = .local,
+        clientShutdown: @escaping @Sendable (GatewayChannelActor) async -> Void = { await $0.shutdown() },
         _ sendHook: @escaping GatewayTestWebSocketTask.SendHook,
         operation: (GatewayConnection, GatewayTestWebSocketSession) async throws -> T) async throws -> T
     {
@@ -1308,11 +1363,13 @@ extension GatewayConnectionControlTests {
                     endpointProvider: {
                         GatewayConnection.EndpointSnapshot(
                             config: (url: URL(string: "ws://127.0.0.1:\(port)")!, token: nil, password: nil),
-                            routeAuthority: nil)
+                            routeAuthority: nil,
+                            revision: 1)
                     },
                     supportsSharedEndpointRecovery: true,
                     activationBindingKeyProvider: { nil },
-                    sessionBox: WebSocketSessionBox(session: session))
+                    sessionBox: WebSocketSessionBox(session: session),
+                    clientShutdown: clientShutdown)
                 let manager = GatewayProcessManager.shared
                 let priorMode = AppStateStore.shared.connectionMode
                 AppStateStore.shared.connectionMode = mode

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -7,7 +7,7 @@ import Testing
 @testable import OpenClawKit
 @testable import OpenClawMacCLI
 
-private func makeGatewayGenerationSnapshot(version: String) -> HelloOk {
+func makeGatewayGenerationSnapshot(version: String, mainSessionKey: String? = nil) -> HelloOk {
     HelloOk(
         type: "hello-ok",
         _protocol: 3,
@@ -20,7 +20,7 @@ private func makeGatewayGenerationSnapshot(version: String) -> HelloOk {
             uptimems: 0,
             configpath: nil,
             statedir: nil,
-            sessiondefaults: nil,
+            sessiondefaults: mainSessionKey.map { ["mainSessionKey": OpenClawProtocol.AnyCodable($0)] },
             authmode: nil,
             updateavailable: nil),
         controluitabs: nil,
@@ -29,9 +29,18 @@ private func makeGatewayGenerationSnapshot(version: String) -> HelloOk {
         policy: [:])
 }
 
-private func gatewayGenerationSnapshotVersion(_ push: GatewayPush?) -> String? {
-    guard case let .snapshot(snapshot) = push else { return nil }
+private func gatewayGenerationSnapshotVersion(_ delivery: GatewayConnection.PushDelivery?) -> String? {
+    guard let delivery, delivery.isCurrent, case let .snapshot(snapshot) = delivery.push else { return nil }
     return snapshot.server["version"]?.value as? String
+}
+
+private func nextCurrentGatewayPush(
+    _ iterator: inout AsyncStream<GatewayConnection.PushDelivery>.Iterator) async -> GatewayConnection.PushDelivery?
+{
+    while let delivery = await iterator.next() {
+        if delivery.isCurrent, delivery.push != nil { return delivery }
+    }
+    return nil
 }
 
 private final class WebSocketMessageRecorder: @unchecked Sendable {
@@ -87,7 +96,7 @@ final class GatewayConnectionEndpointSource: @unchecked Sendable {
     }
 }
 
-private actor GatewayConnectionSuspensionGate {
+actor GatewayConnectionSuspensionGate {
     private var didStart = false
     private var isOpen = false
     private var startWaiters: [CheckedContinuation<Void, Never>] = []
@@ -275,7 +284,7 @@ private func assertConfigLookupCannotRecreateRoute(
         #expect(firstRecovery == .connected)
         #expect(alerts.presentation == nil)
         let queued = await buffered.next()
-        guard case .snapshot = queued else {
+        guard case .snapshot = queued?.push else {
             Issue.record("expected the successful handshake before replacing its route")
             await connection.shutdown()
             return
@@ -315,6 +324,39 @@ private func assertConfigLookupCannotRecreateRoute(
         #expect(session.snapshotMakeCount() == socketCount)
         await connection.shutdown()
         #expect(connection.connectedEndpointRevision == nil)
+    }
+
+    @Test @MainActor
+    func `only primary snapshots update the menu bar main session`() async throws {
+        try await TestIsolation.withIsolatedState {
+            let activity = WorkActivityStore.shared
+            let previousMainSessionKey = activity.mainSessionKey
+            defer { activity.setMainSessionKey(previousMainSessionKey) }
+            let primary = makeActivityGatewayConnection(mainSessionKey: "primary-next")
+            let control = ControlChannel(gateway: primary, endpointRevision: { 1 })
+            activity.setMainSessionKey("primary-initial")
+
+            let profile = makeActivityGatewayConnection(mainSessionKey: "profile-main")
+            _ = try await profile.request(method: "health", params: nil, retryTransportFailures: false)
+            #expect(await !self.waitForMainSessionKey("profile-main"))
+            #expect(activity.mainSessionKey == "primary-initial")
+
+            _ = try await primary.request(method: "health", params: nil, retryTransportFailures: false)
+            #expect(await self.waitForMainSessionKey("primary-next"))
+
+            await profile.shutdown()
+            await control.disconnect()
+        }
+    }
+
+    @MainActor
+    func waitForMainSessionKey(_ key: String) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if WorkActivityStore.shared.mainSessionKey == key { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return WorkActivityStore.shared.mainSessionKey == key
     }
 
     @Test @MainActor
@@ -910,8 +952,9 @@ extension GatewayConnectionControlTests {
             routeB: (tunnelURL, ownerB))
     }
 
-    @Test func `retired socket callbacks cannot mutate cache or subscribers`() async {
+    @Test func `retired socket callbacks cannot mutate cache or subscribers`() async throws {
         let (connection, _) = makeTestGatewayConnection()
+        try await connection.refresh()
         let routeGeneration = await connection._test_routeGeneration()
         let stream = await connection.subscribe(bufferingNewest: 10)
         var iterator = stream.makeAsyncIterator()
@@ -938,18 +981,17 @@ extension GatewayConnectionControlTests {
             routeGeneration: routeGeneration,
             socketGeneration: 1)
 
-        let firstPush = await iterator.next()
-        let secondPush = await iterator.next()
-        #expect(gatewayGenerationSnapshotVersion(firstPush) == "socket-1")
-        #expect(gatewayGenerationSnapshotVersion(secondPush) == "socket-2")
+        let currentPush = await nextCurrentGatewayPush(&iterator)
+        #expect(gatewayGenerationSnapshotVersion(currentPush) == "socket-2")
         #expect(await connection.cachedGatewayVersion() == "socket-2")
         await connection.shutdown()
     }
 
-    @Test func `replaced route rejects callbacks from previous client`() async {
+    @Test func `replaced route rejects callbacks from previous client`() async throws {
         let (connection, _) = makeTestGatewayConnection()
         let replacedRouteGeneration = await connection._test_routeGeneration()
         await connection.shutdown()
+        try await connection.refresh()
         let currentRouteGeneration = await connection._test_routeGeneration()
         let stream = await connection.subscribe(bufferingNewest: 10)
         var iterator = stream.makeAsyncIterator()
@@ -1224,7 +1266,7 @@ extension GatewayConnectionControlTests {
         #expect(try GatewayConnection.decodeConfiguredInferenceModel(Data(json.utf8)) == expected)
     }
 
-    private static func messageData(_ message: URLSessionWebSocketTask.Message) -> Data? {
+    static func messageData(_ message: URLSessionWebSocketTask.Message) -> Data? {
         switch message {
         case let .string(text):
             Data(text.utf8)

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionPushOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionPushOwnershipTests.swift
@@ -1,0 +1,213 @@
+import ConcurrencyExtras
+import Foundation
+import OpenClawProtocol
+import Testing
+@testable import OpenClaw
+@testable import OpenClawKit
+
+extension GatewayConnectionControlTests {
+    @Test(arguments: ["unavailable", "adopted", "admitted", "reconnect", "shutdown", "replaced-shutdown"]) @MainActor
+    func `buffered primary pushes cannot restore retired work or reset a current handshake`(
+        replacement: String) async throws
+    {
+        try await TestIsolation.withIsolatedState {
+            let source = GatewayConnectionEndpointSource(endpoint: GatewayConnection.EndpointSnapshot(
+                config: (URL(string: "ws://127.0.0.1:49225")!, nil, nil), routeAuthority: nil, revision: 1))
+            let mainKey = LockIsolated("a-main")
+            let rejectConnect = LockIsolated(false)
+            let session = GatewayTestWebSocketSession(taskFactory: {
+                GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                    guard sendIndex > 0, let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
+                    socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+                }, receiveHook: { socket, receiveIndex in
+                    if receiveIndex == 0 { return .data(GatewayWebSocketTestSupport.connectChallengeData()) }
+                    if rejectConnect.value { throw URLError(.cannotConnectToHost) }
+                    return .data(GatewayWebSocketTestSupport.connectOkData(
+                        id: socket.snapshotConnectRequestID() ?? "connect", mainSessionKey: mainKey.value))
+                })
+            })
+            let connection = GatewayConnection(
+                testEndpointProvider: { source.snapshot() },
+                currentEndpointRevision: { source.snapshot().revision! },
+                sessionBox: WebSocketSessionBox(session: session))
+            let control = ControlChannel(gateway: connection, endpointRevision: { source.snapshot().revision! })
+            let activity = WorkActivityStore.shared
+            let previousKey = activity.mainSessionKey
+            let previousAccent = AppStateStore.shared.profileAccentHex
+            AppStateStore.shared.profileAccentHex = "#123456"
+            defer {
+                activity.reset()
+                activity.setMainSessionKey(previousKey)
+                AppStateStore.shared.profileAccentHex = previousAccent
+            }
+            _ = try await connection.request(method: "health", params: nil, retryTransportFailures: false)
+            #expect(await self.waitForMainSessionKey("a-main"))
+            let initialDeadline = ContinuousClock.now + .seconds(2)
+            while AppStateStore.shared.profileAccentHex != nil, ContinuousClock.now < initialDeadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(AppStateStore.shared.profileAccentHex == nil)
+
+            let acknowledgement = UUID().uuidString
+            let acknowledged = LockIsolated(false)
+            let observer = NotificationCenter.default.addObserver(
+                forName: .controlHeartbeat, object: nil, queue: .main)
+            { notification in
+                guard let data = notification.object as? Data,
+                      let heartbeat = try? JSONDecoder().decode(ControlHeartbeatEvent.self, from: data),
+                      heartbeat.status == acknowledgement
+                else { return }
+                acknowledged.withValue { $0 = true }
+            }
+            defer { NotificationCenter.default.removeObserver(observer) }
+
+            let queued = DispatchSemaphore(value: 0)
+            // Hold the actual MainActor consumer while the socket owner advances.
+            // The queued hello and agent event must retain their original ownership.
+            let producer = Task.detached {
+                defer { queued.signal() }
+                if replacement.contains("shutdown") {
+                    await connection._test_handlePush(
+                        .event(EventFrame(type: "event", event: "shutdown")), socketGeneration: 1)
+                } else {
+                    await connection._test_handlePush(
+                        .snapshot(makeGatewayGenerationSnapshot(version: "gateway-a", mainSessionKey: "a-main")),
+                        socketGeneration: 1)
+                    await connection._test_handlePush(Self.workStarted(sessionKey: "a-main"), socketGeneration: 1)
+                }
+                mainKey.withValue { $0 = "b-main" }
+                rejectConnect.withValue {
+                    $0 = replacement == "unavailable" || replacement == "adopted" || replacement == "shutdown"
+                }
+                if replacement == "reconnect" || replacement == "shutdown" {
+                    session.latestTask()?.emitReceiveFailure()
+                    let deadline = ContinuousClock.now + .seconds(2)
+                    while await connection._test_activeSocketGeneration() != nil, ContinuousClock.now < deadline {
+                        try await Task.sleep(for: .milliseconds(10))
+                    }
+                } else {
+                    if replacement != "shutdown" {
+                        source.setEndpoint(GatewayConnection.EndpointSnapshot(
+                            config: (URL(string: "ws://127.0.0.1:49226")!, nil, nil), routeAuthority: nil, revision: 2))
+                    }
+                    if replacement != "adopted" { await connection.shutdown() }
+                }
+                let socket: UInt64 = replacement == "reconnect" ? 2 : 1
+                if replacement == "admitted" || replacement == "reconnect" || replacement == "replaced-shutdown" {
+                    _ = try await connection.request(method: "health", params: nil, retryTransportFailures: false)
+                    let hello = makeGatewayGenerationSnapshot(version: "gateway-b", mainSessionKey: "b-main")
+                    await connection._test_handlePush(.snapshot(hello), socketGeneration: socket)
+                    await connection._test_handlePush(Self.workStarted(sessionKey: "b-main"), socketGeneration: socket)
+                    await connection._test_handlePush(.snapshot(hello), socketGeneration: socket)
+                    await connection._test_handlePush(
+                        .event(EventFrame(
+                            type: "event",
+                            event: "heartbeat",
+                            payload: OpenClawProtocol.AnyCodable(["ts": 1, "status": acknowledgement]))),
+                        socketGeneration: socket)
+                }
+            }
+            #expect(Self.waitForQueuedPushes(queued))
+            try await producer.value
+            let deadline = ContinuousClock.now + .seconds(2)
+            while !acknowledged.value,
+                  !(["unavailable", "adopted"].contains(replacement) && activity.current?.sessionKey == "a-main"),
+                  ContinuousClock.now < deadline
+            {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            if replacement == "shutdown" {
+                guard case .degraded = control.state else {
+                    Issue.record("current Gateway shutdown must remain visible")
+                    await control.disconnect()
+                    return
+                }
+            } else if replacement == "unavailable" || replacement == "adopted" {
+                #expect(activity.mainSessionKey == "a-main")
+                #expect(activity.current == nil)
+            } else {
+                #expect(acknowledged.value)
+                #expect(activity.mainSessionKey == "b-main")
+                #expect(activity.current?.sessionKey == "b-main")
+                #expect(activity.iconState == .workingMain(.job))
+                #expect(control.state == .connected)
+            }
+            await control.disconnect()
+        }
+    }
+
+    private nonisolated static func waitForQueuedPushes(_ queued: DispatchSemaphore) -> Bool {
+        queued.wait(timeout: .now() + 2) == .success
+    }
+
+    private nonisolated static func workStarted(sessionKey: String) -> GatewayPush {
+        .event(EventFrame(
+            type: "event",
+            event: "agent",
+            payload: OpenClawProtocol.AnyCodable([
+                "runId": "buffered-work", "seq": 1, "stream": "job", "ts": 1,
+                "data": ["sessionKey": sessionKey, "state": "started"],
+            ])))
+    }
+
+    @Test(arguments: [false, true]) @MainActor
+    func `an admitted profile accent response cannot publish after Primary changes`(failResponse: Bool) async throws {
+        try await TestIsolation.withIsolatedState {
+            let source = GatewayConnectionEndpointSource(endpoint: GatewayConnection.EndpointSnapshot(
+                config: (URL(string: "ws://127.0.0.1:49227")!, nil, nil), routeAuthority: nil, revision: 1))
+            let gate = GatewayConnectionSuspensionGate()
+            let deferAccent = LockIsolated(false)
+            let replied = LockIsolated(false)
+            let session = GatewayTestWebSocketSession(taskFactory: {
+                GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                    guard sendIndex > 0, let id = GatewayWebSocketTestSupport.requestID(from: message),
+                          let data = Self.messageData(message),
+                          let frame = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                    else { return }
+                    if frame["method"] as? String == "users.prefs.get", deferAccent.value {
+                        await gate.suspend()
+                        defer { replied.withValue { $0 = true } }
+                        if failResponse { throw URLError(.networkConnectionLost) }
+                        socket.emitReceiveSuccess(.data(Data("""
+                        {"type":"res","id":"\(id)","ok":true,
+                        "payload":{"status":"ok","entries":{"ui.accent":"#aa0000"}}}
+                        """.utf8)))
+                    } else {
+                        socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+                    }
+                })
+            })
+            let connection = GatewayConnection(
+                testEndpointProvider: { source.snapshot() },
+                currentEndpointRevision: { source.snapshot().revision! },
+                sessionBox: WebSocketSessionBox(session: session))
+            let control = ControlChannel(gateway: connection, endpointRevision: { source.snapshot().revision! })
+            let state = AppStateStore.shared
+            let previousAccent = state.profileAccentHex
+            defer { state.profileAccentHex = previousAccent }
+            state.profileAccentHex = "#123456"
+            _ = try await connection.request(method: "health", params: nil, retryTransportFailures: false)
+            let initialDeadline = ContinuousClock.now + .seconds(2)
+            while state.profileAccentHex != nil, ContinuousClock.now < initialDeadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(state.profileAccentHex == nil)
+
+            deferAccent.withValue { $0 = true }
+            await connection._test_handlePush(
+                .event(EventFrame(type: "event", event: "users.prefs.changed")), socketGeneration: 1)
+            await gate.waitUntilStarted()
+            source.setEndpoint(GatewayConnection.EndpointSnapshot(
+                config: (URL(string: "ws://127.0.0.1:49228")!, nil, nil), routeAuthority: nil, revision: 2))
+            state.profileAccentHex = "#0000bb"
+            await gate.open()
+            let deadline = ContinuousClock.now + .seconds(2)
+            while state.profileAccentHex == "#0000bb", ContinuousClock.now < deadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(replied.value)
+            #expect(state.profileAccentHex == "#0000bb")
+            await control.disconnect()
+        }
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionPushOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionPushOwnershipTests.swift
@@ -11,6 +11,11 @@ extension GatewayConnectionControlTests {
         replacement: String) async throws
     {
         try await TestIsolation.withIsolatedState {
+            let previousMode = AppStateStore.shared.connectionMode
+            // This synthetic transport owns no local process. Recovery's process
+            // handoff is exercised by the dedicated local/remote recovery fixtures.
+            AppStateStore.shared.connectionMode = .unconfigured
+            defer { AppStateStore.shared.connectionMode = previousMode }
             let source = GatewayConnectionEndpointSource(endpoint: GatewayConnection.EndpointSnapshot(
                 config: (URL(string: "ws://127.0.0.1:49225")!, nil, nil), routeAuthority: nil, revision: 1))
             let mainKey = LockIsolated("a-main")

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionPushOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionPushOwnershipTests.swift
@@ -61,11 +61,10 @@ extension GatewayConnectionControlTests {
             }
             defer { NotificationCenter.default.removeObserver(observer) }
 
-            let queued = DispatchSemaphore(value: 0)
-            // Hold the actual MainActor consumer while the socket owner advances.
-            // The queued hello and agent event must retain their original ownership.
+            let buffered = await connection.subscribe()
+            // Leave this real subscription unread while its owner advances. The
+            // live Control consumer stays free to process work on the MainActor.
             let producer = Task.detached {
-                defer { queued.signal() }
                 if replacement.contains("shutdown") {
                     await connection._test_handlePush(
                         .event(EventFrame(type: "event", event: "shutdown")), socketGeneration: 1)
@@ -89,6 +88,8 @@ extension GatewayConnectionControlTests {
                     if replacement != "shutdown" {
                         source.setEndpoint(GatewayConnection.EndpointSnapshot(
                             config: (URL(string: "ws://127.0.0.1:49226")!, nil, nil), routeAuthority: nil, revision: 2))
+                        await control.endpointDidChange(.connecting(
+                            mode: .remote, detail: "Switching Gateway", routeRevision: 2))
                     }
                     if replacement != "adopted" { await connection.shutdown() }
                 }
@@ -107,8 +108,13 @@ extension GatewayConnectionControlTests {
                         socketGeneration: socket)
                 }
             }
-            #expect(Self.waitForQueuedPushes(queued))
-            try await producer.value
+            do {
+                try await producer.value
+                try await Self.assertBufferedOwnership(buffered, replacement: replacement)
+            } catch {
+                await control.disconnect()
+                throw error
+            }
             let deadline = ContinuousClock.now + .seconds(2)
             while !acknowledged.value,
                   !(["unavailable", "adopted"].contains(replacement) && activity.current?.sessionKey == "a-main"),
@@ -136,8 +142,45 @@ extension GatewayConnectionControlTests {
         }
     }
 
-    private nonisolated static func waitForQueuedPushes(_ queued: DispatchSemaphore) -> Bool {
-        queued.wait(timeout: .now() + 2) == .success
+    private nonisolated static func assertBufferedOwnership(
+        _ stream: AsyncStream<GatewayConnection.PushDelivery>,
+        replacement: String) async throws
+    {
+        let admitsReplacement = ["admitted", "reconnect", "replaced-shutdown"].contains(replacement)
+        let terminalEvent = admitsReplacement ? "heartbeat" : (replacement == "shutdown" ? "shutdown" : "agent")
+        let deliveries = try await AsyncTimeout.withTimeout(
+            seconds: 2,
+            onTimeout: { CancellationError() },
+            operation: {
+                var queued: [GatewayConnection.PushDelivery] = []
+                for await delivery in stream {
+                    queued.append(delivery)
+                    if case let .event(event) = delivery.push, event.event == terminalEvent { break }
+                }
+                return queued
+            })
+        let oldDeliveries = deliveries.filter { $0.mainSessionKey == "a-main" }
+        #expect(oldDeliveries.contains {
+            if case .snapshot = $0.push {
+                true
+            } else {
+                false
+            }
+        })
+        #expect(oldDeliveries.contains {
+            guard case let .event(event) = $0.push else { return false }
+            return event.event == (replacement.contains("shutdown") ? "shutdown" : "agent")
+        })
+        for delivery in oldDeliveries {
+            #expect(!delivery.isCurrent)
+        }
+        if admitsReplacement {
+            let currentDeliveries = deliveries.filter { $0.mainSessionKey == "b-main" }
+            #expect(!currentDeliveries.isEmpty)
+            for delivery in currentDeliveries {
+                #expect(delivery.isCurrent)
+            }
+        }
     }
 
     private nonisolated static func workStarted(sessionKey: String) -> GatewayPush {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -1123,6 +1123,139 @@ extension GatewayEndpointStoreTests {
         }
     }
 
+    @Test(arguments: [false, true])
+    func `remote recovery publishes its outcome after its only waiter cancels`(fails: Bool) async throws {
+        try await TestIsolation.withUserDefaultsValues([connectionModeKey: "unconfigured"]) {
+            let source = self.source(mode: .remote, token: "remote-token", transport: .ssh)
+            let oldRoute = LockIsolated<RemoteTunnelManager.Route?>(.init(localPort: 28788, generation: 6))
+            let remoteGate = GatewayEndpointRemoteEnsureGate(route: .init(localPort: 28789, generation: 7))
+            let store = self.makeStore(
+                sourceSnapshot: { source },
+                remoteRouteIfRunning: {
+                    if let route = oldRoute.value { return route }
+                    return await remoteGate.routeIfRunning()
+                },
+                remoteRouteIsCurrent: { await remoteGate.isCurrent($0) },
+                ensureRemoteTunnel: {
+                    let route = await remoteGate.ensure()
+                    if fails {
+                        throw NSError(domain: "TunnelFixture", code: 1, userInfo: [
+                            NSLocalizedDescriptionKey: "fixture tunnel unavailable",
+                        ])
+                    }
+                    return route
+                })
+            let original = try await store.requireEndpoint()
+            oldRoute.setValue(nil)
+            let stream = await store.subscribe(bufferingNewest: 10)
+            let recovery = Task { try await store.ensureRemoteControlTunnel() }
+            await remoteGate.waitUntilEnsureStarts()
+            let connecting = await store.currentState()
+            #expect(connecting.routeRevision != original.revision)
+            recovery.cancel()
+            await remoteGate.releaseEnsure()
+            await #expect(throws: CancellationError.self) { try await recovery.value }
+
+            // Observe publication only. Another endpoint read would hide this bug by
+            // completing the abandoned waiter's ready/error publication itself.
+            let outcome = try? await AsyncTimeout.withTimeout(
+                seconds: 1,
+                onTimeout: { CancellationError() },
+                operation: { () async -> GatewayEndpointState? in
+                    for await state in stream where state.routeRevision == connecting.routeRevision {
+                        if case .connecting = state { continue }
+                        return state
+                    }
+                    return nil
+                })
+            if fails {
+                #expect(outcome == .unavailable(
+                    mode: .remote,
+                    reason: "Remote control tunnel failed (fixture tunnel unavailable)",
+                    routeRevision: connecting.routeRevision))
+            } else {
+                #expect(outcome == .ready(
+                    mode: .remote,
+                    url: URL(string: "ws://127.0.0.1:28789")!,
+                    token: "remote-token",
+                    password: nil,
+                    routeRevision: connecting.routeRevision))
+            }
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `completed remote ensure cannot publish over a replacement selection`(fails: Bool) async throws {
+        try await TestIsolation.withUserDefaultsValues([connectionModeKey: "unconfigured"]) {
+            let sourceGate = GatewayEndpointSourceGate(self.source(mode: .remote, token: "token-a", transport: .ssh))
+            let remoteGate = GatewayEndpointRemoteEnsureGate(route: .init(localPort: 28789, generation: 7))
+            let store = self.makeStore(
+                sourceSnapshot: { await sourceGate.snapshot() },
+                remoteRouteIfRunning: { await remoteGate.routeIfRunning() },
+                remoteRouteIsCurrent: { await remoteGate.isCurrent($0) },
+                ensureRemoteTunnel: {
+                    let route = await remoteGate.ensure()
+                    if fails { throw URLError(.cannotConnectToHost) }
+                    return route
+                })
+            let stale = Task { try await store.requireEndpoint() }
+            await remoteGate.waitUntilEnsureStarts()
+            let sourceB = self.source(
+                mode: .remote,
+                token: "token-b",
+                transport: .direct,
+                directURL: URL(string: "wss://gateway-b.example.test"),
+                deviceAuthGatewayID: "route-b")
+            await sourceGate.update(sourceB)
+            _ = try await store.requireEndpoint()
+            let replacement = await store.currentState()
+            await remoteGate.releaseEnsure()
+            await #expect(throws: CancellationError.self) { try await stale.value }
+            #expect(await store.currentState() == replacement)
+        }
+    }
+
+    @Test func `older tunnel lookup cannot retire a concurrently completed endpoint`() async throws {
+        try await TestIsolation.withUserDefaultsValues([connectionModeKey: "unconfigured"]) {
+            let source = self.source(mode: .remote, token: "remote-token", transport: .ssh)
+            let lookupGate = GatewayEndpointRouteLookupGate()
+            let route = RemoteTunnelManager.Route(localPort: 28789, generation: 7)
+            let remoteGate = GatewayEndpointRemoteEnsureGate(route: route)
+            let lookups = LockIsolated(0)
+            let store = self.makeStore(
+                sourceSnapshot: { source },
+                remoteRouteIfRunning: {
+                    let first = lookups.withValue { count in
+                        count += 1
+                        return count == 1
+                    }
+                    return await (first ? lookupGate.lookup() : remoteGate.routeIfRunning())
+                },
+                remoteRouteIsCurrent: { await remoteGate.isCurrent($0) },
+                ensureRemoteTunnel: {
+                    if let running = await remoteGate.routeIfRunning() { return running }
+                    return await remoteGate.ensure()
+                })
+            let olderRefresh = Task { await store.refresh() }
+            await lookupGate.waitUntilStarted()
+            let request = Task { try await store.requireEndpoint() }
+            await remoteGate.waitUntilEnsureStarts()
+            await remoteGate.releaseEnsure()
+            let endpoint = try await request.value
+            await lookupGate.release()
+            await olderRefresh.value
+
+            let revision = try #require(endpoint.revision)
+            #expect(store.routeRevision == revision)
+            #expect(await store.currentState() == .ready(
+                mode: .remote,
+                url: endpoint.config.url,
+                token: "remote-token",
+                password: nil,
+                routeRevision: revision))
+        }
+    }
+
     @Test func `cancelling one remote waiter does not poison a shared tunnel ensure`() async throws {
         try await TestIsolation.withUserDefaultsValues([connectionModeKey: "unconfigured"]) {
             let source = self.source(

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -1,5 +1,26 @@
 import Foundation
+@testable import OpenClaw
 @testable import OpenClawKit
+
+func makeActivityGatewayConnection(mainSessionKey: String) -> GatewayConnection {
+    let session = GatewayTestWebSocketSession(taskFactory: {
+        GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+            guard sendIndex > 0, let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
+            socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+        }, receiveHook: { socket, receiveIndex in
+            if receiveIndex == 0 { return .data(GatewayWebSocketTestSupport.connectChallengeData()) }
+            return .data(GatewayWebSocketTestSupport.connectOkData(
+                id: socket.snapshotConnectRequestID() ?? "connect", mainSessionKey: mainSessionKey))
+        })
+    })
+    return GatewayConnection(
+        testEndpointProvider: {
+            GatewayConnection.EndpointSnapshot(
+                config: (URL(string: "ws://127.0.0.1:49229")!, nil, nil), routeAuthority: nil, revision: 1)
+        },
+        currentEndpointRevision: { 1 },
+        sessionBox: WebSocketSessionBox(session: session))
+}
 
 extension WebSocketTasking {
     /// Keep unit-test doubles resilient to protocol additions.
@@ -63,11 +84,13 @@ enum GatewayWebSocketTestSupport {
         id: String,
         tickIntervalMs: Int = 30000,
         deviceToken: String? = nil,
+        mainSessionKey: String? = nil,
         canvasPluginSurfaceURL: String? = nil,
         methods: [String] = [],
         capabilities: [String] = []) -> Data
     {
         let deviceTokenField = deviceToken.map { #", "deviceToken": "\#($0)""# } ?? ""
+        let sessionDefaultsField = mainSessionKey.map { #", "sessionDefaults": {"mainSessionKey": "\#($0)"}"# } ?? ""
         let pluginSurfaceField = canvasPluginSurfaceURL.map {
             #", "pluginSurfaceUrls": { "canvas": "\#($0)" }"#
         } ?? ""
@@ -91,7 +114,7 @@ enum GatewayWebSocketTestSupport {
               "presence": [ { "ts": 1 } ],
               "health": {},
               "stateVersion": { "presence": 0, "health": 0 },
-              "uptimeMs": 0
+              "uptimeMs": 0\(sessionDefaultsField)
             },
             "auth": { "role": "operator", "scopes": []\(deviceTokenField) },
             "policy": { "maxPayload": 1, "maxBufferedBytes": 1, "tickIntervalMs": \(tickIntervalMs) }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -2,26 +2,6 @@ import Foundation
 @testable import OpenClaw
 @testable import OpenClawKit
 
-func makeActivityGatewayConnection(mainSessionKey: String) -> GatewayConnection {
-    let session = GatewayTestWebSocketSession(taskFactory: {
-        GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
-            guard sendIndex > 0, let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
-            socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
-        }, receiveHook: { socket, receiveIndex in
-            if receiveIndex == 0 { return .data(GatewayWebSocketTestSupport.connectChallengeData()) }
-            return .data(GatewayWebSocketTestSupport.connectOkData(
-                id: socket.snapshotConnectRequestID() ?? "connect", mainSessionKey: mainSessionKey))
-        })
-    })
-    return GatewayConnection(
-        testEndpointProvider: {
-            GatewayConnection.EndpointSnapshot(
-                config: (URL(string: "ws://127.0.0.1:49229")!, nil, nil), routeAuthority: nil, revision: 1)
-        },
-        currentEndpointRevision: { 1 },
-        sessionBox: WebSocketSessionBox(session: session))
-}
-
 extension WebSocketTasking {
     /// Keep unit-test doubles resilient to protocol additions.
     func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {

--- a/apps/macos/Tests/OpenClawIPCTests/NodePairingApprovalPrompterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NodePairingApprovalPrompterTests.swift
@@ -248,7 +248,7 @@ struct PairingCardPresentationTests {
     }
 
     @Test func `panel auto presents only for unseen requests`() {
-        #expect(!PairingApprovalCenter.shouldAutoPresent(cardIds: [], snoozedIds: []))
+        #expect(!PairingApprovalCenter.shouldAutoPresent(cardIds: [String](), snoozedIds: []))
         #expect(PairingApprovalCenter.shouldAutoPresent(cardIds: ["a"], snoozedIds: []))
         // Everything on screen was snoozed: stay hidden.
         #expect(!PairingApprovalCenter.shouldAutoPresent(cardIds: ["a"], snoozedIds: ["a"]))
@@ -302,8 +302,9 @@ struct PairingApprovalCenterBulkDecisionTests {
             self.card(kind: .device, requestId: "req-2"),
         ]
 
+        center._testSetCards(rendered)
         center.decideAll(rendered, .approve)
-        #expect(center.decisionsInFlight == ["req-1", "req-2"])
+        #expect(center.decisionsInFlight == Set(rendered.map(\.id)))
         // A second bulk click while decisions are in flight must not re-fire.
         center.decideAll(rendered, .approve)
 
@@ -325,6 +326,7 @@ struct PairingApprovalCenterBulkDecisionTests {
             self.card(kind: .device, requestId: "req-2"),
         ]
 
+        center._testSetCards(rendered)
         center.decideAll(rendered, .reject)
 
         var attempts = 0
@@ -355,6 +357,24 @@ struct PairingApprovalCenterBulkDecisionTests {
             await Task.yield()
         }
         #expect(recorder.decided == ["node:req-seen:approve"])
-        #expect(!center.decisionsInFlight.contains("req-unseen"))
+        #expect(!center.decisionsInFlight.contains(self.card(kind: .device, requestId: "req-unseen").id))
+    }
+
+    @Test func `node and device decisions do not share request id ownership`() async {
+        let center = PairingApprovalCenter()
+        let recorder = DecisionRecorder()
+        center.register(kind: .node) { recorder.record("node", $0, $1) }
+        center.register(kind: .device) { recorder.record("device", $0, $1) }
+        let rendered = [
+            self.card(kind: .node, requestId: "same-id"),
+            self.card(kind: .device, requestId: "same-id"),
+        ]
+        center._testSetCards(rendered)
+        center.decideAll(rendered, .approve)
+        for _ in 0..<10000 {
+            if center.decisionsInFlight.isEmpty { break }
+            await Task.yield()
+        }
+        #expect(recorder.decided.sorted() == ["device:same-id:approve", "node:same-id:approve"])
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -2728,9 +2728,14 @@ struct OnboardingAISetupTests {
     @Test func `failed pending verification keeps activation lease before deadline`() async throws {
         let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingPendingVerificationFailureTests"))
         markPending(defaults)
+        let retryGate = AISetupRequestGate()
         let url = try #require(URL(string: "ws://example.invalid"))
-        let harness = AISetupHarness(url: url) { _, request, _ in
-            request.method == "openclaw.setup.verify" ? rejectedSetupVerificationResponse(id: request.id) : nil
+        let harness = AISetupHarness(url: url) { _, request, recorder in
+            guard request.method == "openclaw.setup.verify" else { return nil }
+            if await recorder.snapshot().methods.count == 2 {
+                await retryGate.wait()
+            }
+            return rejectedSetupVerificationResponse(id: request.id)
         }
         let model = harness.model(defaults: defaults)
 
@@ -2752,7 +2757,9 @@ struct OnboardingAISetupTests {
         #expect(model.detectError == nil)
         #expect(OnboardingController.shared.busyReason == "OpenClaw is testing your AI connection.")
 
-        await settleQueuedAISetupTasks()
+        await retryGate.waitUntilStarted()
+        await retryGate.release()
+        await waitForAISetupState { model.phase != .detecting }
 
         #expect(model.phase == .ready)
         #expect(model.detectError?.detail == "expired login")
@@ -2763,9 +2770,11 @@ struct OnboardingAISetupTests {
     @Test func `completed activation receipt survives verification transport failure`() async throws {
         let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingCompletedVerificationRetryTests"))
         let recorder = AISetupRequestRecorder()
+        let retryGate = AISetupRequestGate()
         let session = makeAISetupRequestSession(recorder: recorder) { task, request in
             guard request.method == "openclaw.setup.verify" else { return }
             let verifyCount = await recorder.snapshot().methods.count
+            if verifyCount == 2 { await retryGate.wait() }
             let response = verifyCount == 1
                 ? unavailableGatewayResponse(id: request.id)
                 : verifiedSetupResponse(id: request.id)
@@ -2797,8 +2806,10 @@ struct OnboardingAISetupTests {
         #expect(model.detectError == nil)
         #expect(OnboardingController.shared.busyReason == "OpenClaw is testing your AI connection.")
 
-        let requests = await waitForAISetupRequests(recorder, count: 2)
-        await settleQueuedAISetupTasks()
+        await retryGate.waitUntilStarted()
+        await retryGate.release()
+        await waitForAISetupState { model.phase != .detecting }
+        let requests = await recorder.snapshot()
 
         #expect(model.connected)
         #expect(OnboardingController.shared.busyReason == nil)

--- a/apps/macos/Tests/OpenClawIPCTests/PairingGatewayOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PairingGatewayOwnershipTests.swift
@@ -1,0 +1,256 @@
+import AppKit
+import ConcurrencyExtras
+import Foundation
+import Observation
+import Testing
+@testable import OpenClaw
+@testable import OpenClawKit
+
+private final class PairingListReplyGate: @unchecked Sendable {
+    let isWaiting = LockIsolated(false)
+    private struct State {
+        var released = false
+        var continuation: CheckedContinuation<Void, Never>?
+    }
+
+    private let state = LockIsolated(State())
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            let released = self.state.withValue { state in
+                guard !state.released else { return true }
+                state.continuation = continuation
+                return false
+            }
+            if released { continuation.resume() }
+            self.isWaiting.setValue(true)
+        }
+    }
+
+    func resume() {
+        let continuation = self.state.withValue { state in
+            state.released = true
+            defer { state.continuation = nil }
+            return state.continuation
+        }
+        continuation?.resume()
+    }
+}
+
+private final class PairingGatewayFixture: @unchecked Sendable {
+    struct Decision: Equatable, Sendable {
+        let server: UInt64
+        let method: String
+    }
+
+    let revision = LockIsolated<UInt64>(1)
+    let decisions = LockIsolated<[Decision]>([])
+    let pending = LockIsolated(true)
+    let additionalPendingRequestIds = LockIsolated<[String]>([])
+    let listReads = LockIsolated(0)
+    let nextListGate = LockIsolated<PairingListReplyGate?>(nil)
+    let session: GatewayTestWebSocketSession
+    let gateway: GatewayConnection
+
+    init() {
+        let revision = self.revision
+        let decisions = self.decisions
+        let pending = self.pending
+        let additionalPendingRequestIds = self.additionalPendingRequestIds
+        let listReads = self.listReads
+        let nextListGate = self.nextListGate
+        let session = GatewayTestWebSocketSession {
+            let server = revision.value
+            return GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                guard sendIndex > 0 else { return }
+                let data: Data
+                switch message {
+                case let .data(value): data = value
+                case let .string(value): data = Data(value.utf8)
+                @unknown default: return
+                }
+                guard let frame = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let id = frame["id"] as? String,
+                      let method = frame["method"] as? String
+                else { return }
+                if method.hasSuffix(".approve") || method.hasSuffix(".reject") {
+                    decisions.withValue { $0.append(Decision(server: server, method: method)) }
+                }
+                let payload: String
+                if method.hasSuffix(".pair.list") {
+                    let requests = (pending.value ? [Self.pendingRequest(server: server)] : []) +
+                        additionalPendingRequestIds.value.map { Self.pendingRequest(server: server, requestId: $0) }
+                    payload = #"{"pending":[\#(requests.joined(separator: ","))],"paired":[]}"#
+                    listReads.withValue { $0 += 1 }
+                    let gate = nextListGate.withValue { value in
+                        defer { value = nil }
+                        return value
+                    }
+                    await gate?.wait()
+                } else {
+                    payload = #"{"ok":true}"#
+                }
+                let response = #"{"type":"res","id":"\#(id)","ok":true,"payload":\#(payload)}"#
+                socket.emitReceiveSuccess(.data(Data(response.utf8)))
+            })
+        }
+        self.session = session
+        self.gateway = GatewayConnection(
+            testEndpointProvider: {
+                let value = revision.value
+                return GatewayConnection.EndpointSnapshot(
+                    config: (url: URL(string: "ws://127.0.0.1:\(32000 + value)")!, token: nil, password: nil),
+                    routeAuthority: value,
+                    revision: value)
+            },
+            currentEndpointRevision: { revision.value },
+            sessionBox: WebSocketSessionBox(session: session))
+    }
+
+    static func pendingRequest(server: UInt64 = 1, requestId: String = "same-request") -> String {
+        #"""
+        {"requestId":"\#(requestId)","nodeId":"\#(requestId)-node","deviceId":"\#(requestId)-device",
+         "publicKey":"synthetic","displayName":"Gateway \#(server)","silent":false,"ts":1800000000000}
+        """#
+    }
+}
+
+@Suite(.serialized)
+@MainActor
+struct PairingGatewayOwnershipTests {
+    @Test(arguments: PairingApprovalCenter.Kind.allCases, [PairingApprovalCenter.Decision.approve, .reject])
+    func `a retained pairing card cannot decide on a replacement gateway`(
+        kind: PairingApprovalCenter.Kind,
+        decision: PairingApprovalCenter.Decision) async throws
+    {
+        try await self.withPrompter(kind: kind) { fixture, center, _ in
+            try await self.waitUntil("initial card") { center.cards.count == 1 }
+            let retained = try #require(center.cards.first)
+            #expect(retained.displayName == "Gateway 1")
+
+            // Change the authoritative selection before its socket or the queued
+            // UI task catches up. Request ids are intentionally identical on B.
+            fixture.revision.setValue(2)
+            center.decide(retained, decision)
+            try await self.waitUntil("decision completion") { center.decisionsInFlight.isEmpty }
+            #expect(fixture.decisions.value.isEmpty)
+
+            _ = try await fixture.gateway.acquireServerLease()
+            try await self.waitUntil("replacement card") { center.cards.first?.displayName == "Gateway 2" }
+            let replacement = try #require(center.cards.first)
+            center.decide(replacement, decision)
+            try await self.waitUntil("decision completion") { center.decisionsInFlight.isEmpty }
+            let suffix = decision == .approve ? "approve" : "reject"
+            #expect(fixture.decisions.value == [.init(server: 2, method: "\(kind.rawValue).pair.\(suffix)")])
+        }
+    }
+
+    @Test func `a node list captured before resolution cannot resurrect its card`() async throws {
+        try await self.withPrompter(kind: .node) { fixture, center, node in
+            let gate = PairingListReplyGate()
+            defer { gate.resume() }
+            try await self
+                .waitUntil("initial card and periodic list") { center.cards.count == 1 && fixture.listReads.value >= 2 }
+            let socket = try #require(fixture.session.latestTask())
+            fixture.nextListGate.setValue(gate)
+            try await self.waitUntil("receive handler") { socket.hasPendingReceiveHandler() }
+            socket.emitReceiveSuccessOnce(.string(
+                #"""
+                {"type":"event","event":"node.pair.requested",
+                 "payload":\#(PairingGatewayFixture.pendingRequest()),"seq":1}
+                """#))
+            try await self.waitUntil("held list reply") { gate.isWaiting.value }
+            fixture.pending.setValue(false)
+            try await self.waitUntil("receive handler") { socket.hasPendingReceiveHandler() }
+            socket.emitReceiveSuccessOnce(.string(
+                #"""
+                {"type":"event","event":"node.pair.resolved",
+                 "payload":{"requestId":"same-request","decision":"rejected","ts":1800000000001},"seq":2}
+                """#))
+            try await self.waitUntil("authoritative resolution") { center.cards.isEmpty }
+            let countChanged = LockIsolated(false)
+            withObservationTracking { _ = node.pendingCount } onChange: { countChanged.setValue(true) }
+            gate.resume()
+            // Drain the resumed response and its MainActor projection before
+            // checking that authoritative resolution still owns the visible queue.
+            _ = try await fixture.gateway.acquireServerLease()
+            try await Task.sleep(for: .milliseconds(100))
+            #expect(center.cards.isEmpty)
+            #expect(node.pendingCount == 0)
+            #expect(!countChanged.value)
+        }
+    }
+
+    @Test(arguments: PairingApprovalCenter.Kind.allCases)
+    func `an initial list invalidated by resolution still discovers unrelated requests`(
+        kind: PairingApprovalCenter.Kind) async throws
+    {
+        let gate = PairingListReplyGate()
+        defer { gate.resume() }
+        try await self.withPrompter(
+            kind: kind,
+            prepare: { fixture in
+                fixture.additionalPendingRequestIds.setValue(["untouched-request"])
+                fixture.nextListGate.setValue(gate)
+            },
+            operation: { fixture, center, _ in
+                try await self.waitUntil("held initial list") { gate.isWaiting.value }
+                #expect(center.cards.isEmpty)
+                let socket = try #require(fixture.session.latestTask())
+                fixture.pending.setValue(false)
+                try await self.waitUntil("receive handler") { socket.hasPendingReceiveHandler() }
+                socket.emitReceiveSuccessOnce(.string(
+                    #"""
+                    {"type":"event","event":"\#(kind.rawValue).pair.resolved",
+                     "payload":{"requestId":"same-request","decision":"rejected","ts":1800000000001},"seq":1}
+                    """#))
+                try await self.waitUntil("receive handler after resolution") { socket.hasPendingReceiveHandler() }
+                _ = try await fixture.gateway.acquireServerLease()
+                try await Task.sleep(for: .milliseconds(100))
+                gate.resume()
+                try await self.waitUntil("unrelated pending request after concurrent resolution") {
+                    center.cards.map(\.requestId) == ["untouched-request"]
+                }
+                #expect(center.cards.allSatisfy { $0.source?.isCurrent == true })
+            })
+    }
+
+    private func withPrompter(
+        kind: PairingApprovalCenter.Kind,
+        prepare: (PairingGatewayFixture) -> Void = { _ in },
+        operation: (PairingGatewayFixture, PairingApprovalCenter, NodePairingApprovalPrompter) async throws -> Void)
+        async throws
+    {
+        try await TestIsolation.withIsolatedState {
+            _ = NSApplication.shared
+            let fixture = PairingGatewayFixture()
+            prepare(fixture)
+            let center = PairingApprovalCenter()
+            let node = NodePairingApprovalPrompter(gateway: fixture.gateway, center: center)
+            let device = DevicePairingApprovalPrompter(gateway: fixture.gateway, center: center)
+            switch kind {
+            case .node: node.start()
+            case .device: device.start()
+            }
+            do {
+                try await operation(fixture, center, node)
+            } catch {
+                node.stop()
+                device.stop()
+                await fixture.gateway.shutdown()
+                throw error
+            }
+            node.stop()
+            device.stop()
+            await fixture.gateway.shutdown()
+        }
+    }
+
+    private func waitUntil(_ phase: String, _ predicate: @MainActor () -> Bool) async throws {
+        let deadline = ContinuousClock.now + .seconds(3)
+        while !predicate(), ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try #require(predicate(), "Pairing phase: \(phase)")
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/PairingSSHTargetOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PairingSSHTargetOwnershipTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import OpenClawDiscovery
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct PairingSSHTargetOwnershipTests {
+    @Test func `direct gateway never uses the previous SSH gateway target`() throws {
+        let settings = self.settings(transport: .direct, target: "operator@gateway-a.local:2222")
+        let target = try NodePairingApprovalPrompter.silentPairingSSHTarget(
+            settings: settings,
+            gatewayURL: #require(URL(string: "ws://gateway-b.local:18789")),
+            gateways: [],
+            preferredStableID: nil,
+            user: "operator")
+        #expect(target == nil)
+    }
+
+    @Test func `discovery SSH proof follows the connected endpoint rather than the preferred gateway`() throws {
+        let gateways = [self.gateway("gateway-a.local", sshPort: 2201), self.gateway("gateway-b.local", sshPort: 2202)]
+        let target = try NodePairingApprovalPrompter.silentPairingSSHTarget(
+            settings: self.settings(transport: .direct),
+            gatewayURL: #require(URL(string: "ws://gateway-b.local:18789/")),
+            gateways: gateways,
+            preferredStableID: "gateway-a.local",
+            user: "operator")
+        #expect(target == .init(host: "gateway-b.local", port: 2202))
+    }
+
+    @Test func `active SSH transport keeps its configured host and checks the local user`() throws {
+        let url = try #require(URL(string: "ws://127.0.0.1:18789"))
+        let settings = self.settings(transport: .ssh, target: "operator@gateway-a.local:2222")
+        #expect(NodePairingApprovalPrompter.silentPairingSSHTarget(
+            settings: settings,
+            gatewayURL: url,
+            gateways: [],
+            preferredStableID: nil,
+            user: "operator") == .init(host: "gateway-a.local", port: 2222))
+        #expect(NodePairingApprovalPrompter.silentPairingSSHTarget(
+            settings: settings,
+            gatewayURL: url,
+            gateways: [],
+            preferredStableID: nil,
+            user: "other") == nil)
+    }
+
+    private func settings(transport: AppState.RemoteTransport, target: String = "") -> CommandResolver.RemoteSettings {
+        .init(
+            mode: .remote,
+            transport: transport,
+            target: target,
+            identity: "",
+            projectRoot: "",
+            cliPath: "",
+            sshHostKeyPolicy: .strict)
+    }
+
+    private func gateway(_ host: String, sshPort: Int) -> GatewayDiscoveryModel.DiscoveredGateway {
+        .init(
+            displayName: host,
+            serviceHost: host,
+            servicePort: 18789,
+            lanHost: nil,
+            tailnetDns: nil,
+            sshPort: sshPort,
+            gatewayPort: 18789,
+            gatewayTls: false,
+            cliPath: nil,
+            stableID: host,
+            debugID: host,
+            isLocal: false)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/TalkModeRuntimeSpeechTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkModeRuntimeSpeechTests.swift
@@ -101,6 +101,7 @@ private final class RuntimeTestSignal<Value: Sendable>: @unchecked Sendable {
 private final class RuntimeTestAudioCapture: RealtimeTalkAudioCapturing {
     let suppressesInputDuringOutput = false
     var startError: Error?
+    var onStart: (() -> Void)?
     private(set) var startCount = 0
 
     func start(
@@ -112,6 +113,7 @@ private final class RuntimeTestAudioCapture: RealtimeTalkAudioCapturing {
         if let startError = self.startError {
             throw startError
         }
+        self.onStart?()
     }
 
     func stop() {}
@@ -512,60 +514,65 @@ struct TalkModeRuntimeSpeechTests {
         #expect(TalkModeRuntime.realtimeRestartDelayNanoseconds(attempt: 3) == nil)
     }
 
-    @Test @MainActor func `ready then audio failure clears relay owner and schedules bounded recovery`() async {
-        let runtime = TalkModeRuntime()
-        let session = RealtimeTalkRelaySession(
-            transport: RealtimeTalkRelayTransport(
-                subscribeServerEvents: { _ in AsyncStream { $0.finish() } },
-                request: { _, _, _ in throw CancellationError() }),
-            options: .init(sessionKey: "main", provider: "openai", model: "gpt-realtime-2", voice: nil),
-            audioCapture: RuntimeTestAudioCapture(),
-            pcmPlayer: RuntimeTestPCMPlayer(),
-            onStatus: { _ in },
-            onSpeakingChanged: { _ in })
-        let relayGeneration = await runtime._test_prepareEnabledRealtimeSessionForClose(session)
+    @Test(arguments: ["audio failure", "selected microphone", "unpause"])
+    @MainActor
+    func `capture failures close the old relay and start a replacement microphone`(source: String) async throws {
+        try await TestIsolation.withUserDefaultsValues([talkRealtimeRelayEnabledKey: true]) {
+            let previousRelayPreference = AppStateStore.shared.talkRealtimeRelayEnabled
+            AppStateStore.shared.talkRealtimeRelayEnabled = true
+            defer { AppStateStore.shared.talkRealtimeRelayEnabled = previousRelayPreference }
 
-        await runtime.handleRealtimeTermination(
-            .remoteClose(reason: "stale"),
-            relayGeneration: relayGeneration &- 1)
-        #expect(await runtime.realtimeSession != nil)
+            let requests = RuntimeTestRelayRequestLog()
+            let recoveryRequests = RuntimeTestRelayRequestLog()
+            let bootstrap = try makeRuntimeTestBootstrap(requests: recoveryRequests)
+            let runtime = TalkModeRuntime(realtimeTalkBootstrapProvider: { bootstrap })
+            let recoveryStarted = RuntimeTestSignal<Void>()
+            let recoveryCapture = RuntimeTestAudioCapture()
+            recoveryCapture.onStart = { recoveryStarted.send(()) }
+            await runtime._test_setRealtimeAudioCaptureProvider { recoveryCapture }
+            await runtime._test_setVoiceWakeReadiness(supported: true, permissionGranted: true)
+            let audioCapture = RuntimeTestAudioCapture()
+            let session = makeRecordingRelaySession(requests: requests, audioCapture: audioCapture)
+            defer { session.stop() }
+            let generation = await runtime._test_prepareEnabledRealtimeSessionForClose(session)
 
-        await runtime.handleRealtimeTermination(
-            .audioInputFailed(message: "microphone unavailable"),
-            relayGeneration: relayGeneration)
+            do {
+                await runtime.handleRealtimeTermination(.remoteClose(reason: "stale"), relayGeneration: generation &- 1)
+                #expect(await runtime.realtimeSession === session)
+                #expect(await requests.snapshot().methods.isEmpty)
+                audioCapture.startError = RuntimeTestAudioCaptureError.inputUnavailable
+                switch source {
+                case "audio failure":
+                    await runtime.handleRealtimeTermination(
+                        .audioInputFailed(message: "microphone unavailable"), relayGeneration: generation)
+                case "selected microphone":
+                    await runtime.inputDeviceSelectionDidChange()
+                case "unpause":
+                    await runtime.setPaused(true)
+                    await runtime.setPaused(false)
+                default:
+                    Issue.record("unexpected capture failure source")
+                }
 
-        #expect(await runtime.realtimeSession == nil)
-        #expect(await runtime.rapidRealtimeRestartCount == 1)
-        #expect(await runtime.realtimeRestartTask != nil)
-
-        await runtime.setEnabled(false)
-        session.stop()
-    }
-
-    @Test @MainActor func `selected microphone restart failure closes relay and schedules recovery`() async throws {
-        let runtime = TalkModeRuntime()
-        let requests = RuntimeTestRelayRequestLog()
-        let session = makeRecordingRelaySession(
-            requests: requests,
-            audioCapture: RuntimeTestAudioCapture())
-        let relayGeneration = await runtime._test_prepareEnabledRealtimeSessionForClose(session)
-
-        await runtime.handleRealtimeInputRestartFailure(
-            "selected microphone unavailable",
-            relayGeneration: relayGeneration)
-
-        #expect(await runtime.realtimeSession == nil)
-        #expect(await runtime.rapidRealtimeRestartCount == 1)
-        #expect(await runtime.realtimeRestartTask != nil)
-
-        // Ownership must not be dropped while the server relay stays live; recovery would then
-        // run a second session against the same gateway lease.
-        let recorded = try await waitForRelayClose(requests)
-        #expect(recorded == ["talk.session.close"])
-        #expect(await requests.snapshot().sessionIds == ["relay-1"])
-
-        await runtime.setEnabled(false)
-        session.stop()
+                // Recovery can consume its scheduled task before this test resumes. Prove that
+                // failed capture closes the old relay and actually starts a fresh microphone.
+                let recorded = try await waitForRelayClose(requests)
+                #expect(recorded == ["talk.session.close"])
+                #expect(await requests.snapshot().sessionIds == ["relay-1"])
+                _ = try await recoveryStarted.next("replacement realtime microphone")
+                #expect(recoveryCapture.startCount == 1)
+                #expect(await runtime.rapidRealtimeRestartCount == 1)
+                #expect(await recoveryRequests.snapshot().methods == ["talk.session.create"])
+                let replacement = try #require(await runtime.realtimeSession)
+                #expect(replacement !== session)
+            } catch {
+                await runtime.setEnabled(false)
+                throw error
+            }
+            await runtime.setEnabled(false)
+            try await recoveryRequests.waitForCount(2)
+            #expect(await recoveryRequests.snapshot().methods == ["talk.session.create", "talk.session.close"])
+        }
     }
 
     @Test func `stale termination and callbacks cannot tear down or project over a successor`() async throws {
@@ -695,30 +702,6 @@ struct TalkModeRuntimeSpeechTests {
         await runtime._test_setRecognitionCleanupProbe(nil)
         await runtime.setEnabled(false)
         await MainActor.run { sessionB.stop() }
-    }
-
-    @Test @MainActor func `unpause that cannot restart capture closes relay and schedules recovery`() async throws {
-        let runtime = TalkModeRuntime()
-        let requests = RuntimeTestRelayRequestLog()
-        let audioCapture = RuntimeTestAudioCapture()
-        let session = makeRecordingRelaySession(requests: requests, audioCapture: audioCapture)
-        _ = await runtime._test_prepareEnabledRealtimeSessionForClose(session)
-
-        await runtime.setPaused(true)
-        audioCapture.startError = RuntimeTestAudioCaptureError.inputUnavailable
-        await runtime.setPaused(false)
-
-        // Talk must never stay enabled with no microphone and no route back: the failed unpause
-        // has to reach the same bounded recovery / native-speech fallback as any other capture loss.
-        #expect(await runtime.realtimeSession == nil)
-        #expect(await runtime.rapidRealtimeRestartCount == 1)
-        #expect(await runtime.realtimeRestartTask != nil)
-
-        let recorded = try await waitForRelayClose(requests)
-        #expect(recorded == ["talk.session.close"])
-
-        await runtime.setEnabled(false)
-        session.stop()
     }
 
     @Test @MainActor func `paused reenable lets pinned bootstrap refresh realtime selection`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceWakeGatewayOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceWakeGatewayOwnershipTests.swift
@@ -1,0 +1,70 @@
+import ConcurrencyExtras
+import Foundation
+import Testing
+@testable import OpenClaw
+@testable import OpenClawKit
+
+extension VoiceWakeGlobalSettingsSyncTests {
+    @Test(arguments: [false, true])
+    func `new primary connection reloads its current voice wake triggers`(switchGateway: Bool) async throws {
+        try await TestIsolation.withIsolatedState {
+            let previous = AppStateStore.shared.swabbleTriggerWords
+            defer { AppStateStore.shared.applyGlobalVoiceWakeTriggers(previous) }
+            let port = LockIsolated(49260)
+            let triggers = LockIsolated("gateway-a")
+            let session = GatewayTestWebSocketSession {
+                GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                    guard sendIndex > 0 else { return }
+                    let data: Data
+                    switch message {
+                    case let .data(value): data = value
+                    case let .string(value): data = Data(value.utf8)
+                    @unknown default: return
+                    }
+                    guard let frame = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                          let id = frame["id"] as? String,
+                          let method = frame["method"] as? String
+                    else { return }
+                    let payload: String
+                    if method == "voicewake.get" {
+                        let value = triggers.value
+                        payload = #"{"triggers":["\#(value)"]}"#
+                    } else {
+                        payload = #"{"ok":true}"#
+                    }
+                    let response = #"{"type":"res","id":"\#(id)","ok":true,"payload":\#(payload)}"#
+                    socket.emitReceiveSuccess(.data(Data(response.utf8)))
+                })
+            }
+            let gateway = GatewayConnection(
+                configProvider: {
+                    (url: URL(string: "ws://127.0.0.1:\(port.value)")!, token: nil, password: nil)
+                },
+                sessionBox: WebSocketSessionBox(session: session))
+            let sync = VoiceWakeGlobalSettingsSync(gateway: gateway)
+            sync.start()
+            do {
+                try await self.waitUntil { AppStateStore.shared.swabbleTriggerWords == ["gateway-a"] }
+                await gateway.shutdown()
+                if switchGateway { port.setValue(49261) }
+                triggers.setValue("gateway-b")
+                _ = try await gateway.acquireServerLease()
+                try await self.waitUntil { AppStateStore.shared.swabbleTriggerWords == ["gateway-b"] }
+            } catch {
+                sync.stop()
+                await gateway.shutdown()
+                throw error
+            }
+            sync.stop()
+            await gateway.shutdown()
+        }
+    }
+
+    private func waitUntil(_ predicate: @MainActor () -> Bool) async throws {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while !predicate(), ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        try #require(predicate())
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceWakeGlobalSettingsSyncTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceWakeGlobalSettingsSyncTests.swift
@@ -105,7 +105,7 @@ struct VoiceWakeGlobalSettingsSyncTests {
             "computer",
         ]]))
 
-        await VoiceWakeGlobalSettingsSync.shared.handle(push: .event(evt))
+        VoiceWakeGlobalSettingsSync.shared.handle(push: .event(evt))
 
         let updated = await MainActor.run { AppStateStore.shared.swabbleTriggerWords }
         #expect(updated == ["openclaw", "computer"])
@@ -119,7 +119,7 @@ struct VoiceWakeGlobalSettingsSyncTests {
         let previous = await applyTriggersAndCapturePrevious(["before"])
         let evt = self.voiceWakeChangedEvent(payload: OpenClawProtocol.AnyCodable(["unexpected": 123]))
 
-        await VoiceWakeGlobalSettingsSync.shared.handle(push: .event(evt))
+        VoiceWakeGlobalSettingsSync.shared.handle(push: .event(evt))
 
         let updated = await MainActor.run { AppStateStore.shared.swabbleTriggerWords }
         #expect(updated == ["before"])

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
@@ -168,21 +168,64 @@ struct WebChatSwiftUISmokeTests {
     }
 
     @Test func `one Gateway profile can own multiple independent windows`() async throws {
-        let manager = WebChatManager()
-        let profile = try MacGatewayProfile(
-            id: "same-gateway",
-            name: "Same Gateway",
-            url: #require(URL(string: "wss://same.example")))
+        try await withIsolatedWebChatManager { manager in
+            let profile = try MacGatewayProfile(
+                id: "same-gateway",
+                name: "Same Gateway",
+                url: #require(URL(string: "wss://same.example")))
 
-        try await manager.show(profile: profile)
-        try await manager.show(profile: profile)
-        let connection = await MacGatewayConnectionFleet.shared.connection(profileID: profile.id)
+            try await manager.show(profile: profile)
+            try await manager.show(profile: profile)
+            let connection = await MacGatewayConnectionFleet.shared.connection(profileID: profile.id)
 
-        #expect(manager._testProfileWindowCount(profileID: profile.id) == 2)
-        #expect(manager._testSessionObserverVisible(connection: connection))
-        await manager.closeGatewayWindows(profileID: profile.id)
-        #expect(manager._testProfileWindowCount(profileID: profile.id) == 0)
-        #expect(!manager._testSessionObserverVisible(connection: connection))
+            #expect(manager._testProfileWindowCount(profileID: profile.id) == 2)
+            #expect(manager._testSessionObserverVisible(connection: connection))
+            manager.resetPrimaryConnections()
+            #expect(manager._testProfileWindowCount(profileID: profile.id) == 2)
+            #expect(manager._testSessionObserverVisible(connection: connection))
+            await manager.closeGatewayWindows(profileID: profile.id)
+            #expect(manager._testProfileWindowCount(profileID: profile.id) == 0)
+            #expect(!manager._testSessionObserverVisible(connection: connection))
+        }
+    }
+
+    @Test func `closing chat retires a profile window still waiting for its connection`() async throws {
+        try await withIsolatedWebChatManager { manager in
+            let profile = try MacGatewayProfile(
+                id: "pending-window-\(UUID().uuidString)",
+                name: "Pending Gateway",
+                url: #require(URL(string: "wss://pending.example")))
+            let fleet = MacGatewayConnectionFleet.shared
+            let release = DispatchSemaphore(value: 0)
+            let gateEntered = AsyncStream.makeStream(of: Void.self)
+            let blockedFleet = Task.detached {
+                await fleet.holdForPendingWindowRegression(
+                    entered: gateEntered.continuation,
+                    release: release)
+            }
+            defer { release.signal() }
+            var gateIterator = gateEntered.stream.makeAsyncIterator()
+            await gateIterator.next()
+
+            let openStarted = AsyncStream.makeStream(of: Void.self)
+            let pendingOpen = Task { @MainActor in
+                openStarted.continuation.yield()
+                openStarted.continuation.finish()
+                try await manager.show(profile: profile)
+            }
+            var openIterator = openStarted.stream.makeAsyncIterator()
+            await openIterator.next()
+            #expect(manager._testProfileWindowCount(profileID: profile.id) == 0)
+            manager.close()
+            release.signal()
+            #expect(await blockedFleet.value)
+
+            if case let .failure(error) = await pendingOpen.result, !(error is CancellationError) {
+                Issue.record("Pending window failed unexpectedly: \(error)")
+            }
+            #expect(manager._testProfileWindowCount(profileID: profile.id) == 0)
+            await manager.closeGatewayWindows(profileID: profile.id)
+        }
     }
 
     @Test func `initial draft populates an empty composer without replacing user text`() {
@@ -238,5 +281,18 @@ struct WebChatSwiftUISmokeTests {
 
         #expect(WebChatSwiftUIWindowController.persistedVerboseLevel(defaults: defaults) == nil)
         #expect(defaults.object(forKey: "openclaw.webchat.verboseLevel") == nil)
+    }
+}
+
+extension MacGatewayConnectionFleet {
+    fileprivate func holdForPendingWindowRegression(
+        entered: AsyncStream<Void>.Continuation,
+        release: DispatchSemaphore) -> Bool
+    {
+        // Hold the actual fleet admission boundary so close runs after show
+        // starts but before it can acquire its connection.
+        entered.yield()
+        entered.finish()
+        return release.wait(timeout: .now() + 5) == .success
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatWindowLifetimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatWindowLifetimeTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+@testable import OpenClawChatUI
+
+@MainActor
+struct WebChatWindowLifetimeTests {
+    @Test func `a pending primary open cannot outlive its manager`() async throws {
+        try await withIsolatedWebChatManager { manager in
+            let release = DispatchSemaphore(value: 0)
+            let gateEntered = AsyncStream.makeStream(of: Void.self)
+            let blockedConnection = Task.detached {
+                await GatewayConnection.shared.holdForPendingPrimaryOpenRegression(
+                    entered: gateEntered.continuation,
+                    release: release)
+            }
+            defer {
+                release.signal()
+            }
+            var gateIterator = gateEntered.stream.makeAsyncIterator()
+            await gateIterator.next()
+            manager.show()
+            manager.close()
+            release.signal()
+            #expect(await blockedConnection.value)
+            #expect(await !self.eventually { manager.activeSessionKey != nil })
+        }
+    }
+
+    @Test func `selecting a profile session preserves the primary active session`() async {
+        await TestIsolation.withIsolatedState {
+            let manager = WebChatManager.shared
+            defer { manager.resetPrimaryConnections() }
+            manager.recordActiveSessionKey("primary-session")
+            let connection = GatewayConnection(
+                endpointProvider: { throw CancellationError() },
+                supportsSharedEndpointRecovery: false)
+            let transport = MacGatewayChatTransport(connection: connection)
+
+            try? await transport.setActiveSessionKey("profile-session")
+
+            #expect(manager.activeSessionKey == "primary-session")
+            await connection.shutdown()
+        }
+    }
+
+    @Test func `admitting a replacement primary Gateway retires only its native window`() async throws {
+        try await withIsolatedWebChatManager { manager in
+            let profile = try MacGatewayProfile(
+                id: "independent-profile-\(UUID().uuidString)",
+                name: "Independent Gateway",
+                url: #require(URL(string: "wss://independent.example")))
+            try await manager.show(profile: profile)
+            var primaryVisibility: [Bool] = []
+            manager.onChatWindowVisibilityChanged = { primaryVisibility.append($0) }
+            manager.show(sessionKey: "primary-proof")
+            let originalGatewayID = GatewayDiscoveryPreferences.deviceAuthGatewayID(root: OpenClawConfigFile.loadDict())
+
+            manager.preparePrimaryGateway(gatewayID: originalGatewayID)
+            #expect(primaryVisibility == [true])
+            #expect(manager.activeSessionKey == "primary-proof")
+
+            manager.preparePrimaryGateway(gatewayID: "replacement-primary")
+            #expect(primaryVisibility == [true, false])
+            #expect(manager.activeSessionKey == nil)
+            #expect(manager._testProfileWindowCount(profileID: profile.id) == 1)
+            await manager.closeGatewayWindows(profileID: profile.id)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `retiring a profile connection releases its session observer`(closeAll: Bool) async throws {
+        try await withIsolatedWebChatManager { manager in
+            let profile = try MacGatewayProfile(
+                id: "retired-profile-\(UUID().uuidString)",
+                name: "Retired Gateway",
+                url: #require(URL(string: "wss://retired.example")))
+            var connection: GatewayConnection? = await MacGatewayConnectionFleet.shared
+                .connection(profileID: profile.id)
+            weak var retiredConnection = connection
+            try await manager.show(profile: profile)
+            if closeAll {
+                manager.close()
+            } else {
+                await manager.closeGatewayWindows(profileID: profile.id)
+            }
+            connection = nil
+
+            #expect(await self.eventually { retiredConnection == nil })
+        }
+    }
+
+    @Test func `closing a chat window retires observation and rejects late history cache writes`() async throws {
+        let transport = ClosingWindowChatTransport()
+        let cache = ClosingWindowTranscriptCache()
+        let controller = WebChatSwiftUIWindowController(
+            sessionKey: "main",
+            transport: transport,
+            transcriptCache: cache)
+        defer {
+            transport.releaseHistory.open()
+            transport.finishEvents()
+            controller.close()
+        }
+
+        controller.show()
+        try #require(await self.eventually { transport.historyStarted })
+        controller.close()
+        transport.releaseHistory.open()
+        try #require(await self.eventually { transport.historyReturned })
+
+        #expect(await self.eventually { transport.observationTerminated })
+        #expect(await cache.savedTranscripts.isEmpty)
+    }
+
+    private func eventually(_ predicate: @escaping () async -> Bool) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now + .seconds(3)
+        while clock.now < deadline {
+            if await predicate() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return await predicate()
+    }
+}
+
+@MainActor
+func withIsolatedWebChatManager(_ body: (WebChatManager) async throws -> Void) async throws {
+    try await TestIsolation.withIsolatedState {
+        weak var retiredManager: WebChatManager?
+        var failure: (any Error)?
+        do {
+            let manager = WebChatManager()
+            retiredManager = manager
+            defer { manager.close() }
+            try await body(manager)
+        } catch {
+            failure = error
+        }
+        // close() owns asynchronous fleet retirement. Keep the global lease
+        // until that task releases its manager so it cannot shut down the next fixture.
+        let deadline = ContinuousClock.now + .seconds(3)
+        while retiredManager != nil, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(retiredManager == nil)
+        if let failure { throw failure }
+    }
+}
+
+extension GatewayConnection {
+    fileprivate func holdForPendingPrimaryOpenRegression(
+        entered: AsyncStream<Void>.Continuation,
+        release: DispatchSemaphore) -> Bool
+    {
+        entered.yield()
+        entered.finish()
+        return release.wait(timeout: .now() + 5) == .success
+    }
+}
+
+private final class ClosingWindowChatTransport: @unchecked Sendable, OpenClawChatTransport {
+    let releaseHistory = AsyncTestGate()
+    private let lock = NSLock()
+    private var didStartHistory = false
+    private var didReturnHistory = false
+    private var didTerminateObservation = false
+    private let stream: AsyncStream<OpenClawChatTransportEvent>
+    private let continuation: AsyncStream<OpenClawChatTransportEvent>.Continuation
+
+    init() {
+        (self.stream, self.continuation) = AsyncStream.makeStream()
+        self.continuation.onTermination = { [weak self] _ in
+            guard let self else { return }
+            self.lock.withLock { self.didTerminateObservation = true }
+        }
+    }
+
+    var historyStarted: Bool {
+        self.lock.withLock { self.didStartHistory }
+    }
+
+    var historyReturned: Bool {
+        self.lock.withLock { self.didReturnHistory }
+    }
+
+    var observationTerminated: Bool {
+        self.lock.withLock { self.didTerminateObservation }
+    }
+
+    func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
+        self.lock.withLock { self.didStartHistory = true }
+        await self.releaseHistory.wait()
+        self.lock.withLock { self.didReturnHistory = true }
+        // A response may already have been decoded when its caller is canceled.
+        return try JSONDecoder().decode(OpenClawChatHistoryPayload.self, from: Data("""
+        {"sessionKey":"\(sessionKey)","sessionId":"late-history","thinkingLevel":"off",\
+        "messages":[{"role":"assistant","content":[{"type":"text","text":"late Gateway history"}]}]}
+        """.utf8))
+    }
+
+    func sendMessage(
+        sessionKey _: String,
+        message _: String,
+        thinking _: String,
+        idempotencyKey: String,
+        attachments _: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
+    {
+        OpenClawChatSendResponse(runId: idempotencyKey, status: "accepted")
+    }
+
+    func requestHealth(timeoutMs _: Int) async throws -> Bool {
+        true
+    }
+
+    func events() -> AsyncStream<OpenClawChatTransportEvent> {
+        self.stream
+    }
+
+    func finishEvents() {
+        self.continuation.finish()
+    }
+}
+
+private actor ClosingWindowTranscriptCache: OpenClawChatTranscriptCache {
+    private(set) var savedTranscripts: [[OpenClawChatMessage]] = []
+
+    func loadSessions() async -> [OpenClawChatSessionEntry] {
+        []
+    }
+
+    func loadTranscript(sessionKey _: String) async -> [OpenClawChatMessage] {
+        []
+    }
+
+    func storeSessions(_: [OpenClawChatSessionEntry]) async {}
+
+    func storeCanonicalTranscript(
+        sessionKey _: String,
+        agentID _: String?,
+        messages: [OpenClawChatMessage],
+        canonicalMessageIdempotencyKeys _: Set<String>) async
+    {
+        self.savedTranscripts.append(messages)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/WorkActivityStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WorkActivityStoreTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import OpenClawProtocol
 import Testing
 @testable import OpenClaw
+@testable import OpenClawKit
 
 @MainActor
 struct WorkActivityStoreTests {
@@ -167,4 +168,24 @@ struct WorkActivityStoreTests {
 @MainActor
 private final class WorkActivityAcknowledgement {
     var received = false
+}
+
+func makeActivityGatewayConnection(mainSessionKey: String) -> GatewayConnection {
+    let session = GatewayTestWebSocketSession(taskFactory: {
+        GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+            guard sendIndex > 0, let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
+            socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+        }, receiveHook: { socket, receiveIndex in
+            if receiveIndex == 0 { return .data(GatewayWebSocketTestSupport.connectChallengeData()) }
+            return .data(GatewayWebSocketTestSupport.connectOkData(
+                id: socket.snapshotConnectRequestID() ?? "connect", mainSessionKey: mainSessionKey))
+        })
+    })
+    return GatewayConnection(
+        testEndpointProvider: {
+            GatewayConnection.EndpointSnapshot(
+                config: (URL(string: "ws://127.0.0.1:49229")!, nil, nil), routeAuthority: nil, revision: 1)
+        },
+        currentEndpointRevision: { 1 },
+        sessionBox: WebSocketSessionBox(session: session))
 }

--- a/apps/macos/Tests/OpenClawIPCTests/WorkActivityStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WorkActivityStoreTests.swift
@@ -5,6 +5,73 @@ import Testing
 
 @MainActor
 struct WorkActivityStoreTests {
+    @Test func `replacement primary clears old work without retiring the new same-key tool`() async throws {
+        try await TestIsolation.withIsolatedState {
+            let connection = makeActivityGatewayConnection(mainSessionKey: "main")
+            let control = ControlChannel(gateway: connection, endpointRevision: { 1 })
+            let store = WorkActivityStore.shared
+            let previousMainKey = store.mainSessionKey
+            defer {
+                store.handleJob(sessionKey: "main", state: "done")
+                store.setMainSessionKey(previousMainKey)
+            }
+            store.setMainSessionKey("before-primary")
+            _ = try await connection.request(method: "health", params: nil, retryTransportFailures: false)
+            #expect(await self.eventually { store.mainSessionKey == "main" })
+
+            store.handleJob(sessionKey: "main", state: "started")
+            store.handleTool(sessionKey: "main", phase: "start", name: "read", meta: "old-tool", args: nil)
+            store.handleTool(sessionKey: "main", phase: "result", name: "read", meta: "old-tool", args: nil)
+
+            // The heartbeat acknowledges that the primary consumer processed the preceding hello.
+            let acknowledgement = WorkActivityAcknowledgement()
+            let observer = NotificationCenter.default.addObserver(
+                forName: .controlHeartbeat,
+                object: nil,
+                queue: .main)
+            { notification in
+                guard let data = notification.object as? Data,
+                      let heartbeat = try? JSONDecoder().decode(ControlHeartbeatEvent.self, from: data),
+                      heartbeat.status == "work-lifetime-proof"
+                else { return }
+                Task { @MainActor in acknowledgement.received = true }
+            }
+            defer { NotificationCenter.default.removeObserver(observer) }
+            await connection.shutdown()
+            _ = try await connection.request(method: "health", params: nil, retryTransportFailures: false)
+            let snapshot = try #require(await connection.lastSnapshot)
+            await connection._test_handlePush(.snapshot(snapshot), socketGeneration: 1)
+            await connection._test_handlePush(
+                .event(EventFrame(
+                    type: "event",
+                    event: "heartbeat",
+                    payload: AnyCodable(["ts": 1, "status": "work-lifetime-proof"]))),
+                socketGeneration: 1)
+            #expect(await self.eventually { acknowledgement.received })
+            #expect(store.current == nil)
+            #expect(store.iconState == .idle)
+            #expect(store.lastToolUpdatedAt == nil)
+
+            store.handleTool(sessionKey: "main", phase: "start", name: "read", meta: "new-tool", args: nil)
+            let newTool = store.current
+            let newToolUpdatedAt = store.lastToolUpdatedAt
+            try? await Task.sleep(for: .seconds(3))
+            #expect(store.current == newTool)
+            #expect(store.iconState == .workingMain(.tool(.read)))
+            #expect(store.lastToolUpdatedAt == newToolUpdatedAt)
+            await control.disconnect()
+        }
+    }
+
+    private func eventually(_ predicate: () -> Bool) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if predicate() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return predicate()
+    }
+
     @Test func `main session job preempts other`() {
         let store = WorkActivityStore()
 
@@ -95,4 +162,9 @@ struct WorkActivityStoreTests {
         store.resolveIconState(override: .otherEdit)
         #expect(store.iconState == .overridden(.tool(.edit)))
     }
+}
+
+@MainActor
+private final class WorkActivityAcknowledgement {
+    var received = false
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -576,6 +576,7 @@ public final class OpenClawChatViewModel {
         self.endPendingToolActivities()
         self.eventTask?.cancel()
         self.bootstrapTask?.cancel()
+        self.bootstrapOutboxBranchStateCapture?.task.cancel()
         self.swarmRefreshTask?.cancel()
         self.outboxRetryTask?.cancel()
         for task in self.outboxBranchReconcileRetryTasks.values {
@@ -590,6 +591,10 @@ public final class OpenClawChatViewModel {
         }
         for (_, task) in self.pendingRunOwnerTasks {
             task.cancel()
+        }
+        for tail in self.settingsPatchTailsByTarget.values {
+            tail.routeLeaseTask.cancel()
+            tail.task.cancel()
         }
     }
 

--- a/docs/platforms/mac/voicewake.md
+++ b/docs/platforms/mac/voicewake.md
@@ -47,6 +47,7 @@ Voice Wake requires Apple Speech to support on-device recognition for the select
 - **Hold Right Option to talk**: enables the push-to-talk monitor.
 - If the selected language lacks on-device recognition on this Mac, Voice Wake stays disabled while push-to-talk and Talk Mode remain available.
 - Language and mic pickers, a live level meter, a trigger-word table, and a tester (local-only, never forwards).
+- Trigger words follow the Primary Gateway and refresh when it reconnects or you select a different Primary. Opening a saved Gateway chat does not change them.
 - The mic picker preserves the last selection if a device disconnects, shows a disconnected hint, and temporarily falls back to the system default until it returns.
 - **Sounds**: chimes on trigger detect and on send, defaulting to the macOS "Glass" system sound. Pick any `NSSound`-loadable file (e.g. MP3/WAV/AIFF) per event, or choose **No Sound**.
 

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -49,8 +49,9 @@ optional token or password; credentials are stored in the macOS Keychain.
 Secure profiles maintain their own system-trust-gated first-use certificate pin
 and do not inherit `gateway.remote.tlsFingerprint` from the primary Gateway.
 Dashboard windows enforce that same saved-profile pinning policy.
-Removing a profile also closes its open windows and shuts down its secondary
-connection.
+Removing a profile closes its native chat windows and shuts down its secondary
+connection. Dashboard windows showing that profile return to Primary.
+Updating a saved profile's credentials refreshes its open dashboard windows.
 
 Choose **File → New Gateway Window…** or press Cmd-N, then select one of those
 saved profiles. The picker remembers the most recently used profile. Every
@@ -66,6 +67,7 @@ The menu-bar app's configured Gateway remains the owner of Mac node
 capabilities and Talk Mode. Additional Gateway windows are operator-only, so a
 second Gateway cannot silently retarget global microphone or device controls.
 Listen/TTS and normal chat actions use the window's own Gateway connection.
+Inline widgets also load from that window's Gateway.
 
 ### Gateway picker
 
@@ -73,10 +75,19 @@ The dashboard header shows a Gateway picker when the Mac app has at least two
 configured Gateways. Choose a Gateway to replace the current dashboard in the
 same window, or Option-click it to open a separate dashboard window. **Set as
 primary…** makes the viewed token-authenticated profile the Mac app's primary
-Gateway after confirmation; this resets Talk Mode, the widget panel, and chat
-connections. While connected, the sidebar footer also shows the current Gateway
-and marks it when it is primary. Password-only profiles can be viewed but cannot
-be made primary.
+Gateway after confirmation. The app replaces the primary Gateway's credentials
+and closes its native chat window; independent saved-profile windows stay open.
+Dashboard windows displaying **Primary** follow the new connection, including
+windows opened separately. While connected, the sidebar footer also shows the
+current Gateway and marks it when it is primary. Password-only profiles can be
+viewed but cannot be made primary.
+
+Native dashboard commands such as New Session and the command palette act on
+the frontmost Gateway window.
+
+Native approval cards and dialogs apply only to the Gateway connection that
+requested them. Changing Primary does not transfer a pending approval to the
+new Gateway.
 
 ## Quick Chat bar
 


### PR DESCRIPTION
Closes #136940

## What Problem This Solves

Fixes an issue where users working with several Gateways in the macOS app could keep a dashboard on an obsolete Primary route, send native commands to the wrong window, or render another Gateway’s widget inside a chat. Changing Primary could retain the previous password, while secondary chats could overwrite the primary session and activity state. Closing or switching windows also left pending opens, transport work, and observers alive. Intentional control-channel disconnect scheduled automatic recovery, allowing retired work to restart a local Gateway.

## Why This Change Was Made

Gateway ownership now stays with the connection and native window that admitted the work. Every dashboard targeting Primary follows the current primary route; saved-profile windows remain independent, including a second window for a profile that another window promotes to Primary. Profile existence comes from the profile store, independently of picker deduplication.

Each native window owns its pending selection and ordered commands across document replacement. Explicit selection, profile removal, and close retire obsolete actions; reconnect and credential refresh preserve current actions. Recovery cannot overwrite a pending picker selection, and an obsolete Primary presentation cannot blank the newly selected dashboard with a late error.

Primary replacement commits the complete URL/token/TLS configuration and clears the previous password before publishing the selection. Native chat closes its old transcript owner before accepting a different primary route, uses the existing shared `detachTransport` lifetime operation, and retires profile observers when their connection ends. Widgets use their own operator connection. The control channel cancels its event listener and recovery work on intentional disconnect; delayed endpoint and tunnel work retain their admitted generation. The endpoint store owns SSH tunnel completion and publication independently of any individual waiting task, so cancelling a retired waiter cannot strand an otherwise successful replacement tunnel. Unexpected endpoint failure still recovers. Only the primary control-channel consumer updates global session activity. Each admitted connection adopts its activity once, so delayed duplicate hello notifications cannot erase work already received from that connection.

Queued events now retain their physical Gateway connection and endpoint revision through consumer execution. A selection change immediately invalidates old payloads; exact-source retirement receipts clear only the old connection’s state. Delayed appearance responses cannot repaint the new Gateway. Approval rows, modal decisions, pairing cards, list replies, and automatic pairing probes retain the same source ownership, so a retained A action cannot resolve a same-ID request on B. Pending command and system-agent approvals automatically reload after each admitted connection through their existing advertised list APIs; intervening approval events trigger a fresh authoritative list pass so unresolved cards cannot disappear; a temporary failure preserves a still-current unresolved card. Voice Wake reloads settings after a new Primary handshake or reconnect and rejects retired read results. Pairing SSH checks use the active SSH target or discovery matching the connected Gateway, never a dormant target from another Gateway.

## User Impact

Operators can keep several Gateways open, switch and promote them, and refresh their credentials without mixing connections, sessions, widgets, queued commands, or approval decisions. No configuration keys, database schemas, protocol versions, or dependencies change.

## Evidence

Regression-first macOS VM runs reproduced stale Primary dashboards, credential replacement, close/open races, late chat history, retained profile observers, secondary activity contamination, and the picker/reconnect/command cases. The failing scenarios also showed a removed profile’s queued command running on Primary, a superseded Primary open blanking the selected profile, and menu/bridge opens surviving a close before task execution.

- Final application source at `b2438071c0d3`: 2,007 native tests across 205 suites passed at CI's parallelization width 8, in the original execution order (65.171 seconds). The separate named-profile lane passed both tests. SwiftFormat, strict SwiftLint, docs checks, and strict macOS Periphery passed.
- Shared chat siblings: 653 Swift Testing cases across 16 suites plus 20 attachment XCTest cases passed on the rebased baseline; the shared source is unchanged since that run.
- Independent review of the full production candidate completed in six passes without accepted/actionable P0–P2 findings. The final Control/tunnel correction passed a separate two-pass review. The iOS-shared fixture correction passed another independent review and changes no application code.

The full native run exposed test isolation problems as well as the recovery bug. A buffered event fixture inherited Local process ownership and started a real recovery operation that contaminated a later readiness assertion. That fixture now owns and retires its process context explicitly; dedicated recovery tests and readiness assertions remain intact. A notification test now admits its action in the same MainActor operation that chooses focus. Hosted iOS compilation also caught a Mac-only helper in the shared WebSocket fixture; the unchanged helper moved to its Mac test owner.

Hosted macOS CI exposed an existing onboarding retry fixture that checked completion after a fixed 100 ms sleep. Holding the second response reproduced five premature assertions across the failed-verification and successful-retry cases; releasing it produced the expected results. Both cases now control that response and await the existing observable terminal state. Their exact outcome, busy-state, activation-lease and request-count assertions remain intact. The two repaired tests passed in 0.028 seconds with no production change. The signed `de0ce19450f8` live proof above covers the same application source; the later change affects only this test fixture.

Additional failing-before cases reproduced queued A events reaching B’s activity, duplicate hello clearing current work, A appearance success/failure overwriting B, retained node/device pairing decisions reaching B, cross-kind pairing ID suppression, and direct B checking A’s dormant SSH target. Both real Gateway processes advertised and successfully served the existing system-agent approval-list API. Mock event/decision regressions and real-server live checks are recorded separately.

A Developer ID-signed Cocoa host exercised the actual native approval presenter over deterministic A/B WebSocket fixtures. The retained A dialog was denied after source replacement; the B dialog was allowed once. Throwing assertions confirmed exactly one resolution RPC, addressed to B with `allow-once`, and no redirected A decision. The host completed successfully. Separate failure-first regressions cover automatic reconnection with the menu kept open and approval events arriving during the initial list.

The signed baseline visibly reproduced Gateway B’s chat rendering Gateway A’s widget. The ordered synthetic traffic was A node admission, B chat history, then A widget HTTP retrieval. The final Developer ID-signed app at `de0ce19450f8` rendered B’s widget through B’s operator connection while A’s node remained active. The fixture recorded A node admission, B chat history, and then B widget HTTP retrieval, with no A widget request.

The same signed app connected to two real, authenticated Gateway processes through native Settings, opened independent native chats and four dashboards, then promoted A followed by B. All three Primary dashboards followed B. The saved A dashboard stayed on A and read A’s task-owned automation; a Primary B window read B’s distinct automation. A’s saved dashboard kept its original WebSocket throughout promotion. The original A/B native chat sockets and green connected indicators remained intact. No provider/model turn was invoked.

An actual SSH recovery check then terminated only the app-owned forwarding process. The unchanged app created a new forward in the next wall-clock second and returned from degraded to connected in 588 ms, without Test remote, manual reconnect, a selection change, or an external Gateway probe. Logs show the replacement tunnel becoming ready, the retired recovery waiter cancelling, and the endpoint-change consumer connecting successfully. The real Gateway processes remained running. Task-only SSH keys, host trust, listener, and forwarding processes were cleaned up afterwards. The expected cancelled waiter still emits an error-level diagnostic; the adjacent Control-channel owner follow-up will remove that misleading line.

![Before: Gateway B chat incorrectly renders Gateway A widget](https://github.com/user-attachments/assets/b869a88d-e241-4f24-aa3b-4c35a0da505c)

![After: final signed app renders Gateway B’s own widget](https://github.com/user-attachments/assets/4f86ca67-3a7e-46f0-9615-128ad191e43d)

![Saved Gateway A remains selected after Gateway B becomes Primary](https://github.com/user-attachments/assets/69b9be2c-898a-4ca7-8ec8-dbc9f41019f9)

Production +1630/−1120 (net +510); tests/test support +2727/−381 (net +2346); docs +18/−6. The raw production churn includes an unchanged 52-line Cron API move; discounting that move does not change the net growth. The production growth records native-window selection lifetime, primary transcript retirement, and the physical connection ownership required for buffered events, approval decisions, pairing checks, and settings publication. These facts must survive queued UI work and asynchronous replies; checking only the current selection at dispatch cannot preserve their origin. It replaces duplicate command queues, configuration rollback, per-waiter tunnel publication, and the primary-node widget fallback. The final Control/tunnel correction removes 13 production lines. The shared model change is five cancellation lines on top of #136702's existing detach operation.

ClawSweeper rank-up work is covered by the preserved current-main stale-read cancellation and revision-aware endpoint admission, combined native and dead-code checks, the final signed-app widget/A–B/SSH proofs above, and production-growth accounting that discounts the unchanged Cron API move. Exact-head CI remains the merge gate.

Adjacent repairs are tracked separately: native Cron row/editor/read ownership (including a signed-app A-editor save dispatched to B), Skills/ClawHub retained actions and catalog ownership, shared Health/Instances/Nodes and usage/cost publication, and Channels/config draft/login ownership. These legacy panes are reachable through the existing Settings > Debug > Show native settings panes option; the default dashboard flow is tested separately. This PR only adapts their event subscriptions where required by the shared delivery contract.
