### PR TITLE
perf: reuse runtime marker patterns in outbound cleanup

### DIFF
--- a/src/infra/outbound/protocol-scaffolding.ts
+++ b/src/infra/outbound/protocol-scaffolding.ts
@@ -21,10 +21,12 @@ const INTERNAL_RUNTIME_SCAFFOLDING_TAG_RE = new RegExp(
   `<\\s*\\/?\\s*(?:${INTERNAL_RUNTIME_SCAFFOLDING_TAG_PATTERN})\\b[^>]*>`,
   "gi",
 );
-const INTERNAL_RUNTIME_MARKER_LINES = [
+const INTERNAL_RUNTIME_MARKER_LINE_PATTERNS = [
   "<<<BEGIN_UNTRUSTED_CHILD_RESULT>>>",
   "<<<END_UNTRUSTED_CHILD_RESULT>>>",
-] as const;
+].map(
+  (marker) => new RegExp(`(?:^|\\r?\\n)[ \\t]*${escapeRegExp(marker)}[ \\t]*(?=\\r?\\n|$)`, "g"),
+);
 const ESCAPED_INTERNAL_RUNTIME_CONTEXT_BEGIN = escapeRegExp(INTERNAL_RUNTIME_CONTEXT_BEGIN);
 // Runtime producers escape nested opening delimiters. Consume every closing
 // marker before the next opener so marker-shaped payload text cannot escape.
@@ -51,14 +53,6 @@ function stripInlineInternalRuntimeContextBlocks(text: string): string {
     (block, offset: number, value: string) =>
       isStandaloneMarkerAt(value, INTERNAL_RUNTIME_CONTEXT_BEGIN, offset) ? block : "",
   );
-}
-
-function standaloneLinePattern(token: string): string {
-  return `(?:^|\\r?\\n)[ \\t]*${escapeRegExp(token)}[ \\t]*(?=\\r?\\n|$)`;
-}
-
-function stripStandaloneMarkerLine(text: string, marker: string): string {
-  return text.replace(new RegExp(standaloneLinePattern(marker), "g"), "");
 }
 
 function isPromptDataHeaderLine(line: string): boolean {
@@ -100,8 +94,9 @@ export function stripInternalRuntimeScaffolding(text: string): string {
       .replace(INTERNAL_RUNTIME_SCAFFOLDING_TAG_RE, ""),
     { preserveSurroundingWhitespace: true },
   );
-  for (const marker of INTERNAL_RUNTIME_MARKER_LINES) {
-    stripped = stripStandaloneMarkerLine(stripped, marker);
+  // Global replacement resets lastIndex, including between nested payload fields.
+  for (const pattern of INTERNAL_RUNTIME_MARKER_LINE_PATTERNS) {
+    stripped = stripped.replace(pattern, "");
   }
   return stripPlainTextToolCallBlocks(stripped, { resolveProtectedRanges: findCodeRegions });
 }


### PR DESCRIPTION
## What Problem This Solves

Outbound text and nested payload cleanup prepare the same two child-result marker patterns for every text field. This adds avoidable work to reply sanitization, even though the marker grammar is fixed for the process.

This is part of a maintainer-requested performance and cleanup pass. It does not fix a reported content discrepancy or change the text users receive.

## Why This Change Was Made

Prepare the two private regular expressions once in the existing scaffolding owner, then preserve the exact sequential replacement order. Remove the two single-use pattern-building wrappers. The pattern bytes and flags remain identical; global string replacement resets `lastIndex` before each use, including successive nested payload fields. The pinned Node 26.8.1 V8 replacement implementation was inspected directly.

This removes repeated pattern-string preparation and RegExp allocation; it does not claim that the engine previously recompiled the expression on every call. No cache keys, invalidation path, new dependency, configuration, protocol, or persistence changes.

Production LOC: +7/-12 (net -5). Tests: unchanged. Existing assertions already cover the relevant output contracts, so no implementation-mirroring test was added.

## User Impact

Reply cleanup performs less local CPU work while retaining the same output for ordinary text, runtime markers, code fences, XML-like content and nested delivery payloads. Model latency, Gateway startup and channel-send latency were not measured by this experiment and are not claimed to improve.

## Evidence

The frozen native experiment used Node 26.8.1, a before/candidate/candidate/before process order, 8 workload rows, 16 controls, 48 untimed proof calls and 4,864 timing calls through complete exported operations. Each row/process used one first call, two warm calls and 16 measured means of 8 calls. Full output/identity graphs and loaded export bodies were checked before timing; an independent reviewer recomputed the results from retained raw observations.

| Complete operation | Forward median improvement | Reverse median improvement |
| --- | ---: | ---: |
| Scalar runtime scaffolding cleanup | 28.00% | 31.85% |
| Recursive outbound payload cleanup | 36.99% | 38.96% |
| Whole plain-text sanitizer | 14.61% | 12.04% |

All three primary rows passed the preset 3% gate in both orders. The protected fenced-XML row was **4.51% slower (+3.570 microseconds)** forward and **9.57% faster (-8.300 microseconds)** reverse. Its measured-mean p95 moved +65.33%/-50.28%. It passed the preset protected gate, which rejects a >3% and >1 microsecond regression in both orders. This is mixed control evidence, not a claim that every input improved. Other first/warm/tail samples also fluctuated; raw results were retained. These p95 values are nearest-rank maxima of 16 measured means, not population confidence bounds.

Kernel RSS decreased 0.62%/0.28%; sampled RSS decreased 0.43%/0.25%. CPU totals were mixed. Module import took seconds and is outside the per-call gain; no startup claim is made.

The performance baseline was `2fffd4e8ba116813222b28b89179fd911784aeae`; the exact owner and two outbound callers were unchanged when preparing this PR on `4091eb91edb34b96f502dc5466b13eaed871a635`. Fresh validation on that main baseline and the candidate:

- `node scripts/run-vitest.mjs src/infra/outbound/sanitize-text.test.ts src/infra/outbound/payloads.test.ts src/agents/internal-runtime-context.test.ts --reporter=verbose --reporter=json --outputFile=<local-result.json>`: the same 174 cases passed before and after.
- `node scripts/check-changed.mjs -- src/infra/outbound/protocol-scaffolding.ts`: passed; observed process groups and children terminated normally.
- Fresh independent Codex review: no actionable P0-P2 findings.
- Native proof validates real exported cleanup/sanitizer/payload functions; it is not an authenticated Gateway or live-channel test. This behavior-neutral owner refactor does not alter delivery, provider, or network boundaries.

Local immutable proof identifiers: final native evidence `d77f0fcf08684e7280fe3edf143b1e92ffd75dd4c5999f0024053939240e94d2`; independent audit `00b7c3b24a03d0ddf3a15c3e6f82db7f932172615074a0b0b5af04e826c17a31`; exact 174-case comparison `d91ed568e9114d64e7f566de8b2b86a6db90bc447037eb858ae8e06dea999e7b`. These identify retained local artifacts, not downloadable public attachments.
