### PR TITLE
fix(discord): accept system-agent approval kind in callback codec

### DIFF
--- a/extensions/discord/src/approval-custom-id.ts
+++ b/extensions/discord/src/approval-custom-id.ts
@@ -34,7 +34,9 @@ function encodeBoundedDiscordApprovalCustomId(action: DiscordApprovalAction): st
 export function buildDiscordApprovalCustomId(action: DiscordApprovalAction): string | undefined {
   if (
     !action.approvalId ||
-    (action.approvalKind !== "exec" && action.approvalKind !== "plugin") ||
+    (action.approvalKind !== "exec" &&
+      action.approvalKind !== "plugin" &&
+      action.approvalKind !== "system-agent") ||
     (action.decision !== "allow-once" &&
       action.decision !== "allow-always" &&
       action.decision !== "deny")
@@ -78,7 +80,11 @@ export function parseExecApprovalData(data: ComponentData): {
   const rawId = coerce(data.id);
   const rawKind = coerce(data.kind);
   const rawAction = coerce(data.action);
-  if (!rawId || (rawKind !== "exec" && rawKind !== "plugin") || !rawAction) {
+  if (
+    !rawId ||
+    (rawKind !== "exec" && rawKind !== "plugin" && rawKind !== "system-agent") ||
+    !rawAction
+  ) {
     return null;
   }
   if (rawAction !== "allow-once" && rawAction !== "allow-always" && rawAction !== "deny") {

--- a/extensions/discord/src/monitor/exec-approvals.test.ts
+++ b/extensions/discord/src/monitor/exec-approvals.test.ts
@@ -2,7 +2,11 @@
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { buildExecApprovalCustomId, parseExecApprovalData } from "../approval-custom-id.js";
+import {
+  buildDiscordApprovalCustomId,
+  buildExecApprovalCustomId,
+  parseExecApprovalData,
+} from "../approval-custom-id.js";
 import { parseCustomId, type ButtonInteraction, type ComponentData } from "../internal/discord.js";
 
 const resolveApprovalOverGatewayMock = vi.hoisted(() => vi.fn());
@@ -71,6 +75,7 @@ describe("discord exec approval monitor helpers", () => {
   it.each([
     ["exec", "plugin:looks-like-plugin", "allow-once"],
     ["plugin", "plain-plugin-id", "deny"],
+    ["system-agent", "system-agent-request", "allow-always"],
   ] as const)("round-trips %s approval custom ids", (approvalKind, approvalId, action) => {
     const customId = buildExecApprovalCustomId(approvalId, approvalKind, action);
     const parsed = parseCustomId(customId);
@@ -80,6 +85,25 @@ describe("discord exec approval monitor helpers", () => {
       approvalId,
       approvalKind,
       action,
+    });
+  });
+
+  it("builds and parses a custom id for system-agent approvals through the shared-interactive path", () => {
+    // The shared-interactive emit path builds buttons via the guarded
+    // buildDiscordApprovalCustomId helper, which previously dropped
+    // system-agent approvals before they could be rendered.
+    const customId = buildDiscordApprovalCustomId({
+      type: "approval",
+      approvalId: "system-agent-request",
+      approvalKind: "system-agent",
+      decision: "allow-once",
+    });
+    expect(customId).not.toBeUndefined();
+    const parsed = parseCustomId(customId!);
+    expect(parseExecApprovalData(parsed.data)).toEqual({
+      approvalId: "system-agent-request",
+      approvalKind: "system-agent",
+      action: "allow-once",
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

`main` subscribes Discord's native approval runtime to `system-agent` requests and renders an OpenClaw Change approval card, but the Discord callback codec only accepted `exec` and `plugin` approval kinds. A `system-agent` button emitted through `buildExecApprovalCustomId` (used by `approval-handler.runtime.ts`) produces `execapproval:kind=system-agent;...`, which `parseExecApprovalData` rejected before channel authorization or the canonical `approval.resolve` path could run. The operator was left with a button that nothing could complete.

Closes #137142.

## Approach

`ChannelApprovalKind` is already `"exec" | "plugin" | "system-agent"` (`src/infra/approval-types.ts`), and `MessagePresentationAction`'s approval variant carries it. The codec simply had not been updated when `system-agent` was added to the subscription list. Both guards now accept `system-agent`:

- `parseExecApprovalData` (`extensions/discord/src/approval-custom-id.ts`) — the interaction path that previously returned `null` for `kind=system-agent`.
- `buildDiscordApprovalCustomId` — the shared-interactive emit path (`extensions/discord/src/shared-interactive.ts`) that previously returned `undefined` for `system-agent` approvals, silently dropping the button before it could be rendered.

After parsing, the existing kind-agnostic `resolveApproval(approvalId, approvalKind, action, userId)` path handles the resolution, so no further routing change is needed.

## Evidence

- `npx vitest run extensions/discord/src/monitor/exec-approvals.test.ts` → 18 passed (16 baseline + `round-trips system-agent approval custom ids` + `builds and parses a custom id for system-agent approvals through the shared-interactive path`).
- `npx vitest run extensions/discord/src/shared-interactive.test.ts` → 26 passed (build-guard change is backwards-compatible with exec/plugin).
- `oxlint` → exit 0; `oxfmt --check` → all files correct format.
- Confirmed no other `exec`/`plugin`-only approval-kind guards exist in the Discord extension (`approval-handler.runtime.ts:254` already special-cases `system-agent`; `:394` subscribes to `["exec","plugin","system-agent"]`).

## Risk

Minimal. The change widens two allowlists by one already-typed enum member; no control flow or authorization change. `system-agent` approvals still pass through the same approver-membership + gateway `approval.resolve` path as `exec`/`plugin`.
