### PR TITLE
fix(release): verify target-declared worker artifacts

### DIFF
--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -297,8 +297,10 @@ on pinned current `main` as the exact command and validation contract.
    tag checkout and accepts canonical-branch, current-main, or trusted-pinned
    validation evidence; the prepared tarball and every evidence identity must
    still match the candidate SHA.
-8. From a clean current-`main` checkout, run
-   `node --import tsx scripts/openclaw-npm-postpublish-verify.ts YYYY.M.P`.
+8. Let `<validated-frozen-target-root>` be the absolute path to the checkout
+   whose `HEAD` was already proven equal to the immutable release candidate SHA.
+   From a clean current-`main` checkout, run
+   `node --import tsx scripts/openclaw-npm-postpublish-verify.ts YYYY.M.P <validated-frozen-target-root>`.
    Verify signatures, provenance, inventories, exact versions, and selectors.
    Use the generated repair only for the root selector; repair other selectors
    with approved credential-isolated tooling. Never republish a version.
@@ -748,7 +750,7 @@ For a non-root smoke path:
 After npm publish, run:
 
 ```bash
-node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>
+node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version> <validated-frozen-target-root>
 ```
 
 - This verifies the published registry install path in a fresh temp prefix.
@@ -822,7 +824,7 @@ node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>
     blocking performance. Native artifact publication retains its own build,
     signing, notarization, and promotion gates.
 - Post-published beta verification roster:
-  - `node --import tsx scripts/openclaw-npm-postpublish-verify.ts <beta-version>`
+  - `node --import tsx scripts/openclaw-npm-postpublish-verify.ts <beta-version> <validated-frozen-target-root>`
   - install/update smoke against the published beta channel
   - Docker install/update coverage that exercises the published beta package
   - published npm Telegram proof: dispatch Actions > `NPM Telegram Beta E2E`
@@ -1151,7 +1153,7 @@ node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>
     Android approval/build/publication remains independent. Report app failures
     and recover only the failed platform. For a failed required publish stage,
     keep immutable child evidence and use the standalone recovery probe:
-    `node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>`.
+    `node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version> <validated-frozen-target-root>`.
     For a failed parent after successful children, run
     `pnpm release:verify-beta -- <published-version> ... --skip-github-release`
     with the original child run IDs and an evidence output path before restoring

--- a/.agents/skills/verify-release/SKILL.md
+++ b/.agents/skills/verify-release/SKILL.md
@@ -93,9 +93,11 @@ registry, provenance, and image state directly.
    `publishToNpm === true` official plugin derived from the tag. Compare the
    plugin plan, jobs, and complete readback; never infer inventory from diffs.
 4. **Provenance:** from trusted current tooling, run
-   `node --import tsx scripts/openclaw-npm-postpublish-verify.ts <VERSION>`.
+   `node --import tsx scripts/openclaw-npm-postpublish-verify.ts <VERSION>
+<validated-target-root>`.
    Require signatures, canonical-branch provenance, and publish/preflight
-   digest binding to the release SHA. Preserve output and workflow URLs.
+   digest binding to the release SHA. The target root supplies the exact worker
+   artifact declaration contract. Preserve output and workflow URLs.
 5. **Docker:** verify exact default, slim, browser, and architecture images and
    attestations in both registries. Only the three `extended-stable*` aliases may
    resolve to those digests. Repair aliases through current-main `Docker Channel

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -170,7 +170,7 @@ approval, or readback checks. Never use it for production.
 From a separate clean current-`main` checkout, not the frozen branch, run:
 
 ```bash
-node --import tsx scripts/openclaw-npm-postpublish-verify.ts YYYY.M.P
+node --import tsx scripts/openclaw-npm-postpublish-verify.ts YYYY.M.P <validated-target-root>
 npm view openclaw@YYYY.M.P version --userconfig "$(mktemp)"
 npm view openclaw@extended-stable version --userconfig "$(mktemp)"
 ```
@@ -355,7 +355,7 @@ For correction artifact preparation, validate the immutable SHA with `--target-r
 - Before tagging a release candidate locally, run `RELEASE_TAG=vYYYY.M.PATCH-beta.N pnpm release:fast-pretag-check`. The helper runs the fast release guardrails, plugin npm/ClawHub release checks, build, UI build, and `release:openclaw:npm:check` in the order that catches common approval-blocking mistakes before the GitHub publish workflow starts.
 - Plugin `openclaw.release.requireLatestDependencies` declarations remain release metadata, but npm `latest` drift is advisory. Checks warn with the plugin, dependency, pinned version, and current latest version; a failed latest lookup also warns and does not establish that the pin is unusable. Full Release Validation's Codex lanes validate the `@openclaw/codex` harness pin. Keep that frozen, tested pin when upstream publishes a newer version. Missing or malformed required runtime dependency metadata, package/install failures, and failed required validation lanes still block release.
 - Run `RELEASE_TAG=vYYYY.M.PATCH node --import tsx scripts/openclaw-npm-release-check.ts` (or the matching prerelease/correction tag) before approval.
