### PR TITLE
refactor(test): type the respawn exit mock directly

### DIFF
--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -385,7 +385,7 @@ describe("runCliRespawnPlan", () => {
     const child = new EventEmitter() as ChildProcess;
     const spawn = vi.fn(() => child);
     const attachChildProcessBridge = vi.fn();
-    const exit = vi.fn();
+    const exit = vi.fn<(code?: number) => never>();
     const writeError = vi.fn();
 
     runCliRespawnPlan(
@@ -398,7 +398,7 @@ describe("runCliRespawnPlan", () => {
       {
         spawn: spawn as unknown as typeof import("node:child_process").spawn,
         attachChildProcessBridge,
-        exit: exit as unknown as (code?: number) => never,
+        exit,
         writeError,
       },
     );


### PR DESCRIPTION
## What Problem This Solves

The CLI respawn test double-asserted an untyped exit mock to its runtime contract, even though Vitest can declare that type directly.

## Why This Change Was Made

Declare the existing `(code?: number) => never` signature in `vi.fn` and pass the mock directly. The mock implementation, PID-less child, spawn adapter, and all lifecycle assertions remain unchanged.

## User Impact

No user-visible change. Production +0/−0; tests +2/−2. Existing Windows, CA, Gmail, terminal, signal, and child-cleanup coverage is preserved.

## Evidence

- Before and after: the same 44 cases passed across `entry.respawn`, `respawn-child-runner`, `child-process-bridge`, and the canonical `expect` helper suites.
- The complete one-path `check-changed` gate passed all 20 stages, including core-test typecheck, typed lint, and dead-export scans.
- Managed Codex P2 review: no actionable findings. Installed Vitest 4.1.11 types and implementation confirm identical mock behavior.
