### PR TITLE
feat(catalog): hydrate published models from models.dev

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -313,6 +313,18 @@ build stamp is ignored.
 
 The hosted file is published from the public
 [`openclaw/catalog`](https://github.com/openclaw/catalog) GitHub repository.
+At publish time, it also hydrates model ids and metadata from models.dev for
+providers whose owning plugin explicitly opts in with
+[`modelCatalog.modelsDev`](/plugins/manifest#modelcatalog-reference). Each mapping
+names the upstream provider once, rather than mapping individual models; there
+is no central provider fallback. Manifest values remain authoritative, so
+hydration only fills undefined metadata and never supplies transport settings
+or prices; costs still come from each provider's pricing policy. Only rows with
+tool calling and text output are imported, and rows models.dev marks deprecated
+or retired are skipped. Hydration errors fail publication and preserve the last
+published artifact instead of publishing an incomplete replacement. This is a
+publication-time contract: it adds no Gateway fetches or hot reload, and updated
+metadata still becomes visible after a Gateway restart.
 Its scheduled workflow checks OpenClaw's default-branch plugin manifests and
 public pricing sources every four hours; every catalog content change is
 preserved as a public commit. Provider-owned policies select complete price

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1070,12 +1070,15 @@ Fields:
 
 ## modelCatalog reference
 
-Use `modelCatalog` when OpenClaw should know provider model metadata before loading plugin runtime. This is the manifest-owned source for fixed catalog rows, provider aliases, suppression rules, and discovery mode. Runtime refresh still belongs in provider runtime code, but the manifest tells core when runtime is required.
+Use `modelCatalog` when OpenClaw should know provider model metadata before loading plugin runtime. This is the manifest-owned source for fixed catalog rows, publication-time metadata sources, provider aliases, suppression rules, and discovery mode. Runtime refresh still belongs in provider runtime code, but the manifest tells core when runtime is required.
 
 ```json
 {
   "providers": ["openai"],
   "modelCatalog": {
+    "modelsDev": {
+      "openai": "openai"
+    },
     "providers": {
       "openai": {
         "baseUrl": "https://api.openai.com/v1",
@@ -1123,11 +1126,18 @@ Top-level fields:
 
 | Field            | Type                                                     | What it means                                                                                               |
 | ---------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `modelsDev`      | `Record<string, string>`                                 | Publication-time opt-in mapping from an owned OpenClaw provider id to a models.dev provider id.             |
 | `providers`      | `Record<string, object>`                                 | Catalog rows for provider ids owned by this plugin. Keys should also appear in top-level `providers`.       |
 | `aliases`        | `Record<string, object>`                                 | Provider aliases that should resolve to an owned provider for catalog or suppression planning.              |
 | `suppressions`   | `object[]`                                               | Model rows from another source that this plugin suppresses for a provider-specific reason.                  |
 | `discovery`      | `Record<string, "static" \| "refreshable" \| "runtime">` | Whether the provider catalog can be read from manifest metadata, refreshed into cache, or requires runtime. |
 | `runtimeAugment` | `boolean`                                                | Set to `true` only when the provider runtime must append catalog rows after manifest/config planning.       |
+
+`modelsDev` opts an owned provider into models.dev metadata hydration when the hosted catalog is published. Declare the upstream provider once per OpenClaw provider, not once per model. Omission means no models.dev hydration; there is no central provider fallback. Keys are normalized as OpenClaw provider ids and source ids are trimmed. Empty or non-string source ids and mappings for unowned providers are ignored; an alias alone does not grant ownership. A mapping does not create catalog provider rows or relax their validation.
+
+Hydration adds eligible model ids and fills only undefined metadata. Explicit manifest values remain authoritative, including `false`; models.dev never supplies transport settings or prices. Prices still follow the provider-owned pricing policy. Opt in only when the provider defaults are appropriate for newly imported rows; providers that choose a transport per model should not opt in unless those defaults are safe. Hydration errors fail publication, leaving the last published artifact intact. The publisher hydrates opted-in metadata even without `--pricing`; that flag controls price enrichment only. A dry run performs the same metadata hydration without writing the artifact.
+
+This field is publication-time authoring metadata, not a Gateway discovery hook. It does not add runtime network calls or hot reload; the existing [hosted catalog update lifecycle](/concepts/models#hosted-catalog-updates) is unchanged.
 
 `aliases` participates in provider ownership lookup for model-catalog planning. Alias targets must be top-level providers owned by the same plugin. When a provider-filtered list uses an alias, OpenClaw can read the owning manifest and apply alias API/base URL overrides without loading provider runtime. Aliases do not expand unfiltered catalog listings; broad lists emit the owning canonical provider rows only.
 

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -23,6 +23,9 @@
   },
   "providerCatalogEntry": "./provider-discovery.ts",
   "modelCatalog": {
+    "modelsDev": {
+      "anthropic": "anthropic"
+    },
     "providers": {
       "claude-cli": {
         "models": [

--- a/extensions/baseten/openclaw.plugin.json
+++ b/extensions/baseten/openclaw.plugin.json
@@ -20,6 +20,9 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "baseten": "baseten"
+    },
     "providers": {
       "baseten": {
         "baseUrl": "https://inference.baseten.co/v1",

--- a/extensions/cerebras/openclaw.plugin.json
+++ b/extensions/cerebras/openclaw.plugin.json
@@ -24,6 +24,9 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "cerebras": "cerebras"
+    },
     "providers": {
       "cerebras": {
         "baseUrl": "https://api.cerebras.ai/v1",

--- a/extensions/chutes/openclaw.plugin.json
+++ b/extensions/chutes/openclaw.plugin.json
@@ -65,6 +65,9 @@
     "properties": {}
   },
   "modelCatalog": {
+    "modelsDev": {
+      "chutes": "chutes"
+    },
     "providers": {
       "chutes": {
         "baseUrl": "https://llm.chutes.ai/v1",

--- a/extensions/cohere/openclaw.plugin.json
+++ b/extensions/cohere/openclaw.plugin.json
@@ -8,6 +8,9 @@
   "enabledByDefault": true,
   "providers": ["cohere"],
   "modelCatalog": {
+    "modelsDev": {
+      "cohere": "cohere"
+    },
     "providers": {
       "cohere": {
         "baseUrl": "https://api.cohere.ai/compatibility/v1",

--- a/extensions/deepinfra/openclaw.plugin.json
+++ b/extensions/deepinfra/openclaw.plugin.json
@@ -32,6 +32,9 @@
     ]
   },
   "modelCatalog": {
+    "modelsDev": {
+      "deepinfra": "deepinfra"
+    },
     "providers": {
       "deepinfra": {
         "baseUrl": "https://api.deepinfra.com/v1/openai",

--- a/extensions/deepseek/openclaw.plugin.json
+++ b/extensions/deepseek/openclaw.plugin.json
@@ -23,6 +23,9 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "deepseek": "deepseek"
+    },
     "providers": {
       "deepseek": {
         "baseUrl": "https://api.deepseek.com",

--- a/extensions/fireworks/openclaw.plugin.json
+++ b/extensions/fireworks/openclaw.plugin.json
@@ -30,6 +30,9 @@
     }
   ],
   "modelCatalog": {
+    "modelsDev": {
+      "fireworks": "fireworks-ai"
+    },
     "providers": {
       "fireworks": {
         "baseUrl": "https://api.fireworks.ai/inference/v1",

--- a/extensions/gmi/openclaw.plugin.json
+++ b/extensions/gmi/openclaw.plugin.json
@@ -61,6 +61,9 @@
     "properties": {}
   },
   "modelCatalog": {
+    "modelsDev": {
+      "gmi": "gmicloud"
+    },
     "aliases": {
       "gmi-cloud": {
         "provider": "gmi"

--- a/extensions/groq/openclaw.plugin.json
+++ b/extensions/groq/openclaw.plugin.json
@@ -44,6 +44,9 @@
     }
   ],
   "modelCatalog": {
+    "modelsDev": {
+      "groq": "groq"
+    },
     "providers": {
       "groq": {
         "baseUrl": "https://api.groq.com/openai/v1",

--- a/extensions/kilocode/openclaw.plugin.json
+++ b/extensions/kilocode/openclaw.plugin.json
@@ -48,6 +48,9 @@
     "properties": {}
   },
   "modelCatalog": {
+    "modelsDev": {
+      "kilocode": "kilo"
+    },
     "providers": {
       "kilocode": {
         "baseUrl": "https://api.kilo.ai/api/gateway/",

--- a/extensions/kimi-coding/openclaw.plugin.json
+++ b/extensions/kimi-coding/openclaw.plugin.json
@@ -18,6 +18,9 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "kimi": "kimi-for-coding"
+    },
     "providers": {
       "kimi": {
         "baseUrl": "https://api.kimi.com/coding/",

--- a/extensions/longcat/openclaw.plugin.json
+++ b/extensions/longcat/openclaw.plugin.json
@@ -18,6 +18,9 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "longcat": "longcat"
+    },
     "providers": {
       "longcat": {
         "baseUrl": "https://api.longcat.chat/openai",

--- a/extensions/meta/openclaw.plugin.json
+++ b/extensions/meta/openclaw.plugin.json
@@ -23,6 +23,9 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "meta": "meta"
+    },
     "providers": {
       "meta": {
         "baseUrl": "https://api.meta.ai/v1",

--- a/extensions/mistral/openclaw.plugin.json
+++ b/extensions/mistral/openclaw.plugin.json
@@ -19,6 +19,9 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "mistral": "mistral"
+    },
     "providers": {
       "mistral": {
         "baseUrl": "https://api.mistral.ai/v1",

--- a/extensions/moonshot/openclaw.plugin.json
+++ b/extensions/moonshot/openclaw.plugin.json
@@ -42,6 +42,9 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "moonshot": "moonshotai"
+    },
     "aliases": {
       "moonshotai": {
         "provider": "moonshot"

--- a/extensions/novita/openclaw.plugin.json
+++ b/extensions/novita/openclaw.plugin.json
@@ -59,6 +59,9 @@
     "properties": {}
   },
   "modelCatalog": {
+    "modelsDev": {
+      "novita": "novita-ai"
+    },
     "aliases": {
       "novita-ai": {
         "provider": "novita"

--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -20,6 +20,9 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "nvidia": "nvidia"
+    },
     "providers": {
       "nvidia": {
         "baseUrl": "https://integrate.api.nvidia.com/v1",

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -77,6 +77,9 @@
     }
   ],
   "modelCatalog": {
+    "modelsDev": {
+      "ollama-cloud": "ollama-cloud"
+    },
     "runtimeAugment": true,
     "providers": {
       "ollama-cloud": {

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -42,6 +42,9 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "openai": "openai"
+    },
     "providers": {
       "openai": {
         "baseUrl": "https://api.openai.com/v1",

--- a/extensions/qwen/openclaw.plugin.json
+++ b/extensions/qwen/openclaw.plugin.json
@@ -48,6 +48,10 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "qwen": "alibaba-coding-plan",
+      "qwen-token-plan": "alibaba-token-plan"
+    },
     "suppressions": [
       {
         "provider": "qwen",

--- a/extensions/stepfun/openclaw.plugin.json
+++ b/extensions/stepfun/openclaw.plugin.json
@@ -20,6 +20,10 @@
     ]
   },
   "modelCatalog": {
+    "modelsDev": {
+      "stepfun": "stepfun-ai",
+      "stepfun-plan": "stepfun-ai-step-plan"
+    },
     "providers": {
       "stepfun": {
         "baseUrl": "https://api.stepfun.ai/v1",

--- a/extensions/tencent/openclaw.plugin.json
+++ b/extensions/tencent/openclaw.plugin.json
@@ -7,6 +7,10 @@
   "providerCatalogEntry": "./provider-discovery.ts",
   "providers": ["tencent-tokenhub", "tencent-tokenplan"],
   "modelCatalog": {
+    "modelsDev": {
+      "tencent-tokenhub": "tencent-tokenhub",
+      "tencent-tokenplan": "tencent-token-plan"
+    },
     "providers": {
       "tencent-tokenhub": {
         "baseUrl": "https://tokenhub.tencentmaas.com/v1",

--- a/extensions/together/openclaw.plugin.json
+++ b/extensions/together/openclaw.plugin.json
@@ -40,6 +40,9 @@
     "videoGenerationProviders": ["together"]
   },
   "modelCatalog": {
+    "modelsDev": {
+      "together": "togetherai"
+    },
     "providers": {
       "together": {
         "baseUrl": "https://api.together.xyz/v1",

--- a/extensions/venice/openclaw.plugin.json
+++ b/extensions/venice/openclaw.plugin.json
@@ -44,6 +44,9 @@
     ]
   },
   "modelCatalog": {
+    "modelsDev": {
+      "venice": "venice"
+    },
     "providers": {
       "venice": {
         "baseUrl": "https://api.venice.ai/api/v1",

--- a/extensions/volcengine/openclaw.plugin.json
+++ b/extensions/volcengine/openclaw.plugin.json
@@ -46,6 +46,10 @@
     }
   },
   "modelCatalog": {
+    "modelsDev": {
+      "volcengine": "volcengine",
+      "volcengine-plan": "volcengine-coding-plan"
+    },
     "providers": {
       "volcengine": {
         "baseUrl": "https://ark.cn-beijing.volces.com/api/v3",

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -19,6 +19,10 @@
     ]
   },
   "modelCatalog": {
+    "modelsDev": {
+      "xiaomi": "xiaomi",
+      "xiaomi-token-plan": "xiaomi-token-plan-sgp"
+    },
     "providers": {
       "xiaomi": {
         "baseUrl": "https://api.xiaomimimo.com/v1",

--- a/extensions/zai/openclaw.plugin.json
+++ b/extensions/zai/openclaw.plugin.json
@@ -28,6 +28,9 @@
     ]
   },
   "modelCatalog": {
+    "modelsDev": {
+      "zai": "zai"
+    },
     "providers": {
       "zai": {
         "baseUrl": "https://api.z.ai/api/paas/v4",

--- a/packages/model-catalog-core/src/model-catalog-normalize.test.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.test.ts
@@ -222,6 +222,27 @@ describe("model catalog normalization", () => {
     });
   });
 
+  it("keeps only explicit owned models.dev mappings without creating provider rows", () => {
+    expect(
+      normalizeModelCatalog(
+        {
+          modelsDev: {
+            " Example ": " Upstream-ID ",
+            other: "other-source",
+            alias: "alias-source",
+            Constructor: "blocked-source",
+          },
+          providers: { example: { models: [] } },
+          aliases: { alias: { provider: "example" } },
+        },
+        { ownedProviders: new Set([" EXAMPLE ", "constructor"]) },
+      ),
+    ).toEqual({
+      modelsDev: { example: "Upstream-ID" },
+      aliases: { alias: { provider: "example" } },
+    });
+  });
+
   it("builds normalized rows with provider defaults and stable refs", () => {
     const rows = normalizeModelCatalogProviderRows({
       provider: "OpenAI",
@@ -395,6 +416,13 @@ describe("model catalog normalization", () => {
     { name: "unowned alias", value: { aliases: { alias: { provider: "anthropic" } } } },
     { name: "invalid suppression", value: { suppressions: [{ provider: "openai" }] } },
     { name: "unknown discovery", value: { discovery: { openai: "unknown" } } },
+    { name: "non-record models.dev mapping", value: { modelsDev: "openai" } },
+    { name: "array models.dev mapping", value: { modelsDev: ["openai"] } },
+    { name: "null models.dev mapping", value: { modelsDev: null } },
+    { name: "empty models.dev mapping", value: { modelsDev: {} } },
+    { name: "blank models.dev source", value: { modelsDev: { openai: "  " } } },
+    { name: "non-string models.dev source", value: { modelsDev: { openai: true } } },
+    { name: "unowned models.dev mapping", value: { modelsDev: { anthropic: "anthropic" } } },
   ])("rejects a $name instead of publishing an empty catalog", ({ value }) => {
     expect(normalizeModelCatalog(value, { ownedProviders: new Set(["openai"]) })).toBeUndefined();
   });

--- a/packages/model-catalog-core/src/model-catalog-normalize.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.ts
@@ -630,12 +630,23 @@ export function normalizeModelCatalog(
     return undefined;
   }
   const ownedProviders = normalizeOwnedProviderSet(params.ownedProviders);
+  const modelsDev = Object.fromEntries(
+    Object.entries(normalizeStringMap(value.modelsDev) ?? {}).flatMap(
+      ([rawProviderId, sourceId]) => {
+        const providerId = normalizeProviderId(rawProviderId);
+        return ownedProviders.has(providerId) && !isBlockedObjectKey(providerId)
+          ? [[providerId, sourceId] as const]
+          : [];
+      },
+    ),
+  );
   const providers = normalizeModelCatalogProviders(value.providers, ownedProviders);
   const aliases = normalizeModelCatalogAliases(value.aliases, ownedProviders);
   const suppressions = normalizeModelCatalogSuppressions(value.suppressions);
   const discovery = normalizeModelCatalogDiscovery(value.discovery, ownedProviders);
   const runtimeAugment = value.runtimeAugment === true;
   const catalog = {
+    ...(Object.keys(modelsDev).length > 0 ? { modelsDev } : {}),
     ...(providers ? { providers } : {}),
     ...(aliases ? { aliases } : {}),
     ...(suppressions ? { suppressions } : {}),

--- a/packages/model-catalog-core/src/model-catalog-types.ts
+++ b/packages/model-catalog-core/src/model-catalog-types.ts
@@ -294,6 +294,8 @@ export type ModelCatalogSuppression = {
 
 /** Raw model catalog manifest shape. */
 export type ModelCatalog = {
+  /** Publication-time opt-in: owned OpenClaw provider id -> models.dev provider id. */
+  modelsDev?: Record<string, string>;
   providers?: Record<string, ModelCatalogProvider>;
   aliases?: Record<string, ModelCatalogAlias>;
   suppressions?: ModelCatalogSuppression[];

--- a/scripts/publish-model-catalog.mts
+++ b/scripts/publish-model-catalog.mts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { normalizeModelCatalog } from "@openclaw/model-catalog-core/model-catalog-normalize";
 import {
   MODEL_PRICING_SOURCES,
   normalizeModelPricingCatalog,
@@ -18,6 +19,7 @@ import { parseCerebrasPricingCatalog } from "../extensions/cerebras/pricing-api.
 import { parseChutesPricingCatalog } from "../extensions/chutes/pricing-api.js";
 import { parseDeepInfraPricingCatalog } from "../extensions/deepinfra/pricing-api.js";
 import { parseVenicePricingCatalog } from "../extensions/venice/pricing-api.js";
+import type { ModelCatalogModel } from "../packages/model-catalog-core/src/model-catalog-types.js";
 import type {
   RemoteModelCatalogBundle,
   RemoteModelCatalogPricing,
@@ -29,7 +31,11 @@ type ModelCatalogManifestInput = {
   manifestPath: string;
   manifest: {
     providers?: string[];
-    modelCatalog?: { providers?: Record<string, unknown> };
+    modelCatalog?: {
+      providers?: Record<string, unknown>;
+      modelsDev?: Record<string, unknown>;
+      suppressions?: Array<{ provider?: string; model?: string; when?: unknown }>;
+    };
     modelPricing?: { providers?: Record<string, unknown> };
   };
 };
@@ -44,10 +50,19 @@ type LoadedPricingSource = PricingSource & {
   aliases: string[][];
 };
 type BundleValidator = (bundle: unknown) => PublishedModelCatalogBundle;
+type ModelsDevModel = Record<string, unknown> & {
+  id: string;
+  modalities: { input: unknown[]; output: unknown[] };
+  limit: Record<string, unknown>;
+};
+type ModelCatalogHydrationCounts = { added: number; filled: number; skipped: number };
+type ModelCatalogHydrationResult = Record<string, ModelCatalogHydrationCounts>;
+type ModelCatalogSourceLoader = (url: string, label: string) => Promise<unknown>;
 const MODEL_CATALOG_MIN_VERSION = "2026.7.0";
 export const MODEL_CATALOG_MIN_MODELS = 200;
 
 const SCRIPT_LABEL = "publish-model-catalog";
+const MODELS_DEV_CATALOG_URL = "https://models.opencode.ai/api.json";
 const PRICING_FETCH_TIMEOUT_MS = 60_000;
 const MAX_PRICING_CATALOG_BYTES = 5 * 1024 * 1024;
 const BUNDLE_SIZE_WARNING_BYTES = 2 * 1024 * 1024;
@@ -386,6 +401,158 @@ async function readJsonResponse(response: Response, source: string) {
   return payload;
 }
 
+function createModelCatalogSourceLoader(fetchImpl: typeof fetch = fetch): ModelCatalogSourceLoader {
+  // Metadata and pricing consume the same response within one publication. A failed
+  // metadata request must not be retried as pricing and publish a smaller catalog.
+  const sources = new Map<string, Promise<unknown>>();
+  return (url, label) => {
+    let source = sources.get(url);
+    if (!source) {
+      source = fetchImpl(url, {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(PRICING_FETCH_TIMEOUT_MS),
+      })
+        .then((response) => readJsonResponse(response, label))
+        .catch((cause: unknown) => {
+          throw new Error(`${label} catalog unavailable: ${String(cause)}`, { cause });
+        });
+      sources.set(url, source);
+    }
+    return source;
+  };
+}
+
+function isModelsDevModel(value: unknown, modelId: string): value is ModelsDevModel {
+  return (
+    isRecord(value) &&
+    value.id === modelId &&
+    isRecord(value.modalities) &&
+    Array.isArray(value.modalities.input) &&
+    Array.isArray(value.modalities.output) &&
+    isRecord(value.limit)
+  );
+}
+
+// Metadata only: cost stays with the provider pricing policy in enrichModelCatalogPricing.
+function translateModelsDevModel(model: ModelsDevModel): ModelCatalogModel {
+  const contextWindow = parseStrictFiniteNumber(model.limit.context);
+  const maxTokens = parseStrictFiniteNumber(model.limit.output);
+  return {
+    id: model.id,
+    ...(typeof model.name === "string" ? { name: model.name } : {}),
+    ...(typeof model.reasoning === "boolean" ? { reasoning: model.reasoning } : {}),
+    input: [
+      ...new Set(
+        model.modalities.input.flatMap((value) =>
+          value === "text" || value === "image" ? value : value === "pdf" ? "document" : [],
+        ),
+      ),
+    ],
+    ...(contextWindow !== undefined && contextWindow > 0 ? { contextWindow } : {}),
+    ...(maxTokens !== undefined && maxTokens > 0 ? { maxTokens } : {}),
+  };
+}
+
+const HYDRATED_MODEL_FIELDS = [
+  "name",
+  "reasoning",
+  "input",
+  "contextWindow",
+  "maxTokens",
+] as const satisfies readonly (keyof ModelCatalogModel)[];
+
+export async function hydrateModelCatalogFromModelsDev(options: {
+  bundle: PublishedModelCatalogBundle;
+  manifests: ModelCatalogManifestInput[];
+  fetchImpl?: typeof fetch;
+  loadSource?: ModelCatalogSourceLoader;
+}): Promise<ModelCatalogHydrationResult> {
+  const result: ModelCatalogHydrationResult = {};
+  const mappings = new Map<string, string>();
+  const suppressions = new Set<string>();
+  for (const { manifest } of options.manifests) {
+    const ownedProviders = new Set((manifest.providers ?? []).map(normalizeModelCatalogProviderId));
+    const catalog = normalizeModelCatalog(manifest.modelCatalog, { ownedProviders });
+    for (const [provider, source] of Object.entries(catalog?.modelsDev ?? {})) {
+      if (catalog?.providers?.[provider] && options.bundle.providers[provider]) {
+        mappings.set(provider, source);
+      }
+    }
+    // Endpoint-specific rules remain runtime-owned. Another plugin cannot veto
+    // an owner's imports through an unowned shared-catalog suppression.
+    for (const { provider, model, when } of catalog?.suppressions ?? []) {
+      if (ownedProviders.has(provider) && when === undefined) {
+        suppressions.add(`${provider}/${model.toLowerCase()}`);
+      }
+    }
+  }
+  if (mappings.size === 0) {
+    return result;
+  }
+  const loadSource = options.loadSource ?? createModelCatalogSourceLoader(options.fetchImpl);
+  const catalog = await loadSource(MODELS_DEV_CATALOG_URL, "models.dev");
+  if (!isRecord(catalog)) {
+    throw new Error("models.dev response is not a JSON object");
+  }
+  for (const [providerId, provider] of Object.entries(options.bundle.providers)) {
+    const upstreamProviderId = mappings.get(providerId);
+    if (!upstreamProviderId) {
+      continue;
+    }
+    const upstreamProvider = catalog[upstreamProviderId];
+    if (
+      !isRecord(upstreamProvider) ||
+      upstreamProvider.id !== upstreamProviderId ||
+      !isRecord(upstreamProvider.models)
+    ) {
+      throw new Error(`models.dev catalog missing or malformed for provider ${upstreamProviderId}`);
+    }
+    if (provider.models.some((model) => model.api !== undefined)) {
+      process.stderr.write(
+        `[${SCRIPT_LABEL}] warning: skipping models.dev hydration for ${providerId}; its rows pick a transport per model\n`,
+      );
+      continue;
+    }
+    const existing = new Map(provider.models.map((model) => [model.id, model]));
+    let filled = 0;
+    let skipped = 0;
+    const additions = Object.entries(upstreamProvider.models).flatMap(([modelId, rawModel]) => {
+      // Agents need tool calling; models.dev rows without it are embeddings, image, guard, and
+      // safety models that would only clutter the picker.
+      if (
+        !isModelsDevModel(rawModel, modelId) ||
+        rawModel.tool_call !== true ||
+        !rawModel.modalities.output.includes("text") ||
+        rawModel.status === "deprecated" ||
+        rawModel.status === "retired" ||
+        suppressions.has(`${providerId}/${modelId.toLowerCase()}`)
+      ) {
+        skipped += 1;
+        return [];
+      }
+      const current = existing.get(modelId);
+      if (!current) {
+        return [translateModelsDevModel(rawModel)];
+      }
+      const translated = translateModelsDevModel(rawModel);
+      let modelFilled = false;
+      for (const key of HYDRATED_MODEL_FIELDS) {
+        if (current[key] === undefined && translated[key] !== undefined) {
+          Object.assign(current, { [key]: translated[key] });
+          modelFilled = true;
+        }
+      }
+      if (modelFilled) {
+        filled += 1;
+      }
+      return [];
+    });
+    provider.models.push(...additions);
+    result[providerId] = { added: additions.length, filled, skipped };
+  }
+  return result;
+}
+
 function parsePricingCatalog(
   source: PricingSource,
   body: unknown,
@@ -459,21 +626,19 @@ function parsePricingCatalog(
   return { ...source, catalog, aliases };
 }
 
-async function fetchPricingSources(fetchImpl: typeof fetch, policies: PricingPolicies) {
+async function fetchPricingSources(
+  loadSource: ModelCatalogSourceLoader,
+  policies: PricingPolicies,
+) {
   const sources = MODEL_PRICING_SOURCES.filter(
     (source) =>
       !source.authoritative ||
       [...policies.keys()].some((id) => sourcePolicy(policies, id, source)),
   );
-  const signal = AbortSignal.timeout(PRICING_FETCH_TIMEOUT_MS);
   const loaded = await Promise.all(
     sources.map(async (source) => {
       try {
-        const response = await fetchImpl(source.url, {
-          headers: { Accept: "application/json" },
-          signal,
-        });
-        const body = await readJsonResponse(response, source.label);
+        const body = await loadSource(source.url, source.label);
         return parsePricingCatalog(source, body, policies);
       } catch (cause) {
         return {
@@ -559,10 +724,14 @@ export async function enrichModelCatalogPricing(options: {
   bundle: PublishedModelCatalogBundle;
   manifests: ModelCatalogManifestInput[];
   fetchImpl?: typeof fetch;
+  loadSource?: ModelCatalogSourceLoader;
   validateBundle?: BundleValidator;
 }): Promise<{ modelsEnriched: number; pricingEntries: number }> {
   const policies = readPricingPolicies(options.manifests);
-  const sources = await fetchPricingSources(options.fetchImpl ?? fetch, policies);
+  const sources = await fetchPricingSources(
+    options.loadSource ?? createModelCatalogSourceLoader(options.fetchImpl),
+    policies,
+  );
   let enriched = 0;
   const coveredKeys = new Set<string>();
   const metadataOwnedKeys = new Set<string>();
@@ -697,8 +866,10 @@ async function runPublishModelCatalog(
   const sourceCommit = options.sourceCommit ?? resolveSourceCommit(rootDir);
   const manifests = readModelCatalogManifests({ rootDir });
   const bundle = await assembleModelCatalogBundle({ manifests, generatedAt, sourceCommit });
+  const loadSource = createModelCatalogSourceLoader(options.fetchImpl);
+  const hydrationResult = await hydrateModelCatalogFromModelsDev({ bundle, manifests, loadSource });
   const pricingResult = args.pricing
-    ? await enrichModelCatalogPricing({ bundle, manifests, fetchImpl: options.fetchImpl })
+    ? await enrichModelCatalogPricing({ bundle, manifests, loadSource })
     : { modelsEnriched: 0, pricingEntries: 0 };
   const summary = summarizeModelCatalogBundle(bundle);
   const serialized = serializeModelCatalogBundle(bundle);
@@ -713,9 +884,16 @@ async function runPublishModelCatalog(
       `catalog bundle ${bundleBytes} bytes exceeds client limit ${CLIENT_BUNDLE_LIMIT_BYTES} bytes`,
     );
   }
+  const hydrationSummary = Object.entries(hydrationResult)
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(
+      ([providerId, { added, filled, skipped }]) =>
+        `[${SCRIPT_LABEL}] models.dev provider=${providerId} added=${added} filled=${filled} skipped=${skipped}\n`,
+    )
+    .join("");
   const stats = `schemaVersion=1 providers=${summary.providers} models=${summary.models} costModels=${summary.costModels} pricingEnriched=${pricingResult.modelsEnriched} pricingEntries=${pricingResult.pricingEntries} bundleBytes=${bundleBytes} generatedAt=${bundle.generatedAt} minVersion=${bundle.minVersion} sourceCommit=${bundle.sourceCommit}`;
   if (args.dryRun) {
-    process.stdout.write(`[${SCRIPT_LABEL}] dry-run ${stats}\n`);
+    process.stdout.write(`[${SCRIPT_LABEL}] dry-run ${stats}\n${hydrationSummary}`);
     return { bundle, summary, pricingEnriched: pricingResult.modelsEnriched, wrote: false };
   }
   if (!args.out) {
@@ -724,7 +902,7 @@ async function runPublishModelCatalog(
   const outputFile = path.resolve(rootDir, args.out);
   fs.mkdirSync(path.dirname(outputFile), { recursive: true });
   fs.writeFileSync(outputFile, serialized);
-  process.stdout.write(`[${SCRIPT_LABEL}] published ${stats} out=${args.out}\n`);
+  process.stdout.write(`[${SCRIPT_LABEL}] published ${stats} out=${args.out}\n${hydrationSummary}`);
   return { bundle, summary, pricingEnriched: pricingResult.modelsEnriched, wrote: true };
 }
 

--- a/scripts/publish-model-catalog.mts
+++ b/scripts/publish-model-catalog.mts
@@ -725,7 +725,6 @@ export async function enrichModelCatalogPricing(options: {
   manifests: ModelCatalogManifestInput[];
   fetchImpl?: typeof fetch;
   loadSource?: ModelCatalogSourceLoader;
-  validateBundle?: BundleValidator;
 }): Promise<{ modelsEnriched: number; pricingEntries: number }> {
   const policies = readPricingPolicies(options.manifests);
   const sources = await fetchPricingSources(
@@ -807,10 +806,6 @@ export async function enrichModelCatalogPricing(options: {
       .toSorted(([left], [right]) => left.localeCompare(right))
       .map(([key, pricing]) => [key, compactPricing(pricing)]),
   );
-  const validateBundle = options.validateBundle ?? (await loadClientBundleValidator());
-  const validated = validateBundle(options.bundle);
-  options.bundle.providers = validated.providers;
-  options.bundle.pricing = validated.pricing;
   return { modelsEnriched: enriched, pricingEntries: hosted.size };
 }
 
@@ -865,12 +860,16 @@ async function runPublishModelCatalog(
   const generatedAt = (options.now ?? Date.now)();
   const sourceCommit = options.sourceCommit ?? resolveSourceCommit(rootDir);
   const manifests = readModelCatalogManifests({ rootDir });
-  const bundle = await assembleModelCatalogBundle({ manifests, generatedAt, sourceCommit });
+  let bundle = await assembleModelCatalogBundle({ manifests, generatedAt, sourceCommit });
   const loadSource = createModelCatalogSourceLoader(options.fetchImpl);
   const hydrationResult = await hydrateModelCatalogFromModelsDev({ bundle, manifests, loadSource });
   const pricingResult = args.pricing
     ? await enrichModelCatalogPricing({ bundle, manifests, loadSource })
     : { modelsEnriched: 0, pricingEntries: 0 };
+  // Validate after all enrichment so metadata-only and dry-run output obey the
+  // same client contract as priced catalogs.
+  const validateBundle = await loadClientBundleValidator();
+  bundle = validateBundle(bundle);
   const summary = summarizeModelCatalogBundle(bundle);
   const serialized = serializeModelCatalogBundle(bundle);
   const bundleBytes = Buffer.byteLength(serialized);

--- a/src/plugins/manifest-model-catalog.test.ts
+++ b/src/plugins/manifest-model-catalog.test.ts
@@ -20,6 +20,24 @@ describe("plugin manifest model catalog", () => {
     cleanupTrackedTempDirs(tempDirs);
   });
 
+  it.each([true, false])("loads models.dev opt-in only with provider ownership: %s", (owned) => {
+    const dir = makePluginDir();
+    writeManifest(dir, {
+      id: "example-plugin",
+      providers: owned ? [" Example "] : [],
+      modelCatalog: { modelsDev: { " EXAMPLE ": " upstream-id ", other: "other-source" } },
+      configSchema: { type: "object" },
+    });
+
+    const result = loadPluginManifest(dir);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    expect(result.manifest.modelCatalog).toEqual(
+      owned ? { modelsDev: { example: "upstream-id" } } : undefined,
+    );
+  });
+
   it("allows cli backends to own manifest model catalog rows", () => {
     const dir = makePluginDir();
     writeManifest(dir, {

--- a/test/scripts/publish-model-catalog.test.ts
+++ b/test/scripts/publish-model-catalog.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assembleModelCatalogBundle,
   enrichModelCatalogPricing,
+  hydrateModelCatalogFromModelsDev,
   MODEL_CATALOG_MIN_MODELS,
   parsePublishModelCatalogArgs,
   readModelCatalogManifests,
@@ -36,17 +37,44 @@ afterEach(() => {
   }
 });
 
-function fixtureProvider(
-  prefix: string,
-  count: number,
-): {
-  models: Array<{ id: string; cost?: { input: number; output: number } }>;
-} {
+type FixtureModel = RemoteModelCatalogBundle["providers"][string]["models"][number];
+
+function fixtureProvider(prefix: string, count: number): { models: FixtureModel[] } {
   return { models: Array.from({ length: count }, (_, index) => ({ id: `${prefix}-${index}` })) };
 }
 
 function requestUrl(input: string | URL | Request): string {
   return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+}
+
+type ModelsDevFixtureModel = { id: string } & Record<string, unknown>;
+const MODELS_DEV_CATALOG_URL = "https://models.opencode.ai/api.json";
+
+function modelsDevModel(
+  id: string,
+  overrides: Record<string, unknown> = {},
+): ModelsDevFixtureModel {
+  return {
+    id,
+    name: `Feed ${id}`,
+    reasoning: true,
+    tool_call: true,
+    modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+    limit: { context: 128000, output: 32000 },
+    cost: { input: 1, output: 2, cache_read: 0.1, cache_write: 0.2 },
+    ...overrides,
+  };
+}
+
+function modelsDevCatalog(
+  providers: Record<string, ModelsDevFixtureModel[]>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(providers).map(([id, models]) => [
+      id,
+      { id, models: Object.fromEntries(models.map((model) => [model.id, model])) },
+    ]),
+  );
 }
 
 function publishedPricingParams(bundle: RemoteModelCatalogBundle, provider: string) {
@@ -340,30 +368,298 @@ describe("publish model catalog", () => {
     ).rejects.toThrow();
   });
 
+  it("hydrates missing models and fills only undefined manifest metadata", async () => {
+    const anthropic = fixtureProvider("claude", 100);
+    anthropic.models[0] = {
+      id: "manifest-owned",
+      name: "Manifest name",
+      reasoning: false,
+      input: ["text"],
+      contextWindow: 999,
+      maxTokens: 888,
+    };
+    anthropic.models[1] = { id: "manifest-partial" };
+    const openai = fixtureProvider("gpt", 100);
+    const manifests = [
+      {
+        pluginId: "fixture",
+        manifestPath: "fixture.json",
+        manifest: {
+          providers: ["anthropic", "openai"],
+          modelCatalog: {
+            providers: { anthropic, openai },
+            modelsDev: { anthropic: "upstream-anthropic" },
+          },
+        },
+      },
+    ];
+    const bundle = await assembleModelCatalogBundle({
+      manifests,
+      generatedAt: Date.now(),
+      sourceCommit: "fixture-sha",
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      expect(requestUrl(input)).toBe(MODELS_DEV_CATALOG_URL);
+      return Response.json(
+        modelsDevCatalog({
+          "upstream-anthropic": [
+            modelsDevModel("manifest-owned", {
+              name: "Feed name",
+              reasoning: true,
+              modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+              limit: { context: 128000, output: 32000 },
+            }),
+            modelsDevModel("manifest-partial"),
+            modelsDevModel("new-model"),
+          ],
+        }),
+      );
+    });
+
+    await expect(
+      hydrateModelCatalogFromModelsDev({ bundle, manifests, fetchImpl }),
+    ).resolves.toEqual({ anthropic: { added: 1, filled: 1, skipped: 0 } });
+    const models = bundle.providers.anthropic?.models ?? [];
+    expect(models[0]?.id).toBe("manifest-owned");
+    expect(models[1]?.id).toBe("manifest-partial");
+    expect(models.find((model) => model.id === "manifest-owned")).toEqual({
+      id: "manifest-owned",
+      name: "Manifest name",
+      reasoning: false,
+      input: ["text"],
+      contextWindow: 999,
+      maxTokens: 888,
+    });
+    expect(models.find((model) => model.id === "manifest-partial")).toEqual({
+      id: "manifest-partial",
+      name: "Feed manifest-partial",
+      reasoning: true,
+      input: ["text", "image", "document"],
+      contextWindow: 128000,
+      maxTokens: 32000,
+    });
+    expect(models.find((model) => model.id === "new-model")).toEqual({
+      id: "new-model",
+      name: "Feed new-model",
+      reasoning: true,
+      input: ["text", "image", "document"],
+      contextWindow: 128000,
+      maxTokens: 32000,
+    });
+    const hydratedKeys = new Set([
+      "id",
+      "name",
+      "reasoning",
+      "input",
+      "contextWindow",
+      "maxTokens",
+    ]);
+    expect(
+      Object.keys(models.find((model) => model.id === "new-model") ?? {}).every((key) =>
+        hydratedKeys.has(key),
+      ),
+    ).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("skips rows without tool calls or text output, suppressions, and unmapped providers", async () => {
+    const anthropic = fixtureProvider("claude", 100);
+    const openai = fixtureProvider("gpt", 100);
+    const featherless = { models: [{ id: "existing-featherless" }] };
+    const manifests = [
+      {
+        pluginId: "fixture",
+        manifestPath: "fixture.json",
+        manifest: {
+          providers: ["anthropic", "openai", "featherless"],
+          modelCatalog: {
+            providers: { anthropic, openai, featherless },
+            modelsDev: { openai: "openai" },
+            suppressions: [
+              { provider: "openai", model: "suppressed-model" },
+              {
+                provider: "openai",
+                model: "endpoint-model",
+                when: { baseUrlHosts: ["api.openai.example"] },
+              },
+            ],
+          },
+        },
+      },
+      {
+        pluginId: "unrelated",
+        manifestPath: "unrelated.json",
+        manifest: {
+          providers: [],
+          modelCatalog: { suppressions: [{ provider: "openai", model: "allowed-model" }] },
+        },
+      },
+    ];
+    const bundle = await assembleModelCatalogBundle({
+      manifests,
+      generatedAt: Date.now(),
+      sourceCommit: "fixture-sha",
+    });
+    const result = await hydrateModelCatalogFromModelsDev({
+      bundle,
+      manifests,
+      fetchImpl: async (input) => {
+        expect(requestUrl(input)).toBe(MODELS_DEV_CATALOG_URL);
+        return Response.json({
+          openai: {
+            id: "openai",
+            models: {
+              "image-model": modelsDevModel("image-model", {
+                modalities: { input: ["text"], output: ["image"] },
+              }),
+              "embedding-model": modelsDevModel("embedding-model", { tool_call: false }),
+              "suppressed-model": modelsDevModel("suppressed-model"),
+              "endpoint-model": modelsDevModel("endpoint-model"),
+              "deprecated-model": modelsDevModel("deprecated-model", { status: "deprecated" }),
+              "malformed-model": { id: "malformed-model" },
+              "allowed-model": modelsDevModel("allowed-model"),
+            },
+          },
+          featherless: {
+            id: "featherless",
+            models: { "feed-model": modelsDevModel("feed-model") },
+          },
+        });
+      },
+    });
+    expect(result.openai).toEqual({ added: 2, filled: 0, skipped: 5 });
+    expect(bundle.providers.openai?.models.map((model) => model.id)).toEqual([
+      ...fixtureProvider("gpt", 100).models.map((model) => model.id),
+      "endpoint-model",
+      "allowed-model",
+    ]);
+    expect(bundle.providers.featherless?.models.map((model) => model.id)).toEqual([
+      "existing-featherless",
+    ]);
+  });
+
+  it("skips providers whose manifest rows pick a transport per model", async () => {
+    const anthropic = fixtureProvider("claude", 100);
+    anthropic.models[0] = { id: "manifest-anthropic", api: "anthropic-messages" };
+    const openai = fixtureProvider("gpt", 100);
+    const manifests = [
+      {
+        pluginId: "fixture",
+        manifestPath: "fixture.json",
+        manifest: {
+          providers: ["anthropic", "openai"],
+          modelCatalog: { providers: { anthropic, openai }, modelsDev: { anthropic: "anthropic" } },
+        },
+      },
+    ];
+    const bundle = await assembleModelCatalogBundle({
+      manifests,
+      generatedAt: Date.now(),
+      sourceCommit: "fixture-sha",
+    });
+    const previous = serializeModelCatalogBundle(bundle);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const result = await hydrateModelCatalogFromModelsDev({
+        bundle,
+        manifests,
+        fetchImpl: async () =>
+          Response.json(modelsDevCatalog({ anthropic: [modelsDevModel("new-model")] })),
+      });
+      expect(result.anthropic).toBeUndefined();
+    } finally {
+      stderr.mockRestore();
+    }
+    expect(serializeModelCatalogBundle(bundle)).toBe(previous);
+  });
+
+  it.each(["fetch failure", "malformed feed", "missing mapped provider"])(
+    "rejects models.dev %s before changing the bundle",
+    async (scenario) => {
+      const manifests = [
+        {
+          pluginId: "fixture",
+          manifestPath: "fixture.json",
+          manifest: {
+            providers: ["anthropic", "openai"],
+            modelCatalog: {
+              modelsDev: { anthropic: "anthropic" },
+              providers: {
+                anthropic: fixtureProvider("claude", 100),
+                openai: fixtureProvider("gpt", 100),
+              },
+            },
+          },
+        },
+      ];
+      const bundle = await assembleModelCatalogBundle({
+        manifests,
+        generatedAt: Date.now(),
+        sourceCommit: "fixture-sha",
+      });
+      const previous = serializeModelCatalogBundle(bundle);
+      await expect(
+        hydrateModelCatalogFromModelsDev({
+          bundle,
+          manifests,
+          fetchImpl: async () => {
+            if (scenario === "fetch failure") {
+              throw new Error("fixture outage");
+            }
+            return Response.json(scenario === "malformed feed" ? [] : {});
+          },
+        }),
+      ).rejects.toThrow("models.dev");
+      expect(serializeModelCatalogBundle(bundle)).toBe(previous);
+    },
+  );
+
+  it.each(["absent", "unowned", "without provider catalog"])(
+    "does not fetch models.dev with source declaration: %s",
+    async (scenario) => {
+      const modelsDev = scenario === "absent" ? undefined : { other: "upstream-other" };
+      const manifests = [
+        {
+          pluginId: "fixture",
+          manifestPath: "fixture.json",
+          manifest: {
+            providers:
+              scenario === "unowned" ? ["anthropic", "openai"] : ["anthropic", "openai", "other"],
+            modelCatalog: {
+              modelsDev,
+              providers: {
+                anthropic: fixtureProvider("claude", 100),
+                openai: fixtureProvider("gpt", 100),
+                ...(scenario === "unowned" ? { other: fixtureProvider("other", 1) } : {}),
+              },
+            },
+          },
+        },
+      ];
+      const bundle = await assembleModelCatalogBundle({
+        manifests,
+        generatedAt: Date.now(),
+        sourceCommit: "fixture-sha",
+      });
+      const fetchImpl = vi.fn<typeof fetch>();
+      await expect(
+        hydrateModelCatalogFromModelsDev({ bundle, manifests, fetchImpl }),
+      ).resolves.toEqual({});
+      expect(fetchImpl).not.toHaveBeenCalled();
+    },
+  );
+
   it("parses supported CLI arguments and rejects missing output", () => {
     expect(parsePublishModelCatalogArgs(["--dry-run", "--out", "ignored.json"])).toEqual({
       dryRun: true,
       pricing: false,
       out: "ignored.json",
     });
+    expect(parsePublishModelCatalogArgs(["--pricing", "--dry-run"])).toEqual({
+      dryRun: true,
+      pricing: true,
+    });
     expect(() => parsePublishModelCatalogArgs([])).toThrow("provide --out");
-  });
-
-  it("dry-runs the repository manifests without writing output", () => {
-    const root = process.cwd();
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-publish-catalog-smoke-"));
-    tempDirs.push(tempDir);
-    const out = path.join(tempDir, "catalog.json");
-    const result = spawnSync(
-      process.execPath,
-      ["--import", "tsx", "scripts/publish-model-catalog.mts", "--dry-run", "--out", out],
-      { cwd: root, encoding: "utf8" },
-    );
-    expect(result.status, result.stderr).toBe(0);
-    const stats = /dry-run schemaVersion=1 providers=[1-9]\d* models=(\d+)/u.exec(result.stdout);
-    expect(stats).not.toBeNull();
-    expect(Number(stats?.[1])).toBeGreaterThanOrEqual(MODEL_CATALOG_MIN_MODELS);
-    expect(fs.existsSync(out)).toBe(false);
   });
 
   it("enriches catalog models and emits unmatched hosted pricing keys", async () => {
@@ -1051,7 +1347,17 @@ describe("publish model catalog", () => {
   });
 
   it.each([
-    { source: "OpenCode", scenario: "unreachable" },
+    ...[
+      "transient metadata outage",
+      "transient metadata outage without pricing",
+      "malformed metadata",
+      "shared response",
+      "metadata without pricing",
+      "dry run",
+    ].map((scenario) => ({
+      source: "models.dev",
+      scenario,
+    })),
     ...["unreachable", "malformed body", "invalid price"].map((scenario) => ({
       source: "DeepInfra",
       scenario,
@@ -1060,21 +1366,23 @@ describe("publish model catalog", () => {
       source: "Venice",
       scenario,
     })),
-  ])(
-    "leaves published output untouched when $source pricing is $scenario",
-    ({ source, scenario }) => {
-      const root = fs.realpathSync(
-        fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-publish-failure-")),
-      );
-      tempDirs.push(root);
-      const out = path.join(root, "catalog.json");
-      const preload = path.join(root, "offline.mjs");
-      fs.writeFileSync(out, "previous published catalog\n");
-      fs.writeFileSync(
-        preload,
-        `const manifests = ${JSON.stringify(readModelCatalogManifests().map((entry) => entry.manifest))};
+  ])("publishes only verified source data: $source $scenario", ({ source, scenario }) => {
+    const root = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-publish-failure-")),
+    );
+    tempDirs.push(root);
+    const out = path.join(root, "catalog.json");
+    const preload = path.join(root, "offline.mjs");
+    fs.writeFileSync(out, "previous published catalog\n");
+    fs.writeFileSync(
+      preload,
+      `const manifests = ${JSON.stringify(readModelCatalogManifests().map((entry) => entry.manifest))};
 const openCode = {};
 for (const manifest of manifests) {
+  for (const [provider, id] of Object.entries(manifest.modelCatalog?.modelsDev ?? {})) {
+    const models = manifest.modelCatalog?.providers?.[provider]?.models ?? [];
+    openCode[id] = { id, models: Object.fromEntries(models.map((model) => [model.id, { id: model.id, tool_call: true, modalities: { input: ["text"], output: ["text"] }, limit: { context: 128000, output: 32000 }, cost: { input: 1, output: 2 } }])) };
+  }
   for (const [provider, policy] of Object.entries(manifest.modelPricing?.providers ?? {})) {
     if (!policy.openCode) continue;
     const id = policy.openCode.provider ?? provider;
@@ -1082,9 +1390,21 @@ for (const manifest of manifests) {
     openCode[id] = { id, models: Object.fromEntries(models.map((model) => [model.id, { id: model.id, cost: { input: 1, output: 2 } }])) };
   }
 }
+openCode.anthropic.models["fixture-discovered-model"] = { id: "fixture-discovered-model", tool_call: true, modalities: { input: ["text"], output: ["text"] }, limit: { context: 128000, output: 32000 } };
+let metadataFetched = false;
 globalThis.fetch = async (url) => {
-  if (${JSON.stringify(source)} === "OpenCode") throw new Error("fixture outage");
-  if (url === ${JSON.stringify(OPENCODE_PRICING_URL)}) return Response.json(openCode);
+  if (url === ${JSON.stringify(OPENCODE_PRICING_URL)}) {
+    if (${JSON.stringify(source)} === "models.dev") {
+      if (!metadataFetched) {
+        metadataFetched = true;
+        if (${JSON.stringify(scenario)}.startsWith("transient metadata outage")) throw new Error("fixture transient metadata outage");
+        if (${JSON.stringify(scenario)} === "malformed metadata") return Response.json([]);
+      } else if (${JSON.stringify(scenario)} === "shared response") {
+        throw new Error("metadata and pricing fetched different source snapshots");
+      }
+    }
+    return Response.json(openCode);
+  }
   if (${JSON.stringify(source)} === "DeepInfra") {
     if (url === "https://api.deepinfra.com/models/list") {
       if (${JSON.stringify(scenario)} === "unreachable") throw new Error("fixture outage");
@@ -1100,29 +1420,43 @@ globalThis.fetch = async (url) => {
     if (${JSON.stringify(scenario)} === "malformed body") return Response.json({});
     if (${JSON.stringify(scenario)} === "invalid price") return Response.json({ data: manifests.flatMap((manifest) => (manifest.modelCatalog?.providers?.venice?.models ?? []).map((model) => ({ id: model.id, type: "text", model_spec: { pricing: { input: { usd: -1 }, output: { usd: 2 } } } }))) });
   }
+  if (url === "https://api.deepinfra.com/models/list") return Response.json([{ model_name: "fixture/chat", pricing: { type: "tokens", cents_per_input_token: 0.0002, cents_per_output_token: 0.001 } }]);
+  if (url === "https://llm.chutes.ai/v1/models") return Response.json({ data: [{ id: "fixture/chat", pricing: { prompt: 2, completion: 10 } }] });
+  if (url === "https://api.cerebras.ai/public/v1/models") return Response.json({ data: [{ id: "fixture/chat", pricing: { prompt: "0.000002", completion: "0.00001" } }] });
+  if (url === ${JSON.stringify(VENICE_PRICING_URL)}) return Response.json(${JSON.stringify(scenario)} === "missing model" ? { data: [] } : { data: [{ id: "fixture/chat", type: "text", model_spec: { pricing: { input: { usd: 2 }, output: { usd: 10 } } } }] });
   return Response.json({ data: [] });
 };`,
-      );
-      const result = spawnSync(
-        process.execPath,
-        [
-          "--import",
-          "tsx",
-          "--import",
-          preload,
-          "scripts/publish-model-catalog.mts",
-          "--pricing",
-          "--out",
-          out,
-        ],
-        { cwd: process.cwd(), encoding: "utf8" },
-      );
-      expect(result.status, result.stderr).toBe(1);
-      expect(result.stderr).toContain(`${source} pricing`);
-      expect(result.stderr.trim().split("\n").at(-1)).toBe(
-        "[publish-model-catalog] FAILED (exit 1)",
-      );
-      expect(fs.readFileSync(out, "utf8")).toBe("previous published catalog\n");
-    },
-  );
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "--import",
+        preload,
+        "scripts/publish-model-catalog.mts",
+        ...(scenario.endsWith("without pricing") ? [] : ["--pricing"]),
+        ...(scenario === "dry run" ? ["--dry-run"] : []),
+        "--out",
+        out,
+      ],
+      { cwd: process.cwd(), encoding: "utf8" },
+    );
+    if (["shared response", "metadata without pricing", "dry run"].includes(scenario)) {
+      expect(result.status, result.stderr).toBe(0);
+      if (scenario === "dry run") {
+        expect(result.stdout).toContain("dry-run schemaVersion=1");
+        expect(fs.readFileSync(out, "utf8")).toBe("previous published catalog\n");
+      } else {
+        expect(JSON.parse(fs.readFileSync(out, "utf8")).providers.anthropic.models).toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: "fixture-discovered-model" })]),
+        );
+      }
+      return;
+    }
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain(source === "models.dev" ? "models.dev" : `${source} pricing`);
+    expect(result.stderr.trim().split("\n").at(-1)).toBe("[publish-model-catalog] FAILED (exit 1)");
+    expect(fs.readFileSync(out, "utf8")).toBe("previous published catalog\n");
+  });
 });