-- After npm publish, run `node --import tsx scripts/openclaw-npm-postpublish-verify.ts YYYY.M.PATCH` (or the matching beta/correction version) to verify the published registry install path in a fresh temp prefix.
+- After npm publish, run `node --import tsx scripts/openclaw-npm-postpublish-verify.ts YYYY.M.PATCH <validated-target-root>` (or the matching beta/correction version) to verify the target-declared worker artifacts and published registry install path in a fresh temp prefix.
 - After a beta publish, run `OPENCLAW_NPM_TELEGRAM_PACKAGE_SPEC=openclaw@YYYY.M.PATCH-beta.N OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE=maintainer pnpm test:docker:npm-telegram-live` with `OPENCLAW_QA_CONVEX_SITE_URL` and `OPENCLAW_QA_CONVEX_SECRET_MAINTAINER` set. This verifies installed-package onboarding, Telegram setup, and real Telegram E2E against the published npm package using the shared Test Server userbot pool. CI uses the `ci` role and `OPENCLAW_QA_CONVEX_SECRET_CI` instead.
 - To run the full post-publish beta smoke from a maintainer machine, use `pnpm release:beta-smoke -- --beta betaN`. The helper runs Parallels npm update/fresh-target validation, dispatches `NPM Telegram Beta E2E`, polls the exact workflow run, downloads the artifact, and prints the Telegram report.
 - Maintainers can run the same post-publish check from GitHub Actions via the manual `NPM Telegram Beta E2E` workflow. It is intentionally manual-only and does not run on every merge.

--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -1334,7 +1334,7 @@ export async function verifyBetaRelease(
       rootDir,
       args.postpublishVerifier,
     );
