### PR TITLE
fix(recovery): preserve restart-safe tool ownership

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -7124,30 +7124,32 @@ Update and merge these partial structured summaries.`,
   it.each([
     {
       label: "direct body tools",
-      declarations: { tools: restartCheckpointTools },
-      additionalTools: undefined,
+      surface: "direct",
     },
     {
       label: "developer additional tools",
-      declarations: {},
-      additionalTools: restartCheckpointTools,
+      surface: "developer",
     },
   ])(
     "derives three restart checkpoints from request history without server counters via $label",
-    async ({ declarations, additionalTools }) => {
+    async ({ surface }) => {
       const server = await startMockServer();
       const prompt =
         "Code Mode restart wait QA check. Original prompt marker: RESTART-CODE-MODE-PROMPT.";
-      const declarationInput: Array<Record<string, unknown>> = additionalTools
-        ? [{ type: "additional_tools", role: "developer", tools: additionalTools }]
-        : [];
-      const input: Array<Record<string, unknown>> = [...declarationInput, makeUserInput(prompt)];
+      const withDeclarationSurface = (
+        tools: Array<Record<string, unknown>>,
+        input: Array<Record<string, unknown>>,
+      ) =>
+        surface === "direct"
+          ? { tools, input }
+          : { input: [{ type: "additional_tools", role: "developer", tools }, ...input] };
+      const input: Array<Record<string, unknown>> = [makeUserInput(prompt)];
 
       for (const checkpoint of [1, 2, 3]) {
-        const execPayload = await expectOpenAiNonStreamingResponsesJson(server, {
-          ...declarations,
-          input,
-        });
+        const execPayload = await expectOpenAiNonStreamingResponsesJson(
+          server,
+          withDeclarationSurface(restartCheckpointTools, input),
+        );
         const execCall = outputToolCall(execPayload, "exec");
         const execArgs = outputToolArgsFromItem(execCall);
         await expectRestartCheckpointExecution(execArgs, checkpoint);
@@ -7160,25 +7162,44 @@ Update and merge these partial structured summaries.`,
             JSON.stringify({ status: "waiting", runId }),
           ),
         );
-        const waitPayload = await expectOpenAiNonStreamingResponsesJson(server, {
-          ...declarations,
-          input,
-        });
+        const waitPayload = await expectOpenAiNonStreamingResponsesJson(
+          server,
+          withDeclarationSurface(restartCheckpointTools, input),
+        );
         const waitCall = outputToolCall(waitPayload, "wait");
         expect(outputToolArgsFromItem(waitCall)).toEqual({ runId });
         input.push(waitCall, makeUserInput(restartRecoveryPrompt));
       }
 
-      const finalPayload = await expectOpenAiNonStreamingResponsesJson(server, {
-        ...declarations,
-        input,
-      });
+      const finalPayload = await expectOpenAiNonStreamingResponsesJson(
+        server,
+        withDeclarationSurface(restartCheckpointTools, input),
+      );
       expect(outputText(finalPayload)).toBe("unsafeVisible=false\nRESTART-CODE-MODE-WAIT-OK");
 
