### PR TITLE
fix(codex): recover conversations after native thread deletion

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -1070,6 +1070,11 @@ the problem and keeps the selected native thread intact. It does not silently
 start another thread. Use `/new` to start with the current harness tools, or
 continue the preserved thread in native Codex.
 
+If an ordinary OpenClaw-managed native thread was deleted, the next turn starts
+a fresh native thread while keeping the selected model and provider. This
+recovery preserves pending manual attachments and native-model-owned threads.
+It does not replay a turn whose native outcome is uncertain.
+
 ### Shared Fast mode and Codex fast mode
 
 `/fast` controls the shared OpenClaw policy. A directive-only `/fast off`

--- a/extensions/codex/src/app-server/rpc-error.ts
+++ b/extensions/codex/src/app-server/rpc-error.ts
@@ -15,6 +15,17 @@ export class CodexAppServerRpcError extends Error {
   }
 }
 
+export function isCodexThreadReadMissingError(error: unknown, threadId: string): boolean {
+  // codex-rs read_thread_view uses this exact invalid_request for a gone thread.
+  // Other validation/storage errors cannot authorize unlinking or replacement.
+  return (
+    error instanceof CodexAppServerRpcError &&
+    error.method === "thread/read" &&
+    error.code === -32_600 &&
+    error.message === `thread not loaded: ${threadId}`
+  );
+}
+
 function formatCodexAppServerRpcErrorMessage(
   error: { message: string; data?: JsonValue },
   method: string,

--- a/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
@@ -29,6 +29,7 @@ import type {
   CodexAppServerThreadLifecycleBinding,
   CodexStartOrResumeThreadParams,
   CodexThreadRequestContext,
+  CodexThreadResumePreparation,
 } from "./thread-lifecycle-types.js";
 import { releaseCodexConsumedLiveThread } from "./thread-lifecycle-warm.js";
 import {
@@ -139,11 +140,12 @@ export async function resumePendingCodexThread(
     ? await lifecycleTiming.measure("plugin-config-build", () => params.pluginThreadConfig?.build())
     : undefined;
   const clientId = resolveCodexAppServerClientInstanceId(params.client);
-  const configuration = await preparePendingCodexThreadResume(
-    params,
-    binding,
-    context.dynamicToolsFingerprint,
-    async (assertCurrent) => {
+  const resumed = await resumeExistingCodexThread(params, {
+    ...context,
+    prebuiltPluginThreadConfig,
+    prepareResume: () =>
+      preparePendingCodexThreadResume(params, binding, context.dynamicToolsFingerprint),
+    releaseRetainedThread: async (assertCurrent) => {
       const released = await context.releaseRetainedThread(binding.threadId, assertCurrent);
       assertCurrent();
       if (!released || (binding.clientId && binding.clientId !== clientId)) {
@@ -156,21 +158,11 @@ export async function resumePendingCodexThread(
         });
       }
     },
-  );
-  try {
-    const resumed = await resumeExistingCodexThread(params, {
-      ...context,
-      prebuiltPluginThreadConfig,
-      assertResumeConfiguration: configuration.assertConfigured,
-      assertResumeOwnership: configuration.assertCurrent,
-    });
-    if (!resumed) {
-      throw new Error(`Codex did not configure resumed thread ${binding.threadId}.`);
-    }
-    return resumed;
-  } finally {
-    configuration.dispose();
+  });
+  if (!resumed) {
+    throw new Error(`Codex did not configure resumed thread ${binding.threadId}.`);
   }
+  return resumed;
 }
 
 /** Manual attachment is intent, never evidence that loaded native overrides took effect. */
@@ -178,8 +170,7 @@ async function preparePendingCodexThreadResume(
   params: CodexStartOrResumeThreadParams,
   binding: CodexAppServerThreadBinding,
   dynamicToolsFingerprint: string,
-  releaseSubscription: (assertCurrent: () => void) => Promise<void>,
-): Promise<{ assertConfigured: () => void; assertCurrent: () => void; dispose: () => void }> {
+): Promise<CodexThreadResumePreparation> {
   const fail = (reason: string) =>
     new Error(
       `Cannot configure resumed Codex thread ${binding.threadId}: ${reason}. ` +
@@ -240,8 +231,6 @@ async function preparePendingCodexThreadResume(
       throw fail("its immutable native tool catalog does not match the current OpenClaw tools");
     }
     assertCurrent();
-    await releaseSubscription(assertCurrent);
-    assertCurrent();
     return {
       assertConfigured: observation.assertConfigured,
       assertCurrent,
@@ -258,7 +247,7 @@ export async function prepareCodexThreadResume(
   params: CodexStartOrResumeThreadParams,
   binding: CodexAppServerThreadBinding,
   context: Pick<CodexThreadRequestContext, "lifecycleTiming" | "throwIfAborted">,
-) {
+): Promise<CodexThreadResumePreparation> {
   const assertClient = captureCodexAppServerClientLifetime(
     params.client,
     binding.connectionScope === "supervision" ? "connection" : "native-process",
@@ -272,8 +261,13 @@ export async function prepareCodexThreadResume(
     }
   };
   assertCurrent();
-  const thread = await assertAdoptedCodexThreadResumeAllowed(params, binding.threadId, context);
-  assertCurrent();
+  let thread: CodexThread;
+  try {
+    thread = await assertAdoptedCodexThreadResumeAllowed(params, binding.threadId, context);
+  } finally {
+    // A failed read cannot authorize recovery after its physical or host owner closes.
+    assertCurrent();
+  }
   // Known supervision keeps its native home; manual adoption's stricter home and catalog
   // checks remain in preparePendingCodexThreadResume, before this common handoff.
   assertCodexSupervisionThreadLineage(binding, thread);

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -28,6 +28,7 @@ import {
   assertCodexThreadAcceptsDirectInput,
   assertCodexThreadStartResponse,
 } from "./protocol-validators.js";
+import { isCodexThreadReadMissingError } from "./rpc-error.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
 import {
   fingerprintCodexThreadConfig,
@@ -47,6 +48,7 @@ import type {
   CodexStartOrResumeThreadParams,
   CodexResumeThreadContext,
   CodexStartThreadContext,
+  CodexThreadResumePreparation,
 } from "./thread-lifecycle-types.js";
 import { resolveCodexAppServerModelProvider } from "./thread-model-selection.js";
 import { CodexThreadPolicyHandoffError, refreshCodexThreadPolicy } from "./thread-policy.js";
@@ -82,19 +84,20 @@ export async function resumeExistingCodexThread(
     throwIfAborted,
     clearCurrentBinding,
   } = context;
+  let acceptedConfiguration: CodexThreadResumePreparation | undefined;
+  let disposeConfiguration: (() => void) | undefined;
   let resumeReservation: { release: () => void } | undefined;
-  let resumeResponseAccepted = false;
   let ordinaryAppConfigChanged = false;
   let policyOutcome: CodexThreadPolicyHandoffError["outcome"] = "not-written";
-  const assertHandoffCurrent = () => {
-    params.params.hostCapabilities.assertActive();
-    throwIfAborted();
-    context.assertResumeOwnership();
-    context.assertResumeConfiguration();
-  };
   const abandonClient =
     params.abandonClient ?? (() => closeCodexStartupClientBestEffort(params.client));
   try {
+    // Preparation reads must share resume recovery, before any subscription is acquired.
+    const configuration = await context.prepareResume();
+    const assertHandoffCurrent = configuration.assertConfigured;
+    disposeConfiguration = configuration.dispose;
+    await context.releaseRetainedThread(configuration.assertCurrent);
+    configuration.assertCurrent();
     const authProfileId =
       resumeBinding.connectionScope === "supervision"
         ? undefined
@@ -168,12 +171,12 @@ export async function resumeExistingCodexThread(
         abandonClient,
         request: resumeParams,
         signal: params.signal,
-        assertCurrent: context.assertResumeOwnership,
+        assertCurrent: configuration.assertCurrent,
       }),
     );
-    resumeResponseAccepted = true;
+    acceptedConfiguration = configuration;
     assertCodexThreadAcceptsDirectInput(response.thread);
-    context.assertResumeConfiguration();
+    configuration.assertConfigured();
     // Current-policy denial must release this subscription and stop, not retry
     // as a fresh thread. A confirmed config change still follows normal rotation.
     const loadedPluginThreadConfig = await context.buildLoadedPluginThreadConfig?.(resumeBinding);
@@ -320,12 +323,15 @@ export async function resumeExistingCodexThread(
     // Pre-write ownership conflicts and unsafe helper outcomes cannot rotate
     // the binding. Overload is an exact pre-enqueue rejection, not a stale thread.
     if (
-      !resumeResponseAccepted &&
-      (!(error instanceof CodexAppServerRpcError) || isCodexAppServerOverloadError(error))
+      !acceptedConfiguration &&
+      (!(error instanceof CodexAppServerRpcError) ||
+        (error.method === "thread/read" &&
+          !isCodexThreadReadMissingError(error, resumeBinding.threadId)) ||
+        isCodexAppServerOverloadError(error))
     ) {
       throw error;
     }
-    if (resumeResponseAccepted) {
+    if (acceptedConfiguration) {
       const handoffError =
         error instanceof CodexThreadPolicyHandoffError ||
         error instanceof CodexAppServerUnsafeSubscriptionError
@@ -336,7 +342,7 @@ export async function resumeExistingCodexThread(
       const subscriptionReleased = await unsubscribeCodexThreadBestEffort(params.client, {
         threadId: resumeBinding.threadId,
         timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-        assertCurrent: context.assertResumeOwnership,
+        assertCurrent: acceptedConfiguration.assertCurrent,
       }).catch(() => false);
       if (
         !subscriptionReleased ||
@@ -369,10 +375,11 @@ export async function resumeExistingCodexThread(
       if (!ordinaryAppConfigChanged || !subscriptionReleased) {
         throw handoffError;
       }
-      assertHandoffCurrent();
+      acceptedConfiguration.assertConfigured();
     }
     if (
       resumeBinding.pendingResumeConfiguration ||
+      resumeBinding.preserveNativeModel ||
       resumeBinding.connectionScope === "supervision" ||
       params.signal?.aborted
     ) {
@@ -382,6 +389,8 @@ export async function resumeExistingCodexThread(
       error,
     });
     await clearCurrentBinding("rotating a stale thread binding");
+  } finally {
+    disposeConfiguration?.();
   }
 
   return undefined;

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -669,31 +669,25 @@ export async function startOrResumeThread(
               : "rotating a stale plugin app binding",
           );
         } else {
-          // Native adoption must be checked before releasing any retained owner;
-          // a passive refusal neither acquires nor authorizes dropping a subscription.
-          const configuration = await prepareCodexThreadResume(params, binding, requestContext);
-          try {
-            await releaseRetainedThread(
-              binding.threadId,
-              binding.clientId,
-              configuration.assertCurrent,
-            );
-            configuration.assertCurrent();
-            const resumed = await resumeExistingCodexThread(params, {
-              ...requestContext,
-              binding,
-              clearCurrentBinding,
-              prebuiltFinalConfigPatch: warmReuse.prebuiltFinalConfigPatch,
-              prebuiltPluginThreadConfig,
-              buildLoadedPluginThreadConfig,
-              assertResumeOwnership: configuration.assertCurrent,
-              assertResumeConfiguration: configuration.assertConfigured,
-            });
-            if (resumed) {
-              return resumed;
-            }
-          } finally {
-            configuration.dispose();
+          const resumeBinding = binding;
+          const resumed = await resumeExistingCodexThread(params, {
+            ...requestContext,
+            binding: resumeBinding,
+            clearCurrentBinding,
+            prebuiltFinalConfigPatch: warmReuse.prebuiltFinalConfigPatch,
+            prebuiltPluginThreadConfig,
+            buildLoadedPluginThreadConfig,
+            prepareResume: () => prepareCodexThreadResume(params, resumeBinding, requestContext),
+            releaseRetainedThread: async (assertCurrent) => {
+              await releaseRetainedThread(
+                resumeBinding.threadId,
+                resumeBinding.clientId,
+                assertCurrent,
+              );
+            },
+          });
+          if (resumed) {
+            return resumed;
           }
         }
       }

--- a/extensions/codex/src/app-server/thread-lifecycle-types.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-types.ts
@@ -127,6 +127,12 @@ export type CodexThreadRequestContext = {
   throwIfAborted: () => void;
 };
 
+export type CodexThreadResumePreparation = {
+  assertConfigured: () => void;
+  assertCurrent: () => void;
+  dispose: () => void;
+};
+
 export type CodexResumeThreadContext = CodexThreadRequestContext & {
   binding: CodexAppServerThreadBinding;
   clearCurrentBinding: (operation: string) => Promise<void>;
@@ -135,8 +141,8 @@ export type CodexResumeThreadContext = CodexThreadRequestContext & {
     binding: CodexAppServerThreadBinding,
   ) => Promise<CodexPluginThreadConfig | undefined>;
   prebuiltFinalConfigPatch?: CodexThreadFinalConfigPatchResult;
-  assertResumeConfiguration: () => void;
-  assertResumeOwnership: () => void;
+  prepareResume: () => Promise<CodexThreadResumePreparation>;
+  releaseRetainedThread: (assertCurrent: () => void) => Promise<void>;
 };
 
 export type CodexStartThreadContext = CodexThreadRequestContext & {

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -3631,62 +3631,173 @@ describe("Codex app-server thread lifecycle bindings", () => {
     ]);
   });
 
-  it("keeps the bound local provider when recoverable resume failure starts a fresh thread", async () => {
-    const sessionFile = path.join(tempDir, "session.jsonl");
+  it.each(["thread/read", "thread/resume"])(
+    "keeps the bound local provider when %s fails before resume admission",
+    async (failureMethod) => {
+      const sessionFile = path.join(tempDir, "session.jsonl");
+      const workspaceDir = path.join(tempDir, "workspace");
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: "thread-existing",
+        cwd: workspaceDir,
+        model: "local-model",
+        modelProvider: "lmstudio",
+        approvalPolicy: "on-request",
+        sandbox: "workspace-write",
+      });
+      const params = createParams(sessionFile, workspaceDir);
+      params.provider = "codex";
+      params.modelId = "local-model-2";
+      const appServer = createThreadLifecycleAppServerOptions();
+      const fixture = await createLeasedLifecycleWireClient(
+        path.join(tempDir, "agent"),
+        ({ method }) => {
+          if (method === failureMethod) {
+            throw new CodexAppServerRpcError(
+              { code: -32_600, message: "thread not loaded: thread-existing" },
+              method,
+            );
+          }
+          if (method === "thread/read") {
+            return {
+              thread: {
+                ...threadStartResult("thread-existing").thread,
+                status: { type: "notLoaded" },
+              },
+            };
+          }
+          if (method === "thread/unsubscribe") {
+            return { status: "notLoaded" };
+          }
+          if (method === "thread/start") {
+            const response = threadStartResult("thread-new");
+            response.model = "local-model-2";
+            response.modelProvider = "lmstudio";
+            response.thread.modelProvider = "lmstudio";
+            return response;
+          }
+          throw new Error(`unexpected method: ${method}`);
+        },
+      );
+      const { client } = fixture;
+      const request = vi.spyOn(client, "request");
+      try {
+        const binding = await startOrResumeThread({
+          client,
+          params,
+          cwd: workspaceDir,
+          dynamicTools: [],
+          appServer,
+        });
+
+        const startParams = request.mock.calls.find(
+          ([method]) => method === "thread/start",
+        )?.[1] as Record<string, unknown> | undefined;
+        expect(request.mock.calls.map(([method]) => method)).toEqual(
+          failureMethod === "thread/read"
+            ? ["thread/read", "thread/start"]
+            : ["thread/read", "thread/resume", "thread/unsubscribe", "thread/start"],
+        );
+        expect(startParams?.model).toBe("local-model-2");
+        expect(startParams?.modelProvider).toBe("lmstudio");
+        expect(binding.threadId).toBe("thread-new");
+        expect(binding.modelProvider).toBe("lmstudio");
+        await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
+          threadId: "thread-new",
+          modelProvider: "lmstudio",
+        });
+      } finally {
+        releaseLeasedSharedCodexAppServerClient(client);
+        await client.closeAndWait();
+      }
+    },
+  );
+
+  it.each([
+    "native-model",
+    "pending-adoption",
+    "overload",
+    "storage-failure",
+    "unrelated-invalid-request",
+    "wrong-thread",
+    "aborted",
+    "retired-client",
+    "closed-host",
+    "active-thread",
+    "parent-owned",
+  ] as const)("preserves the binding when cold preparation is %s", async (condition) => {
+    const sessionFile = path.join(tempDir, "preserved-cold.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
-    await writeCodexAppServerBinding(sessionFile, {
-      threadId: "thread-existing",
-      cwd: workspaceDir,
-      model: "local-model",
-      modelProvider: "lmstudio",
-      approvalPolicy: "on-request",
-      sandbox: "workspace-write",
-    });
-    const params = createParams(sessionFile, workspaceDir);
-    params.provider = "codex";
-    params.modelId = "local-model-2";
-    const appServer = createThreadLifecycleAppServerOptions();
-    const respond = vi.fn(async (method: string, _requestParams?: unknown) => {
-      if (method === "thread/resume") {
-        throw new CodexAppServerRpcError({ code: -32_000, message: "stale thread" }, method);
+    const agentDir = path.join(tempDir, "agent");
+    const params = { ...createParams(sessionFile, workspaceDir), agentDir };
+    const closeHost = await bindProductionHarnessHostCapabilitiesForTest(params);
+    const controller = new AbortController();
+    const wire = await createLeasedLifecycleWireClient(agentDir, ({ method }) => {
+      if (method !== "thread/read") {
+        throw new Error(`Unexpected cold preparation request: ${method}`);
       }
-      if (method === "thread/start") {
-        const response = threadStartResult("thread-new");
-        response.model = "local-model-2";
-        response.modelProvider = "lmstudio";
-        response.thread.modelProvider = "lmstudio";
-        return response;
+      if (condition === "aborted") {
+        controller.abort(new Error("preparation canceled"));
+      } else if (condition === "retired-client") {
+        retireSharedCodexAppServerClientIfCurrent(wire.client);
+      } else if (condition === "closed-host") {
+        closeHost();
+      } else if (condition === "active-thread" || condition === "parent-owned") {
+        return {
+          thread: {
+            ...threadStartResult("thread-preserved").thread,
+            status: { type: condition === "active-thread" ? "active" : "notLoaded" },
+            canAcceptDirectInput: condition !== "parent-owned",
+          },
+        };
       }
-      throw new Error(`unexpected method: ${method}`);
+      throw new CodexAppServerRpcError(
+        {
+          code:
+            condition === "overload"
+              ? -32_001
+              : condition === "storage-failure"
+                ? -32_603
+                : -32_600,
+          message:
+            condition === "storage-failure"
+              ? "failed to read thread: store unavailable"
+              : condition === "unrelated-invalid-request"
+                ? "invalid thread request"
+                : `thread not loaded: ${condition === "wrong-thread" ? "thread-other" : "thread-preserved"}`,
+        },
+        method,
+      );
     });
-    const fixture = await createLeasedCodexLifecycleHarness({
-      agentDir: path.join(tempDir, "agent"),
-      respond,
-      persistedThreads: ["thread-existing"],
-    });
-    const { client, request } = fixture;
-
-    const binding = await startOrResumeThread({
-      client,
-      params,
-      cwd: workspaceDir,
-      dynamicTools: [],
-      appServer,
-    });
-
-    const startParams = request.mock.calls.find(([method]) => method === "thread/start")?.[1] as
-      | Record<string, unknown>
-      | undefined;
-    expect(request.mock.calls.map(([method]) => method)).toEqual([
-      "thread/read",
-      "thread/resume",
-      "thread/unsubscribe",
-      "thread/start",
-    ]);
-    expect(startParams?.model).toBe("local-model-2");
-    expect(startParams?.modelProvider).toBe("lmstudio");
-    expect(binding.threadId).toBe("thread-new");
-    expect(binding.modelProvider).toBe("lmstudio");
+    try {
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: "thread-preserved",
+        clientId: wire.client.getInstanceId(),
+        cwd: workspaceDir,
+        modelProvider: "openai",
+        ...(condition === "native-model" ? { preserveNativeModel: true } : {}),
+        ...(condition === "pending-adoption" ? { pendingResumeConfiguration: true } : {}),
+      });
+      const before = await readCodexAppServerBinding(sessionFile);
+      await expect(
+        startOrResumeThread({
+          client: wire.client,
+          params,
+          cwd: workspaceDir,
+          dynamicTools: [],
+          appServer: createThreadLifecycleAppServerOptions(),
+          userMcpServersEnabled: false,
+          signal: controller.signal,
+        }),
+      ).rejects.toThrow();
+      await expect(readCodexAppServerBinding(sessionFile)).resolves.toEqual(before);
+      expect(
+        new Set(wire.writes.map((message) => (JSON.parse(message) as RpcRequest).method)),
+      ).toEqual(new Set(["thread/read"]));
+    } finally {
+      closeHost();
+      releaseLeasedSharedCodexAppServerClient(wire.client);
+      await wire.client.closeAndWait();
+    }
   });
 
   it("fails closed when a structured resume failure cannot release its subscription", async () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.native.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.native.test.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { createPluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-store-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCodexNativeTestState } from "./native-app-server.test-support.js";
+import { isJsonObject } from "./protocol.js";
+import {
+  createCodexAppServerBindingStore,
+  sessionBindingIdentity,
+  type StoredCodexAppServerBinding,
+} from "./session-binding.js";
+import { createIsolatedCodexAppServerClient } from "./shared-client.js";
+import { startOrResumeThread } from "./thread-lifecycle.js";
+import {
+  createAppServerOptions,
+  createParams,
+  resetThreadLifecycleTestFixtures,
+} from "./thread-lifecycle.test-fixtures.js";
+import { CODEX_APP_SERVER_VERSION } from "./version.js";
+
+vi.unmock("node:child_process");
+afterEach(resetThreadLifecycleTestFixtures);
+
+describe("native Codex cold thread recovery", () => {
+  it(
+    "replaces a deleted ordinary binding and completes its next turn",
+    { timeout: 75_000 },
+    async (context) => {
+      const tempDirs = useAutoCleanupTempDirTracker(context.onTestFinished);
+      const root = await fs.realpath(tempDirs.make("codex-missing-thread-"));
+      const native = await createCodexNativeTestState(root);
+      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(root, "state"));
+      vi.stubEnv("HOME", native.env.HOME);
+      vi.stubEnv("CODEX_HOME", native.codexHome);
+      let requests = 0;
+      const server = http.createServer((request, response) => {
+        request.resume();
+        request.on("end", () => {
+          if (request.method !== "POST" || request.url !== "/v1/responses") {
+            response.writeHead(404).end();
+            return;
+          }
+          requests += 1;
+          const events = [
+            { type: "response.created", response: { id: "recovered-response" } },
+            {
+              type: "response.output_item.done",
+              item: {
+                type: "message",
+                role: "assistant",
+                id: "recovered-answer",
+                content: [{ type: "output_text", text: "Recovered conversation." }],
+              },
+            },
+            {
+              type: "response.completed",
+              response: {
+                id: "recovered-response",
+                usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+              },
+            },
+          ];
+          response.writeHead(200, { "Content-Type": "text/event-stream" });
+          response.end(
+            events
+              .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+              .join(""),
+          );
+        });
+      });
+      context.onTestFinished(async () => {
+        server.closeAllConnections();
+        if (server.listening) {
+          await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+          });
+        }
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback provider address");
+      }
+      await fs.writeFile(
+        path.join(native.codexHome, "config.toml"),
+        [
+          'model="gpt-5.6-luna"',
+          'model_provider="recovery-fixture"',
+          'cli_auth_credentials_store="ephemeral"',
+          'web_search="disabled"',
+          'approval_policy="never"',
+          'sandbox_mode="read-only"',
+          "allow_login_shell=false",
+          "[features]",
+          "shell_snapshot=false",
+          "[analytics]",
+          "enabled=false",
+          "[feedback]",
+          "enabled=false",
+          "[model_providers.recovery-fixture]",
+          'name="Synthetic recovery provider"',
+          `base_url="http://127.0.0.1:${address.port}/v1"`,
+          'wire_api="responses"',
+          "requires_openai_auth=false",
+          "supports_websockets=false",
+          "request_max_retries=0",
+          "stream_max_retries=0",
+        ].join("\n"),
+      );
+      const agentDir = path.join(root, "agent");
+      const childEnv = Object.fromEntries(
+        Object.entries(native.env).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined,
+        ),
+      );
+      const appServer = {
+        ...createAppServerOptions(),
+        start: {
+          transport: "stdio" as const,
+          command: native.command,
+          commandSource: "config" as const,
+          args: ["app-server"],
+          cwd: native.cwd,
+          headers: {},
+          env: childEnv,
+          clearEnv: Object.keys(process.env).filter((key) => !(key in childEnv)),
+        },
+      };
+      const client = await createIsolatedCodexAppServerClient({
+        startOptions: appServer.start,
+        agentDir,
+        authProfileId: null,
+        config: {},
+        timeoutMs: 20_000,
+      });
+      context.onTestFinished(async () => expect(await client.closeAndWait()).toBe(true));
+      expect(client.getRuntimeIdentity()?.serverVersion).toBe(CODEX_APP_SERVER_VERSION);
+      const params = {
+        ...createParams(path.join(root, "session.jsonl"), native.cwd),
+        agentId: "main",
+        agentDir,
+        modelId: "gpt-5.6-luna",
+      };
+      const store = createPluginStateSyncKeyedStore<StoredCodexAppServerBinding>("codex", {
+        namespace: "native-recovery-test",
+        maxEntries: 32,
+      });
+      const bindingStore = createCodexAppServerBindingStore(store);
+      const common = {
+        client,
+        bindingStore,
+        params,
+        cwd: native.cwd,
+        dynamicTools: [],
+        appServer,
+        userMcpServersEnabled: false,
+        signal: AbortSignal.timeout(60_000),
+      };
+      const first = await startOrResumeThread(common);
+      await client.request("thread/inject_items", {
+        threadId: first.threadId,
+        items: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Synthetic previous history." }],
+          },
+        ],
+      });
+      await client.request("thread/delete", { threadId: first.threadId });
+      await expect(
+        client.request("thread/read", { threadId: first.threadId, includeTurns: false }),
+      ).rejects.toMatchObject({ code: -32_600 });
+      const identity = sessionBindingIdentity(params);
+      expect(bindingStore.read(identity)?.threadId).toBe(first.threadId);
+      const recovered = await startOrResumeThread(common);
+      expect(recovered.threadId).not.toBe(first.threadId);
+      expect(recovered).toMatchObject({
+        model: "gpt-5.6-luna",
+        modelProvider: "recovery-fixture",
+        lifecycle: { action: "started" },
+      });
+      expect(bindingStore.read(identity)?.threadId).toBe(recovered.threadId);
+      const completed = createDeferred<unknown>();
+      const removeHandler = client.addNotificationHandler((notification) => {
+        if (
+          notification.method === "turn/completed" &&
+          isJsonObject(notification.params) &&
+          notification.params.threadId === recovered.threadId
+        ) {
+          completed.resolve(notification.params.turn);
+        }
+      });
+      context.onTestFinished(removeHandler);
+      await client.request("turn/start", {
+        threadId: recovered.threadId,
+        input: [{ type: "text", text: "Continue the conversation.", text_elements: [] }],
+      });
+      await expect(completed.promise).resolves.toMatchObject({ status: "completed" });
+      expect(requests).toBe(1);
+      const history = await client.request("thread/read", {
+        threadId: recovered.threadId,
+        includeTurns: true,
+      });
+      expect(JSON.stringify(history.thread.turns)).toContain("Recovered conversation.");
+    },
+  );
+});

--- a/extensions/codex/src/session-upstream-activity.test.ts
+++ b/extensions/codex/src/session-upstream-activity.test.ts
@@ -199,24 +199,14 @@ describe("Codex upstream activity", () => {
     expect(readThread).toHaveBeenCalledWith("thread-1", false);
   });
 
-  it("treats non-definitive thread/read failures as inconclusive", async () => {
+  it.each([
+    { code: -32603, message: "store hiccup", method: "thread/read" },
+    { code: -32600, message: "some other validation failure", method: "thread/read" },
+    { code: -32600, message: "thread not loaded: thread-other", method: "thread/read" },
+    { code: -32600, message: "thread not loaded: thread-1", method: "thread/resume" },
+  ])("treats non-definitive failures as inconclusive: $method $message", async (error) => {
     const readThread = vi.fn(async () => {
-      throw new CodexAppServerRpcError({ code: -32603, message: "store hiccup" }, "thread/read");
-    });
-    const control = createControl({
-      listTurnPage: async () => ({ data: [] }),
-      readThread,
-    });
-
-    await expect(createActivityChecker({ control })([probe()])).resolves.toEqual([]);
-  });
-
-  it("treats other invalid-request thread/read failures as inconclusive", async () => {
-    const readThread = vi.fn(async () => {
-      throw new CodexAppServerRpcError(
-        { code: -32600, message: "some other validation failure" },
-        "thread/read",
-      );
+      throw new CodexAppServerRpcError(error, error.method);
     });
     const control = createControl({
       listTurnPage: async () => ({ data: [] }),

--- a/extensions/codex/src/session-upstream-activity.ts
+++ b/extensions/codex/src/session-upstream-activity.ts
@@ -6,8 +6,8 @@ import type {
   SessionUpstreamProbe,
 } from "openclaw/plugin-sdk/session-catalog";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { CodexAppServerRpcError } from "./app-server/client.js";
 import type { CodexTurn, CodexUserInput } from "./app-server/protocol.js";
+import { isCodexThreadReadMissingError } from "./app-server/rpc-error.js";
 import {
   sessionBindingIdentity,
   type CodexAppServerBindingStore,
@@ -18,20 +18,6 @@ import type {
 } from "./session-catalog-types.js";
 
 const CODEX_UPSTREAM_TURN_LIMIT = 100;
-// codex-rs app-server thread/read maps a gone rollout to JSON-RPC invalid_request
-// with exactly this message prefix (read_thread_view "thread not loaded"). The code
-// alone is generic (other store validation reuses it), so both must match; a harness
-// message rename degrades to the old silent gap instead of unlinking live threads.
-const CODEX_APP_SERVER_INVALID_REQUEST_CODE = -32600;
-const CODEX_THREAD_NOT_LOADED_MESSAGE_PREFIX = "thread not loaded:";
-
-function isCodexThreadGoneError(error: unknown): boolean {
-  return (
-    error instanceof CodexAppServerRpcError &&
-    error.code === CODEX_APP_SERVER_INVALID_REQUEST_CODE &&
-    error.message.startsWith(CODEX_THREAD_NOT_LOADED_MESSAGE_PREFIX)
-  );
-}
 
 type CodexUpstreamControl = Pick<
   CodexSessionCatalogControl,
@@ -177,7 +163,7 @@ async function checkCodexUpstreamActivity(
           try {
             await pinned.readThread(threadId, false);
           } catch (error) {
-            if (isCodexThreadGoneError(error)) {
+            if (isCodexThreadReadMissingError(error, threadId)) {
               activities.push({ kind: "missing", sessionKey: probe.sessionKey });
             }
           }


### PR DESCRIPTION
Closes #137121

<details>
<summary>Additional instructions</summary>

Keep Allow edits from maintainers enabled.

</details>

## What Problem This Solves

Fixes an issue where users continuing an ordinary OpenClaw-managed Codex conversation would repeatedly receive a missing-thread error after its native thread was deleted. The stale binding survived every attempt instead of using the existing fresh-thread recovery path.

## Why This Change Was Made

Cold resume preparation now belongs to the same IO lifecycle that owns resume recovery, retained-subscription release, and configuration-observer disposal. Both ordinary and pending-adoption callers use that owner; their duplicate outer cleanup paths are removed.

The existing upstream-activity missing-thread classifier moves into the RPC-error owner and is shared by both consumers. Recovery requires Codex's exact `thread/read` method, invalid-request code, and missing-thread identity—not a generic storage or validation failure. Native-model-owned, pending-adoption, supervised, active, aborted, revoked, and indeterminate accepted-request paths remain protected. The existing resume-subscription safety policy remains canonical.

Production LOC: +84/-84 (net 0). No new configuration, environment variable, schema, protocol, or dependency surface.

## User Impact

Ordinary conversations recover with a fresh native thread while retaining the selected model and provider. Transient storage failures leave the existing binding intact. The change does not silently replace pending manual attachments or native-model-owned threads, and does not replay a turn whose native outcome is uncertain.

## Evidence

- The full OpenClaw lifecycle regression failed before the repair on preparatory `thread/read`, while its existing `thread/resume` recovery control passed. Both pass with the shared preparation owner.
- Actual pinned Codex 0.152.1 process, production isolated client, real SQLite binding store, native deletion, OpenClaw lifecycle recovery, and a subsequent native turn: failed on the original production source and passed with the repair. Model responses came from a synthetic loopback Responses provider; no external credentials or model inference were used.
- The same native lifecycle proof passes with the current pinned Codex 0.153.0. The five-file owner/native/activity suite passes 426 tests, covering pending/native-model adoption, supervision, warm owners, host/client revocation, overload, policy failure, and uncertain resume cleanup.
- Added storage/internal, unrelated validation, and wrong-thread negative cases failed before tightening the shared classifier and pass afterward. They assert that the binding survives and no replacement is started.
- Real packaged Gateway flow also passed: chat reply → stop → native thread/delete → verify unchanged SQLite binding → restart → next chat reply. Both assistant messages carry native Codex mirror provenance; the replacement retains the OpenClaw session and model/provider. Exactly two successful Responses POSTs; native WebSocket negotiation receives fixture404 before HTTP fallback. Gateway/native inspector stopped, no active runs or cleanup errors, all owned temporary roots removed.
- Complete changed-code gate, runtime build, final Codex P2 autoreview, and a separate frozen-candidate independent review passed. The coordinator personally replayed the new native process/SQLite regression successfully on the exact candidate. Production+84/-84; tests+384/-70; docs+5/-0.
- Directly checked Codex `rust-v0.153.0` (`41e22fee981a63b3698df7ed36bad393cda24715`), `codex-rs/app-server/src/request_processors/thread_processor.rs`: `read_thread_view` and `read_stored_thread_for_read` (2808–2958), loaded-owner resume behavior (4100–4220), stored resume (4439–4508), and error mapping (5663–5670). The corresponding 0.152.1 contract is unchanged.

Regression provenance: the parent-relative patch for `759e127777b54426c922e8ab4c228523ddac04e9` moved ordinary cold preparation outside resume recovery. Stable `v2026.8.2` only pre-read native-model-adopted threads. No changelog changes.

Exact-head CI and repository-native landing gates remain pending publication. No live external-provider inference or visual UI gesture is claimed.
