### PR TITLE
test(cli): reuse canonical pairing call guard

### DIFF
--- a/src/cli/pairing-cli.test.ts
+++ b/src/cli/pairing-cli.test.ts
@@ -1,4 +1,5 @@
 // Pairing CLI tests cover pairing command registration and pairing status output.
+import { expectDefined } from "@openclaw/normalization-core";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { theme } from "../../packages/terminal-core/src/theme.js";
@@ -43,14 +44,6 @@ const pairingIdLabels: Record<string, string> = {
   telegram: "telegramUserId",
   discord: "discordUserId",
 };
-
-function requireFirstMockCall(calls: readonly unknown[][], label: string): unknown[] {
-  const call = calls.at(0);
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call;
-}
 
 vi.mock("../pairing/pairing-store.js", () => ({
   listChannelPairingRequests: mocks.listChannelPairingRequests,
@@ -298,8 +291,8 @@ describe("pairing cli", () => {
         channel: "telegram",
         code: "ABCDEFGH",
       });
-      const replaceCall = requireFirstMockCall(
-        replaceConfigFile.mock.calls,
+      const replaceCall = expectDefined<unknown[]>(
+        replaceConfigFile.mock.calls.at(0),
         "config replace",
       )[0] as { nextConfig?: { commands?: { ownerAllowFrom?: string[] } } } | undefined;
       expect(replaceCall?.nextConfig?.commands?.ownerAllowFrom).toEqual(["telegram:123"]);


### PR DESCRIPTION
Replace the single-use Pairing CLI mock-call guard with the existing `expectDefined<unknown[]>` helper. The test still selects the first call and first argument and preserves the exact scoped-owner, log-order, and non-overwrite assertions. All 18 CLI cases remain; no production code changes.

Validation: the complete Pairing CLI, Doctor command-owner, and shared-helper suites passed 26 tests before and after in identical order. The normal local changed-file gate and a fresh independent Codex review through P2 passed. Test delta: +3/-10 lines.
