### PR TITLE
refactor: share Control UI PR subscription lifecycle ownership

### DIFF
--- a/src/gateway/control-ui-session-pr-subscriptions.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.ts
@@ -127,8 +127,8 @@ export function parseControlUiSessionPullRequestsSubscribeParams(
 export function createControlUiSessionPullRequestSubscriptions(
   deps: SubscriptionDeps,
 ): ControlUiSessionPullRequestSubscriptions {
+  // Only nonempty replace-sets enter this map; each row also owns its hydration generation.
   const subscriptions = new Map<string, { keys: Set<string>; delivered: Set<string> }>();
-  const replacementTokens = new Map<string, object>();
   const snapshots = new Map<
     string,
     { hash: string; snapshot: ControlUiSessionPullRequestSnapshot }
@@ -217,7 +217,7 @@ export function createControlUiSessionPullRequestSubscriptions(
   };
 
   const schedulePoll = () => {
-    if (stopped || timer !== null || watchedKeys().size === 0) {
+    if (stopped || timer !== null || subscriptions.size === 0) {
       return;
     }
     timer = setTimer(() => {
@@ -273,16 +273,9 @@ export function createControlUiSessionPullRequestSubscriptions(
     if (!normalizedConnId || deps.isConnectionActive?.(normalizedConnId) === false) {
       return;
     }
-    const replacementToken = {};
-    replacementTokens.set(normalizedConnId, replacementToken);
     const next = new Set(sessionKeys);
     if (next.size === 0) {
-      subscriptions.delete(normalizedConnId);
-      pruneOrphans();
-      if (watchedKeys().size === 0 && timer !== null) {
-        clearTimer(timer);
-        timer = null;
-      }
+      unsubscribe(normalizedConnId);
       return;
     }
     const delivered = subscriptions.get(normalizedConnId)?.delivered ?? new Set<string>();
@@ -291,7 +284,8 @@ export function createControlUiSessionPullRequestSubscriptions(
         delivered.delete(sessionKey);
       }
     }
-    subscriptions.set(normalizedConnId, { keys: next, delivered });
+    const subscription = { keys: next, delivered };
+    subscriptions.set(normalizedConnId, subscription);
     pruneOrphans();
     schedulePoll();
 
@@ -311,7 +305,7 @@ export function createControlUiSessionPullRequestSubscriptions(
     }
 
     await loadKeysInParallel(pendingKeys, async (sessionKey) => {
-      if (stopped || replacementTokens.get(normalizedConnId) !== replacementToken) {
+      if (stopped || subscriptions.get(normalizedConnId) !== subscription) {
         return;
       }
       const previous = snapshots.get(sessionKey);
@@ -319,7 +313,7 @@ export function createControlUiSessionPullRequestSubscriptions(
       const snapshot = await loadSnapshot(sessionKey, refresh);
       // A later replace-set owns the connection immediately; an older async
       // initial load must never publish keys after that ownership changed.
-      if (replacementTokens.get(normalizedConnId) !== replacementToken) {
+      if (subscriptions.get(normalizedConnId) !== subscription) {
         return;
       }
       const hash = snapshotHash(snapshot);
@@ -339,10 +333,9 @@ export function createControlUiSessionPullRequestSubscriptions(
     if (!normalizedConnId) {
       return;
     }
-    replacementTokens.delete(normalizedConnId);
     subscriptions.delete(normalizedConnId);
     pruneOrphans();
-    if (watchedKeys().size === 0 && timer !== null) {
+    if (subscriptions.size === 0 && timer !== null) {
       clearTimer(timer);
       timer = null;
     }
@@ -355,7 +348,6 @@ export function createControlUiSessionPullRequestSubscriptions(
       timer = null;
     }
     subscriptions.clear();
-    replacementTokens.clear();
     snapshots.clear();
     inflight.clear();
   };


### PR DESCRIPTION
## What Problem This Solves

Control UI PR subscriptions kept a second map of replacement tokens alongside the subscriptions they identified. Empty watch replacements removed the subscription but left a token entry until disconnect. Use the privately owned subscription row as its hydration generation, and route empty replacements through the existing unsubscribe owner. Since stored rows always have nonempty watch sets, checking whether any watches exist now reads the subscription map instead of rebuilding their union.

## Why This Change Was Made

The key union remains where actual keys are needed. Replacement, disconnect, stop, forced refresh ordering, four-load concurrency, per-connection delivered tracking, parser limits and public RPC behavior remain unchanged. Production LOC is +8/−16 (**−8**); tests/support are unchanged. No configuration, protocol, storage, or dependency change.

## User Impact

PR subscriptions retain their existing behavior with less duplicate lifecycle bookkeeping and fewer temporary union sets. There is no visual UI change.

## Evidence

- 148 ordered actual-owner observations match across 12 scenarios, including superseded and queued loads, empty then resubscribe, cached replay, overlapping watches, refresh behind polling, inactive connections, stop and synchronous broadcast re-entry.
- The same trace constructs 64 → 36 watched-union Sets and makes 470 → 239 Set.add calls. These are logical operation counts, not bytes, RSS or latency.
- 29 existing subscription-owner and RPC tests passed. The full changed-file gate, format and diff checks passed with unchanged source pins. Independent managed Codex review found no actionable findings through P2.
- A bounded WeakRef witness records the lifetime tradeoff: a retired row is now retained until its pending replace settles; its two Sets were already retained in both versions. After settlement all three are collectible. No large retained-memory reduction is claimed.

## Review context and limits

The RPC parser produces fresh bounded string arrays; the UI sends an empty array when hidden. The private row cannot be mutated by callers, so row identity has the same supersession meaning as the former token. Read the full owner, RPC producer, browser watch store, Gateway lifecycle wiring, default loader, tests and installed p-limit/queue implementation. A separate map would duplicate that authority; downstream guards would leave its teardown divergence.

The owner trace uses the existing injected synthetic loader/timer/broadcast seam. Real Gateway proof of the final combined candidate is pending and will be recorded before landing; this local proof does not claim browser or GitHub API execution. The small empty-token retention is shown before editing; no implementation-coupled map-size test was added to the product suite because existing behavior tests and the recorded lifecycle probe cover this refactor. No unrelated follow-up is introduced.
