### PR TITLE
refactor(delivery): share state-dir argument helper

### DIFF
--- a/src/gateway/server-restart-sentinel-agent-delivery.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.ts
@@ -29,6 +29,7 @@ import {
   SessionDeliveryDeferredError,
   SessionDeliveryRetryChargedError,
   SessionDeliverySafeRetryError,
+  sessionDeliveryStateDirArgs,
   type QueuedSessionDelivery,
   type SessionDeliveryRoute,
 } from "../infra/session-delivery-queue-storage.js";
@@ -48,10 +49,6 @@ const log = createSubsystemLogger("gateway/restart-sentinel");
 const AGENT_DELIVERY_OWNERSHIP_RETRY_MS = 1_000;
 
 type QueuedAgentTurnSessionDelivery = Extract<QueuedSessionDelivery, { kind: "agentTurn" }>;
-
-function sessionDeliveryStateDirArgs(stateDir?: string): [] | [string] {
-  return stateDir === undefined ? [] : [stateDir];
-}
 
 async function deadLetterSessionDelivery(
   entry: QueuedAgentTurnSessionDelivery,

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -34,6 +34,7 @@ import {
   enqueueSessionDelivery,
   markSessionDeliveryAttemptStarted,
   markSessionDeliverySettlement,
+  sessionDeliveryStateDirArgs,
   SessionDeliveryDeadLetteredError,
   SessionDeliverySafeRetryError,
   type QueuedSessionDelivery,
@@ -85,10 +86,6 @@ export const settleQueuedSessionDelivery: SettleSessionDeliveryFn = async (entry
 };
 
 type QueuedAgentTurnSessionDelivery = Extract<QueuedSessionDelivery, { kind: "agentTurn" }>;
-
-function sessionDeliveryStateDirArgs(stateDir?: string): [] | [string] {
-  return stateDir === undefined ? [] : [stateDir];
-}
 
 function cloneRestartSentinelPayload(
   payload: RestartSentinelPayload | null,

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -21,6 +21,10 @@ import { generateSecureUuid } from "./secure-random.js";
 // delivery acknowledges them or recovery exhausts retry policy.
 export const SESSION_DELIVERY_QUEUE_NAME = "session";
 
+export function sessionDeliveryStateDirArgs(stateDir?: string): [] | [string] {
+  return stateDir === undefined ? [] : [stateDir];
+}
+
 type SessionDeliveryOwnerReference = {
   kind: "subagent_completion";
   runId: string;


### PR DESCRIPTION
## What Problem This Solves

Removes duplicate state-directory argument normalization from the restart recovery paths so the queue storage owner defines the contract once.

## Why This Change Was Made

Both Gateway callers used the same tuple helper to preserve omitted optional argument arity. This moves the byte-identical helper into session delivery queue storage and keeps every spread call unchanged.

No public barrel, Plugin SDK, config, protocol, schema, migration, persistence behavior, test, docs, or changelog surface changes.

## User Impact

No user-visible behavior change. Restart recovery keeps the same default and explicit state-directory routing.

## Evidence

- Session delivery storage and recovery: 35/35 passed.
- Gateway runtime services: 37/37 passed.
- Import cycle checks: 0 runtime value cycles; 0 Madge cycles.
- Direct format and lint checks passed for all three changed files.
- Changed-file gates passed through core typecheck; typecheck was blocked only by missing shared Markdown and phone dependencies.
- The restart sentinel suite was blocked at import time by the same missing shared Markdown dependency.
- Full build was blocked by missing shared `@pierre/diffs` and Shiki language packages.
- Exact autoreview: scoped-clean, correctness 0.99.
