### PR TITLE
refactor(migrate-claude): reuse memory directory reader

### DIFF
--- a/extensions/migrate-claude/memory.ts
+++ b/extensions/migrate-claude/memory.ts
@@ -1,5 +1,4 @@
 // Migrate Claude plugin module implements memory behavior.
-import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -11,6 +10,7 @@ import type { MigrationItem } from "openclaw/plugin-sdk/plugin-entry";
 import {
   CLAUDE_AUTO_MEMORY_MAX_FILES,
   CLAUDE_AUTO_MEMORY_MAX_SCAN_ENTRIES,
+  readMemoryDir,
   type ClaudeSource,
 } from "./source.js";
 import type { PlannedTargets } from "./targets.js";
@@ -57,16 +57,6 @@ async function addInstructionItem(params: {
       details: { sourceLabel: params.sourceLabel },
     }),
   );
-}
-
-async function readMemoryDir(dir: string): Promise<Dirent[]> {
-  try {
-    return await fs.readdir(dir, { withFileTypes: true });
-  } catch (error) {
-    throw new Error(`Unable to read Claude Code auto-memory directory: ${dir}`, {
-      cause: error,
-    });
-  }
 }
 
 type MarkdownFileScan = {

--- a/extensions/migrate-claude/source.ts
+++ b/extensions/migrate-claude/source.ts
@@ -95,7 +95,7 @@ async function safeReadDir(dir: string): Promise<Dirent[]> {
   }
 }
 
-async function readMemoryDir(dir: string): Promise<Dirent[]> {
+export async function readMemoryDir(dir: string): Promise<Dirent[]> {
   try {
     return await fs.readdir(dir, { withFileTypes: true });
   } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

Removes duplicate Claude Code auto-memory directory traversal behavior that could drift between migration source discovery and migration planning.

## Why This Change Was Made

The migrate-Claude plugin now keeps `readMemoryDir` in its existing source owner and reuses it from the planning module, which already depends on that module. The plugin-private helper preserves `fs.readdir(..., { withFileTypes: true })`, the exact `Unable to read Claude Code auto-memory directory: ${dir}` error, and the original error as `cause`.

## User Impact

No user-visible behavior changes. Discovery and planning now share one implementation of the shipped directory-read semantics.

Production LOC: +2/-12 (net -10) | Tests: +0/-0

No Plugin SDK, package export, config, protocol, persistence, dependency, authority, or security surface changes.

## Evidence

- `node scripts/run-vitest.mjs extensions/migrate-claude/provider.test.ts`: 30/30 passed
- `pnpm test:extension migrate-claude`: 30/30 passed
- Doctor contract declaration and closure guards: 5/5 passed
- Actual changed-file policy, boundary, lint, dead-export, and extension typecheck gates passed
- `pnpm check:import-cycles`: 0 runtime value cycles
- `pnpm check:madge-import-cycles`: 0 cycles
- `pnpm build`: passed
- Exact autoreview: scoped clean, correctness 0.99
