### PR TITLE
fix(infra): keep gateway restart timing correct when the system clock steps

### DIFF
--- a/src/infra/restart.monotonic-clock.test.ts
+++ b/src/infra/restart.monotonic-clock.test.ts
@@ -1,0 +1,88 @@
+// Regression: restart control-flow deadlines must follow the monotonic clock.
+// A wall-clock step (NTP correction, VM suspend/resume) must not extend the
+// SIGUSR1 authorization grace, fire deferral timeouts early, or collapse the
+// restart cooldown. setSystemTime moves only the wall clock; the faked
+// performance clock stays monotonic, which models the real failure mode.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js";
+import {
+  consumeGatewaySigusr1RestartAuthorization,
+  deferGatewayRestartUntilIdle,
+  markGatewaySigusr1RestartHandled,
+  requestGatewayRestartWithSignalAdmission,
+  resetGatewayRestartStateForInProcessRestart,
+  scheduleGatewaySigusr1Restart,
+} from "./restart.js";
+
+const sigusr1Handler = () => {};
+
+describe("restart control-flow deadlines use the monotonic clock", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetGatewayRestartStateForInProcessRestart();
+    resetGatewayWorkAdmission();
+    process.on("SIGUSR1", sigusr1Handler);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    resetGatewayRestartStateForInProcessRestart();
+    resetGatewayWorkAdmission();
+    process.removeListener("SIGUSR1", sigusr1Handler);
+  });
+
+  it("expires SIGUSR1 authorization grace on monotonic time despite wall-clock rollback", () => {
+    expect(requestGatewayRestartWithSignalAdmission("probe")).toEqual({ status: "emitted" });
+    vi.advanceTimersByTime(4_000);
+    vi.setSystemTime(Date.now() - 10_000);
+    vi.advanceTimersByTime(4_000); // monotonic 8s > 5s grace
+    expect(consumeGatewaySigusr1RestartAuthorization()).toBe(false);
+  });
+
+  it("keeps SIGUSR1 authorization grace when monotonic time is inside the window", () => {
+    expect(requestGatewayRestartWithSignalAdmission("probe")).toEqual({ status: "emitted" });
+    vi.advanceTimersByTime(4_000);
+    vi.setSystemTime(Date.now() - 10_000); // wall-clock rollback only
+    expect(consumeGatewaySigusr1RestartAuthorization()).toBe(true);
+  });
+
+  it("does not fire the deferral timeout early on a wall-clock forward jump", () => {
+    const onTimeout = vi.fn();
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => 1,
+      hooks: { onTimeout },
+      maxWaitMs: 120_000,
+    });
+    vi.advanceTimersByTime(10_000);
+    vi.setSystemTime(Date.now() + 300_000); // VM suspend/resume
+    vi.advanceTimersByTime(500);
+    expect(onTimeout).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(110_000); // monotonic reaches the 120s cap
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires the deferral timeout at the cap despite wall-clock rollback", () => {
+    const onTimeout = vi.fn();
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => 1,
+      hooks: { onTimeout },
+      maxWaitMs: 120_000,
+    });
+    vi.advanceTimersByTime(119_000);
+    vi.setSystemTime(Date.now() - 60_000);
+    vi.advanceTimersByTime(1_000); // monotonic 120s reaches the cap
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the restart cooldown across a wall-clock forward jump", () => {
+    expect(requestGatewayRestartWithSignalAdmission("first")).toEqual({ status: "emitted" });
+    expect(consumeGatewaySigusr1RestartAuthorization()).toBe(true);
+    markGatewaySigusr1RestartHandled();
+
+    vi.setSystemTime(Date.now() + 60_000);
+    const second = scheduleGatewaySigusr1Restart({ delayMs: 0, reason: "second" });
+    expect(second.cooldownMsApplied).toBe(30_000);
+    expect(second.delayMs).toBe(30_000);
+  });
+});

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -33,6 +33,11 @@ const LAUNCHCTL_ALREADY_LOADED_EXIT_CODE = 37;
 
 const restartLog = createSubsystemLogger("restart");
 
