### PR TITLE
test(voice-call): share response cancellation fixtures

### DIFF
--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../test-support/streaming-error-response.js";
 import { resolveTwilioStatusCallbackUrl } from "./public-webhook-url.js";
 import {
   buildTwilioInboundMessage,
@@ -77,28 +78,6 @@ async function readTestTwilioForm(body: string): Promise<Record<string, string>>
   const req = createMockIncomingRequest([body]);
   req.headers = { "content-length": String(Buffer.byteLength(body)) };
   return await readTwilioWebhookForm(req);
-}
-
-function cancelTrackedTextResponse(
-  text: string,
-  init?: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
 }
 
 describe("Twilio SMS helpers", () => {

--- a/extensions/test-support/streaming-error-response.ts
+++ b/extensions/test-support/streaming-error-response.ts
@@ -48,3 +48,27 @@ export function createStreamingErrorResponse(params: {
 }): StreamingResponseFixture {
   return createStreamingResponse(params);
 }
+
+// Keep the body open after its first chunk so cancellation reaches the source.
+// Provider 404 and overflow tests observe that callback.
+export function cancelTrackedTextResponse(
+  text: string,
+  init?: ResponseInit,
+): {
+  response: Response;
+  wasCanceled: () => boolean;
+} {
+  let canceled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(stream, init),
+    wasCanceled: () => canceled,
+  };
+}

--- a/extensions/voice-call/src/providers/shared/guarded-json-api.test.ts
+++ b/extensions/voice-call/src/providers/shared/guarded-json-api.test.ts
@@ -1,5 +1,6 @@
 // Voice Call tests cover guarded json api plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../../../test-support/streaming-error-response.js";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -10,28 +11,6 @@ vi.mock("../../../api.js", () => ({
 }));
 
 import { guardedJsonApiRequest } from "./guarded-json-api.js";
-
-function cancelTrackedTextResponse(
-  text: string,
-  init?: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
 
 describe("guardedJsonApiRequest", () => {
   beforeEach(() => {

--- a/extensions/voice-call/src/providers/twilio/api.test.ts
+++ b/extensions/voice-call/src/providers/twilio/api.test.ts
@@ -1,5 +1,6 @@
 // Voice Call tests cover api plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { cancelTrackedTextResponse } from "../../../../test-support/streaming-error-response.js";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -32,28 +33,6 @@ function requireFirstFetchGuardRequest(): FetchGuardRequest {
     throw new Error("expected guarded fetch request");
   }
   return request as FetchGuardRequest;
-}
-
-function cancelTrackedTextResponse(
-  text: string,
-  init?: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(text));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
 }
 
 describe("twilioApiRequest", () => {


### PR DESCRIPTION
The SMS Twilio, voice-call Twilio API, and shared JSON API tests duplicate the same open-response cancellation fixture. Move it into the existing streaming test-support module and import it from all three suites. Each call still synchronously enqueues one UTF-8 chunk, leaves the stream open, and exposes independent cancellation state. Existing finite-stream helpers remain unchanged.

All 56 test declarations, 153 assertions, and seven fixture call sites are preserved, including unread 404 cancellation, oversized bodies, malformed data, UTF-8 limits, reader cleanup, redaction, and structured Twilio errors. Production delta: 0 lines; test and test-support delta: +27/-66, net -39. The SMS import migration addresses the Before merge and Rank-up request in the [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/137384#issuecomment-5528360767).

Validation: the same five complete suites passed before and after the SMS follow-up with 137 identical ordered cases: SMS Twilio, voice-call Twilio API, shared JSON API, canonical HTTP response handling, and ElevenLabs TTS. The original four-suite 69-case proof is retained. The full four-path LOCAL changed gate passed, and a fresh scoped Codex P2 review of the complete four-file change found no actionable issues. An initial optional evidence selection was refused before inference; the completed review omitted only that unrelated unchanged selection. These checks use synthetic streams and mocked provider HTTP; they do not establish live provider, SMS delivery, or telephony behavior.

Separate follow-up: audit the ElevenLabs local first-fetch-call wrapper for possible consolidation. It is unchanged here.
