### PR TITLE
test(voice-call): reuse shared stale-call reaper deferreds

### DIFF
--- a/extensions/voice-call/src/webhook/stale-call-reaper.test.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.test.ts
@@ -1,4 +1,5 @@
 // Voice Call tests cover stale call reaper plugin behavior.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startStaleCallReaper } from "./stale-call-reaper.js";
 
@@ -56,13 +57,10 @@ describe("startStaleCallReaper", () => {
 
   it("does not overlap reaps, logs typed failure, and retries after settlement", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    let resolveFirstEndCall!: (result: { success: false; error: string }) => void;
-    const firstEndCall = new Promise<{ success: false; error: string }>((resolve) => {
-      resolveFirstEndCall = resolve;
-    });
+    const firstEndCall = createDeferred<{ success: false; error: string }>();
     const endCall = vi
       .fn()
-      .mockImplementationOnce(() => firstEndCall)
+      .mockImplementationOnce(() => firstEndCall.promise)
       .mockResolvedValue({ success: true });
     const manager = {
       getActiveCalls: vi.fn(() => [
@@ -85,8 +83,8 @@ describe("startStaleCallReaper", () => {
 
     expect(endCall).toHaveBeenCalledTimes(1);
 
-    resolveFirstEndCall({ success: false, error: "network" });
-    await firstEndCall;
+    firstEndCall.resolve({ success: false, error: "network" });
+    await firstEndCall.promise;
     await Promise.resolve();
     expect(warn).toHaveBeenCalledWith("[voice-call] Reaper failed to end call call-stale: network");
     await vi.advanceTimersByTimeAsync(30_000);

--- a/extensions/voice-call/src/webhook/stale-call-reaper.transport.test.ts
+++ b/extensions/voice-call/src/webhook/stale-call-reaper.transport.test.ts
@@ -1,21 +1,12 @@
 // Voice Call tests cover stale-call reaping through a real provider HTTP boundary.
 import type { ServerResponse } from "node:http";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { withFetchPreconnect, withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { endCall } from "../manager/outbound.js";
 import { TelnyxProvider } from "../providers/telnyx.js";
 import type { CallRecord } from "../types.js";
 import { startStaleCallReaper } from "./stale-call-reaper.js";
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((settle, fail) => {
-    resolve = settle;
-    reject = fail;
-  });
-  return { promise, reject, resolve };
-}
 
 async function waitForProofEvent<T>(promise: Promise<T>, label: string): Promise<T> {
   // AbortSignal.timeout stays real while this suite fakes the global timer functions.
@@ -50,9 +41,9 @@ describe("stale-call reaper provider transport", () => {
     });
     vi.setSystemTime(new Date("2026-07-15T12:00:00.000Z"));
 
-    const firstRequestStarted = deferred<void>();
-    const firstResponseClosed = deferred<void>();
-    const secondRequestStarted = deferred<void>();
+    const firstRequestStarted = createDeferred<void>();
+    const firstResponseClosed = createDeferred<void>();
+    const secondRequestStarted = createDeferred<void>();
     let requestCount = 0;
     let firstResponse: ServerResponse | undefined;
 


### PR DESCRIPTION
The stale-call reaper tests duplicate Promise resolver setup. Reuse the existing SDK `createDeferred` helper for the three transport event barriers and the typed pending hangup result. Preserve all 24 assertions, the actual returned-Promise identity check, watchdog and listener cleanup, timeout/socket-close evidence, settlement order, and retry coverage.

Production delta: 0. Test delta: +9/-20, net -11 lines. The unchanged baseline and candidate each passed all 12 cases across both complete reaper suites and the manager lifecycle sibling, with identical ordered outcomes. Full local changed-file checks passed; independent Codex review through P2 found no actionable issues. Coverage uses synthetic providers and local HTTP transport, not a live telephony service.
