### PR TITLE
fix(openai): preserve ChatGPT HTTP status for retry pacing

### DIFF
--- a/docs/concepts/retry.md
+++ b/docs/concepts/retry.md
@@ -26,7 +26,7 @@ title: "Retry policy"
 
 ### Model providers
 
-Embedded model runs use the [model failover controller](/concepts/model-failover#model-fallback) for transient retries. It honors provider pacing within one attempt budget and a fixed retry window; provider transports do not add their own transient retry loops. ChatGPT SSE errors preserve HTTP status and `Retry-After` together, so a transient HTTP response remains retryable even when its message or provider code is unfamiliar.
+Embedded model runs use the [model failover controller](/concepts/model-failover#model-fallback) for transient HTTP-response retries. It honors provider pacing within one attempt budget and a fixed retry window. ChatGPT SSE errors preserve HTTP status and `Retry-After` together, so a transient HTTP response remains retryable even when its message or provider code is unfamiliar. The ChatGPT transport separately reconnects once for `websocket_connection_limit_reached` before streaming; this is not an SSE HTTP-response retry.
 
 For SDK calls that retain internal retries, Stainless-based SDKs such as Anthropic and OpenAI can receive `retry-after-ms` or `retry-after` on retryable responses (`408`, `409`, `429`, and `5xx`). When that wait is longer than 60 seconds, OpenClaw injects `x-should-retry: false` so the SDK returns control promptly. Override this SDK-only cap with `OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS=<seconds>`. Set it to `0`, `false`, `off`, `none`, or `disabled` to let those SDK calls honor long `Retry-After` sleeps internally.
 

--- a/docs/concepts/retry.md
+++ b/docs/concepts/retry.md
@@ -26,9 +26,9 @@ title: "Retry policy"
 
 ### Model providers
 
-- OpenClaw lets provider SDKs handle normal short retries.
-- For Stainless-based SDKs such as Anthropic and OpenAI, retryable responses (`408`, `409`, `429`, and `5xx`) can include `retry-after-ms` or `retry-after`. When that wait is longer than 60 seconds, OpenClaw injects `x-should-retry: false` so the SDK surfaces the error immediately and model failover can rotate to another auth profile or fallback model.
-- Override the cap with `OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS=<seconds>`. Set it to `0`, `false`, `off`, `none`, or `disabled` to let SDKs honor long `Retry-After` sleeps internally.
+Embedded model runs use the [model failover controller](/concepts/model-failover#model-fallback) for transient retries. It honors provider pacing within one attempt budget and a fixed retry window; provider transports do not add their own transient retry loops. ChatGPT SSE errors preserve HTTP status and `Retry-After` together, so a transient HTTP response remains retryable even when its message or provider code is unfamiliar.
+
+For SDK calls that retain internal retries, Stainless-based SDKs such as Anthropic and OpenAI can receive `retry-after-ms` or `retry-after` on retryable responses (`408`, `409`, `429`, and `5xx`). When that wait is longer than 60 seconds, OpenClaw injects `x-should-retry: false` so the SDK returns control promptly. Override this SDK-only cap with `OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS=<seconds>`. Set it to `0`, `false`, `off`, `none`, or `disabled` to let those SDK calls honor long `Retry-After` sleeps internally.
 
 ### Discord
 

--- a/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
@@ -393,7 +393,11 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
     };
 
     const failed = await streamOpenAICodexResponses(model, context, options).result();
-    expect(failed).toMatchObject({ stopReason: "error", errorMessage: "unsupported_parameter" });
+    expect(failed).toMatchObject({
+      stopReason: "error",
+      errorMessage: "400: unsupported_parameter",
+      errorCode: "unsupported_parameter",
+    });
     expect(failed.providerReplay).toBeUndefined();
     expect(onCompactionRejected).not.toHaveBeenCalled();
     await streamOpenAICodexResponses(model, nextTurn(context, failed), options).result();

--- a/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
@@ -204,40 +204,10 @@ describe("streamOpenAICodexResponses retry classification", () => {
     { label: "unparseable", retryAfterMs: "not-a-number" },
     { label: "empty", retryAfterMs: "" },
   ])("honors retry-after when retry-after-ms is $label", async ({ retryAfterMs }) => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        new Response("rate limited", {
-          status: 429,
-          headers: { "retry-after-ms": retryAfterMs, "retry-after": "7" },
-        }),
-      )
-      .mockRejectedValueOnce(new Error("usage limit: stop after retry delay"));
-    vi.stubGlobal("fetch", fetchMock);
-    const setTimeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockImplementation((callback: TimerHandler) => {
-        if (typeof callback === "function") {
-          callback();
-        }
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      });
-
-    await streamOpenAICodexResponses(model, context, {
-      apiKey: jwt,
-      transport: "sse",
-    }).result();
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(setTimeoutSpy).not.toHaveBeenCalled();
-  });
-
-  it("carries Retry-After header timing in the terminal error text", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(JSON.stringify({ error: { message: "Too many requests" } }), {
+      new Response("rate limited", {
         status: 429,
-        statusText: "Too Many Requests",
-        headers: { "retry-after": "7" },
+        headers: { "retry-after-ms": retryAfterMs, "retry-after": "7" },
       }),
     );
     vi.stubGlobal("fetch", fetchMock);
@@ -247,10 +217,38 @@ describe("streamOpenAICodexResponses retry classification", () => {
       transport: "sse",
     }).result();
 
-    expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("Retry-After: 7 seconds");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    { status: 429, code: undefined, message: "Too many requests" },
+    { status: 500, code: undefined, message: "Maintenance in progress." },
+    { status: 503, code: undefined, message: "Maintenance in progress." },
+    { status: 503, code: "maintenance", message: "Maintenance in progress." },
+  ])(
+    "preserves HTTP $status and provider code $code for the retry owner",
+    async ({ status, code, message }) => {
+      const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ error: { message, code } }), {
+          status,
+          headers: { "retry-after": "7" },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await streamOpenAICodexResponses(model, context, {
+        apiKey: jwt,
+        transport: "sse",
+      }).result();
+
+      expect(result.stopReason).toBe("error");
+      expect(result.errorMessage).toMatch(new RegExp(`^${status}: `));
+      expect(result.errorCode).toBe(code ?? String(status));
+      expect(result.errorMessage).toContain("Retry-After: 7 seconds");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("does not retry a bodyless 304 response", async () => {
     const fetchMock = vi
@@ -265,7 +263,7 @@ describe("streamOpenAICodexResponses retry classification", () => {
     }).result();
 
     expect(result.stopReason).toBe("error");
-    expect(result.errorMessage).toBe("Not Modified");
+    expect(result.errorMessage).toBe("304: Not Modified");
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(setTimeoutSpy).not.toHaveBeenCalled();
   });

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -511,22 +511,7 @@ export const streamOpenAICodexResponses: StreamFunction<
           readChatGptResponsesErrorTextLimited(attemptResponse, activeSignal),
           hookStream[Symbol.asyncIterator]().next(),
         ]);
