### PR TITLE
fix: keep Usage day totals within the selected session scope

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -521,6 +521,7 @@ This label does not change which request the approval buttons resolve.
   <Accordion title="Usage">
     - Session-derived token and estimated-cost analysis stays separate from provider billing.
     - Filter sessions with the provider, model, channel, or tool menus, or type case-insensitive `key:value` terms. Values within one category match as alternatives. Toggling a menu option preserves the other filters and their quoted text.
+    - Selecting days narrows token and cost totals to those days within the active session filters. Daily charts and exports retain that session scope. Provider/model/tool queries select matching sessions, including all usage within each matched session; hour filters select sessions active in those hours.
     - Select **Local** or **UTC** for hourly charts and peak error hours. Historical hour labels stay tied to the selected time zone, including when you view them across a daylight-saving transition.
     - Provider cards call `usage.status` and show live plan names, quota windows, balances, spend, and budgets reported by configured provider plugins.
     - A provider usage failure does not block the session/cost dashboard; unavailable provider cards show their own error state.

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createEmptyCostUsageTotals } from "../../infra/session-cost-usage-totals.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 
@@ -74,19 +75,7 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
       return [];
     }),
     loadSessionCostSummariesFromCache: vi.fn(async (params: { sessions: unknown[] }) => ({
-      summaries: params.sessions.map(() => ({
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        totalCost: 0,
-        inputCost: 0,
-        outputCost: 0,
-        cacheReadCost: 0,
-        cacheWriteCost: 0,
-        missingCostEntries: 0,
-      })),
+      summaries: params.sessions.map(() => createEmptyCostUsageTotals()),
       cacheStatus: {
         status: "fresh",
         cachedFiles: params.sessions.length,
@@ -335,17 +324,11 @@ describe("sessions.usage", () => {
         }
         const tokens = session.sessionId === "s-a" ? 10 : 20;
         return {
+          ...createEmptyCostUsageTotals(),
           input: tokens,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
           totalTokens: tokens,
           totalCost: tokens / 1000,
           inputCost: tokens / 1000,
-          outputCost: 0,
-          cacheReadCost: 0,
-          cacheWriteCost: 0,
-          missingCostEntries: 0,
         };
       }),
       cacheStatus: {
@@ -744,17 +727,11 @@ describe("sessions.usage", () => {
           const totalTokens = historical ? 10 : 20;
           const totalCost = historical ? 0.02 : 0.01;
           const totals = {
+            ...createEmptyCostUsageTotals(),
             input: totalTokens,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
             totalTokens,
             totalCost,
             inputCost: totalCost,
-            outputCost: 0,
-            cacheReadCost: 0,
-            cacheWriteCost: 0,
-            missingCostEntries: 0,
           };
           const daily = {
             ...totals,
@@ -1067,19 +1044,7 @@ describe("sessions.usage", () => {
       .mockResolvedValueOnce([]); // second agent (opus) — no extra sessions
 
     const buildUsage = (sessionId?: string) => {
-      const emptyUsage = {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        totalCost: 0,
-        inputCost: 0,
-        outputCost: 0,
-        cacheReadCost: 0,
-        cacheWriteCost: 0,
-        missingCostEntries: 0,
-      };
+      const emptyUsage = createEmptyCostUsageTotals();
       if (sessionId === "s-late") {
         // Range-filtered summary with no in-range entries: zero counts, no
         // first/last activity. Must not count as an active session.

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -716,6 +716,7 @@ describe("sessions.usage", () => {
 
   it("rolls up known session family ids when historical usage is requested", async () => {
     const storeKey = "agent:opus:main";
+    const dailySources: Array<{ missingCostByModel: Record<string, number> }> = [];
 
     await withUsageState(async (writeSessionFile) => {
       const oldSessionFile = writeSessionFile("old.jsonl.reset.2026-02-01T00-00-00.000Z");
@@ -755,8 +756,18 @@ describe("sessions.usage", () => {
             cacheWriteCost: 0,
             missingCostEntries: 0,
           };
+          const daily = {
+            ...totals,
+            date: "2026-02-01",
+            tokens: totalTokens,
+            cost: totalCost,
+            missingCostEntries: 1,
+            missingCostByModel: { "fixture/unpriced": 1 },
+          };
+          dailySources.push(daily);
           return {
             ...totals,
+            dailyBreakdown: [daily],
             messageCounts: {
               total: 1,
               user: 1,
@@ -815,6 +826,12 @@ describe("sessions.usage", () => {
           usage?: {
             totalTokens: number;
             totalCost: number;
+            dailyBreakdown?: Array<{
+              totalTokens: number;
+              totalCost: number;
+              missingCostEntries: number;
+              missingCostByModel?: Record<string, number>;
+            }>;
             messageCounts?: { total: number };
             modelUsage?: Array<{ provider?: string; model?: string }>;
             dailyModelUsage?: Array<{ provider?: string; model?: string }>;
@@ -833,6 +850,24 @@ describe("sessions.usage", () => {
       expect(result.sessions[0]?.includedSessionIds).toEqual(["current", "old"]);
       expect(result.sessions[0]?.usage?.totalTokens).toBe(30);
       expect(result.sessions[0]?.usage?.totalCost).toBeCloseTo(0.03);
+      expect(result.sessions[0]?.usage?.dailyBreakdown).toMatchObject([
+        {
+          date: "2026-02-01",
+          tokens: 30,
+          cost: 0.03,
+          totalTokens: 30,
+          totalCost: 0.03,
+          input: 30,
+          inputCost: 0.03,
+          missingCostEntries: 2,
+          missingCostByModel: { "fixture/unpriced": 2 },
+        },
+      ]);
+      expect(dailySources).toHaveLength(2);
+      expect(dailySources.map((day) => day.missingCostByModel)).toEqual([
+        { "fixture/unpriced": 1 },
+        { "fixture/unpriced": 1 },
+      ]);
       expect(result.sessions[0]?.usage?.messageCounts?.total).toBe(2);
       expect(result.sessions[0]?.usage?.toolUsage?.tools.map((tool) => tool.name)).toEqual([
         "z-first",

--- a/src/infra/session-cost-usage-rollup.ts
+++ b/src/infra/session-cost-usage-rollup.ts
@@ -348,6 +348,7 @@ function mergeDatedRows<T extends { date: string; quarterIndex?: number }>(
   left: T[] | undefined,
   right: T[] | undefined,
   add: (target: T, source: T) => void,
+  clone: (row: T) => T = (row) => ({ ...row }),
 ): T[] | undefined {
   const rows = new Map<string, T>();
   for (const row of [...(left ?? []), ...(right ?? [])]) {
@@ -356,7 +357,7 @@ function mergeDatedRows<T extends { date: string; quarterIndex?: number }>(
     if (existing) {
       add(existing, row);
     } else {
-      rows.set(key, { ...row });
+      rows.set(key, clone(row));
     }
   }
   return rows.size
@@ -480,9 +481,11 @@ export function mergeSessionCostSummaryInto(
     target.dailyBreakdown,
     source.dailyBreakdown,
     (current, row) => {
+      addCostUsageTotals(current, row);
       current.tokens += row.tokens;
       current.cost += row.cost;
     },
+    (row) => ({ ...row, ...cloneCostUsageTotals(row) }),
   );
   target.dailyMessageCounts = mergeDatedRows(
     target.dailyMessageCounts,
@@ -546,7 +549,7 @@ export function buildSessionCostSummaryFromRollup(params: {
   const tools = new Map<string, number>();
   const models = new Map<string, SessionModelUsage>();
   const activityDates = new Set<string>();
-  const dailyUsage = new Map<string, { tokens: number; cost: number }>();
+  const dailyUsage = new Map<string, CostUsageTotals>();
   const dailyMessages = new Map<string, SessionDailyMessageCounts>();
   const quarterMessages = new Map<string, SessionUtcQuarterHourMessageCounts>();
   const quarterTokens = new Map<string, SessionUtcQuarterHourTokenUsage>();
@@ -572,9 +575,8 @@ export function buildSessionCostSummaryFromRollup(params: {
     mergeTools(tools, bucket.tools);
     mergeModels(models, bucket.models);
 
-    const daily = dailyUsage.get(dayKey) ?? { tokens: 0, cost: 0 };
-    daily.tokens += bucket.totals.totalTokens;
-    daily.cost += bucket.totals.totalCost;
+    const daily = dailyUsage.get(dayKey) ?? createEmptyCostUsageTotals();
+    addCostUsageTotals(daily, bucket.totals);
     dailyUsage.set(dayKey, daily);
 
     const dailyMessage = dailyMessages.get(dayKey) ?? { date: dayKey, ...emptyMessageCounts() };
@@ -663,7 +665,7 @@ export function buildSessionCostSummaryFromRollup(params: {
         : undefined,
     activityDates: Array.from(activityDates).toSorted(),
     dailyBreakdown: Array.from(dailyUsage, ([date, usage]) =>
-      Object.assign({ date }, usage),
+      Object.assign({ date, tokens: usage.totalTokens, cost: usage.totalCost }, usage),
     ).toSorted((a, b) => a.date.localeCompare(b.date)),
     dailyMessageCounts: Array.from(dailyMessages.values()).toSorted((a, b) =>
       a.date.localeCompare(b.date),

--- a/src/infra/session-cost-usage-rollup.ts
+++ b/src/infra/session-cost-usage-rollup.ts
@@ -371,14 +371,12 @@ function mergeMessageCountSummaries(
   left: SessionMessageCounts | undefined,
   right: SessionMessageCounts | undefined,
 ): SessionMessageCounts | undefined {
-  if (!left && !right) {
-    return undefined;
+  if (!left) {
+    return right ? { ...right } : undefined;
   }
-  const counts = emptyMessageCounts();
-  for (const source of [left, right]) {
-    if (source) {
-      addMessageCounts(counts, source);
-    }
+  const counts = { ...left };
+  if (right) {
+    addMessageCounts(counts, right);
   }
   return counts;
 }
@@ -451,7 +449,6 @@ function mergeDailyModels(
     : undefined;
 }
 
-/** Merges historical session summaries through the canonical usage aggregation rules. */
 export function mergeSessionCostSummaryInto(
   target: SessionCostSummary,
   source: SessionCostSummary,

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -887,6 +887,9 @@ describe("session cost usage", () => {
 
       const sessionSummary = await loadSessionCostSummary({ sessionFile });
       expect(sessionSummary?.missingCostByModel).toEqual(summary.totals.missingCostByModel);
+      expect(sessionSummary?.dailyBreakdown?.[0]?.missingCostByModel).toEqual(
+        summary.totals.missingCostByModel,
+      );
     });
   });
 
@@ -987,7 +990,9 @@ describe("session cost usage", () => {
     });
 
     expect(ranged?.totalTokens).toBe(20);
-    expect(ranged?.dailyBreakdown).toEqual([{ date: "2026-02-05", tokens: 20, cost: 0.02 }]);
+    expect(ranged?.dailyBreakdown).toMatchObject([
+      { date: "2026-02-05", tokens: 20, cost: 0.02, totalTokens: 20, totalCost: 0.02 },
+    ]);
     expect(ranged?.modelUsage?.map((entry) => entry.model)).toEqual(["gpt-5.5"]);
 
     const upperBounded = await loadSessionCostSummary({ sessionFile, endMs: rangeEndMs });
@@ -2106,7 +2111,9 @@ describe("session cost usage", () => {
       const global = await loadCostUsageSummary({ agentId: "main", ...range });
 
       expect(direct?.totalTokens).toBe(20);
-      expect(direct?.dailyBreakdown).toEqual([{ date: "2026-02-01", tokens: 20, cost: 0.02 }]);
+      expect(direct?.dailyBreakdown).toMatchObject([
+        { date: "2026-02-01", tokens: 20, cost: 0.02, totalTokens: 20, totalCost: 0.02 },
+      ]);
       expect(global.totals.totalTokens).toBe(20);
     });
   });
@@ -2171,6 +2178,17 @@ describe("session cost usage", () => {
     const summary = await loadSessionCostSummary({ sessionFile });
     expect(summary?.totalTokens).toBe(99);
     expect(summary?.dailyBreakdown?.[0]?.tokens).toBe(99);
+    expect(summary?.dailyBreakdown?.[0]).toMatchObject({
+      input: 1,
+      output: 2,
+      totalTokens: 99,
+      totalCost: 0.099,
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+    });
     expect(summary?.dailyModelUsage?.[0]?.tokens).toBe(99);
     expect(summary?.utcQuarterHourTokenUsage?.[0]?.totalTokens).toBe(99);
   });

--- a/src/infra/session-cost-usage.types.ts
+++ b/src/infra/session-cost-usage.types.ts
@@ -64,7 +64,7 @@ export type UsageDailyBucket =
   | { mode: "utc-offset"; utcOffsetMinutes: number }
   | { mode: "time-zone"; timeZone: string };
 
-type SessionDailyUsage = {
+type SessionDailyUsage = CostUsageTotals & {
   date: string; // YYYY-MM-DD
   tokens: number;
   cost: number;
@@ -87,9 +87,7 @@ export type SessionUtcQuarterHourTokenUsage = {
   cacheRead: number;
   cacheWrite: number;
   // Uses the same token total basis as CostUsageTotals: usage.total when present,
-  // otherwise input + output + cacheRead + cacheWrite. This intentionally differs
-  // from legacy dailyBreakdown.tokens, which preserves its existing component-sum
-  // behavior until daily usage buckets are refactored separately.
+  // otherwise input + output + cacheRead + cacheWrite.
   totalTokens: number;
   totalCost: number;
 };

--- a/src/shared/usage-aggregates.test.ts
+++ b/src/shared/usage-aggregates.test.ts
@@ -176,8 +176,8 @@ describe("shared/usage-aggregates", () => {
         latency: quick,
         dailyLatency: [{ date: later, ...quick }],
         dailyBreakdown: [
-          { date: later, tokens: 3, cost: 4 },
-          { date: earlier, tokens: 5, cost: 6 },
+          { ...usage({ totalTokens: 3, totalCost: 4 }), date: later, tokens: 3, cost: 4 },
+          { ...usage({ totalTokens: 5, totalCost: 6 }), date: earlier, tokens: 5, cost: 6 },
         ],
         dailyModelUsage: [
           { date: later, provider: "fixture", model: "one", tokens: 3, cost: 4, count: 2 },
@@ -191,7 +191,9 @@ describe("shared/usage-aggregates", () => {
           { date: later, ...slow },
           { date: earlier, ...slow },
         ],
-        dailyBreakdown: [{ date: later, tokens: 7, cost: 8 }],
+        dailyBreakdown: [
+          { ...usage({ totalTokens: 7, totalCost: 8 }), date: later, tokens: 7, cost: 8 },
+        ],
         dailyMessageCounts: [
           { date: later, total: 9, user: 5, assistant: 4, toolCalls: 2, toolResults: 2, errors: 1 },
         ],

--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -462,7 +462,12 @@ suite.define(() => {
                     ...totals,
                     activityDates: [selectedDay],
                     dailyBreakdown: [
-                      { date: selectedDay, cost: totals.totalCost, tokens: totals.totalTokens },
+                      {
+                        ...totals,
+                        date: selectedDay,
+                        cost: totals.totalCost,
+                        tokens: totals.totalTokens,
+                      },
                     ],
                   },
                 },
@@ -546,7 +551,7 @@ suite.define(() => {
       usage: {
         ...totals,
         activityDates: [date],
-        dailyBreakdown: [{ date, cost: totals.totalCost, tokens: totals.totalTokens }],
+        dailyBreakdown: [{ ...totals, date, cost: totals.totalCost, tokens: totals.totalTokens }],
       },
     }));
     const empty = emptyUsageResponses();
@@ -675,7 +680,7 @@ suite.define(() => {
                     ...totals,
                     activityDates: daily.map((entry) => entry.date),
                     dailyBreakdown: daily.map((entry) => ({
-                      date: entry.date,
+                      ...entry,
                       cost: entry.totalCost,
                       tokens: entry.totalTokens,
                     })),

--- a/ui/src/e2e/usage-reconnect.e2e.test.ts
+++ b/ui/src/e2e/usage-reconnect.e2e.test.ts
@@ -76,7 +76,12 @@ function sessionsUsage(
           ...usageTotals,
           activityDates: [today()],
           dailyBreakdown: [
-            { date: today(), tokens: usageTotals.totalTokens, cost: usageTotals.totalCost },
+            {
+              ...usageTotals,
+              date: today(),
+              tokens: usageTotals.totalTokens,
+              cost: usageTotals.totalCost,
+            },
           ],
           messageCounts: {
             total: 2,

--- a/ui/src/e2e/usage-session-unicode.e2e.test.ts
+++ b/ui/src/e2e/usage-session-unicode.e2e.test.ts
@@ -57,7 +57,12 @@ function usageResponse(sessionKey?: string) {
               ...usageTotals,
               activityDates: [day],
               dailyBreakdown: [
-                { date: day, tokens: usageTotals.totalTokens, cost: usageTotals.totalCost },
+                {
+                  ...usageTotals,
+                  date: day,
+                  tokens: usageTotals.totalTokens,
+                  cost: usageTotals.totalCost,
+                },
               ],
               messageCounts: {
                 total: 2,

--- a/ui/src/pages/usage/view-overview.test.ts
+++ b/ui/src/pages/usage/view-overview.test.ts
@@ -655,7 +655,9 @@ describe("renderSessionsCard", () => {
           ...totals,
           totalCost: 100,
           totalTokens: 100,
-          dailyBreakdown: [{ date: "2026-02-05", cost: 1, tokens: 1 }],
+          dailyBreakdown: [
+            { ...totals, date: "2026-02-05", cost: 1, tokens: 1, totalCost: 1, totalTokens: 1 },
+          ],
         },
       } as UsageSessionEntry,
       {
@@ -666,7 +668,9 @@ describe("renderSessionsCard", () => {
           ...totals,
           totalCost: 50,
           totalTokens: 50,
-          dailyBreakdown: [{ date: "2026-02-05", cost: 10, tokens: 10 }],
+          dailyBreakdown: [
+            { ...totals, date: "2026-02-05", cost: 10, tokens: 10, totalCost: 10, totalTokens: 10 },
+          ],
         },
       } as UsageSessionEntry,
     ];

--- a/ui/src/pages/usage/view.test.ts
+++ b/ui/src/pages/usage/view.test.ts
@@ -169,6 +169,104 @@ function createUsageProps(overrides: Partial<UsageProps> = {}): UsageProps {
   };
 }
 
+it.each([
+  { query: "provider:openai" },
+  { agentId: "main" },
+  { selectedSessions: ["agent:main:matched"] },
+  { selectedSessions: ["agent:main:matched", "agent:main:earlier"] },
+  { query: "provider:openai", selectedHours: [12] },
+])("intersects selected days with the session scope %j", (scope) => {
+  const base = createUsageProps();
+  const matched = usageSession("agent:main:matched", "main", "openai", {
+    totalTokens: 800,
+    totalCost: 80,
+  });
+  const other = usageSession("agent:other:other", "other", "anthropic", {
+    totalTokens: 900,
+    totalCost: 90,
+  });
+  const selectedDay = {
+    date: "2026-05-14",
+    tokens: 99,
+    cost: 10,
+    input: 1,
+    output: 2,
+    cacheRead: 3,
+    cacheWrite: 4,
+    totalTokens: 99,
+    totalCost: 10,
+    inputCost: 1,
+    outputCost: 2,
+    cacheReadCost: 3,
+    cacheWriteCost: 4,
+    missingCostEntries: 1,
+    missingCostByModel: { "openai/unpriced": 1 },
+  };
+  matched.usage!.activityDates = ["2026-05-13", "2026-05-14"];
+  matched.usage!.firstActivity = Date.UTC(2026, 4, 14, 12);
+  matched.usage!.lastActivity = matched.usage!.firstActivity;
+  matched.usage!.dailyBreakdown = [
+    { ...selectedDay, date: "2026-05-13", tokens: 701, cost: 70, totalTokens: 701, totalCost: 70 },
+    selectedDay,
+  ];
+  other.usage!.activityDates = ["2026-05-14"];
+  other.usage!.dailyBreakdown = [
+    { ...selectedDay, tokens: 900, cost: 90, totalTokens: 900, totalCost: 90 },
+  ];
+  const earlier = usageSession("agent:main:earlier", "main", "openai", { totalCost: 5 });
+  earlier.usage!.activityDates = ["2026-05-13"];
+  earlier.usage!.firstActivity = Date.UTC(2026, 4, 13, 12);
+  earlier.usage!.lastActivity = earlier.usage!.firstActivity;
+  earlier.usage!.dailyBreakdown = [
+    {
+      ...selectedDay,
+      date: "2026-05-13",
+      tokens: 50,
+      cost: 5,
+      totalTokens: 50,
+      totalCost: 5,
+    },
+  ];
+  const onExportJson = vi.fn();
+  const container = document.createElement("div");
+  render(
+    renderUsage(
+      createUsageProps({
+        data: {
+          ...base.data,
+          sessions: [matched, other, earlier],
+          totals: { ...selectedDay, totalCost: 170 },
+          costDaily: [{ ...selectedDay, totalTokens: 999, totalCost: 100 }],
+        },
+        filters: { ...base.filters, ...scope, timeZone: "utc", selectedDays: [selectedDay.date] },
+        callbacks: {
+          ...base.callbacks,
+          display: { ...base.callbacks.display, onExportJson },
+        },
+      }),
+    ),
+    container,
+  );
+  expect(
+    [...container.querySelectorAll(".usage-metric-badge strong")].map((el) => el.textContent),
+  ).toEqual(["99", "$10.00", "1"]);
+  container.querySelector(".usage-export-menu")!.dispatchEvent(
+    new CustomEvent("wa-select", {
+      detail: { item: { value: "json" } },
+    }),
+  );
+  const { date, tokens: _tokens, cost: _cost, ...expectedTotals } = selectedDay;
+  expect(onExportJson.mock.calls[0]?.[0].totals).toEqual(expectedTotals);
+  expect(
+    onExportJson.mock.calls[0]?.[0].daily.find(
+      (day: { date: string }) => day.date === "2026-05-13",
+    ),
+  ).toMatchObject({ totalCost: scope.selectedSessions?.length === 1 ? 70 : 75 });
+  expect(onExportJson.mock.calls[0]?.[0].daily).toEqual(
+    expect.arrayContaining([{ date, ...expectedTotals }]),
+  );
+});
+
 it("renders shared skeletons while initial usage is loading", () => {
   const container = document.createElement("div");
   const props = createUsageProps();

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -178,30 +178,25 @@ export function renderUsage(props: UsageProps) {
       )
     : sortedSessions;
 
-  // Filter sessions by selected days
-  const dayFilteredSessions =
-    selectedDaySet.size > 0
-      ? agentScopedSessions.filter((s) => {
-          if (s.usage?.activityDates?.length) {
-            return s.usage.activityDates.some((d) => selectedDaySet.has(d));
-          }
-          if (!s.updatedAt) {
-            return false;
-          }
-          return selectedDaySet.has(usageDateKey(s.updatedAt, filters.timeZone));
-        })
-      : agentScopedSessions;
-
   const hourFilteredSessions =
     filters.selectedHours.length > 0
-      ? dayFilteredSessions.filter((s) =>
-          sessionTouchesSelectedHours(s, filters.selectedHours, filters.timeZone),
+      ? agentScopedSessions.filter((session) =>
+          sessionTouchesSelectedHours(session, filters.selectedHours, filters.timeZone),
         )
-      : dayFilteredSessions;
-
-  // Filter sessions by query (client-side)
+      : agentScopedSessions;
   const queryResult = filterSessionsByQuery(hourFilteredSessions, filters.query);
-  const filteredSessions = queryResult.sessions;
+  const matchesSelectedDays = (session: UsageSessionEntry) => {
+    if (selectedDaySet.size === 0) {
+      return true;
+    }
+    if (session.usage?.activityDates?.length) {
+      return session.usage.activityDates.some((date) => selectedDaySet.has(date));
+    }
+    return Boolean(
+      session.updatedAt && selectedDaySet.has(usageDateKey(session.updatedAt, filters.timeZone)),
+    );
+  };
+  const filteredSessions = queryResult.sessions.filter(matchesSelectedDays);
   const queryWarnings = queryResult.warnings;
   const querySuggestions = buildQuerySuggestions(
     filters.queryDraft,
@@ -247,77 +242,54 @@ export function renderUsage(props: UsageProps) {
         filteredSessions.find((s) => s.key === filters.selectedSessions[0]))
       : null;
 
-  // Compute totals from sessions
-  const computeSessionTotals = (sessions: UsageSessionEntry[]): UsageTotals => {
-    const totals = createEmptyCostUsageTotals();
-    for (const session of sessions) {
-      if (session.usage) {
-        addCostUsageTotals(totals, session.usage);
-      }
-    }
-    return totals;
-  };
-
-  // Compute totals from daily data for selected days (more accurate than session totals)
-  const computeDailyTotals = (days: ReadonlySet<string>): UsageTotals => {
-    const totals = createEmptyCostUsageTotals();
-    for (const day of data.costDaily) {
-      if (days.has(day.date)) {
-        addCostUsageTotals(totals, day);
-      }
-    }
-    return totals;
-  };
-
-  // Compute display totals and count based on filters
-  let displayTotals: UsageTotals | null;
-  let displaySessionCount: number;
-  const totalSessions = agentScopedSessions.length;
-
-  if (filters.selectedSessions.length > 0) {
-    // Sessions selected - compute totals from selected sessions
-    const selectedSessionEntries = filteredSessions.filter((s) => selectedSessionSet.has(s.key));
-    displayTotals = computeSessionTotals(selectedSessionEntries);
-    displaySessionCount = selectedSessionEntries.length;
-  } else if (filters.selectedDays.length > 0 && filters.selectedHours.length === 0) {
-    // Days selected - use daily aggregates for accurate per-day totals
-    displayTotals = computeDailyTotals(selectedDaySet);
-    displaySessionCount = filteredSessions.length;
-  } else if (filters.selectedHours.length > 0) {
-    displayTotals = computeSessionTotals(filteredSessions);
-    displaySessionCount = filteredSessions.length;
-  } else if (hasQuery) {
-    displayTotals = computeSessionTotals(filteredSessions);
-    displaySessionCount = filteredSessions.length;
-  } else if (filters.agentId) {
-    displayTotals = computeSessionTotals(agentScopedSessions);
-    displaySessionCount = totalSessions;
-  } else {
-    // No filters - show all
-    displayTotals = data.totals;
-    displaySessionCount = totalSessions;
-  }
-
-  const aggregateSessions =
-    filters.selectedSessions.length > 0
-      ? filteredSessions.filter((s) => selectedSessionSet.has(s.key))
-      : hasQuery || filters.selectedHours.length > 0
-        ? filteredSessions
-        : filters.selectedDays.length > 0
-          ? dayFilteredSessions
-          : agentScopedSessions;
-  const hasAggregateFilters =
-    filters.selectedSessions.length > 0 ||
+  const scopedSessions = selectedSessionSet.size
+    ? queryResult.sessions.filter((session) => selectedSessionSet.has(session.key))
+    : queryResult.sessions;
+  const aggregateSessions = scopedSessions.filter(matchesSelectedDays);
+  const hasSessionFilters =
+    selectedSessionSet.size > 0 ||
     hasQuery ||
     filters.selectedHours.length > 0 ||
-    filters.selectedDays.length > 0 ||
     Boolean(filters.agentId);
+  const hasAggregateFilters = hasSessionFilters || selectedDaySet.size > 0;
+  const computeTotals = (sources: Iterable<UsageTotals | null | undefined>): UsageTotals => {
+    const totals = createEmptyCostUsageTotals();
+    for (const source of sources) {
+      if (source) {
+        addCostUsageTotals(totals, source);
+      }
+    }
+    return totals;
+  };
+  // Keep global daily totals when no row scope is active: the visible session page can be capped.
+  const filteredDaily = hasSessionFilters
+    ? (() => {
+        const days = new Map<string, UsageTotals>();
+        for (const session of scopedSessions) {
+          for (const day of session.usage?.dailyBreakdown ?? []) {
+            const totals = days.get(day.date) ?? createEmptyCostUsageTotals();
+            addCostUsageTotals(totals, day);
+            days.set(day.date, totals);
+          }
+        }
+        return Array.from(days, ([date, totals]) => ({ date, ...totals })).toSorted((a, b) =>
+          a.date.localeCompare(b.date),
+        );
+      })()
+    : data.costDaily;
+  const displayTotals = selectedDaySet.size
+    ? computeTotals(filteredDaily.filter((day) => selectedDaySet.has(day.date)))
+    : hasSessionFilters
+      ? computeTotals(aggregateSessions.map((session) => session.usage))
+      : data.totals;
+  const displaySessionCount = aggregateSessions.length;
+  const totalSessions = agentScopedSessions.length;
   const activeAggregates = hasAggregateFilters
     ? buildAggregatesFromSessions(aggregateSessions)
     : buildAggregatesFromSessions([], data.aggregates);
   const insightsUseVisiblePage = data.sessionsLimitReached && !hasAggregateFilters;
   const insightTotals = insightsUseVisiblePage
-    ? computeSessionTotals(aggregateSessions)
+    ? computeTotals(aggregateSessions.map((session) => session.usage))
     : displayTotals;
   const insightAggregates = insightsUseVisiblePage
     ? buildAggregatesFromSessions(aggregateSessions)
@@ -326,23 +298,6 @@ export function renderUsage(props: UsageProps) {
   const costWindowComparison = hasAggregateFilters
     ? nothing
     : renderCostWindowComparison(data.costDaily, filters.startDate, filters.endDate);
-
-  // Filter daily chart data if sessions are selected
-  const filteredDaily =
-    filters.selectedSessions.length > 0
-      ? (() => {
-          const selectedEntries = filteredSessions.filter((s) => selectedSessionSet.has(s.key));
-          const allActivityDates = new Set<string>();
-          for (const entry of selectedEntries) {
-            for (const date of entry.usage?.activityDates ?? []) {
-              allActivityDates.add(date);
-            }
-          }
-          return allActivityDates.size > 0
-            ? data.costDaily.filter((d) => allActivityDates.has(d.date))
-            : data.costDaily;
-        })()
-      : data.costDaily;
 
   const insightStats = buildUsageInsightStats(aggregateSessions, insightTotals, insightAggregates);
   // The gateway always returns a totals object (all-zero when idle), so key


### PR DESCRIPTION
Closes #137388

## What Problem This Solves

Fixes an issue where selecting a Usage day discarded the active provider, agent, or session scope. An OpenAI session with $70 yesterday and $10 today, alongside another provider's $90 today, showed $100 or $80 instead of $10.

## Why This Change Was Made

The existing timestamped rollup already contains exact token components, cost components and missing-price attribution. Preserve those facts in the daily session summary and merge them through the existing family owner. The view now resolves the session scope once, then applies day selection to accounting totals. Daily charts keep matching sessions' history throughout the requested range.

This removes the competing global-day and whole-session total branches. The existing `date`, `tokens`, and `cost` response fields remain; complete accounting fields are additive. No schema, stored format, cache version, request fanout, pricing, or query grammar changes.

## User Impact

Headers, cost breakdowns and exported accounting totals agree with the selected days and sessions. Daily charts and daily exports honor the active session scope. Queries still select whole matching sessions; hour filters still select sessions active in those hours. Unfiltered global totals remain accurate when the visible session page is capped.

## Evidence

Final exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/33778764552) passed.

- Five query/agent/hour/session selection variants pass; the original four cases failed on current main with $100 or $80 instead of $10.
- A review regression caught loss of an earlier-only matching session from daily charts; it failed before the scope refinement and now passes.
- Backend producer, family aggregation and shared aggregate suites pass, including exact provider token totals and non-mutating missing-price maps.
- Focused UI view/overview/metrics tests, ten existing Usage browser E2E cases, UI type checking and canonical UI build pass.
- Independent Codex autoreview is clean through P2 after the chart-scope correction.
- Production LOC: +67/−115 (**−48 net**). Tests: +189/−52. Docs: +1.

Live browser verification used the normal Gateway and its production UI, canonical SQLite sessions/rollups, and explicitly authorized isolated Chromium. There was no transport mocking or provider call. Exact source and served JavaScript hashes were verified before and after. Both final runs completed with zero page or console errors.

| Interaction | Baseline | Fixed head |
|---|---:|---:|
| OpenAI scope, both days | $80 / 800 tokens | $80 / 807 tokens |
| Select September 3 | $100 / 1,000 tokens | $10 / 107 tokens |
| Also select the spanning session | $80 / 800 tokens | $10 / 107 tokens |
| Clear session, day, then query | Original behavior reproduced | Correct scoped and global totals restored |

The candidate deliberately adds seven unpriced input tokens to the otherwise shared fixture; costs are unchanged. JSON and Daily CSV were downloaded through the real Export menu. Their daily rows retain both requested dates and the selected session scope. The JSON headline remains the selected-day intersection. Excerpt of the actual candidate download:

```json
{
  "totals": {
    "input": 47,
    "output": 30,
    "cacheRead": 20,
    "cacheWrite": 10,
    "totalTokens": 107,
    "totalCost": 10,
    "inputCost": 4,
    "outputCost": 3,
    "cacheReadCost": 2,
    "cacheWriteCost": 1,
    "missingCostEntries": 1,
    "missingCostByModel": {
      "openai/qa-unpriced-model": 1
    }
  },
  "daily": [
    {
      "date": "2026-09-02",
      "totalTokens": 700,
      "totalCost": 70
    },
    {
      "date": "2026-09-03",
      "totalTokens": 107,
      "totalCost": 10
    }
  ]
}
```

Download SHA-256: `41447657f78e6d6cecb4704a839665c9804f0298f3641fde392efc2555bdb21d` (JSON), `00a9b400502178a4b1d9f3d5b6b35c813cd8cbf7ee4555aba749fc68dde38261` (Daily CSV). Real Gateway RPC checks also passed before and after, including both instance and family summaries.

The final synthetic profile and screenshots were inspected before upload. Initial proof attempts were retained: expected missing-avatar 404s failed the blanket diagnostics assertion; supplying a synthetic avatar through `users.setAvatar` resolved the fixture without changing production or weakening assertions.

**Before: provider plus selected day**

![Before: global day total incorrectly shows $100](https://github.com/user-attachments/assets/1d170afe-5d66-4780-aa6e-075ecd123698)

**Before: adding session selection**

![Before: whole-session total incorrectly shows $80](https://github.com/user-attachments/assets/5e3ec1c2-63ef-40b7-9db1-76fb5a91e2f9)

**After: day and session intersection**

![After: selected day and session correctly show $10 and 107 tokens](https://github.com/user-attachments/assets/c68b3dd9-d90d-4dda-9b87-49a3eb2503ff)

ClawSweeper follow-up: the requested exact-head selected-day and JSON daily-export evidence is provided above. Its latest review has no code findings; the proof gap is resolved. A fresh complete-branch Codex autoreview remains clean through P2.
