### PR TITLE
test(infra): reuse the shared npm call presence guard

### DIFF
--- a/src/infra/npm-managed-root.test.ts
+++ b/src/infra/npm-managed-root.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { CommandOptions } from "../process/exec.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
@@ -76,17 +77,6 @@ async function expectPathMissing(targetPath: string): Promise<void> {
     return;
   }
   throw new Error(`Expected path to be missing: ${targetPath}`);
-}
-
-function requireFirstMockCall<T extends unknown[]>(
-  mock: { mock: { calls: T[] } },
-  label: string,
-): T {
-  const call = mock.mock.calls[0];
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call;
 }
 
 function requireCommandOptions(
@@ -859,7 +849,10 @@ describe("managed npm root", () => {
 
     await expect(syncManagedNpmRootPeerDependencies({ npmRoot, runCommand })).resolves.toBe(true);
 
-    const [args, rawOptions] = requireFirstMockCall(runCommand, "npm peer plan command");
+    const [args, rawOptions] = expectDefined(
+      runCommand.mock.calls[0],
+      "npm peer plan command call",
+    );
     const options = requireCommandOptions(rawOptions, "npm peer plan");
     expect(args).toEqual([
       "npm",
@@ -1419,7 +1412,10 @@ describe("managed npm root", () => {
     const runCommand = vi.fn().mockResolvedValue(successfulSpawn);
     await expect(repairManagedNpmRootOpenClawPeer({ npmRoot, runCommand })).resolves.toBe(true);
     expect(runCommand).toHaveBeenCalledTimes(1);
-    const [repairArgs, rawRepairOptions] = requireFirstMockCall(runCommand, "repair command");
+    const [repairArgs, rawRepairOptions] = expectDefined(
+      runCommand.mock.calls[0],
+      "repair command call",
+    );
     const repairOptions = requireCommandOptions(rawRepairOptions, "repair");
     expect(repairArgs).toEqual([
       "npm",


### PR DESCRIPTION
## What Problem This Solves

The managed npm-root tests use a local generic helper solely to unwrap the first recorded command call, duplicating existing assertion support.

## Why This Change Was Made

Use the shared `expectDefined` helper through its narrow entrypoint at both assertion sites. Preserve first-call tuple checks, the existing repair call count, and all command arguments and options. Keep `requireCommandOptions`, which distinguishes the runner's numeric options variant.

## User Impact

No runtime behavior changes. All existing fallback, manifest and lockfile, plugin preservation, host and symlink, executable-shim, path-safety, and fixture-cleanup assertions remain. Production: 0 lines changed; tests: +9/-13 (net -4). No test cases were added or removed.

## Evidence

- The same complete managed npm-root, safe-package-install, and canonical assertion-helper suites passed all 39 cases before and after, with identical case inventories and suite order.
- `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- src/infra/npm-managed-root.test.ts`: all 20 selected canonical local stages passed, including infra test types, unused-export scans, and type-aware lint.
- Formatting and independent Codex review passed with no actionable P0-P2 findings. Node 26.8.1 was pinned. This is test-only proof; no live npm operation was needed.
