### PR TITLE
fix(qa): keep repeated Telegram RTT on the selected scenario route

### DIFF
--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -289,7 +289,9 @@ inside every shard.
     fail immediately, while unknown or inapplicable ids fail canonical scenario
     validation. The package runner promotes the selected RTT scenario once to
     the first position before the remaining taxonomy-backed fail-fast release
-    scenarios.
+    scenarios. Repeated probes use that scenario's declared
+    `execution.config.conversationId` and transport policy, so DM-only scenarios
+    stay in DMs while mention-gated scenarios stay in groups.
   - Uses the same Convex-leased Test Server userbot credentials as
     `pnpm openclaw qa telegram`. Set `OPENCLAW_QA_CONVEX_SITE_URL` and the
     secret for the selected role. The Docker wrapper selects Convex by default.

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -73,16 +73,17 @@ describe("qa scenario catalog channel contracts", () => {
   it("runs the Telegram RTT exact-marker scenario through an isolated direct message", () => {
     const scenario = requireFlowScenario(readQaScenarioById("telegram-reply-chain-exact-marker"));
     expect(scenario.execution.transportPolicy).toEqual({ directMessageOnly: true });
+    expect(scenario.execution.config?.conversationId).toBe("telegram-reply-chain-dm");
     expect(scenario.execution.flow?.steps[0]?.actions).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           sendInbound: expect.objectContaining({
-            conversation: { id: "telegram-reply-chain-dm", kind: "direct" },
+            conversation: { id: { ref: "config.conversationId" }, kind: "direct" },
           }),
         }),
         expect.objectContaining({
           waitForOutbound: expect.objectContaining({
-            conversation: { id: "telegram-reply-chain-dm", kind: "direct" },
+            conversation: { id: { ref: "config.conversationId" }, kind: "direct" },
           }),
         }),
       ]),

--- a/extensions/qa-lab/src/suite-round-trip.test.ts
+++ b/extensions/qa-lab/src/suite-round-trip.test.ts
@@ -1,7 +1,52 @@
 import { describe, expect, it, vi } from "vitest";
