### PR TITLE
fix: resume parents after sibling subagents settle

### DIFF
--- a/src/agents/subagents/registry/subagent-registry.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.test.ts
@@ -20,7 +20,10 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { GatewayRecoveryRuntime } from "../../../gateway/server-instance-runtime.types.js";
 import type { AgentEventPayload } from "../../../infra/agent-events.js";
 import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
-import { getPluginRuntimeGatewayRequestScope } from "../../../plugins/runtime/gateway-request-scope.js";
+import {
+  getPluginRuntimeGatewayRequestScope,
+  getSharedGatewayContextResolver,
+} from "../../../plugins/runtime/gateway-request-scope.js";
 import {
   getActiveGatewayRootWorkCount,
   markGatewayRestartDraining,
@@ -2067,6 +2070,25 @@ describe("subagent registry seam flow", () => {
     const run = findRequesterRun("run-interrupted-wait");
     expect(run?.execution.endedAt).toBeUndefined();
     expect(run?.execution.outcome).toBeUndefined();
+  });
+
+  it("shares the lifecycle Gateway resolver across fallback sibling registrations", () => {
+    mockPendingAgentWait();
+    const activeGatewayContext = { recoveryRuntime } as never;
+    mod.activateSubagentRegistry(
+      () =>
+        ({
+          recoveryRuntime,
+          resolveGatewayContext: () => activeGatewayContext,
+        }) as never,
+    );
+
+    mod.registerSubagentRun({ runId: "run-sibling-first", task: "first sibling" });
+    mod.registerSubagentRun({ runId: "run-sibling-second", task: "second sibling" });
+
+    const first = expectDefined(mod.getSubagentRunByRunId("run-sibling-first"));
+    const second = expectDefined(mod.getSubagentRunByRunId("run-sibling-second"));
+    expect(getSharedGatewayContextResolver([first, second])?.()).toBe(activeGatewayContext);
   });
 
   it("detaches subagent completion from a disposed requester transcript owner", async () => {

--- a/src/agents/subagents/registry/subagent-registry.ts
+++ b/src/agents/subagents/registry/subagent-registry.ts
@@ -68,6 +68,7 @@ const subagentRegistryBootstrapState: {
 
 const resumeRetryTimers = new Set<ReturnType<typeof setTimeout>>();
 let activeGatewayContextResolver: GatewayContextResolver | undefined;
+let activeLifecycleGatewayContextResolver: GatewayContextResolver | undefined;
 const SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
 const GATEWAY_ADMISSION_RETRY_DELAY_MS = 1_000;
 /** Admission pressure for recoverable completion deliveries; rows are never pruned for capacity. */
@@ -330,8 +331,7 @@ const subagentRestorer = createSubagentRegistryRestorer({
   runs: subagentRuns,
   resumedRuns,
   deps: () => subagentRegistryDeps,
-  getGatewayContextResolver: () =>
-    fenceScheduledGatewayContextResolver(activeGatewayContextResolver),
+  getGatewayContextResolver: () => activeLifecycleGatewayContextResolver,
   persist: persistSubagentRuns,
   persistOrThrow: persistSubagentRunsOrThrow,
   settleRequesterTurn: settleRequesterTurnAfterSessionSpawns,
@@ -479,9 +479,7 @@ export const releaseSubagentRunKillClaim = subagentRunManager.releaseSubagentRun
 export function registerSubagentRun(params: RegisterSubagentRunParams): void {
   subagentRunManager.registerSubagentRun({
     ...params,
-    gatewayContextResolver:
-      params.gatewayContextResolver ??
-      fenceScheduledGatewayContextResolver(activeGatewayContextResolver),
+    gatewayContextResolver: params.gatewayContextResolver ?? activeLifecycleGatewayContextResolver,
   });
 }
 export const startQueuedSubagentRun = subagentRunManager.startQueuedSubagentRun;
@@ -558,6 +556,7 @@ function resetSubagentRegistryForTests(opts?: { persist?: boolean }) {
   subagentSweeper.reset();
   subagentRestorer.reset();
   activeGatewayContextResolver = undefined;
+  activeLifecycleGatewayContextResolver = undefined;
   subagentListener.reset();
   if (opts?.persist !== false) {
     persistSubagentRuns();
@@ -617,6 +616,7 @@ export function activateSubagentRegistry(resolveGatewayContext: GatewayContextRe
   const lifecycleGatewayContextResolver =
     fenceScheduledGatewayContextResolver(resolveGatewayContext);
   activeGatewayContextResolver = resolveGatewayContext;
+  activeLifecycleGatewayContextResolver = lifecycleGatewayContextResolver;
   for (const entry of subagentRuns.values()) {
     // Deserialized rows have no in-memory owner. The activating Gateway may
     // claim those rows once, but must not replace a live run's exact owner.


### PR DESCRIPTION
Superseded by #137606, which fixed #137467.

## What Problem This Solves

Fixes an issue where a parent agent that called `sessions_yield` could remain paused after multiple sibling subagents completed. Their results were persisted, but the final requester-settle wake could fail before reaching the parent session.

## Why This Change Was Made

The subagent registry now creates one lifecycle-fenced Gateway resolver when activated and reuses it for registry-owned fallback registrations and restoration. This preserves the existing rejection of genuinely mixed Gateway owners while allowing siblings from the same lifecycle to share a valid direct-delivery binding.

## User Impact

Parent sessions reliably resume after their sibling subagents settle instead of waiting indefinitely for another user message.

## Evidence

- Added a regression test for two fallback sibling registrations.
- The test reproduced the failure before the fix: the shared resolver returned `undefined`.
- `pnpm test src/agents/subagents/registry/subagent-registry.test.ts` — 153 passed.
- `pnpm exec oxfmt --check src/agents/subagents/registry/subagent-registry.ts src/agents/subagents/registry/subagent-registry.test.ts` — passed.
- `pnpm exec oxlint src/agents/subagents/registry/subagent-registry.ts src/agents/subagents/registry/subagent-registry.test.ts` — 0 warnings, 0 errors.
- `git diff --check $(git merge-base HEAD origin/main)` — passed.

---
[View the OpenClaw team session](https://openclaw-fsn1.tailf72dd7.ts.net/chat/main/dashboard/b162ae20-933b-4db5-97f1-ee4cd07179e4)
