### PR TITLE
fix(memory): watcher warnings recommend a removed setting

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -8,6 +8,7 @@ read_when:
   - You want to understand hybrid search, MMR, or temporal-decay defaults
   - You want to enable multimodal memory indexing
   - You need to exclude specific session sources from automatic dreaming ingestion
+  - You see a memory file-watching pressure warning
 ---
 
 This page lists every configuration knob for OpenClaw memory search. For conceptual overviews, see:
@@ -370,6 +371,26 @@ Use `provider: "openai-compatible"` for a generic OpenAI-compatible
 Memory engines own synchronization, batching, watch, and post-compaction
 indexing heuristics. OpenClaw keeps these behaviors enabled with maintained
 defaults rather than exposing per-install timing switches.
+
+### File-watcher pressure
+
+The "Memory file watching is tracking ..." warning reports an advisory count of
+watched paths or directories, not a measured host limit or confirmed exhaustion.
+Remove unnecessary `memory.search.extraPaths` entries or narrow their directory
+roots. Global entries and `agents.entries.<id>.memory.search.extraPaths` entries
+are combined: an empty per-agent list does not remove global roots. Changing only
+an entry's `pattern` filters indexed files, not the directory tree being watched.
+
+Removing extra-path entries does not exclude files that still belong to the
+default `MEMORY.md`, `USER.md`, or `memory/` roots. If reducing extra paths is
+insufficient, review file-watch and open-file limits on the Gateway host. There is no supported
+`memory.search.sync.watch` setting.
+
+After changes, restart the Gateway. To refresh the affected index, run
+`openclaw memory index --force --agent <id>` on the Gateway host using its profile
+and environment, including any `OPENCLAW_STATE_DIR` or `OPENCLAW_CONFIG_PATH`
+overrides. Use the affected agent's ID; the command printed in the warning includes
+it and the active profile or container hint. See [memory index](/cli/memory#memory-index).
 
 ## Hybrid search config
 

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -14,6 +14,7 @@ import {
   normalizeExtraMemoryPathEntries,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { formatCliCommand } from "openclaw/plugin-sdk/setup-tools";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { MemoryManagerSyncBase } from "./manager-sync-base.js";
 import {
@@ -235,12 +236,15 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
   }
 
   private warnIfMemoryWatchPressure(count: number, unit: MemoryWatchPressureUnit): void {
+    const reindexCommand = formatCliCommand(
+      `openclaw memory index --force --agent ${this.agentId}`,
+    );
     warnIfMemoryWatchPressureHigh(
       this.memoryWatchPressureWarning,
       count,
       unit,
       "Large memory folders or extraPaths can make OpenClaw run out of file watchers or open files.",
-      "Remove large extraPaths, or set memory.search.sync.watch to false and refresh memory manually.",
+      `Remove unnecessary memory.search.extraPaths entries or narrow their directory roots, including per-agent entries; otherwise review the host's file-watch/open-file limits. After changes, restart the Gateway. To refresh the affected index, run in the Gateway's environment: ${reindexCommand}.`,
       (message) => log.warn(message),
     );
   }

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -230,31 +230,23 @@ describe("memory watcher config", () => {
   }
 
   function createWatcherConfig(overrides?: Partial<MemorySearchConfig>): OpenClawConfig {
-    const defaults: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> = {
-      workspace: workspaceDir,
-    };
     return isolateMemoryManagerTestConfig({
       memory: {
-        backend: "builtin",
         search: {
           provider: "openai",
           model: "mock-embed",
           store: { vector: { enabled: false } },
-          sync: { watch: true, onSessionStart: false, onSearch: false },
-          query: { minScore: 0, hybrid: { enabled: false } },
+          query: { minScore: 0 },
           extraPaths: [extraDir],
           ...overrides,
         },
       },
-      agents: {
-        defaults,
-        list: [{ id: "main", default: true }],
-      },
-    } as OpenClawConfig);
+      agents: { entries: { main: { workspace: workspaceDir } } },
+    });
   }
 
-  async function expectWatcherManager(cfg: OpenClawConfig) {
-    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+  async function expectWatcherManager(cfg: OpenClawConfig, agentId = "main") {
+    const result = await getMemorySearchManager({ cfg, agentId });
     if (!result.manager) {
       throw new Error("manager missing");
     }
@@ -608,16 +600,20 @@ describe("memory watcher config", () => {
         await fs.mkdir(path.join(root, `topic-${i}`));
       }
       const cfg = createWatcherConfig({ extraPaths: [] });
+      cfg.agents = {
+        ownership: "explicit",
+        entries: { main: {}, "watch-linux": { workspace: workspaceDir } },
+      };
       vi.useFakeTimers();
 
-      await expectWatcherManager(cfg);
-      expect(memoryLoggerWarn).not.toHaveBeenCalledWith(
-        expect.stringContaining("Memory file watching is tracking 2002 directories."),
-      );
+      await expectWatcherManager(cfg, "watch-linux");
+      expect(memoryLoggerWarn).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(memoryLoggerWarn).toHaveBeenCalledTimes(1);
       await vi.advanceTimersByTimeAsync(10_000);
 
-      expect(memoryLoggerWarn).toHaveBeenCalledWith(
-        expect.stringContaining("Memory file watching is tracking 2002 directories."),
+      expect(memoryLoggerWarn).toHaveBeenCalledExactlyOnceWith(
+        "Memory file watching is tracking 2002 directories. Large memory folders or extraPaths can make OpenClaw run out of file watchers or open files. Remove unnecessary memory.search.extraPaths entries or narrow their directory roots, including per-agent entries; otherwise review the host's file-watch/open-file limits. After changes, restart the Gateway. To refresh the affected index, run in the Gateway's environment: openclaw memory index --force --agent watch-linux.",
       );
     } finally {
       Object.defineProperty(process, "platform", {
@@ -1125,26 +1121,38 @@ describe("memory watcher config", () => {
   });
 
   it("warns when chokidar memory watching tracks many paths", async () => {
-    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-    const cfg = createWatcherConfig();
-    vi.useFakeTimers();
+    vi.stubEnv("OPENCLAW_PROFILE", "memory-watch");
+    try {
+      await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+      const cfg = createWatcherConfig();
+      cfg.agents = {
+        ownership: "explicit",
+        entries: { main: {}, "watch-paths": { workspace: workspaceDir } },
+      };
+      vi.useFakeTimers();
 
-    await expectWatcherManager(cfg);
+      const activeManager = await expectWatcherManager(cfg, "watch-paths");
 
-    const chokidarWatcher = createdChokidarWatchers[0];
-    if (!chokidarWatcher) {
-      throw new Error("expected chokidar watcher");
+      const chokidarWatcher = createdChokidarWatchers[0];
+      if (!chokidarWatcher) {
+        throw new Error("expected chokidar watcher");
+      }
+      chokidarWatcher.watchedEntries = {
+        [workspaceDir]: Array.from({ length: 2_001 }, (_value, index) => `${index}.md`),
+      };
+      expect(memoryLoggerWarn).not.toHaveBeenCalled();
+      chokidarWatcher.emit("ready");
+      expect(memoryLoggerWarn).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await activeManager.close();
+      expect(chokidarWatcher.close).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(memoryLoggerWarn).toHaveBeenCalledExactlyOnceWith(
+        "Memory file watching is tracking 2002 paths. Large memory folders or extraPaths can make OpenClaw run out of file watchers or open files. Remove unnecessary memory.search.extraPaths entries or narrow their directory roots, including per-agent entries; otherwise review the host's file-watch/open-file limits. After changes, restart the Gateway. To refresh the affected index, run in the Gateway's environment: openclaw --profile memory-watch memory index --force --agent watch-paths.",
+      );
+    } finally {
+      vi.unstubAllEnvs();
     }
-    chokidarWatcher.watchedEntries = {
-      [workspaceDir]: Array.from({ length: 2_001 }, (_value, index) => `${index}.md`),
-    };
-    expect(memoryLoggerWarn).not.toHaveBeenCalledWith(
-      expect.stringContaining("Memory file watching is tracking 2002 paths."),
-    );
-    await vi.advanceTimersByTimeAsync(10_000);
-
-    expect(memoryLoggerWarn).toHaveBeenCalledWith(
-      expect.stringContaining("Memory file watching is tracking 2002 paths."),
-    );
   });
 });


### PR DESCRIPTION
Closes #137156

## What Problem This Solves

Fixes an issue where following the memory file-watcher pressure warning would make configuration invalid: it recommended `memory.search.sync.watch`, which the same build rejects. The warning offered an unusable recovery step.

## Why This Change Was Made

Replace stale advice at the warning producer with supported extra-path/root reduction, host-limit review, Gateway restart, and reindexing the affected agent in the Gateway's environment. Reuse the existing CLI formatter for the active profile or container hint. Watcher behavior, thresholds, timers, configuration schemas, defaults, and storage remain unchanged.

The existing regression fixture now uses canonical configuration and its existing manager helper, removing ignored legacy setup. After an actual merge conflict, the redundant process-test repair was dropped because main had landed the owner-correct coverage in [PR #137157](https://github.com/openclaw/openclaw/pull/137157). This PR is back to its original three memory files. Those files are byte-identical to the previously reviewed head.

## User Impact

Operators get a usable command targeting the agent whose watcher emitted the warning. Documentation explains that global and per-agent extra paths combine, narrowing only a glob does not reduce watched directory roots, and default memory roots remain eligible.

The count is advisory, not proof of descriptor exhaustion. This change does not raise host limits, disable watching, add configuration options, or migrate data. See [memory configuration](https://docs.openclaw.ai/reference/memory-config) and [memory indexing](https://docs.openclaw.ai/cli/memory#memory-index).

## Evidence

Candidate: `9adf91dc2160dfdd63ba0e29af801e7e93917507`, based on `88be1b80f58df698fe730b4f3f34934ecae92e21`. Native main-baseline inspection at `13b1f71c7010baaf2394555198e2fc04bef03586` found no additional changes in the inspected memory, formatter, schema, or dependency contracts.

**Fail-first proof:** the original isolated Gateway indexed 2,001 synthetic files and emitted one warning recommending the retired key. A separate config copy containing that key failed actual CLI validation. Both existing native-directory/Chokidar warning cases failed against the old wording and pass with affected-agent/profile-qualified guidance.

**Fresh post-rebase validation:** 90 memory watcher/filesystem/registry tests, 343 config/retired-key/profile tests, and 105 adopted process/CLI tests passed with zero failures or skips. The complete three-file changed gate passed all 25 checks, including five doctor-contract tests. No guard, baseline, suppression, or timeout was relaxed.

```bash
node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.watcher-config.test.ts extensions/memory-core/src/memory/manager.watcher-filesystem.test.ts extensions/memory-core/src/memory/manager-registry.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/memory-search.test.ts src/config/dead-config-keys.test.ts src/cli/profile.test.ts
```

```bash
node scripts/run-vitest.mjs src/commands/agent-exec.construction.test.ts src/commands/agent-exec.test.ts src/process/supervisor/supervisor.test.ts src/process/supervisor/adapters/child.service-lifecycle.test.ts
```

```bash
node scripts/check-changed.mjs --timed --base 88be1b80f58df698fe730b4f3f34934ecae92e21 -- extensions/memory-core/src/memory/manager-watch-ops.ts extensions/memory-core/src/memory/manager.watcher-config.test.ts docs/reference/memory-config.md
```

**Fresh independent review and build:** isolated Codex autoreview covered the complete three-file diff plus 12 source/context datasets, with no findings or filtering at the configured P0 threshold. Mandatory scanning and reviewer isolation remained intact. `pnpm build:ci-artifacts` passed in 105.2 seconds on Node 24.15.0 and pnpm 12.1.0. Exact build: `2026.8.1-9adf91dc2160-2026-09-03T11-59-35.447Z`. Source remained clean and matched the reviewed hashes. No ineffective-dynamic-import warning occurred; dependency direct-eval, browser externalization, and plugin-timing diagnostics remain recorded.

**Fresh exact-build recovery:** a new isolated Gateway/state/profile indexed 2,001 physical files, returned both sentinels through the normal HTTP memory tool, and emitted the exact affected-agent/profile-qualified command once. After stopping that owned Gateway, only effective extra paths changed to one entry. All 2,001 physical source hashes were preserved. The same state/profile was restarted and the displayed command executed:

```bash
openclaw --profile memory-watch memory index --force --agent qa-memory
```

The CLI and HTTP searches then retained the included sentinel and excluded the removed scope, with a valid one-file FTS index and no stale/disabled/unavailable result. No new watcher-pressure warning appeared through the startup-check window. Both configurations passed CLI validation with zero schema warnings. The parent independently compared raw HTTP responses, index status, configuration changes, physical file hashes, command arguments, and genuine shutdown receipts.

```json
{"physicalFilesPreserved":2001,"indexedFilesBefore":2001,"indexedFilesAfter":1,"httpBefore":{"retained":1,"excluded":1},"httpAfter":{"retained":1,"excluded":0},"cliAfter":{"retained":1,"excluded":0},"newPressureWarnings":0,"configurationChangedOnlyExtraPaths":true,"launcherReceiptsWritten":true,"ownedGatewaysStopped":true,"listenerAbsent":true,"rawResponsesIndependentlyCompared":true}
```

**CI history:** [run 33740221493](https://github.com/openclaw/openclaw/actions/runs/33740221493) exposed a process test selecting the SDK process owner while claiming relay coverage. Main now owns its replacement, including a real CLI process-backend construction test; all 105 relevant cases passed after adopting it. The subsequent watcher for [run 33748627404](https://github.com/openclaw/openclaw/actions/runs/33748627404) stopped on a verified merge conflict, not an observed test failure. The current head passed [CI run 33753098239](https://github.com/openclaw/openclaw/actions/runs/33753098239) on attempt 1. The native watcher returned GREEN with zero pending checks.

**Review disposition and LOC:** production +5/-1 (net +4), tests +45/-37 (net +8), docs +21. The four production lines bind the existing formatter to the affected agent. This is the narrow producer-owned fix; restoring the retired setting or adding a new formatting path would create unnecessary policy/compatibility surface. This addresses the production-growth item in the [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/137181#issuecomment-5522961720). Its green exact-head CI requirement is now satisfied.

**Provenance:** [config-surface consolidation](https://github.com/openclaw/openclaw/pull/111527) retired the public synchronization switches while carrying the stale warning forward. The first affected stable release is not established.

**Gaps and retained evidence:** this is real CLI/HTTP behavior, not rendered UI proof; browser tab capacity prevented rendered preview access. Earlier attempts and reviews retain their original identities, including the incomplete older run missing a launcher receipt and the successful older recovery in the [previous proof comment](https://github.com/openclaw/openclaw/pull/137181#issuecomment-5524883750). Neither is relabeled as current-head evidence. Required exact-head CI passed. Native preparation and merge completed through `scripts/pr`; landed as [f4647c4d1af59b3bb798a0a9a0f27f87cb7075dd](https://github.com/openclaw/openclaw/commit/f4647c4d1af59b3bb798a0a9a0f27f87cb7075dd). The native workflow reported its default advisory for newer CI/tooling changes on main; no strict-drift override was set. The merged files and synchronized clean main match the reviewed hashes. No gate was bypassed.
