### PR TITLE
improve: reduce gateway restart test startup time

### DIFF
--- a/scripts/lib/vitest-worker-artifacts.mts
+++ b/scripts/lib/vitest-worker-artifacts.mts
@@ -10,6 +10,8 @@ export const runtimeProcessDeclarationEntries = {
 };
 export const vitestWorkerDeclarationEntries = {
   ...runtimeProcessDeclarationEntries,
+  "test-support/channel-ingress-gateway-restart-entrypoint":
+    "test/fixtures/channel-ingress-gateway-restart-entrypoint.ts",
   "extensions/qa-lab/gateway-child-artifacts-runtime.test-support":
     "extensions/qa-lab/src/gateway-child-artifacts-runtime.test-support.ts",
   "agents/code-mode-retention-entrypoint.test-support":

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -9,6 +9,7 @@ import { nodeHostConfigRuntimeEntrypoint } from "../../src/node-host/config-runt
 import { persistenceRuntimeEntrypoint } from "../../src/skills/library/persistence-runtime.test-support.ts";
 import { stateLeaseProcessExitRuntimeEntrypoint } from "../../src/state/openclaw-state-lease-runtime.test-support.ts";
 import { tuiPtyRuntimeEntrypoints } from "../../src/tui/tui-pty-runtime-test-support.ts";
+import { channelIngressGatewayRestartEntrypoint } from "../../test/fixtures/channel-ingress-gateway-restart-entrypoint.ts";
 import { runtimeProcessBuildEntries } from "./runtime-process-build-entries.mts";
 
 // Test-only roots share the invocation generation without changing package entries.
@@ -23,6 +24,7 @@ export const vitestWorkerBuildEntries = {
       ...Object.values(sessionTitleRetentionEntrypoints),
       sessionListCacheRetentionEntrypoint,
       nodeHostConfigRuntimeEntrypoint,
+      channelIngressGatewayRestartEntrypoint,
       persistenceRuntimeEntrypoint,
       qaGatewayCleanupRuntimeEntrypoint,
       stateLeaseProcessExitRuntimeEntrypoint,

--- a/src/channels/message/ingress-monitor.restart-drain.test.ts
+++ b/src/channels/message/ingress-monitor.restart-drain.test.ts
@@ -1,7 +1,11 @@
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
 import { afterEach, expect, it, vi } from "vitest";
+import { channelIngressGatewayRestartEntrypoint } from "../../../test/fixtures/channel-ingress-gateway-restart-entrypoint.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  resolveRuntimeWorkerArgv,
+  resolveRuntimeWorkerUrl,
+} from "../../infra/runtime-worker-url.js";
 import {
   beginGatewayRestartSignalAdmission,
   markGatewayRestartDraining,
@@ -69,10 +73,8 @@ function createMonitor(
 
 function runRestartDrainFixture(stateDir: string): Promise<RestartDrainProof> {
   return new Promise((resolve, reject) => {
-    const fixture = fileURLToPath(
-      new URL("../../../test/fixtures/channel-ingress-gateway-restart.ts", import.meta.url),
-    );
-    const child = spawn(process.execPath, ["--import", "tsx", fixture, stateDir], {
+    const fixture = resolveRuntimeWorkerUrl(channelIngressGatewayRestartEntrypoint);
+    const child = spawn(process.execPath, [...resolveRuntimeWorkerArgv(fixture), stateDir], {
       cwd: process.cwd(),
       env: { ...process.env, TMPDIR: stateDir },
       stdio: ["ignore", "ignore", "pipe", "ipc"],
@@ -118,7 +120,12 @@ function runRestartDrainFixture(stateDir: string): Promise<RestartDrainProof> {
       clearTimeout(startupTimer);
       clearTimeout(idleTimer);
       if (failure) {
-        reject(failure);
+        reject(
+          new Error(
+            `${failure.message}; code=${String(code)} signal=${String(signal)} stderr=${stderr}`,
+            { cause: failure },
+          ),
+        );
         return;
       }
       if (code !== 0 || !proof) {

--- a/test/fixtures/channel-ingress-gateway-restart-entrypoint.ts
+++ b/test/fixtures/channel-ingress-gateway-restart-entrypoint.ts
@@ -1,0 +1,6 @@
+// The test invocation prepares the real restart fixture before its startup deadline.
+export const channelIngressGatewayRestartEntrypoint = {
+  currentModuleUrl: import.meta.url,
+  sourceWorkerName: "channel-ingress-gateway-restart",
+  distWorkerPath: "test-support/channel-ingress-gateway-restart.js",
+} as const;


### PR DESCRIPTION
## What Problem This Solves

The real Gateway restart/drain test launches a separate TypeScript source process, even though the test invocation already prepares compiled worker artifacts. In the measured Linux runs, roughly 10 seconds passed from its initial imports to the first Gateway start, consuming much of its unchanged 30-second startup deadline.

This was investigated after a CI startup timeout, but the original timeout did not reproduce. This PR improves measured test startup; it does not claim to establish or fix the cause of that historical timeout.

## Why This Change Was Made

Register the existing restart fixture with the canonical compiled-worker declaration/build flow and launch it through the existing runtime-worker resolver. Keep the real fixture, its temporary-directory isolation, process ownership, and all 30-second/3-second/<1-second/40-second assertions unchanged. Preserve intentional eager Gateway lifecycle loading. If startup fails, include the captured stderr and termination details while retaining the original error as `cause`.

No custom bundle, fallback, timeout increase, mock, or diagnostic IPC is added. Production runtime LOC is unchanged; tooling is +4/-0 and tests/support +19/-6.

## User Impact

Developers get a faster real restart test and more useful startup failure messages. There is no production Gateway behavior or configuration change.

## Evidence

Linux Node 24.19.0 / pnpm 12.1.0, one declared B/C/C/B sequence of independent full six-case invocations:

| Run | Full invocation, including compilation | Compiler preparation | Real restart case |
| --- | ---: | ---: | ---: |
| Before 1 | 18.950 s | 2.978 s | 11.553 s |
| Candidate 1 | 5.812 s | 2.097 s | 0.969 s |
| Candidate 2 | 5.180 s | 2.122 s | 0.942 s |
| Before 2 | 16.273 s | 2.011 s | 11.800 s |

All 24 comparison cases passed, as did one complete unchanged channels run: 1,294 cases across 107 files. Both comparison variants used identical temporary phase IPC; that instrumentation is excluded from this PR. The measured loading bracket includes transformation, eager runtime loading, and start setup, so it does not isolate transformation cost. The 16-vCPU Linux proof did not reproduce the original 32-vCPU concurrent artifact workload. [Testbox host workflow](https://github.com/openclaw/openclaw/actions/runs/33738158582); the retained command receipts all exited 0, independently of the host workflow's lease-cleanup status. The lease was stopped and task authentication removed.

The final candidate without diagnostics passed 72/72 cases, no skips, across the complete restart/drain, runtime-worker resolution, artifact compilation, transformation, verification and shutdown suites. Fresh managed Codex review found no P0-P2 issues.

The initial changed-check passed all 21 preceding stages, including guards, core-test/scripts typechecks and dead exports, then its safety monitor terminated unsplit core lint at 17,197,219,840 bytes of observed process-tree RSS, above the existing 16 GiB limit. That operational failure is retained. The remaining coverage completed through the existing five disjoint CI core stripes, followed by the original `pnpm lint:scripts`; every stripe and scripts lint passed with zero warnings/errors. The canonical target-union check covered all 123 targets. The complete continuation took 200.400 seconds under the unchanged 900-second/16-GiB owner; its largest sampled process tree was 14,526,824,448 bytes. All recorded child groups closed, and source hashes remained unchanged.

Separate follow-up: evaluate whether broad `check-changed` core lint should use its existing bounded stripe owner to avoid the unsplit Program memory spike. No lint-runner changes are bundled here.

## Refreshed native CI

Mechanically rebased onto current main without changing the reviewed patch; the two unrelated failures from the earlier run were already fixed by #137157 and #137223. Fresh independent Codex review found no P0–P2 findings.

[CI 33780352537](https://github.com/openclaw/openclaw/actions/runs/33780352537) passed at `f6c846668ea44591ca8f21e7a9efaea2103aa7de`: 81 jobs passed, 17 skipped, and the aggregate gate passed. Its native merge has the same complete Git tree as the reviewed head. Windows was skipped by the unchanged path selection.

The native build-artifacts job reported eight actual CPUs and Node 24.19.0. All 1,294 channel cases passed, including all six restart/drain cases; the real restart case took 1.807 seconds. The existing wrapper prepared the compiled generation and verified it before successful cleanup. Child argv and directory removal are not printed as separate receipts; their ownership follows the inspected canonical worker path and successful wrapper return.

Build-artifacts finished 5m43s after run creation. The last non-Windows job finished at 10m37s and the aggregate at 10m46s, so this is not an eight-minute full-CI result. No timeout, concurrency, test assertion, or production behavior was weakened.
