### PR TITLE
improve: skip redundant plugin entrypoint deduplication

### DIFF
--- a/src/plugins/package-entry-resolution.ts
+++ b/src/plugins/package-entry-resolution.ts
@@ -381,7 +381,7 @@ function resolvePackageEntrySource(params: {
     }
   }
 
-  for (const candidate of new Set(candidates)) {
+  for (const candidate of candidates) {
     if (!pluginCacheExistsSync(candidate)) {
       continue;
     }

--- a/src/plugins/package-entrypoints.ts
+++ b/src/plugins/package-entrypoints.ts
@@ -25,13 +25,10 @@ export function listBuiltRuntimeEntryCandidates(entryPath: string): string[] {
       : sourceExtension === ".cts"
         ? [".cjs", ".js", ".mjs"]
         : [".js", ".mjs", ".cjs"];
-  const outputBases = [
+  // Dist/source bases and JS suffixes form unique candidates, never the TS source.
+  return [
     distWithoutExtension,
     ...(normalizedRelative.startsWith("src/") ? [`./dist/${normalizedRelative}`] : []),
     withoutExtension,
-  ];
-  const candidates = outputBases.flatMap((basePath) =>
-    outputExtensions.map((extension) => `${basePath}${extension}`),
-  );
-  return [...new Set(candidates)].filter((candidate) => candidate !== normalized);
+  ].flatMap((basePath) => outputExtensions.map((extension) => `${basePath}${extension}`));
 }


### PR DESCRIPTION
## What Problem This Solves

Plugin entry-point resolution deduplicated candidate strings that its own construction already guarantees are distinct, creating redundant Sets, copies and a filter pass during package discovery and installation.

## Why This Change Was Made

TypeScript admission and the distinct output bases/JavaScript suffixes make the generated candidate list unique and exclude the original source path. The separate source resolver already checks that its optional second candidate differs from the first. Both can use their constructed arrays directly.

## User Impact

Candidate order, raw path strings, diagnostics, source fallback and file-boundary checks remain unchanged. Filesystem-equivalent aliases are intentionally not normalized or deduplicated. Production LOC is **−3**; tests and support code are unchanged.

## Evidence

A fixed original/candidate comparison matched 410 POSIX/Win32 path-algorithm cases and 19 actual temporary-package runtime, setup and install scenarios, including strict hardlink/symlink refusal and trusted fallback. All 58 existing entry-point tests passed in both versions, and nine selected discovery-boundary tests passed. The canonical changed-file gate and source-embedded independent Codex review through P2 passed.

The observed helper Set/filter passes fell from 297 to zero; actual resolver Set constructions fell from 78 to 44 for runtime resolution and 34 to zero for setup resolution. These are operation counts, not heap bytes, startup timing or a Gateway RSS claim. Imports and returned candidates are unchanged. Gitcrawl plus a current open-PR search found no matching parallel implementation.
