### PR TITLE
fix(ai): preserve local model request prefixes

### DIFF
--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -243,6 +243,15 @@ Key design choices:
 
 If you see unexpected `cacheWrite` spikes after a config or workspace change, check whether the change lands above or below the cache boundary. Moving volatile content below the boundary (or stabilizing it) usually resolves the issue.
 
+Chat Completions routes without an explicit message-cache breakpoint move the
+bounded Runtime facts line to the first emitted user message. This keeps session
+identifiers behind the system-and-tools prefix on compatible local servers.
+The line stays on that first message during follow-ups. Behavioral instructions,
+including hook additions, permission notices, and Git coauthor guidance, retain
+their system/developer role. Routes with explicit message breakpoints keep their
+existing system layout. Current-turn Runtime Context snapshots still use their
+separate transient carrier; they do not become permanent first-message context.
+
 ## OpenClaw cache-stability guards
 
 - Active exec sessions, subagent state, and media-generation progress travel in compact Runtime Context carriers after the current user message, so changes do not rewrite the system prompt ahead of conversation history. Project Memory facts, channel-specific ACP hints, delegation/orchestration mode, and the current elevated level stay below the system-prompt cache boundary; static recall, safety, and capability guidance stay above it.

--- a/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.accounting-replay.test.ts
@@ -6,7 +6,11 @@ import {
   ConverseStreamCommand,
   StopReason as BedrockStopReason,
 } from "@aws-sdk/client-bedrock-runtime";
-import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
+import {
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END,
+} from "@openclaw/ai/internal/shared";
 import type { Context, Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BedrockOptions } from "./bedrock-options.js";
@@ -469,7 +473,7 @@ describe("Bedrock prompt cache ownership", () => {
               name: "Claude Haiku 4.5",
             }),
             {
-              systemPrompt: `Stable workspace${SYSTEM_PROMPT_CACHE_BOUNDARY}${suffix}`,
+              systemPrompt: `${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY.trim()}Stable workspace${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END.trim()}${SYSTEM_PROMPT_CACHE_BOUNDARY}${suffix}`,
               messages: [{ role: "user", content: "Hello", timestamp: 0 }],
             },
             { cacheRetention },
@@ -501,6 +505,26 @@ describe("Bedrock prompt cache ownership", () => {
 
   const model = () =>
     bedrockModel({ id: "anthropic.claude-haiku-4-5-20251001-v1:0", name: "Claude Haiku 4.5" });
+
+  it("strips relocation markers from a prompt without a cache boundary", async () => {
+    const payload = await capturePayload(
+      model(),
+      {
+        systemPrompt: `${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY.trim()}Complete policy${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END.trim()}`,
+        messages: [{ role: "user", content: "Hello", timestamp: 0 }],
+      },
+      { cacheRetention: "short" },
+    );
+
+    expect(payload.system).toEqual([
+      { text: "Complete policy" },
+      { cachePoint: { type: "default" } },
+    ]);
+    expect(payload.messages?.[0]?.content).toEqual([
+      { text: "Hello" },
+      { cachePoint: { type: "default" } },
+    ]);
+  });
 
   it("anchors prompt caching on the last stable user turn instead of transient runtime context", async () => {
     const messages = await captureMessages(

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -948,7 +948,7 @@ function buildSystemPrompt(
   const split = splitSystemPromptCacheBoundary(systemPrompt);
   const stablePrefix = split?.stablePrefix ?? systemPrompt;
   const blocks: SystemContentBlock[] = stablePrefix
-    ? [{ text: sanitizeSurrogates(stablePrefix) }]
+    ? [{ text: sanitizeSurrogates(stripSystemPromptCacheBoundary(stablePrefix)) }]
     : [];
 
   if (stablePrefix && cachePoint) {

--- a/packages/ai/src/openai-completions-messages.test.ts
+++ b/packages/ai/src/openai-completions-messages.test.ts
@@ -4,6 +4,11 @@ import type { ProviderContext, ProviderModel } from "./provider-types.js";
 import { resolveOpenAICompletionsCompat } from "./transports/openai-completions-compat.js";
 import type { AssistantMessage, Context, Model } from "./types.js";
 import { createZeroUsage } from "./usage.test-support.js";
+import {
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END,
+} from "./utils/system-prompt-cache-boundary.js";
 
 const model: Model<"openai-completions"> = {
   id: "test-model",
@@ -451,5 +456,213 @@ describe("convertMessages parallel tool-result image ownership", () => {
     expect(labelText).not.toMatch(/[\uD800-\uDFFF]/u);
     const toolMessage = converted.find((message) => message.role === "tool");
     expect(toolMessage?.role === "tool" && toolMessage.tool_call_id).toBe(longCallId);
+  });
+});
+
+describe("convertMessages relocatable region", () => {
+  const compat = () => resolveOpenAICompletionsCompat(model);
+  /** Wrap producer-marked runtime facts the way the system prompt builder does. */
+  const marked = (facts: string) =>
+    `${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}${facts}${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}`;
+  const contextForSession = (sessionId: string): Context =>
+    ({
+      systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Reactions guidance${marked(`## Runtime\nRuntime: session=${sessionId}`)}`,
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    }) as unknown as Context;
+
+  it("carries the non-behavioral region on the first user turn", () => {
+    const converted = convertMessages(model, contextForSession("alpha"), compat());
+
+    expect(converted[0]).toEqual({
+      role: "system",
+      content: "Stable prefix\nReactions guidance",
+    });
+    expect(converted[1]?.content).toBe("hi\n\n## Runtime\nRuntime: session=alpha");
+  });
+
+  it("keeps behavioral guidance at system authority", () => {
+    // Only the marked region moves. Everything outside it, including guidance
+    // that merely sits below the cache boundary, stays in the system message.
+    const converted = convertMessages(model, contextForSession("alpha"), compat());
+
+    expect(converted[0]?.content).toContain("Reactions guidance");
+    expect(converted[1]?.content).not.toContain("Reactions guidance");
+  });
+
+  it("does not relocate when only the cache boundary is present", () => {
+    const context = {
+      systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Reactions guidance`,
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    } as unknown as Context;
+
+    const converted = convertMessages(model, context, compat());
+
+    expect(converted[0]?.content).toBe("Stable prefix\nReactions guidance");
+    expect(converted[1]?.content).toBe("hi");
+  });
+
+  it("keeps the system message byte-identical across sessions", () => {
+    const first = convertMessages(model, contextForSession("alpha"), compat());
+    const second = convertMessages(model, contextForSession("beta"), compat());
+
+    expect(first[0]).toEqual(second[0]);
+    expect(first[1]?.content).not.toEqual(second[1]?.content);
+  });
+
+  it("keeps the region in the system prompt when the only user turn projects away", () => {
+    // Media projection can leave a user turn with no renderable content, and the
+    // converter skips it. The region must survive rather than vanish with it.
+    const context = {
+      systemPrompt: `Stable prefix${marked("Runtime facts")}`,
+      messages: [{ role: "user", content: [], timestamp: 1 }],
+    } as unknown as Context;
+
+    const converted = convertMessages(model, context, compat());
+
+    expect(converted).toHaveLength(1);
+    expect(converted[0]?.content).toBe("Stable prefix\nRuntime facts");
+  });
+
+  it("never leaks an internal marker to the provider", () => {
+    const converted = convertMessages(model, contextForSession("alpha"), compat());
+
+    expect(JSON.stringify(converted)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+    expect(JSON.stringify(converted)).not.toContain("OPENCLAW-RELOCATABLE-BOUNDARY");
+  });
+
+  it("leaves the boundary in place when the caller preserves it", () => {
+    const converted = convertMessages(model, contextForSession("alpha"), compat(), {
+      preserveSystemPromptCacheBoundary: true,
+    });
+
+    expect(converted[0]?.content).toContain(SYSTEM_PROMPT_CACHE_BOUNDARY.trim());
+    expect(converted[1]?.content).toBe("hi");
+  });
+
+  it("leaves a trailing structural marker in the system prompt", () => {
+    // The attempt-section marker closes a region of the system prompt; it must
+    // not ride onto the user turn with the relocated facts. It sits outside the
+    // marked region, so the closing boundary keeps it where it belongs.
+    const context = {
+      systemPrompt: `Stable prefix${marked("Runtime: session=alpha")}<!-- /openclaw:attempt:DYNAMIC -->`,
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    } as unknown as Context;
+
+    const converted = convertMessages(model, context, compat());
+
+    expect(converted[0]?.content).toBe("Stable prefix\n<!-- /openclaw:attempt:DYNAMIC -->");
+    expect(converted[1]?.content).toBe("hi\n\nRuntime: session=alpha");
+  });
+
+  it("keeps the previous turn byte-identical across follow-up requests", () => {
+    // The region must not migrate to whichever user turn happens to be last: that
+    // would change the earlier turn on every follow-up and fork the prefix
+    // there, costing the whole prior exchange including tool results. Reported
+    // on the PR by a reviewer who ran exactly this comparison.
+    const toolResult = "X".repeat(30000);
+    const turn1 = {
+      systemPrompt: `Stable prefix${marked("Runtime: session=alpha")}`,
+      messages: [{ role: "user", content: "user1", timestamp: 1 }],
+    } as unknown as Context;
+    const turn2 = {
+      systemPrompt: `Stable prefix${marked("Runtime: session=alpha")}`,
+      messages: [
+        { role: "user", content: "user1", timestamp: 1 },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "c1", name: "read", arguments: "{}" }],
+          timestamp: 2,
+        },
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: toolResult }],
+          toolCallId: "c1",
+          timestamp: 3,
+        },
+        { role: "user", content: "user2", timestamp: 4 },
+      ],
+    } as unknown as Context;
+
+    const first = convertMessages(model, turn1, compat());
+    const second = convertMessages(model, turn2, compat());
+
+    // Every param of turn 1 must appear unchanged at the same index in turn 2.
+    for (let index = 0; index < first.length; index++) {
+      expect(JSON.stringify(second[index])).toBe(JSON.stringify(first[index]));
+    }
+  });
+
+  it("keeps the system message stable across conversations while doing so", () => {
+    // The two properties are in tension: satisfying one by sacrificing the
+    // other is the failure this pair guards against.
+    const convo = (session: string, user: string): Context =>
+      ({
+        systemPrompt: `Stable prefix${marked(`Runtime: session=${session}`)}`,
+        messages: [{ role: "user", content: user, timestamp: 1 }],
+      }) as unknown as Context;
+
+    const a = convertMessages(model, convo("alpha", "hello"), compat());
+    const b = convertMessages(model, convo("beta", "hello"), compat());
+
+    expect(a[0]).toEqual(b[0]);
+    expect(a[1]?.content).not.toEqual(b[1]?.content);
+  });
+
+  it("keeps hook system context in the system message", () => {
+    // `composeSystemPromptWithHookContext` appends `appendSystemContext` after
+    // the built prompt, so it lands past the marked region. It is behavioral
+    // instruction from a documented hook and must keep its system authority.
+    const context = {
+      systemPrompt: `Stable prefix${marked("Runtime: session=alpha")}## Team\nAlways answer in German.`,
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    } as unknown as Context;
+
+    const converted = convertMessages(model, context, compat());
+
+    expect(converted[0]?.content).toBe("Stable prefix\n## Team\nAlways answer in German.");
+    expect(converted[1]?.content).toBe("hi\n\nRuntime: session=alpha");
+  });
+
+  it("keeps a refreshed permission notice in the system message", () => {
+    // `refreshSystemPrompt` appends its PERMISSION section to the end of the
+    // prompt when none is present yet. Demoting that to user content would
+    // lower the authority of retry and interrupted-action guidance.
+    const notice = [
+      "<!-- openclaw:attempt:PERMISSION -->",
+      "Permissions changed. Inspect interrupted actions; do not repeat completed ones.",
+      "<!-- /openclaw:attempt:PERMISSION -->",
+    ].join("\n");
+    const context = {
+      systemPrompt: `Stable prefix${marked("Runtime: session=alpha")}\n${notice}`,
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    } as unknown as Context;
+
+    const converted = convertMessages(model, context, compat());
+
+    expect(converted[0]?.content).toContain("Inspect interrupted actions");
+    expect(converted[1]?.content).not.toContain("Inspect interrupted actions");
+    expect(converted[1]?.content).toBe("hi\n\nRuntime: session=alpha");
+  });
+
+  it("does not relocate when the region is never closed", () => {
+    // A prompt carrying only the opening marker is left whole: relocating its
+    // remainder would sweep up whatever a caller appended after it.
+    const context = {
+      systemPrompt: `Stable prefix${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}Runtime: session=alpha`,
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    } as unknown as Context;
+
+    const converted = convertMessages(model, context, compat());
+
+    expect(converted[0]?.content).toBe("Stable prefix\nRuntime: session=alpha");
+    expect(converted[1]?.content).toBe("hi");
+  });
+
+  it("marks the carrying turn as cache opt-out", () => {
+    const cacheOptOutIndexes = new Set<number>();
+
+    convertMessages(model, contextForSession("alpha"), compat(), { cacheOptOutIndexes });
+
+    expect(cacheOptOutIndexes.has(1)).toBe(true);
   });
 });

