### PR TITLE
fix(tts): preserve free-text [[tts:...]] reply across final and caption delivery (#137281)

### DIFF
--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -3618,6 +3618,37 @@ describe("tryDispatchAcpReplyCore", () => {
     expect(dispatcherCall(dispatcher.sendFinalReply).text).toBeUndefined();
   });
 
+  it("keeps a free-text [[tts:<prose>]] reply visible in the Telegram voice caption", async () => {
+    setReadyAcpResolution();
+    ttsCapabilityMocks.captionedFinalText = true;
+    queueTtsReplies({
+      text: "Yes—I understand you clearly now.",
+      mediaUrl: "/tmp/openclaw-media/acp-tts.ogg",
+      audioAsVoice: true,
+      spokenText: "Yes—I understand you clearly now.",
+      ttsSupplement: { spokenText: "Yes—I understand you clearly now." },
+    } as MockTtsReply);
+    mockVisibleTextTurn("[[tts:Yes—I understand you clearly now.]]");
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "reply",
+      cfg: createAcpTestConfig({
+        acp: { enabled: true, stream: { deliveryMode: "live" } },
+        tts: { auto: "always" },
+      }),
+      dispatcher,
+      ctxOverrides: { Provider: "telegram", Surface: "telegram" },
+    });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcherCall(dispatcher.sendFinalReply)).toMatchObject({
+      text: "Yes—I understand you clearly now.",
+      mediaUrl: "/tmp/openclaw-media/acp-tts.ogg",
+      audioAsVoice: true,
+    });
+  });
+
   it("keeps cross-block ACP TTS-only text out of the Telegram caption", async () => {
     setReadyAcpResolution();
     ttsCapabilityMocks.captionedFinalText = true;

--- a/src/tts/captioned-final.test.ts
+++ b/src/tts/captioned-final.test.ts
@@ -19,4 +19,35 @@ describe("cleanDeferredFinalText", () => {
       "Visible.  Done.",
     );
   });
+
+  it("preserves a free-text [[tts:...]] body instead of emptying the visible final", () => {
+    expect(cleanDeferredFinalText("Visible [[tts:Yes—I understand you clearly now.]] done")).toBe(
+      "Visible Yes—I understand you clearly now. done",
+    );
+  });
+
+  it("still strips key=value directives from the deferred visible final", () => {
+    expect(cleanDeferredFinalText("say [[tts:voice=alice]] now")).toBe("say  now");
+  });
+
+  it("still hides tts:text blocks while preserving free-text tts bodies", () => {
+    expect(
+      cleanDeferredFinalText("A [[tts:text]]whisper[[/tts:text]] [[tts:answered aloud]] Z"),
+    ).toBe("A  answered aloud Z");
+  });
+
+  it("keeps a lone [[tts:text]] marker out of the deferred visible caption", () => {
+    expect(cleanDeferredFinalText("[[tts:text]]")).toBe("");
+    expect(cleanDeferredFinalText("say hi [[tts:text]] and beyond")).toBe("say hi ");
+  });
+
+  it("preserves a multiline free-text [[tts:...]] body in the deferred caption", () => {
+    expect(cleanDeferredFinalText("Before. [[tts:first line\nsecond line]] after")).toBe(
+      "Before. first line\nsecond line after",
+    );
+  });
+
+  it("trims a leading newline after [[tts:]] in the deferred caption", () => {
+    expect(cleanDeferredFinalText("Go [[tts:\nhello]] now")).toBe("Go hello now");
+  });
 });

