### PR TITLE
feat(directives): trace pre-run directive rejections as diagnostic events

### DIFF
--- a/extensions/diagnostics-otel/src/service-events.ts
+++ b/extensions/diagnostics-otel/src/service-events.ts
@@ -236,6 +236,9 @@ export function createDiagnosticsEventHandler(params: {
           return;
         case "model.failover":
           recordModelFailover(evt, metadata);
+          break;
+        case "directive.rejected":
+          break;
       }
     } catch (err) {
       logger.error(`diagnostics-otel: event handler failed (${evt.type}): ${formatError(err)}`);

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -949,6 +949,7 @@ function recordDiagnosticEvent(
         numericValue(evt.queueLength),
       );
       break;
+    case "directive.rejected":
     case "diagnostic.heartbeat":
       break;
     case "telemetry.exporter":

--- a/src/auto-reply/reply/get-reply-directives-apply.test.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.test.ts
@@ -1,5 +1,9 @@
 // Tests applying parsed directives to get-reply execution options.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+} from "../../infra/diagnostic-events.js";
 import { MODEL_SELECTION_LOCKED_MESSAGE } from "../../sessions/model-overrides.js";
 import { applyMixedDirectives } from "./directive-handling.mixed-inline.test-helpers.js";
 import { parseInlineSessionDirectives } from "./directive-handling.parse.js";
@@ -354,4 +358,75 @@ describe("applyInlineDirectiveOverrides", () => {
       expect(mocks.handleDirective).toHaveBeenCalledOnce();
     },
   );
+});
+
+describe("directive.rejected diagnostic trace", () => {
+  beforeEach(() => {
+    resetDiagnosticEventsForTest();
+  });
+
+  it("emits a pre_run directive.rejected trace when a model directive is rejected pre-run", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      events.push(event as unknown as Record<string, unknown>);
+    });
+
+    try {
+      const ctx = buildTestCtx({
+        Body: "/model openai/gpt-5.5 -a -g",
+        CommandBody: "/model openai/gpt-5.5 -a -g",
+        CommandAuthorized: true,
+        SessionKey: "agent:main:main",
+        Provider: "webchat",
+        Surface: "webchat",
+        OriginatingChannel: "webchat",
+        MessageSidFull: "msg-123",
+      });
+      const result = await resolveReplyDirectives({
+        ctx,
+        cfg: { agents: { ownership: "explicit", entries: { main: {} } } },
+        agentId: "main",
+        agentDir: "/tmp/main-agent",
+        workspaceDir: "/tmp/workspace",
+        agentCfg: {},
+        sessionCtx: ctx,
+        sessionEntry: { sessionId: "session-1", updatedAt: 1 },
+        sessionStore: {},
+        sessionKey: "agent:main:main",
+        sessionScope: undefined,
+        groupResolution: undefined,
+        isGroup: false,
+        triggerBodyNormalized: "/model openai/gpt-5.5 -a -g",
+        resetTriggered: false,
+        commandAuthorized: true,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.5",
+        aliasIndex: { byAlias: new Map(), byKey: new Map() },
+        provider: "openai",
+        model: "gpt-5.5",
+        hasResolvedHeartbeatModelOverride: false,
+        typing: createTypingController({}),
+      });
+
+      expect(result).toMatchObject({
+        kind: "reply",
+        reply: { text: "Use only one model scope option.", isError: true },
+      });
+
+      const rejected = events.find((e) => e.type === "directive.rejected");
+      expect(rejected).toBeDefined();
+      expect(rejected).toMatchObject({
+        type: "directive.rejected",
+        stage: "pre_run",
+        sessionKey: "agent:main:main",
+        channel: "webchat",
+        messageId: "msg-123",
+        directiveType: "model",
+        errorText: "Use only one model scope option.",
+      });
+      expect(rejected?.rawToken).toEqual(expect.any(String));
+    } finally {
+      unsubscribe();
+    }
+  });
 });

--- a/src/auto-reply/reply/get-reply-directives-diagnostic.ts
+++ b/src/auto-reply/reply/get-reply-directives-diagnostic.ts
@@ -12,7 +12,7 @@ import type { InlineDirectives } from "./directive-handling.parse.js";
  * (e.g. `/model <ref>` resolving to a disallowed model); other directive
  * categories fall back to their type with no raw token.
  */
