### PR TITLE
improve: avoid discarded schema hints in Code Mode namespaces

### DIFF
--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -506,11 +506,12 @@ export class ToolSearchRuntime {
     );
 
   namespaceEntries = () =>
-    resolveCatalog(this.ctx).entries.map((entry) =>
-      Object.assign(compactToolSearchCatalogEntry(entry), {
-        ...(entry.mcp ? { mcp: entry.mcp } : {}),
-        parameters: entry.parameters ?? {},
-      }),
+    // Snapshot host metadata without rendering hints or retaining the executable tool.
+    resolveCatalog(this.ctx).entries.map(
+      ({ tool: _tool, outputSchema: _outputSchema, ...entry }) => {
+        entry.parameters ??= {};
+        return entry;
+      },
     );
 
   describe = async (id: string, options?: CatalogVisibilityOptions & UnknownToolErrorOptions) => {


### PR DESCRIPTION
## What Problem This Solves

Code Mode namespace preparation rendered model-facing schema hints and immediately discarded them while building host metadata.

## Why This Change Was Made

The internal namespace projection now snapshots the catalog's routing and schema metadata directly, omitting the executable tool and unused output schema. Fresh row bindings, shared parameter/MCP references and nullish parameter defaults are preserved. The model-facing catalog formatter and live dispatch checks retain their existing owners.

## User Impact

MCP API declarations, defaults, dispatch, headless namespaces and catalog closure behavior remain unchanged while repeated hint construction disappears. Production +1 LOC keeps the ownership comment and explicit omissions readable; tests/support do not grow. No public option, plugin SDK or cache is added.

## Evidence

- Twelve exact caller-visible observations and the generic catalog match across actual namespace/headless/bridge owners, including naming collisions, hostile client schema proxies, shared-schema mutation, restrictions and closure.
- Precise coverage observes 210 to 1 compact catalog projections, 194 to 0 input hints, 194 to 0 output hints and 6,402 to 0 compact schema visits. The remaining projection belongs to the accepted call result.
- 49 selected existing tests across five files and the canonical changed-file gate pass. Managed Codex review through P2 is clean.
- A single process pair had differing host load; no general speed or RSS reduction is claimed. Real Gateway verification with an actual MCP server passed; details below.


## Real Gateway integration (2026-09-03)

A prebuilt, isolated Gateway with a real OpenAI API key passed four fixed turns: ordinary completion, real `web_fetch` of example.com, a 1.31 MB Unicode return through Code Mode, and a real MCP stdio tool with default and explicit arguments. Fifty-seven Gateway RPCs verified three session identities, full/repeated/paginated/subscribed list rows, descriptions and final previews, transcript completion, an explicit reconnect, empty approval replay and unsubscribe.

The MCP server observed the default `id: alpha` before server-side validation, followed by explicit `id: beta`; both nested call identities/order, structured results and metadata projection matched. The Unicode prefix remained well formed and within its byte budget with exact omitted-byte accounting. All four turns completed without retries.

The local immutable composite `3bb6e3164a06e5c35fb50b368cc63cbb05826384` contains the twelve published campaign changes through #137148, including this PR’s reviewed source. Source/build/dependency identity was checked before and after. Both clients closed, the Gateway exited successfully without escalation, all recorded MCP processes exited, and private state/port cleanup passed. This is functional integration proof; it does not attribute memory or latency differences to this PR.
