### PR TITLE
test(voice-call): reuse shared guards and deferred gates

### DIFF
--- a/extensions/voice-call/src/manager.notify.test.ts
+++ b/extensions/voice-call/src/manager.notify.test.ts
@@ -1,4 +1,5 @@
 // Voice Call tests cover manager.notify plugin behavior.
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { createManagerHarness, FakeProvider } from "./manager.test-harness.js";
@@ -90,14 +91,6 @@ const requireRecord = createRequireRecord("record", "expected-label-record");
 function requireSingleStartListeningCall(provider: FakeProvider) {
   expect(provider.startListeningCalls).toHaveLength(1);
   return requireRecord(provider.startListeningCalls.at(0), "start listening call");
-}
-
-function requireFirstMockCall(calls: readonly unknown[][], label: string): unknown[] {
-  const call = calls.at(0);
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call;
 }
 
 type HarnessManager = Awaited<ReturnType<typeof createManagerHarness>>["manager"];
@@ -363,7 +356,7 @@ describe("CallManager notify and mapping", () => {
       expect(startListeningCall.callId).toBe(callId);
       expect(startListeningCall.providerCallId).toBe("call-uuid");
       expect(warn).toHaveBeenCalledOnce();
-      expect(String(requireFirstMockCall(warn.mock.calls, "console warn")[0])).toContain(
+      expect(String(expectDefined(warn.mock.calls.at(0), "console warn")[0])).toContain(
         `[voice-call] Failed to speak initial message for call ${callId}: synthetic start listening failure`,
       );
     } finally {

--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -1,6 +1,7 @@
 // Voice Call tests cover media stream plugin behavior.
 import type { IncomingMessage } from "node:http";
 import net from "node:net";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import type {
@@ -61,14 +62,6 @@ const requireRecord = (value: unknown, label: string): Record<string, unknown> =
     throw new Error(`Expected ${label} to be a record`);
   }
   return value as Record<string, unknown>;
-};
-
-const requireFirstMockCall = <T extends unknown[]>(calls: readonly T[], label: string): T => {
-  const call = calls.at(0);
-  if (!call) {
-    throw new Error(`Expected ${label}`);
-  }
-  return call;
 };
 
 const requireTalkEvent = (events: TalkEvent[], type: TalkEvent["type"]) => {
@@ -623,10 +616,7 @@ describe("MediaStreamHandler security hardening", () => {
     }
     completeUpgrade({} as WebSocket);
     expect(fakeWss.emit).toHaveBeenCalledOnce();
-    const emitCall = requireFirstMockCall(
-      fakeWss.emit.mock.calls,
-      "websocket connection emit call",
-    );
+    const emitCall = expectDefined(fakeWss.emit.mock.calls.at(0), "websocket connection emit call");
     expect(emitCall[0]).toBe("connection");
     if (!emitCall[1]) {
       throw new Error("Expected websocket connection argument");
@@ -711,8 +701,8 @@ describe("MediaStreamHandler security hardening", () => {
       await vi.waitFor(() => {
         expect(shouldAcceptStream).toHaveBeenCalledOnce();
       });
-      const acceptedStreamCall = requireFirstMockCall(
-        shouldAcceptStream.mock.calls,
+      const acceptedStreamCall = expectDefined(
+        shouldAcceptStream.mock.calls.at(0),
         "accepted stream call",
       );
       const acceptedStream = requireRecord(acceptedStreamCall[0], "accepted stream params");

--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -1,5 +1,6 @@
-// Voice Call tests cover response generator plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+// Voice Call tests cover response generator plugin behavior.
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "../api.js";
 import { VoiceCallConfigSchema } from "./config.js";
@@ -179,8 +180,8 @@ function createAgentRuntime(
 
 function requireEmbeddedAgentArgs(runEmbeddedAgent: ReturnType<typeof vi.fn>) {
   const calls = runEmbeddedAgent.mock.calls as unknown[][];
-  const firstCall = requireFirstMockCall(
-    calls,
+  const firstCall = expectDefined(
+    calls.at(0),
     "voice response generator embedded agent invocation",
   );
   const args = firstCall[0] as Partial<EmbeddedAgentArgs> | undefined;
@@ -188,14 +189,6 @@ function requireEmbeddedAgentArgs(runEmbeddedAgent: ReturnType<typeof vi.fn>) {
     throw new Error("voice response generator did not pass the spoken-output contract prompt");
   }
   return args as EmbeddedAgentArgs;
-}
-
-function requireFirstMockCall(calls: readonly unknown[][], label: string): unknown[] {
-  const call = calls.at(0);
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call;
 }
 
 async function runGenerateVoiceResponse(
@@ -656,8 +649,8 @@ describe("generateVoiceResponse", () => {
     expect(pinnedSessionEntry?.modelProvider).toBeUndefined();
     expect(pinnedSessionEntry?.contextTokens).toBeUndefined();
     expect(pinnedSessionEntry?.authProfileOverride).toBeUndefined();
-    const patchSessionEntryCall = requireFirstMockCall(
-      patchSessionEntry.mock.calls,
+    const patchSessionEntryCall = expectDefined(
+      patchSessionEntry.mock.calls.at(0),
       "session entry patch",
     );
     expect(patchSessionEntryCall[0]).toMatchObject({

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -1,6 +1,7 @@
 // Voice Call tests cover webhook plugin behavior.
 import crypto from "node:crypto";
 import { request, type IncomingMessage } from "node:http";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { RealtimeTranscriptionProviderPlugin } from "openclaw/plugin-sdk/realtime-transcription";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -165,14 +166,6 @@ function requireBoundRequestUrl(server: VoiceCallWebhookServer, baseUrl: string)
   const requestUrl = new URL(baseUrl);
   requestUrl.port = String(address.port);
   return requestUrl;
-}
-
-function requireFirstMockCall(calls: readonly unknown[][], label: string): unknown[] {
-  const call = calls.at(0);
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call;
 }
 
 function createCapturingLogger() {
@@ -1962,7 +1955,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
 
       expect(response.status).toBe(200);
       expect(parseWebhookEvent).toHaveBeenCalledTimes(1);
-      const parseOptions = requireFirstMockCall(parseWebhookEvent.mock.calls, "webhook parse")[1];
+      const parseOptions = expectDefined(parseWebhookEvent.mock.calls.at(0), "webhook parse")[1];
       if (!parseOptions) {
         throw new Error("webhook server did not pass verified parse options");
       }
@@ -1970,7 +1963,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
         verifiedRequestKey: "verified:req:123",
       });
       expect(processEvent).toHaveBeenCalledTimes(1);
-      const firstEvent = requireFirstMockCall(processEvent.mock.calls, "processed event")[0] as
+      const firstEvent = expectDefined(processEvent.mock.calls.at(0), "processed event")[0] as
         | NormalizedEvent
         | undefined;
       if (!firstEvent) {
@@ -2072,19 +2065,8 @@ describe("VoiceCallWebhookServer pre-auth webhook guards", () => {
     const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
 
     let enteredReads = 0;
-    let releaseReads: (() => void) | undefined;
-    let unblockReadBodies: (() => void) | undefined;
-    const enteredEightReads = new Promise<void>((resolve) => {
-      releaseReads = resolve;
-    });
-    const unblockReads = new Promise<void>((resolve) => {
-      unblockReadBodies = resolve;
-    });
-    if (!releaseReads || !unblockReadBodies) {
-      throw new Error("Expected webhook read gates to be initialized");
-    }
-    const releaseEnteredReads = releaseReads;
-    const unblockStartedReads = unblockReadBodies;
+    const enteredEightReads = createDeferred<void>();
+    const unblockReads = createDeferred<void>();
     const readBodySpy = vi.spyOn(
       server as unknown as {
         readBody: (req: unknown, maxBytes: number, timeoutMs?: number) => Promise<string>;
@@ -2094,10 +2076,10 @@ describe("VoiceCallWebhookServer pre-auth webhook guards", () => {
     readBodySpy.mockImplementation(async () => {
       enteredReads += 1;
       if (enteredReads === 8) {
-        releaseEnteredReads();
+        enteredEightReads.resolve();
       }
       if (enteredReads <= 8) {
-        await unblockReads;
+        await unblockReads.promise;
       }
       return "CallSid=CA123&SpeechResult=hello";
     });
@@ -2108,18 +2090,18 @@ describe("VoiceCallWebhookServer pre-auth webhook guards", () => {
       const inFlightRequests = Array.from({ length: 8 }, () =>
         postWebhookFormWithHeaders(server, baseUrl, "CallSid=CA123", headers),
       );
-      await enteredEightReads;
+      await enteredEightReads.promise;
 
       const rejected = await postWebhookFormWithHeaders(server, baseUrl, "CallSid=CA999", headers);
       expect(rejected.status).toBe(429);
       expect(await rejected.text()).toBe("Too Many Requests");
 
-      unblockStartedReads();
+      unblockReads.resolve();
 
       const settled = await Promise.all(inFlightRequests);
       expect(settled.map((response) => response.status)).toEqual(Array(8).fill(200));
     } finally {
-      unblockStartedReads();
+      unblockReads.resolve();
       readBodySpy.mockRestore();
       await server.stop();
     }
@@ -2144,19 +2126,8 @@ describe("VoiceCallWebhookServer pre-auth webhook guards", () => {
     ).runWebhookPipeline.bind(server);
 
     let enteredReads = 0;
-    let releaseReads: (() => void) | undefined;
-    let unblockReadBodies: (() => void) | undefined;
-    const enteredEightReads = new Promise<void>((resolve) => {
-      releaseReads = resolve;
-    });
-    const unblockReads = new Promise<void>((resolve) => {
-      unblockReadBodies = resolve;
-    });
-    if (!releaseReads || !unblockReadBodies) {
-      throw new Error("Expected webhook read gates to be initialized");
-    }
-    const releaseEnteredReads = releaseReads;
-    const unblockStartedReads = unblockReadBodies;
+    const enteredEightReads = createDeferred<void>();
+    const unblockReads = createDeferred<void>();
     const readBodySpy = vi.spyOn(
       server as unknown as {
         readBody: (req: unknown, maxBytes: number, timeoutMs?: number) => Promise<string>;
@@ -2166,9 +2137,9 @@ describe("VoiceCallWebhookServer pre-auth webhook guards", () => {
     readBodySpy.mockImplementation(async () => {
       enteredReads += 1;
       if (enteredReads === 8) {
-        releaseEnteredReads();
+        enteredEightReads.resolve();
       }
-      await unblockReads;
+      await unblockReads.promise;
       return "CallSid=CA123&SpeechResult=hello";
     });
 
@@ -2184,7 +2155,7 @@ describe("VoiceCallWebhookServer pre-auth webhook guards", () => {
       const inFlightRequests = Array.from({ length: 8 }, () =>
         runWebhookPipeline(makeRequestWithoutRemoteAddress(), "/voice/webhook"),
       );
-      await enteredEightReads;
+      await enteredEightReads.promise;
 
       const rejected = await runWebhookPipeline(
         makeRequestWithoutRemoteAddress(),
@@ -2194,12 +2165,12 @@ describe("VoiceCallWebhookServer pre-auth webhook guards", () => {
       expect(rejected.body).toBe("Too Many Requests");
       expect(readBodySpy).toHaveBeenCalledTimes(8);
 
-      unblockStartedReads();
+      unblockReads.resolve();
 
       const settled = await Promise.all(inFlightRequests);
       expect(settled.map((response) => response.statusCode)).toEqual(Array(8).fill(200));
     } finally {
-      unblockStartedReads();
+      unblockReads.resolve();
       readBodySpy.mockRestore();
     }
   });
@@ -2242,8 +2213,8 @@ describe("VoiceCallWebhookServer classic response routing", () => {
       }
     ).handleInboundResponse(call.callId, "hello");
 
-    const params = requireFirstMockCall(
-      mocks.generateVoiceResponse.mock.calls,
+    const params = expectDefined<unknown[]>(
+      mocks.generateVoiceResponse.mock.calls.at(0),
       "classic voice response",
     )[0] as
       | { agentId?: string; senderIsOwner?: boolean; voiceConfig?: VoiceCallConfig }
@@ -2677,8 +2648,8 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       expect(clearTtsQueue).toHaveBeenCalledTimes(2);
       expect(handleInboundResponse).toHaveBeenCalledTimes(1);
       expect(processEvent).toHaveBeenCalledTimes(1);
-      const [calledCallId, calledTranscript] = requireFirstMockCall(
-        handleInboundResponse.mock.calls,
+      const [calledCallId, calledTranscript] = expectDefined<unknown[]>(
+        handleInboundResponse.mock.calls.at(0),
         "inbound response",
       ) as [string | undefined, string | undefined];
       expect(calledCallId).toBe(call.callId);
@@ -2746,7 +2717,7 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       media.config.onTranscript?.("CA-inbound", "hello", "MZ-inbound");
       expect(clearTtsQueue).toHaveBeenCalledTimes(2);
       expect(processEvent).toHaveBeenCalledTimes(1);
-      const event = requireFirstMockCall(processEvent.mock.calls, "inbound processed event")[0] as
+      const event = expectDefined(processEvent.mock.calls.at(0), "inbound processed event")[0] as
         | NormalizedEvent
         | undefined;
       expect(event?.type).toBe("call.speech");

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -604,14 +604,13 @@ describe("RealtimeCallHandler lifecycle", () => {
   });
 
   it("does not hang up a replacement when its stale predecessor rejects startup", async () => {
-    let rejectStartup: (error: Error) => void = () => {};
-    const pendingStartup = new Promise<void>((_resolve, reject) => {
-      rejectStartup = reject;
-    });
+    const pendingStartup = createDeferred<void>();
     const replacementGreeting = vi.fn();
     const createBridgeForCall = vi
       .fn<RealtimeVoiceProviderPlugin["createBridge"]>()
-      .mockImplementationOnce(() => createBridge(vi.fn(), { connect: () => pendingStartup }))
+      .mockImplementationOnce(() =>
+        createBridge(vi.fn(), { connect: () => pendingStartup.promise }),
+      )
       .mockImplementationOnce(() =>
         createBridge(vi.fn(), { triggerGreeting: replacementGreeting }),
       );
@@ -639,7 +638,7 @@ describe("RealtimeCallHandler lifecycle", () => {
       await vi.waitFor(() => expect(createBridgeForCall).toHaveBeenCalledTimes(2));
 
       const previousClosed = waitForClose(previous.ws);
-      rejectStartup(new Error("superseded provider rejected startup"));
+      pendingStartup.reject(new Error("superseded provider rejected startup"));
       expect(await previousClosed).toEqual({ code: 1011, reason: "Failed to connect" });
       expect(hangupCall).not.toHaveBeenCalled();
       expect(processEvent.mock.calls.filter(([event]) => event.type === "call.ended")).toHaveLength(
@@ -664,13 +663,10 @@ describe("RealtimeCallHandler lifecycle", () => {
   });
 
   it("ends an idle realtime call after the media inactivity grace", async () => {
-    let resolveBridgeStarted = () => {};
-    const bridgeStarted = new Promise<void>((resolve) => {
-      resolveBridgeStarted = resolve;
-    });
+    const bridgeStarted = createDeferred<void>();
     const closeBridge = vi.fn();
     const { call, handler, hangupCall, processEvent } = createCarrierLifecycleHarness(() => {
-      resolveBridgeStarted();
+      bridgeStarted.resolve();
       return createBridge(closeBridge);
     });
     const { server, ws } = await connectCarrierStream(handler);
@@ -683,7 +679,7 @@ describe("RealtimeCallHandler lifecycle", () => {
           start: { streamSid: "MZ-inactivity", callSid: call.providerCallId },
         }),
       );
-      await bridgeStarted;
+      await bridgeStarted.promise;
 
       await vi.advanceTimersByTimeAsync(30_000);
       expect(processEvent.mock.calls.filter(([event]) => event.type === "call.ended")).toHaveLength(
@@ -720,17 +716,11 @@ describe("RealtimeCallHandler lifecycle", () => {
   });
 
   it("renews realtime liveness when inbound media continues", async () => {
-    let resolveBridgeStarted = () => {};
-    const bridgeStarted = new Promise<void>((resolve) => {
-      resolveBridgeStarted = resolve;
-    });
-    let resolveMediaReceived = () => {};
-    const mediaReceived = new Promise<void>((resolve) => {
-      resolveMediaReceived = resolve;
-    });
-    const sendAudio = vi.fn(() => resolveMediaReceived());
+    const bridgeStarted = createDeferred<void>();
+    const mediaReceived = createDeferred<void>();
+    const sendAudio = vi.fn(() => mediaReceived.resolve());
     const { call, handler, hangupCall, processEvent } = createCarrierLifecycleHarness(() => {
-      resolveBridgeStarted();
+      bridgeStarted.resolve();
       return createBridge(vi.fn(), { sendAudio });
     });
     const { server, ws } = await connectCarrierStream(handler);
@@ -743,7 +733,7 @@ describe("RealtimeCallHandler lifecycle", () => {
           start: { streamSid: "MZ-active-media", callSid: call.providerCallId },
         }),
       );
-      await bridgeStarted;
+      await bridgeStarted.promise;
 
       await vi.advanceTimersByTimeAsync(29_999);
       ws.send(
@@ -752,7 +742,7 @@ describe("RealtimeCallHandler lifecycle", () => {
           media: { payload: Buffer.from([0xff]).toString("base64") },
         }),
       );
-      await mediaReceived;
+      await mediaReceived.promise;
       await vi.advanceTimersByTimeAsync(29_999);
 
       expect(sendAudio).toHaveBeenCalledOnce();

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1,6 +1,6 @@
 // Voice Call tests cover realtime handler plugin behavior.
 import http from "node:http";
-import { expectDefined } from "@openclaw/normalization-core";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type {
   RealtimeVoiceBridge,
@@ -212,14 +212,6 @@ async function waitForRealtimeTest(
   options: { timeout?: number; interval?: number } = {},
 ) {
   await vi.waitFor(callback, { interval: 1, ...options });
-}
-
-function requireFirstMockCall(calls: readonly unknown[][], label: string): unknown[] {
-  const call = calls.at(0);
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call;
 }
 
 type RealtimeBridgeRequest = Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0];
@@ -523,7 +515,7 @@ describe("RealtimeCallHandler path routing", () => {
           channels: 1,
         });
         callbacks?.onReady?.();
-        const event = requireFirstMockCall(processEvent.mock.calls, "processed event")[0] as
+        const event = expectDefined(processEvent.mock.calls.at(0), "processed event")[0] as
           | NormalizedEvent
           | undefined;
         expect(event?.type).toBe("call.initiated");
@@ -867,16 +859,13 @@ describe("RealtimeCallHandler path routing", () => {
       processEvent,
       "disconnect-grace-expired",
     );
-    let resolveDisconnect: (() => void) | undefined;
-    const disconnected = new Promise<void>((resolve) => {
-      resolveDisconnect = resolve;
-    });
+    const disconnected = createDeferred<void>();
     const originalDisconnect = streamDisconnectLifecycle.disconnect.bind(streamDisconnectLifecycle);
     const disconnect = vi
       .spyOn(streamDisconnectLifecycle, "disconnect")
       .mockImplementation((providerCallId, streamId) => {
         originalDisconnect(providerCallId, streamId);
-        resolveDisconnect?.();
+        disconnected.resolve();
       });
     const handler = makeHandler(undefined, {
       manager: {
@@ -905,7 +894,7 @@ describe("RealtimeCallHandler path routing", () => {
         vi.useFakeTimers();
         ws.send(JSON.stringify({ event: "stop" }));
 
-        await disconnected;
+        await disconnected.promise;
         const events = processEvent.mock.calls.map(([event]) => event as NormalizedEvent);
         expect(close).toHaveBeenCalledTimes(1);
         expect(disconnect).toHaveBeenCalledExactlyOnceWith("CA-complete", "MZ-complete");
@@ -958,16 +947,13 @@ describe("RealtimeCallHandler path routing", () => {
       processEvent,
       "abnormal-disconnect-grace-expired",
     );
-    let resolveDisconnect: (() => void) | undefined;
-    const disconnected = new Promise<void>((resolve) => {
-      resolveDisconnect = resolve;
-    });
+    const disconnected = createDeferred<void>();
     const originalDisconnect = streamDisconnectLifecycle.disconnect.bind(streamDisconnectLifecycle);
     const disconnect = vi
       .spyOn(streamDisconnectLifecycle, "disconnect")
       .mockImplementation((disconnectedProviderCallId, disconnectedStreamId) => {
         originalDisconnect(disconnectedProviderCallId, disconnectedStreamId);
-        resolveDisconnect?.();
+        disconnected.resolve();
       });
     const handler = makeHandler(undefined, {
       manager: {
@@ -993,7 +979,7 @@ describe("RealtimeCallHandler path routing", () => {
       const closed = waitForClose(ws);
       ws.terminate();
       expect(await closed).toEqual({ code: 1006, reason: "" });
-      await disconnected;
+      await disconnected.promise;
 
       expect(close).toHaveBeenCalledTimes(1);
       expect(disconnect).toHaveBeenCalledExactlyOnceWith(providerCallId, streamId);
@@ -2061,7 +2047,7 @@ describe("RealtimeCallHandler path routing", () => {
         await waitForRealtimeTest(() => {
           expect(consult).toHaveBeenCalledTimes(1);
         });
-        const [args, callId, context] = requireFirstMockCall(consult.mock.calls, "consult");
+        const [args, callId, context] = expectDefined(consult.mock.calls.at(0), "consult");
         expect(args).toEqual({
           question: "Create a smoke test file for me.",
         });
@@ -2071,7 +2057,7 @@ describe("RealtimeCallHandler path routing", () => {
         expect(context).toEqual({ abortSignal: expect.any(AbortSignal) });
         await waitForRealtimeTest(() => {
           expect(sendUserMessage).toHaveBeenCalledTimes(1);
-          expect(requireFirstMockCall(sendUserMessage.mock.calls, "user message")).toEqual([
+          expect(expectDefined(sendUserMessage.mock.calls.at(0), "user message")).toEqual([
             "Internal OpenClaw consult result is ready.\nDo not call tools for this internal result.\nSpeak the following answer to the caller now, briefly and naturally:\nI created the smoke test file.",
           ]);
         });
@@ -3036,7 +3022,7 @@ describe("RealtimeCallHandler path routing", () => {
           },
           { timeout: 2_000 },
         );
-        const [args, callId, context] = requireFirstMockCall(consult.mock.calls, "consult");
+        const [args, callId, context] = expectDefined(consult.mock.calls.at(0), "consult");
         const consultArgs = args as { question?: string; context?: string } | undefined;
         expect(consultArgs?.question).toBe("Send a Discord message.");
         expect(consultArgs?.context).toBe(


### PR DESCRIPTION
Voice Call tests copied first-mock-call presence checks and simple Promise resolver setup. Reuse the existing focused SDK `expectDefined` and `createDeferred` helpers across six test files. Keep domain assertions, abort and cancellation handling, request concurrency limits, disconnect grace periods, and teardown order intact.

Production delta: 0. Test delta: +59/-136, net -77 lines. The unchanged baseline and candidate each passed all 241 cases across the six complete suites plus the outbound-helper sibling, with identical ordered case outcomes. Full local changed-file checks passed; independent Codex review through P2 found no actionable issues. Coverage uses mock providers and local HTTP/WebSocket paths.

Separate follow-up: **provisional final transcript during bridge creation**. Source-only inspection identified a conditional session-initialization question if a provider synchronously emits a final user transcript while its bridge is being created. This cleanup does not change that path; no runtime defect or live reproduction has been established.
