### PR TITLE
fix: target Control UI repairs at the detected checkout

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -86,6 +86,18 @@ If migration or config repair cannot finish, Doctor leaves the stopped service
 stopped and reports an incomplete repair. Resolve the reported blocker, rerun
 `openclaw doctor --fix`, then start the service through its owner.
 
+## Control UI assets
+
+For source installs, Doctor can build missing Control UI assets or rebuild stale
+assets after protocol changes. Its manual build command includes the detected
+checkout path (`pnpm --dir <checkout> ui:build`), so you can run the displayed
+command from another directory. Use the complete command, including its quoted
+path, rather than running `pnpm ui:build` in an unrelated project.
+
+Packaged installs without UI sources receive reinstall guidance instead of a
+source-build command. Doctor does not download a source checkout to repair a
+packaged installation.
+
 ## Examples
 
 ```bash

--- a/src/cli/installation-target-format.ts
+++ b/src/cli/installation-target-format.ts
@@ -1,6 +1,6 @@
 import type { InstallationTarget } from "../infra/installation-target-context.js";
 import { formatCliCommand } from "./command-format.js";
-import { quoteCliArg } from "./quote-cli-arg.js";
+import { quoteCliArg, quotePowerShellArg } from "./quote-cli-arg.js";
 
 /** Bind diagnostic handoffs to their installation in POSIX shells or Windows PowerShell. */
 export function formatInstallationTargetCommand(
@@ -9,9 +9,8 @@ export function formatInstallationTargetCommand(
   options: { stdinPath?: string; env?: NodeJS.ProcessEnv } = {},
 ): string {
   const windows = process.platform === "win32";
-  // PowerShell recognizes typographic single quotes as delimiters too.
   const quote = (value: string) =>
-    `'${windows ? value.replace(/['\u2018-\u201b]/gu, "$&$&") : value.replaceAll("'", "'\\''")}'`;
+    windows ? quotePowerShellArg(value) : `'${value.replaceAll("'", "'\\''")}'`;
   const command = formatCliCommand(
     argv
       .map((value) =>

--- a/src/cli/quote-cli-arg.ts
+++ b/src/cli/quote-cli-arg.ts
@@ -1,3 +1,8 @@
+export function quotePowerShellArg(value: string): string {
+  // PowerShell recognizes typographic single quotes as delimiters too.
+  return `'${value.replace(/['‘-‛]/gu, "$&$&")}'`;
+}
+
 export function quoteCliArg(value: string): string {
   if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) {
     return value;

--- a/src/commands/doctor-ui.test.ts
+++ b/src/commands/doctor-ui.test.ts
@@ -23,8 +23,8 @@ function issue(overrides: Partial<UiProtocolFreshnessIssue> = {}): UiProtocolFre
   } as UiProtocolFreshnessIssue;
 }
 
-async function createOpenClawRoot(): Promise<string> {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-ui-"));
+async function createOpenClawRoot(prefix = "openclaw-doctor-ui-"): Promise<string> {
+  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), prefix)));
   tempRoots.push(root);
   await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
   await fs.mkdir(path.join(root, "packages/gateway-protocol/src"), { recursive: true });
@@ -84,6 +84,61 @@ describe("UI protocol freshness health mapping", () => {
       },
     ]);
   });
