### PR TITLE
fix(codex): scope app approvals to native threads

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -222,7 +222,7 @@ extensions/codex/src/app-server/session-binding.ts	2
 extensions/codex/src/app-server/shared-client.ts	4
 extensions/codex/src/app-server/side-question.ts	8
 extensions/codex/src/app-server/startup-binding.ts	2
-extensions/codex/src/app-server/thread-fingerprints.ts	2
+extensions/codex/src/app-server/thread-fingerprints.ts	1
 extensions/codex/src/app-server/thread-lifecycle-run.ts	1
 extensions/codex/src/app-server/tool-abort-terminal-reason.ts	1
 extensions/codex/src/app-server/tool-progress-normalization.ts	1

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -326,7 +326,10 @@ entries asynchronously. The cache is process-local; restarting the CLI or
 gateway drops it.
 
 Missing inventory methods, authentication errors, transport failures, and
-connector refresh failures fail closed.
+connector refresh failures do not admit app tools. Ordinary turns, including
+those using `allow_destructive_actions: "ask"`, can continue with native apps
+disabled when inventory exceeds its startup budget. Scheduled runs stop if
+their captured app policy cannot be revalidated within that budget.
 
 Migration and runtime use separate cache keys:
 
@@ -437,6 +440,7 @@ plugins, while unsafe schemas and ambiguous ownership fail closed:
   for the app before the thread starts, and offers only one-shot approval or
   denial so durable approvals cannot suppress later write-action prompts. These
   checks also run before reusing a thread or answering a `/btw` side question.
+  Successful cleanup refreshes loaded native threads as well as saved settings.
   For each admitted app using `"ask"`, OpenClaw selects Codex's human approvals
   reviewer for that app so Codex sends its approval elicitations to
   OpenClaw; other apps and non-app thread approvals keep their configured

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -436,11 +436,11 @@ plugins, while unsafe schemas and ambiguous ownership fail closed:
   turns ownership-proven MCP approval elicitations into OpenClaw plugin
   approvals before returning the Codex approval response.
 - `"ask"`: OpenClaw uses the same Codex write/destructive gating as
-  `"auto"`, clears durable Codex per-tool and per-account approval overrides
-  for the app before the thread starts, and offers only one-shot approval or
-  denial so durable approvals cannot suppress later write-action prompts. These
-  checks also run before reusing a thread or answering a `/btw` side question.
-  Successful cleanup refreshes loaded native threads as well as saved settings.
+  `"auto"`, overrides saved per-tool and per-account approvals in the native
+  thread's configuration, and offers only one-shot approval or denial. Saved
+  native settings stay unchanged, and user-config reloads preserve the thread's
+  approval policy. These checks also run before reusing a thread or answering a
+  `/btw` side question. Changed override keys rebuild the thread with current policy.
   For each admitted app using `"ask"`, OpenClaw selects Codex's human approvals
   reviewer for that app so Codex sends its approval elicitations to
   OpenClaw; other apps and non-app thread approvals keep their configured
@@ -452,7 +452,10 @@ Apps outside the admitted policy stay disabled even if native Codex settings
 enable them. Native settings must be verified before an enabled policy can admit
 app tools. When no app can be admitted, Codex's app tool surface is disabled
 without reading native app settings. Disabling plugin apps also skips app
-inventory discovery.
+inventory discovery. Active legacy managed app settings outrank native thread
+configuration and prevent app admission; move those app settings to a supported
+user or project configuration layer. Native administrative requirements remain
+authoritative.
 
 ## Troubleshooting
 

--- a/extensions/codex/src/app-server/config-layer-policy.ts
+++ b/extensions/codex/src/app-server/config-layer-policy.ts
@@ -1,0 +1,11 @@
+// Native session flags override these layers. Legacy managed layers sit above
+// them, so app admission and restricted turns cannot replace their tool policy.
+export const CODEX_SESSION_OVERRIDABLE_LAYER_TYPES = new Set([
+  "packagedDefaults",
+  "mdm",
+  "system",
+  "enterpriseManaged",
+  "user",
+  "project",
+  "sessionFlags",
+]);

--- a/extensions/codex/src/app-server/plugin-app-approval-overrides.ts
+++ b/extensions/codex/src/app-server/plugin-app-approval-overrides.ts
@@ -1,113 +1,45 @@
-import type { ResolvedCodexPluginPolicy } from "./config.js";
-import type { CodexPluginOwnedApp, CodexPluginRuntimeRequest } from "./plugin-inventory.js";
-import { isJsonObject, type CodexConfigEdit, type JsonObject } from "./protocol.js";
+import type { CodexPluginOwnedApp } from "./plugin-inventory.js";
+import { isJsonObject, type JsonObject } from "./protocol.js";
 
-export type CodexAppApprovalOverrideDiagnostic = {
-  code: "approval_overrides_clear_failed";
-  plugin?: ResolvedCodexPluginPolicy;
-  message: string;
-};
-
-export async function clearPersistedAppApprovalOverrides(params: {
-  request: CodexPluginRuntimeRequest;
-  configCwd?: string;
-  config: JsonObject;
-  plugin?: ResolvedCodexPluginPolicy;
-  app: CodexPluginOwnedApp;
-  diagnostics: Pick<CodexAppApprovalOverrideDiagnostic[], "push">;
-}): Promise<boolean> {
-  try {
-    const overrideKeyPaths = readPersistedAppApprovalOverrideKeyPaths(params.config, params.app);
-    if (overrideKeyPaths.length === 0) {
-      return true;
-    }
-    const edits = overrideKeyPaths.map(
-      (keyPath): CodexConfigEdit => ({
-        keyPath,
-        value: null,
-        mergeStrategy: "replace",
-      }),
-    );
-    // Durable readback alone does not refresh a warm thread's captured app overrides.
-    const response = await params.request("config/batchWrite", { edits, reloadUserConfig: true });
-    if (
-      !isJsonObject(response) ||
-      (response.status !== "ok" && response.status !== "okOverridden")
-    ) {
-      throw new Error("Codex did not confirm the approval override batch");
-    }
-    if (response.status === "okOverridden") {
-      throw new Error(
-        `approval override for ${overrideKeyPaths.join(", ")} is controlled by another config layer`,
-      );
-    }
-    const confirmed = await params.request("config/read", {
-      includeLayers: false,
-      ...(params.configCwd ? { cwd: params.configCwd } : {}),
-    });
-    if (!isJsonObject(confirmed) || !isJsonObject(confirmed.config)) {
-      throw new Error("Codex did not confirm effective app approval configuration");
-    }
-    const remainingOverrideKeyPaths = readPersistedAppApprovalOverrideKeyPaths(
-      confirmed.config,
-      params.app,
-    );
-    if (remainingOverrideKeyPaths.length > 0) {
-      throw new Error(
-        `effective approval overrides remain for ${remainingOverrideKeyPaths.join(", ")}`,
-      );
-    }
-    return true;
-  } catch (error) {
-    params.diagnostics.push({
-      code: "approval_overrides_clear_failed",
-      ...(params.plugin ? { plugin: params.plugin } : {}),
-      message: `Could not clear durable Codex app approval overrides for ${params.app.id}: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    });
-    return false;
-  }
-}
-
-function readPersistedAppApprovalOverrideKeyPaths(
-  config: JsonObject,
-  app: CodexPluginOwnedApp,
-): string[] {
+/** Projects ask approvals into the native session layer without changing saved settings. */
+export function buildCodexAppApprovalOverrides(
+  config: Record<string, unknown>,
+  app: Pick<CodexPluginOwnedApp, "id" | "approvalOverrideToolConfigKeys">,
+): JsonObject {
   const appsRoot = config.apps;
   const appConfig = isJsonObject(appsRoot) ? appsRoot[app.id] : undefined;
   if (!isJsonObject(appConfig)) {
-    return [];
+    return {};
   }
+  const overrides: JsonObject = {};
   const keys = app.approvalOverrideToolConfigKeys;
-  const appKeyPath = `apps.${quoteConfigKeyPathSegment(app.id)}`;
-  const overrideKeyPaths: string[] = [];
-  // Native account-link policy takes precedence over the app defaults used by ask.
+  // Link and tool policy outrank app defaults. Session overlays survive native
+  // user-config reloads; durable writes cannot acknowledge every loaded thread.
   for (const [section, fields] of [
-    ["tools", ["approval_mode"]],
-    ["links", ["approvals_reviewer", "default_tools_approval_mode"]],
+    ["tools", { approval_mode: "auto" }],
+    ["links", { approvals_reviewer: "user", default_tools_approval_mode: "auto" }],
   ] as const) {
     const entries = appConfig[section];
     if (!isJsonObject(entries)) {
       continue;
     }
-    for (const [name, value] of Object.entries(entries)) {
+    const projected: Array<[string, JsonObject]> = [];
+    for (const [name, value] of Object.entries(entries).toSorted(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
       if (!isJsonObject(value) || (section === "tools" && keys && !keys.includes(name))) {
         continue;
       }
-      for (const field of fields) {
-        // Codex returns null for cleared optionals; those must not deny app admission.
-        if (value[field] !== undefined && value[field] !== null) {
-          overrideKeyPaths.push(
-            `${appKeyPath}.${section}.${quoteConfigKeyPathSegment(name)}.${field}`,
-          );
-        }
+      if (
+        Object.keys(fields).some((field) => value[field] !== undefined && value[field] !== null)
+      ) {
+        // Merge only approval fields, preserving native disabled tools and other settings.
+        projected.push([name, fields]);
       }
     }
+    if (projected.length > 0) {
+      overrides[section] = Object.fromEntries(projected);
+    }
   }
-  return overrideKeyPaths.toSorted();
-}
-
-function quoteConfigKeyPathSegment(segment: string): string {
-  return `"${segment.replace(/["\\]/g, (char) => `\\${char}`)}"`;
+  return overrides;
 }

--- a/extensions/codex/src/app-server/plugin-app-approval-overrides.ts
+++ b/extensions/codex/src/app-server/plugin-app-approval-overrides.ts
@@ -28,7 +28,8 @@ export async function clearPersistedAppApprovalOverrides(params: {
         mergeStrategy: "replace",
       }),
     );