-      const freshPayload = await expectOpenAiNonStreamingResponsesJson(server, {
-        ...declarations,
-        input: [...declarationInput, makeUserInput(prompt)],
-      });
+      const unsafePayload = await expectOpenAiNonStreamingResponsesJson(
+        server,
+        withDeclarationSurface(
+          [
+            ...restartCheckpointTools,
+            {
+              type: "function",
+              name: "qa_restart_unsafe_probe",
+              parameters: { type: "object" },
+            },
+          ],
+          input,
+        ),
+      );
+      expect(
+        outputToolArgsFromItem(outputToolCall(unsafePayload, "qa_restart_unsafe_probe")),
+      ).toEqual({});
+      expect(outputItems(unsafePayload).map((item) => item.type)).toEqual(["function_call"]);
+
+      const freshPayload = await expectOpenAiNonStreamingResponsesJson(
+        server,
+        withDeclarationSurface(restartCheckpointTools, [makeUserInput(prompt)]),
+      );
       expect(outputToolArgsFromItem(outputToolCall(freshPayload, "exec")).code).toContain(
         "CHECKPOINT-1",
       );

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -7121,44 +7121,69 @@ Update and merge these partial structured summaries.`,
     expect(outputToolArgsFromItem(outputToolCall(freshPayload, "exec"))).toEqual(execArgs);
   });
 
-  it("derives three restart checkpoints from request history without server counters", async () => {
-    const server = await startMockServer();
-    const prompt =
-      "Code Mode restart wait QA check. Original prompt marker: RESTART-CODE-MODE-PROMPT.";
-    const tools = restartCheckpointTools;
-    const input: Array<Record<string, unknown>> = [makeUserInput(prompt)];
+  it.each([
+    {
+      label: "direct body tools",
+      declarations: { tools: restartCheckpointTools },
+      additionalTools: undefined,
+    },
+    {
+      label: "developer additional tools",
+      declarations: {},
+      additionalTools: restartCheckpointTools,
+    },
+  ])(
+    "derives three restart checkpoints from request history without server counters via $label",
+    async ({ declarations, additionalTools }) => {
+      const server = await startMockServer();
+      const prompt =
+        "Code Mode restart wait QA check. Original prompt marker: RESTART-CODE-MODE-PROMPT.";
+      const declarationInput: Array<Record<string, unknown>> = additionalTools
+        ? [{ type: "additional_tools", role: "developer", tools: additionalTools }]
+        : [];
+      const input: Array<Record<string, unknown>> = [...declarationInput, makeUserInput(prompt)];
 
-    for (const checkpoint of [1, 2, 3]) {
-      const execPayload = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });
-      const execCall = outputToolCall(execPayload, "exec");
-      const execArgs = outputToolArgsFromItem(execCall);
-      await expectRestartCheckpointExecution(execArgs, checkpoint);
+      for (const checkpoint of [1, 2, 3]) {
+        const execPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+          ...declarations,
+          input,
+        });
+        const execCall = outputToolCall(execPayload, "exec");
+        const execArgs = outputToolArgsFromItem(execCall);
+        await expectRestartCheckpointExecution(execArgs, checkpoint);
 
-      const runId = `restart-checkpoint-${checkpoint}`;
-      input.push(
-        execCall,
-        makeToolOutputWithCallId(
-          outputToolCallId(execCall, `checkpoint-exec-${checkpoint}`),
-          JSON.stringify({ status: "waiting", runId }),
-        ),
+        const runId = `restart-checkpoint-${checkpoint}`;
+        input.push(
+          execCall,
+          makeToolOutputWithCallId(
+            outputToolCallId(execCall, `checkpoint-exec-${checkpoint}`),
+            JSON.stringify({ status: "waiting", runId }),
+          ),
+        );
+        const waitPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+          ...declarations,
+          input,
+        });
+        const waitCall = outputToolCall(waitPayload, "wait");
+        expect(outputToolArgsFromItem(waitCall)).toEqual({ runId });
+        input.push(waitCall, makeUserInput(restartRecoveryPrompt));
+      }
+
+      const finalPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+        ...declarations,
+        input,
+      });
+      expect(outputText(finalPayload)).toBe("unsafeVisible=false\nRESTART-CODE-MODE-WAIT-OK");
+
+      const freshPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+        ...declarations,
+        input: [...declarationInput, makeUserInput(prompt)],
+      });
+      expect(outputToolArgsFromItem(outputToolCall(freshPayload, "exec")).code).toContain(
+        "CHECKPOINT-1",
       );
-      const waitPayload = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });
-      const waitCall = outputToolCall(waitPayload, "wait");
-      expect(outputToolArgsFromItem(waitCall)).toEqual({ runId });
-      input.push(waitCall, makeUserInput(restartRecoveryPrompt));
-    }
-
-    const finalPayload = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });
-    expect(outputText(finalPayload)).toBe("unsafeVisible=false\nRESTART-CODE-MODE-WAIT-OK");
-
-    const freshPayload = await expectOpenAiNonStreamingResponsesJson(server, {
-      tools,
-      input: [makeUserInput(prompt)],
-    });
-    expect(outputToolArgsFromItem(outputToolCall(freshPayload, "exec")).code).toContain(
-      "CHECKPOINT-1",
-    );
-  });
+    },
+  );
 
   it("routes Anthropic image generation through Code Mode when only exec and wait are visible", async () => {
     const server = await startMockServer();

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1005,7 +1005,7 @@ async function buildResponsesPayload(
     if (!QA_RESTART_RECOVERY_PROMPT_RE.test(allInputText)) {
       return buildAssistantEvents("RESTART-CODE-MODE-WAIT-FAIL");
     }
-    if (hasToolDefinition(body, "qa_restart_unsafe_probe")) {
+    if (hasToolDefinition(toolDeclarationBody, "qa_restart_unsafe_probe")) {
       return buildToolCallEventsWithArgs("qa_restart_unsafe_probe", {});
     }
     return buildAssistantEvents(QA_RESTART_FINAL_TEXT);

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -965,14 +965,14 @@ async function buildResponsesPayload(
         codeModeControlJson?.status === "waiting" &&
         "runId" in codeModeControlJson &&
         typeof codeModeControlJson.runId === "string" &&
-        hasDeclaredTool(body, "wait")
+        hasDeclaredTool(toolDeclarationBody, "wait")
       ) {
         return buildToolCallEventsWithArgs("wait", { runId: codeModeControlJson.runId });
       }
       if (
         toolJson?.status === "waiting" &&
         typeof toolJson.runId === "string" &&
-        hasDeclaredTool(body, "wait")
+        hasDeclaredTool(toolDeclarationBody, "wait")
       ) {
         return buildToolCallEventsWithArgs("wait", { runId: toolJson.runId });
       }
@@ -984,7 +984,7 @@ async function buildResponsesPayload(
       if (nextCheckpoint > 1 && !QA_RESTART_RECOVERY_PROMPT_RE.test(allInputText)) {
         return buildAssistantEvents("RESTART-CODE-MODE-WAIT-FAIL");
       }
-      if (hasDeclaredTool(body, "exec")) {
+      if (hasDeclaredTool(toolDeclarationBody, "exec")) {
         const encodedTarget = encodeCodeModeTarget("qa_restart_wait", {});
         return buildToolCallEventsWithArgs("exec", {
           language: "javascript",

--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -215,10 +215,13 @@ describe("qa scenario catalog causality", () => {
     expect(contract.match(/"sendInbound"/gu)).toHaveLength(1);
     expect(contract).not.toContain("startAgentRun");
     expect(contract).not.toContain("chat.send");
-    expect(contract).toContain(
+    expect(contract).toContain("pendingCodeModeExecNeedle: `CHECKPOINT-${checkpoint}`");
+    expect(contract).toContain("summary.hasPendingCodeModeWait");
+    expect(contract).toContain("checkpointTranscript.hasPendingCodeModeWait");
+    expect(contract).not.toContain(
       "assistantToolCallCounts.wait ?? 0) > (summary.completedToolCallCounts.wait ?? 0)",
     );
-    expect(contract).toContain(
+    expect(contract).not.toContain(
       "checkpointTranscript.assistantToolCallCounts.wait ?? 0) > (checkpointTranscript.completedToolCallCounts.wait ?? 0)",
     );
     expect(contract).toContain("probeText: config.promptMarker");

--- a/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
+++ b/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
@@ -123,11 +123,11 @@ flow:
                 args:
                   - lambda:
                       async: true
-                      expr: "readSessionTranscriptSummary(env, sessionKey, { probeText: config.promptMarker }).then((summary) => (summary.assistantToolCallCounts.exec ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) > (summary.completedToolCallCounts.wait ?? 0) ? summary : undefined).catch(() => undefined)"
+                      expr: "readSessionTranscriptSummary(env, sessionKey, { probeText: config.promptMarker, pendingCodeModeExecNeedle: `CHECKPOINT-${checkpoint}` }).then((summary) => summary.hasPendingCodeModeWait ? summary : undefined).catch(() => undefined)"
                   - expr: liveTurnTimeoutMs(env, 120000)
                   - 25
               - assert:
-                  expr: "(checkpointTranscript.assistantToolCallCounts.wait ?? 0) > (checkpointTranscript.completedToolCallCounts.wait ?? 0)"
+                  expr: checkpointTranscript.hasPendingCodeModeWait
                   message:
                     expr: "`checkpoint ${checkpoint} wait was not pending before restart: ${JSON.stringify(checkpointTranscript)}`"
               - set: checkpointRequests

--- a/src/config/sessions/session-snapshot-merge.test.ts
+++ b/src/config/sessions/session-snapshot-merge.test.ts
@@ -479,6 +479,77 @@ describe("session snapshot merge", () => {
     expect(merged.mainRestartRecovery).toEqual(current.mainRestartRecovery);
   });
 
+  it("preserves the safe-tools guard when a newer recovery owner wins a stale clear", () => {
+    const initialRecovery: SessionEntry = {
+      ...initial,
+      abortedLastRun: true,
+      restartRecoveryForceSafeTools: true,
+      mainRestartRecovery: {
+        cycleId: "cycle-1",
+        revision: 1,
+        chargedAttempts: 1,
+      },
+    };
+    const next: SessionEntry = {
+      ...initialRecovery,
+      updatedAt: 2,
+      abortedLastRun: false,
+      restartRecoveryForceSafeTools: undefined,
+      mainRestartRecovery: undefined,
+    };
+    const current: SessionEntry = {
+      ...initialRecovery,
+      updatedAt: 3,
+      mainRestartRecovery: {
+        ...initialRecovery.mainRestartRecovery!,
+        revision: 2,
+      },
+    };
+
+    const merged = mergeSessionSnapshotChanges({ initial: initialRecovery, next, current });
+
+    expect(merged.restartRecoveryForceSafeTools).toBe(true);
+    expect(merged.abortedLastRun).toBe(true);
+    expect(merged.mainRestartRecovery).toEqual(current.mainRestartRecovery);
+  });
+
+  it("preserves recovery state when the safe-tools guard is acquired during fence cleanup", () => {
+    const initialRecovery: SessionEntry = {
+      ...initial,
+      abortedLastRun: true,
+      restartRecoveryRuns: [
+        { runId: "interrupted-run", lifecycleGeneration: "generation-1" },
+        { runId: "recovery-run", lifecycleGeneration: "generation-1" },
+      ],
+      mainRestartRecovery: {
+        cycleId: "cycle-1",
+        revision: 3,
+        chargedAttempts: 1,
+      },
+    };
+    const next: SessionEntry = {
+      ...initialRecovery,
+      updatedAt: 2,
+      abortedLastRun: false,
+      restartRecoveryRuns: undefined,
+      restartRecoveryForceSafeTools: undefined,
+      mainRestartRecovery: undefined,
+    };
+    const current: SessionEntry = {
+      ...structuredClone(initialRecovery),
+      updatedAt: 3,
+      abortedLastRun: false,
+      restartRecoveryRuns: [{ runId: "interrupted-run", lifecycleGeneration: "generation-1" }],
+      restartRecoveryForceSafeTools: true,
+    };
+
+    const merged = mergeSessionSnapshotChanges({ initial: initialRecovery, next, current });
+
+    expect(merged.restartRecoveryForceSafeTools).toBe(true);
+    expect(merged.restartRecoveryRuns).toEqual(current.restartRecoveryRuns);
+    expect(merged.mainRestartRecovery).toEqual(current.mainRestartRecovery);
+  });
+
   it("clears recovery after lifecycle settlement consumes its run fence", () => {
     const initialRecovery: SessionEntry = {
       ...initial,

--- a/src/config/sessions/session-snapshot-merge.ts
+++ b/src/config/sessions/session-snapshot-merge.ts
@@ -44,6 +44,7 @@ const MODEL_OVERRIDE_CONFLICT_DEPENDENT_FIELDS = ["contextWindow", "thinkingLeve
 const MAIN_SESSION_RECOVERY_TRANSACTION_FIELDS = [
   "abortedLastRun",
   "restartRecoveryRuns",
+  "restartRecoveryForceSafeTools",
   "mainRestartRecovery",
 ] as const satisfies ReadonlyArray<keyof SessionEntry>;
 
@@ -61,6 +62,7 @@ function mainSessionRecoveryTransactionChanged(before: SessionEntry, after: Sess
   return (
     before.abortedLastRun !== after.abortedLastRun ||
     !isDeepStrictEqual(before.restartRecoveryRuns, after.restartRecoveryRuns) ||
+    before.restartRecoveryForceSafeTools !== after.restartRecoveryForceSafeTools ||
     beforeState?.cycleId !== afterState?.cycleId ||
     beforeState?.chargedAttempts !== afterState?.chargedAttempts ||
     beforeState?.startedAttempt !== afterState?.startedAttempt ||
@@ -110,6 +112,7 @@ function isCanonicalMainSessionRecoveryClear(entry: SessionEntry): boolean {
   return (
     entry.abortedLastRun === false &&
     entry.restartRecoveryRuns === undefined &&
+    entry.restartRecoveryForceSafeTools === undefined &&
     entry.mainRestartRecovery === undefined
   );
 }
@@ -223,13 +226,14 @@ export function projectSessionSnapshotChanges(params: {
     isCanonicalMainSessionRecoveryClear(params.next) &&
     !mainRecoveryOwnershipChangedConcurrently &&
     mainSessionRecoveryCycleStateUnchanged(params.initial, params.current) &&
+    params.initial.restartRecoveryForceSafeTools === params.current.restartRecoveryForceSafeTools &&
     restartRecoveryRunsOnlyConsumed(params.initial, params.current);
   if (
     mainRecoveryChanged &&
     !mainRecoveryOwnershipChangedConcurrently &&
     (!mainRecoveryChangedConcurrently || currentOnlyConsumedLifecycleFences)
   ) {
-    // Apply all three fields together. Concurrent ownership changes settle through
+    // Apply all four fields together. Concurrent ownership changes settle through
     // their lifecycle/release owner, never through an older run-local snapshot.
     for (const field of MAIN_SESSION_RECOVERY_TRANSACTION_FIELDS) {
       patchRecord[field] = Object.hasOwn(params.next, field) ? next[field] : undefined;


### PR DESCRIPTION
## Problem

Two serial blockers were exposed by exact-head hosted runs:

1. A stale old-run finalizer snapshot could clear `restartRecoveryForceSafeTools` after a newer recovery owner and revision had won. Recovery then continued without the restart-safe tool restriction, and the deterministic three-restart scenario timed out.
2. After repairing that product transaction race, the mock provider still inspected the raw request body instead of the resolved tool declaration surface. Developer `additional_tools` declarations were therefore invisible to the restart fixture.

The scenario's old aggregate pending-wait checkpoint gate was also non-causal: it could observe an unrelated pending wait instead of the wait for the current checkpoint.

## Root Cause And Owner

The recovery snapshot transaction in `src/config/sessions/session-snapshot-merge.ts` omitted `restartRecoveryForceSafeTools`. The consumed-lifecycle-fence exception also did not fence concurrent safe-tools guard acquisition.

The restart checkpoint handler in `extensions/qa-lab/src/providers/mock-openai/server.ts` used the raw request body for declaration checks even though the provider's declaration owner had already resolved direct tools and developer `additional_tools` into `toolDeclarationBody`.

This is the conditional W4 lifecycle race. Its prerequisites have landed:

- https://github.com/openclaw/openclaw/pull/130856
- https://github.com/openclaw/openclaw/pull/129583

## Fix

- Make `restartRecoveryForceSafeTools` the fourth atomic main-session recovery transaction field.
- Include the guard in recovery change detection and canonical-clear recognition.
- Require initial/current guard equality before the consumed-fence exception may apply.
- Bind each QA restart to the exact pending Code Mode wait containing `CHECKPOINT-${checkpoint}`.
- Reject the old aggregate assistant/completed wait-count predicate in the scenario catalog contract.
- Use `toolDeclarationBody` for the restart fixture's `exec`, `wait`, and `qa_restart_unsafe_probe` checks.
- Cover direct tools and developer `additional_tools` in one table-driven checkpoint flow, including positive safe completion, unsafe-probe visibility, and fresh-history reset.

## Failure Classification

- https://github.com/openclaw/openclaw/actions/runs/33798365964 failed the earlier restart scenario at the first checkpoint gate.
- https://github.com/openclaw/openclaw/actions/runs/33800502712 failed the changed-head restart scenario and established the product lifecycle race.
- https://github.com/openclaw/openclaw/actions/runs/33804508494 ran exact head `75ae571b684e3606cfe3f9e93773ef9132a373ce` and produced `0/1`: it timed out after the first restart with no final delivery. This changed-head failure established the surviving declaration-surface defect and justified the follow-up patch.
- Cancellation in these runs occurred after the delegated command exited and was Testbox teardown fallout, not the root failure.

## Evidence

- Exact head: `4c34f9184f2eb0baf6d8659f953ccbb6c22ffdca`
- Branch base: `2010e3733272a7cfab693988e0e75e60177ffe40`
- Current main: `9acf0d48294c86c09dbb0016b914f75eca567290` (disjoint; all six touched files unchanged and merge-tree conflict-free)

Red proofs:

- Recovery owner regression: `node scripts/run-vitest.mjs src/config/sessions/session-snapshot-merge.test.ts`
  - `2 failed / 22 passed`
  - Intended failures included `expected undefined to be true` and the stale consumed-fence projection losing the current recovery run fence.
- Restart declaration surface:
  - Direct tools passed while developer `additional_tools` failed with `Expected exec tool call`.
  - With completed checkpoint history and an unsafe developer declaration, the pre-fix handler falsely returned the success marker instead of the expected `qa_restart_unsafe_probe` call.

Green proofs:

- Recovery owner: `24/24`.
- Recovery sibling suite: `305/305` across session snapshot merge, session store, and main-session restart recovery.
- Targeted mock checkpoint table: `2/2`.
- Full mock-provider suite: `285/285`.
- Scenario catalog and transcript helper suite: `37/37`.
- Scoped format, oxlint, changed-file gate, and `git diff --check` passed.
- Independent exact-diff review: **APPROVE**.
- Final mandatory diff-scoped autoreview: P0-P2 scoped-clean.
- Test-audit: the owner regressions fail on pre-fix source, the declaration test reuses one flow across both supported envelopes, and no duplicate scenario or production seam was added.

The task-owned full-clone local diagnostic attempts failed before QA startup because workspace package links could not resolve. They produced no scenario evidence, were not branch regressions, and stopped without further retry.

One changed-head exact hosted scenario and an exact-head ClawSweeper re-review remain required before landing. No full FRV rerun was dispatched.

## Change Size

- Production: `+5/-1`
- QA harness: `+6/-6`
- Tests: `+155/-35`
- QA scenario definition: `+2/-2`

There is no schema, config, protocol, or persistence migration. The YAML is a static QA scenario definition, not a persisted data-model change. No changelog entry is required.
