### PR TITLE
ci: remove redundant contract runs and costly test work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1250,6 +1250,8 @@ jobs:
           const runNodeFastCiRouting =
             runNode && parseBoolean(process.env.OPENCLAW_CI_RUN_NODE_FAST_CI_ROUTING);
           const runPluginContractShards = runNodeFull || runNodeFastPluginContracts;
+          const pluginContractShards = runPluginContractShards ? createPluginContractTestShards() : [];
+          const channelContractShards = runNodeFull ? createChannelContractTestShards() : [];
           const runMacos =
             parseBoolean(process.env.OPENCLAW_CI_RUN_MACOS) && !docsOnly && isCanonicalRepository;
           // Older selected checkouts report only run_macos; retain their native Node coverage.
@@ -1396,7 +1398,9 @@ jobs:
                 throw new Error(`Current PR CI target does not export ${name}`);
               }
             }
-            changedNodeTestShards = changedNodeTestPlan.createChangedNodeTestShards(changedPaths);
+            changedNodeTestShards = changedNodeTestPlan.createChangedNodeTestShards(changedPaths, {
+              dedicatedContractShards: [...pluginContractShards, ...channelContractShards],
+            });
             if (changedNodeTestShards === null) {
               changedExtensionFallbackShards =
                 changedNodeTestPlan.createChangedExtensionFallbackShards(changedPaths);
@@ -1524,7 +1528,6 @@ jobs:
           const runNodeCoreDist =
             (changedNodeTestShards !== null && runBuildArtifacts) ||
             nodeTestDistShards.length > 0;
-          const channelContractShards = runNodeFull ? createChannelContractTestShards() : [];
           const protocolCoverageRequested = runNode || runIosBuild || runAndroid;
           const runProtocolEventCoverage =
             protocolCoverageRequested &&
@@ -1586,7 +1589,7 @@ jobs:
             checks_fast_core_matrix: createMatrix(checksFastCoreTasks),
             run_plugin_contracts_shards: runPluginContractShards,
             plugin_contracts_matrix: createContractMatrix(
-              runPluginContractShards ? createPluginContractTestShards() : [],
+              pluginContractShards,
               "contracts-plugins",
             ),
             run_channel_contracts_shards: channelContractShards.length > 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Session host selection:** show command-policy denial separately from pending pairing approval after a live Gateway configuration change. (#137220)
 - **Update readiness:** select declared health-check owners before loading plugin APIs, preventing unrelated optional Doctor checks from interrupting upgrades while retaining mandatory readiness failures.
 
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Session host selection:** show command-policy denial separately from pending pairing approval after a live Gateway configuration change. (#137220)
 - **Update readiness:** select declared health-check owners before loading plugin APIs, preventing unrelated optional Doctor checks from interrupting upgrades while retaining mandatory readiness failures.
 
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.

--- a/extensions/qa-lab/src/session-host-command-state.real-gateway.e2e.test.ts
+++ b/extensions/qa-lab/src/session-host-command-state.real-gateway.e2e.test.ts
@@ -79,7 +79,7 @@ suite.define(() => {
                 sshVerify: false,
               },
             },
-            reload: { mode: "hot" },
+            reload: { mode: "hybrid" },
           },
           agents: {
             ...config.agents,
@@ -214,8 +214,7 @@ suite.define(() => {
               },
               { interval: 250, timeout: 60_000 },
             );
-            await waitForReconnect(unauthorizedNode, unauthorizedHelloCount);
-            await publishSessionHost(unauthorizedNode);
+            expect(helloCounts.get(unauthorizedNode)).toBe(unauthorizedHelloCount);
 
             await page.reload();
             await page.locator("#new-session-where-trigger").click();
@@ -228,8 +227,9 @@ suite.define(() => {
             await page.screenshot({
               animations: "disabled",
               fullPage: true,
-              path: path.join(suite.artifactDir, "02-unauthorized-after-restart.png"),
+              path: path.join(suite.artifactDir, "02-unauthorized-after-hot-reload.png"),
             });
+            expect(helloCounts.get(unauthorizedNode)).toBe(unauthorizedHelloCount);
           },
         );
       } finally {
@@ -430,13 +430,6 @@ async function publishSessionHost(node: GatewayClient): Promise<void> {
       environmentSession: NODE_WORKER_ENVIRONMENT_SESSION_VERSION,
       capacity: { total: 1, available: 1 },
     },
-  });
-}
-
-async function waitForReconnect(client: GatewayClient, previousCount: number): Promise<void> {
-  await vi.waitFor(() => expect(helloCounts.get(client) ?? 0).toBeGreaterThan(previousCount), {
-    interval: 100,
-    timeout: 60_000,
   });
 }
 

--- a/scripts/changed-lanes.mts
+++ b/scripts/changed-lanes.mts
@@ -212,7 +212,11 @@ export function detectChangedLanes(
       continue;
     }
 
