### PR TITLE
fix(cli): drain stdout before exiting after message CLI actions

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -369,15 +369,17 @@ describe("models list JSON failure process output", () => {
 });
 
 describe("message broadcast process exit", () => {
-  it("exits nonzero after a structured target failure", async () => {
+  it("drains a large piped JSON payload before exiting nonzero on a structured target failure", async () => {
     const root = tempDirs.make("openclaw-message-broadcast-exit-");
     const stateDir = path.join(root, "state");
     const configPath = path.join(stateDir, "openclaw.json");
     const entryPath = path.join(root, "run-message-broadcast.mjs");
+    const largePayload = "x".repeat(8_388_608);
     await fs.writeFile(
       entryPath,
       `import { registerHooks } from "node:module";
 const messageModule = "data:text/javascript," + encodeURIComponent(\`export async function messageCommand() {
+  process.stdout.write(JSON.stringify(${JSON.stringify({ payload: largePayload })}) + "\\\\n");
   return ${JSON.stringify({
     kind: "broadcast",
     channel: "fixture",
@@ -400,11 +402,18 @@ registerHooks({
   },
 });
 const { createMessageCliHelpers } = await import(${JSON.stringify(pathToFileURL(path.resolve("src/cli/program/message/helpers.ts")).href)});
+const { runCliWithExitFinalization } = await import(${JSON.stringify(pathToFileURL(path.resolve("src/cli/one-shot-exit.ts")).href)});
 const { runMessageAction } = createMessageCliHelpers("fixture");
-await runMessageAction("broadcast", {
-  channel: "fixture",
-  targets: ["ok-target", "failed-target"],
-  message: "hello",
+await runCliWithExitFinalization({
+  run: () =>
+    runMessageAction("broadcast", {
+      channel: "fixture",
+      targets: ["ok-target", "failed-target"],
+      message: "hello",
+    }),
+  onError: (err) => {
+    console.error(err);
+  },
 });
 `,
     );
@@ -412,6 +421,7 @@ await runMessageAction("broadcast", {
     const child = spawnSync(process.execPath, ["--import", "tsx", entryPath], {
       cwd: path.resolve("."),
       encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
       env: {
         ...process.env,
         HOME: root,
@@ -429,6 +439,7 @@ await runMessageAction("broadcast", {
     expect(child.error).toBeUndefined();
     expect(child.signal).toBeNull();
     expect(child.status, child.stderr).toBe(1);
+    expect(JSON.parse(child.stdout.trim())).toEqual({ payload: largePayload });
   });
 });
 

--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -66,6 +66,15 @@ vi.mock("../../../runtime.js", async (importOriginal) => ({
   defaultRuntime: runtimeMock,
 }));
 
+// Forward to the same synchronous-throwing exit mock: runMessageAction only defers the
+// real exit via the one-shot output drain, which these tests don't exercise directly.
+vi.mock("../../one-shot-exit.js", () => ({
+  requestExitAfterOneShotOutput: (runtime: { exit: (code: number) => never }, exitCode = 0) => {
+    runtime.exit(exitCode);
+    return true;
+  },
+}));
+
 vi.mock("../../deps.js", () => ({
   createDefaultDeps: () => ({}),
 }));

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -32,6 +32,7 @@ import {
 } from "../../../utils/absolute-deadline.js";
 import { runCommandWithRuntime } from "../../cli-utils.js";
 import { createDefaultDeps } from "../../deps.js";
+import { requestExitAfterOneShotOutput } from "../../one-shot-exit.js";
 
 /** Shared helpers used by every message subcommand registration. */
 export type MessageCliHelpers = {
@@ -219,7 +220,7 @@ export function createMessageCliHelpers(messageChannelOptions: string): MessageC
         }
       }
       failed ||= result !== undefined && !resolveMessageActionOutcome(result).ok;
-      defaultRuntime.exit(failed ? 1 : 0);
+      requestExitAfterOneShotOutput(defaultRuntime, failed ? 1 : 0);
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #137216. Large JSON from `openclaw message ... --json` can stop mid-document when stdout is a pipe. The command can report success even though the caller cannot parse its output.

## Why This Change Was Made

The shared message helper writes its result, runs plugin cleanup, then calls `defaultRuntime.exit(...)`. That direct exit bypasses the existing outer `runCliWithExitFinalization` output drain.

The repair replaces that direct exit with `requestExitAfterOneShotOutput(defaultRuntime, failed ? 1 : 0)`. The existing finalizer drains stdout and stderr, then exits with the same status. Plugin cleanup stays in its existing position. There is no new buffer, retry, timeout, configuration, or compatibility path.

Original repair and regression coverage by @chelsealong. Independent verification below uses the unchanged contributor head `aca2eeec07af4347a4b217091aad614a265e193b`.

## User Impact

Piped message JSON remains complete, including large broadcast results. Successful actions still exit 0; malformed targets still produce a failed result and exit 1. Plugin shutdown behavior stays unchanged.

## Evidence

Built both current-main baseline `74241294500ced3a835949092fc161b80c5a4da7` and the exact contributor head with frozen-lockfile installs and `pnpm build:ci-artifacts` in an isolated, secretless Linux container.

Ran the actual built CLI, not a source-import fixture:

```sh
openclaw message broadcast --channel discord --targets <synthetic-targets> --message hi --dry-run --json | cat > result.json
```

Each run used fresh inert config/home/state. Networking was disconnected. Every valid per-target payload and result reports `dryRun: true`; no messages were sent. The original CLI status was captured from `PIPESTATUS[0]`, separately from the reader status.

| Case | Main | Exact head | CLI status |
| --- | --- | --- | --- |
| 750 valid + 1 malformed, pipe | 65,536 bytes; invalid JSON | 367,088 bytes; all 751 results | 1 |
| 750 valid, pipe | 65,536 bytes; invalid JSON | 366,900 bytes; all 750 results | 0 |
| 1,500 valid + 1 malformed, pipe | 65,536 bytes; invalid JSON | 733,838 bytes; all 1,501 results | 1 |
| 3,000 valid, pipe | 65,536 bytes; invalid JSON | 1,467,150 bytes; all 3,000 results | 0 |
| 2 valid, pipe | Complete, 1,128 bytes | Same complete result | 0 |
| 2 valid + 1 malformed, pipe | Complete, 1,316 bytes | Same complete result | 1 |
| 1,500 valid + 1 malformed, regular file | Complete, 733,838 bytes | Same complete result | 1 |

A separate small command with V8 coverage confirms plugin cleanup runs once on both revisions. The main command never reaches the exit request or final stream drain; the exact head reaches both once. No cleanup timeout occurs.

The added 8 MiB process regression also fails against baseline production source at `JSON.parse` with an unterminated string, after its expected nonzero status assertion passes. It passes on the exact head. This supports, but does not replace, the built-CLI proof above.

Focused validation on the exact head:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.cli-process.config.ts src/cli/help-exit.process.test.ts src/cli/one-shot-exit.test.ts --maxWorkers=1
node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/program/message/helpers.test.ts --maxWorkers=1
```

- 120 tests pass: 63 process/finalizer tests and 57 message-helper tests.
- Changed-file formatting and lint pass with zero warnings or errors.
- Max-lines, environment-count, assertion-safety, conflict-marker, and diff-whitespace checks pass.
- Production: +2/-1, net +1 for the required import. Tests: +25/-5, net +20. The only removed runtime path is the message helper's direct exit.
- Sibling coverage includes error status preservation, read-only cleanup skips, cleanup failure/timeout handling, and the shared output finalizer.

### Separate existing follow-up

The broadcast envelope currently reports `dryRun: false` / `handledBy: core` even when every successful per-target payload and result reports `dryRun: true`. Both revisions behave this way. The effective mode is applied at the send boundary but not propagated to the broadcast envelope. This metadata issue is separate from output draining and is not changed here.
