### PR TITLE
refactor: reuse shared guards in media runner tests

### DIFF
--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -1,8 +1,9 @@
-// Auto-audio runner tests cover provider fallback selection and local binary
-// discovery for audio transcription.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+// Auto-audio runner tests cover provider fallback selection and local binary
+// discovery for audio transcription.
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { describe, expect, it, vi } from "vitest";
 import { ProviderAuthError } from "../agents/model-auth-runtime-shared.js";
 import type { OpenClawConfig } from "../config/types.js";
@@ -101,16 +102,6 @@ async function runAutoAudioCase(params: {
   return runResult;
 }
 
-type CapabilityResult = Awaited<ReturnType<typeof runCapability>>;
-
-function requireCapabilityOutput(result: CapabilityResult, index: number) {
-  const output = result.outputs[index];
-  if (!output) {
-    throw new Error(`expected media-understanding output at index ${index}`);
-  }
-  return output;
-}
-
 describe("runCapability auto audio entries", () => {
   it("resolves audio credentials after loading each attachment", async () => {
     await withAudioFixture("openclaw-audio-late-auth", async ({ ctx, media, cache }) => {
@@ -189,7 +180,7 @@ describe("runCapability auto audio entries", () => {
         return { text: "ok", model: req.model ?? "unknown" };
       },
     });
-    expect(requireCapabilityOutput(result, 0).text).toBe("ok");
+    expect(expectDefined(result.outputs[0], "media output 0").text).toBe("ok");
     expect(seenModel).toBe("gpt-4o-transcribe");
     expect(result.decision.outcome).toBe("success");
   });
@@ -429,7 +420,7 @@ describe("runCapability auto audio entries", () => {
         });
 
         expect(result.decision.outcome).toBe("success");
-        expect(requireCapabilityOutput(result, 0)).toEqual({
+        expect(expectDefined(result.outputs[0], "media output 0")).toEqual({
           kind: "audio.transcription",
           attachmentIndex: 0,
           provider: "mistral",
@@ -487,7 +478,7 @@ describe("runCapability auto audio entries", () => {
       });
 
       expect(result.decision.outcome).toBe("success");
-      expect(requireCapabilityOutput(result, 0).text).toBe("workspace test-key");
+      expect(expectDefined(result.outputs[0], "media output 0").text).toBe("workspace test-key");
     });
 
     expect(resolveApiKeyForProviderCore).toHaveBeenCalledWith(
@@ -540,7 +531,7 @@ describe("runCapability auto audio entries", () => {
     if (!runResult) {
       throw new Error("expected Codex audio result");
     }
-    expect(requireCapabilityOutput(runResult, 0)).toEqual({
+    expect(expectDefined(runResult.outputs[0], "media output 0")).toEqual({
       kind: "audio.transcription",
       attachmentIndex: 0,
       provider: "openai",
@@ -590,7 +581,7 @@ describe("runCapability auto audio entries", () => {
     if (!runResult) {
       throw new Error("expected xAI audio result");
     }
-    expect(requireCapabilityOutput(runResult, 0)).toEqual({
+    expect(expectDefined(runResult.outputs[0], "media output 0")).toEqual({
       kind: "audio.transcription",
       attachmentIndex: 0,
       provider: "xai",
@@ -621,7 +612,7 @@ describe("runCapability auto audio entries", () => {
               }),
             }),
         );
-        const output = requireCapabilityOutput(result, 0);
+        const output = expectDefined(result.outputs[0], "media output 0");
         expect(output.provider).toBe("openai");
         expect(output.text).toBe("provider transcription");
       });
@@ -677,7 +668,7 @@ describe("runCapability auto audio entries", () => {
       },
     });
 
-    expect(requireCapabilityOutput(result, 0).text).toBe("ok");
+    expect(expectDefined(result.outputs[0], "media output 0").text).toBe("ok");
     expect(seenModel).toBe("whisper-1");
   });
 
@@ -714,7 +705,7 @@ describe("runCapability auto audio entries", () => {
       } as Partial<OpenClawConfig>,
     });
 
-    expect(requireCapabilityOutput(result, 0).text).toBe("ok");
+    expect(expectDefined(result.outputs[0], "media output 0").text).toBe("ok");
     expect(seenLanguage).toBe("en");
     expect(seenPrompt).toBe("Focus on names");
   });
@@ -741,7 +732,7 @@ describe("runCapability auto audio entries", () => {
       } as Partial<OpenClawConfig>,
     });
 
-    expect(requireCapabilityOutput(result, 0).text).toBe("ok");
+    expect(expectDefined(result.outputs[0], "media output 0").text).toBe("ok");
     expect(seenLanguage).toBe("ru");
     expect(seenPrompt).toBeUndefined();
   });
@@ -812,7 +803,7 @@ describe("runCapability auto audio entries", () => {
           },
         },
       });
-      expect(requireCapabilityOutput(result, 0).text).toBe("Bonjour.");
+      expect(expectDefined(result.outputs[0], "media output 0").text).toBe("Bonjour.");
       expect(requests).toHaveLength(1);
       expect(requests[0]?.prompt).toBeUndefined();
       expect(requests[0]?.language).toBe(language);
@@ -889,7 +880,7 @@ describe("runCapability auto audio entries", () => {
       throw new Error("Expected auto audio mistral result");
     }
     expect(runResult.decision.outcome).toBe("success");
-    const output = requireCapabilityOutput(runResult, 0);
+    const output = expectDefined(runResult.outputs[0], "media output 0");
     expect(output.provider).toBe("mistral");
     expect(output.model).toBe("voxtral-mini-latest");
     expect(output.text).toBe("mistral");

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -1,5 +1,6 @@
 // Video runner tests cover provider request wiring, auth/config precedence, and
 // provider output handling for video attachments.
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { describe, expect, it, vi } from "vitest";
 import {
   formatAudioTranscripts,
@@ -33,16 +34,6 @@ vi.mock("../agents/model-auth.js", async () => {
   const { createAvailableModelAuthMockModule } = await import("./runner.test-mocks.js");
   return createAvailableModelAuthMockModule();
 });
-
-type CapabilityResult = Awaited<ReturnType<typeof runCapability>>;
-
-function requireCapabilityOutput(result: CapabilityResult, index: number) {
-  const output = result.outputs[index];
-  if (!output) {
-    throw new Error(`expected media-understanding output at index ${index}`);
-  }
-  return output;
-}
 
 describe("runCapability video provider wiring", () => {
   it("truncates provider output without splitting a boundary emoji", async () => {
@@ -93,7 +84,7 @@ describe("runCapability video provider wiring", () => {
         ]),
       });
 
-      const output = requireCapabilityOutput(result, 0);
+      const output = expectDefined(result.outputs[0], "media output 0");
       expect(output.text).toBe(prefix);
       expect(output.text).not.toContain(String.fromCharCode(0xd83d));
     });
@@ -160,7 +151,7 @@ describe("runCapability video provider wiring", () => {
           ]),
         });
 
-        const output = requireCapabilityOutput(result, 0);
+        const output = expectDefined(result.outputs[0], "media output 0");
         expect(output.text).toBe("video ok");
         expect(output.provider).toBe("moonshot");
         expect(seenBaseUrl).toBe("https://entry.example/v1");
@@ -232,7 +223,7 @@ describe("runCapability video provider wiring", () => {
             });
 
             expect(result.decision.outcome).toBe("success");
-            const output = requireCapabilityOutput(result, 0);
+            const output = expectDefined(result.outputs[0], "media output 0");
             expect(output.provider).toBe("moonshot");
             expect(output.text).toBe("moonshot");
           });
@@ -290,7 +281,7 @@ describe("runCapability video provider wiring", () => {
         });
 
         expect(result.decision.outcome).toBe("success");
-        const output = requireCapabilityOutput(result, 0);
+        const output = expectDefined(result.outputs[0], "media output 0");
         expect(output.provider).toBe("moonshot");
         expect(output.model).toBe("kimi-k2.5");
         expect(seenModel).toBe("kimi-k2.5");
@@ -348,7 +339,7 @@ describe("runCapability video provider wiring", () => {
           });
 
           expect(result.decision.outcome).toBe("success");
-          const output = requireCapabilityOutput(result, 0);
+          const output = expectDefined(result.outputs[0], "media output 0");
           expect(output.provider).toBe("moonshot");
           expect(output.model).toBe("provider-default");
           expect(seenModel).toBeUndefined();
@@ -402,7 +393,7 @@ describe("runCapability video provider wiring", () => {
         });
 
         expect(result.decision.outcome).toBe("success");
-        const output = requireCapabilityOutput(result, 0);
+        const output = expectDefined(result.outputs[0], "media output 0");
         expect(output.provider).toBe("moonshot");
         expect(output.model).toBe("kimi-k2.5");
         expect(seenModel).toBe("kimi-k2.5");

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -1,6 +1,7 @@
+import path from "node:path";
 // Vision skip tests cover auto image-model selection and text-only model
 // rejection across bundled provider metadata.
-import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
@@ -101,24 +102,6 @@ function setCompatibleActiveMediaUnderstandingRegistry(
   setActivePluginRegistry(pluginRegistry, cacheKey);
 }
 
-type CapabilityResult = Awaited<ReturnType<typeof runCapability>>;
-
-function requireDecisionAttachment(result: CapabilityResult, index: number) {
-  const attachment = result.decision.attachments[index];
-  if (!attachment) {
-    throw new Error(`expected media-understanding decision attachment ${index}`);
-  }
-  return attachment;
-}
-
-function requireCapabilityOutput(result: CapabilityResult, index: number) {
-  const output = result.outputs[index];
-  if (!output) {
-    throw new Error(`expected media-understanding output ${index}`);
-  }
-  return output;
-}
-
 describe("runCapability image skip", () => {
   beforeAll(async () => {
     vi.doMock("../agents/prepared-model-catalog.js", () => {
@@ -158,7 +141,10 @@ describe("runCapability image skip", () => {
       expect(result.outputs).toHaveLength(0);
       expect(result.decision.outcome).toBe("skipped");
       expect(result.decision.attachments).toHaveLength(1);
-      const attachment = requireDecisionAttachment(result, 0);
+      const attachment = expectDefined(
+        result.decision.attachments[0],
+        "media decision attachment 0",
+      );
       expect(attachment.attachmentIndex).toBe(0);
       const attempt = attachment.attempts[0];
       if (!attempt) {
@@ -589,7 +575,7 @@ describe("runCapability image skip", () => {
         });
 
         expect(result.decision.outcome).toBe("success");
-        expect(requireCapabilityOutput(result, 0)).toEqual({
+        expect(expectDefined(result.outputs[0], "media output 0")).toEqual({
           kind: "image.description",
           attachmentIndex: 0,
           provider: "openrouter",
@@ -778,14 +764,17 @@ describe("runCapability image skip", () => {
         });
 
         expect(result.decision.outcome).toBe("success");
-        expect(requireCapabilityOutput(result, 0)).toEqual({
+        expect(expectDefined(result.outputs[0], "media output 0")).toEqual({
           kind: "image.description",
           attachmentIndex: 0,
           provider: "ollama",
           model: "qwen2.5vl:7b",
           text: "ok qwen2.5vl:7b",
         });
-        const attachment = requireDecisionAttachment(result, 0);
+        const attachment = expectDefined(
+          result.decision.attachments[0],
+          "media decision attachment 0",
+        );
         expect(attachment.attempts).toEqual([
           expect.objectContaining({
             type: "provider",
@@ -923,7 +912,7 @@ describe("runCapability image skip", () => {
           });
 
           expect(result.decision.outcome).toBe("success");
-          expect(requireCapabilityOutput(result, 0)).toEqual({
+          expect(expectDefined(result.outputs[0], "media output 0")).toEqual({
             kind: "image.description",
             attachmentIndex: 0,
             provider: "minimax-portal",
@@ -989,7 +978,7 @@ describe("runCapability image skip", () => {
 
           expect(result.decision.outcome).toBe("success");
           expect(seenProviders).toEqual(["minimax-cn"]);
-          expect(requireCapabilityOutput(result, 0)).toEqual({
+          expect(expectDefined(result.outputs[0], "media output 0")).toEqual({
             kind: "image.description",
             attachmentIndex: 0,
             provider: "minimax-cn",
@@ -1060,7 +1049,7 @@ describe("runCapability image skip", () => {
 
         expect(result.decision.outcome).toBe("success");
         expect(seenModel).toBe("MiniMax-VL-01");
-        expect(requireCapabilityOutput(result, 0)).toMatchObject({
+        expect(expectDefined(result.outputs[0], "media output 0")).toMatchObject({
           provider: "minimax",
           model: "MiniMax-VL-01",
           text: "vlm ok",
@@ -1118,7 +1107,7 @@ describe("runCapability image skip", () => {
 
         expect(result.decision.outcome).toBe("success");
         expect(seenProviders).toEqual(["google"]);
-        expect(requireCapabilityOutput(result, 0)).toEqual({
+        expect(expectDefined(result.outputs[0], "media output 0")).toEqual({
           kind: "image.description",
           attachmentIndex: 0,
           provider: "google",
@@ -1244,7 +1233,7 @@ describe("runCapability image skip", () => {
           });
 
           expect(result.decision.outcome).toBe("success");
-          expect(requireCapabilityOutput(result, 0)).toMatchObject({
+          expect(expectDefined(result.outputs[0], "media output 0")).toMatchObject({
             provider: "workspace-vision",
             model: "vision-v1",
             text: "workspace auth ok",
@@ -1307,7 +1296,7 @@ describe("runCapability image skip", () => {
         });
 
         expect(result.decision.outcome).toBe("success");
-        const output = requireCapabilityOutput(result, 0);
+        const output = expectDefined(result.outputs[0], "media output 0");
         expect(output.provider).toBe("openrouter");
         expect(output.model).toBe("auto");
         expect(output.text).toBe("openrouter ok");


### PR DESCRIPTION
Related: #137047

## What Problem This Solves

Three media runner test suites duplicate result-presence guards already available in the shared normalization package, adding scaffolding without additional coverage. This is part of the maintainer-requested test audit.

## Why This Change Was Made

Use `expectDefined` for all 27 existing output and decision attachment reads, removing four local wrappers and three unused type aliases. The result producers return objects; missing array entries remain guarded. All 169 assertions, existing tables and cases, optional member types, and outer and nested guards remain intact. Production LOC: **0**. Test LOC: **+39/-68 (net -29)**.

## User Impact

No user-visible behavior change. Existing upload privacy, provider/authentication, native vision, model-routing, language, UTF-16, cleanup, and ordering checks remain unchanged.

## Evidence

- The unchanged baseline and candidate each passed **74/74 tests** through the same normal wrapper selection: the three changed runner suites plus the canonical `expect` helper suite. Expanded per-file case order, outcomes, routed include order, and result file order match. Providers are mocked; this is not live provider proof.
- The full three-path `check-changed` gate passed locally with Node 26.8.1 and pnpm 12.1.0, including type checking, guards, formatting, all three dead-export scans, and lint. Only inherited `OPENCLAW_TESTBOX` was unset for the documented trusted-local route.
- Fresh Codex review through P2 found no actionable issues.

The initial baseline failed before collecting tests with a Vitest 4.1.11 cache-write ENOENT. After the normal `--clearCache` command cleared the two scheduler-selected task cache leaves, the fresh unchanged baseline and candidate passed. The initial failure is retained under the existing Vitest cache lifecycle investigation; its deletion event was not captured here, and no dependency, cache configuration, assertion, or timeout was changed to pass.

Named follow-up left separate: `runner.skip-tiny-audio.test.ts` can replace repeated nested presence calls with named attachment and attempt values while preserving its four threshold cases.

CI refresh: the first exact-head run, [33730383015](https://github.com/openclaw/openclaw/actions/runs/33730383015), failed core lint because its merged main baseline carried `src/node-host/runner.test.ts` at 1006 counted lines. Canonical #137149 splits that test below the limit. A mechanical refresh brings in that existing fix while preserving this PR's exact three-file patch and unchanged audited owner/dependency context. Fresh CI on the refreshed head is required; the failed run is not treated as passing.