-        const info = parseErrorResponseText(
-          errorText,
-          attemptResponse.status,
-          attemptResponse.statusText,
-        );
-        const retryAfterSeconds = parseRetryAfterSeconds(attemptResponse.headers);
-        // Keep retry timing in the canonical error text so every retry owner sees
-        // the same bounded signal without extending the public AssistantMessage
-        // contract; mirrors formatAnthropicMessagesHttpError.
-        const retryAfterSuffix = Number.isFinite(retryAfterSeconds)
-          ? `; Retry-After: ${Math.ceil(retryAfterSeconds ?? 0)} seconds`
-          : "";
-        const terminalResponseError = new CodexApiError(
-          `${info.friendlyMessage || info.message}${retryAfterSuffix}`,
-          { code: info.code },
-        );
+        const terminalResponseError = parseErrorResponse(errorText, attemptResponse);
         if (activeSignal?.aborted) {
           throw transportAbortError(activeSignal);
         }
@@ -740,15 +725,22 @@ function resolveCodexWebSocketUrl(baseUrl?: string): string {
 
 class CodexApiError extends Error {
   readonly code?: string;
+  readonly status?: number;
   readonly payload?: Record<string, unknown>;
 
   constructor(
     message: string,
-    options?: { code?: string; payload?: Record<string, unknown>; cause?: unknown },
+    options?: {
+      code?: string;
+      status?: number;
+      payload?: Record<string, unknown>;
+      cause?: unknown;
+    },
   ) {
     super(message);
     this.name = "CodexApiError";
     this.code = options?.code;
+    this.status = options?.status;
     this.payload = options?.payload;
     this.cause = options?.cause;
   }
@@ -1625,11 +1617,8 @@ async function readChatGptResponsesErrorTextLimited(
   return text;
 }
 
-function parseErrorResponseText(
-  raw: string,
-  status: number,
-  statusText: string,
-): { code?: string; message: string; friendlyMessage?: string } {
+function parseErrorResponse(raw: string, response: Response): CodexApiError {
+  const { status, statusText } = response;
   let message = raw || statusText || "Request failed";
   let friendlyMessage: string | undefined;
   let code: string | undefined;
@@ -1662,7 +1651,13 @@ function parseErrorResponseText(
     }
   } catch {}
 
-  return { ...(code ? { code } : {}), message, friendlyMessage };
+  const retryAfterSeconds = parseRetryAfterSeconds(response.headers);
+  // The canonical projection retains HTTP status; retry owners read its bounded
+  // terminal text for pacing, matching formatAnthropicMessagesHttpError.
+  const retryAfterSuffix = Number.isFinite(retryAfterSeconds)
+    ? `; Retry-After: ${Math.ceil(retryAfterSeconds ?? 0)} seconds`
+    : "";
+  return new CodexApiError(`${friendlyMessage || message}${retryAfterSuffix}`, { code, status });
 }
 
 // ============================================================================

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -150,6 +150,7 @@ describe("gateway update action", () => {
           signal,
           timeoutMs: 1_200_000,
           forceSyntheticClient: true,
+          operatorRoleActor: { kind: "system" },
           syntheticScopes: ["operator.admin"],
           resolveGatewayContext: expect.any(Function),
         },

--- a/src/auto-reply/reply/commands-update.test.ts
+++ b/src/auto-reply/reply/commands-update.test.ts
@@ -146,6 +146,7 @@ describe("handleUpdateCommand", () => {
         timeoutMs: 1_200_000,
         resolveGatewayContext: expect.any(Function),
         forceSyntheticClient: true,
+        operatorRoleActor: { kind: "system" },
         syntheticScopes: ["operator.admin"],
       },
     );


### PR DESCRIPTION
Closes #137145

Related: #134281

## What Problem This Solves

Fixes an issue where users of the ChatGPT SSE transport could receive an avoidable failure or premature model fallback during a temporary HTTP outage. A response such as HTTP 503 with an unfamiliar message lost its status before retry classification, so three immediate empty-error retries exhausted recovery despite `Retry-After: 7`.

## Why This Change Was Made

HTTP error parsing now creates the typed provider error directly, carrying HTTP status and provider code into the existing canonical terminal projection alongside the retry hint. The failover controller remains the transient HTTP-response retry owner; WebSocket errors and encrypted-content recovery keep their existing paths. The temporary parsed-info handoff is removed, and retry documentation distinguishes embedded retries from SDK-only retry caps.

## User Impact

Transient ChatGPT SSE HTTP errors retain server-requested pacing even when their text or provider code is unfamiliar. Permanent HTTP failures keep their status and provider-specific code. No new configuration, dependency, public message field, or retry loop is introduced.

## Evidence

- Before the fix, four new transport regressions failed because HTTP 429/500/503 status was missing. After the fix, all 241 focused provider, projection, encrypted-replay, WebSocket, failure-owner, and retry-controller tests pass.
- Actual loopback HTTP 503 plus `Retry-After: 7`, using the real SSE transport and failure/retry controller: before, four requests arrived as a burst without consulting the controller; after, request times were 0/7114/14121/21124 ms without a fallback and 0/7005/14011/21020 ms with one. Every retry slept seven seconds, and the empty-error counter stayed zero. This is a synthetic server, not an authenticated outage test.
- A separate real loopback 503-then-200 recovery completed the expected synthetic reply after one paced retry (requests 0/7886 ms).
- Authenticated ChatGPT SSE smoke with `gpt-5.6-luna`: HTTP 200, completed expected synthetic reply, 26 input/10 output tokens, 1161 ms. A separate safe unsupported-parameter request returned HTTP 400 and retained the canonical status in its terminal error, with zero tokens. Existing read-only credential resolution was used; no refresh, auth-file copy, or operator-state change.
- Focused command: `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs packages/ai/src/providers/openai-chatgpt-responses packages/ai/src/utils/provider-error.test.ts src/agents/embedded-agent-runner/run/assistant-failure.test.ts src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts src/agents/embedded-agent-runner/run/helpers.test.ts`.
- `git diff --check` and the full `node scripts/check-changed.mjs -- <four changed paths>` gate pass, including core/core-test typechecks, formatting, lint, import cycles, and selected guards. Independent isolated Codex autoreview is scoped-clean through P2; a separate frozen-head review also found no P0/P1/P2 issue. The coordinator personally read the full producer, canonical projector, central retry owner and exact pinned dependency sources, then replayed 34 tests and real loopback 503-to-200 recovery (requests 0/7141 ms).
- Personally inspected pinned Codex `rust-v0.153.0` retry and API-error mapping contracts: `codex-rs/codex-client/src/retry.rs:22–35` and `codex-rs/codex-api/src/api_bridge.rs:66–186`. They preserve HTTP status; this does not alter native app-server retry policy.

Production LOC: +18/-23, net -5. Tests: +39/-35, net +4. Docs: +3/-3. No material persistent-store, protocol, or configuration changes.

The original 503 outage timing is exercised deterministically on loopback, not forced against the live service. The existing central classifier's 503-to-timeout reason mapping is unchanged. No further cleanup in this repair's invariant remains.

Exact publication candidate: `579f4ad615bb5910fa5f69c0eb1d94564ddf163d`. Hosted CI and repository-native landing gates remain pending; no release or publication of package artifacts is included.

### Integration and CI recovery

The initial CI merge failed an inherited node-host test-file max-lines check. Mainline PR #137149 now splits the exact failing file while retaining all 41 cases, so this candidate was rebased onto that fix and a redundant local fixture cleanup was discarded. The original four-file SSE patch and every source hash remain unchanged.

Refreshed local proof on this candidate: all 282 tests pass (the original 241 plus both upstream runner suites), the complete four-path changed gate passes, and fresh isolated Codex review is clean through P2. Actual loopback 503-to-200 recovery completes after one 7.064-second retry with no empty-error retry. Native Codex and OpenAI dependency versions are unchanged. Refreshed exact-head CI is required before landing.

### Shared-dispatch test correction

The refreshed CI run also exposed four inherited failures in the update-tool and `/update` tests. Mainline #136952 added the shared dispatcher’s explicit system actor, but those two exact expectations still omitted it. The coordinator reproduced all four failures on untouched main and added the missing actor field to both assertions. Owner gates, trusted routing, scopes, deadlines and no-remote-fallback assertions remain exact; no production policy or timeout changed.

On the final six-file candidate, all 332 tests across 15 files pass, including the two update callers and their shared helper; the complete changed-file gate passes. Fresh isolated Codex review is clean through P2. Real loopback HTTP 503-to-200 recovery completes after one 7.108-second paced retry with HTTP status preserved and zero empty-error retries. The original four-file SSE patch is byte-identical. Production remains net −5 lines; the CI correction adds two test lines. Earlier authenticated 200/400 receipts remain evidence for the unchanged transport, not newly rerun inference. Exact-head CI is still required before landing.

### Final documentation correction

Addressed the latest ClawSweeper finding and rank-up move: the retry page now explicitly preserves the one-time pre-stream WebSocket connection-limit reconnect and scopes controller ownership to transient HTTP-response retries. Runtime and test bytes are unchanged from the 332-test candidate above; the docs-only changed gate passes and a fresh isolated P0–P2 review is clean. Mainline #137196 independently added the same two update-test expectations, so those files are identical at merge and do not add duplicate changes. Exact-head hosted CI remains required.
