### PR TITLE
fix(systemd): preserve services after backslash comments

### DIFF
--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -92,10 +92,21 @@ describe("detectMarkerLineWithGateway", () => {
     expect(detectMarkerLineWithGateway(CLAWDBOT_GATEWAY_CONTENTS)).toBe("clawdbot");
   });
 
-  it("handles line continuations — marker and gateway split across physical lines", () => {
-    const contents = `[Service]\nExecStart=/usr/bin/node /opt/openclaw/dist/entry.js \\\n  gateway --port 18789\n`;
-    expect(detectMarkerLineWithGateway(contents)).toBe("openclaw");
+  it.each([
+    "ExecStart=/usr/bin/openclaw \\\n  gateway",
+    "# comment \\\nExecStart=/usr/bin/openclaw gateway",
+    "; comment \\\nExecStart=/usr/bin/openclaw gateway",
+    "ExecStart=/usr/bin/openclaw \\\n# comment\n  gateway",
+  ])("detects commands through native comments and continuations: %s", (command) => {
+    expect(detectMarkerLineWithGateway(`[Service]\n${command}\n`)).toBe("openclaw");
   });
+
+  it.each(["After", "Requires", "Description", "Environment"])(
+    "ignores gateway mentions in %s instead of an executable directive",
+    (key) => {
+      expect(detectMarkerLineWithGateway(`${key}=openclaw gateway\n`)).toBeNull();
+    },
+  );
 
   it("ignores dependency-only references to the gateway unit", () => {
     expect(detectMarkerLineWithGateway(COMPANION_SERVICE_CONTENTS)).toBeNull();
@@ -341,14 +352,17 @@ describe("findExtraGatewayServices (linux / scanSystemdDir) — real filesystem"
     },
   );
 
-  it.skipIf(!isLinux)(
-    "reports custom-named gateway units that execute openclaw gateway",
-    async () => {
+  it.skipIf(!isLinux).each(["", "# comment \\\n", "; comment \\\n"])(
+    "reports custom-named gateway units after a physical comment: %j",
+    async (comment) => {
       const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
       const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
       const unitPath = path.join(systemdDir, "custom-openclaw.service");
       await fs.mkdir(systemdDir, { recursive: true });
-      await fs.writeFile(unitPath, CUSTOM_OPENCLAW_GATEWAY_CONTENTS);
+      await fs.writeFile(
+        unitPath,
+        CUSTOM_OPENCLAW_GATEWAY_CONTENTS.replace("ExecStart=", `${comment}ExecStart=`),
+      );
       const result = await findExtraGatewayServices({ HOME: tmpHome });
       expect(result).toEqual([
         {

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -15,7 +15,7 @@ import { parseLaunchdPlistLabel } from "./launchd-plist.js";
 import { readLaunchDaemonPlistLabel } from "./launchd-system.js";
 import { resolveDaemonHomeDir } from "./paths.js";
 import { execSchtasks } from "./schtasks-exec.js";
-import { parseSystemdExecStart } from "./systemd-unit.js";
+import { parseSystemdExecStart, splitSystemdLogicalLines } from "./systemd-unit.js";
 
 export type ExtraGatewayService = {
   platform: "darwin" | "linux" | "win32";
@@ -31,19 +31,6 @@ export type FindExtraGatewayServicesOptions = {
 };
 
 const EXTRA_MARKERS = ["openclaw", "clawdbot"] as const;
-const SYSTEMD_REFERENCE_ONLY_KEYS = new Set([
-  "after",
-  "before",
-  "bindsto",
-  "conflicts",
-  "partof",
-  "propagatesreloadto",
-  "reloadpropagatedfrom",
-  "requisite",
-  "requires",
-  "upholds",
-  "wants",
-]);
 
 function quotePosixCleanupArgument(value: string): string {
   return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
@@ -113,27 +100,20 @@ function hasGatewaySubcommandArg(args: string[]): boolean {
 }
 
 export function detectMarkerLineWithGateway(contents: string): Marker | null {
-  // Join line continuations before scanning systemd ExecStart commands; marker
-  // detection must ignore relationship-only unit keys.
-  const lower = normalizeLowercaseStringOrEmpty(contents.replace(/\\\r?\n\s*/g, " "));
-  for (const line of lower.split(/\r?\n/)) {
-    const trimmed = line.trim();
+  // Use the same physical-comment rules as service rewrites; comments must not
+  // hide a runnable extra service from diagnostics.
+  for (const line of splitSystemdLogicalLines(contents)) {
+    const trimmed = normalizeLowercaseStringOrEmpty(line);
     if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith(";")) {
       continue;
     }
     const assignment = trimmed.indexOf("=");
     if (assignment > 0) {
       const key = trimmed.slice(0, assignment).trim();
-      if (SYSTEMD_REFERENCE_ONLY_KEYS.has(key)) {
-        continue;
-      }
       if (
-        key === "execstart" &&
+        key !== "execstart" ||
         !hasGatewaySubcommandArg(parseSystemdExecStart(trimmed.slice(assignment + 1).trim()))
       ) {
-        continue;
-      }
-      if (key !== "execstart") {
         continue;
       }
     }

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -12,6 +12,8 @@ import {
 import { buildServiceEnvironment } from "./service-env.js";
 import type { GatewayServiceEnvironmentValueSource } from "./service-types.js";
 
+const SYSTEMD_CONTINUATIONS = ["", "\\\n  # continued setting \\\n  ; ignored comment\n  "];
+
 const execSystemctlUser = vi.hoisted(() =>
   vi.fn<
     (
@@ -701,50 +703,57 @@ describe("auditGatewayServiceConfig", () => {
     `warns when KillMode is %s in explicit unit file`,
     async (killMode) => {
       const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-killmode-"));
-      await writeSystemdUnitForAudit(home, [
-        "After=network-online.target",
-        "Wants=network-online.target",
-        "RestartSec=5",
-        `KillMode=${killMode}`,
-      ]);
+      try {
+        for (const continuation of SYSTEMD_CONTINUATIONS) {
+          await writeSystemdUnitForAudit(home, [
+            "After=network-online.target",
+            "Wants=network-online.target",
+            "RestartSec=5",
+            `KillMode=${continuation}${killMode}`,
+          ]);
 
-      const audit = await auditGatewayServiceConfig({
-        env: { HOME: home },
-        platform: "linux",
-        command: {
-          programArguments: ["/usr/bin/node", "gateway"],
-          environment: { PATH: "/usr/bin:/bin" },
-        },
-      });
-      expect(
-        audit.issues.some(
-          (entry) => entry.code === SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone,
-        ),
-      ).toBe(true);
-      expect(execSystemctlUser).toHaveBeenCalledWith({ HOME: home }, expect.any(Array), 10_000);
+          const audit = await auditGatewayServiceConfig({
+            env: { HOME: home },
+            platform: "linux",
+            command: {
+              programArguments: ["/usr/bin/node", "gateway"],
+              environment: { PATH: "/usr/bin:/bin" },
+            },
+          });
+          expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone)).toBe(true);
+          expect(execSystemctlUser).toHaveBeenCalledWith({ HOME: home }, expect.any(Array), 10_000);
+        }
+      } finally {
+        await fs.rm(home, { recursive: true, force: true });
+      }
     },
   );
 
-  it("does not warn when KillMode is control-group", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-killmode-"));
-    await writeSystemdUnitForAudit(home, [
-      "After=network-online.target",
-      "Wants=network-online.target",
-      "RestartSec=5",
-      "KillMode=control-group",
-    ]);
-    const audit = await auditGatewayServiceConfig({
-      env: { HOME: home },
-      platform: "linux",
-      command: {
-        programArguments: ["/usr/bin/node", "gateway"],
-        environment: { PATH: "/usr/bin:/bin" },
-      },
-    });
-    expect(
-      audit.issues.some((entry) => entry.code === SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone),
-    ).toBe(false);
-  });
+  it.each(SYSTEMD_CONTINUATIONS)(
+    "accepts resilient unit settings with continuation %j when the manager is unavailable",
+    async (continuation) => {
+      const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-settings-"));
+      try {
+        await writeSystemdUnitForAudit(home, [
+          `After=basic.target ${continuation}network-online.target`,
+          `Wants=basic.target ${continuation}network-online.target`,
+          `RestartSec=${continuation}5s`,
+          `KillMode=${continuation}control-group`,
+        ]);
+        const audit = await auditGatewayServiceConfig({
+          env: { HOME: home },
+          platform: "linux",
+          command: {
+            programArguments: ["/usr/bin/node", "gateway"],
+            environment: { PATH: "/usr/bin:/bin" },
+          },
+        });
+        expect(audit.issues.filter((issue) => issue.code.startsWith("systemd-"))).toEqual([]);
+      } finally {
+        await fs.rm(home, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.each([
     {
@@ -827,25 +836,6 @@ describe("auditGatewayServiceConfig", () => {
     } finally {
       await fs.rm(home, { recursive: true, force: true });
     }
-  });
-
-  it("accepts systemd RestartSec values with seconds suffixes", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-restartsec-"));
-    await writeSystemdUnitForAudit(home, [
-      "After=network-online.target",
-      "Wants=network-online.target",
-      "RestartSec=5s",
-      "KillMode=control-group",
-    ]);
-    const audit = await auditGatewayServiceConfig({
-      env: { HOME: home },
-      platform: "linux",
-      command: {
-        programArguments: ["/usr/bin/node", "gateway"],
-        environment: { PATH: "/usr/bin:/bin" },
-      },
-    });
-    expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdRestartSec)).toBe(false);
   });
 
   it("flags embedded service token even when it matches config token", async () => {

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -121,7 +121,7 @@ function parseSystemdUnit(content: string): {
 
   // Parse only unit keys relevant to service resilience; this is not a full
   // systemd parser and intentionally ignores sections.
-  for (const rawLine of content.split(/\r?\n/)) {
+  for (const rawLine of splitSystemdLogicalLines(content)) {
     const line = rawLine.trim();
     if (!line) {
       continue;

--- a/src/daemon/systemd-install.ts
+++ b/src/daemon/systemd-install.ts
@@ -170,7 +170,7 @@ function removeLegacyGatewayVersionMetadata(content: string): string {
   }
   const inlineEnvironment = new Map<string, string>();
   let inServiceSection = false;
-  for (const rawLine of content.split("\n")) {
+  for (const rawLine of splitSystemdLogicalLines(content)) {
     const line = rawLine.trim();
     if (/^\[[^\]]+\]$/u.test(line)) {
       inServiceSection = line === "[Service]";

--- a/src/daemon/systemd-service-files.ts
+++ b/src/daemon/systemd-service-files.ts
@@ -252,7 +252,7 @@ async function readSystemdDropInOverrides(
     const content = await fs.readFile(pathname, "utf8");
     let inService = false;
     // Loaded drop-ins own directives even when their current values equal the managed base.
-    for (const rawLine of content.replace(/\\\r?\n\s*/g, " ").split(/\r?\n/)) {
+    for (const rawLine of splitSystemdLogicalLines(content)) {
       const line = rawLine.trim();
       if (!line || line.startsWith("#") || line.startsWith(";")) {
         continue;

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -5,6 +5,7 @@ import {
   parseSystemdEnvAssignments,
   parseSystemdExecStart,
   renderSystemdEnvAssignment,
+  splitSystemdLogicalLines,
 } from "./systemd-unit.js";
 
 // Values that need quoting, including the backslash and quote shapes the
@@ -18,6 +19,40 @@ const ROUND_TRIP_VALUES = [
   'mix \\ and " here',
   "trailing\\",
 ];
+
+describe("systemd logical lines", () => {
+  it.each([
+    {
+      name: "standalone comment backslashes",
+      input: ["# note \\", "; note \\", "ExecStart=/usr/bin/openclaw gateway run"],
+      expected: ["# note \\", "; note \\", "ExecStart=/usr/bin/openclaw gateway run"],
+    },
+    {
+      name: "comments inside a continued quoted value",
+      input: ['Environment="SETTING=one\\', " # note \\", " ; note", '  two"'],
+      expected: ['Environment="SETTING=one   two"'],
+    },
+    {
+      name: "escaped trailing backslash pairs",
+      input: ["Environment=SETTING=one\\\\", "ExecStart=/usr/bin/openclaw gateway run"],
+      expected: ["Environment=SETTING=one\\\\", "ExecStart=/usr/bin/openclaw gateway run"],
+    },
+    {
+      name: "blank line ending a continuation",
+      input: ["Environment=SETTING=one\\", "", "ExecStart=/usr/bin/openclaw gateway run"],
+      expected: ["Environment=SETTING=one ", "ExecStart=/usr/bin/openclaw gateway run"],
+    },
+    {
+      name: "continued value at EOF",
+      input: ["Environment=SETTING=one\\", " # note"],
+      expected: ["Environment=SETTING=one "],
+    },
+  ])("preserves $name for LF and CRLF", ({ input, expected }) => {
+    for (const separator of ["\n", "\r\n"]) {
+      expect(splitSystemdLogicalLines(input.join(separator))).toEqual(expected);
+    }
+  });
+});
 
 describe("systemd unit value round-trips", () => {
   it.each(ROUND_TRIP_VALUES)("round-trips %p through Environment=", (value) => {

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -111,41 +111,43 @@ export function parseSystemdExecStart(value: string): string[] {
   return splitArgsPreservingQuotes(value, { escapeMode: "backslash" });
 }
 
-function parseSystemdEnvAssignment(raw: string): { key: string; value: string } | null {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  // The shared splitter already removes quotes and consumes escapes before an
-  // assignment reaches this helper.
-  const eq = trimmed.indexOf("=");
-  if (eq <= 0) {
-    return null;
-  }
-  const key = trimmed.slice(0, eq).trim();
-  if (!key) {
-    return null;
-  }
-  const value = trimmed.slice(eq + 1);
-  return { key, value };
-}
-
 export function parseSystemdEnvAssignments(raw: string): Array<{ key: string; value: string }> {
   return splitArgsPreservingQuotes(raw, {
     escapeMode: "backslash",
     quoteChars: ['"', "'"],
     quoteStart: "item-start",
   }).flatMap((entry) => {
-    const parsed = parseSystemdEnvAssignment(entry);
-    return parsed ? [parsed] : [];
+    // The splitter has already removed quotes and consumed escapes.
+    const assignment = entry.trim();
+    const separator = assignment.indexOf("=");
+    return separator <= 0
+      ? []
+      : [{ key: assignment.slice(0, separator).trim(), value: assignment.slice(separator + 1) }];
   });
 }
 
 export function splitSystemdLogicalLines(content: string): string[] {
-  // A trailing backslash joins the next physical line. Comments inside that
-  // continuation are skipped by systemd and must not hide later assignments.
-  return content.replace(/\\\r?\n(?:\s*[#;][^\r\n]*\r?\n)*\s*/g, " ").split(/\r?\n/);
+  const lines: string[] = [];
+  let continued = "";
+  for (const physicalLine of content.split(/\r?\n/)) {
+    // systemd skips physical comments before continuation handling. Keep standalone
+    // comments for unit rewrites, but never let their backslashes consume directives.
+    if (/^\s*[#;]/u.test(physicalLine)) {
+      if (!continued) {
+        lines.push(physicalLine);
+      }
+      continue;
+    }
+    const line = continued + physicalLine;
+    // Only an unmatched final backslash continues; indentation inside quotes is data.
+    if (/(?:^|[^\\])(?:\\\\)*\\$/u.test(line)) {
+      continued = `${line.slice(0, -1)} `;
+    } else {
+      lines.push(line);
+      continued = "";
+    }
+  }
+  return continued ? [...lines, continued] : lines;
 }
 
 export function renderSystemdEnvAssignment(key: string, value: string): string {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -2002,42 +2002,49 @@ describe("readSystemdServiceExecStart", () => {
     });
   });
 
-  it("retains loaded drop-in ownership even when its launcher and environment values equal the base", async () => {
-    const dropInPath = `${TEST_SERVICE_HOME}/.config/systemd/user/${GATEWAY_SERVICE}.d/operator.conf`;
-    mockReadGatewayServiceFile(
-      [
-        "[Service]",
-        "ExecStart=/usr/bin/openclaw gateway run",
-        "WorkingDirectory=/srv/openclaw",
-        "Environment=OPENCLAW_GATEWAY_TOKEN=shared NODE_COMPILE_CACHE=/tmp/cache",
-      ],
-      {
-        [dropInPath]: [
+  it.each(["", "# operator note \\", "; operator note \\"])(
+    "retains loaded drop-in ownership with comment %j even when values equal the base",
+    async (comment) => {
+      const dropInPath = `${TEST_SERVICE_HOME}/.config/systemd/user/${GATEWAY_SERVICE}.d/operator.conf`;
+      mockReadGatewayServiceFile(
+        [
           "[Service]",
-          "ExecStart=",
           "ExecStart=/usr/bin/openclaw gateway run",
           "WorkingDirectory=/srv/openclaw",
           "Environment=OPENCLAW_GATEWAY_TOKEN=shared NODE_COMPILE_CACHE=/tmp/cache",
-        ].join("\n"),
-      },
-    );
-    mockSystemdManagerSnapshot({
-      programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-      workingDirectory: "/srv/openclaw",
-      environment: ["OPENCLAW_GATEWAY_TOKEN=shared", "NODE_COMPILE_CACHE=/tmp/cache"],
-      dropInPaths: [dropInPath],
-    });
+        ],
+        {
+          [dropInPath]: [
+            "[Service]",
+            comment,
+            "ExecStart=",
+            comment,
+            "ExecStart=/usr/bin/openclaw gateway run",
+            comment,
+            "WorkingDirectory=/srv/openclaw",
+            comment,
+            "Environment=OPENCLAW_GATEWAY_TOKEN=shared NODE_COMPILE_CACHE=/tmp/cache",
+          ].join("\n"),
+        },
+      );
+      mockSystemdManagerSnapshot({
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        workingDirectory: "/srv/openclaw",
+        environment: ["OPENCLAW_GATEWAY_TOKEN=shared", "NODE_COMPILE_CACHE=/tmp/cache"],
+        dropInPaths: [dropInPath],
+      });
 
-    const command = await readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME });
+      const command = await readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME });
 
-    expect(command).toMatchObject({
-      managedDefinition: { environment: { OPENCLAW_GATEWAY_TOKEN: "shared" } },
-      managedOverrides: {
-        launcher: "command",
-        environment: { keys: ["OPENCLAW_GATEWAY_TOKEN", "NODE_COMPILE_CACHE"] },
-      },
-    });
-  });
+      expect(command).toMatchObject({
+        managedDefinition: { environment: { OPENCLAW_GATEWAY_TOKEN: "shared" } },
+        managedOverrides: {
+          launcher: "command",
+          environment: { keys: ["OPENCLAW_GATEWAY_TOKEN", "NODE_COMPILE_CACHE"] },
+        },
+      });
+    },
+  );
 
   it("preserves managed removals while clearing superseded drop-in ownership in directive order", async () => {
     const firstDropIn = `${TEST_SERVICE_HOME}/.config/systemd/user/${GATEWAY_SERVICE}.d/10-file.conf`;
@@ -2394,46 +2401,52 @@ describe("stageSystemdService", () => {
     assertNoSystemSystemdOwnershipMock.mockResolvedValue();
   });
 
-  it("removes legacy gateway version metadata without restarting the service", async () => {
-    await withStageFixture(async ({ env, unitPath }) => {
-      await fs.mkdir(path.dirname(unitPath), { recursive: true });
-      await fs.writeFile(
-        unitPath,
-        [
-          "[Unit]",
-          "Description=OpenClaw Gateway (v2026.7.1-2)",
-          "",
-          "[Service]",
-          "ExecStart=/usr/bin/openclaw gateway run",
-          "Environment=OPENCLAW_SERVICE_MARKER=openclaw",
-          "Environment=OPENCLAW_SERVICE_KIND=gateway",
-          'Environment=OPENCLAW_SERVICE_VERSION=2026.7.1-2 "OTHER_SETTING=kept value"',
-          "Environment=OPENCLAW_GATEWAY_PORT=18789",
-          "",
-        ].join("\n"),
-        "utf8",
-      );
-      execFileMock.mockImplementationOnce(systemctlUserSuccess("daemon-reload"));
+  it.each(["", "# operator note \\", "; operator note \\"])(
+    "removes legacy gateway version metadata with comment %j without restarting",
+    async (comment) => {
+      await withStageFixture(async ({ env, unitPath }) => {
+        await fs.mkdir(path.dirname(unitPath), { recursive: true });
+        await fs.writeFile(
+          unitPath,
+          [
+            "[Unit]",
+            "Description=OpenClaw Gateway (v2026.7.1-2)",
+            "",
+            "[Service]",
+            comment,
+            "ExecStart=/usr/bin/openclaw gateway run",
+            "Environment=OPENCLAW_SERVICE_MARKER=openclaw \\",
+            "  # managed stamps span physical lines",
+            "  OPENCLAW_SERVICE_KIND=gateway",
+            'Environment=OPENCLAW_SERVICE_VERSION=2026.7.1-2 "OTHER_SETTING=kept value"',
+            "Environment=OPENCLAW_GATEWAY_PORT=18789",
+            "",
+          ].join("\n"),
+          "utf8",
+        );
+        execFileMock.mockImplementationOnce(systemctlUserSuccess("daemon-reload"));
 
-      await expect(refreshLegacySystemdServiceMetadata(env, 5_000)).resolves.toBe(true);
+        await expect(refreshLegacySystemdServiceMetadata(env, 5_000)).resolves.toBe(true);
 
-      const unit = await fs.readFile(unitPath, "utf8");
-      expect(unit).toContain("Description=OpenClaw Gateway\n");
-      expect(unit).not.toContain("OPENCLAW_SERVICE_VERSION");
-      expect(unit).toContain('Environment="OTHER_SETTING=kept value"');
-      expect(unit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
-      expect(execFileMock).toHaveBeenCalledTimes(1);
-      for (const [, timeoutMs] of assertNoSystemSystemdOwnershipMock.mock.calls) {
-        expect(timeoutMs).toBeGreaterThan(0);
-        expect(timeoutMs).toBeLessThanOrEqual(5_000);
-      }
-      expect(assertNoSystemSystemdOwnershipMock).toHaveBeenCalledTimes(3);
-      expect(execFileMock.mock.calls[0]?.[2]).toMatchObject({
-        killSignal: "SIGKILL",
-        timeout: expect.any(Number),
+        const unit = await fs.readFile(unitPath, "utf8");
+        expect(unit).toContain("Description=OpenClaw Gateway\n");
+        expect(unit.split("\n")).toContain("ExecStart=/usr/bin/openclaw gateway run");
+        expect(unit).not.toContain("OPENCLAW_SERVICE_VERSION");
+        expect(unit).toContain('Environment="OTHER_SETTING=kept value"');
+        expect(unit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
+        expect(execFileMock).toHaveBeenCalledTimes(1);
+        for (const [, timeoutMs] of assertNoSystemSystemdOwnershipMock.mock.calls) {
+          expect(timeoutMs).toBeGreaterThan(0);
+          expect(timeoutMs).toBeLessThanOrEqual(5_000);
+        }
+        expect(assertNoSystemSystemdOwnershipMock).toHaveBeenCalledTimes(3);
+        expect(execFileMock.mock.calls[0]?.[2]).toMatchObject({
+          killSignal: "SIGKILL",
+          timeout: expect.any(Number),
+        });
       });
-    });
-  });
+    },
+  );
 
   it("preserves a hand-written unit with the formerly documented version metadata", async () => {
     await withStageFixture(async ({ env, unitPath }) => {
@@ -2962,57 +2975,62 @@ describe("stageSystemdService", () => {
     });
   });
 
-  it("sanitizes file-backed managed values out of the backup unit on re-stage", async () => {
-    await withStageFixture(async ({ env, unitPath }) => {
-      await fs.mkdir(path.dirname(unitPath), { recursive: true });
-      await fs.writeFile(
-        unitPath,
-        [
-          "[Service]",
-          "ExecStart=/usr/bin/openclaw node run",
-          "Environment=FOO=bar OPENCLAW_GATEWAY_TOKEN=inline-token BAZ=qux",
-          "Environment=OPENCLAW_GATEWAY_TOKEN=token-only-line",
-          "Environment='OPENCLAW_GATEWAY_TOKEN=single-quoted-token' FROM_SINGLE=kept",
-          "Environment=",
-          "Environment=OPENCLAW_GATEWAY_PORT=18789",
-        ].join("\n"),
-        { encoding: "utf8", mode: 0o600 },
-      );
-      await fs.chmod(unitPath, 0o600);
+  it.each(["", "# operator note \\", "; operator note \\"])(
+    "sanitizes file-backed backup values with comment %j on re-stage",
+    async (comment) => {
+      await withStageFixture(async ({ env, unitPath }) => {
+        await fs.mkdir(path.dirname(unitPath), { recursive: true });
+        await fs.writeFile(
+          unitPath,
+          [
+            "[Service]",
+            comment,
+            "ExecStart=/usr/bin/openclaw node run",
+            comment,
+            "Environment=FOO=bar OPENCLAW_GATEWAY_TOKEN=inline-token BAZ=qux",
+            "Environment=OPENCLAW_GATEWAY_TOKEN=token-only-line",
+            "Environment='OPENCLAW_GATEWAY_TOKEN=single-quoted-token' FROM_SINGLE=kept",
+            "Environment=",
+            "Environment=OPENCLAW_GATEWAY_PORT=18789",
+          ].join("\n"),
+          { encoding: "utf8", mode: 0o600 },
+        );
+        await fs.chmod(unitPath, 0o600);
 
-      mockSystemctlStatusOk();
+        mockSystemctlStatusOk();
 
-      await stageSystemdService(
-        nodeSystemdServiceFixture(env, {
-          environment: {
-            OPENCLAW_GATEWAY_TOKEN: "fresh-token",
-            OPENCLAW_GATEWAY_PORT: "18789",
-            OPENCLAW_SERVICE_KIND: "node",
-          },
-          environmentValueSources: {
-            OPENCLAW_GATEWAY_TOKEN: "file",
-          },
-        }),
-      );
+        await stageSystemdService(
+          nodeSystemdServiceFixture(env, {
+            environment: {
+              OPENCLAW_GATEWAY_TOKEN: "fresh-token",
+              OPENCLAW_GATEWAY_PORT: "18789",
+              OPENCLAW_SERVICE_KIND: "node",
+            },
+            environmentValueSources: {
+              OPENCLAW_GATEWAY_TOKEN: "file",
+            },
+          }),
+        );
 
-      const [unit, backupUnit, backupStat] = await Promise.all([
-        fs.readFile(unitPath, "utf8"),
-        fs.readFile(`${unitPath}.bak`, "utf8"),
-        fs.stat(`${unitPath}.bak`),
-      ]);
+        const [unit, backupUnit, backupStat] = await Promise.all([
+          fs.readFile(unitPath, "utf8"),
+          fs.readFile(`${unitPath}.bak`, "utf8"),
+          fs.stat(`${unitPath}.bak`),
+        ]);
 
-      expect(unit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=fresh-token");
-      expect(backupUnit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=inline-token");
-      expect(backupUnit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=token-only-line");
-      expect(backupUnit).not.toContain("single-quoted-token");
-      expect(backupUnit).toContain("[Service]");
-      expect(backupUnit).toContain("ExecStart=/usr/bin/openclaw node run");
-      expect(backupUnit).toContain("Environment=FOO=bar BAZ=qux");
-      expect(backupUnit).toContain("Environment=FROM_SINGLE=kept\nEnvironment=\n");
-      expect(backupUnit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
-      expect(backupStat.mode & 0o777).toBe(0o600);
-    });
-  });
+        expect(unit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=fresh-token");
+        expect(backupUnit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=inline-token");
+        expect(backupUnit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=token-only-line");
+        expect(backupUnit).not.toContain("single-quoted-token");
+        expect(backupUnit).toContain("[Service]");
+        expect(backupUnit.split("\n")).toContain("ExecStart=/usr/bin/openclaw node run");
+        expect(backupUnit).toContain("Environment=FOO=bar BAZ=qux");
+        expect(backupUnit).toContain("Environment=FROM_SINGLE=kept\nEnvironment=\n");
+        expect(backupUnit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
+        expect(backupStat.mode & 0o777).toBe(0o600);
+      });
+    },
+  );
 
   it("protects tokenless gateway units and backups from legacy credentials", async () => {
     await withStageFixture(async ({ env, unitPath }) => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainer-owned branch in `openclaw/openclaw`; repository collaborators retain normal branch access.

</details>

## What Problem This Solves

Fixes an issue where Linux operators could lose a runnable systemd service during metadata refresh when a valid comment ending in a backslash preceded `ExecStart`. The generated recovery backup could also lose the command, and equivalent operator drop-ins could lose their ownership classification.

Closes #137447

## Why This Change Was Made

The existing logical-line splitter now follows systemd's physical-line rules: recognize comments before continuations, continue only an unmatched final backslash, and preserve quoted indentation, blank-line boundaries, and pending EOF content. Metadata ownership, drop-in ownership, extra-service discovery, and fallback service auditing all use that one reader. The repair leaves native manager authority, service publication checks, credential sanitation, and service policy unchanged.

A nearby one-call environment-assignment decoder is folded into its existing owner, removing unreachable rejection branches. Production LOC is **+36/−54, net −18**; tests are **+240/−183, net +57**. The shared decoder replaces multiple regex paths, and removing an already-redundant diagnostic key filter absorbs the additional native line semantics. No new configuration, dependency, schema, public API, retry, or fallback is added.

## User Impact

Valid commented or continued unit definitions remain runnable through managed metadata maintenance and produce usable recovery backups. OpenClaw retains operator ownership for loaded, equal-valued drop-ins. If the native manager cannot be queried, service auditing correctly recognizes continued dependency, restart-delay, and kill-mode settings instead of issuing false warnings or missing unsafe kill-mode warnings.

This prevents new corruption; it does not reconstruct unit files already damaged by an earlier build. Post-publication rollback still requires fresh writable ownership and an exact publication fingerprint; when native inspection is unavailable it deliberately refuses a stale restore. Existing units with ordinary comments and unchanged service settings keep their behavior.

## Evidence

- `node scripts/run-vitest.mjs src/daemon/service-audit.test.ts src/daemon/systemd-unit.test.ts src/daemon/systemd.test.ts` — **310 tests pass**. Before repair: five parser cases and six service-owner cases failed; the later sibling audit repair first reproduced three failures in its 58-test suite. Continued metadata-marker ownership has separate pre-fix failure evidence.
- Full seven-path `node scripts/check-changed.mjs -- ...` — exit 0, including formatting, lint, core/test typechecks, full-tree dead-export scans, and architecture guards. Managed P2 Codex autoreview — scoped-clean, both passes with no actionable findings.
- `node scripts/run-vitest.mjs src/daemon/systemd-definition-mutation.test.ts` — **84 tests pass**, covering fresh publication ownership, rollback, concurrent edits, alias changes, and bounded inspection.
- Native Linux proof on [Blacksmith Testbox run 33780721904](https://github.com/openclaw/openclaw/actions/runs/33780721904), systemd `255.4-1ubuntu8.12`, Node `24.19.0`. An exact full baseline clone at `46018ecf111636e981c3ab1a0921ee73217c6274` was compared with the three unchanged service-parser candidate files in fresh Node processes. Actual service APIs and systemd were used, not a mocked service manager.

| Native check | Ordinary comment, before/after | Backslash `#` or `;` comment, before | Backslash `#` or `;` comment, after |
| --- | --- | --- | --- |
| Original service starts | Pass | Pass | Pass |
| Metadata refresh preserves native start | Pass | Published command swallowed; start fails | Pass |
| Arguments and unrelated environment survive | Pass | No successful post-refresh execution | Identical receipt |
| Recovery backup passes systemd validation | Pass | Fails: no executable directive | Pass |
| Equal-valued drop-in runs and keeps ownership | Pass | Runs, but ownership omitted | Runs, ownership retained |

All six test units, drop-ins, backups, and temporary clones were removed; a final resource audit found none remaining and the lease is stopped. Native proof exercises real service publication/activation and D-Bus ownership, not a full Gateway session, installed npm package, or provider. The later one-line audit-reader repair is proved at the exported audit API using a failed-manager mock; it does not alter the three service files exercised natively.

The first native attempt failed because its cleanup masked the baseline publication error. That failure was retained, the exact owned leftover was removed, and the corrected harness records primary errors and byte-checked cleanup independently. The final before/after and sibling runs passed. The prepared image emits existing executable-mode warnings for unrelated system units during `systemd-analyze verify`; candidate verification still exits zero.

Dependency contract: [systemd v255 conf-parser.c](https://github.com/systemd/systemd/blob/v255/src/shared/conf-parser.c#L326-L443) and [systemd.syntax](https://www.freedesktop.org/software/systemd/man/latest/systemd.syntax.html). The fix reuses the existing OpenClaw parser rather than adding a library or alternate parsing path.

## Review follow-up: extra-service diagnostics

The [latest review](https://github.com/openclaw/openclaw/pull/137448#issuecomment-5529643202) identified one remaining sibling in `inspect.ts`. This is addressed in the same repair: the diagnostic scanner now uses the shared reader. Its separate relationship-key set was redundant because the existing later gate already excluded every non-`ExecStart` assignment; that set and duplicate branches are removed. Companion, description, environment, and non-gateway-command exclusions remain covered. No extra cleanup authority or removal policy is added.

Three added detector cases failed against the original PR head. The expanded local suite passes **429 tests**; nine existing/parameterized native-Linux filesystem cases are skipped on macOS. The full nine-path changed gate exits zero, and fresh managed P0–P2 review is scoped-clean.

Additional actual Linux proof: [Testbox run 33786301242](https://github.com/openclaw/openclaw/actions/runs/33786301242), systemd255.4, Node24.19. An exact clone of original PR head `f37fa7bac2675899a4e469ac0efc4586566851bd` was compared with the hash-verified candidate in fresh processes. Five real units per phase all started and remained active. Before: ordinary gateway detected; hash-backslash, semicolon-backslash and comment-in-continuation gateways incorrectly omitted. After: all four gateways detected with exact scoped cleanup hints; the companion remained excluded. Native child receipts verified the expected arguments. Hints were inspected, not executed. All ten units and temporary roots were removed, a separate native resource audit found zero remaining, and the lease is stopped. This exercises actual user-unit discovery and hint rendering; it does not claim a full Doctor repair or native system-scope install. The three original service-publication runtime files remain byte-identical to the earlier six-case native proof.

The first diagnostic invocation exceeded the OS argument-size limit before its Python probe started. Its failure is retained; the exact same source payload was compressed for transport, with all decoded hashes revalidated. The corrected before/after probe and cleanup audit both exited zero.
