### PR TITLE
refactor(ai): share replay identity hashing

### DIFF
--- a/packages/ai/src/transports/anthropic-compaction-replay.test.ts
+++ b/packages/ai/src/transports/anthropic-compaction-replay.test.ts
@@ -26,6 +26,12 @@ const replayOptions = {
   authProfileId: "anthropic:work",
 };
 
+type ReplayOptions = {
+  enabled?: boolean;
+  sessionId?: string;
+  authProfileId?: string;
+};
+
 function assistant(texts: string[]): AssistantMessage {
   return {
     role: "assistant",
@@ -50,16 +56,21 @@ function captureCheckpoint(
   message: AssistantMessage,
   summary: string,
   replayIndex: number,
-  options = replayOptions,
+  options: ReplayOptions = replayOptions,
+  captureModel: Model = model,
 ): void {
-  const capture = createCompactionCapture(message, model, options);
+  const capture = createCompactionCapture(message, captureModel, options);
   capture.begin(0, { type: "compaction", content: summary }, replayIndex);
   capture.complete(0);
 }
 
-function contextWithCheckpoint(summary = "summary of the earlier conversation"): Context {
+function contextWithCheckpoint(
+  summary = "summary of the earlier conversation",
+  options: ReplayOptions = replayOptions,
+  captureModel: Model = model,
+): Context {
   const checkpoint = assistant(["before checkpoint", "after checkpoint"]);
-  captureCheckpoint(checkpoint, summary, 1);
+  captureCheckpoint(checkpoint, summary, 1, options, captureModel);
   return {
     messages: [
       { role: "user", content: "old question", timestamp: 0 },
@@ -70,7 +81,7 @@ function contextWithCheckpoint(summary = "summary of the earlier conversation"):
 }
 
 describe("Anthropic compaction replay", () => {
-  it("captures a route-fenced summary and slices the outbound prefix", () => {
+  it("captures the complete route-fenced identity", () => {
     const context = contextWithCheckpoint();
     const checkpoint = context.messages[1];
 
@@ -90,19 +101,55 @@ describe("Anthropic compaction replay", () => {
     expect(checkpoint.providerReplay?.baseUrlHash).toBeTypeOf("string");
     expect(checkpoint.providerReplay?.sessionHash).toBeTypeOf("string");
     expect(checkpoint.providerReplay?.authProfileHash).toBeTypeOf("string");
-
-    const plan = buildAnthropicReplayPlan(context.messages, model, replayOptions);
-
-    expect(plan.compaction).toEqual({
-      type: "compaction",
-      content: "summary of the earlier conversation",
-    });
-    expect(plan.messages.map((message) => message.role)).toEqual(["assistant", "user"]);
-    expect(plan.messages[0]).toMatchObject({
-      role: "assistant",
-      content: [{ type: "text", text: "after checkpoint" }],
-    });
   });
+
+  it.each([
+    {
+      name: "exact identity",
+      captureModel: model,
+      captureOptions: replayOptions,
+      requestModel: model,
+      requestOptions: replayOptions,
+    },
+    {
+      name: "surrounding whitespace",
+      captureModel: { ...model, baseUrl: ` ${model.baseUrl} ` },
+      captureOptions: {
+        enabled: true,
+        sessionId: ` ${replayOptions.sessionId} `,
+        authProfileId: ` ${replayOptions.authProfileId} `,
+      },
+      requestModel: model,
+      requestOptions: replayOptions,
+    },
+    {
+      name: "blank and missing optional identity",
+      captureModel: model,
+      captureOptions: { enabled: true, sessionId: " ", authProfileId: "" },
+      requestModel: model,
+      requestOptions: { enabled: true },
+    },
+  ])(
+    "replays and slices the checkpoint for $name",
+    ({ captureModel, captureOptions, requestModel, requestOptions }) => {
+      const context = contextWithCheckpoint(
+        "summary of the earlier conversation",
+        captureOptions,
+        captureModel,
+      );
+      const plan = buildAnthropicReplayPlan(context.messages, requestModel, requestOptions);
+
+      expect(plan.compaction).toEqual({
+        type: "compaction",
+        content: "summary of the earlier conversation",
+      });
+      expect(plan.messages.map((message) => message.role)).toEqual(["assistant", "user"]);
+      expect(plan.messages[0]).toMatchObject({
+        role: "assistant",
+        content: [{ type: "text", text: "after checkpoint" }],
+      });
+    },
+  );
 
   it("uses the newest matching checkpoint", () => {
     const context = contextWithCheckpoint("older summary");
@@ -121,11 +168,41 @@ describe("Anthropic compaction replay", () => {
     expect(plan.messages[0]).toMatchObject({ role: "assistant", content: newest.content });
   });
 
-  it("falls back to full history when the route fence differs", () => {
+  it.each([
+    {
+      name: "session",
+      requestModel: model,
+      requestOptions: { ...replayOptions, sessionId: "session-2" },
+    },
+    {
+      name: "auth profile",
+      requestModel: model,
+      requestOptions: { ...replayOptions, authProfileId: "anthropic:personal" },
+    },
+    {
+      name: "base URL",
+      requestModel: { ...model, baseUrl: "https://api.example.com/v1" },
+      requestOptions: replayOptions,
+    },
+    {
+      name: "provider",
+      requestModel: { ...model, provider: "other-provider" },
+      requestOptions: replayOptions,
+    },
+    {
+      name: "API",
+      requestModel: { ...model, api: "openai-responses" as const },
+      requestOptions: replayOptions,
+    },
+    {
+      name: "model",
+      requestModel: { ...model, id: "claude-opus-5" },
+      requestOptions: replayOptions,
+    },
+  ])("falls back to full history when the $name differs", ({ requestModel, requestOptions }) => {
     const context = contextWithCheckpoint();
-    const otherModel = { ...model, id: "claude-opus-5" };
 
-    const plan = buildAnthropicReplayPlan(context.messages, otherModel, replayOptions);
+    const plan = buildAnthropicReplayPlan(context.messages, requestModel, requestOptions);
 
     expect(plan).toEqual({ messages: context.messages });
   });

--- a/packages/ai/src/transports/anthropic-compaction-replay.ts
+++ b/packages/ai/src/transports/anthropic-compaction-replay.ts
@@ -1,20 +1,13 @@
 import type { AssistantMessage, Context, Model, ProviderReplayState } from "@openclaw/llm-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { shortHash } from "../utils/hash.js";
-import { providerReplayContextMatches } from "./provider-replay-context.js";
+import {
+  buildProviderReplayContext,
+  providerReplayContextMatches,
+} from "./provider-replay-context.js";
 
 const ANTHROPIC_COMPACTION_REPLAY_TYPE = "anthropic-compaction";
 const ANTHROPIC_COMPACTION_SUPPRESSION_TYPE = "anthropic-compaction-suppression";
 const ANTHROPIC_COMPACTION_SUPPRESSION_DATA = "rejected";
-
-type AnthropicReplayContext = {
-  provider: string;
-  api: Model["api"];
-  model: string;
-  baseUrlHash?: string;
-  sessionHash?: string;
-  authProfileHash?: string;
-};
 
 type AnthropicCompactionReplayState = ProviderReplayState & {
   type: typeof ANTHROPIC_COMPACTION_REPLAY_TYPE;
@@ -71,22 +64,6 @@ export function createCompactionCapture(output: ReplayOut, model: Model, options
   };
 }
 
-function hashReplayValue(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  return normalized ? shortHash(normalized) : undefined;
-}
-
-function buildAnthropicReplayContext(model: Model, options?: ReplayOpts): AnthropicReplayContext {
-  return {
-    provider: model.provider,
-    api: model.api,
-    model: model.id,
-    baseUrlHash: hashReplayValue(model.baseUrl),
-    sessionHash: hashReplayValue(options?.sessionId),
-    authProfileHash: hashReplayValue(options?.authProfileId),
-  };
-}
-
 function isAnthropicCompactionState(
   state: Record<string, unknown>,
 ): state is Record<string, unknown> &
@@ -129,7 +106,7 @@ function captureAnthropicCompaction(
   model: Model,
   options?: ReplayOpts,
 ): void {
-  const context = buildAnthropicReplayContext(model, options);
+  const context = buildProviderReplayContext(model, options);
   if (!summary || !context.baseUrlHash || !Number.isSafeInteger(replayIndex) || replayIndex < 0) {
     return;
   }
@@ -148,7 +125,7 @@ export function suppressAnthropicCompaction(
   model: Model,
   options?: ReplayOpts,
 ): void {
-  const context = buildAnthropicReplayContext(model, options);
+  const context = buildProviderReplayContext(model, options);
   if (!context.baseUrlHash) {
     return;
   }
@@ -166,7 +143,7 @@ export function resolveNewestAnthropicCompaction(
   model: Model,
   options?: ReplayOpts,
 ): { owner: AssistantMessage; replayIndex: number; summary: string } | undefined {
-  const context = buildAnthropicReplayContext(model, options);
+  const context = buildProviderReplayContext(model, options);
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (message?.role !== "assistant") {

--- a/packages/ai/src/transports/openai-responses-compaction-replay.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.ts
@@ -8,7 +8,6 @@ import type {
   BaseOpenAIStreamOptions,
   OpenAIResponsesCompactionRejection,
 } from "../provider-options.js";
-import { shortHash } from "../utils/hash.js";
 import {
   isOpenAIResponsesCompactionOutput,
   readOpenAIResponsesCompactionWindow,
@@ -24,7 +23,10 @@ import {
   type ReplayableResponseCompactionItem,
 } from "./openai-responses-contracts.js";
 import { log } from "./openai-transport-shared.js";
-import { providerReplayContextMatches } from "./provider-replay-context.js";
+import {
+  buildProviderReplayContext,
+  providerReplayContextMatches,
+} from "./provider-replay-context.js";
 
 const OPENAI_RESPONSES_COMPACTION_SUPPRESSION_TYPE = "openai-responses-compaction-suppression";
 const OPENAI_RESPONSES_COMPACTION_SUPPRESSION_DATA = "rejected";
@@ -34,23 +36,11 @@ type OpenAIResponsesCompactionSuppressionState = ProviderReplayState & {
   baseUrlHash: string;
 };
 
-function hashOptionalReplayContextValue(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  return normalized ? shortHash(normalized) : undefined;
-}
-
 export function buildOpenAIResponsesReplayContext(
   model: Model,
   options?: Pick<BaseOpenAIStreamOptions, "authProfileId" | "sessionId">,
 ): OpenAIResponsesReplayContext {
-  return {
-    provider: model.provider,
-    api: model.api,
-    model: model.id,
-    baseUrlHash: hashOptionalReplayContextValue(model.baseUrl),
-    sessionHash: hashOptionalReplayContextValue(options?.sessionId),
-    authProfileHash: hashOptionalReplayContextValue(options?.authProfileId),
-  };
+  return buildProviderReplayContext(model, options);
 }
 
 export function isOpenAIResponsesReplayContext(

--- a/packages/ai/src/transports/provider-replay-context.ts
+++ b/packages/ai/src/transports/provider-replay-context.ts
@@ -1,4 +1,5 @@
-import type { ProviderReplayState } from "@openclaw/llm-core";
+import type { Model, ProviderReplayState } from "@openclaw/llm-core";
+import { shortHash } from "../utils/hash.js";
 
 type ProviderReplayContext = Readonly<
   Pick<
@@ -6,6 +7,25 @@ type ProviderReplayContext = Readonly<
     "provider" | "api" | "model" | "baseUrlHash" | "sessionHash" | "authProfileHash"
   >
 >;
+
+function hashReplayContextValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? shortHash(normalized) : undefined;
+}
+
+export function buildProviderReplayContext(
+  model: Model,
+  options?: { authProfileId?: string; sessionId?: string },
+): ProviderReplayContext {
+  return {
+    provider: model.provider,
+    api: model.api,
+    model: model.id,
+    baseUrlHash: hashReplayContextValue(model.baseUrl),
+    sessionHash: hashReplayContextValue(options?.sessionId),
+    authProfileHash: hashReplayContextValue(options?.authProfileId),
+  };
+}
 
 export function providerReplayContextMatches(
   state: ProviderReplayContext,


### PR DESCRIPTION
Related: #135727

## What Problem This Solves

Replay identity construction was duplicated across the OpenAI Responses and Anthropic compaction paths. These fields fence provider replay by provider, API, model, endpoint, session, and authentication identity, so separate builders create avoidable drift risk in a security-sensitive invariant.

## Why This Change Was Made

This moves the complete six-field replay-context construction into the shared owner established by #135727. Anthropic now uses that builder directly, while the existing OpenAI builder remains as a thin internal wrapper for its current callers. The shared owner also retains the exact existing trim, blank-to-undefined, and short-hash behavior.

## User Impact

No user-visible behavior changes. Replay checkpoints remain fenced to the same provider, API, model, endpoint, session, and authentication identities.

## Evidence

- Production LOC: `+33/-46`, net `-13`; test LOC: `+97/-20`, net `+77`.
- 80/80 focused replay tests passed across the Anthropic, OpenAI Responses, and shared provider compaction suites.
- Behavioral coverage now proves exact identity replay, surrounding-whitespace equivalence, blank-versus-missing optional identity, and fail-closed behavior for session, auth profile, base URL, provider, API, and model mismatches.
- Changed-file formatting, oxlint, repository ratchets, dependency pins, plugin boundaries, package patches, and conflict-marker checks passed.
- The local changed-path gate reached core typecheck, where the shared checkout could not resolve existing markdown and phone-number dependencies; no reported error referenced a changed file. Exact-head CI remains the authoritative typecheck.
- Exact autoreview found no actionable findings and rated the patch correct at 0.98 confidence.
- Direct inspection of `openai/codex` at `cc4b8bdeb8446144bc6a5e3f6d31b4d5c633c6f4` confirmed compaction uses the active provider, authentication, and session identity while the opaque compaction item does not encode those facts, leaving this replay fence correctly owned by OpenClaw.
- No public barrel or package export was added. No config, protocol, persistence, dependency, authority, security policy, or prompt-cache behavior changed.