--- a/test/scripts/publish-model-catalog.test.ts
+++ b/test/scripts/publish-model-catalog.test.ts
@@ -2,7 +2,10 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { RemoteModelCatalogBundle } from "@openclaw/model-catalog-core";
+import {
+  parseRemoteModelCatalogBundle,
+  type RemoteModelCatalogBundle,
+} from "@openclaw/model-catalog-core";
 import {
   LITELLM_PRICING_URL,
   OPENROUTER_MODELS_URL,
@@ -1354,6 +1357,14 @@ describe("publish model catalog", () => {
       "shared response",
       "metadata without pricing",
       "dry run",
+      "blank model id",
+      "blank model id without pricing",
+      "blank model id dry run without pricing",
+      "colliding model id",
+      "colliding model id without pricing",
+      "colliding model id dry run without pricing",
+      "trimmed model id",
+      "trimmed model id without pricing",
     ].map((scenario) => ({
       source: "models.dev",
       scenario,
@@ -1373,6 +1384,13 @@ describe("publish model catalog", () => {
     tempDirs.push(root);
     const out = path.join(root, "catalog.json");
     const preload = path.join(root, "offline.mjs");
+    const discoveredIds = scenario.startsWith("blank model id")
+      ? [" "]
+      : scenario.startsWith("colliding model id")
+        ? ["fixture-discovered-model", " fixture-discovered-model "]
+        : scenario.startsWith("trimmed model id")
+          ? [" fixture-discovered-model "]
+          : ["fixture-discovered-model"];
     fs.writeFileSync(out, "previous published catalog\n");
     fs.writeFileSync(
       preload,
@@ -1390,7 +1408,7 @@ for (const manifest of manifests) {
     openCode[id] = { id, models: Object.fromEntries(models.map((model) => [model.id, { id: model.id, cost: { input: 1, output: 2 } }])) };
   }
 }
-openCode.anthropic.models["fixture-discovered-model"] = { id: "fixture-discovered-model", tool_call: true, modalities: { input: ["text"], output: ["text"] }, limit: { context: 128000, output: 32000 } };
+Object.assign(openCode.anthropic.models, ${JSON.stringify(Object.fromEntries(discoveredIds.map((id) => [id, modelsDevModel(id)])))});
 let metadataFetched = false;
 globalThis.fetch = async (url) => {
   if (url === ${JSON.stringify(OPENCODE_PRICING_URL)}) {
@@ -1436,26 +1454,39 @@ globalThis.fetch = async (url) => {
         preload,
         "scripts/publish-model-catalog.mts",
         ...(scenario.endsWith("without pricing") ? [] : ["--pricing"]),
-        ...(scenario === "dry run" ? ["--dry-run"] : []),
+        ...(scenario.includes("dry run") ? ["--dry-run"] : []),
         "--out",
         out,
       ],
       { cwd: process.cwd(), encoding: "utf8" },
     );
-    if (["shared response", "metadata without pricing", "dry run"].includes(scenario)) {
+    if (
+      ["shared response", "metadata without pricing", "dry run"].includes(scenario) ||
+      scenario.startsWith("trimmed model id")
+    ) {
       expect(result.status, result.stderr).toBe(0);
       if (scenario === "dry run") {
         expect(result.stdout).toContain("dry-run schemaVersion=1");
         expect(fs.readFileSync(out, "utf8")).toBe("previous published catalog\n");
       } else {
-        expect(JSON.parse(fs.readFileSync(out, "utf8")).providers.anthropic.models).toEqual(
+        const published = JSON.parse(fs.readFileSync(out, "utf8"));
+        parseRemoteModelCatalogBundle(published);
+        expect(published.providers.anthropic.models).toEqual(
           expect.arrayContaining([expect.objectContaining({ id: "fixture-discovered-model" })]),
         );
       }
       return;
     }
     expect(result.status, result.stderr).toBe(1);
-    expect(result.stderr).toContain(source === "models.dev" ? "models.dev" : `${source} pricing`);
+    expect(result.stderr).toContain(
+      scenario.startsWith("blank model id")
+        ? "Too small"
+        : scenario.startsWith("colliding model id")
+          ? "duplicate model id"
+          : source === "models.dev"
+            ? "models.dev"
+            : `${source} pricing`,
+    );
     expect(result.stderr.trim().split("\n").at(-1)).toBe("[publish-model-catalog] FAILED (exit 1)");
     expect(fs.readFileSync(out, "utf8")).toBe("previous published catalog\n");
   });


### PR DESCRIPTION
## What Problem This Solves

New upstream models required a manifest change before they could appear in the hosted catalog. A metadata outage could also replace a complete catalog with a smaller one.

## Why This Change Was Made

The publisher imports eligible metadata through provider-owned mappings, sharing one validated response with pricing. Explicit manifest values win; transport and pricing policy stay with their existing owners. Every output mode validates the completed bundle before publication. Failed hydration or invalid identifiers leave the previous output intact.

## User Impact

Compatible installations can discover new eligible models without per-model manifest updates. Authentication, allowlists, and endpoint restrictions remain in force. Applying downloaded updates still requires a Gateway restart.

## Evidence

Publisher failure injection reproduced catalog loss before the fix and preserved the prior artifact afterward. All 122 focused tests passed. Live publication with and without pricing produced 994 models; released readers and planners from 2026.8.1, 2026.8.2, and 2026.9.1 accepted the output. Inference was not tested for every model. Related validation repairs: #138238, #138094.

Consumers: the catalog publisher reads provider-owned mappings; catalog readers receive additional eligible model metadata.

Worked on by: @obviyus

Co-authored-by: obviyus <22031114+obviyus@users.noreply.github.com>
