### PR TITLE
fix(test): process-group termination test flakes on hosted runners

### DIFF
--- a/test/scripts/openclaw-e2e-instance.test.ts
+++ b/test/scripts/openclaw-e2e-instance.test.ts
@@ -757,7 +757,7 @@ fi
 set -euo pipefail
 source ${shellQuote(helperPath)}
 tracked_pid="$(openclaw_e2e_start_tracked_process ${shellQuote(logPath)} ${shellQuote(process.execPath)} ${shellQuote(parentPath)} ${shellQuote(childPath)} ${shellQuote(parentPidPath)} ${shellQuote(childPidPath)} ${shellQuote(childTermPath)})"
-for ((i = 0; i < 100; i += 1)); do
+for ((i = 0; i < 500; i += 1)); do
   [ -s ${shellQuote(parentPidPath)} ] && [ -s ${shellQuote(childPidPath)} ] && break
   /bin/sleep 0.02
 done
@@ -765,7 +765,7 @@ done
 [ -s ${shellQuote(childPidPath)} ]
 child_pid="$(/bin/cat ${shellQuote(childPidPath)})"
 openclaw_e2e_stop_process "$tracked_pid"
-for ((i = 0; i < 100; i += 1)); do
+for ((i = 0; i < 500; i += 1)); do
   [ -s ${shellQuote(childTermPath)} ] && break
   /bin/sleep 0.02
 done
@@ -773,7 +773,7 @@ done
   echo "tracked child did not receive SIGTERM" >&2
   exit 1
 }
-for ((i = 0; i < 100; i += 1)); do
+for ((i = 0; i < 500; i += 1)); do
   kill -0 "$child_pid" 2>/dev/null || exit 0
   /bin/sleep 0.02
 done
@@ -781,7 +781,9 @@ echo "tracked child still alive after group termination" >&2
 exit 1
 `;
 
-      const result = runBash(script, { PATH: hostPath }, 5_000);
+      // Hosted 4-core runners can take well over two seconds to start two Node processes,
+      // so each readiness and termination window allows ten seconds.
+      const result = runBash(script, { PATH: hostPath }, 40_000);
 
       expectShellSuccess(result);
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the `checks-node-compact-small-*` shard failed on unrelated changes when `test/scripts/openclaw-e2e-instance.test.ts` › "terminates descendants in the tracked process group" ran on a hosted 4-core runner: the test allowed only two seconds for two Node processes to publish PID files, receive SIGTERM, and exit, and reported "tracked child still alive" or "did not receive SIGTERM" under load.

## Why This Change Was Made

The three poll windows in the embedded bash script grow from 100 to 500 iterations of 20 ms (ten seconds each), and the `runBash` timeout grows to 40 s so it can never cut the windows short. The assertions and the helper under test are unchanged; this only gives a timing-dependent check a tolerance proportionate to slow runners.

## User Impact

None for users. Maintainers stop seeing this shard fail on hosted reruns of unrelated PRs.

## Evidence

- Failing occurrence on a Swift-only PR after a hosted rerun: https://github.com/openclaw/openclaw/actions/runs/33723004348/job/100547029771 (`AssertionError: expected 1 to be +0` at `expectShellSuccess`, shard `core-tooling-isolated`).
- Local: `node scripts/run-vitest.mjs test/scripts/openclaw-e2e-instance.test.ts` → 38 tests passed.
- `oxfmt --check` clean; Codex autoreview scoped-clean.
