### PR TITLE
fix(update): stop detached updates after chat ownership is revoked

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -475,12 +475,13 @@ response includes `ackDelivered` so clients can distinguish a delivered
 acknowledgement from an unavailable or failed route. A synchronous failure after
 a delivered acknowledgement sends a second notice when no restart is scheduled.
 
-The Control UI includes its active session in the update request. After restart,
-updates without an originating session send their notice to the system main
-session when it has an external route, otherwise to the most recently used
-eligible direct chat. If neither exists, recovery keeps the system-session wake
-without an outbound chat notice. Session-less recovery never resumes a supplied
-continuation as another chat's turn.
+The Control UI includes its active session in the update request. Internal/webchat
+sessions receive the outcome as a transcript message after restart; sessions with
+an external delivery route receive a durable notice in that channel. Updates
+without an originating session send their notice through the system main
+session's external route when available. Otherwise, recovery keeps the
+system-session wake without an outbound chat notice. Session-less recovery never
+resumes a supplied continuation as another chat's turn.
 
 The Control UI sidebar update card shows **Update Gateway** when it will start
 this `update.run` flow directly. This covers browser-hosted Control UI, remote

--- a/src/cli/daemon-cli.ts
+++ b/src/cli/daemon-cli.ts
@@ -15,4 +15,7 @@ export type {
   GatewayRpcOpts,
 } from "./daemon-cli/types.js";
 
-export { waitForGatewayUpdateRecovery } from "./daemon-cli/lifecycle-context.js";
+export {
+  isManagedUpdateRequesterOwner,
+  waitForGatewayUpdateRecovery,
+} from "./daemon-cli/lifecycle-context.js";

--- a/src/cli/daemon-cli/lifecycle-context.ts
+++ b/src/cli/daemon-cli/lifecycle-context.ts
@@ -1,8 +1,14 @@
-import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
+import { isConfiguredCommandOwner } from "../../auto-reply/command-auth.js";
+import {
+  readBestEffortConfig,
+  readConfigFileSnapshot,
+  resolveGatewayPort,
+} from "../../config/config.js";
 import { createConfigIO } from "../../config/io.js";
 import { mergeGatewayServiceEnv } from "../../daemon/service-env-merge.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
+import { ensureCliPluginRegistryLoaded } from "../plugin-registry-loader.js";
 import { waitForGatewayHealthyRestart } from "./restart-health.js";
 
 export async function resolveGatewayLifecycleContext(
@@ -55,4 +61,13 @@ export async function waitForGatewayUpdateRecovery(
     requireRunningService: true,
     settle: { probes: 12 },
   });
+}
+
+// The helper rechecks external chat authority after parent exit and service stop.
+export async function isManagedUpdateRequesterOwner(
+  requester: Parameters<typeof isConfiguredCommandOwner>[1],
+) {
+  await ensureCliPluginRegistryLoaded({ scope: "configured-channels", routeLogsToStderr: true });
+  const snapshot = await readConfigFileSnapshot({ observe: false, skipPluginValidation: true });
+  return snapshot.valid && isConfiguredCommandOwner(snapshot.config, requester);
 }

--- a/src/gateway/server-methods/update-owner.test.ts
+++ b/src/gateway/server-methods/update-owner.test.ts
@@ -95,6 +95,19 @@ describe("update.run current owner authority", () => {
     },
   );
 
