### PR TITLE
improve: build core tool catalogs faster

### DIFF
--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -458,6 +458,13 @@ const CORE_TOOL_BY_ID = new Map<string, CoreToolDefinition>(
   CORE_TOOL_DEFINITIONS.map((tool) => [tool.id, tool]),
 );
 
+// Section membership is static; capability filtering and response objects stay per request.
+const CORE_TOOL_SECTIONS = CORE_TOOL_SECTION_ORDER.map(({ id, label }) => ({
+  id,
+  label,
+  tools: CORE_TOOL_DEFINITIONS.filter((tool) => tool.sectionId === id),
+}));
+
 function listCoreToolIdsForProfile(profile: ToolProfileId): string[] {
   return CORE_TOOL_DEFINITIONS.filter((tool) => tool.profiles.includes(profile)).map(
     (tool) => tool.id,
@@ -533,21 +540,22 @@ export function listCoreToolSections(params?: {
   // Callers resolve the swarm gate and pass the fact in; resolving config here
   // would couple this ui-shared module to the server graph.
   const swarmEnabled = params?.swarmEnabled === true;
-  return CORE_TOOL_SECTION_ORDER.map((section) => ({
+  return CORE_TOOL_SECTIONS.map((section) => ({
     id: section.id,
     label: section.label,
-    tools: CORE_TOOL_DEFINITIONS.filter(
-      (tool) =>
-        tool.sectionId === section.id &&
-        (tool.id !== "agents_wait" || swarmEnabled) &&
-        (tool.id !== "github_identity_status" ||
-          params?.githubPublicationAvailable !== undefined) &&
-        (tool.id !== "github_publish" || params?.githubPublicationAvailable === true),
-    ).map((tool) => ({
-      id: tool.id,
-      label: tool.id,
-      description: tool.description,
-    })),
+    tools: section.tools
+      .filter(
+        (tool) =>
+          (tool.id !== "agents_wait" || swarmEnabled) &&
+          (tool.id !== "github_identity_status" ||
+            params?.githubPublicationAvailable !== undefined) &&
+          (tool.id !== "github_publish" || params?.githubPublicationAvailable === true),
+      )
+      .map((tool) => ({
+        id: tool.id,
+        label: tool.id,
+        description: tool.description,
+      })),
   })).filter((section) => section.tools.length > 0);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Core tool catalog requests repeatedly scan every tool definition for each section, even though section membership is fixed for the process. That adds avoidable work to catalog generation and the Gateway's core-only catalog response.

## Why This Change Was Made

Prepare private section membership once in the existing UI-safe catalog module. Each request still applies live capability gates and creates fresh response objects. Ordering, labels, profile/group APIs, getter evaluation order, and the separation from server runtime dependencies stay unchanged. No request-result cache or new configuration is introduced.

Production: +21/-13, net +8. Tests: unchanged. The small private grouping replaces the repeated cross-section scan while keeping capability and response ownership per request.

## User Impact

Faster catalog generation with the same available tools and response shape. This does not claim faster plugin discovery, full Control UI loading, Gateway startup, or model turns.

## Evidence

All 13 existing cases across the complete catalog and handler test files passed on baseline and final candidate. The full changed-path check passed. Fresh independent Codex review through P2 found no actionable defects.

A fixed Node 26.8.1 experiment ran baseline/candidate/candidate/baseline in fresh processes. It retained all 5,274 complete target results, 576 measured batch means, first/warm observations, and process-tree RSS. Mutation, fresh nested-object ownership, changing capability getters, thrown-value identity, invalid params, and callback errors were checked before timing.

| Complete operation | Forward median improvement | Reverse median improvement |
| --- | ---: | ---: |
| Default core catalog | 67.09% | 65.95% |
| Core catalog with all capabilities enabled | 69.11% | 64.26% |
| Core-only `tools.catalog` handler, swarm disabled | 26.50% | 21.20% |
| Core-only `tools.catalog` handler, swarm enabled | 27.41% | 25.75% |

The actual handler includes normal validation, agent/config resolution, profile projection and the response callback. These RPC rows use `includePlugins:false`; the Control UI normally requests plugins too, so they do not establish total UI latency. All seven direct capability combinations preserve complete output and input state.

Tradeoffs retained: sampled process-tree peak RSS increased 3.47%/3.56%. One reverse direct-catalog p95 rose from 5.33 to 47.53 microseconds, despite its median improving by 66.06%; no cause is inferred. All slower first/warm/tail observations remain in the raw evidence. The fixed primary/protected/RSS gates passed without retries or after-data retuning.

The independent audit reconstructed all complete outputs and recomputed every raw statistic before opening the aggregate report. It agreed with the fixed-gate result. Other retained observations include the reverse core-only handler warm median increasing 75.99%, three slower first-call rows, and kernel child peak RSS increasing 12.75%/3.42% (distinct from sampled tree RSS). These are not relabeled as heap allocation or whole-process speed improvements.

The sealed local evidence is identified by `04289621c13845263afe14eb086a869725081abcc531c372744a787e0c6b7efc`; the independent raw-first audit seal is `595eedc77758a365e0f945e4097beb411adfd81fc8a106f750bc70e047c9f908`. The measured catalog/handler/test source correspondence was verified at `b03e0ec8cf8`; that is historical measurement evidence, not a fresh measurement on later main.

## Current Publication

Head `69d576986606bf1b27c2133bee9753688cb4f410` mechanically refreshes the unchanged optimization onto `b2b4ac58`, including the separate session-test fixture repair #137743. The complete parent-relative patch and all 19 selected owner, caller, test and dependency files are byte-identical to the previous candidate. Fresh managed Codex P0–P2 review found no actionable defects. The prior 13-case results, 28-stage full changed check and measured samples remain historical evidence; no measurements were rerun. The old hosted failures remain recorded, and exact-head CI must pass before landing.

## Audit-repair refresh

The reviewed refresh is `94d39455ef9252b4eba6e09effe8eadc59cfc572`, based on `c86d5b2d270eb2eb2a98cf5070f5efe19eb068c3` to adopt the landed npm advisory reliability repair #137825. This updates the publication status above without changing the catalog optimization: the complete 2,241-byte parent-relative patch remains identical, SHA-256 `89ad57428b318af90272b114dd0ea7ee9a79e11881b5c9c0f16f125c1258d4ee`.

All 19 previously selected owner, caller, test and dependency facts remain byte-identical. An expanded 44-path comparison finds 40 unchanged paths; the four inherited changes are the audit helper, its two associated test files, and separate Chrome MCP workflow setup. This is selected source correspondence, not a claim that all transitive runtime inputs or all of main are unchanged.

Fresh managed Codex review of exact head `94d39455` through P2 completed with no actionable findings, confidence 0.99. Production remains +21/-13 (net +8), tests unchanged: the private membership table owns the static fact while capability checks and fresh response construction remain per request. The original 13-case pairs, 28-stage full check and benchmark remain historical evidence; no tests or measurements were rerun for this mechanical refresh. All adverse tail, first/warm, RSS and core-only scope qualifications above remain in force. Preparing membership adds module-evaluation work and retained arrays; no cold-import or heap improvement is claimed.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/137237#issuecomment-5524177884), reviewed at 2026-09-04 02:02 UTC on `69d576`, reported no code or security finding. Its remaining before-merge requirement and rank-up item are successful required CI on the current head. Exact-head CI for this refresh is still pending; this update does not claim that requirement is satisfied.
