### PR TITLE
refactor(scripts): share non-negative integer parsing

### DIFF
--- a/scripts/lib/arg-utils.mts
+++ b/scripts/lib/arg-utils.mts
@@ -1,1 +1,11 @@
+import { classifyBoundedUnsignedDecimal } from "./arg-utils.runtime.mjs";
+
 export * from "./arg-utils.runtime.mjs";
+
+export function parseNonNegativeIntegerArg(raw: string | undefined, optionName: string): number {
+  const result = classifyBoundedUnsignedDecimal(raw, 0, Number.MAX_SAFE_INTEGER);
+  if (result.kind === "value") {
+    return result.value;
+  }
+  throw new Error(`${optionName} expects a non-negative integer`);
+}

--- a/scripts/test-env-mutation-report.ts
+++ b/scripts/test-env-mutation-report.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { isCodeFile, isTestRelatedFile, listRepoFilesSync } from "./check-file-utils.js";
+import { parseNonNegativeIntegerArg } from "./lib/arg-utils.mts";
 
 type EnvMutationOperation = "assign" | "delete" | "replace" | "stubEnv";
 
@@ -349,7 +350,7 @@ function parseArgs(argv: string[]): {
       continue;
     }
     if (arg === "--limit") {
-      limit = readNonNegativeIntArg(argv[index + 1]);
+      limit = parseNonNegativeIntegerArg(argv[index + 1], "--limit");
       index += 1;
       continue;
     }
@@ -366,17 +367,6 @@ function parseArgs(argv: string[]): {
   }
 
   return { help, includeAllowed, json, limit, repoRoot };
-}
-
-function readNonNegativeIntArg(raw: string | undefined): number {
-  if (!raw || raw.startsWith("--") || !/^\d+$/u.test(raw)) {
-    throw new Error("--limit expects a non-negative integer");
-  }
-  const value = Number(raw);
-  if (!Number.isSafeInteger(value)) {
-    throw new Error("--limit expects a non-negative integer");
-  }
-  return value;
 }
 
 function printHelp(): void {

--- a/scripts/test-skip-inventory.ts
+++ b/scripts/test-skip-inventory.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { isCodeFile, isTestRelatedFile, listRepoFilesSync } from "./check-file-utils.js";
+import { parseNonNegativeIntegerArg } from "./lib/arg-utils.mts";
 
 type SkipInventoryKind = "alias" | "call";
 type SkipInventoryReason =
@@ -383,17 +384,6 @@ export function renderTestSkipInventoryReport(
   return `${lines.join("\n")}\n`;
 }
 
-function readNonNegativeIntArg(raw: string | undefined): number {
-  if (!raw || raw.startsWith("--") || !/^\d+$/u.test(raw)) {
-    throw new Error("--limit expects a non-negative integer");
-  }
-  const value = Number(raw);
-  if (!Number.isSafeInteger(value)) {
-    throw new Error("--limit expects a non-negative integer");
-  }
-  return value;
-}
-
 function parseArgs(argv: string[]): {
   help: boolean;
   json: boolean;
@@ -419,7 +409,7 @@ function parseArgs(argv: string[]): {
       continue;
     }
     if (arg === "--limit") {
-      limit = readNonNegativeIntArg(argv[index + 1]);
+      limit = parseNonNegativeIntegerArg(argv[index + 1], "--limit");
       index += 1;
       continue;
     }

--- a/test/scripts/arg-utils.test.ts
+++ b/test/scripts/arg-utils.test.ts
@@ -1,5 +1,6 @@
 // Arg Utils tests cover arg utils script behavior.
 import { describe, expect, it } from "vitest";
+import { parseNonNegativeIntegerArg } from "../../scripts/lib/arg-utils.mts";
 import {
   booleanFlag,
   classifyBoundedUnsignedDecimal,
@@ -73,6 +74,31 @@ describe("scripts/lib/arg-utils required option arguments", () => {
     expect(() => requireOptionArgument(argv, 0, "--output")).toThrow(
       new Error("--output requires a value"),
     );
+  });
+});
+
+describe("scripts/lib/arg-utils non-negative integer arguments", () => {
+  it.each([
+    { input: "0", expected: 0 },
+    { input: "001", expected: 1 },
+    { input: String(Number.MAX_SAFE_INTEGER), expected: Number.MAX_SAFE_INTEGER },
+    { input: "-1", error: true },
+    { input: "NaN", error: true },
+    { input: "1.5", error: true },
+    { input: "1e3", error: true },
+    { input: " 1", error: true },
+    { input: "1 ", error: true },
+    { input: undefined, error: true },
+    { input: "--next", error: true },
+    { input: String(Number.MAX_SAFE_INTEGER + 1), error: true },
+  ])("parses non-negative integer argument %#", ({ input, expected, error }) => {
+    if (error) {
+      expect(() => parseNonNegativeIntegerArg(input, "--limit")).toThrow(
+        "--limit expects a non-negative integer",
+      );
+      return;
+    }
+    expect(parseNonNegativeIntegerArg(input, "--limit")).toBe(expected);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Two repository reports maintained identical private parsers for `--limit`, making their accepted grammar and error behavior easy to drift apart.

## Why This Change Was Made

Moves the shared non-negative safe-integer contract into the existing TypeScript argument facade. Both report loops keep their existing option consumption and last-value-wins behavior; runtime declarations and broader numeric helpers are unchanged.

## User Impact

No user-visible behavior changes. Repository tooling now has one owner for this argument contract.

## Evidence

- Focused tests: 102 passed across `arg-utils`, env-mutation report, and skip-inventory suites.
- Contract table covers zero, leading zeros, missing and flag-shaped values, whitespace, negative, decimal, exponent, `NaN`, and safe-integer boundaries.
- Format and direct lint checks passed.
- Script erasability and both import-cycle checks passed with zero cycles.
- P1 autoreview: scoped-clean, correctness 0.99.
- Tooling LOC: +14/-24, net -10. Tests: +26/-0.
- `check:changed` passed through script erasability, then the scripts typecheck was blocked by missing shared checkout dependencies including Shiki, Discord/Slack, Markdown, phone, and Control UI modules. No changed-file diagnostic was reported.
