### PR TITLE
feat: support enforceable source-aware message policy

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -1075,7 +1075,9 @@ Use message hooks for channel-level routing and delivery policy:
 - `message_sending`: rewrite `content` or return `{ cancel: true }`.
 - `reply_payload_sending`: rewrite normalized `ReplyPayload` objects
   (including `presentation`, `delivery`, media refs, and text) or return
-  `{ cancel: true }`.
+  `{ cancel: true }`. A final-reply cancellation may also return
+  `{ suppressFallback: true }` when the plugin intentionally owns the terminal
+  outcome and OpenClaw must not synthesize a visible no-reply fallback.
 - `message_sent`: observe final success or failure.
 
 For audio-only TTS replies, `content` may contain the hidden spoken

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -238,16 +238,17 @@ cancellation and shutdown lifecycle.
 
 The standard runner applies these defaults **per handler**:
 
-| Hooks                                                                                                          | Default timeout                     | On thrown error or timeout                                       |
-| -------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------- |
-| `before_agent_run`, `before_tool_call`, `before_install`                                                       | 15 seconds                          | Fail closed: block the run, tool call, or install                |
-| `before_agent_finalize`, `before_prompt_build`, `message_sending`, `reply_payload_sending`, `resolve_exec_env` | 15 seconds                          | Log and skip the failed handler; retain other successful results |
-| `agent_end`, `before_compaction`, `after_compaction`, `skill_changed`, `skill_proposal_changed`                | 30 seconds                          | Log and continue                                                 |
-| `channel_pairing_requested`                                                                                    | 2 seconds                           | Log and continue                                                 |
-| `gateway_stop`                                                                                                 | 5 seconds                           | Log and continue shutdown                                        |
-| `skill_proposal_evaluate`                                                                                      | 120 seconds                         | Record an attributed error outcome                               |
-| Other asynchronous hooks, including claim hooks                                                                | No runner timeout unless configured | Log and continue                                                 |
-| `tool_result_persist`, `before_message_write`                                                                  | No asynchronous timeout             | Synchronous errors are logged; failed results are ignored        |
+| Hooks                                                                                           | Default timeout                     | On thrown error or timeout                                             |
+| ----------------------------------------------------------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------- |
+| `before_agent_run`, `before_tool_call`, `before_install`                                        | 15 seconds                          | Fail closed: block the run, tool call, or install                      |
+| `before_agent_finalize`, `before_prompt_build`, `reply_payload_sending`, `resolve_exec_env`     | 15 seconds                          | Log and skip the failed handler; retain other successful results       |
+| `message_sending`                                                                               | 15 seconds                          | Fail open by default; registrations may select fail-closed suppression |
+| `agent_end`, `before_compaction`, `after_compaction`, `skill_changed`, `skill_proposal_changed` | 30 seconds                          | Log and continue                                                       |
+| `channel_pairing_requested`                                                                     | 2 seconds                           | Log and continue                                                       |
+| `gateway_stop`                                                                                  | 5 seconds                           | Log and continue shutdown                                              |
+| `skill_proposal_evaluate`                                                                       | 120 seconds                         | Record an attributed error outcome                                     |
+| Other asynchronous hooks, including claim hooks                                                 | No runner timeout unless configured | Log and continue                                                       |
+| `tool_result_persist`, `before_message_write`                                                   | No asynchronous timeout             | Synchronous errors are logged; failed results are ignored              |
 
 An emitter can impose a tighter overall lifecycle budget, such as the
 shutdown `session_end` drain below. A timeout only bounds an asynchronous
@@ -751,8 +752,10 @@ Use the phase-specific hooks for new plugins:
 - `agent_turn_prepare`: receives the current prompt, prepared session
   messages, and queued injections consumed for this session.
   Return `prependContext` or `appendContext`.
-- `before_prompt_build`: receives the current prompt and session messages.
-  Return `prependContext`, `appendContext`, `systemPrompt`,
+- `before_prompt_build`: receives the assembled model prompt, the exact current
+  `transcriptPrompt` when available, and session messages.
+  Return `prompt` to replace the model-visible current prompt without changing
+  the persisted transcript text. Return `prependContext`, `appendContext`, `systemPrompt`,
   `prependSystemContext`, `appendSystemContext`, or `toolsAllow`. `toolsAllow`
   can only narrow the host-resolved tool surface for the current turn; `[]`
   submits no optional tools, while omitting it leaves the existing surface unchanged.
@@ -1098,6 +1101,10 @@ and context.
 Prefer typed `threadId` and `replyToId` fields before using channel-specific
 metadata.
 
+For outbound sends initiated by an authenticated Gateway operator,
+`message_sending` also receives `ctx.gatewayClientScopes`. Agent and background
+delivery paths omit this field.
+
 Inbound claim and message-received events expose `media?:
 PluginHookMediaFact[]` as the canonical attachment API. Each fact can carry
 `path`, `url`, `contentType`, `kind`, `transcribed`, `messageId`, and
@@ -1116,6 +1123,11 @@ Decision rules:
 
 - `message_sending` with `cancel: true` is terminal.
 - `message_sending` with `cancel: false` is treated as no decision.
+- A `message_sending` enforcement hook can register with
+  `{ failurePolicy: "fail-closed" }`. If that handler throws or times out,
+  OpenClaw suppresses delivery with reason `message_sending_hook_failed_closed`
+  and skips lower-priority handlers. Other registrations remain fail open by
+  default.
 - Each `message_sending` handler receives the original event content. The last
   returned `content` wins; a later handler can still cancel delivery.
 - `reply_payload_sending` runs after payload normalization and before channel

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -797,6 +797,7 @@ cover CLI and Gateway-backed install or update paths.
 - `reply_dispatch`: returning `{ handled: true, ... }` is terminal. Once any handler claims dispatch, lower-priority handlers and the default model dispatch path are skipped.
 - `message_sending`: returning `{ cancel: true }` is terminal. Once any handler sets it, lower-priority handlers are skipped.
 - `message_sending`: returning `{ cancel: false }` is treated as no decision (same as omitting `cancel`), not as an override.
