### PR TITLE
fix(memory): degrade to polling when the kernel has no watch capacity

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -741,7 +741,6 @@ extensions/memory-core/src/memory/manager-search-orchestration.ts	1
 extensions/memory-core/src/memory/manager-search.ts	9
 extensions/memory-core/src/memory/manager-sync-base.ts	4
 extensions/memory-core/src/memory/manager-vector-rebuild-state.ts	1
-extensions/memory-core/src/memory/manager-watch-ops.ts	4
 extensions/memory-core/src/memory/manager.ts	2
 extensions/memory-core/src/memory/project-ranking.ts	1
 extensions/memory-core/src/memory/search-deadline.ts	1

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -132,6 +132,9 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
   >();
   protected providerKey: string | null = null;
   protected watcher: FSWatcher | null = null;
+  protected pollingWatchers: FSWatcher[] = [];
+  protected closingWatcherPromises = new Set<Promise<void>>();
+  protected regularWatchPaths = new Set<string>();
   protected watchTimer: NodeJS.Timeout | null = null;
   protected sessionWatchTimer: NodeJS.Timeout | null = null;
   protected sessionUnsubscribe: (() => void) | null = null;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -315,16 +315,27 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         const shouldSyncSessions = this.shouldSyncSessions(params, needsFullReindex);
 
         if (this.shouldDeferSourceWideBatch()) {
-          await this.executeSourceWideSync({
-            shouldSyncMemory,
-            shouldSyncSessions,
-            needsFullReindex,
-            needsFullSessionReindex,
-            targetArchiveFiles: targetArchiveFiles ? Array.from(targetArchiveFiles) : undefined,
-            progress: progress ?? undefined,
-          });
+          const memoryFullRetryDirty = this.memoryFullRetryDirty;
           if (shouldSyncMemory) {
+            // Claim this generation before awaiting I/O so watcher events that
+            // arrive during the refresh remain dirty for the next generation.
             this.clearMemoryRetryState();
+          }
+          try {
+            await this.executeSourceWideSync({
+              shouldSyncMemory,
+              shouldSyncSessions,
+              needsFullReindex,
+              needsFullSessionReindex,
+              targetArchiveFiles: targetArchiveFiles ? Array.from(targetArchiveFiles) : undefined,
+              progress: progress ?? undefined,
+            });
+          } catch (err) {
+            if (shouldSyncMemory) {
+              this.dirty = true;
+              this.memoryFullRetryDirty ||= memoryFullRetryDirty;
+            }
+            throw err;
           }
           if (shouldSyncSessions) {
             this.clearSessionRetryState();
@@ -333,8 +344,15 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
           }
         } else {
           if (shouldSyncMemory) {
-            await this.syncMemoryFiles({ needsFullReindex, progress: progress ?? undefined });
+            const memoryFullRetryDirty = this.memoryFullRetryDirty;
             this.clearMemoryRetryState();
+            try {
+              await this.syncMemoryFiles({ needsFullReindex, progress: progress ?? undefined });
+            } catch (err) {
+              this.dirty = true;
+              this.memoryFullRetryDirty ||= memoryFullRetryDirty;
+              throw err;
+            }
           }
 
           if (shouldSyncSessions) {

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -1,7 +1,6 @@
 // Memory Core plugin module owns memory filesystem watch synchronization.
 import fsSync from "node:fs";
 import path from "node:path";
-import chokidar from "chokidar";
 import { isPathInside } from "openclaw/plugin-sdk/file-access-runtime";
 import { classifyMemoryMultimodalPath } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
@@ -17,6 +16,11 @@ import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { formatCliCommand } from "openclaw/plugin-sdk/setup-tools";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { MemoryManagerSyncBase } from "./manager-sync-base.js";
+import {
+  isWatchCapacityError,
+  resolveMemoryNativeWatchFactory,
+  resolveMemoryWatchFactory,
+} from "./watch-factories.js";
 import {
   countChokidarWatchedEntries,
   type MemoryWatchPressureUnit,
@@ -40,8 +44,6 @@ const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
   "__pycache__",
 ]);
 const log = createSubsystemLogger("memory");
-const TEST_MEMORY_WATCH_FACTORY_KEY = Symbol.for("openclaw.test.memoryWatchFactory");
-const TEST_MEMORY_NATIVE_WATCH_FACTORY_KEY = Symbol.for("openclaw.test.memoryNativeWatchFactory");
 
 type NativeMemoryWatchPair = {
   dir: string;
@@ -50,34 +52,12 @@ type NativeMemoryWatchPair = {
   treeWatchers?: Map<string, LinuxMemoryDirectoryWatcher>;
 };
 
-type NativeMemoryWatchResult = "attached" | "missing" | "failed";
+type NativeMemoryWatchResult = "attached" | "missing" | "failed" | "no-capacity";
 
 type LinuxMemoryDirectoryWatcher = {
   watcher: fsSync.FSWatcher;
   ino: number;
 };
-
-function resolveMemoryWatchFactory(): typeof chokidar.watch {
-  if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") {
-    const override = (globalThis as Record<PropertyKey, unknown>)[TEST_MEMORY_WATCH_FACTORY_KEY];
-    if (typeof override === "function") {
-      return override as typeof chokidar.watch;
-    }
-  }
-  return chokidar.watch.bind(chokidar);
-}
-
-function resolveMemoryNativeWatchFactory(): typeof fsSync.watch {
-  if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") {
-    const override = (globalThis as Record<PropertyKey, unknown>)[
-      TEST_MEMORY_NATIVE_WATCH_FACTORY_KEY
-    ];
-    if (typeof override === "function") {
-      return override as typeof fsSync.watch;
-    }
-  }
-  return fsSync.watch.bind(fsSync);
-}
 
 function shouldIgnoreMemoryWatchPath(
   watchPath: string,
@@ -120,7 +100,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     if (!this.sources.has("memory") || !this.settings.sync.watch) {
       return;
     }
-    if (this.watcher || this.nativeMemoryWatchPairs.length > 0) {
+    if (this.watcher || this.pollingWatchers.length > 0 || this.nativeMemoryWatchPairs.length > 0) {
       // Already initialized — preserve idempotence.
       return;
     }
@@ -195,9 +175,12 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
         : process.platform === "linux"
           ? this.attachLinuxMemoryDirectoryTreeWatchForDir(dir, markDirty)
           : "failed";
+      if (attached === "no-capacity") {
+        this.attachMemoryChokidarFallback(dir, markDirty, true);
+        continue;
+      }
       if (attached !== "attached") {
-        // Native creation failed (dir missing, unsupported FS, throw) —
-        // fall back to chokidar so directory coverage isn't dropped.
+        // Native creation failed; use chokidar so directory coverage isn't dropped.
         fileWatchPaths.add(dir);
       }
     }
@@ -301,6 +284,9 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       if (isFileMissingError(err)) {
         return "missing";
       }
+      if (isWatchCapacityError(err)) {
+        return "no-capacity";
+      }
       log.warn(
         `failed to start native recursive watcher on ${dir}: ${String(err)}; falling back to chokidar`,
       );
@@ -323,7 +309,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       // still drive watch sync (intervalMinutes defaults to 0; without
       // a watcher the directory would stop being indexed).
       markDirty();
-      this.attachMemoryChokidarFallback(dir, markDirty);
+      this.attachMemoryChokidarFallback(dir, markDirty, isWatchCapacityError(err));
     });
     this.nativeMemoryWatchPairs.push(pair);
     this.attachNativeMemoryParentWatch(pair, recordedInode, markDirty, "native", () =>
@@ -403,8 +389,8 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
           // New coverage must attach before the old parent closes: the root
           // can disappear again between the inode check and native attachment.
           this.closeNativeMemoryWatchPair(pair);
-          if (result === "failed") {
-            this.attachMemoryChokidarFallback(dir, markDirty);
+          if (result === "failed" || result === "no-capacity") {
+            this.attachMemoryChokidarFallback(dir, markDirty, result === "no-capacity");
           }
         },
       );
@@ -460,9 +446,9 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
 
     let pair: NativeMemoryWatchPair | null = null;
     const treeWatchers = new Map<string, LinuxMemoryDirectoryWatcher>();
-    let rootMissing = false;
+    let [rootMissing, capacityExhausted] = [false, false];
 
-    const closeAndFallback = (message: string) => {
+    const closeAndFallback = (message: string, usePolling = false) => {
       log.warn(message);
       if (pair) {
         this.closeNativeMemoryWatchPair(pair);
@@ -471,7 +457,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
         return;
       }
       markDirty();
-      this.attachMemoryChokidarFallback(dir, markDirty);
+      this.attachMemoryChokidarFallback(dir, markDirty, usePolling);
     };
 
     const closeDirectorySubtree = (watchDir: string) => {
@@ -525,6 +511,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
               if (!this.attachLinuxMemoryDirectoryTreeSubtree(watchDir, attachDirectory)) {
                 closeAndFallback(
                   `failed to refresh Linux memory directory watchers under ${watchDir}; falling back to chokidar`,
+                  capacityExhausted,
                 );
               }
               return;
@@ -547,6 +534,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
               if (!this.attachLinuxMemoryDirectoryTreeSubtree(full, attachDirectory)) {
                 closeAndFallback(
                   `failed to attach Linux memory directory watcher under ${full}; falling back to chokidar`,
+                  capacityExhausted,
                 );
                 return;
               }
@@ -559,7 +547,8 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
         );
       } catch (err) {
         rootMissing ||= watchDir === dir && isFileMissingError(err);
-        if (watchDir === dir && !rootMissing) {
+        capacityExhausted ||= isWatchCapacityError(err);
+        if (watchDir === dir && !rootMissing && !capacityExhausted) {
           log.warn(
             `failed to start Linux memory directory watcher on ${watchDir}: ${String(err)}; falling back to chokidar`,
           );
@@ -572,14 +561,17 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
           return;
         }
         const detail = err instanceof Error ? err.message : String(err);
-        closeAndFallback(`memory Linux directory watcher error on ${watchDir}: ${detail}`);
+        closeAndFallback(
+          `memory Linux directory watcher error on ${watchDir}: ${detail}`,
+          isWatchCapacityError(err),
+        );
       });
       return watcher;
     };
 
     const mainWatcher = attachDirectory(dir);
     if (!mainWatcher) {
-      return rootMissing ? "missing" : "failed";
+      return rootMissing ? "missing" : capacityExhausted ? "no-capacity" : "failed";
     }
     pair = { dir, main: mainWatcher, parent: null, treeWatchers };
     this.nativeMemoryWatchPairs.push(pair);
