### PR TITLE
refactor(normalization): reuse ASCII control predicate

### DIFF
--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -4,6 +4,7 @@
  * failures into structured failover reasons and remediation metadata.
  */
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
+import { containsAsciiControlCharacter } from "@openclaw/normalization-core/string-normalization";
 import { formatCliCommand } from "../cli/command-format.js";
 import { isAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
 import { copyErrorDiagnostic } from "../infra/error-diagnostics.js";
@@ -574,23 +575,13 @@ export function buildProviderReauthCommand(
   env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
 ): string | undefined {
   const trimmed = provider.trim();
-  if (!trimmed || hasControlCharacter(trimmed)) {
+  if (!trimmed || containsAsciiControlCharacter(trimmed)) {
     return undefined;
   }
   return formatCliCommand(
     `openclaw models auth login --provider ${quotePosixShellArg(trimmed)} --force`,
     env,
   );
-}
-
-function hasControlCharacter(value: string): boolean {
-  for (let i = 0; i < value.length; i += 1) {
-    const code = value.charCodeAt(i);
-    if (code < 0x20 || code === 0x7f) {
-      return true;
-    }
-  }
-  return false;
 }
 
 /** Convert a failover or raw error into structured fields for logs/UI. */

--- a/src/boards/board-capabilities.ts
+++ b/src/boards/board-capabilities.ts
@@ -1,3 +1,4 @@
+import { containsAsciiControlCharacter } from "@openclaw/normalization-core/string-normalization";
 import {
   BOARD_WIDGET_TOOL_MAX_LENGTH,
   type BoardWidgetDeclared,
@@ -11,16 +12,6 @@ const MAX_DECLARED_TOOLS = 64;
 
 function invalidDeclaration(message: string): never {
   throw new BoardValidationError("invalid_operation", message);
-}
-
-function hasControlCharacter(value: string): boolean {
-  for (let index = 0; index < value.length; index += 1) {
-    const code = value.charCodeAt(index);
-    if (code <= 31 || code === 127) {
-      return true;
-    }
-  }
-  return false;
 }
 
 function normalizeBoardNetOrigin(value: string): string {
@@ -59,7 +50,7 @@ function normalizeTool(value: string): string {
     tool.length === 0 ||
     tool.length > BOARD_WIDGET_TOOL_MAX_LENGTH ||
     tool !== value ||
-    hasControlCharacter(tool)
+    containsAsciiControlCharacter(tool)
   ) {
     return invalidDeclaration(`invalid board widget tool capability: ${value}`);
   }

--- a/src/canvas/documents.ts
+++ b/src/canvas/documents.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { containsAsciiControlCharacter } from "@openclaw/normalization-core/string-normalization";
 import { resolveStateDir } from "../config/paths.js";
 import { sanitizeUntrustedFileName } from "../infra/fs-safe-advanced.js";
 import { root as fsRoot } from "../infra/fs-safe.js";
@@ -62,23 +63,14 @@ function buildPdfWrapper(url: string): string {
   return `<!doctype html><html><body style="margin:0;background:#e5e7eb;"><object data="${escaped}" type="application/pdf" style="width:100%;height:100vh;border:0;"><iframe src="${escaped}" style="width:100%;height:100vh;border:0;"></iframe><p style="padding:16px;font:14px system-ui,sans-serif;">Unable to render PDF preview. <a href="${escaped}" target="_blank" rel="noopener noreferrer">Open PDF</a>.</p></object></body></html>`;
 }
 
-function hasControlCharacter(value: string): boolean {
-  for (const char of value) {
-    const code = char.charCodeAt(0);
-    if (code < 0x20 || code === 0x7f) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function normalizeLogicalPath(value: string): string {
   const normalized = value.replaceAll("\\", "/").replace(/^\/+/, "");
   const parts = normalized.split("/").filter(Boolean);
   if (
     parts.length === 0 ||
     parts.some(
-      (part) => part === "." || part === ".." || part.includes(":") || hasControlCharacter(part),
+      (part) =>
+        part === "." || part === ".." || part.includes(":") || containsAsciiControlCharacter(part),
     )
   ) {
     throw new Error("canvas document logicalPath invalid");

--- a/src/config/model-policy-ref.ts
+++ b/src/config/model-policy-ref.ts
@@ -1,18 +1,9 @@
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { containsAsciiControlCharacter } from "@openclaw/normalization-core/string-normalization";
 
 const MODEL_POLICY_COMPAT_SELECTORS = new Set(["openrouter:auto", "openrouter:free"]);
-
-function hasControlCharacter(value: string): boolean {
-  for (const char of value) {
-    const codePoint = char.codePointAt(0) ?? 0;
-    if (codePoint <= 0x1f || codePoint === 0x7f) {
-      return true;
-    }
-  }
-  return false;
-}
 
 function hasValidSegments(
   segments: readonly string[],
@@ -26,7 +17,7 @@ function hasValidSegments(
         segment.length > 0 &&
         !segment.includes("*") &&
         !/\s/u.test(segment) &&
-        !hasControlCharacter(segment),
+        !containsAsciiControlCharacter(segment),
     )
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Four core call sites independently implemented the same ASCII C0 and DEL rejection rule. Keeping identical validation loops in multiple owners creates avoidable drift risk when the shared normalization contract changes.

## Why This Change Was Made

Use `containsAsciiControlCharacter` from `@openclaw/normalization-core/string-normalization`, the existing canonical owner for this predicate. This removes the four local `hasControlCharacter` implementations while preserving each caller's validation flow.

The change is intentionally limited to:

- `src/boards/board-capabilities.ts`
- `src/canvas/documents.ts`
- `src/config/model-policy-ref.ts`
- `src/agents/failover-error.ts`

Plugin, TUI, and script variants remain excluded because they are outside this core owner consolidation and may enforce different input boundaries. No config, protocol, SDK, persistence, security, dependency, canonical-helper, or test surface changes.

## User Impact

No user-visible behavior changes. Core validation now uses one canonical ASCII control-character predicate instead of four duplicate implementations.

## Evidence

- Production LOC: `+9/-44`, net `-35`; tests: `0`.
- Exhaustive equivalence: all 65,536 UTF-16 code units plus surrogate/control sequences matched across the four removed predicates and the canonical helper.
- Focused tests: 146 passed across the normalization-core, board capabilities, Canvas documents, and two config suites.
- `src/agents/failover-error.test.ts` could not collect because the shared worktree dependency install is missing `mdast-util-from-markdown`; no worktree install was performed.
- `pnpm check:changed` passed all gates through the core typecheck, which stopped on the same incomplete shared dependency install (`mdast-util-*`, `micromark-extension-gfm-table`, `markdown-it-cjk-friendly`, and `libphonenumber-js/min`).
- Targeted core oxlint passed.
- Formatting and `git diff --check` passed.
- Import-cycle check passed with zero runtime value cycles.
- Autoreview: scoped-clean, patch correct at 0.99 confidence.
- Test audit: no new tests warranted; the canonical predicate suite owns C0/DEL/C1/Unicode semantics and existing caller suites cover the affected boundaries.
