### PR TITLE
fix(linux): prevent AppImage startup failures from bundled host libraries

### DIFF
--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -271,6 +271,7 @@ jobs:
             /usr/bin/python3 apps/linux/tests/packaged_runtime_smoke.py \
             "dist/linux-app/release/OpenClaw-${version}-amd64.AppImage" \
             --output "${RUNNER_TEMP}/linux-packaged-runtime" \
+            --require-fuse \
             --shell-container \
               "archlinux@sha256:82b1b08faae9d61e3e7e13d562f4d09114d939105b0d59ff34140f3bd418593a"
 

--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -172,18 +172,36 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
+            at-spi2-core \
             build-essential \
             curl \
+            dbus-x11 \
+            ffmpeg \
             file \
+            gir1.2-atspi-2.0 \
             gstreamer1.0-libav \
             gstreamer1.0-plugins-bad \
             gstreamer1.0-plugins-good \
+            gstreamer1.0-tools \
+            libatk-adaptor \
             libayatana-appindicator3-dev \
+            libegl1 \
+            libgles2 \
             librsvg2-dev \
             libssl-dev \
             libwebkit2gtk-4.1-dev \
             libxdo-dev \
-            wget
+            mesa-utils \
+            patchelf \
+            pciutils \
+            procps \
+            psmisc \
+            python3-gi \
+            wget \
+            wmctrl \
+            xauth \
+            xdg-utils \
+            xvfb
 
       - name: Install Rust
         run: rustup toolchain install stable --profile minimal
@@ -193,6 +211,13 @@ jobs:
         with:
           cache-mode: restore
           install-bun: "false"
+
+      - name: Stage AppImage GStreamer plugins
+        run: |
+          plugins="${RUNNER_TEMP}/openclaw-gstreamer-plugins"
+          apps/linux/scripts/stage-appimage-gstreamer.sh "$plugins" \
+            | tee "${RUNNER_TEMP}/openclaw-gstreamer-elements.tsv"
+          echo "GSTREAMER_PLUGINS_DIR=$plugins" >> "$GITHUB_ENV"
 
       - name: Build Linux companion bundles
         working-directory: apps/linux/src-tauri
@@ -234,6 +259,29 @@ jobs:
           cp "${appimages[0]}" "dist/linux-app/release/OpenClaw-${version}-amd64.AppImage"
           cp "${appimages[0]}.sig" \
             "dist/linux-app/signatures/OpenClaw-${version}-amd64.AppImage.sig"
+
+      - name: Test packaged AppImage runtime
+        id: packaged-runtime
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          xvfb-run -a -s '-screen 0 1280x1024x24' dbus-run-session -- \
+            /usr/bin/python3 apps/linux/tests/packaged_runtime_smoke.py \
+            "dist/linux-app/release/OpenClaw-${version}-amd64.AppImage" \
+            --output "${RUNNER_TEMP}/linux-packaged-runtime" \
+            --shell-container \
+              "archlinux@sha256:82b1b08faae9d61e3e7e13d562f4d09114d939105b0d59ff34140f3bd418593a"
+
+      - name: Upload packaged runtime failure evidence
+        if: failure() && steps.packaged-runtime.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: linux-app-release-runtime-failure
+          retention-days: 14
+          if-no-files-found: warn
+          path: ${{ runner.temp }}/linux-packaged-runtime
 
       - name: Upload Linux bundles
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -144,6 +144,7 @@ jobs:
             /usr/bin/python3 apps/linux/tests/packaged_runtime_smoke.py \
             "${appimages[0]}" \
             --output "${RUNNER_TEMP}/linux-packaged-runtime" \
+            --require-fuse \
             --shell-container \
               "archlinux@sha256:82b1b08faae9d61e3e7e13d562f4d09114d939105b0d59ff34140f3bd418593a"
 

--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -40,20 +40,31 @@ jobs:
             build-essential \
             curl \
             dbus-x11 \
+            ffmpeg \
             file \
             gir1.2-atspi-2.0 \
             gstreamer1.0-libav \
             gstreamer1.0-plugins-bad \
             gstreamer1.0-plugins-good \
+            gstreamer1.0-tools \
             libatk-adaptor \
             libayatana-appindicator3-dev \
+            libegl1 \
+            libgles2 \
             librsvg2-dev \
             libssl-dev \
             libwebkit2gtk-4.1-dev \
             libxdo-dev \
+            mesa-utils \
+            patchelf \
+            pciutils \
+            procps \
+            psmisc \
             python3-gi \
             wget \
+            wmctrl \
             xauth \
+            xdg-utils \
             xvfb
 
       - name: Install Rust
@@ -84,6 +95,13 @@ jobs:
         working-directory: apps/linux/src-tauri
         run: cargo +stable test --locked --all-targets
 