+
+  it.each([
+    { kind: "missing-assets", field: "message" },
+    { kind: "stale-assets", field: "fixHint" },
+  ] as const)(
+    "runs the $kind manual repair in its source root, not cwd",
+    async ({ kind, field }) => {
+      const root = await createOpenClawRoot("openclaw-doctor-ui-owner's source-");
+      const unrelated = await createOpenClawRoot();
+      for (const directory of [root, unrelated]) {
+        await fs.writeFile(
+          path.join(directory, "package.json"),
+          JSON.stringify({
+            name: "openclaw",
+            private: true,
+            scripts: { "ui:build": "node build.cjs" },
+          }),
+        );
+        await fs.writeFile(
+          path.join(directory, "build.cjs"),
+          'require("node:fs").writeFileSync("built-root.txt", process.cwd());\n',
+        );
+      }
+      await touch(path.join(root, "ui/package.json"), new Date("2026-01-01"));
+      if (kind === "stale-assets") {
+        await touch(path.join(root, "dist/control-ui/index.html"), new Date("2026-01-01"));
+      }
+      const findings = await detectUiProtocolFreshnessIssues({
+        root,
+        cwd: unrelated,
+        collectChangesSinceBuild: async () => ["abc123 protocol changed"],
+      });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.kind).toBe(kind);
+      const finding = uiProtocolFreshnessIssueToHealthFinding(findings[0]!);
+      const command = finding[field]?.match(/pnpm [^`\n]+/u)?.[0];
+      expect(command).toBeDefined();
+
+      const windows = process.platform === "win32";
+      execFileSync(
+        windows ? "powershell.exe" : "/bin/sh",
+        windows
+          ? ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command!]
+          : ["-c", command!],
+        { cwd: unrelated, timeout: 10_000, stdio: "pipe" },
+      );
+
+      await expect(
+        fs.readFile(path.join(unrelated, "built-root.txt"), "utf8"),
+      ).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(fs.readFile(path.join(root, "built-root.txt"), "utf8")).resolves.toBe(root);
+    },
+  );
 
   it("does not report dry-run effects when UI sources are unavailable", () => {
     expect(uiProtocolFreshnessIssueToRepairEffects(issue({ canBuild: false }))).toEqual([]);

--- a/src/commands/doctor-ui.ts
+++ b/src/commands/doctor-ui.ts
@@ -5,6 +5,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
 import {
   ensureControlUiAssetsBuilt,
+  formatControlUiSourceCommand,
   resolveControlUiAssetHealth,
   resolveControlUiDistIndexPathForRoot,
 } from "../infra/control-ui-assets.js";
@@ -124,7 +125,7 @@ export function uiProtocolFreshnessIssueToHealthFinding(
     fixHint: issue.canBuild
       ? issue.kind === "missing-assets"
         ? "Run `openclaw doctor --fix` to build Control UI assets."
-        : "Run `openclaw doctor --fix --force` to rebuild Control UI assets, or run `pnpm ui:build`."
+        : `Run \`openclaw doctor --fix --force\` to rebuild Control UI assets, or run \`${formatControlUiSourceCommand(issue.root, "build")}\`.`
       : "Reinstall OpenClaw to restore bundled Control UI assets.",
   };
 }
@@ -152,7 +153,7 @@ function formatUiProtocolFreshnessIssue(issue: UiProtocolFreshnessIssue): string
     return [
       "- Control UI assets are missing.",
       issue.canBuild
-        ? "- Run: pnpm ui:build"
+        ? `- Run: ${formatControlUiSourceCommand(issue.root, "build")}`
         : "- Reinstall OpenClaw to restore bundled Control UI assets.",
     ].join("\n");
   }

--- a/src/gateway/server-control-ui-root.resolve.test.ts
+++ b/src/gateway/server-control-ui-root.resolve.test.ts
@@ -325,7 +325,7 @@ describe("createGatewayControlUiRootLifecycle", () => {
 
     expect(lifecycle.state).toEqual({ kind: "failed" });
     expect(warn).toHaveBeenCalledWith(
-      "gateway: Control UI build completed, but its assets are still unavailable. Run `pnpm ui:build`.",
+      "gateway: Control UI build completed, but its assets are still unavailable. Run `openclaw doctor --fix` or reinstall OpenClaw.",
     );
   });
 });

