### PR TITLE
improve: prepare node subscription fanout without staging arrays

### DIFF
--- a/src/gateway/server-node-subscriptions.ts
+++ b/src/gateway/server-node-subscriptions.ts
@@ -50,10 +50,15 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
     }
   };
 
-  const settleFanout = async (sends: Array<() => void | Promise<unknown>>): Promise<void> => {
-    // Public gateway callers intentionally fire-and-forget fanout. Settle every
-    // sender so one transport failure cannot become an unhandled rejection.
-    await Promise.allSettled(sends.map((send) => Promise.resolve().then(send)));
+  const settleFanout = async <Entry>(
+    entries: Iterable<Entry>,
+    createSend: (entry: Entry) => () => ReturnType<NodeSendEventFn>,
+  ): Promise<void> => {
+    // Build sender closures before yielding without retaining iterator tuples.
+    // Settle failures because public Gateway callers fire-and-forget this fanout.
+    await Promise.allSettled(
+      Array.from(entries, (entry) => Promise.resolve().then(createSend(entry))),
+    );
   };
 
   const subscribe = (nodeId: string, pairingGeneration: string, sessionKey: string) => {
@@ -187,11 +192,10 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
     // Serialize once per event and reuse across all subscribed nodes to keep
     // fanout deterministic and avoid repeated JSON conversion.
     await settleFanout(
-      [...subscribers].map(
-        ([nodeId, pairingGeneration]) =>
-          () =>
-            sendEvent({ nodeId, pairingGeneration, event, payloadJSON }),
-      ),
+      subscribers,
+      ([nodeId, pairingGeneration]) =>
+        () =>
+          sendEvent({ nodeId, pairingGeneration, event, payloadJSON }),
     );
   };
 
@@ -208,16 +212,15 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
       return;
     }
     await settleFanout(
-      [...nodeSubscriptions].map(
-        ([nodeId, subscription]) =>
-          () =>
-            sendEvent({
-              nodeId,
-              pairingGeneration: subscription.pairingGeneration,
-              event,
-              payloadJSON,
-            }),
-      ),
+      nodeSubscriptions,
+      ([nodeId, subscription]) =>
+        () =>
+          sendEvent({
+            nodeId,
+            pairingGeneration: subscription.pairingGeneration,
+            event,
+            payloadJSON,
+          }),
     );
   };
 


### PR DESCRIPTION
## What problem does this solve?

Every subscription fanout built an entry array, a sender-callback array and a promise array before sending an event. The first two arrays only staged the same recipients for the final promise list.

## Why this change

The existing settlement helper now consumes the private Map iterable and creates each deferred sender immediately while constructing the promise list. Both fanout callers keep one canonical settlement path. Payload serialization remains once per event, before membership capture; callbacks still start in microtasks, and synchronous throws/asynchronous rejections remain settled. Session fanout captures the generation string; all-node fanout retains its existing later read from the captured subscription object.

Production +3 lines define the shared iterable/factory boundary; tests and support are unchanged. This removes two staging arrays per nonempty fanout without a new cache or dispatch path.

## Evidence

The actual-owner before/after corpus preserves all 57 semantic observations, including generation changes, payload serialization reentry, insertion order, unsubscribe/re-pair and sender failures. At 128 recipients the observed staging arrays fall from three to one and logical element slots from384 to128. This is not a physical-byte, retained-memory, RSS or throughput measurement.

- Existing manager/runtime/socket lifecycle suites:13 tests pass.
- Existing real local Gateway/WebSocket subscription suite:2 tests pass, including reconnect, alias unsubscribe and one final/error delivery. Dispatch fixtures are synthetic; this is not external-provider proof.
- `node scripts/check-changed.mjs -- src/gateway/server-node-subscriptions.ts`: passes, along with targeted formatting/lint.
- Independent managed Codex review through P2: no actionable finding.

No public protocol, authorization, subscription policy, storage or cleanup semantics change. Iterator tuples, per-recipient closures/promises and allSettled result objects still exist; only the redundant preparation stages are removed.