+- `message_sending`: policy plugins can register with `{ failurePolicy: "fail-closed" }` to suppress delivery when their handler throws or times out; the default remains fail open.
 - `message_received`: use the typed `threadId` field when you need inbound thread/topic routing. Keep `metadata` for channel-specific extras.
 - `message_sending`: use typed `replyToId` / `threadId` routing fields before falling back to channel-specific `metadata`.
 - `gateway_start`: use `ctx.config`, `ctx.workspaceDir`, and `ctx.getCron?.()` for gateway-owned startup state instead of relying on internal `gateway:startup` hooks. Cron may still be loading at this point.

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -188,6 +188,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
   const buildPromptFromCurrentInputs = async () => {
     const result = await resolveAgentHarnessBeforePromptBuildResult({
       prompt: prependCurrentInboundContext(promptState.promptText, params.currentInboundContext),
+      transcriptPrompt: params.transcriptPrompt ?? params.prompt,
       developerInstructions: {
         build: ({ toolsAllow }) => {
           if (isRestrictivePromptToolsAllow(toolsAllow)) {

--- a/extensions/copilot/src/attempt-session-setup.ts
+++ b/extensions/copilot/src/attempt-session-setup.ts
@@ -82,6 +82,7 @@ export async function createCopilotSessionSetup(params: {
     }
     promptBuild = await resolveAgentHarnessBeforePromptBuildResult({
       prompt: input.prompt,
+      transcriptPrompt: input.transcriptPrompt ?? input.prompt,
       developerInstructions: {
         build: ({ toolsAllow }) => {
           promptPolicyResult = promptToolPolicy.apply({ toolsAllow, forceToolNames });

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -184,6 +184,8 @@ async function runCliAgentInternal(
             ...buildAgentHookContextIdentityFields({
               trigger: params.trigger,
               senderId: params.senderId,
+              senderName: params.senderName,
+              senderE164: params.senderE164,
               chatId: params.chatId,
               channelContext: params.channelContext,
             }),
@@ -310,6 +312,8 @@ export async function runPreparedCliAgent(
     ...buildAgentHookContextIdentityFields({
       trigger: params.trigger,
       senderId: params.senderId,
+      senderName: params.senderName,
+      senderE164: params.senderE164,
       chatId: params.chatId,
       channelContext: params.channelContext,
     }),

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1982,12 +1982,21 @@ describe("prepareCliRunContext", () => {
     });
     const hookRunner = {
       hasHooks: vi.fn((hookName: string) => hookName === "before_prompt_build"),
-      runBeforePromptBuild: vi.fn(async ({ messages }: { messages: unknown[] }) => ({
-        prependContext: `history:${messages.length}`,
-        systemPrompt: "hook system",
-        prependSystemContext: "prepend system",
-        appendSystemContext: "append system",
-      })),
+      runBeforePromptBuild: vi.fn(
+        async ({
+          messages,
+          transcriptPrompt,
+        }: {
+          messages: unknown[];
+          transcriptPrompt?: string;
+        }) => ({
+          prompt: `<read_only><message>${transcriptPrompt}</message></read_only>`,
+          prependContext: `history:${messages.length}`,
+          systemPrompt: "hook system",
+          prependSystemContext: "prepend system",
+          appendSystemContext: "append system",
+        }),
+      ),
     };
     mockGetGlobalHookRunner.mockReturnValue(hookRunner as never);
 
@@ -2005,7 +2014,9 @@ describe("prepareCliRunContext", () => {
       },
     });
 
-    expect(context.params.prompt).toBe("history:2\n\nlatest ask");
+    expect(context.params.prompt).toBe(
+      "history:2\n\n<read_only><message>latest ask</message></read_only>",
+    );
     expect(context.contextEngineTurnPrompt).toBe("latest ask");
     expect(context.systemPrompt).toBe(
       `${wrappedPluginSystemContext("prepend system")}\n\nhook system\n\n${wrappedPluginSystemContext("append system")}${SYSTEM_PROMPT_CACHE_BOUNDARY}\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
@@ -2016,6 +2027,7 @@ describe("prepareCliRunContext", () => {
     >;
     expect(beforePromptBuildCalls[0]?.[0]).toEqual({
       prompt: "latest ask",
+      transcriptPrompt: "latest ask",
       messages: [
         { role: "user", content: "earlier context", timestamp: 1 },
         {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -828,6 +828,7 @@ export async function prepareCliRunContext(
       return await resolvePromptBuildHookResult({
         config: runConfig,
         prompt: params.prompt,
+        transcriptPrompt: params.transcriptPrompt ?? params.prompt,
         messages: await loadOpenClawHistoryMessages(),
         hookCtx: promptBuildHookContext,
         hookRunner: promptBuildHookRunner,
@@ -1784,6 +1785,9 @@ export async function prepareCliRunContext(
     if (!skipsTurnPreparation) {
       try {
         const hookResult = promptBuildHookResult;
+        if (hookResult?.prompt !== undefined) {
+          preparedPrompt = hookResult.prompt;
+        }
         const prependContext = [
           hookResult?.prependContext,
           authorizedPromptBuildResult?.prependContext,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
@@ -155,6 +155,8 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
     ...buildAgentHookContextIdentityFields({
       trigger: attempt.trigger,
       senderId: attempt.senderId,
+      senderName: attempt.senderName,
+      senderE164: attempt.senderE164,
       chatId: attempt.chatId,
       channelContext: attempt.channelContext,
     }),

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
@@ -161,12 +161,17 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
   };
   const promptBuildMessages =
     pruneProcessedHistoryImages(input.activeSession.messages) ?? input.activeSession.messages;
-  const promptEvent = { prompt: attempt.prompt, messages: promptBuildMessages };
+  const promptEvent = {
+    prompt: attempt.prompt,
+    transcriptPrompt: attempt.transcriptPrompt ?? attempt.prompt,
+    messages: promptBuildMessages,
+  };
   const hookResult = preserveExactPrompt
     ? undefined
     : await resolvePromptBuildHookResult({
         config: attempt.config ?? getRuntimeConfig(),
         prompt: attempt.prompt,
+        transcriptPrompt: attempt.transcriptPrompt ?? attempt.prompt,
         messages: promptBuildMessages,
         hookCtx,
         hookRunner: input.hookRunner,
@@ -212,7 +217,14 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
     authorizedHookResult?.appendContext,
   );
   const hasPromptBuildContext =
-    Boolean(promptBuildPrependContext?.trim()) || Boolean(promptBuildAppendContext?.trim());
+    hookResult?.prompt !== undefined ||
+    Boolean(promptBuildPrependContext?.trim()) ||
+    Boolean(promptBuildAppendContext?.trim());
+
+  if (hookResult?.prompt !== undefined) {
+    effectivePrompt = hookResult.prompt;
+    log.debug(`hooks: replaced prompt (${hookResult.prompt.length} chars)`);
+  }
 
   if (promptBuildPrependContext) {
     effectivePrompt = `${promptBuildPrependContext}\n\n${effectivePrompt}`;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-helpers.ts
@@ -96,6 +96,7 @@ export function forgetPromptBuildDrainCacheForRun(runId: string | undefined): vo
 export async function resolvePromptBuildHookResult(params: {
   config: OpenClawConfig;
   prompt: string;
+  transcriptPrompt?: string;
   messages: unknown[];
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
@@ -157,6 +158,9 @@ export async function resolvePromptBuildHookResult(params: {
         .runBeforePromptBuild(
           {
             prompt: params.prompt,
+            ...(params.transcriptPrompt !== undefined
+              ? { transcriptPrompt: params.transcriptPrompt }
+              : {}),
             messages: params.messages,
           },
           params.hookCtx,
@@ -167,6 +171,7 @@ export async function resolvePromptBuildHookResult(params: {
         })
     : undefined;
   return {
+    ...(promptBuildResult?.prompt !== undefined ? { prompt: promptBuildResult.prompt } : {}),
     systemPrompt: promptBuildResult?.systemPrompt,
     ...(promptBuildResult?.toolsAllow !== undefined
       ? { toolsAllow: promptBuildResult.toolsAllow }

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -125,6 +125,7 @@ describe("resolvePromptBuildHookResult", () => {
     const hookRunner = {
       hasHooks: vi.fn(() => true),
       runBeforePromptBuild: vi.fn(async () => ({
+        prompt: "replacement prompt",
         prependContext: "prompt context",
         appendContext: "prompt append context",
         prependSystemContext: "prompt prepend",
@@ -135,11 +136,17 @@ describe("resolvePromptBuildHookResult", () => {
     const result = await resolvePromptBuildHookResult({
       config: {},
       prompt: "hello",
+      transcriptPrompt: "transcript hello",
       messages: [],
       hookCtx: {},
       hookRunner,
     });
 
+    expect(result.prompt).toBe("replacement prompt");
+    expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledWith(
+      { prompt: "hello", transcriptPrompt: "transcript hello", messages: [] },
+      {},
+    );
     expect(result.prependContext).toBe("prompt context");
     expect(result.appendContext).toBe("prompt append context");
     expect(result.prependSystemContext).toBe(wrappedPluginSystemContext("prompt prepend"));

--- a/src/agents/harness/hook-context.ts
+++ b/src/agents/harness/hook-context.ts
@@ -35,6 +35,8 @@ export type AgentHarnessHookContext = {
   contextWindowReferenceTokens?: number;
   config?: OpenClawConfig;
   senderId?: string;
+  senderName?: string;
+  senderE164?: string;
   chatId?: string;
   channel?: string;
   channelContext?: PluginHookChannelContext;
@@ -67,6 +69,8 @@ export function buildAgentHookContext(params: AgentHarnessHookContext): PluginHo
     ...buildAgentHookContextIdentityFields({
       trigger: params.trigger,
       senderId: params.senderId,
+      senderName: params.senderName,
+      senderE164: params.senderE164,
       chatId: params.chatId,
       channelContext: params.channelContext,
     }),

--- a/src/agents/harness/prompt-compaction-hook-helpers.test.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.test.ts
@@ -13,6 +13,45 @@ afterEach(() => {
 });
 
 describe("resolveAgentHarnessBeforePromptBuildResult", () => {
+  it("replaces the model prompt without duplicating the original input", async () => {
+    const seenEvents: unknown[] = [];
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_prompt_build",
+          handler: (event) => {
+            seenEvents.push(event);
+            return {
+              prompt: `<read_only><message>${event.transcriptPrompt}</message></read_only>`,
+            };
+          },
+        },
+      ]),
+    );
+
+    const result = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "OpenClaw assembled context\n\nhello",
+      transcriptPrompt: "hello",
+      developerInstructions: "base instructions",
+      messages: [],
+      ctx: {},
+    });
+
+    expect(result).toEqual({
+      prompt: "<read_only><message>hello</message></read_only>",
+      developerInstructions: "base instructions",
+      promptInputRange: { start: 0, end: 47 },
+    });
+    expect(seenEvents).toEqual([
+      {
+        prompt: "OpenClaw assembled context\n\nhello",
+        transcriptPrompt: "hello",
+        messages: [],
+      },
+    ]);
+    expect(result.prompt.match(/hello/g)).toHaveLength(1);
+  });
+
   it.each([false, true])(
     "isolates nested prompt history across rebuilds (authorized=%s)",
     async (authorized) => {

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -32,6 +32,7 @@ type AgentHarnessDeveloperInstructionBuilder = {
 /** Runs before-prompt hooks and returns the adjusted prompt fields. */
 export async function resolveAgentHarnessBeforePromptBuildResult(params: {
   prompt: string;
+  transcriptPrompt?: string;
   developerInstructions: string | AgentHarnessDeveloperInstructionBuilder;
   messages: unknown[];
   ctx: AgentHarnessHookContext;
@@ -62,6 +63,7 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
   const hookCtx = buildAgentHookContext(params.ctx);
   const promptEvent = {
     prompt: params.prompt,
+    ...(params.transcriptPrompt !== undefined ? { transcriptPrompt: params.transcriptPrompt } : {}),
     messages: params.messages,
   };
 
@@ -124,10 +126,10 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
     promptBuildResult?.appendContext,
     authorizedPromptBuildResult?.appendContext,
   ]);
-  const prompt =
-    joinPresentTextSegments([promptPrefix, params.prompt, promptSuffix]) ?? params.prompt;
+  const modelPrompt = promptBuildResult?.prompt ?? params.prompt;
+  const prompt = joinPresentTextSegments([promptPrefix, modelPrompt, promptSuffix]) ?? modelPrompt;
   const promptInputStart =
-    params.prompt.length === 0
+    modelPrompt.length === 0
       ? (promptPrefix?.length ?? 0)
       : promptPrefix
         ? promptPrefix.length + 2
@@ -145,7 +147,7 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
       ]) ?? systemPrompt,
     promptInputRange: {
       start: promptInputStart,
-      end: promptInputStart + params.prompt.length,
+      end: promptInputStart + modelPrompt.length,
     },
   };
 }

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -305,6 +305,8 @@ export type ReplyPayloadMetadata = {
   replyDispatcherNormalizationOwner?: object;
   /** The command owner produced this terminal reply without starting an agent run. */
   commandReply?: true;
+  /** A reply hook intentionally owns terminal silence; do not synthesize a visible fallback. */
+  replyHookSuppressesFallback?: true;
   /** Exact key for replacing a runtime-owned assistant row after media materialization. */
   assistantTranscriptIdempotencyKey?: string;
   /** Original session-writer claim that must still hold at final delivery. */

--- a/src/auto-reply/reply/before-deliver.test.ts
+++ b/src/auto-reply/reply/before-deliver.test.ts
@@ -109,6 +109,25 @@ describe("beforeDeliver in reply dispatcher", () => {
     expect(receipt?.counts.final.cancelled).toBe(0);
   });
 
+  it("does not retry an attached fallback after terminal hook cancellation", async () => {
+    const deliver = vi.fn(async () => {});
+    const primary = setReplyPayloadMetadata(
+      { text: "policy token", mediaUrl: "/tmp/voice.ogg" } satisfies ReplyPayload,
+      { replyHookSuppressesFallback: true },
+    );
+    attachReplyDispatchUndeliveredFallback(primary, { text: "policy token" });
+    const outcome = captureReplyDispatchDeliveryOutcome(primary);
+    const dispatcher = createReplyDispatcher({ beforeDeliver: async () => null, deliver });
+
+    expect(dispatcher.sendFinalReply(primary)).toBe(true);
+    dispatcher.markComplete();
+    const receipt = await dispatcher.waitForIdle();
+
+    expect(deliver).not.toHaveBeenCalled();
+    await expect(outcome.promise).resolves.toBe("cancelled-suppress-fallback");
+    expect(receipt?.counts.final.cancelled).toBe(1);
+  });
+
   it("does not resurrect fallback text after a channel transform veto", async () => {
     const delivered: ReplyPayload[] = [];
     const skipped: string[] = [];

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -277,6 +277,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     queuedFinal: boolean;
     routedFinalCount: number;
     suppressionReason?: NormalizeReplySkipReason;
+    suppressFallback?: true;
     sessionWriterDeliveryRevoked?: true;
     dispatcherOutcome?: Promise<ReplyDispatchDeliveryOutcome>;
   }> => {
@@ -443,6 +444,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
       return {
         queuedFinal: result.ok,
         routedFinalCount: isRoutedReplyDelivered(result) ? 1 : 0,
+        ...(result.suppressFallback ? { suppressFallback: true } : {}),
       };
     }
     throwIfFinalDeliveryAborted();

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -76,7 +76,9 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   let acceptedFinal = false;
   let sessionWriterDeliveryRevoked = false;
   let channelTransformSuppressedFinal = false;
+  let replyHookSuppressedFallback = false;
   const finalDeliveries: Array<Promise<ReplyDispatchDeliveryOutcome> | undefined> = [];
+  const fallbackSuppressionOutcomes: Array<Promise<ReplyDispatchDeliveryOutcome>> = [];
   const sentFinalPayloadDedupeKeys = new Set<string>();
   let deferredTtsTextPending = state.progressState.accumulatedBlockTtsText;
   let continuationSettlementAttempted = false;
@@ -153,6 +155,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
             }
           : {}),
       });
+      replyHookSuppressedFallback ||= finalReply.suppressFallback === true;
       if (finalReply.sessionWriterDeliveryRevoked) {
         sessionWriterDeliveryRevoked = true;
         continue;
@@ -175,6 +178,9 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       routedFinalCount += finalReply.routedFinalCount;
       if (finalReply.queuedFinal) {
         finalDeliveries.push(finalReply.dispatcherOutcome);
+        if (finalReply.dispatcherOutcome) {
+          fallbackSuppressionOutcomes.push(finalReply.dispatcherOutcome);
+        }
       }
       // Metadata survives usage, threading, and transcript decoration; object identity does not.
       if (pendingContinuationSettlement && getReplyPayloadMetadata(reply)?.continuationStatus) {
@@ -269,6 +275,10 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
             abortSignal: getDispatchAbortSignal(),
             skipTts: true,
           });
+          replyHookSuppressedFallback ||= finalReply.suppressFallback === true;
+          if (finalReply.dispatcherOutcome) {
+            fallbackSuppressionOutcomes.push(finalReply.dispatcherOutcome);
+          }
           queuedFinal = finalReply.queuedFinal || queuedFinal;
           routedFinalCount += finalReply.routedFinalCount;
         } else if (
@@ -282,6 +292,10 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
             abortSignal: getDispatchAbortSignal(),
             skipTts: true,
           });
+          replyHookSuppressedFallback ||= finalReply.suppressFallback === true;
+          if (finalReply.dispatcherOutcome) {
+            fallbackSuppressionOutcomes.push(finalReply.dispatcherOutcome);
+          }
           queuedFinal = finalReply.queuedFinal || queuedFinal;
           routedFinalCount += finalReply.routedFinalCount;
         }
@@ -298,6 +312,10 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
             { text: deferredVisibleText },
             { abortSignal: getDispatchAbortSignal(), skipTts: true },
           );
+          replyHookSuppressedFallback ||= finalReply.suppressFallback === true;
+          if (finalReply.dispatcherOutcome) {
+            fallbackSuppressionOutcomes.push(finalReply.dispatcherOutcome);
+          }
           queuedFinal = finalReply.queuedFinal || queuedFinal;
           routedFinalCount += finalReply.routedFinalCount;
         }
@@ -324,6 +342,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     !pendingContinuation &&
     !sessionWriterDeliveryRevoked &&
     !channelTransformSuppressed &&
+    !replyHookSuppressedFallback &&
     !getObservedReplyDelivery() &&
     !replyAcceptedByActiveRun &&
     !turnLedger.hasVisibleDelivery();
@@ -337,6 +356,11 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     queuedSettleResult = await turnLedger.settleQueued(getDispatchAbortSignal());
   }
   if (queuedSettleResult === "settled") {
+    replyHookSuppressedFallback ||=
+      fallbackSuppressionOutcomes.length > 0 &&
+      (await Promise.all(fallbackSuppressionOutcomes)).some(
+        (outcome) => outcome === "cancelled-suppress-fallback",
+      );
     // Adapter-owned presentation may capture a final after sending hooks. Keep that
     // intentional suppression distinct from invisible, cancelled, or failed delivery.
     channelTransformSuppressed ||=
@@ -461,7 +485,8 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     !emptyFinalAllowedAsSilent &&
     !deliberateSilentTerminalReply &&
     !pendingContinuation &&
-    !channelTransformSuppressed
+    !channelTransformSuppressed &&
+    !replyHookSuppressedFallback
       ? { noVisibleReplyFallbackEligible: true }
       : {}),
     ...(noVisibleReplyFallbackDelivered ? { noVisibleReplyFallbackDelivered: true } : {}),

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -548,6 +548,32 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result.noVisibleReplyFallbackDelivered).toBe(true);
   });
 
+  it("does not synthesize a fallback after terminal reply-hook cancellation", async () => {
+    setNoAbort();
+    const deliver = vi.fn(async () => {});
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      beforeDeliver: async (payload) => {
+        setReplyPayloadMetadata(payload, { replyHookSuppressesFallback: true });
+        return null;
+      },
+    });
+    const replyResolver = vi.fn(async () => ({ text: "SKIP_RELAY" }));
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ ChatType: "direct" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
+  });
+
   it("reports queue-cap rejection instead of a temporary model failure", async () => {
     setNoAbort();
     diagnosticMocks.logMessageDispatchCompleted.mockClear();

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -21,6 +21,7 @@ import { readChannelContextAdmissionEvidence } from "../../channels/message-acce
 import { conversationIdentityFromMsgContext } from "../../config/sessions/conversation-identity.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import { normalizeMediaFacts } from "../../media/media-facts.js";
+import { withAgentHookSenderSelf } from "../../plugins/hook-agent-context.js";
 import { MEDIA_ONLY_USER_TEXT } from "../../sessions/user-turn-media.js";
 import {
   createUserTurnTranscriptRecorder,
@@ -424,7 +425,10 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
       // Parent lineage authenticates inherited group policy for queued CLI/MCP runs.
       spawnedBy: normalizeOptionalString(preparedSessionState.sessionEntry?.spawnedBy),
       senderId: normalizeOptionalString(sessionCtx.SenderId),
-      channelContext: ctx.ChannelContext ?? sessionCtx.ChannelContext,
+      channelContext: withAgentHookSenderSelf({
+        channelContext: ctx.ChannelContext ?? sessionCtx.ChannelContext,
+        senderIsSelf: sessionCtx.SenderIsSelf === true,
+      }),
       senderName: normalizeOptionalString(sessionCtx.SenderName),
       senderUsername: normalizeOptionalString(sessionCtx.SenderUsername),
       senderE164: normalizeOptionalString(sessionCtx.SenderE164),

--- a/src/auto-reply/reply/reply-dispatch-outcome.ts
+++ b/src/auto-reply/reply/reply-dispatch-outcome.ts
@@ -8,6 +8,7 @@ export const REPLY_DISPATCH_OUTCOME_COUNTS = {
   "delivered-not-visible": "deliveredNotVisible",
   "channel-transform": "deliveredNotVisible",
   cancelled: "cancelled",
+  "cancelled-suppress-fallback": "cancelled",
   "failed-before-deliver": "failedBeforeSend",
   "failed-deliver": "failedAfterSend",
 } as const satisfies Record<string, keyof ReplyDispatchSettledCounts>;

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -394,7 +394,11 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             ]);
           }
           await notifyBeforeDeliverCancelled(payload, info);
-          return { settlement: Promise.resolve<ReplyDispatchDeliveryOutcome>("cancelled") };
+          const outcome: ReplyDispatchDeliveryOutcome =
+            getReplyPayloadMetadata(payload)?.replyHookSuppressesFallback === true
+              ? "cancelled-suppress-fallback"
+              : "cancelled";
+          return { settlement: Promise.resolve(outcome) };
         }
         deliverPayload = copyReplyPayloadMetadata(payload, deliverPayload);
       }

--- a/src/auto-reply/reply/reply-payload-sending-hook.ts
+++ b/src/auto-reply/reply/reply-payload-sending-hook.ts
@@ -4,7 +4,7 @@ import type {
   PluginHookReplyPayloadSendingContext,
   PluginHookReplyUsageState,
 } from "../../plugins/hook-types.js";
-import { copyReplyPayloadMetadata } from "../reply-payload.js";
+import { copyReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { ReplyDispatchKind } from "./reply-dispatcher.types.js";
 
@@ -36,6 +36,9 @@ export async function runReplyPayloadSendingHook(params: {
   );
 
   if (result?.cancel) {
+    if (params.kind === "final" && result.suppressFallback === true) {
+      setReplyPayloadMetadata(params.payload, { replyHookSuppressesFallback: true });
+    }
     return null;
   }
   const payload = (result?.payload as ReplyPayload | undefined) ?? params.payload;

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -583,6 +583,7 @@ describe("routeReply", () => {
           index: 0,
           status: "suppressed",
           reason: "cancelled_by_reply_payload_sending_hook",
+          hookEffect: { suppressFallback: true },
         });
         return [];
       },
@@ -598,6 +599,7 @@ describe("routeReply", () => {
       ok: true,
       delivered: false,
       suppressed: true,
+      suppressFallback: true,
       reason: "cancelled_by_reply_payload_sending_hook",
     });
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -132,6 +132,8 @@ type RouteReplyResult = {
   ambiguous?: boolean;
   /** True when a hook intentionally suppressed provider delivery. */
   suppressed?: boolean;
+  /** True when hook suppression intentionally owns the terminal reply outcome. */
+  suppressFallback?: true;
   /** Delivery disposition reason when additional caller context is useful. */
   reason?:
     | "reasoning_payload_not_external"
@@ -413,6 +415,12 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
         delivered: false,
         suppressed: true,
         reason: send.reason,
+        ...(send.payloadOutcomes?.some(
+          (outcome) =>
+            outcome.status === "suppressed" && outcome.hookEffect?.suppressFallback === true,
+        )
+          ? { suppressFallback: true }
+          : {}),
       };
     }
     if (send.status === "suppressed" && durableMessageBatchMayHaveReachedRecipient(send)) {

--- a/src/channels/turn/delivery-result.ts
+++ b/src/channels/turn/delivery-result.ts
@@ -16,6 +16,7 @@ export function createSuppressedChannelDeliveryResult(params: {
   reason: NonNullable<ChannelDeliveryResult["suppression"]>["reason"];
   cancelReason?: string;
   metadata?: Record<string, unknown>;
+  suppressFallback?: true;
 }): ChannelDeliveryResult {
   return {
     visibleReplySent: false,
@@ -23,6 +24,7 @@ export function createSuppressedChannelDeliveryResult(params: {
       reason: params.reason,
       ...(params.cancelReason ? { cancelReason: params.cancelReason } : {}),
       ...(params.metadata ? { metadata: params.metadata } : {}),
+      ...(params.suppressFallback ? { suppressFallback: true } : {}),
     },
   };
 }

--- a/src/channels/turn/durable-delivery.ts
+++ b/src/channels/turn/durable-delivery.ts
@@ -116,6 +116,7 @@ function resolveDurableSuppression(
     reason: send.reason,
     ...(hookEffect?.cancelReason ? { cancelReason: hookEffect.cancelReason } : {}),
     ...(hookEffect?.metadata ? { metadata: hookEffect.metadata } : {}),
+    ...(hookEffect?.suppressFallback ? { suppressFallback: true } : {}),
   };
 }
 

--- a/src/channels/turn/lifecycle.ts
+++ b/src/channels/turn/lifecycle.ts
@@ -1,6 +1,10 @@
 import type { ExecutionIdentityAdmissionToken as ExecutionToken } from "../../audit/execution-identity-admission.js";
 import { dispatchInboundMessageWithRoutedChannelDispatcher } from "../../auto-reply/dispatch.js";
-import { copyReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
+import {
+  copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
+  type ReplyPayload,
+} from "../../auto-reply/reply-payload.js";
 import { suppressPendingFinalDelivery } from "../../auto-reply/reply/dispatch-from-config.pending-final.js";
 import { runWithSessionInitConflictRetry } from "../../auto-reply/reply/session-init-conflict-retry.js";
 import { withReplySystemEventSessionKey } from "../../auto-reply/reply/system-event-session-key.js";
@@ -466,7 +470,13 @@ async function dispatchChannelTurnWithDeliveryOwner(
                           onDelivered: delivery.onDelivered,
                           payload,
                           info,
-                          result: createSuppressedChannelDeliveryResult({ reason }),
+                          result: createSuppressedChannelDeliveryResult({
+                            reason,
+                            ...(getReplyPayloadMetadata(payload)?.replyHookSuppressesFallback ===
+                            true
+                              ? { suppressFallback: true }
+                              : {}),
+                          }),
                         });
                       },
                     }

--- a/src/channels/turn/lifecycle.ts
+++ b/src/channels/turn/lifecycle.ts
@@ -336,6 +336,7 @@ async function applyRoutedDirectMessageSending(params: {
       params.turn.ctxPayload.ReplyToId,
     threadId: params.turn.ctxPayload.MessageThreadId,
     sessionKey: params.turn.routeSessionKey,
+    gatewayClientScopes: params.turn.ctxPayload.GatewayClientScopes,
   });
   if (hookResult.cancelled) {
     return {

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -198,6 +198,7 @@ export type ChannelDeliveryResult = ChannelDeliveryOutcome & {
     reason: OutboundPayloadDeliverySuppressionReason | "channel_transform" | "no_visible_result";
     cancelReason?: string;
     metadata?: Record<string, unknown>;
+    suppressFallback?: true;
   };
   /** Same-payload native settlement; resolved fields override this result before observation. */
   finalization?: Promise<ChannelDeliveryOutcome>;

--- a/src/infra/outbound/deliver-hooks.ts
+++ b/src/infra/outbound/deliver-hooks.ts
@@ -1,4 +1,7 @@
-import { copyReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import {
+  copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
+} from "../../auto-reply/reply-payload.js";
 import { finalizeInboundContext } from "../../auto-reply/reply/inbound-context.js";
 import {
   markReplyDispatchBeforeDeliverDeadlineOwned,
@@ -239,6 +242,7 @@ export async function applyReplyPayloadSendingHook(params: {
   cancelled: boolean;
   payload: ReplyPayload;
   changed: boolean;
+  suppressFallback?: true;
 }> {
   if (!params.hook) {
     return { cancelled: false, payload: params.payload, changed: false };
@@ -252,7 +256,14 @@ export async function applyReplyPayloadSendingHook(params: {
     context: params.hook.context,
   });
   if (!nextPayload) {
-    return { cancelled: true, payload: params.payload, changed: false };
+    return {
+      cancelled: true,
+      payload: params.payload,
+      changed: false,
+      ...(getReplyPayloadMetadata(params.payload)?.replyHookSuppressesFallback === true
+        ? { suppressFallback: true }
+        : {}),
+    };
   }
   return {
     cancelled: false,
@@ -284,6 +295,7 @@ export function suppressedPayloadOutcome(params: {
   hookEffect?: {
     cancelReason?: string;
     metadata?: Record<string, unknown>;
+    suppressFallback?: true;
   };
 }): OutboundPayloadDeliveryOutcome {
   return {

--- a/src/infra/outbound/deliver-hooks.ts
+++ b/src/infra/outbound/deliver-hooks.ts
@@ -117,6 +117,7 @@ export function buildProjectedInboundMessageSendingBeforeDeliver(
       replyToId: payload.replyToId ?? finalized.ReplyToIdFull ?? finalized.ReplyToId,
       threadId: finalized.MessageThreadId,
       sessionKey: finalized.SessionKey,
+      gatewayClientScopes: finalized.GatewayClientScopes,
     });
     if (hookResult.cancelled) {
       return null;
@@ -136,6 +137,7 @@ export async function applyMessageSendingHook(params: {
   replyToId?: string | null;
   threadId?: string | number | null;
   sessionKey?: string;
+  gatewayClientScopes?: readonly string[];
 }): Promise<{
   cancelled: boolean;
   cancelReason?: string;
@@ -169,6 +171,7 @@ export async function applyMessageSendingHook(params: {
         channelId: params.channel,
         accountId: params.accountId ?? undefined,
         conversationId: params.to,
+        ...(params.gatewayClientScopes ? { gatewayClientScopes: params.gatewayClientScopes } : {}),
         ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
       },
     );

--- a/src/infra/outbound/deliver-prepare.ts
+++ b/src/infra/outbound/deliver-prepare.ts
@@ -174,6 +174,7 @@ export async function prepareOutboundPayloadBatch(
         sourceIndex,
         status: "suppressed",
         reason: "cancelled_by_reply_payload_sending_hook",
+        ...(replyHookResult.suppressFallback ? { hookEffect: { suppressFallback: true } } : {}),
       });
       continue;
     }

--- a/src/infra/outbound/deliver-prepare.ts
+++ b/src/infra/outbound/deliver-prepare.ts
@@ -192,6 +192,7 @@ export async function prepareOutboundPayloadBatch(
         replyToId: resolveCurrentReplyTo(replyPayload).replyToId,
         threadId: params.threadId,
         sessionKey: sessionKeyForHooks,
+        gatewayClientScopes: params.gatewayClientScopes,
       });
     } catch (error) {
       // Modifier handlers are fail-open. Only a host invariant failure can

--- a/src/infra/outbound/deliver-types.ts
+++ b/src/infra/outbound/deliver-types.ts
@@ -100,6 +100,7 @@ export type OutboundPayloadDeliveryOutcome =
       hookEffect?: {
         cancelReason?: string;
         metadata?: Record<string, unknown>;
+        suppressFallback?: true;
       };
     }
   | {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1170,6 +1170,39 @@ describe("deliverOutboundPayloads", () => {
     expect(hookMocks.runner.runMessageSending).not.toHaveBeenCalled();
   });
 
+  it("preserves terminal reply-hook cancellation through prepared delivery", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "reply_payload_sending",
+    );
+    hookMocks.runner.runReplyPayloadSending.mockResolvedValueOnce({
+      cancel: true,
+      suppressFallback: true,
+    });
+
+    await expect(
+      prepareOutboundPayloadBatch({
+        cfg: {},
+        channel: "matrix",
+        to: "!room:example",
+        payloads: [{ text: "policy token" }],
+        deps: { matrix: vi.fn() },
+        replyPayloadSendingHook: {
+          kind: "final",
+          context: { channelId: "matrix" },
+        },
+      }),
+    ).resolves.toMatchObject({
+      entries: [
+        {
+          sourceIndex: 0,
+          status: "suppressed",
+          reason: "cancelled_by_reply_payload_sending_hook",
+          hookEffect: { suppressFallback: true },
+        },
+      ],
+    });
+  });
+
   it("revalidates conversation authority after queue admission and before the adapter", async () => {
     const order: string[] = [];
     queueMocks.enqueueDelivery.mockImplementationOnce(async () => {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -5501,6 +5501,24 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("threads Gateway operator scopes into the message_sending hook context", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "message_sending",
+    );
+    installTextOutbound({ channel: "matrix", messageId: "mx-scoped", roomId: "!room" });
+
+    await deliverMatrix({
+      to: "!room",
+      payloads: [{ text: "operator message" }],
+      gatewayClientScopes: ["operator.write"],
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ gatewayClientScopes: ["operator.write"] }),
+    );
+  });
+
   it("forwards session.key (canonical) into message_sending ctx and never falls back to policyKey", async () => {
     // Contract test for OutboundSessionContext.key semantics:
     // session.key MUST reach plugins via ctx.sessionKey, even when a
@@ -5622,6 +5640,45 @@ describe("deliverOutboundPayloads", () => {
     expect(low).not.toHaveBeenCalled();
     expect(sendMatrix).not.toHaveBeenCalled();
     expect(hookMocks.runner.runMessageSent).not.toHaveBeenCalled();
+  });
+
+  it("suppresses delivery and records the enforcing plugin when a fail-closed hook fails", async () => {
+    const hookRegistry = createEmptyPluginRegistry();
+    addTestHook({
+      registry: hookRegistry,
+      pluginId: "outbound-policy",
+      hookName: "message_sending",
+      handler: vi.fn().mockRejectedValue(new Error("policy unavailable")),
+      failurePolicy: "fail-closed",
+    });
+    const realRunner = createHookRunner(hookRegistry);
+    hookMocks.runner.hasHooks.mockImplementation((hookName?: string) =>
+      realRunner.hasHooks((hookName ?? "") as never),
+    );
+    hookMocks.runner.runMessageSending.mockImplementation((event, ctx) =>
+      realRunner.runMessageSending(event as never, ctx as never),
+    );
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+    const outcomes: unknown[] = [];
+
+    await expect(
+      deliverMatrix({
+        deps: { matrix: sendMatrix },
+        onPayloadDeliveryOutcome: (outcome) => outcomes.push(outcome),
+      }),
+    ).resolves.toEqual([]);
+
+    expect(sendMatrix).not.toHaveBeenCalled();
+    expect(outcomes).toEqual([
+      expect.objectContaining({
+        status: "suppressed",
+        reason: "cancelled_by_message_sending_hook",
+        hookEffect: {
+          cancelReason: "message_sending_hook_failed_closed",
+          metadata: { pluginId: "outbound-policy" },
+        },
+      }),
+    ]);
   });
 
   it("keeps text-only error payloads on the normal text path by default", async () => {

--- a/src/infra/outbound/prepared-batch.ts
+++ b/src/infra/outbound/prepared-batch.ts
@@ -24,6 +24,7 @@ type PreparedOutboundSuppressedEntry = {
   hookEffect?: {
     cancelReason?: string;
     metadata?: Record<string, unknown>;
+    suppressFallback?: true;
   };
 };
 

--- a/src/plugins/hook-agent-context.test.ts
+++ b/src/plugins/hook-agent-context.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildAgentHookContextChannelFields,
   buildAgentHookContextIdentityFields,
+  withAgentHookSenderSelf,
 } from "./hook-agent-context.js";
 
 describe("buildAgentHookContextChannelFields", () => {
@@ -88,5 +89,21 @@ describe("buildAgentHookContextIdentityFields", () => {
         chatId: "chat-1",
       }),
     ).toEqual({});
+  });
+});
+
+describe("withAgentHookSenderSelf", () => {
+  it("preserves an ingress-authenticated self sender", () => {
+    expect(
+      withAgentHookSenderSelf({
+        channelContext: { sender: { id: "+15551234567" } },
+        senderIsSelf: true,
+      }),
+    ).toEqual({ sender: { id: "+15551234567", isSelf: true } });
+  });
+
+  it("does not invent a self sender for ordinary inbound messages", () => {
+    const channelContext = { sender: { id: "+15551234567" } };
+    expect(withAgentHookSenderSelf({ channelContext })).toBe(channelContext);
   });
 });

--- a/src/plugins/hook-agent-context.test.ts
+++ b/src/plugins/hook-agent-context.test.ts
@@ -46,10 +46,14 @@ describe("buildAgentHookContextIdentityFields", () => {
     expect(
       buildAgentHookContextIdentityFields({
         senderId: "open-id-1",
+        senderName: "Alice",
+        senderE164: "+15551234567",
         chatId: "chat-1",
       }),
     ).toEqual({
       senderId: "open-id-1",
+      senderName: "Alice",
+      senderE164: "+15551234567",
       chatId: "chat-1",
       channelContext: {
         sender: { id: "open-id-1" },
@@ -79,6 +83,8 @@ describe("buildAgentHookContextIdentityFields", () => {
       buildAgentHookContextIdentityFields({
         trigger: "cron",
         senderId: "open-id-1",
+        senderName: "Alice",
+        senderE164: "+15551234567",
         chatId: "chat-1",
       }),
     ).toEqual({});

--- a/src/plugins/hook-agent-context.ts
+++ b/src/plugins/hook-agent-context.ts
@@ -129,15 +129,22 @@ export function buildAgentHookContextChannelFields(params: {
 export function buildAgentHookContextIdentityFields(params: {
   trigger?: string | null;
   senderId?: string | null;
+  senderName?: string | null;
+  senderE164?: string | null;
   chatId?: string | null;
   channelContext?: PluginHookChannelContext;
-}): Pick<PluginHookAgentContext, "senderId" | "chatId" | "channelContext"> {
+}): Pick<
+  PluginHookAgentContext,
+  "senderId" | "senderName" | "senderE164" | "chatId" | "channelContext"
+> {
   const trigger = normalizeOptionalString(params.trigger);
   if (trigger && trigger !== "user") {
     return {};
   }
 
   const senderId = normalizeOptionalString(params.senderId);
+  const senderName = normalizeOptionalString(params.senderName);
+  const senderE164 = normalizeOptionalString(params.senderE164);
   const chatId = normalizeOptionalString(params.chatId);
   const sender = senderId
     ? { ...params.channelContext?.sender, id: senderId }
@@ -156,6 +163,8 @@ export function buildAgentHookContextIdentityFields(params: {
 
   return {
     ...(senderId ? { senderId } : {}),
+    ...(senderName ? { senderName } : {}),
+    ...(senderE164 ? { senderE164 } : {}),
     ...(chatId ? { chatId } : {}),
     ...(channelContext ? { channelContext } : {}),
   };

--- a/src/plugins/hook-agent-context.ts
+++ b/src/plugins/hook-agent-context.ts
@@ -169,3 +169,17 @@ export function buildAgentHookContextIdentityFields(params: {
     ...(channelContext ? { channelContext } : {}),
   };
 }
+
+/** Preserve a channel-authenticated self-sender fact for downstream hooks. */
+export function withAgentHookSenderSelf(params: {
+  channelContext?: PluginHookChannelContext;
+  senderIsSelf?: boolean;
+}): PluginHookChannelContext | undefined {
+  if (params.senderIsSelf !== true) {
+    return params.channelContext;
+  }
+  return {
+    ...params.channelContext,
+    sender: { ...params.channelContext?.sender, isSelf: true },
+  };
+}

--- a/src/plugins/hook-before-agent-start.types.ts
+++ b/src/plugins/hook-before-agent-start.types.ts
@@ -20,12 +20,16 @@ export type PluginHookBeforeModelResolveResult = {
 
 // before_prompt_build hook
 export type PluginHookBeforePromptBuildEvent = {
+  /** Current user text as persisted in the transcript, before model-only context is assembled. */
+  transcriptPrompt?: string;
   prompt: string;
   /** Session messages prepared for this run. */
   messages: unknown[];
 };
 
 export type PluginHookBeforePromptBuildResult = {
+  /** Replace the current model prompt without changing the persisted transcript text. */
+  prompt?: string;
   systemPrompt?: string;
   prependContext?: string;
   appendContext?: string;

--- a/src/plugins/hook-channel-context.types.ts
+++ b/src/plugins/hook-channel-context.types.ts
@@ -1,6 +1,8 @@
 export interface PluginHookChannelSenderContext {
   /** Channel-scoped sender ID, matching `ctx.senderId` when both are present. */
   id?: string;
+  /** Whether the originating channel identified this as its own account. */
+  isSelf?: boolean;
   [key: string]: unknown;
 }
 

--- a/src/plugins/hook-message.types.ts
+++ b/src/plugins/hook-message.types.ts
@@ -61,6 +61,8 @@ export type PluginHookMessageContext = {
   channelId: string;
   accountId?: string;
   conversationId?: string;
+  /** Gateway scopes attached to an operator-originated delivery, when present. */
+  gatewayClientScopes?: readonly string[];
   /**
    * Canonical session key for this conversation — the same value the agent
    * runtime sees as `params.sessionKey` for the run that produced the

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -685,6 +685,8 @@ export type PluginHookReplyPayloadSendingResult = {
   payload?: PluginHookReplyPayload;
   cancel?: boolean;
   reason?: string;
+  /** Treat this cancellation as the terminal reply outcome instead of synthesizing a fallback. */
+  suppressFallback?: boolean;
 };
 
 export type PluginHookToolKind = "code_mode_exec";

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -258,6 +258,8 @@ export const isPluginHookReplyDispatchKind = (kind: unknown): kind is PluginHook
 
 export type PluginToolMatcher = readonly [string, ...string[]];
 
+export type PluginHookFailurePolicy = "fail-open" | "fail-closed";
+
 export type PluginHookRegistrationOptions<K extends PluginHookName> = {
   priority?: number;
   registrationId?: string;
@@ -280,6 +282,12 @@ export type PluginHookRegistrationOptions<K extends PluginHookName> = {
   (K extends "before_tool_call" | "after_tool_call"
     ? { matcher?: PluginToolMatcher }
     : { matcher?: never }) &
+  (K extends "message_sending"
+    ? {
+        /** Suppress delivery when this enforcement handler throws or times out. */
+        failurePolicy?: PluginHookFailurePolicy;
+      }
+    : { failurePolicy?: never }) &
   (K extends "before_prompt_build"
     ? {
         /** Run only after the host has finalized the turn's policy-filtered tool surface. */
@@ -1390,6 +1398,7 @@ export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = 
   matcher?: PluginToolMatcher;
   priority?: number;
   timeoutMs?: number;
+  failurePolicy?: PluginHookFailurePolicy;
   eligibleTriggers?: readonly PluginHookAgentTrigger[];
   eligibleDispatchKinds?: readonly PluginHookReplyDispatchKind[];
   requiresToolAuthority?: true;

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -325,6 +325,10 @@ export type PluginHookAgentContext = {
   chatId?: string;
   /** Sender identity for channel-originated runs when available. */
   senderId?: string;
+  /** Channel-provided sender display name when available. */
+  senderName?: string;
+  /** Sender phone number in E.164 form when the channel resolved one. */
+  senderE164?: string;
   trigger?: string;
   channelId?: string;
   /** Resolved effective context-token budget after model/config/agent caps. */

--- a/src/plugins/hooks.phase-hooks.test.ts
+++ b/src/plugins/hooks.phase-hooks.test.ts
@@ -71,6 +71,22 @@ describe("phase hooks merger", () => {
       },
     },
     {
+      name: "before_prompt_build keeps the higher-priority prompt replacement",
+      hookName: "before_prompt_build" as const,
+      hooks: [
+        { pluginId: "low", result: { prompt: "low replacement" }, priority: 1 },
+        { pluginId: "high", result: { prompt: "high replacement" }, priority: 10 },
+      ],
+      expected: {
+        prompt: "high replacement",
+        systemPrompt: undefined,
+        prependContext: undefined,
+        appendContext: undefined,
+        prependSystemContext: undefined,
+        appendSystemContext: undefined,
+      },
+    },
+    {
       name: "before_prompt_build concatenates prependContext and preserves systemPrompt precedence",
       hookName: "before_prompt_build" as const,
       hooks: [

--- a/src/plugins/hooks.test-fixtures.ts
+++ b/src/plugins/hooks.test-fixtures.ts
@@ -5,6 +5,7 @@ import type { PluginRegistry } from "./registry.js";
 import type {
   PluginHookAgentContext,
   PluginHookAgentTrigger,
+  PluginHookFailurePolicy,
   PluginHookRegistration,
   PluginToolMatcher,
 } from "./types.js";
@@ -56,6 +57,7 @@ export function createHookRunnerWithRegistry(
     pluginId?: string;
     priority?: number;
     timeoutMs?: number;
+    failurePolicy?: PluginHookFailurePolicy;
     eligibleTriggers?: readonly PluginHookAgentTrigger[];
     requiresToolAuthority?: true;
   }>,

--- a/src/plugins/hooks.test-helpers.ts
+++ b/src/plugins/hooks.test-helpers.ts
@@ -3,7 +3,12 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRegistry } from "./registry.js";
 import { createPluginRecord } from "./status.test-helpers.js";
-import type { PluginHookAgentTrigger, PluginHookRegistration, PluginToolMatcher } from "./types.js";
+import type {
+  PluginHookAgentTrigger,
+  PluginHookFailurePolicy,
+  PluginHookRegistration,
+  PluginToolMatcher,
+} from "./types.js";
 
 export function createMockPluginRegistry(
   hooks: Array<{
@@ -14,6 +19,7 @@ export function createMockPluginRegistry(
     priority?: number;
     registrationId?: string;
     timeoutMs?: number;
+    failurePolicy?: PluginHookFailurePolicy;
     eligibleTriggers?: readonly PluginHookAgentTrigger[];
     requiresToolAuthority?: true;
   }>,
@@ -41,6 +47,7 @@ export function createMockPluginRegistry(
       priority: h.priority ?? 0,
       ...(h.registrationId ? { registrationId: h.registrationId } : {}),
       ...(h.timeoutMs !== undefined ? { timeoutMs: h.timeoutMs } : {}),
+      ...(h.failurePolicy ? { failurePolicy: h.failurePolicy } : {}),
       ...(h.eligibleTriggers !== undefined ? { eligibleTriggers: h.eligibleTriggers } : {}),
       ...(h.requiresToolAuthority ? { requiresToolAuthority: true } : {}),
       source: "test",
@@ -56,6 +63,7 @@ export function addTestHook(params: {
   priority?: number;
   registrationId?: string;
   timeoutMs?: number;
+  failurePolicy?: PluginHookFailurePolicy;
   eligibleTriggers?: readonly PluginHookAgentTrigger[];
   requiresToolAuthority?: true;
 }) {
@@ -67,6 +75,7 @@ export function addTestHook(params: {
     priority: params.priority ?? 0,
     ...(params.registrationId ? { registrationId: params.registrationId } : {}),
     ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+    ...(params.failurePolicy ? { failurePolicy: params.failurePolicy } : {}),
     ...(params.eligibleTriggers !== undefined ? { eligibleTriggers: params.eligibleTriggers } : {}),
     ...(params.requiresToolAuthority ? { requiresToolAuthority: true } : {}),
     source: "test",

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -69,6 +69,7 @@ import type {
   PluginHookMessageContext,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
+  PluginHookFailurePolicy,
   PluginHookName,
   PluginHookRegistration,
   PluginHookSubagentContext,
@@ -111,7 +112,6 @@ type HookRunnerLogger = {
   error: (message: string) => void;
 };
 
-type HookFailurePolicy = "fail-open" | "fail-closed";
 export type VoidHookRunOptions = {
   unrefTimeout?: boolean;
 };
@@ -129,7 +129,7 @@ type HookRunnerOptions = {
    * Optional per-hook failure policy.
    * Defaults to fail-open unless explicitly overridden for a hook name.
    */
-  failurePolicyByHook?: Partial<Record<PluginHookName, HookFailurePolicy>>;
+  failurePolicyByHook?: Partial<Record<PluginHookName, PluginHookFailurePolicy>>;
   /**
    * Optional timeout for void/observation hooks. A timed-out hook is logged and
    * the runner continues, but the plugin's underlying work is not cancelled.
@@ -215,6 +215,7 @@ type ModifyingHookPolicy<K extends PluginHookName, TResult> = {
     result: TResult | undefined;
   }) => void;
   onHandlerError?: (hook: PluginHookRegistration<K>, failOpen: boolean) => void;
+  mapFailClosedError?: (params: { hook: PluginHookRegistration<K>; error: unknown }) => TResult;
 };
 
 type PluginTargetedInboundClaimOutcome =
@@ -310,7 +311,7 @@ export function createHookRunner(
   const failurePolicyByHook = {
     before_agent_run: "fail-closed",
     ...options.failurePolicyByHook,
-  } satisfies Partial<Record<PluginHookName, HookFailurePolicy>>;
+  } satisfies Partial<Record<PluginHookName, PluginHookFailurePolicy>>;
   const voidHookTimeoutMsByHook = {
     ...DEFAULT_VOID_HOOK_TIMEOUT_MS_BY_HOOK,
     ...options.voidHookTimeoutMsByHook,
@@ -325,8 +326,15 @@ export function createHookRunner(
   const runtimeDecisionScopeId = randomUUID();
   let runtimeDecisionOrdinal = 0;
 
-  const shouldCatchHookErrors = (hookName: PluginHookName): boolean =>
-    catchErrors && (failurePolicyByHook[hookName] ?? "fail-open") === "fail-open";
+  const resolveHookFailurePolicy = (
+    hookName: PluginHookName,
+    hook?: PluginHookRegistration,
+  ): PluginHookFailurePolicy => hook?.failurePolicy ?? failurePolicyByHook[hookName] ?? "fail-open";
+
+  const shouldCatchHookErrors = (
+    hookName: PluginHookName,
+    hook?: PluginHookRegistration,
+  ): boolean => catchErrors && resolveHookFailurePolicy(hookName, hook) === "fail-open";
 
   const recordBeforeToolCallDecision = (params: {
     event: PluginHookBeforeToolCallEvent;
@@ -509,7 +517,10 @@ export function createHookRunner(
             ],
             toolRestrictions,
           );
+    const prompt = firstDefined(acc?.prompt, next.prompt);
     return {
+      // Keep the first defined replacement so higher-priority hooks win.
+      ...(prompt !== undefined ? { prompt } : {}),
       // Keep the first defined system prompt so higher-priority hooks win.
       systemPrompt: firstDefined(acc?.systemPrompt, next.systemPrompt),
       prependContext: concatOptionalTextSegments({
@@ -643,10 +654,11 @@ export function createHookRunner(
   const handleHookError = (params: {
     hookName: PluginHookName;
     pluginId: string;
+    hook?: PluginHookRegistration;
     error: unknown;
   }): never | void => {
     const msg = `[hooks] ${params.hookName} handler from ${params.pluginId} failed: ${formatHookErrorForLog(params.error)}`;
-    if (shouldCatchHookErrors(params.hookName)) {
+    if (shouldCatchHookErrors(params.hookName, params.hook)) {
       logger?.error(msg);
       return;
     }
@@ -885,12 +897,24 @@ export function createHookRunner(
           }
         }
       } catch (err) {
-        const failOpen = !(err instanceof HookIsolationError) && shouldCatchHookErrors(hookName);
+        const failOpen =
+          !(err instanceof HookIsolationError) && shouldCatchHookErrors(hookName, hook);
         policy.onHandlerError?.(hook, failOpen);
         if (err instanceof HookIsolationError) {
           throw err;
         }
-        handleHookError({ hookName, pluginId: hook.pluginId, error: err });
+        if (
+          resolveHookFailurePolicy(hookName, hook) === "fail-closed" &&
+          policy.mapFailClosedError
+        ) {
+          logger?.error(
+            `[hooks] ${hookName} handler from ${hook.pluginId} failed closed: ${formatHookErrorForLog(err)}`,
+          );
+          result = policy.mapFailClosedError({ hook, error: err });
+          shouldStop = policy.shouldStop?.(result) ?? true;
+        } else {
+          handleHookError({ hookName, pluginId: hook.pluginId, hook, error: err });
+        }
       }
       policy.assertHandlerBoundaryActive?.();
       if (shouldStop) {
@@ -1377,6 +1401,11 @@ export function createHookRunner(
         },
         shouldStop: (result) => result.cancel === true,
         terminalLabel: "cancel=true",
+        mapFailClosedError: ({ hook }) => ({
+          cancel: true,
+          cancelReason: "message_sending_hook_failed_closed",
+          metadata: { pluginId: hook.pluginId },
+        }),
       },
     );
   }

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -1357,6 +1357,9 @@ export function createHookRunner(
           payload: currentPayload as PluginHookReplyPayload,
           cancel: stickyTrue(result?.cancel, handlerResult.cancel),
           reason: lastDefined(result?.reason, handlerResult.reason),
+          ...(stickyTrue(result?.suppressFallback, handlerResult.suppressFallback)
+            ? { suppressFallback: true }
+            : {}),
         };
 
         if (result.cancel === true) {

--- a/src/plugins/registry-registrars-tools-hooks.ts
+++ b/src/plugins/registry-registrars-tools-hooks.ts
@@ -410,6 +410,9 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
     if (opts?.matcher && hookName !== "before_tool_call" && hookName !== "after_tool_call") {
       reportRegistrationWarning(record, `typed hook "${hookName}" ignores tool matcher`);
     }
+    if (opts?.failurePolicy && hookName !== "message_sending") {
+      reportRegistrationWarning(record, `typed hook "${hookName}" ignores failure policy`);
+    }
     record.hookCount += 1;
     registry.typedHooks.push({
       pluginId: record.id,
@@ -419,6 +422,9 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
       ...(matcher ? { matcher } : {}),
       priority: opts?.priority,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      ...(hookName === "message_sending" && opts?.failurePolicy
+        ? { failurePolicy: opts.failurePolicy }
+        : {}),
       ...(eligibleTriggers ? { eligibleTriggers } : {}),
       ...(eligibleDispatchKinds ? { eligibleDispatchKinds } : {}),
       ...(hookName === "before_prompt_build" && opts?.requiresToolAuthority === true

--- a/src/plugins/registry.diagnostics.test.ts
+++ b/src/plugins/registry.diagnostics.test.ts
@@ -30,6 +30,30 @@ function createDiagnosticFixture() {
 }
 
 describe("plugin registration diagnostics", () => {
+  it("retains fail-closed policy only for message_sending registrations", () => {
+    const { builder, createRecord } = createDiagnosticFixture();
+    const record = createRecord("outbound-policy");
+    const api = builder.createApi(record, { config: {} });
+
+    api.on("message_sending", () => undefined, { failurePolicy: "fail-closed" });
+    // @ts-expect-error Untyped JavaScript plugins can pass this option to unsupported hooks.
+    api.on("message_received", () => undefined, { failurePolicy: "fail-closed" });
+
+    expect(builder.registry.typedHooks).toEqual([
+      expect.objectContaining({
+        hookName: "message_sending",
+        failurePolicy: "fail-closed",
+      }),
+      expect.not.objectContaining({ failurePolicy: expect.anything() }),
+    ]);
+    expect(builder.registry.diagnostics).toEqual([
+      expect.objectContaining({
+        level: "warn",
+        message: 'typed hook "message_received" ignores failure policy',
+      }),
+    ]);
+  });
+
   it("preserves ordered severity and call-time provenance across registrars and rollback", () => {
     const { builder, createRecord } = createDiagnosticFixture();
     const alpha = createRecord("alpha");

--- a/src/plugins/wired-hooks-message.test.ts
+++ b/src/plugins/wired-hooks-message.test.ts
@@ -103,6 +103,83 @@ describe("message_sending hook runner", () => {
     }
   });
 
+  it("fails closed when an enforcement handler throws", async () => {
+    const logger = { warn: vi.fn(), error: vi.fn() };
+    const second = vi.fn().mockResolvedValue({ content: "must not send" });
+    const { runner } = createHookRunnerWithRegistry(
+      [
+        {
+          hookName: "message_sending",
+          handler: vi.fn().mockRejectedValue(new Error("policy unavailable")),
+          failurePolicy: "fail-closed",
+        },
+        { hookName: "message_sending", handler: second },
+      ],
+      { logger },
+    );
+
+    await expect(
+      runner.runMessageSending({ to: "user-123", content: "original content" }, demoChannelCtx),
+    ).resolves.toEqual({
+      cancel: true,
+      cancelReason: "message_sending_hook_failed_closed",
+      metadata: { pluginId: "test-plugin" },
+    });
+    expect(second).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      "[hooks] message_sending handler from test-plugin failed closed: policy unavailable",
+    );
+  });
+
+  it("propagates ordinary handler errors when catching is disabled", async () => {
+    const { runner } = createHookRunnerWithRegistry(
+      [
+        {
+          hookName: "message_sending",
+          handler: vi.fn().mockRejectedValue(new Error("handler failed")),
+        },
+      ],
+      { catchErrors: false },
+    );
+
+    await expect(
+      runner.runMessageSending({ to: "user-123", content: "original content" }, demoChannelCtx),
+    ).rejects.toThrow("handler failed");
+  });
+
+  it("fails closed after an enforcement handler timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const firstStarted = createDeferred();
+      const { runner } = createHookRunnerWithRegistry([
+        {
+          hookName: "message_sending",
+          handler: vi.fn(() => {
+            firstStarted.resolve();
+            return new Promise<PluginHookMessageSendingResult>(() => {});
+          }),
+          failurePolicy: "fail-closed",
+        },
+      ]);
+
+      const resultPromise = runner.runMessageSending(
+        { to: "user-123", content: "original content" },
+        demoChannelCtx,
+      );
+      await firstStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await expect(resultPromise).resolves.toEqual({
+        cancel: true,
+        cancelReason: "message_sending_hook_failed_closed",
+        metadata: { pluginId: "test-plugin" },
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("preserves a handler-specific timeout longer than the default", async () => {
     vi.useFakeTimers();
     try {

--- a/src/plugins/wired-hooks-reply-payload-sending.test.ts
+++ b/src/plugins/wired-hooks-reply-payload-sending.test.ts
@@ -122,7 +122,9 @@ describe("reply_payload_sending hook runner", () => {
   });
 
   it("stops at the first handler that cancels delivery", async () => {
-    const first = vi.fn().mockResolvedValue({ cancel: true, reason: "blocked" });
+    const first = vi
+      .fn()
+      .mockResolvedValue({ cancel: true, reason: "blocked", suppressFallback: true });
     const second = vi.fn();
     const { runner } = createHookRunnerWithRegistry([
       { hookName: "reply_payload_sending", handler: first },
@@ -138,6 +140,7 @@ describe("reply_payload_sending hook runner", () => {
       payload: { text: "hello" },
       cancel: true,
       reason: "blocked",
+      suppressFallback: true,
     });
     expect(second).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Related: #56349
Related: #54519
Follow-up to #112167

## What Problem This Solves

External policy plugins can observe or cancel outgoing messages, but they cannot currently make that enforcement deterministic: a `message_sending` handler error or timeout is fail-open. They also cannot reliably distinguish an automatic response to the current inbound source from an explicit operator-authorized send, or replace the model-facing inbound prompt without changing the transcript. This prevents a plugin from implementing source-aware read-only channels safely.

## Why This Change Was Made

This extends the existing plugin boundaries rather than creating a second delivery lifecycle. `message_sending` registrations may opt into fail-closed behavior, automatic gateway deliveries expose their authenticated client scopes, and prompt-build hooks receive the transcript prompt and may return a model-only replacement. Core remains policy-neutral: it defines no blocked channels, performs no cross-channel rerouting, and retains fail-open behavior unless a plugin explicitly requests enforcement.

This is message-egress control, not a complete zero-egress mode. It does not suppress typing indicators, reactions, acknowledgements, read receipts, or other native channel effects tracked by #54519.

## User Impact

Plugin authors can implement enforceable, source-aware delivery policy while preserving normal operator CLI sends and transcript history. If an enforcing plugin crashes or exceeds its hook timeout, the affected message is suppressed with an auditable cancellation reason instead of being delivered.

An example external plugin using the contract is available at [rabsef-bicrym/openclaw-read-only-relay](https://github.com/rabsef-bicrym/openclaw-read-only-relay/tree/codex/openclaw-2). It ships with no channels blocked and keeps channel selection, prompt annotation, relay destination, and `SKIP_RELAY` behavior in plugin configuration.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/registry.diagnostics.test.ts` - 32 passed
- `node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts` - 222 passed
- `node scripts/run-vitest.mjs src/plugins/wired-hooks-message.test.ts` - 9 passed
- Core TypeScript check passed with `tsconfig.core.json`
- Root test TypeScript check passed with `test/tsconfig/tsconfig.test.root.json`
- External plugin: 19 tests passed; typecheck and build passed
- `git diff --check openclaw/main...HEAD` passed
- Prior live proof demonstrated an iMessage inbound turn withheld from iMessage and relayed to Telegram; current-contract live validation will be added after the stable runtime backport is installed.
