### PR TITLE
refactor: unify approval subscription cleanup

### DIFF
--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -578,20 +578,7 @@ export function createSessionMessageSubscriberRegistry(
           connToSessionRecency.delete(normalizedConnId);
         }
       }
-      const approvalConnIds = approvalSessionToConnIds.get(normalizedSessionKey);
-      if (approvalConnIds) {
-        approvalConnIds.delete(normalizedConnId);
-        if (approvalConnIds.size === 0) {
-          approvalSessionToConnIds.delete(normalizedSessionKey);
-        }
-      }
-      const approvalSessionKeys = connToApprovalSessionKeys.get(normalizedConnId);
-      if (approvalSessionKeys) {
-        approvalSessionKeys.delete(normalizedSessionKey);
-        if (approvalSessionKeys.size === 0) {
-          connToApprovalSessionKeys.delete(normalizedConnId);
-        }
-      }
+      setApprovalSubscription(normalizedConnId, normalizedSessionKey, false);
     },
     unsubscribeAll: (connId: string) => {
       const normalizedConnId = normalize(connId);
@@ -614,13 +601,8 @@ export function createSessionMessageSubscriberRegistry(
 
       const approvalSessionKeys = connToApprovalSessionKeys.get(normalizedConnId);
       for (const sessionKey of approvalSessionKeys ?? []) {
-        const connIds = approvalSessionToConnIds.get(sessionKey);
-        connIds?.delete(normalizedConnId);
-        if (connIds?.size === 0) {
-          approvalSessionToConnIds.delete(sessionKey);
-        }
+        setApprovalSubscription(normalizedConnId, sessionKey, false);
       }
-      connToApprovalSessionKeys.delete(normalizedConnId);
     },
     get: (sessionKey: string) => {
       const normalizedSessionKey = normalize(sessionKey);


### PR DESCRIPTION
## What Problem This Solves

Single-session and connection teardown duplicated approval-index cleanup, giving the same bidirectional membership invariant several implementations.

## Why This Change Was Made

Both paths now call the registry's existing approval-subscription owner. Message callbacks, provisional replay invalidation and approval removal keep their original ordering. Connection cleanup deletes the current member of its private reverse Set through a synchronous helper with no callbacks or awaits.

## User Impact

Subscription, approval opt-in, replay, disconnect and retained recipient-Set behavior remain unchanged. Production −18 LOC; tests and support unchanged. This is a code ownership simplification, with no claimed speed or memory reduction.

## Evidence

The same actual registry trace produces 65 identical observations across ten scenarios: mixed memberships, two connections, retained recipient Sets, repeated cleanup, replay commit/rollback, reconnect, reentrant listeners and a throwing listener. The same 39 tests in four existing registry, RPC, approval-event and connection-liveness suites pass before and after. The canonical changed-file gate passes; managed Codex review through P2 is clean.

Connection teardown now performs per-member reverse-index deletion rather than dropping the bucket once; both remain linear. No authorization, public schema, configuration or persistence semantics change. Real Gateway subscription, empty approval replay, reconnect and teardown coverage passed; details below.


## Real Gateway integration (2026-09-03)

A prebuilt, isolated Gateway with a real OpenAI API key passed four fixed turns: ordinary completion, real `web_fetch` of example.com, a 1.31 MB Unicode return through Code Mode, and a real MCP stdio tool with default and explicit arguments. Fifty-seven Gateway RPCs verified three session identities, full/repeated/paginated/subscribed list rows, descriptions and final previews, transcript completion, an explicit reconnect, empty approval replay and unsubscribe.

The MCP server observed the default `id: alpha` before server-side validation, followed by explicit `id: beta`; both nested call identities/order, structured results and metadata projection matched. The Unicode prefix remained well formed and within its byte budget with exact omitted-byte accounting. All four turns completed without retries.

The local immutable composite `3bb6e3164a06e5c35fb50b368cc63cbb05826384` contains the twelve published campaign changes through #137148, including this PR’s reviewed source. Source/build/dependency identity was checked before and after. Both clients closed, the Gateway exited successfully without escalation, all recorded MCP processes exited, and private state/port cleanup passed. This is functional integration proof; it does not attribute memory or latency differences to this PR.