--- a/src/tts/directive-facts.test.ts
+++ b/src/tts/directive-facts.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { extractTtsDirectiveFacts } from "./directive-facts.js";
+
+describe("extractTtsDirectiveFacts", () => {
+  it("keeps text unchanged when there is no TTS markup", () => {
+    expect(extractTtsDirectiveFacts("plain prose")).toEqual({ cleanedText: "plain prose" });
+  });
+
+  it("records key=value directives and strips the tag from visible text", () => {
+    const result = extractTtsDirectiveFacts("hello [[tts:provider=x voice=a]] world");
+    expect(result.cleanedText).toBe("hello  world");
+    expect(result.facts).toEqual({
+      tagged: true,
+      directives: [{ provider: "x", values: { voice: "a" } }],
+    });
+  });
+
+  it("preserves a free-text [[tts:<prose>]] body as visible and spoken text", () => {
+    const result = extractTtsDirectiveFacts("[[tts:Yes—I understand you clearly now.]]");
+    expect(result.cleanedText).toBe("Yes—I understand you clearly now.");
+    expect(result.facts).toEqual({
+      tagged: true,
+      text: "Yes—I understand you clearly now.",
+    });
+  });
+
+  it("keeps free-text prose surrounding a preserved directive body", () => {
+    const result = extractTtsDirectiveFacts("Go [[tts:hello world]] and return");
+    expect(result.cleanedText).toBe("Go hello world and return");
+    expect(result.facts?.text).toBe("hello world");
+  });
+
+  it("preserves a multiline free-text [[tts:...]] body", () => {
+    const result = extractTtsDirectiveFacts("[[tts:first line\nsecond line]] tail");
+    expect(result.cleanedText).toBe("first line\nsecond line tail");
+    expect(result.facts).toEqual({
+      tagged: true,
+      text: "first line\nsecond line",
+    });
+  });
+
+  it("trims a leading newline after [[tts:]] in the parser body", () => {
+    const result = extractTtsDirectiveFacts("Go [[tts:\nhello]] now");
+    expect(result.cleanedText).toBe("Go hello now");
+    expect(result.facts?.text).toBe("hello");
+  });
+
+  it("still hides tts:text private blocks from the visible text", () => {
+    const result = extractTtsDirectiveFacts("A [[tts:text]]whisper[[/tts:text]] Z");
+    expect(result.cleanedText).toBe("A  Z");
+    expect(result.facts).toEqual({ tagged: true, text: "whisper" });
+  });
+
+  it("keeps a lone [[tts:text]] marker audio-only instead of surfacing literal text", () => {
+    const result = extractTtsDirectiveFacts("[[tts:text]]");
+    expect(result.cleanedText).toBe("");
+    expect(result.facts).toEqual({ tagged: true });
+  });
+
+  it("drops a lone [[tts:text]] marker but keeps the surrounding prose visible", () => {
+    const result = extractTtsDirectiveFacts("say hi [[tts:text]] now");
+    expect(result.cleanedText).toBe("say hi  now");
+    expect(result.facts).toEqual({ tagged: true });
+  });
+
+  it("leaves single bare tts tags only tagged without silently dropping prose", () => {
+    const result = extractTtsDirectiveFacts("[[tts]] read this aloud");
+    expect(result.cleanedText).toBe(" read this aloud");
+    expect(result.facts?.tagged).toBe(true);
+  });
+});

--- a/src/tts/directive-facts.ts
+++ b/src/tts/directive-facts.ts
@@ -48,6 +48,19 @@ function replaceOutsideMarkdownCode(
   });
 }
 
+/**
+ * A directive tag body declares speech overrides only when it carries a
+ * whitespace token shaped `key=value`. A colon-form tag whose body has none is
+ * free prose the model wrapped in the tag by mistake; both parsed and streamed
+ * cleaners preserve it as reply text instead of discarding it.
+ */
+export function bodyHasTtsDirectiveKeyValue(body: string): boolean {
+  return body
+    .split(/\s+/)
+    .filter(Boolean)
+    .some((token) => token.includes("="));
+}
+
 /** Extract final-text TTS syntax into persisted facts, leaving markdown code spans unchanged. */
 export function extractTtsDirectiveFacts(text: string): {
   cleanedText: string;
@@ -108,6 +121,21 @@ export function extractTtsDirectiveFacts(text: string): {
     if (provider || Object.keys(values).length > 0) {
       next.directives ??= [];
       next.directives.push({ ...(provider ? { provider } : {}), values });
+    } else if (
+      !bodyHasTtsDirectiveKeyValue(body) &&
+      normalizeLowercaseStringOrEmpty(body.trim()) !== "text"
+    ) {
+      // No parseable directive and no key=value shaped token means the model
+      // wrapped its spoken reply in [[tts:<free text>]] by mistake. Keep that
+      // prose as visible reply text so delivery does not collapse to the
+      // empty-reply fallback. Mixed values deliberately keep existing
+      // behavior, and the reserved [[tts:text]] marker stays audio-only (never
+      // surfaced as literal speech) to match the streaming/caption cleaner.
+      const spoken = body.trim();
+      if (spoken) {
+        next.text ??= spoken;
+        return spoken;
+      }
     }
     return "";
   });

--- a/src/tts/directives.test.ts
+++ b/src/tts/directives.test.ts
@@ -381,4 +381,43 @@ describe("createTtsDirectiveTextStreamCleaner", () => {
     expect(cleaner.push("See [[note")).toBe("See ");
     expect(cleaner.flush()).toBe("[[note");
   });
