### PR TITLE
docs: bundle memory operations skill

### DIFF
--- a/skills/memory-ops/SKILL.md
+++ b/skills/memory-ops/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: memory-ops
+description: "Operate OpenClaw memory on the default memory-core path: recall with memory_search and memory_get, write notes to the right file, diagnose an empty or keyword-only index, and preview before running memory forget."
+---
+
+# Memory operations
+
+Use OpenClaw's memory tools for recall and the `openclaw memory` CLI for index
+and deletion work. Read and preview before changing anything.
+
+## Mental model
+
+- Memory is files in the agent workspace plus an index over them. There is no
+  hidden state; the agent remembers only what reaches disk.
+- `MEMORY.md` and `USER.md` are the curated bootstrap layer. They load at
+  session start and stay evergreen in ranking.
+- `memory/YYYY-MM-DD.md` and `memory/YYYY-MM-DD-<slug>.md` are the working
+  layer. They are indexed for search but not injected every turn, and they
+  decay in ranking with a 30-day half-life.
+- Imported notes under `memory/imports/*` are indexed, not merged into
+  `MEMORY.md`.
+- `memory_search` finds notes. `memory_get` reads an exact excerpt. Neither
+  writes memory.
+- The CLI owns index health (`status`, `index`), promotion (`promote`), and
+  deletion (`forget`). `forget` is the only destructive command here.
+- Dreaming promotes material from daily notes into `MEMORY.md` in the
+  background. Direct edits to `MEMORY.md` are allowed but bypass its scoring.
+
+If the `memory-wiki` plugin is active, its `wiki-maintainer` skill owns the
+vault. Use `corpus: "all"` for one recall pass across memory and wiki, and
+leave wiki page edits to that skill.
+
+## Recall before you answer
+
+Before answering about prior work, decisions, dates, people, preferences, or
+todos:
+
+1. Call `memory_search` with a natural-language `query`. Hybrid search matches
+   meaning and exact terms, so include identifiers, error strings, and config
+   keys verbatim.
+2. Read only the lines you need with `memory_get` (`path`, optional `from` and
+   `lines`). Do not re-read whole files into context.
+3. Surface a corpus warning to the user. It means results are partial.
+4. Cite `Source: <path#line>` when citations are enabled and it helps the user
+   verify a snippet.
+
+Trigger recall injects at most three trusted entries from `MEMORY.md` and
+`USER.md` automatically. Daily notes, imports, and transcripts never inject; an
+explicit `memory_search` is the only way to reach them.
+
+For exact quotes from earlier conversations use `sessions_search`, then open
+the hit with `sessions_history`. `memory_search` covers transcripts only when
+`experimental.sessionMemory` is on and `"sessions"` is in the configured
+sources.
+
+Read [recall.md](references/recall.md) for parameters, corpus scoping, and
+what an empty result means.
+
+## Write to the right place
+
+- A durable non-profile fact or standing decision goes in `MEMORY.md`, as a
+  short entry, not a log line.
+- A stable preference or profile fact goes in `USER.md` as an imperative
+  directive. Supersede a changed preference in place instead of appending a
+  contradiction.
+- Running context, observations, and session summaries go in today's
+  `memory/YYYY-MM-DD.md`.
+- Do not create ad hoc note files elsewhere in the workspace. They are not
+  indexed unless `memory.search.extraPaths` names them.
+- When a note changes future behavior, record when it applies, when it expires,
+  what to avoid, and who the source is. Memory preserves that context; it does
+  not enforce it. Use approvals, sandboxing, or scheduled tasks for hard
+  controls, and scheduled tasks for time-based reminders.
+
+If `MEMORY.md` is reported truncated in context, move detail into
+`memory/*.md` and keep a summary. Check with `/context list` or
+`openclaw doctor`.
+
+## Diagnose recall
+
+| Symptom                       | Check                                 | Fix                                            |
+| ----------------------------- | ------------------------------------- | ---------------------------------------------- |
+| No results at all             | `openclaw memory status --agent <id>` | `openclaw memory index --force --agent <id>`   |
+| Only keyword matches          | `openclaw memory status --deep`       | Configure `memory.search.provider` or its key  |
+| Memory reported unavailable   | `status --deep` provider probe        | Fix the named provider; `none` for FTS-only    |
+| Dreaming line stays `off`     | Default agent heartbeat               | See the dreaming doc; the cron rides heartbeat |
+| Index says its source changed | A purge or edit ran during indexing   | Rerun `openclaw memory index --agent <id>`     |
+
+Pass `--agent` explicitly. Without it, `status` and `index` run for every
+configured agent.
+
+## Delete safely
+
+`openclaw memory forget` deletes immediately unless `--dry-run` is set. There
+is no confirmation prompt and no `--apply` flag. Always:
+
+1. Resolve the exact session ID or key with `openclaw sessions --agent <id>
+--limit all --json`. IDs are exact and case-sensitive; an abbreviation
+   selects nothing.
+2. Run the same selectors with `--dry-run --json` and read
+   `sessionResolutions`, `entryKeys`, `mixedLineageEntryKeys`, and `refusals`.
+3. Repeat without `--dry-run` only after the user confirms the selection.
+4. Run the preview again and report what remains.
+
+Selectors pick sessions, never individual facts. An entry with mixed lineage
+is removed whole. Transcripts, freeform edits, paraphrases, other agents'
+stores, and untracked older entries are outside this cleanup. Do not claim
+that information is erased; report the counters.
+
+Admission policy is a different control. It keeps future sessions out of
+dreaming ingestion and backfill and does not remove existing data.
+
+Read [forget.md](references/forget.md) before any deletion or exclusion work.

