### PR TITLE
fix(telegram): keep provider failure settlement proof deterministic

### DIFF
--- a/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
@@ -10,8 +10,12 @@ type JsonObject = Record<string, unknown>;
 const BOT_TOKEN = `424242:${"A".repeat(35)}`;
 const CHAT_ID = -1001234;
 const SENDER_ID = 777;
-const FAILURE_TEXT =
-  "⚠️ mock-openai/gpt-5.6-luna-alt request failed (provider internal error, HTTP 500). This is usually temporary — try again shortly.";
+const PRIMARY_MODEL_ID = "gpt-5.6-luna";
+const FALLBACK_MODEL_ID = "gpt-5.6-luna-alt";
+const PRIMARY_MODEL = `mock-openai/${PRIMARY_MODEL_ID}`;
+const FALLBACK_MODEL = `mock-openai/${FALLBACK_MODEL_ID}`;
+const GENERIC_FAILURE_TEXT =
+  "Something went wrong while processing your request. Please try again.";
 const RAW_ERROR_CANARY = "untrusted-provider-detail-qa-canary";
 
 async function readRequest(req: IncomingMessage): Promise<JsonObject> {
@@ -29,6 +33,7 @@ function succeed(res: ServerResponse, result: unknown = true) {
 test("visibly settles a message-tool-only Telegram turn after a provider failure", async () => {
   const pendingPolls = new Set<ServerResponse>();
   const telegramSends: JsonObject[] = [];
+  const providerModels: string[] = [];
   let providerRequests = 0;
   let updateDelivered = false;
 
@@ -47,6 +52,10 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
     const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
     if (pathname.startsWith("/v1/")) {
       providerRequests += 1;
+      const body = await readRequest(req);
+      if (typeof body.model === "string") {
+        providerModels.push(body.model);
+      }
       writeJson(res, 500, { error: { message: `provider returned HTTP 500 ${RAW_ERROR_CANARY}` } });
       return;
     }
@@ -104,6 +113,8 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
             repoRoot,
             useRepoCli: true,
             providerBaseUrl: `${apiRoot}/v1`,
+            primaryModel: PRIMARY_MODEL,
+            alternateModel: FALLBACK_MODEL,
             transportBaseUrl: apiRoot,
             transport: {
               requiredPluginIds: ["telegram"],
@@ -155,22 +166,25 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
 
           await expect
             .poll(
-              () => ({
-                providerRequests,
-                sends: telegramSends.map((send) => ({
+              () =>
+                telegramSends.map((send) => ({
                   chatId: send.chat_id,
                   silent: send.disable_notification,
                   text: send.text,
                 })),
-              }),
               { interval: 100, timeout: 30_000 },
             )
-            .toEqual({
-              providerRequests: expect.any(Number),
-              sends: [{ chatId: String(CHAT_ID), silent: true, text: FAILURE_TEXT }],
-            });
+            .toEqual([{ chatId: String(CHAT_ID), silent: true, text: expect.any(String) }]);
           expect(providerRequests).toBeGreaterThan(0);
-          expect(telegramSends.map((send) => send.text).join("\n")).not.toContain(RAW_ERROR_CANARY);
+          expect(providerModels).toContain(PRIMARY_MODEL_ID);
+          expect(providerModels).toContain(FALLBACK_MODEL_ID);
+          const failureText = String(telegramSends[0]?.text ?? "");
+          expect(failureText).toContain(`${FALLBACK_MODEL} request failed`);
+          expect(failureText).toContain("provider internal error");
+          expect(failureText).toContain("HTTP 500");
+          expect(failureText).toContain("This is usually temporary");
+          expect(failureText).not.toContain(RAW_ERROR_CANARY);
+          expect(failureText).not.toBe(GENERIC_FAILURE_TEXT);
         } finally {
           await stopQaGatewayFixture(gatewayOwner);
           for (const poll of pendingPolls) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI fragility where the Telegram provider-failure settlement proof coupled safe classified error copy to one exact rendered sentence.

CI context: https://github.com/openclaw/openclaw/actions/runs/33715186698

## Why This Change Was Made

The fixture retains distinct mock primary and fallback models, records both provider request routes, and asserts the user-visible contract semantically: one silent Telegram send from the exhausted fallback with classified HTTP 500/server-error recovery guidance, without raw provider details or the generic fallback.

This changes test coverage only. Runtime provider-failure behavior is unchanged.

## User Impact

No user-visible behavior change. Maintainers get a deterministic Gateway E2E signal for Telegram message-tool-only failure settlement.

## Evidence

- `git diff --check` passes.
- `oxfmt --check test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts` passes.
- ClawSweeper's fallback-coverage finding is addressed by restoring distinct `gpt-5.6-luna` / `gpt-5.6-luna-alt` routes and asserting requests to both.
- Exact-head Blacksmith Testbox proof is pending for the updated branch.
- Local runtime proof is blocked by the shared checkout's stale dependency install (`mdast-util-from-markdown`, `@pierre/diffs`, and Shiki language packages are unresolved).
- Repository autoreview preparation passed, but execution is unavailable because the host does not have the required standalone Codex CLI.
