### PR TITLE
fix(daemon): systemd install no longer aborts on "ownership could not be verified" after a clock step

### DIFF
--- a/src/daemon/systemd-deadline-clock-step.test.ts
+++ b/src/daemon/systemd-deadline-clock-step.test.ts
@@ -1,0 +1,173 @@
+// The shared systemd manager budgets are measured on a monotonic clock: a wall-clock step
+// while a probe runs must neither drain the remaining budget to the 1 ms floor nor inflate it.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildSystemdManagerPropertyOutput,
+  buildSystemdUnitPropertyOutput,
+} from "./service.test-helpers.js";
+
+const assertNoSystemOwnership = vi.hoisted(() =>
+  vi.fn<typeof import("./systemd-system.js").assertNoSystemSystemdOwnership>(),
+);
+const busctl = vi.hoisted(() => vi.fn<typeof import("./systemd-exec.js").execBusctlUser>());
+const reloadUserManager = vi.hoisted(() =>
+  vi.fn<typeof import("./systemd-exec.js").reloadSystemdUserManager>(),
+);
+
+vi.mock("./systemd-system.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./systemd-system.js")>()),
+  assertNoSystemSystemdOwnership: assertNoSystemOwnership,
+}));
+vi.mock("./systemd-exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./systemd-exec.js")>()),
+  assertSystemdAvailable: async () => {},
+  execBusctlUser: busctl,
+  reloadSystemdUserManager: reloadUserManager,
+}));
+
+import { withSystemdDefinitionMutation } from "./systemd-definition-mutation.js";
+import { refreshLegacySystemdServiceMetadata } from "./systemd-install.js";
+import { readSystemdServiceExecStart } from "./systemd-service-files.js";
+
+const BUDGET_MS = 5_000;
+const STEPS = [60_000, -60_000] as const;
+
+function unitNotFound(unit: string) {
+  return {
+    code: 1,
+    termination: "exit" as const,
+    stdout: "",
+    stderr: `Call failed: Unit ${unit}.service not found.`,
+  };
+}
+
+function expectBudgetShares(timeouts: Array<number | undefined>, minMs: number) {
+  expect(timeouts.length).toBeGreaterThan(1);
+  for (const timeout of timeouts) {
+    expect(timeout).toBeGreaterThan(minMs);
+    expect(timeout).toBeLessThanOrEqual(BUDGET_MS);
+  }
+}
+
+describe.skipIf(process.platform === "win32")("systemd budgets across a wall-clock step", () => {
+  let root: string;
+  let env: Record<string, string>;
+  let unitPath: string;
+  const realNow = Date.now;
+  let offset = 0;
+
+  beforeEach(async () => {
+    offset = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => realNow() + offset);
+    assertNoSystemOwnership.mockReset().mockResolvedValue(undefined);
+    reloadUserManager.mockReset().mockResolvedValue(undefined);
+    busctl.mockReset();
+    root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-clock-step-")));
+    env = {
+      HOME: path.join(root, "home"),
+      OPENCLAW_STATE_DIR: path.join(root, "state"),
+      OPENCLAW_SYSTEMD_UNIT: "openclaw-owned",
+    };
+    unitPath = path.join(env.HOME!, ".config/systemd/user/openclaw-owned.service");
+    await fs.mkdir(path.dirname(unitPath), { recursive: true });
+    await fs.mkdir(env.OPENCLAW_STATE_DIR!);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it.each(STEPS)(
+    "definition-mutation capability probes keep their budget through a %s ms step",
+    async (stepMs) => {
+      busctl.mockImplementation(async (serviceEnv) => {
+        offset = stepMs;
+        return unitNotFound(serviceEnv.OPENCLAW_SYSTEMD_UNIT ?? "openclaw-owned");
+      });
+
+      await withSystemdDefinitionMutation(env, env, async () => undefined, {
+        timeoutMs: BUDGET_MS,
+      });
+
+      // The budget is split across the remaining manager calls (three at most).
+      expectBudgetShares(
+        busctl.mock.calls.map((call) => call[2]),
+        BUDGET_MS / 3 - 100,
+      );
+    },
+  );
+
+  it.each(STEPS)(
+    "effective-manager queries for a loaded unit keep their budget through a %s ms step",
+    async (stepMs) => {
+      const snapshot = {
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        fragmentPath: "/etc/systemd/user/openclaw-owned.service",
+      };
+      busctl.mockImplementation(async (_serviceEnv, args) => {
+        offset = stepMs;
+        const stdout = args.includes("LoadUnit")
+          ? JSON.stringify({
+              type: "o",
+              data: ["/org/freedesktop/systemd1/unit/openclaw_2downed_2eservice"],
+            })
+          : args.includes("org.freedesktop.systemd1.Unit")
+            ? buildSystemdUnitPropertyOutput(snapshot)
+            : buildSystemdManagerPropertyOutput(snapshot);
+        return { code: 0, termination: "exit" as const, stdout, stderr: "" };
+      });
+
+      await expect(
+        readSystemdServiceExecStart(env, { requireEffective: true, timeoutMs: BUDGET_MS }),
+      ).resolves.toMatchObject({ programArguments: snapshot.programArguments });
+
+      expect(busctl).toHaveBeenCalledTimes(3);
+      expectBudgetShares(
+        busctl.mock.calls.map((call) => call[2]),
+        BUDGET_MS / 3 - 100,
+      );
+    },
+  );
+
+  it.each(STEPS)(
+    "legacy metadata refresh keeps its operation budget through a %s ms step",
+    async (stepMs) => {
+      await fs.writeFile(
+        unitPath,
+        [
+          "[Unit]",
+          "Description=OpenClaw Gateway (v2026.7.1-2)",
+          "",
+          "[Service]",
+          "ExecStart=/usr/bin/openclaw gateway run",
+          "Environment=OPENCLAW_SERVICE_MARKER=openclaw",
+          "Environment=OPENCLAW_SERVICE_KIND=gateway",
+          'Environment=OPENCLAW_SERVICE_VERSION=2026.7.1-2 "OTHER_SETTING=kept value"',
+          "Environment=OPENCLAW_GATEWAY_PORT=18789",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      busctl.mockImplementation(async (serviceEnv) =>
+        unitNotFound(serviceEnv.OPENCLAW_SYSTEMD_UNIT ?? "openclaw-owned"),
+      );
+      assertNoSystemOwnership.mockImplementation(async () => {
+        offset = stepMs;
+      });
+
+      await expect(refreshLegacySystemdServiceMetadata(env, BUDGET_MS)).resolves.toBe(true);
+
+      // Three ownership checks plus the manager reload draw on one operation budget.
+      const timeouts = [
+        ...assertNoSystemOwnership.mock.calls.map((call) => call[1]),
+        ...reloadUserManager.mock.calls.map((call) => call[1]),
+      ];
+      expect(assertNoSystemOwnership).toHaveBeenCalledTimes(3);
+      expectBudgetShares(timeouts, BUDGET_MS - 1_000);
+    },
+  );
+});

--- a/src/daemon/systemd-definition-mutation.test.ts
+++ b/src/daemon/systemd-definition-mutation.test.ts
@@ -1019,6 +1019,40 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
     }
   });
 
