### PR TITLE
fix(gateway): use elapsed time for ACP readiness

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -4,6 +4,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { writeRestartSentinel } from "../infra/restart-sentinel.js";
@@ -467,64 +468,6 @@ function firstGatewayStartCall(
   return call as [PluginHookGatewayStartEvent, PluginHookGatewayContext];
 }
 
-describe("waitForAcpRuntimeBackendReady", () => {
-  beforeEach(() => {
-    hoisted.getAcpRuntimeBackend.mockReset().mockReturnValue({
-      id: "acpx",
-      runtime: {},
-      healthy: () => false,
-    });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it.each([
-    { direction: "forward", shiftedWallClockMs: 10_000, shouldSettle: false },
-    { direction: "backward", shiftedWallClockMs: -10_000, shouldSettle: true },
-  ])(
-    "uses elapsed time instead of a $direction wall-clock shift for its deadline",
-    async ({ shiftedWallClockMs, shouldSettle }) => {
-      let wallClockMs = 10_000;
-      let monotonicMs = 0;
-      vi.spyOn(Date, "now").mockImplementation(() => wallClockMs);
-      let resolveBackend: (() => void) | undefined;
-      const backendChecked = new Promise<void>((resolve) => {
-        resolveBackend = resolve;
-      });
-      hoisted.getAcpRuntimeBackend.mockImplementation(() => {
-        resolveBackend?.();
-        return { id: "acpx", runtime: {}, healthy: () => false };
-      });
-      let settled = false;
-      const waiting = testing
-        .waitForAcpRuntimeBackendReady({
-          backendId: "acpx",
-          timeoutMs: 5_000,
-          pollMs: 1,
-          nowMs: () => monotonicMs,
-        })
-        .then(() => {
-          settled = true;
-        });
-
-      await backendChecked;
-      expect(hoisted.getAcpRuntimeBackend).toHaveBeenCalledWith("acpx");
-
-      wallClockMs += shiftedWallClockMs;
-      monotonicMs = shouldSettle ? 5_000 : 50;
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(settled).toBe(shouldSettle);
-      if (!shouldSettle) {
-        monotonicMs = 5_000;
-      }
-      await waiting;
-    },
-  );
-});
-
 describe("startGatewayPostAttachRuntime", () => {
   beforeEach(() => {
     resetGatewayWorkAdmission();
@@ -590,6 +533,7 @@ describe("startGatewayPostAttachRuntime", () => {
 
   afterEach(async () => {
     await cleanupGatewayTestState();
+    vi.restoreAllMocks();
   });
 
   it("drains tracked sidecars and resets fixture state after the first cleanup failure", async () => {
@@ -3890,56 +3834,73 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(trace.measures).not.toContain("sidecars.restart-sentinel");
   });
 
-  it("waits for a healthy ACP runtime backend before startup identity reconcile", async () => {
-    const trace = createStartupTraceRecorder();
-    let healthy = false;
-    hoisted.getAcpRuntimeBackend.mockImplementation((id?: string) => ({
-      id: id ?? "acpx",
-      runtime: {},
-      healthy: () => healthy,
-    }));
+  it.each([
+    { direction: "forward", shiftedWallClockMs: 10_000, monotonicMs: 50, timedOut: false },
+    { direction: "backward", shiftedWallClockMs: -10_000, monotonicMs: 5_000, timedOut: true },
+  ])(
+    "waits for a healthy ACP runtime backend before startup identity reconcile after a $direction wall-clock shift",
+    async ({ shiftedWallClockMs, monotonicMs, timedOut }) => {
+      const trace = createStartupTraceRecorder();
+      let healthy = false;
+      let wallClockMs = 10_000;
+      vi.spyOn(Date, "now").mockImplementation(() => wallClockMs);
+      vi.spyOn(performance, "now").mockReturnValue(0);
+      hoisted.getAcpRuntimeBackend.mockImplementation((id?: string) => ({
+        id: id ?? "acpx",
+        runtime: {},
+        healthy: () => healthy,
+      }));
 
-    await startGatewaySidecars({
-      cfg: {
-        hooks: { internal: { enabled: false } },
-        acp: { enabled: true, backend: "acpx" },
-      } as never,
-      pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
-      deps: {} as never,
-      startChannels: vi.fn(async () => {}),
-      log: { warn: vi.fn() },
-      logHooks: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      logChannels: {
-        info: vi.fn(),
-        error: vi.fn(),
-      },
-      startupTrace: trace.startupTrace,
-    });
+      await startGatewaySidecars({
+        cfg: {
+          hooks: { internal: { enabled: false } },
+          acp: { enabled: true, backend: "acpx" },
+        } as never,
+        pluginRegistry: createPostAttachParams().pluginRegistry,
+        defaultWorkspaceDir: "/tmp/openclaw-workspace",
+        deps: {} as never,
+        startChannels: vi.fn(async () => {}),
+        log: { warn: vi.fn() },
+        logHooks: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        logChannels: {
+          info: vi.fn(),
+          error: vi.fn(),
+        },
+        startupTrace: trace.startupTrace,
+      });
 
-    await waitForGatewayTestState(() => {
-      expect(hoisted.getAcpRuntimeBackend).toHaveBeenCalledWith("acpx");
-    });
-    expect(hoisted.reconcilePendingSessionIdentities).not.toHaveBeenCalled();
+      await waitForGatewayTestState(() => {
+        expect(hoisted.getAcpRuntimeBackend).toHaveBeenCalledWith("acpx");
+      });
+      expect(hoisted.reconcilePendingSessionIdentities).not.toHaveBeenCalled();
 
-    healthy = true;
-    await waitForGatewayTestState(() => {
-      expect(hoisted.reconcilePendingSessionIdentities).toHaveBeenCalledTimes(1);
-    });
-    expect(trace.measures).toContain("sidecars.acp.runtime-ready");
-    expect(trace.measures).toContain("sidecars.acp.identity-reconcile");
-    expect(trace.details).toContainEqual({
-      name: "sidecars.acp.runtime-ready",
-      metrics: [
-        ["readyCount", 1],
-        ["backend", "acpx"],
-      ],
-    });
-  });
+      wallClockMs += shiftedWallClockMs;
+      vi.mocked(performance.now).mockReturnValue(monotonicMs);
+      if (!timedOut) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 60);
+        });
+        expect(hoisted.reconcilePendingSessionIdentities).not.toHaveBeenCalled();
+        healthy = true;
+      }
+      await waitForGatewayTestState(() => {
+        expect(hoisted.reconcilePendingSessionIdentities).toHaveBeenCalledTimes(1);
+      });
+      expect(trace.measures).toContain("sidecars.acp.runtime-ready");
+      expect(trace.measures).toContain("sidecars.acp.identity-reconcile");
+      expect(trace.details).toContainEqual({
+        name: "sidecars.acp.runtime-ready",
+        metrics: [
+          ["readyCount", timedOut ? 0 : 1],
+          ["backend", "acpx"],
+        ],
+      });
+    },
+  );
 
   it("passes typed gateway_start context with config, workspace dir, and a live cron getter", async () => {
     const runGatewayStart = vi.fn<

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -3844,7 +3844,7 @@ describe("startGatewayPostAttachRuntime", () => {
       let healthy = false;
       let wallClockMs = 10_000;
       vi.spyOn(Date, "now").mockImplementation(() => wallClockMs);
-      vi.spyOn(performance, "now").mockReturnValue(0);
+      const monotonicNow = vi.spyOn(performance, "now").mockReturnValue(0);
       hoisted.getAcpRuntimeBackend.mockImplementation((id?: string) => ({
         id: id ?? "acpx",
         runtime: {},
@@ -3879,7 +3879,7 @@ describe("startGatewayPostAttachRuntime", () => {
       expect(hoisted.reconcilePendingSessionIdentities).not.toHaveBeenCalled();
 
       wallClockMs += shiftedWallClockMs;
-      vi.mocked(performance.now).mockReturnValue(monotonicMs);
+      monotonicNow.mockReturnValue(monotonicMs);
       if (!timedOut) {
         await new Promise<void>((resolve) => {
           setTimeout(resolve, 60);

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -467,6 +467,64 @@ function firstGatewayStartCall(
   return call as [PluginHookGatewayStartEvent, PluginHookGatewayContext];
 }
 
+describe("waitForAcpRuntimeBackendReady", () => {
+  beforeEach(() => {
+    hoisted.getAcpRuntimeBackend.mockReset().mockReturnValue({
+      id: "acpx",
+      runtime: {},
+      healthy: () => false,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    { direction: "forward", shiftedWallClockMs: 10_000, shouldSettle: false },
+    { direction: "backward", shiftedWallClockMs: -10_000, shouldSettle: true },
+  ])(
+    "uses elapsed time instead of a $direction wall-clock shift for its deadline",
+    async ({ shiftedWallClockMs, shouldSettle }) => {
+      let wallClockMs = 10_000;
+      let monotonicMs = 0;
+      vi.spyOn(Date, "now").mockImplementation(() => wallClockMs);
+      let resolveBackend: (() => void) | undefined;
+      const backendChecked = new Promise<void>((resolve) => {
+        resolveBackend = resolve;
+      });
+      hoisted.getAcpRuntimeBackend.mockImplementation(() => {
+        resolveBackend?.();
+        return { id: "acpx", runtime: {}, healthy: () => false };
+      });
+      let settled = false;
+      const waiting = testing
+        .waitForAcpRuntimeBackendReady({
+          backendId: "acpx",
+          timeoutMs: 5_000,
+          pollMs: 1,
+          nowMs: () => monotonicMs,
+        })
+        .then(() => {
+          settled = true;
+        });
+
+      await backendChecked;
+      expect(hoisted.getAcpRuntimeBackend).toHaveBeenCalledWith("acpx");
+
+      wallClockMs += shiftedWallClockMs;
+      monotonicMs = shouldSettle ? 5_000 : 50;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(settled).toBe(shouldSettle);
+      if (!shouldSettle) {
+        monotonicMs = 5_000;
+      }
+      await waiting;
+    },
+  );
+});
+
 describe("startGatewayPostAttachRuntime", () => {
   beforeEach(() => {
     resetGatewayWorkAdmission();

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -421,13 +421,11 @@ async function waitForAcpRuntimeBackendReady(params: {
   backendId?: string;
   timeoutMs?: number;
   pollMs?: number;
-  nowMs?: () => number;
 }): Promise<boolean> {
   const { getAcpRuntimeBackend } = await import("../acp/runtime/registry.js");
   const timeoutMs = params.timeoutMs ?? ACP_BACKEND_READY_TIMEOUT_MS;
   const pollMs = params.pollMs ?? ACP_BACKEND_READY_POLL_MS;
-  const nowMs = params.nowMs ?? (() => performance.now());
-  const deadline = nowMs() + timeoutMs;
+  const deadline = performance.now() + timeoutMs;
 
   do {
     const backend = getAcpRuntimeBackend(params.backendId);
@@ -441,7 +439,7 @@ async function waitForAcpRuntimeBackendReady(params: {
       }
     }
     await sleep(pollMs, undefined, { ref: false });
-  } while (nowMs() < deadline);
+  } while (performance.now() < deadline);
 
   return false;
 }
@@ -1703,6 +1701,5 @@ export const testing = {
   scheduleProviderAuthStatePrewarm,
   scheduleRestartSentinelWakeAfterReady,
   shouldSkipStartupModelPrewarm,
-  waitForAcpRuntimeBackendReady,
 };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -421,11 +421,13 @@ async function waitForAcpRuntimeBackendReady(params: {
   backendId?: string;
   timeoutMs?: number;
   pollMs?: number;
+  nowMs?: () => number;
 }): Promise<boolean> {
   const { getAcpRuntimeBackend } = await import("../acp/runtime/registry.js");
   const timeoutMs = params.timeoutMs ?? ACP_BACKEND_READY_TIMEOUT_MS;
   const pollMs = params.pollMs ?? ACP_BACKEND_READY_POLL_MS;
-  const deadline = Date.now() + timeoutMs;
+  const nowMs = params.nowMs ?? (() => performance.now());
+  const deadline = nowMs() + timeoutMs;
 
   do {
     const backend = getAcpRuntimeBackend(params.backendId);
@@ -439,7 +441,7 @@ async function waitForAcpRuntimeBackendReady(params: {
       }
     }
     await sleep(pollMs, undefined, { ref: false });
-  } while (Date.now() < deadline);
+  } while (nowMs() < deadline);
 
   return false;
 }
@@ -1701,5 +1703,6 @@ export const testing = {
   scheduleProviderAuthStatePrewarm,
   scheduleRestartSentinelWakeAfterReady,
   shouldSkipStartupModelPrewarm,
+  waitForAcpRuntimeBackendReady,
 };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
ACP startup readiness uses a five-second budget. A forward wall-clock correction could end the wait before the backend was healthy; a backward correction could keep it waiting beyond that budget.

Use `performance.now()` for both private deadline reads. Keep the timeout, polling interval, backend selection, transient health-error handling, identity reconciliation, and public timestamps unchanged. Extend the existing regression case to cover both clock directions and drain its startup work before test cleanup.

Public Gateway validation used ACP enabled and a configured local plugin that registers a backend through the public SDK and creates a real pending session identity through the session manager. Only process-local `Date.now()` changed; system time, monotonic time, and native timers stayed unchanged.

| Scenario | Baseline `c490e6c6127b` | Candidate `c0fa6f2e7058` |
| --- | --- | --- |
| Forward clock step; backend healthy at 1.5 s | Readiness ended at 104.4 ms; identity stayed pending | Waited 1,510.5 ms for health; identity resolved |
| Backward clock step; backend healthy at 6.5 s | Readiness ran for 6,529.8 ms | Budget expired at 5,016.9 ms; one reconciliation scan, identity stayed pending |
| No clock step; backend healthy at 1.5 s | — | Readiness at 1,504.2 ms; identity resolved |
| No clock step; backend healthy at 6.5 s | — | Budget expired at 5,020.6 ms; one reconciliation scan |

All candidate cases returned HTTP 200 from `/healthz` and `/readyz` and exited normally with the port released. Early SIGTERM exercised the existing active-work drain: the already-admitted readiness and reconciliation settled before server close. This does not claim immediate cancellation on signal or an external ACP provider run.

Validation: both final regression cases fail on baseline for the intended reasons; 122 Gateway startup/trace tests, seven ACP manager tests, and seven registry tests pass. Focused formatting, lint, line/assertion checks, commit hook, and runtime build pass. Independent source and public behavior reviews are retained. Hosted checks and final review remain landing gates.

Preserves @qingminglong's contributor history and the original private-clock repair.
