### PR TITLE
fix(release): bind controller continuation to the plan coverage policy

### DIFF
--- a/scripts/frv.mjs
+++ b/scripts/frv.mjs
@@ -353,6 +353,7 @@ export async function preflightContinuation(
     validateReleaseChildDispatchBinding({
       child,
       log: parentLog,
+      coveragePolicy: plan.coveragePolicy,
       plannedRunAttempt: child.runAttempt,
       repository,
       targetSha: plan.targetSha,

--- a/test/scripts/frv.test.ts
+++ b/test/scripts/frv.test.ts
@@ -224,7 +224,7 @@ function rootRun(
 function preflightMethods(
   children: ReturnType<typeof child>[],
   childRun: (entry: ReturnType<typeof child>) => Record<string, unknown>,
-  options: { failFast?: boolean; childRunIdOverride?: string } = {},
+  options: { failFast?: boolean; childRunIdOverride?: string; ciReleaseScope?: string } = {},
 ) {
   const byRunId = new Map(children.map((entry) => [entry.runId, entry]));
   const parentJobs = [
@@ -257,6 +257,9 @@ function preflightMethods(
       return [
         `TARGET_SHA: ${TARGET_SHA}`,
         ...(entry.key === "productPerformance" ? ["-f publish_reports=false"] : []),
+        ...(entry.key === "normalCi" && options.ciReleaseScope
+          ? [`CI_RELEASE_SCOPE: ${options.ciReleaseScope}`]
+          : []),
         `Dispatched ${entry.workflow}: https://github.com/${REPOSITORY}/actions/runs/${runId} (attempt 1)`,
       ].join("\n");
     },
@@ -590,6 +593,21 @@ describe("FRV continuation preflight", () => {
         }),
       }),
     ).rejects.toThrow("release child is not uniquely emitted by its parent job");
+  });
+
+  it("binds the normal CI dispatch scope to the plan's coverage policy", async () => {
+    const selected = child("normalCi", "101");
+    const stablePlan = { ...plan([selected]), coveragePolicy: "npm-stable-v1" };
+    const methods = (scope: string) =>
+      preflightMethods([selected], (entry) => runFor(entry, 1, "failure"), {
+        ciReleaseScope: scope,
+      });
+    await expect(
+      preflightContinuation(stablePlan, "77", methods("npm-stable")),
+    ).resolves.toBeDefined();
+    await expect(preflightContinuation(stablePlan, "77", methods("full"))).rejects.toThrow(
+      "release normal CI dispatch scope differs from its coverage policy",
+    );
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

`pnpm frv continue --failed --run <parent>` refused to recover Full Release Validation run 33722524584 with `release normal CI dispatch scope differs from its coverage policy`, even though the parent had dispatched CI exactly as its sealed `npm-stable-v1` plan required. The only failure in that run was a flaky dependency download in the CI child, which is precisely the case the controller exists for.

## Why This Change Was Made

`scripts/frv.mjs` called `validateReleaseChildDispatchBinding` without the plan's `coveragePolicy`, so the binding check derived the expected scope as `full` while #136790 made stable plans dispatch `CI_RELEASE_SCOPE: npm-stable`. The workflow-side caller in `scripts/release-ci-summary.mjs` already passes the policy; the controller now does the same from the sealed plan.

## User Impact

Release operators can recover flaky children on stable/npm-scoped Full Release Validation runs through the attempt-aware controller instead of redispatching a full parent.

## Evidence

- New `test/scripts/frv.test.ts` case "binds the normal CI dispatch scope to the plan's coverage policy": rejects before the fix, resolves after; 45/45 controller tests pass.
- `node scripts/check-changed.mjs -- scripts/frv.mjs test/scripts/frv.test.ts` passes.
- Observed: with this patch, `frv status --run 33722524584` reads the plan and reports per-child attempts; without it the same command fails with the scope error.
