### PR TITLE
fix(release): include src/plugins in the trusted plugin npm tooling checkout

### DIFF
--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -497,6 +497,7 @@ jobs:
           sparse-checkout: |
             packages/normalization-core
             scripts
+            src/plugins
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -760,6 +761,7 @@ jobs:
           sparse-checkout: |
             .github/workflows
             scripts
+            src/plugins
 
       - name: Download immutable npm preflight artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -143,7 +143,7 @@ describe("plugin npm extended-stable workflow", () => {
     expect(preflightCheckout.with).toMatchObject({
       ref: "${{ github.workflow_sha }}",
       path: ".release-tooling",
-      "sparse-checkout": "packages/normalization-core\nscripts\n",
+      "sparse-checkout": "packages/normalization-core\nscripts\nsrc/plugins\n",
     });
     const pack = step(parsed.jobs?.preview_plugin_pack, "Prepare immutable npm preflight artifact");
     expect(pack.run).toContain(".release-tooling/scripts/plugin-npm-publish.sh");


### PR DESCRIPTION
## What Problem This Solves

OpenClaw Release Publish run 33776082117 (v2026.9.1) failed before publishing anything: every `preview_plugin_pack` job in the plugin npm child run 33776684661 died with `ERR_MODULE_NOT_FOUND: .release-tooling/src/plugins/package-entrypoints.ts imported from .release-tooling/scripts/lib/plugin-npm-runtime-build.mts`.

## Why This Change Was Made

#136458 made `scripts/lib/plugin-npm-runtime-build.mts` import `src/plugins/package-entrypoints.ts`, but the plugin npm release workflow checks the trusted tooling out sparsely with only `scripts` and `packages/normalization-core`. Both sparse tooling checkouts now include `src/plugins` (the imported module depends only on `node:path`).

## User Impact

Plugin npm/ClawHub publication works again for releases whose tooling includes #136458; unblocks the 2026.9.1 stable publish.

## Evidence

- Failing child: https://github.com/openclaw/openclaw/actions/runs/33776684661 (all preview_plugin_pack jobs, step "Prepare immutable npm preflight artifact").
- Import: `scripts/lib/plugin-npm-runtime-build.mts:5`.
- `git diff --check` clean; workflow-only change.
