### PR TITLE
fix: release retired session-list cache pages

### DIFF
--- a/scripts/lib/vitest-worker-artifacts.mts
+++ b/scripts/lib/vitest-worker-artifacts.mts
@@ -15,6 +15,8 @@ export const vitestWorkerDeclarationEntries = {
   "agents/command/cli-compaction-runtime.test-support":
     "src/agents/command/cli-compaction-runtime.test-support.ts",
   "cron/owner-hardening-runtime.test-support": "src/cron/owner-hardening-runtime.test-support.ts",
+  "gateway/server-methods/sessions-list-cache-retention-entrypoint.test-support":
+    "src/gateway/server-methods/sessions-list-cache-retention-entrypoint.test-support.ts",
   "gateway/session-title-retention.test-support":
     "src/gateway/session-title-retention.test-support.ts",
   "node-host/config-runtime.test-support": "src/node-host/config-runtime.test-support.ts",

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -2,6 +2,7 @@ import { fileURLToPath } from "node:url";
 import { qaGatewayCleanupRuntimeEntrypoint } from "../../extensions/qa-lab/src/gateway-child-artifacts-runtime.test-support.ts";
 import { cliCompactionBackendEntrypoints } from "../../src/agents/command/cli-compaction-runtime.test-support.ts";
 import { cronOwnerHardeningEntrypoints } from "../../src/cron/owner-hardening-runtime.test-support.ts";
+import { sessionListCacheRetentionEntrypoint } from "../../src/gateway/server-methods/sessions-list-cache-retention-entrypoint.test-support.ts";
 import { sessionTitleRetentionEntrypoints } from "../../src/gateway/session-title-retention.test-support.ts";
 import { nodeHostConfigRuntimeEntrypoint } from "../../src/node-host/config-runtime.test-support.ts";
 import { persistenceRuntimeEntrypoint } from "../../src/skills/library/persistence-runtime.test-support.ts";
@@ -18,6 +19,7 @@ export const vitestWorkerBuildEntries = {
       ...Object.values(cronOwnerHardeningEntrypoints),
       ...Object.values(tuiPtyRuntimeEntrypoints),
       ...Object.values(sessionTitleRetentionEntrypoints),
+      sessionListCacheRetentionEntrypoint,
       nodeHostConfigRuntimeEntrypoint,
       persistenceRuntimeEntrypoint,
       qaGatewayCleanupRuntimeEntrypoint,

--- a/src/gateway/server-methods/sessions-list-cache-retention-entrypoint.test-support.ts
+++ b/src/gateway/server-methods/sessions-list-cache-retention-entrypoint.test-support.ts
@@ -1,0 +1,6 @@
+// Prepare the runtime graph before the retention child's bounded GC checks.
+export const sessionListCacheRetentionEntrypoint = {
+  currentModuleUrl: import.meta.url,
+  sourceWorkerName: "sessions-list-cache-retention.test-support",
+  distWorkerPath: "gateway/server-methods/sessions-list-cache-retention.test-support.js",
+} as const;

--- a/src/gateway/server-methods/sessions-list-cache-retention.test-support.ts
+++ b/src/gateway/server-methods/sessions-list-cache-retention.test-support.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { bumpSessionAutomationVersion } from "../session-automation-index.js";
+import type { SessionsListResult } from "../session-utils.types.js";
+import { respondWithCachedSessionList } from "./sessions-list-cache.js";
+import type { GatewayRequestContext } from "./types.js";
+
+function requireGc() {
+  const gc = globalThis.gc;
+  assert.ok(gc, "The retention child requires --expose-gc");
+  return gc;
+}
+
+const gc = requireGc();
+
+function result(key: string, hasActiveRun = false): SessionsListResult {
+  return {
+    ts: 1,
+    path: "synthetic",
+    count: 1,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: [{ key, kind: "direct", updatedAt: 1, hasActiveRun }],
+  };
+}
+
+async function retainedAfterRotation(rotation: "fence" | "config" | "catalog" | "expiry") {
+  const context = {} as GatewayRequestContext;
+  let config: OpenClawConfig = {};
+  const retired: WeakRef<SessionsListResult>[] = [];
+  const control = new WeakRef(result("uncached"));
+  const modelCatalog = new Map([["main", { entries: [] }]]);
+  const readNow = Date.now;
+  const expiresAt = readNow() + 60_000;
+  const currentKeyOnly = rotation === "catalog" || rotation === "expiry";
+  const request = async (offset: number, run: () => Promise<SessionsListResult>) => {
+    let response: unknown;
+    await respondWithCachedSessionList({
+      context,
+      config,
+      client: null,
+      modelCatalog,
+      request: { offset, limit: 1 },
+      run,
+      respond: (ok, payload) => {
+        assert.equal(ok, true);
+        response = payload;
+      },
+    });
+    return response;
+  };
+  for (const offset of [0, 1]) {
+    await request(offset, async () => {
+      const page = result(`cached-${offset}`);
+      if (rotation === "expiry") {
+        page.sessions[0]!.agentStatus = { note: "Temporary status", expiresAt };
+      }
+      if (!currentKeyOnly || offset === 0) {
+        retired.push(new WeakRef(page));
+      }
+      return page;
+    });
+  }
+  const started = createDeferredCore();
+  const release = createDeferredCore();
+  const pending = request(2, async () => {
+    started.resolve();
+    await release.promise;
+    return result("original-caller");
+  });
+  const refreshStarted = createDeferredCore();
+  const releaseRefresh = createDeferredCore();
+  let refresh: Promise<unknown> | undefined;
+  const collect = async () => {
+    // Dereferencing during collection would itself keep pages alive for that job.
+    for (let pass = 0; pass < 8; pass += 1) {
+      await setImmediate();
+      gc();
+    }
+    assert.equal(control.deref(), undefined, "The uncached control must be collected");
+    return retired.flatMap((reference, index) => (reference.deref() ? [index] : []));
+  };
+  try {
+    await started.promise;
+    if (rotation === "fence") {
+      bumpSessionAutomationVersion();
+    } else if (rotation === "config") {
+      config = {};
+    } else if (rotation === "catalog") {
+      modelCatalog.set("main", { entries: [] });
+    } else {
+      Date.now = () => expiresAt;
+    }
+    refresh = request(currentKeyOnly ? 0 : 3, async () => {
+      refreshStarted.resolve();
+      await releaseRefresh.promise;
+      return result("current", true);
+    });
+    await refreshStarted.promise;
+    // An old in-flight call keeps its state alive. It must not also keep pages
+    // that no request can reuse, including while an invalid-page refresh awaits.
+    const whileRefreshing = await collect();
+    releaseRefresh.resolve();
+    await refresh;
+    return { whileRefreshing, afterActiveResult: await collect() };
+  } finally {
+    Date.now = readNow;
+    releaseRefresh.resolve();
+    release.resolve();
+    await refresh;
+    assert.deepEqual(await pending, result("original-caller"));
+  }
+}
+
+process.stdout.write(
+  JSON.stringify({
+    fence: await retainedAfterRotation("fence"),
+    config: await retainedAfterRotation("config"),
+    catalog: await retainedAfterRotation("catalog"),
+    expiry: await retainedAfterRotation("expiry"),
+  }),
+);

--- a/src/gateway/server-methods/sessions-list-cache-retention.test.ts
+++ b/src/gateway/server-methods/sessions-list-cache-retention.test.ts
@@ -1,6 +1,11 @@
 import { fileURLToPath } from "node:url";
 import { expect, it } from "vitest";
 import { runNodeScript } from "../../../test/helpers/run-node-script.js";
+import {
+  resolveRuntimeWorkerArgv,
+  resolveRuntimeWorkerUrl,
+} from "../../infra/runtime-worker-url.js";
+import { sessionListCacheRetentionEntrypoint } from "./sessions-list-cache-retention-entrypoint.test-support.js";
 
 it("releases retired pages while their generation still has a pending caller", async ({
   signal,
@@ -8,9 +13,7 @@ it("releases retired pages while their generation still has a pending caller", a
   const result = await runNodeScript(
     [
       "--expose-gc",
-      "--import",
-      "tsx",
-      fileURLToPath(new URL("./sessions-list-cache-retention.test-support.ts", import.meta.url)),
+      ...resolveRuntimeWorkerArgv(resolveRuntimeWorkerUrl(sessionListCacheRetentionEntrypoint)),
     ],
     { ...process.env, NODE_OPTIONS: "", TSX_DISABLE_CACHE: "1" },
     15_000,

--- a/src/gateway/server-methods/sessions-list-cache-retention.test.ts
+++ b/src/gateway/server-methods/sessions-list-cache-retention.test.ts
@@ -1,0 +1,32 @@
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+import { runNodeScript } from "../../../test/helpers/run-node-script.js";
+
+it("releases retired pages while their generation still has a pending caller", async ({
+  signal,
+}) => {
+  const result = await runNodeScript(
+    [
+      "--expose-gc",
+      "--import",
+      "tsx",
+      fileURLToPath(new URL("./sessions-list-cache-retention.test-support.ts", import.meta.url)),
+    ],
+    { ...process.env, NODE_OPTIONS: "", TSX_DISABLE_CACHE: "1" },
+    15_000,
+    {
+      cwd: fileURLToPath(new URL("../../../", import.meta.url)),
+      signal,
+      maxBuffer: 64 * 1024,
+      requireProcessTreeExit: process.platform !== "win32",
+    },
+  );
+  expect(result.error, result.stderr).toBeUndefined();
+  expect(result.status, result.stderr).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual({
+    fence: { whileRefreshing: [], afterActiveResult: [] },
+    config: { whileRefreshing: [], afterActiveResult: [] },
+    catalog: { whileRefreshing: [], afterActiveResult: [] },
+    expiry: { whileRefreshing: [], afterActiveResult: [] },
+  });
+}, 30_000);

--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -1,6 +1,7 @@
 import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readAgentRunIndexVersion } from "../../infra/agent-run-registry.js";
+import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import {
   readSessionIdentityMutationVersion,
   readSessionLifecycleVersion,
@@ -26,7 +27,6 @@ type SessionListFence = {
   agentDatabaseRegistryToken: symbol;
   incognitoDatabaseGeneration: number;
   lifecyclePersistenceVersion: number;
-  modelCatalogRevision: string;
   sessionAutomationVersion: number;
   sessionIdentityMutationVersion: number;
   sessionLifecycleVersion: number;
@@ -38,9 +38,10 @@ type SessionListFence = {
   workerPlacementDiskSpaceVersion: number;
   workerPlacementRunnerAvailabilityVersion: number;
 };
-type SessionListOperation = SessionListFence & { promise: Promise<SessionsListResult> };
-type SessionListCompleted = SessionListFence & { expiresAt?: number; result: SessionsListResult };
-type SessionListState = {
+type CatalogFence = { modelCatalogRevision: string };
+type SessionListOperation = CatalogFence & { promise: Promise<SessionsListResult> };
+type SessionListCompleted = CatalogFence & { expiresAt?: number; result: SessionsListResult };
+type SessionListState = SessionListFence & {
   completed: Map<string, SessionListCompleted>;
   config: OpenClawConfig;
   inFlight: Map<string, SessionListOperation>;
@@ -84,16 +85,12 @@ function readSessionListModelCatalogFence(
     .join(",");
 }
 
-function readSessionListFence(
-  context: GatewayRequestContext,
-  modelCatalog: SessionListModelCatalog | undefined,
-): SessionListFence {
+function readSessionListFence(context: GatewayRequestContext): SessionListFence {
   return {
     agentRunIndexVersion: readAgentRunIndexVersion(),
     agentDatabaseRegistryToken: readOpenClawAgentDatabaseRegistryToken(),
     incognitoDatabaseGeneration: readOpenIncognitoAgentDatabaseGeneration(),
     lifecyclePersistenceVersion: readSessionLifecyclePersistenceVersion(),
-    modelCatalogRevision: readSessionListModelCatalogFence(modelCatalog),
     sessionAutomationVersion: readSessionAutomationVersion(),
     sessionIdentityMutationVersion: readSessionIdentityMutationVersion(),
     sessionLifecycleVersion: readSessionLifecycleVersion(),
@@ -116,7 +113,6 @@ function matchesSessionListFence(value: SessionListFence, fence: SessionListFenc
     value.agentDatabaseRegistryToken === fence.agentDatabaseRegistryToken &&
     value.incognitoDatabaseGeneration === fence.incognitoDatabaseGeneration &&
     value.lifecyclePersistenceVersion === fence.lifecyclePersistenceVersion &&
-    value.modelCatalogRevision === fence.modelCatalogRevision &&
     value.sessionAutomationVersion === fence.sessionAutomationVersion &&
     value.sessionIdentityMutationVersion === fence.sessionIdentityMutationVersion &&
     value.sessionLifecycleVersion === fence.sessionLifecycleVersion &&
@@ -149,27 +145,34 @@ function sessionListState(
   config: OpenClawConfig,
 ): SessionListState {
   let state = sessionListsByContext.get(context);
-  if (!state || state.config !== config) {
-    state = { completed: new Map(), config, inFlight: new Map() };
+  // Every input that can change a projected row must fence reuse. Session identity,
+  // Gateway projection, and live-run mutations have separate monotonic owners.
+  const fence = readSessionListFence(context);
+  if (!state || state.config !== config || !matchesSessionListFence(state, fence)) {
+    // Pending callers retain their generation until they settle, but its completed
+    // pages are already unusable and must not remain reachable through those callers.
+    state?.completed.clear();
+    state = { ...fence, completed: new Map(), config, inFlight: new Map() };
     sessionListsByContext.set(context, state);
   }
   return state;
 }
 
-function rememberCompletedSessionList(
+function readCompletedSessionList(
   state: SessionListState,
   workKey: string,
-  completed: SessionListCompleted,
-): void {
-  state.completed.delete(workKey);
-  state.completed.set(workKey, completed);
-  while (state.completed.size > SESSIONS_LIST_COMPLETED_CACHE_LIMIT) {
-    const oldest = state.completed.keys().next().value;
-    if (oldest === undefined) {
-      break;
-    }
-    state.completed.delete(oldest);
+  modelCatalogRevision: string,
+): SessionsListResult | undefined {
+  const completed = state.completed.get(workKey);
+  if (
+    completed?.modelCatalogRevision === modelCatalogRevision &&
+    (completed.expiresAt === undefined || completed.expiresAt > Date.now())
+  ) {
+    return completed.result;
   }
+  // Keep invalid lookups in this synchronous frame, not a suspended refresh.
+  state.completed.delete(workKey);
+  return undefined;
 }
 
 function resolveSessionListExpiration(result: SessionsListResult): number | null | undefined {
@@ -202,23 +205,19 @@ export async function respondWithCachedSessionList(params: {
 }): Promise<void> {
   const workKey = sessionListWorkKey(params.request, params.client, params.config);
   const state = sessionListState(params.context, params.config);
-  // Every input that can change a projected row must fence reuse. Session identity,
-  // Gateway projection, and live-run mutations have separate monotonic owners.
-  const fence = readSessionListFence(params.context, params.modelCatalog);
+  const modelCatalogRevision = readSessionListModelCatalogFence(params.modelCatalog);
   // Activity windows and child retention expire without mutations; hidden paginated rows
   // prevent deriving a safe deadline, so only concurrent temporal requests share work.
   const cacheCompleted = params.request.activeMinutes === undefined && !params.request.spawnedBy;
-  const completed = cacheCompleted ? state.completed.get(workKey) : undefined;
-  if (
-    completed &&
-    matchesSessionListFence(completed, fence) &&
-    (completed.expiresAt === undefined || completed.expiresAt > Date.now())
-  ) {
-    params.respond(true, completed.result, undefined);
+  const completed = cacheCompleted
+    ? readCompletedSessionList(state, workKey, modelCatalogRevision)
+    : undefined;
+  if (completed) {
+    params.respond(true, completed, undefined);
     return;
   }
   const pending = state.inFlight.get(workKey);
-  if (pending && matchesSessionListFence(pending, fence)) {
+  if (pending?.modelCatalogRevision === modelCatalogRevision) {
     params.respond(true, await pending.promise, undefined);
     return;
   }
@@ -230,16 +229,20 @@ export async function respondWithCachedSessionList(params: {
     .then((result) => {
       if (
         cacheCompleted &&
-        matchesSessionListFence(readSessionListFence(params.context, params.modelCatalog), fence)
+        sessionListsByContext.get(params.context) === state &&
+        matchesSessionListFence(state, readSessionListFence(params.context)) &&
+        readSessionListModelCatalogFence(params.modelCatalog) === modelCatalogRevision
       ) {
         const expiresAt = resolveSessionListExpiration(result);
         if (expiresAt !== null && (expiresAt === undefined || expiresAt > Date.now())) {
-          rememberCompletedSessionList(state, workKey, { ...fence, result, expiresAt });
+          state.completed.delete(workKey);
+          state.completed.set(workKey, { modelCatalogRevision, result, expiresAt });
+          pruneMapToMaxSize(state.completed, SESSIONS_LIST_COMPLETED_CACHE_LIMIT);
         }
       }
       return result;
     });
-  const operation = { ...fence, promise };
+  const operation = { modelCatalogRevision, promise };
   state.inFlight.set(workKey, operation);
   try {
     params.respond(true, await promise, undefined);

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -307,13 +307,20 @@ describe("sessions.list single-flight", () => {
       expect(await listSessions({ client, context, request })).toBe(first);
       expect(loader.calls).toHaveBeenCalledTimes(1);
 
+      const mainRequest = { ...request, agentId: "main" };
+      const workRequest = { ...request, agentId: "work" };
+      const main = await listSessions({ client, context, request: mainRequest });
+      const work = await listSessions({ client, context, request: workRequest });
+      expect(await listSessions({ client, context, request: mainRequest })).toBe(main);
+      expect(await listSessions({ client, context, request: workRequest })).toBe(work);
+      expect(await listSessions({ client, context, request })).toBe(first);
       catalog = fullCatalog;
       const refreshed = await listSessions({ client, context, request });
       expect(refreshed).not.toBe(first);
       expect(
         refreshed.sessions.find((session) => session.agentId === "main")?.thinkingOptions,
       ).toEqual(expect.arrayContaining(["off", "low", "high", "max"]));
-      expect(loader.calls).toHaveBeenCalledTimes(2);
+      expect(loader.calls).toHaveBeenCalledTimes(4);
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Session-list pages that could no longer be reused remained reachable through old cache generations and pending requests. A current-key catalog or expiry miss could also hold its stale result throughout a blocked refresh.

## Why This Change Was Made

The cache owner now holds global fences once per generation, clears retired completed pages before replacing that generation, and refuses admission from retired work. Catalog revisions stay scoped to each request. A synchronous lookup consumes invalid entries before an async refresh can capture them. The old write-only eviction helper is replaced by the canonical bounded Map helper.

## User Impact

Unusable cached pages can be collected while pending callers still receive their original responses. The existing request identity, visibility, catalog scope, expiry and 64-entry policies remain unchanged. Invalidation is lazy on the next cache operation; unvisited catalog-stale/expired keys retain their existing bounded policy.

Production +3 LOC expresses the necessary synchronous ownership boundary. Removing only the Map entry or narrowing its lexical block was reproduced and still retained the page while awaiting refresh.

## Evidence

- The public cache-API regression fails against the original owner and passes for global-fence, config, catalog and expiry transitions, including a blocked refresh and an old pending caller. An uncached GC control and original-caller response are checked independently.
- A larger actual-owner lifetime witness reduced reachable old page objects from 16 to 0 while work was pending, and 15 to 0 afterward. Synthetic preview payload size is not an RSS or heap-size measurement.
- Existing focused behavior/catalog/pruning coverage passes 47 tests.
- Independent source review and managed Codex review through P2 found no actionable finding.

Canonical changed-file checks pass after correcting a TypeScript narrowing issue in the test helper; the final helper still fails on the original cache owner and passes on the repair. Real Gateway candidate verification passed: ten real OpenAI turns on a changes-only composite containing this repair and four other campaign changes covered web fetch, file reads, Unicode output, Tool Search, session history, and repeated session listings across real mutations. Both Gateway profiles shut down cleanly. Sampled Unicode allocations fell 34.5% and 30.8%; idle post-GC RSS was +0.66 MiB and +1.02 MiB, with main-isolate retained heap essentially flat. These composite observations are not a cache-specific RSS claim. The four invalidation lifetime regressions above remain the direct cache-owner evidence.
