### PR TITLE
fix(ui): keep dashboard progress tied to target runs

### DIFF
--- a/ui/src/components/board/board-widget-cell-plugin.test.ts
+++ b/ui/src/components/board/board-widget-cell-plugin.test.ts
@@ -215,6 +215,10 @@ describe("plugin board widget cells", () => {
     for (const [index, scenario] of responses.entries()) {
       const request = vi.fn(async () => scenario.response);
       const context = {
+        agentSelection: {
+          state: { scopeId: null },
+          subscribe: () => () => undefined,
+        },
         sessions: {
           state: {
             result: {
@@ -239,6 +243,33 @@ describe("plugin board widget cells", () => {
             },
           },
           subscribe: () => () => undefined,
+          subscribeList: () => () => undefined,
+          listSnapshot: () => ({
+            result: {
+              sessions: [
+                { key: "global", agentId: "main", status: "failed", startedAt: 0, endedAt: 2 },
+                { key: "global", agentId: "research", status: "done", startedAt: 0, endedAt: 2 },
+                {
+                  key: "agent:main:notes",
+                  agentId: "main",
+                  status: "failed",
+                  startedAt: 0,
+                  endedAt: 2,
+                },
+                {
+                  key: "agent:research:notes",
+                  agentId: "research",
+                  status: "done",
+                  startedAt: 0,
+                  endedAt: 2,
+                },
+              ],
+            },
+            agentId: null,
+            loading: false,
+            error: null,
+          }),
+          refreshList: async () => undefined,
         },
         gateway: {
           snapshot: {
@@ -354,6 +385,16 @@ describe("plugin board widget cells", () => {
       };
     });
     const context = {
+      agentSelection: {
+        state: { scopeId: null },
+        subscribe: () => () => undefined,
+      },
+      sessions: {
+        subscribe: () => () => undefined,
+        subscribeList: () => () => undefined,
+        listSnapshot: () => ({ result: null, agentId: null, loading: false, error: null }),
+        refreshList: async () => undefined,
+      },
       gateway: {
         snapshot: {
           phase: "connected",
@@ -472,5 +513,110 @@ describe("plugin board widget cells", () => {
     );
     expect(cell.querySelector('[data-test-id="session-progress-error"] button')).toBeNull();
     expect(request).toHaveBeenCalledTimes(6);
+  });
+
+  it("keeps a board-less running target live on another session's dashboard", async () => {
+    const boardOwnerKey = "agent:main:dashboard";
+    const boardlessTargetKey = "agent:main:boardless";
+    const now = Date.now();
+    const targetRow = {
+      key: boardlessTargetKey,
+      agentId: "main",
+      status: "running",
+      hasActiveRun: true,
+      startedAt: now - 60_000,
+    };
+    const rosterQueries: Array<{ hasBoard?: boolean }> = [];
+    const request = vi.fn(async () => ({
+      card: {
+        sessionKey: boardlessTargetKey,
+        revision: 1,
+        updatedAt: now,
+        markdown: `Progress for ${boardlessTargetKey}`,
+        steps: [{ step: "Owned work", status: "in_progress" }],
+      },
+    }));
+    const context = {
+      agentSelection: {
+        state: { scopeId: null },
+        subscribe: () => () => undefined,
+      },
+      sessions: {
+        state: { result: null },
+        subscribe: () => () => undefined,
+        subscribeList: (query: { hasBoard?: boolean }) => {
+          rosterQueries.push(query);
+          return () => undefined;
+        },
+        listSnapshot: (query: { hasBoard?: boolean }) => ({
+          // The Gateway filters hasBoard against each session's own board
+          // inventory, so the board-less target only exists in the shared roster.
+          result: {
+            sessions: [
+              { key: boardOwnerKey, agentId: "main", status: "done", startedAt: 0, endedAt: 2 },
+              ...(query.hasBoard ? [] : [targetRow]),
+            ],
+          },
+          agentId: null,
+          loading: false,
+          error: null,
+        }),
+        refreshList: async () => undefined,
+      },
+      gateway: {
+        snapshot: {
+          phase: "connected",
+          client: { request },
+          hello: {
+            features: { methods: ["progressCard.get"] },
+            controlUiWidgetKinds: [
+              { pluginId: "session", kind: "session:progress", label: "Session progress" },
+            ],
+          },
+        },
+        subscribe: () => () => undefined,
+        subscribeEvents: () => () => undefined,
+      },
+    } as unknown as ApplicationContext;
+    const widget: BoardWidget = {
+      name: "cross-session-progress",
+      tabId: "main",
+      title: "Session progress",
+      contentKind: "plugin",
+      pluginKind: "session:progress",
+      props: { sessionKey: boardlessTargetKey },
+      sizeW: 6,
+      sizeH: 4,
+      position: 0,
+      grantState: "none",
+      revision: 1,
+    };
+    const provider = createApplicationContextProvider(context);
+    const cell = document.createElement("openclaw-board-widget-cell");
+    cell.widget = widget;
+    cell.rect = { name: widget.name, x: 0, y: 0, w: 6, h: 4 };
+    cell.sessionKey = boardOwnerKey;
+    cell.session = { sessionKey: boardOwnerKey, agentId: "main" };
+    cell.active = true;
+    cell.callbacks = callbacks();
+    provider.append(cell);
+    document.body.append(provider);
+
+    await vi.waitFor(
+      () =>
+        expect(request).toHaveBeenCalledWith("progressCard.get", {
+          sessionKey: boardlessTargetKey,
+        }),
+      CHUNK_LOAD_WAIT,
+    );
+    const element = cell.querySelector("openclaw-session-progress-widget");
+    await vi.waitFor(
+      () => expect(element?.querySelector(".session-run-spinner")).not.toBeNull(),
+      CHUNK_LOAD_WAIT,
+    );
+    expect(element?.querySelector(".session-progress-card__step--paused")).toBeNull();
+    // Liveness must not depend on dashboard gallery membership.
+    expect(rosterQueries.length).toBeGreaterThan(0);
+    expect(rosterQueries.every((query) => query.hasBoard === undefined)).toBe(true);
   });
 });

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -221,6 +221,86 @@ describe("renderSessionProgressCard", () => {
     expect(pausedStep?.querySelector("polyline")).not.toBeNull();
   });
 
+  it.each([
+    ["stale", RUN_STARTED_MS - 1, "paused", false],
+    ["current", RUN_STARTED_MS, "in_progress", true],
+  ] as const)(
+    "treats %s progress as current only after the active run starts",
+    (_name, updatedAt, expectedStatus, expectedLive) => {
+      const container = document.createElement("div");
+      render(
+        renderSessionProgressCard(
+          { ...progressCard, updatedAt },
+          "composer",
+          undefined,
+          "running",
+          RUN_STARTED_MS,
+          undefined,
+          true,
+        ),
+        container,
+      );
+
+      expect(
+        container.querySelector(
+          `.session-progress-card__current-marker[data-status="${expectedStatus}"]`,
+        ),
+      ).not.toBeNull();
+      expect(container.querySelector(".session-run-spinner") !== null).toBe(expectedLive);
+    },
+  );
+
+  it("pauses timestamped progress while a later active run is still queued", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionProgressCard(
+        { ...progressCard, updatedAt: RUN_STARTED_MS - 1 },
+        "composer",
+        undefined,
+        "queued",
+        undefined,
+        undefined,
+        true,
+      ),
+      container,
+    );
+
+    expect(
+      container.querySelector('.session-progress-card__current-marker[data-status="paused"]'),
+    ).not.toBeNull();
+    expect(container.querySelector(".session-progress-card__step--paused")).not.toBeNull();
+    expect(container.querySelector(".session-run-spinner")).toBeNull();
+  });
+
+  it.each([
+    ["stale", RUN_STARTED_MS - 1, "paused", false],
+    ["current", RUN_STARTED_MS, "in_progress", true],
+  ] as const)(
+    "treats %s status-less progress as current only after the active run starts",
+    (_name, updatedAt, expectedStatus, expectedLive) => {
+      const container = document.createElement("div");
+      render(
+        renderSessionProgressCard(
+          { ...progressCard, updatedAt },
+          "composer",
+          undefined,
+          undefined,
+          RUN_STARTED_MS,
+          undefined,
+          true,
+        ),
+        container,
+      );
+
+      expect(
+        container.querySelector(
+          `.session-progress-card__current-marker[data-status="${expectedStatus}"]`,
+        ),
+      ).not.toBeNull();
+      expect(container.querySelector(".session-run-spinner") !== null).toBe(expectedLive);
+    },
+  );
+
   it("keeps a disclosure affordance beside a completed dismissible composer card", () => {
     const container = document.createElement("div");
     const completed = {

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -250,27 +250,33 @@ describe("renderSessionProgressCard", () => {
     },
   );
 
-  it("pauses timestamped progress while a later active run is still queued", () => {
-    const container = document.createElement("div");
-    render(
-      renderSessionProgressCard(
-        { ...progressCard, updatedAt: RUN_STARTED_MS - 1 },
-        "composer",
-        undefined,
-        "queued",
-        undefined,
-        undefined,
-        true,
-      ),
-      container,
-    );
+  it.each([
+    ["fresh", undefined, undefined],
+    ["reused", RUN_STARTED_MS - 1_000, RUN_STARTED_MS],
+  ] as const)(
+    "pauses timestamped progress while a %s session run is queued",
+    (_name, startedAt, endedAt) => {
+      const container = document.createElement("div");
+      render(
+        renderSessionProgressCard(
+          { ...progressCard, updatedAt: RUN_STARTED_MS - 1 },
+          "composer",
+          undefined,
+          "queued",
+          startedAt,
+          endedAt,
+          true,
+        ),
+        container,
+      );
 
-    expect(
-      container.querySelector('.session-progress-card__current-marker[data-status="paused"]'),
-    ).not.toBeNull();
-    expect(container.querySelector(".session-progress-card__step--paused")).not.toBeNull();
-    expect(container.querySelector(".session-run-spinner")).toBeNull();
-  });
+      expect(
+        container.querySelector('.session-progress-card__current-marker[data-status="paused"]'),
+      ).not.toBeNull();
+      expect(container.querySelector(".session-progress-card__step--paused")).not.toBeNull();
+      expect(container.querySelector(".session-run-spinner")).toBeNull();
+    },
+  );
 
   it.each([
     ["stale", RUN_STARTED_MS - 1, "paused", false],

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -357,8 +357,15 @@ export function renderSessionProgressCard(
     validEndedAt >= validStartedAt &&
     validUpdatedAt !== undefined &&
     validUpdatedAt >= validStartedAt;
-  // A later run does not own durable progress last updated before it started.
-  const effectiveHasActiveRun = hasActiveRun && !isProgressCardStaleForRun(card, startedAt);
+  // A later run does not own durable progress last updated before it starts.
+  // A queued run has no start timestamp, so prior progress remains paused.
+  const hasCurrentRunActivity =
+    hasActiveRun &&
+    !isProgressCardStaleForRun(card, startedAt) &&
+    (validUpdatedAt === undefined ||
+      (validStartedAt === undefined
+        ? sessionStatus === undefined
+        : validUpdatedAt >= validStartedAt));
   const terminalTimestamp =
     sessionStatus && TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus] && hasValidRunWindow
       ? validEndedAt
@@ -414,7 +421,7 @@ export function renderSessionProgressCard(
         })
       : nothing;
     const presentedCurrentStatus =
-      currentStep?.status === "in_progress" && !effectiveHasActiveRun && !terminalOutcomeKey
+      currentStep?.status === "in_progress" && !hasCurrentRunActivity && !terminalOutcomeKey
         ? "paused"
         : currentStep?.status;
     const summaryIndicator =
@@ -487,7 +494,7 @@ export function renderSessionProgressCard(
       </summary>
       <div class="session-progress-card__body" role="region" aria-label=${composerCountLabel}>
         ${renderProgressCardMarkdown(card.markdown)}
-        ${renderSteps(card, effectiveHasActiveRun, effectiveSessionStatus)}
+        ${renderSteps(card, hasCurrentRunActivity, effectiveSessionStatus)}
       </div>
     </details>`;
   }
@@ -504,6 +511,6 @@ export function renderSessionProgressCard(
         >${dismiss}
       </span>
     </div>
-    ${renderBody(card, effectiveHasActiveRun, effectiveSessionStatus)}
+    ${renderBody(card, hasCurrentRunActivity, effectiveSessionStatus)}
   </section>`;
 }

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -358,14 +358,13 @@ export function renderSessionProgressCard(
     validUpdatedAt !== undefined &&
     validUpdatedAt >= validStartedAt;
   // A later run does not own durable progress last updated before it starts.
-  // A queued run has no start timestamp, so prior progress remains paused.
+  // Queued runs can retain the previous run's timestamps, but do not own its progress.
   const hasCurrentRunActivity =
     hasActiveRun &&
     !isProgressCardStaleForRun(card, startedAt) &&
     (validUpdatedAt === undefined ||
-      (validStartedAt === undefined
-        ? sessionStatus === undefined
-        : validUpdatedAt >= validStartedAt));
+      (sessionStatus !== "queued" &&
+        (validStartedAt !== undefined || sessionStatus === undefined)));
   const terminalTimestamp =
     sessionStatus && TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus] && hasValidRunWindow
       ? validEndedAt

--- a/ui/src/e2e/session-progress-widget.e2e.test.ts
+++ b/ui/src/e2e/session-progress-widget.e2e.test.ts
@@ -15,6 +15,62 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 const sessionKey = "agent:main:progress-dashboard";
+const dashboardFeatureMethods = [
+  "board.get",
+  "chat.metadata",
+  "chat.startup",
+  "progressCard.get",
+  "sessions.list",
+  "sessions.patch",
+];
+const englishDesktopPageOptions = {
+  locale: "en-US",
+  viewport: { height: 900, width: 1280 },
+};
+
+function boardResponse(key: string, widgetOverrides?: Record<string, unknown>) {
+  return {
+    sessionKey: key,
+    revision: 1,
+    tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
+    widgets: [
+      {
+        name: "session-progress",
+        tabId: "main",
+        title: "Session progress",
+        contentKind: "plugin",
+        pluginKind: "session:progress",
+        sizeW: 6,
+        sizeH: 5,
+        position: 0,
+        grantState: "none",
+        revision: 1,
+        ...widgetOverrides,
+      },
+    ],
+  };
+}
+
+function sessionListResponse(
+  key: string,
+  label: string,
+  state: {
+    endedAt?: number;
+    hasActiveRun: boolean;
+    startedAt?: number;
+    status?: string;
+    updatedAt: number;
+  },
+) {
+  return {
+    count: 1,
+    defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+    path: "",
+    sessions: [{ key, kind: "direct", label, status: "running", ...state }],
+    ts: Date.now(),
+  };
+}
+
 let proofDir: string;
 beforeEach(() => {
   proofDir = createControlUiE2eArtifactDir("session-progress-widget");
@@ -27,7 +83,7 @@ suite.define(() => {
     { height: 900, name: "bare-route", width: 1440, routeKey: "progress-dashboard" },
     { height: 900, name: "inactive", width: 1440, routeKey: sessionKey },
   ])("keeps unowned progress paused on $name", async (viewport) => {
-    await suite.withPage({ viewport }, async ({ page }) => {
+    await suite.withPage({ locale: "en-US", viewport }, async ({ page }) => {
       const now = Date.now();
       const gateway = await installMockGateway(page, {
         sessionKey,
@@ -43,25 +99,7 @@ suite.define(() => {
           "sessions.patch",
         ],
         methodResponses: {
-          "board.get": {
-            sessionKey,
-            revision: 1,
-            tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
-            widgets: [
-              {
-                name: "session-progress",
-                tabId: "main",
-                title: "Session progress",
-                contentKind: "plugin",
-                pluginKind: "session:progress",
-                sizeW: 6,
-                sizeH: 5,
-                position: 0,
-                grantState: "none",
-                revision: 1,
-              },
-            ],
-          },
+          "board.get": boardResponse(sessionKey),
           "progressCard.get": {
             card: {
               sessionKey,
@@ -236,6 +274,454 @@ suite.define(() => {
         fullPage: true,
         path: path.join(proofDir, `session-progress-widget-${viewport.name}-access-denied.png`),
       });
+    });
+  });
+
+  it("keeps target liveness when the selected agent scope changes", async () => {
+    await suite.withPage(englishDesktopPageOptions, async ({ page }) => {
+      const now = Date.now();
+      const gateway = await installMockGateway(page, {
+        sessionKey,
+        controlUiWidgetKinds: [
+          { pluginId: "session", kind: "session:progress", label: "Session progress" },
+        ],
+        featureMethods: dashboardFeatureMethods,
+        methodResponses: {
+          "board.get": boardResponse(sessionKey),
+          "progressCard.get": {
+            card: {
+              sessionKey,
+              revision: 1,
+              updatedAt: now - 10_000,
+              markdown: "**Scope-transition dashboard tile** follows the dashboard roster.",
+              steps: [{ step: "Show the selected scope", status: "in_progress" }],
+            },
+          },
+          "sessions.list": {
+            cases: [
+              {
+                match: { agentId: "main" },
+                response: sessionListResponse(sessionKey, "Main progress dashboard", {
+                  hasActiveRun: true,
+                  startedAt: now - 30_000,
+                  updatedAt: now,
+                }),
+              },
+              {
+                match: { agentId: "writer" },
+                response: sessionListResponse(sessionKey, "Writer progress dashboard", {
+                  endedAt: now - 1_000,
+                  hasActiveRun: false,
+                  startedAt: now - 5_000,
+                  status: "done",
+                  updatedAt: now - 30_000,
+                }),
+              },
+            ],
+          },
+        },
+      });
+
+      const storageKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+      await page.addInitScript(
+        ({ key, storage }) => {
+          localStorage.setItem(
+            storage,
+            JSON.stringify({ boardSessionViews: { [key]: { activeTabId: "main" } } }),
+          );
+        },
+        { key: sessionKey, storage: storageKey },
+      );
+
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey, "dashboard"));
+      const card = page.locator('[data-progress-card-placement="board"]');
+      await card.waitFor();
+      await expect.poll(() => card.locator(".session-run-spinner").count()).toBe(1);
+      await expect.poll(() => card.locator(".session-progress-card__step--paused").count()).toBe(0);
+
+      await page.waitForFunction(() => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: { context?: { agentSelection?: { setScope?: (agentId: string) => void } } };
+        };
+        return typeof app.runtime?.context?.agentSelection?.setScope === "function";
+      });
+      await page.evaluate(() => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: { context?: { agentSelection?: { setScope?: (agentId: string) => void } } };
+        };
+        app.runtime?.context?.agentSelection?.setScope?.("writer");
+      });
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("sessions.list")).some((request) => {
+            const params = request.params as {
+              agentId?: string;
+              archived?: string;
+              hasBoard?: boolean;
+            };
+            // The widget's target roster follows the captured main-agent target,
+            // not the unrelated page filter, and remains archive-inclusive.
+            return (
+              params.agentId === "main" &&
+              params.archived === "all" &&
+              params.hasBoard === undefined
+            );
+          }),
+        )
+        .toBe(true);
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("sessions.list")).some((request) => {
+            const params = request.params as {
+              agentId?: string;
+              archived?: string;
+              hasBoard?: boolean;
+            };
+            return (
+              params.agentId === "writer" &&
+              params.archived === "all" &&
+              params.hasBoard === undefined
+            );
+          }),
+        )
+        .toBe(false);
+      await expect.poll(() => card.locator(".session-run-spinner").count()).toBe(1);
+      await expect.poll(() => card.locator(".session-progress-card__step--paused").count()).toBe(0);
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(proofDir, "session-progress-widget-scope-transition.png"),
+      });
+    });
+  });
+
+  it("pauses a dashboard card when the session has no active run", async () => {
+    const inactiveSessionKey = "agent:main:progress-dashboard-inactive";
+    await suite.withPage(englishDesktopPageOptions, async ({ page }) => {
+      await installMockGateway(page, {
+        sessionKey: inactiveSessionKey,
+        controlUiWidgetKinds: [
+          { pluginId: "session", kind: "session:progress", label: "Session progress" },
+        ],
+        featureMethods: dashboardFeatureMethods,
+        methodResponses: {
+          "board.get": boardResponse(inactiveSessionKey),
+          "progressCard.get": {
+            card: {
+              sessionKey: inactiveSessionKey,
+              revision: 1,
+              updatedAt: 3,
+              markdown: "**Paused dashboard tile** is durable work.",
+              steps: [{ step: "Resume the dashboard task", status: "in_progress" }],
+            },
+          },
+          "sessions.list": sessionListResponse(inactiveSessionKey, "Inactive progress dashboard", {
+            hasActiveRun: false,
+            startedAt: 3,
+            updatedAt: 3,
+          }),
+        },
+      });
+
+      const storageKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+      await page.addInitScript(
+        ({ key, storage }) => {
+          localStorage.setItem(
+            storage,
+            JSON.stringify({ boardSessionViews: { [key]: { activeTabId: "main" } } }),
+          );
+        },
+        { key: inactiveSessionKey, storage: storageKey },
+      );
+
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, inactiveSessionKey, "dashboard"));
+      const card = page.locator('[data-progress-card-placement="board"]');
+      await card.waitFor();
+      await expect.poll(() => card.locator(".session-progress-card__step--paused").count()).toBe(1);
+      await expect.poll(() => card.locator(".session-run-spinner").count()).toBe(0);
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(proofDir, "session-progress-widget-inactive.png"),
+      });
+    });
+  });
+
+  it("pauses a dashboard card that predates the current active run", async () => {
+    const staleSessionKey = "agent:main:progress-dashboard-stale";
+    await suite.withPage(englishDesktopPageOptions, async ({ page }) => {
+      await installMockGateway(page, {
+        sessionKey: staleSessionKey,
+        controlUiWidgetKinds: [
+          { pluginId: "session", kind: "session:progress", label: "Session progress" },
+        ],
+        featureMethods: dashboardFeatureMethods,
+        methodResponses: {
+          "board.get": boardResponse(staleSessionKey),
+          "progressCard.get": {
+            card: {
+              sessionKey: staleSessionKey,
+              revision: 1,
+              updatedAt: 3,
+              markdown: "**Stale dashboard tile** belongs to an earlier run.",
+              steps: [{ step: "Show the current run", status: "in_progress" }],
+            },
+          },
+          "sessions.list": sessionListResponse(staleSessionKey, "Stale progress dashboard", {
+            hasActiveRun: true,
+            startedAt: 4,
+            updatedAt: 4,
+          }),
+        },
+      });
+
+      const storageKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+      await page.addInitScript(
+        ({ key, storage }) => {
+          localStorage.setItem(
+            storage,
+            JSON.stringify({ boardSessionViews: { [key]: { activeTabId: "main" } } }),
+          );
+        },
+        { key: staleSessionKey, storage: storageKey },
+      );
+
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, staleSessionKey, "dashboard"));
+      const card = page.locator('[data-progress-card-placement="board"]');
+      await card.waitFor();
+      await expect.poll(() => card.textContent()).toContain("Stale dashboard tile");
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(proofDir, "session-progress-widget-stale.png"),
+      });
+      await expect.poll(() => card.locator(".session-progress-card__step--paused").count()).toBe(1);
+      await expect.poll(() => card.locator(".session-run-spinner").count()).toBe(0);
+    });
+  });
+
+  it("reads target liveness from the shared roster independently of board membership", async () => {
+    const splitRosterSessionKey = "agent:main:progress:dashboard:split-roster";
+    await suite.withPage(englishDesktopPageOptions, async ({ page }) => {
+      const now = Date.now();
+      await installMockGateway(page, {
+        sessionKey: splitRosterSessionKey,
+        controlUiWidgetKinds: [
+          { pluginId: "session", kind: "session:progress", label: "Session progress" },
+        ],
+        featureMethods: dashboardFeatureMethods,
+        methodResponses: {
+          "board.get": boardResponse(splitRosterSessionKey),
+          "progressCard.get": {
+            card: {
+              sessionKey: splitRosterSessionKey,
+              revision: 1,
+              updatedAt: now,
+              markdown: "**Split roster dashboard tile** follows its target session.",
+              steps: [{ step: "Read the dashboard roster", status: "in_progress" }],
+            },
+          },
+          "sessions.list": {
+            cases: [
+              {
+                // The dashboard gallery view sees an idle board inventory.
+                match: { hasBoard: true },
+                response: sessionListResponse(splitRosterSessionKey, "Split roster dashboard", {
+                  hasActiveRun: false,
+                  startedAt: 2,
+                  updatedAt: 3,
+                }),
+              },
+              {
+                // The shared target roster still reports the live run.
+                match: {},
+                response: sessionListResponse(splitRosterSessionKey, "Split roster dashboard", {
+                  hasActiveRun: true,
+                  startedAt: now - 30_000,
+                  updatedAt: now,
+                }),
+              },
+            ],
+          },
+        },
+      });
+
+      const storageKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+      await page.addInitScript(
+        ({ key, storage }) => {
+          localStorage.setItem(
+            storage,
+            JSON.stringify({ boardSessionViews: { [key]: { activeTabId: "main" } } }),
+          );
+        },
+        { key: splitRosterSessionKey, storage: storageKey },
+      );
+
+      await page.goto(
+        controlUiSessionUrl(suite.server.baseUrl, splitRosterSessionKey, "dashboard"),
+      );
+      const card = page.locator('[data-progress-card-placement="board"]');
+      await card.waitFor();
+      await expect.poll(() => card.textContent()).toContain("Split roster dashboard tile");
+      // Liveness comes from the shared target roster, not the gallery-filtered view.
+      await expect.poll(() => card.locator(".session-run-spinner").count()).toBe(1);
+      await expect.poll(() => card.locator(".session-progress-card__step--paused").count()).toBe(0);
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(proofDir, "session-progress-widget-split-roster.png"),
+      });
+    });
+  });
+
+  it("keeps a board-less running target live on another session's dashboard widget", async () => {
+    const boardOwnerKey = "agent:main:progress-board-owner";
+    const boardlessTargetKey = "agent:main:progress-boardless-target";
+    await suite.withPage(englishDesktopPageOptions, async ({ page }) => {
+      const now = Date.now();
+      await installMockGateway(page, {
+        sessionKey: boardOwnerKey,
+        controlUiWidgetKinds: [
+          { pluginId: "session", kind: "session:progress", label: "Session progress" },
+        ],
+        featureMethods: dashboardFeatureMethods,
+        methodResponses: {
+          "board.get": boardResponse(boardOwnerKey, {
+            name: "session-progress",
+            props: { sessionKey: boardlessTargetKey },
+          }),
+          "progressCard.get": {
+            card: {
+              sessionKey: boardlessTargetKey,
+              revision: 1,
+              updatedAt: now,
+              markdown: "**Board-less target tile** stays live while it runs.",
+              steps: [{ step: "Run without a dashboard", status: "in_progress" }],
+            },
+          },
+          "sessions.list": {
+            cases: [
+              {
+                // The Gateway filters hasBoard against each session's own board
+                // inventory, so the board-less target is absent from this view.
+                match: { hasBoard: true },
+                response: sessionListResponse(boardOwnerKey, "Progress board owner", {
+                  hasActiveRun: false,
+                  startedAt: 2,
+                  updatedAt: 3,
+                }),
+              },
+              {
+                match: {},
+                response: {
+                  count: 2,
+                  defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+                  path: "",
+                  sessions: [
+                    {
+                      key: boardOwnerKey,
+                      kind: "direct",
+                      label: "Progress board owner",
+                      status: "done",
+                      hasActiveRun: false,
+                      startedAt: 2,
+                      endedAt: 3,
+                      updatedAt: 3,
+                    },
+                    {
+                      key: boardlessTargetKey,
+                      kind: "direct",
+                      label: "Board-less running target",
+                      status: "running",
+                      hasActiveRun: true,
+                      startedAt: now - 30_000,
+                      updatedAt: now,
+                    },
+                  ],
+                  ts: now,
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const storageKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+      await page.addInitScript(
+        ({ key, storage }) => {
+          localStorage.setItem(
+            storage,
+            JSON.stringify({ boardSessionViews: { [key]: { activeTabId: "main" } } }),
+          );
+        },
+        { key: boardOwnerKey, storage: storageKey },
+      );
+
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, boardOwnerKey, "dashboard"));
+      const card = page.locator('[data-progress-card-placement="board"]');
+      await card.waitFor();
+      await expect.poll(() => card.textContent()).toContain("Board-less target tile");
+      // A running target without its own dashboard must not render as paused.
+      await expect.poll(() => card.locator(".session-run-spinner").count()).toBe(1);
+      await expect.poll(() => card.locator(".session-progress-card__step--paused").count()).toBe(0);
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(proofDir, "session-progress-widget-boardless-target.png"),
+      });
+    });
+  });
+
+  it("pauses a dashboard card while the successor run is queued", async () => {
+    const queuedSessionKey = "agent:main:progress-dashboard-queued";
+    await suite.withPage(englishDesktopPageOptions, async ({ page }) => {
+      await installMockGateway(page, {
+        sessionKey: queuedSessionKey,
+        controlUiWidgetKinds: [
+          { pluginId: "session", kind: "session:progress", label: "Session progress" },
+        ],
+        featureMethods: dashboardFeatureMethods,
+        methodResponses: {
+          "board.get": boardResponse(queuedSessionKey),
+          "progressCard.get": {
+            card: {
+              sessionKey: queuedSessionKey,
+              revision: 1,
+              updatedAt: 3,
+              markdown: "**Queued dashboard tile** belongs to an earlier run.",
+              steps: [{ step: "Wait for the queued run", status: "in_progress" }],
+            },
+          },
+          "sessions.list": sessionListResponse(queuedSessionKey, "Queued progress dashboard", {
+            hasActiveRun: true,
+            status: "queued",
+            updatedAt: 4,
+          }),
+        },
+      });
+
+      const storageKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+      await page.addInitScript(
+        ({ key, storage }) => {
+          localStorage.setItem(
+            storage,
+            JSON.stringify({ boardSessionViews: { [key]: { activeTabId: "main" } } }),
+          );
+        },
+        { key: queuedSessionKey, storage: storageKey },
+      );
+
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, queuedSessionKey, "dashboard"));
+      const card = page.locator('[data-progress-card-placement="board"]');
+      await card.waitFor();
+      await expect.poll(() => card.textContent()).toContain("Queued dashboard tile");
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(proofDir, "session-progress-widget-queued.png"),
+      });
+      await expect.poll(() => card.locator(".session-progress-card__step--paused").count()).toBe(1);
+      await expect.poll(() => card.locator(".session-run-spinner").count()).toBe(0);
     });
   });
 });

