### PR TITLE
fix(cli): reject blank channels capabilities selectors

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -246,6 +246,7 @@ Notes:
 
 - `--channel` is optional; omit it to list every channel (including plugin-provided channels).
 - `--account` is only valid with `--channel`.
+- A blank `--channel`, `--agent`, `--account`, or `--target` is rejected; omit the flag instead of passing an empty value.
 - Each account probe and diagnostics step has its own timeout. A stalled step is reported in both text and JSON output, and the command continues with the remaining accounts.
 - `--target` accepts `channel:<id>` or a raw numeric channel id and only applies to Discord. For Discord voice channels, the permission check flags missing `ViewChannel`, `Connect`, `Speak`, `SendMessages`, and `ReadMessageHistory`.
 - Probes are provider-specific: Discord bot identity + intents plus optional channel permissions; Slack bot + user scopes; Telegram bot flags + webhook; Signal daemon version; Microsoft Teams app token + Graph roles/scopes (annotated where known). Channels without probes report `Probe: unavailable`.

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -806,4 +806,22 @@ describe("gateway-backed CLI process exit", () => {
       expect(result.stderr).toContain("Invalid --timeout");
     }
   });
+
+  it.each([
+    { flag: "--channel", value: "" },
+    { flag: "--target", value: " " },
+  ])("rejects a blank $flag for channels capabilities", async ({ flag, value }) => {
+    const root = tempDirs.make("openclaw-capabilities-blank-selector-");
+    const { stateDir, configPath } = await prepareGatewayCliFixture(root, { mode: "local" });
+
+    const result = await runIsolatedGatewayCli({
+      args: ["channels", "capabilities", flag, value, "--json"],
+      root,
+      stateDir,
+      configPath,
+    });
+
+    expect(result, result.stderr).toMatchObject({ code: 1, signal: null });
+    expect(result.stderr).toContain(`${flag} must not be blank`);
+  });
 });

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -217,6 +217,48 @@ describe("channelsCapabilitiesCommand", () => {
       discoversChannels: false,
     },
     {
+      name: "blank channel",
+      options: { channel: "" },
+      message: "--channel must not be blank",
+      discoversChannels: false,
+    },
+    {
+      name: "blank agent with all channels",
+      options: { channel: "all", agent: " " },
+      message: "--agent must not be blank",
+      discoversChannels: false,
+    },
+    {
+      name: "blank account without a channel",
+      options: { account: "" },
+      message: "--account must not be blank",
+      discoversChannels: false,
+    },
+    {
+      name: "whitespace account without a channel",
+      options: { account: "   ", json: true },
+      message: "--account must not be blank",
+      discoversChannels: false,
+    },
+    {
+      name: "whitespace account with a channel",
+      options: { channel: "slack", account: "   " },
+      message: "--account must not be blank",
+      discoversChannels: false,
+    },
+    {
+      name: "blank target without a channel",
+      options: { target: "  " },
+      message: "--target must not be blank",
+      discoversChannels: false,
+    },
+    {
+      name: "blank target with a channel",
+      options: { channel: "discord", target: "", json: true },
+      message: "--target must not be blank",
+      discoversChannels: false,
+    },
+    {
       name: "unknown channel after installable plugin lookup",
       options: { channel: "definitely-not-a-channel", json: true },
       message:
@@ -254,6 +296,42 @@ describe("channelsCapabilitiesCommand", () => {
     expect(probeAccount).not.toHaveBeenCalled();
     expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
     expect(mocks.refreshPluginRegistryAfterConfigMutation).not.toHaveBeenCalled();
+  });
+
+  it("reports every configured account when --account is omitted", async () => {
+    const plugin = buildPlugin({ id: "slack" });
+    plugin.config.listAccountIds = () => ["ops", "sales"];
+    plugin.config.resolveAccount = (_cfg: OpenClawConfig, accountId?: string | null) => ({
+      accountId,
+    });
+    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+      cfg: { channels: {} },
+      channelId: "slack",
+      plugin,
+      configChanged: false,
+    });
+
+    await channelsCapabilitiesCommand({ channel: "slack", json: true }, runtime);
+
+    const payload = JSON.parse(logs[0] ?? "{}") as {
+      channels?: Array<{ accountId?: string }>;
+    };
+    expect(payload.channels?.map((entry) => entry.accountId)).toStrictEqual(["ops", "sales"]);
+  });
+
+  it("reports every channel when --channel is omitted", async () => {
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([
+      buildPlugin({ id: "slack" }),
+      buildPlugin({ id: "discord" }),
+    ]);
+
+    await channelsCapabilitiesCommand({ json: true }, runtime);
+
+    const payload = JSON.parse(logs[0] ?? "{}") as {
+      channels?: Array<{ channel?: string }>;
+    };
+    expect(payload.channels?.map((entry) => entry.channel)).toStrictEqual(["slack", "discord"]);
+    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -280,6 +280,18 @@ export async function channelsCapabilitiesCommand(
   if (!configSnapshot) {
     return;
   }
+  // An explicit blank selector must not change scope.
+  for (const [option, value] of [
+    ["--channel", opts.channel],
+    ["--agent", opts.agent],
+    ["--account", opts.account],
+    ["--target", opts.target],
+  ] as const) {
+    if (typeof value === "string" && !value.trim()) {
+      const message = `${option} must not be blank`;
+      throw new ExpectedCliError({ message, humanOutput: danger(message), machineOutput: message });
+    }
+  }
   let cfg = await resolveCapabilitiesRuntimeConfig(configSnapshot.config, runtime);
   const timeoutMs = Math.min(
     parseTimeoutMsWithFallback(opts.timeout, 10_000, { invalidType: "error" }),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw channels capabilities` treated an explicit blank selector value as if the flag had been omitted, so a blank changed what the command probed or skipped work instead of failing.

- `--channel ""` reported every channel.
- `--channel slack --account ""` probed every configured Slack account instead of the one the caller meant to name.
- `--channel discord --target ""` ran the report but skipped the documented Discord permission audit without saying so.
- `--account ""` with no `--channel` slipped past the "`--account` requires a specific `--channel`" check, because that check tests the raw option for truthiness. A whitespace-only value hit the check instead and got a message naming the wrong problem.
- `--agent ""` was rejected only once a specific channel reached the owner resolver, and was ignored on the all-channels path.

The usual source of a blank value is an unset shell variable, so a script that meant to scope a probe widened it. The docs already describe `--account` and `--target` as requiring `--channel` and say to omit `--channel` to list every channel.

## Why This Change Was Made

One check, placed after the config snapshot is validated and before channel secrets are resolved, rejects a blank or whitespace-only value for the four documented string selectors (`--channel`, `--agent`, `--account`, `--target`) with the same `<flag> must not be blank` wording that `channels dead-letters` and the channel auth commands already use. Omission keeps every current behavior.

Two things this does not change, stated so they are not mistaken for oversights. On the all-channels path a non-blank `--agent` is still not read by this command; only the blank is now rejected, consistent with `channels resolve`, which already rejects a blank `--agent`. And `channels resolve` itself is not touched here.

This follows #133781, which did the same for this command's `--timeout`, and #136412 for the mutating `channels` verbs.

## User Impact

A blank selector now fails fast with a message naming the flag, before any plugin is resolved, any secret is fetched, or any account is probed. Omitting a flag still selects the default: every channel, every configured account, no target. Scripts that pass an empty variable will see an error instead of a wider report.

## Evidence

Baseline `cf0f8f90a7b6317a5a618ac5d5a7e69e01c050d2`, recorded at `19d8f01de3a0f3d1d1f57306dce151485defad29` rather than the current head. Since then the branch merged upstream main and dropped `--account` from the guard, because `parseAccountSelector` already rejects a blank at option-parse time for this command. The `--account` row below therefore now exercises that parser rather than the guard. The message is unchanged, and `formatCliJsonFailure` renders a plain error into the same `cli_error` envelope, so the transcript still describes the output. `src/cli/account-selector-boundary.test.ts` covers that rejection before command startup.

- `src/commands/channels/capabilities.test.ts`: seven rows added to the existing rejection table plus two omission controls.
  - Rows on the baseline with the production file unchanged: 7 fail, 19 pass (four rows resolve instead of rejecting; the whitespace-account row gets the "requires a specific --channel" message; the two specific-channel rows reach plugin discovery)
  - With the fix: 26 of 26 pass
  - Wrong fix, the check moved after the channel-scope guard: 1 fail, 25 pass (only the whitespace-account row discriminates this one, since `normalizeOptionalString` trims a blank target before the guard sees it)
  - Wrong fix, the check limited to the no-channel branch: 2 fail, 24 pass
- `src/cli/gateway-backed-exit.process.test.ts`: two real-subprocess rows (`--channel ""`, `--target " "`), exit 1 with the message on stderr: both pass on the head; on the baseline both fail because the CLI exits 0
- `src/commands/channels/`: 33 of 33 pass
- `src/cli/capability-cli.test.ts` and `src/cli/channel-auth.owner.integration.test.ts` (callers that share the message): 227 of 227 pass
- `pnpm tsgo:core`, `pnpm check:test-types`, `pnpm check:assertion-safety --base upstream/main`, `oxlint`, `oxfmt --check` on the touched paths: all exit 0 on the head (the assertion count held at 4095 files and 12520 grandfathered assertions, with none added)

Real built CLI, `NO_COLOR=1`, a config with Slack accounts `ops` and `sales` in an isolated home.

Baseline:

```
$ openclaw channels capabilities --channel slack --account "" --json --timeout 1000
exit=0
reported: slack:ops, slack:sales
$ openclaw channels capabilities --channel discord --target "" --json --timeout 1000
exit=0
reported: discord:default
$ openclaw channels capabilities --account "" --json --timeout 1000
exit=0
reported: slack:ops, slack:sales
$ openclaw channels capabilities --channel "" --json --timeout 1000
exit=0
reported: slack:ops, slack:sales
$ openclaw channels capabilities --channel all --agent "  " --json --timeout 1000
exit=0
reported: slack:ops, slack:sales
```

Exact head:

```
$ openclaw channels capabilities --channel slack --account "" --json --timeout 1000
exit=1
stdout: {"ok": false, "error": {"type": "cli_error", "message": "--account must not be blank"}}
stderr: --account must not be blank
$ openclaw channels capabilities --channel discord --target "" --json --timeout 1000
exit=1
stdout: {"ok": false, "error": {"type": "cli_error", "message": "--target must not be blank"}}
stderr: --target must not be blank
$ openclaw channels capabilities --account "" --json --timeout 1000
exit=1
stdout: {"ok": false, "error": {"type": "cli_error", "message": "--account must not be blank"}}
stderr: --account must not be blank
$ openclaw channels capabilities --channel "" --json --timeout 1000
exit=1
stdout: {"ok": false, "error": {"type": "cli_error", "message": "--channel must not be blank"}}
stderr: --channel must not be blank
$ openclaw channels capabilities --channel all --agent "  " --json --timeout 1000
exit=1
stdout: {"ok": false, "error": {"type": "cli_error", "message": "--agent must not be blank"}}
stderr: --agent must not be blank
$ openclaw channels capabilities --channel slack --json --timeout 1000   # control, --account omitted
exit=0
reported: slack:ops, slack:sales
```