--- a/packages/ai/src/openai-completions-messages.test.ts
+++ b/packages/ai/src/openai-completions-messages.test.ts
@@ -1,10 +1,16 @@
+import type { ChatCompletionContentPart } from "openai/resources/chat/completions.js";
 import { describe, expect, it } from "vitest";
 import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
 import { convertMessages } from "./openai-completions-messages.js";
 import type { ProviderContext, ProviderModel } from "./provider-types.js";
 import { resolveOpenAICompletionsCompat } from "./transports/openai-completions-compat.js";
-import type { AssistantMessage, Context, Model } from "./types.js";
+import type { AssistantMessage, Context, Model, UserMessage } from "./types.js";
 import { createZeroUsage } from "./usage.test-support.js";
+import {
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END,
+} from "./utils/system-prompt-cache-boundary.js";
 
 const model: Model<"openai-completions"> = {
   id: "test-model",
@@ -462,5 +468,375 @@ describe("convertMessages parallel tool-result image ownership", () => {
     expect(labelText).not.toMatch(/[\uD800-\uDFFF]/u);
     const toolMessage = converted.find((message) => message.role === "tool");
     expect(toolMessage?.role === "tool" && toolMessage.tool_call_id).toBe(longCallId);
+  });
+});
+
+describe("convertMessages relocatable region", () => {
+  const compat = () => resolveOpenAICompletionsCompat(model);
+  const marked = (facts: string) =>
+    `${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}${facts}${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}`;
+  const contextForSession = (sessionId: string): Context => ({
+    systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Reactions guidance${marked(`## Runtime\nRuntime: session=${sessionId}`)}`,
+    messages: [{ role: "user", content: "hi", timestamp: 1 }],
+  });
+
+  it.each([
+    { reasoning: false, role: "system" },
+    { reasoning: true, role: "developer" },
+  ])(
+    "keeps behavioral guidance at $role authority while relocating facts",
+    ({ reasoning, role }) => {
+      const cacheOptOutIndexes = new Set<number>();
+      const converted = convertMessages(
+        { ...model, reasoning },
+        contextForSession("alpha"),
+        { ...compat(), supportsDeveloperRole: true },
+        { cacheOptOutIndexes },
+      );
+
+      expect(converted).toEqual([
+        { role, content: "Stable prefix\nReactions guidance" },
+        { role: "user", content: "hi\n\n## Runtime\nRuntime: session=alpha" },
+      ]);
+      expect(cacheOptOutIndexes).toEqual(new Set([1]));
+    },
+  );
+
+  it("does not relocate when only the cache boundary is present", () => {
+    const context: Context = {
+      systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Reactions guidance`,
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    };
+
+    const converted = convertMessages(model, context, compat());
+
+    expect(converted[0]?.content).toBe("Stable prefix\nReactions guidance");
+    expect(converted[1]?.content).toBe("hi");
+  });
+
+  it("keeps the system message byte-identical across sessions", () => {
+    const first = convertMessages(model, contextForSession("alpha"), compat());
+    const second = convertMessages(model, contextForSession("beta"), compat());
+
+    expect(JSON.stringify(first[0])).toBe(JSON.stringify(second[0]));
+    expect(first[1]?.content).not.toEqual(second[1]?.content);
+  });
+
+  it.each([
+    { name: "empty content", content: [] },
+    {
+      name: "unsupported empty image",
+      content: [{ type: "image", mimeType: "image/png", data: "" }],
+    },
+  ] satisfies Array<{ name: string; content: UserMessage["content"] }>)(
+    "keeps Runtime in system content when the only user turn contains $name",
+    ({ content }) => {
+      const context: Context = {
+        systemPrompt: `Stable prefix${marked("Runtime facts")}`,
+        messages: [{ role: "user", content, timestamp: 1 }],
+      };
+      const cacheOptOutIndexes = new Set<number>();
+
+      const converted = convertMessages(model, context, compat(), { cacheOptOutIndexes });
+
+      expect(converted).toEqual([{ role: "system", content: "Stable prefix\nRuntime facts" }]);
+      expect(cacheOptOutIndexes.size).toBe(0);
+    },
+  );
+
+  it.each([
+    {
+      name: "supported image",
+      input: ["text", "image"],
+      expectedImage: { type: "image_url", image_url: { url: "data:image/png;base64,aW1n" } },
+    },
+    {
+      name: "unsupported image placeholder",
+      input: ["text"],
+      expectedImage: { type: "text", text: "(image omitted: model does not support images)" },
+    },
+  ] satisfies Array<{
+    name: string;
+    input: Model<"openai-completions">["input"];
+    expectedImage: ChatCompletionContentPart;
+  }>)(
+    "preserves the emitted $name and surrounding text on the carrier",
+    ({ input, expectedImage }) => {
+      const context: Context = {
+        systemPrompt: `Stable prefix${marked("Runtime facts")}`,
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "before" },
+              { type: "image", mimeType: "image/png", data: "aW1n" },
+              { type: "text", text: "after" },
+            ],
+            timestamp: 1,
+          },
+        ],
+      };
+
+      const converted = convertMessages({ ...model, input }, context, compat());
+
+      expect(converted).toEqual([
+        { role: "system", content: "Stable prefix" },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "before" },
+            expectedImage,
+            { type: "text", text: "after" },
+            { type: "text", text: "Runtime facts" },
+          ],
+        },
+      ]);
+    },
+  );
+
+  it("uses the later emitted user turn when an unsupported empty image projects away", () => {
+    const context: Context = {
+      systemPrompt: `Stable prefix${marked("Runtime facts")}`,
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "image", mimeType: "image/png", data: "" }],
+          timestamp: 1,
+        },
+        { role: "user", content: "surviving turn", timestamp: 2 },
+      ],
+    };
+    const cacheOptOutIndexes = new Set<number>();
+
+    const converted = convertMessages(model, context, compat(), { cacheOptOutIndexes });
+
+    expect(converted).toEqual([
+      { role: "system", content: "Stable prefix" },
+      { role: "user", content: "surviving turn\n\nRuntime facts" },
+    ]);
+    expect(cacheOptOutIndexes).toEqual(new Set([1]));
+  });
+
+  it("uses the first emitted tool-result image carrier and preserves later cache opt-outs", () => {
+    const imageModel: Model<"openai-completions"> = { ...model, input: ["text", "image"] };
+    const assistant: AssistantMessage = {
+      role: "assistant",
+      api: imageModel.api,
+      provider: imageModel.provider,
+      model: imageModel.id,
+      content: [
+        { type: "toolCall", id: "image_call", name: "read", arguments: { path: "image.png" } },
+      ],
+      usage: emptyUsage,
+      stopReason: "toolUse",
+      timestamp: 2,
+    };
+    const context: Context = {
+      systemPrompt: `Stable prefix${marked("Runtime facts")}`,
+      messages: [
+        { role: "user", content: [], timestamp: 1 },
+        assistant,
+        {
+          role: "toolResult",
+          toolCallId: "image_call",
+          toolName: "read",
+          content: [{ type: "image", mimeType: "image/png", data: "aW1n" }],
+          isError: false,
+          timestamp: 3,
+        },
+        { role: "user", content: "later context", runtimeContextCarrier: true, timestamp: 4 },
+      ],
+    };
+    const cacheOptOutIndexes = new Set<number>();
+
+    const converted = convertMessages(imageModel, context, compat(), { cacheOptOutIndexes });
+
+    expect(converted).toEqual([
+      { role: "system", content: "Stable prefix" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "image_call",
+            type: "function",
+            function: { name: "read", arguments: '{"path":"image.png"}' },
+          },
+        ],
+      },
+      { role: "tool", tool_call_id: "image_call", content: "(see attached image)" },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Image(s) from tool result #1 (read):" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,aW1n" } },
+          { type: "text", text: "Runtime facts" },
+        ],
+      },
+      { role: "user", content: "later context" },
+    ]);
+    expect(cacheOptOutIndexes).toEqual(new Set([3, 4]));
+  });
+
+  it("leaves the boundary in place when the caller preserves it", () => {
+    const converted = convertMessages(model, contextForSession("alpha"), compat(), {
+      preserveSystemPromptCacheBoundary: true,
+    });
+
+    expect(converted).toEqual([
+      {
+        role: "system",
+        content: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Reactions guidance\n## Runtime\nRuntime: session=alpha`,
+      },
+      { role: "user", content: "hi" },
+    ]);
+  });
+
+  it("leaves a trailing structural marker in the system prompt", () => {
+    const context: Context = {
+      systemPrompt: `Stable prefix${marked("Runtime: session=alpha")}<!-- /openclaw:attempt:DYNAMIC -->`,
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    };
+
+    const converted = convertMessages(model, context, compat());
+
+    expect(converted[0]?.content).toBe("Stable prefix\n<!-- /openclaw:attempt:DYNAMIC -->");
+    expect(converted[1]?.content).toBe("hi\n\nRuntime: session=alpha");
+  });
+
+  it("preserves all prior messages including the full tool result on follow-up", () => {
+    // Moving Runtime to the last user turn used to rewrite the earlier cached prefix.
+    const toolResult = "X".repeat(30000);
+    const turn1: Context = {
+      systemPrompt: `Stable prefix${marked("Runtime: session=alpha")}`,
+      messages: [{ role: "user", content: "user1", timestamp: 1 }],
+    };
+    const assistant: AssistantMessage = {
+      role: "assistant",
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      content: [{ type: "toolCall", id: "c1", name: "read", arguments: {} }],
+      usage: emptyUsage,
+      stopReason: "toolUse",
+      timestamp: 2,
+    };
+    const withToolResult: Context = {
+      ...turn1,
+      messages: [
+        ...turn1.messages,
+        assistant,
+        makeTextToolResult("c1", "read", toolResult, false, 3),
+      ],
+    };
+    const followUp: Context = {
+      ...withToolResult,
+      messages: [...withToolResult.messages, { role: "user", content: "user2", timestamp: 4 }],
+    };
+
+    const first = convertMessages(model, turn1, compat());
+    const beforeFollowUp = convertMessages(model, withToolResult, compat());
+    const afterFollowUp = convertMessages(model, followUp, compat());
+
+    expect(beforeFollowUp).toEqual([
+      ...first,
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{ id: "c1", type: "function", function: { name: "read", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "c1", content: toolResult },
+    ]);
+    expect(JSON.stringify(afterFollowUp.slice(0, beforeFollowUp.length))).toBe(
+      JSON.stringify(beforeFollowUp),
+    );
+    expect(afterFollowUp.at(-1)).toEqual({ role: "user", content: "user2" });
+  });
+
+  it("keeps trailing hook guidance in the system message", () => {
+    const context: Context = {
+      systemPrompt: `Stable prefix${marked("Runtime: session=alpha")}## Team\nAlways answer in German.`,
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    };
+
+    const converted = convertMessages(model, context, compat());
+
+    expect(converted[0]?.content).toBe("Stable prefix\n## Team\nAlways answer in German.");
+    expect(converted[1]?.content).toBe("hi\n\nRuntime: session=alpha");
+  });
+
+  it("keeps trailing permission guidance in the system message", () => {
+    const notice = [
+      "<!-- openclaw:attempt:PERMISSION -->",
+      "Permissions changed. Inspect interrupted actions; do not repeat completed ones.",
+      "<!-- /openclaw:attempt:PERMISSION -->",
+    ].join("\n");
+    const context: Context = {
+      systemPrompt: `Stable prefix${marked("Runtime: session=alpha")}\n${notice}`,
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    };
+
+    const converted = convertMessages(model, context, compat());
+
+    expect(converted[0]?.content).toContain("Inspect interrupted actions");
+    expect(converted[1]?.content).not.toContain("Inspect interrupted actions");
+    expect(converted[1]?.content).toBe("hi\n\nRuntime: session=alpha");
+  });
+
+  it.each([
+    {
+      name: "missing closing marker",
+      systemPrompt: `Stable prefix${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}Runtime facts`,
+      expectedSystem: "Stable prefix\nRuntime facts",
+    },
+    {
+      name: "missing opening marker",
+      systemPrompt: `Stable prefix\nRuntime facts${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}\nRetry guidance`,
+      expectedSystem: "Stable prefix\nRuntime facts\nRetry guidance",
+    },
+    {
+      name: "reversed markers",
+      systemPrompt: `Stable prefix${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}\nRetry guidance${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}Runtime facts`,
+      expectedSystem: "Stable prefix\nRetry guidance\nRuntime facts",
+    },
+    {
+      name: "literal opening before the complete region",
+      systemPrompt: `Stable prefix${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}Retry guidance${SYSTEM_PROMPT_CACHE_BOUNDARY}Reactions guidance${marked("Runtime facts")}`,
+      expectedSystem: "Stable prefix\nRetry guidance\nReactions guidance\nRuntime facts",
+    },
+    {
+      name: "literal closing before the complete region",
+      systemPrompt: `Stable prefix${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}\nRetry guidance${marked("Runtime facts")}`,
+      expectedSystem: "Stable prefix\nRetry guidance\nRuntime facts",
+    },
+    {
+      name: "two complete regions",
+      systemPrompt: `Stable prefix${marked("Retry guidance")}${marked("Runtime facts")}`,
+      expectedSystem: "Stable prefix\nRetry guidance\nRuntime facts",
+    },
+    {
+      name: "duplicate opening after the complete region",
+      systemPrompt: `Stable prefix${marked("Runtime facts")}${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}Retry guidance`,
+      expectedSystem: "Stable prefix\nRuntime facts\nRetry guidance",
+    },
+    {
+      name: "duplicate closing after the complete region",
+      systemPrompt: `Stable prefix${marked("Runtime facts")}${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}\nRetry guidance`,
+      expectedSystem: "Stable prefix\nRuntime facts\nRetry guidance",
+    },
+  ])("retains all text at system authority for $name", ({ systemPrompt, expectedSystem }) => {
+    const context: Context = {
+      systemPrompt,
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    };
+    const cacheOptOutIndexes = new Set<number>();
+
+    const converted = convertMessages(model, context, compat(), { cacheOptOutIndexes });
+
+    expect(converted).toEqual([
+      { role: "system", content: expectedSystem },
+      { role: "user", content: "hi" },
+    ]);
+    expect(cacheOptOutIndexes.size).toBe(0);
   });
 });

