### PR TITLE
refactor(approvals): clarify structured error coverage

### DIFF
--- a/src/infra/approval-errors.test.ts
+++ b/src/infra/approval-errors.test.ts
@@ -4,18 +4,17 @@ import { isApprovalNotFoundError, isApprovalStaleError } from "./approval-errors
 
 describe("isApprovalNotFoundError", () => {
   it("matches direct approval-not-found gateway codes", () => {
-    const err = new Error("approval not found") as Error & { gatewayCode?: string };
-    err.gatewayCode = "APPROVAL_NOT_FOUND";
+    const err = Object.assign(new Error("approval not found"), {
+      gatewayCode: "APPROVAL_NOT_FOUND",
+    });
     expect(isApprovalNotFoundError(err)).toBe(true);
   });
 
   it("matches structured invalid-request approval-not-found details", () => {
-    const err = new Error("approval not found") as Error & {
-      gatewayCode?: string;
-      details?: { reason?: string };
-    };
-    err.gatewayCode = "INVALID_REQUEST";
-    err.details = { reason: "APPROVAL_NOT_FOUND" };
+    const err = Object.assign(new Error("approval not found"), {
+      gatewayCode: "INVALID_REQUEST",
+      details: { reason: "APPROVAL_NOT_FOUND" },
+    });
     expect(isApprovalNotFoundError(err)).toBe(true);
   });
 
@@ -32,18 +31,17 @@ describe("isApprovalNotFoundError", () => {
 
 describe("isApprovalStaleError", () => {
   it("matches structured already-resolved gateway errors", () => {
-    const err = new Error("approval already resolved") as Error & {
-      gatewayCode?: string;
-      details?: { reason?: string };
-    };
-    err.gatewayCode = "INVALID_REQUEST";
-    err.details = { reason: "APPROVAL_ALREADY_RESOLVED" };
+    const err = Object.assign(new Error("request rejected"), {
+      gatewayCode: "INVALID_REQUEST",
+      details: { reason: "APPROVAL_ALREADY_RESOLVED" },
+    });
     expect(isApprovalStaleError(err)).toBe(true);
   });
 
   it("includes approval-not-found errors", () => {
-    const err = new Error("approval not found") as Error & { gatewayCode?: string };
-    err.gatewayCode = "APPROVAL_NOT_FOUND";
+    const err = Object.assign(new Error("approval not found"), {
+      gatewayCode: "APPROVAL_NOT_FOUND",
+    });
     expect(isApprovalStaleError(err)).toBe(true);
   });
 


### PR DESCRIPTION
## What Problem This Solves

The structured already-resolved approval test could keep passing when structured-reason handling broke: its message also matched the legacy fallback. Four fixtures also repeated type assertions and field assignments to construct ordinary enriched errors.

## Why This Change Was Made

Use the existing `Object.assign(new Error(...), fields)` pattern and give the structured already-resolved case a neutral message. The same assertion now depends on the structured code and reason. All seven cases and nine assertions remain; the production classifier, legacy spellings, SDK export and approval lifecycle are unchanged.

## User Impact

No user-visible behavior change. Developers get a stronger regression check with less fixture setup: production delta zero, test delta +14/−16 (net −2 lines).

## Evidence

The same canonical four-suite selection passed all 115 cases before and after: approval errors (7), error helpers (38), Gateway resolver (42), and TUI approvals (28), with identical ordered case names.

A temporary control omitted only the structured already-resolved arm. The original seven tests passed; the revised suite failed exactly its structured case (`expected false to be true`) while the other six passed. The owner was restored byte-for-byte before final validation. The TUI stale fixture remains useful lifecycle coverage, but is not claimed as independent structured-arm sensitivity.

`node scripts/check-changed.mjs -- src/infra/approval-errors.test.ts` passed the full configured local gate, including test typechecking, lint and required guards. Formatting made no further changes. Managed Codex review was clean through P2. Source and installed application lock sections matched; no install or cache override was needed. Hosted CI will be checked on the published head.
