### PR TITLE
fix(discord): delayed realtime voice transcripts get attributed to a newer speaker

### DIFF
--- a/extensions/discord/src/voice/manager.e2e.test-support.ts
+++ b/extensions/discord/src/voice/manager.e2e.test-support.ts
@@ -3,6 +3,7 @@ import type {
   RealtimeVoiceBridgeEvent,
   RealtimeVoiceBridgeCreateRequest,
   RealtimeVoiceResponseOutcome,
+  RealtimeVoiceTranscriptSource,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { vi, type Mock } from "vitest";
 import { ChannelType } from "../internal/discord.js";
@@ -26,7 +27,12 @@ export type TestRealtimeBridgeParams = {
     event: { args: unknown; callId: string; itemId: string; name: string },
     session: unknown,
   ) => Promise<void> | void;
-  onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
+  onTranscript?: (
+    role: "user" | "assistant",
+    text: string,
+    isFinal: boolean,
+    source?: RealtimeVoiceTranscriptSource,
+  ) => void;
   tools?: Array<{ name: string }>;
 };
 

--- a/extensions/discord/src/voice/realtime-session.runtime.ts
+++ b/extensions/discord/src/voice/realtime-session.runtime.ts
@@ -347,7 +347,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
           this.harness.flushOutput(() => this.playback.clearOutputAudio("provider-clear-audio"));
         },
       },
