### PR TITLE
fix(docs): remove unsupported automation update command

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -15,7 +15,7 @@ Run `openclaw automations --help` for the full command surface. See [Automations
 </Tip>
 
 <Note>
-All automation mutations (`add`/`create`, `update`/`edit`, `remove`, `run`) require `operator.admin`. Command-payload runs execute directly in the Gateway process, not as an agent `tools.exec` tool call; `tools.exec.*` and exec approvals still govern model-visible exec tools.
+All automation mutations (`add`/`create`, `edit`, `remove`, `run`) require `operator.admin`. Command-payload runs execute directly in the Gateway process, not as an agent `tools.exec` tool call; `tools.exec.*` and exec approvals still govern model-visible exec tools.
 </Note>
 
 Every automation subcommand accepts the shared Gateway connection options. Use


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators reading the automation CLI reference could try `openclaw automations update`, which OpenClaw rejects as an unknown command.

## Why This Change Was Made

Removes the unsupported `update` spelling from the mutation list and keeps the registered `edit` command. The internal `cron.update` RPC is separate from the CLI command name. The surrounding permissions and execution guidance stay intact.

## User Impact

The reference points operators to a working command. This changes one documentation line; runtime and test code are unchanged. Production LOC: +0/-0. Documentation: +1/-1.

Thanks to @qingminglong for the original correction, which remains unchanged in the reviewed PR head.

## Evidence

- [Real built CLI proof](https://github.com/steipete/openclaw/actions/runs/34124667553/job/101751560616): all eight help/parser cases passed on protected-main source `1d694c876d2b74efeee0f1aed2ca22d9bb28ef3f`, using Node 24.20.0 and Commander 15.0.0. Both `automations update --help` and `cron update --help` exited 1 with the exact unknown-command diagnostic. Both `edit --help` and parent help worked, and two unrelated unknown-child controls rejected correctly.
- The canonical build passed. Generated files and literal dependency links were unchanged across the CLI probes; all processes joined normally, account/config/state remained unchanged, and synthetic state was removed.
- Current main and stable `v2026.9.2` retain the incorrect wording. The original PR's edit/alias/parser owners match the proven source; its lazy registrar also routes both command spellings to the same owner.
- The branch-pinned formatter and whitespace check pass. [Fresh CI for contributor head `541116454dfdd54a50e025e1a8c53eafc9352e9d`](https://github.com/openclaw/openclaw/actions/runs/34134648052) passed, including the docs check and required CI gate. The executed GitHub merge commit `f5155881731ade287102765798bad5af7025a83d` contains that original head and base `dcc733dc20e8e6da5b1f72c48a3755192c26368e`; its document matches the base plus this one-line correction. [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/34134648035) also passed. The docs glossary-coverage subcheck self-skipped because its merge base was unavailable; this change introduces no new glossary terms. Fresh structured and separate ephemeral committed-head reviews found no actionable P0–P2 issue.

The CLI proof exercises parser/help behavior; it does not create or modify an automation, start a Gateway, or claim an authenticated scheduler run. A new runtime test would only duplicate existing command coverage for this documentation-only correction.
