### PR TITLE
fix(gateway): show denied commands correctly after policy reload

### DIFF
--- a/extensions/qa-lab/src/session-host-command-state.real-gateway.e2e.test.ts
+++ b/extensions/qa-lab/src/session-host-command-state.real-gateway.e2e.test.ts
@@ -214,8 +214,7 @@ suite.define(() => {
               },
               { interval: 250, timeout: 60_000 },
             );
-            await waitForReconnect(unauthorizedNode, unauthorizedHelloCount);
-            await publishSessionHost(unauthorizedNode);
+            expect(helloCounts.get(unauthorizedNode)).toBe(unauthorizedHelloCount);
 
             await page.reload();
             await page.locator("#new-session-where-trigger").click();
@@ -228,7 +227,7 @@ suite.define(() => {
             await page.screenshot({
               animations: "disabled",
               fullPage: true,
-              path: path.join(suite.artifactDir, "02-unauthorized-after-restart.png"),
+              path: path.join(suite.artifactDir, "02-unauthorized-after-hot-reload.png"),
             });
           },
         );
@@ -430,13 +429,6 @@ async function publishSessionHost(node: GatewayClient): Promise<void> {
       environmentSession: NODE_WORKER_ENVIRONMENT_SESSION_VERSION,
       capacity: { total: 1, available: 1 },
     },
