### PR TITLE
fix(discord): accept system-agent approval callbacks through the custom-id codec

### DIFF
--- a/extensions/discord/src/approval-custom-id.ts
+++ b/extensions/discord/src/approval-custom-id.ts
@@ -3,7 +3,15 @@ import { buildApprovalResolutionRef } from "openclaw/plugin-sdk/approval-referen
 import type { MessagePresentationAction } from "openclaw/plugin-sdk/interactive-runtime";
 import type { ComponentData } from "./internal/discord.js";
 
+const DISCORD_APPROVAL_KINDS = ["exec", "plugin", "system-agent"] as const;
+type DiscordApprovalKind = (typeof DISCORD_APPROVAL_KINDS)[number];
+
 type DiscordApprovalAction = Extract<MessagePresentationAction, { type: "approval" }>;
+
+function isDiscordApprovalKind(value: string): value is DiscordApprovalKind {
+  // SAFETY: includes() accepts any string; the tuple contents never change.
+  return (DISCORD_APPROVAL_KINDS as readonly string[]).includes(value);
+}
 
 const DISCORD_APPROVAL_CUSTOM_ID_MAX_CHARS = 100;
 
@@ -34,7 +42,7 @@ function encodeBoundedDiscordApprovalCustomId(action: DiscordApprovalAction): st
 export function buildDiscordApprovalCustomId(action: DiscordApprovalAction): string | undefined {
   if (
     !action.approvalId ||
-    (action.approvalKind !== "exec" && action.approvalKind !== "plugin") ||
+    !isDiscordApprovalKind(action.approvalKind) ||
     (action.decision !== "allow-once" &&
       action.decision !== "allow-always" &&
       action.decision !== "deny")
@@ -78,7 +86,7 @@ export function parseExecApprovalData(data: ComponentData): {
   const rawId = coerce(data.id);
   const rawKind = coerce(data.kind);
   const rawAction = coerce(data.action);
-  if (!rawId || (rawKind !== "exec" && rawKind !== "plugin") || !rawAction) {
+  if (!rawId || !isDiscordApprovalKind(rawKind) || !rawAction) {
     return null;
   }
   if (rawAction !== "allow-once" && rawAction !== "allow-always" && rawAction !== "deny") {

--- a/extensions/discord/src/approval-handler.runtime.test.ts
+++ b/extensions/discord/src/approval-handler.runtime.test.ts
@@ -1,6 +1,8 @@
 // Discord tests cover approval handler plugin behavior.
 import { describe, expect, it } from "vitest";
+import { parseExecApprovalData } from "./approval-custom-id.js";
 import { discordApprovalNativeRuntime } from "./approval-handler.runtime.js";
+import { parseCustomId } from "./internal/discord.js";
 import { DiscordUiContainer } from "./ui.js";
 
 async function buildExecApprovalPayloadText(commandText: string): Promise<string> {
@@ -140,6 +142,89 @@ describe("discordApprovalNativeRuntime", () => {
     await expect(buildPluginApprovalPayloadText()).resolves.toContain(
       "execapproval:kind=plugin;id=plain-plugin-id;action=deny",
     );
+  });
+
+  it("round-trips system-agent approval buttons through the callback codec", async () => {
+    const pending = await discordApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "main",
+      context: {
+        token: "discord-token",
+        config: {} as never,
+      },
+      request: {
+        id: "change-1",
+        request: {
+          title: "Apply proposed change",
+          description: "Rewrite the scheduler.",
+          command: "rewrite scheduler",
+          proposalHash: "hash-1",
+          sessionId: "session-1",
+          allowedDecisions: ["allow-once", "deny"],
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1_000,
+      },
+      approvalKind: "system-agent",
+      nowMs: 0,
+      view: {
+        approvalKind: "system-agent",
+        phase: "pending",
+        approvalId: "change-1",
+        title: "OpenClaw change requires approval",
+        description: "Rewrite the scheduler.",
+        commandText: "Rewrite the scheduler.",
+        commandPreview: "Rewrite the scheduler.",
+        operationSummary: "Rewrite the scheduler.",
+        cwd: null,
+        host: "gateway",
+        nodeId: null,
+        sessionKey: "session-1",
+        metadata: [],
+        expiresAtMs: 1_000,
+        actions: [
+          {
+            label: "Allow Once",
+            decision: "allow-once",
+            style: "success",
+            command: "/approve change-1 allow-once",
+            action: {
+              type: "approval",
+              approvalId: "change-1",
+              approvalKind: "system-agent",
+              decision: "allow-once",
+            },
+          },
+          {
+            label: "Deny",
+            decision: "deny",
+            style: "danger",
+            command: "/approve change-1 deny",
+            action: {
+              type: "approval",
+              approvalId: "change-1",
+              approvalKind: "system-agent",
+              decision: "deny",
+            },
+          },
+        ],
+      },
+    });
+    const payload = JSON.stringify(pending);
+    expect(payload).toContain("execapproval:kind=system-agent;id=change-1;action=allow-once");
+    expect(payload).toContain("execapproval:kind=system-agent;id=change-1;action=deny");
+    expect(payload).not.toContain("action=allow-always");
+    // The emitted system-agent custom id must survive the callback codec used by
+    // the interaction path; otherwise the card renders but its buttons die on click.
+    expect(
+      parseExecApprovalData(
+        parseCustomId("execapproval:kind=system-agent;id=change-1;action=allow-once").data,
+      ),
+    ).toEqual({
+      approvalId: "change-1",
+      approvalKind: "system-agent",
+      action: "allow-once",
+    });
   });
 
   it.each([

--- a/extensions/discord/src/monitor/exec-approvals.test.ts
+++ b/extensions/discord/src/monitor/exec-approvals.test.ts
@@ -71,6 +71,8 @@ describe("discord exec approval monitor helpers", () => {
   it.each([
     ["exec", "plugin:looks-like-plugin", "allow-once"],
     ["plugin", "plain-plugin-id", "deny"],
+    ["system-agent", "change-1", "allow-once"],
+    ["system-agent", "change-2", "deny"],
   ] as const)("round-trips %s approval custom ids", (approvalKind, approvalId, action) => {
     const customId = buildExecApprovalCustomId(approvalId, approvalKind, action);
     const parsed = parseCustomId(customId);
@@ -106,22 +108,33 @@ describe("discord exec approval monitor helpers", () => {
     });
   });
 
-  it("blocks non-approvers from approving", async () => {
-    const interaction = createInteraction({ userId: "999" });
-    const button = createExecApprovalButton({
-      getApprovers: () => ["123"],
-      resolveApproval: async () => ({ ok: true, resolution: createApprovalResolution() }),
-    });
+  it.each(["exec", "plugin", "system-agent"] as const)(
+    "blocks non-approvers from approving %s clicks before resolution",
+    async (approvalKind) => {
+      const interaction = createInteraction({ userId: "999" });
+      const resolveApproval = vi.fn(
+        async () =>
+          ({
+            ok: true,
+            resolution: createApprovalResolution(),
+          }) as const,
+      );
+      const button = createExecApprovalButton({
+        getApprovers: () => ["123"],
+        resolveApproval,
+      });
 
-    await button.run(interaction, { kind: "exec", id: "abc", action: "allow-once" });
+      await button.run(interaction, { kind: approvalKind, id: "abc", action: "allow-once" });
 
-    expect(interaction["reply"]).toHaveBeenCalledWith({
-      content: "⛔ You are not authorized to approve requests.",
-      ephemeral: true,
-    });
-  });
+      expect(interaction["reply"]).toHaveBeenCalledWith({
+        content: "⛔ You are not authorized to approve requests.",
+        ephemeral: true,
+      });
+      expect(resolveApproval).not.toHaveBeenCalled();
+    },
+  );
 
-  it.each(["exec", "plugin"] as const)(
+  it.each(["exec", "plugin", "system-agent"] as const)(
     "acknowledges and resolves valid %s approval clicks",
     async (approvalKind) => {
       const editReply = vi.fn();
@@ -248,7 +261,7 @@ describe("discord exec approval monitor helpers", () => {
     });
   });
 
-  it.each(["exec", "plugin"] as const)(
+  it.each(["exec", "plugin", "system-agent"] as const)(
     "routes %s button resolutions through the canonical gateway method",
     async (approvalKind) => {
       const cfg = buildConfig({ enabled: true, approvers: ["123"] });

--- a/extensions/discord/src/shared-interactive.test.ts
+++ b/extensions/discord/src/shared-interactive.test.ts
@@ -308,6 +308,39 @@ describe("buildDiscordInteractiveComponents", () => {
     });
   });
 
+  it("renders system-agent approvals as actionable Discord controls", () => {
+    const rendered = buildDiscordPresentationComponents({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            {
+              label: "Allow Once",
+              action: {
+                type: "approval",
+                approvalId: "change-1",
+                approvalKind: "system-agent",
+                decision: "allow-once",
+              },
+              value: "/approve change-1 allow-once",
+              style: "success",
+            },
+          ],
+        },
+      ],
+    });
+
+    const firstBlock = rendered?.blocks?.[0];
+    const customId =
+      firstBlock?.type === "actions" ? firstBlock.buttons?.[0]?.internalCustomId : undefined;
+    expect(customId).toBe("execapproval:kind=system-agent;id=change-1;action=allow-once");
+    expect(parseExecApprovalData(parseCustomId(customId ?? "").data)).toEqual({
+      approvalId: "change-1",
+      approvalKind: "system-agent",
+      action: "allow-once",
+    });
+  });
+
   it("renders typed approvals as actionable transport-private Discord controls", () => {
     const rendered = buildDiscordPresentationComponents({
       blocks: [

--- a/extensions/slack/src/approval-actions.test.ts
+++ b/extensions/slack/src/approval-actions.test.ts
@@ -19,6 +19,22 @@ describe("Slack approval actions", () => {
     expect(decodeSlackApprovalAction(encoded)).toEqual(action);
   });
 
+  it("round-trips system-agent approval facts emitted by the shared normalizer", () => {
+    for (const decision of ["allow-once", "deny"] as const) {
+      const action = {
+        type: "approval" as const,
+        approvalId: "system-agent:0d939e63-1c97-4b53-9c6f-6caae6d95bd0",
+        approvalKind: "system-agent" as const,
+        decision,
+      };
+
+      const encoded = encodeSlackApprovalAction(action);
+
+      expect(encoded).not.toContain("/approve ");
+      expect(decodeSlackApprovalAction(encoded)).toEqual(action);
+    }
+  });
+
   it("uses the durable transport reference when a Unicode id exceeds Slack's value limit", () => {
     const approvalId = `approval/${"\u{1F4F1}".repeat(SLACK_BUTTON_VALUE_MAX)}`;
     const action = {
@@ -42,6 +58,7 @@ describe("Slack approval actions", () => {
     "openclaw:approval:v1:not-json",
     'openclaw:approval:v1:{"approvalId":"req-1","decision":"allow-once"}',
     'openclaw:approval:v1:{"approvalId":"req-1","approvalKind":"exec","decision":"accept"}',
+    'openclaw:approval:v1:{"approvalId":"req-1","approvalKind":"tool","decision":"deny"}',
     'openclaw:approval:v1:{"approvalId":"req-1","approvalKind":"exec","decision":"deny","extra":true}',
   ])("rejects malformed or non-approval input %#", (value) => {
     expect(decodeSlackApprovalAction(value)).toBeNull();

--- a/extensions/slack/src/approval-actions.ts
+++ b/extensions/slack/src/approval-actions.ts
@@ -8,6 +8,14 @@ export const SLACK_APPROVAL_HEADER_BLOCK_ID = "openclaw_approval_header";
 
 export type SlackApprovalAction = Extract<MessagePresentationAction, { type: "approval" }>;
 
+const SLACK_APPROVAL_KINDS = ["exec", "plugin", "system-agent"] as const;
+type SlackApprovalKind = (typeof SLACK_APPROVAL_KINDS)[number];
+
+function isSlackApprovalKind(value: unknown): value is SlackApprovalKind {
+  // SAFETY: includes() accepts any string; the tuple contents never change.
+  return typeof value === "string" && (SLACK_APPROVAL_KINDS as readonly string[]).includes(value);
+}
+
 function isApprovalDecision(value: unknown): value is SlackApprovalAction["decision"] {
   return value === "allow-once" || value === "allow-always" || value === "deny";
 }
@@ -46,7 +54,7 @@ export function decodeSlackApprovalAction(value: unknown): SlackApprovalAction |
       Object.keys(record).length !== 3 ||
       typeof record.approvalId !== "string" ||
       record.approvalId.length === 0 ||
-      (record.approvalKind !== "exec" && record.approvalKind !== "plugin") ||
+      !isSlackApprovalKind(record.approvalKind) ||
       !isApprovalDecision(record.decision)
     ) {
       return null;

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -1591,6 +1591,124 @@ describe("registerSlackInteractionEvents", () => {
     expect(respond).not.toHaveBeenCalled();
   });
 
+  it("resolves typed system-agent approvals from Slack-private action data", async () => {
+    const { ctx, app, getHandler } = createContext({
+      allowFrom: ["U999"],
+      cfg: {
+        channels: {
+          slack: {
+            execApprovals: {
+              enabled: true,
+              approvers: ["u123"],
+              target: "both",
+            },
+          },
+        },
+      },
+    });
+    registerSlackInteractionEvents({ ctx: ctx as never });
+
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await getHandler()({
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond,
+      body: {
+        user: { id: "U123" },
+        channel: { id: "C1" },
+        container: { channel_id: "C1", message_ts: "100.200", thread_ts: "100.100" },
+        message: {
+          ts: "100.200",
+          text: "OpenClaw change approval required",
+          blocks: [
+            {
+              type: "actions",
+              block_id: "exec_actions",
+              elements: [{ type: "button", action_id: "openclaw:approval_button:1:1" }],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "openclaw:approval_button:1:1",
+        block_id: "exec_actions",
+        value:
+          'openclaw:approval:v1:{"approvalId":"system-agent:0d939e63-1c97-4b53-9c6f-6caae6d95bd0","approvalKind":"system-agent","decision":"allow-once"}',
+        text: { type: "plain_text", text: "Allow once" },
+      },
+    });
+
+    expect(resolveApprovalOverGatewayMock).toHaveBeenCalledWith({
+      cfg: ctx.cfg,
+      approvalId: "system-agent:0d939e63-1c97-4b53-9c6f-6caae6d95bd0",
+      approvalKind: "system-agent",
+      decision: "allow-once",
+      senderId: "U123",
+      channel: "slack",
+      accountId: "default",
+    });
+    expectRecordFields(chatUpdateCall(app), {
+      channel: "C1",
+      ts: "100.200",
+      text: "Resolved: Allowed once",
+    });
+    expect(respond).not.toHaveBeenCalled();
+  });
+
+  it("blocks non-approvers from resolving system-agent approvals before resolution", async () => {
+    const { ctx, getHandler } = createContext({
+      allowFrom: ["U999"],
+      cfg: {
+        channels: {
+          slack: {
+            execApprovals: {
+              enabled: true,
+              approvers: ["u123"],
+              target: "both",
+            },
+          },
+        },
+      },
+    });
+    registerSlackInteractionEvents({ ctx: ctx as never });
+
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await getHandler()({
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond,
+      body: {
+        user: { id: "U999" },
+        channel: { id: "C1" },
+        container: { channel_id: "C1", message_ts: "100.200", thread_ts: "100.100" },
+        message: {
+          ts: "100.200",
+          text: "OpenClaw change approval required",
+          blocks: [
+            {
+              type: "actions",
+              block_id: "exec_actions",
+              elements: [{ type: "button", action_id: "openclaw:approval_button:1:1" }],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "openclaw:approval_button:1:1",
+        block_id: "exec_actions",
+        value:
+          'openclaw:approval:v1:{"approvalId":"system-agent:0d939e63-1c97-4b53-9c6f-6caae6d95bd0","approvalKind":"system-agent","decision":"deny"}',
+        text: { type: "plain_text", text: "Deny" },
+      },
+    });
+
+    expect(resolveApprovalOverGatewayMock).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith({
+      text: "You are not authorized to approve this request.",
+      response_type: "ephemeral",
+    });
+  });
+
   it("authorizes plugin approval buttons only in the configured Grid workspace", async () => {
     const { ctx, getHandler } = createContext({
       installationIdentity: { kind: "enterprise", enterpriseId: "E1" },

--- a/src/infra/approval-view-model.test.ts
+++ b/src/infra/approval-view-model.test.ts
@@ -77,6 +77,44 @@ describe("buildPendingApprovalView", () => {
     });
   });
 
+  it("builds system-agent pending views with allow-once and deny only", () => {
+    const request = {
+      id: "system-change-1",
+      createdAtMs: 1,
+      expiresAtMs: 2,
+      request: {
+        title: "Apply proposed change",
+        description: "Rewrite the scheduler to prefer cooperative yields.",
+        command: "rewrite scheduler",
+        proposalHash: "hash-1",
+        sessionId: "session-1",
+        allowedDecisions: ["allow-once", "deny"] as const,
+      },
+    };
+
+    const view = buildPendingApprovalView(request);
+
+    expect(view.approvalKind).toBe("system-agent");
+    if (view.approvalKind !== "system-agent") {
+      throw new Error("expected system-agent approval view");
+    }
+    expect(view.operationSummary).toBe("Rewrite the scheduler to prefer cooperative yields.");
+    expect(view.actions.map((action) => action.action)).toEqual([
+      {
+        type: "approval",
+        approvalId: "system-change-1",
+        approvalKind: "system-agent",
+        decision: "allow-once",
+      },
+      {
+        type: "approval",
+        approvalId: "system-change-1",
+        approvalKind: "system-agent",
+        decision: "deny",
+      },
+    ]);
+  });
+
   const approvalRequestBase = { id: "approval-id", createdAtMs: 1, expiresAtMs: 2 };
 
   it.each([

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -542,7 +542,7 @@ function normalizePresentationAction(raw: unknown): MessagePresentationAction | 
     if (
       typeof approvalId !== "string" ||
       !isWellFormedApprovalId(approvalId) ||
-      (approvalKind !== "exec" && approvalKind !== "plugin") ||
+      (approvalKind !== "exec" && approvalKind !== "plugin" && approvalKind !== "system-agent") ||
       (decision !== "allow-once" && decision !== "allow-always" && decision !== "deny")
     ) {
       return undefined;


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #137142

## What Problem This Solves

Fixes an issue where a system-agent approval delivered to Discord renders an "OpenClaw Change" approval card, but clicking its native buttons is rejected by the Discord callback parser before the configured-approver check or the canonical `approval.resolve` path runs. The operator sees the pending request but cannot complete it from Discord and must switch to another approval surface.

- **Related:** #134670 (introduced first-class system-agent native-channel delivery and left this narrow callback-codec gap); maintainer clawsweeper review confirms a focused three-kind codec repair with no open competing PR, and flagged that widening the shared normalizer also reaches Slack's callback envelope — this PR now brings both transport-private codecs to the same three-kind contract.

## Why This Change Was Made

Extend the Discord transport-private approval-kind allowlist from `exec | plugin` to the existing three-kind contract `exec | plugin | system-agent` in the custom-ID builder/parser, align the shared interactive presentation normalizer to the same contract, and extend Slack's transport-private callback envelope (`decodeSlackApprovalAction`) to the identical three-kind contract so a system-agent card rendered by either native adapter stays decodable end to end. The native approval runtimes, typed approval views (`allow-once`/`deny` for system-agent), approver authorization, and the canonical Gateway resolver already support system-agent approvals, so no channel-specific execution or authorization path is added.

- **Intended outcome:** a Discord or Slack system-agent card's buttons round-trip that channel's callback codec, authenticate the configured approver, and resolve the Gateway-owned record with `kind: "system-agent"`.
- **Out of scope:** Gateway authorization, config, persistence, decision sets, Control UI behavior, and reaction-based native channels: Signal, WhatsApp, and iMessage also subscribe to system-agent approvals but their reaction-target registration still accepts only `exec`/`plugin` — that pre-existing gap is unchanged by this PR and is not repaired here, so this PR must not be read as complete native-channel parity (per the clawsweeper merge-risk note, it warrants a separate owner-boundary repair).
- **Highest-risk area:** widening a parse allowlist could accidentally accept an unsupported kind, or strand a rendered button whose channel codec rejects the new kind (the cross-channel regression clawsweeper identified for Slack).
- **How is that risk mitigated?** each allowlist is closed to exactly the three canonical kinds in its own transport-private codec; malformed ids, unknown kinds, and unknown decisions still fail closed (existing rejection tests retained); Slack codec and interaction regressions cover system-agent round-trip, authorized resolution, and non-approver rejection before resolution.

## User Impact

Operators who use Discord or Slack as their primary approval surface can now complete a system-agent (OpenClaw Change) approval entirely through the rendered native card: the exact pending operation is shown, only the allowed `allow-once`/`deny` decisions are presented, the configured approver is authenticated, and the terminal card reflects the applied or non-applied canonical outcome. Previously a Slack-rendered system-agent button was rejected as invalid on click, and a Discord one was rejected by the callback parser before authorization.

- **Success criteria:** system-agent custom ids built by the native runtimes and the generic interactive builder round-trip `parseExecApprovalData` (Discord) and `decodeSlackApprovalAction` (Slack); both button handlers forward the exact `system-agent` kind to the resolver; malformed and unsupported kinds still fail closed; `allow-always` is not presented for system-agent; exec/plugin behavior unchanged.
- **What should reviewers focus on?** `extensions/discord/src/approval-custom-id.ts`, `extensions/slack/src/approval-actions.ts`, `src/interactive/payload.ts`, and the system-agent regression fixtures in Discord `approval-handler.runtime.test.ts`, `monitor/exec-approvals.test.ts`, `shared-interactive.test.ts`, Slack `approval-actions.test.ts` and `monitor/events/interactions.test.ts`, plus `src/infra/approval-view-model.test.ts`.

## Evidence

- **Real environment tested:** local worktree on branch `feat/issue-137142-discord-system-agent-approval` (Node v26.7.0), `validate.sh` green (oxfmt + oxlint + same-dir vitest + `tsgo:core`).
- **Exact steps or commands run after this patch:**
  ```bash
  node scripts/run-vitest.mjs extensions/discord/src/approval-handler.runtime.test.ts extensions/discord/src/monitor/exec-approvals.test.ts extensions/discord/src/shared-interactive.test.ts
  node scripts/run-vitest.mjs extensions/slack/src/approval-actions.test.ts extensions/slack/src/approval-handler.runtime.test.ts extensions/slack/src/monitor/events/interactions.test.ts
  node scripts/run-vitest.mjs src/interactive/payload.test.ts src/infra/approval-view-model.test.ts
  # L2: direct production-function round trip (no mocks)
  node --import ./scripts/tsx.mjs /tmp/issue-137142-evidence.mts
  # L3: full ephemeral-Gateway authority-chain harness (real gateway components, no mocked resolver)
  node --import ./scripts/tsx.mjs <evidence-dir>/ephemeral-gateway-proof.mts
  ```
- **Evidence after fix:** Slack codec parity — `decodeSlackApprovalAction(encodeSlackApprovalAction({approvalKind: "system-agent", decision}))` round-trips for `allow-once` and `deny`; unknown kind `tool` and unknown decision `accept` still return `null`. The Slack interaction handler resolves a clicked system-agent button through the configured exec approver (`resolveApprovalOverGateway` called with `approvalKind: "system-agent"`, `senderId: "U123"`, terminal card `Resolved: Allowed once`) and blocks a non-approver (`U999`) with an ephemeral "You are not authorized to approve this request." before any resolution. Suites: `Test Files 3 passed (3)`, `Tests 101 passed (101)`.
- **Evidence after fix (ephemeral-Gateway authority-chain harness, L3):** an in-process harness runs the real components end to end — real Discord custom-id codec (encode → `parseCustomId` → `parseExecApprovalData`, including the durable resolution-ref path for long ids), real Discord button handler with an SDK-shaped interaction, real `resolveApprovalOverGateway` (canonical branch, no override) inside `withGatewayNativeApprovalRuntime` (the same in-process principal wiring the Gateway uses for channel account tasks), real `approval.resolve` Gateway handler invoked with the same synthetic APPROVALS-scope principal the Gateway's native-approval runtime uses, real channel custody (`prepareApprovalChannelCustody` → real discord plugin `authorizeActorAction`), and a real SQLite-persisted `ExecApprovalManager<SystemAgentApprovalRequestPayload>` with a real claimed run authority:

  | Authority-chain case | Verdict |
  |---|---|
  | Authorized Discord reviewer (`123` ∈ approvers) clicks `allow-once` on a pending system-agent record | applied; manager decision `allow-once`; terminal card "Approval resolved: Allowed once"; durable record resolved with resolver `{kind: "channel", id: "discord:default"}` — pass |
  | Non-approver (`999`) clicks | ephemeral "⛔ You are not authorized to approve requests." at the Discord boundary; resolver never reached; record still pending — pass |
  | Stale click (record already resolved) | "This approval was already resolved: Allowed once."; first-answer winner intact (`allow-once`), no re-opened execution rights — pass |
  | Custody mismatch (button rendered by another Discord account than the record's bound account) | Gateway rejects with approval-not-found before resolution; record still pending — pass |
  | Kind mismatch (`exec` kind sent against a `system-agent` record) | fail-closed malformed-verdict deny; the operation is never applied — pass |
  | Disallowed decision (`allow-always`) | fail-closed malformed-verdict deny — pass |
  | Run authority revoked after the request was admitted | force-denied with `run-aborted` before application I/O; terminal card "Already resolved: Cancelled" — pass |

  Full structured JSON: `ephemeral-gateway-proof.json` (7/7 cases, verdict "all authority-chain cases behaved as specified"). Synthetic parts, stated honestly: no WebSocket transport (the harness dispatches the real `approval.resolve` handler in-process, mirroring the Gateway's own native-approval in-process dispatch), and the pending record is created through the real `manager.create/register` API (the same API `prepareDelegatedSystemAgentApproval` calls) instead of a live system-agent chat turn.
- **Observed result after fix:** all seven authority-chain cases behaved as specified (authorized resolve applied with channel-resolver attribution; non-approver, stale, custody-mismatch, kind-mismatch, disallowed-decision, and revoked-authority cases all fail closed before application I/O); Slack suites 101/101, Discord suites 65/65, `payload.test.ts` 45/45; `validate.sh` reports `[validate] 全部通过 ✅`.
- **Documented mock-gateway run (boundary evidence, L2):** the approval authority chain is additionally exercised at the Discord button-handler boundary with the plugin-sdk gateway runtime mocked at the transport call site (`monitor/exec-approvals.test.ts`): allowed approver resolves, non-approver rejected before resolution, rendered buttons round-trip the codec, unsupported kinds / malformed ids fail closed. `Test Files 3 passed (3)`, `Tests 65 passed (65)`; `payload.test.ts` 45 passed.
- **Before evidence:** on `origin/main` the new regression tests failed — `buildDiscordApprovalCustomId` returned `undefined` for `system-agent` (generic builder dropped the button), `parseExecApprovalData` returned `null` for `system-agent` custom ids (round-trip failed), and the button handler never reached the resolver ("no longer valid" reply).
- **What was not tested:** live Discord/Slack API interaction round trips (require real bot credentials not available in this environment); the system-agent chat turn that creates the approval record in production (the harness admits the record through the same manager API that turn uses); WebSocket transport (replaced by the in-process dispatch described above); reaction-based channels (Signal/WhatsApp/iMessage) whose system-agent registration gap predates this PR. Gateway-owned custody/state checks run against the live approval record on the Gateway side and are unchanged by this PR.
- **Proof tier:** L3 for the authority chain (real gateway approval service, custody, resolver, and manager with real SQLite persistence driven by the real channel handler code), L2 for codec round-trips.
- **Review state:** clawsweeper re-review of `c54dc40841f` rates proof and patch quality `platinum hermit` with no actionable findings (`proof: sufficient`, `status: ready for maintainer look`); the remaining before-merge item is the maintainer decision on the pre-existing reaction-channel parity gap noted above.

