### PR TITLE
improve: reuse UTF-8 encoding while fitting Code Mode output

### DIFF
--- a/src/agents/code-mode-json.ts
+++ b/src/agents/code-mode-json.ts
@@ -1,5 +1,5 @@
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
-import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
+import { createUtf8PrefixTruncator, truncateUtf8Prefix } from "../utils/utf8-truncate.js";
 import { toolResultFitsBudget, type ToolResultBudget } from "./tool-result-limits.js";
 import { renderToolSearchControlText } from "./tool-search-control-result.js";
 
@@ -74,17 +74,18 @@ const TRUNCATION_GUIDANCE = "Output truncated; rerun with narrower args.";
 function fitJsonPrefix<T>(text: string, maxBytes: number, project: (prefix: string) => T): T {
   let low = 0;
   let high = Math.min(Buffer.byteLength(text, "utf8"), maxBytes);
+  const prefix = createUtf8PrefixTruncator(text, Math.ceil(high));
   // JSON escaping makes serialized bytes cost more than raw prefix bytes.
   // Measure the complete projection so fitting cannot erase a useful prefix.
   while (low < high) {
     const middle = Math.ceil((low + high) / 2);
-    if (jsonUtf8Bytes(project(truncateUtf8Prefix(text, middle))) <= maxBytes) {
+    if (jsonUtf8Bytes(project(prefix(middle))) <= maxBytes) {
       low = middle;
     } else {
       high = middle - 1;
     }
   }
-  return project(truncateUtf8Prefix(text, low));
+  return project(prefix(low));
 }
 
 function truncationMarker(source: CodeModeJsonSource, maxBytes: number) {

--- a/src/utils/utf8-truncate.test.ts
+++ b/src/utils/utf8-truncate.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { truncateUtf8Prefix, truncateUtf8Suffix } from "./utf8-truncate.js";
+import {
+  createUtf8PrefixTruncator,
+  truncateUtf8Prefix,
+  truncateUtf8Suffix,
+} from "./utf8-truncate.js";
 
 describe("UTF-8 byte truncation", () => {
   it.each([
@@ -32,6 +36,14 @@ describe("UTF-8 byte truncation", () => {
   it("returns an empty string for a non-positive limit", () => {
     expect(truncateUtf8Prefix("value", 0)).toBe("");
     expect(truncateUtf8Suffix("value", -1)).toBe("");
+    expect(createUtf8PrefixTruncator("value", -1)(-1)).toBe("");
+    expect(createUtf8PrefixTruncator("value", 0)(0)).toBe("");
+  });
+
+  it("keeps prepared prefix reads independent across limits", () => {
+    const value = "a🌍\ud800z";
+    const prefix = createUtf8PrefixTruncator(value, 9);
+    expect([0, 1, 4, 5, 8, 9, 1].map(prefix)).toEqual(["", "a", "a", "a🌍", "a🌍�", value, "a"]);
   });
 
   it.each([
@@ -47,6 +59,7 @@ describe("UTF-8 byte truncation", () => {
     "preserves conversion and fractional limits for $value at $maxBytes bytes",
     ({ value, maxBytes, prefix, suffix }) => {
       expect(truncateUtf8Prefix(value, maxBytes)).toBe(prefix);
+      expect(createUtf8PrefixTruncator(value, maxBytes)(maxBytes)).toBe(prefix);
       expect(truncateUtf8Suffix(value, maxBytes)).toBe(suffix);
     },
   );

--- a/src/utils/utf8-truncate.ts
+++ b/src/utils/utf8-truncate.ts
@@ -4,6 +4,14 @@ function isContinuationByte(byte: number | undefined): boolean {
   return byte !== undefined && (byte & 0xc0) === 0x80;
 }
 
+function truncateEncodedPrefix(bytes: Buffer, maxBytes: number): string {
+  let end = maxBytes;
+  while (end > 0 && isContinuationByte(bytes[end])) {
+    end -= 1;
+  }
+  return bytes.subarray(0, end).toString("utf8");
+}
+
 /** Keeps the longest UTF-8 prefix that fits within the byte limit. */
 export function truncateUtf8Prefix(value: string, maxBytes: number): string {
   if (maxBytes <= 0) {
@@ -13,12 +21,21 @@ export function truncateUtf8Prefix(value: string, maxBytes: number): string {
     return value;
   }
   // Only this many UTF-16 units can contribute to the retained UTF-8 prefix.
-  const bytes = Buffer.from(value.slice(0, maxBytes));
-  let end = maxBytes;
-  while (end > 0 && isContinuationByte(bytes[end])) {
-    end -= 1;
+  return truncateEncodedPrefix(Buffer.from(value.slice(0, maxBytes)), maxBytes);
+}
+
+/** Reuses bounded encoding for repeated prefix limits no greater than maxBytes. */
+export function createUtf8PrefixTruncator(value: string, maxBytes: number) {
+  if (maxBytes <= 0) {
+    return () => "";
   }
-  return bytes.subarray(0, end).toString("utf8");
+  const bytes = Buffer.from(value.slice(0, maxBytes));
+  return (limit: number): string =>
+    limit <= 0
+      ? ""
+      : value.length <= limit && bytes.byteLength <= limit
+        ? value
+        : truncateEncodedPrefix(bytes, limit);
 }
 
 /** Keeps the longest UTF-8 suffix that fits within the byte limit. */


### PR DESCRIPTION
## What Problem This Solves

Fitting Code Mode output to a JSON budget repeatedly encoded the same string during binary-search trials.

## Why This Change Was Made

The result owner now prepares one bounded UTF-8 encoding per synchronous prefix search and shares the existing boundary decoder. One-shot truncation retains its allocation-free full-fit path. Nonpositive bounds return before encoding; prepared limits cannot exceed the bound used to create the helper.

## User Impact

Output, error text, Unicode handling and byte/context budgets remain unchanged. Production +18 LOC expresses the bound-owned prepared encoding and shared decoder; tests +13. No cache, public option or plugin SDK export is added.

## Evidence

- All 672 actual-owner projections match exactly across byte/context limits, errors, repeated waits and network content. Another 1,224 supported-bound comparisons match one-shot truncation, including fractional limits and lone surrogates.
- Ten fixed projections perform 340 string-to-Buffer conversions instead of 4,770. Their summed encoded byte volume falls from 45,335,820 to 4,406,570. Buffer pooling means this is conversion work, not physical allocation or retained memory.
- Independent review caught eager encoding for negative bounds in the first candidate. The corrected version eliminates that conversion; its original source, adverse allocation observation and correction proof remain retained. No whole-Gateway RSS or general throughput improvement is claimed.
- UTF-8, Code Mode output and result-budget tests pass, as does the canonical changed-file gate. Independent source review and managed Codex review through P2 are clean. Real Gateway oversized-Unicode output verification passed; details below.

The first hosted CI run failed on unchanged `src/node-host/runner.test.ts` exceeding the repository line limit (1,006 versus 1,000). That main-branch test cleanup is being repaired separately; this PR will not land until its checks pass.


## Real Gateway integration (2026-09-03)

A prebuilt, isolated Gateway with a real OpenAI API key passed four fixed turns: ordinary completion, real `web_fetch` of example.com, a 1.31 MB Unicode return through Code Mode, and a real MCP stdio tool with default and explicit arguments. Fifty-seven Gateway RPCs verified three session identities, full/repeated/paginated/subscribed list rows, descriptions and final previews, transcript completion, an explicit reconnect, empty approval replay and unsubscribe.

The MCP server observed the default `id: alpha` before server-side validation, followed by explicit `id: beta`; both nested call identities/order, structured results and metadata projection matched. The Unicode prefix remained well formed and within its byte budget with exact omitted-byte accounting. All four turns completed without retries.

The local immutable composite `3bb6e3164a06e5c35fb50b368cc63cbb05826384` contains the twelve published campaign changes through #137148, including this PR’s reviewed source. Source/build/dependency identity was checked before and after. Both clients closed, the Gateway exited successfully without escalation, all recorded MCP processes exited, and private state/port cleanup passed. This is functional integration proof; it does not attribute memory or latency differences to this PR.

## Scoped wall-time and RSS benchmark

A fixed ABBA run used fresh Node 26.8.1 processes, 10 warmup projections and 100 measured projections of the same oversized Unicode output/value through the actual Code Mode JSON owner. Every timed result digest matched across all four processes; source hashes were checked before and after. No Inspector sampling or forced GC was used.

| Arm | 100-projection wall time | Whole-process wall time | Peak RSS |
|---|---:|---:|---:|
| Baseline A1 | 1291.46 ms | 1.61 s | 145.06 MiB |
| Candidate B1 | 904.45 ms | 1.19 s | 131.33 MiB |
| Candidate B2 | 896.91 ms | 1.17 s | 130.73 MiB |
| Baseline A2 | 1286.85 ms | 1.61 s | 145.97 MiB |

Peak RSS is the macOS `/usr/bin/time -l` whole-process high-water mark, including imports and warmup. This narrow workload improved in both pairs, but two observations per arm do not establish a general throughput or retained-memory improvement. The separate real Gateway comparison is a different multi-change experiment and is not attributed to this PR. Earlier allocation samples, including the initial candidate's adverse result, remain recorded.

Benchmark source SHA-256: `9bb9264d3f749689961ee0f5ea960ca96097ec34361b5ff45c720490b34c7585`. Fixed output digest: `3419d9fdb044f9ddbe4a1fd92251b66a4275a2c0f8b3d25715de56c9a3c7ef24`. All four supervised processes exited zero; their process groups and private runtime directories were removed.
