### PR TITLE
refactor(scripts): reuse strict boolean argument parser

### DIFF
--- a/scripts/plugin-publication-artifact.mjs
+++ b/scripts/plugin-publication-artifact.mjs
@@ -16,6 +16,7 @@ import {
   validateActionsArtifactBinding,
   validateActionsArtifactProducerJob,
 } from "./lib/actions-artifact-archive.mjs";
+import { parseStrictBooleanArg } from "./lib/arg-utils.runtime.mjs";
 import { resolveNpmPublishPlan } from "./lib/npm-publish-plan.mjs";
 
 export {
@@ -108,16 +109,6 @@ function assertPositiveInteger(value, label) {
     throw new Error(`${label} must be a safe positive integer.`);
   }
   return value;
-}
-
-function assertBooleanString(value, label) {
-  if (value === "true") {
-    return true;
-  }
-  if (value === "false") {
-    return false;
-  }
-  throw new Error(`${label} must be true or false.`);
 }
 
 function hasControlCharacters(value) {
@@ -1198,7 +1189,7 @@ function commonCliParams(values) {
     requiresManualOverride:
       values.requiresManualOverride === undefined
         ? false
-        : assertBooleanString(values.requiresManualOverride, "requires-manual-override"),
+        : parseStrictBooleanArg(values.requiresManualOverride, "requires-manual-override"),
     route: values.route,
     publicationReason: values.publicationReason,
     publisherPolicy:


### PR DESCRIPTION
## What Problem This Solves

Resolves duplicated strict Boolean argument parsing in plugin publication tooling, where a local implementation could drift from the canonical script coercion contract.

## Why This Change Was Made

The publication artifact CLI now uses `parseStrictBooleanArg` from `scripts/lib/arg-utils.runtime.mjs` and removes its duplicate parser. The invariant is unchanged: only lowercase `"true"` and `"false"` are accepted, and every other value throws the exact `${label} must be true or false.` error.

## User Impact

No user-visible behavior changes. This keeps release tooling on one canonical Boolean coercion owner and reduces future contract drift.

Tooling LOC: +2/-11 (net -9) | Tests: +0/-0

No public API, configuration, plugin SDK, protocol, persistence, dependency, authority, or security behavior changes.

## Evidence

- 19/19 old-vs-canonical behavior and error-text equivalence cases passed.
- 144/144 focused tests passed:
  - `test/scripts/arg-utils.test.ts`
  - `test/scripts/plugin-publication-artifact.test.ts`
  - `test/scripts/check-coercion-helper-declarations.test.ts`
- `pnpm check:coercion-helpers` passed with 111 allowlisted declarations.
- Node syntax, scoped script lint, formatting, and `git diff --check` passed.
- `node scripts/check-changed.mjs --dry-run -- scripts/plugin-publication-artifact.mjs` classified the change as tooling-only.
- Exact autoreview was scoped-clean with correctness confidence 0.96.
