### PR TITLE
fix(qa-channel): preserve conversation kind for implicit actions

### DIFF
--- a/docs/channels/qa-channel.md
+++ b/docs/channels/qa-channel.md
@@ -17,6 +17,7 @@ read_when:
   - `group:<room>`
   - `thread:<room>/<thread>`
 - Shared `channel:` and `group:` conversations are surfaced to agents as group/channel room turns, so they exercise the same visible-reply and message-tool routing policy used by Discord, Slack, Telegram, and similar transports.
+- Message sends that omit `target` and `to` preserve the inbound conversation kind: direct, group, or channel.
 - HTTP-backed synthetic bus for inbound message injection, outbound transcript capture, thread creation, reactions, edits, deletes, and search/read actions.
 - Media-bearing streamed replies deliver attachments and the current tool trace together. A later identical text-only final is suppressed only when its caption and tool trace were already delivered successfully.
 - Host-side self-check runner that writes a Markdown report to `.artifacts/qa-e2e/`.

--- a/extensions/qa-channel/src/channel.threading.test.ts
+++ b/extensions/qa-channel/src/channel.threading.test.ts
@@ -2,30 +2,46 @@ import { describe, expect, it } from "vitest";
 import { qaChannelPlugin } from "../api.js";
 
 describe("qa-channel thread delivery contracts", () => {
-  it("publishes the current QA thread to message-tool delivery proof", () => {
+  it.each([
+    {
+      name: "channel thread with shared-room ChatType",
+      To: "thread:qa-room/thread-1",
+      NativeChannelId: "qa-room",
+      ChatType: "group",
+      root: "channel:qa-room",
+    },
+    {
+      name: "direct thread with a distinct native root",
+      To: "thread:/v1/dm/qa-peer/thread-1",
+      NativeChannelId: "native-peer",
+      ChatType: "direct",
+      root: "dm:native-peer",
+    },
+    {
+      name: "group thread without native metadata",
+      To: "thread:/v1/group/qa-room/thread-1",
+      ChatType: "group",
+      root: "group:qa-room",
+    },
+  ] as const)("keeps the typed root separate from $name", (testCase) => {
     const hasRepliedRef = { value: false };
     const context = qaChannelPlugin.threading?.buildToolContext?.({
       cfg: {},
-      context: {
-        To: "thread:qa-room/thread-1",
-        NativeChannelId: "qa-room",
-        ChatType: "channel",
-        MessageThreadId: "thread-1",
-      },
+      context: testCase,
       hasRepliedRef,
     });
 
     expect(context).toEqual({
-      currentChannelId: "qa-room",
-      currentChatType: "channel",
-      currentMessagingTarget: "thread:qa-room/thread-1",
+      currentChannelId: testCase.root,
+      currentChatType: testCase.ChatType,
+      currentMessagingTarget: testCase.To,
       currentThreadTs: "thread-1",
       replyToMode: "all",
       hasRepliedRef,
     });
     expect(
       qaChannelPlugin.threading?.matchesToolContextTarget?.({
-        target: "qa-room",
+        target: testCase.root,
         toolContext: context!,
       }),
     ).toBe(true);
@@ -35,6 +51,21 @@ describe("qa-channel thread delivery contracts", () => {
         toolContext: context!,
       }),
     ).toBe(false);
+  });
+
+  it("retains native-only context and explicit thread metadata when To is absent", () => {
+    expect(
+      qaChannelPlugin.threading?.buildToolContext?.({
+        cfg: {},
+        context: { NativeChannelId: "qa-peer", ChatType: "direct", MessageThreadId: "thread-1" },
+      }),
+    ).toMatchObject({
+      currentChannelId: "qa-peer",
+      currentChatType: "direct",
+      currentMessagingTarget: undefined,
+      currentThreadTs: "thread-1",
+      replyToMode: "all",
+    });
   });
 
   it("extracts thread replies as canonical QA thread targets", () => {

--- a/extensions/qa-channel/src/channel.ts
+++ b/extensions/qa-channel/src/channel.ts
@@ -244,31 +244,32 @@ export const qaChannelPlugin: ChannelPlugin<ResolvedQaChannelAccount> = createCh
       },
       buildToolContext: ({ context, hasRepliedRef }) => {
         const currentMessagingTarget = context.To?.trim() || undefined;
+        const chatType =
+          context.ChatType === "direct" ||
+          context.ChatType === "group" ||
+          context.ChatType === "channel"
+            ? context.ChatType
+            : undefined;
         const parsedTarget = currentMessagingTarget
           ? parseQaTarget(currentMessagingTarget, {
-              defaultChatType:
-                context.ChatType === "direct" ||
-                context.ChatType === "group" ||
-                context.ChatType === "channel"
-                  ? context.ChatType
-                  : "channel",
+              defaultChatType: chatType ?? "channel",
             })
           : undefined;
+        const nativeChannelId = context.NativeChannelId?.trim() || undefined;
         const currentThreadTs =
           context.MessageThreadId != null
             ? String(context.MessageThreadId)
             : parsedTarget?.threadId;
         return {
-          currentChannelId:
-            context.NativeChannelId?.trim() ||
-            parsedTarget?.conversationId ||
-            currentMessagingTarget,
-          currentChatType:
-            context.ChatType === "direct" ||
-            context.ChatType === "group" ||
-            context.ChatType === "channel"
-              ? context.ChatType
-              : parsedTarget?.chatType,
+          // Implicit actions need a typed root; embedding To's thread would
+          // bypass topLevel/threadId:null opt-outs.
+          currentChannelId: parsedTarget
+            ? buildQaTarget({
+                chatType: parsedTarget.chatType,
+                conversationId: nativeChannelId || parsedTarget.conversationId,
+              })
+            : nativeChannelId,
+          currentChatType: chatType ?? parsedTarget?.chatType,
           currentMessagingTarget,
           currentThreadTs,
           ...(currentThreadTs ? { replyToMode: "all" as const } : {}),

--- a/test/qa-channel-message-tool-delivery.test.ts
+++ b/test/qa-channel-message-tool-delivery.test.ts
@@ -1,0 +1,283 @@
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getQaBusState,
+  injectQaBusInboundMessage,
+  qaChannelPlugin,
+  type QaBusConversationKind,
+  type QaBusMessage,
+} from "../extensions/qa-channel/api.js";
+import { createQaBusState, startQaBusServer } from "../extensions/qa-lab/bus-api.js";
+import { createMessageTool } from "../src/agents/tools/message-tool-execution.js";
+import { buildThreadingToolContext } from "../src/auto-reply/reply/agent-runner-utils.js";
+import { resolveReplyToMode } from "../src/auto-reply/reply/reply-threading.js";
+import * as bootstrapRegistry from "../src/channels/plugins/bootstrap-registry.js";
+import type { OpenClawConfig } from "../src/config/config.js";
+import {
+  mintMessageActionTurnCapability,
+  revokeMessageActionTurnCapability,
+} from "../src/gateway/message-action-turn-capability.js";
+import { runMessageAction } from "../src/infra/outbound/message-action-runner.js";
+import { createStartAccountContext } from "../src/plugin-sdk/test-helpers/start-account-context.js";
+import { setActivePluginRegistry } from "../src/plugins/runtime.js";
+import { createRuntimeChannel } from "../src/plugins/runtime/runtime-channel.js";
+import { createTestRegistry } from "../src/test-utils/channel-plugins.js";
+import { withOpenClawTestState } from "../src/test-utils/openclaw-test-state.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setActivePluginRegistry(createTestRegistry([]));
+});
+
+const conversationId = "qa-shared-id";
+const nonce = "implicit-target-nonce";
+
+async function withQaMessageTool(
+  source: {
+    kind: QaBusConversationKind;
+    threadId?: string;
+    trusted?: boolean;
+    sourceReplyOnly?: boolean;
+  },
+  exercise: (fixture: {
+    tool: ReturnType<typeof createMessageTool>;
+    inbound: QaBusMessage;
+    busState: ReturnType<typeof createQaBusState>;
+    baseUrl: string;
+  }) => Promise<void>,
+) {
+  await withOpenClawTestState({ prefix: "message-tool-qa-target-" }, async (state) => {
+    const busState = createQaBusState();
+    const bus = await startQaBusServer({ state: busState });
+    const controller = new AbortController();
+    let capability: string | undefined;
+    // Reuse the real plugin's metadata instead of source-JIT loading another
+    // copy; bootstrap loading is not part of this delivery boundary.
+    vi.spyOn(bootstrapRegistry, "getBootstrapChannelPlugin").mockImplementation((id) => {
+      expect(id).toBe("qa-channel");
+      return qaChannelPlugin;
+    });
+    try {
+      const config = {
+        agents: { entries: { main: { default: true, workspace: state.workspaceDir } } },
+        session: { dmScope: "per-channel-peer" },
+        channels: { "qa-channel": { baseUrl: bus.baseUrl } },
+      } satisfies OpenClawConfig;
+      // External-plugin canonicalization would hide a kind lost by the QA
+      // producer. Match the bundled runtime's authorization path.
+      setActivePluginRegistry(
+        createTestRegistry([
+          { pluginId: "qa-channel", source: "test", origin: "bundled", plugin: qaChannelPlugin },
+        ]),
+      );
+      const { message: inbound } = await injectQaBusInboundMessage({
+        baseUrl: bus.baseUrl,
+        input: {
+          accountId: "default",
+          conversation: { kind: source.kind, id: conversationId },
+          senderId: "qa-peer",
+          senderName: "QA Peer",
+          text: "Reply in this conversation.",
+          threadId: source.threadId,
+        },
+      });
+      let dispatched = 0;
+      let dispatchError: Error | undefined;
+      const channelRuntime = createRuntimeChannel({
+        // Replace only the model dispatcher; ingress, session recording, tool
+        // normalization, authorization, QA parsing, and HTTP bus delivery stay real.
+        dispatchReplyFromConfig: async ({ ctx }) => {
+          try {
+            dispatched++;
+            expect(ctx).toMatchObject({
+              Provider: "qa-channel",
+              NativeChannelId: conversationId,
+              ChatType: source.kind === "direct" ? "direct" : "group",
+              AccountId: "default",
+              MessageSid: inbound.id,
+            });
+            const toolContext = buildThreadingToolContext({
+              sessionCtx: {
+                ...ctx,
+                ReplyToMode: resolveReplyToMode(config, "qa-channel", ctx.AccountId, ctx.ChatType),
+              },
+              config,
+              hasRepliedRef: { value: false },
+            });
+            if (source.trusted) {
+              capability = mintMessageActionTurnCapability({
+                agentId: "main",
+                runId: "qa-resource-run",
+                sessionKey: ctx.SessionKey!,
+                requesterAccountId: ctx.AccountId,
+                requesterSenderId: ctx.SenderId,
+                toolContext,
+              });
+            }
+            const tool = createMessageTool({
+              config,
+              agentId: "main",
+              agentSessionKey: ctx.SessionKey,
+              agentAccountId: ctx.AccountId,
+              ...toolContext,
+              messageActionTurnCapability: capability,
+              runId: source.trusted ? "qa-resource-run" : undefined,
+              sourceReplyOnly: source.sourceReplyOnly,
+              sourceReplyDeliveryMode: "message_tool_only",
+              workspaceDir: state.workspaceDir,
+              runMessageAction,
+              getScopedChannelsCommandSecretTargets: () => ({ targetIds: new Set<string>() }),
+              resolveCommandSecretRefsViaGateway: async ({ config: inputConfig }) => ({
+                resolvedConfig: inputConfig,
+                diagnostics: [],
+                targetStatesByPath: {},
+                hadUnresolvedTargets: false,
+              }),
+            });
+            await exercise({ tool, inbound, busState, baseUrl: bus.baseUrl });
+          } catch (error) {
+            dispatchError = toErrorObject(error, "QA message-tool dispatch failed");
+          } finally {
+            controller.abort();
+          }
+          return {
+            queuedFinal: false,
+            counts: { tool: 0, block: 0, final: 0 },
+            observedReplyDelivery: true,
+          };
+        },
+      });
+      const startAccount = qaChannelPlugin.gateway?.startAccount;
+      expect(startAccount).toBeDefined();
+      await startAccount!({
+        ...createStartAccountContext({
+          cfg: config,
+          account: qaChannelPlugin.config.resolveAccount(config, "default"),
+          abortSignal: controller.signal,
+        }),
+        channelRuntime,
+      });
+      expect(dispatched).toBe(1);
+      if (dispatchError) {
+        throw dispatchError;
+      }
+    } finally {
+      if (capability) {
+        revokeMessageActionTurnCapability(capability);
+      }
+      controller.abort();
+      await bus.stop();
+    }
+  });
+}
+
+describe("QA message-tool current conversation delivery", () => {
+  it.each([
+    { name: "implicit direct", kind: "direct", explicit: false },
+    { name: "implicit group", kind: "group", explicit: false },
+    { name: "implicit channel", kind: "channel", explicit: false },
+    { name: "explicit canonical DM", kind: "direct", explicit: true },
+    { name: "source-only direct", kind: "direct", explicit: false, sourceReplyOnly: true },
+  ] as const)("preserves the inbound conversation for $name", async (testCase) => {
+    await withQaMessageTool(testCase, async ({ tool, inbound, baseUrl }) => {
+      if ("sourceReplyOnly" in testCase) {
+        await expect(
+          tool.execute("foreign-kind", {
+            action: "send",
+            target: `channel:${conversationId}`,
+            message: nonce,
+          }),
+        ).rejects.toThrow("cannot target another conversation or thread");
+      }
+      await tool.execute("qa-send", {
+        action: "send",
+        message: nonce,
+        final: true,
+        ...(testCase.explicit ? { target: `dm:${conversationId}` } : {}),
+      });
+      const snapshot = await getQaBusState(baseUrl);
+      const outbound = snapshot.messages.filter((message) => message.direction === "outbound");
+      expect(outbound).toEqual([
+        expect.objectContaining({
+          conversation: inbound.conversation,
+          accountId: inbound.accountId,
+          text: nonce,
+          replyToId: inbound.id,
+          attachments: [],
+        }),
+      ]);
+      expect(outbound[0]?.threadId).toBeUndefined();
+      expect(snapshot.threads).toEqual([]);
+    });
+  });
+
+  it.each(["direct", "group"] as const)(
+    "scopes targetless read/react/edit to the %s source, rejecting same-ID foreign kinds",
+    async (kind) => {
+      await withQaMessageTool({ kind, trusted: true }, async ({ tool, busState, baseUrl }) => {
+        const own = busState.addOutboundMessage({
+          to: `${kind === "direct" ? "dm" : kind}:${conversationId}`,
+          text: "original",
+        });
+        const foreign = busState.addOutboundMessage({
+          to: `channel:${conversationId}`,
+          text: "foreign",
+        });
+        for (const args of [
+          { action: "read" },
+          { action: "react", emoji: "white_check_mark" },
+          { action: "edit", message: "edited" },
+        ]) {
+          await expect(
+            tool.execute(`foreign-${args.action}`, { ...args, messageId: foreign.id }),
+          ).rejects.toThrow("not in the selected conversation");
+          const result = await tool.execute(`own-${args.action}`, { ...args, messageId: own.id });
+          expect(result.details).toMatchObject({
+            message: { id: own.id, conversation: own.conversation },
+          });
+        }
+        const snapshot = await getQaBusState(baseUrl);
+        expect(snapshot.messages.find((message) => message.id === own.id)).toMatchObject({
+          text: "edited",
+          reactions: [expect.objectContaining({ emoji: "white_check_mark", senderId: "openclaw" })],
+        });
+        expect(snapshot.messages.find((message) => message.id === foreign.id)).toEqual(foreign);
+      });
+    },
+  );
+
+  it.each([
+    { name: "topLevel", args: { topLevel: true }, threadId: undefined, reply: false },
+    { name: "null threadId", args: { threadId: null }, threadId: undefined, reply: false },
+    {
+      name: "explicit thread target",
+      args: { target: `thread:${conversationId}/topic` },
+      threadId: "topic",
+      reply: true,
+    },
+  ])("keeps thread targeting separate for $name", async (testCase) => {
+    await withQaMessageTool(
+      { kind: "channel", threadId: "topic" },
+      async ({ tool, inbound, baseUrl }) => {
+        await tool.execute("qa-thread-send", {
+          action: "send",
+          message: nonce,
+          final: true,
+          ...testCase.args,
+        });
+        const snapshot = await getQaBusState(baseUrl);
+        const outbound = snapshot.messages.filter((message) => message.direction === "outbound");
+        expect(outbound).toEqual([
+          expect.objectContaining({
+            conversation: inbound.conversation,
+            accountId: inbound.accountId,
+            text: nonce,
+            attachments: [],
+          }),
+        ]);
+        expect(outbound[0]?.threadId).toBe(testCase.threadId);
+        expect(outbound[0]?.replyToId).toBe(testCase.reply ? inbound.id : undefined);
+      },
+    );
+  });
+});

--- a/test/qa-channel-message-tool-delivery.test.ts
+++ b/test/qa-channel-message-tool-delivery.test.ts
@@ -7,7 +7,7 @@ import {
   type QaBusConversationKind,
   type QaBusMessage,
 } from "../extensions/qa-channel/api.js";
-import { createQaBusState, startQaBusServer } from "../extensions/qa-lab/bus-api.js";
+import { createQaBusState, startQaBusServer } from "../extensions/qa-lab/api.js";
 import { createMessageTool } from "../src/agents/tools/message-tool-execution.js";
 import { buildThreadingToolContext } from "../src/auto-reply/reply/agent-runner-utils.js";
 import { resolveReplyToMode } from "../src/auto-reply/reply/reply-threading.js";


### PR DESCRIPTION
Closes #137339

<details>
<summary>Additional instructions</summary>

This same-repository branch remains writable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where QA-channel replies sent without an explicit destination could appear in a channel conversation instead of the original direct or group conversation, even though the conversation ID, account, text, and reply reference were correct. The same kind loss could make targetless resource actions select a same-ID message from the wrong conversation kind.

## Why This Change Was Made

Preserve the conversation kind at QA's threading-context producer by encoding the native/root ID with the existing target builder. The default target remains an unthreaded root, while the full messaging target and thread metadata stay separate. This repairs the input consumed by the shared message-action flow without changing shared target precedence, parser defaults, or authorization.

Globally preferring the messaging target would break native-channel resource actions in transports such as Slack. Copying a threaded target into the default would also defeat explicit root opt-outs. The QA-owned producer is the narrow canonical repair.

Production LOC: **+17/-16 (net +1)**. Consolidating duplicate kind selection makes executable code net -1; two invariant-comment lines explain why the root must remain unthreaded. Tests: **+325/-11 (net +314)**. Documentation: **+1**.

Maintainer decision on ClawSweeper's remaining merge-risk item: **retain the +1 net line**. The two comment lines protect the root/thread opt-out invariant, while executable code shrinks. No additional guard, fallback, helper, or public surface is introduced; deleting the invariant explanation just to reduce the raw count would make the repair worse.

## User Impact

Repo-local QA runs preserve direct/group/channel identity for implicit replies and keep same-ID foreign-kind messages outside the selected resource-action scope. Explicit destinations and root/thread opt-outs remain intact. The [QA channel documentation](https://docs.openclaw.ai/channels/qa-channel) records the behavior.

No public API, configuration option, schema, persistent representation, dependency, source-custody policy, or native execution-authority change. No claim that real Slack/Discord transports had this QA-specific defect. Pre-existing ordinary QA implicit-thread inheritance remains a separate follow-up.

## Evidence

The final ten-case regression fixture fails **five cases on the original producer** and passes **all ten with this repair**. Failures are wrong-kind direct/group/source-only replies and incorrectly accepted same-ID foreign-kind reads; explicit DM and root/thread controls remain passing. The original producer was restored only for the negative control, then the identical repair patch was reapplied.

```bash
node scripts/run-vitest.mjs test/qa-channel-message-tool-delivery.test.ts
```

The regression uses actual QA HTTP ingress, account polling, session recording, shared message-tool/action dispatch, and HTTP bus readback. It reuses the real loaded plugin for bootstrap metadata instead of source-JIT loading a second copy; it does not mock target parsing, authorization, or delivery, and does not increase a timeout.

An additional **436 tests across nine focused files** passed: QA action/threading contracts, shared normalization/threading, exact-current message-action security, capability expiry/revocation, message-tool source/account/hidden-text guards, agent-runner context, and Slack native/routable target behavior.

```bash
node scripts/check-changed.mjs -- docs/channels/qa-channel.md extensions/qa-channel/src/channel.ts extensions/qa-channel/src/channel.threading.test.ts test/qa-channel-message-tool-delivery.test.ts
```

```bash
OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build qaRuntime
```

Changed checks, the private QA runtime build, and `git diff --check` passed. Fresh isolated Codex autoreview is scoped-clean at its configured P0 priority. Initial fixture placement/type/lint failures were fixed without changing guards, baselines, or tsconfig rules.

The first CI run caught one additional test import-boundary violation: the root fixture used QA Lab's `bus-api.js` rather than its accepted public `api.js` barrel. Both already export the same bus implementations. The test now uses `api.js`; the unchanged boundary guard and all ten delivery cases pass (**20 tests total**), as do root-test typecheck, targeted lint, and a fresh review of that correction. Production bytes and the real mock-Gateway proof below are unchanged.

```bash
node scripts/run-vitest.mjs test/extension-test-boundary.test.ts test/qa-channel-message-tool-delivery.test.ts
```

### Real mock-Gateway behavior proof

An actual built Gateway, the real QA plugin/bus, and a loopback mock OpenAI-compatible provider processed three ordinary inbound turns. The provider saw the real message schema and called `message` with only `action` and `message`—no target or recipient. All three turns produced exactly one visible message with the exact nonce, account, conversation ID/kind, and inbound reply ID; no thread or attachments were introduced.

```json
{
  "status": "pass",
  "proofKind": "real-built-gateway-with-loopback-mock-provider",
  "runtime": "openclaw",
  "buildBase": "01cf9f25bde3e5bc1f377109d6e6c8421e7f3228",
  "candidateQaSourceSha256": "a69a70426953eb94b316c1eaf3ab1a151f9e49d6a75d756984f6c463e0daf07c",
  "tool": "message",
  "argumentKeys": ["action", "message"],
  "cases": [
    {"inboundKind": "direct", "outboundKind": "direct", "visibleResults": 1, "status": "pass"},
    {"inboundKind": "group", "outboundKind": "group", "visibleResults": 1, "status": "pass"},
    {"inboundKind": "channel", "outboundKind": "channel", "visibleResults": 1, "status": "pass"}
  ],
  "account": "default",
  "dmScope": "per-channel-peer",
  "exactNonceAndReplyToId": true,
  "threadsOrAttachments": false,
  "sourceAndBuildCustodyUnchanged": true,
  "cleanup": "gateway, bus, provider stopped; owned ports closed; temporary runtime removed"
}
```

The build base plus unchanged candidate source/build digests bind this pre-commit run to the repair; this is **not** a fresh authenticated native Codex/provider run. The selected mock runtime did not expose `final`, so the provider did not fabricate that argument. Existing boundary coverage separately exercises `final: true`. The exact upstream Codex 0.152.1 JSON argument-forwarding source was personally inspected during attribution; no Codex-side change is proposed.

Proof used isolated synthetic home/state/workspace and non-default loopback ports, with live auth environment removed. Team, operator gateways/state, and real channel accounts were untouched. Original failures remain recorded as failures; the original observation's unrelated SQL instrumentation was not used as delivery proof.
