### PR TITLE
docs(linux): state AppImage runtime floor

### DIFF
--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -2,6 +2,12 @@
 
 The Linux companion is a Tauri v2 desktop shell for local and remote OpenClaw Gateways. It discovers nearby Gateways over Bonjour, installs the CLI when local setup needs it, delegates local Gateway service management to `openclaw gateway`, opens the selected Gateway's Control UI, and stays available in the system tray.
 
+Published AMD64 AppImages are built on Ubuntu 22.04 and require glibc 2.35 or
+newer plus a `libstdc++` that provides `GLIBCXX_3.4.30`. Ubuntu 22.04 and
+Debian 12 meet that ABI floor. RHEL 9 and Rocky Linux 9 ship glibc 2.34, so
+they cannot run the published AppImage. Extraction does not bypass this
+requirement.
+
 ## Linux prerequisites
 
 Debian and Ubuntu development packages:

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -121,6 +121,12 @@ or mark the AppImage executable and run it directly. The AppImage runtime
 needs FUSE 2 (`sudo apt install libfuse2`, or `libfuse2t64` on Ubuntu 24.04+);
 without it, run the AppImage with `APPIMAGE_EXTRACT_AND_RUN=1`.
 
+Published AMD64 AppImages are built on Ubuntu 22.04 and require glibc 2.35 or
+newer plus a `libstdc++` that provides `GLIBCXX_3.4.30`. Ubuntu 22.04 and
+Debian 12 meet that ABI floor. RHEL 9 and Rocky Linux 9 ship glibc 2.34, so
+they cannot run the published AppImage. Extracting the AppImage does not bypass
+this requirement.
+
 ### Media codecs
 
 The companion uses GStreamer plugins for audio and video playback.


### PR DESCRIPTION
Related: #136148

Follow-up to https://github.com/openclaw/openclaw/pull/137106.

## What Problem This Solves

Fixes an issue where Linux users could reasonably expect the published AMD64
AppImage to run on RHEL 9 or Rocky Linux 9, but both distributions remain on
glibc 2.34 and the bundle requires glibc 2.35.

## Why This Change Was Made

Documents the existing published-bundle ABI floor next to the AppImage install
instructions and in the Linux app README. It also makes clear that
`APPIMAGE_EXTRACT_AND_RUN=1` bypasses FUSE only, not the glibc or libstdc++ ABI
requirements.

This does not broaden the runtime, bundle glibc, or claim native Wayland support.

## User Impact

Users can identify supported userspaces before downloading the companion.
Ubuntu 22.04 and Debian 12 meet the published bundle floor. RHEL 9 and Rocky
Linux 9 do not.

## Evidence

Artifact:

- GitHub Actions run: https://github.com/openclaw/openclaw/actions/runs/33725712996
- exact head: `14111f8017f888127a179b95554b0ecad1c7f22d`
- AppImage SHA-256: `a130ffb7d420e7a40efeae79802c9bf6035d279eb848a1bf9ef93f3b7eb0a6a0`

Pinned userspaces:

- Debian 12: `debian@sha256:6ebd97fa83deb272194a2cf015b3d26a4d538e9ad3a7a79d544c8af5b0a01443`
- Rocky Linux 9: `rockylinux@sha256:d7be1c094cc5845ee815d4632fe377514ee6ebcf8efaed6892889657e5ddaaa6`

Observed behavior:

- Debian 12 / glibc 2.36: packaged smoke passed. Extracted AppRun stayed alive,
  `/bin/sh` and `/bin/bash` passed under the packaged library path, all 34
  bundled-only GStreamer elements resolved, and WAV/MP3/OGG/WebM/MP4 playback
  passed: https://crabbox.openclaw.ai/portal/runs/run_ece9a0bbc789
- Rocky Linux 9 / glibc 2.34: extracted AppRun exited with loader errors because
  bundled Cairo, WebKitGTK, and JSC require `GLIBC_2.35`; WebKitGTK and JSC also
  require `GLIBCXX_3.4.30`:
  https://crabbox.openclaw.ai/portal/runs/run_f6d992268628
- Rocky targeted completion: extraction and host shell probes passed, while six
  bundled GStreamer elements, all five real media playbacks, and AppRun failed
  on the same incompatible library floor:
  https://crabbox.openclaw.ai/portal/runs/run_127927bac234
  and https://crabbox.openclaw.ai/portal/runs/run_85af4b7061ca

Container FUSE results are intentionally not treated as native FUSE evidence.
Native Ubuntu AMD64 and ARM64 FUSE behavior was already covered by the preceding
qualification.

Checks:

- `pnpm docs:list`
- `pnpm format:docs:check`
- `pnpm docs:check-mdx`
- focused markdownlint
- `node scripts/check-changed.mjs -- docs/platforms/linux.md apps/linux/README.md`
- autoreview: scoped-clean, no findings

Test audit:

1. Contract: the published AppImage's documented minimum userspace ABI.
2. Credible regression: raising the release build base would silently raise the
   ABI floor.
3. Existing coverage: release and PR builds are pinned to Ubuntu 22.04 and run
   the packaged-runtime smoke; a negative Rocky test would encode an unsupported
   target rather than protect supported behavior.
4. Test-only seams: none.

LOC: production `+0/-0`; tests/test support `+0/-0`; docs `+12/-0`.