--- a/packages/ai/src/openai-completions-messages.ts
+++ b/packages/ai/src/openai-completions-messages.ts
@@ -17,7 +17,11 @@ import {
 import type { ResolvedOpenAICompletionsCompat } from "./transports/openai-completions-compat.js";
 import type { Context, Model, TextContent, ThinkingContent, ToolCall } from "./types.js";
 import { sanitizeSurrogates } from "./utils/sanitize-unicode.js";
-import { stripSystemPromptCacheBoundary } from "./utils/system-prompt-cache-boundary.js";
+import {
+  splitSystemPromptRelocatableBoundary,
+  stripSystemPromptCacheBoundary,
+  stripSystemPromptRelocatableBoundary,
+} from "./utils/system-prompt-cache-boundary.js";
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
 type ChatCompletionContentPartVideo = {
@@ -83,12 +87,30 @@ export function convertMessages(
     normalizeToolCallId(id),
   ) as ProviderMessage[];
 
+  // Chat templates serialize `tools` after the system message, so a volatile
+  // region left inside it still sits ahead of the tool schemas and forks the
+  // cacheable prefix on every new conversation. Carry it past the tools on a
+  // user turn instead, keeping the full prompt in place until a carrier turn is
+  // actually emitted so a projected-away turn cannot drop the region.
+  let relocatableSplit: { remainingPrompt: string; relocatable: string } | undefined;
+  let systemParamIndex: number | undefined;
   if (context.systemPrompt) {
     const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
     const role = useDeveloperRole ? "developer" : "system";
-    const systemPrompt = options.preserveSystemPromptCacheBoundary
-      ? context.systemPrompt
-      : stripSystemPromptCacheBoundary(context.systemPrompt);
+    let systemPrompt: string;
+    if (options.preserveSystemPromptCacheBoundary) {
+      // The cache boundary stays so the caller can anchor its breakpoint on it,
+      // but nothing downstream relocates, so the relocatable markers would
+      // otherwise survive into the payload.
+      systemPrompt = stripSystemPromptRelocatableBoundary(context.systemPrompt);
+    } else {
+      const split = splitSystemPromptRelocatableBoundary(context.systemPrompt);
+      if (split && split.relocatable.length > 0) {
+        relocatableSplit = split;
+      }
+      systemPrompt = stripSystemPromptCacheBoundary(context.systemPrompt);
+    }
+    systemParamIndex = params.length;
     params.push({ role, content: sanitizeSurrogates(systemPrompt) });
   }
 
@@ -305,5 +327,64 @@ export function convertMessages(
     lastRole = msg.role;
   }
 
+  if (relocatableSplit !== undefined && systemParamIndex !== undefined) {
+    relocateNonBehavioralRegion({
+      params,
+      systemParamIndex,
+      split: relocatableSplit,
+      cacheOptOutIndexes: options.cacheOptOutIndexes,
+    });
+  }
+
   return params;
+}
+
+/**
+ * Attach the producer-marked non-behavioral region to the first user turn.
+ *
+ * Keeping per-session facts below `SYSTEM_PROMPT_CACHE_BOUNDARY` only stabilizes
+ * the prefix for providers that anchor a breakpoint there; Chat Completions
+ * serializes tool schemas after the whole system message, so the region still
+ * divides the prefix ahead of them. Everything outside the marked region stays
+ * in the system message at its original authority.
+ */
+function relocateNonBehavioralRegion(args: {
+  params: ChatCompletionMessageParam[];
+  systemParamIndex: number;
+  split: { remainingPrompt: string; relocatable: string };
+  cacheOptOutIndexes?: Set<number>;
+}): void {
+  const text = sanitizeSurrogates(args.split.relocatable);
+  // The FIRST user turn, not the last: a trailing turn changes every request, so
+  // the region would move off the previous turn on each follow-up and fork the
+  // prefix there, costing the whole prior exchange including tool results. The
+  // first turn is byte-identical for the life of the conversation and still sits
+  // after the tool schemas, which is all the relocation needs.
+  for (let index = args.systemParamIndex + 1; index < args.params.length; index++) {
+    const param = args.params[index];
+    if (!param || param.role !== "user") {
+      continue;
+    }
+    if (typeof param.content === "string") {
+      param.content = `${param.content}\n\n${text}`;
+    } else if (Array.isArray(param.content)) {
+      param.content = [
+        ...param.content,
+        { type: "text", text } satisfies ChatCompletionContentPartText,
+      ];
+    } else {
+      continue;
+    }
+    // Shrink the system message only once a carrier turn is secured, so a
+    // projected-away user turn leaves the region where it already is.
+    const systemParam = args.params[args.systemParamIndex];
+    if (systemParam) {
+      systemParam.content = sanitizeSurrogates(
+        stripSystemPromptCacheBoundary(args.split.remainingPrompt),
+      );
+    }
+    // The turn now carries volatile text, so it must not anchor a cache breakpoint.
+    args.cacheOptOutIndexes?.add(index);
+    return;
+  }
 }

--- a/packages/ai/src/openai-completions-messages.ts
+++ b/packages/ai/src/openai-completions-messages.ts
@@ -17,7 +17,11 @@ import {
 import type { ResolvedOpenAICompletionsCompat } from "./transports/openai-completions-compat.js";
 import type { Context, Model, ThinkingContent, ToolCall } from "./types.js";
 import { sanitizeSurrogates } from "./utils/sanitize-unicode.js";
-import { stripSystemPromptCacheBoundary } from "./utils/system-prompt-cache-boundary.js";
+import {
+  splitSystemPromptRelocatableBoundary,
+  stripSystemPromptCacheBoundary,
+  stripSystemPromptRelocatableBoundary,
+} from "./utils/system-prompt-cache-boundary.js";
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
 type ChatCompletionContentPartVideo = {
@@ -71,12 +75,25 @@ export function convertMessages(
     normalizeToolCallId(id),
   ) as ProviderMessage[];
 
+  // Local chat templates can place tools after system content. Move only the
+  // bounded Runtime facts so session identifiers do not split that prefix.
+  let relocatableSplit: { remainingPrompt: string; relocatable: string } | undefined;
+  let systemParamIndex: number | undefined;
   if (context.systemPrompt) {
     const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
     const role = useDeveloperRole ? "developer" : "system";
-    const systemPrompt = options.preserveSystemPromptCacheBoundary
-      ? context.systemPrompt
-      : stripSystemPromptCacheBoundary(context.systemPrompt);
+    let systemPrompt: string;
+    if (options.preserveSystemPromptCacheBoundary) {
+      // Explicit message breakpoints retain the existing system layout.
+      systemPrompt = stripSystemPromptRelocatableBoundary(context.systemPrompt);
+    } else {
+      const split = splitSystemPromptRelocatableBoundary(context.systemPrompt);
+      if (split && split.relocatable.length > 0) {
+        relocatableSplit = split;
+      }
+      systemPrompt = stripSystemPromptCacheBoundary(context.systemPrompt);
+    }
+    systemParamIndex = params.length;
     params.push({ role, content: sanitizeSurrogates(systemPrompt) });
   }
 
@@ -288,5 +305,52 @@ export function convertMessages(
     lastRole = msg.role;
   }
 
+  if (relocatableSplit !== undefined && systemParamIndex !== undefined) {
+    relocateNonBehavioralRegion({
+      params,
+      systemParamIndex,
+      split: relocatableSplit,
+      cacheOptOutIndexes: options.cacheOptOutIndexes,
+    });
+  }
+
   return params;
+}
+
+/** Commit relocation only after finding an emitted carrier. */
+function relocateNonBehavioralRegion(args: {
+  params: ChatCompletionMessageParam[];
+  systemParamIndex: number;
+  split: { remainingPrompt: string; relocatable: string };
+  cacheOptOutIndexes?: Set<number>;
+}): void {
+  const text = sanitizeSurrogates(stripSystemPromptCacheBoundary(args.split.relocatable));
+  // A trailing carrier would rewrite the earlier user turn on every follow-up.
+  for (let index = args.systemParamIndex + 1; index < args.params.length; index++) {
+    const param = args.params[index];
+    if (!param || param.role !== "user") {
+      continue;
+    }
+    if (typeof param.content === "string") {
+      param.content = `${param.content}\n\n${text}`;
+    } else if (Array.isArray(param.content)) {
+      param.content = [
+        ...param.content,
+        { type: "text", text } satisfies ChatCompletionContentPartText,
+      ];
+    } else {
+      continue;
+    }
+    // Shrink the system message only once a carrier turn is secured, so a
+    // projected-away user turn leaves the region where it already is.
+    const systemParam = args.params[args.systemParamIndex];
+    if (systemParam) {
+      systemParam.content = sanitizeSurrogates(
+        stripSystemPromptCacheBoundary(args.split.remainingPrompt),
+      );
+    }
+    // The turn now carries volatile text, so it must not anchor a cache breakpoint.
+    args.cacheOptOutIndexes?.add(index);
+    return;
+  }
 }

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -2,7 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import type { AssistantMessage, Context, Model, Tool } from "../types.js";
-import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
+import {
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+} from "../utils/system-prompt-cache-boundary.js";
 
 const anthropicMockState = vi.hoisted(() => ({
   configs: [] as unknown[],
@@ -2411,6 +2414,36 @@ describe("Anthropic provider", () => {
       {
         type: "text",
         text: "Dynamic suffix",
+      },
+    ]);
+  });
+
+  it("keeps the relocatable marker out of native Anthropic system blocks", async () => {
+    // Native Anthropic relocates nothing, so the marker must not survive into
+    // the payload while the cache breakpoint still lands on the stable prefix.
+    const { payload: capturedPayload, result } = await captureSimpleAnthropicPayload(
+      {},
+      { stopBeforeNetwork: true },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Reactions guidance${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}Runtime: session=alpha`,
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      },
+    );
+
+    expect(result.stopReason).toBe("error");
+    const system = (capturedPayload as { system?: unknown }).system;
+    const serialized = JSON.stringify(system);
+    expect(serialized).not.toContain("OPENCLAW-RELOCATABLE-BOUNDARY");
+    expect(serialized).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+    expect(system).toEqual([
+      {
+        type: "text",
+        text: "Stable prefix",
+        cache_control: { type: "ephemeral" },
+      },
+      {
+        type: "text",
+        text: "Reactions guidance\nRuntime: session=alpha",
       },
     ]);
   });

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -2,7 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import type { AssistantMessage, Context, Model, Tool } from "../types.js";
-import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
+import {
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END,
+} from "../utils/system-prompt-cache-boundary.js";
 
 const anthropicMockState = vi.hoisted(() => ({
   configs: [] as unknown[],
@@ -2398,6 +2402,36 @@ describe("Anthropic provider", () => {
       {
         type: "text",
         text: "Dynamic suffix",
+      },
+    ]);
+  });
+
+  it("keeps the relocatable marker out of native Anthropic system blocks", async () => {
+    // Native Anthropic relocates nothing, so the marker must not survive into
+    // the payload while the cache breakpoint still lands on the stable prefix.
+    const { payload: capturedPayload, result } = await captureSimpleAnthropicPayload(
+      {},
+      { stopBeforeNetwork: true },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Reactions guidance${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}Runtime: session=alpha${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}`,
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      },
+    );
+
+    expect(result.stopReason).toBe("error");
+    const system = (capturedPayload as { system?: unknown }).system;
+    const serialized = JSON.stringify(system);
+    expect(serialized).not.toContain("OPENCLAW-RELOCATABLE-BOUNDARY");
+    expect(serialized).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+    expect(system).toEqual([
+      {
+        type: "text",
+        text: "Stable prefix",
+        cache_control: { type: "ephemeral" },
+      },
+      {
+        type: "text",
+        text: "Reactions guidance\nRuntime: session=alpha",
       },
     ]);
   });

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import type { Context, Model, SimpleStreamOptions, TextContent } from "../types.js";
 import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
-import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
+import {
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END,
+} from "../utils/system-prompt-cache-boundary.js";
 
 type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 type OpenAICompatibleDelta = DeepPartial<ChatCompletionChunk["choices"][number]["delta"]> & {
@@ -1015,12 +1019,12 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedRetention).toBe("24h");
   });
 
