### PR TITLE
fix: point Doctor service recovery to the right commands

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -53,13 +53,20 @@ manual allowlist rules unchanged. Rerun affected workflows and choose
 Explicit repair stops the matching managed Gateway before inspecting plugins or
 mutable state, excludes other processes during repair, verifies readiness,
 and restarts the same service once. It preserves the service definition and does
-not start a service that was already stopped. Run repair from a shell outside the
-Gateway process tree. For externally supervised or unmatched installations, stop
+not activate a service confirmed offline before maintenance. A loaded, enabled
+macOS job between respawns is not offline: Doctor stops it before repair and
+resumes it afterward. Run repair from a shell outside the Gateway process tree. For externally supervised or unmatched installations, stop
 and start the Gateway through its owning supervisor.
 
 This maintenance window also applies when repair ultimately finds no changes.
-Diagnostic runs without `--fix`, `--repair`, or `--yes` do not enter maintenance.
+Runs without `--fix`, `--repair`, or `--yes` do not enter maintenance.
 Custom state directories remain runtime-only and do not adopt a native service.
+
+`--force` alone does not select repair mode: `openclaw doctor --force` remains
+guided and still requires interactive consent before an eligible service rewrite.
+With `--fix`, `--repair`, or `--yes`, it allows aggressive config/state repairs
+but preserves the installed service definition. Force does not bypass service
+ownership, write-access, or interactive-only confirmation requirements.
 
 <Warning>
   `doctor --fix` follows explicitly configured workspace and store paths, including
@@ -85,6 +92,20 @@ Doctor can repair its selected state without changing or starting that service.
 If migration or config repair cannot finish, Doctor leaves the stopped service
 stopped and reports an incomplete repair. Resolve the reported blocker, rerun
 `openclaw doctor --fix`, then start the service through its owner.
+
+## Gateway service recovery
+
+Run `openclaw gateway status --deep` to inspect the installed service and its
+runtime before choosing a recovery action. Use `openclaw gateway install` for a
+missing service, `openclaw gateway start` for an installed service that is not
+loaded, or `openclaw gateway install --force` from the intended installation to
+replace its service definition. Externally managed services still belong to
+their supervisor.
+
+For legacy services or conflicting systemd scopes, run `openclaw doctor`
+interactively to review the findings and confirm supported cleanup. Cleanup
+reports what it removed or skipped; it does not guarantee a replacement service
+will be installed. Explicit repair maintenance skips this separate cleanup flow.
 
 ## Remote Gateway recovery
 
@@ -152,7 +173,7 @@ openclaw channels status --probe
 | `--no-workspace-suggestions`    | Disable workspace memory/search suggestions.                                                                                                                                                                |
 | `--yes`                         | Accept defaults and enter repair maintenance without prompting.                                                                                                                                             |
 | `--repair` / `--fix`            | Apply recommended repairs while coordinating maintenance with the matching managed Gateway (`--fix` is an alias). Preserve the installed service definition; use explicit `gateway` commands to replace it. |
-| `--force`                       | Apply aggressive config/state repairs. Repair maintenance still preserves the installed service definition.                                                                                                 |
+| `--force`                       | Allow aggressive repair choices. Alone, remains guided; with `--fix`, `--repair`, or `--yes`, preserves the installed service definition.                                                                   |
 | `--non-interactive`             | Run without prompts; safe automatic migrations still apply. Combine with `--fix`, `--repair`, or `--yes` to enter repair maintenance.                                                                       |
 | `--generate-gateway-token`      | Generate and configure a gateway token.                                                                                                                                                                     |
 | `--allow-exec`                  | Allow doctor to execute configured `exec` SecretRefs while verifying secrets.                                                                                                                               |

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -84,12 +84,12 @@ cat ~/.openclaw/openclaw.json
 `openclaw doctor --fix`. They share the same Doctor rule registry, but they do
 not select or act on rules in the same way:
 
-| Mode                     | Prompts   | Writes config/state     | Output                 | Use it for                       |
-| ------------------------ | --------- | ----------------------- | ---------------------- | -------------------------------- |
-| `openclaw doctor`        | yes       | no                      | friendly health report | a human checking status          |
-| `openclaw doctor --json` | no        | no                      | JSON advisory report   | machine-readable operator checks |
-| `openclaw doctor --fix`  | sometimes | yes, with repair policy | friendly repair log    | applying approved repairs        |
-| `openclaw doctor --lint` | no        | no                      | structured findings    | CI, preflight, and review gates  |
+| Mode                     | Prompts   | Writes config/state                        | Output                 | Use it for                       |
+| ------------------------ | --------- | ------------------------------------------ | ---------------------- | -------------------------------- |
+| `openclaw doctor`        | yes       | yes, safe migrations and confirmed repairs | friendly health report | guided checks and repairs        |
+| `openclaw doctor --json` | no        | no                                         | JSON advisory report   | machine-readable operator checks |
+| `openclaw doctor --fix`  | sometimes | yes, with repair policy                    | friendly repair log    | applying approved repairs        |
+| `openclaw doctor --lint` | no        | no                                         | structured findings    | CI, preflight, and review gates  |
 
 Default `doctor --lint` runs the broad-safe automation profile: checks that are
 static, local, and useful in CI or preflight output. It skips opt-in checks that
