### PR TITLE
fix: stop returning expired tool event recipients

### DIFF
--- a/src/gateway/server-chat-state.test.ts
+++ b/src/gateway/server-chat-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createChatAbortMarker,
   createChatRunState,
@@ -6,6 +6,32 @@ import {
 } from "./server-chat-state.js";
 
 describe("createChatRunState", () => {
+  it.each([false, true])(
+    "stops returning finalized recipients at expiry (other state: %s)",
+    (keepState) => {
+      let now = 1_000;
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+      try {
+        const state = createChatRunState();
+        state.toolEventRecipients.add("finished", "conn-finished");
+        state.toolEventRecipients.add("active", "conn-active");
+        if (keepState) {
+          state.getOrCreate("finished").buffer = "retained";
+        }
+        state.toolEventRecipients.markFinal("finished");
+        now += 29_999;
+        expect(state.toolEventRecipients.get("finished")).toEqual(new Set(["conn-finished"]));
+        now += 1;
+        expect(state.toolEventRecipients.get("finished")).toBeUndefined();
+        expect(state.toolEventRecipients.get("finished")).toBeUndefined();
+        expect(state.toolEventRecipients.get("active")).toEqual(new Set(["conn-active"]));
+        expect(state.runs.has("finished")).toBe(keepState);
+      } finally {
+        clock.mockRestore();
+      }
+    },
+  );
+
   it("clears transient projection state without dropping run ownership or abort tombstones", () => {
     const state = createChatRunState();
     state.registry.add("run-1", { sessionKey: "session-1", clientRunId: "client-1" });

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -688,12 +688,12 @@ function createToolEventRecipientRegistryForStore(
 
   const get = (runId: string) => {
     const entry = store.runs.get(runId)?.toolRecipient;
-    if (!entry) {
-      return undefined;
+    if (entry) {
+      entry.updatedAt = Date.now();
+      prune();
     }
-    entry.updatedAt = Date.now();
-    prune();
-    return entry.connIds;
+    // Pruning may retire this finalized run; never return its former audience.
+    return store.runs.get(runId)?.toolRecipient?.connIds;
   };
 
   const markFinal = (runId: string) => {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2550,6 +2550,30 @@ describe("agent event handler", () => {
     );
   });
 
+  it("drops an expired run audience while preserving current session subscribers", () => {
+    const { nowSpy, broadcastToConnIds, toolEventRecipients, sessionEventSubscribers, handler } =
+      createHarness({ now: 1_000, resolveSessionKeyForRun: () => "session-1" });
+    try {
+      registerAgentRunContext("run-expired", { sessionKey: "session-1", verboseLevel: "off" });
+      toolEventRecipients.add("run-expired", "conn-run");
+      sessionEventSubscribers.subscribe("conn-session");
+      toolEventRecipients.markFinal("run-expired");
+      nowSpy!.mockReturnValue(31_000);
+
+      emitAgentEvent(handler, "run-expired", "tool", {
+        phase: "result",
+        name: "read",
+        toolCallId: "late-result",
+      });
+
+      expect(
+        broadcastToConnIds.mock.calls.map(([event, , recipients]) => [event, recipients]),
+      ).toEqual([["session.tool", new Set(["conn-session"])]]);
+    } finally {
+      nowSpy?.mockRestore();
+    }
+  });
+
   it("broadcasts tool events to WS recipients even when verbose is off, but skips node send", () => {
     const { broadcastToConnIds, nodeSendToSession, toolEventRecipients, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-1",


### PR DESCRIPTION
## What problem does this PR solve?

After the existing 30-second final grace expires, the first late tool event can still reach a finished run’s former audience. The recipient registry prunes its record but returns the Set captured before pruning. The actual agent-event handler then broadcasts to that expired audience once.

## Why is this the right fix?

The registry now returns the current store membership after pruning. Active recipient renewal, the fixed final grace, retained unrelated run state, and current session subscribers keep their existing behavior. This fixes the lifecycle owner rather than adding a consumer guard. Production +5/−5 (net zero); tests net +50. No memory or throughput claim.

## User-visible impact

Expired run subscriptions stop receiving late tool events immediately at their existing deadline. Current session subscribers continue receiving their tool events. There is no protocol, configuration, persistence, or permission change.

## Evidence

Before editing production, the original registry failed both expiry regressions, including a run with other retained state. The actual agent-event handler also failed by sending an extra `agent` event to the expired run connection while delivering the expected `session.tool` event to the current subscriber. The same regressions and both full affected suites pass after the fix: 217 tests.

- `node scripts/run-vitest.mjs run src/gateway/server-chat-state.test.ts src/gateway/server-chat.agent-events.test.ts`
- `node scripts/check-changed.mjs -- src/gateway/server-chat-state.ts src/gateway/server-chat-state.test.ts src/gateway/server-chat.agent-events.test.ts` passed (297.75 seconds).
- Independent source/history/lifecycle review and managed Codex review found no actionable P0–P2 issue. The behavior is reachable from stable v2026.2.12; the original implementation introduced the stale return.

The handler regression uses actual registry and routing with simulated event ingress/broadcast. It proves the deadline defect deterministically, not a live WebSocket late-event reproduction. Ordinary real-key Gateway integration passed in the campaign’s next feature run; the exact late-event deadline remains covered by the deterministic handler regression.


## Real Gateway integration (2026-09-03)

A prebuilt, isolated Gateway with a real OpenAI API key passed four fixed turns: ordinary completion, real `web_fetch` of example.com, a 1.31 MB Unicode return through Code Mode, and a real MCP stdio tool with default and explicit arguments. Fifty-seven Gateway RPCs verified three session identities, full/repeated/paginated/subscribed list rows, descriptions and final previews, transcript completion, an explicit reconnect, empty approval replay and unsubscribe.

The MCP server observed the default `id: alpha` before server-side validation, followed by explicit `id: beta`; both nested call identities/order, structured results and metadata projection matched. The Unicode prefix remained well formed and within its byte budget with exact omitted-byte accounting. All four turns completed without retries.

The local immutable composite `3bb6e3164a06e5c35fb50b368cc63cbb05826384` contains the twelve published campaign changes through #137148, including this PR’s reviewed source. Source/build/dependency identity was checked before and after. Both clients closed, the Gateway exited successfully without escalation, all recorded MCP processes exited, and private state/port cleanup passed. This is functional integration proof; it does not attribute memory or latency differences to this PR.
