### PR TITLE
fix(msteams,signal): authorize registered plugin commands

### DIFF
--- a/extensions/msteams/src/monitor-handler/access.ts
+++ b/extensions/msteams/src/monitor-handler/access.ts
@@ -118,7 +118,7 @@ function formatMSTeamsSenderReason(params: {
 export async function resolveMSTeamsSenderAccess(params: {
   cfg: OpenClawConfig;
   activity: MSTeamsTurnContext["activity"];
-  hasControlCommand?: boolean;
+  shouldComputeCommandAuthorized?: boolean;
   conversationThreadId?: string;
   contextBinding?: ChannelIngressContextBinding;
 }) {
@@ -220,7 +220,7 @@ export async function resolveMSTeamsSenderAccess(params: {
     groupAllowFrom,
     command: {
       allowTextCommands: true,
-      hasControlCommand: params.hasControlCommand === true,
+      hasControlCommand: params.shouldComputeCommandAuthorized === true,
       directGroupAllowFrom: isDirectMessage ? "effective" : "none",
     },
   });
@@ -258,10 +258,13 @@ export async function admitMSTeamsMessage(params: {
   });
   const isControlCommand =
     allowTextCommands && core.channel.commands.isControlCommandMessage(params.text, params.cfg);
+  const shouldComputeCommandAuthorized =
+    allowTextCommands &&
+    core.channel.commands.shouldComputeCommandAuthorized(params.text, params.cfg);
   const access = await resolveMSTeamsSenderAccess({
     cfg: params.cfg,
     activity: params.activity,
-    hasControlCommand: isControlCommand,
+    shouldComputeCommandAuthorized,
   });
   const {
     dmPolicy,
@@ -394,7 +397,7 @@ export async function admitMSTeamsMessage(params: {
     }
   }
 
-  if (commandAccess.shouldBlockControlCommand) {
+  if (isControlCommand && !commandAccess.authorized) {
     logInboundDrop({
       log: params.logVerboseMessage,
       channel: "msteams",
@@ -416,6 +419,7 @@ export async function admitMSTeamsMessage(params: {
     ...access,
     allowTextCommands,
     isControlCommand,
+    shouldComputeCommandAuthorized,
     commandAuthorized: commandAccess.requested ? commandAccess.authorized : undefined,
     effectiveDmAllowFrom,
     effectiveGroupAllowFrom,

--- a/extensions/msteams/src/monitor-handler/inbound-dispatch.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-dispatch.ts
@@ -149,7 +149,7 @@ export async function dispatchMSTeamsInboundTurn(params: {
   const boundIngress = await resolveMSTeamsSenderAccess({
     cfg,
     activity,
-    hasControlCommand: admission.isControlCommand,
+    shouldComputeCommandAuthorized: admission.shouldComputeCommandAuthorized,
     conversationThreadId: facts.threadId,
     contextBinding: {
       agentId: route.agentId,

--- a/extensions/msteams/src/monitor-handler/message-handler.conversation-authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.conversation-authz.test.ts
@@ -2,8 +2,9 @@
 import { once } from "node:events";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
-import { describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../../runtime-api.js";
+import { clearPluginCommands, registerPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig, PluginRuntime } from "../../runtime-api.js";
 // Preserve module setup before modules that consume it.
 // oxfmt-ignore
 import { getRuntimeApiMockState } from "./message-handler-mock-support.test-support.js";
@@ -34,7 +35,13 @@ vi.mock("../team-identity.js", () => ({
   resolveTeamGroupId: vi.fn(async () => "group-1"),
 }));
 
-function createDeps(cfg: OpenClawConfig) {
+function createDeps(
+  cfg: OpenClawConfig,
+  options: {
+    isControlCommandMessage?: PluginRuntime["channel"]["commands"]["isControlCommandMessage"];
+    shouldComputeCommandAuthorized?: PluginRuntime["channel"]["commands"]["shouldComputeCommandAuthorized"];
+  } = {},
+) {
   return createMessageHandlerDeps(cfg, {
     readAllowFromStore: vi.fn(async () => ["attacker-aad"]),
     upsertPairingRequest: vi.fn(async () => null),
@@ -44,6 +51,8 @@ function createDeps(cfg: OpenClawConfig) {
       agentId: "default",
       accountId: "default",
     })),
+    isControlCommandMessage: options.isControlCommandMessage,
+    shouldComputeCommandAuthorized: options.shouldComputeCommandAuthorized,
   });
 }
 
@@ -119,6 +128,72 @@ async function dispatchBotFrameworkActivityOverHttp(params: {
 }
 
 describe("msteams group conversation allowlist authorization", () => {
+  afterEach(() => {
+    clearPluginCommands();
+  });
+
+  it("carries the final authorization boundary for allowed and unauthorized registered commands", async () => {
+    runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher.mockClear();
+    registerPluginCommand("msteams-test-plugin", {
+      name: "msteams-plugin-auth",
+      description: "Test Microsoft Teams plugin command authorization.",
+      acceptsArgs: true,
+      handler: async () => ({ text: "ok" }),
+    });
+    const { deps } = createDeps(
+      {
+        commands: { useAccessGroups: true },
+        channels: {
+          msteams: {
+            groupPolicy: "open",
+            groupAllowFrom: ["member-aad"],
+            requireMention: false,
+          },
+        },
+      } as OpenClawConfig,
+      {
+        isControlCommandMessage: vi.fn(() => false),
+        shouldComputeCommandAuthorized: vi.fn(() => true),
+      },
+    );
+    const handler = createMSTeamsMessageHandler(deps);
+
+    await handler(
+      createMessageActivity({
+        id: "allowed-plugin-command-message",
+        text: "/msteams-plugin-auth check",
+        from: { id: "member-bot-framework-id", aadObjectId: "member-aad", name: "Group Member" },
+        conversation: { id: "19:group@thread.tacv2", conversationType: "groupChat" },
+      }),
+    );
+    await handler(
+      createMessageActivity({
+        id: "unauthorized-plugin-command-message",
+        text: "/msteams-plugin-auth check",
+        from: {
+          id: "unlisted-bot-framework-id",
+          aadObjectId: "unlisted-aad",
+          name: "Unlisted Member",
+        },
+        conversation: { id: "19:group@thread.tacv2", conversationType: "groupChat" },
+      }),
+    );
+
+    const dispatched = runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher.mock.calls.map(
+      ([params]) => params as { ctx?: { CommandAuthorized?: boolean; SenderId?: string } },
+    );
+    expect(dispatched).toHaveLength(2);
+    expect(
+      dispatched.map(({ ctx }) => ({
+        CommandAuthorized: ctx?.CommandAuthorized,
+        SenderId: ctx?.SenderId,
+      })),
+    ).toEqual([
+      { CommandAuthorized: true, SenderId: "member-aad" },
+      { CommandAuthorized: false, SenderId: "unlisted-aad" },
+    ]);
+  });
+
   it.each([
     {
       label: "a group chat",

--- a/extensions/signal/src/monitor/access-policy.test.ts
+++ b/extensions/signal/src/monitor/access-policy.test.ts
@@ -254,7 +254,7 @@ describe("resolveSignalAccessState", () => {
       sender: SIGNAL_SENDER,
       groupId: SIGNAL_GROUP_ID,
       isGroup: true,
-      hasControlCommand: true,
+      shouldComputeCommandAuthorized: true,
     });
 
     expect(access.senderAccess.decision).toBe("allow");
@@ -272,7 +272,7 @@ describe("resolveSignalAccessState", () => {
       sender: SIGNAL_SENDER,
       groupId: SIGNAL_GROUP_ID,
       isGroup: true,
-      hasControlCommand: true,
+      shouldComputeCommandAuthorized: true,
     });
 
     expect(access.commandAccess.authorized).toBe(true);
@@ -289,7 +289,7 @@ describe("resolveSignalAccessState", () => {
       sender: resolveAliasedSignalSender(),
       groupId: SIGNAL_GROUP_ID,
       isGroup: true,
-      hasControlCommand: true,
+      shouldComputeCommandAuthorized: true,
     });
 
     expect(access.senderAccess.decision).toBe("allow");

--- a/extensions/signal/src/monitor/access-policy.ts
+++ b/extensions/signal/src/monitor/access-policy.ts
@@ -120,13 +120,13 @@ export async function resolveSignalAccessState(params: {
   groupId?: string;
   isGroup?: boolean;
   cfg?: Pick<OpenClawConfig, "accessGroups" | "commands">;
-  hasControlCommand?: boolean;
+  shouldComputeCommandAuthorized?: boolean;
   readStoreAllowFrom?: () => Promise<string[]>;
   contextBinding?: ChannelIngressContextBinding;
 }) {
   const isGroup = params.isGroup ?? params.groupId != null;
   const command =
-    params.hasControlCommand === true
+    params.shouldComputeCommandAuthorized === true
       ? {
           allowTextCommands: true,
           directGroupAllowFrom: "effective" as const,

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -1,8 +1,9 @@
 // Signal tests cover event handler.inbound context plugin behavior.
 import { expectChannelInboundContextContract as expectInboundContextContract } from "openclaw/plugin-sdk/channel-contract-testing";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { clearPluginCommands, registerPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveSignalReplyContextWithPersistence } from "../reply-authors.js";
 import { resetSignalReplyAuthorsForTests } from "../reply-authors.test-helpers.js";
 import type {
@@ -452,6 +453,10 @@ describe("signal createSignalEventHandler inbound context", () => {
     logVerboseMock.mockClear();
     shouldLogVerboseMock.mockReset().mockReturnValue(false);
     approvalReactionMocks.maybeResolveSignalApprovalReaction.mockReset().mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    clearPluginCommands();
   });
 
   it("passes a finalized MsgContext to dispatchInboundMessage", async () => {
@@ -1298,6 +1303,29 @@ describe("signal createSignalEventHandler inbound context", () => {
     });
 
     await receiveGroupMessage(handler, "/status");
+
+    expect(requireCapturedContext().CommandAuthorized).toBe(true);
+  });
+
+  it("authorizes registered plugin commands from admitted direct senders", async () => {
+    registerPluginCommand("signal-test-plugin", {
+      name: "signal-plugin-auth",
+      description: "Test Signal plugin command authorization.",
+      acceptsArgs: true,
+      handler: async () => ({ text: "ok" }),
+    });
+    const handler = createTestHandler({
+      cfg: createDirectConfig({
+        signal: {
+          dmPolicy: "allowlist",
+          allowFrom: ["+15550001111"],
+        },
+      }),
+      dmPolicy: "allowlist",
+      allowFrom: ["+15550001111"],
+    });
+
+    await receiveMessage(handler, { message: "hey / signal-plugin-auth check", attachments: [] });
 
     expect(requireCapturedContext().CommandAuthorized).toBe(true);
   });

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -45,7 +45,10 @@ import {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
 } from "openclaw/plugin-sdk/channel-policy";
-import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
+import {
+  isControlCommandMessage,
+  shouldComputeCommandAuthorized,
+} from "openclaw/plugin-sdk/command-detection";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createInternalHookEvent,
@@ -1011,6 +1014,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const groupId = dataMessage?.groupInfo?.groupId ?? reaction?.groupInfo?.groupId ?? undefined;
     const isGroup = Boolean(groupId);
     const hasControlCommandInMessage = isControlCommandMessage(messageText, deps.cfg);
+    const shouldComputeCommandAuth = shouldComputeCommandAuthorized(messageText, deps.cfg);
 
     const senderDisplay = formatSignalSenderDisplay(sender);
     const resolveChannelIngress = async (contextBinding?: ChannelIngressContextBinding) =>
@@ -1024,7 +1028,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         groupId,
         isGroup,
         cfg: deps.cfg,
-        hasControlCommand: hasControlCommandInMessage,
+        shouldComputeCommandAuthorized: shouldComputeCommandAuth,
         contextBinding,
       });
     const accessDecision = await resolveChannelIngress();
@@ -1111,7 +1115,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     }
 
     const commandAuthorized = commandAccess.authorized;
-    if (isGroup && commandAccess.shouldBlockControlCommand) {
+    if (isGroup && hasControlCommandInMessage && !commandAuthorized) {
       logInboundDrop({
         log: logVerbose,
         channel: "signal",

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -694,6 +694,84 @@ describe("handlePluginCommand", () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
+  it("executes an allowed Microsoft Teams plugin command and stops the nearest unauthorized ingress", async () => {
+    const handler = vi.fn(async () => ({ text: "plugin handler reached" }));
+    expect(
+      registerPluginCommandInRegistry(registry, "msteams-test-plugin", {
+        name: "msteams-plugin-auth",
+        description: "Test Microsoft Teams plugin command authorization.",
+        acceptsArgs: true,
+        handler,
+      }),
+    ).toEqual({ ok: true });
+
+    const cfg = {
+      commands: { text: true, useAccessGroups: true },
+      channels: {
+        msteams: {
+          groupPolicy: "open",
+          groupAllowFrom: ["member-aad"],
+          requireMention: false,
+        },
+      },
+    } as OpenClawConfig;
+    const commandBody = "/msteams-plugin-auth check";
+    const executeFromFinalIngress = async (params: {
+      senderId: string;
+      commandAuthorized: boolean;
+    }) => {
+      const ctx = finalizeInboundContext({
+        Provider: "msteams",
+        Surface: "msteams",
+        OriginatingChannel: "msteams",
+        Body: commandBody,
+        CommandBody: commandBody,
+        CommandSource: "text",
+        CommandAuthorized: params.commandAuthorized,
+        SenderId: params.senderId,
+        From: `msteams:group:${params.senderId}`,
+        To: "conversation:19:group@thread.tacv2",
+      });
+      const replyOptions: NonNullable<HandleCommandsParams["opts"]> &
+        PluginCommandExecutionReplyOptions = {};
+      expect(shouldBypassPluginOwnedBindingForCommand(ctx, cfg, replyOptions)).toBe(
+        params.commandAuthorized,
+      );
+
+      const commandParams = buildPluginParams(commandBody, cfg);
+      commandParams.ctx = ctx;
+      commandParams.opts = replyOptions;
+      commandParams.command = buildCommandContext({
+        ctx,
+        cfg,
+        sessionKey: commandParams.sessionKey,
+        isGroup: true,
+        triggerBodyNormalized: commandBody,
+        commandAuthorized: params.commandAuthorized,
+      });
+      return await handlePluginCommand(commandParams, true);
+    };
+
+    await expect(
+      executeFromFinalIngress({ senderId: "member-aad", commandAuthorized: true }),
+    ).resolves.toEqual({
+      shouldContinue: false,
+      reply: { text: "plugin handler reached" },
+    });
+    await expect(
+      executeFromFinalIngress({ senderId: "unlisted-aad", commandAuthorized: false }),
+    ).resolves.toEqual({
+      shouldContinue: false,
+      reply: { text: "⚠️ This command requires authorization." },
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(firstCommandContext(handler)).toMatchObject({
+      channel: "msteams",
+      commandBody,
+      senderId: "member-aad",
+    });
+  });
+
   it.each([
     {
       name: "Gateway command routed to its originating channel",


### PR DESCRIPTION
Related: #135502

## What Problem This Solves

Registered plugin commands received through Microsoft Teams or Signal did not request command authorization unless they also matched the narrower built-in control-command detector. An admitted sender could therefore reach plugin-command dispatch without `CommandAuthorized` being set.

## Why This Change Was Made

Microsoft Teams binds the final session route immediately before dispatch. The broader registered-command authorization probe must be retained through that final ingress rebind so the dispatched context carries the same authorization decision. The existing narrow control-command detector remains responsible only for control-command drop behavior.

## User Impact

Allowlisted Microsoft Teams and Signal users can execute registered plugin commands with the expected authorization context. An unlisted sender reaches the default plugin authorization gate and the registered handler is not invoked. Existing control-command and group-access behavior is preserved.

## Evidence

Redacted Microsoft Teams boundary trace:

- Allowed sender `member-aad` → `CommandAuthorized: true` → registered plugin handler invoked.
- Unlisted sender `unlisted-aad` → `CommandAuthorized: false` → `This command requires authorization.` → handler not invoked.

Automated checks:

- `message-handler.conversation-authz.test.ts` — 18 passed.
- `commands-plugin.test.ts -t "executes an allowed Microsoft Teams"` — 1 passed.
- Microsoft Teams focused authorization tests — 40 passed.
- Signal focused authorization tests — 70 passed.
- Formatting and type-aware lint checks passed.