### PR TITLE
refactor(agents): centralize replay invalid classification

### DIFF
--- a/src/agents/embedded-agent-helpers/provider-runtime-failure.ts
+++ b/src/agents/embedded-agent-helpers/provider-runtime-failure.ts
@@ -6,6 +6,7 @@ import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import {
   inferSignalStatus,
   isExactUnknownNoDetailsError,
+  isReplayInvalidErrorMessage,
 } from "../failover/classification-rules.js";
 import { classifyFailoverReason, classifyFailoverSignal } from "../failover/classify.js";
 import { isContextOverflowErrorFromTables } from "../failover/context-overflow.js";
@@ -50,10 +51,6 @@ const PROXY_ERROR_RE =
 const DNS_ERROR_RE = /\benotfound\b|\beai_again\b|\bgetaddrinfo\b|\bno such host\b|\bdns\b/i;
 const INTERRUPTED_NETWORK_ERROR_RE =
   /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;
-const REPLAY_INVALID_RE =
-  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
-const THINKING_SIGNATURE_ERROR_RE =
-  /\b(?:invalid|expired)\b.*\bsignature\b|\bsignature\b.*\b(?:invalid|expired)\b/i;
 const SANDBOX_BLOCKED_RE =
   /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b|\bexec denied\s*\(/i;
 function stripErrorPrefix(raw: string): string {
@@ -121,12 +118,6 @@ function isProxyErrorMessage(raw: string, status?: number): boolean {
 }
 function isDnsTransportErrorMessage(raw: string): boolean {
   return DNS_ERROR_RE.test(raw);
-}
-function isReplayInvalidErrorMessage(raw: string): boolean {
-  return REPLAY_INVALID_RE.test(raw) || isThinkingSignatureReplayInvalidErrorMessage(raw);
-}
-function isThinkingSignatureReplayInvalidErrorMessage(raw: string): boolean {
-  return /\bthinking\b/i.test(raw) && THINKING_SIGNATURE_ERROR_RE.test(raw);
 }
 function isSandboxBlockedErrorMessage(raw: string): boolean {
   return Boolean(formatExecDeniedUserMessage(raw)) || SANDBOX_BLOCKED_RE.test(raw);

--- a/src/agents/failover/classification-rules.ts
+++ b/src/agents/failover/classification-rules.ts
@@ -370,6 +370,16 @@ function isBilling429MessageForProvider(raw: string, provider: string | undefine
   }
   return hasProviderBilling429Override(provider) || !isAmbiguousGeneric429BalanceMessage(raw);
 }
+const REPLAY_INVALID_RE =
+  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
+const THINKING_SIGNATURE_ERROR_RE =
+  /\b(?:invalid|expired)\b.*\bsignature\b|\bsignature\b.*\b(?:invalid|expired)\b/i;
+function isThinkingSignatureReplayInvalidErrorMessage(raw: string): boolean {
+  return /\bthinking\b/i.test(raw) && THINKING_SIGNATURE_ERROR_RE.test(raw);
+}
+export function isReplayInvalidErrorMessage(raw: string): boolean {
+  return REPLAY_INVALID_RE.test(raw) || isThinkingSignatureReplayInvalidErrorMessage(raw);
+}
 // shared model runtime providers throw `Error("An unknown error occurred")` provider-agnostically
 // (anthropic, google, vertex, openai-completions, mistral, bedrock, etc.) when a
 // stream ends with stopReason === "aborted" | "error" without specific info. Treat

--- a/src/agents/failover/classify.ts
+++ b/src/agents/failover/classify.ts
@@ -25,6 +25,7 @@ import {
   isClaudeCliAuthError,
   isExactUnknownNoDetailsError,
   isGenericUnknownStreamErrorMessage,
+  isReplayInvalidErrorMessage,
   isUnsupportedImageInputErrorMessage,
   toPluginClassification,
   toReasonClassification,
@@ -69,16 +70,6 @@ export {
 export { extractFailoverSignalDetails } from "./signal-details.js";
 const HTML_BODY_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const HTML_CLOSE_RE = /<\/html>/i;
-const REPLAY_INVALID_RE =
-  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
-const THINKING_SIGNATURE_ERROR_RE =
-  /\b(?:invalid|expired)\b.*\bsignature\b|\bsignature\b.*\b(?:invalid|expired)\b/i;
-function isThinkingSignatureReplayInvalidErrorMessage(raw: string): boolean {
-  return /\bthinking\b/i.test(raw) && THINKING_SIGNATURE_ERROR_RE.test(raw);
-}
-function isReplayInvalidErrorMessage(raw: string): boolean {
-  return REPLAY_INVALID_RE.test(raw) || isThinkingSignatureReplayInvalidErrorMessage(raw);
-}
 function isHtmlErrorResponse(raw: string, status?: number): boolean {
   const trimmed = raw.trim();
   if (!trimmed) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a maintenance problem where failover classification and provider runtime failure projection each owned identical replay-invalid message grammar. Keeping two copies made provider replay recovery vulnerable to silent drift between the two decision paths.

## Why This Change Was Made

The exact replay-invalid and thinking-signature predicates now live in the existing internal failover classification-rules owner. Both consumers import the same narrow predicate; classification order and regex bytes are unchanged. The refreshed branch preserves the newer HTTP classification behavior from #137771.

Production delta: `+12/-20`, net `-8`. Test delta: `0`.

## User Impact

No user-visible behavior changes. Previous-response, missing tool input, role ordering, connection-bound item, and thinking-signature failures retain the same failover and runtime-failure classifications.

No Plugin SDK, public barrel, configuration, protocol, persistence, dependency, or security surface changes.

## Evidence

- Refreshed signed head: `5754ef8f228da7fe60cb1669d9a20ca094004a82`.
- Provider-runtime coverage: 22/22 passed.
- Failover coverage: 688/688 passed.
- Production typecheck passed.
- Import-cycle checks reported zero cycles.
- Formatting, targeted lint, dead-export checks, and fresh independent autoreview passed.
- Current main changed repeatedly during refresh; none of the three touched files changed after the port base, and the refreshed head remains merge-clean.
- The remaining core test-type shard reached an unrelated existing `markdown-it` type mismatch in the Control UI. Exact-head hosted CI/Testbox remains the acceptance gate for that broader surface.
