### PR TITLE
fix: recover Session Observer models after catalog failure

### DIFF
--- a/ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
+++ b/ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
@@ -1,0 +1,167 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  installMockGateway,
+  pauseVirtualClock,
+  waitForControlUiSettingsTakeover,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Session Observer model catalog recovery",
+  startServerBeforeBrowser: true,
+});
+
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+
+suite.define(() => {
+  it("retries an initial catalog failure and restores recovered models", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+        ...(captureUiProof
+          ? {
+              recordVideo: {
+                dir: suite.artifactDir,
+                size: { height: 900, width: 1280 },
+              },
+            }
+          : {}),
+      },
+      async ({ page }) => {
+        await page.clock.install();
+        const config = {
+          agents: { defaults: { model: "openai/gpt-5.5" } },
+          ui: { prefs: { themeMode: "dark" } },
+        };
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["config.get", "config.patch", "models.list", "system.info"],
+          methodResponses: {
+            "config.get": {
+              config,
+              hash: "session-observer-catalog-recovery",
+              issues: [],
+              raw: JSON.stringify(config),
+              runtimeConfig: config,
+              valid: true,
+            },
+            "config.patch": { ok: true },
+            "models.list": {
+              __mockError: {
+                code: "UNAVAILABLE",
+                message: "Model catalog temporarily unavailable",
+              },
+            },
+          },
+        });
+
+        const response = await page.goto(
+          `${suite.server.baseUrl}settings/appearance?section=__appearance__#settings-appearance-sidebar`,
+        );
+        expect(response?.status()).toBe(200);
+        await waitForControlUiSettingsTakeover(page);
+        const section = page.locator("#settings-appearance-sidebar");
+        await section.getByRole("heading", { name: "Session observer" }).waitFor();
+        const picker = section.locator("wa-select.model-picker__select");
+        await picker.waitFor();
+        await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(1);
+        await pauseVirtualClock(page);
+
+        const initialRequest = (await gateway.getRequests("models.list"))[0];
+        expect(initialRequest?.params).toEqual({
+          agentId: "main",
+          preparedOnly: true,
+          view: "configured",
+        });
+        const initialWarningVisible = await section
+          .getByText("Explicit model catalog unavailable", { exact: true })
+          .isVisible()
+          .catch(() => false);
+        const initialOptions = (await picker.locator("wa-option").allTextContents()).map((text) =>
+          text.trim(),
+        );
+        if (captureUiProof) {
+          await section.screenshot({
+            animations: "disabled",
+            path: path.join(suite.artifactDir, "01-initial-failure.png"),
+          });
+          await page.evaluate(() => {
+            const cue = document.createElement("div");
+            cue.id = "session-observer-proof-cue";
+            cue.textContent = "Advancing the next 10-second status poll";
+            Object.assign(cue.style, {
+              background: "#111827",
+              border: "1px solid #f9fafb",
+              bottom: "16px",
+              color: "#f9fafb",
+              font: "14px system-ui",
+              left: "16px",
+              padding: "8px 10px",
+              position: "fixed",
+              zIndex: "2147483647",
+            });
+            document.body.append(cue);
+          });
+        }
+
+        const recoveredModels = [
+          {
+            available: true,
+            id: "gpt-recovered",
+            name: "GPT Recovered",
+            provider: "openai",
+          },
+          {
+            available: true,
+            id: "claude-recovered",
+            name: "Claude Recovered",
+            provider: "anthropic",
+          },
+        ];
+        await gateway.setMethodResponse("models.list", { models: recoveredModels });
+        await page.clock.runFor(10_000);
+        const finalRequestCount = (await gateway.getRequests("models.list")).length;
+        const finalWarningVisible = await section
+          .getByText("Explicit model catalog unavailable", { exact: true })
+          .isVisible()
+          .catch(() => false);
+        const finalOptions = (await picker.locator("wa-option").allTextContents()).map((text) =>
+          text.trim(),
+        );
+        if (captureUiProof) {
+          await page.evaluate((requestCount) => {
+            const cue = document.querySelector<HTMLElement>("#session-observer-proof-cue");
+            if (cue) {
+              cue.textContent = `models.list requests after recovery: ${requestCount}`;
+            }
+          }, finalRequestCount);
+          await section.screenshot({
+            animations: "disabled",
+            path: path.join(suite.artifactDir, "02-after-recovery-poll.png"),
+          });
+        }
+
+        expect(initialWarningVisible).toBe(true);
+        expect(initialOptions).toEqual(["Auto (provider default)", "Disabled"]);
+        expect(finalRequestCount).toBe(2);
+        expect(finalWarningVisible).toBe(false);
+        expect(finalOptions).toEqual([
+          "Auto (provider default)",
+          "Disabled",
+          "Claude Recovered",
+          "GPT Recovered",
+        ]);
+
+        await picker.click();
+        await picker.getByRole("option", { name: "GPT Recovered", exact: true }).click();
+        const patchRequest = await gateway.waitForRequest("config.patch");
+        expect(JSON.parse(String((patchRequest.params as { raw?: unknown }).raw))).toEqual({
+          agents: { defaults: { utilityModel: "openai/gpt-recovered" } },
+        });
+      },
+    );
+  });
+});

