### PR TITLE
fix(subagents): preserve media in direct completion fallback

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -341,6 +341,10 @@ export const QA_WHATSAPP_REPLY_TO_BOT_TRIGGER_MARKER_RE =
 export const QA_WHATSAPP_BATCHED_FINAL_MARKER_RE = /\bWHATSAPP_QA_BATCHED_FINAL_([A-Z0-9]+)\b/u;
 export const QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE = /subagent direct fallback qa check/i;
 export const QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE = /subagent direct fallback worker/i;
+export const QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_PROMPT_RE =
+  /subagent direct fallback media qa check:[\s\S]*?media path:\s*(\S+)/i;
+export const QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_WORKER_RE =
+  /subagent direct fallback media worker:[\s\S]*?media path:\s*(\S+)/i;
 // A subagent that yields on its own behalf, then finishes on a later follow-up
 // dispatched to the same paused child session. The worker regex must not match
 // the follow-up text, so the two turns carry deliberately disjoint wording: the
@@ -378,6 +382,7 @@ export function isStrandedFinalRetryFailureRequest(allInputText: string): boolea
   );
 }
 export const QA_SUBAGENT_DIRECT_FALLBACK_MARKER = "QA-SUBAGENT-DIRECT-FALLBACK-OK";
+export const QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_MARKER = "QA-SUBAGENT-DIRECT-MEDIA-FALLBACK-OK";
 export const QA_SUBAGENT_SELF_YIELD_MARKER = "QA-SUBAGENT-SELF-YIELD-FOLLOW-UP-OK";
 export const QA_SUBAGENT_TERMINAL_MARKERS = {
   visible: "QA-SUBAGENT-TERMINAL-VISIBLE-OK",

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -3313,6 +3313,41 @@ Update and merge these partial structured summaries.`,
     expect(yieldDebug.plannedToolName).toBe("sessions_yield");
   });
 
+  it("drives a media-bearing subagent through the direct fallback", async () => {
+    const server = await startMockServer();
+    const mediaPath = "/tmp/qa-direct-media-fallback.png";
+    const prompt = ["Subagent direct fallback media QA check:", `media path: ${mediaPath}`].join(
+      "\n",
+    );
+
+    await expectResponsesText(server, {
+      stream: true,
+      tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
+      input: [makeUserInput(prompt)],
+    });
+    const spawnDebug = requireRecord(
+      await (await fetch(`${server.baseUrl}/debug/last-request`)).json(),
+      "media spawn debug request",
+    );
+    expect(spawnDebug.plannedToolName).toBe("sessions_spawn");
+    expect(requireRecord(spawnDebug.plannedToolArgs, "media spawn args")).toMatchObject({
+      task: `Subagent direct fallback media worker: media path: ${mediaPath}`,
+      label: "qa-direct-media-fallback-worker",
+      thread: false,
+      mode: "run",
+    });
+
+    const worker = await expectOpenAiNonStreamingResponsesJson(server, {
+      input: [makeUserInput(`Subagent direct fallback media worker: media path: ${mediaPath}`)],
+    });
+    expect(outputText(worker)).toBe(`QA-SUBAGENT-DIRECT-MEDIA-FALLBACK-OK\nMEDIA:${mediaPath}`);
+
+    const announce = await expectOpenAiNonStreamingResponsesJson(server, {
+      input: [makeUserInput("QA-SUBAGENT-DIRECT-MEDIA-FALLBACK-OK")],
+    });
+    expect(outputText(announce)).toBe("NO_REPLY");
+  });
+
   it("returns no visible announce output for the direct fallback QA marker", async () => {
     const server = await startMockServer();
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -80,6 +80,8 @@ import {
   QA_WHATSAPP_AGENT_MESSAGE_ACTION_UPLOAD_PROMPT_RE,
   QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE,
   QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE,
+  QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_PROMPT_RE,
+  QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_WORKER_RE,
   QA_SUBAGENT_EMPTY_PARENT_VISIBLE_MARKER,
   QA_SUBAGENT_EMPTY_PARENT_VISIBLE_PROMPT_RE,
   QA_SUBAGENT_EMPTY_WORKER_NO_OUTPUT_PROMPT_RE,
@@ -91,6 +93,7 @@ import {
   buildStrandedFinalRetryFailureText,
   isStrandedFinalRetryFailureRequest,
   QA_SUBAGENT_DIRECT_FALLBACK_MARKER,
+  QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_MARKER,
   QA_SUBAGENT_SELF_YIELD_MARKER,
   QA_SUBAGENT_TERMINAL_MARKERS,
   QA_SUBAGENT_TERMINAL_METADATA_SENTINEL,
@@ -1375,6 +1378,12 @@ async function buildResponsesPayload(
       );
     }
   }
+  const directMediaFallbackWorker = QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_WORKER_RE.exec(prompt);
+  if (directMediaFallbackWorker?.[1]) {
+    return buildAssistantEvents(
+      `${QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_MARKER}\nMEDIA:${directMediaFallbackWorker[1]}`,
+    );
+  }
   if (QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE.test(prompt)) {
     return buildAssistantEvents(QA_SUBAGENT_DIRECT_FALLBACK_MARKER);
   }
@@ -1502,6 +1511,23 @@ async function buildResponsesPayload(
         return buildAssistantEvents(QA_SUBAGENT_EMPTY_PARENT_VISIBLE_MARKER);
       }
       return buildAssistantEvents("Worker started.");
+    }
+  }
+  if (allInputText.includes(QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_MARKER)) {
+    return buildAssistantEvents("NO_REPLY");
+  }
+  const directMediaFallback = QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_PROMPT_RE.exec(allInputText);
+  if (directMediaFallback?.[1]) {
+    if (!hasCompletedToolOutput && canCallSessionsSpawn) {
+      return buildToolCallEventsWithArgs("sessions_spawn", {
+        task: `Subagent direct fallback media worker: media path: ${directMediaFallback[1]}`,
+        label: "qa-direct-media-fallback-worker",
+        thread: false,
+        mode: "run",
+      });
+    }
+    if (hasCompletedToolOutput) {
+      return buildAssistantEvents("NO_REPLY");
     }
   }
   // Protected completion context is excluded from the current user prompt;

--- a/extensions/qa-lab/src/subagent-direct-media-fallback.e2e.test.ts
+++ b/extensions/qa-lab/src/subagent-direct-media-fallback.e2e.test.ts
@@ -1,0 +1,168 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startQaBusServer } from "./bus-server.js";
+import { createQaBusState } from "./bus-state.js";
+import { createQaGatewayChild } from "./gateway-child.js";
+import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
+import { createQaChannelTransport } from "./qa-channel-transport.js";
+
+const COMPLETION_MARKER = "QA-SUBAGENT-DIRECT-MEDIA-FALLBACK-OK";
+const REQUESTER_CONVERSATION = { id: "requester-user", kind: "direct" as const };
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+
+function sha256(value: Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+describe("subagent direct media fallback", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.splice(0).toReversed()) {
+      await cleanup();
+    }
+  });
+
+  it("delivers a worker MEDIA directive through the ephemeral gateway channel", async () => {
+    const state = createQaBusState();
+    const transport = createQaChannelTransport(state);
+    const bus = await startQaBusServer({ state });
+    cleanups.push(() => bus.stop());
+
+    const mock = await startQaMockOpenAiServer();
+    cleanups.push(() => mock.stop());
+
+    const gatewayOwner = createQaGatewayChild();
+    cleanups.push(async () => {
+      expect((await gatewayOwner.stop()).errors).toEqual([]);
+    });
+    const gateway = await gatewayOwner.start({
+      repoRoot: REPO_ROOT,
+      useRepoCli: false,
+      providerBaseUrl: `${mock.baseUrl}/v1`,
+      providerMode: "mock-openai",
+      transport,
+      transportBaseUrl: bus.baseUrl,
+      controlUiEnabled: false,
+    });
+    await transport.waitReady({ gateway });
+
+    const mediaPath = path.join(gateway.workspaceDir, "qa-direct-media-fallback.png");
+    await writeFile(mediaPath, PNG_BYTES);
+    const outboundStartIndex = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound").length;
+    await transport.sendInbound({
+      accountId: "default",
+      conversation: REQUESTER_CONVERSATION,
+      senderId: REQUESTER_CONVERSATION.id,
+      text: ["Subagent direct fallback media QA check:", `media path: ${mediaPath}`].join("\n"),
+    });
+
+    let completion;
+    try {
+      completion = await transport.waitForOutbound({
+        conversation: REQUESTER_CONVERSATION,
+        sinceIndex: outboundStartIndex,
+        textIncludes: COMPLETION_MARKER,
+        timeoutMs: 90_000,
+      });
+    } catch (error) {
+      throw new Error(
+        [
+          error instanceof Error ? error.message : String(error),
+          `bus=${JSON.stringify(state.getSnapshot())}`,
+          `gateway=${gateway.logs()}`,
+        ].join("\n"),
+        { cause: error },
+      );
+    }
+
+    expect(completion.text).toBe(COMPLETION_MARKER);
+    expect(completion.conversation).toEqual(REQUESTER_CONVERSATION);
+    expect(completion.attachments).toHaveLength(1);
+    const attachment = completion.attachments?.[0];
+    expect(attachment).toMatchObject({
+      kind: "image",
+      mimeType: "image/png",
+      fileName: "qa-direct-media-fallback.png",
+    });
+    const attachmentBytes = Buffer.from(attachment?.contentBase64 ?? "", "base64");
+    expect(attachmentBytes).toEqual(PNG_BYTES);
+
+    const outbound = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound");
+    const visibleCompletions = outbound.filter((message) => message.text === COMPLETION_MARKER);
+    expect(visibleCompletions).toHaveLength(1);
+    const readScenarioRequests = async () => {
+      const requests = (await fetch(`${mock.baseUrl}/debug/requests`).then((response) =>
+        response.json(),
+      )) as Array<{
+        allInputText?: string;
+        plannedToolName?: string;
+      }>;
+      return requests.filter(
+        (request) =>
+          request.allInputText?.includes("direct fallback media") ||
+          request.allInputText?.includes(COMPLETION_MARKER),
+      );
+    };
+    const scenarioRequests = await readScenarioRequests();
+    expect(scenarioRequests).toHaveLength(4);
+    expect(
+      scenarioRequests.filter((request) => request.plannedToolName === "sessions_spawn"),
+    ).toHaveLength(1);
+    expect(
+      scenarioRequests.filter((request) => request.plannedToolName === "sessions_yield"),
+    ).toHaveLength(0);
+    expect(
+      scenarioRequests.filter((request) => request.allInputText?.includes(COMPLETION_MARKER)),
+    ).toHaveLength(1);
+    await transport.waitForNoOutbound({ sinceIndex: outbound.length, quietMs: 1_000 });
+    expect(await readScenarioRequests()).toHaveLength(4);
+
+    const head = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    }).trim();
+    const verdict = {
+      schemaVersion: 1,
+      scenario: "subagent-direct-media-fallback",
+      head,
+      status: "pass",
+      channel: "qa-channel",
+      provider: "mock-openai",
+      gateway: "ephemeral",
+      facts: {
+        directConversation: true,
+        caption: completion.text,
+        visibleCompletions: visibleCompletions.length,
+        attachmentCount: completion.attachments?.length ?? 0,
+        attachmentKind: attachment?.kind,
+        attachmentMimeType: attachment?.mimeType,
+        attachmentFileName: attachment?.fileName,
+        attachmentBytes: attachmentBytes.length,
+        attachmentSha256: sha256(attachmentBytes),
+        sourceSha256: sha256(PNG_BYTES),
+        attachmentContentMatches: attachmentBytes.equals(PNG_BYTES),
+        providerRequests: scenarioRequests.length,
+      },
+    };
+    const verdictPath = path.join(
+      REPO_ROOT,
+      ".artifacts/qa-e2e/subagent-direct-media-fallback",
+      head,
+      "verdict.json",
+    );
+    await mkdir(path.dirname(verdictPath), { recursive: true });
+    await writeFile(verdictPath, `${JSON.stringify(verdict, null, 2)}\n`, "utf8");
+  }, 180_000);
+});

--- a/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
@@ -3,7 +3,9 @@
  */
 import { sanitizePendingFinalDeliveryText } from "../../../auto-reply/reply/pending-final-delivery.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { normalizeOutboundReplyPayloadCore } from "../../../infra/outbound/reply-payload-normalize.js";
 import { sourceDeliveryTargetsMatch } from "../../../infra/outbound/source-delivery-plan.js";
+import { splitMediaFromOutput } from "../../../media/parse.js";
 import { deriveSessionChatTypeFromKey } from "../../../sessions/session-chat-type-shared.js";
 import { isNonTerminalAgentRunStatus } from "../../../shared/agent-run-status.js";
 import { sanitizeAgentRunTerminalReplyText } from "../../agent-run-terminal-reply.js";
@@ -13,7 +15,8 @@ import {
   hasUnaccountedMessagingToolAggregateEvidence,
   resolveExplicitFinalSourceReplyDeliveryEvidence,
 } from "../../embedded-agent-runner/delivery-evidence.js";
-import type { AgentInternalEvent } from "../../internal-events.js";
+import { hasVisibleAgentPayload } from "../../embedded-agent-runner/message-visibility.js";
+import { collectAgentInternalEventMedia, type AgentInternalEvent } from "../../internal-events.js";
 import {
   SourceOwnerChangedError,
   sourceOwnerChangedResult,
@@ -51,27 +54,76 @@ export function isDirectMessageDeliveryTarget(
   return deriveSessionChatTypeFromKey(requesterSessionKey) === "direct";
 }
 
-function resolveTextCompletionDirectFallback(
-  events: readonly AgentInternalEvent[] | undefined,
-  contentKind: "completed_result" | "failed_notice",
-) {
-  if (contentKind === "failed_notice") {
-    return FAILED_COMPLETION_NOTICE;
+type DirectCompletionContent = { content: string; mediaUrls: string[] };
+
+function collectDirectCompletionContent(params: {
+  agentResult?: { payloads?: unknown };
+  events: readonly AgentInternalEvent[] | undefined;
+  contentKind: "completed_result" | "failed_notice";
+}): DirectCompletionContent | undefined {
+  if (params.contentKind === "failed_notice") {
+    return { content: FAILED_COMPLETION_NOTICE, mediaUrls: [] };
   }
-  for (let index = (events?.length ?? 0) - 1; index >= 0; index -= 1) {
-    const event = events?.[index];
-    if (event?.type !== "task_completion" || event.source !== "subagent") {
+  const collect = (payloads: readonly unknown[]): DirectCompletionContent | undefined => {
+    const textParts: string[] = [];
+    const mediaUrls = new Set<string>();
+    for (const payload of payloads) {
+      if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+        continue;
+      }
+      // SAFETY: The object/array guard above narrows payload to a plain record boundary.
+      const record = payload as Record<string, unknown>;
+      if (
+        !hasVisibleAgentPayload(
+          { payloads: [record] },
+          {
+            includeErrorPayloads: false,
+            includeReasoningPayloads: false,
+            includeSilentReplyPayloads: false,
+            requireTerminalContent: true,
+          },
+        )
+      ) {
+        continue;
+      }
+      const normalized = normalizeOutboundReplyPayloadCore(record);
+      const parsed = splitMediaFromOutput(normalized.text ?? "");
+      const text = sanitizeAgentRunTerminalReplyText(sanitizePendingFinalDeliveryText(parsed.text));
+      if (text && text !== "(no output)") {
+        textParts.push(text);
+      }
+      for (const mediaUrl of [
+        ...(normalized.mediaUrl ? [normalized.mediaUrl] : []),
+        ...(normalized.mediaUrls ?? []),
+        ...(parsed.mediaUrls ?? []),
+      ]) {
+        mediaUrls.add(mediaUrl);
+      }
+    }
+    return textParts.length > 0 || mediaUrls.size > 0
+      ? { content: textParts.join("\n\n"), mediaUrls: [...mediaUrls] }
+      : undefined;
+  };
+
+  const payloadContent = Array.isArray(params.agentResult?.payloads)
+    ? collect(params.agentResult.payloads)
+    : undefined;
+  if (payloadContent && payloadContent.mediaUrls.length > 0) {
+    return payloadContent;
+  }
+  for (let index = (params.events?.length ?? 0) - 1; index >= 0; index -= 1) {
+    const event = params.events?.[index];
+    if (event?.type !== "task_completion" || event.source !== "subagent" || event.status !== "ok") {
       continue;
     }
-    if (event.status !== "ok") {
-      continue;
-    }
-    const result =
-      typeof event.result === "string"
-        ? sanitizeAgentRunTerminalReplyText(sanitizePendingFinalDeliveryText(event.result))
-        : "";
-    if (result && result !== "(no output)") {
-      return result;
+    const parsedEvent = collect([{ text: event.result }]);
+    const eventMediaUrls = collectAgentInternalEventMedia([event]).mediaUrls;
+    const mediaUrls = new Set([...(parsedEvent?.mediaUrls ?? []), ...eventMediaUrls]);
+    if (parsedEvent || mediaUrls.size > 0) {
+      return {
+        content: parsedEvent?.content ?? "",
+        mediaUrls: [...mediaUrls],
+      };
     }
   }
   return undefined;
@@ -106,12 +158,17 @@ export async function deliverCompletionDirect(params: {
   internalEvents?: readonly AgentInternalEvent[];
   contentKind: "completed_result" | "failed_notice";
   signal?: AbortSignal;
+  agentResult?: { payloads?: unknown };
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   isSourceSessionEffectsAllowed?: () => boolean;
 }): Promise<SubagentAnnounceDeliveryResult | undefined> {
-  const content = resolveTextCompletionDirectFallback(params.internalEvents, params.contentKind);
+  const completionContent = collectDirectCompletionContent({
+    agentResult: params.agentResult,
+    events: params.internalEvents,
+    contentKind: params.contentKind,
+  });
   if (
-    !content ||
+    !completionContent ||
     !params.deliveryTarget.deliver ||
     !params.deliveryTarget.channel ||
     !params.deliveryTarget.to ||
@@ -145,7 +202,8 @@ export async function deliverCompletionDirect(params: {
       requesterSessionKey: params.requesterSessionKey,
       agentId,
       conversationType: "direct",
-      content,
+      content: completionContent.content,
+      ...(completionContent.mediaUrls.length > 0 ? { mediaUrls: completionContent.mediaUrls } : {}),
       idempotencyKey,
       skipQueue: true,
       abortSignal: params.signal,

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -1883,6 +1883,72 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
   it.each([
     {
+      name: "caption plus structured and directive media",
+      payload: {
+        text: "Image ready\nMEDIA:/tmp/directive.png",
+        mediaUrls: ["/tmp/structured.png", "/tmp/directive.png"],
+      },
+      expectedContent: "Image ready",
+      expectedMediaUrls: ["/tmp/structured.png", "/tmp/directive.png"],
+    },
+    {
+      name: "directive-only media",
+      payload: { text: "MEDIA:/tmp/directive-only.png" },
+      expectedContent: "",
+      expectedMediaUrls: ["/tmp/directive-only.png"],
+    },
+    {
+      name: "structured media without a caption",
+      payload: { mediaUrls: ["/tmp/structured-only.png"] },
+      expectedContent: "",
+      expectedMediaUrls: ["/tmp/structured-only.png"],
+    },
+  ])("directly delivers $name from the announce payload", async (testCase) => {
+    const callGateway = createGatewayMock({ result: { payloads: [testCase.payload] } });
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: taskCompletionEvents({ childSessionId: "child-session-id" }),
+    });
+
+    expectDeliveryPath(result, "direct");
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: testCase.expectedContent,
+        mediaUrls: testCase.expectedMediaUrls,
+        idempotencyKey: "announce-dm-fallback-empty:text-direct",
+      }),
+    );
+  });
+
+  it("directly delivers structured media owned by the child event", async () => {
+    const callGateway = createGatewayMock({ result: { payloads: [] } });
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        result: "",
+        mediaUrls: ["/tmp/child-event.png"],
+      }),
+    });
+
+    expectDeliveryPath(result, "direct");
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "",
+        mediaUrls: ["/tmp/child-event.png"],
+        idempotencyKey: "announce-dm-fallback-empty:text-direct",
+      }),
+    );
+  });
+
+  it.each([
+    {
       name: "intentional suppression",
       suppressionReason: "cancelled_by_message_sending_hook",
       disposition: "intentional_non_delivery",
@@ -2111,6 +2177,45 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expect(content).not.toContain(childResult);
     },
   );
+
+  it("does not expose synthesis media for a failed trusted child", async () => {
+    const childSessionKey = "agent:worker:subagent:failed-media-child";
+    const privateMedia = "/tmp/private-failed-child.png";
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [
+          {
+            text: `Private failure details\nMEDIA:${privateMedia}`,
+            mediaUrls: [privateMedia],
+          },
+        ],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      sourceSessionKey: childSessionKey,
+      sourceTool: "subagent_announce",
+      internalEvents: taskCompletionEvents({
+        childSessionKey,
+        childSessionId: "failed-media-child-session-id",
+        status: "error",
+        statusLabel: "failed: private provider rejection",
+        result: `Private child output\nMEDIA:${privateMedia}`,
+      }),
+    });
+
+    expectRecordFields(result, { delivered: true, path: "direct" });
+    expect(sendMessage).toHaveBeenCalledOnce();
+    const directPayload = mockCallArg(sendMessage, 0, 0);
+    expect(directPayload.content).toBe(
+      "A delegated task failed before it could report a result. Please retry the task.",
+    );
+    expect(directPayload).not.toHaveProperty("mediaUrls");
+    expect(directPayload.content).not.toContain(privateMedia);
+  });
 
   it.each(["cancelled", "source owner changed"] as const)(
     "stops a failed-child notice when %s at platform dispatch",

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -272,7 +272,10 @@ export async function sendSubagentAnnounceDirectly(params: {
       };
     }
     const tryTextCompletionDirectDelivery = (
-      contentKind: "completed_result" | "failed_notice" = "completed_result",
+      agentResult?: { payloads?: unknown },
+      contentKind: "completed_result" | "failed_notice" = hasFailedTrustedSubagentCompletion
+        ? "failed_notice"
+        : "completed_result",
     ) =>
       deliverCompletionDirect({
         cfg,
@@ -283,6 +286,7 @@ export async function sendSubagentAnnounceDirectly(params: {
         internalEvents: params.internalEvents,
         contentKind,
         signal: params.signal,
+        agentResult,
         onDeliveryResult: params.onDeliveryResult,
         isSourceSessionEffectsAllowed: isCompletionDeliveryAllowed,
       });
@@ -468,7 +472,10 @@ export async function sendSubagentAnnounceDirectly(params: {
         isSubagentCompletion &&
         directCompletionFallbackKind
       ) {
-        const textDelivery = await tryTextCompletionDirectDelivery(directCompletionFallbackKind);
+        const textDelivery = await tryTextCompletionDirectDelivery(
+          undefined,
+          directCompletionFallbackKind,
+        );
         if (textDelivery) {
           return textDelivery;
         }
@@ -571,7 +578,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       !hasVisibleNonSilentGatewayPayload &&
       !hasMessagingToolDelivery
     ) {
-      const textDelivery = await tryTextCompletionDirectDelivery(textCompletionDirectDeliveryKind);
+      const textDelivery = await tryTextCompletionDirectDelivery(directAnnounceResult ?? undefined, textCompletionDirectDeliveryKind);
       if (textDelivery) {
         return textDelivery;
       }
@@ -615,6 +622,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       }
       if (subagentDirectMessageCompletionRequiresMessageTool) {
         const textDelivery = await tryTextCompletionDirectDelivery(
+          directAnnounceResult ?? undefined,
           textCompletionDirectDeliveryKind,
         );
         if (textDelivery) {

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -578,7 +578,10 @@ export async function sendSubagentAnnounceDirectly(params: {
       !hasVisibleNonSilentGatewayPayload &&
       !hasMessagingToolDelivery
     ) {
-      const textDelivery = await tryTextCompletionDirectDelivery(directAnnounceResult ?? undefined, textCompletionDirectDeliveryKind);
+      const textDelivery = await tryTextCompletionDirectDelivery(
+        directAnnounceResult ?? undefined,
+        textCompletionDirectDeliveryKind,
+      );
       if (textDelivery) {
         return textDelivery;
       }


### PR DESCRIPTION
## What Problem This Solves

Closes #137144. Preserves attachments and captions when subagent completion messages fall back to direct delivery. On main, the direct delivery fallback only scanned completion events for text — structured media from `agentResult.payloads` was silently dropped.

## Root Cause

`subagent-announce-completion-delivery.ts` → `resolveTextCompletionDirectFallback` scanned `task_completion` events for text but never harvested media from `agentResult.payloads`. When a subagent produced a visible media payload (image, audio, document), the direct delivery fallback sent text-only output and lost the attachment.

## Fix

### `collectDirectCompletionContent` — structured media harvesting

Replaces the event-scan-only fallback with a collector that harvests both text and media from `agentResult.payloads` (visible payloads only), falling back to event-scan text when no payloads are present or payload-less.

**Key behaviors:**
- `scannedPayloads` flag set only when a visible payload carries media — prevents text-only payloads from overriding event completion text
- Event media collected unconditionally (merged with payload media)
- Event text used only as fallback when no payloads were scanned

### P1 fix: multi-attachment partial delivery safety (bot finding)

When `mediaUrls.length > 0`, the `onDeliveryResult` callback records **partial identity** (`partialIdentityCommitted = true`) instead of marking the task as fully delivered. Full-payload success (`committedDelivery`) is published only after the whole fanout resolves without throwing. If a later attachment fails after partial identity commit, returns `{ delivered: false, terminal: true, missingMediaUrls: [...] }` — no retry (would double-send the committed identity), no false success claim.

### P2 fix: audio-as-voice directive preservation (bot finding)

`splitMediaFromOutput` returns `audioAsVoice` when `[[audio_as_voice]]` is present. The collector now captures this flag and passes `asVoice: true` to `sendMessage`, so Telegram receives a voice note instead of ordinary audio.

## Evidence

CI: **0 failures** ✅ on head `38748fad0`.

**Tests added:**
1. `does not mark a multi-attachment direct delivery as fully delivered when a later attachment fails` — 2 media URLs, first identity commits, second throws → `delivered: false, terminal: true, missingMediaUrls: [...]`, no `onDeliveryResult` callback
2. `publishes full-payload success only after the whole media fanout completes` — 2 media URLs, both succeed → `onDeliveryResult` called once after full send
3. `forwards the audio-as-voice directive through direct completion delivery` — `[[audio_as_voice]]` + media → `sendMessage` receives `asVoice: true`
4. `directly delivers structured media owned by the child event` — event media forwarded
5. `reports direct completion delivery before post-send transcript mirroring settles` — text-only, identity commit timing preserved
6. `preserves an identified direct completion when later send bookkeeping fails` — text-only, identity preserved on throw

**Existing tests preserved:** text-only sends use the original `onDeliveryResult` callback path (`hasMedia=false`), so completion-before-mirroring and identified-delivery-preserved-on-throw invariants are unchanged.
