### PR TITLE
fix(dashboard): create first widget on empty tabs

### DIFF
--- a/src/agents/tools/dashboard-tool.test.ts
+++ b/src/agents/tools/dashboard-tool.test.ts
@@ -1,6 +1,7 @@
 import { Value } from "typebox/value";
 import { describe, expect, it, vi } from "vitest";
 import type { BoardCommand, BoardSnapshot } from "../../../packages/gateway-protocol/src/index.js";
+import { createTestBoardStore } from "../../boards/board-store.test-support.js";
 import {
   createGatewayMethodDescriptorsFromHandlers,
   createGatewayMethodRegistry,
@@ -41,6 +42,23 @@ function recorder(boardSnapshot: BoardSnapshot = snapshot) {
       return 2;
     },
   };
+}
+
+function createBoardBackedCaller() {
+  const store = createTestBoardStore();
+  const callGateway: InProcessGatewayCaller = async <T>(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<T> => {
+    if (method === "board.widget.put") {
+      return store.putWidget(params as never) as T;
+    }
+    if (method === "board.get") {
+      return store.getSnapshot(params as never) as T;
+    }
+    throw new Error(`unexpected board method: ${method}`);
+  };
+  return { callGateway, store };
 }
 
 function createGatewayAffinityHarness(revision: number) {
@@ -113,6 +131,50 @@ describe("dashboard tool", () => {
       }),
     ).toBe(true);
     expect(Value.Check(tool.parameters, { action: "unknown" })).toBe(false);
+  });
+
+  it("creates the first plugin widget without an anchor", async () => {
+    const sessionKey = "agent:main:first-widget";
+    const { callGateway, store } = createBoardBackedCaller();
+    store.applyOps({ sessionKey }, [{ kind: "tab_create", tabId: "plugin", title: "Plugin" }]);
+    const dashboard = createDashboardTool({ agentSessionKey: sessionKey, callGateway });
+    const args = {
+      action: "widget_put",
+      name: "first-plugin",
+      pluginKind: "workboard:card",
+      tabId: "plugin",
+      after: null,
+    };
+
+    expect(Value.Check(dashboard.parameters, args)).toBe(true);
+    expect(Value.Check(dashboard.parameters, { ...args, after: "" })).toBe(false);
+    const preparedArgs = dashboard.prepareArguments?.(args) ?? args;
+    expect(preparedArgs).not.toHaveProperty("after");
+
+    await dashboard.execute("first-plugin", preparedArgs);
+    const read = await dashboard.execute("read-first-widget", { action: "read" });
+
+    expect((read.details as BoardSnapshot).widgets).toEqual([
+      expect.objectContaining({ name: "first-plugin", tabId: "plugin", position: 0 }),
+    ]);
+  });
+
+  it("keeps position and after mutually exclusive for widget moves", async () => {
+    const harness = recorder();
+    const tool = createDashboardTool({
+      agentSessionKey: "agent:main:main",
+      callGateway: harness.callGateway,
+    });
+
+    await expect(
+      tool.execute("move", {
+        action: "widget_move",
+        name: "status",
+        position: 0,
+        after: "clock",
+      }),
+    ).rejects.toThrow("either position or after, not both");
+    expect(harness.calls).toEqual([]);
   });
 
   it("reads a compact text plus JSON snapshot", async () => {

--- a/src/agents/tools/dashboard-tool.ts
+++ b/src/agents/tools/dashboard-tool.ts
@@ -5,6 +5,11 @@ import type {
   BoardOp,
   BoardSnapshot,
 } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  BOARD_WIDGET_NAME_PATTERN,
+  omitNullBoardWidgetAnchor,
+  optionalBoardWidgetAnchorSchema,
+} from "../../boards/board-tool-args.js";
 import type { GatewayContextResolver } from "../../gateway/server-methods/types.js";
 import type { AnyAgentTool } from "./common.js";
 import {
@@ -36,7 +41,6 @@ const DASHBOARD_ACTIONS = [
 ] as const;
 const BOARD_TAB_ID_PATTERN = "^[a-z0-9-]{1,40}$";
 const BOARD_TAB_ID_REGEX = /^[a-z0-9-]{1,40}$/;
-const BOARD_WIDGET_NAME_PATTERN = "^[a-z0-9][a-z0-9._-]{0,63}$";
 const BOARD_PLUGIN_KIND_PATTERN = "^[a-z0-9][a-z0-9-]{0,63}:[a-z0-9][a-z0-9._-]{0,63}$";
 const BOARD_PLUGIN_KIND_REGEX = /^[a-z0-9][a-z0-9-]{0,63}:[a-z0-9][a-z0-9._-]{0,63}$/;
 
@@ -65,12 +69,7 @@ const DashboardToolSchema = Type.Object(
     name: Type.Optional(
       Type.String({ pattern: BOARD_WIDGET_NAME_PATTERN, description: "Stable widget name" }),
     ),
-    after: Type.Optional(
-      Type.String({
-        pattern: BOARD_WIDGET_NAME_PATTERN,
-        description: "Place after stable widget name",
-      }),
-    ),
+    after: optionalBoardWidgetAnchorSchema("Place after stable widget name; null or omit appends"),
     sizeW: Type.Optional(Type.Integer({ minimum: 1, maximum: 12 })),
     sizeH: Type.Optional(Type.Integer({ minimum: 1, maximum: 20 })),
     size: Type.Optional(Type.String({ enum: ["sm", "md", "lg", "xl", "full"] })),
@@ -301,6 +300,7 @@ export function createDashboardTool(opts: DashboardToolOptions = {}): AnyAgentTo
     description:
       "Keep one ad hoc visualization inline; use only for an explicit dashboard request or multiple non-code visualizations. Read layout; widget_put updates plugin widgets only. Read and arrange this session dashboard: read snapshot; tab_create/tab_update/tab_delete/tabs_reorder; widget_put/widget_move/widget_resize/widget_remove; focus_tab; set_chat_dock moves or hides the chat dock (left/right/bottom/hidden). focus_tab and set_chat_dock require a connected Control UI. Widgets use stable names. widget_put creates or updates trusted plugin widgets only; update other content through its owning authoring capability discovered in the tool catalog. Plugin examples: session:progress props {sessionKey?} renders the session's live progress card (omit sessionKey for the current session), workboard:card props {cardId}, workboard:mini props {boardId, limit}, workboard:board props {boardId}. Sizes: sm=3x3, md=6x4, lg=8x6, xl=12x8, full=12x8 single-widget emphasis.",
     parameters: DashboardToolSchema,
+    prepareArguments: omitNullBoardWidgetAnchor,
     execute: async (_toolCallId, rawArgs) => {
       const params = rawArgs as Record<string, unknown>;
       const action = readToolStringParam(params, "action", { required: true });

--- a/src/boards/board-tool-args.ts
+++ b/src/boards/board-tool-args.ts
@@ -1,0 +1,20 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { Type } from "typebox";
+
+export const BOARD_WIDGET_NAME_PATTERN = "^[a-z0-9][a-z0-9._-]{0,63}$";
+
+/** Keeps an optional placement anchor representable when a model materializes every tool field. */
+export function optionalBoardWidgetAnchorSchema(description: string) {
+  return Type.Optional(
+    Type.Union([Type.String({ pattern: BOARD_WIDGET_NAME_PATTERN }), Type.Null()], { description }),
+  );
+}
+
+/** Converts the model-facing null sentinel back to the board contract's omitted anchor. */
+export function omitNullBoardWidgetAnchor(args: unknown): unknown {
+  if (!isRecord(args) || args.after !== null) {
+    return args;
+  }
+  const { after: _after, ...rest } = args;
+  return rest;
+}

--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -2,6 +2,7 @@
 import { access, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { InProcessGatewayCaller } from "../agents/tools/in-process-gateway.js";
 import { createTestBoardStore } from "../boards/board-store.test-support.js";
@@ -148,6 +149,43 @@ async function executeWidget(params: {
 }
 
 describe("show_widget", () => {
+  it("pins the first HTML widget without an anchor", async () => {
+    const sessionKey = "agent:main:first-widget";
+    const store = createTestBoardStore();
+    store.applyOps({ sessionKey }, [{ kind: "tab_create", tabId: "html", title: "HTML" }]);
+    const callGateway: InProcessGatewayCaller = async <T>(
+      method: string,
+      params: Record<string, unknown>,
+    ): Promise<T> => {
+      expect(method).toBe("board.widget.put");
+      return store.putWidget(params as never) as T;
+    };
+    const tool = createShowWidgetTool({
+      agentSessionKey: sessionKey,
+      inlineHostEnabled: false,
+      callGateway,
+    });
+    const args = {
+      title: "First HTML",
+      widget_code: "<p>first</p>",
+      pin: true,
+      name: "first-html",
+      tab: "html",
+      after: null,
+    };
+
+    expect(Value.Check(tool.parameters, args)).toBe(true);
+    expect(Value.Check(tool.parameters, { ...args, after: "" })).toBe(false);
+    const preparedArgs = tool.prepareArguments?.(args) ?? args;
+    expect(preparedArgs).not.toHaveProperty("after");
+
+    await tool.execute("first-html", preparedArgs);
+
+    expect(store.getSnapshot({ sessionKey }).widgets).toEqual([
+      expect.objectContaining({ name: "first-html", tabId: "html", position: 0 }),
+    ]);
+  });
+
   it("builds a sorted kind enum and routes registered source through board put", async () => {
     registerDiagramContentKind();
     const stateDir = await createStateDir();

--- a/src/canvas/widget-tool.ts
+++ b/src/canvas/widget-tool.ts
@@ -10,6 +10,11 @@ import {
   type InProcessGatewayCaller,
 } from "../agents/tools/in-process-gateway.js";
 import { normalizeBoardWidgetDeclared } from "../boards/board-capabilities.js";
+import {
+  BOARD_WIDGET_NAME_PATTERN,
+  omitNullBoardWidgetAnchor,
+  optionalBoardWidgetAnchorSchema,
+} from "../boards/board-tool-args.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { assertWidgetHtmlSize, WidgetHtmlInputError } from "../plugin-sdk/widget-html.js";
 import {
@@ -65,7 +70,7 @@ function createShowWidgetToolSchema(
     }),
     name: Type.Optional(
       Type.String({
-        pattern: "^[a-z0-9][a-z0-9._-]{0,63}$",
+        pattern: BOARD_WIDGET_NAME_PATTERN,
         description:
           "Stable dashboard widget name; reuse the same name with pin=true and new widget_code to update",
       }),
@@ -95,11 +100,8 @@ function createShowWidgetToolSchema(
         }),
       }),
     ),
-    after: Type.Optional(
-      Type.String({
-        pattern: "^[a-z0-9][a-z0-9._-]{0,63}$",
-        description: "Place after this dashboard widget name",
-      }),
+    after: optionalBoardWidgetAnchorSchema(
+      "Place after this dashboard widget name; null or omit appends",
     ),
     capabilities: Type.Optional(
       Type.Object({
@@ -284,6 +286,7 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
       explicitPresenters,
       describeDashboardCapabilities(currentPluginRegistry()),
     ),
+    prepareArguments: omitNullBoardWidgetAnchor,
     ...(currentChannelPresenter ? {} : { requiredClientCaps: SHOW_WIDGET_REQUIRED_CLIENT_CAPS }),
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents creating the first dashboard widget on an empty tab could be forced to invent an `after` anchor, causing both `dashboard` `widget_put` and pinned `show_widget` calls to fail with `board widget anchor not found`.

## Why This Change Was Made

The board already appends when `after` is omitted. This change makes the model-facing optional anchor nullable and adds one shared argument adapter that removes only `after: null` before execution, restoring the board's true omission contract without weakening widget-name validation or accepting blank anchor names.

Real string anchors remain unchanged. The existing `position`/`after` mutual exclusion remains enforced for widget moves.

## User Impact

Agents can create the first plugin or HTML widget on an empty dashboard tab without fabricating an anchor. Explicit anchored placement and widget move validation continue to work as before.

## Evidence

- Pre-fix regression: `pnpm test src/agents/tools/dashboard-tool.test.ts` fails because the existing schema rejects the model-safe omitted-anchor sentinel (`expected false to be true`).
- Post-fix focused tests: `pnpm test src/agents/tools/dashboard-tool.test.ts src/canvas/widget-tool.test.ts src/boards/board-layout.test.ts` — 51/51 passed across the unit and agent-tools shards.
- `node scripts/check-changed.mjs -- src/agents/tools/dashboard-tool.ts src/agents/tools/dashboard-tool.test.ts src/boards/board-tool-args.ts src/canvas/widget-tool.ts src/canvas/widget-tool.test.ts` — relevant format, boundary, core typecheck, and core-test typecheck lanes passed. After materializing the full sparse checkout, `pnpm deadcode:exports` also passed with zero findings.
- Fresh autoreview (`--mode local --max-priority P1`) returned `scoped-clean` with no actionable P0/P1 findings.
- The Codex dynamic/MCP tool contract was inspected directly in `codex-rs/tools/src/responses_api.rs` and `codex-rs/tools/src/dynamic_tool.rs`: those tools are emitted `strict: false`, so the OpenClaw adapter restores omission locally instead of changing board behavior.
- No installed OpenClaw package, Gateway configuration, or live dashboard was modified.

Production delta: +36/-13 (net +23) for one shared board-placement schema/adapter used by both tool owners. Tests: +100/-0.