+
+  it("keeps a free-text [[tts:...]] body visible through the cleaner", () => {
+    const cleaner = createTtsDirectiveTextStreamCleaner();
+
+    expect(cleaner.push("Some [[tts:hello there]] note")).toBe("Some hello there note");
+    expect(cleaner.flush()).toBe("");
+  });
+
+  it("keeps a free-text tts body whose tag spans streamed chunks", () => {
+    const cleaner = createTtsDirectiveTextStreamCleaner();
+
+    expect(cleaner.push("Go [[tts:")).toBe("Go ");
+    expect(cleaner.push("answered aloud]] back")).toBe("answered aloud back");
+    expect(cleaner.flush()).toBe("");
+  });
+
+  it("keeps a multiline free-text tts body visible through the cleaner", () => {
+    const cleaner = createTtsDirectiveTextStreamCleaner();
+
+    expect(cleaner.push("Done. [[tts:first line\nsecond line]] more")).toBe(
+      "Done. first line\nsecond line more",
+    );
+    expect(cleaner.flush()).toBe("");
+  });
+
+  it("keeps a free-text tts body that starts on the line after [[tts:", () => {
+    const cleaner = createTtsDirectiveTextStreamCleaner();
+
+    expect(cleaner.push("Go [[tts:\nhello]] now")).toBe("Go hello now");
+    expect(cleaner.flush()).toBe("");
+  });
+
+  it("still strips key=value directive tags in the cleaner", () => {
+    const cleaner = createTtsDirectiveTextStreamCleaner();
+
+    expect(cleaner.push("say [[tts:voice=al")).toBe("say ");
+    expect(cleaner.push("ice]] now")).toBe(" now");
+    expect(cleaner.flush()).toBe("");
+  });
 });

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -3,7 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import type { OpenClawConfig } from "../config/types.js";
 import type { AssistantDeliveryTtsFacts } from "../llm/types.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
-import { extractTtsDirectiveFacts } from "./directive-facts.js";
+import { bodyHasTtsDirectiveKeyValue, extractTtsDirectiveFacts } from "./directive-facts.js";
 import { compareSpeechProviderOrder } from "./provider-registry-core.js";
 import { listSpeechProviders } from "./provider-registry.js";
 import type {
@@ -129,6 +129,32 @@ function classifyTtsTag(body: string): "hidden-open" | "hidden-close" | "tts" | 
   return "other";
 }
 
+/**
+ * A single colon tag `[[tts:<prose>]]` without any `key=value` token carries the
+ * model's wrapped spoken reply, not directives. Returns that prose so streaming
+ * and caption cleaners keep it visible; returns null for bare delimiters
+ * (`[[tts]]`, closers) and real directive bodies.
+ */
+function resolveFreeTextTtsBody(bracketBody: string): string | null {
+  // Match the final parser's colon-tag grammar: any whitespace (including a
+  // line break) around `tts:` and after the colon is accepted, then the body is
+  // trimmed like the parser's spoken value. `[[tts:\nhello]]` therefore yields
+  // `hello` and a multi-line interior stays intact.
+  const colonMatch = /^[\s]*tts[\s]*:([\s\S]*)$/i.exec(bracketBody);
+  if (!colonMatch) {
+    return null;
+  }
+  const captured = colonMatch[1];
+  if (captured === undefined) {
+    return null;
+  }
+  const prose = captured.trim();
+  if (!prose || bodyHasTtsDirectiveKeyValue(prose)) {
+    return null;
+  }
+  return prose;
+}
+
 /** Create an incremental cleaner for hiding [[tts:*]] directive text while streaming. */
 export function createTtsDirectiveTextStreamCleaner(): TtsDirectiveTextStreamCleaner {
   let pending = "";
@@ -170,6 +196,11 @@ export function createTtsDirectiveTextStreamCleaner(): TtsDirectiveTextStreamCle
           insideHiddenTextBlock = false;
         } else if (tag === "other" && !insideHiddenTextBlock) {
           output += rawTag;
+        } else if (tag === "tts" && !insideHiddenTextBlock) {
+          const freeText = resolveFreeTextTtsBody(input.slice(tagStart + 2, tagEnd));
+          if (freeText) {
+            output += freeText;
+          }
         }
 
         index = tagEnd + 2;


### PR DESCRIPTION
Closes #137281

> Merge-note: an open concurrent fix #137288 covers only the parsed final path. This PR is the complete two-boundary repair; reconcile before landing (see Scope note).

## What Problem This Solves

When `tts.auto` enables inbound/automatic TTS, the model sometimes reads the "wrap the reply in `[[tts:...]]`" hint literally and emits the whole spoken reply as free-text inside a single colon tag — e.g. a reply like `[[tts:Yes—I understand you clearly now.]]`, possibly multiline or with a leading line break. Two independent owners then stripped that reply:

