### PR TITLE
fix(media): attachments lose duration and dimensions with ffprobe 4.x/5.x

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3284,7 +3284,6 @@ src/media/fetch.ts	2
 src/media/input-files.ts	1
 src/media/local-media-access.ts	1
 src/media/media-facts.ts	16
-src/media/media-probe.ts	1
 src/media/playback-transcode.ts	1
 src/media/runtime-prompt-image-provenance.ts	1
 src/media/store.remote.runtime.ts	1

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -157,22 +157,31 @@ describe("probeMediaFile", () => {
     expect(runFfprobe).toHaveBeenCalledOnce();
   });
 
-  it("falls back to pipe input when older ffprobe lacks the fd protocol", async () => {
-    runFfprobe
-      .mockRejectedValueOnce(
-        Object.assign(new Error("ffprobe failed"), { stderr: "fd:: Protocol not found" }),
-      )
-      .mockResolvedValueOnce(JSON.stringify({ format: { duration: "2" } }));
+  it.each([
+    ["fd protocol missing", "fd:: Protocol not found"],
+    [
+      "fd option unrecognized",
+      "Unrecognized option 'fd'.\nError splitting the argument list: Option not found",
+    ],
+    // ffprobe 4.4 (Ubuntu 22.04) and 5.x report the `-fd` option this way.
+    ["fd option value rejected", "Failed to set value '0' for option 'fd': Option not found"],
+  ])(
+    "falls back to pipe input when older ffprobe lacks fd support (%s)",
+    async (_label, stderr) => {
+      runFfprobe
+        .mockRejectedValueOnce(Object.assign(new Error("ffprobe failed"), { stderr }))
+        .mockResolvedValueOnce(JSON.stringify({ format: { duration: "2" } }));
 
-    await expect(probePlaybackMediaFileDescriptor(17, "audio")).resolves.toEqual({
-      durationMs: 2000,
-    });
-    expect(runFfprobe).toHaveBeenNthCalledWith(
-      2,
-      expect.arrayContaining(["-protocol_whitelist", "pipe", "pipe:0"]),
-      { stdinFileDescriptor: 17 },
-    );
-  });
+      await expect(probePlaybackMediaFileDescriptor(17, "audio")).resolves.toEqual({
+        durationMs: 2000,
+      });
+      expect(runFfprobe).toHaveBeenNthCalledWith(
+        2,
+        expect.arrayContaining(["-protocol_whitelist", "pipe", "pipe:0"]),
+        { stdinFileDescriptor: 17 },
+      );
+    },
+  );
 
   it("uses stream duration when the container duration is absent", async () => {
     runFfprobe.mockResolvedValueOnce(

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -183,6 +183,16 @@ describe("probeMediaFile", () => {
     },
   );
 
+  it.each([
+    "Failed to set value '0' for option 'threads': Option not found",
+    "Failed to set value '0' for option 'fdfoo': Option not found",
+  ])("does not retry an unrelated ffprobe option failure: %s", async (stderr) => {
+    runFfprobe.mockRejectedValue(Object.assign(new Error("ffprobe failed"), { stderr }));
+
+    await expect(probePlaybackMediaFileDescriptor(17, "audio")).resolves.toBeNull();
+    expect(runFfprobe).toHaveBeenCalledOnce();
+  });
+
   it("uses stream duration when the container duration is absent", async () => {
     runFfprobe.mockResolvedValueOnce(
       JSON.stringify({ streams: [{ codec_type: "audio", duration: "1.5" }] }),

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -150,7 +150,8 @@ function isMissingFdProtocolError(error: unknown): boolean {
   }
   const stderr = (error as { stderr?: unknown }).stderr;
   const message = typeof stderr === "string" ? stderr : error instanceof Error ? error.message : "";
-  return /(?:fd:.*protocol not found|protocol not found.*fd|unrecognized option ['"]?fd|option fd not found)/is.test(
+  // ffprobe < 6.1 rejects `-fd` with "Failed to set value '0' for option 'fd': Option not found".
+  return /(?:fd:.*protocol not found|protocol not found.*fd|unrecognized option ['"]?fd|option ['"]?fd['"]?\b.*not found)/is.test(
     message,
   );
 }

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -150,7 +150,8 @@ function isMissingFdProtocolError(error: unknown): boolean {
   }
   const stderr = (error as { stderr?: unknown }).stderr;
   const message = typeof stderr === "string" ? stderr : error instanceof Error ? error.message : "";
-  // ffprobe < 6.1 rejects `-fd` with "Failed to set value '0' for option 'fd': Option not found".
+  // ffprobe < 6.0 (no fd: protocol, e.g. 4.4 and 5.1) rejects `-fd` with
+  // "Failed to set value '0' for option 'fd': Option not found".
   return /(?:fd:.*protocol not found|protocol not found.*fd|unrecognized option ['"]?fd|option ['"]?fd['"]?\b.*not found)/is.test(
     message,
   );

--- a/src/media/media-probe.ts
+++ b/src/media/media-probe.ts
@@ -145,14 +145,11 @@ function buildFfprobeMetadataArgs(protocol: "fd" | "pipe"): string[] {
 }
 
 function isMissingFdProtocolError(error: unknown): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-  const stderr = (error as { stderr?: unknown }).stderr;
+  const stderr = readRecord(error)?.stderr;
   const message = typeof stderr === "string" ? stderr : error instanceof Error ? error.message : "";
   // ffprobe < 6.0 (no fd: protocol, e.g. 4.4 and 5.1) rejects `-fd` with
   // "Failed to set value '0' for option 'fd': Option not found".
-  return /(?:fd:.*protocol not found|protocol not found.*fd|unrecognized option ['"]?fd|option ['"]?fd['"]?\b.*not found)/is.test(
+  return /(?:fd:.*protocol not found|protocol not found.*fd|unrecognized option ['"]?fd|option ['"]?fd\b.*not found)/is.test(
     message,
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes missing attachment duration and video dimensions on Gateway hosts using ffprobe 4.x or 5.x. These versions reject the descriptor option with a quoted option name; OpenClaw did not recognize that diagnostic and silently omitted metadata instead of taking its existing pipe-input fallback.

## Why This Change Was Made

The existing media-probe owner now recognizes that diagnostic, while preserving descriptor-first seeking on newer ffprobe and declining to retry unrelated failures. The error reader also reuses the module's canonical record coercion, removing a redundant object guard and cast. Production is net **−1 LOC** (+4/−5); tests are net +19 (+33/−14).

A separate version probe would add a subprocess and misclassify customized builds. Always using pipe input would lose the regular-file seek support provided by the descriptor protocol. The repair keeps both existing paths under their original owner.

## User Impact

Inbound attachment facts, chat attachment metadata, and playback inspection can recover duration and video dimensions with older system ffprobe installations. Operators need no new setting. Buffer-based video probing and best-effort handling of invalid or missing media remain unchanged.

## Evidence

Current candidate: `ee1bc05ca776d0147a5c1e9b08f10e7433332069`. The first required CI run identified an obsolete assertion-ratchet entry after the cast removal; this exact shrink-only entry has now been removed. [Final exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33996829369). An unchanged Gateway test hit an ENOTEMPTY cleanup failure on the initial run; investigation found no attributable writer, so its cause remains a recorded follow-up. No change to that test was needed for the successful final run.

[Secretless real-process proof](https://github.com/steipete/openclaw/actions/runs/33996111032) ran the production owner and normal inbound-media enrichment with synthetic one-second FLAC and 160×96 MKV files:

| System ffprobe | Before | After |
| --- | --- | --- |
| 4.4.2, Ubuntu 22.04 | File-batch and inbound metadata absent; playback probe null | Duration 1000 ms, video 160×96, playback codec/duration restored |
| 6.1.1, Ubuntu 24.04 | Correct duration/dimensions | Same correct results |

Buffer probing and invalid/missing-file controls passed on both versions. Each unit baseline failed precisely the new quoted-option case, with 14 other cases passing; each repaired suite passed all 15 cases. Pinned formatting passed. Both runtime/test file hashes exactly match the published candidate, including after the baseline-only follow-up. This proof calls the normal inbound enrichment boundary directly; it does not claim a channel-transport run. FFmpeg 5.1.7 was inspected at source, not executed.

A separate trusted-main fixture preflight also passed with system ffprobe 9.0.1. Normal guarded commit hooks passed; the repair removes production code and its now-obsolete assertion baseline entry.

The focused fallback test now covers the exact quoted diagnostic alongside the previously supported forms. Negative cases protect unrelated options and similarly named options. The synthetic real-process probe exercises file batches, descriptor playback inspection, normal inbound-media enrichment, buffer input, and invalid/missing files; it records the actual resolved ffprobe binary and version.

Dependency contract inspected directly: FFmpeg [5.1.7 option handling](https://github.com/FFmpeg/FFmpeg/blob/n5.1.7/fftools/cmdutils.c#L271) emits the quoted option diagnostic, and the [6.0 protocol documentation](https://github.com/FFmpeg/FFmpeg/blob/n6.0/doc/protocols.texi#L258) documents seekable descriptor input. The 5.1.7 protocol list lacks that protocol. This resolves the earlier bot review's upstream-verification gap; the production cleanup also resolves its LOC concern.

Deslop, fresh independent autoreview, a separate read-only review process, and an independent source/artifact verifier found no actionable P0–P2 findings. The verifier confirmed the exact published source hashes and the older/newer ffprobe boundary evidence. Exact Execa 10.0.1 Error construction and stderr assignment were also inspected directly, resolving the review environment’s dependency-source gap. Final required CI passed. The latest same-head ClawSweeper review has no findings and accepts the real-process proof.

Original fix and ffprobe 4.4.2 report by @coderdailyone; maintainer rewrite preserves their commits and credit.
