### PR TITLE
fix(qa): restore Slack transport under isolated installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2153,6 +2153,7 @@
     "@shikijs/engine-javascript": "4.4.3",
     "@shikijs/engine-oniguruma": "4.4.3",
     "@sindresorhus/slugify": "2.2.0",
+    "@slack/web-api": "8.0.0",
     "@types/express": "5.0.6",
     "@types/hosted-git-info": "3.0.5",
     "@types/jsdom": "30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,6 +399,9 @@ importers:
       '@sindresorhus/slugify':
         specifier: 2.2.0
         version: 2.2.0
+      '@slack/web-api':
+        specifier: 8.0.0
+        version: 8.0.0
       '@types/express':
         specifier: 5.0.6
         version: 5.0.6

--- a/test/scripts/tsdown-runtime-config.test.ts
+++ b/test/scripts/tsdown-runtime-config.test.ts
@@ -1,5 +1,6 @@
 // Covers bundling rules encoded in the root tsdown config.
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { bundledPluginRoot } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
@@ -368,6 +369,28 @@ describe("tsdown config", () => {
     }
     const externalize = external;
     expect(externalize("jimp", undefined, false)).toBe(true);
+  });
+
+  it("keeps the externalized Slack Web API resolvable from root dist", () => {
+    const rootPackage = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as { devDependencies?: Record<string, string> };
+    const slackPackage = JSON.parse(
+      readFileSync(new URL("../../extensions/slack/package.json", import.meta.url), "utf8"),
+    ) as { dependencies?: Record<string, string> };
+    const slackWebApiVersion = slackPackage.dependencies?.["@slack/web-api"];
+
+    expect(rootPackage.devDependencies?.["@slack/web-api"]).toBe(slackWebApiVersion);
+
+    const requireFromRootDist = createRequire(
+      new URL("../../dist/private-qa-runtime.cjs", import.meta.url),
+    );
+    const resolvedPackage = JSON.parse(
+      readFileSync(requireFromRootDist.resolve("@slack/web-api/package.json"), "utf8"),
+    ) as { name?: string; version?: string };
+
+    expect(resolvedPackage.name).toBe("@slack/web-api");
+    expect(resolvedPackage.version).toBe(slackWebApiVersion);
   });
 
   it("bundles SDK-owned helpers while retaining fs-safe package ownership", () => {


### PR DESCRIPTION
Fixes #137245

## What Problem This Solves

Fixes an issue where maintainers running the source-only private QA Slack transport would see it fail before credential acquisition after an isolated pnpm install.

## Why This Change Was Made

The private QA build emits its Slack consumer under the root `dist` graph while deliberately externalizing `@slack/web-api`. The root package now declares the same pinned SDK version as the Slack plugin, so Node can resolve that external dependency under pnpm's isolated linker without changing plugin ownership or bundling topology.

## User Impact

Slack QA and RTT qualification can start the live transport again after an isolated frozen install.

## Evidence

- Reproduction: https://github.com/openclaw/openclaw-rtt/actions/runs/33742750602 failed 3/3 attempts before any Slack API call with `Cannot find package '@slack/web-api'`.
- Full Testbox gate: https://github.com/openclaw/openclaw/actions/runs/33747001332
  - isolated frozen install passed
  - focused regression passed: 24/24
  - `check:changed` passed, including typecheck, lint, dependency, SDK, boundary, and import-cycle gates
  - private QA build passed
  - root-dist resolver reported `SLACK_WEB_API_RESOLVED=8.0.0`
- Exact rebased candidate: https://github.com/openclaw/openclaw/actions/runs/33751530615
  - isolated frozen install passed
  - focused regression passed: 24/24
  - private QA build passed
  - root-dist resolver reported `SLACK_WEB_API_RESOLVED=8.0.0`
- `git diff --check` passed.
- Fresh branch autoreview found no accepted or actionable findings through P2.