--- a/ui/src/lib/board/widgets/session-progress.ts
+++ b/ui/src/lib/board/widgets/session-progress.ts
@@ -11,6 +11,7 @@ import { SubscriptionsController } from "../../../lit/subscriptions-controller.t
 import { resolveSessionProgressCardTarget } from "../../session-progress-cards.ts";
 import { isSessionRunActive } from "../../session-run-state.ts";
 import { parseAgentSessionKey } from "../../sessions/session-key.ts";
+import { sessionProgressTargetQuery } from "../../sessions/session-requests.ts";
 import type { BoardWidget } from "../types.ts";
 
 function resolveSessionTarget(
@@ -33,6 +34,10 @@ class OpenClawSessionProgressWidget extends OpenClawLightDomElement {
   @property({ attribute: false }) session: BoardGetParams = { sessionKey: "" };
   @property({ attribute: false }) active = true;
 
+  private observedSessions?: ApplicationContext["sessions"];
+  private observedTargetAgentId?: string;
+  private unsubscribeList?: () => void;
+
   private readonly progressCard = new SessionProgressCardController(this, {
     gateway: () =>
       this.active && resolveSessionTarget(this.widget, this.session).sessionKey
@@ -40,15 +45,30 @@ class OpenClawSessionProgressWidget extends OpenClawLightDomElement {
         : undefined,
     target: () => resolveSessionTarget(this.widget, this.session),
   });
+
   constructor() {
     super();
-    void new SubscriptionsController(this).watch(
-      () =>
-        this.active && resolveSessionTarget(this.widget, this.session).sessionKey
-          ? this.context?.sessions
-          : undefined,
-      (sessions, notify) => sessions.subscribe(notify),
+    void new SubscriptionsController(this).effect(
+      () => this.context?.agentSelection,
+      (agentSelection) => {
+        this.bindSessionList();
+        return agentSelection.subscribe(() => this.bindSessionList());
+      },
     );
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.bindSessionList();
+  }
+
+  override disconnectedCallback(): void {
+    this.releaseSessionList();
+    super.disconnectedCallback();
+  }
+
+  override willUpdate(): void {
+    this.bindSessionList();
   }
 
   override render() {
@@ -93,11 +113,14 @@ class OpenClawSessionProgressWidget extends OpenClawLightDomElement {
       this.context?.gateway.snapshot ?? {},
       resolveSessionTarget(this.widget, this.session),
     );
-    const row = this.context?.sessions?.state.result?.sessions.find(
-      (entry) =>
-        entry.key === identity.sessionKey &&
-        (entry.agentId ?? parseAgentSessionKey(entry.key)?.agentId) === identity.agentId,
-    );
+    const targetQuery = sessionProgressTargetQuery(identity.agentId);
+    const row = this.context?.sessions
+      .listSnapshot(targetQuery)
+      .result?.sessions.find(
+        (entry) =>
+          entry.key === identity.sessionKey &&
+          (entry.agentId ?? parseAgentSessionKey(entry.key)?.agentId) === identity.agentId,
+      );
     return html`${errorNotice}${renderSessionProgressCard(
       card,
       "board",
@@ -107,6 +130,50 @@ class OpenClawSessionProgressWidget extends OpenClawLightDomElement {
       row?.endedAt,
       isSessionRunActive(row ?? {}),
     )}`;
+  }
+
+  private bindSessionList(): void {
+    const context = this.context;
+    if (!context) {
+      return;
+    }
+    const sessions = context.sessions;
+    const identity = resolveSessionProgressCardTarget(
+      context.gateway.snapshot,
+      resolveSessionTarget(this.widget, this.session),
+    );
+    const targetAgentId = identity.agentId;
+    const shouldObserve =
+      this.active && Boolean(resolveSessionTarget(this.widget, this.session).sessionKey);
+    if (!shouldObserve) {
+      this.releaseSessionList();
+      return;
+    }
+    if (sessions === this.observedSessions && targetAgentId === this.observedTargetAgentId) {
+      return;
+    }
+    this.releaseSessionList();
+    this.observedSessions = sessions;
+    this.observedTargetAgentId = targetAgentId;
+    const query = sessionProgressTargetQuery(targetAgentId);
+    this.unsubscribeList = sessions.subscribeList(query, () => this.requestUpdate());
+    const snapshot = sessions.listSnapshot(query);
+    this.requestUpdate();
+    if (
+      !snapshot.result &&
+      !snapshot.loading &&
+      !snapshot.error &&
+      context.gateway.snapshot.phase === "connected"
+    ) {
+      void sessions.refreshList({ ...query, force: true });
+    }
+  }
+
+  private releaseSessionList(): void {
+    this.unsubscribeList?.();
+    this.unsubscribeList = undefined;
+    this.observedSessions = undefined;
+    this.observedTargetAgentId = undefined;
   }
 }
 

--- a/ui/src/lib/sessions/session-requests.ts
+++ b/ui/src/lib/sessions/session-requests.ts
@@ -33,6 +33,29 @@ export const DEFAULT_SESSION_LIST_QUERY = {
   limit: SIDEBAR_SESSION_ROSTER_LIMIT,
 } as const satisfies SessionListOptions;
 
+export function dashboardSessionListQuery(agentId?: string | null): SessionListOptions {
+  const normalizedAgentId = agentId?.trim();
+  return {
+    ...DEFAULT_SESSION_LIST_QUERY,
+    hasBoard: true,
+    archivedFilter: "all",
+    ...(normalizedAgentId ? { agentId: normalizedAgentId } : {}),
+  };
+}
+
+/** Progress cards resolve an explicit cross-session target independently of
+ *  dashboard gallery membership: the Gateway filters hasBoard against each
+ *  session's own board inventory, so a running target without its own board
+ *  would disappear from a gallery-filtered roster and render as paused. */
+export function sessionProgressTargetQuery(agentId?: string | null): SessionListOptions {
+  const normalizedAgentId = agentId?.trim();
+  return {
+    ...DEFAULT_SESSION_LIST_QUERY,
+    archivedFilter: "all",
+    ...(normalizedAgentId ? { agentId: normalizedAgentId } : {}),
+  };
+}
+
 /** Starting page size for the Sessions page's explicit, user-editable limit
  *  field, kept separate from the roster page so tuning one never moves the other. */
 export const SESSIONS_PAGE_DEFAULT_LIMIT = 50;

--- a/ui/src/pages/dashboards/route.ts
+++ b/ui/src/pages/dashboards/route.ts
@@ -2,24 +2,14 @@ import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import {
-  DEFAULT_SESSION_LIST_QUERY,
-  type SessionListOptions,
-  type SessionListSnapshot,
-} from "../../lib/sessions/index.ts";
+import type { SessionListOptions, SessionListSnapshot } from "../../lib/sessions/index.ts";
 import { resolveSessionNavigationAgentId } from "../../lib/sessions/route-navigation.ts";
 import { resolveUiConfiguredMainKey } from "../../lib/sessions/session-key.ts";
+import { dashboardSessionListQuery as dashboardSessionListQueryForAgent } from "../../lib/sessions/session-requests.ts";
 import type { DashboardsRouteData } from "./view.ts";
 
 export function dashboardSessionListQuery(context: ApplicationContext): SessionListOptions {
-  return {
-    ...DEFAULT_SESSION_LIST_QUERY,
-    hasBoard: true,
-    archivedFilter: "all",
-    ...(context.agentSelection.state.scopeId
-      ? { agentId: context.agentSelection.state.scopeId }
-      : {}),
-  };
+  return dashboardSessionListQueryForAgent(context.agentSelection.state.scopeId);
 }
 
 export function dashboardsRouteData(


### PR DESCRIPTION
Related #137188.

## What Problem This Solves

Fixes an issue where a dashboard progress widget could show an accessible, active target as paused when that target was outside the page's selected agent scope. The target can have no dashboard of its own. Older progress could also show a live spinner while a later run was queued, including reused sessions that retain the previous run's timestamps.

## Why This Change Was Made

The widget subscribes to the captured target agent's archive-inclusive session list, separate from the dashboard gallery and without its board-membership filter. The shared card renderer keeps prior progress paused during queued work and preserves the existing timestamp fence. Queued status takes precedence over retained timestamps from a completed run.

## User Impact

Cross-session dashboard widgets retain live progress while another agent owns page selection, including desktop split view. Older unfinished steps stay paused until the new run starts and updates the card. Saved progress, session access checks, gallery membership, and existing terminal-outcome presentation keep their prior behavior.

## Evidence

- Real built Gateway and served Control UI: baseline `fd490cf304fea7d4fd83c3a8643078ebe2884ff7` showed zero spinners and one paused step for an active board-less target from another agent. Final `77db446647f57c6ee898f9ce3edea3dd1b4f495a` shows one spinner and no paused step through the same public flow.
- Public Gateway operations created the sessions, board, card, and real target runs against a deterministic local HTTP provider. Actual browser traffic confirmed an archive-inclusive target-agent query without a board filter. Target boards stayed empty, and the gallery remained separate.
- Independent browser validation covered fresh and reused queued runs, older/current cards, split-view agent switching and focus, archived-card availability, online reopening after an offline page load, and mobile rendering and widget controls. Private captures and complete raw traces are retained.
- The new reused-queue regression failed unchanged production, then passed after correction. Formatting and focused syntax lint passed; 46 component tests and all 10 tests in the existing progress-widget browser suite passed.
- Retry and access-denied handling were checked by that existing mocked-Gateway browser suite. They are supplemental boundary proof; no separate live cross-user denial or in-place network-drop reconnect claim is made.

Original implementation by @sunlit-deng. The timestamp-fence work in #137323 is preserved. Broader progress-card lifecycle work remains outside this change.
