### PR TITLE
fix: exec host picker inserts canonical syntax

### DIFF
--- a/ui/src/e2e/chat-thinking-arguments.e2e.test.ts
+++ b/ui/src/e2e/chat-thinking-arguments.e2e.test.ts
@@ -16,10 +16,7 @@ const VIEWPORTS = [
 ] as const;
 
 suite.define(() => {
-  it.each([
-    ["elevated full", "/elevated full"],
-    ["exec gateway", "/exec gateway"],
-  ])("executes inline /%s separately from the draft", async (typedCommand, sentCommand) => {
+  it("executes a typed inline /elevated argument separately from the draft", async () => {
     await suite.withPage({}, async ({ page }) => {
       const gateway = await installMockGateway(page, {
         deferredMethods: ["chat.send"],
@@ -31,11 +28,34 @@ suite.define(() => {
       await composer.waitFor({ state: "visible" });
       await expect.poll(() => composer.isEnabled()).toBe(true);
 
-      await composer.fill(`Keep this /${typedCommand}`);
+      await composer.fill("Keep this /elevated full");
       await composer.press("Enter");
 
       const request = await gateway.waitForRequest("chat.send");
-      expect((request.params as { message?: unknown }).message).toBe(sentCommand);
+      expect((request.params as { message?: unknown }).message).toBe("/elevated full");
+      await expect.poll(() => composer.inputValue()).toBe("Keep this ");
+    });
+  });
+
+  it("serializes a selected inline /exec host argument canonically", async () => {
+    await suite.withPage({}, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["chat.send"],
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.waitFor({ state: "visible" });
+      await expect.poll(() => composer.isEnabled()).toBe(true);
+
+      await composer.fill("Keep this /exec");
+      await composer.press("Tab");
+      await composer.press("ArrowDown");
+      await composer.press("Enter");
+
+      const request = await gateway.waitForRequest("chat.send");
+      expect((request.params as { message?: unknown }).message).toBe("/exec host=gateway");
       await expect.poll(() => composer.inputValue()).toBe("Keep this ");
     });
   });

--- a/ui/src/lib/chat/commands.test.ts
+++ b/ui/src/lib/chat/commands.test.ts
@@ -327,6 +327,14 @@ describe("parseSlashCommand", () => {
     expectParsedSlash("/tools verbose", { name: "tools" }, "verbose");
   });
 
+  it("formats structured argument choices with the shared command serializer", () => {
+    expect(requireCommandByName("exec").argOptions).toEqual([
+      "host=sandbox",
+      "host=gateway",
+      "host=node",
+    ]);
+  });
+
   it("parses slash aliases through the shared registry", () => {
     const exportCommand = requireCommandByKey("export-session");
     expectRecordFields(exportCommand, "export-session command", {

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -4,6 +4,7 @@ import { asNullableRecord as asRecord } from "@openclaw/normalization-core/recor
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { CommandEntry } from "../../../../packages/gateway-protocol/src/index.js";
+import type { CommandArgValues } from "../../../../src/auto-reply/commands-args.types.js";
 import { buildBuiltinChatCommands } from "../../../../src/auto-reply/commands-registry.shared.js";
 import { t } from "../../i18n/index.ts";
 
@@ -47,6 +48,7 @@ type CommandLike = {
     required?: boolean;
     choices?: LocalArgChoice[];
   }>;
+  formatArgs?: (values: CommandArgValues) => string | undefined;
   category?: string;
   tier?: string;
   source?: "native" | "plugin" | "skill";
@@ -201,8 +203,9 @@ function formatArgs(command: CommandLike): string | undefined {
     .join(" ");
 }
 
-function choiceToValue(choice: LocalArgChoice): string {
-  return typeof choice === "string" ? choice : choice.value;
+function choiceToValue(command: CommandLike, argName: string, choice: LocalArgChoice): string {
+  const value = typeof choice === "string" ? choice : choice.value;
+  return command.formatArgs?.({ [argName]: value }) ?? value;
 }
 
 function getArgOptions(command: CommandLike): string[] | undefined {
@@ -210,7 +213,9 @@ function getArgOptions(command: CommandLike): string[] | undefined {
   if (!firstArg) {
     return undefined;
   }
-  const options = firstArg.choices?.map(choiceToValue).filter(Boolean);
+  const options = firstArg.choices
+    ?.map((choice) => choiceToValue(command, firstArg.name, choice))
+    .filter(Boolean);
   return options?.length ? options : undefined;
 }
 
@@ -368,6 +373,7 @@ function buildLocalSlashCommands(): SlashCommandDef[] {
         required: arg.required,
         choices: Array.isArray(arg.choices) ? arg.choices : undefined,
       })),
+      formatArgs: command.formatArgs,
       category: command.category,
       tier: command.tier,
     }))

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -4882,10 +4882,7 @@ describe("chat slash menu accessibility", () => {
     expect(draft).toBe("Please use $weather ");
   });
 
-  it.each([
-    ["reset", "/reset"],
-    ["exec gateway", "/exec gateway"],
-  ])("executes inline /%s like its standalone command", (typedCommand, dispatchedCommand) => {
+  it("executes an inline /reset like its standalone command", () => {
     let draft = "";
     const onDraftChange = vi.fn((next: string) => {
       draft = next;
@@ -4894,10 +4891,30 @@ describe("chat slash menu accessibility", () => {
     const onSlashCommand = vi.fn();
     const { container } = createReactiveDraftHarness({ onDraftChange, onSend, onSlashCommand });
 
-    inputDraftAtEnd(container, `Please /${typedCommand}`);
+    inputDraftAtEnd(container, "Please /reset");
     keydownComposer(container, "Enter");
 
-    expect(onSlashCommand).toHaveBeenCalledExactlyOnceWith(dispatchedCommand);
+    expect(onSlashCommand).toHaveBeenCalledExactlyOnceWith("/reset");
+    expect(draft).toBe("Please ");
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe(draft);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("serializes a selected inline /exec host argument canonically", () => {
+    let draft = "";
+    const onDraftChange = vi.fn((next: string) => {
+      draft = next;
+    });
+    const onSend = vi.fn();
+    const onSlashCommand = vi.fn();
+    const { container } = createReactiveDraftHarness({ onDraftChange, onSend, onSlashCommand });
+
+    inputDraftAtEnd(container, "Please /exec");
+    keydownComposer(container, "Tab");
+    keydownComposer(container, "ArrowDown");
+    keydownComposer(container, "Enter");
+
+    expect(onSlashCommand).toHaveBeenCalledExactlyOnceWith("/exec host=gateway");
     expect(draft).toBe("Please ");
     expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe(draft);
     expect(onSend).not.toHaveBeenCalled();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting the gateway host from the Control UI `/exec` slash-command picker would get the invalid positional form `/exec gateway` instead of the canonical `/exec host=gateway` command.

## Why This Change Was Made

The Control UI now preserves and applies each built-in command's shared structured-argument formatter when producing picker values. This keeps the UI aligned with the canonical command serializer while leaving commands without a formatter unchanged.

The separate parser behavior for manually entered invalid positional input such as `/exec gateway` is intentionally not changed here; it crosses the core command-routing ownership boundary and is tracked separately.

## User Impact

Selecting sandbox, gateway, or node from the `/exec` host picker now inserts valid canonical syntax and dispatches the intended execution-host setting.

## Evidence

- `node scripts/run-vitest.mjs ui/src/lib/chat/commands.test.ts` — 32 tests passed
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts -t 'executes an inline /reset|serializes a selected inline /exec host argument canonically'` — 2 tests passed
- `pnpm ui:build` — passed
- `pnpm check:changed` — passed
- Autoreview (`branch`, P0/P1) — scoped clean; patch correctness 0.97

The updated browser E2E assertion covers the canonical dispatch path, but local Playwright execution remains unavailable because this host lacks Chromium runtime libraries.