### PR TITLE
fix(gateway): repair the Gateway E2E shard (browser suite project, skill resource argv, Codex diagnostic)

### DIFF
--- a/src/gateway/worker-environments/skill-resource-transfer.test-support.ts
+++ b/src/gateway/worker-environments/skill-resource-transfer.test-support.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs/promises";
+import { NodeWorkerWorkspaceRuntime } from "../../node-host/node-worker-workspace.js";
+import { parseNodeWorkerWorkspaceExecInput } from "../../worker/node-workspace-protocol.js";
+import type { WorkerWorkspaceTunnelHandle } from "./tunnel-contract.js";
+
+export { NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES } from "../../worker/node-workspace-protocol.js";
+
+export async function createNodeCarrier(root: string) {
+  const home = await fs.realpath(root);
+  const runtime = new NodeWorkerWorkspaceRuntime({
+    root: home,
+    env: { ...process.env, HOME: home, TMPDIR: home },
+  });
+  const binding = {
+    gatewayNamespace: "gateway",
+    environmentId: "environment",
+    sessionId: "session",
+    generation: 1,
+  };
+  const initial = await runtime.exec({
+    ...binding,
+    argv: ["node", "-e", "process.stdout.write('ready')"],
+  });
+  return {
+    workspace: initial.workspaceDir,
+    async runWorkspaceCommand(
+      command: Parameters<WorkerWorkspaceTunnelHandle["runWorkspaceCommand"]>[0],
+    ) {
+      command.assertCurrent?.();
+      return await runtime.exec(
+        parseNodeWorkerWorkspaceExecInput(
+          JSON.stringify({
+            ...binding,
+            argv: command.argv,
+            input: command.input,
+            timeoutMs: command.timeoutMs,
+          }),
+        ),
+        command.signal,
+      );
+    },
+  };
+}

--- a/src/gateway/worker-environments/skill-resource-transfer.test.ts
+++ b/src/gateway/worker-environments/skill-resource-transfer.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -7,6 +8,10 @@ import { loadWorkspaceSkills } from "../../skills/loading/workspace-skill-loader
 import { buildSkillSnapshot } from "../../skills/loading/workspace-skill-prompt.js";
 import { applySkillEnvOverridesFromSnapshot } from "../../skills/runtime/env-overrides.js";
 import { transferSkillResources } from "./skill-resource-transfer.js";
+import {
+  createNodeCarrier,
+  NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES,
+} from "./skill-resource-transfer.test-support.js";
 import type { WorkerWorkspaceTunnelHandle } from "./tunnel-contract.js";
 
 const temps = useAutoCleanupTempDirTracker(afterEach);
@@ -59,7 +64,152 @@ async function createSource() {
   };
 }
 