+  it("carries the admitted chat requester into the managed handoff", async () => {
+    detectRespawnSupervisorMock.mockReturnValue("launchd");
+    const result = await runOwnerTool(
+      createGatewayTool({ senderIsOwner: true, requesterSenderId: "owner" }),
+    );
+    expect(result.details).toMatchObject({ ok: true });
+    expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requester: { channel: "slack", accountId: "primary", senderId: "owner" },
+      }),
+    );
+  });
+
   it.each([false, true])("rechecks after awaited acknowledgement (managed=%s)", async (managed) => {
     detectRespawnSupervisorMock.mockReturnValue(managed ? "launchd" : null);
     sendGatewayLifecycleNoticeMock.mockImplementationOnce(async () => {

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -451,6 +451,7 @@ export const updateHandlers: GatewayRequestHandlers = {
               return;
             }
             const started = await startManagedServiceUpdateHandoff({
+              requester: params.requester,
               root: installRoot,
               timeoutMs,
               restartDrainTimeoutMs: resolveGatewayRestartDeferralTimeoutMs(),

--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -29,6 +29,7 @@ export type ManagedServiceManagerBoundaryOptions = {
   systemdPostExitStates?: ManagedSystemdPostExitState[];
   systemdStopDelayMs?: number;
   revokeOwner?: boolean;
+  requester?: { channel?: string; accountId?: string; senderId?: string };
   updaterExitCode?: number;
   recoveryExitCode?: number;
   recoveryHang?: boolean;
@@ -429,4 +430,59 @@ export function createManagedServiceLaunchdClockPreload(params: {
     "  return child;",
     "};",
   ].join("\n");
+}
+
+export function registerManagedHandoffOwnerTests(
+  runManagedServiceManagerBoundary: (
+    kind: "systemd",
+    options?: ManagedServiceManagerBoundaryOptions,
+  ) => Promise<ManagedServiceManagerBoundaryResult>,
+  itUnix: typeof import("vitest").it,
+  expect: typeof import("vitest").expect,
+): void {
+  itUnix.each(["revoked", "unchanged", "internal", "channel-less"] as const)(
+    "rechecks the %s requester after helper readiness and parent exit",
+    async (owner) => {
+      const { state, sentinel, log, sensitiveFilesRemoved } =
+        await runManagedServiceManagerBoundary("systemd", {
+          requester: {
+            channel:
+              owner === "internal" ? "webchat" : owner === "channel-less" ? undefined : "slack",
+            accountId: "primary",
+            senderId: "owner",
+          },
+          revokeOwner: owner === "revoked",
+          helperExitCode: owner === "revoked" ? 1 : 0,
+          updaterExitCode: 0,
+          updaterResult: { status: "ok", mode: "npm" },
+        });
+      expect(state).toMatchObject({ parked: true, stopCompleted: true });
+      expect(state.ownerChecked).toBe(
+        owner === "revoked" || owner === "unchanged" ? true : undefined,
+      );
+      if (owner === "revoked") {
+        expect(state).toMatchObject({
+          ownerRevokedAfterExit: true,
+          restored: true,
+          healthProbed: true,
+        });
+        expect(sentinel).toMatchObject({
+          payload: {
+            status: "error",
+            stats: {
+              reason: "owner_required",
+              steps: expect.arrayContaining([
+                expect.objectContaining({ name: "service-restore", log: { exitCode: 0 } }),
+              ]),
+            },
+          },
+        });
+        expect(log).toContain("owner_required");
+        expect(log).not.toContain("starting managed update command");
+      } else {
+        expect(log).toContain("starting managed update command");
+      }
+      expect(sensitiveFilesRemoved).toBe(true);
+    },
+  );
 }

--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -28,6 +28,7 @@ export type ManagedServiceManagerBoundaryOptions = {
   systemdHandoffFailure?: boolean;
   systemdPostExitStates?: ManagedSystemdPostExitState[];
   systemdStopDelayMs?: number;
+  revokeOwner?: boolean;
   updaterExitCode?: number;
   recoveryExitCode?: number;
   recoveryHang?: boolean;
@@ -213,6 +214,7 @@ if (${JSON.stringify(kind)} === "systemd") {
       try { process.kill(${parentPid}, 0); sleep(10); } catch { break; }
     }
     sleep(${options?.systemdStopDelayMs ?? 0});
+    ${options?.revokeOwner ? `fs.writeFileSync(process.env.OPENCLAW_CONFIG_PATH, JSON.stringify({ commands: { ownerAllowFrom: [] } })); state.ownerRevokedAfterExit = true;` : ""}
     state.stopCompleted = true;
   }
   if (action === "reset-failed") state.reset = true;

--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -437,7 +437,7 @@ export function registerManagedHandoffOwnerTests(
     kind: "systemd",
     options?: ManagedServiceManagerBoundaryOptions,
   ) => Promise<ManagedServiceManagerBoundaryResult>,
-  itUnix: typeof import("vitest").it,
+  itUnix: ReturnType<typeof import("vitest").it.runIf>,
   expect: typeof import("vitest").expect,
 ): void {
   itUnix.each(["revoked", "unchanged", "internal", "channel-less"] as const)(

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -3,10 +3,12 @@
  */
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { PassThrough } from "node:stream";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writeTriageUpdateFailure } from "../commands/triage-update.js";
 import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
@@ -140,6 +142,7 @@ async function runManagedServiceManagerBoundary(
   options?: ManagedServiceManagerBoundaryOptions & {
     controlDisconnect?: "transferred" | "unarmed" | "dead-parent";
     relativeInput?: boolean;
+    requester?: { channel?: string; accountId?: string; senderId?: string };
   },
 ): Promise<ManagedServiceManagerBoundaryResult> {
   const { spawn } =
@@ -217,8 +220,32 @@ async function runManagedServiceManagerBoundary(
   const env = {
     ...process.env,
     OPENCLAW_STATE_DIR: root,
+    OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
     PATH: `${root}${path.delimiter}${process.env.PATH ?? ""}`,
   };
+  if (options?.requester) {
+    await fs.writeFile(
+      env.OPENCLAW_CONFIG_PATH,
+      JSON.stringify({
+        commands: { ownerAllowFrom: ["slack:owner"] },
+        channels: { slack: { enabled: true } },
+      }),
+    );
+    await fs.appendFile(
+      recoveryModulePath,
+      `
+      export async function isManagedUpdateRequesterOwner(requester) {
+        const state = JSON.parse(fs.readFileSync(${JSON.stringify(statePath)}, "utf8"));
+        state.ownerChecked = true;
+        fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));
+        const { register } = await import(${JSON.stringify(pathToFileURL(createRequire(import.meta.url).resolve("tsx/esm/api")).href)});
+        register();
+        const runtime = await import(${JSON.stringify(new URL("../cli/daemon-cli/lifecycle-context.ts", import.meta.url).href)});
+        return runtime.isManagedUpdateRequesterOwner(requester);
+      }
+    `,
+    );
+  }
   let helper: import("node:child_process").ChildProcess | undefined;
   try {
     await startManagedServiceUpdateHandoff({
@@ -226,6 +253,7 @@ async function runManagedServiceManagerBoundary(
       restartDrainTimeoutMs: 300_000,
       parentPid,
       invocationCwd,
+      requester: options?.requester,
       execPath: process.execPath,
       argv1: process.argv[1],
       handoffId: `${kind}-boundary`,
@@ -451,7 +479,9 @@ async function runManagedServiceManagerBoundary(
             options?.helperExitCode ??
               (options?.systemdHandoffFailure ? 1 : (options?.updaterExitCode ?? 7)),
           );
-        await expect(pathExists(updaterPath)).resolves.toBe(!options?.systemdHandoffFailure);
+        await expect(pathExists(updaterPath)).resolves.toBe(
+          !options?.systemdHandoffFailure && !options?.revokeOwner,
+        );
       }
     }
     expect(readLease()).toBeNull();
@@ -502,6 +532,52 @@ async function runManagedServiceManagerBoundary(
 
 describe("managed service update handoff", () => {
   const itUnix = it.runIf(process.platform !== "win32");
+
+  itUnix.each(["revoked", "unchanged", "internal", "channel-less"] as const)(
+    "rechecks the %s requester after helper readiness and parent exit",
+    async (owner) => {
+      const { state, sentinel, log, sensitiveFilesRemoved } =
+        await runManagedServiceManagerBoundary("systemd", {
+          requester: {
+            channel:
+              owner === "internal" ? "webchat" : owner === "channel-less" ? undefined : "slack",
+            accountId: "primary",
+            senderId: "owner",
+          },
+          revokeOwner: owner === "revoked",
+          helperExitCode: owner === "revoked" ? 1 : 0,
+          updaterExitCode: 0,
+          updaterResult: { status: "ok", mode: "npm" },
+        });
+      expect(state).toMatchObject({ parked: true, stopCompleted: true });
+      expect(state.ownerChecked).toBe(
+        owner === "revoked" || owner === "unchanged" ? true : undefined,
+      );
+      if (owner === "revoked") {
+        expect(state).toMatchObject({
+          ownerRevokedAfterExit: true,
+          restored: true,
+          healthProbed: true,
+        });
+        expect(sentinel).toMatchObject({
+          payload: {
+            status: "error",
+            stats: {
+              reason: "owner_required",
+              steps: expect.arrayContaining([
+                expect.objectContaining({ name: "service-restore", log: { exitCode: 0 } }),
+              ]),
+            },
+          },
+        });
+        expect(log).toContain("owner_required");
+        expect(log).not.toContain("starting managed update command");
+      } else {
+        expect(log).toContain("starting managed update command");
+      }
+      expect(sensitiveFilesRemoved).toBe(true);
+    },
+  );
 
   itUnix.each(
     (["systemd", "launchd"] as const).flatMap((kind) =>

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -37,6 +37,7 @@ import {
   createManagedServiceUpdaterFixtureScript,
   createManagedServiceManagerFixtureScript,
   registerManagedSystemdHandoffConvergenceTests,
+  registerManagedHandoffOwnerTests,
   type ManagedServiceCommandTiming,
   type ManagedServiceManagerBoundaryOptions,
   type ManagedServiceManagerBoundaryResult,
@@ -142,7 +143,6 @@ async function runManagedServiceManagerBoundary(
   options?: ManagedServiceManagerBoundaryOptions & {
     controlDisconnect?: "transferred" | "unarmed" | "dead-parent";
     relativeInput?: boolean;
-    requester?: { channel?: string; accountId?: string; senderId?: string };
   },
 ): Promise<ManagedServiceManagerBoundaryResult> {
   const { spawn } =
@@ -533,51 +533,7 @@ async function runManagedServiceManagerBoundary(
 describe("managed service update handoff", () => {
   const itUnix = it.runIf(process.platform !== "win32");
 
-  itUnix.each(["revoked", "unchanged", "internal", "channel-less"] as const)(
-    "rechecks the %s requester after helper readiness and parent exit",
-    async (owner) => {
-      const { state, sentinel, log, sensitiveFilesRemoved } =
-        await runManagedServiceManagerBoundary("systemd", {
-          requester: {
-            channel:
-              owner === "internal" ? "webchat" : owner === "channel-less" ? undefined : "slack",
-            accountId: "primary",
-            senderId: "owner",
-          },
-          revokeOwner: owner === "revoked",
-          helperExitCode: owner === "revoked" ? 1 : 0,
-          updaterExitCode: 0,
-          updaterResult: { status: "ok", mode: "npm" },
-        });
-      expect(state).toMatchObject({ parked: true, stopCompleted: true });
-      expect(state.ownerChecked).toBe(
-        owner === "revoked" || owner === "unchanged" ? true : undefined,
-      );
-      if (owner === "revoked") {
-        expect(state).toMatchObject({
-          ownerRevokedAfterExit: true,
-          restored: true,
-          healthProbed: true,
-        });
-        expect(sentinel).toMatchObject({
-          payload: {
-            status: "error",
-            stats: {
-              reason: "owner_required",
-              steps: expect.arrayContaining([
-                expect.objectContaining({ name: "service-restore", log: { exitCode: 0 } }),
-              ]),
-            },
-          },
-        });
-        expect(log).toContain("owner_required");
-        expect(log).not.toContain("starting managed update command");
-      } else {
-        expect(log).toContain("starting managed update command");
-      }
-      expect(sensitiveFilesRemoved).toBe(true);
-    },
-  );
+  registerManagedHandoffOwnerTests(runManagedServiceManagerBoundary, itUnix, expect);
 
   itUnix.each(
     (["systemd", "launchd"] as const).flatMap((kind) =>

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -23,6 +23,7 @@ import {
 } from "../shared/pid-alive.js";
 import { SKIPPED_UPDATE_OUTCOMES } from "../shared/update-outcome.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { isInternalMessageChannel } from "../utils/message-channel.js";
 import { resolveExecutableFromPathEnv } from "./executable-path.js";
 import { resolveInstallationTarget } from "./installation-target-context.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "./kysely-sync.js";
@@ -1266,6 +1267,12 @@ async function collectUpdateFailureTriage() {
       }
     }
 
+    if (params.requester) {
+      const { isManagedUpdateRequesterOwner } = await import(pathToFileURL(params.recoveryModulePath).href);
+      if (!(await isManagedUpdateRequesterOwner(params.requester))) {
+        throw Object.assign(new Error("owner_required: chat requester is no longer a configured command owner"), { code: "owner_required" });
+      }
+    }
     appendLog("starting managed update command: " + params.commandLabel);
     // Update inputs retain shell-relative paths; recovery keeps the durable helper cwd.
     const exit = await runOwnedUpdateCommand("update", params.commandArgv, undefined, params.invocationCwd);
@@ -1312,8 +1319,9 @@ async function collectUpdateFailureTriage() {
     appendLog("handoff failed: " + (err && err.stack ? err.stack : String(err)));
     if (managedUpdateLeaseOwned) {
       bindManagedUpdateLeaseToProcess(process.pid);
-      if (restorationArmed && !updaterStarted) await restoreGatewayService("managed-service-handoff-helper-failed");
-      else recordUpdateHandoffOutcome("managed-service-handoff-helper-failed");
+      const reason = err?.code === "owner_required" ? "owner_required" : "managed-service-handoff-helper-failed";
+      if (restorationArmed && !updaterStarted) await restoreGatewayService(reason);
+      else recordUpdateHandoffOutcome(reason);
     }
     process.exitCode = 1;
   } finally {
@@ -1342,6 +1350,7 @@ type ManagedServiceUpdateHandoffParams = {
   tag?: string;
   acceptCapabilities?: boolean;
   meta: UpdateRestartSentinelMeta;
+  requester?: { channel?: string; accountId?: string; senderId?: string };
   handoffId?: string;
   supervisor?: RespawnSupervisor | null;
   env?: NodeJS.ProcessEnv;
@@ -1597,6 +1606,10 @@ async function spawnManagedServiceUpdateHandoff(
       PARENT_EXIT_SHUTDOWN_RESERVE_MS,
   );
   const helperParams = {
+    requester:
+      params.requester?.channel && !isInternalMessageChannel(params.requester.channel)
+        ? params.requester
+        : undefined,
     parentPid,
     parentStartIdentity: String(parentStartIdentity),
     parentExitTimeoutMs,


### PR DESCRIPTION
Related: #136588 (chat update reliability) and #136995 (owner refusals and restart recovery).

## What Problem This Solves

Fixes an issue where a chat requester whose ownership was revoked while a managed update helper waited for the Gateway to exit could still start the update. Addresses ClawSweeper's [helper-time owner recheck finding](https://github.com/openclaw/openclaw/pull/136588#issuecomment-5516137784) and its stale session-less routing documentation finding.

## Why This Change Was Made

The Gateway passes the admitted external requester into the existing private handoff. After parent exit and service stop, the helper loads the installed daemon runtime, reads current configuration, and applies the canonical command-owner predicate immediately before launching the updater. The runtime initializes configured channel metadata first so prefixed owner entries retain the Gateway's semantics. A refusal follows the existing pre-updater service recovery path and records an error sentinel with reason `owner_required`.

The update guide now describes the implemented system-main-session route, internal/webchat transcript outcomes, and external channel notices. No configuration option, schema, or migration was added. Production delta: +36/-4 (net +32), required to carry and revalidate the requester across the detached-process boundary; existing recovery is reused.

## User Impact

Removing chat ownership before the detached helper starts its updater now prevents the update, restores the parked service, and leaves a failure notice for recovery. Unchanged owners still update; internal and channel-less callers retain their admission authority without the extra config read.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/update-owner.test.ts src/infra/update-managed-service-handoff-lifecycle.test.ts src/cli/daemon-cli/lifecycle.test.ts`: 187 tests passed (8 Gateway owner, 134 handoff lifecycle, 45 daemon lifecycle).
- `pnpm check:changed`: exit 0. Initial local attempts caught the lifecycle test file's line limit and a conditional Vitest callback type; both were corrected without changing runtime behavior.
- `pnpm build`: exit 0. Built `dist/cli/daemon-cli.js` smoke: unchanged owner `true`, same requester after config revocation `false`.
- Independent Codex branch autoreview against `origin/main`, high reasoning, through P2: scoped-clean, no actionable findings.
- Regression provenance: WIP commit `3083e81cf5d` was reverted with `git revert --no-commit` in a separate temporary worktree, then the final regression tests were reapplied. All four runtime files were verified byte-identical to `origin/main`. The revocation case failed: the updater marker existed and helper exit was 0 instead of 1. On the candidate it passes with no updater spawn, restored service/readiness, failed `owner_required` sentinel, and private handoff cleanup. Internal/channel-less requesters skip the runtime/config check; an unchanged prefixed owner launches.
- Existing notice contract tests: `node scripts/run-vitest.mjs src/gateway/server-restart-sentinel.test.ts -t 'internal update outcome|keeps durable'`: 6 passed. Internal outcomes append/broadcast to the transcript; externally routed sessions send durable channel notices without appending the transcript.
- Addressed [ClawSweeper's docs finding](https://github.com/openclaw/openclaw/pull/137312#issuecomment-5526433482) in the existing docs commit: Control UI can select either kind of session, so the guide now distinguishes their delivery behavior. Runtime/test files are byte-identical to the first validated head; production growth remains +32 net because no smaller existing owner spans the detached requester binding and final check.
- Base verified as `3d8c35b3a5d`, containing `d809c115eb7` (#136588) and `a5f3623302f` (#136995).

ClawSweeper rank-up moves from the linked review: helper-time revalidation and documentation correction are implemented; final candidate race proof is above. Authenticated Telegram outcome proof is not included in this explicitly scoped fake-manager work order. This change reuses the existing failed-sentinel notice delivery path.

Proof uses the real generated detached helper, real parent-process exit, a temporary config and SQLite sentinel, and fake systemd/launchd managers. It does not mutate a live operator service or package install. No authenticated chat delivery or real service-manager mutation was performed: this work order explicitly selects the fake-manager lifecycle boundary and prohibits touching the operator Gateway. Existing recovery/notice delivery behavior is reused.

Latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/137312#issuecomment-5526433482): no code/security findings; previous docs finding resolved. Its current-main refresh request is addressed against [a4ad6c76a4d](https://github.com/openclaw/openclaw/commit/a4ad6c76a4d19ec47394f0a1905c749252d308c1): changed runtime files, owner-policy/config/registry dependencies, affected tests, notice routing, and guide are unchanged from the validated base. Direct source still shows the unchecked helper launch at `src/infra/update-managed-service-handoff.ts:1269`. No conflicting owner-boundary change exists. This repair and native landing are explicitly requested by the maintainer in W17.

Final exact-head CI: [run 33761500980](https://github.com/openclaw/openclaw/actions/runs/33761500980), head [0fe00f642910](https://github.com/openclaw/openclaw/commit/0fe00f642910faf0c939f127c230be74a2c8a135). `node scripts/watch-pr-ci.mjs 137312 0fe00f642910faf0c939f127c230be74a2c8a135 --timeout 1500` exited 0 with `GREEN`; zero pending or failed jobs, GitHub `MERGEABLE`. Cancelled older label/dispatch jobs have successful or skipped replacements.
