### PR TITLE
fix(release): install first-hop fixtures through the candidate registry

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/update-first-hop-compat.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-first-hop-compat.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 source scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+source scripts/lib/docker-e2e-logs.sh
 
 if [ "${OPENCLAW_QA_ALLOW_UPDATE_FIRST_HOP:-0}" != "1" ]; then
   echo "blocked destructive package self-update; set OPENCLAW_QA_ALLOW_UPDATE_FIRST_HOP=1 to run" >&2
@@ -38,11 +39,20 @@ package_root() {
   printf '%s/lib/node_modules/openclaw\n' "$npm_config_prefix"
 }
 
-write_update_command() {
-  local output="$1" target="$2"
+run_update() {
+  local output="$ARTIFACT_DIR/$1" target="$2" update_status=0
   printf '%q ' env "PATH=$PATH" "npm_config_prefix=$npm_config_prefix" openclaw \
-    update --yes "--tag=$target" --json >"$output"
-  printf '\n' >>"$output"
+    update --yes "--tag=$target" --json >"$output-command.txt"
+  printf '\n' >>"$output-command.txt"
+  openclaw update --yes "--tag=$target" --json \
+    >"$output.stdout" 2>"$output.stderr" || update_status="$?"
+  printf '%s\n' "$update_status" >"$output.exit"
+  if [ "$update_status" -ne 0 ]; then
+    echo "package update $1 exited with status $update_status" >&2
+    docker_e2e_print_log "$output.stdout" >&2
+    docker_e2e_print_log "$output.stderr" >&2
+  fi
+  return "$update_status"
 }
 
 record_residue() {
@@ -108,7 +118,10 @@ setup_lane() {
 
   mkdir -p "$OPENCLAW_STATE_DIR" "$npm_config_prefix" "$npm_config_cache"
   npm install -g --prefix "$npm_config_prefix" "$SOURCE_PACKAGE" --no-fund --no-audit \
-    >"$ARTIFACT_DIR/$lane-install-source.log" 2>&1
+    >"$ARTIFACT_DIR/$lane-install-source.log" 2>&1 || {
+      docker_e2e_print_log "$ARTIFACT_DIR/$lane-install-source.log" >&2
+      return 1
+    }
   openclaw --version >"$ARTIFACT_DIR/$lane-source-version.txt"
   install_update_restart_systemctl_shim
   openclaw config set gateway.mode local >"$ARTIFACT_DIR/$lane-config.log" 2>&1
@@ -138,14 +151,8 @@ reset_lane() {
 run_negative_control() {
   local lane=negative
   setup_lane "$lane" 18791
-  write_update_command "$ARTIFACT_DIR/$lane-update-command.txt" "$NEGATIVE_PACKAGE"
-  set +e
-  openclaw update --yes "--tag=$NEGATIVE_PACKAGE" --json \
-    >"$ARTIFACT_DIR/$lane-update.stdout" \
-    2>"$ARTIFACT_DIR/$lane-update.stderr"
-  local update_status="$?"
-  set -e
-  printf '%s\n' "$update_status" >"$ARTIFACT_DIR/$lane-update.exit"
+  local update_status=0
+  run_update "$lane-update" "$NEGATIVE_PACKAGE" || update_status="$?"
   assert_installed_build "$CANDIDATE_PACKAGE" "$ARTIFACT_DIR/$lane-installed-build-info.json"
   record_residue "$ARTIFACT_DIR/$lane-transaction-residue.txt"
   assert_no_residue "$ARTIFACT_DIR/$lane-transaction-residue.txt"
@@ -174,11 +181,7 @@ run_positive_hops() {
   local first_pid
   first_pid="$(cat "$ARTIFACT_DIR/$lane-before.pid")"
 
-  write_update_command "$ARTIFACT_DIR/$lane-first-command.txt" "$CANDIDATE_PACKAGE"
-  openclaw update --yes "--tag=$CANDIDATE_PACKAGE" --json \
-    >"$ARTIFACT_DIR/$lane-first.stdout" \
-    2>"$ARTIFACT_DIR/$lane-first.stderr"
-  printf '0\n' >"$ARTIFACT_DIR/$lane-first.exit"
+  run_update "$lane-first" "$CANDIDATE_PACKAGE"
   assert_installed_build "$CANDIDATE_PACKAGE" "$ARTIFACT_DIR/$lane-first-build-info.json"
   wait_service_active
   local candidate_pid
@@ -196,11 +199,7 @@ run_positive_hops() {
   assert_no_residue "$ARTIFACT_DIR/$lane-first-transaction-residue.txt"
   record_service_state "$ARTIFACT_DIR/$lane-service-after-first.txt"
 
-  write_update_command "$ARTIFACT_DIR/$lane-second-command.txt" "$FUTURE_PACKAGE"
-  openclaw update --yes "--tag=$FUTURE_PACKAGE" --json \
-    >"$ARTIFACT_DIR/$lane-second.stdout" \
-    2>"$ARTIFACT_DIR/$lane-second.stderr"
-  printf '0\n' >"$ARTIFACT_DIR/$lane-second.exit"
+  run_update "$lane-second" "$FUTURE_PACKAGE"
   assert_installed_build "$FUTURE_PACKAGE" "$ARTIFACT_DIR/$lane-second-build-info.json"
   wait_service_active
   local future_pid

--- a/scripts/e2e/update-first-hop-compat-docker.sh
+++ b/scripts/e2e/update-first-hop-compat-docker.sh
@@ -62,6 +62,7 @@ PACKAGE_TGZ="$(
     update-first-hop-compat \
     "${OPENCLAW_UPDATE_FIRST_HOP_CANDIDATE_PACKAGE_TGZ:-}"
 )"
+docker_e2e_package_mount_args "$PACKAGE_TGZ" /tmp/openclaw-update-first-hop-candidate.tgz
 
 mkdir -p "$FIXTURE_ROOT/packages/negative" "$FIXTURE_ROOT/packages/future"
 tar -xzf "$PACKAGE_TGZ" -C "$FIXTURE_ROOT/packages/negative"
@@ -104,7 +105,7 @@ docker_e2e_run_with_harness \
   -e OPENCLAW_UPDATE_FIRST_HOP_EXPECTED_MISSING_CHUNK="$EXPECTED_MISSING_CHUNK" \
   -v "$ARTIFACT_DIR:/tmp/openclaw-update-first-hop-artifacts" \
   -v "$(docker_e2e_abs_path "$SOURCE_PACKAGE"):/tmp/openclaw-update-first-hop-source.tgz:ro" \
-  -v "$PACKAGE_TGZ:/tmp/openclaw-update-first-hop-candidate.tgz:ro" \
+  "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   -v "$FIXTURE_ROOT/negative.tgz:/tmp/openclaw-update-first-hop-negative.tgz:ro" \
   -v "$FIXTURE_ROOT/future.tgz:/tmp/openclaw-update-first-hop-future.tgz:ro" \
   "$IMAGE_NAME" \

--- a/test/scripts/update-first-hop-package-fixtures.test.ts
+++ b/test/scripts/update-first-hop-package-fixtures.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -18,7 +19,11 @@ function writeJson(filePath: string, value: unknown) {
 
 function makePackageFixture() {
   const root = tempDirs.make("openclaw-first-hop-package-");
-  writeJson(path.join(root, "package.json"), { name: "openclaw", version: "2026.8.1" });
+  writeJson(path.join(root, "package.json"), {
+    name: "openclaw",
+    version: "2026.8.1",
+    dependencies: { "@openclaw/ai": "2026.8.1" },
+  });
   writeJson(path.join(root, "dist", "build-info.json"), {
     version: "2026.8.1",
     commit: "a".repeat(40),
@@ -62,6 +67,7 @@ describe("first-hop package fixtures", () => {
       fs.readFileSync(path.join(root, "dist", "build-info.json"), "utf8"),
     );
     expect(packageJson.version).toBe(FUTURE_FIXTURE_VERSION);
+    expect(packageJson.dependencies).toEqual({ "@openclaw/ai": "2026.8.1" });
     expect(buildInfo.version).toBe(FUTURE_FIXTURE_VERSION);
     expect(buildInfo.buildId).toContain("future-fixture");
     const inventory = JSON.parse(
@@ -72,4 +78,59 @@ describe("first-hop package fixtures", () => {
       expect(fs.existsSync(path.join(root, "dist", name))).toBe(false);
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "carries the candidate registry into the first-hop Docker lane",
+    () => {
+      const root = fs.realpathSync(tempDirs.make("openclaw-first-hop-docker-"));
+      const bin = path.join(root, "bin");
+      const registry = path.join(root, "registry");
+      const dockerArgs = path.join(root, "docker-args.json");
+      const tarball = path.join(root, "candidate.tgz");
+      fs.mkdirSync(bin);
+      fs.cpSync(makePackageFixture(), path.join(root, "package"), { recursive: true });
+      execFileSync("tar", ["-czf", tarball, "-C", root, "package"]);
+      writeJson(path.join(registry, "prepublish-plugin-registry.json"), {
+        candidateVersion: "2026.8.1",
+        sourceSha: "a".repeat(40),
+        packages: [],
+      });
+      fs.writeFileSync(
+        path.join(bin, "docker"),
+        `#!${process.execPath}
+import fs from "node:fs";
+if (process.argv[2] === "run") fs.writeFileSync(process.env.DOCKER_ARGS_FILE, JSON.stringify(process.argv.slice(3)));
+`,
+        { mode: 0o755 },
+      );
+      const result = spawnSync("bash", ["scripts/e2e/update-first-hop-compat-docker.sh"], {
+        encoding: "utf8",
+        timeout: 30_000,
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          DOCKER_ARGS_FILE: dockerArgs,
+          OPENCLAW_QA_ALLOW_UPDATE_FIRST_HOP: "1",
+          OPENCLAW_UPDATE_FIRST_HOP_E2E_SKIP_BUILD: "1",
+          OPENCLAW_UPDATE_FIRST_HOP_SOURCE_PACKAGE_TGZ: tarball,
+          OPENCLAW_UPDATE_FIRST_HOP_CANDIDATE_PACKAGE_TGZ: tarball,
+          OPENCLAW_UPDATE_FIRST_HOP_ARTIFACT_DIR: path.join(root, "artifacts"),
+          OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: registry,
+          OPENCLAW_DOCKER_E2E_SELECTED_SHA: "a".repeat(40),
+          OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION: "2026.8.1",
+          OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256: "",
+        },
+      });
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+      const args: string[] = JSON.parse(fs.readFileSync(dockerArgs, "utf8"));
+      expect(args[args.indexOf("--entrypoint") + 1]).toBe(
+        "/opt/openclaw-e2e/scripts/e2e/lib/prepublish-plugin-registry.sh",
+      );
+      expect(args).toContain(`${registry}:/tmp/openclaw-prepublish-plugin-registry:ro`);
+      expect(args).toContain(`${tarball}:/tmp/openclaw-update-first-hop-candidate.tgz:ro`);
+      expect(args).toContain("OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION=2026.8.1");
+      expect(args).toContain("bash");
+      expect(args).toContain("scripts/e2e/lib/upgrade-survivor/update-first-hop-compat.sh");
+    },
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where stable release validation stops before exercising the packaged updater's first hop when the candidate's companion packages are not yet published. In [Full Release Validation 33728228813](https://github.com/openclaw/openclaw/actions/runs/33728228813), the negative fixture install failed with npm `ETARGET` for `@openclaw/ai@2026.9.1`, leaving the published `openclaw@2026.8.2` installed. The lane printed only the subsequent build-info mismatch.

Related: #136395 (the packaged updater bridge and first-hop compatibility lane).

## Why This Change Was Made

The first-hop Docker wrapper bypassed the shared package-mount owner, so it never received the verified candidate registry entrypoint. It now uses `docker_e2e_package_mount_args`, keeping the existing registry alive across the negative, repaired, and fake-future fixture updates. Root packages still come from their explicit fixture tarballs; all three resolve companion versions through the candidate registry, including the future fixture's unchanged dependency versions.

The lane uses one update runner to preserve command/exit artifacts and print captured stdout/stderr on nonzero exit, including the expected negative control. Baseline npm install failures also print their log. No product code, candidate bytes, or configuration/environment surface changes. The two shell files are net-neutral: 24 lines added, 24 removed; tests add 61 net lines.

## User Impact

Release maintainers can validate unpublished stable candidates through all three first-hop stages and see npm/update diagnostics directly in a failing lane log. Installed-user update behavior is unchanged.

## Evidence

Frozen candidate: `caa2719de7f4c6229249bee632de32fafa58a429` (`2026.9.1`, including the bridge chunks). Built in a second detached worktree with `pnpm install && pnpm build && OPENCLAW_PREPACK_PREPARED=1 pnpm pack`. Used the existing `prepareNpmPackageBundle()` producer to pack the core packages and the registry artifact creator's `preparedBundleDir` input; the root tarball was reused byte-for-byte. Local execution used OrbStack Linux/arm64 and the repository's `bare` Docker E2E image.

- Before: the unchanged lane exited 1 in the negative stage, retained `2026.8.2`, and captured `ETARGET: No matching version found for @openclaw/ai@2026.9.1` only in its update artifact.
- After: the lane exited 0. The negative fixture installed `2026.9.1` and exited 1 for the expected missing `shared-Y6bNiw2w.js`; the repaired hop exited 0 at `2026.9.1`, and the second hop exited 0 at `2026.9.99-first-hop.0`. Both positive hops replaced the managed-service process and recorded active service state; all three stages left zero transaction residue. All installed build records retained the frozen commit SHA.
- Diagnostic fault injection: removed the registry input from the fixed lane. It exited 1 and printed the actual npm `ETARGET` message in the main lane log before the build-info diff.
- Regression: the new executable Docker-boundary test failed before the mount fix and passed after it. The future-fixture test also checks that companion dependency versions remain unchanged.
- `pnpm test test/scripts/update-first-hop-package-fixtures.test.ts test/scripts/docker-e2e-plan.test.ts test/scripts/package-acceptance-workflow.test.ts test/scripts/prepublish-plugin-registry-shell.test.ts` — 461 tests passed across 4 files. The registry helper suite includes real npm installs and registry cleanup.
- `pnpm check:changed` — passed.
- `shellcheck -x -e SC2016 scripts/e2e/update-first-hop-compat-docker.sh scripts/e2e/lib/upgrade-survivor/update-first-hop-compat.sh` — passed; SC2016 is the existing embedded-JavaScript literal warning.
- `git diff --check` — passed.
- Autoreview through P2: local review clean; `--mode branch --base origin/main --max-priority P2` clean.

Lane command, with `FROZEN_WORKTREE` pointing to the detached candidate checkout and `REGISTRY_DIR` to its verified registry artifact:

```bash
OPENCLAW_QA_ALLOW_UPDATE_FIRST_HOP=1 \
OPENCLAW_UPDATE_FIRST_HOP_CANDIDATE_PACKAGE_TGZ="$FROZEN_WORKTREE/openclaw-2026.9.1.tgz" \
OPENCLAW_RELEASE_CHECK_LOCAL_PACKAGE_TARBALL_DIR="$CORE_TARBALL_DIR" \
OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR="$REGISTRY_DIR" \
OPENCLAW_DOCKER_E2E_SELECTED_SHA=caa2719de7f4c6229249bee632de32fafa58a429 \
OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION=2026.9.1 \
bash scripts/e2e/update-first-hop-compat-docker.sh
```

This is local lane proof. The hosted Full Release Validation jobs have not been rerun, and this PR does not publish or modify the frozen release candidate.
