### PR TITLE
test: consolidate logging mock-call guards

### DIFF
--- a/src/logging/console-capture.test.ts
+++ b/src/logging/console-capture.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../logging.js";
 import { defaultRuntime } from "../runtime.js";
 import { withEnv } from "../test-utils/env.js";
+import { mockCall } from "../test-utils/mock-call-assertions.js";
 import { createSuiteLogPathTracker } from "./log-test-helpers.js";
 import { applyLoggingConfig } from "./logger.js";
 import { testApi } from "./logger.test-support.js";
@@ -58,14 +59,6 @@ afterAll(async () => {
   await logPathTracker.cleanup();
 });
 
-function firstMockArgAsString(mock: { mock: { calls: readonly unknown[][] } }): string {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error("expected mock call");
-  }
-  return String(call[0]);
-}
-
 describe("enableConsoleCapture", () => {
   const secret = "sk-testsecret1234567890abcd";
 
@@ -99,7 +92,7 @@ describe("enableConsoleCapture", () => {
     enableConsoleCapture();
     console.warn("[EventQueue] Slow listener detected");
     expect(warn).toHaveBeenCalledTimes(1);
-    const firstArg = firstMockArgAsString(warn);
+    const firstArg = String(mockCall(warn)[0]);
     // Timestamp uses local time with timezone offset instead of UTC "Z" suffix
     expect(firstArg).toMatch(
       /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2} \[EventQueue\]/,
@@ -126,7 +119,7 @@ describe("enableConsoleCapture", () => {
     const payload = JSON.stringify({ ok: true });
     console.log(payload);
     expect(log).toHaveBeenCalledTimes(1);
-    const firstArg = firstMockArgAsString(log);
+    const firstArg = String(mockCall(log)[0]);
     expect(firstArg).toMatch(/^(?:\d{2}:\d{2}:\d{2}|\d{4}-\d{2}-\d{2}T)/);
     expect(firstArg.endsWith(` ${payload}`)).toBe(true);
   });
@@ -148,7 +141,7 @@ describe("enableConsoleCapture", () => {
 
       expect(warn).toHaveBeenCalledTimes(1);
       if (consoleStyle === "json") {
-        expect(JSON.parse(firstMockArgAsString(warn))).toMatchObject({
+        expect(JSON.parse(String(mockCall(warn)[0]))).toMatchObject({
           level: "warn",
           message: "tool failed { attempt: 1 }",
         });
@@ -167,7 +160,7 @@ describe("enableConsoleCapture", () => {
     createSubsystemLogger("gateway/auth").warn("authentication retry", { attempt: 2 });
 
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(firstMockArgAsString(warn))).toMatchObject({
+    expect(JSON.parse(String(mockCall(warn)[0]))).toMatchObject({
       level: "warn",
       subsystem: "gateway/auth",
       message: "authentication retry",
@@ -209,7 +202,7 @@ describe("enableConsoleCapture", () => {
         expect.objectContaining({ _meta: expect.objectContaining({ logLevelName: "TRACE" }) }),
       ]);
       expect(stderrWrite).toHaveBeenCalledTimes(1);
-      const written = firstMockArgAsString(stderrWrite);
+      const written = String(mockCall(stderrWrite)[0]);
       const event = consoleStyle === "json" ? JSON.parse(written) : { stack: written };
       if (consoleStyle === "json") {
         expect(event).toMatchObject({ level: "trace", message: "trace diagnostic\nsecond line" });
@@ -227,7 +220,7 @@ describe("enableConsoleCapture", () => {
 
     console.trace(`Authorization: Bearer ${secret}`);
 
-    const written = firstMockArgAsString(error);
+    const written = String(mockCall(error)[0]);
     const event = JSON.parse(written) as Record<string, unknown>;
     expect(event).toMatchObject({ level: "trace" });
     expect(written).not.toContain(secret);
@@ -265,7 +258,7 @@ describe("enableConsoleCapture", () => {
       );
     });
 
-    const written = firstMockArgAsString(warn);
+    const written = String(mockCall(warn)[0]);
     const event = JSON.parse(written) as {
       message: string;
       level: string;
@@ -302,7 +295,7 @@ describe("enableConsoleCapture", () => {
       console.trace("custom-only-secret");
     });
 
-    const written = firstMockArgAsString(error);
+    const written = String(mockCall(error)[0]);
     const event = JSON.parse(written) as { message: string; stack: string };
     expect(written).not.toContain("custom-only-secret");
     expect(event.message).not.toBe("custom-only-secret");
@@ -326,7 +319,7 @@ describe("enableConsoleCapture", () => {
 
       expect(error).toHaveBeenCalledTimes(1);
       if (consoleStyle === "json") {
-        expect(JSON.parse(firstMockArgAsString(error))).toMatchObject({
+        expect(JSON.parse(String(mockCall(error)[0]))).toMatchObject({
           level: "error",
           message: "[tools] exec failed",
         });
@@ -345,7 +338,7 @@ describe("enableConsoleCapture", () => {
     console.error(`Authorization: Bearer ${secret}`);
 
     expect(stderrWrite).toHaveBeenCalledTimes(1);
-    const written = firstMockArgAsString(stderrWrite);
+    const written = String(mockCall(stderrWrite)[0]);
     expect(JSON.parse(written)).toMatchObject({ level: "error" });
     expect(written).not.toContain(secret);
   });
@@ -365,7 +358,7 @@ describe("enableConsoleCapture", () => {
     console.log("diag");
     defaultRuntime.writeJson({ ok: true });
 
-    expect(JSON.parse(firstMockArgAsString(stderrWrite))).toMatchObject({
+    expect(JSON.parse(String(mockCall(stderrWrite)[0]))).toMatchObject({
       level: "info",
       message: "diag",
     });
@@ -421,7 +414,7 @@ describe("enableConsoleCapture", () => {
         countMatchingLines(fs.readFileSync(logPath, "utf-8"), "[tools] operation failed"),
       ).toBe(1);
       expect(consoleSpy).toHaveBeenCalledTimes(1);
-      const consoleLine = firstMockArgAsString(consoleSpy);
+      const consoleLine = String(mockCall(consoleSpy)[0]);
       expect(consoleLine).toContain("[tools] operation failed");
       expect(consoleLine).not.toContain(secret);
     },
@@ -436,7 +429,7 @@ describe("enableConsoleCapture", () => {
     console.log("apiKey:", secret);
 
     expect(log).toHaveBeenCalledTimes(1);
-    const line = firstMockArgAsString(log);
+    const line = String(mockCall(log)[0]);
     expect(line).toContain("apiKey:");
     expect(line).not.toContain(secret);
   });
@@ -450,7 +443,7 @@ describe("enableConsoleCapture", () => {
     console.error(`Authorization: Bearer ${secret}`);
 
     expect(stderrWrite).toHaveBeenCalledTimes(1);
-    const line = firstMockArgAsString(stderrWrite);
+    const line = String(mockCall(stderrWrite)[0]);
     expect(line).toContain("Authorization: Bearer");
     expect(line).not.toContain(secret);
   });
@@ -465,7 +458,7 @@ describe("enableConsoleCapture", () => {
     console.warn(`token=${secret}`);
 
     expect(warn).toHaveBeenCalledTimes(1);
-    const line = firstMockArgAsString(warn);
+    const line = String(mockCall(warn)[0]);
     expect(line).toMatch(/^(?:\d{2}:\d{2}:\d{2}|\d{4}-\d{2}-\d{2}T)/);
     expect(line).toContain("token=");
     expect(line).not.toContain(secret);

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { Logger as TsLogger } from "tslog";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { mockCall } from "../test-utils/mock-call-assertions.js";
 import { setConsoleSubsystemFilter, shouldLogSubsystemToConsole } from "./console.js";
 import { createSuiteLogPathTracker } from "./log-test-helpers.js";
 import { applyLoggingConfig, resetLogger, setLoggerOverride } from "./logger.js";
@@ -21,14 +22,6 @@ function installConsoleMethodSpy(method: "log" | "warn" | "error") {
     error: method === "error" ? spy : vi.fn(),
   };
   return spy;
-}
-
-function firstMockArgAsString(mock: { mock: { calls: readonly unknown[][] } }): string {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error("expected console mock call");
-  }
-  return String(call[0]);
 }
 
 beforeAll(async () => {
@@ -139,7 +132,7 @@ describe("createSubsystemLogger().isEnabled", () => {
 
       log.warn("subsystem diagnostic");
       expect(warn).toHaveBeenCalledTimes(1);
-      expect(firstMockArgAsString(warn)).toContain(`[${subsystem ?? "unknown"}]`);
+      expect(String(mockCall(warn)[0])).toContain(`[${subsystem ?? "unknown"}]`);
     },
   );
 
@@ -255,7 +248,7 @@ describe("createSubsystemLogger().isEnabled", () => {
     log.warn(`token=${secret}`);
 
     expect(warn).toHaveBeenCalledTimes(1);
-    const written = firstMockArgAsString(warn);
+    const written = String(mockCall(warn)[0]);
     expect(written).not.toContain(secret);
     expect(written).toMatch(/sk-sup…2345|\*\*\*/);
   });
@@ -269,7 +262,7 @@ describe("createSubsystemLogger().isEnabled", () => {
     log.error(`Authorization failed: ${bearer}`);
 
     expect(error).toHaveBeenCalledTimes(1);
-    const written = firstMockArgAsString(error);
+    const written = String(mockCall(error)[0]);
     expect(written).not.toContain("abcdefghijklmnopqrstuvwxyz");
     expect(written).toContain("Bearer ");
   });
@@ -289,7 +282,7 @@ describe("createSubsystemLogger().isEnabled", () => {
         log.info(`provider API_KEY=${secret}`);
 
         expect(logSpy).toHaveBeenCalledTimes(1);
-        const written = firstMockArgAsString(logSpy);
+        const written = String(mockCall(logSpy)[0]);
         expect(written).not.toContain(secret);
         expect(written).toContain("API_KEY=***");
         expect(written).toContain("[auth]");
@@ -307,7 +300,7 @@ describe("createSubsystemLogger().isEnabled", () => {
     log.raw(`raw token ${secret}`);
 
     expect(logSpy).toHaveBeenCalledTimes(1);
-    const written = firstMockArgAsString(logSpy);
+    const written = String(mockCall(logSpy)[0]);
     expect(written).not.toContain(secret);
     expect(written).toContain("sk-raw…3456");
   });
@@ -319,7 +312,7 @@ describe("createSubsystemLogger().isEnabled", () => {
     createSubsystemLogger("gateway/auth").raw("raw diagnostic");
 
     expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(firstMockArgAsString(logSpy))).toMatchObject({
+    expect(JSON.parse(String(mockCall(logSpy)[0]))).toMatchObject({
       level: "info",
       subsystem: "gateway/auth",
       message: "raw diagnostic",
@@ -344,7 +337,7 @@ describe("createSubsystemLogger().isEnabled", () => {
 
     createSubsystemLogger("gateway/auth").warn("authentication retry", { attempt: 2 });
 
-    expect(JSON.parse(firstMockArgAsString(warn))).toMatchObject({
+    expect(JSON.parse(String(mockCall(warn)[0]))).toMatchObject({
       level: "warn",
       subsystem: "gateway/auth",
       message: "authentication retry",


### PR DESCRIPTION
## What Problem This Solves

The console-capture and subsystem tests duplicate the same helper for checking the first mock call and converting its first argument to text.

## Why This Change Was Made

Use the existing `mockCall` helper at all 22 call sites and retain explicit `String` conversion. Missing calls still fail, while existing calls containing `undefined` or `null` keep their prior conversion semantics.

## User Impact

No runtime or user-facing behavior changes. All existing assertions and cleanup remain; the two test files lose 14 net lines. The internal missing-call message now comes from the canonical helper.

## Evidence

Both complete suites passed before and after the change: 67 cases and all 119 assertions retained. Per-file case order matched; normal concurrent workers produced different cross-file log interleaving.

The normal two-path local changed gate passed all 20 stages, including services test typechecking and scoped lint. Fresh managed Codex P2 review found no actionable issues. Production delta is zero.
