### PR TITLE
fix(codex): stop marketplace polling when native plugins are disabled

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -229,6 +229,7 @@ marketplace fields choose where Codex should find `computer-use`.
 Fresh Codex homes may need a short moment to seed their official
 marketplaces. During install, OpenClaw polls `plugin/list` for up to
 `marketplaceDiscoveryTimeoutMs` milliseconds (default 60 seconds).
+When Codex reports `features.plugins` as disabled, OpenClaw skips this discovery wait.
 
 If multiple known marketplaces contain Computer Use, OpenClaw prefers
 `openai-bundled`, then `openai-curated`, then `local`. Unknown ambiguous

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -1743,6 +1743,63 @@ describe("Codex Computer Use setup", () => {
     ).toHaveLength(3);
   });
 
+  it("fails fast when Codex native plugins are disabled", async () => {
+    vi.useFakeTimers();
+    const request = createComputerUseRequest({
+      installed: false,
+      nativePluginsEnabled: false,
+      marketplaceAvailableAfterListCalls: Number.POSITIVE_INFINITY,
+    });
+    const install = installCodexComputerUse({
+      pluginConfig: { computerUse: {} },
+      request,
+    });
+    const pending = expectSetupErrorStatus(install, {
+      ready: false,
+      reason: "marketplace_missing",
+      message: expect.stringContaining("features.plugins = false"),
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await pending;
+
+    expect(requestCalls(request).filter(([method]) => method === "plugin/list")).toHaveLength(1);
+    expect(
+      requestCalls(request).filter(([method]) => method === "experimentalFeature/list"),
+    ).toHaveLength(1);
+    expectRequestMethodNotCalled(request, "plugin/install");
+    await expect(install).rejects.toThrow("/codex computer-use install");
+  });
+
+  it("keeps waiting for marketplace discovery when the feature list does not report plugins", async () => {
+    vi.useFakeTimers();
+    const request = createComputerUseRequest({
+      installed: false,
+      nativePluginsEnabled: "absent",
+      marketplaceAvailableAfterListCalls: 3,
+    });
+    const installed = installCodexComputerUse({
+      pluginConfig: { computerUse: {} },
+      request,
+    });
+
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    expectStatusFields(await installed, { ready: true, reason: "ready" });
+    expect(requestCalls(request).filter(([method]) => method === "plugin/list")).toHaveLength(3);
+    expect(
+      requestCalls(request).filter(([method]) => method === "experimentalFeature/list"),
+    ).toHaveLength(1);
+  });
+
+  it("does not read native plugin state when the marketplace is immediately available", async () => {
+    const request = createComputerUseRequest({ installed: false });
+
+    await installCodexComputerUse({ pluginConfig: { computerUse: {} }, request });
+
+    expectRequestMethodNotCalled(request, "experimentalFeature/list");
+  });
+
   it("prefers the official Computer Use marketplace when multiple matches are present", async () => {
     const request = createMultiMarketplaceComputerUseRequest();
 
@@ -1766,6 +1823,7 @@ describe("Codex Computer Use setup", () => {
 function createComputerUseRequest(params: {
   installed: boolean;
   enabled?: boolean;
+  nativePluginsEnabled?: boolean | "absent";
   marketplaceAvailableAfterListCalls?: number;
   liveTestFailures?: number;
   reloadFailures?: number;
@@ -1791,7 +1849,18 @@ function createComputerUseRequest(params: {
     pluginSummary(installed, marketplaceName, enabled, source, params.remoteMarketplace?.pluginId);
   return vi.fn(async (method: string, requestParams?: unknown) => {
     if (method === "experimentalFeature/enablement/set") {
-      return { enablement: { plugins: true } };
+      return {
+        enablement: params.nativePluginsEnabled === false ? {} : { plugins: true },
+      };
+    }
+    if (method === "experimentalFeature/list") {
+      return {
+        data:
+          params.nativePluginsEnabled === "absent"
+            ? []
+            : [{ name: "plugins", enabled: params.nativePluginsEnabled ?? true }],
+        nextCursor: null,
+      };
     }
     if (method === "marketplace/add") {
       return {

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -29,8 +29,9 @@ import {
 import { isManagedCodexDesktopCommand } from "./managed-binary.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import type {
-  CodexListMcpServerStatusResponse,
+  CodexAppServerRequestResult,
   CodexConfigReadResponse,
+  CodexListMcpServerStatusResponse,
   CodexMcpServerStatus,
   CodexPluginDetail,
   CodexPluginListResponse,
@@ -841,6 +842,16 @@ async function resolveMarketplaceRef(params: {
   }
 
   const waitUntil = marketplaceDiscoveryWaitUntil(params);
+  if (
+    candidates.length === 0 &&
+    waitUntil > Date.now() &&
+    (await codexNativePluginsDisabled(params.request))
+  ) {
+    return {
+      message:
+        "Codex native plugin support is disabled (features.plugins = false). Enable it in the Codex config, then run /codex computer-use install.",
+    };
+  }
   while (candidates.length === 0) {
     if (Date.now() >= waitUntil) {
       break;
@@ -925,6 +936,15 @@ async function listComputerUseMarketplaceCandidates(
     cwds: [],
   } satisfies CodexRequestObject);
   return findComputerUseMarketplaces(listed, config.pluginName);
+}
+
+async function codexNativePluginsDisabled(request: CodexComputerUseRequest): Promise<boolean> {
+  const response = await request<CodexAppServerRequestResult<"experimentalFeature/list">>(
+    "experimentalFeature/list",
+    {},
+  );
+  // Codex returns the full catalog when limit is omitted; absent plugins remains unknown so polling continues.
+  return response.data.find(({ name }) => name === "plugins")?.enabled === false;
 }
 
 function blockUnsafeAutoInstallStatus(

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -675,6 +675,11 @@ type CodexAppServerRequestParamsOverride = {
   "config/read": CodexConfigReadParams;
   "config/value/write": CodexConfigValueWriteParams;
   "environment/add": { environmentId: string; execServerUrl: string };
+  "experimentalFeature/list": {
+    cursor?: string | null;
+    limit?: number | null;
+    threadId?: string | null;
+  };
   "plugin/installed": CodexPluginInstalledParams;
   "plugin/install": CodexPluginInstallParams;
   "plugin/list": CodexPluginListParams;
@@ -717,6 +722,10 @@ type CodexAppServerRequestResultMap = {
   "configRequirements/read": CodexConfigRequirementsReadResponse;
   "config/value/write": CodexConfigWriteResponse;
   "environment/add": JsonValue;
+  "experimentalFeature/list": {
+    data: Array<{ name: string; enabled: boolean }>;
+    nextCursor?: string | null;
+  };
   "experimentalFeature/enablement/set": JsonValue;
   "feedback/upload": JsonValue;
   "hooks/list": CodexHooksListResponse;

--- a/extensions/codex/src/app-server/request.test.ts
+++ b/extensions/codex/src/app-server/request.test.ts
@@ -105,6 +105,11 @@ describe("requestCodexAppServerJson sandbox guard", () => {
       response: { marketplaces: [], marketplaceLoadErrors: [] },
     },
     {
+      method: "experimentalFeature/list" as const,
+      requestParams: {},
+      response: { data: [], nextCursor: null },
+    },
+    {
       method: "config/batchWrite" as const,
       requestParams: {
         edits: [

--- a/extensions/codex/src/app-server/sandbox-guard.ts
+++ b/extensions/codex/src/app-server/sandbox-guard.ts
@@ -28,6 +28,7 @@ const DIRECT_METHOD_POLICIES = new Map<string, DirectMethodPolicy>([
   ["config/read", "allowed-control-plane"],
   ["config/value/write", "allowed-control-plane"],
   ["environment/add", "allowed-control-plane"],
+  ["experimentalFeature/list", "allowed-control-plane"],
   ["experimentalFeature/enablement/set", "allowed-control-plane"],
   ["feedback/upload", "allowed-control-plane"],
   ["hooks/list", "allowed-control-plane"],


### PR DESCRIPTION
Fixes #125360

## What Problem This Solves

When native Codex plugins are disabled, an empty inventory cannot become ready through polling. Computer Use readiness still waited the full discovery window and returned generic marketplace advice. This delayed startup and explicit install commands by about a minute.

## Why This Change Was Made

Read the effective native `plugins` feature after the first empty Computer Use inventory, only when the existing discovery wait would start. A conclusive disabled state returns the existing `marketplace_missing` result with the setting and rerun command. Enabled or unknown state retains polling. The feature query uses the existing read-only control-plane policy.

The native contract was checked directly at 0.153.4, the current integration pin, and the documented 0.149.0 floor. Both return the complete effective feature catalog when no limit is supplied. The existing enablement call excludes `plugins` from its supported keys, so its empty acknowledgement cannot establish state.

## User Impact

Operators get a prompt, actionable diagnostic when native plugins are disabled. Existing discovery, marketplace selection, status-only behavior and sandbox protections remain. No global timeout, plugin enablement, configuration key, schema or protocol version changes.

## Evidence

The real Gateway received `/codex computer-use install` through authenticated `chat.send`. The normal command owner leased a real app-server, and the client received a correlated terminal reply. Every condition used a fresh isolated native home. A transparent configured-command recorder forwarded normal traffic unchanged.

| Native version | Pinned-main command | Candidate command | Inventory requests, before → after |
| --- | --- | --- | --- |
| 0.153.4 | 60.6 s; generic marketplace failure | 0.6 s; disabled setting and rerun guidance | 31 → 1 |
| 0.149.0 | 60.9 s; generic marketplace failure | 0.4 s; disabled setting and rerun guidance | 31 → 1 |

Candidate disabled runs make one feature query after the first inventory and no install request. Full startup traffic is retained separately from the install-owner counts. Times run from command send to terminal reply, including native client acquisition but excluding Gateway startup.

- Enabled discovery retains the full 60-second window and 31 inventory reads on both versions. Native catalogs start empty and can populate unrelated plugins while Computer Use remains absent.
- A separately labeled dependency-fault control removes only the `plugins` feature entry from the real response. Original and delivered frames are retained; unknown state keeps the full wait. Naturally absent native catalogs are not claimed.
- A real local marketplace is found on the first inventory without a feature query. Native installation and readback succeed for a metadata-only plugin, then report its missing tool server. This proves discovery behavior, not desktop readiness.
- Status-only remains nonwaiting with one inventory, no feature query, no enablement call and no install.
- All 94 focused Computer Use, marketplace and request-policy tests passed. The disabled-state regression fails on original production for the expected generic-message result. That negative run also reports the same assertion through its pending promise; current candidate tests are clean.
- Fresh source-blind acceptance exercised 12 cases across both versions: 14 clauses passed, no behavior failure was found, and four internal or final gates remained outside its interface. Source and focused boundary evidence cover the internal result code, sandbox classification and unchanged configuration contracts. The original independent report and its limits are retained.

No model turn or desktop action was requested through the observed native stream. Network egress was not packet-captured. This is Linux catalog/readiness proof; macOS desktop operation is not claimed. Complete source, raw command/native observations, provenance, failures and review evidence are retained privately.

AI-assisted verification. Contributor implementation and human credit retained.