-export function deriveRejectedDirectiveFacts(directives: InlineDirectives): {
+function deriveRejectedDirectiveFacts(directives: InlineDirectives): {
   directiveType?: string;
   rawToken?: string;
 } {

--- a/src/auto-reply/reply/get-reply-directives-diagnostic.ts
+++ b/src/auto-reply/reply/get-reply-directives-diagnostic.ts
@@ -1,0 +1,69 @@
+// Diagnostic trace helpers for pre-run directive rejections. Kept in a
+// dedicated module so the directive resolver stays under its line budget and
+// the trace logic is independently testable.
+import { emitTrustedDiagnosticEvent } from "../../infra/diagnostic-events.js";
+import type { FinalizedRuntimeMsgContext } from "../templating.js";
+import type { ReplyPayload } from "../types.js";
+import type { InlineDirectives } from "./directive-handling.parse.js";
+
+/**
+ * Derives the rejected directive category and its raw token from the parsed
+ * inline directives. The model directive is the most common rejection target
+ * (e.g. `/model <ref>` resolving to a disallowed model); other directive
+ * categories fall back to their type with no raw token.
+ */
+export function deriveRejectedDirectiveFacts(directives: InlineDirectives): {
+  directiveType?: string;
+  rawToken?: string;
+} {
+  if (directives.hasModelDirective) {
+    return { directiveType: "model", rawToken: directives.rawModelDirective };
+  }
+  if (directives.hasElevatedDirective) {
+    return { directiveType: "elevated" };
+  }
+  if (directives.clearThinkLevel || directives.thinkLevel !== undefined) {
+    return { directiveType: "think" };
+  }
+  if (directives.reasoningLevel !== undefined) {
+    return { directiveType: "reasoning" };
+  }
+  if (directives.verboseLevel !== undefined) {
+    return { directiveType: "verbose" };
+  }
+  if (directives.clearFastMode || directives.fastMode !== undefined) {
+    return { directiveType: "fast" };
+  }
+  return {};
+}
+
+/**
+ * Emits a `directive.rejected` diagnostic trace when an inline directive was
+ * rejected before any agent run started, so external diagnostic surfaces can
+ * correlate the rejected inbound message with the parser decision. Only error
+ * replies (not ack/status replies) are traced.
+ */
+export function emitPreRunDirectiveRejectionDiagnostic(params: {
+  ctx: FinalizedRuntimeMsgContext;
+  sessionKey: string;
+  directives: InlineDirectives;
+  reply: ReplyPayload | ReplyPayload[] | undefined;
+}): void {
+  const { ctx, sessionKey, directives, reply } = params;
+  if (Array.isArray(reply) || !reply || reply.isError !== true) {
+    return;
+  }
+  const { directiveType, rawToken } = deriveRejectedDirectiveFacts(directives);
+  emitTrustedDiagnosticEvent({
+    type: "directive.rejected",
+    stage: "pre_run",
+    sessionKey,
+    channel: ctx.OriginatingChannel ?? ctx.Provider ?? ctx.Surface,
+    messageId: ctx.MessageSidFull ?? ctx.MessageSid,
+    chatId: ctx.ChatId,
+    agentId: ctx.AgentId,
+    directiveType,
+    rawToken,
+    errorText: reply.text,
+  });
+}

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -49,6 +49,7 @@ import {
   resolveConfiguredDirectiveAliases,
 } from "./get-reply-directive-aliases.js";
 import { applyInlineDirectiveOverrides } from "./get-reply-directives-apply.js";
+import { emitPreRunDirectiveRejectionDiagnostic } from "./get-reply-directives-diagnostic.js";
 import { resolveReplyDirectiveRouting } from "./get-reply-directives-routing.js";
 import { type ReplyExecOverrides, resolveReplyExecOverrides } from "./get-reply-exec-overrides.js";
 import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
@@ -565,6 +566,12 @@ export async function resolveReplyDirectives(params: {
     typing,
   });
   if (applyResult.kind === "reply") {
+    emitPreRunDirectiveRejectionDiagnostic({
+      ctx,
+      sessionKey,
+      directives,
+      reply: applyResult.reply,
+    });
     return { kind: "reply", reply: markCommandReplyForDelivery(applyResult.reply) };
   }
   directives = applyResult.directives;

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -226,6 +226,31 @@ export type DiagnosticMessageProcessedEvent = DiagnosticBaseEvent & {
   error?: string;
 };
 
+/**
+ * Pre-run directive rejection trace. Emitted when an inline reply directive
+ * (e.g. `/model <ref>`) is rejected before any agent run starts, so external
+ * diagnostic surfaces can correlate the rejected inbound message with the
+ * parser decision. Coarse `stage: "pre_run"` covers rejections surfaced from
+ * inline directive application; `errorText` carries the reply returned to the
+ * sender (it already contains the rejection reason).
+ */
+export type DiagnosticDirectiveRejectedEvent = DiagnosticBaseEvent & {
+  type: "directive.rejected";
+  stage: "pre_run";
+  sessionKey?: string;
+  sessionId?: string;
+  channel?: string;
+  messageId?: number | string;
+  chatId?: number | string;
+  agentId?: string;
+  /** Directive category that was rejected (e.g. "model"). */
+  directiveType?: string;
+  /** Raw token parsed for the directive, when available (e.g. the requested model ref). */
+  rawToken?: string;
+  /** Human-readable rejection text returned to the sender. */
+  errorText?: string;
+};
+
 export type DiagnosticMessageDeliveryKind = "text" | "media" | "edit" | "reaction" | "other";
 
 type DiagnosticMessageDeliveryBaseEvent = DiagnosticBaseEvent & {
@@ -808,6 +833,7 @@ export type DiagnosticEventPayload =
   | DiagnosticMessageDispatchStartedEvent
   | DiagnosticMessageDispatchCompletedEvent
   | DiagnosticMessageProcessedEvent
+  | DiagnosticDirectiveRejectedEvent
   | DiagnosticMessageDeliveryStartedEvent
   | DiagnosticMessageDeliveryCompletedEvent
   | DiagnosticMessageDeliveryErrorEvent

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -599,6 +599,12 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.model = event.fromModel;
       assignReasonCode(record, event.reason);
       break;
+    case "directive.rejected":
+      record.channel = event.channel;
+      record.source = event.agentId;
+      record.outcome = event.directiveType;
+      assignReasonCode(record, event.errorText);
+      break;
   }
 
   return record;


### PR DESCRIPTION
## What Problem This Solves

Closes #137198.

When an inline reply directive is rejected before any agent run starts (e.g. `/model deepseek/bzw.` resolving to a disallowed model, or conflicting `/model ... -a -g` scope flags), the rejection reply is returned to the sender but leaves **no structured diagnostic trace**. Investigators trying to correlate the inbound channel event with the parser decision have nothing to query — the rejection vanishes into the reply text.

This adds a new `directive.rejected` diagnostic event emitted at the single chokepoint where `applyInlineDirectiveOverrides` returns a reply, so external diagnostic surfaces can correlate the rejected inbound message with the parser decision.

### Scope

This first cut covers rejections surfaced from inline directive **application** (model scope conflict, model/runtime resolution, applied-directive rejection, persistence rejection) — the path the issue's `/model` repro flows through. The event carries:

- `sessionKey`, `channel`, `messageId`, `chatId`, `agentId` — correlate with the inbound channel event
- `directiveType` — which directive category was rejected (`model` / `think` / `reasoning` / `elevated` / `verbose` / `fast`)
- `rawToken` — the parsed raw directive token (e.g. the requested model ref), when available
- `stage: "pre_run"` — coarse stage marker
- `errorText` — the rejection text returned to the sender (already contains the reason)

Rejections that surface earlier in `resolveReplyDirectives` (elevated-unavailable pre-check, `ModelSelectionLockedError` from model-selection state construction) are separate rejection categories and are intentionally left as follow-up to keep this change focused.

## Evidence

- New `DiagnosticDirectiveRejectedEvent` type added to the `DiagnosticEventPayload` union. The diagnostic-events system uses runtime Set/Array membership for event-type filtering (no exhaustive switches), so adding a type is additive and type-safe.
- Trace helpers live in `src/auto-reply/reply/get-reply-directives-diagnostic.ts` (keeps the directive resolver under its line budget); the emit is a single call at the `applyResult.kind === "reply"` chokepoint in `get-reply-directives.ts`, filtered to error replies only (ack/status replies are not rejections).
- Test `directive.rejected diagnostic trace > emits a pre_run directive.rejected trace when a model directive is rejected pre-run` drives a real `/model openai/gpt-5.5 -a -g` (scope-conflict) rejection through `resolveReplyDirectives` and asserts the event carries `stage: "pre_run"`, `sessionKey`, `channel`, `messageId`, `directiveType: "model"`, and the rejection `errorText`.
- `npx tsc --noEmit` clean for all touched files; `oxlint` + `oxfmt` clean; existing `diagnostic-events.test.ts` (37) + `get-reply-directives-apply.test.ts` (11) all pass.