+  it.each([60_000, -60_000])(
+    "keeps the mutation deadline through a %s ms wall-clock step",
+    async (stepMs) => {
+      const now = Date.now;
+      let offset = 0;
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => now() + offset);
+      busctl.mockImplementation(async (serviceEnv) => {
+        offset = stepMs;
+        return {
+          code: 1,
+          termination: "exit",
+          stdout: "",
+          stderr: `Call failed: Unit ${serviceEnv.OPENCLAW_SYSTEMD_UNIT}.service not found.`,
+        };
+      });
+      try {
+        await withSystemdDefinitionMutation(env, env, async () => undefined, {
+          timeoutMs: 5_000,
+        });
+
+        expect(busctl).toHaveBeenCalled();
+        for (const call of busctl.mock.calls) {
+          // The budget is split across the remaining manager calls; the clock step must
+          // neither drain a share to the 1 ms floor nor inflate it past the whole budget.
+          const timeoutMs = call[2];
+          expect(timeoutMs).toBeGreaterThan(1_000);
+          expect(timeoutMs).toBeLessThanOrEqual(5_000);
+        }
+      } finally {
+        clock.mockRestore();
+      }
+    },
+  );
+
   it("bounds lock acquisition by the mutation deadline", async () => {
     const { promise: barrier, resolve: release } = createDeferred();
     const { promise: firstStarted, resolve: entered } = createDeferred();

--- a/src/daemon/systemd-definition-mutation.test.ts
+++ b/src/daemon/systemd-definition-mutation.test.ts
@@ -1019,40 +1019,6 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
     }
   });
 
