### PR TITLE
fix(test): stabilize Windows process census

### DIFF
--- a/test/scripts/ci-checkout.test-support.ts
+++ b/test/scripts/ci-checkout.test-support.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
-import { fork, type ChildProcess } from "node:child_process";
+import { fork, spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
 import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import net, { type Socket } from "node:net";
 import path from "node:path";
+import { createInterface } from "node:readline";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
@@ -49,10 +53,28 @@ const reportSchema = z.object({
 });
 type Report = z.infer<typeof reportSchema>;
 type CloseResult = { code: number | null; signal: NodeJS.Signals | null };
+type CensusService = {
+  env: NodeJS.ProcessEnv;
+  token: string;
+  connect(payload?: Buffer): Promise<Socket>;
+  exchange(payload: Buffer, options?: { end?: boolean; timeoutMs?: number }): Promise<unknown>;
+  request(request: { op: string; [key: string]: unknown }, timeoutMs?: number): Promise<unknown>;
+  waitForExit(timeoutMs?: number): Promise<CloseResult>;
+};
 
 export const ciCheckoutFixture = fileURLToPath(
   new URL("./fixtures/ci-platform-checkout.mjs", import.meta.url),
 );
+const windowsCensusFixture = fileURLToPath(
+  new URL("./fixtures/ci-windows-process-census.py", import.meta.url),
+);
+const within = <T>(promise: Promise<T>, timeoutMs: number, label: string) =>
+  Promise.race([
+    promise,
+    delay(timeoutMs, undefined, { ref: false }).then(() => {
+      throw new Error(`${label} timed out`);
+    }),
+  ]);
 const workflow = parse(readFileSync(".github/workflows/ci.yml", "utf8")) as {
   jobs: Record<string, { steps: Step[] }>;
 };
@@ -69,21 +91,22 @@ export function renderGitTestClock(
   source: string,
   options: { realClock?: boolean; realDrain?: boolean } = {},
 ) {
+  let rendered = source;
   // Command deadlines and TERM grace are independent. Real-clock callers keep
   // real grace unless they explicitly opt into the fixture's immediate escalation.
   if (!(options.realDrain ?? options.realClock)) {
-    source = source.replace(
+    rendered = rendered.replace(
       "kill_at = deadline - cleanup_seconds / 2",
       "kill_at = time.monotonic()",
     );
   }
   if (options.realClock) {
-    return source;
+    return rendered;
   }
   // Only a ready, deliberately stalled tree advances the fetch clock. Real
   // process startup and teardown retain their independent wall-clock watchdogs.
   return (
-    source
+    rendered
       .replace(/fetch_timeout_seconds = [^\n]+/u, "fetch_timeout_seconds = 2")
       .replace(
         "def run_git(",
@@ -125,6 +148,96 @@ export function expectCiCheckoutCleanup(report: Report) {
     [],
     "Git descendants survived BEFORE deletion, reuse, consumption, or exit",
   );
+}
+
+export async function withWindowsCensusService<T>(
+  run: (service: CensusService) => T | Promise<T>,
+  options: { parentPid?: number } = {},
+): Promise<T> {
+  assert.equal(process.platform, "win32", "Windows census service requires Windows");
+  const token = randomUUID();
+  const child = spawn("python", ["-I", "-S", windowsCensusFixture], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      OPENCLAW_CI_CENSUS_TOKEN: token,
+      OPENCLAW_CI_CENSUS_PARENT_PID: String(options.parentPid ?? process.pid),
+      OPENCLAW_CI_CENSUS_MAX_LIFETIME_MS: "49000",
+    },
+  });
+  let stderr = "";
+  child.stderr?.on("data", (data) => (stderr += String(data)));
+  const closed = once(child, "close").then(([code, signal]) => ({ code, signal }));
+  const stdout = child.stdout;
+  assert(stdout);
+  const lines = createInterface({ input: stdout });
+  const [line] = await within(once(lines, "line"), 5_000, "Census service readiness");
+  lines.close();
+  const ready = JSON.parse(String(line)) as { v: number; port: number };
+  assert.deepEqual(Object.keys(ready).toSorted(), ["port", "v"]);
+  assert.equal(ready.v, 1);
+  assert(Number.isInteger(ready.port) && ready.port >= 1 && ready.port <= 65_535);
+
+  const connect = async (payload?: Buffer) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port: ready.port });
+    if (payload) {
+      socket.write(payload);
+    }
+    await within(once(socket, "connect"), 2_000, "Census connection");
+    socket.on("error", () => {});
+    return socket;
+  };
+  const exchange = async (
+    payload: Buffer,
+    { end = true, timeoutMs = 2_000 }: { end?: boolean; timeoutMs?: number } = {},
+  ) => {
+    const socket = await connect();
+    const chunks: Buffer[] = [];
+    socket.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    if (end) {
+      socket.end(payload);
+    } else {
+      socket.write(payload);
+    }
+    await within(once(socket, "end"), timeoutMs, "Census request");
+    const data = Buffer.concat(chunks).toString();
+    assert(Buffer.byteLength(data) <= 16_384, "Census response was oversized");
+    const [responseLine, tail, extra] = data.split("\n");
+    assert(responseLine && tail === "" && extra === undefined, "Census response frame was invalid");
+    return JSON.parse(responseLine);
+  };
+  const waitForExit = (timeoutMs = 2_000) => within(closed, timeoutMs, "Census service exit");
+  const service: CensusService = {
+    env: {
+      OPENCLAW_CI_CENSUS_TOKEN: token,
+      OPENCLAW_CI_CENSUS_PORT: String(ready.port),
+      OPENCLAW_CI_CENSUS_DEADLINE_MS: String(Date.now() + 45_000),
+    },
+    token,
+    connect,
+    exchange,
+    request: (request, timeoutMs) =>
+      exchange(Buffer.from(`${JSON.stringify({ v: 1, token, ...request })}\n`), { timeoutMs }),
+    waitForExit,
+  };
+  try {
+    return await run(service);
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      try {
+        await service.request({ op: "shutdown" }, 1_000);
+      } catch {}
+    }
+    let exit;
+    try {
+      exit = await waitForExit();
+    } catch {
+      child.kill("SIGKILL");
+      exit = await closed;
+    }
+    assert.deepEqual(exit, { code: 0, signal: null }, stderr);
+    assert.equal(stderr, "");
+  }
 }
 
 export async function withCiCheckoutFixture<T>(

--- a/test/scripts/ci-checkout.test-support.ts
+++ b/test/scripts/ci-checkout.test-support.ts
@@ -19,6 +19,12 @@ const processRecord = z.object({
   instance: z.string(),
   creationTime: z.string().regex(/^\d+$/u).optional(),
 });
+const processDiagnostic = z.object({
+  command: z.string(),
+  code: z.number().nullable(),
+  signal: z.string().nullable(),
+  stderr: z.string().max(4_096),
+});
 const reportSchema = z.object({
   code: z.number().nullable(),
   cancelledDuringCleanup: z.boolean(),
@@ -39,6 +45,7 @@ const reportSchema = z.object({
     }),
   ),
   output: z.string(),
+  processDiagnostics: z.record(z.enum(["censusService", "sentinel"]), processDiagnostic.nullable()),
 });
 type Report = z.infer<typeof reportSchema>;
 type CloseResult = { code: number | null; signal: NodeJS.Signals | null };

