### PR TITLE
fix: agent turns fail with reading 'trim' after an attachment enters session history

### DIFF
--- a/packages/ai/src/transcript-transform.test.ts
+++ b/packages/ai/src/transcript-transform.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { transformMessages } from "./transcript-transform.js";
+import type { AssistantMessage, Model } from "./types.js";
+
+const model: Model<"openai-responses"> = {
+  id: "test-model",
+  name: "Test model",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://proxy.example/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 4_096,
+};
+
+const otherModel: Model<"openai-responses"> = { ...model, id: "other-model" };
+
+const emptyUsage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+// Persisted session history can carry assistant blocks outside the declared
+// content union: the gateway's managed-media path appends `attachment` /
+// `attachment_error` display blocks to the assistant message it stores.
+const attachmentBlock = {
+  type: "attachment",
+  attachment: {
+    artifactId: "artifact_managed_media_00000000-0000-4000-8000-000000000001",
+    url: "/api/chat/media/outgoing/session/00000000-0000-4000-8000-000000000001/full",
+    kind: "document",
+    label: "report.pdf",
+  },
+} as unknown as AssistantMessage["content"][number];
+
+function assistantWith(content: AssistantMessage["content"], modelId = model.id): AssistantMessage {
+  return {
+    role: "assistant",
+    api: model.api,
+    provider: model.provider,
+    model: modelId,
+    content,
+    usage: emptyUsage,
+    stopReason: "stop",
+    timestamp: 2,
+  };
+}
+
+describe("transformMessages assistant content outside the declared union", () => {
+  it("passes an attachment block through instead of throwing on block.id.trim()", () => {
+    const assistant = assistantWith([{ type: "text", text: "Here is the file." }, attachmentBlock]);
+    const messages = [{ role: "user" as const, content: "hello", timestamp: 1 }, assistant];
+
+    const result = transformMessages(messages, model);
+
+    expect(result).toHaveLength(2);
+    const transformed = result[1] as AssistantMessage;
+    expect(transformed.content).toEqual([
+      { type: "text", text: "Here is the file." },
+      attachmentBlock,
+    ]);
+  });
+
+  it("keeps passing the block through when replaying for a different model", () => {
+    const assistant = assistantWith([{ type: "text", text: "Here is the file." }, attachmentBlock]);
+    const messages = [{ role: "user" as const, content: "hello", timestamp: 1 }, assistant];
+
+    const result = transformMessages(messages, otherModel, (id) => `norm-${id}`);
+
+    const transformed = result[1] as AssistantMessage;
+    expect(transformed.content).toContainEqual(attachmentBlock);
+  });
+
+  it("still trims and pairs real tool call ids around the foreign block", () => {
+    const assistant = assistantWith([
+      attachmentBlock,
+      { type: "toolCall", id: " call_1 ", name: "read", arguments: {} },
+    ]);
+    const messages = [
+      { role: "user" as const, content: "hello", timestamp: 1 },
+      assistant,
+      {
+        role: "toolResult" as const,
+        toolCallId: " call_1 ",
+        toolName: "read",
+        content: [{ type: "text" as const, text: "ok" }],
+        isError: false,
+        timestamp: 3,
+      },
+    ];
+
+    const result = transformMessages(messages, model);
+
+    const transformed = result[1] as AssistantMessage;
+    expect(transformed.content).toContainEqual({
+      type: "toolCall",
+      id: "call_1",
+      name: "read",
+      arguments: {},
+    });
+    expect(result[2]).toMatchObject({ role: "toolResult", toolCallId: "call_1" });
+  });
+});

--- a/packages/ai/src/transcript-transform.ts
+++ b/packages/ai/src/transcript-transform.ts
@@ -102,6 +102,13 @@ function transformAssistant<TApi extends Api>(
     if (block.type === "text") {
       return sameModel ? block : { type: "text" as const, text: block.text };
     }
+    if (block.type !== "toolCall" || typeof block.id !== "string") {
+      // Persisted assistant content can carry blocks outside the declared union
+      // (managed-media `attachment` / `attachment_error` display blocks written
+      // by the gateway). They are not tool calls: pass them through untouched
+      // instead of crashing the whole history transform on `block.id.trim()`.
+      return block;
+    }
     const { thoughtSignature: _, ...unsigned } = block;
     // Pairing uses these IDs as shared keys, before model-specific normalization runs.
     const trimmedId = block.id.trim();


### PR DESCRIPTION
Related: #135747, #135061, #134226
Related: #135185 (fixes the producer side on main; this PR hardens the consumer side)

## What Problem This Solves

Fixes an issue where every agent turn in a session fails with
`TypeError: Cannot read properties of undefined (reading 'trim')` once an
assistant message carrying a managed-media `attachment` block (a file the agent
sent to the user) has been persisted into that session's history. From that
point the session is unusable: request assembly throws before any model call,
on every subsequent turn, regardless of model (reported by Control UI users in
#135747 / #135061; reproduced on v2026.8.1 and v2026.8.2).

## Why This Change Was Made

`transformAssistant` in `packages/ai/src/transcript-transform.ts` handles
`thinking` and `text` blocks explicitly and treats **every other** block as a
`ToolCall`, calling `block.id.trim()` unconditionally. `AssistantMessage.content`
is declared as `(TextContent | ThinkingContent | ToolCall)[]`, but the persisted
history is wider than the type: the gateway's managed-media path
(`src/gateway/managed-image-attachments.ts`, `attachManagedOutgoingMediaToMessage`)
appends `{ type: "attachment", attachment: {…} }` / `attachment_error` blocks to the
assistant message it stores, on both the legacy `MEDIA:` line path and the
structured message-tool path.

Before the transcript transform moved into `@openclaw/ai` (2026.7.x), the replay
safety pass in `src/agents/tool-call-id.ts` already guarded this exact case
(`typeof typedBlock.id === "string" ? typedBlock.id.trim() : ""`); the guard was
lost in the refactor, which is why v2026.7.1 tolerated the same persisted blocks
and 2026.8.x does not.

#135185 keeps display blocks out of the durable model history going forward, on
main. This change is complementary: the transform must not take the whole
history down when it meets a block it does not model — existing sessions
already carry such blocks, and any other producer of out-of-union content would
reintroduce the crash. Blocks that are not tool calls are passed through
untouched; tool-call trimming, cross-model id normalization and tool-result
pairing are unchanged.

## User Impact

Sessions that received a file attachment from the agent keep working across
turns instead of failing permanently. No behaviour change for histories that
only contain text, thinking and tool calls.

## Evidence

- Reproduced on `v2026.8.2` (`0965053`): after the agent delivers a file in the
  webchat, the next turn fails in `transformAssistant` (`host-*.mjs:326`), and
  so does every later turn of that session; the gateway log shows
  `Cannot read properties of undefined (reading 'trim') at transformAssistant`.
  The persisted block, read back from `transcript_events`:
  `{"role":"assistant","content":[{"type":"text","text":"…"},{"type":"attachment","attachment":{"artifactId":"artifact_managed_media_…","url":"/api/chat/media/outgoing/…/full","kind":"document",…}}]}`.
- With the guard applied to the same build, the same trigger yields 0 errors
  across four full runs of the same session-level scenario suite (~40 turns
  each), with tool-call pairing and cross-model replay unchanged.
- `packages/ai/src/transcript-transform.test.ts` (new): fails on the current
  file with the `trim` TypeError, passes with this change; also covers the
  cross-model replay path and tool-call trimming/pairing around the foreign block.