-    const response = await params.request("config/batchWrite", { edits });
+    // Durable readback alone does not refresh a warm thread's captured app overrides.
+    const response = await params.request("config/batchWrite", { edits, reloadUserConfig: true });
     if (
       !isJsonObject(response) ||
       (response.status !== "ok" && response.status !== "okOverridden")

--- a/extensions/codex/src/app-server/plugin-thread-app-admission.ts
+++ b/extensions/codex/src/app-server/plugin-thread-app-admission.ts
@@ -5,6 +5,7 @@ import {
   type CodexAppInventoryRequest,
   type CodexAppInventorySnapshot,
 } from "./app-inventory-cache.js";
+import { CODEX_SESSION_OVERRIDABLE_LAYER_TYPES } from "./config-layer-policy.js";
 import type { ResolvedCodexPluginsPolicy } from "./config.js";
 import {
   resolveOwnedAppApprovalOverrideKeys,
@@ -232,7 +233,7 @@ function resolveCodexInstalledAppThreadAdmission(
 
 export async function readCodexConfigForAppAdmission(
   params: CodexPluginThreadAppAdmissionParams,
-): Promise<CodexPluginThreadAppAdmissionConfig | undefined> {
+): Promise<CodexPluginThreadAppAdmissionConfig> {
   try {
     const response = await params.request("config/read", {
       includeLayers: true,
@@ -260,14 +261,27 @@ export async function readCodexConfigForAppAdmission(
         if (!isJsonObject(layer.config)) {
           throw new Error("Codex config/read returned an invalid layer config");
         }
+        if (!isJsonObject(layer.name) || typeof layer.name.type !== "string") {
+          throw new Error("Codex config/read returned an invalid config layer source");
+        }
+        if (
+          layer.config.apps !== undefined &&
+          !CODEX_SESSION_OVERRIDABLE_LAYER_TYPES.has(layer.name.type)
+        ) {
+          throw new Error(
+            `Codex app policy cannot override ${layer.name.type}; move app settings to a supported user or project config layer before exposing native apps`,
+          );
+        }
         return [layer.config];
       }),
     };
   } catch (error) {
-    embeddedAgentLog.warn("codex plugin app admission config read failed", {
-      error: serializeCodexAppInventoryError(error),
-    });
-    return undefined;
+    const details = serializeCodexAppInventoryError(error);
+    embeddedAgentLog.warn("codex plugin app admission config read failed", { error: details });
+    throw new Error(
+      `Could not verify the Codex app allowlist: ${String(details.message)}. No native thread was started; resolve the native configuration error and retry.`,
+      { cause: error },
+    );
   }
 }
 

--- a/extensions/codex/src/app-server/plugin-thread-config-deadline.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config-deadline.ts
@@ -182,14 +182,6 @@ export function createCodexPluginThreadConfigStartupProvider(params: {
     ...buildParams
   } = params;
   const metadataCache = configuredMetadataCache ?? defaultCodexPluginMetadataCache;
-  const failClosedOnTimeout = Boolean(
-    params.scheduledRuntimeAuthority ||
-    (policy?.enabled &&
-      ((policy.allowAllPlugins && policy.destructiveApprovalMode === "ask") ||
-        policy.pluginPolicies.some(
-          (plugin) => plugin.enabled && plugin.destructiveApprovalMode === "ask",
-        ))),
-  );
   return {
     enabled: true,
     // The bound context stores admitted apps only; native config owns excluded
@@ -212,7 +204,7 @@ export function createCodexPluginThreadConfigStartupProvider(params: {
         threadId: buildOptions?.threadId,
         appCache: appCache ?? defaultCodexAppInventoryCache,
         metadataCache,
-        failClosedOnTimeout,
+        failClosedOnTimeout: Boolean(params.scheduledRuntimeAuthority),
         transform: params.scheduledRuntimeAuthority
           ? async (builtConfig, request) =>
               intersectCodexPluginThreadConfigWithScheduledAuthority(

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -3090,7 +3090,8 @@ describe("Codex plugin thread config", () => {
       { apps: { calendar: { tools: { ["__proto__"]: { approval_mode: "auto" } } } } },
     );
     // Only own properties reach the native JSON request.
-    expect(JSON.parse(JSON.stringify(config))).toEqual({
+    const wireConfig = JSON.stringify(config);
+    expect(JSON.parse(wireConfig)).toEqual({
       apps: {
         calendar: {
           tools: { read: { enabled: true }, ["__proto__"]: { approval_mode: "auto" } },

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -720,6 +720,7 @@ describe("Codex plugin thread config", () => {
     expect(request).toHaveBeenCalledWith("config/read", { includeLayers: false });
     expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(2);
     expect(request).toHaveBeenCalledWith("config/batchWrite", {
+      reloadUserConfig: true,
       edits: [
         {
           keyPath: 'apps."google-calendar-app".links."work.\\"primary\\"".approvals_reviewer',
@@ -2037,6 +2038,7 @@ describe("Codex plugin thread config", () => {
         default_tools_approval_mode: "auto",
       });
       expect(request).toHaveBeenCalledWith("config/batchWrite", {
+        reloadUserConfig: true,
         edits: [
           {
             keyPath,

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -21,7 +21,14 @@ import {
   mergeCodexThreadConfigs,
   shouldBuildCodexPluginThreadConfig,
 } from "./plugin-thread-config.js";
-import type { CodexAppServerRequestParams, JsonObject, v2 } from "./protocol.js";
+import type {
+  CodexAppServerRequestParams,
+  CodexConfigReadResponse,
+  JsonObject,
+  v2,
+} from "./protocol.js";
+
+type NativeConfigLayerName = NonNullable<CodexConfigReadResponse["origins"][string]>["name"];
 
 describe("Codex plugin thread config", () => {
   beforeEach(() => {
@@ -603,150 +610,157 @@ describe("Codex plugin thread config", () => {
     });
   });
 
-  it("routes destructive approvals to the user while clearing tool and account overrides for ask mode", async () => {
-    const appCache = new CodexAppInventoryCache();
-    await appCache.refreshNow({
-      key: "runtime",
-      nowMs: 0,
-      request: async (method, params) =>
-        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
-    });
-    let configReadCount = 0;
-    const request = vi.fn(async (method: string, params?: unknown) => {
-      if (method === "plugin/installed" || method === "plugin/list") {
-        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
-      }
-      if (method === "plugin/read") {
-        return pluginDetail(
-          "google-calendar",
-          [appSummary("google-calendar-app")],
-          ["google-calendar"],
-        );
-      }
-      if (method === "config/read") {
-        configReadCount += 1;
-        if ((params as { includeLayers?: boolean } | undefined)?.includeLayers !== true) {
-          return {
-            config: {
-              apps: {
-                "google-calendar-app": {
-                  links: {
-                    'work."primary"': {
-                      approvals_reviewer: null,
-                      default_tools_approval_mode: null,
-                    },
-                  },
-                  tools: {
-                    "calendar/read": {
-                      enabled: false,
-                    },
-                  },
-                },
+  it.each(["Calendar update", "__proto__"])(
+    "projects ask approvals without changing saved settings (%s)",
+    async (title) => {
+      const nativeConfig = {
+        apps: {
+          "google-calendar-app": {
+            links: {
+              [title]: {
+                approvals_reviewer: "auto_review",
+                default_tools_approval_mode: "approve",
               },
             },
-          };
+            tools: {
+              "calendar/create": { approval_mode: "approve", enabled: false },
+              "calendar/read": { approval_mode: "approve", enabled: false },
+              [title]: { approval_mode: "approve", enabled: true },
+            },
+          },
+        },
+      } satisfies JsonObject;
+      const savedConfig = structuredClone(nativeConfig);
+      const appCache = new CodexAppInventoryCache();
+      const calendarApp: v2.AppInfo = {
+        ...appInfo("google-calendar-app", true),
+        toolSummaries: [
+          {
+            name: "calendar/create",
+            title: null,
+            description: "Synthetic calendar action.",
+            isEnabled: false,
+            disabledReason: "App policy",
+            isReadOnly: false,
+          },
+          {
+            name: "calendar/read",
+            title: null,
+            description: "Synthetic calendar action.",
+            isEnabled: false,
+            disabledReason: "App policy",
+            isReadOnly: true,
+          },
+          {
+            name: "calendar/update",
+            title,
+            description: "Synthetic calendar action.",
+            isEnabled: true,
+            disabledReason: null,
+            isReadOnly: false,
+          },
+        ],
+      };
+      await appCache.refreshNow({
+        key: "runtime",
+        nowMs: 0,
+        request: async (method, params) => codexAppInventoryResponse(method, [calendarApp], params),
+      });
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        if (method === "plugin/installed" || method === "plugin/list") {
+          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
         }
-        return {
-          config: {
-            apps: {
-              "google-calendar-app": {
-                links: {
-                  'work."primary"': {
-                    approvals_reviewer: "auto_review",
-                    default_tools_approval_mode: "approve",
-                  },
-                },
-                tools: {
-                  "calendar/create": {
-                    approval_mode: "approve",
-                    enabled: false,
-                  },
-                  "calendar/read": {
-                    enabled: false,
-                  },
-                  "calendar/update": {
-                    approval_mode: "approve",
-                  },
+        if (method === "plugin/read") {
+          return pluginDetail(
+            "google-calendar",
+            [appSummary("google-calendar-app")],
+            ["google-calendar"],
+          );
+        }
+        if (method === "config/read") {
+          expect(params).toEqual({ includeLayers: true, cwd: "/repo/project" });
+          return { config: nativeConfig, layers: [] };
+        }
+        throw new Error(`unexpected request ${method}`);
+      });
+
+      const build = () =>
+        buildCodexPluginThreadConfig({
+          pluginConfig: {
+            codexPlugins: {
+              enabled: true,
+              allow_destructive_actions: "ask",
+              plugins: {
+                "google-calendar": {
+                  marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+                  pluginName: "google-calendar",
                 },
               },
             },
           },
-          layers: [],
-        };
-      }
-      if (method === "config/batchWrite") {
-        return {
-          status: "ok",
-          version: "version-1",
-          filePath: "/home/test/.codex/config.toml",
-          overriddenMetadata: null,
-        };
-      }
-      throw new Error(`unexpected request ${method}`);
-    });
-
-    const config = await buildCodexPluginThreadConfig({
-      pluginConfig: {
-        codexPlugins: {
+          appCache,
+          appCacheKey: "runtime",
+          configCwd: "/repo/project",
+          nowMs: 1,
+          request,
+        });
+      const config = await build();
+      expect(config.configPatch?.apps).toMatchObject({
+        "google-calendar-app": {
           enabled: true,
-          allow_destructive_actions: "ask",
-          plugins: {
-            "google-calendar": {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
+          approvals_reviewer: "user",
+          destructive_enabled: true,
+          open_world_enabled: true,
+          default_tools_approval_mode: "auto",
+          links: {
+            [title]: { approvals_reviewer: "user", default_tools_approval_mode: "auto" },
+          },
+          tools: {
+            "calendar/create": { approval_mode: "auto" },
+            [title]: { approval_mode: "auto" },
           },
         },
-      },
-      appCache,
-      appCacheKey: "runtime",
-      nowMs: 1,
-      request,
-    });
-
-    const apps = config.configPatch?.apps as Record<string, unknown> | undefined;
-    expect(apps?.["google-calendar-app"]).toEqual({
-      enabled: true,
-      approvals_reviewer: "user",
-      destructive_enabled: true,
-      open_world_enabled: true,
-      default_tools_approval_mode: "auto",
-    });
-    expect(config.configPatch).not.toHaveProperty("approvals_reviewer");
-    expect(config.policyContext.apps["google-calendar-app"]).toMatchObject({
-      allowDestructiveActions: true,
-      destructiveApprovalMode: "ask",
-    });
-    expect(request).toHaveBeenCalledWith("config/read", { includeLayers: false });
-    expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(2);
-    expect(request).toHaveBeenCalledWith("config/batchWrite", {
-      reloadUserConfig: true,
-      edits: [
-        {
-          keyPath: 'apps."google-calendar-app".links."work.\\"primary\\"".approvals_reviewer',
-          value: null,
-          mergeStrategy: "replace",
+      });
+      expect(mergeCodexThreadConfigs(nativeConfig, config.configPatch)?.apps).toMatchObject({
+        "google-calendar-app": {
+          tools: {
+            "calendar/create": { approval_mode: "auto", enabled: false },
+            "calendar/read": { approval_mode: "approve", enabled: false },
+            [title]: { approval_mode: "auto" },
+          },
         },
-        {
-          keyPath:
-            'apps."google-calendar-app".links."work.\\"primary\\"".default_tools_approval_mode',
-          value: null,
-          mergeStrategy: "replace",
+      });
+      expect(config.configPatch).not.toHaveProperty("approvals_reviewer");
+      expect(config.policyContext.apps["google-calendar-app"]).toMatchObject({
+        allowDestructiveActions: true,
+        destructiveApprovalMode: "ask",
+      });
+      expect(config.diagnostics).toEqual([]);
+      expect(nativeConfig).toEqual(savedConfig);
+      expect((await build()).fingerprint).toBe(config.fingerprint);
+      Object.assign(nativeConfig.apps["google-calendar-app"].links, {
+        second: { approvals_reviewer: "auto_review" },
+      });
+      const addedLink = await build();
+      expect(addedLink.fingerprint).not.toBe(config.fingerprint);
+      expect(addedLink.configPatch?.apps).toMatchObject({
+        "google-calendar-app": {
+          links: { second: { approvals_reviewer: "user", default_tools_approval_mode: "auto" } },
         },
-        {
-          keyPath: 'apps."google-calendar-app".tools."calendar/create".approval_mode',
-          value: null,
-          mergeStrategy: "replace",
-        },
-        {
-          keyPath: 'apps."google-calendar-app".tools."calendar/update".approval_mode',
-          value: null,
-          mergeStrategy: "replace",
-        },
-      ],
-    });
-    expect(request.mock.calls.map(([method]) => method)).not.toContain("config/value/write");
-  });
+      });
+      Object.assign(nativeConfig.apps["google-calendar-app"].tools, {
+        "calendar/update": { approval_mode: "approve" },
+      });
+      const addedTool = await build();
+      expect(addedTool.fingerprint).not.toBe(addedLink.fingerprint);
+      expect(addedTool.configPatch?.apps).toMatchObject({
+        "google-calendar-app": { tools: { "calendar/update": { approval_mode: "auto" } } },
+      });
+      expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(4);
+      expect(request.mock.calls.map(([method]) => method)).not.toContain("config/batchWrite");
+      expect(request.mock.calls.map(([method]) => method)).not.toContain("config/value/write");
+    },
+  );
 
   it.each([
     ["auto", "auto", undefined],
@@ -958,311 +972,64 @@ describe("Codex plugin thread config", () => {
     },
   );
 
-  it.each([
-    {
-      scope: "tool",
-      appConfig: { tools: { "calendar/create": { approval_mode: "approve" } } },
-      keyPath: 'apps."google-calendar-app".tools."calendar/create".approval_mode',
-    },
-    {
-      scope: "account reviewer",
-      appConfig: { links: { account: { approvals_reviewer: "auto_review" } } },
-      keyPath: 'apps."google-calendar-app".links."account".approvals_reviewer',
-    },
-    {
-      scope: "account approval mode",
-      appConfig: { links: { account: { default_tools_approval_mode: "approve" } } },
-      keyPath: 'apps."google-calendar-app".links."account".default_tools_approval_mode',
-    },
-  ])(
-    "disables ask policy apps when cwd effective $scope overrides remain after cleanup",
-    async ({ appConfig, keyPath }) => {
-      const appCache = new CodexAppInventoryCache();
-      const calendarApp: v2.AppInfo = {
-        ...appInfo("google-calendar-app", true),
-        toolSummaries: [
-          {
-            name: "calendar/create",
-            title: null,
-            description: "Create a calendar event.",
-            isEnabled: true,
-            disabledReason: null,
-            isReadOnly: false,
-          },
-        ],
-      };
-      await appCache.refreshNow({
-        key: "runtime",
-        nowMs: 0,
-        request: async (method, params) => codexAppInventoryResponse(method, [calendarApp], params),
-      });
-      let configReadCount = 0;
-      const request = vi.fn(async (method: string, params?: unknown) => {
-        if (method === "plugin/installed" || method === "plugin/list") {
-          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
-        }
-        if (method === "plugin/read") {
-          return pluginDetail(
-            "google-calendar",
-            [appSummary("google-calendar-app")],
-            ["google-calendar"],
-          );
+  it.each(
+    [
+      { type: "legacyManagedConfigTomlFromFile", file: "/etc/codex/managed_config.toml" },
+      { type: "legacyManagedConfigTomlFromMdm" },
+      { type: "futureConfigSource" },
+    ].flatMap((name) => [
+      { name, hasApps: true, disabled: false },
+      { name, hasApps: true, disabled: true },
+      { name, hasApps: false, disabled: false },
+    ]),
+  )(
+    "contains $name.type app policy, apps=$hasApps disabled=$disabled",
+    async ({ name, hasApps, disabled }) => {
+      const request = vi.fn(async (method: string) => {
+        if (method === "app/installed" || method === "app/read") {
+          return codexAppInventoryResponse(method, [appInfo("calendar-app", true)]);
         }
         if (method === "config/read") {
-          const includeLayers =
-            (params as { includeLayers?: boolean } | undefined)?.includeLayers === true;
-          configReadCount += 1;
           return {
-            config: {
-              apps: {
-                "google-calendar-app": appConfig,
+            config: {},
+            layers: [
+              {
+                name,
+                config: hasApps
+                  ? { apps: { "calendar-app": { approvals_reviewer: "auto_review" } } }
+                  : { model: "gpt-5.6-luna" },
+                disabledReason: disabled ? "inactive policy" : null,
               },
-            },
-            ...(includeLayers ? { layers: [] } : {}),
-          };
-        }
-        if (method === "config/batchWrite") {
-          return {
-            status: "ok",
-            version: "version-1",
-            filePath: "/home/test/.codex/config.toml",
-            overriddenMetadata: null,
+            ],
           };
         }
         throw new Error(`unexpected request ${method}`);
       });
-
-      const config = await buildCodexPluginThreadConfig({
+      const build = buildCodexPluginThreadConfig({
         pluginConfig: {
           codexPlugins: {
             enabled: true,
+            allow_all_plugins: true,
             allow_destructive_actions: "ask",
-            plugins: {
-              "google-calendar": {
-                marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-                pluginName: "google-calendar",
-              },
-            },
           },
         },
-        appCache,
         appCacheKey: "runtime",
-        configCwd: "/repo/project",
-        nowMs: 1,
         request,
       });
 
-      expect(config.configPatch).toEqual({
-        "features.apps": false,
-        apps: {
-          _default: {
-            enabled: false,
-            destructive_enabled: false,
-            open_world_enabled: false,
-          },
-        },
-      });
-      expect(config.policyContext.apps).toStrictEqual({});
-      expect(request).toHaveBeenCalledWith("config/read", {
-        includeLayers: false,
-        cwd: "/repo/project",
-      });
-      expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(2);
-      expect(config.diagnostics).toStrictEqual([
-        {
-          code: "approval_overrides_clear_failed",
-          plugin: {
-            configKey: "google-calendar",
-            marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-            pluginName: "google-calendar",
-            enabled: true,
-            allowDestructiveActions: true,
-            destructiveApprovalMode: "ask",
-          },
-          message: `Could not clear durable Codex app approval overrides for google-calendar-app: effective approval overrides remain for ${keyPath}`,
-        },
-      ]);
+      if (hasApps && !disabled) {
+        await expect(build).rejects.toThrow("Could not verify the Codex app allowlist");
+      } else {
+        const config = await build;
+        expect(config.policyContext.apps["calendar-app"]).toMatchObject({
+          destructiveApprovalMode: "ask",
+        });
+        expect(config.diagnostics).toEqual([]);
+      }
+      expect(request.mock.calls.map(([method]) => method)).not.toContain("config/batchWrite");
+      expect(request.mock.calls.map(([method]) => method)).not.toContain("config/value/write");
     },
   );
-
-  it("disables ask policy apps when account approval override writes are overridden", async () => {
-    const appCache = new CodexAppInventoryCache();
-    await appCache.refreshNow({
-      key: "runtime",
-      nowMs: 0,
-      request: async (method, params) =>
-        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
-    });
-    const request = vi.fn(async (method: string, params?: unknown) => {
-      if (method === "plugin/installed" || method === "plugin/list") {
-        return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
-      }
-      if (method === "plugin/read") {
-        return pluginDetail(
-          "google-calendar",
-          [appSummary("google-calendar-app")],
-          ["google-calendar"],
-        );
-      }
-      if (method === "config/read") {
-        if ((params as { includeLayers?: boolean } | undefined)?.includeLayers === true) {
-          return {
-            config: {
-              apps: {
-                "google-calendar-app": {
-                  links: { account: { approvals_reviewer: "auto_review" } },
-                },
-              },
-            },
-            layers: [],
-          };
-        }
-        throw new Error("unexpected confirmation after an overridden batch");
-      }
-      if (method === "config/batchWrite") {
-        return {
-          status: "okOverridden",
-          version: "version-1",
-          filePath: "/home/test/.codex/config.toml",
-          overriddenMetadata: null,
-        };
-      }
-      throw new Error(`unexpected request ${method}`);
-    });
-
-    const config = await buildCodexPluginThreadConfig({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          allow_destructive_actions: "ask",
-          plugins: {
-            "google-calendar": {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
-          },
-        },
-      },
-      appCache,
-      appCacheKey: "runtime",
-      configCwd: "/repo/project",
-      nowMs: 1,
-      request,
-    });
-
-    expect(config.configPatch).toEqual({
-      "features.apps": false,
-      apps: {
-        _default: {
-          enabled: false,
-          destructive_enabled: false,
-          open_world_enabled: false,
-        },
-      },
-    });
-    expect(config.policyContext.apps).toStrictEqual({});
-    expect(config.provisionalAppIds).toBeUndefined();
-    expect(config.diagnostics).toStrictEqual([
-      {
-        code: "approval_overrides_clear_failed",
-        plugin: {
-          configKey: "google-calendar",
-          marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-          pluginName: "google-calendar",
-          enabled: true,
-          allowDestructiveActions: true,
-          destructiveApprovalMode: "ask",
-        },
-        message:
-          'Could not clear durable Codex app approval overrides for google-calendar-app: approval override for apps."google-calendar-app".links."account".approvals_reviewer is controlled by another config layer',
-      },
-    ]);
-  });
-
-  it("disables ask policy apps when durable approval override cleanup fails", async () => {
-    const appCache = new CodexAppInventoryCache();
-    await appCache.refreshNow({
-      key: "runtime",
-      nowMs: 0,
-      request: async (method, params) =>
-        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
-    });
-
-    const config = await buildCodexPluginThreadConfig({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          allow_destructive_actions: "ask",
-          plugins: {
-            "google-calendar": {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
-          },
-        },
-      },
-      appCache,
-      appCacheKey: "runtime",
-      nowMs: 1,
-      request: async (method, params) => {
-        if (method === "plugin/installed" || method === "plugin/list") {
-          return pluginList([pluginSummary("google-calendar", { installed: true, enabled: true })]);
-        }
-        if (method === "plugin/read") {
-          return pluginDetail(
-            "google-calendar",
-            [appSummary("google-calendar-app")],
-            ["google-calendar"],
-          );
-        }
-        if (method === "config/read") {
-          if ((params as { includeLayers?: boolean } | undefined)?.includeLayers === true) {
-            return {
-              config: {
-                apps: {
-                  "google-calendar-app": {
-                    tools: { "calendar/create": { approval_mode: "approve" } },
-                  },
-                },
-              },
-              layers: [],
-            };
-          }
-        }
-        if (method === "config/batchWrite") {
-          throw new Error("readonly config");
-        }
-        throw new Error(`unexpected request ${method}`);
-      },
-    });
-
-    expect(config.configPatch).toEqual({
-      "features.apps": false,
-      apps: {
-        _default: {
-          enabled: false,
-          destructive_enabled: false,
-          open_world_enabled: false,
-        },
-      },
-    });
-    expect(config.policyContext.apps).toStrictEqual({});
-    expect(config.diagnostics).toStrictEqual([
-      {
-        code: "approval_overrides_clear_failed",
-        plugin: {
-          configKey: "google-calendar",
-          marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-          pluginName: "google-calendar",
-          enabled: true,
-          allowDestructiveActions: true,
-          destructiveApprovalMode: "ask",
-        },
-        message:
-          "Could not clear durable Codex app approval overrides for google-calendar-app: readonly config",
-      },
-    ]);
-  });
 
   it("builds a restrictive app config when native plugin support is disabled", async () => {
     expect(
@@ -1431,7 +1198,7 @@ describe("Codex plugin thread config", () => {
       name: "excludes an account app explicitly disabled by project config",
       layers: [
         {
-          name: "project",
+          name: { type: "project", dotCodexFolder: "/repo/project/.codex" },
           config: { apps: { "chatgpt-meetings": { enabled: false } } },
           disabledReason: null,
         },
@@ -1443,12 +1210,12 @@ describe("Codex plugin thread config", () => {
       name: "uses the highest-precedence account app configuration",
       layers: [
         {
-          name: "project",
+          name: { type: "project", dotCodexFolder: "/repo/project/.codex" },
           config: { apps: { "chatgpt-meetings": { enabled: true } } },
           disabledReason: null,
         },
         {
-          name: "user",
+          name: { type: "user", file: "/home/test/.codex/config.toml", profile: null },
           config: { apps: { "chatgpt-meetings": { enabled: false } } },
           disabledReason: null,
         },
@@ -1460,7 +1227,7 @@ describe("Codex plugin thread config", () => {
       name: "ignores an inactive account app config layer",
       layers: [
         {
-          name: "untrusted-project",
+          name: { type: "project", dotCodexFolder: "/repo/untrusted/.codex" },
           config: { apps: { "chatgpt-meetings": { enabled: false } } },
           disabledReason: "untrusted project",
         },
@@ -1483,7 +1250,11 @@ describe("Codex plugin thread config", () => {
     },
   ] satisfies Array<{
     name: string;
-    layers?: Array<{ name: string; config: JsonObject; disabledReason: string | null }>;
+    layers?: Array<{
+      name: NativeConfigLayerName;
+      config: JsonObject;
+      disabledReason: string | null;
+    }>;
     configUnavailable?: boolean;
     ask?: boolean;
     meetingsExposed: boolean;
@@ -1497,7 +1268,11 @@ describe("Codex plugin thread config", () => {
       meetingsExposed,
       slackExposed,
     }: {
-      layers?: Array<{ name: string; config: JsonObject; disabledReason: string | null }>;
+      layers?: Array<{
+        name: NativeConfigLayerName;
+        config: JsonObject;
+        disabledReason: string | null;
+      }>;
       configUnavailable?: boolean;
       ask?: boolean;
       meetingsExposed: boolean;
@@ -1937,7 +1712,7 @@ describe("Codex plugin thread config", () => {
     },
   );
 
-  it("reads shared account app configuration once when ask mode needs no writes", async () => {
+  it("reads shared account app configuration once for ask admission", async () => {
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "app/installed" || method === "app/read") {
         return codexAppInventoryResponse(method, [
@@ -1979,16 +1754,19 @@ describe("Codex plugin thread config", () => {
     {
       scope: "tool",
       appConfig: { tools: { import_meeting: { approval_mode: "approve" } } },
-      keyPath: 'apps."chatgpt-meetings".tools."import_meeting".approval_mode',
+      expectedOverrides: { tools: { import_meeting: { approval_mode: "auto" } } },
     },
     {
       scope: "account",
       appConfig: { links: { account: { default_tools_approval_mode: "approve" } } },
-      keyPath: 'apps."chatgpt-meetings".links."account".default_tools_approval_mode',
+      expectedOverrides: {
+        links: { account: { approvals_reviewer: "user", default_tools_approval_mode: "auto" } },
+      },
     },
   ])(
-    "clears durable $scope approval overrides for account apps in ask mode",
-    async ({ appConfig, keyPath }) => {
+    "projects $scope approval overrides for account apps without writing native config",
+    async ({ appConfig, expectedOverrides }) => {
+      const savedAppConfig = structuredClone(appConfig);
       const request = vi.fn(async (method: string, params?: unknown) => {
         if (method === "app/installed" || method === "app/read") {
           return codexAppInventoryResponse(method, [
@@ -1996,24 +1774,8 @@ describe("Codex plugin thread config", () => {
           ]);
         }
         if (method === "config/read") {
-          const includeLayers =
-            (params as { includeLayers?: boolean } | undefined)?.includeLayers === true;
-          return {
-            config: {
-              apps: {
-                "chatgpt-meetings": includeLayers ? appConfig : {},
-              },
-            },
-            ...(includeLayers ? { layers: [] } : {}),
-          };
-        }
-        if (method === "config/batchWrite") {
-          return {
-            status: "ok",
-            version: "version-1",
-            filePath: "/home/test/.codex/config.toml",
-            overriddenMetadata: null,
-          };
+          expect(params).toEqual({ includeLayers: true });
+          return { config: { apps: { "chatgpt-meetings": appConfig } }, layers: [] };
         }
         throw new Error(`unexpected request ${method}`);
       });
@@ -2036,92 +1798,15 @@ describe("Codex plugin thread config", () => {
         destructive_enabled: true,
         open_world_enabled: true,
         default_tools_approval_mode: "auto",
+        ...expectedOverrides,
       });
-      expect(request).toHaveBeenCalledWith("config/batchWrite", {
-        reloadUserConfig: true,
-        edits: [
-          {
-            keyPath,
-            value: null,
-            mergeStrategy: "replace",
-          },
-        ],
-      });
-      expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(2);
+      expect(config.diagnostics).toEqual([]);
+      expect(appConfig).toEqual(savedAppConfig);
+      expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(1);
+      expect(request.mock.calls.map(([method]) => method)).not.toContain("config/batchWrite");
       expect(request.mock.calls.map(([method]) => method)).not.toContain("config/value/write");
     },
   );
-
-  it("does not re-admit an excluded plugin-owned app through account-wide policy", async () => {
-    const config = await buildCodexPluginThreadConfig({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          allow_all_plugins: true,
-          allow_destructive_actions: "auto",
-          plugins: {
-            meetings: {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "meetings",
-              allow_destructive_actions: "ask",
-            },
-          },
-        },
-      },
-      appCacheKey: "runtime",
-      request: async (method, params) => {
-        if (method === "plugin/installed" || method === "plugin/list") {
-          return pluginList([pluginSummary("meetings", { installed: true, enabled: true })]);
-        }
-        if (method === "plugin/read") {
-          return pluginDetail("meetings", [appSummary("chatgpt-meetings")]);
-        }
-        if (method === "app/installed" || method === "app/read") {
-          return codexAppInventoryResponse(method, [
-            { ...appInfo("chatgpt-meetings", true), name: "ChatGPT Meetings" },
-          ]);
-        }
-        if (method === "config/read") {
-          if ((params as { includeLayers?: boolean } | undefined)?.includeLayers === true) {
-            return {
-              config: {
-                apps: {
-                  "chatgpt-meetings": {
-                    tools: { import_meeting: { approval_mode: "approve" } },
-                  },
-                },
-              },
-              layers: [],
-            };
-          }
-        }
-        if (method === "config/batchWrite") {
-          throw new Error("approval policy unavailable");
-        }
-        throw new Error(`unexpected request ${method}`);
-      },
-    });
-
-    expect(config.configPatch).toEqual({
-      "features.apps": false,
-      apps: {
-        _default: {
-          enabled: false,
-          destructive_enabled: false,
-          open_world_enabled: false,
-        },
-      },
-    });
-    expect(config.policyContext.apps).toStrictEqual({});
-    expect(config.provisionalAppIds).toBeUndefined();
-    expect(config.diagnostics).toContainEqual(
-      expect.objectContaining({
-        code: "approval_overrides_clear_failed",
-        message:
-          "Could not clear durable Codex app approval overrides for chatgpt-meetings: approval policy unavailable",
-      }),
-    );
-  });
 
   it("does not let per-plugin enablement override disabled native plugin support", async () => {
     expect(
@@ -2279,7 +1964,7 @@ describe("Codex plugin thread config", () => {
             config: {},
             layers: [
               {
-                name: "user",
+                name: { type: "user", file: "/home/test/.codex/config.toml", profile: null },
                 config: { apps: { _default: { enabled: false } } },
                 disabledReason: null,
               },
@@ -2316,7 +2001,11 @@ describe("Codex plugin thread config", () => {
 
   const appPolicyCases: Array<{
     name: string;
-    layers?: Array<{ name: string; config: JsonObject; disabledReason: string | null }>;
+    layers?: Array<{
+      name: NativeConfigLayerName;
+      config: JsonObject;
+      disabledReason: string | null;
+    }>;
     configUnavailable?: boolean;
     ask?: boolean;
     exposed: boolean;
@@ -2325,7 +2014,7 @@ describe("Codex plugin thread config", () => {
       name: "blocks an explicit app-specific Codex disable",
       layers: [
         {
-          name: "project",
+          name: { type: "project", dotCodexFolder: "/repo/project/.codex" },
           config: { apps: { "google-calendar-app": { enabled: false } } },
           disabledReason: null,
         },
@@ -2336,12 +2025,12 @@ describe("Codex plugin thread config", () => {
       name: "honors the highest-precedence explicit app enablement",
       layers: [
         {
-          name: "project",
+          name: { type: "project", dotCodexFolder: "/repo/project/.codex" },
           config: { apps: { "google-calendar-app": { enabled: true } } },
           disabledReason: null,
         },
         {
-          name: "user",
+          name: { type: "user", file: "/home/test/.codex/config.toml", profile: null },
           config: { apps: { "google-calendar-app": { enabled: false } } },
           disabledReason: null,
         },
@@ -2352,12 +2041,12 @@ describe("Codex plugin thread config", () => {
       name: "ignores disabled config layers when deciding plugin admission",
       layers: [
         {
-          name: "untrusted-project",
+          name: { type: "project", dotCodexFolder: "/repo/untrusted/.codex" },
           config: { apps: { "google-calendar-app": { enabled: false } } },
           disabledReason: "untrusted project",
         },
         {
-          name: "user",
+          name: { type: "user", file: "/home/test/.codex/config.toml", profile: null },
           config: { apps: { _default: { enabled: false } } },
           disabledReason: null,
         },
@@ -2395,7 +2084,11 @@ describe("Codex plugin thread config", () => {
       appEnabled,
       ask,
     }: {
-      layers?: Array<{ name: string; config: JsonObject; disabledReason: string | null }>;
+      layers?: Array<{
+        name: NativeConfigLayerName;
+        config: JsonObject;
+        disabledReason: string | null;
+      }>;
       configUnavailable?: boolean;
       exposed: boolean;
       appEnabled: boolean;
@@ -3388,6 +3081,21 @@ describe("Codex plugin thread config", () => {
       "features.hooks": true,
       hooks: { PreToolUse: [] },
       apps: { _default: { enabled: false } },
+    });
+  });
+
+  it("preserves literal keys when merging native approval configuration", () => {
+    const config = mergeCodexThreadConfigs(
+      { apps: { calendar: { tools: { read: { enabled: true } } } } },
+      { apps: { calendar: { tools: { ["__proto__"]: { approval_mode: "auto" } } } } },
+    );
+    // Only own properties reach the native JSON request.
+    expect(JSON.parse(JSON.stringify(config))).toEqual({
+      apps: {
+        calendar: {
+          tools: { read: { enabled: true }, ["__proto__"]: { approval_mode: "auto" } },
+        },
+      },
     });
   });
 

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -14,10 +14,7 @@ import {
   ensureCodexPluginActivation,
   type CodexPluginActivationResult,
 } from "./plugin-activation.js";
-import {
-  clearPersistedAppApprovalOverrides,
-  type CodexAppApprovalOverrideDiagnostic,
-} from "./plugin-app-approval-overrides.js";
+import { buildCodexAppApprovalOverrides } from "./plugin-app-approval-overrides.js";
 import {
   readCodexPluginInventory,
   type CodexPluginInventory,
@@ -78,7 +75,6 @@ export type PluginAppPolicyContext = {
 type CodexPluginThreadConfigDiagnostic =
   | CodexPluginInventoryDiagnostic
   | CodexPluginThreadAppAdmissionDiagnostic
-  | CodexAppApprovalOverrideDiagnostic
   | {
       code:
         | "account_app_ownership_unavailable"
@@ -116,7 +112,7 @@ type BuildCodexPluginThreadConfigParams = {
 
 // Admission changes must rebuild existing bindings too, or older bindings can
 // bypass updated app approval checks after the gateway has been upgraded.
-const CODEX_PLUGIN_THREAD_CONFIG_INPUT_FINGERPRINT_VERSION = 5;
+const CODEX_PLUGIN_THREAD_CONFIG_INPUT_FINGERPRINT_VERSION = 6;
 const CODEX_PLUGIN_THREAD_CONFIG_FINGERPRINT_VERSION = 2;
 
 /** Returns true when plugin config exists and thread config may need app patches. */
@@ -307,8 +303,7 @@ export async function buildCodexPluginThreadConfig(
       : { apps: [] };
   // A deny-all thread needs no native settings; read them only before admitting an app.
   let appAdmissionConfig: Promise<CodexPluginThreadAppAdmissionConfig> | undefined;
-  const getAdmissionConfig = () =>
-    (appAdmissionConfig ??= requireCodexConfigForAppAdmission(params));
+  const getAdmissionConfig = () => (appAdmissionConfig ??= readCodexConfigForAppAdmission(params));
 
   const diagnostics: CodexPluginThreadConfigDiagnostic[] = [
     ...inventory.diagnostics,
@@ -384,21 +379,13 @@ export async function buildCodexPluginThreadConfig(
         });
         continue;
       }
-      if (
-        record.policy.destructiveApprovalMode === "ask" &&
-        !(await clearPersistedAppApprovalOverrides({
-          request: params.request,
-          configCwd: params.configCwd,
-          config: admissionConfig.config,
-          plugin: record.policy,
-          app,
-          diagnostics,
-        }))
-      ) {
-        continue;
-      }
       provisionalAppIds.add(app.id);
-      apps[app.id] = buildEnabledAppConfig(record.policy);
+      apps[app.id] = buildEnabledAppConfig(
+        record.policy,
+        record.policy.destructiveApprovalMode === "ask"
+          ? buildCodexAppApprovalOverrides(admissionConfig.config, app)
+          : undefined,
+      );
       policyApps[app.id] = {
         configKey: record.policy.configKey,
         marketplaceName: record.policy.marketplaceName,
@@ -423,22 +410,14 @@ export async function buildCodexPluginThreadConfig(
       continue;
     }
     const accountApp = toCodexPluginOwnedAccountApp(app);
-    if (
-      policy.destructiveApprovalMode === "ask" &&
-      !(await clearPersistedAppApprovalOverrides({
-        request: params.request,
-        configCwd: params.configCwd,
-        config: admissionConfig.config,
-        app: accountApp,
-        diagnostics,
-      }))
-    ) {
-      continue;
-    }
-    // Global callability does not prove this thread's workspace/managed
-    // policy. Attest only apps that also passed destructive-approval checks.
+    // Global callability does not prove this thread's workspace/managed policy.
     provisionalAppIds.add(app.id);
-    apps[app.id] = buildEnabledAppConfig(policy);
+    apps[app.id] = buildEnabledAppConfig(
+      policy,
+      policy.destructiveApprovalMode === "ask"
+        ? buildCodexAppApprovalOverrides(admissionConfig.config, accountApp)
+        : undefined,
+    );
     policyApps[app.id] = {
       source: "account",
       appName: app.name,
@@ -544,18 +523,6 @@ export function buildDisabledAppsConfigPatch(): JsonObject & { apps: JsonObject 
   };
 }
 
-async function requireCodexConfigForAppAdmission(
-  params: Parameters<typeof readCodexConfigForAppAdmission>[0],
-): Promise<CodexPluginThreadAppAdmissionConfig> {
-  const config = await readCodexConfigForAppAdmission(params);
-  if (!config) {
-    throw new Error(
-      "Could not verify the Codex app allowlist. No native thread was started; retry when native app configuration is available.",
-    );
-  }
-  return config;
-}
-
 export function disableUnlistedCodexApps(
   configPatch: { apps: JsonObject },
   nativeConfig: Record<string, unknown>,
@@ -571,12 +538,16 @@ export function disableUnlistedCodexApps(
   return { ...configPatch, apps };
 }
 
-function buildEnabledAppConfig(policy: {
-  allowDestructiveActions: boolean;
-  allowOpenWorld?: boolean;
-  destructiveApprovalMode?: CodexPluginDestructiveApprovalMode;
-}): JsonObject {
+function buildEnabledAppConfig(
+  policy: {
+    allowDestructiveActions: boolean;
+    allowOpenWorld?: boolean;
+    destructiveApprovalMode?: CodexPluginDestructiveApprovalMode;
+  },
+  approvalOverrides: JsonObject = {},
+): JsonObject {
   return {
+    ...approvalOverrides,
     enabled: true,
     destructive_enabled: policy.allowDestructiveActions,
     open_world_enabled: policy.allowOpenWorld !== false,
@@ -599,7 +570,7 @@ export function buildCodexPluginAppsConfigPatchFromPolicyContext(
   return Object.keys(policyContext.apps).length > 0 ? { apps } : disabledConfigPatch;
 }
 
-/** Rechecks durable ask overrides before a side thread replays its bound app policy. */
+/** Projects current ask overrides before a side thread replays its bound app policy. */
 export async function refreshCodexPluginAppApprovalPolicy(params: {
   policyContext: PluginAppPolicyContext;
   request: CodexPluginRuntimeRequest;
@@ -614,10 +585,10 @@ export async function refreshCodexPluginAppApprovalPolicy(params: {
       diagnostics: [],
     };
   }
-  const targetAppIds = Object.entries(params.policyContext.apps)
+  const targetApps = Object.entries(params.policyContext.apps)
     .filter(([, app]) => app.destructiveApprovalMode === "ask")
-    .map(([id]) => id)
-    .toSorted();
+    .toSorted(([left], [right]) => left.localeCompare(right));
+  const targetAppIds = targetApps.map(([id]) => id);
   const diagnostics: CodexPluginThreadConfigDiagnostic[] = [];
   // A persisted binding can be replayed before any normal turn after restart.
   // Fresh targeted inventory retains the current non-read-only tool scope.
@@ -626,7 +597,7 @@ export async function refreshCodexPluginAppApprovalPolicy(params: {
     targetAppIds.length > 0
       ? refreshCodexPluginAppInventory(readParams, new CodexAppInventoryCache(), { targetAppIds })
       : undefined,
-    requireCodexConfigForAppAdmission(readParams),
+    readCodexConfigForAppAdmission(readParams),
   ]);
   const configPatch = disableUnlistedCodexApps(
     buildCodexPluginAppsConfigPatchFromPolicyContext(params.policyContext),
@@ -636,21 +607,18 @@ export async function refreshCodexPluginAppApprovalPolicy(params: {
     inventory?.apps.map((app) => [app.id, toCodexPluginOwnedAccountApp(app)]),
   );
   const apps = { ...params.policyContext.apps };
-  for (const id of targetAppIds) {
+  for (const [id, policy] of targetApps) {
     const app = currentApps.get(id);
     if (!app) {
       diagnostics.push({
-        code: "approval_overrides_clear_failed",
+        code: "app_not_ready",
         message: `Could not verify current Codex app approval policy for ${id}; the app was not exposed.`,
       });
-    } else if (
-      await clearPersistedAppApprovalOverrides({
-        ...params,
-        config: admissionConfig.config,
-        app,
-        diagnostics,
-      })
-    ) {
+    } else {
+      configPatch.apps[id] = buildEnabledAppConfig(
+        policy,
+        buildCodexAppApprovalOverrides(admissionConfig.config, app),
+      );
       continue;
     }
     delete apps[id];
@@ -733,11 +701,14 @@ function policyFingerprint(policy: ResolvedCodexPluginsPolicy): JsonValue {
 }
 
 function mergeJsonObjects(left: JsonObject, right: JsonObject): JsonObject {
-  const merged: JsonObject = { ...left };
+  // Spreading creates own data properties, including literal native config keys
+  // such as __proto__; assignment into an empty object would drop those overrides.
+  const merged: JsonObject = { ...left, ...right };
   for (const [key, value] of Object.entries(right)) {
-    const existing = merged[key];
-    merged[key] =
-      isJsonObject(existing) && isJsonObject(value) ? mergeJsonObjects(existing, value) : value;
+    const existing = left[key];
+    if (Object.hasOwn(left, key) && isJsonObject(existing) && isJsonObject(value)) {
+      merged[key] = mergeJsonObjects(existing, value);
+    }
   }
   return merged;
 }

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -714,19 +714,19 @@ function mergeJsonObjects(left: JsonObject, right: JsonObject): JsonObject {
 }
 
 function fingerprintJson(value: JsonValue): string {
-  return crypto.createHash("sha256").update(stableStringify(value)).digest("hex");
+  return crypto.createHash("sha256").update(stringifyCodexPluginPolicy(value)).digest("hex");
 }
 
-function stableStringify(value: JsonValue | undefined): string {
+export function stringifyCodexPluginPolicy(value: unknown): string {
   // Fingerprints must be process-stable across object insertion order so prompt
   // cache and thread-binding comparisons do not churn between runs.
   if (Array.isArray(value)) {
-    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+    return `[${value.map((item) => stringifyCodexPluginPolicy(item)).join(",")}]`;
   }
   if (value && typeof value === "object") {
     return `{${Object.entries(value)
       .toSorted(([left], [right]) => left.localeCompare(right))
-      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .map(([key, item]) => `${JSON.stringify(key)}:${stringifyCodexPluginPolicy(item)}`)
       .join(",")}}`;
   }
   return JSON.stringify(value);

--- a/extensions/codex/src/app-server/protocol-control-plane.ts
+++ b/extensions/codex/src/app-server/protocol-control-plane.ts
@@ -225,7 +225,7 @@ export type CodexConfigReadParams = {
 
 type CodexConfigMergeStrategy = "replace" | "upsert";
 
-export type CodexConfigEdit = {
+type CodexConfigEdit = {
   keyPath: string;
   value: JsonValue;
   mergeStrategy: CodexConfigMergeStrategy;

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -36,7 +36,6 @@ import type { JsonObject, JsonValue } from "./protocol-json.js";
 import type * as CodexMcpProtocol from "./protocol-mcp.js";
 
 export type {
-  CodexConfigEdit,
   CodexConfigReadResponse,
   CodexConfigRequirementsReadResponse,
   CodexPluginDetail,

--- a/extensions/codex/src/app-server/scheduled-app-authority.test.ts
+++ b/extensions/codex/src/app-server/scheduled-app-authority.test.ts
@@ -433,6 +433,99 @@ describe("scheduled Codex app authority", () => {
   });
 
   it.each([
+    { current: "ask", captured: "allow" },
+    { current: "allow", captured: "ask" },
+  ] as const)(
+    "keeps link approvals with the user for current $current and captured $captured policy",
+    ({ current, captured }) => {
+      const config = threadConfig();
+      config.policyContext.apps.calendar = {
+        source: "account",
+        appName: "Calendar",
+        mcpServerNames: [],
+        allowDestructiveActions: true,
+        allowOpenWorld: true,
+        destructiveApprovalMode: current,
+      };
+      config.configPatch = {
+        apps: {
+          calendar: {
+            enabled: true,
+            ...(current === "ask"
+              ? {
+                  links: {
+                    account: { approvals_reviewer: "user", default_tools_approval_mode: "auto" },
+                  },
+                }
+              : {}),
+          },
+          newly_connected: { enabled: true },
+        },
+      };
+      const intersected = intersectCodexPluginThreadConfigWithScheduledAuthority(
+        config,
+        authority({
+          apps: [
+            {
+              id: "calendar",
+              allowDestructiveActions: true,
+              allowOpenWorld: true,
+              destructiveApprovalMode: captured,
+              tools: { edit: "approve", blocked: "approve" },
+            },
+          ],
+        }),
+        {
+          config: {
+            apps: {
+              calendar: {
+                enabled: true,
+                links: {
+                  account: {
+                    approvals_reviewer: "auto_review",
+                    default_tools_approval_mode: "approve",
+                  },
+                },
+                tools: {
+                  edit: { approval_mode: "approve" },
+                  blocked: { enabled: false, approval_mode: "approve" },
+                },
+              },
+              newly_connected: { enabled: true },
+            },
+          },
+          toolsByApp: new Map([
+            [
+              "calendar",
+              new Map([
+                ["edit", {}],
+                ["blocked", {}],
+              ]),
+            ],
+          ]),
+        },
+      );
+
+      expect(intersected.provisionalAppIds).toEqual(["calendar"]);
+      expect(intersected.configPatch).toMatchObject({
+        apps: {
+          calendar: {
+            approvals_reviewer: "user",
+            links: {
+              account: { approvals_reviewer: "user", default_tools_approval_mode: "auto" },
+            },
+            tools: {
+              edit: { enabled: true, approval_mode: "prompt" },
+              blocked: { enabled: false, approval_mode: "prompt" },
+            },
+          },
+          newly_connected: { enabled: false },
+        },
+      });
+    },
+  );
+
+  it.each([
     {
       name: "explicit tool disablement",
       appConfig: {

--- a/extensions/codex/src/app-server/scheduled-app-authority.ts
+++ b/extensions/codex/src/app-server/scheduled-app-authority.ts
@@ -15,6 +15,7 @@ import {
   buildCodexPluginAppsConfigPatchFromPolicyContext,
   buildPluginAppPolicyContext,
   disableUnlistedCodexApps,
+  stringifyCodexPluginPolicy,
   type CodexAppPolicyContextEntry,
   type CodexPluginThreadConfig,
   type PluginAppPolicyContext,
@@ -518,19 +519,6 @@ function appApprovalCeiling(mode: CodexPluginDestructiveApprovalMode): CodexAppT
   return mode === "ask" ? "prompt" : "auto";
 }
 
-function stableStringify(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(",")}]`;
-  }
-  if (value && typeof value === "object") {
-    return `{${Object.entries(value)
-      .toSorted(([left], [right]) => left.localeCompare(right))
-      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
-      .join(",")}}`;
-  }
-  return JSON.stringify(value);
-}
-
 /** Intersects a stored app-ID cap with current policy without admitting new apps. */
 export function intersectCodexPluginThreadConfigWithScheduledAuthority(
   config: CodexPluginThreadConfig,
@@ -640,7 +628,7 @@ export function intersectCodexPluginThreadConfigWithScheduledAuthority(
   const fingerprint = crypto
     .createHash("sha256")
     .update(
-      stableStringify({
+      stringifyCodexPluginPolicy({
         version: 1,
         namespace: CODEX_SCHEDULED_APP_AUTHORITY_NAMESPACE,
         authority: scheduled,
@@ -741,7 +729,7 @@ export function buildScheduledCodexAppAuthorityInputFingerprint(
   return crypto
     .createHash("sha256")
     .update(
-      stableStringify({
+      stringifyCodexPluginPolicy({
         version: 1,
         namespace: CODEX_SCHEDULED_APP_AUTHORITY_NAMESPACE,
         baseFingerprint,

--- a/extensions/codex/src/app-server/scheduled-app-authority.ts
+++ b/extensions/codex/src/app-server/scheduled-app-authority.ts
@@ -10,6 +10,7 @@ import {
 import { isCodexAppServerRequestTimeoutError, type CodexAppServerClient } from "./client.js";
 import type { CodexPluginDestructiveApprovalMode } from "./config.js";
 import { readCodexMcpToolConnectorId } from "./mcp-tool-metadata.js";
+import { buildCodexAppApprovalOverrides } from "./plugin-app-approval-overrides.js";
 import {
   buildCodexPluginAppsConfigPatchFromPolicyContext,
   buildPluginAppPolicyContext,
@@ -595,6 +596,17 @@ export function intersectCodexPluginThreadConfigWithScheduledAuthority(
     const currentApp = apps[appId];
     if (!currentApp) {
       continue;
+    }
+    if (currentApp.destructiveApprovalMode === "ask") {
+      // Captured ask can tighten today's policy. Pin the link reviewer too;
+      // per-tool prompt ceilings below do not override native account reviewers.
+      Object.assign(
+        appPatch,
+        buildCodexAppApprovalOverrides(currentPolicy.config, {
+          id: appId,
+          approvalOverrideToolConfigKeys: [],
+        }),
+      );
     }
     const storedAppCeiling = appApprovalCeiling(captured.destructiveApprovalMode);
     const currentAppCeiling = appApprovalCeiling(defaultApprovalMode(currentApp));

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1474,6 +1474,7 @@ describe("runCodexAppServerSideQuestion", () => {
       }
       if (method === "config/batchWrite") {
         expect(requestParams).toEqual({
+          reloadUserConfig: true,
           edits: [
             {
               keyPath: 'apps."ask-app".links."account".approvals_reviewer',

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1385,278 +1385,250 @@ describe("runCodexAppServerSideQuestion", () => {
     );
   });
 
-  it.each([
-    "ok",
-    "okOverridden",
-    "missing-app",
-    "binding-changed",
-    "unbound-native-app",
-    "config-unavailable",
-  ])("revalidates bound ask policy before side-thread forks: %s", async (outcome) => {
-    const approvalSpy = vi.spyOn(elicitationBridge, "routeCodexAppServerElicitationRequest");
-    const rejectsReplay = outcome === "binding-changed" || outcome === "config-unavailable";
-    const client = createFakeClient({ completeTurn: rejectsReplay });
-    const baseRequest = client.request.getMockImplementation()!;
-    client.request.mockImplementation(async (method: string, requestParams?: unknown) => {
-      if (method === "app/installed") {
-        return {
-          apps: ["ask-app", "unbound-app"].map((id) => ({
-            id,
-            runtimeName: id,
-            enabled: true,
-            callable: true,
-          })),
-        };
-      }
-      if (method === "app/read") {
-        expect(requestParams).toEqual({ appIds: ["ask-app"], includeTools: true });
-        return {
-          apps:
-            outcome === "missing-app"
-              ? []
-              : [
-                  {
-                    id: "ask-app",
-                    name: "Ask",
-                    pluginDisplayNames: [],
-                    toolSummaries: [
-                      {
-                        name: "write",
-                        title: null,
-                        description: null,
-                        isEnabled: false,
-                        disabledReason: null,
-                        isReadOnly: false,
-                      },
-                      {
-                        name: "read",
-                        title: null,
-                        description: null,
-                        isEnabled: true,
-                        disabledReason: null,
-                        isReadOnly: true,
-                      },
-                    ],
+  it.each(["ok", "missing-app", "binding-changed", "unbound-native-app", "config-unavailable"])(
+    "projects bound ask policy before side-thread forks: %s",
+    async (outcome) => {
+      const approvalSpy = vi.spyOn(elicitationBridge, "routeCodexAppServerElicitationRequest");
+      const rejectsReplay = outcome === "binding-changed" || outcome === "config-unavailable";
+      const nativeAppConfig = {
+        enabled: true,
+        links: {
+          account: { approvals_reviewer: "auto_review", default_tools_approval_mode: "approve" },
+        },
+        tools: {
+          write: { enabled: false, approval_mode: "approve" },
+          read: { approval_mode: "approve" },
+          retired: { approval_mode: "approve" },
+        },
+      };
+      const savedAppConfig = structuredClone(nativeAppConfig);
+      const client = createFakeClient({ completeTurn: rejectsReplay });
+      const baseRequest = client.request.getMockImplementation()!;
+      client.request.mockImplementation(async (method: string, requestParams?: unknown) => {
+        if (method === "app/installed") {
+          return {
+            apps: ["ask-app", "unbound-app"].map((id) => ({
+              id,
+              runtimeName: id,
+              enabled: true,
+              callable: true,
+            })),
+          };
+        }
+        if (method === "app/read") {
+          expect(requestParams).toEqual({ appIds: ["ask-app"], includeTools: true });
+          return {
+            apps:
+              outcome === "missing-app"
+                ? []
+                : [
+                    {
+                      id: "ask-app",
+                      name: "Ask",
+                      pluginDisplayNames: [],
+                      toolSummaries: [
+                        {
+                          name: "write",
+                          title: null,
+                          description: null,
+                          isEnabled: false,
+                          disabledReason: null,
+                          isReadOnly: false,
+                        },
+                        {
+                          name: "read",
+                          title: null,
+                          description: null,
+                          isEnabled: true,
+                          disabledReason: null,
+                          isReadOnly: true,
+                        },
+                      ],
+                    },
+                  ],
+            missingAppIds: outcome === "missing-app" ? ["ask-app"] : [],
+          };
+        }
+        if (method === "config/read") {
+          if (outcome === "config-unavailable") {
+            throw new Error("native config unavailable");
+          }
+          if (outcome === "binding-changed") {
+            readCodexAppServerBindingMock.mockReturnValue({ threadId: "replacement-thread" });
+          }
+          return { config: { apps: { "ask-app": nativeAppConfig } }, layers: [] };
+        }
+        if (method === "config/batchWrite" || method === "config/value/write") {
+          throw new Error("side-question admission cannot write saved app settings");
+        }
+        return baseRequest(method, requestParams);
+      });
+      getSharedCodexAppServerClientMock.mockResolvedValue(client);
+      readCodexAppServerBindingMock.mockReturnValue({
+        schemaVersion: 2,
+        threadId: "parent-thread",
+        sessionFile: "/tmp/session-1.jsonl",
+        cwd: "/tmp/workspace",
+        authProfileId: "openai:work",
+        model: "gpt-5.5",
+        approvalPolicy: "on-request",
+        sandbox: "workspace-write",
+        pluginAppPolicyContext: {
+          fingerprint: "mixed-plugin-policy",
+          apps: {
+            ...(outcome === "unbound-native-app"
+              ? {}
+              : {
+                  "ask-app": {
+                    configKey: "ask",
+                    marketplaceName: "openai",
+                    pluginName: "ask",
+                    allowDestructiveActions: true,
+                    destructiveApprovalMode: "ask",
+                    mcpServerNames: ["ask"],
                   },
-                ],
-          missingAppIds: outcome === "missing-app" ? ["ask-app"] : [],
-        };
+                }),
+            "true-app": {
+              configKey: "true",
+              marketplaceName: "openai",
+              pluginName: "true",
+              allowDestructiveActions: true,
+              destructiveApprovalMode: "allow",
+              mcpServerNames: ["true"],
+            },
+            "false-app": {
+              configKey: "false",
+              marketplaceName: "openai",
+              pluginName: "false",
+              allowDestructiveActions: false,
+              destructiveApprovalMode: "deny",
+              mcpServerNames: ["false"],
+            },
+            "auto-app": {
+              configKey: "auto",
+              marketplaceName: "openai",
+              pluginName: "auto",
+              allowDestructiveActions: true,
+              destructiveApprovalMode: "auto",
+              mcpServerNames: ["auto"],
+            },
+          },
+          pluginAppIds: {
+            ask: outcome === "unbound-native-app" ? [] : ["ask-app"],
+            true: ["true-app"],
+            false: ["false-app"],
+            auto: ["auto-app"],
+          },
+        },
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      });
+
+      const run = runCodexAppServerSideQuestion(sideParams(), {
+        pluginConfig: { appServer: { mode: "guardian" } },
+      });
+      if (rejectsReplay) {
+        await expect(run).rejects.toThrow(
+          outcome === "binding-changed"
+            ? "binding changed before fork"
+            : "Could not verify the Codex app allowlist",
+        );
+        const methods = client.request.mock.calls.map(([method]) => method);
+        expect(methods).not.toContain("config/batchWrite");
+        expect(methods).not.toContain("config/value/write");
+        expect(methods).not.toContain("thread/fork");
+        return;
       }
-      if (method === "config/read") {
-        if (outcome === "config-unavailable") {
-          throw new Error("native config unavailable");
-        }
-        const confirming = isJsonObject(requestParams) && requestParams.includeLayers === false;
-        if (outcome === "binding-changed") {
-          readCodexAppServerBindingMock.mockReturnValue({ threadId: "replacement-thread" });
-        }
-        return {
-          config: {
-            apps: {
+      await vi.waitFor(() =>
+        expect(client.request.mock.calls.map(([method]) => method)).toContain("turn/start"),
+      );
+      try {
+        await handleClientRequestWhenReady(client, {
+          id: "side-approval-policy",
+          method: "mcpServer/elicitation/request",
+          params: {
+            threadId: "side-thread",
+            turnId: "turn-1",
+            serverName: "forms",
+            mode: "form",
+            message: "Enter a value",
+            requestedSchema: { type: "object", properties: { value: { type: "string" } } },
+          },
+        });
+        const policy = approvalSpy.mock.calls.at(-1)?.[0].pluginAppPolicyContext;
+        expect(Object.keys(policy?.apps ?? {}).toSorted()).toEqual(
+          outcome === "ok"
+            ? ["ask-app", "auto-app", "false-app", "true-app"]
+            : ["auto-app", "false-app", "true-app"],
+        );
+        expect(policy?.pluginAppIds.ask).toEqual(outcome === "ok" ? ["ask-app"] : []);
+      } finally {
+        client.emit(agentDelta("side-thread", "turn-1", "Side answer."));
+        client.emit(turnCompleted("side-thread", "turn-1", "Side answer."));
+        await expect(run).resolves.toEqual({ text: "Side answer." });
+      }
+
+      const methods = client.request.mock.calls.map(([method]) => method);
+      if (outcome === "unbound-native-app") {
+        expect(methods).not.toContain("app/installed");
+        expect(methods).not.toContain("app/read");
+        expect(methods).not.toContain("config/batchWrite");
+      } else {
+        expect(methods.indexOf("app/read")).toBeLessThan(methods.indexOf("thread/fork"));
+      }
+      expect(methods.filter((method) => method === "config/read")).toHaveLength(1);
+      expect(methods).not.toContain("config/batchWrite");
+      expect(methods).not.toContain("config/value/write");
+      expect(nativeAppConfig).toEqual(savedAppConfig);
+      const forkParams = client.request.mock.calls.find(
+        ([method]) => method === "thread/fork",
+      )?.[1] as Record<string, unknown> | undefined;
+      expect(forkParams?.approvalsReviewer).toBe("auto_review");
+      const config = forkParams?.config as Record<string, unknown> | undefined;
+      expect(config).not.toHaveProperty("approvals_reviewer");
+      expect(config?.["features.code_mode"]).toBe(true);
+      expect(config?.apps).toEqual({
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+        ...(outcome === "ok"
+          ? {
               "ask-app": {
                 enabled: true,
+                approvals_reviewer: "user",
+                destructive_enabled: true,
+                open_world_enabled: true,
+                default_tools_approval_mode: "auto",
                 links: {
-                  account: {
-                    approvals_reviewer: confirming ? null : "auto_review",
-                    default_tools_approval_mode: confirming ? null : "approve",
-                  },
+                  account: { approvals_reviewer: "user", default_tools_approval_mode: "auto" },
                 },
-                tools: {
-                  write: { enabled: false, approval_mode: confirming ? null : "approve" },
-                  read: { approval_mode: "approve" },
-                  retired: { approval_mode: "approve" },
-                },
+                tools: { write: { approval_mode: "auto" } },
               },
-            },
-          },
-          layers: [],
-        };
-      }
-      if (method === "config/batchWrite") {
-        expect(requestParams).toEqual({
-          reloadUserConfig: true,
-          edits: [
-            {
-              keyPath: 'apps."ask-app".links."account".approvals_reviewer',
-              value: null,
-              mergeStrategy: "replace",
-            },
-            {
-              keyPath: 'apps."ask-app".links."account".default_tools_approval_mode',
-              value: null,
-              mergeStrategy: "replace",
-            },
-            {
-              keyPath: 'apps."ask-app".tools."write".approval_mode',
-              value: null,
-              mergeStrategy: "replace",
-            },
-          ],
-        });
-        return { status: outcome === "okOverridden" ? "okOverridden" : "ok" };
-      }
-      return baseRequest(method, requestParams);
-    });
-    getSharedCodexAppServerClientMock.mockResolvedValue(client);
-    readCodexAppServerBindingMock.mockReturnValue({
-      schemaVersion: 2,
-      threadId: "parent-thread",
-      sessionFile: "/tmp/session-1.jsonl",
-      cwd: "/tmp/workspace",
-      authProfileId: "openai:work",
-      model: "gpt-5.5",
-      approvalPolicy: "on-request",
-      sandbox: "workspace-write",
-      pluginAppPolicyContext: {
-        fingerprint: "mixed-plugin-policy",
-        apps: {
-          ...(outcome === "unbound-native-app"
-            ? {}
-            : {
-                "ask-app": {
-                  configKey: "ask",
-                  marketplaceName: "openai",
-                  pluginName: "ask",
-                  allowDestructiveActions: true,
-                  destructiveApprovalMode: "ask",
-                  mcpServerNames: ["ask"],
-                },
-              }),
-          "true-app": {
-            configKey: "true",
-            marketplaceName: "openai",
-            pluginName: "true",
-            allowDestructiveActions: true,
-            destructiveApprovalMode: "allow",
-            mcpServerNames: ["true"],
-          },
-          "false-app": {
-            configKey: "false",
-            marketplaceName: "openai",
-            pluginName: "false",
-            allowDestructiveActions: false,
-            destructiveApprovalMode: "deny",
-            mcpServerNames: ["false"],
-          },
-          "auto-app": {
-            configKey: "auto",
-            marketplaceName: "openai",
-            pluginName: "auto",
-            allowDestructiveActions: true,
-            destructiveApprovalMode: "auto",
-            mcpServerNames: ["auto"],
-          },
+            }
+          : { "ask-app": { enabled: false } }),
+        "auto-app": {
+          enabled: true,
+          destructive_enabled: true,
+          open_world_enabled: true,
+          default_tools_approval_mode: "auto",
         },
-        pluginAppIds: {
-          ask: outcome === "unbound-native-app" ? [] : ["ask-app"],
-          true: ["true-app"],
-          false: ["false-app"],
-          auto: ["auto-app"],
+        "false-app": {
+          enabled: true,
+          destructive_enabled: false,
+          open_world_enabled: true,
+          default_tools_approval_mode: "auto",
         },
-      },
-      createdAt: new Date(0).toISOString(),
-      updatedAt: new Date(0).toISOString(),
-    });
-
-    const run = runCodexAppServerSideQuestion(sideParams(), {
-      pluginConfig: { appServer: { mode: "guardian" } },
-    });
-    if (rejectsReplay) {
-      await expect(run).rejects.toThrow(
-        outcome === "binding-changed"
-          ? "binding changed before fork"
-          : "Could not verify the Codex app allowlist",
-      );
-      const methods = client.request.mock.calls.map(([method]) => method);
-      expect(methods).not.toContain("config/batchWrite");
-      expect(methods).not.toContain("thread/fork");
-      return;
-    }
-    await vi.waitFor(() =>
-      expect(client.request.mock.calls.map(([method]) => method)).toContain("turn/start"),
-    );
-    try {
-      await handleClientRequestWhenReady(client, {
-        id: "side-approval-policy",
-        method: "mcpServer/elicitation/request",
-        params: {
-          threadId: "side-thread",
-          turnId: "turn-1",
-          serverName: "forms",
-          mode: "form",
-          message: "Enter a value",
-          requestedSchema: { type: "object", properties: { value: { type: "string" } } },
+        "true-app": {
+          enabled: true,
+          destructive_enabled: true,
+          open_world_enabled: true,
+          default_tools_approval_mode: "auto",
         },
       });
-      const policy = approvalSpy.mock.calls.at(-1)?.[0].pluginAppPolicyContext;
-      expect(Object.keys(policy?.apps ?? {}).toSorted()).toEqual(
-        outcome === "ok"
-          ? ["ask-app", "auto-app", "false-app", "true-app"]
-          : ["auto-app", "false-app", "true-app"],
-      );
-      expect(policy?.pluginAppIds.ask).toEqual(outcome === "ok" ? ["ask-app"] : []);
-    } finally {
-      client.emit(agentDelta("side-thread", "turn-1", "Side answer."));
-      client.emit(turnCompleted("side-thread", "turn-1", "Side answer."));
-      await expect(run).resolves.toEqual({ text: "Side answer." });
-    }
-
-    const methods = client.request.mock.calls.map(([method]) => method);
-    if (outcome === "unbound-native-app") {
-      expect(methods).not.toContain("app/installed");
-      expect(methods).not.toContain("app/read");
-      expect(methods).not.toContain("config/batchWrite");
-    } else {
-      expect(methods.indexOf("app/read")).toBeLessThan(methods.indexOf("thread/fork"));
-    }
-    if (outcome !== "missing-app" && outcome !== "unbound-native-app") {
-      expect(methods.indexOf("config/batchWrite")).toBeGreaterThan(-1);
-      expect(methods.indexOf("config/batchWrite")).toBeLessThan(methods.indexOf("thread/fork"));
-    }
-    const forkParams = client.request.mock.calls.find(
-      ([method]) => method === "thread/fork",
-    )?.[1] as Record<string, unknown> | undefined;
-    expect(forkParams?.approvalsReviewer).toBe("auto_review");
-    const config = forkParams?.config as Record<string, unknown> | undefined;
-    expect(config).not.toHaveProperty("approvals_reviewer");
-    expect(config?.["features.code_mode"]).toBe(true);
-    expect(config?.apps).toEqual({
-      _default: {
-        enabled: false,
-        destructive_enabled: false,
-        open_world_enabled: false,
-      },
-      ...(outcome === "ok"
-        ? {
-            "ask-app": {
-              enabled: true,
-              approvals_reviewer: "user",
-              destructive_enabled: true,
-              open_world_enabled: true,
-              default_tools_approval_mode: "auto",
-            },
-          }
-        : { "ask-app": { enabled: false } }),
-      "auto-app": {
-        enabled: true,
-        destructive_enabled: true,
-        open_world_enabled: true,
-        default_tools_approval_mode: "auto",
-      },
-      "false-app": {
-        enabled: true,
-        destructive_enabled: false,
-        open_world_enabled: true,
-        default_tools_approval_mode: "auto",
-      },
-      "true-app": {
-        enabled: true,
-        destructive_enabled: true,
-        open_world_enabled: true,
-        default_tools_approval_mode: "auto",
-      },
-    });
-  });
+    },
+  );
 
   it("disables hosted search when side-question sender policy removes managed web_search", async () => {
     createOpenClawCodingToolsMock.mockImplementation((options: { senderId?: string }) =>

--- a/extensions/codex/src/app-server/thread-fingerprints.test.ts
+++ b/extensions/codex/src/app-server/thread-fingerprints.test.ts
@@ -3,6 +3,7 @@ import type { CodexDynamicToolFunctionSpec, JsonObject } from "./protocol.js";
 import {
   codexDynamicToolsFingerprint,
   fingerprintCodexThreadConfig,
+  fingerprintUserMcpServersConfigPatch,
   readActiveCodexTurnIdsFromResume,
 } from "./thread-fingerprints.js";
 
@@ -42,6 +43,22 @@ describe("codexDynamicToolsFingerprint", () => {
       codexDynamicToolsFingerprint([
         createMessageTool("Send a message.", "Current Discord channel."),
       ]),
+    );
+  });
+
+  it("changes when a literal __proto__ input property changes", () => {
+    const tool = (description: string): CodexDynamicToolFunctionSpec => ({
+      type: "function",
+      name: "inspect",
+      description: "Inspect a record.",
+      inputSchema: {
+        type: "object",
+        properties: { ["__proto__"]: { type: "string", description } },
+      },
+    });
+
+    expect(codexDynamicToolsFingerprint([tool("Current value.")])).not.toBe(
+      codexDynamicToolsFingerprint([tool("Previous value.")]),
     );
   });
 
@@ -126,6 +143,16 @@ describe("fingerprintCodexThreadConfig", () => {
     );
   });
 
+  it("invalidates reuse when a literal __proto__ app link policy changes", () => {
+    const config = (reviewer: string) => ({
+      apps: { calendar: { links: { ["__proto__"]: { approvals_reviewer: reviewer } } } },
+    });
+
+    expect(fingerprintCodexThreadConfig({ ...request, config: config("user") })).not.toBe(
+      fingerprintCodexThreadConfig({ ...request, config: config("auto_review") }),
+    );
+  });
+
   it.each<{ setting: string; patch: JsonObject }>([
     { setting: "model", patch: { model: "gpt-5.6-terra" } },
     { setting: "requested model", patch: { requestedModel: null } },
@@ -139,6 +166,29 @@ describe("fingerprintCodexThreadConfig", () => {
     expect(fingerprintCodexThreadConfig({ ...request, ...patch }, "openai:personal")).toBe(
       fingerprintCodexThreadConfig(request, "openai:personal"),
     );
+  });
+});
+
+describe("fingerprintUserMcpServersConfigPatch", () => {
+  it.each(["server", "header"])("retains literal __proto__ %s keys during redaction", (scope) => {
+    const config = (value: string): JsonObject => ({
+      mcp_servers: {
+        [scope === "server" ? "__proto__" : "calendar"]: {
+          url: "https://example.test/mcp",
+          http_headers: {
+            Authorization: scope === "server" ? value : "synthetic-access-token",
+            ...(scope === "header" ? { ["__proto__"]: value } : {}),
+          },
+        },
+      },
+    });
+    const first = fingerprintUserMcpServersConfigPatch(config("synthetic-first"));
+    const second = fingerprintUserMcpServersConfigPatch(config("synthetic-second"));
+
+    expect(first).not.toBe(second);
+    expect(first).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(first).not.toContain("synthetic");
+    expect(second).not.toContain("synthetic");
   });
 });
 

--- a/extensions/codex/src/app-server/thread-fingerprints.ts
+++ b/extensions/codex/src/app-server/thread-fingerprints.ts
@@ -58,22 +58,25 @@ function redactUserMcpServersFingerprintSecrets(value: JsonValue): JsonValue {
   if (!value || typeof value !== "object") {
     return value;
   }
-  const next: JsonObject = {};
-  for (const [key, entry] of Object.entries(value)) {
-    if (key === "http_headers" && entry && typeof entry === "object" && !Array.isArray(entry)) {
-      next[key] = Object.fromEntries(
-        Object.entries(entry).map(([header, headerValue]) => [
-          header,
-          header.toLowerCase() === "authorization"
-            ? fingerprintUserMcpServersAuthorizationHeader(headerValue)
-            : headerValue,
-        ]),
-      ) as JsonObject;
-      continue;
-    }
-    next[key] = redactUserMcpServersFingerprintSecrets(entry);
-  }
-  return next;
+  // Native server names are literal keys, including __proto__.
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => {
+      if (key === "http_headers" && entry && typeof entry === "object" && !Array.isArray(entry)) {
+        return [
+          key,
+          Object.fromEntries(
+            Object.entries(entry).map(([header, headerValue]) => [
+              header,
+              header.toLowerCase() === "authorization"
+                ? fingerprintUserMcpServersAuthorizationHeader(headerValue)
+                : headerValue,
+            ]),
+          ),
+        ];
+      }
+      return [key, redactUserMcpServersFingerprintSecrets(entry)];
+    }),
+  );
 }
 
 function fingerprintUserMcpServersAuthorizationHeader(value: unknown): string {
@@ -140,13 +143,12 @@ function stabilizeJsonValue(value: JsonValue): JsonValue {
   if (!isJsonObject(value)) {
     return value;
   }
-  const stable: JsonObject = {};
-  for (const [key, child] of Object.entries(value).toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
-    stable[key] = stabilizeJsonValue(child);
-  }
-  return stable;
+  // Indexed assignment would lose __proto__ schema and policy changes from the fingerprint.
+  return Object.fromEntries(
+    Object.entries(value)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => [key, stabilizeJsonValue(child)]),
+  );
 }
 
 function readActiveCodexTurnIds(thread: unknown): string[] {

--- a/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
@@ -163,6 +163,14 @@ describe("Codex app inventory across physical process restart", () => {
           throw closeError;
         }
       };
+      const reloadUserConfig = () => {
+        for (const threadId of loadedThreads.keys()) {
+          loadedThreads.set(
+            threadId,
+            mergeNativeFixtureConfig(currentConfig, durableThreads.get(threadId)!),
+          );
+        }
+      };
       const fake = await createLeasedCodexLifecycleHarness({
         agentDir,
         persistedThreads: persistedThreadId ? [persistedThreadId] : [],
@@ -221,6 +229,9 @@ describe("Codex app inventory across physical process restart", () => {
               },
             ]);
             nativeLinkPolicy.approvals_reviewer = null;
+            if (requestParams.reloadUserConfig === true) {
+              reloadUserConfig();
+            }
             return { status: "ok" };
           }
           if (method === "configRequirements/read") {
@@ -237,12 +248,17 @@ describe("Codex app inventory across physical process restart", () => {
               await faults.beforeInventory?.();
             }
             assertOpen();
-            const effective = threadId ? loadedThreads.get(threadId) : currentConfig;
+            const effective = threadId
+              ? mergeNativeFixtureConfig(currentConfig, durableThreads.get(threadId)!)
+              : currentConfig;
             const apps = isJsonObject(effective?.apps) ? effective.apps : {};
             const app = isJsonObject(apps[appId]) ? apps[appId] : {};
             const row = {
               ...appInfo(appId, !accountRevoked),
-              isEnabled: app.enabled === true && !(threadId && disabledThreadApps.has(threadId)),
+              isEnabled:
+                effective?.["features.apps"] !== false &&
+                app.enabled === true &&
+                !(threadId && disabledThreadApps.has(threadId)),
               toolSummaries: [
                 {
                   name: "list",
@@ -275,21 +291,28 @@ describe("Codex app inventory across physical process restart", () => {
             if (threadId && requestParams.limit === undefined) {
               await faults.beforeMcpAttestation?.();
             }
+            const effective = threadId
+              ? mergeNativeFixtureConfig(currentConfig, durableThreads.get(threadId)!)
+              : currentConfig;
             return {
               data: [
-                {
-                  name: "codex_apps",
-                  serverInfo: { name: "codex_apps", version: "1" },
-                  tools:
-                    accountRevoked || (threadId && threadToolRevocations.has(threadId))
-                      ? {}
-                      : {
-                          list: {
-                            _meta: { connector_id: appId },
-                            annotations: { destructiveHint: false, openWorldHint: false },
-                          },
-                        },
-                },
+                ...(effective?.["features.apps"] === false
+                  ? []
+                  : [
+                      {
+                        name: "codex_apps",
+                        serverInfo: { name: "codex_apps", version: "1" },
+                        tools:
+                          accountRevoked || (threadId && threadToolRevocations.has(threadId))
+                            ? {}
+                            : {
+                                list: {
+                                  _meta: { connector_id: appId },
+                                  annotations: { destructiveHint: false, openWorldHint: false },
+                                },
+                              },
+                      },
+                    ]),
                 {
                   name: "inherited",
                   serverInfo: faults.activeInheritedMcp
@@ -305,7 +328,7 @@ describe("Codex app inventory across physical process restart", () => {
             const id = `00000000-0000-4000-8000-${String(++sequence).padStart(12, "0")}`;
             const config = isJsonObject(requestParams.config) ? requestParams.config : {};
             durableThreads.set(id, config);
-            loadedThreads.set(id, config);
+            loadedThreads.set(id, mergeNativeFixtureConfig(currentConfig, config));
             subscribedThreads.add(id);
             return { ...threadStartResult(id, workspaceDir), model: params.modelId };
           }
@@ -321,7 +344,7 @@ describe("Codex app inventory across physical process restart", () => {
               const config = isJsonObject(requestParams.config)
                 ? requestParams.config
                 : durableThreads.get(threadId)!;
-              loadedThreads.set(threadId, config);
+              loadedThreads.set(threadId, mergeNativeFixtureConfig(currentConfig, config));
               durableThreads.set(threadId, config);
             }
             subscribedThreads.add(threadId);
@@ -377,6 +400,7 @@ describe("Codex app inventory across physical process restart", () => {
         ...fake,
         close,
         loadedThreads,
+        reloadUserConfig,
         subscribedThreads,
         threadToolRevocations,
         disabledThreadApps,
@@ -572,48 +596,88 @@ describe("Codex app inventory across physical process restart", () => {
       // A native client can add a higher-precedence link reviewer without changing
       // the OpenClaw policy fingerprint or invalidating its cached app inventory.
       f.nativeLinkPolicy.approvals_reviewer = "auto_review";
+      if (lifecycle === "warm") {
+        f.process.reloadUserConfig();
+        expect(f.process.loadedThreads.get(f.first.threadId)).toMatchObject({
+          apps: { [appId]: { links: { account: { approvals_reviewer: "auto_review" } } } },
+        });
+      }
       const boundary = f.calls.length;
       const second = await f.process.run();
       expect(f.nativeLinkPolicy.approvals_reviewer).toBeNull();
-      expect(
-        f.calls.slice(boundary).filter((call) => call.method === "config/batchWrite"),
-      ).toHaveLength(1);
+      const writes = f.calls.slice(boundary).filter((call) => call.method === "config/batchWrite");
+      expect(writes).toHaveLength(1);
       expect(second.threadId).toBe(f.first.threadId);
       expect(f.readBinding()?.pluginAppPolicyContext?.apps[appId]).toMatchObject({
         source: "account",
         destructiveApprovalMode: "ask",
       });
       expect(f.process.loadedThreads.get(second.threadId)).toMatchObject({
-        apps: { [appId]: { enabled: true, approvals_reviewer: "user" } },
+        apps: {
+          [appId]: {
+            enabled: true,
+            approvals_reviewer: "user",
+            links: { account: { approvals_reviewer: null } },
+          },
+        },
       });
+      expect(writes[0]?.params.reloadUserConfig).toBe(true);
     },
   );
 
-  it("stops a warm account app ask continuation when current policy verification times out", async () => {
-    const f = await continuation(false, "warm", {
-      codexPlugins: {
-        enabled: true,
-        allow_all_plugins: true,
-        allow_destructive_actions: "ask",
-      },
-    });
-    const binding = f.readBinding();
-    const release = createDeferred<void>();
-    f.process.faults.beforeInventory = () => release.promise;
-    f.appServer.requestTimeoutMs = 400;
-    const boundary = f.calls.length;
-    try {
-      await expect(f.process.run()).rejects.toThrow(
-        "Codex app policy verification exceeded its 100 ms startup budget",
-      );
-      expect(f.readBinding()).toEqual(binding);
-      expect(f.process.subscribedThreads.has(f.first.threadId)).toBe(false);
-      expect(f.calls.slice(boundary).some((call) => call.method === "thread/start")).toBe(false);
-    } finally {
-      f.process.abort.abort();
-      release.resolve();
-    }
-  });
+  it.each([
+    { lifecycle: "warm", scheduled: false },
+    { lifecycle: "cold", scheduled: false },
+    { lifecycle: "warm", scheduled: true },
+    { lifecycle: "cold", scheduled: true },
+  ])(
+    "contains $lifecycle ask inventory timeouts, scheduled=$scheduled",
+    async ({ lifecycle, scheduled }) => {
+      const f = await continuation(scheduled, lifecycle, {
+        codexPlugins: {
+          enabled: true,
+          allow_all_plugins: true,
+          allow_destructive_actions: "ask",
+        },
+      });
+      const binding = f.readBinding();
+      const release = createDeferred<void>();
+      f.process.faults.beforeInventory = () => release.promise;
+      f.appServer.requestTimeoutMs = 400;
+      const boundary = f.calls.length;
+      try {
+        if (scheduled) {
+          await expect(f.process.run()).rejects.toThrow(
+            "Codex app policy verification exceeded its 100 ms startup budget",
+          );
+          expect(f.readBinding()).toEqual(binding);
+          expect(f.calls.slice(boundary).some((call) => call.method === "thread/start")).toBe(
+            false,
+          );
+          return;
+        }
+        const second = await f.process.run();
+        expect(second.threadId).not.toBe(f.first.threadId);
+        expect(f.readBinding()?.threadId).toBe(second.threadId);
+        expect(f.readBinding()?.pluginAppPolicyContext?.apps).toEqual({});
+        expect(f.process.loadedThreads.get(second.threadId)).toMatchObject({
+          "features.apps": false,
+          apps: { _default: { enabled: false }, [appId]: { enabled: true } },
+        });
+        const mcp = await f.process.client.request("mcpServerStatus/list", {
+          threadId: second.threadId,
+        });
+        expect(mcp.data).not.toContainEqual(expect.objectContaining({ name: "codex_apps" }));
+        expect(f.process.subscribedThreads.has(f.first.threadId)).toBe(false);
+        expect(
+          f.calls.slice(boundary).filter((call) => call.method === "thread/start"),
+        ).toHaveLength(1);
+      } finally {
+        f.process.abort.abort();
+        release.resolve();
+      }
+    },
+  );
 
   it("keeps revoked account apps unavailable after a cold process restart", async () => {
     const f = await continuation(false, "cold");
@@ -777,3 +841,16 @@ describe("Codex app inventory across physical process restart", () => {
     },
   );
 });
+
+// Codex reloads durable user layers while retaining the thread's session overrides.
+function mergeNativeFixtureConfig(base: JsonObject, patch: JsonObject): JsonObject {
+  const merged = structuredClone(base);
+  for (const [key, value] of Object.entries(patch)) {
+    const current = merged[key];
+    merged[key] =
+      isJsonObject(current) && isJsonObject(value)
+        ? mergeNativeFixtureConfig(current, value)
+        : structuredClone(value);
+  }
+  return merged;
+}

--- a/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
@@ -221,18 +221,7 @@ describe("Codex app inventory across physical process restart", () => {
             return { config: currentConfig, layers: [] };
           }
           if (method === "config/batchWrite") {
-            expect(requestParams.edits).toEqual([
-              {
-                keyPath: `apps."${appId}".links."account".approvals_reviewer`,
-                value: null,
-                mergeStrategy: "replace",
-              },
-            ]);
-            nativeLinkPolicy.approvals_reviewer = null;
-            if (requestParams.reloadUserConfig === true) {
-              reloadUserConfig();
-            }
-            return { status: "ok" };
+            throw new Error("App admission must not mutate saved native settings");
           }
           if (method === "configRequirements/read") {
             return { requirements: null };
@@ -580,7 +569,7 @@ describe("Codex app inventory across physical process restart", () => {
   );
 
   it.each(["cold", "warm"])(
-    "rechecks durable account app ask policy on %s continuation",
+    "reconfigures the %s thread when native ask override keys change",
     async (lifecycle) => {
       const f = await continuation(false, lifecycle, {
         codexPlugins: {
@@ -604,10 +593,14 @@ describe("Codex app inventory across physical process restart", () => {
       }
       const boundary = f.calls.length;
       const second = await f.process.run();
-      expect(f.nativeLinkPolicy.approvals_reviewer).toBeNull();
+      expect(f.nativeLinkPolicy.approvals_reviewer).toBe("auto_review");
       const writes = f.calls.slice(boundary).filter((call) => call.method === "config/batchWrite");
-      expect(writes).toHaveLength(1);
-      expect(second.threadId).toBe(f.first.threadId);
+      expect(writes).toHaveLength(0);
+      if (lifecycle === "cold") {
+        expect(second.threadId).toBe(f.first.threadId);
+      } else {
+        expect(second.threadId).not.toBe(f.first.threadId);
+      }
       expect(f.readBinding()?.pluginAppPolicyContext?.apps[appId]).toMatchObject({
         source: "account",
         destructiveApprovalMode: "ask",
@@ -617,11 +610,25 @@ describe("Codex app inventory across physical process restart", () => {
           [appId]: {
             enabled: true,
             approvals_reviewer: "user",
-            links: { account: { approvals_reviewer: null } },
+            links: { account: { approvals_reviewer: "user", default_tools_approval_mode: "auto" } },
           },
         },
       });
-      expect(writes[0]?.params.reloadUserConfig).toBe(true);
+      // A later native reload keeps this thread's higher-precedence ask overlay.
+      expect(
+        await retainCodexAppServerLiveThread(
+          f.process.client,
+          second.threadId,
+          undefined,
+          second.liveThreadConfigFingerprint,
+        ),
+      ).toBe(true);
+      f.process.reloadUserConfig();
+      const third = await f.process.run();
+      expect(third.threadId).toBe(second.threadId);
+      expect(f.process.loadedThreads.get(third.threadId)).toMatchObject({
+        apps: { [appId]: { links: { account: { approvals_reviewer: "user" } } } },
+      });
     },
   );
 

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -6,6 +6,7 @@ import {
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { isIncognitoSessionKey } from "../incognito-session.js";
 import type { CodexAppServerClient } from "./client.js";
+import { CODEX_SESSION_OVERRIDABLE_LAYER_TYPES } from "./config-layer-policy.js";
 import type { CodexAppServerRuntimeOptions } from "./config.js";
 import {
   isMessageOnlyCodexSourceReply,
@@ -144,16 +145,6 @@ const CODEX_RING_ZERO_RESTRICTED_FEATURE_ALIASES = new Map<string, string>([
   ["memory_tool", "memories"],
   ["telepathy", "chronicle"],
   ["codex_hooks", "hooks"],
-]);
-
-const CODEX_RING_ZERO_OVERRIDABLE_LAYER_TYPES = new Set([
-  "packagedDefaults",
-  "mdm",
-  "system",
-  "enterpriseManaged",
-  "user",
-  "project",
-  "sessionFlags",
 ]);
 
 export type CodexThreadConfigurationContext = CodexThreadPromptContext &
@@ -555,7 +546,7 @@ export async function readCodexInheritedMcpServerNames(
         `Codex restricted tool surface cannot override config layer ${layer.name.type}; ${migrationGuidance}.`,
       );
     }
-    if (!CODEX_RING_ZERO_OVERRIDABLE_LAYER_TYPES.has(layer.name.type)) {
+    if (!CODEX_SESSION_OVERRIDABLE_LAYER_TYPES.has(layer.name.type)) {
       throw new Error(
         `Codex restricted tool surface does not recognize config layer ${layer.name.type}`,
       );


### PR DESCRIPTION
Related: #137167.

## What Problem This Solves

A warm Codex conversation in `ask` mode could keep a saved connected-app approval after OpenClaw cleared it. Native config readback describes the current configuration, while tool calls use the loaded thread's captured layers. The first proposed fix requested a reload, but Codex can acknowledge the write while an individual thread reload fails. Ordinary app-inventory timeouts also stopped conversations that could safely continue without apps.

## Why This Change Was Made

App admission now projects the writable-tool and account-link approval settings into the native session configuration. The native merge gives these settings precedence over user/project configuration, and subsequent user-config reloads preserve them. This removes the durable config writes, readback requests, reload dependency, and obsolete failure paths. Saved native settings, read-only tool policy, disabled tools, and unrelated app policy stay intact.

Normal, resumed, and `/btw` fork paths share this projection. Existing binding fingerprints refresh cold configurations and rotate warm bindings when override keys change; a private fingerprint revision also invalidates bindings created before this repair. Scheduled authority applies the same link policy after intersecting current and captured approval modes, then keeps its stricter per-tool ceilings. Active legacy-managed app settings outrank session flags, so admission rejects those layers with migration guidance, using the same native precedence set as restricted turns.

Literal-key preservation also covers binding fingerprints: changes to native dynamic-tool schemas, app-link policy, and MCP settings now invalidate identity correctly. Authorization redaction and ordinary fingerprint bytes are preserved. The identical ordinary/scheduled policy serializer is shared, and the assertion baseline decreases for a removed cast.

Ordinary inventory timeouts use the existing `features.apps=false` recovery. Scheduled runs still stop when their captured authority cannot be verified. No new user configuration, schema, storage format, migration, or protocol version is introduced.

Production: +148/-235, **net -87 lines**, including shared config-layer and policy-serialization declarations. Guard metadata: +1/-1 (assertion allowance lowered). Tests: +760/-849, net -89, replacing obsolete write/readback fixtures with owner and lifecycle coverage. Docs: +13/-6.

## User Impact

`ask` policy applies to the admitted native thread without modifying shared saved preferences. Existing warm conversations remain warm while their projected policy is unchanged. Ordinary conversations continue without app tools during inventory timeouts; scheduled automations retain their authorization ceiling.

## Evidence

- Nine regressions failed against the previous implementation: configured/account app projection, warm/cold continuation, side forks, and active non-overridable app layers. The scheduled intersection then exposed two additional failing cases: current ask/captured allow and current allow/captured ask. Both now preserve human link review and the scheduled tool ceiling.
- A final review caught literal `__proto__` tool-title/link keys being lost during object assignment. The native probe reproduced one synthetic write with zero approval requests. Approval projection now creates own data properties, and the shared configuration merge preserves them through JSON serialization; the same native probe then requested approval and denied execution.
- **327 tests pass** across plugin thread configuration, side questions, physical-process lifecycle, startup, scheduled app authority, managed requirements, shared fingerprints, and user-MCP lifecycle. Coverage includes tool name/title aliases, disabled/read-only/retired tools, unchanged saved settings, changed-key fingerprints, excluded apps, and ordinary versus scheduled timeout behavior.
- Real `@openai/codex@0.153.0` app-server, using the production approval projection helper and synthetic localhost provider/MCP: ordinary, same-thread-after-reload, forked, and scheduled-policy calls each requested one approval; declining each produced zero tool executions. Saved automatic overrides remained unchanged. A separate native probe completed with apps disabled and no exposed app namespace or app MCP server despite saved app enablement. The native model request also retained a literal `__proto__` dynamic-schema property. Four fingerprint collision regressions failed before the shared-owner repair and passed afterward. No real credentials or external services were used; these are native-runtime tests with synthetic services.

```json
{"nativeRuntime":"0.153.0","productionHelperUsed":true,"savedOverridesPreserved":true,"ordinary":{"approvalRequests":1,"toolExecutions":0},"afterUserReload":{"approvalRequests":1,"toolExecutions":0},"fork":{"approvalRequests":1,"toolExecutions":0},"scheduledPolicy":{"approvalRequests":1,"toolExecutions":0}}
```

- Stored-data compatibility: the scheduled authority capture, parser, auth types, and payload construction are byte-identical to the base. Reopened 64 serialized version-1 payloads spanning both auth variants and every app/tool approval mode; old and new input fingerprints matched, including literal tool keys, and neither reader mutated the payload. Sharing the identical serializer changes no stored format or schema version; the changed intersection only projects effective runtime approval policy. No migration is needed.

Direct dependency evidence at `openai/codex` commit `41e22fee981a63b3698df7ed36bad393cda24715`:

- [Config-layer precedence](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/config/src/config_layer_source.rs#L31-L58) and [recursive table merge](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/config/src/merge.rs#L95-L132).
- [Best-effort reload errors](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/app-server/src/request_processors/config_processor.rs#L323-L351) and [loaded user-layer refresh](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/core/src/session/mod.rs#L1867-L1909).
- [Cold resume configuration](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/app-server/src/request_processors/thread_processor.rs#L3806-L3837), [fork configuration](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/app-server/src/request_processors/thread_processor.rs#L4913-L4918), and [link reviewer precedence](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/core/src/connectors.rs#L511-L546).
- [Native schema property preservation](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/tools/src/json_schema.rs#L38-L87) and [dynamic tool schema transport](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/protocol/src/dynamic_tools.rs#L20-L28) explain why binding fingerprints must preserve literal keys.
- The documented minimum 0.149.0 already has [session-layer precedence](https://github.com/openai/codex/blob/rust-v0.149.0/codex-rs/config/src/config_layer_source.rs#L31-L52), [cold resume overlays](https://github.com/openai/codex/blob/rust-v0.149.0/codex-rs/app-server/src/request_processors/thread_processor.rs#L3646-L3658), and [fork overlays](https://github.com/openai/codex/blob/rust-v0.149.0/codex-rs/app-server/src/request_processors/thread_processor.rs#L4715-L4723). This repair no longer depends on the reload flag.

## Review Follow-through

The reload-acknowledgment finding and rank-up request are resolved by removing reload from admission altogether. Unit, lifecycle, native-runtime, and scheduled-sibling evidence cover the replacement. The ordinary timeout and scheduled strictness findings from #137167 remain addressed.

Named follow-up: native administrative requirements can independently force automatic review or per-tool approval. This pre-existing policy precedence is outside saved user/project overrides, and 0.153.0 does not expose app requirements through `configRequirements/read` ([native policy](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/connectors/src/app_tool_policy.rs#L176-L207), [exported requirements](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/app-server-protocol/src/protocol/v2/config.rs#L409-L453)). The docs now make administrative authority explicit; exposing that upstream contract and surfacing conflicting effective policy is separate work.
