### PR TITLE
fix: keep model browsing working across config reloads

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.test.ts
@@ -101,65 +101,97 @@ describe("Mattermost model-picker interaction dispatch", () => {
     });
   });
 
-  it("reserves independent work before ack", async () => {
-    let detachedRun: (() => Promise<void>) | undefined;
-    mocks.runDetachedWebhookWork.mockImplementation((run: () => Promise<void>) => {
-      detachedRun = run;
-      return Promise.resolve();
-    });
-    const updateModelPickerPost = vi.fn(async () => ({}));
-    const monitor = {
-      account: { accountId: "default", config: {} },
-      cfg: {},
-      core: {
-        channel: {
-          commands: { shouldHandleTextCommands: vi.fn(() => true) },
-          inbound: { dispatch: mocks.dispatch },
-          text: {
-            convertMarkdownTables: vi.fn((text: string) => text),
-            hasControlCommand: vi.fn(() => true),
+  it.each(["providers", "back", "list", "select"] as const)(
+    "updates the picker once after loading recovered data for %s",
+    async (action) => {
+      const order: string[] = [];
+      mocks.parseContext.mockReturnValueOnce({
+        action,
+        ownerUserId: "user-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        page: 0,
+      });
+      mocks.buildPreparedModelsProviderData.mockImplementationOnce(async () => {
+        order.push("load");
+        return { providers: [{ id: "openai" }] };
+      });
+      let detachedRun: (() => Promise<void>) | undefined;
+      mocks.runDetachedWebhookWork.mockImplementation((run: () => Promise<void>) => {
+        order.push("detach");
+        detachedRun = run;
+        return Promise.resolve();
+      });
+      const updateModelPickerPost = vi.fn(async () => {
+        order.push("update");
+        return {};
+      });
+      const monitor = {
+        account: { accountId: "default", config: {} },
+        cfg: {},
+        core: {
+          channel: {
+            commands: { shouldHandleTextCommands: vi.fn(() => true) },
+            inbound: { dispatch: mocks.dispatch },
+            text: {
+              convertMarkdownTables: vi.fn((text: string) => text),
+              hasControlCommand: vi.fn(() => true),
+            },
           },
         },
-      },
-      pairing: { readAllowFromStore: vi.fn(async () => []) },
-      resources: {
-        resolveChannelInfo: vi.fn(async () => ({ id: "channel-1", type: "O" })),
-        updateModelPickerPost,
-      },
-      runtime: { error: vi.fn() },
-    } as unknown as MattermostMonitorContext;
-    const handler = createMattermostModelPickerInteractionHandler(monitor);
+        pairing: { readAllowFromStore: vi.fn(async () => []) },
+        resources: {
+          resolveChannelInfo: vi.fn(async () => ({ id: "channel-1", type: "O" })),
+          updateModelPickerPost,
+        },
+        runtime: { error: vi.fn() },
+      } as unknown as MattermostMonitorContext;
+      const handler = createMattermostModelPickerInteractionHandler(monitor);
 
-    const response = await handler({
-      payload: {
-        channel_id: "channel-1",
-        post_id: "picker-post-1",
-        team_id: "team-1",
-        user_id: "user-1",
-      },
-      userName: "tester",
-      context: {},
-      post: { id: "picker-post-1", channel_id: "channel-1", message: "picker" },
-    });
+      const response = await handler({
+        payload: {
+          channel_id: "channel-1",
+          post_id: "picker-post-1",
+          team_id: "team-1",
+          user_id: "user-1",
+        },
+        userName: "tester",
+        context: {},
+        post: { id: "picker-post-1", channel_id: "channel-1", message: "picker" },
+      });
 
-    expect(response).toEqual({});
-    expect(mocks.runDetachedWebhookWork).toHaveBeenCalledOnce();
-    expect(mocks.dispatch).not.toHaveBeenCalled();
-    expect(detachedRun).toBeTypeOf("function");
+      expect(response).toEqual({});
+      expect(mocks.buildPreparedModelsProviderData).toHaveBeenCalledOnce();
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+      if (action !== "select") {
+        expect(mocks.runDetachedWebhookWork).not.toHaveBeenCalled();
+        expect(detachedRun).toBeUndefined();
+        expect(updateModelPickerPost).toHaveBeenCalledOnce();
+        expect(order).toEqual(["load", "update"]);
+        return;
+      }
 
-    await detachedRun?.();
+      expect(mocks.runDetachedWebhookWork).toHaveBeenCalledOnce();
+      expect(detachedRun).toBeTypeOf("function");
+      expect(updateModelPickerPost).not.toHaveBeenCalled();
+      expect(order).toEqual(["load", "detach"]);
 
-    expect(mocks.dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        channel: "mattermost",
-        delivery: expect.objectContaining({ observeMessageSent: true }),
-      }),
-    );
-    expect(mocks.deliverReply).toHaveBeenCalledWith(
-      expect.objectContaining({ channelId: "channel-1", replyToId: "picker-post-1" }),
-    );
-    expect(updateModelPickerPost).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "updated picker" }),
-    );
-  });
+      await detachedRun?.();
+
+      expect(mocks.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: "mattermost",
+          delivery: expect.objectContaining({ observeMessageSent: true }),
+        }),
+      );
+      expect(mocks.deliverReply).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: "channel-1", replyToId: "picker-post-1" }),
+      );
+      expect(updateModelPickerPost).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "updated picker" }),
+      );
+      expect(updateModelPickerPost).toHaveBeenCalledOnce();
+      expect(order).toEqual(["load", "detach", "update"]);
+    },
+  );
 });

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -6,6 +6,9 @@ import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 
+type BuildPreparedModelsProviderData =
+  typeof import("./runtime-api.js").buildPreparedModelsProviderData;
+
 const mockState = vi.hoisted(() => ({
   readRequestBodyWithLimit: vi.fn(async () => "token=valid-token"),
   parseSlashCommandPayload: vi.fn(() => ({
@@ -18,7 +21,13 @@ const mockState = vi.hoisted(() => ({
     team_id: "team-1",
   })),
   resolveCommandText: vi.fn((_trigger: string, text: string) => text),
-  buildPreparedModelsProviderData: vi.fn(async () => ({ providers: [], modelNames: new Map() })),
+  buildPreparedModelsProviderData: vi.fn<BuildPreparedModelsProviderData>(async () => ({
+    byProvider: new Map(),
+    providers: [],
+    resolvedDefault: { provider: "openai", model: "gpt-5.5" },
+    modelCatalog: [],
+    modelNames: new Map(),
+  })),
   resolveMattermostModelPickerEntry: vi.fn((): { kind: string } | null => ({ kind: "summary" })),
   authorizeMattermostCommandInvocation: vi.fn(() => ({
     ok: true,

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -50,6 +50,9 @@ const mockState = vi.hoisted(() => ({
   })),
   listMattermostCommands: vi.fn(async () => []),
   dispatchInbound: vi.fn(async () => undefined),
+  renderMattermostModelSummaryView: vi.fn(),
+  renderMattermostModelsPickerView: vi.fn(),
+  renderMattermostProviderPickerView: vi.fn(),
 }));
 
 vi.mock("./runtime-api.js", () => {
@@ -115,9 +118,9 @@ vi.mock("./client.js", async () => {
 });
 
 vi.mock("./model-picker.js", () => ({
-  renderMattermostModelSummaryView: vi.fn(),
-  renderMattermostModelsPickerView: vi.fn(),
-  renderMattermostProviderPickerView: vi.fn(),
+  renderMattermostModelSummaryView: mockState.renderMattermostModelSummaryView,
+  renderMattermostModelsPickerView: mockState.renderMattermostModelsPickerView,
+  renderMattermostProviderPickerView: mockState.renderMattermostProviderPickerView,
   resolveMattermostModelPickerCurrentModel: vi.fn(),
   resolveMattermostModelPickerEntry: mockState.resolveMattermostModelPickerEntry,
 }));
@@ -265,6 +268,72 @@ describe("slash-http cfg threading", () => {
       expect.objectContaining({
         cfg,
         accountId: "default",
+      }),
+    );
+  });
+
+  it.each([
+    {
+      commandText: "/model",
+      entry: { kind: "summary" },
+      render: "summary",
+      text: "replacement model summary",
+    },
+    {
+      commandText: "/models",
+      entry: { kind: "providers" },
+      render: "providers",
+      text: "replacement provider picker",
+    },
+  ] as const)("sends recovered data for $commandText initial render", async (testCase) => {
+    const cfg = {} as OpenClawConfig;
+    const buttons = [{ text: "OpenAI", value: "openai" }];
+    mockState.resolveCommandText.mockReturnValueOnce(testCase.commandText);
+    mockState.resolveMattermostModelPickerEntry.mockReturnValueOnce(testCase.entry);
+    mockState.buildPreparedModelsProviderData.mockResolvedValueOnce({
+      byProvider: new Map([["openai", new Set(["gpt-5.6-luna"])]]),
+      providers: ["openai"],
+      resolvedDefault: { provider: "openai", model: "gpt-5.6-luna" },
+      modelCatalog: [],
+      modelNames: new Map([["openai/gpt-5.6-luna", "Replacement Luna"]]),
+    });
+    const render =
+      testCase.render === "summary"
+        ? mockState.renderMattermostModelSummaryView
+        : mockState.renderMattermostProviderPickerView;
+    render.mockReturnValueOnce({ text: testCase.text, buttons });
+    const handler = createSlashCommandHttpHandler({
+      account: accountFixture,
+      cfg,
+      runtime: {} as RuntimeEnv,
+      registeredCommands: [
+        {
+          id: "cmd-1",
+          teamId: "team-1",
+          trigger: "oc_models",
+          token: "valid-token",
+          url: callbackUrlFixture,
+          managed: false,
+        },
+      ],
+    });
+    const response = createResponse();
+
+    await handler(createRequest(), response.res);
+
+    expect(response.res.statusCode).toBe(200);
+    expect(response.getBody()).toContain("Processing");
+    expect(mockState.buildPreparedModelsProviderData).toHaveBeenCalledExactlyOnceWith(
+      cfg,
+      "agent-1",
+    );
+    expect(mockState.sendMessageMattermost).toHaveBeenCalledExactlyOnceWith(
+      "channel:chan-1",
+      testCase.text,
+      expect.objectContaining({
+        accountId: "default",
+        buttons,
+        cfg,
       }),
     );
   });

--- a/src/agents/model-catalog-browse.test.ts
+++ b/src/agents/model-catalog-browse.test.ts
@@ -8,10 +8,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   buildProviderConfigModelCatalogForBrowse,
   loadPreparedModelCatalogSnapshotForBrowse,
+  MODEL_CATALOG_BROWSE_TIMEOUT_MS,
 } from "./model-catalog-browse.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
+import { PreparedModelRuntimePublicationSupersededError } from "./prepared-model-runtime.errors.js";
 
-const DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS = 750;
 const readOnlyCatalog: ModelCatalogSnapshot = {
   entries: [{ id: "gpt-readonly", name: "GPT Readonly", provider: "openai" }],
   routeVariants: [{ id: "gpt-readonly", name: "GPT Readonly", provider: "openai" }],
@@ -258,6 +259,29 @@ describe("loadPreparedModelCatalogSnapshotForBrowse", () => {
     expect(onTimeout).toHaveBeenCalledExactlyOnceWith(5);
   });
 
+  it("quietly consumes publication supersession after the browse deadline", async () => {
+    vi.useFakeTimers();
+    const loadCatalog = vi.fn(
+      () =>
+        new Promise<ModelCatalogSnapshot>((_resolve, reject) => {
+          setTimeout(
+            () => reject(new PreparedModelRuntimePublicationSupersededError("late supersession")),
+            10,
+          );
+        }),
+    );
+
+    const resultPromise = loadPreparedModelCatalogSnapshotForBrowse({
+      cfg: config(),
+      loadCatalog,
+      timeoutMs: 5,
+    });
+
+    await vi.advanceTimersByTimeAsync(5);
+    await expect(resultPromise).resolves.toEqual({ entries: [], routeVariants: [] });
+    await vi.advanceTimersByTimeAsync(5);
+  });
+
   it("can preserve the timeout fallback while escalating to full discovery", async () => {
     vi.useFakeTimers();
     const onTimeout = vi.fn();
@@ -316,7 +340,7 @@ describe("loadPreparedModelCatalogSnapshotForBrowse", () => {
     await expect(resultPromise).resolves.toBe(readOnlyCatalog);
     expect(setTimeout).toHaveBeenCalledExactlyOnceWith(
       expect.any(Function),
-      DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS,
+      MODEL_CATALOG_BROWSE_TIMEOUT_MS,
     );
     expect(clearTimeout).toHaveBeenCalledOnce();
     expect(onTimeout).not.toHaveBeenCalled();

--- a/src/agents/model-catalog-browse.ts
+++ b/src/agents/model-catalog-browse.ts
@@ -17,7 +17,7 @@ import {
  * Loads the model catalog shape used by browse/list commands without letting optional
  * provider discovery stall the CLI path.
  */
-const DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS = 750;
+export const MODEL_CATALOG_BROWSE_TIMEOUT_MS = 750;
 
 /** Visible model subset requested by model browse callers. */
 export type ModelCatalogBrowseView = "default" | "configured" | "provider-config" | "all";
@@ -65,10 +65,7 @@ export function modelCatalogBrowseRequiresFullDiscovery(params: {
 }
 
 function resolveModelCatalogBrowseTimeoutMs(value: number | undefined): number {
-  return (
-    clampTimerTimeoutMs(value, 1) ??
-    resolveTimerTimeoutMs(DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS, 1)
-  );
+  return clampTimerTimeoutMs(value, 1) ?? resolveTimerTimeoutMs(MODEL_CATALOG_BROWSE_TIMEOUT_MS, 1);
 }
 
 /** Loads an explicit logical/physical catalog snapshot for route-aware browse surfaces. */

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -75,6 +75,7 @@ import {
   loadResolvedPublishedModelCatalogOwner,
   loadPublishedPreparedModelCatalog,
   loadPublishedPreparedModelCatalogOwnerSnapshot,
+  withPreparedModelCatalogOwner,
 } from "./prepared-model-catalog.js";
 import {
   getPreparedModelRuntimeAuthStore,
@@ -113,6 +114,48 @@ describe("prepared model catalog access", () => {
     mocks.isFullCatalog.mockReset();
     mocks.releaseSnapshot.mockReset();
   });
+
+  it.each([
+    { readOnly: true, rejectProjection: false },
+    { readOnly: true, rejectProjection: true },
+    { readOnly: false, rejectProjection: false },
+    { readOnly: false, rejectProjection: true },
+  ])(
+    "retains the temporary owner through projection and releases it (readOnly=$readOnly, reject=$rejectProjection)",
+    async ({ readOnly, rejectProjection }) => {
+      let current = true;
+      const snapshot = { ...readOnlySnapshot, isCurrent: () => current };
+      const started = Promise.withResolvers<void>();
+      const resume = Promise.withResolvers<void>();
+      const failure = new Error("projection failed");
+      mocks.prepareSnapshot.mockRejectedValue(new PreparedModelRuntimeOwnerNotPublishedError());
+      mocks.loadSnapshot.mockResolvedValue(snapshot);
+      mocks.acquireSnapshot.mockResolvedValue(snapshot);
+      mocks.releaseSnapshot.mockImplementation(() => {
+        current = false;
+      });
+
+      const result = withPreparedModelCatalogOwner({ readOnly }, async (owner) => {
+        expect(owner.isCurrent()).toBe(true);
+        started.resolve();
+        await resume.promise;
+        expect(owner.isCurrent()).toBe(true);
+        if (rejectProjection) {
+          throw failure;
+        }
+        return owner.modelCatalog;
+      });
+      const outcome = rejectProjection
+        ? expect(result).rejects.toBe(failure)
+        : expect(result).resolves.toBe(snapshot.modelCatalog);
+      await started.promise;
+      expect(mocks.releaseSnapshot).not.toHaveBeenCalled();
+      resume.resolve();
+      await outcome;
+      expect(mocks.releaseSnapshot).toHaveBeenCalledOnce();
+      expect(current).toBe(false);
+    },
+  );
 
   it("uses the requested environment for directory selection and workspace activation", async () => {
     mocks.agentIds = ["main", "worker"];

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 
 const mocks = vi.hoisted(() => ({
   config: {} as object,
@@ -125,8 +126,8 @@ describe("prepared model catalog access", () => {
     async ({ readOnly, rejectProjection }) => {
       let current = true;
       const snapshot = { ...readOnlySnapshot, isCurrent: () => current };
-      const started = Promise.withResolvers<void>();
-      const resume = Promise.withResolvers<void>();
+      const started = createDeferred();
+      const resume = createDeferred();
       const failure = new Error("projection failed");
       mocks.prepareSnapshot.mockRejectedValue(new PreparedModelRuntimeOwnerNotPublishedError());
       mocks.loadSnapshot.mockResolvedValue(snapshot);

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -231,7 +231,7 @@ export function getAvailablePreparedModelCatalogSnapshot(
 async function resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
   params: LoadPreparedModelCatalogParams,
   configPolicy: PreparedModelCatalogConfigPolicy,
-): Promise<PreparedModelRuntimeSnapshot> {
+): Promise<{ snapshot: PreparedModelRuntimeSnapshot; release?: () => void }> {
   const { activationExact, activationFull, exact, full } = resolveInputs(params);
   if (params.readOnly) {
     const fullCandidates =
@@ -243,7 +243,7 @@ async function resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
         if (!acceptsPreparedSnapshotConfig(prepared, candidate, configPolicy)) {
           throw new PreparedModelCatalogConfigReplacedError(candidate.agentDir);
         }
-        return prepared;
+        return { snapshot: prepared };
       } catch (error) {
         if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
           throw error;
@@ -251,19 +251,16 @@ async function resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
       }
     }
     const lease = await acquireReadOnlyPreparedModelRuntime(activationExact);
-    try {
-      if (!acceptsPreparedSnapshotConfig(lease.snapshot, activationExact, configPolicy)) {
-        throw new PreparedModelCatalogConfigReplacedError(activationExact.agentDir);
-      }
-      return lease.snapshot;
-    } finally {
+    if (!acceptsPreparedSnapshotConfig(lease.snapshot, activationExact, configPolicy)) {
       lease.release();
+      throw new PreparedModelCatalogConfigReplacedError(activationExact.agentDir);
     }
+    return lease;
   }
   try {
     const preparedExact = await prepareModelRuntimeSnapshot(exact);
     if (acceptsPreparedSnapshotConfig(preparedExact, exact, configPolicy)) {
-      return preparedExact;
+      return { snapshot: preparedExact };
     }
   } catch (error) {
     if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
@@ -274,7 +271,7 @@ async function resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
   // publication belongs exclusively to startup/reload or agent-run admission.
   const activated = await activateStandalonePreparedModelRuntime(activationExact);
   if (activated && acceptsPreparedSnapshotConfig(activated, activationExact, configPolicy)) {
-    return activated;
+    return { snapshot: activated };
   }
   if (activated) {
     throw new PreparedModelRuntimeOwnerNotPublishedError(
@@ -284,36 +281,42 @@ async function resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
   // Gateway pre-run selection can name a spawned workspace before embedded-run admission.
   // Lease a complete exact generation so provider catalog hooks remain visible for this read.
   const lease = await acquireAgentRunPreparedModelRuntime(activationFull);
-  try {
-    if (!acceptsPreparedSnapshotConfig(lease.snapshot, activationFull, configPolicy)) {
-      throw new PreparedModelRuntimeOwnerNotPublishedError(
-        `prepared model catalog owner was not published for the requested config (${activationFull.agentDir})`,
-      );
-    }
-    return lease.snapshot;
-  } finally {
+  if (!acceptsPreparedSnapshotConfig(lease.snapshot, activationFull, configPolicy)) {
     lease.release();
+    throw new PreparedModelRuntimeOwnerNotPublishedError(
+      `prepared model catalog owner was not published for the requested config (${activationFull.agentDir})`,
+    );
   }
+  return lease;
 }
 
-async function loadPreparedModelCatalogOwnerSnapshotWithPolicy(
+async function withPreparedModelCatalogOwnerPolicy<T>(
   params: LoadPreparedModelCatalogParams,
   configPolicy: PreparedModelCatalogConfigPolicy,
-): Promise<PreparedModelRuntimeSnapshot> {
+  read: (snapshot: PreparedModelRuntimeSnapshot) => T | Promise<T>,
+): Promise<T> {
   const publishedReadOnlyOwner = params.readOnly
     ? getPreparedModelCatalogOwnerSnapshot(params)
     : undefined;
-  const snapshot = await resolvePreparedModelCatalogOwnerSnapshotWithPolicy(params, configPolicy);
-  // A fallback read-only lease retires before this projection. Only a published owner can safely
-  // expose its generation cache; the leased snapshot already contains its exact prepared facts.
-  if (params.readOnly && !publishedReadOnlyOwner) {
-    return snapshot;
-  }
-  return await materializeRequestedModelCatalog(
-    snapshot,
-    params.readOnly,
-    params.refreshFullCatalog,
+  const { snapshot, release } = await resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
+    params,
+    configPolicy,
   );
+  try {
+    // Only published owners expose generation caches; temporary reads use their prepared facts.
+    const owner =
+      params.readOnly && !publishedReadOnlyOwner
+        ? snapshot
+        : await materializeRequestedModelCatalog(
+            snapshot,
+            params.readOnly,
+            params.refreshFullCatalog,
+          );
+    // Projection must finish before a temporary lease retires its liveness predicate.
+    return await read(owner);
+  } finally {
+    release?.();
+  }
 }
 
 async function loadScopedReadOnlyModelCatalog(
@@ -428,18 +431,26 @@ export async function loadProviderScopedThinkingCatalog(params: {
   );
 }
 
+/** Keeps the exact catalog owner alive through an asynchronous read. */
+export async function withPreparedModelCatalogOwner<T>(
+  params: LoadPreparedModelCatalogParams,
+  read: (snapshot: PreparedModelRuntimeSnapshot) => T | Promise<T>,
+): Promise<T> {
+  return await withPreparedModelCatalogOwnerPolicy(params, "exact", read);
+}
+
 /** Resolves the lifecycle owner for an exact caller-supplied config. */
 export async function loadPreparedModelCatalogOwnerSnapshot(
   params: LoadPreparedModelCatalogParams = {},
 ): Promise<PreparedModelRuntimeSnapshot> {
-  return await loadPreparedModelCatalogOwnerSnapshotWithPolicy(params, "exact");
+  return await withPreparedModelCatalogOwnerPolicy(params, "exact", (snapshot) => snapshot);
 }
 
 /** Resolves the currently published owner when Gateway config changes during the read. */
 export async function loadPublishedPreparedModelCatalogOwnerSnapshot(
   params: LoadPreparedModelCatalogParams = {},
 ): Promise<PreparedModelRuntimeSnapshot> {
-  return await loadPreparedModelCatalogOwnerSnapshotWithPolicy(params, "published");
+  return await withPreparedModelCatalogOwnerPolicy(params, "published", (snapshot) => snapshot);
 }
 
 /** Resolves a complete published owner for long-lived runtime consumers. */

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -84,19 +84,23 @@ describe("prepared model runtime reload auth adoption", () => {
     const readInput = { ...input, config: nextConfig };
     const published = await prepareModelRuntimeSnapshot(readInput);
 
-    let requestReadSettled = false;
+    const discoveryStarted = createDeferred();
+    mocks.runPreparedModelCatalogWorker.mockImplementation(() => {
+      discoveryStarted.resolve();
+      return liveBuild.promise;
+    });
     const requestRead = loadPreparedModelCatalogOwnerSnapshot({
       ...readInput,
       readOnly: true,
-    }).then(() => {
-      requestReadSettled = true;
     });
-    mocks.runPreparedModelCatalogWorker.mockImplementation(() => liveBuild.promise);
-    for (let i = 0; i < 5; i += 1) {
-      await Promise.resolve();
-    }
     try {
-      expect(requestReadSettled).toBe(true);
+      // Discovery stays withheld so an ordinary read must finish without starting it.
+      await expect(
+        Promise.race([
+          requestRead.then(() => "read"),
+          discoveryStarted.promise.then(() => "discovery"),
+        ]),
+      ).resolves.toBe("read");
       expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
     } finally {
       liveBuild.resolve({ entries: [model], routeVariants: [model] });

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
 import { setPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
+import { PreparedModelRuntimePublicationSupersededError } from "../../agents/prepared-model-runtime.errors.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 const catalogMocks = vi.hoisted(() => ({
@@ -34,7 +35,9 @@ const replacementCfg = {
 } as OpenClawConfig;
 
 afterEach(() => {
-  vi.clearAllMocks();
+  catalogMocks.loadSnapshot.mockReset();
+  catalogMocks.loadPublishedOwner.mockReset();
+  vi.useRealTimers();
   catalogMocks.authStore = { version: 1, profiles: {} };
 });
 
@@ -92,42 +95,151 @@ describe("/models browse catalog recovery", () => {
     expect(catalogMocks.loadPublishedOwner).not.toHaveBeenCalled();
   });
 
-  it("rebuilds the whole browse result from the replacement owner's config, not the stale cfg", async () => {
-    catalogMocks.loadSnapshot
-      .mockRejectedValueOnce(new PreparedModelCatalogConfigReplacedError("/tmp/agent-dir"))
-      .mockResolvedValueOnce({
-        entries: [{ provider: "openai", id: "gpt-5.6-luna", name: "GPT-5.6 Luna" }],
-        routeVariants: [],
-      });
+  it.each([
+    ["config replacement", () => new PreparedModelCatalogConfigReplacedError("/tmp/agent-dir")],
+    [
+      "publication supersession",
+      () => new PreparedModelRuntimePublicationSupersededError("superseded"),
+    ],
+  ])("rebuilds the whole browse result after %s", async (_label, createError) => {
+    catalogMocks.loadSnapshot.mockRejectedValueOnce(createError()).mockResolvedValueOnce({
+      entries: [{ provider: "openai", id: "gpt-5.6-luna", name: "GPT-5.6 Luna" }],
+      routeVariants: [],
+    });
     catalogMocks.loadPublishedOwner.mockResolvedValueOnce({ config: replacementCfg });
 
     const data = await buildPreparedModelsProviderData(staleCfg);
 
-    // The recovered menu reflects the replacement generation end-to-end: its catalog entry
-    // and its resolved default both come from replacementCfg, never staleCfg's stale anthropic
-    // default that the new config already removed.
     expect(data.resolvedDefault).toEqual({ provider: "openai", model: "gpt-5.6-luna" });
     expect(data.byProvider.get("anthropic")).toBeUndefined();
     expect(data.byProvider.get("openai")).toEqual(new Set(["gpt-5.6-luna"]));
+    expect(data.modelNames.get("openai/gpt-5.6-luna")).toBe("GPT-5.6 Luna");
+    expect(data.runtimeChoicesByProvider?.has("openai")).toBe(true);
     expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledTimes(1);
-    expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledWith(
-      expect.objectContaining({ readOnly: true }),
-    );
     expect(catalogMocks.loadSnapshot).toHaveBeenCalledTimes(2);
     expect(catalogMocks.loadSnapshot.mock.calls[1]?.[0]).toMatchObject({ config: replacementCfg });
-    expect(catalogMocks.loadSnapshot.mock.calls.map(([params]) => params.readOnly)).toEqual([
-      true,
-      true,
-    ]);
   });
 
-  it("lets a second owner replacement escape", async () => {
-    const first = new PreparedModelCatalogConfigReplacedError("/tmp/agent-a");
-    const second = new PreparedModelCatalogConfigReplacedError("/tmp/agent-b");
-    catalogMocks.loadSnapshot.mockRejectedValueOnce(first).mockRejectedValueOnce(second);
-    catalogMocks.loadPublishedOwner.mockResolvedValueOnce({ config: replacementCfg });
+  it("uses the current agent directory and selected workspace across multiple reloads", async () => {
+    const intermediateCfg = {
+      agents: {
+        defaults: { model: { primary: "google/gemini-3.1-pro" } },
+        list: [
+          {
+            id: "worker",
+            default: true,
+            agentDir: "/tmp/intermediate-agent",
+            workspace: "/tmp/intermediate-workspace",
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const currentCfg = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.6-luna" } },
+        list: [
+          {
+            id: "worker",
+            default: true,
+            agentDir: "/tmp/current-agent",
+            workspace: "/tmp/current-workspace",
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    catalogMocks.loadSnapshot
+      .mockRejectedValueOnce(new PreparedModelCatalogConfigReplacedError("/tmp/stale-agent"))
+      .mockRejectedValueOnce(new PreparedModelRuntimePublicationSupersededError("superseded again"))
+      .mockResolvedValueOnce({
+        entries: [{ provider: "openai", id: "gpt-5.6-luna", name: "Current Luna" }],
+        routeVariants: [],
+      });
+    catalogMocks.loadPublishedOwner
+      .mockResolvedValueOnce({ config: intermediateCfg })
+      .mockResolvedValueOnce({ config: currentCfg });
 
-    await expect(buildPreparedModelsProviderData(staleCfg)).rejects.toBe(second);
+    const data = await buildPreparedModelsProviderData(staleCfg, "worker", {
+      workspaceDir: "/tmp/selected-workspace",
+    });
+
+    expect(data.resolvedDefault).toEqual({ provider: "openai", model: "gpt-5.6-luna" });
+    expect(data.providers).toEqual(["openai"]);
+    expect(data.modelNames.get("openai/gpt-5.6-luna")).toBe("Current Luna");
+    expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledTimes(2);
+    for (const [params] of catalogMocks.loadPublishedOwner.mock.calls) {
+      expect(params).toMatchObject({
+        agentId: "worker",
+        readOnly: true,
+        workspaceDir: "/tmp/selected-workspace",
+      });
+      expect(params).not.toHaveProperty("config");
+      expect(params).not.toHaveProperty("agentDir");
+    }
+    expect(catalogMocks.loadSnapshot.mock.calls[2]?.[0]).toMatchObject({
+      agentId: "worker",
+      agentDir: "/tmp/current-agent",
+      config: currentCfg,
+      workspaceDir: "/tmp/selected-workspace",
+    });
+  });
+
+  it("uses one browse deadline across repeated owner replacements", async () => {
+    vi.useFakeTimers();
+    const intermediateCfg = {
+      agents: { defaults: { model: { primary: "google/gemini-3.1-pro" } } },
+    } as OpenClawConfig;
+    const currentCfg = {
+      agents: { defaults: { model: { primary: "openai/gpt-5.6-luna" } } },
+    } as OpenClawConfig;
+    const rejectAfter = (delayMs: number, error: Error) =>
+      new Promise<never>((_resolve, reject) => {
+        setTimeout(() => reject(error), delayMs);
+      });
+    catalogMocks.loadSnapshot
+      .mockImplementationOnce(() =>
+        rejectAfter(300, new PreparedModelCatalogConfigReplacedError("/tmp/stale-agent")),
+      )
+      .mockImplementationOnce(() =>
+        rejectAfter(300, new PreparedModelRuntimePublicationSupersededError("superseded again")),
+      )
+      .mockImplementationOnce(() => new Promise(() => {}));
+    catalogMocks.loadPublishedOwner
+      .mockResolvedValueOnce({ config: intermediateCfg })
+      .mockResolvedValueOnce({ config: currentCfg });
+
+    const resultPromise = buildPreparedModelsProviderData(staleCfg);
+    const result = expect(resultPromise).resolves.toMatchObject({
+      resolvedDefault: { provider: "openai", model: "gpt-5.6-luna" },
+      providers: ["openai"],
+    });
+    await vi.advanceTimersByTimeAsync(750);
+    await result;
+    expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledTimes(2);
+    expect(catalogMocks.loadSnapshot).toHaveBeenCalledTimes(3);
+  });
+
+  it("bounds current-owner reacquisition by the original browse deadline", async () => {
+    vi.useFakeTimers();
+    catalogMocks.loadSnapshot.mockImplementationOnce(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(
+            () => reject(new PreparedModelCatalogConfigReplacedError("/tmp/stale-agent")),
+            300,
+          );
+        }),
+    );
+    catalogMocks.loadPublishedOwner.mockImplementationOnce(() => new Promise(() => {}));
+
+    const resultPromise = buildPreparedModelsProviderData(staleCfg);
+    const result = expect(resultPromise).resolves.toMatchObject({
+      resolvedDefault: { provider: "anthropic", model: "claude-opus-4-5" },
+      providers: ["anthropic"],
+    });
+    await vi.advanceTimersByTimeAsync(750);
+    await result;
+
+    expect(catalogMocks.loadSnapshot).toHaveBeenCalledTimes(1);
     expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledTimes(1);
   });
 

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -220,6 +220,25 @@ describe("/models browse catalog recovery", () => {
 
   it("bounds current-owner reacquisition by the original browse deadline", async () => {
     vi.useFakeTimers();
+    const fallbackCfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-5" },
+          models: {
+            "openai/gpt-configured": { alias: "configured" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    catalogMocks.loadSnapshot.mockImplementationOnce(() => new Promise(() => {}));
+
+    const ordinaryTimeoutPromise = buildPreparedModelsProviderData(fallbackCfg);
+    await vi.advanceTimersByTimeAsync(750);
+    const ordinaryTimeout = await ordinaryTimeoutPromise;
+    expect(ordinaryTimeout.byProvider.get("openai")).toEqual(new Set(["gpt-configured"]));
+
+    catalogMocks.loadSnapshot.mockReset();
+    catalogMocks.loadPublishedOwner.mockReset();
     catalogMocks.loadSnapshot.mockImplementationOnce(
       () =>
         new Promise<never>((_resolve, reject) => {
@@ -231,14 +250,11 @@ describe("/models browse catalog recovery", () => {
     );
     catalogMocks.loadPublishedOwner.mockImplementationOnce(() => new Promise(() => {}));
 
-    const resultPromise = buildPreparedModelsProviderData(staleCfg);
-    const result = expect(resultPromise).resolves.toMatchObject({
-      resolvedDefault: { provider: "anthropic", model: "claude-opus-4-5" },
-      providers: ["anthropic"],
-    });
+    const resultPromise = buildPreparedModelsProviderData(fallbackCfg);
     await vi.advanceTimersByTimeAsync(750);
-    await result;
+    const reacquisitionTimeout = await resultPromise;
 
+    expect(reacquisitionTimeout).toEqual(ordinaryTimeout);
     expect(catalogMocks.loadSnapshot).toHaveBeenCalledTimes(1);
     expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledTimes(1);
   });

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -218,6 +218,36 @@ describe("/models browse catalog recovery", () => {
     expect(catalogMocks.loadSnapshot).toHaveBeenCalledTimes(3);
   });
 
+  it("keeps explicit full-catalog recovery unbounded across late supersession", async () => {
+    vi.useFakeTimers();
+    catalogMocks.loadSnapshot
+      .mockImplementationOnce(
+        () =>
+          new Promise<never>((_resolve, reject) => {
+            setTimeout(
+              () => reject(new PreparedModelRuntimePublicationSupersededError("late supersession")),
+              1_000,
+            );
+          }),
+      )
+      .mockResolvedValueOnce({
+        entries: [{ provider: "openai", id: "gpt-5.6-luna", name: "Current Luna" }],
+        routeVariants: [],
+      });
+    catalogMocks.loadPublishedOwner.mockResolvedValueOnce({ config: replacementCfg });
+
+    const resultPromise = buildPreparedModelsProviderData(staleCfg, undefined, { view: "all" });
+    const result = expect(resultPromise).resolves.toMatchObject({
+      resolvedDefault: { provider: "openai", model: "gpt-5.6-luna" },
+      providers: ["openai"],
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await result;
+
+    expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledOnce();
+    expect(catalogMocks.loadSnapshot).toHaveBeenCalledTimes(2);
+  });
+
   it("bounds current-owner reacquisition by the original browse deadline", async () => {
     vi.useFakeTimers();
     const fallbackCfg = {

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -24,7 +24,8 @@ vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadPublishedPreparedModelCatalogOwnerSnapshot: catalogMocks.loadPublishedOwner,
 }));
 
-const { buildPreparedModelsProviderData } = await import("./commands-models.js");
+const { buildPreparedModelsProviderData, resolveModelsCommandReply } =
+  await import("./commands-models.js");
 
 const staleCfg = {
   agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
@@ -95,6 +96,45 @@ describe("/models browse catalog recovery", () => {
     expect(catalogMocks.loadPublishedOwner).not.toHaveBeenCalled();
   });
 
+  it("carries the command-selected directory into current-owner recovery", async () => {
+    catalogMocks.loadSnapshot
+      .mockRejectedValueOnce(new PreparedModelCatalogConfigReplacedError("/tmp/selected-agent"))
+      .mockResolvedValueOnce({
+        entries: [{ provider: "openai", id: "gpt-5.6-luna", name: "Current Luna" }],
+        routeVariants: [],
+      });
+    catalogMocks.loadPublishedOwner.mockResolvedValueOnce({
+      agentDir: "/tmp/current-agent",
+      config: replacementCfg,
+    });
+
+    await resolveModelsCommandReply({
+      cfg: staleCfg,
+      commandBodyNormalized: "/models",
+      agentId: "worker",
+      agentDir: "/tmp/selected-agent",
+      workspaceDir: "/tmp/selected-workspace",
+    });
+
+    expect(catalogMocks.loadSnapshot.mock.calls[0]?.[0]).toMatchObject({
+      agentId: "worker",
+      agentDir: "/tmp/selected-agent",
+      config: staleCfg,
+      workspaceDir: "/tmp/selected-workspace",
+    });
+    expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledWith({
+      agentId: "worker",
+      readOnly: true,
+      workspaceDir: "/tmp/selected-workspace",
+    });
+    expect(catalogMocks.loadSnapshot.mock.calls[1]?.[0]).toMatchObject({
+      agentId: "worker",
+      agentDir: "/tmp/current-agent",
+      config: replacementCfg,
+      workspaceDir: "/tmp/selected-workspace",
+    });
+  });
+
   it.each([
     ["config replacement", () => new PreparedModelCatalogConfigReplacedError("/tmp/agent-dir")],
     [
@@ -155,10 +195,11 @@ describe("/models browse catalog recovery", () => {
         routeVariants: [],
       });
     catalogMocks.loadPublishedOwner
-      .mockResolvedValueOnce({ config: intermediateCfg })
-      .mockResolvedValueOnce({ config: currentCfg });
+      .mockResolvedValueOnce({ agentDir: "/tmp/intermediate-agent", config: intermediateCfg })
+      .mockResolvedValueOnce({ agentDir: "/tmp/current-agent", config: currentCfg });
 
     const data = await buildPreparedModelsProviderData(staleCfg, "worker", {
+      agentDir: "/tmp/selected-agent",
       workspaceDir: "/tmp/selected-workspace",
     });
 
@@ -175,6 +216,18 @@ describe("/models browse catalog recovery", () => {
       expect(params).not.toHaveProperty("config");
       expect(params).not.toHaveProperty("agentDir");
     }
+    expect(catalogMocks.loadSnapshot.mock.calls[0]?.[0]).toMatchObject({
+      agentId: "worker",
+      agentDir: "/tmp/selected-agent",
+      config: staleCfg,
+      workspaceDir: "/tmp/selected-workspace",
+    });
+    expect(catalogMocks.loadSnapshot.mock.calls[1]?.[0]).toMatchObject({
+      agentId: "worker",
+      agentDir: "/tmp/intermediate-agent",
+      config: intermediateCfg,
+      workspaceDir: "/tmp/selected-workspace",
+    });
     expect(catalogMocks.loadSnapshot.mock.calls[2]?.[0]).toMatchObject({
       agentId: "worker",
       agentDir: "/tmp/current-agent",

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import * as providerAuth from "../../agents/model-provider-auth.js";
 import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
@@ -65,8 +66,8 @@ describe("/models browse catalog recovery", () => {
       vi.useFakeTimers();
       let current = true;
       catalogMocks.isCurrent = () => current;
-      const evaluating = Promise.withResolvers<void>();
-      const resumeAuth = Promise.withResolvers<void>();
+      const evaluating = createDeferred();
+      const resumeAuth = createDeferred();
       const evaluateModelAuth = vi.fn(async () => ({
         availability: true as const,
         routeResolution: null,

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -279,14 +279,17 @@ describe("/models browse catalog recovery", () => {
       .mockResolvedValueOnce({ agentDir: "/tmp/intermediate-agent", config: intermediateCfg })
       .mockResolvedValueOnce({ agentDir: "/tmp/current-agent", config: currentCfg });
 
-    const data = await buildPreparedModelsProviderData(staleCfg, "worker", {
+    const reply = await resolveModelsCommandReply({
+      cfg: staleCfg,
+      commandBodyNormalized: "/models",
+      agentId: "worker",
       agentDir: "/tmp/selected-agent",
       workspaceDir: "/tmp/selected-workspace",
     });
 
-    expect(data.resolvedDefault).toEqual({ provider: "openai", model: "gpt-5.6-luna" });
-    expect(data.providers).toEqual(["openai"]);
-    expect(data.modelNames.get("openai/gpt-5.6-luna")).toBe("Current Luna");
+    expect(reply?.text).toContain("openai");
+    expect(reply?.text).not.toContain("anthropic");
+    expect(reply?.text).not.toContain("google");
     expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledTimes(2);
     for (const [params] of catalogMocks.loadPublishedOwner.mock.calls) {
       expect(params).toMatchObject({

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import * as providerAuth from "../../agents/model-provider-auth.js";
 import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
 import { setPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
 import { PreparedModelRuntimePublicationSupersededError } from "../../agents/prepared-model-runtime.errors.js";
@@ -9,20 +10,29 @@ const catalogMocks = vi.hoisted(() => ({
   loadSnapshot: vi.fn(),
   loadPublishedOwner: vi.fn(),
   authStore: { version: 1, profiles: {} } as AuthProfileStore,
+  isCurrent: () => true,
 }));
 
-vi.mock("../../agents/prepared-model-catalog.js", () => ({
-  loadPreparedModelCatalogSnapshot: catalogMocks.loadSnapshot,
-  loadPreparedModelCatalogOwnerSnapshot: async (...args: unknown[]) => {
+vi.mock("../../agents/prepared-model-catalog.js", () => {
+  const loadOwner = async (...args: unknown[]) => {
     const owner = {
       modelCatalog: await catalogMocks.loadSnapshot(...args),
       authModes: {},
+      isCurrent: catalogMocks.isCurrent,
     };
     setPreparedModelRuntimeAuthStore(owner, catalogMocks.authStore);
     return owner;
-  },
-  loadPublishedPreparedModelCatalogOwnerSnapshot: catalogMocks.loadPublishedOwner,
-}));
+  };
+  return {
+    loadPreparedModelCatalogSnapshot: catalogMocks.loadSnapshot,
+    loadPreparedModelCatalogOwnerSnapshot: loadOwner,
+    withPreparedModelCatalogOwner: async (
+      params: unknown,
+      read: (owner: Awaited<ReturnType<typeof loadOwner>>) => unknown,
+    ) => read(await loadOwner(params)),
+    loadPublishedPreparedModelCatalogOwnerSnapshot: catalogMocks.loadPublishedOwner,
+  };
+});
 
 const { buildPreparedModelsProviderData, resolveModelsCommandReply } =
   await import("./commands-models.js");
@@ -40,9 +50,79 @@ afterEach(() => {
   catalogMocks.loadPublishedOwner.mockReset();
   vi.useRealTimers();
   catalogMocks.authStore = { version: 1, profiles: {} };
+  catalogMocks.isCurrent = () => true;
+  vi.restoreAllMocks();
 });
 
 describe("/models browse catalog recovery", () => {
+  it.each([
+    { view: "default", delayMs: 0 },
+    { view: "all", delayMs: 1_000 },
+    { view: "default", delayMs: 1_000 },
+  ] as const)(
+    "recovers supersession during $view auth projection within its deadline (delay=$delayMs)",
+    async ({ view, delayMs }) => {
+      vi.useFakeTimers();
+      let current = true;
+      catalogMocks.isCurrent = () => current;
+      const evaluating = Promise.withResolvers<void>();
+      const resumeAuth = Promise.withResolvers<void>();
+      const evaluateModelAuth = vi.fn(async () => ({
+        availability: true as const,
+        routeResolution: null,
+      }));
+      evaluateModelAuth.mockImplementationOnce(async () => {
+        evaluating.resolve();
+        await resumeAuth.promise;
+        return { availability: true, routeResolution: null };
+      });
+      vi.spyOn(providerAuth, "createProviderAuthChecker").mockReturnValue(
+        Object.assign(async () => true, { evaluateModelAuth }),
+      );
+      catalogMocks.loadSnapshot
+        .mockResolvedValueOnce({
+          entries: [{ provider: "anthropic", id: "claude-opus-4-5", name: "Stale model" }],
+          routeVariants: [],
+        })
+        .mockResolvedValueOnce({
+          entries: [{ provider: "openai", id: "gpt-5.6-luna", name: "Current model" }],
+          routeVariants: [],
+        });
+      catalogMocks.loadPublishedOwner.mockImplementationOnce(async () => {
+        catalogMocks.isCurrent = () => true;
+        return { config: replacementCfg };
+      });
+
+      let settled = false;
+      const result = buildPreparedModelsProviderData(staleCfg, undefined, { view }).then((data) => {
+        settled = true;
+        return data;
+      });
+      await evaluating.promise;
+      current = false;
+      const timedOut = view === "default" && delayMs > 750;
+      if (delayMs) {
+        await vi.advanceTimersByTimeAsync(delayMs);
+        expect(settled).toBe(timedOut);
+      }
+      resumeAuth.resolve();
+      const data = await result;
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(data.resolvedDefault).toEqual(
+        timedOut
+          ? { provider: "anthropic", model: "claude-opus-4-5" }
+          : { provider: "openai", model: "gpt-5.6-luna" },
+      );
+      expect(data.providers).toEqual([timedOut ? "anthropic" : "openai"]);
+      expect(data.modelNames.has("anthropic/claude-opus-4-5")).toBe(false);
+      expect(data.modelNames.get("openai/gpt-5.6-luna")).toBe(
+        timedOut ? undefined : "Current model",
+      );
+      expect(catalogMocks.loadPublishedOwner).toHaveBeenCalledTimes(timedOut ? 0 : 1);
+    },
+  );
+
   it.each([false, true])(
     "projects prepared external OAuth with explicit exclusion=%s",
     async (excluded) => {

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -11,7 +11,7 @@ const catalogMocks = vi.hoisted(() => ({
   loadSnapshot: vi.fn(),
   loadPublishedOwner: vi.fn(),
   authStore: { version: 1, profiles: {} } as AuthProfileStore,
-  isCurrent: () => true,
+  isCurrent: (): boolean => true,
 }));
 
 vi.mock("../../agents/prepared-model-catalog.js", () => {

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -105,10 +105,10 @@ function setFastModelsCliBackendDeps(): void {
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalog: modelCatalogMocks.loadModelCatalog,
-  loadPreparedModelCatalogOwnerSnapshot: async (...args: unknown[]) => {
-    const entries = await modelCatalogMocks.loadModelCatalog(...args);
-    return { modelCatalog: { entries, routeVariants: entries }, authModes: {} };
+  withPreparedModelCatalogOwner: async (params: unknown, read: (owner: object) => unknown) => {
+    const entries = await modelCatalogMocks.loadModelCatalog(params);
+    const modelCatalog = { entries, routeVariants: entries };
+    return read({ modelCatalog, authModes: {}, isCurrent: () => true });
   },
 }));
 

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -12,7 +12,10 @@ import {
 import { listCliRuntimeModelBackendBindings } from "../../agents/cli-backends.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
-import { loadPreparedModelCatalogSnapshotForBrowse } from "../../agents/model-catalog-browse.js";
+import {
+  loadPreparedModelCatalogSnapshotForBrowse,
+  MODEL_CATALOG_BROWSE_TIMEOUT_MS,
+} from "../../agents/model-catalog-browse.js";
 import {
   resolveLogicalModelCatalogEntryState,
   resolveLogicalVisibleModelCatalog,
@@ -38,12 +41,14 @@ import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/open
 import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
 import * as preparedModelCatalog from "../../agents/prepared-model-catalog.js";
 import { getPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
+import { PreparedModelRuntimePublicationSupersededError } from "../../agents/prepared-model-runtime.errors.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.types.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveAgentRuntimeLabel } from "../../status/agent-runtime-label.js";
+import { ABSOLUTE_DEADLINE_EXPIRED, awaitWithinDeadline } from "../../utils/absolute-deadline.js";
 import type { ReplyPayload } from "../types.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
@@ -68,6 +73,11 @@ export type ModelsProviderData = {
 
 type PreparedModelsProviderData = ModelsProviderData & {
   modelCatalog: ModelCatalogEntry[];
+};
+
+type ModelsBrowseOptions = {
+  view?: "default" | "all";
+  workspaceDir?: string;
 };
 
 export type ModelsRuntimeChoice = {
@@ -162,27 +172,80 @@ function addRuntimeChoice(
 export async function buildPreparedModelsProviderData(
   cfg: OpenClawConfig,
   agentId?: string,
-  options: { view?: "default" | "all"; workspaceDir?: string } = {},
+  options: ModelsBrowseOptions = {},
 ): Promise<PreparedModelsProviderData> {
-  return buildPreparedDataForConfig(cfg, agentId, options).catch(async (error: unknown) => {
-    if (!(error instanceof PreparedModelCatalogConfigReplacedError)) {
-      throw error;
+  const deadlineMs = Date.now() + MODEL_CATALOG_BROWSE_TIMEOUT_MS;
+  let currentConfig = cfg;
+  for (;;) {
+    const timeoutMs = deadlineMs - Date.now();
+    if (timeoutMs <= 0) {
+      return buildPreparedDataForConfig(currentConfig, agentId, options, {
+        catalogFallback: true,
+        timeoutMs: 1,
+      });
     }
-    // Catalog, defaults, visibility, auth, aliases, and runtime choices share one config generation.
-    const { config } = await preparedModelCatalog.loadPublishedPreparedModelCatalogOwnerSnapshot({
-      config: cfg,
-      readOnly: true,
+    try {
+      return await buildPreparedDataForConfig(currentConfig, agentId, options, { timeoutMs });
+    } catch (error) {
+      if (!isPreparedModelCatalogOwnerReplacement(error)) {
+        throw error;
+      }
+    }
+    const owner = await loadPublishedModelsOwnerBeforeDeadline({
       agentId,
+      deadlineMs,
       workspaceDir: options.workspaceDir,
     });
-    return buildPreparedDataForConfig(config, agentId, options);
-  });
+    if (!owner) {
+      return buildPreparedDataForConfig(currentConfig, agentId, options, {
+        catalogFallback: true,
+        timeoutMs: 1,
+      });
+    }
+    currentConfig = owner.config;
+  }
+}
+
+function isPreparedModelCatalogOwnerReplacement(error: unknown): boolean {
+  return (
+    error instanceof PreparedModelCatalogConfigReplacedError ||
+    error instanceof PreparedModelRuntimePublicationSupersededError
+  );
+}
+
+async function loadPublishedModelsOwnerBeforeDeadline(params: {
+  agentId?: string;
+  deadlineMs: number;
+  workspaceDir?: string;
+}): Promise<PreparedModelRuntimeSnapshot | undefined> {
+  for (;;) {
+    try {
+      const owner = await awaitWithinDeadline(
+        () =>
+          preparedModelCatalog.loadPublishedPreparedModelCatalogOwnerSnapshot({
+            readOnly: true,
+            agentId: params.agentId,
+            workspaceDir: params.workspaceDir,
+          }),
+        params.deadlineMs,
+      );
+      if (owner === ABSOLUTE_DEADLINE_EXPIRED) {
+        return undefined;
+      }
+      return owner;
+    } catch (error) {
+      if (!isPreparedModelCatalogOwnerReplacement(error)) {
+        throw error;
+      }
+    }
+  }
 }
 
 async function buildPreparedDataForConfig(
   cfg: OpenClawConfig,
   agentId: string | undefined,
-  options: { view?: "default" | "all"; workspaceDir?: string },
+  options: ModelsBrowseOptions,
+  control: { catalogFallback?: boolean; timeoutMs: number },
 ): Promise<PreparedModelsProviderData> {
   const runtimeNormalization = resolveRuntimeNormalization(cfg);
   const resolvedDefault = resolveDefaultModelForAgent({
@@ -199,21 +262,24 @@ async function buildPreparedDataForConfig(
   );
 
   let loadedOwner: PreparedModelRuntimeSnapshot | undefined;
-  const snapshot = await loadPreparedModelCatalogSnapshotForBrowse({
-    cfg,
-    agentId,
-    view: options.view ?? "default",
-    loadCatalog: async ({ readOnly }) => {
-      loadedOwner = await preparedModelCatalog.loadPreparedModelCatalogOwnerSnapshot({
-        config: cfg,
-        readOnly,
-        refreshFullCatalog: "stale",
-        ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
-        ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+  const snapshot = control.catalogFallback
+    ? { entries: [], routeVariants: [] }
+    : await loadPreparedModelCatalogSnapshotForBrowse({
+        cfg,
+        agentId,
+        view: options.view ?? "default",
+        loadCatalog: async ({ readOnly }) => {
+          loadedOwner = await preparedModelCatalog.loadPreparedModelCatalogOwnerSnapshot({
+            config: cfg,
+            readOnly,
+            refreshFullCatalog: "stale",
+            ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
+            ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+          });
+          return loadedOwner.modelCatalog;
+        },
+        timeoutMs: control.timeoutMs,
       });
-      return loadedOwner.modelCatalog;
-    },
-  });
   // A timed-out read can complete later. Only pair auth with the catalog actually returned.
   const owner = loadedOwner?.modelCatalog === snapshot ? loadedOwner : undefined;
   const authStore = owner && getPreparedModelRuntimeAuthStore(owner);

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -76,6 +76,7 @@ type PreparedModelsProviderData = ModelsProviderData & {
 };
 
 type ModelsBrowseOptions = {
+  agentDir?: string;
   view?: "default" | "all";
   workspaceDir?: string;
 };
@@ -176,16 +177,21 @@ export async function buildPreparedModelsProviderData(
 ): Promise<PreparedModelsProviderData> {
   const deadlineMs =
     options.view === "all" ? undefined : Date.now() + MODEL_CATALOG_BROWSE_TIMEOUT_MS;
+  let currentAgentDir = options.agentDir;
   let currentConfig = cfg;
+  const buildCurrentData = (control: { catalogFallback?: boolean; deadlineMs?: number }) =>
+    buildPreparedDataForConfig(
+      currentConfig,
+      agentId,
+      { ...options, agentDir: currentAgentDir },
+      control,
+    );
   for (;;) {
     if (deadlineMs !== undefined && Date.now() >= deadlineMs) {
-      return buildPreparedDataForConfig(currentConfig, agentId, options, {
-        catalogFallback: true,
-        deadlineMs,
-      });
+      return buildCurrentData({ catalogFallback: true, deadlineMs });
     }
     try {
-      return await buildPreparedDataForConfig(currentConfig, agentId, options, { deadlineMs });
+      return await buildCurrentData({ deadlineMs });
     } catch (error) {
       if (!isPreparedModelCatalogOwnerReplacement(error)) {
         throw error;
@@ -197,12 +203,10 @@ export async function buildPreparedModelsProviderData(
       workspaceDir: options.workspaceDir,
     });
     if (!owner) {
-      return buildPreparedDataForConfig(currentConfig, agentId, options, {
-        catalogFallback: true,
-        deadlineMs,
-      });
+      return buildCurrentData({ catalogFallback: true, deadlineMs });
     }
     currentConfig = owner.config;
+    currentAgentDir = owner.agentDir;
   }
 }
 
@@ -260,6 +264,7 @@ async function buildPreparedDataForConfig(
   const cliRuntimeProviders = new Set(
     listCliRuntimeModelBackendBindings().map((binding) => normalizeProviderId(binding.runtime)),
   );
+  const agentDir = options.agentDir ?? (agentId ? resolveAgentDir(cfg, agentId) : undefined);
 
   let loadedOwner: PreparedModelRuntimeSnapshot | undefined;
   const timeoutMs = control.deadlineMs === undefined ? undefined : control.deadlineMs - Date.now();
@@ -275,7 +280,8 @@ async function buildPreparedDataForConfig(
               config: cfg,
               readOnly,
               refreshFullCatalog: "stale",
-              ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
+              ...(agentId ? { agentId } : {}),
+              ...(agentDir ? { agentDir } : {}),
               ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
             });
             return loadedOwner.modelCatalog;
@@ -695,6 +701,7 @@ export async function resolveModelsCommandReply(params: {
     params.cfg,
     params.agentId,
     {
+      agentDir: params.agentDir,
       ...(parsed.action === "list" && parsed.all ? { view: "all" as const } : {}),
       workspaceDir: params.workspaceDir,
     },

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -177,15 +177,14 @@ export async function buildPreparedModelsProviderData(
   const deadlineMs = Date.now() + MODEL_CATALOG_BROWSE_TIMEOUT_MS;
   let currentConfig = cfg;
   for (;;) {
-    const timeoutMs = deadlineMs - Date.now();
-    if (timeoutMs <= 0) {
+    if (Date.now() >= deadlineMs) {
       return buildPreparedDataForConfig(currentConfig, agentId, options, {
         catalogFallback: true,
-        timeoutMs: 1,
+        deadlineMs,
       });
     }
     try {
-      return await buildPreparedDataForConfig(currentConfig, agentId, options, { timeoutMs });
+      return await buildPreparedDataForConfig(currentConfig, agentId, options, { deadlineMs });
     } catch (error) {
       if (!isPreparedModelCatalogOwnerReplacement(error)) {
         throw error;
@@ -199,7 +198,7 @@ export async function buildPreparedModelsProviderData(
     if (!owner) {
       return buildPreparedDataForConfig(currentConfig, agentId, options, {
         catalogFallback: true,
-        timeoutMs: 1,
+        deadlineMs,
       });
     }
     currentConfig = owner.config;
@@ -245,7 +244,7 @@ async function buildPreparedDataForConfig(
   cfg: OpenClawConfig,
   agentId: string | undefined,
   options: ModelsBrowseOptions,
-  control: { catalogFallback?: boolean; timeoutMs: number },
+  control: { catalogFallback?: boolean; deadlineMs: number },
 ): Promise<PreparedModelsProviderData> {
   const runtimeNormalization = resolveRuntimeNormalization(cfg);
   const resolvedDefault = resolveDefaultModelForAgent({
@@ -262,24 +261,26 @@ async function buildPreparedDataForConfig(
   );
 
   let loadedOwner: PreparedModelRuntimeSnapshot | undefined;
-  const snapshot = control.catalogFallback
-    ? { entries: [], routeVariants: [] }
-    : await loadPreparedModelCatalogSnapshotForBrowse({
-        cfg,
-        agentId,
-        view: options.view ?? "default",
-        loadCatalog: async ({ readOnly }) => {
-          loadedOwner = await preparedModelCatalog.loadPreparedModelCatalogOwnerSnapshot({
-            config: cfg,
-            readOnly,
-            refreshFullCatalog: "stale",
-            ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
-            ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
-          });
-          return loadedOwner.modelCatalog;
-        },
-        timeoutMs: control.timeoutMs,
-      });
+  const timeoutMs = control.deadlineMs - Date.now();
+  const snapshot =
+    control.catalogFallback || timeoutMs <= 0
+      ? { entries: [], routeVariants: [] }
+      : await loadPreparedModelCatalogSnapshotForBrowse({
+          cfg,
+          agentId,
+          view: options.view ?? "default",
+          loadCatalog: async ({ readOnly }) => {
+            loadedOwner = await preparedModelCatalog.loadPreparedModelCatalogOwnerSnapshot({
+              config: cfg,
+              readOnly,
+              refreshFullCatalog: "stale",
+              ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
+              ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+            });
+            return loadedOwner.modelCatalog;
+          },
+          timeoutMs,
+        });
   // A timed-out read can complete later. Only pair auth with the catalog actually returned.
   const owner = loadedOwner?.modelCatalog === snapshot ? loadedOwner : undefined;
   const authStore = owner && getPreparedModelRuntimeAuthStore(owner);

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -174,10 +174,11 @@ export async function buildPreparedModelsProviderData(
   agentId?: string,
   options: ModelsBrowseOptions = {},
 ): Promise<PreparedModelsProviderData> {
-  const deadlineMs = Date.now() + MODEL_CATALOG_BROWSE_TIMEOUT_MS;
+  const deadlineMs =
+    options.view === "all" ? undefined : Date.now() + MODEL_CATALOG_BROWSE_TIMEOUT_MS;
   let currentConfig = cfg;
   for (;;) {
-    if (Date.now() >= deadlineMs) {
+    if (deadlineMs !== undefined && Date.now() >= deadlineMs) {
       return buildPreparedDataForConfig(currentConfig, agentId, options, {
         catalogFallback: true,
         deadlineMs,
@@ -190,7 +191,7 @@ export async function buildPreparedModelsProviderData(
         throw error;
       }
     }
-    const owner = await loadPublishedModelsOwnerBeforeDeadline({
+    const owner = await loadPublishedModelsOwner({
       agentId,
       deadlineMs,
       workspaceDir: options.workspaceDir,
@@ -212,9 +213,9 @@ function isPreparedModelCatalogOwnerReplacement(error: unknown): boolean {
   );
 }
 
-async function loadPublishedModelsOwnerBeforeDeadline(params: {
+async function loadPublishedModelsOwner(params: {
   agentId?: string;
-  deadlineMs: number;
+  deadlineMs?: number;
   workspaceDir?: string;
 }): Promise<PreparedModelRuntimeSnapshot | undefined> {
   for (;;) {
@@ -244,7 +245,7 @@ async function buildPreparedDataForConfig(
   cfg: OpenClawConfig,
   agentId: string | undefined,
   options: ModelsBrowseOptions,
-  control: { catalogFallback?: boolean; deadlineMs: number },
+  control: { catalogFallback?: boolean; deadlineMs?: number },
 ): Promise<PreparedModelsProviderData> {
   const runtimeNormalization = resolveRuntimeNormalization(cfg);
   const resolvedDefault = resolveDefaultModelForAgent({
@@ -261,9 +262,9 @@ async function buildPreparedDataForConfig(
   );
 
   let loadedOwner: PreparedModelRuntimeSnapshot | undefined;
-  const timeoutMs = control.deadlineMs - Date.now();
+  const timeoutMs = control.deadlineMs === undefined ? undefined : control.deadlineMs - Date.now();
   const snapshot =
-    control.catalogFallback || timeoutMs <= 0
+    control.catalogFallback || (timeoutMs !== undefined && timeoutMs <= 0)
       ? { entries: [], routeVariants: [] }
       : await loadPreparedModelCatalogSnapshotForBrowse({
           cfg,
@@ -279,7 +280,7 @@ async function buildPreparedDataForConfig(
             });
             return loadedOwner.modelCatalog;
           },
-          timeoutMs,
+          ...(timeoutMs === undefined ? {} : { timeoutMs }),
         });
   // A timed-out read can complete later. Only pair auth with the catalog actually returned.
   const owner = loadedOwner?.modelCatalog === snapshot ? loadedOwner : undefined;

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -13,7 +13,7 @@ import { listCliRuntimeModelBackendBindings } from "../../agents/cli-backends.js
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
 import {
-  loadPreparedModelCatalogSnapshotForBrowse,
+  modelCatalogBrowseRequiresFullDiscovery,
   MODEL_CATALOG_BROWSE_TIMEOUT_MS,
 } from "../../agents/model-catalog-browse.js";
 import {
@@ -251,6 +251,36 @@ async function buildPreparedDataForConfig(
   options: ModelsBrowseOptions,
   control: { catalogFallback?: boolean; deadlineMs?: number },
 ): Promise<PreparedModelsProviderData> {
+  const project = (owner?: PreparedModelRuntimeSnapshot) =>
+    projectPreparedModelsProviderData(cfg, agentId, options, owner);
+  if (control.catalogFallback) {
+    return project();
+  }
+  const agentDir = options.agentDir ?? (agentId ? resolveAgentDir(cfg, agentId) : undefined);
+  const result = await awaitWithinDeadline(
+    () =>
+      preparedModelCatalog.withPreparedModelCatalogOwner(
+        {
+          config: cfg,
+          readOnly: !modelCatalogBrowseRequiresFullDiscovery({ cfg, agentId, view: options.view }),
+          refreshFullCatalog: "stale",
+          ...(agentId ? { agentId } : {}),
+          ...(agentDir ? { agentDir } : {}),
+          ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+        },
+        project,
+      ),
+    control.deadlineMs,
+  );
+  return result === ABSOLUTE_DEADLINE_EXPIRED ? project() : result;
+}
+
+async function projectPreparedModelsProviderData(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+  options: ModelsBrowseOptions,
+  owner?: PreparedModelRuntimeSnapshot,
+): Promise<PreparedModelsProviderData> {
   const runtimeNormalization = resolveRuntimeNormalization(cfg);
   const resolvedDefault = resolveDefaultModelForAgent({
     cfg,
@@ -264,32 +294,7 @@ async function buildPreparedDataForConfig(
   const cliRuntimeProviders = new Set(
     listCliRuntimeModelBackendBindings().map((binding) => normalizeProviderId(binding.runtime)),
   );
-  const agentDir = options.agentDir ?? (agentId ? resolveAgentDir(cfg, agentId) : undefined);
-
-  let loadedOwner: PreparedModelRuntimeSnapshot | undefined;
-  const timeoutMs = control.deadlineMs === undefined ? undefined : control.deadlineMs - Date.now();
-  const snapshot =
-    control.catalogFallback || (timeoutMs !== undefined && timeoutMs <= 0)
-      ? { entries: [], routeVariants: [] }
-      : await loadPreparedModelCatalogSnapshotForBrowse({
-          cfg,
-          agentId,
-          view: options.view ?? "default",
-          loadCatalog: async ({ readOnly }) => {
-            loadedOwner = await preparedModelCatalog.loadPreparedModelCatalogOwnerSnapshot({
-              config: cfg,
-              readOnly,
-              refreshFullCatalog: "stale",
-              ...(agentId ? { agentId } : {}),
-              ...(agentDir ? { agentDir } : {}),
-              ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
-            });
-            return loadedOwner.modelCatalog;
-          },
-          ...(timeoutMs === undefined ? {} : { timeoutMs }),
-        });
-  // A timed-out read can complete later. Only pair auth with the catalog actually returned.
-  const owner = loadedOwner?.modelCatalog === snapshot ? loadedOwner : undefined;
+  const snapshot = owner?.modelCatalog ?? { entries: [], routeVariants: [] };
   const authStore = owner && getPreparedModelRuntimeAuthStore(owner);
   const catalog = snapshot.entries;
   const visibilityPolicy = createModelVisibilityPolicy({
@@ -512,6 +517,11 @@ async function buildPreparedDataForConfig(
       }),
     );
     runtimeChoicesByProvider.set(provider, choices);
+  }
+
+  // Auth and visibility cross awaits. Retired owners must restart the whole projection.
+  if (owner && !owner.isCurrent()) {
+    throw new PreparedModelRuntimePublicationSupersededError("model browse owner was superseded");
   }
 
   return {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -76,10 +76,11 @@ type PreparedModelsProviderData = ModelsProviderData & {
 };
 
 type ModelsBrowseOptions = {
-  agentDir?: string;
   view?: "default" | "all";
   workspaceDir?: string;
 };
+
+type ModelsBrowseContext = ModelsBrowseOptions & { agentDir?: string };
 
 export type ModelsRuntimeChoice = {
   id: string;
@@ -170,14 +171,23 @@ function addRuntimeChoice(
   return choices;
 }
 
-export async function buildPreparedModelsProviderData(
+export function buildPreparedModelsProviderData(
   cfg: OpenClawConfig,
   agentId?: string,
   options: ModelsBrowseOptions = {},
 ): Promise<PreparedModelsProviderData> {
+  return buildPreparedModelsProviderDataWithContext(cfg, agentId, options);
+}
+
+async function buildPreparedModelsProviderDataWithContext(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+  options: ModelsBrowseOptions,
+  agentDir?: string,
+): Promise<PreparedModelsProviderData> {
   const deadlineMs =
     options.view === "all" ? undefined : Date.now() + MODEL_CATALOG_BROWSE_TIMEOUT_MS;
-  let currentAgentDir = options.agentDir;
+  let currentAgentDir = agentDir;
   let currentConfig = cfg;
   const buildCurrentData = (control: { catalogFallback?: boolean; deadlineMs?: number }) =>
     buildPreparedDataForConfig(
@@ -248,7 +258,7 @@ async function loadPublishedModelsOwner(params: {
 async function buildPreparedDataForConfig(
   cfg: OpenClawConfig,
   agentId: string | undefined,
-  options: ModelsBrowseOptions,
+  options: ModelsBrowseContext,
   control: { catalogFallback?: boolean; deadlineMs?: number },
 ): Promise<PreparedModelsProviderData> {
   const project = (owner?: PreparedModelRuntimeSnapshot) =>
@@ -707,14 +717,14 @@ export async function resolveModelsCommandReply(params: {
   const argText = body.replace(/^\/models\b/i, "").trim();
   const parsed = parseModelsArgs(argText);
 
-  const { byProvider, providers, modelNames } = await buildPreparedModelsProviderData(
+  const { byProvider, providers, modelNames } = await buildPreparedModelsProviderDataWithContext(
     params.cfg,
     params.agentId,
     {
-      agentDir: params.agentDir,
       ...(parsed.action === "list" && parsed.all ? { view: "all" as const } : {}),
       workspaceDir: params.workspaceDir,
     },
+    params.agentDir,
   );
   const commandPlugin = params.surface ? getChannelPlugin(params.surface) : null;
   const providerInfos = buildProviderInfos({ providers, byProvider });

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -376,9 +376,20 @@ vi.mock("../../agents/prepared-model-catalog.js", () => {
   return {
     loadPreparedModelCatalog: loadModelCatalog,
     loadProviderScopedThinkingCatalog: loadModelCatalog,
-    loadPreparedModelCatalogOwnerSnapshot: async () => {
+    withPreparedModelCatalogOwner: async (
+      _params: unknown,
+      read: (owner: {
+        modelCatalog: { entries: ModelCatalogEntry[]; routeVariants: ModelCatalogEntry[] };
+        authModes: object;
+        isCurrent: () => boolean;
+      }) => unknown,
+    ) => {
       const entries = await loadModelCatalog();
-      return { modelCatalog: { entries, routeVariants: entries }, authModes: {} };
+      return read({
+        modelCatalog: { entries, routeVariants: entries },
+        authModes: {},
+        isCurrent: () => true,
+      });
     },
   };
 });


### PR DESCRIPTION
Closes #137037

## What Problem This Solves

`/models` commands and durable channel model pickers could fail without updating when a supported configuration reload superseded an in-flight model catalog owner.

## Root Cause

The shared model-browse builder retried one `PreparedModelCatalogConfigReplacedError`, but it rethrew publication supersession and a second supported replacement. Recovery also needed one absolute browse budget so retries could not extend already-bounded picker latency.

The command path additionally resolved a selected `agentDir` but dropped it before catalog materialization, allowing the first read to substitute a config-derived directory.

## Fix

Model browsing now:

- reacquires the current published owner after either supported replacement signal;
- restarts the complete provider-data projection so catalog, default, visibility, auth, aliases, metadata, and runtime choices use one current configuration generation;
- uses the caller-selected agent directory for initial materialization, omits that potentially stale path while reacquiring the current owner, then uses the replacement owner's current directory;
- preserves the caller-selected agent and workspace throughout recovery;
- shares the existing 750 ms absolute deadline across bounded reads and owner acquisition;
- returns the established configured fallback when that bounded deadline wins;
- keeps explicit `view: "all"` discovery unbounded across supported replacement;
- quietly consumes late settlement after a bounded fallback has completed.

No configuration, schema, persistence, protocol, documentation, or release surface changes.

## User Impact

Model menus recover transparently through supported configuration reload races. Normal picker views retain their existing bounded latency and fallback. Explicit full-catalog browsing continues waiting for a coherent current catalog rather than degrading to stale fallback data.

## Evidence

Exact product head: `adc17248f7a976fe4618f1318419202f36edcc5a`

- Focused recovery, command, browse, and Mattermost suites: 78 tests passed.
- Gateway sibling, Discord picker, and Telegram bot suites: 201 tests passed.
- Local `pnpm test:changed`: passed.
- Blacksmith Testbox `tbx_01m1kfxrhzph0wwp52tffc0a0f`: all 279 affected tests and `pnpm test:changed` passed; lease completed. Run: https://github.com/openclaw/openclaw/actions/runs/33749065570
- Repository autoreview: scoped clean, confidence `0.88`.
- Direct Codex inspection: current `origin/main` `728cb12fe5794b0c3a8e776fb4994b1650b973a8`; no Codex protocol, model endpoint, auth, or runtime contract change.
- Exact-head ClawSweeper: in progress.
- Production/test delta: production `+105/-33` (net `+72`), tests `+426/-81` (net `+345`). The production growth is the repeated owner-recovery loop, shared absolute-deadline ownership, and selected-directory handoff; no duplicate channel recovery path was added.

## Remaining Landing Blockers

- Telegram Test Server proof cannot enter the product path because the Convex-leased TDLib user session is not authorized. Runs `33745752402` and `33746883206` failed in the required doctor before the Gateway, Telegram action, or candidate behavior ran. Session repair and credential publication are owner-only operations.
- Required hosted CI continues to hit the same current-main `src/commands/agent-exec.test.ts` process-tree failure outside this PR's changed surface. Current run: https://github.com/openclaw/openclaw/actions/runs/33748958984. A separate production-owner repair is in progress.
- Workloop independent review found and drove the selected-directory correction. Final independent review is pending on the exact corrected head.

Not ready to land until those blockers are closed on the exact final result.
