### PR TITLE
fix(tests): avoid false failures during fixture startup

### DIFF
--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -1147,16 +1147,40 @@ describe("openclaw test instance", () => {
 
   it.runIf(process.platform !== "win32")(
     "reaps terminal children with inherited stdio before starting a new gateway",
-    async () => {
+    async ({ signal: testSignal }) => {
       const stopTimeoutMs = 100;
+      const control = await createGatewayControl();
       const { instance, readAttempts, tracePath } = await createFakeGateway(
         "terminal-drain,ready",
         300,
         stopTimeoutMs,
+        control,
       );
-
+      // Bootstrap is not the teardown deadline. Start policy time at native exit,
+      // keeping the real inherited-pipe drain and failed restart budgets intact.
+      testSignal.throwIfAborted();
+      const now = Date.now.bind(Date);
+      const fixtureTime = now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(fixtureTime);
+      const restoreClock = () => clock.mockRestore();
+      testSignal.addEventListener("abort", restoreClock, { once: true });
+      const exited = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+      control.observers.onLaunch = () => {
+        if (control.launches.length !== 1) {
+          return;
+        }
+        const leader = instance.child;
+        if (!leader) {
+          exited.reject(new Error("fixture launched without a process owner"));
+          return;
+        }
+        leader.once("exit", (code, signal) => exited.resolve({ code, signal }));
+      };
       const startup = trackOperation(instance.startGateway());
       try {
+        expect(await Promise.race([exited.promise, startup])).toEqual({ code: 7, signal: null });
+        const drainStartedAt = now();
+        clock.mockImplementation(() => fixtureTime + now() - drainStartedAt);
         const startupError = await startup.catch((error: unknown) => error);
         expect(startupError).toBeInstanceOf(Error);
         expect((startupError as Error).message).toContain(
@@ -1193,7 +1217,9 @@ describe("openclaw test instance", () => {
         );
         expect(firstChild.stdout.closed).toBe(true);
         expect(firstChild.stderr.closed).toBe(true);
+        clock.mockReturnValue(Date.now());
         await trackOperation(instance.startGateway());
+        restoreClock();
 
         const attempts = await readAttempts();
         expect(attempts).toHaveLength(2);
@@ -1204,6 +1230,8 @@ describe("openclaw test instance", () => {
         expect(isProcessAlive(attempts[1]?.pid as number)).toBe(false);
         await expect.poll(() => isProcessAlive(drainingPid), { timeout: 500 }).toBe(false);
       } finally {
+        restoreClock();
+        testSignal.removeEventListener("abort", restoreClock);
         await fs.writeFile(`${tracePath}.draining-release`, "");
         await Promise.allSettled([startup]);
       }

--- a/test/scripts/plugin-gateway-gauntlet.test.ts
+++ b/test/scripts/plugin-gateway-gauntlet.test.ts
@@ -1,5 +1,6 @@
 // Plugin Gateway Gauntlet tests cover plugin gateway gauntlet script behavior.
 import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -27,6 +28,9 @@ import {
   discoverBundledPluginManifests,
   selectPluginEntries,
 } from "../../scripts/lib/plugin-gateway-gauntlet.mts";
+import { isProcessAlive } from "../helpers/process-wait.js";
+import { withTestTimeout } from "../helpers/promise.js";
+import { runQaGatewayFixture } from "../helpers/qa-gateway-cleanup.js";
 
 const tsxImport = import.meta.resolve("tsx");
 
@@ -169,15 +173,6 @@ describe("plugin gateway gauntlet helpers", () => {
         },
       ],
     };
-  }
-
-  function isProcessAlive(pid: number): boolean {
-    try {
-      process.kill(pid, 0);
-      return true;
-    } catch {
-      return false;
-    }
   }
 
   async function waitFor(predicate: () => Promise<boolean> | boolean, timeoutMs = 5_000) {
@@ -989,7 +984,7 @@ await runMeasuredCommandLive({
       const scriptPath = path.join(repoRoot, "timeout-parent-termination-leader.mjs");
       const grandchildPidPath = path.join(repoRoot, "timeout-grandchild.pid");
       const grandchildReadyPath = path.join(repoRoot, "timeout-grandchild.ready");
-      const leaderExitedPath = path.join(repoRoot, "timeout-leader.exited");
+      const leaderPidPath = path.join(repoRoot, "timeout-leader.pid");
       let grandchildPid = 0;
 
       await fs.writeFile(
@@ -999,20 +994,17 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 
 const grandchildScript = [
-  "const fs = require('node:fs');",
   "process.on('SIGTERM', () => {});",
   "process.on('SIGHUP', () => {});",
-  "fs.writeFileSync(process.argv[2], 'ready');",
+  "process.send('ready');",
   "setInterval(() => {}, 1000);",
 ].join("\\n");
-const grandchild = spawn(process.execPath, ["-e", grandchildScript, "child", process.argv[3]], {
-  stdio: "ignore",
+const grandchild = spawn(process.execPath, ["-e", grandchildScript], {
+  stdio: ["ignore", "ignore", "ignore", "ipc"],
 });
 fs.writeFileSync(process.argv[2], String(grandchild.pid));
-process.on("SIGTERM", () => {
-  fs.writeFileSync(process.argv[4], "exited");
-  process.exit(0);
-});
+process.on("SIGTERM", () => process.exit(0));
+grandchild.once("message", () => process.send("ready", () => process.disconnect()));
 setInterval(() => {}, 1000);
 `,
         "utf8",
@@ -1020,38 +1012,73 @@ setInterval(() => {}, 1000);
       await fs.writeFile(
         harnessPath,
         `
+import assert from "node:assert/strict";
+import { channel } from "node:diagnostics_channel";
+import { once } from "node:events";
 import fs from "node:fs";
+import { mock } from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
 import { runMeasuredCommandLive } from ${JSON.stringify(
           pathToFileURL(path.resolve("scripts/check-plugin-gateway-gauntlet.mts")).href,
         )};
 
+import { inspectManagedProcessGroup } from ${JSON.stringify(
+          pathToFileURL(path.resolve("scripts/lib/managed-child-process.mts")).href,
+        )};
+
+const realDelay = delay;
+// Mocked timers cannot keep Node alive while a native signal is in flight.
+const keepAlive = setInterval(() => {}, 1_000);
+const children = channel("child_process");
+let child, ready, closed;
+const observeChild = ({ process: owned }) => {
+  child = owned;
+  ready = once(child, "message");
+  closed = once(child, "close");
+};
+// Only the controller's policy clock is mocked; readiness, exit, and signals are native.
+mock.timers.enable({ apis: ["Date", "setTimeout"] });
+children.subscribe(observeChild);
 const promise = runMeasuredCommandLive({
   cwd: ${JSON.stringify(repoRoot)},
   env: process.env,
   logDir: ${JSON.stringify(logDir)},
   command: process.execPath,
-  args: [${JSON.stringify(scriptPath)}, ${JSON.stringify(grandchildPidPath)}, ${JSON.stringify(
-    grandchildReadyPath,
-  )}, ${JSON.stringify(leaderExitedPath)}],
+  args: [${JSON.stringify(scriptPath)}, ${JSON.stringify(grandchildPidPath)}],
   label: "timeout-parent-termination",
   phase: "probe",
   timeoutKillGraceMs: 150,
   timeoutMs: 200,
   timeMode: "none",
+  spawnOptions: { stdio: ["ignore", "pipe", "pipe", "ipc"] },
 });
-for (let attempt = 0; attempt < 200 && !fs.existsSync(${JSON.stringify(
-          leaderExitedPath,
-        )}); attempt += 1) {
-  await delay(10);
+children.unsubscribe(observeChild);
+fs.writeFileSync(${JSON.stringify(leaderPidPath)}, String(child.pid));
+try {
+  assert.equal((await ready)[0], "ready");
+  fs.writeFileSync(${JSON.stringify(grandchildReadyPath)}, "ready");
+  mock.timers.tick(200);
+  assert.deepEqual(await closed, [0, null]);
+  assert.equal(inspectManagedProcessGroup(child, { errorPolicy: "indeterminate" }), "live");
+  const termination = once(process, "SIGTERM");
+  process.kill(process.pid, "SIGTERM");
+  await termination;
+  mock.timers.tick(150);
+  await new Promise(setImmediate);
+  const deadline = performance.now() + 5_000;
+  while (inspectManagedProcessGroup(child, { errorPolicy: "indeterminate" }) !== "dead") {
+    assert.ok(performance.now() < deadline, "process group survived SIGKILL");
+    await realDelay(5);
+  }
+  // Linux can retain a zombie group after native death. Drain the owner's existing
+  // 100 ms post-KILL fallback before expecting its original parent signal.
+  mock.timers.tick(100);
+  await promise;
+  process.exitCode = 7;
+} finally {
+  mock.timers.reset();
+  clearInterval(keepAlive);
 }
-if (!fs.existsSync(${JSON.stringify(leaderExitedPath)})) {
-  process.exit(2);
-}
-await delay(20);
-process.kill(process.pid, "SIGTERM");
-await promise;
-process.exit(7);
 `,
         "utf8",
       );
@@ -1060,27 +1087,62 @@ process.exit(7);
         cwd: repoRoot,
         stdio: ["ignore", "pipe", "pipe"],
       });
-      try {
-        await waitFor(async () => {
-          try {
-            await fs.access(grandchildReadyPath);
-            return true;
-          } catch {
-            return false;
+      const closed = once(harness, "close");
+      void closed.catch(() => undefined);
+      let stderr = "";
+      harness.stdout.resume();
+      harness.stderr.on("data", (chunk) => {
+        stderr += String(chunk);
+      });
+      const reapPidFile = async (pidPath: string, group = false) => {
+        let pid: number;
+        try {
+          pid = Number(await fs.readFile(pidPath, "utf8"));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return;
           }
-        });
-        grandchildPid = Number.parseInt(await fs.readFile(grandchildPidPath, "utf8"), 10);
+          throw error;
+        }
+        expect(Number.isSafeInteger(pid) && pid > 1).toBe(true);
+        try {
+          process.kill(group ? -pid : pid, "SIGKILL");
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+            throw error;
+          }
+        }
+        await waitFor(() => !isProcessAlive(pid));
+      };
+      await runQaGatewayFixture(
+        async () => {
+          await waitFor(async () => {
+            try {
+              await fs.access(grandchildReadyPath);
+              return true;
+            } catch {
+              return false;
+            }
+          }).catch((error: unknown) => {
+            throw new Error(`${String(error)}\n${stderr}`, { cause: error });
+          });
+          grandchildPid = Number.parseInt(await fs.readFile(grandchildPidPath, "utf8"), 10);
 
-        await expect(waitForClose(harness)).resolves.toEqual({ code: null, signal: "SIGTERM" });
-        await waitFor(() => !isProcessAlive(grandchildPid));
-      } finally {
-        if (grandchildPid && isProcessAlive(grandchildPid)) {
-          process.kill(grandchildPid, "SIGKILL");
-        }
-        if (harness.pid && isProcessAlive(harness.pid)) {
-          harness.kill("SIGKILL");
-        }
-      }
+          expect(
+            await withTestTimeout(closed, 5_000, "harness did not close after fixture readiness"),
+            stderr,
+          ).toEqual([null, "SIGTERM"]);
+          await waitFor(() => !isProcessAlive(grandchildPid));
+        },
+        () => reapPidFile(leaderPidPath, true),
+        () => reapPidFile(grandchildPidPath),
+        async () => {
+          if (harness.pid && isProcessAlive(harness.pid)) {
+            harness.kill("SIGKILL");
+          }
+          await withTestTimeout(closed, 5_000, "fixture cleanup did not join harness closure");
+        },
+      );
     },
   );
 

--- a/ui/src/pages/chat/chat-pane-placement-restart.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement-restart.test.ts
@@ -55,7 +55,7 @@ describe("chat pane placement restart", () => {
     };
 
     const restarting = dialogs.track(pane.restartHeaderPlacement(session));
-    await vi.waitFor(() => {
+    await dialogs.waitFor(() => {
       expect(document.body.querySelector('[data-value="cloud:aws"]')).not.toBeNull();
     });
     expect(document.body.textContent).toContain(

--- a/ui/src/pages/chat/chat-pane-placement.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement.test.ts
@@ -83,7 +83,7 @@ describe("chat pane placement", () => {
     const session = { ...activePlacementSession(), hasActiveRun: true };
 
     const moving = dialogs.track(pane.moveHeaderPlacement(session));
-    await vi.waitFor(() => {
+    await dialogs.waitFor(() => {
       expect(document.body.querySelector('[data-value="device:runner"]')).not.toBeNull();
     });
     expect(document.body.querySelector('[data-value="cloud:aws"]')).toBeNull();
@@ -155,7 +155,7 @@ describe("chat pane placement", () => {
     const session = activePlacementSession();
 
     const moving = dialogs.track(pane.moveHeaderPlacement(session));
-    await vi.waitFor(() => {
+    await dialogs.waitFor(() => {
       expect(document.body.querySelector('[data-value="cloud:aws"]')).not.toBeNull();
     });
     document.body.querySelector<HTMLButtonElement>('[data-value="cloud:aws"]')?.click();
@@ -252,7 +252,7 @@ describe("chat pane placement", () => {
       } satisfies GatewaySessionRow;
 
       const moving = dialogs.track(pane.moveHeaderPlacement(session));
-      await vi.waitFor(() => {
+      await dialogs.waitFor(() => {
         expect(document.body.querySelector('[data-value="cloud:aws"]')).not.toBeNull();
       });
       const incompatible = document.body.querySelector<HTMLButtonElement>(
@@ -411,7 +411,7 @@ describe("chat pane placement", () => {
     } satisfies GatewaySessionRow;
 
     const moving = dialogs.track(pane.moveHeaderPlacement(session));
-    await vi.waitFor(() => {
+    await dialogs.waitFor(() => {
       expect(document.body.querySelector('[data-value="device:build-mac"]')).not.toBeNull();
     });
     const device = document.body.querySelector<HTMLButtonElement>(
@@ -490,7 +490,7 @@ describe("chat pane placement", () => {
       } satisfies GatewaySessionRow;
 
       const moving = dialogs.track(pane.moveHeaderPlacement(session));
-      await vi.waitFor(() => {
+      await dialogs.waitFor(() => {
         expect(document.body.querySelector('[data-value="device:build-mac"]')).not.toBeNull();
       });
       document.body.querySelector<HTMLButtonElement>('[data-value="device:build-mac"]')?.click();
@@ -609,12 +609,12 @@ describe("chat pane placement", () => {
     } satisfies GatewaySessionRow;
 
     const moving = dialogs.track(pane.moveHeaderPlacement(session));
-    await vi.waitFor(() =>
+    await dialogs.waitFor(() =>
       expect(request).toHaveBeenCalledWith("environments.list", {
         runtimeId: scenario.runtimeId,
       }),
     );
-    await vi.waitFor(() => {
+    await dialogs.waitFor(() => {
       expect(document.body.querySelector('[data-value="device:build-mac"]')).not.toBeNull();
     });
     const device = document.body.querySelector<HTMLButtonElement>(

--- a/ui/src/test-helpers/modal-dialog.ts
+++ b/ui/src/test-helpers/modal-dialog.ts
@@ -1,5 +1,4 @@
 import type WaDialog from "@awesome.me/webawesome/dist/components/dialog/dialog.js";
-// Control UI test helper supports modal dialog setup.
 import { expect, vi } from "vitest";
 import type { OpenClawModalDialog } from "../components/modal-dialog.ts";
 
@@ -41,6 +40,12 @@ export function installDialogPolyfill(): () => void {
     restoreDescriptor("showModal", snapshot.showModal);
     restoreDescriptor("close", snapshot.close);
   };
+}
+
+async function waitForDialog<T>(read: () => T): Promise<T> {
+  // Lazy module loading is fixture setup, not part of the DOM readiness deadline.
+  await vi.dynamicImportSettled();
+  return vi.waitFor(read);
 }
 
 export function createModalDialogTestFixture() {
@@ -99,6 +104,7 @@ export function createModalDialogTestFixture() {
   }
 
   return {
+    waitFor: waitForDialog,
     track: <T>(completion: Promise<T>) => track(completion, operations),
     mockRequest: <Args extends unknown[], Result>(request: (...args: Args) => Promise<Result>) =>
       vi.fn((...args: Args) => track(request(...args), requests)),
@@ -112,7 +118,7 @@ export function createModalDialogTestFixture() {
  * reconnect, an agent switch) while the decision is still pending.
  */
 export function waitForConfirmDialogActions(): Promise<HTMLElement> {
-  return vi.waitFor(() => {
+  return waitForDialog(() => {
     const actions = document.body.querySelector<HTMLElement>(
       "openclaw-modal-dialog .exec-approval-actions",
     );
@@ -135,7 +141,7 @@ export function answerConfirmDialog(actions: HTMLElement, choice: "confirm" | "c
 
 /** Await a dialog whose owner loads it behind a lazy import, then read it. */
 export async function waitForRenderedModalDialog(container: HTMLElement) {
-  await vi.waitFor(() => {
+  await waitForDialog(() => {
     if (!container.querySelector("openclaw-modal-dialog")) {
       throw new Error("Expected openclaw-modal-dialog");
     }
@@ -144,6 +150,7 @@ export async function waitForRenderedModalDialog(container: HTMLElement) {
 }
 
 export async function waitForInputDialog(): Promise<HTMLInputElement> {
+  await vi.dynamicImportSettled();
   for (let attempt = 0; attempt < 50; attempt += 1) {
     const input = document.body.querySelector("openclaw-modal-dialog input");
     if (input instanceof HTMLInputElement) {


### PR DESCRIPTION
Closes #136708. Follow-up to the unrelated CI failures observed while landing the Android cleanup in #136934.

## What Problem This Solves

Resolves false CI failures when cold dialog imports or native child startup consume short deadlines intended to test rendering, pipe draining, or termination behavior. Retrying the Android PR passed unchanged; it did not repair these races.

## Why This Change Was Made

Fixture readiness now precedes the behavior clock. The existing modal helpers join lazy imports before starting their unchanged DOM waits; placement prerequisites use the same helper. They deliberately do not await the action being confirmed or an intentionally held RPC.

The terminal-child fixture starts its real drain budget at native exit. The gauntlet's isolated controller waits for actual descendant IPC readiness before driving its existing 200 ms timeout, verifies native child closure, then sends a real parent SIGTERM during the unchanged 150 ms kill grace. Native process-group inspection handles Linux zombies, and failure cleanup joins the harness and known children. The pre-exit marker/sleep inference and duplicate PID probe are removed.

The refusal/retry and UTF-8 initialization cases from #136708 were already repaired by 6187bd6faff7d71aec9adc7548cf1ec3608bfeb9; their complete owning suites remain covered here.

## User Impact

No product or runtime behavior changes. No longer deadlines, retries, new configuration, dependencies, or weaker business assertions. Production LOC: **+0/-0**. Tests and test support: **+160/-63 (net +97)**.

## Evidence

Controlled regressions on base `2fffd4e8ba116813222b28b89179fd911784aeae`, repeated after the fix:

| Real fixture path | Controlled setup delay | Before → after |
| --- | ---: | --- |
| Placement restart | 2,000 ms real Vite module load | Missing profile selector → pass |
| Stop confirmation | 2,000 ms real Vite module load | Missing confirmation → pass |
| Markdown expanded-table modal | 2,000 ms real Vite module load | Missing modal → pass |
| Header group input | 2,000 ms real Vite module load | Missing input → pass |
| Terminal child with inherited stderr | 600 ms child initialization | Readiness timeout instead of exit 7 → pass |
| Parent termination during gauntlet timeout cleanup | 600 ms child initialization | Descendant never ready before timeout → pass |

The Vite hook returns `null` after its delay, preserving real module exports, components, catalog fixtures, and actions. Each delay overlaps the selected test. All four passing dialog probes finish after import release with zero remaining modals/body children, restored dialog methods, and no unhandled errors. Temporary delay injection is not in this patch.

Normal final-source checks on Darwin/arm64, Node 24.19.0:

- Canonical shared UI caller group: **518 passed** across seven files.
- Canonical isolated UI caller group: **50 passed** across two files.
- Both complete subprocess owning suites: **104 passed**, one existing Windows-only test skipped.
- Three existing managed-child deadline/cleanup sibling cases passed.
- Both changed-check selections passed: formatting, relevant typechecking/lint, and architectural guards. Initial test-style lint failures were corrected before the final pass.
- Fresh independent Codex review: no actionable P0–P2 findings.

Commands:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs --config test/vitest/vitest.ui.config.ts ui/src/components/app-sidebar.test.ts ui/src/components/session-organizer-batch-mutations.test.ts ui/src/pages/config/config-page.test.ts ui/src/pages/devices/devices-page.test.ts ui/src/pages/chat/chat-pane-placement.test.ts ui/src/pages/chat/chat-pane-placement-restart.test.ts ui/src/pages/chat/chat-pane-placement-stop.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs --config test/vitest/vitest.ui-isolated.config.ts ui/src/components/markdown-tables.test.ts ui/src/pages/chat/chat-pane.test.ts
node scripts/run-vitest.mjs --config test/vitest/vitest.tooling.config.ts test/helpers/openclaw-test-instance.test.ts test/scripts/plugin-gateway-gauntlet.test.ts
node scripts/check-changed.mjs -- ui/src/pages/chat/chat-pane-placement-restart.test.ts ui/src/pages/chat/chat-pane-placement.test.ts ui/src/test-helpers/modal-dialog.ts
node scripts/check-changed.mjs -- test/helpers/openclaw-test-instance.test.ts test/scripts/plugin-gateway-gauntlet.test.ts
```

Limits: the original interleaved Linux logs do not identify same-worker predecessor order, and the historical full shards were not replayed locally. Controlled failing synchronization regressions establish the mechanism. Exact-head hosted Linux CI is still required before landing. No browser screenshot is needed for these test-only changes. Historical introduction provenance is unknown; this does not attribute the flakes to the Android changes.

Follow-up: some generic dialog callers have owner-specific failure-teardown needs, especially token-reveal dialogs that intentionally reject cancellation. This patch preserves their behavior; blindly applying generic cancel-and-join cleanup would deadlock those fixtures.
