### PR TITLE
refactor: simplify Code Mode namespace runtime construction

### DIFF
--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -150,17 +150,12 @@ function createCodeModeNamespaceCatalogTool(
   };
 }
 
-function createCodeModeNamespaceLocalFunction(
-  toolName: string,
+function createCodeModeNamespaceApi(
   input: CodeModeNamespaceToolInputMapper,
 ): CodeModeNamespaceToolCall {
-  const normalizedToolName = toolName.trim();
-  if (!normalizedToolName) {
-    throw new Error("Code mode namespace local function name must be non-empty.");
-  }
   return {
     [CODE_MODE_NAMESPACE_TOOL_CALL]: true,
-    toolName: normalizedToolName,
+    toolName: "$api",
     local: true,
     input,
   };
@@ -429,19 +424,15 @@ function createMcpNamespaceModel(
       params: buildMcpParamDocs(entry.parameters),
     });
   }
-  const docs = [...serverDocs.values()]
-    .map((server) =>
-      Object.assign({}, server, {
-        tools: server.tools.toSorted((a, b) => a.method.localeCompare(b.method)),
-      }),
-    )
-    .toSorted((a, b) => a.identifier.localeCompare(b.identifier));
-  root.$api = createCodeModeNamespaceLocalFunction("$api", (args) =>
-    buildMcpApiResponse({ servers: docs, args }),
-  );
+  const docs = Array.from(serverDocs.values(), (server) => {
+    // The model owns these rows until namespace/API publication.
+    server.tools = server.tools.toSorted((a, b) => a.method.localeCompare(b.method));
+    return server;
+  }).toSorted((a, b) => a.identifier.localeCompare(b.identifier));
+  root.$api = createCodeModeNamespaceApi((args) => buildMcpApiResponse({ servers: docs, args }));
   for (const server of docs) {
     const serverScope = scopeAtPath(root, [server.identifier]);
-    serverScope.$api = createCodeModeNamespaceLocalFunction("$api", (args) =>
+    serverScope.$api = createCodeModeNamespaceApi((args) =>
       buildMcpApiResponse({ servers: docs, server, args }),
     );
   }
@@ -591,24 +582,16 @@ function serializeNamespaceScopeValue(
   }
 }
 
-function resolveNamespacePath(
-  scope: CodeModeNamespaceScope,
-  path: readonly string[],
-): {
-  target: unknown;
-  parent: unknown;
-} {
+function resolveNamespacePath(scope: CodeModeNamespaceScope, path: readonly string[]): unknown {
   let current: unknown = scope;
-  let parent: unknown = undefined;
   for (const segment of path) {
     assertNamespacePathSegment(segment);
-    parent = current;
     if (!isRecord(current) && !Array.isArray(current)) {
-      return { target: undefined, parent };
+      return undefined;
     }
     current = (current as Record<string, unknown>)[segment];
   }
-  return { target: current, parent };
+  return current;
 }
 
 /** Creates the runtime descriptor/invocation layer for visible namespaces. */
@@ -616,10 +599,11 @@ export function createCodeModeNamespaceRuntime(
   catalog: readonly CodeModeNamespaceCatalogEntry[] = [],
 ): CodeModeNamespaceRuntime {
   const model = createMcpNamespaceModel(catalog);
-  const entries = model ? [createMcpNamespaceEntry(model)] : [];
-  const byId = new Map(entries.map((entry) => [entry.descriptor.id, entry]));
+  const entry = model ? createMcpNamespaceEntry(model) : undefined;
+  // Registration stays stable if a consumer mutates the exposed descriptor.
+  const registeredId = entry?.descriptor.id;
   return {
-    descriptors: entries.map((entry) => entry.descriptor),
+    descriptors: entry ? [entry.descriptor] : [],
     apiFiles: [
       {
         path: "agents.d.ts",
@@ -630,8 +614,7 @@ export function createCodeModeNamespaceRuntime(
       ...createMcpApiVirtualFiles(model?.docs ?? []),
     ],
     async invoke(namespaceId, path, args, executeTool) {
-      const entry = byId.get(namespaceId);
-      if (!entry) {
+      if (!entry || namespaceId !== registeredId) {
         throw new Error(`Unknown code mode namespace: ${namespaceId}`);
       }
       for (const segment of path) {
@@ -640,7 +623,7 @@ export function createCodeModeNamespaceRuntime(
       if (!entry.callablePaths.has(namespacePathKey(path))) {
         throw new Error(`Code mode namespace path is not callable: ${path.join(".")}`);
       }
-      const { target } = resolveNamespacePath(entry.scope, path);
+      const target = resolveNamespacePath(entry.scope, path);
       if (!isCodeModeNamespaceToolCall(target)) {
         throw new Error(`Code mode namespace path is not callable: ${path.join(".")}`);
       }


### PR DESCRIPTION
## What Problem This Solves

Code Mode namespace construction retained bookkeeping for a more general registry than the runtime builds: an unused path parent, an index map for zero or one MCP entry, copies of fresh private documentation rows, and a generic local-function name accepted only as `$api`.

## Why This Change Was Made

Return the resolved target directly, keep the optional runtime entry and its initially registered ID, decorate the newly owned documentation rows before publication, and specialize the private API marker constructor to its two existing `$api` call sites. Capturing the initial ID preserves dispatch even if a caller later mutates the exposed descriptor. Both path-validation passes, callable checks, mapper receiver, default arguments, effect receipts, tool dispatch and deterministic document ordering remain in place.

The raw production delta is +18/−35 (**−17**); five removed lines are formatter-only, so the substantive reduction is **12 lines**. No tests/support, public API, configuration, protocol, persistent store or dependency change. The unused server-name field remains because constructing it performs an observable metadata read; removing that read would violate the preservation boundary.

## User Impact

Namespace tool calls, API declarations and MCP defaults retain their behavior with fewer intermediate objects and private construction paths. No general Gateway RSS or latency improvement is claimed for this scope.

## Evidence

- 27 exact actual-owner observations match, including the original 23 dispatch/effect/path cases plus descriptor mutation, descriptor-array mutation and empty-runtime behavior. Multi-server ordering and both root/server API calls are covered.
- The original path helper created 15 target/parent wrappers across the observed invocations; it now creates none. Constructor coverage confirms the single-entry index maps and staging arrays disappear, as do fresh server-row copies and four constant-name trims. These are logical operation counts, not heap byte measurements.
- 27 existing namespace/MCP tests passed. The final full changed-file gate passed with source pins unchanged; independent managed Codex review found no actionable P0–P2 findings. Every local process group joined and temporary runtime was removed.
- All prior proof stages are retained. The intermediate process pair had higher peak RSS (+1.3125 MiB); the final pair differs by −0.4375 MiB. Both include imports/instrumentation and varying host load, so neither supports a process-memory or speed claim.

The full owner, runtime/prompt callers, MCP API builder, metadata alias path, tests, original helper history and relevant installed parser contracts were inspected. The private API helper has had exactly two literal `$api` callers since its introduction; it is not an external contract. A final immutable composite will also exercise real OpenAI turns, web, Unicode output and MCP default/explicit dispatch before landing.
