### PR TITLE
fix(ci): preserve package provenance in candidates

### DIFF
--- a/.github/workflows/full-release-candidate.yml
+++ b/.github/workflows/full-release-candidate.yml
@@ -123,6 +123,7 @@ jobs:
       prepared_npm_bundle_json: ${{ inputs.prepared_npm_bundle_json }}
       prepare_only: true
       emit_candidate_evidence: true
+      package_published: ${{ fromJSON(inputs.request_json).packagePublished }}
       release_soak: ${{ fromJSON(inputs.request_json).releaseSoak }}
       include_repo_e2e: false
       include_release_path_suites: false

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -237,6 +237,11 @@ on:
         required: false
         default: false
         type: boolean
+      package_published:
+        description: Whether the selected package candidate is already published
+        required: false
+        default: false
+        type: boolean
       ref:
         description: Ref, tag, or SHA to validate
         required: true
@@ -2399,6 +2404,7 @@ jobs:
         env:
           ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: ${{ inputs.allow_frozen_target_scenario_omissions }}
           ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
+          PACKAGE_PUBLISHED: ${{ inputs.package_published }}
           RELEASE_PROFILE: ${{ inputs.release_test_profile }}
           RELEASE_SOAK: ${{ inputs.release_soak }}
           SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
@@ -2419,6 +2425,7 @@ jobs:
             --arg toolingSha "$TOOLING_SHA" \
             --arg releaseProfile "$RELEASE_PROFILE" \
             --argjson releaseSoak "$RELEASE_SOAK" \
+            --argjson packagePublished "$PACKAGE_PUBLISHED" \
             --arg upgradeSurvivorBaseline "$UPGRADE_SURVIVOR_BASELINE" \
             --arg upgradeSurvivorBaselines "$UPGRADE_SURVIVOR_BASELINES" \
             --arg upgradeSurvivorScenarios "$UPGRADE_SURVIVOR_SCENARIOS" \

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -756,6 +756,51 @@ function runCandidateAcquisitionStep(
   return { output, result };
 }
 
