### PR TITLE
refactor(infra): centralize wildcard TCP host checks

### DIFF
--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -2,7 +2,7 @@
 import net from "node:net";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { formatCliCommand } from "../cli/command-format.js";
-import { parseTcpListenerEndpoint } from "./ports-netstat.js";
+import { isWildcardTcpHost, parseTcpListenerEndpoint } from "./ports-netstat.js";
 import type { PortListener, PortListenerKind, PortUsage } from "./ports-types.js";
 
 /** Classifies a listener as OpenClaw Gateway, SSH tunnel, known non-gateway, or unknown. */
@@ -61,12 +61,8 @@ function classifyLoopbackAddressFamily(host: string): "ipv4" | "ipv6" | null {
   return null;
 }
 
-function isWildcardAddress(host: string): boolean {
-  return host === "0.0.0.0" || host === "::" || host === "*";
-}
-
 function isExpectedGatewayBindAddress(host: string): boolean {
-  return classifyLoopbackAddressFamily(host) !== null || isWildcardAddress(host);
+  return classifyLoopbackAddressFamily(host) !== null || isWildcardTcpHost(host);
 }
 
 type ParsedGatewayListener = { pid: number; host: string };
@@ -132,7 +128,7 @@ function parsedListenersOwnSpecificIpv4WithLoopback(parsed: ParsedGatewayListene
   }
   const hosts = new Set(parsed.map(({ host }) => host));
   const specificHosts = [...hosts].filter(
-    (host) => host !== "127.0.0.1" && net.isIP(host) === 4 && !isWildcardAddress(host),
+    (host) => host !== "127.0.0.1" && net.isIP(host) === 4 && !isWildcardTcpHost(host),
   );
   return hosts.has("127.0.0.1") && specificHosts.length > 0;
 }

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -14,6 +14,7 @@ import {
 } from "./ports-lsof-listeners.js";
 import { resolveLsofCommand } from "./ports-lsof.js";
 import {
+  isWildcardTcpHost,
   parseTcpEndpoint,
   parseTcpListenerEndpoint,
   parseWindowsNetstatListeners,
@@ -625,10 +626,6 @@ async function buildPortUsage(
     detail: result.detail,
     errors: errors.length > 0 ? errors : undefined,
   };
-}
-
-function isWildcardTcpHost(host: string): boolean {
-  return host === "0.0.0.0" || host === "::" || host === "*";
 }
 
 function isSameTcpAddressFamily(leftHost: string, rightHost: string): boolean {

--- a/src/infra/ports-netstat.ts
+++ b/src/infra/ports-netstat.ts
@@ -52,6 +52,10 @@ export function parseTcpListenerEndpoint(raw: string | undefined): {
   return normalized ? parseTcpEndpoint(normalized) : null;
 }
 
+export function isWildcardTcpHost(host: string): boolean {
+  return host === "0.0.0.0" || host === "::" || host === "*";
+}
+
 function isWildcardEndpoint(raw: string | undefined): boolean {
   const endpoint = raw?.trim();
   if (!endpoint || endpoint === "*:*") {
@@ -63,7 +67,7 @@ function isWildcardEndpoint(raw: string | undefined): boolean {
   }
   // Windows localizes the TCP state text, so the wildcard peer is the stable
   // listener signal. Be strict here because force paths can kill the returned PID.
-  return parsed.port === 0 && ["0.0.0.0", "::", "*"].includes(parsed.host);
+  return parsed.port === 0 && isWildcardTcpHost(parsed.host);
 }
 
 export function parseWindowsNetstatListeners(


### PR DESCRIPTION
## What Problem This Solves

Removes three independent definitions of the wildcard TCP host grammar from port diagnostics and listener inspection. Keeping the grammar duplicated risks drift between diagnostic formatting, probe-host filtering, and the fail-closed Windows force path.

## Why This Change Was Made

`src/infra/ports-netstat.ts` now owns the canonical `isWildcardTcpHost` predicate. It accepts exactly `0.0.0.0`, `::`, and `*`; callers retain their existing trimming, lowercase normalization, IPv4-mapped handling, address-family matching, endpoint parsing, and force-path checks.

Production delta: `+9/-12`, net `-3`. Test delta: `0`.

## User Impact

No user-visible behavior changes. Port diagnostics and listener selection now share one exact wildcard-host contract without changing configuration, networking behavior, authorization, or security policy.

## Evidence

- `node scripts/run-vitest.mjs src/infra/ports-format.test.ts src/infra/ports.test.ts src/infra/gateway-processes.test.ts src/cli/program.force.test.ts` - 124 passed, 1 platform-specific skip
- `node scripts/check-changed.mjs --dry-run -- src/infra/ports-netstat.ts src/infra/ports-format.ts src/infra/ports-inspect.ts` - core production lanes selected
- `pnpm check:import-cycles` - 0 runtime value cycles
- `pnpm check:madge-import-cycles` - 0 cycles
- scoped oxlint, oxfmt, and `git diff --check` passed
- exact autoreview: scoped clean, correctness 0.99

`pnpm build` and `pnpm tsgo:core` were attempted but stopped before reaching these files because the shared workspace install is missing unrelated diff-viewer, Markdown, and phone-presentation dependencies. No install was run inside the worktree.