@@ -521,7 +521,7 @@ That stages grounded durable candidates into the short-term dreaming store while
 
   </Accordion>
   <Accordion title="8. Gateway service migrations and cleanup hints">
-    Doctor detects legacy gateway services (launchd/systemd/schtasks) and offers to remove them and install the OpenClaw service using the current gateway port. It can also scan for extra gateway-like services and print cleanup hints. Profile-named OpenClaw gateway services are considered first-class and are not flagged as "extra."
+    Run `openclaw doctor` interactively to review legacy gateway services (launchd/systemd/schtasks) and confirm supported cleanup. Explicit repair maintenance skips this separate cleanup flow. Removal is reported separately from installation; use `openclaw gateway install` when the intended native service is missing. Doctor can also scan for extra gateway-like services and print cleanup hints. Profile-named OpenClaw gateway services are considered first-class and are not flagged as "extra."
 
     Linux user-service cleanup preserves the unit file if stopping or disabling the service fails. An interrupted status probe does not permit file-only removal; that fallback is reported only when `systemctl` is unavailable.
 
@@ -529,7 +529,7 @@ That stages grounded durable candidates into the short-term dreaming store while
 
   </Accordion>
   <Accordion title="8b. Startup Matrix migration">
-    When a Matrix channel account has a pending or actionable legacy state migration, doctor (in `--fix` / `--repair` mode) creates a pre-migration snapshot and then runs the best-effort migration steps: legacy Matrix state migration and legacy encrypted-state preparation. Both steps are non-fatal; errors are logged and startup continues. In read-only mode (`openclaw doctor` without `--fix`) this check is skipped entirely.
+    When a Matrix channel account has a pending or actionable legacy state migration, doctor (in `--fix` / `--repair` mode) creates a pre-migration snapshot and then runs the best-effort migration steps: legacy Matrix state migration and legacy encrypted-state preparation. Both steps are non-fatal; errors are logged and startup continues. Without explicit repair (`--fix`, `--repair`, or `--yes`), this check is skipped.
   </Accordion>
   <Accordion title="8c. Device pairing and auth drift">
     Doctor inspects device-pairing state as part of the normal health pass, reporting:
@@ -609,7 +609,7 @@ That stages grounded durable candidates into the short-term dreaming store while
 
   </Accordion>
   <Accordion title="13. Gateway health check + restart">
-    Doctor runs a health check and offers to restart the gateway when it looks unhealthy.
+    Guided Doctor runs a health check and can offer recovery for a local Gateway, subject to service ownership and confirmation. A failed remote health check does not trigger local service recovery, even when the remote URL is a loopback SSH tunnel. Check the remote connection and recover the Gateway on its host. Explicit repair maintenance only resumes the matching service it stopped. A loaded, enabled macOS job between respawns is not treated as an intentionally stopped service.
   </Accordion>
   <Accordion title="13b. Memory search readiness">
     Doctor checks whether the configured memory search embedding provider is ready for the default agent. The behavior depends on the configured provider:
@@ -633,9 +633,9 @@ That stages grounded durable candidates into the short-term dreaming store while
 
     Notes:
 
-    - `openclaw doctor` prompts before rewriting supervisor config.
+    - `openclaw doctor` prompts before rewriting supervisor config. `openclaw doctor --force` alone remains guided: it allows aggressive repair choices but still requires interactive consent for an eligible service rewrite. It does not enter repair maintenance or bypass ownership and write-access checks.
     - `openclaw doctor --yes` accepts default non-service repair prompts and enters maintenance while preserving the service definition.
-    - `openclaw doctor --fix` applies recommended repairs without prompts (`--repair` is an alias; `--yes` also enters repair maintenance). It stops the matching managed Gateway before plugin or mutable-state inspection, verifies repairs, and restarts the same service once, even when no changes are needed. It preserves the installed service definition, leaves already-stopped services stopped, and refuses to stop an ancestor Gateway. Plain inspection does not enter maintenance, and custom state directories do not adopt native services.
+    - `openclaw doctor --fix` applies recommended repairs without prompts (`--repair` is an alias; `--yes` also enters repair maintenance). It stops the matching managed Gateway before plugin or mutable-state inspection, verifies repairs, and restarts the same service once, even when no changes are needed. It preserves the installed service definition, leaves services confirmed offline before maintenance offline, and refuses to stop an ancestor Gateway. Plain inspection does not enter maintenance, and custom state directories do not adopt native services.
     - Explicit repair refuses unavailable service inspection and unmatched services that may still run. After their owner stops them and the native manager confirms they are offline, Doctor repairs its selected state without changing or starting those services. A disabled systemd unit can still be restarting; Doctor checks runtime state as well as installation state.
     - An updater's explicit Gateway activation policy leaves stop/restart ownership with the updater. Doctor still requires native proof that the service is offline; a live `update --no-restart` repair fails without stopping or restarting it. Stop the service through its owner before retrying the update. Older update parents without that policy retain ordinary Doctor maintenance.
     - `openclaw doctor --fix --force` preserves the service definition too. Use `openclaw gateway install --force` to request a rewrite; operator-owned systemd drop-ins remain unchanged.

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -169,15 +169,32 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(runtime.exit).toHaveBeenCalledWith(2);
   });
 