-  it("strips the internal cache boundary from OpenAI-compatible system prompts", async () => {
+  it("carries the cache-boundary suffix on the trailing user turn for OpenAI-compatible providers", async () => {
     let capturedMessages: unknown;
     const stream = streamOpenAICompletions(
       createModel(32_000),
       {
-        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}Runtime facts${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}`,
         messages: [{ role: "user", content: "hi", timestamp: 1 }],
       },
       {
@@ -1036,10 +1040,18 @@ describe("OpenAI-compatible completions params", () => {
 
     expect(result.stopReason).toBe("error");
     const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    // The stable prefix must not fork; tool schemas are serialized after it.
     expect(messages[0]).toEqual({
       role: "system",
       content: "Stable prefix\nDynamic suffix",
     });
+    // Only the non-behavioral tail rides behind the tools on the user turn.
+    expect(messages[1]).toEqual({
+      role: "user",
+      content: "hi\n\nRuntime facts",
+    });
+    // The internal marker must never reach the provider.
+    expect(JSON.stringify(messages)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
   });
 
   it("splits the cache boundary before applying Anthropic cache control for OpenRouter Anthropic models", async () => {
@@ -1081,6 +1093,59 @@ describe("OpenAI-compatible completions params", () => {
           text: "Dynamic suffix",
         },
       ],
+    });
+  });
+
+  it("keeps the relocatable marker out of the OpenRouter Anthropic cache-control payload", async () => {
+    // This route preserves the cache boundary for its breakpoint and relocates
+    // nothing, so the relocatable marker must not survive into the payload.
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "anthropic/claude-sonnet-4.6",
+        provider: "openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Reactions guidance${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}## Runtime\nRuntime: session=alpha${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    const serialized = JSON.stringify(messages);
+    expect(serialized).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+    expect(serialized).not.toContain("OPENCLAW-RELOCATABLE-BOUNDARY");
+    // The breakpoint still lands on the stable prefix, and nothing is relocated.
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: [
+        {
+          type: "text",
+          text: "Stable prefix",
+          cache_control: { type: "ephemeral" },
+        },
+        {
+          type: "text",
+          text: "Reactions guidance\n## Runtime\nRuntime: session=alpha",
+        },
+      ],
+    });
+    // The user turn carries the conversation breakpoint and nothing relocated.
+    expect(messages[1]).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "hi", cache_control: { type: "ephemeral" } }],
     });
   });
 

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import type { Context, Model, SimpleStreamOptions, TextContent } from "../types.js";
 import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
-import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
+import {
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END,
+} from "../utils/system-prompt-cache-boundary.js";
 
 type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 type OpenAICompatibleDelta = DeepPartial<ChatCompletionChunk["choices"][number]["delta"]> & {
@@ -1017,12 +1021,12 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedRetention).toBe("24h");
   });
 
-  it("strips the internal cache boundary from OpenAI-compatible system prompts", async () => {
+  it("carries bounded Runtime facts on the first user turn for OpenAI-compatible providers", async () => {
     let capturedMessages: unknown;
     const stream = streamOpenAICompletions(
       createModel(32_000),
       {
-        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}Runtime facts${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}`,
         messages: [{ role: "user", content: "hi", timestamp: 1 }],
       },
       {
@@ -1038,10 +1042,18 @@ describe("OpenAI-compatible completions params", () => {
 
     expect(result.stopReason).toBe("error");
     const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    // The stable prefix must not fork; tool schemas are serialized after it.
     expect(messages[0]).toEqual({
       role: "system",
       content: "Stable prefix\nDynamic suffix",
     });
+    // Only the non-behavioral tail rides behind the tools on the user turn.
+    expect(messages[1]).toEqual({
+      role: "user",
+      content: "hi\n\nRuntime facts",
+    });
+    // The internal marker must never reach the provider.
+    expect(JSON.stringify(messages)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
   });
 
   it("splits the cache boundary before applying Anthropic cache control for OpenRouter Anthropic models", async () => {
@@ -1083,6 +1095,59 @@ describe("OpenAI-compatible completions params", () => {
           text: "Dynamic suffix",
         },
       ],
+    });
+  });
+
+  it("keeps the relocatable marker out of the OpenRouter Anthropic cache-control payload", async () => {
+    // This route preserves the cache boundary for its breakpoint and relocates
+    // nothing, so the relocatable marker must not survive into the payload.
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "anthropic/claude-sonnet-4.6",
+        provider: "openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+      },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Reactions guidance${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}## Runtime\nRuntime: session=alpha${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    const serialized = JSON.stringify(messages);
+    expect(serialized).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+    expect(serialized).not.toContain("OPENCLAW-RELOCATABLE-BOUNDARY");
+    // The breakpoint still lands on the stable prefix, and nothing is relocated.
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: [
+        {
+          type: "text",
+          text: "Stable prefix",
+          cache_control: { type: "ephemeral" },
+        },
+        {
+          type: "text",
+          text: "Reactions guidance\n## Runtime\nRuntime: session=alpha",
+        },
+      ],
+    });
+    // The user turn carries the conversation breakpoint and nothing relocated.
+    expect(messages[1]).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "hi", cache_control: { type: "ephemeral" } }],
     });
   });
 