-  it.each([60_000, -60_000])(
-    "keeps the mutation deadline through a %s ms wall-clock step",
-    async (stepMs) => {
-      const now = Date.now;
-      let offset = 0;
-      const clock = vi.spyOn(Date, "now").mockImplementation(() => now() + offset);
-      busctl.mockImplementation(async (serviceEnv) => {
-        offset = stepMs;
-        return {
-          code: 1,
-          termination: "exit",
-          stdout: "",
-          stderr: `Call failed: Unit ${serviceEnv.OPENCLAW_SYSTEMD_UNIT}.service not found.`,
-        };
-      });
-      try {
-        await withSystemdDefinitionMutation(env, env, async () => undefined, {
-          timeoutMs: 5_000,
-        });
-
-        expect(busctl).toHaveBeenCalled();
-        for (const call of busctl.mock.calls) {
-          // The budget is split across the remaining manager calls; the clock step must
-          // neither drain a share to the 1 ms floor nor inflate it past the whole budget.
-          const timeoutMs = call[2];
-          expect(timeoutMs).toBeGreaterThan(1_000);
-          expect(timeoutMs).toBeLessThanOrEqual(5_000);
-        }
-      } finally {
-        clock.mockRestore();
-      }
-    },
-  );
-
   it("bounds lock acquisition by the mutation deadline", async () => {
     const { promise: barrier, resolve: release } = createDeferred();
     const { promise: firstStarted, resolve: entered } = createDeferred();

--- a/src/daemon/systemd-definition-mutation.ts
+++ b/src/daemon/systemd-definition-mutation.ts
@@ -179,12 +179,12 @@ export async function readSystemdDefinitionMutationCapability(
   const selected = path.basename(resolveSystemdUnitPath(env));
   const names =
     selected === "openclaw-gateway.service" ? [selected, "openclaw.service"] : [selected];
-  const deadlineAt = options?.timeoutMs ? Date.now() + options.timeoutMs : undefined;
+  const deadlineAt = options?.timeoutMs ? performance.now() + options.timeoutMs : undefined;
   for (const name of names) {
     try {
       await assertNoSystemSystemdOwnership(
         name,
-        deadlineAt === undefined ? undefined : Math.max(1, deadlineAt - Date.now()),
+        deadlineAt === undefined ? undefined : Math.max(1, deadlineAt - performance.now()),
       );
     } catch (error) {
       const owned =
@@ -204,9 +204,9 @@ export async function withSystemdDefinitionMutation<T>(
   options?: { timeoutMs?: number },
 ): Promise<T> {
   const deadlineAt =
-    options?.timeoutMs && options.timeoutMs > 0 ? Date.now() + options.timeoutMs : undefined;
+    options?.timeoutMs && options.timeoutMs > 0 ? performance.now() + options.timeoutMs : undefined;
   const remainingTimeoutMs = () =>
-    deadlineAt === undefined ? undefined : Math.max(1, deadlineAt - Date.now());
+    deadlineAt === undefined ? undefined : Math.max(1, deadlineAt - performance.now());
   let initial = await inspect(env, environment, remainingTimeoutMs());
   assertServiceDefinitionWritable(initial.capability);
   const { unit, generated } = resolveMutationTargets(env, environment);

--- a/src/daemon/systemd-install.ts
+++ b/src/daemon/systemd-install.ts
@@ -210,8 +210,8 @@ export async function refreshLegacySystemdServiceMetadata(
   env: GatewayServiceEnv,
   timeoutMs: number,
 ): Promise<boolean> {
-  const deadlineAt = Date.now() + Math.max(1, timeoutMs);
-  const remainingTimeoutMs = () => Math.max(1, deadlineAt - Date.now());
+  const deadlineAt = performance.now() + Math.max(1, timeoutMs);
+  const remainingTimeoutMs = () => Math.max(1, deadlineAt - performance.now());
   const unitPath = resolveSystemdUnitPath(env);
   const current = await fs.readFile(unitPath, "utf8").catch((error: unknown) => {
     if (hasErrnoCode(error, "ENOENT")) {

--- a/src/daemon/systemd-service-files.ts
+++ b/src/daemon/systemd-service-files.ts
@@ -99,14 +99,14 @@ async function readSystemdManagerCommand(
   const unavailable = () => new Error("Effective systemd service command could not be inspected.");
   const timeoutMs =
     opts?.timeoutMs && opts.timeoutMs > 0 ? opts.timeoutMs : SYSTEMD_MANAGER_QUERY_TIMEOUT_MS;
-  const deadlineAt = Date.now() + timeoutMs;
+  const deadlineAt = performance.now() + timeoutMs;
   let remainingCalls = 3;
   // All manager D-Bus calls share one deadline so wedged reads reach local fallback promptly.
   const query = async (args: string[], signatures: string[]): Promise<unknown[] | null> => {
     const result = await execBusctlUser(
       env,
       ["--json=short", ...args],
-      Math.max(1, Math.floor((deadlineAt - Date.now()) / remainingCalls--)),
+      Math.max(1, Math.floor((deadlineAt - performance.now()) / remainingCalls--)),
     );
     if (result.code !== 0) {
       if (

--- a/src/daemon/systemd-system.test.ts
+++ b/src/daemon/systemd-system.test.ts
@@ -173,7 +173,7 @@ describe("system systemd ownership", () => {
 
   it("shares one timeout budget across system-manager ownership probes", async () => {
     let now = 1_000;
-    const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const clock = vi.spyOn(performance, "now").mockImplementation(() => now);
     execFileUtf8.mockImplementation(async (_command, args) => {
       now += 20;
       return args.includes("--property=UnitPath") ? state.managerUnitPath : state.systemctl;
@@ -202,6 +202,31 @@ describe("system systemd ownership", () => {
       clock.mockRestore();
     }
   });
+
+  it.each([60_000, -60_000])(
+    "keeps the shared timeout budget through a %s ms wall-clock step",
+    async (stepMs) => {
+      const now = Date.now;
+      let offset = 0;
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => now() + offset);
+      execFileUtf8.mockImplementation(async (_command, args) => {
+        offset = stepMs;
+        return args.includes("--property=UnitPath") ? state.managerUnitPath : state.systemctl;
+      });
+      try {
+        await expect(
+          assertNoSystemSystemdOwnership("openclaw-gateway.service", 5_000),
+        ).resolves.toBeUndefined();
+        const timeouts = execFileUtf8.mock.calls.map((call) => call[2]?.timeout ?? 0);
+        expect(timeouts).toHaveLength(3);
+        // Only real elapsed time (tens of ms) may leave the budget; the clock step must
+        // neither drain it to the 1 ms floor nor inflate it past the budget.
+        expect(timeouts.every((timeout) => timeout > 4_000 && timeout <= 5_000)).toBe(true);
+      } finally {
+        clock.mockRestore();
+      }
+    },
+  );
 
   it.each([
     "Failed to connect to bus: Permission denied",

--- a/src/daemon/systemd-system.ts
+++ b/src/daemon/systemd-system.ts
@@ -103,13 +103,9 @@ async function inspectSystemSystemdOwnership(
     return { status: "absent", unitName };
   }
 
-  const deadlineAt = timeoutMs && timeoutMs > 0 ? performance.now() + timeoutMs : undefined;
-  const run = (args: string[]) =>
-    execSystemctl(
-      args,
-      undefined,
-      deadlineAt ? Math.max(1, deadlineAt - performance.now()) : undefined,
-    );
+  const deadline = timeoutMs && timeoutMs > 0 ? performance.now() + timeoutMs : undefined;
+  const remaining = () => (deadline ? Math.max(1, deadline - performance.now()) : undefined);
+  const run = (args: string[]) => execSystemctl(args, undefined, remaining());
   const initialQuery = await querySystemManager(unitName, run);
   if (initialQuery.status !== "absent") {
     return initialQuery;

--- a/src/daemon/systemd-system.ts
+++ b/src/daemon/systemd-system.ts
@@ -103,9 +103,13 @@ async function inspectSystemSystemdOwnership(
     return { status: "absent", unitName };
   }
 
-  const deadlineAt = timeoutMs && timeoutMs > 0 ? Date.now() + timeoutMs : undefined;
+  const deadlineAt = timeoutMs && timeoutMs > 0 ? performance.now() + timeoutMs : undefined;
   const run = (args: string[]) =>
-    execSystemctl(args, undefined, deadlineAt ? Math.max(1, deadlineAt - Date.now()) : undefined);
+    execSystemctl(
+      args,
+      undefined,
+      deadlineAt ? Math.max(1, deadlineAt - performance.now()) : undefined,
+    );
   const initialQuery = await querySystemManager(unitName, run);
   if (initialQuery.status !== "absent") {
     return initialQuery;

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1943,7 +1943,7 @@ describe("readSystemdServiceExecStart", () => {
   it("fairly reserves the shared deadline across all three manager queries", async () => {
     mockReadGatewayServiceFile(["[Service]", "ExecStart=/usr/bin/openclaw gateway run"]);
     mockSystemdManagerSnapshot({ programArguments: ["/usr/bin/openclaw", "gateway", "run"] });
-    vi.spyOn(Date, "now")
+    vi.spyOn(performance, "now")
       .mockReturnValueOnce(1_000)
       .mockReturnValueOnce(1_000)
       .mockReturnValueOnce(1_100)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators installing, repairing, or updating the Gateway systemd service would see the operation abort with `System systemd ownership for openclaw-gateway.service could not be verified: Command timed out` when the system clock stepped forward while the ownership probes were running (NTP correction, VM resume, manual clock change). A backward step had the opposite effect: the remaining timeout for the manager calls grew far past the configured budget.

`assertNoSystemSystemdOwnership()`, the systemd definition-mutation capability probes, the effective-manager queries for a loaded unit (`readSystemdServiceExecStart()`), and the legacy metadata refresh (`refreshLegacySystemdServiceMetadata()`) each hand their `systemctl` / `busctl` calls the time left on one shared budget, and derived that remaining time from `Date.now()`. After a forward step the later calls got the 1 ms floor, so the manager command was killed immediately and the operation failed closed.

## Why This Change Was Made

All four shared budgets (`systemd-system.ts`, `systemd-definition-mutation.ts`, `systemd-service-files.ts`, `systemd-install.ts`) are now measured with `performance.now()`, the same change the ssh tunnel listener received in #135281. Which calls are made, how the budget is split across them, the `SIGKILL` timeout policy, and the fail-closed behavior on real timeouts are unchanged; only the clock the existing remaining-time arithmetic reads is different. Production is a line-for-line replacement (+11/−11).

## User Impact

`openclaw daemon` install / repair / update on systemd hosts is no longer aborted by a wall-clock adjustment during the ownership check, and the manager probes keep their configured budget in both directions. No configuration or API changes.

## Evidence

### Real `systemctl` across an in-process wall-clock step

Driver calling the real `assertNoSystemSystemdOwnership("openclaw-gateway.service", 2000)` on a systemd 249 host (Ubuntu 22.04). `systemctl` on `PATH` is a wrapper that sleeps 100 ms and then execs `/usr/bin/systemctl`, so each probe takes a visible slice of the budget; the driver replaces `Date.now` in-process and steps it +60 s 50 ms into the first probe. `performance.now()` timestamps are shown as `t+`.

Before this change, the check fails closed and the daemon command would abort:

```
[t+   51ms] wall clock stepped by +60000 ms during the first systemctl probe (budget 2000 ms, each real systemctl call delayed 100 ms)
[t+  232ms] assertNoSystemSystemdOwnership REJECTED: System systemd ownership for openclaw-gateway.service could not be verified: Command timed out
```

After this change, the remaining probes keep their budget and the check completes:

```
[t+   51ms] wall clock stepped by +60000 ms during the first systemctl probe (budget 2000 ms, each real systemctl call delayed 100 ms)
[t+  360ms] assertNoSystemSystemdOwnership resolved: no system-manager ownership, install may proceed
```

### Real loaded user unit: effective-manager read and daemon update path across a wall-clock step

Same host, root's own systemd user manager (`user@0.service`, linger enabled). The driver writes a real unit `~/.config/systemd/user/openclaw-clockproof.service` carrying the legacy `OPENCLAW_SERVICE_VERSION` metadata, runs `systemctl --user daemon-reload` (LoadState=loaded), and then calls the real production functions with `OPENCLAW_SYSTEMD_UNIT=openclaw-clockproof`. `busctl` and `systemctl` on `PATH` are wrappers that sleep 100 ms and exec the real binaries; the driver steps `Date.now` +60 s 50 ms into the first manager call. Budget 5000 ms (with the 100 ms wrapper delay the full refresh needs ~3.1 s of real manager calls). The unit is removed and the manager reloaded afterwards.

**Effective-manager read of the loaded unit** (`readSystemdServiceExecStart(env, { requireEffective: true })`: `LoadUnit` + two property reads on one budget). Before this change the later `busctl` calls get the 1 ms floor and the read fails closed:

```
[t+   50ms] wall clock stepped by +60000 ms during the first manager call (budget 5000 ms)
[t+  241ms] readSystemdServiceExecStart REJECTED: Effective systemd service command could not be inspected.
```

After this change:

```
[t+   52ms] wall clock stepped by +60000 ms during the first manager call (budget 5000 ms)
[t+  374ms] readSystemdServiceExecStart(requireEffective) resolved: programArguments=["/bin/sleep","infinity"] sourcePath=/root/.config/systemd/user/openclaw-clockproof.service
```

**Daemon update path** (`refreshLegacySystemdServiceMetadata(env, 5000)`: three ownership rechecks, the mutation capability probes, publication, and the manager reload on one operation budget). Before this change the second ownership recheck gets the 1 ms floor and the update aborts:

```
[t+   51ms] wall clock stepped by +60000 ms during the first manager call (budget 5000 ms)
[t+  155ms] refreshLegacySystemdServiceMetadata REJECTED: System systemd ownership for openclaw-clockproof.service could not be verified: Command timed out
```

After this change the legacy metadata is rewritten and the manager reloaded, identical to the run without a clock step (3100 ms):

```
[t+   51ms] wall clock stepped by +60000 ms during the first manager call (budget 5000 ms)
[t+ 3128ms] refreshLegacySystemdServiceMetadata resolved: true; unit still carries OPENCLAW_SERVICE_VERSION: false
```

### Tests and checks

- `src/daemon/systemd-deadline-clock-step.test.ts` (new file, so the existing mutation test file stays within its `max-lines` budget) covers a ±60 s `Date.now()` step inside the first manager call for all three multi-call operations: the definition-mutation capability probes, the effective-manager queries for a loaded unit (`LoadUnit` plus two property reads), and the legacy metadata refresh (three ownership rechecks plus the manager reload). Each asserts every later timeout stays a fair share of the 5 s budget, neither the 1 ms floor nor above the budget. All six cases fail on `main` and pass here.
- `src/daemon/systemd-system.test.ts`: `keeps the shared timeout budget through a ±60000 ms wall-clock step` for the direct ownership probes; the existing shared-budget test and `systemd.test.ts`'s "fairly reserves the shared deadline" test now drive the monotonic clock.
- `pnpm test` for `systemd-system`, `systemd-definition-mutation`, `systemd` and the new file: all clock-step and budget tests pass. Pre-existing failures in this environment, identical on `main` and unrelated to the change: five `root-owned` / `aliased` cases in `systemd-definition-mutation.test.ts` and `uses the sudo-u target user for install activation machine-scope retry` in `systemd.test.ts` (the suite runs as root here).
- `pnpm format:check`, `tsgo` for `tsconfig.core.json`, and the `services` core-test shard typecheck passed locally; lint runs in CI.

### Maintainer landing review

- Exact reviewed head: `840adb60cb5f0a1d74b5c4638e0e09c787a984a5`.
- The effective diff against current `main` is conflict-free; `git diff --check` and `git merge-tree --write-tree` passed.
- Fresh independent P0/P1 review found no actionable findings.
- Exact-head CI rerun attempt 2 passed on September 6, 2026, including `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/33886206021
- The latest durable ClawSweeper review covers this exact head and reports `Before merge: None`.
