### PR TITLE
fix(cli): reject blank log numeric options

### DIFF
--- a/src/cli/logs-cli.port.test.ts
+++ b/src/cli/logs-cli.port.test.ts
@@ -25,6 +25,7 @@ async function withLogsGateway(
   run: (fixture: {
     port: string;
     requests: string[];
+    tailParams: Array<Record<string, unknown>>;
     stdout: string[];
     stderr: string[];
   }) => Promise<void>,
@@ -48,6 +49,7 @@ async function withLogsGateway(
       });
       const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
       const requests: string[] = [];
+      const tailParams: Array<Record<string, unknown>> = [];
       server.on("connection", (socket) => {
         sendMinimalGatewayConnectChallenge(socket);
         socket.on("message", (data) => {
@@ -56,6 +58,9 @@ async function withLogsGateway(
             return;
           }
           requests.push(frame.method);
+          if (frame.method === "logs.tail") {
+            tailParams.push(frame.params ?? {});
+          }
           if (frame.method === "connect") {
             sendMinimalGatewayResponse(
               socket,
@@ -102,7 +107,7 @@ async function withLogsGateway(
         throw new ExitError(code);
       });
       try {
-        await run({ port, requests, stdout, stderr });
+        await run({ port, requests, tailParams, stdout, stderr });
       } finally {
         await closeMinimalGatewayServer(server);
       }
@@ -125,6 +130,44 @@ describe("logs local port selection", () => {
       });
     },
   );
+
+  it.each(["--limit", "--max-bytes", "--interval"])(
+    "rejects an explicitly empty numeric %s before contacting Gateway",
+    async (flag) => {
+      await withLogsGateway({}, async ({ port, requests }) => {
+        await expect(
+          runLogs(["--port", port, flag, "", "--json", "--timeout", "1500"]),
+        ).rejects.toThrow(`${flag} must be a positive integer.`);
+        expect(requests).toEqual([]);
+      });
+    },
+  );
+
+  it("preserves omitted defaults and forwards valid numeric limits to Gateway", async () => {
+    await withLogsGateway({}, async ({ port, requests, tailParams }) => {
+      await runLogs(["--port", port, "--json", "--timeout", "1500"]);
+      await expect(
+        runLogs([
+          "--port",
+          port,
+          "--limit",
+          "7",
+          "--max-bytes",
+          "4096",
+          "--interval",
+          "2",
+          "--json",
+          "--timeout",
+          "1500",
+        ]),
+      ).resolves.toBeUndefined();
+      expect(requests).toEqual(["connect", "logs.tail", "connect", "logs.tail"]);
+      expect(tailParams).toEqual([
+        { limit: 200, maxBytes: 250_000 },
+        { limit: 7, maxBytes: 4096 },
+      ]);
+    });
+  });
 
   it.each(["text", "json"])(
     "reports the rejection reason and selected port when the RPC fails in %s mode",

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -114,7 +114,7 @@ const JOURNAL_MAX_LIMIT = 5000;
 const JOURNAL_MAX_BYTES = 1_000_000;
 
 function parsePositiveInt(value: string | undefined, fallback: number, flag: string): number {
-  if (!value) {
+  if (value === undefined) {
     return fallback;
   }
   const parsed = parseStrictPositiveInteger(value);


### PR DESCRIPTION
## What Problem This Solves

Fixes a CLI validation bug where an explicitly empty numeric `logs` option was treated as omitted. For example, `openclaw logs --limit ""` silently selected the default limit and continued to Gateway access. The same omission predicate also affected `--max-bytes` and `--interval`.

## Why This Change Was Made

The shared logs numeric parser now treats only `undefined` as omission. Present-but-empty values flow through the existing strict positive-integer parser, keeping one canonical validation boundary for all three flags without adding a parser, fallback, or configuration surface.

## User Impact

Shell scripts whose variables expand to an empty numeric value now receive a clear validation error before Gateway access. Genuinely omitted flags retain their current defaults, and valid values continue unchanged.

## Evidence

### Exact-head proof receipt

- Product head SHA: `1b3e3443bbd4a4415e562ec349bd27804c12a399`
- Current-main RED baseline: `a4ad6c76a4d19ec47394f0a1905c749252d308c1`
- Production entry: `openclaw logs --port 1 --limit "" --json --timeout 1000`
- Canonical owner exercised: `parsePositiveInt` in `src/cli/logs-cli.ts`
- Decision surface: `--limit`, `--max-bytes`, and `--interval` share this owner before `logs.tail` RPC construction.
- Recorder/readback boundary: the real source CLI's JSON/stderr output distinguishes local validation from the downstream `gateway logs.tail requires credentials` boundary.
- Acceptance RED: the same empty-value command on current main reached `logs.tail` Gateway authorization, proving the blank token had been silently replaced by the default.
- Acceptance GREEN: exact head returns `--limit must be a positive integer` before Gateway contact; the Commander + local WebSocket regression also records zero requests for all three empty flags.
- Legal control: exact head with `--limit 1` advances to `logs.tail` Gateway authorization; focused tests also prove omitted defaults and valid `limit`/`maxBytes` forwarding.
- Cleanup: all CLI runs used isolated temporary state/config paths. The empty-value and valid control created zero state files; all temporary directories were removed.

### Inspectable RED -> GREEN terminal trace

`<EMPTY>` denotes the actual empty argv token passed after the flag. Node `v24.15.0`; verified `2026-09-03T13:52:34Z` (RED) and `2026-09-03T13:47:26Z` (GREEN).

```text
$ git rev-parse HEAD
a4ad6c76a4d19ec47394f0a1905c749252d308c1
$ node --import ./scripts/tsx.mjs src/entry.ts logs \
    --port 1 --limit <EMPTY> --json --timeout 1000
{"type":"error","message":"gateway logs.tail requires credentials before opening a websocket", ...}
exit=1
state_files=0
```

The RED is the downstream Gateway-auth error rather than a numeric validation error. At the product head:

```text
$ git rev-parse HEAD
1b3e3443bbd4a4415e562ec349bd27804c12a399
$ node --import ./scripts/tsx.mjs src/entry.ts logs \
    --port 1 --limit <EMPTY> --json --timeout 1000
{
  "ok": false,
  "error": {"type":"cli_error","message":"--limit must be a positive integer."}
}
exit=1
state_files=0
```

Valid-value control:

```text
$ node --import ./scripts/tsx.mjs src/entry.ts logs \
    --port 1 --limit 1 --json --timeout 1000
{"type":"error","message":"gateway logs.tail requires credentials before opening a websocket", ...}
exit=1
state_files=0
```

### Verification

- Exact-head focused test: `node scripts/run-vitest.mjs run src/cli/logs-cli.port.test.ts -t 'rejects an explicitly empty numeric|preserves omitted defaults'` — 4 passed.
- Full affected suites before the final mechanical main refresh: `src/cli/logs-cli.port.test.ts src/cli/logs-cli.test.ts` — 2 files, 51 tests passed; the final rebase did not touch either file.
- `oxfmt --check` on both changed files — passed at exact head.
- `git diff --check upstream/main...HEAD` — passed.
- Fresh autoreview of the unchanged patch — clean, `patch is correct` with confidence `0.99`.

### Scope and risk

- Production LOC: `+1/-1` (net 0).
- Test LOC: `+44/-1` (net +43).
- Existing-solutions preflight: reuses `parseStrictPositiveInteger`; no new library, plugin, workflow, or custom parsing system.
- Sibling coverage: all three shared numeric flags are rejected before Gateway contact; omitted and valid controls are covered.
- Not tested: an authenticated live Gateway log tail, because the changed behavior terminates before transport. The valid control reaches the transport authorization boundary.
- Config/default, protocol/schema, security, storage, migration, and upgrade impact: none. Existing scripts that intentionally relied on explicit blank values acting as omission will now fail fast.
