### PR TITLE
fix: release settled Code Mode input ownership

### DIFF
--- a/scripts/lib/vitest-worker-artifacts.mts
+++ b/scripts/lib/vitest-worker-artifacts.mts
@@ -12,6 +12,8 @@ export const vitestWorkerDeclarationEntries = {
   ...runtimeProcessDeclarationEntries,
   "extensions/qa-lab/gateway-child-artifacts-runtime.test-support":
     "extensions/qa-lab/src/gateway-child-artifacts-runtime.test-support.ts",
+  "agents/code-mode-retention-entrypoint.test-support":
+    "src/agents/code-mode-retention-entrypoint.test-support.ts",
   "agents/command/cli-compaction-runtime.test-support":
     "src/agents/command/cli-compaction-runtime.test-support.ts",
   "cron/owner-hardening-runtime.test-support": "src/cron/owner-hardening-runtime.test-support.ts",

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { qaGatewayCleanupRuntimeEntrypoint } from "../../extensions/qa-lab/src/gateway-child-artifacts-runtime.test-support.ts";
+import { codeModeRetentionEntrypoint } from "../../src/agents/code-mode-retention-entrypoint.test-support.ts";
 import { cliCompactionBackendEntrypoints } from "../../src/agents/command/cli-compaction-runtime.test-support.ts";
 import { cronOwnerHardeningEntrypoints } from "../../src/cron/owner-hardening-runtime.test-support.ts";
 import { sessionTitleRetentionEntrypoints } from "../../src/gateway/session-title-retention.test-support.ts";
@@ -14,6 +15,7 @@ export const vitestWorkerBuildEntries = {
   ...runtimeProcessBuildEntries,
   ...Object.fromEntries(
     [
+      codeModeRetentionEntrypoint,
       ...cliCompactionBackendEntrypoints,
       ...Object.values(cronOwnerHardeningEntrypoints),
       ...Object.values(tuiPtyRuntimeEntrypoints),
@@ -27,6 +29,8 @@ export const vitestWorkerBuildEntries = {
       fileURLToPath(new URL(`./${entry.sourceWorkerName}.ts`, entry.currentModuleUrl)),
     ]),
   ),
+  // The retention fixture executes the real nested QuickJS worker.
+  "agents/code-mode.worker": "src/agents/code-mode.worker.ts",
   // The real ulimit fixture must import its parent before imposing a file-size limit.
   "infra/sqlite-readonly-location": "src/infra/sqlite-readonly-location.ts",
   // Keep provider preparation in the same compiled graph as payload rendering;

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -314,8 +314,7 @@ async function settleCodeModeResult(params: {
         (request) => !pendingIds.has(request.id),
       );
       pending.push(
-        ...createPendingBridgeStates({
-          pendingRequests: newPendingRequests,
+        ...createPendingBridgeStates(newPendingRequests, {
           config: params.config,
           runtime: params.runtime,
           catalogProjection: params.catalogProjection,
@@ -442,8 +441,7 @@ async function settleCodeModeResult(params: {
         (request) => !pendingIds.has(request.id),
       );
       pending.push(
-        ...createPendingBridgeStates({
-          pendingRequests: newPendingRequests,
+        ...createPendingBridgeStates(newPendingRequests, {
           config: params.config,
           runtime: params.runtime,
           catalogProjection: params.catalogProjection,

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -300,8 +300,7 @@ export async function runCodeModeScriptHeadless(params: {
       }
 
       pending.push(
-        ...createPendingBridgeStates({
-          pendingRequests: newRequests,
+        ...createPendingBridgeStates(newRequests, {
           config,
           runtime,
           catalogProjection,

--- a/src/agents/code-mode-retention-entrypoint.test-support.ts
+++ b/src/agents/code-mode-retention-entrypoint.test-support.ts
@@ -1,0 +1,6 @@
+// Prepare the runtime graph before the retention child's bounded GC checks.
+export const codeModeRetentionEntrypoint = {
+  currentModuleUrl: import.meta.url,
+  sourceWorkerName: "code-mode-retention.test-support",
+  distWorkerPath: "agents/code-mode-retention.test-support.js",
+} as const;

--- a/src/agents/code-mode-retention.test-support.ts
+++ b/src/agents/code-mode-retention.test-support.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { Type } from "typebox";
+import { createDeferredCore } from "../shared/deferred.js";
+import { activeRuns, disposeAllCodeModeRuns } from "./code-mode-state.js";
+import { applyCodeModeCatalog, createCodeModeTools } from "./code-mode.js";
+import { clearToolSearchCatalog, createToolSearchCatalogRef } from "./tool-search.js";
+import { jsonResult, type AnyAgentTool } from "./tools/common.js";
+
+const gc = globalThis.gc;
+assert.ok(gc, "The retention child requires --expose-gc");
+const started = { done: createDeferredCore(), pending: createDeferredCore() };
+const release = { done: createDeferredCore(), pending: createDeferredCore() };
+const inputs = new Map<string, WeakRef<object>>();
+const calls: string[] = [];
+const target: AnyAgentTool = {
+  name: "retain_input",
+  label: "Retain input",
+  description: "A controlled input lifetime fixture.",
+  parameters: Type.Object({ kind: Type.String() }),
+  execute: async (_id, input) => {
+    assert.ok(isRecord(input));
+    const kind = input.kind;
+    assert.ok(kind === "done" || kind === "pending");
+    inputs.set(kind, new WeakRef(input));
+    calls.push(kind);
+    started[kind].resolve();
+    await release[kind].promise;
+    return jsonResult({ kind: input.kind });
+  },
+};
+const config = { tools: { codeMode: true } };
+const ctx = {
+  config,
+  runtimeConfig: config,
+  catalogRef: createToolSearchCatalogRef(),
+  sessionId: "retention-session",
+  sessionKey: "agent:main:retention",
+  runId: "retention-run",
+};
+const tools = createCodeModeTools(ctx);
+applyCodeModeCatalog({ ...ctx, tools: [...tools, target] });
+const exec = tools.find((tool) => tool.name === "exec");
+const wait = tools.find((tool) => tool.name === "wait");
+assert.ok(exec && wait);
+function unownedControl() {
+  return new WeakRef({ unowned: true });
+}
+const control = unownedControl();
+let pending: Promise<unknown>[] = [];
+try {
+  const response = await exec.execute("park-inputs", {
+    code: 'const done = retain_input({ kind: "done" }); const pending = retain_input({ kind: "pending" }); await yield_control(); return await Promise.all([done, pending]);',
+  });
+  assert.ok(isRecord(response.details));
+  assert.equal(response.details.status, "waiting");
+  const runId = response.details.runId;
+  assert.ok(typeof runId === "string");
+  const state = activeRuns.get(runId);
+  assert.ok(state);
+  pending = state.pending.map((entry) => entry.promise);
+  await Promise.all([started.done.promise, started.pending.promise]);
+  const completed = state.pending.find(
+    (entry) => isRecord(entry.args[1]) && entry.args[1].kind === "done",
+  );
+  assert.ok(completed);
+  release.done.resolve();
+  await completed.promise;
+  // A parked cell still owns responses; completed inputs must not ride along.
+  for (let pass = 0; pass < 8; pass += 1) {
+    await setImmediate();
+    gc();
+  }
+  assert.equal(control.deref(), undefined, "Unowned control must collect");
+  assert.equal(inputs.get("done")?.deref(), undefined, "Settled input must be released");
+  assert.ok(inputs.get("pending")?.deref(), "Pending input must remain usable");
+  release.pending.resolve();
+  const resumed = await wait.execute("resume-inputs", { runId });
+  assert.ok(isRecord(resumed.details));
+  assert.equal(resumed.details.status, "completed");
+  assert.deepEqual(resumed.details.value, [{ kind: "done" }, { kind: "pending" }]);
+  assert.deepEqual(calls, ["done", "pending"]);
+  assert.equal(activeRuns.size, 0);
+  process.stdout.write(
+    JSON.stringify({ completedInputReleased: true, pendingInputPreserved: true }),
+  );
+} finally {
+  release.done.resolve();
+  release.pending.resolve();
+  disposeAllCodeModeRuns();
+  await Promise.allSettled(pending);
+  clearToolSearchCatalog(ctx);
+}

--- a/src/agents/code-mode-retention.test.ts
+++ b/src/agents/code-mode-retention.test.ts
@@ -1,0 +1,28 @@
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+import { runNodeScript } from "../../test/helpers/run-node-script.js";
+import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { codeModeRetentionEntrypoint } from "./code-mode-retention-entrypoint.test-support.js";
+
+it("releases completed tool inputs while a real guest remains parked", async ({ signal }) => {
+  const result = await runNodeScript(
+    [
+      "--expose-gc",
+      ...resolveRuntimeWorkerArgv(resolveRuntimeWorkerUrl(codeModeRetentionEntrypoint)),
+    ],
+    { ...process.env, NODE_OPTIONS: "", TSX_DISABLE_CACHE: "1" },
+    15_000,
+    {
+      cwd: fileURLToPath(new URL("../../", import.meta.url)),
+      signal,
+      maxBuffer: 64 * 1024,
+      requireProcessTreeExit: process.platform !== "win32",
+    },
+  );
+  expect(result.error, result.stderr).toBeUndefined();
+  expect(result.status, result.stderr).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual({
+    completedInputReleased: true,
+    pendingInputPreserved: true,
+  });
+}, 30_000);

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -355,22 +355,25 @@ function isPendingBridgeRequestReplaySafe(
   return binding ? runtime.isReplaySafeExactId(binding.id) : false;
 }
 
-export function createPendingBridgeStates(params: {
-  pendingRequests: PendingBridgeRequest[];
-  config: CodeModeConfig;
-  runtime: ToolSearchRuntime;
-  catalogProjection: CodeModeCatalogProjection;
-  namespaceRuntime: CodeModeNamespaceRuntime;
-  parentToolCallId: string;
-  codeModeRunId: string;
-  remainingMs: number;
-  activeRunId?: string;
-  ctx: ToolSearchToolContext;
-  signal: AbortSignal;
-  onUpdate?: AgentToolUpdateCallback;
-  bridgeDispatch: CodeModeBridgeDispatchState;
-}): PendingBridgeState[] {
-  return params.pendingRequests.map((request) => {
+export function createPendingBridgeStates(
+  pendingRequests: PendingBridgeRequest[],
+  params: {
+    config: CodeModeConfig;
+    runtime: ToolSearchRuntime;
+    catalogProjection: CodeModeCatalogProjection;
+    namespaceRuntime: CodeModeNamespaceRuntime;
+    parentToolCallId: string;
+    codeModeRunId: string;
+    remainingMs: number;
+    activeRunId?: string;
+    ctx: ToolSearchToolContext;
+    signal: AbortSignal;
+    onUpdate?: AgentToolUpdateCallback;
+    bridgeDispatch: CodeModeBridgeDispatchState;
+  },
+): PendingBridgeState[] {
+  // Pending siblings retain dispatch context, never the original request batch.
+  return pendingRequests.map((request) => {
     // Bridge calls start immediately while the VM snapshot is stored. Their
     // settled values are later replayed into QuickJS by the wait tool.
     const abortController = new AbortController();
@@ -429,6 +432,9 @@ export function createPendingBridgeStates(params: {
         }
         state.settledSequence = ++nextPendingBridgeSettlementSequence;
         state.settled = settled;
+        // Only the response is needed until guest replay; live calls keep their own request.
+        state.args = [];
+        state.cancel = undefined;
         if (state.method === "agentWait" && params.activeRunId) {
           const active = activeRuns.get(params.activeRunId);
           if (active?.pending.includes(state)) {

--- a/src/agents/code-mode-swarm.lazy.test.ts
+++ b/src/agents/code-mode-swarm.lazy.test.ts
@@ -153,8 +153,7 @@ it("fences swarm effects after owner or policy loss during a shared runtime impo
         config,
         owner,
         dispatch: (pendingRequests = requests) =>
-          createPendingBridgeStates({
-            pendingRequests,
+          createPendingBridgeStates(pendingRequests, {
             config: limits,
             runtime,
             ctx,

--- a/src/infra/worker-task-pool.ts
+++ b/src/infra/worker-task-pool.ts
@@ -233,15 +233,20 @@ export class WorkerTaskPool<Input, Output> {
         void this.retire(slot).then(complete);
         return;
       }
-      slot.worker?.unref();
-      const idleMs = this.options.idleTimeoutMs ?? 60_000;
-      if (idleMs > 0) {
-        slot.idleTimer = setTimeout(() => void this.retire(slot), idleMs);
-        slot.idleTimer.unref();
-      }
+      this.idle(slot);
     }
     complete();
     this.dispatch();
+  }
+
+  // A separate scope keeps the idle timer from retaining the completed task/result.
+  private idle(slot: Slot<Input, Output>): void {
+    slot.worker?.unref();
+    const idleMs = this.options.idleTimeoutMs ?? 60_000;
+    if (idleMs > 0) {
+      slot.idleTimer = setTimeout(() => void this.retire(slot), idleMs);
+      slot.idleTimer.unref();
+    }
   }
 
   private retire(slot: Slot<Input, Output>): Promise<void> {


### PR DESCRIPTION
## What Problem This Solves

Completed Code Mode calls could keep large input objects alive while a sibling call remained pending. The bridge retained settled arguments and the original request batch; a worker idle timer also retained the completed response through its completion scope.

## Why This Change Was Made

The bridge now separates each batch from the dispatch context and releases settled arguments and cancellation closures after recording the result. The worker pool creates its existing idle timer in a separate method so that timer cannot retain the completed task and response. Pending calls, cancellation, replay order and the idle timeout retain their existing behavior.

## User Impact

Completed input objects can be collected before pending siblings finish. No configuration, protocol, persistence or timeout changes. Production LOC is **+8** for explicit batch/dispatch and timer/result lifetimes; tests are **+27**, test support/tooling **+106**.

## Evidence

- The real QuickJS exec/wait regression fails against the original four production owners at the retention assertion and passes after the repair. It also checks that the pending call can still use its input, resumed values remain ordered, and active run state empties.
- Four direct bridge traces preserve dispatch, results and effects. Retained input/argument pairs decrease from four to one while the last call remains pending, then to zero after settlement. The 1 MiB declared payload is not a measured retained-heap size.
- 171 selected tests and the canonical changed-file gate pass. After integration with the already-landed worker-input fix, all ten pool tests and the real Code Mode retention regression pass together.
- Independent source-embedded Codex review through P2 found no actionable issue. The regression uses the existing compiled-child declaration and lifecycle, preserving its eight GC turns, 15-second child budget and 30-second test budget.
- A descriptive process pair was slower and used 2.97 MiB more peak RSS; no overall speed or Gateway-memory improvement is claimed. An earlier timer callback failed lint and an initial compiled fixture omitted its nested worker; both failures are retained in local evidence and fixed without suppression or increased budgets.

Real authenticated Gateway integration for this combined change is pending before landing; the actual-worker regression above exercises the repaired owner directly. Hosted exact-head CI remains required.
