### PR TITLE
fix(auto-reply): agents that deliberately reply silently are reported as fallback failures

### DIFF
--- a/src/auto-reply/reply/agent-runner-core.test.ts
+++ b/src/auto-reply/reply/agent-runner-core.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { resolveFallbackTransition } from "../fallback-state.js";
 import type { TemplateContext } from "../templating.js";
 import {
-  buildSilentFallbackFailurePayload,
   resolveAdmittedRunSessionFile,
   resolveReplyRunDeliveryContext,
 } from "./agent-runner-core.js";
@@ -60,33 +58,5 @@ describe("resolveReplyRunDeliveryContext", () => {
       accountId: "work",
       threadId,
     });
-  });
-});
-
-describe("buildSilentFallbackFailurePayload", () => {
-  const fallbackTransition = resolveFallbackTransition({
-    selectedProvider: "openai",
-    selectedModel: "gpt-5.6-luna",
-    activeProvider: "xai",
-    activeModel: "grok-4.6",
-    attempts: [],
-  });
-  const baseParams = {
-    fallbackTransition,
-    fallbackFailureKnown: true,
-    isHeartbeat: false,
-    hasSuccessfulTerminalDelivery: false,
-  };
-
-  it("warns when the fallback ran and produced nothing", () => {
-    expect(buildSilentFallbackFailurePayload(baseParams)?.text).toContain(
-      "produced no visible reply",
-    );
-  });
-
-  it("stays quiet when the agent deliberately replied silently", () => {
-    expect(
-      buildSilentFallbackFailurePayload({ ...baseParams, hasExplicitSilentReply: true }),
-    ).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/agent-runner-core.test.ts
+++ b/src/auto-reply/reply/agent-runner-core.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { resolveFallbackTransition } from "../fallback-state.js";
 import type { TemplateContext } from "../templating.js";
 import {
+  buildSilentFallbackFailurePayload,
   resolveAdmittedRunSessionFile,
   resolveReplyRunDeliveryContext,
 } from "./agent-runner-core.js";
@@ -58,5 +60,33 @@ describe("resolveReplyRunDeliveryContext", () => {
       accountId: "work",
       threadId,
     });
+  });
+});
+
+describe("buildSilentFallbackFailurePayload", () => {
+  const fallbackTransition = resolveFallbackTransition({
+    selectedProvider: "openai",
+    selectedModel: "gpt-5.6-luna",
+    activeProvider: "xai",
+    activeModel: "grok-4.6",
+    attempts: [],
+  });
+  const baseParams = {
+    fallbackTransition,
+    fallbackFailureKnown: true,
+    isHeartbeat: false,
+    hasSuccessfulTerminalDelivery: false,
+  };
+
+  it("warns when the fallback ran and produced nothing", () => {
+    expect(buildSilentFallbackFailurePayload(baseParams)?.text).toContain(
+      "produced no visible reply",
+    );
+  });
+
+  it("stays quiet when the agent deliberately replied silently", () => {
+    expect(
+      buildSilentFallbackFailurePayload({ ...baseParams, hasExplicitSilentReply: true }),
+    ).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -82,11 +82,13 @@ export function buildSilentFallbackFailurePayload(params: {
   hasSuccessfulTerminalDelivery: boolean;
   allowEmptyAssistantReplyAsSilent?: boolean;
   silentExpected?: boolean;
+  hasExplicitSilentReply?: boolean;
 }): ReplyPayload | undefined {
   if (
     params.isHeartbeat ||
     params.allowEmptyAssistantReplyAsSilent === true ||
     params.silentExpected === true ||
+    params.hasExplicitSilentReply === true ||
     params.hasSuccessfulTerminalDelivery ||
     !params.fallbackTransition.fallbackActive ||
     !params.fallbackFailureKnown

--- a/src/auto-reply/reply/agent-runner-result-accounting.persistence.test.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.persistence.test.ts
@@ -300,6 +300,47 @@ it("accounts a completed compaction before an empty heartbeat skips reply prepar
   expect(fixture.read()?.pendingFinalDelivery).toBeUndefined();
 });
 
+it.each(["NO_REPLY", "hook_block", "empty"] as const)(
+  "finalizes a %s fallback without confusing deliberate silence with failure",
+  async (completion) => {
+    const fixture = await createFixture();
+    const { context } = fixture;
+    const onAgentRunTerminalOutcome = vi.fn();
+    context.opts = { onAgentRunTerminalOutcome };
+    context.execution.resolved = { provider: "fallback-provider", model: "fallback-model" };
+    context.execution.fallback.attempts = [
+      { provider: diagnostic.provider, model: diagnostic.model, reason: "auth", error: "No login" },
+    ];
+    context.execution.result.payloads = [];
+    if (completion === "NO_REPLY") {
+      context.execution.result.meta.finalAssistantRawText = "NO_REPLY";
+    } else if (completion === "hook_block") {
+      context.execution.result.meta.error = { kind: "hook_block", message: "Reply suppressed" };
+    }
+
+    const result = await finalizeReplyAgentRun(context);
+    context.replyOperation.complete();
+
+    if (completion === "empty") {
+      expect(result).toMatchObject({
+        isError: true,
+        text: expect.stringContaining("produced no visible reply"),
+      });
+      expect(context.replyOperation.result).toMatchObject({ kind: "failed", code: "run_failed" });
+      expect(onAgentRunTerminalOutcome).toHaveBeenCalledWith("failed");
+    } else {
+      expect(result).toBeUndefined();
+      expect(context.replyOperation.result).toEqual({ kind: "completed" });
+      expect(onAgentRunTerminalOutcome).not.toHaveBeenCalledWith("failed");
+    }
+    expect(fixture.read()?.fallbackNotice).toMatchObject({
+      kind: "active",
+      activeModel: "fallback-provider/fallback-model",
+    });
+    expect(fixture.read()?.pendingFinalDelivery).toBeUndefined();
+  },
+);
+
 describe("cancelled followup compaction accounting", () => {
   it.each(["user", "restart"] as const)(
     "retains committed compaction facts after %s abort without success bookkeeping",

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -303,6 +303,7 @@ export async function prepareReplyAgentPayloads(state: {
       hasSuccessfulTerminalDelivery: successfulTerminalDelivery,
       allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
       silentExpected: followupRun.run.silentExpected,
+      hasExplicitSilentReply: deliberateSilentTerminalReply,
     });
     if (!silentFallbackFailurePayload) {
       return undefined;


### PR DESCRIPTION
## What Problem This Solves

A fallback model can complete successfully with `NO_REPLY`, yet the reply finalizer sends a visible failure notice and records the turn as failed.

## Why This Change Was Made

The result classifier already recognizes deliberate silence, including `NO_REPLY` and `hook_block`. The finalizer passes that fact to its empty-reply and yield builders, but omitted it from the fallback-warning builder.

This change passes the same fact to that builder. It preserves genuine failure notices and does not change fallback selection.

## User Impact

An intentionally silent fallback stays silent and completes successfully. Ordinary fallback replies and real failures remain visible.

## Evidence

Real Telegram Test Server direct messages were driven through normal Telegram ingress and an isolated source Gateway. The primary was configured without its required OpenRouter credential. The configured fallback used the real Claude CLI backend, not a mock provider. Neither `silentExpected` nor `allowEmptyAssistantReplyAsSilent` was set.

- Baseline main: `8849e7073e193bf0d69652f7439e7d4c9df56bd2`.
- Product-proof head: `bfd3082abcbea082dc4350ba330ed7b42e1d26a2`.
- CI-refresh head: `82ada634326ec0edd5352a6c4029e069cfa09c30`, with the identical source tree `07331c77aedadb43a2174426c7f09798a75c1f35`. This empty commit requests fresh merge validation after main repaired the unrelated memory-test setup. It does not claim a new execution of the product proof.

| Scenario | Main | Candidate |
| --- | --- | --- |
| Primary auth failure, real fallback returns `NO_REPLY` | Telegram receives “produced no visible reply”; dispatch records `outcome=error` | No failure message; dispatch records `outcome=completed` |
| Real fallback returns ordinary text | Not repeated | `FALLBACK_TEXT_CONTROL` delivered |
| Real fallback provider rejects an unavailable model | Not repeated | Provider returns HTTP 404 with `is_error=true`; Telegram receives a failure notice |
| Working model selected directly, returns `NO_REPLY` | Not repeated | Successful silent completion; transient progress message deleted |

For both silent-fallback runs, the raw provider stream contains `result: "NO_REPLY"`, `is_error: false`, and `terminal_reason: "completed"`. The persisted assistant transcript also contains `NO_REPLY`. Structured fallback events confirm the primary failure and the configured fallback's successful second attempt. No message tool delivered the answer.

The candidate recording starts with the silent turn. At 16 seconds, a new prompt requests ordinary fallback text, which arrives at 17.4 seconds. This input variation checks that the repair does not suppress all fallback replies. A separate real-provider failure run returns HTTP 404 and sends its error notice at 3.5 seconds.

<details>
<summary>Redacted Telegram event and provider-result excerpts</summary>

These are selected fields from the retained real runs, not mock responses or a new execution. Telegram times are elapsed milliseconds within each recording. Gateway times retain their recorded UTC offset. Account, chat, message, session, request, model, host, and filesystem identifiers are omitted. Bracketed text marks a redaction.

**Main silent fallback — baseline `8849e707`:**

```json
{"telegram":{"elapsedMs":48,"kind":"action","actionType":"send","status":"completed","text":"Use no tools. For this turn, return exactly NO_REPLY and nothing else."}}
{"gateway":{"time":"2026-09-04T11:50:04.359+02:00","decision":"candidate_failed","candidateRouteOrigin":"requested","attempt":1,"total":2,"reason":"auth","status":401}}
{"provider":{"time":"2026-09-04T11:50:08.127+02:00","type":"result","subtype":"success","is_error":false,"terminal_reason":"completed","result":"NO_REPLY"}}
{"gateway":{"time":"2026-09-04T11:50:08.397+02:00","decision":"candidate_succeeded","candidateRouteOrigin":"configured-fallback","attempt":2,"total":2}}
{"gateway":{"time":"2026-09-04T11:50:08.432+02:00","outcome":"error","duration":"4890ms"}}
{"telegram":{"elapsedMs":5896,"kind":"message","isSut":true,"text":"⚠️ I couldn't reach the configured model backend [redacted]. Fallback used [redacted], but it produced no visible reply."}}
```

**Candidate silent fallback — product-proof head `bfd3082`:**

```json
{"telegram":{"elapsedMs":62,"kind":"action","actionType":"send","status":"completed","text":"Use no tools. For this turn, return exactly NO_REPLY and nothing else."}}
{"gateway":{"time":"2026-09-04T11:59:26.635+02:00","decision":"candidate_failed","candidateRouteOrigin":"requested","attempt":1,"total":2,"reason":"auth","status":401}}
{"provider":{"time":"2026-09-04T11:59:30.270+02:00","type":"result","subtype":"success","is_error":false,"terminal_reason":"completed","result":"NO_REPLY"}}
{"gateway":{"time":"2026-09-04T11:59:30.541+02:00","decision":"candidate_succeeded","candidateRouteOrigin":"configured-fallback","attempt":2,"total":2}}
{"gateway":{"time":"2026-09-04T11:59:30.575+02:00","outcome":"completed","duration":"5071ms"}}
```

The complete Telegram timeline between this send and the next send at `elapsedMs=16039` contains only two bot typing events (`353` and `10400`), with no bot message, edit, or failure notice. The persisted assistant message is `{"role":"assistant","content":[{"type":"text","text":"NO_REPLY"}],"stopReason":"stop"}`.

**Ordinary fallback text — same candidate recording:**

```json
{"telegram":{"elapsedMs":16039,"kind":"action","actionType":"send","status":"completed","text":"Use no tools. For this new turn, return exactly FALLBACK_TEXT_CONTROL and nothing else."}}
{"provider":{"time":"2026-09-04T11:59:42.247+02:00","type":"result","subtype":"success","is_error":false,"terminal_reason":"completed","result":"FALLBACK_TEXT_CONTROL"}}
{"gateway":{"time":"2026-09-04T11:59:42.514+02:00","decision":"candidate_succeeded","candidateRouteOrigin":"configured-fallback","attempt":2,"total":2}}
{"gateway":{"time":"2026-09-04T11:59:42.613+02:00","outcome":"completed","duration":"1334ms"}}
{"telegram":{"elapsedMs":17396,"kind":"message","isSut":true,"text":"FALLBACK_TEXT_CONTROL"}}
```

**Real provider failure — separate candidate recording:**

```json
{"gateway":{"time":"2026-09-04T12:01:17.650+02:00","decision":"candidate_failed","candidateRouteOrigin":"requested","attempt":1,"total":2,"reason":"auth","status":401}}
{"provider":{"time":"2026-09-04T12:01:19.985+02:00","type":"result","subtype":"success","is_error":true,"terminal_reason":"api_error","api_error_status":404}}
{"gateway":{"time":"2026-09-04T12:01:20.247+02:00","decision":"candidate_failed","candidateRouteOrigin":"configured-fallback","attempt":2,"total":2,"fallbackStepFinalOutcome":"chain_exhausted"}}
{"gateway":{"time":"2026-09-04T12:01:20.357+02:00","outcome":"error","duration":"3321ms"}}
{"telegram":{"elapsedMs":3540,"kind":"message","isSut":true,"text":"⚠️ [redacted] request failed."}}
```

The failure result really reports `subtype=success` together with `is_error=true`; the excerpt preserves that raw distinction. It is not classified as deliberate silence.

This addresses the latest ClawSweeper proof request and rank-up move. Raw logs remain private because they contain leased account and runtime metadata.

</details>

Commands used:

```sh
node "$TELEGRAM_E2E_SKILL_DIR/scripts/telegram-test-doctor.mjs"
E2E_ROOT_CONFIG_PATCH='<configured primary and fallback>' \
  node "$TELEGRAM_E2E_SKILL_DIR/scripts/run-mock-sut-user-e2e.mjs" \
  --source-gateway --backend claude-cli --dm \
  --gateway-port <unused-port> --mock-port <unused-port> \
  --scenario <scenario.json> --record <events.ndjson> --output <summary.json>
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-result-accounting.persistence.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-core.test.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/agent-runner-core.ts src/auto-reply/reply/agent-runner-result-payloads.ts src/auto-reply/reply/agent-runner-result-accounting.persistence.test.ts
pnpm check:max-lines-ratchet --base origin/main
git diff --check
```

The source harness needed its launcher changed from `tsx` to the repository-documented `tsx/esm` mode because the former breaks an import-only dependency. The same setup-only change was used on both refs. Product source and provider responses were not replaced. This is source-runtime proof, not packaged-build proof.

The finalizer regression table fails on main for `NO_REPLY` and `hook_block`; the genuine-empty control passes on both. All 76 accounting tests pass with the repair. The contributor head's 46 owner/classifier tests also passed. Focused lint, formatting, and the file-size ratchet pass. CI owns type checking.

Production: **+3/-0**. Tests: **+41/-0**. The three production lines carry an already-classified fact across the existing builder boundary. Combining that fact with the caller's `silentExpected` policy would hide two different meanings. No new config, stored field, public API, or fallback path is introduced.

Maintainer disposition of the latest ClawSweeper size risk: retain this explicit handoff. The existing shared classifier remains the single policy owner; merging its fact into another flag or moving the warning guard into the caller would obscure that boundary. The three lines are necessary to make the missing fact available to the existing builder. The real-event proof request and rank-up move are addressed above; no code finding remains.

The two narrower builder-only tests were replaced with finalizer coverage that detects the caller omission and checks completed-versus-failed accounting.
