### PR TITLE
fix(docs): match source anchor checks to published sections

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,14 +1,15 @@
 # Docs Guide
 
-This directory owns docs authoring, Mintlify link rules, and docs i18n policy.
+This directory owns docs authoring, published link rules, and docs i18n policy.
 
-## Mintlify Rules
+## Published Link Rules
 
 - Docs are published to `https://docs.openclaw.ai` from the `openclaw/docs` mirror.
 - Internal doc links in `docs/**/*.md` must stay root-relative with no `.md` or `.mdx` suffix (example: `[Config](/gateway/configuration)`).
 - Section cross-references should use anchors on root-relative paths (example: `[Hooks](/gateway/configuration-reference#hooks)`).
-- Doc headings should avoid em dashes and apostrophes because Mintlify anchor generation is brittle there.
-- README and other GitHub-rendered docs should keep absolute docs URLs so links work outside Mintlify.
+- Anchor IDs come from the shared publishing parser in `scripts/lib/docs-markdown.mjs`; verify them with `pnpm docs:check-links:anchors`, not Mintlify's independent checker. Published heading IDs stay stable; compatibility aliases never replace an existing target.
+- Use an explicit `<a id="stable-section-name" />` for a durable section link when heading wording may change. Keep existing named anchors when reorganizing content.
+- README and other GitHub-rendered docs should keep absolute docs URLs so links work outside the docs site.
 - Docs content must stay generic: no personal device names, hostnames, or local paths; use placeholders like `user@gateway-host`.
 
 ## Docs Content Rules

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -985,7 +985,8 @@ Useful env vars:
 ## Docs sanity
 
 Run docs checks after doc edits: `pnpm check:docs`.
-Run full Mintlify anchor validation when you need in-page heading checks too: `pnpm docs:check-links:anchors`.
+Run the shared publishing parser's anchor audit when you need in-page heading checks too: `pnpm docs:check-links:anchors`.
+Diagnostics show `unknown` when a reliable source line is unavailable.
 
 ## Offline regression (CI-safe)
 

--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// Audits docs links, routes, redirects, and Mintlify anchors.
-import { spawnSync } from "node:child_process";
+// Audits docs links against the shared publishing parser and route contract.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -11,7 +10,8 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import MarkdownIt from "markdown-it";
 import type { Nodes } from "mdast";
 import { resolveClawHubRepoPath, syncClawHubDocsTree } from "./docs-sync-publish.mjs";
-import { resolveNpmRunner } from "./npm-runner.mts";
+import { parseDocsDocument, resolveDocsFragment } from "./lib/docs-markdown.mjs";
+import { resolveRedirects } from "./lib/docs-redirects.mjs";
 
 const ROOT = process.cwd();
 const DOCS_DIR = path.join(ROOT, "docs");
@@ -22,59 +22,6 @@ const MARKDOWN_PARSER = new MarkdownIt({ html: false });
 const HTML_MARKDOWN_PARSER = new MarkdownIt({ html: true });
 type MarkdownToken = ReturnType<typeof MARKDOWN_PARSER.parse>[number];
 const VERBATIM_MDX_ELEMENTS = new Set(["code", "pre", "script", "style", "textarea"]);
-const MINTLIFY_CLI_VERSION = "4.2.808";
-const MINTLIFY_BROKEN_LINKS_ARGS = [
-  "exec",
-  "--yes",
-  `--package=mint@${MINTLIFY_CLI_VERSION}`,
-  "--",
-  "mint",
-  "broken-links",
-  "--check-anchors",
-];
-const NODE_25_UNSUPPORTED_BY_MINTLIFY = 25;
-
-type ScriptSpawnOptions = {
-  cwd: string;
-  env?: NodeJS.ProcessEnv;
-  shell?: boolean;
-  stdio: "ignore" | "inherit";
-  windowsVerbatimArguments?: boolean;
-};
-
-type ScriptSpawn = (
-  command: string,
-  args: string[],
-  options: ScriptSpawnOptions,
-) => { status: number | null };
-
-type RunDocsLinkAuditOptions = {
-  args?: string[];
-  comSpec?: string;
-  env?: NodeJS.ProcessEnv;
-  nodeExecPath?: string;
-  nodeVersion?: string;
-  platform?: NodeJS.Platform;
-  spawnSyncImpl?: ScriptSpawn;
-  prepareAnchorAuditDocsDirImpl?: typeof prepareAnchorAuditDocsDir;
-  prepareMirroredDocsDirImpl?: typeof prepareMirroredDocsDir;
-  cleanupAnchorAuditDocsDirImpl?: (dir: string) => void;
-};
-
-type MintlifyInvocationParams = Pick<
-  RunDocsLinkAuditOptions,
-  "comSpec" | "env" | "nodeExecPath" | "nodeVersion" | "platform"
-> & {
-  cwd: string;
-  spawnSyncImpl: ScriptSpawn;
-};
-
-type MintlifySpawnSpec = {
-  command: string;
-  args: string[];
-  options?: ScriptSpawnOptions;
-};
-
 if (!fs.existsSync(DOCS_DIR) || !fs.statSync(DOCS_DIR).isDirectory()) {
   console.error("docs:check-links: missing docs directory; run from repo root.");
   process.exit(1);
@@ -120,27 +67,6 @@ function collectMarkdownCodeLines(tokens: MarkdownToken[]): Set<number> {
     }
   }
   return lines;
-}
-
-function collectCodeLines(raw: string): Set<number> {
-  try {
-    const lines = new Set<number>();
-    const visit = (node: Nodes): void => {
-      if (node.type === "code" && node.position) {
-        for (let line = node.position.start.line; line <= node.position.end.line; line++) {
-          lines.add(line - 1);
-        }
-      }
-      if ("children" in node) {
-        node.children.forEach(visit);
-      }
-    };
-    visit(MDX_PROCESSOR.parse(raw));
-    return lines;
-  } catch {
-    // Legacy malformed MDX still needs the same tolerant code ranges as external-link auditing.
-    return collectMarkdownCodeLines(MARKDOWN_PARSER.parse(raw, {}));
-  }
 }
 
 /**
@@ -352,10 +278,6 @@ export function normalizeRoute(p: string) {
   return stripped ? `/${stripped}` : "/";
 }
 
-function stripInlineCode(text: string) {
-  return text.replace(/`[^`]+`/g, "");
-}
-
 function isLocalizedDocPath(p: string) {
   return /^\/?[a-z]{2}(?:-[A-Za-z]{2,8})+\//.test(p);
 }
@@ -510,74 +432,6 @@ function collectNavPageEntries(node: unknown): string[] {
   return entries;
 }
 
-const markdownLinkRegex = /!?\[[^\]]*\]\(([^)]+)\)/g;
-
-export function sanitizeDocsConfigForEnglishOnly(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value
-      .map((item) => sanitizeDocsConfigForEnglishOnly(item))
-      .filter((item) => item !== undefined);
-  }
-
-  if (!isRecord(value)) {
-    if (typeof value === "string" && isLocalizedDocPath(value)) {
-      return undefined;
-    }
-    return value;
-  }
-
-  const record = value;
-  if (typeof record.language === "string" && record.language !== "en") {
-    return undefined;
-  }
-
-  const sanitized: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(record)) {
-    const next = sanitizeDocsConfigForEnglishOnly(child);
-    if (next === undefined) {
-      continue;
-    }
-    if (Array.isArray(next) && next.length === 0) {
-      continue;
-    }
-    if (
-      next &&
-      typeof next === "object" &&
-      !Array.isArray(next) &&
-      Object.keys(next).length === 0
-    ) {
-      continue;
-    }
-    sanitized[key] = next;
-  }
-
-  if (record.pages && !Array.isArray(sanitized.pages)) {
-    return undefined;
-  }
-  if (record.groups && !Array.isArray(sanitized.groups)) {
-    return undefined;
-  }
-  if (record.tabs && !Array.isArray(sanitized.tabs)) {
-    return undefined;
-  }
-  if (
-    "source" in record &&
-    typeof record.source === "string" &&
-    typeof sanitized.source !== "string"
-  ) {
-    return undefined;
-  }
-  if (
-    "destination" in record &&
-    typeof record.destination === "string" &&
-    typeof sanitized.destination !== "string"
-  ) {
-    return undefined;
-  }
-
-  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
-}
-
 /** Prepares a docs directory, mirroring ClawHub docs when available. */
 export function prepareMirroredDocsDir(
   sourceDir = DOCS_DIR,
@@ -604,135 +458,28 @@ export function prepareMirroredDocsDir(
     return { dir: sourceRoot, mirroredClawHub: false, cleanup: () => {} };
   }
 
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docs-link-audit-"));
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docs-link-audit-"));
+  const tempDir = path.join(tempRoot, "docs");
   try {
     fs.cpSync(sourceRoot, tempDir, { recursive: true });
     syncClawHubDocsTreeImpl(tempDir, { repoPath: clawhubRepo, required: false });
     return {
       dir: tempDir,
       mirroredClawHub: true,
-      cleanup: () => fs.rmSync(tempDir, { recursive: true, force: true }),
+      cleanup: () => fs.rmSync(tempRoot, { recursive: true, force: true }),
     };
   } catch (error) {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(tempRoot, { recursive: true, force: true });
     throw error;
   }
-}
-
-/**
- * Creates an English-only temporary docs tree for Mintlify anchor checks.
- */
-export function prepareAnchorAuditDocsDir(sourceDir = DOCS_DIR) {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docs-anchor-audit-"));
-  try {
-    fs.cpSync(sourceDir, tempDir, { recursive: true });
-
-    for (const entry of fs.readdirSync(tempDir, { withFileTypes: true })) {
-      if (!entry.isDirectory()) {
-        continue;
-      }
-      if (!isGeneratedTranslatedDoc(`${entry.name}/`)) {
-        continue;
-      }
-      fs.rmSync(path.join(tempDir, entry.name), { recursive: true, force: true });
-    }
-
-    for (const filePath of walk(tempDir).filter((entry) => /\.mdx?$/iu.test(entry))) {
-      const raw = fs.readFileSync(filePath, "utf8");
-      const normalized = raw.replace(/<!--[\s\S]*?-->/gu, (comment) =>
-        comment.replace(/[^\r\n]/gu, ""),
-      );
-      if (normalized !== raw) {
-        fs.writeFileSync(filePath, normalized, "utf8");
-      }
-    }
-
-    const docsJsonPath = path.join(tempDir, "docs.json");
-    const docsConfig = JSON.parse(fs.readFileSync(docsJsonPath, "utf8"));
-    const sanitized = sanitizeDocsConfigForEnglishOnly(docsConfig);
-    fs.writeFileSync(docsJsonPath, `${JSON.stringify(sanitized, null, 2)}\n`, "utf8");
-
-    return tempDir;
-  } catch (error) {
-    fs.rmSync(tempDir, { recursive: true, force: true });
-    throw error;
-  }
-}
-
-function parseNodeMajor(version: string) {
-  const major = Number.parseInt(version.split(".")[0] ?? "", 10);
-  return Number.isFinite(major) ? major : 0;
-}
-
-function createMintlifyNpmRunnerSpawnSpec(
-  params: MintlifyInvocationParams,
-  options: { nodeExecPath?: string } = {},
-): MintlifySpawnSpec {
-  const env = params.env ?? process.env;
-  const runner = resolveNpmRunner({
-    comSpec: params.comSpec,
-    env,
-    execPath: options.nodeExecPath ?? params.nodeExecPath,
-    npmArgs: MINTLIFY_BROKEN_LINKS_ARGS,
-    platform: params.platform,
-  });
-  return {
-    command: runner.command,
-    args: runner.args,
-    options: {
-      cwd: params.cwd,
-      env: "env" in runner ? (runner.env ?? env) : env,
-      shell: runner.shell,
-      stdio: "inherit",
-      windowsVerbatimArguments:
-        "windowsVerbatimArguments" in runner ? runner.windowsVerbatimArguments : undefined,
-    },
-  };
-}
-
-/**
- * Mintlify currently rejects Node 25+. If the repo script itself is running
- * under a too-new experimental Node, probe common local version managers and
- * use their Node 22 wrapper for only the Mintlify child process.
- */
-function resolveMintlifyAnchorAuditInvocation(params: MintlifyInvocationParams): MintlifySpawnSpec {
-  const nodeVersion = params.nodeVersion ?? process.versions.node;
-  if (parseNodeMajor(nodeVersion) < NODE_25_UNSUPPORTED_BY_MINTLIFY) {
-    return createMintlifyNpmRunnerSpawnSpec(params);
-  }
-
-  const node22Probe = "process.exit(Number(process.versions.node.split('.')[0]) === 22 ? 0 : 1)";
-  const node22Runner = createMintlifyNpmRunnerSpawnSpec(params, { nodeExecPath: "node" });
-  const candidates = [
-    {
-      command: "fnm",
-      probeArgs: ["exec", "--using=22", "node", "-e", node22Probe],
-      args: ["exec", "--using=22", node22Runner.command, ...node22Runner.args],
-    },
-    {
-      command: "mise",
-      probeArgs: ["exec", "node@22", "--", "node", "-e", node22Probe],
-      args: ["exec", "node@22", "--", node22Runner.command, ...node22Runner.args],
-    },
-  ];
-
-  for (const candidate of candidates) {
-    const probe = params.spawnSyncImpl(candidate.command, candidate.probeArgs, {
-      cwd: params.cwd,
-      stdio: "ignore",
-    });
-    if (probe.status === 0) {
-      return { command: candidate.command, args: candidate.args };
-    }
-  }
-
-  return createMintlifyNpmRunnerSpawnSpec(params);
 }
 
 /**
  * Audits local docs links against route, file, and redirect indexes.
  */
