### PR TITLE
perf(workers): defer Browser initialization until requested

### DIFF
--- a/scripts/lib/worker-deploy-build-plugin.mts
+++ b/scripts/lib/worker-deploy-build-plugin.mts
@@ -9,8 +9,13 @@ const PLAYWRIGHT_PACKAGE_INIT = `    packageRoot = import_path9.default.join(__d
     binPath = import_path9.default.join(packageRoot, "bin");`;
 const PLAYWRIGHT_BROWSER_REGISTRY_INIT =
   '    registry = new Registry(require(import_path20.default.join(packageRoot, "browsers.json")));';
-const WORKER_BROWSER_RUNTIME_COMPOSITION = `import { createAttachedBrowserToolRuntime } from "../../extensions/browser/runtime-api.js";
-export default { createAttachedBrowserToolRuntime };`;
+// Keep Browser and Playwright initialization behind the admitted Browser factory.
+const WORKER_BROWSER_RUNTIME_COMPOSITION = `export default {
+  async createAttachedBrowserToolRuntime(params) {
+    const { createAttachedBrowserToolRuntime } = await import("../../extensions/browser/runtime-api.js");
+    return createAttachedBrowserToolRuntime(params);
+  }
+};`;
 const WORKER_PLAYWRIGHT_RUNTIME = `import * as playwrightCore from "playwright-core";
 import { getUserAgent } from "playwright-core/lib/coreBundle";
 export function getPlaywrightCore() { return playwrightCore; }

--- a/test/scripts/worker-deploy-build-plugin.test.ts
+++ b/test/scripts/worker-deploy-build-plugin.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   createWorkerDeployBuildPlugin,
@@ -21,18 +22,55 @@ describe("worker deploy build plugin", () => {
     );
   });
 
-  it("composes the bundled Browser runtime only in the deploy build", () => {
+  it("initializes the composed Browser runtime only when its factory is called", async () => {
     const bridgePath = path.resolve("src/worker/worker-deploy-browser-runtime.ts");
     const source = fs.readFileSync(bridgePath, "utf8");
     const plugin = createWorkerDeployBuildPlugin();
 
     const transformed = plugin.transform.call({ error: fail }, source, bridgePath);
 
-    expect(transformed).toContain(
-      'import { createAttachedBrowserToolRuntime } from "../../extensions/browser/runtime-api.js";',
+    const root = tempDirs.make("openclaw-worker-browser-composition-");
+    const outputPath = path.join(root, "src/worker/browser.mjs");
+    const runtimePath = path.join(root, "extensions/browser/runtime-api.js");
+    const eventsPath = path.join(root, "events.txt");
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.mkdirSync(path.dirname(runtimePath), { recursive: true });
+    fs.writeFileSync(path.join(root, "package.json"), '{"type":"module"}');
+    fs.writeFileSync(outputPath, transformed!);
+    fs.writeFileSync(
+      runtimePath,
+      `import { appendFileSync } from "node:fs";
+const record = event => appendFileSync(${JSON.stringify(eventsPath)}, event + "\\n");
+record("initialized");
+export async function createAttachedBrowserToolRuntime(params) {
+  await params.ensureAttachTarget();
+  return { tool: params, dispose: async () => record("disposed") };
+}`,
     );
-    expect(transformed).toContain("export default { createAttachedBrowserToolRuntime };");
-    expect(transformed).not.toContain("was not composed by the build");
+
+    const { default: browser } = await import(pathToFileURL(outputPath).href);
+    expect(fs.existsSync(eventsPath)).toBe(false);
+    let attached = 0;
+    const params = {
+      cdpUrl: "http://127.0.0.1:9222",
+      ensureAttachTarget: async () => {
+        attached += 1;
+      },
+      agentSessionKey: "worker:session-1",
+      agentDir: path.join(root, "agent"),
+      workspaceDir: path.join(root, "workspace"),
+    };
+    const [first, second] = await Promise.all([
+      browser.createAttachedBrowserToolRuntime(params),
+      browser.createAttachedBrowserToolRuntime(params),
+    ]);
+    expect(attached).toBe(2);
+    expect(first.tool).toBe(params);
+    expect(second.tool).toBe(params);
+    expect(fs.readFileSync(eventsPath, "utf8")).toBe("initialized\n");
+    await first.dispose();
+    await second.dispose();
+    expect(fs.readFileSync(eventsPath, "utf8")).toBe("initialized\ndisposed\ndisposed\n");
   });
 
   it("binds the lazy Playwright accessor to bundled modules", () => {


### PR DESCRIPTION
Related: #134931. This optimization is independent of the prepared-snapshot work and does not change its schema or lifecycle.

## What Problem This Solves

Workers initialize the bundled Browser and Playwright runtime even when a turn has no Browser assignment. That unnecessary work also runs during worker prewarming.

## Why This Change Was Made

Keep the existing sealed dependency bundle, but load the public Browser runtime through its existing asynchronous factory only when Browser is requested. The factory forwards the same arguments and returns the same tool and disposer. Browser admission, capability checks, and caller-owned Chromium cleanup remain unchanged; no configuration, schema, protocol, or dependency changes are needed.

The regression test now executes the generated composition instead of checking source strings. It verifies deferred initialization, one module initialization across concurrent factory calls, parameter identity, and both disposers. The newer fs-safe resolution test from main is preserved.

## User Impact

Worker turns without Browser avoid initializing the Browser dependency graph. Browser-enabled turns retain the existing behavior and cleanup ownership. This change does not claim a measured native-cloud or end-to-end session speedup.

## Evidence

Validated against main `88be1b80f58df698fe730b4f3f34934ecae92e21`:

- The test-only regression fails before the fix because the runtime initializes before the factory is called. After the fix, all **50 tests** pass across build composition, worker command handling, the core Browser adapter, and the attached Browser runtime.
- Canonical changed-scope formatting, type, lint, and ownership checks pass. A frozen pnpm install leaves dependency inputs unchanged.
- The canonical worker-only build passes. Its single sealed artifact contains the deferred Browser initializer inside the factory, with no ineffective dynamic import or unresolved import warning. The inherited dependency direct-eval warning remains.
- A real Chromium check passes against that exact, unchanged artifact: a selector-scoped Playwright snapshot returns the synthetic page nonce; the worker completes with empty stderr; Chromium remains responsive after worker disposal. The fixture then closes Chromium, and an independent read confirms all eight recorded process/group selectors are absent. This is local sealed Browser-engine proof, not production Gateway admission or cloud provisioning proof.
- Independent Codex review is clean through P2. Production/tooling changes are **+7/-2 (net +5)**; tests are **+43/-5 (net +38)**.

The built worker SHA-256 is `67a2c1243316d2b411b7143877e6650c3be93e416a8d4974fd03c62e006aa7b6`. Full package and hosted CI results are separate from the focused local build and proof above.

[Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33753050848) passes on `0cf8098dc099b1fefe15e1f5969456c1e48a01cf`: 88 selected jobs passed and 17 were skipped by normal scope selection. The first attempt timed out while the unrelated session-accessor concurrency fixture waited for its child process to start, before its six scenarios ran. The fixture and accessor match the CI base; all six cases passed unchanged locally, and the single failed shard plus dependent aggregate passed on one targeted retry. No code, timeout, or assertions were changed for that retry. The initial timeout remains recorded; its precise scheduling cause was not established.
