### PR TITLE
refactor(gateway): reuse chat send timing helper

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -55,6 +55,7 @@ import type {
   SessionMessageSubscriberRegistry,
   ToolEventRecipientRegistry,
 } from "./server-chat-state.js";
+import { roundedChatSendTimingMs } from "./server-methods/chat-server-timing.js";
 import { hasSessionChangeReceivers } from "./session-change-receivers.js";
 import { buildGatewaySessionSnapshot } from "./session-event-payload.js";
 import {
@@ -414,10 +415,6 @@ function scheduleLiveTextFlush(
   }, delayMs);
   timer.unref?.();
   pendingFlushes[stream] = { timer, flush };
-}
-
-function roundedChatSendTimingMs(value: number): number {
-  return Math.max(0, Math.round(value * 1000) / 1000);
 }
 
 export function createAgentEventHandler({


### PR DESCRIPTION
## What Problem This Solves

Removes a stranded duplicate of the Gateway chat timing rounding policy, preventing the first-assistant timing path from drifting from the other `chat.send_timing` phases.

## Why This Change Was Made

The earlier Gateway split established `chat-server-timing.ts` as the owner of timing normalization but left an identical helper in `server-chat.ts`. This change reuses the existing owner and deletes the duplicate while preserving the exact `Math.max(0, Math.round(value * 1000) / 1000)` arithmetic.

## User Impact

No user-visible behavior changes. All `chat.send_timing` payloads, phases, routing, and protocol shapes remain unchanged.

Production LOC: `+1/-4`, net `-3`. Test LOC: `0`.

## Evidence

- 16/16 edge-value equivalence cases passed, including negative, non-finite, and rounding-boundary inputs.
- `server-chat.agent-events.test.ts` and `server.chat.gateway-server-chat-b.test.ts`: 333/333 passed.
- Both import-cycle checks passed with zero cycles.
- Core, package, plugin, declaration, and post-build phases passed; the Control UI build passed after expanding the sparse checkout with its tracked build-config inputs.
- Changed-file gates passed. Sparse-checkout omissions were repaired with tracked inputs; the failed guard and every downstream guard then passed.
- Formatting and diff checks passed.
- Exact P1 autoreview: scoped clean, correctness 0.99.

No config, persistence, protocol, SDK, authorization, or security behavior changed.
