### PR TITLE
fix(release): assert the Codex CLI pin the candidate declares

### DIFF
--- a/scripts/e2e/codex-npm-plugin-live-docker.sh
+++ b/scripts/e2e/codex-npm-plugin-live-docker.sh
@@ -204,6 +204,7 @@ echo "Running Codex npm plugin live Docker E2E..."
 echo "Profile file: $PROFILE_STATUS"
 echo "Codex plugin spec: $CODEX_PLUGIN_SPEC"
 if ! docker_e2e_run_with_harness \
+  -v "$CANDIDATE_ROOT/extensions/codex/package.json:/tmp/openclaw-candidate-codex-package.json:ro" \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e OPENCLAW_CODEX_NPM_PLUGIN_ALLOW_BETA_COMPAT_DIAGNOSTICS="${OPENCLAW_CODEX_NPM_PLUGIN_ALLOW_BETA_COMPAT_DIAGNOSTICS:-0}" \
   -e OPENCLAW_CODEX_NPM_PLUGIN_FORCE_UNSAFE_INSTALL="${OPENCLAW_CODEX_NPM_PLUGIN_FORCE_UNSAFE_INSTALL:-1}" \

--- a/scripts/e2e/codex-on-demand-docker.sh
+++ b/scripts/e2e/codex-on-demand-docker.sh
@@ -68,6 +68,7 @@ OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 codex-on-deman
 
 echo "Running Codex on-demand Docker E2E..."
 if ! docker_e2e_run_with_harness \
+  -v "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}/extensions/codex/package.json:/tmp/openclaw-candidate-codex-package.json:ro" \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \

