### PR TITLE
improve: remove repeated SDK registration test setup

### DIFF
--- a/test/scripts/sync-plugin-sdk-exports.test.ts
+++ b/test/scripts/sync-plugin-sdk-exports.test.ts
@@ -215,10 +215,10 @@ describe("plugin SDK registration CLI", () => {
     expect(readOutputs(root)).toEqual(synced);
   });
 
-  it.each(literalEntries)("packs %s without private types or test-only exports", (entry) => {
+  it("packs literal entry names without private types or test-only exports", () => {
     const root = createFixture({
-      entries: ["public-entry", entry, "test-fixtures"],
-      privateEntries: [entry, "test-fixtures", "qa-lab"],
+      entries: ["public-entry", ...literalEntries, "test-fixtures"],
+      privateEntries: [...literalEntries, "test-fixtures", "qa-lab"],
     });
     const included = [
       "assets/public.txt",
@@ -226,7 +226,7 @@ describe("plugin SDK registration CLI", () => {
       "dist/plugin-sdk/owner-extra.d.ts",
       "dist/plugin-sdk/public-entry.js",
       "dist/plugin-sdk/public-entry.d.ts",
-      `dist/plugin-sdk/${entry}.js`,
+      ...literalEntries.map((entry) => `dist/plugin-sdk/${entry}.js`),
     ];
     const excluded = [
       "assets/internal.txt",
@@ -236,7 +236,7 @@ describe("plugin SDK registration CLI", () => {
       "dist/plugin-sdk/.tsbuildinfo",
       "dist/plugin-sdk/qa-lab.js",
       "dist/plugin-sdk/owner_entry.json",
-      `dist/plugin-sdk/${entry}.d.ts`,
+      ...literalEntries.map((entry) => `dist/plugin-sdk/${entry}.d.ts`),
       "dist/plugin-sdk/test-fixtures.js",
       "dist/plugin-sdk/test-fixtures.d.ts",
     ];
@@ -259,7 +259,7 @@ describe("plugin SDK registration CLI", () => {
     );
     expect(readPackage(root).files).toEqual([
       ...fixtureFiles,
-      `!dist/plugin-sdk/${entry}.d.ts`,
+      ...literalEntries.map((entry) => `!dist/plugin-sdk/${entry}.d.ts`),
       "!dist/plugin-sdk/test-fixtures.d.ts",
       "!dist/plugin-sdk/test-fixtures.js",
     ]);
@@ -269,7 +269,12 @@ describe("plugin SDK registration CLI", () => {
         types: "./dist/plugin-sdk/public-entry.d.ts",
         default: "./dist/plugin-sdk/public-entry.js",
       },
-      [`./plugin-sdk/${entry}`]: { default: `./dist/plugin-sdk/${entry}.js` },
+      ...Object.fromEntries(
+        literalEntries.map((entry) => [
+          `./plugin-sdk/${entry}`,
+          { default: `./dist/plugin-sdk/${entry}.js` },
+        ]),
+      ),
     });
     for (const { file, prefix } of declarationConfigs) {
       expect(readConfig(root, file).compilerOptions.paths).toEqual({
@@ -278,9 +283,12 @@ describe("plugin SDK registration CLI", () => {
           `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/custom.d.ts`,
           "./override.d.ts",
         ],
-        [`openclaw/plugin-sdk/${entry}`]: [
-          `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/${entry}.d.ts`,
-        ],
+        ...Object.fromEntries(
+          literalEntries.map((entry) => [
+            `openclaw/plugin-sdk/${entry}`,
+            [`${prefix}packages/plugin-sdk/dist/src/plugin-sdk/${entry}.d.ts`],
+          ]),
+        ),
         "openclaw/plugin-sdk/test-fixtures": [
           `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/test-fixtures.d.ts`,
         ],
@@ -289,21 +297,19 @@ describe("plugin SDK registration CLI", () => {
     expectStableSync(root);
   });
 
-  it.each(
-    literalEntries.flatMap((entry) => ["removed", "public"].map((kind) => ({ entry, kind }))),
-  )(
-    "prunes generated aliases and exclusions when $entry becomes $kind, then re-registers it",
-    ({ entry, kind }) => {
-      const formerEntry = `former-${entry}`;
+  it.each(["removed", "public"])(
+    "prunes generated aliases and exclusions when private entries become %s, then re-registers them",
+    (kind) => {
+      const formerEntries = literalEntries.map((entry) => `former-${entry}`);
       const root = createFixture({
-        entries: ["private-entry", "test-fixtures", formerEntry],
-        privateEntries: ["private-entry", "test-fixtures", formerEntry],
+        entries: ["private-entry", "test-fixtures", ...formerEntries],
+        privateEntries: ["private-entry", "test-fixtures", ...formerEntries],
       });
       expect(runSync(root).status).toBe(0);
       writeJson(root, entryList, [
         "private-entry",
         "test-fixtures",
-        ...(kind === "public" ? [formerEntry] : []),
+        ...(kind === "public" ? formerEntries : []),
       ]);
       writeJson(root, privateList, ["private-entry", "test-fixtures"]);
       const manifest = readPackage(root);
@@ -317,8 +323,10 @@ describe("plugin SDK registration CLI", () => {
         ...retained,
         "!dist/plugin-sdk/private-entry.js",
         "!dist/plugin-sdk/private-entry.d.ts",
-        `!dist/plugin-sdk/${formerEntry}.js`,
-        `!dist/plugin-sdk/${formerEntry}.d.ts`,
+        ...formerEntries.flatMap((entry) => [
+          `!dist/plugin-sdk/${entry}.js`,
+          `!dist/plugin-sdk/${entry}.d.ts`,
+        ]),
       ];
       writeJson(root, "package.json", manifest);
 
@@ -342,30 +350,36 @@ describe("plugin SDK registration CLI", () => {
         });
       }
       const exports = readPackage(root).exports;
-      expect(exports[`./plugin-sdk/${formerEntry}`]).toEqual(
-        kind === "public"
-          ? {
-              types: `./dist/plugin-sdk/${formerEntry}.d.ts`,
-              default: `./dist/plugin-sdk/${formerEntry}.js`,
-            }
-          : undefined,
-      );
+      for (const entry of formerEntries) {
+        expect(exports[`./plugin-sdk/${entry}`]).toEqual(
+          kind === "public"
+            ? {
+                types: `./dist/plugin-sdk/${entry}.d.ts`,
+                default: `./dist/plugin-sdk/${entry}.js`,
+              }
+            : undefined,
+        );
+      }
       expectStableSync(root);
-      writeJson(root, entryList, ["private-entry", "test-fixtures", formerEntry]);
-      writeJson(root, privateList, ["private-entry", "test-fixtures", formerEntry]);
+      writeJson(root, entryList, ["private-entry", "test-fixtures", ...formerEntries]);
+      writeJson(root, privateList, ["private-entry", "test-fixtures", ...formerEntries]);
       expect(runSync(root).status).toBe(0);
       expect(readPackage(root).files).toEqual([
         ...retained,
-        `!dist/plugin-sdk/${formerEntry}.d.ts`,
+        ...formerEntries.map((entry) => `!dist/plugin-sdk/${entry}.d.ts`),
       ]);
       for (const { file, prefix } of declarationConfigs) {
-        expect(
-          readConfig(root, file).compilerOptions.paths[`openclaw/plugin-sdk/${formerEntry}`],
-        ).toEqual([`${prefix}packages/plugin-sdk/dist/src/plugin-sdk/${formerEntry}.d.ts`]);
+        for (const entry of formerEntries) {
+          expect(
+            readConfig(root, file).compilerOptions.paths[`openclaw/plugin-sdk/${entry}`],
+          ).toEqual([`${prefix}packages/plugin-sdk/dist/src/plugin-sdk/${entry}.d.ts`]);
+        }
       }
-      expect(readPackage(root).exports[`./plugin-sdk/${formerEntry}`]).toEqual({
-        default: `./dist/plugin-sdk/${formerEntry}.js`,
-      });
+      for (const entry of formerEntries) {
+        expect(readPackage(root).exports[`./plugin-sdk/${entry}`]).toEqual({
+          default: `./dist/plugin-sdk/${entry}.js`,
+        });
+      }
       expectStableSync(root);
     },
   );


### PR DESCRIPTION
## What Problem This Solves

The SDK registration regression suite starts the same sync CLI and npm packaging flows separately for three literal-name variants. Most of that setup and process startup is repeated work.

## Why This Change Was Made

Exercise all three spellings in one real npm packing fixture and retain two separate lifecycle fixtures for removal and promotion back to public. Each fixture still checks every spelling, exact exports, declaration aliases, ordered exclusions, re-registration, and byte-idempotent sync/check behavior. The six independent drift, per-config, repair and stale-facade controls are unchanged.

This reduces the suite from 15 to 9 case instances. Source-derived child counts fall from 63 sync CLI calls plus 3 npm pack calls to 29 plus 1: 36 fewer launches. No production code, test helper, package contract or shard configuration changes.

## User Impact

Faster development tests with the same SDK packaging and registration coverage. No end-user behavior change.

## Evidence

- Same-base local Node 24 full-suite wall time: 10.42s before; 6.00s and 5.47s after. All 15 baseline cases and all 9 consolidated cases pass.
- Historical negative control: restoring only the pre-#132645 root-metadata function makes the consolidated pack test detect leaked declarations for all three names and test-only files, both lifecycle tests detect stale exclusions, and the existing drift test detect incorrect success. The other five controls pass. Restoring current production bytes returns the suite to 9/9 passing.
- Native [CI run 33788773714](https://github.com/openclaw/openclaw/actions/runs/33788773714) is green: 81 passed / 17 skipped. All nine consolidated SDK cases pass in the actual selected tooling group; Windows was not selected.
- Required changed-file gate passes, including typecheck, formatting, lint and repository guards. Independent Codex review is clean through P2.

The timing is an isolated local measurement, not an overall CI claim. Production/tooling LOC delta: 0. Test-only diff: +52/-38; the additional expectation mapping lets the retained contracts share fixture setup.
