### PR TITLE
perf: prepare default outbound target kind pattern once

### DIFF
--- a/src/infra/outbound/channel-target-prefix.test.ts
+++ b/src/infra/outbound/channel-target-prefix.test.ts
@@ -1,7 +1,47 @@
 // Covers provider-owned target prefixes, generic kind prefixes, topic suffixes,
 // and selected-channel prefix validation.
 import { describe, expect, it } from "vitest";
-import { stripTargetTopicSuffix } from "./channel-target-prefix.js";
+import { stripOutboundTargetKindPrefix, stripTargetTopicSuffix } from "./channel-target-prefix.js";
+
+describe("stripOutboundTargetKindPrefix", () => {
+  it.each(["channel", "conversation", "dm", "group", "room", "thread", "user"])(
+    "removes the default %s kind without changing target casing",
+    (kind) => {
+      expect(stripOutboundTargetKindPrefix(`${kind.toUpperCase()}:Room-A `)).toBe("Room-A");
+    },
+  );
+
+  it.each([
+    ["room:thread:Room-A", "thread:Room-A"],
+    [" room:Room-A ", "room:Room-A"],
+    ["custom:Room-A", "custom:Room-A"],
+  ])("preserves prefix anchoring and removes at most one kind from %s", (raw, expected) => {
+    expect(stripOutboundTargetKindPrefix(raw)).toBe(expected);
+  });
+
+  it("uses the current custom kinds on every call", () => {
+    const kinds = ["room"];
+    expect(stripOutboundTargetKindPrefix("room:Room-A", kinds)).toBe("Room-A");
+    kinds[0] = "user";
+    expect(stripOutboundTargetKindPrefix("room:Room-A", kinds)).toBe("room:Room-A");
+    expect(stripOutboundTargetKindPrefix("user:User-A", kinds)).toBe("User-A");
+    expect(stripOutboundTargetKindPrefix("room:Room-A")).toBe("Room-A");
+  });
+
+  it("preserves custom pattern and empty-list behavior", () => {
+    expect(stripOutboundTargetKindPrefix("THREAD:Room-A", [" room|thread "])).toBe("Room-A");
+    expect(stripOutboundTargetKindPrefix(" room:Room-A ", [])).toBe("room:Room-A");
+    expect(() => stripOutboundTargetKindPrefix("room:Room-A", ["["])).toThrow(SyntaxError);
+  });
+
+  it("supports a nested default call while reading custom kinds", () => {
+    const kinds = ["room"];
+    Object.defineProperty(kinds, 0, {
+      get: () => stripOutboundTargetKindPrefix("channel:room"),
+    });
+    expect(stripOutboundTargetKindPrefix("room:Room-A", kinds)).toBe("Room-A");
+  });
+});
 
 describe("stripTargetTopicSuffix", () => {
   it("strips explicit topic suffixes", () => {

--- a/src/infra/outbound/channel-target-prefix.ts
+++ b/src/infra/outbound/channel-target-prefix.ts
@@ -13,6 +13,8 @@ const TARGET_KIND_PREFIXES = new Set([
   "thread",
   "user",
 ]);
+const DEFAULT_TARGET_KINDS = [...TARGET_KIND_PREFIXES];
+const TARGET_KIND_PATTERN = new RegExp(`^(${DEFAULT_TARGET_KINDS.join("|")}):`, "i");
 
 /** Removes a selected channel/provider prefix from an outbound target string. */
 export function stripTargetProviderPrefix(raw: string, ...providers: string[]): string {
@@ -30,8 +32,11 @@ export function stripTargetProviderPrefix(raw: string, ...providers: string[]): 
 /** Removes generic target-kind prefixes such as room:, thread:, or user:. */
 export function stripOutboundTargetKindPrefix(
   raw: string,
-  kinds: readonly string[] = ["channel", "conversation", "dm", "group", "room", "thread", "user"],
+  kinds: readonly string[] = DEFAULT_TARGET_KINDS,
 ): string {
+  if (kinds === DEFAULT_TARGET_KINDS) {
+    return raw.replace(TARGET_KIND_PATTERN, "").trim();
+  }
   const kindPattern = kinds
     .map((kind) => normalizeOptionalLowercaseString(kind))
     .filter((kind): kind is string => Boolean(kind))


### PR DESCRIPTION
## What Problem This Solves

Outbound conversation and cron route selection repeatedly normalize the same seven default target kinds and rebuild an identical regular expression. This performs avoidable work on ordinary target resolution.

## Why This Change Was Made

Prepare the private default pattern once from the existing canonical kind set. Explicit custom arrays still use their current per-call normalization and regular-expression semantics, including mutable arrays, getters, empty lists and errors. There is no new cache, dependency, configuration or plugin contract.

Production changes are +6/-1 (net +5); tests are +41/-1 (net +40). The additional private constants and identity branch separate the invariant default from the caller-owned dynamic input without caching that input.

## User Impact

Default target parsing and the measured complete cron route-selection call do less work. Target casing, whitespace behavior, one-prefix removal, provider ownership and selected conversation remain unchanged. This does not claim faster model turns or network delivery.

## Evidence

On source baseline `efe2dda63cff3a02ee99c80e97c0c914467c76de`, a fixed before/candidate/candidate/before experiment retained 4,974 selected calls and 512 measured block means. A separate audit reconstructed raw outputs, identities, arithmetic, adverse observations and resource limits.

| Measured complete call | Forward median reduction | Reverse median reduction |
| --- | ---: | ---: |
| Default target-kind stripping | 66.36% | 71.55% |
| Cron route session-key selection | 27.35% | 36.12% |

Controls are not uniformly faster. Custom kind arrays increased 31.45% and 25.92%, or 0.305 and 0.273 microseconds. Their p95 also increased. Other first/warm/tail regressions remain recorded. Sampled process-tree RSS increased 7.47% and 9.98%; kernel peak RSS decreased slightly. The result passes the original two-order 3% primary gate, protected median gate requiring both a >3% and >1 microsecond regression in either order, and 10% memory gate. There is little sampled-RSS headroom; no memory improvement is claimed.

This uses Node 26.8.1 on Darwin, complete real exported owners/callers, and a synthetic channel registry. It does not send channel messages or execute provider turns. The 70 canonical tests additionally cover command conversation resolution, cron delivery selection, group extraction, mutable custom kinds, reentrant calls and malformed custom patterns. All 70 pass on both variants with identical file/case membership.

The measured owner, caller and test neighborhood is unchanged on the landing baseline `f4647c4d1af59b3bb798a0a9a0f27f87cb7075dd`. Fresh baseline and candidate runs again pass all 70 cases across the same five whole files; the full changed-file check passes. Fresh independent Codex P2 review is scoped-clean. Its first report publication failed because the output directory was missing; that failure is retained, and the completed review used unchanged source and evidence.

```text
node scripts/run-vitest.mjs src/infra/outbound/channel-target-prefix.test.ts src/infra/outbound/conversation-id.test.ts src/channels/conversation-resolution.test.ts src/cron/isolated-agent/delivery-dispatch.test.ts src/auto-reply/reply/group-id.test.ts
node scripts/check-changed.mjs -- src/infra/outbound/channel-target-prefix.ts src/infra/outbound/channel-target-prefix.test.ts
```

Raw records, failed preparation attempts, slower controls, source identities, independent audit and actual process closure remain retained locally. Final experiment digest: `046eb433f4fa5364e82e90a2fa25517a59c99f98d422a102aeae8363abd8fb61`. No benchmark harness is added to the product.
