### PR TITLE
test(plugins): reuse the shared cleanup timer call guard

### DIFF
--- a/src/plugins/host-hook-cleanup-timeout.test.ts
+++ b/src/plugins/host-hook-cleanup-timeout.test.ts
@@ -1,16 +1,9 @@
 /** Verifies host hook cleanup timeout behavior and cancellation reporting. */
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withPluginHostCleanupTimeout } from "./host-hook-cleanup-timeout.js";
 
 const PLUGIN_HOST_CLEANUP_TIMEOUT_MS = 5_000;
-
-function requireSetTimeoutCall(callIndex: number): unknown[] {
-  const call = vi.mocked(globalThis.setTimeout).mock.calls[callIndex];
-  if (!call) {
-    throw new Error(`expected setTimeout call ${callIndex}`);
-  }
-  return call as unknown[];
-}
 
 describe("withPluginHostCleanupTimeout", () => {
   afterEach(() => {
@@ -35,9 +28,12 @@ describe("withPluginHostCleanupTimeout", () => {
 
     await expect(withPluginHostCleanupTimeout("fast-cleanup", () => "ok")).resolves.toBe("ok");
 
-    const timeoutCall = requireSetTimeoutCall(0);
-    expect(typeof timeoutCall?.[0]).toBe("function");
-    expect(timeoutCall?.[1]).toBe(PLUGIN_HOST_CLEANUP_TIMEOUT_MS);
+    const timeoutCall = expectDefined(
+      vi.mocked(globalThis.setTimeout).mock.calls[0],
+      "setTimeout call 0",
+    );
+    expect(typeof timeoutCall[0]).toBe("function");
+    expect(timeoutCall[1]).toBe(PLUGIN_HOST_CLEANUP_TIMEOUT_MS);
     expect(unref).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
The plugin cleanup timeout test had a single-use helper that widened Vitest's captured timer arguments to `unknown[]`. Reuse the existing `expectDefined` helper and keep the inferred tuple, so the missing-call invariant is explicit without redundant optional access.

The first-call check, callback and 5,000 ms delay assertions, `unref` count, real timer interception and mock restoration are unchanged. Production delta: 0. Test delta: +7/-11 (net -4).

Candidate `7305f5c8b041b70693dad96464f3bc33bec9b807` is rebased onto main `41d427648c54a6d7717aa4f4293176fc9a35fc96`; its one-file patch and final test bytes are identical to the original reviewed change.

The refresh incorporates the existing Android reader repair from [#137041](https://github.com/openclaw/openclaw/pull/137041), which closed [#137111](https://github.com/openclaw/openclaw/issues/137111). [Old-head CI 33793185558](https://github.com/openclaw/openclaw/actions/runs/33793185558) ran 2,852 Android tests and failed `backgroundHistoryUpdatesDoNotDismissOpenReader` because the newest background message was not displayed. That checkout lacked the landed repair preventing history completion from cancelling an active scroll. Its exact scheduling was not logged; the owner defect was independently reproduced and fixed in #137041. The full-message fixture is unchanged, and no Android edit is added to this PR's diff.

Validation of the rebased candidate:

- The same three complete suites passed all six cases in identical native report order, including configuration-failure cleanup continuation.
- The full one-path local changed gate passed all 20 selected stages, including the plugins-platform type graph and lint.
- Fresh managed Codex review at P2 returned scoped-clean with no actionable findings.
- Source, installed dependency graph, refs and config remained unchanged through those runs. New exact-head hosted CI is still required.

The original three-suite baseline and candidate also passed. Before that baseline, Vitest executed zero tests because it could not open a temporary cache file. One supported, same-selection `--clearCache` completed, then the unchanged baseline and candidate passed. The exact remover remains unknown; the possible installed-cache self-invalidation hazard is a separate follow-up. No cache workaround or runtime scheduler change is included.

The initial hosted run was skipped; one normal CI dispatch produced the retained old-head Android failure above. Three log downloads failed at the transport layer before the supported job-log REST endpoint returned the complete log. Those retrieval failures are separate from the Android assertion. No unchanged-head CI rerun was performed.