- The final parser (`extractTtsDirectiveFacts`) parsed the `[[tts:...]]` body as `key=value` tokens, found none, and substituted an empty string — the reply lost all visible text, `before_agent_finalize` never fired on a visible payload, and the channel fell back to `"No reply was generated for this message..."`.
- On deferred/captioned-final routes (e.g. Telegram voice-note captions), the streaming directive cleaner treated every `[[tts:...]]` as a directive and dropped the body, so the visible caption was emptied independently of any parser fix — and with a newer selector it also mishandled a body that begins right after a newline.

## Why This Change Was Made

The repair covers both owner boundaries with one shared classification and whitespace contract, so an immediate route and a deferred voice-note route cannot diverge:

- `bodyHasTtsDirectiveKeyValue(body)` in `src/tts/directive-facts.ts` is the single shared predicate: a colon body only counts as speech-override directives when some whitespace token is shaped `key=value`.
- The final parser keeps the trimmed body as visible reply text (`facts.text`) when there is no directive value and no `key=value` token.
- The stream cleaner (`src/tts/directives.ts`) adds `resolveFreeTextTtsBody`: a bare colon tag with no `key=value` is emitted as visible text instead of silently dropped, so `cleanDeferredFinalText` (all deferred/captioned finals) retains the caption. Free-text grammar matches the parser across line breaks: whitespace (including a newline) is accepted before and after the colon and the visible body is trimmed, so a single-line, multi-line, and `[[tts:\nhello]]`-style leading-newline body all stay visible on both owners. Real directives (`[[tts:voice=alice]]`) and hidden `[[tts:text]]...[[/tts:text]]` keep existing behavior.
- A lone reserved `[[tts:text]]` marker (no closer) is excluded from the free-text fallback: documented audio-only, it no longer surfaces literal `text`, does not set `facts.text`, and surrounding prose stays visible.
- No new config, no new defaults, no caps, no SQLite changes.

Scope note (analysis only, not a competing intent): concurrent fix #137288 covers only the parsed final path. This PR extends that intent to the deferred/caption boundary #137288 does not reach, so the two overlap on `src/tts/directive-facts.ts` and should be reconciled before either lands.

## User Impact

Operators whose models send a free-text `[[tts:<spoken reply>]]` — single-line, multiline, or with a leading line break — see it again in chat (shown and spoken) instead of an empty fallback, on both final and deferred Telegram-style voice-note caption routes. A leftover lone `[[tts:text]]` marker never appears as literal text.

## Evidence

The fix follows the Codex review's best-solution path: one shared classification across the final parser and the deferred streaming/caption owner, matching parser whitespace (newline-capable) grammar, lone-marker reservation, and regressions at parser/cleaner/caption/producer boundaries.

Real producer-boundary proof (real cleaner/`cleanDeferredFinalText` through the Telegram captioned dispatch harness, mock TTS reply, live dispatcher):

Single-line free-text case:

```
$ node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-acp.test.ts --run -t "keeps a free-text"
 ✓ tryDispatchAcpReplyCore > keeps a free-text [[tts:<prose>]] reply visible in the Telegram voice caption
```
Pre-fix (production reverted to main): `sendFinalReply.text === undefined` — visible caption lost.

Multiline finding [P1] (newline inside a colon tag) — verified:
- On prior head `cleanDeferredFinalText("[[tts:first line\nsecond line]]")` returned `""` while the parser preserved `"first line\nsecond line"`; the cleaner matcher used `.` (no newline handling).
- Post-fix: cleaner + deferred caption keep the multiline body, matching the parser.

Leading-newline finding [P1] (body starts right after the colon) — verified:
- On prior head, `[[tts:\nhello]]` was preserved by the parser but the cleaner kept an untrimmed literal `\nhello`, diverging from the parser's trimmed `"hello"` and producing a stray leading line break in the caption.
- Post-fix: the cleaner accepts any whitespace after the colon (including a newline) and trims to the parser's grammar, so `cleanDeferredFinalText` yields `"hello"` to match `extractTtsDirectiveFacts`. Directive and lone `tts:text` behavior are unchanged.

Lone reserved-marker finding [P2] — verified:
- On the prior commit, `extractTtsDirectiveFacts("[[tts:text]]")` surfaced literal `"text"` + `facts.text`; shipped `main` returns `{cleanedText:"", facts:{tagged}}`. Post fix the marker is audio-only in both parser and deferred caption.

Regression tests fail on pre-fix code for the intended reason (body cleared / caption emptied / literal marker surfaced / multiline or leading-newline dropped).