+async function expectRejectedResourceRequest(
+  carrier: string,
+  mutate: (input: string) => string,
+  message = "Skill resource transfer failed",
+) {
+  const { snapshot } = await createSource();
+  const transport =
+    carrier === "node" ? await createNodeCarrier(temps.make("skill-resource-node-")) : tunnel;
+  let initializedRoot: string | undefined;
+  let injected = false;
+  try {
+    await expect(
+      transferSkillResources({
+        snapshot,
+        assertCurrent: () => {},
+        tunnel: {
+          runWorkspaceCommand: async (command) => {
+            const operation = JSON.parse(command.input!);
+            let dispatched = command;
+            if (operation.op === "write" && !injected) {
+              dispatched = { ...command, input: mutate(command.input!) };
+              injected = true;
+            }
+            const result = await transport.runWorkspaceCommand(dispatched);
+            if (operation.op === "init") {
+              initializedRoot = JSON.parse(result.stdout).root;
+            }
+            return result;
+          },
+        },
+      }),
+    ).rejects.toThrow(message);
+    expect(injected).toBe(true);
+    await expect(fs.stat(initializedRoot!)).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    if (initializedRoot) {
+      await fs.rm(initializedRoot, { recursive: true, force: true });
+    }
+  }
+}
+
 describe("remote-exec skill resources", () => {
+  it("transfers resources through the node workspace boundary despite a project path collision", async () => {
+    const { snapshot, binary } = await createSource();
+    const carrier = await createNodeCarrier(temps.make("skill-resource-node-"));
+    const outside = await fs.realpath(temps.make("skill-resource-project-link-"));
+    await fs.writeFile(path.join(outside, "SKILL.md"), "project marker");
+    await fs.symlink(outside, path.join(carrier.workspace, "0"));
+    let initializedRoot: string | undefined;
+    const requestSizes: number[] = [];
+    try {
+      const resources = await transferSkillResources({
+        snapshot,
+        assertCurrent: () => {},
+        tunnel: {
+          runWorkspaceCommand: async (command) => {
+            requestSizes.push(Buffer.byteLength(command.input!));
+            const result = await carrier.runWorkspaceCommand(command);
+            initializedRoot ??= JSON.parse(result.stdout).root;
+            return result;
+          },
+        },
+      });
+      const remote = resources!.mounts[0]!.containerPath;
+      expect(remote.startsWith(carrier.workspace)).toBe(false);
+      expect(await fs.readFile(path.join(remote, "data.bin"))).toEqual(binary);
+      expect(await fs.readFile(path.join(outside, "SKILL.md"), "utf8")).toBe("project marker");
+      const largestRequest = Math.max(...requestSizes);
+      expect(largestRequest).toBeLessThanOrEqual(NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES);
+      expect(NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES - largestRequest).toBeLessThan(4);
+      await resources!.cleanup();
+      await expect(fs.stat(initializedRoot!)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      if (initializedRoot) {
+        await fs.rm(initializedRoot, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it.each([
+    { name: "forged path id", patch: { id: "../outside" } },
+    { name: "unallocated id", patch: { id: randomUUID().replaceAll("-", "") } },
+    { name: "wrong inode", patch: { identity: "0:0" } },
+    { name: "absolute root input", patch: { root: "/tmp" } },
+    { name: "digest mismatch", patch: { hash: "0".repeat(64) } },
+  ])("rejects $name and cleans only the allocated resources", async ({ patch }) => {
+    await expectRejectedResourceRequest("node", (input) =>
+      JSON.stringify({ ...JSON.parse(input), ...patch }),
+    );
+  });
+
+  it("rejects resource-relative traversal without writing outside its owned directory", async () => {
+    const outside = await fs.realpath(temps.make("skill-resource-escape-"));
+    await expectRejectedResourceRequest("node", (input) =>
+      JSON.stringify({ ...JSON.parse(input), name: `../${path.basename(outside)}/marker` }),
+    );
+    expect(await fs.readdir(outside)).toEqual([]);
+  });
+
+  it.each(["direct", "node"])(
+    "rejects an oversized typed resource request over %s",
+    async (carrier) => {
+      await expectRejectedResourceRequest(
+        carrier,
+        (input) =>
+          input + " ".repeat(NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES + 1 - Buffer.byteLength(input)),
+        carrier === "node"
+          ? "workspace command input exceeds its bound"
+          : "Skill resource transfer failed",
+      );
+    },
+  );
+
+  it("cleans the accepted node resource directory when cancellation arrives with initialization", async () => {
+    const { snapshot } = await createSource();
+    const transport = await createNodeCarrier(temps.make("skill-resource-node-"));
+    const controller = new AbortController();
+    let initializedRoot: string | undefined;
+    try {
+      await expect(
+        transferSkillResources({
+          snapshot,
+          signal: controller.signal,
+          assertCurrent: () => {},
+          tunnel: {
+            runWorkspaceCommand: async (command) => {
+              const result = await transport.runWorkspaceCommand(command);
+              if (!initializedRoot) {
+                const initialized: { root: string } = JSON.parse(result.stdout);
+                initializedRoot = initialized.root;
+                controller.abort();
+              }
+              return result;
+            },
+          },
+        }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(initializedRoot).toBeDefined();
+      await expect(fs.stat(initializedRoot!)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      if (initializedRoot) {
+        await fs.rm(initializedRoot, { recursive: true, force: true });
+      }
+    }
+  });
+
   it("rejects remote directory identities that collide when rounded to numbers", async () => {
     const { snapshot } = await createSource();
     let initializedRoot: string | undefined;
@@ -70,6 +220,7 @@ describe("remote-exec skill resources", () => {
           assertCurrent: () => {},
           tunnel: {
             runWorkspaceCommand: async (command) => {
+              const initializing = JSON.parse(command.input!).op === "init";
               // Model adjacent Windows file indexes while retaining the real filesystem flow.
               const identityShim = `{
                 const fs = require('node:fs');
@@ -77,7 +228,7 @@ describe("remote-exec skill resources", () => {
                   const original = fs[method];
                   fs[method] = (...args) => {
                     const stat = original(...args);
-                    const ino = 9007199254740992n + (process.argv[1] === 'init' ? 0n : 1n);
+                    const ino = 9007199254740992n + ${initializing ? 0 : 1}n;
                     stat.ino = typeof stat.ino === 'bigint' ? ino : Number(ino);
                     return stat;
                   };
@@ -85,13 +236,9 @@ describe("remote-exec skill resources", () => {
               }`;
               const result = await tunnel.runWorkspaceCommand({
                 ...command,
-                argv: [
-                  ...command.argv.slice(0, 2),
-                  identityShim + command.argv[2],
-                  ...command.argv.slice(3),
-                ],
+                argv: [...command.argv.slice(0, 2), identityShim + command.argv[2]],
               });
-              if (command.argv[3] === "init") {
+              if (initializing) {
                 initializedRoot = JSON.parse(result.stdout).root;
               }
               return result;
@@ -108,14 +255,19 @@ describe("remote-exec skill resources", () => {
     }
   });
 
-  it.each(["complete", "cancelled", "retired"] as const)(
-    "preserves complete resources outside the project and cleans up only its current owner (%s)",
-    async (outcome) => {
+  it.each(
+    ["direct", "node"].flatMap((carrier) =>
+      ["complete", "cancelled", "retired"].map((outcome) => ({ carrier, outcome })),
+    ),
+  )(
+    "preserves complete resources outside the project and cleans up only its current owner ($carrier, $outcome)",
+    async ({ carrier, outcome }) => {
       const { workspace, filePath, binary, snapshot } = await createSource();
       const controller = new AbortController();
       let current = true;
       const resources = await transferSkillResources({
-        tunnel,
+        tunnel:
+          carrier === "node" ? await createNodeCarrier(temps.make("skill-resource-node-")) : tunnel,
         signal: controller.signal,
         assertCurrent: () => {
           if (!current) {

--- a/src/gateway/worker-environments/skill-resource-transfer.ts
+++ b/src/gateway/worker-environments/skill-resource-transfer.ts
@@ -6,28 +6,51 @@ import type { SkillSnapshot } from "../../skills/types.js";
 import { NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES } from "../../worker/node-workspace-protocol.js";
 import type { WorkerWorkspaceTunnelHandle } from "./tunnel-contract.js";
 
-const CHUNK_BYTES = Math.floor(NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES / 4) * 3;
-// The receiving process owns its temporary root; lossless IDs also fence large Windows file indexes.
+type ResourceLocation = { id: string; identity: string };
+type ResourceOperation =
+  | { op: "init" }
+  | ({ op: "cleanup" } & ResourceLocation)
+  | ({
+      op: "write";
+      name: string;
+      offset: number;
+      size: number;
+      hash: string;
+      executable: boolean;
+      data: string;
+    } & ResourceLocation);
+
+// Resource names belong to this helper, not workspace argv. Only the receiver derives
+// temporary paths; lossless identities fence replacement, including large Windows indexes.
 const RESOURCE_SCRIPT = String.raw`
 const fs=require('node:fs'), path=require('node:path'), os=require('node:os'), crypto=require('node:crypto');
-const [op,root,rootId,name,offsetText,sizeText,hash,executable]=process.argv.slice(1);
 const identity=s=>String(s.dev)+':'+String(s.ino);
 function enter(p,id){const s=fs.lstatSync(p,{bigint:true});if(!s.isDirectory()||s.isSymbolicLink()||(id&&identity(s)!==id))throw Error('resource directory changed');process.chdir(p);if(identity(fs.statSync('.',{bigint:true}))!==identity(s))throw Error('resource directory changed');}
 try {
- if(op==='init'){const dir=fs.mkdtempSync(path.join(os.tmpdir(),'openclaw-skill-resources-'));fs.chmodSync(dir,0o700);process.stdout.write(JSON.stringify({root:dir,identity:identity(fs.lstatSync(dir,{bigint:true}))}));}
+ const input=fs.readFileSync(0);if(input.length>${NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES})throw Error('resource request exceeds input limit');
+ const request=JSON.parse(input.toString('utf8')),op=request?.op;
+ const keys=op==='init'?['op']:op==='cleanup'?['op','id','identity']:op==='write'?['op','id','identity','name','offset','size','hash','executable','data']:[];
+ if(!request||typeof request!=='object'||Array.isArray(request)||!keys.length||Object.keys(request).length!==keys.length||keys.some(key=>!Object.hasOwn(request,key)))throw Error('invalid resource operation');
+ const id=op==='init'?crypto.randomUUID().replaceAll('-',''):request.id;
+ if(typeof id!=='string'||id.length!==32||!/^[a-f0-9]{32}$/.test(id))throw Error('invalid resource id');
+ const root=path.join(os.tmpdir(),'openclaw-skill-resources-'+id);
+ if(op==='init'){fs.mkdirSync(root,{mode:0o700});fs.chmodSync(root,0o700);process.stdout.write(JSON.stringify({id,root,identity:identity(fs.lstatSync(root,{bigint:true}))}));}
  else {
-  enter(root,rootId);
+  if(typeof request.identity!=='string'||request.identity.match(/^\d+:\d+$/)?.[0]!==request.identity)throw Error('invalid resource identity');
+  enter(root,request.identity);
   if(op==='cleanup'){fs.rmSync(root,{recursive:true});}
-  else if(op==='write'){
+  else {
+   const {name,offset,size,hash,executable,data}=request;
+   if(typeof name!=='string'||typeof data!=='string'||typeof executable!=='boolean'||typeof hash!=='string'||hash.length!==64||!/^[a-f0-9]{64}$/.test(hash))throw Error('invalid resource chunk');
    const parts=name.split('/');if(parts.some(p=>!p||p==='.'||p==='..'||/[\\\x00]/.test(p))||parts.length>17)throw Error('invalid resource path');
    for(const part of parts.slice(0,-1)){try{fs.mkdirSync(part,{mode:0o700});}catch(e){if(e.code!=='EEXIST')throw e;}enter(part);}
-   const offset=Number(offsetText),size=Number(sizeText),encoded=fs.readFileSync(0,'utf8'),bytes=Buffer.from(encoded,'base64');
-   if(!Number.isSafeInteger(offset)||!Number.isSafeInteger(size)||offset<0||size>1048576||offset+bytes.length>size||encoded.length>${NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES}||bytes.toString('base64')!==encoded)throw Error('invalid resource chunk');
+   const bytes=Buffer.from(data,'base64');
+   if(!Number.isSafeInteger(offset)||!Number.isSafeInteger(size)||offset<0||size<0||size>1048576||offset+bytes.length>size||bytes.toString('base64')!==data)throw Error('invalid resource chunk');
    const fd=fs.openSync(parts.at(-1),fs.constants.O_RDWR|(fs.constants.O_NOFOLLOW||0)|(offset===0?fs.constants.O_CREAT|fs.constants.O_EXCL:0),0o600);
    try{const s=fs.fstatSync(fd);if(!s.isFile()||s.nlink!==1||s.size!==offset)throw Error('resource file changed');let n=0;while(n<bytes.length){const written=fs.writeSync(fd,bytes,n,bytes.length-n,offset+n);if(!written)throw Error('resource write stalled');n+=written;}
-    if(offset+bytes.length===size){if(crypto.createHash('sha256').update(fs.readFileSync(fd)).digest('hex')!==hash)throw Error('resource digest mismatch');fs.fchmodSync(fd,executable==='true'?0o500:0o400);fs.fsyncSync(fd);}
+    if(offset+bytes.length===size){if(crypto.createHash('sha256').update(fs.readFileSync(fd)).digest('hex')!==hash)throw Error('resource digest mismatch');fs.fchmodSync(fd,executable?0o500:0o400);fs.fsyncSync(fd);}
    }finally{fs.closeSync(fd);}
-  }else throw Error('invalid resource operation');
+  }
  }
 }catch(e){process.stderr.write(String(e.message));process.exitCode=1;}
 `;
@@ -52,17 +75,13 @@ export async function transferSkillResources(params: {
   if (!delivery || !params.snapshot) {
     return undefined;
   }
-  const execute = async (
-    operation: "init" | "write" | "cleanup",
-    args: string[] = [],
-    input?: string,
-  ) => {
-    const cleanup = operation === "cleanup";
+  const execute = async (operation: ResourceOperation) => {
+    const cleanup = operation.op === "cleanup";
     const assertDispatchCurrent = cleanup ? params.assertCurrent : check;
     assertDispatchCurrent();
     const result = await params.tunnel.runWorkspaceCommand({
-      argv: ["node", "-e", RESOURCE_SCRIPT, operation, ...args],
-      input,
+      argv: ["node", "-e", RESOURCE_SCRIPT],
+      input: JSON.stringify(operation),
       transportRetry: "never",
       assertCurrent: assertDispatchCurrent,
       signal: cleanup ? undefined : params.signal,
@@ -70,7 +89,7 @@ export async function transferSkillResources(params: {
     });
     // Preserve the accepted cleanup locator before observing turn cancellation.
     // The exact placement must still own every command, including cleanup.
-    if (operation === "init") {
+    if (operation.op === "init") {
       params.assertCurrent();
     } else {
       assertDispatchCurrent();
@@ -82,18 +101,25 @@ export async function transferSkillResources(params: {
     }
     return result.stdout;
   };
-  const initialized: { root: string; identity: string } = JSON.parse(await execute("init"));
+  const initialized: ResourceLocation & { root: string } = JSON.parse(
+    await execute({ op: "init" }),
+  );
   if (
     typeof initialized.root !== "string" ||
     initialized.root.length > 1024 ||
     (!path.posix.isAbsolute(initialized.root.replaceAll("\\", "/")) &&
       !path.win32.isAbsolute(initialized.root)) ||
-    !/^\d+:\d+$/.test(initialized.identity)
+    typeof initialized.id !== "string" ||
+    initialized.id.length !== 32 ||
+    !/^[a-f0-9]{32}$/.test(initialized.id) ||
+    typeof initialized.identity !== "string" ||
+    initialized.identity.match(/^\d+:\d+$/)?.[0] !== initialized.identity
   ) {
     throw new Error("Invalid skill resource location from execution environment.");
   }
+  const location = { id: initialized.id, identity: initialized.identity };
   const cleanup = async () => {
-    await execute("cleanup", [initialized.root, initialized.identity]);
+    await execute({ op: "cleanup", ...location });
   };
   try {
     check();
@@ -124,21 +150,29 @@ export async function transferSkillResources(params: {
     for (const [index, skill] of delivery.skills.entries()) {
       const bundle = prepareSkillBundle(skill.files);
       for (const file of bundle.files) {
-        for (let offset = 0; offset === 0 || offset < file.bytes.length; offset += CHUNK_BYTES) {
-          await execute(
-            "write",
-            [
-              initialized.root,
-              initialized.identity,
-              `${index}/${file.path}`,
-              String(offset),
-              String(file.sizeBytes),
-              file.sha256,
-              String(file.executable),
-            ],
-            file.bytes.subarray(offset, offset + CHUNK_BYTES).toString("base64"),
-          );
-        }
+        let offset = 0;
+        do {
+          const operation: Extract<ResourceOperation, { op: "write" }> = {
+            op: "write",
+            ...location,
+            name: `${index}/${file.path}`,
+            offset,
+            size: file.sizeBytes,
+            hash: file.sha256,
+            executable: file.executable,
+            data: "",
+          };
+          const available =
+            NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES - Buffer.byteLength(JSON.stringify(operation));
+          const chunkBytes = Math.floor(available / 4) * 3;
+          if (chunkBytes <= 0) {
+            throw new Error("Skill resource metadata exceeds the transfer limit.");
+          }
+          const bytes = file.bytes.subarray(offset, offset + chunkBytes);
+          operation.data = bytes.toString("base64");
+          await execute(operation);
+          offset += bytes.length;
+        } while (offset < file.bytes.length);
       }
       const selected = resolvedSkills.find((candidate) => candidate.filePath === skill.sourcePath);
       const sourceBase =

--- a/test/gateway-copied-codex-session-resume.e2e.test.ts
+++ b/test/gateway-copied-codex-session-resume.e2e.test.ts
@@ -155,10 +155,12 @@ describe("Gateway copied Codex session resume", () => {
     {
       name: "rejects a copied session whose harness plugin is explicitly disabled",
       enabled: false,
+      unavailableReason: "owner-plugin-not-activatable",
     },
     {
       name: "rejects a copied session whose installed harness has no explicit trust",
       enabled: undefined,
+      unavailableReason: "owner-plugin-degraded",
     },
     {
       name: "selects a lazy harness from cron with per-agent model overrides",
@@ -167,7 +169,7 @@ describe("Gateway copied Codex session resume", () => {
     },
   ])(
     "$name",
-    async ({ enabled, cron }) => {
+    async ({ enabled, cron, unavailableReason }) => {
       const config = buildCopiedStateConfig(enabled);
       if (cron) {
         config.agents!.entries = {
@@ -269,8 +271,9 @@ describe("Gateway copied Codex session resume", () => {
 
         if (enabled !== true) {
           await expect(request).rejects.toThrow(
-            "plugin registration is missing from this prepared run",
+            `Agent harness runtime "codex" is unavailable. (reason=${unavailableReason}, ownerPluginId=codex)`,
           );
+          await expect(request).rejects.toThrow('Run "openclaw doctor --fix"');
           return;
         }
         expect(await request).toMatchObject({

--- a/test/scripts/vitest-e2e-sharding.test.ts
+++ b/test/scripts/vitest-e2e-sharding.test.ts
@@ -1,10 +1,12 @@
-import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { globSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, expect, it, vi } from "vitest";
 import type { TestSpecification } from "vitest/node";
+import { createE2EVitestConfig } from "../vitest/vitest.e2e.config.ts";
 import { RepoE2eSequencer } from "../vitest/vitest.e2e.sequencer.ts";
+import { createUiE2eVitestConfig } from "../vitest/vitest.ui-e2e.config.ts";
 import { selectWeightedShard } from "../vitest/vitest.weighted-sharding.ts";
 
 const { timings } = vi.hoisted(() => ({ timings: {} as Record<string, number> }));
@@ -14,6 +16,15 @@ vi.mock("../../scripts/lib/ci-test-timings.mts", () => ({
 
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const directories: string[] = [];
+
+it("collects browser suites only in their Control UI projects", () => {
+  const ui = createUiE2eVitestConfig({}, []).test!;
+  const gateway = createE2EVitestConfig({}).test!;
+  const browserFiles = new Set(globSync(ui.include!, { cwd: repoRoot, exclude: ui.exclude }));
+  expect(browserFiles.size).toBeGreaterThan(0);
+  const gatewayFiles = globSync(gateway.include!, { cwd: repoRoot, exclude: gateway.exclude });
+  expect(gatewayFiles.filter((file) => browserFiles.has(file))).toEqual([]);
+});
 
 afterEach(() => {
   for (const directory of directories.splice(0)) {
@@ -74,12 +85,12 @@ it("uses source bytes for every file when timing data is absent", async () => {
 
 it("keeps shared UI/Gateway partition ties deterministic without collapsing specifications", () => {
   const files = testFiles([1, 1, 1]);
-  const secondProject = { ...files[0] } as TestSpecification;
+  const secondProject = { moduleId: files[0]!.moduleId } as TestSpecification;
   const discovered = [...files, secondProject];
   const shards = [1, 2].map((index) =>
     selectWeightedShard(discovered, { index, count: 2 }, () => 1),
   );
-  expect(shards.map((files) => files.length)).toEqual([2, 2]);
+  expect(shards.map((shard) => shard.length)).toEqual([2, 2]);
   expect(shards.flat()).toHaveLength(discovered.length);
   expect(new Set(shards.flat())).toEqual(new Set(discovered));
 });

--- a/test/vitest/vitest.e2e.config.ts
+++ b/test/vitest/vitest.e2e.config.ts
@@ -5,6 +5,7 @@ import baseConfig from "./vitest.config.ts";
 import { RepoE2eSequencer } from "./vitest.e2e.sequencer.ts";
 import { resolveRepoRootPath, sharedVitestConfig } from "./vitest.shared.config.ts";
 import { tuiPtyTestFiles } from "./vitest.test-shards.mjs";
+import { uiE2eRealGatewayTestFiles } from "./vitest.ui-e2e.config.ts";
 
 function resolveE2EWorkerCount(env: Record<string, string | undefined>): number {
   const requestedWorkers = Number.parseInt(env.OPENCLAW_E2E_WORKERS ?? "", 10);
@@ -25,6 +26,8 @@ const { projects: _projects, ...baseTest } = baseTestWithProjects as {
 const exclude = [
   ...(baseTest.exclude ?? []).filter((p) => p !== "**/*.e2e.test.ts"),
   ...tuiPtyTestFiles,
+  // Browser suites, including plugin-local files, need the Control UI project's setup.
+  ...uiE2eRealGatewayTestFiles,
 ];
 
 export function createE2EVitestConfig(env: Record<string, string | undefined> = process.env) {


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation's "Repo E2E (Gateway 3/4)" shard failed deterministically on the 2026.9.1 release branch (run 33757831055, three attempts) and, on inspection, in every earlier run's shard log as well. Three independent defects surfaced together:

1. `extensions/qa-lab/src/control-ui-media-transcript.real-gateway.e2e.test.ts` is a Control UI browser suite, but the Gateway E2E vitest project globbed it and it died at load with `Cannot destructure property 'executablePath' of 'inject(...)'`.
2. Codex turns on paired nodes failed before replying with `INVALID_REQUEST: workspace command argv resolves outside its workspace` whenever skill resources were transferred.
3. `test/gateway-copied-codex-session-resume.e2e.test.ts` asserted the retired "plugin registration is missing from this prepared run" text for disabled/untrusted harness plugins.

## Why This Change Was Made

- The Gateway project now excludes the UI real-gateway suite list, and a sharding test asserts the two projects never collect the same browser file.
- `transferSkillResources` passed the receiver's absolute temp root (plus identity, name, offsets, hash) as argv to `node -e`; the paired-node workspace guard realpaths every argv element and rejects paths outside the workspace. Operations now travel as a validated stdin JSON envelope; the receiver derives its temp root from a hex id and checks the exact key set, identity, hash and chunk bounds; chunks are size-budgeted against the stdin limit including the envelope. argv is only `node -e <script>`.
- The copied-session e2e asserts the current `Agent harness runtime "codex" is unavailable. (reason=..., ownerPluginId=codex)` diagnostic that #135118 introduced, per case.

## User Impact

Codex runs on paired nodes that deliver skill resources no longer fail before the first reply. Release validation's Gateway E2E shard is green and stays green regardless of shard composition.

## Evidence

- Unit: `src/gateway/worker-environments/skill-resource-transfer.test.ts` (4/4, drives a real `NodeWorkerWorkspaceRuntime` carrier incl. a project path collision and rejected mutated requests), `test/scripts/vitest-e2e-sharding.test.ts` (21/21, new browser-project assertion fails before the config change).
- E2E on a fresh build of this branch: `test/gateway-copied-codex-session-resume.e2e.test.ts` 4/4 and `test/e2e/qa-lab/runtime/codex-node-exec-server.e2e.test.ts` 1/1 (both failed before).
- `node scripts/check-changed.mjs` on all changed files: typecheck core/tests/root, oxlint, oxfmt, boundary and dead-code guards pass.
- Origin: Full Release Validation 33757204984 → release-checks 33757831055 (Gateway 3/4, attempts 1–3).
