### PR TITLE
improve(testing): add watchOS Gateway upgrade survivor

### DIFF
--- a/.github/workflows/update-migration.yml
+++ b/.github/workflows/update-migration.yml
@@ -1,8 +1,6 @@
 name: Update Migration
 
 on:
-  schedule:
-    - cron: "41 6 * * 1"
   workflow_dispatch:
     inputs:
       workflow_ref:
@@ -37,13 +35,13 @@ jobs:
     name: Update migration matrix
     uses: ./.github/workflows/package-acceptance.yml
     with:
-      workflow_ref: ${{ inputs.workflow_ref || 'main' }}
+      workflow_ref: ${{ inputs.workflow_ref }}
       source: ref
-      package_ref: ${{ inputs.package_ref || 'main' }}
+      package_ref: ${{ inputs.package_ref }}
       suite_profile: custom
       docker_lanes: update-migration
-      published_upgrade_survivor_baselines: ${{ github.event_name == 'schedule' && '2026.8.1' || inputs.baselines }}
-      published_upgrade_survivor_scenarios: ${{ github.event_name == 'schedule' && 'watchos-direct-node' || inputs.scenarios }}
+      published_upgrade_survivor_baselines: ${{ inputs.baselines }}
+      published_upgrade_survivor_scenarios: ${{ inputs.scenarios }}
       shared_image_artifact_namespace: update-migration
       shared_image_policy: no-push-artifact
       telegram_mode: none

--- a/.github/workflows/update-migration.yml
+++ b/.github/workflows/update-migration.yml
@@ -1,6 +1,8 @@
 name: Update Migration
 
 on:
+  schedule:
+    - cron: "41 6 * * 1"
   workflow_dispatch:
     inputs:
       workflow_ref:
@@ -35,13 +37,13 @@ jobs:
     name: Update migration matrix
     uses: ./.github/workflows/package-acceptance.yml
     with:
-      workflow_ref: ${{ inputs.workflow_ref }}
+      workflow_ref: ${{ inputs.workflow_ref || 'main' }}
       source: ref
-      package_ref: ${{ inputs.package_ref }}
+      package_ref: ${{ inputs.package_ref || 'main' }}
       suite_profile: custom
       docker_lanes: update-migration
-      published_upgrade_survivor_baselines: ${{ inputs.baselines }}
-      published_upgrade_survivor_scenarios: ${{ inputs.scenarios }}
+      published_upgrade_survivor_baselines: ${{ github.event_name == 'schedule' && '2026.8.1' || inputs.baselines }}
+      published_upgrade_survivor_scenarios: ${{ github.event_name == 'schedule' && 'watchos-direct-node' || inputs.scenarios }}
       shared_image_artifact_namespace: update-migration
       shared_image_policy: no-push-artifact
       telegram_mode: none

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -84,6 +84,7 @@ const repositoryScriptEntries = [
   "scripts/e2e/lib/upgrade-survivor/recovery-cleanup.mjs!",
   // update-restart-auth.sh installs this manager/launch adapter into the fixture bin directory.
   "scripts/e2e/lib/upgrade-survivor/systemd-fixture.mjs!",
+  "scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs!",
   "scripts/embedded-run-abort-leak.ts!",
   "scripts/fixtures/packed-plugin-sdk-type-smoke.ts!",
   // CI executes screenshot evidence from the workflow-owned harness copy.

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -372,6 +372,11 @@ function seedState() {
     version: 1,
     setupCompletedAt: "2026-04-01T00:00:00.000Z",
   });