+// Control-flow deadlines (SIGUSR1 grace, deferral caps, restart cooldown) run on
+// the monotonic clock: a wall-clock step (NTP correction, VM suspend/resume)
+// would otherwise extend authorization grace or fire/skip deferral timeouts.
+const monotonicNow = () => performance.now();
+
 let sigusr1AuthorizedCount = 0;
 let sigusr1AuthorizedUntil = 0;
 let sigusr1ExternalAllowed = false;
@@ -42,7 +47,10 @@ let emittedRestartToken = 0;
 let consumedRestartToken = 0;
 let emittedRestartReason: string | undefined;
 let emittedRestartIntent: GatewayRestartIntent | undefined;
-let lastRestartEmittedAt = 0;
+// null marks "never emitted": a 0 sentinel would collide with the monotonic
+// clock origin and impose a phantom cooldown during the first RESTART_COOLDOWN_MS
+// of process life.
+let lastRestartEmittedAt: number | null = null;
 let pendingRestartTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingRestartDueAt = 0;
 let pendingRestartReason: string | undefined;
@@ -136,7 +144,7 @@ function clearGatewayRestartTransientState(): void {
   consumedRestartToken = 0;
   emittedRestartReason = undefined;
   emittedRestartIntent = undefined;
-  lastRestartEmittedAt = 0;
+  lastRestartEmittedAt = null;
   clearActiveDeferralPolls();
   clearPendingScheduledRestart();
   clearPendingRestartSignalAdmission();
@@ -235,7 +243,7 @@ function emitGatewayRestart(reasonOverride?: string, intent?: GatewayRestartInte
     rollBackGatewayRestartEmission();
     return false;
   }
-  lastRestartEmittedAt = Date.now();
+  lastRestartEmittedAt = monotonicNow();
   return true;
 }
 
@@ -283,7 +291,7 @@ export function requestGatewayRestartWithSignalAdmission(
   return { status: hadUnconsumedRestartSignal ? "coalesced" : "failed" };
 }
 
