### PR TITLE
fix(doctor): name the fixed USER.md bootstrap cap, drop the no-op tip

### DIFF
--- a/src/commands/doctor-bootstrap-size.test.ts
+++ b/src/commands/doctor-bootstrap-size.test.ts
@@ -131,3 +131,37 @@ describe("noteBootstrapFileSize", () => {
     expect(resolveBootstrapContextForRun).toHaveBeenCalledTimes(2);
   });
 });
+
+it("names the fixed USER.md cap and omits the bootstrapMaxChars tip when only USER.md is truncated", async () => {
+  vi.resetAllMocks();
+  listAgentIds.mockReturnValue(["main"]);
+  resolveDefaultAgentId.mockReturnValue("main");
+  resolveAgentWorkspaceDir.mockReturnValue("/tmp/workspace");
+  resolveBootstrapMaxChars.mockReturnValue(20_000);
+  resolveBootstrapTotalMaxChars.mockReturnValue(150_000);
+  resolveBootstrapContextForRun.mockResolvedValue({
+    bootstrapFiles: [
+      {
+        name: "USER.md",
+        path: "/tmp/workspace/USER.md",
+        content: "a".repeat(10_983),
+        missing: false,
+      },
+    ],
+    contextFiles: [{ path: "/tmp/workspace/USER.md", content: "a".repeat(4_000) }],
+  });
+  await noteBootstrapFileSize({} as OpenClawConfig);
+  expect(note).toHaveBeenCalledTimes(1);
+  const [message, title] = note.mock.calls[0] ?? [];
+  expect(title).toBe("Bootstrap file size");
+  expect(message).toBe(
+    [
+      "Workspace bootstrap files exceed limits and will be truncated:",
+      "- USER.md: 10,983 raw / 4,000 injected (64% truncated; max/file)",
+      "Total bootstrap injected chars: 4,000 (3% of max/total 150,000).",
+      "Total bootstrap raw chars (before truncation): 10,983.",
+      "- USER.md has a fixed 4,000-character bootstrap cap; keep it compact.",
+    ].join("\n"),
+  );
+  expect(message).not.toContain("bootstrapMaxChars");
+});

--- a/src/commands/doctor-bootstrap-size.ts
+++ b/src/commands/doctor-bootstrap-size.ts
@@ -14,6 +14,7 @@ import {
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
 } from "../agents/embedded-agent-helpers.js";
+import { USER_BOOTSTRAP_MAX_CHARS } from "../agents/embedded-agent-helpers/bootstrap.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 // Every warning uses the same locale; silent checks never need a formatter.
@@ -110,9 +111,26 @@ export async function noteBootstrapFileSize(cfg: OpenClawConfig) {
       `Total bootstrap raw chars (before truncation): ${formatInt(analysis.totals.rawChars)}.`,
     );
 
+    // USER.md is capped by Math.min(bootstrapMaxChars, USER_BOOTSTRAP_MAX_CHARS), so
+    // raising bootstrapMaxChars cannot lift its limit. Name the fixed cap and mirror
+    // the suppression the sibling prompt-warning renderer already applies
+    // (src/agents/bootstrap-budget-warning.ts) instead of offering a knob that
+    // has no effect here.
+    const isFixedUserCapFile = (file: { name?: string; effectiveFileLimit: number }) =>
+      file.name?.toLowerCase() === "user.md" &&
+      file.effectiveFileLimit === USER_BOOTSTRAP_MAX_CHARS;
+    const fixedUserCapApplied = analysis.truncatedFiles.some(
+      (file) => isFixedUserCapFile(file) && file.causes.includes("per-file-limit"),
+    );
+    if (fixedUserCapApplied) {
+      lines.push(
+        `- USER.md has a fixed ${formatInt(USER_BOOTSTRAP_MAX_CHARS)}-character bootstrap cap; keep it compact.`,
+      );
+    }
     const needsPerFileTip =
-      analysis.truncatedFiles.some((file) => file.causes.includes("per-file-limit")) ||
-      analysis.nearLimitFiles.length > 0;
+      analysis.truncatedFiles.some(
+        (file) => file.causes.includes("per-file-limit") && !isFixedUserCapFile(file),
+      ) || analysis.nearLimitFiles.some((file) => !file.truncated && !isFixedUserCapFile(file));
     const needsTotalTip =
       analysis.truncatedFiles.some((file) => file.causes.includes("total-limit")) ||
       analysis.totalNearLimit;


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor` flags `USER.md` as truncated and then tells the operator to raise `agents.defaults.bootstrapMaxChars`. That knob cannot raise the `USER.md` cap — it is clamped by `Math.min(bootstrapMaxChars, USER_BOOTSTRAP_MAX_CHARS)` and can only ever lower it (see #136733). The tip recommends a setting that is already set ten times higher than the reported limit and that has no effect on the only file being flagged.

The codebase already has the correct behaviour two files away: `src/agents/bootstrap-budget-warning.ts` (the prompt-warning renderer over the same `analyzeBootstrapBudget` result) names the fixed cap and explicitly suppresses the `bootstrapMaxChars` tip for exactly this case. `src/commands/doctor-bootstrap-size.ts` had no equivalent — its `needsPerFileTip` fired on the bare presence of a `per-file-limit` cause.

Closes #137307.

## Approach

Mirror the sibling renderer's suppression in `noteBootstrapFileSize`:

- import `USER_BOOTSTRAP_MAX_CHARS` from `embedded-agent-helpers/bootstrap.js` (same module the prompt-warning renderer uses);
- add an `isFixedUserCapFile` helper (`name === "user.md" && effectiveFileLimit === USER_BOOTSTRAP_MAX_CHARS`);
- when any truncated file is a fixed-cap USER.md with a `per-file-limit` cause, emit `- USER.md has a fixed 4,000-character bootstrap cap; keep it compact.` (the doctor's bullet style; same wording as the sibling renderer);
- refine `needsPerFileTip` so the `bootstrapMaxChars` tip only fires for a *configurable* per-file limit — a truncated file with `per-file-limit` that is **not** a fixed-cap USER.md, or a non-truncated near-limit file that is **not** a fixed-cap USER.md. The `total-limit` / `totalNearLimit` path is untouched.

The terminal/outcome derivation (`hasValidRunWindow`, `terminalTimestamp`) is untouched, so the rest of the doctor note is unchanged.

## Evidence

- `npx vitest run src/commands/doctor-bootstrap-size.test.ts` → 5 passed (4 baseline + 1 new).
- New test `names the fixed USER.md cap and omits the bootstrapMaxChars tip when only USER.md is truncated`: a 10,983-char `USER.md` truncated to 4,000 (the fixed cap) produces a note that contains `- USER.md has a fixed 4,000-character bootstrap cap; keep it compact.` and does **not** contain `bootstrapMaxChars`. The test uses `vi.resetAllMocks()` to stay self-contained against the shared mock suite.
- The baseline `emits a warning when bootstrap files are truncated` test (AGENTS.md, configurable per-file limit) still passes unchanged — the `bootstrapMaxChars` tip still fires for configurable limits.
- `oxlint` → exit 0; `oxfmt --check` → clean; `tsc -p tsconfig.json` → no errors in the changed file.

## Scope

Narrow: one doctor renderer (`src/commands/doctor-bootstrap-size.ts`) + one new test. No analysis/types change, no runtime bootstrap path change. The sibling prompt-warning renderer already had this suppression; this PR brings the doctor surface to parity.