Focused suites:

```
$ node scripts/run-vitest.mjs src/tts/directive-facts.test.ts src/tts/directives.test.ts src/tts/captioned-final.test.ts --run
 Test Files  3 passed (3)
      Tests  48 passed (48)

$ node scripts/run-vitest.mjs src/tts/ --run
 Test Files  18 passed (18)
      Tests  218 passed (218)
```

Sibling no-regression (hidden `[[tts:text]]` blocks and directive stripping preserved in the dispatcher/cleaner file):

```
$ node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-acp.test.ts --run
 Test Files  1 passed (1)
      Tests  127 passed (127)
```

Type, lint, and format gates on the touched files:

```
$ pnpm tsgo:core
# exit 0

$ ./node_modules/.bin/oxlint src/tts/directive-facts.ts src/tts/directives.ts src/tts/directive-facts.test.ts src/tts/directives.test.ts src/tts/captioned-final.test.ts src/auto-reply/reply/dispatch-acp.test.ts
Found 0 warnings and 0 errors.

$ ./node_modules/.bin/oxfmt src/tts/directive-facts.ts src/tts/directives.ts src/tts/directive-facts.test.ts src/tts/directives.test.ts src/tts/captioned-final.test.ts src/auto-reply/reply/dispatch-acp.test.ts
```

Note: `pnpm tsgo:test:src` reports one pre-existing, unrelated error `packages/mermaid-renderer/src/renderer.ts(3,36): Cannot find module 'mermaid'` — that package is unchanged by this PR and `mermaid` is missing from this checkout's `node_modules` (a dev-dependency install gap, not caused by this change).

Production code is net +59 across `src/tts/directive-facts.ts` (+28, shared predicate + final free-text branch + lone-marker reservation) and `src/tts/directives.ts` (+32/−1, parser-consistent whitespace stream-clean branch). Tests are net +172 (`directive-facts.test.ts` +71 new, `directives.test.ts` +39, `captioned-final.test.ts` +31, `dispatch-acp.test.ts` +31) covering parsed and streamed free text, chunk splits, multiline, leading-newline, lone-marker, and captioned-final behavior plus hidden-block/directive no-regressions. No core, config, defaults, docs, or SQLite changes. The shared two-boundary classification and matching whitespace grammar explain the production delta.

## CI runs (failures are outside this change set)

This PR only touches `src/tts/*` and `src/auto-reply/reply/dispatch-acp.test.ts`. The CI shards below reported failures exclusively in areas this diff does not modify (`src/state`, `src/gateway`, cli-process). Rerunning those exact files on this head in isolation is green here:

- `src/state/openclaw-state-lease-heartbeat.test.ts` (lease heartbeat "acknowledges ownership checks ...") — 10/10 pass.
- `src/gateway/local-request-context.session-tools.test.ts` (visible-spawn rollback "unchanged" timed out; "active" assertion) — 14/14 pass, each well under the CI wall-time budget.
- Agentic cli-process-hosted shard failure — carries no assertion mapped to this change and touches none of this PR's code.

The failing shards ran 216–350s wall time with unrelated long imports (one ~21s outlier) under parallelism, and the "unchanged" case needs ~33s even locally before CI's 120s timeout — signs of runner load / shard-timing flakes rather than a regression introduced here. No `src/state`, `src/gateway`, or cli-process code is changed by this PR, so these failures are not attributable to it.

## Review response

- `[P2]` LONE RESERVED `tts:text` MARKER — fixed: parser reserves the audio-only marker; parser + deferred-caption regressions.
- `[P1]` PRESERVE MULTILINE free-text `tts:` bodies — fixed: stream matcher is newline-capable, matching the parser.
- `[P1]` ACCEPT LEADING-NEWLINE free-text `tts:` bodies — fixed in this commit: the deferred-cleaner colon grammar accepts any whitespace (incl. newline) after the colon and trims to the parser's contract; direct-cleaner, parser, and deferred-caption regressions added.
- `[Proof]` / `proof: telegram-e2e` — mock/harness evidence only; no Telegram Test Server transport credential is available in this environment. Deferred caption behavior is proven at the dispatch boundary (mock channel + mock TTS reply + live dispatcher). Flagged as a remaining owner-side proof item.
- Overlap with #137288 — left to maintainer to reconcile into one canonical parser behavior before landing.
- CI — shards `core-unit-src-security-3`, `agentic-gateway-core-3`, `agentic-cli-process-hosted-7` failed outside this diff (`src/state`, `src/gateway`, cli-process); rerun of those exact files on this head is green in isolation (10/10, 14/14). See the CI runs section above.