### PR TITLE
refactor(infra): consolidate HTTP byte-limit test cases

### DIFF
--- a/src/infra/http-error-body.test.ts
+++ b/src/infra/http-error-body.test.ts
@@ -36,25 +36,18 @@ describe("readResponseBodySnippet", () => {
     expect(result).toBe("abcde");
   });
 
-  it("truncates by maxBytes in the body-less path", async () => {
-    const text = "a".repeat(200);
+  it.each([
+    { textLength: 200, maxBytes: 50 },
+    { textLength: 500, maxBytes: 30 },
+  ])("caps body-less text at $maxBytes bytes", async ({ textLength, maxBytes }) => {
+    const text = "a".repeat(textLength);
     const result = await readResponseBodySnippet(bodyLessResponse(text), {
-      maxBytes: 50,
+      maxBytes,
       maxChars: 500,
     });
     const byteLen = new TextEncoder().encode(result).length;
-    expect(byteLen).toBeLessThanOrEqual(50);
+    expect(byteLen).toBeLessThanOrEqual(maxBytes);
     expect(result.length).toBeLessThan(text.length);
-  });
-
-  it("enforces maxBytes before maxChars in the body-less path", async () => {
-    const text = "a".repeat(500);
-    const result = await readResponseBodySnippet(bodyLessResponse(text), {
-      maxBytes: 30,
-      maxChars: 500,
-    });
-    const byteLen = new TextEncoder().encode(result).length;
-    expect(byteLen).toBeLessThanOrEqual(30);
   });
 
   it("does not split multi-byte UTF-8 characters at the byte boundary", async () => {


### PR DESCRIPTION
## What Problem This Solves
Two body-less HTTP error-response tests repeat the same fixture, read and byte-cap assertions with different inputs and limits.

## Why This Change Was Made
Use the file's existing table-test pattern for both rows: 200 characters with a 50-byte limit, then 500 characters with a 30-byte limit. All 15 scenarios remain. The first case's shorter-than-input assertion now also applies to the second. Production code is unchanged; test code decreases seven lines.

## User Impact
No runtime behavior changes. UTF-8 boundaries, surrogate pairs, stream limits, cancellation, timeout and error-visibility coverage remain intact.

## Evidence
- The same four canonical suites passed on baseline and candidate: **79 tests each**, including all 15 HTTP error-body cases, response lifecycle tests and UTF helpers.
- The current frozen dependency install passed. Stale selected Vitest caches were cleared once through the normal command before baseline; no cache override or dependency upgrade was added.
- Independent Codex review through P2: scoped-clean, no findings. Its first attempt stopped before inference on an optional unchanged MiniMax test's sensitive filename; the successful attempt omitted that file entirely with explicit disclosure. The maintainer review inspected it directly.
- The full normal one-file changed gate passed, including infra test typechecking, format, lint, repository guards and all three dead-export scans. Original hosted run [33729702016](https://github.com/openclaw/openclaw/actions/runs/33729702016) failed in core-lint stripe 4 because unchanged `src/node-host/runner.test.ts` exceeded the 1,000-line limit (1,006 counted); the required CI gate failed as a consequence. The other selected jobs recorded 37 successes and 19 skips.
- Mechanically refreshed onto captured main `08c80feb35fda8ecd79b7f448de53595574200c2`, which contains the separate canonical runner-test split [#137149](https://github.com/openclaw/openclaw/pull/137149). The reviewed one-file patch, all 37 inspected HTTP/source/dependency contexts and 94 native workflow components are preserved. Local tests and review were not repeated for this mechanical refresh; fresh exact-head CI is required.