--- a/ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
+++ b/ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
@@ -69,6 +69,8 @@ suite.define(() => {
         await picker.waitFor();
         await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(1);
         await pauseVirtualClock(page);
+        const initialSystemInfoRequestCount = (await gateway.getRequests("system.info")).length;
+        expect(initialSystemInfoRequestCount).toBeGreaterThan(0);
 
         const initialRequest = (await gateway.getRequests("models.list"))[0];
         expect(initialRequest?.params).toEqual({
@@ -123,6 +125,11 @@ suite.define(() => {
         ];
         await gateway.setMethodResponse("models.list", { models: recoveredModels });
         await page.clock.runFor(10_000);
+        await expect
+          .poll(async () => (await gateway.getRequests("system.info")).length)
+          .toBe(initialSystemInfoRequestCount + 1);
+        await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
+        const finalSystemInfoRequestCount = (await gateway.getRequests("system.info")).length;
         const finalRequestCount = (await gateway.getRequests("models.list")).length;
         const finalWarningVisible = await section
           .getByText("Explicit model catalog unavailable", { exact: true })
@@ -148,6 +155,7 @@ suite.define(() => {
 
         expect(initialWarningVisible).toBe(true);
         expect(initialOptions).toEqual(["Auto (provider default)", "Disabled"]);
+        expect(finalSystemInfoRequestCount).toBe(initialSystemInfoRequestCount + 1);
         expect(finalRequestCount).toBe(2);
         expect(finalWarningVisible).toBe(false);
         expect(finalOptions).toEqual([

--- a/ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
+++ b/ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
@@ -128,6 +128,8 @@ suite.define(() => {
           .getByText("Explicit model catalog unavailable", { exact: true })
           .isVisible()
           .catch(() => false);
+        await picker.click();
+        await expect.poll(() => picker.getAttribute("open")).not.toBeNull();
         const finalOptions = (await picker.locator("wa-option").allTextContents()).map((text) =>
           text.trim(),
         );
@@ -138,7 +140,7 @@ suite.define(() => {
               cue.textContent = `models.list requests after recovery: ${requestCount}`;
             }
           }, finalRequestCount);
-          await section.screenshot({
+          await page.screenshot({
             animations: "disabled",
             path: path.join(suite.artifactDir, "02-after-recovery-poll.png"),
           });
@@ -155,7 +157,6 @@ suite.define(() => {
           "GPT Recovered",
         ]);
 
-        await picker.click();
         await picker.getByRole("option", { name: "GPT Recovered", exact: true }).click();
         const patchRequest = await gateway.waitForRequest("config.patch");
         expect(JSON.parse(String((patchRequest.params as { raw?: unknown }).raw))).toEqual({

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -691,52 +691,12 @@ describe("ConfigPage session observer models", () => {
     expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(1, firstClient, {
       agentId: "main",
       preparedOnly: true,
+      rejectOnFailure: true,
     });
     expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(2, secondClient, {
       agentId: "main",
       preparedOnly: true,
-    });
-  });
-
-  it("retries a transient catalog failure on the next status refresh", async () => {
-    const recoveredModels = [{ id: "small", name: "Small", provider: "openai" }];
-    vi.spyOn(modelCatalogStore, "loadModelCatalog")
-      .mockRejectedValueOnce(new Error("catalog unavailable"))
-      .mockResolvedValueOnce({ models: recoveredModels });
-    const client = {} as GatewayBrowserClient;
-    const gateway = {
-      snapshot: { client, phase: "connected" },
-    } as unknown as ApplicationGateway;
-    const page = new ConfigPage();
-    const state = page as unknown as {
-      context: ApplicationContext;
-      systemInfoGatewaySource: ApplicationGateway;
-      sessionObserverModels: ModelCatalogEntry[];
-      sessionObserverModelsUnavailable: boolean;
-      ensureSessionObserverModels: (
-        client: GatewayBrowserClient,
-        agentId: string | null,
-      ) => Promise<void>;
-    };
-    Object.defineProperty(page, "isConnected", { configurable: true, value: true });
-    state.context = {
-      gateway,
-      agentSelection: { state: { selectedId: "main" } },
-    } as ApplicationContext;
-    state.systemInfoGatewaySource = gateway;
-
-    await state.ensureSessionObserverModels(client, "main");
-    expect(state.sessionObserverModels).toEqual([]);
-    expect(state.sessionObserverModelsUnavailable).toBe(true);
-
-    await state.ensureSessionObserverModels(client, "main");
-
-    expect(state.sessionObserverModels).toEqual(recoveredModels);
-    expect(state.sessionObserverModelsUnavailable).toBe(false);
-    expect(modelCatalogStore.loadModelCatalog).toHaveBeenCalledTimes(2);
-    expect(modelCatalogStore.loadModelCatalog).toHaveBeenLastCalledWith(client, {
-      agentId: "main",
-      preparedOnly: true,
+      rejectOnFailure: true,
     });
   });
 
@@ -782,10 +742,12 @@ describe("ConfigPage session observer models", () => {
     expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(1, client, {
       agentId: "main",
       preparedOnly: true,
+      rejectOnFailure: true,
     });
     expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(2, client, {
       agentId: "writer",
       preparedOnly: true,
+      rejectOnFailure: true,
     });
 
     selectionState.selectedId = null;

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -808,7 +808,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       this.systemInfoGatewaySource === gatewaySource &&
       this.context.gateway.snapshot.client === client &&
       this.context.agentSelection.state.selectedId === agentId;
-    const promise = loadModelCatalog(client, { agentId, preparedOnly: true })
+    const promise = loadModelCatalog(client, { agentId, preparedOnly: true, rejectOnFailure: true })
       .then(({ models }) => {
         if (isCurrent()) {
           this.sessionObserverModels = models;


### PR DESCRIPTION
Closes #137103

## What Problem This Solves

Fixes an issue where the Session Observer model picker could remain empty after
its first catalog request failed temporarily. The picker appeared healthy and
hid available utility models until the selected agent, Gateway client, or page
changed.

## Why This Change Was Made

The Session Observer caller now preserves catalog request failures instead of
accepting the shared store's fallback as a successful empty catalog. Its
existing unavailable state remains retryable on the next status poll, while
shared cache fallback behavior stays unchanged for callers that intentionally
use it.

The regression test exercises the real mocked Gateway request, shared catalog
store, Config page lifecycle, polling retry, recovered picker options, and
utility-model patch. It replaces the former unit test that mocked the catalog
store itself and could not catch this failure.

## User Impact

After a temporary Gateway or catalog failure, users see that explicit models
are unavailable. When the Gateway recovers, the same page automatically
retries and restores available utility models without requiring an agent
switch or reload.

## Evidence

- Reproduced on base `7b67c28e2e9`: the initial catalog request failed, the
  unavailable warning remained absent, and the browser regression failed on
  that missing state.
- Proven source head `f0b1595ba9d`: the browser scenario passed, explicitly observed
  the next `system.info` poll, issued a second prepared `models.list` request
  for the same client and agent, removed the warning, rendered both recovered
  models, and emitted the canonical utility-model patch.
- Prepared head `4265ad427a2` is a conflict-free rebase onto current `main`;
  `git range-diff` maps all three commits as patch-equivalent.
- Focused exact-head coverage passed 223 UI owner and sibling tests plus 31
  Session Observer runtime tests.
- A task-local real Gateway integration passed the captured utility-model
  patch through canonical `config.patch`, read it back through `config.get`
  with unrelated settings preserved, and completed one Session Observer model
  call through production utility-model resolution.
- Blacksmith Testbox ran the browser, Gateway, and focused UI suites against
  exact prepared head `4265ad427a2` with exit code 0.
- Direct Codex source inspection at `728cb12fe579` confirmed that refresh
  failure can preserve the current catalog while a genuinely empty
  `model/list` is a valid successful response, so the repair remains
  caller-local.
- Prepared base `0c64b9ea962` is confirmed as genuine upstream history; the
  prepared merge tree is conflict-free and current `origin/main` contains that base.
- Prepared-head CI completed all required UI, build, type, lint, security,
  contract, and aggregate gate lanes successfully.
- Fresh autoreview and independent Workloop whole-outcome review are clean on
  exact prepared head `4265ad427a2`.

## ClawSweeper Before-Merge Items

- Current-main comparison: resolved by direct source and merge-tree inspection
  at `0c64b9ea962`.
- Exact-head checks: all required CI passed on prepared head `4265ad427a2`.
- ClawSweeper: exact-head Platinum review completed with no before-merge items.
- Maintainer decision: landing is explicitly authorized by the issue owner.

## Visual Evidence

| Before | After |
| --- | --- |
| ![Session Observer picker after recovery poll on the baseline, showing one models.list request and only Auto and Disabled](https://github.com/user-attachments/assets/5dfa4a76-79dd-4d14-909f-e981978bed4d) | ![Session Observer picker after recovery poll on the fixed head, showing two models.list requests and both recovered models](https://github.com/user-attachments/assets/d2607365-d9e0-440a-aa5a-34ff264ab37d) |

### Initial Failure And Automatic Recovery

https://github.com/user-attachments/assets/7818baf9-001c-4c0c-81d6-8686c4746ce1

### Visual Verification

- Baseline: `origin/main@7b67c28e2e96237b4eea9ce095a74d6936ce8c50`
- Proven source head: `f0b1595ba9d41d353d77aa872e52a582eed58779`
- Prepared head: `4265ad427a29488c3754767b3a34b834dcbdee7f`
- Scenario: reject the first prepared catalog request, restore two models, and
  advance the next 10-second status poll without replacing the client or
  agent.
- Initial failure state: baseline warning absent; fixed warning visible.
- Recovery requests: one additional `system.info`; `models.list` advances from
  one to two.
- Recovered options: baseline has Auto and Disabled; fixed head also has
  Claude Recovered and GPT Recovered.
- Saved selection: `agents.defaults.utilityModel = openai/gpt-recovered`.