### PR TITLE
test(doctor): reuse canonical transcript call guard

### DIFF
--- a/src/commands/doctor-session-transcripts.test.ts
+++ b/src/commands/doctor-session-transcripts.test.ts
@@ -81,14 +81,6 @@ function countNonEmptyLines(value: string): number {
   return count;
 }
 
-function requireFirstMockCall<T>(mock: { mock: { calls: T[][] } }, label: string): T[] {
-  const call = mock.mock.calls[0];
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call;
-}
-
 describe("doctor session transcript repair", () => {
   let root: string;
 
@@ -350,7 +342,10 @@ describe("doctor session transcript repair", () => {
     await noteSessionTranscriptHealth({ shouldRepair: false, sessionDirs: [sessionsDir] });
 
     expect(note).toHaveBeenCalledTimes(1);
-    const [message, title] = requireFirstMockCall(note, "doctor note") as [string, string];
+    const [message, title] = expectDefined<unknown[]>(note.mock.calls[0], "doctor note") as [
+      string,
+      string,
+    ];
     expect(title).toBe("Session transcripts");
     expect(message).toContain("legacy state");
     expect(message).toContain('Run "openclaw doctor --fix"');


### PR DESCRIPTION
Replace the single-use Doctor transcript mock-call guard with the existing `expectDefined<unknown[]>` helper. The test still selects the first call and preserves the note title, repair guidance, and original-file assertions. All 25 transcript cases remain, including backup failures, read-only inspection, and SQLite migration ordering. No production code changes.

Validation: the complete transcript and shared-helper suites passed 29 tests before and after with identical expanded names and order. The normal local changed-file gate and a fresh independent Codex review through P2 passed. Test delta: +4/-9 lines.
