### PR TITLE
fix(ui): sidebar header controls read misaligned after the + button lost its border

### DIFF
--- a/ui/src/e2e/native-nav-responsive-layout.e2e.test.ts
+++ b/ui/src/e2e/native-nav-responsive-layout.e2e.test.ts
@@ -190,6 +190,22 @@ suite.define(() => {
       )
       .toEqual([12, 12, 12]);
 
+    // One rail, one gap: adjacent controls touch in both directions, so no
+    // button carries a private optical offset left over from a bordered box.
+    const controlGaps = () =>
+      sidebarBrand
+        .locator(".sidebar-brand__collapse, .sidebar-brand__search, .sidebar-brand__new-thread")
+        .evaluateAll((actions) => {
+          const boxes = actions.map((action) => action.getBoundingClientRect());
+          return boxes
+            .slice(1)
+            .map((box, index) =>
+              Math.round(Math.max(box.left - boxes[index].right, boxes[index].left - box.right)),
+            );
+        });
+
+    await expect.poll(controlGaps).toEqual([0, 0]);
+
     const actionInset = async (direction: "ltr" | "rtl") => {
       const [brandBox, actionsBox] = await Promise.all([
         sidebarBrand.boundingBox(),
@@ -214,6 +230,7 @@ suite.define(() => {
       document.documentElement.dir = "rtl";
     });
     await expect.poll(() => actionInset("rtl")).toBe(0);
+    await expect.poll(controlGaps).toEqual([0, 0]);
     await expect.poll(nameFade).toEqual(["8px", "0px", expect.stringContaining("270deg")]);
   });
 

--- a/ui/src/e2e/native-nav-responsive-layout.e2e.test.ts
+++ b/ui/src/e2e/native-nav-responsive-layout.e2e.test.ts
@@ -196,12 +196,16 @@ suite.define(() => {
       sidebarBrand
         .locator(".sidebar-brand__collapse, .sidebar-brand__search, .sidebar-brand__new-thread")
         .evaluateAll((actions) => {
-          const boxes = actions.map((action) => action.getBoundingClientRect());
-          return boxes
-            .slice(1)
-            .map((box, index) =>
-              Math.round(Math.max(box.left - boxes[index].right, boxes[index].left - box.right)),
-            );
+          const [first, ...rest] = actions.map((action) => action.getBoundingClientRect());
+          if (!first) {
+            return [];
+          }
+          let previous = first;
+          return rest.map((box) => {
+            const gap = Math.round(Math.max(box.left - previous.right, previous.left - box.right));
+            previous = box;
+            return gap;
+          });
         });
 
     await expect.poll(controlGaps).toEqual([0, 0]);

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1046,6 +1046,9 @@ openclaw-settings-save-indicator:empty {
 .sidebar-brand__actions {
   display: flex;
   align-items: center;
+  /* One hit-box size and one gap for every header control: the glyph inset
+     inside each 28px box is the only spacing. A per-button offset here reads
+     as a hole in the rail once that button has no border to sit inside. */
   gap: 0;
   /* Keep the action rail independent from the fit-content identity card so
      short agent names never pull navigation controls away from the edge. */
@@ -1066,10 +1069,6 @@ openclaw-settings-save-indicator:empty {
 
 .sidebar-brand__header-control:hover:not(:disabled, [aria-disabled="true"]) svg {
   opacity: 1;
-}
-
-.sidebar-brand__new-thread {
-  margin-inline-start: 5px;
 }
 
 .sidebar-brand__icon {


### PR DESCRIPTION
Closes #137316

## What Problem This Solves

Fixes an issue where operators looking at the Control UI workspace sidebar would see the three header controls — sidebar-collapse, search, and new-session `+` — read as misaligned, because the `+` sat 5px further from search than search sat from collapse.

## Why This Change Was Made

The `+` used to render as a bordered chrome button (`shell-chrome-controls__button`: 1px border, `--shadow-sm`, panel background), and #134365 (@vyctorbrzezowski) gave it `margin-inline-start: 5px` as optical alignment so that filled box would not crowd the two borderless glyphs beside it. #136608 (@Patrick-Erichsen) correctly re-based the `+` onto the borderless `.sidebar-brand__icon` / `.sidebar-brand__header-control` pair but kept the offset, so with no box left to sit inside it became pure extra gap.

The fix is to delete the offset rather than tune a new number: `.sidebar-brand__actions` already declares `gap`, so the actions row becomes the single owner of control spacing and all three controls share one 28x28 hit box and one gap. The `+` stays borderless. Its 20px glyph (versus 16px) is deliberate and untouched — the plus path fills less of its viewBox, and the existing e2e already proves all three render 12px of ink.

Net production change is -1 line (a 4-line rule removed, a 3-line comment added at the new owner so nobody re-adds a per-button offset).

## User Impact

The sidebar header controls now read as one rail: equal boxes, equal gaps, in Light and Dark, LTR and RTL. No behavior, no config, no new options.

## Evidence

Gaps measured with `getBoundingClientRect()` on the mocked Control UI dev server at 1440px, `deviceScaleFactor: 2`:

| Variant | collapse -> search | search -> `+` | Control sizes |
| --- | --- | --- | --- |
| Light, before | 0px | **5px** | 28x28, 28x28, 28x28 |
| Light, after | 0px | **0px** | 28x28, 28x28, 28x28 |
| Dark, before | 0px | **5px** | 28x28, 28x28, 28x28 |
| Dark, after | 0px | **0px** | 28x28, 28x28, 28x28 |
| RTL, before | 0px | **5px** | 28x28, 28x28, 28x28 |
| RTL, after | 0px | **0px** | 28x28, 28x28, 28x28 |

**Light, 2x — before / after**

![before, light](https://github.com/user-attachments/assets/e547095b-a352-4de6-a571-15abbf3fa49f)

![after, light](https://github.com/user-attachments/assets/9d4dca4b-5335-432f-8e52-140425a68168)

**Dark, 2x — before / after**

![before, dark](https://github.com/user-attachments/assets/a3d1a6fd-ca79-40c2-a5be-f3b1bca4332e)

![after, dark](https://github.com/user-attachments/assets/e7bf5352-7ce7-4aad-accf-ffe7652d3a35)

**RTL, 2x — before / after**

![before, RTL](https://github.com/user-attachments/assets/7adb10c2-0af3-4e2d-8c28-742981d3a49d)

![after, RTL](https://github.com/user-attachments/assets/d93cc6bd-aa36-4423-81ae-ea43796b1d64)

**Sidebar top with surrounding rows — before / after.** The `+` stays anchored to the trailing edge; collapse and search move 5px toward it to close the hole. Nothing below the header moves.

![before, sidebar top](https://github.com/user-attachments/assets/25886e96-4154-41a5-b780-cbeeefe82bb3)

![after, sidebar top](https://github.com/user-attachments/assets/30b6a82e-6d49-4718-bade-b05b77054aa8)

Regression coverage lands in the existing sidebar-header geometry test, `ui/src/e2e/native-nav-responsive-layout.e2e.test.ts` ("keeps browser sidebar header geometry aligned in LTR and RTL"), next to the assertions that already pin hit-box size, ink width, border state, and trailing inset. The new `controlGaps` poll asserts `[0, 0]` in LTR and again after the RTL flip; it measures adjacent-box distance direction-agnostically, so it fails on pre-fix code with `[0, 5]` in both directions.

Local proof on this machine: mocked Control UI dev server, headless Chromium captures above (every capture opened and inspected), `stylelint` and `oxfmt` clean on both touched files, and a clean `autoreview` pass (`gpt-5.6-sol`, high, `scoped-clean`). Suites and typecheck are left to CI on this head.

## Risk and coverage

**What else could shift.**

- *Other icon rows on the same tokens.* `--shell-chrome-control-size` and `.sidebar-brand__icon` are shared. The change touches neither: it deletes a rule scoped to `.sidebar-brand__new-thread` and adds a comment. `grep` for `sidebar-brand__new-thread` shows exactly two remaining production rules (the 20px glyph size, untouched, and the cursor-policy selector list) plus the render call site.
- *Mobile / drawer header.* `.shell--mobile-nav .sidebar-brand__desktop-control { display: none }` leaves the `+` as the only control in the actions row. `.sidebar-brand__actions` carries `margin-inline-start: auto`, so the row is trailing-anchored and its content width shrank by 5px while the `+` itself did not move. No mobile-visible change.
- *RTL.* The removed property was `margin-inline-start`, i.e. already logical, so removal is symmetric by construction — and the RTL captures plus the new RTL assertion confirm it. The pre-existing RTL asymmetry in `.sidebar-brand`'s physical `padding: 0 2px 10px 0` (which the existing test pins as `actionInset` 2 in LTR, 0 in RTL) is untouched and out of scope here.
- *Collapsed sidebar and native hosts.* The collapsed rail and the native-nav / web-chrome hosts hide these controls through `.sidebar-brand__collapse` and `.sidebar-brand__desktop-control` display rules and render their own chrome; none of them reads the deleted margin. The native-host assertions in the same e2e file are unchanged and still pass their own geometry checks.
- *Hover and focus rings.* Both are painted on the 28x28 box by `.sidebar-brand__icon`, which is untouched. With `gap: 0` the hover fills of adjacent controls now touch for all three pairs instead of two — the same behavior collapse and search already shipped.

**What is uncovered.** These captures are headless Chromium on macOS at 1440px, `deviceScaleFactor: 2`, default Claw theme. Not captured here: real Safari/Firefox rendering, non-default themes and custom themes (they change color tokens, not the geometry this touches), text-scale settings other than 100%, and the packaged macOS/native-nav app chrome, where the sidebar controls are hidden by design and so cannot regress from this diff. Full test suites, typecheck, and build run on CI for this head rather than locally.



## Landing notes

Head moved from `3a7f9273bfe` to `7d5e48da7eb`. The second commit is a test-only type fix, no CSS or behavior change; the gap measurements and captures above still describe the shipped result.

ClawSweeper review of `3a7f9273bfe` recorded **no code findings** (patch quality 4/6, findings: None, security: None). Its blockers and rank-up move were all the exact-head CI failure. Each item, and what was done:

- **Resolve merge risk (P1)** — *applied.* The failure was mine, not main's. `check-test-types-core-4` runs with `noUncheckedIndexedAccess`, and the gap walk I added read `boxes[index]`, which is `| undefined` under that flag: `native-nav-responsive-layout.e2e.test.ts(203,46)` and `(203,66)`, `error TS2532: Object is possibly 'undefined'`. `openclaw/ci-gate` was the cascade, not a second defect.
- **Complete next step (P2)** — *applied.* Fixed at the source rather than asserted past the checker: the walk now carries the previous rect forward, so every read is non-optional by construction and no indexed access remains. Exact-head CI is green on `7d5e48da7eb`.
- **Rank-up move: establish provenance for the failing checks** — *applied.* Provenance is this PR's first commit, not current `main`; named above with the exact file, lines, and TS error code.
- **Resolve maintainer decision** — *resolved by the owner.* ClawSweeper's recommendation was "approve after CI is green"; the repository owner authorized this land explicitly, which is the human handling the `maintainer` label asks for.

No re-review requested: the only push after the review addressed a review blocker and changed no behavior beyond it.

