### PR TITLE
refactor: snapshot tool entries without redundant wrapper objects

### DIFF
--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -289,6 +289,27 @@ describe("runtime tool input schema projection", () => {
     });
   });
 
+  it("snapshots tool references before schema getters replace later array entries", () => {
+    const captured = { name: "captured", parameters: { type: "object" } };
+    const replacement = { name: "replacement", parameters: { type: "array" } };
+    const tools = [
+      {
+        name: "first",
+        get parameters() {
+          tools[1] = replacement;
+          return { type: "object" };
+        },
+      },
+      captured,
+    ];
+
+    expect(filterRuntimeCompatibleTools(tools)).toEqual({
+      tools: [tools[0], captured],
+      diagnostics: [],
+    });
+    expect(tools[1]).toBe(replacement);
+  });
+
   it("keeps provider-normalizable object schemas for provider-specific cleanup", () => {
     const dynamicSchema = {
       name: "fuzzplugin_dynamic_ref",

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -25,55 +25,32 @@ type RuntimeToolSchemaInspection<TTool extends Pick<AnyAgentTool, "name" | "para
   readonly diagnostics: readonly RuntimeToolSchemaDiagnostic[];
 };
 
-type RuntimeToolEntryRead<TTool extends Pick<AnyAgentTool, "name" | "parameters">> =
-  | {
-      readonly ok: true;
-      readonly tool: TTool;
-      readonly toolIndex: number;
-    }
-  | {
-      readonly ok: false;
-      readonly diagnostic: RuntimeToolSchemaDiagnostic;
-    };
-
 type ToolSchemaInspectionMode = "runtime" | "provider-normalizable";
 
-function unreadableRuntimeToolEntry<
-  TTool extends Pick<AnyAgentTool, "name" | "parameters"> = Pick<
-    AnyAgentTool,
-    "name" | "parameters"
-  >,
->(toolIndex: number): RuntimeToolEntryRead<TTool> {
+function unreadableRuntimeToolDiagnostic(toolIndex: number): RuntimeToolSchemaDiagnostic {
   return {
-    ok: false,
-    diagnostic: {
-      toolName: `tool[${toolIndex}]`,
-      toolIndex,
-      violations: [`tool[${toolIndex}] is unreadable`],
-    },
+    toolName: `tool[${toolIndex}]`,
+    toolIndex,
+    violations: [`tool[${toolIndex}] is unreadable`],
   };
 }
 
 function readRuntimeToolEntries<TTool extends Pick<AnyAgentTool, "name" | "parameters">>(
   tools: readonly TTool[],
-): RuntimeToolEntryRead<TTool>[] {
+): (TTool | undefined)[] {
   let length: number;
   try {
     length = tools.length;
   } catch {
-    return [unreadableRuntimeToolEntry<TTool>(0)];
+    return [undefined];
   }
-  const entries: RuntimeToolEntryRead<TTool>[] = [];
+  // Snapshot every entry before schema getters can mutate the source array.
+  const entries: (TTool | undefined)[] = [];
   for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
     try {
-      const tool = tools.at(toolIndex);
-      entries.push(
-        tool === undefined
-          ? unreadableRuntimeToolEntry<TTool>(toolIndex)
-          : { ok: true, tool, toolIndex },
-      );
+      entries.push(tools.at(toolIndex));
     } catch {
-      entries.push(unreadableRuntimeToolEntry<TTool>(toolIndex));
+      entries.push(undefined);
     }
   }
   return entries;
@@ -134,22 +111,23 @@ function inspectToolSchema(
 }
 
 function inspectToolEntries<TTool extends Pick<AnyAgentTool, "name" | "parameters">>(
-  entries: readonly RuntimeToolEntryRead<TTool>[],
+  entries: readonly (TTool | undefined)[],
   mode: ToolSchemaInspectionMode,
 ): RuntimeToolSchemaInspection<TTool> {
   const diagnostics: RuntimeToolSchemaDiagnostic[] = [];
   const compatibleTools: TTool[] = [];
-  for (const entry of entries) {
-    if (!entry.ok) {
-      diagnostics.push(entry.diagnostic);
+  for (let toolIndex = 0; toolIndex < entries.length; toolIndex += 1) {
+    const tool = entries[toolIndex];
+    if (tool === undefined) {
+      diagnostics.push(unreadableRuntimeToolDiagnostic(toolIndex));
       continue;
     }
-    const diagnostic = inspectToolSchema(entry.tool, entry.toolIndex, mode);
+    const diagnostic = inspectToolSchema(tool, toolIndex, mode);
     if (diagnostic) {
       diagnostics.push(diagnostic);
       continue;
     }
-    compatibleTools.push(entry.tool);
+    compatibleTools.push(tool);
   }
   return { tools: compatibleTools, diagnostics };
 }


### PR DESCRIPTION
## What Problem This Solves

Tool schema projection allocated a wrapper object for every input entry, then immediately unpacked those wrappers during inspection. The snapshot must remain eager because schema getters can change later entries in the caller's array.

## Why This Change Was Made

The private snapshot now stores tool references directly, using undefined for the existing unreadable-entry case. Inspection creates the same diagnostics in the same order. The obsolete read-result union and wrappers are removed; all entries are still captured before any schema getter runs.

## User Impact

Runtime/provider filtering, quarantine diagnostics, tool identity and fresh mutable result arrays remain unchanged. Production LOC is **−22**, tests **+21**. The added preservation test verifies that a schema getter replacing a later source-array entry does not change the captured tool.

## Evidence

All 63 fixed observations across the three exported APIs match the original, including throwing getters/proxies, sparse/undefined entries, malformed schemas and ordering. A real runtime-plan normalization caller preserves outputs and references. The fixed corpus avoids 178 readable-entry and 21 unreadable-entry staging objects while preserving the 21 diagnostics; these are logical operation counts.

All 56 focused tests and the canonical changed-file gate pass. Independent source-embedded Codex review through P2 found no actionable issue. Direct sibling Codex inspection covered `codex-rs/protocol/src/dynamic_tools.rs:12`, `codex-rs/app-server/src/dynamic_tools.rs:18`, `codex-rs/tools/src/dynamic_tool.rs:5` and `codex-rs/tools/src/json_schema.rs:189` at e017e93aceafb2fe04bed1c926e448a5fb4f913d. This change does not modify that protocol or schema contract.

The instrumented whole-process pair was 3.87 seconds / 439.14 MiB peak RSS before and 2.96 seconds / 462.53 MiB after. Host load differed and candidate RSS increased 23.39 MiB, so no overall speed or memory reduction is claimed. Final authenticated Gateway integration is pending before landing.
