### PR TITLE
fix(qa): restore Slack private QA startup

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
@@ -1,11 +1,6 @@
 // Qa Lab plugin module implements Slack live transport adapter behavior.
 import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
-import {
-  createSlackWebClient,
-  createSlackWriteClient,
-  resolveSlackWebClientOptions,
-} from "@openclaw/slack/api.js";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { toStringifiedError } from "openclaw/plugin-sdk/error-runtime";
 import { acquireDebugProxyCaptureStore } from "openclaw/plugin-sdk/proxy-capture";
@@ -33,6 +28,7 @@ import {
   listSlackThreadMessages,
   sendSlackChannelMessage,
 } from "./slack-live.observations.js";
+import { loadSlackQaRuntime } from "./slack-plugin.runtime.js";
 
 type AdapterFactory = NonNullable<QaRunnerCliRegistration["adapterFactory"]>;
 type FactoryContext = Parameters<AdapterFactory["create"]>[0];
@@ -117,6 +113,8 @@ async function recordSlackObservedMessage(params: {
 export async function createSlackQaTransportAdapter(
   context: FactoryContext,
 ): Promise<AdapterDefinition> {
+  const { createSlackWebClient, createSlackWriteClient, resolveSlackWebClientOptions } =
+    loadSlackQaRuntime();
   const options = context.adapterOptions ?? {};
   const lease = await acquireQaCredentialLease<SlackQaRuntimeEnv>({
     kind: "slack",

--- a/extensions/qa-lab/src/live-transports/slack/slack-boundary.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-boundary.test.ts
@@ -1,0 +1,49 @@
+// QA Lab tests enforce Slack runtime dependency ownership.
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+async function listRuntimeTypeScriptFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return await listRuntimeTypeScriptFiles(fullPath);
+      }
+      return entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")
+        ? [fullPath]
+        : [];
+    }),
+  );
+  return files.flat();
+}
+
+describe("Slack QA transport boundary", () => {
+  it("loads Slack operations through the plugin test facade", async () => {
+    const files = await listRuntimeTypeScriptFiles(
+      path.resolve("extensions/qa-lab/src/live-transports/slack"),
+    );
+    const sources = await Promise.all(
+      files.map(async (file) => [file, await readFile(file, "utf8")] as const),
+    );
+
+    for (const [file, source] of sources) {
+      expect(source, file).not.toContain("@openclaw/slack/api.js");
+      if (source.includes("@openclaw/slack/test-api.js")) {
+        expect(source, file).toMatch(
+          /import type \{[^}]+\} from "@openclaw\/slack\/test-api\.js";/su,
+        );
+      }
+    }
+    expect(
+      sources
+        .filter(([, source]) => source.includes("@openclaw/slack/test-api.js"))
+        .map(([file]) => path.relative(process.cwd(), file))
+        .toSorted(),
+    ).toEqual([
+      "extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts",
+      "extensions/qa-lab/src/live-transports/slack/slack-plugin.runtime.ts",
+    ]);
+  });
+});

--- a/extensions/qa-lab/src/live-transports/slack/slack-boundary.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-boundary.test.ts
@@ -32,7 +32,7 @@ describe("Slack QA transport boundary", () => {
       expect(source, file).not.toContain("@openclaw/slack/api.js");
       if (source.includes("@openclaw/slack/test-api.js")) {
         expect(source, file).toMatch(
-          /import type \{[^}]+\} from "@openclaw\/slack\/test-api\.js";/su,
+          /type \w+ = typeof import\("@openclaw\/slack\/test-api\.js"\);/u,
         );
       }
     }

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.codex-approval.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.codex-approval.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { listSlackReactions } from "@openclaw/slack/api.js";
 import { extractGatewayMessageText } from "../../gateway-log-sentinel.js";
 import { formatApprovalResultValue } from "../shared/live-approval-result.js";
 import { asPlainRecord } from "./slack-live.config.js";
@@ -14,6 +13,7 @@ import {
   type SlackQaScenarioMetadata,
   type SlackQaWebClient as WebClient,
 } from "./slack-live.contracts.js";
