### PR TITLE
refactor(cron): share runtime model thinking setup

### DIFF
--- a/src/cron/isolated-agent/run.cron-runtime-model-thinking.test.ts
+++ b/src/cron/isolated-agent/run.cron-runtime-model-thinking.test.ts
@@ -75,6 +75,12 @@ describe("runCronIsolatedAgentTurn runtime model thinking", () => {
         isNewSession: true,
       }),
     );
+    runWithModelFallbackMock.mockImplementation(async (params: TestModelFallbackRunnerParams) => ({
+      result: await runInitialModelFallbackAttempt(params),
+      provider: params.provider,
+      model: params.model,
+      attempts: [],
+    }));
   });
 
   afterEach(() => {
@@ -98,12 +104,6 @@ describe("runCronIsolatedAgentTurn runtime model thinking", () => {
         level === "off" || catalog?.some((entry) => entry.reasoning === true) === true,
     );
     resolveSupportedThinkingLevelMock.mockReturnValue("off");
-    runWithModelFallbackMock.mockImplementation(async (params: TestModelFallbackRunnerParams) => ({
-      result: await runInitialModelFallbackAttempt(params),
-      provider: params.provider,
-      model: params.model,
-      attempts: [],
-    }));
 
     await runCronIsolatedAgentTurn({
       cfg: {
@@ -152,12 +152,6 @@ describe("runCronIsolatedAgentTurn runtime model thinking", () => {
       ref: { provider: "ollama", model: "minimax-m3:cloud" },
     });
     loadModelCatalogMock.mockResolvedValue([]);
-    runWithModelFallbackMock.mockImplementation(async (params: TestModelFallbackRunnerParams) => ({
-      result: await runInitialModelFallbackAttempt(params),
-      provider: params.provider,
-      model: params.model,
-      attempts: [],
-    }));
 
     await runCronIsolatedAgentTurn({
       cfg: {
@@ -200,14 +194,6 @@ describe("runCronIsolatedAgentTurn runtime model thinking", () => {
         ref: { provider: "ollama", model: "minimax-m3:cloud" },
       });
       loadModelCatalogMock.mockResolvedValue([]);
-      runWithModelFallbackMock.mockImplementation(
-        async (params: TestModelFallbackRunnerParams) => ({
-          result: await runInitialModelFallbackAttempt(params),
-          provider: params.provider,
-          model: params.model,
-          attempts: [],
-        }),
-      );
 
       await runCronIsolatedAgentTurn({
         cfg: {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Cron runtime-thinking tests repeat the same initial-attempt fallback setup in three places, making the fixture more cumbersome to maintain.

## Why This Change Was Made

Set that default once in the suite's existing `beforeEach`. Keep both per-test fallback overrides and the provenance-aware helper so initial and fallback attempts retain their existing arguments and order.

## User Impact

No runtime behavior changes. All six thinking cases and their assertions remain; the cleanup removes 14 test lines with no production or shared-harness changes.

## Evidence

The complete runtime-thinking and model-override suites passed all 15 cases before and after, with identical case and execution order. Scoped formatting, the normal selected local changed gate, and an independent Codex P2 review passed. The sibling suite retains auth-profile, disallowed-model, pre-run persistence and error-path coverage.

Source-only follow-up: the model-override forwarding suite has a deferred CLI lookup with an assertion before release/join and no finally. That separate fixture question is unchanged and has no failing reproduction; this PR makes no leak or runtime-defect claim.