--- a/packages/ai/src/transports/anthropic-payload-policy.ts
+++ b/packages/ai/src/transports/anthropic-payload-policy.ts
@@ -12,6 +12,7 @@ import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
+  stripSystemPromptRelocatableBoundary,
 } from "../utils/system-prompt-cache-boundary.js";
 /**
  * Anthropic-family request payload policy helpers.
@@ -265,11 +266,16 @@ function applyAnthropicCacheControlToSystem(
       continue;
     }
     const record = block as Record<string, unknown>;
-    if (record.type !== "text" || typeof record.text !== "string") {
+    const blockText = record.text;
+    if (record.type !== "text" || typeof blockText !== "string") {
       normalizedBlocks.push(block);
       continue;
     }
-    const split = splitSystemPromptCacheBoundary(record.text);
+    // This transport relocates nothing, so the relocatable marker must not
+    // survive into the payload; the cache boundary stays for the breakpoint.
+    const text = stripSystemPromptRelocatableBoundary(blockText);
+    record.text = text;
+    const split = splitSystemPromptCacheBoundary(text);
     if (!split) {
       if (record.cache_control === undefined) {
         record.cache_control = cacheControl;

--- a/packages/ai/src/transports/anthropic-payload-policy.ts
+++ b/packages/ai/src/transports/anthropic-payload-policy.ts
@@ -12,6 +12,7 @@ import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
+  stripSystemPromptRelocatableBoundary,
 } from "../utils/system-prompt-cache-boundary.js";
 /**
  * Anthropic-family request payload policy helpers.
@@ -266,11 +267,16 @@ function applyAnthropicCacheControlToSystem(
       continue;
     }
     const record = block as Record<string, unknown>;
-    if (record.type !== "text" || typeof record.text !== "string") {
+    const blockText = record.text;
+    if (record.type !== "text" || typeof blockText !== "string") {
       normalizedBlocks.push(block);
       continue;
     }
-    const split = splitSystemPromptCacheBoundary(record.text);
+    // This transport relocates nothing, so the relocatable marker must not
+    // survive into the payload; the cache boundary stays for the breakpoint.
+    const text = stripSystemPromptRelocatableBoundary(blockText);
+    record.text = text;
+    const split = splitSystemPromptCacheBoundary(text);
     if (!split) {
       if (record.cache_control === undefined) {
         record.cache_control = cacheControl;

--- a/packages/ai/src/transports/openai-completions-params.ts
+++ b/packages/ai/src/transports/openai-completions-params.ts
@@ -348,6 +348,10 @@ export function buildOpenAICompletionsRequest(
     endpointClass !== "modelstudio-native" &&
     !(endpointClass === "default" && ["modelstudio", "dashscope", "qwen"].includes(model.provider));
   const cacheOptOutIndexes = new Set<number>();
+  // convertMessages owns the cache boundary here: it carries the marked runtime
+  // region past the tool schemas when a user turn can hold it, and strips the
+  // markers when the caller preserves the boundary instead. Pre-stripping the
+  // prompt at this call site would hide the boundary from that logic.
   let messages: unknown[] = convertMessages(model as never, context, compat as never, {
     cacheOptOutIndexes,
     preserveSystemPromptCacheBoundary:

--- a/packages/ai/src/transports/openai-completions-params.ts
+++ b/packages/ai/src/transports/openai-completions-params.ts
@@ -348,6 +348,7 @@ export function buildOpenAICompletionsRequest(
     endpointClass !== "modelstudio-native" &&
     !(endpointClass === "default" && ["modelstudio", "dashscope", "qwen"].includes(model.provider));
   const cacheOptOutIndexes = new Set<number>();
+  // The converter needs intact boundaries for Runtime relocation or cache markers.
   let messages: unknown[] = convertMessages(model as never, context, compat as never, {
     cacheOptOutIndexes,
     preserveSystemPromptCacheBoundary:

--- a/packages/ai/src/utils/system-prompt-cache-boundary.test.ts
+++ b/packages/ai/src/utils/system-prompt-cache-boundary.test.ts
@@ -5,8 +5,11 @@ import {
   ensureSystemPromptCacheBoundary,
   prependSystemPromptAdditionAfterCacheBoundary,
   splitSystemPromptCacheBoundary,
+  splitSystemPromptRelocatableBoundary,
   stripSystemPromptCacheBoundary,
   SYSTEM_PROMPT_CACHE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END,
 } from "./system-prompt-cache-boundary.js";
 
 describe("system prompt cache boundary helpers", () => {
@@ -99,5 +102,54 @@ describe("ensureSystemPromptCacheBoundary", () => {
       stablePrefix: "Marker-free override",
       dynamicSuffix: "Per-turn media task hint",
     });
+  });
+});
+
+describe("relocatable region splitting", () => {
+  const marked = (facts: string) =>
+    `${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}${facts}${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}`;
+
+  it("cuts the marked region out of the prompt", () => {
+    expect(
+      splitSystemPromptRelocatableBoundary(
+        `Behavioral guidance${marked("Runtime: session=alpha")}`,
+      ),
+    ).toEqual({
+      remainingPrompt: "Behavioral guidance",
+      relocatable: "Runtime: session=alpha",
+    });
+  });
+
+  it("keeps text appended after the region in the prompt", () => {
+    // Hook context and permission notices are appended once the prompt is
+    // built. They must not travel with the runtime facts.
+    expect(
+      splitSystemPromptRelocatableBoundary(
+        `Behavioral guidance${marked("Runtime: session=alpha")}Hook instruction`,
+      ),
+    ).toEqual({
+      remainingPrompt: "Behavioral guidance\nHook instruction",
+      relocatable: "Runtime: session=alpha",
+    });
+  });
+
+  it("returns undefined when the region is never closed", () => {
+    expect(
+      splitSystemPromptRelocatableBoundary(
+        `Behavioral guidance${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}Runtime: session=alpha`,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for an unmarked prompt", () => {
+    expect(splitSystemPromptRelocatableBoundary("Behavioral guidance")).toBeUndefined();
+  });
+
+  it("strips both markers from prompt text", () => {
+    const stripped = stripSystemPromptCacheBoundary(
+      `Behavioral guidance${marked("Runtime: session=alpha")}`,
+    );
+    expect(stripped).not.toContain("OPENCLAW-RELOCATABLE-BOUNDARY");
+    expect(stripped).toContain("Runtime: session=alpha");
   });
 });

--- a/packages/ai/src/utils/system-prompt-cache-boundary.ts
+++ b/packages/ai/src/utils/system-prompt-cache-boundary.ts
@@ -7,8 +7,53 @@ import { normalizeStructuredPromptSection } from "./prompt-cache-stability.js";
 
 export const SYSTEM_PROMPT_CACHE_BOUNDARY = "\n<!-- OPENCLAW_CACHE_BOUNDARY -->\n";
 
+/**
+ * Delimits a bounded region of the system prompt that carries no behavioral
+ * guidance: per-session runtime facts. Transports whose tool schemas serialize
+ * after the system message may move this region behind them so the cacheable
+ * prefix stays byte-identical across sessions.
+ *
+ * Bounded at both ends rather than running to the end of the prompt, because
+ * callers append once it is built — an `appendSystemContext` hook, a permission
+ * refresh notice — and an open-ended region would sweep those into the relocated
+ * text and demote them to user content.
+ */
+// The marker text is hyphenated rather than underscored on purpose: an
+// `OPENCLAW_*` token here would register as a new environment-variable name in
+// the `config/env-var-count-budget.txt` ratchet, which is meant to ratchet down.
+export const SYSTEM_PROMPT_RELOCATABLE_BOUNDARY = "\n<!-- OPENCLAW-RELOCATABLE-BOUNDARY -->\n";
+export const SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END = "\n<!-- /OPENCLAW-RELOCATABLE-BOUNDARY -->";
+
 export function stripSystemPromptCacheBoundary(text: string): string {
-  return text.replaceAll(SYSTEM_PROMPT_CACHE_BOUNDARY, "\n");
+  // Both internal markers are stripped here so every existing caller keeps the
+  // guarantee that no marker reaches a provider.
+  return stripSystemPromptRelocatableBoundary(text.replaceAll(SYSTEM_PROMPT_CACHE_BOUNDARY, "\n"));
+}
+
+/**
+ * Cut out the non-behavioral region a transport may carry past its tool schemas.
+ *
+ * `remainingPrompt` is the prompt with the region excised, so text appended once
+ * the prompt was built — hook context, a permission notice, a section-closing
+ * comment — stays in the system message in its original role. Returns undefined
+ * unless both markers are present in order, leaving a prompt that carries only
+ * the opening marker whole rather than relocating its remainder.
+ */
+export function splitSystemPromptRelocatableBoundary(
+  text: string,
+): { remainingPrompt: string; relocatable: string } | undefined {
+  const opened = splitOnBoundary(text, SYSTEM_PROMPT_RELOCATABLE_BOUNDARY);
+  if (!opened) {
+    return undefined;
+  }
+  const closed = splitOnBoundary(opened.suffix, SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END);
+  if (!closed) {
+    return undefined;
+  }
+  return {
+    remainingPrompt: [opened.prefix, closed.suffix].filter(Boolean).join("\n"),
+    relocatable: closed.prefix,
+  };
 }
 
 // Append the cache boundary when a prompt has none (e.g. a hook systemPrompt override),
