### PR TITLE
fix(agents): runtime-only turns persist a fabricated user turn in session transcripts

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
@@ -419,6 +419,86 @@ describe("runEmbeddedAttemptPromptPhase", () => {
     expect(mocks.releasePendingSteering).not.toHaveBeenCalled();
   });
 
+  it("arms one-shot persistence suppression around runtime-only submissions", async () => {
+    const fixture = createFixture();
+    const armSuppression = vi.fn(() => fixture.order.push("arm-suppression"));
+    const clearSuppression = vi.fn(() => fixture.order.push("clear-suppression"));
+    const preparePromptContext = mocks.preparePromptContext.getMockImplementation();
+    mocks.preparePromptContext.mockImplementation(() => ({
+      ...(preparePromptContext?.() as Record<string, unknown>),
+      promptSubmission: { prompt: "Continue the OpenClaw runtime event.", runtimeOnly: true },
+    }));
+    fixture.input.sessionManager = {
+      appendCustomEntry: vi.fn(),
+      getEntries: vi.fn(() => []),
+      armNextUserMessagePersistenceSuppression: armSuppression,
+      clearNextUserMessagePersistenceSuppression: clearSuppression,
+    } as unknown as PromptPhaseInput["sessionManager"];
+
+    await runEmbeddedAttemptPromptPhase(fixture.input);
+
+    expect(mocks.submitPrompt).toHaveBeenCalledWith(expect.objectContaining({ runtimeOnly: true }));
+    expect(fixture.order).toEqual([
+      "assembly",
+      "context",
+      "before-agent-run",
+      "google-cache",
+      "images",
+      "observe",
+      "publish",
+      "preflight",
+      "publish",
+      "arm-suppression",
+      "submit",
+      "clear-suppression",
+      "publish",
+      "stop-steering",
+    ]);
+    expect(armSuppression).toHaveBeenCalledTimes(1);
+    expect(clearSuppression).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears armed suppression when a runtime-only submission fails", async () => {
+    const fixture = createFixture();
+    const armSuppression = vi.fn();
+    const clearSuppression = vi.fn();
+    const preparePromptContext = mocks.preparePromptContext.getMockImplementation();
+    mocks.preparePromptContext.mockImplementation(() => ({
+      ...(preparePromptContext?.() as Record<string, unknown>),
+      promptSubmission: { prompt: "Continue the OpenClaw runtime event.", runtimeOnly: true },
+    }));
+    fixture.input.sessionManager = {
+      appendCustomEntry: vi.fn(),
+      getEntries: vi.fn(() => []),
+      armNextUserMessagePersistenceSuppression: armSuppression,
+      clearNextUserMessagePersistenceSuppression: clearSuppression,
+    } as unknown as PromptPhaseInput["sessionManager"];
+    mocks.submitPrompt.mockRejectedValueOnce(new Error("submission failed"));
+
+    await runEmbeddedAttemptPromptPhase(fixture.input);
+
+    expect(armSuppression).toHaveBeenCalledTimes(1);
+    expect(clearSuppression).toHaveBeenCalledTimes(1);
+    expect(mocks.handlePromptError).toHaveBeenCalledOnce();
+  });
+
+  it("leaves persistence untouched for user-authored submissions", async () => {
+    const fixture = createFixture();
+    const armSuppression = vi.fn();
+    const clearSuppression = vi.fn();
+    fixture.input.sessionManager = {
+      appendCustomEntry: vi.fn(),
+      getEntries: vi.fn(() => []),
+      armNextUserMessagePersistenceSuppression: armSuppression,
+      clearNextUserMessagePersistenceSuppression: clearSuppression,
+    } as unknown as PromptPhaseInput["sessionManager"];
+
+    await runEmbeddedAttemptPromptPhase(fixture.input);
+
+    expect(armSuppression).not.toHaveBeenCalled();
+    expect(clearSuppression).not.toHaveBeenCalled();
+  });
+
   it("records a final prompt policy that removes core read", async () => {
     const fixture = createFixture();
     mocks.applyPromptToolsAllow.mockReturnValueOnce({

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -4,6 +4,7 @@ import {
   buildHeartbeatOutcomeContext,
   claimHeartbeatOutcomeForRun,
 } from "../../../infra/heartbeat-outcome-store.js";
+import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { releasePendingAgentSteeringItems } from "../../subagents/registry/subagent-registry.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
@@ -103,7 +104,7 @@ type WithOwnedTranscriptWrite = <T>(operation: () => Promise<T> | T) => Promise<
 export async function runEmbeddedAttemptPromptPhase(input: {
   attempt: PromptAssemblyInput["attempt"];
   activeSession: PromptAssemblyInput["activeSession"];
-  sessionManager: PromptAssemblyInput["sessionManager"];
+  sessionManager: ReturnType<typeof guardSessionManager>;
   withOwnedTranscriptWrite: WithOwnedTranscriptWrite;
   getCompactionReserveTokens: () => number;
   emptyExplicitToolAllowlistError?: Error;
@@ -342,30 +343,45 @@ export async function runEmbeddedAttemptPromptPhase(input: {
     publishDispatchState(state);
 
     if (!state.skipPromptSubmission) {
-      await submitEmbeddedAttemptPrompt({
-        ...(promptBuildAppendContext ? { appendContext: promptBuildAppendContext } : {}),
-        attempt,
-        activeSession,
-        contextTokenBudget: promptContext.contextTokenBudget,
-        images: imageResult.images,
-        ...(leasedSteering ? { leasedSteering } : {}),
-        modelPrompt: promptContext.promptForModel,
-        onFinalPromptText: input.lifecycle.setFinalPromptText,
-        onSteeringAcknowledged: () => {
-          leasedSteering = undefined;
-        },
-        ...(promptBuildPrependContext ? { prependContext: promptBuildPrependContext } : {}),
-        ...(promptContext.runtimeContextMessageForCurrentTurn
-          ? { runtimeContextMessage: promptContext.runtimeContextMessageForCurrentTurn }
-          : {}),
-        runtimeOnly: promptContext.promptSubmission.runtimeOnly === true,
-        systemPrompt: promptContext.systemPromptForHook,
-        toolResultAggregateMaxChars: promptContext.promptToolResultAggregateMaxChars,
-        toolResultMaxChars: promptContext.promptToolResultMaxChars,
-        transcriptLeafId,
-        transcriptPrompt: promptContext.promptForSession,
-        ...input.submission,
-      });
+      // Runtime-only turns submit a synthetic continuation marker instead of user
+      // text. Persisting that marker would fabricate a user turn (#124244), so arm
+      // the existing one-shot persistence suppression before submitting. The
+      // marker's own write consumes it; disarm in case the submission never
+      // produced that user message.
+      const runtimeOnlySubmission = promptContext.promptSubmission.runtimeOnly === true;
+      if (runtimeOnlySubmission) {
+        sessionManager.armNextUserMessagePersistenceSuppression?.();
+      }
+      try {
+        await submitEmbeddedAttemptPrompt({
+          ...(promptBuildAppendContext ? { appendContext: promptBuildAppendContext } : {}),
+          attempt,
+          activeSession,
+          contextTokenBudget: promptContext.contextTokenBudget,
+          images: imageResult.images,
+          ...(leasedSteering ? { leasedSteering } : {}),
+          modelPrompt: promptContext.promptForModel,
+          onFinalPromptText: input.lifecycle.setFinalPromptText,
+          onSteeringAcknowledged: () => {
+            leasedSteering = undefined;
+          },
+          ...(promptBuildPrependContext ? { prependContext: promptBuildPrependContext } : {}),
+          ...(promptContext.runtimeContextMessageForCurrentTurn
+            ? { runtimeContextMessage: promptContext.runtimeContextMessageForCurrentTurn }
+            : {}),
+          runtimeOnly: promptContext.promptSubmission.runtimeOnly === true,
+          systemPrompt: promptContext.systemPromptForHook,
+          toolResultAggregateMaxChars: promptContext.promptToolResultAggregateMaxChars,
+          toolResultMaxChars: promptContext.promptToolResultMaxChars,
+          transcriptLeafId,
+          transcriptPrompt: promptContext.promptForSession,
+          ...input.submission,
+        });
+      } finally {
+        if (runtimeOnlySubmission) {
+          sessionManager.clearNextUserMessagePersistenceSuppression?.();
+        }
+      }
     } else {
       releaseLeasedSteering(state.promptError ?? "prompt submission skipped");
     }

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -40,6 +40,8 @@ type GuardedSessionManager = SessionManager & {
   flushPendingToolResults?: () => void;
   /** Clear pending tool calls without persisting synthetic tool results. Idempotent. */
   clearPendingToolResults?: () => void;
+  /** Suppress the next persisted user message without dropping the runtime copy. */
+  armNextUserMessagePersistenceSuppression?: () => void;
   /** Persist the next user message when an earlier canonical entry was removed. */
   clearNextUserMessagePersistenceSuppression?: () => void;
   /** Refresh the exact owning run when a caller reuses this guarded manager. */
@@ -290,6 +292,8 @@ export function guardSessionManager(
   guardedSessionManager.clearPendingToolResults = guard.clearPendingToolResults;
   guardedSessionManager.clearNextUserMessagePersistenceSuppression =
     guard.clearNextUserMessagePersistenceSuppression;
+  guardedSessionManager.armNextUserMessagePersistenceSuppression =
+    guard.armNextUserMessagePersistenceSuppression;
   guardedSessionManager.setTranscriptRunContext = (runId, prepare, skipHooks) => {
     guard.setTranscriptRunId(runId);
     prepareAssistantTranscriptMessage = prepare;

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -894,6 +894,17 @@ describe("installSessionToolResultGuard", () => {
     expect((persisted[0] as { content?: unknown } | undefined)?.content).toBe("second");
   });
 
+  it("arms one-shot user persistence suppression at runtime", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm);
+    guard.armNextUserMessagePersistenceSuppression();
+    sm.appendMessage(asAppendMessage({ role: "user", content: "marker turn", timestamp: 1 }));
+    sm.appendMessage(asAppendMessage({ role: "user", content: "real user turn", timestamp: 2 }));
+    const persisted = getPersistedMessages(sm);
+    expect(persisted).toHaveLength(1);
+    expect((persisted[0] as { content?: unknown } | undefined)?.content).toBe("real user turn");
+  });
+
   it("re-enables the next user write after the canonical entry is removed", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm, {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -666,6 +666,7 @@ export function installSessionToolResultGuard(
 ): {
   flushPendingToolResults: () => void;
   clearPendingToolResults: () => void;
+  armNextUserMessagePersistenceSuppression: () => void;
   clearNextUserMessagePersistenceSuppression: () => void;
   getPendingIds: () => string[];
   setTranscriptRunId: (runId: string | undefined) => void;
@@ -1029,6 +1030,9 @@ export function installSessionToolResultGuard(
   return {
     flushPendingToolResults,
     clearPendingToolResults,
+    armNextUserMessagePersistenceSuppression: () => {
+      suppressNextUserMessagePersistence = true;
+    },
     clearNextUserMessagePersistenceSuppression: () => {
       suppressNextUserMessagePersistence = false;
     },


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #124244

## What Problem This Solves

- Fixes an issue where a runtime-only turn (an agent turn with no user-authored prompt text, e.g. a room event or another runtime event routed through the prompt path) persisted the synthetic `Continue the OpenClaw runtime event.` marker as a user-role message in the session transcript. The transcript then attributes text the user never wrote to the user, and the model can quote that fabricated text back to them.
- **Related:** #124244. The other defects in that report (duplicate timeout sends, ingress-timeout handling, the restart loop) shipped fixed in v2026.8.2; the clawsweeper re-review narrowed the remaining scope to this transcript-attribution defect.

## Why This Change Was Made

- **Intended outcome:** runtime-generated context still reaches the model exactly as before (the runtime message stays in the in-memory conversation and the runtime system context stays composed into the system prompt), but the synthetic continuation marker is no longer written to the transcript as a user turn. The next real user message in the same session persists normally.
- **Out of scope:** no changes to channel transport, timeout policy, prompt derivation, or storage schema; runtime-event prompt building (`resolveRuntimeContextPromptParts`) is untouched.
- **How:** reuses the existing one-shot persistence-suppression path already exercised by replayed turns and stranded-reply recovery. The session tool-result guard gains an `armNextUserMessagePersistenceSuppression()` method (the mirror of the existing `clearNextUserMessagePersistenceSuppression()`), and the prompt phase arms it around runtime-only submissions, clearing it if the submission never produced the marker user message.
- **Highest-risk area:** the arming scope in the prompt phase — a lingering armed flag could suppress a later, unrelated user message. **Mitigation:** the flag is one-shot (consumed by the marker's own write) and is cleared in a `finally` right after submission, covered by a dedicated failure-path test.

## User Impact

- **Success criteria:** after a runtime-only turn, the session transcript contains no user message carrying the runtime marker, while the model still receives the runtime event content; the follow-up user-authored turn still persists with its real text.
- **What should reviewers focus on?** `src/agents/session-tool-result-guard.ts` (arm method), `src/agents/session-tool-result-guard-wrapper.ts` (exposure on the guarded manager), `src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts` (arming scope); regression tests `arms one-shot user persistence suppression at runtime` (guard) and `arms one-shot persistence suppression around runtime-only submissions` / `clears armed suppression when a runtime-only submission fails` (prompt phase).

## Evidence

- **Real environment tested:** isolated worktree at `aispace/worktrees/issue-124244` (branch `feat/issue-124244-runtime-marker-persistence`). The end-to-end proof below drives the **real embedded prompt phase** (`runEmbeddedAttemptPromptPhase`) through the real prompt assembly and runtime-only derivation (`attempt-prompt-build` / `resolveRuntimeContextPromptParts`), real preflight/observation, real submission (`attempt-prompt-submit`) into a real `AgentSession.prompt()` agent loop, the real session tool-result guard (`guardSessionManager`), and a real SQLite-backed `SessionManager` transcript store that is re-opened from disk after the run. No module is mocked, and the script never arms or clears the suppression guard itself — the suppression recorded below was armed by the production prompt phase. The only substituted boundary is the model provider stream (an in-process canned assistant response registered via `ModelRegistry.registerProvider`; no network, no provider credentials).
- **Exact steps or commands run after this patch:**
  ```bash
  node --import ./scripts/tsx.mjs marker-persistence-check-v2.mts   # zero-mock end-to-end prompt-phase persistence check (run from the worktree, then removed)
  skills/fix-pr/scripts/validate.sh src/agents/session-tool-result-guard.ts src/agents/session-tool-result-guard-wrapper.ts src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts src/agents/session-tool-result-guard.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
  node --import ./scripts/tsx.mjs scripts/run-tsgo.mts -b test/tsconfig/tsconfig.core.test.agents-root.json --builders 1
  node --import ./scripts/tsx.mjs scripts/run-tsgo.mts -b test/tsconfig/tsconfig.core.test.agents-other.json --builders 1
  ```
- **Evidence after fix:** a runtime-only submission (empty user-visible transcript prompt, delimited internal runtime context in the model prompt) followed by a real user-authored turn, both submitted through the real prompt phase; persisted history is read back from the durable SQLite transcript store:
  ```json
  {
    "scenario": "runtime-only embedded prompt through the real prompt phase",
    "armMethodExposedByGuard": true,
    "userMessagesSuppressedByPhaseArming": ["Continue the OpenClaw runtime event."],
    "persistedUserTextsFromDisk": ["actual user text"],
    "markerAbsentFromPersistedHistory": true,
    "runtimeEventBodyInModelSystemPrompt": true,
    "markerUserMessageDeliveredToModel": true,
    "followupUserTextDeliveredToModel": true,
    "followupUserTextPersistedFromDisk": true,
    "persistedEntryTypes": ["model_change", "thinking_level_change", "message", "message", "message"]
  }
  ```
  The runtime-only turn's marker user message was suppressed by the guard armed by the prompt phase itself (`userMessagesSuppressedByPhaseArming`), so the durable transcript contains no fabricated user turn (3 message entries: assistant + follow-up user + assistant), while the model still received the runtime event body (composed into the system prompt) and the marker user message in-context; the follow-up real user turn persists with its real text. `validate.sh` passed end-to-end (oxfmt + oxlint + 51/51 guard tests + 13/13 prompt-phase tests + `tsgo:core`), and both affected test-type shards (`agents-root`, `agents-other`) type-check clean.
- **Observed result after fix:** runtime-only turns no longer fabricate a user turn in the transcript; user-authored turns are unaffected.
- **Before evidence (optional, visual changes encouraged):** the identical script with the three changed source files restored to `origin/main` (main has not touched them since the merge base) persists the marker as a user turn read back from disk:
  ```json
  {
    "scenario": "runtime-only embedded prompt through the real prompt phase",
    "armMethodExposedByGuard": false,
    "userMessagesSuppressedByPhaseArming": [],
    "persistedUserTextsFromDisk": ["Continue the OpenClaw runtime event.", "actual user text"],
    "markerAbsentFromPersistedHistory": false,
    "runtimeEventBodyInModelSystemPrompt": true,
    "markerUserMessageDeliveredToModel": true,
    "followupUserTextDeliveredToModel": true,
    "followupUserTextPersistedFromDisk": true,
    "persistedEntryTypes": ["model_change", "thinking_level_change", "message", "message", "message", "message"]
  }
  ```
  On main the same real chain writes the marker as a 4th user message (4 message entries include the fabricated user turn) and no suppression occurs, because no arming path exists.
- **What was not tested:** a full live agent turn against a real model provider/gateway (no provider credentials in this environment — the provider stream is the only substituted boundary, and the persistence decision under test happens before any provider I/O would matter); CI lanes ran on GitHub Actions (final run green: `openclaw/ci-gate` pass, `build-artifacts` pass).
- **Proof tier:** L2
- **Proof limitations:** the model provider response is canned in-process (the persistence behavior under test is deterministic and does not depend on provider output).
- **Review state:** CI green; awaiting maintainer review.
