### PR TITLE
refactor(outbound): reuse send normalization helper

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -26,7 +26,6 @@ import { validateExplicitMessageAccountSelection } from "./message-account-selec
 import {
   resolveMessageSendOutcome,
   type MessageActionInput,
-  type MessageActionNormalization,
   type MessageActionResult,
   type ResolvedActionContext,
 } from "./message-action-contracts.js";
@@ -42,6 +41,7 @@ import {
   resolveExtraActionMediaSourceParamKeys,
 } from "./message-action-params.js";
 import { prepareMessageRoute, resolveMessageTarget } from "./message-action-routing.js";
+import { withSendNormalization } from "./message-action-send-payload.js";
 import { buildMessagePayload, executeMessageSend } from "./message-action-send.js";
 import type { MessageSendResult } from "./message.js";
 import {
@@ -56,13 +56,6 @@ const loadInternalSourceReplyPersistence = createLazyRuntimeModule(
 
 export function getToolResult(result: MessageActionResult): AgentToolResult<unknown> | undefined {
   return "toolResult" in result ? result.toolResult : undefined;
-}
-
-function withSendNormalization(
-  result: MessageActionResult,
-  normalization?: MessageActionNormalization,
-): MessageActionResult {
-  return normalization && result.kind === "send" ? { ...result, normalization } : result;
 }
 
 async function handleBroadcastAction(


### PR DESCRIPTION
## What Problem This Solves

Removes a duplicate outbound send-normalization implementation that could drift from the canonical payload helper used by sibling send paths.

## Why This Change Was Made

The outbound action runner now reuses `withSendNormalization` from the send-payload owner. The invariant remains exact: only a `send` result with present normalization is cloned with the normalization field; non-send results and sends without normalization retain their original object identity and shape.

## User Impact

No user-visible behavior changes. Outbound normalization now has one internal owner across the runner and sibling send paths.

## Evidence

- Production LOC: `+1/-8`, net `-7`; test LOC: `0`.
- Focused outbound suites: 47/47 passed.
- Import-cycle checks: 0 runtime value cycles and 0 Madge cycles.
- Full build phases passed. The initial sparse checkout omitted tracked Control UI config modules; after adding that checkout path, the exact failed `ui:build` phase passed.
- `check:changed` gates passed across formatting, lint, core and test typechecks, dead exports, dependency/plugin boundaries, native-state schema, database-first, media, runtime-sidecar, webhook, and auth guards.
- Exact P1 autoreview: scoped clean, correctness 0.97.
- Adjacent PRs #79200, #108979, #121484, and #131804 do not touch this helper or call site.
- No channel, protocol, Plugin SDK, config, persistence, authorization, or authority behavior changes.
