### PR TITLE
refactor(ui): reuse canonical deferreds in subscription tests

### DIFF
--- a/packages/gateway-client/src/session-subscriptions.test.ts
+++ b/packages/gateway-client/src/session-subscriptions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   GatewayProtocolRequestTimeoutError,
   type GatewayProtocolRequestOptions,
@@ -25,16 +26,6 @@ function createClient(
     } as unknown as GatewaySessionMessageRequestClient,
     request,
   };
-}
-
-function deferred<T>() {
-  let resolve: (value: T) => void = () => undefined;
-  let reject: (error: unknown) => void = () => undefined;
-  const promise = new Promise<T>((next, fail) => {
-    resolve = next;
-    reject = fail;
-  });
-  return { promise, resolve, reject };
 }
 
 function createStalledRequestClient(stalledMethod: string, stalledKey: string) {
@@ -176,7 +167,7 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
   ])(
     "coalesces $name aliases before the first canonical acknowledgment",
     async ({ requestedKey, canonicalKey }) => {
-      const acknowledgement = deferred<unknown>();
+      const acknowledgement = createDeferred<unknown>();
       const { client, request } = createClient(async (method) =>
         method === "sessions.messages.subscribe" ? await acknowledgement.promise : {},
       );
@@ -208,7 +199,7 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
   );
 
   it("upgrades a provisional canonical alias without creating a competing plain observer", async () => {
-    const acknowledgement = deferred<unknown>();
+    const acknowledgement = createDeferred<unknown>();
     const replay = { approvals: [{ id: "approval-after-ack" }] };
     const { client, request } = createClient(async (method, params) => {
       if (method === "sessions.messages.unsubscribe") {
@@ -250,7 +241,7 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
   });
 
   it("keeps unacknowledged subscriptions isolated by canonical agent", async () => {
-    const acknowledgement = deferred<unknown>();
+    const acknowledgement = createDeferred<unknown>();
     const { client, request } = createClient(async (_method, params) =>
       params.agentId === "main" ? await acknowledgement.promise : { key: params.key },
     );
@@ -359,7 +350,7 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
   });
 
   it("coalesces concurrent releases of the final lease", async () => {
-    const unsubscribe = deferred<unknown>();
+    const unsubscribe = createDeferred<unknown>();
     const { client, request } = createClient(async (method, params) =>
       method === "sessions.messages.subscribe" ? { key: params.key } : await unsubscribe.promise,
     );
@@ -376,7 +367,7 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
   });
 
   it("waits for a closing observer before acquiring its replacement", async () => {
-    const unsubscribe = deferred<unknown>();
+    const unsubscribe = createDeferred<unknown>();
     const { client, request } = createClient(async (method, params) =>
       method === "sessions.messages.subscribe" ? { key: params.key } : await unsubscribe.promise,
     );
@@ -494,7 +485,7 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
   });
 
   it("lets concurrent plain observers recover when the first approval request is unauthorized", async () => {
-    const approval = deferred<unknown>();
+    const approval = createDeferred<unknown>();
     const { client, request } = createClient(async (method, params) => {
       if (method === "sessions.messages.unsubscribe") {
         return {};
@@ -525,7 +516,7 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
   });
 
   it("releases the last plain owner after its provisional approval upgrade fails", async () => {
-    const approval = deferred<unknown>();
+    const approval = createDeferred<unknown>();
     const { client, request } = createClient(async (method, params) => {
       if (method === "sessions.messages.unsubscribe") {
         return {};
@@ -606,7 +597,7 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
   });
 
   it("rejects a subscribe acknowledgment from a retired connection", async () => {
-    const response = deferred<unknown>();
+    const response = createDeferred<unknown>();
     const { client, request } = createClient(async () => await response.promise);
     const coordinator = getGatewaySessionMessageSubscriptionCoordinator(client);
     const pending = coordinator.acquire("main");

--- a/ui/src/lib/sessions/index-subscriptions.test.ts
+++ b/ui/src/lib/sessions/index-subscriptions.test.ts
@@ -4,6 +4,7 @@ import {
   GatewayProtocolRequestTimeoutError,
 } from "@openclaw/gateway-client/browser";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createSessionCapability } from "./index.ts";
 import { createSessionScopedOperations } from "./session-scoped-operations.ts";
@@ -273,20 +274,14 @@ describe("createSessionCapability message subscriptions", () => {
       timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
       requestSent: true,
     });
-    let recoveryStarted: () => void = () => undefined;
-    let rejectRecovery: (error: Error) => void = () => undefined;
-    const recovering = new Promise<void>((resolve) => {
-      recoveryStarted = resolve;
-    });
-    const recovery = new Promise<never>((_resolve, reject) => {
-      rejectRecovery = reject;
-    });
+    const recovering = createDeferred();
+    const recovery = createDeferred<never>();
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.messages.subscribe") {
         throw timeout;
       }
-      recoveryStarted();
-      return await recovery;
+      recovering.resolve();
+      return await recovery.promise;
     });
     const forceReconnect = vi.fn();
     const client = { request, forceReconnect } as unknown as GatewayBrowserClient;
@@ -303,10 +298,10 @@ describe("createSessionCapability message subscriptions", () => {
     });
     const failure = operations.subscribeMessages("main").catch((error: unknown) => error);
 
-    await recovering;
+    await recovering.promise;
     current = false;
     operations.retireConnection(client);
-    rejectRecovery(new Error("retired Gateway connection"));
+    recovery.reject(new Error("retired Gateway connection"));
 
     await expect(failure).resolves.toBe(timeout);
     expect(forceReconnect).not.toHaveBeenCalled();

--- a/ui/src/pages/chat/chat-history-subscription-disposal.test.ts
+++ b/ui/src/pages/chat/chat-history-subscription-disposal.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
@@ -68,22 +69,19 @@ describe("disposed chat message subscriptions", () => {
   });
 
   it("releases a subscription that resolves after its pane is disposed", async () => {
-    let resolveSubscription: (value: typeof subscription) => void = () => undefined;
-    const pendingSubscription = new Promise<typeof subscription>((resolve) => {
-      resolveSubscription = resolve;
-    });
+    const pendingSubscription = createDeferred<typeof subscription>();
     const unsubscribeMessages = vi
       .fn<SessionCapability["unsubscribeMessages"]>()
       .mockResolvedValue(undefined);
     const state = createSubscriptionState(
       unsubscribeMessages,
-      vi.fn<SessionCapability["subscribeMessages"]>().mockReturnValue(pendingSubscription),
+      vi.fn<SessionCapability["subscribeMessages"]>().mockReturnValue(pendingSubscription.promise),
     );
 
     const sync = syncSelectedSessionMessageSubscription(state as never);
     await Promise.resolve();
     disposeSelectedSessionMessageSubscription(state);
-    resolveSubscription(subscription);
+    pendingSubscription.resolve(subscription);
     await sync;
 
     expect(unsubscribeMessages).toHaveBeenCalledExactlyOnceWith(subscription);

--- a/ui/src/pages/chat/chat-history-subscription-errors.test.ts
+++ b/ui/src/pages/chat/chat-history-subscription-errors.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
   disposeSelectedSessionMessageSubscription,
@@ -140,18 +141,17 @@ describe("visible chat message subscription failures", () => {
   });
 
   it("never publishes a failed subscription after its pane is disposed", async () => {
-    let rejectSubscription: (error: Error) => void = () => undefined;
-    const pending = new Promise<Subscription>((_resolve, reject) => {
-      rejectSubscription = reject;
-    });
+    const pending = createDeferred<Subscription>();
     const { state } = createSubscriptionState({
-      subscribeMessages: vi.fn<SessionCapability["subscribeMessages"]>().mockReturnValue(pending),
+      subscribeMessages: vi
+        .fn<SessionCapability["subscribeMessages"]>()
+        .mockReturnValue(pending.promise),
     });
 
     const sync = syncSelectedSessionMessageSubscription(state);
     await Promise.resolve();
     disposeSelectedSessionMessageSubscription(state);
-    rejectSubscription(new Error("Retired observer unavailable"));
+    pending.reject(new Error("Retired observer unavailable"));
     await sync;
 
     expect(state.lastError).toBeNull();
@@ -160,18 +160,17 @@ describe("visible chat message subscription failures", () => {
   });
 
   it("never publishes a failed subscription from a replaced same-client generation", async () => {
-    let rejectSubscription: (error: Error) => void = () => undefined;
-    const pending = new Promise<Subscription>((_resolve, reject) => {
-      rejectSubscription = reject;
-    });
+    const pending = createDeferred<Subscription>();
     const { state } = createSubscriptionState({
-      subscribeMessages: vi.fn<SessionCapability["subscribeMessages"]>().mockReturnValue(pending),
+      subscribeMessages: vi
+        .fn<SessionCapability["subscribeMessages"]>()
+        .mockReturnValue(pending.promise),
     });
 
     const sync = syncSelectedSessionMessageSubscription(state);
     await Promise.resolve();
     state.connectionEpoch += 1;
-    rejectSubscription(new Error("Prior connection generation unavailable"));
+    pending.reject(new Error("Prior connection generation unavailable"));
     await sync;
 
     expect(state.lastError).toBeNull();
@@ -252,20 +251,14 @@ describe("selected agent subscription changes", () => {
 
   it("keeps the latest selection when pending release retries settle out of order", async () => {
     const previous = { key: "agent:main:previous", agentId: null };
-    let resolveSecondRetry: () => void = () => undefined;
-    let resolveLatestRetry: () => void = () => undefined;
-    const secondRetry = new Promise<void>((resolve) => {
-      resolveSecondRetry = resolve;
-    });
-    const latestRetry = new Promise<void>((resolve) => {
-      resolveLatestRetry = resolve;
-    });
+    const secondRetry = createDeferred();
+    const latestRetry = createDeferred();
     const unsubscribeMessages = vi
       .fn()
       .mockRejectedValueOnce(new Error("previous release failed"))
       .mockRejectedValueOnce(new Error("replacement release failed"))
-      .mockReturnValueOnce(secondRetry)
-      .mockReturnValueOnce(latestRetry)
+      .mockReturnValueOnce(secondRetry.promise)
+      .mockReturnValueOnce(latestRetry.promise)
       .mockResolvedValue(undefined);
     const subscribeMessages = vi.fn(async (key: string) => ({ key, agentId: null }));
     const state = {
@@ -285,9 +278,9 @@ describe("selected agent subscription changes", () => {
     const latestSync = syncSelectedSessionMessageSubscription(state as never);
     await Promise.resolve();
 
-    resolveLatestRetry();
+    latestRetry.resolve();
     await latestSync;
-    resolveSecondRetry();
+    secondRetry.resolve();
     await secondSync;
 
     expect(state.chatSessionMessageSubscriptionRequestedKey).toBe("agent:main:latest");

--- a/ui/src/pages/chat/chat-history.test.ts
+++ b/ui/src/pages/chat/chat-history.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { reduceSessionProjection } from "@openclaw/gateway-client/browser";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import { rewindChatHistory, switchChatHistoryBranch } from "./chat-history-actions.ts";
 import type { ChatHistoryResult } from "./chat-history-snapshot.ts";
@@ -207,16 +208,13 @@ describe("syncSelectedSessionMessageSubscription", () => {
   it("retries a stale generation's rejected subscription release", async () => {
     const stale = { key: "agent:main:stale", agentId: null };
     const selected = { key: "agent:main:selected", agentId: null };
-    let resolveStale: (subscription: typeof stale) => void = () => undefined;
-    const staleSubscription = new Promise<typeof stale>((resolve) => {
-      resolveStale = resolve;
-    });
+    const staleSubscription = createDeferred<typeof stale>();
     const unsubscribeMessages = vi
       .fn()
       .mockRejectedValueOnce(new Error("stale release temporarily failed"))
       .mockResolvedValueOnce(undefined);
     const subscribeMessages = vi.fn(async (key: string) =>
-      key === stale.key ? await staleSubscription : selected,
+      key === stale.key ? await staleSubscription.promise : selected,
     );
     const state = createState({ messages: [] }) as TestState & {
       chatSessionMessageSubscriptionRequestedKey: string | null;
@@ -236,7 +234,7 @@ describe("syncSelectedSessionMessageSubscription", () => {
     state.sessionKey = selected.key;
     await syncSelectedSessionMessageSubscription(state as never);
 
-    resolveStale(stale);
+    staleSubscription.resolve(stale);
     await staleSync;
 
     expect(state.chatSessionMessageSubscription).toBe(selected);


### PR DESCRIPTION
## What Problem This Solves

Subscription tests duplicate promise/resolver setup that the shared test helper already provides. This makes the fixtures longer without adding coverage.

## Why This Change Was Made

Use `createDeferred` for eight eagerly allocated UI gates and replace the gateway-client suite’s local deferred helper at its eight call sites. Existing per-invocation lazy gates and the timeout-producing promise remain unchanged. The diff changes five test files: production 0 lines; tests +41/−66 (net −25).

## User Impact

No user-visible behavior changes. Subscription aliases, approval access, generation retirement, selection ordering, retries, and disposal retain their existing coverage.

## Evidence

The same normal five-file route passed all 77 cases before and after the cleanup. All 280 assertion statements, case tables, timer calls, and non-ASCII strings are unchanged. Case order within every file is identical; the normal runner selected a different order between files.

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/chat-history.test.ts ui/src/pages/chat/chat-history-subscription-errors.test.ts ui/src/pages/chat/chat-history-subscription-disposal.test.ts ui/src/lib/sessions/index-subscriptions.test.ts packages/gateway-client/src/session-subscriptions.test.ts
node scripts/check-changed.mjs -- ui/src/pages/chat/chat-history.test.ts ui/src/pages/chat/chat-history-subscription-errors.test.ts ui/src/pages/chat/chat-history-subscription-disposal.test.ts ui/src/lib/sessions/index-subscriptions.test.ts packages/gateway-client/src/session-subscriptions.test.ts
```

The initial full gate ran through Testbox because the launcher inherited its routing flag and failed on three redundant `<void>` arguments. After omitting those default arguments, the same 77 cases, scoped lint, and the full local changed gate passed. The original failed run and completed cleanup remain recorded separately. Fresh managed Codex review found no actionable P0/P1/P2 issues; that review was static and did not independently rerun the proof commands.
