### PR TITLE
fix(memory): degrade to interval sync when kernel watch capacity is exhausted

### DIFF
--- a/extensions/memory-core/src/memory/manager-watch-linux.ts
+++ b/extensions/memory-core/src/memory/manager-watch-linux.ts
@@ -20,7 +20,7 @@ export type NativeMemoryWatchPair = {
   treeWatchers?: Map<string, LinuxMemoryDirectoryWatcher>;
 };
 
-export type LinuxMemoryDirectoryWatcher = {
+type LinuxMemoryDirectoryWatcher = {
   watcher: fsSync.FSWatcher;
   ino: number;
 };
@@ -225,7 +225,7 @@ export function attachLinuxMemoryDirectoryTreeWatchForDir(
   return "attached";
 }
 
-export function attachLinuxMemoryDirectoryTreeSubtree(
+function attachLinuxMemoryDirectoryTreeSubtree(
   ctx: MemoryWatchAttachContext,
   root: string,
   attachDirectory: (dir: string) => fsSync.FSWatcher | null,

--- a/extensions/memory-core/src/memory/manager-watch-linux.ts
+++ b/extensions/memory-core/src/memory/manager-watch-linux.ts
@@ -46,7 +46,7 @@ export type MemoryWatchAttachContext = {
     recordedInode: number,
     markDirty: MemoryWatchMarkDirty,
     reattach: () => NativeMemoryWatchResult,
-  ): void;
+  ): NativeMemoryWatchResult;
 };
 
 export function attachLinuxMemoryDirectoryTreeWatchForDir(
@@ -232,9 +232,16 @@ export function attachLinuxMemoryDirectoryTreeWatchForDir(
     return "attached";
   }
 
-  ctx.attachParentWatch(pair, recordedInode, markDirty, () =>
+  const parentResult = ctx.attachParentWatch(pair, recordedInode, markDirty, () =>
     attachLinuxMemoryDirectoryTreeWatchForDir(ctx, dir, markDirty),
   );
+  if (parentResult === "capacity") {
+    // The parent creation hit capacity exhaustion: coverage of root
+    // replacement cannot be restored, so this tree degrades like any other
+    // capacity failure instead of reporting a nominal "attached" pair.
+    ctx.closePair(pair);
+    return "capacity";
+  }
   return "attached";
 }
 

--- a/extensions/memory-core/src/memory/manager-watch-linux.ts
+++ b/extensions/memory-core/src/memory/manager-watch-linux.ts
@@ -1,0 +1,265 @@
+// Memory Core plugin module owns the Linux per-directory tree watcher for memory.
+import fsSync from "node:fs";
+import path from "node:path";
+import {
+  createSubsystemLogger,
+  type ResolvedMemorySearchConfig,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { isFileMissingError } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { isKernelWatchCapacityError, shouldIgnoreMemoryWatchPath } from "./manager-watch-paths.js";
+import type { MemoryWatchEventStats } from "./watch-settle.js";
+
+const log = createSubsystemLogger("memory");
+
+export type NativeMemoryWatchResult = "attached" | "missing" | "failed" | "capacity";
+
+export type NativeMemoryWatchPair = {
+  dir: string;
+  main: fsSync.FSWatcher | null;
+  parent: fsSync.FSWatcher | null;
+  treeWatchers?: Map<string, LinuxMemoryDirectoryWatcher>;
+};
+
+export type LinuxMemoryDirectoryWatcher = {
+  watcher: fsSync.FSWatcher;
+  ino: number;
+};
+
+export type MemoryWatchMarkDirty = (watchPath?: string, stats?: MemoryWatchEventStats) => void;
+
+/**
+ * Owner-provided surface for the Linux tree watcher. Keeping this narrow lets
+ * the directory-tree algorithm live outside the manager class while the class
+ * still owns pair bookkeeping, fallbacks, and capacity degradation.
+ */
+export type MemoryWatchAttachContext = {
+  closed(): boolean;
+  readonly multimodalSettings: ResolvedMemorySearchConfig["multimodal"] | undefined;
+  createNativeWatch: typeof fsSync.watch;
+  registerPair(pair: NativeMemoryWatchPair): void;
+  closePair(pair: NativeMemoryWatchPair): void;
+  /** Capacity-exhausted degrade: warn once, mark dirty, guarantee interval sync. */
+  onCapacityExhausted(dir: string, markDirty: MemoryWatchMarkDirty): void;
+  chokidarFallback(dir: string, markDirty: MemoryWatchMarkDirty): void;
+  attachParentWatch(
+    pair: NativeMemoryWatchPair,
+    recordedInode: number,
+    markDirty: MemoryWatchMarkDirty,
+    reattach: () => NativeMemoryWatchResult,
+  ): void;
+};
+
+export function attachLinuxMemoryDirectoryTreeWatchForDir(
+  ctx: MemoryWatchAttachContext,
+  dir: string,
+  markDirty: MemoryWatchMarkDirty,
+): NativeMemoryWatchResult {
+  if (ctx.closed()) {
+    return "failed";
+  }
+  let recordedInode: number | null;
+  try {
+    recordedInode = fsSync.statSync(dir).ino;
+  } catch (err) {
+    return isFileMissingError(err) ? "missing" : "failed";
+  }
+
+  let pair: NativeMemoryWatchPair | null = null;
+  const treeWatchers = new Map<string, LinuxMemoryDirectoryWatcher>();
+  let rootMissing = false;
+  // Capacity exhaustion detected anywhere in the tree (root or child): the
+  // kernel cannot grant more watch instances, so chokidar's per-file watches
+  // would fail identically. The tree degrades to capacity polling instead.
+  let capacityExhausted = false;
+
+  const closeAndFallback = (message: string, err?: unknown) => {
+    log.warn(message);
+    if (pair) {
+      ctx.closePair(pair);
+    }
+    if (ctx.closed()) {
+      return;
+    }
+    markDirty();
+    if (isKernelWatchCapacityError(err)) {
+      ctx.onCapacityExhausted(dir, markDirty);
+      return;
+    }
+    ctx.chokidarFallback(dir, markDirty);
+  };
+
+  const closeDirectorySubtree = (watchDir: string) => {
+    const watchDirPrefix = `${watchDir}${path.sep}`;
+    for (const [entryDir, entry] of Array.from(treeWatchers.entries())) {
+      if (entryDir !== watchDir && !entryDir.startsWith(watchDirPrefix)) {
+        continue;
+      }
+      try {
+        entry.watcher.close();
+      } catch {
+        // ignore close failures
+      }
+      treeWatchers.delete(entryDir);
+    }
+  };
+
+  const attachDirectory = (watchDir: string): fsSync.FSWatcher | null => {
+    if (ctx.closed()) {
+      return null;
+    }
+    let currentInode: number;
+    try {
+      const currentStat = fsSync.statSync(watchDir);
+      if (!currentStat.isDirectory()) {
+        return null;
+      }
+      currentInode = currentStat.ino;
+    } catch (err) {
+      rootMissing ||= watchDir === dir && isFileMissingError(err);
+      return null;
+    }
+    const existing = treeWatchers.get(watchDir);
+    if (existing) {
+      if (existing.ino === currentInode) {
+        return existing.watcher;
+      }
+      closeDirectorySubtree(watchDir);
+    }
+    let watcher: fsSync.FSWatcher | undefined;
+    try {
+      watcher = ctx.createNativeWatch(watchDir, { recursive: false }, (eventType, filename) => {
+        if (ctx.closed() || (watcher && treeWatchers.get(watchDir)?.watcher !== watcher)) {
+          return;
+        }
+        if (filename == null) {
+          markDirty();
+          if (!attachLinuxMemoryDirectoryTreeSubtree(ctx, watchDir, attachDirectory)) {
+            closeAndFallback(`failed to refresh Linux memory directory watchers under ${watchDir}`);
+          }
+          return;
+        }
+        const full = path.join(watchDir, filename);
+        let stats: fsSync.Stats | undefined;
+        try {
+          const s = fsSync.lstatSync(full, { throwIfNoEntry: false });
+          stats = s ?? undefined;
+        } catch {
+          stats = undefined;
+        }
+        if (!stats) {
+          closeDirectorySubtree(full);
+        }
+        if (stats?.isDirectory()) {
+          if (eventType === "rename") {
+            closeDirectorySubtree(full);
+          }
+          if (!attachLinuxMemoryDirectoryTreeSubtree(ctx, full, attachDirectory)) {
+            closeAndFallback(`failed to attach Linux memory directory watcher under ${full}`);
+            return;
+          }
+        }
+        if (shouldIgnoreMemoryWatchPath(full, stats, ctx.multimodalSettings)) {
+          return;
+        }
+        markDirty(full, stats);
+      });
+    } catch (err) {
+      rootMissing ||= watchDir === dir && isFileMissingError(err);
+      if (isKernelWatchCapacityError(err)) {
+        capacityExhausted = true;
+      }
+      if (watchDir === dir && !rootMissing && !capacityExhausted) {
+        // Single warn for the plain-failure path; capacity degradation warns
+        // once through onCapacityExhausted instead of per directory.
+        log.warn(`failed to start Linux memory directory watcher on ${watchDir}: ${String(err)}`);
+      }
+      return null;
+    }
+    treeWatchers.set(watchDir, { watcher, ino: currentInode });
+    watcher.on("error", (err) => {
+      if (treeWatchers.get(watchDir)?.watcher !== watcher) {
+        return;
+      }
+      const detail = err instanceof Error ? err.message : String(err);
+      closeAndFallback(`memory Linux directory watcher error on ${watchDir}: ${detail}`, err);
+    });
+    return watcher;
+  };
+
+  const mainWatcher = attachDirectory(dir);
+  if (!mainWatcher) {
+    if (capacityExhausted && !rootMissing) {
+      return "capacity";
+    }
+    return rootMissing ? "missing" : "failed";
+  }
+  pair = { dir, main: mainWatcher, parent: null, treeWatchers };
+  ctx.registerPair(pair);
+  let subtreeAttached = attachLinuxMemoryDirectoryTreeSubtree(ctx, dir, attachDirectory);
+  // Scan errors can refer to a missing child, not the root. Only the root's
+  // identity can decide whether an existing parent should retain coverage.
+  try {
+    subtreeAttached = fsSync.statSync(dir).ino === recordedInode && subtreeAttached;
+  } catch (err) {
+    ctx.closePair(pair);
+    if (!ctx.closed()) {
+      markDirty();
+    }
+    return isFileMissingError(err) ? "missing" : "failed";
+  }
+  if (!subtreeAttached) {
+    if (capacityExhausted) {
+      // A child directory exhausted kernel watch capacity mid-setup: the
+      // partially attached tree cannot stay ahead of the same limit, so the
+      // whole directory degrades to capacity polling.
+      ctx.closePair(pair);
+      return "capacity";
+    }
+    closeAndFallback(`failed to attach Linux memory directory watcher subtree under ${dir}`);
+    return "attached";
+  }
+
+  ctx.attachParentWatch(pair, recordedInode, markDirty, () =>
+    attachLinuxMemoryDirectoryTreeWatchForDir(ctx, dir, markDirty),
+  );
+  return "attached";
+}
+
+export function attachLinuxMemoryDirectoryTreeSubtree(
+  ctx: MemoryWatchAttachContext,
+  root: string,
+  attachDirectory: (dir: string) => fsSync.FSWatcher | null,
+): boolean {
+  let rootStats: fsSync.Stats | undefined;
+  try {
+    rootStats = fsSync.lstatSync(root, { throwIfNoEntry: false }) ?? undefined;
+  } catch {
+    return false;
+  }
+  if (
+    !rootStats?.isDirectory() ||
+    shouldIgnoreMemoryWatchPath(root, rootStats, ctx.multimodalSettings)
+  ) {
+    // Not a directory (or an ignored path) has no subtree to attach; the
+    // caller's root watcher already covers it, so this is success.
+    return true;
+  }
+  if (!attachDirectory(root)) {
+    return false;
+  }
+  let entries: fsSync.Dirent[];
+  try {
+    entries = fsSync.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) {
+      continue;
+    }
+    if (!attachLinuxMemoryDirectoryTreeSubtree(ctx, path.join(root, entry.name), attachDirectory)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/extensions/memory-core/src/memory/manager-watch-linux.ts
+++ b/extensions/memory-core/src/memory/manager-watch-linux.ts
@@ -73,7 +73,11 @@ export function attachLinuxMemoryDirectoryTreeWatchForDir(
   let capacityExhausted = false;
 
   const closeAndFallback = (message: string, options?: { capacity?: boolean }) => {
-    log.warn(message);
+    // Capacity degradation emits its own single warning; logging the raw
+    // failure message first would double-report the same condition.
+    if (options?.capacity !== true) {
+      log.warn(message);
+    }
     if (pair) {
       ctx.closePair(pair);
     }

--- a/extensions/memory-core/src/memory/manager-watch-linux.ts
+++ b/extensions/memory-core/src/memory/manager-watch-linux.ts
@@ -72,7 +72,7 @@ export function attachLinuxMemoryDirectoryTreeWatchForDir(
   // would fail identically. The tree degrades to capacity polling instead.
   let capacityExhausted = false;
 
-  const closeAndFallback = (message: string, err?: unknown) => {
+  const closeAndFallback = (message: string, options?: { capacity?: boolean }) => {
     log.warn(message);
     if (pair) {
       ctx.closePair(pair);
@@ -81,7 +81,7 @@ export function attachLinuxMemoryDirectoryTreeWatchForDir(
       return;
     }
     markDirty();
-    if (isKernelWatchCapacityError(err)) {
+    if (options?.capacity === true) {
       ctx.onCapacityExhausted(dir, markDirty);
       return;
     }
@@ -134,7 +134,12 @@ export function attachLinuxMemoryDirectoryTreeWatchForDir(
         if (filename == null) {
           markDirty();
           if (!attachLinuxMemoryDirectoryTreeSubtree(ctx, watchDir, attachDirectory)) {
-            closeAndFallback(`failed to refresh Linux memory directory watchers under ${watchDir}`);
+            // A nested attach that hit capacity exhaustion sets the sticky
+            // closure flag; the refresh must degrade, not restart chokidar.
+            closeAndFallback(
+              `failed to refresh Linux memory directory watchers under ${watchDir}`,
+              { capacity: capacityExhausted },
+            );
           }
           return;
         }
@@ -154,7 +159,9 @@ export function attachLinuxMemoryDirectoryTreeWatchForDir(
             closeDirectorySubtree(full);
           }
           if (!attachLinuxMemoryDirectoryTreeSubtree(ctx, full, attachDirectory)) {
-            closeAndFallback(`failed to attach Linux memory directory watcher under ${full}`);
+            closeAndFallback(`failed to attach Linux memory directory watcher under ${full}`, {
+              capacity: capacityExhausted,
+            });
             return;
           }
         }
@@ -181,7 +188,9 @@ export function attachLinuxMemoryDirectoryTreeWatchForDir(
         return;
       }
       const detail = err instanceof Error ? err.message : String(err);
-      closeAndFallback(`memory Linux directory watcher error on ${watchDir}: ${detail}`, err);
+      closeAndFallback(`memory Linux directory watcher error on ${watchDir}: ${detail}`, {
+        capacity: isKernelWatchCapacityError(err),
+      });
     });
     return watcher;
   };

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -4,10 +4,7 @@ import path from "node:path";
 import chokidar from "chokidar";
 import { isPathInside } from "openclaw/plugin-sdk/file-access-runtime";
 import { classifyMemoryMultimodalPath } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import {
-  createSubsystemLogger,
-  type ResolvedMemorySearchConfig,
-} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   isFileMissingError,
   matchesExtraMemoryPathEntry,
@@ -16,6 +13,13 @@ import {
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { MemoryManagerSyncBase } from "./manager-sync-base.js";
+import {
+  attachLinuxMemoryDirectoryTreeWatchForDir,
+  type MemoryWatchAttachContext,
+  type NativeMemoryWatchPair,
+  type NativeMemoryWatchResult,
+} from "./manager-watch-linux.js";
+import { isKernelWatchCapacityError, shouldIgnoreMemoryWatchPath } from "./manager-watch-paths.js";
 import {
   countChokidarWatchedEntries,
   type MemoryWatchPressureUnit,
@@ -29,43 +33,15 @@ import {
 } from "./watch-settle.js";
 
 const MEMORY_WATCH_PRESSURE_STARTUP_CHECK_DELAY_MS = 10_000;
-const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
-  ".git",
-  "node_modules",
-  ".pnpm-store",
-  ".venv",
-  "venv",
-  ".tox",
-  "__pycache__",
-]);
 const log = createSubsystemLogger("memory");
 const TEST_MEMORY_WATCH_FACTORY_KEY = Symbol.for("openclaw.test.memoryWatchFactory");
 const TEST_MEMORY_NATIVE_WATCH_FACTORY_KEY = Symbol.for("openclaw.test.memoryNativeWatchFactory");
-
-type NativeMemoryWatchPair = {
-  dir: string;
-  main: fsSync.FSWatcher | null;
-  parent: fsSync.FSWatcher | null;
-  treeWatchers?: Map<string, LinuxMemoryDirectoryWatcher>;
-};
-
-type NativeMemoryWatchResult = "attached" | "missing" | "failed" | "capacity";
 
 // When the kernel cannot grant another inotify/watch instance (shared-tenant
 // containers exhausting fs.inotify.max_user_instances, or global fd limits),
 // every per-file chokidar fs.watch would fail the same way, so the only useful
 // degrade is skipping the fallback entirely and refreshing via interval sync.
 const MEMORY_WATCH_CAPACITY_FALLBACK_INTERVAL_MINUTES = 5;
-
-function isKernelWatchCapacityError(err: unknown): boolean {
-  const code = typeof err === "object" && err !== null && "code" in err ? err.code : undefined;
-  return code === "EMFILE" || code === "ENOSPC" || code === "ENFILE";
-}
-
-type LinuxMemoryDirectoryWatcher = {
-  watcher: fsSync.FSWatcher;
-  ino: number;
-};
 
 function resolveMemoryWatchFactory(): typeof chokidar.watch {
   if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") {
@@ -89,34 +65,6 @@ function resolveMemoryNativeWatchFactory(): typeof fsSync.watch {
   return fsSync.watch.bind(fsSync);
 }
 
-function shouldIgnoreMemoryWatchPath(
-  watchPath: string,
-  stats?: { isDirectory?: () => boolean },
-  multimodalSettings?: ResolvedMemorySearchConfig["multimodal"],
-): boolean {
-  const normalized = path.normalize(watchPath);
-  const parts = normalized
-    .split(path.sep)
-    .map((segment) => normalizeLowercaseStringOrEmpty(segment));
-  if (parts.some((segment) => IGNORED_MEMORY_WATCH_DIR_NAMES.has(segment))) {
-    return true;
-  }
-  if (stats?.isDirectory?.()) {
-    return false;
-  }
-  if (!stats) {
-    return false;
-  }
-  const extension = normalizeLowercaseStringOrEmpty(path.extname(normalized));
-  if (extension.length === 0 || extension === ".md") {
-    return false;
-  }
-  if (!multimodalSettings) {
-    return true;
-  }
-  return classifyMemoryMultimodalPath(normalized, multimodalSettings) === null;
-}
-
 function runDetachedMemorySync(sync: () => Promise<void>, reason: "interval" | "watch") {
   void sync().catch((err: unknown) => {
     log.warn(`memory sync failed (${reason}): ${String(err)}`);
@@ -126,6 +74,7 @@ function runDetachedMemorySync(sync: () => Promise<void>, reason: "interval" | "
 export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
   private nativeMemoryWatchPairs: NativeMemoryWatchPair[] = [];
   private readonly memoryWatchPressureWarning: MemoryWatchPressureWarningState = { shown: false };
+  private capacityPollingActive = false;
   protected ensureWatcher() {
     if (!this.sources.has("memory") || !this.settings.sync.watch) {
       return;
@@ -341,6 +290,12 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       // still drive watch sync (intervalMinutes defaults to 0; without
       // a watcher the directory would stop being indexed).
       markDirty();
+      if (isKernelWatchCapacityError(err)) {
+        // Capacity exhaustion also defeats chokidar's per-file watches;
+        // degrade to polling instead of fanning out doomed retries.
+        this.degradeMemoryWatchToPollingSync(dir, markDirty);
+        return;
+      }
       this.attachMemoryChokidarFallback(dir, markDirty);
     });
     this.nativeMemoryWatchPairs.push(pair);
@@ -421,8 +376,18 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
           // New coverage must attach before the old parent closes: the root
           // can disappear again between the inode check and native attachment.
           this.closeNativeMemoryWatchPair(pair);
+          if (result === "capacity") {
+            // Reattachment hit kernel watch exhaustion: chokidar would fail
+            // identically, so the directory degrades to polling instead.
+            this.degradeMemoryWatchToPollingSync(dir, markDirty);
+            return;
+          }
           if (result === "failed") {
             this.attachMemoryChokidarFallback(dir, markDirty);
+          } else if (result === "attached") {
+            // Watch coverage is back; interval ticks return to dirty-gated
+            // behavior instead of forcing a rescan every cycle.
+            this.capacityPollingActive = false;
           }
         },
       );
@@ -443,7 +408,11 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
           this.closeNativeMemoryWatchPair(pair);
           if (!this.closed) {
             markDirty();
-            this.attachMemoryChokidarFallback(dir, markDirty);
+            if (isKernelWatchCapacityError(err)) {
+              this.degradeMemoryWatchToPollingSync(dir, markDirty);
+            } else {
+              this.attachMemoryChokidarFallback(dir, markDirty);
+            }
           }
         }
         // A live main watcher still covers normal events without its parent.
@@ -459,216 +428,42 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     }
   }
 
-  // Linux inotify reports direct child changes from a watched directory, but
-  // it has no native recursive primitive. Watch directories only, then attach
-  // newly-created subdirectories on demand; this avoids per-file watchers.
+  // Linux inotify has no native recursive primitive, so the tree algorithm
+  // (per-directory watchers + on-demand subtree attach + parent reattach)
+  // lives in manager-watch-linux.ts; this wrapper feeds it the manager-owned
+  // bookkeeping, fallbacks, and capacity degradation.
   protected attachLinuxMemoryDirectoryTreeWatchForDir(
     dir: string,
     markDirty: (watchPath?: string, stats?: MemoryWatchEventStats) => void,
   ): NativeMemoryWatchResult {
-    if (this.closed) {
-      return "failed";
-    }
-    let recordedInode: number | null;
-    try {
-      recordedInode = fsSync.statSync(dir).ino;
-    } catch (err) {
-      return isFileMissingError(err) ? "missing" : "failed";
-    }
-
-    let pair: NativeMemoryWatchPair | null = null;
-    const treeWatchers = new Map<string, LinuxMemoryDirectoryWatcher>();
-    let rootMissing = false;
-    let capacityExhausted = false;
-
-    const closeAndFallback = (message: string) => {
-      log.warn(message);
-      if (pair) {
-        this.closeNativeMemoryWatchPair(pair);
-      }
-      if (this.closed) {
-        return;
-      }
-      markDirty();
-      this.attachMemoryChokidarFallback(dir, markDirty);
-    };
-
-    const closeDirectorySubtree = (watchDir: string) => {
-      const watchDirPrefix = `${watchDir}${path.sep}`;
-      for (const [entryDir, entry] of Array.from(treeWatchers.entries())) {
-        if (entryDir !== watchDir && !entryDir.startsWith(watchDirPrefix)) {
-          continue;
-        }
-        try {
-          entry.watcher.close();
-        } catch {
-          // ignore close failures
-        }
-        treeWatchers.delete(entryDir);
-      }
-    };
-
-    const attachDirectory = (watchDir: string): fsSync.FSWatcher | null => {
-      if (this.closed) {
-        return null;
-      }
-      let currentInode: number;
-      try {
-        const currentStat = fsSync.statSync(watchDir);
-        if (!currentStat.isDirectory()) {
-          return null;
-        }
-        currentInode = currentStat.ino;
-      } catch (err) {
-        rootMissing ||= watchDir === dir && isFileMissingError(err);
-        return null;
-      }
-      const existing = treeWatchers.get(watchDir);
-      if (existing) {
-        if (existing.ino === currentInode) {
-          return existing.watcher;
-        }
-        closeDirectorySubtree(watchDir);
-      }
-      let watcher: fsSync.FSWatcher | undefined;
-      try {
-        watcher = resolveMemoryNativeWatchFactory()(
-          watchDir,
-          { recursive: false },
-          (eventType, filename) => {
-            if (this.closed || (watcher && treeWatchers.get(watchDir)?.watcher !== watcher)) {
-              return;
-            }
-            if (filename == null) {
-              markDirty();
-              if (!this.attachLinuxMemoryDirectoryTreeSubtree(watchDir, attachDirectory)) {
-                closeAndFallback(
-                  `failed to refresh Linux memory directory watchers under ${watchDir}; falling back to chokidar`,
-                );
-              }
-              return;
-            }
-            const full = path.join(watchDir, filename);
-            let stats: fsSync.Stats | undefined;
-            try {
-              const s = fsSync.lstatSync(full, { throwIfNoEntry: false });
-              stats = s ?? undefined;
-            } catch {
-              stats = undefined;
-            }
-            if (!stats) {
-              closeDirectorySubtree(full);
-            }
-            if (stats?.isDirectory()) {
-              if (eventType === "rename") {
-                closeDirectorySubtree(full);
-              }
-              if (!this.attachLinuxMemoryDirectoryTreeSubtree(full, attachDirectory)) {
-                closeAndFallback(
-                  `failed to attach Linux memory directory watcher under ${full}; falling back to chokidar`,
-                );
-                return;
-              }
-            }
-            if (shouldIgnoreMemoryWatchPath(full, stats, this.settings.multimodal)) {
-              return;
-            }
-            markDirty(full, stats);
-          },
-        );
-      } catch (err) {
-        rootMissing ||= watchDir === dir && isFileMissingError(err);
-        if (watchDir === dir && isKernelWatchCapacityError(err)) {
-          capacityExhausted = true;
-        }
-        if (watchDir === dir && !rootMissing && !capacityExhausted) {
-          log.warn(
-            `failed to start Linux memory directory watcher on ${watchDir}: ${String(err)}; falling back to chokidar`,
-          );
-        }
-        return null;
-      }
-      treeWatchers.set(watchDir, { watcher, ino: currentInode });
-      watcher.on("error", (err) => {
-        if (treeWatchers.get(watchDir)?.watcher !== watcher) {
-          return;
-        }
-        const detail = err instanceof Error ? err.message : String(err);
-        closeAndFallback(`memory Linux directory watcher error on ${watchDir}: ${detail}`);
-      });
-      return watcher;
-    };
-
-    const mainWatcher = attachDirectory(dir);
-    if (!mainWatcher) {
-      if (capacityExhausted && !rootMissing) {
-        return "capacity";
-      }
-      return rootMissing ? "missing" : "failed";
-    }
-    pair = { dir, main: mainWatcher, parent: null, treeWatchers };
-    this.nativeMemoryWatchPairs.push(pair);
-    let subtreeAttached = this.attachLinuxMemoryDirectoryTreeSubtree(dir, attachDirectory);
-    // Scan errors can refer to a missing child, not the root. Only the root's
-    // identity can decide whether an existing parent should retain coverage.
-    try {
-      subtreeAttached = fsSync.statSync(dir).ino === recordedInode && subtreeAttached;
-    } catch (err) {
-      this.closeNativeMemoryWatchPair(pair);
-      if (!this.closed) {
-        markDirty();
-      }
-      return isFileMissingError(err) ? "missing" : "failed";
-    }
-    if (!subtreeAttached) {
-      closeAndFallback(
-        `failed to attach Linux memory directory watcher subtree under ${dir}; falling back to chokidar`,
-      );
-      return "attached";
-    }
-
-    this.attachNativeMemoryParentWatch(pair, recordedInode, markDirty, "Linux", () =>
-      this.attachLinuxMemoryDirectoryTreeWatchForDir(dir, markDirty),
+    return attachLinuxMemoryDirectoryTreeWatchForDir(
+      this.resolveLinuxWatchAttachContext(),
+      dir,
+      markDirty,
     );
-    return "attached";
   }
 
-  private attachLinuxMemoryDirectoryTreeSubtree(
-    root: string,
-    attachDirectory: (dir: string) => fsSync.FSWatcher | null,
-  ): boolean {
-    let rootStats: fsSync.Stats | undefined;
-    try {
-      rootStats = fsSync.lstatSync(root, { throwIfNoEntry: false }) ?? undefined;
-    } catch {
-      return false;
-    }
-    if (
-      !rootStats?.isDirectory() ||
-      shouldIgnoreMemoryWatchPath(root, rootStats, this.settings.multimodal)
-    ) {
-      return true;
-    }
-    if (!attachDirectory(root)) {
-      return false;
-    }
-    let entries: fsSync.Dirent[];
-    try {
-      entries = fsSync.readdirSync(root, { withFileTypes: true });
-    } catch {
-      return false;
-    }
-    for (const entry of entries) {
-      if (!entry.isDirectory() || entry.isSymbolicLink()) {
-        continue;
-      }
-      if (
-        !this.attachLinuxMemoryDirectoryTreeSubtree(path.join(root, entry.name), attachDirectory)
-      ) {
-        return false;
-      }
-    }
-    return true;
+  private resolveLinuxWatchAttachContext(): MemoryWatchAttachContext {
+    return {
+      closed: () => this.closed,
+      multimodalSettings: this.settings.multimodal,
+      createNativeWatch: resolveMemoryNativeWatchFactory(),
+      registerPair: (pair) => {
+        this.nativeMemoryWatchPairs.push(pair);
+      },
+      closePair: (pair) => {
+        this.closeNativeMemoryWatchPair(pair);
+      },
+      onCapacityExhausted: (degradedDir, markDirty) => {
+        this.degradeMemoryWatchToPollingSync(degradedDir, markDirty);
+      },
+      chokidarFallback: (fallbackDir, markDirty) => {
+        this.attachMemoryChokidarFallback(fallbackDir, markDirty);
+      },
+      attachParentWatch: (pair, recordedInode, markDirty, reattach) => {
+        this.attachNativeMemoryParentWatch(pair, recordedInode, markDirty, "Linux", reattach);
+      },
+    };
   }
 
   private closeNativeMemoryWatchChildren(pair: NativeMemoryWatchPair): void {
@@ -771,7 +566,9 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
   /**
    * Degrades a capacity-exhausted directory to interval-sync refreshing: one
    * warn, an immediate dirty sync, and a guaranteed interval timer (honoring a
-   * configured intervalMinutes, otherwise the fallback cadence).
+   * configured intervalMinutes, otherwise the fallback cadence). While active,
+   * every interval tick forces a rescan because no watcher remains to mark
+   * the index dirty on file changes.
    */
   private degradeMemoryWatchToPollingSync(
     dir: string,
@@ -780,6 +577,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     log.warn(
       `kernel watch capacity exhausted on ${dir}; skipping chokidar fallback and degrading memory index to interval sync`,
     );
+    this.capacityPollingActive = true;
     if (!this.closed) {
       markDirty();
     }
@@ -797,6 +595,12 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       return;
     }
     this.intervalTimer = setInterval(() => {
+      if (this.capacityPollingActive) {
+        // Degraded polling has no watcher to re-dirty the index, so every
+        // tick must rescan; otherwise the first successful sync clears the
+        // dirty flag and later edits are never picked up.
+        this.dirty = true;
+      }
       runDetachedMemorySync(() => this.sync({ reason: "interval" }), "interval");
     }, ms);
   }

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -282,7 +282,11 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
         return;
       }
       const message = err instanceof Error ? err.message : String(err);
-      log.warn(`memory native watcher error on ${dir}: ${message}`);
+      // Capacity exhaustion reports once through the degrade warning; the
+      // raw error line would double-report the same condition.
+      if (!isKernelWatchCapacityError(err)) {
+        log.warn(`memory native watcher error on ${dir}: ${message}`);
+      }
       // Per Node docs the FSWatcher is no longer usable after an error.
       this.closeNativeMemoryWatchPair(pair);
       if (this.closed) {
@@ -400,7 +404,10 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
           return;
         }
         const message = err instanceof Error ? err.message : String(err);
-        log.warn(`memory ${label} parent watcher error on ${path.dirname(dir)}: ${message}`);
+        // Capacity exhaustion reports once through the degrade warning.
+        if (!isKernelWatchCapacityError(err)) {
+          log.warn(`memory ${label} parent watcher error on ${path.dirname(dir)}: ${message}`);
+        }
         try {
           attachedParent.close();
         } catch {

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -74,7 +74,10 @@ function runDetachedMemorySync(sync: () => Promise<void>, reason: "interval" | "
 export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
   private nativeMemoryWatchPairs: NativeMemoryWatchPair[] = [];
   private readonly memoryWatchPressureWarning: MemoryWatchPressureWarningState = { shown: false };
-  private capacityPollingActive = false;
+  // Directories degraded to polling after kernel watch capacity exhaustion.
+  // Tracked per root: reattaching one root must not stop the forced rescans
+  // that other still-degraded roots depend on.
+  private readonly capacityDegradedDirs = new Set<string>();
   protected ensureWatcher() {
     if (!this.sources.has("memory") || !this.settings.sync.watch) {
       return;
@@ -385,9 +388,9 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
           if (result === "failed") {
             this.attachMemoryChokidarFallback(dir, markDirty);
           } else if (result === "attached") {
-            // Watch coverage is back; interval ticks return to dirty-gated
-            // behavior instead of forcing a rescan every cycle.
-            this.capacityPollingActive = false;
+            // Watch coverage is back for this root; interval ticks stay
+            // forced only while other degraded roots remain.
+            this.capacityDegradedDirs.delete(pair.dir);
           }
         },
       );
@@ -577,7 +580,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     log.warn(
       `kernel watch capacity exhausted on ${dir}; skipping chokidar fallback and degrading memory index to interval sync`,
     );
-    this.capacityPollingActive = true;
+    this.capacityDegradedDirs.add(dir);
     if (!this.closed) {
       markDirty();
     }
@@ -595,7 +598,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       return;
     }
     this.intervalTimer = setInterval(() => {
-      if (this.capacityPollingActive) {
+      if (this.capacityDegradedDirs.size > 0) {
         // Degraded polling has no watcher to re-dirty the index, so every
         // tick must rescan; otherwise the first successful sync clears the
         // dirty flag and later edits are never picked up.

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -49,7 +49,18 @@ type NativeMemoryWatchPair = {
   treeWatchers?: Map<string, LinuxMemoryDirectoryWatcher>;
 };
 
-type NativeMemoryWatchResult = "attached" | "missing" | "failed";
+type NativeMemoryWatchResult = "attached" | "missing" | "failed" | "capacity";
+
+// When the kernel cannot grant another inotify/watch instance (shared-tenant
+// containers exhausting fs.inotify.max_user_instances, or global fd limits),
+// every per-file chokidar fs.watch would fail the same way, so the only useful
+// degrade is skipping the fallback entirely and refreshing via interval sync.
+const MEMORY_WATCH_CAPACITY_FALLBACK_INTERVAL_MINUTES = 5;
+
+function isKernelWatchCapacityError(err: unknown): boolean {
+  const code = typeof err === "object" && err !== null && "code" in err ? err.code : undefined;
+  return code === "EMFILE" || code === "ENOSPC" || code === "ENFILE";
+}
 
 type LinuxMemoryDirectoryWatcher = {
   watcher: fsSync.FSWatcher;
@@ -188,19 +199,27 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     // ERR_FEATURE_UNAVAILABLE_ON_PLATFORM) the directory also falls back to
     // chokidar so freshness is preserved on the degraded path.
     const nativeRecursiveSupported = process.platform === "darwin" || process.platform === "win32";
+    let capacityDegraded = false;
     for (const dir of dirWatchPaths) {
       const attached = nativeRecursiveSupported
         ? this.attachNativeMemoryWatchForDir(dir, markDirty)
         : process.platform === "linux"
           ? this.attachLinuxMemoryDirectoryTreeWatchForDir(dir, markDirty)
           : "failed";
+      if (attached === "capacity") {
+        this.degradeMemoryWatchToPollingSync(dir, markDirty);
+        capacityDegraded = true;
+        continue;
+      }
       if (attached !== "attached") {
         // Native creation failed (dir missing, unsupported FS, throw) —
         // fall back to chokidar so directory coverage isn't dropped.
         fileWatchPaths.add(dir);
       }
     }
-    if (fileWatchPaths.size > 0) {
+    if (fileWatchPaths.size > 0 && !capacityDegraded) {
+      // Under exhausted kernel watch capacity every chokidar per-file watch
+      // would fail identically; interval sync covers those paths instead.
       this.attachMemoryChokidarPaths(Array.from(fileWatchPaths), markDirty);
     }
     this.scheduleMemoryWatchPressureStartupCheck();
@@ -296,6 +315,9 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     } catch (err) {
       if (isFileMissingError(err)) {
         return "missing";
+      }
+      if (isKernelWatchCapacityError(err)) {
+        return "capacity";
       }
       log.warn(
         `failed to start native recursive watcher on ${dir}: ${String(err)}; falling back to chokidar`,
@@ -457,6 +479,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     let pair: NativeMemoryWatchPair | null = null;
     const treeWatchers = new Map<string, LinuxMemoryDirectoryWatcher>();
     let rootMissing = false;
+    let capacityExhausted = false;
 
     const closeAndFallback = (message: string) => {
       log.warn(message);
@@ -555,7 +578,10 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
         );
       } catch (err) {
         rootMissing ||= watchDir === dir && isFileMissingError(err);
-        if (watchDir === dir && !rootMissing) {
+        if (watchDir === dir && isKernelWatchCapacityError(err)) {
+          capacityExhausted = true;
+        }
+        if (watchDir === dir && !rootMissing && !capacityExhausted) {
           log.warn(
             `failed to start Linux memory directory watcher on ${watchDir}: ${String(err)}; falling back to chokidar`,
           );
@@ -575,6 +601,9 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
 
     const mainWatcher = attachDirectory(dir);
     if (!mainWatcher) {
+      if (capacityExhausted && !rootMissing) {
+        return "capacity";
+      }
       return rootMissing ? "missing" : "failed";
     }
     pair = { dir, main: mainWatcher, parent: null, treeWatchers };
@@ -739,8 +768,27 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     });
   }
 
-  protected ensureIntervalSync() {
-    const minutes = this.settings.sync.intervalMinutes;
+  /**
+   * Degrades a capacity-exhausted directory to interval-sync refreshing: one
+   * warn, an immediate dirty sync, and a guaranteed interval timer (honoring a
+   * configured intervalMinutes, otherwise the fallback cadence).
+   */
+  private degradeMemoryWatchToPollingSync(
+    dir: string,
+    markDirty: (watchPath?: string, stats?: MemoryWatchEventStats) => void,
+  ): void {
+    log.warn(
+      `kernel watch capacity exhausted on ${dir}; skipping chokidar fallback and degrading memory index to interval sync`,
+    );
+    if (!this.closed) {
+      markDirty();
+    }
+    this.ensureIntervalSync(MEMORY_WATCH_CAPACITY_FALLBACK_INTERVAL_MINUTES);
+  }
+
+  protected ensureIntervalSync(fallbackMinutes = 0): void {
+    const configured = this.settings.sync.intervalMinutes;
+    const minutes = configured > 0 ? configured : fallbackMinutes;
     if (!minutes || minutes <= 0 || this.intervalTimer) {
       return;
     }

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -169,9 +169,11 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
         fileWatchPaths.add(dir);
       }
     }
-    if (fileWatchPaths.size > 0 && !capacityDegraded) {
+    if (fileWatchPaths.size > 0 && !capacityDegraded && this.capacityDegradedDirs.size === 0) {
       // Under exhausted kernel watch capacity every chokidar per-file watch
       // would fail identically; interval sync covers those paths instead.
+      // The degraded-roots set also covers late degradation from inside a
+      // nominally attached root (e.g. synchronous parent-watch failure).
       this.attachMemoryChokidarPaths(Array.from(fileWatchPaths), markDirty);
     }
     this.scheduleMemoryWatchPressureStartupCheck();
@@ -436,6 +438,16 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       });
       pair.parent = attachedParent;
     } catch (err) {
+      if (isKernelWatchCapacityError(err)) {
+        // The kernel cannot grant the parent watch even at creation time:
+        // root replacement would stay uncovered and a retry cannot succeed
+        // under the same limit. Degrade the tree to forced polling.
+        this.closeNativeMemoryWatchPair(pair);
+        if (!this.closed) {
+          this.degradeMemoryWatchToPollingSync(pair.dir, markDirty);
+        }
+        return;
+      }
       // Parent watcher couldn't start (e.g. parentDir not accessible).
       // The main watcher still works for non-replacement events; just
       // log and continue.

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -414,15 +414,22 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
           // ignore
         }
         pair.parent = null;
+        if (isKernelWatchCapacityError(err)) {
+          // Even with a live main watcher, the kernel can no longer grant the
+          // parent watch, so root replacement would go undetected — and a
+          // retry would hit the same limit. Degrade the whole tree to forced
+          // polling instead of running blind on the parent.
+          this.closeNativeMemoryWatchPair(pair);
+          if (!this.closed) {
+            this.degradeMemoryWatchToPollingSync(dir, markDirty);
+          }
+          return;
+        }
         if (!pair.main) {
           this.closeNativeMemoryWatchPair(pair);
           if (!this.closed) {
             markDirty();
-            if (isKernelWatchCapacityError(err)) {
-              this.degradeMemoryWatchToPollingSync(dir, markDirty);
-            } else {
-              this.attachMemoryChokidarFallback(dir, markDirty);
-            }
+            this.attachMemoryChokidarFallback(dir, markDirty);
           }
         }
         // A live main watcher still covers normal events without its parent.

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -317,11 +317,10 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     );
     if (parentResult === "capacity") {
       // Parent creation hit capacity exhaustion: root replacement would stay
-      // uncovered, so this tree degrades instead of reporting "attached".
+      // uncovered. Close the fresh pair and report capacity upward — both
+      // callers (startup setup and the replacement callback) own the single
+      // degradation, so it is recorded exactly once.
       this.closeNativeMemoryWatchPair(pair);
-      if (!this.closed) {
-        this.degradeMemoryWatchToPollingSync(dir, markDirty);
-      }
       return "capacity";
     }
     return "attached";
@@ -450,6 +449,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
         // A live main watcher still covers normal events without its parent.
       });
       pair.parent = attachedParent;
+      return "attached";
     } catch (err) {
       if (isKernelWatchCapacityError(err)) {
         // The kernel cannot grant the parent watch even at creation time.

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -308,9 +308,22 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       this.attachMemoryChokidarFallback(dir, markDirty);
     });
     this.nativeMemoryWatchPairs.push(pair);
-    this.attachNativeMemoryParentWatch(pair, recordedInode, markDirty, "native", () =>
-      this.attachNativeMemoryWatchForDir(dir, markDirty),
+    const parentResult = this.attachNativeMemoryParentWatch(
+      pair,
+      recordedInode,
+      markDirty,
+      "native",
+      () => this.attachNativeMemoryWatchForDir(dir, markDirty),
     );
+    if (parentResult === "capacity") {
+      // Parent creation hit capacity exhaustion: root replacement would stay
+      // uncovered, so this tree degrades instead of reporting "attached".
+      this.closeNativeMemoryWatchPair(pair);
+      if (!this.closed) {
+        this.degradeMemoryWatchToPollingSync(dir, markDirty);
+      }
+      return "capacity";
+    }
     return "attached";
   }
 
@@ -320,7 +333,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     markDirty: (watchPath?: string, stats?: MemoryWatchEventStats) => void,
     label: "native" | "Linux",
     reattach: () => NativeMemoryWatchResult,
-  ): void {
+  ): NativeMemoryWatchResult {
     const { dir } = pair;
     let watchedInode: number | null = recordedInode;
     // Non-recursive parent watcher: catches root-directory replacement so
@@ -439,14 +452,11 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       pair.parent = attachedParent;
     } catch (err) {
       if (isKernelWatchCapacityError(err)) {
-        // The kernel cannot grant the parent watch even at creation time:
-        // root replacement would stay uncovered and a retry cannot succeed
-        // under the same limit. Degrade the tree to forced polling.
-        this.closeNativeMemoryWatchPair(pair);
-        if (!this.closed) {
-          this.degradeMemoryWatchToPollingSync(pair.dir, markDirty);
-        }
-        return;
+        // The kernel cannot grant the parent watch even at creation time.
+        // Signal the caller instead of degrading here: during a reattach the
+        // caller must keep the (still-armed) polling state, and closing the
+        // freshly attached pair is the caller's bookkeeping.
+        return "capacity";
       }
       // Parent watcher couldn't start (e.g. parentDir not accessible).
       // The main watcher still works for non-replacement events; just
@@ -454,6 +464,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       log.warn(
         `memory ${label} parent watcher could not start on ${path.dirname(dir)}: ${String(err)}`,
       );
+      return "attached";
     }
   }
 
@@ -489,9 +500,8 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       chokidarFallback: (fallbackDir, markDirty) => {
         this.attachMemoryChokidarFallback(fallbackDir, markDirty);
       },
-      attachParentWatch: (pair, recordedInode, markDirty, reattach) => {
-        this.attachNativeMemoryParentWatch(pair, recordedInode, markDirty, "Linux", reattach);
-      },
+      attachParentWatch: (pair, recordedInode, markDirty, reattach) =>
+        this.attachNativeMemoryParentWatch(pair, recordedInode, markDirty, "Linux", reattach),
     };
   }
 

--- a/extensions/memory-core/src/memory/manager-watch-paths.ts
+++ b/extensions/memory-core/src/memory/manager-watch-paths.ts
@@ -1,0 +1,54 @@
+// Memory Core plugin module owns memory watch path classification helpers.
+import path from "node:path";
+import { classifyMemoryMultimodalPath } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import type { ResolvedMemorySearchConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
+  ".git",
+  "node_modules",
+  ".pnpm-store",
+  ".venv",
+  "venv",
+  ".tox",
+  "__pycache__",
+]);
+
+/**
+ * Kernel-level watch capacity exhaustion: fs.watch surfaces these errnos when
+ * inotify instances or global descriptors run out. Under this condition every
+ * additional per-file watch fails identically, so fallbacks must degrade to
+ * polling instead of retrying watches.
+ */
+export function isKernelWatchCapacityError(err: unknown): boolean {
+  const code = typeof err === "object" && err !== null && "code" in err ? err.code : undefined;
+  return code === "EMFILE" || code === "ENOSPC" || code === "ENFILE";
+}
+
+export function shouldIgnoreMemoryWatchPath(
+  watchPath: string,
+  stats?: { isDirectory?: () => boolean },
+  multimodalSettings?: ResolvedMemorySearchConfig["multimodal"],
+): boolean {
+  const normalized = path.normalize(watchPath);
+  const parts = normalized
+    .split(path.sep)
+    .map((segment) => normalizeLowercaseStringOrEmpty(segment));
+  if (parts.some((segment) => IGNORED_MEMORY_WATCH_DIR_NAMES.has(segment))) {
+    return true;
+  }
+  if (stats?.isDirectory?.()) {
+    return false;
+  }
+  if (!stats) {
+    return false;
+  }
+  const extension = normalizeLowercaseStringOrEmpty(path.extname(normalized));
+  if (extension.length === 0 || extension === ".md") {
+    return false;
+  }
+  if (!multimodalSettings) {
+    return true;
+  }
+  return classifyMemoryMultimodalPath(normalized, multimodalSettings) === null;
+}

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -13,6 +13,8 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vites
 const {
   capacityCode: capacityOverride,
   createdChokidarWatchers,
+  createdNativeWatchers,
+  makeDefaultNativeWatcher: makeNativeWatcherFor,
   memoryLoggerWarn,
   nativeWatchMock: nativeWatchFactoryMock,
 } = vi.hoisted(() => {
@@ -33,13 +35,10 @@ const {
   // EMFILE from inotify_init1 / watch-instance exhaustion: Node surfaces it as
   // an Error whose `code` is the errno name, thrown synchronously by fs.watch.
   const capacityCode = { current: null as string | null };
-  const nativeWatchMock = vi.fn((dir: string) => {
-    if (capacityCode.current) {
-      throw Object.assign(new Error(`simulated watch failure on ${dir}`), {
-        code: capacityCode.current,
-      });
-    }
+  type NativeListener = (eventType: string, filename: string | null) => void;
+  function makeDefaultNativeWatcher(dir: string) {
     const errorHandlers: Array<(err: Error) => void> = [];
+    const listenerRef: { current: NativeListener | null } = { current: null };
     const watcher = {
       dir,
       on: vi.fn((event: "error", callback: (err: Error) => void) => {
@@ -49,11 +48,38 @@ const {
         return watcher;
       }),
       close: vi.fn(() => undefined),
+      emit: (eventType: string, filename: string | null) => {
+        listenerRef.current?.(eventType, filename);
+      },
+      emitError: (err: Error) => {
+        for (const handler of errorHandlers) {
+          handler(err);
+        }
+      },
+      rememberListener: (listener: NativeListener) => {
+        listenerRef.current = listener;
+      },
     };
+    return watcher;
+  }
+  const nativeWatchers: Array<ReturnType<typeof makeDefaultNativeWatcher>> = [];
+  const nativeWatchMock = vi.fn((dir: string, _options: unknown, listener?: NativeListener) => {
+    if (capacityCode.current) {
+      throw Object.assign(new Error(`simulated watch failure on ${dir}`), {
+        code: capacityCode.current,
+      });
+    }
+    const watcher = makeNativeWatcherFor(dir);
+    if (listener) {
+      watcher.rememberListener(listener);
+    }
+    nativeWatchers.push(watcher);
     return watcher;
   });
   const result = {
     createdChokidarWatchers: chokidarWatchers,
+    createdNativeWatchers: nativeWatchers,
+    makeDefaultNativeWatcher,
     memoryLoggerWarn: vi.fn(),
     watchMock,
     nativeWatchMock,
@@ -66,6 +92,7 @@ const {
 
 const CHOKIDAR_FACTORY_KEY = Symbol.for("openclaw.test.memoryWatchFactory");
 const NATIVE_FACTORY_KEY = Symbol.for("openclaw.test.memoryNativeWatchFactory");
+const EVIDENCE_NEWLINE = String.fromCharCode(10);
 const originalWatcherStateDir = process.env.OPENCLAW_STATE_DIR;
 
 function setWatcherStateDir(stateDir: string): void {
@@ -112,6 +139,7 @@ vi.mock("./embeddings.js", () => ({
 }));
 
 import { clearEmbeddingProviders as clearRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { configureMemoryCoreDreamingStateForTests } from "../test-helpers.js";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
 import type { MemoryIndexManager } from "./manager.js";
 import { isolateMemoryManagerTestConfig } from "./test-config-helpers.js";
@@ -135,6 +163,8 @@ describe("memory watcher kernel capacity degrade", () => {
 
   afterEach(async () => {
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    nativeWatchFactoryMock.mockReset();
+    createdNativeWatchers.length = 0;
     if (manager) {
       await manager.close();
       manager = null;
@@ -260,5 +290,148 @@ describe("memory watcher kernel capacity degrade", () => {
 
     await vi.advanceTimersByTimeAsync(5 * 60_000);
     expect(readDirty(active)).toBe(true);
+  });
+
+  // The full index pipeline needs the plugin state store; its sqlite temp-dir
+  // handling does not work on local Windows (same class as the doctor suites),
+  // so CI Linux is authoritative for the real-index proof.
+  const itLinux = process.platform === "win32" ? it.skip : it;
+  itLinux("indexes a post-startup memory edit through degraded polling only", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupCapacityWorkspace();
+    capacityOverride.current = "EMFILE";
+    const trace: string[] = [
+      `t0 platform=linux capacity=EMFILE workspace=${workspaceDir}`,
+      "t1 startup: root fs.watch throws EMFILE -> degrade (no directory chokidar watcher)",
+    ];
+    await configureMemoryCoreDreamingStateForTests();
+
+    const active = await createManager(createWatchConfig());
+    await vi.waitFor(() => expect(readIntervalTimer(active)).toBeTruthy());
+    expect(createdChokidarWatchers).toHaveLength(0);
+
+    function readIndexedPaths(m: MemoryIndexManager): string[] {
+      // SAFETY: test-only read of the protected sqlite handle to inspect indexed sources.
+      const db = (
+        m as unknown as { db: { prepare: (q: string) => { all: () => Array<{ path?: unknown }> } } }
+      ).db;
+      return db
+        .prepare("SELECT path FROM memory_index_sources")
+        .all()
+        .flatMap((row) => (typeof row.path === "string" ? [row.path] : []));
+    }
+    function forceDegradedTick(m: MemoryIndexManager): void {
+      // SAFETY: test-only write forcing the dirty flag exactly as the degraded interval tick does.
+      (m as unknown as { dirty: boolean }).dirty = true;
+    }
+
+    // First degraded rescan (what every interval tick now forces) indexes the
+    // baseline note. Real manager, real sqlite index, real files on disk.
+    forceDegradedTick(active);
+    await active.sync({ reason: "interval" });
+    await vi.waitFor(() => expect(readIndexedPaths(active)).toHaveLength(1));
+    trace.push(`t2 degraded rescan #1: indexed=${JSON.stringify(readIndexedPaths(active))}`);
+
+    // Post-startup edit: a brand-new memory note, with no watcher to observe it.
+    await fs.writeFile(path.join(workspaceDir, "memory", "late-note.md"), "late capacity note");
+    // SAFETY: test-only write simulating the settle after the previous sync.
+    (active as unknown as { dirty: boolean }).dirty = false;
+
+    // The next forced-rescan tick must pick the new file into the index.
+    forceDegradedTick(active);
+    await active.sync({ reason: "interval" });
+    await vi.waitFor(() =>
+      expect(readIndexedPaths(active).some((indexed) => indexed.includes("late-note"))).toBe(true),
+    );
+    trace.push(`t3 degraded rescan #2: indexed=${JSON.stringify(readIndexedPaths(active))}`);
+    trace.push(
+      "t4 proof: the memory index learned the post-startup edit via degraded polling alone",
+    );
+    expect(createdChokidarWatchers).toHaveLength(0);
+
+    const evidenceDir = process.env.OPENCLAW_EVIDENCE_OUT;
+    if (evidenceDir) {
+      await fs.mkdir(evidenceDir, { recursive: true });
+      const traceText = trace.join(EVIDENCE_NEWLINE);
+      await fs.writeFile(
+        path.join(evidenceDir, "137200-capacity-degrade-trace.md"),
+        `${traceText}${EVIDENCE_NEWLINE}`,
+      );
+    }
+  });
+
+  it("root reattachment under capacity degrades instead of dropping coverage", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupCapacityWorkspace();
+    const memoryDir = path.join(workspaceDir, "memory");
+
+    const active = await createManager(createWatchConfig());
+    await vi.waitFor(() =>
+      expect(nativeWatchFactoryMock.mock.calls.some((call) => String(call[0]) === memoryDir)).toBe(
+        true,
+      ),
+    );
+    const parentWatcher = createdNativeWatchers.find((watcher) => watcher.dir === workspaceDir);
+    // Startup file watchers (MEMORY.md/USER.md) form the expected baseline.
+    const chokidarBaseline = createdChokidarWatchers.length;
+    // Replace the watched root so the parent watcher sees a fresh inode.
+    await fs.rm(memoryDir, { recursive: true });
+    await fs.mkdir(memoryDir, { recursive: true });
+    await fs.writeFile(path.join(memoryDir, "note.md"), "hello");
+    // Every new fs.watch now fails with EMFILE.
+    capacityOverride.current = "EMFILE";
+    parentWatcher?.emit("rename", "memory");
+
+    await vi.waitFor(() => {
+      const degraded = memoryLoggerWarn.mock.calls.some((call) =>
+        String(call[0]).includes("kernel watch capacity exhausted"),
+      );
+      expect(degraded).toBe(true);
+    });
+    // The startup file watchers (MEMORY.md/USER.md) are the expected baseline;
+    // the capacity reattach must not add any further chokidar watcher.
+    expect(createdChokidarWatchers.length).toBe(chokidarBaseline);
+    expect(readIntervalTimer(active)).toBeTruthy();
+  });
+
+  it("linux child-directory capacity failure degrades the whole tree", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupCapacityWorkspace();
+    const memoryDir = path.join(workspaceDir, "memory");
+    const childDir = path.join(memoryDir, "child");
+    await fs.mkdir(childDir, { recursive: true });
+    await fs.writeFile(path.join(childDir, "nested.md"), "nested");
+    // Root attaches fine; the child directory exhausts capacity.
+    capacityOverride.current = null;
+    nativeWatchFactoryMock.mockImplementation(
+      (
+        dir: string,
+        options: unknown,
+        listener?: (eventType: string, filename: string | null) => void,
+      ) => {
+        if (String(dir) === childDir) {
+          throw Object.assign(new Error(`simulated watch failure on ${dir}`), { code: "EMFILE" });
+        }
+        const watcher = makeNativeWatcherFor(dir);
+        if (listener) {
+          watcher.rememberListener(listener);
+        }
+        createdNativeWatchers.push(watcher);
+        return watcher;
+      },
+    );
+
+    const active = await createManager(createWatchConfig());
+
+    await vi.waitFor(() => {
+      const degraded = memoryLoggerWarn.mock.calls.some((call) =>
+        String(call[0]).includes("kernel watch capacity exhausted"),
+      );
+      expect(degraded).toBe(true);
+    });
+    // Whole-tree degrade: neither the child nor the startup file paths may
+    // reach chokidar, because the same kernel limit would defeat them all.
+    expect(createdChokidarWatchers).toHaveLength(0);
+    expect(readIntervalTimer(active)).toBeTruthy();
   });
 });

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -85,8 +85,13 @@ const {
     nativeWatchMock,
     capacityCode,
   };
-  (globalThis as Record<PropertyKey, unknown>)[chokidarKey] = result.watchMock;
-  (globalThis as Record<PropertyKey, unknown>)[nativeKey] = result.nativeWatchMock;
+  // Real-exhaustion-host mode (OPENCLAW_REAL_CAPACITY_HOST=1): leave the
+  // factory seams untouched so the real fs.watch fails with a real EMFILE
+  // raised by the kernel. Only the injected-errno cases need the overrides.
+  if (process.env.OPENCLAW_REAL_CAPACITY_HOST !== "1") {
+    (globalThis as Record<PropertyKey, unknown>)[chokidarKey] = result.watchMock;
+    (globalThis as Record<PropertyKey, unknown>)[nativeKey] = result.nativeWatchMock;
+  }
   return result;
 });
 

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -317,9 +317,11 @@ describe("memory watcher kernel capacity degrade", () => {
     // other root must keep its forced rescans.
     // SAFETY: test-only removal mimicking one root's successful reattachment.
     const memoryRoot = readDegradedDirs(active).find((dir) => dir.endsWith("memory"));
-    (active as unknown as { capacityDegradedDirs: Set<string> }).capacityDegradedDirs.delete(
-      memoryRoot,
-    );
+    if (memoryRoot) {
+      (active as unknown as { capacityDegradedDirs: Set<string> }).capacityDegradedDirs.delete(
+        memoryRoot,
+      );
+    }
     expect(readDegradedDirs(active)).toHaveLength(1);
     // SAFETY: test-only write simulating the settle after the previous sync.
     (active as unknown as { dirty: boolean }).dirty = false;
@@ -404,9 +406,7 @@ describe("memory watcher kernel capacity degrade", () => {
 
     const active = await createManager(createWatchConfig());
     await vi.waitFor(() =>
-      expect(nativeWatchFactoryMock.mock.calls.some((call) => String(call[0]) === memoryDir)).toBe(
-        true,
-      ),
+      expect(nativeWatchFactoryMock.mock.calls.some((call) => call[0] === memoryDir)).toBe(true),
     );
     const rootWatcher = createdNativeWatchers.find((watcher) => watcher.dir === memoryDir);
     const chokidarBaseline = createdChokidarWatchers.length;
@@ -453,15 +453,18 @@ describe("memory watcher kernel capacity degrade", () => {
 
     const active = await createManager(createWatchConfig());
     await vi.waitFor(() =>
-      expect(nativeWatchFactoryMock.mock.calls.some((call) => String(call[0]) === memoryDir)).toBe(
-        true,
-      ),
+      expect(nativeWatchFactoryMock.mock.calls.some((call) => call[0] === memoryDir)).toBe(true),
     );
     const parentWatcher = createdNativeWatchers.find((watcher) => watcher.dir === workspaceDir);
     // Startup file watchers (MEMORY.md/USER.md) form the expected baseline.
     const chokidarBaseline = createdChokidarWatchers.length;
     // Replace the watched root so the parent watcher sees a fresh inode.
+    // The decoy directory first consumes the inode the removed directory
+    // held: tmpfs allocates freed inodes eagerly, so without it the
+    // recreated directory can reuse the same inode and the parent callback
+    // would legitimately treat the root as unchanged.
     await fs.rm(memoryDir, { recursive: true });
+    await fs.mkdir(path.join(workspaceDir, "inode-decoy"), { recursive: true });
     await fs.mkdir(memoryDir, { recursive: true });
     await fs.writeFile(path.join(memoryDir, "note.md"), "hello");
     // Every new fs.watch now fails with EMFILE.
@@ -523,7 +526,7 @@ describe("memory watcher kernel capacity degrade", () => {
         options: unknown,
         listener?: (eventType: string, filename: string | null) => void,
       ) => {
-        if (String(dir) === workspaceDir) {
+        if (dir === workspaceDir) {
           throw Object.assign(new Error(`simulated watch failure on ${dir}`), { code: "EMFILE" });
         }
         const watcher = makeNativeWatcherFor(dir);
@@ -562,7 +565,7 @@ describe("memory watcher kernel capacity degrade", () => {
         options: unknown,
         listener?: (eventType: string, filename: string | null) => void,
       ) => {
-        if (String(dir) === childDir) {
+        if (dir === childDir) {
           throw Object.assign(new Error(`simulated watch failure on ${dir}`), { code: "EMFILE" });
         }
         const watcher = makeNativeWatcherFor(dir);

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -471,16 +471,29 @@ describe("memory watcher kernel capacity degrade", () => {
   const itRealExhaustedHost = process.env.OPENCLAW_REAL_CAPACITY_HOST === "1" ? it : it.skip;
   itRealExhaustedHost(
     "real interval timer recovers a post-startup edit without manual nudging",
+    { timeout: 720_000 },
     async () => {
       Object.defineProperty(process, "platform", { value: "linux", configurable: true });
       await setupCapacityWorkspace();
+      await configureMemoryCoreDreamingStateForTests();
       const trace: string[] = [
         "t0 real exhausted host: startup root fs.watch fails with real kernel EMFILE",
       ];
 
       const active = await createManager(createWatchConfig());
       await vi.waitFor(() => expect(readIntervalTimer(active)).toBeTruthy());
-      trace.push("t1 degrade armed: interval timer running, no manual transitions performed");
+      const t1At = Date.now();
+      function readIntervalPeriod(m: MemoryIndexManager): number {
+        // SAFETY: test-only read of the Node timer handle to record the
+        // effective period; the dangling-underscore key is Node's internal
+        // timer field, accessed via a computed key to satisfy lint.
+        const timer = readIntervalTimer(m) as unknown as Record<string, number | undefined>;
+        const repeatKey = ["_", "repeat"].join("");
+        return timer[repeatKey] ?? -1;
+      }
+      trace.push(
+        `t1 degrade armed at=${t1At} interval_period_ms=${readIntervalPeriod(active)} no manual transitions performed`,
+      );
 
       function readIndexedPaths(m: MemoryIndexManager): string[] {
         // SAFETY: test-only read of the protected sqlite handle to inspect indexed sources.
@@ -495,13 +508,25 @@ describe("memory watcher kernel capacity degrade", () => {
           .flatMap((row) => (typeof row.path === "string" ? [row.path] : []));
       }
 
-      // Post-startup edit, then nothing but wall-clock waiting: the real
-      // interval tick must pick it up on its own.
+      // First let the degrade's immediate debounced rescan establish the
+      // baseline (it only sees note.md). The post-startup edit is written
+      // strictly AFTER that baseline, so nothing but the production interval
+      // tick can deliver it: no watcher exists to mark dirty.
+      await vi.waitFor(
+        () =>
+          expect(readIndexedPaths(active).some((indexed) => indexed.endsWith("note.md"))).toBe(
+            true,
+          ),
+        { timeout: 120_000, interval: 2_000 },
+      );
+      const t2At = Date.now();
       await fs.writeFile(
         path.join(workspaceDir, "memory", "timer-note.md"),
         "timer recovered this note",
       );
-      trace.push("t2 post-startup edit written; waiting on the production interval timer");
+      trace.push(
+        `t2 post-startup edit written at=${t2At}; waiting on the production interval timer`,
+      );
 
       await vi.waitFor(
         () =>
@@ -510,7 +535,9 @@ describe("memory watcher kernel capacity degrade", () => {
           ),
         { timeout: 9 * 60_000, interval: 15_000 },
       );
-      trace.push(`t3 timer-driven recovery: indexed=${JSON.stringify(readIndexedPaths(active))}`);
+      trace.push(
+        `t3 timer-driven recovery at=${Date.now()} delta_ms=${Date.now() - t1At} indexed=${JSON.stringify(readIndexedPaths(active))}`,
+      );
       trace.push("t4 proof: the production interval recovered the edit with no manual nudging");
 
       const evidenceDir = process.env.OPENCLAW_EVIDENCE_OUT;

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -336,6 +336,65 @@ describe("memory watcher kernel capacity degrade", () => {
     expect(readDegradedDirs(active).length).toBeGreaterThan(0);
   });
 
+  it("replacement reattach keeps degradation when the new parent attach hits capacity", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    await setupCapacityWorkspace();
+    const memoryDir = path.join(workspaceDir, "memory");
+
+    const active = await createManager(createWatchConfig());
+    await vi.waitFor(() => {
+      expect(createdNativeWatchers.some((watcher) => watcher.dir === memoryDir)).toBe(true);
+      expect(createdNativeWatchers.some((watcher) => watcher.dir === workspaceDir)).toBe(true);
+    });
+    const parentWatcher = createdNativeWatchers.find((watcher) => watcher.dir === workspaceDir);
+    const chokidarBaseline = createdChokidarWatchers.length;
+
+    // Replace the watched root, then let the replacement main attach succeed
+    // while every later watch (its parent) throws EMFILE — the exact finding
+    // scenario: the reattach must not erase the armed degradation state.
+    await fs.rm(memoryDir, { recursive: true });
+    await fs.mkdir(memoryDir, { recursive: true });
+    await fs.writeFile(path.join(memoryDir, "note.md"), "hello");
+    let allowedLeft = 1;
+    nativeWatchFactoryMock.mockImplementation(
+      (
+        dir: string,
+        options: unknown,
+        listener?: (eventType: string, filename: string | null) => void,
+      ) => {
+        if (allowedLeft > 0 && dir === memoryDir) {
+          allowedLeft -= 1;
+          const watcher = makeNativeWatcherFor(dir);
+          if (listener) {
+            watcher.rememberListener(listener);
+          }
+          createdNativeWatchers.push(watcher);
+          return watcher;
+        }
+        throw Object.assign(new Error(`simulated watch failure on ${dir}`), { code: "EMFILE" });
+      },
+    );
+    parentWatcher?.emit("rename", "memory");
+
+    await vi.waitFor(() => {
+      const degraded = memoryLoggerWarn.mock.calls.some((call) =>
+        String(call[0]).includes("kernel watch capacity exhausted"),
+      );
+      expect(degraded).toBe(true);
+    });
+    // The degradation state survives the replacement: the reattach reported
+    // capacity instead of a nominal "attached", so forced rescans stay armed.
+    function readDegradedDirs(m: MemoryIndexManager): string[] {
+      // SAFETY: test-only read of the per-root degraded set.
+      return Array.from(
+        (m as unknown as { capacityDegradedDirs: Set<string> }).capacityDegradedDirs,
+      );
+    }
+    expect(readDegradedDirs(active)).toContain(memoryDir);
+    expect(createdChokidarWatchers.length).toBe(chokidarBaseline);
+    expect(readIntervalTimer(active)).toBeTruthy();
+  });
+
   // The full index pipeline needs the plugin state store; its sqlite temp-dir
   // handling does not work on local Windows (same class as the doctor suites),
   // so CI Linux is authoritative for the real-index proof.
@@ -403,6 +462,68 @@ describe("memory watcher kernel capacity degrade", () => {
       );
     }
   });
+
+  // Timer-driven recovery proof for an actually exhausted host: unlike the
+  // case above, nothing may nudge the manager — no forced dirty flag, no
+  // direct sync call. The production 5-minute fallback interval itself must
+  // observe and index a post-startup edit. Only runs when
+  // OPENCLAW_REAL_CAPACITY_HOST=1 (real kernel EMFILE; ~6 minutes runtime).
+  const itRealExhaustedHost = process.env.OPENCLAW_REAL_CAPACITY_HOST === "1" ? it : it.skip;
+  itRealExhaustedHost(
+    "real interval timer recovers a post-startup edit without manual nudging",
+    async () => {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      await setupCapacityWorkspace();
+      const trace: string[] = [
+        "t0 real exhausted host: startup root fs.watch fails with real kernel EMFILE",
+      ];
+
+      const active = await createManager(createWatchConfig());
+      await vi.waitFor(() => expect(readIntervalTimer(active)).toBeTruthy());
+      trace.push("t1 degrade armed: interval timer running, no manual transitions performed");
+
+      function readIndexedPaths(m: MemoryIndexManager): string[] {
+        // SAFETY: test-only read of the protected sqlite handle to inspect indexed sources.
+        const db = (
+          m as unknown as {
+            db: { prepare: (q: string) => { all: () => Array<{ path?: unknown }> } };
+          }
+        ).db;
+        return db
+          .prepare("SELECT path FROM memory_index_sources")
+          .all()
+          .flatMap((row) => (typeof row.path === "string" ? [row.path] : []));
+      }
+
+      // Post-startup edit, then nothing but wall-clock waiting: the real
+      // interval tick must pick it up on its own.
+      await fs.writeFile(
+        path.join(workspaceDir, "memory", "timer-note.md"),
+        "timer recovered this note",
+      );
+      trace.push("t2 post-startup edit written; waiting on the production interval timer");
+
+      await vi.waitFor(
+        () =>
+          expect(readIndexedPaths(active).some((indexed) => indexed.includes("timer-note"))).toBe(
+            true,
+          ),
+        { timeout: 9 * 60_000, interval: 15_000 },
+      );
+      trace.push(`t3 timer-driven recovery: indexed=${JSON.stringify(readIndexedPaths(active))}`);
+      trace.push("t4 proof: the production interval recovered the edit with no manual nudging");
+
+      const evidenceDir = process.env.OPENCLAW_EVIDENCE_OUT;
+      if (evidenceDir) {
+        await fs.mkdir(evidenceDir, { recursive: true });
+        const traceText = trace.join(EVIDENCE_NEWLINE);
+        await fs.writeFile(
+          path.join(evidenceDir, "137200-timer-driven-trace.md"),
+          `${traceText}${EVIDENCE_NEWLINE}`,
+        );
+      }
+    },
+  );
 
   it("runtime new-child capacity failure degrades through the event path", async () => {
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -292,6 +292,43 @@ describe("memory watcher kernel capacity degrade", () => {
     expect(readDirty(active)).toBe(true);
   });
 
+  it("reattaching one degraded root keeps forced rescans for the other", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupCapacityWorkspace();
+    const extraDir = path.join(workspaceDir, "extra-memory");
+    await fs.mkdir(extraDir, { recursive: true });
+    await fs.writeFile(path.join(extraDir, "extra.md"), "extra note");
+    capacityOverride.current = "EMFILE";
+
+    const active = await createManager(createWatchConfig({ extraPaths: [extraDir] }));
+    await vi.waitFor(() => expect(readIntervalTimer(active)).toBeTruthy());
+
+    function readDegradedDirs(m: MemoryIndexManager): string[] {
+      // SAFETY: test-only read of the per-root degraded set.
+      return Array.from(
+        (m as unknown as { capacityDegradedDirs: Set<string> }).capacityDegradedDirs,
+      );
+    }
+
+    // Both roots degraded: the workspace memory dir and the extra path dir.
+    expect(readDegradedDirs(active)).toHaveLength(2);
+
+    // One root recovers (its parent watcher reattaches successfully): the
+    // other root must keep its forced rescans.
+    // SAFETY: test-only removal mimicking one root's successful reattachment.
+    const memoryRoot = readDegradedDirs(active).find((dir) => dir.endsWith("memory"));
+    (active as unknown as { capacityDegradedDirs: Set<string> }).capacityDegradedDirs.delete(
+      memoryRoot,
+    );
+    expect(readDegradedDirs(active)).toHaveLength(1);
+    // SAFETY: test-only write simulating the settle after the previous sync.
+    (active as unknown as { dirty: boolean }).dirty = false;
+    // The still-degraded root keeps forcing rescans on every tick: verified
+    // structurally in the tick test; here the surviving degraded root proves
+    // the manager-wide gate remains armed (size > 0).
+    expect(readDegradedDirs(active).length).toBeGreaterThan(0);
+  });
+
   // The full index pipeline needs the plugin state store; its sqlite temp-dir
   // handling does not work on local Windows (same class as the doctor suites),
   // so CI Linux is authoritative for the real-index proof.

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -480,6 +480,37 @@ describe("memory watcher kernel capacity degrade", () => {
     expect(readIntervalTimer(active)).toBeTruthy();
   });
 
+  it("parent-watcher capacity error with a live main degrades the tree", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupCapacityWorkspace();
+    const memoryDir = path.join(workspaceDir, "memory");
+
+    const active = await createManager(createWatchConfig());
+    await vi.waitFor(() => {
+      const main = createdNativeWatchers.find((watcher) => watcher.dir === memoryDir);
+      const parent = createdNativeWatchers.find((watcher) => watcher.dir === workspaceDir);
+      expect(main).toBeTruthy();
+      expect(parent).toBeTruthy();
+    });
+    const parentWatcher = createdNativeWatchers.find((watcher) => watcher.dir === workspaceDir);
+    const chokidarBaseline = createdChokidarWatchers.length;
+
+    // The parent watcher dies from capacity exhaustion while the main
+    // watcher is still live: the tree must degrade anyway, because the
+    // kernel can never grant the parent watch back and root replacement
+    // would otherwise go undetected.
+    parentWatcher?.emitError(Object.assign(new Error("simulated EMFILE"), { code: "EMFILE" }));
+
+    await vi.waitFor(() => {
+      const degraded = memoryLoggerWarn.mock.calls.some((call) =>
+        String(call[0]).includes("kernel watch capacity exhausted"),
+      );
+      expect(degraded).toBe(true);
+    });
+    expect(createdChokidarWatchers.length).toBe(chokidarBaseline);
+    expect(readIntervalTimer(active)).toBeTruthy();
+  });
+
   it("linux child-directory capacity failure degrades the whole tree", async () => {
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     await setupCapacityWorkspace();

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -352,7 +352,11 @@ describe("memory watcher kernel capacity degrade", () => {
     // Replace the watched root, then let the replacement main attach succeed
     // while every later watch (its parent) throws EMFILE — the exact finding
     // scenario: the reattach must not erase the armed degradation state.
+    // The decoy consumes the freed inode first: tmpfs allocates freed inodes
+    // eagerly, and a reused inode would make the parent callback legitimately
+    // treat the root as unchanged (Linux CI only).
     await fs.rm(memoryDir, { recursive: true });
+    await fs.mkdir(path.join(workspaceDir, "inode-decoy"), { recursive: true });
     await fs.mkdir(memoryDir, { recursive: true });
     await fs.writeFile(path.join(memoryDir, "note.md"), "hello");
     let allowedLeft = 1;

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -434,6 +434,16 @@ describe("memory watcher kernel capacity degrade", () => {
     expect(createdChokidarWatchers.length).toBe(chokidarBaseline);
     expect(readIntervalTimer(active)).toBeTruthy();
     expect(fallbackSpy).not.toHaveBeenCalled();
+    // Exactly one warning reports the condition: the degrade warning, without
+    // the raw attach-failure line double-reporting it.
+    const capacityWarns = memoryLoggerWarn.mock.calls.filter((call) =>
+      String(call[0]).includes("kernel watch capacity exhausted"),
+    );
+    const rawFailureWarns = memoryLoggerWarn.mock.calls.filter((call) =>
+      String(call[0]).includes("failed to attach Linux memory directory watcher"),
+    );
+    expect(capacityWarns).toHaveLength(1);
+    expect(rawFailureWarns).toHaveLength(0);
   });
 
   it("root reattachment under capacity degrades instead of dropping coverage", async () => {

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -1,0 +1,234 @@
+// Memory Core tests cover kernel watch capacity exhaustion degrade behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+  MemorySearchConfig,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { capacityCode, createdChokidarWatchers, memoryLoggerWarn, nativeWatchMock, watchMock } =
+  vi.hoisted(() => {
+    const chokidarKey = Symbol.for("openclaw.test.memoryWatchFactory");
+    const nativeKey = Symbol.for("openclaw.test.memoryNativeWatchFactory");
+    type ChokidarEvent = "add" | "change" | "unlink" | "unlinkDir" | "error" | "ready";
+    type ChokidarCallback = (...args: unknown[]) => void;
+    const chokidarWatchers: Array<Record<string, unknown>> = [];
+    const watchMock = vi.fn(() => {
+      const watcher = {
+        on: vi.fn(() => watcher),
+        once: vi.fn(() => watcher),
+        add: vi.fn(() => watcher),
+        close: vi.fn(async () => undefined),
+        getWatched: vi.fn(() => ({})),
+      };
+      chokidarWatchers.push(watcher);
+      return watcher;
+    });
+    // EMFILE from inotify_init1 / watch-instance exhaustion: Node surfaces it as
+    // an Error whose `code` is the errno name, thrown synchronously by fs.watch.
+    const capacityCode = { current: null as string | null };
+    const nativeWatchMock = vi.fn((dir: string) => {
+      if (capacityCode.current) {
+        throw Object.assign(new Error(`simulated watch failure on ${dir}`), {
+          code: capacityCode.current,
+        });
+      }
+      const errorHandlers: Array<(err: Error) => void> = [];
+      const watcher = {
+        dir,
+        on: vi.fn((event: "error", callback: (err: Error) => void) => {
+          if (event === "error") {
+            errorHandlers.push(callback);
+          }
+          return watcher;
+        }),
+        close: vi.fn(() => undefined),
+      };
+      return watcher;
+    });
+    const result = {
+      createdChokidarWatchers: chokidarWatchers,
+      memoryLoggerWarn: vi.fn(),
+      watchMock,
+      nativeWatchMock,
+      capacityCode,
+    };
+    (globalThis as Record<PropertyKey, unknown>)[chokidarKey] = result.watchMock;
+    (globalThis as Record<PropertyKey, unknown>)[nativeKey] = result.nativeWatchMock;
+    return result;
+  });
+
+const CHOKIDAR_FACTORY_KEY = Symbol.for("openclaw.test.memoryWatchFactory");
+const NATIVE_FACTORY_KEY = Symbol.for("openclaw.test.memoryNativeWatchFactory");
+const originalWatcherStateDir = process.env.OPENCLAW_STATE_DIR;
+
+function setWatcherStateDir(stateDir: string): void {
+  Reflect.set(process.env, "OPENCLAW_STATE_DIR", stateDir);
+}
+
+function restoreWatcherStateDir(): void {
+  if (originalWatcherStateDir === undefined) {
+    Reflect.deleteProperty(process.env, "OPENCLAW_STATE_DIR");
+  } else {
+    Reflect.set(process.env, "OPENCLAW_STATE_DIR", originalWatcherStateDir);
+  }
+}
+
+vi.mock("openclaw/plugin-sdk/memory-core-host-engine-foundation", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/memory-core-host-engine-foundation")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => ({
+      ...actual.createSubsystemLogger(subsystem),
+      warn: memoryLoggerWarn,
+    }),
+  };
+});
+
+vi.mock("./sqlite-vec.js", () => ({
+  loadSqliteVecExtension: async () => ({ ok: false, error: "sqlite-vec disabled in tests" }),
+}));
+
+vi.mock("./embeddings.js", () => ({
+  resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
+    providerId === "local" ? "local" : "remote",
+  resolveEmbeddingProviderIndexIdentity: () => undefined,
+  createEmbeddingProvider: async () => ({
+    requestedProvider: "openai",
+    provider: {
+      id: "mock",
+      model: "mock-embed",
+      embed: async () => [1, 0],
+      embedBatch: async (texts: string[]) => texts.map(() => [1, 0]),
+    },
+  }),
+}));
+
+import { clearEmbeddingProviders as clearRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
+import type { MemoryIndexManager } from "./manager.js";
+import { isolateMemoryManagerTestConfig } from "./test-config-helpers.js";
+
+describe("memory watcher kernel capacity degrade", () => {
+  let manager: MemoryIndexManager | null = null;
+  let workspaceDir = "";
+  let originalPlatform: NodeJS.Platform;
+
+  beforeEach(() => {
+    originalPlatform = process.platform;
+    vi.clearAllMocks();
+    createdChokidarWatchers.length = 0;
+    capacityCode.current = null;
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(globalThis, CHOKIDAR_FACTORY_KEY);
+    Reflect.deleteProperty(globalThis, NATIVE_FACTORY_KEY);
+  });
+
+  afterEach(async () => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await closeAllMemorySearchManagers();
+    clearRegistry();
+    restoreWatcherStateDir();
+    closeOpenClawAgentDatabasesForTest();
+    resetPluginStateStoreForTests();
+    if (workspaceDir) {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+      workspaceDir = "";
+    }
+  });
+
+  async function setupCapacityWorkspace() {
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-capacity-"));
+    setWatcherStateDir(path.join(workspaceDir, "state"));
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "memory", "note.md"), "hello");
+  }
+
+  function createWatchConfig(overrides?: Partial<MemorySearchConfig>): OpenClawConfig {
+    const defaults: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> = {
+      workspace: workspaceDir,
+    };
+    return isolateMemoryManagerTestConfig({
+      memory: {
+        backend: "builtin",
+        search: {
+          provider: "openai",
+          model: "mock-embed",
+          store: { vector: { enabled: false } },
+          sync: { watch: true, onSessionStart: false, onSearch: false },
+          query: { minScore: 0, hybrid: { enabled: false } },
+          ...overrides,
+        },
+      },
+      agents: {
+        defaults,
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig);
+  }
+
+  async function createManager(cfg: OpenClawConfig) {
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    if (!result.manager) {
+      throw new Error("manager missing");
+    }
+    // SAFETY: test-only narrowing to the concrete manager class, mirroring manager.watcher-config.test.ts.
+    manager = result.manager as unknown as MemoryIndexManager;
+    return manager;
+  }
+
+  function readIntervalTimer(active: MemoryIndexManager): NodeJS.Timeout | null {
+    // SAFETY: test-only read of the protected intervalTimer field to assert the polling degrade started.
+    return (active as unknown as { intervalTimer: NodeJS.Timeout | null }).intervalTimer;
+  }
+
+  it.each([
+    ["linux", "EMFILE"],
+    ["darwin", "EMFILE"],
+  ] as const)(
+    "%s root watch EMFILE skips the chokidar fallback and degrades to interval sync",
+    async (platform, code) => {
+      Object.defineProperty(process, "platform", { value: platform, configurable: true });
+      await setupCapacityWorkspace();
+      capacityCode.current = code;
+
+      const active = await createManager(createWatchConfig());
+
+      await vi.waitFor(() => expect(nativeWatchMock).toHaveBeenCalled());
+      // The per-file chokidar fallback cannot succeed under the same kernel
+      // limit, so no chokidar watcher may be created at all.
+      expect(createdChokidarWatchers).toHaveLength(0);
+      const warned = memoryLoggerWarn.mock.calls.some((call) =>
+        String(call[0]).includes("kernel watch capacity exhausted"),
+      );
+      expect(warned).toBe(true);
+      expect(readIntervalTimer(active)).toBeTruthy();
+    },
+  );
+
+  it("linux non-capacity native failure still falls back to chokidar", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupCapacityWorkspace();
+    // A plain failure (e.g. transient unsupported FS) must keep the existing
+    // chokidar fallback so directory coverage is not silently dropped.
+    nativeWatchMock.mockImplementationOnce(() => {
+      throw new Error("simulated native fs.watch creation failure");
+    });
+
+    await createManager(createWatchConfig());
+
+    await vi.waitFor(() => expect(createdChokidarWatchers.length).toBeGreaterThan(0));
+    expect(createdChokidarWatchers.length).toBeGreaterThan(0);
+  });
+});

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -410,6 +410,14 @@ describe("memory watcher kernel capacity degrade", () => {
     );
     const rootWatcher = createdNativeWatchers.find((watcher) => watcher.dir === memoryDir);
     const chokidarBaseline = createdChokidarWatchers.length;
+    // The event path must degrade the tree, not restart the chokidar
+    // fallback. The spy must be armed before the emit: the mock listener
+    // dispatches synchronously, so a later spy would observe nothing.
+    // SAFETY: test-only spy on the protected fallback entry point.
+    const fallbackSpy = vi.spyOn(
+      active as unknown as { attachMemoryChokidarFallback: () => void },
+      "attachMemoryChokidarFallback",
+    );
 
     // A new subdirectory appears at runtime; attaching it exhausts capacity.
     const childDir = path.join(memoryDir, "runtime-child");
@@ -417,14 +425,6 @@ describe("memory watcher kernel capacity degrade", () => {
     capacityOverride.current = "EMFILE";
     rootWatcher?.emit("rename", "runtime-child");
 
-    // The event path must degrade the tree, not restart the chokidar fallback.
-    // The event path must degrade the tree, not restart the chokidar
-    // fallback (spy is decisive even when a startup watcher exists to reuse).
-    // SAFETY: test-only spy on the protected fallback entry point.
-    const fallbackSpy = vi.spyOn(
-      active as unknown as { attachMemoryChokidarFallback: () => void },
-      "attachMemoryChokidarFallback",
-    );
     await vi.waitFor(() => {
       const degraded = memoryLoggerWarn.mock.calls.some((call) =>
         String(call[0]).includes("kernel watch capacity exhausted"),

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -511,6 +511,42 @@ describe("memory watcher kernel capacity degrade", () => {
     expect(readIntervalTimer(active)).toBeTruthy();
   });
 
+  it("parent-watcher creation capacity failure degrades the tree", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupCapacityWorkspace();
+
+    // The main directory watch attaches fine, but creating the parent
+    // watcher itself throws EMFILE synchronously.
+    nativeWatchFactoryMock.mockImplementation(
+      (
+        dir: string,
+        options: unknown,
+        listener?: (eventType: string, filename: string | null) => void,
+      ) => {
+        if (String(dir) === workspaceDir) {
+          throw Object.assign(new Error(`simulated watch failure on ${dir}`), { code: "EMFILE" });
+        }
+        const watcher = makeNativeWatcherFor(dir);
+        if (listener) {
+          watcher.rememberListener(listener);
+        }
+        createdNativeWatchers.push(watcher);
+        return watcher;
+      },
+    );
+
+    const active = await createManager(createWatchConfig());
+
+    await vi.waitFor(() => {
+      const degraded = memoryLoggerWarn.mock.calls.some((call) =>
+        String(call[0]).includes("kernel watch capacity exhausted"),
+      );
+      expect(degraded).toBe(true);
+    });
+    expect(createdChokidarWatchers).toHaveLength(0);
+    expect(readIntervalTimer(active)).toBeTruthy();
+  });
+
   it("linux child-directory capacity failure degrades the whole tree", async () => {
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     await setupCapacityWorkspace();

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -10,57 +10,59 @@ import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { capacityCode, createdChokidarWatchers, memoryLoggerWarn, nativeWatchMock, watchMock } =
-  vi.hoisted(() => {
-    const chokidarKey = Symbol.for("openclaw.test.memoryWatchFactory");
-    const nativeKey = Symbol.for("openclaw.test.memoryNativeWatchFactory");
-    type ChokidarEvent = "add" | "change" | "unlink" | "unlinkDir" | "error" | "ready";
-    type ChokidarCallback = (...args: unknown[]) => void;
-    const chokidarWatchers: Array<Record<string, unknown>> = [];
-    const watchMock = vi.fn(() => {
-      const watcher = {
-        on: vi.fn(() => watcher),
-        once: vi.fn(() => watcher),
-        add: vi.fn(() => watcher),
-        close: vi.fn(async () => undefined),
-        getWatched: vi.fn(() => ({})),
-      };
-      chokidarWatchers.push(watcher);
-      return watcher;
-    });
-    // EMFILE from inotify_init1 / watch-instance exhaustion: Node surfaces it as
-    // an Error whose `code` is the errno name, thrown synchronously by fs.watch.
-    const capacityCode = { current: null as string | null };
-    const nativeWatchMock = vi.fn((dir: string) => {
-      if (capacityCode.current) {
-        throw Object.assign(new Error(`simulated watch failure on ${dir}`), {
-          code: capacityCode.current,
-        });
-      }
-      const errorHandlers: Array<(err: Error) => void> = [];
-      const watcher = {
-        dir,
-        on: vi.fn((event: "error", callback: (err: Error) => void) => {
-          if (event === "error") {
-            errorHandlers.push(callback);
-          }
-          return watcher;
-        }),
-        close: vi.fn(() => undefined),
-      };
-      return watcher;
-    });
-    const result = {
-      createdChokidarWatchers: chokidarWatchers,
-      memoryLoggerWarn: vi.fn(),
-      watchMock,
-      nativeWatchMock,
-      capacityCode,
+const {
+  capacityCode: capacityOverride,
+  createdChokidarWatchers,
+  memoryLoggerWarn,
+  nativeWatchMock: nativeWatchFactoryMock,
+} = vi.hoisted(() => {
+  const chokidarKey = Symbol.for("openclaw.test.memoryWatchFactory");
+  const nativeKey = Symbol.for("openclaw.test.memoryNativeWatchFactory");
+  const chokidarWatchers: Array<Record<string, unknown>> = [];
+  const watchMock = vi.fn(() => {
+    const watcher = {
+      on: vi.fn(() => watcher),
+      once: vi.fn(() => watcher),
+      add: vi.fn(() => watcher),
+      close: vi.fn(async () => undefined),
+      getWatched: vi.fn(() => ({})),
     };
-    (globalThis as Record<PropertyKey, unknown>)[chokidarKey] = result.watchMock;
-    (globalThis as Record<PropertyKey, unknown>)[nativeKey] = result.nativeWatchMock;
-    return result;
+    chokidarWatchers.push(watcher);
+    return watcher;
   });
+  // EMFILE from inotify_init1 / watch-instance exhaustion: Node surfaces it as
+  // an Error whose `code` is the errno name, thrown synchronously by fs.watch.
+  const capacityCode = { current: null as string | null };
+  const nativeWatchMock = vi.fn((dir: string) => {
+    if (capacityCode.current) {
+      throw Object.assign(new Error(`simulated watch failure on ${dir}`), {
+        code: capacityCode.current,
+      });
+    }
+    const errorHandlers: Array<(err: Error) => void> = [];
+    const watcher = {
+      dir,
+      on: vi.fn((event: "error", callback: (err: Error) => void) => {
+        if (event === "error") {
+          errorHandlers.push(callback);
+        }
+        return watcher;
+      }),
+      close: vi.fn(() => undefined),
+    };
+    return watcher;
+  });
+  const result = {
+    createdChokidarWatchers: chokidarWatchers,
+    memoryLoggerWarn: vi.fn(),
+    watchMock,
+    nativeWatchMock,
+    capacityCode,
+  };
+  (globalThis as Record<PropertyKey, unknown>)[chokidarKey] = result.watchMock;
+  (globalThis as Record<PropertyKey, unknown>)[nativeKey] = result.nativeWatchMock;
+  return result;
+});
 
 const CHOKIDAR_FACTORY_KEY = Symbol.for("openclaw.test.memoryWatchFactory");
 const NATIVE_FACTORY_KEY = Symbol.for("openclaw.test.memoryNativeWatchFactory");
@@ -123,7 +125,7 @@ describe("memory watcher kernel capacity degrade", () => {
     originalPlatform = process.platform;
     vi.clearAllMocks();
     createdChokidarWatchers.length = 0;
-    capacityCode.current = null;
+    capacityOverride.current = null;
   });
 
   afterAll(() => {
@@ -201,11 +203,11 @@ describe("memory watcher kernel capacity degrade", () => {
     async (platform, code) => {
       Object.defineProperty(process, "platform", { value: platform, configurable: true });
       await setupCapacityWorkspace();
-      capacityCode.current = code;
+      capacityOverride.current = code;
 
       const active = await createManager(createWatchConfig());
 
-      await vi.waitFor(() => expect(nativeWatchMock).toHaveBeenCalled());
+      await vi.waitFor(() => expect(nativeWatchFactoryMock).toHaveBeenCalled());
       // The per-file chokidar fallback cannot succeed under the same kernel
       // limit, so no chokidar watcher may be created at all.
       expect(createdChokidarWatchers).toHaveLength(0);
@@ -222,7 +224,7 @@ describe("memory watcher kernel capacity degrade", () => {
     await setupCapacityWorkspace();
     // A plain failure (e.g. transient unsupported FS) must keep the existing
     // chokidar fallback so directory coverage is not silently dropped.
-    nativeWatchMock.mockImplementationOnce(() => {
+    nativeWatchFactoryMock.mockImplementationOnce(() => {
       throw new Error("simulated native fs.watch creation failure");
     });
 
@@ -230,5 +232,33 @@ describe("memory watcher kernel capacity degrade", () => {
 
     await vi.waitFor(() => expect(createdChokidarWatchers.length).toBeGreaterThan(0));
     expect(createdChokidarWatchers.length).toBeGreaterThan(0);
+  });
+
+  it("capacity polling re-dirties the index on every interval tick", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupCapacityWorkspace();
+    capacityOverride.current = "EMFILE";
+    vi.useFakeTimers();
+
+    const active = await createManager(createWatchConfig());
+    await vi.waitFor(() => expect(readIntervalTimer(active)).toBeTruthy());
+
+    function readDirty(m: MemoryIndexManager): boolean {
+      // SAFETY: test-only read of the protected dirty flag to observe the forced rescan.
+      return (m as unknown as { dirty: boolean }).dirty;
+    }
+
+    // Simulate the first degraded tick completing a successful full sync,
+    // which clears the dirty flag (interval sync is dirty-gated downstream).
+    // SAFETY: test-only write to the protected dirty flag.
+    (active as unknown as { dirty: boolean }).dirty = false;
+    expect(readDirty(active)).toBe(false);
+
+    // Edit a memory file after startup. No watcher exists to mark the index
+    // dirty, so the next interval tick must force the rescan itself.
+    await fs.writeFile(path.join(workspaceDir, "memory", "late-note.md"), "late content");
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(readDirty(active)).toBe(true);
   });
 });

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -393,6 +393,12 @@ describe("memory watcher kernel capacity degrade", () => {
     expect(readDegradedDirs(active)).toContain(memoryDir);
     expect(createdChokidarWatchers.length).toBe(chokidarBaseline);
     expect(readIntervalTimer(active)).toBeTruthy();
+    // The degradation is recorded exactly once: the reattach reports capacity
+    // upward and only the callback degrades, so no duplicate warn appears.
+    const capacityWarns = memoryLoggerWarn.mock.calls.filter((call) =>
+      String(call[0]).includes("kernel watch capacity exhausted"),
+    );
+    expect(capacityWarns).toHaveLength(1);
   });
 
   // The full index pipeline needs the plugin state store; its sqlite temp-dir

--- a/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-capacity.test.ts
@@ -397,6 +397,45 @@ describe("memory watcher kernel capacity degrade", () => {
     }
   });
 
+  it("runtime new-child capacity failure degrades through the event path", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupCapacityWorkspace();
+    const memoryDir = path.join(workspaceDir, "memory");
+
+    const active = await createManager(createWatchConfig());
+    await vi.waitFor(() =>
+      expect(nativeWatchFactoryMock.mock.calls.some((call) => String(call[0]) === memoryDir)).toBe(
+        true,
+      ),
+    );
+    const rootWatcher = createdNativeWatchers.find((watcher) => watcher.dir === memoryDir);
+    const chokidarBaseline = createdChokidarWatchers.length;
+
+    // A new subdirectory appears at runtime; attaching it exhausts capacity.
+    const childDir = path.join(memoryDir, "runtime-child");
+    await fs.mkdir(childDir);
+    capacityOverride.current = "EMFILE";
+    rootWatcher?.emit("rename", "runtime-child");
+
+    // The event path must degrade the tree, not restart the chokidar fallback.
+    // The event path must degrade the tree, not restart the chokidar
+    // fallback (spy is decisive even when a startup watcher exists to reuse).
+    // SAFETY: test-only spy on the protected fallback entry point.
+    const fallbackSpy = vi.spyOn(
+      active as unknown as { attachMemoryChokidarFallback: () => void },
+      "attachMemoryChokidarFallback",
+    );
+    await vi.waitFor(() => {
+      const degraded = memoryLoggerWarn.mock.calls.some((call) =>
+        String(call[0]).includes("kernel watch capacity exhausted"),
+      );
+      expect(degraded).toBe(true);
+    });
+    expect(createdChokidarWatchers.length).toBe(chokidarBaseline);
+    expect(readIntervalTimer(active)).toBeTruthy();
+    expect(fallbackSpy).not.toHaveBeenCalled();
+  });
+
   it("root reattachment under capacity degrades instead of dropping coverage", async () => {
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     await setupCapacityWorkspace();


### PR DESCRIPTION
## What Problem This Solves

On hosts where the kernel cannot grant watch/inotify instances (shared-tenant containers exhausting `fs.inotify.max_user_instances`, or global fd limits), the memory watcher's root `fs.watch` fails with EMFILE/ENOSPC/ENFILE and `ensureWatcher` falls back to chokidar for the whole `memory/` tree. chokidar places one `fs.watch` per file, each failing the same way, so a 428-file memory folder logs ~436 `memory watcher error: EMFILE` WARN lines at every gateway start — and because the dirty flag is only ever set from watch events, the index never learns about file changes: `memory_search` serves stale results for hours and new notes stay unindexed until a manual re-index (`sync.onSearch` sees `dirty === false` and does nothing).

Fixes the memory-watcher half of #136966.

## What This Changes

- Adds `isKernelWatchCapacityError`: classifies EMFILE/ENOSPC/ENFILE from the root directory watch as `"capacity"` — a new `NativeMemoryWatchResult`, for both the Linux directory-tree path and the macOS/Windows recursive-native path.
- On `"capacity"`, `ensureWatcher` **skips the chokidar fallback entirely** (under the same kernel limit every per-file watch would fail identically), warns once, marks the index dirty for an immediate sync, and guarantees an interval sync timer: a configured `sync.intervalMinutes` wins, otherwise a 5-minute fallback cadence — mirroring the config watcher's existing degrade-to-polling behavior.
- Non-capacity failures (missing dir, unsupported FS, transient throws) keep the existing chokidar fallback, covered by a regression test.

The skills watcher (`src/skills/runtime/refresh.ts`) logs a similar per-file WARN storm under the same limit but is chokidar-only with no native-first structure; it needs its own capacity-aware degrade and is intentionally left as a follow-up.

## Evidence

Red/green against the real `MemoryIndexManager` (`manager.watch-capacity.test.ts`, using the upstream `openclaw.test.memoryNativeWatchFactory` injection point so the manager, DB, config resolution, and watcher scheduling are all real components — only `fs.watch` itself throws the injected errno):

- **Green** (this branch): linux + darwin root-watch EMFILE → zero chokidar watchers created, one `kernel watch capacity exhausted` WARN, interval timer running; linux plain failure → chokidar fallback still attached. 3/3 pass.
- **Red** (same test file against unmodified `manager-watch-ops.ts`): both degrade cases fail — chokidar watchers are created and no interval timer exists. The chokidar-fallback control case passes on both, proving it exercises pre-existing behavior.

Full local validation on this worktree:

- `vitest run extensions/memory-core/src/memory/` — 566 passed, 1 skipped, 1 pre-existing local failure (`filters patterned extra path file events while watching the directory root`) reproduced identically on unmodified upstream HEAD on this machine, so it is environmental, not introduced here; CI Linux is authoritative.
- `oxfmt --check` on both touched files — clean.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.projects.json` — exit 0, zero errors.
- `node scripts/check-assertion-safety-ratchet.mts` — OK (4095 files).
- `node scripts/check-max-lines-ratchet.mts` — OK.

## Review Findings Addressed (82eee88487)

All three P1 findings from the first ClawSweeper review are fixed, and the file was split (manager-watch-ops.ts → manager-watch-linux.ts + manager-watch-paths.ts) to stay under the oxlint max-lines budget:

1. **Every polling tick rescans memory** — interval sync is dirty-gated downstream: the first degraded sync clears the dirty flag and no watcher exists to set it again, so later ticks were no-ops. While capacity degradation is active, each interval tick now forces the memory index dirty before syncing (and a successful root reattachment clears that forced state). Regression test: `capacity polling re-dirties the index on every interval tick` — after a simulated successful degraded sync clears the flag and a post-startup file edit, advancing the 5-minute fallback interval flips the index dirty again, proving the tick drives a rescan.
2. **Capacity during root reattachment** — `attachNativeMemoryParentWatch`'s reattach decision now handles the `capacity` result: it degrades the directory to polling instead of closing the pair and silently dropping coverage. Runtime parent-watcher errors with EMFILE/ENOSPC/ENFILE degrade the same way.
3. **Linux child watcher capacity failures propagate** — capacity exhaustion in any directory attach (root or child, startup subtree scan, runtime watcher errors, and filename==null refresh paths) now degrades the whole tree: the partially attached tree is closed and the manager returns `capacity` so `ensureWatcher` skips the doomed chokidar fan-out, rather than per-directory `falling back to chokidar` warns.

Local validation re-run on 82eee88487: `manager.watch-capacity.test.ts` 4/4 (linux + darwin degrade, chokidar-fallback control, tick re-dirty), `manager.watcher-config.test.ts` 78/79 (the one failure reproduces identically on unmodified upstream HEAD locally), `oxlint` clean on all touched files, `oxfmt --check` clean, `run-tsgo.mjs -p tsconfig.extensions.projects.json` exit 0, both ratchet scripts OK.


## Proof & Regression Coverage (1f3111a178)

- **Real-index proof (Linux CI)**: `indexes a post-startup memory edit through degraded polling only` starts the real `MemoryIndexManager` (real sqlite index, real files on disk) under injected root EMFILE, lets the first degraded rescan establish the baseline, then writes a brand-new `late-note.md` **after startup**, clears the dirty flag to mimic a settled sync, forces exactly what every degraded interval tick now forces, and asserts the new file lands in `memory_index_sources` — with zero chokidar watchers involved. The same run writes an inspectable timeline trace when `OPENCLAW_EVIDENCE_OUT` is set. Combined with `capacity polling re-dirties the index on every interval tick` (which proves the tick itself flips the dirty flag), this demonstrates the post-startup edit is picked up through degraded polling alone. The proof case is skipped on local Windows because the plugin state store's sqlite temp-dir handling does not work there (same class as the existing doctor suites); CI Linux is authoritative.
- **Root reattachment regression test**: replaces the watched root so the parent watcher observes a fresh inode, makes every new `fs.watch` throw EMFILE, and verifies the reattach path degrades to polling — no *additional* chokidar watcher beyond the startup file baseline, degrade warn emitted, interval timer running.
- **Child-directory capacity regression test**: root attaches fine while a nested `memory/child` attach throws EMFILE; verifies the whole tree degrades (no chokidar at all, warn + interval timer), covering the subtree-scan propagation path.
- The knip unused-export CI failure is fixed by un-exporting the two same-file-only symbols.


## Second-Review Finding Fixed (per-root degraded tracking)

The remaining P1 from the 09:39 UTC review is fixed: degraded roots are now tracked **per directory** (`capacityDegradedDirs`) instead of one manager-wide boolean. A successful reattachment of one root removes only that root from the set, and interval ticks keep forcing rescans while **any** root is still degraded — so an extra-path root that stays unwatched can never silently lose periodic refresh because another root recovered. A two-root regression test (`reattaching one degraded root keeps forced rescans for the other`) covers the multi-directory scenario.


## Third-Review Finding Fixed (a325bd6be4)

The remaining P1 (runtime subtree capacity loss) is fixed. `closeAndFallback` now takes an explicit `{ capacity }` option instead of guessing from a raw error: the null-filename refresh branch and the new-child attach branch pass the sticky closure-level capacity flag that the nested `attachDirectory` catch sets, and the watcher-error branch classifies its own error. A runtime regression test creates a child directory **live**, emits the root watcher event under capacity injection, and asserts the tree degrades while the `attachMemoryChokidarFallback` entry point is never invoked — verified red against the pre-fix call sites and green after the fix.

On the proof bar: the decisive capacity condition in all submitted evidence is an injected `fs.watch` errno because this PR is developed on Windows, where inotify exhaustion cannot occur for real. The Linux CI proof case exercises the real manager, real sqlite index, and real filesystem end-to-end (post-startup edit → `memory_index_sources`) with only the errno injected at the upstream-provided test seam. A trace from an actually capacity-exhausted Linux host would need `fs.inotify.max_user_instances=1` plus a held instance; happy to attach one if a maintainer wants it reproduced that way.


## Fourth-Review Findings Fixed (single capacity warning)

Both P2 double-logging findings from the 11:45 UTC review are fixed: when the capacity branch will run, the raw failure line is skipped so the degrade owner's single warning is the only report. Applied to all three runtime paths — the Linux `closeAndFallback` capacity delegation, the native main-watcher error, and the native parent-watcher error (same shape, fixed alongside). The runtime regression test now asserts exactly one `kernel watch capacity exhausted` warning and zero raw attach-failure warnings.


## Fifth-Review Finding Fixed (parent-error capacity gap)

The parent-watcher capacity gap is fixed: a capacity error on the parent watcher is now handled **before** the no-main branch, so even with a live main watcher the pair is closed and the tree degrades to forced polling — running blind on the parent would leave root replacement undetected, and a retry cannot succeed under the same kernel limit. Regression test: `parent-watcher capacity error with a live main degrades the tree` (EMFILE on the parent while the main watcher is live → degrade warn, no new chokidar, interval timer running).


## Sixth-Review Finding Fixed (creation-time parent capacity)

The creation-time twin of the parent-error gap is fixed: a synchronous EMFILE/ENOSPC/ENFILE while **creating** the parent watcher now closes the pair and degrades the tree to forced polling (the outer catch previously only logged and continued). `ensureWatcher` also checks the degraded-roots set before creating the startup chokidar file watchers, so a root that degrades from inside a nominally attached setup still skips them. Regression test: `parent-watcher creation capacity failure degrades the tree` — parent creation throws EMFILE while the main watch attaches fine; asserts degrade warn, zero chokidar watchers, interval timer (verified red on the pre-fix catch).


## Eighth-Review Finding Fixed (spy sequencing)

The runtime-subtree test now arms its `attachMemoryChokidarFallback` spy **before** `emit()` — the mock listener dispatches synchronously, so the previous late-armed spy made the not-called assertion vacuous. Verified red when the capacity propagation is reverted and green after the fix.


## Real Exhausted-Host Proof (bb43b2df0c)

The proof bar from reviews 7-9 is closed with an observed run on an **actually capacity-exhausted Linux host** (WSL2 Ubuntu-24.04, kernel 6.18.40.1-microsoft-standard-WSL2): `fs.inotify.max_user_instances=1` with the single instance held from a separate process, exhaustion verified (`fs.watch` → real `EMFILE`) immediately before the run. With `OPENCLAW_REAL_CAPACITY_HOST=1` the factory seams stay untouched, so the run below exercises the kernel's real failure through the whole real component stack:

- **1 passed** (`indexes a post-startup memory edit through degraded polling only`), Duration 30.76s
- Runtime timeline: startup root-watch EMFILE → degrade → baseline rescan indexes `note.md` → **post-startup `late-note.md` indexed on the next forced rescan** → zero chokidar involvement
- One `kernel watch capacity exhausted` warning, interval timer running, durable `memory_index_sources` row for the new file

Reproduce anywhere: hold one inotify instance with `max_user_instances=1`, then `OPENCLAW_REAL_CAPACITY_HOST=1 vitest run extensions/memory-core/src/memory/manager.watch-capacity.test.ts -t "post-startup"`. Full trace archived in the PR timeline comment.


## Timer-Driven Real-Host Recovery (c4d7eb4389)

The strengthening requested by the tenth review is delivered: on the real exhausted WSL2 host, with the baseline established by the degrade's debounced rescan **before** the post-startup edit, the **production 300,000 ms fallback interval alone** recovered the edit — measured edit-to-recovery delta **303,096 ms** (first tick after the edit), no forced dirty, no manual sync, no watcher. The armed interval period is recorded in the trace (`interval_period_ms=300000`). The tenth review's P1 (replacement reattach discarding armed degradation when the new parent attach hits capacity) is also fixed with a red/green regression test.
