### PR TITLE
fix: make completion permission recovery actionable

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -44,6 +44,19 @@ Profile changes are staged beside the destination and atomically replace it only
 
 Installed source lines preserve literal cache paths, including spaces, quotes, dollar signs, and backslashes. Reinstalling replaces OpenClaw's previous source line after the state directory changes.
 
+## Permission failures
+
+If Doctor or onboarding cannot update your shell profile, completion remains
+optional and setup continues. When a cache is available, the warning includes a
+command to load that cache in your current matching shell session. Run the complete
+command as printed. This does not install completion for future shell sessions.
+
+For persistent installation, resolve the reported permission or read-only error
+before retrying `openclaw completion --install`. The failure location may be a
+staging directory or a symlink target, not the profile itself. Atomic replacement
+also needs write access to the destination directory. The installer uses the
+profile selected in the table above; it has no profile-file destination option.
+
 ## Notes
 
 - Without `--install` or `--write-state`, the command prints the script to stdout.

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -473,7 +473,7 @@ describe("completion-runtime", () => {
     async ({ shell, generation }) => {
       await withBashCompletionHome(async () => {
         const previousStateDir = tempDirs.make(
-          `openclaw-completion-previous-${process.platform === "win32" ? "" : '"'}$state's-`,
+          `openclaw-completion-previous-${process.platform === "win32" ? "" : '"'}$state's ‘quoted’-`,
         );
         const profilePath = resolveCompletionProfilePath(shell);
         await withEnvAsync({ OPENCLAW_STATE_DIR: previousStateDir }, async () => {
@@ -708,10 +708,11 @@ describe("completion-runtime", () => {
     });
   });
 
-  it("formats PowerShell reload commands with single-quoted paths", () => {
-    expect(formatCompletionReloadCommand("powershell", "C:\\Users\\Ada\\profile.ps1")).toBe(
-      ". 'C:\\Users\\Ada\\profile.ps1'",
-    );
+  it.each([
+    { profile: "C:\\Users\\Ada\\profile.ps1", command: ". 'C:\\Users\\Ada\\profile.ps1'" },
+    { profile: "C:\\Users\\Ada’s\\profile.ps1", command: ". 'C:\\Users\\Ada’’s\\profile.ps1'" },
+  ])("formats a literal PowerShell reload command for $profile", ({ profile, command }) => {
+    expect(formatCompletionReloadCommand("powershell", profile)).toBe(command);
   });
 
   it.each(["bash", "zsh"] as const)(

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -12,6 +12,7 @@ import { isErrno } from "../infra/errors.js";
 import { decodeWindowsTextFileBuffer } from "../infra/windows-encoding.js";
 import { pathExists } from "../utils.js";
 import { publishOutputFileAtomically } from "./output-file.runtime.js";
+import { quotePowerShellArg } from "./quote-cli-arg.js";
 
 export const COMPLETION_SHELLS = ["zsh", "bash", "powershell", "fish"] as const;
 export type CompletionShell = (typeof COMPLETION_SHELLS)[number];
@@ -111,7 +112,7 @@ export async function completionCacheExists(
 
 function quoteCompletionPath(shell: CompletionShell, value: string): string {
   if (shell === "powershell") {
-    return `'${value.replace(/'/g, "''")}'`;
+    return quotePowerShellArg(value);
   }
   // Single quotes also keep pasted reload hints literal when interactive history expansion is on.
   const escaped =
@@ -141,16 +142,16 @@ function appendCompletionProfilePath(
   return `${nativeDirectory}${separator}${segments.join(pathApi.sep)}`;
 }
 
-/** Formats the command users can run to reload the shell profile after installation. */
-export function formatCompletionReloadCommand(shell: CompletionShell, profilePath: string): string {
+/** Formats a current-shell command to load a profile or cached completion script. */
+export function formatCompletionReloadCommand(shell: CompletionShell, scriptPath: string): string {
   if (shell === "powershell") {
-    return `. ${quoteCompletionPath(shell, profilePath)}`;
+    return `. ${quoteCompletionPath(shell, scriptPath)}`;
   }
-  if (/^[a-zA-Z0-9_./~+-]+$/u.test(profilePath)) {
-    return `source ${profilePath}`;
+  if (/^[a-zA-Z0-9_./~+-]+$/u.test(scriptPath)) {
+    return `source ${scriptPath}`;
   }
-  const homePrefix = profilePath.startsWith("~/") ? "~/" : "";
-  const value = profilePath.slice(homePrefix.length);
+  const homePrefix = scriptPath.startsWith("~/") ? "~/" : "";
+  const value = scriptPath.slice(homePrefix.length);
   return `source ${homePrefix}${quoteCompletionPath(shell, value)}`;
 }
 
@@ -195,12 +196,20 @@ function isPreviousCompletionSourceLine(
   const sourcePath =
     legacyPath ??
     (quoteShell === "powershell"
-      ? escapedPath.replaceAll("''", "'")
+      ? escapedPath.replace(/(['‘-‛])\1/gu, "$1")
       : quoteShell === "fish"
         ? escapedPath.replace(/\\([\\'])/gu, "$1")
         : escapedPath.replaceAll("'\\''", "'"));
+  // v2026.8.2 escaped only ASCII quotes in PowerShell profiles. Recognize those
+  // owned lines during replacement, while new writes use the complete literal rule.
+  const matchesLegacyPowerShellLiteral =
+    quoteShell === "powershell" && `'${sourcePath.replaceAll("'", "''")}'` === quotedPath;
   // Only our complete literal operand is owned; never consume compound profile commands.
-  if (!legacyPath && quoteCompletionPath(quoteShell, sourcePath) !== quotedPath) {
+  if (
+    !legacyPath &&
+    !matchesLegacyPowerShellLiteral &&
+    quoteCompletionPath(quoteShell, sourcePath) !== quotedPath
+  ) {
     return false;
   }
   const sourcePaths = sourcePath.includes("\\") ? path.win32 : path;

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -271,6 +271,8 @@ describe("successful update finalization ordering", () => {
     const output = vi.mocked(defaultRuntime.log).mock.calls.flat().map(String).join("\n");
     expect.soft(failure).toBeUndefined();
     expect.soft(output).toContain("Shell completion refresh failed");
+    expect.soft(output).toContain("Resolve the reported error before retrying");
+    expect.soft(output).not.toContain("session only");
     expect.soft(mocks.restartService).toHaveBeenCalledOnce();
     expect(mocks.restartService.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.checkCompletionStatus.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
@@ -317,6 +319,8 @@ describe("successful update finalization ordering", () => {
 
     const output = vi.mocked(defaultRuntime.log).mock.calls.flat().map(String).join("\n");
     expect(output).toContain("completion cache generation failed");
+    expect(output).toContain("Resolve the reported error before retrying");
+    expect(output).not.toContain("source /tmp/openclaw-completion.zsh");
     expect(output).toContain("openclaw completion --write-state --install");
     expect(mocks.restartService).toHaveBeenCalledOnce();
     expect(mocks.restartService.mock.invocationCallOrder[0]).toBeLessThan(

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -150,7 +150,7 @@ export async function tryInstallShellCompletion(opts: {
     const message = formatErrorMessage(err);
     defaultRuntime.log(
       theme.warn(
-        `Shell completion refresh failed: ${message}. Update will continue; retry with: ${replaceCliName(formatCliCommand("openclaw completion --write-state --install"), CLI_NAME)}`,
+        `Shell completion refresh failed: ${message}. Update will continue. Resolve the reported error before retrying: ${replaceCliName(formatCliCommand("openclaw completion --write-state --install"), CLI_NAME)}`,
       ),
     );
   }

--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as noteModule from "../../packages/terminal-core/src/note.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { COMPLETION_SKIP_PLUGIN_COMMANDS_ENV } from "../cli/completion-runtime.js";
+import {
+  COMPLETION_SKIP_PLUGIN_COMMANDS_ENV,
+  formatCompletionReloadCommand,
+  resolveCompletionCachePath,
+} from "../cli/completion-runtime.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import {
   checkShellCompletionStatus,
@@ -326,22 +330,24 @@ describe("doctorShellCompletion", () => {
     { code: "EACCES", usesSlowPattern: false, action: "installed" },
     { code: "EPERM", usesSlowPattern: false, action: "installed" },
     { code: "EROFS", usesSlowPattern: false, action: "installed" },
-  ])("keeps $action completion best-effort for wrapped $code errors", async (testCase) => {
+  ])("offers session recovery when completion is not $action after $code", async (testCase) => {
     const profilePath = await setupDoctorCompletionTest(testCase.usesSlowPattern);
-    installCompletionMock.mockRejectedValue(wrappedFsError(testCase.code, profilePath));
+    const failedPath = path.dirname(profilePath);
+    installCompletionMock.mockRejectedValue(wrappedFsError(testCase.code, failedPath));
     const noteSpy = vi.spyOn(noteModule, "note");
 
     await expect(doctorShellCompletion({} as never, mockPrompter())).resolves.not.toThrow();
 
+    const command = formatCompletionReloadCommand(
+      "bash",
+      resolveCompletionCachePath("bash", "openclaw"),
+    );
+    expect(noteSpy).toHaveBeenCalledWith(expect.stringContaining(command), "Shell completion");
     expect(noteSpy).toHaveBeenCalledWith(
-      expect.stringMatching(
-        new RegExp(
-          `Shell completion not ${testCase.action}: .* is not writable.*completion --install`,
-        ),
-      ),
+      expect.stringContaining("session only"),
       "Shell completion",
     );
-    expect(noteSpy).toHaveBeenCalledWith(expect.stringContaining(profilePath), "Shell completion");
+    expect(noteSpy).toHaveBeenCalledWith(expect.stringContaining(failedPath), "Shell completion");
   });
 
   it("re-throws non-permission errors from installCompletion", async () => {

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -33,7 +33,7 @@ export type CompletionCacheGenerationOptions = ShellCompletionStatusOptions & {
 };
 
 async function installCompletionForDoctor(
-  shell: CompletionShell,
+  { shell, cachePath }: ShellCompletionStatus,
   cliName: string,
   action: "installed" | "upgraded",
 ): Promise<void> {
@@ -50,9 +50,10 @@ async function installCompletionForDoctor(
     if (!writeError) {
       throw err;
     }
-    const profilePath = writeError.path ?? resolveCompletionProfilePath(shell);
+    const failedPath = writeError.path ?? resolveCompletionProfilePath(shell);
+    const command = formatCompletionReloadCommand(shell, cachePath);
     note(
-      `Shell completion not ${action}: ${profilePath} is not writable. Run \`${cliName} completion --install\` against a writable profile file.`,
+      `Shell completion could not be ${action} (permission or read-only error at ${failedPath}). For this ${shell} session only, run:\n${command}`,
       "Shell completion",
     );
   }
@@ -220,7 +221,7 @@ export async function doctorShellCompletion(
       }
     }
 
-    await installCompletionForDoctor(status.shell, cliName, "upgraded");
+    await installCompletionForDoctor(status, cliName, "upgraded");
     return;
   }
 
@@ -261,7 +262,7 @@ export async function doctorShellCompletion(
         return;
       }
 
-      await installCompletionForDoctor(status.shell, cliName, "installed");
+      await installCompletionForDoctor(status, cliName, "installed");
     }
   }
 }

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -122,7 +122,7 @@ export const en = {
       enable: "Enable {shell} shell completion for {cli}?",
       installed: "Shell completion installed. {reloadHint}",
       profileNotWritable:
-        "Shell completion was not changed: {profile} is not writable. Run `{command}` against a writable profile file.",
+        "Automatic shell completion installation failed (permission or read-only error at {profile}). For this {shell} session only, run:\n{command}",
       reloadPowerShell: "Restart your shell or run: {command}",
       reloadShell: "Restart your shell or run: source {profile}",
       title: "Shell completion",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -121,7 +121,7 @@ export const zh_CN = {
       enable: "为 {cli} 启用 {shell} shell completion？",
       installed: "Shell completion 已安装。{reloadHint}",
       profileNotWritable:
-        "Shell completion 未更改：{profile} 不可写。请对可写的 profile 文件运行 `{command}`。",
+        "Shell completion 自动安装失败（权限或只读错误位置：{profile}）。仅在当前 {shell} 会话中启用补全，请运行：\n{command}",
       reloadPowerShell: "重启 shell 或运行：{command}",
       reloadShell: "重启 shell 或运行：source {profile}",
       title: "Shell completion",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -121,7 +121,7 @@ export const zh_TW = {
       enable: "為 {cli} 啟用 {shell} shell completion？",
       installed: "Shell completion 已安裝。{reloadHint}",
       profileNotWritable:
-        "Shell completion 未變更：{profile} 無法寫入。請對可寫入的 profile 檔案執行 `{command}`。",
+        "Shell completion 自動安裝失敗（權限或唯讀錯誤位置：{profile}）。僅在目前的 {shell} 工作階段中啟用補全，請執行：\n{command}",
       reloadPowerShell: "重新啟動 shell 或執行：{command}",
       reloadShell: "重新啟動 shell 或執行：source {profile}",
       title: "Shell completion",

--- a/src/wizard/setup.completion.test.ts
+++ b/src/wizard/setup.completion.test.ts
@@ -85,42 +85,53 @@ describe("setupWizardShellCompletion", () => {
     expect(prompter.note).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      description: "upgrading a slow shell profile",
-      profileInstalled: true,
-      usesSlowPattern: true,
-    },
-    {
-      description: "installing a new shell profile",
-      profileInstalled: false,
-      usesSlowPattern: false,
-    },
-  ])(
-    "keeps onboarding completion optional when $description is not writable",
-    async ({ profileInstalled, usesSlowPattern }) => {
-      const profilePath = "/tmp/read-only/.zshrc";
-      const prompter = createPrompter();
-      const deps = createDeps();
-      vi.mocked(deps.checkShellCompletionStatus!).mockResolvedValue({
-        shell: "zsh",
-        profileInstalled,
-        cacheExists: false,
-        cachePath: "/tmp/openclaw.zsh",
-        usesSlowPattern,
-      });
-      vi.mocked(deps.installCompletion!).mockRejectedValue(wrappedFsError("EACCES", profilePath));
+  describe.each(["en", "zh-CN", "zh-TW"])("%s permission recovery", (locale) => {
+    it.each([
+      {
+        description: "upgrading a slow shell profile",
+        profileInstalled: true,
+        usesSlowPattern: true,
+      },
+      {
+        description: "installing a new shell profile",
+        profileInstalled: false,
+        usesSlowPattern: false,
+      },
+    ])(
+      "offers session recovery when $description fails",
+      async ({ profileInstalled, usesSlowPattern }) => {
+        await withLocale(locale, async () => {
+          const failedPath = "/tmp/read-only/.openclaw-completion-profile-stage";
+          const prompter = createPrompter();
+          const deps = createDeps();
+          vi.mocked(deps.checkShellCompletionStatus!).mockResolvedValue({
+            shell: "zsh",
+            profileInstalled,
+            cacheExists: false,
+            cachePath: "/tmp/openclaw.zsh",
+            usesSlowPattern,
+          });
+          vi.mocked(deps.installCompletion!).mockRejectedValue(
+            wrappedFsError("EACCES", failedPath),
+          );
 
-      await expect(
-        setupWizardShellCompletion({ flow: "quickstart", prompter, deps }),
-      ).resolves.not.toThrow();
+          await expect(
+            setupWizardShellCompletion({ flow: "quickstart", prompter, deps }),
+          ).resolves.not.toThrow();
 
-      expect(prompter.note).toHaveBeenCalledWith(
-        `Shell completion was not changed: ${profilePath} is not writable. Run \`openclaw completion --install\` against a writable profile file.`,
-        "Shell completion",
-      );
-    },
-  );
+          expect(prompter.note).toHaveBeenCalledTimes(1);
+          expect(prompter.note).toHaveBeenCalledWith(
+            expect.stringContaining("source /tmp/openclaw.zsh"),
+            "Shell completion",
+          );
+          expect(prompter.note).toHaveBeenCalledWith(
+            expect.stringContaining(failedPath),
+            "Shell completion",
+          );
+        });
+      },
+    );
+  });
 
   it("re-throws unexpected completion installation errors", async () => {
     const prompter = createPrompter();
@@ -174,6 +185,7 @@ describe("setupWizardShellCompletion", () => {
         "Shell completion",
       );
       expect(deps.installCompletion).not.toHaveBeenCalled();
+      expect(prompter.note.mock.calls.flat().join("\n")).not.toContain("source /tmp/openclaw.zsh");
     },
   );
 

--- a/src/wizard/setup.completion.ts
+++ b/src/wizard/setup.completion.ts
@@ -56,7 +56,11 @@ export async function setupWizardShellCompletion(params: {
       await params.prompter.note(
         t("wizard.completion.profileNotWritable", {
           profile: writeError.path ?? resolveCompletionProfilePath(completionStatus.shell),
-          command: `${cliName} completion --install`,
+          shell: completionStatus.shell,
+          command: formatCompletionReloadCommand(
+            completionStatus.shell,
+            completionStatus.cachePath,
+          ),
         }),
         t("wizard.completion.title"),
       );


### PR DESCRIPTION
Closes #137409 (unusable completion recovery after profile-write denial).

<details>
<summary>Additional instructions</summary>

This repository-owned branch remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users enabling shell completion through Doctor or onboarding received a command that repeated the same permission failure when their selected profile location could not be updated. The warning suggested choosing a writable profile even though the installer has no profile-file destination option.

## Why This Change Was Made

The installation boundary already knows the shell and cache path, and checks that the cache exists before touching the profile. Doctor and onboarding now carry those prepared facts into the existing shell-aware source-command formatter, giving users a current-session alternative without changing profile selection or permissions. The updater's broader catch can also cover inspection or cache-generation failures, so it retains generic retry guidance with an explicit prerequisite to resolve the reported error.

Real-shell validation found a connected PowerShell literal-path defect with typographic apostrophes. The existing quoting owner now reuses the shared PowerShell literal helper and preserves replacement of the exact older profile-source form written by stable v2026.8.2. No new formatter, destination option, automatic permission repair, or parallel installer is added.

## User Impact

After a profile permission/read-only failure, users can load the prepared cache in their current matching shell using the complete displayed command. Persistent installation still requires resolving the reported failure and rerunning the existing installer. Warnings identify the failure location without incorrectly calling a staging path the profile or promising rollback after every possible late publication failure.

English, Simplified Chinese, and Traditional Chinese onboarding messages are aligned. Existing nonfatal permission handling, unexpected-error propagation, atomic profile publication, and updater service ordering are preserved. PowerShell literal commands now escape typographic apostrophes correctly.

## Evidence

Tested head: `147df8b637bfd6461871c8b683ec7edd86099f17`.

- **Fail first:** 15 intended failures before production edits: six Doctor cases, six onboarding locale/operation cases, one PowerShell literal case, and two updater guidance cases. The other 110 tests passed.
- **Final regression coverage:** 520 passed, zero failed or skipped across the seven focused/sibling suites below.
- **Changed gate:** complete formatting, core/test typechecks, lint, dead-export, architecture, and relevant repository guards passed. An initial test-only map/spread lint failure was corrected with nested parameterized suites, preserving all cases and assertions without suppression.
- **Review:** fresh Codex autoreview on the final patch was scoped-clean at the configured P0 threshold, with zero findings across both automatically partitioned passes. The final committed patch matches the reviewed input.
- **Build:** final `build:ci-artifacts` passed. Build ID: `2026.8.1-147df8b637bf-2026-09-03T16-42-50.295Z`. No ineffective-dynamic-import warning; existing dependency EVAL/plugin-timing warnings were retained.

### Actual before/after recovery

An isolated, dist-backed CLI generated a real Bash completion cache. The production onboarding completion owner then ran with its real status/cache/installer dependencies and normal terminal note renderer under a child-process OS sandbox that denied profile-parent writes. No filesystem permission change was used.

Before the patch, the owner returned its optional warning, but executing the exact displayed `openclaw completion --install` command failed again with `EPERM` from staging output in the same directory. With the final committed artifact, the displayed source command returned zero and registered:

```text
complete -F _openclaw_completion openclaw
```

Profile and configuration bytes remained unchanged in this pre-publication-denial scenario, and all process groups exited. Intermediate source-owner proof was also rerun against the final committed artifact rather than substituted for it.

### Actual CLI and shell coverage

The final artifact also passed generation, installation, execution of its printed reload command, and idempotent reinstallation in **Bash, Zsh, Fish, and PowerShell**: 16 successful CLI/shell operations. Cache paths contained spaces, straight quotes, and typographic quotes. Existing operator-authored profile content remained present, and configuration bytes were unchanged. Zsh completion was initialized normally with `compinit` in its isolated shell.

Observed registration/completion output:

```text
Bash:       complete -F _openclaw_completion openclaw
Zsh:        _openclaw_root_completion
Fish:       status
PowerShell: status
```

Separate PowerShell 7.6.5 controls reused the same retained ordinary, straight-apostrophe, and typographic-apostrophe paths. The typographic path failed before the repair; all three loaded afterward. This was PowerShell on macOS, not native-Windows OS proof.

### Commands

Run in a task-owned checkout with private HOME, config/state, cache, and temporary directories:

```bash
node scripts/run-vitest.mjs src/commands/doctor-completion.test.ts src/wizard/setup.completion.test.ts src/cli/completion-runtime.test.ts src/cli/update-cli/update-command-post-update.test.ts src/cli/completion-cli.write-state.test.ts src/cli/update-cli.test.ts src/cli/quote-cli-arg.test.ts
```

```bash
node scripts/check-changed.mjs -- docs/cli/completion.md src/cli/completion-runtime.test.ts src/cli/completion-runtime.ts src/cli/update-cli/update-command-post-update.test.ts src/cli/update-cli/update-command-service.ts src/commands/doctor-completion.test.ts src/commands/doctor-completion.ts src/wizard/i18n/locales/en.ts src/wizard/i18n/locales/zh-CN.ts src/wizard/i18n/locales/zh-TW.ts src/wizard/setup.completion.test.ts src/wizard/setup.completion.ts
```

```bash
pnpm build:ci-artifacts
```

### Scope and compatibility

Production **+34/-20 (net +14)**; tests **+71/-48 (net +23)**; docs **+13**. Production growth carries the existing cache into actionable recovery and retains the tagged profile-literal replacement contract. Reusing the existing formatter is smaller than adding a selector, new rendering layer, or another install flow.

No SQLite schema, state-store design, config option, dependency, native-service policy, or protocol change. Shell-profile compatibility is exercised through legacy/current source-line replacement, unrelated/compound-line preservation, actual generated scripts, and byte-identical reinstallation. Full Doctor/onboarding was not run: mutating Doctor cannot be scoped with `--only`, and unrelated state/service operations were outside this proof. The completion owner and real CLI installation paths were exercised directly instead. No operator installation, profile, service, credentials, model, or channel was used.

Related context: [Doctor's nonfatal permission repair](https://github.com/openclaw/openclaw/pull/99540), [onboarding's corresponding repair](https://github.com/openclaw/openclaw/pull/125263), and [updater restart ordering](https://github.com/openclaw/openclaw/pull/131393) remain intact. [The older quoting PR](https://github.com/openclaw/openclaw/pull/117219) retains a distinct legacy-hook detection question; this patch does not change that classification or close it as fully superseded.

Docs: https://docs.openclaw.ai/cli/completion

[Exact-head CI33781070268](https://github.com/openclaw/openclaw/actions/runs/33781070268) passed on `147df8b637bfd6461871c8b683ec7edd86099f17`, attempt1. Native preparation and merge checks follow.


## Maintainer review disposition

The [current ClawSweeper review](https://github.com/openclaw/openclaw/pull/137431#issuecomment-5529193336) reports no code or security findings and recommends merging with the existing profile-compatibility coverage after exact-head checks complete. I accept that option and resolve its two maintainer items as follows:

- **Production growth and persisted profile compatibility:** accept the net +14 production lines for carrying the already-prepared cache into recovery and retaining the stable v2026.8.2 PowerShell literal form during replacement. The existing formatter and installer remain canonical. Coverage includes legacy/current source replacement across all four shells, unrelated/compound user-line preservation, real generated-script loading, and byte-identical reinstallation. This changes an owned source statement in an external shell-profile artifact, not a SQLite schema or state-store design. No database migration was performed or is required.
- **Native Windows proof:** accept the explicitly documented gap for this bounded literal-grammar change. Actual PowerShell 7.6.5 command and final-artifact profile/completion proof ran on macOS. Windows-specific profile selection and encoding logic are unchanged. The existing `completion-runtime.windows.test.ts` suite is gated to Windows; it is not being counted as locally executed proof. Native-Windows end-to-end behavior is not claimed.

No source change is needed for these dispositions. The reviewed head remains `147df8b637bfd6461871c8b683ec7edd86099f17`; successful exact-head CI is still required before native preparation and merge.
