### PR TITLE
refactor(tooling): reuse benchmark integer parser

### DIFF
--- a/scripts/bench-agent-concurrency-worker.ts
+++ b/scripts/bench-agent-concurrency-worker.ts
@@ -11,7 +11,7 @@ import {
   type WorkerResult,
   type WorkerScenario,
 } from "./bench-agent-concurrency.js";
-import { classifyBoundedUnsignedDecimal } from "./lib/arg-utils.mts";
+import { parseBenchmarkInteger } from "./lib/benchmark-harness.mts";
 
 type WorkerOptions = {
   scenario: WorkerScenario;
@@ -33,17 +33,6 @@ const SCENARIOS = new Set<WorkerScenario>([
   "duplicateSuppression",
 ]);
 
-function parseInteger(raw: string | undefined, flag: string, min: number, max: number): number {
-  const result = classifyBoundedUnsignedDecimal(raw, min, max);
-  if (result.kind === "syntax") {
-    throw new Error(`${flag} must be an integer`);
-  }
-  if (result.kind !== "value") {
-    throw new Error(`${flag} must be between ${min} and ${max}`);
-  }
-  return result.value;
-}
-
 function parseOptions(argv: string[]): WorkerOptions {
   const values = new Map<string, string>();
   for (let index = 0; index < argv.length; index += 2) {
@@ -63,9 +52,9 @@ function parseOptions(argv: string[]): WorkerOptions {
   }
   return {
     scenario,
-    size: parseInteger(values.get("--size"), "--size", 1, 4096),
-    runs: parseInteger(values.get("--runs"), "--runs", 1, 100),
-    warmup: parseInteger(values.get("--warmup"), "--warmup", 0, 20),
+    size: parseBenchmarkInteger(values.get("--size"), "--size", 1, 4096, "combined"),
+    runs: parseBenchmarkInteger(values.get("--runs"), "--runs", 1, 100, "combined"),
+    warmup: parseBenchmarkInteger(values.get("--warmup"), "--warmup", 0, 20, "combined"),
   };
 }
 

--- a/scripts/bench-task-registry-sqlite-worker.ts
+++ b/scripts/bench-task-registry-sqlite-worker.ts
@@ -11,7 +11,7 @@ import {
   type RetainedMemoryMetrics,
   type WorkerResult,
 } from "./bench-task-registry-sqlite.js";
-import { classifyBoundedUnsignedDecimal } from "./lib/arg-utils.mts";
+import { parseBenchmarkInteger } from "./lib/benchmark-harness.mts";
 
 type WorkerOptions = {
   size: number;
@@ -44,17 +44,6 @@ type TaskRegistryQueryApi = Pick<
   "deleteTaskRecordById"
 >;
 
-function parseInteger(raw: string | undefined, flag: string, min: number, max: number): number {
-  const result = classifyBoundedUnsignedDecimal(raw, min, max);
-  if (result.kind === "syntax") {
-    throw new Error(`${flag} must be an integer`);
-  }
-  if (result.kind !== "value") {
-    throw new Error(`${flag} must be between ${min} and ${max}`);
-  }
-  return result.value;
-}
-
 function parseOptions(argv: string[]): WorkerOptions {
   const values = new Map<string, string>();
   for (let index = 0; index < argv.length; index += 2) {
@@ -73,9 +62,9 @@ function parseOptions(argv: string[]): WorkerOptions {
     throw new Error("--state-dir must be an absolute path");
   }
   return {
-    size: parseInteger(values.get("--size"), "--size", 1, 4096),
-    cycles: parseInteger(values.get("--cycles"), "--cycles", 1, 200),
-    warmup: parseInteger(values.get("--warmup"), "--warmup", 0, 20),
+    size: parseBenchmarkInteger(values.get("--size"), "--size", 1, 4096, "combined"),
+    cycles: parseBenchmarkInteger(values.get("--cycles"), "--cycles", 1, 200, "combined"),
+    warmup: parseBenchmarkInteger(values.get("--warmup"), "--warmup", 0, 20, "combined"),
     stateDir,
   };
 }

--- a/scripts/lib/benchmark-harness.mts
+++ b/scripts/lib/benchmark-harness.mts
@@ -38,10 +38,19 @@ export type BenchmarkWorkerSpawner = (
   },
 ) => BenchmarkWorkerProcessResult;
 
-export function parseBenchmarkInteger(raw: string, flag: string, min: number, max: number) {
+export function parseBenchmarkInteger(
+  raw: string | undefined,
+  flag: string,
+  min: number,
+  max: number,
+  rangeErrorStyle: "directional" | "combined" = "directional",
+) {
   const result = classifyBoundedUnsignedDecimal(raw, min, max);
   if (result.kind === "syntax") {
     throw new Error(`${flag} must be an integer`);
+  }
+  if (result.kind !== "value" && rangeErrorStyle === "combined") {
+    throw new Error(`${flag} must be between ${min} and ${max}`);
   }
   if (result.kind === "below") {
     throw new Error(`${flag} must be at least ${min}`);

--- a/test/scripts/bench-agent-concurrency.test.ts
+++ b/test/scripts/bench-agent-concurrency.test.ts
@@ -95,6 +95,7 @@ describe("agent concurrency benchmark", () => {
       json: true,
     });
     expect(() => testing.parseOptions(["--runs", "101"])).toThrow("--runs must be at most 100");
+    expect(() => testing.parseOptions(["--runs", "0"])).toThrow("--runs must be at least 1");
     expect(() => testing.parseOptions(["--fanout", "1,1"])).toThrow(
       "--fanout contains duplicate values",
     );
@@ -340,5 +341,28 @@ describe("agent concurrency benchmark", () => {
     expect(failure.stderr.trim().split("\n").at(-1)).toBe(
       "[bench-agent-concurrency] FAILED (exit 1)",
     );
+  });
+
+  it("preserves combined range errors at the worker boundary", () => {
+    const failure = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "scripts/bench-agent-concurrency-worker.ts",
+        "--scenario",
+        "admission",
+        "--size",
+        "0",
+        "--runs",
+        "1",
+        "--warmup",
+        "0",
+      ],
+      { cwd: process.cwd(), encoding: "utf8", env: { ...process.env, NODE_NO_WARNINGS: "1" } },
+    );
+
+    expect(failure.status).toBe(1);
+    expect(failure.stderr).toContain("--size must be between 1 and 4096");
   });
 });

--- a/test/scripts/bench-task-registry-sqlite.test.ts
+++ b/test/scripts/bench-task-registry-sqlite.test.ts
@@ -389,4 +389,27 @@ describe("durable task registry churn benchmark", () => {
       "[bench-task-registry-sqlite] FAILED (exit 1)",
     );
   });
+
+  it("preserves combined range errors at the worker boundary", () => {
+    const failure = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "scripts/bench-task-registry-sqlite-worker.ts",
+        "--size",
+        "4097",
+        "--cycles",
+        "1",
+        "--warmup",
+        "0",
+        "--state-dir",
+        process.cwd(),
+      ],
+      { cwd: process.cwd(), encoding: "utf8", env: { ...process.env, NODE_NO_WARNINGS: "1" } },
+    );
+
+    expect(failure.status).toBe(1);
+    expect(failure.stderr).toContain("--size must be between 1 and 4096");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

The two benchmark workers duplicated bounded integer parsing already owned by the shared benchmark harness. Keeping three implementations made worker and parent error behavior easy to drift during future benchmark maintenance.

## Why This Change Was Made

The shared parser now supports its existing directional range errors plus an explicit combined range-error style. Both workers reuse that owner with combined mode, preserving their exact CLI wording while deleting the duplicate implementations.

## User Impact

No user-visible behavior changes. Benchmark maintainers get one bounded integer parser while existing parent and worker CLI errors remain stable.

## Evidence

- 11 former-worker equivalence cases and 3 default-mode checks passed.
- 34 focused parser and worker-boundary assertions passed after formatting.
- Both import-cycle checks report zero cycles.
- Targeted script/test lint, formatting, and diff checks passed.
- P1 autoreview: scoped-clean, correctness 0.98.
- `check:changed` passed all pre-typecheck gates, then stopped on missing shared Shiki, Markdown, Discord, and Slack dependencies.
- `pnpm build` stopped in the unchanged diffs viewer on missing `@pierre/diffs` and curated Shiki packages.
