### PR TITLE
test(doctor): simplify platform note assertions

### DIFF
--- a/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
+++ b/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
@@ -1,5 +1,6 @@
 // Doctor launchctl environment tests cover macOS gateway platform warnings for env overrides.
 import fs from "node:fs";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
@@ -17,39 +18,9 @@ import {
   noteMacStaleOpenClawUpdateLaunchdJobs,
 } from "./doctor-platform-notes.js";
 
-function requireNoteCall(noteFn: { mock: { calls: unknown[][] } }, index = 0): unknown[] {
-  const call = noteFn.mock.calls[index];
-  if (!call) {
-    throw new Error(`expected note call ${index}`);
-  }
-  return call;
-}
-
 describe("noteMacLaunchctlGatewayEnvOverrides", () => {
   beforeEach(() => {
     processMocks.runExec.mockReset().mockResolvedValue({ stdout: "", stderr: "" });
-  });
-
-  it("collects clear unsetenv instructions for token override", async () => {
-    const noteFn = vi.fn();
-    const getenv = vi.fn(async (name: string) =>
-      name === "OPENCLAW_GATEWAY_TOKEN" ? "launchctl-token" : undefined,
-    );
-    const cfg = {
-      gateway: {
-        auth: {
-          token: "config-token",
-        },
-      },
-    } as OpenClawConfig;
-
-    await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "darwin", getenv, noteFn });
-    const [warning] = requireNoteCall(noteFn);
-
-    expect(warning).toContain("Host-wide launchctl gateway auth overrides detected");
-    expect(warning).toContain("OPENCLAW_GATEWAY_TOKEN");
-    expect(warning).toContain("launchctl unsetenv OPENCLAW_GATEWAY_TOKEN");
-    expect(warning).not.toContain("OPENCLAW_GATEWAY_PASSWORD");
   });
 
   it("prints clear unsetenv instructions for token override", async () => {
@@ -70,7 +41,7 @@ describe("noteMacLaunchctlGatewayEnvOverrides", () => {
     expect(noteFn).toHaveBeenCalledTimes(1);
     expect(getenv).toHaveBeenCalledTimes(2);
 
-    const [message, title] = requireNoteCall(noteFn);
+    const [message, title] = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call 0");
     expect(title).toBe("Gateway (macOS)");
     expect(message).toContain("Host-wide launchctl gateway auth overrides detected");
     expect(message).toContain("Current managed Gateway installs do not need these values");
@@ -111,7 +82,7 @@ describe("noteMacLaunchctlGatewayEnvOverrides", () => {
     await noteMacLaunchctlGatewayEnvOverrides(cfg, { platform: "darwin", getenv, noteFn });
 
     expect(noteFn).toHaveBeenCalledTimes(1);
-    const [message] = requireNoteCall(noteFn);
+    const [message] = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call 0");
     expect(message).toContain("OPENCLAW_GATEWAY_PASSWORD");
   });
 
@@ -242,7 +213,7 @@ describe("noteMacStaleOpenClawUpdateLaunchdJobs", () => {
     });
 
     expect(findJobs).toHaveBeenCalledTimes(1);
-    const [message, title] = requireNoteCall(noteFn);
+    const [message, title] = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call 0");
     expect(title).toBe("Gateway (macOS)");
     expect(message).toContain("Stale OpenClaw updater launchd job(s) detected");
     expect(message).toContain("ai.openclaw.update.2026.5.12");

--- a/src/commands/doctor-platform-notes.startup-optimization.test.ts
+++ b/src/commands/doctor-platform-notes.startup-optimization.test.ts
@@ -1,10 +1,7 @@
 // Doctor platform note tests cover startup optimization hints and note output.
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { describe, expect, it, vi } from "vitest";
 import { noteStartupOptimizationHints } from "./doctor-platform-notes.js";
-
-function firstNoteCall(noteFn: ReturnType<typeof vi.fn>) {
-  return noteFn.mock.calls[0] ?? [];
-}
 
 describe("noteStartupOptimizationHints", () => {
   it("does not warn when compile cache and no-respawn are configured", () => {
@@ -32,7 +29,7 @@ describe("noteStartupOptimizationHints", () => {
     );
 
     expect(noteFn).toHaveBeenCalledTimes(1);
-    const [message, title] = firstNoteCall(noteFn);
+    const [message, title] = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call 0");
     expect(title).toBe("Startup optimization");
     expect(message).toBe(
       [
@@ -59,7 +56,7 @@ describe("noteStartupOptimizationHints", () => {
     );
 
     expect(noteFn).toHaveBeenCalledTimes(1);
-    const [message] = firstNoteCall(noteFn);
+    const [message] = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call 0");
     expect(message).toBe(
       [
         "- NODE_DISABLE_COMPILE_CACHE is set; startup compile cache is disabled.",


### PR DESCRIPTION
Reuse the canonical presence assertion for Doctor platform-note mock calls and remove a redundant token-override case already covered by the adjacent emitter test. Runtime code is unchanged.

Validation: the same four suites passed 27 cases before and 26 after on Node 26.5.0, with every retained case and assertion preserved. The normal two-file changed check passed, and a fresh Codex P2 review found no actionable defects.
