### PR TITLE
docs: bundle Control UI operations skill

### DIFF
--- a/skills/control-ui/SKILL.md
+++ b/skills/control-ui/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: control-ui
+description: "Operate and troubleshoot the OpenClaw Control UI: navigate connected clients, organize sessions, build session dashboards, and handle direct or Tailscale-hosted Gateways."
+---
+
+# Control UI
+
+Use OpenClaw's typed UI tools for state and layout. Use browser automation only
+to inspect or interact with rendered pixels.
+
+## Mental model
+
+- A sidebar item is a **session**, not a dashboard page.
+- Each session owns one board. The board contains tabs and widgets.
+- Pinning a session keeps it in the sidebar. Showing its Dashboard face makes it
+  appear under `/dashboards`.
+- `screen` changes connected Control UI layout and navigation. It does not read
+  the page or take screenshots.
+- `sessions_list` finds sessions. `sessions` renames, groups, pins, or archives
+  them. It does not edit board content.
+- `dashboard` reads and arranges the current session's board and registered
+  plugin widgets. `show_widget` authors or updates custom HTML/SVG widgets.
+
+Do not replace these operations with shell calls or raw Gateway RPC when the
+typed tool exists.
+
+## Start safely
+
+1. Identify the target session and whether the Control UI is local/direct or
+   published through Tailscale or another HTTPS proxy.
+2. Read current state before changing it:
+   - use `sessions_list` to resolve the session;
+   - use `dashboard` with `action: "read"` for the current session;
+   - inspect existing tabs, stable widget names, owners, sizes, and dock state.
+3. If the task targets another session's board, move the work into that session.
+   Dashboard tools intentionally operate on the current session.
+
+Read [hosting.md](references/hosting.md) before opening or repairing a remote
+Control UI. Read [dashboards.md](references/dashboards.md) before creating or
+restructuring a board.
+
+## Navigate and arrange the UI
+
+Use `screen` for deterministic client commands:
+
+- `navigate` to open a Control UI route;
+- `sidebar_show` / `sidebar_hide` for the session sidebar;
+- `split_right` / `split_down`, `focus`, and `close_pane` for panes;
+- `terminal_show` / `terminal_hide` and `browser_show` / `browser_hide` for
+  docked panels.
+
+`screen` broadcasts to every connected Control UI that advertises UI commands;
+it cannot select one browser tab. Confirm the blast radius when several clients
+may be open. If it reports no capable client, ask the user to open the Control
+UI and retry.
+
+Use the in-app browser or an available browser-control tool when the task needs
+DOM inspection, clicking, typing, or screenshots. Reuse the existing signed-in
+Control UI tab when possible.
+
+## Build a session dashboard
+
+1. Call `dashboard read`. Reuse suitable tabs and widget names.
+2. Create or rename tabs with `tab_create` / `tab_update`; use short lowercase
+   slug IDs.
+3. Add content with the correct owner:
+   - custom HTML/SVG or registered-source content: `show_widget` with
+     `pin: true`;
+   - trusted plugin widgets: `dashboard widget_put` with an advertised
+     `pluginKind`.
+4. Use a stable `name` when calling `show_widget`. Reusing the same name with
+   new `widget_code` updates the widget in place.
+5. Arrange with `widget_move`, `widget_resize`, tab reordering, and
+   `set_chat_dock`. Prefer size presets and board order over pixel placement.
+6. Pin the current session with `sessions patch` when it should stay prominent.
+7. Call `dashboard focus_tab` to show the intended tab. A connected Control UI
+   switches to Dashboard and persists that session's preferred face. If no UI
+   is connected, the command returns unavailable; have the user open the
+   session, select Dashboard once, and retry.
+
+Never create a fake top-level page for a dashboard. For a dedicated dashboard,
+use a dedicated session, pin that session, and build its board from inside it.
+
+## Update without breaking the board
+
+- Read first and mutate the smallest unit.
+- Keep stable tab IDs and widget names unless replacement is intentional.
+- Do not change a widget's content owner in place. Remove it, then recreate it
+  with the new owner or registered kind.
+- Capability grants are bound to exact widget bytes and revision. Changed
+  content may require approval again.
+- Resetting a conversation preserves its board. Deleting the session deletes
+  the board.
+
+## Verify the result
+
+Use two layers of proof:
+
+1. **State:** `dashboard read` shows the expected tabs, widgets, names, owners,
+   order, sizes, and dock state; `sessions_list` shows the expected session
+   metadata.
+2. **Rendered UI:** open the actual Control UI, confirm the correct session and
+   Dashboard face, then inspect or screenshot the widget frame. Exercise any
+   important controls.
+
+An HTTP 200 for the shell or widget route is transport proof, not visual proof.
+Do not claim the dashboard works until the sandboxed frame renders.
+
+## Recovery order
+
+When a widget is blank or stale:
+
+1. confirm the expected session, tab, widget name, and revision with
+   `dashboard read`;
+2. classify the hosting path using [hosting.md](references/hosting.md);
+3. verify the Control UI origin and the separate widget sandbox origin;
+4. after a Gateway restart or routing change, republish/update the widget so the
+   browser receives a fresh ticketed frame URL;
+5. reload the Control UI and verify the rendered frame, not only route status.