-    execFileSync("node", ["--import", "tsx", postpublishVerifier, args.version], {
+    execFileSync("node", ["--import", "tsx", postpublishVerifier, args.version, rootDir], {
       stdio: "inherit",
     });
     lines.push("openclaw postpublish verifier OK");

--- a/scripts/lib/worker-deploy-target-contract.mts
+++ b/scripts/lib/worker-deploy-target-contract.mts
@@ -1,0 +1,43 @@
+import { lstatSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+
+const ARTIFACT_NAME = /^WORKER_BUNDLE_[A-Z0-9_]+_PATH$/u;
+const SAFE_BASENAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
+
+export function readWorkerDeployTargetPaths(targetRoot: string): string[] {
+  const sourcePath = join(targetRoot, "src/shared/worker-bundle-hash.ts");
+  const sourceStat = lstatSync(sourcePath);
+  if (!sourceStat.isFile() || sourceStat.size > 64 * 1024) {
+    throw new Error("Target worker artifact declarations are invalid.");
+  }
+  const sourceText = readFileSync(sourcePath, "utf8");
+  const source = ts.createSourceFile(sourcePath, sourceText, ts.ScriptTarget.Latest);
+  const artifacts: Array<[string, string]> = [];
+  for (const statement of source.statements.filter(ts.isVariableStatement)) {
+    if (statement.modifiers?.some(({ kind }) => kind === ts.SyntaxKind.ExportKeyword)) {
+      for (const declaration of statement.declarationList.declarations) {
+        const name = ts.isIdentifier(declaration.name) ? declaration.name.text : "";
+        if (ARTIFACT_NAME.test(name)) {
+          const artifact =
+            declaration.initializer && ts.isStringLiteral(declaration.initializer)
+              ? declaration.initializer.text
+              : null;
+          if (
+            !(statement.declarationList.flags & ts.NodeFlags.Const) ||
+            artifact === null ||
+            !SAFE_BASENAME.test(artifact) ||
+            artifacts.some(([declaredName, path]) => declaredName === name || path === artifact)
+          ) {
+            throw new Error(`Target worker artifact declaration is invalid: ${name}.`);
+          }
+          artifacts.push([name, artifact]);
+        }
+      }
+    }
+  }
+  if (artifacts.length < 2 || artifacts.length > 16) {
+    throw new Error("Target worker artifact count must be between 2 and 16.");
+  }
+  return artifacts.map(([, path]) => `dist/worker/${path}`).toSorted();
+}

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -19,10 +19,6 @@ import { pathToFileURL } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { ALWAYS_ALLOWED_RUNTIME_DIR_NAMES } from "../src/plugin-sdk/facade-activation-contract.ts";
 import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../src/plugins/runtime-sidecar-paths.ts";
-import {
-  WORKER_BUNDLE_ENTRY_PATH,
-  WORKER_BUNDLE_RSYNC_RECEIVER_PATH,
-} from "../src/shared/worker-bundle-hash.js";
 import { readBoundedResponseText } from "./lib/bounded-response.mjs";
 import { listBundledPluginPackArtifacts } from "./lib/bundled-plugin-build-entries.mjs";
 import { formatErrorMessage } from "./lib/error-format.mts";
@@ -36,6 +32,7 @@ import {
   packageNameFromSpecifier,
 } from "./lib/plugin-package-dependencies.mts";
 import { classifyReleaseTrain } from "./lib/release-version.mjs";
+import { readWorkerDeployTargetPaths } from "./lib/worker-deploy-target-contract.mts";
 import { runInstalledWorkspaceBootstrapSmoke } from "./lib/workspace-bootstrap-smoke.mts";
 import { parseReleaseVersion, resolveNpmCommandInvocation } from "./openclaw-npm-release-check.ts";
 import { buildCmdExeCommandLine, resolveWindowsCmdExePath } from "./windows-cmd-helpers.mjs";
@@ -77,11 +74,6 @@ const MAX_INSTALLED_WORKER_DEPLOY_DIST_JS_BYTES = 80 * 1024 * 1024;
 // Keep the dependency scan bounded while allowing headroom for generated root chunks.
 const MAX_INSTALLED_ROOT_DIST_JS_FILES = 10_000;
 const ROOT_DIST_JAVASCRIPT_MODULE_FILE_RE = /\.(?:c|m)?js$/u;
-// The ~69 MB self-contained worker needs extra headroom, but synchronous read/parse stays bounded.
-const SELF_CONTAINED_WORKER_DEPLOY_DIST_PATHS = new Set([
-  `worker/${WORKER_BUNDLE_ENTRY_PATH}`,
-  `worker/${WORKER_BUNDLE_RSYNC_RECEIVER_PATH}`,
-]);
 const OPTIONAL_OR_EXTERNALIZED_RUNTIME_IMPORTS = new Set([
   // Optional A2UI markdown renderer. The Canvas host bundle catches the missing
   // package and falls back when the optional renderer is unavailable.
@@ -122,6 +114,7 @@ type PublishedInstallScenario = {
 type OpenClawNpmPostpublishVerifyArgs =
   | {
       help: false;
+      targetRoot: string;
       version: string;
     }
   | {
@@ -130,7 +123,7 @@ type OpenClawNpmPostpublishVerifyArgs =
     };
 
 export function openClawNpmPostpublishVerifyUsage(): string {
-  return "Usage: node --import tsx scripts/openclaw-npm-postpublish-verify.ts <version>";
+  return "Usage: node --import tsx scripts/openclaw-npm-postpublish-verify.ts <version> [target-root]";
 }
 
 export function parseOpenClawNpmPostpublishVerifyArgs(
@@ -147,11 +140,13 @@ export function parseOpenClawNpmPostpublishVerifyArgs(
   if (version.startsWith("-")) {
     throw new Error(`Unknown openclaw npm postpublish verifier option: ${version}`);
   }
-  const extraArg = args[1]?.trim();
+  const targetArg = args[1]?.trim() || ".";
+  const targetRoot = isAbsolute(targetArg) ? targetArg : join(process.cwd(), targetArg);
+  const extraArg = args[2]?.trim();
   if (extraArg) {
     throw new Error(`Unexpected openclaw npm postpublish verifier argument: ${extraArg}`);
   }
-  return { help: false, version };
+  return { help: false, targetRoot, version };
 }
 
 export function buildPublishedInstallScenarios(version: string): PublishedInstallScenario[] {
@@ -460,9 +455,11 @@ export function collectInstalledPackageErrors(params: {
   expectedVersion: string;
   installedVersion: string;
   packageRoot: string;
+  workerDeployPaths: readonly string[];
 }): string[] {
   const errors: string[] = [];
   const installedVersion = normalizeInstalledBinaryVersion(params.installedVersion);
+  const workerDistPaths = new Set(params.workerDeployPaths.map((path) => path.slice(5)));
 
   if (installedVersion !== params.expectedVersion) {
     errors.push(
@@ -475,12 +472,20 @@ export function collectInstalledPackageErrors(params: {
       errors.push(`installed package is missing required bundled runtime sidecar: ${relativePath}`);
     }
   }
+  for (const relativePath of params.workerDeployPaths) {
+    const artifactPath = join(params.packageRoot, relativePath);
+    const artifactStat = existsSync(artifactPath) ? lstatSync(artifactPath) : null;
+    if (!artifactStat?.isFile()) {
+      const problem = artifactStat ? "not a regular file" : "missing";
+      errors.push(`installed package worker deploy artifact is ${problem}: ${relativePath}.`);
+    }
+  }
 
   errors.push(...collectInstalledBundledExtensionManifestErrors(params.packageRoot));
   errors.push(...collectInstalledAlwaysAllowedRuntimeFacadeErrors(params.packageRoot));
-  errors.push(...collectInstalledContextEngineRuntimeErrors(params.packageRoot));
+  errors.push(...collectInstalledContextEngineRuntimeErrors(params.packageRoot, workerDistPaths));
   errors.push(...collectInstalledPluginSdkDeclarationErrors(params.packageRoot));
-  errors.push(...collectInstalledRootDependencyManifestErrors(params.packageRoot));
+  errors.push(...collectInstalledRootDependencyManifestErrors(params.packageRoot, workerDistPaths));
 
   return [...new Set(errors)];
 }
@@ -598,9 +603,10 @@ function formatInstalledDistFileScanLimitError(scope: string, limit: number): st
 function readInstalledRootDistJavaScriptFile(
   packageRoot: string,
   filePath: string,
+  workerDistPaths: ReadonlySet<string>,
 ): InstalledRootDistJavaScriptReadResult {
   const relativePath = relative(join(packageRoot, "dist"), filePath).replaceAll("\\", "/");
-  const maxBytes = SELF_CONTAINED_WORKER_DEPLOY_DIST_PATHS.has(relativePath)
+  const maxBytes = workerDistPaths.has(relativePath)
     ? MAX_INSTALLED_WORKER_DEPLOY_DIST_JS_BYTES
     : MAX_INSTALLED_ROOT_DIST_JS_BYTES;
   const fileStat = lstatSync(filePath);
@@ -613,7 +619,10 @@ function readInstalledRootDistJavaScriptFile(
   return { ok: true, relativePath, source: readFileSync(filePath, "utf8") };
 }
 
-export function collectInstalledContextEngineRuntimeErrors(packageRoot: string): string[] {
+export function collectInstalledContextEngineRuntimeErrors(
+  packageRoot: string,
+  workerDistPaths: ReadonlySet<string> = new Set(),
+): string[] {
   const distFiles = listInstalledRootDistJavaScriptFiles(packageRoot);
   if (distFiles.limitExceeded) {
     return [formatInstalledDistFileScanLimitError("root dist", distFiles.limit)];
@@ -621,7 +630,7 @@ export function collectInstalledContextEngineRuntimeErrors(packageRoot: string):
 
   // The legacy marker is a root runtime bundling contract; extension assets are plugin-owned.
   for (const filePath of distFiles.files) {
-    const file = readInstalledRootDistJavaScriptFile(packageRoot, filePath);
+    const file = readInstalledRootDistJavaScriptFile(packageRoot, filePath, workerDistPaths);
     if (!file.ok) {
       return [file.error];
     }
@@ -739,7 +748,10 @@ function extractJavaScriptImportSpecifiers(source: string): ParsedImportSpecifie
   return { ok: true, specifiers };
 }
 
-export function collectInstalledRootDependencyManifestErrors(packageRoot: string): string[] {
+export function collectInstalledRootDependencyManifestErrors(
+  packageRoot: string,
+  workerDistPaths: ReadonlySet<string> = new Set(),
+): string[] {
   const packageJsonPath = join(packageRoot, "package.json");
   if (!existsSync(packageJsonPath)) {
     return ["installed package is missing package.json."];
@@ -769,7 +781,7 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
     collectBundledExtensionRuntimeDependencyOwners(packageRoot);
 
   for (const filePath of distFiles.files) {
-    const file = readInstalledRootDistJavaScriptFile(packageRoot, filePath);
+    const file = readInstalledRootDistJavaScriptFile(packageRoot, filePath, workerDistPaths);
     if (!file.ok) {
       return [file.error];
     }
@@ -1168,9 +1180,10 @@ function readInstalledBinaryVersion(prefixDir: string, cwd: string): string {
   return runNpmVerifyCommand(invocation, cwd);
 }
 
-function verifyScenario(version: string, scenario: PublishedInstallScenario): void {
+function verifyScenario(scenario: PublishedInstallScenario, paths: readonly string[]): void {
   const workingDir = mkdtempSync(join(tmpdir(), `openclaw-postpublish-${scenario.name}.`));
   const prefixDir = join(workingDir, "prefix");
+  const { expectedVersion } = scenario;
 
   try {
     for (const spec of scenario.installSpecs) {
@@ -1183,15 +1196,16 @@ function verifyScenario(version: string, scenario: PublishedInstallScenario): vo
       readFileSync(join(packageRoot, "package.json"), "utf8"),
     ) as InstalledPackageJson;
     const errors = collectInstalledPackageErrors({
-      expectedVersion: scenario.expectedVersion,
+      expectedVersion,
       installedVersion: pkg.version?.trim() ?? "",
       packageRoot,
+      workerDeployPaths: paths,
     });
     const installedBinaryVersion = readInstalledBinaryVersion(prefixDir, workingDir);
 
-    if (normalizeInstalledBinaryVersion(installedBinaryVersion) !== scenario.expectedVersion) {
+    if (normalizeInstalledBinaryVersion(installedBinaryVersion) !== expectedVersion) {
       errors.push(
-        `installed openclaw binary version mismatch: expected ${scenario.expectedVersion}, found ${installedBinaryVersion || "<missing>"}.`,
+        `installed openclaw binary version mismatch: expected ${expectedVersion}, found ${installedBinaryVersion || "<missing>"}.`,
       );
     }
 
@@ -1203,7 +1217,7 @@ function verifyScenario(version: string, scenario: PublishedInstallScenario): vo
       throw new Error(`${scenario.name} failed:\n- ${errors.join("\n- ")}`);
     }
 
-    console.log(`openclaw-npm-postpublish-verify: ${scenario.name} OK (${version})`);
+    console.log(`openclaw-npm-postpublish-verify: ${scenario.name} OK (${expectedVersion})`);
   } finally {
     rmSync(workingDir, { force: true, recursive: true });
   }
@@ -1216,11 +1230,12 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     return;
   }
 
-  const { version } = args;
+  const { targetRoot, version } = args;
+  const workerDeployPaths = readWorkerDeployTargetPaths(targetRoot);
   const scenarios = buildPublishedInstallScenarios(version);
   await verifyPublishedRegistryProvenance(version);
   for (const scenario of scenarios) {
-    verifyScenario(version, scenario);
+    verifyScenario(scenario, workerDeployPaths);
   }
 
   console.log(

--- a/scripts/openclaw-npm-prepublish-verify.ts
+++ b/scripts/openclaw-npm-prepublish-verify.ts
@@ -4,11 +4,12 @@
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { formatErrorMessage } from "../src/infra/errors.ts";
 import { type NpmVerifyCommandInvocation, runNpmVerifyCommand } from "./lib/npm-verify-exec.ts";
+import { readWorkerDeployTargetPaths } from "./lib/worker-deploy-target-contract.mts";
 import { runInstalledWorkspaceBootstrapSmoke } from "./lib/workspace-bootstrap-smoke.mts";
 import {
   collectInstalledPackageErrors,
@@ -130,6 +131,7 @@ function main(argv = process.argv.slice(2)): void {
     console.log(openClawNpmPrepublishVerifyUsage());
     return;
   }
+  const workerDeployPaths = readWorkerDeployTargetPaths(resolve("."));
 
   const workingDir = mkdtempSync(join(tmpdir(), "openclaw-prepublish-"));
   const prefixDir = join(workingDir, "prefix");
@@ -201,6 +203,7 @@ function main(argv = process.argv.slice(2)): void {
       expectedVersion: resolvedExpectedVersion,
       installedVersion: pkg.version?.trim() ?? "",
       packageRoot,
+      workerDeployPaths,
     });
     const installedBinaryVersion = runNpmVerifyCommand(binaryInvocation, workingDir);
     if (normalizeInstalledBinaryVersion(installedBinaryVersion) !== resolvedExpectedVersion) {

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -20,7 +20,6 @@ import { basename, dirname, join, resolve, win32 } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 import { extract } from "tar";
-import { tsImport } from "tsx/esm/api";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { COMPLETION_SKIP_PLUGIN_COMMANDS_ENV } from "../src/cli/completion-runtime.ts";
 import { escapeRegExp } from "../src/shared/regexp.js";
@@ -47,6 +46,7 @@ import {
   listUnpackagedPrivatePluginSdkDistArtifacts,
 } from "./lib/plugin-sdk-entries.mts";
 import { listStaticExtensionAssetOutputs } from "./lib/static-extension-assets.mts";
+import { readWorkerDeployTargetPaths } from "./lib/worker-deploy-target-contract.mts";
 import {
   runInstalledWorkspaceBootstrapSmoke,
   WORKSPACE_TEMPLATE_PACK_PATHS,
@@ -89,6 +89,7 @@ const targetPluginSdkEntries = JSON.parse(
 const targetPrivatePluginSdkEntries = JSON.parse(
   readFileSync(resolve("scripts/lib/plugin-sdk-private-local-only-subpaths.json"), "utf8"),
 ) as string[];
+const targetWorkerDeployPaths = readWorkerDeployTargetPaths(resolve("."));
 const requiredPathGroups = [
   PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
   ["dist/index.js", "dist/index.mjs"],
@@ -717,6 +718,7 @@ export function collectPackedInstalledPackageVerificationErrors(params: {
     expectedVersion: params.expectedVersion,
     installedVersion: packageJson.version?.trim() ?? "",
     packageRoot: params.packageRoot,
+    workerDeployPaths: targetWorkerDeployPaths,
   });
   if (
     params.installedBinaryVersion !== undefined &&
@@ -1386,7 +1388,7 @@ async function main() {
     if (packedPackage.name !== "openclaw" || packedPackage.version !== rootPackage.version) {
       throw new Error("release-check: prepared tarball does not match the target package version.");
     }
-    await verifyPackedContents(results, packedRoot);
+    verifyPackedContents(results, packedRoot);
     runPackedBundledChannelEntrySmoke(tarballPath, packedRoot);
     console.log("release-check: final npm tarball contents and installed runtime look OK.");
   } finally {
@@ -1394,24 +1396,10 @@ async function main() {
   }
 }
 
-async function verifyPackedContents(results: NpmPackResult[], packedRoot: string): Promise<void> {
-  // WORKER_BUNDLE_*_PATH exports declare the target's sealed deploy artifacts.
-  // Trusted tooling may be newer than the frozen target in the working directory.
-  const workerBundle = await tsImport(
-    pathToFileURL(resolve("src/shared/worker-bundle-hash.ts")).href,
-    import.meta.url,
-  );
-  const workerDeployEntrypoints = Object.entries(workerBundle)
-    .filter(([name]) => /^WORKER_BUNDLE_.*_PATH$/u.test(name))
-    .map(([name, value]) => {
-      if (typeof value !== "string") {
-        throw new Error(`release-check: target worker artifact ${name} must be a path string.`);
-      }
-      return `dist/worker/${value}`;
-    });
+function verifyPackedContents(results: NpmPackResult[], packedRoot: string): void {
   checkCliBootstrapExternalImports({
     rootDir: packedRoot,
-    workerDeployEntrypoints,
+    workerDeployEntrypoints: targetWorkerDeployPaths,
     logger: {
       error: (message: string) => console.error(`release-check: ${message}`),
     },

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -85,6 +85,18 @@ describe("parseOpenClawNpmPostpublishVerifyArgs", () => {
       "Unexpected openclaw npm postpublish verifier argument: extra",
     );
   });
+
+  it("binds every release-maintainer invocation to the validated frozen target root", () => {
+    const skill = readFileSync(".agents/skills/release-openclaw-maintainer/SKILL.md", "utf8");
+    const command = "node --import tsx scripts/openclaw-npm-postpublish-verify.ts";
+    const invocations = skill.split("\n").filter((line) => line.includes(command));
+
+    expect(invocations.length).toBeGreaterThan(0);
+    for (const invocation of invocations) {
+      expect(invocation).toContain("<validated-frozen-target-root>");
+    }
+    expect(skill).toContain("already proven equal to the immutable release candidate SHA");
+  });
 });
 
 function writeDistJavaScriptFiles(packageRoot: string, count: number): void {

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -1,9 +1,17 @@
 import { spawnSync } from "node:child_process";
 import { generateKeyPairSync, sign } from "node:crypto";
 // OpenClaw npm postpublish tests validate postpublish verification behavior.
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, truncateSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { listBundledPluginPackArtifacts } from "../scripts/lib/bundled-plugin-build-entries.mjs";
 import {
@@ -27,12 +35,19 @@ import {
 } from "../scripts/openclaw-npm-postpublish-verify.ts";
 import {
   WORKER_BUNDLE_ENTRY_PATH,
+  WORKER_BUNDLE_GITHUB_EXEC_LAUNCHER_PATH,
   WORKER_BUNDLE_RSYNC_RECEIVER_PATH,
 } from "../src/shared/worker-bundle-hash.js";
 import { withEnv } from "../src/test-utils/env.js";
 
 const INSTALLED_ROOT_DIST_JS_FILE_SCAN_LIMIT = 10_000;
 const requiredBundledPluginPackPaths = listBundledPluginPackArtifacts();
+const workerDeployPaths = [
+  `dist/worker/${WORKER_BUNDLE_ENTRY_PATH}`,
+  `dist/worker/${WORKER_BUNDLE_GITHUB_EXEC_LAUNCHER_PATH}`,
+  `dist/worker/${WORKER_BUNDLE_RSYNC_RECEIVER_PATH}`,
+];
+const workerDistPaths = new Set(workerDeployPaths.map((path) => path.slice("dist/".length)));
 
 describe("parseOpenClawNpmPostpublishVerifyArgs", () => {
   it("keeps trusted release verification independent from target app dependencies", () => {
@@ -49,6 +64,12 @@ describe("parseOpenClawNpmPostpublishVerifyArgs", () => {
     });
     expect(parseOpenClawNpmPostpublishVerifyArgs(["--", "2026.3.23"])).toEqual({
       help: false,
+      targetRoot: resolve("."),
+      version: "2026.3.23",
+    });
+    expect(parseOpenClawNpmPostpublishVerifyArgs(["2026.3.23", "/tmp/target"])).toEqual({
+      help: false,
+      targetRoot: "/tmp/target",
       version: "2026.3.23",
     });
   });
@@ -60,7 +81,7 @@ describe("parseOpenClawNpmPostpublishVerifyArgs", () => {
     expect(() => parseOpenClawNpmPostpublishVerifyArgs(["--tag"])).toThrow(
       "Unknown openclaw npm postpublish verifier option: --tag",
     );
-    expect(() => parseOpenClawNpmPostpublishVerifyArgs(["2026.3.23", "extra"])).toThrow(
+    expect(() => parseOpenClawNpmPostpublishVerifyArgs(["2026.3.23", ".", "extra"])).toThrow(
       "Unexpected openclaw npm postpublish verifier argument: extra",
     );
   });
@@ -596,6 +617,7 @@ describe("collectInstalledPackageErrors", () => {
       expectedVersion: "2026.3.23-2",
       installedVersion: "2026.3.23",
       packageRoot: "/tmp/empty-openclaw",
+      workerDeployPaths,
     });
 
     expect(errors[0]).toBe(
@@ -617,6 +639,7 @@ describe("collectInstalledPackageErrors", () => {
         expectedVersion: "2026.3.23",
         installedVersion: "2026.3.23",
         packageRoot,
+        workerDeployPaths,
       });
       const sizeError = `installed package root dist file 'worker/${WORKER_BUNDLE_ENTRY_PATH}' is invalid or exceeds 83886080 bytes.`;
 
@@ -662,6 +685,7 @@ describe("collectInstalledPackageErrors", () => {
             expectedVersion: "2026.3.23",
             installedVersion: "2026.3.23",
             packageRoot,
+            workerDeployPaths,
           }),
         ).toContain(expectedError);
       } finally {
@@ -846,6 +870,7 @@ describe("collectInstalledPackageErrors", () => {
           expectedVersion: "2026.3.23",
           installedVersion: "2026.3.23",
           packageRoot,
+          workerDeployPaths,
         }),
       ).toContain(
         "installed package is missing required bundled runtime sidecar: dist/extensions/telegram/runtime-api.js",
@@ -885,8 +910,57 @@ describe("collectInstalledPackageErrors", () => {
           expectedVersion: "2026.3.23",
           installedVersion: "2026.3.23",
           packageRoot,
+          workerDeployPaths,
         }),
       ).toContain(manifestErrors[0]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    [
+      "missing",
+      undefined,
+      "installed package worker deploy artifact is missing: dist/worker/github-exec-launcher.mjs.",
+    ],
+    [
+      "symlink",
+      "symlink",
+      "installed package worker deploy artifact is not a regular file: dist/worker/github-exec-launcher.mjs.",
+    ],
+    [
+      "directory",
+      "directory",
+      "installed package worker deploy artifact is not a regular file: dist/worker/github-exec-launcher.mjs.",
+    ],
+  ])("rejects a %s target-declared worker artifact", (_, kind, expectedError) => {
+    const packageRoot = makeInstalledPackageRoot();
+    const launcherPath = join(
+      packageRoot,
+      `dist/worker/${WORKER_BUNDLE_GITHUB_EXEC_LAUNCHER_PATH}`,
+    );
+    try {
+      mkdirSync(dirname(launcherPath), { recursive: true });
+      writeFileSync(join(packageRoot, "package.json"), '{"version":"2026.3.23"}\n');
+      writeFileSync(join(packageRoot, `dist/worker/${WORKER_BUNDLE_ENTRY_PATH}`), "export {};\n");
+      writeFileSync(
+        join(packageRoot, `dist/worker/${WORKER_BUNDLE_RSYNC_RECEIVER_PATH}`),
+        "export {};\n",
+      );
+      if (kind === "symlink") {
+        symlinkSync(WORKER_BUNDLE_ENTRY_PATH, launcherPath);
+      } else if (kind === "directory") {
+        mkdirSync(launcherPath);
+      }
+      expect(
+        collectInstalledPackageErrors({
+          expectedVersion: "2026.3.23",
+          installedVersion: "2026.3.23",
+          packageRoot,
+          workerDeployPaths,
+        }),
+      ).toContain(expectedError);
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });
     }
@@ -1310,7 +1384,9 @@ describe("collectInstalledRootDependencyManifestErrors", () => {
         writeFileSync(filePath, `/* ${"x".repeat(6 * 1024 * 1024)} */\n`, "utf8");
       }
 
-      expect(collectInstalledRootDependencyManifestErrors(packageRoot)).toEqual(expected);
+      expect(collectInstalledRootDependencyManifestErrors(packageRoot, workerDistPaths)).toEqual(
+        expected,
+      );
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });
     }

--- a/test/openclaw-npm-prepublish-verify.test.ts
+++ b/test/openclaw-npm-prepublish-verify.test.ts
@@ -1,4 +1,8 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { readWorkerDeployTargetPaths } from "../scripts/lib/worker-deploy-target-contract.mts";
 import {
   openClawNpmPrepublishVerifyUsage,
   parseOpenClawNpmPrepublishVerifyArgs,
@@ -54,5 +58,70 @@ describe("usesPreparedLocalDependencyInstall", () => {
     expect(usesPreparedLocalDependencyInstall(0)).toBe(false);
     expect(usesPreparedLocalDependencyInstall(1)).toBe(true);
     expect(usesPreparedLocalDependencyInstall(2)).toBe(false);
+  });
+});
+
+describe("readWorkerDeployTargetPaths", () => {
+  it.each([
+    ["historical", ""],
+    [
+      "modern",
+      'export const WORKER_BUNDLE_GITHUB_EXEC_LAUNCHER_PATH = "github-exec-launcher.mjs";\n',
+    ],
+  ])("reads the %s target contract without executing it", (_, extraDeclaration) => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-worker-target-"));
+    try {
+      const sourceDir = join(root, "src/shared");
+      mkdirSync(sourceDir, { recursive: true });
+      writeFileSync(
+        join(sourceDir, "worker-bundle-hash.ts"),
+        'export const WORKER_BUNDLE_ENTRY_PATH = "worker.mjs";\n' +
+          'export const WORKER_BUNDLE_RSYNC_RECEIVER_PATH = "workspace-rsync-receiver.mjs";\n' +
+          extraDeclaration +
+          'throw new Error("must not execute target source");\n',
+      );
+      expect(readWorkerDeployTargetPaths(root)).toEqual(
+        [
+          "dist/worker/worker.mjs",
+          "dist/worker/workspace-rsync-receiver.mjs",
+          ...(extraDeclaration ? ["dist/worker/github-exec-launcher.mjs"] : []),
+        ].toSorted(),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    [
+      "unsafe basenames",
+      'export const WORKER_BUNDLE_ENTRY_PATH = "../worker.mjs";\n' +
+        'export const WORKER_BUNDLE_RSYNC_RECEIVER_PATH = "workspace-rsync-receiver.mjs";\n',
+      "Target worker artifact declaration is invalid: WORKER_BUNDLE_ENTRY_PATH.",
+    ],
+    [
+      "duplicate basenames",
+      'export const WORKER_BUNDLE_ENTRY_PATH = "worker.mjs";\n' +
+        'export const WORKER_BUNDLE_RSYNC_RECEIVER_PATH = "worker.mjs";\n',
+      "Target worker artifact declaration is invalid: WORKER_BUNDLE_RSYNC_RECEIVER_PATH.",
+    ],
+    [
+      "unbounded declarations",
+      Array.from(
+        { length: 17 },
+        (_, index) => `export const WORKER_BUNDLE_${index}_PATH = "worker-${index}.mjs";`,
+      ).join("\n"),
+      "Target worker artifact count must be between 2 and 16.",
+    ],
+  ])("rejects %s", (_, source, expectedError) => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-worker-target-invalid-"));
+    try {
+      const sourceDir = join(root, "src/shared");
+      mkdirSync(sourceDir, { recursive: true });
+      writeFileSync(join(sourceDir, "worker-bundle-hash.ts"), source);
+      expect(() => readWorkerDeployTargetPaths(root)).toThrow(expectedError);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -777,6 +777,9 @@ describe("collectMissingPackPaths", () => {
       for (const relativePath of [
         "facade-activation-check.runtime.js",
         "extensions/image-generation-core/runtime-api.js",
+        "worker/github-exec-launcher.mjs",
+        "worker/worker.mjs",
+        "worker/workspace-rsync-receiver.mjs",
       ]) {
         const filePath = join(distDir, relativePath);
         mkdirSync(dirname(filePath), { recursive: true });

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -96,7 +96,11 @@ afterEach(() => {
 describe("verifyBetaRelease workflow outcomes", () => {
   const version = "2026.5.10-beta.3";
 
-  function workflowFixture(overrides: Record<string, unknown> = {}, telegram = true) {
+  function workflowFixture(
+    overrides: Record<string, unknown> = {},
+    telegram = true,
+    skipPostpublish = true,
+  ) {
     const rootDir = tempDirs.make("release-workflow-outcome-");
     const binDir = join(rootDir, "bin");
     mkdirSync(binDir);
@@ -135,7 +139,7 @@ if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1] ==
     vi.stubEnv("PATH", `${binDir}:${process.env.PATH}`);
     const args = parseReleaseVerifyBetaArgs([
       version,
-      "--skip-postpublish",
+      ...(skipPostpublish ? ["--skip-postpublish"] : []),
       "--skip-github-release",
       "--skip-clawhub",
       "--workflow-ref",
@@ -222,6 +226,20 @@ if (path.basename(process.argv[1]) === "npm" && args[0] === "view" && args[1] ==
     await expect(verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir })).rejects.toThrow(
       "OpenClaw NPM Release: run 44 is",
     );
+  });
+
+  it("passes the selected target root to postpublish verification", async () => {
+    const fixture = workflowFixture({}, true, false);
+    const capturePath = join(fixture.rootDir, "postpublish-args.json");
+    mkdirSync(join(fixture.rootDir, "scripts"));
+    writeFileSync(
+      join(fixture.rootDir, "scripts/openclaw-npm-postpublish-verify.ts"),
+      `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(process.argv.slice(2)));`,
+    );
+
+    await verifyBetaRelease(fixture.args, { rootDir: fixture.rootDir });
+
+    expect(JSON.parse(readFileSync(capturePath, "utf8"))).toEqual([version, fixture.rootDir]);
   });
 });
 

--- a/test/scripts/release-check.test.ts
+++ b/test/scripts/release-check.test.ts
@@ -74,6 +74,12 @@ describe("release-check", () => {
         join(root, "scripts/lib/plugin-sdk-private-local-only-subpaths.json"),
         JSON.stringify(["target-private"]),
       );
+      mkdirSync(join(root, "src/shared"), { recursive: true });
+      writeFileSync(
+        join(root, "src/shared/worker-bundle-hash.ts"),
+        'export const WORKER_BUNDLE_ENTRY_PATH = "worker.mjs";\n' +
+          'export const WORKER_BUNDLE_RSYNC_RECEIVER_PATH = "workspace-rsync-receiver.mjs";\n',
+      );
       mkdirSync(join(root, "scripts", "fixtures"));
       writeFileSync(
         join(root, "scripts/fixtures/packed-plugin-sdk-type-smoke.ts"),
@@ -112,7 +118,6 @@ describe("release-check", () => {
       });
 
       copyFileSync("appcast.xml", join(root, "appcast.xml"));
-      mkdirSync(join(root, "src/shared"), { recursive: true });
       const packedRoot = join(root, "package");
       const packedFiles = {
         "package.json": packageJson,
@@ -129,14 +134,16 @@ describe("release-check", () => {
       }
       const tarball = join(root, "target.tgz");
       create({ cwd: root, file: tarball, gzip: true, sync: true }, ["package"]);
-      for (const declaresLauncher of [false, true]) {
+      for (const contract of ["historical", "modern", "malformed"] as const) {
         writeFileSync(
           join(root, "src/shared/worker-bundle-hash.ts"),
           'export const WORKER_BUNDLE_ENTRY_PATH = "worker.mjs";\n' +
             'export const WORKER_BUNDLE_RSYNC_RECEIVER_PATH = "workspace-rsync-receiver.mjs";\n' +
-            (declaresLauncher
+            (contract === "modern"
               ? 'export const WORKER_BUNDLE_GITHUB_EXEC_LAUNCHER_PATH = "github-exec-launcher.mjs";\n'
-              : ""),
+              : contract === "malformed"
+                ? "export const WORKER_BUNDLE_EXTRA_PATH = makePath();\n"
+                : ""),
         );
         const result = spawnSync(
           process.execPath,
@@ -156,9 +163,11 @@ describe("release-check", () => {
         expect(result.status).toBe(1);
         // The two-artifact target reaches the next check; the fixture omits SDK output.
         expect(result.stderr).toContain(
-          declaresLauncher
+          contract === "modern"
             ? "Worker deploy artifact dist/worker/github-exec-launcher.mjs is missing."
-            : "release-check: packed dist/plugin-sdk directory not found.",
+            : contract === "malformed"
+              ? "Target worker artifact declaration is invalid: WORKER_BUNDLE_EXTRA_PATH."
+              : "release-check: packed dist/plugin-sdk directory not found.",
         );
       }
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation gap where a target version could declare an additional worker deployment artifact without prepublish or postpublish verification requiring that artifact in the package.

## Why This Change Was Made

Release tooling previously mixed two unsafe ownership models: `release-check` executed the target's TypeScript declaration module, while npm verification hardcoded the two historical worker files. The modern target adds `github-exec-launcher.mjs`, so a package missing that declared artifact could pass postpublish verification.

This change introduces one bounded TypeScript AST reader for the exact selected target's exported `WORKER_BUNDLE_*_PATH` string constants. It accepts the historical two-artifact contract and the modern three-artifact contract, rejects malformed, duplicate, unsafe, or unbounded declarations, and returns deterministic `dist/worker/*` paths without executing target code.

All release verification consumers now use that single target-derived result. Installed artifacts must be regular, non-symlink files, worker parser-size exemptions come from the same contract, and automated plus release-maintainer runbook verification passes the exact validated frozen target root to postpublish verification.

## User Impact

Maintainers get target-version-correct npm artifact validation before and after publish. Historical targets continue to verify with their two declared worker files; modern targets specifically require `worker.mjs`, `workspace-rsync-receiver.mjs`, and `github-exec-launcher.mjs`.

There is no runtime, workflow, manifest, protocol, configuration, or UI behavior change.

## Evidence

- Pre-fix reproduction: an installed package containing the historical two worker files but missing the modern GitHub launcher returned no worker artifact errors.
- ClawSweeper repair reproduction: all four release-maintainer postpublish commands omitted the target-root argument. The new structural regression failed 1/61 before the runbook repair and passed 61/61 afterward.
- Focused tooling tests: 5 files, 177 tests passed.
- ClawSweeper acceptance suite after the runbook repair: 4 files, 116 tests passed.
- Linux Testbox: provider `blacksmith-testbox`, lease `tbx_01m1jzve2zeh3zndzkebpyp7m2`, run https://github.com/openclaw/openclaw/actions/runs/33724182753. The same 5-file suite passed 177/177 at runtime-identical parent `6babcb680660527bb37f7bf85fcb96e6294b3adb`; the one-shot lease stopped after success. The follow-up changes only release guidance and its structural test, so the Testbox run was not repeated.
- Covers historical two-file and modern three-file declarations, non-executing AST reads, malformed/unsafe/duplicate/unbounded declarations, missing/symlink/directory artifacts, target-derived large-file exemptions, and exact beta target-root propagation.
- Formatting: current repository `oxfmt` passed for the follow-up skill and test files. ClawSweeper's requested `pnpm exec prettier` command is not runnable at this head because the repository no longer declares a Prettier binary.
- Direct changed-file Oxlint: passed for the follow-up test.
- `git diff --check`: passed.
- Test audit: passed; the added structural case protects the operator-visible runbook contract, demonstrably failed before the repair, and adds no test-only production seam.
- Sol/high P0-P2 autoreview: scoped clean, no findings, confidence 0.96.
- `check:changed`: passed conflict-marker, attribution, deprecation, architecture, dependency, formatting, patch, temp-path, and core-boundary checks. It then stopped at the root test typecheck because the shared dependency graph lacks unrelated extension packages; no diagnostic referenced either follow-up file.

LOC split:

- Release tooling: +95/-46, net +49.
- Tests: +199/-12, net +187.
- Release docs/skill guidance: +13/-9, net +4.
- Total: +307/-67 across 13 files.

No changelog entry was added because repository policy generates changelogs from merged PRs and commits at release time.
