### PR TITLE
improve: reuse plugin activation preparation per operation

### DIFF
--- a/src/commands/models/list.auth-index.test.ts
+++ b/src/commands/models/list.auth-index.test.ts
@@ -287,15 +287,10 @@ describe("createModelListAuthIndex", () => {
   );
 
   it("uses explicit synthetic refs without loading plugin metadata", () => {
-    const metadataSnapshot = {
-      registrySource: "persisted",
-      plugins: [],
-    } as unknown as PluginMetadataSnapshot;
     const index = createTestModelListAuthIndex({
       cfg: {},
       authStore: emptyStore,
       env: {},
-      metadataSnapshot,
       syntheticAuthProviderRefs: ["codex"],
       routeResolverFactory: dualRouteResolverFactory,
     });

--- a/src/plugins/installed-plugin-index.ts
+++ b/src/plugins/installed-plugin-index.ts
@@ -3,7 +3,12 @@ import type { OpenClawConfig } from "../config/types.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
 import { isBundledProviderCompatPlugin } from "./bundled-provider-compat.js";
-import { normalizePluginsConfig, resolveEffectivePluginActivationState } from "./config-state.js";
+import {
+  createPluginActivationSource,
+  normalizePluginsConfig,
+  resolveEffectivePluginActivationState,
+  type PluginActivationConfigSource,
+} from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import { discoverOpenClawPlugins, type PluginDiscoveryResult } from "./discovery.js";
 import { normalizeInstallRecordMap } from "./installed-plugin-index-install-records.js";
@@ -173,34 +178,60 @@ export function isInstalledPluginEnabled(
   env?: NodeJS.ProcessEnv,
 ): boolean {
   const record = getInstalledPluginRecord(index, pluginId);
-  if (!record) {
-    return false;
+  if (!record || !config) {
+    return record?.enabled ?? false;
   }
-  if (!config) {
-    return record.enabled;
-  }
-  const activationConfig = withBundledPluginEnablementCompat({
-    config,
-    env,
-    pluginIds: isBundledProviderCompatPlugin({
-      origin: record.origin,
-      providers: record.contributions?.providers,
-      contracts: record.contributions?.contracts,
-    })
-      ? [record.pluginId]
-      : [],
-    activation: "defaults",
-  });
-  const normalizedConfig = normalizePluginsConfig(activationConfig?.plugins);
-  const state = resolveEffectivePluginActivationState({
-    id: record.pluginId,
+  return createInstalledPluginEnabledPredicate([record], config, env)(pluginId);
+}
+
+function isInstalledBundledProvider(record: InstalledPluginIndexRecord): boolean {
+  return isBundledProviderCompatPlugin({
     origin: record.origin,
-    channelIds: record.contributions?.channels,
-    config: normalizedConfig,
-    rootConfig: activationConfig,
-    enabledByDefault: isPluginEnabledByDefaultForPlatform(record),
+    providers: record.contributions?.providers,
+    contracts: record.contributions?.contracts,
   });
-  // The index records startup policy; current activation is evaluated against
-  // the same package facts without making the startup enablement sticky.
-  return state.enabled;
+}
+
+/** Prepare live policy for one synchronous operation, never across config/root changes. */
+export function createInstalledPluginEnabledPredicate(
+  plugins: readonly InstalledPluginIndexRecord[],
+  config?: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): (pluginId: string) => boolean {
+  let source: PluginActivationConfigSource | undefined;
+  let bundledSource: PluginActivationConfigSource | undefined;
+  return (pluginId) => {
+    const record = plugins.find((plugin) => plugin.pluginId === pluginId);
+    if (!record || !config) {
+      return record?.enabled ?? false;
+    }
+    let activationSource: PluginActivationConfigSource;
+    if (isInstalledBundledProvider(record)) {
+      if (!bundledSource) {
+        const bundledConfig = withBundledPluginEnablementCompat({
+          config,
+          env,
+          pluginIds: plugins.filter(isInstalledBundledProvider).map((entry) => entry.pluginId),
+          activation: "defaults",
+        });
+        // Provider compat may extend an allowlist; non-provider owners must retain the original.
+        bundledSource =
+          bundledConfig === config
+            ? (source ??= createPluginActivationSource({ config }))
+            : createPluginActivationSource({ config: bundledConfig });
+      }
+      activationSource = bundledSource;
+    } else {
+      activationSource = source ??= createPluginActivationSource({ config });
+    }
+    return resolveEffectivePluginActivationState({
+      id: record.pluginId,
+      origin: record.origin,
+      channelIds: record.contributions?.channels,
+      config: activationSource.plugins,
+      rootConfig: activationSource.rootConfig,
+      activationSource,
+      enabledByDefault: isPluginEnabledByDefaultForPlatform(record),
+    }).enabled;
+  };
 }

--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -5,7 +5,7 @@ import {
   normalizePluginsConfigWithResolverCore,
   type NormalizedPluginsConfig,
 } from "./config-normalization-shared.js";
-import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
+import { createInstalledPluginEnabledPredicate } from "./installed-plugin-index.js";
 import { loadPluginManifestRegistryForInstalledIndex } from "./manifest-registry-installed.js";
 import type {
   BundledChannelConfigCollector,
@@ -172,22 +172,6 @@ function listManifestContributionIds(
   return [];
 }
 
-function resolveContributionPluginIds(params: {
-  index: PluginRegistrySnapshot;
-  includeDisabled?: boolean;
-  config?: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-}): readonly string[] {
-  if (params.includeDisabled) {
-    return params.index.plugins.map((plugin) => plugin.pluginId);
-  }
-  return params.index.plugins
-    .filter((plugin) =>
-      isInstalledPluginEnabled(params.index, plugin.pluginId, params.config, params.env),
-    )
-    .map((plugin) => plugin.pluginId);
-}
-
 function createContributionPluginFilter(
   params: PluginRegistryContributionOptions,
   index: PluginRegistrySnapshot,
@@ -197,7 +181,7 @@ function createContributionPluginFilter(
     const installedPluginIds = new Set(index.plugins.map((plugin) => plugin.pluginId));
     return (pluginId) => installedPluginIds.has(pluginId);
   }
-  return (pluginId) => isInstalledPluginEnabled(index, pluginId, params.config, params.env);
+  return createInstalledPluginEnabledPredicate(index.plugins, params.config, params.env);
 }
 
 function loadContributionManifestRegistry(
@@ -206,17 +190,17 @@ function loadContributionManifestRegistry(
     includeDisabled?: boolean;
   },
 ): PluginManifestRegistry {
+  const pluginIds = params.index.plugins.map((plugin) => plugin.pluginId);
   return loadPluginManifestRegistryForInstalledIndex({
     index: params.index,
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
-    pluginIds: resolveContributionPluginIds({
-      index: params.index,
-      includeDisabled: params.includeDisabled,
-      config: params.config,
-      env: params.env,
-    }),
+    pluginIds: params.includeDisabled
+      ? pluginIds
+      : pluginIds.filter(
+          createInstalledPluginEnabledPredicate(params.index.plugins, params.config, params.env),
+        ),
     includeDisabled: true,
   });
 }

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sanitizeEnvVars } from "../agents/sandbox/sanitize-env-vars.js";
-import * as installedPluginIndex from "../plugins/installed-plugin-index.js";
+import * as pluginConfigState from "../plugins/config-state.js";
 import { resolveLocalProviderAuthEvidence } from "./provider-auth-evidence.js";
 import {
   getProviderEnvVars,
@@ -802,13 +802,13 @@ describe("provider env vars dynamic manifest metadata", () => {
       },
     );
 
-    const policy = vi.spyOn(installedPluginIndex, "isInstalledPluginEnabled");
+    const policy = vi.spyOn(pluginConfigState, "resolveEffectivePluginActivationState");
     let lookupMaps: ReturnType<typeof resolveProviderAuthLookupMaps>;
     try {
       lookupMaps = resolveProviderAuthLookupMaps({ config: {} });
       expect(policy.mock.calls.length).toBeLessThanOrEqual(2);
-      expect(policy.mock.calls.map(([, pluginId]) => pluginId)).not.toContain("channel-only");
-      expect(policy.mock.calls.map(([, pluginId]) => pluginId)).not.toContain("metadata-only");
+      expect(policy.mock.calls.map(([{ id }]) => id)).not.toContain("channel-only");
+      expect(policy.mock.calls.map(([{ id }]) => id)).not.toContain("metadata-only");
     } finally {
       policy.mockRestore();
     }

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -5,7 +5,7 @@ import { resolveProviderAuthAliasMap } from "../agents/provider-auth-aliases.js"
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
-import { isInstalledPluginEnabled } from "../plugins/installed-plugin-index.js";
+import { createInstalledPluginEnabledPredicate } from "../plugins/installed-plugin-index.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import {
   isWorkspacePluginAllowedByConfig,
@@ -227,6 +227,7 @@ function resolveManifestRuntimeAuthFacts(
 ) {
   const evidenceByProvider: Record<string, ProviderAuthEvidence[]> = {};
   const refs = new Set<string>();
+  const isEnabled = createInstalledPluginEnabledPredicate(snapshot.index.plugins, params?.config);
   for (const plugin of snapshot.plugins) {
     const evidenceProviders = (plugin.setup?.providers ?? []).filter(
       (provider) => provider.authEvidence?.length,
@@ -240,10 +241,7 @@ function resolveManifestRuntimeAuthFacts(
     }
     // Package contributions are fixed, but their eligibility follows current config.
     // Evaluate each contributing owner once without narrowing credential-scrubbing hints.
-    if (
-      snapshot.index.plugins.length > 0 &&
-      !isInstalledPluginEnabled(snapshot.index, plugin.id, params?.config)
-    ) {
+    if (snapshot.index.plugins.length > 0 && !isEnabled(plugin.id)) {
       continue;
     }
     if (shouldUsePluginProviderAuthEvidence(plugin, params)) {


### PR DESCRIPTION
## What Problem This Solves

Provider-auth and plugin-contribution lookups repeatedly prepared the same activation policy for each installed owner during one synchronous operation.

## Why This Change Was Made

The installed-index owner now prepares at most two lazy activation sources per operation: original policy and bundled-provider compatibility policy. Keeping them separate preserves non-provider eligibility when compatibility expands an allowlist. Batch callers reuse those prepared facts, and the contribution loader's old one-use wrapper disappears. Singleton callers use the same evaluator with only their selected record.

## User Impact

Eligibility, trust, root selection, current configuration and disabled-owner inspection stay unchanged. There is no new cache, option or persistence surface. Production +13 LOC creates the operation-owned preparation boundary; the existing test change is net zero. Singleton calls add a small one-record array/closure; the measured benefit below applies to batch callers.

## Evidence

- All 39 fixed actual-source observations match across configuration, allowlist, bundled mode, root A/B/A, invalidation, contribution and provider-auth cases.
- Across 40 composed operations, canonical normalizations fell from 3,960 to 280 and compatibility memo reads from 2,440 to 160. Separate sampled allocation estimates fell from 33,932,680 to 15,792,240 bytes; these are not retained heap or Gateway RSS.
- 94 existing tests across seven files pass, as does the canonical changed-file gate. Managed Codex review through P2 is clean.
- Real Gateway verification with MCP and session features passed on a composite containing this exact patch; details below.


## Real Gateway integration (2026-09-03)

A prebuilt, isolated Gateway with a real OpenAI API key passed four fixed turns: ordinary completion, real `web_fetch` of example.com, a 1.31 MB Unicode return through Code Mode, and a real MCP stdio tool with default and explicit arguments. Fifty-seven Gateway RPCs verified three session identities, full/repeated/paginated/subscribed list rows, descriptions and final previews, transcript completion, an explicit reconnect, empty approval replay and unsubscribe.

The MCP server observed the default `id: alpha` before server-side validation, followed by explicit `id: beta`; both nested call identities/order, structured results and metadata projection matched. The Unicode prefix remained well formed and within its byte budget with exact omitted-byte accounting. All four turns completed without retries.

The local immutable composite `3bb6e3164a06e5c35fb50b368cc63cbb05826384` contains the twelve published campaign changes through #137148, including this PR’s reviewed source. Source/build/dependency identity was checked before and after. Both clients closed, the Gateway exited successfully without escalation, all recorded MCP processes exited, and private state/port cleanup passed. This is functional integration proof; it does not attribute memory or latency differences to this PR.

## CI follow-up

The model-list auth-index test had a partial local snapshot without its required installed index. It now reuses the shared empty fixture that supplies the installed index and diagnostics. The explicit synthetic references and evidence assertion are unchanged. The original test failed at the missing index; all 43 model-list/provider-env tests now pass, and independent Codex review through P2 is clean. Production code is unchanged by this follow-up; five duplicate test lines are removed. The branch also includes the upstream main lint repair #137149.
