### PR TITLE
fix: fence Session Observer catalog requests

### DIFF
--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -756,6 +756,55 @@ describe("ConfigPage session observer models", () => {
     expect(state.sessionObserverModelsUnavailable).toBe(true);
     expect(modelCatalogStore.loadModelCatalog).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps an earlier request stale after switching away and back to the same agent", async () => {
+    const firstMain = deferred<ModelCatalogResult>();
+    const writer = deferred<ModelCatalogResult>();
+    const secondMain = deferred<ModelCatalogResult>();
+    vi.spyOn(modelCatalogStore, "loadModelCatalog")
+      .mockReturnValueOnce(firstMain.promise)
+      .mockReturnValueOnce(writer.promise)
+      .mockReturnValueOnce(secondMain.promise);
+    const client = {} as GatewayBrowserClient;
+    const gateway = {
+      snapshot: { client, phase: "connected" },
+    } as unknown as ApplicationGateway;
+    const selectionState = { selectedId: "main" as string | null };
+    const page = new ConfigPage();
+    const state = page as unknown as {
+      context: ApplicationContext;
+      systemInfoGatewaySource: ApplicationGateway;
+      sessionObserverModels: ModelCatalogEntry[];
+      ensureSessionObserverModels: (
+        client: GatewayBrowserClient,
+        agentId: string | null,
+      ) => Promise<void>;
+    };
+    Object.defineProperty(page, "isConnected", { configurable: true, value: true });
+    state.context = {
+      gateway,
+      agentSelection: { state: selectionState },
+    } as ApplicationContext;
+    state.systemInfoGatewaySource = gateway;
+
+    const firstMainLoad = state.ensureSessionObserverModels(client, "main");
+    selectionState.selectedId = "writer";
+    const writerLoad = state.ensureSessionObserverModels(client, "writer");
+    selectionState.selectedId = "main";
+    const secondMainLoad = state.ensureSessionObserverModels(client, "main");
+
+    const currentModels = [{ id: "current", name: "Current", provider: "openai" }];
+    secondMain.resolve({ models: currentModels });
+    await secondMainLoad;
+    expect(state.sessionObserverModels).toEqual(currentModels);
+
+    firstMain.resolve({ models: [{ id: "stale", name: "Stale", provider: "openai" }] });
+    writer.resolve({ models: [{ id: "writer", name: "Writer", provider: "openai" }] });
+    await Promise.all([firstMainLoad, writerLoad]);
+
+    expect(state.sessionObserverModels).toEqual(currentModels);
+    expect(modelCatalogStore.loadModelCatalog).toHaveBeenCalledTimes(3);
+  });
 });
 
 describe("ConfigPage curated mutation eligibility", () => {

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -704,11 +704,16 @@ describe("ConfigPage session observer models", () => {
     const firstMain = deferred<ModelCatalogResult>();
     const writer = deferred<ModelCatalogResult>();
     const secondMain = deferred<ModelCatalogResult>();
-    vi.spyOn(modelCatalogStore, "loadModelCatalog")
-      .mockReturnValueOnce(firstMain.promise)
-      .mockReturnValueOnce(writer.promise)
-      .mockReturnValueOnce(secondMain.promise);
-    const client = {} as GatewayBrowserClient;
+    let mainRequests = 0;
+    const request = vi.fn((_method: string, params: unknown) => {
+      const agentId = (params as { agentId?: string }).agentId;
+      if (agentId === "writer") {
+        return writer.promise;
+      }
+      mainRequests += 1;
+      return mainRequests === 1 ? firstMain.promise : secondMain.promise;
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
     const gateway = {
       snapshot: { client, phase: "connected" },
     } as unknown as ApplicationGateway;
@@ -739,6 +744,7 @@ describe("ConfigPage session observer models", () => {
     await writerLoad;
     expect(state.sessionObserverModels).toEqual(writerModels);
 
+    modelCatalogStore.invalidateModelCatalogCache(client);
     selectionState.selectedId = "main";
     const secondMainLoad = state.ensureSessionObserverModels(client, "main");
     const currentMainModels = [{ id: "current-main", name: "Current Main", provider: "openai" }];
@@ -750,27 +756,27 @@ describe("ConfigPage session observer models", () => {
     await mainLoad;
 
     expect(state.sessionObserverModels).toEqual(currentMainModels);
-    expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(1, client, {
+    expect(request).toHaveBeenNthCalledWith(1, "models.list", {
       agentId: "main",
       preparedOnly: true,
-      rejectOnFailure: true,
+      view: "configured",
     });
-    expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(2, client, {
+    expect(request).toHaveBeenNthCalledWith(2, "models.list", {
       agentId: "writer",
       preparedOnly: true,
-      rejectOnFailure: true,
+      view: "configured",
     });
-    expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(3, client, {
+    expect(request).toHaveBeenNthCalledWith(3, "models.list", {
       agentId: "main",
       preparedOnly: true,
-      rejectOnFailure: true,
+      view: "configured",
     });
 
     selectionState.selectedId = null;
     await state.ensureSessionObserverModels(client, null);
     expect(state.sessionObserverModels).toEqual([]);
     expect(state.sessionObserverModelsUnavailable).toBe(true);
-    expect(modelCatalogStore.loadModelCatalog).toHaveBeenCalledTimes(3);
+    expect(request).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -700,12 +700,14 @@ describe("ConfigPage session observer models", () => {
     });
   });
 
-  it("keeps a same-client agent switch from restoring stale observer models", async () => {
-    const main = deferred<ModelCatalogResult>();
+  it("keeps same-client agent switches from restoring stale observer models", async () => {
+    const firstMain = deferred<ModelCatalogResult>();
     const writer = deferred<ModelCatalogResult>();
-    vi.spyOn(modelCatalogStore, "loadModelCatalog").mockImplementation((_client, options) =>
-      options.agentId === "writer" ? writer.promise : main.promise,
-    );
+    const secondMain = deferred<ModelCatalogResult>();
+    vi.spyOn(modelCatalogStore, "loadModelCatalog")
+      .mockReturnValueOnce(firstMain.promise)
+      .mockReturnValueOnce(writer.promise)
+      .mockReturnValueOnce(secondMain.promise);
     const client = {} as GatewayBrowserClient;
     const gateway = {
       snapshot: { client, phase: "connected" },
@@ -735,10 +737,19 @@ describe("ConfigPage session observer models", () => {
     const writerModels = [{ id: "writer-model", name: "Writer Model", provider: "openai" }];
     writer.resolve({ models: writerModels });
     await writerLoad;
-    main.resolve({ models: [{ id: "main-model", name: "Main Model", provider: "openai" }] });
+    expect(state.sessionObserverModels).toEqual(writerModels);
+
+    selectionState.selectedId = "main";
+    const secondMainLoad = state.ensureSessionObserverModels(client, "main");
+    const currentMainModels = [{ id: "current-main", name: "Current Main", provider: "openai" }];
+    secondMain.resolve({ models: currentMainModels });
+    await secondMainLoad;
+    firstMain.resolve({
+      models: [{ id: "stale-main", name: "Stale Main", provider: "openai" }],
+    });
     await mainLoad;
 
-    expect(state.sessionObserverModels).toEqual(writerModels);
+    expect(state.sessionObserverModels).toEqual(currentMainModels);
     expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(1, client, {
       agentId: "main",
       preparedOnly: true,
@@ -749,60 +760,16 @@ describe("ConfigPage session observer models", () => {
       preparedOnly: true,
       rejectOnFailure: true,
     });
+    expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(3, client, {
+      agentId: "main",
+      preparedOnly: true,
+      rejectOnFailure: true,
+    });
 
     selectionState.selectedId = null;
     await state.ensureSessionObserverModels(client, null);
     expect(state.sessionObserverModels).toEqual([]);
     expect(state.sessionObserverModelsUnavailable).toBe(true);
-    expect(modelCatalogStore.loadModelCatalog).toHaveBeenCalledTimes(2);
-  });
-
-  it("keeps an earlier request stale after switching away and back to the same agent", async () => {
-    const firstMain = deferred<ModelCatalogResult>();
-    const writer = deferred<ModelCatalogResult>();
-    const secondMain = deferred<ModelCatalogResult>();
-    vi.spyOn(modelCatalogStore, "loadModelCatalog")
-      .mockReturnValueOnce(firstMain.promise)
-      .mockReturnValueOnce(writer.promise)
-      .mockReturnValueOnce(secondMain.promise);
-    const client = {} as GatewayBrowserClient;
-    const gateway = {
-      snapshot: { client, phase: "connected" },
-    } as unknown as ApplicationGateway;
-    const selectionState = { selectedId: "main" as string | null };
-    const page = new ConfigPage();
-    const state = page as unknown as {
-      context: ApplicationContext;
-      systemInfoGatewaySource: ApplicationGateway;
-      sessionObserverModels: ModelCatalogEntry[];
-      ensureSessionObserverModels: (
-        client: GatewayBrowserClient,
-        agentId: string | null,
-      ) => Promise<void>;
-    };
-    Object.defineProperty(page, "isConnected", { configurable: true, value: true });
-    state.context = {
-      gateway,
-      agentSelection: { state: selectionState },
-    } as ApplicationContext;
-    state.systemInfoGatewaySource = gateway;
-
-    const firstMainLoad = state.ensureSessionObserverModels(client, "main");
-    selectionState.selectedId = "writer";
-    const writerLoad = state.ensureSessionObserverModels(client, "writer");
-    selectionState.selectedId = "main";
-    const secondMainLoad = state.ensureSessionObserverModels(client, "main");
-
-    const currentModels = [{ id: "current", name: "Current", provider: "openai" }];
-    secondMain.resolve({ models: currentModels });
-    await secondMainLoad;
-    expect(state.sessionObserverModels).toEqual(currentModels);
-
-    firstMain.resolve({ models: [{ id: "stale", name: "Stale", provider: "openai" }] });
-    writer.resolve({ models: [{ id: "writer", name: "Writer", provider: "openai" }] });
-    await Promise.all([firstMainLoad, writerLoad]);
-
-    expect(state.sessionObserverModels).toEqual(currentModels);
     expect(modelCatalogStore.loadModelCatalog).toHaveBeenCalledTimes(3);
   });
 });

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -803,12 +803,15 @@ export class ConfigPage extends OpenClawLightDomElement {
       return existing.promise;
     }
     const gatewaySource = this.systemInfoGatewaySource;
+    let promise: Promise<void>;
     const isCurrent = () =>
       this.isConnected &&
       this.systemInfoGatewaySource === gatewaySource &&
       this.context.gateway.snapshot.client === client &&
-      this.context.agentSelection.state.selectedId === agentId;
-    const promise = loadModelCatalog(client, { agentId, preparedOnly: true, rejectOnFailure: true })
+      this.context.agentSelection.state.selectedId === agentId &&
+      // Agent selection can cycle A -> B -> A while the first A load is still pending.
+      this.sessionObserverModelsRequest?.promise === promise;
+    promise = loadModelCatalog(client, { agentId, preparedOnly: true, rejectOnFailure: true })
       .then(({ models }) => {
         if (isCurrent()) {
           this.sessionObserverModels = models;

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -803,7 +803,6 @@ export class ConfigPage extends OpenClawLightDomElement {
       return existing.promise;
     }
     const gatewaySource = this.systemInfoGatewaySource;
-    let promise: Promise<void>;
     const isCurrent = () =>
       this.isConnected &&
       this.systemInfoGatewaySource === gatewaySource &&
@@ -811,7 +810,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       this.context.agentSelection.state.selectedId === agentId &&
       // Agent selection can cycle A -> B -> A while the first A load is still pending.
       this.sessionObserverModelsRequest?.promise === promise;
-    promise = loadModelCatalog(client, { agentId, preparedOnly: true, rejectOnFailure: true })
+    const promise = loadModelCatalog(client, { agentId, preparedOnly: true, rejectOnFailure: true })
       .then(({ models }) => {
         if (isCurrent()) {
           this.sessionObserverModels = models;


### PR DESCRIPTION
Refs #137103
Follow-up to #137171.

## What Problem This Solves

A Session Observer catalog request could become current again after the selected
agent cycled A -> B -> A. If the first A request completed after the newer A
request, its stale result could overwrite the current picker options.

## Root Cause

The completion fence checked the current Gateway client and selected agent, but
those identities are reusable. It did not verify that the completing promise
was still the page's active catalog request.

## Fix

Bind success and failure settlement to the current request promise in addition
to the existing Gateway, client, and agent checks. Older generations can no
longer update or reset the picker after a newer request starts.

## Regression Coverage

The Config-page owner test uses the real shared catalog store. It keeps the
first Main request pending, completes Writer, invalidates the client catalog as
`config.changed` and `chat.metadata.changed` do, starts a distinct newer Main
request, then resolves the original Main request last. The test fails without
the request fence because the stale result replaces Current Main, and passes
with the promise-identity check.

## Verification

- The complete Config-page suite passed 53/53.
- Exact-head Testbox passed lint, the Session Observer browser recovery, all 31
  Session Observer tests, and the 223-test focused UI suite.
- The predicate-removal mutation reproduced the stale overwrite before the
  fence.
- The real Gateway proof preserved unrelated config, selected the recovered
  utility model, and completed Session Observer model work.
- Independent Workloop review and autoreview are clean.
- Exact-head ClawSweeper review is Platinum with no correctness finding. Its
  production-growth item is resolved by the owner-local promise identity fence;
  no net-neutral form preserves the explicit generation check.
- Initial CI failures were isolated to unrelated current-main defects in
  agent-exec timeout coverage and node command-state classification. Both were
  reproduced on current main and repaired by merged PR #137220.

## Visual Evidence

PR #137171 retains the visible picker recovery screenshots and recording. A new
A -> B -> A recording is omitted here because the Settings route coalesces the
held Main request until cache invalidation, and the browser harness cannot drive
that invalidation plus a third generation without mutating private request
state. The real-store owner test is the closest deterministic proof of this
settlement ordering.