+      - name: Stage AppImage GStreamer plugins
+        run: |
+          plugins="${RUNNER_TEMP}/openclaw-gstreamer-plugins"
+          apps/linux/scripts/stage-appimage-gstreamer.sh "$plugins" \
+            | tee "${RUNNER_TEMP}/openclaw-gstreamer-elements.tsv"
+          echo "GSTREAMER_PLUGINS_DIR=$plugins" >> "$GITHUB_ENV"
+
       - name: Build Linux companion bundles
         working-directory: apps/linux/src-tauri
         env:
@@ -111,6 +129,32 @@ jobs:
           retention-days: 14
           if-no-files-found: error
           path: ${{ runner.temp }}/linux-first-run.log
+
+      - name: Test packaged AppImage runtime
+        id: packaged-runtime
+        shell: bash
+        run: |
+          shopt -s nullglob
+          appimages=(apps/linux/src-tauri/target/release/bundle/appimage/*.AppImage)
+          if [[ ${#appimages[@]} -ne 1 ]]; then
+            echo "Expected one AppImage, found ${#appimages[@]}"
+            exit 1
+          fi
+          xvfb-run -a -s '-screen 0 1280x1024x24' dbus-run-session -- \
+            /usr/bin/python3 apps/linux/tests/packaged_runtime_smoke.py \
+            "${appimages[0]}" \
+            --output "${RUNNER_TEMP}/linux-packaged-runtime" \
+            --shell-container \
+              "archlinux@sha256:82b1b08faae9d61e3e7e13d562f4d09114d939105b0d59ff34140f3bd418593a"
+
+      - name: Upload packaged runtime failure evidence
+        if: failure() && steps.packaged-runtime.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: linux-packaged-runtime-failure
+          retention-days: 14
+          if-no-files-found: warn
+          path: ${{ runner.temp }}/linux-packaged-runtime
 
       - name: Upload bundles
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -9,7 +9,8 @@ Debian and Ubuntu development packages:
 ```bash
 sudo apt update
 sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
-  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev \
+  patchelf xdg-utils
 ```
 
 Install a current stable Rust toolchain with `rustup`.
@@ -21,15 +22,17 @@ WebM/VP9, Opus, Vorbis, and WAV normally work through `plugins-good`.
 H.264/MP4, AAC, and MP3 require the `libav` and/or `plugins-bad` packages.
 The `.deb` uses the host's plugins and declares all three packages as
 dependencies. The AppImage bundles the GStreamer media framework and the
-plugins available on its Ubuntu build host. For a source build or when
-rebuilding either Linux bundle, install the packages explicitly:
+plugins required for the formats above. For a source build or when rebuilding
+either Linux bundle, install the packages and inspection tool explicitly:
 
 ```bash
-sudo apt update && sudo apt install gstreamer1.0-libav gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
+sudo apt update && sudo apt install gstreamer1.0-libav gstreamer1.0-plugins-good \
+  gstreamer1.0-plugins-bad gstreamer1.0-tools patchelf xdg-utils
 ```
 
-The released AppImage therefore carries the codecs installed by the release
-workflow instead of relying on GStreamer packages from the user's system.
+The packaging script stages only that media capability set before Tauri invokes
+linuxdeploy. This prevents optional host plugins from adding unrelated system
+libraries to the AppImage dependency closure.
 
 ## Develop and build
 
@@ -133,8 +136,11 @@ menu bar images into. Non-Apple platforms keep the full-color `32x32.png`.
 Build a `.deb` and AppImage locally (the same command CI runs):
 
 ```bash
+plugins=$(mktemp -d)
+apps/linux/scripts/stage-appimage-gstreamer.sh "$plugins"
 cd apps/linux/src-tauri
-pnpm dlx @tauri-apps/cli@2.11.4 build --bundles deb,appimage
+GSTREAMER_PLUGINS_DIR="$plugins" \
+  pnpm dlx @tauri-apps/cli@2.11.4 build --bundles deb,appimage
 ```
 
 Bundles land in `target/release/bundle/{deb,appimage}/`. The `Linux App` CI

--- a/apps/linux/scripts/stage-appimage-gstreamer.sh
+++ b/apps/linux/scripts/stage-appimage-gstreamer.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 OUTPUT_DIR" >&2
+  exit 2
+fi
+
+command -v gst-inspect-1.0 >/dev/null || {
+  echo "gst-inspect-1.0 is required" >&2
+  exit 1
+}
+
+output=$1
+parent=$(dirname "$output")
+mkdir -p "$parent"
+parent=$(cd "$parent" && pwd -P)
+output="$parent/$(basename "$output")"
+staging=$(mktemp -d "$parent/.openclaw-gstreamer.XXXXXX")
+trap 'rm -rf "$staging"' EXIT
+
+# linuxdeploy's GStreamer plugin recursively bundles the dependency closure of
+# every staged plugin. Keep this list at the media capabilities the companion
+# ships so optional host plugins cannot pull unrelated libraries into AppRun.
+elements=(
+  filesrc
+  queue
+  typefind
+  typefindfunctions
+  appsrc
+  appsink
+  giosrc
+  souphttpsrc
+  playbin
+  decodebin
+  audioconvert
+  audioresample
+  volume
+  videoconvert
+  videoscale
+  videorate
+  autoaudiosink
+  pulsesink
+  qtdemux
+  matroskademux
+  wavparse
+  oggdemux
+  opusparse
+  opusdec
+  vorbisdec
+  vp8dec
+  vp9dec
+  aacparse
+  h264parse
+  id3demux
+  mpegaudioparse
+  avdec_aac
+  avdec_h264
+  avdec_mp3
+)
+
+declare -A sources=()
+for element in "${elements[@]}"; do
+  inspection=$(gst-inspect-1.0 "$element")
+  plugin=$(awk '$1 == "Filename" { print $2; exit }' <<<"$inspection")
+  if [[ ! -f "$plugin" ]]; then
+    echo "missing GStreamer plugin for $element" >&2
+    exit 1
+  fi
+
+  name=$(basename "$plugin")
+  source=$(realpath "$plugin")
+  if [[ -n ${sources[$name]:-} && ${sources[$name]} != "$source" ]]; then
+    echo "conflicting GStreamer plugins named $name" >&2
+    exit 1
+  fi
+  if [[ -z ${sources[$name]:-} ]]; then
+    cp -L "$plugin" "$staging/$name"
+    sources[$name]=$source
+  fi
+  printf '%s\t%s\n' "$element" "$name"
+done
+
+rm -rf "$output"
+mv "$staging" "$output"
+trap - EXIT

--- a/apps/linux/tests/first_run.py
+++ b/apps/linux/tests/first_run.py
@@ -20,8 +20,17 @@ import tempfile
 import time
 
 
-def exercise(app, Atspi, GLib):
+def exercise(app, Atspi, GLib, *, remote_only):
     last_headings = set()
+
+    def text_content(node):
+        text = node.get_text_iface()
+        if text is None:
+            return None
+        # Ubuntu 24's GI bindings dispatch text.get_text(...) back through
+        # Accessible.get_text(). Calling the interface method is stable on both
+        # the Ubuntu 22 and 24 AT-SPI API shapes.
+        return Atspi.Text.get_text(text, 0, -1)
 
     def nodes():
         desktop = Atspi.get_desktop(0)
@@ -61,8 +70,7 @@ def exercise(app, Atspi, GLib):
                     if actual_role == "heading":
                         last_headings.add(name)
                     if role is None:
-                        text = node.get_text_iface()
-                        matches = text is not None and text.get_text(0, -1) == label
+                        matches = text_content(node) == label
                     else:
                         matches = actual_role == role and (
                             name.startswith(label) if prefix else name == label
@@ -94,7 +102,7 @@ def exercise(app, Atspi, GLib):
 
     def empty_entry(label):
         node = wait(label, "entry")
-        if node.get_text_iface().get_text(0, -1):
+        if text_content(node):
             raise RuntimeError(f"Expected an empty {label!r}; refusing a remote connection")
 
     wait("Welcome to OpenClaw", "heading")
@@ -111,6 +119,9 @@ def exercise(app, Atspi, GLib):
     wait("Gateway port", "entry")
     click("Connect to Gateway")
     wait("Enter an SSH target to continue.")
+    if remote_only:
+        print("PASS: native first-run remote choices", flush=True)
+        return
     click("Back")
     wait("Welcome to OpenClaw", "heading")
     click("Get started")
@@ -132,7 +143,7 @@ def interrupted(signum, _frame):
     raise RuntimeError(f"Native first-run smoke interrupted by signal {signum}")
 
 
-def drive(binary):
+def drive(binary, *, remote_only):
     try:
         import gi
 
@@ -153,7 +164,7 @@ def drive(binary):
             stderr=subprocess.STDOUT,
         )
         try:
-            exercise(app, Atspi, GLib)
+            exercise(app, Atspi, GLib, remote_only=remote_only)
         finally:
             if app.poll() is None:
                 app.terminate()
@@ -169,6 +180,11 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("binary", type=Path)
     parser.add_argument("--driver", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--remote-only",
+        action="store_true",
+        help="Stop after validating release-safe remote setup choices",
+    )
     args = parser.parse_args()
     if sys.platform != "linux" or os.geteuid() == 0:
         parser.error("Run on Linux as a non-root user; do not disable the WebKit sandbox")
@@ -182,7 +198,7 @@ def main():
         parser.error("The minimal system PATH must not contain an OpenClaw CLI")
 
     if args.driver:
-        drive(binary)
+        drive(binary, remote_only=args.remote_only)
         return
 
     for sig in (signal.SIGTERM, signal.SIGINT):
@@ -218,8 +234,12 @@ def main():
             env[variable] = str(path)
         # Native AT-SPI calls can block Python signal handlers. Keep the deadline
         # and cleanup outside that process, with its app in the same owned group.
+        command = [sys.executable, str(Path(__file__).resolve()), "--driver"]
+        if args.remote_only:
+            command.append("--remote-only")
+        command.append(str(binary))
         worker = subprocess.Popen(
-            [sys.executable, str(Path(__file__).resolve()), "--driver", str(binary)],
+            command,
             cwd=root,
             env=env,
             stdin=subprocess.DEVNULL,

--- a/apps/linux/tests/packaged_runtime_smoke.py
+++ b/apps/linux/tests/packaged_runtime_smoke.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""Collect evidence and smoke-test a Linux companion AppImage.
+
+Run as a non-root user inside a private X11 and D-Bus session:
+  xvfb-run -a dbus-run-session -- \
+    python3 apps/linux/tests/packaged_runtime_smoke.py APPIMAGE --output DIR
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+REQUIRED_GSTREAMER_ELEMENTS = (
+    "filesrc",
+    "queue",
+    "typefind",
+    "typefindfunctions",
+    "appsrc",
+    "appsink",
+    "giosrc",
+    "souphttpsrc",
+    "playbin",
+    "decodebin",
+    "audioconvert",
+    "audioresample",
+    "volume",
+    "videoconvert",
+    "videoscale",
+    "videorate",
+    "autoaudiosink",
+    "pulsesink",
+    "qtdemux",
+    "matroskademux",
+    "wavparse",
+    "oggdemux",
+    "opusparse",
+    "opusdec",
+    "vorbisdec",
+    "vp8dec",
+    "vp9dec",
+    "aacparse",
+    "h264parse",
+    "id3demux",
+    "mpegaudioparse",
+    "avdec_aac",
+    "avdec_h264",
+    "avdec_mp3",
+)
+
+
+def write_command(output, name, command, *, cwd=None, env=None):
+    path = output / name
+    executable = shutil.which(command[0])
+    if executable is None:
+        path.write_text(f"{command[0]}: not installed\n")
+        return 127, ""
+    result = subprocess.run(
+        [executable, *command[1:]],
+        cwd=cwd,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    path.write_text(result.stdout)
+    return result.returncode, result.stdout
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def isolated_environment(root):
+    env = {
+        key: os.environ[key]
+        for key in (
+            "DBUS_SESSION_BUS_ADDRESS",
+            "DISPLAY",
+            "LANG",
+            "LC_ALL",
+            "XAUTHORITY",
+            "XDG_RUNTIME_DIR",
+            "XDG_SESSION_TYPE",
+        )
+        if key in os.environ
+    }
+    env.update(HOME=str(root), PATH="/usr/bin:/bin")
+    for variable, relative in (
+        ("XDG_CONFIG_HOME", ".config"),
+        ("XDG_CACHE_HOME", ".cache"),
+        ("XDG_DATA_HOME", ".local/share"),
+        ("XDG_STATE_HOME", ".local/state"),
+        ("TMPDIR", "tmp"),
+    ):
+        path = root / relative
+        path.mkdir(mode=0o700, parents=True)
+        env[variable] = str(path)
+    return env
+
+
+def process_ids(root_pid):
+    found = {root_pid}
+    pending = [root_pid]
+    while pending:
+        parent = pending.pop()
+        result = subprocess.run(
+            ["pgrep", "-P", str(parent)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+        )
+        for value in result.stdout.split():
+            child = int(value)
+            if child not in found:
+                found.add(child)
+                pending.append(child)
+    return sorted(found)
+
+
+def launch_probe(command, output, label, *, cwd, env, duration=5):
+    with (output / f"{label}.log").open("wb") as log:
+        app = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            deadline = time.monotonic() + duration
+            while time.monotonic() < deadline and app.poll() is None:
+                time.sleep(0.1)
+            if app.poll() is not None:
+                return {"alive": False, "exitCode": app.returncode, "pids": []}
+            pids = process_ids(app.pid)
+            write_command(
+                output,
+                f"{label}.processes.txt",
+                ["ps", "-ww", "-o", "pid,ppid,stat,comm,args", "-p", ",".join(map(str, pids))],
+            )
+            write_command(output, f"{label}.tree.txt", ["pstree", "-ap", str(app.pid)])
+            write_command(output, f"{label}.windows.txt", ["wmctrl", "-lpGx"])
+            with (output / f"{label}.maps.txt").open("w") as maps:
+                for pid in pids:
+                    path = Path(f"/proc/{pid}/maps")
+                    if path.is_file():
+                        maps.write(f"== pid {pid} ==\n")
+                        maps.write(path.read_text(errors="replace"))
+            return {"alive": True, "exitCode": None, "pids": pids}
+        finally:
+            if app.poll() is None:
+                os.killpg(app.pid, signal.SIGTERM)
+                try:
+                    app.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    os.killpg(app.pid, signal.SIGKILL)
+                    app.wait(timeout=5)
+
+
+def container_shell_probe(image, appdir, output):
+    results = {}
+    failed = []
+    for shell in ("sh", "bash"):
+        command = [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            f"/bin/{shell}",
+            "--env",
+            "LD_LIBRARY_PATH=/openclaw-libs",
+            "--volume",
+            f"{appdir / 'usr/lib'}:/openclaw-libs:ro",
+            image,
+            "-lc",
+            f"printf '{shell}-ok\\n'",
+        ]
+        code, text = write_command(output, f"container-{shell}.txt", command)
+        results[shell] = {"exitCode": code, "output": text.strip()}
+        if code:
+            failed.append(shell)
+    if failed:
+        raise RuntimeError(
+            f"{image} packaged-library shell probe failed: {', '.join(failed)}"
+        )
+    return results
+
+
+def generate_media_samples(root, output):
+    samples = root / "media"
+    samples.mkdir()
+    commands = {
+        "wav": [
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=0.25",
+        ],
+        "mp3": [
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=0.25",
+            "-c:a",
+            "libmp3lame",
+        ],
+        "ogg": [
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=0.25",
+            "-c:a",
+            "libvorbis",
+        ],
+        "webm": [
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=160x90:rate=10:duration=0.25",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=0.25",
+            "-c:v",
+            "libvpx-vp9",
+            "-c:a",
+            "libopus",
+            "-shortest",
+        ],
+        "mp4": [
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc2=size=160x90:rate=10:duration=0.25",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=0.25",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            "-shortest",
+        ],
+    }
+    generated = []
+    for extension, arguments in commands.items():
+        sample = samples / f"sample.{extension}"
+        code, _ = write_command(
+            output,
+            f"generate-{extension}.txt",
+            ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", *arguments, str(sample)],
+        )
+        if code:
+            raise RuntimeError(f"Failed to generate {extension} media sample")
+        generated.append(sample)
+    return generated
+
+
+def bundled_gstreamer_probe(appdir, output, env, samples):
+    hook = appdir / "apprun-hooks/linuxdeploy-plugin-gstreamer.sh"
+    if not hook.is_file():
+        raise RuntimeError("Missing packaged GStreamer AppRun hook")
+
+    common = """
+set -euo pipefail
+export APPDIR=$1
+source "$APPDIR/apprun-hooks/linuxdeploy-plugin-gstreamer.sh"
+# Refuse host plugin fallback: this is a contract test for the AppImage payload.
+export GST_PLUGIN_PATH_1_0=
+export GST_PLUGIN_SYSTEM_PATH_1_0="$APPDIR/usr/lib/gstreamer-1.0"
+"""
+    command = [
+        "/bin/bash",
+        "-c",
+        common
+        + """
+shift
+for element; do
+  gst-inspect-1.0 "$element" >/dev/null
+  printf '%s\\tok\\n' "$element"
+done
+""",
+        "bundled-gstreamer-probe",
+        str(appdir),
+        *REQUIRED_GSTREAMER_ELEMENTS,
+    ]
+    code, text = write_command(
+        output,
+        "bundled-gstreamer-elements.txt",
+        command,
+        cwd=appdir,
+        env=env,
+    )
+    if code:
+        raise RuntimeError("Packaged GStreamer element probe failed")
+
+    playback = {}
+    registry = output / "gstreamer-registry.bin"
+    for sample in samples:
+        code, media_output = write_command(
+            output,
+            f"playback-{sample.suffix.removeprefix('.')}.txt",
+            [
+                "/bin/bash",
+                "-c",
+                common
+                + """
+export GST_REGISTRY_1_0=$2
+exec timeout 30s gst-launch-1.0 -q playbin "uri=file://$3" \
+  audio-sink=fakesink video-sink=fakesink
+""",
+                "bundled-gstreamer-playback",
+                str(appdir),
+                str(registry),
+                str(sample),
+            ],
+            cwd=appdir,
+            env=env,
+        )
+        playback[sample.suffix.removeprefix(".")] = {
+            "exitCode": code,
+            "output": media_output.strip(),
+        }
+        if code:
+            raise RuntimeError(f"Packaged playback failed for {sample.name}")
+    return {
+        "elements": text.splitlines(),
+        "playback": playback,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("appimage", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--expected-sha256")
+    parser.add_argument("--require-fuse", action="store_true")
+    parser.add_argument("--shell-container")
+    parser.add_argument("--skip-ui", action="store_true")
+    args = parser.parse_args()
+
+    if sys.platform != "linux" or os.geteuid() == 0:
+        parser.error("Run on Linux as a non-root user")
+    for key in ("DISPLAY", "DBUS_SESSION_BUS_ADDRESS"):
+        if not os.environ.get(key):
+            parser.error("Run inside xvfb-run and dbus-run-session")
+
+    appimage = args.appimage.resolve(strict=True)
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    artifact_sha = sha256(appimage)
+    (output / "sha256.txt").write_text(f"{artifact_sha}  {appimage.name}\n")
+    if args.expected_sha256 and artifact_sha != args.expected_sha256.lower():
+        raise RuntimeError(f"SHA-256 mismatch: got {artifact_sha}")
+
+    write_command(output, "uname.txt", ["uname", "-a"])
+    if Path("/etc/os-release").is_file():
+        shutil.copyfile("/etc/os-release", output / "os-release.txt")
+    (output / "display-environment.txt").write_text(
+        "".join(
+            f"{key}={os.environ.get(key, '')}\n"
+            for key in ("DISPLAY", "XDG_SESSION_TYPE", "XDG_CURRENT_DESKTOP", "GDK_BACKEND")
+        )
+    )
+    for name, command in (
+        ("artifact-file.txt", ["file", str(appimage)]),
+        ("display.txt", ["xdpyinfo"]),
+        ("glx.txt", ["glxinfo", "-B"]),
+        ("egl.txt", ["eglinfo", "-B"]),
+        ("pci.txt", ["lspci", "-nnk"]),
+        ("gstreamer.txt", ["gst-inspect-1.0", "--version"]),
+    ):
+        write_command(output, name, command)
+
+    with tempfile.TemporaryDirectory(prefix="openclaw-packaged-smoke-") as directory:
+        root = Path(directory)
+        env = isolated_environment(root / "home")
+        fuse = launch_probe(
+            [str(appimage)],
+            output,
+            "fuse-launch",
+            cwd=root,
+            env=env,
+        )
+        if args.require_fuse and not fuse["alive"]:
+            raise RuntimeError(f"FUSE launch exited with {fuse['exitCode']}")
+
+        extract = subprocess.run(
+            [str(appimage), "--appimage-extract"],
+            cwd=root,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+        (output / "extract.log").write_text(extract.stdout)
+        if extract.returncode:
+            raise RuntimeError(f"AppImage extraction exited with {extract.returncode}")
+        appdir = root / "squashfs-root"
+        apprun = appdir / "AppRun"
+        binary = appdir / "usr/bin/openclaw-desktop"
+        for required in (apprun, binary):
+            if not required.is_file():
+                raise RuntimeError(f"Missing packaged runtime file: {required.relative_to(appdir)}")
+
+        shutil.copyfile(apprun, output / "AppRun.txt")
+        hooks = appdir / "apprun-hooks"
+        if hooks.is_dir():
+            for hook in hooks.glob("*"):
+                if hook.is_file():
+                    shutil.copyfile(hook, output / hook.name)
+        write_command(output, "binary-dynamic.txt", ["readelf", "-dW", str(binary)])
+        _, ldd = write_command(output, "binary-ldd.txt", ["ldd", str(binary)])
+        if "not found" in ldd:
+            raise RuntimeError("Packaged desktop binary has unresolved dynamic libraries")
+
+        libraries = sorted(
+            path.relative_to(appdir).as_posix()
+            for path in (appdir / "usr/lib").rglob("*")
+            if path.is_file()
+        )
+        (output / "libraries.txt").write_text("\n".join(libraries) + "\n")
+
+        library_paths = [
+            appdir / "usr/lib",
+            appdir / "usr/lib/x86_64-linux-gnu",
+            appdir / "usr/lib/aarch64-linux-gnu",
+        ]
+        shell_env = dict(env)
+        shell_env["LD_LIBRARY_PATH"] = ":".join(
+            str(path) for path in library_paths if path.is_dir()
+        )
+        shell_results = {}
+        for shell in ("/bin/sh", "/bin/bash"):
+            if not Path(shell).is_file():
+                continue
+            code, text = write_command(
+                output,
+                f"{Path(shell).name}-probe.txt",
+                [shell, "-lc", f"printf '{Path(shell).name}-ok\\n'"],
+                cwd=appdir,
+                env=shell_env,
+            )
+            shell_results[shell] = {"exitCode": code, "output": text.strip()}
+            if code:
+                raise RuntimeError(f"{shell} failed under the packaged library path")
+
+        container_shells = None
+        if args.shell_container:
+            container_shells = container_shell_probe(
+                args.shell_container,
+                appdir,
+                output,
+            )
+
+        samples = generate_media_samples(root, output)
+        gstreamer = bundled_gstreamer_probe(
+            appdir,
+            output,
+            shell_env,
+            samples,
+        )
+
+        extracted = launch_probe(
+            [str(apprun)],
+            output,
+            "extract-launch",
+            cwd=appdir,
+            env=env,
+        )
+        if not extracted["alive"]:
+            raise RuntimeError(f"Extracted AppRun exited with {extracted['exitCode']}")
+
+        ui_code = None
+        if not args.skip_ui:
+            ui_env = dict(env)
+            # AT-SPI creates a Unix socket below TMPDIR. The isolated HOME path
+            # can exceed sockaddr_un's limit in deep CI workspaces.
+            with tempfile.TemporaryDirectory(prefix="openclaw-ui-") as ui_tmp:
+                ui_env["TMPDIR"] = ui_tmp
+                ui_code, _ = write_command(
+                    output,
+                    "atspi-first-run.txt",
+                    [
+                        sys.executable,
+                        str(Path(__file__).with_name("first_run.py")),
+                        "--remote-only",
+                        str(apprun),
+                    ],
+                    cwd=appdir,
+                    env=ui_env,
+                )
+            if ui_code:
+                raise RuntimeError("Packaged first-run AT-SPI smoke failed")
+
+        summary = {
+            "artifact": appimage.name,
+            "sha256": artifact_sha,
+            "fuse": fuse,
+            "extracted": extracted,
+            "shells": shell_results,
+            "containerShells": container_shells,
+            "gstreamer": gstreamer,
+            "uiExitCode": ui_code,
+        }
+        (output / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+
+    print(f"PASS: packaged Linux runtime smoke ({appimage.name})")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -128,21 +128,26 @@ WebM/VP9, Opus, Vorbis, and WAV normally work through `plugins-good`.
 H.264/MP4, AAC, and MP3 require the `libav` and/or `plugins-bad` packages.
 The `.deb` uses the host's plugins and declares all three packages as
 dependencies. The AppImage bundles the GStreamer media framework and the
-plugins available on its Ubuntu build host. For a source build or when
-rebuilding either Linux bundle, install the packages explicitly:
+plugins required for those formats. For a source build or when rebuilding
+either Linux bundle, install the packages and inspection tool explicitly:
 
 ```bash
-sudo apt update && sudo apt install gstreamer1.0-libav gstreamer1.0-plugins-good gstreamer1.0-plugins-bad
+sudo apt update && sudo apt install gstreamer1.0-libav gstreamer1.0-plugins-good \
+  gstreamer1.0-plugins-bad gstreamer1.0-tools patchelf xdg-utils
 ```
 
-The released AppImage therefore carries the codecs installed by the release
-workflow instead of relying on GStreamer packages from the user's system.
+The packaging script stages only that media capability set before Tauri invokes
+linuxdeploy. This prevents optional host plugins from adding unrelated system
+libraries to the AppImage dependency closure.
 
 You can also build the same bundles from a source checkout:
 
 ```bash
+plugins=$(mktemp -d)
+apps/linux/scripts/stage-appimage-gstreamer.sh "$plugins"
 cd apps/linux/src-tauri
-pnpm dlx @tauri-apps/cli@2.11.4 build --bundles deb,appimage
+GSTREAMER_PLUGINS_DIR="$plugins" \
+  pnpm dlx @tauri-apps/cli@2.11.4 build --bundles deb,appimage
 ```
 
 The `Linux App` CI workflow uploads the same bundles as the


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/136148
Regression source: https://github.com/openclaw/openclaw/pull/115616

## What Problem This Solves

Fixes an issue where the Linux AppImage could bundle unrelated build-host
libraries while recursively collecting every installed GStreamer plugin. Those
libraries can override compatible host libraries at runtime; on an
Arch-equivalent userspace, the shipped 2026.8.2 AppImage makes both `/bin/sh`
and `/bin/bash` fail during loader startup.

## Why This Change Was Made

The AppImage build now stages only the GStreamer plugins needed for the shipped
WAV, MP3, OGG, WebM, and MP4 media contract before Tauri invokes linuxdeploy.
A reusable packaged-runtime smoke executes the resulting AppImage, rejects
foreign-shell ABI contamination, plays independently generated media samples
using only bundled plugins, and exercises both FUSE and extracted launches plus
the real AT-SPI onboarding UI.

Tauri CLI v2.11.4 still intentionally packages GTK through X11/XWayland. This
change does not claim native Wayland support or close the physical
Hyprland/GPU-specific report in #136148. Upstream context:
https://github.com/tauri-apps/tauri/issues/8541

## User Impact

Linux AppImage users keep the documented media formats without inheriting
unrelated terminal libraries from the Ubuntu release host. The `.deb` behavior
is unchanged.

## Evidence

### Reproduction and dependency contract

- Shipped artifact: `OpenClaw-2026.8.2-amd64.AppImage`
  - SHA256: `4501dcfd1d5c30dc0eb8c25829be7f1f5fc4a177895ec7c0c404a20e2eec7f6a`
  - Ubuntu host `/bin/sh` and `/bin/bash`: pass.
  - Pinned Arch userspace with shipped AppImage libraries: both exit 127 with
    `undefined symbol: rl_trim_arg_from_keyseq`.
- Same source and host comparison:
  - `bundleMediaFramework=true`: `/bin/sh` and `/bin/bash` exit 127 with
    `undefined symbol: rl_print_keybinding`.
  - `bundleMediaFramework=false`: both exit 0.
  - The unrestricted closure includes `gstfluidsynth -> fluidsynth ->
    libreadline`, plus unrelated terminal libraries.
- Exact Tauri source inspected: tag `tauri-cli-v2.11.4`, commit
  `8909f221`. Its GTK plugin exports `GDK_BACKEND=x11`; its GStreamer plugin
  copies every staged plugin, invokes recursive dependency collection, and
  requires `patchelf`. The AppImage bundler also copies `/usr/bin/xdg-mime`.
- Arch shell proof:
  https://crabbox.openclaw.ai/portal/runs/run_08c6f34603d6

### Candidate runtime

- Ubuntu 24.04 amd64 X11/Xfce:
  - Candidate AppImage SHA256:
    `f51bad2a9b5e37248697d801fa401f8f4606b589b4d115f0ed8a2bf5fc7750ee`
  - Candidate `.deb` SHA256:
    `0baf8a88598bd93da9422caa7701c9db8fdd1345af5500f344d3878691eb2263`
  - FUSE and extract launches pass.
  - Ubuntu and pinned Arch `/bin/sh` + `/bin/bash` pass.
  - Fixed bundled element contract and WAV/MP3/OGG/WebM/MP4 playback pass.
  - AT-SPI remote onboarding passes.
  - Shipped `.deb` install, candidate upgrade, and removal pass.
  - Focused final run:
    https://crabbox.openclaw.ai/portal/runs/run_6fe748b0c3f9
- Nested Sway/Wayland on the same AWS desktop:
  - Tauri launches through XWayland as expected; the window and remote
    onboarding pass.
  - This is cloud XWayland evidence, not physical Hyprland/GPU proof.
  - https://crabbox.openclaw.ai/portal/runs/run_28f8c00d28b3
- Ubuntu 24.04 ARM64 source lane:
  - Rust: 133 unit tests and 10 integration tests pass; 1 existing test ignored.
  - ARM64 `.deb` and AppImage build pass.
  - AppImage SHA256:
    `0e8c4bd4194b9234de11c0cd926a93e58399d855a856eb75cf0565c55252abf4`
  - Direct remote onboarding, FUSE/extract launches, host shells, bundled media,
    and packaged AT-SPI UI pass.
  - https://crabbox.openclaw.ai/portal/runs/run_1b49e38c4c67

Debian 12 and Rocky 9 official-AMI lanes were attempted but blocked before
allocation: the broker requires admin-token authorization for custom AWS AMI
selectors. No lease was created for either lane.

### Test audit

1. Observable contract: the shipped AppImage launches in FUSE/extract modes,
   does not poison host shell loading, contains the fixed media capabilities,
   plays five real formats without host plugin fallback, and exposes usable
   first-run UI through AT-SPI.
2. Credible regression: restoring an unrestricted plugin directory reintroduces
   the proven readline ABI failure; dropping a required codec fails the fixed
   element list or real playback.
3. Existing coverage gap: Rust and unbundled first-run tests do not execute
   AppRun, its library closure, foreign shells, or bundled codecs.
4. Production seam: none. `--remote-only` is test-driver behavior at the real
   UI boundary for release-stamped packages.

The fixed consumer element list is independent of staging output, and actual
media playback prevents producer and test from agreeing on an accidentally
deleted codec. `TMPDIR` is shortened under `/tmp` only for the AT-SPI child
because deep CI paths exceed the Unix socket path limit.

Both PR and release workflow callers pass `--require-fuse`, so a failed direct
AppImage launch cannot be masked by a successful extracted `AppRun`.

### Focused checks

- `shellcheck apps/linux/scripts/stage-appimage-gstreamer.sh`
- `python3 -m py_compile apps/linux/tests/first_run.py apps/linux/tests/packaged_runtime_smoke.py`
- `actionlint .github/workflows/linux-app.yml .github/workflows/linux-app-release.yml`
- `pnpm docs:list`
- `node scripts/check-changed.mjs -- <changed paths>`
- `git diff --check`
- Autoreview: scoped clean at P0/P1, confidence 0.90.

### LOC

- App runtime: `+0/-0`
- Packaging producer: `+86/-0`
- Tests and test support: `+566/-8`
- CI/tooling: `+95/-1`
- Docs: `+24/-13`
- Raw total: `+771/-22`

No changelog entry: normal repairs are recorded in the PR body and generated
release notes rather than editing `CHANGELOG.md`.
