### PR TITLE
fix(cron): recover duplicated system monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cron system monitors:** remove duplicate heartbeat and skill-review monitor rows before declarative convergence, recovering automatically from ambiguous declaration keys after migration.
 - **Update readiness:** select declared health-check owners before loading plugin APIs, preventing unrelated optional Doctor checks from interrupting upgrades while retaining mandatory readiness failures.
 
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cron system monitors:** remove duplicate heartbeat and skill-review monitor rows before declarative convergence, recovering automatically from ambiguous declaration keys after migration.
 - **Update readiness:** select declared health-check owners before loading plugin APIs, preventing unrelated optional Doctor checks from interrupting upgrades while retaining mandatory readiness failures.
 
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.

--- a/src/cron/heartbeat-monitor.test.ts
+++ b/src/cron/heartbeat-monitor.test.ts
@@ -86,6 +86,29 @@ describe("heartbeat monitor desired-state planning", () => {
     ]);
   });
 
+  it("removes duplicate monitors before updating the retained row", () => {
+    const cfg = {
+      agents: { defaults: { heartbeat: { every: "15m" } } },
+    } as OpenClawConfig;
+    const options = { schedulerSeed: "test-seed" };
+    const input = resolveHeartbeatMonitorPlan(cfg, [], options).specs[0]?.input;
+    if (!input) {
+      throw new Error("expected configured heartbeat monitor spec");
+    }
+    const older = { ...monitorJob(input, "older"), updatedAtMs: 1 };
+    const newer = {
+      ...monitorJob({ ...input, enabled: false }, "newer"),
+      updatedAtMs: 2,
+    };
+
+    const plan = resolveHeartbeatMonitorPlan(cfg, [older, newer], options);
+
+    expect(plan.changes).toEqual([
+      { kind: "remove", agentId: "main", job: older },
+      expect.objectContaining({ kind: "update", agentId: "main" }),
+    ]);
+  });
+
   it.each([
     { field: "name", value: "stale-name", changes: ["update"] },
     { field: "agentId", value: "stale-agent", changes: ["update"] },

--- a/src/cron/heartbeat-monitor.ts
+++ b/src/cron/heartbeat-monitor.ts
@@ -8,6 +8,7 @@ import {
   resolveHeartbeatSchedulerSeed,
 } from "../infra/heartbeat-schedule.js";
 import type { CronService } from "./service.js";
+import { partitionSystemMonitors } from "./system-monitor-jobs.js";
 import type { CronJob, CronJobCreate } from "./types.js";
 
 const HEARTBEAT_DECLARATION_PREFIX = "heartbeat:";
@@ -73,13 +74,10 @@ export function resolveHeartbeatMonitorPlan(
   existingJobs: readonly CronJob[],
   options: { schedulerSeed?: string } = {},
 ): HeartbeatMonitorPlan {
-  const existingByAgentId = new Map<string, CronJob>();
-  for (const job of existingJobs) {
-    const agentId = heartbeatMonitorAgentId(job);
-    if (agentId) {
-      existingByAgentId.set(agentId, job);
-    }
-  }
+  const { retained: existingByAgentId, duplicates } = partitionSystemMonitors(
+    existingJobs,
+    heartbeatMonitorAgentId,
+  );
 
   const schedulerSeed = resolveHeartbeatSchedulerSeed(options.schedulerSeed);
   const specs: HeartbeatMonitorSpec[] = resolveHeartbeatAgents(cfg).flatMap((agent) => {
@@ -122,7 +120,13 @@ export function resolveHeartbeatMonitorPlan(
     ];
   });
 
-  const changes: HeartbeatMonitorChange[] = [];
+  // Remove duplicate declaration keys before declarative upserts, which reject
+  // ambiguous matches by design.
+  const changes: HeartbeatMonitorChange[] = duplicates.map(({ agentId, job }) => ({
+    kind: "remove",
+    agentId,
+    job,
+  }));
   for (const spec of specs) {
     const existing = existingByAgentId.get(spec.agentId);
     if (!existing) {

--- a/src/cron/system-monitor-jobs.ts
+++ b/src/cron/system-monitor-jobs.ts
@@ -1,0 +1,23 @@
+import type { CronJob } from "./types.js";
+
+export function partitionSystemMonitors(
+  jobs: readonly CronJob[],
+  resolveAgentId: (job: CronJob) => string | undefined,
+) {
+  const retained = new Map<string, CronJob>();
+  const duplicates: Array<{ agentId: string; job: CronJob }> = [];
+  for (const job of jobs) {
+    const agentId = resolveAgentId(job);
+    if (!agentId) continue;
+    const current = retained.get(agentId);
+    if (!current) {
+      retained.set(agentId, job);
+    } else if (job.updatedAtMs > current.updatedAtMs) {
+      retained.set(agentId, job);
+      duplicates.push({ agentId, job: current });
+    } else {
+      duplicates.push({ agentId, job });
+    }
+  }
+  return { retained, duplicates };
+}

--- a/src/cron/system-monitor-jobs.ts
+++ b/src/cron/system-monitor-jobs.ts
@@ -8,7 +8,9 @@ export function partitionSystemMonitors(
   const duplicates: Array<{ agentId: string; job: CronJob }> = [];
   for (const job of jobs) {
     const agentId = resolveAgentId(job);
-    if (!agentId) continue;
+    if (!agentId) {
+      continue;
+    }
     const current = retained.get(agentId);
     if (!current) {
       retained.set(agentId, job);

--- a/src/gateway/server-cron-skill-review-jobs.test.ts
+++ b/src/gateway/server-cron-skill-review-jobs.test.ts
@@ -44,7 +44,8 @@ describe("reconcileSkillCollectionReviewJobs", () => {
     const remove = vi.fn(async () => ({ ok: true }));
     const list = vi.fn(async () => [
       monitorJob("main"),
-      monitorJob("stale"),
+      monitorJob("stale", "stale-older"),
+      { ...monitorJob("stale", "stale-newer"), updatedAtMs: 2 },
       {
         ...monitorJob("collider"),
         id: "user-job",
@@ -77,8 +78,9 @@ describe("reconcileSkillCollectionReviewJobs", () => {
       enabledExplicit: true,
       systemOwned: true,
     });
-    expect(remove).toHaveBeenCalledWith("job-stale", { systemOwned: true });
-    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenNthCalledWith(1, "stale-older", { systemOwned: true });
+    expect(remove).toHaveBeenNthCalledWith(2, "stale-newer", { systemOwned: true });
+    expect(remove).toHaveBeenCalledTimes(2);
   });
 
   it("removes duplicate monitors before converging their declaration", async () => {

--- a/src/gateway/server-cron-skill-review-jobs.test.ts
+++ b/src/gateway/server-cron-skill-review-jobs.test.ts
@@ -81,6 +81,43 @@ describe("reconcileSkillCollectionReviewJobs", () => {
     expect(remove).toHaveBeenCalledTimes(1);
   });
 
+  it("removes duplicate monitors before converging their declaration", async () => {
+    const older = monitorJob("main", "older");
+    const newer = { ...monitorJob("main", "newer"), updatedAtMs: 2 };
+    const jobs = [older, newer];
+    const remove = vi.fn(async (jobId: string) => {
+      const index = jobs.findIndex((job) => job.id === jobId);
+      if (index >= 0) {
+        jobs.splice(index, 1);
+      }
+      return { ok: true };
+    });
+    const add = vi.fn(
+      async (_input: unknown, options?: { matchesExisting?: (job: CronJob) => boolean }) => {
+        const matches = jobs.filter((job) => options?.matchesExisting?.(job));
+        if (matches.length > 1) {
+          throw new Error("ambiguous declaration key");
+        }
+        return { job: matches[0] };
+      },
+    );
+    const cfg = {
+      agents: { list: [{ id: "main", default: true, workspace: "/tmp/openclaw-main" }] },
+      skills: { workshop: { autonomous: { mode: "propose" } } },
+    } as OpenClawConfig;
+
+    await expect(
+      reconcileSkillCollectionReviewJobs({
+        cron: { add, list: vi.fn(async () => jobs), remove } as never,
+        cfg,
+        logger,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(remove).toHaveBeenNthCalledWith(1, "older", { systemOwned: true });
+    expect(add).toHaveBeenCalledOnce();
+  });
+
   it("revokes an active review through gateway reconciliation before its final write", async () => {
     const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-review-revoke-"));
     const workspaceDir = path.join(rootDir, "workspace");

--- a/src/gateway/server-cron-skill-review-jobs.ts
+++ b/src/gateway/server-cron-skill-review-jobs.ts
@@ -4,6 +4,7 @@ import {
   resolveSkillCollectionReviewMonitorSpecs,
   skillCollectionReviewMonitorAgentId,
 } from "../cron/skill-collection-review-monitor.js";
+import { partitionSystemMonitors } from "../cron/system-monitor-jobs.js";
 import type { CronJob } from "../cron/types.js";
 import type { GatewayCronServiceContract } from "./server-cron-contract.js";
 
@@ -27,6 +28,22 @@ export async function reconcileSkillCollectionReviewJobs(params: {
 
   const specs = resolveSkillCollectionReviewMonitorSpecs(params.cfg);
   const desired = new Set(specs.map((spec) => spec.agentId));
+  const { duplicates } = partitionSystemMonitors(jobs, skillCollectionReviewMonitorAgentId);
+  for (const { agentId, job } of duplicates) {
+    try {
+      await params.cron.remove(job.id, {
+        systemOwned: true,
+        ...(params.commitGuard ? { commitGuard: params.commitGuard } : {}),
+      });
+    } catch (error) {
+      params.commitGuard?.();
+      ok = false;
+      params.logger.warn(
+        { agentId, err: String(error) },
+        "cron-skill-review: duplicate monitor cleanup failed",
+      );
+    }
+  }
   for (const spec of specs) {
     try {
       await params.cron.add(spec.input, {

--- a/src/gateway/server-cron-skill-review-jobs.ts
+++ b/src/gateway/server-cron-skill-review-jobs.ts
@@ -28,7 +28,10 @@ export async function reconcileSkillCollectionReviewJobs(params: {
 
   const specs = resolveSkillCollectionReviewMonitorSpecs(params.cfg);
   const desired = new Set(specs.map((spec) => spec.agentId));
-  const { duplicates } = partitionSystemMonitors(jobs, skillCollectionReviewMonitorAgentId);
+  const { retained, duplicates } = partitionSystemMonitors(
+    jobs,
+    skillCollectionReviewMonitorAgentId,
+  );
   for (const { agentId, job } of duplicates) {
     try {
       await params.cron.remove(job.id, {
@@ -62,9 +65,8 @@ export async function reconcileSkillCollectionReviewJobs(params: {
     }
   }
 
-  for (const job of jobs) {
-    const agentId = skillCollectionReviewMonitorAgentId(job);
-    if (!agentId || desired.has(agentId)) {
+  for (const [agentId, job] of retained) {
+    if (desired.has(agentId)) {
       continue;
     }
     try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where gateways with duplicate system-owned cron rows could remain permanently wedged during startup and config reload. Declarative convergence rejected the duplicated heartbeat and skill-review declaration keys as ambiguous, while operators could not delete those protected rows through the public cron API.

## Why This Change Was Made

System monitor reconciliation now retains the most recently updated row per agent and removes older duplicates before running the existing declarative upsert. The same partitioning helper covers heartbeat and skill collection review monitors while preserving their system-owned deletion boundary.

## User Impact

Gateways recover automatically if migration or another interrupted transition leaves duplicate system monitor rows. Operators no longer need offline database surgery to restore monitor convergence.

## Evidence

### Pre-fix incident evidence (redacted)

A production scheduler contained two rows for one heartbeat declaration and two rows for each of nine skill-review declarations. Gateway logs repeated the following every reconciliation cycle:

```text
cron declarationKey is ambiguous within caller scope: heartbeat:[agent]
cron declarationKey is ambiguous within caller scope: skill-collection-review:[agent]
```

The public delete path correctly refused recovery because these rows are system-owned. After an offline, exact-ID cleanup and gateway restart, the scheduler changed from 51 to 41 jobs, had zero duplicate declaration keys, and both gateway and iMessage channel health returned ready. Agent identifiers, message destinations, and row IDs are intentionally omitted.

### Deterministic integration and unit proof

```text
src/cron/heartbeat-monitor.test.ts: 9 passed
src/gateway/server-cron-skill-review-jobs.test.ts: 3 passed
```

The new regression cases begin with two monitor rows for the same agent. They assert that the older row is removed before the declarative add/update, so the upsert sees exactly one match instead of throwing the ambiguity error.

Formatting and `git diff --check` pass. `check:changed` could not complete because the repository's `minimumReleaseAge` policy rejects its newly pinned pnpm 12.1.0 package on 2026-09-03; both directly affected test shards were run successfully with the installed test runner.

Autoreview: scoped clean at P0-P2, correctness confidence 0.9.
