### PR TITLE
fix: keep remote Doctor failures out of local recovery

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -86,6 +86,17 @@ If migration or config repair cannot finish, Doctor leaves the stopped service
 stopped and reports an incomplete repair. Resolve the reported blocker, rerun
 `openclaw doctor --fix`, then start the service through its owner.
 
+## Remote Gateway recovery
+
+With `gateway.mode: "remote"`, a failed Gateway health check does not trigger
+local service install, start, restart, or bootstrap prompts. Check the remote
+URL, credentials, and SSH tunnel or network connection. If the Gateway itself
+needs recovery, run service commands on the host that runs it. A loopback remote
+URL can be an SSH tunnel; it does not make the Gateway a local service.
+
+See [Remote access](/gateway/remote) for connection checks. Other Doctor config
+and state checks still follow the selected posture above.
+
 ## Control UI assets
 
 For source installs, Doctor can build missing Control UI assets or rebuild stale

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -343,16 +343,6 @@ describe("maybeRepairGatewayDaemon", () => {
     );
   });
 
-  it("still inspects the managed service for the default install identity", async () => {
-    await withEnvAsync(
-      { OPENCLAW_STATE_DIR: undefined, OPENCLAW_CONFIG_PATH: undefined },
-      runNonInteractiveRepair,
-    );
-
-    expect(service.isLoaded).toHaveBeenCalledTimes(1);
-    expect(service.readRuntime).toHaveBeenCalledTimes(1);
-  });
-
   it.each([
     { environment: "container without an OpenClaw service", detected: true },
     { environment: "Kubernetes pod without container markers", kubernetes: true },
@@ -391,7 +381,7 @@ describe("maybeRepairGatewayDaemon", () => {
     },
   );
 
-  it("inspects an installed OpenClaw service through a reachable Docker systemd manager", async () => {
+  it("recovers an installed local service through a reachable Docker systemd manager", async () => {
     setPlatform("linux");
     isContainerEnvironment.mockReturnValue(true);
     findInstalledSystemdGatewayScope.mockResolvedValue({
@@ -399,11 +389,25 @@ describe("maybeRepairGatewayDaemon", () => {
       unitName: "openclaw-gateway.service",
       unitPath: "/home/alice/.config/systemd/user/openclaw-gateway.service",
     });
+    service.readRuntime.mockResolvedValue({ status: "stopped" });
+    const prompter = createPrompter(() => true);
 
-    await runNonInteractiveRepair();
+    await maybeRepairGatewayDaemon({
+      cfg: { gateway: { mode: "local" } },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      prompter,
+      options: {},
+      gatewayDetailsMessage: "details",
+      healthOk: false,
+      healthSkipped: false,
+    });
 
     expect(service.isLoaded).toHaveBeenCalledWith({ env: process.env, timeoutMs: 5_000 });
     expect(service.readRuntime).toHaveBeenCalledOnce();
+    expect(prompter.confirmRuntimeRepair).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Start gateway service now?" }),
+    );
+    expect(service.restart).toHaveBeenCalledOnce();
     expect(note).not.toHaveBeenCalledWith(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
   });
 
@@ -520,24 +524,74 @@ describe("maybeRepairGatewayDaemon", () => {
     expect(findSystemGatewayServices).not.toHaveBeenCalled();
   });
 
-  it("does not audit local services when skipped gateway health is remote", async () => {
-    setPlatform("linux");
+  describe.each(["darwin", "linux", "win32"] as const)("%s remote health", (platform) => {
+    it.each([
+      { name: "failed with a stopped local service", runtimeStatus: "stopped" },
+      { name: "failed with an unknown local runtime", runtimeStatus: "unknown" },
+      { name: "failed with a running local service", runtimeStatus: "running" },
+      { name: "failed through a loopback tunnel", url: "ws://127.0.0.1:18789" },
+      { name: "failed without a remote URL", url: undefined },
+      { name: "failed without a local service", loaded: false },
+      { name: "skipped", healthSkipped: true },
+      { name: "healthy", healthOk: true },
+    ])("never inspects or repairs local services when $name", async (scenario) => {
+      setPlatform(platform);
+      service.isLoaded.mockResolvedValue(scenario.loaded !== false);
+      service.readRuntime.mockResolvedValue({ status: scenario.runtimeStatus ?? "running" });
+      const prompter = createPrompter(() => true);
+      const url = "url" in scenario ? scenario.url : "wss://gateway.example";
 
-    await maybeRepairGatewayDaemon({
-      cfg: { gateway: { mode: "remote" } },
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      prompter: createDoctorPrompter({
+      await maybeRepairGatewayDaemon({
+        cfg: { gateway: { mode: "remote", remote: { url } } },
         runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-        options: { nonInteractive: true },
-      }),
-      options: { deep: false, nonInteractive: true },
-      gatewayDetailsMessage: "details",
-      healthOk: false,
-      healthSkipped: true,
-    });
+        prompter,
+        options: { deep: true },
+        gatewayDetailsMessage: "remote connection details",
+        healthOk: scenario.healthOk === true,
+        healthSkipped: scenario.healthSkipped === true,
+      });
 
+      expect(service.restart).not.toHaveBeenCalled();
+      expect(service.install).not.toHaveBeenCalled();
+      expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
+      expect(service.isLoaded).not.toHaveBeenCalled();
+      expect(service.readRuntime).not.toHaveBeenCalled();
+      expect(service.readCommand).not.toHaveBeenCalled();
+      expect(launchd.repairLaunchAgentBootstrap).not.toHaveBeenCalled();
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+      expect(inspectPortConnections).not.toHaveBeenCalled();
+      expect(note).not.toHaveBeenCalled();
+    });
+  });
+
+  it("preserves a real remote health failure through the ordered recovery contributions", async () => {
+    const {
+      createDoctorHealthFlowContext,
+      resolveDoctorHealthContributions,
+      runDoctorHealthContributionList,
+    } = await import("../flows/doctor-health-contributions.test-support.js");
+    const prompter = createPrompter(() => true);
+    const ctx = createDoctorHealthFlowContext({
+      cfg: { gateway: { mode: "remote" } },
+      prompter,
+    });
+    const contributions = resolveDoctorHealthContributions().filter(
+      ({ id }) => id === "doctor:gateway-health" || id === "doctor:gateway-daemon",
+    );
+    expect(contributions.map(({ id }) => id)).toEqual([
+      "doctor:gateway-health",
+      "doctor:gateway-daemon",
+    ]);
+
+    // The real Gateway call rejects a missing remote URL before opening a socket.
+    await runDoctorHealthContributionList(ctx, contributions);
+
+    expect(ctx).toMatchObject({ healthOk: false, gatewayHealthSkipped: false });
+    expect(ctx.runtime.error).toHaveBeenCalledOnce();
+    expect(service.restart).not.toHaveBeenCalled();
     expect(service.isLoaded).not.toHaveBeenCalled();
-    expect(note).not.toHaveBeenCalledWith("Gateway service not installed.", "Gateway");
+    expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
+    expect(note).not.toHaveBeenCalled();
   });
 
   it("does not start loaded services with unknown runtime when health was skipped", async () => {
@@ -745,11 +799,13 @@ describe("maybeRepairGatewayDaemon", () => {
     expect(service.restart).not.toHaveBeenCalled();
   });
 
-  it("skips running service restart during non-interactive repairs", async () => {
+  it("inspects but does not restart a running service during non-interactive repairs", async () => {
     setPlatform("linux");
 
     await runNonInteractiveRepair();
 
+    expect(service.isLoaded).toHaveBeenCalledOnce();
+    expect(service.readRuntime).toHaveBeenCalledOnce();
     expect(service.restart).not.toHaveBeenCalled();
   });
 
@@ -762,10 +818,10 @@ describe("maybeRepairGatewayDaemon", () => {
     expect(service.restart).toHaveBeenCalledTimes(1);
   });
 
-  it("restarts running service when repair is explicitly approved", async () => {
+  it.each([{ repair: true }, { yes: true }])("restarts with explicit %j", async (options) => {
     setPlatform("linux");
 
-    await runAutoRepair();
+    await runAutoRepair(options);
 
     expect(service.restart).toHaveBeenCalledTimes(1);
   });
@@ -789,21 +845,16 @@ describe("maybeRepairGatewayDaemon", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("restarts running service when --yes explicitly approves repairs", async () => {
+  it.each([
+    { action: "install", loaded: false, runtime: "stopped" },
+    { action: "start", loaded: true, runtime: "stopped" },
+    { action: "restart", loaded: true, runtime: "running" },
+  ])("skips service $action under external repair policy", async ({ loaded, runtime }) => {
     setPlatform("linux");
+    service.isLoaded.mockResolvedValue(loaded);
+    service.readRuntime.mockResolvedValue({ status: runtime });
 
-    await runAutoRepair({ yes: true });
-
-    expect(service.restart).toHaveBeenCalledTimes(1);
-  });
-
-  it("skips gateway service install when service repair policy is external", async () => {
-    setPlatform("linux");
-    service.isLoaded.mockResolvedValue(false);
-
-    await withEnvAsync({ OPENCLAW_SERVICE_REPAIR_POLICY: "external" }, async () => {
-      await runAutoRepair();
-    });
+    await withEnvAsync({ OPENCLAW_SERVICE_REPAIR_POLICY: "external" }, runAutoRepair);
 
     expect(service.install).not.toHaveBeenCalled();
     expect(service.restart).not.toHaveBeenCalled();
@@ -839,29 +890,6 @@ describe("maybeRepairGatewayDaemon", () => {
       ].join("\n"),
       "Gateway",
     );
-  });
-
-  it("skips gateway service start when service repair policy is external", async () => {
-    setPlatform("linux");
-    service.readRuntime.mockResolvedValue({ status: "stopped" });
-
-    await withEnvAsync({ OPENCLAW_SERVICE_REPAIR_POLICY: "external" }, async () => {
-      await runAutoRepair();
-    });
-
-    expect(service.restart).not.toHaveBeenCalled();
-    expect(note).toHaveBeenCalledWith(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
-  });
-
-  it("skips gateway service restart when service repair policy is external", async () => {
-    setPlatform("linux");
-
-    await withEnvAsync({ OPENCLAW_SERVICE_REPAIR_POLICY: "external" }, async () => {
-      await runAutoRepair();
-    });
-
-    expect(service.restart).not.toHaveBeenCalled();
-    expect(note).toHaveBeenCalledWith(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
   });
 
   it("skips LaunchAgent bootstrap repair when service repair policy is external", async () => {

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -163,7 +163,7 @@ async function maybeReportEstablishedGatewayClients(
   deep: boolean,
   port?: number,
 ): Promise<void> {
-  if (!deep || cfg.gateway?.mode === "remote") {
+  if (!deep) {
     return;
   }
   const targetPort = port ?? resolveGatewayPort(cfg, process.env);
@@ -224,18 +224,18 @@ export async function maybeRepairGatewayDaemon(params: {
     note(NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON, "Gateway");
     return;
   }
+  // A remote health failure says nothing about the local service, even when
+  // the remote URL is loopback (for example, an SSH tunnel).
+  if (params.cfg.gateway?.mode === "remote") {
+    return;
+  }
   if (params.healthOk) {
     await maybeReportEstablishedGatewayClients(params.cfg, params.options.deep ?? false);
     return;
   }
-  if (params.healthSkipped && params.cfg.gateway?.mode === "remote") {
-    return;
-  }
 
   if (!(await shouldManageGatewayService())) {
-    if (params.cfg.gateway?.mode !== "remote") {
-      await noteGatewayPortDiagnostics(params.cfg, params.options.deep ?? false);
-    }
+    await noteGatewayPortDiagnostics(params.cfg, params.options.deep ?? false);
     note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
     return;
   }
@@ -252,8 +252,7 @@ export async function maybeRepairGatewayDaemon(params: {
       return null;
     }
   };
-  const isLocalDarwinGateway =
-    process.platform === "darwin" && params.cfg.gateway?.mode !== "remote";
+  const isLocalDarwinGateway = process.platform === "darwin";
   const serviceState = await readGatewayServiceState(service, { env: process.env });
   if (serviceState.loadState.status === "unknown") {
     await noteGatewayServiceInspectionFailure(serviceState.loadState);
@@ -319,13 +318,11 @@ export async function maybeRepairGatewayDaemon(params: {
     return;
   }
 
-  if (params.cfg.gateway?.mode !== "remote") {
-    const conflict = await noteGatewayPortDiagnostics(params.cfg, params.options.deep ?? false);
-    if (!conflict && loaded && serviceRuntime?.status === "running") {
-      const lastError = await readLastGatewayErrorLine(process.env);
-      if (lastError) {
-        note(`Last gateway error: ${lastError}`, "Gateway");
-      }
+  const conflict = await noteGatewayPortDiagnostics(params.cfg, params.options.deep ?? false);
+  if (!conflict && loaded && serviceRuntime?.status === "running") {
+    const lastError = await readLastGatewayErrorLine(process.env);
+    if (lastError) {
+      note(`Last gateway error: ${lastError}`, "Gateway");
     }
   }
 
@@ -341,83 +338,81 @@ export async function maybeRepairGatewayDaemon(params: {
       return;
     }
     note("Gateway service not installed.", "Gateway");
-    if (params.cfg.gateway?.mode !== "remote") {
-      if (process.platform === "linux") {
-        const systemGatewayServices = await findSystemGatewayServices();
-        if (systemGatewayServices.length > 0) {
-          note(renderBlockingSystemGatewayServices(systemGatewayServices), "Gateway");
-          return;
-        }
-      }
-      if (serviceRepairExternal) {
-        note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
+    if (process.platform === "linux") {
+      const systemGatewayServices = await findSystemGatewayServices();
+      if (systemGatewayServices.length > 0) {
+        note(renderBlockingSystemGatewayServices(systemGatewayServices), "Gateway");
         return;
       }
-      const install = await confirmDoctorServiceRepair(
-        params.prompter,
-        {
-          message: "Install gateway service now?",
-          initialValue: true,
-          requiresInteractiveConfirmation: true,
-        },
-        serviceRepairPolicy,
+    }
+    if (serviceRepairExternal) {
+      note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
+      return;
+    }
+    const install = await confirmDoctorServiceRepair(
+      params.prompter,
+      {
+        message: "Install gateway service now?",
+        initialValue: true,
+        requiresInteractiveConfirmation: true,
+      },
+      serviceRepairPolicy,
+    );
+    if (!install) {
+      note(
+        `Run ${formatCliCommand("openclaw gateway install")} when you want to install the gateway service.`,
+        "Gateway",
       );
-      if (!install) {
+    }
+    if (install) {
+      const daemonRuntime = await params.prompter.select<GatewayDaemonRuntime>(
+        {
+          message: "Gateway service runtime",
+          options: GATEWAY_DAEMON_RUNTIME_OPTIONS,
+          initialValue: DEFAULT_GATEWAY_DAEMON_RUNTIME,
+        },
+        DEFAULT_GATEWAY_DAEMON_RUNTIME,
+      );
+      const tokenResolution = await resolveGatewayInstallToken({
+        config: params.cfg,
+        env: process.env,
+      });
+      for (const warning of tokenResolution.warnings) {
+        note(warning, "Gateway");
+      }
+      if (tokenResolution.unavailableReason) {
         note(
-          `Run ${formatCliCommand("openclaw gateway install")} when you want to install the gateway service.`,
+          [
+            "Gateway service install aborted.",
+            tokenResolution.unavailableReason,
+            "Fix gateway auth config/token input and rerun doctor.",
+          ].join("\n"),
           "Gateway",
         );
+        return;
       }
-      if (install) {
-        const daemonRuntime = await params.prompter.select<GatewayDaemonRuntime>(
-          {
-            message: "Gateway service runtime",
-            options: GATEWAY_DAEMON_RUNTIME_OPTIONS,
-            initialValue: DEFAULT_GATEWAY_DAEMON_RUNTIME,
-          },
-          DEFAULT_GATEWAY_DAEMON_RUNTIME,
-        );
-        const tokenResolution = await resolveGatewayInstallToken({
-          config: params.cfg,
+      const port = resolveGatewayPort(params.cfg, process.env);
+      const { programArguments, workingDirectory, environment, environmentValueSources } =
+        await buildGatewayInstallPlan({
           env: process.env,
+          port,
+          runtime: daemonRuntime,
+          existingCommand: serviceState.command,
+          warn: (message, title) => note(message, title),
+          config: params.cfg,
         });
-        for (const warning of tokenResolution.warnings) {
-          note(warning, "Gateway");
-        }
-        if (tokenResolution.unavailableReason) {
-          note(
-            [
-              "Gateway service install aborted.",
-              tokenResolution.unavailableReason,
-              "Fix gateway auth config/token input and rerun doctor.",
-            ].join("\n"),
-            "Gateway",
-          );
-          return;
-        }
-        const port = resolveGatewayPort(params.cfg, process.env);
-        const { programArguments, workingDirectory, environment, environmentValueSources } =
-          await buildGatewayInstallPlan({
-            env: process.env,
-            port,
-            runtime: daemonRuntime,
-            existingCommand: serviceState.command,
-            warn: (message, title) => note(message, title),
-            config: params.cfg,
-          });
-        try {
-          await service.install({
-            env: process.env,
-            stdout: process.stdout,
-            programArguments,
-            workingDirectory,
-            environment,
-            environmentValueSources,
-          });
-        } catch (err) {
-          note(`Gateway service install failed: ${String(err)}`, "Gateway");
-          note(gatewayInstallErrorHint(), "Gateway");
-        }
+      try {
+        await service.install({
+          env: process.env,
+          stdout: process.stdout,
+          programArguments,
+          workingDirectory,
+          environment,
+          environmentValueSources,
+        });
+      } catch (err) {
+        note(`Gateway service install failed: ${String(err)}`, "Gateway");
+        note(gatewayInstallErrorHint(), "Gateway");
       }
     }
     return;

--- a/src/flows/doctor-health.test-support.ts
+++ b/src/flows/doctor-health.test-support.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   runContributions: vi.fn<(ctx: DoctorHealthFlowContext) => Promise<void>>(),
   writeUpdatePostInstallDoctorResult: vi.fn(),
   service: vi.fn(),
+  probePortUsage: vi.fn<(typeof import("../infra/ports-probe.js"))["probePortUsage"]>(),
   packageRoot: vi.fn<() => string | undefined>(),
   restartedHealthy: true,
   emulateNativeInstall: true,
@@ -34,6 +35,13 @@ vi.mock("../infra/openclaw-root.js", async (importOriginal) => ({
 vi.mock("../daemon/service.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../daemon/service.js")>()),
   resolveGatewayService: () => mocks.service(),
+}));
+
+// Service absence requires a free port too; never consult the host Gateway
+// while exercising the fixture's in-memory native manager.
+vi.mock("../infra/ports-probe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/ports-probe.js")>()),
+  probePortUsage: mocks.probePortUsage,
 }));
 
 vi.mock("../config/paths.js", async (importOriginal) => {

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -75,6 +75,7 @@ describe("runDoctorHealthFlow", () => {
     mocks.config.mockReturnValue({});
     mocks.packageRoot.mockReturnValue(undefined);
     mocks.service.mockReset();
+    mocks.probePortUsage.mockReset().mockResolvedValue("free");
     mocks.restartedHealthy = true;
     mocks.emulateNativeInstall = true;
     mocks.servicePlatform = undefined;
@@ -104,6 +105,8 @@ describe("runDoctorHealthFlow", () => {
       "unresolved-respawning",
       "absent",
       "absent-unknown",
+      "absent-busy-port",
+      "absent-unknown-port",
       "windows-ready",
       "windows-disabled",
       "windows-queued",
@@ -126,6 +129,9 @@ describe("runDoctorHealthFlow", () => {
         )) {
           vi.stubEnv(key, value);
         }
+      }
+      if (kind === "absent-busy-port" || kind === "absent-unknown-port") {
+        mocks.probePortUsage.mockResolvedValue(kind === "absent-busy-port" ? "busy" : "unknown");
       }
       const windows = kind.startsWith("windows");
       mocks.emulateNativeInstall = kind !== "runtime-only";
@@ -269,6 +275,9 @@ describe("runDoctorHealthFlow", () => {
           expect(fs.existsSync(databasePath)).toBe(false);
           expect(fs.existsSync(coordinatorPath)).toBe(false);
           expect(mocks.outro).not.toHaveBeenCalledWith("Doctor complete.");
+        }
+        if (kind === "absent" || kind === "absent-busy-port" || kind === "absent-unknown-port") {
+          expect(mocks.probePortUsage).toHaveBeenCalledOnce();
         }
         if (windows) {
           expect(mocks.taskDefinitelyStopped).toHaveBeenCalled();


### PR DESCRIPTION
Closes #137457

## What Problem This Solves

Fixes an issue where operators diagnosing a remote Gateway with ordinary guided Doctor could be prompted to start or restart a local Gateway after the remote health check failed. Accepting that prompt acted on the local service, not the remote endpoint. A loopback remote URL can be an SSH tunnel and has the same ownership distinction.

## Why This Change Was Made

Remote exclusion now happens once at the local daemon-recovery entry, regardless of whether health succeeded, failed, or was intentionally skipped. This removes redundant remote checks below that boundary while leaving local recovery, explicit maintenance, native commands, external-supervisor policy, and installed user services in managed containers intact.

The broader proof exposed an existing maintenance fixture that faked the service manager but still probed the real host port. Its port boundary is now isolated, with busy/unknown-port refusal controls. Duplicate daemon-policy tests were consolidated without removing scenarios or suppressing the line limit. No production maintenance or storage policy changed.

## User Impact

Failed remote health remains a connection diagnostic and no longer triggers local install/start/restart/bootstrap prompts. Local guided recovery still works when its existing ownership and consent checks allow it. Other Doctor config and state checks retain their existing posture; ordinary Doctor is not made read-only.

[Doctor recovery guidance](https://docs.openclaw.ai/cli/doctor) explains where to recover a remote Gateway. Separate stale legacy/dueling-service referrals remain a tracked follow-up rather than widening native action authority here.

## Evidence

- Exact baseline `41344e0b7dbd5629f797c535c985fd87a323abe5`: **19 intended failures, 45 passing controls, zero skipped** in the expanded daemon suite. The baseline owner is byte-identical to its stable `v2026.8.2` source.
- The matrix covers remote failures with local stopped/unknown/running/missing services, a loopback tunnel, and a missing remote URL across simulated macOS/Linux/Windows adapters, plus healthy and skipped-health controls.
- The composition regression runs the real ordered Gateway-health and Gateway-daemon contributions with real `checkGatewayHealth`/`callGateway`. Missing remote URL fails before opening a socket, records failed/non-skipped health, and no longer reaches local recovery. Native adapters and terminal sinks are fake.
- Final six-suite proof: **459 passed, zero failed/skipped**. This includes explicit maintenance, local recovery, managed-container eligibility, Gateway call/credential selection, and all four busy/unknown-port refusal cases.
- **Complete changed gate passed**, including formatting, core and test typechecks, lint, dead-export scans, and selected guards.
- Fresh final-scope Codex autoreview: **scoped-clean at P0**, no findings. This is the configured priority scope, not an all-priority audit.

Test command, executed with private HOME/state/config/cache and the repository-pinned runtime (JSON report destination omitted):

```bash
node scripts/run-vitest.mjs src/commands/doctor-gateway-daemon-flow.test.ts src/commands/doctor-service-repair-policy.test.ts src/commands/doctor-gateway-health.test.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health.test.ts src/gateway/call.test.ts --reporter=json
```

Changed gate:

```bash
node scripts/check-changed.mjs -- src/commands/doctor-gateway-daemon-flow.ts src/commands/doctor-gateway-daemon-flow.test.ts src/flows/doctor-health.test.ts src/flows/doctor-health.test-support.ts docs/cli/doctor.md
```

The first broad attempt exposed two absent-service fixture failures (204/206 passed in its first shard). Its unsuccessful report set was retained, not presented as green. After isolating the fixture's port probe, all 460 tests passed. The subsequent line-limit failure was repaired by table-driving equivalent external-policy and explicit-consent cases, and moving a duplicate mock-only default-identity test's inspection assertions into the existing noninteractive control. The final 459-test run and complete five-file gate both passed. No assertion, safety condition, timeout, or baseline was weakened.

**Proof boundary:** no full native-service CLI E2E or real remote Gateway recovery is claimed. The development host runs an operator-owned Gateway; a temporary HOME does not isolate its native manager, so reproduction used existing fake service adapters. The real health producer/caller/recovery composition and local-positive controls are covered without operating that service. No browser layout changed.

Production: **+76/-81, net -5** (mostly outdenting the existing install block). Tests/test support: **+109/-64, net +45**. Docs: **+11**. No config option, schema/store change, dependency change, public protocol change, or new production test seam.

## Maintainer review and CI

Maintainer disposition for [the completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/137465#issuecomment-5530110917): **data-model compatibility proof is not applicable to this change**.

The complete production diff is confined to `src/commands/doctor-gateway-daemon-flow.ts`. It adds an early remote-mode return and removes redundant remote checks; the existing local `service.install` payload is unchanged apart from indentation. No config schema, SQLite schema/version, serialized representation, migration, retention rule, persistence owner, or native service definition format changes. The two maintenance-test files only replace a real host-port probe with a typed fixture and verify busy/unknown refusal. Existing private-store migration and preservation assertions still run. No migration or store change is needed to address the automated `unknown-data-model-change` classification.

[CI run 33788233736](https://github.com/openclaw/openclaw/actions/runs/33788233736) completed successfully on exact head `9314addba65b634cd8b28fdfae6a6f59ac87f9f8`, attempt 1. Final local proof is 459/459 passing tests, the complete changed gate, and fresh scoped-clean P0 autoreview. The 19 fail-first regressions include the real ordered health/recovery composition; original local recovery and explicit maintenance remain covered. Exact commands are in the PR body.

Native main baseline `0bc6bdc0b8d2f7a5c202c360c94ad5668dee69c1` has no drift in the 18 compared owner/context/package/lock paths since the tested base. Production is net -5 lines. Full native-service CLI E2E remains explicitly unclaimed; no operator service was operated. The source head has not changed since final proof. Proceeding through the native preparation and merge gates.
