### PR TITLE
fix(qa): preserve RTT measurement provenance

### DIFF
--- a/extensions/qa-lab/src/evidence-summary.test.ts
+++ b/extensions/qa-lab/src/evidence-summary.test.ts
@@ -124,6 +124,91 @@ describe("evidence summary", () => {
     });
   });
 
+  it("records complete structured RTT provenance and gives it canonical timing precedence", () => {
+    const rttMeasurement = {
+      finalMatchedReplyRttMs: 1750,
+      requestStartedAt: "2026-09-03T00:00:00.000Z",
+      responseObservedAt: "2026-09-03T00:00:01.750Z",
+      source: "request-to-observed-message",
+    };
+    const evidence = buildQaSuiteEvidenceSummary({
+      artifactPaths: [],
+      channelId: "slack",
+      generatedAt: "2026-09-03T00:00:02.000Z",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      providerMode: "mock-openai",
+      scenarioDefinitions: [{ id: "slack-canary", title: "Slack canary" }],
+      scenarioResults: [
+        {
+          name: "Slack canary",
+          status: "pass",
+          timing: { rttMs: 999 },
+          rttMeasurement,
+        },
+      ],
+    });
+
+    expect(evidence.schemaVersion).toBe(2);
+    expect(evidence.entries[0]?.result).toMatchObject({
+      status: "pass",
+      timing: { rttMs: 1750 },
+      rttMeasurement,
+    });
+    expect(validateQaEvidenceSummaryJson(evidence)).toEqual(evidence);
+  });
+
+  it.each([
+    ["timing only", { timing: { rttMs: 1750 } }],
+    [
+      "incomplete measurement",
+      { rttMeasurement: { finalMatchedReplyRttMs: 1750, source: "summary-rtt" } },
+    ],
+  ])("does not fabricate structured RTT provenance from %s input", (_label, resultInput) => {
+    const evidence = buildQaSuiteEvidenceSummary({
+      artifactPaths: [],
+      channelId: "slack",
+      generatedAt: "2026-09-03T00:00:02.000Z",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      providerMode: "mock-openai",
+      scenarioDefinitions: [{ id: "slack-canary", title: "Slack canary" }],
+      scenarioResults: [{ name: "Slack canary", status: "pass", ...resultInput }],
+    });
+
+    expect(evidence.entries[0]?.result.timing).toEqual({ rttMs: 1750 });
+    expect(evidence.entries[0]?.result.rttMeasurement).toBeUndefined();
+  });
+
+  it("validates structured RTT measurements as strict schema-v2 objects", () => {
+    const evidence = buildQaSuiteEvidenceSummary({
+      artifactPaths: [],
+      channelId: "slack",
+      generatedAt: "2026-09-03T00:00:02.000Z",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      providerMode: "mock-openai",
+      scenarioDefinitions: [{ id: "slack-canary", title: "Slack canary" }],
+      scenarioResults: [
+        {
+          name: "Slack canary",
+          status: "pass",
+          rttMeasurement: {
+            finalMatchedReplyRttMs: 1750,
+            requestStartedAt: "2026-09-03T00:00:00.000Z",
+            responseObservedAt: "2026-09-03T00:00:01.750Z",
+            source: "request-to-observed-message",
+          },
+        },
+      ],
+    });
+    const invalidEvidence = structuredClone(evidence) as unknown as {
+      entries: Array<{ result: { rttMeasurement?: Record<string, unknown> } }>;
+    };
+    const invalidEntry = expectDefined(invalidEvidence.entries[0], "QA evidence entry");
+    const invalidMeasurement = expectDefined(invalidEntry.result.rttMeasurement, "RTT measurement");
+    invalidMeasurement.extra = true;
+
+    expect(() => validateQaEvidenceSummaryJson(invalidEvidence)).toThrow();
+  });
+
   it.each([
     ["live Discord transport", "discord", "live", undefined, "live", true],
     ["live Matrix transport", "matrix", "live", undefined, "live", true],

--- a/extensions/qa-lab/src/evidence-summary.ts
+++ b/extensions/qa-lab/src/evidence-summary.ts
@@ -69,6 +69,13 @@ const qaEvidenceTimingSchema = z.strictObject({
   failedSamples: z.number().int().nonnegative().optional(),
 });
 
+const qaEvidenceRttMeasurementSchema = z.strictObject({
+  finalMatchedReplyRttMs: z.number().finite().positive(),
+  requestStartedAt: nonEmptyStringSchema,
+  responseObservedAt: nonEmptyStringSchema,
+  source: nonEmptyStringSchema,
+});
+
 const qaEvidenceTestSchema = z.strictObject({
   kind: nonEmptyStringSchema,
   id: nonEmptyStringSchema,
@@ -145,6 +152,7 @@ const qaEvidenceResultSchema = z.strictObject({
   status: qaEvidenceStatusSchema,
   failure: qaEvidenceFailureSchema.optional(),
   timing: qaEvidenceTimingSchema.optional(),
+  rttMeasurement: qaEvidenceRttMeasurementSchema.optional(),
 });
 
 const qaEvidencePostureSchema = z.enum(["direct-gateway", "native-approval", "user-path"]);
@@ -173,6 +181,7 @@ const qaEvidenceSummarySchema = z.strictObject({
 type QaEvidenceProfile = z.infer<typeof qaEvidenceProfileIdSchema>;
 export type QaEvidenceStatus = z.infer<typeof qaEvidenceStatusSchema>;
 export type QaEvidenceTiming = z.infer<typeof qaEvidenceTimingSchema>;
+export type QaEvidenceRttMeasurement = z.infer<typeof qaEvidenceRttMeasurementSchema>;
 export type QaEvidencePackageSource = z.infer<typeof qaEvidencePackageSourceSchema>;
 export type QaEvidenceScorecardJson = z.infer<typeof qaEvidenceScorecardSchema>;
 export type QaEvidenceSummaryEntry = z.infer<typeof qaEvidenceSummaryEntrySchema>;
@@ -204,6 +213,9 @@ type QaEvidenceScenarioResultInput = {
   rttMs?: number;
   rttMeasurement?: {
     finalMatchedReplyRttMs?: number;
+    requestStartedAt?: string;
+    responseObservedAt?: string;
+    source?: string;
   };
 };
 
@@ -387,18 +399,25 @@ function failureForResult(result: {
   };
 }
 
-function timingForRttResult(check: QaEvidenceRttInput) {
+function evidenceForRttResult(check: QaEvidenceRttInput) {
   const timing: QaEvidenceTiming = { ...check.timing };
-  const rttMs = check.rttMeasurement?.finalMatchedReplyRttMs ?? check.rttMs;
-  if (
+  const parsedMeasurement = qaEvidenceRttMeasurementSchema.safeParse(check.rttMeasurement);
+  const rttMeasurement = parsedMeasurement.success ? parsedMeasurement.data : undefined;
+  const fallbackRttMs = check.rttMeasurement?.finalMatchedReplyRttMs ?? check.rttMs;
+  if (rttMeasurement) {
+    timing.rttMs = rttMeasurement.finalMatchedReplyRttMs;
+  } else if (
     timing.rttMs === undefined &&
-    typeof rttMs === "number" &&
-    Number.isFinite(rttMs) &&
-    rttMs > 0
+    typeof fallbackRttMs === "number" &&
+    Number.isFinite(fallbackRttMs) &&
+    fallbackRttMs > 0
   ) {
-    timing.rttMs = rttMs;
+    timing.rttMs = fallbackRttMs;
   }
-  return Object.keys(timing).length > 0 ? timing : undefined;
+  return {
+    timing: Object.keys(timing).length > 0 ? timing : undefined,
+    rttMeasurement,
+  };
 }
 
 function timingForTestResult(result: QaEvidenceTestResultInput) {
@@ -412,11 +431,13 @@ function timingForTestResult(result: QaEvidenceTestResultInput) {
 function resultForEvidence(
   result: { details?: string; failureMessage?: string; status: QaEvidenceStatusInput },
   timing?: QaEvidenceTiming,
+  rttMeasurement?: QaEvidenceRttMeasurement,
 ) {
   return {
     status: normalizeQaEvidenceStatus(result.status),
     failure: failureForResult(result),
     timing,
+    rttMeasurement,
   };
 }
 
@@ -519,7 +540,7 @@ export function buildQaSuiteEvidenceSummary(
       docsRefs: scenario?.docsRefs,
       codeRefs: scenario?.codeRefs,
     });
-    const timing = timingForRttResult(result);
+    const { timing, rttMeasurement } = evidenceForRttResult(result);
     return {
       test: {
         kind: "qa-scenario",
@@ -545,7 +566,7 @@ export function buildQaSuiteEvidenceSummary(
         packageSource,
         artifacts: buildQaEvidenceArtifacts(params.artifactPaths, "qa-suite"),
       },
-      result: resultForEvidence(result, timing),
+      result: resultForEvidence(result, timing, rttMeasurement),
     };
   });
   return buildQaEvidenceSummary({

--- a/extensions/qa-lab/src/scenario-flow-runner.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.ts
@@ -1,5 +1,6 @@
 // Qa Lab plugin module implements scenario flow runner behavior.
 import { isRecord as isPlainObject } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { QaEvidenceRttMeasurement } from "./evidence-summary.js";
 import type { QaTransportState } from "./qa-transport.js";
 import type { QaScenarioFlow, QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaSuiteScenarioResult, QaSuiteStep, QaSuiteStepOutcome } from "./suite-types.js";
@@ -82,14 +83,48 @@ function formatFlowDetails(details: unknown) {
   return JSON.stringify(details, null, 2);
 }
 
-function resolveFlowResultRttMs(result: unknown) {
+function resolveFlowRttMeasurement(value: unknown): QaEvidenceRttMeasurement | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+  const { finalMatchedReplyRttMs, requestStartedAt, responseObservedAt, source } = value;
+  if (
+    typeof finalMatchedReplyRttMs !== "number" ||
+    !Number.isFinite(finalMatchedReplyRttMs) ||
+    finalMatchedReplyRttMs <= 0 ||
+    typeof requestStartedAt !== "string" ||
+    !requestStartedAt.trim() ||
+    typeof responseObservedAt !== "string" ||
+    !responseObservedAt.trim() ||
+    typeof source !== "string" ||
+    !source.trim()
+  ) {
+    return undefined;
+  }
+  return {
+    finalMatchedReplyRttMs,
+    requestStartedAt: requestStartedAt.trim(),
+    responseObservedAt: responseObservedAt.trim(),
+    source: source.trim(),
+  };
+}
+
+function resolveFlowResultRtt(result: unknown) {
   if (!isPlainObject(result)) {
     return undefined;
   }
   const timing = isPlainObject(result.timing) ? result.timing : undefined;
-  const measurement = isPlainObject(result.rttMeasurement) ? result.rttMeasurement : undefined;
-  const rttMs = timing?.rttMs ?? measurement?.finalMatchedReplyRttMs ?? result.rttMs;
-  return typeof rttMs === "number" && Number.isFinite(rttMs) && rttMs > 0 ? rttMs : undefined;
+  const measurement = resolveFlowRttMeasurement(result.rttMeasurement);
+  const rawMeasurement = isPlainObject(result.rttMeasurement) ? result.rttMeasurement : undefined;
+  const fallbackRttMs = timing?.rttMs ?? rawMeasurement?.finalMatchedReplyRttMs ?? result.rttMs;
+  const rttMs = measurement?.finalMatchedReplyRttMs ?? fallbackRttMs;
+  if (typeof rttMs !== "number" || !Number.isFinite(rttMs) || rttMs <= 0) {
+    return undefined;
+  }
+  return {
+    timing: { rttMs },
+    ...(measurement ? { rttMeasurement: measurement } : {}),
+  } satisfies Pick<QaSuiteStepOutcome, "timing" | "rttMeasurement">;
 }
 
 function getPathWithParent(
@@ -398,15 +433,15 @@ export async function runScenarioFlow(params: {
         const details = step.detailsExpr
           ? formatFlowDetails(await evalExpr(step.detailsExpr, params.api, vars))
           : undefined;
-        const rttMs = step.resultExpr
-          ? resolveFlowResultRttMs(await evalExpr(step.resultExpr, params.api, vars))
+        const rtt = step.resultExpr
+          ? resolveFlowResultRtt(await evalExpr(step.resultExpr, params.api, vars))
           : undefined;
-        if (rttMs === undefined) {
+        if (!rtt) {
           return details === undefined ? undefined : { details };
         }
         return {
           ...(details === undefined ? {} : { details }),
-          timing: { rttMs },
+          ...rtt,
         } satisfies QaSuiteStepOutcome;
       } finally {
         throwIfFlowAborted(params.api);

--- a/extensions/qa-lab/src/scenario-module-flow.test.ts
+++ b/extensions/qa-lab/src/scenario-module-flow.test.ts
@@ -9,7 +9,7 @@ import { runQaSuiteScenarioSteps } from "./suite-runtime-flow.js";
 describe("QA scenario module flow", () => {
   it.each([
     ["canonical timing", { timing: { rttMs: 1750 } }],
-    ["structured measurement", { rttMeasurement: { finalMatchedReplyRttMs: 1750 } }],
+    ["incomplete structured measurement", { rttMeasurement: { finalMatchedReplyRttMs: 1750 } }],
     ["top-level RTT", { rttMs: 1750 }],
   ])("carries %s from a module result into final QA evidence", async (_label, timingResult) => {
     const moduleSource = [
@@ -53,7 +53,70 @@ describe("QA scenario module flow", () => {
     });
 
     expect(result.timing).toEqual({ rttMs: 1750 });
+    expect(result.rttMeasurement).toBeUndefined();
     expect(evidence.entries[0]?.result.timing).toEqual({ rttMs: 1750 });
+    expect(evidence.entries[0]?.result.rttMeasurement).toBeUndefined();
+  });
+
+  it("preserves complete structured RTT provenance as the canonical measurement", async () => {
+    const rttMeasurement = {
+      finalMatchedReplyRttMs: 1750,
+      requestStartedAt: "2026-09-03T00:00:00.000Z",
+      responseObservedAt: "2026-09-03T00:00:01.750Z",
+      source: "request-to-observed-message",
+    };
+    const moduleSource = [
+      "export async function runScenario() {",
+      `  return ${JSON.stringify({
+        details: "reply matched",
+        timing: { rttMs: 999 },
+        rttMeasurement,
+      })};`,
+      "}",
+    ].join("\n");
+    const moduleFlow = qaScenarioModuleFlow.moduleSchema.parse({
+      module: `data:text/javascript,${encodeURIComponent(moduleSource)}`,
+      call: "runScenario",
+    });
+    const flow = qaScenarioModuleFlow.resolveFlow(moduleFlow, "Discord canary") as QaScenarioFlow;
+    const scenario = {
+      id: "discord-canary",
+      title: "Discord canary",
+      sourcePath: "qa/scenarios/discord-canary.yaml",
+      surface: "discord",
+      objective: "measure Discord reply latency",
+      successCriteria: ["matched reply records RTT"],
+      execution: { kind: "flow", flow, flowKind: "module" },
+    } satisfies QaSeedScenarioWithSource;
+
+    const result = await runScenarioFlow({
+      api: {
+        state: createQaBusState(),
+        scenario,
+        config: {},
+        runScenario: runQaSuiteScenarioSteps,
+      },
+      flow,
+      scenarioTitle: scenario.title,
+    });
+    const evidence = buildQaSuiteEvidenceSummary({
+      artifactPaths: [],
+      channelId: "discord",
+      generatedAt: "2026-09-03T00:00:00.000Z",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      providerMode: "mock-openai",
+      scenarioDefinitions: [scenario],
+      scenarioResults: [result],
+    });
+
+    expect(result).toMatchObject({
+      timing: { rttMs: 1750 },
+      rttMeasurement,
+    });
+    expect(evidence.entries[0]?.result).toMatchObject({
+      timing: { rttMs: 1750 },
+      rttMeasurement,
+    });
   });
 
   it("resolves a module export argument against the loaded scenario module", () => {

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -138,6 +138,60 @@ describe("qa suite runtime flow", () => {
     expect(laterStep).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["pass", undefined],
+    ["fail", new Error("later failure")],
+    ["skip", new QaSuiteScenarioSkipError("later skip")],
+  ] as const)(
+    "keeps the latest structured RTT measurement when the scenario ends in %s",
+    async (expectedStatus, terminalError) => {
+      const firstMeasurement = {
+        finalMatchedReplyRttMs: 100,
+        requestStartedAt: "2026-09-03T00:00:00.000Z",
+        responseObservedAt: "2026-09-03T00:00:00.100Z",
+        source: "first-observation",
+      };
+      const latestMeasurement = {
+        finalMatchedReplyRttMs: 200,
+        requestStartedAt: "2026-09-03T00:00:01.000Z",
+        responseObservedAt: "2026-09-03T00:00:01.200Z",
+        source: "latest-observation",
+      };
+      const result = await runQaSuiteScenarioSteps("RTT retention", [
+        {
+          name: "First measurement",
+          run: async () => ({
+            timing: { wallMs: 10, rttMs: 999 },
+            rttMeasurement: firstMeasurement,
+          }),
+        },
+        {
+          name: "Latest measurement",
+          run: async () => ({
+            timing: { rttMs: 888 },
+            rttMeasurement: latestMeasurement,
+          }),
+        },
+        {
+          name: "Later timing only",
+          run: async () => ({ timing: { rttMs: 777, p50Ms: 50 } }),
+        },
+        {
+          name: "Terminal step",
+          run: async () => {
+            if (terminalError) {
+              throw terminalError;
+            }
+          },
+        },
+      ]);
+
+      expect(result.status).toBe(expectedStatus);
+      expect(result.timing).toEqual({ wallMs: 10, rttMs: 200, p50Ms: 50 });
+      expect(result.rttMeasurement).toEqual(latestMeasurement);
+    },
+  );
+
   it("wires the split suite runtime deps into the scenario runtime api", async () => {
     const env = createQaSuiteRuntimeFlowTestEnv();
     const scenario = {

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -101,6 +101,7 @@ export async function runQaSuiteScenarioSteps(
 ): Promise<QaSuiteScenarioResult> {
   const stepResults: QaSuiteScenarioResult["steps"] = [];
   let timing: QaSuiteScenarioResult["timing"];
+  let rttMeasurement: QaSuiteScenarioResult["rttMeasurement"];
   for (const step of steps) {
     try {
       if (process.env.OPENCLAW_QA_DEBUG === "1") {
@@ -111,6 +112,13 @@ export async function runQaSuiteScenarioSteps(
       if (outcome?.timing) {
         timing ??= {};
         Object.assign(timing, outcome.timing);
+      }
+      if (outcome?.rttMeasurement) {
+        rttMeasurement = outcome.rttMeasurement;
+      }
+      if (rttMeasurement) {
+        timing ??= {};
+        timing.rttMs = rttMeasurement.finalMatchedReplyRttMs;
       }
       if (process.env.OPENCLAW_QA_DEBUG === "1") {
         console.error(`[qa-suite] pass scenario="${name}" step="${step.name}"`);
@@ -130,6 +138,7 @@ export async function runQaSuiteScenarioSteps(
           steps: stepResults,
           details,
           ...(timing ? { timing } : {}),
+          ...(rttMeasurement ? { rttMeasurement } : {}),
         };
       }
       if (process.env.OPENCLAW_QA_DEBUG === "1") {
@@ -142,10 +151,17 @@ export async function runQaSuiteScenarioSteps(
         steps: stepResults,
         details,
         ...(timing ? { timing } : {}),
+        ...(rttMeasurement ? { rttMeasurement } : {}),
       };
     }
   }
-  return { name, status: "pass", steps: stepResults, ...(timing ? { timing } : {}) };
+  return {
+    name,
+    status: "pass",
+    steps: stepResults,
+    ...(timing ? { timing } : {}),
+    ...(rttMeasurement ? { rttMeasurement } : {}),
+  };
 }
 
 type QaSuiteScenarioDepsParams = {

--- a/extensions/qa-lab/src/suite-types.ts
+++ b/extensions/qa-lab/src/suite-types.ts
@@ -1,6 +1,10 @@
 import type { OpenClawCrablineChannelDriverSelection } from "@openclaw/crabline";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type { QaEvidenceTiming, QaEvidenceSummaryJson } from "./evidence-summary.js";
+import type {
+  QaEvidenceRttMeasurement,
+  QaEvidenceTiming,
+  QaEvidenceSummaryJson,
+} from "./evidence-summary.js";
 import type { QaCliBackendAuthMode, QaGatewayChildCommand } from "./gateway-child.js";
 import type { QaLabServerHandle, QaLabServerStartParams } from "./lab-server.types.js";
 import type { QaProviderMode } from "./model-selection.js";
@@ -19,6 +23,7 @@ import type { QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
 export type QaSuiteStepOutcome = {
   details?: string;
   timing?: QaEvidenceTiming;
+  rttMeasurement?: QaEvidenceRttMeasurement;
 };
 
 export type QaSuiteStep = {
@@ -32,6 +37,7 @@ export type QaSuiteScenarioResult = {
   steps: QaReportCheck[];
   details?: string;
   timing?: QaEvidenceTiming;
+  rttMeasurement?: QaEvidenceRttMeasurement;
   modelSwitchEvidence?: Record<string, unknown>;
   runtimeParity?: RuntimeParityResult;
 };


### PR DESCRIPTION
Closes #137380

## What Problem This Solves

Fixes an issue where live QA scenarios lost structured RTT provenance when canonical QA evidence was written, leaving downstream qualification rows labeled as scalar summary fallbacks.

## Why This Change Was Made

Carry the complete measurement through flow steps, scenario aggregation, and schema-v2 evidence while retaining `timing.rttMs`. Complete structured measurement wins conflicting scalar timing; timing-only or incomplete input never invents provenance.

## User Impact

QA and RTT consumers can distinguish request-to-observed and approval timing sources with their timestamps. No raw message sidecar is required.

## Evidence

- 45 focused tests passed: https://github.com/openclaw/openclaw/actions/runs/33777319801
- Full changed gate and private QA build passed: https://github.com/openclaw/openclaw/actions/runs/33775730331
- Fresh exact-base autoreview found no accepted or actionable findings.
- Live before-fix reproduction: https://github.com/openclaw/openclaw-rtt/actions/runs/33771350656
