### PR TITLE
test: simplify entry diagnostic mocks

### DIFF
--- a/src/entry.test.ts
+++ b/src/entry.test.ts
@@ -126,12 +126,10 @@ describe("entry root help fast path", () => {
   it("structures root help rendering failures for JSON console style", async () => {
     const logging = await import("./logging.js");
     logging.setLoggerOverride({ level: "silent", consoleLevel: "info", consoleStyle: "json" });
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
       throw new Error(`exit ${String(code)}`);
-    }) as typeof process.exit);
+    });
 
     try {
       await expect(


### PR DESCRIPTION
## Summary

Simplify two mocks in the existing root-help JSON diagnostic failure test: use `mockReturnValue(true)` for stderr and let the always-throwing exit callback receive its type from `spyOn`. This removes unnecessary type assertions while preserving runtime behavior. Production code is unchanged; the test diff removes two net lines.

## Changes

Keep the real JSON formatter and default error route, exit(1) observation, parsed error/message assertions, and finally cleanup. All 32 Entry cases and 53 expectations remain.

## Validation

The unchanged baseline and candidate each passed the same ordered 71 cases across Entry, version fast path, and console capture. The normal one-path changed gate passed all 20 stages. Managed Codex review completed with no actionable P0–P2 findings after earlier review transport failures; no source or proof was weakened.

## Follow-up

Audit the separate `firstMockArgAsString` duplication in logging tests. Nonthrowing exit fixtures retain their meaningful void-versus-never boundary.
