### PR TITLE
fix(inbound-meta): drop schema marker from trusted inbound metadata to avoid Anthropic billing rejection

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -165,7 +165,12 @@ describe("buildInboundMetaSystemPrompt", () => {
     );
 
     const payload = parseInboundMetaPayload(prompt);
-    expect(payload["schema"]).toBe("openclaw.inbound_meta.v2");
+    // Regression for #137413: Anthropic's harness detection rejects prompts containing
+    // the `openclaw.inbound_meta.*` marker string (billed as third-party usage → 400
+    // "out of extra usage"). The schema discriminator had no runtime consumer, so the
+    // trusted inbound metadata payload must not carry any versioned marker token.
+    expect(payload["schema"]).toBeUndefined();
+    expect(prompt).not.toContain("openclaw.inbound_meta");
     expect(payload["chat_id"]).toBeUndefined();
     expect(payload["account_id"]).toBe("work");
     expect(payload["channel"]).toBe("telegram");

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -579,7 +579,6 @@ export function buildInboundMetaSystemPrompt(
   const channelValue = resolveInboundChannel(ctx);
 
   const payload = {
-    schema: "openclaw.inbound_meta.v2",
     account_id: normalizePromptMetadataString(ctx.AccountId),
     channel: channelValue,
     provider: normalizePromptMetadataString(ctx.Provider),

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=ab32abe89402ee97110c1f1743cfb5219851567fa3d338487c183be3b7870fec
-+++ discord-group-codex-message-tool.md	sha256=5b05e1897e50f9298208b4cd0e116261c92dab9fa4b42b237678c620e8be92af
+--- telegram-direct-codex-message-tool.md	sha256=5d86b24a900d357fa9dd21cfd6f74868caf10f09b90a0787e55069d18709739a
++++ discord-group-codex-message-tool.md	sha256=a3f99cbb6fd56a5a505958ea8e7e2a433d485cbd88b08c3a650ca6e0fe9c8b8a
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -34,26 +34,26 @@
 +    "chars": 57527,
 +    "roughTokens": 14382
 @@ -246,2 +246,2 @@
--    "chars": 3224,
--    "roughTokens": 806
-+    "chars": 4333,
-+    "roughTokens": 1084
+-    "chars": 3184,
+-    "roughTokens": 796
++    "chars": 4293,
++    "roughTokens": 1074
 @@ -250,2 +250,2 @@
--    "chars": 27170,
--    "roughTokens": 6793
-+    "chars": 28650,
-+    "roughTokens": 7163
+-    "chars": 27130,
+-    "roughTokens": 6783
++    "chars": 28610,
++    "roughTokens": 7153
 @@ -254,2 +254,2 @@
--    "chars": 84143,
--    "roughTokens": 21036
-+    "chars": 86179,
-+    "roughTokens": 21545
+-    "chars": 84103,
+-    "roughTokens": 21026
++    "chars": 86139,
++    "roughTokens": 21535
 @@ -258,2 +258,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
 +    "chars": 1234,
 +    "roughTokens": 309
-@@ -467,4 +467,4 @@
+@@ -466,4 +466,4 @@
 -  "channel": "telegram",
 -  "provider": "telegram",
 -  "surface": "telegram",
@@ -62,21 +62,21 @@
 +  "provider": "discord",
 +  "surface": "discord",
 +  "chat_type": "group"
-@@ -475,1 +475,3 @@
+@@ -474,1 +474,3 @@
 -You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
 +You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to this group chat. Be extremely selective: reply only when directly addressed or clearly helpful.
 +
 +Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.
-@@ -531,1 +533,1 @@
+@@ -530,1 +532,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"channel:987654321","message_id":"discord-msg-0001","conversation_label":"OpenClaw/#agent-sandbox","sender":{"id":"424242","name":"Pash","username":"pash"},"group_subject":"OpenClaw maintainers","group_channel":"#agent-sandbox","group_space":"OpenClaw","is_group_chat":true,"was_mentioned":true,"history_count":2}
-@@ -534,1 +536,5 @@
+@@ -533,1 +535,5 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Chat history since last reply: ⟦openclaw:ctx⟧
 +Peter: I pushed the Discord-side message-tool bridge.
 +Pash: @OpenClaw please verify the Codex happy path too.
 +
 +can you audit whether this prompt path has conflicting silence instructions?
-@@ -539,1 +545,1 @@
+@@ -538,1 +544,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.discord-group.json` (base: `codex-dynamic-tools.telegram-direct.json`)

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -243,16 +243,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 14243
   },
   "openClawDeveloperInstructions": {
-    "chars": 3224,
-    "roughTokens": 806
+    "chars": 3184,
+    "roughTokens": 796
   },
   "totalTextOnly": {
-    "chars": 27170,
-    "roughTokens": 6793
+    "chars": 27130,
+    "roughTokens": 6783
   },
   "totalWithDynamicToolsJson": {
-    "chars": 84143,
-    "roughTokens": 21036
+    "chars": 84103,
+    "roughTokens": 21026
   },
   "userInputText": {
     "chars": 863,
@@ -462,7 +462,6 @@ When explicitly_mentioned_bot is true, the incoming message mentions your channe
 
 ```json
 {
-  "schema": "openclaw.inbound_meta.v2",
   "account_id": "primary",
   "channel": "telegram",
   "provider": "telegram",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=ab32abe89402ee97110c1f1743cfb5219851567fa3d338487c183be3b7870fec
-+++ telegram-heartbeat-codex-tool.md	sha256=f68316b0804b003071ce62b66a701f6fce67b16db8b35233286a2cc8068e1be2
+--- telegram-direct-codex-message-tool.md	sha256=5d86b24a900d357fa9dd21cfd6f74868caf10f09b90a0787e55069d18709739a
++++ telegram-heartbeat-codex-tool.md	sha256=8e542ae17ba57f1805c8ae503834c5f3128ccb395cdaa5c1674a500ec085ffe1
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -35,32 +35,32 @@
 +    "chars": 58464,
 +    "roughTokens": 14616
 @@ -250,2 +247,2 @@
--    "chars": 27170,
--    "roughTokens": 6793
-+    "chars": 27512,
-+    "roughTokens": 6878
+-    "chars": 27130,
+-    "roughTokens": 6783
++    "chars": 27472,
++    "roughTokens": 6868
 @@ -254,2 +251,2 @@
--    "chars": 84143,
--    "roughTokens": 21036
-+    "chars": 85978,
-+    "roughTokens": 21495
+-    "chars": 84103,
+-    "roughTokens": 21026
++    "chars": 85938,
++    "roughTokens": 21485
 @@ -258,2 +255,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
 +    "chars": 1205,
 +    "roughTokens": 302
-@@ -531,1 +528,1 @@
+@@ -530,1 +527,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"user:1000001","message_id":"heartbeat-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
-@@ -534,1 +531,1 @@
+@@ -533,1 +530,1 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Follow the heartbeat monitor scratch context when provided. Recurring tasks are automations; create or change their schedules with the automations tool, not heartbeat scratch. Do not infer or repeat old tasks from prior chats. Use heartbeat_respond to report the wake outcome. Set notify=false when nothing needs the user's attention. Set notify=true with notificationText only when the user should be interrupted.
-@@ -539,1 +536,1 @@
+@@ -538,1 +535,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.heartbeat-turn.json` (base: `codex-dynamic-tools.telegram-direct.json`)
-@@ -559,0 +557,1 @@
+@@ -558,0 +556,1 @@
 +  "heartbeat_respond",
-@@ -706,0 +705,39 @@
+@@ -705,0 +704,39 @@
 +  },
 +  {
 +    "description": "Accept heartbeat result for post-turn handling. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only.",


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #137413

## What Problem This Solves

Fixes an issue where users routing Anthropic models through the bundled Claude CLI runtime (subscription OAuth via `claude auth login`) would get every Claude turn rejected with `API Error: 400 You're out of extra usage` once any channel-originated turn carries the trusted inbound metadata block. Anthropic's harness detection bills requests containing the literal marker string `openclaw.inbound_meta.v2` as third-party usage, so all Anthropic attempts fail for subscription users (who then hit `All models failed` once fallbacks are exhausted), even with subscription quota remaining. This is a recurrence of #65399 — the earlier mitigation renamed the marker `v1` → `v2`, and the filter has since been extended to cover `v2`.

- **Related:** #65399 (same failure class, earlier v1 marker); clawsweeper review on this issue confirmed current main still emits the v2 marker into the Claude CLI/Agent SDK system prompt and recommends removing the unconsumed discriminator rather than another versioned rename.

## Why This Change Was Made

Removes the `schema: "openclaw.inbound_meta.v2"` discriminator from the trusted inbound metadata payload instead of renaming it to yet another versioned token. The field had no runtime consumer (the payload is a JSON block embedded in the system prompt; nothing parses it back), so deleting it eliminates the provider-visible marker entirely — no config surface, no future rename treadmill when the filter extends again. The surrounding trusted context fields (`account_id`, `channel`, `provider`, `surface`, `chat_type`, `response_format`) and the mixed-trust guidance text are unchanged. `openclaw.diagnostics.v1` is untouched: it is only serialized into the optional local diagnostics timeline JSONL file and never reaches any outbound prompt.

- **Intended outcome:** the system prompt sent to Claude CLI / Agent SDK (and every other provider) no longer contains any `openclaw.inbound_meta.*` marker string, so Anthropic's third-party-usage filter no longer rejects subscription turns.
- **Out of scope:** `openclaw.diagnostics.v1` (local-only, no outbound emission); the `⟦openclaw:ctx⟧` inbound context marker (different mechanism, used for stripping stored text, not flagged); no prompt-injection guidance changes.
- **Highest-risk area:** prompt snapshot fixtures drift if regeneration is skipped.
- **How is that risk mitigated?** snapshots regenerated via `pnpm prompt:snapshots:gen` and the snapshot test (`test/scripts/prompt-snapshots.test.ts`) verifies generated output matches committed fixtures.

## User Impact

Subscription users routing Anthropic models via the Claude CLI runtime can send channel-originated turns again without being mis-billed/mis-classified as third-party usage. No behavior change for other providers — the only difference in outbound prompts is one removed JSON key.

- **Success criteria:** `buildInboundMetaSystemPrompt` output contains no `openclaw.inbound_meta` marker (regression test in `src/auto-reply/reply/inbound-meta.test.ts`); regenerated prompt snapshots contain no marker; live Claude CLI turn with a subscription OAuth token no longer returns the billing 400 (needs reporter/maintainer verification — see Proof limitations).
- **What should reviewers focus on?** `src/auto-reply/reply/inbound-meta.ts` (single-line payload change) and the regression assertion in `src/auto-reply/reply/inbound-meta.test.ts`; snapshot fixture `test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md`.

## Evidence

- **Real environment tested:** local checkout on branch `feat/issue-137413-anthropic-inbound-meta-marker` (rebased on latest `origin/main`), Node 26, `pnpm install` + full targeted verification green (format, lint, focused tests, `tsgo:core`).
- **Exact steps or commands run after this patch:**
  ```bash
  # Regression test RED on unfixed source (marker still emitted):
  node scripts/run-vitest.mjs run src/auto-reply/reply/inbound-meta.test.ts
  # → 1 failed: expected 'openclaw.inbound_meta.v2' to be undefined

  # After fix:
  pnpm prompt:snapshots:gen   # regenerate fixtures, marker line removed
  node scripts/run-vitest.mjs run src/auto-reply/reply/inbound-meta.test.ts   # 78 passed
  node scripts/run-vitest.mjs run test/scripts/prompt-snapshots.test.ts       # 16 passed
  skills/fix-pr/scripts/validate.sh src/auto-reply/reply/inbound-meta.ts \
    src/auto-reply/reply/inbound-meta.test.ts \
    test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/*          # all green (oxfmt + oxlint + tsgo:core)
  ```
- **Evidence after fix:** regenerated snapshot prompt block no longer contains the marker:
  ```diff
   ```json
   {
  -  "schema": "openclaw.inbound_meta.v2",
     "account_id": "primary",
     "channel": "telegram",
     "provider": "telegram",
     "surface": "telegram",
     "chat_type": "direct"
   }
  ```
- **Observed result after fix:** the trusted inbound metadata JSON block (embedded in the system prompt that the Claude CLI backend forwards through the Agent SDK) now contains only the trusted context fields — no versioned marker token anywhere in the outbound prompt. `rg "openclaw.inbound_meta"` over the worktree matches only the regression test's negative assertion.
- **Before evidence (optional, visual changes encouraged):** on `origin/main`, the same prompt block contains `"schema": "openclaw.inbound_meta.v2"` (source line `src/auto-reply/reply/inbound-meta.ts:582` and committed snapshot fixture line 465), and the issue's minimal repro shows `claude -p "<openclaw.inbound_meta.v2>ctx</openclaw.inbound_meta.v2> say ok"` → 400 billing rejection while the same token without the marker succeeds.
- **What was not tested:** live authenticated Claude CLI/Agent SDK round-trip against Anthropic (billing filter behavior is server-side and requires a Claude subscription OAuth token, which this environment does not have). CI lanes (`check:test-types` full run, `test:unit:fast`) run on GitHub Actions.
- **Proof tier:** L1
- **Proof limitations:** the outbound prompt content change is proven at source level (RED→GREEN regression test + regenerated snapshots), but the end-to-end billing 400 → success transition needs a live subscription-authenticated Claude CLI turn; issue reporter offered to run further diagnostics and can validate with the same one-line repro from the issue.
- **Review state:** needs reporter/maintainer live repro confirmation of the billing path; CI lanes pending on Actions.