-    if (PUBLIC_EXTENSION_CONTRACT_RE.test(changedPath)) {
+    // Test leaves exercise contracts; shared helpers and suites can affect their consumers.
+    if (
+      PUBLIC_EXTENSION_CONTRACT_RE.test(changedPath) &&
+      !/\.(?:test|spec)\.[cm]?[jt]sx?$/u.test(changedPath)
+    ) {
       lanes.core = true;
       lanes.coreTests = true;
       lanes.extensions = true;

--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -1,9 +1,12 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
+import { pluginContractPatterns } from "../../test/vitest/vitest.contracts-paths.mjs";
 import { isUiBrowserTestFile } from "../../test/vitest/vitest.ui-paths.mjs";
 import { detectChangedLanes } from "../changed-lanes.mts";
 import {
   buildVitestRunPlans,
+  CHANNEL_CONTRACT_CONFIG_PATTERNS,
+  CONTRACTS_PLUGIN_VITEST_CONFIG,
   findUnmatchedExplicitTestTargets,
   hasImportGraphImpactOnTargets,
   isTestFileTarget,
@@ -325,7 +328,7 @@ function resolvePreciseChangedTargets(
   ) {
     return null;
   }
-  return targetPlans.map(({ target }) => target);
+  return targetPlans;
 }
 
 function createChangedTargetShards(
@@ -543,7 +546,9 @@ export function createChangedExtensionFallbackShards(
  */
 export function createChangedNodeTestShards(
   changedPaths: string[],
-  options: CwdOptions = {},
+  options: CwdOptions & {
+    dedicatedContractShards?: readonly { task: string; includePatterns: readonly string[] }[];
+  } = {},
 ): ChangedNodeTestShard[] | null {
   const cwd = options.cwd ?? process.cwd();
   if (!Array.isArray(changedPaths) || changedPaths.length === 0) {
@@ -584,7 +589,7 @@ export function createChangedNodeTestShards(
     return null;
   }
 
-  const targets = resolvePreciseChangedTargets(regularLivePaths, cwd, [
+  const targetPlans = resolvePreciseChangedTargets(regularLivePaths, cwd, [
     ...[...policyTargetsByPath.values()].flat(),
     // Plugin changes normally select only extension suites. This host-owned
     // proof also exercises the real Copilot entrypoint and manifest discovery.
@@ -592,9 +597,33 @@ export function createChangedNodeTestShards(
       ? ["src/agents/prepared-model-runtime.copilot.integration.test.ts"]
       : []),
   ]);
-  if (targets === null) {
+  if (targetPlans === null) {
     return null;
   }
+  // CI supplies the same enabled envelopes it emits. Validate all changed paths
+  // first, then subtract only exact targets owned by those configs and includes.
+  const targets = targetPlans
+    .filter(
+      ({ target, plans }) =>
+        !plans.every((plan) => {
+          const plugin = plan.config === CONTRACTS_PLUGIN_VITEST_CONFIG;
+          const patterns = plugin
+            ? pluginContractPatterns
+            : CHANNEL_CONTRACT_CONFIG_PATTERNS.get(plan.config);
+          return (
+            !plan.watchMode &&
+            plan.forwardedArgs.length === 0 &&
+            plan.includePatterns?.every((pattern) => pattern === target) &&
+            patterns?.some((pattern) => path.matchesGlob(target, pattern)) &&
+            options.dedicatedContractShards?.some(
+              (shard) =>
+                shard.task === (plugin ? "contracts-plugins" : "contracts-channels") &&
+                shard.includePatterns.includes(target),
+            )
+          );
+        }),
+    )
+    .map(({ target }) => target);
 
   // Boundary-config targets run as regular nondist targets: the boundary
   // suite scans the checked-out tree and never consumes the built dist.
@@ -610,5 +639,6 @@ export function createChangedNodeTestShards(
     ),
     ...(hasBuildArtifactAffectingChange(changedPaths) ? [] : [createBoundaryShard()]),
   ];
-  return shards.length > 0 ? shards : null;
+  // Covered source targets keep build-artifacts ownership even with no Node rows.
+  return shards.length > 0 || targets.length < targetPlans.length ? shards : null;
 }

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -2830,6 +2830,7 @@ const SEMANTIC_TOOLING_TARGET_PATTERNS: Array<[RegExp, string[]]> = [
     /^test\/vitest\/vitest\.contracts-paths\.mjs$/u,
     [
       "test-projects",
+      "test/vitest-projects-config.test.ts",
       "test/vitest/vitest.contracts-channel-surface.config.ts",
       "test/vitest/vitest.contracts-channel-config.config.ts",
       "test/vitest/vitest.contracts-channel-registry.config.ts",

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -215,7 +215,7 @@ const CONTRACTS_CHANNEL_SESSION_VITEST_CONFIG =
   "test/vitest/vitest.contracts-channel-session.config.ts";
 const CONTRACTS_CHANNEL_SURFACE_VITEST_CONFIG =
   "test/vitest/vitest.contracts-channel-surface.config.ts";
-const CONTRACTS_PLUGIN_VITEST_CONFIG = "test/vitest/vitest.contracts-plugin.config.ts";
+export const CONTRACTS_PLUGIN_VITEST_CONFIG = "test/vitest/vitest.contracts-plugin.config.ts";
 const CRON_VITEST_CONFIG = "test/vitest/vitest.cron.config.ts";
 const DAEMON_VITEST_CONFIG = "test/vitest/vitest.daemon.config.ts";
 const E2E_VITEST_CONFIG = "test/vitest/vitest.e2e.config.ts";

--- a/src/commands/agent-exec.test.ts
+++ b/src/commands/agent-exec.test.ts
@@ -6,7 +6,6 @@ import { Readable } from "node:stream";
 import { promisify } from "node:util";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { waitForDead, waitForPidFile } from "../../test/helpers/process-wait.js";
 import { cleanupTempDirs, useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { AgentRunTerminalOutcomeError } from "../agents/agent-run-terminal-error.js";
 import { createAgentHarnessToolSurfaceRuntimeCore } from "../agents/harness/tool-surface-bridge.js";
@@ -19,7 +18,6 @@ import {
 } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { withEnvAsync } from "../test-utils/env.js";
 import {
   buildExecRunConfig,
   resolveAgentExecPrompt,
@@ -198,74 +196,6 @@ describe("agent exec strict result classification", () => {
 });
 
 describe("agent exec command composition", () => {
-  it("bounds blocked service-relay construction through the shipped CLI command", async () => {
-    const root = tempDirs.make("openclaw-agent-exec-service-construction-");
-    const binDir = path.join(root, "bin");
-    const pidPath = path.join(root, "command.pid");
-    const configPath = path.join(root, "openclaw.json");
-    await fs.mkdir(binDir);
-    const claudePath = path.join(binDir, "claude");
-    await fs.writeFile(
-      claudePath,
-      `#!/bin/sh
-printf '%s' "$$" > ${JSON.stringify(pidPath)}
-sleep 60
-`,
-      "utf8",
-    );
-    await fs.chmod(claudePath, 0o755);
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        agents: {
-          defaults: {
-            model: { primary: "anthropic/claude-opus-4-7" },
-            models: {
-              "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
-            },
-          },
-        },
-      }),
-      "utf8",
-    );
-
-    const completed = await withEnvAsync(
-      {
-        ANTHROPIC_API_KEY: "synthetic-proof-key",
-        NODE_DISABLE_COMPILE_CACHE: "1",
-        OPENCLAW_SERVICE_MARKER: "openclaw",
-        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-      },
-      async () => {
-        const { runtime } = createRuntime();
-        const result = agentExecCommand(
-          "probe",
-          { config: configPath, cwd: root, timeout: "1", json: true },
-          runtime,
-        );
-        let commandPid: number;
-        try {
-          commandPid = await waitForPidFile(pidPath, 3_000);
-        } catch (error) {
-          const failed = await result;
-          throw new Error(
-            `agent exec did not start the fake CLI: ${String(error)} exit=${String(failed.exitCode)} envelope=${JSON.stringify(failed.envelope)}`,
-            { cause: error },
-          );
-        }
-        expect(commandPid).toBeGreaterThan(0);
-        const finished = await result;
-        await waitForDead(commandPid, 5_000);
-        return finished;
-      },
-    );
-    expect(completed.exitCode).toBe(2);
-    expect(completed.envelope).toMatchObject({
-      ok: false,
-      status: "timeout",
-    });
-  });
-
   it("writes plain final text to stdout when diagnostics are routed to stderr", async () => {
     const source = `
       import { agentExecCommand } from "./src/commands/agent-exec.ts";
@@ -709,15 +639,15 @@ sleep 60
     });
   });
 
-  it("threads --cwd to both workspace and tool cwd", async () => {
+  it("threads --cwd and --timeout to the agent", async () => {
     const root = tempDirs.make("openclaw-agent-exec-cwd-");
     const { runtime } = createRuntime();
     const runAgent = vi.fn(async () => successResult());
 
-    await agentExecCommand("inspect", { cwd: root }, runtime, { runAgent });
+    await agentExecCommand("inspect", { cwd: root, timeout: "7" }, runtime, { runAgent });
 
     expect(runAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceDir: root, cwd: root }),
+      expect.objectContaining({ workspaceDir: root, cwd: root, timeout: "7" }),
       expect.any(Object),
     );
   });

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -590,7 +590,12 @@ export function resolveRequiredNodeCommandAuthority(params: {
     ) {
       continue;
     }
-    if (declaredCommands.has(command) && !effectiveCommands.has(command)) {
+    // Hot reload retains declarations; a policy denial is not a new pairing request.
+    if (
+      declaredCommands.has(command) &&
+      !effectiveCommands.has(command) &&
+      !withheldCommands.has(command)
+    ) {
       return { command, state: "pending-approval" };
     }
     if (declaredCommands.has(command) || withheldCommands.has(command)) {

--- a/src/gateway/node-registry-policy.test.ts
+++ b/src/gateway/node-registry-policy.test.ts
@@ -6,7 +6,11 @@ import {
   mergeRemoteNodeSkillEntries,
   removeRemoteNodeSkills,
 } from "../skills/runtime/remote-skills.js";
-import { TALK_PTT_COMMANDS } from "./node-command-policy.js";
+import {
+  resolveNodeCommandAllowlist,
+  resolveRequiredNodeCommandAuthority,
+  TALK_PTT_COMMANDS,
+} from "./node-command-policy.js";
 import { listConnectedNodePluginTools } from "./node-plugin-tool-snapshot.js";
 import { NodeRegistry, readNodeSessionWithheldCommands } from "./node-registry.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
@@ -303,18 +307,40 @@ describe("connected node runtime policy", () => {
 
   it("withdraws and restores approved commands without granting an unapproved declaration", () => {
     const { node, client, socket, reload } = createFixture();
-    reload({ gateway: { nodes: { commands: { deny: ["computer.act"] } } } });
+    const commandAuthority = (config: OpenClawConfig, command: string) =>
+      resolveRequiredNodeCommandAuthority({
+        requiredCommands: [command],
+        declaredCommands: node.declaredCommands,
+        effectiveCommands: node.commands,
+        withheldCommands: readNodeSessionWithheldCommands(node),
+        allowlist: resolveNodeCommandAllowlist(config, node),
+      });
+    const deniedConfig = { gateway: { nodes: { commands: { deny: ["computer.act"] } } } };
+    reload(deniedConfig);
 
     expect(node.commands).toEqual(["system.run"]);
     expect(node.caps).toEqual([]);
     expect(client.connect.commands).toEqual(["system.run"]);
     expect(readNodeSessionWithheldCommands(node)).toContain("computer.act");
+    expect(commandAuthority(deniedConfig, "computer.act")).toEqual({
+      command: "computer.act",
+      state: "unauthorized",
+    });
 
-    reload({ gateway: { nodes: { commands: { allow: ["screen.snapshot"] } } } });
+    const restoredConfig = { gateway: { nodes: { commands: { allow: ["screen.snapshot"] } } } };
+    reload(restoredConfig);
 
     expect(node.commands).toEqual(["computer.act", "system.run"]);
     expect(node.caps).toEqual(["computer"]);
     expect(readNodeSessionWithheldCommands(node)).not.toContain("computer.act");
+    expect(commandAuthority(restoredConfig, "computer.act")).toEqual({
+      command: "computer.act",
+      state: "invocable",
+    });
+    expect(commandAuthority(restoredConfig, "screen.snapshot")).toEqual({
+      command: "screen.snapshot",
+      state: "pending-approval",
+    });
     expect(node.connId).toBe("policy-conn");
     expect(node.pairingGeneration).toBe("policy-generation");
     expect(socket.close).not.toHaveBeenCalled();

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -1755,16 +1755,21 @@ describe("scripts/changed-lanes", () => {
   });
 
   it.each([
-    {
-      name: "selects compiler-owned graphs for core test leaf changes",
-      path: "src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts",
+    ...[
+      "src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts",
+      "src/plugin-sdk/config-runtime.test.ts",
+      "src/plugins/contracts/registry.retry.test.ts",
+      "src/channels/plugins/config-schema.test.ts",
+    ].map((path) => ({
+      name: "selects core test graphs",
+      path,
       expected: {
         lanes: { coreTests: true },
         includes: ["tsgo:core:test"],
-        excludes: ["tsgo:core"],
+        excludes: ["tsgo:core", "tsgo:extensions", "tsgo:extensions:test", "lint:extensions"],
         coreTestChecks: ["checkBoundary", "checkTypes"],
       },
-    },
+    })),
     {
       name: "routes core test-only changes to core test lanes only",
       path: "packages/normalization-core/src/string-normalization.test-support.ts",
@@ -1792,12 +1797,13 @@ describe("scripts/changed-lanes", () => {
         excludes: ["tsgo:extensions"],
       },
     },
-  ])("$name", ({ path: changedPath, expected }) => {
+  ])("$name: $path", ({ path: changedPath, expected }) => {
     const result = detectChangedLanes([changedPath]);
     const plan = createChangedCheckPlan(result);
     const commands = plan.commands.map((command) => command.args[0]);
 
     expectLanes(result.lanes, expected.lanes);
+    expect(result.extensionImpactFromCore).toBe(false);
     expect(plan.commands.flatMap((command) => command.coreTestCheck ?? [])).toEqual(
       "coreTestChecks" in expected ? expected.coreTestChecks : [],
     );
@@ -1809,10 +1815,25 @@ describe("scripts/changed-lanes", () => {
     }
   });
 
-  it.each([{ otherPaths: [] }, { otherPaths: [githubActivityHelper] }])(
-    "expands public core/plugin contracts with $otherPaths to extension validation",
-    ({ otherPaths }) => {
-      const result = detectChangedLanes(["src/plugin-sdk/core.ts", ...otherPaths]);
+  it.each([
+    { contractPath: "src/plugin-sdk/core.ts", otherPaths: [] },
+    { contractPath: "src/plugin-sdk/core.ts", otherPaths: [githubActivityHelper] },
+    ...[
+      "src/plugin-sdk/qa-runtime.test-helpers.ts",
+      "src/plugin-sdk/channel-contract.ts",
+      "src/plugins/contracts/registry.ts",
+      "src/plugins/contracts/contract.suite.ts",
+      "src/channels/plugins/contracts/test-helpers/surface-contract-suite.ts",
+      "src/channels/plugins/types.plugin.ts",
+      "scripts/lib/plugin-sdk-entrypoints.json",
+    ].map((contractPath) => ({
+      contractPath,
+      otherPaths: ["src/plugin-sdk/test-state.test.ts"],
+    })),
+  ])(
+    "expands public core/plugin contract $contractPath with $otherPaths to extension validation",
+    ({ contractPath, otherPaths }) => {
+      const result = detectChangedLanes([contractPath, ...otherPaths]);
       const plan = createChangedCheckPlan(result);
 
       expect(result.extensionImpactFromCore).toBe(true);
@@ -1821,7 +1842,7 @@ describe("scripts/changed-lanes", () => {
         coreTests: true,
         extensions: true,
         extensionTests: true,
-        tooling: otherPaths.length > 0,
+        tooling: otherPaths.includes(githubActivityHelper),
       });
       expect(plan.commands.map((command) => command.args[0])).toEqual(
         expect.arrayContaining([

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -1760,9 +1760,9 @@ describe("scripts/changed-lanes", () => {
       "src/plugin-sdk/config-runtime.test.ts",
       "src/plugins/contracts/registry.retry.test.ts",
       "src/channels/plugins/config-schema.test.ts",
-    ].map((path) => ({
+    ].map((changedPath) => ({
       name: "selects core test graphs",
-      path,
+      path: changedPath,
       expected: {
         lanes: { coreTests: true },
         includes: ["tsgo:core:test"],

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -197,8 +197,14 @@ describe("CI changed Node test plan", () => {
     ]);
   });
 
-  it("keeps an exact default-unit change focused while retaining boundary coverage", () => {
-    const target = "src/node-host/node-worker-bundle-installer.test.ts";
+  it.each([
+    "src/node-host/node-worker-bundle-installer.test.ts",
+    "src/plugin-sdk/config-runtime.test.ts",
+    "src/plugins/contracts/registry.retry.test.ts",
+    "src/channels/plugins/config-schema.test.ts",
+  ])("keeps exact test leaf %s focused while retaining boundary coverage", (target) => {
+    expect(hasCoreExtensionImpact([target])).toBe(false);
+    expect(createChangedExtensionFallbackShards([target])).toEqual([]);
     expect(createChangedNodeTestShards([target])).toEqual([
       {
         checkName: "checks-node-changed",
@@ -415,10 +421,16 @@ describe("CI changed Node test plan", () => {
     expect(targets).toContain("src/agents/live-model-filter.test.ts");
   });
 
-  it("runs only the boundary shard when a diff deletes test files", () => {
+  it.each([
+    "src/gone.test.ts",
+    "src/plugin-sdk/gone.test.ts",
+    "src/plugins/contracts/gone.test.ts",
+    "src/channels/plugins/gone.test.ts",
+  ])("runs only the boundary shard when a diff deletes %s", (target) => {
     const cwd = mkdtempSync(path.join(tmpdir(), "openclaw-ci-deleted-test-"));
     try {
-      expect(createChangedNodeTestShards(["src/gone.test.ts"], { cwd })).toEqual([
+      expect(createChangedExtensionFallbackShards([target], { cwd })).toEqual([]);
+      expect(createChangedNodeTestShards([target], { cwd })).toEqual([
         {
           checkName: "checks-node-changed-boundary",
           configs: ["test/vitest/vitest.boundary.config.ts"],
@@ -438,9 +450,28 @@ describe("CI changed Node test plan", () => {
     ).toBeNull();
   });
 
-  it("fails safe when public SDK changes affect extension imports", () => {
-    expect(createChangedNodeTestShards(["src/plugin-sdk/core.ts"])).toBeNull();
-  });
+  it.each([
+    { changedPaths: ["src/plugin-sdk/core.ts"] },
+    { changedPaths: ["src/plugin-sdk/core.ts", "src/plugin-sdk/config-runtime.test.ts"] },
+    {
+      changedPaths: [
+        "src/plugins/contracts/registry.ts",
+        "src/plugins/contracts/registry.retry.test.ts",
+      ],
+    },
+    {
+      changedPaths: [
+        "src/channels/plugins/config-schema.ts",
+        "src/channels/plugins/config-schema.test.ts",
+      ],
+    },
+  ])(
+    "fails safe when public contracts affect extension imports: $changedPaths",
+    ({ changedPaths }) => {
+      expect(createChangedNodeTestShards(changedPaths)).toBeNull();
+      expectAllExtensionConfigs(createChangedExtensionFallbackShards(changedPaths));
+    },
+  );
 
   it("fails safe when a core change reaches package consumers through the public SDK", () => {
     expect(createChangedNodeTestShards(["src/shared/text/strip-markdown.ts"])).toBeNull();

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -224,6 +224,94 @@ describe("CI changed Node test plan", () => {
     ]);
   });
 
+  it.each([
+    ["src/plugins/contracts/registry.retry.test.ts", "contracts-plugins"],
+    [
+      "src/channels/plugins/contracts/session-binding.registry-backed.contract.test.ts",
+      "contracts-channels",
+    ],
+  ])("leaves covered contract target %s to its dedicated matrix", (target, task) => {
+    const before = createChangedNodeTestShards([target]);
+    const dedicatedContractShards = [{ task, includePatterns: [target] }];
+    expect(createChangedNodeTestShards([target], { dedicatedContractShards })).toEqual(
+      before?.filter((shard) => !shard.targets),
+    );
+    // The same path is still a direct local target; CI coverage is opt-in.
+    expect(buildVitestRunPlans([target]).flatMap((plan) => plan.includePatterns ?? [])).toEqual([
+      target,
+    ]);
+    for (const coverage of [
+      [],
+      [{ task, includePatterns: [] }],
+      [{ task, includePatterns: ["src/plugins/contracts/other.test.ts"] }],
+      [{ task: "unrelated-task", includePatterns: [target] }],
+    ]) {
+      expect(createChangedNodeTestShards([target], { dedicatedContractShards: coverage })).toEqual(
+        before,
+      );
+    }
+  });
+
+  it("keeps uncovered and deleted-path coverage beside a dedicated contract target", () => {
+    const target = "src/plugins/contracts/registry.retry.test.ts";
+    const remaining = [
+      "src/plugin-sdk/config-runtime.test.ts",
+      "src/channels/plugins/config-schema.test.ts",
+      "src/plugins/contracts/deleted.test.ts",
+    ];
+    const options = {
+      dedicatedContractShards: [{ task: "contracts-plugins", includePatterns: [target] }],
+    };
+    expect(createChangedNodeTestShards([target, ...remaining], options)).toEqual(
+      createChangedNodeTestShards(remaining),
+    );
+    expect(createChangedNodeTestShards([target, "src/deleted.ts"], options)).toBeNull();
+    expect(createChangedNodeTestShards([target, "tsconfig.json"], options)).toBeNull();
+  });
+
+  it("requires dedicated config ownership and preserves an empty precise build plan", () => {
+    const cwd = mkdtempSync(path.join(tmpdir(), "openclaw-contract-coverage-"));
+    const target = "src/plugins/contracts/fixture.test.ts";
+    const source = "src/fixture.ts";
+    const unrelated = [
+      "src/plugins/contracts/fixture.e2e.test.ts",
+      "src/channels/plugins/contracts/unowned.test.ts",
+    ];
+    try {
+      for (const file of [target, source, ...unrelated]) {
+        mkdirSync(path.dirname(path.join(cwd, file)), { recursive: true });
+        writeFileSync(
+          path.join(cwd, file),
+          file === target ? 'import "../../fixture.js";\nexport {};\n' : "export {};\n",
+        );
+      }
+      for (const file of unrelated) {
+        const before = createChangedNodeTestShards([file], { cwd });
+        // E2E configs require full-suite metadata; an unknown channel pattern
+        // keeps its exact target rather than claiming dedicated coverage.
+        expect(before?.flatMap((shard) => shard.targets ?? []) ?? null).toEqual(
+          file.endsWith(".e2e.test.ts") ? null : [file],
+        );
+        expect(
+          createChangedNodeTestShards([file], {
+            cwd,
+            dedicatedContractShards: [
+              { task: "contracts-plugins", includePatterns: [file] },
+              { task: "contracts-channels", includePatterns: [file] },
+            ],
+          }),
+        ).toEqual(before);
+      }
+      const dedicatedContractShards = [{ task: "contracts-plugins", includePatterns: [target] }];
+      expect(
+        createChangedNodeTestShards([source], { cwd })?.flatMap((shard) => shard.targets ?? []),
+      ).toEqual([target]);
+      expect(createChangedNodeTestShards([source], { cwd, dedicatedContractShards })).toEqual([]);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
   it("keeps boundary coverage on test-only diffs without the build-artifacts lane", () => {
     // Test-only diffs skip build-artifacts (which hosts the full boundary
     // gate), so the plan carries its own nondist boundary shard instead.

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4049,6 +4049,55 @@ NODE
     expect(workflow.jobs["security-fast"].needs).toBeUndefined();
   });
 
+  it.each([false, true])(
+    "composes dedicated contract coverage before precise planning (build=%s)",
+    (buildImpact) => {
+      const manifest = runCiManifestFixture({
+        bundledPlanner: true,
+        eventName: "pull_request",
+        changedPaths: [buildImpact ? "src/fixture.ts" : "src/plugins/contracts/fixture-a.test.ts"],
+        changedPlannerSource: `
+        export const createChangedNodeTestShards = (_paths, options = {}) => {
+          console.log("dedicated-coverage:" + JSON.stringify(options.dedicatedContractShards ?? null));
+          return ${
+            buildImpact
+              ? "[]"
+              : `[{ checkName: "changed-boundary", shardName: "changed-boundary",
+            configs: ["test/vitest/vitest.boundary.config.ts"], requiresDist: false,
+            runner: "ubuntu-24.04" }]`
+          };
+        };
+        export const createChangedExtensionFallbackShards = () => { throw new Error("Unexpected broad fallback"); };
+        export const hasBuildArtifactAffectingChange = () => ${buildImpact};
+        export const hasSqliteSessionLifecycleAffectingChange = () => false;
+      `,
+      });
+      expect(manifest.status, manifest.output).toBe(0);
+      const dedicated = ["plugin", "channel"].flatMap((family) => {
+        expect(manifest.outputs[`run_${family}_contracts_shards`]).toBe("true");
+        const rows = JSON.parse(
+          expectDefined(manifest.outputs[`${family}_contracts_matrix`], family),
+        ).include;
+        expect(rows).toHaveLength(1);
+        return rows.flatMap((row: { groups: unknown[] }) => row.groups);
+      });
+      expect(dedicated).toHaveLength(4);
+      const coverage = expectDefined(
+        manifest.output.split("\n").find((line) => line.startsWith("dedicated-coverage:")),
+        "precise planner coverage input",
+      );
+      expect(JSON.parse(coverage.slice("dedicated-coverage:".length))).toEqual(dedicated);
+      const nodeRows = JSON.parse(
+        expectDefined(manifest.outputs.checks_node_core_nondist_matrix, "precise matrix"),
+      ).include;
+      expect(nodeRows).toEqual(
+        buildImpact ? [] : [expect.objectContaining({ shard_name: "changed-boundary" })],
+      );
+      expect(manifest.outputs.run_build_artifacts).toBe(String(buildImpact));
+      expect(manifest.outputs.run_checks_node_core_dist).toBe(String(buildImpact));
+    },
+  );
+
   it.each([
     ["push", "blacksmith", false],
     ["pull_request", "github", false],

--- a/test/scripts/plain-gh.test.ts
+++ b/test/scripts/plain-gh.test.ts
@@ -359,7 +359,8 @@ describe("plain gh subprocess contracts", () => {
         killSignal: "SIGKILL" as const,
       };
       const output = execute(["--version"], options);
-      expect(output).toEqual(Buffer.alloc(2 * 1024 * 1024, 0xff));
+      expect(Buffer.isBuffer(output)).toBe(true);
+      expect(Buffer.alloc(2 * 1024 * 1024, 0xff).equals(output)).toBe(true);
       expect(() => execute(["--version"], { ...options, maxBuffer: 1024 })).toThrow(
         expect.objectContaining({ code: "ENOBUFS" }),
       );
@@ -370,7 +371,7 @@ describe("plain gh subprocess contracts", () => {
       } finally {
         closeSync(fd);
       }
-      expect(readFileSync(destination)).toEqual(output);
+      expect(readFileSync(destination).equals(output)).toBe(true);
     },
   );
 

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1432,6 +1432,7 @@ describe("scripts/test-projects changed-target routing", () => {
   it("routes shared contract ownership and declarations through every affected lane", () => {
     const targets = [
       "test/scripts/test-projects.test.ts",
+      "test/vitest-projects-config.test.ts",
       "test/vitest/vitest.contracts-channel-surface.config.ts",
       "test/vitest/vitest.contracts-channel-config.config.ts",
       "test/vitest/vitest.contracts-channel-registry.config.ts",

--- a/test/vitest/vitest.contracts-paths.d.mts
+++ b/test/vitest/vitest.contracts-paths.d.mts
@@ -2,3 +2,4 @@ export const channelSurfaceContractPatterns: string[];
 export const channelConfigContractPatterns: string[];
 export const channelRegistryContractPatterns: string[];
 export const channelSessionContractPatterns: string[];
+export const pluginContractPatterns: string[];

--- a/test/vitest/vitest.contracts-paths.mjs
+++ b/test/vitest/vitest.contracts-paths.mjs
@@ -36,3 +36,5 @@ export const channelSessionContractPatterns = [
   "src/channels/plugins/contracts/*-shard-d.contract.test.ts",
   "src/channels/plugins/contracts/*-shard-h.contract.test.ts",
 ];
+
+export const pluginContractPatterns = ["src/plugins/contracts/**/*.test.ts"];

--- a/test/vitest/vitest.contracts-shared.ts
+++ b/test/vitest/vitest.contracts-shared.ts
@@ -5,6 +5,7 @@ import {
   channelRegistryContractPatterns,
   channelSessionContractPatterns,
   channelSurfaceContractPatterns,
+  pluginContractPatterns,
 } from "./vitest.contracts-paths.mjs";
 import {
   intersectIncludePatterns,
@@ -18,12 +19,11 @@ export {
   channelRegistryContractPatterns,
   channelSessionContractPatterns,
   channelSurfaceContractPatterns,
+  pluginContractPatterns,
 };
 
 const base = sharedVitestConfig as Record<string, unknown>;
 const baseTest = sharedVitestConfig.test ?? {};
-
-export const pluginContractPatterns = ["src/plugins/contracts/**/*.test.ts"];
 
 export function createContractsVitestConfig(
   includePatterns: string[],


### PR DESCRIPTION
## What Problem This Solves

CI treated public-contract test edits like broad runtime changes and could run the same contract test in both the Node and dedicated contract matrices. Two binary-output tests also spent most of their time deeply traversing multi-megabyte buffers. This removes redundant work while retaining the actual test contracts.

The broad CI run exposed a separate integration regression: after hot-reloading a node command denial, Session host selection said the command was awaiting pairing approval. The corrected state keeps that existing real-Gateway regression test useful.

## Why This Change Was Made

Executable test/spec leaves under SDK and contract directories now follow the existing test classifier. Helpers, suites, public runtime contracts, metadata, mixed source changes and unresolved import impact keep conservative coverage. CI constructs its enabled plugin/channel contract envelopes once and passes those exact envelopes to the precise Node planner. Only targets covered by every canonical plan and a matching enabled dedicated envelope are removed from Node. Filtering happens after all-path proof; empty precise plans retain the build-artifacts boundary owner. Changes to the shared contract-pattern module and its declarations also select the existing full-suite ownership audit, which detects missing and multiply owned plugin tests.

The branch removed the misbound agent-exec construction-timeout case from #136507. While CI was running, #137157 independently landed the same removal and repaired the registered-process readiness proof; the final merge retains that upstream deletion and adds timeout forwarding to an existing command assertion. Its Anthropic SDK backend bypasses the supervisor it claims to exercise; the early PID wait races bootstrap and cannot distinguish the version probe from execution. It took 66.121 seconds and failed in the retained reproduction. Both supervisor construction deadlines, late-adapter cleanup, the real blocked-secret child regression, cancellation composition, timeout JSON/exit status and built CLI integration tests remain. Timeout forwarding shares an existing command assertion.

Keep both binary subprocess cases, their 2 MiB payloads, buffer limits, streamed writes and cleanup, but compare complete bytes with native Buffer equality and explicitly assert the output kind. No decoding, truncation, new helper or subprocess removal.

For the Gateway regression, the registry already records commands withheld by policy. The shared command-state resolver now uses that authoritative fact before reporting pending pairing. The existing denial/restoration test verifies revoked, restored and genuinely unapproved commands. The browser test retains its state and visible-guidance assertions, uses canonical hybrid reload mode, and proves the node stays connected instead of waiting for an obsolete restart.

## User Impact

Developers avoid duplicate contract execution and expensive assertion overhead. Session host selection gives the correct next action after a live command-policy denial. This changes guidance, with no broader execution grant, new configuration or persistence surface.

The user target is eight minutes with fewer shards. Replaying #137205's test-only cleanup selects two precise Node rows rather than the earlier 86-row broad plan. This PR touches CI ownership sources, so its own validation intentionally remains broad. Planner counts are not measured end-to-end savings.

## Evidence

- Classifier: nine intended pre-fix failures; 25 focused and 377 complete owner cases passed.
- Dedicated contract ownership: six intended pre-fix failures; 14 focused and 15 existing sibling cases passed, including executable workflow composition, empty precise plans, frozen/full flows, config intersections, complete partitions and serial failure handling.
- Command cleanup: all 53 remaining agent-exec cases plus 29 existing supervisor/relay/cancellation cases passed. Command owner: 11.61 seconds; combined canonical proof: 30.79 seconds.
- Binary assertions: identical 33-case inventories passed before and after, with fixture cleanup. Two binary cases fell from 9.903 seconds to 0.196 seconds; complete wrapper time fell from 14.652 seconds to 3.950 seconds. This is one local before/after comparison, not a whole-CI timing claim.
- Gateway: the existing registered-node test reproduced the incorrect pending state before the fix; all 64 cases across registry policy, platform/pairing policy and environments RPC tests passed afterward. Deny/restore uses the same connection and pairing generation, and an unapproved declaration stays pending.
- Formatting, workflow actionlint/offline zizmor, selected policy/boundary guards and core typecheck passed. The changed Gateway test graph, test-root typecheck and all changed-file lints passed. The full local core-test typecheck terminated with exit 137; subsequent current-head CI passed the full type checks. The local browser build hit a stale linked AI package missing `isAnthropicServerToolClearingEnabled`; no dependency reconciliation or guard bypass was used.
- Shared-pattern audit routing: the existing mapping case fails before the correction and passes afterward; all 455 cases in the changed-target and Vitest ownership suites pass, with no skips. No new test case was added.
- Managed reviews cover the original change at the normal P0 threshold and the final review fixes through P2. The original eleven-file patch and 32 context owners remain byte-identical across the necessary rebase. The current head passed all selected CI and the required aggregate.

[CI on the runtime/test cleanup revision](https://github.com/openclaw/openclaw/actions/runs/33747183683) passed 142 jobs with 9 intentional skips, including all 86 Node jobs, both Windows suites and all 19 real-Gateway browser cases. The repaired command-state case passed in 19.392 seconds. Non-Windows work finished in 18m14s; the aggregate finished in 18m21s. Preflight waited 3m56s before a 42-second execution, and the final Node jobs waited another 8m14s after matrix creation. These timings do not establish the eight-minute target. The subsequent two-line ownership-audit correction also passed its own full CI gate.

[Final-head CI at `0f49ffb`](https://github.com/openclaw/openclaw/actions/runs/33750116253) passed 141 jobs with 10 intentional skips: all 86 Node jobs, both Windows suites, UI, real-Gateway, Docker and the required gate. Non-Windows work finished in **21m41s**, and the aggregate in **21m47s**. Preflight checkout consumed 325 seconds; the final Node job waited 8m31s after matrix creation, then ran for 7m17s. These delays are observed; the logs do not establish their provider cause. The eight-minute target remains open. Repository-native preparation accepted this exact green head without a rebase or additional push.

Runtime code: +5 net lines to consume the existing policy-denial fact; CI/tooling: +38; shared test configuration: +3; tests: +210 in the final parent-relative merge (+140 on the original branch, before the overlapping 70-line deletion landed in #137157). The manual changelog line was removed under the repository release-generation policy; the user-facing release-note context remains above. The remaining built agent-exec harness and registered process-CLI tests cover distinct integration paths; the removed SDK case never provided literal agentExec-to-service-relay construction-timeout coverage. Runner sizing, concurrency, trust rules and test variants remain unchanged.

## Review Follow-through

Both P2 findings from the earlier ClawSweeper review are addressed: shared pattern/declaration changes select `test/vitest-projects-config.test.ts`, and this PR no longer edits release-owned `CHANGELOG.md`. The native [real-Gateway Chromium job](https://github.com/openclaw/openclaw/actions/runs/33747183683/job/100623577667) verifies post-reload unauthorized guidance while the node stays connected. A separate recording is not attached: this changes the shared state resolver, with unchanged UI components, and ordinary PR runs do not publish the manual `capture_ui_proof` media artifacts. The retained real-browser assertions supply the behavioral proof. The latest ClawSweeper review on the final head reports no findings; its remaining rank-up move was successful exact-head CI, now complete.

Landed as [51fe03b61727](https://github.com/openclaw/openclaw/commit/51fe03b61727cb890d442d7c0a6eef044c58da4f). Post-merge verification on current `main` confirms the command test file exactly matches the reviewed head; the only patch-identity difference is the already-landed deletion from #137157.
