### PR TITLE
fix(transcripts): review and deslop pass over the transcripts domain

### DIFF
--- a/docs/cli/transcripts.md
+++ b/docs/cli/transcripts.md
@@ -336,6 +336,11 @@ bots never count. After the last human leaves, a fixed 30-second grace period
 allows short reconnects without splitting the meeting. A human returning during
 that grace cancels the stop. Otherwise, OpenClaw stops capture and generates notes.
 
+After auto-start retries are exhausted, an empty newly created capture that never
+started successfully is removed; the same cleanup runs when startup is abandoned
+because the room stays empty or the Gateway stops. Reopened meetings, captured
+utterances, saved notes, and explicit exports are retained.
+
 Occupancy episodes use generated IDs; an entry's `sessionId` is ignored. To
 continue a meeting across a Gateway restart, OpenClaw reopens the most recent
 session for the same provider, account, guild, and channel when it stopped within

--- a/extensions/discord/src/voice/transcripts-source.ts
+++ b/extensions/discord/src/voice/transcripts-source.ts
@@ -1,7 +1,6 @@
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { summarizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-// Discord plugin module implements transcripts source behavior.
 import type {
   TranscriptSourceProvider,
   TranscriptOccupancyWatchRequest,

--- a/extensions/discord/src/voice/transcripts-source.ts
+++ b/extensions/discord/src/voice/transcripts-source.ts
@@ -12,6 +12,10 @@ import { resolveDiscordVoiceAccess } from "./owner-access.js";
 import type { DiscordVoiceManager } from "./voice-runtime.js";
 
 const managersByAccountId = new Map<string, DiscordVoiceManager>();
+const occupancyWatchers = new Set<{
+  accountId: string;
+  setManager: (manager: DiscordVoiceManager | undefined) => void;
+}>();
 const managerWaiters = new Set<{
   accountId?: string;
   resolve: () => void;
@@ -44,6 +48,11 @@ export function setDiscordTranscriptsVoiceManager(params: {
     }
   } else {
     managersByAccountId.delete(params.accountId);
+  }
+  for (const watcher of occupancyWatchers) {
+    if (watcher.accountId === params.accountId) {
+      watcher.setManager(params.manager ?? undefined);
+    }
   }
 }
 
@@ -117,7 +126,10 @@ async function waitForManager(
     TranscriptOccupancyWatchRequest,
     "cfg" | "source" | "abortSignal" | "startupWaitMs"
   >,
-): Promise<{ ok: true; value: DiscordVoiceManager | undefined } | { ok: false; error: string }> {
+): Promise<
+  | { ok: true; value: { accountId: string; manager: DiscordVoiceManager } | undefined }
+  | { ok: false; error: string }
+> {
   const accountResolution = resolveDiscordTranscriptsAccountId({
     cfg: request.cfg,
     source: request.source,
@@ -127,8 +139,8 @@ async function waitForManager(
   }
   const accountId = accountResolution.value;
   const existing = accountId ? managersByAccountId.get(accountId) : undefined;
-  if (existing) {
-    return { ok: true, value: existing };
+  if (accountId && existing) {
+    return { ok: true, value: { accountId, manager: existing } };
   }
   if (request.abortSignal?.aborted) {
     return { ok: true, value: undefined };
@@ -155,7 +167,8 @@ async function waitForManager(
   if (request.abortSignal?.aborted) {
     return { ok: true, value: undefined };
   }
-  return { ok: true, value: accountId ? managersByAccountId.get(accountId) : undefined };
+  const manager = accountId ? managersByAccountId.get(accountId) : undefined;
+  return { ok: true, value: accountId && manager ? { accountId, manager } : undefined };
 }
 
 export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
@@ -232,18 +245,53 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
     if (!guildId || !channelId) {
       return { ok: false, error: "Discord transcripts require guildId and channelId." };
     }
-    const unsubscribe = manager.watchChannelOccupancy({ guildId, channelId }, ({ occupied }) => {
-      if (occupied) {
-        request.onOccupied();
-      } else {
-        request.onEmpty();
-      }
-    });
+    let occupied = false;
+    let attachedManager: DiscordVoiceManager | undefined;
+    let unsubscribe: (() => void) | undefined;
+    const watcher = {
+      accountId: manager.accountId,
+      setManager(nextManager: DiscordVoiceManager | undefined) {
+        if (attachedManager === nextManager) {
+          return;
+        }
+        unsubscribe?.();
+        unsubscribe = undefined;
+        attachedManager = nextManager;
+        if (!nextManager) {
+          return;
+        }
+        // Account restarts replace managers; retain the last known occupancy until
+        // the replacement has a snapshot, so an outage cannot manufacture emptiness.
+        const release = nextManager.watchChannelOccupancy(
+          { guildId, channelId, ...(occupied ? { previouslyOccupied: true } : {}) },
+          ({ occupied: nextOccupied }) => {
+            if (attachedManager !== nextManager) {
+              return;
+            }
+            occupied = nextOccupied;
+            if (occupied) {
+              request.onOccupied();
+            } else {
+              request.onEmpty();
+            }
+          },
+        );
+        // Initial occupancy can synchronously abort or replace this subscription.
+        if (attachedManager === nextManager) {
+          unsubscribe = release;
+        } else {
+          release();
+        }
+      },
+    };
     const stop = () => {
-      unsubscribe();
+      occupancyWatchers.delete(watcher);
+      watcher.setManager(undefined);
       request.abortSignal?.removeEventListener("abort", stop);
     };
+    occupancyWatchers.add(watcher);
     request.abortSignal?.addEventListener("abort", stop, { once: true });
+    watcher.setManager(managersByAccountId.get(watcher.accountId));
     if (request.abortSignal?.aborted) {
       stop();
     }
@@ -254,7 +302,7 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
     if (!managerResolution.ok) {
       return managerResolution;
     }
-    const manager = managerResolution.value;
+    const manager = managerResolution.value?.manager;
     if (!manager) {
       return { ok: false, error: "Discord voice manager is not available." };
     }

--- a/extensions/discord/src/voice/voice-occupancy.test.ts
+++ b/extensions/discord/src/voice/voice-occupancy.test.ts
@@ -128,6 +128,102 @@ defineDiscordVoiceTests(
       expect(listener).toHaveBeenCalledTimes(3);
     });
 
+    it.each([
+      {
+        label: "empty to occupied",
+        initialOccupied: false,
+        replacementOccupied: true,
+        eventsAfterReplacement: ["occupied"],
+        eventsAfterToggle: ["occupied", "empty"],
+        ending: "stop",
+      },
+      {
+        label: "occupied to empty",
+        initialOccupied: true,
+        replacementOccupied: false,
+        eventsAfterReplacement: ["occupied", "empty"],
+        eventsAfterToggle: ["occupied", "empty", "occupied"],
+        ending: "abort",
+      },
+      {
+        label: "still occupied",
+        initialOccupied: true,
+        replacementOccupied: true,
+        eventsAfterReplacement: ["occupied"],
+        eventsAfterToggle: ["occupied", "empty"],
+        ending: "stop",
+      },
+    ])(
+      "keeps transcript occupancy watching after account restart: $label",
+      async ({
+        initialOccupied,
+        replacementOccupied,
+        eventsAfterReplacement,
+        eventsAfterToggle,
+        ending,
+      }) => {
+        const { discordVoiceTranscriptsSourceProvider, setDiscordTranscriptsVoiceManager } =
+          await import("./transcripts-source.js");
+        const original = fixture();
+        const replacement = fixture();
+        const later = fixture();
+        const watchReplacement = vi.spyOn(replacement.manager, "watchChannelOccupancy");
+        const watchLater = vi.spyOn(later.manager, "watchChannelOccupancy");
+        const controller = new AbortController();
+        const events: string[] = [];
+        let stop: (() => void) | undefined;
+        try {
+          await original.update(voiceState("human", initialOccupied ? "1001" : "1002"));
+          setDiscordTranscriptsVoiceManager({ accountId: "primary", manager: original.manager });
+          const result = await discordVoiceTranscriptsSourceProvider.watchOccupancy?.({
+            source: { providerId: "discord-voice", accountId: "primary", ...room },
+            abortSignal: controller.signal,
+            onOccupied: () => {
+              events.push("occupied");
+            },
+            onEmpty: () => {
+              events.push("empty");
+            },
+          });
+          if (!result?.ok) {
+            throw new Error("expected occupancy subscription");
+          }
+          stop = result.value.stop;
+          expect(events).toEqual(initialOccupied ? ["occupied"] : []);
+
+          await original.manager.destroy();
+          setDiscordTranscriptsVoiceManager({ accountId: "primary", manager: null });
+          setDiscordTranscriptsVoiceManager({ accountId: "primary", manager: replacement.manager });
+          // An unavailable manager or unknown replacement snapshot is not an empty room.
+          expect(events).toEqual(initialOccupied ? ["occupied"] : []);
+          await replacement.update(voiceState("human", replacementOccupied ? "1001" : "1002"));
+          expect(events).toEqual(eventsAfterReplacement);
+          setDiscordTranscriptsVoiceManager({ accountId: "primary", manager: replacement.manager });
+          expect(watchReplacement).toHaveBeenCalledOnce();
+          await replacement.update(voiceState("human", replacementOccupied ? "1002" : "1001"));
+          expect(events).toEqual(eventsAfterToggle);
+
+          if (ending === "abort") {
+            controller.abort();
+          } else {
+            stop();
+          }
+          stop();
+          await replacement.update(voiceState("human", replacementOccupied ? "1001" : "1002"));
+          setDiscordTranscriptsVoiceManager({ accountId: "primary", manager: later.manager });
+          await later.update(voiceState("human", "1001"));
+          expect(events).toEqual(eventsAfterToggle);
+          expect(watchLater).not.toHaveBeenCalled();
+        } finally {
+          stop?.();
+          setDiscordTranscriptsVoiceManager({ accountId: "primary", manager: null });
+          await original.manager.destroy();
+          await replacement.manager.destroy();
+          await later.manager.destroy();
+        }
+      },
+    );
+
     it("returns the joined channel title without another channel lookup or starting realtime", async () => {
       const { discordVoiceTranscriptsSourceProvider, setDiscordTranscriptsVoiceManager } =
         await import("./transcripts-source.js");

--- a/extensions/discord/src/voice/voice-runtime.ts
+++ b/extensions/discord/src/voice/voice-runtime.ts
@@ -191,7 +191,7 @@ export class DiscordVoiceManager {
   }
 
   watchChannelOccupancy(
-    params: { guildId: string; channelId: string },
+    params: { guildId: string; channelId: string; previouslyOccupied?: boolean },
     listener: (state: { occupied: boolean }) => void,
   ): () => void {
     if (this.destroyed) {
@@ -199,7 +199,7 @@ export class DiscordVoiceManager {
     }
     const guildId = params.guildId.trim();
     const channelId = params.channelId.trim();
-    let wasOccupied = false;
+    let wasOccupied = params.previouslyOccupied ?? false;
     const watcher = {
       guildId,
       refresh: () => {

--- a/extensions/google-meet/src/runtime.ts
+++ b/extensions/google-meet/src/runtime.ts
@@ -190,6 +190,7 @@ export class GoogleMeetRuntime {
         await this.#speakViaTransport(session, instructions),
       durableTranscripts: {
         config: params.fullConfig.transcripts,
+        cfg: params.fullConfig,
         providerId: "google-meet",
         providerName: "Google Meet",
       },

--- a/src/agents/openclaw-tools.transcripts.ts
+++ b/src/agents/openclaw-tools.transcripts.ts
@@ -4,7 +4,7 @@ import { bindActiveOperatorTurnAuthority } from "./cron-creator-authority-contex
 import type { AnyAgentTool } from "./tools/common.js";
 import { createTranscriptsTool } from "./tools/transcripts-tool.js";
 
-function resolveTranscriptCaller(options: {
+type TranscriptCallerOptions = {
   agentChannel?: string;
   agentAccountId?: string;
   agentGroupId?: string | null;
@@ -16,7 +16,11 @@ function resolveTranscriptCaller(options: {
   gatewayCallerScheduled?: boolean;
   requesterSenderId?: string | null;
   runId?: string;
-}): { caller: TranscriptToolCaller; assertCallerActive?: () => void } | undefined {
+};
+
+function resolveTranscriptCaller(
+  options: TranscriptCallerOptions,
+): { caller: TranscriptToolCaller; assertCallerActive?: () => void } | undefined {
   const accountId = options.gatewayCallerAccountId ?? options.agentAccountId;
   const channel =
     options.gatewayCallerLocal || options.gatewayCallerChannel === null
@@ -57,21 +61,7 @@ function resolveTranscriptCaller(options: {
 export function resolveTranscriptsTool(
   config: OpenClawConfig | undefined,
   agentId: string,
-  options:
-    | {
-        agentChannel?: string;
-        agentAccountId?: string;
-        gatewayCallerAccountId?: string;
-        gatewayCallerChannel?: string | null;
-        gatewayCallerLocal?: boolean;
-        gatewayCallerScheduled?: boolean;
-        requesterSenderId?: string | null;
-        runId?: string;
-        agentGroupId?: string | null;
-        agentGroupSpace?: string | null;
-        agentMemberRoleIds?: string[];
-      }
-    | undefined,
+  options: TranscriptCallerOptions | undefined,
 ): AnyAgentTool | undefined {
   if (config?.transcripts?.enabled === false) {
     return undefined;
@@ -82,10 +72,6 @@ export function resolveTranscriptsTool(
   }
   return createTranscriptsTool({
     agentId,
-    agentChannel: options?.gatewayCallerLocal
-      ? undefined
-      : (options?.gatewayCallerChannel ?? options?.agentChannel),
-    agentAccountId: options?.gatewayCallerAccountId ?? options?.agentAccountId,
     caller: caller.caller,
     ...(caller.assertCallerActive ? { assertCallerActive: caller.assertCallerActive } : {}),
     config,

--- a/src/agents/openclaw-tools.tts-config.test.ts
+++ b/src/agents/openclaw-tools.tts-config.test.ts
@@ -293,8 +293,6 @@ describe("createOpenClawTools transcript ownership wiring", () => {
     expect(mocks.createTranscriptsToolOptions).toHaveBeenLastCalledWith(
       expect.objectContaining({
         agentId: "main",
-        agentChannel: "telegram",
-        agentAccountId: "creator",
         caller: { kind: "operator", source: "scheduled" },
         config: injectedConfig,
       }),
@@ -312,8 +310,6 @@ describe("createOpenClawTools transcript ownership wiring", () => {
 
     expect(mocks.createTranscriptsToolOptions).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        agentChannel: "discord",
-        agentAccountId: "delivery",
         caller: expect.objectContaining({
           kind: "channel",
           channel: "discord",
@@ -361,8 +357,6 @@ describe("createOpenClawTools transcript ownership wiring", () => {
 
     expect(mocks.createTranscriptsToolOptions).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        agentChannel: undefined,
-        agentAccountId: "creator",
         caller: { kind: "operator", source: "scheduled" },
       }),
     );

--- a/src/agents/tools/transcripts-auto-start.ts
+++ b/src/agents/tools/transcripts-auto-start.ts
@@ -98,6 +98,8 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
   };
   const ownsCapture = (capture: OwnedCapture) =>
     activeSessions.get(capture.sessionId)?.lifecycleToken === capture.lifecycleToken;
+  // A capture the runtime still owns (failed startup with pending cleanup) stays in
+  // startedSessions so shutdown retries its exact stop; only released captures are forgotten.
   const forgetCapture = (capture: OwnedCapture) => {
     if (
       !ownsCapture(capture) &&

--- a/src/agents/tools/transcripts-auto-start.ts
+++ b/src/agents/tools/transcripts-auto-start.ts
@@ -7,7 +7,6 @@ import {
 import type {
   TranscriptOccupancyWatchHandle,
   TranscriptSourceLocator,
-  TranscriptSessionDescriptor,
 } from "../../transcripts/provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "../../transcripts/source-locator.js";
 import { createTranscriptsStore, type TranscriptsStore } from "../../transcripts/store.js";
@@ -21,6 +20,7 @@ import {
   sourceFromParams,
   startTranscripts,
   type TranscriptsRuntimeContext,
+  type TranscriptsStartCandidate,
 } from "./transcripts-tool-runtime.js";
 import { stopTranscripts } from "./transcripts-tool-stop.js";
 
@@ -69,6 +69,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
   const controllers = new Set<AbortController>();
   const pendingStarts = new Set<Promise<void>>();
   const pendingStops = new Set<Promise<void>>();
+  const candidates = new Set<TranscriptsStartCandidate>();
   const guildOwners = new Map<string, number>();
   const schedule = (run: () => void, delay: number) => {
     const timer = setTimeout(() => {
@@ -103,6 +104,28 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
       startedSessions.get(capture.sessionId) === capture.lifecycleToken
     ) {
       startedSessions.delete(capture.sessionId);
+    }
+  };
+
+  const discardCandidate = (candidate: TranscriptsStartCandidate, store: TranscriptsStore) => {
+    const session = candidate.session;
+    if (
+      session &&
+      (isTranscriptSessionStarting(session.sessionId) || activeSessions.has(session.sessionId))
+    ) {
+      return;
+    }
+    try {
+      if (session && candidate.discardable) {
+        store.deleteEmptySessionCandidate(session);
+      }
+      candidates.delete(candidate);
+      delete candidate.session;
+      delete candidate.discardable;
+    } catch (error) {
+      ctx.logger.warn(
+        `transcripts autoStart candidate cleanup failed: ${formatAutoStopDiagnostic(error)}; empty candidate retained.`,
+      );
     }
   };
 
@@ -141,10 +164,12 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
     entry: ResolvedTranscriptsAutoStartConfig & { sessionId: string },
     attempt: number,
     store: TranscriptsStore,
+    candidate: TranscriptsStartCandidate = {},
   ) => {
     if (stopped || startedSessions.has(entry.sessionId)) {
       return;
     }
+    candidates.add(candidate);
     const capture = { sessionId: entry.sessionId, lifecycleToken: Symbol(entry.sessionId) };
     // Startup can reject after accepting provider ownership; shutdown must still
     // find that exact capture when its first cleanup attempt fails.
@@ -158,13 +183,16 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
           startupWaitMs: AUTO_START_PROVIDER_READY_TIMEOUT_MS,
           configuredLifecycle: true,
           lifecycleToken: capture.lifecycleToken,
+          candidate,
           rawParams: { action: "start", ...entry },
         });
+        candidates.delete(candidate);
       } catch (error) {
         forgetCapture(capture);
         if (stopped) {
           // Startup may settle after the service's bounded shutdown wait.
           await stopCapture(capture, store);
+          discardCandidate(candidate, store);
           return;
         }
         if (ownsCapture(capture)) {
@@ -172,11 +200,15 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
             `transcripts autoStart session=${formatAutoStopDiagnostic(capture.sessionId)} still owns capture after startup failed: ${formatAutoStopDiagnostic(error)}; use transcripts stop to retry cleanup.`,
           );
         } else if (attempt >= AUTO_START_RETRY_ATTEMPTS) {
+          discardCandidate(candidate, store);
           ctx.logger.warn(
             `transcripts autoStart failed provider=${entry.providerId}: ${formatAutoStopDiagnostic(error)} (check the transcripts.autoStart entry in your config)`,
           );
         } else {
-          schedule(() => startContinuous(entry, attempt + 1, store), AUTO_START_RETRY_MS);
+          schedule(
+            () => startContinuous(entry, attempt + 1, store, candidate),
+            AUTO_START_RETRY_MS,
+          );
         }
       }
     });
@@ -190,7 +222,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
     let occupied = false;
     let ready = false;
     let capture: OwnedCapture | undefined;
-    let candidate: TranscriptSessionDescriptor | undefined;
+    let candidate: TranscriptsStartCandidate = {};
     let starting: Promise<void> | undefined;
     let stopping: Promise<void> | undefined;
     let startController: AbortController | undefined;
@@ -208,6 +240,9 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
         return;
       }
       if (attempt >= AUTO_START_RETRY_ATTEMPTS) {
+        if (phase === "capture") {
+          discardCandidate(candidate, store);
+        }
         ctx.logger.warn(
           `${label} failed: ${formatAutoStopDiagnostic(error)}; check the entry and provider connection. ${phase === "watch" ? "Restart the gateway to retry occupancy watching." : "Waiting for the next occupancy transition."}`,
         );
@@ -246,28 +281,34 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
           }
           const now = Date.now();
           const recent =
-            candidate ??
+            candidate.session ??
             store.readRecentStoppedSession(
               sanitizeTranscriptSourceLocator(source),
               new Date(now - AUTO_START_OCCUPANCY_REOPEN_WINDOW_MS).toISOString(),
               new Date(now).toISOString(),
             );
-          candidate =
+          if (
             recent &&
             !activeSessions.has(recent.sessionId) &&
             !isTranscriptSessionStarting(recent.sessionId) &&
             !startedSessions.has(recent.sessionId)
-              ? recent
-              : {
-                  sessionId: createTranscriptSessionId(),
-                  source: sanitizeTranscriptSourceLocator(source),
-                  startedAt: new Date(now).toISOString(),
-                  stoppedAt: new Date(now).toISOString(),
-                };
+          ) {
+            candidate.session = recent;
+          } else {
+            candidate = {
+              session: {
+                sessionId: createTranscriptSessionId(),
+                source: sanitizeTranscriptSourceLocator(source),
+                startedAt: new Date(now).toISOString(),
+                stoppedAt: new Date(now).toISOString(),
+              },
+            };
+          }
           const owned = {
-            sessionId: candidate.sessionId,
+            sessionId: candidate.session.sessionId,
             lifecycleToken: Symbol(label),
           };
+          candidates.add(candidate);
           capture = owned;
           startedSessions.set(owned.sessionId, owned.lifecycleToken);
           const result = await startTranscripts({
@@ -277,7 +318,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
             startupWaitMs: AUTO_START_PROVIDER_READY_TIMEOUT_MS,
             configuredLifecycle: true,
             lifecycleToken: owned.lifecycleToken,
-            existingSession: candidate,
+            candidate,
             rawParams: { ...entry, ...source, sessionId: owned.sessionId },
             onCaptureEnded: () => {
               if (capture !== owned || stopped || !occupied) {
@@ -288,7 +329,8 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
               retryTimer = schedule(() => begin(1), AUTO_START_RETRY_MS);
             },
           });
-          candidate = undefined;
+          candidates.delete(candidate);
+          candidate = {};
           if (result.details.active === false) {
             throw new Error("capture ended during startup");
           }
@@ -297,7 +339,9 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
             forgetCapture(capture);
             capture = undefined;
           }
-          if (occupied && !controller.signal.aborted) {
+          if (stopped) {
+            discardCandidate(candidate, store);
+          } else if (occupied && !controller.signal.aborted) {
             retry(() => begin(attempt + 1), attempt, error, "capture");
           }
         } finally {
@@ -314,9 +358,9 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
       const task = (async () => {
         startController?.abort();
         await starting;
-        // Failed startup may restore its candidate while settling. A new
-        // occupancy episode must consult the durable reopen window again.
-        candidate = undefined;
+        // Settle callbacks before discarding a failed episode's empty admission.
+        discardCandidate(candidate, store);
+        candidate = {};
         if (capture) {
           await stopCapture(capture, store);
           if (!ownsCapture(capture)) {
@@ -351,7 +395,6 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
             );
             return;
           }
-          candidate = undefined;
           source = resolveTranscriptSourceOwnership({
             ctx,
             operation: "start",
@@ -469,6 +512,9 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
         await stopCapture({ sessionId, lifecycleToken }, store);
       }
       startedSessions.clear();
+      for (const candidate of candidates) {
+        discardCandidate(candidate, store);
+      }
     },
   };
 }

--- a/src/agents/tools/transcripts-auto-start.ts
+++ b/src/agents/tools/transcripts-auto-start.ts
@@ -340,6 +340,9 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
             capture = undefined;
           }
           if (stopped) {
+            if (capture) {
+              await stopCapture(capture, store);
+            }
             discardCandidate(candidate, store);
           } else if (occupied && !controller.signal.aborted) {
             retry(() => begin(attempt + 1), attempt, error, "capture");

--- a/src/agents/tools/transcripts-auto-start.ts
+++ b/src/agents/tools/transcripts-auto-start.ts
@@ -341,7 +341,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
       }
       void runPending(async (controller) => {
         try {
-          const provider = resolveSourceProvider(entry.providerId, ctx);
+          const provider = resolveSourceProvider(entry.providerId, ctx.config);
           if (!provider) {
             throw new Error("provider is not available");
           }

--- a/src/agents/tools/transcripts-auto-start.ts
+++ b/src/agents/tools/transcripts-auto-start.ts
@@ -139,34 +139,40 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
   };
 
   const startContinuous = (
-    entry: ResolvedTranscriptsAutoStartConfig,
+    entry: ResolvedTranscriptsAutoStartConfig & { sessionId: string },
     attempt: number,
     store: TranscriptsStore,
   ) => {
-    if (stopped || startedSessions.has(entry.sessionId ?? "")) {
+    if (stopped || startedSessions.has(entry.sessionId)) {
       return;
     }
-    const lifecycleToken = Symbol(entry.sessionId);
+    const capture = { sessionId: entry.sessionId, lifecycleToken: Symbol(entry.sessionId) };
+    // Startup can reject after accepting provider ownership; shutdown must still
+    // find that exact capture when its first cleanup attempt fails.
+    startedSessions.set(capture.sessionId, capture.lifecycleToken);
     void runPending(async (controller) => {
       try {
-        const result = await startTranscripts({
+        await startTranscripts({
           ctx,
           store,
           abortSignal: controller.signal,
           startupWaitMs: AUTO_START_PROVIDER_READY_TIMEOUT_MS,
           configuredLifecycle: true,
-          lifecycleToken,
+          lifecycleToken: capture.lifecycleToken,
           rawParams: { action: "start", ...entry },
         });
-        const sessionId = result.details.sessionId;
-        if (typeof sessionId === "string") {
-          startedSessions.set(sessionId, lifecycleToken);
-        }
       } catch (error) {
+        forgetCapture(capture);
         if (stopped) {
+          // Startup may settle after the service's bounded shutdown wait.
+          await stopCapture(capture, store);
           return;
         }
-        if (attempt >= AUTO_START_RETRY_ATTEMPTS) {
+        if (ownsCapture(capture)) {
+          ctx.logger.warn(
+            `transcripts autoStart session=${formatAutoStopDiagnostic(capture.sessionId)} still owns capture after startup failed: ${formatAutoStopDiagnostic(error)}; use transcripts stop to retry cleanup.`,
+          );
+        } else if (attempt >= AUTO_START_RETRY_ATTEMPTS) {
           ctx.logger.warn(
             `transcripts autoStart failed provider=${entry.providerId}: ${formatAutoStopDiagnostic(error)} (check the transcripts.autoStart entry in your config)`,
           );

--- a/src/agents/tools/transcripts-auto-start.ts
+++ b/src/agents/tools/transcripts-auto-start.ts
@@ -358,7 +358,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
             provider,
             source: { ...sourceFromParams(entry), providerId: provider.id },
             configuredLifecycle: true,
-          }).source;
+          });
           // Guild voice transports own one connection per account. Claim before
           // awaiting readiness so later entries cannot displace the first room.
           if (source.guildId) {

--- a/src/agents/tools/transcripts-auto-start.ts
+++ b/src/agents/tools/transcripts-auto-start.ts
@@ -295,13 +295,12 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
           ) {
             candidate.session = recent;
           } else {
-            candidate = {
-              session: {
-                sessionId: createTranscriptSessionId(),
-                source: sanitizeTranscriptSourceLocator(source),
-                startedAt: new Date(now).toISOString(),
-                stoppedAt: new Date(now).toISOString(),
-              },
+            candidate = {};
+            candidate.session = {
+              sessionId: createTranscriptSessionId(),
+              source: sanitizeTranscriptSourceLocator(source),
+              startedAt: new Date(now).toISOString(),
+              stoppedAt: new Date(now).toISOString(),
             };
           }
           const owned = {

--- a/src/agents/tools/transcripts-auto-start.ts
+++ b/src/agents/tools/transcripts-auto-start.ts
@@ -10,12 +10,11 @@ import type {
   TranscriptSessionDescriptor,
 } from "../../transcripts/provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "../../transcripts/source-locator.js";
-import type { TranscriptsStore } from "../../transcripts/store.js";
+import { createTranscriptsStore, type TranscriptsStore } from "../../transcripts/store.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import {
   activeSessions,
   createTranscriptSessionId,
-  createTranscriptsStore,
   isTranscriptSessionStarting,
   resolveSourceProvider,
   resolveTranscriptSourceOwnership,
@@ -430,7 +429,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
       if (!config.enabled || !config.autoStart.length) {
         return;
       }
-      const store = createTranscriptsStore(ctx);
+      const store = createTranscriptsStore(ctx.stateDir);
       for (const [index, entry] of config.autoStart.entries()) {
         if (entry.whenOccupied) {
           watchEntry(entry, index, store);
@@ -465,7 +464,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
       if (pendingStartsSettled) {
         await Promise.allSettled(pendingStops);
       }
-      const store = createTranscriptsStore(ctx);
+      const store = createTranscriptsStore(ctx.stateDir);
       for (const [sessionId, lifecycleToken] of startedSessions) {
         await stopCapture({ sessionId, lifecycleToken }, store);
       }

--- a/src/agents/tools/transcripts-tool-read.test.ts
+++ b/src/agents/tools/transcripts-tool-read.test.ts
@@ -88,20 +88,18 @@ describe("transcripts read actions", () => {
         text: expect.stringContaining("Authorized notes"),
       });
 
-      const readSummary = TranscriptsStore.prototype.readSummary;
-      vi.spyOn(TranscriptsStore.prototype, "readSummary").mockImplementationOnce(
-        async function (this: TranscriptsStore, row) {
-          await store.writeSession({
-            ...session,
-            source: { providerId: "voice", guildId: "other" },
-          });
-          await store.writeSummary(
-            summarizeTranscripts({ session, utterances: [{ text: "Other guild notes" }] }),
-            session,
-          );
-          return readSummary.call(this, row);
-        },
-      );
+      const readSummary = store.readSummary.bind(store);
+      vi.spyOn(TranscriptsStore.prototype, "readSummary").mockImplementationOnce(async (row) => {
+        await store.writeSession({
+          ...session,
+          source: { providerId: "voice", guildId: "other" },
+        });
+        await store.writeSummary(
+          summarizeTranscripts({ session, utterances: [{ text: "Other guild notes" }] }),
+          session,
+        );
+        return readSummary(row);
+      });
       const shown = await run(params, true);
       expect(shown.details).toMatchObject({ sessionId: "meeting", skipped: true });
       expect(JSON.stringify(shown)).not.toContain("Other guild notes");

--- a/src/agents/tools/transcripts-tool-read.test.ts
+++ b/src/agents/tools/transcripts-tool-read.test.ts
@@ -59,11 +59,55 @@ beforeEach(async () => {
   await store.writeSession(session);
 });
 afterEach(() => {
+  vi.restoreAllMocks();
   activeSessions.clear();
   closeOpenClawStateDatabaseForTest();
 });
 
 describe("transcripts read actions", () => {
+  it.each([false, true])(
+    "refuses notes rewritten after authorization (active: %s)",
+    async (active) => {
+      getProvider.mockReturnValue({
+        id: "voice",
+        accessControl: {
+          channelId: "discord",
+          authorize: async ({ source }: { source: { guildId?: string } }) =>
+            source.guildId === "team" ? { ok: true } : { ok: false, error: "denied" },
+        },
+      });
+      if (active) {
+        activeSessions.set(session.sessionId, { session, providerId: "voice", phase: "active" });
+      }
+      await store.writeSummary(
+        summarizeTranscripts({ session, utterances: [{ text: "Authorized notes" }] }),
+        session,
+      );
+      const params = { action: "show", selector: transcriptSessionSelector(session) };
+      expect((await run(params, true)).details).toMatchObject({
+        text: expect.stringContaining("Authorized notes"),
+      });
+
+      const readSummary = TranscriptsStore.prototype.readSummary;
+      vi.spyOn(TranscriptsStore.prototype, "readSummary").mockImplementationOnce(
+        async function (this: TranscriptsStore, row) {
+          await store.writeSession({
+            ...session,
+            source: { providerId: "voice", guildId: "other" },
+          });
+          await store.writeSummary(
+            summarizeTranscripts({ session, utterances: [{ text: "Other guild notes" }] }),
+            session,
+          );
+          return readSummary.call(this, row);
+        },
+      );
+      const shown = await run(params, true);
+      expect(shown.details).toMatchObject({ sessionId: "meeting", skipped: true });
+      expect(JSON.stringify(shown)).not.toContain("Other guild notes");
+    },
+  );
+
   it("reads across agent ownership without widening mutation authority", async () => {
     await store.appendUtteranceForSession(session, {
       text: "Ship the design",

--- a/src/agents/tools/transcripts-tool-read.test.ts
+++ b/src/agents/tools/transcripts-tool-read.test.ts
@@ -5,6 +5,12 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import type { TranscriptSourceProvider } from "../../transcripts/provider-types.js";
 import { TranscriptsStore, transcriptSessionSelector } from "../../transcripts/store.js";
 import { summarizeTranscripts } from "../../transcripts/summary.js";
+import {
+  createToolSearchCatalogRef,
+  registerHeadlessToolSearchCatalog,
+} from "../tool-search-catalog.js";
+import { resolveToolSearchConfig } from "../tool-search-config.js";
+import { ToolSearchRuntime } from "../tool-search-runtime.js";
 import { activeSessions } from "./transcripts-tool-runtime.js";
 import { createTranscriptsTool } from "./transcripts-tool.js";
 
@@ -34,6 +40,14 @@ function tool(channel = false) {
 }
 function run(params: Record<string, unknown>, channel = false) {
   return tool(channel).execute("read", params);
+}
+function readThroughCatalog(params: Record<string, unknown>) {
+  const catalogRef = createToolSearchCatalogRef();
+  registerHeadlessToolSearchCatalog({ catalogRef, tools: [tool()] });
+  const runtime = new ToolSearchRuntime({ catalogRef }, resolveToolSearchConfig(), {
+    validateInput: true,
+  });
+  return runtime.callValue("transcripts", params);
 }
 
 beforeEach(async () => {
@@ -68,6 +82,9 @@ describe("transcripts read actions", () => {
     expect(shown.content).toEqual([
       { type: "text", text: expect.stringContaining("Ship the design") },
     ]);
+    await expect(
+      readThroughCatalog({ action: "show", selector: transcriptSessionSelector(session) }),
+    ).resolves.toMatchObject({ text: expect.stringContaining("Ship the design") });
     await expect(
       run({ action: "stop", selector: transcriptSessionSelector(session) }),
     ).rejects.toThrow("not found");
@@ -146,6 +163,12 @@ describe("transcripts read actions", () => {
     expect((await run({ action: "show", sessionId: "meeting" })).details).toMatchObject({
       active: true,
     });
+    await expect(
+      readThroughCatalog({ action: "show", sessionId: "meeting" }),
+    ).resolves.toMatchObject({
+      active: true,
+      text: "No summary exists yet for this meeting. Capture is active.",
+    });
     await store.writeSummary(
       { ...summarizeTranscripts({ session, utterances: [] }), overview: "x".repeat(20000) },
       session,
@@ -159,6 +182,11 @@ describe("transcripts read actions", () => {
     expect(text.text).toContain(
       `[truncated; run openclaw transcripts show ${transcriptSessionSelector(session)} for the full notes]`,
     );
+    await expect(
+      readThroughCatalog({ action: "show", sessionId: "meeting" }),
+    ).resolves.toMatchObject({
+      text: text.text,
+    });
     for (let index = 0; index < 50; index++) {
       await store.writeSession({
         ...session,

--- a/src/agents/tools/transcripts-tool-read.ts
+++ b/src/agents/tools/transcripts-tool-read.ts
@@ -104,6 +104,7 @@ export async function showPastTranscript(params: ReadParams) {
   return {
     content: [{ type: "text" as const, text }],
     details: {
+      text,
       selector,
       sessionId,
       title,

--- a/src/agents/tools/transcripts-tool-read.ts
+++ b/src/agents/tools/transcripts-tool-read.ts
@@ -11,7 +11,9 @@ import {
 } from "./transcripts-tool-runtime.js";
 import {
   canAccessTranscriptSession,
+  isTranscriptSelectionCurrent,
   resolveTranscriptToolSession,
+  transcriptSelectionNoLongerActive,
 } from "./transcripts-tool-selection.js";
 
 const TRANSCRIPTS_SHOW_MAX_CHARS = 12_000;
@@ -78,6 +80,9 @@ export async function showPastTranscript(params: ReadParams) {
   }
   const notes = await readTranscriptNotes(store, selection.session);
   ctx.assertCallerActive?.();
+  if (!isTranscriptSelectionCurrent(selection, store)) {
+    return transcriptSelectionNoLongerActive(selection);
+  }
   const session = projectTranscriptSession(
     { ...entry, session: selection.session },
     isTranscriptSessionActive(selection.session),

--- a/src/agents/tools/transcripts-tool-read.ts
+++ b/src/agents/tools/transcripts-tool-read.ts
@@ -39,7 +39,7 @@ export async function listPastTranscripts({ ctx, store, rawParams }: ReadParams)
       const { overview: _overview, ...session } = projectTranscriptSession(
         entry,
         isTranscriptSessionActive(entry.session),
-        resolveSourceProvider(entry.session.source.providerId, ctx)?.name,
+        resolveSourceProvider(entry.session.source.providerId, ctx.config)?.name,
       );
       sessions.push(session);
       if (sessions.length === limit) {

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -225,15 +225,13 @@ function bindSourceToTurnAccount(params: {
   operation: "import" | "start";
   provider: TranscriptSourceProvider;
   source: TranscriptSourceLocator;
-}): {
-  source: TranscriptSourceLocator;
-} {
+}): TranscriptSourceLocator {
   const ownership = params.provider.accessControl;
   if (!ownership) {
-    return { source: params.source };
+    return params.source;
   }
   if (params.ctx.caller?.kind === "operator") {
-    return { source: params.source };
+    return params.source;
   }
   const ownerChannel = ownership.channelId.trim().toLowerCase();
   if (!ownerChannel) {
@@ -244,7 +242,7 @@ function bindSourceToTurnAccount(params: {
   const channel = params.ctx.caller?.channel?.trim().toLowerCase();
   const accountId = params.ctx.caller?.accountId?.trim();
   if (!channel) {
-    return { source: params.source };
+    return params.source;
   }
   if (channel !== ownerChannel) {
     throw new Error(
@@ -258,9 +256,7 @@ function bindSourceToTurnAccount(params: {
   }
   // Same-channel capture stays on the trusted inbound account; model input
   // cannot redirect or later control another configured channel account.
-  return {
-    source: { ...params.source, accountId },
-  };
+  return { ...params.source, accountId };
 }
 
 export async function authorizeTranscriptSource(params: {
@@ -296,9 +292,7 @@ export function resolveTranscriptSourceOwnership(params: {
   provider: TranscriptSourceProvider;
   source: TranscriptSourceLocator;
   configuredLifecycle?: boolean;
-}): {
-  source: TranscriptSourceLocator;
-} {
+}): TranscriptSourceLocator {
   const boundSource = bindSourceToTurnAccount(params);
   const ownership = params.provider.accessControl;
   const trustedAccountId =
@@ -306,8 +300,8 @@ export function resolveTranscriptSourceOwnership(params: {
       ? params.ctx.caller.accountId?.trim()
       : undefined;
   const sourceForResolution = trustedAccountId
-    ? { ...boundSource.source, accountId: trustedAccountId }
-    : boundSource.source;
+    ? { ...boundSource, accountId: trustedAccountId }
+    : boundSource;
   const accountResolution = ownership?.resolveAccountId({
     cfg: params.ctx.config,
     source: sourceForResolution,
@@ -331,7 +325,7 @@ export function resolveTranscriptSourceOwnership(params: {
       `transcripts provider ${params.provider.id} could not resolve an account for configured auto-start`,
     );
   }
-  return { source: providerSource };
+  return providerSource;
 }
 
 export function toolText(text: string, details?: Record<string, unknown> & { selector?: string }) {
@@ -390,14 +384,13 @@ export async function startTranscripts(params: {
   if (!provider?.start) {
     throw new Error(`transcripts provider ${requestedSource.providerId} cannot start live capture`);
   }
-  const resolvedSource = resolveTranscriptSourceOwnership({
+  const providerSource = resolveTranscriptSourceOwnership({
     ctx: params.ctx,
     operation: "start",
     provider,
     source: requestedSource,
     configuredLifecycle: params.configuredLifecycle,
   });
-  const providerSource = resolvedSource.source;
   if (!params.configuredLifecycle) {
     await authorizeTranscriptSource({
       action: "start",

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveTranscriptsConfig } from "../../transcripts/config.js";
 import { manualTranscriptSourceProvider } from "../../transcripts/manual-source.js";
@@ -14,7 +13,7 @@ import type {
 } from "../../transcripts/provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "../../transcripts/source-locator.js";
 import { transcriptSessionSelector } from "../../transcripts/store-artifacts.js";
-import { TranscriptsStore, TranscriptsSummaryChangedError } from "../../transcripts/store.js";
+import { TranscriptsSummaryChangedError, type TranscriptsStore } from "../../transcripts/store.js";
 import { summarizeTranscriptsWithModel } from "../../transcripts/summary-model.js";
 import { summarizeTranscripts } from "../../transcripts/summary.js";
 import { truncateUtf16Safe } from "../../utils.js";
@@ -69,12 +68,6 @@ const startingSessionIds = new Set<string>();
 
 export function isTranscriptSessionStarting(sessionId: string): boolean {
   return startingSessionIds.has(sessionId);
-}
-
-export function createTranscriptsStore(ctx: TranscriptsRuntimeContext): TranscriptsStore {
-  return new TranscriptsStore(path.join(ctx.stateDir, "transcripts"), {
-    env: { ...process.env, OPENCLAW_STATE_DIR: ctx.stateDir },
-  });
 }
 
 export async function readTranscriptSummary(params: {

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -36,6 +36,11 @@ export type TranscriptsRuntimeContext = {
   logger: TranscriptsLogger;
 };
 
+export type TranscriptsStartCandidate = {
+  session?: TranscriptSessionDescriptor;
+  discardable?: true;
+};
+
 type ActiveTranscriptsSession = {
   session: TranscriptSessionDescriptor;
   providerId: string;
@@ -329,7 +334,7 @@ export async function startTranscripts(params: {
   startupWaitMs?: number;
   configuredLifecycle?: true;
   lifecycleToken?: symbol;
-  existingSession?: TranscriptSessionDescriptor;
+  candidate?: TranscriptsStartCandidate;
   onCaptureEnded?: () => void;
 }) {
   if (params.abortSignal?.aborted) {
@@ -358,18 +363,19 @@ export async function startTranscripts(params: {
       source: providerSource,
     });
   }
+  const previousSession = params.candidate?.session;
   const session: TranscriptSessionDescriptor = {
     sessionId:
-      params.existingSession?.sessionId ??
+      previousSession?.sessionId ??
       readTranscriptStringParam(params.rawParams, "sessionId", { trim: true }) ??
       createTranscriptSessionId(),
     title:
       readTranscriptStringParam(params.rawParams, "title", { trim: true }) ??
-      params.existingSession?.title,
+      previousSession?.title,
     source: sanitizeTranscriptSourceLocator(providerSource),
-    startedAt: params.existingSession?.startedAt ?? new Date().toISOString(),
+    startedAt: previousSession?.startedAt ?? new Date().toISOString(),
     metadata: {
-      ...params.existingSession?.metadata,
+      ...previousSession?.metadata,
       ...(params.ctx.agentId ? { agentId: params.ctx.agentId } : {}),
     },
   };
@@ -385,7 +391,13 @@ export async function startTranscripts(params: {
   };
   const startupAbort = createStartupAbortScope(params.abortSignal);
   try {
-    await params.store.writeSession(session);
+    const inserted = await params.store.writeSession(session);
+    if (params.candidate) {
+      params.candidate.session = session;
+      if (inserted) {
+        params.candidate.discardable = true;
+      }
+    }
     let result: TranscriptsStartResult;
     try {
       result = await provider.start({
@@ -438,6 +450,10 @@ export async function startTranscripts(params: {
     if (!result.ok) {
       entry.phase = "failed";
       throw new Error(result.error);
+    }
+    // Accepted capture is a real meeting even when it ends without any speech.
+    if (params.candidate) {
+      delete params.candidate.discardable;
     }
     activeSessions.set(session.sessionId, entry);
     if (!session.title) {
@@ -507,10 +523,14 @@ export async function startTranscripts(params: {
       }
       await finalizeTranscriptCapture({ ...params, entry });
     }
-    // Failed reopening must not erase the durable stop time: the next bounded
-    // attempt still needs to find this same meeting, not create an empty sibling.
-    if (entry.phase === "failed" && params.existingSession) {
-      await params.store.writeSession(params.existingSession);
+    // Retain one tuple through retries and preserve the stop time of reopened history.
+    if (entry.phase === "failed" && params.candidate) {
+      const stopped = {
+        ...(previousSession ?? session),
+        stoppedAt: previousSession?.stoppedAt ?? new Date().toISOString(),
+      };
+      await params.store.writeSession(stopped);
+      params.candidate.session = stopped;
     }
     throw error;
   } finally {

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -13,11 +13,9 @@ import type {
 } from "../../transcripts/provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "../../transcripts/source-locator.js";
 import { transcriptSessionSelector } from "../../transcripts/store-artifacts.js";
-import { TranscriptsSummaryChangedError, type TranscriptsStore } from "../../transcripts/store.js";
-import { summarizeTranscriptsWithModel } from "../../transcripts/summary-model.js";
-import { summarizeTranscripts } from "../../transcripts/summary.js";
+import type { TranscriptsStore } from "../../transcripts/store.js";
+import { persistTranscriptSummary } from "../../transcripts/summary-persistence.js";
 import { truncateUtf16Safe } from "../../utils.js";
-import { resolveDefaultAgentId } from "../agent-scope-config.js";
 
 const ACCOUNT_ID_OUTPUT_MAX_CHARS = 64;
 
@@ -66,45 +64,6 @@ const startingSessionIds = new Set<string>();
 
 export function isTranscriptSessionStarting(sessionId: string): boolean {
   return startingSessionIds.has(sessionId);
-}
-
-export async function readTranscriptSummary(params: {
-  config: ReturnType<typeof resolveTranscriptsConfig>;
-  cfg?: OpenClawConfig;
-  store: TranscriptsStore;
-  session: TranscriptSessionDescriptor;
-}) {
-  const utterances = await params.store.readUtterancesForSession(params.session, {
-    maxUtterances: params.config.maxUtterances,
-  });
-  const agentId = params.session.metadata?.agentId;
-  if (params.cfg) {
-    const modeled = await summarizeTranscriptsWithModel({
-      cfg: params.cfg,
-      agentId:
-        typeof agentId === "string" && agentId.trim() ? agentId : resolveDefaultAgentId(params.cfg),
-      session: params.session,
-      utterances,
-    });
-    if (modeled) {
-      return modeled;
-    }
-  }
-  // Heuristic notes are the deterministic base; model inference is an enhancement
-  // so an unavailable model never loses the captured meeting notes.
-  return summarizeTranscripts({ session: params.session, utterances });
-}
-
-export async function persistTranscriptSummary(
-  params: Parameters<typeof readTranscriptSummary>[0],
-) {
-  const revision = params.store.readSummaryInputRevision(params.session);
-  if (revision === undefined) {
-    throw new TranscriptsSummaryChangedError();
-  }
-  const summary = await readTranscriptSummary(params);
-  const intendedSummaryPath = await params.store.writeSummary(summary, params.session, revision);
-  return { summary, intendedSummaryPath };
 }
 
 // Retain the exact owner on failure so stop can retry persistence without touching

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -31,8 +31,6 @@ export type TranscriptsLogger = {
 
 export type TranscriptsRuntimeContext = {
   agentId?: string;
-  agentChannel?: string;
-  agentAccountId?: string;
   caller?: TranscriptToolCaller;
   assertCallerActive?: () => void;
   config?: OpenClawConfig;

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -216,10 +216,10 @@ export function sourceFromParams(params: Record<string, unknown>): TranscriptSou
   };
 }
 
-export function resolveSourceProvider(providerId: string, ctx: TranscriptsRuntimeContext) {
+export function resolveSourceProvider(providerId: string, config?: OpenClawConfig) {
   return providerId === manualTranscriptSourceProvider.id
     ? manualTranscriptSourceProvider
-    : getTranscriptSourceProvider(providerId, ctx.config);
+    : getTranscriptSourceProvider(providerId, config);
 }
 
 function bindSourceToTurnAccount(params: {
@@ -388,7 +388,7 @@ export async function startTranscripts(params: {
     ...sourceFromParams(params.rawParams),
     ...(params.ctx.agentId ? { agentId: params.ctx.agentId } : {}),
   };
-  const provider = resolveSourceProvider(requestedSource.providerId, params.ctx);
+  const provider = resolveSourceProvider(requestedSource.providerId, params.ctx.config);
   if (!provider?.start) {
     throw new Error(`transcripts provider ${requestedSource.providerId} cannot start live capture`);
   }

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -87,23 +87,17 @@ export async function readTranscriptSummary(params: {
     maxUtterances: params.config.maxUtterances,
   });
   const agentId = params.session.metadata?.agentId;
-  try {
-    if (params.cfg) {
-      const modeled = await summarizeTranscriptsWithModel({
-        cfg: params.cfg,
-        agentId:
-          typeof agentId === "string" && agentId.trim()
-            ? agentId
-            : resolveDefaultAgentId(params.cfg),
-        session: params.session,
-        utterances,
-      });
-      if (modeled) {
-        return modeled;
-      }
+  if (params.cfg) {
+    const modeled = await summarizeTranscriptsWithModel({
+      cfg: params.cfg,
+      agentId:
+        typeof agentId === "string" && agentId.trim() ? agentId : resolveDefaultAgentId(params.cfg),
+      session: params.session,
+      utterances,
+    });
+    if (modeled) {
+      return modeled;
     }
-  } catch {
-    // Historical captures may have no resolvable agent; they still get notes.
   }
   // Heuristic notes are the deterministic base; model inference is an enhancement
   // so an unavailable model never loses the captured meeting notes.

--- a/src/agents/tools/transcripts-tool-selection.ts
+++ b/src/agents/tools/transcripts-tool-selection.ts
@@ -43,7 +43,7 @@ export async function canAccessTranscriptSession(
   if (readOnly && ctx.caller?.kind === "operator") {
     return true;
   }
-  const provider = resolveSourceProvider(session.source.providerId, ctx);
+  const provider = resolveSourceProvider(session.source.providerId, ctx.config);
   if (readOnly && (ctx.caller?.kind !== "channel" || !provider?.accessControl)) {
     return false;
   }

--- a/src/agents/tools/transcripts-tool-selection.ts
+++ b/src/agents/tools/transcripts-tool-selection.ts
@@ -106,7 +106,10 @@ export async function resolveTranscriptToolSession(params: {
     ? exactActive
     : entry && activeSessions.get(entry.session.sessionId);
   const selectedActive =
-    entry && activeCandidate && sameSessionIdentity(entry.session, activeCandidate.session)
+    !durableRead &&
+    entry &&
+    activeCandidate &&
+    sameSessionIdentity(entry.session, activeCandidate.session)
       ? activeCandidate
       : undefined;
   // Reads authorize the durable descriptor that owns the notes. Mutations keep

--- a/src/agents/tools/transcripts-tool-stop.ts
+++ b/src/agents/tools/transcripts-tool-stop.ts
@@ -91,7 +91,7 @@ export async function stopTranscripts(params: {
   try {
     let providerStopError: string | undefined;
     if (selectedActive && selectedActive.phase !== "terminal") {
-      const provider = resolveSourceProvider(selectedActive.providerId, params.ctx);
+      const provider = resolveSourceProvider(selectedActive.providerId, params.ctx.config);
       if (selectedActive.cleanupPending) {
         providerStopError = await stopPendingTranscriptCapture({
           ctx: params.ctx,

--- a/src/agents/tools/transcripts-tool-stop.ts
+++ b/src/agents/tools/transcripts-tool-stop.ts
@@ -1,11 +1,11 @@
 import { resolveTranscriptsConfig } from "../../transcripts/config.js";
 import type { TranscriptSessionDescriptor } from "../../transcripts/provider-types.js";
 import { transcriptSessionSelector, type TranscriptsStore } from "../../transcripts/store.js";
+import { persistTranscriptSummary } from "../../transcripts/summary-persistence.js";
 import {
   activeSessions,
   finalizeTranscriptCapture,
   isTranscriptSessionStarting,
-  persistTranscriptSummary,
   readTranscriptStringParam,
   resolveSourceProvider,
   stopPendingTranscriptCapture,

--- a/src/agents/tools/transcripts-tool.account-ownership.test.ts
+++ b/src/agents/tools/transcripts-tool.account-ownership.test.ts
@@ -29,8 +29,6 @@ function createTool(
     config: { transcripts: { enabled: true } },
     stateDir,
     agentId,
-    ...(origin ? { agentChannel: origin.channel } : {}),
-    ...(origin?.accountId ? { agentAccountId: origin.accountId } : {}),
     caller: origin
       ? {
           kind: "channel",

--- a/src/agents/tools/transcripts-tool.auto-start.test.ts
+++ b/src/agents/tools/transcripts-tool.auto-start.test.ts
@@ -97,7 +97,7 @@ describe("transcripts auto-start stop reporting", () => {
           release.resolve();
           await stopping;
           await vi.waitFor(() => {
-            expect(stop.mock.calls.map(([request]) => request.sessionId)).toEqual([
+            expect(stop.mock.calls.map(([stopRequest]) => stopRequest.sessionId)).toEqual([
               sessionId,
               sessionId,
             ]);

--- a/src/agents/tools/transcripts-tool.auto-start.test.ts
+++ b/src/agents/tools/transcripts-tool.auto-start.test.ts
@@ -21,6 +21,8 @@ import { TranscriptsStore } from "../../transcripts/store.js";
 import { activeSessions } from "./transcripts-tool-runtime.js";
 import { createTranscriptsAutoStartService, createTranscriptsTool } from "./transcripts-tool.js";
 
+// Stop paths write SQLite and generate notes; vitest's default 1s waitFor budget flakes under CI load.
+const WAIT_FOR_OPTIONS = { timeout: 15_000 } as const;
 const tempDirs = createTempDirTracker();
 const capturedText = "Private captured decision: keep these notes out of operator logs.";
 const obstruction = "existing file; do not overwrite\n";
@@ -102,7 +104,7 @@ describe("transcripts auto-start stop reporting", () => {
               sessionId,
             ]);
             expect(activeSessions.has(sessionId)).toBe(false);
-          });
+          }, WAIT_FOR_OPTIONS);
         } finally {
           release.resolve();
           await stopping;
@@ -203,7 +205,7 @@ describe("transcripts auto-start stop reporting", () => {
                 active: expect.arrayContaining([expect.objectContaining({ sessionId: id })]),
               },
             });
-          });
+          }, WAIT_FOR_OPTIONS);
           const request = requests.get(id)!;
           await request.onUtterance({ text: capturedText, final: true });
           await expect(store.readUtterancesForSession(request.session)).resolves.toEqual([

--- a/src/agents/tools/transcripts-tool.auto-start.test.ts
+++ b/src/agents/tools/transcripts-tool.auto-start.test.ts
@@ -18,6 +18,7 @@ import type {
   TranscriptStopRequest,
 } from "../../transcripts/provider-types.js";
 import { TranscriptsStore } from "../../transcripts/store.js";
+import { activeSessions } from "./transcripts-tool-runtime.js";
 import { createTranscriptsAutoStartService, createTranscriptsTool } from "./transcripts-tool.js";
 
 const tempDirs = createTempDirTracker();
@@ -27,11 +28,80 @@ const credential = "fixture-secret-value-1234567890";
 const providerError = `fixture stop failure\n\u001b[31mred\u001b[0m\u0085 token=${credential} ${"🦞".repeat(2_000)}`;
 
 afterEach(() => {
+  vi.useRealTimers();
   closeOpenClawStateDatabaseForTest();
   tempDirs.cleanup();
 });
 
 describe("transcripts auto-start stop reporting", () => {
+  it.each([false, true])(
+    "retries startup cleanup even after shutdown times out: %s",
+    async (late) => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const stateDir = tempDirs.make("transcripts-start-cleanup-");
+      const entered = createDeferred();
+      const release = createDeferred();
+      const stop = vi
+        .fn<NonNullable<TranscriptSourceProvider["stop"]>>()
+        .mockResolvedValueOnce({ ok: false, error: "cleanup temporarily unavailable" })
+        .mockImplementation(async ({ sessionId }) => ({ ok: true, sessionId }));
+      const provider: TranscriptSourceProvider = {
+        id: "start-cleanup",
+        name: "Start cleanup",
+        sourceKinds: ["live-audio"],
+        async start(request) {
+          entered.resolve();
+          await release.promise;
+          return { ok: true, session: request.session };
+        },
+        stop,
+      };
+      const registry = createEmptyPluginRegistry();
+      registry.transcriptSourceProviders.push({
+        pluginId: provider.id,
+        provider,
+        source: import.meta.url,
+      });
+      const ctx = {
+        stateDir,
+        config: { transcripts: { autoStart: [{ providerId: provider.id, sessionId: "pending" }] } },
+        caller: { kind: "operator" as const, source: "local" as const },
+        logger: { warn: vi.fn() },
+      };
+      const service = createTranscriptsAutoStartService(ctx);
+      await withPluginRuntimeRegistryScope(registry, async () => {
+        let stopping: Promise<void> | undefined;
+        try {
+          service.start();
+          await entered.promise;
+          stopping = service.stop();
+          if (late) {
+            await vi.advanceTimersByTimeAsync(5_000);
+            await stopping;
+          }
+          release.resolve();
+          await stopping;
+          await vi.waitFor(() => {
+            expect(stop.mock.calls.map(([request]) => request.sessionId)).toEqual([
+              "pending",
+              "pending",
+            ]);
+            expect(activeSessions.has("pending")).toBe(false);
+          });
+        } finally {
+          release.resolve();
+          await stopping;
+          await service.stop();
+          await createTranscriptsTool(ctx).execute("cleanup", {
+            action: "stop",
+            sessionId: "pending",
+          });
+          vi.useRealTimers();
+        }
+      });
+    },
+  );
+
   it.each([
     { name: "export failure", blocked: true, outcome: "ok", manual: false },
     { name: "fulfilled provider warning", blocked: false, outcome: "warn", manual: false },

--- a/src/agents/tools/transcripts-tool.auto-start.test.ts
+++ b/src/agents/tools/transcripts-tool.auto-start.test.ts
@@ -34,12 +34,17 @@ afterEach(() => {
 });
 
 describe("transcripts auto-start stop reporting", () => {
-  it.each([false, true])(
-    "retries startup cleanup even after shutdown times out: %s",
-    async (late) => {
+  it.each([
+    { whenOccupied: false, late: false },
+    { whenOccupied: false, late: true },
+    { whenOccupied: true, late: false },
+    { whenOccupied: true, late: true },
+  ])(
+    "retries startup cleanup (occupied=$whenOccupied, late=$late)",
+    async ({ whenOccupied, late }) => {
       vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
       const stateDir = tempDirs.make("transcripts-start-cleanup-");
-      const entered = createDeferred();
+      const entered = createDeferred<TranscriptStartRequest>();
       const release = createDeferred();
       const stop = vi
         .fn<NonNullable<TranscriptSourceProvider["stop"]>>()
@@ -49,8 +54,12 @@ describe("transcripts auto-start stop reporting", () => {
         id: "start-cleanup",
         name: "Start cleanup",
         sourceKinds: ["live-audio"],
+        async watchOccupancy(request) {
+          request.onOccupied();
+          return { ok: true, value: { stop() {} } };
+        },
         async start(request) {
-          entered.resolve();
+          entered.resolve(request);
           await release.promise;
           return { ok: true, session: request.session };
         },
@@ -64,16 +73,22 @@ describe("transcripts auto-start stop reporting", () => {
       });
       const ctx = {
         stateDir,
-        config: { transcripts: { autoStart: [{ providerId: provider.id, sessionId: "pending" }] } },
+        config: {
+          transcripts: {
+            autoStart: [{ providerId: provider.id, sessionId: "pending", whenOccupied }],
+          },
+        },
         caller: { kind: "operator" as const, source: "local" as const },
         logger: { warn: vi.fn() },
       };
       const service = createTranscriptsAutoStartService(ctx);
       await withPluginRuntimeRegistryScope(registry, async () => {
         let stopping: Promise<void> | undefined;
+        let request: TranscriptStartRequest | undefined;
         try {
           service.start();
-          await entered.promise;
+          request = await entered.promise;
+          const sessionId = request.session.sessionId;
           stopping = service.stop();
           if (late) {
             await vi.advanceTimersByTimeAsync(5_000);
@@ -83,19 +98,21 @@ describe("transcripts auto-start stop reporting", () => {
           await stopping;
           await vi.waitFor(() => {
             expect(stop.mock.calls.map(([request]) => request.sessionId)).toEqual([
-              "pending",
-              "pending",
+              sessionId,
+              sessionId,
             ]);
-            expect(activeSessions.has("pending")).toBe(false);
+            expect(activeSessions.has(sessionId)).toBe(false);
           });
         } finally {
           release.resolve();
           await stopping;
           await service.stop();
-          await createTranscriptsTool(ctx).execute("cleanup", {
-            action: "stop",
-            sessionId: "pending",
-          });
+          if (request) {
+            await createTranscriptsTool(ctx).execute("cleanup", {
+              action: "stop",
+              sessionId: request.session.sessionId,
+            });
+          }
           vi.useRealTimers();
         }
       });

--- a/src/agents/tools/transcripts-tool.lifecycle.test.ts
+++ b/src/agents/tools/transcripts-tool.lifecycle.test.ts
@@ -100,7 +100,7 @@ describe("transcript capture ownership", () => {
             throw new Error("title write unavailable");
           }
         }
-        await originalWrite(session);
+        return await originalWrite(session);
       });
       const start = h
         .createTool()

--- a/src/agents/tools/transcripts-tool.occupancy.test.ts
+++ b/src/agents/tools/transcripts-tool.occupancy.test.ts
@@ -12,11 +12,13 @@ import type {
   TranscriptStartRequest,
 } from "../../transcripts/provider-types.js";
 import { TranscriptsStore } from "../../transcripts/store.js";
-import { activeSessions } from "./transcripts-tool-runtime.js";
+import { summarizeTranscripts } from "../../transcripts/summary.js";
+import { activeSessions, isTranscriptSessionStarting } from "./transcripts-tool-runtime.js";
 import { createTranscriptsAutoStartService, createTranscriptsTool } from "./transcripts-tool.js";
 
 const tempDirs = createTempDirTracker();
 afterEach(() => {
+  vi.restoreAllMocks();
   activeSessions.clear();
   vi.useRealTimers();
   closeOpenClawStateDatabaseForTest();
@@ -102,7 +104,225 @@ function harness() {
   };
 }
 
+async function waitForFailedAttempt(h: ReturnType<typeof harness>, count: number) {
+  await vi.waitFor(() => {
+    expect(h.requests).toHaveLength(count);
+    expect(isTranscriptSessionStarting(h.requests[count - 1]!.session.sessionId)).toBe(false);
+  });
+}
+
 describe("occupancy-driven transcript lifecycle", () => {
+  it("retains the admitted descriptor when retry admission fails", async () => {
+    const h = harness();
+    h.provider.start = async (request) => {
+      h.requests.push(request);
+      return { ok: false, error: "capture unavailable" };
+    };
+    await withPluginRuntimeRegistryScope(h.registry, async () => {
+      const service = h.service();
+      try {
+        service.start();
+        await vi.waitFor(() => expect(h.watches).toHaveLength(1));
+        h.watches[0]!.onOccupied();
+        await waitForFailedAttempt(h, 1);
+        vi.spyOn(TranscriptsStore.prototype, "writeSession").mockRejectedValue(
+          new Error("retry admission write failed"),
+        );
+        for (let attempt = 1; attempt < 12; attempt++) {
+          await vi.advanceTimersByTimeAsync(5_000);
+        }
+        await vi.waitFor(() => expect(h.logger.warn).toHaveBeenCalledOnce());
+        expect(await h.store.listSessionEntries()).toEqual([]);
+        expect(h.requests).toHaveLength(1);
+      } finally {
+        await service.stop();
+      }
+    });
+  });
+
+  it.each([false, true])(
+    "discards only the empty admitted row after twelve failed starts (occupied=%s)",
+    async (whenOccupied) => {
+      const h = harness();
+      h.provider.start = vi.fn<NonNullable<TranscriptSourceProvider["start"]>>(async (request) => {
+        h.requests.push(request);
+        return { ok: false, error: "capture unavailable" };
+      });
+      await withPluginRuntimeRegistryScope(h.registry, async () => {
+        const service = h.service([{ ...h.entry, whenOccupied }]);
+        try {
+          service.start();
+          if (whenOccupied) {
+            await vi.waitFor(() => expect(h.watches).toHaveLength(1));
+            h.watches[0]!.onOccupied();
+          }
+          await waitForFailedAttempt(h, 1);
+          for (let attempt = 1; attempt < 12; attempt++) {
+            expect(await h.store.listSessionEntries()).toHaveLength(1);
+            await vi.advanceTimersByTimeAsync(5_000);
+            await vi.waitFor(() =>
+              expect(isTranscriptSessionStarting(h.requests[0]!.session.sessionId)).toBe(false),
+            );
+          }
+          expect(
+            new Set(h.requests.map(({ session }) => `${session.sessionId}/${session.startedAt}`))
+              .size,
+          ).toBe(1);
+          await vi.waitFor(() => expect(h.logger.warn).toHaveBeenCalledOnce());
+          await vi.waitFor(async () => expect(await h.store.listSessionEntries()).toEqual([]));
+          await vi.advanceTimersByTimeAsync(60_000);
+          expect(h.provider.start).toHaveBeenCalledTimes(12);
+        } finally {
+          await service.stop();
+        }
+      });
+    },
+  );
+
+  it.each([
+    "reopened empty",
+    "inline utterance",
+    "partial speech after stop-write failure",
+    "concurrent summary",
+    "export",
+  ] as const)("preserves %s evidence after terminal startup failure", async (retained) => {
+    const h = harness();
+    const partialSpeech =
+      retained === "inline utterance" || retained === "partial speech after stop-write failure";
+    const summaryGate = createDeferred();
+    const historical = {
+      sessionId: "existing-empty-meeting",
+      startedAt: "2026-08-01T11:50:00.000Z",
+      stoppedAt: "2026-08-01T11:59:00.000Z",
+      source: {
+        providerId: h.provider.id,
+        accountId: "default",
+        guildId: h.entry.guildId,
+        channelId: h.entry.channelId,
+      },
+    };
+    if (retained === "reopened empty") {
+      await h.store.writeSession(historical);
+    }
+    h.provider.start = vi.fn<NonNullable<TranscriptSourceProvider["start"]>>(async (request) => {
+      h.requests.push(request);
+      if (partialSpeech && h.requests.length === 1) {
+        await request.onUtterance({ text: "Captured before startup failed.", final: true });
+        if (retained === "partial speech after stop-write failure") {
+          vi.spyOn(TranscriptsStore.prototype, "writeSession").mockRejectedValueOnce(
+            new Error("stop timestamp write failed"),
+          );
+        }
+      }
+      if (
+        (retained === "concurrent summary" || retained === "export") &&
+        h.requests.length === 12
+      ) {
+        await summaryGate.promise;
+      }
+      return { ok: false, error: "capture unavailable" };
+    });
+    await withPluginRuntimeRegistryScope(h.registry, async () => {
+      const service = h.service();
+      try {
+        service.start();
+        await vi.waitFor(() => expect(h.watches).toHaveLength(1));
+        h.watches[0]!.onOccupied();
+        for (let attempt = 1; attempt <= 12; attempt++) {
+          if ((retained === "concurrent summary" || retained === "export") && attempt === 12) {
+            await vi.waitFor(() => expect(h.requests).toHaveLength(12));
+            const session = h.requests[11]!.session;
+            if (retained === "export") {
+              await h.store.materializeSessionArtifacts(session, "metadata");
+            } else {
+              await h.store.writeSummary(
+                summarizeTranscripts({ session, utterances: [] }),
+                session,
+              );
+            }
+            summaryGate.resolve();
+          }
+          await waitForFailedAttempt(h, attempt);
+          if (attempt < 12) {
+            await vi.advanceTimersByTimeAsync(5_000);
+          }
+        }
+        await vi.waitFor(() => expect(h.logger.warn).toHaveBeenCalledOnce());
+        const entries = await h.store.listSessionEntries();
+        expect(entries).toHaveLength(1);
+        const session = entries[0]!.session;
+        if (retained === "reopened empty") {
+          expect(session).toEqual(historical);
+          expect(await h.store.readUtterancesForSession(session)).toEqual([]);
+          expect(await h.store.readSummary(session)).toEqual({});
+        } else if (partialSpeech) {
+          expect(session.stoppedAt).toEqual(expect.any(String));
+          expect(await h.store.readUtterancesForSession(session)).toMatchObject([
+            { text: "Captured before startup failed.", final: true },
+          ]);
+        } else if (retained === "export") {
+          expect(await h.store.readSummary(session)).toEqual({});
+        } else {
+          expect(await h.store.readSummary(session)).toMatchObject({
+            summary: { utteranceCount: 0 },
+            markdown: expect.stringContaining("No transcript captured yet."),
+          });
+        }
+      } finally {
+        summaryGate.resolve();
+        await service.stop();
+      }
+    });
+  });
+
+  it.each(["empty grace", "shutdown", "late shutdown", "stop-write failure"] as const)(
+    "discards an empty failed start when interrupted by %s",
+    async (interruption) => {
+      const h = harness();
+      const release = createDeferred();
+      h.provider.start = vi.fn<NonNullable<TranscriptSourceProvider["start"]>>(async (request) => {
+        h.requests.push(request);
+        await release.promise;
+        return { ok: false, error: "startup interrupted" };
+      });
+      await withPluginRuntimeRegistryScope(h.registry, async () => {
+        const service = h.service();
+        let stopping: Promise<void> | undefined;
+        try {
+          service.start();
+          await vi.waitFor(() => expect(h.watches).toHaveLength(1));
+          h.watches[0]!.onOccupied();
+          await vi.waitFor(() => expect(h.requests).toHaveLength(1));
+          if (interruption === "stop-write failure") {
+            vi.spyOn(TranscriptsStore.prototype, "writeSession").mockRejectedValueOnce(
+              new Error("stop timestamp write failed"),
+            );
+          }
+          if (interruption === "empty grace") {
+            h.watches[0]!.onEmpty();
+            await vi.advanceTimersByTimeAsync(30_000);
+          } else {
+            stopping = service.stop();
+            if (interruption === "late shutdown") {
+              await vi.advanceTimersByTimeAsync(5_000);
+              await stopping;
+            }
+          }
+          release.resolve();
+          await stopping;
+          await waitForFailedAttempt(h, 1);
+          await vi.waitFor(async () => expect(await h.store.listSessionEntries()).toEqual([]));
+          await vi.advanceTimersByTimeAsync(60_000);
+          expect(h.provider.start).toHaveBeenCalledOnce();
+        } finally {
+          release.resolve();
+          await stopping;
+          await service.stop();
+        }
+      });
+    },
+  );
+
   it("retains one stopped candidate across failed starts and admits synchronous initial occupancy", async () => {
     const h = harness();
     const identities: Array<{ sessionId: string; startedAt: string }> = [];

--- a/src/agents/tools/transcripts-tool.test.ts
+++ b/src/agents/tools/transcripts-tool.test.ts
@@ -49,7 +49,6 @@ async function createHarness(
       stateDir,
       logger,
       ...(agentId ? { agentId } : {}),
-      ...(origin ? { agentChannel: origin.channel, agentAccountId: origin.accountId } : {}),
       caller: origin
         ? {
             kind: "channel",

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -1,8 +1,3 @@
-/**
- * transcripts built-in tool.
- *
- * Manages live capture, manual import, summarization, and process-local transcript sessions.
- */
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { Type } from "typebox";

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -90,13 +90,12 @@ async function importTranscripts(params: {
   if (!provider?.importTranscript) {
     throw new Error(`transcripts provider ${requestedSource.providerId} cannot import transcripts`);
   }
-  const resolvedSource = resolveTranscriptSourceOwnership({
+  const providerSource = resolveTranscriptSourceOwnership({
     ctx: params.ctx,
     operation: "import",
     provider,
     source: requestedSource,
   });
-  const providerSource = resolvedSource.source;
   await authorizeTranscriptSource({
     action: "import",
     ctx: params.ctx,

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -12,6 +12,7 @@ import type {
 } from "../../transcripts/provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "../../transcripts/source-locator.js";
 import {
+  createTranscriptsStore,
   transcriptSessionSelector,
   TranscriptsSummaryChangedError,
   type TranscriptsStore,
@@ -22,7 +23,6 @@ import {
   activeSessions,
   authorizeTranscriptSource,
   createTranscriptSessionId,
-  createTranscriptsStore,
   persistTranscriptSummary,
   readTranscriptStringParam,
   readTranscriptSummary,
@@ -314,7 +314,7 @@ export function createTranscriptsTool(options?: {
       ) {
         throw new Error("selector is only supported for stop, summarize, or show.");
       }
-      const store = createTranscriptsStore(ctx);
+      const store = createTranscriptsStore(ctx.stateDir);
       switch (action) {
         case "list":
           return await listPastTranscripts({ ctx, store, rawParams: params });

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -275,8 +275,6 @@ async function statusTranscripts(ctx: TranscriptsRuntimeContext) {
 /** Create the agent-facing transcripts tool. */
 export function createTranscriptsTool(options?: {
   agentId?: string;
-  agentChannel?: string;
-  agentAccountId?: string;
   caller?: TranscriptToolCaller;
   assertCallerActive?: () => void;
   config?: OpenClawConfig;
@@ -288,8 +286,6 @@ export function createTranscriptsTool(options?: {
     stateDir: options?.stateDir ?? resolveStateDir(),
     logger: options?.logger ?? console,
     ...(options?.agentId ? { agentId: options.agentId } : {}),
-    ...(options?.agentChannel ? { agentChannel: options.agentChannel } : {}),
-    ...(options?.agentAccountId ? { agentAccountId: options.agentAccountId } : {}),
     ...(options?.caller ? { caller: options.caller } : {}),
     ...(options?.assertCallerActive ? { assertCallerActive: options.assertCallerActive } : {}),
   };

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -86,7 +86,7 @@ async function importTranscripts(params: {
     ...sourceFromParams(params.rawParams),
     ...(params.ctx.agentId ? { agentId: params.ctx.agentId } : {}),
   };
-  const provider = resolveSourceProvider(requestedSource.providerId, params.ctx);
+  const provider = resolveSourceProvider(requestedSource.providerId, params.ctx.config);
   if (!provider?.importTranscript) {
     throw new Error(`transcripts provider ${requestedSource.providerId} cannot import transcripts`);
   }

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -17,15 +17,17 @@ import {
   TranscriptsSummaryChangedError,
   type TranscriptsStore,
 } from "../../transcripts/store.js";
+import {
+  persistTranscriptSummary,
+  readTranscriptSummary,
+} from "../../transcripts/summary-persistence.js";
 import type { AnyAgentTool } from "./common.js";
 import { listPastTranscripts, showPastTranscript } from "./transcripts-tool-read.js";
 import {
   activeSessions,
   authorizeTranscriptSource,
   createTranscriptSessionId,
-  persistTranscriptSummary,
   readTranscriptStringParam,
-  readTranscriptSummary,
   resolveTranscriptSourceOwnership,
   resolveSourceProvider,
   sourceFromParams,

--- a/src/cli/program/register.transcripts.ts
+++ b/src/cli/program/register.transcripts.ts
@@ -1,11 +1,9 @@
 // `openclaw transcripts`: SQLite-backed transcript inspector and artifact exporter.
-import path from "node:path";
 import type { Command } from "commander";
 import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
-import { resolveStateDir } from "../../config/paths.js";
 import { normalizeExportText } from "../../transcripts/store-artifacts.js";
 import {
-  TranscriptsStore,
+  createTranscriptsStore,
   type TranscriptArtifactKind,
   type TranscriptsSessionEntry,
 } from "../../transcripts/store.js";
@@ -19,13 +17,6 @@ type TranscriptsPathOptions = TranscriptsCliOptions & {
   metadata?: boolean;
   transcript?: boolean;
 };
-
-function createStore(): TranscriptsStore {
-  const stateDir = resolveStateDir();
-  return new TranscriptsStore(path.join(stateDir, "transcripts"), {
-    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-  });
-}
 
 function writeLine(value: string): void {
   process.stdout.write(`${value}\n`);
@@ -52,7 +43,7 @@ function formatSessionLine(entry: TranscriptsSessionEntry): string {
 }
 
 async function listCommand(options: TranscriptsCliOptions): Promise<void> {
-  const sessions = await createStore().listSessionEntries();
+  const sessions = await createTranscriptsStore().listSessionEntries();
   if (options.json) {
     writeJson(
       sessions.map((entry) => ({
@@ -80,7 +71,7 @@ async function listCommand(options: TranscriptsCliOptions): Promise<void> {
 }
 
 async function showCommand(sessionSelector: string, options: TranscriptsCliOptions): Promise<void> {
-  const store = createStore();
+  const store = createTranscriptsStore();
   const entry = await store.readSessionEntry(sessionSelector);
   if (!entry) {
     throw new Error(`transcripts session not found: ${sessionSelector}`);
@@ -120,7 +111,7 @@ function selectedArtifactKind(options: TranscriptsPathOptions): TranscriptArtifa
 }
 
 async function pathCommand(selector: string, options: TranscriptsPathOptions): Promise<void> {
-  const store = createStore();
+  const store = createTranscriptsStore();
   const entry = await store.readSessionEntry(selector);
   if (!entry) {
     throw new Error(`transcripts session not found: ${selector}`);

--- a/src/gateway/server-methods/transcripts.ts
+++ b/src/gateway/server-methods/transcripts.ts
@@ -9,7 +9,6 @@ import {
   isTranscriptSessionActive,
   resolveSourceProvider,
 } from "../../agents/tools/transcripts-tool-runtime.js";
-import { resolveStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveTranscriptsConfig } from "../../transcripts/config.js";
 import { projectTranscriptSession, readTranscriptNotes } from "../../transcripts/read.js";
@@ -24,11 +23,7 @@ function projectSessions(entries: TranscriptReadEntry[], config: OpenClawConfig)
   return entries.map((entry) => {
     const providerId = entry.session.source.providerId;
     if (!names.has(providerId)) {
-      names.set(
-        providerId,
-        resolveSourceProvider(providerId, { config, stateDir: resolveStateDir(), logger: console })
-          ?.name,
-      );
+      names.set(providerId, resolveSourceProvider(providerId, config)?.name);
     }
     return projectTranscriptSession(
       entry,

--- a/src/gateway/server-methods/transcripts.ts
+++ b/src/gateway/server-methods/transcripts.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import {
   ErrorCodes,
   errorShape,
@@ -15,17 +14,10 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveTranscriptsConfig } from "../../transcripts/config.js";
 import { projectTranscriptSession, readTranscriptNotes } from "../../transcripts/read.js";
 import type { TranscriptReadEntry } from "../../transcripts/store-read.js";
-import { TranscriptsStore } from "../../transcripts/store.js";
+import { createTranscriptsStore } from "../../transcripts/store.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
-
-function createStore() {
-  const stateDir = resolveStateDir();
-  return new TranscriptsStore(path.join(stateDir, "transcripts"), {
-    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-  });
-}
 
 function projectSessions(entries: TranscriptReadEntry[], config: OpenClawConfig) {
   const names = new Map<string, string | undefined>();
@@ -51,7 +43,7 @@ export const transcriptsHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateTranscriptsListParams, "transcripts.list", respond)) {
       return;
     }
-    const entries = createStore().listReadEntries({
+    const entries = createTranscriptsStore().listReadEntries({
       limit: params.limit ?? 50,
       providerId: params.providerId,
     });
@@ -61,7 +53,7 @@ export const transcriptsHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateTranscriptsGetParams, "transcripts.get", respond)) {
       return;
     }
-    const store = createStore();
+    const store = createTranscriptsStore();
     const session = await store.readSession(params.selector);
     if (!session) {
       respond(

--- a/src/meeting-bot/runtime-facade.ts
+++ b/src/meeting-bot/runtime-facade.ts
@@ -129,6 +129,7 @@ export function createMeetingRuntimeFacade<
         speakViaTransport: async () => undefined,
         durableTranscripts: {
           config: params.fullConfig.transcripts,
+          cfg: params.fullConfig,
           ...options.messages.durableTranscripts,
         },
       });

--- a/src/meeting-bot/transcripts-bridge.runtime.ts
+++ b/src/meeting-bot/transcripts-bridge.runtime.ts
@@ -24,7 +24,7 @@ import type {
 
 const CAPTURE_INTERVAL_MS = 5_000;
 
-type ActiveCapture<TSession extends MeetingSessionRecord> = {
+type ActiveCapture = {
   closing: boolean;
   descriptor: TranscriptSessionDescriptor;
   finalCaptureError?: string;
@@ -33,7 +33,6 @@ type ActiveCapture<TSession extends MeetingSessionRecord> = {
   initializationWarned: boolean;
   polling: boolean;
   runCapture(task: () => Promise<void>): Promise<void>;
-  session: TSession;
   timer?: ReturnType<typeof setInterval>;
   utteranceCount: number;
 };
@@ -98,7 +97,7 @@ export function createMeetingDurableTranscriptBridge<
   const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
     env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
   });
-  const captures = new Map<string, ActiveCapture<TSession>>();
+  const captures = new Map<string, ActiveCapture>();
   const pendingSubscribers = new Map<string, Subscriber>();
   const subscribers = new Map<string, Subscriber>();
   const lifecycleTasks = new KeyedAsyncQueue();
@@ -144,18 +143,17 @@ export function createMeetingDurableTranscriptBridge<
           );
           return await result;
         };
-        const active: ActiveCapture<TSession> = {
+        const active: ActiveCapture = {
           closing: false,
           descriptor,
           initialized: false,
           initializationWarned: false,
           polling: false,
           runCapture,
-          session,
           utteranceCount: 0,
         };
         captures.set(session.id, active);
-        // Start and stop share runLifecycle(session.id), so teardown cannot mark
+        // Start and stop share lifecycleTasks, so teardown cannot mark
         // this published capture closing while initialization awaits.
         const initialize = async () => {
           if (active.initialized) {

--- a/src/meeting-bot/transcripts-bridge.runtime.ts
+++ b/src/meeting-bot/transcripts-bridge.runtime.ts
@@ -11,7 +11,7 @@ import type {
 } from "../transcripts/provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "../transcripts/source-locator.js";
 import { createTranscriptsStore } from "../transcripts/store.js";
-import { summarizeTranscripts } from "../transcripts/summary.js";
+import { persistTranscriptSummary } from "../transcripts/summary-persistence.js";
 import { MeetingTranscriptDeliveryError } from "./session-transcript-store.js";
 import type { MeetingSessionRecord, MeetingTranscriptLine } from "./session-types.js";
 import type {
@@ -316,13 +316,12 @@ export function createMeetingDurableTranscriptBridge<
         try {
           await tasks.enqueue(session.id, async () => {
             await store.writeSession(stopped);
-            const utterances = await store.readUtterancesForSession(stopped, {
-              maxUtterances: config.maxUtterances,
+            await persistTranscriptSummary({
+              config,
+              cfg: params.options.cfg,
+              store,
+              session: stopped,
             });
-            await store.writeSummary(
-              summarizeTranscripts({ session: stopped, utterances }),
-              stopped,
-            );
           });
         } catch (error) {
           params.logger.warn(

--- a/src/meeting-bot/transcripts-bridge.runtime.ts
+++ b/src/meeting-bot/transcripts-bridge.runtime.ts
@@ -1,6 +1,4 @@
-import path from "node:path";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
-import { resolveStateDir } from "../config/paths.js";
 import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 import { resolveTranscriptsConfig } from "../transcripts/config.js";
 import type {
@@ -12,7 +10,7 @@ import type {
   TranscriptUtterance,
 } from "../transcripts/provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "../transcripts/source-locator.js";
-import { TranscriptsStore } from "../transcripts/store.js";
+import { createTranscriptsStore } from "../transcripts/store.js";
 import { summarizeTranscripts } from "../transcripts/summary.js";
 import { MeetingTranscriptDeliveryError } from "./session-transcript-store.js";
 import type { MeetingSessionRecord, MeetingTranscriptLine } from "./session-types.js";
@@ -93,10 +91,7 @@ export function createMeetingDurableTranscriptBridge<
   options: MeetingDurableTranscriptsOptions;
 }): MeetingDurableTranscriptBridge<TSession> {
   const config = resolveTranscriptsConfig(params.options.config);
-  const stateDir = params.options.stateDir ?? resolveStateDir();
-  const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
-    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-  });
+  const store = createTranscriptsStore(params.options.stateDir);
   const captures = new Map<string, ActiveCapture>();
   const pendingSubscribers = new Map<string, Subscriber>();
   const subscribers = new Map<string, Subscriber>();

--- a/src/meeting-bot/transcripts-bridge.summary.test.ts
+++ b/src/meeting-bot/transcripts-bridge.summary.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createTranscriptsStore } from "../transcripts/store.js";
+import type { MeetingSessionRecord } from "./session-types.js";
+import { createMeetingDurableTranscriptBridge } from "./transcripts-bridge.runtime.js";
+
+const { runIsolatedCompletion, resolveSimpleCompletionSelectionForAgent } = vi.hoisted(() => ({
+  runIsolatedCompletion:
+    vi.fn<typeof import("../transcripts/summary-model.runtime.js").runIsolatedCompletion>(),
+  resolveSimpleCompletionSelectionForAgent:
+    vi.fn<
+      typeof import("../transcripts/summary-model.runtime.js").resolveSimpleCompletionSelectionForAgent
+    >(),
+}));
+vi.mock("../transcripts/summary-model.runtime.js", () => ({
+  runIsolatedCompletion,
+  resolveSimpleCompletionSelectionForAgent,
+}));
+const tempDirs = createTempDirTracker();
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  tempDirs.cleanup();
+  vi.clearAllMocks();
+});
+
+const session: MeetingSessionRecord = {
+  id: "meeting-summary",
+  url: "https://meeting.example/research",
+  transport: "chrome",
+  mode: "agent",
+  agentId: "research",
+  state: "active",
+  createdAt: "2026-09-02T10:00:00.000Z",
+  updatedAt: "2026-09-02T10:00:00.000Z",
+  participantIdentity: "OpenClaw browser guest",
+  realtime: { enabled: false, toolPolicy: "none" },
+  notes: [],
+};
+const modelNotes = {
+  overview: "The team will publish meeting notes.",
+  decisions: ["Publish the notes"],
+  actionItems: ["Blake: send the announcement"],
+  risks: [],
+};
+
+describe("meeting transcript summary persistence", () => {
+  it.each(["model", "no-model", "failure"] as const)(
+    "saves canonical meeting notes with %s inference",
+    async (mode) => {
+      const stateDir = tempDirs.make("meeting-summary-");
+      const cfg: OpenClawConfig =
+        mode === "no-model"
+          ? { agents: { defaults: { utilityModel: "" } } }
+          : {
+              agents: {
+                defaults: {
+                  model: "openai/gpt-5.6-sol",
+                  utilityModel: "openai/gpt-5.6-sol",
+                },
+                list: [
+                  {
+                    id: "research",
+                    model: "openai/gpt-5.6-sol",
+                    utilityModel: "openai/gpt-5.6-luna",
+                  },
+                ],
+              },
+            };
+      resolveSimpleCompletionSelectionForAgent.mockReset().mockImplementation(({ modelRef }) => {
+        if (!modelRef) {
+          throw new Error("expected configured model reference");
+        }
+        return {
+          provider: "openai",
+          modelId: modelRef.slice("openai/".length),
+          agentDir: stateDir,
+        };
+      });
+      runIsolatedCompletion.mockReset().mockImplementation(async ({ provider, model }) => ({
+        text: JSON.stringify(modelNotes),
+        provider,
+        model,
+        owner: { kind: "harness", id: "meeting-summary-fixture" },
+      }));
+      if (mode === "failure") {
+        runIsolatedCompletion.mockRejectedValue(new Error("inference unavailable"));
+      }
+      const bridge = createMeetingDurableTranscriptBridge({
+        logger: { warn: vi.fn() },
+        options: { cfg, providerId: "meeting", providerName: "Meeting", stateDir },
+      });
+      const store = createTranscriptsStore(stateDir);
+      try {
+        await bridge.start(session, async () => {});
+        await bridge.ingest(session, [{ speaker: "Avery", text: "We agreed to ship the notes." }]);
+        await expect(
+          bridge.stop(session, async () => {
+            await bridge.ingest(session, [
+              { speaker: "Blake", text: "I will send the announcement." },
+            ]);
+          }),
+        ).resolves.toBe(true);
+        closeOpenClawStateDatabaseForTest();
+        const stored = await store.readSession(session.id);
+        if (!stored) {
+          throw new Error("expected durable meeting session");
+        }
+        expect(stored).toMatchObject({
+          metadata: { agentId: "research" },
+          stoppedAt: expect.any(String),
+        });
+        const notes = await store.readSummary(stored);
+        expect(notes.summary).toMatchObject({
+          sessionId: session.id,
+          participants: ["Avery", "Blake"],
+          utteranceCount: 2,
+          transcript: [
+            "Avery: We agreed to ship the notes.",
+            "Blake: I will send the announcement.",
+          ],
+        });
+        expect(notes.markdown).toContain("Blake: I will send the announcement.");
+        if (mode === "model") {
+          expect(notes.summary).toMatchObject({
+            ...modelNotes,
+            source: "model",
+            model: "openai/gpt-5.6-luna",
+          });
+          expect(notes.markdown).toContain(modelNotes.overview);
+          expect(runIsolatedCompletion).toHaveBeenCalledWith(
+            expect.objectContaining({
+              config: cfg,
+              agentId: "research",
+              model: "gpt-5.6-luna",
+            }),
+          );
+        } else {
+          expect(notes.summary).toMatchObject({
+            source: "heuristic",
+            decisions: ["Avery: We agreed to ship the notes."],
+          });
+          expect(notes.summary).not.toHaveProperty("model");
+          if (mode === "no-model") {
+            expect(runIsolatedCompletion).not.toHaveBeenCalled();
+          } else {
+            expect(runIsolatedCompletion).toHaveBeenCalled();
+          }
+        }
+      } finally {
+        await bridge.stop(session, async () => {});
+      }
+    },
+  );
+});

--- a/src/meeting-bot/transcripts-bridge.ts
+++ b/src/meeting-bot/transcripts-bridge.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
   TranscriptSourceProvider,
   TranscriptStartRequest,
@@ -9,6 +10,7 @@ import type { MeetingSessionRecord, MeetingTranscriptLine } from "./session-type
 
 export type MeetingDurableTranscriptsOptions = {
   config?: unknown;
+  cfg?: OpenClawConfig;
   providerId: string;
   providerName: string;
   stateDir?: string;

--- a/src/transcripts/config.ts
+++ b/src/transcripts/config.ts
@@ -1,13 +1,5 @@
-// Resolves transcript source configuration from OpenClaw config.
 import { normalizeOptionalString as readString } from "@openclaw/normalization-core/string-coerce";
 
-/**
- * Configuration normalization for transcript capture/import.
- *
- * Raw config can contain optional auto-start provider locators; resolution
- * returns bounded defaults and drops malformed entries before runtime startup.
- */
-/** Raw auto-start transcript source entry from config. */
 type TranscriptsAutoStartConfig = {
   providerId: string;
   whenOccupied?: boolean;
@@ -19,7 +11,6 @@ type TranscriptsAutoStartConfig = {
   meetingUrl?: string;
 };
 
-/** Normalized auto-start source entry consumed by transcript runtime code. */
 export type ResolvedTranscriptsAutoStartConfig = {
   providerId: string;
   whenOccupied: boolean;
@@ -31,13 +22,11 @@ export type ResolvedTranscriptsAutoStartConfig = {
   meetingUrl?: string;
 };
 
-/** Raw transcripts config block. */
 export type TranscriptsConfig = {
   enabled?: boolean;
   autoStart?: TranscriptsAutoStartConfig[];
 };
 
-/** Resolved transcripts config with defaults applied. */
 type ResolvedTranscriptsConfig = {
   enabled: boolean;
   maxUtterances: number;
@@ -71,7 +60,6 @@ function resolveAutoStart(raw: unknown): ResolvedTranscriptsAutoStartConfig[] {
     .filter((entry): entry is ResolvedTranscriptsAutoStartConfig => entry !== undefined);
 }
 
-/** Normalize raw transcripts config into runtime settings. */
 export function resolveTranscriptsConfig(raw: unknown): ResolvedTranscriptsConfig {
   const config = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
   return {

--- a/src/transcripts/manual-source.ts
+++ b/src/transcripts/manual-source.ts
@@ -1,12 +1,5 @@
-// Provides manual transcript source entries for user-supplied transcript text.
 import type { TranscriptSourceProvider } from "./provider-types.js";
 
-/**
- * Manual transcript import provider.
- *
- * This provider turns pasted text into final transcript utterances, optionally
- * splitting "Speaker: text" prefixes into speaker labels.
- */
 function parseSpeakerLine(line: string): { speakerLabel?: string; text: string } {
   const match = /^([^:\n]{1,80}):\s+(.+)$/.exec(line.trim());
   if (!match) {
@@ -15,7 +8,6 @@ function parseSpeakerLine(line: string): { speakerLabel?: string; text: string }
   return { speakerLabel: match[1]?.trim(), text: match[2]?.trim() ?? "" };
 }
 
-/** Built-in provider for post-hoc transcript text imports. */
 export const manualTranscriptSourceProvider: TranscriptSourceProvider = {
   id: "manual-transcript",
   aliases: ["import", "transcript"],

--- a/src/transcripts/provider-types.ts
+++ b/src/transcripts/provider-types.ts
@@ -1,13 +1,6 @@
-// Transcript provider contracts for external and manual transcript sources.
 import type { Result } from "@openclaw/normalization-core/result";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
-/**
- * Public contracts for transcript source providers.
- *
- * Providers can stream live utterances, import post-hoc transcript text, expose
- * status, and stop active sessions using shared session/source descriptors.
- */
 /** Supported source families for transcript providers. */
 export type TranscriptSourceKind =
   | "live-audio"

--- a/src/transcripts/source-locator.ts
+++ b/src/transcripts/source-locator.ts
@@ -1,6 +1,6 @@
 import type { TranscriptSourceLocator } from "./provider-types.js";
 
-/** Strip invitation credentials from meeting locators before persistence/provider handoff. */
+/** Keep invitation credentials out of persisted and projected meeting locators. */
 export function sanitizeTranscriptSourceLocator(
   source: TranscriptSourceLocator,
 ): TranscriptSourceLocator {

--- a/src/transcripts/store-sqlite.ts
+++ b/src/transcripts/store-sqlite.ts
@@ -12,6 +12,11 @@ import type {
   TranscriptSourceLocator,
   TranscriptUtterance,
 } from "./provider-types.js";
+import {
+  safeTranscriptPathSegment,
+  transcriptSessionExportKey,
+  transcriptSessionSelector,
+} from "./store-artifacts.js";
 import type { TranscriptsSummary } from "./summary.js";
 
 type MeetingTranscriptsDatabase = Pick<
@@ -41,6 +46,92 @@ export function meetingTranscriptSessionQuery(
     .selectFrom("meeting_transcript_sessions")
     .where("session_id", "=", session.sessionId)
     .where("started_at", "=", session.startedAt);
+}
+
+export function writeMeetingTranscriptSession(
+  database: DatabaseSync,
+  session: TranscriptSessionDescriptor,
+  now: number,
+): boolean {
+  // Admission provenance comes from this writer lock, not an earlier filesystem check.
+  const existing = executeSqliteQueryTakeFirstSync(
+    database,
+    meetingTranscriptSessionQuery(database, session).select("session_id"),
+  );
+  const sessionValues = {
+    selector: transcriptSessionSelector(session),
+    export_key: transcriptSessionExportKey(session),
+    session_slug: safeTranscriptPathSegment(session.sessionId),
+    provider_id: session.source.providerId,
+    title: session.title ?? null,
+    source_json: JSON.stringify(session.source),
+    stopped_at: session.stoppedAt ?? null,
+    metadata_json: session.metadata ? JSON.stringify(session.metadata) : null,
+  };
+  executeSqliteQuerySync(
+    database,
+    meetingTranscriptDb(database)
+      .insertInto("meeting_transcript_sessions")
+      .values({
+        session_id: session.sessionId,
+        started_at: session.startedAt,
+        ...sessionValues,
+        export_manifest_json: "{}",
+        export_pending_json: "[]",
+        next_utterance_seq: 0,
+        created_at_ms: now,
+        updated_at_ms: now,
+      })
+      .onConflict((conflict) =>
+        conflict.columns(["session_id", "started_at"]).doUpdateSet({
+          ...sessionValues,
+          updated_at_ms: now,
+        }),
+      ),
+  );
+  return existing === undefined;
+}
+
+export function deleteEmptyMeetingTranscriptCandidate(
+  database: DatabaseSync,
+  session: TranscriptSessionDescriptor,
+): void {
+  const stored = executeSqliteQueryTakeFirstSync(
+    database,
+    meetingTranscriptSessionQuery(database, session).selectAll(),
+  );
+  // Failed-start cleanup cannot consume rewritten history, notes, or exported artifacts.
+  if (
+    !stored ||
+    stored.stopped_at !== (session.stoppedAt ?? null) ||
+    stored.source_json !== JSON.stringify(session.source) ||
+    stored.title !== (session.title ?? null) ||
+    stored.metadata_json !== (session.metadata ? JSON.stringify(session.metadata) : null) ||
+    stored.next_utterance_seq !== 0 ||
+    stored.export_manifest_json !== "{}" ||
+    stored.export_pending_json !== "[]"
+  ) {
+    return;
+  }
+  const db = meetingTranscriptDb(database);
+  executeSqliteQuerySync(
+    database,
+    db
+      .deleteFrom("meeting_transcript_sessions")
+      .where("session_id", "=", session.sessionId)
+      .where("started_at", "=", session.startedAt)
+      .where((eb) =>
+        eb.not(
+          eb.exists(
+            db
+              .selectFrom("meeting_transcript_summaries")
+              .select("session_id")
+              .where("session_id", "=", session.sessionId)
+              .where("session_started_at", "=", session.startedAt),
+          ),
+        ),
+      ),
+  );
 }
 
 export function readTranscriptSummaryInputRevision(

--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -142,7 +142,7 @@ describe("TranscriptsStore", () => {
     const { store } = createStore();
     await store.writeSession(session(".", "2026-07-01T10:00:00.000Z"));
     await store.writeSession(session(".", "2026-07-02T10:00:00.000Z"));
-    await expect(store.writeSession(session(".."))).resolves.toBeUndefined();
+    await store.writeSession(session(".."));
   });
 
   it("matches bare selector slugs literally and case-sensitively", async () => {
@@ -192,7 +192,7 @@ describe("TranscriptsStore", () => {
     const lower = session("capital", "2026-07-01T11:00:00.000Z");
     await store.writeSession(lower);
     await store.materializeSessionArtifacts(lower, "metadata");
-    await expect(store.writeSession(upper)).resolves.toBeUndefined();
+    await store.writeSession(upper);
 
     if (fs.existsSync(store.sessionDir(upper))) {
       await expect(store.materializeSessionArtifacts(lower, "metadata")).resolves.toMatchObject({
@@ -217,7 +217,7 @@ describe("TranscriptsStore", () => {
     const artifacts = await store.materializeSessionArtifacts(upper, "transcript");
     fs.rmSync(artifacts.metadataPath);
 
-    await expect(store.writeSession(lower)).resolves.toBeUndefined();
+    await store.writeSession(lower);
   });
 
   it("does not let a case-distinct SQLite owner mask a legacy directory", async () => {
@@ -251,7 +251,7 @@ describe("TranscriptsStore", () => {
     if (fs.existsSync(path.join(store.sessionDir(lower), "transcript.jsonl"))) {
       await expect(store.writeSession(lower)).rejects.toThrow("run openclaw doctor --fix");
     } else {
-      await expect(store.writeSession(lower)).resolves.toBeUndefined();
+      await store.writeSession(lower);
     }
   });
 
@@ -300,9 +300,7 @@ describe("TranscriptsStore", () => {
     const artifacts = await store.materializeSessionArtifacts(target, "transcript");
     fs.appendFileSync(artifacts.transcriptPath, '{"text":"external edit"}\n');
 
-    await expect(
-      store.writeSession({ ...target, stoppedAt: "2026-07-01T11:00:00.000Z" }),
-    ).resolves.toBeUndefined();
+    await store.writeSession({ ...target, stoppedAt: "2026-07-01T11:00:00.000Z" });
     await expect(store.readSession(target.sessionId)).resolves.toMatchObject({
       stoppedAt: "2026-07-01T11:00:00.000Z",
     });

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -43,6 +43,7 @@ import {
 import { queryTranscriptReadEntries, type TranscriptReadOptions } from "./store-read.js";
 import {
   appendMeetingTranscriptUtterance,
+  deleteEmptyMeetingTranscriptCandidate,
   meetingTranscriptDb,
   meetingTranscriptSessionQuery,
   meetingTranscriptUtteranceQuery,
@@ -52,6 +53,7 @@ import {
   sessionFromRow,
   summaryFromRow,
   utteranceFromRow,
+  writeMeetingTranscriptSession,
 } from "./store-sqlite.js";
 import type * as StoreTypes from "./store-types.js";
 import type { TranscriptsSummary } from "./summary.js";
@@ -84,11 +86,11 @@ export class TranscriptsStore {
     return openOpenClawStateDatabase(this.databaseOptions);
   }
 
-  private transaction(
+  private transaction<T>(
     operationLabel: string,
-    operation: (database: OpenClawStateDatabase) => void,
-  ): void {
-    runOpenClawStateWriteTransaction(operation, this.databaseOptions, { operationLabel });
+    operation: (database: OpenClawStateDatabase) => T,
+  ): T {
+    return runOpenClawStateWriteTransaction(operation, this.databaseOptions, { operationLabel });
   }
 
   sessionDir(session: TranscriptSessionDescriptor): string {
@@ -367,7 +369,7 @@ export class TranscriptsStore {
     ).rows.toReversed();
   }
 
-  async writeSession(session: TranscriptSessionDescriptor): Promise<void> {
+  async writeSession(session: TranscriptSessionDescriptor): Promise<boolean> {
     ensureMeetingTranscriptsSchema(this.databaseOptions);
     if (
       !this.readSessionByIdentity(session) &&
@@ -394,40 +396,16 @@ export class TranscriptsStore {
         }
       }
     }
-    const sessionValues = {
-      selector: transcriptSessionSelector(session),
-      export_key: transcriptSessionExportKey(session),
-      session_slug: safeTranscriptPathSegment(session.sessionId),
-      provider_id: session.source.providerId,
-      title: session.title ?? null,
-      source_json: JSON.stringify(session.source),
-      stopped_at: session.stoppedAt ?? null,
-      metadata_json: session.metadata ? JSON.stringify(session.metadata) : null,
-    };
-    const now = Date.now();
-    this.transaction("meeting-transcripts.session.write", ({ db: database }) => {
-      executeSqliteQuerySync(
-        database,
-        meetingTranscriptDb(database)
-          .insertInto("meeting_transcript_sessions")
-          .values({
-            session_id: session.sessionId,
-            started_at: session.startedAt,
-            ...sessionValues,
-            export_manifest_json: "{}",
-            export_pending_json: "[]",
-            next_utterance_seq: 0,
-            created_at_ms: now,
-            updated_at_ms: now,
-          })
-          .onConflict((conflict) =>
-            conflict.columns(["session_id", "started_at"]).doUpdateSet({
-              ...sessionValues,
-              updated_at_ms: now,
-            }),
-          ),
-      );
-    });
+    return this.transaction("meeting-transcripts.session.write", ({ db }) =>
+      writeMeetingTranscriptSession(db, session, Date.now()),
+    );
+  }
+
+  deleteEmptySessionCandidate(session: TranscriptSessionDescriptor): void {
+    ensureMeetingTranscriptsSchema(this.databaseOptions);
+    this.transaction("meeting-transcripts.session.discard-empty", ({ db }) =>
+      deleteEmptyMeetingTranscriptCandidate(db, session),
+    );
   }
 
   async readSession(sessionSelector: string): Promise<TranscriptSessionDescriptor | undefined> {

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -348,22 +348,15 @@ export class TranscriptsStore {
     return queryTranscriptReadEntries(this.database().db, options);
   }
 
-  readUtteranceEntries(session: TranscriptSessionDescriptor, maxUtterances: number) {
+  readUtteranceEntries(session: TranscriptSessionDescriptor, maxUtterances?: number) {
     const database = this.database();
+    const query = meetingTranscriptUtteranceQuery(database.db, session).selectAll();
+    if (maxUtterances === undefined) {
+      return executeSqliteQuerySync(database.db, query.orderBy("sequence", "asc")).rows;
+    }
     return executeSqliteQuerySync(
       database.db,
-      meetingTranscriptUtteranceQuery(database.db, session)
-        .select([
-          "sequence",
-          "started_at",
-          "ended_at",
-          "speaker_id",
-          "speaker_label",
-          "text",
-          "final",
-        ])
-        .orderBy("sequence", "desc")
-        .limit(maxUtterances),
+      query.orderBy("sequence", "desc").limit(maxUtterances),
     ).rows.toReversed();
   }
 
@@ -514,20 +507,8 @@ export class TranscriptsStore {
     session: TranscriptSessionDescriptor,
     options: { maxUtterances?: number } = {},
   ): Promise<TranscriptUtterance[]> {
-    const database = this.database();
     const maxUtterances = resolveOptionalIntegerOption(options.maxUtterances, { min: 1 });
-    const query = meetingTranscriptUtteranceQuery(database.db, session).selectAll();
-    if (maxUtterances === undefined) {
-      return executeSqliteQuerySync(database.db, query.orderBy("sequence", "asc")).rows.map(
-        utteranceFromRow,
-      );
-    }
-    return executeSqliteQuerySync(
-      database.db,
-      query.orderBy("sequence", "desc").limit(maxUtterances),
-    )
-      .rows.toReversed()
-      .map(utteranceFromRow);
+    return this.readUtteranceEntries(session, maxUtterances).map(utteranceFromRow);
   }
 
   async writeSummary(

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveOptionalIntegerOption } from "@openclaw/normalization-core/number-coercion";
+import { resolveStateDir } from "../config/paths.js";
 import { sha256File, sha256Hex } from "../infra/crypto-digest.js";
 import { ensureAbsoluteDirectory } from "../infra/fs-safe.js";
 import {
@@ -58,6 +59,12 @@ import { renderTranscriptsMarkdown } from "./summary.js";
 
 export type * from "./store-types.js";
 export { safeTranscriptPathSegment, transcriptSessionExportKey, transcriptSessionSelector };
+
+export function createTranscriptsStore(stateDir: string = resolveStateDir()): TranscriptsStore {
+  return new TranscriptsStore(path.join(stateDir, "transcripts"), {
+    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+  });
+}
 
 export class TranscriptsSummaryChangedError extends Error {
   constructor() {

--- a/src/transcripts/summary-persistence.test.ts
+++ b/src/transcripts/summary-persistence.test.ts
@@ -1,0 +1,51 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { resolveTranscriptsConfig } from "./config.js";
+import type { TranscriptSessionDescriptor } from "./provider-types.js";
+import { TranscriptsStore } from "./store.js";
+import { readTranscriptSummary } from "./summary-persistence.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+describe("readTranscriptSummary", () => {
+  it("falls back to heuristic notes when no agent can be resolved for the model", async () => {
+    const stateDir = tempDirs.make("openclaw-transcript-summary-");
+    const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    // Ownerless row (no metadata.agentId) on a multi-agent host with explicit
+    // ownership and no default marker: resolveDefaultAgentId throws for this shape.
+    const session: TranscriptSessionDescriptor = {
+      sessionId: "session-1",
+      source: { providerId: "manual-transcript" },
+      startedAt: "2026-07-01T10:00:00.000Z",
+      stoppedAt: "2026-07-01T10:30:00.000Z",
+      metadata: {},
+    };
+    await store.writeSession(session);
+    await store.appendUtteranceForSession(session, {
+      speaker: { label: "Ada" },
+      text: "We agreed to ship the checklist.",
+      final: true,
+    });
+    const cfg = {
+      agents: { ownership: "explicit", entries: { alpha: {}, beta: {} } },
+    } as OpenClawConfig;
+
+    const summary = await readTranscriptSummary({
+      config: resolveTranscriptsConfig(undefined),
+      cfg,
+      store,
+      session,
+    });
+
+    expect(summary.source).toBe("heuristic");
+    expect(summary.participants).toEqual(["Ada"]);
+    expect(summary.utteranceCount).toBe(1);
+  });
+});

--- a/src/transcripts/summary-persistence.ts
+++ b/src/transcripts/summary-persistence.ts
@@ -1,0 +1,46 @@
+import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { resolveTranscriptsConfig } from "./config.js";
+import type { TranscriptSessionDescriptor } from "./provider-types.js";
+import { TranscriptsSummaryChangedError, type TranscriptsStore } from "./store.js";
+import { summarizeTranscriptsWithModel } from "./summary-model.js";
+import { summarizeTranscripts } from "./summary.js";
+
+export async function readTranscriptSummary(params: {
+  config: ReturnType<typeof resolveTranscriptsConfig>;
+  cfg?: OpenClawConfig;
+  store: TranscriptsStore;
+  session: TranscriptSessionDescriptor;
+}) {
+  const utterances = await params.store.readUtterancesForSession(params.session, {
+    maxUtterances: params.config.maxUtterances,
+  });
+  const agentId = params.session.metadata?.agentId;
+  if (params.cfg) {
+    const modeled = await summarizeTranscriptsWithModel({
+      cfg: params.cfg,
+      agentId:
+        typeof agentId === "string" && agentId.trim() ? agentId : resolveDefaultAgentId(params.cfg),
+      session: params.session,
+      utterances,
+    });
+    if (modeled) {
+      return modeled;
+    }
+  }
+  // Heuristic notes are the deterministic base; model inference is an enhancement
+  // so an unavailable model never loses the captured meeting notes.
+  return summarizeTranscripts({ session: params.session, utterances });
+}
+
+export async function persistTranscriptSummary(
+  params: Parameters<typeof readTranscriptSummary>[0],
+) {
+  const revision = params.store.readSummaryInputRevision(params.session);
+  if (revision === undefined) {
+    throw new TranscriptsSummaryChangedError();
+  }
+  const summary = await readTranscriptSummary(params);
+  const intendedSummaryPath = await params.store.writeSummary(summary, params.session, revision);
+  return { summary, intendedSummaryPath };
+}

--- a/src/transcripts/summary-persistence.ts
+++ b/src/transcripts/summary-persistence.ts
@@ -17,15 +17,22 @@ export async function readTranscriptSummary(params: {
   });
   const agentId = params.session.metadata?.agentId;
   if (params.cfg) {
-    const modeled = await summarizeTranscriptsWithModel({
-      cfg: params.cfg,
-      agentId:
-        typeof agentId === "string" && agentId.trim() ? agentId : resolveDefaultAgentId(params.cfg),
-      session: params.session,
-      utterances,
-    });
-    if (modeled) {
-      return modeled;
+    try {
+      const modeled = await summarizeTranscriptsWithModel({
+        cfg: params.cfg,
+        agentId:
+          typeof agentId === "string" && agentId.trim()
+            ? agentId
+            : resolveDefaultAgentId(params.cfg),
+        session: params.session,
+        utterances,
+      });
+      if (modeled) {
+        return modeled;
+      }
+    } catch {
+      // Ownerless rows on a multi-agent host cannot select a model
+      // (resolveDefaultAgentId throws); they still get notes.
     }
   }
   // Heuristic notes are the deterministic base; model inference is an enhancement

--- a/src/transcripts/summary.ts
+++ b/src/transcripts/summary.ts
@@ -1,4 +1,3 @@
-// Builds transcript summaries and normalized transcript metadata.
 import {
   normalizeStringEntries,
   normalizeUniqueStringEntries,
@@ -6,13 +5,6 @@ import {
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import type { TranscriptSessionDescriptor, TranscriptUtterance } from "./provider-types.js";
 
-/**
- * Lightweight transcript summarization and markdown rendering.
- *
- * This is a deterministic heuristic summary used for captured/imported
- * transcripts when no model-backed summarizer is involved.
- */
-/** Summary artifact written alongside transcript sessions. */
 export type TranscriptsSummary = {
   sessionId: string;
   title: string;
@@ -71,10 +63,6 @@ function formatSpeakerLine(utterance: TranscriptUtterance): string {
   return speaker ? `${speaker}: ${text}` : text;
 }
 
-function formatTranscript(utterances: TranscriptUtterance[]): string[] {
-  return utterances.map(formatSpeakerLine).filter(Boolean);
-}
-
 /** Build a deterministic summary from transcript utterances. */
 export function summarizeTranscripts(params: {
   session: TranscriptSessionDescriptor;
@@ -92,7 +80,7 @@ export function summarizeTranscripts(params: {
       utterances.map((utterance) => utterance.speaker?.label ?? ""),
     ),
     source: "heuristic",
-    transcript: formatTranscript(utterances),
+    transcript: utterances.map(formatSpeakerLine).filter(Boolean),
     decisions: collectMatches(utterances, DECISION_PATTERNS),
     actionItems: collectMatches(utterances, ACTION_PATTERNS),
     risks: collectMatches(utterances, RISK_PATTERNS),

--- a/test/transcripts-tool.discord-provider.integration.test.ts
+++ b/test/transcripts-tool.discord-provider.integration.test.ts
@@ -27,7 +27,6 @@ const resolveAccessTarget = async (guildId: string, channelId: string) => ({
 });
 
 function createTool(params: {
-  accountId: string;
   caller:
     | { kind: "operator"; source: "channel-owner" | "local" | "scheduled" }
     | {
@@ -43,8 +42,6 @@ function createTool(params: {
 }) {
   return createTranscriptsTool({
     agentId: "main",
-    agentAccountId: params.accountId,
-    agentChannel: "discord",
     caller: params.caller,
     config: params.config,
     stateDir: params.stateDir,
@@ -117,7 +114,6 @@ describe("transcripts tool with the registered Discord provider", () => {
       transcripts: { enabled: true },
     } satisfies OpenClawConfig;
     const ownerTool = createTool({
-      accountId: "account-a",
       caller: {
         kind: "channel",
         channel: "discord",
@@ -130,7 +126,6 @@ describe("transcripts tool with the registered Discord provider", () => {
       stateDir,
     });
     const otherAccountTool = createTool({
-      accountId: "account-b",
       caller: {
         kind: "channel",
         channel: "discord",
@@ -143,7 +138,6 @@ describe("transcripts tool with the registered Discord provider", () => {
       stateDir,
     });
     const deniedSameAccountTool = createTool({
-      accountId: "account-a",
       caller: {
         kind: "channel",
         channel: "discord",
@@ -239,7 +233,6 @@ describe("transcripts tool with the registered Discord provider", () => {
       transcripts: { enabled: true },
     } satisfies OpenClawConfig;
     const deniedTool = createTool({
-      accountId: "account-a",
       caller: {
         kind: "channel",
         channel: "discord",

--- a/ui/src/e2e/meetings.e2e.test.ts
+++ b/ui/src/e2e/meetings.e2e.test.ts
@@ -95,6 +95,10 @@ suite.define(() => {
           await view.getByText("Ada: prepare the revised prototype.", { exact: true }).isVisible(),
         ).toBe(true);
         expect.soft(await view.locator("details").count()).toBe(0);
+        expect(await view.getByRole("heading", { name: "Participants", exact: true }).count()).toBe(
+          1,
+        );
+        expect.soft(await view.getByText("Participants:", { exact: true }).count()).toBe(0);
         expect(await view.getByRole("heading", { name: "Transcript", exact: true }).count()).toBe(
           1,
         );

--- a/ui/src/pages/meetings/meetings-page.ts
+++ b/ui/src/pages/meetings/meetings-page.ts
@@ -225,12 +225,6 @@ class MeetingsPage extends OpenClawLightDomElement {
                 ? html`<span class="meetings-live">${t("meetings.inProgress")}</span>`
                 : nothing}
             </div>
-            ${detail.summary?.participants.length
-              ? html`<p>
-                  <strong>${t("meetings.participants")}:</strong>
-                  ${detail.summary.participants.join(", ")}
-                </p>`
-              : nothing}
             ${detail.summary
               ? html`<div class="meetings-notes markdown">
                   ${unsafeHTML(toSanitizedMarkdownHtml(detail.summary.markdown))}


### PR DESCRIPTION
## What Problem This Solves

A full review and deslop pass over the transcripts domain (durable meeting transcripts, notes, occupancy capture, tool and RPC reads, the Meetings page, and the Discord and browser-meeting providers) after #136679 landed. The pass read the whole domain, not only the recent diff, and found real defects alongside the expected cleanup:

- Code Mode callers of the `transcripts` tool's `show` action received metadata but no notes, because the notes lived only in rendered content while Code Mode reads structured details.
- A continuous auto-start capture could lose shutdown cleanup ownership when provider startup accepted the capture but a later abort cleanup failed; the operator recovery path disappeared with it.
- A Discord account restart replaced the voice manager and silently orphaned the Gateway-owned occupancy subscription, so occupancy capture never resumed until the Gateway restarted.
- `show` could authorize one durable descriptor and then return notes from a same-tuple rewritten row after the awaited read.
- Browser meeting captures (Google Meet, Teams, Zoom) got heuristic-only notes because the meeting-bot bridge bypassed the model-aware summary owner.
- A start that exhausted its retries left an empty stopped session row behind, visible on the Meetings page.
- The Meetings detail pane printed participants twice.

## Why This Change Was Made

Each defect is fixed at its owner with a regression test that fails before the fix. The structure findings collapse duplicate policy: one `createTranscriptsStore` owner replaces five ad-hoc store constructions (tool runtime, RPC, CLI, auto-start, meeting bridge); the RPC no longer fabricates a runtime context to look up a provider name; the two ordered-tail utterance readers share one implementation; the tool runtime drops caller-context copies that duplicated the authoritative `caller`; ownership helpers return locators directly instead of a one-field wrapper. The deslop commit removes narration comments, a redundant error catch around an already-contained model call, a one-use formatter, and an incorrect sanitization comment, with zero behavior change.

Non-goals: no config, SQLite schema, protocol, or public SDK export changes; no dependency changes. Items left on record as notes rather than changes: long-meeting sampling (the 2,000-utterance tail is selected before the model's 48k-character head/tail window), converting the occupancy closure state machine into an explicit episode object (no proven simplification yet), and the sanitization boundary for pre-existing custom markdown.

## User Impact

Agents using Code Mode can now read meeting notes through `show`; occupancy capture survives Discord account restarts; Meet, Teams, and Zoom meetings get the same model-backed notes as Discord captures; failed starts no longer leave empty meetings in the list; shutdown always retains the exact capture it owns. Nothing changes for operators' configuration.

## Evidence

Review method: the whole transcripts domain (34 production files, about 6,000 lines, plus colocated tests and callers) was read completely before any edit; findings are ranked in a report with file:line evidence, and every BUG fix has a regression test that was run red before the fix and green after.

Local proof on the branch (`OPENCLAW_VITEST_MAX_WORKERS=2`):

- Focused Vitest across the domain: 43 files, 435 tests passed (`src/transcripts`, `src/agents/tools/transcripts-*`, `src/gateway/server-methods/transcripts`, `src/meeting-bot`, `src/cli/program/register.transcripts`, `extensions/discord/src/voice/transcripts-source` and `voice-occupancy`, protocol schema). New regression coverage: Code Mode `show` details, cleanup ownership after failed and late startup, Discord manager replacement re-binding occupancy, durable re-validation after an awaited read, browser-bridge summaries with and without a model, failed-start row cleanup (continuous, occupancy, and reopened cases).
- Meetings e2e: 2 tests passed; the only UI change removes the duplicated participants line, screenshots inspected in both themes.
- `node scripts/check-changed.mjs` exit 0; `pnpm plugin-sdk:surface:check` exit 0 (the only SDK-visible change is an optional `cfg` field on `MeetingDurableTranscriptsOptions`).
- LOC against the branch base: production +420/−344 (net +76, of which the deslop and structure commits are net −79 and the fixes carry the growth), tests +640/−25, docs +5.
- Autoreview (Codex, branch mode at P2): two findings. One confirmed and fixed with a regression test: the deslop had removed the catch around the model summary attempt, and `resolveDefaultAgentId` throws for ownerless rows on hosts with explicit agent ownership, which would have failed notes persistence instead of falling back to heuristic notes. One rejected with evidence: the "lost cleanup ownership" report misread `forgetCapture`, which only forgets captures the runtime no longer owns; retained captures stay in the shutdown cleanup set (now stated in an invariant comment).
