### PR TITLE
refactor(cron): reuse shared mock-call assertions

### DIFF
--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../../process/gateway-work-admission.js";
 import { CommandLane } from "../../process/lanes.js";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { mockCall } from "../../test-utils/mock-call-assertions.js";
 import { isCronJobActive } from "../active-jobs.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import { cronStoreKey } from "../store/key.js";
@@ -49,26 +50,12 @@ function expectQueuedRunAck(result: unknown) {
   return ack.runId as string;
 }
 
-function requireMockCall(
-  mock: { mock: { calls: unknown[][] } },
-  callIndex: number,
-  label: string,
-): unknown[] {
-  const call = mock.mock.calls[callIndex];
-  if (!call) {
-    throw new Error(`expected ${label} call ${callIndex}`);
-  }
-  return call;
-}
-
 function expectIsolatedRunJobId(
   runIsolatedAgentJob: ReturnType<typeof vi.fn>,
   callIndex: number,
   jobId: string,
 ) {
-  const [params] = requireMockCall(runIsolatedAgentJob, callIndex, "runIsolatedAgentJob") as [
-    { job?: { id?: string } }?,
-  ];
+  const [params] = mockCall(runIsolatedAgentJob, callIndex) as [{ job?: { id?: string } }?];
   expect(params?.job?.id).toBe(jobId);
 }
 
@@ -506,9 +493,7 @@ describe("cron service ops regressions", () => {
 
     expect(runResult).toEqual({ ok: true, ran: true });
     expect(runIsolatedAgentJob).toHaveBeenCalledOnce();
-    const [params] = requireMockCall(runIsolatedAgentJob, 0, "runIsolatedAgentJob") as [
-      { message?: unknown }?,
-    ];
+    const [params] = mockCall(runIsolatedAgentJob, 0) as [{ message?: unknown }?];
     expect(params?.message).toBe(marker);
   });
 
@@ -595,10 +580,7 @@ describe("cron service ops regressions", () => {
     const result = await run(state, "stale-running", "force");
     expect(result).toEqual({ ok: true, ran: true });
     expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
-    const [text, options] = requireMockCall(enqueueSystemEvent, 0, "enqueueSystemEvent") as [
-      string,
-      { agentId?: unknown }?,
-    ];
+    const [text, options] = mockCall(enqueueSystemEvent, 0) as [string, { agentId?: unknown }?];
     expect(text).toBe("stale-running");
     expect(options?.agentId).toBe("main");
   });


### PR DESCRIPTION
## What Problem This Solves

Cron operation regressions duplicated the shared mock-call guard, adding another implementation to maintain.

## Why This Change Was Made

Use the existing `mockCall` helper at three call sites. Preserve the recorded call indexes, missing-call failures and payload tuple types; only the unasserted missing-call diagnostic becomes canonical.

## User Impact

No runtime behavior changes. All 20 cases and 78 assertions remain, including timeout, cancellation, detached admission, queue ordering and on-exit outcomes. Production delta 0; test net−18 lines.

## Evidence

The complete baseline and candidate suites each passed 20/20 in identical order. The full normal LOCAL changed gate passed, and independent Codex P2 review found no actionable issues. Source retention confirms all assertions and three tuple casts are preserved.

The separately noted assertion-failure fixture-settlement concern remains unproven and unchanged.
