### PR TITLE
improve: avoid unused channel metadata work during plugin setup

### DIFF
--- a/src/agents/provider-auth-aliases.test.ts
+++ b/src/agents/provider-auth-aliases.test.ts
@@ -9,7 +9,7 @@ const pluginRegistryMocks = vi.hoisted(() => {
   return {
     loadPluginManifestRegistryForInstalledIndex: loadManifestRegistry,
     loadPluginManifestRegistryForPluginRegistry: loadManifestRegistry,
-    loadPluginRegistrySnapshot: vi.fn(() => ({ plugins: [] })),
+    loadPluginRegistrySnapshotWithMetadata: vi.fn(() => ({ snapshot: { plugins: [] } })),
     resolveInstalledManifestRegistryIndexFingerprint: vi.fn(() => "test-index"),
     loadPluginMetadataSnapshot: vi.fn((params: unknown) => {
       const registry = loadManifestRegistry(params) ?? { plugins: [], diagnostics: [] };
@@ -38,7 +38,8 @@ vi.mock("../plugins/manifest-registry-installed.js", () => ({
 vi.mock("../plugins/plugin-registry.js", () => ({
   loadPluginManifestRegistryForPluginRegistry:
     pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry,
-  loadPluginRegistrySnapshot: pluginRegistryMocks.loadPluginRegistrySnapshot,
+  loadPluginRegistrySnapshotWithMetadata:
+    pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata,
 }));
 
 vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
@@ -163,8 +164,10 @@ describe("provider auth aliases", () => {
       plugins: [],
       diagnostics: [],
     });
-    pluginRegistryMocks.loadPluginRegistrySnapshot.mockReset();
-    pluginRegistryMocks.loadPluginRegistrySnapshot.mockReturnValue({ plugins: [] });
+    pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReset();
+    pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      snapshot: { plugins: [] },
+    });
     pluginRegistryMocks.loadPluginMetadataSnapshot.mockClear();
   });
 

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -497,6 +497,23 @@ function toPluginCandidate(
   );
 }
 
+/** Selects installed owners without projecting unrelated manifest fields. */
+export function selectInstalledPluginManifestRecords(
+  index: InstalledPluginIndex,
+  registry: PluginManifestRegistry,
+  pluginIds: ReadonlySet<string> | null,
+  includeDisabled?: boolean,
+): PluginManifestRecord[] {
+  const enabledPluginIds = new Set(
+    index.plugins
+      .filter((plugin) => includeDisabled || plugin.enabled)
+      .map((plugin) => plugin.pluginId),
+  );
+  return registry.plugins
+    .filter((plugin) => enabledPluginIds.has(plugin.id))
+    .filter((plugin) => !pluginIds || pluginIds.has(plugin.id));
+}
+
 export function loadPluginManifestRegistryForInstalledIndex(params: {
   index: InstalledPluginIndex;
   manifestRegistry?: PluginManifestRegistry;
@@ -522,16 +539,13 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
           })
         : params.index.diagnostics;
       if (params.manifestRegistry && !params.bundledChannelConfigCollector) {
-        const enabledPluginIds = new Set(
-          params.index.plugins
-            .filter((plugin) => params.includeDisabled || plugin.enabled)
-            .map((plugin) => plugin.pluginId),
-        );
         return {
-          plugins: params.manifestRegistry.plugins
-            .filter((plugin) => enabledPluginIds.has(plugin.id))
-            .filter((plugin) => !pluginIdSet || pluginIdSet.has(plugin.id))
-            .map(normalizePreparedManifestRecord),
+          plugins: selectInstalledPluginManifestRecords(
+            params.index,
+            params.manifestRegistry,
+            pluginIdSet,
+            params.includeDisabled,
+          ).map(normalizePreparedManifestRecord),
           diagnostics: [...diagnostics],
         };
       }

--- a/src/plugins/setup-registry.lifecycle.test.ts
+++ b/src/plugins/setup-registry.lifecycle.test.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withPluginMetadataSnapshotScope } from "./current-plugin-metadata-snapshot.js";
 import type { PluginManifestRegistry } from "./manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
-import { resolvePluginSetupRegistry } from "./setup-registry.js";
+import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
+import { resolvePluginSetupProviderCore, resolvePluginSetupRegistry } from "./setup-registry.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
 const tempDirs: string[] = [];
@@ -11,9 +13,55 @@ const tempDirs: string[] = [];
 afterEach(() => {
   clearPluginMetadataLifecycleCaches();
   cleanupTrackedTempDirs(tempDirs);
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
 });
 
 describe("plugin setup registry artifact lifecycle", () => {
+  it.each([undefined, ["trace-provider"], []])(
+    "traces prepared setup lookup with plugin IDs %j",
+    (pluginIds) => {
+      const rootDir = fs.realpathSync(makeTrackedTempDir("openclaw-setup-trace", tempDirs));
+      const setupSource = path.join(rootDir, "setup-api.cjs");
+      fs.writeFileSync(
+        setupSource,
+        'module.exports = { register(api) { api.registerProvider({ id: "trace-provider", label: "Trace provider" }); } };\n',
+      );
+      const snapshot = createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "trace-provider",
+            rootDir,
+            origin: "global",
+            setupSource,
+            setup: { requiresRuntime: true, providers: [{ id: "trace-provider" }] },
+          },
+        ],
+      });
+      vi.stubEnv("OPENCLAW_PLUGIN_LIFECYCLE_TRACE", "1");
+      const trace = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      const provider = withPluginMetadataSnapshotScope(
+        snapshot,
+        () => resolvePluginSetupProviderCore({ provider: "trace-provider", pluginIds }),
+        { trustConfigIdentity: true },
+      );
+
+      expect(provider?.label).toBe(pluginIds?.length === 0 ? undefined : "Trace provider");
+      const phases = trace.mock.calls
+        .map(([message]) => message)
+        .filter((message) => message.includes('phase="manifest registry"'));
+      const pluginIdCount = pluginIds ? ` pluginIdCount=${pluginIds.length}` : "";
+      expect(phases).toEqual([
+        expect.stringMatching(
+          new RegExp(
+            `^\\[plugins:lifecycle\\] phase="manifest registry" ms=\\d+\\.\\d{2} status=ok includeDisabled=true${pluginIdCount} indexPluginCount=1$`,
+          ),
+        ),
+      ]);
+    },
+  );
+
   it.each<{
     artifactDir: string;
     declared: boolean;

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -18,6 +18,7 @@ import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-re
 import { createPluginCacheKey, PluginLruCache } from "./plugin-cache-primitives.js";
 import { getPluginCache, getPluginCacheRoot } from "./plugin-cache.js";
 import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
+import { tracePluginLifecyclePhase } from "./plugin-lifecycle-trace.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-snapshot.js";
 import { getCachedPluginModuleLoader } from "./plugin-module-loader-cache.js";
@@ -448,20 +449,29 @@ function loadSetupManifestRecords(params: {
   pluginIds?: readonly string[];
 }) {
   const { snapshot: index, manifestRegistry } = loadPluginRegistrySnapshotWithMetadata(params);
-  if (params.pluginIds?.length === 0) {
-    return [];
+  if (!manifestRegistry) {
+    return loadPluginManifestRegistryForInstalledIndex({ ...params, index, includeDisabled: true })
+      .plugins;
   }
   // Setup consumes descriptors and entry paths, not channel presentation. Keep
   // prepared records intact; the generic registry still normalizes supplied fields.
-  return manifestRegistry
-    ? selectInstalledPluginManifestRecords(
-        index,
-        manifestRegistry,
-        params.pluginIds ? new Set(params.pluginIds) : null,
-        true,
-      )
-    : loadPluginManifestRegistryForInstalledIndex({ ...params, index, includeDisabled: true })
-        .plugins;
+  return tracePluginLifecyclePhase(
+    "manifest registry",
+    () =>
+      params.pluginIds?.length === 0
+        ? []
+        : selectInstalledPluginManifestRecords(
+            index,
+            manifestRegistry,
+            params.pluginIds ? new Set(params.pluginIds) : null,
+            true,
+          ),
+    {
+      includeDisabled: true,
+      pluginIdCount: params.pluginIds?.length,
+      indexPluginCount: index.plugins.length,
+    },
+  );
 }
 
 function findUniqueSetupManifestOwner(params: {

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -10,6 +10,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildPluginApi, createUnavailableRuntime } from "./api-builder.js";
 import { hasPluginConfigMigrationSource } from "./config-contract-matches.js";
+import {
+  loadPluginManifestRegistryForInstalledIndex,
+  selectInstalledPluginManifestRecords,
+} from "./manifest-registry-installed.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import { createPluginCacheKey, PluginLruCache } from "./plugin-cache-primitives.js";
 import { getPluginCache, getPluginCacheRoot } from "./plugin-cache.js";
@@ -17,7 +21,7 @@ import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-con
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-snapshot.js";
 import { getCachedPluginModuleLoader } from "./plugin-module-loader-cache.js";
-import { loadPluginManifestRegistryForPluginRegistry } from "./plugin-registry.js";
+import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry.js";
 import { resolvePreferredBundledRootArtifact } from "./plugin-runtime-artifact-selection.js";
 import { resolvePluginRootArtifactPath } from "./root-artifact-path.js";
 import { listSetupCliBackendIds, listSetupProviderIds } from "./setup-descriptors.js";
@@ -177,12 +181,12 @@ function resolveRelevantSetupMigrationPluginIds(params: {
   env?: NodeJS.ProcessEnv;
 }): string[] {
   const ids = new Set<string>(collectConfiguredPluginEntryIds(params.config));
-  const registry = loadSetupManifestRegistry({
+  const plugins = loadSetupManifestRecords({
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
   });
-  for (const plugin of registry.plugins) {
+  for (const plugin of plugins) {
     if (
       hasPluginConfigMigrationSource({
         root: params.config,
@@ -437,27 +441,35 @@ function cloneSetupRegistry(registry: PluginSetupRegistry): PluginSetupRegistry 
   return cloneSetupRegistryValue(registry);
 }
 
-function loadSetupManifestRegistry(params?: {
+function loadSetupManifestRecords(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   pluginIds?: readonly string[];
 }) {
-  return loadPluginManifestRegistryForPluginRegistry({
-    config: params?.config,
-    workspaceDir: params?.workspaceDir,
-    env: params?.env ?? process.env,
-    pluginIds: params?.pluginIds,
-    includeDisabled: true,
-  });
+  const { snapshot: index, manifestRegistry } = loadPluginRegistrySnapshotWithMetadata(params);
+  if (params.pluginIds?.length === 0) {
+    return [];
+  }
+  // Setup consumes descriptors and entry paths, not channel presentation. Keep
+  // prepared records intact; the generic registry still normalizes supplied fields.
+  return manifestRegistry
+    ? selectInstalledPluginManifestRecords(
+        index,
+        manifestRegistry,
+        params.pluginIds ? new Set(params.pluginIds) : null,
+        true,
+      )
+    : loadPluginManifestRegistryForInstalledIndex({ ...params, index, includeDisabled: true })
+        .plugins;
 }
 
 function findUniqueSetupManifestOwner(params: {
-  registry: ReturnType<typeof loadSetupManifestRegistry>;
+  plugins: readonly PluginManifestRecord[];
   normalizedId: string;
   listIds: (record: PluginManifestRecord) => readonly string[];
 }): PluginManifestRecord | undefined {
-  const matches = params.registry.plugins.filter((entry) =>
+  const matches = params.plugins.filter((entry) =>
     params.listIds(entry).some((id) => normalizeProviderId(id) === params.normalizedId),
   );
   if (matches.length === 0) {
@@ -587,16 +599,17 @@ export function resolvePluginSetupRegistry(params?: {
   let providerKeys = new Set<string>();
   let cliBackendKeys = new Set<string>();
 
-  const manifestRegistry =
-    params?.manifestRegistry ??
-    loadSetupManifestRegistry({
-      config: params?.config,
-      workspaceDir: params?.workspaceDir,
-      env,
-      pluginIds: params?.pluginIds,
-    });
+  const plugins =
+    params?.manifestRegistry == null
+      ? loadSetupManifestRecords({
+          config: params?.config,
+          workspaceDir: params?.workspaceDir,
+          env,
+          pluginIds: params?.pluginIds,
+        })
+      : params.manifestRegistry.plugins;
 
-  for (const record of manifestRegistry.plugins) {
+  for (const record of plugins) {
     if (scopedPluginIds && !scopedPluginIds.has(record.id)) {
       continue;
     }
@@ -720,14 +733,14 @@ export function resolvePluginSetupProviderCore(params: {
 }): ProviderPlugin | undefined {
   const env = params.env ?? process.env;
   const normalizedProvider = normalizeProviderId(params.provider);
-  const manifestRegistry = loadSetupManifestRegistry({
+  const plugins = loadSetupManifestRecords({
     config: params.config,
     workspaceDir: params.workspaceDir,
     env,
     pluginIds: params.pluginIds,
   });
   const record = findUniqueSetupManifestOwner({
-    registry: manifestRegistry,
+    plugins,
     normalizedId: normalizedProvider,
     listIds: listSetupProviderIds,
   });
@@ -751,13 +764,13 @@ export function resolvePluginSetupCliBackend(params: {
   // Narrow setup lookup from manifest-owned descriptors before executing any
   // plugin setup module. This avoids booting every setup-api just to find one
   // backend owner.
-  const manifestRegistry = loadSetupManifestRegistry({
+  const plugins = loadSetupManifestRecords({
     config: params.config,
     workspaceDir: params.workspaceDir,
     env,
   });
   const record = findUniqueSetupManifestOwner({
-    registry: manifestRegistry,
+    plugins,
     normalizedId: normalized,
     listIds: listSetupCliBackendIds,
   });

--- a/src/plugins/test-helpers/registry-jiti-mocks.ts
+++ b/src/plugins/test-helpers/registry-jiti-mocks.ts
@@ -20,7 +20,8 @@ vi.mock("../manifest-registry.js", () => ({
   ) => registryJitiMocks.loadPluginManifestRegistry(...args),
 }));
 
-vi.mock("../manifest-registry-installed.js", () => ({
+vi.mock("../manifest-registry-installed.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../manifest-registry-installed.js")>()),
   loadPluginManifestRegistryForInstalledIndex: (
     ...args: Parameters<typeof registryJitiMocks.loadPluginManifestRegistry>
   ) => registryJitiMocks.loadPluginManifestRegistry(...args),
@@ -33,6 +34,9 @@ vi.mock("../plugin-registry.js", async (importOriginal) => {
     loadPluginRegistrySnapshot: (
       ...args: Parameters<typeof registryJitiMocks.loadPluginRegistrySnapshot>
     ) => registryJitiMocks.loadPluginRegistrySnapshot(...args),
+    loadPluginRegistrySnapshotWithMetadata: (
+      ...args: Parameters<typeof registryJitiMocks.loadPluginRegistrySnapshot>
+    ) => ({ snapshot: registryJitiMocks.loadPluginRegistrySnapshot(...args) }),
     loadPluginManifestRegistryForPluginRegistry: (
       ...args: Parameters<typeof registryJitiMocks.loadPluginManifestRegistry>
     ) => registryJitiMocks.loadPluginManifestRegistry(...args),


### PR DESCRIPTION
## What Problem This Solves

Provider and CLI setup selection normalized channel presentation and setup-field metadata for every selected plugin, even though those lookups consume only owner descriptors and entry paths.

## Why This Change Was Made

A shared installed-owner selector now separates membership and ordering from field normalization. Setup reuses prepared records; the generic manifest loader retains its field validator and canonical cold reconstruction. The snapshot producer and its configuration, workspace and lifecycle rules remain unchanged.

## User Impact

Setup aliases, ambiguity handling, disabled-owner inspection, runtime cutoff, registration and mutable-result isolation retain their existing behavior. No configuration, schema, dependency or public SDK changes are added. Production +37 LOC names the selection and tracing boundaries while preserving cold and supplied-record contracts; tests +51 and test support +4 cover the repaired trace and mock contract.

## Evidence

- All 23 actual-source observations and setup registration traces match, including root A/B/A, lifecycle clear, malformed generic fields and empty scope. Both measured arms loaded 17 fixture modules and performed 213 registrations.
- Twenty fixed composed operations previously performed 1,280 channel normalizations and 6,400 flag parses. The candidate uses 80 shared selections. Separate sampled allocation estimates fell from 22,284,432 to 6,662,296 bytes; this is not retained heap, RSS or a Gateway benchmark.
- Final functional verification includes the empty-scope and nullish supplied-record contracts. All 128 existing tests across seven files and the canonical changed-file gate pass. Managed Codex review through P2 is clean.
- Actual Gateway startup and feature integration passed. The focused synthetic setup modules exercise callback selection directly; the live flow does not claim to invoke every setup callback.


## Real Gateway integration (2026-09-03)

A prebuilt, isolated Gateway with a real OpenAI API key passed four fixed turns: ordinary completion, real `web_fetch` of example.com, a 1.31 MB Unicode return through Code Mode, and a real MCP stdio tool with default and explicit arguments. Fifty-seven Gateway RPCs verified three session identities, full/repeated/paginated/subscribed list rows, descriptions and final previews, transcript completion, an explicit reconnect, empty approval replay and unsubscribe.

The MCP server observed the default `id: alpha` before server-side validation, followed by explicit `id: beta`; both nested call identities/order, structured results and metadata projection matched. The Unicode prefix remained well formed and within its byte budget with exact omitted-byte accounting. All four turns completed without retries.

The local immutable composite `3bb6e3164a06e5c35fb50b368cc63cbb05826384` contains the twelve published campaign changes through #137148, including this PR’s initial selection change, before the trace follow-up described below. Source/build/dependency identity was checked before and after. Both clients closed, the Gateway exited successfully without escalation, all recorded MCP processes exited, and private state/port cleanup passed. This is functional integration proof; it does not attribute memory or latency differences to this PR.

## Review and CI follow-up

The prepared path now emits the existing `manifest registry` lifecycle phase, including all/selected/empty ID scopes and the normal details, without restoring unused channel normalization. The cold path delegates to its existing traced owner. Three real setup-provider lookup cases failed on the previous PR head and pass after this repair; 73 focused trace/setup tests and the full changed-file gate pass.

CI also exposed a provider-auth-alias test mock still exporting the old registry loader. The fixture now returns the same empty cold inventory through the metadata-bearing loader; all trust assertions remain unchanged. That exact case failed before and passed after, and 115 relevant tests passed. A combined source-embedded independent Codex review through P2 is clean. The production total is +37, tests +51, test support +4.

The previously recorded four-turn/57-RPC real Gateway composition predates this trace follow-up and is not claimed as proof of the new trace. The new local setup-provider flow proves the emitted phase directly; final authenticated Gateway integration remains pending before landing. The branch also includes the upstream main lint repair #137149.
