### PR TITLE
fix(telegram): return approval results to the originating topic

### DIFF
--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
@@ -690,6 +690,7 @@ def normalize_message(message, users=None):
     sender_id = sender.get("user_id") or sender.get("chat_id")
     sender_user = users.get(int(sender_id or 0), {}) if sender_id else {}
     content = message.get("content") or {}
+    topic = message.get("topic_id") or {}
     reply_to_message_id = message.get("reply_to_message_id") or (message.get("reply_to") or {}).get("message_id")
     return {
         "messageId": message.get("id"),
@@ -698,7 +699,8 @@ def normalize_message(message, users=None):
         "senderUsername": sender_user.get("username") or "",
         "date": message.get("date"),
         "replyToMessageId": reply_to_message_id,
-        "threadId": message.get("message_thread_id"),
+        "threadId": topic.get("message_thread_id"),
+        "forumTopicId": topic.get("forum_topic_id"),
         **message_content(content),
         "raw": message,
     }
@@ -992,6 +994,7 @@ def serve_message(message, users):
         "senderId": normalized.get("senderId"),
         "senderUsername": normalized.get("senderUsername"),
         "replyToMessageId": normalized.get("replyToMessageId"),
+        "forumTopicId": normalized.get("forumTopicId"),
         "timestamp": int(message.get("date") or 0) * 1000,
         "contentType": normalized["contentType"],
         "text": normalized["text"],

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
@@ -110,6 +110,7 @@ class PhotoContentTest(unittest.TestCase):
             "sender_id": {"user_id": 101},
             "date": 123,
             "reply_to": {"message_id": 7},