-function resetSigusr1AuthorizationIfExpired(now = Date.now()) {
+function resetSigusr1AuthorizationIfExpired(now = monotonicNow()) {
   if (sigusr1AuthorizedCount <= 0 || now <= sigusr1AuthorizedUntil) {
     return;
   }
@@ -300,7 +308,7 @@ export function isGatewaySigusr1RestartExternallyAllowed() {
 }
 
 function authorizeGatewaySigusr1Restart() {
-  const expiresAt = Date.now() + SIGUSR1_AUTH_GRACE_MS;
+  const expiresAt = monotonicNow() + SIGUSR1_AUTH_GRACE_MS;
   sigusr1AuthorizedCount += 1;
   if (expiresAt > sigusr1AuthorizedUntil) {
     sigusr1AuthorizedUntil = expiresAt;
@@ -713,7 +721,7 @@ export function deferGatewayRestartUntilIdle(opts: {
     stopPoll();
   };
   const handle = { cancel };
-  const startedAt = Date.now();
+  const startedAt = monotonicNow();
   let nextStillPendingAt = startedAt + DEFAULT_DEFERRAL_STILL_PENDING_WARN_MS;
   const attemptEmission = (params: {
     intent?: GatewayRestartIntent;
@@ -775,10 +783,10 @@ export function deferGatewayRestartUntilIdle(opts: {
       attemptEmission({ notifyReady: true });
       return;
     }
-    const elapsedMs = Date.now() - startedAt;
-    if (Date.now() >= nextStillPendingAt) {
+    const elapsedMs = monotonicNow() - startedAt;
+    if (monotonicNow() >= nextStillPendingAt) {
       opts.hooks?.onStillPending?.(current, elapsedMs);
-      nextStillPendingAt = Date.now() + DEFAULT_DEFERRAL_STILL_PENDING_WARN_MS;
+      nextStillPendingAt = monotonicNow() + DEFAULT_DEFERRAL_STILL_PENDING_WARN_MS;
     }
     if (maxWaitMs !== undefined && elapsedMs >= maxWaitMs) {
       stopPoll();
@@ -997,9 +1005,9 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       : process.platform === "win32"
         ? "supervisor"
         : "signal";
-  const nowMs = Date.now();
+  const nowMs = monotonicNow();
   const cooldownMsApplied =
-    opts?.skipCooldown === true
+    opts?.skipCooldown === true || lastRestartEmittedAt === null
       ? 0
       : Math.max(0, lastRestartEmittedAt + RESTART_COOLDOWN_MS - nowMs);
   const restartResultBase = {

--- a/test/tsconfig/tsconfig.core.test.infra.json
+++ b/test/tsconfig/tsconfig.core.test.infra.json
@@ -6,5 +6,11 @@
   "include": [
     "../../src/infra/**/*.test.ts",
     "../../src/infra/**/*.test.tsx"
+  ],
+  "exclude": [
+    "../../node_modules",
+    "../../dist",
+    "../../**/dist/**",
+    "../../src/infra/outbound/**"
   ]
 }

--- a/test/tsconfig/tsconfig.core.test.messaging.json
+++ b/test/tsconfig/tsconfig.core.test.messaging.json
@@ -8,6 +8,8 @@
     "../../src/auto-reply/**/*.test.tsx",
     "../../src/channels/**/*.test.ts",
     "../../src/channels/**/*.test.tsx",
+    "../../src/infra/outbound/**/*.test.ts",
+    "../../src/infra/outbound/**/*.test.tsx",
     "../../src/media/**/*.test.ts",
     "../../src/media/**/*.test.tsx"
   ]


### PR DESCRIPTION
Related: #135292, #86541, #133354, #128374 (merged monotonic-clock fixes); #134703 (open, different surface — Code Mode budget)

## What Problem This Solves

Fixes an issue where gateway restarts scheduled while work was pending could fire too early or never fire when the system clock steps (NTP correction, VM suspend/resume). On a forward jump (e.g. a laptop or VM waking from suspend), the restart-deferral timeout fired with the idle check skipped while sessions were still active, interrupting them; on a backward step the timeout cap never engaged and the restart silently never happened. The same clock steps also extended the SIGUSR1 external-restart authorization grace beyond its intended 5s window (or expired it early), and collapsed the 30s restart cooldown.

## Why This Change Was Made

Restart control-flow deadlines (SIGUSR1 authorization grace, deferral elapsed/timeout, restart cooldown) were computed with `Date.now()` wall-clock values; a wall-clock step distorts every duration comparison. They now run on `performance.now()` (monotonic) via a file-local `monotonicNow`, matching the in-tree precedent (`src/infra/startup-migration-checkpoint.ts`, `src/cli/daemon-cli/restart-health.ts`). `lastRestartEmittedAt` changed from a `0` sentinel to `null`, because `0` is a valid monotonic timestamp and would impose a phantom cooldown during the first 30s of process life.

Non-goals / boundaries: scheduled-restart delivery via `setTimeout` was already monotonic (Node timers) and is untouched; `restart-intent.ts` keeps wall-clock timestamps because they persist across processes, where wall clock is the only shared clock; no public API, config, or plugin-SDK surface changes.

## User Impact

Operators running the gateway on hosts with NTP stepping or VMs/laptops that suspend and resume get restart timing that matches real elapsed time: pending-work restarts no longer fire mid-session after a resume, no longer hang silently after a backward step, the external SIGUSR1 authorization window is exactly its intended 5s, and the restart cooldown cannot be bypassed by a clock jump. No behavior change when the clock does not step.

## Evidence

### Before fix

New regression tests against pre-fix code (via `git stash` of `src/infra/restart.ts`):

```
× expires SIGUSR1 authorization grace on monotonic time despite wall-clock rollback
✓ keeps SIGUSR1 authorization grace when monotonic time is inside the window
× does not fire the deferral timeout early on a wall-clock forward jump
× fires the deferral timeout at the cap despite wall-clock rollback
× keeps the restart cooldown across a wall-clock forward jump
Tests  4 failed | 1 passed (5)
```

The failures reproduce the reported behavior: grace extended past 5s after a backward step, deferral timeout fired after ~10s monotonic time (maxWait 120s) with the idle check skipped while work was still pending, deferral timeout delayed past its cap after a backward step, and cooldown collapsed to 0 after a forward jump.

### After fix

```
pnpm test src/infra/restart.monotonic-clock.test.ts
✓ × 5 — Tests 5 passed (5)

pnpm test <9 restart-related test files>
Tests  206 passed (206)

tsgo core incremental: clean
tsgo core-test infra shard: clean
oxlint (config/tsconfig/oxlint.core.json): 0 warnings, 0 errors
oxfmt --check: clean
```

- Regression gate: the 4 failing tests above fail on pre-fix code for the intended reasons and pass after the fix.
- Review: `openclaw-pr-review` PASSED, best-fix verdict `best`, no P0/P1/P2 findings; sibling surfaces audited (`restart-intent.ts` cross-process timestamps correctly excluded; all `scheduleGatewaySigusr1Restart` callers consume returned values as durations only).

### Real behavior proof (real OS processes, stepped wall clock)

ClawSweeper asked for final-effect proof through the authorization boundary, beyond Vitest fake timers. Both scenarios below run the real `src/infra/restart.ts` in a real Node child process (no mocks; SIGUSR1 delivered via `process.kill`), with the wall clock stepped at runtime by libfaketime (`FAKETIME_DONT_FAKE_MONOTONIC=1`, so only `CLOCK_REALTIME` moves — exactly what an NTP correction / VM suspend-resume does to a live process; Node's monotonic clock is untouched). Each scenario runs twice: against upstream/main's `restart.ts` (bug expected) and against this PR's (fix expected). The listener mirrors the Gateway run loop's SIGUSR1 consumer (`src/cli/gateway-cli/run-loop.ts`): consume authorization -> restart I/O, otherwise log-and-ignore before any restart I/O.

Scenario A — expired internal SIGUSR1 authorization rejected before restart I/O. An internal `requestGatewayRestartWithSignalAdmission("update.run")` grants a 5s grace authorization that stays pending unconsumed (the run loop's async handler consumes only after `await loadGatewayLifecycleRuntimeModule`). The wall clock steps back 1h; at monotonic 8.6s (grace long expired) an external SIGUSR1 arrives.

```
variant=upstream/main  (Date.now() arithmetic)
[child 5326ms]  wall clock stepped by -3600 (spec file updated)
[child 11827ms] sending external SIGUSR1 at mono=8580ms
[child 11828ms] RESTART-IO #1 (external SIGUSR1 honored via stale authorization)
VERDICT: BUG — monotonically expired internal authorization was accepted; external SIGUSR1 drove restart I/O   (exit 10)

variant=PR  (performance.now() arithmetic)
[child 5292ms]  wall clock stepped by -3600 (spec file updated)
[child 11793ms] sending external SIGUSR1 at mono=8564ms
[child 11794ms] SIGUSR1 restart ignored (not authorized; commands.restart=false).
VERDICT: OK — expired internal authorization rejected before restart I/O   (exit 0)
```

Scenario B — active-work deferral cap fires on monotonic elapsed time. `deferGatewayRestartUntilIdle` with `getPendingCount: () => 1` (work never drains; only the 4000ms cap can end deferral) and a +10min wall-clock forward jump at monotonic 1s.

```
variant=upstream/main
[child 4521ms] wall after step=...+600s
[child 4523ms] onTimeout pending=1 elapsedMs(reported)=601004 atMono=1006ms
VERDICT: BUG — deferral timeout fired at monotonic 1006ms, 2994ms early vs 4000ms cap   (exit 12)

variant=PR
[child 4331ms] wall after step=...+600s
[child 7341ms] onTimeout pending=1 elapsedMs(reported)=4012 atMono=4014ms
VERDICT: OK — deferral cap fired at monotonic 4014ms (cap 4000ms)   (exit 0)
```

Both forced-timeout emissions also pass through the real restart-signal admission fence (`[admission] closed/reopened: restart-signal fence`) and drive actual restart I/O only in the intended cases.

### Rebase note

The failing CI shards on the previous head (`gateway-tool.test.ts` / `commands-update.test.ts` expecting `operatorRoleActor`) were unrelated to this diff: main temporarily shipped the producer without the matching assertion update; #137196 fixed the assertions on main. Rebased onto current `upstream/main` (head `173951ed9cb`); those shards' code is untouched by this PR.

