### PR TITLE
fix(cron): preserve payload options when cloning automations

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -538,6 +538,7 @@ This label does not change which request the approval buttons resolve.
   </Accordion>
   <Accordion title="Automations panel notes">
     - Selecting a row opens a full-page detail view with an Active/Paused switch and Run now in the header (run-if-due, clone, and remove in its menu); the Settings tab edits the automation inline (prompt, details, frequency, advanced overrides) and the Run history tab shows that automation's runs.
+    - Cloning an agent task retains its stored tool allowlist, model fallback list, lightweight-context setting, and external-content setting, including empty lists and explicit `false` values. Fields you change in the copy's form take precedence. The new task is authorized by the current operator; captured execution grants are not copied.
     - Both Run history views show a recorded delivery-suppression reason alongside the delivery status when available. Intentional suppression remains separate from delivery errors; the history does not infer a reason from a successful run.
     - Starter automations under the table prefill the create form with an editable prompt and schedule.
     - New isolated tasks default to internal-only delivery. Select announce explicitly to send a summary to a channel.

--- a/ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts
@@ -68,7 +68,9 @@ async function capture(page: Page, name: string, observed: unknown) {
   if (!captureEnabled) {
     return;
   }
-  await page.screenshot({ path: path.join(suite.artifactDir, `${name}.png`), fullPage: true });
+  await page
+    .locator(".cron-page")
+    .screenshot({ path: path.join(suite.artifactDir, `${name}.png`) });
   await fs.writeFile(
     path.join(suite.artifactDir, `${name}.json`),
     `${JSON.stringify(observed, null, 2)}\n`,
@@ -481,6 +483,118 @@ suite.define(() => {
           servedAssets: await Promise.all(servedAssets),
         });
       });