-function auditDocsLinks(options: { docsDir?: string; allowExternalClawHubRoutes?: boolean } = {}) {
+function auditDocsLinks(
+  options: { docsDir?: string; allowExternalClawHubRoutes?: boolean; anchors?: boolean } = {},
+) {
   const docsDir = options.docsDir ?? DOCS_DIR;
   const index = buildAuditIndex(docsDir, {
     allowExternalClawHubRoutes: options.allowExternalClawHubRoutes === true,
@@ -740,97 +487,113 @@ function auditDocsLinks(options: { docsDir?: string; allowExternalClawHubRoutes?
   const broken: Array<{ file: string; line: number; link: string; reason: string }> = [];
   let checked = 0;
 
+  const pages = new Map<string, ReturnType<typeof parseDocsDocument>>();
+  const pageRoute = (rel: string) =>
+    normalizeRoute(rel.replace(/\.mdx?$/i, "").replace(/(?:^|\/)index$/, ""));
   for (const abs of index.markdownFiles) {
     const rel = normalizeSlashes(path.relative(index.docsDir, abs));
-    const baseDir = normalizeSlashes(path.dirname(rel));
+    pages.set(
+      pageRoute(rel),
+      parseDocsDocument(fs.readFileSync(abs, "utf8"), undefined, {
+        sourceFile: abs,
+        root: path.dirname(index.docsDir),
+        pageRoute: pageRoute(rel),
+      }),
+    );
+  }
+  const collisions = [...pages].flatMap(([route, document]) =>
+    document.collisions.map((collision) => ({ route, ...collision })),
+  );
+  if (options.anchors) {
+    for (const collision of collisions) {
+      if (collision.reason === "duplicate authored/canonical ID") {
+        broken.push({
+          file: collision.route,
+          line: 0,
+          link: `#${collision.id}`,
+          reason: collision.reason,
+        });
+      }
+    }
+  }
+  const redirectTargets = new Map<string, string>();
+  if (options.anchors) {
+    const records = resolveRedirects({
+      redirects: index.docsConfig.redirects ?? [],
+      pages: [...pages.keys()].map((route) => ({ route, markdownRoute: `${route}.md` })),
+      localeCodes: ["en"],
+      prefixes: [],
+      publicPath: (route: string) => route,
+      onError: (source: string, error: Error) =>
+        broken.push({ file: "docs.json", line: 0, link: source, reason: error.message }),
+    });
+    for (const record of records) {
+      redirectTargets.set(record.source, record.destination);
+      const destination = new URL(record.destination, "https://docs.openclaw.ai");
+      const page = pages.get(destination.pathname);
+      if (page && destination.hash && !resolveDocsFragment(destination.hash, new Set(page.ids))) {
+        broken.push({
+          file: "docs.json",
+          line: 0,
+          link: record.source,
+          reason: `redirect fragment not found: ${record.destination}`,
+        });
+      }
+    }
+  }
+  for (const abs of index.markdownFiles) {
+    const rel = normalizeSlashes(path.relative(index.docsDir, abs));
     const rawText = fs.readFileSync(abs, "utf8");
-    const lines = rawText.split("\n");
-
-    const codeLines = collectCodeLines(rawText);
-
-    for (let lineNum = 0; lineNum < lines.length; lineNum++) {
-      let line = lines[lineNum];
-      if (line === undefined) {
+    const document = pages.get(pageRoute(rel))!;
+    for (const raw of document.links) {
+      const local = !/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(raw);
+      const url = new URL(raw, `https://docs.openclaw.ai${pageRoute(rel)}`);
+      if (!local && url.hostname !== "docs.openclaw.ai") {
         continue;
       }
-
-      if (codeLines.has(lineNum)) {
+      if (!options.anchors && (!local || raw.startsWith("#"))) {
         continue;
       }
-
-      line = stripInlineCode(line);
-
-      for (const match of line.matchAll(markdownLinkRegex)) {
-        const raw = match[1]?.trim();
-        if (!raw) {
-          continue;
-        }
-        if (/^(https?:|mailto:|tel:|data:|#)/i.test(raw)) {
-          continue;
-        }
-
-        const pathPart = raw.split("#")[0] ?? "";
-        const clean = pathPart.split("?")[0];
-        if (!clean) {
-          continue;
-        }
-        checked++;
-
-        if (clean.startsWith("/")) {
-          const route = normalizeRoute(clean);
-          const resolvedRoute = resolveRoute(route, {
-            redirects: index.redirects,
-            routes: index.routes,
-          });
-          if (!resolvedRoute.ok) {
-            const staticRel = route.replace(/^\//, "");
-            if (!index.relAllFiles.has(staticRel)) {
-              broken.push({
-                file: rel,
-                line: lineNum + 1,
-                link: raw,
-                reason: `route/file not found (terminal: ${resolvedRoute.terminal})`,
-              });
-              continue;
-            }
-          }
-          continue;
-        }
-
-        if (!clean.startsWith(".") && !clean.includes("/")) {
-          continue;
-        }
-
-        const normalizedRel = normalizeSlashes(path.normalize(path.join(baseDir, clean)));
-
-        if (/\.[a-zA-Z0-9]+$/.test(normalizedRel)) {
-          if (!index.relAllFiles.has(normalizedRel)) {
-            broken.push({
-              file: rel,
-              line: lineNum + 1,
-              link: raw,
-              reason: "relative file not found",
-            });
-          }
-          continue;
-        }
-
-        const candidates = [
-          normalizedRel,
-          `${normalizedRel}.md`,
-          `${normalizedRel}.mdx`,
-          `${normalizedRel}/index.md`,
-          `${normalizedRel}/index.mdx`,
-        ];
-
-        if (!candidates.some((candidate) => index.relAllFiles.has(candidate))) {
-          broken.push({
-            file: rel,
-            line: lineNum + 1,
-            link: raw,
-            reason: "relative doc target not found",
-          });
-        }
+      checked++;
+      const offset = rawText.indexOf(raw);
+      const line = offset < 0 ? 0 : rawText.slice(0, offset).split("\n").length;
+      const route = pageRoute(decodeURIComponent(url.pathname)).replace(/^\/en(?:\/|$)/, "/");
+      let destination = url;
+      if (options.anchors && !pages.has(route) && redirectTargets.has(route)) {
+        destination = new URL(redirectTargets.get(route)!, url);
+      }
+      if (destination.hostname !== "docs.openclaw.ai") {
+        continue;
+      }
+      const terminal = pageRoute(destination.pathname).replace(/^\/en(?:\/|$)/, "/");
+      const page = pages.get(terminal);
+      const resolved = resolveRoute(route, { redirects: index.redirects, routes: index.routes });
+      if (
+        !page &&
+        (options.anchors || !resolved.ok) &&
+        !index.relAllFiles.has(decodeURIComponent(url.pathname).slice(1))
+      ) {
+        broken.push({
+          file: rel,
+          line,
+          link: raw,
+          reason: `route/file not found (terminal: ${resolved.terminal})`,
+        });
+      } else if (
+        options.anchors &&
+        destination.hash &&
+        page &&
+        (/\.mdx?$/.test(destination.pathname) ||
+          !resolveDocsFragment(destination.hash, new Set(page.ids)))
+      ) {
+        broken.push({
+          file: rel,
+          line,
+          link: raw,
+          reason: /\.mdx?$/.test(destination.pathname)
+            ? "fragment requires an HTML page, not raw Markdown"
+            : `fragment not found (terminal: ${terminal}${destination.hash})`,
+        });
       }
     }
   }
@@ -857,12 +620,12 @@ function auditDocsLinks(options: { docsDir?: string; allowExternalClawHubRoutes?
     });
   }
 
-  return { checked, broken };
+  return { checked, broken, collisions };
 }
 
 /** Runs the docs link audit CLI. */
-export function runDocsLinkAuditCli(options: RunDocsLinkAuditOptions = {}) {
-  const args = options.args ?? process.argv.slice(2);
+function runDocsLinkAuditCli() {
+  const args = process.argv.slice(2);
   if (args[0] === "--prepare-external-links") {
     if (args.length !== 2 || !args[1]) {
       console.error("usage: docs-link-audit.mjs --prepare-external-links <output-dir>");
@@ -874,60 +637,20 @@ export function runDocsLinkAuditCli(options: RunDocsLinkAuditOptions = {}) {
     return 0;
   }
 
-  if (args.includes("--anchors")) {
-    const spawnSyncImpl: ScriptSpawn =
-      options.spawnSyncImpl ??
-      ((command, spawnArgs, spawnOptions) => {
-        return spawnSync(command, spawnArgs, {
-          ...spawnOptions,
-          stdio: spawnOptions.stdio,
-        });
-      });
-    const prepareAnchorAuditDocsDirImpl =
-      options.prepareAnchorAuditDocsDirImpl ?? prepareAnchorAuditDocsDir;
-    const cleanupAnchorAuditDocsDirImpl =
-      options.cleanupAnchorAuditDocsDirImpl ??
-      ((dir) => fs.rmSync(dir, { recursive: true, force: true }));
-    const prepareMirroredDocsDirImpl = options.prepareMirroredDocsDirImpl ?? prepareMirroredDocsDir;
-    const mirroredDocsDir = prepareMirroredDocsDirImpl(DOCS_DIR);
-    let anchorDocsDir: string | undefined;
-
-    try {
-      anchorDocsDir = prepareAnchorAuditDocsDirImpl(mirroredDocsDir.dir);
-      // Mintlify's package graph expects npm's hoisted layout; pnpm dlx can fail
-      // to resolve declared transitive packages from its strict store layout.
-      const invocation = resolveMintlifyAnchorAuditInvocation({
-        comSpec: options.comSpec,
-        cwd: anchorDocsDir,
-        env: options.env,
-        nodeExecPath: options.nodeExecPath,
-        nodeVersion: options.nodeVersion,
-        platform: options.platform,
-        spawnSyncImpl,
-      });
-      const result = spawnSyncImpl(invocation.command, invocation.args, {
-        ...invocation.options,
-        cwd: anchorDocsDir,
-        stdio: "inherit",
-      });
-
-      return result.status ?? 1;
-    } finally {
-      if (anchorDocsDir) {
-        cleanupAnchorAuditDocsDirImpl(anchorDocsDir);
-      }
-      mirroredDocsDir.cleanup();
-    }
-  }
-
   const mirroredDocsDir = prepareMirroredDocsDir(DOCS_DIR);
   try {
-    const { checked, broken } = auditDocsLinks({
+    const { checked, broken, collisions } = auditDocsLinks({
       docsDir: mirroredDocsDir.dir,
       allowExternalClawHubRoutes: !mirroredDocsDir.mirroredClawHub,
+      anchors: args.includes("--anchors"),
     });
     console.log(`checked_internal_links=${checked}`);
     console.log(`broken_links=${broken.length}`);
+    if (args.includes("--anchors")) {
+      console.log(
+        `omitted_compatibility_aliases=${collisions.filter((item) => item.reason === "compatibility alias collision").length}`,
+      );
+    }
 
     for (const item of broken) {
       console.log(`${item.file}:${item.line} :: ${item.link} :: ${item.reason}`);

--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { createProcessor } from "@mdx-js/mdx";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import MarkdownIt from "markdown-it";
 import type { Nodes } from "mdast";
 import { resolveClawHubRepoPath, syncClawHubDocsTree } from "./docs-sync-publish.mjs";
@@ -474,6 +475,23 @@ export function prepareMirroredDocsDir(
   }
 }
 
+function parseAuditUrl(
+  href: string,
+  base = "https://docs.openclaw.ai",
+): Result<{ hostname: string; pathname: string; hash: string }, string> {
+  try {
+    const url = new URL(href, base);
+    return ok({
+      hostname: url.hostname,
+      pathname:
+        url.hostname === "docs.openclaw.ai" ? decodeURIComponent(url.pathname) : url.pathname,
+      hash: url.hash,
+    });
+  } catch (error) {
+    return err(error instanceof URIError ? "malformed URL path" : "malformed URL");
+  }
+}
+
 /**
  * Audits local docs links against route, file, and redirect indexes.
  */
@@ -500,6 +518,7 @@ function auditDocsLinks(
         sourceFile: abs,
         root: path.dirname(index.docsDir),
         pageRoute: pageRoute(rel),
+        mapLink: (href: string, line: number | undefined) => ({ href, line: line ?? 0 }),
       }),
     );
   }
@@ -518,7 +537,7 @@ function auditDocsLinks(
       }
     }
   }
-  const redirectTargets = new Map<string, string>();
+  const redirectTargets = new Map<string, ReturnType<typeof parseAuditUrl>>();
   if (options.anchors) {
     const records = resolveRedirects({
       redirects: index.docsConfig.redirects ?? [],
@@ -530,8 +549,21 @@ function auditDocsLinks(
         broken.push({ file: "docs.json", line: 0, link: source, reason: error.message }),
     });
     for (const record of records) {
-      redirectTargets.set(record.source, record.destination);
-      const destination = new URL(record.destination, "https://docs.openclaw.ai");
+      const destinationResult = parseAuditUrl(record.destination);
+      redirectTargets.set(record.source, destinationResult);
+      if (!destinationResult.ok) {
+        broken.push({
+          file: "docs.json",
+          line: 0,
+          link: record.source,
+          reason: destinationResult.error,
+        });
+        continue;
+      }
+      const destination = destinationResult.value;
+      if (destination.hostname !== "docs.openclaw.ai") {
+        continue;
+      }
       const page = pages.get(destination.pathname);
       if (page && destination.hash && !resolveDocsFragment(destination.hash, new Set(page.ids))) {
         broken.push({
@@ -545,25 +577,32 @@ function auditDocsLinks(
   }
   for (const abs of index.markdownFiles) {
     const rel = normalizeSlashes(path.relative(index.docsDir, abs));
-    const rawText = fs.readFileSync(abs, "utf8");
     const document = pages.get(pageRoute(rel))!;
-    for (const raw of document.links) {
+    for (const { href: raw, line } of document.links) {
       const local = !/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(raw);
-      const url = new URL(raw, `https://docs.openclaw.ai${pageRoute(rel)}`);
-      if (!local && url.hostname !== "docs.openclaw.ai") {
-        continue;
-      }
       if (!options.anchors && (!local || raw.startsWith("#"))) {
         continue;
       }
-      checked++;
-      const offset = rawText.indexOf(raw);
-      const line = offset < 0 ? 0 : rawText.slice(0, offset).split("\n").length;
-      const route = pageRoute(decodeURIComponent(url.pathname)).replace(/^\/en(?:\/|$)/, "/");
-      let destination = url;
-      if (options.anchors && !pages.has(route) && redirectTargets.has(route)) {
-        destination = new URL(redirectTargets.get(route)!, url);
+      const urlResult = parseAuditUrl(raw, `https://docs.openclaw.ai${pageRoute(rel)}`);
+      if (urlResult.ok && urlResult.value.hostname !== "docs.openclaw.ai") {
+        continue;
       }
+      checked++;
+      if (!urlResult.ok) {
+        broken.push({ file: rel, line, link: raw, reason: urlResult.error });
+        continue;
+      }
+      const url = urlResult.value;
+      const route = pageRoute(url.pathname).replace(/^\/en(?:\/|$)/, "/");
+      const destinationResult =
+        options.anchors && !pages.has(route) && redirectTargets.has(route)
+          ? redirectTargets.get(route)!
+          : urlResult;
+      if (!destinationResult.ok) {
+        broken.push({ file: rel, line, link: raw, reason: destinationResult.error });
+        continue;
+      }
+      const destination = destinationResult.value;
       if (destination.hostname !== "docs.openclaw.ai") {
         continue;
       }
@@ -573,7 +612,7 @@ function auditDocsLinks(
       if (
         !page &&
         (options.anchors || !resolved.ok) &&
-        !index.relAllFiles.has(decodeURIComponent(url.pathname).slice(1))
+        !index.relAllFiles.has(url.pathname.slice(1))
       ) {
         broken.push({
           file: rel,
@@ -655,7 +694,7 @@ function runDocsLinkAuditCli() {
     }
 
     for (const item of broken) {
-      console.log(`${item.file}:${item.line} :: ${item.link} :: ${item.reason}`);
+      console.log(`${item.file}:${item.line || "unknown"} :: ${item.link} :: ${item.reason}`);
     }
 
     return broken.length > 0 ? 1 : 0;

--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -487,6 +487,8 @@ function auditDocsLinks(
   const broken: Array<{ file: string; line: number; link: string; reason: string }> = [];
   let checked = 0;
 
+  // The publisher writes physical/index routes; frontmatter permalinks do not
+  // create pages. Only emitted pages and configured redirects can prove fragments.
   const pages = new Map<string, ReturnType<typeof parseDocsDocument>>();
   const pageRoute = (rel: string) =>
     normalizeRoute(rel.replace(/\.mdx?$/i, "").replace(/(?:^|\/)index$/, ""));

--- a/scripts/lib/docs-markdown.mjs
+++ b/scripts/lib/docs-markdown.mjs
@@ -57,6 +57,68 @@ const inlineComponents = new Set(["Badge", "Tooltip"]);
 const gridComponents = new Set(["CardGroup", "Columns"]);
 const componentTag = /<(\/)?([A-Z][A-Za-z0-9_.-]*)\b([^>]*)>/g;
 
+// Track source lines through the existing rewrites; inserted snippet content has
+// no location in the including file. This metadata never enters rendered tokens.
+class DocsSource {
+  constructor(text, firstLine) {
+    this.text = text;
+    if (firstLine === undefined) {
+      this.origins = [];
+      return;
+    }
+    let line = firstLine;
+    this.origins = Array.from({ length: text.length }, (_, index) => {
+      const origin = line;
+      if (text[index] === "\n") {
+        line++;
+      }
+      return origin;
+    });
+  }
+
+  replace(pattern, replacement, mapped = true) {
+    if (!this.origins.length) {
+      this.text = this.text.replace(pattern, replacement);
+      return this;
+    }
+    const origins = [];
+    let end = 0;
+    this.text = this.text.replace(pattern, (...args) => {
+      const offset = args.at(-2);
+      const value = typeof replacement === "function" ? replacement(...args) : replacement;
+      for (let i = end; i < offset; i++) {
+        origins.push(this.origins[i]);
+      }
+      for (let i = 0; i < value.length; i++) {
+        origins.push(
+          value === args[0] ? this.origins[offset + i] : mapped ? this.origins[offset] : undefined,
+        );
+      }
+      end = offset + args[0].length;
+      return value;
+    });
+    for (let i = end; i < this.origins.length; i++) {
+      origins.push(this.origins[i]);
+    }
+    this.origins = origins;
+    return this;
+  }
+
+  lines() {
+    if (!this.origins.length) {
+      return [];
+    }
+    let offset = 0;
+    return this.text.split("\n").map((line) => {
+      const origins = new Set(
+        this.origins.slice(offset, offset + line.length).filter((origin) => origin !== undefined),
+      );
+      offset += line.length + 1;
+      return origins.size === 1 ? origins.values().next().value : undefined;
+    });
+  }
+}
+
 function preprocess(input) {
   let out = input.replace(/\r\n/g, "\n").replace(/^import\s+.+?;?\s*$/gm, "");
   out = out.replace(
@@ -139,16 +201,32 @@ function escapeAttr(value) {
   return escapeHtml(value).replaceAll("'", "&#39;");
 }
 
+// Inline tokens lack block maps. Capture the parser cursor before link rules
+// normalize hrefs or replace reference metadata, only for diagnostic projections.
+const inlineLines = new WeakMap();
+
 /** @public Consumed by openclaw/docs mdx-ish.mjs through the docs-sync support contract. */
 export function createDocsMarkdown(options = {}) {
-  return new MarkdownIt({ html: true, linkify: false, typographer: false, ...options }).use(anchor);
+  const md = new MarkdownIt({ html: true, linkify: false, typographer: false, ...options }).use(
+    anchor,
+  );
+  md.inline.State = class extends md.inline.State {
+    push(type, tag, nesting) {
+      const token = super.push(type, tag, nesting);
+      if (this.env.trackSourceLines && ["link_open", "image", "html_inline"].includes(type)) {
+        inlineLines.set(token, this.src.slice(0, this.pos).split("\n").length - 1);
+      }
+      return token;
+    }
+  };
+  return md;
 }
 
 const codeParser = new MarkdownIt({ html: false });
 
 // Normalize the renderer's component indentation before CommonMark identifies code.
 // Literal regions are restored only after preprocessing, so examples cannot become components.
-function prepareDocument(input, { sourceFile, root, seen = new Set() } = {}) {
+function prepareDocument(input, { sourceFile, root, seen = new Set() }, firstLine) {
   const saved = [];
   let prefix = "OPENCLAWVERBATIM";
   while (input.includes(prefix)) {
@@ -162,7 +240,7 @@ function prepareDocument(input, { sourceFile, root, seen = new Set() } = {}) {
     return key;
   };
   const jsxComments = new Set();
-  let text = input.replace(
+  let text = new DocsSource(input, firstLine).replace(
     /<!--[^]*?-->|\{\/\*[^]*?\*\/\}|<(pre|code|script|style|textarea)\b[^>]*>[^]*?<\/\1\s*>/g,
     (value) => {
       if (value.startsWith("{/*")) {
@@ -173,61 +251,58 @@ function prepareDocument(input, { sourceFile, root, seen = new Set() } = {}) {
   );
   let depth = 0;
   let fence;
-  text = text
-    .split("\n")
-    .map((line) => {
-      const normalized = depth ? line.replace(new RegExp(`^ {1,${depth * 2}}`), "") : line;
-      const match = normalized.match(/^\s*(?:[-*+] |\d+[.)] )?(`{3,}|~{3,})(.*)$/);
-      if (fence) {
-        if (
-          match &&
-          match[1][0] === fence[0] &&
-          match[1].length >= fence.length &&
-          !match[2].trim()
-        ) {
-          fence = undefined;
-        }
-        return normalized;
-      }
-      if (match) {
-        fence = match[1];
-        return normalized;
-      }
-      for (const [, closing, name, attrs] of normalized
-        .replace(/(`+)[^\n]*?\1/g, "")
-        .matchAll(componentTag)) {
-        if (
-          inlineComponents.has(name) ||
-          !(
-            components.has(name) ||
-            knownBlocks.has(name) ||
-            callouts.has(name) ||
-            gridComponents.has(name)
-          )
-        ) {
-          continue;
-        }
-        if (closing) {
-          depth = Math.max(0, depth - 1);
-        } else if (!attrs.endsWith("/")) {
-          depth++;
-        }
+  // Keep split("\n") semantics: CRLF must not create extra code-line entries.
+  text = text.replace(/(?<=^|\n)[^\n]*/g, (line) => {
+    const normalized = depth ? line.replace(new RegExp(`^ {1,${depth * 2}}`), "") : line;
+    const match = normalized.match(/^\s*(?:[-*+] |\d+[.)] )?(`{3,}|~{3,})(.*)$/);
+    if (fence) {
+      if (
+        match &&
+        match[1][0] === fence[0] &&
+        match[1].length >= fence.length &&
+        !match[2].trim()
+      ) {
+        fence = undefined;
       }
       return normalized;
-    })
-    .join("\n");
-  const lines = text.split("\n");
+    }
+    if (match) {
+      fence = match[1];
+      return normalized;
+    }
+    for (const [, closing, name, attrs] of normalized
+      .replace(/(`+)[^\n]*?\1/g, "")
+      .matchAll(componentTag)) {
+      if (
+        inlineComponents.has(name) ||
+        !(
+          components.has(name) ||
+          knownBlocks.has(name) ||
+          callouts.has(name) ||
+          gridComponents.has(name)
+        )
+      ) {
+        continue;
+      }
+      if (closing) {
+        depth = Math.max(0, depth - 1);
+      } else if (!attrs.endsWith("/")) {
+        depth++;
+      }
+    }
+    return normalized;
+  });
   const codeLines = new Set();
-  for (const token of codeParser.parse(text, {})) {
+  for (const token of codeParser.parse(text.text, {})) {
     if ((token.type === "fence" || token.type === "code_block") && token.map) {
       for (let i = token.map[0]; i < token.map[1]; i++) {
         codeLines.add(i);
       }
     }
   }
-  text = lines
-    .map((line, i) => (codeLines.has(i) ? hold(line) : line))
-    .join("\n")
+  let sourceLine = 0;
+  text = text
+    .replace(/(?<=^|\n)[^\n]*/g, (line) => (codeLines.has(sourceLine++) ? hold(line) : line))
     .replace(/(`+)([^]*?)\1/g, hold);
   // Code captures have already restored their inner comment bytes. Remove only
   // standalone JSX comments, never comment syntax inside a protected literal.
@@ -235,28 +310,32 @@ function prepareDocument(input, { sourceFile, root, seen = new Set() } = {}) {
     jsxComments.has(Number(index)) ? saved[Number(index)].replace(/[^\n]/g, " ") : key,
   );
   if (sourceFile) {
-    text = text.replace(/<Snippet\b([^>]*)\/>/g, (_, rawAttrs) => {
-      const attrs = parseAttrs(rawAttrs);
-      const ref = attrs.file ?? attrs.src;
-      if (!ref) {
-        return "";
-      }
-      const target = path.resolve(path.dirname(sourceFile), ref);
-      const relative = path.relative(root, target);
-      if (
-        relative.startsWith("..") ||
-        path.isAbsolute(relative) ||
-        seen.has(target) ||
-        !fs.existsSync(target)
-      ) {
-        return "";
-      }
-      const content = parseFrontmatter(fs.readFileSync(target, "utf8")).content;
-      return `\n${prepareDocument(content, { sourceFile: target, root, seen: new Set([...seen, target]) }).trim()}\n`;
-    });
+    text = text.replace(
+      /<Snippet\b([^>]*)\/>/g,
+      (_, rawAttrs) => {
+        const attrs = parseAttrs(rawAttrs);
+        const ref = attrs.file ?? attrs.src;
+        if (!ref) {
+          return "";
+        }
+        const target = path.resolve(path.dirname(sourceFile), ref);
+        const relative = path.relative(root, target);
+        if (
+          relative.startsWith("..") ||
+          path.isAbsolute(relative) ||
+          seen.has(target) ||
+          !fs.existsSync(target)
+        ) {
+          return "";
+        }
+        const content = parseFrontmatter(fs.readFileSync(target, "utf8")).content;
+        return `\n${prepareDocument(content, { sourceFile: target, root, seen: new Set([...seen, target]) }).text.trim()}\n`;
+      },
+      false,
+    );
   }
   text = preprocess(text);
-  return restore(text);
+  return text.replace(placeholder, (_, index) => saved[Number(index)], false);
 }
 
 // mint@4.2.808 -> common@1.0.1096: slugify.js and remarkComponentIds.js.
@@ -293,10 +372,12 @@ function deduplicateMintId(id, seen) {
   return result;
 }
 
-function readHtmlTargets(html) {
+function readHtmlTargets(chunks) {
   const ids = [];
   const links = [];
   let verbatim = 0;
+  let chunk;
+  let offset = 0;
   const parser = new Parser({
     onopentag(name, attrs) {
       if (attrs.id) {
@@ -308,7 +389,10 @@ function readHtmlTargets(html) {
       if (!verbatim) {
         for (const key of ["href", "src", "data-href"]) {
           if (attrs[key]) {
-            links.push(attrs[key]);
+            const line = chunk.lineAt?.(
+              chunk.html.slice(0, parser.startIndex - offset).split("\n").length - 1,
+            );
+            links.push({ href: attrs[key], line });
           }
         }
       }
@@ -319,7 +403,11 @@ function readHtmlTargets(html) {
       }
     },
   });
-  parser.end(html);
+  for (chunk of chunks) {
+    parser.write(chunk.html);
+    offset += chunk.html.length;
+  }
+  parser.end();
   return { ids, links };
 }
 
@@ -339,9 +427,14 @@ export function resolveDocsFragment(hash, ids) {
 
 /** @public Consumed by openclaw/docs mdx-ish.mjs through the docs-sync support contract. */
 export function parseDocsDocument(markdown, md = createDocsMarkdown(), options = {}) {
-  const env = {};
+  const env = options.mapLink ? { trackSourceLines: true } : {};
   const parsed = parseFrontmatter(markdown);
-  const tokens = md.parse(prepareDocument(parsed.content, options), env);
+  const firstLine = options.mapLink
+    ? markdown.slice(0, markdown.length - parsed.content.length).split("\n").length
+    : undefined;
+  const source = prepareDocument(parsed.content, options, firstLine);
+  const sourceLines = source.lines();
+  const tokens = md.parse(source.text, env);
   const reserved = new Set();
   const ids = [];
   const links = [];
@@ -363,13 +456,15 @@ export function parseDocsDocument(markdown, md = createDocsMarkdown(), options =
       ids.push(id);
     }
   };
-  const scanHtml = (html) => {
-    const found = readHtmlTargets(html);
+  const scanHtml = (chunks) => {
+    const found = readHtmlTargets(chunks);
     found.ids.forEach(reserve);
     links.push(...found.links);
   };
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i];
+    const lineAt =
+      options.mapLink && token.map ? (offset) => sourceLines[token.map[0] + offset] : undefined;
     if (token.type === "heading_open") {
       const id = token.attrGet("id");
       reserve(id);
@@ -401,11 +496,12 @@ export function parseDocsDocument(markdown, md = createDocsMarkdown(), options =
       }
     }
     if (token.type === "html_block") {
+      const original = token.content;
       token.content = token.content.replace(
         /(<div class="maturity-category-docs">)([\s\S]*?)(<\/div>)/g,
         (_, open, body, close) => `${open}${normalizeEmbeddedMarkdownLinks(body)}${close}`,
       );
-      scanHtml(token.content);
+      scanHtml([{ html: token.content, lineAt: token.content === original ? lineAt : undefined }]);
     }
     if (token.type !== "inline") {
       continue;
@@ -453,12 +549,23 @@ export function parseDocsDocument(markdown, md = createDocsMarkdown(), options =
       }
       for (const key of ["href", "primaryHref", "secondaryHref"]) {
         if (attrs[key]) {
-          links.push(md.utils.unescapeAll(attrs[key]));
+          links.push({ href: md.utils.unescapeAll(attrs[key]), line: lineAt?.(0) });
         }
       }
       continue;
     }
-    scanHtml(md.renderer.renderInline(token.children ?? [], md.options, env));
+    const children = token.children ?? [];
+    scanHtml(
+      children.map((child, index) => ({
+        html: md.renderer.rules[child.type]
+          ? md.renderer.rules[child.type](children, index, md.options, env, md.renderer)
+          : md.renderer.renderToken(children, index, md.options),
+        lineAt:
+          lineAt && inlineLines.has(child)
+            ? (offset) => lineAt(inlineLines.get(child) + offset)
+            : undefined,
+      })),
+    );
   }
   // Published headings and authored HTML/component IDs win regardless of order.
   // Aliases never steal them; ambiguous aliases are omitted and reported.
@@ -502,7 +609,12 @@ export function parseDocsDocument(markdown, md = createDocsMarkdown(), options =
     tokens,
     env,
     ids,
-    links: links.map((href) => relativeDocsHref(href, options)),
+    // The publisher consumes href strings. Audits project each occurrence here,
+    // before its source location is discarded, without a parallel return field.
+    links: links.map(({ href, line }) => {
+      const target = relativeDocsHref(href, options);
+      return options.mapLink ? options.mapLink(target, line) : target;
+    }),
     collisions,
   };
 }

--- a/src/commands/agent-exec.construction.test.ts
+++ b/src/commands/agent-exec.construction.test.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as realDelay } from "node:timers/promises";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isProcessAlive, waitForDead, waitForPidFile } from "../../test/helpers/process-wait.js";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import * as cliBackends from "../plugins/cli-backends.runtime.js";
+import { getProcessSupervisor } from "../process/supervisor/index.js";
+import type { SpawnInput } from "../process/supervisor/types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { agentExecCommand } from "./agent-exec.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("agent exec command composition", () => {
+  it("bounds blocked service-relay construction through the shipped CLI command", async () => {
+    const root = tempDirs.make("openclaw-agent-exec-service-construction-");
+    const pidPath = path.join(root, "command.pid");
+    const configPath = path.join(root, "openclaw.json");
+    const createSecretData = vi.fn(() => Buffer.alloc(8 * 1024 * 1024, 97));
+    // Claude's plugin-owned SDK bypasses the supervisor. A registered process backend
+    // keeps the real command route and blocks construction on an unread secret pipe.
+    vi.spyOn(cliBackends, "resolveRuntimeCliBackends").mockReturnValue([
+      {
+        id: "construction-cli",
+        pluginId: "construction-test",
+        config: {
+          command: process.execPath,
+          args: [
+            "-e",
+            `require("node:fs").writeFileSync(${JSON.stringify(pidPath)}, String(process.pid)); setInterval(() => {}, 1000);`,
+          ],
+          input: "stdin",
+          output: "text",
+        },
+        prepareExecution: () => ({
+          beforeExecution: async () => {
+            // Freeze at the backend's queue admission, after cold command preparation.
+            // Real process readiness must precede advancing the construction deadline.
+            vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+          },
+          secretInput: {
+            fd: 3,
+            fingerprint: "synthetic-construction",
+            createData: createSecretData,
+          },
+        }),
+      },
+    ]);
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        agents: {
+          defaults: {
+            model: { primary: "construction-cli/model-a" },
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const completed = await withEnvAsync(
+      {
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+      },
+      async () => {
+        const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+        const supervisor = getProcessSupervisor();
+        const spawn = supervisor.spawn.bind(supervisor);
+        const admitted = createDeferred<SpawnInput>();
+        vi.spyOn(supervisor, "spawn").mockImplementation((input) => {
+          const pending = spawn(input);
+          admitted.resolve(input);
+          return pending;
+        });
+        const result = agentExecCommand(
+          "probe",
+          { config: configPath, cwd: root, timeout: "1", json: true },
+          runtime,
+        );
+        let commandPid: number | undefined;
+        let input: SpawnInput | undefined;
+        try {
+          input = await Promise.race([
+            admitted.promise,
+            result.then((finished) => {
+              throw new Error(
+                `Command ended before supervisor admission: ${JSON.stringify(finished)}`,
+              );
+            }),
+          ]);
+          commandPid = await waitForPidFile(pidPath, 3_000, realDelay);
+          expect(isProcessAlive(commandPid)).toBe(true);
+          expect(createSecretData).toHaveBeenCalledOnce();
+          expect(input).toMatchObject({
+            mode: "child",
+            backendId: "construction-cli",
+            timeoutMs: 1_000,
+          });
+          const runId = expectDefined(input.runId, "command supervisor run ID");
+          expect(supervisor.getRecord(runId)).toMatchObject({ state: "starting" });
+          await vi.advanceTimersByTimeAsync(999);
+          expect(supervisor.getRecord(runId)).toMatchObject({ state: "starting" });
+          await vi.advanceTimersByTimeAsync(1);
+          expect(supervisor.getRecord(runId)).toMatchObject({
+            state: "exited",
+            terminationReason: "overall-timeout",
+          });
+          vi.useRealTimers();
+          const finished = await result;
+          await waitForDead(commandPid, 5_000);
+          return finished;
+        } finally {
+          vi.useRealTimers();
+          if (input?.runId) {
+            supervisor.cancel(input.runId);
+          }
+          if (commandPid && isProcessAlive(commandPid)) {
+            process.kill(commandPid, "SIGKILL");
+          }
+          await result;
+        }
+      },
+    );
+    expect(completed.exitCode).toBe(2);
+    expect(completed.envelope).toMatchObject({
+      ok: false,
+      status: "timeout",
+    });
+  });
+});

--- a/src/commands/agent-exec.test.ts
+++ b/src/commands/agent-exec.test.ts
@@ -6,7 +6,6 @@ import { Readable } from "node:stream";
 import { promisify } from "node:util";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { waitForDead, waitForPidFile } from "../../test/helpers/process-wait.js";
 import { cleanupTempDirs, useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { AgentRunTerminalOutcomeError } from "../agents/agent-run-terminal-error.js";
 import { createAgentHarnessToolSurfaceRuntimeCore } from "../agents/harness/tool-surface-bridge.js";
@@ -19,7 +18,6 @@ import {
 } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { withEnvAsync } from "../test-utils/env.js";
 import {
   buildExecRunConfig,
   resolveAgentExecPrompt,
@@ -198,74 +196,6 @@ describe("agent exec strict result classification", () => {
 });
 
 describe("agent exec command composition", () => {
-  it("bounds blocked service-relay construction through the shipped CLI command", async () => {
-    const root = tempDirs.make("openclaw-agent-exec-service-construction-");
-    const binDir = path.join(root, "bin");
-    const pidPath = path.join(root, "command.pid");
-    const configPath = path.join(root, "openclaw.json");
-    await fs.mkdir(binDir);
-    const claudePath = path.join(binDir, "claude");
-    await fs.writeFile(
-      claudePath,
-      `#!/bin/sh
-printf '%s' "$$" > ${JSON.stringify(pidPath)}
-sleep 60
-`,
-      "utf8",
-    );
-    await fs.chmod(claudePath, 0o755);
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        agents: {
-          defaults: {
-            model: { primary: "anthropic/claude-opus-4-7" },
-            models: {
-              "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
-            },
-          },
-        },
-      }),
-      "utf8",
-    );
-
-    const completed = await withEnvAsync(
-      {
-        ANTHROPIC_API_KEY: "synthetic-proof-key",
-        NODE_DISABLE_COMPILE_CACHE: "1",
-        OPENCLAW_SERVICE_MARKER: "openclaw",
-        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-      },
-      async () => {
-        const { runtime } = createRuntime();
-        const result = agentExecCommand(
-          "probe",
-          { config: configPath, cwd: root, timeout: "1", json: true },
-          runtime,
-        );
-        let commandPid: number;
-        try {
-          commandPid = await waitForPidFile(pidPath, 3_000);
-        } catch (error) {
-          const failed = await result;
-          throw new Error(
-            `agent exec did not start the fake CLI: ${String(error)} exit=${String(failed.exitCode)} envelope=${JSON.stringify(failed.envelope)}`,
-            { cause: error },
-          );
-        }
-        expect(commandPid).toBeGreaterThan(0);
-        const finished = await result;
-        await waitForDead(commandPid, 5_000);
-        return finished;
-      },
-    );
-    expect(completed.exitCode).toBe(2);
-    expect(completed.envelope).toMatchObject({
-      ok: false,
-      status: "timeout",
-    });
-  });
-
   it("writes plain final text to stdout when diagnostics are routed to stderr", async () => {
     const source = `
       import { agentExecCommand } from "./src/commands/agent-exec.ts";

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -2,7 +2,8 @@ import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { setTimeout as realDelay } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { waitForPidFile } from "../../../../test/helpers/process-wait.js";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { createProcessSupervisor } from "../supervisor.js";
@@ -35,9 +36,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<voi
     if (Date.now() >= deadline) {
       throw new Error("timed out waiting for process state");
     }
-    await new Promise((resolve) => {
-      setTimeout(resolve, 20);
-    });
+    await realDelay(20);
   }
 }
 
@@ -50,6 +49,7 @@ function parsePidPair(output: string): [number, number] {
 }
 
 afterEach(async () => {
+  vi.useRealTimers();
   delete process.env.OPENCLAW_SERVICE_MARKER;
   for (const pid of activePids) {
     try {
@@ -124,7 +124,10 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     { reason: "no-output-timeout" as const, timeoutMs: undefined, noOutputTimeoutMs: 100 },
   ])("removes the group before returning $reason", async (timing) => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
-    const run = await createProcessSupervisor().spawn({
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const supervisor = createProcessSupervisor();
+    let output = "";
+    const run = await supervisor.spawn({
       mode: "child",
       argv: [
         "/bin/sh",
@@ -136,12 +139,26 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       backendId: "service-lifecycle-test",
       timeoutMs: timing.timeoutMs,
       noOutputTimeoutMs: timing.noOutputTimeoutMs,
+      onStdout: (chunk) => {
+        output += chunk;
+      },
     });
-    const exit = await run.wait();
-    const [rootPid, descendantPid] = parsePidPair(exit.stdout);
-
-    expect(exit.reason).toBe(timing.reason);
-    await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
+    try {
+      // Startup owns part of the deadline; observe both processes before firing it.
+      await waitFor(() => /^\d+ \d+/u.test(output));
+      const [rootPid, descendantPid] = parsePidPair(output);
+      activePids.add(rootPid);
+      activePids.add(descendantPid);
+      expect(isAlive(rootPid) && isAlive(descendantPid)).toBe(true);
+      await vi.advanceTimersByTimeAsync(100);
+      const exit = await run.wait();
+      expect(exit.reason).toBe(timing.reason);
+      expect(parsePidPair(exit.stdout)).toEqual([rootPid, descendantPid]);
+      await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
+    } finally {
+      vi.useRealTimers();
+      await supervisor.shutdown();
+    }
   });
 
   it("bounds construction while secret delivery blocks and cleans the real command", async () => {
@@ -153,7 +170,10 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       setInterval(() => {}, 1000);
     `;
     const supervisor = createProcessSupervisor();
+    const runId = "service-secret-construction";
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const pendingRun = supervisor.spawn({
+      runId,
       mode: "child",
       argv: [process.execPath, "-e", command],
       stdinMode: "pipe-closed",
@@ -165,17 +185,33 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
         createData: () => Buffer.alloc(8 * 1024 * 1024, 97),
       },
     });
-    const commandPid = await waitForPidFile(pidPath, 5_000);
-    activePids.add(commandPid);
-    expect(isAlive(commandPid)).toBe(true);
-
-    const run = await pendingRun;
-    await expect(run.wait()).resolves.toMatchObject({
-      reason: "overall-timeout",
-      timedOut: true,
-    });
-    await waitFor(() => !isAlive(commandPid));
-    await supervisor.shutdown();
+    let commandPid: number | undefined;
+    try {
+      const startedPid = await waitForPidFile(pidPath, 5_000, realDelay);
+      commandPid = startedPid;
+      activePids.add(startedPid);
+      expect(isAlive(startedPid)).toBe(true);
+      expect(supervisor.getRecord(runId)).toMatchObject({ state: "starting" });
+      await vi.advanceTimersByTimeAsync(500);
+      expect(supervisor.getRecord(runId)).toMatchObject({
+        state: "exited",
+        terminationReason: "overall-timeout",
+      });
+      const run = await pendingRun;
+      await expect(run.wait()).resolves.toMatchObject({
+        reason: "overall-timeout",
+        timedOut: true,
+      });
+      await waitFor(() => !isAlive(startedPid));
+    } finally {
+      vi.useRealTimers();
+      supervisor.cancel(runId);
+      if (commandPid && isAlive(commandPid)) {
+        process.kill(commandPid, "SIGKILL");
+      }
+      await pendingRun.catch(() => {});
+      await supervisor.shutdown();
+    }
   });
 
   it("preserves root-result timing while retaining descendant cleanup ownership", async () => {

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -5,17 +5,48 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { createDocsMarkdown, parseDocsDocument } from "../../scripts/lib/docs-markdown.mjs";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
 const { normalizeRoute, prepareExternalLinkAuditTree, prepareMirroredDocsDir, resolveRoute } =
   await import("../../scripts/docs-link-audit.mts");
+
+type AuditCliCase = {
+  name: string;
+  source: string[];
+  broken: number;
+  anchors?: boolean;
+  diagnostics?: string[];
+  files?: Record<string, string>;
+  redirects?: Array<{ source: string; destination: string }>;
+};
 
 describe("docs-link-audit", () => {
   function tempEntries(prefix: string): Set<string> {
     return new Set(fs.readdirSync(os.tmpdir()).filter((entry) => entry.startsWith(prefix)));
   }
 
-  it.each([
+  it.each(["\n", "\r\n"])("preserves code literals with line ending %j", (newline) => {
+    const source = [
+      "Intro",
+      "",
+      "```md",
+      '<Card href="/same" title="Literal" />',
+      "```",
+      "",
+      "[live](/same)",
+    ].join(newline);
+    const md = createDocsMarkdown();
+    const document = parseDocsDocument(source, md, {
+      mapLink: (href: string, line: number | undefined) => ({ href, line }),
+    });
+    expect(document.links).toEqual([{ href: "/same", line: 7 }]);
+    expect(md.renderer.render(document.tokens, md.options, document.env)).toContain(
+      "&lt;Card href=&quot;/same&quot; title=&quot;Literal&quot; /&gt;",
+    );
+  });
+
+  it.each<AuditCliCase>([
     {
       name: "component and list fences",
       source: [
@@ -59,6 +90,119 @@ describe("docs-link-audit", () => {
     },
     { name: "valid prose", source: ["[valid](/page)"], broken: 0 },
     {
+      name: "repeated occurrences beside protected literals",
+      source: [
+        "---",
+        "title: Positions",
+        "---",
+        "```md",
+        "[hidden](/missing-page)",
+        "```",
+        "[first](/missing-page)",
+        "[second](/missing-page)",
+        "",
+        "`[hidden](/missing-page)` [third](/missing-page)",
+        "[valid](/page)",
+      ],
+      broken: 3,
+      diagnostics: [7, 8, 10].map(
+        (line) => `page.mdx:${line} :: /missing-page :: route/file not found`,
+      ),
+    },
+    {
+      name: "reference, HTML, component and normalized relative occurrences",
+      source: [
+        "[reference][missing]",
+        "",
+        "[missing]: /missing-page",
+        "",
+        '<a href="/missing-page">HTML</a>',
+        "",
+        '<Card href="/missing-page" title="Component" />',
+        "",
+        "[relative](./missing-page.md)",
+        "[valid](/page)",
+      ],
+      broken: 4,
+      diagnostics: [1, 5, 7, 9].map(
+        (line) => `page.mdx:${line} :: /missing-page :: route/file not found`,
+      ),
+    },
+    {
+      name: "unmapped expansions",
+      source: [
+        '<Snippet file="./part.txt" />',
+        "",
+        '<div class="maturity-category-docs">',
+        "[embedded](/missing-page)",
+        "</div>",
+        "",
+        "[valid](/page)",
+      ],
+      files: { "docs/part.txt": "[included](/missing-page)\n" },
+      broken: 2,
+      diagnostics: ["page.mdx:unknown :: /missing-page :: route/file not found"],
+    },
+    {
+      name: "decoded direct paths and HTML-alias targets",
+      anchors: true,
+      source: [
+        "[direct](/caf%C3%A9#known)",
+        "[literal percent](/100%25#known)",
+        "[asset](/image%20space.svg)",
+        "[redirect](/via)",
+        "[bad redirect](/invalid)",
+        "[raw Markdown redirect](/raw)",
+        "[after](/missing-page)",
+        "[external](/outside)",
+      ],
+      files: {
+        "docs/café.md": "## Known\n",
+        "docs/100%.md": "## Known\n",
+        "docs/image space.svg": "<svg />",
+      },
+      redirects: [
+        { source: "/via", destination: "https://docs.openclaw.ai/caf%C3%A9#known" },
+        { source: "/invalid", destination: "https://docs.openclaw.ai/bad%" },
+        { source: "/raw", destination: "/café.md#known" },
+        { source: "/outside", destination: "https://example.test/page#external-section" },
+      ],
+      broken: 4,
+      diagnostics: [
+        "docs.json:unknown :: /invalid :: malformed URL path",
+        "page.mdx:5 :: /invalid :: malformed URL path",
+        "page.mdx:6 :: /raw :: fragment requires an HTML page, not raw Markdown",
+        "page.mdx:7 :: /missing-page :: route/file not found",
+      ],
+    },
+    ...[false, true].map((anchors) => ({
+      name: `malformed emitted paths (anchors=${anchors})`,
+      anchors,
+      source: [
+        '<Card href="/bad%" title="Component" />',
+        "",
+        '<a href="/bad%FF">HTML</a>',
+        "",
+        '<img src="/bad%2" />',
+        "",
+        '<CTA primaryHref="/bad%zz" secondaryHref="https://docs.openclaw.ai/bad%" />',
+        "",
+        "[markdown](/bad%FF)",
+        "[reference][bad]",
+        "",
+        "[bad]: /bad%FF",
+        "",
+        "[after](/missing-page)",
+        "[valid](/page)",
+      ],
+      broken: anchors ? 8 : 7,
+      diagnostics: [
+        ":: /bad% :: malformed URL path",
+        ":: /bad%FF :: malformed URL path",
+        ":: /missing-page :: route/file not found",
+      ],
+    })),
+    {
       name: "shared emitted fragments",
       anchors: true,
       broken: 4,
@@ -95,76 +239,88 @@ describe("docs-link-audit", () => {
         '<!-- <a id="phantom" href="/hidden-comment"> -->',
       ],
     },
-  ])("audits real CLI links after $name", ({ source, broken, anchors = false }) => {
-    const tempDirs: string[] = [];
-    const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-cli-");
-    const docsRoot = path.join(fixtureRoot, "docs");
-    const clawHubRoot = path.join(fixtureRoot, "clawhub");
-    const home = path.join(fixtureRoot, "home");
-    fs.mkdirSync(docsRoot);
-    fs.mkdirSync(path.join(clawHubRoot, "docs"), { recursive: true });
-    fs.mkdirSync(home);
-    fs.writeFileSync(
-      path.join(docsRoot, "docs.json"),
-      JSON.stringify({
-        navigation: [],
-        redirects: anchors
-          ? [
-              { source: "/legacy", destination: "/page#connection" },
-              { source: "/middle", destination: "/legacy#nested" },
-              { source: "/drops", destination: "/next" },
-            ]
-          : [],
-      }),
-    );
-    if (anchors) {
-      fs.writeFileSync(path.join(docsRoot, "index.md"), "## Root\n\n[next](next#target)\n");
-      fs.writeFileSync(path.join(docsRoot, "next.md"), "## Target\n");
-    }
-    const pageSource = anchors ? ["---", "permalink: /unpublished", "---", ...source] : source;
-    fs.writeFileSync(path.join(docsRoot, "page.mdx"), `${pageSource.join("\n")}\n`);
-
-    try {
-      const result = spawnSync(
-        process.execPath,
-        [
-          fileURLToPath(new URL("../../scripts/docs-link-audit.mjs", import.meta.url)),
-          ...(anchors ? ["--anchors"] : []),
-        ],
-        {
-          cwd: fixtureRoot,
-          encoding: "utf8",
-          env: {
-            PATH: process.env.PATH,
-            HOME: home,
-            USERPROFILE: home,
-            TSX_TSCONFIG_PATH: fileURLToPath(new URL("../../tsconfig.json", import.meta.url)),
-            OPENCLAW_DOCS_SYNC_CLAWHUB_REPO: clawHubRoot,
-          },
-          timeout: 30_000,
-        },
+  ])(
+    "audits real CLI links after $name",
+    ({ source, broken, anchors = false, diagnostics, files = {}, redirects }) => {
+      const tempDirs: string[] = [];
+      const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-cli-");
+      const docsRoot = path.join(fixtureRoot, "docs");
+      const clawHubRoot = path.join(fixtureRoot, "clawhub");
+      const home = path.join(fixtureRoot, "home");
+      fs.mkdirSync(docsRoot);
+      fs.mkdirSync(path.join(clawHubRoot, "docs"), { recursive: true });
+      fs.mkdirSync(home);
+      fs.writeFileSync(
+        path.join(docsRoot, "docs.json"),
+        JSON.stringify({
+          navigation: [],
+          redirects:
+            redirects ??
+            (anchors && !diagnostics
+              ? [
+                  { source: "/legacy", destination: "/page#connection" },
+                  { source: "/middle", destination: "/legacy#nested" },
+                  { source: "/drops", destination: "/next" },
+                ]
+              : []),
+        }),
       );
-      expect(result.error).toBeUndefined();
-      expect(result.stderr).toBe("");
-      expect(result.status).toBe(broken ? 1 : 0);
-      if (!anchors) {
-        expect(result.stdout).toContain(`checked_internal_links=${broken + 1}\n`);
+      for (const [file, content] of Object.entries(files)) {
+        fs.writeFileSync(path.join(fixtureRoot, file), content);
       }
-      expect(result.stdout).toContain(`broken_links=${broken}\n`);
-      expect(result.stdout).not.toContain("/hidden-");
       if (anchors) {
-        expect(result.stdout).toContain("#missing :: fragment not found");
-        expect(result.stdout).toContain("/unpublished#connection :: route/file not found");
+        fs.writeFileSync(path.join(docsRoot, "index.md"), "## Root\n\n[next](next#target)\n");
+        fs.writeFileSync(path.join(docsRoot, "next.md"), "## Target\n");
       }
-      if (broken && !anchors) {
-        expect(result.stdout).toContain(
-          `page.mdx:${source.findIndex((line) => line.includes("/missing-page")) + 1} :: /missing-page :: route/file not found`,
+      const pageSource =
+        anchors && !diagnostics ? ["---", "permalink: /unpublished", "---", ...source] : source;
+      fs.writeFileSync(path.join(docsRoot, "page.mdx"), `${pageSource.join("\n")}\n`);
+
+      try {
+        const result = spawnSync(
+          process.execPath,
+          [
+            fileURLToPath(new URL("../../scripts/docs-link-audit.mjs", import.meta.url)),
+            ...(anchors ? ["--anchors"] : []),
+          ],
+          {
+            cwd: fixtureRoot,
+            encoding: "utf8",
+            env: {
+              PATH: process.env.PATH,
+              HOME: home,
+              USERPROFILE: home,
+              TSX_TSCONFIG_PATH: fileURLToPath(new URL("../../tsconfig.json", import.meta.url)),
+              OPENCLAW_DOCS_SYNC_CLAWHUB_REPO: clawHubRoot,
+            },
+            timeout: 30_000,
+          },
         );
+        expect(result.error).toBeUndefined();
+        expect(result.stderr).toBe("");
+        expect(result.status).toBe(broken ? 1 : 0);
+        if (!anchors) {
+          expect(result.stdout).toContain(`checked_internal_links=${broken + 1}\n`);
+        }
+        expect(result.stdout).toContain(`broken_links=${broken}\n`);
+        expect(result.stdout).not.toContain("/hidden-");
+        if (anchors && !diagnostics) {
+          expect(result.stdout).toContain("#missing :: fragment not found");
+          expect(result.stdout).toContain("/unpublished#connection :: route/file not found");
+        }
+        for (const diagnostic of diagnostics ?? []) {
+          expect(result.stdout).toContain(diagnostic);
+        }
+        if (broken && !anchors && !diagnostics) {
+          expect(result.stdout).toContain(
+            `page.mdx:${source.findIndex((line) => line.includes("/missing-page")) + 1} :: /missing-page :: route/file not found`,
+          );
+        }
+      } finally {
+        cleanupTempDirs(tempDirs);
       }
-    } finally {
-      cleanupTempDirs(tempDirs);
-    }
-  });
+    },
+  );
 
   it("normalizes route fragments away", () => {
     expect(normalizeRoute("/plugins/building-plugins#registering-agent-tools")).toBe(

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -7,15 +7,8 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
-const {
-  normalizeRoute,
-  prepareAnchorAuditDocsDir,
-  prepareExternalLinkAuditTree,
-  prepareMirroredDocsDir,
-  resolveRoute,
-  runDocsLinkAuditCli,
-  sanitizeDocsConfigForEnglishOnly,
-} = await import("../../scripts/docs-link-audit.mts");
+const { normalizeRoute, prepareExternalLinkAuditTree, prepareMirroredDocsDir, resolveRoute } =
+  await import("../../scripts/docs-link-audit.mts");
 
 describe("docs-link-audit", () => {
   function tempEntries(prefix: string): Set<string> {
@@ -65,7 +58,44 @@ describe("docs-link-audit", () => {
       broken: 1,
     },
     { name: "valid prose", source: ["[valid](/page)"], broken: 0 },
-  ])("audits real CLI links after $name", ({ source, broken }) => {
+    {
+      name: "shared emitted fragments",
+      anchors: true,
+      broken: 4,
+      source: [
+        "## agents.defaults.cwd",
+        "",
+        '<Accordion title="Connect" id="connection">',
+        "",
+        "## Nested",
+        "",
+        "</Accordion>",
+        "",
+        "[legacy](#agents-defaults-cwd)",
+        "[canonical](#agents.defaults.cwd)",
+        "[component](#connection)",
+        "[nested](https://docs.openclaw.ai/page#nested)",
+        "[absent](#missing)",
+        "[relative](./page.mdx#connection)",
+        "[raw Markdown](/page.md#connection)",
+        "[root](/#root)",
+        "[missing root alias](/index#missing)",
+        "[unpublished permalink](/unpublished#missing)",
+        "[dropped incoming fragment](/drops#missing)",
+        "[redirect](/legacy#wrong-incoming-fragment)",
+        "[chain](/middle#also-wrong)",
+        "[reference][ref]",
+        "",
+        "[ref]: /page#connection",
+        "",
+        "```md",
+        "## Phantom",
+        "[hidden](/hidden-code)",
+        "```",
+        '<!-- <a id="phantom" href="/hidden-comment"> -->',
+      ],
+    },
+  ])("audits real CLI links after $name", ({ source, broken, anchors = false }) => {
     const tempDirs: string[] = [];
     const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-cli-");
     const docsRoot = path.join(fixtureRoot, "docs");
@@ -74,13 +104,33 @@ describe("docs-link-audit", () => {
     fs.mkdirSync(docsRoot);
     fs.mkdirSync(path.join(clawHubRoot, "docs"), { recursive: true });
     fs.mkdirSync(home);
-    fs.writeFileSync(path.join(docsRoot, "docs.json"), JSON.stringify({ navigation: [] }));
-    fs.writeFileSync(path.join(docsRoot, "page.mdx"), `${source.join("\n")}\n`);
+    fs.writeFileSync(
+      path.join(docsRoot, "docs.json"),
+      JSON.stringify({
+        navigation: [],
+        redirects: anchors
+          ? [
+              { source: "/legacy", destination: "/page#connection" },
+              { source: "/middle", destination: "/legacy#nested" },
+              { source: "/drops", destination: "/next" },
+            ]
+          : [],
+      }),
+    );
+    if (anchors) {
+      fs.writeFileSync(path.join(docsRoot, "index.md"), "## Root\n\n[next](next#target)\n");
+      fs.writeFileSync(path.join(docsRoot, "next.md"), "## Target\n");
+    }
+    const pageSource = anchors ? ["---", "permalink: /unpublished", "---", ...source] : source;
+    fs.writeFileSync(path.join(docsRoot, "page.mdx"), `${pageSource.join("\n")}\n`);
 
     try {
       const result = spawnSync(
         process.execPath,
-        [fileURLToPath(new URL("../../scripts/docs-link-audit.mjs", import.meta.url))],
+        [
+          fileURLToPath(new URL("../../scripts/docs-link-audit.mjs", import.meta.url)),
+          ...(anchors ? ["--anchors"] : []),
+        ],
         {
           cwd: fixtureRoot,
           encoding: "utf8",
@@ -97,10 +147,15 @@ describe("docs-link-audit", () => {
       expect(result.error).toBeUndefined();
       expect(result.stderr).toBe("");
       expect(result.status).toBe(broken ? 1 : 0);
-      expect(result.stdout).toContain(`checked_internal_links=${broken + 1}\n`);
+      if (!anchors) {
+        expect(result.stdout).toContain(`checked_internal_links=${broken + 1}\n`);
+      }
       expect(result.stdout).toContain(`broken_links=${broken}\n`);
       expect(result.stdout).not.toContain("/hidden-");
-      if (broken) {
+      if (anchors) {
+        expect(result.stdout).toContain("#missing :: fragment not found");
+      }
+      if (broken && !anchors) {
         expect(result.stdout).toContain(
           `page.mdx:${source.findIndex((line) => line.includes("/missing-page")) + 1} :: /missing-page :: route/file not found`,
         );
@@ -273,137 +328,6 @@ describe("docs-link-audit", () => {
     });
   });
 
-  it("sanitizes docs.json to English-only route targets", () => {
-    expect(
-      sanitizeDocsConfigForEnglishOnly({
-        navigation: [
-          {
-            language: "en",
-            tabs: [
-              {
-                tab: "Docs",
-                groups: [
-                  {
-                    group: "Keep",
-                    pages: ["help/testing", "zh-CN/help/testing", "ja-JP/help/testing"],
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            language: "zh-Hans",
-            tabs: [{ tab: "中文", groups: [{ group: "帮助", pages: ["zh-CN/help/testing"] }] }],
-          },
-        ],
-        redirects: [
-          { source: "/help/testing", destination: "/help/testing" },
-          { source: "/zh-CN/help/testing", destination: "/help/testing" },
-          { source: "/help/testing", destination: "/ja-JP/help/testing" },
-        ],
-      }),
-    ).toEqual({
-      navigation: [
-        {
-          language: "en",
-          tabs: [
-            {
-              tab: "Docs",
-              groups: [{ group: "Keep", pages: ["help/testing"] }],
-            },
-          ],
-        },
-      ],
-      redirects: [{ source: "/help/testing", destination: "/help/testing" }],
-    });
-  });
-
-  it("builds an English-only docs tree for anchor audits", () => {
-    const tempDirs: string[] = [];
-    const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-fixture-");
-    const docsRoot = path.join(fixtureRoot, "docs");
-    fs.mkdirSync(path.join(docsRoot, "help"), { recursive: true });
-    fs.mkdirSync(path.join(docsRoot, "zh-CN", "help"), { recursive: true });
-    fs.writeFileSync(
-      path.join(docsRoot, "docs.json"),
-      `${JSON.stringify(
-        {
-          navigation: [
-            {
-              language: "en",
-              tabs: [{ tab: "Docs", groups: [{ group: "Help", pages: ["help/testing"] }] }],
-            },
-            {
-              language: "zh-Hans",
-              tabs: [{ tab: "中文", groups: [{ group: "帮助", pages: ["zh-CN/help/testing"] }] }],
-            },
-          ],
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-    fs.writeFileSync(
-      path.join(docsRoot, "help", "testing.md"),
-      [
-        "# testing",
-        "<!-- BEGIN GENERATED: example -->",
-        "visible <!-- a multiline",
-        "comment --> text",
-        "<!-- END GENERATED: example -->",
-        "",
-      ].join("\n"),
-      "utf8",
-    );
-    fs.writeFileSync(path.join(docsRoot, "zh-CN", "help", "testing.md"), "# 测试\n", "utf8");
-
-    const anchorDocsDir = prepareAnchorAuditDocsDir(docsRoot);
-    try {
-      expect(fs.existsSync(path.join(anchorDocsDir, "help", "testing.md"))).toBe(true);
-      expect(fs.existsSync(path.join(anchorDocsDir, "zh-CN"))).toBe(false);
-      const preparedMarkdown = fs.readFileSync(
-        path.join(anchorDocsDir, "help", "testing.md"),
-        "utf8",
-      );
-      expect(preparedMarkdown).not.toContain("<!--");
-      expect(preparedMarkdown).not.toContain("BEGIN GENERATED");
-      expect(preparedMarkdown.split("\n")).toHaveLength(6);
-
-      const sanitizedDocsJson = JSON.parse(
-        fs.readFileSync(path.join(anchorDocsDir, "docs.json"), "utf8"),
-      );
-      expect(sanitizedDocsJson).toEqual({
-        navigation: [
-          {
-            language: "en",
-            tabs: [{ tab: "Docs", groups: [{ group: "Help", pages: ["help/testing"] }] }],
-          },
-        ],
-      });
-    } finally {
-      fs.rmSync(anchorDocsDir, { recursive: true, force: true });
-      cleanupTempDirs(tempDirs);
-    }
-  });
-
-  it("cleans anchor audit docs copies when docs.json is invalid", () => {
-    const tempDirs: string[] = [];
-    const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-invalid-");
-    const docsRoot = path.join(fixtureRoot, "docs");
-    fs.mkdirSync(docsRoot, { recursive: true });
-    fs.writeFileSync(path.join(docsRoot, "docs.json"), "{ invalid json", "utf8");
-
-    const before = tempEntries("openclaw-docs-anchor-audit-");
-    try {
-      expect(() => prepareAnchorAuditDocsDir(docsRoot)).toThrow();
-      const after = tempEntries("openclaw-docs-anchor-audit-");
-      expect([...after].filter((entry) => !before.has(entry))).toEqual([]);
-    } finally {
-      cleanupTempDirs(tempDirs);
-    }
-  });
-
   it("does not create mirrored docs copies for non-root docs trees", () => {
     const tempDirs: string[] = [];
     const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-mirror-");
@@ -442,142 +366,5 @@ describe("docs-link-audit", () => {
 
     const after = tempEntries("openclaw-docs-link-audit-");
     expect([...after].filter((entry) => !before.has(entry))).toEqual([]);
-  });
-
-  it("cleans mirrored docs copies when anchor prep fails", () => {
-    let mirroredCleaned = false;
-
-    expect(() =>
-      runDocsLinkAuditCli({
-        args: ["--anchors"],
-        cleanupAnchorAuditDocsDirImpl() {
-          throw new Error("anchor cleanup should not run");
-        },
-        prepareAnchorAuditDocsDirImpl() {
-          throw new Error("anchor prep failed");
-        },
-        prepareMirroredDocsDirImpl: () => ({
-          cleanup() {
-            mirroredCleaned = true;
-          },
-          dir: path.join(os.tmpdir(), "openclaw-docs-mirrored"),
-          mirroredClawHub: true,
-        }),
-      }),
-    ).toThrow("anchor prep failed");
-    expect(mirroredCleaned).toBe(true);
-  });
-
-  it("uses a pinned Mintlify package through npm for anchor validation", () => {
-    let invocation:
-      | {
-          command: string;
-          args: string[];
-          options: { cwd: string; env?: NodeJS.ProcessEnv; shell?: boolean; stdio: string };
-        }
-      | undefined;
-    let cleanedDir: string | undefined;
-    const anchorDocsDir = path.join(os.tmpdir(), "docs-link-audit-anchor");
-    fs.mkdirSync(anchorDocsDir, { recursive: true });
-
-    const exitCode = runDocsLinkAuditCli({
-      args: ["--anchors"],
-      env: { ...process.env, OPENCLAW_DOCS_LINK_SENTINEL: "1" },
-      nodeExecPath: "/opt/node/bin/node",
-      nodeVersion: "22.21.1",
-      prepareAnchorAuditDocsDirImpl() {
-        return anchorDocsDir;
-      },
-      cleanupAnchorAuditDocsDirImpl(dir) {
-        cleanedDir = dir;
-      },
-      spawnSyncImpl(command, args, options) {
-        invocation = { command, args, options };
-        return { status: 0 };
-      },
-    });
-
-    expect(exitCode).toBe(0);
-    expect(invocation).toEqual({
-      command: "npm",
-      args: [
-        "exec",
-        "--yes",
-        "--package=mint@4.2.808",
-        "--",
-        "mint",
-        "broken-links",
-        "--check-anchors",
-      ],
-      options: expect.objectContaining({
-        cwd: anchorDocsDir,
-        env: expect.objectContaining({ OPENCLAW_DOCS_LINK_SENTINEL: "1" }),
-        shell: false,
-        stdio: "inherit",
-      }),
-    });
-    expect(cleanedDir).toBe(anchorDocsDir);
-  });
-
-  it("wraps Mintlify with Node 22 when the current Node is too new", () => {
-    const invocations: Array<{
-      command: string;
-      args: string[];
-      options: { cwd: string; stdio: string };
-    }> = [];
-    let cleanedDir: string | undefined;
-    const anchorDocsDir = path.join(os.tmpdir(), "docs-link-audit-anchor");
-    fs.mkdirSync(anchorDocsDir, { recursive: true });
-
-    const exitCode = runDocsLinkAuditCli({
-      args: ["--anchors"],
-      nodeExecPath: "/opt/node/bin/node",
-      nodeVersion: "25.3.0",
-      prepareAnchorAuditDocsDirImpl() {
-        return anchorDocsDir;
-      },
-      cleanupAnchorAuditDocsDirImpl(dir) {
-        cleanedDir = dir;
-      },
-      spawnSyncImpl(command, args, options) {
-        invocations.push({ command, args, options });
-        return { status: 0 };
-      },
-    });
-
-    expect(exitCode).toBe(0);
-    expect(invocations).toHaveLength(2);
-    const [versionCheck, linkCheck] = invocations;
-    if (!versionCheck || !linkCheck) {
-      throw new Error("Expected Mintlify wrapper invocations");
-    }
-    expect(versionCheck).toEqual({
-      command: "fnm",
-      args: [
-        "exec",
-        "--using=22",
-        "node",
-        "-e",
-        "process.exit(Number(process.versions.node.split('.')[0]) === 22 ? 0 : 1)",
-      ],
-      options: { cwd: anchorDocsDir, stdio: "ignore" },
-    });
-    expect(linkCheck).toEqual({
-      command: "fnm",
-      args: [
-        "exec",
-        "--using=22",
-        "npm",
-        "exec",
-        "--yes",
-        "--package=mint@4.2.808",
-        "--",
-        "mint",
-        "broken-links",
-        "--check-anchors",
-      ],
-      options: { cwd: anchorDocsDir, stdio: "inherit" },
-    });
-    expect(cleanedDir).toBe(anchorDocsDir);
   });
 });

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -80,7 +80,7 @@ describe("docs-link-audit", () => {
         "[raw Markdown](/page.md#connection)",
         "[root](/#root)",
         "[missing root alias](/index#missing)",
-        "[unpublished permalink](/unpublished#missing)",
+        "[unpublished permalink](/unpublished#connection)",
         "[dropped incoming fragment](/drops#missing)",
         "[redirect](/legacy#wrong-incoming-fragment)",
         "[chain](/middle#also-wrong)",
@@ -154,6 +154,7 @@ describe("docs-link-audit", () => {
       expect(result.stdout).not.toContain("/hidden-");
       if (anchors) {
         expect(result.stdout).toContain("#missing :: fragment not found");
+        expect(result.stdout).toContain("/unpublished#connection :: route/file not found");
       }
       if (broken && !anchors) {
         expect(result.stdout).toContain(

--- a/test/helpers/process-wait.ts
+++ b/test/helpers/process-wait.ts
@@ -22,7 +22,12 @@ export async function waitForFile(filePath: string, timeoutMs: number): Promise<
 }
 
 // writeFileSync can expose an open-truncate window, so wait for valid contents, not existence.
-export async function waitForPidFile(filePath: string, timeoutMs: number): Promise<number> {
+// Inject a real delay when the caller controls execution deadlines with fake timers.
+export async function waitForPidFile(
+  filePath: string,
+  timeoutMs: number,
+  delay: (ms: number) => Promise<unknown> = sleep,
+): Promise<number> {
   const deadlineAt = Date.now() + timeoutMs;
   while (true) {
     if (existsSync(filePath)) {
@@ -34,7 +39,7 @@ export async function waitForPidFile(filePath: string, timeoutMs: number): Promi
     if (Date.now() >= deadlineAt) {
       throw new Error(`timeout waiting for pid in ${filePath}`);
     }
-    await sleep(5);
+    await delay(5);
   }
 }
 


### PR DESCRIPTION
> **Resolved and published (2026-09-03).** All three rollout PRs are merged, normal source sync and R2 publication succeeded, and post-publication browser/live smoke passed. [Final rollout and remaining content findings](https://github.com/openclaw/openclaw/issues/137032#issuecomment-5525222650).

Related: https://github.com/openclaw/openclaw/issues/137032
Support: https://github.com/openclaw/openclaw/pull/137038
Renderer: https://github.com/openclaw/docs/pull/157
Production proof: https://github.com/openclaw/docs/pull/157#issuecomment-5522338636

## What Problem This Solves

Source anchor checks could accept nonexistent published sections or reject links that work on the live docs site. The independent Mintlify checker does not implement the publisher's heading, component, duplicate-ID, and HTML-alias redirect behavior. The replacement also needs reliable diagnostics: repeated links must identify their own source occurrences, and malformed URLs must not abort reporting for the rest of the document.

## Why This Change Was Made

Use the same source-owned document/ID and redirect contracts consumed by the deployed renderer. This follows the approved support → renderer → audit rollout: support was normally synced, the renderer merged, and real production navigation passed before audit activation was published.

Delete the Mint subprocess, Node-version workaround, temporary anchor projection and obsolete tests rather than adding another guessed slugger. Keep external-link projection and canonical ClawHub mirroring intact. Literal IDs take precedence over one fragment decode; only real emitted aliases/components count as targets. Relative links use final published page URLs, and redirects follow the publisher's actual HTML-alias behavior.

Source-line provenance travels through shared preprocessing and existing MarkdownIt/htmlparser2 positions, before href normalization loses occurrence identity. An opt-in `mapLink` projection preserves the publisher's default string-link API and avoids diagnostic tracking during ordinary publishing. URL construction/decoding has one `Result` boundary: malformed internal paths become normal diagnostics, later links are still checked, and external redirect fragments are not checked against local pages.

## User Impact

Maintainers can trust `pnpm docs:check-links:anchors` to check actual published targets while preserving old heading URLs. Repeated/reference/component links report their own locations; unmapped snippet/embedded expansions report `unknown`, not a guessed line. Author/testing guides describe the shared parser accurately. No product configuration, schema, protocol, dependency pin, runtime gateway behavior, or page-specific anchor rewrite changes are included.

## Evidence

- The [actual R2 deployment](https://github.com/openclaw/docs/actions/runs/33727893894), attempt 1, completed source checkout, full build, smoke and upload. Docs SHA `831a0b636e82fef6c95b6bc34c854176d86f3ab6` contains renderer merge `d309865b27755f63268824fbbb364cca71800da9`. The earlier stale/skipped run was not counted as publication.
- Ten real production Chromium flows pass with HTTP 200 and no page errors: dotted primary/alias URLs, slash/parenthesis and plus/dev fragments, canonical TOC/copy behavior, and an opened details target. Inspected screenshots and live links are in the production proof comment above.
- Six new CLI cases fail on isolated pre-fix script/parser copies while five established cases pass. Repeated live links formerly reported fenced-code line 5; now they report lines 7, 8, and 10. Malformed component paths no longer throw `URIError` or hide following findings. An executed regression also caught an external redirect whose pathname matched a local page; it no longer receives a false local-fragment diagnostic.
- `node scripts/run-vitest.mjs src/scripts/docs-link-audit.test.ts test/scripts/docs-sync-publish.test.ts`: **25/25 pass**. Selected formatting, lint, types and repository guards pass. `git diff --check` passes.
- **760 publisher inputs** (750 source documents plus ten LF/CRLF fixtures) retain byte-identical HTML, IDs, href strings and collision records. Seven assembled-publisher boundary tests pass, including real Chromium DOM/fragment navigation. The current rebase and timing-test repair leave those parser/audit bytes unchanged.
- The real source-sync script populated a full isolated publisher fixture; `make docs-check` passed: **14,934 pages built; 14,933 pages indexed in 21 languages; 85,003 R2 objects prepared; full smoke passed**. Source indexing processed 17,923 of 34,123 files, with 97 large-file and 16,103 budget skips under existing limits. Source/generated parser SHA-256: `162d4b5e8f383311517e5f8f07381afbfa890a145c07789a66f436946ae55118`. This is candidate proof, not a claim that the latest diagnostic module is already deployed. [Exact publisher-consumer inspection](https://github.com/openclaw/openclaw/pull/137157#issuecomment-5524555596) records the unchanged default string-link contract. No generated mirror file was hand-edited.
- Fresh independent Codex review of the complete candidate, including the new construction test, is scoped-clean at the configured **P0-only** threshold. Separately verified P2/P3 diagnostic and wording findings were repaired, not dismissed by that threshold.
- Canonical ClawHub source is pinned to `fae070615057acd3d104c7c6dc2e8813ded9888c`. Ordinary route audit: **8,044 links, zero failures**. Full anchor audit: **8,327 links, 14 real source-content findings**, intentionally exit 1. These are ten stale callers in the separate page-specific repair, one computer-use caller, and duplicate groups `podman-and-tailscale`, `surface-explorer`, and `product-areas`. The latter four are a named source-owner follow-up. One conflicting `github-actions-2` alias is omitted to preserve its existing target owner.
- Complete candidate: production/tooling **+349/-473 (net −124)**; tests/test support **+466/-411 (net +55)**; docs/guidance **+7/-5 (net +2)**, across nine files. Source provenance and typed diagnostics replace obsolete audit machinery. No source changelog edit; release-note context is here.

### CI follow-through

Earlier CI exposed a node-host line-limit failure and two stale exact update-dispatch actor expectations. Their repairs are now on main; the redundant branch patches were dropped on rebase. The dispatch investigation verified all 24 production caller modules and 953 tests across 45 files without weakening assertions.

[The next exact-head run](https://github.com/openclaw/openclaw/actions/runs/33743595200) failed the independent command-construction timing regression. It began a three-second PID wait before cold command preparation completed; its one-second execution deadline could fire before PID readiness. Its chosen Anthropic SDK backend also bypassed the supervisor/service relay that the regression purported to exercise.

The test-only repair uses the existing registered process-backend resolver and queue-admission hook, with the real command, supervisor, relay, anonymous pipe and child. An unread 8 MiB synthetic secret blocks construction. The test observes actual admission, a live child and `starting` state before advancing the original deadline: still starting at 999 ms, `overall-timeout` at 1,000 ms, timeout envelope/exit 2 and PID death before fallback cleanup. Three sibling timeout cases use the same readiness ordering. No execution/readiness/cleanup budget increased; no production seam or behavior changed. The original case was moved, not duplicated.

Before/after proof: original command file **1 failed/53 passed**; repaired **54 passed**. A controlled 600 ms child startup delay fails the original 500 ms sibling case and passes the repaired case with that same deadline. Against the exact pre-fix supervisor, both repaired construction tests fail at the intended `starting` versus `exited/overall-timeout` assertion; current production source was restored byte-for-byte. Combined adjacent proof: **161 tests across eight files passed**. Final organized command proof: **54 tests across two files passed**. Final changed gates pass. Timing repair alone: **production 0; tests/support +204/-93 (net +111)**.

Exact commands:

```bash
node scripts/run-vitest.mjs src/commands/agent-exec.construction.test.ts src/commands/agent-exec.test.ts --reporter=verbose
```

```bash
node scripts/run-vitest.mjs src/commands/agent-exec.test.ts src/process/supervisor/adapters/child.service-lifecycle.test.ts src/process/supervisor/supervisor.test.ts src/process/supervisor/supervisor.cancellation-reason.test.ts src/process/supervisor/service-child-relay-host.test.ts src/process/supervisor/adapters/child.secret-abort.test.ts src/process/spawn-secret-input.test.ts test/helpers/process-wait.test.ts --reporter=verbose
```

```bash
node scripts/check-changed.mjs -- src/commands/agent-exec.test.ts src/commands/agent-exec.construction.test.ts src/process/supervisor/adapters/child.service-lifecycle.test.ts test/helpers/process-wait.ts
```

Separate test follow-up: replace fixed descendant lifetimes with explicit release gates in `preserves root-result timing while retaining descendant cleanup ownership` and `flushes incomplete UTF-8 before exposing a root result with retained authority`. Both passed; they test a different lifetime boundary and were not rewritten here.

## Review disposition

The initial permalink finding and its rank-up moves are not applied as proposed: they infer publication from the old auditor/i18n inventory rather than the real publisher. `collectPages` derives physical slugs, `pageRoute` uses locale plus slug, and `writeRedirects` consumes declared redirects. Frontmatter-only permalinks do not emit aliases. The cited formal-verification value differs from its physical route only by a trailing slash and works live. Actual builder → R2 manifest → Worker proof: physical route/fragment = 200, distinct frontmatter-only route = 404, explicit redirect = 200. The source regression rejects `/unpublished#connection` despite that fragment existing on the physical page.

The repeated-location, malformed-percent and Docs sanity findings **are accepted and repaired**. Positions are captured at the producer, malformed URLs do not abort, URI host ownership is preserved, and wording is corrected. Direct publisher inspection, byte-equivalence checks and full candidate/production proof address the review environment's DNS limitation and latest rank-up move; no uninspected compatibility risk is being accepted.

The full content anchor audit is not represented as green. Remaining findings are authored/generator defects, not phantom targets or parser/renderer disagreement. This rollout does not duplicate or overwrite the separate authored-page patch.
