### PR TITLE
fix(ci): restore chat-update dispatch assertions

### DIFF
--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -150,6 +150,7 @@ describe("gateway update action", () => {
           signal,
           timeoutMs: 1_200_000,
           forceSyntheticClient: true,
+          operatorRoleActor: { kind: "system" },
           syntheticScopes: ["operator.admin"],
           resolveGatewayContext: expect.any(Function),
         },

--- a/src/auto-reply/reply/commands-update.test.ts
+++ b/src/auto-reply/reply/commands-update.test.ts
@@ -146,6 +146,7 @@ describe("handleUpdateCommand", () => {
         timeoutMs: 1_200_000,
         resolveGatewayContext: expect.any(Function),
         forceSyntheticClient: true,
+        operatorRoleActor: { kind: "system" },
         syntheticScopes: ["operator.admin"],
       },
     );


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where CI fails four chat-update tests because their exact dispatch assertions omit the system actor carried by the shared Gateway helper.

## Why This Change Was Made

The shared in-process dispatcher and its owner tests gained the explicit system actor in #136952. This updates the two remaining caller assertions while preserving their owner checks, trusted routing, admin scopes, abort signal, and 20-minute timeout.

Reuses Peter Steinberger's exact two-line fix from [0fee3dcee](https://github.com/openclaw/openclaw/commit/0fee3dcee793f5a1f0367191d822323bf08fb22b), already present in #137041. It is separated here so this CI prerequisite can land independently of that PR's unrelated UI and Android changes.

## User Impact

No runtime behavior changes. Restores the update test gate for current main and dependent PRs.

## Evidence

- Before: reproduced all four assertion failures on main `993ad3048bf`; the other 46 tests passed.
- After: all 50 tests pass across the update tool, `/update`, and shared in-process Gateway helper.
- Command: `node scripts/run-vitest.mjs src/agents/tools/gateway-tool.test.ts src/auto-reply/reply/commands-update.test.ts src/agents/tools/in-process-gateway.test.ts`.
- Production delta: 0 lines; test delta: +2 lines. No new tests, mocks, timeouts, config keys, or schema changes.
- Changed-file gate passed, including formatting, core-test typechecks, lint, and repository guards.
- Fresh independent Codex review: scoped-clean through P2; no actionable findings.
