### PR TITLE
test(agents): align fault sequences with retry owner

### DIFF
--- a/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
@@ -20,22 +20,17 @@ import {
   makeEmbeddedRunnerAttempt as makeAttempt,
 } from "./test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import {
-  installEmbeddedRunnerBackoffE2eMocks,
   installEmbeddedRunnerBaseE2eMocks,
   installEmbeddedRunnerFastRunE2eMocks,
+  installEmbeddedRunnerRetrySleepE2eMocks,
 } from "./test-helpers/embedded-agent-runner-e2e-mocks.js";
 
 const runEmbeddedAttemptMock = vi.fn<(params: unknown) => Promise<EmbeddedRunAttemptResult>>();
 const resolveCopilotApiTokenMock = vi.fn();
-const { computeBackoffMock, sleepWithAbortMock } = vi.hoisted(() => ({
-  computeBackoffMock: vi.fn(
-    (
-      _policy: { initialMs: number; maxMs: number; factor: number; jitter: number },
-      _attempt: number,
-    ) => 321,
-  ),
+const { sleepWithAbortMock } = vi.hoisted(() => ({
   sleepWithAbortMock: vi.fn(async (_ms: number, _abortSignal?: AbortSignal) => undefined),
 }));
+let mathRandomMock: ReturnType<typeof vi.spyOn> | undefined;
 
 const installRunEmbeddedMocks = () => {
   installEmbeddedRunnerBaseE2eMocks();
@@ -83,8 +78,7 @@ const installRunEmbeddedMocks = () => {
       };
     },
   }));