-import { runQaSuiteRoundTripProbe } from "./suite-round-trip.js";
+import {
+  resolveQaSuiteRoundTripConversation,
+  runQaSuiteRoundTripProbe,
+} from "./suite-round-trip.js";
 
 describe("QA suite round-trip probe", () => {
+  it.each([
+    {
+      policy: { directMessageOnly: true },
+      conversationId: "telegram-reply-chain-dm",
+      expected: { id: "telegram-reply-chain-dm", kind: "direct" },
+    },
+    {
+      policy: { requireGroupMention: true },
+      conversationId: "qa-routing-primary",
+      expected: { id: "qa-routing-primary", kind: "group" },
+    },
+  ])("resolves the scenario-owned $expected.kind route", ({ policy, conversationId, expected }) => {
+    expect(
+      resolveQaSuiteRoundTripConversation({
+        id: "scenario",
+        execution: { transportPolicy: policy, config: { conversationId } },
+      }),
+    ).toEqual(expected);
+  });
+
+  it.each([
+    {
+      execution: { transportPolicy: { directMessageOnly: true }, config: {} },
+      error: "must declare config.conversationId",
+    },
+    {
+      execution: {
+        transportPolicy: { directMessageOnly: true, requireGroupMention: true },
+        config: { conversationId: "room" },
+      },
+      error: "declares conflicting transport routes",
+    },
+    {
+      execution: { transportPolicy: {}, config: { conversationId: "room" } },
+      error: "does not declare a supported transport route",
+    },
+  ])("rejects invalid scenario route declarations: $error", ({ execution, error }) => {
+    expect(() =>
+      resolveQaSuiteRoundTripConversation({ id: "invalid-scenario", execution }),
+    ).toThrow(error);
+  });
+
   it("collects requested samples and chains native replies", async () => {
     const messages: Array<{ direction: "outbound"; id: string }> = [];
     const sendInbound = vi.fn().mockResolvedValue({ id: "inbound" });

--- a/extensions/qa-lab/src/suite-round-trip.ts
+++ b/extensions/qa-lab/src/suite-round-trip.ts
@@ -5,6 +5,11 @@ import {
 } from "./live-transports/shared/live-transport-rtt.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 import type { QaBusInboundMessageInput } from "./runtime-api.js";
+import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
+
+type QaSuiteRoundTripScenario = Pick<QaSeedScenarioWithSource, "id"> & {
+  execution: Pick<QaSeedScenarioWithSource["execution"], "transportPolicy" | "config">;
+};
 
 export type QaSuiteRoundTripProbe = {
   scenarioId: string;
@@ -16,6 +21,23 @@ export type QaSuiteRoundTripProbe = {
   textPrefix: string;
   chainReplies?: boolean;
 };
+
+export function resolveQaSuiteRoundTripConversation(
+  scenario: QaSuiteRoundTripScenario,
+): QaBusInboundMessageInput["conversation"] {
+  const { directMessageOnly, requireGroupMention } = scenario.execution.transportPolicy ?? {};
+  const conversationId = scenario.execution.config?.conversationId;
+  if (typeof conversationId !== "string" || !conversationId.trim()) {
+    throw new Error(`QA RTT scenario ${scenario.id} must declare config.conversationId`);
+  }
+  if (directMessageOnly && requireGroupMention) {
+    throw new Error(`QA RTT scenario ${scenario.id} declares conflicting transport routes`);
+  }
+  if (!directMessageOnly && !requireGroupMention) {
+    throw new Error(`QA RTT scenario ${scenario.id} does not declare a supported transport route`);
+  }
+  return { id: conversationId.trim(), kind: directMessageOnly ? "direct" : "group" };
+}
 
 export async function runQaSuiteRoundTripProbe(params: {
   probe: QaSuiteRoundTripProbe;

--- a/qa/scenarios/channels/telegram-reply-chain-exact-marker.yaml
+++ b/qa/scenarios/channels/telegram-reply-chain-exact-marker.yaml
@@ -22,6 +22,7 @@ scenario:
     summary: Request one exact Telegram marker and verify single-message delivery.
     config:
       requiredProviderMode: mock-openai
+      conversationId: telegram-reply-chain-dm
       marker: QA-TELEGRAM-REPLY-CHAIN-OK
 
 flow:
@@ -33,13 +34,13 @@ flow:
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - sendInbound:
-            conversation: { id: telegram-reply-chain-dm, kind: direct }
+            conversation: { id: { ref: config.conversationId }, kind: direct }
             senderId: qa-command-operator
             senderName: QA Command Operator
             text:
               expr: "`Telegram reply-chain marker QA. Reply exactly: ${config.marker}`"
         - waitForOutbound:
-            conversation: { id: telegram-reply-chain-dm, kind: direct }
+            conversation: { id: { ref: config.conversationId }, kind: direct }
             sinceIndex: { ref: startIndex }
             textIncludes: { ref: config.marker }
             timeoutMs: 90000

--- a/scripts/e2e/npm-telegram-live-runner.ts
+++ b/scripts/e2e/npm-telegram-live-runner.ts
@@ -7,7 +7,10 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { QaProviderMode } from "../../extensions/qa-lab/src/run-config.ts";
-import type { QaSuiteRoundTripProbe } from "../../extensions/qa-lab/src/suite-round-trip.ts";
+import {
+  resolveQaSuiteRoundTripConversation,
+  type QaSuiteRoundTripProbe,
+} from "../../extensions/qa-lab/src/suite-round-trip.ts";
 import { normalizeCsvOrLooseStringList } from "../../packages/normalization-core/src/string-normalization.ts";
 import { isStrictAffirmativeValue } from "../lib/arg-utils.mts";
 import { compareReleaseVersions } from "../lib/release-version.mjs";
@@ -168,15 +171,19 @@ function resolveRttOptions(env: NodeJS.ProcessEnv, selectedScenarioIds: readonly
 
 function createRoundTripProbe(
   options: ReturnType<typeof resolveRttOptions>,
+  scenario?: Parameters<typeof resolveQaSuiteRoundTripConversation>[0],
 ): QaSuiteRoundTripProbe | undefined {
   if (!options) {
     return undefined;
+  }
+  if (!scenario) {
+    throw new Error(`missing QA RTT scenario: ${options.scenarioId}`);
   }
   return {
     ...options,
     markerPrefix: "QA-TELEGRAM-RTT",
     input: {
-      conversation: { id: "telegram-rtt-room", kind: "group" },
+      conversation: resolveQaSuiteRoundTripConversation(scenario),
       senderId: "qa-rtt-driver",
       senderName: "QA RTT Driver",
     },
@@ -245,10 +252,12 @@ async function main() {
     { runQaTelegramSuite },
     { resolveTelegramQaScenarioIds },
     { DEFAULT_QA_LIVE_PROVIDER_MODE },
+    { readQaScenarioById },
   ] = await Promise.all([
     import("../../extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts"),
     import("../../extensions/qa-lab/src/live-transports/telegram/scenario-selection.ts"),
     import("../../extensions/qa-lab/src/providers/index.ts"),
+    import("../../extensions/qa-lab/src/scenario-catalog.ts"),
   ]);
   const rawSutOpenClawCommand = process.env.OPENCLAW_NPM_TELEGRAM_SUT_COMMAND?.trim();
   if (!rawSutOpenClawCommand) {
@@ -273,6 +282,7 @@ async function main() {
       }),
   );
   const rttOptions = resolveRttOptions(process.env, scenarioIds);
+  const rttScenario = rttOptions ? readQaScenarioById(rttOptions.scenarioId) : undefined;
   const result = await runQaTelegramSuite({
     allowFailures: true,
     failFast: true,
@@ -285,7 +295,7 @@ async function main() {
     fastMode: isStrictAffirmativeValue(process.env.OPENCLAW_NPM_TELEGRAM_FAST),
     scenarioIds,
     resolvedScenarioIds: prioritizeRoundTripProbeScenario(resolvedScenarioIds, rttOptions),
-    roundTripProbe: createRoundTripProbe(rttOptions),
+    roundTripProbe: createRoundTripProbe(rttOptions, rttScenario),
     ...(mutateConfig ? { mutateConfig } : {}),
     sutAccountId: process.env.OPENCLAW_NPM_TELEGRAM_SUT_ACCOUNT,
     credentialSource: resolveCredentialSource(process.env),

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -411,19 +411,34 @@ describe("package Telegram live Docker E2E", () => {
     ).toThrow("unknown QA scenario id(s): telegram-unknown-rtt-check");
   });
 
-  it("builds a generic suite probe for the Telegram RTT lane", () => {
-    const probe = testing.createRoundTripProbe(testing.resolveRttOptions({}));
-
-    expect(probe).toMatchObject({
+  it.each([
+    {
+      name: "default canary group",
+      env: {},
       scenarioId: "channel-canary",
+      policy: { requireGroupMention: true },
+      conversation: { id: "qa-routing-primary", kind: "group" },
+    },
+    {
+      name: "selected exact-marker direct message",
+      env: { OPENCLAW_NPM_TELEGRAM_RTT_CHECKS: "telegram-reply-chain-exact-marker" },
+      scenarioId: "telegram-reply-chain-exact-marker",
+      policy: { directMessageOnly: true },
+      conversation: { id: "telegram-reply-chain-dm", kind: "direct" },
+    },
+  ] as const)("builds the $name RTT route", ({ env, scenarioId, policy, conversation }) => {
+    const probe = testing.createRoundTripProbe(testing.resolveRttOptions(env), {
+      id: scenarioId,
+      execution: { transportPolicy: policy, config: { conversationId: conversation.id } },
+    });
+    expect(probe).toMatchObject({
+      scenarioId,
       count: 20,
       timeoutMs: 30_000,
       markerPrefix: "QA-TELEGRAM-RTT",
       textPrefix: "@openclaw Telegram RTT check. Reply exactly: ",
       chainReplies: true,
-      input: {
-        conversation: { id: "telegram-rtt-room", kind: "group" },
-      },
+      input: { conversation },
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where repeated Telegram RTT checks for a selected direct-message scenario were sent through a hard-coded group conversation instead of the scenario's logical conversation.

## Why This Change Was Made

The selected catalog scenario now owns the RTT conversation ID and direct/group policy. A canonical QA resolver rejects missing, conflicting, or unsupported declarations, while the existing channel-canary remains on `qa-routing-primary` as a group route. No scenario-ID special cases, action parsing, or new RTT route input were added.

## User Impact

Telegram release validation can repeatedly exercise a DM-only scenario in its declared DM conversation without silently switching to a group. Mention-gated group scenarios keep their existing route.

## Evidence

- Pre-fix regression: the selected `telegram-reply-chain-exact-marker` case expected `telegram-reply-chain-dm/direct` but received `telegram-rtt-room/group`.
- Focused tests: 82 passed across `test/scripts/npm-telegram-live.test.ts`, `extensions/qa-lab/src/suite-round-trip.test.ts`, and `extensions/qa-lab/src/scenario-catalog-channels.test.ts`.
- Exact-head Testbox proof at `6049c3918826e742ca91cb10d5db78d5a7607a0e`: provider `blacksmith-testbox`, lease `tbx_01m1k2gfsfzgmds5cyqvzp3ay0`, run https://github.com/openclaw/openclaw/actions/runs/33727995380.
- Testbox command: `CI=1 node scripts/run-vitest.mjs extensions/qa-lab/src/suite-round-trip.test.ts extensions/qa-lab/src/scenario-catalog-channels.test.ts test/scripts/npm-telegram-live.test.ts`; result: 3 files, 82/82 tests passed, one-shot lease stopped after success.
- Direct lint and typed root-test lint passed; targeted formatting and `git diff --check` passed.
- `check-changed` passed its first 12 gates, then stopped in the unrelated plugin doctor declaration test because the shared workspace is missing `@noble/hashes/sha2.js`; extension boundary preparation also reports missing markdown/phone dependencies.
- Test audit: the runner regression fails on pre-fix code for the DM-to-group mismatch; resolver/catalog coverage protects independent route-declaration contracts without a test-only seam.
- Independent Sol/high autoreview: scoped-clean, no P0-P2 findings.
- Telegram Test Server direct + group proof: blocked before lease acquisition. `telegram-test-doctor.mjs` returned `ok:false` because this host has neither an authenticated `convex` CLI nor the non-interactive Convex broker environment pair. No Telegram action was sent. Direct and group proof remain an explicit gate; deterministic Testbox coverage does not replace that live proof.

Production/tooling LOC: +38/-5 (net +33). Tests: +71/-10. Docs: +3/-1.