+            "topic_id": {"@type": "messageTopicForum", "forum_topic_id": 18},
             "content": {
                 "@type": "messageText",
                 "text": {"@type": "formattedText", "text": text, "entities": entities},
@@ -123,6 +124,7 @@ class PhotoContentTest(unittest.TestCase):
         self.assertEqual(created["botApiMessageId"], 42)
         self.assertEqual(created["senderUsername"], "sut_bot")
         self.assertEqual(created["replyToMessageId"], 7)
+        self.assertEqual(created["forumTopicId"], 18)
         self.assertEqual(created["timestamp"], 123000)
         self.assertEqual(created["contentType"], "messageText")
         self.assertEqual(created["text"], text)
@@ -156,6 +158,7 @@ class PhotoContentTest(unittest.TestCase):
                 self.assertEqual(edited["text"], edited_text)
                 self.assertEqual(edited["entities"], edited_entities)
                 self.assertEqual(edited["senderId"], 101)
+                self.assertEqual(edited["forumTopicId"], 18)
                 self.assertEqual(known[message_id]["entities"], edited_entities)
 
     def test_preserves_native_content_type_and_caption_entities_in_messages_and_edits(self):

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -880,6 +880,8 @@ openclaw message poll --channel telegram --target -1001234567890:topic:42 \
 
     Channel delivery shows the command text in the chat; only enable `channel` or `both` in trusted groups/topics. When the prompt lands in a forum topic, OpenClaw preserves the topic for the approval prompt and follow-up. Exec approvals expire after 30 minutes by default.
 
+    For delegated OpenClaw changes, the terminal result also returns to the originating topic when the approval card was delivered elsewhere, including another topic in the same chat. An updated card in the originating topic does not produce a duplicate notice.
+
     Inline approval buttons also require `channels.telegram.capabilities.inlineButtons` to allow the target surface (`dm`, `group`, or `all`). Approval IDs prefixed with `plugin:` resolve through plugin approvals; others resolve through exec approvals first.
 
     See [Exec approvals](/tools/exec-approvals).

--- a/extensions/qa-lab/src/live-transports/telegram/approval-topics.fixture.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/approval-topics.fixture.ts
@@ -1,0 +1,297 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+import type { createChannelApprovalHandlerFromCapability } from "openclaw/plugin-sdk/approval-handler-runtime";
+import type { SystemAgentApprovalRequest } from "openclaw/plugin-sdk/approval-runtime";
+import type { sendMessageTelegram } from "../../../../telegram/runtime-api.js";
+import type { QaSuiteRuntimeEnv } from "../../suite-runtime-types.js";
+import type { TelegramUserbotUpdate } from "./userbot-driver.runtime.js";
+
+type CreateHandler = typeof createChannelApprovalHandlerFromCapability;
+type Observation = Pick<TelegramUserbotUpdate, "kind" | "messageId" | "forumTopicId" | "text">;
+type CaseProof = {
+  target: "channel" | "dm";
+  pending?: Observation;
+  edited?: Observation;
+  notices?: Observation[];
+  passed: boolean;
+};
+
+function observe({ kind, messageId, forumTopicId, text }: TelegramUserbotUpdate): Observation {
+  return { kind, messageId, forumTopicId, text };
+}
+
+export async function proveTelegramApprovalTopics(params: {
+  env: QaSuiteRuntimeEnv;
+  readTelegramMessages: () => TelegramUserbotUpdate[];
+  signal?: AbortSignal;
+}) {
+  const { env, readTelegramMessages, signal } = params;
+  const accountId = env.transport.accountId;
+  const account = env.cfg.channels?.telegram?.accounts?.[accountId];
+  const configuredToken = account?.botToken;
+  const chatId = String(account?.allowFrom?.[0] ?? "");
+  const apiRoot = account?.apiRoot;
+  if (
+    env.transport.id !== "telegram" ||
+    env.providerMode !== "mock-openai" ||
+    account?.dmPolicy !== "allowlist" ||
+    typeof configuredToken !== "string" ||
+    !/^\d+$/u.test(chatId) ||
+    !apiRoot ||
+    new URL(apiRoot).hostname !== "127.0.0.1"
+  ) {
+    throw new Error("Approval topic proof requires the leased Telegram Test Server DM adapter.");
+  }
+  const token: string = configuredToken;
+
+  // The harness checkout can differ from the SUT. Resolve both runtime owners from its installed bin.
+  const command = process.env.OPENCLAW_NPM_TELEGRAM_SUT_COMMAND;
+  const prefix = process.env.NPM_CONFIG_PREFIX;
+  if (!command || !prefix || !path.isAbsolute(command)) {
+    throw new Error("Approval topic proof requires the package acceptance installed command.");
+  }
+  const realCommand = await fs.realpath(command);
+  const realPrefix = await fs.realpath(prefix);
+  if (
+    !realCommand.startsWith(`${realPrefix}${path.sep}`) ||
+    path.basename(realCommand) !== "openclaw.mjs"
+  ) {
+    throw new Error("Approval topic proof command is not the installed OpenClaw package.");
+  }
+  const packageRoot = path.dirname(realCommand);
+  const packageJson = JSON.parse(await fs.readFile(path.join(packageRoot, "package.json"), "utf8"));
+  const build = JSON.parse(
+    await fs.readFile(path.join(packageRoot, "dist/build-info.json"), "utf8"),
+  );
+  if (packageJson.name !== "openclaw" || !/^[a-f0-9]{40}$/u.test(build.commit)) {
+    throw new Error("Approval topic proof requires an identified OpenClaw package build.");
+  }
+  const sdk: { createChannelApprovalHandlerFromCapability: CreateHandler } = await import(
+    pathToFileURL(path.join(packageRoot, "dist/plugin-sdk/approval-handler-runtime.js")).href
+  );
+  const {
+    telegramPlugin,
+  }: { telegramPlugin: { approvalCapability: Parameters<CreateHandler>[0]["capability"] } } =
+    await import(
+      pathToFileURL(path.join(packageRoot, "dist/extensions/telegram/channel-plugin-api.js")).href
+    );
+  const telegramRuntime: { sendMessageTelegram: typeof sendMessageTelegram } = await import(
+    pathToFileURL(path.join(packageRoot, "dist/extensions/telegram/runtime-api.js")).href
+  );
+  const deliveries = new Map<string, { chatId: string; messageId: string }>();
+  const sendMessage: typeof sendMessageTelegram = (to, text, options) =>
+    telegramRuntime.sendMessageTelegram(to, text, {
+      ...options,
+      onDeliveryResult: async (delivery) => {
+        deliveries.set(`${delivery.chatId}:${delivery.messageId}`, {
+          chatId: delivery.chatId,
+          messageId: delivery.messageId,
+        });
+        await options.onDeliveryResult?.(delivery);
+      },
+    });
+
+  const cases: CaseProof[] = [];
+  const deletedMessageIds: string[] = [];
+  const proof = {
+    transport: "Telegram Test Server",
+    package: { commit: build.commit, version: packageJson.version },
+    entryBoundary:
+      "native approval handler requested/resolved events; not delegated authority admission",
+    modelInvocation: false,
+    privateTopicsEnabled: false,
+    topicId: 0,
+    cases,
+    deletedMessageIds,
+    cleanup: false,
+    passed: false,
+  };
+  const artifact = path.join(env.outputDir, "telegram-approval-terminal-topics.json");
+  async function botApi(method: string, body: Record<string, unknown>, cleanup = false) {
+    try {
+      const timeout = AbortSignal.timeout(20_000);
+      const response = await fetch(`${apiRoot}/bot${token}/${method}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+        signal: signal && !cleanup ? AbortSignal.any([signal, timeout]) : timeout,
+      });
+      const result = await response.json();
+      if (!response.ok || result.ok !== true) {
+        throw new Error("Bot API request failed");
+      }
+      return result.result;
+    } catch {
+      // Native request errors can contain the token-bearing URL. Artifact failures name only the method.
+      throw new Error(`Telegram Test Server ${method} failed.`);
+    }
+  }
+  const terminalText = "❌ OpenClaw change denied. No change was made.";
+  try {
+    proof.privateTopicsEnabled = (await botApi("getMe", {})).has_topics_enabled === true;
+    if (!proof.privateTopicsEnabled) {
+      throw new Error("Leased bot has no private-topic capability; no bot settings were changed.");
+    }
+    const topic = await botApi("createForumTopic", {
+      chat_id: chatId,
+      name: `QA approvals ${randomUUID()}`,
+    });
+    if (!Number.isSafeInteger(topic.message_thread_id) || topic.message_thread_id <= 0) {
+      throw new Error("Telegram did not create a distinct private approval topic.");
+    }
+    proof.topicId = topic.message_thread_id;
+    for (const target of ["channel", "dm"] as const) {
+      signal?.throwIfAborted();
+      const caseProof: CaseProof = { target, passed: false };
+      proof.cases.push(caseProof);
+      const cfg = {
+        ...env.cfg,
+        channels: {
+          ...env.cfg.channels,
+          telegram: {
+            ...env.cfg.channels?.telegram,
+            accounts: {
+              ...env.cfg.channels?.telegram?.accounts,
+              [accountId]: {
+                ...account,
+                execApprovals: { enabled: true, approvers: [chatId], target },
+              },
+            },
+          },
+        },
+      };
+      const handler = await sdk.createChannelApprovalHandlerFromCapability({
+        capability: telegramPlugin.approvalCapability,
+        label: "telegram/approvals",
+        clientDisplayName: "Telegram approvals",
+        channel: "telegram",
+        channelLabel: "Telegram",
+        cfg,
+        accountId,
+        context: { token, deps: { sendMessage } },
+      });
+      if (!handler) {
+        throw new Error("Installed Telegram native approval handler is unavailable.");
+      }
+      const marker = `QA-APPROVAL-${target}-${randomUUID()}`;
+      const now = Date.now();
+      const request: SystemAgentApprovalRequest = {
+        approvalKind: "system-agent",
+        id: `system-agent:${randomUUID()}`,
+        request: {
+          title: "OpenClaw change",
+          description: marker,
+          command: marker,
+          proposalHash: "a".repeat(64),
+          allowedDecisions: ["allow-once", "deny"],
+          sessionId: randomUUID(),
+          turnSourceChannel: "telegram",
+          turnSourceAccountId: accountId,
+          turnSourceTo: chatId,
+          turnSourceThreadId: proof.topicId,
+        },
+        createdAtMs: now,
+        expiresAtMs: now + 90_000,
+      };
+      const existingIds = new Set(readTelegramMessages().map((message) => message.messageId));
+      const messages = () =>
+        readTelegramMessages().filter((message) => !existingIds.has(message.messageId));
+      try {
+        // Do not start(): the QA Gateway already owns the sole Bot API update subscriber.
+        await handler.handleRequested(request);
+        const pending = await env.transport.waitForCondition(
+          () => messages().find((message) => message.text.includes(marker)),
+          30_000,
+        );
+        caseProof.pending = observe(pending);
+        if ((pending.forumTopicId === proof.topicId) !== (target === "channel")) {
+          throw new Error(`Pending ${target} card did not follow the native delivery plan.`);
+        }
+        await handler.handleResolved({ id: request.id, decision: "deny", ts: Date.now() });
+        const edited = await env.transport.waitForCondition(
+          () =>
+            messages().find(
+              (message) =>
+                message.messageId === pending.messageId &&
+                message.kind === "edit" &&
+                message.text === terminalText,
+            ),
+          30_000,
+        );
+        caseProof.edited = observe(edited);
+        if (target === "dm") {
+          await env.transport.waitForCondition(
+            () =>
+              messages().find(
+                (message) =>
+                  message.messageId !== pending.messageId &&
+                  message.text === terminalText &&
+                  message.forumTopicId === proof.topicId,
+              ),
+            30_000,
+          );
+        }
+        await sleep(2_000, undefined, { signal });
+        caseProof.notices = messages()
+          .filter(
+            (message) => message.messageId !== pending.messageId && message.text === terminalText,
+          )
+          .map(observe);
+        caseProof.passed =
+          caseProof.notices.length === (target === "dm" ? 1 : 0) &&
+          edited.forumTopicId === pending.forumTopicId;
+        if (!caseProof.passed) {
+          throw new Error(`Terminal ${target} result was duplicated or moved topics.`);
+        }
+      } finally {
+        // An unstarted handler retains timers on stop; drain our synthetic request first.
+        try {
+          await handler.handleExpired(request.id);
+        } finally {
+          await handler.stop();
+        }
+        caseProof.notices ??= messages()
+          .filter(
+            (message) =>
+              message.messageId !== caseProof.pending?.messageId && message.text === terminalText,
+          )
+          .map(observe);
+      }
+    }
+  } finally {
+    try {
+      // Use Bot API receipts, not the tester's private-chat message IDs, for deletion.
+      const deletions = await Promise.allSettled(
+        [...deliveries.values()].map(async (delivery) => {
+          await botApi(
+            "deleteMessage",
+            { chat_id: delivery.chatId, message_id: delivery.messageId },
+            true,
+          );
+          deletedMessageIds.push(delivery.messageId);
+        }),
+      );
+      proof.cleanup = deletions.every((result) => result.status === "fulfilled");
+      if (proof.topicId > 0) {
+        await botApi(
+          "deleteForumTopic",
+          { chat_id: chatId, message_thread_id: proof.topicId },
+          true,
+        ).catch(() => {
+          proof.cleanup = false;
+        });
+      }
+    } finally {
+      proof.passed =
+        proof.cleanup && proof.cases.length === 2 && proof.cases.every((entry) => entry.passed);
+      await fs.writeFile(artifact, `${JSON.stringify(proof, null, 2)}\n`);
+    }
+  }
+  if (!proof.cleanup) {
+    throw new Error("Telegram proof could not delete every fixture-owned message and topic.");
+  }
+  return { details: JSON.stringify(proof), artifacts: [artifact] };
+}

--- a/extensions/qa-lab/src/live-transports/telegram/approval-topics.fixture.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/approval-topics.fixture.ts
@@ -5,11 +5,24 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 import type { createChannelApprovalHandlerFromCapability } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { SystemAgentApprovalRequest } from "openclaw/plugin-sdk/approval-runtime";
-import type { sendMessageTelegram } from "../../../../telegram/runtime-api.js";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
+} from "openclaw/plugin-sdk/ssrf-runtime";
+import { readQaJsonResponse } from "../../ignored-response-body.js";
 import type { QaSuiteRuntimeEnv } from "../../suite-runtime-types.js";
 import type { TelegramUserbotUpdate } from "./userbot-driver.runtime.js";
 
 type CreateHandler = typeof createChannelApprovalHandlerFromCapability;
+type Delivery = { chatId: string; messageId: string };
+// The installed sender owns options and results; the fixture observes only its delivery receipts.
+type ObservedSend = (
+  to: string,
+  text: string,
+  options: Record<string, unknown> & {
+    onDeliveryResult?: (delivery: Delivery) => Promise<void> | void;
+  },
+) => Promise<unknown>;
 type Observation = Pick<TelegramUserbotUpdate, "kind" | "messageId" | "forumTopicId" | "text">;
 type CaseProof = {
   target: "channel" | "dm";
@@ -46,6 +59,7 @@ export async function proveTelegramApprovalTopics(params: {
     throw new Error("Approval topic proof requires the leased Telegram Test Server DM adapter.");
   }
   const token: string = configuredToken;
+  const botApiPolicy = ssrfPolicyFromHttpBaseUrlAllowedOrigin(apiRoot);
 
   // The harness checkout can differ from the SUT. Resolve both runtime owners from its installed bin.
   const command = process.env.OPENCLAW_NPM_TELEGRAM_SUT_COMMAND;
@@ -78,11 +92,11 @@ export async function proveTelegramApprovalTopics(params: {
     await import(
       pathToFileURL(path.join(packageRoot, "dist/extensions/telegram/channel-plugin-api.js")).href
     );
-  const telegramRuntime: { sendMessageTelegram: typeof sendMessageTelegram } = await import(
+  const telegramRuntime: { sendMessageTelegram: ObservedSend } = await import(
     pathToFileURL(path.join(packageRoot, "dist/extensions/telegram/runtime-api.js")).href
   );
-  const deliveries = new Map<string, { chatId: string; messageId: string }>();
-  const sendMessage: typeof sendMessageTelegram = (to, text, options) =>
+  const deliveries = new Map<string, Delivery>();
+  const sendMessage: ObservedSend = (to, text, options) =>
     telegramRuntime.sendMessageTelegram(to, text, {
       ...options,
       onDeliveryResult: async (delivery) => {
@@ -110,17 +124,29 @@ export async function proveTelegramApprovalTopics(params: {
     passed: false,
   };
   const artifact = path.join(env.outputDir, "telegram-approval-terminal-topics.json");
-  async function botApi(method: string, body: Record<string, unknown>, cleanup = false) {
+  async function botApi<T>(method: string, body: Record<string, unknown>, cleanup = false) {
     try {
-      const timeout = AbortSignal.timeout(20_000);
-      const response = await fetch(`${apiRoot}/bot${token}/${method}`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(body),
-        signal: signal && !cleanup ? AbortSignal.any([signal, timeout]) : timeout,
+      const { response, release } = await fetchWithSsrFGuard({
+        url: `${apiRoot}/bot${token}/${method}`,
+        init: {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        policy: botApiPolicy,
+        // The lease token is in the path: keep requests local and out of HTTP captures.
+        maxRedirects: 0,
+        capture: false,
+        timeoutMs: 20_000,
+        signal: cleanup ? undefined : signal,
+        auditContext: "qa-lab-telegram-approval-topics",
       });
-      const result = await response.json();
-      if (!response.ok || result.ok !== true) {
+      const result = await readQaJsonResponse<{ ok: unknown; result: T }>(
+        response,
+        release,
+        "Telegram Test Server",
+      );
+      if (result.ok !== true) {
         throw new Error("Bot API request failed");
       }
       return result.result;
@@ -131,11 +157,12 @@ export async function proveTelegramApprovalTopics(params: {
   }
   const terminalText = "❌ OpenClaw change denied. No change was made.";
   try {
-    proof.privateTopicsEnabled = (await botApi("getMe", {})).has_topics_enabled === true;
+    proof.privateTopicsEnabled =
+      (await botApi<{ has_topics_enabled?: boolean }>("getMe", {})).has_topics_enabled === true;
     if (!proof.privateTopicsEnabled) {
       throw new Error("Leased bot has no private-topic capability; no bot settings were changed.");
     }
-    const topic = await botApi("createForumTopic", {
+    const topic = await botApi<{ message_thread_id: number }>("createForumTopic", {
       chat_id: chatId,
       name: `QA approvals ${randomUUID()}`,
     });

--- a/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.test.ts
@@ -43,12 +43,12 @@ describe("Telegram userbot driver runtime", () => {
         "for line in sys.stdin:",
         "    request = json.loads(line)",
         "    message_id = 10 + int(request['id'])",
-        "    update = {'kind':'message','chatId':-1001,'messageId':message_id + 1,'senderId':200,'timestamp':1000,'text':request['text'],'entities':entities,'contentType':'messagePhoto'}",
+        "    update = {'kind':'message','chatId':-1001,'messageId':message_id + 1,'senderId':200,'timestamp':1000,'forumTopicId':42,'text':request['text'],'entities':entities,'contentType':'messagePhoto'}",
         "    print(json.dumps({'type':'update','update':update}), flush=True)",
         "    for replacement in [edited_entities, []]:",
         "        update = {**update, 'kind':'edit', 'entities':replacement, 'contentType':'messageVideo'}",
         "        print(json.dumps({'type':'update','update':update}), flush=True)",
-        "    result = {'chatId':-1001,'messageId':message_id,'senderId':100,'timestamp':1000,'text':request['text'],'entities':entities,'contentType':'messageText'}",
+        "    result = {'chatId':-1001,'messageId':message_id,'senderId':100,'timestamp':1000,'forumTopicId':42,'text':request['text'],'entities':entities,'contentType':'messageText'}",
         "    print(json.dumps({'type':'response','id':request['id'],'result':result}), flush=True)",
       ].join("\n"),
     );
@@ -68,6 +68,7 @@ describe("Telegram userbot driver runtime", () => {
       await expect(driver.send({ text })).resolves.toMatchObject({
         messageId: 11,
         senderId: 100,
+        forumTopicId: 42,
         contentType: "messageText",
         text,
         entities,
@@ -78,6 +79,7 @@ describe("Telegram userbot driver runtime", () => {
           kind: "message",
           messageId: 12,
           senderId: 200,
+          forumTopicId: 42,
           contentType: "messagePhoto",
           text,
           entities,
@@ -86,10 +88,18 @@ describe("Telegram userbot driver runtime", () => {
           kind: "edit",
           messageId: 12,
           contentType: "messageVideo",
+          forumTopicId: 42,
           text,
           entities: editedEntities,
         },
-        { kind: "edit", messageId: 12, contentType: "messageVideo", text, entities: [] },
+        {
+          kind: "edit",
+          messageId: 12,
+          contentType: "messageVideo",
+          forumTopicId: 42,
+          text,
+          entities: [],
+        },
       ]);
       expect(() => driver.assertHealthy()).not.toThrow();
     } finally {

--- a/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.ts
@@ -14,6 +14,7 @@ export type TelegramUserbotUpdate = {
   botApiMessageId?: number;
   chatId: number;
   contentType?: string;
+  forumTopicId?: number;
   kind: "edit" | "message";
   messageId: number;
   replyToMessageId?: number;
@@ -87,6 +88,7 @@ function parseUserbotUpdate(value: unknown): TelegramUserbotUpdate {
     timestamp,
     text: value.text,
     entities: parseTextEntities(value.entities, value.text),
+    ...(typeof value.forumTopicId === "number" ? { forumTopicId: value.forumTopicId } : {}),
     ...(typeof value.contentType === "string" ? { contentType: value.contentType } : {}),
     ...(typeof value.botApiMessageId === "number"
       ? { botApiMessageId: value.botApiMessageId }

--- a/extensions/qa-lab/src/scenario-flow-runner.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.ts
@@ -65,6 +65,8 @@ const qaFlowImportLoaders: Record<string, QaFlowImportLoader> = {
     import("./live-transports/discord/scenario-runtime.js"),
   "./live-transports/slack/scenario-runtime.js": () =>
     import("./live-transports/slack/scenario-runtime.js"),
+  "./live-transports/telegram/approval-topics.fixture.js": () =>
+    import("./live-transports/telegram/approval-topics.fixture.js"),
   "./live-transports/whatsapp/scenario-runtime.js": () =>
     import("./live-transports/whatsapp/scenario-runtime.js"),
   "./tool-search-gateway.fixture.js": () => import("./tool-search-gateway.fixture.js"),

--- a/extensions/telegram/src/approval-handler.runtime.test.ts
+++ b/extensions/telegram/src/approval-handler.runtime.test.ts
@@ -1,12 +1,40 @@
 // Telegram tests cover approval handler plugin behavior.
+import { createChannelApprovalHandlerFromCapability } from "openclaw/plugin-sdk/approval-handler-runtime";
+import type { SystemAgentApprovalRequest } from "openclaw/plugin-sdk/approval-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { telegramApprovalNativeRuntime } from "./approval-handler.runtime.js";
+import { telegramApprovalCapability } from "./approval-native.js";
 import { buildTelegramCanonicalApprovalTerminalText } from "./approval-terminal.js";
 
 type TelegramPayload = {
   text: string;
   buttons?: Array<Array<{ text: string; callback_data?: string }>>;
 };
+
+function systemAgentRequest(
+  id: string,
+  source: Pick<
+    SystemAgentApprovalRequest["request"],
+    "turnSourceTo" | "turnSourceThreadId" | "turnSourceAccountId"
+  >,
+): SystemAgentApprovalRequest {
+  return {
+    approvalKind: "system-agent",
+    id: `system-agent:${id}`,
+    request: {
+      title: "OpenClaw change",
+      description: "restart the Gateway",
+      command: "restart the Gateway",
+      proposalHash: "a".repeat(64),
+      allowedDecisions: ["allow-once", "deny"],
+      sessionId: `delegation-${id}`,
+      turnSourceChannel: "telegram",
+      ...source,
+    },
+    createdAtMs: 0,
+    expiresAtMs: 60_000,
+  };
+}
 
 describe("telegramApprovalNativeRuntime", () => {
   it("subscribes to system-agent approval events", () => {
@@ -498,23 +526,10 @@ describe("telegramApprovalNativeRuntime", () => {
   it("sends one terminal origin result and releases its dedupe entry after finalization", async () => {
     const editMessage = vi.fn().mockResolvedValue({ ok: true });
     const sendMessage = vi.fn().mockResolvedValue({ ok: true });
-    const request = {
-      approvalKind: "system-agent" as const,
-      id: "system-agent:origin-followup",
-      request: {
-        title: "OpenClaw change",
-        description: "restart the Gateway",
-        command: "restart the Gateway",
-        proposalHash: "d".repeat(64),
-        allowedDecisions: ["allow-once", "deny"] as const,
-        sessionId: "delegation-origin-followup",
-        turnSourceChannel: "telegram",
-        turnSourceTo: "1234",
-        turnSourceThreadId: 42,
-      },
-      createdAtMs: 0,
-      expiresAtMs: 60_000,
-    };
+    const request = systemAgentRequest("origin-followup", {
+      turnSourceTo: "1234",
+      turnSourceThreadId: 42,
+    });
 
     await telegramApprovalNativeRuntime.transport.updateEntry?.({
       cfg: {} as never,
@@ -573,32 +588,20 @@ describe("telegramApprovalNativeRuntime", () => {
     expect(sendMessage).toHaveBeenCalledTimes(2);
   });
 
-  it("sends the origin result when the approver card edit fails", async () => {
+  it("sends the origin result when the same-route approver card edit fails", async () => {
     const editMessage = vi.fn().mockRejectedValue(new Error("message was deleted"));
     const sendMessage = vi.fn().mockResolvedValue({ ok: true });
-    const request = {
-      approvalKind: "system-agent" as const,
-      id: "system-agent:origin-edit-failure",
-      request: {
-        title: "OpenClaw change",
-        description: "restart the Gateway",
-        command: "restart the Gateway",
-        proposalHash: "f".repeat(64),
-        allowedDecisions: ["allow-once", "deny"] as const,
-        sessionId: "delegation-origin-edit-failure",
-        turnSourceChannel: "telegram",
-        turnSourceTo: "1234",
-      },
-      createdAtMs: 0,
-      expiresAtMs: 60_000,
-    };
+    const request = systemAgentRequest("origin-edit-failure", {
+      turnSourceTo: "1234",
+      turnSourceThreadId: 42,
+    });
 
     await expect(
       telegramApprovalNativeRuntime.transport.updateEntry?.({
         cfg: {} as never,
         accountId: "default",
         context: { token: "tg-token", deps: { editMessage, sendMessage } },
-        entry: { chatId: "5678", messageId: "m1" },
+        entry: { chatId: "1234", messageThreadId: 42, messageId: "m1" },
         request,
         approvalKind: "system-agent",
         payload: { text: "⚠️ OpenClaw change approved, but it was not applied." },
@@ -613,6 +616,7 @@ describe("telegramApprovalNativeRuntime", () => {
         token: "tg-token",
         accountId: "default",
         textMode: "html",
+        messageThreadId: 42,
       },
     );
   });
@@ -620,23 +624,10 @@ describe("telegramApprovalNativeRuntime", () => {
   it("sends origin notices only through the originating Telegram account", async () => {
     const editMessage = vi.fn().mockResolvedValue({ ok: true });
     const sendMessage = vi.fn().mockResolvedValue({ ok: true });
-    const request = {
-      approvalKind: "system-agent" as const,
-      id: "system-agent:origin-account",
-      request: {
-        title: "OpenClaw change",
-        description: "restart the Gateway",
-        command: "restart the Gateway",
-        proposalHash: "g".repeat(64),
-        allowedDecisions: ["allow-once", "deny"] as const,
-        sessionId: "delegation-origin-account",
-        turnSourceChannel: "telegram",
-        turnSourceTo: "1234",
-        turnSourceAccountId: "origin",
-      },
-      createdAtMs: 0,
-      expiresAtMs: 60_000,
-    };
+    const request = systemAgentRequest("origin-account", {
+      turnSourceTo: "1234",
+      turnSourceAccountId: "origin",
+    });
     const payload = { text: "✅ OpenClaw change approved and applied." };
 
     await telegramApprovalNativeRuntime.transport.updateEntry?.({
@@ -664,6 +655,172 @@ describe("telegramApprovalNativeRuntime", () => {
     expect(sendMessage).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    ["private root to topic", "1234", "1234", 42, true],
+    ["same private topic", "1234:topic:42", "telegram:1234", 42, false],
+    ["scoped source thread", "1234:topic:42", "1234", "1234:42", false],
+    ["different private topic", "1234:topic:43", "1234:topic:42", undefined, true],
+    ["private topic one is not the root", "1234:topic:1", "1234", undefined, true],
+    ["forum General is the root", "-1001234:topic:1", "-1001234", undefined, false],
+    ["forum root is General", "-1001234", "-1001234", 1, false],
+    ["different forum topic", "-1001234:topic:43", "-1001234", 42, true],
+    [
+      "same Direct Messages topic",
+      "-1001234:direct-topic:77",
+      "-1001234:direct-topic:77",
+      undefined,
+      false,
+    ],
+    [
+      "different Direct Messages topic",
+      "-1001234:direct-topic:78",
+      "-1001234:direct-topic:77",
+      undefined,
+      true,
+    ],
+    [
+      "Direct Messages topic one is not the root",
+      "-1001234:direct-topic:1",
+      "-1001234",
+      undefined,
+      true,
+    ],
+    [
+      "forum and Direct Messages topics differ",
+      "-1001234:topic:77",
+      "-1001234:direct-topic:77",
+      undefined,
+      true,
+    ],
+    ["Direct Messages and forum topics differ", "-1001234:direct-topic:77", "-1001234", 77, true],
+  ] as const)(
+    "retains delivered routing for terminal notices: %s",
+    async (_name, to, origin, threadId, needsNotice) => {
+      const sendTyping = vi.fn().mockResolvedValue(undefined);
+      const sendMessage = vi.fn().mockResolvedValue({ chatId: to.split(":")[0], messageId: "m1" });
+      const editMessage = vi.fn().mockResolvedValue({ ok: true });
+      const request = systemAgentRequest(`route-${_name}`, {
+        turnSourceTo: origin,
+        turnSourceThreadId: threadId,
+      });
+      const common = {
+        cfg: {},
+        accountId: "default",
+        context: { token: "tg-token", deps: { sendTyping, sendMessage, editMessage } },
+        request,
+        approvalKind: "system-agent" as const,
+      };
+      const delivery = {
+        ...common,
+        plannedTarget: { surface: "origin" as const, reason: "preferred" as const, target: { to } },
+        view: {
+          approvalKind: "system-agent" as const,
+          approvalId: request.id,
+          phase: "pending" as const,
+          title: "OpenClaw change",
+          metadata: [],
+          commandText: request.request.command,
+          operationSummary: request.request.description,
+          actions: [],
+          expiresAtMs: request.expiresAtMs,
+        },
+        pendingPayload: { text: "Pending change", buttons: [] },
+      };
+      const prepared = await telegramApprovalNativeRuntime.transport.prepareTarget(delivery);
+      expect(prepared).not.toBeNull();
+      const entry = await telegramApprovalNativeRuntime.transport.deliverPending({
+        ...delivery,
+        preparedTarget: prepared!.target,
+      });
+      expect(entry).not.toBeNull();
+      sendMessage.mockClear();
+      try {
+        await telegramApprovalNativeRuntime.transport.updateEntry?.({
+          ...common,
+          entry: entry!,
+          payload: { text: "Change denied" },
+          phase: "resolved",
+        });
+        expect(editMessage).toHaveBeenCalledOnce();
+        expect(sendMessage).toHaveBeenCalledTimes(needsNotice ? 1 : 0);
+        if (needsNotice) {
+          expect(sendMessage).toHaveBeenCalledWith(
+            origin.split(":")[0],
+            "Change denied",
+            expect.objectContaining({
+              accountId: "default",
+              ...(threadId === undefined ? {} : { messageThreadId: threadId }),
+              ...(origin.includes(":direct-topic:") ? { directMessagesTopicId: 77 } : {}),
+            }),
+          );
+        }
+      } finally {
+        telegramApprovalNativeRuntime.observe?.onFinalized?.({ ...common, phase: "resolved" });
+      }
+    },
+  );
+
+  it.each([
+    ["dm", undefined, 1, 1, "❌ OpenClaw change denied. No change was made."],
+    ["channel", undefined, 1, 0, undefined],
+    ["both", undefined, 2, 0, undefined],
+    ["dm", "expired", 1, 1, "⏱️ OpenClaw change expired. No change was made."],
+    [
+      "dm",
+      "cancelled",
+      1,
+      1,
+      "⚠️ OpenClaw change was cancelled because its run ended. No change was made. Retry.",
+    ],
+  ] as const)(
+    "finalizes the real %s / %s delivery plan without losing the private origin topic",
+    async (target, terminalStatus, pendingCount, noticeCount, terminalText) => {
+      const sendTyping = vi.fn().mockResolvedValue(undefined);
+      const sendMessage = vi.fn().mockResolvedValue({ chatId: "1234", messageId: "m1" });
+      const editMessage = vi.fn().mockResolvedValue({ ok: true });
+      const handler = await createChannelApprovalHandlerFromCapability({
+        capability: telegramApprovalCapability,
+        label: "telegram/approvals",
+        clientDisplayName: "Telegram approvals",
+        channel: "telegram",
+        channelLabel: "Telegram",
+        cfg: {
+          channels: {
+            telegram: {
+              botToken: "tg-token",
+              execApprovals: { enabled: true, approvers: ["1234"], target },
+            },
+          },
+        },
+        accountId: "default",
+        context: { token: "tg-token", deps: { sendTyping, sendMessage, editMessage } },
+        nowMs: () => 0,
+      });
+      const request = systemAgentRequest(`plan-${target}-${terminalStatus}`, {
+        turnSourceTo: "1234",
+        turnSourceThreadId: 42,
+      });
+      expect(handler).not.toBeNull();
+      try {
+        await handler!.handleRequested(request);
+        expect(sendMessage).toHaveBeenCalledTimes(pendingCount);
+        sendMessage.mockClear();
+        await handler!.handleResolved({ id: request.id, decision: "deny", terminalStatus, ts: 1 });
+        expect(editMessage).toHaveBeenCalledTimes(pendingCount);
+        expect(sendMessage).toHaveBeenCalledTimes(noticeCount);
+        if (noticeCount) {
+          expect(sendMessage).toHaveBeenCalledWith(
+            "1234",
+            terminalText,
+            expect.objectContaining({ messageThreadId: 42 }),
+          );
+        }
+      } finally {
+        await handler!.stop();
+      }
+    },
+  );
+
   it("passes topic thread ids to typing and message delivery", async () => {
     const sendTyping = vi.fn().mockResolvedValue({ ok: true });
     const sendMessage = vi.fn().mockResolvedValue({
@@ -671,7 +828,7 @@ describe("telegramApprovalNativeRuntime", () => {
       messageId: "m1",
     });
 
-    const entry = await telegramApprovalNativeRuntime.transport.deliverPending({
+    await telegramApprovalNativeRuntime.transport.deliverPending({
       cfg: {} as never,
       accountId: "default",
       context: {
@@ -726,10 +883,6 @@ describe("telegramApprovalNativeRuntime", () => {
       accountId: "default",
       buttons: [],
       messageThreadId: 928,
-    });
-    expect(entry).toEqual({
-      chatId: "-1003841603622",
-      messageId: "m1",
     });
   });
 

--- a/extensions/telegram/src/approval-handler.runtime.ts
+++ b/extensions/telegram/src/approval-handler.runtime.ts
@@ -20,7 +20,6 @@ import type {
 } from "openclaw/plugin-sdk/approval-runtime";
 import { resolveGatewayPublicOrigin } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { buildTelegramApprovalCallbackData } from "./approval-callback-data.js";
@@ -28,12 +27,15 @@ import {
   buildTelegramNativeExpiredApprovalText,
   buildTelegramNativeResolvedApprovalText,
 } from "./approval-terminal.js";
+import { buildTelegramRoutingTarget } from "./bot/helpers.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";
 import {
   isTelegramExecApprovalHandlerConfigured,
   shouldHandleTelegramExecApprovalRequest,
 } from "./exec-approvals.js";
 import { escapeTelegramHtml } from "./format.js";
+import { parseTelegramThreadId } from "./outbound-params.js";
+import { resolveTelegramSendThreadSpec } from "./reply-parameters.js";
 import {
   editMessageReplyMarkupTelegram,
   editMessageTelegram,
@@ -48,10 +50,12 @@ const log = createSubsystemLogger("telegram/approvals");
 const terminalizedSystemAgentApprovals = new Set<string>();
 
 type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest | SystemAgentApprovalRequest;
-type PendingMessage = {
+type ApprovalTarget = {
   chatId: string;
-  messageId: string;
+  messageThreadId?: number;
+  directMessagesTopicId?: number;
 };
+type PendingMessage = ApprovalTarget & { messageId: string };
 type TelegramPendingDelivery = {
   text: string;
   buttons: ReturnType<typeof resolveTelegramInlineButtons>;
@@ -72,6 +76,17 @@ type TelegramApprovalHandlerContext = {
   token: string;
   deps?: TelegramExecApprovalHandlerDeps;
 };
+
+function approvalTargetKey(target: ApprovalTarget): string {
+  return buildTelegramRoutingTarget(
+    target.chatId,
+    resolveTelegramSendThreadSpec({
+      messageThreadId: target.messageThreadId,
+      targetDirectMessagesTopicId: target.directMessagesTopicId,
+      chatType: parseTelegramTarget(target.chatId).chatType,
+    }),
+  );
+}
 
 function resolveHandlerContext(params: ChannelApprovalCapabilityHandlerContext): {
   accountId: string;
@@ -171,7 +186,7 @@ function buildPendingPayload(params: {
 
 export const telegramApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdapter<
   TelegramPendingDelivery,
-  { chatId: string; messageThreadId?: number; directMessagesTopicId?: number },
+  ApprovalTarget,
   PendingMessage,
   never,
   TelegramFinalDelivery
@@ -236,23 +251,18 @@ export const telegramApprovalNativeRuntime = createChannelApprovalNativeRuntimeA
         cfg,
         token: resolved.context.token,
         accountId: resolved.accountId,
-        ...(preparedTarget.messageThreadId != null
-          ? { messageThreadId: preparedTarget.messageThreadId }
-          : {}),
+        messageThreadId: preparedTarget.messageThreadId,
       }).catch(() => {});
       const result = await sendMessage(preparedTarget.chatId, pendingPayload.text, {
         cfg,
         token: resolved.context.token,
         accountId: resolved.accountId,
         buttons: pendingPayload.buttons,
-        ...(preparedTarget.messageThreadId != null
-          ? { messageThreadId: preparedTarget.messageThreadId }
-          : {}),
-        ...(preparedTarget.directMessagesTopicId != null
-          ? { directMessagesTopicId: preparedTarget.directMessagesTopicId }
-          : {}),
+        messageThreadId: preparedTarget.messageThreadId,
+        directMessagesTopicId: preparedTarget.directMessagesTopicId,
       });
       return {
+        ...preparedTarget,
         chatId: result.chatId,
         messageId: result.messageId,
       };
@@ -285,29 +295,28 @@ export const telegramApprovalNativeRuntime = createChannelApprovalNativeRuntimeA
           ? normalizeTelegramChatId(parsedOrigin.chatId)
           : undefined;
         const originThreadId =
-          parseStrictPositiveInteger(request.request.turnSourceThreadId) ??
+          parseTelegramThreadId(request.request.turnSourceThreadId) ??
           parsedOrigin?.messageThreadId;
         const sourceAccountId = request.request.turnSourceAccountId?.trim();
         const isSourceAccount = !sourceAccountId || sourceAccountId === resolved.accountId;
-        if (
-          originChatId &&
-          isSourceAccount &&
-          (entry.chatId !== originChatId || editError !== undefined)
-        ) {
-          if (!terminalizedSystemAgentApprovals.has(request.id)) {
+        if (originChatId && isSourceAccount && !terminalizedSystemAgentApprovals.has(request.id)) {
+          const origin = {
+            chatId: originChatId,
+            messageThreadId: originThreadId,
+            directMessagesTopicId: parsedOrigin?.directMessagesTopicId,
+          };
+          // An edit notifies only its delivered topic; normalize General exactly as the sender does.
+          if (editError !== undefined || approvalTargetKey(entry) !== approvalTargetKey(origin)) {
             const sendMessage = resolved.context.deps?.sendMessage ?? sendMessageTelegram;
-            const originTo =
-              parsedOrigin?.directMessagesTopicId != null ? originTarget! : originChatId;
-            await sendMessage(originTo, escapeTelegramHtml(payload.text), {
+            await sendMessage(originChatId, escapeTelegramHtml(payload.text), {
               cfg,
               token: resolved.context.token,
               accountId: resolved.accountId,
               textMode: "html",
-              ...(originThreadId != null ? { messageThreadId: originThreadId } : {}),
+              messageThreadId: origin.messageThreadId,
+              directMessagesTopicId: origin.directMessagesTopicId,
             });
-            terminalizedSystemAgentApprovals.add(request.id);
           }
-        } else if (originChatId && isSourceAccount) {
           terminalizedSystemAgentApprovals.add(request.id);
         }
       }

--- a/qa/scenarios/channels/telegram-approval-terminal-topics.yaml
+++ b/qa/scenarios/channels/telegram-approval-terminal-topics.yaml
@@ -1,0 +1,51 @@
+title: Telegram approval terminal topic delivery
+
+scenario:
+  id: telegram-approval-terminal-topics
+  surface: channels
+  coverage:
+    primary:
+      - telegram.conversation-routing-and-delivery
+  objective: Return delegated-change approval results to the originating private topic without duplicate same-route notices.
+  successCriteria:
+    - The installed package's native planner delivers real approval cards to the configured DM or origin topic.
+    - TDLib observes the pending card and a successful terminal edit of that same message.
+    - DM-only approval returns one result to the origin topic; an origin-topic card produces no extra notice.
+  docsRefs:
+    - docs/channels/telegram.md
+  codeRefs:
+    - extensions/telegram/src/approval-handler.runtime.ts
+    - extensions/telegram/src/approval-native.ts
+  execution:
+    kind: flow
+    channel: telegram
+    retryCount: 0
+    timeoutMs: 180000
+    suiteIsolation: isolated
+    isolationReason: Native approval events and private-topic receive observations belong to one leased bot.
+    transportPolicy:
+      directMessageOnly: true
+    summary: Feed deterministic approval events to the installed native handler and observe actual Telegram Test Server messages and edits.
+    config:
+      requiredProviderMode: mock-openai
+      requiredChannelDriver: live
+
+flow:
+  steps:
+    - name: same-route edit and cross-topic terminal notice
+      actions:
+        - call: waitForGatewayHealthy
+          args: [{ ref: env }, 60000]
+        - call: waitForTransportReady
+          args: [{ ref: env }, 60000]
+        - resetTransport: true
+        - set: fixture
+          value:
+            expr: "await qaImport('./live-transports/telegram/approval-topics.fixture.js')"
+        - call: fixture.proveTelegramApprovalTopics
+          args:
+            - env: { ref: env }
+              readTelegramMessages: { ref: readTelegramMessages }
+              signal: { ref: signal }
+          saveAs: result
+      detailsExpr: result.details


### PR DESCRIPTION
Closes #137437
Related: #134670

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch in `openclaw/openclaw`; repository collaborators retain normal branch access.

</details>

## What Problem This Solves

Fixes an issue where operators resolving a delegated OpenClaw change would see the approval card update but receive no result in the originating Telegram topic when the card was delivered elsewhere in the same chat. The default DM-only approval route can put the card at the private-chat root while the requesting turn belongs to a private topic. Expiration and run cancellation have the same missing-notice failure.

## Why This Change Was Made

The Telegram approval delivery owner now carries the already-prepared thread and Direct Messages topic through its private pending entry. Terminal deduplication compares the full delivered route using the same normalization as the sender, rather than comparing only chat IDs. A successful edit suppresses a notice only in that exact destination; a failed edit still attempts the origin notice and propagates its error.

This preserves forum General normalization without collapsing private topic 1 or confusing forum topics with channel Direct Messages topics. It also uses the native Telegram thread parser for scoped source-thread identifiers. Redundant conditional spreads, duplicate dedupe branches, and direct-topic string reconstruction are removed. There are no config, dependency, protocol, SDK, database, or persistence changes.

Production delta is +35/−26 (+9): the retained route coordinates and canonical comparison replace the insufficient chat/message-only pending representation. Tests and QA-only recorder/fixture code are counted separately. The QA recorder reads the pinned TDLib 1.8.67 `topic_id.messageTopicForum.forum_topic_id` unchanged; message-thread IDs remain distinct.

## User Impact

Operators see denied, expired, cancelled, and approved outcomes in the topic that requested the change, even when the approval card is elsewhere in the same chat. An updated card in the originating topic does not create a duplicate notice. Existing source-account checks and sequential fanout behavior remain intact; no operator migration or new setting is required.

## Evidence

- Exact baseline `d2a616bdf373a5b3cac0add8e9b2f70cd0802f42`: the final regression suite has 11 failures and 31 passes. All failures are missing expected origin notices, including the actual exported native capability and generic handler for DM-only denied/expired/cancelled events.
- Candidate focused verification: 127 tests pass across Telegram approval runtime/planner, the TDLib process boundary, scenario catalog, and scenario selection. Python recorder lifecycle: 9 tests pass; the same changed test errors on the baseline recorder because the forum topic is dropped.
- All extension project typechecks and final full lint/import-cycle checks pass. All pre-lint components of the full changed-surface gate passed; its earlier wrapper run stopped on fixture lint findings that are now corrected. The refreshed complete private-QA build passes on integrated main `1b6eea93c8610221ba9052e986915199ee4b12a7`, including all 149 public SDK subpaths and the Control UI size gates.
- Integration-specific verification: 117 QA flow/evidence/catalog/selection tests pass on `1b6eea93c8610221ba9052e986915199ee4b12a7`. The sole overlapping file retains the upstream RTT changes; all other owned files are byte-identical to the reviewed candidate. Compiled package imports expose the exact generic-handler, native-capability, and Telegram-transport entry points used by the fixture.
- Independent P0–P2 review is clean after correcting fixture cleanup. The fixture drains its synthetic pending request, captures actual candidate Bot API send receipts through the existing observer callback, and deletes its own root-DM/topic messages before removing the created topic.
- Live Test Server proof is running: [baseline Package Acceptance](https://github.com/openclaw/openclaw/actions/runs/33782590314) and [candidate Package Acceptance](https://github.com/openclaw/openclaw/actions/runs/33782596982), both using reviewed harness `8230ccb174bb4a569bc9cb3d076d1fb3471e290e`. No live success is claimed yet. The scenario uses the exact installed candidate's generic approval handler, native planner, and real Telegram transport, observed by the leased TDLib user. It tests same-route no-duplicate behavior and cross-topic notice delivery after a successful same-message card edit. It does not claim delegated-authority admission or Gateway route-coordinator coverage. A bot without existing private-topic capability fails with an explicit prerequisite; no bot settings or permissions are changed.

Related discovery: #125166 and #125190 concern missing thread metadata during initial plugin-approval target selection, not this delegated-change terminal notice loss; this PR does not claim to resolve them. A separate QA tooling follow-up is recorded for the userbot CLI's older send-message thread argument shape; this scenario does not use that path.

## CI repair and live limitation

The initial PR CI found two QA-fixture boundary violations: an unguarded Bot API fetch and a type-only sibling-plugin import that pulled Telegram source into qa-lab's isolated TypeScript package. The fixture now uses the existing guarded HTTP and bounded-response/release owners, and describes only the opaque send pass-through and receipt fields it observes. No guard allowlist, package boundary, SDK, dependency, or Telegram production change was made. This follow-up is QA support only (+42/−15, net +27).

Both errors reproduced on published head `8230ccb174bb4a569bc9cb3d076d1fb3471e290e`. Targeted raw-fetch guard, isolated qa-lab package compilation, typed fixture lint, formatting, and 127 focused Telegram/QA tests pass after repair. Local real-loopback smoke checks capability rejection, no redirect replay, malformed JSON and cancellation with sanitized errors/artifacts. Independent P0–P2 review is scoped-clean. Local HTTP smoke is not Telegram or installed-package behavior proof.

Paired Package Acceptance baseline run 33782590314 and candidate run 33782596982 used the immutable original `8230ccb` harness. Both reached Telegram, then failed at the explicit prerequisite: the leased bot did not expose private-topic capability. Neither run reached the pending-card/edit/terminal-routing assertions, so neither is a live routing verdict. No bot setting or permission was changed. The current broker allocates by credential kind and availability/least-recent use, not topic capability; it has no supported capability or credential-ID selection input. Pool-wide capability availability remains unverified. Do not blindly re-dispatch or imply successful live validation.