--- a/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
+++ b/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
@@ -467,7 +467,6 @@ function assertNpmDeps(options = {}) {
   if (!openAiCodexPackageJson) {
     throw new Error("missing @openai/codex dependency under .openclaw/npm");
   }
-  assertPathInside(npmRoot, openAiCodexPackageJson, "@openai/codex dependency");
 
   assertCodexReleasePackageContract({
     pluginPackageJson,

--- a/scripts/e2e/lib/codex-on-demand/assertions.mjs
+++ b/scripts/e2e/lib/codex-on-demand/assertions.mjs
@@ -64,7 +64,6 @@ const openAiCodexPackageJson = findPackageJson("@openai/codex", [
 if (!openAiCodexPackageJson) {
   throw new Error("missing @openai/codex dependency under managed npm root");
 }
-assertPathInside(npmRoot, openAiCodexPackageJson, "@openai/codex dependency");
 assertCodexReleasePackageContract({
   pluginPackageJson: codexPackageJson,
   codexPackageJson: openAiCodexPackageJson,

--- a/scripts/e2e/lib/codex-release-package-assertions.mjs
+++ b/scripts/e2e/lib/codex-release-package-assertions.mjs
@@ -4,7 +4,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { assertPathInside, findPackageJson, readJson } from "./codex-install-utils.mjs";
 
-const EXPECTED_CODEX_VERSION = "0.153.0";
 const CODEX_PLATFORM_TARGETS = new Map([
   ["linux:x64", { alias: "@openai/codex-linux-x64", os: "linux", cpu: "x64" }],
   ["linux:arm64", { alias: "@openai/codex-linux-arm64", os: "linux", cpu: "arm64" }],
@@ -18,12 +17,6 @@ function exactStringArray(value, expected) {
   return Array.isArray(value) && value.length === 1 && value[0] === expected;
 }
 
-function recordEvidence(evidence) {
-  for (const [key, value] of Object.entries(evidence)) {
-    process.stdout.write(`[codex-release] ${key}=${value}\n`);
-  }
-}
-
 export function assertCodexReleasePackageContract(params) {
   const platform = params.platform ?? process.platform;
   const arch = params.arch ?? process.arch;
@@ -32,11 +25,14 @@ export function assertCodexReleasePackageContract(params) {
     throw new Error(`unsupported Codex release platform: ${platform}/${arch}`);
   }
 
+  // The lane mounts candidate metadata separately from the trusted harness checkout.
+  const candidate = readJson("/tmp/openclaw-candidate-codex-package.json");
+  const expectedVersion = candidate.dependencies?.["@openai/codex"];
   const pluginPackage = readJson(params.pluginPackageJson);
-  const expectedDependency = pluginPackage.dependencies?.["@openai/codex"];
-  if (expectedDependency !== EXPECTED_CODEX_VERSION) {
+  const dependency = pluginPackage.dependencies?.["@openai/codex"];
+  if (!/^\d+\.\d+\.\d+(?:-[\w.-]+)?$/u.test(expectedVersion) || dependency !== expectedVersion) {
     throw new Error(
-      `@openclaw/codex must depend on @openai/codex ${EXPECTED_CODEX_VERSION}; found ${String(expectedDependency)}`,
+      `@openclaw/codex must depend on @openai/codex ${expectedVersion}; found ${String(dependency)}`,
     );
   }
   const requiredPlatformPackages = pluginPackage.openclaw?.install?.requiredPlatformPackages;
@@ -51,12 +47,12 @@ export function assertCodexReleasePackageContract(params) {
 
   assertPathInside(params.managedRoot, params.codexPackageJson, "@openai/codex dependency");
   const codexPackage = readJson(params.codexPackageJson);
-  if (codexPackage.version !== EXPECTED_CODEX_VERSION) {
+  if (codexPackage.version !== expectedVersion) {
     throw new Error(
-      `installed @openai/codex version mismatch: expected ${EXPECTED_CODEX_VERSION}, got ${String(codexPackage.version)}`,
+      `installed @openai/codex version mismatch: expected ${expectedVersion}, got ${String(codexPackage.version)}`,
     );
   }
-  const expectedAliasSpec = `npm:@openai/codex@${EXPECTED_CODEX_VERSION}-${platform}-${arch}`;
+  const expectedAliasSpec = `npm:@openai/codex@${expectedVersion}-${platform}-${arch}`;
   if (codexPackage.optionalDependencies?.[target.alias] !== expectedAliasSpec) {
     throw new Error(
       `@openai/codex current platform alias mismatch: expected ${target.alias}=${expectedAliasSpec}`,
@@ -69,7 +65,7 @@ export function assertCodexReleasePackageContract(params) {
   }
   assertPathInside(params.managedRoot, platformPackageJson, "Codex platform package");
   const platformPackage = readJson(platformPackageJson);
-  const expectedPlatformVersion = `${EXPECTED_CODEX_VERSION}-${platform}-${arch}`;
+  const expectedPlatformVersion = `${expectedVersion}-${platform}-${arch}`;
   if (platformPackage.version !== expectedPlatformVersion) {
     throw new Error(
       `installed ${target.alias} version mismatch: expected ${expectedPlatformVersion}, got ${String(platformPackage.version)}`,
@@ -115,9 +111,9 @@ export function assertCodexReleasePackageContract(params) {
     );
   }
   const versionMatch = /^codex-cli\s+(\S+)$/u.exec(stdout);
-  if (versionMatch?.[1] !== EXPECTED_CODEX_VERSION) {
+  if (versionMatch?.[1] !== expectedVersion) {
     throw new Error(
-      `managed Codex CLI version mismatch: expected ${EXPECTED_CODEX_VERSION}, got ${JSON.stringify(stdout)}`,
+      `managed Codex CLI version mismatch: expected ${expectedVersion}, got ${JSON.stringify(stdout)}`,
     );
   }
 
@@ -130,7 +126,9 @@ export function assertCodexReleasePackageContract(params) {
     platformCpu: target.cpu,
   };
   if (params.recordEvidence !== false) {
-    recordEvidence(evidence);
+    for (const [key, value] of Object.entries(evidence)) {
+      process.stdout.write(`[codex-release] ${key}=${value}\n`);
+    }
   }
   return { codexBin, evidence };
 }

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -864,15 +864,20 @@ describe("Codex install helpers", () => {
 
   it.each([undefined, "^0.152.1", "latest"])("rejects a non-exact candidate pin %s", (pin) => {
     const root = makeTempDir(tempDirs, "openclaw-codex-candidate-invalid-pin-");
-    createCodexInstallFixture(root);
+    const fixture = createCodexInstallFixture(root);
     writeJson("/tmp/openclaw-candidate-codex-package.json", {
       dependencies: { "@openai/codex": pin },
     });
+    const pluginPackage = JSON.parse(readFileSync(fixture.pluginPackageJson, "utf8"));
+    pluginPackage.dependencies["@openai/codex"] = pin;
+    writeJson(fixture.pluginPackageJson, pluginPackage);
 
     const result = runCodexOnDemandAssertions(root);
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("@openclaw/codex must depend on @openai/codex");
+    expect(result.stderr).toContain(
+      `@openclaw/codex must depend on @openai/codex ${String(pin)}; found ${String(pin)}`,
+    );
   });
 
   it("rejects an installed @openai/codex package outside the exact release version", () => {

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -18,9 +18,11 @@ const CODEX_ON_DEMAND_ASSERTIONS_SCRIPT = "scripts/e2e/lib/codex-on-demand/asser
 const CODEX_NPM_PLUGIN_LIVE_ASSERTIONS_SCRIPT =
   "scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs";
 const DISABLE_EXPERIMENTAL_WARNING = "--disable-warning=ExperimentalWarning";
-const CODEX_VERSION = "0.153.0";
+// Frozen candidate deliberately differs from the trusted checkout pin.
+const CODEX_VERSION = "0.152.1";
 const tempDirs: string[] = [];
 const tmpFixtureFiles = [
+  "/tmp/openclaw-candidate-codex-package.json",
   "/tmp/openclaw-codex-agent.err",
   "/tmp/openclaw-codex-agent.json",
   "/tmp/openclaw-codex-agent-after-uninstall.err",
@@ -565,6 +567,9 @@ function currentCodexPlatformTarget() {
 }
 
 function createCodexInstallFixture(root: string) {
+  writeJson("/tmp/openclaw-candidate-codex-package.json", {
+    dependencies: { "@openai/codex": CODEX_VERSION },
+  });
   const stateDir = path.join(root, "state");
   const npmRoot = path.join(stateDir, "npm");
   const installPath = path.join(npmRoot, "projects", "codex", "node_modules", "@openclaw", "codex");
@@ -837,6 +842,37 @@ describe("Codex install helpers", () => {
     expect(result.stdout).toContain(
       `[codex-release] platformAlias=${currentCodexPlatformTarget().alias}`,
     );
+  });
+
+  it.each([
+    ["on-demand", runCodexOnDemandAssertions],
+    ["npm-live", runCodexNpmPluginLiveDependencyAssertions],
+  ] as const)("rejects %s plugin pins that differ from the candidate", (_lane, runAssertions) => {
+    const root = makeTempDir(tempDirs, "openclaw-codex-candidate-pin-");
+    const fixture = createCodexInstallFixture(root);
+    const pluginPackage = JSON.parse(readFileSync(fixture.pluginPackageJson, "utf8"));
+    pluginPackage.dependencies["@openai/codex"] = "0.153.0";
+    writeJson(fixture.pluginPackageJson, pluginPackage);
+
+    const result = runAssertions(root);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      `@openclaw/codex must depend on @openai/codex ${CODEX_VERSION}; found 0.153.0`,
+    );
+  });
+
+  it.each([undefined, "^0.152.1", "latest"])("rejects a non-exact candidate pin %s", (pin) => {
+    const root = makeTempDir(tempDirs, "openclaw-codex-candidate-invalid-pin-");
+    createCodexInstallFixture(root);
+    writeJson("/tmp/openclaw-candidate-codex-package.json", {
+      dependencies: { "@openai/codex": pin },
+    });
+
+    const result = runCodexOnDemandAssertions(root);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("@openclaw/codex must depend on @openai/codex");
   });
 
   it("rejects an installed @openai/codex package outside the exact release version", () => {


### PR DESCRIPTION
Related: #136918 (make plugin dependency freshness advisory for frozen releases).

## What Problem This Solves

Resolves a problem where release operators validating the frozen 2026.9.1 candidate with newer trusted tooling hit false failures in `codex-on-demand` and `live-codex-npm-plugin`. [Full Release Validation 33722524584](https://github.com/openclaw/openclaw/actions/runs/33722524584) hit this in [Docker job 100549513614](https://github.com/openclaw/openclaw/actions/runs/33723822495/job/100549513614): the candidate declares Codex CLI `0.152.1`, while the tooling required main's `0.153.0`.

## Why This Change Was Made

Each lane mounts its candidate checkout's `extensions/codex/package.json` read-only, separately from the trusted harness, and the shared assertion uses that manifest's exact CLI pin. It still requires the installed plugin dependency, resolved CLI package, platform alias specification/version, and executable `--version` to match that pin, retaining platform metadata and managed-path containment checks.

The candidate checkout already owns package/plugin preparation: on-demand receives `OPENCLAW_DOCKER_E2E_REPO_ROOT`, and npm-live uses `CANDIDATE_ROOT`. The core tarball excludes `dist/extensions/codex/**`, and its external-plugin catalog has no CLI pin; using the installed plugin alone would lose the independent candidate/plugin comparison. Duplicate caller containment checks and a one-use evidence writer are removed.

## User Impact

Release operators can validate a self-consistent frozen candidate after main advances its Codex version. Candidate/plugin mismatches and non-exact pins remain blocking. No candidate, runtime, configuration, environment option, dependency version, or publication change.

## Evidence

- Before: the two archived CI lane logs show `@openclaw/codex must depend on @openai/codex 0.153.0; found 0.152.1`. The frozen unit fixtures also fail against the original assertion for this mismatch.
- `pnpm test test/scripts/codex-install-assertions.test.ts test/scripts/codex-client-version-contract.test.ts`: **51 passed**. Both callers accept the frozen pin and reject a plugin pin differing from the candidate; the three non-exact candidate-pin cases now use the same invalid pin in candidate and plugin metadata, fail against pre-fix code for the intended hardcoded-version error, and pass on this branch. Existing installed-package, platform, CLI, and missing-native-binary checks remain covered.
- `pnpm check:changed`: **passed**. `bash -n` for both changed Docker scripts and `git diff --check` also passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base 7aff510afad21033fd0e7cd9bfc8197fdab1d4f3 --max-priority P2`: **scoped-clean**, no actionable P0–P2 findings after the invalid-pin test correction. Intervening main changes did not touch these files, and the current three-way merge is clean.
- Frozen candidate `904200199c209c1abeaa42914e6359e5cb36afc4`: `pnpm install && pnpm build` **passed** in a second detached worktree. `node scripts/package-openclaw-for-docker.mjs --source-dir "$candidate" --skip-build --output-dir "$candidate/.artifacts/codex-pin-proof" --output-name openclaw-current.tgz` **passed**, including tarball integrity/import-graph checks. Core tarball SHA-256: `91b3d3f7392310bd45a6b704af1630e1977e5c8c3959a78890569d1a88284709`.
- The existing `prepublish-plugin-registry-artifact.mjs create` helper built the companion from that same clean frozen checkout; packed `@openclaw/codex@2026.9.1` declares `@openai/codex: 0.152.1`.

Tooling LOC: **+17/-19 (net −2)**; tests: **+42/-1**. Direct Codex source inspection at `728cb12fe5794b0c3a8e776fb4994b1650b973a8` confirmed the platform aliases in `codex-cli/bin/codex.js`, npm alias/version generation in `codex-cli/scripts/build_npm_package.py`, and the CLI package/bin contract in `codex-cli/package.json`.

Local Docker proof used the exact lane command below on Linux ARM64 (CI was Linux x64), with the same rebuilt core/plugin artifacts for both runs:

```bash
OPENCLAW_SKIP_DOCKER_BUILD=1 \
OPENCLAW_DOCKER_E2E_IMAGE=openclaw-codex-pin-proof:bare \
OPENCLAW_DOCKER_E2E_REPO_ROOT="$candidate" \
OPENCLAW_DOCKER_E2E_SELECTED_SHA=904200199c209c1abeaa42914e6359e5cb36afc4 \
OPENCLAW_CURRENT_PACKAGE_TGZ="$candidate/.artifacts/codex-pin-proof/openclaw-current.tgz" \
OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR="$candidate/.artifacts/codex-pin-proof/registry" \
OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION=2026.9.1 \
bash scripts/e2e/codex-on-demand-docker.sh
```

- Original tooling `13799ec4f8380c14f7ce1836ce611291254bdda2`: **exit 1**, reproducing `must depend on @openai/codex 0.153.0; found 0.152.1` at the shared assertion.
- PR head `4a9f799ae6cbff007f0bfb6f1ca0ee0507b2137b`: **exit 0**, full `Codex on-demand Docker E2E passed`. Evidence: package and CLI `0.152.1`, platform alias `@openai/codex-linux-arm64`, platform version `0.152.1-linux-arm64`, OS `linux`, CPU `arm64`. The managed-app-server doctor check returned `ok:true` with zero findings. Ordinary doctor completed 30 checks with the empty-fixture heartbeat and loopback onboarding warnings expected by the lane.

Not rerun: hosted Full Release Validation/Linux x64 lanes or credentialed live Codex agent turns. Both assertion callers are covered by unit tests; real Docker proof covers installation, onboarding, native CLI execution, and doctor. The release candidate remains unchanged.
