### PR TITLE
fix: keep restored Usage navigation from being replaced by Chat

### DIFF
--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -102,6 +102,11 @@ unknown values stay on stable app builds.
 
 ## Open dashboard links
 
+Opening the embedded dashboard at its default Chat landing restores the last
+page you visited, such as **Usage**, for that Gateway origin. Explicit session
+links and navigation requests take precedence over the remembered page, and
+first-run model setup still runs when needed.
+
 In the macOS app's embedded dashboard, clicking an external web link opens it in a resizable browser sidebar at half the window width. Drag the divider in either direction to choose another width; the app remembers it. Widening the browser lets the dashboard switch to compact navigation, with a 400-point minimum for the dashboard and a 320-point minimum for the browser. Each link opens in its own tab, the tab strip appears when multiple pages are open, and clicking the same link again reuses its existing tab. Drag tabs to reorder them, close them with the tab close button or a middle-click, and right-click a tab for **Open in Default Browser**, **Copy Link**, **Reload**, **Close Tab**, and **Close Other Tabs**. The window's titlebar back/forward controls and trackpad swipes navigate dashboard history; the sidebar's own back/forward controls navigate the active tab's history. The sidebar also has reload, open-in-default-browser, and close controls.
 
 The titlebar controls follow the app sidebar: while it is expanded, back/forward sit at its right edge next to the sidebar toggle; while it is collapsed, they make way for a search button (opens the command palette) and a new-session button.

