### PR TITLE
fix(webchat): avoid duplicate captions when finalizing media replies

### DIFF
--- a/src/config/sessions/transcript-mirror.test.ts
+++ b/src/config/sessions/transcript-mirror.test.ts
@@ -20,11 +20,14 @@ describe("resolveMirroredTranscriptText", () => {
     ).toBe("See attachments\na.png, b.pdf");
   });
 
-  it("keeps text with the media placeholder when no name can be derived", () => {
-    expect(resolveMirroredTranscriptText({ text: "hello", mediaUrls: ["   /   "] })).toBe(
-      "hello\nmedia",
-    );
-  });
+  it.each(["   /   ", "data:image/png;base64,aGVsbG8=", "data:text/plain,hello"])(
+    "uses the media placeholder when %s has no filename",
+    (mediaUrl) => {
+      expect(resolveMirroredTranscriptText({ text: "hello", mediaUrls: [mediaUrl] })).toBe(
+        "hello\nmedia",
+      );
+    },
+  );
 
   it("returns media names alone when there is no text", () => {
     expect(

--- a/src/config/sessions/transcript-mirror.ts
+++ b/src/config/sessions/transcript-mirror.ts
@@ -15,7 +15,8 @@ function extractFileNameFromMediaUrl(value: string): string | null {
   const cleaned = stripQuery(trimmed);
   try {
     const parsed = new URL(cleaned);
-    const base = path.basename(parsed.pathname);
+    // Data URLs carry inline bytes, not a filename suitable for transcript text.
+    const base = parsed.protocol === "data:" ? "" : path.basename(parsed.pathname);
     if (!base) {
       return null;
     }

--- a/src/gateway/server-methods/chat-transcript-persistence.ts
+++ b/src/gateway/server-methods/chat-transcript-persistence.ts
@@ -74,48 +74,6 @@ export type SourceReplyContentState = {
   backedManagedOutgoingContent: boolean;
 };
 
-function replaceAssistantTextWithDisplayText(
-  message: Record<string, unknown>,
-  displayContent: AssistantDisplayContentBlock[],
-): AssistantDisplayContentBlock[] {
-  const original = Array.isArray(message.content)
-    ? (message.content as AssistantDisplayContentBlock[])
-    : [];
-  const content: AssistantDisplayContentBlock[] = [];
-  const seenText = new Set<string>();
-  for (const block of original) {
-    if (block.type === "thinking" || block.type === "toolCall") {
-      content.push(block);
-      continue;
-    }
-    if (block.type !== "text" || typeof block.text !== "string") {
-      continue;
-    }
-    const splitText = splitMediaFromOutput(block.text).text;
-    if (splitText === block.text && /\bMEDIA:/iu.test(block.text)) {
-      continue;
-    }
-    const text = sanitizeAssistantDisplayText(splitText, {
-      preserveBoundaries: true,
-    });
-    if (text) {
-      if (text === block.text) {
-        content.push(block);
-      } else {
-        const { textSignature: _textSignature, ...rest } = block;
-        content.push({ ...rest, text });
-      }
-      seenText.add(text);
-    }
-  }
-  for (const block of displayContent) {
-    if (block.type === "text" && typeof block.text === "string" && !seenText.has(block.text)) {
-      content.push(block);
-    }
-  }
-  return content;
-}
-
 function mergeAssistantDisplayContent(
   modelContent: AssistantDisplayContentBlock[],
   preparedDisplayContent: AssistantDisplayContentBlock[],
@@ -149,6 +107,7 @@ function buildAssistantDisplayRewrite(params: {
   message: Record<string, unknown>;
   displayContent: AssistantDisplayContentBlock[];
   managedMediaUrls?: readonly string[];
+  retainOriginalText?: true;
 }): Record<string, unknown> {
   const prepared = applyAssistantDeliveryDirectives(
     {
@@ -157,7 +116,48 @@ function buildAssistantDisplayRewrite(params: {
     },
     { managedMediaUrls: params.managedMediaUrls },
   );
-  const content = replaceAssistantTextWithDisplayText(params.message, prepared.content);
+  const original = Array.isArray(params.message.content)
+    ? (params.message.content as AssistantDisplayContentBlock[])
+    : [];
+  const content: AssistantDisplayContentBlock[] = [];
+  const seenText = new Set<string>();
+  for (const block of original) {
+    if (block.type === "thinking" || block.type === "toolCall") {
+      content.push(block);
+      continue;
+    }
+    if (
+      block.type !== "text" ||
+      typeof block.text !== "string" ||
+      (!params.retainOriginalText &&
+        !prepared.content.some(
+          (candidate) => candidate.type === "text" && candidate.text === block.text,
+        ))
+    ) {
+      continue;
+    }
+    const splitText = splitMediaFromOutput(block.text).text;
+    if (splitText === block.text && /\bMEDIA:/iu.test(block.text)) {
+      continue;
+    }
+    const text = sanitizeAssistantDisplayText(splitText, {
+      preserveBoundaries: true,
+    });
+    if (text) {
+      if (text === block.text) {
+        content.push(block);
+      } else {
+        const { textSignature: _textSignature, ...rest } = block;
+        content.push({ ...rest, text });
+      }
+      seenText.add(text);
+    }
+  }
+  for (const block of prepared.content) {
+    if (block.type === "text" && typeof block.text === "string" && !seenText.has(block.text)) {
+      content.push(block);
+    }
+  }
   return {
     ...prepared,
     content,
@@ -639,6 +639,8 @@ export async function rewriteAssistantTranscriptMessageByTurnIndexAndMedia(param
     message: target.message,
     displayContent: params.content,
     managedMediaUrls: params.mediaUrls,
+    // Indexed replies can contain earlier chunks; exact final/mirror replacements cannot.
+    retainOriginalText: true,
   });
   const rewrittenEvent = Object.assign({}, targetRow.event as Record<string, unknown>, {
     message: rewrittenMessage,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -3321,68 +3321,84 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
   });
 
-  it("replaces reply-to-current with an explicit id on a runtime-owned media rewrite", async () => {
-    await withTranscriptFixtureState("openclaw-chat-send-owned-media-", async (fixtureDir) => {
-      const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
-      writeSavedPng(fixtureDir, "reply.png");
-      await appendSourceReplyMirrorEntry({
-        idempotencyKey: "older-distinct-assistant",
-        text: "A distinct earlier reply.",
-        provider: "openai",
-        model: "codex",
-      });
-      await appendSourceReplyMirrorEntry({
-        idempotencyKey: "runtime-owned-assistant",
-        openclawDelivery: { audioAsVoice: true, replyToCurrent: true },
-        text: `Dinner options\nMEDIA:${mediaUrl}`,
-        provider: "openai",
-        model: "codex",
-      });
-      setAgentRunReplies([
-        {
-          kind: "final",
-          payload: setReplyPayloadMetadata(
-            {
-              text: "Dinner options",
-              mediaUrl,
-              mediaUrls: [mediaUrl],
-              replyToId: "3114cf3c-e628-4c33-9214-894a1d8b6c60",
-            },
-            {
-              assistantTranscriptOwned: true,
-              assistantTranscriptIdempotencyKey: "runtime-owned-assistant",
-            },
-          ),
-        },
-      ]);
-      const { send } = createChatRequestFixture();
+  it.each([false, true])(
+    "replaces reply-to-current on a runtime-owned media rewrite (signed=%s)",
+    async (signed) => {
+      await withTranscriptFixtureState("openclaw-chat-send-owned-media-", async (fixtureDir) => {
+        const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+        writeSavedPng(fixtureDir, "reply.png");
+        await appendSourceReplyMirrorEntry({
+          idempotencyKey: "older-distinct-assistant",
+          text: "A distinct earlier reply.",
+          provider: "openai",
+          model: "codex",
+        });
+        await appendSourceReplyMirrorEntry({
+          idempotencyKey: "runtime-owned-assistant",
+          openclawDelivery: { audioAsVoice: true, replyToCurrent: true },
+          text: `Dinner options\nMEDIA:${mediaUrl}`,
+          ...(signed
+            ? {
+                content: [
+                  { type: "text", text: "Dinner options", textSignature: "msg_final" },
+                  { type: "text", text: `MEDIA:${mediaUrl}` },
+                ],
+              }
+            : {}),
+          provider: "openai",
+          model: "codex",
+        });
+        setAgentRunReplies([
+          {
+            kind: "final",
+            payload: setReplyPayloadMetadata(
+              {
+                text: "Dinner options",
+                mediaUrl,
+                mediaUrls: [mediaUrl],
+                replyToId: "3114cf3c-e628-4c33-9214-894a1d8b6c60",
+              },
+              {
+                assistantTranscriptOwned: true,
+                assistantTranscriptIdempotencyKey: "runtime-owned-assistant",
+              },
+            ),
+          },
+        ]);
+        const { send } = createChatRequestFixture();
 
-      await send({
-        idempotencyKey: "idem-owned-media",
-        expectBroadcast: false,
-        waitFor: "dedupe",
-      });
+        await send({
+          idempotencyKey: "idem-owned-media",
+          expectBroadcast: false,
+          waitFor: "dedupe",
+        });
 
-      const messages = await readActiveAssistantTranscriptMessages();
-      expect(messages.map((message) => message.idempotencyKey)).toEqual([
-        "older-distinct-assistant",
-        "runtime-owned-assistant",
-      ]);
-      const rewritten = messages[1];
-      const content = Array.isArray(rewritten?.content)
-        ? (rewritten.content as Array<Record<string, unknown>>)
-        : [];
-      expect(content[0]).toEqual({ type: "text", text: "Dinner options" });
-      expect(content.filter((block) => block.type === "image")).toHaveLength(1);
-      expect(rewritten?.openclawDelivery).toEqual({
-        audioAsVoice: true,
-        mediaUrls: [mediaUrl],
-        replyToId: "3114cf3c-e628-4c33-9214-894a1d8b6c60",
+        const messages = await readActiveAssistantTranscriptMessages();
+        expect(messages.map((message) => message.idempotencyKey)).toEqual([
+          "older-distinct-assistant",
+          "runtime-owned-assistant",
+        ]);
+        const rewritten = messages[1];
+        const content = Array.isArray(rewritten?.content)
+          ? (rewritten.content as Array<Record<string, unknown>>)
+          : [];
+        expect(content[0]).toEqual({ type: "text", text: "Dinner options" });
+        expect(content.filter((block) => block.type === "image")).toHaveLength(1);
+        if (signed) {
+          expect((await readRawActiveAssistantTranscriptMessages())[1]?.content).toEqual([
+            { type: "text", text: "Dinner options", textSignature: "msg_final" },
+          ]);
+        }
+        expect(rewritten?.openclawDelivery).toEqual({
+          audioAsVoice: true,
+          mediaUrls: [mediaUrl],
+          replyToId: "3114cf3c-e628-4c33-9214-894a1d8b6c60",
+        });
+        expect(JSON.stringify(rewritten)).not.toContain("[[reply_to:");
+        expect(JSON.stringify(messages)).not.toContain(":assistant-media");
       });
-      expect(JSON.stringify(rewritten)).not.toContain("[[reply_to:");
-      expect(JSON.stringify(messages)).not.toContain(":assistant-media");
-    });
-  });
+    },
+  );
 
   it("persists agent media only after a disposed attempt transcript owner has unwound", async () => {
     await withTranscriptFixtureState(
@@ -3943,7 +3959,14 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         const assistantEntries = await readActiveAssistantTranscriptMessages();
         expect(assistantEntries).toHaveLength(1);
         expect(assistantEntries[0]?.idempotencyKey).toBe(mirrorIdempotencyKey);
-        expect(JSON.stringify(assistantEntries[0])).toContain(replyText);
+        for (const message of [
+          assistantEntries[0],
+          ...(await readRawActiveAssistantTranscriptMessages()),
+        ]) {
+          expect(getMessageContent({ message }).filter((block) => block.type === "text")).toEqual([
+            { type: "text", text: replyText },
+          ]);
+        }
         expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
         expect(JSON.stringify(assistantEntries[0]?.content)).not.toContain(mediaUrl);
       },


### PR DESCRIPTION
Closes #137499
Related: #135185, #135061

## What Problem This Solves

Fixes an issue where users reopening a media reply in WebChat can see its caption twice when the reply was persisted as a compact caption-plus-filename mirror before exact media finalization. Also prevents inline data-URL bytes from appearing as filenames in compact mirror text.

## Why This Change Was Made

The exact finalization owner previously kept all original text and appended prepared text. A compact caption-plus-filename block differs from the final caption, so both remained. Exact replacements now keep only matching final text, preserving unchanged text signatures plus thinking/tool-call blocks. Turn-index aggregation explicitly retains earlier chunks.

The one-call text helper is absorbed into the canonical rewrite; no UI deduplication or second persistence path is added. This preserves #135185's separation of visible media-failure guidance from durable model content. Data URLs use the existing unnamed-media placeholder, consistent with [RFC 2397](https://www.rfc-editor.org/info/rfc2397/).

Best-fix verdict: repair exact replacement at its owner. A UI-only filter leaves saved content wrong; dropping prior text indiscriminately breaks indexed multi-chunk replies. Production LOC: +47/-44 (net **+3**); tests: +91/-65 (net **+26**), including a table reindent. The small production increase preserves signed-text metadata and the distinct indexed-aggregation contract after removing the separate helper. No dependency, config, API, schema, migration, or authorization change.

## User Impact

Finalized media replies keep one caption across reloads while retaining their attachment. Matching signed text, earlier indexed chunks, and thinking/tool-call metadata remain intact. Existing already-finalized duplicate history is not bulk-rewritten.

This is a saved/display-history repair: delivery mirrors are intentionally excluded from provider replay. It does not claim duplicated provider prompts.

## Evidence

- Existing Gateway mirror test reproduced the duplicate before the fix. Both data-URL table cases also failed on the old implementation. A signed-text control caught an intermediate candidate regression; the final fix preserves that signature.
- **351 tests passed** across Gateway directive/finalization, reply dispatch, WebChat media, compact transcript mirrors, agent reply payloads, and internal source-reply integration. Full changed-code gate passed, including core/test types, format, lint, and policy checks. Independent Codex review: no actionable P0–P2 findings.
- **Real Chrome + built Gateway, baseline then candidate on one isolated Blacksmith Testbox:** caption count **2 → 1**, including after reload; the synthetic PNG loaded in both; the same follow-up completed in both. Actual HTTP provider requests numbered one per phase and excluded the mirror caption. The provider response was deterministic, not a live commercial model call.
- [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33791948081), lease `tbx_01m1m95nk06met2yft65xj90dm`, wrapper exit **0**, command time **12m30.736s**. Both runtime builds succeeded; all 10,863 runtime-file hashes per phase were recorded. Both Gateway owners reported `confirmed-stopped` with no cleanup errors; the temporary source clone was removed and the lease stopped. Operator Chrome profile was used only for the owned synthetic proof tab, now closed.

Proof boundary: the fixture calls the canonical compact-mirror producer and actual exact writer, then loads the real Gateway history/media and sends a browser follow-up. It does **not** assert that a fresh message-tool call currently creates a compact mirror. Baseline: `6883d5abc56429f448f83e5ba62812261e0a6702`; the four affected files were unchanged on refreshed main `6d44018b15af7a2b2d16919741cb9b43544baf8d`. Candidate source hashes match this PR. Local evidence archive SHA-256: `b0a5a4d885a231d2810d6aba6d4d264901af8372a4976833c0e4bbbb2ac61229`.

### Before

![Baseline: caption appears twice](https://github.com/user-attachments/assets/d5e4337d-64f3-42d1-b244-bf86de12924c)

### After

![Candidate: one caption with the attachment retained](https://github.com/user-attachments/assets/094d4038-15cb-49fc-bc99-15d3b83e8677)

### Regression provenance

Raw-parent comparison identifies the implicated helper in `9030d86e7be98e2fee4fe021cca3ee7570c908d2` (parent `59bcbd156fa31568f47eb4b73e8b76cbe785a764`), merged via #135185 on 2026-09-01. PR author: @gaoanze888; merger: @obviyus; commit committer: GitHub. Specific line authorship and any automation trigger are not inferred from those roles. Thanks to @gaoanze888 and @snls1994 for the original media-history repair and report; that behavior remains covered.
