### PR TITLE
fix(cli): reject blank directory accounts

### DIFF
--- a/docs/cli/directory.md
+++ b/docs/cli/directory.md
@@ -19,6 +19,9 @@ Results are meant to be pasted into other commands, especially `openclaw message
 - `--json`: output JSON
 - `--limit <n>`: positive integer cap for peers/groups/members listings
 
+Omit `--account` to select the channel default. Explicitly empty and whitespace-only account
+values fail with `--account must not be blank` before account setup or lookup.
+
 `--limit` requires a positive integer. Omit `--limit` to use the selected channel plugin's default.
 Explicitly empty and whitespace-only values are rejected.
 

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -9,7 +9,7 @@ import {
   normalizeChannelId,
 } from "../channels/plugins/index.js";
 import { resolveInstallableChannelPlugin } from "../commands/channel-setup/channel-plugin-resolution.js";
-import { assertAccountSelectorForMutation } from "../commands/channels/account-selector.js";
+import { parseAccountSelector } from "../commands/channels/account-selector.js";
 import { requireValidConfigForWrite } from "../commands/config-validation.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
@@ -104,7 +104,7 @@ async function resolveChannelPluginForMode(
   channelId: string;
   plugin: ChannelPlugin;
 } | null> {
-  assertAccountSelectorForMutation(opts.account);
+  parseAccountSelector(opts.account);
   const writeSnapshot = await requireValidConfigForWrite(runtime);
   if (!writeSnapshot) {
     return null;

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -9,7 +9,7 @@ import {
   normalizeChannelId,
 } from "../channels/plugins/index.js";
 import { resolveInstallableChannelPlugin } from "../commands/channel-setup/channel-plugin-resolution.js";
-import { assertAccountSelectorForMutation } from "../commands/channels/account-selector.js";
+import { assertAccountSelector } from "../commands/channels/account-selector.js";
 import { requireValidConfigFileSnapshot } from "../commands/config-validation.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
@@ -104,7 +104,7 @@ async function resolveChannelPluginForMode(
   channelId: string;
   plugin: ChannelPlugin;
 } | null> {
-  assertAccountSelectorForMutation(opts.account);
+  assertAccountSelector(opts.account);
   const snapshot = await requireValidConfigFileSnapshot(runtime);
   if (!snapshot) {
     return null;

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -118,6 +118,29 @@ describe("registerDirectoryCli", () => {
     });
   });
 
+  describe.each([
+    ["self", ["directory", "self"]],
+    ["peers", ["directory", "peers", "list"]],
+    ["groups", ["directory", "groups", "list"]],
+    ["members", ["directory", "groups", "members", "--group-id", "group-1"]],
+  ])("%s account input", (_leaf, args) => {
+    it.each(["", " \t\n "])("rejects blank %j before command startup", async (account) => {
+      const startup = vi.fn(() => {
+        throw new Error("Command startup reached");
+      });
+      const program = new Command().name("openclaw").hook("preAction", startup);
+      registerDirectoryCli(program);
+
+      await expect(
+        program.parseAsync([...args, "--channel", "slack", "--account", account], {
+          from: "user",
+        }),
+      ).rejects.toThrow("--account must not be blank");
+
+      expect(startup).not.toHaveBeenCalled();
+    });
+  });
+
   it("installs an explicit optional directory channel on demand", async () => {
     const tokenRef = {
       source: "env",

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -118,6 +118,68 @@ describe("registerDirectoryCli", () => {
     });
   });
 
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", " \t "],
+  ])(
+    "rejects explicit $0 directory account before plugin, secret, or default resolution",
+    async (_label, account) => {
+      const self = vi.fn().mockResolvedValue({ id: "self-1" });
+      mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+        cfg: { channels: { slack: {} } },
+        channelId: "slack",
+        plugin: { id: "slack", directory: { self } },
+        configChanged: false,
+      });
+
+      const program = new Command().name("openclaw");
+      registerDirectoryCli(program);
+
+      await expect(
+        program.parseAsync(
+          ["directory", "self", "--channel", "slack", "--account", account, "--json"],
+          { from: "user" },
+        ),
+      ).rejects.toThrow("--account must not be blank");
+
+      expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+      expect(mocks.resolveMessageChannelSelection).not.toHaveBeenCalled();
+      expect(mocks.resolveChannelDefaultAccountId).not.toHaveBeenCalled();
+      expect(mocks.getScopedChannelsCommandSecretTargets).not.toHaveBeenCalled();
+      expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+      expect(self).not.toHaveBeenCalled();
+      expect(runtimeState.defaultRuntime.writeJson).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["peers", ["directory", "peers", "list", "--channel", "slack"]],
+    ["groups", ["directory", "groups", "list", "--channel", "slack"]],
+    [
+      "group members",
+      ["directory", "groups", "members", "--channel", "slack", "--group-id", "group-1"],
+    ],
+  ])(
+    "rejects blank account for the $0 sibling leaf before shared resolution",
+    async (_label, args) => {
+      const program = new Command().name("openclaw");
+      registerDirectoryCli(program);
+
+      await expect(
+        program.parseAsync([...args, "--account", "", "--json"], { from: "user" }),
+      ).rejects.toThrow("--account must not be blank");
+
+      expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+      expect(mocks.resolveMessageChannelSelection).not.toHaveBeenCalled();
+      expect(mocks.resolveChannelDefaultAccountId).not.toHaveBeenCalled();
+      expect(mocks.getScopedChannelsCommandSecretTargets).not.toHaveBeenCalled();
+      expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+      expect(runtimeState.defaultRuntime.writeJson).not.toHaveBeenCalled();
+    },
+  );
+
   it("installs an explicit optional directory channel on demand", async () => {
     const tokenRef = {
       source: "env",

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -15,6 +15,7 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import { nullChannelDirectorySelf } from "../channels/plugins/directory-adapters.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { resolveInstallableChannelPlugin } from "../commands/channel-setup/channel-plugin-resolution.js";
+import { parseAccountSelector } from "../commands/channels/account-selector.js";
 import { requireValidConfigForWrite } from "../commands/config-validation.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
@@ -106,7 +107,7 @@ export function registerDirectoryCli(program: Command) {
   const withChannel = (cmd: Command) =>
     cmd
       .option("--channel <name>", "Channel (auto when only one is configured)")
-      .option("--account <id>", "Account id (accountId)")
+      .option("--account <id>", "Account id (accountId)", parseAccountSelector)
       .option("--json", "Output JSON", false);
 
   const resolve = async (opts: { channel?: string; account?: string }) => {

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -15,6 +15,7 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import { nullChannelDirectorySelf } from "../channels/plugins/directory-adapters.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { resolveInstallableChannelPlugin } from "../commands/channel-setup/channel-plugin-resolution.js";
+import { assertAccountSelector } from "../commands/channels/account-selector.js";
 import { requireValidConfigFileSnapshot } from "../commands/config-validation.js";
 import { getRuntimeConfig, replaceConfigFile } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
@@ -110,6 +111,7 @@ export function registerDirectoryCli(program: Command) {
       .option("--json", "Output JSON", false);
 
   const resolve = async (opts: { channel?: string; account?: string }) => {
+    assertAccountSelector(opts.account);
     const sourceSnapshot = await requireValidConfigFileSnapshot(defaultRuntime);
     if (!sourceSnapshot) {
       return null;

--- a/src/commands/channels/account-selector.ts
+++ b/src/commands/channels/account-selector.ts
@@ -1,8 +1,9 @@
-// Owns strict CLI account selection for state-mutating channel commands.
-export function assertAccountSelectorForMutation(account: string | undefined): void {
+// Owns strict CLI account selection for channel commands.
+export function parseAccountSelector(account: string | undefined): string | undefined {
   // Only omission selects the default account. Blank input often comes from an unset
-  // shell variable and must fail before channel setup, auth, or removal mutates state.
+  // shell variable and must fail before channel setup, auth, removal, or lookup runs.
   if (account !== undefined && !account.trim()) {
     throw new Error("--account must not be blank");
   }
+  return account;
 }

--- a/src/commands/channels/account-selector.ts
+++ b/src/commands/channels/account-selector.ts
@@ -1,7 +1,7 @@
-// Owns strict CLI account selection for state-mutating channel commands.
-export function assertAccountSelectorForMutation(account: string | undefined): void {
+// Owns strict CLI account selection for channel commands.
+export function assertAccountSelector(account: string | undefined): void {
   // Only omission selects the default account. Blank input often comes from an unset
-  // shell variable and must fail before channel setup, auth, or removal mutates state.
+  // shell variable and must fail before channel setup, auth, removal, or lookup runs.
   if (account !== undefined && !account.trim()) {
     throw new Error("--account must not be blank");
   }

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -26,7 +26,7 @@ import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { WizardCancelledError } from "../../wizard/prompts.js";
 import { normalizeExternalChannelSetupConfig } from "../channel-setup/config-compatibility.js";
 import { resolveChannelSetupOwner } from "../channel-setup/owner.js";
-import { assertAccountSelectorForMutation } from "./account-selector.js";
+import { parseAccountSelector } from "./account-selector.js";
 import { channelLabel } from "./runtime-label.js";
 import { requireValidConfigForWrite, shouldUseWizard } from "./shared.js";
 
@@ -132,7 +132,7 @@ async function channelsAddCommandImpl(
   runtime: RuntimeEnv,
   params?: { hasFlags?: boolean; beforePersistentEffect?: () => Promise<void> },
 ) {
-  assertAccountSelectorForMutation(opts.account);
+  parseAccountSelector(opts.account);
   const writeSnapshot = await requireValidConfigForWrite(runtime);
   if (!writeSnapshot) {
     return;

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -26,7 +26,7 @@ import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { WizardCancelledError } from "../../wizard/prompts.js";
 import { normalizeExternalChannelSetupConfig } from "../channel-setup/config-compatibility.js";
 import { resolveChannelSetupOwner } from "../channel-setup/owner.js";
-import { assertAccountSelectorForMutation } from "./account-selector.js";
+import { assertAccountSelector } from "./account-selector.js";
 import { channelLabel } from "./runtime-label.js";
 import { requireValidConfigFileSnapshot, shouldUseWizard } from "./shared.js";
 
@@ -132,7 +132,7 @@ async function channelsAddCommandImpl(
   runtime: RuntimeEnv,
   params?: { hasFlags?: boolean; beforePersistentEffect?: () => Promise<void> },
 ) {
-  assertAccountSelectorForMutation(opts.account);
+  assertAccountSelector(opts.account);
   const configSnapshot = await requireValidConfigFileSnapshot(runtime);
   if (!configSnapshot) {
     return;

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -19,7 +19,7 @@ import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-ke
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
-import { assertAccountSelectorForMutation } from "./account-selector.js";
+import { parseAccountSelector } from "./account-selector.js";
 import { persistChannelPluginConfig } from "./plugin-config-persistence.js";
 import { channelLabel } from "./runtime-label.js";
 import { type ChatChannel, requireValidConfigForWrite, shouldUseWizard } from "./shared.js";
@@ -79,7 +79,7 @@ export async function channelsRemoveCommand(
   runtime: RuntimeEnv = defaultRuntime,
   params?: { hasFlags?: boolean },
 ) {
-  assertAccountSelectorForMutation(opts.account);
+  parseAccountSelector(opts.account);
   const writeSnapshot = await requireValidConfigForWrite(runtime);
   if (!writeSnapshot) {
     return;

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -19,7 +19,7 @@ import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-ke
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
-import { assertAccountSelectorForMutation } from "./account-selector.js";
+import { assertAccountSelector } from "./account-selector.js";
 import { persistChannelPluginConfig } from "./plugin-config-persistence.js";
 import { channelLabel } from "./runtime-label.js";
 import { type ChatChannel, requireValidConfigFileSnapshot, shouldUseWizard } from "./shared.js";
@@ -79,7 +79,7 @@ export async function channelsRemoveCommand(
   runtime: RuntimeEnv = defaultRuntime,
   params?: { hasFlags?: boolean },
 ) {
-  assertAccountSelectorForMutation(opts.account);
+  assertAccountSelector(opts.account);
   const configSnapshot = await requireValidConfigFileSnapshot(runtime);
   if (!configSnapshot) {
     return;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scripts that passed an empty or whitespace-only `--account` value to `openclaw directory` queried the channel's default account.

## Why This Change Was Made

The shared account selector validates directory account values during option parsing, before command startup. Self, peer, group, and group-member lookups use the same rule. Existing add, remove, login, and logout guards keep their behavior.

## User Impact

Blank values fail with `--account must not be blank` before account setup or lookup. Scripts that want the channel default must omit `--account`. Valid explicit values retain their spelling and normal selection behavior.

## Evidence

- Exercised the normal built CLI from an unrelated working directory with isolated synthetic file credentials: 48 baseline cases and 48 candidate cases across all four directory commands, both output formats, empty/whitespace input, omission, explicit `default`, and distinct case-sensitive selectors.
- Baseline `9465116fd3bda32bef0c3c06f32d40eb2c704e1a` selected and queried the default account for blank inputs. Candidate `3ebcb01bdb128c38d95bee11e7a715c582dd1c72` returned the expected failure for those inputs.
- Eight new regression cases fail on the baseline because command startup runs first. All 51 focused directory and channel-selector tests pass on the candidate.
- Independent behavior review passes all 48 cases. Additional decoded kernel observations confirm that rejected inputs cause no account access or lookup; ordinary startup diagnostics remain visible.
- Formatting, scoped syntax lint, conflict-marker, line-count, and assertion checks pass. Full hosted checks remain required before merge.

The original contribution and contributor credit are preserved. Private raw traces and runtime details are retained outside the repository.
