### PR TITLE
test: use runner-owned exit mock types

### DIFF
--- a/src/process/respawn-child-runner.test.ts
+++ b/src/process/respawn-child-runner.test.ts
@@ -9,7 +9,10 @@ vi.mock("./kill-tree.js", () => ({
   signalProcessTree: signalProcessTreeMock,
 }));
 
-import { runRespawnChildWithSignalBridge } from "./respawn-child-runner.js";
+import {
+  type RespawnChildRuntime,
+  runRespawnChildWithSignalBridge,
+} from "./respawn-child-runner.js";
 
 function createChild(pid?: number): { child: ChildProcess; kill: ReturnType<typeof vi.fn> } {
   const kill = vi.fn(() => true);
@@ -38,7 +41,7 @@ describe("runRespawnChildWithSignalBridge", () => {
       runtime: {
         spawn: spawnChild as unknown as typeof spawn,
         attachChildProcessBridge: vi.fn(),
-        exit: vi.fn() as unknown as (code?: number) => never,
+        exit: vi.fn<RespawnChildRuntime["exit"]>(),
       },
       onError: vi.fn(),
     });
@@ -55,7 +58,7 @@ describe("runRespawnChildWithSignalBridge", () => {
     { signal: "SIGTERM" as const, laterSignal: "SIGINT" as const, exitCode: 143 },
   ])("exits $exitCode when the child exits by forwarded $signal", (testCase) => {
     const { child } = createChild(2345);
-    const exit = vi.fn();
+    const exit = vi.fn<RespawnChildRuntime["exit"]>();
     let onSignal: ((signal: NodeJS.Signals) => void) | undefined;
 
     runRespawnChildWithSignalBridge({
@@ -68,7 +71,7 @@ describe("runRespawnChildWithSignalBridge", () => {
           onSignal = options?.onSignal;
           return { detach: vi.fn() };
         }),
-        exit: exit as unknown as (code?: number) => never,
+        exit,
       },
       onError: vi.fn(),
     });
@@ -84,7 +87,7 @@ describe("runRespawnChildWithSignalBridge", () => {
     vi.useFakeTimers();
     const { child, kill } = createChild(2468);
     const spawnChild = vi.fn(() => child);
-    const exit = vi.fn();
+    const exit = vi.fn<RespawnChildRuntime["exit"]>();
     let onSignal: ((signal: NodeJS.Signals) => void) | undefined;
 
     try {
@@ -100,7 +103,7 @@ describe("runRespawnChildWithSignalBridge", () => {
             onSignal = options?.onSignal;
             return { detach: vi.fn() };
           }),
-          exit: exit as unknown as (code?: number) => never,
+          exit,
         },
         onError: vi.fn(),
       });
@@ -139,7 +142,7 @@ describe("runRespawnChildWithSignalBridge", () => {
     vi.useFakeTimers();
     const { child, kill } = createChild(3579);
     const spawnChild = vi.fn(() => child);
-    const exit = vi.fn();
+    const exit = vi.fn<RespawnChildRuntime["exit"]>();
     let onSignal: ((signal: NodeJS.Signals) => void) | undefined;
 
     try {
@@ -155,7 +158,7 @@ describe("runRespawnChildWithSignalBridge", () => {
             onSignal = options?.onSignal;
             return { detach: vi.fn() };
           }),
-          exit: exit as unknown as (code?: number) => never,
+          exit,
         },
         onError: vi.fn(),
       });
@@ -190,7 +193,7 @@ describe("runRespawnChildWithSignalBridge", () => {
       runtime: {
         spawn: spawnChild as unknown as typeof spawn,
         attachChildProcessBridge: vi.fn(),
-        exit: vi.fn() as unknown as (code?: number) => never,
+        exit: vi.fn<RespawnChildRuntime["exit"]>(),
       },
       onError: vi.fn(),
     });
@@ -209,7 +212,7 @@ describe("runRespawnChildWithSignalBridge", () => {
   it("settles a spawn error when the child has no pid", () => {
     const { child } = createChild();
     const onError = vi.fn();
-    const exit = vi.fn();
+    const exit = vi.fn<RespawnChildRuntime["exit"]>();
 
     runRespawnChildWithSignalBridge({
       command: "missing-command",
@@ -218,7 +221,7 @@ describe("runRespawnChildWithSignalBridge", () => {
       runtime: {
         spawn: vi.fn(() => child) as unknown as typeof spawn,
         attachChildProcessBridge: vi.fn(),
-        exit: exit as unknown as (code?: number) => never,
+        exit,
       },
       onError,
     });
@@ -234,7 +237,7 @@ describe("runRespawnChildWithSignalBridge", () => {
     vi.useFakeTimers();
     const { child, kill } = createChild(5678);
     const onError = vi.fn();
-    const exit = vi.fn();
+    const exit = vi.fn<RespawnChildRuntime["exit"]>();
     let onSignal: ((signal: NodeJS.Signals) => void) | undefined;
 
     try {
@@ -248,7 +251,7 @@ describe("runRespawnChildWithSignalBridge", () => {
             onSignal = options?.onSignal;
             return { detach: vi.fn() };
           }),
-          exit: exit as unknown as (code?: number) => never,
+          exit,
         },
         onError,
       });


### PR DESCRIPTION
## What Problem This Solves

The respawn runner tests repeated their exit callback signature through seven double type assertions, allowing their mock typing to drift from the runner's contract.

## Why This Change Was Made

Use the existing `RespawnChildRuntime["exit"]` type directly in `vi.fn` and pass named mocks without casts. This changes static typing only; the mocks retain their existing recording no-op behavior.

## User Impact

No user-visible or production change. All eight runner cases retain their signal ordering, Windows/POSIX process cleanup, PID-less spawn failure, operational-error handling and timer assertions. The partial child and spawn adapters remain.

## Evidence

The identical 59-case owner, bridge and two entry-caller selection passed before and after. The complete 20-stage local changed gate passed, including typecheck and typed lint; managed Codex P2 review found no actionable issues. Production +0/-0; tests +16/-13, with the three added lines from import formatting.

Separate follow-up: audit the distinct stderr-write and throwing-exit fixture assertions in `src/entry.test.ts`.