--- a/ui/src/app/router-outlet-controller.test.ts
+++ b/ui/src/app/router-outlet-controller.test.ts
@@ -237,8 +237,8 @@ describe("RouterOutletController not-found boundary", () => {
           id: "first",
           path: "/first",
           component: () => module("first"),
-          loader: () => {
-            throw { type: "notFound" };
+          loader: (): TestData => {
+            throw Object.assign(new Error("Initial route not found"), { type: "notFound" });
           },
         }),
         definePage({

--- a/ui/src/app/router-outlet-controller.test.ts
+++ b/ui/src/app/router-outlet-controller.test.ts
@@ -229,6 +229,58 @@ describe("RouterOutletController not-found boundary", () => {
     router.stop();
   });
 
+  it("keeps a navigation started by an earlier not-found subscriber", async () => {
+    const secondModule = deferred<TestModule>();
+    const router = createRouter<RouteId, TestContext, TestModule, TestData>({
+      routes: [
+        definePage({
+          id: "first",
+          path: "/first",
+          component: () => module("first"),
+          loader: () => {
+            throw { type: "notFound" };
+          },
+        }),
+        definePage({
+          id: "second",
+          path: "/second",
+          component: () => secondModule.promise,
+          loader: () => ({ label: "second" }),
+        }),
+      ],
+    });
+    let recovery: Promise<void> | undefined;
+    let redirected = false;
+    const unsubscribe = router.subscribe((state) => {
+      if (state.status === "notFound" && !redirected) {
+        redirected = true;
+        recovery = router.navigate("second", { label: "test" });
+      }
+    });
+    const onNotFound = vi.fn();
+    const controller = new RouterOutletController<RouteId, TestContext, TestModule, TestData>(
+      vi.fn(),
+    );
+    controller.setInputs({ router, onNotFound });
+    controller.connect();
+    try {
+      await expect(router.navigate("first", { label: "test" })).rejects.toMatchObject({
+        type: "notFound",
+      });
+      await flushPromises();
+
+      expect(router.getState().status).toBe("loading");
+      expect(onNotFound).not.toHaveBeenCalled();
+      expect(controller.snapshot.pending?.routeId).toBe("second");
+    } finally {
+      secondModule.resolve(module("second"));
+      await recovery;
+      unsubscribe();
+      controller.disconnect();
+      router.stop();
+    }
+  });
+
   it("cancels the queued fallback on disconnect and re-evaluates it on reconnect", async () => {
     const router = createTestRouter();
     const onNotFound = vi.fn();

--- a/ui/src/app/router-outlet-controller.ts
+++ b/ui/src/app/router-outlet-controller.ts
@@ -50,17 +50,6 @@ function selectRouterOutletState<TRouteId extends string, TModule, TData>(
   };
 }
 
-function equalRouterOutletState(
-  previous: RouterOutletStateSlice,
-  next: RouterOutletStateSlice,
-): boolean {
-  return (
-    previous.status === next.status &&
-    previous.active === next.active &&
-    previous.pending === next.pending
-  );
-}
-
 function idleSnapshot<TRouteId extends string, TModule, TData>(): RouterOutletSnapshot<
   TRouteId,
   TModule,
@@ -170,10 +159,10 @@ export class RouterOutletController<
       return;
     }
     this.applySelection(selectRouterOutletState(router.getState()), notify);
-    this.unsubscribe = router.subscribeSelector(
-      selectRouterOutletState,
-      (selection) => this.applySelection(selection),
-      equalRouterOutletState,
+    // An earlier subscriber can navigate during this notification. Read the
+    // current route so its superseded not-found snapshot cannot trigger recovery.
+    this.unsubscribe = router.subscribe(() =>
+      this.applySelection(selectRouterOutletState(router.getState())),
     );
   }
 


### PR DESCRIPTION
Closes #137391

## What Problem This Solves

Fixes an issue where the native dashboard briefly restored remembered Usage, then jumped back to Chat during startup.

## Why This Change Was Made

An earlier router subscriber can start another navigation while a not-found notification is still being delivered. The outlet consumed the obsolete outer snapshot after seeing the newer navigation and queued Chat recovery. It now reads the router's current state on notification, using its existing publication comparison instead of a second selector comparison.

This repairs the shared route-presentation owner. Native route memory, explicit deep links, first-run setup, pending-page retention and recovery readiness retain their existing policies. No dependency or persistent preference changes.

## User Impact

Remembered Usage stays open. A navigation started by an earlier subscriber is no longer overwritten by recovery from a superseded route.

## Evidence

Final exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/33778941988) passed.

- A regression using the real `@openclaw/uirouter` 0.1.1 fails on main with an obsolete not-found callback while the replacement route is already loading; it passes after the repair.
- 118 focused tests across eight files pass, covering outlet timing/reconnection, retained views, native memory, deleted-session recovery and bootstrap precedence.
- The identical preserved-bundle browser probe goes from 2/3 to 3/3 passing contracts: remembered Usage, invalid stored route and explicit deep link. No page or console errors in the final before/after runs.
- Both canonical UI builds pass; independent Codex autoreview is clean through P2.
- Production LOC: +4/−15 (**−11 net**). Tests: +52. Docs: +5.

Live Gateway verification now passes on the exact head in explicitly authorized isolated Chromium. The Gateway uses canonical synthetic SQLite sessions, the real connection/route lifecycle, and its production UI; no transport mocking or provider calls. Document-start native bridge markers are simulated. This is not a signed macOS/WebKit application test.

| Entry with remembered Usage | Baseline | Fixed head |
|---|---|---|
| Default `/chat` | Ends `/chat/main`; overwrites remembered route to Chat | Ends `/usage?agent=main`; remembers Usage |
| Explicit `/chat/main/qa/usage-openai` | Exact session URL and recorded transcript retained | Exact session URL and recorded transcript retained |

All four observations pass with unchanged source/bundles and verified served JavaScript hashes. The remembered-route cases have zero page, console or HTTP errors. Each explicit-session control records one intentional missing-workspace-icon 404 and verifies the documented visible folder fallback; there are no unexpected errors. The synthetic profile and screenshots were inspected before publication.

**Before: remembered Usage is overwritten by Chat**

![Real Gateway baseline falls back to Chat](https://github.com/user-attachments/assets/f937e63c-3c77-441e-a439-d350d552dc21)

**After: remembered Usage remains open**

![Real Gateway candidate retains Usage](https://github.com/user-attachments/assets/908a8469-dbc8-4366-a0f7-4c5fafc7b975)

Direct dependency inspection confirmed `@openclaw/uirouter` 0.1.1: installed `dist/index.js:204–216` captures `next = readState()` before iterating its listener set synchronously; `dist/index.js:345–354` applies selectors to that delivered snapshot. Source SHA-256: `3f4179f5ff957232e5067142cdb0c40ca3d5cd1c77c006a38be1d52b434b58bb`. The real-router regression records this ordering:

```text
outer notFound publication captures its snapshot
  earlier shell subscriber starts Usage navigation
    nested loading publication reaches the outlet
  outer publication resumes and delivers stale notFound
before: router loading, one obsolete recovery callback
 after: router loading, no obsolete recovery callback
```

Fresh main `cd8c74889d21ddcc9f3a2d47fe868224a0e44acb` still has the identical outlet owner as the reproduced baseline. The maintainer personally inspected the dependency and current-main source, closing the review environment's source-access gaps.

ClawSweeper disposition: the real Gateway before/after media and direct notification-order evidence above address both rank-up moves and the requested proof/contract follow-ups. The macOS binary remains untested; the user explicitly authorized isolated Chromium for this completion, and the changed owner is the shared browser outlet, with native/setup policy unchanged. The fresh independent complete-branch Codex review is clean through P2. Its evidence resolves the confidence gaps; a new ClawSweeper rating is not an enforced review rule or a prerequisite under the repository's fresh-review policy.
