### PR TITLE
docs: fix dashboard video sizing

### DIFF
--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -47,10 +47,9 @@ state, so each browser can keep its own working layout.
 Watch Patrick Erichsen build an OpenClaw 2.0 release dashboard from one prompt:
 
 <iframe
-  className="w-full aspect-video rounded-lg"
+  style={{ width: "100%", height: "auto", aspectRatio: "16 / 9", border: 0, borderRadius: "8px" }}
   src="https://www.youtube-nocookie.com/embed/gHyBueWideg"
   title="Build an OpenClaw Dashboard with One Prompt"
-  frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   referrerPolicy="strict-origin-when-cross-origin"
   allowFullScreen


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the newly embedded dashboard demo renders at the iframe default `300×150` size instead of filling the documentation content column at 16:9.

## Why This Change Was Made

Replaces Mintlify utility classes that are preserved but not applied in production with explicit responsive dimensions on the iframe.

## User Impact

Readers see a full-width 16:9 video that scales with the dashboard guide on desktop and mobile.

## Evidence

- Production before: iframe `300×150`, ratio `2.0`, inside a `590px` content column
- Browser proof with the proposed style: iframe `590×331.875`, ratio `1.7777778`, no horizontal overflow
- Single-page Docs MDX validation passed
- `oxfmt` and repository markdownlint passed
- `git diff --check` passed
- Production desktop and mobile verification will be repeated after merge and R2 deployment.