### PR TITLE
refactor: reuse the shared assertion in respawn tests

### DIFF
--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -1,6 +1,7 @@
 // Tests entrypoint respawn behavior for compile cache and process flags.
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { describe, expect, it, vi } from "vitest";
 import { buildCliRespawnPlan, runCliRespawnPlan } from "./entry.respawn.js";
 
@@ -15,14 +16,6 @@ function expectCliRespawnPlan(plan: ReturnType<typeof buildCliRespawnPlan>): Cli
     throw new Error("Expected CLI respawn plan");
   }
   return plan;
-}
-
-function requireFirstMockCall(mock: { mock: { calls: unknown[][] } }, label: string): unknown[] {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call;
 }
 
 describe("buildCliRespawnPlan", () => {
@@ -419,9 +412,9 @@ describe("runCliRespawnPlan", () => {
         detached: process.platform !== "win32" && !(process.stdin.isTTY || process.stdout.isTTY),
       },
     );
-    const [bridgeChild, bridgeOptions] = requireFirstMockCall(
-      attachChildProcessBridge,
-      "child process bridge attach",
+    const [bridgeChild, bridgeOptions] = expectDefined<unknown[]>(
+      attachChildProcessBridge.mock.calls[0],
+      "child process bridge attach call",
     );
     expect(bridgeChild).toBe(child);
     expect(bridgeOptions).toEqual({ onSignal: expect.any(Function) });


### PR DESCRIPTION
## What Problem This Solves

The respawn tests maintain a one-use helper that duplicates the shared missing-value assertion.

## Why This Change Was Made

Use `expectDefined<unknown[]>` for the first bridge mock call. This preserves both the missing-call failure and the original `unknown[]` boundary while removing the local helper. The reusable plan assertion remains unchanged.

## User Impact

Test maintenance only. Production code is unchanged, and the test diff is seven lines smaller. All 30 respawn cases retain their startup, CA, Gmail, native-hook, Windows, terminal, spawn and child-lifecycle assertions.

## Evidence

The same canonical invocation passed all 44 cases before and after the change:

```sh
node scripts/run-vitest.mjs \
  src/entry.respawn.test.ts \
  src/process/respawn-child-runner.test.ts \
  src/process/child-process-bridge.test.ts \
  packages/normalization-core/src/expect.test.ts
```

The full configured one-path changed gate passed all 20 stages, including core test typechecking, typed lint and the three dead-export scans. Codex review was clean through P2. Direct Vitest source/type inspection confirmed the actual array-or-undefined mock-row contract and the preserved static type boundary.

Separate follow-up: audit the existing spawn/exit fixture type assertions while preserving the PID-less child; this change leaves them intact.
