### PR TITLE
refactor(logging): remove redundant stderr spy casts

### DIFF
--- a/src/logging/log-file-size-cap.test.ts
+++ b/src/logging/log-file-size-cap.test.ts
@@ -60,9 +60,7 @@ describe("log file size cap", () => {
   });
 
   it("rotates file writes after cap is reached and keeps logging", async () => {
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(
-      () => true as unknown as ReturnType<typeof process.stderr.write>, // preserve stream contract in test spy
-    );
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 256 });
     const logger = getLogger();
 
@@ -86,9 +84,7 @@ describe("log file size cap", () => {
     vi.spyOn(fs, "renameSync").mockImplementation(() => {
       throw new Error("rotation denied");
     });
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     setLoggerOverride({
       level: "info",
       file: logPath,

--- a/src/logging/logger-env.test.ts
+++ b/src/logging/logger-env.test.ts
@@ -72,9 +72,7 @@ describe("OPENCLAW_LOG_LEVEL", () => {
       file: testLogPath,
     });
     process.env.OPENCLAW_LOG_LEVEL = "nope";
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(
-      () => true as unknown as ReturnType<typeof process.stderr.write>, // preserve stream contract in test spy
-    );
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     expect(getResolvedLoggerSettings().level).toBe("error");
     expect(getResolvedLoggerSettings().maxFileBytes).toBe(defaultMaxFileBytes);
@@ -96,9 +94,7 @@ describe("OPENCLAW_LOG_LEVEL", () => {
       file: testLogPath,
     });
     process.env.OPENCLAW_LOG_LEVEL = "nope";
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     expect(getResolvedConsoleSettings().level).toBe("info");
 


### PR DESCRIPTION
## What Problem This Solves
Four stderr spies use double type assertions even though the stream write method already returns boolean.

## Why This Change Was Made
Return `true` directly, matching the existing transport and console test pattern. The two files retain all nine scenarios and every assertion, queue drain and cleanup step. Production code is unchanged; test code decreases eight lines.

## User Impact
No runtime behavior changes. Environment warning deduplication, JSON diagnostics, file rotation and continued writes remain covered, along with the existing transport durability, privacy and console error-handling tests.

## Evidence
- The same four complete canonical suites passed on baseline and candidate: **53 tests each**, with identical per-file ordered cases.
- The full normal two-file changed gate passed, including services test typechecking, formatting, lint, repository guards and all three dead-export scans.
- Independent Codex review through P2: scoped-clean, no findings.
- The installed dependency graph matched the source lock. The selected stale Vitest cache was cleared once through its normal command before baseline; no install, dependency change or cache override was needed.
- Hosted CI has not run for this unpublished candidate.