+import { loadSlackQaRuntime } from "./slack-plugin.runtime.js";
 
 export function resolveCodexFileApprovalTargetPath(token: string) {
   return path.join(os.homedir(), `.openclaw-qa-codex-file-approval-${token.toLowerCase()}.txt`);
@@ -76,6 +76,7 @@ export async function waitForSlackReaction(params: {
   sutUserId: string;
   timeoutMs: number;
 }) {
+  const { listSlackReactions } = loadSlackQaRuntime();
   const deadline = Date.now() + params.timeoutMs;
   while (true) {
     const reactions = await listSlackReactions(params.channelId, params.messageId, {

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
@@ -1,14 +1,16 @@
 // QA Lab Slack live domain contracts and wire schemas.
-import type { createSlackWebClient } from "@openclaw/slack/api.js";
+import type { SlackQaRuntime } from "@openclaw/slack/test-api.js";
 import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { z } from "zod";
 import type { QaGatewayChild } from "../../gateway-child.js";
 import { splitQaModelRef } from "../../model-selection.js";
 
-export type SlackQaWebClient = ReturnType<typeof createSlackWebClient>;
+type CreateSlackWebClient = SlackQaRuntime["createSlackWebClient"];
+
+export type SlackQaWebClient = ReturnType<CreateSlackWebClient>;
 export type SlackQaFetchFunction = NonNullable<
-  NonNullable<Parameters<typeof createSlackWebClient>[1]>["fetch"]
+  NonNullable<Parameters<CreateSlackWebClient>[1]>["fetch"]
 >;
 type WebClient = SlackQaWebClient;
 

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
@@ -1,11 +1,11 @@
 // QA Lab Slack live domain contracts and wire schemas.
-import type { SlackQaRuntime } from "@openclaw/slack/test-api.js";
 import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { z } from "zod";
 import type { QaGatewayChild } from "../../gateway-child.js";
 import { splitQaModelRef } from "../../model-selection.js";
 
+type SlackQaRuntime = typeof import("@openclaw/slack/test-api.js");
 type CreateSlackWebClient = SlackQaRuntime["createSlackWebClient"];
 
 export type SlackQaWebClient = ReturnType<CreateSlackWebClient>;

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
@@ -1,6 +1,5 @@
 // QA Lab Slack Web API and stored-message observations.
 import { isDeepStrictEqual } from "node:util";
-import { createSlackWebClient, sendSlackMessage } from "@openclaw/slack/api.js";
 import {
   asPlainRecord,
   countSlackNativeDataBlocks,
@@ -25,8 +24,10 @@ import {
   type SlackQaWebClient as WebClient,
 } from "./slack-live.contracts.js";
 import { buildSlackInvalidBlocksTableProbe } from "./slack-live.invalid-blocks.js";
+import { loadSlackQaRuntime } from "./slack-plugin.runtime.js";
 
 export async function getSlackIdentity(token: string): Promise<SlackAuthIdentity> {
+  const { createSlackWebClient } = loadSlackQaRuntime();
   const client = createSlackWebClient(token, { timeout: SLACK_QA_WEB_API_TIMEOUT_MS });
   const auth = slackAuthTestSchema.parse(await client.auth.test());
   if (!auth.user_id) {
@@ -346,6 +347,7 @@ export function isExpectedSlackNativeTableMessage(
 export async function runSlackTableInvalidBlocksFallbackScenario(
   context: SlackQaDirectTransportScenarioContext,
 ): Promise<SlackQaDirectTransportScenarioResult> {
+  const { sendSlackMessage } = loadSlackQaRuntime();
   const probe = buildSlackInvalidBlocksTableProbe();
   const oldestTs = ((Date.now() - 5_000) / 1_000).toFixed(6);
   const originalPostMessage = context.sutWriteClient.chat.postMessage;

--- a/extensions/qa-lab/src/live-transports/slack/slack-plugin.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-plugin.runtime.test.ts
@@ -1,0 +1,32 @@
+// QA Lab tests cover the Slack plugin runtime facade.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadQaRunnerBundledPluginTestApi = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/qa-runner-runtime", () => ({
+  loadQaRunnerBundledPluginTestApi,
+}));
+
+describe("Slack plugin runtime facade", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loadQaRunnerBundledPluginTestApi.mockReset();
+  });
+
+  it("loads the Slack test API once and reuses its namespaced runtime", async () => {
+    const slackQaRuntime = {
+      createSlackWebClient: vi.fn(),
+      createSlackWriteClient: vi.fn(),
+      listSlackReactions: vi.fn(),
+      resolveSlackWebClientOptions: vi.fn(),
+      sendSlackMessage: vi.fn(),
+    };
+    loadQaRunnerBundledPluginTestApi.mockReturnValue({ slackQaRuntime });
+
+    const { loadSlackQaRuntime } = await import("./slack-plugin.runtime.js");
+
+    expect(loadSlackQaRuntime()).toBe(slackQaRuntime);
+    expect(loadSlackQaRuntime()).toBe(slackQaRuntime);
+    expect(loadQaRunnerBundledPluginTestApi).toHaveBeenCalledExactlyOnceWith("slack");
+  });
+});

--- a/extensions/qa-lab/src/live-transports/slack/slack-plugin.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-plugin.runtime.test.ts
@@ -21,7 +21,7 @@ describe("Slack plugin runtime facade", () => {
       resolveSlackWebClientOptions: vi.fn(),
       sendSlackMessage: vi.fn(),
     };
-    loadQaRunnerBundledPluginTestApi.mockReturnValue({ slackQaRuntime });
+    loadQaRunnerBundledPluginTestApi.mockReturnValue(slackQaRuntime);
 
     const { loadSlackQaRuntime } = await import("./slack-plugin.runtime.js");
 

--- a/extensions/qa-lab/src/live-transports/slack/slack-plugin.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-plugin.runtime.ts
@@ -1,14 +1,11 @@
 // QA Lab resolves Slack operations from the owning plugin's isolated dependency scope.
-import type { SlackQaRuntime } from "@openclaw/slack/test-api.js";
 import { loadQaRunnerBundledPluginTestApi } from "openclaw/plugin-sdk/qa-runner-runtime";
 
-type SlackQaTestApi = {
-  slackQaRuntime: SlackQaRuntime;
-};
+type SlackQaRuntime = typeof import("@openclaw/slack/test-api.js");
 
 let cachedSlackQaRuntime: SlackQaRuntime | undefined;
 
 export function loadSlackQaRuntime(): SlackQaRuntime {
-  cachedSlackQaRuntime ??= loadQaRunnerBundledPluginTestApi<SlackQaTestApi>("slack").slackQaRuntime;
+  cachedSlackQaRuntime ??= loadQaRunnerBundledPluginTestApi<SlackQaRuntime>("slack");
   return cachedSlackQaRuntime;
 }

--- a/extensions/qa-lab/src/live-transports/slack/slack-plugin.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-plugin.runtime.ts
@@ -1,0 +1,14 @@
+// QA Lab resolves Slack operations from the owning plugin's isolated dependency scope.
+import type { SlackQaRuntime } from "@openclaw/slack/test-api.js";
+import { loadQaRunnerBundledPluginTestApi } from "openclaw/plugin-sdk/qa-runner-runtime";
+
+type SlackQaTestApi = {
+  slackQaRuntime: SlackQaRuntime;
+};
+
+let cachedSlackQaRuntime: SlackQaRuntime | undefined;
+
+export function loadSlackQaRuntime(): SlackQaRuntime {
+  cachedSlackQaRuntime ??= loadQaRunnerBundledPluginTestApi<SlackQaTestApi>("slack").slackQaRuntime;
+  return cachedSlackQaRuntime;
+}

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -2,8 +2,9 @@
 import { installChannelOutboundPayloadContractSuite } from "openclaw/plugin-sdk/channel-contract-testing";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { describe, expect, it, vi } from "vitest";
-import { createSlackOutboundPayloadHarness as createHarness, slackOutbound } from "../test-api.js";
 import { createSlackSendTestClient } from "./blocks.test-helpers.js";
+import { slackOutbound } from "./outbound-adapter.js";
+import { createSlackOutboundPayloadHarness as createHarness } from "./outbound-payload.test-harness.js";
 import type { SlackReplyBlockSegment } from "./reply-blocks.js";
 import { sendMessageSlack } from "./send.js";
 

--- a/extensions/slack/test-api.test.ts
+++ b/extensions/slack/test-api.test.ts
@@ -1,6 +1,6 @@
 // Slack test API tests enforce the narrow private-QA runtime surface.
 import { describe, expect, it } from "vitest";
-import { slackQaRuntime } from "./test-api.js";
+import * as slackQaRuntime from "./test-api.js";
 
 describe("Slack test API", () => {
   it("exports exactly the Slack operations owned by private QA", () => {

--- a/extensions/slack/test-api.test.ts
+++ b/extensions/slack/test-api.test.ts
@@ -1,0 +1,18 @@
+// Slack test API tests enforce the narrow private-QA runtime surface.
+import { describe, expect, it } from "vitest";
+import { slackQaRuntime } from "./test-api.js";
+
+describe("Slack test API", () => {
+  it("exports exactly the Slack operations owned by private QA", () => {
+    expect(Object.keys(slackQaRuntime).toSorted()).toEqual([
+      "createSlackWebClient",
+      "createSlackWriteClient",
+      "listSlackReactions",
+      "resolveSlackWebClientOptions",
+      "sendSlackMessage",
+    ]);
+    for (const operation of Object.values(slackQaRuntime)) {
+      expect(operation).toBeTypeOf("function");
+    }
+  });
+});

--- a/extensions/slack/test-api.ts
+++ b/extensions/slack/test-api.ts
@@ -1,3 +1,16 @@
-// Slack test API exposes outbound payload fixtures.
-export { createSlackOutboundPayloadHarness } from "./src/outbound-payload.test-harness.js";
-export { slackOutbound } from "./src/outbound-adapter.js";
+// Slack test API exposes QA runtime operations from the owning plugin.
+import { listSlackReactions, sendSlackMessage } from "./src/actions.js";
+import {
+  createSlackWebClient,
+  createSlackWriteClient,
+  resolveSlackWebClientOptions,
+} from "./src/client.js";
+
+export const slackQaRuntime = {
+  createSlackWebClient,
+  createSlackWriteClient,
+  listSlackReactions,
+  resolveSlackWebClientOptions,
+  sendSlackMessage,
+};
+export type SlackQaRuntime = typeof slackQaRuntime;

--- a/extensions/slack/test-api.ts
+++ b/extensions/slack/test-api.ts
@@ -1,16 +1,7 @@
 // Slack test API exposes QA runtime operations from the owning plugin.
-import { listSlackReactions, sendSlackMessage } from "./src/actions.js";
-import {
+export { listSlackReactions, sendSlackMessage } from "./src/actions.js";
+export {
   createSlackWebClient,
   createSlackWriteClient,
   resolveSlackWebClientOptions,
 } from "./src/client.js";
-
-export const slackQaRuntime = {
-  createSlackWebClient,
-  createSlackWriteClient,
-  listSlackReactions,
-  resolveSlackWebClientOptions,
-  sendSlackMessage,
-};
-export type SlackQaRuntime = typeof slackQaRuntime;

--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -581,8 +581,8 @@
       "@openclaw/discord/api.js": [
         "../.artifacts/extension-package-boundary/plugins/discord/api.d.ts"
       ],
-      "@openclaw/slack/api.js": [
-        "../.artifacts/extension-package-boundary/plugins/slack/api.d.ts"
+      "@openclaw/slack/test-api.js": [
+        "../.artifacts/extension-package-boundary/plugins/slack/test-api.d.ts"
       ],
       "@openclaw/telegram/api.js": [
         "../.artifacts/extension-package-boundary/plugins/telegram/api.d.ts"

--- a/package.json
+++ b/package.json
@@ -2153,7 +2153,6 @@
     "@shikijs/engine-javascript": "4.4.3",
     "@shikijs/engine-oniguruma": "4.4.3",
     "@sindresorhus/slugify": "2.2.0",
-    "@slack/web-api": "8.0.0",
     "@types/express": "5.0.6",
     "@types/hosted-git-info": "3.0.5",
     "@types/jsdom": "30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,9 +399,6 @@ importers:
       '@sindresorhus/slugify':
         specifier: 2.2.0
         version: 2.2.0
-      '@slack/web-api':
-        specifier: 8.0.0
-        version: 8.0.0
       '@types/express':
         specifier: 5.0.6
         version: 5.0.6

--- a/scripts/lib/extension-boundary-inputs.mts
+++ b/scripts/lib/extension-boundary-inputs.mts
@@ -17,7 +17,7 @@ export const BOUNDARY_PLUGIN_UNITS = [
   ["memory-core", "api"],
   ["matrix", "test-api"],
   ["discord", "api"],
-  ["slack", "api"],
+  ["slack", "test-api"],
   ["telegram", "api"],
   ["whatsapp", "api"],
 ] as const;

--- a/src/plugins/contracts/extension-package-project-boundaries.test.ts
+++ b/src/plugins/contracts/extension-package-project-boundaries.test.ts
@@ -25,7 +25,9 @@ const XAI_OMITTED_BOUNDARY_PATHS = {
     "../.artifacts/extension-package-boundary/plugins/matrix/test-api.d.ts",
   ],
   "@openclaw/discord/api.js": ["../.artifacts/extension-package-boundary/plugins/discord/api.d.ts"],
-  "@openclaw/slack/api.js": ["../.artifacts/extension-package-boundary/plugins/slack/api.d.ts"],
+  "@openclaw/slack/test-api.js": [
+    "../.artifacts/extension-package-boundary/plugins/slack/test-api.d.ts",
+  ],
   "@openclaw/telegram/api.js": [
     "../.artifacts/extension-package-boundary/plugins/telegram/api.d.ts",
   ],

--- a/test/scripts/dist-artifact-ownership.test.ts
+++ b/test/scripts/dist-artifact-ownership.test.ts
@@ -9,6 +9,7 @@ import {
   resolveDistArtifactLockPath,
   withDistArtifactOwnership,
 } from "../../scripts/lib/dist-artifact-ownership.mts";
+import { BOUNDARY_PLUGIN_UNITS } from "../../scripts/lib/extension-boundary-inputs.mts";
 import {
   TSDOWN_NON_SDK_DTS_CONFIG_GROUPS,
   TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS,
@@ -761,16 +762,8 @@ describe.skipIf(process.platform === "win32")("dist artifact ownership", () => {
           compilerOptions: { outDir: "dist", tsBuildInfoFile: "dist/.tsbuildinfo" },
         }),
       );
-      for (const name of [
-        "qa-channel",
-        "memory-core",
-        "matrix",
-        "discord",
-        "slack",
-        "telegram",
-        "whatsapp",
-      ]) {
-        const entry = name === "matrix" ? "test-api.ts" : "api.ts";
+      for (const [name, entryName] of BOUNDARY_PLUGIN_UNITS) {
+        const entry = `${entryName}.ts`;
         write(root, `extensions/${name}/${entry}`, "export interface Plugin { id: string }\n");
         write(
           root,

--- a/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
@@ -173,9 +173,13 @@ describe("prepare-extension-package-boundary-artifacts", () => {
         };
         await run();
         if (mode === "all") {
+          const slackBoundaryEntry = BOUNDARY_PLUGIN_UNITS.find(([id]) => id === "slack")?.[1];
+          if (!slackBoundaryEntry) {
+            throw new Error("Slack extension boundary entry is missing");
+          }
           write(
             "consumer.ts",
-            'import { consume } from "./.artifacts/extension-package-boundary/plugins/slack/api.js"; consume(value => value.toUpperCase());',
+            `import { consume } from "./.artifacts/extension-package-boundary/plugins/slack/${slackBoundaryEntry}.js"; consume(value => value.toUpperCase());`,
           );
           await runNodeStep(
             "isolated-boundary-consumer",

--- a/test/scripts/tsdown-runtime-config.test.ts
+++ b/test/scripts/tsdown-runtime-config.test.ts
@@ -1,6 +1,5 @@
 // Covers bundling rules encoded in the root tsdown config.
 import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { bundledPluginRoot } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
@@ -369,28 +368,6 @@ describe("tsdown config", () => {
     }
     const externalize = external;
     expect(externalize("jimp", undefined, false)).toBe(true);
-  });
-
-  it("keeps the externalized Slack Web API resolvable from root dist", () => {
-    const rootPackage = JSON.parse(
-      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
-    ) as { devDependencies?: Record<string, string> };
-    const slackPackage = JSON.parse(
-      readFileSync(new URL("../../extensions/slack/package.json", import.meta.url), "utf8"),
-    ) as { dependencies?: Record<string, string> };
-    const slackWebApiVersion = slackPackage.dependencies?.["@slack/web-api"];
-
-    expect(rootPackage.devDependencies?.["@slack/web-api"]).toBe(slackWebApiVersion);
-
-    const requireFromRootDist = createRequire(
-      new URL("../../dist/private-qa-runtime.cjs", import.meta.url),
-    );
-    const resolvedPackage = JSON.parse(
-      readFileSync(requireFromRootDist.resolve("@slack/web-api/package.json"), "utf8"),
-    ) as { name?: string; version?: string };
-
-    expect(resolvedPackage.name).toBe("@slack/web-api");
-    expect(resolvedPackage.version).toBe(slackWebApiVersion);
   });
 
   it("bundles SDK-owned helpers while retaining fs-safe package ownership", () => {


### PR DESCRIPTION
Fixes #137245

## What Problem This Solves

Private Slack QA and RTT could fail before credential acquisition in an isolated build because the root-built QA Lab runtime tried to resolve Slack SDK packages from the root dependency scope. Adding only `@slack/web-api` at root exposed the next missing plugin-owned package, `@slack/socket-mode`, so expanding the root dependency closure was not a coherent fix.

The original live manifestation reproduced in https://github.com/openclaw/openclaw-rtt/actions/runs/33755258203.

## Why This Change Was Made

QA Lab now loads a narrow `test-api.js` module namespace through the bundled-plugin facade. The Slack plugin remains the single owner of `@slack/web-api`, `@slack/socket-mode`, and their transitive runtime dependencies. The temporary root Slack dependency and lock entries are removed.

The shared extension-package boundary contract now expects `@openclaw/slack/test-api.js` and its generated declaration instead of the removed `api.js` alias.

## Scope And LOC

- Production/tooling: +32/-14, net +18.
- Tests: +112/-36, net +76.
- Package metadata: +2/-6, net -4.

The remaining positive production delta is the ownership boundary itself: an 11-line cached QA Lab loader plus 7 lines of Slack-owned named exports. The nested facade wrapper was flattened, removing 12 avoidable lines while preserving one module-namespace boundary and one cached load path.

## Evidence

Exact head: `f82c95059758d887687e46f7b4707b34ad689107`.

- `pnpm test:contracts:plugins`: 46 files and 1,111 tests passed on Crabbox; the exact shared Slack alias/declaration contract also passed in hosted CI.
- Focused Slack facade, boundary, runtime, and contract proof: 78 tests passed.
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build qaRuntime`: passed on the exact-head hosted retry before the affected extension shard.
- Exact-head CI completed successfully, including `checks-fast-contracts-plugins`, `check-additional-extension-package-boundary`, `build-artifacts`, and the retried `checks-node-changed-extensions-config-48` shard: https://github.com/openclaw/openclaw/actions/runs/33769209677
- Mandatory autoreview: no P0/P1 findings, correctness clean, confidence 0.93.

ClawSweeper rank-up moves are applied: the shared Slack boundary expectation is updated, the plugin contract suite is rerun, and avoidable facade growth is removed.
