### PR TITLE
fix: deliver child completion after a decorated continuation status

### DIFF
--- a/src/auto-reply/dispatch-dispatcher.ts
+++ b/src/auto-reply/dispatch-dispatcher.ts
@@ -15,31 +15,34 @@ export function registerReplyDispatcherSettledTask(
   settledTasksByDispatcher.set(dispatcher, tasks);
 }
 
-async function runReplyDispatcherSettledTasks(dispatcher: ReplyDispatcher): Promise<void> {
-  const tasks = settledTasksByDispatcher.get(dispatcher);
-  if (!tasks) {
-    return;
-  }
-  settledTasksByDispatcher.delete(dispatcher);
-  for (const task of tasks) {
-    await task();
-  }
-}
-
 /** Mark a dispatcher complete, wait for pending work, then run optional cleanup. */
 export async function settleReplyDispatcher(params: {
   dispatcher: ReplyDispatcher;
   onSettled?: () => void | Promise<void>;
 }): Promise<ReplyDispatchReceipt | undefined> {
   params.dispatcher.markComplete();
+  let receipt: ReplyDispatchReceipt | void = undefined;
+  const failures: unknown[] = [];
   try {
-    const receipt = await params.dispatcher.waitForIdle();
-    await runReplyDispatcherSettledTasks(params.dispatcher);
-    return receipt || undefined;
-  } finally {
-    settledTasksByDispatcher.delete(params.dispatcher);
-    await params.onSettled?.();
+    receipt = await params.dispatcher.waitForIdle();
+  } catch (error) {
+    failures.push(error);
   }
+  const tasks = settledTasksByDispatcher.get(params.dispatcher) ?? [];
+  settledTasksByDispatcher.delete(params.dispatcher);
+  // Draining may reject after delivery outcomes settle; release every owner in order
+  // without replacing the original error (including typed retryable no-send errors).
+  for (const task of [...tasks, params.onSettled]) {
+    try {
+      await task?.();
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length > 0) {
+    throw failures[0];
+  }
+  return receipt || undefined;
 }
 
 /** Run work with a dispatcher and always drain it before returning or throwing. */
@@ -49,10 +52,22 @@ export async function withReplyDispatcher<T>(params: {
   onSettled?: () => void | Promise<void>;
   onSettledReceipt?: (receipt: ReplyDispatchReceipt | undefined) => void;
 }): Promise<T> {
+  let run: { value: T } | { error: unknown };
   try {
-    return await params.run();
-  } finally {
+    run = { value: await params.run() };
+  } catch (error) {
+    run = { error };
+  }
+  try {
     const receipt = await settleReplyDispatcher(params);
     params.onSettledReceipt?.(receipt);
+  } catch (error) {
+    if ("value" in run) {
+      throw error;
+    }
   }
+  if ("error" in run) {
+    throw run.error;
+  }
+  return run.value;
 }

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -248,27 +248,63 @@ describe("withReplyDispatcher", () => {
     expect(order).toEqual(["run", "markComplete", "waitForIdle", "settledTask", "onSettled"]);
   });
 
-  it("still drains dispatcher after run throws", async () => {
-    const order: string[] = [];
-    const dispatcher = createDispatcher(order);
-    const onSettled = vi.fn(() => {
-      order.push("onSettled");
-    });
+  it.each(["run", "waitForIdle", "settledTask"])(
+    "runs every cleanup and preserves the original %s failure",
+    async (failedStage) => {
+      const order: string[] = [];
+      const failure = new Error(`${failedStage} failed`);
+      const laterFailure = new Error("later cleanup failed");
+      const visit = (stage: string) => {
+        order.push(stage);
+        if (stage === failedStage) {
+          throw failure;
+        }
+      };
+      const dispatcher = createDispatcher(order);
+      dispatcher.waitForIdle = async () => {
+        visit("waitForIdle");
+      };
+      registerReplyDispatcherSettledTask(dispatcher, () => {
+        visit("settledTask");
+      });
+      registerReplyDispatcherSettledTask(dispatcher, () => {
+        order.push("laterTask");
+        throw laterFailure;
+      });
+      registerReplyDispatcherSettledTask(dispatcher, () => {
+        order.push("lastTask");
+      });
 
-    await expect(
-      withReplyDispatcher({
+      await expect(
+        withReplyDispatcher({
+          dispatcher,
+          run: async () => {
+            visit("run");
+          },
+          onSettled: () => {
+            order.push("onSettled");
+            throw laterFailure;
+          },
+        }),
+      ).rejects.toBe(failure);
+
+      expect(order).toEqual([
+        "run",
+        "markComplete",
+        "waitForIdle",
+        "settledTask",
+        "laterTask",
+        "lastTask",
+        "onSettled",
+      ]);
+      dispatcher.waitForIdle = async () => undefined;
+      await withReplyDispatcher({
         dispatcher,
-        run: async () => {
-          order.push("run");
-          throw new Error("boom");
-        },
-        onSettled,
-      }),
-    ).rejects.toThrow("boom");
-
-    expect(onSettled).toHaveBeenCalledTimes(1);
-    expect(order).toEqual(["run", "markComplete", "waitForIdle", "onSettled"]);
-  });
+        run: async () => undefined,
+      });
+      expect(order.filter((stage) => stage === "settledTask")).toHaveLength(1);
+    },
+  );
 
   it("dispatchInboundMessageWithBufferedDispatcher cleans up typing after a resolver starts it", async () => {
     const typing = {

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -522,7 +522,6 @@ export async function prepareReplyAgentPayloads(state: {
       throw new Error("accepted continuation status could not be prepared for delivery");
     }
     const settlement: PendingContinuationSettlement = {
-      statusPayload,
       settle: async (statusDelivered) => {
         const { settleRequesterAfterSessionSpawns } =
           await import("../../agents/subagents/registry/subagent-registry.js");

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -4345,16 +4345,15 @@ describe("runReplyAgent typing (heartbeat)", () => {
     const onPendingContinuation = vi.fn();
     const { run } = createMinimalRun({ opts: { onPendingContinuation } });
 
-    await expect(run()).resolves.toMatchObject({
+    const result = await run();
+    expect(result).toMatchObject({
       text: "I’m continuing this work and will send the result when it is ready.",
       replyToId: "msg",
     });
     expect(onPendingContinuation).toHaveBeenCalledOnce();
-    expect(onPendingContinuation.mock.calls[0]?.[0]).toMatchObject({
-      statusPayload: {
-        text: "I’m continuing this work and will send the result when it is ready.",
-      },
-    });
+    expect(
+      getReplyPayloadMetadata(requireRecord(result, "continuation status"))?.continuationStatus,
+    ).toBe(true);
   });
 
   it("delivers an explicit yield acknowledgment after accepting a child spawn", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.continuation-settlement.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.continuation-settlement.test.ts
@@ -4,6 +4,8 @@ import { clearAgentHarnesses } from "../../agents/harness/registry.js";
 import { withReplyDispatcher } from "../dispatch-dispatcher.js";
 import { setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
+import { appendUsageLine } from "./agent-runner-usage-line.js";
+import { markCommandSessionMetadataChanged } from "./command-session-metadata.js";
 import {
   createHookCtx,
   emptyConfig,
@@ -106,38 +108,50 @@ describe("accepted continuation status delivery", () => {
     expect(sessionStoreMocks.updateSessionEntry).toHaveBeenCalledTimes(3);
   });
 
-  it("settles an accepted continuation only after its waiting status is delivered", async () => {
-    const order: string[] = [];
-    const statusPayload = { text: "Continuing work; the result will follow." };
-    const settle = vi.fn(async (statusDelivered: boolean) => {
-      order.push(`settle:${statusDelivered}`);
-    });
-    const dispatcher = createReplyDispatcher({
-      deliver: async (payload) => {
-        order.push(`deliver:${payload.text}`);
-      },
-    });
+  it.each([undefined, "Usage: 100 in / 20 out"])(
+    "settles an accepted continuation after delivery with usage footer %s",
+    async (usageLine) => {
+      const order: string[] = [];
+      const statusPayload = setReplyPayloadMetadata(
+        { text: "Continuing work; the result will follow." },
+        { continuationStatus: true },
+      );
+      const settle = vi.fn(async (statusDelivered: boolean) => {
+        order.push(`settle:${statusDelivered}`);
+      });
+      const dispatcher = createReplyDispatcher({
+        deliver: async (payload) => {
+          order.push(`deliver:${payload.text}`);
+        },
+      });
 
-    await withReplyDispatcher({
-      dispatcher,
-      run: () =>
-        dispatchReplyFromConfig({
-          ctx: createHookCtx(),
-          cfg: emptyConfig,
-          dispatcher,
-          replyResolver: async (_ctx, opts) => {
-            opts?.onPendingContinuation?.({ statusPayload, settle });
-            return statusPayload;
-          },
-        }),
-    });
+      await withReplyDispatcher({
+        dispatcher,
+        run: () =>
+          dispatchReplyFromConfig({
+            ctx: createHookCtx(),
+            cfg: emptyConfig,
+            dispatcher,
+            replyResolver: async (_ctx, opts) => {
+              opts?.onPendingContinuation?.({ settle });
+              return usageLine ? appendUsageLine([statusPayload], usageLine) : statusPayload;
+            },
+          }),
+      });
 
-    expect(order).toEqual(["deliver:Continuing work; the result will follow.", "settle:true"]);
-  });
+      expect(order).toEqual([
+        `deliver:${statusPayload.text}${usageLine ? `\n${usageLine}` : ""}`,
+        "settle:true",
+      ]);
+    },
+  );
 
   it("releases child delivery when an acknowledged continuation status cannot settle its batch", async () => {
     const order: string[] = [];
-    const statusPayload = { text: "Continuing work; the result will follow." };
+    const statusPayload = setReplyPayloadMetadata(
+      { text: "Continuing work; the result will follow." },
+      { continuationStatus: true },
+    );
     const settle = vi.fn(async (statusDelivered: boolean) => {
       order.push(`settle:${statusDelivered}`);
       if (statusDelivered) {
@@ -158,7 +172,7 @@ describe("accepted continuation status delivery", () => {
           cfg: emptyConfig,
           dispatcher,
           replyResolver: async (_ctx, opts) => {
-            opts?.onPendingContinuation?.({ statusPayload, settle });
+            opts?.onPendingContinuation?.({ settle });
             return statusPayload;
           },
         }),
@@ -172,7 +186,10 @@ describe("accepted continuation status delivery", () => {
   });
 
   it("releases an accepted continuation when its waiting status is not delivered", async () => {
-    const statusPayload = { text: "Continuing work; the result will follow." };
+    const statusPayload = setReplyPayloadMetadata(
+      { text: "Continuing work; the result will follow." },
+      { continuationStatus: true },
+    );
     const settle = vi.fn(async () => {});
     const dispatcher = createReplyDispatcher({
       deliver: async () => {
@@ -188,7 +205,7 @@ describe("accepted continuation status delivery", () => {
           cfg: emptyConfig,
           dispatcher,
           replyResolver: async (_ctx, opts) => {
-            opts?.onPendingContinuation?.({ statusPayload, settle });
+            opts?.onPendingContinuation?.({ settle });
             return statusPayload;
           },
         }),
@@ -199,7 +216,10 @@ describe("accepted continuation status delivery", () => {
 
   it("releases an accepted continuation when finalization aborts before status dispatch", async () => {
     const abortController = new AbortController();
-    const statusPayload = { text: "Continuing work; the result will follow." };
+    const statusPayload = setReplyPayloadMetadata(
+      { text: "Continuing work; the result will follow." },
+      { continuationStatus: true },
+    );
     const settle = vi.fn(async () => {});
     const dispatcher = createReplyDispatcher({ deliver: vi.fn() });
 
@@ -212,7 +232,7 @@ describe("accepted continuation status delivery", () => {
           dispatcher,
           replyOptions: { abortSignal: abortController.signal },
           replyResolver: async (_ctx, opts) => {
-            opts?.onPendingContinuation?.({ statusPayload, settle });
+            opts?.onPendingContinuation?.({ settle });
             abortController.abort();
             return statusPayload;
           },
@@ -222,36 +242,113 @@ describe("accepted continuation status delivery", () => {
     expect(settle).toHaveBeenCalledExactlyOnceWith(false);
   });
 
-  it("releases an accepted continuation when status dispatch rejects before queueing", async () => {
-    const statusPayload = { text: "Continuing work; the result will follow." };
+  it.each(["before", "status", "after"] as const)(
+    "settles an accepted continuation when dispatch fails %s the status",
+    async (failurePosition) => {
+      const statusPayload = setReplyPayloadMetadata(
+        { text: "Continuing work; the result will follow." },
+        { continuationStatus: true },
+      );
+      const settle = vi.fn(async () => {});
+      const dispatcher = createReplyDispatcher({ deliver: vi.fn() });
+      const sendFinalReply = dispatcher.sendFinalReply.bind(dispatcher);
+      vi.spyOn(dispatcher, "sendFinalReply").mockImplementation((payload) => {
+        if (failurePosition === "status" || payload.isFallbackNotice) {
+          throw new Error("queue unavailable");
+        }
+        return sendFinalReply(payload);
+      });
+
+      await expect(
+        withReplyDispatcher({
+          dispatcher,
+          run: () =>
+            dispatchReplyFromConfig({
+              ctx: createHookCtx(),
+              cfg: emptyConfig,
+              dispatcher,
+              replyResolver: async (_ctx, opts) => {
+                opts?.onPendingContinuation?.({ settle });
+                const notice = { text: "Model route changed.", isFallbackNotice: true };
+                return failurePosition === "before"
+                  ? [notice, statusPayload]
+                  : failurePosition === "after"
+                    ? [statusPayload, notice]
+                    : statusPayload;
+              },
+            }),
+        }),
+      ).rejects.toThrow("queue unavailable");
+
+      expect(settle).toHaveBeenCalledExactlyOnceWith(failurePosition === "after");
+    },
+  );
+
+  it("releases an accepted continuation when its status was removed from the batch", async () => {
     const settle = vi.fn(async () => {});
     const dispatcher = createReplyDispatcher({ deliver: vi.fn() });
-    vi.spyOn(dispatcher, "sendFinalReply").mockImplementation(() => {
-      throw new Error("queue unavailable");
-    });
 
-    await expect(
-      withReplyDispatcher({
-        dispatcher,
-        run: () =>
-          dispatchReplyFromConfig({
-            ctx: createHookCtx(),
-            cfg: emptyConfig,
-            dispatcher,
-            replyResolver: async (_ctx, opts) => {
-              opts?.onPendingContinuation?.({ statusPayload, settle });
-              return statusPayload;
-            },
-          }),
-      }),
-    ).rejects.toThrow("queue unavailable");
+    await withReplyDispatcher({
+      dispatcher,
+      run: () =>
+        dispatchReplyFromConfig({
+          ctx: createHookCtx(),
+          cfg: emptyConfig,
+          dispatcher,
+          replyResolver: async (_ctx, opts) => {
+            opts?.onPendingContinuation?.({ settle });
+            return undefined;
+          },
+        }),
+    });
 
     expect(settle).toHaveBeenCalledExactlyOnceWith(false);
   });
 
+  it.each(["resolver", "session metadata"])(
+    "releases an accepted continuation when %s fails before finalization",
+    async (failurePosition) => {
+      const settle = vi.fn(async () => {});
+      const dispatcher = createReplyDispatcher({ deliver: vi.fn() });
+      const failure = new Error("session owner unavailable");
+
+      await expect(
+        withReplyDispatcher({
+          dispatcher,
+          run: () =>
+            dispatchReplyFromConfig({
+              ctx: createHookCtx(),
+              cfg: emptyConfig,
+              dispatcher,
+              onSessionMetadataChanges: () => {
+                throw failure;
+              },
+              replyResolver: async (ctx, opts) => {
+                opts?.onPendingContinuation?.({ settle });
+                if (failurePosition === "resolver") {
+                  throw failure;
+                }
+                markCommandSessionMetadataChanged({
+                  ctx,
+                  sessionKey: "agent:test:session",
+                  agentId: "test",
+                });
+                return undefined;
+              },
+            }),
+        }),
+      ).rejects.toThrow(failure);
+
+      expect(settle).toHaveBeenCalledExactlyOnceWith(false);
+    },
+  );
+
   it("releases an accepted continuation when buffered commentary routing rejects", async () => {
     sessionStoreMocks.currentEntry = { verboseLevel: "on" };
-    const statusPayload = { text: "Continuing work; the result will follow." };
+    const statusPayload = setReplyPayloadMetadata(
+      { text: "Continuing work; the result will follow." },
+      { continuationStatus: true },
+    );
     const settle = vi.fn(async () => {});
     const dispatcher = createReplyDispatcher({ deliver: vi.fn() });
     const ctx = createHookCtx();
@@ -268,7 +365,7 @@ describe("accepted continuation status delivery", () => {
             dispatcher,
             replyOptions: { onItemEvent: vi.fn() },
             replyResolver: async (_ctx, opts) => {
-              opts?.onPendingContinuation?.({ statusPayload, settle });
+              opts?.onPendingContinuation?.({ settle });
               await opts?.onItemEvent?.({
                 itemId: "commentary-1",
                 kind: "preamble",
@@ -287,6 +384,7 @@ describe("accepted continuation status delivery", () => {
     const statusPayload = setReplyPayloadMetadata(
       { text: "Continuing work; the result will follow." },
       {
+        continuationStatus: true,
         sessionWriterDeliveryAuthority: {
           agentId: "main",
           expectedLifecycleRevision: "revision-before-replacement",
@@ -313,7 +411,7 @@ describe("accepted continuation status delivery", () => {
           cfg: emptyConfig,
           dispatcher,
           replyResolver: async (_ctx, opts) => {
-            opts?.onPendingContinuation?.({ statusPayload, settle });
+            opts?.onPendingContinuation?.({ settle });
             return statusPayload;
           },
         }),

--- a/src/auto-reply/reply/dispatch-from-config.continuation-settlement.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.continuation-settlement.test.ts
@@ -1,6 +1,7 @@
 // Continuation settlement tests cover status delivery and child-terminal handoff.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearAgentHarnesses } from "../../agents/harness/registry.js";
+import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
 import { withReplyDispatcher } from "../dispatch-dispatcher.js";
 import { setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
@@ -146,6 +147,40 @@ describe("accepted continuation status delivery", () => {
     },
   );
 
+  it.each([true, false])(
+    "settles a routed status from its delivered receipt (%s)",
+    async (delivered) => {
+      const statusPayload = setReplyPayloadMetadata(
+        { text: "Continuing work; the result will follow." },
+        { continuationStatus: true },
+      );
+      const settle = vi.fn(async () => {});
+      const deliver = vi.fn();
+      const dispatcher = createReplyDispatcher({ deliver });
+      const ctx = createHookCtx();
+      Object.assign(ctx, { OriginatingChannel: "discord", OriginatingTo: "user:1" });
+      mocks.routeReply.mockResolvedValue({ ok: true, delivered, messageId: "routed-status" });
+
+      await withReplyDispatcher({
+        dispatcher,
+        run: () =>
+          dispatchReplyFromConfig({
+            ctx,
+            cfg: emptyConfig,
+            dispatcher,
+            replyResolver: async (_ctx, opts) => {
+              opts?.onPendingContinuation?.({ settle });
+              return appendUsageLine([statusPayload], "Usage: 100 in / 20 out");
+            },
+          }),
+      });
+
+      expect(mocks.routeReply).toHaveBeenCalledOnce();
+      expect(deliver).not.toHaveBeenCalled();
+      expect(settle).toHaveBeenCalledExactlyOnceWith(delivered);
+    },
+  );
+
   it("releases child delivery when an acknowledged continuation status cannot settle its batch", async () => {
     const order: string[] = [];
     const statusPayload = setReplyPayloadMetadata(
@@ -210,6 +245,41 @@ describe("accepted continuation status delivery", () => {
           },
         }),
     });
+
+    expect(settle).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it("releases a continuation before propagating a retryable no-send drain failure", async () => {
+    const failure = new PlatformMessageNotDispatchedError("offline before dispatch", {
+      cause: new Error("offline"),
+    });
+    const statusPayload = setReplyPayloadMetadata(
+      { text: "Continuing work; the result will follow." },
+      { continuationStatus: true },
+    );
+    const settle = vi.fn(async () => {});
+    const dispatcher = createReplyDispatcher({
+      deliver: async () => {
+        throw failure;
+      },
+      propagateRetryableNoSendFailure: true,
+    });
+
+    await expect(
+      withReplyDispatcher({
+        dispatcher,
+        run: () =>
+          dispatchReplyFromConfig({
+            ctx: createHookCtx(),
+            cfg: emptyConfig,
+            dispatcher,
+            replyResolver: async (_ctx, opts) => {
+              opts?.onPendingContinuation?.({ settle });
+              return statusPayload;
+            },
+          }),
+      }),
+    ).rejects.toBe(failure);
 
     expect(settle).toHaveBeenCalledExactlyOnceWith(false);
   });

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -612,42 +612,45 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
       cfg: replyConfig,
     });
   });
-  if (isDispatchOperationAborted()) {
-    await flushDeferredFinalText();
-  }
-  const sessionMetadataChanges = takeCommandSessionMetadataChanges(ctx);
-  notifySessionMetadataChanges(sessionMetadataChanges);
-  const resolvedCommandReply = isCommandReplyForDelivery(replyResult);
-  const finalDispatchAcquisition = resolvedCommandReply
-    ? ({ status: "ready" } as const)
-    : await state.ensureDispatchReplyOperation("dispatch");
-  if (finalDispatchAcquisition.status === "aborted") {
-    await releasePendingContinuation();
-    return { status: "complete" as const, result: state.finishReplyOperationAbortedDispatch() };
-  }
-  if (finalDispatchAcquisition.status === "busy") {
-    await releasePendingContinuation();
-    return {
-      status: "complete" as const,
-      result: state.finishReplyOperationBusyDispatch({
-        recordAgentDispatchCompleted: true,
-        ...(state.routeState.sessionMetadataChangesForResult
-          ? { sessionMetadataChanges: state.routeState.sessionMetadataChangesForResult }
-          : {}),
-      }),
-    };
-  }
+  try {
+    if (isDispatchOperationAborted()) {
+      await flushDeferredFinalText();
+    }
+    const sessionMetadataChanges = takeCommandSessionMetadataChanges(ctx);
+    notifySessionMetadataChanges(sessionMetadataChanges);
+    const resolvedCommandReply = isCommandReplyForDelivery(replyResult);
+    const finalDispatchAcquisition = resolvedCommandReply
+      ? ({ status: "ready" } as const)
+      : await state.ensureDispatchReplyOperation("dispatch");
+    if (finalDispatchAcquisition.status === "aborted") {
+      return { status: "complete" as const, result: state.finishReplyOperationAbortedDispatch() };
+    }
+    if (finalDispatchAcquisition.status === "busy") {
+      return {
+        status: "complete" as const,
+        result: state.finishReplyOperationBusyDispatch({
+          recordAgentDispatchCompleted: true,
+          ...(state.routeState.sessionMetadataChangesForResult
+            ? { sessionMetadataChanges: state.routeState.sessionMetadataChangesForResult }
+            : {}),
+        }),
+      };
+    }
 
-  const acpTailResult = await handleAcpDispatchTailAfterReset(state);
-  if (acpTailResult) {
+    const acpTailResult = await handleAcpDispatchTailAfterReset(state);
+    if (acpTailResult) {
+      return acpTailResult;
+    }
+    const nextState = extendPreparedDispatchState(state, {
+      deliberateSilentTerminalReply,
+      pendingContinuation,
+      pendingContinuationSettlement,
+      replyResult,
+    });
+    // Finalization now owns the exact settlement; earlier returns and throws release it here.
+    pendingContinuationSettlement = undefined;
+    return { status: "ready" as const, state: nextState };
+  } finally {
     await releasePendingContinuation();
-    return acpTailResult;
   }
-  const nextState = extendPreparedDispatchState(state, {
-    deliberateSilentTerminalReply,
-    pendingContinuation,
-    pendingContinuationSettlement,
-    replyResult,
-  });
-  return { status: "ready" as const, state: nextState };
 }

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -178,7 +178,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       }
       // Metadata survives usage, threading, and transcript decoration; object identity does not.
       if (pendingContinuationSettlement && getReplyPayloadMetadata(reply)?.continuationStatus) {
-        if (finalReply.queuedFinal) {
+        if (finalReply.dispatcherOutcome) {
           registerReplyDispatcherSettledTask(dispatcher, async () => {
             const outcome = await finalReply.dispatcherOutcome;
             // A post-send error can leave visibility unknown. Only an acknowledged

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -66,21 +66,6 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   const pendingFinalDeliveryIdentity = replies
     .map((reply) => getReplyPayloadMetadata(reply)?.pendingFinalDeliveryCompletion)
     .find((completion) => completion !== undefined);
-  // Final delivery is outside the progress wrappers. Wait until every source-ordered callback
-  // has at least started so a delayed tool/reasoning transition cannot appear after the final.
-  try {
-    if (state.preserveProgressCallbackStartOrder) {
-      await state.progressState.progressCallbackStartTail;
-    }
-    // Backstop: silent/streaming-delivered turns end without a visible final
-    // reply; trailing commentary must still land.
-    await state.flushPendingCommentaryProgress();
-  } catch (error) {
-    // Commentary flush precedes the status-specific handoff owner. Release the
-    // child before that pre-queue failure can escape finalization.
-    await pendingContinuationSettlement?.settle(false);
-    throw error;
-  }
   const beforeAgentRunBlocked = replies.some(
     (reply) => getReplyPayloadMetadata(reply)?.beforeAgentRunBlocked === true,
   );
@@ -94,46 +79,45 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   const finalDeliveries: Array<Promise<ReplyDispatchDeliveryOutcome> | undefined> = [];
   const sentFinalPayloadDedupeKeys = new Set<string>();
   let deferredTtsTextPending = state.progressState.accumulatedBlockTtsText;
-  for (const [replyIndex, reply] of replies.entries()) {
-    const continuationSettlement =
-      pendingContinuationSettlement?.statusPayload === reply
-        ? pendingContinuationSettlement
-        : undefined;
-    let continuationSettlementAttempted = false;
-    let continuationSettlementRegistered = false;
-    const settleContinuation = async (statusDelivered: boolean) => {
-      if (!continuationSettlement || continuationSettlementAttempted) {
-        return;
-      }
-      continuationSettlementAttempted = true;
-      try {
-        await continuationSettlement.settle(statusDelivered);
-      } catch (error) {
-        if (!statusDelivered) {
-          throw error;
-        }
-        // A delivered waiting status must not strand its child completion when
-        // the batch handoff races a replaced registry row. Release the child
-        // to its normal terminal-delivery owner instead.
-        logVerbose(
-          `dispatch-from-config: continuation batch handoff failed: ${formatErrorMessage(error)}`,
-        );
-        await continuationSettlement.settle(false);
-      }
-    };
-    const releaseContinuationSettlement = () => settleContinuation(false);
+  let continuationSettlementAttempted = false;
+  let continuationSettlementRegistered = false;
+  const settleContinuation = async (statusDelivered: boolean) => {
+    if (!pendingContinuationSettlement || continuationSettlementAttempted) {
+      return;
+    }
+    continuationSettlementAttempted = true;
     try {
+      await pendingContinuationSettlement.settle(statusDelivered);
+    } catch (error) {
+      if (!statusDelivered) {
+        throw error;
+      }
+      // A delivered waiting status must not strand its child completion when
+      // the batch handoff races a replaced registry row. Release the child
+      // to its normal terminal-delivery owner instead.
+      logVerbose(
+        `dispatch-from-config: continuation batch handoff failed: ${formatErrorMessage(error)}`,
+      );
+      await pendingContinuationSettlement.settle(false);
+    }
+  };
+  try {
+    // Final delivery follows every source-ordered progress callback, including
+    // trailing commentary on silent or streaming-delivered turns.
+    if (state.preserveProgressCallbackStartOrder) {
+      await state.progressState.progressCallbackStartTail;
+    }
+    await state.flushPendingCommentaryProgress();
+    for (const [replyIndex, reply] of replies.entries()) {
       throwIfDispatchOperationAborted();
       // Durable reasoning is a channel-owned lane; generic channels keep the
       // historical suppression unless they explicitly opt in.
       if (reply.isReasoning === true && !state.reasoningPayloadsEnabled) {
         await suppressPendingFinalDelivery(reply);
-        await releaseContinuationSettlement();
         continue;
       }
       if (reply.isCommentary === true && !state.commentaryPayloadsEnabled) {
         await suppressPendingFinalDelivery(reply);
-        await releaseContinuationSettlement();
         continue;
       }
       if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply, state)) {
@@ -152,13 +136,11 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
           );
         }
         await suppressPendingFinalDelivery(reply);
-        await releaseContinuationSettlement();
         continue;
       }
       const finalPayloadDedupeKey = createFinalDispatchPayloadDedupeKey(reply);
       if (sentFinalPayloadDedupeKeys.has(finalPayloadDedupeKey)) {
         await suppressPendingFinalDelivery(reply);
-        await releaseContinuationSettlement();
         continue;
       }
       sentFinalPayloadDedupeKeys.add(finalPayloadDedupeKey);
@@ -173,12 +155,10 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       });
       if (finalReply.sessionWriterDeliveryRevoked) {
         sessionWriterDeliveryRevoked = true;
-        await releaseContinuationSettlement();
         continue;
       }
       if (finalReply.suppressionReason) {
         channelTransformSuppressedFinal ||= finalReply.suppressionReason === "channel_transform";
-        await releaseContinuationSettlement();
         continue;
       }
       acceptedFinal = true;
@@ -188,7 +168,6 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       if (finalReply.dedupedAgainstBlock) {
         // The delivering block already settled into the turn ledger.
         await suppressPendingFinalDelivery(reply);
-        await releaseContinuationSettlement();
         continue;
       }
       attemptedFinalDelivery = true;
@@ -197,7 +176,8 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       if (finalReply.queuedFinal) {
         finalDeliveries.push(finalReply.dispatcherOutcome);
       }
-      if (continuationSettlement) {
+      // Metadata survives usage, threading, and transcript decoration; object identity does not.
+      if (pendingContinuationSettlement && getReplyPayloadMetadata(reply)?.continuationStatus) {
         if (finalReply.queuedFinal) {
           registerReplyDispatcherSettledTask(dispatcher, async () => {
             const outcome = await finalReply.dispatcherOutcome;
@@ -210,11 +190,12 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
           await settleContinuation(finalReply.routedFinalCount > 0);
         }
       }
-    } catch (error) {
-      if (!continuationSettlementRegistered) {
-        await releaseContinuationSettlement();
-      }
-      throw error;
+    }
+  } finally {
+    // The batch owns release even when an earlier payload fails or the status
+    // is filtered out. An admitted status transfers ownership to queue settlement.
+    if (!continuationSettlementRegistered) {
+      await settleContinuation(false);
     }
   }
   let channelTransformSuppressed =

--- a/src/auto-reply/reply/get-reply.types.ts
+++ b/src/auto-reply/reply/get-reply.types.ts
@@ -21,7 +21,6 @@ export type ReplySessionBinding = {
 };
 
 export type PendingContinuationSettlement = {
-  statusPayload: ReplyPayload;
   settle: (statusDelivered: boolean) => Promise<void>;
 };
 


### PR DESCRIPTION
Closes #137099

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users delegating work to a child would never receive the final parent completion when usage decoration copied the continuation status, or when dispatch failed before the status settled. The child could finish successfully while its completion remained blocked by the requester's provisional ownership.

## Why This Change Was Made

Continuation identity now follows the existing private payload metadata through decoration. One batch cleanup owner and an explicit execute-to-finalize transfer replace repeated per-payload and early-return cleanup paths. Delivery settlement uses the actual queued outcome or routed receipt; the dispatcher runs every registered settlement sequentially even when draining or another cleanup fails, preserving the original run/delivery error and typed no-send retry semantics.

The obsolete internal status-object field and separate settled-task runner are removed. Cumulative production changes are **+110 / −113 = −3 lines**; tests are **+283 / −80 = +203 lines**. No configuration, schema, protocol, provider contract, Webchat projection, or registry wake-policy change.

## User Impact

An accepted child can deliver its completion after the parent's waiting status is decorated, filtered, or interrupted. Routed acknowledgments remain delivered, failed sends release normal child delivery, and later cleanup failures cannot strand other registered owners. External provider/channel behavior is unchanged.

## Evidence

- Red-before-green regressions reproduced lost settlement for usage decoration, earlier notice failure, missing status, and a post-resolution metadata callback failure. Additional independent-review regressions failed on routed success and typed retryable no-send draining, with ordered cleanup/error-precedence coverage.
- **103 tests across six affected suites pass** on the final candidate: dispatcher lifecycle, foreground delivery ordering, continuation settlement, final outcome accounting, reply dispatch, and terminal recovery. Full changed-file checks and the exact full build pass. Fresh isolated Codex autoreview and a separate frozen-candidate independent review found no actionable P0–P2 findings.
- **Live Gateway/UI with synthetic provider:** the real UI invokes an actual accepted `sessions_spawn`; the synthetic HTTP provider then ends the parent turn without text and holds the child. An observation-only plugin hook records the real synthesized status with `Usage: 128 in / 40 out`. After releasing the child, baseline delivery remains `pending` with `completion_handoff_pending` and no final parent reply; the candidate records `delivered`, clears requester ownership, and shows exactly one final parent completion through a five-second duplicate-observation window. Both isolated Gateways stop with zero cleanup errors.

The baseline still displays its finished-child activity card. Webchat intentionally does not render the transport-only waiting status/footer; those are observed at the delivery boundary, not presented as visible UI text. This is real Gateway/browser proof with a synthetic provider, not a live provider or channel test.

Before/after screenshots and recordings were personally inspected and contain only synthetic task content. Media will be attached below. Exact PR-head CI and repository-native landing checks remain pending. Regression introduction attribution is unknown; this report does not assign it from merge metadata.