--- a/skills/memory-ops/references/forget.md
+++ b/skills/memory-ops/references/forget.md
@@ -1,0 +1,103 @@
+# Deletion and admission
+
+Both controls belong to the bundled `memory-core` plugin. Other memory plugins
+expose different commands.
+
+## Preview, apply, re-preview
+
+```bash
+openclaw sessions --agent <agent-id> --limit all --json
+openclaw memory forget --agent <agent-id> --session <id-or-key> --dry-run --json
+openclaw memory forget --agent <agent-id> --session <id-or-key> --json
+openclaw memory forget --agent <agent-id> --session <id-or-key> --dry-run --json
+```
+
+- `--agent` defaults to the default agent, not all agents. Name it.
+- At least one selector is required. `--session`, `--hook-source`, and
+  `--participant` are repeatable and combine with OR. `--since <ISO date>`
+  narrows by session creation time.
+- Selectors match recorded identifiers. `--participant` matches a raw actor
+  ID and selects the whole session, including other people's messages.
+  `--hook-source` is exact: `email` for IMAP, `gmail` for Gmail hooks,
+  `webhook` for generic webhooks.
+- The preview is computed from current state, not saved as a plan. Pause
+  direct agent edits and external writers during a sensitive cleanup; they do
+  not share the plugin's mutation lock.
+
+## Read the report
+
+| Field                   | Check                                                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `sessionResolutions`    | Each value resolved `live` or `archived`. `unresolved` means the ID was recorded for exclusion, not that it was found. |
+| `participantMatches`    | Typed identities matched by a raw participant ID; ambiguous matches need review.                                       |
+| `entryKeys`             | Tracked entries with an origin in the selected sessions.                                                               |
+| `mixedLineageEntryKeys` | Entries that also have unselected origins. They are removed whole.                                                     |
+| `untargetableEntryKeys` | Promotion markers with no origin rows. Not selectable by lineage.                                                      |
+| `curatedWrites`         | Files to review by hand. The record does not delete anything.                                                          |
+| `artifacts`             | Counts of files, entries, lines, index chunks, and store rows.                                                         |
+| `refusals`              | Historical highlights needing manual review.                                                                           |
+
+An empty preview means those selectors found nothing more. It is not proof
+that no related information remains.
+
+## What stays after a purge
+
+- Original transcripts and archives. Session deletion is a separate command
+  and ordinarily keeps a deleted-transcript archive.
+- Older entries without origin rows.
+- Freeform edits and arbitrary shell writes. `curatedWrites` points at files
+  to inspect.
+- Paraphrases, exports, external backups, and other plugins' stores.
+- Other agents' stores. Repeat the preview per agent, including agents that
+  share a workspace.
+
+Report these boundaries when the user asks for erasure.
+
+## Purged sessions stay purged
+
+A real purge records each selected session as forgotten in that agent's
+SQLite store before removing artifacts. Dreaming ingestion, session backfill,
+and `memory index --force` all check those records. Repeating the purge does
+not lift the exclusion, and removing an admission rule does not undo it. It
+applies to those session IDs only, not to future conversations with the same
+person or source.
+
+## If a purge fails
+
+Cleanup is not one transaction. Resolve the reported storage or filesystem
+error, rerun the same command with the same selectors, then run `--dry-run`
+again. Do not delete corpus or origin records by hand; the retry needs them to
+find remaining artifacts. If an index run reports that its source changed,
+rerun `openclaw memory index --agent <agent-id>`.
+
+## Admission policy
+
+Admission excludes future sessions from dreaming ingestion and
+`session-backfill`. It does not touch raw transcript indexing, direct writes,
+session hooks, or existing memory.
+
+```json5
+{
+  plugins: {
+    entries: {
+      "memory-core": {
+        config: {
+          memoryPolicy: {
+            excludeSessions: {
+              hookExternalContentSources: ["gmail", "email"],
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Values match recorded session metadata, not words in a conversation. A
+session missing that metadata does not match; select it by full ID. An
+excluded session can still edit `MEMORY.md` or `USER.md` if its tools allow
+it; admission is not a filesystem permission.
+
+Pair the two controls: `forget` for what already exists, an admission rule
+for what should stay out from now on.

--- a/skills/memory-ops/references/recall.md
+++ b/skills/memory-ops/references/recall.md
@@ -1,0 +1,91 @@
+# Recall operations
+
+## Tool parameters
+
+`memory_search`
+
+| Field        | Type    | Notes                                                        |
+| ------------ | ------- | ------------------------------------------------------------ |
+| `query`      | string  | Required. Natural language plus exact identifiers.           |
+| `maxResults` | integer | Optional cap; keep it small and call again with a new query. |
+| `minScore`   | number  | Optional floor; raise it when results are noisy.             |
+| `corpus`     | string  | `memory` (default), `wiki`, `all`, or `sessions`.            |
+
+`memory_get`
+
+| Field    | Type    | Notes                                                   |
+| -------- | ------- | ------------------------------------------------------- |
+| `path`   | string  | Required. Workspace-relative path from a search result. |
+| `from`   | integer | First line, 1-based.                                    |
+| `lines`  | integer | Line count. Omitted means a bounded excerpt.            |
+| `corpus` | string  | `memory` (default), `wiki`, or `all`.                   |
+
+`memory_get` returns `status: "ok"` when the excerpt was read and
+`status: "not_found"` when every requested available corpus missed. It reports
+truncation and continuation when more content exists, so page with `from`
+instead of raising `lines`.
+
+## How ranking behaves
+
+- Vector similarity and BM25 keyword search run in parallel and merge. If only
+  one path is available, the other runs alone.
+- Score = hybrid relevance × recency decay × importance. Dated daily notes
+  decay with a 30-day half-life. `MEMORY.md`, `USER.md`, and undated files
+  under `memory/` do not decay.
+- Filenames are indexed separately. An exact path or stem outranks a partial
+  match, so searching a known filename is reliable.
+- MMR reorders results to reduce near-duplicate snippets. It does not change
+  scores.
+
+A result that looks stale but relevant is usually recency decay. Search again
+with the identifier the note contains, or read the file with `memory_get`.
+
+## Corpus scoping
+
+- `memory`: workspace memory files, imports, and configured extra paths.
+- `wiki`: pages registered by the `memory-wiki` plugin.
+- `all`: one pass across memory and wiki. Use it when the wiki plugin is on.
+- `sessions`: indexed transcripts. Requires `experimental.sessionMemory: true`
+  and `"sessions"` in `memory.search.sources`; hits obey
+  `tools.sessions.visibility` and can include other users' conversations.
+
+A corpus warning in the result means that corpus was unavailable or partial.
+Tell the user instead of treating the answer as complete.
+
+## What an empty result means
+
+1. Nothing indexed: `openclaw memory status --agent <id>` shows the index
+   size. Run `openclaw memory index --force --agent <id>` if it is empty or
+   dirty. An empty corpus indexes as a successful no-op.
+2. Keyword-only mode: `openclaw memory status --deep --agent <id>` probes the
+   embedding provider. With `provider` unset, `auto`, or `local`, a failed
+   embedding setup falls back to keyword search silently. Search for the
+   exact words the note used.
+3. Explicit provider down: when `memory.search.provider` names a provider and
+   it fails, `memory_search` reports memory unavailable instead of degrading.
+   Fix the provider or key. Set `provider: "none"` only for deliberate
+   keyword-only recall.
+4. The note was never written. Ask the user, then write it to the correct
+   file so the next session finds it.
+
+## Active Memory
+
+In the default `escalate` mode a blocking recall sub-agent runs only when the
+message asks about the past and the deterministic lane found no strong hit.
+It can call only the configured memory recall tools. If it fails, the turn
+continues without memory context. Do not depend on it; an explicit
+`memory_search` is the reliable path.
+
+## Promotion
+
+Dreaming promotes daily-note material into `MEMORY.md` through score,
+recall-frequency, and query-diversity gates. To inspect or run it by hand:
+
+```bash
+openclaw memory promote --agent <id>                 # preview candidates
+openclaw memory promote-explain <selector> --agent <id>
+openclaw memory promote --agent <id> --apply         # append selected entries
+```
+
+Promotion re-reads the live daily note before writing, so edit or delete a
+short-term snippet first when a candidate should not graduate.


### PR DESCRIPTION
Closes #137221

## What Problem This Solves

Agents on the default `memory-core` path have no bundled workflow that joins the memory file model, the `memory_search`/`memory_get` contracts, index diagnosis, and the `openclaw memory forget` deletion path. The contracts are spread across seven docs pages. Agents answer from context without recall, write notes to unindexed files, read keyword-only fallback as an empty memory, and can run `memory forget` without a preview even though it deletes immediately and records sessions as forgotten.

## Why This Change Was Made

This adds a core-owned `memory-ops` skill with focused references for recall and deletion. It uses the current tool parameters (`query`, `maxResults`, `minScore`, `corpus`; `path`, `from`, `lines`, `corpus`), the documented ranking and fallback behavior, and the preview, apply, re-preview sequence for `memory forget` with the report fields to check and the documented deletion boundaries. It distinguishes admission policy from deletion and defers to the `memory-wiki` plugin's `wiki-maintainer` skill when that plugin is active.

Bundling is intentional: the skill teaches first-party tools and a destructive first-party command whose semantics change with core. The `memory-wiki` plugin already ships operating skills for its layer; the default path shipped none.

## User Impact

Agents recall before answering, write to the file that will be indexed and bootstrapped, diagnose an empty or keyword-only index instead of guessing, and never apply a purge without a reviewed `--dry-run` report. No runtime or UI behavior change.

## Evidence

- `python3 skills/skill-creator/scripts/quick_validate.py skills/memory-ops` — valid
- `python3 skills/skill-creator/scripts/package_skill.py skills/memory-ops /tmp/memory-ops-pkg` — packaged all three files
- `pnpm check:changed -- skills/memory-ops/SKILL.md skills/memory-ops/references/recall.md skills/memory-ops/references/forget.md` — passed after `oxfmt`
- `python -m ruff check --config skills/pyproject.toml skills` — passed
- `python -m pytest -q -c skills/pyproject.toml skills` — 28 passed
- Live catalog proof on an isolated Gateway state dir (`OPENCLAW_STATE_DIR=/tmp/oc-memops-state`, `OPENCLAW_BUNDLED_SKILLS_DIR=<branch>/skills`):

```
$ openclaw skills list
│ ✓ ready │ control-ui │ Operate and troubleshoot the OpenClaw Control UI: … │ openclaw-bundled │
│ ✓ ready │ memory-ops │ Operate OpenClaw memory on the default memory-core … │ openclaw-bundled │

$ openclaw skills info memory-ops
memory-ops ✓ Ready
  Source: openclaw-bundled
  Visible to model: yes
  Available as command: yes
```

- Reviewed against `docs/concepts/memory.md`, `memory-search.md`, `memory-builtin.md`, `memory-provenance.md`, `active-memory.md`, `docs/cli/memory.md`, `docs/reference/memory-config.md`, and `extensions/memory-core/src/memory-tool-contract.ts`.

Screenshots are not applicable; this is a bundled skill with no rendered UI change. AI-assisted.
