### PR TITLE
improve: collect effective plugin ids without intermediate sets

### DIFF
--- a/src/plugins/effective-plugin-ids.test.ts
+++ b/src/plugins/effective-plugin-ids.test.ts
@@ -1,7 +1,7 @@
 /** Verifies effective plugin id resolution across config, manifests, and activation sources. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
 
 const mocks = vi.hoisted(() => ({
   applyPluginAutoEnable:
@@ -97,9 +97,7 @@ describe("resolveEffectivePluginIds", () => {
       pluginIds: [],
     });
     mocks.resolveConfiguredChannelPluginIds.mockReturnValue([]);
-    mocks.loadManifestMetadataSnapshot.mockReturnValue({
-      plugins: [],
-    } as unknown as PluginMetadataSnapshot);
+    mocks.loadManifestMetadataSnapshot.mockReturnValue(createPluginMetadataSnapshotFixture());
     mocks.passesManifestOwnerBasePolicy.mockReturnValue(true);
   });
 
@@ -127,6 +125,30 @@ describe("resolveEffectivePluginIds", () => {
         },
       }),
     ).toEqual(["lossless-claw"]);
+  });
+
+  it("keeps the selected slot but rechecks bundled owner policy after channel callbacks", async () => {
+    const { passesManifestOwnerBasePolicy } = await vi.importActual<
+      typeof import("./manifest-owner-policy.js")
+    >("./manifest-owner-policy.js");
+    mocks.passesManifestOwnerBasePolicy.mockImplementation(passesManifestOwnerBasePolicy);
+    mocks.listPotentialConfiguredChannelIds.mockReturnValue(["test-channel"]);
+    mocks.loadManifestMetadataSnapshot.mockReturnValue(
+      createPluginMetadataSnapshotFixture({
+        plugins: [{ id: "bundled-channel-owner", channels: ["test-channel"] }],
+      }),
+    );
+    mocks.resolveConfiguredChannelPluginIds.mockImplementation(({ config }) => {
+      config.plugins = {
+        deny: ["bundled-channel-owner"],
+        slots: { contextEngine: "later-context" },
+      };
+      return [];
+    });
+
+    expect(resolve({ plugins: { slots: { contextEngine: "early-context" } } })).toEqual([
+      "early-context",
+    ]);
   });
 
   it("keeps the built-in legacy context engine out of plugin preload ids", () => {

--- a/src/plugins/effective-plugin-ids.ts
+++ b/src/plugins/effective-plugin-ids.ts
@@ -13,7 +13,10 @@ import {
   loadGatewayStartupPluginPlan,
   resolveConfiguredChannelPluginIds,
 } from "./channel-plugin-ids.js";
-import { normalizePluginsConfig, resolveSelectedContextEnginePluginId } from "./config-state.js";
+import {
+  normalizePluginsConfig,
+  resolveSelectedContextEnginePluginIdFromConfig,
+} from "./config-state.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import { passesManifestOwnerBasePolicy } from "./manifest-owner-policy.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
@@ -47,14 +50,16 @@ function collectConfiguredChannelIds(
     .toSorted((left, right) => left.localeCompare(right));
 }
 
-function collectBundledChannelOwnerPluginIds(params: {
+function addBundledChannelOwnerPluginIds(params: {
+  pluginIds: Set<string>;
   config: OpenClawConfig;
   channelIds: readonly string[];
   env: NodeJS.ProcessEnv;
   workspaceDir?: string;
   bundledPluginsDir?: string;
   manifestRecords?: readonly PluginManifestRecord[];
-}): string[] {
+}): void {
+  // Channel state callbacks run before this pass and may update config.
   const plugins = normalizePluginsConfig(params.config.plugins);
   const channelIds = new Set(
     params.channelIds
@@ -62,7 +67,7 @@ function collectBundledChannelOwnerPluginIds(params: {
       .filter((channelId): channelId is string => Boolean(channelId)),
   );
   if (channelIds.size === 0) {
-    return [];
+    return;
   }
   const env = params.bundledPluginsDir
     ? {
@@ -80,7 +85,6 @@ function collectBundledChannelOwnerPluginIds(params: {
       env,
       workspaceDir: params.workspaceDir,
     }).plugins;
-  const pluginIds = new Set<string>();
   for (const plugin of records) {
     if (plugin.origin !== "bundled") {
       continue;
@@ -99,37 +103,10 @@ function collectBundledChannelOwnerPluginIds(params: {
           allowRestrictiveAllowlistBypass: true,
         })
       ) {
-        pluginIds.add(pluginId);
+        params.pluginIds.add(pluginId);
       }
     }
   }
-  return sortUniqueStrings(pluginIds);
-}
-
-function collectExplicitEffectivePluginIds(config: OpenClawConfig): string[] {
-  const plugins = normalizePluginsConfig(config.plugins);
-  if (!plugins.enabled) {
-    return [];
-  }
-
-  const ids = new Set(plugins.allow);
-  for (const [pluginId, entry] of Object.entries(plugins.entries)) {
-    if (
-      entry?.enabled === true &&
-      (plugins.allow.length === 0 || plugins.allow.includes(pluginId))
-    ) {
-      ids.add(pluginId);
-    }
-  }
-  for (const pluginId of plugins.deny) {
-    ids.delete(pluginId);
-  }
-  for (const [pluginId, entry] of Object.entries(plugins.entries)) {
-    if (entry?.enabled === false) {
-      ids.delete(pluginId);
-    }
-  }
-  return sortUniqueStrings(ids);
 }
 
 /** Lists plugin ids that are effectively enabled for a config/discovery context. */