+    });
+  });
+
+  it("clone payload policy: preserves public options through the real Gateway and CLI readback", async () => {
+    await withGatewayCommands("real-clone-policy-commands.json", async (cliJson) => {
+      for (const variant of [
+        { name: "finite-cap", toolsAllow: ["read"], allowUnsafeExternalContent: false },
+        { name: "empty-cap", toolsAllow: [], allowUnsafeExternalContent: true },
+      ]) {
+        const sourceName = `Synthetic clone ${variant.name} source`;
+        const payload = {
+          kind: "agentTurn" as const,
+          message: "node -e \"console.log('synthetic clone fixture')\"",
+          toolsAllow: variant.toolsAllow,
+          fallbacks: [],
+          lightContext: false,
+          allowUnsafeExternalContent: variant.allowUnsafeExternalContent,
+          timeoutSeconds: 0,
+        };
+        const created = await cliJson([
+          "gateway",
+          "call",
+          "cron.add",
+          "--params",
+          JSON.stringify({
+            name: sourceName,
+            agentId: "main",
+            enabled: false,
+            schedule: { kind: "every", everyMs: 60_000 },
+            sessionTarget: "isolated",
+            wakeMode: "now",
+            payload,
+            delivery: { mode: "none" },
+          }),
+          "--json",
+        ]);
+        const sourceId = cronJobId(created);
+        const original = await cliJson(["automations", "get", sourceId, "--json"]);
+        expect(original).toMatchObject({ id: sourceId, enabled: false });
+        expect(original.payload).toEqual(payload);
+
+        await withCronJobPage(cliJson, sourceId, async (evidence) => {
+          const { page, servedDocumentSha256, servedAssets } = evidence;
+          await expect
+            .poll(() => page.locator(".cron-detail-title").textContent())
+            .toBe(original.name);
+          await capture(page, `real-clone-policy-${variant.name}-loaded`, {
+            original,
+            servedDocumentSha256,
+          });
+          const menu = page.locator(".cron-detail-actions wa-dropdown");
+          await menu.locator('button[slot="trigger"]').click();
+          await menu.locator('wa-dropdown-item[value="clone"]').click();
+          await page.locator('.cron-page[data-panel-mode="create"]').waitFor();
+          await expect
+            .poll(() => page.locator("#cron-name").inputValue())
+            .toBe(`${sourceName} copy`);
+          const cloneName = `Synthetic clone ${variant.name} copy`;
+          await page.locator("#cron-name").fill(cloneName);
+          const cloned = await submitCronForm(evidence, cliJson, "cron.add");
+          const cloneId = cronJobId(cloned.stored);
+          await page.locator(`[data-test-id="cron-row-${cloneId}"]`).click();
+          await expect.poll(() => page.locator(".cron-detail-title").textContent()).toBe(cloneName);
+          const originalAfter = await cliJson(["automations", "get", sourceId, "--json"]);
+          await capture(page, `real-clone-policy-${variant.name}-readback`, {
+            original,
+            originalAfter,
+            ...cloned,
+            servedDocumentSha256,
+            servedAssets: await Promise.all(servedAssets),
+          });
+
+          expect.soft(originalAfter, `${variant.name}: source unchanged`).toEqual(original);
+          expect.soft(cloneId, `${variant.name}: new job identity`).not.toBe(sourceId);
+          expect.soft(cloned.stored, `${variant.name}: new disabled task`).toMatchObject({
+            name: cloneName,
+            agentId: "main",
+            enabled: false,
+            sessionTarget: "isolated",
+            wakeMode: "now",
+            delivery: { mode: "none" },
+          });
+          expect
+            .soft(cloned.stored.schedule, `${variant.name}: exact schedule`)
+            .toEqual(original.schedule);
+          const params = requireRecord(cloned.request.params);
+          const submittedPayload = requireRecord(params.payload);
+          const storedPayload = requireRecord(cloned.stored.payload);
+          for (const [field, value] of Object.entries(payload)) {
+            expect
+              .soft(submittedPayload[field], `${variant.name}: submitted ${field}`)
+              .toEqual(value);
+            expect.soft(storedPayload[field], `${variant.name}: stored ${field}`).toEqual(value);
+          }
+          for (const field of ["toolsAllowIsDefault", "externalContentSource"]) {
+            expect
+              .soft(submittedPayload, `${variant.name}: omitted ${field}`)
+              .not.toHaveProperty(field);
+          }
+          for (const field of [
+            "createdActor",
+            "toolsAllowProvenance",
+            "toolsAllowExecTarget",
+            "toolsAllowExecTargetRequirement",
+            "runtimeAuthority",
+            "runtimeAuthorityRecoveryRequired",
+            "skillLibrarySelections",
+          ]) {
+            expect.soft(params, `${variant.name}: omitted ${field}`).not.toHaveProperty(field);
+          }
+        });
+      }
     });
   });
 });

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -2233,6 +2233,289 @@ describe("cron controller", () => {
   });
 
   it.each([
+    { name: "omitted cap", policy: {} },
+    { name: "empty cap", policy: { toolsAllow: [] } },
+    { name: "finite cap", policy: { toolsAllow: ["read"] } },
+    { name: "wildcard cap", policy: { toolsAllow: ["*"] }, effectiveUnrestricted: true },
+    {
+      name: "default-marked cap as a new explicit restriction",
+      policy: { toolsAllow: ["read"], toolsAllowIsDefault: true },
+    },
+  ] satisfies Array<{
+    name: string;
+    effectiveUnrestricted?: boolean;
+    policy: Pick<
+      Extract<CronJob["payload"], { kind: "agentTurn" }>,
+      "toolsAllow" | "toolsAllowIsDefault"
+    >;
+  }>)("clone payload policy: retains $name without a capture marker", async (scenario) => {
+    const { policy } = scenario;
+    const source = createCronJob({
+      id: "cap-source",
+      name: "Public cap source",
+      payload: { kind: "agentTurn", message: "Synthetic clone task", ...policy },
+      delivery: { mode: "none" },
+    });
+    const original = structuredClone(source);
+    const request = createCronRequest("cap-clone");
+    const state = createStateWithRequest(request, { cronJobs: [source] });
+
+    startCronClone(state, source);
+    expect(await addCronJob(state)).toEqual({ saved: true, jobId: "cap-clone" });
+
+    const submitted = requestPayload(findRequestCall(request.mock.calls, "cron.add"));
+    const payload = requireRecord(submitted.payload, "cloned payload");
+    expect(validateCronAddParams(submitted)).toBe(true);
+    expect(source).toEqual(original);
+    expect(payload).not.toHaveProperty("toolsAllowIsDefault");
+    if ("effectiveUnrestricted" in scenario) {
+      // Fresh trusted creation defaults an omitted cap to wildcard.
+      expect(payload.toolsAllow ?? ["*"]).toEqual(["*"]);
+    } else if ("toolsAllow" in policy) {
+      expect(payload.toolsAllow).toEqual(policy.toolsAllow);
+    } else {
+      expect(payload).not.toHaveProperty("toolsAllow");
+    }
+  });
+
+  it.each([
+    { name: "empty fallbacks", policy: { fallbacks: [] } },
+    { name: "explicit fallbacks", policy: { fallbacks: ["openai/gpt-5.5"] } },
+    { name: "unsafe-content false", policy: { allowUnsafeExternalContent: false } },
+    { name: "unsafe-content true", policy: { allowUnsafeExternalContent: true } },
+    { name: "light-context false", policy: { lightContext: false } },
+    { name: "light-context true", policy: { lightContext: true } },
+    { name: "inherited light context", policy: {} },
+  ] satisfies Array<{
+    name: string;
+    policy: Partial<Extract<CronJob["payload"], { kind: "agentTurn" }>>;
+  }>)("clone payload policy: preserves $name for an agent task", async ({ policy }) => {
+    const source = createCronJob({
+      id: "agent-policy-source",
+      name: "Agent policy source",
+      payload: { kind: "agentTurn", message: "Synthetic agent task", ...policy },
+      delivery: { mode: "none" },
+    });
+    const original = structuredClone(source);
+    const request = createCronRequest("agent-policy-clone");
+    const state = createStateWithRequest(request, { cronJobs: [source] });
+
+    startCronClone(state, source);
+    expect(await addCronJob(state)).toEqual({ saved: true, jobId: "agent-policy-clone" });
+
+    const submitted = requestPayload(findRequestCall(request.mock.calls, "cron.add"));
+    expect(validateCronAddParams(submitted)).toBe(true);
+    expect(source).toEqual(original);
+    expect(submitted.payload).toEqual({
+      kind: "agentTurn",
+      message: "Synthetic agent task",
+      ...policy,
+    });
+  });
+
+  it("clone payload policy: visible edits replace stored values including unchecked light context", async () => {
+    const source = createCronJob({
+      id: "edited-payload-source",
+      name: "Editable source",
+      payload: {
+        kind: "agentTurn",
+        message: "Original task",
+        model: "openai/gpt-5.4",
+        thinking: "high",
+        timeoutSeconds: 45,
+        lightContext: true,
+      },
+      delivery: { mode: "none" },
+    });
+    const original = structuredClone(source);
+    const request = createCronRequest("edited-payload-clone");
+    const state = createStateWithRequest(request, { cronJobs: [source] });
+    startCronClone(state, source);
+    Object.assign(state.cronForm, {
+      payloadText: "  Edited task  ",
+      payloadModel: " openai/gpt-5.5 ",
+      payloadThinking: " low ",
+      timeoutSeconds: "0.25",
+      payloadLightContext: false,
+    });
+
+    expect(await addCronJob(state)).toEqual({ saved: true, jobId: "edited-payload-clone" });
+
+    const submitted = requestPayload(findRequestCall(request.mock.calls, "cron.add"));
+    expect(validateCronAddParams(submitted)).toBe(true);
+    expect(source).toEqual(original);
+    expect(submitted.payload).toEqual({
+      kind: "agentTurn",
+      message: "Edited task",
+      model: "openai/gpt-5.5",
+      thinking: "low",
+      timeoutSeconds: 0.25,
+      lightContext: false,
+    });
+  });
+
+  it("clone payload policy: blank visible overrides stay omitted instead of restoring the source", async () => {
+    const source = createCronJob({
+      id: "blank-payload-source",
+      name: "Blank overrides source",
+      payload: {
+        kind: "agentTurn",
+        message: "Synthetic task",
+        model: "openai/gpt-5.5",
+        thinking: "high",
+        timeoutSeconds: 45,
+      },
+      delivery: { mode: "none" },
+    });
+    const original = structuredClone(source);
+    const request = createCronRequest("blank-payload-clone");
+    const state = createStateWithRequest(request, { cronJobs: [source] });
+    startCronClone(state, source);
+    Object.assign(state.cronForm, {
+      payloadModel: " ",
+      payloadThinking: " ",
+      timeoutSeconds: " ",
+    });
+
+    expect(await addCronJob(state)).toEqual({ saved: true, jobId: "blank-payload-clone" });
+
+    const submitted = requestPayload(findRequestCall(request.mock.calls, "cron.add"));
+    expect(validateCronAddParams(submitted)).toBe(true);
+    expect(source).toEqual(original);
+    expect(submitted.payload).toEqual({ kind: "agentTurn", message: "Synthetic task" });
+  });
+
+  it.each([
+    {
+      name: "system event with a trigger",
+      payload: { kind: "systemEvent", text: "Original event", toolsAllow: ["read"] },
+      trigger: { script: "return { fire: true }", once: true },
+      target: "systemEvent",
+    },
+    {
+      name: "system event to agent task",
+      payload: { kind: "systemEvent", text: "Original event", toolsAllow: [] },
+      trigger: { script: "return { fire: true }", once: true },
+      target: "agentTurn",
+    },
+    {
+      name: "agent task to system event",
+      payload: {
+        kind: "agentTurn",
+        message: "Original task",
+        toolsAllow: ["read"],
+        fallbacks: [],
+        allowUnsafeExternalContent: true,
+        lightContext: false,
+      },
+      trigger: undefined,
+      target: "systemEvent",
+    },
+    {
+      name: "command to new agent task",
+      payload: { kind: "command", argv: ["node", "synthetic.mjs"], toolsAllow: [] },
+      trigger: undefined,
+      target: "agentTurn",
+    },
+    {
+      name: "script to new agent task",
+      payload: { kind: "script", script: "return { ok: true }", toolsAllow: ["read"] },
+      trigger: undefined,
+      target: "agentTurn",
+    },
+  ] satisfies Array<{
+    name: string;
+    payload: CronJob["payload"];
+    trigger: CronJob["trigger"];
+    target: "agentTurn" | "systemEvent";
+  }>)("clone payload policy: retains common restrictions for $name", async (scenario) => {
+    const source = createCronJob({
+      id: "kind-source",
+      name: "Kind transition source",
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: scenario.payload.kind === "systemEvent" ? "main" : "isolated",
+      payload: scenario.payload,
+      trigger: scenario.trigger,
+      delivery: { mode: "none" },
+    });
+    const original = structuredClone(source);
+    const request = createCronRequest("kind-clone");
+    const state = createStateWithRequest(request, { cronJobs: [source] });
+    startCronClone(state, source);
+    if (scenario.payload.kind === "command" || scenario.payload.kind === "script") {
+      expect(state.cronForm.payloadText).toBe("");
+      expect(await addCronJob(state)).toEqual({ saved: false });
+      expect(state.cronFieldErrors.payloadText).toBe("cron.errors.agentMessageRequired");
+      expect(request).not.toHaveBeenCalled();
+    }
+    Object.assign(state.cronForm, {
+      payloadKind: scenario.target,
+      sessionTarget: scenario.target === "systemEvent" ? "main" : "isolated",
+      payloadText: "New operator-authored task",
+    });
+
+    expect(await addCronJob(state)).toEqual({ saved: true, jobId: "kind-clone" });
+
+    const submitted = requestPayload(findRequestCall(request.mock.calls, "cron.add"));
+    expect(validateCronAddParams(submitted)).toBe(true);
+    expect(source).toEqual(original);
+    expect(submitted.trigger).toEqual(scenario.trigger);
+    expect(submitted.payload).toEqual({
+      kind: scenario.target,
+      ...(scenario.target === "systemEvent"
+        ? { text: "New operator-authored task" }
+        : { message: "New operator-authored task" }),
+      toolsAllow: scenario.payload.toolsAllow,
+    });
+  });
+
+  it.each([
+    { name: "explicit cap", toolsAllowIsDefault: undefined, target: "agentTurn" },
+    { name: "default-marked cap", toolsAllowIsDefault: true, target: "agentTurn" },
+    { name: "payload kind change", toolsAllowIsDefault: true, target: "systemEvent" },
+  ] as const)(
+    "clone payload policy: does not echo hidden policy during an update with $name",
+    async (scenario) => {
+      const source = createCronJob({
+        id: "update-policy-source",
+        name: "Update policy source",
+        payload: {
+          kind: "agentTurn",
+          message: "Synthetic task",
+          toolsAllow: ["read"],
+          ...(scenario.toolsAllowIsDefault ? { toolsAllowIsDefault: true } : {}),
+          fallbacks: [],
+          allowUnsafeExternalContent: true,
+          lightContext: false,
+        },
+        delivery: { mode: "none" },
+      });
+      const original = structuredClone(source);
+      const { state, submit } = createCronEditHarness(source);
+      state.cronForm.description = "Metadata changed";
+      Object.assign(state.cronForm, {
+        payloadKind: scenario.target,
+        sessionTarget: scenario.target === "systemEvent" ? "main" : "isolated",
+      });
+
+      const call = await submit();
+
+      expect(validateCronUpdateParams(requestPayload(call))).toBe(true);
+      expect(source).toEqual(original);
+      const payload = requireRecord(requestPatch(call).payload, "updated payload");
+      expect(payload.kind).toBe(scenario.target);
+      for (const field of [
+        "toolsAllow",
+        "toolsAllowIsDefault",
+        "fallbacks",
+        "allowUnsafeExternalContent",
+      ]) {
+        expect(payload).not.toHaveProperty(field);
+      }
+    },
+  );
+
+  it.each([
     { name: "precise one-shot", schedule: { kind: "at", at: "2030-01-02T03:04:56.789Z" } },
     {
       name: "anchored interval",

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -1028,13 +1028,17 @@ function buildCronSchedule(form: CronFormState) {
   return { kind: "cron" as const, expr, tz: form.cronTz.trim() || undefined, staggerMs };
 }
 
-function buildCronPayload(form: CronFormState) {
+function buildCronPayload(form: CronFormState, source: CronPayload | null, isUpdate: boolean) {
+  // Clones carry public restrictions, not the source's capture markers or authority.
+  // Updates must omit caps so the Gateway retains that job's existing authority.
+  const toolsAllow = !isUpdate && source && "toolsAllow" in source ? source.toolsAllow : undefined;
+  const restrictions = toolsAllow ? { toolsAllow: [...toolsAllow] } : {};
   if (form.payloadKind === "systemEvent") {
     const text = form.payloadText.trim();
     if (!text) {
       throw new Error(t("cron.errors.systemEventTextRequired"));
     }
-    return { kind: "systemEvent" as const, text };
+    return { kind: "systemEvent" as const, text, ...restrictions };
   }
   if (form.payloadKind !== "agentTurn") {
     throw new Error(`Cron ${form.payloadKind} payloads are read-only in Control UI.`);
@@ -1043,33 +1047,35 @@ function buildCronPayload(form: CronFormState) {
   if (!message) {
     throw new Error(t("cron.errors.agentMessageRequiredShort"));
   }
-  const payload: {
-    kind: "agentTurn";
-    message: string;
-    model?: string | null;
-    thinking?: string | null;
-    timeoutSeconds?: number;
-    lightContext?: boolean;
-  } = { kind: "agentTurn", message };
-  const model = form.payloadModel.trim();
-  if (model) {
-    payload.model = model;
-  }
-  const thinking = form.payloadThinking.trim();
-  if (thinking) {
-    payload.thinking = thinking;
-  }
+  const original = source?.kind === "agentTurn" ? source : undefined;
+  const cloned = isUpdate ? undefined : original;
+  // Blank stored overrides clear on update; a new job leaves them inherited.
+  const model =
+    form.payloadModel.trim() || (isUpdate && original?.model !== undefined ? null : undefined);
+  const thinking =
+    form.payloadThinking.trim() ||
+    (isUpdate && original?.thinking !== undefined ? null : undefined);
   const timeoutRaw = form.timeoutSeconds.trim();
-  if (timeoutRaw) {
-    const timeoutSeconds = toNumber(timeoutRaw, Number.NaN);
-    if (Number.isFinite(timeoutSeconds) && timeoutSeconds >= 0) {
-      payload.timeoutSeconds = timeoutSeconds;
-    }
-  }
-  if (form.payloadLightContext) {
-    payload.lightContext = true;
-  }
-  return payload;
+  const timeoutSeconds = toNumber(timeoutRaw, Number.NaN);
+  const lightContext =
+    form.payloadLightContext || original?.lightContext !== undefined
+      ? form.payloadLightContext
+      : undefined;
+  return {
+    kind: "agentTurn" as const,
+    message,
+    ...(model !== undefined ? { model } : {}),
+    ...(thinking !== undefined ? { thinking } : {}),
+    ...(timeoutRaw && Number.isFinite(timeoutSeconds) && timeoutSeconds >= 0
+      ? { timeoutSeconds }
+      : {}),
+    ...(lightContext !== undefined ? { lightContext } : {}),
+    ...restrictions,
+    ...(cloned?.fallbacks ? { fallbacks: [...cloned.fallbacks] } : {}),
+    ...(cloned?.allowUnsafeExternalContent !== undefined
+      ? { allowUnsafeExternalContent: cloned.allowUnsafeExternalContent }
+      : {}),
+  };
 }
 
 function normalizePersistedDeliveryChannel(
@@ -1166,8 +1172,8 @@ export async function addCronJob(state: CronState): Promise<CronSaveResult> {
     const expectedConfigRevision = editingJob
       ? requireCronConfigRevision(state.cronEditingConfigRevision)
       : undefined;
-    const editingPayload = editingJob ? getCronJobPayload(editingJob) : null;
     const sourceJob = editingJob ?? state.cronCloningJob;
+    const sourcePayload = sourceJob ? getCronJobPayload(sourceJob) : null;
     // Form fields cannot represent process commands, anchors, or full timestamp precision.
     const schedule =
       sourceJob && hasUnchangedCronSchedule(form, sourceJob)
@@ -1176,24 +1182,11 @@ export async function addCronJob(state: CronState): Promise<CronSaveResult> {
           : sourceJob.schedule
         : buildCronSchedule(form);
     const preserveLockedPayload = Boolean(
-      editingJob && form.payloadLocked && isReadOnlyCronPayload(editingPayload),
+      editingJob && form.payloadLocked && isReadOnlyCronPayload(sourcePayload),
     );
-    const payload = preserveLockedPayload ? undefined : buildCronPayload(form);
-    if (payload?.kind === "agentTurn" && editingJob && editingPayload?.kind === "agentTurn") {
-      // When editing, a blanked field that previously held a stored override must
-      // send an explicit clear; an omitted key means "leave unchanged" on merge.
-      // The form only shows stored overrides (not inherited defaults), so a blank
-      // input with a stored value is an intentional clear.
-      if (!form.payloadModel.trim() && editingPayload.model !== undefined) {
-        payload.model = null;
-      }
-      if (!form.payloadThinking.trim() && editingPayload.thinking !== undefined) {
-        payload.thinking = null;
-      }
-      if (!form.payloadLightContext && editingPayload.lightContext !== undefined) {
-        payload.lightContext = false;
-      }
-    }
+    const payload = preserveLockedPayload
+      ? undefined
+      : buildCronPayload(form, sourcePayload, Boolean(editingJob));
     const selectedDeliveryMode = form.deliveryMode;
     const normalizedDeliveryAccountId = form.deliveryAccountId.trim();
     // Update patches need null to clear stored routing; create payloads must


### PR DESCRIPTION
Closes #137394

## What Problem This Solves

Fixes an issue where users cloning an automation in the Control UI would silently lose stored payload options. A finite or empty tool allowlist became the default wildcard policy, an empty model fallback list disappeared, and explicit lightweight-context and external-content settings were omitted.

## Why This Change Was Made

The existing form payload builder now carries the clone source's public options alongside the operator's visible edits. It also handles update-field clears, replacing the separate update post-processing path. Updates continue omitting hidden policy so the Gateway retains the existing task's authority. A clone remains a newly authorized operator-created task: captured execution grants and provenance are not copied.

This is a UI serialization repair. There are no backend, storage, schema, configuration, dependency, or protocol changes. The existing conversion of command/script clones into a newly authored agent prompt remains unchanged.

## User Impact

Cloned tasks retain their stored tool allowlist, agent model fallback list, lightweight-context choice, and external-content setting, including empty lists and explicit `false` values. Changes made in the clone form take precedence. The Control UI documentation now describes the behavior and the authority boundary.

## Evidence

Candidate: `37421c694554b69b34ca316958b6bbb27b0ce5e8` (exact reviewed source bytes).

On base `d2a616bdf373a5b3cac0add8e9b2f70cd0802f42`, the new controller cases reproduced 14 failures with eight controls passing. The same test bytes pass after the fix; all 202 controller tests and 77 backend payload-merge, patch, and fallback-policy tests pass.

A real local Gateway served the built Control UI. Playwright opened each disabled synthetic task, used Clone and Create, and independently read the original and new task through the Gateway CLI. Before the repair, the two variants produced 16 request/storage assertion failures in total. After the repair, both variants pass; originals are unchanged. The full four-case browser file also passes in its original order, covering existing duration and failure-alert behavior.

| Stored clone payload | Before | After |
| --- | --- | --- |
| Finite `toolsAllow: ["read"]` | `["*"]` | `["read"]` |
| Empty `toolsAllow: []` | `["*"]` | `[]` |
| `fallbacks: []` | absent | `[]` |
| `lightContext: false` | absent | `false` |
| `allowUnsafeExternalContent: false` / `true` | absent | exact original boolean |

The same values were checked in the actual `cron.add` request and independent stored-job readback. Fixtures remained disabled; this proves Clone/Create persistence, not model/tool execution or transfer of native execution authority. Attached before/after screenshots show the synthetic UI flow; hidden policy values are established by request and CLI assertions, not pixels.

Both normal paired builds passed. The candidate's startup JavaScript is 350,132 compressed bytes against the unchanged 350,141-byte gate; no budgets or baselines were raised.

Production: **39 added / 46 removed (net −7)**. Tests: **398 added / 1 removed (net +397)**. Documentation: **1 line added**. The cleanup removes the separate update payload correction path and redundant incremental payload construction.

All 20 canonical changed-path checks pass. A test-only lint error found during the first pass was corrected by using the known fixture name; the full browser file and all required checks passed again. Two independent Codex reviews of the final candidate completed with no actionable P0–P2 findings (four complete source batches each). [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33779356045) passed on this exact head on attempt 1: 94 successful jobs and 12 skipped, including the required `openclaw/ci-gate`. No CI retries or cancellations were needed.

![Before fix: synthetic clone; CLI readback loses the finite tool cap.](https://github.com/user-attachments/assets/4e58abfb-02ad-419a-800f-6ac15f72a623)

![After fix: synthetic clone; CLI readback preserves the finite tool cap.](https://github.com/user-attachments/assets/29df7d0f-d561-48ea-9f64-e8118cee9f8c)

ClawSweeper completed its review of this exact head at 2026-09-03 16:46 UTC: no actionable correctness or security findings, Before merge: None, and no Rank-up moves. Root read the complete published review and agrees with its owner-boundary assessment. Review: https://github.com/openclaw/openclaw/pull/137419#issuecomment-5529047878
