### PR TITLE
refactor: share session subscriber delivery without staging arrays

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1082,6 +1082,26 @@ export function createAgentEventHandler({
     broadcastChatDelta(sessionKey, agentId, clientRunId, sourceRunId, seq, text, opts);
   };
 
+  const sendSessionMessagePayload = (
+    event: "chat" | "agent",
+    deliverySessionKeys: string[],
+    payload: unknown,
+    dropIfSlow: boolean | undefined,
+  ) => {
+    const recipients = new Set<string>();
+    for (const key of deliverySessionKeys) {
+      for (const connId of sessionMessageSubscribers.get(key)) {
+        recipients.add(connId);
+      }
+    }
+    if (recipients.size > 0) {
+      broadcastToConnIds(event, payload, recipients, {
+        dropIfSlow,
+        sessionKeys: deliverySessionKeys,
+      });
+    }
+  };
+
   const sendChatPayload = (
     sessionKey: string,
     payload: unknown,
@@ -1096,15 +1116,7 @@ export function createAgentEventHandler({
       sendNodeSessionPayloadForAgent(sessionKey, "chat", payload, opts?.agentId);
       return;
     }
-    const recipients = new Set(
-      deliverySessionKeys.flatMap((deliveryKey) => [...sessionMessageSubscribers.get(deliveryKey)]),
-    );
-    if (recipients.size > 0) {
-      broadcastToConnIds("chat", payload, recipients, {
-        dropIfSlow: opts?.dropIfSlow,
-        sessionKeys: deliverySessionKeys,
-      });
-    }
+    sendSessionMessagePayload("chat", deliverySessionKeys, payload, opts?.dropIfSlow);
   };
 
   const emitChatTerminal = (
@@ -1197,25 +1209,7 @@ export function createAgentEventHandler({
       return;
     }
     const deliverySessionKeys = resolveSessionDeliveryKeys(sessionKey, opts?.agentId);
-    const recipients = new Set(
-      deliverySessionKeys.flatMap((deliveryKey) => [...sessionMessageSubscribers.get(deliveryKey)]),
-    );
-    if (recipients.size > 0) {
-      broadcastToConnIds("agent", payload, recipients, {
-        dropIfSlow: opts?.dropIfSlow,
-        sessionKeys: deliverySessionKeys,
-      });
-    }
-  };
-
-  const sendNodeAgentPayload = (
-    sessionKey: string | undefined,
-    payload: AgentEventPayload & { spawnedBy?: string },
-    agentId?: string,
-  ) => {
-    if (sessionKey) {
-      sendNodeSessionPayloadForAgent(sessionKey, "agent", payload, agentId);
-    }
+    sendSessionMessagePayload("agent", deliverySessionKeys, payload, opts?.dropIfSlow);
   };
 
   const flushBufferedAgentDeltaIfNeeded = (clientRunId: string) => {
@@ -1666,8 +1660,9 @@ export function createAgentEventHandler({
         !suppressHeartbeatToolEvents &&
         toolVerbose !== "off"
       ) {
-        sendNodeAgentPayload(
+        sendNodeSessionPayloadForAgent(
           sessionKey,
+          "agent",
           projectToolSearchCodeEventForChannelPayload({
             ...channelToolPayload,
             ...buildSessionEventSnapshot(sessionKey, undefined, sessionAgentId),


### PR DESCRIPTION
## What Problem This Solves

Hidden chat and agent events duplicated the same subscriber-union and broadcast logic. Each path created per-session arrays and a flattened array before constructing the recipient Set.

## Why This Change Was Made

A shared private helper adds subscribers directly to the delivery Set, preserving delivery-key and connection order. The single-call node wrapper is removed; its caller already has the same session-key guard and now calls the existing node sender directly.

## User Impact

Visibility rules, global aliases, session subscriptions, node fanout and slow-client handling remain unchanged. Production LOC is **−5**, with no test, configuration or protocol changes. The removed arrays are a source-level allocation reduction; no byte, retained-memory or throughput estimate is claimed.

## Evidence

All 196 existing agent-event tests passed before and after, including hidden/visible delivery, aliasing, terminal events, heartbeat and verbose-tool handling. The canonical changed-file gate passed. Independent source-embedded Codex review through P2 and a separate subagent review found no actionable issue after inspecting the registry, broadcaster, node sender and history. The registry reads have no callbacks; both implementations finish collecting an owned audience before broadcasting, and false/undefined slow-client options stay uncoerced.

The handler tests exercise the actual event-handler owner with synthetic ingress and broadcasts. Authenticated Gateway integration containing this final source is pending before landing; these tests are not presented as real network delivery.
