### PR TITLE
refactor(control-ui): simplify mention Inbox request ownership

### DIFF
--- a/ui/src/app/mentions.ts
+++ b/ui/src/app/mentions.ts
@@ -36,7 +36,7 @@ type MentionConnection = {
   connectionRevision: number;
   profileId: string;
   gatewayInstanceId: string;
-  result: MentionsListResult | null;
+  revision: number | null;
   requiredRevision: number | null;
   dismissing: Set<string>;
   refreshRequested: boolean;
@@ -72,37 +72,45 @@ export function createMentionsCapability(
     gateway.connectionRevision === owner.connectionRevision &&
     gateway.snapshot.selfUser?.identity?.id === owner.profileId;
 
-  const applyResult = (owner: MentionConnection, result: MentionsListResult) => {
-    if (
-      !isCurrent(owner) ||
-      result.gatewayInstanceId !== owner.gatewayInstanceId ||
-      (owner.result !== null && result.revision < owner.result.revision) ||
-      (owner.requiredRevision !== null && result.revision < owner.requiredRevision)
-    ) {
-      return;
-    }
-    owner.result = result;
-    publish({ phase: "ready", items: result.items, error: null });
-  };
-
-  const handleError = (owner: MentionConnection, error: unknown) => {
+  const requestSnapshot = async (
+    owner: MentionConnection,
+    method: "mentions.list" | "mentions.dismiss",
+    params: { ids?: readonly string[] },
+  ) => {
     if (!isCurrent(owner)) {
       return;
     }
-    const accessLost =
-      error instanceof GatewayRequestError &&
-      (error.gatewayCode === "FORBIDDEN" ||
-        resolveGatewayErrorDetailCode(error) ===
-          ConnectErrorDetailCodes.AUTHENTICATED_PROFILE_UNAVAILABLE);
-    if (accessLost) {
-      // Retire in-flight reads too; an earlier success cannot restore a revoked Inbox.
-      connection = null;
+    try {
+      const result = await owner.client.request<MentionsListResult>(method, params);
+      if (
+        !isCurrent(owner) ||
+        result.gatewayInstanceId !== owner.gatewayInstanceId ||
+        (owner.revision !== null && result.revision < owner.revision) ||
+        (owner.requiredRevision !== null && result.revision < owner.requiredRevision)
+      ) {
+        return;
+      }
+      owner.revision = result.revision;
+      publish({ phase: "ready", items: result.items, error: null });
+    } catch (error) {
+      if (!isCurrent(owner)) {
+        return;
+      }
+      const accessLost =
+        error instanceof GatewayRequestError &&
+        (error.gatewayCode === "FORBIDDEN" ||
+          resolveGatewayErrorDetailCode(error) ===
+            ConnectErrorDetailCodes.AUTHENTICATED_PROFILE_UNAVAILABLE);
+      if (accessLost) {
+        // Retire in-flight reads too; an earlier success cannot restore a revoked Inbox.
+        connection = null;
+      }
+      publish({
+        phase: "error",
+        error: formatUiError(error),
+        ...(accessLost ? { items: [], dismissing: [] } : {}),
+      });
     }
-    publish({
-      phase: "error",
-      error: formatUiError(error),
-      ...(accessLost ? { items: [], dismissing: [] } : {}),
-    });
   };
 
   const refreshOwner = (owner: MentionConnection): Promise<void> => {
@@ -113,26 +121,15 @@ export function createMentionsCapability(
     if (owner.refreshPromise) {
       return owner.refreshPromise;
     }
-    const run = async () => {
-      while (isCurrent(owner) && owner.refreshRequested) {
-        owner.refreshRequested = false;
-        publish({ phase: "loading", error: null });
-        if (!isCurrent(owner)) {
-          return;
-        }
-        try {
-          const result = await owner.client.request<MentionsListResult>("mentions.list", {});
-          applyResult(owner, result);
-        } catch (error) {
-          handleError(owner, error);
-        }
-        // An invalidation during a read gets one more authoritative snapshot;
-        // revisions also fence an older read that finishes after dismissal.
-      }
-    };
     owner.refreshPromise = Promise.resolve().then(async () => {
       try {
-        await run();
+        while (isCurrent(owner) && owner.refreshRequested) {
+          owner.refreshRequested = false;
+          publish({ phase: "loading", error: null });
+          await requestSnapshot(owner, "mentions.list", {});
+          // An invalidation during a read gets one more authoritative snapshot;
+          // revisions also fence an older read that finishes after dismissal.
+        }
       } finally {
         owner.refreshPromise = null;
         if (isCurrent(owner) && owner.refreshRequested) {
@@ -169,7 +166,7 @@ export function createMentionsCapability(
       connectionRevision: gateway.connectionRevision,
       profileId,
       gatewayInstanceId,
-      result: null,
+      revision: null,
       requiredRevision: null,
       dismissing: new Set(),
       refreshRequested: false,
@@ -198,7 +195,7 @@ export function createMentionsCapability(
       typeof payload.revision !== "number" ||
       !Number.isSafeInteger(payload.revision) ||
       payload.revision < 0 ||
-      (owner.result !== null && payload.revision <= owner.result.revision)
+      (owner.revision !== null && payload.revision <= owner.revision)
     ) {
       return;
     }
@@ -239,15 +236,7 @@ export function createMentionsCapability(
       }
       publish({ dismissing: [...owner.dismissing], error: null });
       try {
-        if (!isCurrent(owner)) {
-          return;
-        }
-        const result = await owner.client.request<MentionsListResult>("mentions.dismiss", {
-          ids: pendingIds,
-        });
-        applyResult(owner, result);
-      } catch (error) {
-        handleError(owner, error);
+        await requestSnapshot(owner, "mentions.dismiss", { ids: pendingIds });
       } finally {
         for (const id of pendingIds) {
           owner.dismissing.delete(id);


### PR DESCRIPTION
Related: #135853

## What Problem This Solves

Maintainer-requested, behavior-preserving cleanup of the Control UI mention Inbox. Refresh and dismissal duplicated request/error handling, and each connection retained a full response solely to read its revision.

## Why This Change Was Made

Both operations now use one connection-owned request path with the same pre-dispatch and post-response ownership checks, revision fences, and access-revocation handling. Store only the accepted revision and simplify refresh cleanup without changing invalidation coalescing or dismissal semantics.

Production: +46/-57 (net -11). Tests: unchanged. No database/schema, migration, configuration, dependency, public RPC, visual, or lazy-loading changes.

## User Impact

No intended user-visible change. Stale reads still cannot restore dismissed or revoked Inbox items; profile changes and disposal still retire in-flight work.

## Evidence

- 72 existing tests passed across application mentions, connection bootstrap, sidebar attention/store, and Gateway method permissions.
- UI TypeScript check, targeted Oxlint, Oxfmt, and `git diff --check` passed on the final source.
- The broader Blacksmith Testbox changed gate (run 33765155076) passed early guards and localization, then was deliberately stopped during core-test typechecking. It is not claimed as a completed gate; the PR's exact-head CI remains required.
- Direct source review of the controller, Gateway permission helper, bootstrap coordinator, sidebar callers, and existing race/lifecycle coverage. No additional review agents were used, per the maintainer's explicit request.
- No new test needed: existing tests cover invalidation coalescing, late responses, revocation, profile/connection changes, bootstrap, and disposal. No separate live/browser rerun for this behavior-neutral internal refactor.
