### PR TITLE
perf: decorate owned session rows before publication

### DIFF
--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -392,12 +392,12 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
           const projectPlacement = createSessionPlacementBatchProjector(context, result.sessions);
           const trackedActiveRuns = collectTrackedActiveSessionRuns(context);
           const projectedAgentRunIndex = buildProjectedAgentRunIndex();
-          // Row building and sharing resolution yielded; publication owns fresh caller facts.
+          // These rows are unpublished; decorate them with fresh caller facts after the yields.
           const sharing = prepareSessionSharing({ client, cfg });
-          const sessions = measureDiagnosticsTimelineSpanSync(
+          measureDiagnosticsTimelineSpanSync(
             "gateway.sessions.list.active_run_flags",
-            () => {
-              return result.sessions.map((session, index) => {
+            () =>
+              result.sessions.forEach((session, index) => {
                 const sharingTarget = sharingTargets[index];
                 const visibility = sharingTarget
                   ? resolveSessionVisibility(sharingTarget.entry)
@@ -412,7 +412,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                   trackedActiveRuns,
                   projectedAgentRunIndex,
                 });
-                return Object.assign({}, session, {
+                Object.assign(session, {
                   visibility,
                   ...(sharingTarget
                     ? {
@@ -433,8 +433,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                     ? { activeRunIds: activeRunState.runIds }
                     : {}),
                 });
-              });
-            },
+              }),
             {
               config: cfg,
               phase: "sessions.list",
@@ -447,15 +446,15 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
           // visibility, ownership, membership, and operator roles may all drift.
           const currentVisibilityFilter = sharing.entryFilter;
           const visibleSessions = currentVisibilityFilter
-            ? sessions.filter((_, index) => {
+            ? result.sessions.filter((_, index) => {
                 const target = sharingTargets[index];
                 return target ? currentVisibilityFilter(target.storeKey, target.entry) : false;
               })
-            : sessions;
-          if (visibleSessions.length !== sessions.length) {
+            : result.sessions;
+          if (visibleSessions.length !== result.sessions.length) {
             const visibleKeys = new Set(visibleSessions.map((session) => session.key));
             const excludedKeys = new Set(options.excludedKeys);
-            for (const session of sessions) {
+            for (const session of result.sessions) {
               if (!visibleKeys.has(session.key)) {
                 excludedKeys.add(session.key);
               }
@@ -642,7 +641,8 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
       includeLastMessage: params.includeLastMessage,
       transcriptUsageMaxBytes: 64 * 1024,
     });
-    respond(true, { session: { ...row, ...readSessionPlacementFields(context, row.sessionId) } });
+    Object.assign(row, readSessionPlacementFields(context, row.sessionId));
+    respond(true, { session: row });
   },
   "sessions.resolve": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateSessionsResolveParams, "sessions.resolve", respond)) {


### PR DESCRIPTION
## What Problem This Solves

Session reads cloned freshly built, unpublished rows to attach sharing, active-run and placement fields. A normal 100-row list therefore copied every row and allocated another array before responding.

## Why This Change Was Made

Decorate the owned rows directly inside the existing diagnostics span. Apply the same ownership rule to sessions.describe placement fields. The builders return fresh objects, and placement preparation captures session IDs rather than retaining these rows.

## User Impact

Session responses preserve their fields, property order, visibility checks, refill behavior and cache identity while avoiding redundant copies. Production LOC is net zero; no tests, configuration or dependencies change.

## Evidence

- A fixed actual-handler corpus produced equal full response JSON and property order for empty, one-row, 100-row, active and settled cases. Stored entries remain unchanged and the repeated request returns the same cached response.
- The 100-row page removes 100 extra row copies, 11,700 copied enumerable fields and one intermediate decoration array. These are scoped allocation/work counts, not measured heap bytes or latency.
- All 87 existing focused tests and canonical changed-file checks pass. Source-embedded managed Codex review through P2 found no actionable finding.
- Real Gateway candidate confirmation passed; details below.


## Real Gateway integration (2026-09-03)

A prebuilt, isolated Gateway with a real OpenAI API key passed four fixed turns: ordinary completion, real `web_fetch` of example.com, a 1.31 MB Unicode return through Code Mode, and a real MCP stdio tool with default and explicit arguments. Fifty-seven Gateway RPCs verified three session identities, full/repeated/paginated/subscribed list rows, descriptions and final previews, transcript completion, an explicit reconnect, empty approval replay and unsubscribe.

The MCP server observed the default `id: alpha` before server-side validation, followed by explicit `id: beta`; both nested call identities/order, structured results and metadata projection matched. The Unicode prefix remained well formed and within its byte budget with exact omitted-byte accounting. All four turns completed without retries.

The local immutable composite `3bb6e3164a06e5c35fb50b368cc63cbb05826384` contains the twelve published campaign changes through #137148, including this PR’s reviewed source. Source/build/dependency identity was checked before and after. Both clients closed, the Gateway exited successfully without escalation, all recorded MCP processes exited, and private state/port cleanup passed. This is functional integration proof; it does not attribute memory or latency differences to this PR.
