### PR TITLE
refactor(e2e): share WebSocket close formatting

### DIFF
--- a/scripts/e2e/lib/gateway-network/ws-frames.mts
+++ b/scripts/e2e/lib/gateway-network/ws-frames.mts
@@ -1,4 +1,6 @@
 // WebSocket frame helpers for gateway network E2E fixtures.
+import { formatCloseValue } from "../websocket-open.mjs";
+
 type FrameSocket = {
   off?: (event: string, listener: (...args: unknown[]) => void) => unknown;
   on: (event: "message", listener: (data: unknown) => void) => unknown;
@@ -17,22 +19,6 @@ function isFrameSocket(value: unknown): value is FrameSocket {
     "once" in value &&
     typeof value.once === "function"
   );
-}
-
-function formatCloseValue(value: unknown) {
-  if (value === undefined || value === null) {
-    return "";
-  }
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
-    return value.toString();
-  }
-  if (value instanceof Uint8Array) {
-    return Buffer.from(value).toString();
-  }
-  return JSON.stringify(value) ?? "";
 }
 
 export function onceFrame(

--- a/scripts/e2e/lib/websocket-open.mjs
+++ b/scripts/e2e/lib/websocket-open.mjs
@@ -1,5 +1,5 @@
 // WebSocket open/close wait helper for E2E clients.
-function formatCloseValue(value) {
+export function formatCloseValue(value) {
   if (value === undefined || value === null) {
     return "";
   }


### PR DESCRIPTION
## What Problem This Solves

The gateway network E2E helpers carried two identical WebSocket close-value formatters. Keeping both copies creates an avoidable drift risk for close diagnostics.

## Why This Change Was Made

This exports the existing formatter from the WebSocket open helper and reuses it from the frame helper. The formatter body and all call sites remain unchanged.

## User Impact

No product behavior changes. Maintainers get one canonical close-value formatter across these E2E paths.

## Evidence

- Focused tooling tests: 27/27 passed.
- Adversarial equivalence probe: 15/15 passed, including circular JSON throws, `Error` formatting, symbols/functions, bigint, and UTF-8 `Uint8Array`.
- Script erasability passed for 575 TypeScript implementation files.
- Import-cycle and Madge cycle checks: 0 cycles.
- Changed-file formatting and targeted Oxlint passed.
- Exact P1 autoreview: scoped-clean, correctness 0.98.
- `tsgo:scripts` and the aggregate changed-file gate reached script typecheck, then stopped on pre-existing missing shared dependencies.
- Docker gateway-network proof was not run because Docker is unavailable on this host.