-  installEmbeddedRunnerBackoffE2eMocks({
-    computeBackoff: (policy, attempt) => computeBackoffMock(policy, attempt),
+  installEmbeddedRunnerRetrySleepE2eMocks({
     sleepWithAbort: (ms, abortSignal) => sleepWithAbortMock(ms, abortSignal),
   });
   vi.doMock("./embedded-agent-runner/compact.js", () => ({
@@ -137,6 +131,7 @@ async function runEmbeddedAgentInline(
 
 beforeEach(() => {
   vi.useRealTimers();
+  mathRandomMock = vi.spyOn(Math, "random").mockReturnValue(0);
   runEmbeddedAttemptMock.mockReset();
   runEmbeddedAttemptMock.mockImplementation(async () => {
     throw new Error("unexpected extra runEmbeddedAttempt call");
@@ -149,11 +144,12 @@ beforeEach(() => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
     throw new Error(`Unexpected fetch in test: ${url}`);
   }) as unknown as typeof fetch;
-  computeBackoffMock.mockClear();
   sleepWithAbortMock.mockClear();
 });
 
 afterEach(() => {
+  mathRandomMock?.mockRestore();
+  mathRandomMock = undefined;
   globalThis.fetch = originalFetch;
   cleanupLogCapture?.();
   cleanupLogCapture = undefined;
@@ -486,7 +482,9 @@ async function runAutoPinnedRotationCase(params: {
         ? ["openai:p1", "openai:p1", "openai:p1", "openai:p1", "openai:p2"]
         : ["openai:p1", "openai:p2"],
     );
-    expect(sleepWithAbortMock).toHaveBeenCalledTimes(params.exhaustTransientRetries ? 3 : 0);
+    expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual(
+      params.exhaustTransientRetries ? [500, 1_000, 2_000] : [],
+    );
     const usageStats = await readUsageStats(agentDir);
     expect(usageStats["openai:p2"]?.lastUsed).toBeGreaterThan(2);
     return { usageStats };
@@ -935,7 +933,6 @@ describe("runEmbeddedAgent auth profile rotation", () => {
       runId: "run:overloaded-rotation",
     });
     expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
-    expect(computeBackoffMock).not.toHaveBeenCalled();
   });
 
   it("logs structured failover decision metadata for overloaded assistant rotation", async () => {
@@ -989,7 +986,6 @@ describe("runEmbeddedAgent auth profile rotation", () => {
       runId: "run:overloaded-prompt-rotation",
     });
     expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
-    expect(computeBackoffMock).not.toHaveBeenCalled();
   });
 
   it("marks inline provider api key billing prompt failures without an auth profile", async () => {
@@ -1040,7 +1036,6 @@ describe("runEmbeddedAgent auth profile rotation", () => {
     const lastFailureAt = failedProfile?.lastFailureAt;
     expect(lastFailureAt).toBeTypeOf("number");
     expect(failedProfile?.cooldownUntil).toBe(lastFailureAt! + 30_000);
-    expect(computeBackoffMock).not.toHaveBeenCalled();
   });
 
   it("rotates on bare service unavailable without cooling down the profile", async () => {

--- a/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   classifyEmbeddedAgentRunResultForModelFallback,
@@ -17,9 +17,9 @@ import {
   makeEmbeddedRunnerAttempt,
 } from "./test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import {
-  installEmbeddedRunnerBackoffE2eMocks,
   installEmbeddedRunnerBaseE2eMocks,
   installEmbeddedRunnerFastRunE2eMocks,
+  installEmbeddedRunnerRetrySleepE2eMocks,
 } from "./test-helpers/embedded-agent-runner-e2e-mocks.js";
 
 type ProviderFault =
@@ -52,6 +52,7 @@ const runEmbeddedAttemptMock = vi.fn<(params: unknown) => Promise<EmbeddedRunAtt
 const { sleepWithAbortMock } = vi.hoisted(() => ({
   sleepWithAbortMock: vi.fn(async (_ms: number, _abortSignal?: AbortSignal) => undefined),
 }));
+let mathRandomMock: ReturnType<typeof vi.spyOn> | undefined;
 
 vi.mock("./models-config.js", async () => {
   const actual = await vi.importActual<typeof import("./models-config.js")>("./models-config.js");
@@ -72,8 +73,7 @@ beforeAll(async () => {
   installEmbeddedRunnerFastRunE2eMocks({
     runEmbeddedAttempt: (params) => runEmbeddedAttemptMock(params),
   });
-  installEmbeddedRunnerBackoffE2eMocks({
-    computeBackoff: () => 0,
+  installEmbeddedRunnerRetrySleepE2eMocks({
     sleepWithAbort: (ms, abortSignal) => sleepWithAbortMock(ms, abortSignal),
   });
   vi.doMock("./embedded-agent-runner/model.js", () => ({
@@ -90,8 +90,14 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  mathRandomMock = vi.spyOn(Math, "random").mockReturnValue(0);
   runEmbeddedAttemptMock.mockReset();
   sleepWithAbortMock.mockClear();
+});
+
+afterEach(() => {
+  mathRandomMock?.mockRestore();
+  mathRandomMock = undefined;
 });
 
 function makeProviderConfig(fallbacks: string[]): OpenClawConfig {

--- a/src/agents/model-fallback.reply-entry.e2e.test.ts
+++ b/src/agents/model-fallback.reply-entry.e2e.test.ts
@@ -1,6 +1,6 @@
 // Proves the pinned fallback decision survives the complete reply-entry path.
 import path from "node:path";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../auto-reply/templating.js";
 import {
   clearRuntimeConfigSnapshot,
@@ -22,23 +22,18 @@ import {
   makeEmbeddedRunnerAttempt,
 } from "./test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import {
-  installEmbeddedRunnerBackoffE2eMocks,
   installEmbeddedRunnerBaseE2eMocks,
   installEmbeddedRunnerFastRunE2eMocks,
+  installEmbeddedRunnerRetrySleepE2eMocks,
 } from "./test-helpers/embedded-agent-runner-e2e-mocks.js";
 
 const runEmbeddedAttemptMock = vi.fn<(params: unknown) => Promise<EmbeddedRunAttemptResult>>();
 const emptyPluginRegistry = createEmptyPluginRegistry();
 const suspendSessionMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-const { computeBackoffMock, sleepWithAbortMock } = vi.hoisted(() => ({
-  computeBackoffMock: vi.fn(
-    (
-      _policy: { initialMs: number; maxMs: number; factor: number; jitter: number },
-      _attempt: number,
-    ) => 321,
-  ),
+const { sleepWithAbortMock } = vi.hoisted(() => ({
   sleepWithAbortMock: vi.fn(async (_ms: number, _abortSignal?: AbortSignal) => undefined),
 }));
+let mathRandomMock: ReturnType<typeof vi.spyOn> | undefined;
 
 vi.mock("./models-config.js", () => ({
   ensureOpenClawModelsJson: vi.fn(async () => ({ wrote: false })),
@@ -58,8 +53,7 @@ function installReplyEntryMocks() {
   installEmbeddedRunnerFastRunE2eMocks({
     runEmbeddedAttempt: (params) => runEmbeddedAttemptMock(params),
   });
-  installEmbeddedRunnerBackoffE2eMocks({
-    computeBackoff: (policy, attempt) => computeBackoffMock(policy, attempt),
+  installEmbeddedRunnerRetrySleepE2eMocks({
     sleepWithAbort: (ms, abortSignal) => sleepWithAbortMock(ms, abortSignal),
   });
   vi.doMock("./embedded-agent-runner/model.js", () => ({
@@ -84,12 +78,17 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  mathRandomMock = vi.spyOn(Math, "random").mockReturnValue(0);
   vi.stubEnv("OPENCLAW_ALLOW_SLOW_REPLY_TESTS", "1");
   resetFallbackSkipCacheForTest();
   runEmbeddedAttemptMock.mockReset();
   suspendSessionMock.mockClear();
-  computeBackoffMock.mockClear();
   sleepWithAbortMock.mockClear();
+});
+
+afterEach(() => {
+  mathRandomMock?.mockRestore();
+  mathRandomMock = undefined;
 });
 
 function countProviderAttempts(provider: string): number {

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -1,5 +1,5 @@
 // Exercises model fallback through the embedded runner integration surface.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { wrapRunWithTestPreparedAdmission } from "./admitted-run-context.test-support.js";
 import type { ModelFallbackAvailability } from "./agent-scope.js";
@@ -22,9 +22,9 @@ import {
   makeEmbeddedRunnerAttempt,
 } from "./test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import {
-  installEmbeddedRunnerBackoffE2eMocks,
   installEmbeddedRunnerBaseE2eMocks,
   installEmbeddedRunnerFastRunE2eMocks,
+  installEmbeddedRunnerRetrySleepE2eMocks,
 } from "./test-helpers/embedded-agent-runner-e2e-mocks.js";
 
 const runEmbeddedAttemptMock = vi.fn<(params: unknown) => Promise<EmbeddedRunAttemptResult>>();
@@ -33,15 +33,10 @@ const observedModelRoutingProvenance: Array<{
   fallbackReason?: string;
 }> = [];
 const suspendSessionMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-const { computeBackoffMock, sleepWithAbortMock } = vi.hoisted(() => ({
-  computeBackoffMock: vi.fn(
-    (
-      _policy: { initialMs: number; maxMs: number; factor: number; jitter: number },
-      _attempt: number,
-    ) => 321,
-  ),
+const { sleepWithAbortMock } = vi.hoisted(() => ({
   sleepWithAbortMock: vi.fn(async (_ms: number, _abortSignal?: AbortSignal) => undefined),
 }));
+let mathRandomMock: ReturnType<typeof vi.spyOn> | undefined;
 
 vi.mock("./models-config.js", () => ({
   ensureOpenClawModelsJson: vi.fn(async () => ({ wrote: false })),
@@ -62,8 +57,7 @@ const installRunEmbeddedMocks = () => {
   installEmbeddedRunnerFastRunE2eMocks({
     runEmbeddedAttempt: (params) => runEmbeddedAttemptMock(params),
   });
-  installEmbeddedRunnerBackoffE2eMocks({
-    computeBackoff: (policy, attempt) => computeBackoffMock(policy, attempt),
+  installEmbeddedRunnerRetrySleepE2eMocks({
     sleepWithAbort: (ms, abortSignal) => sleepWithAbortMock(ms, abortSignal),
   });
   vi.doMock("./embedded-agent-runner/model.js", () => ({
@@ -100,12 +94,17 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  mathRandomMock = vi.spyOn(Math, "random").mockReturnValue(0);
   resetFallbackSkipCacheForTest();
   observedModelRoutingProvenance.length = 0;
   runEmbeddedAttemptMock.mockReset();
   suspendSessionMock.mockClear();
-  computeBackoffMock.mockClear();
   sleepWithAbortMock.mockClear();
+});
+
+afterEach(() => {
+  mathRandomMock?.mockRestore();
+  mathRandomMock = undefined;
 });
 
 const OVERLOADED_ERROR_PAYLOAD =
@@ -678,7 +677,6 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       expect(countProviderAttempts("azure-foundry")).toBeGreaterThan(0);
       expect(countProviderAttempts("openai")).toBe(0);
       expect(countProviderAttempts("groq")).toBe(1);
-      expect(computeBackoffMock).not.toHaveBeenCalled();
       expect(sleepWithAbortMock).not.toHaveBeenCalled();
     });
   });
@@ -706,8 +704,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       expect(typeof usageStats["groq:p1"]?.lastUsed).toBe("number");
 
       expectOpenAiThenGroqAttemptOrder({ primaryAttempts: 4 });
-      expect(computeBackoffMock).not.toHaveBeenCalled();
-      expect(sleepWithAbortMock).toHaveBeenCalledTimes(3);
+      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([500, 1_000, 2_000]);
     });
   });
 
@@ -731,7 +728,6 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       await withModelFallbackWorkspace(async ({ agentDir, workspaceDir }) => {
         await writeFallbackAuthStore(agentDir);
         runEmbeddedAttemptMock.mockClear();
-        computeBackoffMock.mockClear();
         sleepWithAbortMock.mockClear();
         mockPrimaryErrorThenFallbackSuccess(message);
 
@@ -753,8 +749,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
         expect(typeof usageStats["groq:p1"]?.lastUsed).toBe("number");
 
         expectOpenAiThenGroqAttemptOrder({ primaryAttempts: 4 });
-        expect(computeBackoffMock).not.toHaveBeenCalled();
-        expect(sleepWithAbortMock).toHaveBeenCalledTimes(3);
+        expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([500, 1_000, 2_000]);
       });
     }
   });
@@ -840,8 +835,9 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
         ...Array.from({ length: 4 }, () => ({ provider: "openai", authProfileId: "openai:p1" })),
         ...Array.from({ length: 4 }, () => ({ provider: "groq", authProfileId: "groq:p1" })),
       ]);
-      expect(computeBackoffMock).not.toHaveBeenCalled();
-      expect(sleepWithAbortMock).toHaveBeenCalledTimes(6);
+      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([
+        500, 1_000, 2_000, 500, 1_000, 2_000,
+      ]);
     });
   });
 
@@ -885,7 +881,6 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       expect(firstResult.provider).toBe("groq");
 
       runEmbeddedAttemptMock.mockClear();
-      computeBackoffMock.mockClear();
       sleepWithAbortMock.mockClear();
 
       mockPrimaryOverloadedThenFallbackSuccess();
@@ -903,8 +898,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       const usageStats = await readFallbackUsageStats(agentDir);
       expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
       expect(usageStats["openai:p1"]?.failureCounts?.overloaded).toBeUndefined();
-      expect(computeBackoffMock).not.toHaveBeenCalled();
-      expect(sleepWithAbortMock).toHaveBeenCalledTimes(3);
+      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([500, 1_000, 2_000]);
     });
   });
 
@@ -927,8 +921,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
       expect(usageStats["openai:p1"]?.failureCounts).toBeUndefined();
       expectOpenAiThenGroqAttemptOrder({ primaryAttempts: 4 });
-      expect(computeBackoffMock).not.toHaveBeenCalled();
-      expect(sleepWithAbortMock).toHaveBeenCalledTimes(3);
+      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([500, 1_000, 2_000]);
     });
   });
 
@@ -963,7 +956,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
         { provider: "openai", authProfileId: "openai:p2" },
         { provider: "groq", authProfileId: "groq:p1" },
       ]);
-      expect(sleepWithAbortMock).toHaveBeenCalledTimes(3);
+      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([500, 1_000, 2_000]);
     });
   });
 

--- a/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
+++ b/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
@@ -22,11 +22,7 @@ type EmbeddedRunnerFastRunMockOptions = {
   }) => unknown;
 };
 
-type EmbeddedRunnerBackoffMockOptions = {
-  computeBackoff: (
-    policy: { initialMs: number; maxMs: number; factor: number; jitter: number },
-    attempt: number,
-  ) => number;
+type EmbeddedRunnerRetrySleepMockOptions = {
   sleepWithAbort: (ms: number, abortSignal?: AbortSignal) => unknown;
 };
 
@@ -403,16 +399,17 @@ function resolveMockHarnessId(params: {
     : "openclaw";
 }
 
-/** Installs deterministic backoff mocks for retry/timeout E2E tests. */
-export function installEmbeddedRunnerBackoffE2eMocks(
-  options: EmbeddedRunnerBackoffMockOptions,
+/** Captures retry sleeps while leaving delay selection with the production owner. */
+export function installEmbeddedRunnerRetrySleepE2eMocks(
+  options: EmbeddedRunnerRetrySleepMockOptions,
 ): void {
-  vi.doMock("../../infra/backoff.js", () => ({
-    computeBackoff: (
-      policy: { initialMs: number; maxMs: number; factor: number; jitter: number },
-      attempt: number,
-    ) => options.computeBackoff(policy, attempt),
-    sleepWithAbort: (ms: number, abortSignal?: AbortSignal) =>
-      options.sleepWithAbort(ms, abortSignal),
-  }));
+  vi.doMock("../../infra/backoff.js", async () => {
+    const actual =
+      await vi.importActual<typeof import("../../infra/backoff.js")>("../../infra/backoff.js");
+    return {
+      ...actual,
+      sleepWithAbort: (ms: number, abortSignal?: AbortSignal) =>
+        options.sleepWithAbort(ms, abortSignal),
+    };
+  });
 }


### PR DESCRIPTION
Related: #134281

## What Problem This Solves

Resolves stale embedded-runner fault-sequence fixtures that still mocked the old backoff helper after retry timing moved to the transient retry owner. The stale helper contract also left sibling model-fallback E2E suites importing a removed mock installer.

## Why This Change Was Made

The fixtures now leave delay selection with `resolveTransientRetryDelayMs`, pin `Math.random()` only to make jitter deterministic, and capture `sleepWithAbort` calls for exact assertions. The mixed and exhausted fault chains provide four consecutive 500s so the current three same-model retries are exercised before model fallback. The two model-fallback E2E consumers now use the same retry-sleep helper instead of stale `computeBackoff` mocks.

## User Impact

No runtime behavior change. This keeps agent failover regression coverage aligned with the shipped retry owner so future failures point at the real boundary.

## Evidence

- `OPENCLAW_E2E_SKIP_BUILD=1 /usr/bin/time -l node scripts/run-vitest.mjs src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts src/agents/model-fallback.run-embedded.e2e.test.ts src/agents/model-fallback.reply-entry.e2e.test.ts` passed three bounded combined runs after the five-file fix: 62 tests each; wrapper times 148.98s, 122.06s, 196.33s.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/helpers.test.ts src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts src/agents/embedded-agent-runner/run.shared-integration.test.ts` passed: `run.shared-integration` 116 tests and `helpers`/`failover-retry-controller` 29 tests; 296.26s wrapper time.
- After rebasing onto `origin/main` `a4ad6c76a4d19ec47394f0a1905c749252d308c1`, `OPENCLAW_E2E_SKIP_BUILD=1 /usr/bin/time -l node scripts/run-vitest.mjs src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts src/agents/model-fallback.run-embedded.e2e.test.ts src/agents/model-fallback.reply-entry.e2e.test.ts` passed: 4 files, 62 tests, 129.20s wrapper time.
- `node_modules/.bin/oxfmt --write --threads=1 src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts src/agents/model-fallback.reply-entry.e2e.test.ts src/agents/model-fallback.run-embedded.e2e.test.ts`
- `git diff --check origin/main...HEAD`
- `rg -n "computeBackoff|installEmbeddedRunnerBackoffE2eMocks|sleepWithAbortMock\\)\\.toHaveBeenCalledTimes" src/agents/model-fallback.reply-entry.e2e.test.ts src/agents/model-fallback.run-embedded.e2e.test.ts src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts` returned no hits.

Notes: the default E2E pretest build path was blocked locally before Vitest by the managed pnpm cache containing the placeholder `pnpm` binary for the pinned package-manager version, so focused E2E runs used the repository's documented `OPENCLAW_E2E_SKIP_BUILD=1` path. Hosted Gateway shard proof was skipped after maintainer instruction; PR remains draft and unmerged.
