### PR TITLE
fix: restore node-host test lint with direct tail assertions

### DIFF
--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -1067,9 +1067,7 @@ describe("runNodeHost", () => {
       }),
     ).rejects.toThrow("event loop readiness timeout");
 
-    const lastConfigured =
-      mocks.capturedConfiguredGatewayConfigs[mocks.capturedConfiguredGatewayConfigs.length - 1];
-    expect(lastConfigured?.contextPath).toBe("/gws");
+    expect(mocks.capturedConfiguredGatewayConfigs.at(-1)?.contextPath).toBe("/gws");
   });
 
   it("clears configured contextPath when opts do not pass one (retarget scenario)", async () => {
@@ -1080,9 +1078,7 @@ describe("runNodeHost", () => {
       }),
     ).rejects.toThrow("event loop readiness timeout");
 
-    const lastConfigured =
-      mocks.capturedConfiguredGatewayConfigs[mocks.capturedConfiguredGatewayConfigs.length - 1];
-    expect(lastConfigured?.contextPath).toBeUndefined();
+    expect(mocks.capturedConfiguredGatewayConfigs.at(-1)?.contextPath).toBeUndefined();
     expect(lastCapturedOptions()?.url).toBe("ws://192.168.1.1:9999");
   });
 
@@ -1095,9 +1091,7 @@ describe("runNodeHost", () => {
       }),
     ).rejects.toThrow("event loop readiness timeout");
 
-    const lastConfigured =
-      mocks.capturedConfiguredGatewayConfigs[mocks.capturedConfiguredGatewayConfigs.length - 1];
-    expect(lastConfigured?.contextPath || undefined).toBeUndefined();
+    expect(mocks.capturedConfiguredGatewayConfigs.at(-1)?.contextPath || undefined).toBeUndefined();
     expect(lastCapturedOptions()?.url).toBe("ws://127.0.0.1:18789");
   });
 });


### PR DESCRIPTION
## What problem does this PR solve?

Main’s node-host runner test exceeded the configured 1,000-line lint limit by six lines, failing unrelated PR checks. The failure is visible in [check-lint-core-4](https://github.com/openclaw/openclaw/actions/runs/33727589892/job/100560249055) for #137132; the offending test file is identical on the current main inspected here.

## Why this change

Use the same `Array.at(-1)` last-entry idiom already used by `lastCapturedOptions` in this test, and assert directly instead of repeating length-based indexing and one-use locals three times. All test cases, input values, expected values, optional access and empty-context-path semantics remain unchanged. This removes six test lines; production LOC is unchanged. The existing lint limit stays enforced.

## Validation

- `node node_modules/oxlint/bin/oxlint --type-aware --threads=1 src/node-host/runner.test.ts`: passes with no warning/error.
- `node scripts/run-vitest.mjs run src/node-host/runner.test.ts`: all 41 tests pass.
- Independent managed Codex review through P2: no actionable finding.

This is a test maintenance and CI repair. It changes no runtime behavior, dependencies, configuration, persistence or public API and makes no memory or speed claim.
