### PR TITLE
perf: keep normal continuation diagnostics at debug level

### DIFF
--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -43,6 +43,7 @@ openclaw logs --follow
 - **File logs** are controlled exclusively by `logging.level`.
 - `--verbose` only affects **console verbosity** (and WS log style) - it does **not** raise the file log level.
 - To capture verbose-only details in file logs, set `logging.level` to `debug` or `trace`.
+- Embedded-run `continue_normal` decisions log at `debug`; retry, profile-rotation, model-fallback, and error decisions remain warnings.
 - Trace logging also includes diagnostic timing summaries for selected hot paths, such as plugin tool factory preparation. See [/tools/plugin#slow-plugin-tool-setup](/tools/plugin#slow-plugin-tool-setup).
 
 ## Console capture

--- a/src/agents/embedded-agent-runner/run/failover-observation.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.test.ts
@@ -126,6 +126,24 @@ describe("createFailoverDecisionLogger counters", () => {
 });
 
 describe("createFailoverDecisionLogger", () => {
+  it.each([true, false])("keeps normal continuation at debug level (enabled=%s)", (enabled) => {
+    vi.spyOn(log, "isEnabled").mockReturnValue(enabled);
+    const debugSpy = vi.spyOn(log, "debug").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    createDecisionLogger()("continue_normal");
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledTimes(enabled ? 1 : 0);
+    if (enabled) {
+      expect(firstWarnDetails(debugSpy)).toMatchObject({
+        event: "embedded_run_failover_decision",
+        decision: "continue_normal",
+        failoverReason: null,
+      });
+    }
+  });
+
   it("includes from and to model refs when the source differs from the selected target", () => {
     const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
     const logDecision = createDecisionLogger({

--- a/src/agents/embedded-agent-runner/run/failover-observation.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.ts
@@ -43,20 +43,6 @@ type FailoverDecisionLoggerInput = {
 type FailoverDecisionLoggerBase = Omit<FailoverDecisionLoggerInput, "decision" | "status">;
 
 /**
- * Derives timeout failure reasons for logs that were built from timeout state
- * before the normal provider error classifier had a raw error to inspect.
- */
-function normalizeFailoverDecisionObservationBase(
-  base: FailoverDecisionLoggerBase,
-): FailoverDecisionLoggerBase {
-  return {
-    ...base,
-    failoverReason: base.failoverReason ?? (base.timedOut ? "timeout" : null),
-    profileFailureReason: base.profileFailureReason ?? (base.timedOut ? "timeout" : null),
-  };
-}
-
-/**
  * Captures sanitized failover context and returns a decision logger. The closure
  * keeps prompt/assistant failover branches consistent while still allowing the
  * final decision and HTTP status to be supplied at the action point.
@@ -67,7 +53,11 @@ export function createFailoverDecisionLogger(
   decision: FailoverDecisionLoggerInput["decision"],
   extra?: Pick<FailoverDecisionLoggerInput, "status" | "retryCount" | "profileRotationCount">,
 ) => void {
-  const normalizedBase = normalizeFailoverDecisionObservationBase(base);
+  const normalizedBase = {
+    ...base,
+    failoverReason: base.failoverReason ?? (base.timedOut ? "timeout" : null),
+    profileFailureReason: base.profileFailureReason ?? (base.timedOut ? "timeout" : null),
+  };
   const safeProfileId = normalizedBase.profileId
     ? redactIdentifier(normalizedBase.profileId, { len: 12 })
     : undefined;
@@ -80,6 +70,12 @@ export function createFailoverDecisionLogger(
   const reasonText = normalizedBase.failoverReason ?? "none";
   const sourceChanged = safeSourceProvider !== safeProvider || safeSourceModel !== safeModel;
   return (decision, extra) => {
+    const level = decision === "continue_normal" ? "debug" : "warn";
+    // Keep normal continuation in diagnostics; avoid per-decision formatting
+    // and log transport when neither sink requests those diagnostics.
+    if (level === "debug" && !log.isEnabled(level)) {
+      return;
+    }
     const observedError = buildApiErrorObservationFields(normalizedBase.rawError);
     const safeRawErrorPreview = sanitizeForConsole(observedError.rawErrorPreview);
     // Some provider/runtime failure kinds already have normalized detail fields.
@@ -92,7 +88,7 @@ export function createFailoverDecisionLogger(
         : "";
     const retryCount = extra?.retryCount ?? normalizedBase.retryCount;
     const profileRotationCount = extra?.profileRotationCount ?? normalizedBase.profileRotationCount;
-    log.warn("embedded run failover decision", {
+    log[level]("embedded run failover decision", {
       event: "embedded_run_failover_decision",
       tags: ["error_handling", "failover", normalizedBase.stage, decision],
       runId: normalizedBase.runId,


### PR DESCRIPTION
## Problem and change

Normal embedded-run continuation currently emits a warning and constructs its per-decision error metadata and console message even when diagnostics are not requested. This makes ordinary successful operation noisy and adds avoidable work to the continuation path.

Keep `continue_normal` at debug level and return before per-decision formatting when neither sink enables debug. Static context is still captured, normalized and sanitized eagerly by the factory. Retries, profile rotation, model fallback and surfaced errors retain warning logging, structured fields, redaction, counters and callbacks. Inline the single-use normalization helper and document the logging level. Production +12/-16 (net -4), tests +18, docs +1; no new configuration, dependencies, protocol or storage changes.

## Measurement

A fixed native before/candidate/candidate/before experiment used the complete source modules, real logging transport and flush boundary, with 3,744 product observations and 384 measured means. Direct factory/decision work improved 97.655% and 97.116%; the complete normal continuation caller improved 96.802% and 96.924%. These are synthetic local logging measurements, not end-to-end Gateway/provider-turn or durable-fsync claims.

All slower controls remain in the result. Rotation warnings regressed 17.818%/0.604% (+42.789/+1.594 microseconds); model fallback warnings changed +2.960%/-2.324%; debug-enabled normal changed +5.866%/-3.867%; reused warnings regressed 3.028%/2.445% (+12.630/+10.555 microseconds). Forty adverse first/warm/measured summaries are retained. The preset primary gate required at least 3% improvement in both orders; a protected rejection required over 3% AND 1 microsecond regression in both orders. Kernel RSS changed +1.170%/-7.591%, sampled process-tree RSS +1.136%/-6.366%. The candidate passed those fixed gates; this does not claim every warning path became faster.

Immutable final measurement SHA256: `40863bc7d70af6a4c0184eb4b8ff37d0a456bf4f3ec9c02b34ad6685464236c9`. Independent raw evidence audit and all original adverse observations are retained locally. No samples were rerun during landing validation.

## Validation

- Fresh isolated checkout at main `45e7a54c13a4693b03f9989207714c5657d30403`; all 15 selected source/caller/test/docs paths match the measured baseline. This selected equivalence is not a claim about all transitive dependencies.
- Identical 81 cases across three complete suites: baseline 79 pass with exactly the two expected normal-log-level regression failures; candidate 81 pass, no skips.
- Complete changed-file check passed in 269.714 seconds, including formatting, types, dead exports, lint and applicable guards. Its normal ratchet reference was `49f1bea621581d1914c13c6ad98b02f0a20b3626`; no check bypass was used.
- Fresh independent managed Codex review: no findings, confidence 0.98. Parent read the complete owner, patch and review and verified all 74 sealed landing evidence members and exact patch.
- Real native logging verifies INFO suppression, DEBUG output, warning parity and flush behavior. All 232 observed validation PIDs and 110 groups were closed. Prior rejected experiments remain separate.

Intentional user-visible change: normal continuation appears only at debug/trace verbosity. Operational failure warnings remain visible. A full live Gateway latency improvement is not established by this narrow experiment. No changelog edit before release.