-  it("maps --fix to repair=true", async () => {
+  it.each([
+    { args: [], repair: false, force: false, yes: false },
+    { args: ["--fix"], repair: true, force: false, yes: false },
+    { args: ["--force"], repair: false, force: true, yes: false },
+    { args: ["--fix", "--force"], repair: true, force: true, yes: false },
+    { args: ["--repair", "--force"], repair: true, force: true, yes: false },
+    { args: ["--yes", "--force"], repair: false, force: true, yes: true },
+  ])("forwards repair and force independently for $args", async ({ args, repair, force, yes }) => {
     doctorCommand.mockResolvedValue(undefined);
 
-    await runMaintenanceCli(["doctor", "--fix"]);
+    await runMaintenanceCli(["doctor", ...args]);
 
     expect(doctorCommand).toHaveBeenCalledTimes(1);
     const [runtimeArg, options] = commandCall(doctorCommand);
     expect(runtimeArg).toBe(runtime);
-    expect(options.repair).toBe(true);
+    expect(options).toMatchObject({ repair, force, yes });
+  });
+
+  it("explains the force option without promising service rewrites during repair", () => {
+    const program = new Command();
+    registerMaintenanceCommands(program);
+    const doctor = program.commands.find((command) => command.name() === "doctor");
+    const help = doctor?.helpInformation().replace(/\s+/gu, " ");
+
+    expect(help).toContain("Allow aggressive repair choices");
+    expect(help).toContain("(with --fix, preserves service definitions)");
   });
 
   it("passes session sqlite options to doctor command", async () => {

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -56,7 +56,11 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--yes", "Accept defaults without prompting", false)
     .option("--repair", "Apply recommended repairs without prompting", false)
     .option("--fix", "Apply recommended repairs (alias for --repair)", false)
-    .option("--force", "Apply aggressive repairs (overwrites custom service config)", false)
+    .option(
+      "--force",
+      "Allow aggressive repair choices (with --fix, preserves service definitions)",
+      false,
+    )
     .option("--non-interactive", "Run without prompts (safe migrations only)", false)
     .option("--generate-gateway-token", "Generate and configure a gateway token", false)
     .option(

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -1950,6 +1950,11 @@ describe("maybeRepairGatewayServiceConfig", () => {
         await runRepair({ gateway: {} });
 
         expectNoteContaining("resolves to a source checkout", "Gateway service config");
+        expectNoteContaining(
+          "Run `openclaw gateway install --force` from the intended package install to replace the gateway service definition.",
+          "Gateway service config",
+        );
+        expectNoNoteContaining("openclaw doctor --fix", "Gateway service config");
         expect(mocks.install).not.toHaveBeenCalled();
       } finally {
         await fs.rm(root, { recursive: true, force: true });
@@ -2181,7 +2186,7 @@ describe("maybeScanExtraGatewayServices", () => {
     );
   });
 
-  it("keeps legacy gateway services warning-level", () => {
+  it("keeps legacy gateway services warning-level with guided cleanup advice", () => {
     expect(
       extraGatewayServiceToHealthFinding({
         platform: "linux",
@@ -2196,6 +2201,8 @@ describe("maybeScanExtraGatewayServices", () => {
         severity: "warning",
         source: "linux",
         target: "openclaw-gateway.service",
+        fixHint:
+          "Run `openclaw doctor` interactively to review legacy gateway services and confirm supported cleanup.",
       }),
     );
   });
@@ -2251,23 +2258,8 @@ describe("maybeScanExtraGatewayServices", () => {
       },
     ]);
 
-    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
-    const prompter = {
-      confirm: vi.fn(),
-      confirmAutoFix: vi.fn(),
-      confirmAggressiveAutoFix: vi.fn(),
-      confirmRuntimeRepair: vi.fn().mockResolvedValue(true),
-      select: vi.fn(),
-      shouldRepair: false,
-      shouldForce: false,
-      repairMode: {
-        shouldRepair: false,
-        shouldForce: false,
-        nonInteractive: false,
-        canPrompt: true,
-        updateInProgress: false,
-      },
-    };
+    const runtime = makeDoctorIo();
+    const prompter = makeDoctorPrompts();
 
     await maybeScanExtraGatewayServices({ deep: false }, runtime, prompter);
 
@@ -2277,8 +2269,8 @@ describe("maybeScanExtraGatewayServices", () => {
       stdout: process.stdout,
     });
     expectNoteContaining("clawdbot-gateway.service", "Legacy gateway removed");
-    expect(runtime.log).toHaveBeenCalledWith(
-      "Legacy gateway services removed. Installing OpenClaw gateway next.",
+    expect(runtime.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("Installing OpenClaw gateway next."),
     );
   });
 
@@ -2298,8 +2290,8 @@ describe("maybeScanExtraGatewayServices", () => {
       expect(rename).toHaveBeenCalledTimes(1);
       expectNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
       expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway cleanup skipped");
-      expect(runtime.log).toHaveBeenCalledWith(
-        "Legacy gateway services removed. Installing OpenClaw gateway next.",
+      expect(runtime.log).not.toHaveBeenCalledWith(
+        expect.stringContaining("Installing OpenClaw gateway next."),
       );
     },
   );

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -341,7 +341,7 @@ export function extraGatewayServiceToHealthFinding(service: ExtraGatewayService)
     target: service.label,
     fixHint:
       service.legacy === true
-        ? "Run openclaw doctor --fix to remove legacy gateway services."
+        ? "Run `openclaw doctor` interactively to review legacy gateway services and confirm supported cleanup."
         : "Run a single gateway per machine unless this extra gateway is intentional.",
   };
 }
@@ -568,7 +568,7 @@ export async function maybeRepairGatewayServiceConfig(
   const sourceCheckoutWarning = serviceLayout?.entrypointSourceCheckout
     ? [
         `Gateway service entrypoint resolves to a source checkout: ${serviceLayout.packageRootReal ?? serviceLayout.packageRoot ?? serviceLayout.entrypointReal ?? serviceLayout.entrypoint}.`,
-        "Run `openclaw doctor --fix` from the intended package install, or reinstall the gateway service with `openclaw gateway install --force`.",
+        "Run `openclaw gateway install --force` from the intended package install to replace the gateway service definition.",
       ].join("\n")
     : null;
 
@@ -1031,9 +1031,6 @@ export async function maybeScanExtraGatewayServices(
       }
       if (failed.length > 0) {
         note(failed.map((line) => `- ${line}`).join("\n"), "Legacy gateway cleanup skipped");
-      }
-      if (removed.length > 0) {
-        runtime.log("Legacy gateway services removed. Installing OpenClaw gateway next.");
       }
     }
   }

--- a/src/commands/doctor-prompter.test.ts
+++ b/src/commands/doctor-prompter.test.ts
@@ -5,20 +5,21 @@ import { createDoctorPrompter } from "./doctor-prompter.js";
 const confirmMock = vi.fn();
 const selectMock = vi.fn();
 
-vi.mock("@clack/prompts", () => ({
+vi.mock("@clack/prompts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@clack/prompts")>()),
   confirm: (options: unknown) => confirmMock(options),
   select: (options: unknown) => selectMock(options),
 }));
 
-function setNonInteractiveTerminal() {
+function setTerminal(isTTY: boolean) {
   Object.defineProperty(process.stdin, "isTTY", {
-    value: false,
+    value: isTTY,
     configurable: true,
   });
 }
 
 function createRepairPrompter(params?: { force?: boolean }) {
-  setNonInteractiveTerminal();
+  setTerminal(false);
   return createDoctorPrompter({
     runtime: {
       log: vi.fn(),
@@ -34,15 +35,16 @@ function createRepairPrompter(params?: { force?: boolean }) {
 }
 
 describe("createDoctorPrompter", () => {
-  const originalStdinIsTTY = process.stdin.isTTY;
+  const originalStdinIsTTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
   const originalUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
 
   afterEach(() => {
     vi.resetAllMocks();
-    Object.defineProperty(process.stdin, "isTTY", {
-      value: originalStdinIsTTY,
-      configurable: true,
-    });
+    if (originalStdinIsTTY) {
+      Object.defineProperty(process.stdin, "isTTY", originalStdinIsTTY);
+    } else {
+      Reflect.deleteProperty(process.stdin, "isTTY");
+    }
     if (originalUpdateInProgress === undefined) {
       delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
     } else {
@@ -86,40 +88,44 @@ describe("createDoctorPrompter", () => {
     expect(confirmMock).not.toHaveBeenCalled();
   });
 
-  it("does not auto-accept runtime repairs that require interactive confirmation", async () => {
-    const prompter = createRepairPrompter();
+  it.each([{ repair: true }, { repair: true, force: true }, { yes: true }, { force: true }])(
+    "refuses interactive-only repairs without a terminal for %j",
+    async (options) => {
+      setTerminal(false);
+      const prompter = createDoctorPrompter({
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        options,
+      });
 
-    await expect(
-      prompter.confirmRuntimeRepair({
-        message: "Archive orphan transcripts?",
-        initialValue: false,
-        requiresInteractiveConfirmation: true,
-      }),
-    ).resolves.toBe(false);
-    expect(confirmMock).not.toHaveBeenCalled();
-  });
+      await expect(
+        prompter.confirmRuntimeRepair({
+          message: "Overwrite gateway service config?",
+          initialValue: true,
+          requiresInteractiveConfirmation: true,
+        }),
+      ).resolves.toBe(false);
+      expect(confirmMock).not.toHaveBeenCalled();
+    },
+  );
 
-  it("does not accept interactive-only runtime repairs through --yes defaults", async () => {
-    setNonInteractiveTerminal();
+  it.each([false, true])("honors interactive consent with force alone: %s", async (approved) => {
+    setTerminal(true);
+    confirmMock.mockResolvedValueOnce(approved);
     const prompter = createDoctorPrompter({
-      runtime: {
-        log: vi.fn(),
-        error: vi.fn(),
-        exit: vi.fn(),
-      },
-      options: {
-        yes: true,
-      },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: { force: true },
     });
 
+    expect(prompter.shouldRepair).toBe(false);
+    expect(prompter.shouldForce).toBe(true);
     await expect(
       prompter.confirmRuntimeRepair({
-        message: "Archive orphan transcripts?",
+        message: "Overwrite gateway service config?",
         initialValue: true,
         requiresInteractiveConfirmation: true,
       }),
-    ).resolves.toBe(false);
-    expect(confirmMock).not.toHaveBeenCalled();
+    ).resolves.toBe(approved);
+    expect(confirmMock).toHaveBeenCalledOnce();
   });
 
   it("keeps skip-in-non-interactive prompts disabled during update-mode repairs", async () => {

--- a/src/daemon/systemd-scope.ts
+++ b/src/daemon/systemd-scope.ts
@@ -292,10 +292,10 @@ export function formatDuelingScopesWarning(
   const { user, system } = installation;
   // Deliberately no copy-paste removal command: this formatter has no ownership
   // evidence, and blindly deleting the user unit can remove the only working
-  // gateway. `doctor --fix` decides that behind the active+enabled probe.
+  // gateway. Guided Doctor decides that behind the active+enabled probe.
   return (
     `detected BOTH a user-scope (${user.unitPath}) and a system-scope (${system.unitPath}) ` +
     `gateway unit bound to port ${port}; they will SIGTERM each other in a restart loop. ` +
-    `Run \`openclaw doctor --fix\` to resolve which unit should own this gateway.`
+    `Run \`openclaw doctor\` interactively to inspect both scopes and review supported cleanup.`
   );
 }

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -918,7 +918,9 @@ describe("system-scope gateway unit detection (openclaw#87577)", () => {
     expect(warning).toContain("/.config/systemd/user/openclaw-gateway.service");
     expect(warning).toContain("/etc/systemd/system/openclaw-gateway.service");
     expect(warning).toContain("18789");
-    expect(warning).toContain("openclaw doctor --fix");
+    expect(warning).toContain(
+      "Run `openclaw doctor` interactively to inspect both scopes and review supported cleanup.",
+    );
     // The unguarded startup path must not hand out a destructive command.
     expect(warning).not.toContain("rm ");
     expect(warning).not.toContain("disable --now");

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -65,6 +65,12 @@ vi.mock("../infra/container-environment.js", () => ({
   isContainerEnvironment: mocks.isContainerEnvironment,
 }));
 
+vi.mock("../daemon/systemd.js", () => ({
+  findInstalledSystemdGatewayScope: vi
+    .fn<typeof import("../daemon/systemd.js").findInstalledSystemdGatewayScope>()
+    .mockResolvedValue(null),
+}));
+
 vi.mock("../plugins/provider-runtime.js", () => ({
   inspectProviderToolSchemasWithPlugin: () => [],
   normalizeProviderToolSchemasWithPlugin: mocks.normalizeProviderToolSchemasWithPlugin,
@@ -726,6 +732,8 @@ describe("doctor gateway runtime checks", () => {
       credentialsRequired: true,
       message:
         "Gateway status could not be inspected because this CLI has no usable token/password or paired device token for read-scope RPCs.",
+      fixHint:
+        "Configure the Gateway token/password or pair this device, then rerun the selected health check.",
     },
     {
       label: "an unavailable Gateway authentication SecretRef",
@@ -733,6 +741,8 @@ describe("doctor gateway runtime checks", () => {
       credentialsRequired: false,
       message:
         "Gateway status could not be inspected because this CLI has no usable token/password or paired device token for read-scope RPCs.",
+      fixHint:
+        "Configure the Gateway token/password or pair this device, then rerun the selected health check.",
     },
     {
       label: "temporary Gateway authentication rate limiting",
@@ -744,12 +754,15 @@ describe("doctor gateway runtime checks", () => {
       }),
       credentialsRequired: false,
       message: GATEWAY_HEALTH_RATE_LIMITED_MESSAGE,
+      fixHint: "Wait for the temporary authentication lockout to expire, then rerun doctor.",
     },
     {
       label: "an unreachable Gateway with terminal control characters",
       error: new Error("connect ECONNREFUSED 127.0.0.1:5829\u001b]52;c;attack\u0007\u009b"),
       credentialsRequired: false,
       message: "Gateway status could not be inspected: connect ECONNREFUSED 127.0.0.1:5829",
+      fixHint:
+        "Inspect the service with `openclaw gateway status --deep`, or run `openclaw doctor` for guided checks.",
     },
   ])("reports $label from exactly one sanitized status attempt", async (entry) => {
     if (entry.error instanceof GatewayClientRequestError) {
@@ -767,6 +780,7 @@ describe("doctor gateway runtime checks", () => {
         message: entry.message,
         path: "gateway.mode",
         target: "http://127.0.0.1:5829",
+        fixHint: entry.fixHint,
       }),
     ]);
     expect(JSON.stringify(findings)).not.toContain("SYNTHETIC_PRIVATE_TOKEN");
@@ -812,7 +826,8 @@ describe("doctor gateway runtime checks", () => {
         checkId: "core/doctor/gateway-health",
         severity: "warning",
         message: expect.stringContaining("intentionally skipped"),
-        fixHint: expect.stringContaining("--allow-exec"),
+        fixHint:
+          "Rerun `openclaw doctor --lint --only core/doctor/gateway-health --allow-exec` to permit configured secret execution.",
       }),
     ]);
     expect(JSON.stringify(findings)).not.toContain("PRIVATE_REF_ID");
@@ -847,25 +862,59 @@ describe("doctor gateway runtime checks", () => {
     expect(JSON.stringify(findings)).not.toContain("token=secret");
   });
 
-  it("reports missing local gateway daemon service", async () => {
-    mocks.readGatewayServiceState.mockResolvedValueOnce({
+  it.each([
+    {
+      label: "missing",
       installed: false,
-      loadState: { status: "not-loaded" },
+      loadState: "not-loaded",
+      runtimeStatus: "stopped",
+      message: "Gateway service is not installed.",
+      path: "gateway.mode",
+      fixHint: "Run `openclaw gateway install` to install the service.",
+    },
+    {
+      label: "installed but not loaded",
+      installed: true,
+      loadState: "not-loaded",
+      runtimeStatus: "stopped",
+      message: "Gateway service is installed but not loaded.",
+      path: "/tmp/gateway.service",
+      fixHint: "Start the installed service with `openclaw gateway start`.",
+    },
+    {
+      label: "loaded with unconfirmed runtime",
+      installed: true,
+      loadState: "loaded",
+      runtimeStatus: "unknown",
+      message: "Gateway service runtime is unknown, not running.",
+      path: "/tmp/gateway.service",
+      fixHint:
+        "Run `openclaw gateway status --deep` to inspect the service before choosing a recovery action.",
+    },
+  ])("reports actionable advice for a $label local gateway daemon", async (entry) => {
+    mocks.readGatewayServiceState.mockResolvedValueOnce({
+      installed: entry.installed,
+      loadState: { status: entry.loadState },
       running: false,
       env: {},
-      command: null,
+      command: entry.installed
+        ? { programArguments: ["openclaw", "gateway"], sourcePath: "/tmp/gateway.service" }
+        : null,
+      runtime: { status: entry.runtimeStatus },
     });
 
     await expect(
       collectGatewayDaemonFindings({ cfg: { gateway: { mode: "local" } } }),
-    ).resolves.toContainEqual({
-      checkId: "core/doctor/gateway-daemon",
-      severity: "warning",
-      message: "Gateway service is not installed.",
-      path: "gateway.mode",
-      target: "openclaw-gateway",
-      fixHint: "Run `openclaw doctor --fix` or `openclaw gateway install` to install it.",
-    });
+    ).resolves.toEqual([
+      {
+        checkId: "core/doctor/gateway-daemon",
+        severity: "warning",
+        message: entry.message,
+        path: entry.path,
+        target: "openclaw-gateway",
+        fixHint: entry.fixHint,
+      },
+    ]);
   });
 
   it("skips daemon findings for remote gateway mode", async () => {

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -193,7 +193,7 @@ export async function collectGatewayHealthFindings(
             fixHint:
               mode === "remote"
                 ? "Verify the remote Gateway URL, network path, TLS settings, and credentials."
-                : "Start the Gateway service or run `openclaw doctor --fix` for service repair prompts.",
+                : "Inspect the service with `openclaw gateway status --deep`, or run `openclaw doctor` for guided checks.",
           };
     return [warning(diagnostic.message, diagnostic.fixHint)];
   }
@@ -230,7 +230,7 @@ export async function collectGatewayDaemonFindings(
       message: "Gateway service is not installed.",
       path: "gateway.mode",
       target: service.label,
-      fixHint: "Run `openclaw doctor --fix` or `openclaw gateway install` to install it.",
+      fixHint: "Run `openclaw gateway install` to install the service.",
     });
     return findings;
   }
@@ -241,7 +241,7 @@ export async function collectGatewayDaemonFindings(
       message: "Gateway service is installed but not loaded.",
       path: state.command?.sourcePath,
       target: service.label,
-      fixHint: "Run `openclaw doctor --fix` or `openclaw gateway start` to load it.",
+      fixHint: "Start the installed service with `openclaw gateway start`.",
     });
   }
   const status = gatewayRuntimeStatus(state.runtime);
@@ -254,7 +254,8 @@ export async function collectGatewayDaemonFindings(
         : "Gateway service is loaded but runtime status could not confirm it is running.",
       path: state.command?.sourcePath,
       target: service.label,
-      fixHint: "Run `openclaw gateway status --deep` or `openclaw doctor --fix` for repair hints.",
+      fixHint:
+        "Run `openclaw gateway status --deep` to inspect the service before choosing a recovery action.",
     });
   }
   if (state.runtime?.missingGuiSession) {

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -298,6 +298,8 @@ describe("runDoctorHealthFlow", () => {
     "ready",
     "clean-repair",
     "clean-inspect",
+    "clean-force-repair",
+    "clean-force-inspect",
     "update-no-restart",
     "update-no-restart-stopped",
     "update-parent-stopped",
@@ -316,6 +318,8 @@ describe("runDoctorHealthFlow", () => {
     async (outcome) => {
       await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
         const clean = outcome.startsWith("clean-") || outcome.startsWith("update-");
+        const inspectionOnly = outcome === "clean-inspect" || outcome === "clean-force-inspect";
+        const force = outcome.startsWith("clean-force-");
         const cfg: OpenClawConfig = {
           agents: {
             ownership: "explicit",
@@ -435,7 +439,7 @@ describe("runDoctorHealthFlow", () => {
         });
         mocks.runContributions.mockImplementation(async (ctx) => {
           events.push("repair");
-          expect(ctx.gatewayMaintenanceActive).toBe(outcome !== "clean-inspect");
+          expect(ctx.gatewayMaintenanceActive).toBe(!inspectionOnly);
           if (clean) {
             return;
           }
@@ -539,7 +543,8 @@ describe("runDoctorHealthFlow", () => {
           }
           mocks.restartedHealthy = outcome !== "restart-unhealthy";
           const run = runDoctorHealthFlow(runtime, {
-            ...(outcome === "clean-inspect" ? {} : { repair: true }),
+            ...(inspectionOnly ? {} : { repair: true }),
+            force,
             nonInteractive: true,
           });
           if (outcome === "update-no-restart") {
@@ -588,17 +593,23 @@ describe("runDoctorHealthFlow", () => {
             outcome === "ready" ||
             outcome === "restart-unhealthy" ||
             outcome === "clean-repair" ||
+            outcome === "clean-force-repair" ||
             outcome === "approvals-migrated" ||
             outcome === "update-legacy";
           expect(events).toEqual(
-            outcome === "clean-inspect"
+            inspectionOnly
               ? ["repair"]
               : shouldRestart
                 ? ["stop", "repair", "restart"]
                 : ["stop", "repair"],
           );
-          expect(stop).toHaveBeenCalledTimes(outcome === "clean-inspect" ? 0 : 1);
+          expect(stop).toHaveBeenCalledTimes(inspectionOnly ? 0 : 1);
           expect(restart).toHaveBeenCalledTimes(shouldRestart ? 1 : 0);
+          if (shouldRestart) {
+            expect(restart).toHaveBeenCalledWith(
+              expect.objectContaining({ preserveDefinition: true }),
+            );
+          }
           if (clean) {
             expect(fs.readFileSync(state.configPath)).toEqual(configBefore);
             expect(fs.readFileSync(initial.path)).toEqual(agentBefore);


### PR DESCRIPTION
Closes #137497

<details>
<summary>Additional instructions</summary>

This branch is in the upstream repository and remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where operators following Doctor's service-recovery messages would be sent to `doctor --fix` for cleanup, installation, startup, or definition replacement that explicit repair maintenance does not perform. The CLI also described `--force` as overwriting service configuration without distinguishing force-only guided mode from force plus explicit repair. Successful legacy cleanup could promise an installation that had not happened.

## Why This Change Was Made

The messages were left behind when explicit repair became definition-preserving maintenance. Correct the existing message producers rather than broaden maintenance authority: guided Doctor owns confirmed cleanup and eligible service rewrites; explicit Gateway commands own installation, startup, and definition replacement. Delete the cleanup owner's unsupported future-install announcement while retaining its factual removed/skipped notes.

`--force` alone remains guided and requires interactive consent for an eligible service rewrite. With `--fix`, `--repair`, or `--yes`, maintenance preserves the installed definition and only resumes the matching service it stopped. Ownership, write-access, external-supervision, active-systemd, drop-in, and interactive-only confirmation checks are unchanged. The docs also distinguish a genuinely offline service from a loaded macOS job between automatic respawns, and stop calling ordinary Doctor read-only.

No flag, default, config option, stored representation, schema, migration, retention, dependency, service eligibility, or native lifecycle behavior changes. Existing command owners solve this; no new abstraction or dependency is needed.

## User Impact

Service findings now direct operators to interactive Doctor for supported cleanup, `gateway install` for a missing native service, `gateway start` for an unloaded installed service, and `gateway install --force` from the intended installation for definition replacement. Unconfirmed local health/runtime findings recommend diagnosis instead of promising a repair. Cleanup reports what actually happened. Remote, authentication, rate-limit, and exec-secret guidance remains unchanged.

See [Doctor CLI](https://docs.openclaw.ai/cli/doctor) and [Gateway Doctor](https://docs.openclaw.ai/gateway/doctor).

## Evidence

Tested base: `7315811a5686f33369e087d3d2b548948d90e128`. Reviewed and built head: `341d0a6a1b466bd5b259001621802cd6f76da089`.

**Fail-first and controls:** 11 intended stale-guidance/help failures on unchanged production. All 82 maintenance controls passed on that baseline, including force-only versus force-plus-repair. Two new TTY controls initially failed because the old Clack mock omitted `isCancel`; retaining real module exports repaired the fixture, and all 10 prompter controls then passed on baseline. Those two setup failures are not counted as product regressions.

**Final focused proof:** 591 passed, zero failed or skipped across eight suites. Existing tests exercise cleanup success/failure, guarded dueling scopes, native write authority, external supervision, parser forwarding, interactive consent, and definition-preserving maintenance. The final documentation refinements leave every tested production/test byte unchanged.

```bash
node scripts/run-vitest.mjs src/commands/doctor-gateway-services.test.ts src/daemon/systemd.test.ts src/flows/doctor-core-checks.runtime.test.ts src/cli/program/register.maintenance.test.ts src/commands/doctor-prompter.test.ts src/flows/doctor-health.test.ts src/commands/doctor-gateway-services.authority.test.ts src/commands/doctor-service-repair-policy.test.ts --reporter=json --outputFile="$EVIDENCE/green-001.json"
```

Tests ran through an environment allowlist with private home/state/config/cache/temp roots and synthetic native-manager edges. No operator service was changed.

**Checks:** the complete changed-file formatting/typecheck/lint/guard/import-cycle plan passed; final docs formatting and `git diff --check` passed. `pnpm docs:list` passed. Fresh final Codex autoreview returned scoped-clean at the configured P0 threshold, with zero findings across its two complete bundle chunks. This is a scoped review, not an all-priority audit.

```bash
node scripts/check-changed.mjs -- docs/cli/doctor.md docs/gateway/doctor.md src/cli/program/register.maintenance.test.ts src/cli/program/register.maintenance.ts src/commands/doctor-gateway-services.test.ts src/commands/doctor-gateway-services.ts src/commands/doctor-prompter.test.ts src/daemon/systemd-scope.ts src/daemon/systemd.test.ts src/flows/doctor-core-checks.runtime.test.ts src/flows/doctor-core-checks.runtime.ts src/flows/doctor-health.test.ts
```

**Real CLI before/after:** both immutable builds completed `pnpm build`, and their dist-backed `doctor --help` commands exited 0 with fresh private home/state/config roots. Build-info commits matched the tested Git heads, no state/config files were created, and both child process groups were gone afterward. The candidate build emitted no ineffective-dynamic-import warnings.

```text
Before (7315811):
--force  Apply aggressive repairs (overwrites custom service config)

After (341d0a6):
--force  Allow aggressive repair choices (with --fix, preserves service definitions)
```

This is actual CLI help proof. Full native-service Doctor E2E was not run because the host's native manager belongs to an operator Gateway and temporary HOME does not isolate it. Synthetic native fixtures prove the service-owner behavior; they are not represented as live service operations.

**Change size:** production +14/-12 (net +2), tests +154/-77 (net +77), docs +36/-15 (net +21). Production growth is solely formatter wrapping of longer existing strings; the only deleted control-flow block was the three-line unsupported announcement. No new branch, helper, or authority path was added.

**Separate follow-up:** service-install hints still need actual install-eligibility facts for Nix/external/noncanonical identities. This patch corrects Doctor posture referrals, not that separate eligibility projection or Node-specific command naming. That follow-up also includes the remaining service-config-audit Doctor referral in Gateway status.

**Pre-merge status:** [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33794284165) completed successfully on `341d0a6a1b466bd5b259001621802cd6f76da089`, attempt 1. Native reviewed main `27183e4286420d2b257a5cd53cf35dc1d8ad965e` has no drift across the compared owner/caller/test/doc/policy/package/lock paths from the tested base. Native review guards and artifact validation passed. One artifact-initialization viewer preflight failed with unknown HTTP status; the exact same request then verified the expected writer and the normal retry passed, without changing credentials, routing, or gate policy.

**Completed ClawSweeper review and maintainer disposition:** [The completed review](https://github.com/openclaw/openclaw/pull/137505#issuecomment-5530862133) covers the exact head, reports no code/security findings, and recommends this producer-level fix. Its sole before-merge item is an automated data-model compatibility classification for the four production files. The parent inspected the complete base-to-head production diff: `register.maintenance.ts` changes only help text; `doctor-gateway-services.ts` changes two messages and deletes a log-only block; `systemd-scope.ts` changes one warning and its comment; `doctor-core-checks.runtime.ts` changes four `fixHint` strings. No data type, key, representation, storage operation, schema, migration, retention, or native service-definition format changes.

Disposition: the data-model item is **not applicable**, not a waived migration gate. There is no changed data contract requiring migration or upgrade proof. Existing maintenance and private-state preservation tests pass unchanged in behavior, and the full production diff is limited to the presentation changes described above. No migration or database change was added to satisfy the classification. Native prepare passed using exact-head hosted CI, without rebasing or repushing the reviewed source.
