### PR TITLE
fix(cli): reject blank audit bounds

### DIFF
--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -73,6 +73,8 @@ describe("audit command parsing", () => {
     { flag: "--after", options: { after: "-1" } },
     { flag: "--before", options: { before: "July 1, 2026" } },
     { flag: "--after", options: { after: "not-a-date" } },
+    { flag: "--after", options: { after: "" } },
+    { flag: "--before", options: { before: " \t" } },
   ])("rejects invalid $flag before calling the Gateway", async ({ flag, options }) => {
     await expect(auditListCommand(options, runtime)).rejects.toThrow(flag);
     expect(callGateway).not.toHaveBeenCalled();
@@ -112,6 +114,11 @@ describe("audit command parsing", () => {
 
     callGateway.mockClear();
     await expect(auditListCommand({ limit: "501" }, runtime)).rejects.toThrow("1 and 500");
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it.each(["", " \t"])("rejects an explicit empty list limit %#", async (limit) => {
+    await expect(auditListCommand({ limit }, runtime)).rejects.toThrow("1 and 500");
     expect(callGateway).not.toHaveBeenCalled();
   });
 
@@ -450,6 +457,13 @@ describe("audit run explanation", () => {
     callGateway.mockClear();
     await expect(
       auditListCommand({ explain: true, executionId: "execution-1", limit: "101" }, runtime),
+    ).rejects.toThrow("with --explain");
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it.each(["", " \t"])("rejects an explicit empty decision limit %#", async (limit) => {
+    await expect(
+      auditListCommand({ explain: true, runId: "run-1", limit }, runtime),
     ).rejects.toThrow("with --explain");
     expect(callGateway).not.toHaveBeenCalled();
   });

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -67,7 +67,7 @@ type AuditCliEvent = {
 
 function parseAuditTimestamp(value: string | undefined, flag: string): number | undefined {
   const trimmed = value?.trim();
-  if (!trimmed) {
+  if (trimmed === undefined) {
     return undefined;
   }
   if (/^\d+$/.test(trimmed)) {
@@ -84,7 +84,7 @@ function parseAuditTimestamp(value: string | undefined, flag: string): number | 
 }
 
 function parseAuditLimit(value: string | undefined): number {
-  if (!value) {
+  if (value === undefined) {
     return DEFAULT_AUDIT_LIMIT;
   }
   const parsed = parseStrictPositiveInteger(value);
@@ -95,7 +95,7 @@ function parseAuditLimit(value: string | undefined): number {
 }
 
 function parseAuditDecisionLimit(value: string | undefined): number {
-  if (!value) {
+  if (value === undefined) {
     return DEFAULT_AUDIT_DECISION_LIMIT;
   }
   const parsed = parseStrictPositiveInteger(value);


### PR DESCRIPTION
## What Problem This Solves

Fixes audit CLI bounds that silently accepted explicit blank values. `openclaw audit --after ""` removed the time boundary and queried a broader result set; an empty `--limit` silently selected the default page size. The same issue affected `--before` and the `--explain` decision limit.

## Why This Change Was Made

The audit parsers now distinguish omission (`undefined`) from present-but-invalid input. Blank timestamps reach the existing timestamp error, and blank limits reach the existing strict positive-integer bounds. This keeps validation at the canonical audit command owner with no new parser or policy branch.

## User Impact

Operators and scripts now get an explicit error when a shell-expanded audit bound is empty, instead of unknowingly querying a wider time range or larger page. Omitted values and valid timestamps/limits keep their existing behavior.

## Evidence

### Exact-head proof receipt

- Product head SHA: `0cffbf8ea24063f4665493d0a2fee10cc8c8ae6f`
- Current-main RED baseline: `a4ad6c76a4d19ec47394f0a1905c749252d308c1`
- Production entry: `openclaw audit --after "" --json`
- Canonical owner exercised: `parseAuditTimestamp`, `parseAuditLimit`, and `parseAuditDecisionLimit` in `src/commands/audit.ts`
- Decision surface: list `--after`/`--before`/`--limit` and explain-mode `--limit`, all before `audit.activity.list` or `audit.run.inspect`.
- Recorder/readback boundary: real source CLI structured output shows whether the command stops locally or reaches Gateway method authorization.
- Acceptance RED: the same empty `--after` command on current main reached `gateway audit.activity.list requires credentials`, proving the empty timestamp was silently omitted.
- Acceptance GREEN: exact head returns `--after must be an ISO timestamp or Unix milliseconds` before any Gateway call. Tests cover empty/whitespace timestamps plus list and explain limits.
- Legal control: exact head with `--after 1234 --limit 1` reaches `audit.activity.list` Gateway authorization, proving valid bounds still proceed.
- Cleanup: runs used isolated temporary state/config paths. Empty-input runs created zero state files; valid-control transient files remained inside the isolated directory and all temporary directories were removed.

### Inspectable RED -> GREEN terminal trace

`<EMPTY>` denotes the actual empty argv token. Node `v24.15.0`; verified `2026-09-03T13:52:34Z` (RED) and `2026-09-03T13:47:26Z` (GREEN).

```text
$ git rev-parse HEAD
a4ad6c76a4d19ec47394f0a1905c749252d308c1
$ node --import ./scripts/tsx.mjs src/entry.ts audit --after <EMPTY> --json
{
  "ok": false,
  "error": {"type":"cli_error","message":"gateway audit.activity.list requires credentials before opening a websocket"}
}
exit=1
```

The RED reaches Gateway authorization. At the product head:

```text
$ git rev-parse HEAD
0cffbf8ea24063f4665493d0a2fee10cc8c8ae6f
$ node --import ./scripts/tsx.mjs src/entry.ts audit --after <EMPTY> --json
{
  "ok": false,
  "error": {"type":"cli_error","message":"--after must be an ISO timestamp or Unix milliseconds."}
}
exit=1
state_files=0
```

Valid-value control:

```text
$ node --import ./scripts/tsx.mjs src/entry.ts audit --after 1234 --limit 1 --json
{
  "ok": false,
  "error": {"type":"cli_error","message":"gateway audit.activity.list requires credentials before opening a websocket"}
}
exit=1
```

### Verification

- Exact-head focused test: `node scripts/run-vitest.mjs run src/commands/audit.test.ts -t 'rejects invalid|explicit empty|keeps decision and run discovery queries bounded|converts ISO'` — 21 passed, 19 skipped.
- Full affected suite before the final mechanical main refresh: `src/commands/audit.test.ts` — 40 tests passed; the final rebase did not touch either changed file.
- `oxfmt --check` on both changed files — passed at exact head.
- `git diff --check upstream/main...HEAD` — passed.
- Fresh autoreview of the unchanged patch — clean, `patch is correct` with confidence `0.99`.

### Scope and risk

- Production LOC: `+3/-3` (net 0).
- Test LOC: `+14/-0` (net +14).
- Existing-solutions preflight: reuses existing audit timestamp validation and `parseStrictPositiveInteger`; no new library, plugin, workflow, or parsing system.
- Sibling coverage: both list timestamps, the normal list limit, and the explain-mode decision limit; omitted/default and valid controls remain covered.
- Not tested: an authenticated live audit query, because the changed path stops before RPC. The valid control reaches the exact Gateway authorization boundary.
- Config/default, protocol/schema, authorization, storage, migration, and upgrade impact: none. Explicit blanks that previously acted as omission now fail fast.