+  // The watch row proves only direct-node identity/auth survival. Unrelated
+  // migration specimens can prevent the shipped baseline Gateway from starting.
+  if (scenario === "watchos-direct-node") {
+    return;
+  }
   writeJson(path.join(stateDir, "agents", "main", "sessions", "legacy-session.json"), {
     id: "legacy-session",
     agentId: "main",
@@ -640,6 +645,9 @@ function assertStateSurvived() {
   const scenario = getScenario();
   const stage = process.env.OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE || "survival";
   assert(fs.existsSync(path.join(workspace, "IDENTITY.md")), "workspace identity file missing");
+  if (scenario === "watchos-direct-node") {
+    return;
+  }
   assert(
     fs.existsSync(path.join(stateDir, "agents", "main", "sessions", "legacy-session.json")),
     "legacy session file missing",
@@ -1641,10 +1649,12 @@ if (command === "list-scenarios") {
 } else if (command === "seed") {
   seedState();
 } else if (command === "assert-exec-approvals") {
-  assertExecApprovalPolicySurvived(
-    requireEnv("OPENCLAW_STATE_DIR"),
-    process.env.OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE || "survival",
-  );
+  if (getScenario() !== "watchos-direct-node") {
+    assertExecApprovalPolicySurvived(
+      requireEnv("OPENCLAW_STATE_DIR"),
+      process.env.OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE || "survival",
+    );
+  }
 } else if (command === "seed-volume") {
   assert(getScenario() === "sqlite-volume", "seed-volume requires the sqlite-volume scenario");
   const stateDir = requireEnv("OPENCLAW_STATE_DIR");

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -33,6 +33,7 @@ const SCENARIOS = new Set([
   "sqlite-volume",
   "recovery-cleanup",
   "auth-profile-v2026-7-2-beta-5",
+  "watchos-direct-node",
 ]);
 
 const PERSONA_FILES = new Map([

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
@@ -249,12 +249,7 @@ const sharedRecipe: ConfigStep[] = [
   },
 ];
 
-const watchDirectNodeOmittedIntents = new Set([
-  "plugins",
-  "discord-channel",
-  "telegram-channel",
-  "whatsapp-channel",
-]);
+const watchDirectNodeSharedIntents = new Set(["gateway"]);
 
 export function resolveUpgradeSurvivorConfigSteps(
   scenario = "base",
@@ -269,8 +264,7 @@ export function resolveUpgradeSurvivorConfigSteps(
   const sharedSteps = sharedRecipe
     .slice(0, -1)
     .filter(
-      (step) =>
-        scenario !== "watchos-direct-node" || !watchDirectNodeOmittedIntents.has(step.intent),
+      (step) => scenario !== "watchos-direct-node" || watchDirectNodeSharedIntents.has(step.intent),
     )
     .map((step) => {
       if (scenario !== "recovery-cleanup" || step.id !== "agents") {

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
@@ -249,6 +249,13 @@ const sharedRecipe: ConfigStep[] = [
   },
 ];
 
+const watchDirectNodeOmittedIntents = new Set([
+  "plugins",
+  "discord-channel",
+  "telegram-channel",
+  "whatsapp-channel",
+]);
+
 export function resolveUpgradeSurvivorConfigSteps(
   scenario = "base",
   configuredUpdateChannel = process.env.OPENCLAW_UPGRADE_SURVIVOR_UPDATE_CHANNEL,
@@ -259,22 +266,28 @@ export function resolveUpgradeSurvivorConfigSteps(
   if (updateChannel !== "stable" && updateChannel !== "beta") {
     throw new Error(`invalid upgrade survivor update channel: ${updateChannel}`);
   }
-  const sharedSteps = sharedRecipe.slice(0, -1).map((step) => {
-    if (scenario !== "recovery-cleanup" || step.id !== "agents") {
-      return step;
-    }
-    const agentsJson = step.argv[3];
-    if (agentsJson === undefined) {
-      throw new Error(`config recipe step ${step.id} is missing its JSON value`);
-    }
-    // Extend the canonical roster before the baseline adapter chooses entries or legacy list.
-    // A second agents.list write bypasses that version contract and can lose ownership defaults.
-    const agents = JSON.parse(agentsJson);
-    agents.entries["recovery-clean"] = { workspace: "~/workspace/recovery-clean" };
-    agents.entries["recovery-protected"] = { workspace: "~/workspace/recovery-protected" };
-    const argv = [...step.argv.slice(0, 3), JSON.stringify(agents), ...step.argv.slice(4)];
-    return Object.assign({}, step, { argv });
-  });
+  const sharedSteps = sharedRecipe
+    .slice(0, -1)
+    .filter(
+      (step) =>
+        scenario !== "watchos-direct-node" || !watchDirectNodeOmittedIntents.has(step.intent),
+    )
+    .map((step) => {
+      if (scenario !== "recovery-cleanup" || step.id !== "agents") {
+        return step;
+      }
+      const agentsJson = step.argv[3];
+      if (agentsJson === undefined) {
+        throw new Error(`config recipe step ${step.id} is missing its JSON value`);
+      }
+      // Extend the canonical roster before the baseline adapter chooses entries or legacy list.
+      // A second agents.list write bypasses that version contract and can lose ownership defaults.
+      const agents = JSON.parse(agentsJson);
+      agents.entries["recovery-clean"] = { workspace: "~/workspace/recovery-clean" };
+      agents.entries["recovery-protected"] = { workspace: "~/workspace/recovery-protected" };
+      const argv = [...step.argv.slice(0, 3), JSON.stringify(agents), ...step.argv.slice(4)];
+      return Object.assign({}, step, { argv });
+    });
   return [
     {
       id: "update-channel",
@@ -453,7 +466,7 @@ function applyRecipe() {
   const summaryPath = option("--summary");
   const baselineVersion = option("--baseline-version", null);
   const scenario = selectedScenario();
-  const scenarioSteps = resolveScenarioConfigSteps(scenario);
+  const recipeSteps = resolveUpgradeSurvivorConfigSteps(scenario);
   const summary: {
     source: string;
     recipe: string;
@@ -467,29 +480,21 @@ function applyRecipe() {
     recipe: "upgrade-survivor-v1",
     baselineVersion,
     scenario,
-    acceptedIntents: [
-      "update",
-      "gateway",
-      "models",
-      "agents",
-      "skills",
-      "plugins",
-      "discord-channel",
-      "telegram-channel",
-      "whatsapp-channel",
-      ...scenarioSteps.map((step) => step.intent),
-    ],
+    acceptedIntents: [],
     skippedIntents: [],
     steps: [],
   };
 
-  for (const step of resolveUpgradeSurvivorConfigSteps(scenario)) {
+  for (const step of recipeSteps) {
     const adaptedStep = adaptStepForBaseline(step, baselineVersion, summary);
     if (!adaptedStep) {
       continue;
     }
     const outcome = runUpgradeSurvivorOpenClawStep(adaptedStep);
     summary.steps.push(outcome);
+    if (outcome.ok && !summary.acceptedIntents.includes(adaptedStep.intent)) {
+      summary.acceptedIntents.push(adaptedStep.intent);
+    }
     writeJson(summaryPath, summary);
     if (!outcome.ok) {
       const detail = outcome.errorCode ?? outcome.signal ?? outcome.status ?? "unknown";

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -36,9 +36,13 @@ case "$LIVE_OPENAI" in
     ;;
 esac
 export GATEWAY_AUTH_TOKEN_REF="upgrade-survivor-token"
-export OPENAI_API_KEY="sk-openclaw-upgrade-survivor"
-export DISCORD_BOT_TOKEN="upgrade-survivor-discord-token"
-export TELEGRAM_BOT_TOKEN="123456:upgrade-survivor-telegram-token"
+if [ "$SCENARIO" = "watchos-direct-node" ]; then
+  unset OPENAI_API_KEY DISCORD_BOT_TOKEN TELEGRAM_BOT_TOKEN
+else
+  export OPENAI_API_KEY="sk-openclaw-upgrade-survivor"
+  export DISCORD_BOT_TOKEN="upgrade-survivor-discord-token"
+  export TELEGRAM_BOT_TOKEN="123456:upgrade-survivor-telegram-token"
+fi
 if [ "$SCENARIO" = "feishu-channel" ]; then
   export FEISHU_APP_SECRET="upgrade-survivor-feishu-secret"
 fi

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -128,6 +128,17 @@ SYSTEMCTL_SHIM_LOG="$ARTIFACT_ROOT/systemctl-shim.log"
 SYSTEMCTL_SHIM_PID_FILE="$ARTIFACT_ROOT/systemctl-shim.pid"
 SYSTEMCTL_SHIM_DAEMON_LOG="$ARTIFACT_ROOT/systemctl-shim-gateway.log"
 CONFIG_COVERAGE_JSON="$ARTIFACT_ROOT/config-recipe.json"
+WATCH_RUNTIME_ROOT="$RUNTIME_ROOT/watchos-direct-node"
+WATCH_STATE_JSON="$WATCH_RUNTIME_ROOT/state.json"
+WATCH_SETUP_JSON="$WATCH_RUNTIME_ROOT/setup.json"
+WATCH_NODES_JSON="$WATCH_RUNTIME_ROOT/nodes.json"
+WATCH_DEVICES_JSON="$WATCH_RUNTIME_ROOT/devices.json"
+WATCH_BASELINE_CONNECT_JSON="$ARTIFACT_ROOT/watchos-baseline-connect.json"
+WATCH_BASELINE_STATE_JSON="$ARTIFACT_ROOT/watchos-baseline-state.json"
+WATCH_CANDIDATE_CONNECT_JSON="$ARTIFACT_ROOT/watchos-candidate-connect.json"
+WATCH_CANDIDATE_STATE_JSON="$ARTIFACT_ROOT/watchos-candidate-state.json"
+WATCH_RESTART_CONNECT_JSON="$ARTIFACT_ROOT/watchos-restart-connect.json"
+WATCH_RESTART_STATE_JSON="$ARTIFACT_ROOT/watchos-restart-state.json"
 export OPENCLAW_UPGRADE_SURVIVOR_CONFIG_COVERAGE_JSON="$CONFIG_COVERAGE_JSON"
 rm -f "$SUMMARY_JSON" "$CONFIG_COVERAGE_JSON"
 : >"$PHASE_LOG"
@@ -225,6 +236,12 @@ write_summary() {
     SUMMARY_STATUS_SECONDS="$status_seconds" \
     SUMMARY_FAILURE_PHASE="$FAILURE_PHASE" \
     SUMMARY_CONFIG_COVERAGE="$CONFIG_COVERAGE_JSON" \
+    SUMMARY_WATCH_BASELINE_CONNECT="$WATCH_BASELINE_CONNECT_JSON" \
+    SUMMARY_WATCH_BASELINE_STATE="$WATCH_BASELINE_STATE_JSON" \
+    SUMMARY_WATCH_CANDIDATE_CONNECT="$WATCH_CANDIDATE_CONNECT_JSON" \
+    SUMMARY_WATCH_CANDIDATE_STATE="$WATCH_CANDIDATE_STATE_JSON" \
+    SUMMARY_WATCH_RESTART_CONNECT="$WATCH_RESTART_CONNECT_JSON" \
+    SUMMARY_WATCH_RESTART_STATE="$WATCH_RESTART_STATE_JSON" \
     node <<'NODE'
 const fs = require("node:fs");
 const phaseLog = process.env.SUMMARY_PHASE_LOG;
@@ -268,6 +285,31 @@ const summary = {
   recovery: process.env.SUMMARY_SCENARIO === "recovery-cleanup"
     ? readJsonOrNull(require("node:path").join(require("node:path").dirname(process.env.SUMMARY_JSON), "recovery-evidence.json"))
     : undefined,
+  watchosDirectNode: process.env.SUMMARY_SCENARIO === "watchos-direct-node"
+    ? {
+        contract: {
+          signature: "v3",
+          clientId: "openclaw-watchos",
+          clientMode: "node",
+          protocolRange: [4, 4],
+          stableInstanceId: "watchos-upgrade-survivor",
+          bootstrapAuthField: "bootstrapToken",
+          reconnectAuthField: "deviceToken",
+        },
+        baseline: {
+          connect: readJsonOrNull(process.env.SUMMARY_WATCH_BASELINE_CONNECT),
+          state: readJsonOrNull(process.env.SUMMARY_WATCH_BASELINE_STATE),
+        },
+        candidate: {
+          connect: readJsonOrNull(process.env.SUMMARY_WATCH_CANDIDATE_CONNECT),
+          state: readJsonOrNull(process.env.SUMMARY_WATCH_CANDIDATE_STATE),
+        },
+        restart: {
+          connect: readJsonOrNull(process.env.SUMMARY_WATCH_RESTART_CONNECT),
+          state: readJsonOrNull(process.env.SUMMARY_WATCH_RESTART_STATE),
+        },
+      }
+    : undefined,
   failure: process.env.SUMMARY_STATUS === "passed"
     ? null
     : {
@@ -294,6 +336,69 @@ stop_gateway() {
     fi
   fi
   rm -f "$SYSTEMCTL_SHIM_PID_FILE"
+}
+
+watchos_gateway_call() {
+  local method="$1"
+  local params="$2"
+  local output="$3"
+  openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw gateway call "$method" \
+    --port 18789 \
+    --token "$GATEWAY_AUTH_TOKEN_REF" \
+    --params "$params" \
+    --timeout 20000 \
+    --json >"$output"
+  chmod 600 "$output"
+}
+
+watchos_assert_gateway_state() {
+  local label="$1"
+  local output="$2"
+  watchos_gateway_call node.list '{}' "$WATCH_NODES_JSON"
+  watchos_gateway_call device.pair.list '{}' "$WATCH_DEVICES_JSON"
+  node scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs assert-state \
+    --state "$WATCH_STATE_JSON" \
+    --nodes "$WATCH_NODES_JSON" \
+    --devices "$WATCH_DEVICES_JSON" \
+    --out "$output" \
+    --label "$label"
+}
+
+watchos_connect() {
+  local mode="$1"
+  local credential="$2"
+  local output="$3"
+  local label="$4"
+  openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" \
+    node scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs connect \
+    --mode "$mode" \
+    --base-url http://127.0.0.1:18789/api/nodes/watch \
+    --credential "$credential" \
+    --state "$WATCH_STATE_JSON" \
+    --out "$output" \
+    --label "$label"
+}
+
+watchos_pair_baseline() {
+  mkdir -p "$WATCH_RUNTIME_ROOT"
+  chmod 700 "$WATCH_RUNTIME_ROOT"
+  start_gateway
+  watchos_gateway_call device.pair.setupCode \
+    '{"includeQr":false,"bootstrapProfile":"node","publicUrl":"ws://127.0.0.1:18789"}' \
+    "$WATCH_SETUP_JSON"
+  watchos_connect bootstrap "$WATCH_SETUP_JSON" "$WATCH_BASELINE_CONNECT_JSON" baseline
+  watchos_assert_gateway_state baseline "$WATCH_BASELINE_STATE_JSON"
+  stop_gateway
+}
+
+watchos_reconnect_candidate() {
+  watchos_connect device "$WATCH_STATE_JSON" "$WATCH_CANDIDATE_CONNECT_JSON" candidate
+  watchos_assert_gateway_state candidate "$WATCH_CANDIDATE_STATE_JSON"
+}
+
+watchos_reconnect_restarted_candidate() {
+  watchos_connect device "$WATCH_STATE_JSON" "$WATCH_RESTART_CONNECT_JSON" restart
+  watchos_assert_gateway_state restart "$WATCH_RESTART_STATE_JSON"
 }
 
 cleanup() {
@@ -1327,6 +1432,9 @@ if [ "$SCENARIO" = "sqlite-volume" ]; then
   phase validate-volume-baseline-config validate_baseline_config
 fi
 phase assert-baseline assert_baseline_state
+if [ "$SCENARIO" = "watchos-direct-node" ]; then
+  phase watchos-baseline-pair watchos_pair_baseline
+fi
 if [ "$SCENARIO" = "recovery-cleanup" ]; then
   phase seed-recovery-state node scripts/e2e/lib/upgrade-survivor/recovery-cleanup.mjs seed
 fi
@@ -1369,6 +1477,15 @@ fi
 phase gateway-start ensure_gateway_started
 phase gateway-probes check_gateway_probes
 phase gateway-status check_gateway_status
+if [ "$SCENARIO" = "watchos-direct-node" ]; then
+  phase watchos-candidate-reconnect watchos_reconnect_candidate
+  phase gateway-stop stop_gateway
+  phase gateway-restart start_gateway
+  phase gateway-restart-probes check_gateway_probes
+  phase gateway-restart-status check_gateway_status
+  phase watchos-restart-reconnect watchos_reconnect_restarted_candidate
+  phase assert-restarted-survival assert_survival
+fi
 if [ "$SCENARIO" = "recovery-cleanup" ]; then
   phase recovery-live node scripts/e2e/lib/upgrade-survivor/recovery-cleanup.mjs live
   phase gateway-stop stop_gateway

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -139,6 +139,15 @@ WATCH_CANDIDATE_CONNECT_JSON="$ARTIFACT_ROOT/watchos-candidate-connect.json"
 WATCH_CANDIDATE_STATE_JSON="$ARTIFACT_ROOT/watchos-candidate-state.json"
 WATCH_RESTART_CONNECT_JSON="$ARTIFACT_ROOT/watchos-restart-connect.json"
 WATCH_RESTART_STATE_JSON="$ARTIFACT_ROOT/watchos-restart-state.json"
+WATCH_TLS_ROOT="$WATCH_RUNTIME_ROOT/tls"
+WATCH_TLS_CA_KEY="$WATCH_TLS_ROOT/ca-key.pem"
+WATCH_TLS_CA_CERT="$WATCH_TLS_ROOT/ca-cert.pem"
+WATCH_TLS_SERVER_KEY="$WATCH_TLS_ROOT/server-key.pem"
+WATCH_TLS_SERVER_CSR="$WATCH_TLS_ROOT/server.csr"
+WATCH_TLS_SERVER_CERT="$WATCH_TLS_ROOT/server-cert.pem"
+WATCH_TLS_SERVER_EXT="$WATCH_TLS_ROOT/server.ext"
+WATCH_GATEWAY_WS_URL="wss://localhost:18789"
+WATCH_GATEWAY_HTTP_URL="https://localhost:18789"
 export OPENCLAW_UPGRADE_SURVIVOR_CONFIG_COVERAGE_JSON="$CONFIG_COVERAGE_JSON"
 rm -f "$SUMMARY_JSON" "$CONFIG_COVERAGE_JSON"
 : >"$PHASE_LOG"
@@ -343,7 +352,7 @@ watchos_gateway_call() {
   local params="$2"
   local output="$3"
   openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw gateway call "$method" \
-    --port 18789 \
+    --url "$WATCH_GATEWAY_WS_URL" \
     --token "$GATEWAY_AUTH_TOKEN_REF" \
     --params "$params" \
     --timeout 20000 \
@@ -369,14 +378,19 @@ watchos_connect() {
   local credential="$2"
   local output="$3"
   local label="$4"
-  openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" \
-    node scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs connect \
-    --mode "$mode" \
-    --base-url http://127.0.0.1:18789/api/nodes/watch \
-    --credential "$credential" \
-    --state "$WATCH_STATE_JSON" \
-    --out "$output" \
+  local args=(
+    scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs
+    connect
+    --mode "$mode"
+    --state "$WATCH_STATE_JSON"
+    --out "$output"
     --label "$label"
+  )
+  if [ "$mode" = "bootstrap" ]; then
+    args+=(--credential "$credential")
+  fi
+  openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" \
+    node "${args[@]}"
 }
 
 watchos_pair_baseline() {
@@ -384,7 +398,7 @@ watchos_pair_baseline() {
   chmod 700 "$WATCH_RUNTIME_ROOT"
   start_gateway
   watchos_gateway_call device.pair.setupCode \
-    '{"includeQr":false,"bootstrapProfile":"node","publicUrl":"ws://127.0.0.1:18789"}' \
+    '{"includeQr":false,"bootstrapProfile":"node","publicUrl":"wss://localhost:18789"}' \
     "$WATCH_SETUP_JSON"
   watchos_connect bootstrap "$WATCH_SETUP_JSON" "$WATCH_BASELINE_CONNECT_JSON" baseline
   watchos_assert_gateway_state baseline "$WATCH_BASELINE_STATE_JSON"
@@ -970,6 +984,55 @@ apply_baseline_config_recipe() {
     --baseline-version "$baseline_version"
 }
 
+configure_watchos_tls_fixture() {
+  [ "$SCENARIO" = "watchos-direct-node" ] || return 0
+  command -v openssl >/dev/null || {
+    echo "watchOS direct-node survivor requires openssl" >&2
+    return 1
+  }
+  mkdir -p "$WATCH_TLS_ROOT"
+  chmod 700 "$WATCH_TLS_ROOT"
+  openssl req -x509 -newkey rsa:2048 -nodes -sha256 -days 1 \
+    -subj "/CN=OpenClaw watchOS survivor CA" \
+    -addext "basicConstraints=critical,CA:TRUE" \
+    -addext "keyUsage=critical,keyCertSign,cRLSign" \
+    -keyout "$WATCH_TLS_CA_KEY" \
+    -out "$WATCH_TLS_CA_CERT" >/dev/null 2>&1
+  openssl req -newkey rsa:2048 -nodes -sha256 \
+    -subj "/CN=localhost" \
+    -keyout "$WATCH_TLS_SERVER_KEY" \
+    -out "$WATCH_TLS_SERVER_CSR" >/dev/null 2>&1
+  printf '%s\n' \
+    "basicConstraints=critical,CA:FALSE" \
+    "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+    "keyUsage=critical,digitalSignature,keyEncipherment" \
+    "extendedKeyUsage=serverAuth" >"$WATCH_TLS_SERVER_EXT"
+  openssl x509 -req \
+    -in "$WATCH_TLS_SERVER_CSR" \
+    -CA "$WATCH_TLS_CA_CERT" \
+    -CAkey "$WATCH_TLS_CA_KEY" \
+    -CAcreateserial \
+    -days 1 \
+    -sha256 \
+    -extfile "$WATCH_TLS_SERVER_EXT" \
+    -out "$WATCH_TLS_SERVER_CERT" >/dev/null 2>&1
+  chmod 600 "$WATCH_TLS_CA_KEY" "$WATCH_TLS_CA_CERT" "$WATCH_TLS_SERVER_KEY" \
+    "$WATCH_TLS_SERVER_CSR" "$WATCH_TLS_SERVER_CERT" "$WATCH_TLS_SERVER_EXT"
+  local tls_config
+  tls_config="$(
+    node -e '
+      process.stdout.write(JSON.stringify({
+        enabled: true,
+        autoGenerate: false,
+        certPath: process.argv[1],
+        keyPath: process.argv[2],
+      }));
+    ' "$WATCH_TLS_SERVER_CERT" "$WATCH_TLS_SERVER_KEY"
+  )"
+  openclaw config set gateway.tls "$tls_config" --strict-json >/dev/null
+  export NODE_EXTRA_CA_CERTS="$WATCH_TLS_CA_CERT"
+}
+
 validate_baseline_config() {
   if ! openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw config validate >"$BASELINE_CONFIG_VALIDATE_LOG" 2>&1; then
     echo "generated baseline config failed baseline validation" >&2
@@ -1300,8 +1363,12 @@ probe_gateway_endpoint() {
   local out_file="$3"
   local start_epoch
   local end_epoch
+  local gateway_http_url="http://127.0.0.1:18789"
+  if [ "$SCENARIO" = "watchos-direct-node" ]; then
+    gateway_http_url="$WATCH_GATEWAY_HTTP_URL"
+  fi
   local args=(
-    --base-url "http://127.0.0.1:18789"
+    --base-url "$gateway_http_url"
     --path "$path"
     --expect "$expect_kind"
   )
@@ -1328,7 +1395,11 @@ start_gateway() {
   start_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
   env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway --port "$port" --bind loopback --allow-unconfigured >"$GATEWAY_LOG" 2>&1 &
   gateway_pid="$!"
-  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$port" || return "$?"
+  local readiness_mode="strict"
+  if [ "$SCENARIO" = "watchos-direct-node" ]; then
+    readiness_mode="legacy-ready-log-ok"
+  fi
+  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$port" "$readiness_mode" || return "$?"
   ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
   start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
   if [ "$start_seconds" -gt "$budget" ]; then
@@ -1352,12 +1423,16 @@ check_gateway_probes() {
 
 check_gateway_status() {
   local port=18789
+  local gateway_ws_url="ws://127.0.0.1:$port"
+  if [ "$SCENARIO" = "watchos-direct-node" ]; then
+    gateway_ws_url="$WATCH_GATEWAY_WS_URL"
+  fi
   local budget
   budget="$(openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS 30)"
   local status_start
   local status_end
   status_start="$(node -e "process.stdout.write(String(Date.now()))")"
-  if ! openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw gateway status --url "ws://127.0.0.1:$port" --token "$GATEWAY_AUTH_TOKEN_REF" --require-rpc --timeout 30000 --json >"$STATUS_JSON" 2>"$STATUS_ERR"; then
+  if ! openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw gateway status --url "$gateway_ws_url" --token "$GATEWAY_AUTH_TOKEN_REF" --require-rpc --timeout 30000 --json >"$STATUS_JSON" 2>"$STATUS_ERR"; then
     echo "gateway status failed" >&2
     openclaw_e2e_print_log "$STATUS_ERR" >&2
     openclaw_e2e_print_log "$GATEWAY_LOG" >&2
@@ -1414,6 +1489,9 @@ phase reset-run-state reset_run_state
 phase install-baseline install_baseline
 phase initialize-state initialize_state
 phase apply-baseline-config-recipe apply_baseline_config_recipe
+if [ "$SCENARIO" = "watchos-direct-node" ]; then
+  phase configure-watchos-tls configure_watchos_tls_fixture
+fi
 phase validate-baseline-config validate_baseline_config
 phase resolve-candidate resolve_candidate_version
 phase configure-clawhub-fixture configure_clawhub_fixture

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1320,7 +1320,11 @@ repair_fixture_plugin_consent() {
     fi
   fi
   if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
-    phase assert-prepublish-recovery-requests assert_prepublish_plugin_install
+    if [ "$SCENARIO" = "watchos-direct-node" ]; then
+      phase assert-prepublish-recovery-idle assert_prepublish_fixture_idle
+    else
+      phase assert-prepublish-recovery-requests assert_prepublish_plugin_install
+    fi
   fi
 }
 
@@ -1536,7 +1540,11 @@ if [ "$SCENARIO" = "recovery-cleanup" ]; then
   phase assert-recovery-migration node scripts/e2e/lib/upgrade-survivor/recovery-cleanup.mjs migrated
 fi
 if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
-  phase assert-prepublish-requests assert_prepublish_plugin_install 1
+  if [ "$SCENARIO" = "watchos-direct-node" ]; then
+    phase assert-prepublish-idle assert_prepublish_fixture_idle
+  else
+    phase assert-prepublish-requests assert_prepublish_plugin_install 1
+  fi
 fi
 phase root-managed-vps-cli-usable assert_root_managed_vps_cli_usable
 phase assert-legacy-plugin-dependency-debris-before-doctor assert_legacy_plugin_dependency_debris_before_doctor

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -985,7 +985,7 @@ apply_baseline_config_recipe() {
 }
 
 configure_watchos_tls_fixture() {
-  [ "$SCENARIO" = "watchos-direct-node" ] || return 0
+  [ "${SCENARIO:-}" = "watchos-direct-node" ] || return 0
   command -v openssl >/dev/null || {
     echo "watchOS direct-node survivor requires openssl" >&2
     return 1
@@ -1364,7 +1364,7 @@ probe_gateway_endpoint() {
   local start_epoch
   local end_epoch
   local gateway_http_url="http://127.0.0.1:18789"
-  if [ "$SCENARIO" = "watchos-direct-node" ]; then
+  if [ "${SCENARIO:-}" = "watchos-direct-node" ]; then
     gateway_http_url="$WATCH_GATEWAY_HTTP_URL"
   fi
   local args=(
@@ -1396,7 +1396,7 @@ start_gateway() {
   env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway --port "$port" --bind loopback --allow-unconfigured >"$GATEWAY_LOG" 2>&1 &
   gateway_pid="$!"
   local readiness_mode="strict"
-  if [ "$SCENARIO" = "watchos-direct-node" ]; then
+  if [ "${SCENARIO:-}" = "watchos-direct-node" ]; then
     readiness_mode="legacy-ready-log-ok"
   fi
   openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$port" "$readiness_mode" || return "$?"
@@ -1424,7 +1424,7 @@ check_gateway_probes() {
 check_gateway_status() {
   local port=18789
   local gateway_ws_url="ws://127.0.0.1:$port"
-  if [ "$SCENARIO" = "watchos-direct-node" ]; then
+  if [ "${SCENARIO:-}" = "watchos-direct-node" ]; then
     gateway_ws_url="$WATCH_GATEWAY_WS_URL"
   fi
   local budget

--- a/scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { parseArgs } from "node:util";
+
+const WATCH_CLIENT = Object.freeze({
+  id: "openclaw-watchos",
+  displayName: "Upgrade Survivor Watch",
+  version: "2026.8.10",
+  platform: "watchOS 11.5.0",
+  deviceFamily: "Apple Watch",
+  mode: "node",
+  instanceId: "watchos-upgrade-survivor",
+});
+const WATCH_COMMANDS = Object.freeze(["device.info", "device.status", "system.notify"]);
+const WATCH_PROTOCOL = 4;
+
+function requiredOption(values, name) {
+  const value = values[name];
+  assert(typeof value === "string" && value.length > 0, `--${name} is required`);
+  return value;
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function normalizeDeviceMetadata(value) {
+  return value.trim().replace(/[A-Z]/g, (char) => String.fromCharCode(char.charCodeAt(0) + 32));
+}
+
+function buildSignaturePayload({ deviceId, signedAt, token, nonce }) {
+  return [
+    "v3",
+    deviceId,
+    WATCH_CLIENT.id,
+    WATCH_CLIENT.mode,
+    "node",
+    "",
+    String(signedAt),
+    token,
+    nonce,
+    normalizeDeviceMetadata(WATCH_CLIENT.platform),
+    normalizeDeviceMetadata(WATCH_CLIENT.deviceFamily),
+  ].join("|");
+}
+
+function createIdentity() {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  const publicDer = publicKey.export({ format: "der", type: "spki" });
+  const rawPublicKey = Buffer.from(publicDer).subarray(-32);
+  return {
+    deviceId: sha256(rawPublicKey),
+    publicKey: rawPublicKey.toString("base64url"),
+    privateKeyPem: privateKey.export({ format: "pem", type: "pkcs8" }).toString(),
+    instanceId: WATCH_CLIENT.instanceId,
+  };
+}
+
+function loadIdentity(stateFile) {
+  const state = fs.existsSync(stateFile) ? readJson(stateFile) : createIdentity();
+  for (const field of ["deviceId", "publicKey", "privateKeyPem", "instanceId"]) {
+    assert(typeof state[field] === "string" && state[field].length > 0, `state omitted ${field}`);
+  }
+  assert.equal(state.instanceId, WATCH_CLIENT.instanceId, "watch instanceId changed");
+  return state;
+}
+
+function decodeBootstrapToken(setupFile) {
+  const result = readJson(setupFile);
+  assert(typeof result.setupCode === "string", "setupCode missing");
+  const encoded = result.setupCode.toLowerCase().startsWith("oc-pair://")
+    ? result.setupCode.slice("oc-pair://".length)
+    : result.setupCode;
+  const payload = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+  assert(typeof payload.bootstrapToken === "string", "bootstrapToken missing");
+  return payload.bootstrapToken;
+}
+
+async function readResponseJson(response, label) {
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${label} ${response.status}: non-JSON response`);
+  }
+}
+
+async function connect(values) {
+  const mode = requiredOption(values, "mode");
+  assert(mode === "bootstrap" || mode === "device", `unsupported connect mode: ${mode}`);
+  const baseUrl = requiredOption(values, "base-url").replace(/\/+$/u, "");
+  const stateFile = requiredOption(values, "state");
+  const outputFile = requiredOption(values, "out");
+  const label = requiredOption(values, "label");
+  const state = loadIdentity(stateFile);
+  const credential =
+    mode === "bootstrap"
+      ? decodeBootstrapToken(requiredOption(values, "credential"))
+      : state.deviceToken;
+  assert(typeof credential === "string" && credential.length > 0, `${mode} credential missing`);
+
+  const challengeResponse = await fetch(`${baseUrl}/challenge`, {
+    headers: { accept: "application/json" },
+  });
+  const challenge = await readResponseJson(challengeResponse, "challenge");
+  assert.equal(challengeResponse.status, 200, `challenge failed: ${JSON.stringify(challenge)}`);
+  assert.equal(challenge.ok, true, "challenge response was not ok");
+  assert(
+    typeof challenge.nonce === "string" && challenge.nonce.length > 0,
+    "challenge nonce missing",
+  );
+  const signedAt = Number.isSafeInteger(challenge.ts) ? challenge.ts : Date.now();
+  const privateKey = crypto.createPrivateKey(state.privateKeyPem);
+  const signature = crypto
+    .sign(
+      null,
+      Buffer.from(
+        buildSignaturePayload({
+          deviceId: state.deviceId,
+          signedAt,
+          token: credential,
+          nonce: challenge.nonce,
+        }),
+        "utf8",
+      ),
+      privateKey,
+    )
+    .toString("base64url");
+  const auth = mode === "bootstrap" ? { bootstrapToken: credential } : { deviceToken: credential };
+  const body = {
+    minProtocol: WATCH_PROTOCOL,
+    maxProtocol: WATCH_PROTOCOL,
+    client: WATCH_CLIENT,
+    caps: [],
+    commands: WATCH_COMMANDS,
+    permissions: { notifications: true },
+    role: "node",
+    scopes: [],
+    auth,
+    device: {
+      id: state.deviceId,
+      publicKey: state.publicKey,
+      signature,
+      signedAt,
+      nonce: challenge.nonce,
+    },
+    locale: "en-US",
+    userAgent: WATCH_CLIENT.platform,
+  };
+  const connectResponse = await fetch(`${baseUrl}/connect`, {
+    method: "POST",
+    headers: { accept: "application/json", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const response = await readResponseJson(connectResponse, "connect");
+  assert.equal(connectResponse.status, 200, `connect failed: ${JSON.stringify(response)}`);
+  assert.equal(response.ok, true, "connect response was not ok");
+  for (const field of ["sessionToken", "deviceToken", "nodeId"]) {
+    assert(
+      typeof response[field] === "string" && response[field].length > 0,
+      `connect omitted ${field}`,
+    );
+  }
+  assert.equal(response.nodeId, state.deviceId, "connect returned another node identity");
+  assert.equal(response.protocol, WATCH_PROTOCOL, "connect negotiated another protocol");
+  state.deviceToken = response.deviceToken;
+  writeJson(stateFile, state);
+  const artifact = {
+    label,
+    ok: true,
+    mode,
+    authField: mode === "bootstrap" ? "bootstrapToken" : "deviceToken",
+    challengeStatus: challengeResponse.status,
+    connectStatus: connectResponse.status,
+    challengeTimestampSource: Number.isSafeInteger(challenge.ts) ? "gateway" : "local-clock",
+    protocol: response.protocol,
+    protocolRange: [WATCH_PROTOCOL, WATCH_PROTOCOL],
+    clientId: WATCH_CLIENT.id,
+    clientMode: WATCH_CLIENT.mode,
+    nodeId: state.deviceId,
+    instanceId: state.instanceId,
+    deviceTokenSha256: sha256(response.deviceToken),
+    sessionTokenSha256: sha256(response.sessionToken),
+  };
+  writeJson(outputFile, artifact);
+  process.stdout.write(`${JSON.stringify(artifact)}\n`);
+}
+
+function assertGatewayState(values) {
+  const state = readJson(requiredOption(values, "state"));
+  const nodesResult = readJson(requiredOption(values, "nodes"));
+  const devicesResult = readJson(requiredOption(values, "devices"));
+  const outputFile = requiredOption(values, "out");
+  const label = requiredOption(values, "label");
+  const nodes = Array.isArray(nodesResult) ? nodesResult : nodesResult.nodes;
+  const pending = Array.isArray(devicesResult.pending) ? devicesResult.pending : [];
+  const paired = Array.isArray(devicesResult.paired) ? devicesResult.paired : [];
+  assert(Array.isArray(nodes), "node.list result omitted nodes");
+  const node = nodes.find(
+    (entry) => entry?.id === state.deviceId || entry?.nodeId === state.deviceId,
+  );
+  const pendingForWatch = pending.filter((entry) => entry?.deviceId === state.deviceId);
+  const pairedForWatch = paired.filter((entry) => entry?.deviceId === state.deviceId);
+  assert(node, `${label}: watch missing from node.list`);
+  assert.equal(node.clientId ?? node.client?.id, WATCH_CLIENT.id, `${label}: wrong client id`);
+  assert.equal(
+    node.clientMode ?? node.client?.mode,
+    WATCH_CLIENT.mode,
+    `${label}: wrong client mode`,
+  );
+  assert.equal(pending.length, 0, `${label}: pending pairing table is not empty`);
+  assert.equal(pendingForWatch.length, 0, `${label}: watch pairing remains pending`);
+  assert.equal(pairedForWatch.length, 1, `${label}: expected one paired watch`);
+  const artifact = {
+    label,
+    ok: true,
+    onlineNode: true,
+    pendingTotal: pending.length,
+    pendingForWatch: pendingForWatch.length,
+    pairedForWatch: pairedForWatch.length,
+    clientId: WATCH_CLIENT.id,
+    clientMode: WATCH_CLIENT.mode,
+    nodeId: state.deviceId,
+    instanceId: state.instanceId,
+  };
+  writeJson(outputFile, artifact);
+  process.stdout.write(`${JSON.stringify(artifact)}\n`);
+}
+
+async function main() {
+  const command = process.argv[2];
+  const { values } = parseArgs({
+    args: process.argv.slice(3),
+    options: {
+      "base-url": { type: "string" },
+      credential: { type: "string" },
+      devices: { type: "string" },
+      label: { type: "string" },
+      mode: { type: "string" },
+      nodes: { type: "string" },
+      out: { type: "string" },
+      state: { type: "string" },
+    },
+    strict: true,
+  });
+  if (command === "connect") {
+    await connect(values);
+    return;
+  }
+  if (command === "assert-state") {
+    assertGatewayState(values);
+    return;
+  }
+  throw new Error(`unknown watchOS direct-node command: ${command ?? "<missing>"}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : String(error));
+  console.error("[watchos-direct-node] FAILED (exit 1)");
+  process.exitCode = 1;
+});

--- a/scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs
@@ -61,7 +61,7 @@ function createIdentity() {
   return {
     deviceId: sha256(rawPublicKey),
     publicKey: rawPublicKey.toString("base64url"),
-    privateKeyPem: privateKey.export({ format: "pem", type: "pkcs8" }).toString(),
+    privateKeyPem: privateKey.export({ format: "pem", type: "pkcs8" }),
     instanceId: WATCH_CLIENT.instanceId,
   };
 }
@@ -264,7 +264,7 @@ async function main() {
   throw new Error(`unknown watchOS direct-node command: ${command ?? "<missing>"}`);
 }
 
-main().catch((error) => {
+main().catch((/** @type {unknown} */ error) => {
   console.error(error instanceof Error ? error.stack : String(error));
   console.error("[watchos-direct-node] FAILED (exit 1)");
   process.exitCode = 1;

--- a/scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs
@@ -75,7 +75,7 @@ function loadIdentity(stateFile) {
   return state;
 }
 
-function decodeBootstrapToken(setupFile) {
+function decodeBootstrapSetup(setupFile) {
   const result = readJson(setupFile);
   assert(typeof result.setupCode === "string", "setupCode missing");
   const encoded = result.setupCode.toLowerCase().startsWith("oc-pair://")
@@ -83,7 +83,55 @@ function decodeBootstrapToken(setupFile) {
     : result.setupCode;
   const payload = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
   assert(typeof payload.bootstrapToken === "string", "bootstrapToken missing");
-  return payload.bootstrapToken;
+  assert(payload.token === undefined, "setup payload included a gateway token");
+  assert(payload.password === undefined, "setup payload included a gateway password");
+  if (payload.expiresAtMs !== undefined) {
+    assert(
+      Number.isSafeInteger(payload.expiresAtMs) && payload.expiresAtMs > Date.now(),
+      "setup payload expired",
+    );
+  }
+  const candidates = [payload.url, ...(Array.isArray(payload.urls) ? payload.urls : [])];
+  let secureUrl;
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    try {
+      const parsed = new URL(candidate);
+      if (parsed.protocol === "wss:" || parsed.protocol === "https:") {
+        secureUrl = parsed;
+        break;
+      }
+    } catch {
+      // Match the app parser: an invalid candidate does not hide a later secure fallback.
+    }
+  }
+  assert(secureUrl, "setup payload omitted a trusted TLS endpoint");
+  assert(!secureUrl.username && !secureUrl.password, "setup endpoint included userinfo");
+  assert(!secureUrl.search && !secureUrl.hash, "setup endpoint included query or fragment");
+  return {
+    credential: payload.bootstrapToken,
+    endpoint: {
+      host: secureUrl.hostname,
+      port: Number(secureUrl.port || "443"),
+      tls: true,
+    },
+  };
+}
+
+function watchApiBaseUrlFromEndpoint(endpoint) {
+  assert(endpoint && typeof endpoint === "object", "persisted endpoint missing");
+  assert.equal(endpoint.tls, true, "persisted endpoint is not TLS");
+  assert(typeof endpoint.host === "string" && endpoint.host.length > 0, "endpoint host missing");
+  assert(
+    Number.isSafeInteger(endpoint.port) && endpoint.port >= 1 && endpoint.port <= 65535,
+    "endpoint port invalid",
+  );
+  const url = new URL("https://localhost");
+  url.hostname = endpoint.host;
+  url.port = String(endpoint.port);
+  return `${url.origin}/api/nodes/watch`;
 }
 
 async function readResponseJson(response, label) {
@@ -98,15 +146,19 @@ async function readResponseJson(response, label) {
 async function connect(values) {
   const mode = requiredOption(values, "mode");
   assert(mode === "bootstrap" || mode === "device", `unsupported connect mode: ${mode}`);
-  const baseUrl = requiredOption(values, "base-url").replace(/\/+$/u, "");
   const stateFile = requiredOption(values, "state");
   const outputFile = requiredOption(values, "out");
   const label = requiredOption(values, "label");
   const state = loadIdentity(stateFile);
-  const credential =
-    mode === "bootstrap"
-      ? decodeBootstrapToken(requiredOption(values, "credential"))
-      : state.deviceToken;
+  const setup =
+    mode === "bootstrap" ? decodeBootstrapSetup(requiredOption(values, "credential")) : undefined;
+  if (setup) {
+    state.endpoint = setup.endpoint;
+    writeJson(stateFile, state);
+  }
+  const endpointSource = setup ? "setupCode" : "persistedState";
+  const baseUrl = watchApiBaseUrlFromEndpoint(state.endpoint);
+  const credential = setup ? setup.credential : state.deviceToken;
   assert(typeof credential === "string" && credential.length > 0, `${mode} credential missing`);
 
   const challengeResponse = await fetch(`${baseUrl}/challenge`, {
@@ -175,6 +227,16 @@ async function connect(values) {
   assert.equal(response.protocol, WATCH_PROTOCOL, "connect negotiated another protocol");
   state.deviceToken = response.deviceToken;
   writeJson(stateFile, state);
+  const pollResponse = await fetch(`${baseUrl}/poll`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${response.sessionToken}`,
+    },
+  });
+  const poll = await readResponseJson(pollResponse, "poll");
+  assert.equal(pollResponse.status, 200, `poll failed: ${JSON.stringify(poll)}`);
+  assert.equal(poll.ok, true, "poll response was not ok");
   const artifact = {
     label,
     ok: true,
@@ -182,6 +244,10 @@ async function connect(values) {
     authField: mode === "bootstrap" ? "bootstrapToken" : "deviceToken",
     challengeStatus: challengeResponse.status,
     connectStatus: connectResponse.status,
+    pollStatus: pollResponse.status,
+    pollAuthenticated: true,
+    transport: "https",
+    endpointSource,
     challengeTimestampSource: Number.isSafeInteger(challenge.ts) ? "gateway" : "local-clock",
     protocol: response.protocol,
     protocolRange: [WATCH_PROTOCOL, WATCH_PROTOCOL],
@@ -242,7 +308,6 @@ async function main() {
   const { values } = parseArgs({
     args: process.argv.slice(3),
     options: {
-      "base-url": { type: "string" },
       credential: { type: "string" },
       devices: { type: "string" },
       label: { type: "string" },

--- a/scripts/lib/docker-e2e-plan.mts
+++ b/scripts/lib/docker-e2e-plan.mts
@@ -117,6 +117,10 @@ const UPGRADE_SURVIVOR_RUNTIME_COMPANION_PACKAGES = ["@openclaw/codex"];
 // closed instead of requiring a dependency or reimplementing a JavaScript parser.
 const LEGACY_UPGRADE_SURVIVOR_SCENARIO_CATALOGS = new Map([
   [
+    "dd12482a81dc5cc82dbb23f1cf3128321ec97a2176673c34adecbeed18d00484",
+    "base acpx-openclaw-tools-bridge feishu-channel bootstrap-persona channel-post-core-restore codex-allowlist-survival plugin-deps-cleanup configured-plugin-installs stale-source-plugin-shadow prerelease-plugin-registry tilde-log-path meeting-transcripts-sqlite versioned-runtime-deps cron-scheduled-authority sqlite-volume recovery-cleanup auth-profile-v2026-7-2-beta-5 watchos-direct-node",
+  ],
+  [
     "bb984a8abf8e4f5a5caaa0c6e10fc36efb6a05ca9f44fb960e4a6583cd52695d",
     "base acpx-openclaw-tools-bridge feishu-channel bootstrap-persona channel-post-core-restore codex-allowlist-survival plugin-deps-cleanup configured-plugin-installs stale-source-plugin-shadow prerelease-plugin-registry tilde-log-path meeting-transcripts-sqlite versioned-runtime-deps cron-scheduled-authority sqlite-volume recovery-cleanup auth-profile-v2026-7-2-beta-5",
   ],

--- a/scripts/lib/upgrade-survivor-policy.mjs
+++ b/scripts/lib/upgrade-survivor-policy.mjs
@@ -15,6 +15,7 @@ const UPGRADE_SURVIVOR_SCENARIOS = Object.freeze([
   "sqlite-volume",
   "recovery-cleanup",
   "auth-profile-v2026-7-2-beta-5",
+  "watchos-direct-node",
 ]);
 
 // Registry proof needs its artifact contract; versioned auth fixtures exercise
@@ -26,7 +27,12 @@ const aggregateScenarios = UPGRADE_SURVIVOR_SCENARIOS.filter(
     scenario !== "recovery-cleanup",
 );
 const scenarioAliases = new Map([
-  ["reported-issues", aggregateScenarios.filter((scenario) => scenario !== "sqlite-volume")],
+  [
+    "reported-issues",
+    aggregateScenarios.filter(
+      (scenario) => scenario !== "sqlite-volume" && scenario !== "watchos-direct-node",
+    ),
+  ],
   ["far-reaching", aggregateScenarios],
 ]);
 
@@ -134,11 +140,23 @@ function supportsUpgradeSurvivorAcpToolsBridge(baselineSpec) {
   return comparePublishedReleaseVersion(version, { year: 2026, month: 4, patch: 22 }) >= 0;
 }
 
+function supportsUpgradeSurvivorWatchDirectNode(baselineSpec) {
+  if (!baselineSpec) {
+    return true;
+  }
+  const version = parsePublishedReleaseVersion(baselineSpec);
+  if (!version) {
+    return true;
+  }
+  return comparePublishedReleaseVersion(version, { year: 2026, month: 8, patch: 1 }) >= 0;
+}
+
 export function supportsUpgradeSurvivorScenarioAtBaseline(scenario, baselineSpec) {
   return (
     (scenario !== "plugin-deps-cleanup" ||
       supportsUpgradeSurvivorPluginDependencyCleanup(baselineSpec)) &&
     (scenario !== "acpx-openclaw-tools-bridge" ||
-      supportsUpgradeSurvivorAcpToolsBridge(baselineSpec))
+      supportsUpgradeSurvivorAcpToolsBridge(baselineSpec)) &&
+    (scenario !== "watchos-direct-node" || supportsUpgradeSurvivorWatchDirectNode(baselineSpec))
   );
 }

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -2286,6 +2286,7 @@ const EXACT_TOOLING_TARGETS = new Map<string, string[]>([
   ["scripts/package-manifest.mjs", ["test/openclaw-prepack.test.ts"]],
   ["scripts/openclaw-npm-prepublish-verify.ts", ["test/openclaw-npm-prepublish-verify.test.ts"]],
   ["scripts/lib/docker-e2e-scenarios.mts", [dockerE2e, pluginPrerelease]],
+  ["scripts/lib/upgrade-survivor-policy.mjs", [dockerE2e]],
   ["scripts/e2e/kitchen-sink-rpc-walk.mts", ["kitchen-sink-rpc-walk", pluginPrerelease]],
   [
     "scripts/e2e/agents-delete-shared-workspace-docker.sh",
@@ -2324,7 +2325,15 @@ const EXACT_TOOLING_TARGETS = new Map<string, string[]>([
   ],
   [
     "scripts/e2e/lib/upgrade-survivor/run.sh",
-    ["upgrade-survivor-assertions", "upgrade-survivor-recovery-cleanup"],
+    [
+      "upgrade-survivor-assertions",
+      "upgrade-survivor-recovery-cleanup",
+      "upgrade-survivor-watchos-direct-node",
+    ],
+  ],
+  [
+    "scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs",
+    ["upgrade-survivor-watchos-direct-node"],
   ],
   [
     "scripts/e2e/lib/upgrade-survivor/recovery-cleanup-fixture.mjs",

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2739,6 +2739,24 @@ docker_e2e_docker_run_cmd run demo
     expect(publishedRunner.indexOf("phase update-candidate update_candidate")).toBeLessThan(
       publishedRunner.indexOf("phase assert-prepublish-requests assert_prepublish_plugin_install"),
     );
+    expect(publishedRunner).toContain(
+      [
+        'if [ "$SCENARIO" = "watchos-direct-node" ]; then',
+        "    phase assert-prepublish-idle assert_prepublish_fixture_idle",
+        "  else",
+        "    phase assert-prepublish-requests assert_prepublish_plugin_install 1",
+        "  fi",
+      ].join("\n"),
+    );
+    expect(publishedRunner).toContain(
+      [
+        'if [ "$SCENARIO" = "watchos-direct-node" ]; then',
+        "      phase assert-prepublish-recovery-idle assert_prepublish_fixture_idle",
+        "    else",
+        "      phase assert-prepublish-recovery-requests assert_prepublish_plugin_install",
+        "    fi",
+      ].join("\n"),
+    );
     expect(publishedRunner).not.toContain('if [ "$candidate_version" = "2026.6.35" ]; then');
     expect(publishedRunner).toContain(
       'local tarball="$fixture_root/openclaw-brave-plugin-${candidate_version}.tgz"',

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2790,6 +2790,17 @@ docker_e2e_docker_run_cmd run demo
         "fi",
       ].join("\n"),
     );
+    expect(publishedRunner).toContain(
+      [
+        'if [ "$SCENARIO" = "watchos-direct-node" ]; then',
+        "  unset OPENAI_API_KEY DISCORD_BOT_TOKEN TELEGRAM_BOT_TOKEN",
+        "else",
+        '  export OPENAI_API_KEY="sk-openclaw-upgrade-survivor"',
+        '  export DISCORD_BOT_TOKEN="upgrade-survivor-discord-token"',
+        '  export TELEGRAM_BOT_TOKEN="123456:upgrade-survivor-telegram-token"',
+        "fi",
+      ].join("\n"),
+    );
     expect(runner).toContain(
       [
         'if [ "$SCENARIO" = "configured-plugin-installs" ] || [ "$SCENARIO" = "sqlite-volume" ]; then',

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -1075,7 +1075,7 @@ describe("scripts/lib/docker-e2e-plan", () => {
     ]);
   });
 
-  it("keeps SQLite volume stress out of release soak and in far-reaching runs", () => {
+  it("keeps expensive platform survivors out of release soak and in far-reaching runs", () => {
     const scenariosFor = (upgradeSurvivorScenarios: string) =>
       planFor({
         selectedLaneNames: ["published-upgrade-survivor"],
@@ -1089,6 +1089,28 @@ describe("scripts/lib/docker-e2e-plan", () => {
     expect(scenariosFor("far-reaching")).toContain(
       "published-upgrade-survivor-2026.7.1-2-sqlite-volume",
     );
+    expect(scenariosFor("reported-issues")).not.toContain(
+      "published-upgrade-survivor-2026.8.1-watchos-direct-node",
+    );
+    expect(
+      planFor({
+        selectedLaneNames: ["published-upgrade-survivor"],
+        upgradeSurvivorBaselines: "2026.8.1",
+        upgradeSurvivorScenarios: "far-reaching",
+      }).lanes.map((lane) => lane.name),
+    ).toContain("published-upgrade-survivor-2026.8.1-watchos-direct-node");
+  });
+
+  it("runs the watchOS direct-node survivor only from its shipped gateway floor", () => {
+    const plan = planFor({
+      selectedLaneNames: ["published-upgrade-survivor"],
+      upgradeSurvivorBaselines: "2026.7.1 2026.8.1",
+      upgradeSurvivorScenarios: "watchos-direct-node",
+    });
+
+    expect(plan.lanes.map((lane) => lane.name)).toEqual([
+      "published-upgrade-survivor-2026.8.1-watchos-direct-node",
+    ]);
   });
 
   it("omits trusted-current scenarios unsupported by a frozen target harness", () => {

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -1076,10 +1076,13 @@ describe("scripts/lib/docker-e2e-plan", () => {
   });
 
   it("keeps expensive platform survivors out of release soak and in far-reaching runs", () => {
-    const scenariosFor = (upgradeSurvivorScenarios: string) =>
+    const scenariosFor = (
+      upgradeSurvivorScenarios: string,
+      upgradeSurvivorBaselines = "2026.7.1-2",
+    ) =>
       planFor({
         selectedLaneNames: ["published-upgrade-survivor"],
-        upgradeSurvivorBaselines: "2026.7.1-2",
+        upgradeSurvivorBaselines,
         upgradeSurvivorScenarios,
       }).lanes.map((lane) => lane.name);
 
@@ -1089,16 +1092,12 @@ describe("scripts/lib/docker-e2e-plan", () => {
     expect(scenariosFor("far-reaching")).toContain(
       "published-upgrade-survivor-2026.7.1-2-sqlite-volume",
     );
-    expect(scenariosFor("reported-issues")).not.toContain(
+    expect(scenariosFor("reported-issues", "2026.8.1")).not.toContain(
       "published-upgrade-survivor-2026.8.1-watchos-direct-node",
     );
-    expect(
-      planFor({
-        selectedLaneNames: ["published-upgrade-survivor"],
-        upgradeSurvivorBaselines: "2026.8.1",
-        upgradeSurvivorScenarios: "far-reaching",
-      }).lanes.map((lane) => lane.name),
-    ).toContain("published-upgrade-survivor-2026.8.1-watchos-direct-node");
+    expect(scenariosFor("far-reaching", "2026.8.1")).toContain(
+      "published-upgrade-survivor-2026.8.1-watchos-direct-node",
+    );
   });
 
   it("runs the watchOS direct-node survivor only from its shipped gateway floor", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -237,7 +237,6 @@ type Workflow = {
   env?: Record<string, string>;
   jobs?: Record<string, WorkflowJob>;
   on?: {
-    schedule?: Array<{ cron?: string }>;
     workflow_call?: {
       inputs?: Record<string, unknown>;
     };
@@ -5279,10 +5278,9 @@ test "$package_manager" = "pnpm@12.1.0"
     }
   });
 
-  it("defaults update migration to stable with optional historical replays", () => {
+  it("keeps update migration manual with optional historical replays", () => {
     const workflow = readFileSync(UPDATE_MIGRATION_WORKFLOW, "utf8");
     const packageWorkflow = readFileSync(PACKAGE_ACCEPTANCE_WORKFLOW, "utf8");
-    const migration = readWorkflow(UPDATE_MIGRATION_WORKFLOW);
     const job = workflowJob(UPDATE_MIGRATION_WORKFLOW, "update_migration");
 
     expect(workflow).toContain("name: Update Migration");
@@ -5297,14 +5295,12 @@ test "$package_manager" = "pnpm@12.1.0"
       required: false,
     });
     expect(workflow).toContain("default: plugin-deps-cleanup");
-    expect(migration.on?.schedule).toEqual([{ cron: "41 6 * * 1" }]);
+    expect(workflow).not.toMatch(/\n {2}schedule:/u);
     expect(job.with).toMatchObject({
-      workflow_ref: "${{ inputs.workflow_ref || 'main' }}",
-      package_ref: "${{ inputs.package_ref || 'main' }}",
-      published_upgrade_survivor_baselines:
-        "${{ github.event_name == 'schedule' && '2026.8.1' || inputs.baselines }}",
-      published_upgrade_survivor_scenarios:
-        "${{ github.event_name == 'schedule' && 'watchos-direct-node' || inputs.scenarios }}",
+      workflow_ref: "${{ inputs.workflow_ref }}",
+      package_ref: "${{ inputs.package_ref }}",
+      published_upgrade_survivor_baselines: "${{ inputs.baselines }}",
+      published_upgrade_survivor_scenarios: "${{ inputs.scenarios }}",
     });
     expect(workflow).toContain("telegram_mode: none");
     expect(workflow).toContain("secrets: inherit");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -237,6 +237,7 @@ type Workflow = {
   env?: Record<string, string>;
   jobs?: Record<string, WorkflowJob>;
   on?: {
+    schedule?: Array<{ cron?: string }>;
     workflow_call?: {
       inputs?: Record<string, unknown>;
     };
@@ -5281,6 +5282,8 @@ test "$package_manager" = "pnpm@12.1.0"
   it("defaults update migration to stable with optional historical replays", () => {
     const workflow = readFileSync(UPDATE_MIGRATION_WORKFLOW, "utf8");
     const packageWorkflow = readFileSync(PACKAGE_ACCEPTANCE_WORKFLOW, "utf8");
+    const migration = readWorkflow(UPDATE_MIGRATION_WORKFLOW);
+    const job = workflowJob(UPDATE_MIGRATION_WORKFLOW, "update_migration");
 
     expect(workflow).toContain("name: Update Migration");
     expect(workflow).toContain("uses: ./.github/workflows/package-acceptance.yml");
@@ -5294,6 +5297,15 @@ test "$package_manager" = "pnpm@12.1.0"
       required: false,
     });
     expect(workflow).toContain("default: plugin-deps-cleanup");
+    expect(migration.on?.schedule).toEqual([{ cron: "41 6 * * 1" }]);
+    expect(job.with).toMatchObject({
+      workflow_ref: "${{ inputs.workflow_ref || 'main' }}",
+      package_ref: "${{ inputs.package_ref || 'main' }}",
+      published_upgrade_survivor_baselines:
+        "${{ github.event_name == 'schedule' && '2026.8.1' || inputs.baselines }}",
+      published_upgrade_survivor_scenarios:
+        "${{ github.event_name == 'schedule' && 'watchos-direct-node' || inputs.scenarios }}",
+    });
     expect(workflow).toContain("telegram_mode: none");
     expect(workflow).toContain("secrets: inherit");
     expect(packageWorkflow).toContain("published-upgrade-survivor/update-migration");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -5614,6 +5614,12 @@ describe("package artifact reuse", () => {
     expect(publishedUpgradeSurvivor).toContain("plugin_deps_cleanup_plugin_dirs");
     expect(publishedUpgradeSurvivor).toContain('"$(package_root)/extensions/$plugin"');
     expect(publishedUpgradeSurvivor).toContain("probe_gateway_endpoint");
+    expect(publishedUpgradeSurvivor).toContain("configure_watchos_tls_fixture");
+    expect(publishedUpgradeSurvivor).toContain('"publicUrl":"wss://localhost:18789"');
+    expect(publishedUpgradeSurvivor).toContain('export NODE_EXTRA_CA_CERTS="$WATCH_TLS_CA_CERT"');
+    expect(publishedUpgradeSurvivor).not.toContain(
+      "--base-url http://127.0.0.1:18789/api/nodes/watch",
+    );
     expect(publishedUpgradeSurvivor).toContain(
       "assert_legacy_plugin_dependency_debris_before_doctor",
     );

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -635,7 +635,17 @@ describe("scripts/test-projects changed-target routing", () => {
         throw new Error(`Missing recovery test owner: ${file}`);
       }
       expect(plan.targets).toContain("test/scripts/upgrade-survivor-recovery-cleanup.test.ts");
+      if (file.endsWith("/run.sh")) {
+        expect(plan.targets).toContain("test/scripts/upgrade-survivor-watchos-direct-node.test.ts");
+      }
     }
+  });
+
+  it("routes the watchOS survivor adapter to its contract test", () => {
+    expectChangedTargets(
+      ["scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs"],
+      ["test/scripts/upgrade-survivor-watchos-direct-node.test.ts"],
+    );
   });
 
   it("keeps force-test runner edits on its safe CLI tests", () => {

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -4,6 +4,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   cpSync,
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -1237,6 +1238,51 @@ process.stdout.write(sessionDir + "\\n");
       }
     },
   );
+
+  it("keeps the watch direct-node seed free of unrelated migration specimens", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-watch-seed-"));
+    try {
+      const stateDir = join(root, "state");
+      const workspace = join(root, "workspace");
+      mkdirSync(stateDir, { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+      const env = {
+        ...process.env,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_TEST_WORKSPACE_DIR: workspace,
+        OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "watchos-direct-node",
+      };
+
+      execFileSync(process.execPath, [ASSERTIONS_PATH, "seed"], { env, stdio: "pipe" });
+
+      expect(existsSync(join(workspace, "IDENTITY.md"))).toBe(true);
+      expect(existsSync(join(workspace, ".openclaw", "workspace-state.json"))).toBe(true);
+      for (const relative of [
+        "sessions/sessions.json",
+        "agents/main/sessions/legacy-session.json",
+        "exec-approvals.json",
+        "plugin-runtime-deps",
+      ]) {
+        expect(existsSync(join(stateDir, relative)), relative).toBe(false);
+      }
+      for (const stage of ["baseline", "survival"]) {
+        const stageEnv = {
+          ...env,
+          OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE: stage,
+        };
+        execFileSync(process.execPath, [ASSERTIONS_PATH, "assert-state"], {
+          env: stageEnv,
+          stdio: "pipe",
+        });
+        execFileSync(process.execPath, [ASSERTIONS_PATH, "assert-exec-approvals"], {
+          env: stageEnv,
+          stdio: "pipe",
+        });
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
 
   it("requires every seeded legacy cron specimen before update", () => {
     const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-cron-"));

--- a/test/scripts/upgrade-survivor-config-recipe.test.ts
+++ b/test/scripts/upgrade-survivor-config-recipe.test.ts
@@ -203,12 +203,7 @@ esac
     const steps = resolveUpgradeSurvivorConfigSteps("watchos-direct-node");
     const intents = steps.map((step) => step.intent);
 
-    expect(intents).toContain("gateway");
-    expect(intents).toContain("agents");
-    expect(intents).not.toContain("plugins");
-    expect(intents).not.toContain("discord-channel");
-    expect(intents).not.toContain("telegram-channel");
-    expect(intents).not.toContain("whatsapp-channel");
+    expect(intents).toEqual(["update", "gateway", "validate"]);
     expect(steps.at(-1)?.id).toBe("validate");
   });
 

--- a/test/scripts/upgrade-survivor-config-recipe.test.ts
+++ b/test/scripts/upgrade-survivor-config-recipe.test.ts
@@ -199,6 +199,19 @@ esac
     expect(steps.at(-1)?.id).toBe("validate");
   });
 
+  it("keeps the watch direct-node recipe isolated from unrelated plugin fixtures", () => {
+    const steps = resolveUpgradeSurvivorConfigSteps("watchos-direct-node");
+    const intents = steps.map((step) => step.intent);
+
+    expect(intents).toContain("gateway");
+    expect(intents).toContain("agents");
+    expect(intents).not.toContain("plugins");
+    expect(intents).not.toContain("discord-channel");
+    expect(intents).not.toContain("telegram-channel");
+    expect(intents).not.toContain("whatsapp-channel");
+    expect(steps.at(-1)?.id).toBe("validate");
+  });
+
   it("composes configured plugin installs into the SQLite volume scenario", () => {
     expect(resolveScenarioConfigSteps("sqlite-volume")).toEqual(
       resolveScenarioConfigSteps("configured-plugin-installs"),
@@ -421,6 +434,7 @@ process.exit(0);
           .split("\n")
           .map((line) => JSON.parse(line));
         expect(summary.skippedIntents).toContain("acpx-openclaw-tools-bridge");
+        expect(summary.acceptedIntents).not.toContain("acpx-openclaw-tools-bridge");
         expect(summary.baselineVersion).toBe("2026.4.21");
         expect(loggedArgs.at(-1)).toEqual(["config", "validate"]);
         expect(loggedArgs).not.toContainEqual(

--- a/test/scripts/upgrade-survivor-watchos-direct-node.test.ts
+++ b/test/scripts/upgrade-survivor-watchos-direct-node.test.ts
@@ -74,7 +74,9 @@ describe.skipIf(process.platform === "win32")(
         response.statusCode = 404;
         response.end();
       });
-      await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+      await new Promise<void>((resolveListen) => {
+        server.listen(0, "127.0.0.1", resolveListen);
+      });
       const address = server.address();
       if (!address || typeof address === "string") {
         throw new Error("failed to bind watch fixture");
@@ -121,11 +123,16 @@ describe.skipIf(process.platform === "win32")(
           "candidate",
         ]);
       } finally {
-        await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+        await new Promise<void>((resolveClose) => {
+          server.close(() => resolveClose());
+        });
       }
 
       expect(requests).toHaveLength(2);
       const [bootstrap, reconnect] = requests;
+      if (!bootstrap || !reconnect) {
+        throw new Error("watch fixture omitted bootstrap or reconnect request");
+      }
       expect(bootstrap).toMatchObject({
         minProtocol: 4,
         maxProtocol: 4,
@@ -305,7 +312,9 @@ describe.skipIf(process.platform === "win32")(
         response.statusCode = 404;
         response.end();
       });
-      await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+      await new Promise<void>((resolveListen) => {
+        server.listen(0, "127.0.0.1", resolveListen);
+      });
       const address = server.address();
       if (!address || typeof address === "string") {
         throw new Error("failed to bind watch fixture");
@@ -345,7 +354,9 @@ describe.skipIf(process.platform === "win32")(
           "restart",
         ]);
       } finally {
-        await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+        await new Promise<void>((resolveClose) => {
+          server.close(() => resolveClose());
+        });
       }
 
       expect(authenticatedTokens).toEqual([retainedToken, rotatedToken]);

--- a/test/scripts/upgrade-survivor-watchos-direct-node.test.ts
+++ b/test/scripts/upgrade-survivor-watchos-direct-node.test.ts
@@ -1,7 +1,7 @@
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import crypto from "node:crypto";
-import { readFileSync, writeFileSync } from "node:fs";
-import { createServer } from "node:http";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:https";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +10,99 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const adapter = resolve("scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs");
+
+function createTlsFixture(root: string) {
+  const tlsRoot = join(root, "tls");
+  const caKey = join(tlsRoot, "ca-key.pem");
+  const caCert = join(tlsRoot, "ca-cert.pem");
+  const serverKey = join(tlsRoot, "server-key.pem");
+  const serverCsr = join(tlsRoot, "server.csr");
+  const serverCert = join(tlsRoot, "server-cert.pem");
+  const serverExt = join(tlsRoot, "server.ext");
+  mkdirSync(tlsRoot);
+  execFileSync(
+    "openssl",
+    [
+      "req",
+      "-x509",
+      "-newkey",
+      "rsa:2048",
+      "-nodes",
+      "-sha256",
+      "-days",
+      "1",
+      "-subj",
+      "/CN=OpenClaw watchOS survivor test CA",
+      "-addext",
+      "basicConstraints=critical,CA:TRUE",
+      "-addext",
+      "keyUsage=critical,keyCertSign,cRLSign",
+      "-keyout",
+      caKey,
+      "-out",
+      caCert,
+    ],
+    { stdio: "ignore" },
+  );
+  execFileSync(
+    "openssl",
+    [
+      "req",
+      "-newkey",
+      "rsa:2048",
+      "-nodes",
+      "-sha256",
+      "-subj",
+      "/CN=localhost",
+      "-keyout",
+      serverKey,
+      "-out",
+      serverCsr,
+    ],
+    { stdio: "ignore" },
+  );
+  writeFileSync(
+    serverExt,
+    [
+      "basicConstraints=critical,CA:FALSE",
+      "subjectAltName=DNS:localhost,IP:127.0.0.1",
+      "keyUsage=critical,digitalSignature,keyEncipherment",
+      "extendedKeyUsage=serverAuth",
+      "",
+    ].join("\n"),
+  );
+  execFileSync(
+    "openssl",
+    [
+      "x509",
+      "-req",
+      "-in",
+      serverCsr,
+      "-CA",
+      caCert,
+      "-CAkey",
+      caKey,
+      "-CAcreateserial",
+      "-days",
+      "1",
+      "-sha256",
+      "-extfile",
+      serverExt,
+      "-out",
+      serverCert,
+    ],
+    { stdio: "ignore" },
+  );
+  return {
+    caCert,
+    cert: readFileSync(serverCert),
+    key: readFileSync(serverKey),
+  };
+}
+
+function adapterEnv(caCert: string) {
+  return { ...process.env, NODE_EXTRA_CA_CERTS: caCert };
+}
 
 function signaturePayload(body: Record<string, any>, token: string): string {
   return [
@@ -36,11 +129,13 @@ describe.skipIf(process.platform === "win32")(
       const setup = join(root, "setup.json");
       const bootstrapArtifact = join(root, "bootstrap.json");
       const reconnectArtifact = join(root, "reconnect.json");
+      const tls = createTlsFixture(root);
       const bootstrapToken = "bootstrap-secret";
       const deviceToken = "retained-device-secret";
       const requests: Array<Record<string, any>> = [];
+      const pollTokens: string[] = [];
       let challengeCount = 0;
-      const server = createServer((request, response) => {
+      const server = createServer({ cert: tls.cert, key: tls.key }, (request, response) => {
         if (request.url?.endsWith("/challenge")) {
           challengeCount += 1;
           response.setHeader("content-type", "application/json");
@@ -71,6 +166,12 @@ describe.skipIf(process.platform === "win32")(
           });
           return;
         }
+        if (request.url?.endsWith("/poll")) {
+          pollTokens.push(request.headers.authorization ?? "");
+          response.setHeader("content-type", "application/json");
+          response.end(JSON.stringify({ ok: true, event: null }));
+          return;
+        }
         response.statusCode = 404;
         response.end();
       });
@@ -81,47 +182,54 @@ describe.skipIf(process.platform === "win32")(
       if (!address || typeof address === "string") {
         throw new Error("failed to bind watch fixture");
       }
-      const baseUrl = `http://127.0.0.1:${address.port}/api/nodes/watch`;
       writeFileSync(
         setup,
         JSON.stringify({
-          setupCode: `oc-pair://${Buffer.from(JSON.stringify({ bootstrapToken })).toString("base64url")}`,
+          setupCode: `oc-pair://${Buffer.from(
+            JSON.stringify({
+              url: `wss://localhost:${address.port}`,
+              bootstrapToken,
+              expiresAtMs: Date.now() + 60_000,
+            }),
+          ).toString("base64url")}`,
         }),
       );
 
       try {
-        await execFileAsync(process.execPath, [
-          adapter,
-          "connect",
-          "--mode",
-          "bootstrap",
-          "--base-url",
-          baseUrl,
-          "--credential",
-          setup,
-          "--state",
-          state,
-          "--out",
-          bootstrapArtifact,
-          "--label",
-          "baseline",
-        ]);
-        await execFileAsync(process.execPath, [
-          adapter,
-          "connect",
-          "--mode",
-          "device",
-          "--base-url",
-          baseUrl,
-          "--credential",
-          state,
-          "--state",
-          state,
-          "--out",
-          reconnectArtifact,
-          "--label",
-          "candidate",
-        ]);
+        await execFileAsync(
+          process.execPath,
+          [
+            adapter,
+            "connect",
+            "--mode",
+            "bootstrap",
+            "--credential",
+            setup,
+            "--state",
+            state,
+            "--out",
+            bootstrapArtifact,
+            "--label",
+            "baseline",
+          ],
+          { env: adapterEnv(tls.caCert) },
+        );
+        await execFileAsync(
+          process.execPath,
+          [
+            adapter,
+            "connect",
+            "--mode",
+            "device",
+            "--state",
+            state,
+            "--out",
+            reconnectArtifact,
+            "--label",
+            "candidate",
+          ],
+          { env: adapterEnv(tls.caCert) },
+        );
       } finally {
         await new Promise<void>((resolveClose) => {
           server.close(() => resolveClose());
@@ -129,6 +237,7 @@ describe.skipIf(process.platform === "win32")(
       }
 
       expect(requests).toHaveLength(2);
+      expect(pollTokens).toEqual(["Bearer session-1", "Bearer session-2"]);
       const [bootstrap, reconnect] = requests;
       if (!bootstrap || !reconnect) {
         throw new Error("watch fixture omitted bootstrap or reconnect request");
@@ -181,20 +290,30 @@ describe.skipIf(process.platform === "win32")(
         deviceId: bootstrap.device.id,
         instanceId: "watchos-upgrade-survivor",
         deviceToken,
+        endpoint: {
+          host: "localhost",
+          port: address.port,
+          tls: true,
+        },
       });
-      for (const artifactPath of [bootstrapArtifact, reconnectArtifact]) {
+      for (const [index, artifactPath] of [bootstrapArtifact, reconnectArtifact].entries()) {
         const raw = readFileSync(artifactPath, "utf8");
         expect(raw).not.toContain(bootstrapToken);
         expect(raw).not.toContain(deviceToken);
+        expect(raw).not.toContain(`session-${index + 1}`);
         expect(JSON.parse(raw)).toMatchObject({
           ok: true,
           challengeStatus: 200,
           connectStatus: 200,
+          pollStatus: 200,
+          pollAuthenticated: true,
+          transport: "https",
           protocol: 4,
           protocolRange: [4, 4],
           clientId: "openclaw-watchos",
           clientMode: "node",
           instanceId: "watchos-upgrade-survivor",
+          endpointSource: index === 0 ? "setupCode" : "persistedState",
         });
       }
     });
@@ -269,20 +388,12 @@ describe.skipIf(process.platform === "win32")(
       const retainedToken = "retained-device-secret";
       const rotatedToken = "rotated-device-secret";
       const authenticatedTokens: string[] = [];
+      const pollTokens: string[] = [];
+      const tls = createTlsFixture(root);
       const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
       const publicDer = publicKey.export({ format: "der", type: "spki" });
       const rawPublicKey = Buffer.from(publicDer).subarray(-32);
-      writeFileSync(
-        state,
-        JSON.stringify({
-          deviceId: crypto.createHash("sha256").update(rawPublicKey).digest("hex"),
-          publicKey: rawPublicKey.toString("base64url"),
-          privateKeyPem: privateKey.export({ format: "pem", type: "pkcs8" }).toString(),
-          instanceId: "watchos-upgrade-survivor",
-          deviceToken: retainedToken,
-        }),
-      );
-      const server = createServer((request, response) => {
+      const server = createServer({ cert: tls.cert, key: tls.key }, (request, response) => {
         response.setHeader("content-type", "application/json");
         if (request.url?.endsWith("/challenge")) {
           response.end(JSON.stringify({ ok: true, nonce: "rotation-nonce", ts: Date.now() }));
@@ -309,6 +420,11 @@ describe.skipIf(process.platform === "win32")(
           });
           return;
         }
+        if (request.url?.endsWith("/poll")) {
+          pollTokens.push(request.headers.authorization ?? "");
+          response.end(JSON.stringify({ ok: true, event: null }));
+          return;
+        }
         response.statusCode = 404;
         response.end();
       });
@@ -319,40 +435,51 @@ describe.skipIf(process.platform === "win32")(
       if (!address || typeof address === "string") {
         throw new Error("failed to bind watch fixture");
       }
+      writeFileSync(
+        state,
+        JSON.stringify({
+          deviceId: crypto.createHash("sha256").update(rawPublicKey).digest("hex"),
+          publicKey: rawPublicKey.toString("base64url"),
+          privateKeyPem: privateKey.export({ format: "pem", type: "pkcs8" }),
+          instanceId: "watchos-upgrade-survivor",
+          deviceToken: retainedToken,
+          endpoint: { host: "localhost", port: address.port, tls: true },
+        }),
+      );
 
       try {
-        await execFileAsync(process.execPath, [
-          adapter,
-          "connect",
-          "--mode",
-          "device",
-          "--base-url",
-          `http://127.0.0.1:${address.port}/api/nodes/watch`,
-          "--credential",
-          state,
-          "--state",
-          state,
-          "--out",
-          firstArtifact,
-          "--label",
-          "candidate",
-        ]);
-        await execFileAsync(process.execPath, [
-          adapter,
-          "connect",
-          "--mode",
-          "device",
-          "--base-url",
-          `http://127.0.0.1:${address.port}/api/nodes/watch`,
-          "--credential",
-          state,
-          "--state",
-          state,
-          "--out",
-          secondArtifact,
-          "--label",
-          "restart",
-        ]);
+        await execFileAsync(
+          process.execPath,
+          [
+            adapter,
+            "connect",
+            "--mode",
+            "device",
+            "--state",
+            state,
+            "--out",
+            firstArtifact,
+            "--label",
+            "candidate",
+          ],
+          { env: adapterEnv(tls.caCert) },
+        );
+        await execFileAsync(
+          process.execPath,
+          [
+            adapter,
+            "connect",
+            "--mode",
+            "device",
+            "--state",
+            state,
+            "--out",
+            secondArtifact,
+            "--label",
+            "restart",
+          ],
+          { env: adapterEnv(tls.caCert) },
+        );
       } finally {
         await new Promise<void>((resolveClose) => {
           server.close(() => resolveClose());
@@ -360,13 +487,21 @@ describe.skipIf(process.platform === "win32")(
       }
 
       expect(authenticatedTokens).toEqual([retainedToken, rotatedToken]);
+      expect(pollTokens).toEqual(["Bearer rotation-session-1", "Bearer rotation-session-2"]);
       expect(JSON.parse(readFileSync(state, "utf8"))).toMatchObject({
         deviceToken: rotatedToken,
       });
-      for (const artifactPath of [firstArtifact, secondArtifact]) {
+      for (const [index, artifactPath] of [firstArtifact, secondArtifact].entries()) {
         const raw = readFileSync(artifactPath, "utf8");
         expect(raw).not.toContain(retainedToken);
         expect(raw).not.toContain(rotatedToken);
+        expect(raw).not.toContain(`rotation-session-${index + 1}`);
+        expect(JSON.parse(raw)).toMatchObject({
+          pollStatus: 200,
+          pollAuthenticated: true,
+          transport: "https",
+          endpointSource: "persistedState",
+        });
       }
     });
   },

--- a/test/scripts/upgrade-survivor-watchos-direct-node.test.ts
+++ b/test/scripts/upgrade-survivor-watchos-direct-node.test.ts
@@ -1,0 +1,362 @@
+import { execFile } from "node:child_process";
+import crypto from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const execFileAsync = promisify(execFile);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const adapter = resolve("scripts/e2e/lib/upgrade-survivor/watchos-direct-node.mjs");
+
+function signaturePayload(body: Record<string, any>, token: string): string {
+  return [
+    "v3",
+    body.device.id,
+    body.client.id,
+    body.client.mode,
+    body.role,
+    body.scopes.join(","),
+    String(body.device.signedAt),
+    token,
+    body.device.nonce,
+    body.client.platform.toLowerCase(),
+    body.client.deviceFamily.toLowerCase(),
+  ].join("|");
+}
+
+describe.skipIf(process.platform === "win32")(
+  "watchOS direct-node upgrade survivor adapter",
+  () => {
+    it("bootstraps and reconnects with the exact shipped WatchDirectNode contract", async () => {
+      const root = tempDirs.make("watchos-direct-node-");
+      const state = join(root, "state.json");
+      const setup = join(root, "setup.json");
+      const bootstrapArtifact = join(root, "bootstrap.json");
+      const reconnectArtifact = join(root, "reconnect.json");
+      const bootstrapToken = "bootstrap-secret";
+      const deviceToken = "retained-device-secret";
+      const requests: Array<Record<string, any>> = [];
+      let challengeCount = 0;
+      const server = createServer((request, response) => {
+        if (request.url?.endsWith("/challenge")) {
+          challengeCount += 1;
+          response.setHeader("content-type", "application/json");
+          response.end(
+            JSON.stringify({ ok: true, nonce: `nonce-${challengeCount}`, ts: Date.now() }),
+          );
+          return;
+        }
+        if (request.url?.endsWith("/connect")) {
+          let raw = "";
+          request.setEncoding("utf8");
+          request.on("data", (chunk) => {
+            raw += chunk;
+          });
+          request.on("end", () => {
+            const body = JSON.parse(raw);
+            requests.push(body);
+            response.setHeader("content-type", "application/json");
+            response.end(
+              JSON.stringify({
+                ok: true,
+                sessionToken: `session-${requests.length}`,
+                deviceToken,
+                nodeId: body.device.id,
+                protocol: 4,
+              }),
+            );
+          });
+          return;
+        }
+        response.statusCode = 404;
+        response.end();
+      });
+      await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("failed to bind watch fixture");
+      }
+      const baseUrl = `http://127.0.0.1:${address.port}/api/nodes/watch`;
+      writeFileSync(
+        setup,
+        JSON.stringify({
+          setupCode: `oc-pair://${Buffer.from(JSON.stringify({ bootstrapToken })).toString("base64url")}`,
+        }),
+      );
+
+      try {
+        await execFileAsync(process.execPath, [
+          adapter,
+          "connect",
+          "--mode",
+          "bootstrap",
+          "--base-url",
+          baseUrl,
+          "--credential",
+          setup,
+          "--state",
+          state,
+          "--out",
+          bootstrapArtifact,
+          "--label",
+          "baseline",
+        ]);
+        await execFileAsync(process.execPath, [
+          adapter,
+          "connect",
+          "--mode",
+          "device",
+          "--base-url",
+          baseUrl,
+          "--credential",
+          state,
+          "--state",
+          state,
+          "--out",
+          reconnectArtifact,
+          "--label",
+          "candidate",
+        ]);
+      } finally {
+        await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+      }
+
+      expect(requests).toHaveLength(2);
+      const [bootstrap, reconnect] = requests;
+      expect(bootstrap).toMatchObject({
+        minProtocol: 4,
+        maxProtocol: 4,
+        client: {
+          id: "openclaw-watchos",
+          version: "2026.8.10",
+          platform: "watchOS 11.5.0",
+          deviceFamily: "Apple Watch",
+          mode: "node",
+          instanceId: "watchos-upgrade-survivor",
+        },
+        caps: [],
+        commands: ["device.info", "device.status", "system.notify"],
+        permissions: { notifications: true },
+        role: "node",
+        scopes: [],
+        auth: { bootstrapToken },
+      });
+      expect(reconnect).toMatchObject({
+        client: { id: "openclaw-watchos", mode: "node", instanceId: "watchos-upgrade-survivor" },
+        auth: { deviceToken },
+        device: { id: bootstrap.device.id, publicKey: bootstrap.device.publicKey },
+      });
+      const publicKey = crypto.createPublicKey({
+        key: Buffer.concat([
+          Buffer.from("302a300506032b6570032100", "hex"),
+          Buffer.from(bootstrap.device.publicKey, "base64url"),
+        ]),
+        format: "der",
+        type: "spki",
+      });
+      for (const [body, token] of [
+        [bootstrap, bootstrapToken],
+        [reconnect, deviceToken],
+      ] as const) {
+        expect(
+          crypto.verify(
+            null,
+            Buffer.from(signaturePayload(body, token)),
+            publicKey,
+            Buffer.from(body.device.signature, "base64url"),
+          ),
+        ).toBe(true);
+      }
+      expect(JSON.parse(readFileSync(state, "utf8"))).toMatchObject({
+        deviceId: bootstrap.device.id,
+        instanceId: "watchos-upgrade-survivor",
+        deviceToken,
+      });
+      for (const artifactPath of [bootstrapArtifact, reconnectArtifact]) {
+        const raw = readFileSync(artifactPath, "utf8");
+        expect(raw).not.toContain(bootstrapToken);
+        expect(raw).not.toContain(deviceToken);
+        expect(JSON.parse(raw)).toMatchObject({
+          ok: true,
+          challengeStatus: 200,
+          connectStatus: 200,
+          protocol: 4,
+          protocolRange: [4, 4],
+          clientId: "openclaw-watchos",
+          clientMode: "node",
+          instanceId: "watchos-upgrade-survivor",
+        });
+      }
+    });
+
+    it("asserts online node presence with one paired watch and no pending pairing", async () => {
+      const root = tempDirs.make("watchos-direct-node-state-");
+      const state = join(root, "state.json");
+      const nodes = join(root, "nodes.json");
+      const devices = join(root, "devices.json");
+      const artifact = join(root, "artifact.json");
+      writeFileSync(
+        state,
+        JSON.stringify({
+          deviceId: "watch-device",
+          instanceId: "watchos-upgrade-survivor",
+        }),
+      );
+      writeFileSync(
+        nodes,
+        JSON.stringify({
+          nodes: [
+            {
+              nodeId: "watch-device",
+              clientId: "openclaw-watchos",
+              clientMode: "node",
+            },
+          ],
+        }),
+      );
+      writeFileSync(
+        devices,
+        JSON.stringify({
+          pending: [],
+          paired: [{ deviceId: "watch-device" }],
+        }),
+      );
+
+      await execFileAsync(process.execPath, [
+        adapter,
+        "assert-state",
+        "--state",
+        state,
+        "--nodes",
+        nodes,
+        "--devices",
+        devices,
+        "--out",
+        artifact,
+        "--label",
+        "candidate",
+      ]);
+
+      expect(JSON.parse(readFileSync(artifact, "utf8"))).toEqual({
+        label: "candidate",
+        ok: true,
+        onlineNode: true,
+        pendingTotal: 0,
+        pendingForWatch: 0,
+        pairedForWatch: 1,
+        clientId: "openclaw-watchos",
+        clientMode: "node",
+        nodeId: "watch-device",
+        instanceId: "watchos-upgrade-survivor",
+      });
+    });
+
+    it("persists a rotated token for the next reconnect without leaking credentials", async () => {
+      const root = tempDirs.make("watchos-direct-node-rotation-");
+      const state = join(root, "state.json");
+      const firstArtifact = join(root, "reconnect-first.json");
+      const secondArtifact = join(root, "reconnect-second.json");
+      const retainedToken = "retained-device-secret";
+      const rotatedToken = "rotated-device-secret";
+      const authenticatedTokens: string[] = [];
+      const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+      const publicDer = publicKey.export({ format: "der", type: "spki" });
+      const rawPublicKey = Buffer.from(publicDer).subarray(-32);
+      writeFileSync(
+        state,
+        JSON.stringify({
+          deviceId: crypto.createHash("sha256").update(rawPublicKey).digest("hex"),
+          publicKey: rawPublicKey.toString("base64url"),
+          privateKeyPem: privateKey.export({ format: "pem", type: "pkcs8" }).toString(),
+          instanceId: "watchos-upgrade-survivor",
+          deviceToken: retainedToken,
+        }),
+      );
+      const server = createServer((request, response) => {
+        response.setHeader("content-type", "application/json");
+        if (request.url?.endsWith("/challenge")) {
+          response.end(JSON.stringify({ ok: true, nonce: "rotation-nonce", ts: Date.now() }));
+          return;
+        }
+        if (request.url?.endsWith("/connect")) {
+          let raw = "";
+          request.setEncoding("utf8");
+          request.on("data", (chunk) => {
+            raw += chunk;
+          });
+          request.on("end", () => {
+            const body = JSON.parse(raw);
+            authenticatedTokens.push(body.auth.deviceToken);
+            response.end(
+              JSON.stringify({
+                ok: true,
+                sessionToken: `rotation-session-${authenticatedTokens.length}`,
+                deviceToken: rotatedToken,
+                nodeId: body.device.id,
+                protocol: 4,
+              }),
+            );
+          });
+          return;
+        }
+        response.statusCode = 404;
+        response.end();
+      });
+      await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("failed to bind watch fixture");
+      }
+
+      try {
+        await execFileAsync(process.execPath, [
+          adapter,
+          "connect",
+          "--mode",
+          "device",
+          "--base-url",
+          `http://127.0.0.1:${address.port}/api/nodes/watch`,
+          "--credential",
+          state,
+          "--state",
+          state,
+          "--out",
+          firstArtifact,
+          "--label",
+          "candidate",
+        ]);
+        await execFileAsync(process.execPath, [
+          adapter,
+          "connect",
+          "--mode",
+          "device",
+          "--base-url",
+          `http://127.0.0.1:${address.port}/api/nodes/watch`,
+          "--credential",
+          state,
+          "--state",
+          state,
+          "--out",
+          secondArtifact,
+          "--label",
+          "restart",
+        ]);
+      } finally {
+        await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+      }
+
+      expect(authenticatedTokens).toEqual([retainedToken, rotatedToken]);
+      expect(JSON.parse(readFileSync(state, "utf8"))).toMatchObject({
+        deviceToken: rotatedToken,
+      });
+      for (const artifactPath of [firstArtifact, secondArtifact]) {
+        const raw = readFileSync(artifactPath, "utf8");
+        expect(raw).not.toContain(retainedToken);
+        expect(raw).not.toContain(rotatedToken);
+      }
+    });
+  },
+);


### PR DESCRIPTION
## What Problem This Solves

Resolves a gap where Gateway upgrades could break an already-paired Apple Watch direct-node connection without any retained-identity compatibility coverage.

## Why This Change Was Made

Adds a synthetic client matching the shipped `WatchDirectNode` V3 HTTP contract, then proves bootstrap pairing on `openclaw@2026.8.1`, retained-token reconnect after upgrade, valid token rollover, and another reconnect after candidate restart.

The expensive row remains outside normal `reported-issues` stable/full shards. It is available only through explicit `workflow_dispatch` selection and `far-reaching`; this PR adds no scheduled trigger.

## User Impact

Maintainers can detect when a Gateway change would lock out previously paired watches across an upgrade or restart without adding package/E2E overhead to normal release shards.

## Evidence

- Exact-head AWS compatibility proof `run_486b01537387` at `85b258cd0e894fba6d6d9668d8dd1566dac888f8`: published `openclaw@2026.8.1` bootstrapped the watch through the decoded HTTPS setup endpoint, then the packed candidate reconnected with the retained device token and reconnected again after a candidate Gateway restart.
- Baseline, candidate, and restart each returned HTTP 200 for challenge, connect, and authenticated poll. All three retained V3, protocol `[4,4]`, client `openclaw-watchos` / mode `node`, stable instance/device identity, one paired watch, and zero pending pairing.
- Redacted proof artifact: `.artifacts/watchos-tls-85b258c/summary.json`, SHA-256 `8a68c24470193fabd0f8c9f681e9a4758f6353432c55ef63e06cc68a936af0b7`. Only token hashes are recorded.
- `run_9f53d08cc317` proved the baseline watch pair and candidate update, then exposed a harness-only plugin-registry assertion that expected an unrelated WhatsApp install. `run_4c8ebbc213d0` exposed the earlier generic legacy-session seed before watch pairing. Both fixtures are now scenario-isolated; neither was a watch product verdict.
- Focused proof: the four relevant adapter/assertion/config/runner files passed 363 tests with 2 skips; the final exact-head runner policy change passed the Docker helper suite, 273 tests with 2 skips.
- Targeted formatting/lint, shell syntax, and `git diff --check` passed. Fresh fix-only autoreviews were scoped-clean at 0.99 confidence.
- Exact-head CodeQL high-severity jobs, workflow sanity, dependency/security guards, and OpenGrep passed. The remaining main CI fanout is tracked on the PR.
- Earlier Testbox Actions runs `33734397052` and `33736350534` were infrastructure-cancelled during delegated lifecycle before the scenario command; neither produced a product verdict.

This is test infrastructure only. No Gateway product schema, persistent store, or runtime protocol changed.
