### PR TITLE
docs(cli): list worktrees in the CLI index

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -29,6 +29,7 @@ Setup commands by intent:
 | Models and inference         | [`models`](/cli/models) · [`promos`](/cli/promos) · [`infer`](/cli/infer) · `capability` (alias for [`infer`](/cli/infer)) · [`memory`](/cli/memory) · [`wiki`](/cli/wiki)                                                            |
 | Network and nodes            | [`connect`](/cli/connect) · [`directory`](/cli/directory) · [`nodes`](/cli/nodes) · [`devices`](/cli/devices) · [`node`](/cli/node) · [`worker`](/cli/worker)                                                                         |
 | Runtime and sandbox          | [`approvals`](/cli/approvals) · `exec-policy` (see [`approvals`](/cli/approvals)) · [`sandbox`](/cli/sandbox) · [`tui`](/cli/tui) · `chat`/`terminal` (aliases for [`tui --local`](/cli/tui)) · [`browser`](/cli/browser)             |
+| Worktrees                    | [`worktrees`](/concepts/managed-worktrees)                                                                                                                                                                                            |
 | Automation                   | [`cron`](/cli/cron) · [`tasks`](/cli/tasks) · [`hooks`](/cli/hooks) · [`webhooks`](/cli/webhooks) · [`transcripts`](/cli/transcripts)                                                                                                 |
 | Discovery and docs           | [`dns`](/cli/dns) · [`docs`](/cli/docs)                                                                                                                                                                                               |
 | Pairing and channels         | [`pairing`](/cli/pairing) · [`qr`](/cli/qr) · [`channels`](/cli/channels)                                                                                                                                                             |
@@ -323,6 +324,12 @@ openclaw [--dev] [--profile <name>] <command>
     restart
     upgrade
     rm
+  worktrees
+    list
+    create
+    remove
+    restore
+    gc
   daemon
     status
     install


### PR DESCRIPTION
## What Problem This Solves

The CLI index omits the existing `openclaw worktrees` command. Readers cannot discover its reference from the command table or find its operations in the command tree.

## Why This Change Was Made

Add a Worktrees entry linked to the existing managed-worktrees guide, and list `list`, `create`, `remove`, `restore`, and `gc` under `worktrees`. The guide remains the single detailed reference. This preserves the contributor's seven-line change and current index updates.

## User Impact

Operators can find the existing worktree commands from the CLI index. Command behavior, flags, defaults, and storage do not change.

## Evidence

- Generated the baseline and candidate with the official documentation publisher and renderer.
- Baseline browser check: the command table and expanded command tree omit worktrees.
- Candidate browser check: the index lists all five operations and links to the existing guide.
- Native changed-file checks, docs formatting, docs-list, MDX validation, internal-link validation, and commit hook passed.
- No worktree creation, removal, restore, or garbage collection was needed.

Thanks to @qingminglong for the original contribution.
