### PR TITLE
test(plugins): reuse canonical hook call guard

### DIFF
--- a/src/plugins/wired-hooks-gateway.test.ts
+++ b/src/plugins/wired-hooks-gateway.test.ts
@@ -5,6 +5,7 @@
  * calls at the unit level by verifying the hook runner functions exist
  * and validating the integration pattern.
  */
+import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import { createHookRunnerWithRegistry } from "./hooks.test-fixtures.js";
 import type {
@@ -33,14 +34,6 @@ async function expectGatewayHookCall(params: {
   }
 
   expect(handler).toHaveBeenCalledWith(params.event, params.gatewayCtx);
-}
-
-function requireFirstMockCall(mock: { mock: { calls: unknown[][] } }, label: string): unknown[] {
-  const call = mock.mock.calls[0];
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call;
 }
 
 describe("gateway hook runner methods", () => {
@@ -159,7 +152,7 @@ describe("gateway hook runner methods", () => {
     expect(handler).toHaveBeenCalledWith(event, gatewayCtx);
   });
 
-  it("runCronChanged handles removed events without job", async () => {
+  it("runCronChanged passes removed events with the deleted job snapshot", async () => {
     const handler = vi.fn();
     const { runner } = createHookRunnerWithRegistry([{ hookName: "cron_changed", handler }]);
     const event: PluginHookCronChangedEvent = {
@@ -172,7 +165,10 @@ describe("gateway hook runner methods", () => {
     await runner.runCronChanged(event, gatewayCtx);
 
     expect(handler).toHaveBeenCalledWith(event, gatewayCtx);
-    const [cronChangedEvent] = requireFirstMockCall(handler, "cron_changed handler");
+    const [cronChangedEvent] = expectDefined<unknown[]>(
+      handler.mock.calls[0],
+      "cron_changed handler",
+    );
     expect((cronChangedEvent as PluginHookCronChangedEvent).job).toEqual({
       id: "job-3",
       name: "deleted-job",


### PR DESCRIPTION
## What Problem This Solves

The gateway hook test has a one-use helper that only checks whether the first mock call exists. Its removed-event case is also titled “without job” even though it checks the deleted job snapshot.

## Why This Change Was Made

Use the existing `expectDefined` helper and correct the title. All nine cases, first-call selection, event/context assertions, and the exact deleted-job snapshot assertion remain.

## User Impact

None. This changes test code only: 6 lines added, 10 removed; production code and runtime behavior are unchanged.

## Evidence

- The complete gateway hook, global hook runner, and shared expect suites pass 19/19 before and after on Node 26.5.0. Case order is unchanged within each file, with one explicit title rename.
- `node scripts/check-changed.mjs -- src/plugins/wired-hooks-gateway.test.ts` passed, including formatting, types, all three Knip scans, and lint.
- Deslop and fresh isolated Codex review through P2 completed with no findings.
