### PR TITLE
test(ui): simplify fixtures and await lazy diff highlighting

### DIFF
--- a/ui/src/pages/chat/components/session-diff-panel.test.ts
+++ b/ui/src/pages/chat/components/session-diff-panel.test.ts
@@ -72,7 +72,8 @@ function fileResult(patch: string): SessionsDiffResult {
   };
 }
 
-afterEach(() => {
+afterEach(async () => {
+  await vi.dynamicImportSettled();
   document.body.replaceChildren();
   clearNativeGatewayTestState();
   vi.restoreAllMocks();
@@ -124,6 +125,8 @@ describe("SessionDiffPanel", () => {
       data.files[0]!.path = "example.ts";
       panel.loader = async () => data;
       document.body.append(panel);
+      await panel.updateComplete;
+      await vi.dynamicImportSettled();
       await vi.waitFor(() =>
         expect(panel.querySelector(".tok-string")?.textContent).toContain("before"),
       );
@@ -163,6 +166,8 @@ describe("SessionDiffPanel", () => {
     };
     panel.loader = async () => data;
     document.body.append(panel);
+    await panel.updateComplete;
+    await vi.dynamicImportSettled();
 
     const oldSide = split ? ".session-diff-split__side--left" : ".chat-diff__row--del";
     const newSide = split ? ".session-diff-split__side--right" : ".chat-diff__row--add";

--- a/ui/src/pages/chat/realtime-talk-consult.test.ts
+++ b/ui/src/pages/chat/realtime-talk-consult.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import {
   steerRealtimeTalkActiveConsult,
   submitRealtimeTalkConsult,
@@ -85,11 +86,8 @@ describe("RealtimeTalkSession consult handoff", () => {
   });
 
   it("does not start a consult after aborting during the transcript flush", async () => {
-    let releaseFlush!: () => void;
-    const flushPending = new Promise<void>((resolve) => {
-      releaseFlush = resolve;
-    });
-    const flushTranscriptWrites = vi.fn(async () => await flushPending);
+    const flushPending = createDeferred();
+    const flushTranscriptWrites = vi.fn(async () => await flushPending.promise);
     const request = vi.fn();
     const submit = vi.fn();
     const controller = new AbortController();
@@ -110,7 +108,7 @@ describe("RealtimeTalkSession consult handoff", () => {
     await vi.waitFor(() => expect(flushTranscriptWrites).toHaveBeenCalledOnce());
 
     controller.abort();
-    releaseFlush();
+    flushPending.resolve();
     await consult;
 
     expect(request).not.toHaveBeenCalled();
@@ -121,15 +119,12 @@ describe("RealtimeTalkSession consult handoff", () => {
     "keeps the acknowledgement alive and cancels its exact %s target",
     async (agentSessionKey) => {
       type Acknowledgement = { runId: string; agentId: string; agentSessionKey: string };
-      let acknowledge!: (value: Acknowledgement) => void;
-      const pendingAcknowledgement = new Promise<Acknowledgement>((resolve) => {
-        acknowledge = resolve;
-      });
+      const pendingAcknowledgement = createDeferred<Acknowledgement>();
       const request = vi.fn(
         async (method: string, _params: unknown, options?: { signal?: AbortSignal }) => {
           if (method === "talk.client.toolCall") {
             expect(options).toBeUndefined();
-            return await pendingAcknowledgement;
+            return await pendingAcknowledgement.promise;
           }
           if (method === "chat.abort") {
             return { ok: true, aborted: true };
@@ -154,7 +149,7 @@ describe("RealtimeTalkSession consult handoff", () => {
       await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
 
       controller.abort();
-      acknowledge({ runId: "run-1", agentId: "voice", agentSessionKey });
+      pendingAcknowledgement.resolve({ runId: "run-1", agentId: "voice", agentSessionKey });
       await consult;
 
       expect(request).toHaveBeenCalledWith("chat.abort", {
@@ -306,10 +301,7 @@ describe("RealtimeTalkSession consult handoff", () => {
 
   it("keeps source-reply final text when the empty-final wait completes later", async () => {
     let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
-    let resolveWait: ((value: { runId: string; status: "ok" }) => void) | undefined;
-    const waitResult = new Promise<{ runId: string; status: "ok" }>((resolve) => {
-      resolveWait = resolve;
-    });
+    const waitResult = createDeferred<{ runId: string; status: "ok" }>();
     const request = vi.fn(async (method: string) => {
       if (method === "talk.client.toolCall") {
         setImmediate(() => {
@@ -345,7 +337,7 @@ describe("RealtimeTalkSession consult handoff", () => {
         };
       }
       if (method === "agent.wait") {
-        return await waitResult;
+        return await waitResult.promise;
       }
       throw new Error(`unexpected request: ${method}`);
     });
@@ -367,7 +359,7 @@ describe("RealtimeTalkSession consult handoff", () => {
       args: { question: "Check status" },
       submit,
     });
-    resolveWait?.({ runId: "run-1", status: "ok" });
+    waitResult.resolve({ runId: "run-1", status: "ok" });
     await Promise.resolve();
 
     expect(request).toHaveBeenCalledWith("agent.wait", {

--- a/ui/src/pages/chat/realtime-talk-webrtc-support.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-support.test.ts
@@ -31,7 +31,7 @@ describe("RealtimeTalkWebRtcOfferExchange", () => {
 
   it("resolves relative offer routes against the connected Gateway", async () => {
     const fetchMock = vi.fn(async () => new Response("answer-sdp"));
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.stubGlobal("fetch", fetchMock);
     const exchange = new RealtimeTalkWebRtcOfferExchange();
 
     await exchange.readAnswer({
@@ -103,16 +103,13 @@ describe("RealtimeTalkWebRtcOfferExchange", () => {
     });
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () =>
-          ({
-            ok: true,
-            status: 200,
-            headers: new Headers(),
-            body,
-            text: vi.fn(),
-          }) as unknown as Response,
-      ),
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body,
+        text: vi.fn(),
+      })),
     );
     const exchange = new RealtimeTalkWebRtcOfferExchange();
 
@@ -132,18 +129,15 @@ describe("RealtimeTalkWebRtcOfferExchange", () => {
       });
       vi.stubGlobal(
         "fetch",
-        vi.fn(
-          async () =>
-            ({
-              ok: true,
-              status: 200,
-              headers: new Headers({
-                "content-length": contentLength,
-              }),
-              body: { cancel, getReader },
-              text: vi.fn(),
-            }) as unknown as Response,
-        ),
+        vi.fn(async () => ({
+          ok: true,
+          status: 200,
+          headers: new Headers({
+            "content-length": contentLength,
+          }),
+          body: { cancel, getReader },
+          text: vi.fn(),
+        })),
       );
       const exchange = new RealtimeTalkWebRtcOfferExchange();
 
@@ -159,14 +153,11 @@ describe("RealtimeTalkWebRtcOfferExchange", () => {
     const cancel = vi.fn(() => new Promise<void>(() => {}));
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () =>
-          ({
-            ok: false,
-            status: 502,
-            body: { cancel },
-          }) as unknown as Response,
-      ),
+      vi.fn(async () => ({
+        ok: false,
+        status: 502,
+        body: { cancel },
+      })),
     );
     const exchange = new RealtimeTalkWebRtcOfferExchange();
 
@@ -178,14 +169,11 @@ describe("RealtimeTalkWebRtcOfferExchange", () => {
     const cancel = vi.fn(() => Promise.resolve());
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () =>
-          ({
-            ok: true,
-            status: 200,
-            body: { cancel },
-          }) as unknown as Response,
-      ),
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        body: { cancel },
+      })),
     );
     const exchange = new RealtimeTalkWebRtcOfferExchange();
 


### PR DESCRIPTION
## What Problem This Solves

Realtime Talk tests repeat manual Promise/resolver setup and add double casts where Vitest accepts the fixture value directly. During CI for this cleanup, the session diff panel’s first highlighting assertion also failed while using a one-second polling window for lazy loading and rendered output.

## Why This Change Was Made

Use the canonical `createDeferred` helper for three consult fixtures and remove five unnecessary casts from SDP fetch fixtures. `vi.stubGlobal` accepts `unknown`; the casts supplied no structural checking. Fixture values and resolution order remain unchanged.

The panel tests now await mounted updates and dynamic imports before checking syntax tokens, and settle imports before their existing teardown. This follows the same renderer's tool-card tests. Loading still starts after mount; no timeout is increased and no production code changes.

## User Impact

No user-visible behavior change. Production: **0 lines**; tests: **+43 / −58**. All 45 cases and 92 assertion lines in the three changed files remain. Coverage includes acknowledged-target cancellation, late-result timing, SDP size limits and reader release, deliberately non-settling cancellation, escaped source text, both diff layouts and rename languages.

## Evidence

The realtime suites passed the same normal command before and after their fixture cleanup:

```sh
pnpm test ui/src/pages/chat/realtime-talk-consult.test.ts ui/src/pages/chat/realtime-talk-webrtc-support.test.ts
```

```text
Test Files  2 passed (2)
     Tests  29 passed (29)
```

Those source afterimages, assertion order, and all 33 consult plus 14 SDP assertion lines remain unchanged.

[CI run 33735963574](https://github.com/openclaw/openclaw/actions/runs/33735963574) at `4740aeb` failed the first `split=false` panel highlight assertion: `.tok-string` was absent. Its [UI shard](https://github.com/openclaw/openclaw/actions/runs/33735963574/job/100586960053) reported 5,082 passes and one failure; both realtime suites passed there. That failed run is retained, with no retry requested.

The full panel and existing highlighting sibling passed before and after the readiness repair:

```sh
pnpm test ui/src/pages/chat/components/session-diff-panel.test.ts ui/src/pages/chat/components/chat-tool-cards.highlight.test.ts
```

```text
Test Files  2 passed (2)
     Tests  24 passed (24)
```

A temporary 1,250 ms delay in the real lazy module's evaluation reproduced the original first-case assertion failure: **1 failed / 23 passed**. With the candidate's own waits, the identical delay passed **24 / 24**. The trace showed loading begin after mount and expected syntax tokens present when readiness completed. Temporary instrumentation was restored exactly. This demonstrates the late-import readiness defect; it does not establish the original hosted transform's exact duration or cause. All 16 panel cases, 45 assertion lines and original case order remain.

```sh
node scripts/check-changed.mjs -- ui/src/pages/chat/realtime-talk-consult.test.ts ui/src/pages/chat/realtime-talk-webrtc-support.test.ts ui/src/pages/chat/components/session-diff-panel.test.ts
```

The full three-path gate passed, including UI test types, formatting, lint, repository guards and all three unused-export scans. A fresh isolated Codex review through P2 covered the complete three-file diff and found no actionable findings.

The three commits were mechanically refreshed onto `a5f36233` with unchanged test afterimages and three equal range-diff entries. After a normal frozen install, the same focused commands again passed **29 + 24 cases**, with unchanged case inventories. The complete three-path local gate and a fresh independent Codex P2 review also passed on the refreshed head.

[CI run 33741309578](https://github.com/openclaw/openclaw/actions/runs/33741309578) at `5e9aaacd` failed a separate real-Gateway denied-command scenario. Main now contains [the canonical repair in #137220](https://github.com/openclaw/openclaw/commit/51fe03b61727cb890d442d7c0a6eef044c58da4f); its three relevant source blobs match [successful CI 33750116253](https://github.com/openclaw/openclaw/actions/runs/33750116253), including the real-Gateway job. This refresh consumes that landed fix without adding a duplicate runtime patch. The failed run remains in the history; fresh exact-head CI is required for the refreshed head.

This PR’s UI validation is synthetic test-fixture proof; no live Gateway or microphone operation was performed for those UI tests.
