### PR TITLE
feat(reef): add host-approved remote session prompts

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1059,7 +1059,7 @@ extensions/reef/protocol/canonical.ts	1
 extensions/reef/protocol/envelope.ts	1
 extensions/reef/protocol/guard-adapters.ts	1
 extensions/reef/protocol/guard.ts	1
-extensions/reef/src/channel.ts	6
+extensions/reef/src/channel.ts	4
 extensions/reef/src/cli.ts	6
 extensions/reef/src/doctor-durable-state.ts	2
 extensions/reef/src/legacy-key-guard.ts	1

--- a/docs/channels/reef.md
+++ b/docs/channels/reef.md
@@ -50,6 +50,33 @@ openclaw reef friend remove @friend
 
 A friendship you requested is adopted automatically once the peer accepts; inbound requests still require `openclaw pairing approve reef <CODE>`.
 
+## Prototype: remote session prompts
+
+Two paired Gateways can test host-approved prompts against one host session. This prototype carries text prompts only. It does not mirror the transcript, stream output to the guest, or transfer attachments.
+
+On the host Gateway, send this owner command in a channel that supports `/reef`:
+
+```text
+/reef session share @guest agent:main:session-key
+```
+
+The command returns a mount ID and sends the mount to the guest Gateway. On the guest Gateway, list mounts and submit a prompt:
+
+```text
+/reef session list
+/reef session prompt reef-mount-... Check the current build
+```
+
+The host sees the existing approval card inline above that session's composer and in **Inbox → Approvals**. **Allow once** admits only that prompt. **Always allow here** admits later prompts from that exact peer and mount until revocation. **Deny** rejects the prompt.
+
+Revoke the mount from the host Gateway:
+
+```text
+/reef session revoke reef-mount-...
+```
+
+The host remains the only execution authority. Session resets, Reef key changes, and grant-generation changes invalidate stale prompt proposals.
+
 ## Configuration
 
 Reef lives under `channels.reef`:

--- a/docs/channels/reef.md
+++ b/docs/channels/reef.md
@@ -60,7 +60,7 @@ On the host Gateway, send this owner command in a channel that supports `/reef`:
 /reef session share @guest agent:main:session-key
 ```
 
-The command returns a mount ID and sends the mount to the guest Gateway. On the guest Gateway, list mounts and submit a prompt:
+The command returns a mount ID and sends the mount to the guest Gateway. Mounts expire after seven days, and each peer may hold at most 32 mounts. On the guest Gateway, list mounts and submit a prompt:
 
 ```text
 /reef session list

--- a/docs/channels/reef.md
+++ b/docs/channels/reef.md
@@ -67,7 +67,7 @@ The command returns a mount ID and sends the mount to the guest Gateway. Mounts 
 /reef session prompt reef-mount-... Check the current build
 ```
 
-The host sees the existing approval card inline above that session's composer and in **Inbox → Approvals**. **Allow once** admits only that prompt. **Always allow here** admits later prompts from that exact peer and mount until revocation. **Deny** rejects the prompt.
+The host sees the existing approval card inline above that session's composer and in **Inbox → Approvals**. **Allow once** admits only that prompt. **Always allow** admits later prompts from that exact peer and mount until revocation. **Deny** rejects the prompt.
 
 Revoke the mount from the host Gateway:
 

--- a/docs/channels/reef.md
+++ b/docs/channels/reef.md
@@ -54,6 +54,8 @@ A friendship you requested is adopted automatically once the peer accepts; inbou
 
 Two paired Gateways can test host-approved prompts against one host session. This prototype carries text prompts only. It does not mirror the transcript, stream output to the guest, or transfer attachments.
 
+Session federation frames do not pass through the ordinary Reef chat guard. They use pinned peer identity, a session mount, and host approval or a standing grant instead. Configuring a guard is still required to start Reef; do not assume it screens guest session prompts.
+
 On the host Gateway, send this owner command in a channel that supports `/reef`:
 
 ```text

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -114,7 +114,9 @@ Use `createPluginRuntimeStore` to store the runtime reference for use outside th
 </Steps>
 
 <Note>
-Prefer `pluginId` for the runtime-store identity. The lower-level `key` form is for uncommon cases where one plugin intentionally needs more than one runtime slot.
+Prefer `pluginId` for the runtime-store identity. Each plugin registry owns its runtime: discovery and setup cannot replace the runtime used by an active channel. Reads follow the current registration, request, or active registry and fail if that registry has no initialized slot.
+
+Without a selected registry, standalone callers retain the most recently registered runtime. The lower-level `key` form remains process-wide; use it only for a deliberately shared slot with its own lifecycle.
 </Note>
 
 ## Other top-level `api` fields

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -43,33 +43,33 @@ register(api) {
 
 Every `api.runtime` namespace and the page that documents it.
 
-| Namespace                        | Page                                                                            |
-| -------------------------------- | ------------------------------------------------------------------------------- |
-| `api.runtime.agent`              | [Agent and sessions](/plugins/sdk-runtime/agent#api-runtime-agent)              |
-| `api.runtime.agent.defaults`     | [Agent and sessions](/plugins/sdk-runtime/agent#api-runtime-agent-defaults)     |
-| `api.runtime.llm`                | [Model helpers](/plugins/sdk-runtime/models#api-runtime-llm)                    |
+| Namespace                        | Page                                                                                       |
+| -------------------------------- | ------------------------------------------------------------------------------------------ |
+| `api.runtime.agent`              | [Agent and sessions](/plugins/sdk-runtime/agent#api-runtime-agent)                         |
+| `api.runtime.agent.defaults`     | [Agent and sessions](/plugins/sdk-runtime/agent#api-runtime-agent-defaults)                |
+| `api.runtime.llm`                | [Model helpers](/plugins/sdk-runtime/models#api-runtime-llm)                               |
 | `api.runtime.crossSessionGrants` | [Gateway and nodes](/plugins/sdk-runtime/gateway-and-nodes#api-runtime-crosssessiongrants) |
-| `api.runtime.gateway`            | [Gateway and nodes](/plugins/sdk-runtime/gateway-and-nodes#api-runtime-gateway) |
-| `api.runtime.hooks`              | [Background work](/plugins/sdk-runtime/background-work#api-runtime-hooks)       |
-| `api.runtime.subagent`           | [Background work](/plugins/sdk-runtime/background-work#api-runtime-subagent)    |
-| `api.runtime.sandbox`            | [Agent and sessions](/plugins/sdk-runtime/agent#api-runtime-sandbox)            |
-| `api.runtime.nodes`              | [Gateway and nodes](/plugins/sdk-runtime/gateway-and-nodes#api-runtime-nodes)   |
-| `api.runtime.tasks`              | [Background work](/plugins/sdk-runtime/background-work#api-runtime-tasks)       |
-| `api.runtime.tts`                | [Media helpers](/plugins/sdk-runtime/media#api-runtime-tts)                     |
-| `api.runtime.mediaUnderstanding` | [Media helpers](/plugins/sdk-runtime/media#api-runtime-mediaunderstanding)      |
-| `api.runtime.imageGeneration`    | [Media helpers](/plugins/sdk-runtime/media#api-runtime-imagegeneration)         |
-| `api.runtime.videoGeneration`    | [Media helpers](/plugins/sdk-runtime/media#api-runtime-videogeneration)         |
-| `api.runtime.musicGeneration`    | [Media helpers](/plugins/sdk-runtime/media#api-runtime-musicgeneration)         |
-| `api.runtime.webSearch`          | [Media helpers](/plugins/sdk-runtime/media#api-runtime-websearch)               |
-| `api.runtime.media`              | [Media helpers](/plugins/sdk-runtime/media#api-runtime-media)                   |
-| `api.runtime.config`             | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-config)    |
-| `api.runtime.system`             | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-system)    |
-| `api.runtime.events`             | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-events)    |
-| `api.runtime.logging`            | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-logging)   |
-| `api.runtime.modelConfig`        | [Model helpers](/plugins/sdk-runtime/models#api-runtime-modelconfig)            |
-| `api.runtime.modelAuth`          | [Model helpers](/plugins/sdk-runtime/models#api-runtime-modelauth)              |
-| `api.runtime.state`              | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-state)     |
-| `api.runtime.channel`            | [Channel helpers](/plugins/sdk-runtime/channel#api-runtime-channel)             |
+| `api.runtime.gateway`            | [Gateway and nodes](/plugins/sdk-runtime/gateway-and-nodes#api-runtime-gateway)            |
+| `api.runtime.hooks`              | [Background work](/plugins/sdk-runtime/background-work#api-runtime-hooks)                  |
+| `api.runtime.subagent`           | [Background work](/plugins/sdk-runtime/background-work#api-runtime-subagent)               |
+| `api.runtime.sandbox`            | [Agent and sessions](/plugins/sdk-runtime/agent#api-runtime-sandbox)                       |
+| `api.runtime.nodes`              | [Gateway and nodes](/plugins/sdk-runtime/gateway-and-nodes#api-runtime-nodes)              |
+| `api.runtime.tasks`              | [Background work](/plugins/sdk-runtime/background-work#api-runtime-tasks)                  |
+| `api.runtime.tts`                | [Media helpers](/plugins/sdk-runtime/media#api-runtime-tts)                                |
+| `api.runtime.mediaUnderstanding` | [Media helpers](/plugins/sdk-runtime/media#api-runtime-mediaunderstanding)                 |
+| `api.runtime.imageGeneration`    | [Media helpers](/plugins/sdk-runtime/media#api-runtime-imagegeneration)                    |
+| `api.runtime.videoGeneration`    | [Media helpers](/plugins/sdk-runtime/media#api-runtime-videogeneration)                    |
+| `api.runtime.musicGeneration`    | [Media helpers](/plugins/sdk-runtime/media#api-runtime-musicgeneration)                    |
+| `api.runtime.webSearch`          | [Media helpers](/plugins/sdk-runtime/media#api-runtime-websearch)                          |
+| `api.runtime.media`              | [Media helpers](/plugins/sdk-runtime/media#api-runtime-media)                              |
+| `api.runtime.config`             | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-config)               |
+| `api.runtime.system`             | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-system)               |
+| `api.runtime.events`             | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-events)               |
+| `api.runtime.logging`            | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-logging)              |
+| `api.runtime.modelConfig`        | [Model helpers](/plugins/sdk-runtime/models#api-runtime-modelconfig)                       |
+| `api.runtime.modelAuth`          | [Model helpers](/plugins/sdk-runtime/models#api-runtime-modelauth)                         |
+| `api.runtime.state`              | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-state)                |
+| `api.runtime.channel`            | [Channel helpers](/plugins/sdk-runtime/channel#api-runtime-channel)                        |
 
 ## Storing runtime references
 

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -48,6 +48,7 @@ Every `api.runtime` namespace and the page that documents it.
 | `api.runtime.agent`              | [Agent and sessions](/plugins/sdk-runtime/agent#api-runtime-agent)              |
 | `api.runtime.agent.defaults`     | [Agent and sessions](/plugins/sdk-runtime/agent#api-runtime-agent-defaults)     |
 | `api.runtime.llm`                | [Model helpers](/plugins/sdk-runtime/models#api-runtime-llm)                    |
+| `api.runtime.crossSessionGrants` | [Gateway and nodes](/plugins/sdk-runtime/gateway-and-nodes#api-runtime-crosssessiongrants) |
 | `api.runtime.gateway`            | [Gateway and nodes](/plugins/sdk-runtime/gateway-and-nodes#api-runtime-gateway) |
 | `api.runtime.hooks`              | [Background work](/plugins/sdk-runtime/background-work#api-runtime-hooks)       |
 | `api.runtime.subagent`           | [Background work](/plugins/sdk-runtime/background-work#api-runtime-subagent)    |

--- a/docs/plugins/sdk-runtime/gateway-and-nodes.md
+++ b/docs/plugins/sdk-runtime/gateway-and-nodes.md
@@ -13,6 +13,43 @@ Reach the Gateway and paired nodes from plugin code, and the events a long-lived
 ## Gateway and node namespaces
 
 <AccordionGroup>
+  <Accordion title="api.runtime.crossSessionGrants">
+    Create and enforce persistent, exact grants for a trusted plugin that transports work between
+    sessions. Core owns storage, lifecycle revalidation, standing authorization, and revocation;
+    the plugin supplies only its authenticated subject binding and target session incarnation.
+
+    ```typescript
+    api.runtime.crossSessionGrants.create(
+      {
+        grantId,
+        subjectId,
+        subjectBinding,
+        role: "issuer",
+        targetSessionKey,
+        targetSessionId,
+        generation: 0,
+      },
+      lifecycleSignal,
+    );
+
+    const authorized = api.runtime.crossSessionGrants.authorize({
+      grantId,
+      subjectId,
+      subjectBinding,
+      targetSessionId,
+      generation,
+      signal: lifecycleSignal,
+    });
+    ```
+
+    Supply the current lifecycle signal to every operation. Call `authorize(...)` immediately before
+    privileged work and `allowStanding(...)` immediately after awaited approval work. Operations
+    fail closed when the plugin registry or supplied lifecycle is no longer live. `revoke(...)`
+    advances issuer generations; `applyRevocation(...)` accepts only a newer generation for the
+    exact holder subject and target binding. Retained runtime references cannot authorize after
+    plugin replacement.
+
+  </Accordion>
   <Accordion title="api.runtime.gateway">
     Call another Gateway method in process while preserving the current plugin's trusted runtime
     identity. This is intended for bundled or trusted official plugins that compose plugin-owned
@@ -29,9 +66,12 @@ Reach the Gateway and paired nodes from plugin code, and the events a long-lived
     ```
 
     Requests use `operator.write` scope and do not grant admin scope. Calls from arbitrary external
-    plugins are rejected. Failed methods throw a `GatewayClientRequestError`, preserving structured
-    `details`, retry metadata, and the Gateway error code for recovery flows. Use `isAvailable()`
-    before choosing this path from tools that can also run in standalone agent processes.
+    plugins are rejected. Pass `signal` to bind a pending dispatch to the plugin lifecycle. A local
+    timeout or abort can occur after method execution starts, so idempotent callers must retain their
+    operation key and reconcile instead of recording a terminal failure. Failed methods throw a
+    `GatewayClientRequestError`, preserving structured `details`, retry metadata, and the Gateway
+    error code for recovery flows. Use `isAvailable()` before choosing this path from tools that can
+    also run in standalone agent processes.
 
   </Accordion>
   <Accordion title="api.runtime.nodes">

--- a/docs/plugins/sdk-runtime/gateway-and-nodes.md
+++ b/docs/plugins/sdk-runtime/gateway-and-nodes.md
@@ -43,7 +43,9 @@ Reach the Gateway and paired nodes from plugin code, and the events a long-lived
     ```
 
     Supply the current lifecycle signal to every operation. Call `authorize(...)` immediately before
-    privileged work and `allowStanding(...)` immediately after awaited approval work. Operations
+    privileged work and `allowStanding(...)` immediately after awaited approval work. For agent
+    dispatch, repeat authorization inside `gateway.request`'s `assertAdmissionCurrent` callback:
+    asynchronous preparation can outlive the initial grant check. Operations
     fail closed when the plugin registry or supplied lifecycle is no longer live. `revoke(...)`
     advances issuer generations; `applyRevocation(...)` accepts only a newer generation for the
     exact holder subject and target binding. Retained runtime references cannot authorize after
@@ -72,6 +74,13 @@ Reach the Gateway and paired nodes from plugin code, and the events a long-lived
     `GatewayClientRequestError`, preserving structured `details`, retry metadata, and the Gateway
     error code for recovery flows. Use `isAvailable()` before choosing this path from tools that can
     also run in standalone agent processes.
+
+    For authority that can change during agent preparation, pass a synchronous
+    `assertAdmissionCurrent: () => void` callback. It must recheck the exact live grant, target, and
+    lifecycle and throw when they no longer authorize the input. The Gateway repeats this narrowing
+    check before durable session mutations and input acceptance, including after asynchronous work.
+    It grants no additional permissions. Once agent input is accepted, the host run owns it;
+    later source revocation does not retract that accepted input.
 
   </Accordion>
   <Accordion title="api.runtime.nodes">

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -666,6 +666,8 @@ describe("iMessage monitor last-route updates", () => {
         },
       ]),
     );
+    // The binding fixture owns a new registry, so install its runtime before monitoring.
+    installIMessageStateRuntimeForTest();
     return {
       ...overrides,
       agents: { list: [{ id: "main" }, { id: "codex" }] },

--- a/extensions/matrix/src/delivery-trace.test.ts
+++ b/extensions/matrix/src/delivery-trace.test.ts
@@ -33,7 +33,7 @@ import {
 } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
-import { beforeAll, describe, it, vi } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import {
   createMatrixHandlerTestHarness,
   createMatrixTextMessageEvent,
@@ -45,7 +45,7 @@ const ROOM_ID = "!room:example.org";
 const BOT_USER_ID = "@openclaw:example.org";
 const INBOUND_EVENT_ID = "$inbound-1";
 
-beforeAll(() => {
+beforeEach(() => {
   // send.ts/replies.ts read text helpers and the monitor's mention gating from
   // the module runtime slot; bind the real chunking/table implementations so
   // rendered wire content is part of the recorded lifecycle (mirrors the

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -495,10 +495,13 @@ function makeKeyBackupTrust(overrides: Record<string, unknown> = {}) {
   };
 }
 
+beforeEach(() => {
+  resetPluginStateStoreForTests();
+  installMatrixTestRuntime();
+});
+
 describe("MatrixClient request hardening", () => {
   beforeEach(() => {
-    resetPluginStateStoreForTests();
-    installMatrixTestRuntime();
     matrixJsClient = createMatrixJsClientStub();
     lastCreateClientOpts = null;
     vi.useRealTimers();
@@ -2718,8 +2721,6 @@ describe("MatrixClient crypto bootstrapping", () => {
   });
 
   it("does not persist or start sync when startup aborts during crypto initialization", async () => {
-    resetPluginStateStoreForTests();
-    installMatrixTestRuntime();
     const tempDir = tempDirs.make("matrix-idb-startup-abort-");
     const databasePrefix = "openclaw-matrix-startup-abort";
     const initCrypto = createDeferred<void>();
@@ -3099,8 +3100,6 @@ describe("MatrixClient crypto bootstrapping", () => {
   });
 
   it("awaits and cancels active periodic crypto persistence during discard shutdown", async () => {
-    resetPluginStateStoreForTests();
-    installMatrixTestRuntime();
     const tempDir = tempDirs.make("matrix-idb-interval-");
     const pendingDatabases = createDeferred<IDBDatabaseInfo[]>();
     const databasesSpy = vi

--- a/extensions/mattermost/src/mattermost/interactions.test.ts
+++ b/extensions/mattermost/src/mattermost/interactions.test.ts
@@ -496,20 +496,20 @@ describe("buildButtonProps attachments", () => {
   });
 });
 
-describe("createMattermostInteractionHandler", () => {
-  function setInteractionRuntime(
-    enqueueSystemEvent: (
-      text: string,
-      options: { sessionKey?: string | null; sessionId?: string | null; userId?: string | null },
-    ) => boolean = () => true,
-  ) {
-    setMattermostRuntime({
-      system: {
-        enqueueSystemEvent,
-      },
-    } as unknown as PluginRuntime);
-  }
+function setInteractionRuntime(
+  enqueueSystemEvent: (
+    text: string,
+    options: { sessionKey?: string | null; sessionId?: string | null; userId?: string | null },
+  ) => boolean = () => true,
+) {
+  setMattermostRuntime({
+    system: {
+      enqueueSystemEvent,
+    },
+  } as unknown as PluginRuntime);
+}
 
+describe("createMattermostInteractionHandler", () => {
   function createMattermostClientMock(
     requestImpl: (path: string, init?: { method?: string }) => Promise<unknown>,
   ): MattermostClient {
@@ -984,6 +984,10 @@ describe("createMattermostInteractionHandler", () => {
 });
 
 describe("createMattermostInteractionHandler body limits", () => {
+  beforeEach(() => {
+    setInteractionRuntime();
+  });
+
   // The 10s read deadline makes the sibling 408 case too slow to drive here; slash-http
   // and Synology Chat cover that half of the same branch.
   it("delivers 413 for an over-limit callback body and then closes the connection", async () => {

--- a/extensions/reef/browser/index.test.ts
+++ b/extensions/reef/browser/index.test.ts
@@ -1,0 +1,447 @@
+/* @vitest-environment jsdom */
+
+import type { ControlUiHost, ControlUiView } from "openclaw/plugin-sdk/control-ui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+type Status = {
+  enabled: boolean;
+  configured: boolean;
+  running: boolean;
+  handle: string | null;
+  relayUrl: string;
+  unavailableReason?: string;
+  friends: Array<{ peer: string; status: string; autonomy: string | null }>;
+  mounts: Array<{
+    mountId: string;
+    peer: string;
+    role: "host" | "guest";
+    sessionKey: string;
+    revoked: boolean;
+    revocationPending: boolean;
+  }>;
+  proposals: Array<{
+    direction: "inbound" | "outbound";
+    peer: string;
+    text: string;
+    status: "pending" | "accepted" | "denied" | "failed";
+    reason: string | null;
+    message: string | null;
+  }>;
+};
+
+const unconfigured: Status = {
+  enabled: false,
+  configured: false,
+  running: false,
+  handle: null,
+  relayUrl: "https://reefwire.ai",
+  friends: [],
+  mounts: [],
+  proposals: [],
+};
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement | undefined {
+  return [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+    (button) => button.textContent === label,
+  );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+function activate(
+  status: Status,
+  sessions = {
+    rows: [{ key: "agent:main:shared", label: "Shared plan" }],
+    selectedKey: "agent:main:shared",
+  },
+) {
+  let mount: ControlUiView | undefined;
+  const request = vi.fn().mockResolvedValue(status);
+  const host = {
+    apiVersion: 1,
+    pluginId: "reef",
+    signal: new AbortController().signal,
+    basePath: "",
+    locale: "en",
+    connection: {
+      connected: true,
+      canRead: true,
+      canWrite: true,
+      canGrant: true,
+      canAdmin: true,
+      assistantAgentId: "main",
+    },
+    request,
+    sessions,
+    agents: {
+      rows: [],
+      selectedId: "main",
+      defaultId: "main",
+      scopeId: null,
+    },
+    ui: {
+      registerPage: vi.fn((page: { mount: ControlUiView }) => {
+        mount = page.mount;
+        return vi.fn();
+      }),
+      registerNavigation: vi.fn(() => vi.fn()),
+    },
+  } as unknown as ControlUiHost;
+  const dispose = plugin.activate(host);
+  if (!mount) {
+    throw new Error("Reef page was not registered");
+  }
+  const container = document.createElement("main");
+  document.body.append(container);
+  const context = {
+    host,
+    signal: host.signal,
+    props: {},
+    presented: true,
+    mountDefault: () => vi.fn(),
+  };
+  const view = mount(container, context);
+  return { container, context, dispose, host, request, view };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("Reef native Control UI", () => {
+  it("does not register its admin page or navigation for read-only operators", () => {
+    const registerPage = vi.fn();
+    const registerNavigation = vi.fn();
+
+    plugin.activate({
+      connection: { canAdmin: false },
+      ui: { registerPage, registerNavigation },
+    } as unknown as ControlUiHost);
+
+    expect(registerPage).not.toHaveBeenCalled();
+    expect(registerNavigation).not.toHaveBeenCalled();
+  });
+
+  it("shows actionable setup without fabricating channel availability", async () => {
+    const page = activate(unconfigured);
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Finish Reef setup"));
+    expect(page.container.textContent).toContain("explicitly enable it");
+    expect(
+      page.container.querySelector<HTMLAnchorElement>('a[href="/channels"]')?.textContent,
+    ).toBe("Open channel setup");
+
+    page.view?.dispose?.();
+    if (typeof page.dispose === "function") {
+      page.dispose();
+    }
+  });
+
+  it("explains a configured channel that is currently unavailable", async () => {
+    const page = activate({
+      ...unconfigured,
+      enabled: true,
+      configured: true,
+      handle: "host",
+      unavailableReason: "Relay connection closed",
+    });
+
+    await vi.waitFor(() =>
+      expect(page.container.textContent).toContain("Reef is configured but unavailable"),
+    );
+    expect(page.container.textContent).toContain("Relay connection closed");
+    expect(page.container.textContent).not.toContain("Share session");
+
+    page.view?.dispose?.();
+    if (typeof page.dispose === "function") {
+      page.dispose();
+    }
+  });
+
+  it("links a configured but disabled channel back to setup", async () => {
+    const page = activate({
+      ...unconfigured,
+      configured: true,
+      handle: "host",
+    });
+
+    await vi.waitFor(() =>
+      expect(page.container.textContent).toContain("Reef is configured but disabled"),
+    );
+    expect(page.container.textContent).toContain("Enable Reef in Channels");
+    expect(
+      page.container.querySelector<HTMLAnchorElement>('a[href="/channels"]')?.textContent,
+    ).toBe("Open channel setup");
+
+    page.view?.dispose?.();
+    if (typeof page.dispose === "function") {
+      page.dispose();
+    }
+  });
+
+  it("keeps successful action feedback visible after refreshing status", async () => {
+    const running: Status = {
+      ...unconfigured,
+      enabled: true,
+      configured: true,
+      running: true,
+      handle: "host",
+    };
+    const page = activate(running);
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Request pairing"));
+    page.request
+      .mockResolvedValueOnce({ message: "Pairing requested." })
+      .mockResolvedValueOnce(running);
+    findButton(page.container, "Request pairing")?.click();
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Pairing requested."));
+
+    page.view?.dispose?.();
+    if (typeof page.dispose === "function") {
+      page.dispose();
+    }
+  });
+
+  it("shows direct action request failures", async () => {
+    const page = activate({
+      ...unconfigured,
+      enabled: true,
+      configured: true,
+      running: true,
+      handle: "host",
+    });
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Generate friend code"));
+    page.request.mockRejectedValueOnce(new Error("Friend code unavailable"));
+    findButton(page.container, "Generate friend code")?.click();
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Friend code unavailable"));
+
+    page.view?.dispose?.();
+    if (typeof page.dispose === "function") {
+      page.dispose();
+    }
+  });
+
+  it("defaults session sharing to the selected session's canonical agent key", async () => {
+    const running: Status = {
+      ...unconfigured,
+      enabled: true,
+      configured: true,
+      running: true,
+      handle: "host",
+      friends: [{ peer: "guest", status: "active", autonomy: "bounded" }],
+    };
+    const page = activate(running, {
+      rows: [
+        { key: "global", label: "Other agent", agentId: "other" },
+        { key: "global", label: "Selected agent", agentId: "main" },
+      ],
+      selectedKey: "global",
+    });
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Share session"));
+    const sessionInput = [...page.container.querySelectorAll<HTMLInputElement>("input")].find(
+      (input) => input.closest("label")?.textContent?.includes("Host session key"),
+    );
+    expect(sessionInput?.value).toBe("agent:main:global");
+    page.request.mockResolvedValueOnce({ message: "Shared." }).mockResolvedValueOnce(running);
+    findButton(page.container, "Share session")?.click();
+
+    await vi.waitFor(() =>
+      expect(page.request).toHaveBeenCalledWith("reef.controlUi.sessionShare", {
+        peer: "guest",
+        sessionKey: "agent:main:global",
+      }),
+    );
+
+    page.view?.dispose?.();
+    if (typeof page.dispose === "function") {
+      page.dispose();
+    }
+  });
+
+  it("replaces stale controls when a host-driven status refresh fails", async () => {
+    const page = activate({
+      ...unconfigured,
+      enabled: true,
+      configured: true,
+      running: true,
+      handle: "host",
+    });
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Share session"));
+    page.request.mockRejectedValueOnce(new Error("Status refresh failed"));
+    page.view?.update?.(page.context);
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Status refresh failed"));
+    expect(page.container.textContent).not.toContain("Share session");
+
+    page.view?.dispose?.();
+    if (typeof page.dispose === "function") {
+      page.dispose();
+    }
+  });
+
+  it("does not let an older status response overwrite newer state", async () => {
+    const running: Status = {
+      ...unconfigured,
+      enabled: true,
+      configured: true,
+      running: true,
+      handle: "host",
+    };
+    const disabled: Status = {
+      ...running,
+      enabled: false,
+      running: false,
+    };
+    const older = deferred<Status>();
+    const page = activate(running);
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Share session"));
+    page.request.mockReturnValueOnce(older.promise).mockResolvedValueOnce(disabled);
+    page.view?.update?.(page.context);
+    page.view?.update?.(page.context);
+
+    await vi.waitFor(() =>
+      expect(page.container.textContent).toContain("Reef is configured but disabled"),
+    );
+    older.resolve(running);
+    await older.promise;
+    await Promise.resolve();
+    expect(page.container.textContent).not.toContain("Share session");
+
+    page.view?.dispose?.();
+    if (typeof page.dispose === "function") {
+      page.dispose();
+    }
+  });
+
+  it("clears stale controls when a post-action status refresh fails", async () => {
+    const running: Status = {
+      ...unconfigured,
+      enabled: true,
+      configured: true,
+      running: true,
+      handle: "host",
+    };
+    const page = activate(running);
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Request pairing"));
+    page.request
+      .mockResolvedValueOnce({ message: "Pairing requested." })
+      .mockRejectedValueOnce(new Error("Status refresh failed"));
+    findButton(page.container, "Request pairing")?.click();
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Pairing requested."));
+    expect(page.container.textContent).toContain("Status refresh failed");
+    expect(page.container.textContent).not.toContain("Request pairing");
+    expect(page.container.textContent).not.toContain("Share session");
+
+    page.view?.dispose?.();
+    if (typeof page.dispose === "function") {
+      page.dispose();
+    }
+  });
+
+  it("renders a pending revocation without another mount action", async () => {
+    const page = activate({
+      ...unconfigured,
+      enabled: true,
+      configured: true,
+      running: true,
+      handle: "host",
+      mounts: [
+        {
+          mountId: "mount-host",
+          peer: "guest",
+          role: "host",
+          sessionKey: "agent:main:shared",
+          revoked: true,
+          revocationPending: true,
+        },
+      ],
+    });
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Revocation pending"));
+    expect(findButton(page.container, "Revoke access")).toBeUndefined();
+
+    page.view?.dispose?.();
+    if (typeof page.dispose === "function") {
+      page.dispose();
+    }
+  });
+
+  it("renders mounts and text-only proposal outcomes on the running surface", async () => {
+    const page = activate({
+      enabled: true,
+      configured: true,
+      running: true,
+      handle: "host",
+      relayUrl: "http://127.0.0.1:36641",
+      friends: [{ peer: "guest", status: "active", autonomy: "bounded" }],
+      mounts: [
+        {
+          mountId: "mount-host",
+          peer: "guest",
+          role: "host",
+          sessionKey: "agent:main:shared",
+          revoked: false,
+          revocationPending: false,
+        },
+        {
+          mountId: "mount-guest",
+          peer: "host",
+          role: "guest",
+          sessionKey: "agent:host:shared",
+          revoked: false,
+          revocationPending: false,
+        },
+      ],
+      proposals: [
+        {
+          direction: "inbound",
+          peer: "guest",
+          text: "Use the real host transcript",
+          status: "pending",
+          reason: null,
+          message: null,
+        },
+        {
+          direction: "outbound",
+          peer: "host",
+          text: "Return the proof marker",
+          status: "accepted",
+          reason: null,
+          message: null,
+        },
+      ],
+    });
+
+    await vi.waitFor(() => expect(page.container.textContent).toContain("Connected"));
+    expect(page.container.textContent).toContain("Share a host session");
+    expect(page.container.textContent).toContain("Mounted from @host");
+    expect(page.container.textContent).toContain("Use the real host transcript");
+    expect(page.container.textContent).toContain("pending");
+    expect(page.container.textContent).toContain("accepted");
+    expect(
+      page.container.querySelector<HTMLAnchorElement>('a[href="/approvals"]')?.textContent,
+    ).toBe("Open approvals");
+    expect(page.container.textContent).not.toContain("assistant reply");
+
+    page.view?.dispose?.();
+    if (typeof page.dispose === "function") {
+      page.dispose();
+    }
+  });
+});

--- a/extensions/reef/browser/index.ts
+++ b/extensions/reef/browser/index.ts
@@ -1,0 +1,453 @@
+import { defineControlUiPlugin, type ControlUiHost } from "openclaw/plugin-sdk/control-ui";
+import "./reef.css";
+
+type ReefStatus = {
+  enabled: boolean;
+  configured: boolean;
+  running: boolean;
+  handle: string | null;
+  relayUrl: string;
+  unavailableReason?: string;
+  friends: Array<{ peer: string; status: string; autonomy: string | null }>;
+  mounts: Array<{
+    mountId: string;
+    peer: string;
+    role: "host" | "guest";
+    sessionKey: string;
+    revoked: boolean;
+    revocationPending: boolean;
+  }>;
+  proposals: Array<{
+    direction: "inbound" | "outbound";
+    peer: string;
+    text: string;
+    status: "pending" | "accepted" | "denied" | "failed";
+    reason: string | null;
+    message: string | null;
+  }>;
+};
+
+function node<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const value = document.createElement(tag);
+  if (className) {
+    value.className = className;
+  }
+  if (text !== undefined) {
+    value.textContent = text;
+  }
+  return value;
+}
+
+function action(
+  label: string,
+  run: () => Promise<void>,
+  onError: (error: unknown) => void,
+  secondary = false,
+): HTMLButtonElement {
+  const value = node(
+    "button",
+    secondary ? "reef-button reef-button--secondary" : "reef-button",
+    label,
+  );
+  value.type = "button";
+  value.addEventListener("click", () => {
+    value.disabled = true;
+    void run()
+      .catch(onError)
+      .finally(() => {
+        value.disabled = false;
+      });
+  });
+  return value;
+}
+
+function field(label: string, control: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement) {
+  const value = node("label", "reef-field");
+  value.append(node("span", "reef-field__label", label), control);
+  return value;
+}
+
+function createReefPage(host: ControlUiHost) {
+  return (container: HTMLElement) => {
+    let disposed = false;
+    let renderGeneration = 0;
+    const page = node("div", "reef-page");
+    const notices = node("div", "reef-notices");
+    const root = node("div", "reef-content");
+    page.append(notices, root);
+    container.replaceChildren(page);
+
+    const request = async <T>(method: string, params: Record<string, unknown> = {}) =>
+      await host.request<T>(method, params);
+    const notice = (message: string, error = false) => {
+      const value = node("div", error ? "reef-notice reef-notice--error" : "reef-notice", message);
+      notices.prepend(value);
+      window.setTimeout(() => value.remove(), 6000);
+    };
+    const reportError = (error: unknown) => {
+      notice(error instanceof Error ? error.message : "Reef action failed.", true);
+    };
+
+    const render = async () => {
+      const generation = ++renderGeneration;
+      let status: ReefStatus;
+      try {
+        status = await request<ReefStatus>("reef.controlUi.status");
+      } catch (error) {
+        if (disposed || generation !== renderGeneration) {
+          return;
+        }
+        throw error;
+      }
+      if (disposed || generation !== renderGeneration) {
+        return;
+      }
+      root.replaceChildren();
+
+      const hero = node("section", "reef-hero");
+      const copy = node("div");
+      copy.append(
+        node("p", "reef-eyebrow", "PRIVATE CLAW FEDERATION"),
+        node("h1", "reef-title", "Reef"),
+        node(
+          "p",
+          "reef-subtitle",
+          "Pair trusted claws and share selected sessions without moving the host transcript.",
+        ),
+      );
+      const identity = node("div", "reef-identity");
+      identity.append(
+        node(
+          "span",
+          `reef-status reef-status--${status.running ? "online" : "offline"}`,
+          status.running ? "Connected" : "Unavailable",
+        ),
+        node("strong", "reef-handle", status.handle ? `@${status.handle}` : "Not configured"),
+        node("span", "reef-muted", status.relayUrl),
+      );
+      hero.append(copy, identity);
+      root.append(hero);
+
+      if (!status.configured) {
+        const empty = node("section", "reef-card reef-empty");
+        empty.append(
+          node("h2", undefined, "Finish Reef setup"),
+          node(
+            "p",
+            undefined,
+            "Register a handle, relay, and guard model in Channels. Reef remains off until you explicitly enable it.",
+          ),
+        );
+        const link = node("a", "reef-button", "Open channel setup");
+        link.href = `${host.basePath || ""}/channels`;
+        empty.append(link);
+        root.append(empty);
+        return;
+      }
+
+      if (!status.enabled) {
+        const empty = node("section", "reef-card reef-empty");
+        empty.append(
+          node("h2", undefined, "Reef is configured but disabled"),
+          node("p", undefined, "Enable Reef in Channels before connecting to the relay."),
+        );
+        const link = node("a", "reef-button", "Open channel setup");
+        link.href = `${host.basePath || ""}/channels`;
+        empty.append(link);
+        root.append(empty);
+        return;
+      }
+
+      if (!status.running) {
+        const empty = node("section", "reef-card reef-empty");
+        empty.append(
+          node("h2", undefined, "Reef is configured but unavailable"),
+          node(
+            "p",
+            undefined,
+            status.unavailableReason ?? "Check the channel status and relay connection.",
+          ),
+          action("Check again", render, reportError, true),
+        );
+        root.append(empty);
+        return;
+      }
+
+      const run = async (method: string, params: Record<string, unknown> = {}) => {
+        let result: { message: string };
+        try {
+          result = await request<{ message: string }>(method, params);
+        } catch (error) {
+          reportError(error);
+          return;
+        }
+        try {
+          await render();
+          notice(result.message);
+        } catch (error) {
+          renderError(error);
+          notice(result.message);
+          reportError(error);
+        }
+      };
+
+      const grid = node("div", "reef-grid");
+      const pair = node("section", "reef-card");
+      pair.append(node("h2", undefined, "Pair a claw"));
+      const codeOutput = node("output", "reef-code", "Generate a short-lived friend code.");
+      pair.append(
+        codeOutput,
+        action(
+          "Generate friend code",
+          async () => {
+            const result = await request<{ message: string }>("reef.controlUi.friendCode");
+            codeOutput.textContent = result.message;
+          },
+          reportError,
+        ),
+      );
+      const peer = node("input");
+      peer.placeholder = "@handle";
+      const code = node("input");
+      code.placeholder = "Friend code";
+      pair.append(
+        field("Friend handle", peer),
+        field("Code", code),
+        action(
+          "Request pairing",
+          () =>
+            run("reef.controlUi.friendRequest", {
+              peer: peer.value,
+              code: code.value || undefined,
+            }),
+          reportError,
+        ),
+      );
+
+      const share = node("section", "reef-card");
+      share.append(node("h2", undefined, "Share a host session"));
+      const friendSelect = node("select");
+      for (const friend of status.friends.filter((entry) => entry.status === "active")) {
+        const option = node("option", undefined, `@${friend.peer}`);
+        option.value = friend.peer;
+        friendSelect.append(option);
+      }
+      const sessionInput = node("input");
+      sessionInput.placeholder = "agent:main:session-key";
+      const selectedAgentId = host.agents.selectedId;
+      const selectedRow = host.sessions.rows.find(
+        (session) =>
+          session.key === host.sessions.selectedKey &&
+          (!selectedAgentId || session.agentId === selectedAgentId),
+      );
+      const canonicalAgentId = selectedRow?.agentId ?? selectedAgentId;
+      sessionInput.value = host.sessions.selectedKey.startsWith("agent:")
+        ? host.sessions.selectedKey
+        : canonicalAgentId
+          ? `agent:${canonicalAgentId}:${host.sessions.selectedKey}`
+          : "";
+      const shareAction = action(
+        "Share session",
+        () =>
+          run("reef.controlUi.sessionShare", {
+            peer: friendSelect.value,
+            sessionKey: sessionInput.value,
+          }),
+        reportError,
+      );
+      const syncShareAction = () => {
+        shareAction.disabled = !friendSelect.value || !sessionInput.value.trim();
+      };
+      friendSelect.addEventListener("change", syncShareAction);
+      sessionInput.addEventListener("input", syncShareAction);
+      syncShareAction();
+      share.append(
+        field("Trusted claw", friendSelect),
+        field("Host session key", sessionInput),
+        shareAction,
+      );
+      grid.append(pair, share);
+      root.append(grid);
+
+      root.append(
+        renderFriends(status, run, reportError),
+        renderMounts(status, run, reportError),
+        renderProposals(status, host),
+      );
+    };
+
+    const renderError = (error: unknown) => {
+      root.replaceChildren(
+        node(
+          "section",
+          "reef-card reef-empty",
+          error instanceof Error ? error.message : "Could not load Reef.",
+        ),
+      );
+    };
+    void render().catch(renderError);
+    return {
+      update: () => void render().catch(renderError),
+      dispose: () => void (disposed = true),
+    };
+  };
+}
+
+function renderFriends(
+  status: ReefStatus,
+  run: (method: string, params?: Record<string, unknown>) => Promise<void>,
+  reportError: (error: unknown) => void,
+) {
+  const card = node("section", "reef-card");
+  card.append(node("h2", undefined, `Trusted claws · ${status.friends.length}`));
+  const list = node("div", "reef-list");
+  for (const friend of status.friends) {
+    const row = node("article", "reef-row");
+    const copy = node("div");
+    copy.append(
+      node("strong", undefined, `@${friend.peer}`),
+      node(
+        "span",
+        "reef-muted",
+        `${friend.status} · ${friend.autonomy ?? "autonomy not approved"}`,
+      ),
+    );
+    row.append(
+      copy,
+      action(
+        "Remove",
+        () => run("reef.controlUi.friendRemove", { peer: friend.peer }),
+        reportError,
+        true,
+      ),
+    );
+    list.append(row);
+  }
+  if (!status.friends.length) {
+    list.append(node("p", "reef-muted", "No trusted claws yet."));
+  }
+  card.append(list);
+  return card;
+}
+
+function renderMounts(
+  status: ReefStatus,
+  run: (method: string, params?: Record<string, unknown>) => Promise<void>,
+  reportError: (error: unknown) => void,
+) {
+  const card = node("section", "reef-card");
+  card.append(node("h2", undefined, `Session mounts · ${status.mounts.length}`));
+  const list = node("div", "reef-list");
+  for (const mount of status.mounts) {
+    const row = node("article", "reef-row reef-row--stack");
+    const head = node("div", "reef-row__head");
+    const mountState = mount.revocationPending ? "pending" : mount.revoked ? "revoked" : "active";
+    head.append(
+      node(
+        "strong",
+        undefined,
+        `${mount.role === "host" ? "Shared with" : "Mounted from"} @${mount.peer}`,
+      ),
+      node(
+        "span",
+        `reef-pill reef-pill--${mountState}`,
+        mount.revocationPending ? "Revocation pending" : mount.revoked ? "Revoked" : mount.role,
+      ),
+    );
+    row.append(
+      head,
+      node("code", undefined, mount.sessionKey),
+      node("small", "reef-muted", mount.mountId),
+    );
+    if (mount.role === "host" && !mount.revoked && !mount.revocationPending) {
+      row.append(
+        action(
+          "Revoke access",
+          () => run("reef.controlUi.sessionRevoke", { mountId: mount.mountId }),
+          reportError,
+          true,
+        ),
+      );
+    } else if (mount.role === "guest" && !mount.revoked && !mount.revocationPending) {
+      const prompt = node("textarea");
+      prompt.placeholder = "Propose a text prompt to the host session";
+      row.append(
+        field("Prompt proposal", prompt),
+        action(
+          "Send proposal",
+          () => run("reef.controlUi.sessionPrompt", { mountId: mount.mountId, text: prompt.value }),
+          reportError,
+        ),
+      );
+    }
+    list.append(row);
+  }
+  if (!status.mounts.length) {
+    list.append(node("p", "reef-muted", "No shared session mounts."));
+  }
+  card.append(list);
+  return card;
+}
+
+function renderProposals(status: ReefStatus, host: ControlUiHost) {
+  const card = node("section", "reef-card");
+  const heading = node("div", "reef-section-heading");
+  heading.append(node("h2", undefined, `Prompt proposals · ${status.proposals.length}`));
+  const approvals = node("a", "reef-link", "Open approvals");
+  approvals.href = `${host.basePath || ""}/approvals`;
+  heading.append(approvals);
+  card.append(heading);
+  const list = node("div", "reef-list");
+  for (const proposal of status.proposals.toReversed()) {
+    const row = node("article", "reef-row reef-row--stack");
+    const head = node("div", "reef-row__head");
+    head.append(
+      node(
+        "strong",
+        undefined,
+        `${proposal.direction === "inbound" ? "From" : "To"} @${proposal.peer}`,
+      ),
+      node("span", `reef-pill reef-pill--${proposal.status}`, proposal.status),
+    );
+    row.append(head, node("p", "reef-prompt", proposal.text));
+    if (proposal.reason || proposal.message) {
+      row.append(node("small", "reef-muted", proposal.reason ?? proposal.message ?? ""));
+    }
+    list.append(row);
+  }
+  if (!status.proposals.length) {
+    list.append(
+      node(
+        "p",
+        "reef-muted",
+        "No prompt proposals yet. Guest prompts appear here as pending, accepted, denied, or failed.",
+      ),
+    );
+  }
+  card.append(list);
+  return card;
+}
+
+export default defineControlUiPlugin({
+  id: "reef",
+  activate(host) {
+    if (!host.connection.canAdmin) {
+      return;
+    }
+    const registrations = [
+      host.ui.registerPage({ id: "reef", label: "Reef", mount: createReefPage(host) }),
+      host.ui.registerNavigation({
+        id: "reef",
+        label: "Reef",
+        page: { id: "reef" },
+        icon: "waves",
+        order: 35,
+      }),
+    ];
+    return () => registrations.toReversed().forEach((dispose) => dispose());
+  },
+});

--- a/extensions/reef/browser/reef.css
+++ b/extensions/reef/browser/reef.css
@@ -1,0 +1,243 @@
+.reef-page {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 28px;
+  display: grid;
+  gap: 18px;
+  color: var(--text);
+}
+.reef-content {
+  display: contents;
+}
+.reef-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 34px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--accent) 34%, var(--border));
+  border-radius: 24px;
+  background:
+    radial-gradient(
+      circle at 90% 5%,
+      color-mix(in srgb, var(--accent) 24%, transparent),
+      transparent 42%
+    ),
+    linear-gradient(135deg, color-mix(in srgb, var(--accent) 10%, var(--surface)), var(--surface));
+}
+.reef-eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+}
+.reef-title {
+  margin: 0;
+  font-size: clamp(38px, 7vw, 72px);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+}
+.reef-subtitle {
+  max-width: 620px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1.6;
+}
+.reef-identity {
+  min-width: 220px;
+  align-self: center;
+  display: grid;
+  gap: 8px;
+  text-align: right;
+}
+.reef-status,
+.reef-pill {
+  justify-self: end;
+  width: fit-content;
+  padding: 5px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.reef-status--online,
+.reef-pill--active,
+.reef-pill--accepted {
+  color: #82f2c0;
+  background: #0d3b2d;
+}
+.reef-status--offline,
+.reef-pill--failed,
+.reef-pill--revoked {
+  color: #ff9e9e;
+  background: #441d24;
+}
+.reef-pill--pending {
+  color: #ffe2a7;
+  background: #493512;
+}
+.reef-pill--denied {
+  color: #ffc1d1;
+  background: #481d31;
+}
+.reef-handle {
+  font-size: 22px;
+}
+.reef-muted {
+  color: var(--muted);
+}
+.reef-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+.reef-card {
+  padding: 22px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--surface) 94%, var(--accent));
+  box-shadow: 0 12px 32px rgb(0 0 0 / 8%);
+}
+.reef-card h2 {
+  margin: 0 0 16px;
+  font-size: 17px;
+}
+.reef-empty {
+  min-height: 180px;
+  display: grid;
+  align-content: center;
+  justify-items: start;
+}
+.reef-field {
+  display: grid;
+  gap: 7px;
+  margin: 14px 0;
+}
+.reef-field__label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+.reef-field input,
+.reef-field select,
+.reef-field textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  padding: 10px 12px;
+  color: var(--text);
+  background: var(--background);
+  font: inherit;
+}
+.reef-field textarea {
+  min-height: 88px;
+  resize: vertical;
+}
+.reef-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  border: 0;
+  border-radius: 11px;
+  padding: 10px 14px;
+  color: var(--accent-contrast, white);
+  background: var(--accent);
+  font: inherit;
+  font-weight: 750;
+  text-decoration: none;
+  cursor: pointer;
+}
+.reef-button--secondary {
+  color: var(--text);
+  background: color-mix(in srgb, var(--muted) 14%, transparent);
+}
+.reef-button:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+.reef-code {
+  display: block;
+  min-height: 24px;
+  margin: 0 0 12px;
+  color: var(--muted);
+  font-family: var(--font-mono, monospace);
+}
+.reef-list {
+  display: grid;
+  gap: 10px;
+}
+.reef-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px;
+  border-radius: 13px;
+  background: color-mix(in srgb, var(--background) 70%, transparent);
+}
+.reef-row > div:not(.reef-row__head) {
+  display: grid;
+  gap: 4px;
+}
+.reef-row--stack {
+  align-items: stretch;
+  display: grid;
+}
+.reef-row__head,
+.reef-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.reef-row code {
+  overflow-wrap: anywhere;
+  color: var(--accent);
+}
+.reef-prompt {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+.reef-link {
+  color: var(--accent);
+  font-weight: 700;
+}
+.reef-notice {
+  position: sticky;
+  top: 12px;
+  z-index: 5;
+  padding: 12px 16px;
+  border-radius: 12px;
+  color: #baf5dc;
+  background: #123d31;
+  box-shadow: 0 12px 30px rgb(0 0 0 / 18%);
+}
+.reef-notice--error {
+  color: #ffd1d1;
+  background: #4a2026;
+}
+@media (max-width: 760px) {
+  .reef-page {
+    padding: 16px;
+  }
+  .reef-hero {
+    display: grid;
+    padding: 24px;
+  }
+  .reef-identity {
+    min-width: 0;
+    text-align: left;
+  }
+  .reef-status {
+    justify-self: start;
+  }
+  .reef-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/extensions/reef/index.ts
+++ b/extensions/reef/index.ts
@@ -4,10 +4,21 @@ import {
 } from "openclaw/plugin-sdk/channel-entry-contract";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { registerReefCliMetadata } from "./cli-metadata.js";
+import { registerReefControlUiGatewayMethods } from "./src/control-ui-gateway.js";
 
 const loadReefCommandsRuntime = createLazyRuntimeModule(() => import("./commands.runtime.js"));
 
 function registerReefFullRuntime(api: OpenClawPluginApi): void {
+  api.session.controls.registerControlUiDescriptor({
+    surface: "tab",
+    id: "reef",
+    label: "Reef",
+    description: "Pair claws and manage shared session proposals.",
+    icon: "waves",
+    group: "control",
+    requiredScopes: ["operator.admin"],
+  });
+  registerReefControlUiGatewayMethods(api);
   api.registerCommand({
     name: "reef",
     description: "Manage Reef friends and owner review approvals",

--- a/extensions/reef/openclaw.plugin.json
+++ b/extensions/reef/openclaw.plugin.json
@@ -3,15 +3,26 @@
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": [
-      { "id": "reef-keys-json-to-plugin-state" },
-      { "id": "reef-registration-json-to-plugin-state" },
-      { "id": "reef-audit-jsonl-to-plugin-state" },
-      { "id": "reef-runtime-files-to-plugin-state" },
-      { "id": "reef-config-trust-to-plugin-state" }
+      {
+        "id": "reef-keys-json-to-plugin-state"
+      },
+      {
+        "id": "reef-registration-json-to-plugin-state"
+      },
+      {
+        "id": "reef-audit-jsonl-to-plugin-state"
+      },
+      {
+        "id": "reef-runtime-files-to-plugin-state"
+      },
+      {
+        "id": "reef-config-trust-to-plugin-state"
+      }
     ]
   },
   "name": "Reef",
   "description": "Guarded end-to-end encrypted claw channel",
+  "enabledByDefault": false,
   "cliCommands": [
     {
       "name": "reef",
@@ -37,5 +48,11 @@
     {
       "name": "reef"
     }
-  ]
+  ],
+  "controlUi": {
+    "entry": "dist/control-ui/6b3fc1f4b54d12625d00a0e559f975625e1a694e6dcfcfcff3f86f4c4fd84de7/index.js",
+    "styles": [
+      "dist/control-ui/6b3fc1f4b54d12625d00a0e559f975625e1a694e6dcfcfcff3f86f4c4fd84de7/index.css"
+    ]
+  }
 }

--- a/extensions/reef/package.json
+++ b/extensions/reef/package.json
@@ -14,6 +14,14 @@
     "extensions": [
       "./index.ts"
     ],
+    "controlUi": "./browser/index.ts",
+    "assetScripts": {
+      "build": "node --import ../../scripts/tsx.mjs ../../scripts/run-with-env.mts TSX_TSCONFIG_PATH=../../tsconfig.json -- node --import ../../scripts/tsx.mjs ../../scripts/build-plugin-control-ui.mts",
+      "copy": "node --import ../../scripts/tsx.mjs ../../scripts/run-with-env.mts TSX_TSCONFIG_PATH=../../tsconfig.json -- node --import ../../scripts/tsx.mjs ../../scripts/build-plugin-control-ui.mts --copy",
+      "buildOutputs": [
+        "openclaw.plugin.json"
+      ]
+    },
     "install": {
       "minHostVersion": ">=2026.7.2"
     },
@@ -33,6 +41,7 @@
     }
   },
   "devDependencies": {
-    "@openclaw/plugin-sdk": "workspace:*"
+    "@openclaw/plugin-sdk": "workspace:*",
+    "openclaw": "workspace:*"
   }
 }

--- a/extensions/reef/protocol/envelope.ts
+++ b/extensions/reef/protocol/envelope.ts
@@ -5,6 +5,11 @@ import { sha256 } from "@noble/hashes/sha2.js";
 import { randomBytes } from "@noble/hashes/utils.js";
 import { canonicalBytes } from "./canonical.js";
 import { base64, decodeUtf8, fromBase64, fromBase64url, hex, utf8 } from "./encoding.js";
+import {
+  isReefFederationBody,
+  validateReefFederationBody,
+  type ReefFederationBody,
+} from "./federation.js";
 import { parseHandleEpoch } from "./identity.js";
 import type { SignedReceipt } from "./receipts.js";
 
@@ -27,11 +32,13 @@ export interface ReplayStore {
   completed(peer: string, id: string): Promise<CompletedReplay | undefined>;
 }
 
-export interface MessageBody {
+export interface ChatMessageBody {
   text: string;
   replyTo?: string;
   thread?: string;
 }
+
+export type MessageBody = ChatMessageBody | ReefFederationBody;
 
 export interface UnsignedEnvelope {
   v: 1;
@@ -295,6 +302,14 @@ export function validateEnvelopeMetadata(id: string, from: string, to: string, t
 }
 
 export function validateMessageBody(value: unknown): asserts value is MessageBody {
+  if (isReefFederationBody(value)) {
+    try {
+      validateReefFederationBody(value);
+      return;
+    } catch {
+      throw new MalformedError("invalid federation body");
+    }
+  }
   if (!isExactObject(value, ["text", "replyTo", "thread"])) {
     throw new MalformedError("invalid body");
   }

--- a/extensions/reef/protocol/federation.test.ts
+++ b/extensions/reef/protocol/federation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { open, seal, validateMessageBody } from "./envelope.js";
+import {
+  createReefFederatedPromptDigest,
+  REEF_FEDERATION_NAMESPACE,
+  validateReefFederationBody,
+  type ReefFederationBody,
+} from "./federation.js";
+import { generateIdentity } from "./identity.js";
+import { MemoryReplayStore } from "./replay.js";
+
+const envelopeId = "01JZ0000000000000000000000";
+
+function proposedBody(text = "inspect the failing build"): ReefFederationBody {
+  const binding = {
+    from: "guest#1",
+    to: "host#2",
+    mountId: "mount-1",
+    proposalId: "proposal-1",
+    sessionId: "session-1",
+    grantGeneration: 3,
+    text,
+  };
+  return {
+    namespace: REEF_FEDERATION_NAMESPACE,
+    frame: {
+      type: "session.prompt.propose",
+      mountId: binding.mountId,
+      proposalId: binding.proposalId,
+      sessionId: binding.sessionId,
+      grantGeneration: binding.grantGeneration,
+      text,
+      textSha256: createReefFederatedPromptDigest(binding),
+    },
+  };
+}
+
+describe("Reef session federation protocol", () => {
+  it("seals and opens a typed federation frame", async () => {
+    const guest = generateIdentity();
+    const host = generateIdentity();
+    const body = proposedBody();
+    const envelope = seal({
+      id: envelopeId,
+      from: "guest#1",
+      to: "host#2",
+      body,
+      senderSigningSecretKey: guest.signing.secretKey,
+      recipientEncryptionPublicKey: host.encryption.publicKey,
+      ts: 1_756_000_000,
+    });
+
+    await expect(
+      open({
+        envelope,
+        self: "host#2",
+        recipientEncryptionSecretKey: host.encryption.secretKey,
+        senderSigningPublicKey: guest.signing.publicKey,
+        replayStore: new MemoryReplayStore(),
+        now: 1_756_000_000,
+      }),
+    ).resolves.toEqual(body);
+  });
+
+  it("binds the digest to both peers and the session authority", () => {
+    const body = proposedBody();
+    const frame = body.frame;
+    if (frame.type !== "session.prompt.propose") {
+      throw new Error("expected prompt frame");
+    }
+    const expected = frame.textSha256;
+    const base = {
+      from: "guest#1",
+      to: "host#2",
+      mountId: frame.mountId,
+      proposalId: frame.proposalId,
+      sessionId: frame.sessionId,
+      grantGeneration: frame.grantGeneration,
+      text: frame.text,
+    };
+
+    expect(createReefFederatedPromptDigest(base)).toBe(expected);
+    expect(createReefFederatedPromptDigest({ ...base, from: "attacker#1" })).not.toBe(expected);
+    expect(createReefFederatedPromptDigest({ ...base, sessionId: "session-2" })).not.toBe(expected);
+    expect(createReefFederatedPromptDigest({ ...base, grantGeneration: 4 })).not.toBe(expected);
+  });
+
+  it("rejects unknown and over-broad federation frames", () => {
+    expect(() =>
+      validateReefFederationBody({
+        ...proposedBody(),
+        frame: { ...proposedBody().frame, unexpected: true },
+      }),
+    ).toThrow("invalid federation frame fields");
+    expect(() =>
+      validateMessageBody({
+        namespace: REEF_FEDERATION_NAMESPACE,
+        frame: { type: "session.prompt.execute", mountId: "mount-1" },
+      }),
+    ).toThrow("invalid federation body");
+  });
+});

--- a/extensions/reef/protocol/federation.ts
+++ b/extensions/reef/protocol/federation.ts
@@ -1,0 +1,173 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+import { canonicalBytes } from "./canonical.js";
+import { decodeUtf8, hex, utf8 } from "./encoding.js";
+
+export const REEF_FEDERATION_NAMESPACE = "openclaw.session-federation.v1";
+export const REEF_FEDERATION_TEXT_MAX_BYTES = 24 * 1024;
+
+type PromptFrameBinding = {
+  mountId: string;
+  proposalId: string;
+  sessionId: string;
+};
+
+export type ReefFederationFrame =
+  | (PromptFrameBinding & {
+      type: "session.prompt.propose";
+      grantGeneration: number;
+      text: string;
+      textSha256: string;
+    })
+  | (PromptFrameBinding & {
+      type: "session.prompt.accepted";
+      runId: string;
+    })
+  | (PromptFrameBinding & {
+      type: "session.prompt.denied";
+      reason: "host-denied" | "grant-revoked" | "stale-session";
+    })
+  | (PromptFrameBinding & {
+      type: "session.prompt.failed";
+      code: string;
+      message: string;
+    })
+  | {
+      type: "session.grant.revoked";
+      mountId: string;
+      sessionId: string;
+      grantGeneration: number;
+    };
+
+export type ReefFederationBody = {
+  namespace: typeof REEF_FEDERATION_NAMESPACE;
+  frame: ReefFederationFrame;
+};
+
+const ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+/** Build the digest that binds a proposed prompt to its exact transport and session authority. */
+export function createReefFederatedPromptDigest(params: {
+  from: string;
+  to: string;
+  mountId: string;
+  proposalId: string;
+  sessionId: string;
+  grantGeneration: number;
+  text: string;
+}): string {
+  return hex(
+    sha256(
+      canonicalBytes({
+        namespace: REEF_FEDERATION_NAMESPACE,
+        type: "session.prompt.propose",
+        ...params,
+      }),
+    ),
+  );
+}
+
+/** Return whether an opened Reef body belongs to the session-federation namespace. */
+export function isReefFederationBody(value: unknown): value is ReefFederationBody {
+  return (
+    isRecord(value) &&
+    value.namespace === REEF_FEDERATION_NAMESPACE &&
+    Object.keys(value).length === 2 &&
+    "frame" in value
+  );
+}
+
+/** Validate a bounded, exact session-federation body before it reaches runtime logic. */
+export function validateReefFederationBody(value: unknown): asserts value is ReefFederationBody {
+  if (!isReefFederationBody(value) || !isRecord(value.frame)) {
+    throw new Error("invalid federation body");
+  }
+  const frame = value.frame;
+  switch (frame.type) {
+    case "session.prompt.propose":
+      assertExactKeys(frame, [
+        "type",
+        "mountId",
+        "proposalId",
+        "sessionId",
+        "grantGeneration",
+        "text",
+        "textSha256",
+      ]);
+      assertPromptBinding(frame);
+      assertGeneration(frame.grantGeneration);
+      assertBoundedText(frame.text, REEF_FEDERATION_TEXT_MAX_BYTES, "prompt text");
+      if (typeof frame.textSha256 !== "string" || !SHA256_PATTERN.test(frame.textSha256)) {
+        throw new Error("invalid prompt digest");
+      }
+      return;
+    case "session.prompt.accepted":
+      assertExactKeys(frame, ["type", "mountId", "proposalId", "sessionId", "runId"]);
+      assertPromptBinding(frame);
+      assertId(frame.runId, "run id");
+      return;
+    case "session.prompt.denied":
+      assertExactKeys(frame, ["type", "mountId", "proposalId", "sessionId", "reason"]);
+      assertPromptBinding(frame);
+      if (!new Set(["host-denied", "grant-revoked", "stale-session"]).has(String(frame.reason))) {
+        throw new Error("invalid denial reason");
+      }
+      return;
+    case "session.prompt.failed":
+      assertExactKeys(frame, ["type", "mountId", "proposalId", "sessionId", "code", "message"]);
+      assertPromptBinding(frame);
+      assertId(frame.code, "failure code");
+      assertBoundedText(frame.message, 512, "failure message");
+      return;
+    case "session.grant.revoked":
+      assertExactKeys(frame, ["type", "mountId", "sessionId", "grantGeneration"]);
+      assertId(frame.mountId, "mount id");
+      assertId(frame.sessionId, "session id");
+      assertGeneration(frame.grantGeneration);
+      return;
+    default:
+      throw new Error("unknown federation frame");
+  }
+}
+
+function assertPromptBinding(value: Record<string, unknown>): void {
+  assertId(value.mountId, "mount id");
+  assertId(value.proposalId, "proposal id");
+  assertId(value.sessionId, "session id");
+}
+
+function assertId(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || !ID_PATTERN.test(value)) {
+    throw new Error(`invalid ${label}`);
+  }
+}
+
+function assertGeneration(value: unknown): asserts value is number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error("invalid grant generation");
+  }
+}
+
+function assertBoundedText(
+  value: unknown,
+  maxBytes: number,
+  label: string,
+): asserts value is string {
+  if (typeof value !== "string" || value.length === 0 || utf8(value).length > maxBytes) {
+    throw new Error(`invalid ${label}`);
+  }
+  if (decodeUtf8(utf8(value)) !== value) {
+    throw new Error(`invalid UTF-8 ${label}`);
+  }
+}
+
+function assertExactKeys(value: Record<string, unknown>, keys: readonly string[]): void {
+  const actual = Object.keys(value);
+  if (actual.length !== keys.length || actual.some((key) => !keys.includes(key))) {
+    throw new Error("invalid federation frame fields");
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/extensions/reef/protocol/federation.ts
+++ b/extensions/reef/protocol/federation.ts
@@ -3,7 +3,7 @@ import { canonicalBytes } from "./canonical.js";
 import { decodeUtf8, hex, utf8 } from "./encoding.js";
 
 export const REEF_FEDERATION_NAMESPACE = "openclaw.session-federation.v1";
-export const REEF_FEDERATION_TEXT_MAX_BYTES = 24 * 1024;
+export const REEF_FEDERATION_TEXT_MAX_BYTES = 512;
 
 type PromptFrameBinding = {
   mountId: string;

--- a/extensions/reef/protocol/federation.ts
+++ b/extensions/reef/protocol/federation.ts
@@ -12,6 +12,13 @@ type PromptFrameBinding = {
 };
 
 export type ReefFederationFrame =
+  | {
+      type: "session.mount.offer";
+      mountId: string;
+      sessionKey: string;
+      sessionId: string;
+      grantGeneration: number;
+    }
   | (PromptFrameBinding & {
       type: "session.prompt.propose";
       grantGeneration: number;
@@ -70,7 +77,7 @@ export function createReefFederatedPromptDigest(params: {
 /** Return whether an opened Reef body belongs to the session-federation namespace. */
 export function isReefFederationBody(value: unknown): value is ReefFederationBody {
   return (
-    isRecord(value) &&
+    isFederationRecord(value) &&
     value.namespace === REEF_FEDERATION_NAMESPACE &&
     Object.keys(value).length === 2 &&
     "frame" in value
@@ -79,11 +86,18 @@ export function isReefFederationBody(value: unknown): value is ReefFederationBod
 
 /** Validate a bounded, exact session-federation body before it reaches runtime logic. */
 export function validateReefFederationBody(value: unknown): asserts value is ReefFederationBody {
-  if (!isReefFederationBody(value) || !isRecord(value.frame)) {
+  if (!isReefFederationBody(value) || !isFederationRecord(value.frame)) {
     throw new Error("invalid federation body");
   }
   const frame = value.frame;
   switch (frame.type) {
+    case "session.mount.offer":
+      assertExactKeys(frame, ["type", "mountId", "sessionKey", "sessionId", "grantGeneration"]);
+      assertId(frame.mountId, "mount id");
+      assertBoundedText(frame.sessionKey, 256, "session key");
+      assertId(frame.sessionId, "session id");
+      assertGeneration(frame.grantGeneration);
+      return;
     case "session.prompt.propose":
       assertExactKeys(frame, [
         "type",
@@ -109,7 +123,7 @@ export function validateReefFederationBody(value: unknown): asserts value is Ree
     case "session.prompt.denied":
       assertExactKeys(frame, ["type", "mountId", "proposalId", "sessionId", "reason"]);
       assertPromptBinding(frame);
-      if (!new Set(["host-denied", "grant-revoked", "stale-session"]).has(String(frame.reason))) {
+      if (!new Set(["host-denied", "grant-revoked", "stale-session"]).has(frame.reason)) {
         throw new Error("invalid denial reason");
       }
       return;
@@ -168,6 +182,6 @@ function assertExactKeys(value: Record<string, unknown>, keys: readonly string[]
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isFederationRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/extensions/reef/protocol/index.ts
+++ b/extensions/reef/protocol/index.ts
@@ -3,6 +3,7 @@ export * from "./canonical.js";
 export * from "./checks.js";
 export * from "./encoding.js";
 export * from "./envelope.js";
+export * from "./federation.js";
 export * from "./friendcode.js";
 export * from "./guard.js";
 export * from "./guard-adapters.js";

--- a/extensions/reef/protocol/pipeline.test.ts
+++ b/extensions/reef/protocol/pipeline.test.ts
@@ -186,8 +186,8 @@ describe("pipeline", () => {
     });
     const inbound = await composeInbound(options);
     expect(inbound.disposition).toBe("accepted");
-    if (inbound.disposition !== "accepted") {
-      throw new Error("expected accepted result");
+    if (inbound.disposition !== "accepted" || "federation" in inbound) {
+      throw new Error("expected accepted chat result");
     }
     expect(inbound.body.text).toBe("hello");
     expect(inbound.receipt).toMatchObject({ id: outbound.envelope.id, status: "accepted" });

--- a/extensions/reef/protocol/pipeline.ts
+++ b/extensions/reef/protocol/pipeline.ts
@@ -10,9 +10,11 @@ import {
   seal,
   validateEnvelopeMetadata,
   validateMessageBody,
+  type ChatMessageBody,
   type Envelope,
   type MessageBody,
 } from "./envelope.js";
+import { isReefFederationBody } from "./federation.js";
 import {
   admitVerdict,
   type GuardAdapter,
@@ -75,7 +77,7 @@ export interface ComposeOutboundOptions extends GuardedPipelineOptions {
   id: string;
   from: string;
   to: string;
-  body: MessageBody;
+  body: ChatMessageBody;
   senderSigningSecretKey: string;
   recipientEncryptionPublicKey: string;
   ts?: number;
@@ -163,7 +165,8 @@ export interface ComposeInboundOptions extends GuardedPipelineOptions {
 }
 
 export type InboundResult =
-  | { disposition: "accepted"; body: MessageBody; verdict: Verdict; receipt: SignedReceipt }
+  | { disposition: "accepted"; body: ChatMessageBody; verdict: Verdict; receipt: SignedReceipt }
+  | { disposition: "accepted"; body: MessageBody; federation: true; receipt: SignedReceipt }
   | { disposition: "duplicate"; body?: MessageBody; receipt: SignedReceipt };
 
 const REPLAY_CLAIM_HEARTBEAT_MS = 60_000;
@@ -201,6 +204,32 @@ export async function composeInbound(options: ComposeInboundOptions): Promise<In
       proposalHash,
       options.policyVersion,
     );
+    if (isReefFederationBody(opened.body)) {
+      await refreshClaim();
+      const inboxEntry = await appendAudit(options.audit, "federation_inbox", {
+        id: options.envelope.id,
+        bodyHash: proposalHash,
+        namespace: opened.body.namespace,
+        frameType: opened.body.frame.type,
+      });
+      const receipt = signReceipt(
+        {
+          id: options.envelope.id,
+          bodyHash: proposalHash,
+          auditHead: inboxEntry.entryHash,
+          status: "accepted",
+        },
+        options.recipientSigningSecretKey,
+      );
+      await appendAudit(options.audit, "receipt", {
+        id: options.envelope.id,
+        approvalDigest,
+        receipt,
+      });
+      await options.replayStore.complete(peer, options.envelope.id, receipt, opened.body);
+      finalized = true;
+      return { disposition: "accepted", body: opened.body, federation: true, receipt };
+    }
     const checks = deterministicChecks(opened.body.text);
     if (!checks.allowed) {
       await refreshClaim();

--- a/extensions/reef/src/channel.test.ts
+++ b/extensions/reef/src/channel.test.ts
@@ -19,6 +19,11 @@ import { runReefChannelLifecycle } from "./channel-lifecycle.js";
 import { reefPlugin } from "./channel.js";
 import { handleReefCommand } from "./commands.js";
 import { resolveReefConfig } from "./config-schema.js";
+import {
+  matchesFederatedPromptPeer,
+  retryFederatedRevocations,
+  retryUnsentFederatedPrompts,
+} from "./federation-recovery.js";
 import { reefKeys } from "./flow.test-helpers.js";
 import { ReefFriendManager } from "./friends.js";
 import { resolveReefInboundDispatchContent } from "./inbound.js";
@@ -181,6 +186,108 @@ describe("Reef conversation directory", () => {
         runtime: defaultRuntime,
       }),
     ).resolves.toEqual([{ kind: "user", id: "molty", name: "@molty's agent", handle: "@molty" }]);
+  });
+});
+
+describe("Reef federation outcome recovery", () => {
+  it("resubmits a durable unsent outcome during reconciliation", () => {
+    const request = {
+      from: "guest#1",
+      to: "host#1",
+      peer: "guest",
+      peerIdentity: {
+        ed25519PublicKey: "A".repeat(43),
+        x25519PublicKey: "B".repeat(43),
+        keyEpoch: 1,
+      },
+      frame: {
+        type: "session.prompt.propose" as const,
+        mountId: "mount-1",
+        proposalId: "proposal-1",
+        sessionId: "session-1",
+        grantGeneration: 0,
+        text: "Check the build",
+        textSha256: "a".repeat(64),
+      },
+    };
+    const outcome = {
+      type: "session.prompt.accepted" as const,
+      mountId: "mount-1",
+      proposalId: "proposal-1",
+      sessionId: "session-1",
+      runId: "run-1",
+    };
+    const start = vi.fn();
+
+    retryUnsentFederatedPrompts(
+      {
+        listUnsentProposals: () => [
+          {
+            proposalId: "proposal-1",
+            mountId: "mount-1",
+            digest: "a".repeat(64),
+            status: "accepted",
+            request,
+            outcome,
+          },
+        ],
+      },
+      start,
+    );
+
+    expect(start).toHaveBeenCalledWith(request, outcome);
+    expect(matchesFederatedPromptPeer(request, request.peerIdentity)).toBe(true);
+    expect(
+      matchesFederatedPromptPeer(request, {
+        ...request.peerIdentity,
+        ed25519PublicKey: "C".repeat(43),
+      }),
+    ).toBe(false);
+    expect(matchesFederatedPromptPeer(request, undefined)).toBe(false);
+  });
+
+  it("retries every durably revoked host grant", async () => {
+    const send = vi.fn(async () => undefined);
+
+    await retryFederatedRevocations(
+      {
+        listMounts: () => [
+          {
+            mountId: "mount-1",
+            peer: "guest",
+            peerIdentity: {
+              ed25519PublicKey: "A".repeat(43),
+              x25519PublicKey: "B".repeat(43),
+              keyEpoch: 1,
+            },
+            role: "host" as const,
+            sessionKey: "agent:main:shared",
+            sessionId: "session-1",
+            grantGeneration: 2,
+            allowAlways: false,
+            revoked: true,
+            revocationPending: true,
+          },
+        ],
+        acknowledgeRevocation: vi.fn(() => true),
+      },
+      send,
+    );
+
+    expect(send).toHaveBeenCalledWith(
+      "guest",
+      {
+        type: "session.grant.revoked",
+        mountId: "mount-1",
+        sessionId: "session-1",
+        grantGeneration: 2,
+      },
+      {
+        ed25519PublicKey: "A".repeat(43),
+        x25519PublicKey: "B".repeat(43),
+        keyEpoch: 1,
+      },
+    );
   });
 });
 

--- a/extensions/reef/src/channel.test.ts
+++ b/extensions/reef/src/channel.test.ts
@@ -14,7 +14,7 @@ import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime
 import { defaultRuntime } from "openclaw/plugin-sdk/runtime";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { generateIdentity } from "../protocol/index.js";
+import { createReefFederatedPromptDigest, generateIdentity, seal } from "../protocol/index.js";
 import { runReefChannelLifecycle } from "./channel-lifecycle.js";
 import { reefPlugin } from "./channel.js";
 import { handleReefCommand } from "./commands.js";
@@ -25,12 +25,14 @@ import {
   retryUnsentFederatedPrompts,
 } from "./federation-recovery.js";
 import { reefKeys } from "./flow.test-helpers.js";
+import { reefPeerIdentity } from "./friend-types.js";
 import { ReefFriendManager } from "./friends.js";
 import { resolveReefInboundDispatchContent } from "./inbound.js";
-import { getActiveReef, setReefRuntime } from "./runtime.js";
+import { getActiveReef, getReefRuntime, setReefRuntime } from "./runtime.js";
 import {
   finalizeReefIdentityBinding,
   generateAndStoreKeys,
+  loadKeys,
   reserveReefIdentityBinding,
 } from "./state.js";
 import { ReefInboxConnection, ReefTransportClient } from "./transport.js";
@@ -411,6 +413,136 @@ describe("Reef gateway account ownership", () => {
     }
     return send({ cfg, accountId: "default", to: "@molty", text });
   }
+
+  it("returns and acknowledges peer-capacity without agent work or blocking later inbox entries", async () => {
+    startAccount();
+    await vi.waitFor(() => expect(inboxDrains).toHaveLength(1));
+    const active = getActiveReef();
+    const runtime = getReefRuntime();
+    const hostKeys = await loadKeys(runtime);
+    const guestKeys = generateIdentity();
+    const guestTrust = {
+      autonomy: "bounded" as const,
+      ed25519PublicKey: guestKeys.signing.publicKey,
+      x25519PublicKey: guestKeys.encryption.publicKey,
+      keyEpoch: 1,
+      safetyNumberChanged: false,
+      approvedAt: 1,
+    };
+    active.trust.set("guest", guestTrust);
+    const peerIdentity = reefPeerIdentity(guestTrust);
+    const mountId = "mount-capacity";
+    const sessionId = "session-capacity";
+    for (let index = 0; index < 128; index += 1) {
+      const frame = {
+        type: "session.prompt.propose" as const,
+        mountId,
+        proposalId: `retained-${index}`,
+        sessionId,
+        grantGeneration: 0,
+        text: `retained ${index}`,
+        textSha256: index.toString(16).padStart(64, "0"),
+      };
+      expect(
+        active.federation.claimPrompt({
+          from: "guest#1",
+          to: "clawd#1",
+          peer: "guest",
+          peerIdentity,
+          frame,
+        }),
+      ).toBe("new");
+    }
+    const binding = {
+      from: "guest#1",
+      to: "clawd#1",
+      mountId,
+      proposalId: "over-capacity",
+      sessionId,
+      grantGeneration: 0,
+      text: "capacity probe",
+    };
+    const frame = {
+      type: "session.prompt.propose" as const,
+      mountId,
+      proposalId: binding.proposalId,
+      sessionId,
+      grantGeneration: 0,
+      text: binding.text,
+      textSha256: createReefFederatedPromptDigest(binding),
+    };
+    const envelope = seal({
+      id: "01JZ0000000000000000000137",
+      from: binding.from,
+      to: binding.to,
+      body: { namespace: "openclaw.session-federation.v1", frame },
+      senderSigningSecretKey: guestKeys.signing.secretKey,
+      recipientEncryptionPublicKey: hostKeys.encryption.publicKey,
+    });
+    const nextMountEnvelope = seal({
+      id: "01JZ0000000000000000000138",
+      from: binding.from,
+      to: binding.to,
+      body: {
+        namespace: "openclaw.session-federation.v1",
+        frame: {
+          type: "session.prompt.accepted",
+          mountId: "mount-after-capacity",
+          proposalId: "after-capacity",
+          sessionId,
+          runId: "run-after-capacity",
+        },
+      },
+      senderSigningSecretKey: guestKeys.signing.secretKey,
+      recipientEncryptionPublicKey: hostKeys.encryption.publicKey,
+    });
+    const acknowledge = vi
+      .spyOn(ReefTransportClient.prototype, "acknowledge")
+      .mockResolvedValue({ result: "deleted" });
+    const sendFederation = vi
+      .spyOn(active.flow, "sendFederation")
+      .mockRejectedValueOnce(new Error("relay unavailable"))
+      .mockResolvedValue("outcome-1");
+    const gatewayRequest = vi.mocked(runtime.gateway.request);
+    const capacityEntry = {
+      seq: 1,
+      peer: "guest",
+      id: envelope.id,
+      kind: "message" as const,
+      envelope,
+      ts: 1,
+    };
+
+    await expect(active.flow.processEntries([capacityEntry])).rejects.toThrow("relay unavailable");
+    expect(acknowledge).not.toHaveBeenCalled();
+    await active.flow.processEntries([
+      { ...capacityEntry, seq: 2 },
+      {
+        seq: 3,
+        peer: "guest",
+        id: nextMountEnvelope.id,
+        kind: "message",
+        envelope: nextMountEnvelope,
+        ts: 2,
+      },
+    ]);
+
+    await vi.waitFor(() =>
+      expect(sendFederation).toHaveBeenCalledWith(
+        "guest",
+        expect.objectContaining({
+          type: "session.prompt.failed",
+          proposalId: "over-capacity",
+          code: "peer-capacity",
+        }),
+        { expectedRecipient: peerIdentity },
+      ),
+    );
+    expect(sendFederation).toHaveBeenCalledTimes(2);
+    expect(acknowledge).toHaveBeenCalledTimes(2);
+    expect(gatewayRequest).not.toHaveBeenCalled();
+    expect(active.federation.listUnsentProposals()).toHaveLength(128);
+  });
 
   it("retires outbound, command, and pairing authority before account shutdown drains", async () => {
     const account = startAccount();

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -363,7 +363,10 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         handle: ctx.account.config.handle!,
       });
       const federation = new ReefFederationState(runtime);
-      const federationCoordinator = new ReefFederationCoordinator(runtime, federation);
+      const federationCoordinator = new ReefFederationCoordinator(runtime, federation, (peer) => {
+        const friend = trust.get(peer);
+        return friend && !friend.safetyNumberChanged ? friend.keyEpoch : undefined;
+      });
       const flow = new ReefMessageFlow({
         config: ctx.account.config,
         trust,

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -12,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/core";
 import { createChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
 import { channelReadyPatch } from "openclaw/plugin-sdk/gateway-runtime";
+import type { ReefFederationFrame } from "../protocol/federation.js";
 import { runReefChannelLifecycle } from "./channel-lifecycle.js";
 import {
   ReefChannelConfigSchema,
@@ -22,7 +23,7 @@ import {
   type ReefCoreConfig,
 } from "./config-schema.js";
 import { ReefFederationCoordinator } from "./federation-coordinator.js";
-import { ReefFederationState } from "./federation-state.js";
+import { ReefFederationState, type ReefFederationPromptRequest } from "./federation-state.js";
 import { createConfiguredGuard, ReefMessageFlow } from "./flow.js";
 import { ReefFriendManager } from "./friends.js";
 import { resolveReefInboundDispatchContent } from "./inbound.js";
@@ -53,10 +54,7 @@ import type { ReefAccount, ReefIngressMessage } from "./types.js";
 
 function formatFederationOutcome(
   peer: string,
-  frame: Exclude<
-    import("../protocol/federation.js").ReefFederationFrame,
-    { type: "session.mount.offer" | "session.prompt.propose" }
-  >,
+  frame: Exclude<ReefFederationFrame, { type: "session.mount.offer" | "session.prompt.propose" }>,
 ): string {
   switch (frame.type) {
     case "session.prompt.accepted":
@@ -367,6 +365,43 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         const friend = trust.get(peer);
         return friend && !friend.safetyNumberChanged ? friend.keyEpoch : undefined;
       });
+      const federationTasks = new Map<string, Promise<void>>();
+      const startFederatedPrompt = (
+        request: ReefFederationPromptRequest,
+        storedOutcome?: Exclude<
+          ReefFederationFrame,
+          { type: "session.mount.offer" | "session.prompt.propose" }
+        >,
+      ) => {
+        const taskKey = `${request.frame.proposalId}:${request.frame.textSha256}`;
+        if (federationTasks.has(taskKey)) {
+          return;
+        }
+        const task = (async () => {
+          const outcome = storedOutcome ?? (await federationCoordinator.handlePrompt(request));
+          await flow.sendFederation(request.peer, outcome);
+          if (!federation.markOutcomeSent(request.frame.proposalId, request.frame.textSha256)) {
+            throw new Error(`Reef proposal ${request.frame.proposalId} lost its durable outcome`);
+          }
+        })();
+        federationTasks.set(taskKey, task);
+        void task
+          .catch(async (error: unknown) => {
+            ctx.log?.error?.(
+              `reef federated prompt ${request.frame.proposalId} failed: ${String(error)}`,
+            );
+            try {
+              await ownerNotice({
+                text: `Reef prompt ${request.frame.proposalId} is pending retry after a local failure.`,
+                peer: request.peer,
+                contextKey: `reef:federation:${request.frame.proposalId}:retry`,
+              });
+            } catch (noticeError) {
+              ctx.log?.error?.(`reef federation retry notice failed: ${String(noticeError)}`);
+            }
+          })
+          .finally(() => federationTasks.delete(taskKey));
+      };
       const flow = new ReefMessageFlow({
         config: ctx.account.config,
         trust,
@@ -385,7 +420,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
             if (!friend || friend.safetyNumberChanged) {
               throw new Error(`unapproved Reef sender @${peer}`);
             }
-            federation.createMount({
+            const created = federation.createMount({
               mountId: frame.mountId,
               peer,
               peerKeyEpoch: friend.keyEpoch,
@@ -397,7 +432,9 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
               revoked: false,
             });
             await ownerNotice({
-              text: `Reef session mount ${frame.mountId} from @${peer} is ready.`,
+              text: created
+                ? `Reef session mount ${frame.mountId} from @${peer} is ready.`
+                : `Reef session mount ${frame.mountId} from @${peer} was rejected because its identifier already exists or that peer reached its mount limit.`,
               peer,
               contextKey: `reef:federation:${frame.mountId}`,
             });
@@ -408,14 +445,13 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
             if (!friend || friend.safetyNumberChanged) {
               throw new Error(`unapproved Reef sender @${peer}`);
             }
-            const outcome = await federationCoordinator.handlePrompt({
+            startFederatedPrompt({
               from,
               to,
               peer,
               peerKeyEpoch: friend.keyEpoch,
               frame,
             });
-            await flow.sendFederation(peer, outcome);
             return;
           }
           if (frame.type === "session.grant.revoked") {
@@ -531,6 +567,9 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           return;
         }
         authority.activate({ flow, friends, reviews, federation, trust });
+        for (const proposal of federation.listUnsentProposals()) {
+          startFederatedPrompt(proposal.request, proposal.outcome);
+        }
         ctx.setStatus({ accountId: "default", running: true, connected: false });
       };
       const inbox = new ReefInboxConnection(

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -394,6 +394,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
               sessionId: frame.sessionId,
               grantGeneration: frame.grantGeneration,
               allowAlways: false,
+              revoked: false,
             });
             await ownerNotice({
               text: `Reef session mount ${frame.mountId} from @${peer} is ready.`,

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -25,6 +25,7 @@ import {
 import { ReefFederationCoordinator } from "./federation-coordinator.js";
 import { ReefFederationState, type ReefFederationPromptRequest } from "./federation-state.js";
 import { createConfiguredGuard, ReefMessageFlow } from "./flow.js";
+import { reefPeerIdentity } from "./friend-types.js";
 import { ReefFriendManager } from "./friends.js";
 import { resolveReefInboundDispatchContent } from "./inbound.js";
 import { reefMessageAdapter, reefOutboundAdapter } from "./outbound.js";
@@ -363,7 +364,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
       const federation = new ReefFederationState(runtime);
       const federationCoordinator = new ReefFederationCoordinator(runtime, federation, (peer) => {
         const friend = trust.get(peer);
-        return friend && !friend.safetyNumberChanged ? friend.keyEpoch : undefined;
+        return friend && !friend.safetyNumberChanged ? reefPeerIdentity(friend) : undefined;
       });
       const federationTasks = new Map<string, Promise<void>>();
       const startFederatedPrompt = (
@@ -423,7 +424,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
             const created = federation.createMount({
               mountId: frame.mountId,
               peer,
-              peerKeyEpoch: friend.keyEpoch,
+              peerIdentity: reefPeerIdentity(friend),
               role: "guest",
               sessionKey: frame.sessionKey,
               sessionId: frame.sessionId,
@@ -449,7 +450,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
               from,
               to,
               peer,
-              peerKeyEpoch: friend.keyEpoch,
+              peerIdentity: reefPeerIdentity(friend),
               frame,
             });
             return;

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -21,6 +21,8 @@ import {
   resolveReefConfig,
   type ReefCoreConfig,
 } from "./config-schema.js";
+import { ReefFederationCoordinator } from "./federation-coordinator.js";
+import { ReefFederationState } from "./federation-state.js";
 import { createConfiguredGuard, ReefMessageFlow } from "./flow.js";
 import { ReefFriendManager } from "./friends.js";
 import { resolveReefInboundDispatchContent } from "./inbound.js";
@@ -48,6 +50,26 @@ import {
 } from "./transport.js";
 import { isReefPairingApprovalToken, openReefTrustStore } from "./trust-store.js";
 import type { ReefAccount, ReefIngressMessage } from "./types.js";
+
+function formatFederationOutcome(
+  peer: string,
+  frame: Exclude<
+    import("../protocol/federation.js").ReefFederationFrame,
+    { type: "session.mount.offer" | "session.prompt.propose" }
+  >,
+): string {
+  switch (frame.type) {
+    case "session.prompt.accepted":
+      return `Reef prompt ${frame.proposalId} was accepted by @${peer}.`;
+    case "session.prompt.denied":
+      return `Reef prompt ${frame.proposalId} was denied by @${peer}: ${frame.reason}.`;
+    case "session.prompt.failed":
+      return `Reef prompt ${frame.proposalId} failed at @${peer}: ${frame.message}`;
+    case "session.grant.revoked":
+      return `Reef session mount ${frame.mountId} was revoked by @${peer}.`;
+  }
+  throw new Error("unsupported Reef federation outcome");
+}
 
 function resolveAccount(cfg: unknown): ReefAccount {
   const config = resolveReefConfig(cfg as ReefCoreConfig);
@@ -340,7 +362,9 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         accountId: "default",
         handle: ctx.account.config.handle!,
       });
-      const flow: ReefMessageFlow = new ReefMessageFlow({
+      const federation = new ReefFederationState(runtime);
+      const federationCoordinator = new ReefFederationCoordinator(runtime, federation);
+      const flow = new ReefMessageFlow({
         config: ctx.account.config,
         trust,
         keys,
@@ -352,6 +376,53 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         delivered: stores.delivered,
         authoritySignal: authority.signal,
         onIngress,
+        onFederation: async ({ peer, from, to, frame }) => {
+          if (frame.type === "session.mount.offer") {
+            const friend = trust.get(peer);
+            if (!friend || friend.safetyNumberChanged) {
+              throw new Error(`unapproved Reef sender @${peer}`);
+            }
+            federation.createMount({
+              mountId: frame.mountId,
+              peer,
+              peerKeyEpoch: friend.keyEpoch,
+              role: "guest",
+              sessionKey: frame.sessionKey,
+              sessionId: frame.sessionId,
+              grantGeneration: frame.grantGeneration,
+              allowAlways: false,
+            });
+            await ownerNotice({
+              text: `Reef session mount ${frame.mountId} from @${peer} is ready.`,
+              peer,
+              contextKey: `reef:federation:${frame.mountId}`,
+            });
+            return;
+          }
+          if (frame.type === "session.prompt.propose") {
+            const friend = trust.get(peer);
+            if (!friend || friend.safetyNumberChanged) {
+              throw new Error(`unapproved Reef sender @${peer}`);
+            }
+            const outcome = await federationCoordinator.handlePrompt({
+              from,
+              to,
+              peer,
+              peerKeyEpoch: friend.keyEpoch,
+              frame,
+            });
+            await flow.sendFederation(peer, outcome);
+            return;
+          }
+          if (frame.type === "session.grant.revoked") {
+            federation.applyRevocation(frame.mountId, frame.grantGeneration);
+          }
+          await ownerNotice({
+            text: formatFederationOutcome(peer, frame),
+            peer,
+            contextKey: `reef:federation:${frame.mountId}:${"proposalId" in frame ? frame.proposalId : frame.grantGeneration}`,
+          });
+        },
         onOwnerNotice: async (text) =>
           ownerNotice({
             text,
@@ -455,7 +526,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         if (ctx.abortSignal.aborted) {
           return;
         }
-        authority.activate({ flow, friends, reviews });
+        authority.activate({ flow, friends, reviews, federation, trust });
         ctx.setStatus({ accountId: "default", running: true, connected: false });
       };
       const inbox = new ReefInboxConnection(

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -485,7 +485,9 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
               peerIdentity: reefPeerIdentity(friend),
               frame,
             };
-            await startFederatedPrompt(request);
+            // The synchronous prefix durably claims the proposal before returning. Approval and
+            // agent dispatch continue under the account-owned task so one peer cannot stall ingress.
+            void startFederatedPrompt(request);
             return;
           }
           const friend = trust.get(peer);

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -362,10 +362,15 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         handle: ctx.account.config.handle!,
       });
       const federation = new ReefFederationState(runtime);
-      const federationCoordinator = new ReefFederationCoordinator(runtime, federation, (peer) => {
-        const friend = trust.get(peer);
-        return friend && !friend.safetyNumberChanged ? reefPeerIdentity(friend) : undefined;
-      });
+      const federationCoordinator = new ReefFederationCoordinator(
+        runtime,
+        federation,
+        (peer) => {
+          const friend = trust.get(peer);
+          return friend && !friend.safetyNumberChanged ? reefPeerIdentity(friend) : undefined;
+        },
+        authority.signal,
+      );
       const federationTasks = new Map<string, Promise<void>>();
       const startFederatedPrompt = (
         request: ReefFederationPromptRequest,

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -23,6 +23,11 @@ import {
   type ReefCoreConfig,
 } from "./config-schema.js";
 import { ReefFederationCoordinator } from "./federation-coordinator.js";
+import {
+  matchesFederatedPromptPeer,
+  retryFederatedRevocations,
+  retryUnsentFederatedPrompts,
+} from "./federation-recovery.js";
 import { ReefFederationState, type ReefFederationPromptRequest } from "./federation-state.js";
 import { createConfiguredGuard, ReefMessageFlow } from "./flow.js";
 import { reefPeerIdentity } from "./friend-types.js";
@@ -361,7 +366,11 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         accountId: "default",
         handle: ctx.account.config.handle!,
       });
-      const federation = new ReefFederationState(runtime);
+      const federation = new ReefFederationState(
+        runtime,
+        authority.signal,
+        `${keys.keyEpoch}:${keys.signing.publicKey}:${keys.encryption.publicKey}`,
+      );
       const federationCoordinator = new ReefFederationCoordinator(
         runtime,
         federation,
@@ -378,14 +387,31 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           ReefFederationFrame,
           { type: "session.mount.offer" | "session.prompt.propose" }
         >,
-      ) => {
+      ): Promise<void> => {
         const taskKey = `${request.frame.proposalId}:${request.frame.textSha256}`;
-        if (federationTasks.has(taskKey)) {
-          return;
+        const running = federationTasks.get(taskKey);
+        if (running) {
+          return running;
         }
         const task = (async () => {
           const outcome = storedOutcome ?? (await federationCoordinator.handlePrompt(request));
-          await flow.sendFederation(request.peer, outcome);
+          const friend = trust.get(request.peer);
+          const currentPeerIdentity =
+            friend && !friend.safetyNumberChanged ? reefPeerIdentity(friend) : undefined;
+          if (!matchesFederatedPromptPeer(request, currentPeerIdentity)) {
+            if (!federation.abandonOutcome(request.frame.proposalId, request.frame.textSha256)) {
+              throw new Error(`Reef proposal ${request.frame.proposalId} lost its durable outcome`);
+            }
+            await ownerNotice({
+              text: `Reef prompt ${request.frame.proposalId} outcome was not sent because @${request.peer}'s identity changed.`,
+              peer: request.peer,
+              contextKey: `reef:federation:${request.frame.proposalId}:identity-changed`,
+            });
+            return;
+          }
+          await flow.sendFederation(request.peer, outcome, {
+            expectedRecipient: request.peerIdentity,
+          });
           if (!federation.markOutcomeSent(request.frame.proposalId, request.frame.textSha256)) {
             throw new Error(`Reef proposal ${request.frame.proposalId} lost its durable outcome`);
           }
@@ -407,6 +433,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
             }
           })
           .finally(() => federationTasks.delete(taskKey));
+        return task;
       };
       const flow = new ReefMessageFlow({
         config: ctx.account.config,
@@ -451,17 +478,34 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
             if (!friend || friend.safetyNumberChanged) {
               throw new Error(`unapproved Reef sender @${peer}`);
             }
-            startFederatedPrompt({
+            const request = {
               from,
               to,
               peer,
               peerIdentity: reefPeerIdentity(friend),
               frame,
-            });
+            };
+            await startFederatedPrompt(request);
             return;
           }
+          const friend = trust.get(peer);
+          if (!friend || friend.safetyNumberChanged) {
+            throw new Error(`unapproved Reef sender @${peer}`);
+          }
+          const peerIdentity = reefPeerIdentity(friend);
           if (frame.type === "session.grant.revoked") {
-            federation.applyRevocation(frame.mountId, frame.grantGeneration);
+            const applied = federation.applyRevocation({
+              mountId: frame.mountId,
+              peer,
+              peerIdentity,
+              sessionId: frame.sessionId,
+              generation: frame.grantGeneration,
+            });
+            if (!applied) {
+              return;
+            }
+          } else if (federation.acceptOutboundOutcome(peer, peerIdentity, frame) === "invalid") {
+            return;
           }
           await ownerNotice({
             text: formatFederationOutcome(peer, frame),
@@ -573,9 +617,14 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           return;
         }
         authority.activate({ flow, friends, reviews, federation, trust });
-        for (const proposal of federation.listUnsentProposals()) {
-          startFederatedPrompt(proposal.request, proposal.outcome);
-        }
+        retryUnsentFederatedPrompts(federation, startFederatedPrompt);
+        await retryFederatedRevocations(
+          federation,
+          (peer, frame, peerIdentity) =>
+            flow.sendFederation(peer, frame, { expectedRecipient: peerIdentity }),
+          (error, peer) =>
+            ctx.log?.warn?.(`reef revocation retry failed for @${peer}: ${String(error)}`),
+        );
         ctx.setStatus({ accountId: "default", running: true, connected: false });
       };
       const inbox = new ReefInboxConnection(
@@ -640,6 +689,15 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
               signal.throwIfAborted();
               ctx.log?.warn?.(`reef inbox poll failed: ${String(error)}`);
             }
+            signal.throwIfAborted();
+            retryUnsentFederatedPrompts(federation, startFederatedPrompt);
+            await retryFederatedRevocations(
+              federation,
+              (peer, frame, peerIdentity) =>
+                flow.sendFederation(peer, frame, { expectedRecipient: peerIdentity }),
+              (error, peer) =>
+                ctx.log?.warn?.(`reef revocation retry failed for @${peer}: ${String(error)}`),
+            );
             if (reconcileError) {
               throw reconcileError;
             }

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -387,6 +387,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           ReefFederationFrame,
           { type: "session.mount.offer" | "session.prompt.propose" }
         >,
+        claim?: ReturnType<ReefFederationCoordinator["claimPrompt"]>,
       ): Promise<void> => {
         const taskKey = `${request.frame.proposalId}:${request.frame.textSha256}`;
         const running = federationTasks.get(taskKey);
@@ -394,7 +395,8 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           return running;
         }
         const task = (async () => {
-          const outcome = storedOutcome ?? (await federationCoordinator.handlePrompt(request));
+          const outcome =
+            storedOutcome ?? (await federationCoordinator.handlePrompt(request, claim));
           const friend = trust.get(request.peer);
           const currentPeerIdentity =
             friend && !friend.safetyNumberChanged ? reefPeerIdentity(friend) : undefined;
@@ -485,9 +487,13 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
               peerIdentity: reefPeerIdentity(friend),
               frame,
             };
-            // The synchronous prefix durably claims the proposal before returning. Approval and
-            // agent dispatch continue under the account-owned task so one peer cannot stall ingress.
-            void startFederatedPrompt(request);
+            const claim = federationCoordinator.claimPrompt(request);
+            if (claim.result === "peer-capacity") {
+              throw new Error(`Reef peer @${peer} exceeded retained prompt capacity`);
+            }
+            // Approval and agent dispatch continue under the account-owned task so one peer cannot
+            // stall ingress after the durable proposal claim succeeds.
+            void startFederatedPrompt(request, undefined, claim);
             return;
           }
           const friend = trust.get(peer);

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -23,6 +23,7 @@ import {
   type ReefCoreConfig,
 } from "./config-schema.js";
 import { ReefFederationCoordinator } from "./federation-coordinator.js";
+import { formatReefFederationOutcome } from "./federation-outcome.js";
 import {
   matchesFederatedPromptPeer,
   retryFederatedRevocations,
@@ -32,7 +33,7 @@ import { ReefFederationState, type ReefFederationPromptRequest } from "./federat
 import { createConfiguredGuard, ReefMessageFlow } from "./flow.js";
 import { reefPeerIdentity } from "./friend-types.js";
 import { ReefFriendManager } from "./friends.js";
-import { resolveReefInboundDispatchContent } from "./inbound.js";
+import { resolveReefInboundDispatchContent, resolveReefReplyText } from "./inbound.js";
 import { reefMessageAdapter, reefOutboundAdapter } from "./outbound.js";
 import {
   createReefOwnerNoticeHandler,
@@ -57,23 +58,6 @@ import {
 } from "./transport.js";
 import { isReefPairingApprovalToken, openReefTrustStore } from "./trust-store.js";
 import type { ReefAccount, ReefIngressMessage } from "./types.js";
-
-function formatFederationOutcome(
-  peer: string,
-  frame: Exclude<ReefFederationFrame, { type: "session.mount.offer" | "session.prompt.propose" }>,
-): string {
-  switch (frame.type) {
-    case "session.prompt.accepted":
-      return `Reef prompt ${frame.proposalId} was accepted by @${peer}.`;
-    case "session.prompt.denied":
-      return `Reef prompt ${frame.proposalId} was denied by @${peer}: ${frame.reason}.`;
-    case "session.prompt.failed":
-      return `Reef prompt ${frame.proposalId} failed at @${peer}: ${frame.message}`;
-    case "session.grant.revoked":
-      return `Reef session mount ${frame.mountId} was revoked by @${peer}.`;
-  }
-  throw new Error("unsupported Reef federation outcome");
-}
 
 function resolveAccount(cfg: unknown): ReefAccount {
   const config = resolveReefConfig(cfg as ReefCoreConfig);
@@ -115,15 +99,6 @@ function listTrustedPeerDirectoryEntries(params: {
     name: `@${peer}'s agent`,
     handle: `@${peer}`,
   }));
-}
-
-function replyText(payload: unknown): string {
-  if (!payload || typeof payload !== "object" || !("text" in payload)) {
-    return "";
-  }
-  return typeof (payload as { text?: unknown }).text === "string"
-    ? (payload as { text: string }).text
-    : "";
 }
 
 function matchesReefToolTarget(target: string, toolContext?: ChannelThreadingToolContext): boolean {
@@ -346,7 +321,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           // ReefMessageFlow invokes ingress only after peer trust and guard approval.
           inboundAccessAuthorized: true,
           deliver: async (payload) => {
-            const text = replyText(payload);
+            const text = resolveReefReplyText(payload);
             if (text.trim()) {
               await flow.send(message.peer, text, {
                 thread: message.thread ?? message.id,
@@ -414,7 +389,10 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           await flow.sendFederation(request.peer, outcome, {
             expectedRecipient: request.peerIdentity,
           });
-          if (!federation.markOutcomeSent(request.frame.proposalId, request.frame.textSha256)) {
+          const sent =
+            claim?.result === "peer-capacity" ||
+            federation.markOutcomeSent(request.frame.proposalId, request.frame.textSha256);
+          if (!sent) {
             throw new Error(`Reef proposal ${request.frame.proposalId} lost its durable outcome`);
           }
         })();
@@ -488,12 +466,10 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
               frame,
             };
             const claim = federationCoordinator.claimPrompt(request);
+            const task = startFederatedPrompt(request, undefined, claim);
             if (claim.result === "peer-capacity") {
-              throw new Error(`Reef peer @${peer} exceeded retained prompt capacity`);
+              await task;
             }
-            // Approval and agent dispatch continue under the account-owned task so one peer cannot
-            // stall ingress after the durable proposal claim succeeds.
-            void startFederatedPrompt(request, undefined, claim);
             return;
           }
           const friend = trust.get(peer);
@@ -516,7 +492,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
             return;
           }
           await ownerNotice({
-            text: formatFederationOutcome(peer, frame),
+            text: formatReefFederationOutcome(peer, frame),
             peer,
             contextKey: `reef:federation:${frame.mountId}:${"proposalId" in frame ? frame.proposalId : frame.grantGeneration}`,
           });
@@ -555,7 +531,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
               if (!notice.allowResend) {
                 return;
               }
-              const text = replyText(payload);
+              const text = resolveReefReplyText(payload);
               if (text.trim()) {
                 resendText = text;
               }

--- a/extensions/reef/src/commands.test.ts
+++ b/extensions/reef/src/commands.test.ts
@@ -82,6 +82,20 @@ describe("Reef session commands", () => {
     );
   });
 
+  it("reports mount quota rejection without sending an offer", async () => {
+    mocks.federation.createMount.mockReturnValueOnce(false);
+
+    await expect(
+      handleReefCommand({
+        args: "session share @guest agent:main:shared",
+        senderIsOwner: true,
+      }),
+    ).resolves.toEqual({
+      text: "Could not create a Reef session mount for @guest; retry after older mounts expire.",
+    });
+    expect(mocks.flow.sendFederation).not.toHaveBeenCalled();
+  });
+
   it("submits and revokes an existing mount", async () => {
     const mount = {
       mountId: "mount-1",

--- a/extensions/reef/src/commands.test.ts
+++ b/extensions/reef/src/commands.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const mounts = new Map<string, Record<string, unknown>>();
+  const federation = {
+    createMount: vi.fn((mount: Record<string, unknown>) => {
+      mounts.set(String(mount.mountId), mount);
+      return true;
+    }),
+    getMount: vi.fn((mountId: string) => mounts.get(mountId)),
+    listMounts: vi.fn(() => [...mounts.values()]),
+    revoke: vi.fn((mountId: string, generation: number) => {
+      const mount = mounts.get(mountId);
+      if (!mount) {
+        return undefined;
+      }
+      const revoked = { ...mount, allowAlways: false, grantGeneration: generation + 1 };
+      mounts.set(mountId, revoked);
+      return revoked;
+    }),
+  };
+  const flow = {
+    sendFederation: vi.fn(async () => "envelope-1"),
+    proposeFederatedPrompt: vi.fn(async () => "proposal-1"),
+  };
+  const trust = {
+    get: vi.fn(() => ({ keyEpoch: 1, safetyNumberChanged: false })),
+  };
+  const gatewayRequest = vi.fn(async () => ({
+    sessions: [{ key: "agent:main:shared", sessionId: "session-1" }],
+  }));
+  return { mounts, federation, flow, trust, gatewayRequest };
+});
+
+vi.mock("./runtime.js", () => ({
+  getActiveReef: () => ({
+    federation: mocks.federation,
+    flow: mocks.flow,
+    trust: mocks.trust,
+    friends: {},
+    reviews: {},
+  }),
+  getReefRuntime: () => ({ gateway: { request: mocks.gatewayRequest } }),
+}));
+
+import { handleReefCommand } from "./commands.js";
+
+describe("Reef session commands", () => {
+  beforeEach(() => {
+    mocks.mounts.clear();
+    vi.clearAllMocks();
+  });
+
+  it("shares an exact session incarnation with a trusted peer", async () => {
+    const result = await handleReefCommand({
+      args: "session share @guest agent:main:shared",
+      senderIsOwner: true,
+    });
+
+    expect(result.text).toMatch(/^Shared agent:main:shared with @guest as mount reef-mount-/);
+    const mount = mocks.federation.createMount.mock.calls[0]![0];
+    expect(mount).toMatchObject({
+      peer: "guest",
+      peerKeyEpoch: 1,
+      role: "host",
+      sessionKey: "agent:main:shared",
+      sessionId: "session-1",
+      grantGeneration: 0,
+    });
+    expect(mocks.flow.sendFederation).toHaveBeenCalledWith(
+      "guest",
+      expect.objectContaining({
+        type: "session.mount.offer",
+        mountId: mount.mountId,
+        sessionId: "session-1",
+      }),
+    );
+  });
+
+  it("submits and revokes an existing mount", async () => {
+    const mount = {
+      mountId: "mount-1",
+      peer: "host",
+      peerKeyEpoch: 1,
+      role: "guest",
+      sessionKey: "agent:main:shared",
+      sessionId: "session-1",
+      grantGeneration: 0,
+      allowAlways: false,
+    };
+    mocks.mounts.set(mount.mountId, mount);
+
+    await expect(
+      handleReefCommand({
+        args: "session prompt mount-1 Check the current build",
+        senderIsOwner: true,
+      }),
+    ).resolves.toEqual({ text: "Sent Reef prompt proposal proposal-1." });
+    expect(mocks.flow.proposeFederatedPrompt).toHaveBeenCalledWith(
+      mount,
+      "Check the current build",
+    );
+    mocks.mounts.set(mount.mountId, { ...mount, role: "host", peer: "host" });
+
+    await expect(
+      handleReefCommand({ args: "session revoke mount-1", senderIsOwner: true }),
+    ).resolves.toEqual({ text: "Revoked Reef session mount mount-1." });
+    expect(mocks.flow.sendFederation).toHaveBeenCalledWith("host", {
+      type: "session.grant.revoked",
+      mountId: "mount-1",
+      sessionId: "session-1",
+      grantGeneration: 1,
+    });
+  });
+
+  it("keeps session mutation commands owner-only", async () => {
+    await expect(
+      handleReefCommand({ args: "session prompt mount-1 hello", senderIsOwner: false }),
+    ).resolves.toEqual({
+      text: "Only an owner in commands.ownerAllowFrom can change Reef friends or decide reviews. Ask a configured owner; friendship changes can also use openclaw reef locally.",
+    });
+    expect(mocks.flow.proposeFederatedPrompt).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/reef/src/commands.test.ts
+++ b/extensions/reef/src/commands.test.ts
@@ -29,7 +29,12 @@ const mocks = vi.hoisted(() => {
     proposeFederatedPrompt: vi.fn(async () => "proposal-1"),
   };
   const trust = {
-    get: vi.fn(() => ({ keyEpoch: 1, safetyNumberChanged: false })),
+    get: vi.fn(() => ({
+      ed25519PublicKey: "A".repeat(43),
+      x25519PublicKey: "B".repeat(43),
+      keyEpoch: 1,
+      safetyNumberChanged: false,
+    })),
   };
   const gatewayRequest = vi.fn(async () => ({
     sessions: [{ key: "agent:main:shared", sessionId: "session-1" }],
@@ -66,7 +71,7 @@ describe("Reef session commands", () => {
     const mount = mocks.federation.createMount.mock.calls[0]![0];
     expect(mount).toMatchObject({
       peer: "guest",
-      peerKeyEpoch: 1,
+      peerIdentity: expect.objectContaining({ keyEpoch: 1 }),
       role: "host",
       sessionKey: "agent:main:shared",
       sessionId: "session-1",
@@ -100,7 +105,11 @@ describe("Reef session commands", () => {
     const mount = {
       mountId: "mount-1",
       peer: "host",
-      peerKeyEpoch: 1,
+      peerIdentity: {
+        ed25519PublicKey: "A".repeat(43),
+        x25519PublicKey: "B".repeat(43),
+        keyEpoch: 1,
+      },
       role: "guest",
       sessionKey: "agent:main:shared",
       sessionId: "session-1",

--- a/extensions/reef/src/commands.test.ts
+++ b/extensions/reef/src/commands.test.ts
@@ -14,7 +14,12 @@ const mocks = vi.hoisted(() => {
       if (!mount) {
         return undefined;
       }
-      const revoked = { ...mount, allowAlways: false, grantGeneration: generation + 1 };
+      const revoked = {
+        ...mount,
+        allowAlways: false,
+        revoked: true,
+        grantGeneration: generation + 1,
+      };
       mounts.set(mountId, revoked);
       return revoked;
     }),
@@ -87,6 +92,7 @@ describe("Reef session commands", () => {
       sessionId: "session-1",
       grantGeneration: 0,
       allowAlways: false,
+      revoked: false,
     };
     mocks.mounts.set(mount.mountId, mount);
 

--- a/extensions/reef/src/commands.test.ts
+++ b/extensions/reef/src/commands.test.ts
@@ -9,10 +9,15 @@ const mocks = vi.hoisted(() => {
     }),
     getMount: vi.fn((mountId: string) => mounts.get(mountId)),
     listMounts: vi.fn(() => [...mounts.values()]),
+    authorizeMount: vi.fn(({ mountId }: { mountId: string }) => mounts.get(mountId)),
+    acknowledgeRevocation: vi.fn(() => true),
     revoke: vi.fn((mountId: string, generation: number) => {
       const mount = mounts.get(mountId);
       if (!mount) {
         return undefined;
+      }
+      if (mount.revoked === true && mount.grantGeneration === generation) {
+        return mount;
       }
       const revoked = {
         ...mount,
@@ -84,6 +89,7 @@ describe("Reef session commands", () => {
         mountId: mount.mountId,
         sessionId: "session-1",
       }),
+      { expectedRecipient: mount.peerIdentity },
     );
   });
 
@@ -99,6 +105,33 @@ describe("Reef session commands", () => {
       text: "Could not create a Reef session mount for @guest; retry after older mounts expire.",
     });
     expect(mocks.flow.sendFederation).not.toHaveBeenCalled();
+  });
+
+  it("reuses the exact mount when an offer delivery is retried", async () => {
+    mocks.flow.sendFederation.mockRejectedValueOnce(new Error("relay unavailable"));
+
+    await expect(
+      handleReefCommand({
+        args: "session share @guest agent:main:shared",
+        senderIsOwner: true,
+      }),
+    ).rejects.toThrow("relay unavailable");
+    const mount = mocks.federation.createMount.mock.calls[0]![0];
+
+    await expect(
+      handleReefCommand({
+        args: "session share @guest agent:main:shared",
+        senderIsOwner: true,
+      }),
+    ).resolves.toEqual({
+      text: `Shared agent:main:shared with @guest as mount ${String(mount.mountId)}.`,
+    });
+    expect(mocks.federation.createMount).toHaveBeenCalledOnce();
+    expect(mocks.flow.sendFederation).toHaveBeenLastCalledWith(
+      "guest",
+      expect.objectContaining({ mountId: mount.mountId }),
+      { expectedRecipient: mount.peerIdentity },
+    );
   });
 
   it("submits and revokes an existing mount", async () => {
@@ -128,26 +161,69 @@ describe("Reef session commands", () => {
     expect(mocks.flow.proposeFederatedPrompt).toHaveBeenCalledWith(
       mount,
       "Check the current build",
+      mocks.federation,
     );
     mocks.mounts.set(mount.mountId, { ...mount, role: "host", peer: "host" });
 
     await expect(
       handleReefCommand({ args: "session revoke mount-1", senderIsOwner: true }),
     ).resolves.toEqual({ text: "Revoked Reef session mount mount-1." });
-    expect(mocks.flow.sendFederation).toHaveBeenCalledWith("host", {
-      type: "session.grant.revoked",
-      mountId: "mount-1",
-      sessionId: "session-1",
-      grantGeneration: 1,
-    });
+    expect(mocks.flow.sendFederation).toHaveBeenCalledWith(
+      "host",
+      {
+        type: "session.grant.revoked",
+        mountId: "mount-1",
+        sessionId: "session-1",
+        grantGeneration: 1,
+      },
+      { expectedRecipient: mount.peerIdentity },
+    );
   });
 
-  it("keeps session mutation commands owner-only", async () => {
+  it("retries delivery of an already committed revocation", async () => {
+    const mount = {
+      mountId: "mount-1",
+      peer: "host",
+      peerIdentity: {
+        ed25519PublicKey: "A".repeat(43),
+        x25519PublicKey: "B".repeat(43),
+        keyEpoch: 1,
+      },
+      role: "host",
+      sessionKey: "agent:main:shared",
+      sessionId: "session-1",
+      grantGeneration: 0,
+      allowAlways: false,
+      revoked: false,
+    };
+    mocks.mounts.set(mount.mountId, mount);
+    mocks.flow.sendFederation.mockRejectedValueOnce(new Error("relay unavailable"));
+
     await expect(
-      handleReefCommand({ args: "session prompt mount-1 hello", senderIsOwner: false }),
-    ).resolves.toEqual({
-      text: "Only an owner in commands.ownerAllowFrom can change Reef friends or decide reviews. Ask a configured owner; friendship changes can also use openclaw reef locally.",
-    });
+      handleReefCommand({ args: "session revoke mount-1", senderIsOwner: true }),
+    ).rejects.toThrow("relay unavailable");
+    await expect(
+      handleReefCommand({ args: "session revoke mount-1", senderIsOwner: true }),
+    ).resolves.toEqual({ text: "Revoked Reef session mount mount-1." });
+    expect(mocks.flow.sendFederation).toHaveBeenLastCalledWith(
+      "host",
+      {
+        type: "session.grant.revoked",
+        mountId: "mount-1",
+        sessionId: "session-1",
+        grantGeneration: 1,
+      },
+      { expectedRecipient: mount.peerIdentity },
+    );
+  });
+
+  it("keeps every session command owner-only", async () => {
+    for (const args of ["session list", "session prompt mount-1 hello"]) {
+      await expect(handleReefCommand({ args, senderIsOwner: false })).resolves.toEqual({
+        text: "Only an owner in commands.ownerAllowFrom can change Reef friends, decide reviews, or share, prompt, and revoke session mounts. Ask a configured owner; friendship changes can also use openclaw reef locally.",
+      });
+    }
+    expect(mocks.federation.listMounts).not.toHaveBeenCalled();
     expect(mocks.flow.proposeFederatedPrompt).not.toHaveBeenCalled();
   });
 });

--- a/extensions/reef/src/commands.test.ts
+++ b/extensions/reef/src/commands.test.ts
@@ -10,7 +10,18 @@ const mocks = vi.hoisted(() => {
     getMount: vi.fn((mountId: string) => mounts.get(mountId)),
     listMounts: vi.fn(() => [...mounts.values()]),
     authorizeMount: vi.fn(({ mountId }: { mountId: string }) => mounts.get(mountId)),
-    acknowledgeRevocation: vi.fn(() => true),
+    acknowledgeRevocation: vi.fn((mountId: string, generation: number) => {
+      const mount = mounts.get(mountId);
+      if (
+        mount?.revoked !== true ||
+        mount.revocationPending !== true ||
+        mount.grantGeneration !== generation
+      ) {
+        return false;
+      }
+      mounts.set(mountId, { ...mount, revocationPending: false });
+      return true;
+    }),
     revoke: vi.fn((mountId: string, generation: number) => {
       const mount = mounts.get(mountId);
       if (!mount) {
@@ -23,6 +34,7 @@ const mocks = vi.hoisted(() => {
         ...mount,
         allowAlways: false,
         revoked: true,
+        revocationPending: true,
         grantGeneration: generation + 1,
       };
       mounts.set(mountId, revoked);
@@ -215,6 +227,32 @@ describe("Reef session commands", () => {
       },
       { expectedRecipient: mount.peerIdentity },
     );
+  });
+
+  it("retries an already delivered revocation idempotently", async () => {
+    const mount = {
+      mountId: "mount-1",
+      peer: "host",
+      peerIdentity: {
+        ed25519PublicKey: "A".repeat(43),
+        x25519PublicKey: "B".repeat(43),
+        keyEpoch: 1,
+      },
+      role: "host",
+      sessionKey: "agent:main:shared",
+      sessionId: "session-1",
+      grantGeneration: 1,
+      allowAlways: false,
+      revoked: true,
+      revocationPending: false,
+    };
+    mocks.mounts.set(mount.mountId, mount);
+
+    await expect(
+      handleReefCommand({ args: "session revoke mount-1", senderIsOwner: true }),
+    ).resolves.toEqual({ text: "Revoked Reef session mount mount-1." });
+    expect(mocks.flow.sendFederation).toHaveBeenCalledOnce();
+    expect(mocks.federation.acknowledgeRevocation).not.toHaveBeenCalled();
   });
 
   it("keeps every session command owner-only", async () => {

--- a/extensions/reef/src/commands.ts
+++ b/extensions/reef/src/commands.ts
@@ -80,7 +80,11 @@ export async function handleReefCommand({
       allowAlways: false,
       revoked: false,
     };
-    active.federation.createMount(mount);
+    if (!active.federation.createMount(mount)) {
+      return {
+        text: `Could not create a Reef session mount for @${peer}; retry after older mounts expire.`,
+      };
+    }
     await active.flow.sendFederation(peer, {
       type: "session.mount.offer",
       mountId,

--- a/extensions/reef/src/commands.ts
+++ b/extensions/reef/src/commands.ts
@@ -1,5 +1,5 @@
 import { prepareReefMessageId } from "./flow.js";
-import { ReefAutonomySchema } from "./friend-types.js";
+import { reefPeerIdentity, ReefAutonomySchema } from "./friend-types.js";
 import { getActiveReef, getReefRuntime } from "./runtime.js";
 
 export async function handleReefCommand({
@@ -72,7 +72,7 @@ export async function handleReefCommand({
     const mount = {
       mountId,
       peer,
-      peerKeyEpoch: friend.keyEpoch,
+      peerIdentity: reefPeerIdentity(friend),
       role: "host" as const,
       sessionKey,
       sessionId: session.sessionId,

--- a/extensions/reef/src/commands.ts
+++ b/extensions/reef/src/commands.ts
@@ -78,6 +78,7 @@ export async function handleReefCommand({
       sessionId: session.sessionId,
       grantGeneration: 0,
       allowAlways: false,
+      revoked: false,
     };
     active.federation.createMount(mount);
     await active.flow.sendFederation(peer, {
@@ -91,8 +92,8 @@ export async function handleReefCommand({
   }
   if (words[0] === "session" && words[1] === "prompt" && words[2] && words[3]) {
     const mount = active.federation.getMount(words[2]);
-    if (!mount || mount.role !== "guest") {
-      return { text: `Unknown guest Reef session mount ${words[2]}.` };
+    if (!mount || mount.role !== "guest" || mount.revoked) {
+      return { text: `Unknown active guest Reef session mount ${words[2]}.` };
     }
     const proposalId = await active.flow.proposeFederatedPrompt(mount, words.slice(3).join(" "));
     return { text: `Sent Reef prompt proposal ${proposalId}.` };
@@ -121,7 +122,7 @@ export async function handleReefCommand({
         ? mounts
             .map(
               (mount) =>
-                `${mount.mountId} ${mount.role} @${mount.peer} ${mount.sessionKey} generation=${mount.grantGeneration}${mount.allowAlways ? " allow-always" : " ask"}`,
+                `${mount.mountId} ${mount.role} @${mount.peer} ${mount.sessionKey} generation=${mount.grantGeneration}${mount.revoked ? " revoked" : mount.allowAlways ? " allow-always" : " ask"}`,
             )
             .join("\n")
         : "No Reef session mounts.",

--- a/extensions/reef/src/commands.ts
+++ b/extensions/reef/src/commands.ts
@@ -1,5 +1,6 @@
+import { prepareReefMessageId } from "./flow.js";
 import { ReefAutonomySchema } from "./friend-types.js";
-import { getActiveReef } from "./runtime.js";
+import { getActiveReef, getReefRuntime } from "./runtime.js";
 
 export async function handleReefCommand({
   args,
@@ -12,7 +13,8 @@ export async function handleReefCommand({
   const changesFriendship =
     words[0] === "friend" && /^(code|request|remove|block|autonomy)$/.test(words[1] ?? "");
   const decidesReview = words[0] === "review" && /^(approve|deny)$/.test(words[1] ?? "");
-  if ((changesFriendship || decidesReview) && senderIsOwner !== true) {
+  const changesSession = words[0] === "session" && words[1] !== "list";
+  if ((changesFriendship || decidesReview || changesSession) && senderIsOwner !== true) {
     return {
       text: "Only an owner in commands.ownerAllowFrom can change Reef friends or decide reviews. Ask a configured owner; friendship changes can also use openclaw reef locally.",
     };
@@ -52,6 +54,79 @@ export async function handleReefCommand({
     await active.friends.setAutonomy(peer, autonomy);
     return { text: `Reef friend @${peer} autonomy set to ${autonomy}.` };
   }
+  if (words[0] === "session" && words[1] === "share" && words[2] && words[3]) {
+    const peer = words[2].replace(/^@/, "").toLowerCase();
+    const sessionKey = words[3];
+    const friend = active.trust.get(peer);
+    if (!friend || friend.safetyNumberChanged) {
+      return { text: `Reef peer @${peer} is not approved with current keys.` };
+    }
+    const result = await getReefRuntime().gateway.request<{
+      sessions?: Array<{ key?: string; sessionId?: string }>;
+    }>("sessions.list", { search: sessionKey, limit: 20 });
+    const session = result.sessions?.find((entry) => entry.key === sessionKey);
+    if (!session?.sessionId) {
+      return { text: `Session ${sessionKey} was not found.` };
+    }
+    const mountId = `reef-mount-${prepareReefMessageId()}`;
+    const mount = {
+      mountId,
+      peer,
+      peerKeyEpoch: friend.keyEpoch,
+      role: "host" as const,
+      sessionKey,
+      sessionId: session.sessionId,
+      grantGeneration: 0,
+      allowAlways: false,
+    };
+    active.federation.createMount(mount);
+    await active.flow.sendFederation(peer, {
+      type: "session.mount.offer",
+      mountId,
+      sessionKey,
+      sessionId: session.sessionId,
+      grantGeneration: 0,
+    });
+    return { text: `Shared ${sessionKey} with @${peer} as mount ${mountId}.` };
+  }
+  if (words[0] === "session" && words[1] === "prompt" && words[2] && words[3]) {
+    const mount = active.federation.getMount(words[2]);
+    if (!mount || mount.role !== "guest") {
+      return { text: `Unknown guest Reef session mount ${words[2]}.` };
+    }
+    const proposalId = await active.flow.proposeFederatedPrompt(mount, words.slice(3).join(" "));
+    return { text: `Sent Reef prompt proposal ${proposalId}.` };
+  }
+  if (words[0] === "session" && words[1] === "revoke" && words[2]) {
+    const mount = active.federation.getMount(words[2]);
+    if (!mount || mount.role !== "host") {
+      return { text: `Unknown host Reef session mount ${words[2]}.` };
+    }
+    const revoked = active.federation.revoke(mount.mountId, mount.grantGeneration);
+    if (!revoked) {
+      return { text: `Reef session mount ${mount.mountId} changed before revocation.` };
+    }
+    await active.flow.sendFederation(mount.peer, {
+      type: "session.grant.revoked",
+      mountId: mount.mountId,
+      sessionId: mount.sessionId,
+      grantGeneration: revoked.grantGeneration,
+    });
+    return { text: `Revoked Reef session mount ${mount.mountId}.` };
+  }
+  if (words[0] === "session" && words[1] === "list") {
+    const mounts = active.federation.listMounts();
+    return {
+      text: mounts.length
+        ? mounts
+            .map(
+              (mount) =>
+                `${mount.mountId} ${mount.role} @${mount.peer} ${mount.sessionKey} generation=${mount.grantGeneration}${mount.allowAlways ? " allow-always" : " ask"}`,
+            )
+            .join("\n")
+        : "No Reef session mounts.",
+    };
+  }
   if (words[0] === "review" && words[1] === "list") {
     const reviews = await active.reviews.list();
     return {
@@ -78,6 +153,6 @@ export async function handleReefCommand({
     };
   }
   return {
-    text: "Usage: /reef friend code|request <handle> [code]|list|remove <handle>|autonomy <handle> <notify-only|bounded|extended>; /reef review list|approve <digest>|deny <digest>",
+    text: "Usage: /reef friend code|request <handle> [code]|list|remove <handle>|autonomy <handle> <notify-only|bounded|extended>; /reef review list|approve <digest>|deny <digest>; /reef session share <handle> <session-key>|list|prompt <mount-id> <text>|revoke <mount-id>",
   };
 }

--- a/extensions/reef/src/commands.ts
+++ b/extensions/reef/src/commands.ts
@@ -145,7 +145,10 @@ export async function handleReefCommand({
       },
       { expectedRecipient: mount.peerIdentity },
     );
-    if (!active.federation.acknowledgeRevocation(mount.mountId, revoked.grantGeneration)) {
+    if (
+      revoked.revocationPending &&
+      !active.federation.acknowledgeRevocation(mount.mountId, revoked.grantGeneration)
+    ) {
       throw new Error(`Reef session mount ${mount.mountId} lost its durable revocation`);
     }
     return { text: `Revoked Reef session mount ${mount.mountId}.` };

--- a/extensions/reef/src/commands.ts
+++ b/extensions/reef/src/commands.ts
@@ -1,5 +1,5 @@
 import { prepareReefMessageId } from "./flow.js";
-import { reefPeerIdentity, ReefAutonomySchema } from "./friend-types.js";
+import { reefPeerIdentity, ReefAutonomySchema, sameReefPeerIdentity } from "./friend-types.js";
 import { getActiveReef, getReefRuntime } from "./runtime.js";
 
 export async function handleReefCommand({
@@ -13,10 +13,10 @@ export async function handleReefCommand({
   const changesFriendship =
     words[0] === "friend" && /^(code|request|remove|block|autonomy)$/.test(words[1] ?? "");
   const decidesReview = words[0] === "review" && /^(approve|deny)$/.test(words[1] ?? "");
-  const changesSession = words[0] === "session" && words[1] !== "list";
+  const changesSession = words[0] === "session";
   if ((changesFriendship || decidesReview || changesSession) && senderIsOwner !== true) {
     return {
-      text: "Only an owner in commands.ownerAllowFrom can change Reef friends or decide reviews. Ask a configured owner; friendship changes can also use openclaw reef locally.",
+      text: "Only an owner in commands.ownerAllowFrom can change Reef friends, decide reviews, or share, prompt, and revoke session mounts. Ask a configured owner; friendship changes can also use openclaw reef locally.",
     };
   }
   const active = getActiveReef();
@@ -68,11 +68,27 @@ export async function handleReefCommand({
     if (!session?.sessionId) {
       return { text: `Session ${sessionKey} was not found.` };
     }
-    const mountId = `reef-mount-${prepareReefMessageId()}`;
-    const mount = {
-      mountId,
+    const peerIdentity = reefPeerIdentity(friend);
+    const existing = active.federation.listMounts().find(
+      (mount) =>
+        mount.role === "host" &&
+        !mount.revoked &&
+        mount.peer === peer &&
+        mount.sessionKey === sessionKey &&
+        mount.sessionId === session.sessionId &&
+        sameReefPeerIdentity(mount.peerIdentity, peerIdentity) &&
+        active.federation.authorizeMount({
+          mountId: mount.mountId,
+          peer,
+          peerIdentity,
+          sessionId: mount.sessionId,
+          generation: mount.grantGeneration,
+        }) !== undefined,
+    );
+    const mount = existing ?? {
+      mountId: `reef-mount-${prepareReefMessageId()}`,
       peer,
-      peerIdentity: reefPeerIdentity(friend),
+      peerIdentity,
       role: "host" as const,
       sessionKey,
       sessionId: session.sessionId,
@@ -80,26 +96,34 @@ export async function handleReefCommand({
       allowAlways: false,
       revoked: false,
     };
-    if (!active.federation.createMount(mount)) {
+    if (!existing && !active.federation.createMount(mount)) {
       return {
         text: `Could not create a Reef session mount for @${peer}; retry after older mounts expire.`,
       };
     }
-    await active.flow.sendFederation(peer, {
-      type: "session.mount.offer",
-      mountId,
-      sessionKey,
-      sessionId: session.sessionId,
-      grantGeneration: 0,
-    });
-    return { text: `Shared ${sessionKey} with @${peer} as mount ${mountId}.` };
+    await active.flow.sendFederation(
+      peer,
+      {
+        type: "session.mount.offer",
+        mountId: mount.mountId,
+        sessionKey,
+        sessionId: session.sessionId,
+        grantGeneration: 0,
+      },
+      { expectedRecipient: peerIdentity },
+    );
+    return { text: `Shared ${sessionKey} with @${peer} as mount ${mount.mountId}.` };
   }
   if (words[0] === "session" && words[1] === "prompt" && words[2] && words[3]) {
     const mount = active.federation.getMount(words[2]);
     if (!mount || mount.role !== "guest" || mount.revoked) {
       return { text: `Unknown active guest Reef session mount ${words[2]}.` };
     }
-    const proposalId = await active.flow.proposeFederatedPrompt(mount, words.slice(3).join(" "));
+    const proposalId = await active.flow.proposeFederatedPrompt(
+      mount,
+      words.slice(3).join(" "),
+      active.federation,
+    );
     return { text: `Sent Reef prompt proposal ${proposalId}.` };
   }
   if (words[0] === "session" && words[1] === "revoke" && words[2]) {
@@ -111,12 +135,19 @@ export async function handleReefCommand({
     if (!revoked) {
       return { text: `Reef session mount ${mount.mountId} changed before revocation.` };
     }
-    await active.flow.sendFederation(mount.peer, {
-      type: "session.grant.revoked",
-      mountId: mount.mountId,
-      sessionId: mount.sessionId,
-      grantGeneration: revoked.grantGeneration,
-    });
+    await active.flow.sendFederation(
+      mount.peer,
+      {
+        type: "session.grant.revoked",
+        mountId: mount.mountId,
+        sessionId: mount.sessionId,
+        grantGeneration: revoked.grantGeneration,
+      },
+      { expectedRecipient: mount.peerIdentity },
+    );
+    if (!active.federation.acknowledgeRevocation(mount.mountId, revoked.grantGeneration)) {
+      throw new Error(`Reef session mount ${mount.mountId} lost its durable revocation`);
+    }
     return { text: `Revoked Reef session mount ${mount.mountId}.` };
   }
   if (words[0] === "session" && words[1] === "list") {

--- a/extensions/reef/src/commands.ts
+++ b/extensions/reef/src/commands.ts
@@ -2,14 +2,14 @@ import { prepareReefMessageId } from "./flow.js";
 import { reefPeerIdentity, ReefAutonomySchema, sameReefPeerIdentity } from "./friend-types.js";
 import { getActiveReef, getReefRuntime } from "./runtime.js";
 
-export async function handleReefCommand({
-  args,
+/** Execute a Reef command from already-separated arguments. */
+export async function handleReefCommandWords({
+  words,
   senderIsOwner,
 }: {
-  args?: string;
+  words: string[];
   senderIsOwner?: boolean;
 }): Promise<{ text: string }> {
-  const words = (args ?? "").trim().split(/\s+/).filter(Boolean);
   const changesFriendship =
     words[0] === "friend" && /^(code|request|remove|block|autonomy)$/.test(words[1] ?? "");
   const decidesReview = words[0] === "review" && /^(approve|deny)$/.test(words[1] ?? "");
@@ -194,4 +194,18 @@ export async function handleReefCommand({
   return {
     text: "Usage: /reef friend code|request <handle> [code]|list|remove <handle>|autonomy <handle> <notify-only|bounded|extended>; /reef review list|approve <digest>|deny <digest>; /reef session share <handle> <session-key>|list|prompt <mount-id> <text>|revoke <mount-id>",
   };
+}
+
+/** Parse and execute a Reef slash command. */
+export async function handleReefCommand({
+  args,
+  senderIsOwner,
+}: {
+  args?: string;
+  senderIsOwner?: boolean;
+}): Promise<{ text: string }> {
+  return await handleReefCommandWords({
+    words: (args ?? "").trim().split(/\s+/).filter(Boolean),
+    senderIsOwner,
+  });
 }

--- a/extensions/reef/src/config-schema.test.ts
+++ b/extensions/reef/src/config-schema.test.ts
@@ -121,7 +121,7 @@ describe("Reef configuration boundary", () => {
       reviews: { list: vi.fn(), decide },
     } as never);
     const ownerRequired = {
-      text: "Only an owner in commands.ownerAllowFrom can change Reef friends or decide reviews. Ask a configured owner; friendship changes can also use openclaw reef locally.",
+      text: "Only an owner in commands.ownerAllowFrom can change Reef friends, decide reviews, or share, prompt, and revoke session mounts. Ask a configured owner; friendship changes can also use openclaw reef locally.",
     };
     await expect(
       command.handler({ args: "friend autonomy peer extended", senderIsOwner: false }),

--- a/extensions/reef/src/config-schema.test.ts
+++ b/extensions/reef/src/config-schema.test.ts
@@ -92,9 +92,19 @@ describe("Reef configuration boundary", () => {
 
   it("keeps config mutation off the agent message surface and gates owner commands", async () => {
     const registerCommand = vi.fn();
-    // tool-discovery registration runs only registerFull, which owns /reef.
-    reefChannelEntry.register({ registrationMode: "tool-discovery", registerCommand } as never);
+    const registerControlUiDescriptor = vi.fn();
+    // Tool-discovery registration runs only registerFull, which owns /reef and
+    // its operator-only Control UI surface.
+    reefChannelEntry.register({
+      registrationMode: "tool-discovery",
+      registerCommand,
+      registerGatewayMethod: vi.fn(),
+      session: { controls: { registerControlUiDescriptor } },
+    } as never);
     expect(registerCommand).toHaveBeenCalledOnce();
+    expect(registerControlUiDescriptor).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "reef", requiredScopes: ["operator.admin"] }),
+    );
     const command = registerCommand.mock.calls[0]![0];
     expect(command).toMatchObject({
       name: "reef",

--- a/extensions/reef/src/control-ui-gateway.test.ts
+++ b/extensions/reef/src/control-ui-gateway.test.ts
@@ -1,0 +1,255 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
+import { ErrorCodes } from "openclaw/plugin-sdk/gateway-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerReefControlUiGatewayMethods } from "./control-ui-gateway.js";
+
+const mocks = vi.hoisted(() => ({
+  command: vi.fn(),
+  active: {
+    friends: {
+      list: vi.fn(),
+    },
+    federation: {
+      listMounts: vi.fn(),
+      listPromptProposals: vi.fn(),
+      listOutboundPromptProposals: vi.fn(),
+    },
+  },
+  getActiveReef: vi.fn(),
+}));
+
+vi.mock("./commands.js", () => ({
+  handleReefCommandWords: mocks.command,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getActiveReef: mocks.getActiveReef,
+}));
+
+type GatewayHandler = Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1];
+type GatewayOptions = Parameters<OpenClawPluginApi["registerGatewayMethod"]>[2];
+
+function registerMethods(config: unknown = {}) {
+  const methods = new Map<string, { handler: GatewayHandler; opts: GatewayOptions }>();
+  const api = {
+    runtime: {
+      config: {
+        current: () => config,
+      },
+    },
+    registerGatewayMethod: vi.fn(
+      (method: string, handler: GatewayHandler, opts: GatewayOptions) => {
+        methods.set(method, { handler, opts });
+      },
+    ),
+  } as unknown as OpenClawPluginApi;
+  registerReefControlUiGatewayMethods(api);
+  return methods;
+}
+
+async function call(methods: ReturnType<typeof registerMethods>, method: string, params = {}) {
+  const respond = vi.fn();
+  await methods.get(method)?.handler({ params, respond } as never);
+  return respond.mock.calls[0] ?? [];
+}
+
+describe("Reef Control UI Gateway methods", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getActiveReef.mockReturnValue(mocks.active);
+    mocks.active.friends.list.mockResolvedValue([
+      {
+        peer: "guest",
+        status: "active",
+        autonomy: "bounded",
+        fingerprint: "reef-fingerprint",
+      },
+    ]);
+    mocks.active.federation.listMounts.mockReturnValue([
+      {
+        mountId: "mount-host",
+        peer: "guest",
+        role: "host",
+        sessionKey: "agent:main:shared",
+        grantGeneration: 0,
+        allowAlways: false,
+        revoked: false,
+      },
+    ]);
+    mocks.active.federation.listPromptProposals.mockReturnValue([
+      {
+        proposalId: "proposal-inbound",
+        mountId: "mount-host",
+        status: "pending",
+        approvalId: "plugin:approval",
+        request: { peer: "guest", frame: { text: "Check the build" } },
+      },
+    ]);
+    mocks.active.federation.listOutboundPromptProposals.mockReturnValue([
+      {
+        peer: "host",
+        frame: {
+          proposalId: "proposal-outbound",
+          mountId: "mount-guest",
+          text: "Summarize the result",
+        },
+        outcome: {
+          type: "session.prompt.denied",
+          reason: "operator-denied",
+        },
+      },
+    ]);
+    mocks.command.mockResolvedValue({ text: "Reef command completed." });
+  });
+
+  it("registers one read method and owner-only mutations", () => {
+    const methods = registerMethods();
+
+    expect([...methods.keys()]).toEqual([
+      "reef.controlUi.status",
+      "reef.controlUi.friendCode",
+      "reef.controlUi.friendRequest",
+      "reef.controlUi.friendRemove",
+      "reef.controlUi.sessionShare",
+      "reef.controlUi.sessionRevoke",
+      "reef.controlUi.sessionPrompt",
+    ]);
+    expect(methods.get("reef.controlUi.status")?.opts).toEqual({ scope: "operator.read" });
+    for (const method of [...methods.keys()].slice(1)) {
+      expect(methods.get(method)?.opts).toEqual({ scope: "operator.admin" });
+    }
+  });
+
+  it("projects live friends, mounts, and text-only proposal status", async () => {
+    const methods = registerMethods({
+      channels: {
+        reef: {
+          handle: "host",
+          email: "host@example.com",
+          guard: {
+            provider: "openai",
+            pinnedModel: "gpt-5-mini",
+            apiKeyEnv: "OPENAI_API_KEY",
+            policyVersion: "2026-09-09",
+            timeoutMs: 10_000,
+          },
+        },
+      },
+    });
+
+    const [ok, payload] = await call(methods, "reef.controlUi.status");
+
+    expect(ok).toBe(true);
+    expect(payload).toMatchObject({
+      configured: true,
+      running: true,
+      handle: "host",
+      friends: [{ peer: "guest", status: "active", autonomy: "bounded" }],
+      mounts: [{ mountId: "mount-host", role: "host", revoked: false }],
+      proposals: [
+        {
+          direction: "inbound",
+          peer: "guest",
+          text: "Check the build",
+          status: "pending",
+          approvalId: "plugin:approval",
+        },
+        {
+          direction: "outbound",
+          peer: "host",
+          text: "Summarize the result",
+          status: "denied",
+          reason: "operator-denied",
+        },
+      ],
+    });
+  });
+
+  it("returns an explanatory unavailable state when the channel is inactive", async () => {
+    mocks.getActiveReef.mockImplementation(() => {
+      throw new Error("Reef channel is not running");
+    });
+    const methods = registerMethods({ channels: { reef: { handle: "host" } } });
+
+    const [ok, payload] = await call(methods, "reef.controlUi.status");
+
+    expect(ok).toBe(true);
+    expect(payload).toMatchObject({
+      configured: false,
+      running: false,
+      unavailableReason: "Reef channel is not running",
+      friends: [],
+      mounts: [],
+      proposals: [],
+    });
+  });
+
+  it("keeps mutations on the canonical owner command path", async () => {
+    const methods = registerMethods();
+
+    const [ok, payload] = await call(methods, "reef.controlUi.sessionPrompt", {
+      mountId: "mount-guest",
+      text: "Keep this text only",
+    });
+
+    expect(ok).toBe(true);
+    expect(payload).toEqual({ message: "Reef command completed." });
+    expect(mocks.command).toHaveBeenCalledWith({
+      words: ["session", "prompt", "mount-guest", "Keep this text only"],
+      senderIsOwner: true,
+    });
+  });
+
+  it("does not reinterpret structured values as additional command arguments", async () => {
+    const methods = registerMethods();
+
+    await call(methods, "reef.controlUi.friendRequest", {
+      peer: "guest",
+      code: "code with spaces",
+    });
+
+    expect(mocks.command).toHaveBeenCalledWith({
+      words: ["friend", "request", "guest", "code with spaces"],
+      senderIsOwner: true,
+    });
+  });
+
+  it("rejects malformed mutation parameters before command dispatch", async () => {
+    const methods = registerMethods();
+
+    const [ok, payload, error] = await call(methods, "reef.controlUi.sessionPrompt", {
+      mountId: "mount-guest",
+      text: "",
+    });
+
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(error).toMatchObject({ code: ErrorCodes.INVALID_REQUEST });
+    expect(mocks.command).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed identifiers before command dispatch", async () => {
+    const methods = registerMethods();
+
+    const [ok, payload, error] = await call(methods, "reef.controlUi.sessionShare", {
+      peer: "guest other",
+      sessionKey: "agent:main:shared",
+    });
+
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(error).toMatchObject({ code: ErrorCodes.INVALID_REQUEST });
+    expect(mocks.command).not.toHaveBeenCalled();
+  });
+
+  it("surfaces live status read failures instead of misreporting the channel as stopped", async () => {
+    mocks.active.friends.list.mockRejectedValueOnce(new Error("state read failed"));
+    const methods = registerMethods();
+
+    const [ok, payload, error] = await call(methods, "reef.controlUi.status");
+
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(error).toMatchObject({ code: ErrorCodes.UNAVAILABLE, message: "state read failed" });
+  });
+});

--- a/extensions/reef/src/control-ui-gateway.ts
+++ b/extensions/reef/src/control-ui-gateway.ts
@@ -1,0 +1,168 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import {
+  ErrorCodes,
+  errorShape,
+  type GatewayRequestHandlerOptions,
+} from "openclaw/plugin-sdk/gateway-runtime";
+import { z } from "zod";
+import { handleReefCommandWords } from "./commands.js";
+import { resolveReefConfig, type ReefCoreConfig } from "./config-schema.js";
+import { getActiveReef } from "./runtime.js";
+
+const emptyParams = z.strictObject({});
+const peerSchema = z
+  .string()
+  .trim()
+  .regex(/^@?[a-z0-9][a-z0-9_-]{0,62}$/i);
+const peerParams = z.strictObject({ peer: peerSchema });
+const friendRequestParams = peerParams.extend({
+  code: z.string().trim().min(1).max(256).optional(),
+});
+const shareParams = peerParams.extend({ sessionKey: z.string().trim().min(1).max(256) });
+const mountParams = z.strictObject({ mountId: z.string().trim().min(1).max(256) });
+const promptParams = mountParams.extend({ text: z.string().trim().min(1).max(20_000) });
+
+function respondError(respond: GatewayRequestHandlerOptions["respond"], error: unknown): void {
+  const message = formatErrorMessage(error);
+  respond(
+    false,
+    undefined,
+    errorShape(
+      error instanceof z.ZodError ? ErrorCodes.INVALID_REQUEST : ErrorCodes.UNAVAILABLE,
+      message,
+    ),
+  );
+}
+
+function register(
+  api: OpenClawPluginApi,
+  method: string,
+  scope: "operator.read" | "operator.admin",
+  run: (params: unknown) => Promise<unknown>,
+): void {
+  api.registerGatewayMethod(
+    method,
+    async ({ params, respond }) => {
+      try {
+        respond(true, await run(params ?? {}));
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope },
+  );
+}
+
+async function runOwnerCommand(words: string[]): Promise<{ message: string }> {
+  const result = await handleReefCommandWords({ words, senderIsOwner: true });
+  return { message: result.text };
+}
+
+/** Register the operator-only Reef methods consumed by its native Control UI. */
+export function registerReefControlUiGatewayMethods(api: OpenClawPluginApi): void {
+  register(api, "reef.controlUi.status", "operator.read", async (params) => {
+    emptyParams.parse(params);
+    const config = resolveReefConfig(api.runtime.config.current() as ReefCoreConfig);
+    const configured = Boolean(config.handle && config.email && config.guard);
+    let active: ReturnType<typeof getActiveReef>;
+    try {
+      active = getActiveReef();
+    } catch (error) {
+      return {
+        enabled: config.enabled,
+        configured,
+        running: false,
+        handle: config.handle ?? null,
+        relayUrl: config.relayUrl,
+        unavailableReason: formatErrorMessage(error),
+        friends: [],
+        mounts: [],
+        proposals: [],
+      };
+    }
+    const friends = await active.friends.list();
+    return {
+      enabled: config.enabled,
+      configured,
+      running: true,
+      handle: config.handle ?? null,
+      relayUrl: config.relayUrl,
+      friends: friends.map((friend) => ({
+        peer: friend.peer,
+        status: friend.status,
+        autonomy: friend.autonomy ?? null,
+        fingerprint: friend.fingerprint,
+      })),
+      mounts: active.federation.listMounts().map((mount) => ({
+        mountId: mount.mountId,
+        peer: mount.peer,
+        role: mount.role,
+        sessionKey: mount.sessionKey,
+        grantGeneration: mount.grantGeneration,
+        allowAlways: mount.allowAlways,
+        revoked: mount.revoked,
+        revocationPending: mount.revocationPending ?? false,
+      })),
+      proposals: [
+        ...active.federation.listPromptProposals().map((proposal) => ({
+          direction: "inbound" as const,
+          proposalId: proposal.proposalId,
+          mountId: proposal.mountId,
+          peer: proposal.request.peer,
+          text: proposal.request.frame.text,
+          status: proposal.status,
+          approvalId: proposal.approvalId ?? null,
+          outcome: proposal.outcome?.type ?? null,
+          reason: proposal.outcome && "reason" in proposal.outcome ? proposal.outcome.reason : null,
+          message:
+            proposal.outcome && "message" in proposal.outcome ? proposal.outcome.message : null,
+        })),
+        ...active.federation.listOutboundPromptProposals().map((proposal) => ({
+          direction: "outbound" as const,
+          proposalId: proposal.frame.proposalId,
+          mountId: proposal.frame.mountId,
+          peer: proposal.peer,
+          text: proposal.frame.text,
+          status: proposal.outcome
+            ? proposal.outcome.type === "session.prompt.accepted"
+              ? "accepted"
+              : proposal.outcome.type === "session.prompt.denied"
+                ? "denied"
+                : "failed"
+            : "pending",
+          approvalId: null,
+          outcome: proposal.outcome?.type ?? null,
+          reason: proposal.outcome && "reason" in proposal.outcome ? proposal.outcome.reason : null,
+          message:
+            proposal.outcome && "message" in proposal.outcome ? proposal.outcome.message : null,
+        })),
+      ],
+    };
+  });
+
+  register(api, "reef.controlUi.friendCode", "operator.admin", async (params) => {
+    emptyParams.parse(params);
+    return await runOwnerCommand(["friend", "code"]);
+  });
+  register(api, "reef.controlUi.friendRequest", "operator.admin", async (params) => {
+    const { peer, code } = friendRequestParams.parse(params);
+    return await runOwnerCommand(["friend", "request", peer, ...(code ? [code] : [])]);
+  });
+  register(api, "reef.controlUi.friendRemove", "operator.admin", async (params) => {
+    const { peer } = peerParams.parse(params);
+    return await runOwnerCommand(["friend", "remove", peer]);
+  });
+  register(api, "reef.controlUi.sessionShare", "operator.admin", async (params) => {
+    const { peer, sessionKey } = shareParams.parse(params);
+    return await runOwnerCommand(["session", "share", peer, sessionKey]);
+  });
+  register(api, "reef.controlUi.sessionRevoke", "operator.admin", async (params) => {
+    const { mountId } = mountParams.parse(params);
+    return await runOwnerCommand(["session", "revoke", mountId]);
+  });
+  register(api, "reef.controlUi.sessionPrompt", "operator.admin", async (params) => {
+    const { mountId, text } = promptParams.parse(params);
+    return await runOwnerCommand(["session", "prompt", mountId, text]);
+  });
+}

--- a/extensions/reef/src/control-ui-gateway.ts
+++ b/extensions/reef/src/control-ui-gateway.ts
@@ -63,6 +63,7 @@ async function runOwnerCommand(words: string[]): Promise<{ message: string }> {
 export function registerReefControlUiGatewayMethods(api: OpenClawPluginApi): void {
   register(api, "reef.controlUi.status", "operator.read", async (params) => {
     emptyParams.parse(params);
+    // SAFETY: the host runtime returns the active OpenClaw config; Reef reads only its optional channel subtree.
     const config = resolveReefConfig(api.runtime.config.current() as ReefCoreConfig);
     const configured = Boolean(config.handle && config.email && config.guard);
     let active: ReturnType<typeof getActiveReef>;

--- a/extensions/reef/src/federation-coordinator.test.ts
+++ b/extensions/reef/src/federation-coordinator.test.ts
@@ -197,20 +197,60 @@ describe("Reef federation coordinator", () => {
     expect(request.mock.calls.some(([method]) => method === "agent")).toBe(false);
   });
 
-  it("rejects stale grant and session bindings before approval", async () => {
-    const { coordinator, request } = fixture();
+  it("persists stale grant and session denials before approval", async () => {
+    const { coordinator, proposals, request } = fixture();
 
     await expect(handle(coordinator, promptFrame({ grantGeneration: 1 }))).resolves.toMatchObject({
       type: "session.prompt.denied",
       reason: "grant-revoked",
     });
     await expect(
-      handle(coordinator, promptFrame({ sessionId: "session-2" })),
+      handle(coordinator, promptFrame({ proposalId: "proposal-2", sessionId: "session-2" })),
     ).resolves.toMatchObject({
       type: "session.prompt.denied",
       reason: "stale-session",
     });
     expect(request).not.toHaveBeenCalled();
+    expect([...proposals.values()]).toEqual([
+      expect.objectContaining({
+        status: "denied",
+        outcome: expect.objectContaining({ reason: "grant-revoked" }),
+      }),
+      expect.objectContaining({
+        status: "denied",
+        outcome: expect.objectContaining({ reason: "stale-session" }),
+      }),
+    ]);
+  });
+
+  it("persists digest rejection before returning its terminal outcome", async () => {
+    const { coordinator, proposals, request } = fixture();
+    const frame = { ...promptFrame(), textSha256: "f".repeat(64) };
+
+    await expect(handle(coordinator, frame)).resolves.toMatchObject({
+      type: "session.prompt.failed",
+      code: "digest-mismatch",
+    });
+    expect(proposals.get(frame.proposalId)).toMatchObject({
+      digest: frame.textSha256,
+      status: "failed",
+      outcome: { type: "session.prompt.failed", code: "digest-mismatch" },
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("bounds dispatch failures by UTF-8 bytes", async () => {
+    const { coordinator, proposals, request } = fixture({ allowAlways: true });
+    request.mockRejectedValueOnce(new Error("🦞".repeat(512)));
+
+    const outcome = await handle(coordinator);
+
+    expect(outcome).toMatchObject({ type: "session.prompt.failed", code: "dispatch-failed" });
+    if (outcome.type !== "session.prompt.failed") {
+      throw new Error("expected failed prompt outcome");
+    }
+    expect(Buffer.byteLength(outcome.message, "utf8")).toBe(512);
+    expect(proposals.get("proposal-1")?.outcome).toEqual(outcome);
   });
 
   it("revalidates grant and peer authority after host approval", async () => {

--- a/extensions/reef/src/federation-coordinator.test.ts
+++ b/extensions/reef/src/federation-coordinator.test.ts
@@ -12,6 +12,7 @@ const mount: ReefFederationMount = {
   mountId: "mount-1",
   peer: "guest",
   peerKeyEpoch: 1,
+  role: "host",
   sessionKey: "agent:main:shared",
   sessionId: "session-1",
   grantGeneration: 0,
@@ -42,8 +43,12 @@ function promptFrame(
   };
 }
 
-function fixture(options?: { allowAlways?: boolean }) {
-  let currentMount = { ...mount, allowAlways: options?.allowAlways ?? false };
+function fixture(options?: { allowAlways?: boolean; role?: ReefFederationMount["role"] }) {
+  let currentMount = {
+    ...mount,
+    allowAlways: options?.allowAlways ?? false,
+    role: options?.role ?? mount.role,
+  };
   const proposals = new Map<string, ReefFederationProposal>();
   const state = {
     getMount: vi.fn(() => ({ ...currentMount })),
@@ -82,13 +87,23 @@ function fixture(options?: { allowAlways?: boolean }) {
       },
     ),
   };
-  const request = vi.fn(async (method: string) =>
-    method === "plugin.approval.request"
-      ? { id: "plugin:approval-1", decision: "allow-once" }
-      : { runId: "run-1" },
+  const request = vi.fn(
+    async (method: string, _params?: Record<string, unknown>, _options?: { timeoutMs?: number }) =>
+      method === "plugin.approval.request"
+        ? { id: "plugin:approval-1", decision: "allow-once" }
+        : { runId: "run-1" },
   );
+  const gatewayRequest = async <T>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number },
+  ): Promise<T> => {
+    const response = await request(method, params, options);
+    // SAFETY: this fixture returns the exact response shape for each method the coordinator calls.
+    return response as T;
+  };
   const coordinator = new ReefFederationCoordinator(
-    { gateway: { isAvailable: async () => true, request } },
+    { gateway: { isAvailable: async () => true, request: gatewayRequest } },
     state,
   );
   return { coordinator, request, state, proposals };
@@ -180,6 +195,16 @@ describe("Reef federation coordinator", () => {
     ).resolves.toMatchObject({
       type: "session.prompt.denied",
       reason: "stale-session",
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("rejects a guest-side mount offered back to the host", async () => {
+    const { coordinator, request } = fixture({ role: "guest" });
+
+    await expect(handle(coordinator)).resolves.toMatchObject({
+      type: "session.prompt.denied",
+      reason: "grant-revoked",
     });
     expect(request).not.toHaveBeenCalled();
   });

--- a/extensions/reef/src/federation-coordinator.test.ts
+++ b/extensions/reef/src/federation-coordinator.test.ts
@@ -4,7 +4,11 @@ import {
   type ReefFederationFrame,
 } from "../protocol/federation.js";
 import { ReefFederationCoordinator } from "./federation-coordinator.js";
-import type { ReefFederationMount, ReefFederationProposal } from "./federation-state.js";
+import type {
+  ReefFederationMount,
+  ReefFederationProposal,
+  ReefFederationProposalResolution,
+} from "./federation-state.js";
 
 const from = "guest#1";
 const to = "host#1";
@@ -74,11 +78,7 @@ function fixture(fixtureOptions?: { allowAlways?: boolean; role?: ReefFederation
       };
     }),
     resolveProposal: vi.fn(
-      (
-        proposalId: string,
-        digest: string,
-        outcome: Omit<ReefFederationProposal, "proposalId" | "mountId" | "digest">,
-      ) => {
+      (proposalId: string, digest: string, outcome: ReefFederationProposalResolution) => {
         const existing = proposals.get(proposalId);
         if (!existing || existing.digest !== digest) {
           return undefined;

--- a/extensions/reef/src/federation-coordinator.test.ts
+++ b/extensions/reef/src/federation-coordinator.test.ts
@@ -9,13 +9,18 @@ import type {
   ReefFederationProposal,
   ReefFederationProposalResolution,
 } from "./federation-state.js";
+import type { ReefPeerIdentity } from "./friend-types.js";
 
 const from = "guest#1";
 const to = "host#1";
 const mount: ReefFederationMount = {
   mountId: "mount-1",
   peer: "guest",
-  peerKeyEpoch: 1,
+  peerIdentity: {
+    ed25519PublicKey: "A".repeat(43),
+    x25519PublicKey: "B".repeat(43),
+    keyEpoch: 1,
+  },
   role: "host",
   sessionKey: "agent:main:shared",
   sessionId: "session-1",
@@ -49,7 +54,7 @@ function promptFrame(
 }
 
 function fixture(fixtureOptions?: { allowAlways?: boolean; role?: ReefFederationMount["role"] }) {
-  let currentPeerKeyEpoch = 1;
+  let currentPeerIdentity = { ...mount.peerIdentity };
   let currentMount = {
     ...mount,
     allowAlways: fixtureOptions?.allowAlways ?? false,
@@ -107,27 +112,27 @@ function fixture(fixtureOptions?: { allowAlways?: boolean; role?: ReefFederation
   const coordinator = new ReefFederationCoordinator(
     { gateway: { isAvailable: async () => true, request: gatewayRequest } },
     state,
-    () => currentPeerKeyEpoch,
+    () => ({ ...currentPeerIdentity }),
   );
   const updateMount = (patch: Partial<ReefFederationMount>) => {
     currentMount = { ...currentMount, ...patch };
   };
-  const updatePeerKeyEpoch = (keyEpoch: number) => {
-    currentPeerKeyEpoch = keyEpoch;
+  const updatePeerIdentity = (patch: Partial<ReefPeerIdentity>) => {
+    currentPeerIdentity = { ...currentPeerIdentity, ...patch };
   };
-  return { coordinator, request, state, proposals, updateMount, updatePeerKeyEpoch };
+  return { coordinator, request, state, proposals, updateMount, updatePeerIdentity };
 }
 
 async function handle(
   coordinator: ReefFederationCoordinator,
   frame = promptFrame(),
-  overrides: Partial<{ peer: string; peerKeyEpoch: number }> = {},
+  overrides: Partial<{ peer: string; peerIdentity: ReefPeerIdentity }> = {},
 ) {
   return await coordinator.handlePrompt({
     from,
     to,
     peer: "guest",
-    peerKeyEpoch: 1,
+    peerIdentity: mount.peerIdentity,
     frame,
     ...overrides,
   });
@@ -222,7 +227,7 @@ describe("Reef federation coordinator", () => {
 
     const rotated = fixture();
     rotated.request.mockImplementationOnce(async () => {
-      rotated.updatePeerKeyEpoch(2);
+      rotated.updatePeerIdentity({ ed25519PublicKey: "C".repeat(43) });
       return { id: "plugin:approval-2", decision: "allow-once" };
     });
     await expect(handle(rotated.coordinator)).resolves.toMatchObject({

--- a/extensions/reef/src/federation-coordinator.test.ts
+++ b/extensions/reef/src/federation-coordinator.test.ts
@@ -43,11 +43,12 @@ function promptFrame(
   };
 }
 
-function fixture(options?: { allowAlways?: boolean; role?: ReefFederationMount["role"] }) {
+function fixture(fixtureOptions?: { allowAlways?: boolean; role?: ReefFederationMount["role"] }) {
+  let currentPeerKeyEpoch = 1;
   let currentMount = {
     ...mount,
-    allowAlways: options?.allowAlways ?? false,
-    role: options?.role ?? mount.role,
+    allowAlways: fixtureOptions?.allowAlways ?? false,
+    role: fixtureOptions?.role ?? mount.role,
   };
   const proposals = new Map<string, ReefFederationProposal>();
   const state = {
@@ -105,8 +106,15 @@ function fixture(options?: { allowAlways?: boolean; role?: ReefFederationMount["
   const coordinator = new ReefFederationCoordinator(
     { gateway: { isAvailable: async () => true, request: gatewayRequest } },
     state,
+    () => currentPeerKeyEpoch,
   );
-  return { coordinator, request, state, proposals };
+  const updateMount = (patch: Partial<ReefFederationMount>) => {
+    currentMount = { ...currentMount, ...patch };
+  };
+  const updatePeerKeyEpoch = (keyEpoch: number) => {
+    currentPeerKeyEpoch = keyEpoch;
+  };
+  return { coordinator, request, state, proposals, updateMount, updatePeerKeyEpoch };
 }
 
 async function handle(
@@ -197,6 +205,30 @@ describe("Reef federation coordinator", () => {
       reason: "stale-session",
     });
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it("revalidates grant and peer authority after host approval", async () => {
+    const revoked = fixture();
+    revoked.request.mockImplementationOnce(async () => {
+      revoked.updateMount({ grantGeneration: 1 });
+      return { id: "plugin:approval-1", decision: "allow-once" };
+    });
+    await expect(handle(revoked.coordinator)).resolves.toMatchObject({
+      type: "session.prompt.denied",
+      reason: "grant-revoked",
+    });
+    expect(revoked.request.mock.calls.some(([method]) => method === "agent")).toBe(false);
+
+    const rotated = fixture();
+    rotated.request.mockImplementationOnce(async () => {
+      rotated.updatePeerKeyEpoch(2);
+      return { id: "plugin:approval-2", decision: "allow-once" };
+    });
+    await expect(handle(rotated.coordinator)).resolves.toMatchObject({
+      type: "session.prompt.denied",
+      reason: "grant-revoked",
+    });
+    expect(rotated.request.mock.calls.some(([method]) => method === "agent")).toBe(false);
   });
 
   it("rejects a guest-side mount offered back to the host", async () => {

--- a/extensions/reef/src/federation-coordinator.test.ts
+++ b/extensions/reef/src/federation-coordinator.test.ts
@@ -17,6 +17,7 @@ const mount: ReefFederationMount = {
   sessionId: "session-1",
   grantGeneration: 0,
   allowAlways: false,
+  revoked: false,
 };
 
 function promptFrame(

--- a/extensions/reef/src/federation-coordinator.test.ts
+++ b/extensions/reef/src/federation-coordinator.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createReefFederatedPromptDigest,
+  type ReefFederationFrame,
+} from "../protocol/federation.js";
+import { ReefFederationCoordinator } from "./federation-coordinator.js";
+import type { ReefFederationMount, ReefFederationProposal } from "./federation-state.js";
+
+const from = "guest#1";
+const to = "host#1";
+const mount: ReefFederationMount = {
+  mountId: "mount-1",
+  peer: "guest",
+  peerKeyEpoch: 1,
+  sessionKey: "agent:main:shared",
+  sessionId: "session-1",
+  grantGeneration: 0,
+  allowAlways: false,
+};
+
+function promptFrame(
+  overrides: Partial<Extract<ReefFederationFrame, { type: "session.prompt.propose" }>> = {},
+): Extract<ReefFederationFrame, { type: "session.prompt.propose" }> {
+  const binding = {
+    from,
+    to,
+    mountId: mount.mountId,
+    proposalId: "proposal-1",
+    sessionId: mount.sessionId,
+    grantGeneration: mount.grantGeneration,
+    text: "Check the current build",
+    ...overrides,
+  };
+  return {
+    type: "session.prompt.propose",
+    mountId: binding.mountId,
+    proposalId: binding.proposalId,
+    sessionId: binding.sessionId,
+    grantGeneration: binding.grantGeneration,
+    text: binding.text,
+    textSha256: createReefFederatedPromptDigest(binding),
+  };
+}
+
+function fixture(options?: { allowAlways?: boolean }) {
+  let currentMount = { ...mount, allowAlways: options?.allowAlways ?? false };
+  const proposals = new Map<string, ReefFederationProposal>();
+  const state = {
+    getMount: vi.fn(() => ({ ...currentMount })),
+    allowAlways: vi.fn((mountId: string, generation: number) => {
+      if (mountId !== currentMount.mountId || generation !== currentMount.grantGeneration) {
+        return false;
+      }
+      currentMount = { ...currentMount, allowAlways: true };
+      return true;
+    }),
+    claimProposal: vi.fn((proposal: ReefFederationProposal) => {
+      const existing = proposals.get(proposal.proposalId);
+      if (!existing) {
+        proposals.set(proposal.proposalId, { ...proposal });
+        return { result: "new" as const, proposal };
+      }
+      return {
+        result:
+          existing.digest === proposal.digest ? ("duplicate" as const) : ("mismatch" as const),
+        proposal: { ...existing },
+      };
+    }),
+    resolveProposal: vi.fn(
+      (
+        proposalId: string,
+        digest: string,
+        outcome: Omit<ReefFederationProposal, "proposalId" | "mountId" | "digest">,
+      ) => {
+        const existing = proposals.get(proposalId);
+        if (!existing || existing.digest !== digest) {
+          return undefined;
+        }
+        const resolved = { ...existing, ...outcome };
+        proposals.set(proposalId, resolved);
+        return resolved;
+      },
+    ),
+  };
+  const request = vi.fn(async (method: string) =>
+    method === "plugin.approval.request"
+      ? { id: "plugin:approval-1", decision: "allow-once" }
+      : { runId: "run-1" },
+  );
+  const coordinator = new ReefFederationCoordinator(
+    { gateway: { isAvailable: async () => true, request } },
+    state,
+  );
+  return { coordinator, request, state, proposals };
+}
+
+async function handle(
+  coordinator: ReefFederationCoordinator,
+  frame = promptFrame(),
+  overrides: Partial<{ peer: string; peerKeyEpoch: number }> = {},
+) {
+  return await coordinator.handlePrompt({
+    from,
+    to,
+    peer: "guest",
+    peerKeyEpoch: 1,
+    frame,
+    ...overrides,
+  });
+}
+
+describe("Reef federation coordinator", () => {
+  it("uses the existing plugin approval and canonical agent admission", async () => {
+    const { coordinator, request } = fixture();
+
+    await expect(handle(coordinator)).resolves.toMatchObject({
+      type: "session.prompt.accepted",
+      runId: "run-1",
+    });
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      "plugin.approval.request",
+      expect.objectContaining({
+        pluginId: "reef",
+        description: "Check the current build",
+        sessionKey: mount.sessionKey,
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+      }),
+      expect.any(Object),
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "agent",
+      expect.objectContaining({
+        expectedExistingSessionId: mount.sessionId,
+        idempotencyKey: "reef:proposal-1",
+        inputProvenance: expect.objectContaining({
+          kind: "inter_session",
+          sourceChannel: "reef",
+          sourceTool: "reef_federated_prompt",
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("stores allow-always and skips approval for the next exact proposal", async () => {
+    const { coordinator, request, state } = fixture();
+    request.mockResolvedValueOnce({ id: "plugin:approval-1", decision: "allow-always" });
+
+    await handle(coordinator);
+    await handle(coordinator, promptFrame({ proposalId: "proposal-2" }));
+
+    expect(state.allowAlways).toHaveBeenCalledWith(mount.mountId, 0);
+    expect(
+      request.mock.calls.filter(([method]) => method === "plugin.approval.request"),
+    ).toHaveLength(1);
+  });
+
+  it("records denial without dispatching an agent run", async () => {
+    const { coordinator, request } = fixture();
+    request.mockResolvedValueOnce({ id: "plugin:approval-1", decision: "deny" });
+
+    await expect(handle(coordinator)).resolves.toMatchObject({
+      type: "session.prompt.denied",
+      reason: "host-denied",
+    });
+    expect(request.mock.calls.some(([method]) => method === "agent")).toBe(false);
+  });
+
+  it("rejects stale grant and session bindings before approval", async () => {
+    const { coordinator, request } = fixture();
+
+    await expect(handle(coordinator, promptFrame({ grantGeneration: 1 }))).resolves.toMatchObject({
+      type: "session.prompt.denied",
+      reason: "grant-revoked",
+    });
+    await expect(
+      handle(coordinator, promptFrame({ sessionId: "session-2" })),
+    ).resolves.toMatchObject({
+      type: "session.prompt.denied",
+      reason: "stale-session",
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("returns a committed duplicate outcome without another run", async () => {
+    const { coordinator, request } = fixture({ allowAlways: true });
+
+    const first = await handle(coordinator);
+    const second = await handle(coordinator);
+
+    expect(second).toEqual(first);
+    expect(request.mock.calls.filter(([method]) => method === "agent")).toHaveLength(1);
+  });
+});

--- a/extensions/reef/src/federation-coordinator.test.ts
+++ b/extensions/reef/src/federation-coordinator.test.ts
@@ -53,7 +53,11 @@ function promptFrame(
   };
 }
 
-function fixture(fixtureOptions?: { allowAlways?: boolean; role?: ReefFederationMount["role"] }) {
+function fixture(fixtureOptions?: {
+  allowAlways?: boolean;
+  role?: ReefFederationMount["role"];
+  proposals?: Map<string, ReefFederationProposal>;
+}) {
   const authority = new AbortController();
   let currentPeerIdentity = { ...mount.peerIdentity };
   let currentMount = {
@@ -61,42 +65,84 @@ function fixture(fixtureOptions?: { allowAlways?: boolean; role?: ReefFederation
     allowAlways: fixtureOptions?.allowAlways ?? false,
     role: fixtureOptions?.role ?? mount.role,
   };
-  const proposals = new Map<string, ReefFederationProposal>();
+  const proposals = fixtureOptions?.proposals ?? new Map<string, ReefFederationProposal>();
   const state = {
     getMount: vi.fn(() => ({ ...currentMount })),
-    allowAlways: vi.fn((mountId: string, generation: number) => {
-      if (mountId !== currentMount.mountId || generation !== currentMount.grantGeneration) {
+    authorizeMount: vi.fn(
+      (candidate: {
+        mountId: string;
+        peer: string;
+        peerIdentity: ReefPeerIdentity;
+        sessionId: string;
+        generation: number;
+      }) => {
+        if (
+          authority.signal.aborted ||
+          candidate.mountId !== currentMount.mountId ||
+          candidate.peer !== currentMount.peer ||
+          candidate.sessionId !== currentMount.sessionId ||
+          candidate.generation !== currentMount.grantGeneration ||
+          candidate.peerIdentity.ed25519PublicKey !== currentMount.peerIdentity.ed25519PublicKey ||
+          candidate.peerIdentity.x25519PublicKey !== currentMount.peerIdentity.x25519PublicKey ||
+          candidate.peerIdentity.keyEpoch !== currentMount.peerIdentity.keyEpoch ||
+          currentMount.revoked ||
+          currentMount.role !== "host"
+        ) {
+          return undefined;
+        }
+        return { ...currentMount };
+      },
+    ),
+    allowAlways: vi.fn((candidate: { mountId: string; generation: number }) => {
+      if (
+        authority.signal.aborted ||
+        candidate.mountId !== currentMount.mountId ||
+        candidate.generation !== currentMount.grantGeneration
+      ) {
         return false;
       }
       currentMount = { ...currentMount, allowAlways: true };
       return true;
     }),
-    claimProposal: vi.fn((proposal: ReefFederationProposal) => {
-      const existing = proposals.get(proposal.proposalId);
-      if (!existing) {
-        proposals.set(proposal.proposalId, { ...proposal });
-        return { result: "new" as const, proposal };
-      }
-      return {
-        result:
-          existing.digest === proposal.digest ? ("duplicate" as const) : ("mismatch" as const),
-        proposal: { ...existing },
-      };
-    }),
+    claimProposal: vi.fn(
+      (
+        proposal: ReefFederationProposal,
+      ): {
+        result: "new" | "duplicate" | "mismatch" | "peer-capacity";
+        proposal: ReefFederationProposal;
+      } => {
+        const existing = proposals.get(proposal.proposalId);
+        if (!existing) {
+          proposals.set(proposal.proposalId, { ...proposal });
+          return { result: "new" as const, proposal };
+        }
+        if (existing.digest !== proposal.digest) {
+          proposals.set(`${proposal.proposalId}:${proposal.digest}`, { ...proposal });
+          return { result: "mismatch", proposal };
+        }
+        return { result: "duplicate", proposal: { ...existing } };
+      },
+    ),
     resolveProposal: vi.fn(
       (proposalId: string, digest: string, outcome: ReefFederationProposalResolution) => {
-        const existing = proposals.get(proposalId);
+        const reboundKey = `${proposalId}:${digest}`;
+        const key = proposals.has(reboundKey) ? reboundKey : proposalId;
+        const existing = proposals.get(key);
         if (!existing || existing.digest !== digest) {
           return undefined;
         }
         const resolved = { ...existing, ...outcome };
-        proposals.set(proposalId, resolved);
+        proposals.set(key, resolved);
         return resolved;
       },
     ),
   };
   const request = vi.fn(
-    async (method: string, _params?: Record<string, unknown>, _options?: { timeoutMs?: number }) =>
+    async (
+      method: string,
+      _params?: Record<string, unknown>,
+      _options?: { timeoutMs?: number; signal?: AbortSignal },
+    ) =>
       method === "plugin.approval.request"
         ? { id: "plugin:approval-1", decision: "allow-once" }
         : { runId: "run-1" },
@@ -104,7 +150,7 @@ function fixture(fixtureOptions?: { allowAlways?: boolean; role?: ReefFederation
   const gatewayRequest = async <T>(
     method: string,
     params?: Record<string, unknown>,
-    options?: { timeoutMs?: number },
+    options?: { timeoutMs?: number; signal?: AbortSignal },
   ): Promise<T> => {
     const response = await request(method, params, options);
     // SAFETY: this fixture returns the exact response shape for each method the coordinator calls.
@@ -149,8 +195,8 @@ async function handle(
 }
 
 describe("Reef federation coordinator", () => {
-  it("uses the existing plugin approval and canonical agent admission", async () => {
-    const { coordinator, request } = fixture();
+  it("uses lifecycle-bound canonical agent admission without an ambiguous deadline", async () => {
+    const { authority, coordinator, request } = fixture();
 
     await expect(handle(coordinator)).resolves.toMatchObject({
       type: "session.prompt.accepted",
@@ -165,7 +211,10 @@ describe("Reef federation coordinator", () => {
         sessionKey: mount.sessionKey,
         allowedDecisions: ["allow-once", "allow-always", "deny"],
       }),
-      expect.any(Object),
+      {
+        timeoutMs: 10 * 60_000,
+        signal: authority.signal,
+      },
     );
     expect(request).toHaveBeenNthCalledWith(
       2,
@@ -179,7 +228,7 @@ describe("Reef federation coordinator", () => {
           sourceTool: "reef_federated_prompt",
         }),
       }),
-      expect.any(Object),
+      { signal: authority.signal },
     );
   });
 
@@ -190,7 +239,9 @@ describe("Reef federation coordinator", () => {
     await handle(coordinator);
     await handle(coordinator, promptFrame({ proposalId: "proposal-2" }));
 
-    expect(state.allowAlways).toHaveBeenCalledWith(mount.mountId, 0);
+    expect(state.allowAlways).toHaveBeenCalledWith(
+      expect.objectContaining({ mountId: mount.mountId, generation: 0 }),
+    );
     expect(
       request.mock.calls.filter(([method]) => method === "plugin.approval.request"),
     ).toHaveLength(1);
@@ -249,6 +300,34 @@ describe("Reef federation coordinator", () => {
     expect(request).not.toHaveBeenCalled();
   });
 
+  it("persists a rebound failure independently from the original proposal", async () => {
+    const { coordinator, proposals, request } = fixture();
+    await handle(coordinator);
+    const rebound = promptFrame({ text: "Different content" });
+
+    await expect(handle(coordinator, rebound)).resolves.toMatchObject({
+      type: "session.prompt.failed",
+      code: "proposal-rebound",
+    });
+    expect(proposals.get(`${rebound.proposalId}:${rebound.textSha256}`)).toMatchObject({
+      digest: rebound.textSha256,
+      status: "failed",
+      outcome: { type: "session.prompt.failed", code: "proposal-rebound" },
+    });
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses a protocol-valid fallback when agent admission omits a run ID", async () => {
+    const { coordinator, request } = fixture({ allowAlways: true });
+    const proposalId = `p${"x".repeat(127)}`;
+    request.mockResolvedValueOnce({ runId: "" });
+
+    await expect(handle(coordinator, promptFrame({ proposalId }))).resolves.toMatchObject({
+      type: "session.prompt.accepted",
+      runId: proposalId,
+    });
+  });
+
   it("bounds dispatch failures by UTF-8 bytes", async () => {
     const { coordinator, proposals, request } = fixture({ allowAlways: true });
     request.mockRejectedValueOnce(new Error("🦞".repeat(512)));
@@ -260,6 +339,20 @@ describe("Reef federation coordinator", () => {
       throw new Error("expected failed prompt outcome");
     }
     expect(Buffer.byteLength(outcome.message, "utf8")).toBe(512);
+    expect(proposals.get("proposal-1")?.outcome).toEqual(outcome);
+  });
+
+  it("persists a protocol-valid fallback for an empty dispatch error", async () => {
+    const { coordinator, proposals, request } = fixture({ allowAlways: true });
+    request.mockRejectedValueOnce(new Error());
+
+    const outcome = await handle(coordinator);
+
+    expect(outcome).toMatchObject({
+      type: "session.prompt.failed",
+      code: "dispatch-failed",
+      message: "Agent admission failed.",
+    });
     expect(proposals.get("proposal-1")?.outcome).toEqual(outcome);
   });
 
@@ -299,6 +392,94 @@ describe("Reef federation coordinator", () => {
       reason: "grant-revoked",
     });
     expect(stopped.request.mock.calls.some(([method]) => method === "agent")).toBe(false);
+  });
+
+  it("does not persist allow-always after its Reef lifecycle closes", async () => {
+    const stopped = fixture();
+    stopped.request.mockImplementationOnce(async () => {
+      stopped.authority.abort();
+      return { id: "plugin:approval-1", decision: "allow-always" };
+    });
+
+    await expect(handle(stopped.coordinator)).resolves.toMatchObject({
+      type: "session.prompt.denied",
+      reason: "grant-revoked",
+    });
+    expect(stopped.state.allowAlways).not.toHaveBeenCalled();
+    expect(stopped.request.mock.calls.some(([method]) => method === "agent")).toBe(false);
+  });
+
+  it("cancels a pending approval with the Reef lifecycle without committing an outcome", async () => {
+    const stopped = fixture();
+    stopped.request.mockImplementationOnce(
+      async (_method, _params, options?: { signal?: AbortSignal }) =>
+        await new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () =>
+              reject(
+                options.signal?.reason instanceof Error
+                  ? options.signal.reason
+                  : new Error("Reef lifecycle ended"),
+              ),
+            { once: true },
+          );
+        }),
+    );
+
+    const pending = handle(stopped.coordinator);
+    await vi.waitFor(() => expect(stopped.request).toHaveBeenCalledTimes(1));
+    stopped.authority.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(stopped.proposals.get("proposal-1")).toMatchObject({ status: "pending" });
+    expect(stopped.proposals.get("proposal-1")?.outcome).toBeUndefined();
+  });
+
+  it("leaves an ambiguous agent abort pending for idempotent lifecycle recovery", async () => {
+    const stopped = fixture();
+    stopped.request
+      .mockResolvedValueOnce({ id: "plugin:approval-1", decision: "allow-once" })
+      .mockImplementationOnce(async () => {
+        stopped.authority.abort();
+        throw new Error("agent admission interrupted");
+      });
+
+    await expect(handle(stopped.coordinator)).rejects.toMatchObject({ name: "AbortError" });
+    expect(stopped.proposals.get("proposal-1")).toMatchObject({
+      status: "pending",
+      approvalId: "plugin:approval-1",
+      approvalDecision: "allow-once",
+    });
+    expect(stopped.proposals.get("proposal-1")?.outcome).toBeUndefined();
+
+    const replacement = fixture({ proposals: stopped.proposals });
+    await expect(handle(replacement.coordinator)).resolves.toMatchObject({
+      type: "session.prompt.accepted",
+      runId: "run-1",
+    });
+    expect(replacement.request.mock.calls.map(([method]) => method)).toEqual(["agent"]);
+    expect(replacement.request).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({ idempotencyKey: "reef:proposal-1" }),
+      { signal: replacement.authority.signal },
+    );
+  });
+
+  it("rejects a peer at retained-proposal capacity before authority or agent work", async () => {
+    const bounded = fixture();
+    bounded.state.claimProposal.mockImplementationOnce((proposal) => ({
+      result: "peer-capacity",
+      proposal,
+    }));
+
+    await expect(handle(bounded.coordinator)).resolves.toMatchObject({
+      type: "session.prompt.failed",
+      code: "peer-capacity",
+      message: "Reef peer @guest exceeded retained prompt capacity.",
+    });
+    expect(bounded.state.getMount).not.toHaveBeenCalled();
+    expect(bounded.request).not.toHaveBeenCalled();
   });
 
   it("rejects a guest-side mount offered back to the host", async () => {

--- a/extensions/reef/src/federation-coordinator.test.ts
+++ b/extensions/reef/src/federation-coordinator.test.ts
@@ -214,6 +214,7 @@ describe("Reef federation coordinator", () => {
       {
         timeoutMs: 10 * 60_000,
         signal: authority.signal,
+        scopes: ["operator.approvals"],
       },
     );
     expect(request).toHaveBeenNthCalledWith(

--- a/extensions/reef/src/federation-coordinator.test.ts
+++ b/extensions/reef/src/federation-coordinator.test.ts
@@ -54,6 +54,7 @@ function promptFrame(
 }
 
 function fixture(fixtureOptions?: { allowAlways?: boolean; role?: ReefFederationMount["role"] }) {
+  const authority = new AbortController();
   let currentPeerIdentity = { ...mount.peerIdentity };
   let currentMount = {
     ...mount,
@@ -113,6 +114,7 @@ function fixture(fixtureOptions?: { allowAlways?: boolean; role?: ReefFederation
     { gateway: { isAvailable: async () => true, request: gatewayRequest } },
     state,
     () => ({ ...currentPeerIdentity }),
+    authority.signal,
   );
   const updateMount = (patch: Partial<ReefFederationMount>) => {
     currentMount = { ...currentMount, ...patch };
@@ -120,7 +122,15 @@ function fixture(fixtureOptions?: { allowAlways?: boolean; role?: ReefFederation
   const updatePeerIdentity = (patch: Partial<ReefPeerIdentity>) => {
     currentPeerIdentity = { ...currentPeerIdentity, ...patch };
   };
-  return { coordinator, request, state, proposals, updateMount, updatePeerIdentity };
+  return {
+    authority,
+    coordinator,
+    request,
+    state,
+    proposals,
+    updateMount,
+    updatePeerIdentity,
+  };
 }
 
 async function handle(
@@ -275,6 +285,20 @@ describe("Reef federation coordinator", () => {
       reason: "grant-revoked",
     });
     expect(rotated.request.mock.calls.some(([method]) => method === "agent")).toBe(false);
+  });
+
+  it("rejects an approved prompt when its Reef lifecycle closes", async () => {
+    const stopped = fixture();
+    stopped.request.mockImplementationOnce(async () => {
+      stopped.authority.abort();
+      return { id: "plugin:approval-1", decision: "allow-once" };
+    });
+
+    await expect(handle(stopped.coordinator)).resolves.toMatchObject({
+      type: "session.prompt.denied",
+      reason: "grant-revoked",
+    });
+    expect(stopped.request.mock.calls.some(([method]) => method === "agent")).toBe(false);
   });
 
   it("rejects a guest-side mount offered back to the host", async () => {

--- a/extensions/reef/src/federation-coordinator.test.ts
+++ b/extensions/reef/src/federation-coordinator.test.ts
@@ -141,7 +141,7 @@ function fixture(fixtureOptions?: {
     async (
       method: string,
       _params?: Record<string, unknown>,
-      _options?: { timeoutMs?: number; signal?: AbortSignal },
+      _options?: { timeoutMs?: number; signal?: AbortSignal; assertAdmissionCurrent?: () => void },
     ) =>
       method === "plugin.approval.request"
         ? { id: "plugin:approval-1", decision: "allow-once" }
@@ -150,7 +150,7 @@ function fixture(fixtureOptions?: {
   const gatewayRequest = async <T>(
     method: string,
     params?: Record<string, unknown>,
-    options?: { timeoutMs?: number; signal?: AbortSignal },
+    options?: { timeoutMs?: number; signal?: AbortSignal; assertAdmissionCurrent?: () => void },
   ): Promise<T> => {
     const response = await request(method, params, options);
     // SAFETY: this fixture returns the exact response shape for each method the coordinator calls.
@@ -229,7 +229,7 @@ describe("Reef federation coordinator", () => {
           sourceTool: "reef_federated_prompt",
         }),
       }),
-      { signal: authority.signal },
+      { signal: authority.signal, assertAdmissionCurrent: expect.any(Function) },
     );
   });
 
@@ -395,6 +395,30 @@ describe("Reef federation coordinator", () => {
     expect(stopped.request.mock.calls.some(([method]) => method === "agent")).toBe(false);
   });
 
+  it.each(["grant", "peer"] as const)(
+    "denies %s revocation during agent admission",
+    async (owner) => {
+      const current = fixture({ allowAlways: true });
+      const admitted = vi.fn();
+      current.request.mockImplementationOnce(async (_method, _params, options) => {
+        if (owner === "grant") {
+          current.updateMount({ revoked: true, grantGeneration: 1 });
+        } else {
+          current.updatePeerIdentity({ keyEpoch: 2 });
+        }
+        options?.assertAdmissionCurrent?.();
+        admitted();
+        return { runId: "run-1" };
+      });
+      const outcome = await handle(current.coordinator);
+      expect(outcome).toMatchObject({ type: "session.prompt.denied", reason: "grant-revoked" });
+      expect(admitted).not.toHaveBeenCalled();
+      expect(current.proposals.get("proposal-1")).toMatchObject({ status: "denied", outcome });
+      await expect(handle(current.coordinator)).resolves.toEqual(outcome);
+      expect(current.request).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("does not persist allow-always after its Reef lifecycle closes", async () => {
     const stopped = fixture();
     stopped.request.mockImplementationOnce(async () => {
@@ -463,7 +487,7 @@ describe("Reef federation coordinator", () => {
     expect(replacement.request).toHaveBeenCalledWith(
       "agent",
       expect.objectContaining({ idempotencyKey: "reef:proposal-1" }),
-      { signal: replacement.authority.signal },
+      { signal: replacement.authority.signal, assertAdmissionCurrent: expect.any(Function) },
     );
   });
 

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -35,6 +35,7 @@ export class ReefFederationCoordinator {
   constructor(
     private readonly runtime: Pick<PluginRuntime, "gateway">,
     private readonly state: FederationState,
+    private readonly currentPeerKeyEpoch: (peer: string) => number | undefined,
   ) {}
 
   /** Validate, approve, and dispatch one remote prompt through canonical agent admission. */
@@ -115,14 +116,29 @@ export class ReefFederationCoordinator {
       }
     }
 
+    const currentMount = this.state.getMount(frame.mountId);
+    const currentPeerKeyEpoch = this.currentPeerKeyEpoch(params.peer);
+    const staleAuthority = this.validateMount({
+      ...params,
+      peerKeyEpoch: currentPeerKeyEpoch ?? -1,
+      mount: currentMount,
+    });
+    if (staleAuthority) {
+      this.state.resolveProposal(frame.proposalId, digest, {
+        status: "denied",
+        ...(approvalId ? { approvalId } : {}),
+      });
+      return this.denied(frame, staleAuthority);
+    }
+
     try {
       const runId = `reef:${frame.proposalId}`;
       const result = await this.runtime.gateway.request<AgentResponse>(
         "agent",
         {
           message: frame.text,
-          sessionKey: mount!.sessionKey,
-          expectedExistingSessionId: mount!.sessionId,
+          sessionKey: currentMount!.sessionKey,
+          expectedExistingSessionId: currentMount!.sessionId,
           idempotencyKey: runId,
           deliver: false,
           inputProvenance: {

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -8,6 +8,7 @@ import type {
   ReefFederationProposal,
   ReefFederationProposalResolution,
 } from "./federation-state.js";
+import { sameReefPeerIdentity, type ReefPeerIdentity } from "./friend-types.js";
 
 const REEF_FEDERATION_APPROVAL_TIMEOUT_MS = 10 * 60_000;
 
@@ -39,7 +40,7 @@ export class ReefFederationCoordinator {
   constructor(
     private readonly runtime: Pick<PluginRuntime, "gateway">,
     private readonly state: FederationState,
-    private readonly currentPeerKeyEpoch: (peer: string) => number | undefined,
+    private readonly currentPeerIdentity: (peer: string) => ReefPeerIdentity | undefined,
   ) {}
 
   /** Validate, approve, and dispatch one remote prompt through canonical agent admission. */
@@ -47,7 +48,7 @@ export class ReefFederationCoordinator {
     from: string;
     to: string;
     peer: string;
-    peerKeyEpoch: number;
+    peerIdentity: ReefPeerIdentity;
     frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>;
   }): Promise<Exclude<ReefFederationFrame, { type: "session.prompt.propose" }>> {
     const { frame } = params;
@@ -124,11 +125,11 @@ export class ReefFederationCoordinator {
     }
 
     const currentMount = this.state.getMount(frame.mountId);
-    const currentPeerKeyEpoch = this.currentPeerKeyEpoch(params.peer);
+    const currentPeerIdentity = this.currentPeerIdentity(params.peer);
     const staleAuthority = this.validateMount({
       ...params,
-      peerKeyEpoch: currentPeerKeyEpoch ?? -1,
-      mount: currentMount,
+      peerIdentity: currentPeerIdentity ?? params.peerIdentity,
+      mount: currentPeerIdentity ? currentMount : undefined,
     });
     if (staleAuthority) {
       const denied = this.denied(frame, staleAuthority);
@@ -186,7 +187,7 @@ export class ReefFederationCoordinator {
 
   private validateMount(params: {
     peer: string;
-    peerKeyEpoch: number;
+    peerIdentity: ReefPeerIdentity;
     frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>;
     mount: ReefFederationMount | undefined;
   }): "grant-revoked" | "stale-session" | undefined {
@@ -196,7 +197,7 @@ export class ReefFederationCoordinator {
       mount.role !== "host" ||
       mount.revoked ||
       mount.peer !== params.peer ||
-      mount.peerKeyEpoch !== params.peerKeyEpoch ||
+      !sameReefPeerIdentity(mount.peerIdentity, params.peerIdentity) ||
       mount.grantGeneration !== frame.grantGeneration
     ) {
       return "grant-revoked";

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -143,6 +143,8 @@ export class ReefFederationCoordinator {
 
     try {
       const runId = `reef:${frame.proposalId}`;
+      // Canonical agent admission converts inter-session provenance into the model-facing safety
+      // envelope. Keep the message undecorated so transcript and display projection remain canonical.
       const result = await this.runtime.gateway.request<AgentResponse>(
         "agent",
         {

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -184,6 +184,7 @@ export class ReefFederationCoordinator {
     if (
       !mount ||
       mount.role !== "host" ||
+      mount.revoked ||
       mount.peer !== params.peer ||
       mount.peerKeyEpoch !== params.peerKeyEpoch ||
       mount.grantGeneration !== frame.grantGeneration

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -167,6 +167,7 @@ export class ReefFederationCoordinator {
     const { frame, mount } = params;
     if (
       !mount ||
+      mount.role !== "host" ||
       mount.peer !== params.peer ||
       mount.peerKeyEpoch !== params.peerKeyEpoch ||
       mount.grantGeneration !== frame.grantGeneration

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -3,7 +3,11 @@ import {
   createReefFederatedPromptDigest,
   type ReefFederationFrame,
 } from "../protocol/federation.js";
-import type { ReefFederationMount, ReefFederationProposal } from "./federation-state.js";
+import type {
+  ReefFederationMount,
+  ReefFederationProposal,
+  ReefFederationProposalResolution,
+} from "./federation-state.js";
 
 const REEF_FEDERATION_APPROVAL_TIMEOUT_MS = 10 * 60_000;
 
@@ -17,7 +21,7 @@ type FederationState = {
   resolveProposal(
     proposalId: string,
     digest: string,
-    outcome: Omit<ReefFederationProposal, "proposalId" | "mountId" | "digest">,
+    outcome: ReefFederationProposalResolution,
   ): ReefFederationProposal | undefined;
 };
 
@@ -69,6 +73,7 @@ export class ReefFederationCoordinator {
       mountId: frame.mountId,
       digest,
       status: "pending",
+      request: structuredClone(params),
     });
     if (claim.result === "mismatch") {
       return this.failed(
@@ -77,7 +82,7 @@ export class ReefFederationCoordinator {
         "The proposal ID is already bound to other content.",
       );
     }
-    const prior = priorOutcome(claim.proposal, frame);
+    const prior = priorOutcome(claim.proposal);
     if (prior) {
       return prior;
     }
@@ -87,11 +92,13 @@ export class ReefFederationCoordinator {
       const approval = await this.requestApproval(params.peer, mount!, frame);
       approvalId = approval.id;
       if (approval.decision === "deny") {
+        const denied = this.denied(frame, "host-denied");
         this.state.resolveProposal(frame.proposalId, digest, {
           status: "denied",
+          outcome: denied,
           ...(approvalId ? { approvalId } : {}),
         });
-        return this.denied(frame, "host-denied");
+        return denied;
       }
       if (approval.decision !== "allow-once" && approval.decision !== "allow-always") {
         return this.recordFailure(
@@ -124,11 +131,13 @@ export class ReefFederationCoordinator {
       mount: currentMount,
     });
     if (staleAuthority) {
+      const denied = this.denied(frame, staleAuthority);
       this.state.resolveProposal(frame.proposalId, digest, {
         status: "denied",
+        outcome: denied,
         ...(approvalId ? { approvalId } : {}),
       });
-      return this.denied(frame, staleAuthority);
+      return denied;
     }
 
     try {
@@ -159,6 +168,7 @@ export class ReefFederationCoordinator {
       };
       this.state.resolveProposal(frame.proposalId, digest, {
         status: "accepted",
+        outcome: accepted,
         ...(approvalId ? { approvalId } : {}),
         runId: accepted.runId,
       });
@@ -225,12 +235,14 @@ export class ReefFederationCoordinator {
     message: string,
     approvalId?: string,
   ): Extract<ReefFederationFrame, { type: "session.prompt.failed" }> {
+    const failed = this.failed(frame, code, message);
     this.state.resolveProposal(frame.proposalId, digest, {
       status: "failed",
+      outcome: failed,
       failureCode: code,
       ...(approvalId ? { approvalId } : {}),
     });
-    return this.failed(frame, code, message);
+    return failed;
   }
 
   private denied(
@@ -264,35 +276,8 @@ export class ReefFederationCoordinator {
 
 function priorOutcome(
   proposal: ReefFederationProposal,
-  frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>,
-): Exclude<ReefFederationFrame, { type: "session.prompt.propose" }> | undefined {
-  if (proposal.status === "accepted" && proposal.runId) {
-    return {
-      type: "session.prompt.accepted",
-      mountId: frame.mountId,
-      proposalId: frame.proposalId,
-      sessionId: frame.sessionId,
-      runId: proposal.runId,
-    };
-  }
-  if (proposal.status === "denied") {
-    return {
-      type: "session.prompt.denied",
-      mountId: frame.mountId,
-      proposalId: frame.proposalId,
-      sessionId: frame.sessionId,
-      reason: "host-denied",
-    };
-  }
-  if (proposal.status === "failed") {
-    return {
-      type: "session.prompt.failed",
-      mountId: frame.mountId,
-      proposalId: frame.proposalId,
-      sessionId: frame.sessionId,
-      code: proposal.failureCode || "dispatch-failed",
-      message: "The prior prompt attempt failed.",
-    };
-  }
-  return undefined;
+):
+  | Exclude<ReefFederationFrame, { type: "session.mount.offer" | "session.prompt.propose" }>
+  | undefined {
+  return proposal.outcome ? structuredClone(proposal.outcome) : undefined;
 }

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -1,4 +1,5 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { truncateUtf8Prefix } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   createReefFederatedPromptDigest,
   type ReefFederationFrame,
@@ -52,23 +53,9 @@ export class ReefFederationCoordinator {
     frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>;
   }): Promise<Exclude<ReefFederationFrame, { type: "session.prompt.propose" }>> {
     const { frame } = params;
-    const mount = this.state.getMount(frame.mountId);
-    const invalid = this.validateMount({ ...params, mount });
-    if (invalid) {
-      return this.denied(frame, invalid);
-    }
-    const digest = createReefFederatedPromptDigest({
-      from: params.from,
-      to: params.to,
-      mountId: frame.mountId,
-      proposalId: frame.proposalId,
-      sessionId: frame.sessionId,
-      grantGeneration: frame.grantGeneration,
-      text: frame.text,
-    });
-    if (digest !== frame.textSha256) {
-      return this.failed(frame, "digest-mismatch", "The prompt digest does not match its binding.");
-    }
+    // Claim before any asynchronous work or authority rejection so every terminal result can be
+    // recovered after the source envelope is acknowledged.
+    const digest = frame.textSha256;
     const claim = this.state.claimProposal({
       proposalId: frame.proposalId,
       mountId: frame.mountId,
@@ -88,18 +75,35 @@ export class ReefFederationCoordinator {
       return prior;
     }
 
+    const mount = this.state.getMount(frame.mountId);
+    const invalid = this.validateMount({ ...params, mount });
+    if (invalid) {
+      return this.recordDenial(frame, digest, invalid);
+    }
+    const expectedDigest = createReefFederatedPromptDigest({
+      from: params.from,
+      to: params.to,
+      mountId: frame.mountId,
+      proposalId: frame.proposalId,
+      sessionId: frame.sessionId,
+      grantGeneration: frame.grantGeneration,
+      text: frame.text,
+    });
+    if (expectedDigest !== digest) {
+      return this.recordFailure(
+        frame,
+        digest,
+        "digest-mismatch",
+        "The prompt digest does not match its binding.",
+      );
+    }
+
     let approvalId: string | undefined;
     if (!mount!.allowAlways) {
       const approval = await this.requestApproval(params.peer, mount!, frame);
       approvalId = approval.id;
       if (approval.decision === "deny") {
-        const denied = this.denied(frame, "host-denied");
-        this.state.resolveProposal(frame.proposalId, digest, {
-          status: "denied",
-          outcome: denied,
-          ...(approvalId ? { approvalId } : {}),
-        });
-        return denied;
+        return this.recordDenial(frame, digest, "host-denied", approvalId);
       }
       if (approval.decision !== "allow-once" && approval.decision !== "allow-always") {
         return this.recordFailure(
@@ -132,13 +136,7 @@ export class ReefFederationCoordinator {
       mount: currentPeerIdentity ? currentMount : undefined,
     });
     if (staleAuthority) {
-      const denied = this.denied(frame, staleAuthority);
-      this.state.resolveProposal(frame.proposalId, digest, {
-        status: "denied",
-        outcome: denied,
-        ...(approvalId ? { approvalId } : {}),
-      });
-      return denied;
+      return this.recordDenial(frame, digest, staleAuthority, approvalId);
     }
 
     try {
@@ -248,6 +246,21 @@ export class ReefFederationCoordinator {
     return failed;
   }
 
+  private recordDenial(
+    frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>,
+    digest: string,
+    reason: Extract<ReefFederationFrame, { type: "session.prompt.denied" }>["reason"],
+    approvalId?: string,
+  ): Extract<ReefFederationFrame, { type: "session.prompt.denied" }> {
+    const denied = this.denied(frame, reason);
+    this.state.resolveProposal(frame.proposalId, digest, {
+      status: "denied",
+      outcome: denied,
+      ...(approvalId ? { approvalId } : {}),
+    });
+    return denied;
+  }
+
   private denied(
     frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>,
     reason: Extract<ReefFederationFrame, { type: "session.prompt.denied" }>["reason"],
@@ -272,7 +285,7 @@ export class ReefFederationCoordinator {
       proposalId: frame.proposalId,
       sessionId: frame.sessionId,
       code,
-      message: message.slice(0, 512),
+      message: truncateUtf8Prefix(message, 512),
     };
   }
 }

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -1,0 +1,280 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import {
+  createReefFederatedPromptDigest,
+  type ReefFederationFrame,
+} from "../protocol/federation.js";
+import type { ReefFederationMount, ReefFederationProposal } from "./federation-state.js";
+
+const REEF_FEDERATION_APPROVAL_TIMEOUT_MS = 10 * 60_000;
+
+type FederationState = {
+  getMount(mountId: string): ReefFederationMount | undefined;
+  allowAlways(mountId: string, expectedGeneration: number): boolean;
+  claimProposal(proposal: ReefFederationProposal): {
+    result: "new" | "duplicate" | "mismatch";
+    proposal: ReefFederationProposal;
+  };
+  resolveProposal(
+    proposalId: string,
+    digest: string,
+    outcome: Omit<ReefFederationProposal, "proposalId" | "mountId" | "digest">,
+  ): ReefFederationProposal | undefined;
+};
+
+type ApprovalResponse = {
+  id?: string;
+  decision?: "allow-once" | "allow-always" | "deny" | null;
+};
+
+type AgentResponse = {
+  runId?: string;
+};
+
+/** Home-Gateway coordinator for exact, host-approved remote prompt proposals. */
+export class ReefFederationCoordinator {
+  constructor(
+    private readonly runtime: Pick<PluginRuntime, "gateway">,
+    private readonly state: FederationState,
+  ) {}
+
+  /** Validate, approve, and dispatch one remote prompt through canonical agent admission. */
+  async handlePrompt(params: {
+    from: string;
+    to: string;
+    peer: string;
+    peerKeyEpoch: number;
+    frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>;
+  }): Promise<Exclude<ReefFederationFrame, { type: "session.prompt.propose" }>> {
+    const { frame } = params;
+    const mount = this.state.getMount(frame.mountId);
+    const invalid = this.validateMount({ ...params, mount });
+    if (invalid) {
+      return this.denied(frame, invalid);
+    }
+    const digest = createReefFederatedPromptDigest({
+      from: params.from,
+      to: params.to,
+      mountId: frame.mountId,
+      proposalId: frame.proposalId,
+      sessionId: frame.sessionId,
+      grantGeneration: frame.grantGeneration,
+      text: frame.text,
+    });
+    if (digest !== frame.textSha256) {
+      return this.failed(frame, "digest-mismatch", "The prompt digest does not match its binding.");
+    }
+    const claim = this.state.claimProposal({
+      proposalId: frame.proposalId,
+      mountId: frame.mountId,
+      digest,
+      status: "pending",
+    });
+    if (claim.result === "mismatch") {
+      return this.failed(
+        frame,
+        "proposal-rebound",
+        "The proposal ID is already bound to other content.",
+      );
+    }
+    const prior = priorOutcome(claim.proposal, frame);
+    if (prior) {
+      return prior;
+    }
+
+    let approvalId: string | undefined;
+    if (!mount!.allowAlways) {
+      const approval = await this.requestApproval(params.peer, mount!, frame);
+      approvalId = approval.id;
+      if (approval.decision === "deny") {
+        this.state.resolveProposal(frame.proposalId, digest, {
+          status: "denied",
+          ...(approvalId ? { approvalId } : {}),
+        });
+        return this.denied(frame, "host-denied");
+      }
+      if (approval.decision !== "allow-once" && approval.decision !== "allow-always") {
+        return this.recordFailure(
+          frame,
+          digest,
+          "approval-unavailable",
+          "No host approval route accepted the prompt.",
+          approvalId,
+        );
+      }
+      if (
+        approval.decision === "allow-always" &&
+        !this.state.allowAlways(frame.mountId, frame.grantGeneration)
+      ) {
+        return this.recordFailure(
+          frame,
+          digest,
+          "grant-stale",
+          "The session grant changed before it could be stored.",
+          approvalId,
+        );
+      }
+    }
+
+    try {
+      const runId = `reef:${frame.proposalId}`;
+      const result = await this.runtime.gateway.request<AgentResponse>(
+        "agent",
+        {
+          message: frame.text,
+          sessionKey: mount!.sessionKey,
+          expectedExistingSessionId: mount!.sessionId,
+          idempotencyKey: runId,
+          deliver: false,
+          inputProvenance: {
+            kind: "inter_session",
+            sourceSessionKey: `reef:${params.peer}:${frame.mountId}`,
+            sourceChannel: "reef",
+            sourceTool: "reef_federated_prompt",
+          },
+        },
+        { timeoutMs: REEF_FEDERATION_APPROVAL_TIMEOUT_MS },
+      );
+      const accepted = {
+        type: "session.prompt.accepted" as const,
+        mountId: frame.mountId,
+        proposalId: frame.proposalId,
+        sessionId: frame.sessionId,
+        runId: result.runId || runId,
+      };
+      this.state.resolveProposal(frame.proposalId, digest, {
+        status: "accepted",
+        ...(approvalId ? { approvalId } : {}),
+        runId: accepted.runId,
+      });
+      return accepted;
+    } catch (error) {
+      return this.recordFailure(
+        frame,
+        digest,
+        "dispatch-failed",
+        error instanceof Error ? error.message : "Prompt dispatch failed.",
+        approvalId,
+      );
+    }
+  }
+
+  private validateMount(params: {
+    peer: string;
+    peerKeyEpoch: number;
+    frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>;
+    mount: ReefFederationMount | undefined;
+  }): "grant-revoked" | "stale-session" | undefined {
+    const { frame, mount } = params;
+    if (
+      !mount ||
+      mount.peer !== params.peer ||
+      mount.peerKeyEpoch !== params.peerKeyEpoch ||
+      mount.grantGeneration !== frame.grantGeneration
+    ) {
+      return "grant-revoked";
+    }
+    if (mount.sessionId !== frame.sessionId) {
+      return "stale-session";
+    }
+    return undefined;
+  }
+
+  private async requestApproval(
+    peer: string,
+    mount: ReefFederationMount,
+    frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>,
+  ): Promise<ApprovalResponse> {
+    return await this.runtime.gateway.request<ApprovalResponse>(
+      "plugin.approval.request",
+      {
+        pluginId: "reef",
+        title: `Guest prompt from @${peer}`,
+        description: frame.text,
+        detail: `Session: ${mount.sessionKey}\nRemote peer: @${peer}\nProposal: ${frame.proposalId}`,
+        severity: "info",
+        sessionKey: mount.sessionKey,
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+        timeoutMs: REEF_FEDERATION_APPROVAL_TIMEOUT_MS,
+      },
+      { timeoutMs: REEF_FEDERATION_APPROVAL_TIMEOUT_MS },
+    );
+  }
+
+  private recordFailure(
+    frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>,
+    digest: string,
+    code: string,
+    message: string,
+    approvalId?: string,
+  ): Extract<ReefFederationFrame, { type: "session.prompt.failed" }> {
+    this.state.resolveProposal(frame.proposalId, digest, {
+      status: "failed",
+      failureCode: code,
+      ...(approvalId ? { approvalId } : {}),
+    });
+    return this.failed(frame, code, message);
+  }
+
+  private denied(
+    frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>,
+    reason: Extract<ReefFederationFrame, { type: "session.prompt.denied" }>["reason"],
+  ): Extract<ReefFederationFrame, { type: "session.prompt.denied" }> {
+    return {
+      type: "session.prompt.denied",
+      mountId: frame.mountId,
+      proposalId: frame.proposalId,
+      sessionId: frame.sessionId,
+      reason,
+    };
+  }
+
+  private failed(
+    frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>,
+    code: string,
+    message: string,
+  ): Extract<ReefFederationFrame, { type: "session.prompt.failed" }> {
+    return {
+      type: "session.prompt.failed",
+      mountId: frame.mountId,
+      proposalId: frame.proposalId,
+      sessionId: frame.sessionId,
+      code,
+      message: message.slice(0, 512),
+    };
+  }
+}
+
+function priorOutcome(
+  proposal: ReefFederationProposal,
+  frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>,
+): Exclude<ReefFederationFrame, { type: "session.prompt.propose" }> | undefined {
+  if (proposal.status === "accepted" && proposal.runId) {
+    return {
+      type: "session.prompt.accepted",
+      mountId: frame.mountId,
+      proposalId: frame.proposalId,
+      sessionId: frame.sessionId,
+      runId: proposal.runId,
+    };
+  }
+  if (proposal.status === "denied") {
+    return {
+      type: "session.prompt.denied",
+      mountId: frame.mountId,
+      proposalId: frame.proposalId,
+      sessionId: frame.sessionId,
+      reason: "host-denied",
+    };
+  }
+  if (proposal.status === "failed") {
+    return {
+      type: "session.prompt.failed",
+      mountId: frame.mountId,
+      proposalId: frame.proposalId,
+      sessionId: frame.sessionId,
+      code: proposal.failureCode || "dispatch-failed",
+      message: "The prior prompt attempt failed.",
+    };
+  }
+  return undefined;
+}

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -42,6 +42,7 @@ export class ReefFederationCoordinator {
     private readonly runtime: Pick<PluginRuntime, "gateway">,
     private readonly state: FederationState,
     private readonly currentPeerIdentity: (peer: string) => ReefPeerIdentity | undefined,
+    private readonly authoritySignal: AbortSignal,
   ) {}
 
   /** Validate, approve, and dispatch one remote prompt through canonical agent admission. */
@@ -137,6 +138,9 @@ export class ReefFederationCoordinator {
     });
     if (staleAuthority) {
       return this.recordDenial(frame, digest, staleAuthority, approvalId);
+    }
+    if (this.authoritySignal.aborted) {
+      return this.recordDenial(frame, digest, "grant-revoked", approvalId);
     }
 
     try {

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -302,6 +302,7 @@ export class ReefFederationCoordinator {
       {
         timeoutMs: REEF_FEDERATION_APPROVAL_TIMEOUT_MS,
         signal: this.authoritySignal,
+        scopes: ["operator.approvals"],
       },
     );
   }

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -8,6 +8,7 @@ import type {
   ReefFederationMount,
   ReefFederationProposal,
   ReefFederationProposalResolution,
+  ReefGrantAuthority,
 } from "./federation-state.js";
 import { sameReefPeerIdentity, type ReefPeerIdentity } from "./friend-types.js";
 
@@ -15,9 +16,10 @@ const REEF_FEDERATION_APPROVAL_TIMEOUT_MS = 10 * 60_000;
 
 type FederationState = {
   getMount(mountId: string): ReefFederationMount | undefined;
-  allowAlways(mountId: string, expectedGeneration: number): boolean;
+  authorizeMount(params: ReefGrantAuthority): ReefFederationMount | undefined;
+  allowAlways(params: ReefGrantAuthority): boolean;
   claimProposal(proposal: ReefFederationProposal): {
-    result: "new" | "duplicate" | "mismatch";
+    result: "new" | "duplicate" | "mismatch" | "peer-capacity";
     proposal: ReefFederationProposal;
   };
   resolveProposal(
@@ -65,10 +67,18 @@ export class ReefFederationCoordinator {
       request: structuredClone(params),
     });
     if (claim.result === "mismatch") {
-      return this.failed(
+      return this.recordFailure(
         frame,
+        digest,
         "proposal-rebound",
         "The proposal ID is already bound to other content.",
+      );
+    }
+    if (claim.result === "peer-capacity") {
+      return this.failed(
+        frame,
+        "peer-capacity",
+        `Reef peer @${params.peer} exceeded retained prompt capacity.`,
       );
     }
     const prior = priorOutcome(claim.proposal);
@@ -76,8 +86,15 @@ export class ReefFederationCoordinator {
       return prior;
     }
 
-    const mount = this.state.getMount(frame.mountId);
-    const invalid = this.validateMount({ ...params, mount });
+    const storedMount = this.state.getMount(frame.mountId);
+    const mount = this.state.authorizeMount({
+      mountId: frame.mountId,
+      peer: params.peer,
+      peerIdentity: params.peerIdentity,
+      sessionId: frame.sessionId,
+      generation: frame.grantGeneration,
+    });
+    const invalid = mount ? undefined : this.validateMount({ ...params, mount: storedMount });
     if (invalid) {
       return this.recordDenial(frame, digest, invalid);
     }
@@ -99,8 +116,8 @@ export class ReefFederationCoordinator {
       );
     }
 
-    let approvalId: string | undefined;
-    if (!mount!.allowAlways) {
+    let approvalId = claim.proposal.approvalId;
+    if (!mount!.allowAlways && claim.proposal.approvalDecision !== "allow-once") {
       const approval = await this.requestApproval(params.peer, mount!, frame);
       approvalId = approval.id;
       if (approval.decision === "deny") {
@@ -115,36 +132,69 @@ export class ReefFederationCoordinator {
           approvalId,
         );
       }
-      if (
-        approval.decision === "allow-always" &&
-        !this.state.allowAlways(frame.mountId, frame.grantGeneration)
-      ) {
-        return this.recordFailure(
-          frame,
-          digest,
-          "grant-stale",
-          "The session grant changed before it could be stored.",
+      if (approval.decision === "allow-once") {
+        const recorded = this.state.resolveProposal(frame.proposalId, digest, {
+          status: "pending",
           approvalId,
-        );
+          approvalDecision: "allow-once",
+        });
+        if (!recorded) {
+          throw new Error("Reef could not persist prompt approval before agent admission");
+        }
+      }
+      if (approval.decision === "allow-always") {
+        const grantPeerIdentity = this.currentPeerIdentity(params.peer);
+        if (!grantPeerIdentity) {
+          return this.recordDenial(frame, digest, "grant-revoked", approvalId);
+        }
+        const grantAuthority = this.state.authorizeMount({
+          mountId: frame.mountId,
+          peer: params.peer,
+          peerIdentity: grantPeerIdentity,
+          sessionId: frame.sessionId,
+          generation: frame.grantGeneration,
+        });
+        // Core revalidates the exact grant and lifecycle after awaited approval work and again in
+        // the synchronous standing-grant write, preventing a closed Reef lifecycle from persisting.
+        if (!grantAuthority) {
+          return this.recordDenial(frame, digest, "grant-revoked", approvalId);
+        }
+        if (
+          !this.state.allowAlways({
+            mountId: frame.mountId,
+            peer: params.peer,
+            peerIdentity: grantPeerIdentity,
+            sessionId: frame.sessionId,
+            generation: frame.grantGeneration,
+          })
+        ) {
+          return this.recordFailure(
+            frame,
+            digest,
+            "grant-stale",
+            "The session grant changed before it could be stored.",
+            approvalId,
+          );
+        }
       }
     }
 
-    const currentMount = this.state.getMount(frame.mountId);
     const currentPeerIdentity = this.currentPeerIdentity(params.peer);
-    const staleAuthority = this.validateMount({
-      ...params,
-      peerIdentity: currentPeerIdentity ?? params.peerIdentity,
-      mount: currentPeerIdentity ? currentMount : undefined,
-    });
-    if (staleAuthority) {
-      return this.recordDenial(frame, digest, staleAuthority, approvalId);
-    }
-    if (this.authoritySignal.aborted) {
+    const currentMount = currentPeerIdentity
+      ? this.state.authorizeMount({
+          mountId: frame.mountId,
+          peer: params.peer,
+          peerIdentity: currentPeerIdentity,
+          sessionId: frame.sessionId,
+          generation: frame.grantGeneration,
+        })
+      : undefined;
+    if (!currentMount) {
       return this.recordDenial(frame, digest, "grant-revoked", approvalId);
     }
 
     try {
-      const runId = `reef:${frame.proposalId}`;
+      const idempotencyKey = `reef:${frame.proposalId}`;
       // Canonical agent admission converts inter-session provenance into the model-facing safety
       // envelope. Keep the message undecorated so transcript and display projection remain canonical.
       const result = await this.runtime.gateway.request<AgentResponse>(
@@ -153,7 +203,7 @@ export class ReefFederationCoordinator {
           message: frame.text,
           sessionKey: currentMount!.sessionKey,
           expectedExistingSessionId: currentMount!.sessionId,
-          idempotencyKey: runId,
+          idempotencyKey,
           deliver: false,
           inputProvenance: {
             kind: "inter_session",
@@ -162,14 +212,16 @@ export class ReefFederationCoordinator {
             sourceTool: "reef_federated_prompt",
           },
         },
-        { timeoutMs: REEF_FEDERATION_APPROVAL_TIMEOUT_MS },
+        // Agent admission is in-process and returns on acceptance. Avoid a separate deadline that
+        // could report failure after execution started; lifecycle closure aborts and retries by key.
+        { signal: this.authoritySignal },
       );
       const accepted = {
         type: "session.prompt.accepted" as const,
         mountId: frame.mountId,
         proposalId: frame.proposalId,
         sessionId: frame.sessionId,
-        runId: result.runId || runId,
+        runId: isProtocolId(result.runId) ? result.runId : frame.proposalId,
       };
       this.state.resolveProposal(frame.proposalId, digest, {
         status: "accepted",
@@ -179,6 +231,9 @@ export class ReefFederationCoordinator {
       });
       return accepted;
     } catch (error) {
+      // Lifecycle cancellation can race accepted agent admission. Leave the durable proposal pending
+      // so recovery reconciles the same idempotency key instead of publishing a false failure.
+      this.authoritySignal.throwIfAborted();
       return this.recordFailure(
         frame,
         digest,
@@ -229,7 +284,10 @@ export class ReefFederationCoordinator {
         allowedDecisions: ["allow-once", "allow-always", "deny"],
         timeoutMs: REEF_FEDERATION_APPROVAL_TIMEOUT_MS,
       },
-      { timeoutMs: REEF_FEDERATION_APPROVAL_TIMEOUT_MS },
+      {
+        timeoutMs: REEF_FEDERATION_APPROVAL_TIMEOUT_MS,
+        signal: this.authoritySignal,
+      },
     );
   }
 
@@ -289,9 +347,13 @@ export class ReefFederationCoordinator {
       proposalId: frame.proposalId,
       sessionId: frame.sessionId,
       code,
-      message: truncateUtf8Prefix(message, 512),
+      message: truncateUtf8Prefix(message, 512) || "Agent admission failed.",
     };
   }
+}
+
+function isProtocolId(value: string | undefined): value is string {
+  return Boolean(value && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value));
 }
 
 function priorOutcome(

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -14,6 +14,8 @@ import { sameReefPeerIdentity, type ReefPeerIdentity } from "./friend-types.js";
 
 const REEF_FEDERATION_APPROVAL_TIMEOUT_MS = 10 * 60_000;
 
+type ProposalClaim = ReturnType<FederationState["claimProposal"]>;
+
 type FederationState = {
   getMount(mountId: string): ReefFederationMount | undefined;
   authorizeMount(params: ReefGrantAuthority): ReefFederationMount | undefined;
@@ -47,25 +49,38 @@ export class ReefFederationCoordinator {
     private readonly authoritySignal: AbortSignal,
   ) {}
 
-  /** Validate, approve, and dispatch one remote prompt through canonical agent admission. */
-  async handlePrompt(params: {
+  /** Durably claim one prompt before its transport envelope is acknowledged. */
+  claimPrompt(params: {
     from: string;
     to: string;
     peer: string;
     peerIdentity: ReefPeerIdentity;
     frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>;
-  }): Promise<Exclude<ReefFederationFrame, { type: "session.prompt.propose" }>> {
+  }): ProposalClaim {
+    return this.state.claimProposal({
+      proposalId: params.frame.proposalId,
+      mountId: params.frame.mountId,
+      digest: params.frame.textSha256,
+      status: "pending",
+      request: structuredClone(params),
+    });
+  }
+
+  /** Validate, approve, and dispatch one remote prompt through canonical agent admission. */
+  async handlePrompt(
+    params: {
+      from: string;
+      to: string;
+      peer: string;
+      peerIdentity: ReefPeerIdentity;
+      frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>;
+    },
+    claim = this.claimPrompt(params),
+  ): Promise<Exclude<ReefFederationFrame, { type: "session.prompt.propose" }>> {
     const { frame } = params;
     // Claim before any asynchronous work or authority rejection so every terminal result can be
     // recovered after the source envelope is acknowledged.
     const digest = frame.textSha256;
-    const claim = this.state.claimProposal({
-      proposalId: frame.proposalId,
-      mountId: frame.mountId,
-      digest,
-      status: "pending",
-      request: structuredClone(params),
-    });
     if (claim.result === "mismatch") {
       return this.recordFailure(
         frame,

--- a/extensions/reef/src/federation-coordinator.ts
+++ b/extensions/reef/src/federation-coordinator.ts
@@ -68,15 +68,17 @@ export class ReefFederationCoordinator {
 
   /** Validate, approve, and dispatch one remote prompt through canonical agent admission. */
   async handlePrompt(
-    params: {
+    input: {
       from: string;
       to: string;
       peer: string;
       peerIdentity: ReefPeerIdentity;
       frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>;
     },
-    claim = this.claimPrompt(params),
+    claim = this.claimPrompt(input),
   ): Promise<Exclude<ReefFederationFrame, { type: "session.prompt.propose" }>> {
+    // Retained admission checks must bind the same proposal across asynchronous preparation.
+    const params = structuredClone(input);
     const { frame } = params;
     // Claim before any asynchronous work or authority rejection so every terminal result can be
     // recovered after the source envelope is acknowledged.
@@ -109,9 +111,9 @@ export class ReefFederationCoordinator {
       sessionId: frame.sessionId,
       generation: frame.grantGeneration,
     });
-    const invalid = mount ? undefined : this.validateMount({ ...params, mount: storedMount });
-    if (invalid) {
-      return this.recordDenial(frame, digest, invalid);
+    if (!mount) {
+      const reason = this.validateMount({ ...params, mount: storedMount }) ?? "grant-revoked";
+      return this.recordDenial(frame, digest, reason);
     }
     const expectedDigest = createReefFederatedPromptDigest({
       from: params.from,
@@ -131,9 +133,21 @@ export class ReefFederationCoordinator {
       );
     }
 
+    const currentAuthority = () => {
+      const peerIdentity = this.currentPeerIdentity(params.peer);
+      return peerIdentity
+        ? {
+            mountId: frame.mountId,
+            peer: params.peer,
+            peerIdentity,
+            sessionId: frame.sessionId,
+            generation: frame.grantGeneration,
+          }
+        : undefined;
+    };
     let approvalId = claim.proposal.approvalId;
-    if (!mount!.allowAlways && claim.proposal.approvalDecision !== "allow-once") {
-      const approval = await this.requestApproval(params.peer, mount!, frame);
+    if (!mount.allowAlways && claim.proposal.approvalDecision !== "allow-once") {
+      const approval = await this.requestApproval(params.peer, mount, frame);
       approvalId = approval.id;
       if (approval.decision === "deny") {
         return this.recordDenial(frame, digest, "host-denied", approvalId);
@@ -158,31 +172,12 @@ export class ReefFederationCoordinator {
         }
       }
       if (approval.decision === "allow-always") {
-        const grantPeerIdentity = this.currentPeerIdentity(params.peer);
-        if (!grantPeerIdentity) {
+        const authority = currentAuthority();
+        // Standing authority is revalidated inside the synchronous core write.
+        if (!authority || !this.state.authorizeMount(authority)) {
           return this.recordDenial(frame, digest, "grant-revoked", approvalId);
         }
-        const grantAuthority = this.state.authorizeMount({
-          mountId: frame.mountId,
-          peer: params.peer,
-          peerIdentity: grantPeerIdentity,
-          sessionId: frame.sessionId,
-          generation: frame.grantGeneration,
-        });
-        // Core revalidates the exact grant and lifecycle after awaited approval work and again in
-        // the synchronous standing-grant write, preventing a closed Reef lifecycle from persisting.
-        if (!grantAuthority) {
-          return this.recordDenial(frame, digest, "grant-revoked", approvalId);
-        }
-        if (
-          !this.state.allowAlways({
-            mountId: frame.mountId,
-            peer: params.peer,
-            peerIdentity: grantPeerIdentity,
-            sessionId: frame.sessionId,
-            generation: frame.grantGeneration,
-          })
-        ) {
+        if (!this.state.allowAlways(authority)) {
           return this.recordFailure(
             frame,
             digest,
@@ -194,19 +189,20 @@ export class ReefFederationCoordinator {
       }
     }
 
-    const currentPeerIdentity = this.currentPeerIdentity(params.peer);
-    const currentMount = currentPeerIdentity
-      ? this.state.authorizeMount({
-          mountId: frame.mountId,
-          peer: params.peer,
-          peerIdentity: currentPeerIdentity,
-          sessionId: frame.sessionId,
-          generation: frame.grantGeneration,
-        })
-      : undefined;
+    const authority = currentAuthority();
+    const currentMount = authority ? this.state.authorizeMount(authority) : undefined;
     if (!currentMount) {
       return this.recordDenial(frame, digest, "grant-revoked", approvalId);
     }
+    let admissionRevoked = false;
+    const assertAdmissionCurrent = () => {
+      const liveAuthority = currentAuthority();
+      if (!liveAuthority || !this.state.authorizeMount(liveAuthority)) {
+        // Record the rejection where it happens; a later transport failure may follow acceptance.
+        admissionRevoked = true;
+        throw new Error("Reef session grant revoked before input admission");
+      }
+    };
 
     try {
       const idempotencyKey = `reef:${frame.proposalId}`;
@@ -216,8 +212,8 @@ export class ReefFederationCoordinator {
         "agent",
         {
           message: frame.text,
-          sessionKey: currentMount!.sessionKey,
-          expectedExistingSessionId: currentMount!.sessionId,
+          sessionKey: currentMount.sessionKey,
+          expectedExistingSessionId: currentMount.sessionId,
           idempotencyKey,
           deliver: false,
           inputProvenance: {
@@ -229,7 +225,7 @@ export class ReefFederationCoordinator {
         },
         // Agent admission is in-process and returns on acceptance. Avoid a separate deadline that
         // could report failure after execution started; lifecycle closure aborts and retries by key.
-        { signal: this.authoritySignal },
+        { signal: this.authoritySignal, assertAdmissionCurrent },
       );
       const accepted = {
         type: "session.prompt.accepted" as const,
@@ -249,6 +245,9 @@ export class ReefFederationCoordinator {
       // Lifecycle cancellation can race accepted agent admission. Leave the durable proposal pending
       // so recovery reconciles the same idempotency key instead of publishing a false failure.
       this.authoritySignal.throwIfAborted();
+      if (admissionRevoked) {
+        return this.recordDenial(frame, digest, "grant-revoked", approvalId);
+      }
       return this.recordFailure(
         frame,
         digest,

--- a/extensions/reef/src/federation-e2e.test.ts
+++ b/extensions/reef/src/federation-e2e.test.ts
@@ -92,8 +92,8 @@ describe("Reef federated prompt E2E", () => {
       },
       hostState,
       (peer) => {
-        const trust = hostTrust.values.get(peer);
-        return trust ? reefPeerIdentity(trust) : undefined;
+        const peerTrust = hostTrust.values.get(peer);
+        return peerTrust ? reefPeerIdentity(peerTrust) : undefined;
       },
     );
     const outcomes: string[] = [];

--- a/extensions/reef/src/federation-e2e.test.ts
+++ b/extensions/reef/src/federation-e2e.test.ts
@@ -6,7 +6,11 @@ import {
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MemoryAuditStore, MemoryReplayStore } from "../protocol/index.js";
+import {
+  createReefFederatedPromptDigest,
+  MemoryAuditStore,
+  MemoryReplayStore,
+} from "../protocol/index.js";
 import { ReefChannelConfigSchema } from "./config-schema.js";
 import { ReefFederationCoordinator } from "./federation-coordinator.js";
 import { ReefFederationState, type ReefFederationMount } from "./federation-state.js";
@@ -41,9 +45,9 @@ function config(handle: string) {
   });
 }
 
-function federationState(name: string): ReefFederationState {
+function federationState(name: string, existingStateDir?: string): ReefFederationState {
   const runtime = createPluginRuntimeMock();
-  const stateDir = tempDirs.make(`openclaw-reef-${name}-`);
+  const stateDir = existingStateDir ?? tempDirs.make(`openclaw-reef-${name}-`);
   runtime.state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
     createPluginStateSyncKeyedStoreForTests<T>("reef", {
       ...options,
@@ -68,7 +72,8 @@ describe("Reef federated prompt E2E", () => {
     const guestKeys = reefKeys();
     const hostTrust = trust({ guest: peerTrust(guestKeys) });
     const guestTrust = trust({ host: peerTrust(hostKeys) });
-    const hostState = federationState("host");
+    const hostStateDir = tempDirs.make("openclaw-reef-host-");
+    const hostState = federationState("host", hostStateDir);
     const guestState = federationState("guest");
     const hostStores = flowStores();
     const guestStores = flowStores();
@@ -148,6 +153,9 @@ describe("Reef federated prompt E2E", () => {
           frame,
         });
         await hostFlow.sendFederation(peer, outcome);
+        if (!hostState.markOutcomeSent(frame.proposalId, frame.textSha256)) {
+          throw new Error(`failed to mark ${frame.proposalId} delivered`);
+        }
       },
       onOwnerNotice: async () => {},
     });
@@ -247,6 +255,42 @@ describe("Reef federated prompt E2E", () => {
         "Try after revocation",
       ),
     ).rejects.toThrow("Only active guest Reef mounts can propose prompts");
+
+    const staleBinding = {
+      from: "guest#1",
+      to: "host#1",
+      mountId: hostMount.mountId,
+      proposalId: "proposal-after-revocation",
+      sessionId: hostMount.sessionId,
+      grantGeneration: 0,
+      text: "Bypass the revoked mount",
+    };
+    hostTransport.sendEnvelope.mockRejectedValueOnce(new Error("relay unavailable"));
+    await expect(
+      guestFlow.sendFederation("host", {
+        type: "session.prompt.propose",
+        mountId: staleBinding.mountId,
+        proposalId: staleBinding.proposalId,
+        sessionId: staleBinding.sessionId,
+        grantGeneration: staleBinding.grantGeneration,
+        text: staleBinding.text,
+        textSha256: createReefFederatedPromptDigest(staleBinding),
+      }),
+    ).rejects.toThrow("relay unavailable");
+
+    expect(outcomes).toEqual(["session.prompt.accepted"]);
     expect(gatewayRequest).toHaveBeenCalledTimes(2);
+    const restartedHostState = federationState("host-restart", hostStateDir);
+    const [unsent] = restartedHostState.listUnsentProposals();
+    expect(unsent).toMatchObject({
+      proposalId: "proposal-after-revocation",
+      status: "denied",
+      outcome: expect.objectContaining({ reason: "grant-revoked" }),
+    });
+
+    await hostFlow.sendFederation(unsent!.request.peer, unsent!.outcome!);
+    expect(restartedHostState.markOutcomeSent(unsent!.proposalId, unsent!.digest)).toBe(true);
+    expect(restartedHostState.listUnsentProposals()).toEqual([]);
+    expect(outcomes).toEqual(["session.prompt.accepted", "session.prompt.denied"]);
   });
 });

--- a/extensions/reef/src/federation-e2e.test.ts
+++ b/extensions/reef/src/federation-e2e.test.ts
@@ -92,8 +92,8 @@ describe("Reef federated prompt E2E", () => {
       },
       hostState,
       (peer) => {
-        const peerTrust = hostTrust.values.get(peer);
-        return peerTrust ? reefPeerIdentity(peerTrust) : undefined;
+        const currentTrust = hostTrust.values.get(peer);
+        return currentTrust ? reefPeerIdentity(currentTrust) : undefined;
       },
     );
     const outcomes: string[] = [];

--- a/extensions/reef/src/federation-e2e.test.ts
+++ b/extensions/reef/src/federation-e2e.test.ts
@@ -90,6 +90,7 @@ describe("Reef federated prompt E2E", () => {
         },
       },
       hostState,
+      (peer) => hostTrust.values.get(peer)?.keyEpoch,
     );
     const outcomes: string[] = [];
     let sequence = 0;

--- a/extensions/reef/src/federation-e2e.test.ts
+++ b/extensions/reef/src/federation-e2e.test.ts
@@ -168,6 +168,7 @@ describe("Reef federated prompt E2E", () => {
             sessionId: frame.sessionId,
             grantGeneration: frame.grantGeneration,
             allowAlways: false,
+            revoked: false,
           });
           return;
         }
@@ -189,6 +190,7 @@ describe("Reef federated prompt E2E", () => {
       sessionId: "session-1",
       grantGeneration: 0,
       allowAlways: false,
+      revoked: false,
     };
     expect(hostState.createMount(hostMount)).toBe(true);
     await hostFlow.sendFederation("guest", {
@@ -233,6 +235,14 @@ describe("Reef federated prompt E2E", () => {
     expect(guestState.getMount(hostMount.mountId)).toMatchObject({
       grantGeneration: 1,
       allowAlways: false,
+      revoked: true,
     });
+    await expect(
+      guestFlow.proposeFederatedPrompt(
+        guestState.getMount(hostMount.mountId)!,
+        "Try after revocation",
+      ),
+    ).rejects.toThrow("Only active guest Reef mounts can propose prompts");
+    expect(gatewayRequest).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/reef/src/federation-e2e.test.ts
+++ b/extensions/reef/src/federation-e2e.test.ts
@@ -1,0 +1,237 @@
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryAuditStore, MemoryReplayStore } from "../protocol/index.js";
+import { ReefChannelConfigSchema } from "./config-schema.js";
+import { ReefFederationCoordinator } from "./federation-coordinator.js";
+import { ReefFederationState, type ReefFederationMount } from "./federation-state.js";
+import { ReefMessageFlow } from "./flow.js";
+import {
+  allow,
+  flowStores,
+  guard,
+  peerTrust,
+  reefKeys,
+  resetFlowStoresForTests,
+  transport,
+  trust,
+} from "./flow.test-helpers.js";
+import type { ReefTransportClient } from "./transport.js";
+import type { InboxEntry } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function config(handle: string) {
+  return ReefChannelConfigSchema.parse({
+    handle,
+    email: `${handle}@example.com`,
+    guard: {
+      provider: "openai",
+      pinnedModel: "mock-2026-07-12",
+      apiKeyEnv: "REEF_TEST_KEY",
+      policyVersion: "v1",
+      timeoutMs: 1_000,
+    },
+  });
+}
+
+function federationState(name: string): ReefFederationState {
+  const runtime = createPluginRuntimeMock();
+  const stateDir = tempDirs.make(`openclaw-reef-${name}-`);
+  runtime.state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateSyncKeyedStoreForTests<T>("reef", {
+      ...options,
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+  return new ReefFederationState(runtime);
+}
+
+beforeEach(() => {
+  resetPluginStateStoreForTests();
+  resetFlowStoresForTests();
+});
+
+afterEach(() => {
+  resetPluginStateStoreForTests();
+  resetFlowStoresForTests();
+});
+
+describe("Reef federated prompt E2E", () => {
+  it("mounts, approves, executes, acknowledges, and revokes across two isolated flows", async () => {
+    const hostKeys = reefKeys();
+    const guestKeys = reefKeys();
+    const hostTrust = trust({ guest: peerTrust(guestKeys) });
+    const guestTrust = trust({ host: peerTrust(hostKeys) });
+    const hostState = federationState("host");
+    const guestState = federationState("guest");
+    const hostStores = flowStores();
+    const guestStores = flowStores();
+    const hostTransport = transport();
+    const guestTransport = transport();
+    const gatewayRequest = vi.fn(async (method: string) =>
+      method === "plugin.approval.request"
+        ? { id: "plugin:approval-1", decision: "allow-once" }
+        : { runId: "run-1" },
+    );
+    const coordinator = new ReefFederationCoordinator(
+      {
+        gateway: {
+          isAvailable: async () => true,
+          request: async <T>(method: string) => {
+            const response = await gatewayRequest(method);
+            // SAFETY: this E2E fixture returns the exact response shape for each invoked method.
+            return response as T;
+          },
+        },
+      },
+      hostState,
+    );
+    const outcomes: string[] = [];
+    let sequence = 0;
+
+    hostTransport.sendEnvelope.mockImplementation(async (_peer, envelope) => {
+      await guestFlow.processEntries([
+        {
+          seq: ++sequence,
+          peer: "host",
+          id: envelope.id,
+          kind: "message",
+          envelope,
+          ts: 1,
+        },
+      ]);
+      return { id: envelope.id, status: "queued" };
+    });
+    guestTransport.sendEnvelope.mockImplementation(async (_peer, envelope) => {
+      await hostFlow.processEntries([
+        {
+          seq: ++sequence,
+          peer: "guest",
+          id: envelope.id,
+          kind: "message",
+          envelope,
+          ts: 1,
+        },
+      ]);
+      return { id: envelope.id, status: "queued" };
+    });
+
+    const hostFlow = new ReefMessageFlow({
+      config: config("host"),
+      trust: hostTrust.store,
+      keys: hostKeys,
+      transport: hostTransport as unknown as ReefTransportClient,
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(1)),
+      replay: new MemoryReplayStore(),
+      ...hostStores,
+      onIngress: async () => {},
+      onFederation: async ({ peer, from, to, frame }) => {
+        if (frame.type !== "session.prompt.propose") {
+          throw new Error(`unexpected host frame ${frame.type}`);
+        }
+        const outcome = await coordinator.handlePrompt({
+          peer,
+          from,
+          to,
+          peerKeyEpoch: 1,
+          frame,
+        });
+        await hostFlow.sendFederation(peer, outcome);
+      },
+      onOwnerNotice: async () => {},
+    });
+    const guestFlow = new ReefMessageFlow({
+      config: config("guest"),
+      trust: guestTrust.store,
+      keys: guestKeys,
+      transport: guestTransport as unknown as ReefTransportClient,
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(2)),
+      replay: new MemoryReplayStore(),
+      ...guestStores,
+      onIngress: async () => {},
+      onFederation: async ({ peer, frame }) => {
+        if (frame.type === "session.mount.offer") {
+          guestState.createMount({
+            mountId: frame.mountId,
+            peer,
+            peerKeyEpoch: 1,
+            role: "guest",
+            sessionKey: frame.sessionKey,
+            sessionId: frame.sessionId,
+            grantGeneration: frame.grantGeneration,
+            allowAlways: false,
+          });
+          return;
+        }
+        if (frame.type === "session.grant.revoked") {
+          guestState.applyRevocation(frame.mountId, frame.grantGeneration);
+          return;
+        }
+        outcomes.push(frame.type);
+      },
+      onOwnerNotice: async () => {},
+    });
+
+    const hostMount: ReefFederationMount = {
+      mountId: "mount-1",
+      peer: "guest",
+      peerKeyEpoch: 1,
+      role: "host",
+      sessionKey: "agent:main:shared",
+      sessionId: "session-1",
+      grantGeneration: 0,
+      allowAlways: false,
+    };
+    expect(hostState.createMount(hostMount)).toBe(true);
+    await hostFlow.sendFederation("guest", {
+      type: "session.mount.offer",
+      mountId: hostMount.mountId,
+      sessionKey: hostMount.sessionKey,
+      sessionId: hostMount.sessionId,
+      grantGeneration: hostMount.grantGeneration,
+    });
+
+    const guestMount = guestState.getMount(hostMount.mountId);
+    expect(guestMount).toMatchObject({ role: "guest", sessionId: "session-1" });
+    await guestFlow.proposeFederatedPrompt(guestMount!, "Inspect the current build");
+
+    expect(outcomes).toEqual(["session.prompt.accepted"]);
+    expect(gatewayRequest.mock.calls.map(([method]) => method)).toEqual([
+      "plugin.approval.request",
+      "agent",
+    ]);
+    const sentProposal = guestTransport.sendEnvelope.mock.calls[0]?.[1];
+    expect(sentProposal).toBeDefined();
+    await hostFlow.processEntries([
+      {
+        seq: ++sequence,
+        peer: "guest",
+        id: sentProposal!.id,
+        kind: "message",
+        envelope: sentProposal!,
+        ts: 2,
+      } satisfies InboxEntry,
+    ]);
+    expect(gatewayRequest).toHaveBeenCalledTimes(2);
+
+    const revoked = hostState.revoke(hostMount.mountId, 0);
+    expect(revoked).toMatchObject({ grantGeneration: 1, allowAlways: false });
+    await hostFlow.sendFederation("guest", {
+      type: "session.grant.revoked",
+      mountId: hostMount.mountId,
+      sessionId: hostMount.sessionId,
+      grantGeneration: revoked!.grantGeneration,
+    });
+    expect(guestState.getMount(hostMount.mountId)).toMatchObject({
+      grantGeneration: 1,
+      allowAlways: false,
+    });
+  });
+});

--- a/extensions/reef/src/federation-e2e.test.ts
+++ b/extensions/reef/src/federation-e2e.test.ts
@@ -21,6 +21,7 @@ import {
   transport,
   trust,
 } from "./flow.test-helpers.js";
+import { reefPeerIdentity } from "./friend-types.js";
 import type { ReefTransportClient } from "./transport.js";
 import type { InboxEntry } from "./types.js";
 
@@ -90,7 +91,10 @@ describe("Reef federated prompt E2E", () => {
         },
       },
       hostState,
-      (peer) => hostTrust.values.get(peer)?.keyEpoch,
+      (peer) => {
+        const trust = hostTrust.values.get(peer);
+        return trust ? reefPeerIdentity(trust) : undefined;
+      },
     );
     const outcomes: string[] = [];
     let sequence = 0;
@@ -140,7 +144,7 @@ describe("Reef federated prompt E2E", () => {
           peer,
           from,
           to,
-          peerKeyEpoch: 1,
+          peerIdentity: reefPeerIdentity(hostTrust.values.get(peer)!),
           frame,
         });
         await hostFlow.sendFederation(peer, outcome);
@@ -162,7 +166,7 @@ describe("Reef federated prompt E2E", () => {
           guestState.createMount({
             mountId: frame.mountId,
             peer,
-            peerKeyEpoch: 1,
+            peerIdentity: reefPeerIdentity(guestTrust.values.get(peer)!),
             role: "guest",
             sessionKey: frame.sessionKey,
             sessionId: frame.sessionId,
@@ -184,7 +188,7 @@ describe("Reef federated prompt E2E", () => {
     const hostMount: ReefFederationMount = {
       mountId: "mount-1",
       peer: "guest",
-      peerKeyEpoch: 1,
+      peerIdentity: reefPeerIdentity(hostTrust.values.get("guest")!),
       role: "host",
       sessionKey: "agent:main:shared",
       sessionId: "session-1",

--- a/extensions/reef/src/federation-e2e.test.ts
+++ b/extensions/reef/src/federation-e2e.test.ts
@@ -100,6 +100,7 @@ describe("Reef federated prompt E2E", () => {
         const currentTrust = hostTrust.values.get(peer);
         return currentTrust ? reefPeerIdentity(currentTrust) : undefined;
       },
+      new AbortController().signal,
     );
     const outcomes: string[] = [];
     let sequence = 0;

--- a/extensions/reef/src/federation-e2e.test.ts
+++ b/extensions/reef/src/federation-e2e.test.ts
@@ -1,9 +1,4 @@
-import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
-import {
-  createPluginStateSyncKeyedStoreForTests,
-  resetPluginStateStoreForTests,
-} from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -14,6 +9,10 @@ import {
 import { ReefChannelConfigSchema } from "./config-schema.js";
 import { ReefFederationCoordinator } from "./federation-coordinator.js";
 import { ReefFederationState, type ReefFederationMount } from "./federation-state.js";
+import {
+  createReefFederationTestRuntime,
+  resetReefFederationTestRuntime,
+} from "./federation-test-runtime.test-support.js";
 import { ReefMessageFlow } from "./flow.js";
 import {
   allow,
@@ -46,23 +45,22 @@ function config(handle: string) {
 }
 
 function federationState(name: string, existingStateDir?: string): ReefFederationState {
-  const runtime = createPluginRuntimeMock();
   const stateDir = existingStateDir ?? tempDirs.make(`openclaw-reef-${name}-`);
-  runtime.state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
-    createPluginStateSyncKeyedStoreForTests<T>("reef", {
-      ...options,
-      env: { OPENCLAW_STATE_DIR: stateDir },
-    });
-  return new ReefFederationState(runtime);
+  return new ReefFederationState(
+    createReefFederationTestRuntime(stateDir),
+    new AbortController().signal,
+  );
 }
 
 beforeEach(() => {
   resetPluginStateStoreForTests();
+  resetReefFederationTestRuntime();
   resetFlowStoresForTests();
 });
 
 afterEach(() => {
   resetPluginStateStoreForTests();
+  resetReefFederationTestRuntime();
   resetFlowStoresForTests();
 });
 
@@ -186,10 +184,26 @@ describe("Reef federated prompt E2E", () => {
           return;
         }
         if (frame.type === "session.grant.revoked") {
-          guestState.applyRevocation(frame.mountId, frame.grantGeneration);
+          guestState.applyRevocation({
+            mountId: frame.mountId,
+            peer,
+            sessionId: frame.sessionId,
+            generation: frame.grantGeneration,
+            peerIdentity: reefPeerIdentity(guestTrust.values.get(peer)!),
+          });
           return;
         }
-        outcomes.push(frame.type);
+        if (frame.type === "session.prompt.propose") {
+          throw new Error("guest received a prompt proposal outcome");
+        }
+        const accepted = guestState.acceptOutboundOutcome(
+          peer,
+          reefPeerIdentity(guestTrust.values.get(peer)!),
+          frame,
+        );
+        if (accepted === "accepted") {
+          outcomes.push(frame.type);
+        }
       },
       onOwnerNotice: async () => {},
     });
@@ -216,7 +230,7 @@ describe("Reef federated prompt E2E", () => {
 
     const guestMount = guestState.getMount(hostMount.mountId);
     expect(guestMount).toMatchObject({ role: "guest", sessionId: "session-1" });
-    await guestFlow.proposeFederatedPrompt(guestMount!, "Inspect the current build");
+    await guestFlow.proposeFederatedPrompt(guestMount!, "Inspect the current build", guestState);
 
     expect(outcomes).toEqual(["session.prompt.accepted"]);
     expect(gatewayRequest.mock.calls.map(([method]) => method)).toEqual([
@@ -254,6 +268,7 @@ describe("Reef federated prompt E2E", () => {
       guestFlow.proposeFederatedPrompt(
         guestState.getMount(hostMount.mountId)!,
         "Try after revocation",
+        guestState,
       ),
     ).rejects.toThrow("Only active guest Reef mounts can propose prompts");
 
@@ -292,6 +307,6 @@ describe("Reef federated prompt E2E", () => {
     await hostFlow.sendFederation(unsent!.request.peer, unsent!.outcome!);
     expect(restartedHostState.markOutcomeSent(unsent!.proposalId, unsent!.digest)).toBe(true);
     expect(restartedHostState.listUnsentProposals()).toEqual([]);
-    expect(outcomes).toEqual(["session.prompt.accepted", "session.prompt.denied"]);
+    expect(outcomes).toEqual(["session.prompt.accepted"]);
   });
 });

--- a/extensions/reef/src/federation-outcome.ts
+++ b/extensions/reef/src/federation-outcome.ts
@@ -1,0 +1,18 @@
+import type { ReefFederationFrame } from "../protocol/federation.js";
+
+export function formatReefFederationOutcome(
+  peer: string,
+  frame: Exclude<ReefFederationFrame, { type: "session.mount.offer" | "session.prompt.propose" }>,
+): string {
+  switch (frame.type) {
+    case "session.prompt.accepted":
+      return `Reef prompt ${frame.proposalId} was accepted by @${peer}.`;
+    case "session.prompt.denied":
+      return `Reef prompt ${frame.proposalId} was denied by @${peer}: ${frame.reason}.`;
+    case "session.prompt.failed":
+      return `Reef prompt ${frame.proposalId} failed at @${peer}: ${frame.message}`;
+    case "session.grant.revoked":
+      return `Reef session mount ${frame.mountId} was revoked by @${peer}.`;
+  }
+  throw new Error("unsupported Reef federation outcome");
+}

--- a/extensions/reef/src/federation-recovery.ts
+++ b/extensions/reef/src/federation-recovery.ts
@@ -1,0 +1,61 @@
+import type { ReefFederationFrame } from "../protocol/federation.js";
+import type { ReefFederationPromptRequest, ReefFederationState } from "./federation-state.js";
+import { sameReefPeerIdentity, type ReefPeerIdentity } from "./friend-types.js";
+
+/** Return whether a recovered outcome still belongs to the peer's exact trusted identity. */
+export function matchesFederatedPromptPeer(
+  request: ReefFederationPromptRequest,
+  currentIdentity: ReefPeerIdentity | undefined,
+): boolean {
+  return Boolean(currentIdentity && sameReefPeerIdentity(currentIdentity, request.peerIdentity));
+}
+
+/** Re-submit every durable terminal outcome that is not already running. */
+export function retryUnsentFederatedPrompts(
+  federation: Pick<ReefFederationState, "listUnsentProposals">,
+  start: (
+    request: ReefFederationPromptRequest,
+    outcome?: Exclude<
+      ReefFederationFrame,
+      { type: "session.mount.offer" | "session.prompt.propose" }
+    >,
+  ) => void | Promise<void>,
+): void {
+  for (const proposal of federation.listUnsentProposals()) {
+    void start(proposal.request, proposal.outcome);
+  }
+}
+
+/** Re-send every durably revoked issuer grant; holder application is generation-idempotent. */
+export async function retryFederatedRevocations(
+  federation: Pick<ReefFederationState, "listMounts" | "acknowledgeRevocation">,
+  send: (
+    peer: string,
+    frame: ReefFederationFrame,
+    peerIdentity: ReefPeerIdentity,
+  ) => Promise<unknown>,
+  onError: (error: unknown, peer: string) => void = () => undefined,
+): Promise<void> {
+  for (const mount of federation.listMounts()) {
+    if (mount.role !== "host" || !mount.revoked || !mount.revocationPending) {
+      continue;
+    }
+    try {
+      await send(
+        mount.peer,
+        {
+          type: "session.grant.revoked",
+          mountId: mount.mountId,
+          sessionId: mount.sessionId,
+          grantGeneration: mount.grantGeneration,
+        },
+        mount.peerIdentity,
+      );
+      if (!federation.acknowledgeRevocation(mount.mountId, mount.grantGeneration)) {
+        throw new Error(`Reef mount ${mount.mountId} lost its durable revocation`);
+      }
+    } catch (error) {
+      onError(error, mount.peer);
+    }
+  }
+}

--- a/extensions/reef/src/federation-state.test.ts
+++ b/extensions/reef/src/federation-state.test.ts
@@ -6,7 +6,11 @@ import {
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { ReefFederationState, type ReefFederationMount } from "./federation-state.js";
+import {
+  ReefFederationState,
+  type ReefFederationMount,
+  type ReefFederationProposal,
+} from "./federation-state.js";
 
 function createRuntime(stateDir: string) {
   const runtime = createPluginRuntimeMock();
@@ -29,6 +33,32 @@ const mount: ReefFederationMount = {
   allowAlways: false,
   revoked: false,
 };
+
+function pendingProposal(overrides: Partial<ReefFederationProposal> = {}): ReefFederationProposal {
+  const digest = "a".repeat(64);
+  return {
+    proposalId: "proposal-1",
+    mountId: mount.mountId,
+    digest,
+    status: "pending",
+    request: {
+      from: "guest#1",
+      to: "host#1",
+      peer: "guest",
+      peerKeyEpoch: 1,
+      frame: {
+        type: "session.prompt.propose",
+        mountId: mount.mountId,
+        proposalId: "proposal-1",
+        sessionId: mount.sessionId,
+        grantGeneration: 0,
+        text: "Check the build",
+        textSha256: digest,
+      },
+    },
+    ...overrides,
+  };
+}
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -71,11 +101,13 @@ describe("Reef federation state", () => {
 
   it("deduplicates an exact proposal and rejects ID rebinding", () => {
     const state = new ReefFederationState(createRuntime(stateDir));
-    const proposal = {
-      proposalId: "proposal-1",
+    const proposal = pendingProposal();
+    const outcome = {
+      type: "session.prompt.accepted" as const,
       mountId: mount.mountId,
-      digest: "a".repeat(64),
-      status: "pending" as const,
+      proposalId: proposal.proposalId,
+      sessionId: mount.sessionId,
+      runId: "run-1",
     };
 
     expect(state.claimProposal(proposal).result).toBe("new");
@@ -85,7 +117,24 @@ describe("Reef federation state", () => {
       state.resolveProposal(proposal.proposalId, proposal.digest, {
         status: "accepted",
         runId: "run-1",
+        outcome,
       }),
     ).toMatchObject({ status: "accepted", runId: "run-1" });
+    expect(state.listUnsentProposals()).toEqual([
+      expect.objectContaining({ proposalId: proposal.proposalId, outcome }),
+    ]);
+    expect(state.markOutcomeSent(proposal.proposalId, proposal.digest)).toBe(true);
+    expect(state.listUnsentProposals()).toEqual([]);
+  });
+
+  it("limits live mounts per peer", () => {
+    const state = new ReefFederationState(createRuntime(stateDir));
+    for (let index = 0; index < 32; index += 1) {
+      expect(
+        state.createMount({ ...mount, mountId: `mount-${index}`, sessionId: `session-${index}` }),
+      ).toBe(true);
+    }
+    expect(state.createMount({ ...mount, mountId: "mount-overflow" })).toBe(false);
+    expect(state.createMount({ ...mount, mountId: "other-peer", peer: "other" })).toBe(true);
   });
 });

--- a/extensions/reef/src/federation-state.test.ts
+++ b/extensions/reef/src/federation-state.test.ts
@@ -25,7 +25,11 @@ function createRuntime(stateDir: string) {
 const mount: ReefFederationMount = {
   mountId: "mount-1",
   peer: "guest",
-  peerKeyEpoch: 1,
+  peerIdentity: {
+    ed25519PublicKey: "A".repeat(43),
+    x25519PublicKey: "B".repeat(43),
+    keyEpoch: 1,
+  },
   role: "host",
   sessionKey: "agent:main:shared",
   sessionId: "session-1",
@@ -45,7 +49,7 @@ function pendingProposal(overrides: Partial<ReefFederationProposal> = {}): ReefF
       from: "guest#1",
       to: "host#1",
       peer: "guest",
-      peerKeyEpoch: 1,
+      peerIdentity: mount.peerIdentity,
       frame: {
         type: "session.prompt.propose",
         mountId: mount.mountId,

--- a/extensions/reef/src/federation-state.test.ts
+++ b/extensions/reef/src/federation-state.test.ts
@@ -1,12 +1,10 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ReefFederationState, type ReefFederationMount } from "./federation-state.js";
 
@@ -24,23 +22,25 @@ const mount: ReefFederationMount = {
   mountId: "mount-1",
   peer: "guest",
   peerKeyEpoch: 1,
+  role: "host",
   sessionKey: "agent:main:shared",
   sessionId: "session-1",
   grantGeneration: 0,
   allowAlways: false,
 };
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 describe("Reef federation state", () => {
   let stateDir = "";
 
   beforeEach(() => {
     resetPluginStateStoreForTests();
-    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reef-federation-"));
+    stateDir = tempDirs.make("openclaw-reef-federation-");
   });
 
   afterEach(() => {
     resetPluginStateStoreForTests();
-    fs.rmSync(stateDir, { recursive: true, force: true });
   });
 
   it("persists session-scoped grants and revokes them by generation", () => {
@@ -58,6 +58,12 @@ describe("Reef federation state", () => {
       grantGeneration: 1,
     });
     expect(state.allowAlways(mount.mountId, 0)).toBe(false);
+    expect(state.applyRevocation(mount.mountId, 3)).toBe(true);
+    expect(state.getMount(mount.mountId)).toMatchObject({
+      allowAlways: false,
+      grantGeneration: 3,
+    });
+    expect(state.applyRevocation(mount.mountId, 2)).toBe(false);
   });
 
   it("deduplicates an exact proposal and rejects ID rebinding", () => {

--- a/extensions/reef/src/federation-state.test.ts
+++ b/extensions/reef/src/federation-state.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ReefFederationState, type ReefFederationMount } from "./federation-state.js";
+
+function createRuntime(stateDir: string) {
+  const runtime = createPluginRuntimeMock();
+  runtime.state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateSyncKeyedStoreForTests<T>("reef", {
+      ...options,
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+  return runtime;
+}
+
+const mount: ReefFederationMount = {
+  mountId: "mount-1",
+  peer: "guest",
+  peerKeyEpoch: 1,
+  sessionKey: "agent:main:shared",
+  sessionId: "session-1",
+  grantGeneration: 0,
+  allowAlways: false,
+};
+
+describe("Reef federation state", () => {
+  let stateDir = "";
+
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reef-federation-"));
+  });
+
+  afterEach(() => {
+    resetPluginStateStoreForTests();
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("persists session-scoped grants and revokes them by generation", () => {
+    const state = new ReefFederationState(createRuntime(stateDir));
+    expect(state.createMount(mount)).toBe(true);
+    expect(state.allowAlways(mount.mountId, 0)).toBe(true);
+    expect(new ReefFederationState(createRuntime(stateDir)).getMount(mount.mountId)).toMatchObject({
+      allowAlways: true,
+      grantGeneration: 0,
+      sessionId: mount.sessionId,
+    });
+
+    expect(state.revoke(mount.mountId, 0)).toMatchObject({
+      allowAlways: false,
+      grantGeneration: 1,
+    });
+    expect(state.allowAlways(mount.mountId, 0)).toBe(false);
+  });
+
+  it("deduplicates an exact proposal and rejects ID rebinding", () => {
+    const state = new ReefFederationState(createRuntime(stateDir));
+    const proposal = {
+      proposalId: "proposal-1",
+      mountId: mount.mountId,
+      digest: "a".repeat(64),
+      status: "pending" as const,
+    };
+
+    expect(state.claimProposal(proposal).result).toBe("new");
+    expect(state.claimProposal(proposal).result).toBe("duplicate");
+    expect(state.claimProposal({ ...proposal, digest: "b".repeat(64) }).result).toBe("mismatch");
+    expect(
+      state.resolveProposal(proposal.proposalId, proposal.digest, {
+        status: "accepted",
+        runId: "run-1",
+      }),
+    ).toMatchObject({ status: "accepted", runId: "run-1" });
+  });
+});

--- a/extensions/reef/src/federation-state.test.ts
+++ b/extensions/reef/src/federation-state.test.ts
@@ -27,6 +27,7 @@ const mount: ReefFederationMount = {
   sessionId: "session-1",
   grantGeneration: 0,
   allowAlways: false,
+  revoked: false,
 };
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -55,12 +56,14 @@ describe("Reef federation state", () => {
 
     expect(state.revoke(mount.mountId, 0)).toMatchObject({
       allowAlways: false,
+      revoked: true,
       grantGeneration: 1,
     });
     expect(state.allowAlways(mount.mountId, 0)).toBe(false);
     expect(state.applyRevocation(mount.mountId, 3)).toBe(true);
     expect(state.getMount(mount.mountId)).toMatchObject({
       allowAlways: false,
+      revoked: true,
       grantGeneration: 3,
     });
     expect(state.applyRevocation(mount.mountId, 2)).toBe(false);

--- a/extensions/reef/src/federation-state.test.ts
+++ b/extensions/reef/src/federation-state.test.ts
@@ -1,3 +1,4 @@
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -360,6 +361,47 @@ describe("Reef federation state", () => {
         }),
       ).result,
     ).toBe("new");
+  });
+
+  it("returns peer-capacity when other peers fill the durable proposal store", () => {
+    const runtime = createRuntime(stateDir);
+    const openStore = runtime.state.openSyncKeyedStore;
+    const base = pendingProposal();
+    const retained = Array.from({ length: 5_000 }, (_, index) => {
+      const proposalId = `global-${index}`;
+      return {
+        key: proposalId,
+        value: pendingProposal({
+          proposalId,
+          request: {
+            ...base.request,
+            peer: `peer-${Math.floor(index / 127)}`,
+            frame: { ...base.request.frame, proposalId },
+          },
+        }),
+        createdAt: index,
+      };
+    });
+    runtime.state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) => {
+      const store = openStore<T>(options);
+      return options.namespace === "federation-proposals"
+        ? { ...store, entries: () => retained as Array<(typeof retained)[number] & { value: T }> }
+        : store;
+    };
+    const state = new ReefFederationState(runtime, new AbortController().signal);
+
+    expect(
+      state.claimProposal(
+        pendingProposal({
+          proposalId: "global-overflow",
+          request: {
+            ...base.request,
+            peer: "peer-below-quota",
+            frame: { ...base.request.frame, proposalId: "global-overflow" },
+          },
+        }),
+      ).result,
+    ).toBe("peer-capacity");
   });
 
   it("limits live mounts per peer", () => {

--- a/extensions/reef/src/federation-state.test.ts
+++ b/extensions/reef/src/federation-state.test.ts
@@ -1,9 +1,4 @@
-import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
-import {
-  createPluginStateSyncKeyedStoreForTests,
-  resetPluginStateStoreForTests,
-} from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -11,15 +6,13 @@ import {
   type ReefFederationMount,
   type ReefFederationProposal,
 } from "./federation-state.js";
+import {
+  createReefFederationTestRuntime,
+  resetReefFederationTestRuntime,
+} from "./federation-test-runtime.test-support.js";
 
 function createRuntime(stateDir: string) {
-  const runtime = createPluginRuntimeMock();
-  runtime.state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
-    createPluginStateSyncKeyedStoreForTests<T>("reef", {
-      ...options,
-      env: { OPENCLAW_STATE_DIR: stateDir },
-    });
-  return runtime;
+  return createReefFederationTestRuntime(stateDir);
 }
 
 const mount: ReefFederationMount = {
@@ -71,18 +64,32 @@ describe("Reef federation state", () => {
 
   beforeEach(() => {
     resetPluginStateStoreForTests();
+    resetReefFederationTestRuntime();
     stateDir = tempDirs.make("openclaw-reef-federation-");
   });
 
   afterEach(() => {
     resetPluginStateStoreForTests();
+    resetReefFederationTestRuntime();
   });
 
   it("persists session-scoped grants and revokes them by generation", () => {
-    const state = new ReefFederationState(createRuntime(stateDir));
+    const state = new ReefFederationState(createRuntime(stateDir), new AbortController().signal);
     expect(state.createMount(mount)).toBe(true);
-    expect(state.allowAlways(mount.mountId, 0)).toBe(true);
-    expect(new ReefFederationState(createRuntime(stateDir)).getMount(mount.mountId)).toMatchObject({
+    expect(
+      state.allowAlways({
+        mountId: mount.mountId,
+        peer: mount.peer,
+        peerIdentity: mount.peerIdentity,
+        sessionId: mount.sessionId,
+        generation: 0,
+      }),
+    ).toBe(true);
+    expect(
+      new ReefFederationState(createRuntime(stateDir), new AbortController().signal).getMount(
+        mount.mountId,
+      ),
+    ).toMatchObject({
       allowAlways: true,
       grantGeneration: 0,
       sessionId: mount.sessionId,
@@ -93,18 +100,159 @@ describe("Reef federation state", () => {
       revoked: true,
       grantGeneration: 1,
     });
-    expect(state.allowAlways(mount.mountId, 0)).toBe(false);
-    expect(state.applyRevocation(mount.mountId, 3)).toBe(true);
+    expect(state.revoke(mount.mountId, 1)).toMatchObject({
+      revoked: true,
+      grantGeneration: 1,
+    });
+    expect(
+      state.allowAlways({
+        mountId: mount.mountId,
+        peer: mount.peer,
+        peerIdentity: mount.peerIdentity,
+        sessionId: mount.sessionId,
+        generation: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("invalidates persisted grants when the local Reef identity rotates", () => {
+    const first = new ReefFederationState(
+      createRuntime(stateDir),
+      new AbortController().signal,
+      "local-key-1",
+    );
+    expect(first.createMount(mount)).toBe(true);
+
+    const rotated = new ReefFederationState(
+      createRuntime(stateDir),
+      new AbortController().signal,
+      "local-key-2",
+    );
+    expect(
+      rotated.authorizeMount({
+        mountId: mount.mountId,
+        peer: mount.peer,
+        peerIdentity: mount.peerIdentity,
+        sessionId: mount.sessionId,
+        generation: mount.grantGeneration,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("fails every grant operation closed after the Reef lifecycle ends", () => {
+    const authority = new AbortController();
+    const state = new ReefFederationState(createRuntime(stateDir), authority.signal);
+    expect(state.createMount(mount)).toBe(true);
+
+    authority.abort();
+
+    expect(state.getMount(mount.mountId)).toBeUndefined();
+    expect(state.listMounts()).toEqual([]);
+    expect(state.createMount({ ...mount, mountId: "closed-mount" })).toBe(false);
+    expect(state.revoke(mount.mountId, mount.grantGeneration)).toBeUndefined();
+    expect(
+      state.authorizeMount({
+        mountId: mount.mountId,
+        peer: mount.peer,
+        peerIdentity: mount.peerIdentity,
+        sessionId: mount.sessionId,
+        generation: mount.grantGeneration,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("binds incoming revocations to the peer's exact guest mount", () => {
+    const state = new ReefFederationState(createRuntime(stateDir), new AbortController().signal);
+    expect(state.createMount({ ...mount, role: "guest" })).toBe(true);
+    expect(
+      state.applyRevocation({
+        mountId: mount.mountId,
+        peer: "other-peer",
+        sessionId: mount.sessionId,
+        generation: 3,
+        peerIdentity: mount.peerIdentity,
+      }),
+    ).toBe(false);
+    expect(
+      state.applyRevocation({
+        mountId: mount.mountId,
+        peer: mount.peer,
+        sessionId: "other-session",
+        generation: 3,
+        peerIdentity: mount.peerIdentity,
+      }),
+    ).toBe(false);
+    expect(
+      state.applyRevocation({
+        mountId: mount.mountId,
+        peer: mount.peer,
+        sessionId: mount.sessionId,
+        generation: 3,
+        peerIdentity: mount.peerIdentity,
+      }),
+    ).toBe(true);
     expect(state.getMount(mount.mountId)).toMatchObject({
       allowAlways: false,
       revoked: true,
       grantGeneration: 3,
     });
-    expect(state.applyRevocation(mount.mountId, 2)).toBe(false);
+    expect(
+      state.applyRevocation({
+        mountId: mount.mountId,
+        peer: mount.peer,
+        sessionId: mount.sessionId,
+        generation: 2,
+        peerIdentity: mount.peerIdentity,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts outbound outcomes only for their exact guest mount and proposal binding", () => {
+    const state = new ReefFederationState(createRuntime(stateDir), new AbortController().signal);
+    expect(state.createMount({ ...mount, role: "guest" })).toBe(true);
+    const request = pendingProposal().request;
+    const outcome = {
+      type: "session.prompt.accepted" as const,
+      mountId: mount.mountId,
+      proposalId: request.frame.proposalId,
+      sessionId: mount.sessionId,
+      runId: "run-1",
+    };
+
+    expect(state.registerOutboundProposal(request)).toBe(true);
+    expect(state.registerOutboundProposal(request)).toBe(true);
+    expect(state.acceptOutboundOutcome("other-peer", mount.peerIdentity, outcome)).toBe("invalid");
+    expect(
+      state.acceptOutboundOutcome(mount.peer, mount.peerIdentity, {
+        ...outcome,
+        sessionId: "other-session",
+      }),
+    ).toBe("invalid");
+    expect(state.revoke(mount.mountId, 0)).toBeUndefined();
+    expect(
+      state.applyRevocation({
+        mountId: mount.mountId,
+        peer: mount.peer,
+        peerIdentity: mount.peerIdentity,
+        sessionId: mount.sessionId,
+        generation: 1,
+      }),
+    ).toBe(true);
+    expect(state.acceptOutboundOutcome(mount.peer, mount.peerIdentity, outcome)).toBe("accepted");
+    expect(state.acceptOutboundOutcome(mount.peer, mount.peerIdentity, outcome)).toBe("duplicate");
+  });
+
+  it("finds an unresolved outbound proposal for idempotent command retry", () => {
+    const state = new ReefFederationState(createRuntime(stateDir), new AbortController().signal);
+    const request = pendingProposal().request;
+    expect(state.registerOutboundProposal(request)).toBe(true);
+    expect(state.findOutboundProposal({ ...mount, role: "guest" }, request.frame.text)).toEqual(
+      request,
+    );
   });
 
   it("deduplicates an exact proposal and rejects ID rebinding", () => {
-    const state = new ReefFederationState(createRuntime(stateDir));
+    const state = new ReefFederationState(createRuntime(stateDir), new AbortController().signal);
     const proposal = pendingProposal();
     const outcome = {
       type: "session.prompt.accepted" as const,
@@ -116,7 +264,22 @@ describe("Reef federation state", () => {
 
     expect(state.claimProposal(proposal).result).toBe("new");
     expect(state.claimProposal(proposal).result).toBe("duplicate");
-    expect(state.claimProposal({ ...proposal, digest: "b".repeat(64) }).result).toBe("mismatch");
+    const reboundDigest = "b".repeat(64);
+    expect(state.claimProposal({ ...proposal, digest: reboundDigest }).result).toBe("mismatch");
+    const reboundOutcome = {
+      type: "session.prompt.failed" as const,
+      mountId: mount.mountId,
+      proposalId: proposal.proposalId,
+      sessionId: mount.sessionId,
+      code: "proposal-rebound",
+      message: "The proposal ID is already bound to other content.",
+    };
+    expect(
+      state.resolveProposal(proposal.proposalId, reboundDigest, {
+        status: "failed",
+        outcome: reboundOutcome,
+      }),
+    ).toBeDefined();
     expect(
       state.resolveProposal(proposal.proposalId, proposal.digest, {
         status: "accepted",
@@ -124,15 +287,83 @@ describe("Reef federation state", () => {
         outcome,
       }),
     ).toMatchObject({ status: "accepted", runId: "run-1" });
-    expect(state.listUnsentProposals()).toEqual([
-      expect.objectContaining({ proposalId: proposal.proposalId, outcome }),
-    ]);
+    expect(state.listUnsentProposals()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ proposalId: proposal.proposalId, outcome }),
+        expect.objectContaining({ proposalId: proposal.proposalId, outcome: reboundOutcome }),
+      ]),
+    );
     expect(state.markOutcomeSent(proposal.proposalId, proposal.digest)).toBe(true);
+    expect(state.markOutcomeSent(proposal.proposalId, reboundDigest)).toBe(true);
     expect(state.listUnsentProposals()).toEqual([]);
+
+    const rotatedProposal = pendingProposal({
+      proposalId: "proposal-rotated",
+      request: {
+        ...proposal.request,
+        frame: { ...proposal.request.frame, proposalId: "proposal-rotated" },
+      },
+    });
+    const rotatedOutcome = { ...outcome, proposalId: rotatedProposal.proposalId };
+    expect(state.claimProposal(rotatedProposal).result).toBe("new");
+    expect(
+      state.resolveProposal(rotatedProposal.proposalId, rotatedProposal.digest, {
+        status: "accepted",
+        outcome: rotatedOutcome,
+      }),
+    ).toBeDefined();
+    expect(state.abandonOutcome(rotatedProposal.proposalId, rotatedProposal.digest)).toBe(true);
+    expect(state.listUnsentProposals()).toEqual([]);
+    expect(state.claimProposal(rotatedProposal).proposal).toMatchObject({
+      outcomeAbandonReason: "peer-identity-changed",
+    });
+  });
+
+  it("bounds retained proposals per peer without blocking duplicates or other peers", () => {
+    const state = new ReefFederationState(createRuntime(stateDir), new AbortController().signal);
+    const base = pendingProposal();
+    for (let index = 0; index < 128; index += 1) {
+      const proposalId = `proposal-${index}`;
+      expect(
+        state.claimProposal(
+          pendingProposal({
+            proposalId,
+            request: {
+              ...base.request,
+              frame: { ...base.request.frame, proposalId },
+            },
+          }),
+        ).result,
+      ).toBe("new");
+    }
+
+    const first = pendingProposal({
+      proposalId: "proposal-0",
+      request: {
+        ...base.request,
+        frame: { ...base.request.frame, proposalId: "proposal-0" },
+      },
+    });
+    expect(state.claimProposal(first).result).toBe("duplicate");
+    expect(state.claimProposal(pendingProposal({ proposalId: "proposal-overflow" })).result).toBe(
+      "peer-capacity",
+    );
+    expect(
+      state.claimProposal(
+        pendingProposal({
+          proposalId: "proposal-other-peer",
+          request: {
+            ...base.request,
+            peer: "other",
+            frame: { ...base.request.frame, proposalId: "proposal-other-peer" },
+          },
+        }),
+      ).result,
+    ).toBe("new");
   });
 
   it("limits live mounts per peer", () => {
-    const state = new ReefFederationState(createRuntime(stateDir));
+    const state = new ReefFederationState(createRuntime(stateDir), new AbortController().signal);
     for (let index = 0; index < 32; index += 1) {
       expect(
         state.createMount({ ...mount, mountId: `mount-${index}`, sessionId: `session-${index}` }),

--- a/extensions/reef/src/federation-state.test.ts
+++ b/extensions/reef/src/federation-state.test.ts
@@ -286,6 +286,21 @@ describe("Reef federation state", () => {
     expect(state.acceptOutboundOutcome(mount.peer, mount.peerIdentity, outcome)).toBe("duplicate");
   });
 
+  it("lists cloned inbound and outbound proposals for operator status surfaces", () => {
+    const state = new ReefFederationState(createRuntime(stateDir), new AbortController().signal);
+    const proposal = pendingProposal();
+    expect(state.claimProposal(proposal).result).toBe("new");
+    expect(state.registerOutboundProposal(proposal.request)).toBe(true);
+
+    const inbound = state.listPromptProposals();
+    const outbound = state.listOutboundPromptProposals();
+    inbound[0]!.request.frame.text = "mutated inbound copy";
+    outbound[0]!.frame.text = "mutated outbound copy";
+
+    expect(state.listPromptProposals()[0]?.request.frame.text).toBe("Check the build");
+    expect(state.listOutboundPromptProposals()[0]?.frame.text).toBe("Check the build");
+  });
+
   it("finds an unresolved outbound proposal for idempotent command retry", () => {
     const state = new ReefFederationState(createRuntime(stateDir), new AbortController().signal);
     const request = pendingProposal().request;

--- a/extensions/reef/src/federation-state.test.ts
+++ b/extensions/reef/src/federation-state.test.ts
@@ -1,7 +1,9 @@
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createReefFederatedPromptDigest } from "../protocol/federation.js";
+import { ReefFederationCoordinator } from "./federation-coordinator.js";
 import {
   ReefFederationState,
   type ReefFederationMount,
@@ -116,19 +118,34 @@ describe("Reef federation state", () => {
     ).toBe(false);
   });
 
-  it("invalidates persisted grants when the local Reef identity rotates", () => {
+  it("durably denies retained proposals when the local Reef identity rotates", async () => {
     const first = new ReefFederationState(
       createRuntime(stateDir),
       new AbortController().signal,
       "local-key-1",
     );
     expect(first.createMount(mount)).toBe(true);
+    const proposal = pendingProposal();
+    proposal.digest = createReefFederatedPromptDigest({
+      from: proposal.request.from,
+      to: proposal.request.to,
+      mountId: proposal.mountId,
+      proposalId: proposal.proposalId,
+      sessionId: mount.sessionId,
+      grantGeneration: mount.grantGeneration,
+      text: proposal.request.frame.text,
+    });
+    proposal.request.frame.textSha256 = proposal.digest;
+    expect(first.claimProposal(proposal).result).toBe("new");
+    first.resolveProposal(proposal.proposalId, proposal.digest, {
+      status: "pending",
+      approvalId: "plugin:rotation-proof",
+      approvalDecision: "allow-once",
+    });
 
-    const rotated = new ReefFederationState(
-      createRuntime(stateDir),
-      new AbortController().signal,
-      "local-key-2",
-    );
+    const runtime = createRuntime(stateDir);
+    const signal = new AbortController().signal;
+    const rotated = new ReefFederationState(runtime, signal, "local-key-2");
     expect(
       rotated.authorizeMount({
         mountId: mount.mountId,
@@ -138,6 +155,32 @@ describe("Reef federation state", () => {
         generation: mount.grantGeneration,
       }),
     ).toBeUndefined();
+    // The display projection does not expose local key binding; core authorization must win.
+    expect(rotated.getMount(mount.mountId)).toMatchObject(mount);
+    const request = vi.spyOn(runtime.gateway, "request");
+    const coordinator = new ReefFederationCoordinator(
+      runtime,
+      rotated,
+      () => mount.peerIdentity,
+      signal,
+    );
+    const outcome = await coordinator.handlePrompt(proposal.request);
+    expect(outcome).toMatchObject({ type: "session.prompt.denied", reason: "grant-revoked" });
+    const reopened = new ReefFederationState(createRuntime(stateDir), signal, "local-key-2");
+    expect(reopened.listUnsentProposals()).toEqual([
+      expect.objectContaining({ status: "denied", outcome }),
+    ]);
+    await expect(
+      new ReefFederationCoordinator(
+        runtime,
+        reopened,
+        () => mount.peerIdentity,
+        signal,
+      ).handlePrompt(proposal.request),
+    ).resolves.toEqual(outcome);
+    expect(request).not.toHaveBeenCalled();
+    expect(reopened.markOutcomeSent(proposal.proposalId, proposal.digest)).toBe(true);
+    expect(reopened.listUnsentProposals()).toEqual([]);
   });
 
   it("fails every grant operation closed after the Reef lifecycle ends", () => {

--- a/extensions/reef/src/federation-state.ts
+++ b/extensions/reef/src/federation-state.ts
@@ -1,10 +1,17 @@
 import { createHash } from "node:crypto";
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  REEF_FEDERATION_NAMESPACE,
+  validateReefFederationBody,
+  type ReefFederationFrame,
+} from "../protocol/federation.js";
 
 const REEF_FEDERATION_MOUNTS_NAMESPACE = "federation-mounts";
 const REEF_FEDERATION_PROPOSALS_NAMESPACE = "federation-proposals";
 const REEF_FEDERATION_MOUNTS_MAX_ENTRIES = 1_000;
+const REEF_FEDERATION_MOUNTS_PER_PEER = 32;
+const REEF_FEDERATION_MOUNT_TTL_MS = 7 * 24 * 60 * 60_000;
 const REEF_FEDERATION_PROPOSALS_MAX_ENTRIES = 5_000;
 const REEF_FEDERATION_PROPOSAL_TTL_MS = 30 * 24 * 60 * 60_000;
 
@@ -20,15 +27,32 @@ export type ReefFederationMount = {
   revoked: boolean;
 };
 
+export type ReefFederationPromptRequest = {
+  from: string;
+  to: string;
+  peer: string;
+  peerKeyEpoch: number;
+  frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>;
+};
+
 export type ReefFederationProposal = {
   proposalId: string;
   mountId: string;
   digest: string;
   status: "pending" | "accepted" | "denied" | "failed";
+  request: ReefFederationPromptRequest;
+  outcome?: Exclude<
+    ReefFederationFrame,
+    { type: "session.mount.offer" | "session.prompt.propose" }
+  >;
+  outcomeSentAt?: number;
   approvalId?: string;
   runId?: string;
   failureCode?: string;
 };
+
+export type ReefFederationProposalResolution = Pick<ReefFederationProposal, "status"> &
+  Partial<Pick<ReefFederationProposal, "approvalId" | "runId" | "failureCode" | "outcome">>;
 
 /** Durable Reef-owned state for session mounts, standing grants, and proposal replay outcomes. */
 export class ReefFederationState {
@@ -40,6 +64,7 @@ export class ReefFederationState {
       namespace: REEF_FEDERATION_MOUNTS_NAMESPACE,
       maxEntries: REEF_FEDERATION_MOUNTS_MAX_ENTRIES,
       overflowPolicy: "reject-new",
+      defaultTtlMs: REEF_FEDERATION_MOUNT_TTL_MS,
     });
     this.#proposals = runtime.state.openSyncKeyedStore<ReefFederationProposal>({
       namespace: REEF_FEDERATION_PROPOSALS_NAMESPACE,
@@ -52,6 +77,12 @@ export class ReefFederationState {
   /** Persist a host-issued mount without replacing an existing authority binding. */
   createMount(mount: ReefFederationMount): boolean {
     validateMount(mount);
+    const peerMounts = this.#mounts
+      .entries()
+      .filter((entry) => validateMount(entry.value).peer === mount.peer);
+    if (peerMounts.length >= REEF_FEDERATION_MOUNTS_PER_PEER) {
+      return false;
+    }
     return this.#mounts.registerIfAbsent(mountKey(mount.mountId), structuredClone(mount));
   }
 
@@ -133,11 +164,19 @@ export class ReefFederationState {
     return { result, proposal: structuredClone(current) };
   }
 
+  /** List durable prompt work whose terminal outcome has not reached the peer. */
+  listUnsentProposals(): ReefFederationProposal[] {
+    return this.#proposals
+      .entries()
+      .map((entry) => validateProposal(entry.value))
+      .filter((proposal) => proposal.outcomeSentAt === undefined);
+  }
+
   /** Record a proposal outcome only while its exact digest remains authoritative. */
   resolveProposal(
     proposalId: string,
     digest: string,
-    outcome: Omit<ReefFederationProposal, "proposalId" | "mountId" | "digest">,
+    outcome: ReefFederationProposalResolution,
   ): ReefFederationProposal | undefined {
     let resolved: ReefFederationProposal | undefined;
     const update = this.#proposals.update;
@@ -152,6 +191,23 @@ export class ReefFederationState {
       return resolved;
     });
     return resolved;
+  }
+
+  /** Mark one exact terminal outcome as handed to the Reef transport. */
+  markOutcomeSent(proposalId: string, digest: string): boolean {
+    let changed = false;
+    const update = this.#proposals.update;
+    if (!update) {
+      throw new Error("Reef federation proposals require atomic plugin-state updates");
+    }
+    update(proposalKey(proposalId), (existing) => {
+      if (!existing || existing.digest !== digest || !existing.outcome) {
+        return existing;
+      }
+      changed = true;
+      return validateProposal({ ...existing, outcomeSentAt: Date.now() });
+    });
+    return changed;
   }
 
   #updateMount(
@@ -217,9 +273,26 @@ function validateProposal(value: ReefFederationProposal): ReefFederationProposal
     typeof value.proposalId !== "string" ||
     typeof value.mountId !== "string" ||
     !/^[a-f0-9]{64}$/.test(value.digest) ||
-    !["pending", "accepted", "denied", "failed"].includes(value.status)
+    !["pending", "accepted", "denied", "failed"].includes(value.status) ||
+    !value.request ||
+    typeof value.request.from !== "string" ||
+    typeof value.request.to !== "string" ||
+    typeof value.request.peer !== "string" ||
+    !Number.isSafeInteger(value.request.peerKeyEpoch) ||
+    value.request.peerKeyEpoch < 1 ||
+    (value.outcomeSentAt !== undefined && !Number.isFinite(value.outcomeSentAt))
   ) {
     throw new Error("invalid Reef federation proposal");
+  }
+  validateReefFederationBody({
+    namespace: REEF_FEDERATION_NAMESPACE,
+    frame: value.request.frame,
+  });
+  if (value.outcome) {
+    validateReefFederationBody({ namespace: REEF_FEDERATION_NAMESPACE, frame: value.outcome });
+  }
+  if ((value.status === "pending") === Boolean(value.outcome)) {
+    throw new Error("invalid Reef federation proposal outcome");
   }
   return structuredClone(value);
 }

--- a/extensions/reef/src/federation-state.ts
+++ b/extensions/reef/src/federation-state.ts
@@ -12,6 +12,7 @@ export type ReefFederationMount = {
   mountId: string;
   peer: string;
   peerKeyEpoch: number;
+  role: "host" | "guest";
   sessionKey: string;
   sessionId: string;
   grantGeneration: number;
@@ -53,6 +54,11 @@ export class ReefFederationState {
     return this.#mounts.registerIfAbsent(mountKey(mount.mountId), structuredClone(mount));
   }
 
+  /** List validated mounts for owner commands and status surfaces. */
+  listMounts(): ReefFederationMount[] {
+    return this.#mounts.entries().map((entry) => validateMount(entry.value));
+  }
+
   /** Read one validated mount by its public identifier. */
   getMount(mountId: string): ReefFederationMount | undefined {
     const value = this.#mounts.lookup(mountKey(mountId));
@@ -79,6 +85,27 @@ export class ReefFederationState {
       return revoked;
     });
     return revoked;
+  }
+
+  /** Apply a peer-issued revocation only when it advances the local authority generation. */
+  applyRevocation(mountId: string, generation: number): boolean {
+    let changed = false;
+    const update = this.#mounts.update;
+    if (!update) {
+      throw new Error("Reef federation mounts require atomic plugin-state updates");
+    }
+    update(mountKey(mountId), (existing) => {
+      if (!existing) {
+        return existing;
+      }
+      const mount = validateMount(existing);
+      if (generation <= mount.grantGeneration) {
+        return mount;
+      }
+      changed = true;
+      return { ...mount, grantGeneration: generation, allowAlways: false };
+    });
+    return changed;
   }
 
   /** Claim one exact proposal; duplicate IDs return the prior outcome, while digest reuse fails. */
@@ -169,6 +196,7 @@ function validateMount(value: ReefFederationMount): ReefFederationMount {
     typeof value.peer !== "string" ||
     !Number.isSafeInteger(value.peerKeyEpoch) ||
     value.peerKeyEpoch < 1 ||
+    !["host", "guest"].includes(value.role) ||
     typeof value.sessionKey !== "string" ||
     typeof value.sessionId !== "string" ||
     !Number.isSafeInteger(value.grantGeneration) ||

--- a/extensions/reef/src/federation-state.ts
+++ b/extensions/reef/src/federation-state.ts
@@ -6,6 +6,7 @@ import {
   validateReefFederationBody,
   type ReefFederationFrame,
 } from "../protocol/federation.js";
+import { ReefPeerIdentitySchema, type ReefPeerIdentity } from "./friend-types.js";
 
 const REEF_FEDERATION_MOUNTS_NAMESPACE = "federation-mounts";
 const REEF_FEDERATION_PROPOSALS_NAMESPACE = "federation-proposals";
@@ -18,7 +19,7 @@ const REEF_FEDERATION_PROPOSAL_TTL_MS = 30 * 24 * 60 * 60_000;
 export type ReefFederationMount = {
   mountId: string;
   peer: string;
-  peerKeyEpoch: number;
+  peerIdentity: ReefPeerIdentity;
   role: "host" | "guest";
   sessionKey: string;
   sessionId: string;
@@ -31,7 +32,7 @@ export type ReefFederationPromptRequest = {
   from: string;
   to: string;
   peer: string;
-  peerKeyEpoch: number;
+  peerIdentity: ReefPeerIdentity;
   frame: Extract<ReefFederationFrame, { type: "session.prompt.propose" }>;
 };
 
@@ -252,8 +253,7 @@ function validateMount(value: ReefFederationMount): ReefFederationMount {
     !value ||
     typeof value.mountId !== "string" ||
     typeof value.peer !== "string" ||
-    !Number.isSafeInteger(value.peerKeyEpoch) ||
-    value.peerKeyEpoch < 1 ||
+    !ReefPeerIdentitySchema.safeParse(value.peerIdentity).success ||
     !["host", "guest"].includes(value.role) ||
     typeof value.sessionKey !== "string" ||
     typeof value.sessionId !== "string" ||
@@ -278,8 +278,7 @@ function validateProposal(value: ReefFederationProposal): ReefFederationProposal
     typeof value.request.from !== "string" ||
     typeof value.request.to !== "string" ||
     typeof value.request.peer !== "string" ||
-    !Number.isSafeInteger(value.request.peerKeyEpoch) ||
-    value.request.peerKeyEpoch < 1 ||
+    !ReefPeerIdentitySchema.safeParse(value.request.peerIdentity).success ||
     (value.outcomeSentAt !== undefined && !Number.isFinite(value.outcomeSentAt))
   ) {
     throw new Error("invalid Reef federation proposal");

--- a/extensions/reef/src/federation-state.ts
+++ b/extensions/reef/src/federation-state.ts
@@ -17,6 +17,7 @@ export type ReefFederationMount = {
   sessionId: string;
   grantGeneration: number;
   allowAlways: boolean;
+  revoked: boolean;
 };
 
 export type ReefFederationProposal = {
@@ -80,6 +81,7 @@ export class ReefFederationState {
       revoked = {
         ...mount,
         allowAlways: false,
+        revoked: true,
         grantGeneration: mount.grantGeneration + 1,
       };
       return revoked;
@@ -103,7 +105,7 @@ export class ReefFederationState {
         return mount;
       }
       changed = true;
-      return { ...mount, grantGeneration: generation, allowAlways: false };
+      return { ...mount, grantGeneration: generation, allowAlways: false, revoked: true };
     });
     return changed;
   }
@@ -167,7 +169,7 @@ export class ReefFederationState {
         return existing;
       }
       const mount = validateMount(existing);
-      if (mount.grantGeneration !== expectedGeneration) {
+      if (mount.grantGeneration !== expectedGeneration || mount.revoked) {
         return mount;
       }
       changed = true;
@@ -201,7 +203,8 @@ function validateMount(value: ReefFederationMount): ReefFederationMount {
     typeof value.sessionId !== "string" ||
     !Number.isSafeInteger(value.grantGeneration) ||
     value.grantGeneration < 0 ||
-    typeof value.allowAlways !== "boolean"
+    typeof value.allowAlways !== "boolean" ||
+    typeof value.revoked !== "boolean"
   ) {
     throw new Error("invalid Reef federation mount");
   }

--- a/extensions/reef/src/federation-state.ts
+++ b/extensions/reef/src/federation-state.ts
@@ -1,0 +1,194 @@
+import { createHash } from "node:crypto";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+
+const REEF_FEDERATION_MOUNTS_NAMESPACE = "federation-mounts";
+const REEF_FEDERATION_PROPOSALS_NAMESPACE = "federation-proposals";
+const REEF_FEDERATION_MOUNTS_MAX_ENTRIES = 1_000;
+const REEF_FEDERATION_PROPOSALS_MAX_ENTRIES = 5_000;
+const REEF_FEDERATION_PROPOSAL_TTL_MS = 30 * 24 * 60 * 60_000;
+
+export type ReefFederationMount = {
+  mountId: string;
+  peer: string;
+  peerKeyEpoch: number;
+  sessionKey: string;
+  sessionId: string;
+  grantGeneration: number;
+  allowAlways: boolean;
+};
+
+export type ReefFederationProposal = {
+  proposalId: string;
+  mountId: string;
+  digest: string;
+  status: "pending" | "accepted" | "denied" | "failed";
+  approvalId?: string;
+  runId?: string;
+  failureCode?: string;
+};
+
+/** Durable Reef-owned state for session mounts, standing grants, and proposal replay outcomes. */
+export class ReefFederationState {
+  readonly #mounts: PluginStateSyncKeyedStore<ReefFederationMount>;
+  readonly #proposals: PluginStateSyncKeyedStore<ReefFederationProposal>;
+
+  constructor(runtime: PluginRuntime) {
+    this.#mounts = runtime.state.openSyncKeyedStore<ReefFederationMount>({
+      namespace: REEF_FEDERATION_MOUNTS_NAMESPACE,
+      maxEntries: REEF_FEDERATION_MOUNTS_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
+    });
+    this.#proposals = runtime.state.openSyncKeyedStore<ReefFederationProposal>({
+      namespace: REEF_FEDERATION_PROPOSALS_NAMESPACE,
+      maxEntries: REEF_FEDERATION_PROPOSALS_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
+      defaultTtlMs: REEF_FEDERATION_PROPOSAL_TTL_MS,
+    });
+  }
+
+  /** Persist a host-issued mount without replacing an existing authority binding. */
+  createMount(mount: ReefFederationMount): boolean {
+    validateMount(mount);
+    return this.#mounts.registerIfAbsent(mountKey(mount.mountId), structuredClone(mount));
+  }
+
+  /** Read one validated mount by its public identifier. */
+  getMount(mountId: string): ReefFederationMount | undefined {
+    const value = this.#mounts.lookup(mountKey(mountId));
+    return value ? validateMount(value) : undefined;
+  }
+
+  /** Enable the standing session grant only when the exact authority generation still matches. */
+  allowAlways(mountId: string, expectedGeneration: number): boolean {
+    return this.#updateMount(mountId, expectedGeneration, (mount) => ({
+      ...mount,
+      allowAlways: true,
+    }));
+  }
+
+  /** Revoke a standing grant before returning the new generation to the caller. */
+  revoke(mountId: string, expectedGeneration: number): ReefFederationMount | undefined {
+    let revoked: ReefFederationMount | undefined;
+    this.#updateMount(mountId, expectedGeneration, (mount) => {
+      revoked = {
+        ...mount,
+        allowAlways: false,
+        grantGeneration: mount.grantGeneration + 1,
+      };
+      return revoked;
+    });
+    return revoked;
+  }
+
+  /** Claim one exact proposal; duplicate IDs return the prior outcome, while digest reuse fails. */
+  claimProposal(proposal: ReefFederationProposal): {
+    result: "new" | "duplicate" | "mismatch";
+    proposal: ReefFederationProposal;
+  } {
+    validateProposal(proposal);
+    let result: "new" | "duplicate" | "mismatch" = "new";
+    let current = proposal;
+    const update = this.#proposals.update;
+    if (!update) {
+      throw new Error("Reef federation proposals require atomic plugin-state updates");
+    }
+    update(proposalKey(proposal.proposalId), (existing) => {
+      if (!existing) {
+        return structuredClone(proposal);
+      }
+      current = validateProposal(existing);
+      result = existing.digest === proposal.digest ? "duplicate" : "mismatch";
+      return existing;
+    });
+    return { result, proposal: structuredClone(current) };
+  }
+
+  /** Record a proposal outcome only while its exact digest remains authoritative. */
+  resolveProposal(
+    proposalId: string,
+    digest: string,
+    outcome: Omit<ReefFederationProposal, "proposalId" | "mountId" | "digest">,
+  ): ReefFederationProposal | undefined {
+    let resolved: ReefFederationProposal | undefined;
+    const update = this.#proposals.update;
+    if (!update) {
+      throw new Error("Reef federation proposals require atomic plugin-state updates");
+    }
+    update(proposalKey(proposalId), (existing) => {
+      if (!existing || existing.digest !== digest) {
+        return existing;
+      }
+      resolved = validateProposal({ ...existing, ...outcome });
+      return resolved;
+    });
+    return resolved;
+  }
+
+  #updateMount(
+    mountId: string,
+    expectedGeneration: number,
+    mutate: (mount: ReefFederationMount) => ReefFederationMount,
+  ): boolean {
+    let changed = false;
+    const update = this.#mounts.update;
+    if (!update) {
+      throw new Error("Reef federation mounts require atomic plugin-state updates");
+    }
+    update(mountKey(mountId), (existing) => {
+      if (!existing) {
+        return existing;
+      }
+      const mount = validateMount(existing);
+      if (mount.grantGeneration !== expectedGeneration) {
+        return mount;
+      }
+      changed = true;
+      return validateMount(mutate(mount));
+    });
+    return changed;
+  }
+}
+
+function mountKey(mountId: string): string {
+  return `mount:${hashKey(mountId)}`;
+}
+
+function proposalKey(proposalId: string): string {
+  return `proposal:${hashKey(proposalId)}`;
+}
+
+function hashKey(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function validateMount(value: ReefFederationMount): ReefFederationMount {
+  if (
+    !value ||
+    typeof value.mountId !== "string" ||
+    typeof value.peer !== "string" ||
+    !Number.isSafeInteger(value.peerKeyEpoch) ||
+    value.peerKeyEpoch < 1 ||
+    typeof value.sessionKey !== "string" ||
+    typeof value.sessionId !== "string" ||
+    !Number.isSafeInteger(value.grantGeneration) ||
+    value.grantGeneration < 0 ||
+    typeof value.allowAlways !== "boolean"
+  ) {
+    throw new Error("invalid Reef federation mount");
+  }
+  return structuredClone(value);
+}
+
+function validateProposal(value: ReefFederationProposal): ReefFederationProposal {
+  if (
+    !value ||
+    typeof value.proposalId !== "string" ||
+    typeof value.mountId !== "string" ||
+    !/^[a-f0-9]{64}$/.test(value.digest) ||
+    !["pending", "accepted", "denied", "failed"].includes(value.status)
+  ) {
+    throw new Error("invalid Reef federation proposal");
+  }
+  return structuredClone(value);
+}

--- a/extensions/reef/src/federation-state.ts
+++ b/extensions/reef/src/federation-state.ts
@@ -6,15 +6,21 @@ import {
   validateReefFederationBody,
   type ReefFederationFrame,
 } from "../protocol/federation.js";
-import { ReefPeerIdentitySchema, type ReefPeerIdentity } from "./friend-types.js";
+import {
+  ReefPeerIdentitySchema,
+  sameReefPeerIdentity,
+  type ReefPeerIdentity,
+} from "./friend-types.js";
 
-const REEF_FEDERATION_MOUNTS_NAMESPACE = "federation-mounts";
 const REEF_FEDERATION_PROPOSALS_NAMESPACE = "federation-proposals";
-const REEF_FEDERATION_MOUNTS_MAX_ENTRIES = 1_000;
-const REEF_FEDERATION_MOUNTS_PER_PEER = 32;
-const REEF_FEDERATION_MOUNT_TTL_MS = 7 * 24 * 60 * 60_000;
+const REEF_FEDERATION_OUTBOUND_PROPOSALS_NAMESPACE = "federation-outbound-proposals";
 const REEF_FEDERATION_PROPOSALS_MAX_ENTRIES = 5_000;
+const REEF_FEDERATION_PROPOSALS_MAX_ENTRIES_PER_PEER = 128;
 const REEF_FEDERATION_PROPOSAL_TTL_MS = 30 * 24 * 60 * 60_000;
+
+type CrossSessionGrant = NonNullable<ReturnType<PluginRuntime["crossSessionGrants"]["get"]>>;
+type CrossSessionGrantCreate = Parameters<PluginRuntime["crossSessionGrants"]["create"]>[0];
+type CrossSessionGrantAuthority = Parameters<PluginRuntime["crossSessionGrants"]["authorize"]>[0];
 
 export type ReefFederationMount = {
   mountId: string;
@@ -26,6 +32,15 @@ export type ReefFederationMount = {
   grantGeneration: number;
   allowAlways: boolean;
   revoked: boolean;
+  revocationPending?: boolean;
+};
+
+export type ReefGrantAuthority = {
+  mountId: string;
+  peer: string;
+  peerIdentity: ReefPeerIdentity;
+  sessionId: string;
+  generation: number;
 };
 
 export type ReefFederationPromptRequest = {
@@ -47,120 +62,262 @@ export type ReefFederationProposal = {
     { type: "session.mount.offer" | "session.prompt.propose" }
   >;
   outcomeSentAt?: number;
+  outcomeAbandonedAt?: number;
+  outcomeAbandonReason?: "peer-identity-changed";
   approvalId?: string;
+  approvalDecision?: "allow-once";
   runId?: string;
   failureCode?: string;
 };
 
+export type ReefFederationPromptOutcome = Extract<
+  ReefFederationFrame,
+  {
+    type: "session.prompt.accepted" | "session.prompt.denied" | "session.prompt.failed";
+  }
+>;
+
+type ReefOutboundProposal = ReefFederationPromptRequest & {
+  outcome?: ReefFederationPromptOutcome;
+  outcomeReceivedAt?: number;
+};
+
 export type ReefFederationProposalResolution = Pick<ReefFederationProposal, "status"> &
-  Partial<Pick<ReefFederationProposal, "approvalId" | "runId" | "failureCode" | "outcome">>;
+  Partial<
+    Pick<
+      ReefFederationProposal,
+      "approvalId" | "approvalDecision" | "runId" | "failureCode" | "outcome"
+    >
+  >;
 
-/** Durable Reef-owned state for session mounts, standing grants, and proposal replay outcomes. */
+/** Reef transport projection over host-owned grants plus durable proposal replay outcomes. */
 export class ReefFederationState {
-  readonly #mounts: PluginStateSyncKeyedStore<ReefFederationMount>;
+  readonly #grants: PluginRuntime["crossSessionGrants"];
   readonly #proposals: PluginStateSyncKeyedStore<ReefFederationProposal>;
+  readonly #outboundProposals: PluginStateSyncKeyedStore<ReefOutboundProposal>;
 
-  constructor(runtime: PluginRuntime) {
-    this.#mounts = runtime.state.openSyncKeyedStore<ReefFederationMount>({
-      namespace: REEF_FEDERATION_MOUNTS_NAMESPACE,
-      maxEntries: REEF_FEDERATION_MOUNTS_MAX_ENTRIES,
-      overflowPolicy: "reject-new",
-      defaultTtlMs: REEF_FEDERATION_MOUNT_TTL_MS,
-    });
+  constructor(
+    runtime: PluginRuntime,
+    private readonly authoritySignal: AbortSignal,
+    private readonly localIdentityBinding = "test-local-identity",
+  ) {
+    if (!localIdentityBinding) {
+      throw new Error("Reef federation requires a local identity binding");
+    }
+    this.#grants = runtime.crossSessionGrants;
     this.#proposals = runtime.state.openSyncKeyedStore<ReefFederationProposal>({
       namespace: REEF_FEDERATION_PROPOSALS_NAMESPACE,
       maxEntries: REEF_FEDERATION_PROPOSALS_MAX_ENTRIES,
       overflowPolicy: "reject-new",
       defaultTtlMs: REEF_FEDERATION_PROPOSAL_TTL_MS,
     });
-  }
-
-  /** Persist a host-issued mount without replacing an existing authority binding. */
-  createMount(mount: ReefFederationMount): boolean {
-    validateMount(mount);
-    const peerMounts = this.#mounts
-      .entries()
-      .filter((entry) => validateMount(entry.value).peer === mount.peer);
-    if (peerMounts.length >= REEF_FEDERATION_MOUNTS_PER_PEER) {
-      return false;
-    }
-    return this.#mounts.registerIfAbsent(mountKey(mount.mountId), structuredClone(mount));
-  }
-
-  /** List validated mounts for owner commands and status surfaces. */
-  listMounts(): ReefFederationMount[] {
-    return this.#mounts.entries().map((entry) => validateMount(entry.value));
-  }
-
-  /** Read one validated mount by its public identifier. */
-  getMount(mountId: string): ReefFederationMount | undefined {
-    const value = this.#mounts.lookup(mountKey(mountId));
-    return value ? validateMount(value) : undefined;
-  }
-
-  /** Enable the standing session grant only when the exact authority generation still matches. */
-  allowAlways(mountId: string, expectedGeneration: number): boolean {
-    return this.#updateMount(mountId, expectedGeneration, (mount) => ({
-      ...mount,
-      allowAlways: true,
-    }));
-  }
-
-  /** Revoke a standing grant before returning the new generation to the caller. */
-  revoke(mountId: string, expectedGeneration: number): ReefFederationMount | undefined {
-    let revoked: ReefFederationMount | undefined;
-    this.#updateMount(mountId, expectedGeneration, (mount) => {
-      revoked = {
-        ...mount,
-        allowAlways: false,
-        revoked: true,
-        grantGeneration: mount.grantGeneration + 1,
-      };
-      return revoked;
+    this.#outboundProposals = runtime.state.openSyncKeyedStore<ReefOutboundProposal>({
+      namespace: REEF_FEDERATION_OUTBOUND_PROPOSALS_NAMESPACE,
+      maxEntries: REEF_FEDERATION_PROPOSALS_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
+      defaultTtlMs: REEF_FEDERATION_PROPOSAL_TTL_MS,
     });
-    return revoked;
   }
 
-  /** Apply a peer-issued revocation only when it advances the local authority generation. */
-  applyRevocation(mountId: string, generation: number): boolean {
-    let changed = false;
-    const update = this.#mounts.update;
-    if (!update) {
-      throw new Error("Reef federation mounts require atomic plugin-state updates");
+  /** Persist transport metadata through the host-owned cross-session grant authority. */
+  createMount(mount: ReefFederationMount): boolean {
+    return this.#grants.create(
+      toCrossSessionGrant(validateMount(mount), this.localIdentityBinding),
+      this.authoritySignal,
+    );
+  }
+
+  /** List mounts projected from host-owned grant records. */
+  listMounts(): ReefFederationMount[] {
+    return this.#grants.list(this.authoritySignal).map(fromCrossSessionGrant);
+  }
+
+  /** Read one mount projected from its host-owned grant record. */
+  getMount(mountId: string): ReefFederationMount | undefined {
+    const grant = this.#grants.get(mountId, this.authoritySignal);
+    return grant ? fromCrossSessionGrant(grant) : undefined;
+  }
+
+  /** Revalidate exact lifecycle and transport authority before privileged use. */
+  authorizeMount(params: ReefGrantAuthority): ReefFederationMount | undefined {
+    const grant = this.#grants.authorize(
+      toGrantAuthority(params, this.authoritySignal, this.localIdentityBinding),
+    );
+    return grant ? fromCrossSessionGrant(grant) : undefined;
+  }
+
+  /** Persist standing authority only after core revalidates the exact live grant. */
+  allowAlways(params: ReefGrantAuthority): boolean {
+    return this.#grants.allowStanding(
+      toGrantAuthority(params, this.authoritySignal, this.localIdentityBinding),
+    );
+  }
+
+  /** Revoke a standing grant, or return its committed generation for idempotent delivery. */
+  revoke(mountId: string, expectedGeneration: number): ReefFederationMount | undefined {
+    const grant = this.#grants.revoke({
+      grantId: mountId,
+      expectedGeneration,
+      signal: this.authoritySignal,
+    });
+    return grant ? fromCrossSessionGrant(grant) : undefined;
+  }
+
+  /** Apply a peer-issued revocation only to that peer's exact holder grant. */
+  applyRevocation(params: ReefGrantAuthority): boolean {
+    return this.#grants.applyRevocation(
+      toGrantAuthority(params, this.authoritySignal, this.localIdentityBinding),
+    );
+  }
+
+  /** Stop durable revocation recovery after the exact generation reaches transport. */
+  acknowledgeRevocation(mountId: string, generation: number): boolean {
+    return this.#grants.acknowledgeRevocation({
+      grantId: mountId,
+      generation,
+      signal: this.authoritySignal,
+    });
+  }
+
+  /** Find an unresolved outbound proposal so command retry preserves its idempotency key. */
+  findOutboundProposal(
+    mount: ReefFederationMount,
+    text: string,
+  ): ReefFederationPromptRequest | undefined {
+    const proposal = this.#outboundProposals
+      .entries()
+      .map((entry) => validateOutboundProposal(entry.value))
+      .find(
+        (entry) =>
+          !entry.outcome &&
+          entry.peer === mount.peer &&
+          sameReefPeerIdentity(entry.peerIdentity, mount.peerIdentity) &&
+          entry.frame.mountId === mount.mountId &&
+          entry.frame.sessionId === mount.sessionId &&
+          entry.frame.grantGeneration === mount.grantGeneration &&
+          entry.frame.text === text,
+      );
+    return proposal ? validatePromptRequest(proposal) : undefined;
+  }
+
+  /** Reserve an outbound proposal before its transport outcome becomes ambiguous. */
+  registerOutboundProposal(request: ReefFederationPromptRequest): boolean {
+    const validated = validatePromptRequest(request);
+    const existing = this.#outboundProposals.lookup(outboundProposalKey(request.frame.proposalId));
+    if (existing) {
+      return matchesPromptRequest(validateOutboundProposal(existing), validated);
     }
-    update(mountKey(mountId), (existing) => {
+    const peerCount = this.#outboundProposals
+      .entries()
+      .map((entry) => validateOutboundProposal(entry.value))
+      .filter((entry) => entry.peer === validated.peer).length;
+    return (
+      peerCount < REEF_FEDERATION_PROPOSALS_MAX_ENTRIES_PER_PEER &&
+      this.#outboundProposals.registerIfAbsent(
+        outboundProposalKey(validated.frame.proposalId),
+        validated,
+      )
+    );
+  }
+
+  /** Accept one terminal outcome only for its exact guest mount and outbound proposal binding. */
+  acceptOutboundOutcome(
+    peer: string,
+    peerIdentity: ReefPeerIdentity,
+    outcome: ReefFederationPromptOutcome,
+  ): "accepted" | "duplicate" | "invalid" {
+    let result: "accepted" | "duplicate" | "invalid" = "invalid";
+    const update = this.#outboundProposals.update;
+    if (!update) {
+      throw new Error("Reef outbound proposals require atomic plugin-state updates");
+    }
+    update(outboundProposalKey(outcome.proposalId), (existing) => {
       if (!existing) {
         return existing;
       }
-      const mount = validateMount(existing);
-      if (generation <= mount.grantGeneration) {
-        return mount;
+      const proposal = validateOutboundProposal(existing);
+      if (
+        proposal.peer !== peer ||
+        !sameReefPeerIdentity(proposal.peerIdentity, peerIdentity) ||
+        proposal.frame.mountId !== outcome.mountId ||
+        proposal.frame.sessionId !== outcome.sessionId ||
+        proposal.frame.proposalId !== outcome.proposalId
+      ) {
+        return proposal;
       }
-      changed = true;
-      return { ...mount, grantGeneration: generation, allowAlways: false, revoked: true };
+      if (proposal.outcome) {
+        result = "duplicate";
+        return proposal;
+      }
+      result = "accepted";
+      return validateOutboundProposal({
+        ...proposal,
+        outcome,
+        outcomeReceivedAt: Date.now(),
+      });
     });
-    return changed;
+    return result;
+  }
+
+  /** Claim an inbound request before transport acknowledgement. */
+  claimPrompt(
+    request: ReefFederationPromptRequest,
+  ): "new" | "duplicate" | "mismatch" | "peer-capacity" {
+    return this.claimProposal({
+      proposalId: request.frame.proposalId,
+      mountId: request.frame.mountId,
+      digest: request.frame.textSha256,
+      status: "pending",
+      request: structuredClone(request),
+    }).result;
   }
 
   /** Claim one exact proposal; duplicate IDs return the prior outcome, while digest reuse fails. */
   claimProposal(proposal: ReefFederationProposal): {
-    result: "new" | "duplicate" | "mismatch";
+    result: "new" | "duplicate" | "mismatch" | "peer-capacity";
     proposal: ReefFederationProposal;
   } {
     validateProposal(proposal);
-    let result: "new" | "duplicate" | "mismatch" = "new";
+    const key = proposalKey(proposal.proposalId, proposal.digest);
+    const existing = this.#proposals.lookup(key);
+    if (!existing) {
+      const retained = this.#proposals.entries().map((entry) => validateProposal(entry.value));
+      const peerProposalCount = retained.filter(
+        (entry) => entry.request.peer === proposal.request.peer,
+      ).length;
+      if (peerProposalCount >= REEF_FEDERATION_PROPOSALS_MAX_ENTRIES_PER_PEER) {
+        return { result: "peer-capacity", proposal: structuredClone(proposal) };
+      }
+      const rebound = retained.some(
+        (entry) => entry.proposalId === proposal.proposalId && entry.digest !== proposal.digest,
+      );
+      if (rebound) {
+        let current = proposal;
+        const update = this.#proposals.update;
+        if (!update) {
+          throw new Error("Reef federation proposals require atomic plugin-state updates");
+        }
+        update(key, (currentValue) => {
+          current = currentValue ? validateProposal(currentValue) : structuredClone(proposal);
+          return current;
+        });
+        return { result: "mismatch", proposal: structuredClone(current) };
+      }
+    }
+
+    let result: "new" | "duplicate" = "new";
     let current = proposal;
     const update = this.#proposals.update;
     if (!update) {
       throw new Error("Reef federation proposals require atomic plugin-state updates");
     }
-    update(proposalKey(proposal.proposalId), (existing) => {
-      if (!existing) {
+    update(key, (currentValue) => {
+      if (!currentValue) {
         return structuredClone(proposal);
       }
-      current = validateProposal(existing);
-      result = existing.digest === proposal.digest ? "duplicate" : "mismatch";
-      return existing;
+      current = validateProposal(currentValue);
+      result = "duplicate";
+      return currentValue;
     });
     return { result, proposal: structuredClone(current) };
   }
@@ -170,7 +327,10 @@ export class ReefFederationState {
     return this.#proposals
       .entries()
       .map((entry) => validateProposal(entry.value))
-      .filter((proposal) => proposal.outcomeSentAt === undefined);
+      .filter(
+        (proposal) =>
+          proposal.outcomeSentAt === undefined && proposal.outcomeAbandonedAt === undefined,
+      );
   }
 
   /** Record a proposal outcome only while its exact digest remains authoritative. */
@@ -184,7 +344,7 @@ export class ReefFederationState {
     if (!update) {
       throw new Error("Reef federation proposals require atomic plugin-state updates");
     }
-    update(proposalKey(proposalId), (existing) => {
+    update(proposalKey(proposalId, digest), (existing) => {
       if (!existing || existing.digest !== digest) {
         return existing;
       }
@@ -201,8 +361,13 @@ export class ReefFederationState {
     if (!update) {
       throw new Error("Reef federation proposals require atomic plugin-state updates");
     }
-    update(proposalKey(proposalId), (existing) => {
-      if (!existing || existing.digest !== digest || !existing.outcome) {
+    update(proposalKey(proposalId, digest), (existing) => {
+      if (
+        !existing ||
+        existing.digest !== digest ||
+        !existing.outcome ||
+        existing.outcomeAbandonedAt !== undefined
+      ) {
         return existing;
       }
       changed = true;
@@ -211,37 +376,94 @@ export class ReefFederationState {
     return changed;
   }
 
-  #updateMount(
-    mountId: string,
-    expectedGeneration: number,
-    mutate: (mount: ReefFederationMount) => ReefFederationMount,
-  ): boolean {
+  /** Record that identity rotation made one terminal outcome permanently undeliverable. */
+  abandonOutcome(proposalId: string, digest: string): boolean {
     let changed = false;
-    const update = this.#mounts.update;
+    const update = this.#proposals.update;
     if (!update) {
-      throw new Error("Reef federation mounts require atomic plugin-state updates");
+      throw new Error("Reef federation proposals require atomic plugin-state updates");
     }
-    update(mountKey(mountId), (existing) => {
-      if (!existing) {
+    update(proposalKey(proposalId, digest), (existing) => {
+      if (
+        !existing ||
+        existing.digest !== digest ||
+        !existing.outcome ||
+        existing.outcomeSentAt !== undefined
+      ) {
         return existing;
       }
-      const mount = validateMount(existing);
-      if (mount.grantGeneration !== expectedGeneration || mount.revoked) {
-        return mount;
-      }
       changed = true;
-      return validateMount(mutate(mount));
+      return validateProposal({
+        ...existing,
+        outcomeAbandonedAt: Date.now(),
+        outcomeAbandonReason: "peer-identity-changed",
+      });
     });
     return changed;
   }
 }
 
-function mountKey(mountId: string): string {
-  return `mount:${hashKey(mountId)}`;
+function toCrossSessionGrant(
+  mount: ReefFederationMount,
+  localIdentityBinding: string,
+): CrossSessionGrantCreate {
+  return {
+    grantId: mount.mountId,
+    subjectId: mount.peer,
+    subjectBinding: `${localIdentityBinding}|${peerIdentityBinding(mount.peerIdentity)}`,
+    role: mount.role === "host" ? "issuer" : "holder",
+    targetSessionKey: mount.sessionKey,
+    targetSessionId: mount.sessionId,
+    generation: mount.grantGeneration,
+  };
 }
 
-function proposalKey(proposalId: string): string {
-  return `proposal:${hashKey(proposalId)}`;
+function fromCrossSessionGrant(grant: CrossSessionGrant): ReefFederationMount {
+  const remoteBinding = grant.subjectBinding.split("|").at(-1) ?? "";
+  const [epoch, ed25519PublicKey, x25519PublicKey] = remoteBinding.split(":");
+  return validateMount({
+    mountId: grant.grantId,
+    peer: grant.subjectId,
+    peerIdentity: {
+      keyEpoch: Number(epoch),
+      ed25519PublicKey: ed25519PublicKey ?? "",
+      x25519PublicKey: x25519PublicKey ?? "",
+    },
+    role: grant.role === "issuer" ? "host" : "guest",
+    sessionKey: grant.targetSessionKey,
+    sessionId: grant.targetSessionId,
+    grantGeneration: grant.generation,
+    allowAlways: grant.standing,
+    revoked: grant.revoked,
+    revocationPending: grant.revocationPending,
+  });
+}
+
+function toGrantAuthority(
+  params: ReefGrantAuthority,
+  authoritySignal: AbortSignal,
+  localIdentityBinding: string,
+): CrossSessionGrantAuthority {
+  return {
+    grantId: params.mountId,
+    subjectId: params.peer,
+    subjectBinding: `${localIdentityBinding}|${peerIdentityBinding(params.peerIdentity)}`,
+    targetSessionId: params.sessionId,
+    generation: params.generation,
+    signal: authoritySignal,
+  };
+}
+
+function peerIdentityBinding(identity: ReefPeerIdentity): string {
+  return `${identity.keyEpoch}:${identity.ed25519PublicKey}:${identity.x25519PublicKey}`;
+}
+
+function proposalKey(proposalId: string, digest: string): string {
+  return `proposal:${hashKey(`${proposalId}:${digest}`)}`;
+}
+
+function outboundProposalKey(proposalId: string): string {
+  return `outbound-proposal:${hashKey(proposalId)}`;
 }
 
 function hashKey(value: string): string {
@@ -260,11 +482,56 @@ function validateMount(value: ReefFederationMount): ReefFederationMount {
     !Number.isSafeInteger(value.grantGeneration) ||
     value.grantGeneration < 0 ||
     typeof value.allowAlways !== "boolean" ||
-    typeof value.revoked !== "boolean"
+    typeof value.revoked !== "boolean" ||
+    (value.revocationPending !== undefined && typeof value.revocationPending !== "boolean")
   ) {
     throw new Error("invalid Reef federation mount");
   }
   return structuredClone(value);
+}
+
+function validatePromptRequest(value: ReefFederationPromptRequest): ReefFederationPromptRequest {
+  if (
+    !value ||
+    typeof value.from !== "string" ||
+    typeof value.to !== "string" ||
+    typeof value.peer !== "string" ||
+    !ReefPeerIdentitySchema.safeParse(value.peerIdentity).success
+  ) {
+    throw new Error("invalid Reef outbound proposal request");
+  }
+  validateReefFederationBody({ namespace: REEF_FEDERATION_NAMESPACE, frame: value.frame });
+  if (value.frame.type !== "session.prompt.propose") {
+    throw new Error("invalid Reef outbound proposal frame");
+  }
+  return structuredClone(value);
+}
+
+function validateOutboundProposal(value: ReefOutboundProposal): ReefOutboundProposal {
+  const request = validatePromptRequest(value);
+  if (
+    (value.outcomeReceivedAt !== undefined && !Number.isFinite(value.outcomeReceivedAt)) ||
+    (value.outcomeReceivedAt === undefined) !== (value.outcome === undefined)
+  ) {
+    throw new Error("invalid Reef outbound proposal outcome");
+  }
+  if (value.outcome) {
+    validateReefFederationBody({ namespace: REEF_FEDERATION_NAMESPACE, frame: value.outcome });
+  }
+  return structuredClone({ ...request, ...value });
+}
+
+function matchesPromptRequest(
+  left: ReefFederationPromptRequest,
+  right: ReefFederationPromptRequest,
+): boolean {
+  return (
+    left.from === right.from &&
+    left.to === right.to &&
+    left.peer === right.peer &&
+    sameReefPeerIdentity(left.peerIdentity, right.peerIdentity) &&
+    JSON.stringify(left.frame) === JSON.stringify(right.frame)
+  );
 }
 
 function validateProposal(value: ReefFederationProposal): ReefFederationProposal {
@@ -279,7 +546,14 @@ function validateProposal(value: ReefFederationProposal): ReefFederationProposal
     typeof value.request.to !== "string" ||
     typeof value.request.peer !== "string" ||
     !ReefPeerIdentitySchema.safeParse(value.request.peerIdentity).success ||
-    (value.outcomeSentAt !== undefined && !Number.isFinite(value.outcomeSentAt))
+    (value.outcomeSentAt !== undefined && !Number.isFinite(value.outcomeSentAt)) ||
+    (value.outcomeAbandonedAt !== undefined && !Number.isFinite(value.outcomeAbandonedAt)) ||
+    (value.outcomeAbandonReason !== undefined &&
+      value.outcomeAbandonReason !== "peer-identity-changed") ||
+    (value.approvalDecision !== undefined && value.approvalDecision !== "allow-once") ||
+    (value.approvalDecision !== undefined && typeof value.approvalId !== "string") ||
+    (value.outcomeAbandonedAt === undefined) !== (value.outcomeAbandonReason === undefined) ||
+    (value.outcomeSentAt !== undefined && value.outcomeAbandonedAt !== undefined)
   ) {
     throw new Error("invalid Reef federation proposal");
   }

--- a/extensions/reef/src/federation-state.ts
+++ b/extensions/reef/src/federation-state.ts
@@ -285,7 +285,10 @@ export class ReefFederationState {
       const peerProposalCount = retained.filter(
         (entry) => entry.request.peer === proposal.request.peer,
       ).length;
-      if (peerProposalCount >= REEF_FEDERATION_PROPOSALS_MAX_ENTRIES_PER_PEER) {
+      if (
+        retained.length >= REEF_FEDERATION_PROPOSALS_MAX_ENTRIES ||
+        peerProposalCount >= REEF_FEDERATION_PROPOSALS_MAX_ENTRIES_PER_PEER
+      ) {
         return { result: "peer-capacity", proposal: structuredClone(proposal) };
       }
       const rebound = retained.some(

--- a/extensions/reef/src/federation-state.ts
+++ b/extensions/reef/src/federation-state.ts
@@ -132,6 +132,20 @@ export class ReefFederationState {
     return this.#grants.list(this.authoritySignal).map(fromCrossSessionGrant);
   }
 
+  /** List durable inbound prompt proposals for operator status surfaces. */
+  listPromptProposals(): ReefFederationProposal[] {
+    this.authoritySignal.throwIfAborted();
+    return this.#proposals.entries().map((entry) => structuredClone(validateProposal(entry.value)));
+  }
+
+  /** List durable outbound prompt proposals for operator status surfaces. */
+  listOutboundPromptProposals(): ReefOutboundProposal[] {
+    this.authoritySignal.throwIfAborted();
+    return this.#outboundProposals
+      .entries()
+      .map((entry) => structuredClone(validateOutboundProposal(entry.value)));
+  }
+
   /** Read one mount projected from its host-owned grant record. */
   getMount(mountId: string): ReefFederationMount | undefined {
     const grant = this.#grants.get(mountId, this.authoritySignal);

--- a/extensions/reef/src/federation-test-runtime.test-support.ts
+++ b/extensions/reef/src/federation-test-runtime.test-support.ts
@@ -1,0 +1,141 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+
+type CrossSessionGrant = NonNullable<ReturnType<PluginRuntime["crossSessionGrants"]["get"]>>;
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { createPluginStateSyncKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+
+const grantsByStateDir = new Map<string, Map<string, CrossSessionGrant>>();
+
+/** Build a persistent test runtime for Reef federation state. */
+export function createReefFederationTestRuntime(stateDir: string): PluginRuntime {
+  const runtime = createPluginRuntimeMock();
+  const grants = grantsByStateDir.get(stateDir) ?? new Map<string, CrossSessionGrant>();
+  grantsByStateDir.set(stateDir, grants);
+  runtime.state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateSyncKeyedStoreForTests<T>("reef", {
+      ...options,
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+  runtime.crossSessionGrants = {
+    create: (grant, signal) => {
+      if (signal.aborted) {
+        return false;
+      }
+      const subjectCount = [...grants.values()].filter(
+        (existing) => existing.subjectId === grant.subjectId,
+      ).length;
+      if (grants.has(grant.grantId) || subjectCount >= 32) {
+        return false;
+      }
+      grants.set(
+        grant.grantId,
+        structuredClone({ ...grant, standing: false, revoked: false, revocationPending: false }),
+      );
+      return true;
+    },
+    list: (signal) =>
+      signal.aborted ? [] : [...grants.values()].map((grant) => structuredClone(grant)),
+    get: (grantId, signal) => {
+      const grant = signal.aborted ? undefined : grants.get(grantId);
+      return grant ? structuredClone(grant) : undefined;
+    },
+    authorize: (authority) => {
+      const grant = grants.get(authority.grantId);
+      return grant && !authority.signal.aborted && matches(grant, authority)
+        ? structuredClone(grant)
+        : undefined;
+    },
+    allowStanding: (authority) => {
+      const grant = grants.get(authority.grantId);
+      if (!grant || authority.signal.aborted || !matches(grant, authority)) {
+        return false;
+      }
+      grants.set(grant.grantId, { ...grant, standing: true });
+      return true;
+    },
+    revoke: ({ grantId, expectedGeneration, signal }) => {
+      const grant = signal.aborted ? undefined : grants.get(grantId);
+      if (!grant || grant.role !== "issuer") {
+        return undefined;
+      }
+      if (grant.revoked && grant.generation === expectedGeneration) {
+        return structuredClone(grant);
+      }
+      if (grant.revoked || grant.generation !== expectedGeneration) {
+        return undefined;
+      }
+      const revoked = {
+        ...grant,
+        standing: false,
+        revoked: true,
+        revocationPending: true,
+        generation: grant.generation + 1,
+      };
+      grants.set(grantId, revoked);
+      return structuredClone(revoked);
+    },
+    applyRevocation: (authority) => {
+      const grant = grants.get(authority.grantId);
+      if (
+        !grant ||
+        grant.role !== "holder" ||
+        authority.signal.aborted ||
+        grant.subjectId !== authority.subjectId ||
+        grant.subjectBinding !== authority.subjectBinding ||
+        grant.targetSessionId !== authority.targetSessionId ||
+        authority.generation <= grant.generation
+      ) {
+        return false;
+      }
+      grants.set(grant.grantId, {
+        ...grant,
+        standing: false,
+        revoked: true,
+        revocationPending: false,
+        generation: authority.generation,
+      });
+      return true;
+    },
+    acknowledgeRevocation: (authority) => {
+      const grant = grants.get(authority.grantId);
+      if (
+        !grant ||
+        grant.role !== "issuer" ||
+        authority.signal.aborted ||
+        !matchesRevocation(grant, authority)
+      ) {
+        return false;
+      }
+      grants.set(grant.grantId, { ...grant, revocationPending: false });
+      return true;
+    },
+  };
+  return runtime;
+}
+
+/** Clear persistent grant fixtures between tests. */
+export function resetReefFederationTestRuntime(): void {
+  grantsByStateDir.clear();
+}
+
+function matchesRevocation(
+  grant: CrossSessionGrant,
+  authority: Parameters<PluginRuntime["crossSessionGrants"]["acknowledgeRevocation"]>[0],
+): boolean {
+  return grant.revoked && grant.revocationPending && grant.generation === authority.generation;
+}
+
+function matches(
+  grant: CrossSessionGrant,
+  authority: Parameters<PluginRuntime["crossSessionGrants"]["authorize"]>[0],
+): boolean {
+  return (
+    grant.role === "issuer" &&
+    !grant.revoked &&
+    grant.subjectId === authority.subjectId &&
+    grant.subjectBinding === authority.subjectBinding &&
+    grant.targetSessionId === authority.targetSessionId &&
+    grant.generation === authority.generation
+  );
+}

--- a/extensions/reef/src/flow.test.ts
+++ b/extensions/reef/src/flow.test.ts
@@ -5,10 +5,12 @@ import {
   MemoryAuditStore,
   MemoryReplayStore,
   open,
+  seal,
   sha256Hex,
   verifyReceipt,
   type Verdict,
 } from "../protocol/index.js";
+import { ReefChannelConfigSchema } from "./config-schema.js";
 import { createConfiguredGuard, ReefMessageFlow } from "./flow.js";
 import {
   allow,
@@ -104,6 +106,59 @@ describe("ReefMessageFlow inbound", () => {
     expect(order).toEqual(["ingress", "ack", "ack"]);
     expect(onIngress).toHaveBeenCalledOnce();
     expect(relay.acknowledge).toHaveBeenCalledTimes(2);
+  });
+
+  it("routes typed federation frames before chat ingress and guard classification", async () => {
+    const alice = generateIdentity();
+    const bob = reefKeys();
+    const id = "01JZ0000000000000000000199";
+    const stores = flowStores();
+    const classifier = guard(allow);
+    const relay = transport();
+    const onIngress = vi.fn(async () => {});
+    const onFederation = vi.fn(async () => {});
+    const flow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(alice) }).store,
+      keys: bob,
+      transport: relay as unknown as ReefTransportClient,
+      guard: classifier,
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(12)),
+      replay: new MemoryReplayStore(),
+      ...stores,
+      onIngress,
+      onFederation,
+      onOwnerNotice: async () => {},
+    });
+    const frame = {
+      type: "session.mount.offer" as const,
+      mountId: "mount-1",
+      sessionKey: "agent:main:shared",
+      sessionId: "session-1",
+      grantGeneration: 0,
+    };
+    const sealed = seal({
+      id,
+      from: "alice#1",
+      to: "bob#1",
+      body: { namespace: "openclaw.session-federation.v1", frame },
+      senderSigningSecretKey: alice.signing.secretKey,
+      recipientEncryptionPublicKey: bob.encryption.publicKey,
+    });
+
+    await flow.processEntries([
+      { seq: 1, peer: "alice", id, kind: "message", envelope: sealed, ts: 1 },
+    ]);
+
+    expect(onFederation).toHaveBeenCalledWith({
+      peer: "alice",
+      from: "alice#1",
+      to: "bob#1",
+      frame,
+    });
+    expect(onIngress).not.toHaveBeenCalled();
+    expect(classifier.classify).not.toHaveBeenCalled();
+    expect(relay.acknowledge).toHaveBeenCalledOnce();
   });
 
   it("parks a review-pending inbound message until the owner decides, without re-classifying", async () => {
@@ -302,6 +357,51 @@ describe("ReefMessageFlow inbound", () => {
 });
 
 describe("ReefMessageFlow outbound", () => {
+  it("sends typed federation frames without chat guard classification", async () => {
+    const alice = reefKeys();
+    const bob = generateIdentity();
+    const relay = transport();
+    const classifier = guard(allow);
+    const trusted = trust({ bob: peerTrust(bob) });
+    const flow = new ReefMessageFlow({
+      config: ReefChannelConfigSchema.parse({
+        handle: "alice",
+        email: "alice@example.com",
+        guard: config().guard,
+      }),
+      trust: trusted.store,
+      keys: alice,
+      transport: relay as unknown as ReefTransportClient,
+      guard: classifier,
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(13)),
+      replay: new MemoryReplayStore(),
+      ...flowStores(),
+      onIngress: async () => {},
+      onOwnerNotice: async () => {},
+    });
+    const frame = {
+      type: "session.grant.revoked" as const,
+      mountId: "mount-1",
+      sessionId: "session-1",
+      grantGeneration: 2,
+    };
+
+    const id = await flow.sendFederation("bob", frame);
+
+    expect(classifier.classify).not.toHaveBeenCalled();
+    expect(relay.sendEnvelope).toHaveBeenCalledOnce();
+    const sent = relay.sendEnvelope.mock.calls[0]![1] as Parameters<typeof open>[0]["envelope"];
+    await expect(
+      open({
+        envelope: sent,
+        self: "bob#1",
+        recipientEncryptionSecretKey: bob.encryption.secretKey,
+        senderSigningPublicKey: alice.signing.publicKey,
+        replayStore: new MemoryReplayStore(),
+      }),
+    ).resolves.toEqual({ namespace: "openclaw.session-federation.v1", frame });
+    expect(trusted.store.outboundDelivery("bob", id)).toMatchObject({ recipient: { keyEpoch: 1 } });
+  });
   it("seals and posts an allowed message", async () => {
     const alice = reefKeys();
     const bob = generateIdentity();

--- a/extensions/reef/src/flow.test.ts
+++ b/extensions/reef/src/flow.test.ts
@@ -8,6 +8,7 @@ import {
   seal,
   sha256Hex,
   verifyReceipt,
+  type ReefFederationFrame,
   type Verdict,
 } from "../protocol/index.js";
 import { ReefChannelConfigSchema } from "./config-schema.js";
@@ -24,6 +25,7 @@ import {
   transport,
   trust,
 } from "./flow.test-helpers.js";
+import { reefPeerIdentity } from "./friend-types.js";
 import type { ReefTransportClient } from "./transport.js";
 import type { InboxEntry } from "./types.js";
 
@@ -159,6 +161,68 @@ describe("ReefMessageFlow inbound", () => {
     expect(onIngress).not.toHaveBeenCalled();
     expect(classifier.classify).not.toHaveBeenCalled();
     expect(relay.acknowledge).toHaveBeenCalledOnce();
+  });
+
+  it("reprocesses a completed federation replay when durable semantic handling was interrupted", async () => {
+    const alice = generateIdentity();
+    const bob = reefKeys();
+    const id = "01JZ0000000000000000000198";
+    const stores = flowStores();
+    const relay = transport();
+    const onFederation = vi
+      .fn<
+        (params: {
+          peer: string;
+          from: string;
+          to: string;
+          frame: ReefFederationFrame;
+        }) => Promise<void>
+      >()
+      .mockRejectedValueOnce(new Error("interrupted before semantic claim"))
+      .mockResolvedValueOnce();
+    const flow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(alice) }).store,
+      keys: bob,
+      transport: relay as unknown as ReefTransportClient,
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(12)),
+      replay: new MemoryReplayStore(),
+      ...stores,
+      onIngress: async () => {},
+      onFederation,
+      onOwnerNotice: async () => {},
+    });
+    const frame = {
+      type: "session.mount.offer" as const,
+      mountId: "mount-replay",
+      sessionKey: "agent:main:shared",
+      sessionId: "session-replay",
+      grantGeneration: 0,
+    };
+    const sealed = seal({
+      id,
+      from: "alice#1",
+      to: "bob#1",
+      body: { namespace: "openclaw.session-federation.v1", frame },
+      senderSigningSecretKey: alice.signing.secretKey,
+      recipientEncryptionPublicKey: bob.encryption.publicKey,
+    });
+    const entry: InboxEntry = {
+      seq: 1,
+      peer: "alice",
+      id,
+      kind: "message",
+      envelope: sealed,
+      ts: 1,
+    };
+
+    await expect(flow.processEntries([entry])).rejects.toThrow("interrupted before semantic claim");
+    await flow.processEntries([{ ...entry, seq: 2 }]);
+
+    expect(onFederation).toHaveBeenCalledTimes(2);
+    expect(relay.acknowledge).toHaveBeenCalledOnce();
+    await expect(stores.delivered.has(id)).resolves.toBe(true);
   });
 
   it("parks a review-pending inbound message until the owner decides, without re-classifying", async () => {
@@ -402,6 +466,50 @@ describe("ReefMessageFlow outbound", () => {
     ).resolves.toEqual({ namespace: "openclaw.session-federation.v1", frame });
     expect(trusted.store.outboundDelivery("bob", id)).toMatchObject({ recipient: { keyEpoch: 1 } });
   });
+  it("rejects oversized federated prompts before persistence or transport", async () => {
+    const alice = reefKeys();
+    const bob = generateIdentity();
+    const relay = transport();
+    const trusted = trust({ bob: peerTrust(bob) });
+    const flow = new ReefMessageFlow({
+      config: ReefChannelConfigSchema.parse({
+        handle: "alice",
+        email: "alice@example.com",
+        guard: config().guard,
+      }),
+      trust: trusted.store,
+      keys: alice,
+      transport: relay as unknown as ReefTransportClient,
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(13)),
+      replay: new MemoryReplayStore(),
+      ...flowStores(),
+      onIngress: async () => {},
+      onOwnerNotice: async () => {},
+    });
+    const registerOutboundProposal = vi.fn(() => true);
+
+    await expect(
+      flow.proposeFederatedPrompt(
+        {
+          mountId: "mount-1",
+          peer: "bob",
+          peerIdentity: reefPeerIdentity(trusted.values.get("bob")!),
+          role: "guest",
+          sessionKey: "agent:main:shared",
+          sessionId: "session-1",
+          grantGeneration: 0,
+          allowAlways: false,
+          revoked: false,
+        },
+        "x".repeat(513),
+        { registerOutboundProposal },
+      ),
+    ).rejects.toThrow("invalid prompt text");
+    expect(registerOutboundProposal).not.toHaveBeenCalled();
+    expect(relay.sendEnvelope).not.toHaveBeenCalled();
+  });
+
   it("seals and posts an allowed message", async () => {
     const alice = reefKeys();
     const bob = generateIdentity();

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -239,7 +239,7 @@ export class ReefMessageFlow {
       throw new Error("Only active guest Reef mounts can propose prompts");
     }
     const friend = this.options.trust.get(mount.peer);
-    if (!friend || friend.safetyNumberChanged || friend.keyEpoch !== mount.peerKeyEpoch) {
+    if (!matchesReefPeerIdentity(friend, mount.peerIdentity)) {
       throw new ReefOutboundRejectedError(
         `Reef peer @${mount.peer} is not approved with current keys`,
       );

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -3,6 +3,11 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  createReefFederatedPromptDigest,
+  isReefFederationBody,
+  type ReefFederationFrame,
+} from "../protocol/federation.js";
+import {
   appendAudit,
   appendInboxRead,
   bodyHash as hashMessageBody,
@@ -17,6 +22,7 @@ import {
   InvalidDeliveryReceiptError,
   parseHandleEpoch,
   PipelineError,
+  seal,
   verifyReceipt,
   type AuditEntry,
   type AuditStore,
@@ -26,6 +32,7 @@ import {
 } from "../protocol/index.js";
 import type { ReefChannelConfig } from "./config-schema.js";
 import { autonomyBudget } from "./config-schema.js";
+import type { ReefFederationMount } from "./federation-state.js";
 import {
   matchesReefPeerIdentity,
   reefPeerIdentity,
@@ -147,6 +154,12 @@ export class ReefMessageFlow {
       delivered: ReefDeliveredStore;
       authoritySignal?: AbortSignal;
       onIngress: (message: ReefIngressMessage) => Promise<void>;
+      onFederation?: (params: {
+        peer: string;
+        from: string;
+        to: string;
+        frame: ReefFederationFrame;
+      }) => Promise<void>;
       onOwnerNotice: (text: string) => Promise<void>;
     },
   ) {}
@@ -217,6 +230,83 @@ export class ReefMessageFlow {
     signal?.throwIfAborted();
     await this.options.transport.sendEnvelope(peer, result.envelope, signal);
     signal?.throwIfAborted();
+    return id;
+  }
+
+  /** Propose one prompt against an exact mounted session authority. */
+  async proposeFederatedPrompt(mount: ReefFederationMount, text: string): Promise<string> {
+    if (mount.role !== "guest") {
+      throw new Error("Only guest Reef mounts can propose prompts");
+    }
+    const friend = this.options.trust.get(mount.peer);
+    if (!friend || friend.safetyNumberChanged || friend.keyEpoch !== mount.peerKeyEpoch) {
+      throw new ReefOutboundRejectedError(
+        `Reef peer @${mount.peer} is not approved with current keys`,
+      );
+    }
+    const proposalId = `reef-proposal-${prepareReefMessageId()}`;
+    const from = formatHandleEpoch(this.requireHandle(), this.options.keys.keyEpoch);
+    const to = formatHandleEpoch(mount.peer, friend.keyEpoch);
+    await this.sendFederation(mount.peer, {
+      type: "session.prompt.propose",
+      mountId: mount.mountId,
+      proposalId,
+      sessionId: mount.sessionId,
+      grantGeneration: mount.grantGeneration,
+      text,
+      textSha256: createReefFederatedPromptDigest({
+        from,
+        to,
+        mountId: mount.mountId,
+        proposalId,
+        sessionId: mount.sessionId,
+        grantGeneration: mount.grantGeneration,
+        text,
+      }),
+    });
+    return proposalId;
+  }
+
+  /** Send a typed federation frame without routing it through the chat guard pipeline. */
+  async sendFederation(peer: string, frame: ReefFederationFrame): Promise<string> {
+    const signal = this.options.authoritySignal;
+    signal?.throwIfAborted();
+    const friend = this.options.trust.get(peer);
+    if (!friend || friend.safetyNumberChanged) {
+      throw new ReefOutboundRejectedError(`Reef peer @${peer} is not approved with current keys`);
+    }
+    const recipient = reefPeerIdentity(friend);
+    const id = prepareReefMessageId();
+    const body = { namespace: "openclaw.session-federation.v1" as const, frame };
+    const from = formatHandleEpoch(this.requireHandle(), this.options.keys.keyEpoch);
+    const to = formatHandleEpoch(peer, friend.keyEpoch);
+    const proposalHash = hashMessageBody(body);
+    await appendAudit(this.options.audit, "federation_proposal", {
+      id,
+      from,
+      to,
+      bodyHash: proposalHash,
+      frameType: frame.type,
+    });
+    const envelope = seal({
+      id,
+      from,
+      to,
+      body,
+      senderSigningSecretKey: this.options.keys.signing.secretKey,
+      recipientEncryptionPublicKey: friend.x25519PublicKey,
+    });
+    await appendAudit(this.options.audit, "envelope", { id, envelope });
+    if (!matchesReefPeerIdentity(this.options.trust.get(peer), recipient)) {
+      throw new ReefOutboundRejectedError(
+        `Reef peer @${peer} changed keys while composing the frame`,
+      );
+    }
+    this.options.trust.recordOutboundDelivery(peer, id, {
+      bodyHash: proposalHash,
+      recipient,
+    });
+    await this.options.transport.sendEnvelope(peer, envelope, signal);
     return id;
   }
 
@@ -444,6 +534,20 @@ export class ReefMessageFlow {
       return;
     }
     if (await this.options.delivered.has(envelope.id)) {
+      await this.options.transport.acknowledge(relayPeer, envelope.id, result.receipt);
+      return;
+    }
+    if (isReefFederationBody(result.body)) {
+      if (!this.options.onFederation) {
+        throw new Error("Reef federation handler is unavailable");
+      }
+      await this.options.onFederation({
+        peer: relayPeer,
+        from: envelope.from,
+        to: envelope.to,
+        frame: result.body.frame,
+      });
+      await this.options.delivered.add(envelope.id);
       await this.options.transport.acknowledge(relayPeer, envelope.id, result.receipt);
       return;
     }

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -235,8 +235,8 @@ export class ReefMessageFlow {
 
   /** Propose one prompt against an exact mounted session authority. */
   async proposeFederatedPrompt(mount: ReefFederationMount, text: string): Promise<string> {
-    if (mount.role !== "guest") {
-      throw new Error("Only guest Reef mounts can propose prompts");
+    if (mount.role !== "guest" || mount.revoked) {
+      throw new Error("Only active guest Reef mounts can propose prompts");
     }
     const friend = this.options.trust.get(mount.peer);
     if (!friend || friend.safetyNumberChanged || friend.keyEpoch !== mount.peerKeyEpoch) {

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -239,7 +239,7 @@ export class ReefMessageFlow {
       throw new Error("Only active guest Reef mounts can propose prompts");
     }
     const friend = this.options.trust.get(mount.peer);
-    if (!matchesReefPeerIdentity(friend, mount.peerIdentity)) {
+    if (!friend || !matchesReefPeerIdentity(friend, mount.peerIdentity)) {
       throw new ReefOutboundRejectedError(
         `Reef peer @${mount.peer} is not approved with current keys`,
       );

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -5,6 +5,7 @@ import {
 import {
   createReefFederatedPromptDigest,
   isReefFederationBody,
+  validateReefFederationBody,
   type ReefFederationFrame,
 } from "../protocol/federation.js";
 import {
@@ -32,7 +33,7 @@ import {
 } from "../protocol/index.js";
 import type { ReefChannelConfig } from "./config-schema.js";
 import { autonomyBudget } from "./config-schema.js";
-import type { ReefFederationMount } from "./federation-state.js";
+import type { ReefFederationMount, ReefFederationPromptRequest } from "./federation-state.js";
 import {
   matchesReefPeerIdentity,
   reefPeerIdentity,
@@ -234,7 +235,17 @@ export class ReefMessageFlow {
   }
 
   /** Propose one prompt against an exact mounted session authority. */
-  async proposeFederatedPrompt(mount: ReefFederationMount, text: string): Promise<string> {
+  async proposeFederatedPrompt(
+    mount: ReefFederationMount,
+    text: string,
+    proposals: {
+      findOutboundProposal?: (
+        mount: ReefFederationMount,
+        text: string,
+      ) => ReefFederationPromptRequest | undefined;
+      registerOutboundProposal: (request: ReefFederationPromptRequest) => boolean;
+    },
+  ): Promise<string> {
     if (mount.role !== "guest" || mount.revoked) {
       throw new Error("Only active guest Reef mounts can propose prompts");
     }
@@ -244,11 +255,16 @@ export class ReefMessageFlow {
         `Reef peer @${mount.peer} is not approved with current keys`,
       );
     }
+    const pending = proposals.findOutboundProposal?.(mount, text);
+    if (pending) {
+      await this.sendFederation(mount.peer, pending.frame);
+      return pending.frame.proposalId;
+    }
     const proposalId = `reef-proposal-${prepareReefMessageId()}`;
     const from = formatHandleEpoch(this.requireHandle(), this.options.keys.keyEpoch);
     const to = formatHandleEpoch(mount.peer, friend.keyEpoch);
-    await this.sendFederation(mount.peer, {
-      type: "session.prompt.propose",
+    const frame = {
+      type: "session.prompt.propose" as const,
       mountId: mount.mountId,
       proposalId,
       sessionId: mount.sessionId,
@@ -263,21 +279,44 @@ export class ReefMessageFlow {
         grantGeneration: mount.grantGeneration,
         text,
       }),
-    });
+    };
+    validateReefFederationBody({ namespace: "openclaw.session-federation.v1", frame });
+    if (
+      !proposals.registerOutboundProposal({
+        from,
+        to,
+        peer: mount.peer,
+        peerIdentity: mount.peerIdentity,
+        frame,
+      })
+    ) {
+      throw new Error(`Could not reserve Reef prompt proposal ${proposalId}`);
+    }
+    await this.sendFederation(mount.peer, frame);
     return proposalId;
   }
 
   /** Send a typed federation frame without routing it through the chat guard pipeline. */
-  async sendFederation(peer: string, frame: ReefFederationFrame): Promise<string> {
+  async sendFederation(
+    peer: string,
+    frame: ReefFederationFrame,
+    context: { expectedRecipient?: ReefPeerIdentity } = {},
+  ): Promise<string> {
     const signal = this.options.authoritySignal;
     signal?.throwIfAborted();
     const friend = this.options.trust.get(peer);
-    if (!friend || friend.safetyNumberChanged) {
+    if (
+      !friend ||
+      friend.safetyNumberChanged ||
+      (context.expectedRecipient !== undefined &&
+        !matchesReefPeerIdentity(friend, context.expectedRecipient))
+    ) {
       throw new ReefOutboundRejectedError(`Reef peer @${peer} is not approved with current keys`);
     }
     const recipient = reefPeerIdentity(friend);
     const id = prepareReefMessageId();
     const body = { namespace: "openclaw.session-federation.v1" as const, frame };
+    validateReefFederationBody(body);
     const from = formatHandleEpoch(this.requireHandle(), this.options.keys.keyEpoch);
     const to = formatHandleEpoch(peer, friend.keyEpoch);
     const proposalHash = hashMessageBody(body);

--- a/extensions/reef/src/inbound.ts
+++ b/extensions/reef/src/inbound.ts
@@ -1,5 +1,15 @@
 import type { ReefIngressMessage } from "./types.js";
 
+/** Read a text reply from a channel delivery payload. */
+export function resolveReefReplyText(payload: unknown): string {
+  if (!payload || typeof payload !== "object" || !("text" in payload)) {
+    return "";
+  }
+  // SAFETY: The own-property guard above proves this object has a readable text field.
+  const text = (payload as { text?: unknown }).text;
+  return typeof text === "string" ? text : "";
+}
+
 export function resolveReefInboundDispatchContent(message: ReefIngressMessage) {
   // Reef promotes a new unthreaded exchange to its initiating envelope id.
   // A reply with no thread stays unthreaded so replyTo remains the sole correlation fact.

--- a/extensions/reef/src/runtime.ts
+++ b/extensions/reef/src/runtime.ts
@@ -1,13 +1,17 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
+import type { ReefFederationState } from "./federation-state.js";
 import type { ReefMessageFlow } from "./flow.js";
 import type { ReefFriendManager } from "./friends.js";
 import type { ReviewApprovalStore } from "./state.js";
+import type { ReefTrustStore } from "./trust-store.js";
 
 type ActiveReef = {
   flow: ReefMessageFlow;
   friends: ReefFriendManager;
   reviews: ReviewApprovalStore;
+  federation: ReefFederationState;
+  trust: ReefTrustStore;
 };
 
 const {

--- a/extensions/zalo/src/channel.pre-aborted.integration.test.ts
+++ b/extensions/zalo/src/channel.pre-aborted.integration.test.ts
@@ -67,7 +67,6 @@ describe("configured Zalo gateway with a pre-aborted lifecycle", () => {
       );
     });
     process.env.ZALO_API_URL = await listen(server);
-    setZaloRuntime({} as PluginRuntime);
     setActivePluginRegistry(createEmptyPluginRegistry());
   });
 
@@ -98,6 +97,7 @@ describe("configured Zalo gateway with a pre-aborted lifecycle", () => {
     abort.abort();
     const registry = createEmptyPluginRegistry();
     setActivePluginRegistry(registry);
+    setZaloRuntime({} as PluginRuntime);
 
     await requireStartAccount()(
       createStartAccountContext({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1905,6 +1905,9 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
 
   extensions/runway:
     devDependencies:

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1563,6 +1563,21 @@ describe("loadGatewayPlugins", () => {
     expect(handleGatewayRequest).not.toHaveBeenCalled();
   });
 
+  test("forwards trusted plugin Gateway request lifecycle signals", async () => {
+    loadOpenClawPlugins.mockReturnValue(addLoadedPlugin(createRegistry([]), { id: "google-meet" }));
+    loadGatewayStartupPluginsForTest();
+    serverPluginsModule.setFallbackGatewayContext(createTestContext("plugin-gateway-signal"));
+    const runtime = createRuntimeFromLastGatewayLoad();
+    const signal = new AbortController().signal;
+
+    await gatewayRequestScopeModule.withPluginRuntimePluginScope(
+      { pluginId: "google-meet", pluginOrigin: "bundled" },
+      () => runtime.gateway.request("voicecall.start", { to: "+15550001234" }, { signal }),
+    );
+
+    expect(handleGatewayRequest.mock.calls.at(-1)?.[0].signal).toBe(signal);
+  });
+
   test("lets trusted official plugins request explicit Gateway scopes", async () => {
     loadOpenClawPlugins.mockReturnValue(addLoadedPlugin(createRegistry([]), { id: "google-meet" }));
     loadGatewayStartupPluginsForTest();

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -101,6 +101,7 @@ export async function dispatchTrustedPluginGatewayMethod<T>(
     ...(!scope?.client ? { operatorRoleActor: { kind: "system" as const } } : {}),
     ...(syntheticScopes ? { syntheticScopes } : {}),
     ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+    ...(options?.signal ? { signal: options.signal } : {}),
   });
 }
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -102,6 +102,7 @@ export async function dispatchTrustedPluginGatewayMethod<T>(
     ...(syntheticScopes ? { syntheticScopes } : {}),
     ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
     ...(options?.signal ? { signal: options.signal } : {}),
+    sessionMutationCommitGuard: options?.assertAdmissionCurrent,
   });
 }
 

--- a/src/gateway/server.agent-input-authority.test.ts
+++ b/src/gateway/server.agent-input-authority.test.ts
@@ -63,6 +63,7 @@ describe("spawn input ownership transfer", () => {
     { owner: "plugin grant", boundary: "before facade" },
     { owner: "plugin grant", boundary: "before staging" },
     { owner: "plugin grant", boundary: "after acceptance" },
+    { owner: "plugin grant", boundary: "expired grant" },
   ] as const)(
     "keeps $owner input authority at its current owner: $boundary",
     async ({ owner, boundary }, { signal }) => {
@@ -127,9 +128,22 @@ describe("spawn input ownership transfer", () => {
           generation: 0,
           signal,
         };
-        expect(
-          grants.create({ ...authority, role: "issuer", targetSessionKey: childKey }, signal),
-        ).toBe(true);
+        // Scope wall-clock control to synchronous store operations; the Gateway runs on real time.
+        const now = Date.now();
+        const clock = boundary === "expired grant" ? vi.spyOn(Date, "now") : undefined;
+        try {
+          clock?.mockReturnValue(now - 8 * 24 * 60 * 60_000);
+          expect(
+            grants.create({ ...authority, role: "issuer", targetSessionKey: childKey }, signal),
+          ).toBe(true);
+          if (clock) {
+            expect(grants.allowStanding(authority)).toBe(true);
+            clock.mockReturnValue(now - 2 * 24 * 60 * 60_000);
+            expect(grants.applyRevocation({ ...authority, generation: 1 })).toBe(false);
+          }
+        } finally {
+          clock?.mockRestore();
+        }
         rejection = "grant revoked before input admission";
         guard = () => {
           if (!grants.authorize(authority)) {
@@ -257,17 +271,25 @@ describe("spawn input ownership transfer", () => {
           (value) => ({ value }),
           (error: unknown) => ({ error }),
         );
-        await Promise.race([
-          boundary === "before facade" ? facadeEntered.promise : staged.promise,
-          outcome.then((value) => {
-            if ("error" in value) {
-              throw value.error;
-            }
-            throw new Error(`Dispatch ended before staging: ${JSON.stringify(value)}`);
-          }),
-        ]);
-        if (boundary === "before staging" || boundary === "before facade") {
-          closeAuthority();
+        if (boundary !== "expired grant") {
+          await Promise.race([
+            boundary === "before facade" ? facadeEntered.promise : staged.promise,
+            outcome.then((value) => {
+              if ("error" in value) {
+                throw value.error;
+              }
+              throw new Error(`Dispatch ended before staging: ${JSON.stringify(value)}`);
+            }),
+          ]);
+        }
+        if (
+          boundary === "before staging" ||
+          boundary === "before facade" ||
+          boundary === "expired grant"
+        ) {
+          if (boundary !== "expired grant") {
+            closeAuthority();
+          }
           releaseWriter.resolve();
           releaseFacade.resolve();
           expect(await outcome).toHaveProperty("error.message", rejection);

--- a/src/gateway/server.agent-input-authority.test.ts
+++ b/src/gateway/server.agent-input-authority.test.ts
@@ -17,7 +17,14 @@ import {
   runExclusiveSqliteSessionWrite,
 } from "../config/sessions/session-accessor.sqlite-scope.js";
 import { registerInternalHook, unregisterInternalHook } from "../hooks/internal-hooks.js";
-import { dispatchGatewayMethodInProcess } from "./server-plugins.js";
+import { markPluginRegistryActive } from "../plugins/registry-lifecycle.js";
+import { createPluginRegistry } from "../plugins/registry.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { createPluginRecord } from "../plugins/status.test-fixtures.js";
+import {
+  dispatchGatewayMethodInProcess,
+  dispatchTrustedPluginGatewayMethod,
+} from "./server-plugins.js";
 import { startGatewayServerHarness, type GatewayServerHarness } from "./server.e2e-ws-harness.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { installGatewayTestHooks, prepareGatewayReplyRuntimeForTest } from "./test-helpers.js";
@@ -48,179 +55,223 @@ describe("spawn input ownership transfer", () => {
   });
 
   it.for([
-    "before staging",
-    "after acceptance",
-    "child abort",
-    "before reset",
-    "live reset",
-  ] as const)("keeps input authority at its current owner: %s", async (boundary, { signal }) => {
-    await prepareGatewayReplyRuntimeForTest();
-    const context = kernel.gatewayRequestContext;
-    const cfg = context.getRuntimeConfig();
-    const runId = randomUUID();
-    const parentKey = `agent:main:parent:${runId}`;
-    const childKey = `agent:main:subagent:${runId}`;
-    const sessionId = `child-${runId}`;
-    await sessionAccessor.upsertSessionEntryCore(
-      { agentId: "main", sessionKey: childKey },
-      { sessionId, updatedAt: Date.now() },
-    );
-    const loaded = loadSessionEntry(childKey, { agentId: "main" });
-    const admission = prepareAgentRunAdmission({
-      cfg,
-      operationalRunInstance: createOperationalRunInstanceRef(`parent-${runId}`),
-      facts: {
-        runId: `parent-${runId}`,
-        agentId: "main",
-        ingress: { kind: "system", boundary: "spawn-input-proof", state: "present" },
-      },
-    });
-    const admitted = await admission.admit("embedded");
-    const guard = await withGatewayToolCallerIdentity(
-      createAdmittedGatewayToolCallerIdentity({
-        admittedRunContext: admitted,
-        agentId: "main",
-        sessionKey: parentKey,
-      }),
-      () => captureAgentToolSourceExecutionGuard(),
-    );
-    if (boundary === "before reset" || boundary === "live reset") {
-      const before = loadSessionEntry(childKey, { agentId: "main" }).entry;
-      let hookCalls = 0;
-      const onReset = (event: import("../hooks/internal-hooks.js").InternalHookEvent) => {
-        if (event.sessionKey !== childKey) {
-          return;
-        }
-        hookCalls++;
-        if (boundary === "before reset") {
-          admission.close();
-        }
-      };
-      registerInternalHook("command:new", onReset);
-      try {
-        const reset = dispatchGatewayMethodInProcess(
-          "agent",
-          { message: "/new", sessionKey: childKey, idempotencyKey: runId },
-          {
-            forceSyntheticClient: true,
-            syntheticScopes: ["operator.admin"],
-            resolveGatewayContext: () => context,
-            sessionMutationCommitGuard: guard,
-          },
-        );
-        if (boundary === "before reset") {
-          await expect(reset).rejects.toThrow("tool invocation authority is no longer active");
-          expect(loadSessionEntry(childKey, { agentId: "main" }).entry).toEqual(before);
-        } else {
-          await expect(reset).resolves.toMatchObject({ status: "ok", summary: "completed" });
-          const after = loadSessionEntry(childKey, { agentId: "main" }).entry;
-          expect(after?.sessionId).toBe(sessionId);
-          expect(after?.lifecycleRevision).not.toBe(before?.lifecycleRevision);
-        }
-        expect(hookCalls).toBe(1);
-      } finally {
-        unregisterInternalHook("command:new", onReset);
-        admission.close();
-      }
-      return;
-    }
-    const staged = createDeferred();
-    const releaseWriter = createDeferred();
-    const releaseExecution = createDeferred();
-    const executionEntered = createDeferred();
-    const release = () => {
-      releaseWriter.resolve();
-      releaseExecution.resolve();
-    };
-    signal.addEventListener("abort", release, { once: true });
-    let writer: Promise<unknown> | undefined;
-    let execution: Promise<void> | undefined;
-    let prepared:
-      | import("./agent-turn/agent-run-admission-phase.js").PreparedAgentRunDispatch
-      | undefined;
-    const executionModule = await import("./agent-turn/agent-run-execution-phase.js");
-    const execute = executionModule.startAgentRunExecution;
-    const executionSpy = vi
-      .spyOn(executionModule, "startAgentRunExecution")
-      .mockImplementationOnce((params) => {
-        prepared = params.prepared;
-        executionEntered.resolve();
-        execution = releaseExecution.promise.then(() => execute(params));
-        return execution;
+    { owner: "spawn", boundary: "before staging" },
+    { owner: "spawn", boundary: "after acceptance" },
+    { owner: "spawn", boundary: "child abort" },
+    { owner: "spawn", boundary: "before reset" },
+    { owner: "spawn", boundary: "live reset" },
+    { owner: "plugin grant", boundary: "before facade" },
+    { owner: "plugin grant", boundary: "before staging" },
+    { owner: "plugin grant", boundary: "after acceptance" },
+  ] as const)(
+    "keeps $owner input authority at its current owner: $boundary",
+    async ({ owner, boundary }, { signal }) => {
+      await prepareGatewayReplyRuntimeForTest();
+      const context = kernel.gatewayRequestContext;
+      const cfg = context.getRuntimeConfig();
+      const runId = randomUUID();
+      const parentKey = `agent:main:parent:${runId}`;
+      const childKey = `agent:main:subagent:${runId}`;
+      const sessionId = `child-${runId}`;
+      await sessionAccessor.upsertSessionEntryCore(
+        { agentId: "main", sessionKey: childKey },
+        { sessionId, updatedAt: Date.now() },
+      );
+      const loaded = loadSessionEntry(childKey, { agentId: "main" });
+      const admission = prepareAgentRunAdmission({
+        cfg,
+        operationalRunInstance: createOperationalRunInstanceRef(`parent-${runId}`),
+        facts: {
+          runId: `parent-${runId}`,
+          agentId: "main",
+          ingress: { kind: "system", boundary: "spawn-input-proof", state: "present" },
+        },
       });
-    const stage = sessionAccessor.stageSessionPendingInput;
-    const stageSpy = vi
-      .spyOn(sessionAccessor, "stageSessionPendingInput")
-      .mockImplementationOnce(async (...args) => {
-        if (boundary === "before staging") {
-          const entered = createDeferred();
-          writer = runExclusiveSqliteSessionWrite(
-            resolveSqliteStoreScope(loaded.storePath, { agentId: "main" }),
-            async () => {
-              entered.resolve();
-              await releaseWriter.promise;
+      const admitted = await admission.admit("embedded");
+      let guard = await withGatewayToolCallerIdentity(
+        createAdmittedGatewayToolCallerIdentity({
+          admittedRunContext: admitted,
+          agentId: "main",
+          sessionKey: parentKey,
+        }),
+        () => captureAgentToolSourceExecutionGuard(),
+      );
+      let closeAuthority = () => admission.close();
+      let pluginRuntime: ReturnType<typeof createPluginRuntime> | undefined;
+      let rejection = "tool invocation authority is no longer active";
+      if (owner === "plugin grant") {
+        const builder = createPluginRegistry({
+          logger: { info() {}, warn() {}, error() {}, debug() {} },
+          runtime: createPluginRuntime({
+            gateway: {
+              isAvailable: async () => true,
+              request: (method, params, options) =>
+                dispatchTrustedPluginGatewayMethod(method, params, options, () => context),
+            },
+          }),
+          activateGlobalSideEffects: false,
+        });
+        const record = createPluginRecord({ id: "admission-proof", origin: "bundled" });
+        pluginRuntime = builder.createApi(record, {
+          config: cfg,
+          registrationMode: "full",
+        }).runtime;
+        builder.registry.plugins.push(record);
+        markPluginRegistryActive(builder.registry);
+        const grants = pluginRuntime.crossSessionGrants;
+        const authority = {
+          grantId: runId,
+          subjectId: "remote-peer",
+          subjectBinding: "peer-key-epoch-1",
+          targetSessionId: sessionId,
+          generation: 0,
+          signal,
+        };
+        expect(
+          grants.create({ ...authority, role: "issuer", targetSessionKey: childKey }, signal),
+        ).toBe(true);
+        rejection = "grant revoked before input admission";
+        guard = () => {
+          if (!grants.authorize(authority)) {
+            throw new Error(rejection);
+          }
+        };
+        closeAuthority = () => {
+          grants.revoke({ grantId: runId, expectedGeneration: 0, signal });
+        };
+      }
+      if (boundary === "before reset" || boundary === "live reset") {
+        const before = loadSessionEntry(childKey, { agentId: "main" }).entry;
+        let hookCalls = 0;
+        const onReset = (event: import("../hooks/internal-hooks.js").InternalHookEvent) => {
+          if (event.sessionKey !== childKey) {
+            return;
+          }
+          hookCalls++;
+          if (boundary === "before reset") {
+            admission.close();
+          }
+        };
+        registerInternalHook("command:new", onReset);
+        try {
+          const reset = dispatchGatewayMethodInProcess(
+            "agent",
+            { message: "/new", sessionKey: childKey, idempotencyKey: runId },
+            {
+              forceSyntheticClient: true,
+              syntheticScopes: ["operator.admin"],
+              resolveGatewayContext: () => context,
+              sessionMutationCommitGuard: guard,
             },
           );
-          await entered.promise;
-        }
-        const pending = stage(...args);
-        staged.resolve();
-        return await pending;
-      });
-    let dispatch: Promise<unknown> | undefined;
-    try {
-      dispatch = dispatchGatewayMethodInProcess(
-        "agent",
-        { message: "synthetic staged child input", sessionKey: childKey, idempotencyKey: runId },
-        {
-          forceSyntheticClient: true,
-          resolveGatewayContext: () => context,
-          sessionMutationCommitGuard: guard,
-        },
-      );
-      const outcome = dispatch.then(
-        (value) => ({ value }),
-        (error: unknown) => ({ error }),
-      );
-      await Promise.race([
-        staged.promise,
-        outcome.then((value) => {
-          if ("error" in value) {
-            throw value.error;
+          if (boundary === "before reset") {
+            await expect(reset).rejects.toThrow("tool invocation authority is no longer active");
+            expect(loadSessionEntry(childKey, { agentId: "main" }).entry).toEqual(before);
+          } else {
+            await expect(reset).resolves.toMatchObject({ status: "ok", summary: "completed" });
+            const after = loadSessionEntry(childKey, { agentId: "main" }).entry;
+            expect(after?.sessionId).toBe(sessionId);
+            expect(after?.lifecycleRevision).not.toBe(before?.lifecycleRevision);
           }
-          throw new Error(`Dispatch ended before staging: ${JSON.stringify(value)}`);
-        }),
-      ]);
-      if (boundary === "before staging") {
-        admission.close();
+          expect(hookCalls).toBe(1);
+        } finally {
+          unregisterInternalHook("command:new", onReset);
+          admission.close();
+        }
+        return;
+      }
+      const staged = createDeferred();
+      const releaseWriter = createDeferred();
+      const releaseFacade = createDeferred();
+      const facadeEntered = createDeferred();
+      const createFacade = context.createAgentTurnFacade!;
+      const facadeSpy =
+        boundary === "before facade"
+          ? vi.spyOn(context, "createAgentTurnFacade").mockImplementationOnce(async (...args) => {
+              facadeEntered.resolve();
+              await releaseFacade.promise;
+              return createFacade(...args);
+            })
+          : undefined;
+      const releaseExecution = createDeferred();
+      const executionEntered = createDeferred();
+      const release = () => {
         releaseWriter.resolve();
-        expect(await outcome).toHaveProperty(
-          "error.message",
-          "tool invocation authority is no longer active",
+        releaseFacade.resolve();
+        releaseExecution.resolve();
+      };
+      signal.addEventListener("abort", release, { once: true });
+      let writer: Promise<unknown> | undefined;
+      let execution: Promise<void> | undefined;
+      let prepared:
+        | import("./agent-turn/agent-run-admission-phase.js").PreparedAgentRunDispatch
+        | undefined;
+      const executionModule = await import("./agent-turn/agent-run-execution-phase.js");
+      const execute = executionModule.startAgentRunExecution;
+      const executionSpy = vi
+        .spyOn(executionModule, "startAgentRunExecution")
+        .mockImplementationOnce((params) => {
+          prepared = params.prepared;
+          executionEntered.resolve();
+          execution = releaseExecution.promise.then(() => execute(params));
+          return execution;
+        });
+      const stage = sessionAccessor.stageSessionPendingInput;
+      const stageSpy = vi
+        .spyOn(sessionAccessor, "stageSessionPendingInput")
+        .mockImplementationOnce(async (...args) => {
+          if (boundary === "before staging") {
+            const entered = createDeferred();
+            writer = runExclusiveSqliteSessionWrite(
+              resolveSqliteStoreScope(loaded.storePath, { agentId: "main" }),
+              async () => {
+                entered.resolve();
+                await releaseWriter.promise;
+              },
+            );
+            await entered.promise;
+          }
+          const pending = stage(...args);
+          staged.resolve();
+          return await pending;
+        });
+      let dispatch: Promise<unknown> | undefined;
+      try {
+        const input = {
+          message: "synthetic staged child input",
+          sessionKey: childKey,
+          expectedExistingSessionId: sessionId,
+          idempotencyKey: runId,
+        };
+        const requestOptions = { assertAdmissionCurrent: guard };
+        dispatch = pluginRuntime
+          ? pluginRuntime.gateway.request("agent", input, requestOptions)
+          : dispatchGatewayMethodInProcess("agent", input, {
+              forceSyntheticClient: true,
+              resolveGatewayContext: () => context,
+              sessionMutationCommitGuard: guard,
+            });
+        // Changing the caller-owned object cannot detach a fence already submitted to the runtime.
+        requestOptions.assertAdmissionCurrent = () => {};
+        const outcome = dispatch.then(
+          (value) => ({ value }),
+          (error: unknown) => ({ error }),
         );
-        expect(prepared).toBeUndefined();
-        expect(
-          listSessionPendingInputs({
-            agentId: "main",
-            sessionKey: childKey,
-            sessionId,
-            storePath: loaded.storePath,
-          }).total,
-        ).toBe(0);
-      } else {
-        expect(await outcome).toHaveProperty("value.status", "accepted");
-        await executionEntered.promise;
-        const recorder = prepared!.userTurn.recorder!;
-        expect(recorder.getPendingInputMessage?.()).toBeDefined();
-        admission.close();
-        expect(() => guard()).toThrow("tool invocation authority is no longer active");
-        if (boundary === "child abort") {
-          prepared!.activeRunAbort.controller.abort(new Error("child stopped"));
-          expect(() => recorder.withPendingInput!(() => undefined)).toThrow("child stopped");
-        } else {
-          const persisted = await recorder.withPendingInput!(() => recorder.persistApproved());
-          expect(persisted?.appended).toBe(true);
-          expect(persisted?.message.content).toBe("synthetic staged child input");
+        await Promise.race([
+          boundary === "before facade" ? facadeEntered.promise : staged.promise,
+          outcome.then((value) => {
+            if ("error" in value) {
+              throw value.error;
+            }
+            throw new Error(`Dispatch ended before staging: ${JSON.stringify(value)}`);
+          }),
+        ]);
+        if (boundary === "before staging" || boundary === "before facade") {
+          closeAuthority();
+          releaseWriter.resolve();
+          releaseFacade.resolve();
+          expect(await outcome).toHaveProperty("error.message", rejection);
+          expect(prepared).toBeUndefined();
           expect(
             listSessionPendingInputs({
               agentId: "main",
@@ -229,15 +280,39 @@ describe("spawn input ownership transfer", () => {
               storePath: loaded.storePath,
             }).total,
           ).toBe(0);
+        } else {
+          expect(await outcome).toHaveProperty("value.status", "accepted");
+          await executionEntered.promise;
+          const recorder = prepared!.userTurn.recorder!;
+          expect(recorder.getPendingInputMessage?.()).toBeDefined();
+          closeAuthority();
+          expect(() => guard()).toThrow(rejection);
+          if (boundary === "child abort") {
+            prepared!.activeRunAbort.controller.abort(new Error("child stopped"));
+            expect(() => recorder.withPendingInput!(() => undefined)).toThrow("child stopped");
+          } else {
+            const persisted = await recorder.withPendingInput!(() => recorder.persistApproved());
+            expect(persisted?.appended).toBe(true);
+            expect(persisted?.message.content).toBe("synthetic staged child input");
+            expect(
+              listSessionPendingInputs({
+                agentId: "main",
+                sessionKey: childKey,
+                sessionId,
+                storePath: loaded.storePath,
+              }).total,
+            ).toBe(0);
+          }
         }
+      } finally {
+        release();
+        await Promise.allSettled([writer, dispatch, execution]);
+        admission.close();
+        facadeSpy?.mockRestore();
+        stageSpy.mockRestore();
+        executionSpy.mockRestore();
+        signal.removeEventListener("abort", release);
       }
-    } finally {
-      release();
-      await Promise.allSettled([writer, dispatch, execution]);
-      admission.close();
-      stageSpy.mockRestore();
-      executionSpy.mockRestore();
-      signal.removeEventListener("abort", release);
-    }
-  });
+    },
+  );
 });

--- a/src/plugin-sdk/runtime-store-registry.ts
+++ b/src/plugin-sdk/runtime-store-registry.ts
@@ -1,4 +1,7 @@
-type NamedPluginRuntimeStoreSlot = { runtime: unknown };
+type PluginRuntimeStoreSlot = { runtime: unknown };
+type NamedPluginRuntimeStoreSlot = PluginRuntimeStoreSlot & {
+  owners: WeakMap<object, PluginRuntimeStoreSlot>;
+};
 type NamedPluginRuntimeStoreRegistry = Map<string, NamedPluginRuntimeStoreSlot>;
 
 const pluginRuntimeStoreRegistryKey = Symbol.for("openclaw.plugin-sdk.runtime-store-registry");
@@ -15,7 +18,7 @@ export function getNamedPluginRuntimeStoreSlot(key: string): NamedPluginRuntimeS
   const registry = getNamedPluginRuntimeStoreRegistry();
   let slot = registry.get(key);
   if (!slot) {
-    slot = { runtime: null };
+    slot = { runtime: null, owners: new WeakMap() };
     registry.set(key, slot);
   }
   return slot;
@@ -25,6 +28,36 @@ export function clearNamedPluginRuntimeStoresForTest(): void {
   const registry = getNamedPluginRuntimeStoreRegistry();
   for (const slot of registry.values()) {
     slot.runtime = null;
+    slot.owners = new WeakMap();
   }
   registry.clear();
+}
+
+// Registry projections retain the exact owner without exposing runtimes in diagnostics.
+const runtimeStoreOwner = Symbol.for("openclaw.pluginRuntimeStoreOwner");
+type RuntimeStoreOwnerCarrier = { [runtimeStoreOwner]?: () => object };
+
+/** Select an owner-local slot; an empty registry must never borrow another owner's runtime. */
+export function getScopedPluginRuntimeStoreSlot(
+  namedSlot: NamedPluginRuntimeStoreSlot,
+  registry: object,
+): PluginRuntimeStoreSlot {
+  // SAFETY: Only this module writes the private owner carrier.
+  const carrier = registry as RuntimeStoreOwnerCarrier;
+  let getOwner = carrier[runtimeStoreOwner];
+  if (!getOwner) {
+    const owner = {};
+    getOwner = () => owner;
+    Object.defineProperty(registry, runtimeStoreOwner, {
+      value: getOwner,
+      enumerable: true,
+    });
+  }
+  const owner = getOwner();
+  let slot = namedSlot.owners.get(owner);
+  if (!slot) {
+    slot = { runtime: null };
+    namedSlot.owners.set(owner, slot);
+  }
+  return slot;
 }

--- a/src/plugin-sdk/runtime-store.test.ts
+++ b/src/plugin-sdk/runtime-store.test.ts
@@ -2,11 +2,57 @@
  * Tests runtime store singleton behavior.
  */
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+  withPluginRegistrationContext,
+} from "../plugins/runtime.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { clearNamedPluginRuntimeStoresForTest } from "./runtime-store-registry.js";
 import { createPluginRuntimeStore } from "./runtime-store.js";
 
+afterEach(resetPluginRuntimeStateForTest);
+
 describe("createPluginRuntimeStore", () => {
+  test("isolates registry ownership while retaining standalone and explicit-key behavior", async () => {
+    const root = createEmptyPluginRegistry();
+    const discovery = createEmptyPluginRegistry();
+    const empty = createEmptyPluginRegistry();
+    const store = createPluginRuntimeStore<string>({
+      pluginId: "owner-test",
+      errorMessage: "owner missing",
+    });
+    const active = createPluginRuntimeStore<string>({
+      key: "owner-test:active",
+      errorMessage: "active missing",
+    });
+    withPluginRegistrationContext(root, "owner-test", () => {
+      store.setRuntime("root");
+      active.setRuntime("root-flow");
+    });
+    setActivePluginRegistry(root);
+    withPluginRegistrationContext(discovery, "owner-test", () => store.setRuntime("discovery"));
+    expect(store.getRuntime()).toBe("root");
+    await withPluginRuntimeRegistryScope(discovery, async () => {
+      await Promise.resolve();
+      expect(store.getRuntime()).toBe("discovery");
+      expect(active.getRuntime()).toBe("root-flow");
+      store.clearRuntime();
+      expect(store.tryGetRuntime()).toBeNull();
+      store.setRuntime("standalone");
+    });
+    withPluginRuntimeRegistryScope(empty, () => {
+      expect(store.tryGetRuntime()).toBeNull();
+      expect(() => store.getRuntime()).toThrow("owner missing");
+    });
+    expect(store.getRuntime()).toBe("root");
+    expect(withPluginRuntimeRegistryScope({ ...root }, () => store.getRuntime())).toBe("root");
+    resetPluginRuntimeStateForTest();
+    expect(store.getRuntime()).toBe("standalone");
+  });
+
   test("shares runtime slots for the same plugin id", () => {
     const firstStore = createPluginRuntimeStore<{ value: string }>({
       pluginId: "shared-plugin",

--- a/src/plugin-sdk/runtime-store.ts
+++ b/src/plugin-sdk/runtime-store.ts
@@ -1,5 +1,9 @@
 // Runtime store exports expose plugin runtime type contracts without loading runtime code.
-import { getNamedPluginRuntimeStoreSlot } from "./runtime-store-registry.js";
+import { getPluginRegistryForContext } from "../plugins/runtime/gateway-request-scope.js";
+import {
+  getNamedPluginRuntimeStoreSlot,
+  getScopedPluginRuntimeStoreSlot,
+} from "./runtime-store-registry.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";
 type PluginRuntimeStoreKeyOptions = {
   /** Explicit global registry key for shared runtime slots. */
@@ -39,10 +43,12 @@ function resolvePluginRuntimeStoreOptions(
 }
 
 /**
- * Create a process-local runtime slot that throws when accessed before initialization.
+ * Create an owner-local runtime slot that throws when accessed before initialization.
  *
  * String keys create isolated module-local stores; option objects create global
  * named slots so duplicate SDK module instances share the same plugin runtime.
+ * Plugin-id slots follow the current registration/request/active registry; explicit
+ * keys retain process-local ownership.
  */
 export function createPluginRuntimeStore<T>(errorMessage: string): {
   setRuntime: (next: T) => void;
@@ -50,7 +56,7 @@ export function createPluginRuntimeStore<T>(errorMessage: string): {
   tryGetRuntime: () => T | null;
   getRuntime: () => T;
 };
-/** Create a globally shared runtime slot keyed by plugin id or explicit registry key. */
+/** Share a runtime within its plugin registry, or process-wide for an explicit key. */
 export function createPluginRuntimeStore<T>(options: PluginRuntimeStoreOptions): {
   setRuntime: (next: T) => void;
   clearRuntime: () => void;
@@ -65,26 +71,33 @@ export function createPluginRuntimeStore<T>(options: string | PluginRuntimeStore
   getRuntime: () => T;
 } {
   const resolved = resolvePluginRuntimeStoreOptions(options);
-  const slot =
-    typeof options === "string"
-      ? { runtime: null }
-      : (() => {
-          // Store named slots on globalThis so duplicate SDK module instances
-          // still share one runtime for the same plugin id or explicit key.
-          return getNamedPluginRuntimeStoreSlot(resolved.key);
-        })();
+  const namedSlot =
+    typeof options === "string" ? undefined : getNamedPluginRuntimeStoreSlot(resolved.key);
+  const standaloneSlot = namedSlot ?? { runtime: null };
+  const resolveSlot = () => {
+    const registry =
+      typeof options !== "string" && "pluginId" in options ? getPluginRegistryForContext() : null;
+    return registry && namedSlot
+      ? getScopedPluginRuntimeStoreSlot(namedSlot, registry)
+      : standaloneSlot;
+  };
 
   return {
     setRuntime(next: T) {
-      slot.runtime = next;
+      resolveSlot().runtime = next;
+      // Standalone CLI callbacks have no registry scope. Preserve their existing
+      // last-registration slot; owned calls never fall back to this value.
+      standaloneSlot.runtime = next;
     },
     clearRuntime() {
-      slot.runtime = null;
+      resolveSlot().runtime = null;
+      standaloneSlot.runtime = null;
     },
     tryGetRuntime() {
-      return (slot.runtime as T | null) ?? null;
+      return (resolveSlot().runtime as T | null) ?? null;
     },
     getRuntime() {
+      const slot = resolveSlot();
       if (slot.runtime === null) {
         throw new Error(resolved.errorMessage);
       }

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -505,6 +505,16 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
   };
   const base: PluginRuntime = {
     version: "1.0.0-test",
+    crossSessionGrants: {
+      create: vi.fn(() => false),
+      list: vi.fn(() => []),
+      get: vi.fn(() => undefined),
+      authorize: vi.fn(() => undefined),
+      allowStanding: vi.fn(() => false),
+      revoke: vi.fn(() => undefined),
+      applyRevocation: vi.fn(() => false),
+      acknowledgeRevocation: vi.fn(() => false),
+    },
     gateway: {
       isAvailable: vi.fn(async () => false),
       request: vi.fn(),

--- a/src/plugins/cross-session-grants.test.ts
+++ b/src/plugins/cross-session-grants.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
+import { createCrossSessionGrantRuntime } from "./cross-session-grants.js";
+import type { CrossSessionGrant } from "./runtime/types.js";
+
+const grant: CrossSessionGrant = {
+  grantId: "grant-1",
+  subjectId: "remote-peer",
+  subjectBinding: "peer-key-epoch-1",
+  role: "issuer",
+  targetSessionKey: "agent:main:shared",
+  targetSessionId: "session-1",
+  generation: 0,
+  standing: false,
+  revoked: false,
+  revocationPending: false,
+};
+
+function authority(signal: AbortSignal, overrides: Partial<typeof grant> = {}) {
+  return {
+    grantId: overrides.grantId ?? grant.grantId,
+    subjectId: overrides.subjectId ?? grant.subjectId,
+    subjectBinding: overrides.subjectBinding ?? grant.subjectBinding,
+    targetSessionId: overrides.targetSessionId ?? grant.targetSessionId,
+    generation: overrides.generation ?? grant.generation,
+    signal,
+  };
+}
+
+describe("cross-session grant runtime", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  let stateDir = "";
+  let env: NodeJS.ProcessEnv;
+  let live = true;
+
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    stateDir = tempDirs.make("openclaw-cross-session-grants-");
+    env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    live = true;
+  });
+
+  afterEach(() => {
+    resetPluginStateStoreForTests();
+  });
+
+  it("persists exact grants and rejects stale or closed lifecycle authority", () => {
+    const runtime = createCrossSessionGrantRuntime("reef", () => live, env);
+    const controller = new AbortController();
+
+    expect(runtime.create(grant, controller.signal)).toBe(true);
+    expect(runtime.authorize(authority(controller.signal))).toMatchObject(grant);
+    expect(
+      runtime.authorize(authority(controller.signal, { subjectBinding: "rotated-key" })),
+    ).toBeUndefined();
+
+    controller.abort();
+    expect(runtime.allowStanding(authority(controller.signal))).toBe(false);
+    expect(runtime.get(grant.grantId, controller.signal)).toBeUndefined();
+    expect(runtime.list(controller.signal)).toEqual([]);
+    expect(runtime.create({ ...grant, grantId: "closed-grant" }, controller.signal)).toBe(false);
+    expect(
+      runtime.revoke({
+        grantId: grant.grantId,
+        expectedGeneration: grant.generation,
+        signal: controller.signal,
+      }),
+    ).toBeUndefined();
+
+    const nextLifecycle = new AbortController();
+    expect(runtime.get(grant.grantId, nextLifecycle.signal)?.standing).toBe(false);
+    expect(runtime.allowStanding(authority(nextLifecycle.signal))).toBe(true);
+    expect(
+      createCrossSessionGrantRuntime("reef", () => live, env).get(
+        grant.grantId,
+        nextLifecycle.signal,
+      ),
+    ).toMatchObject({ standing: true, generation: 0 });
+
+    live = false;
+    expect(runtime.authorize(authority(nextLifecycle.signal))).toBeUndefined();
+  });
+
+  it("accepts exact grant redelivery without allowing identifier rebinding", () => {
+    const runtime = createCrossSessionGrantRuntime("reef", () => live, env);
+    const signal = new AbortController().signal;
+
+    expect(runtime.create(grant, signal)).toBe(true);
+    expect(runtime.create(grant, signal)).toBe(true);
+    expect(runtime.create({ ...grant, targetSessionId: "other-session" }, signal)).toBe(false);
+    expect(runtime.list(signal)).toHaveLength(1);
+  });
+
+  it("counts revoked grants against the subject quota until replay state expires", () => {
+    const runtime = createCrossSessionGrantRuntime("reef", () => live, env);
+    const signal = new AbortController().signal;
+    for (let index = 0; index < 32; index += 1) {
+      const grantId = `grant-${index}`;
+      expect(runtime.create({ ...grant, grantId }, signal)).toBe(true);
+      expect(runtime.revoke({ grantId, expectedGeneration: 0, signal })).toMatchObject({
+        revoked: true,
+      });
+    }
+    expect(runtime.create({ ...grant, grantId: "grant-overflow" }, signal)).toBe(false);
+    expect(
+      runtime.create({ ...grant, grantId: "other-subject", subjectId: "other-peer" }, signal),
+    ).toBe(true);
+  });
+
+  it("revokes issuer grants and binds holder revocation to the exact subject", () => {
+    const runtime = createCrossSessionGrantRuntime("reef", () => live, env);
+    const signal = new AbortController().signal;
+    expect(runtime.create(grant, signal)).toBe(true);
+
+    expect(runtime.revoke({ grantId: grant.grantId, expectedGeneration: 0, signal })).toMatchObject(
+      {
+        generation: 1,
+        standing: false,
+        revoked: true,
+        revocationPending: true,
+      },
+    );
+    expect(runtime.acknowledgeRevocation({ grantId: grant.grantId, generation: 1, signal })).toBe(
+      true,
+    );
+    expect(runtime.get(grant.grantId, signal)).toMatchObject({ revocationPending: false });
+    expect(runtime.authorize(authority(signal))).toBeUndefined();
+
+    const holder = { ...grant, grantId: "holder-1", role: "holder" as const };
+    expect(runtime.create(holder, signal)).toBe(true);
+    expect(
+      runtime.applyRevocation(
+        authority(signal, { ...holder, subjectId: "other-peer", generation: 1 }),
+      ),
+    ).toBe(false);
+    expect(runtime.applyRevocation(authority(signal, { ...holder, generation: 1 }))).toBe(true);
+    expect(runtime.get(holder.grantId, signal)).toMatchObject({ generation: 1, revoked: true });
+  });
+});

--- a/src/plugins/cross-session-grants.test.ts
+++ b/src/plugins/cross-session-grants.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
+import { pluginStateEntries } from "../plugin-state/plugin-state-store.sqlite.js";
 import { createCrossSessionGrantRuntime } from "./cross-session-grants.js";
 import type { CrossSessionGrant } from "./runtime/types.js";
 
@@ -42,6 +43,7 @@ describe("cross-session grant runtime", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     resetPluginStateStoreForTests();
   });
 
@@ -81,6 +83,65 @@ describe("cross-session grant runtime", () => {
     live = false;
     expect(runtime.authorize(authority(nextLifecycle.signal))).toBeUndefined();
   });
+
+  it.for(["allowStanding", "revoke", "applyRevocation", "acknowledgeRevocation"] as const)(
+    "keeps rejected %s mutations from extending persisted expiry",
+    (operation) => {
+      const runtime = createCrossSessionGrantRuntime("reef", () => live, env);
+      const controller = new AbortController();
+      const signal = controller.signal;
+      const started = Date.now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(started);
+      expect(runtime.create(grant, signal)).toBe(true);
+      expect(runtime.allowStanding(authority(signal))).toBe(true);
+      const rows = () =>
+        pluginStateEntries({
+          pluginId: "core:cross-session-grants:reef",
+          namespace: "grants",
+          env,
+        });
+      const before = rows();
+      expect(before).toHaveLength(1);
+      expect(before[0]?.expiresAt).toBe(started + 7 * 24 * 60 * 60_000);
+      const reject = () => {
+        switch (operation) {
+          case "allowStanding":
+            expect(runtime.allowStanding(authority(signal, { subjectBinding: "wrong-key" }))).toBe(
+              false,
+            );
+            break;
+          case "revoke":
+            expect(
+              runtime.revoke({ grantId: grant.grantId, expectedGeneration: 1, signal }),
+            ).toBeUndefined();
+            break;
+          case "applyRevocation":
+            expect(runtime.applyRevocation(authority(signal, { generation: 1 }))).toBe(false);
+            break;
+          case "acknowledgeRevocation":
+            expect(
+              runtime.acknowledgeRevocation({ grantId: grant.grantId, generation: 0, signal }),
+            ).toBe(false);
+        }
+      };
+      // Exercise binding/role rejection, then retired and aborted callers, against one original TTL.
+      clock.mockReturnValue(started + 6 * 24 * 60 * 60_000);
+      reject();
+      live = false;
+      reject();
+      live = true;
+      controller.abort();
+      reject();
+      expect(rows()).toEqual(before);
+      resetPluginStateStoreForTests();
+      const reopened = createCrossSessionGrantRuntime("reef", () => live, env);
+      const freshSignal = new AbortController().signal;
+      expect(reopened.authorize(authority(freshSignal))).toMatchObject({ standing: true });
+      clock.mockReturnValue(before[0]!.expiresAt!);
+      expect(reopened.authorize(authority(freshSignal))).toBeUndefined();
+      expect(reopened.list(freshSignal)).toEqual([]);
+    },
+  );
 
   it("accepts exact grant redelivery without allowing identifier rebinding", () => {
     const runtime = createCrossSessionGrantRuntime("reef", () => live, env);

--- a/src/plugins/cross-session-grants.ts
+++ b/src/plugins/cross-session-grants.ts
@@ -1,0 +1,233 @@
+import { createHash } from "node:crypto";
+import {
+  createCorePluginStateSyncKeyedStore,
+  type OpenKeyedStoreOptions,
+} from "../plugin-state/plugin-state-store.js";
+import type {
+  CrossSessionGrant,
+  CrossSessionGrantAuthority,
+  CrossSessionGrantRuntime,
+} from "./runtime/types.js";
+
+const MAX_GRANTS = 1_000;
+const MAX_GRANTS_PER_SUBJECT = 32;
+const GRANT_TTL_MS = 7 * 24 * 60 * 60_000;
+
+/** Create a host-owned, plugin-scoped cross-session grant authority. */
+export function createCrossSessionGrantRuntime(
+  pluginId: string,
+  isPluginLive: () => boolean,
+  env?: OpenKeyedStoreOptions["env"],
+): CrossSessionGrantRuntime {
+  const store = createCorePluginStateSyncKeyedStore<CrossSessionGrant>({
+    ownerId: `core:cross-session-grants:${pluginId}`,
+    namespace: "grants",
+    maxEntries: MAX_GRANTS,
+    overflowPolicy: "reject-new",
+    defaultTtlMs: GRANT_TTL_MS,
+    ...(env ? { env } : {}),
+  });
+
+  const get = (grantId: string, signal: AbortSignal): CrossSessionGrant | undefined => {
+    if (!isPluginLive() || signal.aborted) {
+      return undefined;
+    }
+    const value = store.lookup(grantKey(grantId));
+    return value ? validateGrant(value) : undefined;
+  };
+  const authorize = (authority: CrossSessionGrantAuthority): CrossSessionGrant | undefined => {
+    if (!isPluginLive() || authority.signal.aborted) {
+      return undefined;
+    }
+    const grant = get(authority.grantId, authority.signal);
+    return grant && matchesAuthority(grant, authority) ? grant : undefined;
+  };
+  const update = store.update;
+  if (!update) {
+    throw new Error("Cross-session grants require atomic plugin-state updates");
+  }
+
+  return {
+    create(grant, signal) {
+      if (!isPluginLive() || signal.aborted) {
+        return false;
+      }
+      const validated = validateGrant({
+        ...grant,
+        standing: false,
+        revoked: false,
+        revocationPending: false,
+      });
+      const existing = store.lookup(grantKey(validated.grantId));
+      if (existing) {
+        return matchesRegistration(validateGrant(existing), validated);
+      }
+      // Revoked rows still consume replay-protection capacity until expiry, so include them in the
+      // subject quota rather than letting one peer exhaust the global store through churn.
+      const subjectCount = store
+        .entries()
+        .map((entry) => validateGrant(entry.value))
+        .filter((entry) => entry.subjectId === validated.subjectId).length;
+      if (subjectCount >= MAX_GRANTS_PER_SUBJECT) {
+        return false;
+      }
+      return store.registerIfAbsent(grantKey(validated.grantId), validated);
+    },
+    list(signal) {
+      return isPluginLive() && !signal.aborted
+        ? store.entries().map((entry) => validateGrant(entry.value))
+        : [];
+    },
+    get,
+    authorize,
+    allowStanding(authority) {
+      let changed = false;
+      update(grantKey(authority.grantId), (existing) => {
+        if (!existing || !isPluginLive() || authority.signal.aborted) {
+          return existing;
+        }
+        const grant = validateGrant(existing);
+        if (!matchesAuthority(grant, authority)) {
+          return grant;
+        }
+        changed = true;
+        return validateGrant({ ...grant, standing: true });
+      });
+      return changed;
+    },
+    revoke(params) {
+      if (!isPluginLive() || params.signal.aborted) {
+        return undefined;
+      }
+      const current = get(params.grantId, params.signal);
+      if (current?.revoked && current.generation === params.expectedGeneration) {
+        return current;
+      }
+      let revoked: CrossSessionGrant | undefined;
+      update(grantKey(params.grantId), (existing) => {
+        if (!existing || !isPluginLive() || params.signal.aborted) {
+          return existing;
+        }
+        const grant = validateGrant(existing);
+        if (
+          grant.role !== "issuer" ||
+          grant.revoked ||
+          grant.generation !== params.expectedGeneration
+        ) {
+          return grant;
+        }
+        revoked = validateGrant({
+          ...grant,
+          generation: grant.generation + 1,
+          standing: false,
+          revoked: true,
+          revocationPending: true,
+        });
+        return revoked;
+      });
+      return revoked;
+    },
+    applyRevocation(authority) {
+      let changed = false;
+      update(grantKey(authority.grantId), (existing) => {
+        if (!existing || !isPluginLive() || authority.signal.aborted) {
+          return existing;
+        }
+        const grant = validateGrant(existing);
+        if (
+          grant.role !== "holder" ||
+          grant.subjectId !== authority.subjectId ||
+          grant.subjectBinding !== authority.subjectBinding ||
+          grant.targetSessionId !== authority.targetSessionId ||
+          authority.generation <= grant.generation
+        ) {
+          return grant;
+        }
+        changed = true;
+        return validateGrant({
+          ...grant,
+          generation: authority.generation,
+          standing: false,
+          revoked: true,
+          revocationPending: false,
+        });
+      });
+      return changed;
+    },
+    acknowledgeRevocation(params) {
+      let changed = false;
+      update(grantKey(params.grantId), (existing) => {
+        if (!existing || !isPluginLive() || params.signal.aborted) {
+          return existing;
+        }
+        const grant = validateGrant(existing);
+        if (
+          grant.role !== "issuer" ||
+          !grant.revoked ||
+          !grant.revocationPending ||
+          grant.generation !== params.generation
+        ) {
+          return grant;
+        }
+        changed = true;
+        return validateGrant({ ...grant, revocationPending: false });
+      });
+      return changed;
+    },
+  };
+}
+
+function matchesRegistration(left: CrossSessionGrant, right: CrossSessionGrant): boolean {
+  return (
+    !left.revoked &&
+    left.grantId === right.grantId &&
+    left.subjectId === right.subjectId &&
+    left.subjectBinding === right.subjectBinding &&
+    left.role === right.role &&
+    left.targetSessionKey === right.targetSessionKey &&
+    left.targetSessionId === right.targetSessionId &&
+    left.generation === right.generation
+  );
+}
+
+function matchesAuthority(
+  grant: CrossSessionGrant,
+  authority: CrossSessionGrantAuthority,
+): boolean {
+  return (
+    grant.role === "issuer" &&
+    !grant.revoked &&
+    grant.subjectId === authority.subjectId &&
+    grant.subjectBinding === authority.subjectBinding &&
+    grant.targetSessionId === authority.targetSessionId &&
+    grant.generation === authority.generation
+  );
+}
+
+function grantKey(grantId: string): string {
+  return `grant:${createHash("sha256").update(grantId).digest("hex")}`;
+}
+
+function validateGrant(value: CrossSessionGrant): CrossSessionGrant {
+  if (
+    !value ||
+    !isBoundedString(value.grantId, 512) ||
+    !isBoundedString(value.subjectId, 512) ||
+    !isBoundedString(value.subjectBinding, 2_048) ||
+    (value.role !== "issuer" && value.role !== "holder") ||
+    !isBoundedString(value.targetSessionKey, 4_096) ||
+    !isBoundedString(value.targetSessionId, 512) ||
+    !Number.isSafeInteger(value.generation) ||
+    value.generation < 0 ||
+    typeof value.standing !== "boolean" ||
+    typeof value.revoked !== "boolean" ||
+    typeof value.revocationPending !== "boolean"
+  ) {
+    throw new Error("invalid cross-session grant");
+  }
+  return structuredClone(value);
+}
+
+function isBoundedString(value: unknown, maxLength: number): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= maxLength;
+}

--- a/src/plugins/cross-session-grants.ts
+++ b/src/plugins/cross-session-grants.ts
@@ -42,6 +42,7 @@ export function createCrossSessionGrantRuntime(
     const grant = get(authority.grantId, authority.signal);
     return grant && matchesAuthority(grant, authority) ? grant : undefined;
   };
+  // Returning a value rewrites its TTL; rejected mutations must use the no-write sentinel.
   const update = store.update;
   if (!update) {
     throw new Error("Cross-session grants require atomic plugin-state updates");
@@ -84,11 +85,11 @@ export function createCrossSessionGrantRuntime(
       let changed = false;
       update(grantKey(authority.grantId), (existing) => {
         if (!existing || !isPluginLive() || authority.signal.aborted) {
-          return existing;
+          return undefined;
         }
         const grant = validateGrant(existing);
         if (!matchesAuthority(grant, authority)) {
-          return grant;
+          return undefined;
         }
         changed = true;
         return validateGrant({ ...grant, standing: true });
@@ -106,7 +107,7 @@ export function createCrossSessionGrantRuntime(
       let revoked: CrossSessionGrant | undefined;
       update(grantKey(params.grantId), (existing) => {
         if (!existing || !isPluginLive() || params.signal.aborted) {
-          return existing;
+          return undefined;
         }
         const grant = validateGrant(existing);
         if (
@@ -114,7 +115,7 @@ export function createCrossSessionGrantRuntime(
           grant.revoked ||
           grant.generation !== params.expectedGeneration
         ) {
-          return grant;
+          return undefined;
         }
         revoked = validateGrant({
           ...grant,
@@ -131,7 +132,7 @@ export function createCrossSessionGrantRuntime(
       let changed = false;
       update(grantKey(authority.grantId), (existing) => {
         if (!existing || !isPluginLive() || authority.signal.aborted) {
-          return existing;
+          return undefined;
         }
         const grant = validateGrant(existing);
         if (
@@ -141,7 +142,7 @@ export function createCrossSessionGrantRuntime(
           grant.targetSessionId !== authority.targetSessionId ||
           authority.generation <= grant.generation
         ) {
-          return grant;
+          return undefined;
         }
         changed = true;
         return validateGrant({
@@ -158,7 +159,7 @@ export function createCrossSessionGrantRuntime(
       let changed = false;
       update(grantKey(params.grantId), (existing) => {
         if (!existing || !isPluginLive() || params.signal.aborted) {
-          return existing;
+          return undefined;
         }
         const grant = validateGrant(existing);
         if (
@@ -167,7 +168,7 @@ export function createCrossSessionGrantRuntime(
           !grant.revocationPending ||
           grant.generation !== params.generation
         ) {
-          return grant;
+          return undefined;
         }
         changed = true;
         return validateGrant({ ...grant, revocationPending: false });

--- a/src/plugins/loader-channel-runtime.ts
+++ b/src/plugins/loader-channel-runtime.ts
@@ -134,7 +134,12 @@ export function loadSetupRuntimeChannelCandidate(params: {
     }
     if (runtimeRegistration.setChannelRuntime) {
       try {
-        runtimeRegistration.setChannelRuntime(api.runtime);
+        runPluginRegisterSyncInRegistry(
+          () => runtimeRegistration.setChannelRuntime?.(api.runtime),
+          api,
+          registryBuilder.registry,
+          record.id,
+        );
         runtimeSetterApplied = true;
       } catch (error) {
         recordSetupFailure(error, "load", "failed to apply setup-runtime channel runtime");
@@ -191,7 +196,12 @@ export function loadSetupRuntimeChannelCandidate(params: {
   }
   if (!runtimeSetterApplied) {
     try {
-      mergedSetupRegistration.setChannelRuntime?.(api.runtime);
+      runPluginRegisterSyncInRegistry(
+        () => mergedSetupRegistration.setChannelRuntime?.(api.runtime),
+        api,
+        registryBuilder.registry,
+        record.id,
+      );
     } catch (error) {
       recordSetupFailure(error, "load", "failed to apply setup channel runtime");
       return true;

--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -52,6 +52,7 @@ const LAZY_RUNTIME_PROPERTIES = {
   webSearch: true,
   tasks: true,
   modelConfig: true,
+  crossSessionGrants: true,
 } satisfies Record<keyof PluginRuntime, true>;
 
 function createGuardedPluginRegistrationApi(api: OpenClawPluginApi): {

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -435,6 +435,7 @@ it("keeps version and injected instance surfaces independent of the broad runtim
     "webSearch",
     "tasks",
     "modelConfig",
+    "crossSessionGrants",
   ]);
   expect(Reflect.ownKeys(runtime)).toEqual(Object.keys(descriptors));
   for (const key of Object.keys(descriptors)) {

--- a/src/plugins/loader.runtime-store.test.ts
+++ b/src/plugins/loader.runtime-store.test.ts
@@ -1,0 +1,151 @@
+// Discovery must not replace the runtime consumed by an already registered plugin.
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, expect, it, onTestFinished } from "vitest";
+import { createPluginRuntimeStore } from "../plugin-sdk/runtime-store.js";
+import { loadAndActivateRootPluginRegistry, loadPluginRegistryHandle } from "./loader.js";
+import {
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
+import type { PluginRuntime } from "./runtime/types.js";
+
+afterEach(resetPluginLoaderTestStateForTest);
+
+it("keeps background dispatch on its registration owner after discovery replaces the module slot", async () => {
+  useNoBundledPlugins();
+  const fixtureKey = Symbol.for("openclaw.test.runtimeStoreFactory");
+  const fixtures = globalThis as Record<PropertyKey, unknown>;
+  fixtures[fixtureKey] = createPluginRuntimeStore;
+  onTestFinished(() => {
+    delete fixtures[fixtureKey];
+  });
+  const plugin = writePlugin({
+    id: "runtime-owner",
+    // Keep the SDK in Vitest's module graph; native require may select stale dist artifacts.
+    body: `const createPluginRuntimeStore = globalThis[Symbol.for("openclaw.test.runtimeStoreFactory")];
+      const store = createPluginRuntimeStore({ pluginId: "runtime-owner", errorMessage: "runtime missing" });
+      module.exports = { id: "runtime-owner", register(api) {
+        store.setRuntime(api.runtime);
+        api.registerCli(({ program }) => program.command("dispatch").action(async () => {
+          await Promise.resolve();
+          await store.getRuntime().gateway.request("owner.probe", {}, { scopes: ["operator.read"] });
+        }), { commands: ["dispatch"] });
+      } };`,
+  });
+  const options = {
+    cache: false,
+    pluginSdkResolution: "src" as const,
+    config: {
+      plugins: {
+        allow: [plugin.id],
+        load: { paths: [plugin.file] },
+        slots: { memory: "none" },
+      },
+    },
+  };
+  const calls: string[] = [];
+  const gateway = (owner: string): PluginRuntime["gateway"] => ({
+    isAvailable: async () => true,
+    async request() {
+      calls.push(owner);
+      throw new Error(`${owner} dispatch`);
+    },
+  });
+  const root = loadAndActivateRootPluginRegistry({
+    ...options,
+    runtimeOptions: { gateway: gateway("root") },
+  });
+  const discovered = loadPluginRegistryHandle({
+    ...options,
+    workspaceDir: path.join(makePluginLoaderTempDir(), "discovery"),
+    runtimeOptions: { gateway: gateway("discovery") },
+  });
+  for (const [registry, owner] of [
+    [root, "root"],
+    [discovered, "discovery"],
+    [{ ...root }, "root"],
+  ] as const) {
+    expect(registry.plugins[0]?.status).toBe("loaded");
+    const program = new Command();
+    await registry.cliRegistrars[0]!.register({
+      program,
+      parentPath: [],
+      config: options.config,
+      logger: { info() {}, warn() {}, error() {} },
+    });
+    await expect(
+      withPluginRuntimeRegistryScope(registry, () =>
+        program.parseAsync(["dispatch"], { from: "user" }),
+      ),
+    ).rejects.toThrow(`${owner} dispatch`);
+  }
+  expect(calls).toEqual(["root", "discovery", "root"]);
+});
+
+it.each([true, false])("owns setup runtime setters (full runtime setter: %s)", (fullSetter) => {
+  useNoBundledPlugins();
+  const store = createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "setup-owner",
+    errorMessage: "setup runtime missing",
+  });
+  const fixtureKey = Symbol.for("openclaw.test.setupRuntimeStore");
+  const fixtures = globalThis as Record<PropertyKey, unknown>;
+  fixtures[fixtureKey] = store;
+  onTestFinished(() => {
+    delete fixtures[fixtureKey];
+  });
+  const common = `const store = globalThis[Symbol.for("openclaw.test.setupRuntimeStore")];
+    const plugin = { id: "setup-owner", meta: { id: "setup-owner", label: "Setup owner", selectionLabel: "Setup owner", docsPath: "/channels/setup-owner", blurb: "fixture" },
+      capabilities: { chatTypes: ["direct"] }, config: { listAccountIds: () => [], resolveAccount: () => ({}) } };`;
+  const plugin = writePlugin({
+    id: "setup-owner",
+    filename: "index.cjs",
+    body: `${common} module.exports = { id: "setup-owner", kind: "bundled-channel-entry", loadChannelPlugin: () => plugin,
+      ${fullSetter ? "setChannelRuntime: store.setRuntime," : ""}
+      register(api) { store.setRuntime(api.runtime); api.registerChannel({ plugin }); } };`,
+  });
+  writeFileSync(
+    path.join(plugin.dir, "package.json"),
+    JSON.stringify({
+      name: plugin.id,
+      openclaw: { extensions: ["./index.cjs"], setupEntry: "./setup-entry.cjs" },
+    }),
+  );
+  writeFileSync(
+    path.join(plugin.dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: plugin.id,
+      channels: [plugin.id],
+      configSchema: { type: "object", properties: {}, additionalProperties: false },
+    }),
+  );
+  writeFileSync(
+    path.join(plugin.dir, "setup-entry.cjs"),
+    `${common} module.exports = { kind: "bundled-channel-setup-entry", loadSetupPlugin: () => plugin, setChannelRuntime: store.setRuntime };`,
+  );
+  const options = {
+    cache: false,
+    config: {
+      plugins: {
+        allow: [plugin.id],
+        load: { paths: [plugin.dir] },
+        entries: { [plugin.id]: { enabled: true } },
+        slots: { memory: "none" },
+      },
+    },
+  };
+  const root = loadAndActivateRootPluginRegistry(options);
+  const rootRuntime = store.getRuntime();
+  const setup = loadPluginRegistryHandle({ ...options, channelPluginLoadIntent: "setup" });
+  expect(setup.plugins[0]?.status).toBe("loaded");
+  expect(setup.channels).toHaveLength(1);
+  expect(store.getRuntime() === rootRuntime).toBe(true);
+  const setupRuntime = withPluginRuntimeRegistryScope(setup, () => store.getRuntime());
+  expect(setupRuntime === rootRuntime).toBe(false);
+  expect(withPluginRuntimeRegistryScope(root, () => store.getRuntime()) === rootRuntime).toBe(true);
+});

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -134,7 +134,7 @@ export function createPluginApiFactory(
       registrationMode,
       config: params.config,
       pluginConfig: params.pluginConfig,
-      runtime: resolvePluginRuntime(record.id),
+      runtime: resolvePluginRuntime(record.id, record),
       logger: normalizeLogger(registryParams.logger),
       resolvePath: (input: string) => resolvePluginPath(input, record.rootDir),
       handlers: {

--- a/src/plugins/registry-runtime.cross-session-grants.test.ts
+++ b/src/plugins/registry-runtime.cross-session-grants.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
+import { markPluginRegistryActive } from "./registry-lifecycle.js";
+import { createPluginRegistry } from "./registry.js";
+import { createPluginRuntime } from "./runtime/index.js";
+import type { CrossSessionGrant } from "./runtime/types.js";
+import { createPluginRecord } from "./status.test-fixtures.js";
+
+const grant: CrossSessionGrant = {
+  grantId: "grant-1",
+  subjectId: "remote-peer",
+  subjectBinding: "peer-key-epoch-1",
+  role: "issuer",
+  targetSessionKey: "agent:main:shared",
+  targetSessionId: "session-1",
+  generation: 0,
+  standing: false,
+  revoked: false,
+  revocationPending: false,
+};
+
+describe("plugin runtime cross-session grant ownership", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  let stateDir = "";
+
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    stateDir = tempDirs.make("openclaw-runtime-grants-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetPluginStateStoreForTests();
+  });
+
+  it("permanently retires a grant runtime retained by a replaced plugin record", () => {
+    const registryBuilder = createPluginRegistry({
+      logger: { info() {}, warn() {}, error() {}, debug() {} },
+      runtime: createPluginRuntime(),
+      activateGlobalSideEffects: false,
+    });
+    const original = createPluginRecord({ id: "reef", origin: "bundled" });
+    const originalApi = registryBuilder.createApi(original, {
+      config: {} as OpenClawConfig,
+      registrationMode: "full",
+    });
+    registryBuilder.registry.plugins.push(original);
+    markPluginRegistryActive(registryBuilder.registry);
+
+    const retainedParent = originalApi.runtime;
+    const retained = retainedParent.crossSessionGrants;
+    const signal = new AbortController().signal;
+    expect(retained.create(grant, signal)).toBe(true);
+
+    const replacement = createPluginRecord({ id: "reef", origin: "bundled" });
+    const replacementApi = registryBuilder.createApi(replacement, {
+      config: {} as OpenClawConfig,
+      registrationMode: "full",
+    });
+    registryBuilder.registry.plugins.push(replacement);
+
+    expect(retained.get(grant.grantId, signal)).toBeUndefined();
+    expect(retained.create({ ...grant, grantId: "stale-grant" }, signal)).toBe(false);
+    expect(
+      retainedParent.crossSessionGrants.create({ ...grant, grantId: "stale-parent-grant" }, signal),
+    ).toBe(false);
+    expect(replacementApi.runtime.crossSessionGrants.get(grant.grantId, signal)).toMatchObject(
+      grant,
+    );
+  });
+});

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -343,10 +343,12 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
           return {
             isAvailable: () => runWithPluginScope(() => gateway.isAvailable()),
             request: async (method, params, options) => {
+              // Retain the caller's admission fence before asynchronous ownership preparation.
+              const requestOptions = options ? { ...options } : undefined;
               const { assertGatewaySessionRequestOwned } = await loadSessionOwnership();
               return await runWithPluginScope(async () => {
                 assertGatewaySessionRequestOwned(method, params);
-                return await gateway.request(method, params, options);
+                return await gateway.request(method, params, requestOptions);
               });
             },
           } satisfies PluginRuntime["gateway"];

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -13,9 +13,11 @@ import {
   type OpenKeyedStoreOptions,
 } from "../plugin-state/plugin-state-store.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
+import { createCrossSessionGrantRuntime } from "./cross-session-grants.js";
 import { formatPluginTrustRefusal } from "./plugin-trust.js";
 import {
   activatePluginRecordLifecycleEpoch,
+  capturePluginLifecycleAuthority,
   isPluginRecordLifecycleEpochActive,
   isPluginRegistryActivated,
   isPluginRegistryRetired,
@@ -34,6 +36,7 @@ import type { PluginRuntime } from "./runtime/types.js";
 export function createPluginRuntimeResolver(state: PluginRegistryState) {
   const { registry, registryParams } = state;
   const pluginRuntimeById = new Map<string, PluginRuntime>();
+  const pluginRuntimeByRecord = new WeakMap<PluginRecord, PluginRuntime>();
   const pluginRuntimeRecordById = new Map<string, PluginRecord>();
   const activePluginRuntimeRecords = new WeakSet<PluginRecord>();
   const recordChannelRuntime = new WeakMap<PluginRecord, PluginRuntime["channel"]>();
@@ -153,8 +156,10 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
     return scoped;
   };
 
-  const resolvePluginRuntime = (pluginId: string): PluginRuntime => {
-    const cached = pluginRuntimeById.get(pluginId);
+  const resolvePluginRuntime = (pluginId: string, boundRecord?: PluginRecord): PluginRuntime => {
+    const cached = boundRecord
+      ? pluginRuntimeByRecord.get(boundRecord)
+      : pluginRuntimeById.get(pluginId);
     if (cached) {
       return cached;
     }
@@ -164,6 +169,10 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
       (module) => module.createPluginSessionOwnership(state, pluginId),
     );
     let scopedAgentRuntime: PluginRuntime["agent"] | undefined;
+    const crossSessionGrantsByRecord = new WeakMap<
+      PluginRecord,
+      PluginRuntime["crossSessionGrants"]
+    >();
     const assertTrustedPluginRuntime = (
       methodName:
         | "dispatchHookAgentTurn"
@@ -171,9 +180,11 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
         | "openKeyedStore"
         | "openSyncKeyedStore"
         | "openChannelIngressQueue"
-        | "openChannelIngressDrain",
+        | "openChannelIngressDrain"
+        | "crossSessionGrants",
     ) => {
       const record =
+        boundRecord ??
         pluginRuntimeRecordById.get(pluginId) ??
         registry.plugins.find((entry) => entry.id === pluginId);
       if (record?.origin !== "bundled" && record?.trustedOfficialInstall !== true) {
@@ -191,6 +202,7 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
       get(target, prop, receiver) {
         const runWithPluginScope = <T>(run: () => T): T => {
           const record =
+            boundRecord ??
             pluginRuntimeRecordById.get(pluginId) ??
             registry.plugins.find((entry) => entry.id === pluginId);
           return record?.source
@@ -212,6 +224,31 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
             return addPluginRuntimeResolutionContext({ error, pluginId, prop });
           }
         };
+        if (prop === "crossSessionGrants") {
+          assertTrustedPluginRuntime("crossSessionGrants");
+          const record = boundRecord ?? pluginRuntimeRecordById.get(pluginId);
+          if (!record) {
+            return createCrossSessionGrantRuntime(pluginId, () => false);
+          }
+          const cachedGrants = crossSessionGrantsByRecord.get(record);
+          if (cachedGrants) {
+            return cachedGrants;
+          }
+          const ownsLifecycle = capturePluginLifecycleAuthority(registry, record, {
+            scopedRuntime: true,
+          });
+          // Bind retained authority to this exact plugin record and lifecycle. A replacement or
+          // reactivation must never revive an old plugin's persistent cross-session grants.
+          const scopedGrants = createCrossSessionGrantRuntime(pluginId, () => {
+            return Boolean(
+              ownsLifecycle?.() &&
+              pluginRuntimeRecordById.get(pluginId) === record &&
+              activePluginRuntimeRecords.has(record),
+            );
+          });
+          crossSessionGrantsByRecord.set(record, scopedGrants);
+          return scopedGrants;
+        }
         if (prop === "state") {
           const baseState = getRuntimeProperty();
           return {
@@ -609,7 +646,11 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
         } satisfies PluginRuntime["subagent"];
       },
     });
-    pluginRuntimeById.set(pluginId, runtime);
+    if (boundRecord) {
+      pluginRuntimeByRecord.set(boundRecord, runtime);
+    } else {
+      pluginRuntimeById.set(pluginId, runtime);
+    }
     return runtime;
   };
 

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -150,6 +150,22 @@ function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
   };
 }
 
+function createUnavailableCrossSessionGrantRuntime(): PluginRuntime["crossSessionGrants"] {
+  const unavailable = () => {
+    throw new Error("Cross-session grants are only available through the plugin runtime proxy.");
+  };
+  return {
+    create: unavailable,
+    list: unavailable,
+    get: unavailable,
+    authorize: unavailable,
+    allowStanding: unavailable,
+    revoke: unavailable,
+    applyRevocation: unavailable,
+    acknowledgeRevocation: unavailable,
+  };
+}
+
 function createUnavailableNodesRuntime(): PluginRuntime["nodes"] {
   const unavailable = () => {
     throw new Error("Plugin node runtime is only available inside the Gateway.");
@@ -238,6 +254,7 @@ export const createPluginRuntime: PluginRuntimeFactory = (
     // Sourced from the shared OpenClaw version resolver (#52899) so plugins
     // always see the same version the CLI reports, avoiding API-version drift.
     version: VERSION,
+    crossSessionGrants: createUnavailableCrossSessionGrantRuntime(),
     gateway: _options.gateway ?? createRuntimeGateway(),
     config: base.config,
     agent,

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -126,12 +126,59 @@ type RuntimeNodeDuplexChannel = {
 
 export type RuntimeGatewayRequestOptions = {
   timeoutMs?: number;
+  signal?: AbortSignal;
   /** Requested Gateway scopes. Honored only for bundled or trusted official plugins. */
   scopes?: OperatorScope[];
 };
 
+export type CrossSessionGrant = {
+  grantId: string;
+  subjectId: string;
+  subjectBinding: string;
+  role: "issuer" | "holder";
+  targetSessionKey: string;
+  targetSessionId: string;
+  generation: number;
+  standing: boolean;
+  revoked: boolean;
+  revocationPending: boolean;
+};
+
+type CrossSessionGrantCreate = Omit<
+  CrossSessionGrant,
+  "standing" | "revoked" | "revocationPending"
+>;
+
+export type CrossSessionGrantAuthority = Pick<
+  CrossSessionGrant,
+  "grantId" | "subjectId" | "subjectBinding" | "targetSessionId" | "generation"
+> & {
+  signal: AbortSignal;
+};
+
+export type CrossSessionGrantRuntime = {
+  create: (grant: CrossSessionGrantCreate, signal: AbortSignal) => boolean;
+  list: (signal: AbortSignal) => CrossSessionGrant[];
+  get: (grantId: string, signal: AbortSignal) => CrossSessionGrant | undefined;
+  authorize: (authority: CrossSessionGrantAuthority) => CrossSessionGrant | undefined;
+  allowStanding: (authority: CrossSessionGrantAuthority) => boolean;
+  revoke: (params: {
+    grantId: string;
+    expectedGeneration: number;
+    signal: AbortSignal;
+  }) => CrossSessionGrant | undefined;
+  applyRevocation: (params: CrossSessionGrantAuthority) => boolean;
+  acknowledgeRevocation: (params: {
+    grantId: string;
+    generation: number;
+    signal: AbortSignal;
+  }) => boolean;
+};
+
 /** Trusted in-process runtime surface injected into native plugins. */
 export type PluginRuntime = PluginRuntimeCore & {
+  /** Host-owned persistent authority for exact cross-session grants. */
+  crossSessionGrants: CrossSessionGrantRuntime;
   gateway: {
     /** Whether this process owns an active Gateway request context. */
     isAvailable: () => Promise<boolean>;

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -127,6 +127,8 @@ type RuntimeNodeDuplexChannel = {
 export type RuntimeGatewayRequestOptions = {
   timeoutMs?: number;
   signal?: AbortSignal;
+  /** Synchronous narrowing check at session mutation commits; agent acceptance ends its ownership. */
+  assertAdmissionCurrent?: () => void;
   /** Requested Gateway scopes. Honored only for bundled or trusted official plugins. */
   scopes?: OperatorScope[];
 };

--- a/test/setup-openclaw-runtime.ts
+++ b/test/setup-openclaw-runtime.ts
@@ -1,5 +1,5 @@
 // OpenClaw runtime test setup installs runtime mocks and cleanup.
-import { afterAll, afterEach, beforeAll, vi } from "vitest";
+import { afterAll, afterEach, aroundEach, beforeAll, vi } from "vitest";
 import type {
   ChannelId,
   ChannelOutboundAdapter,
@@ -366,7 +366,16 @@ afterEach(async () => {
   resetContextWindowCacheForTest();
   resetModelsJsonReadyCacheForTest();
   await resetPreparedModelRuntimeSnapshotsForTest();
-  await installDefaultPluginRegistry();
+});
+
+aroundEach(async (runTest) => {
+  try {
+    await runTest();
+  } finally {
+    // Finish hooks still persist fixture state. Retire the registry only after
+    // those hooks finish, while keeping every test/retry isolated.
+    await installDefaultPluginRegistry();
+  }
 });
 
 afterAll(async () => {

--- a/ui/src/components/exec-approval-card.test.ts
+++ b/ui/src/components/exec-approval-card.test.ts
@@ -79,6 +79,15 @@ describe("exec approval card", () => {
     expect(card?.classList.contains("exec-approval-card--severity-warning")).toBe(true);
   });
 
+  it("scopes session-bound plugin standing approval copy to the current session", () => {
+    const card = renderCard(
+      approval({ request: { ...approval().request, allowedDecisions: ["allow-always"] } }),
+      "inline",
+    );
+
+    expect(card?.querySelector("button")?.textContent).toContain("Always allow here");
+  });
+
   it("shows plugin and agent chips with session details in the modal", () => {
     const card = renderCard(approval());
     const details = card?.querySelector<HTMLDetailsElement>(".exec-approval-details");

--- a/ui/src/components/exec-approval-card.test.ts
+++ b/ui/src/components/exec-approval-card.test.ts
@@ -79,13 +79,14 @@ describe("exec approval card", () => {
     expect(card?.classList.contains("exec-approval-card--severity-warning")).toBe(true);
   });
 
-  it("scopes session-bound plugin standing approval copy to the current session", () => {
+  it("does not infer plugin standing approval scope from session metadata", () => {
     const card = renderCard(
       approval({ request: { ...approval().request, allowedDecisions: ["allow-always"] } }),
       "inline",
     );
 
-    expect(card?.querySelector("button")?.textContent).toContain("Always allow here");
+    expect(card?.querySelector("button")?.textContent).toContain("Always allow");
+    expect(card?.querySelector("button")?.textContent).not.toContain("Always allow here");
   });
 
   it("shows plugin and agent chips with session details in the modal", () => {

--- a/ui/src/components/exec-approval-card.ts
+++ b/ui/src/components/exec-approval-card.ts
@@ -223,12 +223,12 @@ export function compactApprovalCommand(command: string): string {
   return singleLine.length > 64 ? `${truncateUtf16Safe(singleLine, 61)}…` : singleLine;
 }
 
-function approvalDecisionLabel(decision: ExecApprovalDecision, kind: ExecApprovalRequest["kind"]) {
+function approvalDecisionLabel(decision: ExecApprovalDecision, approval: ExecApprovalRequest) {
   return t(
     decision === "allow-once"
       ? "execApproval.allowOnce"
       : decision === "allow-always"
-        ? kind === "exec"
+        ? approval.kind === "exec" || approval.request.sessionKey
           ? "execApproval.alwaysAllowHere"
           : "execApproval.alwaysAllow"
         : "execApproval.deny",
@@ -315,7 +315,7 @@ export function renderSidebarApprovalRow(props: SidebarApprovalRowProps) {
         aria-label=${t("approvalPage.actionsLabel")}
       >
         ${resolveApprovalDecisions(approval).map((decision) => {
-          const label = approvalDecisionLabel(decision, approval.kind);
+          const label = approvalDecisionLabel(decision, approval);
           return html`<button
             type="button"
             class="btn btn--xs ${
@@ -441,7 +441,7 @@ export function renderExecApprovalCard(props: ExecApprovalCardProps) {
     }
     <div class="exec-approval-actions">
       ${decisions.map((decision) => {
-        const label = approvalDecisionLabel(decision, props.approval.kind);
+        const label = approvalDecisionLabel(decision, props.approval);
         return html`<button
           class=${decisionClass(decision)}
           type="button"

--- a/ui/src/components/exec-approval-card.ts
+++ b/ui/src/components/exec-approval-card.ts
@@ -223,12 +223,12 @@ export function compactApprovalCommand(command: string): string {
   return singleLine.length > 64 ? `${truncateUtf16Safe(singleLine, 61)}…` : singleLine;
 }
 
-function approvalDecisionLabel(decision: ExecApprovalDecision, approval: ExecApprovalRequest) {
+function approvalDecisionLabel(decision: ExecApprovalDecision, kind: ExecApprovalRequest["kind"]) {
   return t(
     decision === "allow-once"
       ? "execApproval.allowOnce"
       : decision === "allow-always"
-        ? approval.kind === "exec" || approval.request.sessionKey
+        ? kind === "exec"
           ? "execApproval.alwaysAllowHere"
           : "execApproval.alwaysAllow"
         : "execApproval.deny",
@@ -315,7 +315,7 @@ export function renderSidebarApprovalRow(props: SidebarApprovalRowProps) {
         aria-label=${t("approvalPage.actionsLabel")}
       >
         ${resolveApprovalDecisions(approval).map((decision) => {
-          const label = approvalDecisionLabel(decision, approval);
+          const label = approvalDecisionLabel(decision, approval.kind);
           return html`<button
             type="button"
             class="btn btn--xs ${
@@ -441,7 +441,7 @@ export function renderExecApprovalCard(props: ExecApprovalCardProps) {
     }
     <div class="exec-approval-actions">
       ${decisions.map((decision) => {
-        const label = approvalDecisionLabel(decision, props.approval);
+        const label = approvalDecisionLabel(decision, props.approval.kind);
         return html`<button
           class=${decisionClass(decision)}
           type="button"


### PR DESCRIPTION
## What Problem This Solves

Paired Reef Gateways can exchange guarded messages, but one Gateway cannot safely propose a prompt to a session owned by the other. There is no session-scoped mount, host approval, replay-safe admission, or immediate revocation path.

## Why This Change Was Made

This adds a text-only prototype that keeps the host Gateway as the sole session and execution authority. Reef carries typed, encrypted federation frames, while existing OpenClaw plugin approvals and canonical agent admission decide whether one exact remote prompt runs. The host revalidates the mount generation, session incarnation, and exact peer signing and encryption keys after approval and at canonical input-admission commit boundaries.

## User Impact

Operators with two paired Reef Gateways can:

- Share one exact host session with `/reef session share`.
- Propose text prompts from the guest Gateway.
- Approve once, always allow for that mount, or deny.
- Resolve approvals inline above the composer or through Inbox.
- Revoke a mount immediately from the host Gateway.

This prototype does not mirror transcripts, stream output to the guest, or transfer attachments.

## Latest experiment: plugin-gated native Reef Control UI

Commit [`f5c4349af9ebf58d33d103c66fc5284cfce461b1`](https://github.com/openclaw/openclaw/commit/f5c4349af9ebf58d33d103c66fc5284cfce461b1) adds an opt-in native Reef panel without widening the public protocol or plugin SDK. This is experimental remote delegation: a trusted guest proposes text to one explicitly shared host session, while the host remains the sole transcript, approval, admission, model-execution, and revocation authority. It is distinct from ordinary Reef messaging, whose existing guard/classification path remains unchanged.

The panel is hidden unless the Reef plugin is enabled and the connection has `operator.admin`. It covers setup/unavailable states, short-lived pairing codes and requests, trust removal, exact-session sharing, guest prompt proposals, proposal outcomes, pending revocation, and links to native approvals. Read status requires `operator.read`; every mutation requires `operator.admin`, strict bounded validation, and the canonical owner command path. The generic SDK/security-owner decision described below remains outstanding.

### Tested candidate provenance

- The complete dirty-tree candidate over published head `6ef84e685234984ba8cfdc887435c895e1c6577b` was frozen as a 58,582-byte binary patch with SHA-256 `9d8b106bb0bb13aaf299cb771852572b37a7f2ea170ba215dd631582bd55a240`.
- That exact patch was committed as `f5c4349af9ebf58d33d103c66fc5284cfce461b1`; no unrelated files were included.
- GitHub then exposed one assertion-safety ratchet requirement. Follow-up commit [`a7c456b504a229a6f028f67a7aee9aea79c1b79b`](https://github.com/openclaw/openclaw/commit/a7c456b504a229a6f028f67a7aee9aea79c1b79b) adds only the required `// SAFETY:` invariant comment. The ratchet and the 8 Control UI Gateway tests pass.
- The complete published delta from `6ef84e685234984ba8cfdc887435c895e1c6577b` through `a7c456b504a229a6f028f67a7aee9aea79c1b79b` has SHA-256 `3fed548004ddbd381867c306cf1d7c9d8505fa327738efb0be2c63213dc3b50f`.
- Fresh normal actionable P0/P1/P2 autoreview was scoped-clean with no findings and confidence `0.91`.
- Reef validation passed: **12 native Control UI tests**, **382 extension tests across 31 files**, type-aware lint with zero findings, formatting, `git diff --check`, plugin SDK/package-boundary checks, and the full repository build.

### Real runtime and browser proof

A two-Gateway loopback proof used OCM `0.2.33`, distinct registered Reef identities, a real local Wrangler Reef relay, OpenClaw runtime, and `openai/gpt-5-mini` with mocks disabled.

- Pairing and pinned trust survived Gateway restarts.
- Host sharing produced a real guest mount; the guest submitted through the native panel.
- Revocation while approval was pending denied admission with no run ID and no host-history mutation.
- A later **Allow once** approval produced the real host response “The shared answer is 42.”
- Same-session continuation retained both prior host context (`Harbor`) and guest-added context (`42`).
- The configured browser flow covered trust, session sharing, guest proposal submission, the real approval card in the exact host session, accepted outcome, revocation reflected on both peers, friend-code generation, pairing-request submission, friend removal, and disabled-plugin gating.

Limits: the proof used local loopback rather than a public multi-machine relay; it is candidate restart/reopen proof rather than older-release upgrade/downgrade proof; the guest receives proposal outcomes rather than streamed/final host output; attachment transfer and transcript attribution remain out of scope. Current published head `a7c456b504a229a6f028f67a7aee9aea79c1b79b` has triggered fresh exact-head CI, which is not represented as passed here until GitHub completes it. The dependency graph change in `extensions/reef/package.json` / `pnpm-lock.yaml` also requires the repository’s documented current admin or `@openclaw/openclaw-secops` `/allow-dependencies-change` override.

## Proposed SDK Boundary — Owner Decision Still Open

This PR proposes a generic, core-owned plugin runtime capability rather than Reef-only machinery. Explicit SDK/security-owner acceptance of that public durable authority surface is still outstanding; the rationale below is not an approval. Core owns session incarnation, approval scoping, plugin lifecycle, and canonical agent admission; Reef is the first consumer. Keeping the authority primitive at that owner boundary avoids duplicating security policy inside one channel plugin while preserving the strict trusted-official-plugin gate.

## Changes

| File | Change |
| --- | --- |
| `extensions/reef/protocol/federation.ts` | Defines bounded typed federation frames and prompt bindings |
| `extensions/reef/protocol/pipeline.ts` | Opens federation traffic outside ordinary chat ingress |
| `extensions/reef/src/federation-state.ts` | Persists mounts, generations, grants, and proposal outcomes |
| `extensions/reef/src/federation-coordinator.ts` | Validates authority, requests approval, and admits host execution |
| `extensions/reef/src/flow.ts` | Sends federation frames through Reef E2EE transport |
| `extensions/reef/src/channel.ts` | Routes inbound frames and owner-visible outcomes |
| `extensions/reef/src/commands.ts` | Adds share, list, prompt, and revoke commands |
| `ui/src/components/exec-approval-card.test.ts` | Covers session-scoped approval presentation |
| `src/plugin-sdk/runtime-store*.ts`, `src/plugins/loader-channel-runtime.ts` | Keeps active plugin runtime stores owned by their registry through discovery and setup |
| `docs/channels/reef.md` | Documents the two-Gateway prototype workflow |
| `extensions/reef/**/*.test.ts` | Proves protocol, state, admission, replay, revocation, and E2E flow |

## Evidence

### Configured two-Gateway flow

Built and tested exact head `ebc20b31daf42cb41caa1cbb504bdb37a51efc09`. Two isolated Gateways, distinct registered Reef identities, real local Reef relay, encrypted transport, real host approval UI, and a recording loopback agent provider. No operator Gateway changes.

- Guest proposal reached the inline approval card. **Allow once** admitted its text into the host session and delivered `session.prompt.accepted` to the guest. Agent-provider requests increased from **1 to 2**.
- Both candidate Gateways were stopped and reopened against their retained state. The accepted receipt survived; the retained mount admitted another freshly approved prompt. Host-local chat used that same host session.
- Another proposal was left pending, its mount revoked, then approval attempted. The guest received `session.prompt.denied`; provider requests stayed **4 to 4**, and the revoked marker was absent from the host transcript. Reopening both Gateways again retained the denial and absence.
- This is **candidate restart/reopen proof**, not older-release upgrade/downgrade proof. The browser recording covers approval, reconnect, and host-visible input; the exact receipt/provider/absence assertions come from the running Gateway proof.
- **Guard boundary:** federation frames intentionally bypass ordinary chat classification. Host approval/grants and exact peer/mount/session bindings authorize these prompts. A separate ordinary Reef message received matching outbound/inbound **allow** verdicts from the live OpenAI guard for the same encrypted envelope; federation recorded **zero ordinary guard calls**. The agent provider was a recording mock, not a live model.
- An earlier attempt exposed signed-GET replay collisions when repeatedly polling remote friend lists; the final observer reads canonical local trust state without issuing those requests. The transport collision remains a named follow-up. A separate reopen attempt timed out before approval; its cause was not established. The final run used latest-response command assertions and passed the complete restart flow.

![Host approval for a guest prompt](https://github.com/user-attachments/assets/8601af10-2086-4dae-93bd-434a8a670ee5)

![Host transcript after reopened admission and revocation](https://github.com/user-attachments/assets/c49b0826-fa3e-4267-b0d2-4b6cceb7e9ba)

https://github.com/user-attachments/assets/4a77c0cd-510f-4302-9768-092310edb865

### Latest review repairs: admission and local-key recovery

- **Late revocation:** the plugin supplies a synchronous live-grant assertion through the existing canonical input-admission guard. Runtime options are snapshotted before asynchronous loading. Grant/peer revocation during preparation rejects before durable input acceptance; after acceptance, host-owned execution keeps its existing custody. No copied authority, weaker validator, or new store/schema.
- **Local-key rotation:** a failed exact core binding now produces a durable denial even when the display mount still looks valid. Recovery no longer dereferences a missing authorized mount; the denied outcome survives reopen and replay.
- Real Gateway regressions failed on the original producer for revocation before facade dispatch and before input staging, then passed repaired. Coordinator grant/peer regressions and the local-key rotation regression also failed pre-fix. The after-acceptance control remains accepted.
- **134 tests / 7 files passed**, covering canonical Gateway admission, registry/grant ownership, Reef coordinator/state/E2E. Naming-only lint cleanup was followed by **29 coordinator/state tests** passing.
- Complete changed-file check plan passed across the initial run and a serialized continuation from its lint failure (parameter reassignment/shadowing corrected). Core/plugin/test types, formatting, lint, SDK/storage/dependency guards and dead exports passed. The initially failed command itself is not reported as green.
- Full `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` passed at the exact head. Fresh final P0/P1 autoreview was scoped-clean.
- Latest repair delta: production **+48/-44 (net +4)**, tests **+330/-188**, docs **+10/-1**. The small production growth adds the synchronous admission assertion contract; duplicated coordinator checks were absorbed.
- Controlled late-admission race tests are distinct from the video's pending-approval revocation scenario.

```sh
node scripts/run-vitest.mjs src/gateway/server.agent-input-authority.test.ts src/gateway/server-plugins.test.ts src/plugins/registry-runtime.cross-session-grants.test.ts src/plugins/cross-session-grants.test.ts extensions/reef/src/federation-coordinator.test.ts extensions/reef/src/federation-state.test.ts extensions/reef/src/federation-e2e.test.ts
node scripts/check-changed.mjs
OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
```

### Rejected-mutation expiry repair

Current published head: `6ef84e685234984ba8cfdc887435c895e1c6577b`. The preceding `ebc20b31daf42cb41caa1cbb504bdb37a51efc09` passed [full exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34325320063) and is the built two-Gateway recording above. This follow-up changes only rejected core grant mutations and their regression tests; it has not been represented as a new two-Gateway recording.

- ClawSweeper revision 9 confirmed the prior admission/recovery repairs and found that returning an existing grant from the atomic update callback renews its TTL. All four mutation operations now use the store's existing no-write sentinel on lifecycle, role, binding, and generation rejection. Successful host-authorized mutations are unchanged; no schema, API, config, or storage design change.
- **Original failure:** all four store-operation regressions changed `createdAt` and `expiresAt` after rejection. The real Gateway regression accepted a prompt after the original standing grant's deadline because a rejected peer revocation had renewed it.
- **Repaired proof:** actual SQLite metadata remains unchanged. Closing/reopening the candidate store retains the original deadline; authorization fails at that deadline. The real Gateway dispatch rejects the expired grant with zero pending inputs and no prepared execution. These are controlled-clock production-store/Gateway tests, not a seven-day live soak or a new relay recording.
- **93 tests / 7 files / 4 shards passed**, covering store expiry, grant ownership, canonical Gateway admission, and Reef coordinator/state siblings. A braces-only lint correction was followed by **9/9 Gateway tests** passing.
- Full changed-file plan passed across initial and resumed runs: all types, dead exports, formatting, lint, storage, runtime-loading, import-cycle, webhook and pairing guards. The initial run failed only on two missing test braces, which were corrected; no assertions or production behavior were weakened.
- Fresh P0/P1 autoreview: scoped-clean, no actionable findings. Production delta **+9/-8** (eight corrected returns plus one invariant comment); tests **+98/-15**.

```sh
node scripts/run-vitest.mjs src/plugins/cross-session-grants.test.ts src/plugins/registry-runtime.cross-session-grants.test.ts src/gateway/server.agent-input-authority.test.ts src/plugin-state/plugin-state-store.test.ts src/plugin-state/plugin-state-store.expiry.test.ts extensions/reef/src/federation-state.test.ts extensions/reef/src/federation-coordinator.test.ts
node scripts/check-changed.mjs -- src/plugins/cross-session-grants.ts src/plugins/cross-session-grants.test.ts src/gateway/server.agent-input-authority.test.ts
```

### Automated checks

- Focused Reef protocol/flow/coordinator/state/command/channel tests, core grant and lifecycle tests, and approval UI tests passed. The initial configuration-inspection regression was repaired and rerun successfully.
- Registry ownership regression: SDK selection and all three loader setup/discovery cases fail on the original producer. The repaired runtime-store, loader, registry, and cross-session-grant suites pass **242 tests**.
- `node scripts/run-vitest.mjs src/plugin-sdk/runtime-store.test.ts src/plugins/loader.runtime-store.test.ts src/plugins/loader.runtime-registry.test.ts src/plugins/loader.test.ts src/plugins/registry-runtime.cross-session-grants.test.ts`
- `node scripts/check-changed.mjs -- <changed paths>`: formatting, core/plugin and test typechecks, SDK/contract ratchets, lint, dead-code, storage, and import-cycle checks passed. Full PR checks passed before the runtime-owner follow-up; the follow-up's complete changed-surface checks also passed.
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`: passed after the runtime-owner repair.
- Fresh P0/P1 autoreview: scoped-clean for the rebased PR and the runtime-owner repair.
- Existing capacity regression proves terminal failure before ACK, relay-failure retry, no agent request, and continued inbox processing; revocation retries remain idempotent.

### Exact-head CI fixture repair

The first full CI run found six test-lane failures caused by fixtures retaining runtimes across registry replacement. The follow-up initializes iMessage, Matrix, Mattermost, and Zalo runtimes under the fixture registry and retires the shared test registry only after final fixture hooks. Voice Call terminal persistence/timer cleanup now completes before retirement. Production code and assertions are unchanged; test/support delta +38/-24.

- Combined affected suites: **283 tests passed** across six Vitest shards, including the original Voice Call cleanup regression and SDK runtime isolation.
- Complete changed-file formatting, extension/root test typechecks, lint, dependency/SDK/storage guards, and dead-export scans passed.
- Fresh P0/P1 autoreview: scoped-clean.
- `node scripts/run-vitest.mjs extensions/voice-call/src/manager.test-harness.test.ts extensions/voice-call/src/manager.notify.test.ts extensions/voice-call/src/manager.restore.test.ts extensions/zalo/src/channel.pre-aborted.integration.test.ts extensions/imessage/src/monitor.last-route.test.ts extensions/matrix/src/delivery-trace.test.ts extensions/matrix/src/matrix/sdk.test.ts extensions/mattermost/src/mattermost/interactions.test.ts src/plugin-sdk/runtime-store.test.ts`
- `node scripts/check-changed.mjs -- <six changed test/support paths>`

### Remaining boundaries

- Not a shared transcript/composer: guest receives proposal outcomes, not streamed or final host model output. No attachment transfer.
- The host currently renders admitted guest text with its generic “You” label; approval identifies the guest. Transcript attribution is recorded as a separate follow-up, not claimed solved.
- Older-release upgrade/downgrade compatibility has not been demonstrated; candidate reopen is covered above.
- SDK/security-owner acceptance of the proposed generic grant capability is still open. No merge is requested by this evidence update.
- Runtime-owner repair delta: production +74/-18 (net +56), tests +198/-1. Registry ownership is needed to distinguish active/discovery/setup lifecycles while preserving standalone CLI behavior; no authority fallback was added.

### Manual test

Enable and register Reef on both Gateways, configure the guard provider credential, then pair their Reef identities. On the host: `/reef session share @guest <host-session-key>`. On the guest: `/reef session list`, then `/reef session prompt <mount-id> <text>`. Approve in the host session, verify that session receives the prompt and the guest receives acceptance. Leave another proposal pending, run `/reef session revoke <mount-id>` on the host, then try approving it: expect denial and no new host model run. A host-local message still works normally in the host session.

---
[View the OpenClaw team session](https://openclaw-fsn1.tailf72dd7.ts.net/chat/main/dashboard/6bed7bfc-4629-437a-abbe-e91ebd994270)

![Native Reef panel with trusted peer and session mounts](https://github.com/user-attachments/assets/a00b9d0a-7a66-4c9e-a418-61a733c15d8a)

![Real host approval for a guest Reef prompt](https://github.com/user-attachments/assets/5fd24548-6ec7-4931-93eb-57ae1c3f9f39)

![Guest Reef panel showing the accepted proposal outcome](https://github.com/user-attachments/assets/1626add2-1e1e-41ae-b64e-16cd7ba68da8)

![Host Reef panel after mount revocation](https://github.com/user-attachments/assets/1f5b9c4a-3680-4bf7-9cdd-54a9c5fdc5be)
