### PR TITLE
fix(bedrock): socket failures before any output skip transport recovery

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.lifecycle.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.lifecycle.test.ts
@@ -250,4 +250,50 @@ describe("Bedrock stream client lifecycle", () => {
     expect(result.errorMessage).toBe("synthetic abort");
     expectDestroyedClient(send, destroy);
   });
+
+  it("records a transport-failure diagnostic when the request fails before any output", async () => {
+    const send = vi
+      .spyOn(BedrockRuntimeClient.prototype, "send")
+      .mockRejectedValue(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }));
+    const destroy = vi.spyOn(BedrockRuntimeClient.prototype, "destroy");
+
+    const result = await streamBedrockForTest().result();
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "socket hang up",
+      errorCode: "ECONNRESET",
+    });
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        type: "provider_transport_failure",
+        details: { eventsEmitted: false, phase: "before_message_stream_start" },
+      }),
+    ]);
+    expectDestroyedClient(send, destroy);
+  });
+
+  it("keeps partial-output stream failures out of transport-drop recovery", async () => {
+    async function* failingStream() {
+      yield { messageStart: { role: ConversationRole.ASSISTANT } };
+      yield { contentBlockDelta: { contentBlockIndex: 0, delta: { text: "partial" } } };
+      throw Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+    }
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: failingStream(),
+    } as never);
+    const destroy = vi.spyOn(BedrockRuntimeClient.prototype, "destroy");
+
+    const result = await streamBedrockForTest().result();
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "socket hang up",
+      errorCode: "ECONNRESET",
+    });
+    expect(result.content).toEqual([{ type: "text", text: "partial" }]);
+    expect(result.diagnostics).toBeUndefined();
+    expectDestroyedClient(send, destroy);
+  });
 });

--- a/extensions/amazon-bedrock/stream.runtime.lifecycle.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.lifecycle.test.ts
@@ -273,10 +273,35 @@ describe("Bedrock stream client lifecycle", () => {
     expectDestroyedClient(send, destroy);
   });
 
-  it("keeps partial-output stream failures out of transport-drop recovery", async () => {
+  it.each([
+    {
+      label: "text",
+      blocks: [{ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "partial" } } }],
+      content: [{ type: "text", text: "partial" }],
+    },
+    {
+      label: "tool-only output",
+      blocks: [
+        {
+          contentBlockStart: {
+            contentBlockIndex: 0,
+            start: { toolUse: { toolUseId: "call_lookup", name: "lookup" } },
+          },
+        },
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { toolUse: { input: '{"query":"partial"}' } },
+          },
+        },
+        { contentBlockStop: { contentBlockIndex: 0 } },
+      ],
+      content: [],
+    },
+  ])("keeps failures after $label out of transport-drop recovery", async ({ blocks, content }) => {
     async function* failingStream() {
       yield { messageStart: { role: ConversationRole.ASSISTANT } };
-      yield { contentBlockDelta: { contentBlockIndex: 0, delta: { text: "partial" } } };
+      yield* blocks;
       throw Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
     }
     const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
@@ -285,15 +310,22 @@ describe("Bedrock stream client lifecycle", () => {
     } as never);
     const destroy = vi.spyOn(BedrockRuntimeClient.prototype, "destroy");
 
-    const result = await streamBedrockForTest().result();
+    const stream = streamBedrockForTest();
+    const eventTypes: string[] = [];
+    for await (const event of stream) {
+      eventTypes.push(event.type);
+    }
+    const result = await stream.result();
 
     expect(result).toMatchObject({
       stopReason: "error",
       errorMessage: "socket hang up",
       errorCode: "ECONNRESET",
     });
-    expect(result.content).toEqual([{ type: "text", text: "partial" }]);
+    expect(result.content).toEqual(content);
     expect(result.diagnostics).toBeUndefined();
+    expect(eventTypes).not.toContain("toolcall_end");
+    expect(eventTypes.at(-1)).toBe("error");
     expectDestroyedClient(send, destroy);
   });
 });

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -882,19 +882,27 @@ describe("Bedrock Fable contract", () => {
     ]);
   });
 
