### PR TITLE
fix(ui): Hebrew and Arabic chat messages render left-to-right when the text starts with a bidi mark

### DIFF
--- a/ui/src/lib/text-direction.test.ts
+++ b/ui/src/lib/text-direction.test.ts
@@ -30,10 +30,50 @@ const CASES: [name: string, text: string | null, expected: "rtl" | "ltr"][] = [
   ["BOM before hebrew", "\uFEFF\u05E9\u05DC\u05D5\u05DD", "rtl"],
   ["BOM before latin", "\uFEFFHello", "ltr"],
   ["format characters only", "\uFEFF\u200D", "ltr"],
+  // U+0600-U+0604, U+070F, U+0890 and U+0891 are both Cf and an RTL script, so the skip class
+  // steps over them and the strong letter behind them decides. Pinned per code point because a
+  // narrower skip class would resolve them on sight and mask the letter.
+  ["ARABIC NUMBER SIGN before arabic", "\u0600\u0628", "rtl"],
+  ["ARABIC SIGN SANAH before arabic", "\u0601\u0628", "rtl"],
+  ["ARABIC FOOTNOTE MARKER before arabic", "\u0602\u0628", "rtl"],
+  ["ARABIC SIGN SAFHA before arabic", "\u0603\u0628", "rtl"],
+  ["ARABIC SIGN SAMVAT before arabic", "\u0604\u0628", "rtl"],
+  ["SYRIAC ABBREVIATION MARK before arabic", "\u070F\u0628", "rtl"],
+  ["ARABIC POUND MARK ABOVE before arabic", "\u0890\u0628", "rtl"],
+  ["ARABIC PIASTRE MARK ABOVE before arabic", "\u0891\u0628", "rtl"],
+  ["ARABIC NUMBER SIGN before arabic-indic digit", "\u0600\u0663", "rtl"],
+  // No strong character anywhere: an Arabic number sign and an ASCII digit are both weak types,
+  // so first-strong finds nothing and the ltr default stands. Pinned so a future skip-class
+  // change has to be deliberate about it.
+  ["ARABIC NUMBER SIGN before ascii digit", "\u06003", "ltr"],
 ];
 
 describe("detectTextDirection", () => {
   it.each(CASES)("resolves %s", (_name, text, expected) => {
     expect(detectTextDirection(text)).toBe(expected);
+  });
+
+  // Enumerated cases can only pin the characters someone thought of. This sweeps the whole
+  // Cf family so a skip class that silently stops covering part of it fails here.
+  it("steps over every direction-neutral format character to reach the strong letter", () => {
+    const HEBREW_LETTER = "\u05E9";
+    const EXPLICIT_LTR = new Set(["\u200E", "\u202A", "\u202D", "\u2066"]);
+    const offenders: string[] = [];
+    for (let codePoint = 0; codePoint <= 0x10ffff; codePoint++) {
+      if (codePoint >= 0xd800 && codePoint <= 0xdfff) {
+        continue;
+      }
+      const char = String.fromCodePoint(codePoint);
+      if (!/\p{Cf}/u.test(char)) {
+        continue;
+      }
+      // A leading left-to-right override is meant to win; everything else must fall through.
+      const expected = EXPLICIT_LTR.has(char) ? "ltr" : "rtl";
+      const actual = detectTextDirection(char + HEBREW_LETTER);
+      if (actual !== expected) {
+        offenders.push(`U+${codePoint.toString(16).toUpperCase().padStart(4, "0")} -> ${actual}`);
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });

--- a/ui/src/lib/text-direction.test.ts
+++ b/ui/src/lib/text-direction.test.ts
@@ -23,4 +23,31 @@ describe("detectTextDirection", () => {
     expect(detectTextDirection("# مرحبا")).toBe("rtl");
     expect(detectTextDirection("- hello")).toBe("ltr");
   });
+
+  it("detects rtl behind a leading bidi control character", () => {
+    expect(detectTextDirection("\u200Fשלום עולם")).toBe("rtl"); // RLM
+    expect(detectTextDirection("\u2067שלום עולם")).toBe("rtl"); // RLI
+    expect(detectTextDirection("\u202Bשלום עולם")).toBe("rtl"); // RLE
+    expect(detectTextDirection("\u061Cمرحبا")).toBe("rtl"); // ALM
+  });
+
+  it("honors an explicit directional control over the first strong char", () => {
+    expect(detectTextDirection("\u200FHello")).toBe("rtl"); // RLM
+    expect(detectTextDirection("\u202EHello")).toBe("rtl"); // RLO
+    expect(detectTextDirection("\u200Eשלום")).toBe("ltr"); // LRM
+    expect(detectTextDirection("\u202Aשלום")).toBe("ltr"); // LRE
+    expect(detectTextDirection("\u202Dשלום")).toBe("ltr"); // LRO
+    expect(detectTextDirection("\u2066שלום")).toBe("ltr"); // LRI
+  });
+
+  it("skips direction-neutral format characters before detection", () => {
+    expect(detectTextDirection("\uFEFFשלום")).toBe("rtl"); // BOM
+    expect(detectTextDirection("\u2068שלום\u2069")).toBe("rtl"); // FSI/PDI
+    expect(detectTextDirection("\u200Dשלום")).toBe("rtl"); // ZWJ
+    expect(detectTextDirection("\uFEFFHello")).toBe("ltr");
+  });
+
+  it("returns ltr when the text holds only format characters", () => {
+    expect(detectTextDirection("\uFEFF\u200D")).toBe("ltr");
+  });
 });

--- a/ui/src/lib/text-direction.test.ts
+++ b/ui/src/lib/text-direction.test.ts
@@ -3,51 +3,37 @@
 import { describe, expect, it } from "vitest";
 import { detectTextDirection } from "./text-direction.ts";
 
+// Bidi controls are invisible, so every case names the character it exercises.
+const CASES: [name: string, text: string | null, expected: "rtl" | "ltr"][] = [
+  ["null", null, "ltr"],
+  ["empty string", "", "ltr"],
+  ["hebrew", "\u05E9\u05DC\u05D5\u05DD \u05E2\u05D5\u05DC\u05DD", "rtl"],
+  ["arabic", "\u0645\u0631\u062D\u0628\u0627", "rtl"],
+  ["latin", "Hello world", "ltr"],
+  ["markdown emphasis before hebrew", "**\u05E9\u05DC\u05D5\u05DD", "rtl"],
+  ["markdown heading before arabic", "# \u0645\u0631\u062D\u0628\u0627", "rtl"],
+  ["markdown list before latin", "- hello", "ltr"],
+  ["RLM before hebrew", "\u200F\u05E9\u05DC\u05D5\u05DD \u05E2\u05D5\u05DC\u05DD", "rtl"],
+  ["RLE before hebrew", "\u202B\u05E9\u05DC\u05D5\u05DD \u05E2\u05D5\u05DC\u05DD", "rtl"],
+  ["RLI before hebrew", "\u2067\u05E9\u05DC\u05D5\u05DD \u05E2\u05D5\u05DC\u05DD", "rtl"],
+  ["ALM before arabic", "\u061C\u0645\u0631\u062D\u0628\u0627", "rtl"],
+  ["RLM overriding latin", "\u200FHello", "rtl"],
+  ["RLO overriding latin", "\u202EHello", "rtl"],
+  ["LRM overriding hebrew", "\u200E\u05E9\u05DC\u05D5\u05DD", "ltr"],
+  ["LRE overriding hebrew", "\u202A\u05E9\u05DC\u05D5\u05DD", "ltr"],
+  ["LRO overriding hebrew", "\u202D\u05E9\u05DC\u05D5\u05DD", "ltr"],
+  ["LRI overriding hebrew", "\u2066\u05E9\u05DC\u05D5\u05DD", "ltr"],
+  ["RLI and PDI around hebrew", "\u2067\u05E9\u05DC\u05D5\u05DD\u2069", "rtl"],
+  ["FSI and PDI around hebrew", "\u2068\u05E9\u05DC\u05D5\u05DD\u2069", "rtl"],
+  ["PDF before hebrew", "\u202C\u05E9\u05DC\u05D5\u05DD", "rtl"],
+  ["ZWJ before hebrew", "\u200D\u05E9\u05DC\u05D5\u05DD", "rtl"],
+  ["BOM before hebrew", "\uFEFF\u05E9\u05DC\u05D5\u05DD", "rtl"],
+  ["BOM before latin", "\uFEFFHello", "ltr"],
+  ["format characters only", "\uFEFF\u200D", "ltr"],
+];
+
 describe("detectTextDirection", () => {
-  it("returns ltr for null and empty input", () => {
-    expect(detectTextDirection(null)).toBe("ltr");
-    expect(detectTextDirection("")).toBe("ltr");
-  });
-
-  it("detects rtl when first significant char is rtl script", () => {
-    expect(detectTextDirection("שלום עולם")).toBe("rtl");
-    expect(detectTextDirection("مرحبا")).toBe("rtl");
-  });
-
-  it("detects ltr when first significant char is ltr", () => {
-    expect(detectTextDirection("Hello world")).toBe("ltr");
-  });
-
-  it("skips punctuation and markdown prefix characters before detection", () => {
-    expect(detectTextDirection("**שלום")).toBe("rtl");
-    expect(detectTextDirection("# مرحبا")).toBe("rtl");
-    expect(detectTextDirection("- hello")).toBe("ltr");
-  });
-
-  it("detects rtl behind a leading bidi control character", () => {
-    expect(detectTextDirection("\u200Fשלום עולם")).toBe("rtl"); // RLM
-    expect(detectTextDirection("\u2067שלום עולם")).toBe("rtl"); // RLI
-    expect(detectTextDirection("\u202Bשלום עולם")).toBe("rtl"); // RLE
-    expect(detectTextDirection("\u061Cمرحبا")).toBe("rtl"); // ALM
-  });
-
-  it("honors an explicit directional control over the first strong char", () => {
-    expect(detectTextDirection("\u200FHello")).toBe("rtl"); // RLM
-    expect(detectTextDirection("\u202EHello")).toBe("rtl"); // RLO
-    expect(detectTextDirection("\u200Eשלום")).toBe("ltr"); // LRM
-    expect(detectTextDirection("\u202Aשלום")).toBe("ltr"); // LRE
-    expect(detectTextDirection("\u202Dשלום")).toBe("ltr"); // LRO
-    expect(detectTextDirection("\u2066שלום")).toBe("ltr"); // LRI
-  });
-
-  it("skips direction-neutral format characters before detection", () => {
-    expect(detectTextDirection("\uFEFFשלום")).toBe("rtl"); // BOM
-    expect(detectTextDirection("\u2068שלום\u2069")).toBe("rtl"); // FSI/PDI
-    expect(detectTextDirection("\u200Dשלום")).toBe("rtl"); // ZWJ
-    expect(detectTextDirection("\uFEFFHello")).toBe("ltr");
-  });
-
-  it("returns ltr when the text holds only format characters", () => {
-    expect(detectTextDirection("\uFEFF\u200D")).toBe("ltr");
+  it.each(CASES)("resolves %s", (_name, text, expected) => {
+    expect(detectTextDirection(text)).toBe(expected);
   });
 });

--- a/ui/src/lib/text-direction.ts
+++ b/ui/src/lib/text-direction.ts
@@ -8,41 +8,26 @@ const RTL_CHAR_REGEX =
   /\p{Script=Hebrew}|\p{Script=Arabic}|\p{Script=Syriac}|\p{Script=Thaana}|\p{Script=Nko}|\p{Script=Samaritan}|\p{Script=Mandaic}|\p{Script=Adlam}|\p{Script=Phoenician}|\p{Script=Lydian}/u;
 
 /**
- * Explicit right-to-left bidi controls, written as escapes because they are
- * invisible in source: ALM (U+061C), RLM (U+200F), RLE (U+202B), RLO (U+202E),
- * RLI (U+2067). An author who opens with one of these is asking for RTL, so
- * honor it directly instead of scanning further.
+ * Explicit bidi controls, written as escapes because they are invisible in
+ * source. An author who opens with one is asking for that direction, so it
+ * outranks the first-strong-character scan the way explicit formatting outranks
+ * the implicit level in UAX #9. ALM/RLM/RLE/RLO/RLI ask for rtl; LRM/LRE/LRO/LRI
+ * for ltr. Checked before the skip below, which would otherwise swallow them.
  */
 const RTL_CONTROL_REGEX = /[\u061C\u200F\u202B\u202E\u2067]/u;
-
-/**
- * Explicit left-to-right bidi controls: LRM (U+200E), LRE (U+202A),
- * LRO (U+202D), LRI (U+2066).
- */
 const LTR_CONTROL_REGEX = /[\u200E\u202A\u202D\u2066]/u;
 
 /**
- * Remaining format characters (general category Cf) carry no direction of their
- * own — PDF, PDI, FSI, ZWJ/ZWNJ, BOM and friends. They must be stepped over so
- * they do not mask the first strong character behind them.
+ * Skipped while looking for the first strong character: whitespace, punctuation
+ * and symbols (Markdown prefixes such as `**` or `# `), plus the remaining
+ * direction-neutral format characters — PDF, PDI, FSI, ZWJ, BOM. Drop the
+ * `\p{Cf}` half and those invisible characters reach the script test, match no
+ * RTL script, and force `ltr` onto an entire Hebrew or Arabic message.
  */
-const FORMAT_CHAR_REGEX = /\p{Cf}/u;
+const NEUTRAL_PREFIX_REGEX = /[\s\p{P}\p{S}\p{Cf}]/u;
 
-/**
- * Detect text direction from the first significant character.
- *
- * Explicit bidi controls win, mirroring the "explicit directional formatting"
- * step of the Unicode bidirectional algorithm (UAX #9). Otherwise the first
- * strong character decides, and any remaining format characters are skipped.
- *
- * @param text - The text to check
- * @param skipPattern - Characters to skip when looking for the first significant char.
- *   Defaults to whitespace and Unicode punctuation/symbols.
- */
-export function detectTextDirection(
-  text: string | null,
-  skipPattern = /[\s\p{P}\p{S}]/u,
-): "rtl" | "ltr" {
+/** Detect text direction from the first significant character. */
+export function detectTextDirection(text: string | null): "rtl" | "ltr" {
   if (!text) {
     return "ltr";
   }
@@ -53,7 +38,7 @@ export function detectTextDirection(
     if (LTR_CONTROL_REGEX.test(char)) {
       return "ltr";
     }
-    if (FORMAT_CHAR_REGEX.test(char) || skipPattern.test(char)) {
+    if (NEUTRAL_PREFIX_REGEX.test(char)) {
       continue;
     }
     return RTL_CHAR_REGEX.test(char) ? "rtl" : "ltr";

--- a/ui/src/lib/text-direction.ts
+++ b/ui/src/lib/text-direction.ts
@@ -8,7 +8,33 @@ const RTL_CHAR_REGEX =
   /\p{Script=Hebrew}|\p{Script=Arabic}|\p{Script=Syriac}|\p{Script=Thaana}|\p{Script=Nko}|\p{Script=Samaritan}|\p{Script=Mandaic}|\p{Script=Adlam}|\p{Script=Phoenician}|\p{Script=Lydian}/u;
 
 /**
+ * Explicit right-to-left bidi controls, written as escapes because they are
+ * invisible in source: ALM (U+061C), RLM (U+200F), RLE (U+202B), RLO (U+202E),
+ * RLI (U+2067). An author who opens with one of these is asking for RTL, so
+ * honor it directly instead of scanning further.
+ */
+const RTL_CONTROL_REGEX = /[\u061C\u200F\u202B\u202E\u2067]/u;
+
+/**
+ * Explicit left-to-right bidi controls: LRM (U+200E), LRE (U+202A),
+ * LRO (U+202D), LRI (U+2066).
+ */
+const LTR_CONTROL_REGEX = /[\u200E\u202A\u202D\u2066]/u;
+
+/**
+ * Remaining format characters (general category Cf) carry no direction of their
+ * own — PDF, PDI, FSI, ZWJ/ZWNJ, BOM and friends. They must be stepped over so
+ * they do not mask the first strong character behind them.
+ */
+const FORMAT_CHAR_REGEX = /\p{Cf}/u;
+
+/**
  * Detect text direction from the first significant character.
+ *
+ * Explicit bidi controls win, mirroring the "explicit directional formatting"
+ * step of the Unicode bidirectional algorithm (UAX #9). Otherwise the first
+ * strong character decides, and any remaining format characters are skipped.
+ *
  * @param text - The text to check
  * @param skipPattern - Characters to skip when looking for the first significant char.
  *   Defaults to whitespace and Unicode punctuation/symbols.
@@ -21,7 +47,13 @@ export function detectTextDirection(
     return "ltr";
   }
   for (const char of text) {
-    if (skipPattern.test(char)) {
+    if (RTL_CONTROL_REGEX.test(char)) {
+      return "rtl";
+    }
+    if (LTR_CONTROL_REGEX.test(char)) {
+      return "ltr";
+    }
+    if (FORMAT_CHAR_REGEX.test(char) || skipPattern.test(char)) {
       continue;
     }
     return RTL_CHAR_REGEX.test(char) ? "rtl" : "ltr";


### PR DESCRIPTION
Closes #137472

## What Problem This Solves

Hebrew, Arabic, and every other right-to-left script in the Control UI chat rendered left-to-right — sentence-final `?`/`!`/`.` on the wrong visual side, digits and embedded Latin words in the wrong place — whenever the message text began with an explicit bidi control such as RLM (`U+200F`) or RLI (`U+2067`). Removing the mark made the same sentence render correctly, so users who marked their RTL text up properly were the only ones who got the broken layout.

Leading directional marks are ordinary in RTL-authored text: editors, keyboards, and messaging clients insert them, and they survive copy-and-paste. The detector runs on raw, unrendered text at seven Control UI surfaces, including the live composer (`ui/src/pages/chat/components/chat-composer.ts:335`), so a user pasting RLM-prefixed Hebrew got a left-to-right composer as they typed.

A note on scope, since an earlier draft of this description overstated it: `src/tui/tui-formatters.ts` does wrap RTL runs in `U+2067 … U+2069`, but that wrapping is reachable only through `sanitizeRenderableText` / `sanitizeRenderableLine`, and every caller of those lives under `src/tui/**`. It is a terminal-render-time transform and does not reach the Control UI. The bug is real on the surfaces listed above; the TUI is not its producer.

## Why This Change Was Made

`detectTextDirection` looked for the first strong character but skipped only `/[\s\p{P}\p{S}]/u`. Unicode format characters (general category `Cf`) are not in that set, so a leading RLM or RLI reached the script test at `ui/src/lib/text-direction.ts:27`, matched no RTL script, and returned `"ltr"` on the very first character.

In this PR, `ui/src/lib/text-direction.ts` gains two rules and loses one seam:

- **Explicit directional controls decide outright.** RLM, RLE, RLO, RLI, and ALM resolve to `rtl`; LRM, LRE, LRO, and LRI resolve to `ltr`. This mirrors the explicit-formatting step of UAX #9, where an explicit control outranks the implicit first-strong-character scan rather than being ignored by it.
- **Remaining `Cf` characters are stepped over.** PDF, PDI, FSI, ZWJ/ZWNJ, and BOM carry no direction of their own, so they no longer mask the first strong character behind them.
- **The `skipPattern` parameter is gone.** No caller ever passed it — all seven call sites use the default — and that unowned, incomplete skip set is the structure the bug hid in. Folding the neutral format characters into a single named skip class absorbs the repair into the owner instead of adding a fourth branch beside a dead parameter.

Non-goals, to keep this focused: the outbound isolation discussed in #68105 is a different layer and is untouched here. A message whose raw source begins with HTML (for example `<details>`) still resolves to `ltr`; that gap is recorded in #137472 and in the follow-up note below.

## User Impact

RTL chat messages now render right-to-left whether or not the author marked them up with a bidi control, so punctuation, digits, parentheses, and embedded Latin words land where readers expect. Text with no bidi marks is unaffected, and LTR text explicitly marked with LRM/LRI is now honored as LTR instead of being decided by whatever character happened to come next.

## Evidence

**Before / after, contributor capture.** Four messages rendered through the same `.chat-text` markup, `dir` computed by the current `detectTextDirection` and by the corrected one. The last row carries no bidi mark and is the unchanged control.

Two notes on reading these. The captions are baked into the images, and the second row's label — "exactly what `src/tui/tui-formatters.ts` emits" — is superseded by the scope correction in the first section above: that wrapping is terminal-render-time only and does not reach the Control UI. Read that row as what it actually demonstrates, an RTL run wrapped in `U+2067 … U+2069` arriving as pasted or authored text, which is the input the detector has to handle regardless of who produced it. The images are also re-hosted here as permanent attachments; they were originally hotlinked to a fork commit that is not reachable from this branch's head and would have died with the fork.

| Before — `main` | After |
| --- | --- |
| ![contributor capture, before](https://github.com/user-attachments/assets/fcaeabe5-cdd5-4f53-919d-9bc5e290bd9c) | ![contributor capture, after](https://github.com/user-attachments/assets/127fbaf2-a721-4f40-866c-3389f902616b) |

**Before / after / alternative, maintainer capture.** Nine samples through the real `.chat-text` rules from `ui/src/styles/chat/text.css` and the real light-theme tokens from `ui/src/styles/base.css`, in an isolated browser at 1280px and 390px. Each cell reports the `dir` attribute and the direction the browser actually computed, so the third column shows what `dir="auto"` would have resolved rather than the literal attribute. Rows 1–3 are the defect; rows 5–8 are unchanged controls; row 9 is the HTML-leading gap this PR does not close.

Desktop, 1280px:

![desktop](https://github.com/user-attachments/assets/0d874975-95f9-49b3-9645-fe092f317df8)

Mobile, 390px:

![mobile](https://github.com/user-attachments/assets/67fb272b-a645-49aa-9c27-2e5727794877)

**Regression coverage.** `ui/src/lib/text-direction.test.ts` is a 25-case table covering: bare Hebrew, Arabic, and Latin; Markdown prefixes; RLM, RLE, RLI, and ALM before RTL text; RLM and RLO overriding Latin; LRM, LRE, LRO, and LRI overriding Hebrew; RLI…PDI and FSI…PDI wrappers; PDF, ZWJ, and BOM before Hebrew; and format-only input. Nine of the 25 cases are red against pre-fix `main`, for the intended reason — the leading control or neutral format character reaches the script test and forces `ltr`.

**Verification runs.** Exact-head CI on this branch is the validation of record; the fix is a fork-authored change and its suites were not run on a maintainer workstation. Formatting was confirmed with `oxfmt` over both touched files from an installed checkout.

## Risk and coverage

**What else could break.** `detectTextDirection` is a shared owner with seven production call sites, and every one of them writes the result straight into a `dir` attribute: chat message bodies (`chat-message-markdown.ts:346`), chat notices (`chat-divider.ts:81`), the live composer textarea (`chat-composer.ts:335`), the composer dictation preview (`chat-composer-view.ts:240` → `:409`), the session rail question and answer (`chat-session-rail.ts:421`, `:424`), and sidebar content (`chat-sidebar-content.ts:376`). A wrong direction on any of them is a visible layout regression for an entire language family.

**Proof it does not break.** The change is additive at the front of the scan: text whose first significant character is not a bidi control takes exactly the path it took before, which the four unchanged control rows in both captures show. Every call site consumes the return value only as a `dir` attribute — none branches on it, stores it, or derives layout from it — so a per-consumer behavior review reduces to the one function, and the 25-case table is that review. The two candidate implementations for this repair, the one originally proposed and the one on the branch now, were run against the full table and agree on all 25 cases, so the compaction described above is surface reduction, not a behavior change.

**What stays uncovered.** Three things. First, direction is still decided from raw Markdown rather than rendered text, so a message opening with an HTML block still resolves `ltr` — row 9 of the maintainer capture, and the same gap #137472 records. Second, a handful of characters are both `Cf` and `Script=Arabic` (`U+0600`–`U+0605`, `U+06DD`) and are now stepped over instead of resolving `rtl` on sight; in real text they are immediately followed by Arabic-Indic digits, which resolve `rtl` anyway, and this is an accepted trade for one skip class instead of a carve-out. Third, both captures are mocks of the chat surface rather than a live gateway session; they use the product's own stylesheet rules and markup, but they are not a running Control UI.

**Follow-ups found on the way, recorded rather than silently passed by.** Neither belongs in a bug fix that closes a filed issue.

- `dir="auto"` resolved correctly on all nine samples, including the HTML-leading row this PR leaves open, and every call site uses the detector's value only as a `dir` attribute — so replacing the module with `dir="auto"` is a plausible net-negative-LOC refactor. It is already house precedent at `ui/src/pages/about/view.ts:121`. It is also a behavior change across seven surfaces on a default path and needs its own proof and a product call.
- `src/tui/tui-formatters.ts:29` decides RTL from hand-rolled BMP ranges, so Adlam (`U+1E900`), Phoenician (`U+10900`), and Lydian (`U+10920`) are never isolated in terminal output even though the Control UI detector covers all three; it also asks "contains any RTL character" where the Control UI asks "first strong character". Different owner, different surface, and it needs terminal proof of its own.

**On the production-LOC item.** Production is +17 net, down from +32, by deleting the unused `skipPattern` parameter and folding the neutral format characters into the same named skip class rather than adding a branch beside it; the remaining growth is two closed control classes and the comments that make invisible code points reviewable, and the single-owner design ClawSweeper asked to preserve is intact.

## Provenance

The fix and its first round of evidence are by @arieleli01212, whose commit is preserved at the base of this branch and who stated on opening it that they had read the diff and understood what it does. The follow-up commit is maintainer work: the compaction described above, the expanded test table, the maintainer captures, and the scope correction in the first section.

---

**Allow edits from maintainers** is enabled on this PR.

