### PR TITLE
improve: reduce CLI recovery test startup time

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -231,8 +231,11 @@ reply metadata reader, and outbound normalizer. Shared chunks preserve their
 module and WeakMap identity. Generated TUI fixtures remain `.mts` files: Node
 launches them with `--import tsx` for their own syntax, while Bun handles that
 syntax natively without the Node loader. Only their runtime imports change.
-Existing package build entry paths and Vitest source parents stay unchanged. Other
-Worker-thread entries and arbitrary source CLI fixtures remain outside this declared set.
+Existing package build entry paths and Vitest source parents stay unchanged. The
+CLI fork-recovery regression also compiles the real CLI entry and its concurrent
+rebind's session accessor and binding helper together. Both processes use the same
+runtime graph while retaining the durable-write race and process-exit assertions.
+Other Worker-thread entries and arbitrary source CLI fixtures remain outside this declared set.
 
 The session-title retention test declares its title-reader and session-utils roots
 in this same generation. Each fresh heap-measurement child runs their JavaScript

--- a/scripts/lib/vitest-worker-artifacts.mts
+++ b/scripts/lib/vitest-worker-artifacts.mts
@@ -10,6 +10,7 @@ export const runtimeProcessDeclarationEntries = {
 };
 export const vitestWorkerDeclarationEntries = {
   ...runtimeProcessDeclarationEntries,
+  "cli/cli-entrypoint.test-support": "src/cli/cli-entrypoint.test-support.ts",
   "test-support/channel-ingress-gateway-restart-entrypoint":
     "test/fixtures/channel-ingress-gateway-restart-entrypoint.ts",
   "extensions/qa-lab/gateway-child-artifacts-runtime.test-support":

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -2,6 +2,7 @@ import { fileURLToPath } from "node:url";
 import { qaGatewayCleanupRuntimeEntrypoint } from "../../extensions/qa-lab/src/gateway-child-artifacts-runtime.test-support.ts";
 import { codeModeRetentionEntrypoint } from "../../src/agents/code-mode-retention-entrypoint.test-support.ts";
 import { cliCompactionBackendEntrypoints } from "../../src/agents/command/cli-compaction-runtime.test-support.ts";
+import { cliRecoveryEntrypoints } from "../../src/cli/cli-entrypoint.test-support.ts";
 import { cronOwnerHardeningEntrypoints } from "../../src/cron/owner-hardening-runtime.test-support.ts";
 import { sessionListCacheRetentionEntrypoint } from "../../src/gateway/server-methods/sessions-list-cache-retention-entrypoint.test-support.ts";
 import { sessionTitleRetentionEntrypoints } from "../../src/gateway/session-title-retention.test-support.ts";
@@ -19,6 +20,7 @@ export const vitestWorkerBuildEntries = {
     [
       codeModeRetentionEntrypoint,
       ...cliCompactionBackendEntrypoints,
+      ...Object.values(cliRecoveryEntrypoints),
       ...Object.values(cronOwnerHardeningEntrypoints),
       ...Object.values(tuiPtyRuntimeEntrypoints),
       ...Object.values(sessionTitleRetentionEntrypoints),

--- a/src/cli/agent-cli-recovery.process.test.ts
+++ b/src/cli/agent-cli-recovery.process.test.ts
@@ -8,7 +8,9 @@ import {
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import type { InternalSessionEntry } from "../config/sessions/types.js";
+import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { cliRecoveryEntrypoints } from "./cli-entrypoint.test-support.js";
 import { runCliProcessChild } from "./cli-process-child.test-helpers.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -81,9 +83,7 @@ describe("CLI fork recovery process", () => {
 
     const result = await runCliProcessChild({
       nodeArgs: [
-        "--import",
-        "tsx",
-        "src/entry.ts",
+        ...resolveRuntimeWorkerArgv(resolveRuntimeWorkerUrl(cliRecoveryEntrypoints.cli)),
         "agent",
         "--local",
         "--session-key",
@@ -111,7 +111,6 @@ describe("CLI fork recovery process", () => {
         PR135168_NEWER_CLI_SESSION_ID: newerCliSessionId,
         PR135168_REBIND_SCRIPT: rebindScript,
         PR135168_SESSION_KEY: sessionKey,
-        PR135168_SOURCE_DIR: path.resolve("src"),
         PR135168_SPAWN_LOG: spawnLog,
         PR135168_STORE_PATH: storePath,
         PR135168_SUCCESSOR_CLI_SESSION_ID: successorCliSessionId,
@@ -237,11 +236,8 @@ process.stdout.write(JSON.stringify({ result: "stale recovery ran", session_id: 
     ),
     fs.writeFile(
       params.rebindScript,
-      `import path from "node:path";
-import { pathToFileURL } from "node:url";
-const source = process.env.PR135168_SOURCE_DIR;
-const accessor = await import(pathToFileURL(path.join(source, "config/sessions/session-accessor.ts")).href);
-const cliSession = await import(pathToFileURL(path.join(source, "agents/cli-session.ts")).href);
+      `const accessor = await import(${JSON.stringify(resolveRuntimeWorkerUrl(cliRecoveryEntrypoints.sessionAccessor).href)});
+const cliSession = await import(${JSON.stringify(resolveRuntimeWorkerUrl(cliRecoveryEntrypoints.cliSession).href)});
 const scope = { sessionKey: process.env.PR135168_SESSION_KEY, storePath: process.env.PR135168_STORE_PATH };
 const current = accessor.loadSessionEntry({ ...scope, readConsistency: "latest" });
 if (!current) throw new Error("proof session row missing");

--- a/src/cli/cli-entrypoint.test-support.ts
+++ b/src/cli/cli-entrypoint.test-support.ts
@@ -1,0 +1,18 @@
+// Both concurrent writers must use the same runtime graph and version metadata.
+export const cliRecoveryEntrypoints = {
+  cli: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../entry",
+    distWorkerPath: "entry.js",
+  },
+  sessionAccessor: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../config/sessions/session-accessor",
+    distWorkerPath: "config/sessions/session-accessor.js",
+  },
+  cliSession: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../agents/cli-session",
+    distWorkerPath: "agents/cli-session.js",
+  },
+} as const;


### PR DESCRIPTION
## What Problem This Solves

The CLI fork-recovery regression spends most of its runtime loading TypeScript in two real processes. It has also hit the process-completion deadline in a full Linux CI group. The regression is valuable: it verifies that a stale fork cannot report success after another process has rebound its durable session.

## Why This Change Was Made

Register the real CLI entry and the rebind's existing session-accessor and binding-helper roots with the invocation-owned compiled subprocess generation. Both concurrent actors now use the same compiled runtime graph. The existing runner still owns compilation, source/output verification, process cleanup, and artifact disposal; standalone Vitest keeps source execution.

The test retains the real plugin/backend, durable-write interleaving, exact exit/error/session/argv assertions, and existing deadline. No product runtime, database schema, or shard count changes. The obsolete source-directory fixture environment value and source-path assembly are removed.

## User Impact

Faster development tests with the same recovery coverage. No end-user behavior change.

## Evidence

Local Node 24 comparison on the same source base, with fresh generation compilation included:

| Measurement | Source baseline | Compiled candidate |
| --- | --- | --- |
| Recovery case, two runs | 29.42s / 18.85s | 3.21s / 2.92s |
| Complete invocation, two runs | 43.49s / 29.02s | 15.61s / 10.66s |
| Generation preparation | 4.00s / 2.24s | 4.82s / 3.33s |

The fixed graph grows from 7,634 inputs / 3,410 outputs to 8,222 / 4,075. These are isolated local measurements, not a claim that the earlier full Linux group timeout or the overall CI target is resolved.

- Native [CI run 33787747888](https://github.com/openclaw/openclaw/actions/runs/33787747888) is green: 82 passed/16 skipped. The recovery case passes in 4.433s versus 46.359s on the prior main run, with the same observed runner resources and the full 6,713-case CLI inventory retained. The complete PR run takes 9:29; Windows, QA, UI and Docker are not selected by this scope.
- Canonical recovery test: both local candidate runs pass the unchanged case.
- Historical negative control: restoring the pre-fix successor-persistence implementation from the parent of 173f41d682b0d4a05674820a3d390d934da8b066, while retaining today's commit-authority callback, makes this exact optimized test fail on incorrect exit code 0 versus required 1. Original production bytes were restored; the candidate passes again.
- Standalone source fallback: the same case passes without a compiled generation.
- Worker URL and artifact verification siblings: 9/9 pass.
- Required changed-file gate: all checks pass, including core-test/script typechecks, lint, formatting and repository guards. Independent Codex review is clean through P2.

Production runtime LOC delta: 0. Tooling: +3 lines. Tests/support: +14 net lines, including the shared three-root declaration. Documentation: +3 net lines. No test assertions or cases removed.