--- a/skills/control-ui/references/dashboards.md
+++ b/skills/control-ui/references/dashboards.md
@@ -1,0 +1,73 @@
+# Dashboard operations
+
+## Ownership map
+
+| Object                  | Tool                        | Notes                                  |
+| ----------------------- | --------------------------- | -------------------------------------- |
+| Session row             | `sessions_list`, `sessions` | Find, label, group, pin, archive       |
+| Board snapshot          | `dashboard read`            | Current session only                   |
+| Tabs and layout         | `dashboard`                 | Create, rename, reorder, focus, dock   |
+| Custom HTML/SVG         | `show_widget`               | Set `pin: true`; update by stable name |
+| Trusted plugin widget   | `dashboard widget_put`      | Requires an advertised `pluginKind`    |
+| Visible browser state   | Browser-control tool        | Inspect, click, type, screenshot       |
+| Client panes and panels | `screen`                    | Commands connected capable clients     |
+
+## Recommended build sequence
+
+1. Read the board.
+2. Create tabs only when the existing structure does not fit.
+3. Put each widget on its final tab with a stable name.
+4. Move and resize after content exists.
+5. Configure the chat dock.
+6. Pin the session.
+7. Focus the intended tab.
+8. Read again, then verify the rendered UI.
+
+The Dashboard tool's focus and dock commands need a connected Control UI. They
+can return unavailable even though board storage is healthy.
+
+## Updating content
+
+For a custom widget, call `show_widget` again with:
+
+- `pin: true`;
+- the same explicit `name`;
+- the replacement `widget_code`;
+- the existing tab and intended size.
+
+This updates content without discarding the widget's board position. A content
+change creates a new revision and may invalidate prior capability approval.
+
+Use `dashboard widget_put` only for registered plugin kinds. It is not a second
+HTML-authoring path.
+
+## Face and sidebar behavior
+
+The session is the durable sidebar object. A board is not a separate session or
+navigation page.
+
+- `sessions patch` can pin and organize the session.
+- `dashboard focus_tab` broadcasts a focus command. A connected Control UI
+  switches to Dashboard and persists the face preference for that session.
+- The human can also choose Chat, Split, or Dashboard in the session header.
+- Sessions whose stored preference is Dashboard appear under `/dashboards`.
+
+The active tab and remembered dock placement are per-device UI state. The
+Chat/Dashboard preference is server-side session state.
+
+## Verification checklist
+
+- Correct session key and label.
+- Expected Dashboard face and tab.
+- Stable widget names, correct owners, and current revisions.
+- Layout is usable at desktop and narrow widths when relevant.
+- Widget frame loaded; no sandbox-origin or ticket error.
+- Interactive controls perform their intended action.
+- Capability prompts or grants match the widget's declared needs.
+
+Source documentation:
+
+- `docs/web/dashboards.md`
+- `docs/web/dashboard-architecture.md`
+- `docs/tools/screen.md`
+- `docs/tools/show-widget.md`

