### PR TITLE
test(channels): reuse the shared setup call guard

### DIFF
--- a/src/flows/channel-setup.status.test.ts
+++ b/src/flows/channel-setup.status.test.ts
@@ -1,4 +1,5 @@
 // Channel setup status tests cover status text and docs link rendering.
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import {
@@ -83,17 +84,6 @@ import {
   resolveChannelSelectionNoteLines,
   resolveChannelSetupSelectionContributions,
 } from "./channel-setup.status.js";
-
-function requireFirstMockCall<const Calls extends readonly unknown[][]>(
-  calls: Calls,
-  label: string,
-): Calls[number] {
-  const call = calls.at(0);
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call as Calls[number];
-}
 
 describe("resolveChannelSetupSelectionContributions", () => {
   beforeEach(() => {
@@ -474,7 +464,10 @@ describe("resolveChannelSetupSelectionContributions", () => {
     );
 
     expect(formatChannelPrimerLine).toHaveBeenCalledOnce();
-    const [primerMeta] = requireFirstMockCall(formatChannelPrimerLine.mock.calls, "primer line");
+    const [primerMeta] = expectDefined(
+      formatChannelPrimerLine.mock.calls.at(0),
+      "primer line call",
+    );
     expect(primerMeta?.id).toBe("bad\\nid");
     expect(primerMeta?.label).toBe("bad\\nid");
     expect(primerMeta?.selectionLabel).toBe("bad\\nid");
@@ -549,9 +542,9 @@ describe("resolveChannelSetupSelectionContributions", () => {
     });
 
     expect(formatChannelSelectionLine).toHaveBeenCalledOnce();
-    const [selectionMeta, docsLink] = requireFirstMockCall(
-      formatChannelSelectionLine.mock.calls,
-      "selection line",
+    const [selectionMeta, docsLink] = expectDefined(
+      formatChannelSelectionLine.mock.calls.at(0),
+      "selection line call",
     );
     expect(selectionMeta?.label).toBe("Zalo\\nBot");
     expect(selectionMeta?.blurb).toBe("Setup\\nhelp");
@@ -594,9 +587,9 @@ describe("resolveChannelSetupSelectionContributions", () => {
       selection: ["custom-chat"],
     });
 
-    const [selectionMeta] = requireFirstMockCall(
-      formatChannelSelectionLine.mock.calls,
-      "selection line",
+    const [selectionMeta] = expectDefined(
+      formatChannelSelectionLine.mock.calls.at(0),
+      "selection line call",
     );
     expect(selectionMeta?.selectionDocsPrefix).toBe(expected);
   });


### PR DESCRIPTION
## What Problem This Solves

The channel-setup status tests maintain a generic first-call guard and tuple type assertion that duplicate the existing shared presence helper. The wrapper adds test-support code without additional coverage.

## Why This Change Was Made

Use `expectDefined` from `@openclaw/normalization-core/expect` at the three existing call sites. This preserves `.at(0)` and the missing-call failure before destructuring while retaining Vitest's argument-tuple type without a cast. The callback validation, call counts, complete output assertions, empty docs-prefix cases, sanitization and locale cleanup stay unchanged.

## User Impact

No user-visible behavior changes. Production: +0/-0. Tests: +11/-18 (net -7), with no cases or assertions removed.

## Evidence

- The same 47 cases passed before and after across the complete channel-status, channel-registry, terminal safe-text, terminal links and canonical presence-helper suites. Their ordered inventories match.
- All 20 stages of the normal one-path `check-changed` gate passed, including the core test graph, dead-export scans and lint.
- Independent Codex review through P2 found no actionable findings. Formatting preserved the reviewed patch exactly.

Proof used the documented trusted-local route with only inherited `OPENCLAW_TESTBOX` unset. No test, runtime, dependency or configuration surface was added.
