### PR TITLE
fix(ui): render stale progress cards as paused during later runs

### DIFF
--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -398,6 +398,23 @@ describe("renderSessionHovercard", () => {
     expect(container.textContent).not.toContain("This must not appear.");
   });
 
+  it("presents an older progress card as paused during a later run", () => {
+    const container = document.createElement("div");
+    const startedAt = Date.now();
+    render(
+      renderSessionHovercard({
+        row: row({ startedAt, status: "running" }),
+        progressCard: { ...progressCard(), updatedAt: startedAt - 1 },
+      }),
+      container,
+    );
+
+    const plan = container.querySelector(".session-hovercard__plan-row");
+    expect(plan?.getAttribute("aria-label")).toBe("Verify, paused");
+    expect(plan?.querySelector(".session-run-spinner")).toBeNull();
+    expect(plan?.querySelector("polyline")).not.toBeNull();
+  });
+
   it("pins a labeled markdown progress bar above the Agent Notepad copy", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -415,6 +415,22 @@ describe("renderSessionHovercard", () => {
     expect(plan?.querySelector("polyline")).not.toBeNull();
   });
 
+  it("keeps an older progress card paused after the later run ends", () => {
+    const container = document.createElement("div");
+    const startedAt = Date.now();
+    render(
+      renderSessionHovercard({
+        row: row({ startedAt, status: "done" }),
+        progressCard: { ...progressCard(), updatedAt: startedAt - 1 },
+      }),
+      container,
+    );
+
+    const plan = container.querySelector(".session-hovercard__plan-row");
+    expect(plan?.getAttribute("aria-label")).toBe("Verify, paused");
+    expect(plan?.querySelector(".session-run-spinner")).toBeNull();
+  });
+
   it("pins a labeled markdown progress bar above the Agent Notepad copy", () => {
     const container = document.createElement("div");
     render(
@@ -512,7 +528,7 @@ describe("renderSessionHovercard", () => {
   });
 
   it.each(["done", "failed", "timeout", "killed"] as const)(
-    "hides stale plan work after the session is %s",
+    "hides plan work updated during the run after the session is %s",
     (status) => {
       const container = document.createElement("div");
       render(

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -415,15 +415,18 @@ function renderHeader(input: SessionHovercardInput) {
 function renderProgressHeadsUp(
   card: ProgressCard | null | undefined,
   sessionStatus: SidebarSessionHovercardRow["status"],
+  startedAt: SidebarSessionHovercardRow["startedAt"],
 ) {
-  const headsUp = progressCardHeadsUp(card, sessionStatus);
+  const headsUp = progressCardHeadsUp(card, sessionStatus, startedAt);
   if (!headsUp) {
     return nothing;
   }
   const statusLabel = t(
     headsUp.step.status === "in_progress"
       ? "sessionProgressCard.status.inProgress"
-      : "sessionProgressCard.status.pending",
+      : headsUp.step.status === "paused"
+        ? "sessionProgressCard.status.paused"
+        : "sessionProgressCard.status.pending",
   );
   return html`<div
     class="session-hovercard__context-row session-hovercard__plan-row"
@@ -464,7 +467,7 @@ function renderSessionContext({ row, progressCard }: SessionHovercardInput) {
     !placementIdentity &&
     row?.boardFace !== "dashboard" &&
     row?.hasAutomation !== true &&
-    !progressCardHeadsUp(progressCard, row?.status)
+    !progressCardHeadsUp(progressCard, row?.status, row?.startedAt)
   ) {
     return nothing;
   }
@@ -535,7 +538,7 @@ function renderSessionContext({ row, progressCard }: SessionHovercardInput) {
           </div>`
         : nothing
     }
-    ${renderProgressHeadsUp(progressCard, row?.status)}
+    ${renderProgressHeadsUp(progressCard, row?.status, row?.startedAt)}
   </div>`;
 }
 
@@ -639,7 +642,7 @@ export function renderSessionHovercard(input: SessionHovercardInput) {
     (input.row?.placementProviderId && input.row.placementProfileId) ||
     input.row?.boardFace === "dashboard" ||
     input.row?.hasAutomation === true ||
-    progressCardHeadsUp(input.progressCard, input.row?.status),
+    progressCardHeadsUp(input.progressCard, input.row?.status, input.row?.startedAt),
   );
   const lastMessagePreview = input.progressCard
     ? undefined

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -422,9 +422,9 @@ function renderProgressHeadsUp(
     return nothing;
   }
   const statusLabel = t(
-    headsUp.step.status === "in_progress"
+    headsUp.status === "in_progress"
       ? "sessionProgressCard.status.inProgress"
-      : headsUp.step.status === "paused"
+      : headsUp.status === "paused"
         ? "sessionProgressCard.status.paused"
         : "sessionProgressCard.status.pending",
   );
@@ -432,19 +432,19 @@ function renderProgressHeadsUp(
     class="session-hovercard__context-row session-hovercard__plan-row"
     aria-label=${t("sessionProgressCard.stepLabel", {
       status: statusLabel,
-      step: headsUp.step.step,
+      step: headsUp.step,
     })}
-    title=${headsUp.step.step}
+    title=${headsUp.step}
   >
     <span class="session-hovercard__context-icon" aria-hidden="true"
       >${
-        headsUp.step.status === "in_progress"
+        headsUp.status === "in_progress"
           ? html`<span class="session-run-spinner"></span>`
           : icons.clock
       }</span
     >
     <span class="session-hovercard__context-value session-hovercard__plan-step"
-      >${headsUp.step.step}</span
+      >${headsUp.step}</span
     >
     <span class="session-hovercard__plan-count">${headsUp.completed}/${headsUp.total}</span>
   </div>`;

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -467,7 +467,33 @@ describe("renderSessionProgressCard", () => {
 
     expect(container.querySelector("time")?.textContent).toBe("Updated 3m ago");
     expect(container.querySelector("[data-outcome=failed]")).toBeNull();
-    expect(container.querySelector(".session-run-spinner")).not.toBeNull();
+    // The card predates this run, so its in-progress step renders paused
+    // rather than carrying a live session-run spinner.
+    expect(container.querySelector(".session-run-spinner")).toBeNull();
+    expect(container.querySelector(".session-progress-card__step--paused")).not.toBeNull();
+  });
+
+  it("renders a stale in-progress card as paused during a later active run", () => {
+    // Repro from #137188: a card whose task completed earlier flips back to a
+    // live spinner while a later, unrelated run executes in the same session.
+    const container = document.createElement("div");
+    render(
+      renderSessionProgressCard(
+        { ...progressCard, updatedAt: RUN_STARTED_MS - 1 },
+        "board",
+        undefined,
+        "running",
+        RUN_STARTED_MS,
+        undefined,
+        true,
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".session-run-spinner")).toBeNull();
+    const pausedStep = container.querySelector(".session-progress-card__step--paused");
+    expect(pausedStep).not.toBeNull();
+    expect(pausedStep?.getAttribute("aria-label")).toBe("Wire the checklist, paused");
   });
 
   it("falls back safely for timestamps outside the Date range", () => {

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -32,7 +32,7 @@ describe("renderSessionProgressCard", () => {
     vi.useRealTimers();
   });
 
-  it.each(["board", "composer", "hovercard"] as const)(
+  it.each(["board", "composer"] as const)(
     "shows relative activity for %s cards with and without checklist steps",
     (placement) => {
       const container = document.createElement("div");
@@ -44,7 +44,7 @@ describe("renderSessionProgressCard", () => {
         expect(timestamp?.getAttribute("datetime")).toBe(
           new Date(progressCard.updatedAt).toISOString(),
         );
-        expect(timestamp?.textContent).toBe(placement === "hovercard" ? "2m" : "Updated 2m ago");
+        expect(timestamp?.textContent).toBe("Updated 2m ago");
         expect(timestamp?.getAttribute("aria-label")).toBe("Updated 2m ago");
         expect(timestamp?.getAttribute("title")).toBe(timestamp?.getAttribute("aria-label"));
         const accessibleCard =
@@ -130,7 +130,7 @@ describe("renderSessionProgressCard", () => {
 
   it("renders sanitized markdown and one accessible typed checklist", () => {
     const container = document.createElement("div");
-    render(renderSessionProgressCard(progressCard, "hovercard"), container);
+    render(renderSessionProgressCard(progressCard, "board"), container);
 
     const card = container.querySelector(".session-progress-card");
     expect(card?.getAttribute("aria-label")).toBe("1 of 3 completed");
@@ -467,15 +467,11 @@ describe("renderSessionProgressCard", () => {
 
     expect(container.querySelector("time")?.textContent).toBe("Updated 3m ago");
     expect(container.querySelector("[data-outcome=failed]")).toBeNull();
-    // The card predates this run, so its in-progress step renders paused
-    // rather than carrying a live session-run spinner.
     expect(container.querySelector(".session-run-spinner")).toBeNull();
     expect(container.querySelector(".session-progress-card__step--paused")).not.toBeNull();
   });
 
   it("renders a stale in-progress card as paused during a later active run", () => {
-    // Repro from #137188: a card whose task completed earlier flips back to a
-    // live spinner while a later, unrelated run executes in the same session.
     const container = document.createElement("div");
     render(
       renderSessionProgressCard(

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -12,9 +12,6 @@ import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
 type SessionProgressCardPlacement = "board" | "composer";
 type PresentedProgressStepStatus = ProgressCardStep["status"] | "paused";
-type PresentedProgressStep = Omit<ProgressCardStep, "status"> & {
-  status: PresentedProgressStepStatus;
-};
 
 const STATUS_LABEL_KEYS: Record<ProgressCardStep["status"], Parameters<typeof t>[0]> = {
   completed: "sessionProgressCard.status.completed",
@@ -163,9 +160,10 @@ function progressCounts(card: ProgressCard): { completed: number; total: number 
   };
 }
 
-export type ProgressCardHeadsUp = {
+type ProgressCardHeadsUp = {
   completed: number;
-  step: PresentedProgressStep;
+  status: PresentedProgressStepStatus;
+  step: string;
   total: number;
 };
 
@@ -177,11 +175,9 @@ function unfinishedProgressStep(steps: readonly ProgressCardStep[]): ProgressCar
 }
 
 function isProgressCardStaleForRun(card: ProgressCard, startedAt?: number): boolean {
-  const validStartedAt = asDateTimestampMs(startedAt);
-  const validUpdatedAt = asDateTimestampMs(card.updatedAt);
-  return (
-    validStartedAt !== undefined && validUpdatedAt !== undefined && validUpdatedAt < validStartedAt
-  );
+  const runStart = asDateTimestampMs(startedAt);
+  const cardUpdate = asDateTimestampMs(card.updatedAt);
+  return runStart !== undefined && cardUpdate !== undefined && cardUpdate < runStart;
 }
 
 export function progressCardHeadsUp(
@@ -189,7 +185,8 @@ export function progressCardHeadsUp(
   sessionStatus?: SessionRunStatus,
   startedAt?: number,
 ): ProgressCardHeadsUp | null {
-  if (sessionStatus && TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus]) {
+  const staleForRun = card ? isProgressCardStaleForRun(card, startedAt) : false;
+  if (sessionStatus && TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus] && !staleForRun) {
     return null;
   }
   const counts = card ? progressCounts(card) : null;
@@ -200,16 +197,8 @@ export function progressCardHeadsUp(
   if (!step) {
     return null;
   }
-  return {
-    ...counts,
-    step: {
-      ...step,
-      status:
-        step.status === "in_progress" && isProgressCardStaleForRun(card, startedAt)
-          ? "paused"
-          : step.status,
-    },
-  };
+  const status = step.status === "in_progress" && staleForRun ? "paused" : step.status;
+  return { ...counts, status, step: step.step };
 }
 
 function currentProgressStep(steps: readonly ProgressCardStep[]): ProgressCardStep | undefined {

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -10,8 +10,11 @@ import { formatRelativeTimestamp } from "../lib/format.ts";
 import { icons } from "./icons.ts";
 import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
-type SessionProgressCardPlacement = "board" | "composer" | "hovercard";
+type SessionProgressCardPlacement = "board" | "composer";
 type PresentedProgressStepStatus = ProgressCardStep["status"] | "paused";
+type PresentedProgressStep = Omit<ProgressCardStep, "status"> & {
+  status: PresentedProgressStepStatus;
+};
 
 const STATUS_LABEL_KEYS: Record<ProgressCardStep["status"], Parameters<typeof t>[0]> = {
   completed: "sessionProgressCard.status.completed",
@@ -46,13 +49,11 @@ const TERMINAL_STEP_STATUS_LABEL_KEYS: Partial<Record<SessionRunStatus, Paramete
 class ProgressActivityTimeDirective extends AsyncDirective {
   private timestamp = 0;
   private labelKey: Parameters<typeof t>[0] = "sessionProgressCard.activity.updated";
-  private compact = false;
   private timer: ReturnType<typeof setInterval> | undefined;
 
-  render(timestamp: number, labelKey: Parameters<typeof t>[0], compact = false) {
+  render(timestamp: number, labelKey: Parameters<typeof t>[0]) {
     this.timestamp = timestamp;
     this.labelKey = labelKey;
-    this.compact = compact;
     if (this.isConnected) {
       this.startTimer();
     }
@@ -84,15 +85,11 @@ class ProgressActivityTimeDirective extends AsyncDirective {
 
   private renderTime() {
     const label = t(this.labelKey, { time: formatRelativeTimestamp(this.timestamp) });
-    const visibleLabel =
-      this.compact && this.labelKey === "sessionProgressCard.activity.updated"
-        ? formatRelativeTimestamp(this.timestamp, { suffix: false })
-        : label;
     return html`<time
       datetime=${new Date(this.timestamp).toISOString()}
       aria-label=${label}
       title=${label}
-      >${visibleLabel}</time
+      >${label}</time
     >`;
   }
 }
@@ -168,7 +165,7 @@ function progressCounts(card: ProgressCard): { completed: number; total: number 
 
 export type ProgressCardHeadsUp = {
   completed: number;
-  step: ProgressCardStep;
+  step: PresentedProgressStep;
   total: number;
 };
 
@@ -179,9 +176,18 @@ function unfinishedProgressStep(steps: readonly ProgressCardStep[]): ProgressCar
   );
 }
 
+function isProgressCardStaleForRun(card: ProgressCard, startedAt?: number): boolean {
+  const validStartedAt = asDateTimestampMs(startedAt);
+  const validUpdatedAt = asDateTimestampMs(card.updatedAt);
+  return (
+    validStartedAt !== undefined && validUpdatedAt !== undefined && validUpdatedAt < validStartedAt
+  );
+}
+
 export function progressCardHeadsUp(
   card: ProgressCard | null | undefined,
   sessionStatus?: SessionRunStatus,
+  startedAt?: number,
 ): ProgressCardHeadsUp | null {
   if (sessionStatus && TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus]) {
     return null;
@@ -194,7 +200,16 @@ export function progressCardHeadsUp(
   if (!step) {
     return null;
   }
-  return { ...counts, step };
+  return {
+    ...counts,
+    step: {
+      ...step,
+      status:
+        step.status === "in_progress" && isProgressCardStaleForRun(card, startedAt)
+          ? "paused"
+          : step.status,
+    },
+  };
 }
 
 function currentProgressStep(steps: readonly ProgressCardStep[]): ProgressCardStep | undefined {
@@ -351,16 +366,8 @@ export function renderSessionProgressCard(
     validEndedAt >= validStartedAt &&
     validUpdatedAt !== undefined &&
     validUpdatedAt >= validStartedAt;
-  // A card whose last update predates the current run cannot describe that
-  // run's work. Render its in-progress steps as paused (stale) instead of
-  // live, even while a run is in flight, so a later unrelated run does not
-  // revive a completed task's spinner.
-  const staleCard =
-    hasActiveRun &&
-    validStartedAt !== undefined &&
-    validUpdatedAt !== undefined &&
-    validUpdatedAt < validStartedAt;
-  const effectiveHasActiveRun = staleCard ? false : hasActiveRun;
+  // A later run does not own durable progress last updated before it started.
+  const effectiveHasActiveRun = hasActiveRun && !isProgressCardStaleForRun(card, startedAt);
   const terminalTimestamp =
     sessionStatus && TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus] && hasValidRunWindow
       ? validEndedAt
@@ -374,11 +381,7 @@ export function renderSessionProgressCard(
     ? ACTIVITY_LABEL_KEYS[sessionStatus!]
     : "sessionProgressCard.activity.updated";
   const accessibleLabel = countLabel;
-  const lastActivity = progressActivityTime(
-    activityTimestamp,
-    activityKey,
-    placement === "hovercard",
-  );
+  const lastActivity = progressActivityTime(activityTimestamp, activityKey);
   const dismissible = Boolean(
     onDismiss && card.steps?.length && card.steps.every((step) => step.status === "completed"),
   );

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -351,6 +351,16 @@ export function renderSessionProgressCard(
     validEndedAt >= validStartedAt &&
     validUpdatedAt !== undefined &&
     validUpdatedAt >= validStartedAt;
+  // A card whose last update predates the current run cannot describe that
+  // run's work. Render its in-progress steps as paused (stale) instead of
+  // live, even while a run is in flight, so a later unrelated run does not
+  // revive a completed task's spinner.
+  const staleCard =
+    hasActiveRun &&
+    validStartedAt !== undefined &&
+    validUpdatedAt !== undefined &&
+    validUpdatedAt < validStartedAt;
+  const effectiveHasActiveRun = staleCard ? false : hasActiveRun;
   const terminalTimestamp =
     sessionStatus && TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus] && hasValidRunWindow
       ? validEndedAt
@@ -410,7 +420,7 @@ export function renderSessionProgressCard(
         })
       : nothing;
     const presentedCurrentStatus =
-      currentStep?.status === "in_progress" && !hasActiveRun && !terminalOutcomeKey
+      currentStep?.status === "in_progress" && !effectiveHasActiveRun && !terminalOutcomeKey
         ? "paused"
         : currentStep?.status;
     const summaryIndicator =
@@ -483,7 +493,7 @@ export function renderSessionProgressCard(
       </summary>
       <div class="session-progress-card__body" role="region" aria-label=${composerCountLabel}>
         ${renderProgressCardMarkdown(card.markdown)}
-        ${renderSteps(card, hasActiveRun, effectiveSessionStatus)}
+        ${renderSteps(card, effectiveHasActiveRun, effectiveSessionStatus)}
       </div>
     </details>`;
   }
@@ -500,6 +510,6 @@ export function renderSessionProgressCard(
         >${dismiss}
       </span>
     </div>
-    ${renderBody(card, hasActiveRun, effectiveSessionStatus)}
+    ${renderBody(card, effectiveHasActiveRun, effectiveSessionStatus)}
   </section>`;
 }

--- a/ui/src/e2e/session-progress-widget.e2e.test.ts
+++ b/ui/src/e2e/session-progress-widget.e2e.test.ts
@@ -36,6 +36,7 @@ suite.define(() => {
           "chat.metadata",
           "chat.startup",
           "progressCard.get",
+          "sessions.list",
           "sessions.patch",
         ],
         methodResponses: {

--- a/ui/src/e2e/session-progress-widget.e2e.test.ts
+++ b/ui/src/e2e/session-progress-widget.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   controlUiSessionUrl,
   installMockGateway,
 } from "../test-helpers/control-ui-e2e.ts";
+import { chatSessionListResponse } from "./chat-flow.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -19,8 +20,12 @@ beforeEach(() => {
 });
 
 suite.define(() => {
-  it("renders the live session progress card through an advertised dashboard kind", async () => {
-    await suite.withPage({ viewport: { height: 900, width: 1280 } }, async ({ page }) => {
+  it.each([
+    { height: 900, name: "desktop", width: 1440 },
+    { height: 844, name: "mobile", width: 390 },
+  ])("keeps an older progress card paused during a later run on $name", async (viewport) => {
+    await suite.withPage({ viewport }, async ({ page }) => {
+      const now = Date.now();
       const gateway = await installMockGateway(page, {
         sessionKey,
         controlUiWidgetKinds: [
@@ -57,15 +62,26 @@ suite.define(() => {
             card: {
               sessionKey,
               revision: 3,
-              updatedAt: 3,
-              markdown: "**Dashboard tile** follows the live session card.",
+              updatedAt: now - 5 * 60_000,
+              markdown: "**Earlier task** remains available for reference.",
               steps: [
-                { step: "Inspect dashboard seams", status: "completed" },
-                { step: "Render the progress tile", status: "in_progress" },
-                { step: "Capture browser proof", status: "pending" },
+                { step: "Finish the earlier task", status: "completed" },
+                { step: "Archive the earlier checklist", status: "in_progress" },
+                { step: "Start unrelated work", status: "pending" },
               ],
             },
           },
+          "sessions.list": chatSessionListResponse([
+            {
+              hasActiveRun: true,
+              key: sessionKey,
+              kind: "direct",
+              label: "Later active run",
+              startedAt: now - 60_000,
+              status: "running",
+              updatedAt: now,
+            },
+          ]),
         },
       });
       const storageKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
@@ -83,10 +99,8 @@ suite.define(() => {
       const card = page.locator('[data-progress-card-placement="board"]');
       await card.waitFor();
       expect(await card.locator("iframe").count()).toBe(0);
-      await expect.poll(() => card.textContent()).toContain("Dashboard tile");
-      await expect.poll(() => card.textContent()).toContain("Inspect dashboard seams");
-      await expect.poll(() => card.textContent()).toContain("Render the progress tile");
-      await expect.poll(() => card.textContent()).toContain("Capture browser proof");
+      await expect.poll(() => card.textContent()).toContain("Earlier task");
+      await expect.poll(() => card.textContent()).toContain("Archive the earlier checklist");
       await expect
         .poll(() => card.locator(".session-progress-card__heading").textContent())
         .toContain("1/3");
@@ -95,8 +109,12 @@ suite.define(() => {
       await page.screenshot({
         animations: "disabled",
         fullPage: true,
-        path: path.join(proofDir, "session-progress-widget.png"),
+        path: path.join(proofDir, `session-progress-widget-${viewport.name}.png`),
       });
+      expect(await card.locator(".session-run-spinner").count()).toBe(0);
+      const paused = card.locator(".session-progress-card__step--paused");
+      expect(await paused.count()).toBe(1);
+      expect(await paused.getAttribute("aria-label")).toBe("Archive the earlier checklist, paused");
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

A session progress card whose task completed earlier still rendered its `in_progress` step with the live session-run spinner while a later, unrelated run executed in the same session. The card asserted an in-progress task that no longer existed, and nothing corrected it until the run finished or the card was dismissed.

On the board surface the shared renderer's `paused` branch was unreachable for this case: `hasActiveRun` defaults to `true`, and the terminal branch requires a terminal `sessionStatus` (false while a run is in flight). The sidebar hovercard independently projected the same stale step as live work.

Related: #137188. This PR fixes the stale-during-later-run path; it does not close the broader issue, which also tracks idle board reconciliation.

## Approach

The progress-card owner now compares the card's `updatedAt` with the current run's `startedAt`. When both timestamps are valid and the card predates the run, its durable `in_progress` step is presented as paused rather than live.

- The board and composer renderer use the canonical stale-run decision before selecting step markers.
- The sidebar hovercard uses the same decision and exposes the paused state in both its icon and accessible label, including after the unrelated later run reaches a terminal state.
- Missing or invalid timestamps retain the existing behavior; terminal outcome correlation remains scoped to a valid run window.
- The obsolete full-card `hovercard` renderer mode and its compact-time branch were removed. The current sidebar hovercard has its own heads-up renderer, so those paths had no production caller.
- The mocked-Gateway browser scenario advertises and serves `sessions.list`, then covers the real board wiring at desktop and mobile widths.
- The branch is rebased across #137569 and preserves its composer disclosure lifecycle: a new run can still collapse the existing card while timestamp ownership independently controls whether its step appears live or paused.

This keeps the repair at the presentation owner. It does not mutate cards, alter session lifecycle state, or add a second reconciliation path.

## User Impact

Starting unrelated work in a session no longer revives an older checklist spinner. The earlier checklist remains visible for context, but its unfinished step uses the paused clock marker on the board, in the composer, and in the sidebar hovercard.

## Evidence

The browser regression runs against a production Control UI bundle with a mocked Gateway. The pre-fix bundle captured both views and then failed because one live spinner remained; the final bundle passed with one paused step and no spinner.

| View | Before | In this PR |
| --- | --- | --- |
| Desktop, 1440×900 | [![Before: the earlier board checklist shows a live circular spinner during the later run](https://github.com/user-attachments/assets/175750b5-edc0-4a9f-9234-4a6ba275b9f3)](https://github.com/user-attachments/assets/175750b5-edc0-4a9f-9234-4a6ba275b9f3) | [![After: the earlier board checklist shows a paused clock during the later run](https://github.com/user-attachments/assets/480895d8-4a12-4ce4-96c7-e1e577f08d25)](https://github.com/user-attachments/assets/480895d8-4a12-4ce4-96c7-e1e577f08d25) |
| Mobile, 390×844 | [![Before on mobile: the earlier checklist shows a live circular spinner](https://github.com/user-attachments/assets/dd9a241a-16d2-44c3-bea7-9a492263d0e6)](https://github.com/user-attachments/assets/dd9a241a-16d2-44c3-bea7-9a492263d0e6) | [![After on mobile: the earlier checklist shows a paused clock](https://github.com/user-attachments/assets/683d01da-bc6a-4f35-8c91-d2b18bc4e8f7)](https://github.com/user-attachments/assets/683d01da-bc6a-4f35-8c91-d2b18bc4e8f7) |

- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test ui/src/components/session-progress-card.test.ts ui/src/components/session-hovercard.test.ts` — 68 passed after the final rebase (the prior 65, two #137569 lifecycle cases, and the new terminal-later-run regression).
- `OPENCLAW_UI_E2E_ARTIFACT_DIR=/tmp/openclaw-137323-d7418a OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:ui:e2e ui/src/e2e/session-progress-widget.e2e.test.ts` — 2 passed; production bundle built successfully and both final captures were inspected.
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed` — passed, including format, UI/core-test typechecks, i18n, lint, and dead-export scans.

Production LOC: +5 net (`session-progress-card.ts` +2, `session-hovercard.ts` +3). The remaining growth is the shared timestamp ownership decision plus the sidebar hovercard consumer; removing the dead full-card hovercard path absorbed the original renderer-only growth. Tests: +74 net, including the board E2E at two viewports and terminal hovercard ownership coverage.

## ClawSweeper follow-up

The durable ClawSweeper review comment was last updated at `2026-09-04T02:52:51Z` and reviewed the final head `d7418a17214769ab4a1133ab3b26b6179800c325`. It reports no actionable correctness or security finding, accepts the supplied screenshot-backed browser proof, and leaves one maintainer merge-risk decision: the justified net +5 production lines for the shared timestamp owner and hovercard consumer.

- Its earlier closing-keyword concern is fixed: the contributor commit ends with `Refs #137188`, not a closing keyword.
- Its earlier rebase concern is fixed: this branch is based on `d84cdc5c03d378c0f50db1b0abb17537f390b01c`, which contains #137569, and the component, browser, changed-surface, and autoreview gates were rerun.
- The +5 production-line tradeoff is explicit: the canonical timestamp fence and sibling hovercard consumer are the required behavior; removing the obsolete full-card hovercard path absorbed the avoidable growth. Maintainers retain the merge decision.
- No separate live-Gateway claim is made. The production Control UI mock-Gateway harness and supplied desktop/mobile captures exercise the changed board path and satisfy the repository real-behavior gate for this presentation-only change.

## Scope

The change is limited to Control UI progress-card presentation and its tests. It does not change Gateway protocol, session lifecycle production code, persistence, configuration, or card cleanup semantics.

Original diagnosis and renderer fix by @gaoanze888. Reported by @Richard355168.

## Risk and coverage

- Current-run cards still show the live spinner: staleness is established only when both timestamps are valid and `card.updatedAt < run.startedAt`.
- Terminal markers and outcome wording still require the existing valid run window; an older card is not hidden or assigned the outcome of a later terminal run.
- Missing and out-of-range timestamps preserve the old fallback behavior instead of guessing ownership.
- A checklist last updated in a prior turn appears paused from the next run's start until the agent updates that card again. That is the intended ownership rule, including for a still-relevant plan carried across turns.
- #137569's collapse/expand lifecycle remains independent: starting a new run still collapses the existing composer card when the operator enabled that setting.
- The board subscription and progress-card store were not changed; the browser test proves initial projection through the actual widget boundary, but does not add a separate event-refresh scenario.
- #137188 remains open for the distinct idle-board case where no later active run supplies a newer `startedAt`.