--- a/skills/control-ui/references/hosting.md
+++ b/skills/control-ui/references/hosting.md
@@ -1,0 +1,103 @@
+# Control UI hosting paths
+
+Classify the connection before troubleshooting. “Native” can mean a browser on
+the Gateway host, a direct Gateway connection, or a native client; those paths
+do not have identical routing.
+
+## Local or direct Gateway
+
+Prefer `openclaw dashboard` on the Gateway host. It creates a short-lived local
+bootstrap URL and binds the browser to durable device identity. Do not paste or
+log bootstrap credentials.
+
+For a remote browser, prefer an SSH tunnel or HTTPS ingress. Direct browser
+access needs both:
+
+- the Gateway Control UI/WebSocket listener; and
+- the separate widget sandbox listener, normally the Gateway port plus one.
+
+When the browser reaches the Gateway host directly, OpenClaw can derive the
+sandbox origin by substituting the sandbox port. A custom `mcp.apps.sandboxPort`
+changes that listener. The sandbox listener is shared by dashboard HTML frames
+and enabled MCP Apps, but it never serves the authenticated Control UI.
+
+## Tailscale-hosted Control UI
+
+Use managed Tailscale Serve for browser access:
+
+```bash
+openclaw gateway --tailscale serve
+```
+
+Serve keeps the Gateway on loopback and publishes the Control UI and WebSocket
+over HTTPS. With `gateway.auth.allowTailscale: true`, OpenClaw can accept a
+verified Serve identity for Control UI authentication. The browser still needs
+device identity. Externally managed Serve routes are generic trusted-proxy
+ingress and do not inherit managed Serve authentication semantics.
+
+The managed Control UI route does **not** publish the widget sandbox listener.
+For dashboards with HTML or MCP App frames:
+
+1. publish the sandbox listener at a second HTTPS origin reachable by the same
+   browser;
+2. route that origin only to the configured sandbox port;
+3. set `mcp.apps.sandboxOrigin` to that public origin;
+4. restart the Gateway;
+5. update or republish the widget to issue a fresh ticketed frame URL;
+6. verify the frame in the Tailscale-hosted Control UI.
+
+Example shape:
+
+```json5
+{
+  mcp: {
+    apps: {
+      sandboxOrigin: "https://widgets.example.ts.net",
+      sandboxPort: 18790,
+    },
+  },
+}
+```
+
+The sandbox origin must differ from the Control UI origin. Never host
+authenticated or sensitive content on it. Preserve existing Tailscale routes;
+inspect them before adding or changing a route.
+
+Do not use `gateway.bind: "tailnet"` with plain HTTP for a browser Control UI.
+That direct bind is intended for native or CLI clients. Prefer Tailscale Serve
+for a browser. Use Funnel only when public exposure is intentional and protect
+it with the required password.
+
+## Other reverse proxies
+
+The same two-origin rule applies to nginx, Caddy, Cloudflare Tunnel, and other
+TLS terminators:
+
+- one authenticated origin for the Control UI and WebSocket;
+- one unprivileged origin, routed only to the sandbox listener, for widget
+  frames;
+- `mcp.apps.sandboxOrigin` set to the second origin.
+
+Do not forward arbitrary authentication headers. Follow the trusted-proxy
+documentation when a proxy owns identity.
+
+## Diagnose by layer
+
+1. **Gateway:** Control UI and WebSocket reachable; authentication and device
+   identity succeed.
+2. **Board state:** `dashboard read` returns the expected widget and revision.
+3. **Sandbox route:** configured sandbox origin reaches only the sandbox
+   listener.
+4. **Ticket:** the current frame URL is fresh after restart or republish.
+5. **Rendering:** the browser loads the frame and its controls work.
+
+A working Control UI shell with a blank widget usually points to layers 3–5,
+not board storage.
+
+Source documentation:
+
+- `docs/web/control-ui.md`
+- `docs/web/dashboards.md`
+- `docs/web/dashboard-architecture.md`
+- `docs/gateway/tailscale.md`
+- `docs/cli/mcp.md` (MCP Apps sandbox listener)


### PR DESCRIPTION
Closes #137164

## What Problem This Solves

Agents operating the Control UI have no bundled workflow that joins the session/sidebar model, dashboard tools, rendered-UI verification, and remote hosting requirements. This can lead them to model dashboards as separate sidebar pages or conclude a remote dashboard works when only the Control UI shell—not the sandboxed widget frame—is reachable.

## Why This Change Was Made

This adds a core-owned `control-ui` skill and focused references for dashboard operations and hosting. It uses the supported `screen`, `sessions_list`, `sessions`, `dashboard`, and `show_widget` boundaries, and distinguishes direct Gateway access from Tailscale Serve or other reverse proxies that require a separate widget sandbox origin.

Bundling is intentional: the skill teaches first-party OpenClaw tools and a security-sensitive hosting contract that should evolve with core rather than drift in a third-party integration.

## User Impact

Agents can create, update, verify, and recover session dashboards without shell/RPC fallbacks. Operators get explicit guidance for local/direct access, managed Tailscale Serve, generic reverse proxies, restart recovery, and visual verification of the sandboxed frame.

There is no runtime or UI behavior change.

## Evidence

- `python3 skills/skill-creator/scripts/quick_validate.py skills/control-ui` — valid
- `python3 skills/skill-creator/scripts/package_skill.py skills/control-ui /tmp/openclaw-control-ui-skill-package` — packaged all three files
- `pnpm check:changed -- skills/control-ui/SKILL.md skills/control-ui/references/dashboards.md skills/control-ui/references/hosting.md` — passed
- `python -m ruff check --config skills/pyproject.toml skills` — passed
- `python -m pytest -q -c skills/pyproject.toml skills` — 28 passed
- Autoreview (`codex`, P0 gate) — scoped clean, no accepted/actionable findings
- Reviewed against current Control UI, dashboard architecture, screen, show-widget, MCP Apps sandbox, and Tailscale documentation and current tool/UI implementations.

Screenshots are not applicable because this is a bundled skill/documentation-only change with no rendered UI change.