@@ -596,6 +588,13 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       return isFileMissingError(err) ? "missing" : "failed";
     }
     if (!subtreeAttached) {
+      if (capacityExhausted) {
+        this.closeNativeMemoryWatchPair(pair);
+        if (!this.closed) {
+          markDirty();
+        }
+        return "no-capacity";
+      }
       closeAndFallback(
         `failed to attach Linux memory directory watcher subtree under ${dir}; falling back to chokidar`,
       );
@@ -701,34 +700,49 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
   protected attachMemoryChokidarFallback(
     dir: string,
     markDirty: (watchPath?: string, stats?: MemoryWatchEventStats) => void,
+    usePolling = false,
   ): void {
     if (this.closed) {
       // Manager teardown started — don't create new watcher resources.
       return;
     }
     try {
-      this.attachMemoryChokidarPaths(dir, markDirty);
+      this.attachMemoryChokidarPaths(dir, markDirty, usePolling);
     } catch (err) {
-      log.warn(`failed to attach chokidar fallback for ${dir}: ${String(err)}`);
+      log.warn(
+        `failed to attach ${usePolling ? "polling" : "chokidar"} fallback for ${dir}: ${String(err)}`,
+      );
     }
   }
 
   private attachMemoryChokidarPaths(
     paths: string | string[],
     markDirty: (watchPath?: string, stats?: MemoryWatchEventStats) => void,
+    usePolling = false,
   ): void {
-    // Linux subtree startup can create the fallback before ensureWatcher
-    // attaches file paths. Reuse that watcher rather than replacing it.
-    if (this.watcher) {
+    const normalizedPaths = (typeof paths === "string" ? [paths] : paths).map((watchPath) =>
+      path.resolve(watchPath),
+    );
+    if (!usePolling) {
+      for (const watchPath of normalizedPaths) {
+        this.regularWatchPaths.add(watchPath);
+      }
+    }
+    if (!usePolling && this.watcher) {
       this.watcher.add(paths);
       return;
     }
-    const watcher = resolveMemoryWatchFactory()(typeof paths === "string" ? [paths] : paths, {
+    const watcher = resolveMemoryWatchFactory(usePolling)(normalizedPaths, {
       ignoreInitial: true,
+      usePolling,
       ignored: (watchPath, stats) =>
         shouldIgnoreMemoryWatchPath(watchPath, stats, this.settings.multimodal),
     });
-    this.watcher = watcher;
+    if (usePolling) {
+      this.pollingWatchers.push(watcher);
+    } else {
+      this.watcher = watcher;
+    }
     watcher.on("add", markDirty);
     watcher.on("change", markDirty);
     watcher.on("unlink", markDirty);
@@ -737,9 +751,26 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       // File watcher errors must not crash the gateway; manual search still works.
       const message = err instanceof Error ? err.message : String(err);
       log.warn(`memory watcher error: ${message}`);
+      if (usePolling || !isWatchCapacityError(err) || this.watcher !== watcher) {
+        return;
+      }
+      this.watcher = null;
+      const closePromise = watcher.close();
+      this.closingWatcherPromises.add(closePromise);
+      void closePromise.finally(() => this.closingWatcherPromises.delete(closePromise));
+      const recoveryPaths = Array.from(this.regularWatchPaths);
+      this.regularWatchPaths.clear();
+      markDirty();
+      if (!this.closed && recoveryPaths.length > 0) {
+        this.attachMemoryChokidarPaths(recoveryPaths, markDirty, true);
+      }
     });
     watcher.once("ready", () => {
       this.warnIfMemoryWatchPressure(countChokidarWatchedEntries(watcher), "paths");
+      if (usePolling && !this.closed) {
+        // Close the async initial-crawl gap before treating polling coverage as current.
+        markDirty();
+      }
     });
   }
 

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -3,10 +3,7 @@ import fsSync from "node:fs";
 import path from "node:path";
 import { isPathInside } from "openclaw/plugin-sdk/file-access-runtime";
 import { classifyMemoryMultimodalPath } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import {
-  createSubsystemLogger,
-  type ResolvedMemorySearchConfig,
-} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   isFileMissingError,
   matchesExtraMemoryPathEntry,
@@ -21,6 +18,7 @@ import {
   resolveMemoryNativeWatchFactory,
   resolveMemoryWatchFactory,
 } from "./watch-factories.js";
+import { shouldIgnoreMemoryWatchPath } from "./watch-path-ignore.js";
 import {
   countChokidarWatchedEntries,
   type MemoryWatchPressureUnit,
@@ -34,15 +32,6 @@ import {
 } from "./watch-settle.js";
 
 const MEMORY_WATCH_PRESSURE_STARTUP_CHECK_DELAY_MS = 10_000;
-const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
-  ".git",
-  "node_modules",
-  ".pnpm-store",
-  ".venv",
-  "venv",
-  ".tox",
-  "__pycache__",
-]);
 const log = createSubsystemLogger("memory");
 
 type NativeMemoryWatchPair = {
@@ -58,34 +47,6 @@ type LinuxMemoryDirectoryWatcher = {
   watcher: fsSync.FSWatcher;
   ino: number;
 };
-
-function shouldIgnoreMemoryWatchPath(
-  watchPath: string,
-  stats?: { isDirectory?: () => boolean },
-  multimodalSettings?: ResolvedMemorySearchConfig["multimodal"],
-): boolean {
-  const normalized = path.normalize(watchPath);
-  const parts = normalized
-    .split(path.sep)
-    .map((segment) => normalizeLowercaseStringOrEmpty(segment));
-  if (parts.some((segment) => IGNORED_MEMORY_WATCH_DIR_NAMES.has(segment))) {
-    return true;
-  }
-  if (stats?.isDirectory?.()) {
-    return false;
-  }
-  if (!stats) {
-    return false;
-  }
-  const extension = normalizeLowercaseStringOrEmpty(path.extname(normalized));
-  if (extension.length === 0 || extension === ".md") {
-    return false;
-  }
-  if (!multimodalSettings) {
-    return true;
-  }
-  return classifyMemoryMultimodalPath(normalized, multimodalSettings) === null;
-}
 
 function runDetachedMemorySync(sync: () => Promise<void>, reason: "interval" | "watch") {
   void sync().catch((err: unknown) => {

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -130,13 +130,19 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     // ERR_FEATURE_UNAVAILABLE_ON_PLATFORM) the directory also falls back to
     // chokidar so freshness is preserved on the degraded path.
     const nativeRecursiveSupported = process.platform === "darwin" || process.platform === "win32";
+    let watchCapacityExhausted = false;
     for (const dir of dirWatchPaths) {
+      if (watchCapacityExhausted) {
+        this.attachMemoryChokidarFallback(dir, markDirty, true);
+        continue;
+      }
       const attached = nativeRecursiveSupported
         ? this.attachNativeMemoryWatchForDir(dir, markDirty)
         : process.platform === "linux"
           ? this.attachLinuxMemoryDirectoryTreeWatchForDir(dir, markDirty)
           : "failed";
       if (attached === "no-capacity") {
+        watchCapacityExhausted = true;
         this.attachMemoryChokidarFallback(dir, markDirty, true);
         continue;
       }
@@ -146,7 +152,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       }
     }
     if (fileWatchPaths.size > 0) {
-      this.attachMemoryChokidarPaths(Array.from(fileWatchPaths), markDirty);
+      this.attachMemoryChokidarPaths(Array.from(fileWatchPaths), markDirty, watchCapacityExhausted);
     }
     this.scheduleMemoryWatchPressureStartupCheck();
   }

--- a/extensions/memory-core/src/memory/manager-watcher-config.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-watcher-config.test-support.ts
@@ -1,0 +1,44 @@
+import type {
+  MemorySearchConfig,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { isolateMemoryManagerTestConfig } from "./test-config-helpers.js";
+
+export type WatchIgnoredFn = (
+  watchPath: string,
+  stats?: { isDirectory?: () => boolean },
+) => boolean;
+
+const originalWatcherStateDir = process.env.OPENCLAW_STATE_DIR;
+
+export function setWatcherStateDir(stateDir: string): void {
+  Reflect.set(process.env, "OPENCLAW_STATE_DIR", stateDir);
+}
+
+export function createWatcherConfigFixture(
+  workspaceDir: string,
+  extraDir: string,
+  overrides?: Partial<MemorySearchConfig>,
+): OpenClawConfig {
+  return isolateMemoryManagerTestConfig({
+    memory: {
+      search: {
+        provider: "openai",
+        model: "mock-embed",
+        store: { vector: { enabled: false } },
+        query: { minScore: 0 },
+        extraPaths: [extraDir],
+        ...overrides,
+      },
+    },
+    agents: { entries: { main: { workspace: workspaceDir } } },
+  });
+}
+
+export function restoreWatcherStateDir(): void {
+  if (originalWatcherStateDir === undefined) {
+    Reflect.deleteProperty(process.env, "OPENCLAW_STATE_DIR");
+  } else {
+    Reflect.set(process.env, "OPENCLAW_STATE_DIR", originalWatcherStateDir);
+  }
+}

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -649,6 +649,10 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       await this.watcher.close();
       this.watcher = null;
     }
+    const pollingWatchers = this.pollingWatchers.splice(0);
+    await Promise.all(pollingWatchers.map(async (watcher) => await watcher.close()));
+    await Promise.all(Array.from(this.closingWatcherPromises));
+    this.regularWatchPaths.clear();
     this.closeNativeMemoryWatchPairs();
     if (this.sessionUnsubscribe) {
       this.sessionUnsubscribe();

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -8,10 +8,6 @@ import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  configureMemoryCoreDreamingStateForTests,
-  resetMemoryCoreDreamingStateForTests,
-} from "../test-helpers.js";
-import {
   createWatcherConfigFixture,
   restoreWatcherStateDir,
   setWatcherStateDir,
@@ -27,7 +23,6 @@ const {
   watchMock,
   nativeWatchMock,
   nativeWatchMockFailingDir,
-  nativeWatchMockFailureCode,
 } = vi.hoisted(() => {
   // Symbols are also declared at module top-level (CHOKIDAR_FACTORY_KEY,
   // NATIVE_FACTORY_KEY) but vi.hoisted runs before those declarations
@@ -102,7 +97,6 @@ const {
   const chokidarWatchers: Array<ReturnType<typeof createMockChokidarWatcher>> = [];
   const nativeWatchers: Array<ReturnType<typeof createMockNativeWatcher>> = [];
   const failingDir = { current: null as string | null };
-  const failureCode = { current: null as string | null };
 
   const result = {
     createdChokidarWatchers: chokidarWatchers,
@@ -116,9 +110,7 @@ const {
     nativeWatchMock: vi.fn(
       (dir: string, options: { recursive?: boolean }, listener: NativeCallback) => {
         if (failingDir.current && dir === failingDir.current) {
-          throw Object.assign(new Error("simulated native fs.watch creation failure"), {
-            code: failureCode.current,
-          });
+          throw new Error("simulated native fs.watch creation failure");
         }
         const watcher = createMockNativeWatcher(dir, options, listener);
         nativeWatchers.push(watcher);
@@ -126,7 +118,6 @@ const {
       },
     ),
     nativeWatchMockFailingDir: failingDir,
-    nativeWatchMockFailureCode: failureCode,
   };
   (globalThis as Record<PropertyKey, unknown>)[chokidarKey] = result.watchMock;
   (globalThis as Record<PropertyKey, unknown>)[nativeKey] = result.nativeWatchMock;
@@ -183,7 +174,6 @@ describe("memory watcher config", () => {
     vi.clearAllMocks();
     clearRegistry();
     nativeWatchMockFailingDir.current = null;
-    nativeWatchMockFailureCode.current = null;
   });
 
   afterAll(() => {
@@ -199,7 +189,6 @@ describe("memory watcher config", () => {
     createdChokidarWatchers.length = 0;
     createdNativeWatchers.length = 0;
     nativeWatchMockFailingDir.current = null;
-    nativeWatchMockFailureCode.current = null;
     if (manager) {
       await manager.close();
       manager = null;
@@ -211,7 +200,6 @@ describe("memory watcher config", () => {
     // shared handle is released second; otherwise Windows fails the removal with EBUSY.
     closeOpenClawAgentDatabasesForTest();
     resetPluginStateStoreForTests();
-    resetMemoryCoreDreamingStateForTests();
     if (workspaceDir) {
       await fs.rm(workspaceDir, { recursive: true, force: true });
       workspaceDir = "";
@@ -666,27 +654,6 @@ describe("memory watcher config", () => {
     ]);
   });
 
-  it("uses polling when Linux nested watcher setup exhausts capacity", async () => {
-    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
-    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-    const nestedDir = path.join(workspaceDir, "memory", "topic");
-    await fs.mkdir(nestedDir);
-    nativeWatchMockFailingDir.current = nestedDir;
-    nativeWatchMockFailureCode.current = "ENOSPC";
-
-    await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
-
-    expect(watchMock).toHaveBeenCalledTimes(2);
-    expect(watchCall(0)?.[0]).toStrictEqual([path.join(workspaceDir, "memory")]);
-    expect(watchCall(1)?.[0]).toStrictEqual([
-      path.join(workspaceDir, "MEMORY.md"),
-      path.join(workspaceDir, "USER.md"),
-    ]);
-    expect([watchCall(0), watchCall(1)]).toSatisfy((calls) =>
-      calls.every((call) => call?.[1].usePolling === true),
-    );
-  });
-
   it("schedules startup sync when the Linux root disappears during its initial scan", async () => {
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
@@ -797,52 +764,6 @@ describe("memory watcher config", () => {
     await manager?.close();
     expect(regularWatcher?.close).toHaveBeenCalledOnce();
     expect(pollingWatcher?.close).toHaveBeenCalledOnce();
-  });
-
-  it("keeps polling catch-up dirty when a recovery sync is already in flight", async () => {
-    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-    await configureMemoryCoreDreamingStateForTests();
-    const activeManager = await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
-    await activeManager.sync({ reason: "test-initial-index" });
-    const internals = activeManager as unknown as {
-      dirty: boolean;
-      syncing: Promise<void> | null;
-      syncMemoryFiles: (params: {
-        needsFullReindex: boolean;
-        progress?: unknown;
-      }) => Promise<unknown>;
-    };
-    internals.dirty = false;
-    const originalSyncMemoryFiles = internals.syncMemoryFiles.bind(activeManager);
-    let signalSyncStarted = () => {};
-    const syncStarted = new Promise<void>((resolve) => {
-      signalSyncStarted = resolve;
-    });
-    let releaseSync = () => {};
-    const syncRelease = new Promise<void>((resolve) => {
-      releaseSync = resolve;
-    });
-    vi.spyOn(internals, "syncMemoryFiles").mockImplementation(async (params) => {
-      signalSyncStarted();
-      await syncRelease;
-      return await originalSyncMemoryFiles(params);
-    });
-    vi.useFakeTimers();
-    const memoryDir = path.join(workspaceDir, "memory");
-    const memoryWatcher = createdNativeWatchers.find((watcher) => watcher.dir === memoryDir);
-
-    memoryWatcher?.emitError(
-      Object.assign(new Error("watcher capacity exhausted"), { code: "ENOSPC" }),
-    );
-    const firstRefresh = vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
-    await syncStarted;
-    createdChokidarWatchers.at(-1)?.emit("ready");
-    await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
-    releaseSync();
-    await firstRefresh;
-    await internals.syncing;
-
-    expect(internals.dirty).toBe(true);
   });
 
   it("treats null parent-watcher filename as an unknown event and re-checks the inode", async () => {

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -780,34 +780,38 @@ describe("memory watcher config", () => {
     },
   );
 
-  it("creates a chokidar watcher on the fly when no file-path chokidar exists yet", async () => {
+  it("creates a separate polling watcher after runtime native capacity exhaustion", async () => {
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
     const cfg = createWatcherConfig({ extraPaths: [] });
 
-    // Root memory files stay watch paths even when missing, and chokidar handles
-    // missing paths fine. To truly test the "no chokidar
-    // yet" branch we instead simulate by clearing the watchMock buffer and
-    // exercising attachMemoryChokidarFallback directly.
     await expectWatcherManager(cfg);
     vi.useFakeTimers();
 
     const memoryDir = path.join(workspaceDir, "memory");
-    const memoryWatcher = createdNativeWatchers.find((w) => w.dir === memoryDir);
+    const memoryWatcher = createdNativeWatchers.find((watcher) => watcher.dir === memoryDir);
+    const regularWatcher = createdChokidarWatchers[0];
     expect(memoryWatcher).toBeDefined();
-
-    // Pretend chokidar was never set up by clearing the manager.watcher slot,
-    // then trigger the native error; the fallback must spin up a new chokidar.
-    (manager as unknown as { watcher: unknown }).watcher = null;
+    expect(regularWatcher).toBeDefined();
     const chokidarCallsBefore = watchMock.mock.calls.length;
 
-    memoryWatcher?.emitError(new Error("watcher error: ENOSPC"));
+    memoryWatcher?.emitError(
+      Object.assign(new Error("watcher capacity exhausted"), { code: "ENOSPC" }),
+    );
     await vi.advanceTimersByTimeAsync(50);
 
     expect(watchMock.mock.calls.length).toBe(chokidarCallsBefore + 1);
-    const newChokidarCall = watchMock.mock.calls[chokidarCallsBefore] as unknown as
+    expect(regularWatcher?.add).not.toHaveBeenCalledWith(memoryDir);
+    const pollingCall = watchMock.mock.calls[chokidarCallsBefore] as unknown as
       | [string[], Record<string, unknown>]
       | undefined;
-    expect(newChokidarCall?.[0]).toStrictEqual([memoryDir]);
+    expect(pollingCall?.[0]).toStrictEqual([memoryDir]);
+    expect(pollingCall?.[1]).toEqual(expect.objectContaining({ usePolling: true }));
+    const pollingWatcher = createdChokidarWatchers[chokidarCallsBefore];
+    expect(pollingWatcher).not.toBe(regularWatcher);
+
+    await manager?.close();
+    expect(regularWatcher?.close).toHaveBeenCalledTimes(1);
+    expect(pollingWatcher?.close).toHaveBeenCalledTimes(1);
   });
 
   it("treats null parent-watcher filename as an unknown event and re-checks the inode", async () => {
@@ -1107,6 +1111,62 @@ describe("memory watcher config", () => {
     // Recorded path should match the resolved absolute path under extraDir.
     const recordedStats = (initialStats as unknown as { isDirectory: () => boolean }).isDirectory();
     expect(typeof recordedStats).toBe("boolean");
+  });
+
+  it("migrates regular chokidar paths to polling after capacity exhaustion", async () => {
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const cfg = createWatcherConfig({ extraPaths: [] });
+
+    const activeManager = await expectWatcherManager(cfg);
+    vi.useFakeTimers();
+    const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
+    const regularWatcher = createdChokidarWatchers[0];
+    expect(regularWatcher).toBeDefined();
+    const regularPaths = watchMock.mock.calls[0]?.[0];
+
+    regularWatcher?.emit(
+      "error",
+      Object.assign(new Error("watcher capacity exhausted"), { code: "EMFILE" }),
+    );
+
+    const pollingCall = watchMock.mock.calls[1] as unknown as
+      | [string[], Record<string, unknown>]
+      | undefined;
+    expect(regularWatcher?.close).toHaveBeenCalledTimes(1);
+    expect(pollingCall?.[0]).toStrictEqual(regularPaths);
+    expect(pollingCall?.[1]).toEqual(expect.objectContaining({ usePolling: true }));
+
+    createdChokidarWatchers[1]?.emit("ready");
+    await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+    expect(syncSpy).toHaveBeenCalledWith({ reason: "watch" });
+  });
+
+  it("awaits a migrated regular watcher close during manager shutdown", async () => {
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const activeManager = await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
+    const regularWatcher = createdChokidarWatchers[0];
+    let releaseWatcherClose = () => {};
+    regularWatcher?.close.mockImplementationOnce(
+      async () =>
+        await new Promise<void>((resolve) => {
+          releaseWatcherClose = resolve;
+        }),
+    );
+
+    regularWatcher?.emit(
+      "error",
+      Object.assign(new Error("watcher capacity exhausted"), { code: "ENFILE" }),
+    );
+    let managerClosed = false;
+    const closePromise = activeManager.close().then(() => {
+      managerClosed = true;
+    });
+    await Promise.resolve();
+    expect(managerClosed).toBe(false);
+
+    releaseWatcherClose();
+    await closePromise;
+    expect(managerClosed).toBe(true);
   });
 
   it("attaches a logging non-throwing chokidar error listener", async () => {

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -3,15 +3,16 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type {
-  MemorySearchConfig,
-  OpenClawConfig,
-} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-type WatchIgnoredFn = (watchPath: string, stats?: { isDirectory?: () => boolean }) => boolean;
+import {
+  createWatcherConfigFixture,
+  restoreWatcherStateDir,
+  setWatcherStateDir,
+  type WatchIgnoredFn,
+} from "./manager-watcher-config.test-support.js";
 
 const BUILT_IN_WATCH_DEBOUNCE_MS = 1_500;
 
@@ -44,7 +45,7 @@ const {
         return watcher;
       }),
       add: vi.fn((_path: string | string[]) => watcher),
-      close: vi.fn(async () => undefined),
+      close: vi.fn(async (): Promise<void> => undefined),
       getWatched: vi.fn(() => watcher.watchedEntries),
       emit: (event: ChokidarEvent, ...args: unknown[]) => {
         for (const callback of handlers.get(event) ?? []) {
@@ -125,19 +126,6 @@ const {
 
 const CHOKIDAR_FACTORY_KEY = Symbol.for("openclaw.test.memoryWatchFactory");
 const NATIVE_FACTORY_KEY = Symbol.for("openclaw.test.memoryNativeWatchFactory");
-const originalWatcherStateDir = process.env.OPENCLAW_STATE_DIR;
-
-function setWatcherStateDir(stateDir: string): void {
-  Reflect.set(process.env, "OPENCLAW_STATE_DIR", stateDir);
-}
-
-function restoreWatcherStateDir(): void {
-  if (originalWatcherStateDir === undefined) {
-    Reflect.deleteProperty(process.env, "OPENCLAW_STATE_DIR");
-  } else {
-    Reflect.set(process.env, "OPENCLAW_STATE_DIR", originalWatcherStateDir);
-  }
-}
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-foundation", async (importOriginal) => {
   const actual =
@@ -173,7 +161,6 @@ vi.mock("./embeddings.js", () => ({
 import { clearEmbeddingProviders as clearRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
 import type { MemoryIndexManager } from "./manager.js";
-import { isolateMemoryManagerTestConfig } from "./test-config-helpers.js";
 
 describe("memory watcher config", () => {
   let manager: MemoryIndexManager | null = null;
@@ -229,20 +216,18 @@ describe("memory watcher config", () => {
     await fs.writeFile(path.join(extraDir, seedFile.name), seedFile.contents);
   }
 
-  function createWatcherConfig(overrides?: Partial<MemorySearchConfig>): OpenClawConfig {
-    return isolateMemoryManagerTestConfig({
-      memory: {
-        search: {
-          provider: "openai",
-          model: "mock-embed",
-          store: { vector: { enabled: false } },
-          query: { minScore: 0 },
-          extraPaths: [extraDir],
-          ...overrides,
-        },
-      },
-      agents: { entries: { main: { workspace: workspaceDir } } },
-    });
+  function createWatcherConfig(overrides?: Parameters<typeof createWatcherConfigFixture>[2]) {
+    return createWatcherConfigFixture(workspaceDir, extraDir, overrides);
+  }
+
+  function watchCall(index: number) {
+    return (watchMock.mock.calls as unknown as Array<[string[], Record<string, unknown>]>)[index];
+  }
+
+  function nativeWatchCalls() {
+    return nativeWatchMock.mock.calls as unknown as Array<
+      [string, { recursive?: boolean }, unknown]
+    >;
   }
 
   async function expectWatcherManager(cfg: OpenClawConfig, agentId = "main") {
@@ -286,10 +271,7 @@ describe("memory watcher config", () => {
 
       // Chokidar should only see file paths (MEMORY.md); directories use native watch.
       expect(watchMock).toHaveBeenCalledTimes(1);
-      const [chokidarPaths, chokidarOptions] = watchMock.mock.calls[0] as unknown as [
-        string[],
-        Record<string, unknown>,
-      ];
+      const [chokidarPaths, chokidarOptions] = watchCall(0) ?? [[], {}];
       expect(chokidarPaths).toStrictEqual([
         path.join(workspaceDir, "MEMORY.md"),
         path.join(workspaceDir, "USER.md"),
@@ -304,12 +286,8 @@ describe("memory watcher config", () => {
       // replacement (see attachNativeMemoryWatchForDir). 2 dirs × 2 watchers
       // each = 4 native fs.watch calls.
       expect(nativeWatchMock).toHaveBeenCalledTimes(4);
-      const mainNativeCalls = (
-        nativeWatchMock.mock.calls as unknown as [string, { recursive?: boolean }, unknown][]
-      ).filter((call) => call[1].recursive === true);
-      const parentNativeCalls = (
-        nativeWatchMock.mock.calls as unknown as [string, { recursive?: boolean }, unknown][]
-      ).filter((call) => call[1].recursive !== true);
+      const mainNativeCalls = nativeWatchCalls().filter((call) => call[1].recursive === true);
+      const parentNativeCalls = nativeWatchCalls().filter((call) => call[1].recursive !== true);
       expect(mainNativeCalls.map((call) => call[0])).toStrictEqual(
         expect.arrayContaining([path.join(workspaceDir, "memory"), extraDir]),
       );
@@ -392,10 +370,7 @@ describe("memory watcher config", () => {
     await expectWatcherManager(cfg);
 
     expect(watchMock).toHaveBeenCalledTimes(1);
-    const [chokidarPaths, chokidarOptions] = watchMock.mock.calls[0] as unknown as [
-      string[],
-      Record<string, unknown>,
-    ];
+    const [chokidarPaths, chokidarOptions] = watchCall(0) ?? [[], {}];
     expect(chokidarPaths).toStrictEqual([
       path.join(workspaceDir, "MEMORY.md"),
       path.join(workspaceDir, "USER.md"),
@@ -403,9 +378,7 @@ describe("memory watcher config", () => {
 
     // 2 directories × (main + parent) = 4 native watch calls.
     expect(nativeWatchMock).toHaveBeenCalledTimes(4);
-    const nativeDirs = (
-      nativeWatchMock.mock.calls as unknown as [string, { recursive?: boolean }, unknown][]
-    )
+    const nativeDirs = nativeWatchCalls()
       .filter((call) => call[1].recursive === true)
       .map((call) => call[0]);
     expect(nativeDirs).toStrictEqual(
@@ -486,10 +459,7 @@ describe("memory watcher config", () => {
     // Native watch for memory/ threw — that dir should fall back into chokidar's set.
     expect(nativeWatchMock).toHaveBeenCalled();
     expect(watchMock).toHaveBeenCalledTimes(1);
-    const [chokidarPathsFallback] = watchMock.mock.calls[0] as unknown as [
-      string[],
-      Record<string, unknown>,
-    ];
+    const [chokidarPathsFallback] = watchCall(0) ?? [[]];
     expect(chokidarPathsFallback).toStrictEqual(
       expect.arrayContaining([
         path.join(workspaceDir, "MEMORY.md"),
@@ -562,20 +532,13 @@ describe("memory watcher config", () => {
       // Chokidar should only receive file paths. Linux directories use
       // non-recursive native directory watches.
       expect(watchMock).toHaveBeenCalledTimes(1);
-      const [chokidarPathsLinux] = watchMock.mock.calls[0] as unknown as [
-        string[],
-        Record<string, unknown>,
-      ];
+      const [chokidarPathsLinux] = watchCall(0) ?? [[]];
       expect(chokidarPathsLinux).toStrictEqual([
         path.join(workspaceDir, "MEMORY.md"),
         path.join(workspaceDir, "USER.md"),
       ]);
 
-      const nativeCalls = nativeWatchMock.mock.calls as unknown as [
-        string,
-        { recursive?: boolean },
-        unknown,
-      ][];
+      const nativeCalls = nativeWatchCalls();
       expect(nativeCalls.every((call) => call[1].recursive !== true)).toBe(true);
       expect(nativeCalls.map((call) => call[0])).toStrictEqual(
         expect.arrayContaining([
@@ -683,10 +646,7 @@ describe("memory watcher config", () => {
     await expectWatcherManager(cfg);
 
     expect(watchMock).toHaveBeenCalledTimes(1);
-    const [fallbackPaths] = watchMock.mock.calls[0] as unknown as [
-      string[],
-      Record<string, unknown>,
-    ];
+    const [fallbackPaths] = watchCall(0) ?? [[]];
     expect(fallbackPaths).toStrictEqual([path.join(workspaceDir, "memory")]);
     expect(createdChokidarWatchers[0]?.add).toHaveBeenCalledWith([
       path.join(workspaceDir, "MEMORY.md"),
@@ -782,36 +742,28 @@ describe("memory watcher config", () => {
 
   it("creates a separate polling watcher after runtime native capacity exhaustion", async () => {
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-    const cfg = createWatcherConfig({ extraPaths: [] });
-
-    await expectWatcherManager(cfg);
+    await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
     vi.useFakeTimers();
-
     const memoryDir = path.join(workspaceDir, "memory");
     const memoryWatcher = createdNativeWatchers.find((watcher) => watcher.dir === memoryDir);
     const regularWatcher = createdChokidarWatchers[0];
-    expect(memoryWatcher).toBeDefined();
-    expect(regularWatcher).toBeDefined();
-    const chokidarCallsBefore = watchMock.mock.calls.length;
+    const callsBefore = watchMock.mock.calls.length;
 
     memoryWatcher?.emitError(
       Object.assign(new Error("watcher capacity exhausted"), { code: "ENOSPC" }),
     );
     await vi.advanceTimersByTimeAsync(50);
 
-    expect(watchMock.mock.calls.length).toBe(chokidarCallsBefore + 1);
+    expect(watchMock).toHaveBeenCalledTimes(callsBefore + 1);
     expect(regularWatcher?.add).not.toHaveBeenCalledWith(memoryDir);
-    const pollingCall = watchMock.mock.calls[chokidarCallsBefore] as unknown as
-      | [string[], Record<string, unknown>]
-      | undefined;
+    const pollingCall = watchCall(callsBefore);
     expect(pollingCall?.[0]).toStrictEqual([memoryDir]);
     expect(pollingCall?.[1]).toEqual(expect.objectContaining({ usePolling: true }));
-    const pollingWatcher = createdChokidarWatchers[chokidarCallsBefore];
+    const pollingWatcher = createdChokidarWatchers[callsBefore];
     expect(pollingWatcher).not.toBe(regularWatcher);
-
     await manager?.close();
-    expect(regularWatcher?.close).toHaveBeenCalledTimes(1);
-    expect(pollingWatcher?.close).toHaveBeenCalledTimes(1);
+    expect(regularWatcher?.close).toHaveBeenCalledOnce();
+    expect(pollingWatcher?.close).toHaveBeenCalledOnce();
   });
 
   it("treats null parent-watcher filename as an unknown event and re-checks the inode", async () => {
@@ -1113,58 +1065,45 @@ describe("memory watcher config", () => {
     expect(typeof recordedStats).toBe("boolean");
   });
 
-  it("migrates regular chokidar paths to polling after capacity exhaustion", async () => {
+  it("migrates regular chokidar paths to polling and awaits their close", async () => {
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-    const cfg = createWatcherConfig({ extraPaths: [] });
-
-    const activeManager = await expectWatcherManager(cfg);
-    vi.useFakeTimers();
-    const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
+    const activeManager = await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
     const regularWatcher = createdChokidarWatchers[0];
-    expect(regularWatcher).toBeDefined();
-    const regularPaths = watchMock.mock.calls[0]?.[0];
-
+    vi.useFakeTimers();
+    const sync = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
     regularWatcher?.emit(
       "error",
       Object.assign(new Error("watcher capacity exhausted"), { code: "EMFILE" }),
     );
-
-    const pollingCall = watchMock.mock.calls[1] as unknown as
-      | [string[], Record<string, unknown>]
-      | undefined;
-    expect(regularWatcher?.close).toHaveBeenCalledTimes(1);
-    expect(pollingCall?.[0]).toStrictEqual(regularPaths);
+    const pollingCall = watchCall(1);
+    expect(regularWatcher?.close).toHaveBeenCalledOnce();
+    expect(pollingCall?.[0]).toStrictEqual(watchCall(0)?.[0]);
     expect(pollingCall?.[1]).toEqual(expect.objectContaining({ usePolling: true }));
-
     createdChokidarWatchers[1]?.emit("ready");
     await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
-    expect(syncSpy).toHaveBeenCalledWith({ reason: "watch" });
-  });
+    expect(sync).toHaveBeenCalledWith({ reason: "watch" });
 
-  it("awaits a migrated regular watcher close during manager shutdown", async () => {
+    await manager?.close();
+    manager = null;
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-    const activeManager = await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
-    const regularWatcher = createdChokidarWatchers[0];
-    let releaseWatcherClose = () => {};
-    regularWatcher?.close.mockImplementationOnce(
-      async () =>
-        await new Promise<void>((resolve) => {
-          releaseWatcherClose = resolve;
+    const pendingManager = await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
+    const pendingWatcher = createdChokidarWatchers.at(-1);
+    let releaseClose = () => {};
+    pendingWatcher?.close.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseClose = resolve;
         }),
     );
-
-    regularWatcher?.emit(
+    pendingWatcher?.emit(
       "error",
       Object.assign(new Error("watcher capacity exhausted"), { code: "ENFILE" }),
     );
     let managerClosed = false;
-    const closePromise = activeManager.close().then(() => {
-      managerClosed = true;
-    });
+    const closePromise = pendingManager.close().then(() => (managerClosed = true));
     await Promise.resolve();
     expect(managerClosed).toBe(false);
-
-    releaseWatcherClose();
+    releaseClose();
     await closePromise;
     expect(managerClosed).toBe(true);
   });

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -8,6 +8,10 @@ import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  configureMemoryCoreDreamingStateForTests,
+  resetMemoryCoreDreamingStateForTests,
+} from "../test-helpers.js";
+import {
   createWatcherConfigFixture,
   restoreWatcherStateDir,
   setWatcherStateDir,
@@ -23,6 +27,7 @@ const {
   watchMock,
   nativeWatchMock,
   nativeWatchMockFailingDir,
+  nativeWatchMockFailureCode,
 } = vi.hoisted(() => {
   // Symbols are also declared at module top-level (CHOKIDAR_FACTORY_KEY,
   // NATIVE_FACTORY_KEY) but vi.hoisted runs before those declarations
@@ -97,6 +102,7 @@ const {
   const chokidarWatchers: Array<ReturnType<typeof createMockChokidarWatcher>> = [];
   const nativeWatchers: Array<ReturnType<typeof createMockNativeWatcher>> = [];
   const failingDir = { current: null as string | null };
+  const failureCode = { current: null as string | null };
 
   const result = {
     createdChokidarWatchers: chokidarWatchers,
@@ -110,7 +116,9 @@ const {
     nativeWatchMock: vi.fn(
       (dir: string, options: { recursive?: boolean }, listener: NativeCallback) => {
         if (failingDir.current && dir === failingDir.current) {
-          throw new Error("simulated native fs.watch creation failure");
+          throw Object.assign(new Error("simulated native fs.watch creation failure"), {
+            code: failureCode.current,
+          });
         }
         const watcher = createMockNativeWatcher(dir, options, listener);
         nativeWatchers.push(watcher);
@@ -118,6 +126,7 @@ const {
       },
     ),
     nativeWatchMockFailingDir: failingDir,
+    nativeWatchMockFailureCode: failureCode,
   };
   (globalThis as Record<PropertyKey, unknown>)[chokidarKey] = result.watchMock;
   (globalThis as Record<PropertyKey, unknown>)[nativeKey] = result.nativeWatchMock;
@@ -174,6 +183,7 @@ describe("memory watcher config", () => {
     vi.clearAllMocks();
     clearRegistry();
     nativeWatchMockFailingDir.current = null;
+    nativeWatchMockFailureCode.current = null;
   });
 
   afterAll(() => {
@@ -189,6 +199,7 @@ describe("memory watcher config", () => {
     createdChokidarWatchers.length = 0;
     createdNativeWatchers.length = 0;
     nativeWatchMockFailingDir.current = null;
+    nativeWatchMockFailureCode.current = null;
     if (manager) {
       await manager.close();
       manager = null;
@@ -200,6 +211,7 @@ describe("memory watcher config", () => {
     // shared handle is released second; otherwise Windows fails the removal with EBUSY.
     closeOpenClawAgentDatabasesForTest();
     resetPluginStateStoreForTests();
+    resetMemoryCoreDreamingStateForTests();
     if (workspaceDir) {
       await fs.rm(workspaceDir, { recursive: true, force: true });
       workspaceDir = "";
@@ -654,6 +666,27 @@ describe("memory watcher config", () => {
     ]);
   });
 
+  it("uses polling when Linux nested watcher setup exhausts capacity", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const nestedDir = path.join(workspaceDir, "memory", "topic");
+    await fs.mkdir(nestedDir);
+    nativeWatchMockFailingDir.current = nestedDir;
+    nativeWatchMockFailureCode.current = "ENOSPC";
+
+    await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
+
+    expect(watchMock).toHaveBeenCalledTimes(2);
+    expect(watchCall(0)?.[0]).toStrictEqual([path.join(workspaceDir, "memory")]);
+    expect(watchCall(1)?.[0]).toStrictEqual([
+      path.join(workspaceDir, "MEMORY.md"),
+      path.join(workspaceDir, "USER.md"),
+    ]);
+    expect([watchCall(0), watchCall(1)]).toSatisfy((calls) =>
+      calls.every((call) => call?.[1].usePolling === true),
+    );
+  });
+
   it("schedules startup sync when the Linux root disappears during its initial scan", async () => {
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
@@ -764,6 +797,52 @@ describe("memory watcher config", () => {
     await manager?.close();
     expect(regularWatcher?.close).toHaveBeenCalledOnce();
     expect(pollingWatcher?.close).toHaveBeenCalledOnce();
+  });
+
+  it("keeps polling catch-up dirty when a recovery sync is already in flight", async () => {
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    await configureMemoryCoreDreamingStateForTests();
+    const activeManager = await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
+    await activeManager.sync({ reason: "test-initial-index" });
+    const internals = activeManager as unknown as {
+      dirty: boolean;
+      syncing: Promise<void> | null;
+      syncMemoryFiles: (params: {
+        needsFullReindex: boolean;
+        progress?: unknown;
+      }) => Promise<unknown>;
+    };
+    internals.dirty = false;
+    const originalSyncMemoryFiles = internals.syncMemoryFiles.bind(activeManager);
+    let signalSyncStarted = () => {};
+    const syncStarted = new Promise<void>((resolve) => {
+      signalSyncStarted = resolve;
+    });
+    let releaseSync = () => {};
+    const syncRelease = new Promise<void>((resolve) => {
+      releaseSync = resolve;
+    });
+    vi.spyOn(internals, "syncMemoryFiles").mockImplementation(async (params) => {
+      signalSyncStarted();
+      await syncRelease;
+      return await originalSyncMemoryFiles(params);
+    });
+    vi.useFakeTimers();
+    const memoryDir = path.join(workspaceDir, "memory");
+    const memoryWatcher = createdNativeWatchers.find((watcher) => watcher.dir === memoryDir);
+
+    memoryWatcher?.emitError(
+      Object.assign(new Error("watcher capacity exhausted"), { code: "ENOSPC" }),
+    );
+    const firstRefresh = vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+    await syncStarted;
+    createdChokidarWatchers.at(-1)?.emit("ready");
+    await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+    releaseSync();
+    await firstRefresh;
+    await internals.syncing;
+
+    expect(internals.dirty).toBe(true);
   });
 
   it("treats null parent-watcher filename as an unknown event and re-checks the inode", async () => {

--- a/extensions/memory-core/src/memory/manager.watcher-filesystem.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-filesystem.test.ts
@@ -19,6 +19,161 @@ function activeFilesystemWatchers() {
 }
 
 describe("memory watchers on the real filesystem", () => {
+  it.each(["EMFILE", "ENFILE", "ENOSPC"] as const)(
+    "keeps search fresh through Chokidar polling after native watch reports %s",
+    async (code) => {
+      const state = await createOpenClawTestState({ label: "memory-watch-capacity" });
+      const memoryDir = path.join(state.workspaceDir, "memory");
+      await fs.mkdir(memoryDir);
+      await fs.writeFile(path.join(memoryDir, "before.md"), "Quartz sentinel.");
+      const originalWatch = nativeFs.watch;
+      const watchObserver = vi.spyOn(nativeFs, "watch").mockImplementation((...args) => {
+        if (path.resolve(String(args[0])) === memoryDir) {
+          throw Object.assign(new Error(`${code}: native watcher capacity exhausted`), { code });
+        }
+        return originalWatch(...args);
+      });
+      syncBuiltinESMExports();
+      let manager: MemoryIndexManager | null = null;
+      let index: DatabaseSync | undefined;
+      try {
+        await configureMemoryCoreDreamingStateForTests(state.env);
+        const cfg: OpenClawConfig = {
+          plugins: { enabled: false },
+          agents: { defaults: { workspace: state.workspaceDir }, list: [{ id: "main" }] },
+          memory: {
+            search: {
+              provider: "none",
+              sources: ["memory"],
+              store: { vector: { enabled: false } },
+              query: { minScore: 0 },
+            },
+          },
+        };
+        manager = await MemoryIndexManager.get({ cfg, agentId: "main" });
+        if (!manager) {
+          throw new Error("memory manager unavailable");
+        }
+        await manager.sync({ reason: "test-initial-index" });
+        const indexPath = manager.status().dbPath;
+        if (!indexPath) {
+          throw new Error("memory index path unavailable");
+        }
+        index = new DatabaseSync(indexPath, { readOnly: true });
+        const indexedRows = index.prepare(
+          `SELECT path, text FROM ${MEMORY_INDEX_CHUNKS_TABLE} ORDER BY path, start_line`,
+        );
+        expect(indexedRows.all()).toEqual([{ path: "memory/before.md", text: "Quartz sentinel." }]);
+
+        await fs.writeFile(path.join(memoryDir, "after.md"), "Topaz sentinel.");
+
+        await expect
+          .poll(() => indexedRows.all(), { timeout: 15_000 })
+          .toEqual([
+            { path: "memory/after.md", text: "Topaz sentinel." },
+            { path: "memory/before.md", text: "Quartz sentinel." },
+          ]);
+      } finally {
+        index?.close();
+        await manager?.close();
+        watchObserver.mockRestore();
+        syncBuiltinESMExports();
+        resetMemoryCoreDreamingStateForTests();
+        await state.cleanup();
+      }
+    },
+    60_000,
+  );
+
+  it("keeps search fresh when an active native watcher exhausts capacity", async () => {
+    const state = await createOpenClawTestState({ label: "memory-watch-runtime-capacity" });
+    const memoryDir = path.join(state.workspaceDir, "memory");
+    await fs.mkdir(memoryDir);
+    await fs.writeFile(path.join(memoryDir, "before.md"), "Quartz sentinel.");
+    const originalWatch = nativeFs.watch;
+    let memoryWatcher: nativeFs.FSWatcher | undefined;
+    const watchObserver = vi.spyOn(nativeFs, "watch").mockImplementation((...args) => {
+      const watcher = originalWatch(...args);
+      if (path.resolve(String(args[0])) === memoryDir) {
+        memoryWatcher = watcher;
+      }
+      return watcher;
+    });
+    syncBuiltinESMExports();
+    let manager: MemoryIndexManager | null = null;
+    let restoreSyncSpy: (() => void) | undefined;
+    let index: DatabaseSync | undefined;
+    try {
+      await configureMemoryCoreDreamingStateForTests(state.env);
+      const cfg: OpenClawConfig = {
+        plugins: { enabled: false },
+        agents: { defaults: { workspace: state.workspaceDir }, list: [{ id: "main" }] },
+        memory: {
+          search: {
+            provider: "none",
+            sources: ["memory"],
+            store: { vector: { enabled: false } },
+            query: { minScore: 0 },
+          },
+        },
+      };
+      manager = await MemoryIndexManager.get({ cfg, agentId: "main" });
+      if (!manager || !memoryWatcher) {
+        throw new Error("memory manager native watcher unavailable");
+      }
+      await manager.sync({ reason: "test-initial-index" });
+      const indexPath = manager.status().dbPath;
+      if (!indexPath) {
+        throw new Error("memory index path unavailable");
+      }
+      index = new DatabaseSync(indexPath, { readOnly: true });
+      const indexedRows = index.prepare(
+        `SELECT path, text FROM ${MEMORY_INDEX_CHUNKS_TABLE} ORDER BY path, start_line`,
+      );
+      expect(indexedRows.all()).toEqual([{ path: "memory/before.md", text: "Quartz sentinel." }]);
+
+      const originalSync = manager.sync.bind(manager);
+      let watchSyncCount = 0;
+      let resolveRecoverySync = () => {};
+      const recoverySyncCompleted = new Promise<void>((resolve) => {
+        resolveRecoverySync = resolve;
+      });
+      const syncMethodSpy = vi.spyOn(manager, "sync").mockImplementation(async (params) => {
+        await originalSync(params);
+        if (params?.reason === "watch" && ++watchSyncCount === 1) {
+          resolveRecoverySync();
+        }
+      });
+      restoreSyncSpy = () => syncMethodSpy.mockRestore();
+
+      memoryWatcher.emit(
+        "error",
+        Object.assign(new Error("ENOSPC: native watcher capacity exhausted"), {
+          code: "ENOSPC",
+        }),
+      );
+      await recoverySyncCompleted;
+      expect(indexedRows.all()).toEqual([{ path: "memory/before.md", text: "Quartz sentinel." }]);
+
+      await fs.writeFile(path.join(memoryDir, "after.md"), "Topaz sentinel.");
+
+      await expect
+        .poll(() => indexedRows.all(), { timeout: 15_000 })
+        .toEqual([
+          { path: "memory/after.md", text: "Topaz sentinel." },
+          { path: "memory/before.md", text: "Quartz sentinel." },
+        ]);
+    } finally {
+      restoreSyncSpy?.();
+      index?.close();
+      await manager?.close();
+      watchObserver.mockRestore();
+      syncBuiltinESMExports();
+      resetMemoryCoreDreamingStateForTests();
+      await state.cleanup();
+    }
+  }, 60_000);
+
   it.each(["replacement", "removal"] as const)(
     "keeps search fresh after root %s and releases watchers on close",
     async (operation) => {

--- a/extensions/memory-core/src/memory/manager.watcher-polling-regression.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-polling-regression.test.ts
@@ -1,0 +1,309 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  configureMemoryCoreDreamingStateForTests,
+  resetMemoryCoreDreamingStateForTests,
+} from "../test-helpers.js";
+import {
+  createWatcherConfigFixture,
+  restoreWatcherStateDir,
+  setWatcherStateDir,
+} from "./manager-watcher-config.test-support.js";
+
+const BUILT_IN_WATCH_DEBOUNCE_MS = 1_500;
+
+type WatchCall = [string[], Record<string, unknown>];
+type SyncMemoryFilesParams = {
+  needsFullReindex: boolean;
+  progress?: unknown;
+};
+type SyncInternals = {
+  dirty: boolean;
+  syncing: Promise<void> | null;
+  syncMemoryFiles: (params: SyncMemoryFilesParams) => Promise<unknown>;
+};
+
+const {
+  createdChokidarWatchers,
+  createdNativeWatchers,
+  memoryLoggerWarn,
+  watchMock,
+  nativeWatchMock,
+  nativeWatchMockFailingDir,
+  nativeWatchMockFailureCode,
+} = vi.hoisted(() => {
+  const chokidarKey = Symbol.for("openclaw.test.memoryWatchFactory");
+  const nativeKey = Symbol.for("openclaw.test.memoryNativeWatchFactory");
+  type ChokidarEvent = "add" | "change" | "unlink" | "unlinkDir" | "error" | "ready";
+  type ChokidarCallback = (...args: unknown[]) => void;
+  type NativeCallback = (eventType: string, filename: string | null) => void;
+  type NativeErrorCallback = (err: Error) => void;
+
+  function createMockChokidarWatcher() {
+    const handlers = new Map<ChokidarEvent, ChokidarCallback[]>();
+    const onceHandlers = new Map<ChokidarEvent, ChokidarCallback[]>();
+    const watcher = {
+      watchedEntries: {} as Record<string, string[]>,
+      on: vi.fn((event: ChokidarEvent, callback: ChokidarCallback) => {
+        handlers.set(event, [...(handlers.get(event) ?? []), callback]);
+        return watcher;
+      }),
+      once: vi.fn((event: ChokidarEvent, callback: ChokidarCallback) => {
+        onceHandlers.set(event, [...(onceHandlers.get(event) ?? []), callback]);
+        return watcher;
+      }),
+      add: vi.fn((_path: string | string[]) => watcher),
+      close: vi.fn(async (): Promise<void> => undefined),
+      getWatched: vi.fn(() => watcher.watchedEntries),
+      emit: (event: ChokidarEvent, ...args: unknown[]) => {
+        for (const callback of handlers.get(event) ?? []) {
+          callback(...args);
+        }
+        const callbacks = onceHandlers.get(event) ?? [];
+        onceHandlers.delete(event);
+        for (const callback of callbacks) {
+          callback(...args);
+        }
+      },
+    };
+    return watcher;
+  }
+
+  function createMockNativeWatcher(
+    dir: string,
+    options: { recursive?: boolean },
+    listener: NativeCallback,
+  ) {
+    const errorHandlers: NativeErrorCallback[] = [];
+    const watcher = {
+      dir,
+      options,
+      recursive: options.recursive === true,
+      listener,
+      on: vi.fn((event: "error", callback: NativeErrorCallback) => {
+        if (event === "error") {
+          errorHandlers.push(callback);
+        }
+        return watcher;
+      }),
+      close: vi.fn(() => undefined),
+      emitError: (err: Error) => {
+        for (const handler of errorHandlers) {
+          handler(err);
+        }
+      },
+    };
+    return watcher;
+  }
+
+  const chokidarWatchers: Array<ReturnType<typeof createMockChokidarWatcher>> = [];
+  const nativeWatchers: Array<ReturnType<typeof createMockNativeWatcher>> = [];
+  const failingDir = { current: null as string | null };
+  const failureCode = { current: null as string | null };
+  const result = {
+    createdChokidarWatchers: chokidarWatchers,
+    createdNativeWatchers: nativeWatchers,
+    memoryLoggerWarn: vi.fn(),
+    watchMock: vi.fn(() => {
+      const watcher = createMockChokidarWatcher();
+      chokidarWatchers.push(watcher);
+      return watcher;
+    }),
+    nativeWatchMock: vi.fn(
+      (dir: string, options: { recursive?: boolean }, listener: NativeCallback) => {
+        if (failingDir.current && dir === failingDir.current) {
+          throw Object.assign(new Error("simulated native fs.watch creation failure"), {
+            code: failureCode.current,
+          });
+        }
+        const watcher = createMockNativeWatcher(dir, options, listener);
+        nativeWatchers.push(watcher);
+        return watcher;
+      },
+    ),
+    nativeWatchMockFailingDir: failingDir,
+    nativeWatchMockFailureCode: failureCode,
+  };
+  (globalThis as Record<PropertyKey, unknown>)[chokidarKey] = result.watchMock;
+  (globalThis as Record<PropertyKey, unknown>)[nativeKey] = result.nativeWatchMock;
+  return result;
+});
+
+const CHOKIDAR_FACTORY_KEY = Symbol.for("openclaw.test.memoryWatchFactory");
+const NATIVE_FACTORY_KEY = Symbol.for("openclaw.test.memoryNativeWatchFactory");
+
+vi.mock("openclaw/plugin-sdk/memory-core-host-engine-foundation", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/memory-core-host-engine-foundation")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => ({
+      ...actual.createSubsystemLogger(subsystem),
+      warn: memoryLoggerWarn,
+    }),
+  };
+});
+
+vi.mock("./sqlite-vec.js", () => ({
+  loadSqliteVecExtension: async () => ({ ok: false, error: "sqlite-vec disabled in tests" }),
+}));
+
+vi.mock("./embeddings.js", () => ({
+  resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
+    providerId === "local" ? "local" : "remote",
+  resolveEmbeddingProviderIndexIdentity: () => undefined,
+  createEmbeddingProvider: async () => ({
+    requestedProvider: "openai",
+    provider: {
+      id: "mock",
+      model: "mock-embed",
+      embed: async () => [1, 0],
+      embedBatch: async (texts: string[]) => texts.map(() => [1, 0]),
+    },
+  }),
+}));
+
+import { clearEmbeddingProviders as clearRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
+import type { MemoryIndexManager } from "./manager.js";
+
+describe("memory watcher polling regressions", () => {
+  let manager: MemoryIndexManager | null = null;
+  let workspaceDir = "";
+  let extraDir = "";
+  let originalPlatform: NodeJS.Platform;
+
+  beforeEach(() => {
+    originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    vi.clearAllMocks();
+    clearRegistry();
+    nativeWatchMockFailingDir.current = null;
+    nativeWatchMockFailureCode.current = null;
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(globalThis, CHOKIDAR_FACTORY_KEY);
+    Reflect.deleteProperty(globalThis, NATIVE_FACTORY_KEY);
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    watchMock.mockClear();
+    nativeWatchMock.mockClear();
+    createdChokidarWatchers.length = 0;
+    createdNativeWatchers.length = 0;
+    nativeWatchMockFailingDir.current = null;
+    nativeWatchMockFailureCode.current = null;
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await closeAllMemorySearchManagers();
+    clearRegistry();
+    restoreWatcherStateDir();
+    closeOpenClawAgentDatabasesForTest();
+    resetPluginStateStoreForTests();
+    resetMemoryCoreDreamingStateForTests();
+    if (workspaceDir) {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+      workspaceDir = "";
+      extraDir = "";
+    }
+  });
+
+  async function setupWatcherWorkspace(): Promise<void> {
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-watch-polling-"));
+    setWatcherStateDir(path.join(workspaceDir, "state"));
+    extraDir = path.join(workspaceDir, "extra");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.mkdir(extraDir, { recursive: true });
+    await fs.writeFile(path.join(extraDir, "notes.md"), "hello");
+  }
+
+  function createWatcherConfig(): OpenClawConfig {
+    return createWatcherConfigFixture(workspaceDir, extraDir, { extraPaths: [] });
+  }
+
+  function watchCall(index: number): WatchCall | undefined {
+    return (watchMock.mock.calls as unknown as WatchCall[])[index];
+  }
+
+  async function expectWatcherManager(): Promise<MemoryIndexManager> {
+    const result = await getMemorySearchManager({ cfg: createWatcherConfig(), agentId: "main" });
+    if (!result.manager) {
+      throw new Error("manager missing");
+    }
+    manager = result.manager as unknown as MemoryIndexManager;
+    return manager;
+  }
+
+  it("uses polling when Linux nested watcher setup exhausts capacity", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupWatcherWorkspace();
+    const nestedDir = path.join(workspaceDir, "memory", "topic");
+    await fs.mkdir(nestedDir);
+    nativeWatchMockFailingDir.current = nestedDir;
+    nativeWatchMockFailureCode.current = "ENOSPC";
+
+    await expectWatcherManager();
+
+    expect(watchMock).toHaveBeenCalledTimes(2);
+    expect(watchCall(0)?.[0]).toStrictEqual([path.join(workspaceDir, "memory")]);
+    expect(watchCall(1)?.[0]).toStrictEqual([
+      path.join(workspaceDir, "MEMORY.md"),
+      path.join(workspaceDir, "USER.md"),
+    ]);
+    const calls: Array<WatchCall | undefined> = [watchCall(0), watchCall(1)];
+    expect(calls).toSatisfy((entries: Array<WatchCall | undefined>) =>
+      entries.every((call: WatchCall | undefined) => call?.[1].usePolling === true),
+    );
+  });
+
+  it("keeps polling catch-up dirty when a recovery sync is already in flight", async () => {
+    await setupWatcherWorkspace();
+    await configureMemoryCoreDreamingStateForTests();
+    const activeManager = await expectWatcherManager();
+    await activeManager.sync({ reason: "test-initial-index" });
+    const internals = activeManager as unknown as SyncInternals;
+    internals.dirty = false;
+    const originalSyncMemoryFiles = internals.syncMemoryFiles.bind(activeManager);
+    let signalSyncStarted: () => void = () => {};
+    const syncStarted = new Promise<void>((resolve: () => void) => {
+      signalSyncStarted = resolve;
+    });
+    let releaseSync: () => void = () => {};
+    const syncRelease = new Promise<void>((resolve: () => void) => {
+      releaseSync = resolve;
+    });
+    vi.spyOn(internals, "syncMemoryFiles").mockImplementation(
+      async (params: SyncMemoryFilesParams) => {
+        signalSyncStarted();
+        await syncRelease;
+        return await originalSyncMemoryFiles(params);
+      },
+    );
+    vi.useFakeTimers();
+    const memoryDir = path.join(workspaceDir, "memory");
+    const memoryWatcher = createdNativeWatchers.find((watcher) => watcher.dir === memoryDir);
+
+    memoryWatcher?.emitError(
+      Object.assign(new Error("watcher capacity exhausted"), { code: "ENOSPC" }),
+    );
+    const firstRefresh = vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+    await syncStarted;
+    createdChokidarWatchers.at(-1)?.emit("ready");
+    await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+    releaseSync();
+    await firstRefresh;
+    await internals.syncing;
+
+    expect(internals.dirty).toBe(true);
+  });
+});

--- a/extensions/memory-core/src/memory/watch-factories.test.ts
+++ b/extensions/memory-core/src/memory/watch-factories.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveMemoryWatchFactory } from "./watch-factories.js";
+
+const originalPollingEnv = process.env.CHOKIDAR_USEPOLLING;
+
+afterEach(() => {
+  if (originalPollingEnv === undefined) {
+    delete process.env.CHOKIDAR_USEPOLLING;
+  } else {
+    process.env.CHOKIDAR_USEPOLLING = originalPollingEnv;
+  }
+});
+
+describe("memory watcher factories", () => {
+  it("forces polling for capacity recovery when the environment disables it", async () => {
+    process.env.CHOKIDAR_USEPOLLING = "0";
+
+    const watcher = resolveMemoryWatchFactory(true)([], { ignoreInitial: true });
+
+    try {
+      expect(watcher.options.usePolling).toBe(true);
+      expect(process.env.CHOKIDAR_USEPOLLING).toBe("0");
+    } finally {
+      await watcher.close();
+    }
+  });
+});

--- a/extensions/memory-core/src/memory/watch-factories.ts
+++ b/extensions/memory-core/src/memory/watch-factories.ts
@@ -1,0 +1,58 @@
+import fsSync from "node:fs";
+import chokidar, { type FSWatcher } from "chokidar";
+
+const TEST_MEMORY_WATCH_FACTORY_KEY = Symbol.for("openclaw.test.memoryWatchFactory");
+const TEST_MEMORY_NATIVE_WATCH_FACTORY_KEY = Symbol.for("openclaw.test.memoryNativeWatchFactory");
+
+export function isWatchCapacityError(err: unknown): boolean {
+  if (err === null || typeof err !== "object" || !("code" in err)) {
+    return false;
+  }
+  return err.code === "EMFILE" || err.code === "ENFILE" || err.code === "ENOSPC";
+}
+
+export function resolveMemoryWatchFactory(forcePolling = false): typeof chokidar.watch {
+  if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") {
+    // SAFETY: test overrides are stored under this process-global symbol by the memory test harness.
+    const override = (globalThis as Record<PropertyKey, unknown>)[TEST_MEMORY_WATCH_FACTORY_KEY];
+    if (typeof override === "function") {
+      // SAFETY: the runtime function check narrows the test override to the watcher factory contract.
+      return override as typeof chokidar.watch;
+    }
+  }
+  if (!forcePolling) {
+    return chokidar.watch.bind(chokidar);
+  }
+  return (paths, options = {}) => {
+    // Chokidar applies CHOKIDAR_USEPOLLING after constructor options. Capacity
+    // recovery must win even when the environment globally disables polling.
+    const pollingEnv = process.env.CHOKIDAR_USEPOLLING;
+    let watcher: FSWatcher;
+    try {
+      delete process.env.CHOKIDAR_USEPOLLING;
+      watcher = new chokidar.FSWatcher({ ...options, usePolling: true });
+    } finally {
+      if (pollingEnv === undefined) {
+        delete process.env.CHOKIDAR_USEPOLLING;
+      } else {
+        process.env.CHOKIDAR_USEPOLLING = pollingEnv;
+      }
+    }
+    watcher.add(paths);
+    return watcher;
+  };
+}
+
+export function resolveMemoryNativeWatchFactory(): typeof fsSync.watch {
+  if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") {
+    // SAFETY: test overrides are stored under this process-global symbol by the memory test harness.
+    const override = (globalThis as Record<PropertyKey, unknown>)[
+      TEST_MEMORY_NATIVE_WATCH_FACTORY_KEY
+    ];
+    if (typeof override === "function") {
+      // SAFETY: the runtime function check narrows the test override to the native watcher contract.
+      return override as typeof fsSync.watch;
+    }
+  }
+  return fsSync.watch.bind(fsSync);
+}

--- a/extensions/memory-core/src/memory/watch-path-ignore.ts
+++ b/extensions/memory-core/src/memory/watch-path-ignore.ts
@@ -1,0 +1,42 @@
+import path from "node:path";
+import { classifyMemoryMultimodalPath } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import type { ResolvedMemorySearchConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
+  ".git",
+  "node_modules",
+  ".pnpm-store",
+  ".venv",
+  "venv",
+  ".tox",
+  "__pycache__",
+]);
+
+export function shouldIgnoreMemoryWatchPath(
+  watchPath: string,
+  stats?: { isDirectory?: () => boolean },
+  multimodalSettings?: ResolvedMemorySearchConfig["multimodal"],
+): boolean {
+  const normalized = path.normalize(watchPath);
+  const parts = normalized
+    .split(path.sep)
+    .map((segment) => normalizeLowercaseStringOrEmpty(segment));
+  if (parts.some((segment) => IGNORED_MEMORY_WATCH_DIR_NAMES.has(segment))) {
+    return true;
+  }
+  if (stats?.isDirectory?.()) {
+    return false;
+  }
+  if (!stats) {
+    return false;
+  }
+  const extension = normalizeLowercaseStringOrEmpty(path.extname(normalized));
+  if (extension.length === 0 || extension === ".md") {
+    return false;
+  }
+  if (!multimodalSettings) {
+    return true;
+  }
+  return classifyMemoryMultimodalPath(normalized, multimodalSettings) === null;
+}


### PR DESCRIPTION
Fixes #136966

## What Problem This Solves

When native directory watching fails with `EMFILE`, `ENFILE`, or `ENOSPC`, falling back to Chokidar's default backend can consume the same exhausted `fs.watch` capacity. The manager can then emit repeated warnings without restoring watch coverage, leaving later memory-file changes out of the index.

## Why This Change Was Made

Capacity exhaustion needs a different backend, not another registration attempt against the same resource. The pinned Chokidar 5.0.0 implementation selects `fs.watchFile` when `usePolling: true`, so the recovery path now creates a separate polling watcher while keeping ordinary failures on the existing Chokidar path.

The final design:

- classifies `EMFILE`, `ENFILE`, and `ENOSPC` at the watcher boundary;
- creates a dedicated polling watcher after startup or runtime native-watch capacity failures, including nested-directory and root-reattachment paths;
- migrates every registered regular-Chokidar path to polling if that watcher itself later reports a capacity error;
- marks the index dirty when a polling watcher becomes ready, closing the asynchronous initial-crawl gap with a catch-up sync;
- makes explicit polling win even when `CHOKIDAR_USEPOLLING=0` or `false`, then restores the original environment value;
- tracks regular, polling, and migration-in-progress close promises so manager shutdown does not return before watcher resources are released.

This replaces the earlier permanent-dirty/search-refresh/timer fallback with the dependency's existing polling backend. No configuration, schema, migration, or persisted-state change is introduced.

## User Impact

Memory files continue to be indexed after native watcher capacity is exhausted. Ordinary watcher failures keep their existing behavior, while capacity failures avoid repeated native-watch fan-out and retain automatic refresh through polling.

## Evidence

- Focused watcher proof: **3 files / 85 tests passed**.
- Real-filesystem integration stubs only native `fs.watch`; it uses the real pinned Chokidar client, real `MemoryIndexManager`, SQLite/FTS, and automatic watch sync.
- Initial `EMFILE`, `ENFILE`, and `ENOSPC` cases each create a file after degradation and observe it in search through polling.
- Runtime native-capacity coverage waits for the first broad recovery sync to finish, then writes another file; that later file reaches SQLite only through the polling watcher.
- Additional regressions cover regular-Chokidar-to-polling migration, polling `ready` catch-up, root replacement/removal, environment override restoration, and manager shutdown waiting for an in-flight watcher close.
- The complete `memory-core` run exercised the watcher regressions successfully; one unrelated concurrent metadata test failed in the broad run and passed immediately in isolation.
- `git diff --check`, targeted format/lint, conflict-marker, max-lines, assertion-safety, dependency-pin, doctor-contract, and plugin-boundary gates passed.
- Independent P0-P2 autoreview of exact head `2c297db52b` was scoped-clean (confidence 0.93).
- Extension typecheck reports only current-main diagnostics outside this change: missing `yargs-parser` declarations under `extensions/browser` and the existing `assertBeforeRename` option-type drift in `src/infra/install-package-dir.ts`.

## Dependency Contract

The pinned Chokidar 5.0.0 source was inspected directly:

- `usePolling: true` selects the polling backend;
- `CHOKIDAR_USEPOLLING` is applied during construction and can override caller options;
- constructed watcher options are read-only;
- adding paths to an existing watcher does not change its backend.

Those constraints are why recovery constructs a separate polling instance and temporarily isolates the environment override during construction.

## Proof Gap

The capacity error is injected at the native `fs.watch` boundary; this is not a live Linux host with globally exhausted inotify resources. The downstream path is real (Chokidar polling, filesystem writes, manager sync, SQLite/FTS, and search), but a genuine kernel-exhaustion capture remains unavailable from this host.
