### PR TITLE
refactor(plugins): centralize configured provider detection

### DIFF
--- a/src/plugins/provider-config-owner.ts
+++ b/src/plugins/provider-config-owner.ts
@@ -18,6 +18,15 @@ export const CORE_BUILT_IN_MODEL_APIS = new Set([
   "openai-responses",
 ]);
 
+export function hasConfiguredModelProvider(params: {
+  provider: string;
+  config?: OpenClawConfig;
+}): boolean {
+  return (
+    findNormalizedProviderValue(params.config?.models?.providers, params.provider) !== undefined
+  );
+}
+
 /** Returns the plugin API id that owns a provider config when it is not core built-in. */
 export function resolveProviderConfigApiOwnerHint(params: {
   provider: string;

--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -1,5 +1,4 @@
 // Runtime bridge for invoking provider hooks supplied by plugins.
-import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -17,6 +16,7 @@ import {
 import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
 import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
 import {
+  hasConfiguredModelProvider,
   resolveModelCatalogScope,
   resolveProviderConfigApiOwnerHint,
 } from "./provider-config-owner.js";
@@ -204,15 +204,6 @@ function findProviderRuntimePluginInRegistry(params: {
     return matchesProviderPluginRef(plugin, params.provider);
   });
   return entry ? Object.assign({}, entry.provider, { pluginId: entry.pluginId }) : undefined;
-}
-
-function hasConfiguredModelProvider(params: {
-  provider: string;
-  config?: OpenClawConfig;
-}): boolean {
-  return (
-    findNormalizedProviderValue(params.config?.models?.providers, params.provider) !== undefined
-  );
 }
 
 export function resolveLoadedProviderPluginsForHooks(params: {

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -1,8 +1,5 @@
 // Composes provider plugin runtime hooks with shared provider policy.
-import {
-  findNormalizedProviderValue,
-  normalizeProviderId,
-} from "@openclaw/model-catalog-core/provider-id";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { AuthProfileCredential, OAuthCredential } from "../agents/auth-profiles/types.js";
@@ -28,6 +25,7 @@ import type {
   PluginMetadataRegistryView,
   PluginMetadataSnapshot,
 } from "./plugin-metadata-snapshot.types.js";
+import { hasConfiguredModelProvider } from "./provider-config-owner.js";
 import { resolvePluginDiscoveryProvidersRuntime } from "./provider-discovery.runtime.js";
 import {
   prepareProviderExtraParams,
@@ -131,15 +129,6 @@ function hasExplicitProviderRuntimePluginActivation(params: {
   const allow = new Set(params.config.plugins?.allow ?? []);
   const entries = params.config.plugins?.entries ?? {};
   return ownerPluginIds.some((pluginId) => allow.has(pluginId) || entries[pluginId] !== undefined);
-}
-
-function hasConfiguredModelProvider(params: {
-  provider: string;
-  config?: OpenClawConfig;
-}): boolean {
-  return (
-    findNormalizedProviderValue(params.config?.models?.providers, params.provider) !== undefined
-  );
 }
 
 export {


### PR DESCRIPTION
## What Problem This Solves

Provider runtime and hook resolution carried two identical checks for whether a model provider is explicitly configured. Keeping that config classification duplicated makes provider fanout behavior easier to drift across the two runtime paths.

## Why This Change Was Made

Moves the existing normalized configured-provider predicate into the internal provider config owner and reuses it from both runtime consumers. The lookup expression and call sites are unchanged; this adds no public, Plugin SDK, config, or documentation surface.

## User Impact

No user-visible behavior changes. Plugin provider resolution keeps the same case-insensitive configured-provider semantics with one canonical owner.

## Evidence

- Focused equivalence probe: 9/9 normalized lookup cases passed, including case-insensitive and absent-config cases.
- `src/agents/model-catalog-scope.test.ts`: 2/2 passed.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `pnpm check:madge-import-cycles`: 0 cycles.
- Direct formatting and lint checks passed for all three changed files.
- `pnpm check:changed` passed every pre-typecheck gate, then stopped because the shared dependency install cannot resolve existing markdown packages.
- `pnpm test:contracts:plugins` reached 860 tests; 856 passed. Remaining failures were unresolved shared packages, including markdown dependencies and `@lancedb/lancedb`.
- `pnpm build` stopped in bundled plugin assets because the shared install cannot resolve `@pierre/diffs` and Shiki language packages.
- Autoreview: scoped-clean, no P0/P1 findings, confidence 0.98.
- Production LOC: +12/-23 (net -11). Tests: +0/-0.