--- a/test/scripts/ci-platform-checkout.test.ts
+++ b/test/scripts/ci-platform-checkout.test.ts
@@ -109,6 +109,17 @@ it.concurrent.each([
           path.join(root, "checkout.sh"),
           setupFailure ? "printf 'unexpected workflow invocation\\n' >&2\nexit 99\n" : accelerated,
         );
+        if (process.platform === "win32" && scenario === "early-leader-exit") {
+          const preload = path.join(root, "reject-python-spawn-sync.cjs");
+          writeFileSync(
+            preload,
+            `const cp=require("node:child_process"), original=cp.spawnSync;
+cp.spawnSync=(command,...args)=>{if(/python/i.test(require("node:path").basename(command))){const error=new Error("legacy census timed out");error.code="ETIMEDOUT";throw error}return original(command,...args)};
+require("node:module").syncBuiltinESMExports();`,
+          );
+          return { NODE_OPTIONS: `--require=${preload}` };
+        }
+        return undefined;
       },
       (report, result, stderr, root) => {
         const workspace = path.join(root, "workspace");
@@ -130,6 +141,13 @@ it.concurrent.each([
         expect(result, stderr).toEqual({ code: 0, signal: null });
         expect(report.error, stderr).toBeUndefined();
         expectCiCheckoutCleanup(report);
+        if (process.platform === "win32") {
+          expect(report.processDiagnostics.censusService).toMatchObject({
+            code: 0,
+            signal: null,
+            stderr: "",
+          });
+        }
         expect(report.code).toBe(code);
         expect(readFileSync(path.join(workspace, ".git/preexisting.lock"), "utf8")).toBe(
           "not invocation-owned\n",
@@ -788,6 +806,111 @@ it.skipIf(process.platform === "win32")(
   55_000,
 );
 
+it.skipIf(process.platform !== "win32")(
+  "keeps the persistent census protocol bounded and joins authenticated shutdown",
+  () => {
+    const result = spawnSync(
+      "python",
+      [
+        "-I",
+        "-S",
+        "-c",
+        String.raw`
+import json, os, socket, subprocess, sys, uuid
+token = uuid.uuid4().hex
+env = dict(os.environ, OPENCLAW_CI_CENSUS_TOKEN=token, OPENCLAW_CI_CENSUS_PARENT_PID=str(os.getpid()))
+service = subprocess.Popen([sys.executable, "-I", "-S", sys.argv[1]], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+ready = json.loads(service.stdout.readline()); assert list(ready) == ["v", "port"] and ready["v"] == 1
+def exchange(payload):
+    with socket.create_connection(("127.0.0.1", ready["port"]), timeout=5) as connection:
+        connection.sendall(payload); connection.shutdown(socket.SHUT_WR)
+        return json.loads(connection.makefile("rb").readline())
+base = dict(v=1, token=token); shutdown = json.dumps(dict(base, op="shutdown")).encode() + b"\n"
+try:
+    requests = [dict(base, token="wrong", op="census", pids=[]), dict(base, op="census", pids=[], extra=True), dict(base, op="census", pids=[1, 1]), dict(base, op="census", pids=[True]), dict(base, v=True, op="census", pids=[])]
+    invalid = [b"{\n", *(json.dumps(item).encode() + b"\n" for item in requests), b"{" + b"x" * (16 * 1024) + b"}\n"]
+    for payload in invalid: response = exchange(payload); assert response["v"] == 1 and response.get("error")
+    connection = socket.create_connection(("127.0.0.1", ready["port"]), timeout=5); connection.sendall(json.dumps(dict(base, op="census", pids=[])).encode() + b"\n"); connection.close()
+    response = exchange(json.dumps(dict(base, op="census", pids=[os.getpid()])).encode() + b"\n")
+    assert list(response["observations"][0]) == ["pid", "alive", "creationTime"] and response["observations"][0]["alive"]
+    assert exchange(shutdown) == {"v": 1, "ok": True}; assert service.wait(timeout=5) == 0 and service.stderr.read() == ""
+finally:
+    if service.poll() is None:
+        try:
+            exchange(shutdown)
+        except Exception: service.kill()
+        service.wait(timeout=5)
+print("persistent census protocol passed")
+`,
+        fileURLToPath(new URL("./fixtures/ci-windows-process-census.py", import.meta.url)),
+      ],
+      { encoding: "utf8", timeout: 15_000, killSignal: "SIGKILL" },
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("persistent census protocol passed");
+  },
+  20_000,
+);
+
+it.skipIf(process.platform !== "win32")(
+  "fails census startup before spawning actors",
+  async () => {
+    await withCiCheckoutFixture(
+      "census-startup-failure",
+      (root) => writeFileSync(path.join(root, "checkout.sh"), "exit 0\n"),
+      (report, result, stderr) => {
+        expect(result, stderr).toEqual({ code: 1, signal: null });
+        expect(report.code).toBeNull();
+        expect(report.ownedProcesses).toEqual([]);
+        expect(report.processDiagnostics.sentinel).toBeNull();
+        const diagnostic = report.processDiagnostics.censusService;
+        expect(diagnostic).toMatchObject({
+          command: "fixture-missing-python -I -S census-service",
+          code: expect.any(Number),
+          signal: null,
+        });
+        expect(diagnostic?.stderr).toContain("ENOENT");
+        expect(Buffer.byteLength(diagnostic?.stderr ?? "")).toBeLessThanOrEqual(4_096);
+      },
+    );
+  },
+  55_000,
+);
+
+it.skipIf(process.platform !== "win32")(
+  "retains the namespace after unexpected census service death",
+  async () => {
+    let root = "";
+    let errors = "";
+    const log = vi.spyOn(console, "error").mockImplementation((value) => (errors += String(value)));
+    try {
+      await expect(
+        withCiCheckoutFixture(
+          "census-service-exit",
+          (directory) => {
+            root = directory;
+            writeFileSync(path.join(root, "checkout.sh"), "exit 0\n");
+          },
+          () => undefined,
+        ),
+      ).rejects.toThrow();
+      expect(existsSync(root)).toBe(true);
+      expect(existsSync(path.join(root, "report.json"))).toBe(false);
+      for (const text of [
+        "Windows process census service exited",
+        "group extinction: true",
+        '"signal":"SIGKILL"',
+      ]) {
+        expect(errors).toContain(text);
+      }
+    } finally {
+      log.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  55_000,
+);
+
 it("does not revive a terminated fixture instance when its PID is reused", () => {
   const result = spawnSync(
     process.platform === "win32" ? "python" : "python3",
@@ -796,7 +919,7 @@ it("does not revive a terminated fixture instance when its PID is reused", () =>
       "-S",
       "-c",
       String.raw`
-import json, os, pathlib, runpy, subprocess, sys, tempfile
+import json, os, pathlib, runpy, socket, subprocess, sys, tempfile
 
 with tempfile.TemporaryDirectory(prefix="checkout-pid-reuse-") as directory:
     root = pathlib.Path(directory).resolve()
@@ -832,41 +955,58 @@ cp.spawnSync = (command, args, options) => {
 };
 require("node:module").syncBuiltinESMExports();
 ''')
-    with subprocess.Popen([sys.executable, "-I", "-S", "-c", "import sys; sys.stdin.read()"],
-                          stdin=subprocess.PIPE) as child:
-        retired = dict(pid=child.pid, role="grandchild", attempt=1, instance="retired")
-        current = dict(pid=os.getpid(), role="grandchild", attempt=2, instance="current")
-        if os.name == "nt":
-            read_processes = runpy.run_path(sys.argv[3])["read_processes"]
-            identities = read_processes([child.pid, os.getpid()])
-            assert all(identity["alive"] for identity in identities)
-            retired["creationTime"], current["creationTime"] = (
-                identity["creationTime"] for identity in identities)
-        child.communicate(timeout=10)
-        (records / "retired.json").write_text(json.dumps(retired))
-        (records / "current.json").write_text(json.dumps(current))
-        (records / "sentinel.json").write_text(json.dumps(
-            dict(current, role="sentinel", attempt=0, instance="sentinel")))
+    child_env = os.environ.copy()
+    census = None
+    if os.name == "nt":
+        token = os.urandom(16).hex()
+        census_env = dict(child_env, OPENCLAW_CI_CENSUS_TOKEN=token, OPENCLAW_CI_CENSUS_PARENT_PID=str(os.getpid()))
+        census = subprocess.Popen([sys.executable, "-I", "-S", sys.argv[3]], env=census_env, stdout=subprocess.PIPE, text=True)
+        ready = json.loads(census.stdout.readline())
+        child_env.update(OPENCLAW_CI_CENSUS_TOKEN=token, OPENCLAW_CI_CENSUS_PORT=str(ready["port"]), OPENCLAW_CI_CENSUS_DEADLINE_MS="9999999999999")
+    try:
+        with subprocess.Popen([sys.executable, "-I", "-S", "-c", "import sys; sys.stdin.read()"],
+                              stdin=subprocess.PIPE) as child:
+            retired = dict(pid=child.pid, role="grandchild", attempt=1, instance="retired")
+            current = dict(pid=os.getpid(), role="grandchild", attempt=2, instance="current")
+            if os.name == "nt":
+                read_processes = runpy.run_path(sys.argv[3])["read_processes"]
+                identities = read_processes([child.pid, os.getpid()])
+                assert all(identity["alive"] for identity in identities)
+                retired["creationTime"], current["creationTime"] = (
+                    identity["creationTime"] for identity in identities)
+            child.communicate(timeout=10)
+            (records / "retired.json").write_text(json.dumps(retired))
+            (records / "current.json").write_text(json.dumps(current))
+            (records / "sentinel.json").write_text(json.dumps(
+                dict(current, role="sentinel", attempt=0, instance="sentinel")))
 
-        def observe():
-            subprocess.run([sys.argv[1], "--require", str(guard), sys.argv[2], "git", str(root), "early-leader-exit",
-                            "-C", str(workspace), "checkout"], cwd=workspace, check=True)
-            observed = json.loads((root / "events.jsonl").read_text().splitlines()[-1])
-            assert observed["sentinelAlive"], "unrelated live sentinel was lost"
-            return observed["alive"]
+            def observe():
+                subprocess.run([sys.argv[1], "--require", str(guard), sys.argv[2], "git", str(root), "early-leader-exit",
+                                "-C", str(workspace), "checkout"], cwd=workspace, env=child_env, check=True)
+                observed = json.loads((root / "events.jsonl").read_text().splitlines()[-1])
+                assert observed["sentinelAlive"], "unrelated live sentinel was lost"
+                return observed["alive"]
 
-        assert observe() == [current], "first boundary must observe real child termination"
-        # Fault-inject PID reuse only after actual death was observed. The fresh
-        # instance at that live PID must remain visible, never hidden by retirement.
-        retired["pid"] = current["pid"]
-        (records / "retired.json").write_text(json.dumps(retired))
-        assert observe() == [current], "a retired instance was revived by a reused PID"
-        if os.name == "nt":
-            # No death receipt exists for this instance: birth identity must
-            # reject reuse even when no census observed the PID between lives.
-            (records / "unobserved.json").write_text(json.dumps(
-                dict(retired, instance="unobserved")))
-            assert observe() == [current], "an unobserved retired birth was revived by PID reuse"
+            assert observe() == [current], "first boundary must observe real child termination"
+            # Fault-inject PID reuse only after actual death was observed. The fresh
+            # instance at that live PID must remain visible, never hidden by retirement.
+            retired["pid"] = current["pid"]
+            (records / "retired.json").write_text(json.dumps(retired))
+            assert observe() == [current], "a retired instance was revived by a reused PID"
+            if os.name == "nt":
+                # Birth identity rejects reuse even without an intervening dead census.
+                (records / "unobserved.json").write_text(json.dumps(
+                    dict(retired, instance="unobserved")))
+                assert observe() == [current], "an unobserved retired birth was revived by PID reuse"
+    finally:
+        if census and census.poll() is None:
+            try:
+                with socket.create_connection(("127.0.0.1", ready["port"])) as connection:
+                    request = dict(v=1, token=token, op="shutdown")
+                    connection.sendall(json.dumps(request).encode() + b"\n"); connection.shutdown(socket.SHUT_WR); assert json.loads(connection.makefile("rb").readline())["ok"]
+            except Exception:
+                census.kill()
+            assert census.wait(timeout=5) == 0
 print("fixture lifetime contract passed")
 `,
       process.execPath,

--- a/test/scripts/ci-platform-checkout.test.ts
+++ b/test/scripts/ci-platform-checkout.test.ts
@@ -23,6 +23,7 @@ import {
   readCiCheckoutStep,
   renderGitTestClock,
   withCiCheckoutFixture,
+  withWindowsCensusService,
 } from "./ci-checkout.test-support.js";
 import { runCiGitStep } from "./ci-git-owner.test-support.js";
 
@@ -808,46 +809,112 @@ it.skipIf(process.platform === "win32")(
 
 it.skipIf(process.platform !== "win32")(
   "keeps the persistent census protocol bounded and joins authenticated shutdown",
-  () => {
-    const result = spawnSync(
-      "python",
-      [
-        "-I",
-        "-S",
-        "-c",
-        String.raw`
-import json, os, socket, subprocess, sys, uuid
-token = uuid.uuid4().hex
-env = dict(os.environ, OPENCLAW_CI_CENSUS_TOKEN=token, OPENCLAW_CI_CENSUS_PARENT_PID=str(os.getpid()))
-service = subprocess.Popen([sys.executable, "-I", "-S", sys.argv[1]], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-ready = json.loads(service.stdout.readline()); assert list(ready) == ["v", "port"] and ready["v"] == 1
-def exchange(payload):
-    with socket.create_connection(("127.0.0.1", ready["port"]), timeout=5) as connection:
-        connection.sendall(payload); connection.shutdown(socket.SHUT_WR)
-        return json.loads(connection.makefile("rb").readline())
-base = dict(v=1, token=token); shutdown = json.dumps(dict(base, op="shutdown")).encode() + b"\n"
-try:
-    requests = [dict(base, token="wrong", op="census", pids=[]), dict(base, op="census", pids=[], extra=True), dict(base, op="census", pids=[1, 1]), dict(base, op="census", pids=[True]), dict(base, v=True, op="census", pids=[])]
-    invalid = [b"{\n", *(json.dumps(item).encode() + b"\n" for item in requests), b"{" + b"x" * (16 * 1024) + b"}\n"]
-    for payload in invalid: response = exchange(payload); assert response["v"] == 1 and response.get("error")
-    connection = socket.create_connection(("127.0.0.1", ready["port"]), timeout=5); connection.sendall(json.dumps(dict(base, op="census", pids=[])).encode() + b"\n"); connection.close()
-    response = exchange(json.dumps(dict(base, op="census", pids=[os.getpid()])).encode() + b"\n")
-    assert list(response["observations"][0]) == ["pid", "alive", "creationTime"] and response["observations"][0]["alive"]
-    assert exchange(shutdown) == {"v": 1, "ok": True}; assert service.wait(timeout=5) == 0 and service.stderr.read() == ""
-finally:
-    if service.poll() is None:
-        try:
-            exchange(shutdown)
-        except Exception: service.kill()
-        service.wait(timeout=5)
-print("persistent census protocol passed")
-`,
-        fileURLToPath(new URL("./fixtures/ci-windows-process-census.py", import.meta.url)),
-      ],
-      { encoding: "utf8", timeout: 15_000, killSignal: "SIGKILL" },
-    );
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain("persistent census protocol passed");
+  async () => {
+    await withWindowsCensusService(async (service) => {
+      const frame = (request: Record<string, unknown>) =>
+        Buffer.from(`${JSON.stringify({ v: 1, token: service.token, ...request })}\n`);
+      const invalid = [
+        { name: "malformed JSON", payload: Buffer.from("{\n") },
+        { name: "wrong census token", payload: frame({ token: "wrong", op: "census", pids: [] }) },
+        { name: "wrong shutdown token", payload: frame({ token: "wrong", op: "shutdown" }) },
+        { name: "unknown operation", payload: frame({ op: "unknown" }) },
+        { name: "extra fields", payload: frame({ op: "census", pids: [], extra: true }) },
+        { name: "duplicate PIDs", payload: frame({ op: "census", pids: [1, 1] }) },
+        { name: "boolean PID", payload: frame({ op: "census", pids: [true] }) },
+        { name: "boolean version", payload: frame({ v: true, op: "census", pids: [] }) },
+        {
+          name: "oversized frame",
+          payload: Buffer.concat([Buffer.alloc(16 * 1024 + 1, "x"), Buffer.from("\n")]),
+        },
+        {
+          name: "257 PIDs",
+          payload: frame({ op: "census", pids: Array.from({ length: 257 }, (_, i) => i + 1) }),
+        },
+        {
+          name: "trailing frame",
+          payload: Buffer.concat([frame({ op: "census", pids: [] }), Buffer.from("x")]),
+        },
+        { name: "missing EOF", payload: frame({ op: "census", pids: [] }), end: false },
+      ];
+      for (const { name, payload, end } of invalid) {
+        await expect(service.exchange(payload, { end }), name).resolves.toMatchObject({
+          v: 1,
+          error: expect.any(String),
+        });
+      }
+
+      const partial = await service.connect(Buffer.from('{"v":1'));
+      const drip = setInterval(() => partial.write(" "), 100);
+      const partialClosed = new Promise<void>((resolve) => {
+        partial.once("close", () => resolve());
+      });
+      try {
+        const census = await service.request({ op: "census", pids: [process.pid] }, 1_000);
+        expect(census).toMatchObject({
+          v: 1,
+          observations: [{ pid: process.pid, alive: true, creationTime: expect.any(String) }],
+        });
+        const started = Date.now();
+        await expect(service.request({ op: "shutdown" }, 1_000)).resolves.toEqual({
+          v: 1,
+          ok: true,
+        });
+        await expect(service.waitForExit(1_000)).resolves.toEqual({ code: 0, signal: null });
+        expect(Date.now() - started).toBeLessThan(900);
+        await expect(
+          Promise.race([
+            partialClosed,
+            new Promise((_, reject) => {
+              setTimeout(() => reject(new Error("Partial client remained open")), 1_000);
+            }),
+          ]),
+        ).resolves.toBeUndefined();
+      } finally {
+        clearInterval(drip);
+        partial.destroy();
+      }
+    });
+  },
+  20_000,
+);
+
+it.skipIf(process.platform !== "win32")(
+  "exits promptly when its parent dies during a partial frame",
+  async () => {
+    const owner = spawnOwnedVitestProcess({
+      command: process.execPath,
+      args: ["-e", "setInterval(() => {}, 1000)"],
+      options: { stdio: "ignore" },
+    });
+    const parentPid = expectDefined(owner.child.pid, "census parent PID");
+    try {
+      await withWindowsCensusService(
+        async (service) => {
+          const partial = await service.connect(Buffer.from('{"v":1'));
+          const partialClosed = new Promise<void>((resolve) => {
+            partial.once("close", () => resolve());
+          });
+          const started = Date.now();
+          owner.child.kill("SIGKILL");
+          await owner.completion;
+          await expect(service.waitForExit(1_000)).resolves.toEqual({ code: 0, signal: null });
+          expect(Date.now() - started).toBeLessThan(900);
+          await expect(
+            Promise.race([
+              partialClosed,
+              new Promise((_, reject) => {
+                setTimeout(() => reject(new Error("Partial client remained open")), 1_000);
+              }),
+            ]),
+          ).resolves.toBeUndefined();
+          partial.destroy();
+        },
+        { parentPid },
+      );
+    } finally {
+      owner.child.kill("SIGKILL");
+      await owner.completion;
+    }
   },
   20_000,
 );
@@ -911,15 +978,16 @@ it.skipIf(process.platform !== "win32")(
   55_000,
 );
 
-it("does not revive a terminated fixture instance when its PID is reused", () => {
-  const result = spawnSync(
-    process.platform === "win32" ? "python" : "python3",
-    [
-      "-I",
-      "-S",
-      "-c",
-      String.raw`
-import json, os, pathlib, runpy, socket, subprocess, sys, tempfile
+it("does not revive a terminated fixture instance when its PID is reused", async () => {
+  const run = (env: NodeJS.ProcessEnv = process.env) =>
+    spawnSync(
+      process.platform === "win32" ? "python" : "python3",
+      [
+        "-I",
+        "-S",
+        "-c",
+        String.raw`
+import json, os, pathlib, runpy, subprocess, sys, tempfile
 
 with tempfile.TemporaryDirectory(prefix="checkout-pid-reuse-") as directory:
     root = pathlib.Path(directory).resolve()
@@ -956,65 +1024,52 @@ cp.spawnSync = (command, args, options) => {
 require("node:module").syncBuiltinESMExports();
 ''')
     child_env = os.environ.copy()
-    census = None
-    if os.name == "nt":
-        token = os.urandom(16).hex()
-        census_env = dict(child_env, OPENCLAW_CI_CENSUS_TOKEN=token, OPENCLAW_CI_CENSUS_PARENT_PID=str(os.getpid()))
-        census = subprocess.Popen([sys.executable, "-I", "-S", sys.argv[3]], env=census_env, stdout=subprocess.PIPE, text=True)
-        ready = json.loads(census.stdout.readline())
-        child_env.update(OPENCLAW_CI_CENSUS_TOKEN=token, OPENCLAW_CI_CENSUS_PORT=str(ready["port"]), OPENCLAW_CI_CENSUS_DEADLINE_MS="9999999999999")
-    try:
-        with subprocess.Popen([sys.executable, "-I", "-S", "-c", "import sys; sys.stdin.read()"],
-                              stdin=subprocess.PIPE) as child:
-            retired = dict(pid=child.pid, role="grandchild", attempt=1, instance="retired")
-            current = dict(pid=os.getpid(), role="grandchild", attempt=2, instance="current")
-            if os.name == "nt":
-                read_processes = runpy.run_path(sys.argv[3])["read_processes"]
-                identities = read_processes([child.pid, os.getpid()])
-                assert all(identity["alive"] for identity in identities)
-                retired["creationTime"], current["creationTime"] = (
-                    identity["creationTime"] for identity in identities)
-            child.communicate(timeout=10)
-            (records / "retired.json").write_text(json.dumps(retired))
-            (records / "current.json").write_text(json.dumps(current))
-            (records / "sentinel.json").write_text(json.dumps(
-                dict(current, role="sentinel", attempt=0, instance="sentinel")))
+    with subprocess.Popen([sys.executable, "-I", "-S", "-c", "import sys; sys.stdin.read()"],
+                          stdin=subprocess.PIPE) as child:
+        retired = dict(pid=child.pid, role="grandchild", attempt=1, instance="retired")
+        current = dict(pid=os.getpid(), role="grandchild", attempt=2, instance="current")
+        if os.name == "nt":
+            read_processes = runpy.run_path(sys.argv[3])["read_processes"]
+            identities = read_processes([child.pid, os.getpid()])
+            assert all(identity["alive"] for identity in identities)
+            retired["creationTime"], current["creationTime"] = (
+                identity["creationTime"] for identity in identities)
+        child.communicate(timeout=10)
+        (records / "retired.json").write_text(json.dumps(retired))
+        (records / "current.json").write_text(json.dumps(current))
+        (records / "sentinel.json").write_text(json.dumps(
+            dict(current, role="sentinel", attempt=0, instance="sentinel")))
 
-            def observe():
-                subprocess.run([sys.argv[1], "--require", str(guard), sys.argv[2], "git", str(root), "early-leader-exit",
-                                "-C", str(workspace), "checkout"], cwd=workspace, env=child_env, check=True)
-                observed = json.loads((root / "events.jsonl").read_text().splitlines()[-1])
-                assert observed["sentinelAlive"], "unrelated live sentinel was lost"
-                return observed["alive"]
+        def observe():
+            subprocess.run([sys.argv[1], "--require", str(guard), sys.argv[2], "git", str(root), "early-leader-exit",
+                            "-C", str(workspace), "checkout"], cwd=workspace, env=child_env, check=True)
+            observed = json.loads((root / "events.jsonl").read_text().splitlines()[-1])
+            assert observed["sentinelAlive"], "unrelated live sentinel was lost"
+            return observed["alive"]
 
-            assert observe() == [current], "first boundary must observe real child termination"
-            # Fault-inject PID reuse only after actual death was observed. The fresh
-            # instance at that live PID must remain visible, never hidden by retirement.
-            retired["pid"] = current["pid"]
-            (records / "retired.json").write_text(json.dumps(retired))
-            assert observe() == [current], "a retired instance was revived by a reused PID"
-            if os.name == "nt":
-                # Birth identity rejects reuse even without an intervening dead census.
-                (records / "unobserved.json").write_text(json.dumps(
-                    dict(retired, instance="unobserved")))
-                assert observe() == [current], "an unobserved retired birth was revived by PID reuse"
-    finally:
-        if census and census.poll() is None:
-            try:
-                with socket.create_connection(("127.0.0.1", ready["port"])) as connection:
-                    request = dict(v=1, token=token, op="shutdown")
-                    connection.sendall(json.dumps(request).encode() + b"\n"); connection.shutdown(socket.SHUT_WR); assert json.loads(connection.makefile("rb").readline())["ok"]
-            except Exception:
-                census.kill()
-            assert census.wait(timeout=5) == 0
+        assert observe() == [current], "first boundary must observe real child termination"
+        # Fault-inject PID reuse only after actual death was observed. The fresh
+        # instance at that live PID must remain visible, never hidden by retirement.
+        retired["pid"] = current["pid"]
+        (records / "retired.json").write_text(json.dumps(retired))
+        assert observe() == [current], "a retired instance was revived by a reused PID"
+        if os.name == "nt":
+            # Birth identity rejects reuse even without an intervening dead census.
+            (records / "unobserved.json").write_text(json.dumps(
+                dict(retired, instance="unobserved")))
+            assert observe() == [current], "an unobserved retired birth was revived by PID reuse"
 print("fixture lifetime contract passed")
 `,
-      process.execPath,
-      ciCheckoutFixture,
-      fileURLToPath(new URL("./fixtures/ci-windows-process-census.py", import.meta.url)),
-    ],
-    { encoding: "utf8", timeout: 15_000, killSignal: "SIGKILL" },
-  );
+        process.execPath,
+        ciCheckoutFixture,
+        fileURLToPath(new URL("./fixtures/ci-windows-process-census.py", import.meta.url)),
+      ],
+      { env, encoding: "utf8", timeout: 15_000, killSignal: "SIGKILL" },
+    );
+  const result =
+    process.platform === "win32"
+      ? await withWindowsCensusService((service) => run({ ...process.env, ...service.env }))
+      : run();
   expect(result.status, result.stderr).toBe(0);
   expect(result.stdout).toContain("fixture lifetime contract passed");
 });

--- a/test/scripts/fixtures/ci-platform-checkout.mjs
+++ b/test/scripts/fixtures/ci-platform-checkout.mjs
@@ -7,6 +7,8 @@ import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
 const [mode, root, policyScenario, ...args] = process.argv.slice(2);
+const FIXTURE_RUNTIME_MS = 45_000;
+const FIXTURE_CLEANUP_MS = 4_000;
 const linux = policyScenario.startsWith("linux:");
 const scenario = linux ? policyScenario.slice("linux:".length) : policyScenario;
 const fixture = fileURLToPath(import.meta.url);
@@ -1037,7 +1039,7 @@ async function supervise() {
       if (error) {
         report.error = String(error);
       }
-      const deadline = Date.now() + 4_000;
+      const deadline = Date.now() + FIXTURE_CLEANUP_MS;
       try {
         fs.rmSync(lease, { force: true });
         sentinel?.kill("SIGKILL");
@@ -1143,7 +1145,7 @@ async function supervise() {
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
     process.once(signal, () => void stop(`supervisor received ${signal}`));
   }
-  setTimeout(() => void stop("fixture deadline exceeded"), 45_000);
+  setTimeout(() => void stop("fixture deadline exceeded"), FIXTURE_RUNTIME_MS);
   try {
     if (process.platform !== "win32") {
       // A noexec mount can make PATH skip mocks and select real tools. Verify
@@ -1176,7 +1178,7 @@ async function supervise() {
     const actorEnv = process.env.NODE_OPTIONS ? { NODE_OPTIONS: process.env.NODE_OPTIONS } : {};
     if (process.platform === "win32") {
       const token = randomUUID();
-      const deadline = Date.now() + 45_000;
+      const deadline = Date.now() + FIXTURE_RUNTIME_MS;
       const censusCommand =
         scenario === "census-startup-failure" ? "fixture-missing-python" : "python";
       const censusScript = path.join(path.dirname(fixture), "ci-windows-process-census.py");
@@ -1187,6 +1189,7 @@ async function supervise() {
           ...process.env,
           OPENCLAW_CI_CENSUS_TOKEN: token,
           OPENCLAW_CI_CENSUS_PARENT_PID: String(process.pid),
+          OPENCLAW_CI_CENSUS_MAX_LIFETIME_MS: String(FIXTURE_RUNTIME_MS + FIXTURE_CLEANUP_MS),
         },
       });
       report.processDiagnostics.censusService = captureProcessDiagnostic(

--- a/test/scripts/fixtures/ci-platform-checkout.mjs
+++ b/test/scripts/fixtures/ci-platform-checkout.mjs
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import net from "node:net";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
@@ -72,6 +73,40 @@ function publish(name, value) {
   fs.renameSync(`${target}.${process.pid}.tmp`, target);
 }
 
+function captureProcessDiagnostic(child, command) {
+  const diagnostic = { command, code: null, signal: null, stderr: "" };
+  const capture = (data) => {
+    const stderr = Buffer.from(`${diagnostic.stderr}${String(data)}`).subarray(-4_096);
+    diagnostic.stderr = stderr.toString().replace(/^\uFFFD+/u, "");
+  };
+  child.stderr?.on("data", capture);
+  child.once("error", capture);
+  child.once("close", (code, signal) => Object.assign(diagnostic, { code, signal }));
+  return diagnostic;
+}
+
+async function readCensusReady(child, deadline) {
+  let data = "";
+  try {
+    await Promise.race([
+      (async () => {
+        for await (const chunk of child.stdout.iterator({ destroyOnReturn: false })) {
+          data += chunk;
+          if (Buffer.byteLength(data) > 4_096) throw new Error("oversized");
+          if (data.includes("\n")) return;
+        }
+        throw new Error(`process exited (${child.exitCode ?? child.signalCode})`);
+      })(),
+      delay(Math.max(1, deadline - Date.now()), undefined, { ref: false }).then(() => {
+        throw new Error("timed out");
+      }),
+    ]);
+    return JSON.parse(data.slice(0, data.indexOf("\n")));
+  } catch (error) {
+    throw new Error(`Windows process census service readiness was invalid: ${error.message}`);
+  }
+}
+
 function stall(attempt) {
   // Expire only a ready, deliberately stalled tree. Ordinary cancel-* cases
   // wait for their signal; cancelDuringCleanup needs a tick to enter real drain.
@@ -80,21 +115,38 @@ function stall(attempt) {
   }
 }
 
-function readWindowsProcessCensus(pids) {
-  const result = spawnSync(
-    "python",
-    ["-I", "-S", fileURLToPath(new URL("./ci-windows-process-census.py", import.meta.url))],
-    { input: JSON.stringify(pids), encoding: "utf8", timeout: 1_000, killSignal: "SIGKILL" },
-  );
-  if (result.error || result.status !== 0 || result.stderr !== "") {
-    throw new Error(
-      "Fixture Windows process census failed (" +
-        (result.error?.code ?? result.status) +
-        "): " +
-        result.stderr,
-    );
+async function requestWindowsCensus(request, deadline) {
+  deadline ??= Number(process.env.OPENCLAW_CI_CENSUS_DEADLINE_MS);
+  const port = Number(process.env.OPENCLAW_CI_CENSUS_PORT);
+  const token = process.env.OPENCLAW_CI_CENSUS_TOKEN;
+  if (!port || !token || !deadline) {
+    throw new Error("Fixture Windows process census service is unavailable");
   }
-  const observations = JSON.parse(result.stdout);
+  const socket = net.createConnection({ host: "127.0.0.1", port });
+  socket.setEncoding("utf8");
+  socket.setTimeout(Math.max(1, deadline - Date.now()), () =>
+    socket.destroy(new Error("Fixture Windows process census timed out")),
+  );
+  socket.end(`${JSON.stringify({ v: 1, token, ...request })}\n`);
+  let data = "";
+  try {
+    for await (const chunk of socket) {
+      data += chunk;
+      if (Buffer.byteLength(data) > 16_384) throw new Error("response is oversized");
+    }
+    const [line, tail, extra] = data.split("\n");
+    if (!line || tail !== "" || extra !== undefined) throw new Error("invalid response frame");
+    const response = JSON.parse(line);
+    if (response?.v !== 1 || response.error) throw new Error(response?.error || "invalid response");
+    return response;
+  } catch (error) {
+    socket.destroy();
+    throw new Error(`Fixture Windows process census failed: ${error.message}`);
+  }
+}
+
+async function readWindowsProcessCensus(pids) {
+  const observations = (await requestWindowsCensus({ op: "census", pids })).observations;
   if (
     !Array.isArray(observations) ||
     observations.length !== pids.length ||
@@ -111,22 +163,23 @@ function readWindowsProcessCensus(pids) {
   return new Map(observations.map((entry) => [entry.pid, entry]));
 }
 
-function record(pid, role, attempt = 0) {
-  if (process.platform === "win32" && pid === process.pid && !ownWindowsCreationTime) {
-    const identity = readWindowsProcessCensus([pid]).get(pid);
-    if (!identity.alive || !identity.creationTime) {
-      throw new Error("Fixture actor could not capture its own Windows birth");
+async function record(pid, role, attempt = 0) {
+  let creationTime = pid === process.pid ? ownWindowsCreationTime : undefined;
+  if (process.platform === "win32") {
+    if (!creationTime) {
+      const identity = (await readWindowsProcessCensus([pid])).get(pid);
+      if (!identity.alive || !identity.creationTime)
+        throw new Error("Fixture actor could not capture its Windows birth");
+      creationTime = identity.creationTime;
+      if (pid === process.pid) ownWindowsCreationTime = creationTime;
     }
-    ownWindowsCreationTime = identity.creationTime;
   }
   publish(`pids/${pid}.json`, {
     pid,
     role,
     attempt,
     instance: `${instance}-${pid}`,
-    ...(process.platform === "win32" && pid === process.pid
-      ? { creationTime: ownWindowsCreationTime }
-      : {}),
+    ...(creationTime ? { creationTime } : {}),
   });
 }
 
@@ -139,7 +192,7 @@ function records() {
     .map((file) => JSON.parse(fs.readFileSync(path.join(recordsDir, file), "utf8")));
 }
 
-function liveRecords() {
+async function liveRecords() {
   const owned = records().filter(
     (entry) =>
       !fs.existsSync(path.join(recordsDir, `${entry.instance}.dead`)) &&
@@ -152,7 +205,7 @@ function liveRecords() {
   const alive = new Set();
   const pids = new Set(owned.map((entry) => entry.pid));
   const windowsCensus =
-    process.platform === "win32" ? readWindowsProcessCensus([...pids]) : undefined;
+    process.platform === "win32" ? await readWindowsProcessCensus([...pids]) : undefined;
   if (windowsCensus) {
     for (const entry of owned) {
       if (typeof entry.creationTime !== "string" || !/^\d+$/.test(entry.creationTime)) {
@@ -239,8 +292,8 @@ function isWorkflowDescendant(pid, shellPid) {
   return false;
 }
 
-function boundary(name) {
-  const alive = liveRecords();
+async function boundary(name) {
+  const alive = await liveRecords();
   fs.appendFileSync(
     eventsFile,
     `${JSON.stringify({
@@ -253,7 +306,7 @@ function boundary(name) {
 
 async function until(predicate, label, timeout = 4_000) {
   const deadline = Date.now() + timeout;
-  while (!predicate()) {
+  while (!(await predicate())) {
     if (Date.now() >= deadline) {
       throw new Error(`Timed out waiting for ${label}`);
     }
@@ -265,7 +318,7 @@ async function waitForReady(predicate, child, stopped = () => !fs.existsSync(lea
   // Readiness belongs to the owned child's lifetime. The supervisor's existing
   // watchdog bounds startup; an independent short timer can preempt legal Git work.
   while (!stopped() && child.exitCode === null && child.signalCode === null) {
-    if (predicate()) {
+    if (await predicate()) {
       return true;
     }
     await delay(10);
@@ -322,16 +375,20 @@ function writeConsumer(target, tool) {
 
 async function command() {
   holdLease();
-  if (!options.performance || mode !== "observe") record(process.pid, mode);
+  if (
+    (!options.performance || mode !== "observe") &&
+    !(process.platform === "win32" && mode === "sentinel")
+  )
+    await record(process.pid, mode);
   if (mode === "sentinel") {
     return;
   }
   if (mode === "observe") {
-    boundary(args[0]);
+    await boundary(args[0]);
     process.exit(0);
   }
   if (options.performance && ["curl", "tar", "sha256sum", "npm"].includes(mode)) {
-    boundary(`consumer:${mode}`);
+    await boundary(`consumer:${mode}`);
     recordCommand(mode, process.cwd(), args);
     if (mode === "tar") {
       const directory = insideOwnedPath(args[args.indexOf("-C") + 1]);
@@ -346,14 +403,14 @@ async function command() {
   if (mode === "find") {
     insideOwnedPath(args[0]);
     // Observe before the real deletion, while prior Git children can still write.
-    boundary("delete");
+    await boundary("delete");
     const result = spawnSync("/usr/bin/find", args, { stdio: "inherit" });
     process.exit(result.status ?? 1);
   }
   if (mode === "rm") {
     const target = insideOwnedPath(args.at(-1));
     if (target === path.join(workspace, "publish")) {
-      boundary("delete");
+      await boundary("delete");
     }
     recordCommand(mode, process.cwd(), args);
     const result = spawnSync("/bin/rm", args, { stdio: "inherit" });
@@ -373,7 +430,7 @@ async function command() {
         process.exit(0);
       }
     });
-    record(process.pid, mode, attempt);
+    await record(process.pid, mode, attempt);
     if (mode === "child") {
       // Startup faults belong to the caller, not every consumer of this shared fixture.
       const startDelay = path.join(root, `tree-start-delay-${attempt}.json`);
@@ -390,7 +447,7 @@ async function command() {
     const cwd = insideOwnedPath(process.cwd());
     recordCommand(mode, cwd, args);
     if (options.performance && mode === "node") {
-      boundary("consumer:node");
+      await boundary("consumer:node");
       const allowed = [
         options.env.PERFORMANCE_REPORT_SELECTOR,
         options.env.PERFORMANCE_PUBLISHER_HELPER,
@@ -411,7 +468,7 @@ async function command() {
       // The workflow's package-script capability probe; never evaluate candidate code.
       process.exit(0);
     }
-    boundary(`consumer:${mode}`);
+    await boundary(`consumer:${mode}`);
     if (mode === "go") {
       const [build, changeDirectory, source, outputFlag, output, target] = args;
       if (
@@ -484,7 +541,7 @@ async function command() {
   }
   const operation = args.shift();
   if (operation === "init" && !localGit) {
-    boundary("init");
+    await boundary("init");
     const config = path.join(root, "fixture-config.json");
     if (fs.existsSync(config)) {
       await delay(JSON.parse(fs.readFileSync(config, "utf8")).initDelayMs);
@@ -544,9 +601,9 @@ async function command() {
     const attempt = fs.existsSync(treeCounter)
       ? JSON.parse(fs.readFileSync(treeCounter, "utf8")) + 1
       : 1;
-    boundary(`${operation}:${resultAttempt}`);
+    await boundary(`${operation}:${resultAttempt}`);
     publish("tree-attempt.json", attempt);
-    record(process.pid, "parent", attempt);
+    await record(process.pid, "parent", attempt);
     if (operation === "clone" || operation === "worktree") {
       const directory = insideOwnedPath(operation === "clone" ? args.at(-1) : args.at(-2));
       if (operation === "clone" && options.docsPublish && fs.existsSync(directory)) {
@@ -582,7 +639,7 @@ async function command() {
     if (options.cancelDuringCleanup) {
       const pid = process.ppid;
       publish("owner.json", { pid, startTime: getFileLockProcessStartTime(pid) });
-      record(pid, "owner");
+      await record(pid, "owner");
       if (
         options.cleanupCancelMatch &&
         new RegExp(options.cleanupCancelMatch).test([operation, ...args].join(" "))
@@ -599,7 +656,7 @@ async function command() {
       );
     }
     if (scenario.startsWith("cancel-") || commandResult?.code === "cancel") {
-      const owned = liveRecords();
+      const owned = await liveRecords();
       const alive = owned.filter((entry) => entry.attempt === attempt);
       if (
         !["parent", "child", "grandchild"].every((role) =>
@@ -801,7 +858,7 @@ async function command() {
     stall(attempt);
     return;
   } else if (operation === "checkout") {
-    boundary(cwd === path.join(workspace, ".ci-harness") ? "harness-checkout" : "checkout");
+    await boundary(cwd === path.join(workspace, ".ci-harness") ? "harness-checkout" : "checkout");
     if (scenario === "checkout-failure") {
       process.exit(23);
     }
@@ -829,20 +886,20 @@ async function command() {
       (options.docsAgent && args.join(" ") === "--quiet") ||
       options.maturity)
   ) {
-    boundary("diff");
+    await boundary("diff");
     process.exit(options.diffResult ?? (options.maturity ? 0 : 1));
   } else if (
     ["add", "commit"].includes(operation) ||
     (operation === "config" && (options.docsPublish || options.docsAgent)) ||
     (operation === "rebase" && args[0] === "--abort")
   ) {
-    boundary(operation === "rebase" ? "rebase-abort" : operation);
+    await boundary(operation === "rebase" ? "rebase-abort" : operation);
     // An abort without an active rebase is an ordinary ignored Git failure.
     process.exit(operation === "rebase" ? 128 : 0);
   } else if (options.docsAgent && ["ls-files", "diff"].includes(operation)) {
-    boundary(operation);
+    await boundary(operation);
   } else if (operation === "cat-file" || (operation === "show" && options.objects)) {
-    boundary(`${operation}:${args.at(-1)}`);
+    await boundary(`${operation}:${args.at(-1)}`);
     const spec = args.at(-1);
     if (spec.endsWith("^{commit}")) {
       process.exit(options.baseAvailableAfter === 0 ? 0 : 1);
@@ -853,7 +910,7 @@ async function command() {
     }
     process.exit(object ? ((operation === "cat-file" ? object.probe : object.code) ?? 0) : 1);
   } else if (operation === "rev-parse") {
-    boundary("rev-parse");
+    await boundary("rev-parse");
     if (args[0] === "--verify") {
       fs.writeSync(1, "fixture quiet probe stdout\n");
       fs.writeSync(2, "fixture quiet probe stderr\n");
@@ -865,22 +922,22 @@ async function command() {
     }
     fs.writeSync(1, `${args.map((ref) => resolveRef(cwd, ref)).join("\n")}\n`);
   } else if (operation === "tag" && args[0] === "--points-at") {
-    boundary("tag");
+    await boundary("tag");
   } else if (operation === "merge-base" && options.mergeBase) {
-    boundary("merge-base");
+    await boundary("merge-base");
     if (args[0] === "--is-ancestor") {
       process.exit(options.mergeBase.ancestor ? 0 : 1);
     }
     fs.writeSync(1, `${options.mergeBase.revision}\n`);
   } else if (operation === "check-ref-format") {
-    boundary("check-ref-format");
+    await boundary("check-ref-format");
     fs.writeSync(1, "fixture quiet probe stdout\n");
     fs.writeSync(2, "fixture quiet probe stderr\n");
     process.exit(options.invalidRef ? 1 : 0);
   } else if (operation === "remote" && args[0] === "get-url") {
     fs.writeSync(1, "https://example.invalid/fixture.git\n");
   } else if (operation === "show" && args.join(" ").startsWith("-s --format=%P ")) {
-    boundary("show-parents");
+    await boundary("show-parents");
     const snapshot = options.mergeSnapshots?.find((entry) => entry.sha === args.at(-1));
     const head = snapshot?.head ?? "a".repeat(40);
     fs.writeSync(1, `${"c".repeat(40)} ${head}\n`);
@@ -950,6 +1007,7 @@ async function supervise() {
   let sentinel;
   let shell;
   let stopping;
+  let censusService, censusServiceClosed;
   const pendingChildren = new Set();
   const track = (child) => {
     pendingChildren.add(child);
@@ -972,6 +1030,7 @@ async function supervise() {
     ownedProcesses: [],
     commands: [],
     output: "",
+    processDiagnostics: { censusService: null, sentinel: null },
   };
   const stop = (error) => {
     stopping ??= Promise.resolve().then(async () => {
@@ -1008,17 +1067,38 @@ async function supervise() {
           Math.max(0, deadline - Date.now()),
         );
         await until(
-          () => {
-            report.cleanupRemaining = liveRecords();
+          async () => {
+            report.cleanupRemaining = await liveRecords();
             return report.cleanupRemaining.length === 0;
           },
           "fixture cleanup",
           Math.max(0, deadline - Date.now()),
         );
+        if (censusService) {
+          let acknowledged = false;
+          if (sentinel) {
+            acknowledged = (await requestWindowsCensus({ op: "shutdown" }, deadline)).ok === true;
+          } else if (censusService.exitCode === null && censusService.signalCode === null) {
+            censusService.kill("SIGKILL");
+          }
+          const timeout = delay(Math.max(1, deadline - Date.now()), undefined, { ref: false });
+          const exit = await Promise.race([
+            censusServiceClosed,
+            timeout.then(() => Promise.reject(new Error("Census service did not close"))),
+          ]);
+          if (sentinel && (!acknowledged || exit.code !== 0 || exit.signal)) {
+            throw new Error("Fixture Windows process census shutdown was not joined");
+          }
+        }
       } catch (err) {
         // Only the completed report releases the namespace; exit alone does not.
         const detail = err instanceof Error ? err.message : String(err);
-        console.error(`Fixture cleanup unverified; retaining ${root}: ${detail}`);
+        const token = process.env.OPENCLAW_CI_CENSUS_TOKEN ?? "\u0000";
+        const diagnostics = JSON.stringify(report.processDiagnostics).replaceAll(
+          token,
+          "[redacted]",
+        );
+        console.error(`Fixture cleanup unverified; retaining ${root}: ${detail}\n${diagnostics}`);
         fs.closeSync(output);
         process.exit(1);
       }
@@ -1093,6 +1173,51 @@ async function supervise() {
         throw new Error(`Fixture setup: mock command resolution failed: ${detail}`);
       }
     }
+    const actorEnv = process.env.NODE_OPTIONS ? { NODE_OPTIONS: process.env.NODE_OPTIONS } : {};
+    if (process.platform === "win32") {
+      const token = randomUUID();
+      const deadline = Date.now() + 45_000;
+      const censusCommand =
+        scenario === "census-startup-failure" ? "fixture-missing-python" : "python";
+      const censusScript = path.join(path.dirname(fixture), "ci-windows-process-census.py");
+      const censusArgs = ["-I", "-S", censusScript];
+      censusService = spawn(censusCommand, censusArgs, {
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          OPENCLAW_CI_CENSUS_TOKEN: token,
+          OPENCLAW_CI_CENSUS_PARENT_PID: String(process.pid),
+        },
+      });
+      report.processDiagnostics.censusService = captureProcessDiagnostic(
+        censusService,
+        `${censusCommand} -I -S census-service`,
+      );
+      censusServiceClosed = new Promise((resolve) => {
+        censusService.once("close", (code, signal) => {
+          if (sentinel && !stopping) {
+            void stop(`Windows process census service exited (${code ?? signal})`);
+          }
+          resolve({ code, signal });
+        });
+      });
+      const ready = await readCensusReady(censusService, deadline);
+      if (
+        ready?.v !== 1 ||
+        !Number.isInteger(ready.port) ||
+        ready.port < 1 ||
+        ready.port > 65_535 ||
+        Object.keys(ready).toSorted().join(",") !== "port,v"
+      ) {
+        throw new Error("Windows process census service readiness was invalid");
+      }
+      Object.assign(actorEnv, {
+        OPENCLAW_CI_CENSUS_TOKEN: token,
+        OPENCLAW_CI_CENSUS_PORT: String(ready.port),
+        OPENCLAW_CI_CENSUS_DEADLINE_MS: String(deadline),
+      });
+      Object.assign(process.env, actorEnv);
+    }
     if (["git", "python"].includes(options.setupFailure)) {
       fs.writeFileSync(
         path.join(bin, options.setupFailure === "git" ? "git" : "python3"),
@@ -1102,15 +1227,24 @@ async function supervise() {
     }
     sentinel = spawn(process.execPath, [fixture, "sentinel", root, policyScenario], {
       // Parent teardown owns this group even before sentinel self-registration.
-      stdio: "ignore",
+      stdio: ["ignore", "ignore", "pipe"],
+      env: { ...process.env, ...actorEnv },
     });
+    report.processDiagnostics.sentinel = captureProcessDiagnostic(
+      sentinel,
+      "node ci-platform-checkout.mjs sentinel",
+    );
     // stop() joins the sentinel's actual close through pendingChildren before reporting.
     void track(sentinel);
-    const sentinelReady = await waitForReady(
-      () => records().some((entry) => entry.role === "sentinel"),
-      sentinel,
-      () => Boolean(stopping),
-    );
+    const sentinelReady =
+      process.platform === "win32"
+        ? (await record(sentinel.pid, "sentinel"), true)
+        : await waitForReady(
+            () => records().some((entry) => entry.role === "sentinel"),
+            sentinel,
+            () => Boolean(stopping),
+          );
+    if (scenario === "census-service-exit") censusService.kill("SIGKILL");
     if (stopping) {
       return;
     }
@@ -1151,6 +1285,7 @@ async function supervise() {
         GITHUB_PATH: path.join(root, "github-path"),
         RUNNER_OS: linux ? "Linux" : process.platform === "win32" ? "Windows" : "macOS",
         PATHEXT: process.env.PATHEXT,
+        ...actorEnv,
         CHECKOUT_REPO: "fixture/checkout",
         CHECKOUT_SHA: "a".repeat(40),
         CHECKOUT_BASE_SHA: linux && scenario === "early-leader-exit" ? "c".repeat(40) : "",
@@ -1160,7 +1295,7 @@ async function supervise() {
     });
     const closed = track(shell);
     if (shell.pid) {
-      record(shell.pid, "shell");
+      await record(shell.pid, "shell");
     }
     const ready = (name) =>
       waitForReady(
@@ -1203,7 +1338,7 @@ async function supervise() {
         () => Boolean(stopping),
       ))
     ) {
-      boundary("backoff-cancel");
+      await boundary("backoff-cancel");
       shell.kill("SIGTERM");
     }
     const code = await closed;
@@ -1215,14 +1350,14 @@ async function supervise() {
     }
     report.code = code;
     if (options.docsAgent && fs.readFileSync(path.join(root, "github-output"), "utf8")) {
-      boundary("output");
+      await boundary("output");
     }
     if (
       options.objects &&
       fs.existsSync(path.join(root, "github-env")) &&
       fs.readFileSync(path.join(root, "github-env"), "utf8").includes("PRE_COMMIT_CONFIG_PATH=")
     ) {
-      boundary("config-publication");
+      await boundary("config-publication");
     }
     for (const [name, file] of options.publisher || options.maturity || options.performance
       ? [
@@ -1231,9 +1366,9 @@ async function supervise() {
         ]
       : []) {
       if (fs.existsSync(path.join(root, file)) && fs.readFileSync(path.join(root, file), "utf8"))
-        boundary(name);
+        await boundary(name);
     }
-    boundary("exit");
+    await boundary("exit");
     await stop();
   } catch (error) {
     await stop(error);

--- a/test/scripts/fixtures/ci-windows-process-census.py
+++ b/test/scripts/fixtures/ci-windows-process-census.py
@@ -1,23 +1,18 @@
 """Read exact Windows process lifetimes for the checkout fixture."""
-import ctypes as c
+import ctypes as c, json, os, socket, time
 from ctypes import wintypes as w
-import json
-import sys
 
+kernel = c.WinDLL("kernel32", use_last_error=True)
+def bind(name, result, *arguments):
+    function = getattr(kernel, name)
+    function.restype, function.argtypes = result, arguments
+    return function
 
+open_process = bind("OpenProcess", w.HANDLE, w.DWORD, w.BOOL, w.DWORD)
+process_times = bind("GetProcessTimes", w.BOOL, w.HANDLE, *([c.POINTER(w.FILETIME)] * 4))
+wait = bind("WaitForSingleObject", w.DWORD, w.HANDLE, w.DWORD)
+close = bind("CloseHandle", w.BOOL, w.HANDLE)
 def read_processes(pids):
-    kernel = c.WinDLL("kernel32", use_last_error=True)
-
-    def bind(name, result, *arguments):
-        function = getattr(kernel, name)
-        function.restype, function.argtypes = result, arguments
-        return function
-
-    open_process = bind("OpenProcess", w.HANDLE, w.DWORD, w.BOOL, w.DWORD)
-    process_times = bind("GetProcessTimes", w.BOOL, w.HANDLE,
-                         *([c.POINTER(w.FILETIME)] * 4))
-    wait = bind("WaitForSingleObject", w.DWORD, w.HANDLE, w.DWORD)
-    close = bind("CloseHandle", w.BOOL, w.HANDLE)
     observations = []
     for pid in pids:
         if not isinstance(pid, int) or pid <= 0:
@@ -44,6 +39,69 @@ def read_processes(pids):
                 raise c.WinError(c.get_last_error())
     return observations
 
+def respond(request, token):
+    if type(request) is not dict or type(request.get("v")) is not int or request["v"] != 1:
+        raise ValueError("Expected protocol version 1")
+    if request.get("token") != token:
+        raise ValueError("Invalid census token")
+    operation = request.get("op")
+    fields = {"census": {"v", "token", "op", "pids"},
+              "shutdown": {"v", "token", "op"}}.get(operation)
+    if fields is None:
+        raise ValueError("Invalid census operation")
+    if set(request) != fields:
+        raise ValueError("Invalid census request fields")
+    if operation == "shutdown":
+        return {"v": 1, "ok": True}, True
+    pids = request["pids"]
+    valid = type(pids) is list and len(pids) <= 256 and all(
+        type(pid) is int and pid > 0 for pid in pids)
+    if not valid or len(set(pids)) != len(pids):
+        raise ValueError("Expected unique positive process ids")
+    return {"v": 1, "observations": read_processes(pids)}, False
+
+def serve():
+    token = os.environ["OPENCLAW_CI_CENSUS_TOKEN"]
+    deadline = time.monotonic() + 60
+    parent = open_process(0x100000, False, int(
+        os.environ["OPENCLAW_CI_CENSUS_PARENT_PID"]))  # SYNCHRONIZE
+    if not parent:
+        raise c.WinError(c.get_last_error())
+    listener = socket.create_server(("127.0.0.1", 0))
+    listener.settimeout(0.1)
+    print(json.dumps({"v": 1, "port": listener.getsockname()[1]}), flush=True)
+    try:
+        with listener:
+            while time.monotonic() < deadline:
+                parent_state = wait(parent, 0)
+                if parent_state not in (0, 258):
+                    raise c.WinError(c.get_last_error())
+                if parent_state == 0:
+                    break
+                try:
+                    connection, _ = listener.accept()
+                except TimeoutError:
+                    continue
+                with connection:
+                    connection.settimeout(max(0.001, deadline - time.monotonic()))
+                    try:
+                        with connection.makefile("rb") as stream:
+                            line, tail = stream.readline(16 * 1024 + 2), stream.read(1)
+                        if not line.endswith(b"\n") or tail or len(line) > 16 * 1024 + 1:
+                            raise ValueError("Expected one bounded JSON line")
+                        response, shutdown = respond(json.loads(line), token)
+                    except Exception as error:
+                        response, shutdown = {"v": 1, "error": str(error)}, False
+                    try:
+                        connection.sendall(json.dumps(
+                            response, separators=(",", ":")).encode() + b"\n")
+                    except OSError:
+                        continue
+                    if shutdown:
+                        break
+    finally:
+        if not close(parent):
+            raise c.WinError(c.get_last_error())
 
 if __name__ == "__main__":
-    json.dump(read_processes(json.load(sys.stdin)), sys.stdout)
+    serve()

--- a/test/scripts/fixtures/ci-windows-process-census.py
+++ b/test/scripts/fixtures/ci-windows-process-census.py
@@ -1,6 +1,11 @@
 """Read exact Windows process lifetimes for the checkout fixture."""
-import ctypes as c, json, os, socket, time
+import ctypes as c, json, os, socket, socketserver, threading, time
 from ctypes import wintypes as w
+
+FRAME_BYTES = 16 * 1024
+FRAME_TIMEOUT_SECONDS = 0.5
+PARENT_POLL_SECONDS = 0.1
+MAX_CLIENTS = 8
 
 kernel = c.WinDLL("kernel32", use_last_error=True)
 def bind(name, result, *arguments):
@@ -60,48 +65,95 @@ def respond(request, token):
         raise ValueError("Expected unique positive process ids")
     return {"v": 1, "observations": read_processes(pids)}, False
 
+def read_frame(connection):
+    deadline = time.monotonic() + FRAME_TIMEOUT_SECONDS
+    frame = bytearray()
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("Census frame deadline exceeded")
+        connection.settimeout(remaining)
+        chunk = connection.recv(max(1, FRAME_BYTES + 2 - len(frame)))
+        if not chunk:
+            break
+        frame.extend(chunk)
+        if len(frame) > FRAME_BYTES + 1:
+            break
+    if (len(frame) > FRAME_BYTES + 1 or not frame.endswith(b"\n")
+            or b"\n" in frame[:-1]):
+        raise ValueError("Expected one bounded JSON line")
+    return bytes(frame)
+
+class CensusHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        try:
+            response, shutdown = respond(
+                json.loads(read_frame(self.request)), self.server.token)
+        except Exception as error:
+            response, shutdown = {"v": 1, "error": str(error)}, False
+        try:
+            self.request.sendall(json.dumps(
+                response, separators=(",", ":")).encode() + b"\n")
+        except OSError:
+            return
+        if shutdown:
+            # Publish the acknowledgement before asking the owner loop to stop.
+            self.server.stop_event.set()
+
+class CensusServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    daemon_threads = False
+    block_on_close = True
+    request_queue_size = MAX_CLIENTS
+
+    def __init__(self, token):
+        self.token = token
+        self.stop_event = threading.Event()
+        self.slots = threading.BoundedSemaphore(MAX_CLIENTS)
+        super().__init__(("127.0.0.1", 0), CensusHandler)
+        self.timeout = PARENT_POLL_SECONDS
+
+    def process_request(self, request, client_address):
+        if not self.slots.acquire(blocking=False):
+            self.shutdown_request(request)
+            return
+        try:
+            super().process_request(request, client_address)
+        except BaseException:
+            self.slots.release()
+            raise
+
+    def process_request_thread(self, request, client_address):
+        try:
+            super().process_request_thread(request, client_address)
+        finally:
+            self.slots.release()
+
 def serve():
     token = os.environ["OPENCLAW_CI_CENSUS_TOKEN"]
-    deadline = time.monotonic() + 60
+    deadline = time.monotonic() + int(
+        os.environ["OPENCLAW_CI_CENSUS_MAX_LIFETIME_MS"]) / 1000
     parent = open_process(0x100000, False, int(
         os.environ["OPENCLAW_CI_CENSUS_PARENT_PID"]))  # SYNCHRONIZE
     if not parent:
         raise c.WinError(c.get_last_error())
-    listener = socket.create_server(("127.0.0.1", 0))
-    listener.settimeout(0.1)
-    print(json.dumps({"v": 1, "port": listener.getsockname()[1]}), flush=True)
+    server = None
     try:
-        with listener:
-            while time.monotonic() < deadline:
-                parent_state = wait(parent, 0)
-                if parent_state not in (0, 258):
-                    raise c.WinError(c.get_last_error())
-                if parent_state == 0:
-                    break
-                try:
-                    connection, _ = listener.accept()
-                except TimeoutError:
-                    continue
-                with connection:
-                    connection.settimeout(max(0.001, deadline - time.monotonic()))
-                    try:
-                        with connection.makefile("rb") as stream:
-                            line, tail = stream.readline(16 * 1024 + 2), stream.read(1)
-                        if not line.endswith(b"\n") or tail or len(line) > 16 * 1024 + 1:
-                            raise ValueError("Expected one bounded JSON line")
-                        response, shutdown = respond(json.loads(line), token)
-                    except Exception as error:
-                        response, shutdown = {"v": 1, "error": str(error)}, False
-                    try:
-                        connection.sendall(json.dumps(
-                            response, separators=(",", ":")).encode() + b"\n")
-                    except OSError:
-                        continue
-                    if shutdown:
-                        break
+        server = CensusServer(token)
+        print(json.dumps({"v": 1, "port": server.server_address[1]}), flush=True)
+        while time.monotonic() < deadline and not server.stop_event.is_set():
+            parent_state = wait(parent, 0)
+            if parent_state not in (0, 258):
+                raise c.WinError(c.get_last_error())
+            if parent_state == 0:
+                break
+            server.handle_request()
     finally:
-        if not close(parent):
-            raise c.WinError(c.get_last_error())
+        try:
+            if server:
+                server.server_close()
+        finally:
+            if not close(parent):
+                raise c.WinError(c.get_last_error())
 
 if __name__ == "__main__":
     serve()


### PR DESCRIPTION
Fixes #136317

## What Problem This Solves

The Windows checkout fixture owned one census service, but that service accepted one client at a time and then blocked waiting for a newline plus EOF. A partial client therefore stopped parent polling, concurrent census requests, authenticated shutdown, and final cleanup until the independent 60-second service ceiling expired. That exceeded the supervisor's 45-second runtime plus 4-second cleanup window.

## Canonical Repair

Lifecycle ownership remains in `ci-platform-checkout.mjs`: one supervisor-owned service starts before actors, preserves Windows process creation-time identity, and is joined after shutdown.

The service now:

- uses bounded stdlib threading with eight non-daemon handlers and a fixed semaphore cap;
- rejects saturated clients instead of creating unbounded threads;
- applies one absolute 500 ms wall-clock deadline to the complete frame, including EOF, so slow-drip clients cannot retain handlers;
- polls parent death and shutdown at most every 100 ms;
- derives its 49-second ceiling from the existing 45-second fixture runtime plus 4-second cleanup budget;
- accepts exactly one JSON line of at most 16 KiB plus newline and requires EOF after it;
- rejects trailing bytes/frames, malformed JSON, unknown operations, extra fields, wrong tokens, boolean versions/PIDs, duplicate/non-positive PIDs, and more than 256 PIDs before Windows API calls;
- preserves ordered observations and exact `creationTime` identity;
- acknowledges authenticated shutdown before signaling the owner loop;
- closes the listener and parent handle in `finally`, then joins all handlers.

The repair removes the serial accept/read loop and consolidates service startup, request, shutdown, and cleanup in one reusable TypeScript fixture. The PID-reuse test now reuses that fixture instead of embedding a second Python service lifecycle.

## Evidence

Pre-fix red proof against `7bc0f31d27a905b60b9b2822f27133f53ba094f3`:

- a partial client blocked a concurrent valid census for 0.802 seconds in a portable stubbed-Windows harness;
- the original timeout reproduction, startup `ENOENT`, unexpected service death, sentinel diagnostics, and PID-reuse coverage remain.

Post-fix green proof:

- the same harness kept a slow-drip client active while a valid census and authenticated shutdown completed;
- parent death closed the listener and joined the blocked handler within 0.7 seconds;
- `node scripts/run-vitest.mjs test/scripts/ci-platform-checkout.test.ts`: 44 passed, 4 Windows-only skipped;
- malformed/wrong-token/unknown-op/extra-field/duplicate-PID/boolean/oversized/257-PID/trailing-frame/no-EOF requests are table-driven through the shared fixture;
- focused `oxlint`, `pnpm lint:scripts`, `oxfmt --check`, Python compile, Node syntax, and `git diff --check` pass;
- changed-file routing selects `testRoot, tooling`;
- `pnpm tsgo:test:root` is blocked by 286 unrelated missing shared worktree dependencies/assets; filtered output contains no errors for the two touched TypeScript files. No install was run in the worktree.

Independent autoreview found one P1 in the first repair draft: socket inactivity timeouts allowed slow-drip clients to retain all handlers. The final commit replaces that with the absolute deadline above and adds a slow-drip regression.

Direct sibling Codex inspection found only the unrelated experimental exec-server CLI declaration and prompt normalization/test boundary in `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; neither defines this fixture protocol.

## Scope And LOC

Production: `+0/-0`.

Repair commit over frozen source head `7bc0f31d`:

- `test/scripts/ci-checkout.test-support.ts`: `+117/-4`
- `test/scripts/ci-platform-checkout.test.ts`: `+159/-104`
- `test/scripts/fixtures/ci-platform-checkout.mjs`: `+6/-3`
- `test/scripts/fixtures/ci-windows-process-census.py`: `+87/-35`

Repair delta: `+369/-146`, net `+223` test/test-support lines.

Entire PR over parent `993ad304` remains test/test-support only: `+668/-105`, net `+563`.

## Overlap Pins

Checked September 3, 2026:

- current `main`: `74ade6f54c87aa14a73c624047b60c1fa75b4dca`; no overlap in the four allowed files since the PR parent;
- #132180 at `3d2801dd9fc5aeeeed249c86dba7d1742191545d`: no allowed-file overlap;
- #131682 at `fb32d06c6a0160408020200f84b758c0836c734d`: same support/test/fixture files, different lock/readiness hunks;
- #133910 at `b962a6fbdfbab09729d785a0e8847d25cc099f23`: no allowed-file overlap;
- #137014 at `c801902633ececc1fbc13fa831719ac004250bf9`: one unrelated `nodeEntryIndex` test hunk;
- #136334 at `e2c5a7a91550d7e24649b93d5056bbd8f10e58e5`: unrelated checkout-materialization test hunks.

## Remaining Proof

Native Windows proof is intentionally deferred to the lander. Before merge, run `windows-testbox-probe.yml` at exact head `ddd41f058eb5bccedfc7347b3b9bd8b04f1de880` on:

- `blacksmith-16vcpu-windows-2025`
- `blacksmith-32vcpu-windows-2025`

The PR remains draft. No CI or Testbox workflow was manually dispatched.
