### PR TITLE
refactor(queue): reuse shared deferred fixtures

### DIFF
--- a/src/shared/bounded-serial-queue.test.ts
+++ b/src/shared/bounded-serial-queue.test.ts
@@ -1,23 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { BoundedSerialQueue } from "./bounded-serial-queue.js";
-
-function deferred<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (reason: unknown) => void;
-} {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<T>((accept, fail) => {
-    resolve = accept;
-    reject = fail;
-  });
-  return { promise, resolve, reject };
-}
 
 describe("BoundedSerialQueue", () => {
   it("runs one task at a time in FIFO order and continues after failures", async () => {
-    const first = deferred();
+    const first = createDeferred();
     const order: string[] = [];
     const queue = new BoundedSerialQueue({ maxPendingCount: 4, maxPendingWeight: 4 });
 
@@ -55,7 +42,7 @@ describe("BoundedSerialQueue", () => {
   });
 
   it("bounds waiting count and weight, then seals on the first overflow", () => {
-    const first = deferred();
+    const first = createDeferred();
     const queue = new BoundedSerialQueue({ maxPendingCount: 2, maxPendingWeight: 5 });
     const active = queue.enqueue(async () => await first.promise, { weight: 100 });
     const waiting = queue.enqueue(async () => undefined, { weight: 3 });
@@ -71,7 +58,7 @@ describe("BoundedSerialQueue", () => {
   });
 
   it("can reject at capacity without sealing admission", async () => {
-    const first = deferred();
+    const first = createDeferred();
     const queue = new BoundedSerialQueue({ maxPendingCount: 1, maxPendingWeight: 1 });
     const active = queue.enqueue(async () => await first.promise);
     const waiting = queue.enqueue(async () => undefined);
@@ -99,8 +86,8 @@ describe("BoundedSerialQueue", () => {
   });
 
   it("flushes only the accepted prefix visible at call time", async () => {
-    const first = deferred();
-    const second = deferred();
+    const first = createDeferred();
+    const second = createDeferred();
     const queue = new BoundedSerialQueue({ maxPendingCount: 2, maxPendingWeight: 2 });
     const active = queue.enqueue(async () => await first.promise);
     const flush = queue.flush();
@@ -142,7 +129,7 @@ describe("BoundedSerialQueue", () => {
   });
 
   it("seals idempotently while preserving accepted work", async () => {
-    const first = deferred();
+    const first = createDeferred();
     const queue = new BoundedSerialQueue({ maxPendingCount: 1, maxPendingWeight: 1 });
     const active = queue.enqueue(async () => await first.promise);
     const waiting = queue.enqueue(async () => "done");

--- a/src/talk/voice-transcript.test.ts
+++ b/src/talk/voice-transcript.test.ts
@@ -1,21 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   createVoiceTranscriptOperationRegistry,
   VOICE_TRANSCRIPT_QUEUE_POLICY,
 } from "./voice-transcript.js";
 
-function deferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((accept) => {
-    resolve = accept;
-  });
-  return { promise, resolve };
-}
-
 describe("VoiceTranscriptOperationRegistry", () => {
   it("keeps overflow terminal through drain and releases it only on close", async () => {
     const registry = createVoiceTranscriptOperationRegistry(VOICE_TRANSCRIPT_QUEUE_POLICY);
-    const first = deferred();
+    const first = createDeferred();
     const key = "agent\0voice-overflow";
     const accepted = [
       registry.run(key, async () => await first.promise),


### PR DESCRIPTION
## What Problem This Solves

The bounded serial queue and voice transcript registry tests each maintained a local deferred-promise factory despite an existing shared test helper used by the neighboring store-writer queue suite.

## Why This Change Was Made

Replace both local factories with `createDeferred` from `test/helpers/promise`. All seven target cases and 32 assertions remain, with only the factory calls renamed inside their bodies. FIFO ordering, failure barriers, count/weight limits, accepted-prefix flushing, idempotent sealing, and terminal overflow through drain and close/reopen keep their existing checks.

## User Impact

No user-visible behavior change. Production delta is zero; tests are +9/−29, net −20 lines. Runtime queues, registry ownership, shared helpers, and public interfaces are unchanged.

## Evidence

The same canonical five-suite selection passed all 24 cases before and after, with identical per-file order: bounded queue (6), voice registry (1), store-writer queue (3), request-start (6), and Talk Gateway control (8). Proof used Node 26.8.1, pnpm 12.1.0, and Vitest 4.1.11.

After the normal frozen install, the first unchanged baseline failed before collection with a Vitest cache `ENOENT`; zero tests ran. The installed cache owner was inspected, all children were joined, and the same canonical selection with `--clearCache` succeeded. The unchanged baseline retry then passed. The failed attempt remains recorded; no manual cache removal, cache override, source workaround, or timeout increase was used.

`node scripts/check-changed.mjs -- src/shared/bounded-serial-queue.test.ts src/talk/voice-transcript.test.ts` passed the full configured local gate, including test typechecking, lint, and export checks. Formatting preserved the reviewed bytes. Managed Codex review was clean through P2. This is helper consolidation, not new lifecycle coverage; the existing synchronous overflow case's unjoined release remains unchanged. Hosted CI will be checked on the published head.