-  it("discards partial output when the Fable stream ends without messageStop", async () => {
-    vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
-      $metadata: { httpStatusCode: 200 },
-      stream: streamEvents([
-        { messageStart: { role: ConversationRole.ASSISTANT } },
-        {
-          contentBlockDelta: {
-            contentBlockIndex: 0,
-            delta: { text: "unsafe partial output" },
-          },
+  it.each([
+    { label: "ends without messageStop", transportDrop: false },
+    { label: "loses its connection", transportDrop: true },
+  ])("discards partial output when the Fable stream $label", async ({ transportDrop }) => {
+    async function* incompleteStream() {
+      yield { messageStart: { role: ConversationRole.ASSISTANT } };
+      yield {
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: { text: "unsafe partial output" },
         },
-      ]),
+      };
+      if (transportDrop) {
+        throw Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+      }
+    }
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: incompleteStream(),
     } as never);
+    const destroy = vi.spyOn(BedrockRuntimeClient.prototype, "destroy");
 
     const stream = streamSimpleBedrock(fableModel(), context());
     const eventTypes: string[] = [];
@@ -904,8 +912,18 @@ describe("Bedrock Fable contract", () => {
     const result = await stream.result();
 
     expect(eventTypes).toEqual(["error"]);
+    expect(result.stopReason).toBe("error");
     expect(result.content).toEqual([]);
-    expect(result.errorMessage).toContain("ended before messageStop");
+    expect(result.diagnostics).toBeUndefined();
+    if (transportDrop) {
+      expect(result.errorMessage).toBe("socket hang up");
+      expect(result.errorCode).toBe("ECONNRESET");
+    } else {
+      expect(result.errorMessage).toContain("ended before messageStop");
+    }
+    expect(send).toHaveBeenCalledOnce();
+    expect(destroy).toHaveBeenCalledOnce();
+    expect(destroy.mock.contexts[0]).toBe(send.mock.contexts[0]);
   });
 
   it("reports activity while Fable events are buffered", async () => {

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -72,6 +72,7 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import {
   describeToolResultMediaPlaceholder,
+  failTransportStream,
   finalizeTerminalToolCallArguments,
   notifyProviderHttpMetadata,
 } from "openclaw/plugin-sdk/provider-transport-runtime";
@@ -392,20 +393,26 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
       stream.push({ type: "done", reason: output.stopReason, message: output });
       stream.end();
     } catch (error) {
-      output.content = output.content.filter((block) => block.type !== "toolCall");
-      for (const block of output.content) {
-        delete (block as Block).index;
-        // partialJson is only a streaming scratch buffer; never persist it.
-        delete (block as Block).partialJson;
-      }
-      if (refusalBuffer) {
-        refusalBuffer.discard();
-        output.content = [];
-      }
-      output.stopReason = options.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = formatBedrockError(error);
-      stream.push({ type: "error", reason: output.stopReason, error: output });
-      stream.end();
+      failTransportStream({
+        stream,
+        output,
+        signal: options.signal,
+        error,
+        cleanup: () => {
+          output.content = output.content.filter((block) => block.type !== "toolCall");
+          for (const block of output.content) {
+            delete (block as Block).index;
+            // partialJson is only a streaming scratch buffer; never persist it.
+            delete (block as Block).partialJson;
+          }
+          if (refusalBuffer) {
+            refusalBuffer.discard();
+            output.content = [];
+          }
+          // Keep the name-prefixed message that downstream matchers rely on.
+          output.errorMessage = formatBedrockError(error);
+        },
+      });
     } finally {
       // The SDK client owns pooled HTTP resources; release them only after its async stream settles.
       client?.destroy();
@@ -435,6 +442,7 @@ const BEDROCK_ERROR_PREFIXES: Record<string, string> = {
  * extend BedrockRuntimeServiceException. We map the `.name` to a stable
  * human-readable prefix so downstream consumers (retry logic, context-overflow
  * detection) can distinguish error categories via simple string matching.
+ * The shared transport owner projects errorType, errorCode, and diagnostics.
  */
 function formatBedrockError(error: unknown): string {
   const message = error instanceof Error ? error.message : JSON.stringify(error);


### PR DESCRIPTION
Related: #135105

## What Problem This Solves

Fixes an issue where operators running Claude or Nova models through Amazon Bedrock would lose a turn after a settled tool batch when the next Bedrock request failed on the network before any response event arrived, while the same failure on the Anthropic, OpenAI, Mistral, and Google providers resumes the turn without rerunning tools.

#135105 added bounded same-model recovery for silent pre-output transport failures. Recovery keys on a `provider_transport_failure` diagnostic that the shared provider error owner records. The Bedrock stream runtime still projected its own terminal fields by hand and never recorded that diagnostic, so `docs/concepts/model-failover.md` described behavior Bedrock could not deliver.

## Why This Change Was Made

The Bedrock catch block now routes through `failTransportStream`, the shared owner that the Google and Ollama extensions already use through `openclaw/plugin-sdk/provider-transport-runtime`. The projection runs before partial tool-call cleanup, matching the ordering #135105 established for the built-in providers, so partial output still excludes a turn from recovery. Bedrock's name-prefixed error message (`ThrottlingException: ...`, `Validation error: ...`) is preserved byte for byte because context-overflow and failover matching depend on it; the owner adds `errorType`, `errorCode`, and the transport diagnostic on top. No new plugin-SDK surface, configuration, or retry budget is introduced.

## User Impact

A Bedrock request that fails on the socket before the model responds now carries the same recovery evidence as the other providers. After a settled tool batch, the embedded runner can continue the same model up to twice without replaying tools. Existing error messages, abort handling, mid-stream failures, refusal handling, and client teardown are unchanged.

## Evidence

Loopback reproduction with the real AWS SDK transport, no mocks. A `node:http` server on 127.0.0.1 destroys every socket as soon as the request arrives, so the SDK's `NodeHttpHandler` observes a genuine `ECONNRESET` before any Converse event exists. The extension's production `streamSimpleBedrock` is called with `baseUrl` pointed at that port (`AWS_BEDROCK_SKIP_AUTH=1`, `AWS_BEDROCK_FORCE_HTTP1=1`, region `us-east-1`); the SDK retries three times on its own, which is why both arms show three connections. The same harness ran twice on this checkout (`node --import tsx`): once with the source file restored to `origin/main` at `f9a43c083c7` (control), once with this branch.

Control (unchanged `origin/main` source):

```json
{
  "label": "main",
  "connections": 3,
  "eventTypes": ["error"],
  "stopReason": "error",
  "errorMessage": "socket hang up",
  "content": [],
  "retryable": true
}
RESULT main: provider_transport_failure=false
```

This branch:

```json
{
  "label": "branch",
  "connections": 3,
  "eventTypes": ["error"],
  "stopReason": "error",
  "errorMessage": "socket hang up",
  "errorCode": "ECONNRESET",
  "content": [],
  "diagnostics": [
    {
      "type": "provider_transport_failure",
      "error": { "name": "ThrownValue", "message": "socket hang up" },
      "details": { "eventsEmitted": false, "phase": "before_message_stream_start" }
    }
  ],
  "retryable": true
}
RESULT branch: provider_transport_failure=true
```

`retryable` is `isRetryableAssistantError` from `src/llm/utils/retry.ts`, which already classified the main-branch message as retryable. The only missing input for `isSilentTransportDropAssistant` in `src/agents/embedded-agent-runner/run/attempt-recovery.ts` was the diagnostic, which this branch now records. The error message is identical in both arms.

Regression tests in `extensions/amazon-bedrock/stream.runtime.lifecycle.test.ts`, run with `test/vitest/vitest.extension-providers.config.ts`:

- pre-output rejection (`send` rejects with an `ECONNRESET` error): asserts `errorCode`, the unchanged message, and exactly one `provider_transport_failure` diagnostic with `eventsEmitted: false` and `phase: "before_message_stream_start"`;
- partial output (text delta arrives, then the stream iterator throws the same error): asserts the text block survives, `errorCode` is set, and no diagnostic is recorded.

Results: `stream.runtime.lifecycle.test.ts` and `stream.runtime.test.ts` together pass 60 of 60. With the production change stashed and the new tests kept, the same file reports 2 failed and 9 passed; the two failures are exactly the two new cases.

Local checks on the two changed files: `oxlint` and `oxfmt --check` clean; assertion-safety ratchet against `origin/main` unchanged. `git diff --numstat`: `stream.runtime.ts` +22/-14, `stream.runtime.lifecycle.test.ts` +46/-0.

<details>
<summary>Loopback harness (run from the repository root, deleted before commit)</summary>

```ts
import { createServer } from "node:http";
import type { AddressInfo } from "node:net";

process.env.AWS_BEDROCK_SKIP_AUTH = "1";
process.env.AWS_BEDROCK_FORCE_HTTP1 = "1";
process.env.AWS_REGION = "us-east-1";

const label = process.argv[2] ?? "unlabeled";
const { streamSimpleBedrock } = await import("./extensions/amazon-bedrock/stream.runtime.ts");
const { isRetryableAssistantError } = await import("./src/llm/utils/retry.ts");

let connections = 0;
const server = createServer((request) => {
  connections += 1;
  request.socket.destroy();
});
await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
const { port } = server.address() as AddressInfo;

const model = {
  api: "bedrock-converse-stream",
  provider: "amazon-bedrock",
  id: "amazon.nova-micro-v1:0",
  name: "Nova Micro",
  baseUrl: `http://127.0.0.1:${port}`,
  reasoning: false,
  input: ["text"],
  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
  contextWindow: 128_000,
  maxTokens: 4096,
} as const;

const stream = streamSimpleBedrock(
  model as never,
  { messages: [{ role: "user", content: "Hello", timestamp: 0 }] } as never,
  { region: "us-east-1", maxTokens: 32 } as never,
);
const eventTypes: string[] = [];
for await (const event of stream) {
  eventTypes.push(event.type);
}
const result = await stream.result();
server.close();

console.log(
  JSON.stringify(
    {
      label,
      connections,
      eventTypes,
      stopReason: result.stopReason,
      errorMessage: result.errorMessage,
      errorCode: result.errorCode,
      errorType: result.errorType,
      content: result.content,
      diagnostics: result.diagnostics?.map((d) => ({ type: d.type, error: d.error, details: d.details })),
      retryable: isRetryableAssistantError(result),
    },
    null,
    2,
  ),
);
const hasTransportDiagnostic =
  result.diagnostics?.some((d) => d.type === "provider_transport_failure") ?? false;
console.log(`RESULT ${label}: provider_transport_failure=${hasTransportDiagnostic}`);
```

</details>
