### PR TITLE
fix(tests): failed dialog assertions leak unfinished work

### DIFF
--- a/ui/src/pages/chat/chat-pane-placement-stop.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement-stop.test.ts
@@ -8,7 +8,7 @@ import { t } from "../../i18n/index.ts";
 import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import {
   answerConfirmDialog,
-  installDialogPolyfill,
+  createModalDialogTestFixture,
   waitForConfirmDialogActions,
 } from "../../test-helpers/modal-dialog.ts";
 import {
@@ -24,14 +24,16 @@ import {
 } from "./chat-pane.test-support.ts";
 import { renderChatPanePlacement } from "./components/chat-pane-placement.ts";
 
-let restoreDialogPolyfill: () => void;
+let dialogs: ReturnType<typeof createModalDialogTestFixture>;
 beforeEach(() => {
-  restoreDialogPolyfill = installDialogPolyfill();
+  dialogs = createModalDialogTestFixture();
 });
-afterEach(() => {
-  document.body.replaceChildren();
-  restoreDialogPolyfill();
-  vi.unstubAllGlobals();
+afterEach(async () => {
+  try {
+    await dialogs.cleanup();
+  } finally {
+    vi.unstubAllGlobals();
+  }
 });
 
 const placementTiming = { generation: 1, createdAtMs: 1, updatedAtMs: 1, stateChangedAtMs: 1 };
@@ -125,7 +127,7 @@ describe("chat pane worker stop", () => {
   ] as const)(
     "stops $placement.state $targetKind startup from the placement menu",
     async ({ placement, targetKind, copy }) => {
-      const request = vi.fn(async () => ({ ok: true }));
+      const request = dialogs.mockRequest(async () => ({ ok: true }));
       const refreshReplacement = vi.fn(async () => undefined);
       const { pane } = createTestChatPane({
         client: createGatewayBrowserClientFixture({ request }),
@@ -144,7 +146,7 @@ describe("chat pane worker stop", () => {
           session,
           placementStartupStatus: startup,
           onPlacementReclaim: () => {
-            reclaim = pane.reclaimHeaderPlacement(session);
+            reclaim = dialogs.track(pane.reclaimHeaderPlacement(session));
           },
         }),
         container,
@@ -221,7 +223,7 @@ describe("chat pane worker stop", () => {
   });
 
   it("does not issue reclaim for an offline device placement", async () => {
-    const request = vi.fn(async () => ({ ok: true }));
+    const request = dialogs.mockRequest(async () => ({ ok: true }));
     const { pane } = createTestChatPane({
       client: createGatewayBrowserClientFixture({ request }),
       sessions: createSessionCapabilityFixture(),
@@ -278,7 +280,7 @@ describe("chat pane worker stop", () => {
           throw new Error("native confirm must not be used");
         }),
       );
-      const request = vi.fn(async () => ({ ok: true }));
+      const request = dialogs.mockRequest(async () => ({ ok: true }));
       const refreshReplacement = vi.fn(async () => undefined);
       const { pane } = createTestChatPane({
         client: createGatewayBrowserClientFixture({ request }),
@@ -299,7 +301,7 @@ describe("chat pane worker stop", () => {
         targetKind: runner === "device" ? "profile" : "device",
       });
 
-      const reclaim = pane.reclaimHeaderPlacement(session);
+      const reclaim = dialogs.track(pane.reclaimHeaderPlacement(session));
       const actions = await waitForConfirmDialogActions();
       const actionText = actions.textContent;
       const confirmation = document.body.querySelector("openclaw-modal-dialog")?.textContent;
@@ -330,7 +332,7 @@ describe("chat pane worker stop", () => {
   );
 
   it("does not reclaim when the operator cancels", async () => {
-    const request = vi.fn(async () => ({ ok: true }));
+    const request = dialogs.mockRequest(async () => ({ ok: true }));
     const { pane } = createTestChatPane({
       client: createGatewayBrowserClientFixture({ request }),
       sessions: createSessionCapabilityFixture(),
@@ -356,7 +358,7 @@ describe("chat pane worker stop", () => {
       targetKind: "device",
     });
 
-    const reclaim = pane.reclaimHeaderPlacement(session);
+    const reclaim = dialogs.track(pane.reclaimHeaderPlacement(session));
     const actions = await waitForConfirmDialogActions();
     answerConfirmDialog(actions, "cancel");
     await reclaim;
@@ -366,7 +368,7 @@ describe("chat pane worker stop", () => {
   });
 
   it("does not reclaim after the connection changes while confirmation is open", async () => {
-    const request = vi.fn(async () => ({ ok: true }));
+    const request = dialogs.mockRequest(async () => ({ ok: true }));
     const { pane, state } = createTestChatPane({
       client: createGatewayBrowserClientFixture({ request }),
       sessions: createSessionCapabilityFixture(),
@@ -392,7 +394,7 @@ describe("chat pane worker stop", () => {
       targetKind: "device",
     });
 
-    const reclaim = pane.reclaimHeaderPlacement(session);
+    const reclaim = dialogs.track(pane.reclaimHeaderPlacement(session));
     const actions = await waitForConfirmDialogActions();
     pane.connectionGeneration += 1;
     answerConfirmDialog(actions, "confirm");
@@ -405,7 +407,7 @@ describe("chat pane worker stop", () => {
   });
 
   it("publishes a reclaim failure for the current presentation", async () => {
-    const request = vi.fn(async () => {
+    const request = dialogs.mockRequest(async () => {
       throw new Error("reclaim failed");
     });
     const { pane, state } = createTestChatPane({
@@ -418,7 +420,7 @@ describe("chat pane worker stop", () => {
     );
     const session = activePlacementSession();
 
-    const reclaim = pane.reclaimHeaderPlacement(session);
+    const reclaim = dialogs.track(pane.reclaimHeaderPlacement(session));
     const actions = await waitForConfirmDialogActions();
     answerConfirmDialog(actions, "confirm");
     await reclaim;
@@ -428,8 +430,8 @@ describe("chat pane worker stop", () => {
   });
 
   it("does not publish a reclaim failure after leaving and returning", async () => {
-    const response = createDeferred<never>();
-    const request = vi.fn(() => response.promise);
+    const response = createDeferred<{ ok: true }>();
+    const request = dialogs.mockRequest(() => response.promise);
     const { pane, state } = createTestChatPane({
       client: createGatewayBrowserClientFixture({ request }),
       sessions: createSessionCapabilityFixture(),
@@ -440,22 +442,26 @@ describe("chat pane worker stop", () => {
     );
     const session = activePlacementSession();
 
-    const reclaim = pane.reclaimHeaderPlacement(session);
-    const actions = await waitForConfirmDialogActions();
-    answerConfirmDialog(actions, "confirm");
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-    pane.presented = false;
-    pane.presented = true;
-    response.reject(new Error("stale reclaim failed"));
-    await reclaim;
+    try {
+      const reclaim = dialogs.track(pane.reclaimHeaderPlacement(session));
+      const actions = await waitForConfirmDialogActions();
+      answerConfirmDialog(actions, "confirm");
+      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+      pane.presented = false;
+      pane.presented = true;
+      response.reject(new Error("stale reclaim failed"));
+      await reclaim;
 
-    expect(state.lastError).toBeNull();
-    expect(state.chatError).toBeNull();
+      expect(state.lastError).toBeNull();
+      expect(state.chatError).toBeNull();
+    } finally {
+      response.resolve({ ok: true });
+    }
   });
 
   it("keeps reclaim progress with its session when the pane switches rows", async () => {
     const response = createDeferred<{ ok: true }>();
-    const request = vi.fn(() => response.promise);
+    const request = dialogs.mockRequest(() => response.promise);
     const refreshReplacement = vi.fn(async () => undefined);
     const { pane, state } = createTestChatPane({
       client: createGatewayBrowserClientFixture({ request }),
@@ -476,30 +482,34 @@ describe("chat pane worker stop", () => {
       },
     } satisfies GatewaySessionRow;
 
-    const pendingReclaim = pane.reclaimHeaderPlacement(sessionA);
-    const actions = await waitForConfirmDialogActions();
-    answerConfirmDialog(actions, "confirm");
-    await vi.waitFor(() => expect(pane.headerPlacementReclaimingKey).toBe(sessionA.key));
+    try {
+      const pendingReclaim = dialogs.track(pane.reclaimHeaderPlacement(sessionA));
+      const actions = await waitForConfirmDialogActions();
+      answerConfirmDialog(actions, "confirm");
+      await vi.waitFor(() => expect(pane.headerPlacementReclaimingKey).toBe(sessionA.key));
 
-    state.sessionKey = sessionB.key;
-    const placementA = resolveChatPanePlacement({
-      gatewaySnapshot: pane.context.gateway.snapshot,
-      movingKey: null,
-      reclaimingKey: pane.headerPlacementReclaimingKey,
-      row: sessionA,
-    });
-    const placementB = resolveChatPanePlacement({
-      gatewaySnapshot: pane.context.gateway.snapshot,
-      movingKey: null,
-      reclaimingKey: pane.headerPlacementReclaimingKey,
-      row: sessionB,
-    });
-    expect(placementA.reclaimDisabledReason).toBe(t("common.loading"));
-    expect(placementB.reclaimDisabledReason).toBeUndefined();
+      state.sessionKey = sessionB.key;
+      const placementA = resolveChatPanePlacement({
+        gatewaySnapshot: pane.context.gateway.snapshot,
+        movingKey: null,
+        reclaimingKey: pane.headerPlacementReclaimingKey,
+        row: sessionA,
+      });
+      const placementB = resolveChatPanePlacement({
+        gatewaySnapshot: pane.context.gateway.snapshot,
+        movingKey: null,
+        reclaimingKey: pane.headerPlacementReclaimingKey,
+        row: sessionB,
+      });
+      expect(placementA.reclaimDisabledReason).toBe(t("common.loading"));
+      expect(placementB.reclaimDisabledReason).toBeUndefined();
 
-    response.resolve({ ok: true });
-    await pendingReclaim;
+      response.resolve({ ok: true });
+      await pendingReclaim;
 
-    expect(pane.headerPlacementReclaimingKey).toBeNull();
+      expect(pane.headerPlacementReclaimingKey).toBeNull();
+    } finally {
+      response.resolve({ ok: true });
+    }
   });
 });

--- a/ui/src/pages/devices/devices-page.test.ts
+++ b/ui/src/pages/devices/devices-page.test.ts
@@ -18,7 +18,7 @@ import {
   deviceDesktopEnvironments,
 } from "../../test-helpers/devices-fixtures.ts";
 import {
-  installDialogPolyfill,
+  createModalDialogTestFixture,
   waitForRenderedModalDialog,
 } from "../../test-helpers/modal-dialog.ts";
 import "./devices-page.ts";
@@ -61,6 +61,7 @@ type TestDevicesPage = HTMLElement & {
 };
 
 const ROTATED_TOKEN = "rotated-operator-token";
+let dialogs: ReturnType<typeof createModalDialogTestFixture>;
 /** Keep the identity fingerprint off jsdom's absent SubtleCrypto. */
 function stubLocalDeviceIdentity() {
   localStorage.setItem(
@@ -76,7 +77,7 @@ function rotatingClient(token: string | null): GatewayBrowserClient {
   // Answer for the grant that was actually requested, the way the Gateway does: the page now
   // refuses a result naming a different device or role, so a hardcoded id would report a
   // rotation of some other device as this one's.
-  const request = vi.fn(async (method: string, params?: unknown) => {
+  const request = dialogs.mockRequest(async (method: string, params?: unknown) => {
     if (method !== "device.token.rotate") {
       return { paired: [], pending: [] };
     }
@@ -168,10 +169,10 @@ function gateway(
   } as unknown as ApplicationContext["gateway"];
 }
 
-function mountInventoryPage(snapshot: ApplicationGatewaySnapshot) {
+function mountInventoryPage(currentGateway: ApplicationContext["gateway"]) {
   const page = document.createElement("openclaw-devices-page") as TestDevicesPage;
   page.context = {
-    gateway: gateway(snapshot.client, snapshot),
+    gateway: currentGateway,
     runtimeConfig: {
       state: { configSnapshot: {}, configLoading: false },
       subscribe: vi.fn(() => () => undefined),
@@ -198,18 +199,22 @@ function inventorySnapshot(
 }
 
 describe("DevicesPage gateway lifecycle", () => {
-  let restoreDialogPolyfill: () => void;
-
   beforeEach(() => {
-    restoreDialogPolyfill = installDialogPolyfill();
+    dialogs = createModalDialogTestFixture((modal) => {
+      // Devices defaults cancel destructive prompts or acknowledge a synthetic
+      // rotation outcome. A shown token deliberately refuses modal-cancel.
+      modal.querySelector<HTMLButtonElement>(".exec-approval-actions button[autofocus]")?.click();
+    });
   });
 
-  afterEach(() => {
-    document.body.replaceChildren();
-    restoreDialogPolyfill();
-    localStorage.clear();
-    vi.useRealTimers();
-    vi.unstubAllGlobals();
+  afterEach(async () => {
+    try {
+      await dialogs.cleanup();
+    } finally {
+      localStorage.clear();
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
   });
 
   it("preserves matching initial route data, then resets it on provider replacement", () => {
@@ -281,15 +286,7 @@ describe("DevicesPage gateway lifecycle", () => {
         onEvent = listener as typeof onEvent;
         return () => undefined;
       });
-      const page = document.createElement("openclaw-devices-page") as TestDevicesPage;
-      page.context = {
-        gateway: currentGateway,
-        runtimeConfig: {
-          state: { configSnapshot: {}, configLoading: false },
-          subscribe: vi.fn(() => () => undefined),
-        },
-      } as unknown as ApplicationContext;
-      document.body.append(page);
+      const page = mountInventoryPage(currentGateway);
       await vi.waitFor(() => expect(onEvent).toBeDefined());
       const previousNodes = [{ nodeId: "node-1", displayName: "Office Mac", connected: false }];
       page.pageState.nodes = previousNodes;
@@ -329,7 +326,9 @@ describe("DevicesPage gateway lifecycle", () => {
       method === "system.info" ? deviceSystemInfo : { environments: deviceDesktopEnvironments },
     );
     const client = { request } as unknown as GatewayBrowserClient;
-    const page = mountInventoryPage(inventorySnapshot(client, scenario.methods, scenario.scopes));
+    const page = mountInventoryPage(
+      gateway(client, inventorySnapshot(client, scenario.methods, scenario.scopes)),
+    );
     await page.updateComplete;
     await vi.waitFor(() => {
       expect(page.gatewaySystemInfo).toEqual(scenario.systemInfo ? deviceSystemInfo : null);
@@ -355,7 +354,9 @@ describe("DevicesPage gateway lifecycle", () => {
       return { nodes: [], paired: [], pending: [] };
     });
     const client = { request } as unknown as GatewayBrowserClient;
-    const page = mountInventoryPage(inventorySnapshot(client, ["system.info", "desktop.observe"]));
+    const page = mountInventoryPage(
+      gateway(client, inventorySnapshot(client, ["system.info", "desktop.observe"])),
+    );
     await page.updateComplete;
     await vi.advanceTimersByTimeAsync(0);
     request.mockClear();
@@ -389,7 +390,7 @@ describe("DevicesPage gateway lifecycle", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const snapshot = inventorySnapshot(client, ["system.info"]);
-    const page = mountInventoryPage(snapshot);
+    const page = mountInventoryPage(gateway(client, snapshot));
     await page.updateComplete;
     await vi.advanceTimersByTimeAsync(120_000);
     expect(request.mock.calls.filter(([method]) => method === "system.info")).toHaveLength(1);
@@ -411,7 +412,7 @@ describe("DevicesPage gateway lifecycle", () => {
       );
       const client = { request } as unknown as GatewayBrowserClient;
       const snapshot = inventorySnapshot(client, ["system.info", "desktop.observe"]);
-      const page = mountInventoryPage(snapshot);
+      const page = mountInventoryPage(gateway(client, snapshot));
       await page.updateComplete;
       expect(request).toHaveBeenCalledTimes(2);
       if (transition === "detach") {
@@ -583,15 +584,7 @@ describe("DevicesPage gateway lifecycle", () => {
       onEvent = listener as typeof onEvent;
       return () => undefined;
     });
-    const page = document.createElement("openclaw-devices-page") as TestDevicesPage;
-    page.context = {
-      gateway: currentGateway,
-      runtimeConfig: {
-        state: { configSnapshot: {}, configLoading: false },
-        subscribe: vi.fn(() => () => undefined),
-      },
-    } as unknown as ApplicationContext;
-    document.body.append(page);
+    const page = mountInventoryPage(currentGateway);
     await vi.waitFor(() => expect(onEvent).toBeDefined());
     const nodeListCallsBefore = request.mock.calls.filter(([method]) => method === "node.list");
 
@@ -684,15 +677,7 @@ describe("DevicesPage gateway lifecycle", () => {
       onEvent = listener as typeof onEvent;
       return () => undefined;
     });
-    const page = document.createElement("openclaw-devices-page") as TestDevicesPage;
-    page.context = {
-      gateway: currentGateway,
-      runtimeConfig: {
-        state: { configSnapshot: {}, configLoading: false },
-        subscribe: vi.fn(() => () => undefined),
-      },
-    } as unknown as ApplicationContext;
-    document.body.append(page);
+    const page = mountInventoryPage(currentGateway);
     await vi.waitFor(() => expect(onEvent).toBeDefined());
 
     const nodePresence: PresenceEntry = {
@@ -742,15 +727,7 @@ describe("DevicesPage gateway lifecycle", () => {
       onEvent = listener as typeof onEvent;
       return () => undefined;
     });
-    const page = document.createElement("openclaw-devices-page") as TestDevicesPage;
-    page.context = {
-      gateway: currentGateway,
-      runtimeConfig: {
-        state: { configSnapshot: {}, configLoading: false },
-        subscribe: vi.fn(() => () => undefined),
-      },
-    } as unknown as ApplicationContext;
-    document.body.append(page);
+    const page = mountInventoryPage(currentGateway);
     await vi.waitFor(() => expect(onEvent).toBeDefined());
 
     const presence: PresenceEntry[] = [
@@ -877,10 +854,12 @@ describe("DevicesPage gateway lifecycle", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const page = createConnectedPage(client);
 
-    const pending = page.confirmInventoryRemoval({
-      kind: "entry",
-      entry: { id: "device-1", name: "Browser", removeNode: false, removeDevice: true },
-    });
+    const pending = dialogs.track(
+      page.confirmInventoryRemoval({
+        kind: "entry",
+        entry: { id: "device-1", name: "Browser", removeNode: false, removeDevice: true },
+      }),
+    );
     await waitForRenderedModalDialog(document.body);
 
     applyGatewaySnapshot(page, gatewaySnapshot(client, false));
@@ -895,7 +874,7 @@ describe("DevicesPage gateway lifecycle", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const page = createConnectedPage(client);
 
-    const pending = page.confirmPairingReject("device", "request-1");
+    const pending = dialogs.track(page.confirmPairingReject("device", "request-1"));
     const { dialog } = await waitForRenderedModalDialog(document.body);
     expect(dialog.getAttribute("aria-label")).toBe(t("devices.inventory.rejectDevicePromptTitle"));
 
@@ -911,7 +890,7 @@ describe("DevicesPage gateway lifecycle", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const page = createConnectedPage(client);
 
-    const pending = page.confirmPairingReject("node", "request-2");
+    const pending = dialogs.track(page.confirmPairingReject("node", "request-2"));
     await waitForRenderedModalDialog(document.body);
 
     clickDialogButton(t("common.cancel"));
@@ -926,7 +905,7 @@ describe("DevicesPage gateway lifecycle", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const page = createConnectedPage(client);
 
-    const pending = page.confirmTokenRevoke("device-1", "operator");
+    const pending = dialogs.track(page.confirmTokenRevoke("device-1", "operator"));
     const { dialog } = await waitForRenderedModalDialog(document.body);
     expect(dialog.getAttribute("aria-label")).toBe(
       t("devices.inventory.revokePromptTitle", { role: "operator" }),
@@ -947,7 +926,7 @@ describe("DevicesPage gateway lifecycle", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const page = createConnectedPage(client);
 
-    const pending = page.confirmTokenRevoke("device-1", "operator");
+    const pending = dialogs.track(page.confirmTokenRevoke("device-1", "operator"));
     await waitForRenderedModalDialog(document.body);
     const generation = page.requestGeneration;
     const downgraded = gatewaySnapshot(client, true);
@@ -976,11 +955,11 @@ describe("DevicesPage gateway lifecycle", () => {
     const page = createConnectedPage(client);
 
     let acknowledged = false;
-    const pending = page
-      .reportRotationOutcome({ id: "device-1", name: "MacBook Pro" }, "operator")
-      .then(() => {
+    const pending = dialogs.track(
+      page.reportRotationOutcome({ id: "device-1", name: "MacBook Pro" }, "operator").then(() => {
         acknowledged = true;
-      });
+      }),
+    );
     const { dialog } = await waitForRenderedModalDialog(document.body);
 
     expect(dialog.getAttribute("aria-label")).toBe(
@@ -1003,11 +982,11 @@ describe("DevicesPage gateway lifecycle", () => {
     const page = createConnectedPage(client);
 
     let acknowledged = false;
-    const pending = page
-      .reportRotationOutcome({ id: "device-1", name: "MacBook Pro" }, "operator")
-      .then(() => {
+    const pending = dialogs.track(
+      page.reportRotationOutcome({ id: "device-1", name: "MacBook Pro" }, "operator").then(() => {
         acknowledged = true;
-      });
+      }),
+    );
     const { modal, webAwesomeDialog } = await waitForRenderedModalDialog(document.body);
 
     // Escape and backdrop clicks both reach the dialog as a cancelable wa-hide, which
@@ -1029,32 +1008,39 @@ describe("DevicesPage gateway lifecycle", () => {
   it("reveals a rotated token that lands after the request generation moved on", async () => {
     stubLocalDeviceIdentity();
     const rotated = createDeferred<Record<string, unknown>>();
-    const request = vi.fn(async (method: string) =>
+    const request = dialogs.mockRequest(async (method: string) =>
       method === "device.token.rotate" ? rotated.promise : { paired: [], pending: [] },
     );
     const client = { request } as unknown as GatewayBrowserClient;
     const page = createConnectedPage(client);
 
-    const pending = page.reportRotationOutcome({ id: "device-1", name: "MacBook Pro" }, "operator");
-    page.pageState.requestGeneration += 1;
-    rotated.resolve({
+    const outcome = {
       deviceId: "device-1",
       role: "operator",
       scopes: [],
       rotatedAtMs: 1_700_000_000_000,
       token: ROTATED_TOKEN,
       tokenDelivery: "in-band",
-    });
-    await waitForRenderedModalDialog(document.body);
+    };
+    try {
+      const pending = dialogs.track(
+        page.reportRotationOutcome({ id: "device-1", name: "MacBook Pro" }, "operator"),
+      );
+      page.pageState.requestGeneration += 1;
+      rotated.resolve(outcome);
+      await waitForRenderedModalDialog(document.body);
 
-    // The rotate already killed the previous credential, so a mid-flight reconnect must
-    // not swallow its replacement; the epoch guard still blocks the follow-up state writes.
-    expect(secretDialogText()).toBe(ROTATED_TOKEN);
-    expect(request).toHaveBeenCalledTimes(1);
+      // The rotate already killed the previous credential, so a mid-flight reconnect must
+      // not swallow its replacement; the epoch guard still blocks the follow-up state writes.
+      expect(secretDialogText()).toBe(ROTATED_TOKEN);
+      expect(request).toHaveBeenCalledTimes(1);
 
-    clickDialogButton(t("devices.inventory.rotateAcknowledge"));
-    await pending;
-    applyGatewaySnapshot(page, gatewaySnapshot(client, false));
+      clickDialogButton(t("devices.inventory.rotateAcknowledge"));
+      await pending;
+      applyGatewaySnapshot(page, gatewaySnapshot(client, false));
+    } finally {
+      rotated.resolve(outcome);
+    }
   });
 
   it("explains a cross-device rotation the Gateway withheld the token for", async () => {
@@ -1062,7 +1048,9 @@ describe("DevicesPage gateway lifecycle", () => {
     const client = rotatingClient(null);
     const page = createConnectedPage(client);
 
-    const pending = page.reportRotationOutcome({ id: "device-2", name: "Mac Studio" }, "operator");
+    const pending = dialogs.track(
+      page.reportRotationOutcome({ id: "device-2", name: "Mac Studio" }, "operator"),
+    );
     const { dialog } = await waitForRenderedModalDialog(document.body);
 
     // The title carries the announcement and names the device the operator clicked.
@@ -1099,7 +1087,9 @@ describe("DevicesPage gateway lifecycle", () => {
     const client = rotatingClient(null);
     const page = createConnectedPage(client);
 
-    const pending = page.reportRotationOutcome({ id: "device-2", name: "Mac Studio" }, "operator");
+    const pending = dialogs.track(
+      page.reportRotationOutcome({ id: "device-2", name: "Mac Studio" }, "operator"),
+    );
     const { webAwesomeDialog } = await waitForRenderedModalDialog(document.body);
 
     // Nothing here is unrecoverable, so Escape and backdrop settle it like any dialog

--- a/ui/src/test-helpers/modal-dialog.ts
+++ b/ui/src/test-helpers/modal-dialog.ts
@@ -48,7 +48,11 @@ async function waitForDialog<T>(read: () => T): Promise<T> {
   return vi.waitFor(read);
 }
 
-export function createModalDialogTestFixture() {
+export function createModalDialogTestFixture(
+  dismissModal: (modal: HTMLElement) => void = (modal) => {
+    modal.dispatchEvent(new CustomEvent("modal-cancel", { cancelable: true }));
+  },
+) {
   const restoreDialogPolyfill = installDialogPolyfill();
   const operations: Promise<unknown>[] = [];
   const requests: Promise<unknown>[] = [];
@@ -79,7 +83,7 @@ export function createModalDialogTestFixture() {
       captureModals();
       for (const modal of modals) {
         if (modal.parentElement) {
-          modal.dispatchEvent(new CustomEvent("modal-cancel", { cancelable: true }));
+          dismissModal(modal);
         }
       }
       const results = await Promise.allSettled(operations);


### PR DESCRIPTION
Related: #137101.

## What Problem This Solves

Resolves a problem where an early assertion failure in Stop or Devices tests left real dialog operations unfinished. A following Stop test could lose its confirmation because the previous confirmation still owned the same-file latch. A delayed token-rotation response could create a modal after the Devices test had already torn down its DOM.

## Why This Change Was Made

Both test owners now use the existing tracked modal fixture. Teardown joins pending RPCs, settles the actual dialog owner, and joins the returned operation before removing DOM and restoring globals. Held responses release in `finally`. Devices selects its existing safe default action: cancel a destructive confirmation, acknowledge a synthetic displayed token, or close an outcome-only report.

Four duplicate mounted-page setups now use the existing fixture. Production dialog code and the one-time token’s refusal to close on Escape are unchanged. No timeout increases, retries, new runtime test hooks, or weaker assertions.

## User Impact

No product behavior changes. Test failures no longer leave these two dialog owners running or manufacture a second failure during the next test.

## Evidence

Controlled probes use the canonical UI configuration/runner and external test-only transforms; no fault injection is committed.

- **Unanswered Stop confirmation:** abort the existing cancellation test after its real confirmation opens, then run its unchanged immediate successor in the original same-file order. Baseline: both fail. Candidate: only the injected failure remains; the successor passes.
- **Late Devices rotation:** hold the existing mocked rotation reply for 200 ms and abort before awaiting its outcome. Baseline: after teardown the operation is unfinished, then the reply creates a late modal. Candidate: teardown finishes the operation; both immediate and later observations have zero modals and no unhandled errors.
- **Displayed synthetic token:** abort after the real in-band token dialog opens. Candidate cleanup explicitly acknowledges and joins it, with zero remaining modals or unhandled errors. Existing normal cancellation-refusal assertions still pass.

All 97 normal cases across placement, restart, Stop, and Devices passed with no skips. The changed-file gate passed formatting, typechecks, lint, i18n, dependency/coercion, and dead-export checks. A prior max-lines failure was fixed by consolidating repeated mounted-page setup, not by suppressing the check or deleting tests.

Independent Codex P0–P2 review is clean. Its safe-input filter excluded an unchanged secret-reveal source file; that limitation was disclosed, without bypassing the filter. The reviewer had the allowed caller and behavior evidence, and the lead directly inspected the unchanged owner.

Production delta: 0. Test files: +139/−139 (net 0). Existing test support: +6/−2 (net +4). This proves these two owners; it does not claim cross-file module persistence or that every unrelated dialog fixture is fixed.