@@ -22,17 +67,40 @@ export function ensureSystemPromptCacheBoundary(systemPrompt: string): string {
     : `${systemPrompt}${SYSTEM_PROMPT_CACHE_BOUNDARY}`;
 }
 
-export function splitSystemPromptCacheBoundary(
+/** Shared marker split so both boundaries stay on one implementation. */
+function splitOnBoundary(
   text: string,
-): { stablePrefix: string; dynamicSuffix: string } | undefined {
-  const boundaryIndex = text.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY);
+  marker: string,
+): { prefix: string; suffix: string } | undefined {
+  const boundaryIndex = text.indexOf(marker);
   if (boundaryIndex === -1) {
     return undefined;
   }
   return {
-    stablePrefix: text.slice(0, boundaryIndex).trimEnd(),
-    dynamicSuffix: text.slice(boundaryIndex + SYSTEM_PROMPT_CACHE_BOUNDARY.length).trimStart(),
+    prefix: text.slice(0, boundaryIndex).trimEnd(),
+    suffix: text.slice(boundaryIndex + marker.length).trimStart(),
   };
+}
+
+export function splitSystemPromptCacheBoundary(
+  text: string,
+): { stablePrefix: string; dynamicSuffix: string } | undefined {
+  const split = splitOnBoundary(text, SYSTEM_PROMPT_CACHE_BOUNDARY);
+  return split ? { stablePrefix: split.prefix, dynamicSuffix: split.suffix } : undefined;
+}
+
+/**
+ * Remove only the relocatable marker, leaving the cache boundary in place for
+ * transports that anchor a cache breakpoint on it. Those transports do not
+ * relocate anything, so the marker must not survive into their payload.
+ */
+export function stripSystemPromptRelocatableBoundary(text: string): string {
+  // The closing marker carries its own leading newline and is dropped whole:
+  // the prompt builder closes the region on its last line, so substituting a
+  // newline there would leave trailing whitespace the prompt never had.
+  return text
+    .replaceAll(SYSTEM_PROMPT_RELOCATABLE_BOUNDARY, "\n")
+    .replaceAll(SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END, "");
 }
 
 export function prependSystemPromptAdditionAfterCacheBoundary(params: {

--- a/packages/ai/src/utils/system-prompt-cache-boundary.ts
+++ b/packages/ai/src/utils/system-prompt-cache-boundary.ts
@@ -30,8 +30,8 @@ export function splitSystemPromptRelocatableBoundary(
   if (
     start === -1 ||
     end < start ||
-    text.indexOf(opening, start + opening.length) !== -1 ||
-    text.indexOf(closing, end + closing.length) !== -1
+    text.includes(opening, start + opening.length) ||
+    text.includes(closing, end + closing.length)
   ) {
     return undefined;
   }

--- a/packages/ai/src/utils/system-prompt-cache-boundary.ts
+++ b/packages/ai/src/utils/system-prompt-cache-boundary.ts
@@ -7,8 +7,40 @@ import { normalizeStructuredPromptSection } from "./prompt-cache-stability.js";
 
 export const SYSTEM_PROMPT_CACHE_BOUNDARY = "\n<!-- OPENCLAW_CACHE_BOUNDARY -->\n";
 
+/** Producer-delimited Runtime facts; instructions must remain outside this region. */
+export const SYSTEM_PROMPT_RELOCATABLE_BOUNDARY = "\n<!-- OPENCLAW-RELOCATABLE-BOUNDARY -->\n";
+export const SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END = "\n<!-- /OPENCLAW-RELOCATABLE-BOUNDARY -->";
+
 export function stripSystemPromptCacheBoundary(text: string): string {
-  return text.replaceAll(SYSTEM_PROMPT_CACHE_BOUNDARY, "\n");
+  return stripSystemPromptRelocatableBoundary(
+    text
+      .replaceAll(SYSTEM_PROMPT_CACHE_BOUNDARY, "\n")
+      .replaceAll(SYSTEM_PROMPT_CACHE_BOUNDARY.trim(), ""),
+  );
+}
+
+/** Reject ambiguous markers from workspace or hook text instead of moving instructions. */
+export function splitSystemPromptRelocatableBoundary(
+  text: string,
+): { remainingPrompt: string; relocatable: string } | undefined {
+  const opening = SYSTEM_PROMPT_RELOCATABLE_BOUNDARY.trim();
+  const closing = SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END.trim();
+  const start = text.indexOf(opening);
+  const end = text.indexOf(closing);
+  if (
+    start === -1 ||
+    end < start ||
+    text.indexOf(opening, start + opening.length) !== -1 ||
+    text.indexOf(closing, end + closing.length) !== -1
+  ) {
+    return undefined;
+  }
+  return {
+    remainingPrompt: [text.slice(0, start).trimEnd(), text.slice(end + closing.length).trimStart()]
+      .filter(Boolean)
+      .join("\n"),
+    relocatable: text.slice(start + opening.length, end).trim(),
+  };
 }
 
 // Append the cache boundary when a prompt has none (e.g. a hook systemPrompt override),
@@ -33,6 +65,18 @@ export function splitSystemPromptCacheBoundary(
     stablePrefix: text.slice(0, boundaryIndex).trimEnd(),
     dynamicSuffix: text.slice(boundaryIndex + SYSTEM_PROMPT_CACHE_BOUNDARY.length).trimStart(),
   };
+}
+
+/** Keep explicit cache breakpoints while removing relocation metadata. */
+export function stripSystemPromptRelocatableBoundary(text: string): string {
+  // The closing marker carries its own leading newline and is dropped whole:
+  // the prompt builder closes the region on its last line, so substituting a
+  // newline there would leave trailing whitespace the prompt never had.
+  return text
+    .replaceAll(SYSTEM_PROMPT_RELOCATABLE_BOUNDARY, "\n")
+    .replaceAll(SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END, "")
+    .replaceAll(SYSTEM_PROMPT_RELOCATABLE_BOUNDARY.trim(), "")
+    .replaceAll(SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END.trim(), "");
 }
 
 export function prependSystemPromptAdditionAfterCacheBoundary(params: {

--- a/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
@@ -1,6 +1,10 @@
 // Coverage for Google prompt-cache creation, reuse, and request rewriting.
 import crypto from "node:crypto";
-import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
+import {
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END,
+} from "@openclaw/ai/internal/shared";
 import { expectDefined } from "@openclaw/normalization-core";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
@@ -141,10 +145,10 @@ describe("google prompt cache", () => {
   });
 
   it.each([200, 503])(
-    "preserves the final assembled prompt when cache creation returns %s",
+    "strips markers from the cached prefix and preserves inline fallback when creation returns %s",
     async (statusCode) => {
       const stablePrompt = "hook-before\nbase";
-      const systemPrompt = `${stablePrompt}${SYSTEM_PROMPT_CACHE_BOUNDARY}hook-after`;
+      const systemPrompt = `hook-before${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY}base${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}${SYSTEM_PROMPT_CACHE_BOUNDARY}hook-after`;
       const fetchMock = vi.fn(
         async () =>
           new Response(

--- a/src/agents/embedded-agent-runner/google-prompt-cache.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.ts
@@ -562,7 +562,9 @@ export async function prepareGooglePromptCacheStreamFn(
   const inner = params.streamFn;
   return async (model, context, options) => {
     const split = splitSystemPromptCacheBoundary(context.systemPrompt ?? "");
-    const systemPrompt = sanitizeTransportPayloadText(split?.stablePrefix ?? "");
+    const systemPrompt = sanitizeTransportPayloadText(
+      stripSystemPromptCacheBoundary(split?.stablePrefix ?? ""),
+    );
     if (!split || !systemPrompt.trim()) {
       return inner(model, context, options);
     }

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
@@ -1,5 +1,9 @@
 // Coverage for assembling provider-transformed embedded attempt system prompts.
-import { prependSystemPromptAdditionAfterCacheBoundary } from "@openclaw/ai/internal/shared";
+import {
+  prependSystemPromptAdditionAfterCacheBoundary,
+  splitSystemPromptRelocatableBoundary,
+  stripSystemPromptCacheBoundary,
+} from "@openclaw/ai/internal/shared";
 import { Type } from "typebox";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
@@ -297,6 +301,24 @@ describe("buildAttemptSystemPrompt", () => {
     expect(refreshed).toContain("permissions to read-only");
     expect(refreshed).not.toContain("permissions to workspace");
     expect(refreshed.match(/## Permission change/g)).toHaveLength(1);
+  });
+
+  it("keeps an appended permission notice out of the relocatable region", async () => {
+    // `refreshSystemPrompt` appends its PERMISSION section after the built
+    // prompt. The relocatable region is closed before that, so a transport that
+    // carries the region onto a user turn cannot demote the notice with it.
+    const { prepared, read, refreshSystemPrompt } = await preparePermissionPrompt();
+    const refreshed = await refreshSystemPrompt(prepared.systemPromptText, [read]);
+    expect(refreshed).toContain("<!-- openclaw:attempt:PERMISSION -->");
+
+    const split = splitSystemPromptRelocatableBoundary(refreshed);
+
+    expect(split?.relocatable).toContain("Runtime:");
+    expect(split?.relocatable).not.toContain("PERMISSION");
+    expect(split?.remainingPrompt).toContain("<!-- openclaw:attempt:PERMISSION -->");
+    expect(stripSystemPromptCacheBoundary(refreshed)).not.toContain(
+      "OPENCLAW-RELOCATABLE-BOUNDARY",
+    );
   });
 
   it("does not inject permission guidance into raw model prompts", async () => {

--- a/src/agents/system-prompt.cache-prefix.test.ts
+++ b/src/agents/system-prompt.cache-prefix.test.ts
@@ -1,0 +1,120 @@
+import type { Model } from "@openclaw/ai";
+import { buildOpenAICompletionsParams } from "@openclaw/ai/transports";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { composeSystemPromptWithHookContext } from "./embedded-agent-runner/run/attempt-thread-helpers.js";
+import { buildAgentSystemPrompt } from "./system-prompt.js";
+
+const model: Model<"openai-completions"> = {
+  id: "local-model",
+  name: "Local model",
+  provider: "custom-local",
+  api: "openai-completions",
+  baseUrl: "https://local.example/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128000,
+  maxTokens: 1024,
+};
+const tools = [
+  { name: "read", description: "Read a file", parameters: Type.Object({ path: Type.String() }) },
+];
+const coauthor = "When committing, add Co-authored-by: Example User <user@example.com>.";
+const hookInstruction = "Always keep the project instruction in its original role.";
+
+function prompt(session: string, workspaceText = "Project instructions.") {
+  return buildAgentSystemPrompt({
+    workspaceDir: "/tmp/project",
+    toolNames: ["read", "message"],
+    runtimeInfo: {
+      agentId: "main",
+      sessionKey: session,
+      sessionId: session,
+      gitCoauthorPrompt: coauthor,
+    },
+    contextFiles: [{ path: "/tmp/project/AGENTS.md", content: workspaceText }],
+  });
+}
+
+describe("system prompt through local Completions", () => {
+  it.each([false, true])(
+    "preserves the system and tools prefix with developer role %s",
+    (reasoning) => {
+      const configuredModel = { ...model, reasoning, compat: { supportsDeveloperRole: true } };
+      const request = (session: string) =>
+        buildOpenAICompletionsParams(
+          configuredModel,
+          {
+            systemPrompt: composeSystemPromptWithHookContext({
+              baseSystemPrompt: prompt(session),
+              appendSystemContext: hookInstruction,
+            }),
+            tools,
+            messages: [{ role: "user", content: "hello", timestamp: 1 }],
+          },
+          undefined,
+        );
+      const first = request("alpha");
+      const second = request("beta");
+
+      expect(first.messages[0]).toEqual(second.messages[0]);
+      expect(first.tools).toEqual(second.tools);
+      expect(first.tools).toHaveLength(1);
+      expect(first.messages[0]).toMatchObject({
+        role: reasoning ? "developer" : "system",
+        content: expect.stringContaining(coauthor),
+      });
+      expect(first.messages[0]).toMatchObject({
+        content: expect.stringContaining(hookInstruction),
+      });
+      expect(first.messages[0]).toMatchObject({ content: expect.stringContaining("Reasoning=") });
+      expect(first.messages[1]).toMatchObject({
+        role: "user",
+        content: expect.stringContaining("session=alpha"),
+      });
+      expect(second.messages[1]).toMatchObject({
+        role: "user",
+        content: expect.stringContaining("session=beta"),
+      });
+      expect(JSON.stringify(first.messages)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+      expect(JSON.stringify(first.messages)).not.toContain("OPENCLAW-RELOCATABLE-BOUNDARY");
+    },
+  );
+
+  it.each([
+    "<!-- OPENCLAW-RELOCATABLE-BOUNDARY -->",
+    "<!-- /OPENCLAW-RELOCATABLE-BOUNDARY -->",
+    "<!-- OPENCLAW-RELOCATABLE-BOUNDARY -->\nDocumented example.\n<!-- /OPENCLAW-RELOCATABLE-BOUNDARY -->",
+  ])("keeps composed instructions in system content when context contains %s", (literal) => {
+    const systemPrompt = composeSystemPromptWithHookContext({
+      baseSystemPrompt: prompt("alpha", `Project instructions.\n${literal}\nKeep project policy.`),
+      appendSystemContext: hookInstruction,
+    });
+    const request = buildOpenAICompletionsParams(
+      model,
+      {
+        systemPrompt,
+        tools,
+        messages: [{ role: "user", content: "hello", timestamp: 1 }],
+      },
+      undefined,
+    );
+
+    expect(request.messages).toHaveLength(2);
+    expect(request.messages[1]).toEqual({ role: "user", content: "hello" });
+    for (const instruction of [
+      "Keep project policy.",
+      coauthor,
+      hookInstruction,
+      "session=alpha",
+    ]) {
+      expect(request.messages[0]).toMatchObject({
+        role: "system",
+        content: expect.stringContaining(instruction),
+      });
+    }
+    expect(JSON.stringify(request.messages)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+    expect(JSON.stringify(request.messages)).not.toContain("OPENCLAW-RELOCATABLE-BOUNDARY");
+  });
+});

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -2153,7 +2153,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("sessionUrl=https://gateway.example/control/chat/main");
   });
 
-  it("renders exact session Git co-author trailers once immediately after the Runtime line", () => {
+  it("renders exact session Git co-author trailers once outside relocatable Runtime facts", () => {
     const params = { workspaceDir: "/tmp/openclaw", runtimeInfo: { agentId: "work" } };
     const baseline = buildAgentSystemPrompt(params);
     const prompt = buildAgentSystemPrompt({
@@ -2170,8 +2170,8 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toBe(
       baseline.replace(
-        "Runtime: agent=work\n",
-        "Runtime: agent=work\n" +
+        "## Runtime\n",
+        "## Runtime\n" +
           "Git co-authors: add these exact trailers to every commit you make from this session.\n" +
           "Co-authored-by: ada <20+ada@users.noreply.github.com>\n" +
           "Co-authored-by: grace <10+grace@users.noreply.github.com>\n",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -8,6 +8,8 @@ import {
   normalizePromptCapabilityIds,
   normalizeStructuredPromptSection,
   SYSTEM_PROMPT_CACHE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END,
 } from "@openclaw/ai/internal/shared";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -1555,9 +1557,17 @@ export function buildAgentSystemPrompt(params: {
 
   lines.push(
     "## Runtime",
-    buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities),
     ...(modelIdentityLine ? [modelIdentityLine] : []),
     `Reasoning=${reasoningLevel}; hidden unless on/stream. Toggle /reasoning; /status shows when enabled.`,
+    // Only the per-session facts line sits between these markers. It states
+    // session identity and host facts and directs the model to do nothing, so a
+    // transport whose tool schemas serialize after the system message may carry
+    // it past them without moving any instruction out of its authoring role.
+    // The region is closed explicitly: callers append to this prompt afterwards
+    // (hook `appendSystemContext`, the permission refresh notice), and those
+    // additions must keep their instruction role rather than travel with it.
+    SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+    `${buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities)}${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}`,
   );
 
   return lines.filter(Boolean).join("\n");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -8,6 +8,8 @@ import {
   normalizePromptCapabilityIds,
   normalizeStructuredPromptSection,
   SYSTEM_PROMPT_CACHE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+  SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END,
 } from "@openclaw/ai/internal/shared";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -1548,10 +1550,13 @@ export function buildAgentSystemPrompt(params: {
 
   lines.push(
     "## Runtime",
-    buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities),
     ...(runtimeInfo?.gitCoauthorPrompt ? [runtimeInfo.gitCoauthorPrompt] : []),
     ...(modelIdentityLine ? [modelIdentityLine] : []),
     `Reasoning=${reasoningLevel}; hidden unless on/stream. Toggle /reasoning; /status shows when enabled.`,
+    // Only Runtime facts may move behind tools. Close the region before callers
+    // append hook instructions or permission notices that must retain their role.
+    SYSTEM_PROMPT_RELOCATABLE_BOUNDARY,
+    `${buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities)}${SYSTEM_PROMPT_RELOCATABLE_BOUNDARY_END}`,
   );
 
   return lines.filter(Boolean).join("\n");


### PR DESCRIPTION
Closes #137257

## What Problem This Solves

For local Chat Completions servers that render tools after the system message, fresh-session identifiers inside that message split the reusable system-and-tools prefix. The workspace, instructions, and tool schemas can be unchanged while each new conversation still requires prompt reprocessing.

## Why This Change Was Made

Move only the bounded Runtime facts line onto the first emitted user message. Keep behavioral instructions—including coauthor guidance, hook additions, and permission notices—at system/developer authority. Reject duplicated, reversed, or incomplete marker regions, and preserve facts when no user message survives projection.

Explicit message-cache breakpoints retain their existing system layout. Other affected provider paths remove the new markers without changing cache policy. The contributor commit is preserved. The earlier trailing-user approach and its unsupported follow-up latency claim remain withdrawn.

## User Impact

Fresh conversations retain an identical system-and-tools prefix on the supported local route. Follow-ups retain earlier user and tool history. Existing current-turn Runtime Context snapshots remain transient; this change does not persist them on the first message. Actual cache hits and latency still depend on the model server and chat template.

## Evidence

- Two public baseline configurations reproduce session-field divergence before unchanged tools. Five independent candidate cases cover the full and read-only catalogs plus literal opening, closing, and paired-marker workspace controls.
- Each candidate case uses the built public CLI, certificate-verified loopback HTTPS, two fresh sessions, real file reads returning the complete 18 KiB input, and a same-session follow-up. All 25 complete requests are retained; five separate checks confirmed closed listeners and removed fixture keys.
- Candidate system-and-tools values match across sessions: 85,208 bytes with all 41 tools, and 6,809 bytes with only `read`. The read-only complete previous request remains a prefix through the full tool result and follow-up. The full profile preserves real history but intentionally retains its pre-existing transient carrier; its unconditional complete-prefix comparison remains false.
- 590 focused cases have passing final coverage across the original 589 passes and the corrected exact-byte coauthor case. Both committed system/developer regressions fail on original main for the intended session-field difference. Restoring the original splitter produces five intended ambiguity failures and three passing malformed-input controls.
- Public proof uses built commit `af13c228eeadae316f4df84531ea37704a44a08d`. The subsequent two-line lint correction replaces equivalent fixed-string `indexOf` checks with `includes`; 51 fresh utility/converter tests pass. Original build and capture identities are retained.
- Native formatting, syntax lint, changed-file guards, and normal commit hooks pass. Hosted type-aware checks and final review are evaluated against the current PR head; the checks tab is authoritative for their state.

These are request-production, role-preservation, and real tool-execution checks with scripted provider responses. They do not claim natural model inference, server cache hits, or a new measured speedup. Historical contributor timings, corrected claims, and earlier CI failures remain in the discussion and retained evidence.
