### PR TITLE
refactor(cron): reuse isolated run suite hooks

### DIFF
--- a/src/cron/isolated-agent/run.auth-profile-cold-path.test.ts
+++ b/src/cron/isolated-agent/run.auth-profile-cold-path.test.ts
@@ -1,5 +1,5 @@
 // Auth profile cold-path tests cover auth loading for isolated cron runs.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hasAnyAuthProfileStoreSourceMock = vi.fn(() => false);
 
@@ -7,12 +7,10 @@ vi.mock("../../agents/auth-profiles/source-check.js", () => ({
   hasAnyAuthProfileStoreSource: hasAnyAuthProfileStoreSourceMock,
 }));
 
+import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
-  clearFastTestEnv,
   loadRunCronIsolatedAgentTurn,
   resolveSessionAuthSelectionMock,
-  resetRunCronIsolatedAgentTurnHarness,
-  restoreFastTestEnv,
 } from "./run.test-harness.js";
 
 const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
@@ -40,17 +38,11 @@ function makeParams(overrides?: Record<string, unknown>) {
 }
 
 describe("runCronIsolatedAgentTurn auth-profile cold path", () => {
-  let previousFastTestEnv: string | undefined;
+  setupRunCronIsolatedAgentTurnSuite();
 
   beforeEach(() => {
-    previousFastTestEnv = clearFastTestEnv();
-    resetRunCronIsolatedAgentTurnHarness();
     hasAnyAuthProfileStoreSourceMock.mockReset();
     hasAnyAuthProfileStoreSourceMock.mockReturnValue(false);
-  });
-
-  afterEach(() => {
-    restoreFastTestEnv(previousFastTestEnv);
   });
 
   it("skips auth-profile override resolution when no sources exist", async () => {

--- a/src/cron/isolated-agent/run.diagnostic-events.test.ts
+++ b/src/cron/isolated-agent/run.diagnostic-events.test.ts
@@ -1,5 +1,5 @@
 // Run diagnostic event tests cover emitted diagnostics from isolated cron runs.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   onDiagnosticEvent,
   onInternalDiagnosticEvent,
@@ -11,14 +11,12 @@ vi.mock("../../agents/auth-profiles/source-check.js", () => ({
   hasAnyAuthProfileStoreSource: vi.fn(() => false),
 }));
 
+import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
-  clearFastTestEnv,
   loadRunCronIsolatedAgentTurn,
   makeCronSession,
   makeCronSessionEntry,
-  resetRunCronIsolatedAgentTurnHarness,
   resolveCronSessionMock,
-  restoreFastTestEnv,
   runWithModelFallbackMock,
 } from "./run.test-harness.js";
 
@@ -55,17 +53,11 @@ type EventRecord = {
 };
 
 describe("runCronIsolatedAgentTurn diagnostic events", () => {
-  let previousFastTestEnv: string | undefined;
+  setupRunCronIsolatedAgentTurnSuite();
 
   beforeEach(() => {
-    previousFastTestEnv = clearFastTestEnv();
-    resetRunCronIsolatedAgentTurnHarness();
     resetDiagnosticStateForTest();
     resetDiagnosticEventsForTest();
-  });
-
-  afterEach(() => {
-    restoreFastTestEnv(previousFastTestEnv);
   });
 
   it("emits a paired queued/processing/idle/processed lifecycle for an isolated cron run", async () => {


### PR DESCRIPTION
## What Problem This Solves

The auth cold-path and diagnostic-event suites repeat environment restoration and harness reset plumbing already owned by the shared isolated-cron suite helper.

## Why This Change Was Made

Use the existing helper before each suite's local resets. Keep the strict job fixtures, every test body and assertion, per-case overrides, and diagnostic listener cleanup unchanged. This removes 16 test lines with no production or shared-harness changes.

## User Impact

No product behavior changes. Auth cold-path, configured-profile propagation, diagnostic lifecycle/disablement/session attribution, and usage-accounting coverage remain intact.

## Evidence

- All 16 cases across both full target suites and the auth-propagation/usage-accounting siblings passed before and after the change, in the same natural file and case order.
- Scoped formatting, the full two-path LOCAL changed gate, and independent Codex P2 review passed.
- The extra hook await and the existing helper's fresh default-session assignment were checked explicitly; local resets and per-case overrides retain their order, and all listener `finally` cleanup remains unchanged.
- Production delta: 0. Tests: +6/-22, net -16. Proof ran on the fixed `de2382a754063b2625fe1190ef6ccab2f98889e8` base with the frozen dependency graph reconciled.
