### PR TITLE
perf: reuse Code Mode skill field patterns

### DIFF
--- a/src/agents/code-mode-skills.ts
+++ b/src/agents/code-mode-skills.ts
@@ -23,8 +23,11 @@ function decodeXml(value: string): string {
     .replace(/&amp;/g, "&");
 }
 
-function readSkillField(block: string, field: "location" | "name"): string | undefined {
-  const match = new RegExp(`^[ ]{4}<${field}>(.*)</${field}>$`, "mu").exec(block)?.[1];
+const SKILL_NAME_PATTERN = /^[ ]{4}<name>(.*)<\/name>$/mu;
+const SKILL_LOCATION_PATTERN = /^[ ]{4}<location>(.*)<\/location>$/mu;
+
+function readSkillField(block: string, pattern: RegExp): string | undefined {
+  const match = pattern.exec(block)?.[1];
   return match === undefined ? undefined : decodeXml(match);
 }
 
@@ -44,8 +47,8 @@ export function resolveCodeModeSkills(params: {
   const result: CodeModeSkill[] = [];
   for (const match of catalog.matchAll(/^[ ]{2}<skill>\n([\s\S]*?)\n[ ]{2}<\/skill>$/gmu)) {
     const block = match[1] ?? "";
-    const name = readSkillField(block, "name");
-    const location = readSkillField(block, "location");
+    const name = readSkillField(block, SKILL_NAME_PATTERN);
+    const location = readSkillField(block, SKILL_LOCATION_PATTERN);
     const source = name ? candidatesByName.get(name) : undefined;
     if (!name || !location || !source) {
       continue;


### PR DESCRIPTION
Code Mode rebuilt two regular expressions for every skill block while reading the already rendered catalog. The name and location patterns are fixed, so this repeats work during tool preparation without changing the result.

This moves those two patterns to their private owner and passes the appropriate pattern into the existing field reader. Both retain the exact multiline/Unicode flags; neither is global or sticky. XML decoding, catalog eligibility, ordering, source selection, fresh returned objects and reader identity are unchanged. No configuration, plugin API, dependency or prompt text changes.

The change is **+7/-4 production lines, tests unchanged**. The three added lines own the reusable patterns; there is no extra cache or alternate parsing path.

### Measurement

One fixed fresh before/candidate/candidate/before cohort exercised complete exported operations: 5,540 public calls, including real formatter and read-callback controls, with 512 measured eight-call means. Full values, input/output identities, ordering, source/module facts and native resource/closure records were retained and independently audited.

| Measured case | Forward median change | Reverse median change |
| --- | ---: | ---: |
| Primary catalog parser R01 | -24.51% | -23.32% |
| Primary catalog parser R02 | -26.16% | -23.32% |
| Real formatter plus parser R05 | -11.77% | -16.50% |

The original gates passed: each primary improved at least 3% in each order; no protected case exceeded both 3% and 1 µs regression in both orders; RSS stayed within its gate. Kernel RSS changed +2.29%/-4.06%.

This is not uniform across every sample. R03's forward median rose 36.625 ns and R08's rose 242.313 ns; their reverse medians improved. R07's reverse p95 rose 138.04% (+17.859 µs). All 19 adverse summaries remain in the evidence. These are local operation measurements, not whole Gateway or provider-turn latency claims.

An earlier partial experiment stopped on an invalid strict-positive per-call timer assumption. It remains excluded. The fresh cohort retained all 28 zero-resolution intervals without replacement or re-batching; every measured aggregate median was positive. No run within the fresh cohort was retried, and no old sample was reused.

### Validation

- Fresh baseline/candidate validation on main base `a4ad6c76`: the same 45 passing cases, no skips, across `code-mode.skills`, `workspace-skill-prompt` and `workspace-skill-prompt-resolution`.
- Complete changed-code check passed all 28 selected commands, including types, lint, dead exports and applicable guards; complete elapsed time 276.224 seconds.
- Independent managed Codex review: no actionable P0–P2 findings. Root reviewed the exact source, transfer, evidence and slower controls.
- All 237 recorded validation PIDs and 112 process groups closed. Measured processes were separately verified closed.
- All 15 selected unchanged caller/producer/test files match current main `907f6956`; the exact measured candidate is preserved.

Retained local evidence identities: measurement final `380969d61aaca17c2ab5cbc5745602ee3cfa0181db4b263995eff5d120efc8da`; independent raw audit `e95d087790874ce0a9469d8e8a83fa15b1efda5f8928368dfd8b686c6f583969`; fresh landing validation `98b0efc738482431f13193a0a544f55ee30752a68013c654caf543ba6efa9b09`.