-  });
-}
-
-async function waitForReconnect(client: GatewayClient, previousCount: number): Promise<void> {
-  await vi.waitFor(() => expect(helloCounts.get(client) ?? 0).toBeGreaterThan(previousCount), {
-    interval: 100,
-    timeout: 60_000,
   });
 }
 

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -590,13 +590,11 @@ export function resolveRequiredNodeCommandAuthority(params: {
     ) {
       continue;
     }
-    if (declaredCommands.has(command) && !effectiveCommands.has(command)) {
-      return { command, state: "pending-approval" };
+    let state: RequiredNodeCommandAuthority["state"] = "undeclared";
+    if (declaredCommands.has(command)) {
+      state = effectiveCommands.has(command) ? "unauthorized" : "pending-approval";
     }
-    if (declaredCommands.has(command) || withheldCommands.has(command)) {
-      return { command, state: "unauthorized" };
-    }
-    return { command, state: "undeclared" };
+    return { command, state: withheldCommands.has(command) ? "unauthorized" : state };
   }
   const command = params.requiredCommands[0];
   return command ? { command, state: "invocable" } : undefined;

--- a/src/gateway/node-registry-policy.test.ts
+++ b/src/gateway/node-registry-policy.test.ts
@@ -6,7 +6,11 @@ import {
   mergeRemoteNodeSkillEntries,
   removeRemoteNodeSkills,
 } from "../skills/runtime/remote-skills.js";
-import { TALK_PTT_COMMANDS } from "./node-command-policy.js";
+import {
+  resolveNodeCommandAllowlist,
+  resolveRequiredNodeCommandAuthority,
+  TALK_PTT_COMMANDS,
+} from "./node-command-policy.js";
 import { listConnectedNodePluginTools } from "./node-plugin-tool-snapshot.js";
 import { NodeRegistry, readNodeSessionWithheldCommands } from "./node-registry.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
@@ -303,18 +307,48 @@ describe("connected node runtime policy", () => {
 
   it("withdraws and restores approved commands without granting an unapproved declaration", () => {
     const { node, client, socket, reload } = createFixture();
-    reload({ gateway: { nodes: { commands: { deny: ["computer.act"] } } } });
+    const readCommandState = (command: string, config: OpenClawConfig = {}) =>
+      resolveRequiredNodeCommandAuthority({
+        requiredCommands: [command],
+        declaredCommands: node.declaredCommands,
+        effectiveCommands: node.commands,
+        withheldCommands: readNodeSessionWithheldCommands(node),
+        allowlist: resolveNodeCommandAllowlist(config, node),
+      });
+    expect(readCommandState("computer.act")).toEqual({
+      command: "computer.act",
+      state: "invocable",
+    });
+    const deniedConfig: OpenClawConfig = {
+      gateway: { nodes: { commands: { deny: ["computer.act"] } } },
+    };
+    reload(deniedConfig);
 
     expect(node.commands).toEqual(["system.run"]);
     expect(node.caps).toEqual([]);
     expect(client.connect.commands).toEqual(["system.run"]);
     expect(readNodeSessionWithheldCommands(node)).toContain("computer.act");
+    expect(readCommandState("computer.act", deniedConfig)).toEqual({
+      command: "computer.act",
+      state: "unauthorized",
+    });
 
-    reload({ gateway: { nodes: { commands: { allow: ["screen.snapshot"] } } } });
+    const restoredConfig: OpenClawConfig = {
+      gateway: { nodes: { commands: { allow: ["screen.snapshot"] } } },
+    };
+    reload(restoredConfig);
 
     expect(node.commands).toEqual(["computer.act", "system.run"]);
     expect(node.caps).toEqual(["computer"]);
     expect(readNodeSessionWithheldCommands(node)).not.toContain("computer.act");
+    expect(readCommandState("computer.act", restoredConfig)).toEqual({
+      command: "computer.act",
+      state: "invocable",
+    });
+    expect(readCommandState("screen.snapshot", restoredConfig)).toEqual({
+      command: "screen.snapshot",
+      state: "pending-approval",
+    });
     expect(node.connId).toBe("policy-conn");
     expect(node.pairingGeneration).toBe("policy-generation");
     expect(socket.close).not.toHaveBeenCalled();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators denying a connected node's required command would see a pending-approval action in the session device picker after policy hot reload, instead of the unauthorized-command action.

## Why This Change Was Made

The NodeRegistry already records commands withheld by policy and removes them from the effective command set. The classifier checked the declared-but-not-effective state first, obscuring that recorded denial. It now consumes the withheld state while preserving the successful invocable path. The existing registry lifecycle test covers allowed, denied, restored, and still-unapproved commands; the real Gateway test now requires the same connection to survive hot reload.

## User Impact

The device picker gives the action appropriate to the current denial. Authorization, command execution permissions, configuration, stored data, and wire formats are unchanged. Production decreases by 2 lines; tests increase by 26 lines.

## Evidence

- Before the repair, the real Gateway scenario and the added assertion in the existing registry withdrawal/restoration test both failed with `pending-approval` instead of `unauthorized`.
- All 78 owner and sibling cases pass after the repair, retaining their original per-file order. This includes classifier, NodeRegistry, environment-authority, and device-placement coverage.
- A fresh Blacksmith Testbox install and full CI-artifact build passed, followed by the same real Gateway/browser scenario. It verifies the denial action and unchanged connection; the lease was stopped afterward.
- The full three-path `node scripts/check-changed.mjs -- extensions/qa-lab/src/session-host-command-state.real-gateway.e2e.test.ts src/gateway/node-command-policy.ts src/gateway/node-registry-policy.test.ts` gate and independent Codex P2 review passed. Three earlier local gate attempts failed on missing package-local dependency directories in the linked worktree. Completing the existing canonical links for the manifest- and lock-matched installation resolved that layout issue without changing dependency versions or suppressing checks.

Exact-head CI run [33749543312](https://github.com/openclaw/openclaw/actions/runs/33749543312) failed in the existing agent-exec construction-timeout fixture. Its source was unchanged by this PR. This branch was mechanically refreshed onto `1aea7351628f49781710012adda08f18428736db` to consume the already-landed process-fixture repair in [#137157](https://github.com/openclaw/openclaw/pull/137157), preserving this PR’s three-file patch byte-for-byte. That repair establishes real process readiness before advancing the original deadline. The earlier failure is retained; its exact hosted scheduling cause was not traced. The local and Testbox proof above ran before this mechanical refresh; fresh exact-head CI is required for the refreshed head.

The initial remote attempt also exposed a missing Playwright FFmpeg prerequisite; the canonical browser setup resolved it before the original failure was reproduced. The screenshots below show the synthetic scenario before and after the same-connection policy reload; they are two candidate states, not a before/after code comparison.

![Before policy reload: undeclared and pending commands, with the permitted test node available.](https://github.com/user-attachments/assets/c0ecb16a-943d-448b-85d5-eac652b4d589)

![After policy reload on the same connection: denied commands show the authorization action.](https://github.com/user-attachments/assets/e65b4a60-2a6c-490b-929e-ee2422f69399)