+function runFullReleaseCandidateRequest(packagePublished: boolean) {
+  const step = workflowStep(
+    workflowJob(LIVE_E2E_WORKFLOW, "prepare_docker_e2e_image"),
+    "Build full release candidate request",
+  );
+  const workdir = tempDirs.make("full-release-candidate-request-");
+  const harnessRoot = resolve(workdir, ".release-harness");
+  const outputPath = resolve(workdir, "github-output");
+  mkdirSync(harnessRoot);
+  symlinkSync(resolve("scripts"), resolve(harnessRoot, "scripts"), "dir");
+  writeFileSync(outputPath, "", "utf8");
+  const result = spawnSync("bash", ["-c", step.run ?? ""], {
+    cwd: workdir,
+    encoding: "utf8",
+    env: {
+      ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "false",
+      ALLOW_UNRELEASED_CHANGELOG: "false",
+      GITHUB_OUTPUT: outputPath,
+      NODE_OPTIONS: "--preserve-symlinks-main",
+      PACKAGE_PUBLISHED: String(packagePublished),
+      PATH: process.env.PATH,
+      RELEASE_PROFILE: "beta",
+      RELEASE_SOAK: "false",
+      RUNNER_TEMP: workdir,
+      SHARED_IMAGE_POLICY: "no-push-artifact",
+      TARGET_REPOSITORY: "openclaw/openclaw",
+      TARGET_SHA: "a".repeat(40),
+      TOOLING_SHA: "b".repeat(40),
+      UPGRADE_SURVIVOR_BASELINE: "openclaw@latest",
+      UPGRADE_SURVIVOR_BASELINES: "",
+      UPGRADE_SURVIVOR_SCENARIOS: "",
+    },
+  });
+  const output = Object.fromEntries(
+    readFileSync(outputPath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return [line.slice(0, separator), line.slice(separator + 1)];
+      }),
+  );
+  return { output, result };
+}
+
 function createReleaseChecksContextFixture() {
   const root = tempDirs.make("release-checks-context-repo-");
   const repo = resolve(root, "context-source");
@@ -5939,10 +5984,20 @@ describe("package artifact reuse", () => {
     expect(prepare.with).toMatchObject({
       enable_prepublish_plugin_registry: true,
       emit_candidate_evidence: true,
+      package_published: "${{ fromJSON(inputs.request_json).packagePublished }}",
       prepare_only: true,
       release_soak: "${{ fromJSON(inputs.request_json).releaseSoak }}",
       shared_image_policy: "${{ fromJSON(inputs.request_json).sharedImagePolicy }}",
     });
+    expect(
+      readWorkflow(LIVE_E2E_WORKFLOW).on?.workflow_call?.inputs?.package_published,
+    ).toMatchObject({
+      default: false,
+      required: false,
+      type: "boolean",
+    });
+    expect(request.env?.PACKAGE_PUBLISHED).toBe("${{ inputs.package_published }}");
+    expect(request.run).toContain('--argjson packagePublished "$PACKAGE_PUBLISHED"');
     expect(prepare.with?.published_upgrade_survivor_scenarios).toBe(
       "${{ join(fromJSON(inputs.request_json).upgradeSurvivorScenarios, ',') }}",
     );
@@ -6247,6 +6302,16 @@ describe("package artifact reuse", () => {
       ref: "${{ github.sha }}",
     });
   });
+
+  it.each([false, true])(
+    "reconstructs packagePublished=%s in the produced candidate request",
+    (packagePublished) => {
+      const { output, result } = runFullReleaseCandidateRequest(packagePublished);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(output.json ?? "{}")).toMatchObject({ packagePublished });
+    },
+  );
 
   it("gives memory extension shards enough CPU without lowering their planner cost", () => {
     const workflow = readFileSync(PLUGIN_PRERELEASE_WORKFLOW, "utf8");

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -72,6 +72,7 @@ const WORKFLOW_CALL_ONLY_INPUTS = new Set([
   "prepare_only",
   "emit_candidate_evidence",
   "release_soak",
+  "package_published",
   "package_artifact_name",
   "prepared_npm_bundle_json",
   "package_artifact_id",


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-candidate provenance failure where a canonical request carrying `packagePublished` reached the fresh-candidate workflow, but the reusable producer reconstructed the request without that required boolean.

## Why This Change Was Made

The candidate workflow now forwards only the validated `packagePublished` field into a workflow-call-only boolean input. The reusable producer explicitly reconstructs that field alongside the other execution inputs, preserving its role as the execution-input trust boundary rather than forwarding the whole request unchanged.

No runtime product behavior, retry, timeout, permission, trigger, or broad workflow scope changes.

## User Impact

Fresh immutable release candidates retain whether their package is already published, so candidate v2 evidence and downstream package acceptance consume the same provenance selected by the canonical request.

No changelog entry is required for this CI-only repair.

## Evidence

- Red: `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` produced 3 intended failures / 371 passes: missing caller forwarding, plus `packagePublished=false` and `packagePublished=true` reconstruction produced no valid request.
- Green: `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` passed 374/374.
- Final-head focused provenance proof passed 3/3 caller and false/true reconstruction cases.
- `node scripts/run-vitest.mjs test/scripts/release-workflow-matrix-plan.test.ts` passed the new workflow-call-only contract and 13 other tests; one unchanged sibling failed because macOS Bash 3.2 does not support the pre-existing `${GITHUB_REPOSITORY,,}` expression. The final-head focused routing contract passed 1/1.
- `pnpm check:workflows` was attempted twice and stopped before repository validation because the configured Python index does not provide pinned `pre-commit==4.6.2`. Repository-owned follow-on guards passed: CI git owner generation, composite-action input interpolation, and conflict-marker checks.
- Changed-file dry run selected `testRoot, tooling` and the expected scoped format, lint, type, and guard plan.
- Oxfmt, targeted oxlint, `git diff --check`, and diff-scoped autoreview passed with no P0-P3 findings.
- Test-audit: the regression executes the real producer step for both boolean values; existing tests covered canonical request creation but not field-by-field producer reconstruction. No test-only production seam was added.
- LOC: runtime production `0`; workflow tooling `+8/-0`; tests `+66/-0`.
- No hosted workflow or Full Release Validation run was dispatched for this draft.