-      onTranscript: (role, text, isFinal) => {
+      onTranscript: (role, text, isFinal, source) => {
         this.markProviderGenerationObserved();
         if (isFinal && text.trim()) {
           logger.info(
@@ -364,7 +364,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
           this.turns.handlePartialUserTranscript(text);
           return;
         }
-        void this.turns.handleFinalUserTranscript(text);
+        void this.turns.handleFinalUserTranscript(text, source);
       },
       onToolCall: (event, session) => {
         this.markProviderGenerationObserved();
@@ -494,6 +494,15 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     }
     if (event.direction === "server" && event.type === "input_audio_buffer.speech_started") {
       this.turns.resetPartialWakeNameTracking();
+      this.turns.markProviderSpeechSegmentStarted();
+    }
+    if (
+      event.direction === "server" &&
+      (event.type === "conversation.item.added" || event.type === "conversation.item.created") &&
+      event.itemRole === "user" &&
+      event.itemId
+    ) {
+      this.turns.bindSpeakerInputItem(event.itemId);
     }
     if (shouldLogRealtimeVerboseEvent(event)) {
       logVoiceVerbose(`realtime ${event.direction}:${event.type}${detail}`);

--- a/extensions/discord/src/voice/realtime-turns.test.ts
+++ b/extensions/discord/src/voice/realtime-turns.test.ts
@@ -225,6 +225,100 @@ defineDiscordVoiceTests(
       expect(bobCall?.senderIsOwner).toBe(true);
     });
 
+    it("keeps a delayed final transcript on the speaker whose audio produced it", async () => {
+      agentCommandMock.mockResolvedValue({ payloads: [{ text: "talkback answer" }] });
+      const { bridgeParams, entry } = await createJoinedAgentProxyFixture({
+        config: {
+          voice: { realtime: { debounceMs: 1, requireWakeName: false, toolPolicy: "none" } },
+        },
+      });
+
+      const guestTurn = beginSpeakerTurn(entry, {
+        senderIsOwner: false,
+        speakerLabel: "Guest",
+        userId: "u-guest",
+      });
+      bridgeParams?.onEvent?.({
+        direction: "server",
+        type: "input_audio_buffer.speech_started",
+      });
+      guestTurn.close();
+      bridgeParams?.onEvent?.({
+        direction: "server",
+        type: "conversation.item.added",
+        itemId: "item_guest_speech",
+        itemRole: "user",
+      });
+
+      const ownerTurn = beginSpeakerTurn(entry, {
+        senderIsOwner: true,
+        speakerLabel: "Owner",
+        userId: "u-owner",
+      });
+      ownerTurn.sendInputAudio(Buffer.alloc(8));
+      bridgeParams?.onEvent?.({
+        direction: "server",
+        type: "input_audio_buffer.speech_started",
+      });
+      bridgeParams?.onEvent?.({
+        direction: "server",
+        type: "conversation.item.added",
+        itemId: "item_owner_speech",
+        itemRole: "user",
+      });
+
+      await flushRealtimeForcedConsultTimers(() => {
+        bridgeParams?.onTranscript?.("user", "delayed guest question", true, {
+          itemId: "item_guest_speech",
+        });
+      });
+
+      expect(lastAgentCommandArgs().senderIsOwner).toBe(false);
+    });
+
+    it("does not run an uncorrelated delayed transcript with a newer speaker's authority", async () => {
+      agentCommandMock.mockResolvedValue({ payloads: [{ text: "talkback answer" }] });
+      const { bridgeParams, entry } = await createJoinedAgentProxyFixture({
+        config: {
+          voice: { realtime: { debounceMs: 1, requireWakeName: false, toolPolicy: "none" } },
+        },
+      });
+
+      const guestTurn = beginSpeakerTurn(entry, {
+        senderIsOwner: false,
+        speakerLabel: "Guest",
+        userId: "u-guest",
+      });
+      guestTurn.close();
+      bridgeParams?.onEvent?.({
+        direction: "server",
+        type: "conversation.item.added",
+        itemId: "item_guest_speech",
+        itemRole: "user",
+      });
+
+      const ownerTurn = beginSpeakerTurn(entry, {
+        senderIsOwner: true,
+        speakerLabel: "Owner",
+        userId: "u-owner",
+      });
+      ownerTurn.sendInputAudio(Buffer.alloc(8));
+      bridgeParams?.onEvent?.({
+        direction: "server",
+        type: "conversation.item.added",
+        itemId: "item_owner_speech",
+        itemRole: "user",
+      });
+
+      await flushRealtimeForcedConsultTimers(() => {
+        bridgeParams?.onTranscript?.("user", "uncorrelated speech", true, {
+          itemId: "item_unknown_speech",
+        });
+      });
+
+      expect(agentCommandMock).not.toHaveBeenCalled();
+    });
+
     it("drops stale active-run control after provider continuity reset", async () => {
       let resolveOldControl: ((result: RealtimeVoiceAgentControlResult) => void) | undefined;
       controlRealtimeVoiceAgentRunMock

--- a/extensions/discord/src/voice/realtime-turns.test.ts
+++ b/extensions/discord/src/voice/realtime-turns.test.ts
@@ -319,6 +319,92 @@ defineDiscordVoiceTests(
       expect(agentCommandMock).not.toHaveBeenCalled();
     });
 
+    it("keeps an interleaved provider speech segment on the speaker whose audio is streaming", async () => {
+      agentCommandMock.mockResolvedValue({ payloads: [{ text: "talkback answer" }] });
+      const { bridgeParams, entry } = await createJoinedAgentProxyFixture({
+        config: {
+          voice: { realtime: { debounceMs: 1, requireWakeName: false, toolPolicy: "none" } },
+        },
+      });
+
+      // The guest speaks continuously; the owner's capture decodes its first chunk
+      // in between, and the provider's VAD start for the ongoing guest segment is
+      // delivered after that interleaving.
+      const guestTurn = beginSpeakerTurn(entry, {
+        senderIsOwner: false,
+        speakerLabel: "Guest",
+        userId: "u-guest",
+      });
+      beginSpeakerTurn(entry, {
+        senderIsOwner: true,
+        speakerLabel: "Owner",
+        userId: "u-owner",
+      });
+      guestTurn.sendInputAudio(Buffer.alloc(8));
+      bridgeParams?.onEvent?.({
+        direction: "server",
+        type: "input_audio_buffer.speech_started",
+      });
+      bridgeParams?.onEvent?.({
+        direction: "server",
+        type: "conversation.item.added",
+        itemId: "item_guest_speech",
+        itemRole: "user",
+      });
+
+      await flushRealtimeForcedConsultTimers(() => {
+        bridgeParams?.onTranscript?.("user", "guest keeps talking", true, {
+          itemId: "item_guest_speech",
+        });
+      });
+
+      expect(lastAgentCommandArgs().senderIsOwner).toBe(false);
+    });
+
+    it("does not satisfy another speaker's wake-name follow-up with a bound transcript", async () => {
+      agentCommandMock.mockResolvedValue({ payloads: [{ text: "talkback answer" }] });
+      const { bridgeParams, entry } = await createJoinedAgentProxyFixture({
+        config: {
+          voice: { realtime: { debounceMs: 1, requireWakeName: true, toolPolicy: "none" } },
+        },
+      });
+
+      const ownerTurn = beginSpeakerTurn(entry, {
+        senderIsOwner: true,
+        speakerLabel: "Owner",
+        userId: "u-owner",
+      });
+      await flushRealtimeForcedConsultTimers(() => {
+        bridgeParams?.onTranscript?.("user", "OpenClaw,", true);
+      });
+      ownerTurn.close();
+
+      const guestTurn = beginSpeakerTurn(entry, {
+        senderIsOwner: false,
+        speakerLabel: "Guest",
+        userId: "u-guest",
+      });
+      guestTurn.sendInputAudio(Buffer.alloc(8));
+      bridgeParams?.onEvent?.({
+        direction: "server",
+        type: "input_audio_buffer.speech_started",
+      });
+      bridgeParams?.onEvent?.({
+        direction: "server",
+        type: "conversation.item.added",
+        itemId: "item_guest_speech",
+        itemRole: "user",
+      });
+
+      await flushRealtimeForcedConsultTimers(() => {
+        bridgeParams?.onTranscript?.("user", "hello there", true, {
+          itemId: "item_guest_speech",
+        });
+      });
+
+      expect(agentCommandMock).not.toHaveBeenCalled();
+    });
+
     it("drops stale active-run control after provider continuity reset", async () => {
       let resolveOldControl: ((result: RealtimeVoiceAgentControlResult) => void) | undefined;
       controlRealtimeVoiceAgentRunMock

--- a/extensions/discord/src/voice/realtime-turns.ts
+++ b/extensions/discord/src/voice/realtime-turns.ts
@@ -77,7 +77,7 @@ export class DiscordRealtimeTurns {
   // conversation item inherits that binding by item id, and the delayed final transcript
   // resolves its speaker from the item id instead of callback timing.
   private inputItemSpeakers = new Map<string, PendingSpeakerTurn>();
-  private lastAudioTurn: PendingSpeakerTurn | undefined;
+  private lastAudioSender: PendingSpeakerTurn | undefined;
   private pendingSegmentSpeaker: PendingSpeakerTurn | undefined;
   private pendingWakeNameFollowup:
     | {
@@ -180,13 +180,20 @@ export class DiscordRealtimeTurns {
     const wakeNameResult = this.resolveWakeNameTranscript(trimmed, requireWakeName);
     let forcedSpeakerContext: DiscordRealtimeSpeakerContext | undefined;
     if (!wakeNameResult.allowed) {
-      if (this.pendingWakeNameFollowup && boundTurn) {
-        // A pending follow-up is satisfied by this transcript, and the item binding
-        // supplies the actual speaker instead of the timing-armed follow-up context.
+      if (
+        boundTurn &&
+        this.pendingWakeNameFollowup &&
+        this.pendingWakeNameFollowup.context.userId === boundTurn.context.userId
+      ) {
+        // The pending follow-up is satisfied by its own speaker's bound transcript, and
+        // the item binding supplies the actual speaker instead of the timing-armed
+        // follow-up context. Another participant's follow-up never authorizes this.
         this.pendingWakeNameFollowup = undefined;
         forcedSpeakerContext = boundTurn.context;
       } else {
-        const pendingWakeNameFollowup = this.consumePendingWakeNameFollowup();
+        const pendingWakeNameFollowup = boundTurn
+          ? undefined
+          : this.consumePendingWakeNameFollowup();
         transcriptAttribution ??= pendingWakeNameFollowup;
         if (!pendingWakeNameFollowup) {
           this.recordTranscriptUtterance(trimmed, transcriptAttribution, providerEpoch);
@@ -236,22 +243,22 @@ export class DiscordRealtimeTurns {
   clear(): void {
     this.speakerTurns.clear();
     this.resetPartialWakeNameTracking();
-    this.lastAudioTurn = undefined;
+    this.lastAudioSender = undefined;
     this.resetProviderContinuity();
   }
 
   /**
    * Pins the in-flight provider speech segment to the speaker whose audio is streaming.
-   * The VAD start event arrives in band with the audio stream, before any newer capture
-   * can begin, so it is the only reliable point to observe who is speaking.
+   * The VAD start event arrives in band with the audio stream, so it binds to the turn
+   * that most recently sent audio bytes, not to whichever capture merely started first.
    */
   markProviderSpeechSegmentStarted(): void {
-    this.pendingSegmentSpeaker = this.lastAudioTurn;
+    this.pendingSegmentSpeaker = this.lastAudioSender;
   }
 
   /** Binds an admitted provider input item to the speaker pinned for its speech segment. */
   bindSpeakerInputItem(itemId: string): void {
-    const speaker = this.pendingSegmentSpeaker ?? this.lastAudioTurn;
+    const speaker = this.pendingSegmentSpeaker ?? this.lastAudioSender;
     this.pendingSegmentSpeaker = undefined;
     if (!speaker) {
       return;
@@ -303,6 +310,9 @@ export class DiscordRealtimeTurns {
     const realtimePcm = convertDiscordPcm48kStereoToRealtimePcm24kMono(discordPcm48kStereo);
     if (realtimePcm.length > 0) {
       this.registerSpeakerTurnAudioStarted(turn);
+      // Concurrent captures interleave in the shared provider stream; the most recent
+      // sender is the only in-band signal for who produced the bytes the provider sees.
+      this.lastAudioSender = turn;
       turn.inputDiscordBytes += discordPcm48kStereo.length;
       turn.inputRealtimeBytes += realtimePcm.length;
       turn.inputChunks += 1;
@@ -333,7 +343,6 @@ export class DiscordRealtimeTurns {
       return;
     }
     this.speakerTurns.markAudio(turn);
-    this.lastAudioTurn = turn;
     logger.info(
       `discord voice: realtime speaker turn opened guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${turn.context.userId} speaker=${turn.context.speakerLabel} owner=${turn.context.senderIsOwner} pendingTurns=${this.speakerTurns.size()}`,
     );

--- a/extensions/discord/src/voice/realtime-turns.ts
+++ b/extensions/discord/src/voice/realtime-turns.ts
@@ -11,6 +11,7 @@ import {
   type RealtimeVoiceBridgeSession,
   type RealtimeVoiceTurnContextHandle,
   type RealtimeVoiceTurnContextTracker,
+  type RealtimeVoiceTranscriptSource,
   type RealtimeVoiceWakeNamePolicy,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -29,6 +30,7 @@ const logger = createSubsystemLogger("discord/voice");
 const DISCORD_REALTIME_PENDING_SPEAKER_CONTEXT_LIMIT = 32;
 const DISCORD_REALTIME_IGNORED_WAKE_NAME_CONTEXT_TTL_MS = 10_000;
 const DISCORD_REALTIME_WAKE_NAME_FOLLOWUP_TTL_MS = 10_000;
+const DISCORD_REALTIME_INPUT_ITEM_SPEAKER_LIMIT = 64;
 const REALTIME_PCM16_BYTES_PER_SAMPLE = 2;
 const DISCORD_REALTIME_TRAILING_SILENCE_MIN_MS = 700;
 const DISCORD_REALTIME_TRAILING_SILENCE_MAX_MS = 3_000;
@@ -70,6 +72,13 @@ export class DiscordRealtimeTurns {
   );
   private partialUserTranscript = "";
   private wakeNameAckedForTurn = false;
+  // Provider input items are correlated with Discord speakers through in-band VAD events:
+  // speech_started pins the segment to the turn whose audio is streaming, the admitted
+  // conversation item inherits that binding by item id, and the delayed final transcript
+  // resolves its speaker from the item id instead of callback timing.
+  private inputItemSpeakers = new Map<string, PendingSpeakerTurn>();
+  private lastAudioTurn: PendingSpeakerTurn | undefined;
+  private pendingSegmentSpeaker: PendingSpeakerTurn | undefined;
   private pendingWakeNameFollowup:
     | {
         context: DiscordRealtimeSpeakerContext;
@@ -140,45 +149,75 @@ export class DiscordRealtimeTurns {
     this.params.playback.sendWakeNameAck(wakeNameResult);
   }
 
-  async handleFinalUserTranscript(text: string): Promise<void> {
+  async handleFinalUserTranscript(
+    text: string,
+    source?: RealtimeVoiceTranscriptSource,
+  ): Promise<void> {
     const providerEpoch = this.params.providerEpoch();
     const trimmed = text.trim();
     if (!trimmed) {
       return;
     }
     this.partialUserTranscript = "";
-    const transcriptsTurn = this.peekPendingSpeakerTurn();
+    let boundTurn: PendingSpeakerTurn | undefined;
+    if (source) {
+      // Identity-capable providers report which input item produced this transcript.
+      // Callback timing, question text, and model claims cannot establish the speaker,
+      // so an uncorrelated transcript must never borrow the newest pending context.
+      boundTurn = this.takeBoundSpeakerTurn(source.itemId);
+      if (!boundTurn) {
+        logger.warn(
+          `discord voice: realtime transcript dropped without a speaker binding chars=${trimmed.length} voiceSession=${this.params.entry.voiceSessionKey} agent=${this.params.entry.route.agentId}`,
+        );
+        return;
+      }
+      this.speakerTurns.remove(boundTurn);
+    }
+    const transcriptsTurn = boundTurn ?? this.peekPendingSpeakerTurn();
     let transcriptAttribution = this.transcriptAttributionFromTurn(transcriptsTurn);
     const humanParticipantCount = this.params.getHumanParticipantCount();
     const requireWakeName = this.isWakeNameRequired(humanParticipantCount);
     const wakeNameResult = this.resolveWakeNameTranscript(trimmed, requireWakeName);
     let forcedSpeakerContext: DiscordRealtimeSpeakerContext | undefined;
     if (!wakeNameResult.allowed) {
-      const pendingWakeNameFollowup = this.consumePendingWakeNameFollowup();
-      transcriptAttribution ??= pendingWakeNameFollowup;
-      if (!pendingWakeNameFollowup) {
-        this.recordTranscriptUtterance(trimmed, transcriptAttribution, providerEpoch);
-        this.rememberIgnoredWakeNameSpeakerContext(this.consumePendingSpeakerContext());
+      if (this.pendingWakeNameFollowup && boundTurn) {
+        // A pending follow-up is satisfied by this transcript, and the item binding
+        // supplies the actual speaker instead of the timing-armed follow-up context.
+        this.pendingWakeNameFollowup = undefined;
+        forcedSpeakerContext = boundTurn.context;
+      } else {
+        const pendingWakeNameFollowup = this.consumePendingWakeNameFollowup();
+        transcriptAttribution ??= pendingWakeNameFollowup;
+        if (!pendingWakeNameFollowup) {
+          this.recordTranscriptUtterance(trimmed, transcriptAttribution, providerEpoch);
+          this.rememberIgnoredWakeNameSpeakerContext(
+            boundTurn?.context ?? this.consumePendingSpeakerContext(),
+          );
+          logger.info(
+            `discord voice: realtime wake-name gate ignored transcript chars=${trimmed.length} humanParticipants=${humanParticipantCount} voiceSession=${this.params.entry.voiceSessionKey} agent=${this.params.entry.route.agentId} wakeNames=${this.params.wakeNames().join(",") || "none"}`,
+          );
+          return;
+        }
+        forcedSpeakerContext = pendingWakeNameFollowup.context;
         logger.info(
-          `discord voice: realtime wake-name gate ignored transcript chars=${trimmed.length} humanParticipants=${humanParticipantCount} voiceSession=${this.params.entry.voiceSessionKey} agent=${this.params.entry.route.agentId} wakeNames=${this.params.wakeNames().join(",") || "none"}`,
+          `discord voice: realtime wake-name follow-up accepted chars=${trimmed.length} speaker=${forcedSpeakerContext.speakerLabel} voiceSession=${this.params.entry.voiceSessionKey} agent=${this.params.entry.route.agentId}`,
         );
-        return;
       }
-      forcedSpeakerContext = pendingWakeNameFollowup.context;
-      logger.info(
-        `discord voice: realtime wake-name follow-up accepted chars=${trimmed.length} speaker=${forcedSpeakerContext.speakerLabel} voiceSession=${this.params.entry.voiceSessionKey} agent=${this.params.entry.route.agentId}`,
-      );
     }
     this.recordTranscriptUtterance(trimmed, transcriptAttribution, providerEpoch);
     const acceptedText = wakeNameResult.allowed ? wakeNameResult.text || trimmed : trimmed;
     if (wakeNameResult.allowed && !wakeNameResult.text.trim()) {
-      this.armWakeNameFollowup();
+      this.armWakeNameFollowup(boundTurn);
       return;
     }
     if (wakeNameResult.allowed) {
       this.pendingWakeNameFollowup = undefined;
     }
-    await this.params.onAcceptedTranscript(acceptedText, forcedSpeakerContext, providerEpoch);
+    await this.params.onAcceptedTranscript(
+      acceptedText,
+      forcedSpeakerContext ?? boundTurn?.context,
+      providerEpoch,
+    );
   }
 
   resetPartialWakeNameTracking(): void {
@@ -189,12 +228,43 @@ export class DiscordRealtimeTurns {
   resetProviderContinuity(): void {
     this.partialUserTranscript = "";
     this.pendingWakeNameFollowup = undefined;
+    // Provider item ids from a previous connection can never correlate again.
+    this.pendingSegmentSpeaker = undefined;
+    this.inputItemSpeakers.clear();
   }
 
   clear(): void {
     this.speakerTurns.clear();
     this.resetPartialWakeNameTracking();
-    this.pendingWakeNameFollowup = undefined;
+    this.lastAudioTurn = undefined;
+    this.resetProviderContinuity();
+  }
+
+  /**
+   * Pins the in-flight provider speech segment to the speaker whose audio is streaming.
+   * The VAD start event arrives in band with the audio stream, before any newer capture
+   * can begin, so it is the only reliable point to observe who is speaking.
+   */
+  markProviderSpeechSegmentStarted(): void {
+    this.pendingSegmentSpeaker = this.lastAudioTurn;
+  }
+
+  /** Binds an admitted provider input item to the speaker pinned for its speech segment. */
+  bindSpeakerInputItem(itemId: string): void {
+    const speaker = this.pendingSegmentSpeaker ?? this.lastAudioTurn;
+    this.pendingSegmentSpeaker = undefined;
+    if (!speaker) {
+      return;
+    }
+    this.inputItemSpeakers.delete(itemId);
+    this.inputItemSpeakers.set(itemId, speaker);
+    while (this.inputItemSpeakers.size > DISCORD_REALTIME_INPUT_ITEM_SPEAKER_LIMIT) {
+      const oldest = this.inputItemSpeakers.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.inputItemSpeakers.delete(oldest);
+    }
   }
 
   consumePendingSpeakerContext(): DiscordRealtimeSpeakerContext | undefined {
@@ -211,6 +281,18 @@ export class DiscordRealtimeTurns {
 
   hasPendingSpeakerAudioContext(): boolean {
     return this.speakerTurns.hasAudioContext();
+  }
+
+  private takeBoundSpeakerTurn(itemId: string | undefined): PendingSpeakerTurn | undefined {
+    if (!itemId) {
+      return undefined;
+    }
+    const turn = this.inputItemSpeakers.get(itemId);
+    if (!turn) {
+      return undefined;
+    }
+    this.inputItemSpeakers.delete(itemId);
+    return turn;
   }
 
   private sendInputAudioForTurn(turn: PendingSpeakerTurn, discordPcm48kStereo: Buffer): void {
@@ -251,6 +333,7 @@ export class DiscordRealtimeTurns {
       return;
     }
     this.speakerTurns.markAudio(turn);
+    this.lastAudioTurn = turn;
     logger.info(
       `discord voice: realtime speaker turn opened guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${turn.context.userId} speaker=${turn.context.speakerLabel} owner=${turn.context.senderIsOwner} pendingTurns=${this.speakerTurns.size()}`,
     );
@@ -370,9 +453,9 @@ export class DiscordRealtimeTurns {
       });
   }
 
-  private armWakeNameFollowup(): void {
-    const turn = this.peekPendingSpeakerTurn();
-    const context = this.consumePendingSpeakerContext();
+  private armWakeNameFollowup(boundTurn?: PendingSpeakerTurn): void {
+    const turn = boundTurn ?? this.peekPendingSpeakerTurn();
+    const context = boundTurn?.context ?? this.consumePendingSpeakerContext();
     if (!context) {
       logger.warn(
         `discord voice: realtime wake-name follow-up has no speaker context voiceSession=${this.params.entry.voiceSessionKey} agent=${this.params.entry.route.agentId}`,

--- a/extensions/openai/realtime-voice-bridge-events.test.ts
+++ b/extensions/openai/realtime-voice-bridge-events.test.ts
@@ -276,6 +276,36 @@ describe("OpenAI realtime voice bridge events", () => {
     });
   });
 
+  it("forwards admitted input items and their identity on final user transcripts", async () => {
+    const onTranscript = vi.fn();
+    const onEvent = vi.fn();
+    const bridge = createNativeBridge({ onTranscript, onEvent });
+    const socket = await connectReadyBridge(bridge);
+
+    emitServerEvent(socket, {
+      type: "conversation.item.added",
+      item_id: "item_guest_speech",
+      item: { id: "item_guest_speech", type: "message", role: "user" },
+    });
+    emitServerEvent(socket, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "item_guest_speech",
+      transcript: "delayed guest question",
+    });
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        direction: "server",
+        type: "conversation.item.added",
+        itemId: "item_guest_speech",
+        itemRole: "user",
+      }),
+    );
+    expect(onTranscript).toHaveBeenCalledWith("user", "delayed guest question", true, {
+      itemId: "item_guest_speech",
+    });
+  });
+
   it("preserves corrected final text from legacy realtime text events", async () => {
     const onTranscript = vi.fn();
     const bridge = createNativeBridge({ onTranscript });

--- a/extensions/openai/realtime-voice-events.ts
+++ b/extensions/openai/realtime-voice-events.ts
@@ -32,6 +32,7 @@ export abstract class OpenAIRealtimeEvents extends OpenAIRealtimeProtocol {
         type: event.type,
         detail: this.describeServerEvent(event),
         ...(event.item_id ? { itemId: event.item_id } : {}),
+        ...(event.item?.role ? { itemRole: event.item.role } : {}),
         ...((event.response_id ?? event.response?.id)
           ? { responseId: event.response_id ?? event.response?.id }
           : {}),
@@ -131,7 +132,9 @@ export abstract class OpenAIRealtimeEvents extends OpenAIRealtimeProtocol {
 
       case "conversation.item.input_audio_transcription.completed":
         if (event.transcript) {
-          this.config.onTranscript?.("user", event.transcript, true);
+          this.config.onTranscript?.("user", event.transcript, true, {
+            itemId: event.item_id,
+          });
         }
         return;
 

--- a/extensions/openai/realtime-voice-session-policy.ts
+++ b/extensions/openai/realtime-voice-session-policy.ts
@@ -159,6 +159,7 @@ export type RealtimeEvent = {
   item?: {
     id?: string;
     type?: string;
+    role?: string;
     name?: string;
     call_id?: string;
     arguments?: string;

--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -26,6 +26,7 @@ export type {
   RealtimeVoiceTool,
   RealtimeVoiceToolCallEvent,
   RealtimeVoiceToolResultOptions,
+  RealtimeVoiceTranscriptSource,
 } from "../talk/provider-types.js";
 export {
   normalizeRealtimeVoiceResponseOutcome,

--- a/src/talk/provider-types.ts
+++ b/src/talk/provider-types.ts
@@ -91,7 +91,17 @@ export type RealtimeVoiceBridgeEvent = {
   type: string;
   detail?: string;
   itemId?: string;
+  itemRole?: string;
   responseId?: string;
+};
+
+/**
+ * Provider-side identity for the input that produced a transcript callback. Presence
+ * signals that the provider can correlate transcripts with admitted input items, so
+ * consumers must not fall back to timing-based speaker attribution for these callbacks.
+ */
+export type RealtimeVoiceTranscriptSource = {
+  itemId?: string;
 };
 
 export type RealtimeVoiceResponseError = {
@@ -175,7 +185,12 @@ export type RealtimeVoiceBridgeCallbacks = {
   onAudio: (audio: Buffer) => void;
   onClearAudio: (reason?: RealtimeVoiceAudioClearReason) => void;
   onMark?: (markName: string) => void;
-  onTranscript?: (role: RealtimeVoiceRole, text: string, isFinal: boolean) => void;
+  onTranscript?: (
+    role: RealtimeVoiceRole,
+    text: string,
+    isFinal: boolean,
+    source?: RealtimeVoiceTranscriptSource,
+  ) => void;
   onEvent?: (event: RealtimeVoiceBridgeEvent) => void;
   onResponseDone?: (outcome: RealtimeVoiceResponseOutcome) => void;
   onToolCall?: (event: RealtimeVoiceToolCallEvent) => void;

--- a/src/talk/realtime-session-harness.ts
+++ b/src/talk/realtime-session-harness.ts
@@ -311,11 +311,11 @@ export function createRealtimeVoiceSessionHarness<TForcedConsultContext = unknow
     createBridge(bridgeParams) {
       bridge = createRealtimeVoiceBridgeSession({
         ...bridgeParams,
-        onTranscript: (role, text, isFinal) => {
+        onTranscript: (role, text, isFinal, source) => {
           if (isFinal) {
             harness.recordTranscript(role, text);
           }
-          bridgeParams.onTranscript?.(role, text, isFinal);
+          bridgeParams.onTranscript?.(role, text, isFinal, source);
         },
         onEvent: (event) => {
           claimResponseEvent(event);

--- a/src/talk/session-runtime.ts
+++ b/src/talk/session-runtime.ts
@@ -15,6 +15,7 @@ import type {
   RealtimeVoiceTool,
   RealtimeVoiceToolCallEvent,
   RealtimeVoiceToolResultOptions,
+  RealtimeVoiceTranscriptSource,
 } from "./provider-types.js";
 
 /**
@@ -71,7 +72,12 @@ export type RealtimeVoiceBridgeSessionParams = {
   markStrategy?: RealtimeVoiceMarkStrategy;
   triggerGreetingOnReady?: boolean;
   tools?: RealtimeVoiceTool[];
-  onTranscript?: (role: RealtimeVoiceRole, text: string, isFinal: boolean) => void;
+  onTranscript?: (
+    role: RealtimeVoiceRole,
+    text: string,
+    isFinal: boolean,
+    source?: RealtimeVoiceTranscriptSource,
+  ) => void;
   onEvent?: (event: RealtimeVoiceBridgeEvent) => void;
   onResponseDone?: (outcome: RealtimeVoiceResponseOutcome) => void;
   onToolCall?: (

--- a/src/talk/turn-context-tracker.test.ts
+++ b/src/talk/turn-context-tracker.test.ts
@@ -68,6 +68,30 @@ describe("realtime voice turn context tracker", () => {
     expect(tracker.consumeAudioContext()).toBeUndefined();
   });
 
+  it("removes only the targeted turn so resolved bindings stay single-consumption", () => {
+    const tracker = createRealtimeVoiceTurnContextTracker<{ id: string }>();
+    const first = tracker.open({ id: "first" });
+    tracker.markAudio(first);
+    const second = tracker.open({ id: "second" });
+    tracker.markAudio(second);
+
+    tracker.remove(first);
+
+    expect(tracker.consumeAudioContext()).toEqual({ id: "second" });
+    expect(tracker.consumeAudioContext()).toBeUndefined();
+  });
+
+  it("ignores remove for foreign handles", () => {
+    const first = createRealtimeVoiceTurnContextTracker<{ id: string }>();
+    const second = createRealtimeVoiceTurnContextTracker<{ id: string }>();
+    const turn = first.open({ id: "speaker" });
+    first.markAudio(turn);
+
+    second.remove(turn);
+
+    expect(first.consumeAudioContext()).toEqual({ id: "speaker" });
+  });
+
   it("retains caller-owned turn stats on peeked audio turns", () => {
     const tracker = createRealtimeVoiceTurnContextTracker<
       { id: string },

--- a/src/talk/turn-context-tracker.ts
+++ b/src/talk/turn-context-tracker.ts
@@ -46,6 +46,8 @@ export type RealtimeVoiceTurnContextTracker<
   ): RealtimeVoiceTurnContextHandle<TContext, TExtra>;
   markAudio(handle: RealtimeVoiceTurnContextHandle<TContext, TExtra>): void;
   close(handle: RealtimeVoiceTurnContextHandle<TContext, TExtra>): void;
+  /** Removes a specific turn when its consumer resolved it outside the FIFO read path. */
+  remove(handle: RealtimeVoiceTurnContextHandle<TContext, TExtra>): void;
   consumeAudioContext(): TContext | undefined;
   peekAudioTurn(): RealtimeVoiceTurnContextHandle<TContext, TExtra> | undefined;
   hasAudioContext(): boolean;
@@ -167,6 +169,15 @@ export function createRealtimeVoiceTurnContextTracker<
         return;
       }
       prune();
+    },
+    remove(handle) {
+      if (!owns(handle)) {
+        return;
+      }
+      const index = turns.indexOf(handle);
+      if (index >= 0) {
+        turns.splice(index, 1);
+      }
     },
     consumeAudioContext() {
       prepareForAudioContextRead();


### PR DESCRIPTION
Closes #137349

## What Problem This Solves

Fixes an issue where Discord realtime voice attributes a delayed final transcript to the wrong participant: when a speaker's capture closes and another speaker supplies newer audio before the first speaker's final transcript is delivered, the first speaker's transcript reaches voice-agent ingress with the second speaker's user id and owner status. Because that owner status controls the agent turn's tool-authority context, a non-owner's request can arrive carrying another participant's authority.

## Why This Change Was Made

The transcript callback carried no identity, so attribution relied on whichever speaker context was newest — and the pending-context tracker deliberately retires a closed capture once later audio exists. Callback timing, question text, and model-supplied speaker claims cannot establish identity, so this change binds provider input to an immutable Discord speaker instead:

- the in-band VAD speech start pins the current speaker turn to the in-flight speech segment,
- the admitted provider input item inherits that binding by item id,
- the OpenAI realtime bridge forwards the item identity on final user transcripts through a new optional `source` parameter on the shared transcript callback,
- the Discord runtime resolves the delayed transcript's speaker from the item binding, and drops an uncorrelated transcript instead of borrowing the newest pending context.

Providers without input-item identity (Gemini, Grok realtime) keep the previous pending-context behavior unchanged. The shared agent conversation and single room playback owner are untouched, and the tracker's existing stale-context pruning for fresh-audio consumers (native consults, wake-name follow-ups) still applies.

## User Impact

Discord voice keeps each request on the identity and owner status of the speaker who actually supplied its audio, even when transcription is delayed behind a newer speaker. A delayed transcript can no longer acquire another participant's owner-only tool context, and an uncorrelated transcript no longer runs an agent turn at all.

## Evidence

Red on pinned main with the reported two-speaker ordering (manager-boundary regression, real `DiscordVoiceManager` runtime):

```
× keeps a delayed final transcript on the speaker whose audio produced it
  → expected undefined to be 'u-guest'  (senderIsOwner received: true)
× does not run an uncorrelated delayed transcript with a newer speaker's authority
  → agent command was called with the newer speaker's owner context
Test Files  1 failed (1)   Tests  2 failed | 46 skipped (48)
```

Green after the fix, same suite plus a runtime proof driving the real OpenAI realtime provider bridge (real event handling and transport send flow, synthetic audio and synthetic agent execution, only the final callback delayed — the reporter's own proof shape):

```
✓ keeps a delayed final transcript on the speaker whose audio produced it
✓ does not run an uncorrelated delayed transcript with a newer speaker's authority
✓ attributes the delayed guest transcript to the guest speaker end-to-end
    → onAcceptedTranscript: { text: "delayed guest question",
        context: { userId: "u-guest", senderIsOwner: false, speakerLabel: "Guest" } }
✓ does not run an uncorrelated provider transcript with any speaker's authority
Test Files  2 passed (2)   Tests  4 passed (4)
```

Affected suites: Discord voice directory 30 files / 370 tests passed; OpenAI provider project 960 passed (3 pre-existing `embedding-batch.test.ts` failures also fail on clean main — network-dependent, unrelated); talk tracker/harness/session-runtime 46 passed; gateway realtime relay tests 8 passed; `tsgo` core/extensions/test typechecks, oxlint, and oxfmt clean.

## Review Follow-up (second commit `edec051f732`)

The first review flagged two authority-boundary gaps in the initial binding; both were reproduced red on the first commit and are fixed:

1. **VAD start attribution used a capture-order snapshot.** A speech start could bind to a newer speaker's turn when concurrent captures interleaved (guest speaking continuously, owner's first chunk decoded in between, guest's VAD event delivered after). The binding now tracks the turn that most recently sent audio bytes to the shared provider stream, so an in-band speech start pins the speaker whose audio the provider is actually receiving:
   ```
   × keeps an interleaved provider speech segment on the speaker whose audio is streaming
     → expected true to be false            (red on 9bd95e73a715)
   ✓ ...                                   (green on edec051f732, senderIsOwner: false)
   ```
2. **A bound transcript could satisfy another participant's wake-name follow-up.** The follow-up shortcut now requires the same speaker (`userId` equality); another participant's pending follow-up is neither consumed nor authorized by a different speaker's transcript, and stays armed for its own speaker within its TTL:
   ```
   × does not satisfy another speaker's wake-name follow-up with a bound transcript
     → agent command was called 1 times    (red on 9bd95e73a715)
   ✓ ...                                   (green on edec051f732, no agent command)
   ```

The end-to-end runtime proof (real OpenAI realtime provider bridge with real event handling and transport send flow, synthetic audio and synthetic agent execution, only the final callback delayed — the reporter's own proof shape) was rerun against the second commit and extended with the interleaved ordering, covering the allowed guest path, the nearest forbidden guest→owner ordering, and rejection before any agent I/O:

```
✓ attributes the delayed guest transcript to the guest speaker end-to-end
    → onAcceptedTranscript: { text: "delayed guest question",
        context: { userId: "u-guest", senderIsOwner: false, speakerLabel: "Guest" } }
✓ does not run an uncorrelated provider transcript with any speaker's authority
    → no onAcceptedTranscript, no agent I/O
✓ keeps an interleaved guest speech segment on the guest after owner audio interleaves
    → context: { userId: "u-guest", senderIsOwner: false }
Test Files  1 passed (1)   Tests  3 passed (3)
```

Full Discord voice directory after the follow-up: 30 files / 370 tests passed; extension and test typechecks, lint, and format clean.

## Risks

The transcript `source` parameter and bridge-event `itemRole` are additive and optional; existing 3-arg providers and consumers compile and behave unchanged. For identity-capable providers, an input item admitted without an observed speech start still falls back to the last active speaker, and a transcript with no resolvable binding is dropped with a warning rather than misattributed. Multi-segment captures are covered because each segment pins its own speaker at VAD start.
