### PR TITLE
refactor(ollama): remove duplicate node invoke policy

### DIFF
--- a/extensions/ollama/src/node-inference.test.ts
+++ b/extensions/ollama/src/node-inference.test.ts
@@ -2,11 +2,8 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { describe, expect, it, vi } from "vitest";
-import {
-  createOllamaNodeHostCommands,
-  createOllamaNodeInferenceTool,
-  createOllamaNodeInvokePolicy,
-} from "./node-inference.js";
+import { createOllamaNodeInvokePolicy } from "./node-inference-registration.js";
+import { createOllamaNodeHostCommands, createOllamaNodeInferenceTool } from "./node-inference.js";
 
 const [OLLAMA_MODELS_COMMAND, OLLAMA_CHAT_COMMAND] = createOllamaNodeInvokePolicy().commands;
 if (!OLLAMA_MODELS_COMMAND || !OLLAMA_CHAT_COMMAND) {

--- a/extensions/ollama/src/node-inference.ts
+++ b/extensions/ollama/src/node-inference.ts
@@ -11,7 +11,6 @@ import type {
   AnyAgentTool,
   OpenClawPluginApi,
   OpenClawPluginNodeHostCommand,
-  OpenClawPluginNodeInvokePolicy,
 } from "openclaw/plugin-sdk/plugin-entry";
 import {
   readProviderJsonResponse,
@@ -31,8 +30,6 @@ import {
   OLLAMA_CHAT_COMMAND,
   OLLAMA_MODELS_COMMAND,
   OLLAMA_NODE_INFERENCE_CAPABILITY,
-  OLLAMA_NODE_INFERENCE_COMMANDS,
-  OLLAMA_NODE_INFERENCE_DEFAULT_PLATFORMS,
   ollamaNodeInferenceToolDefinition,
 } from "./node-inference-contract.js";
 import {
@@ -363,14 +360,6 @@ export function createOllamaNodeHostCommands(options?: {
       },
     },
   ];
-}
-
-export function createOllamaNodeInvokePolicy(): OpenClawPluginNodeInvokePolicy {
-  return {
-    commands: [...OLLAMA_NODE_INFERENCE_COMMANDS],
-    defaultPlatforms: [...OLLAMA_NODE_INFERENCE_DEFAULT_PLATFORMS],
-    handle: async (ctx) => await ctx.invokeNode(),
-  };
 }
 
 function findNode(nodes: NodeSummary[], query: string): NodeSummary {


### PR DESCRIPTION
## What Problem This Solves

The Ollama heavy node-inference runtime retained a duplicate node invoke policy after production registration moved to a lightweight module. That stale copy could drift from the actual control-plane policy and blurred the lazy-runtime ownership boundary.

This is the maintainer-requested exact-body group 2731 cleanup.

## Why This Change Was Made

The lazy-runtime split in `2fc2fc930b2` made `node-inference-registration.ts` the production owner for node policy metadata, but left the identical factory exported from `node-inference.ts`. This change removes the stranded runtime copy and redirects its existing test to the canonical lightweight owner.

Commands, default platforms, and `ctx.invokeNode()` delegation are unchanged. The heavy runtime remains lazy, and no public plugin barrel is expanded.

## User Impact

No user-visible behavior changes. Ollama node inference now has one policy owner, reducing drift risk while preserving registration and execution behavior.

## Evidence

- Focused policy, registration, and lazy-import suites: 119 tests passed.
- Full Ollama extension lane: 754 tests passed.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `pnpm build`: passed.
- `pnpm check:changed -- extensions/ollama/src/node-inference.ts extensions/ollama/src/node-inference.test.ts`: passed.
- Exact P1 autoreview: scoped-clean, correctness confidence 0.97.
- Production LOC: `+0/-11`; test LOC: `+2/-5`.
- No SDK, config, protocol, persistence, dependency, security-policy, gateway-authority, or lifecycle change.