@@ -156,8 +133,27 @@ export function resolveEffectivePluginIds(params: {
     ...(prepared?.discovery ? { discovery: prepared.discovery } : {}),
   });
   const effectiveConfig = autoEnabled.config;
-  const ids = new Set(collectExplicitEffectivePluginIds(effectiveConfig));
-  const contextEnginePluginId = resolveSelectedContextEnginePluginId(effectiveConfig);
+  const plugins = normalizePluginsConfig(effectiveConfig.plugins);
+  const ids = new Set(plugins.enabled ? plugins.allow : []);
+  if (plugins.enabled) {
+    for (const [pluginId, entry] of Object.entries(plugins.entries)) {
+      if (entry?.enabled === false) {
+        ids.delete(pluginId);
+      } else if (
+        entry?.enabled === true &&
+        (plugins.allow.length === 0 || plugins.allow.includes(pluginId))
+      ) {
+        ids.add(pluginId);
+      }
+    }
+    for (const pluginId of plugins.deny) {
+      ids.delete(pluginId);
+    }
+  }
+  const contextEnginePluginId = resolveSelectedContextEnginePluginIdFromConfig(
+    plugins,
+    plugins.slots.contextEngine,
+  );
   if (contextEnginePluginId) {
     ids.add(contextEnginePluginId);
   }
@@ -177,16 +173,15 @@ export function resolveEffectivePluginIds(params: {
   })) {
     ids.add(pluginId);
   }
-  for (const pluginId of collectBundledChannelOwnerPluginIds({
+  addBundledChannelOwnerPluginIds({
+    pluginIds: ids,
     config: effectiveConfig,
     channelIds: configuredChannelIds,
     env: params.env,
     workspaceDir: params.workspaceDir,
     manifestRecords: prepared?.plugins,
     ...(params.bundledPluginsDir ? { bundledPluginsDir: params.bundledPluginsDir } : {}),
-  })) {
-    ids.add(pluginId);
-  }
+  });
   for (const pluginId of loadGatewayStartupPluginPlan({
     config: effectiveConfig,
     activationSourceConfig: params.config,


### PR DESCRIPTION
## What Problem This Solves

Effective plugin-ID discovery built intermediate sorted arrays and Sets, normalized the same configuration again for adjacent context-engine selection, and traversed explicit entries twice.

## Why This Change Was Made

The owner now collects into one private final Set, reuses the adjacent normalized configuration, and handles enabled/disabled explicit entries in one pass. Final sorting still returns a fresh array. Bundled-owner policy deliberately normalizes again after configured-channel callbacks, which may update the configuration.

## User Impact

Enablement, allow/deny policy, context selection, channel ownership, snapshot admission and output order remain unchanged. Production LOC is **−5**, tests **+22**. The preservation test confirms that context selection keeps its earlier value while bundled-owner policy observes a later callback's disable decision.

## Evidence

Eighteen actual-source observations match across original/candidate policy, alias, slot, metadata, lifecycle and caller-mutation scenarios. All 71 owner/status-discovery/config-state tests and the canonical changed-file gate pass. Independent source-embedded Codex review through P2 found no actionable issue.

A bounded counter-only comparison verified 20 actual owner invocations per arm and observed canonical normalization calls fall from 200 to 180 and shared sort/dedup calls from 100 to 80. Earlier detailed coverage counters disagreed with the known invocation count and are excluded; their cause remains unresolved.

The original separate allocation samples were 55,255,312 versus 48,029,352 bytes (-13.08%) for 20 operations. Those estimates include collected objects and are one observation per arm, not retained heap, RSS, timing or a general performance guarantee. No favorable allocation resampling replaced the original observations. Final authenticated Gateway integration is pending before landing.
