### PR TITLE
perf: avoid discarded Code Mode namespace runtimes

### DIFF
--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -621,6 +621,7 @@ describe("Code Mode catalog and model-visible surface", () => {
         pluginTool("llm-task", "Run an LLM task"),
         pluginTool("llm_task", "Run the exact-name task"),
         pluginTool("catalog", "Collide with discovery"),
+        pluginTool("MCP", "Collide with the namespace global"),
         pluginTool("class", "Use a reserved word"),
         pluginTool("9patch", "Start with a digit"),
       ],
@@ -636,6 +637,7 @@ describe("Code Mode catalog and model-visible surface", () => {
     expect(description).toContain("- llm_task ");
     expect(description).toMatch(/- llm_task_[a-f0-9]{8} /u);
     expect(description).toMatch(/- catalog_[a-f0-9]{8} /u);
+    expect(description).toMatch(/- MCP_[a-f0-9]{8} /u);
     expect(description).toMatch(/- class_[a-f0-9]{8} /u);
     expect(description).toContain("- tool_9patch ");
     expect(description).not.toContain("openclaw:fake-code-mode");

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -20,10 +20,7 @@ import {
 } from "./code-mode-control-tools.js";
 import { runCodeModeExec, runWait } from "./code-mode-execution.js";
 import { runCodeModeScriptHeadless } from "./code-mode-headless.js";
-import {
-  createCodeModeNamespaceRuntime,
-  describeCodeModeNamespacesForPrompt,
-} from "./code-mode-namespaces.js";
+import { describeCodeModeNamespacesForPrompt } from "./code-mode-namespaces.js";
 import { markCodeModePermissionChangeResult } from "./code-mode-repair-provenance.js";
 import {
   isCodeModeEngagedForModel,
@@ -168,15 +165,9 @@ function createCodeModeExecDescription(
     ? " Skills are available through the async `skills` global: use `await skills.list()` and `await skills.read(name)`."
     : "";
   const { maxOutputBytes } = config;
+  // The catalog already reserves built-in namespace globals without constructing their runtimes.
   const projection = catalog
-    ? createCodeModeCatalogProjection(
-        catalog.map((entry) => compactToolSearchCatalogEntry(entry)),
-        {
-          reservedNames: createCodeModeNamespaceRuntime(catalog).descriptors.map(
-            (descriptor) => descriptor.globalName,
-          ),
-        },
-      )
+    ? createCodeModeCatalogProjection(catalog.map((entry) => compactToolSearchCatalogEntry(entry)))
     : undefined;
   const catalogIndex = projection ? formatCodeModeCatalogIndex(projection.bindings) : "";
   return (


### PR DESCRIPTION
## What Problem This Solves

Building the interactive Code Mode description constructed a complete MCP namespace runtime only to extract a reserved global name. Its descriptors, callable paths and virtual API files were then discarded.

## Why This Change Was Made

The canonical catalog projection already reserves built-in globals, including MCP. The description now uses that existing owner directly. Actual execution still constructs its runtime, and headless callers retain custom namespace reservations.

## User Impact

Prompt text, callable naming and tool schemas are unchanged; catalog refreshes do less work. Production −9 LOC; the existing naming test gains two lines covering an MCP collision.

## Evidence

- Eight fixed actual-owner scenarios produced ten byte-identical description/catalog/schema observations, covering empty and large catalogs, MCP, built-in collisions, nodes, client append and restriction.
- Separate precise-coverage runs: discarded namespace runtime constructions 10 → 0, MCP model construction 20 → 10, descriptor recursion visits 182 → 0. No physical heap-size claim is inferred from operation counts.
- One uninstrumented whole-process pair took 3.41 s → 2.89 s, while peak RSS increased 1.58 MiB. This does not establish a general speed or whole-Gateway memory improvement.
- The three owner/MCP/namespace suites pass 51 tests; three selected existing headless custom-namespace/trigger cases also pass. Canonical changed-file checks pass.
- Source-embedded managed Codex review through P2 found no actionable finding.