--- a/src/gateway/server-control-ui-root.ts
+++ b/src/gateway/server-control-ui-root.ts
@@ -144,10 +144,12 @@ export function createGatewayControlUiRootLifecycle(
         const resolvedRoot = resolveAutoRoot();
         if (!resolvedRoot || !isControlUiStartupAssetsReady(resolvedRoot)) {
           const message = resolvedRoot
-            ? `Control UI assets at ${resolvedRoot} remain incomplete. Run \`openclaw doctor --fix\` or reinstall OpenClaw.`
-            : "Control UI build completed, but its assets are still unavailable. Run `pnpm ui:build`.";
+            ? `Control UI assets at ${resolvedRoot} remain incomplete.`
+            : "Control UI build completed, but its assets are still unavailable.";
           Object.assign(preparingState, { kind: "failed" });
-          params.log.warn(`gateway: ${message}`);
+          params.log.warn(
+            `gateway: ${message} Run \`openclaw doctor --fix\` or reinstall OpenClaw.`,
+          );
           return;
         }
         // Listeners retain this object from before bind; replacing it would strand

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
 
 type FakeFsEntry = { kind: "file"; content: string } | { kind: "dir" };
 
@@ -316,12 +317,20 @@ describe("control UI assets helpers (fs-mocked)", () => {
       return { stdout: "", stderr: "", code: 0, signal: null, killed: false, termination: "exit" };
     });
 
+    const runtime = { log: vi.fn<RuntimeEnv["log"]>(), error: vi.fn(), exit: vi.fn() };
     await expect(
-      ensureControlUiAssetsBuilt(undefined, {
+      ensureControlUiAssetsBuilt(runtime, {
         argv1: path.join(packagedRoot, "dist", "entry.js"),
         cwd: checkoutRoot,
       }),
     ).resolves.toEqual({ ok: true, built: true });
+    const message = runtime.log.mock.calls.flat().join("\n");
+    const commands = [...message.matchAll(/`(pnpm [^`]+)`/gu)].map((match) => match[1]);
+    expect(commands).toHaveLength(2);
+    for (const command of commands) {
+      expect(command).toContain(checkoutRoot);
+      expect(command).not.toContain(packagedRoot);
+    }
     expect(state.runCommandWithTimeout).toHaveBeenCalledWith(
       [process.execPath, path.join(checkoutRoot, "scripts", "ui.js"), "build"],
       expect.objectContaining({ cwd: checkoutRoot }),

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -3,10 +3,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { quoteCliArg, quotePowerShellArg } from "../cli/quote-cli-arg.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import * as controlUiFsRuntime from "./control-ui-assets.fs.runtime.js";
 import { resolveOpenClawPackageRoot, resolveOpenClawPackageRootSync } from "./openclaw-root.js";
+
+export function formatControlUiSourceCommand(root: string, action: "build" | "dev"): string {
+  const directory = process.platform === "win32" ? quotePowerShellArg(root) : quoteCliArg(root);
+  return `pnpm --dir ${directory} ui:${action}`;
+}
 
 export function resolveControlUiDistIndexPathForRoot(root: string): string {
   return path.join(root, "dist", "control-ui", "index.html");
@@ -398,8 +404,10 @@ export async function ensureControlUiAssetsBuilt(
   if (opts.onBuildStart) {
     opts.onBuildStart();
   } else {
+    const buildCommand = formatControlUiSourceCommand(repoRoot, "build");
+    const devCommand = formatControlUiSourceCommand(repoRoot, "dev");
     runtime.log(
-      "Control UI assets missing; building them now (rerun `pnpm ui:build` after UI changes, or use `pnpm ui:dev` while developing the Control UI)…",
+      `Control UI assets missing; building them now (rerun \`${buildCommand}\` after UI changes, or use \`${devCommand}\` while developing the Control UI)…`,
     );
   }
 


### PR DESCRIPTION
Closes #137345.

<details>
<summary>Additional instructions</summary>

Maintainers can edit this repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where users following Doctor's Control UI repair instructions could run an unrelated project's build script when their terminal was outside the detected OpenClaw checkout. Doctor knew which checkout needed repair, but its manual `pnpm ui:build` instruction discarded that information. The asset owner's build/development log had the same omission, and the Gateway's unresolved-root fallback suggested a source build without identifying a checkout.

## Why This Change Was Made

Manual source commands now carry the already-discovered root through one shared `pnpm --dir <checkout>` formatter. The change reuses POSIX quoting and factors the existing PowerShell literal handling into a shared primitive. It does not change the automatic builder, which already runs the absolute UI script with the correct working directory.

Packaged installations without UI sources still receive reinstall guidance. When the Gateway cannot resolve its assets after a build, it points to Doctor/reinstallation rather than an unqualified source build. No configuration, dependency, protocol, storage, or service-lifecycle behavior changes.

## User Impact

Operators can copy the complete displayed build command from another directory without accidentally running that directory's project script. Source-root paths containing spaces and apostrophes remain usable. Commands use POSIX quoting on Unix and PowerShell quoting on Windows; existing installation-target handoffs retain their behavior.

## Evidence

Reviewed and built head: `6359b13f04f1a3c19290217ccf66169569f86718`.

**Actual built CLI before/after:** with fresh private HOME, config, state, workspace, logs, and a foreign working directory outside any pnpm workspace, the unchanged build returned a healthy result, then the expected missing-assets warning. Its displayed command exited zero but wrote the unrelated project's marker and left OpenClaw's index missing. Restoring the original index restored the healthy control. On the final build, the displayed root-bound command rebuilt OpenClaw's actual UI assets in 7.1 seconds, left the unrelated project untouched, and the next diagnostic returned `ok:true` with no findings. Config bytes stayed unchanged, no state database was created, and every process group drained.

**Regression and sibling proof:** four regressions were observed before production edits. The final seven suites pass **107/107, zero failures or skips**, covering missing/stale guidance, automatic source builds, packaged recovery, Gateway root lifecycle, and the existing triage/update-triage quoting callers. Fourteen additional real-shell command executions passed across Bash, Zsh, Fish, and PowerShell on macOS, including straight and typographic apostrophes in source paths. PowerShell execution exercised Windows presentation syntax; this is not a native-Windows OS proof claim.

The following source-relative commands were run through an isolated environment wrapper with Node 24.15.0 and pnpm 12.1.0. JSON-report output destinations are omitted here.

```bash
node scripts/run-vitest.mjs src/commands/doctor-ui.test.ts src/commands/doctor-ui.repair.test.ts src/infra/control-ui-assets.test.ts src/gateway/server-control-ui-root.resolve.test.ts src/cli/quote-cli-arg.test.ts src/commands/triage.test.ts src/infra/update-triage.test.ts --reporter=json
```

```bash
node scripts/check-changed.mjs -- docs/cli/doctor.md src/cli/installation-target-format.ts src/cli/quote-cli-arg.ts src/commands/doctor-ui.test.ts src/commands/doctor-ui.ts src/gateway/server-control-ui-root.resolve.test.ts src/gateway/server-control-ui-root.ts src/infra/control-ui-assets.test.ts src/infra/control-ui-assets.ts
```

```bash
pnpm build:ci-artifacts
```

The complete changed-file gate passed. The final artifact build passed with no ineffective-dynamic-import warning; existing dependency eval/plugin-timing diagnostics were retained. Fresh independent Codex autoreview of the final nine-file patch was scoped-clean at P0, with no findings.

**Validation notes:** the new worktree initially lacked local tool binaries, so its locked dependencies were installed without manifest/version changes. That exposed a separate Vitest 4.1.11 cache-invalidation ordering defect after the installed-lock identity changed. The failure and cache evidence were preserved, Vitest's own cache-clear operation was limited to task-owned caches, and the original test order then passed. The upstream cache lifecycle is a named follow-up, not a fix claimed by this PR. Two CLI fixture setup attempts also exposed inherited pnpm workspace discovery; the successful proofs use non-repository temporary directories. No cache policy, timeout, or dependency patch was changed to make this repair pass.

Production: **+24/-9 (net +15)**. Tests: **+68/-4 (net +64)**. Docs: **+12**. Production growth provides shared source-root-bound commands for two existing owners and reuses the existing shell-literal contract instead of adding another escaping implementation.

This is CLI/log guidance, not a rendered UI layout change. Exact-head CI and native review-artifact validation passed. Native preparation and merge follow.


## Maintainer review disposition

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/137354#issuecomment-5527532707) found no patch or security defect and identified this as the best owner-boundary fix. Its two remaining prompts are addressed as follows:

- **Production growth:** accepted as the concrete capability needed to make the displayed command target its already-discovered source root. The implementation has one root-bound renderer shared by Doctor and the asset owner, and it factors the existing PowerShell literal contract rather than creating a second escaping path. Automatic execution is unchanged. A prose-only directory prerequisite would leave copy-pasted commands unsafe from another project; using the installation-state formatter would add unrelated state selectors. The final production delta remains +24/-9 (net +15), with no further rendering path added.
- **Data-model compatibility proof:** not applicable. The two flagged files change only command/message projection and its import. No schema, migration, backfill, database access, stored representation, retention, or recovery policy changes. The automatic repair call and Gateway state transitions remain unchanged. The built CLI proof additionally verified unchanged config bytes and no state database creation. No migration was run or is required for this patch.

[Exact-head CI run 33768095321](https://github.com/openclaw/openclaw/actions/runs/33768095321) completed successfully on `6359b13f04f1a3c19290217ccf66169569f86718`, attempt 1, with no unsuccessful or pending jobs. These are evidence/disposition updates only; the reviewed source head has not changed.
