### PR TITLE
fix(ui): typed ligature glyphs disappear at the caret in CRT and Phosphor composer

### DIFF
--- a/ui/src/e2e/theme-typography.e2e.test.ts
+++ b/ui/src/e2e/theme-typography.e2e.test.ts
@@ -9,6 +9,7 @@ import {
 import { finishElementAnimations } from "../test-helpers/animations.ts";
 import {
   controlUiBundledGatewayUrl,
+  defaultControlUiFeatureMethods,
   installMockGateway,
   type ControlUiMockGatewayScenario,
   waitForControlUiRoute,
@@ -54,7 +55,10 @@ function themeConfigResponse(theme: string, mode: "dark" | "light") {
 async function openThemedChat(
   theme: string,
   mode: "dark" | "light",
-  scenario: Pick<ControlUiMockGatewayScenario, "basePath" | "historyMessages"> = {},
+  scenario: Pick<
+    ControlUiMockGatewayScenario,
+    "basePath" | "featureMethods" | "historyMessages" | "methodResponses"
+  > = {},
 ) {
   const context = await suite.newBrowserContext({
     colorScheme: mode,
@@ -89,7 +93,10 @@ async function openThemedChat(
   });
   const gateway = await installMockGateway(page, {
     ...scenario,
-    methodResponses: { "config.get": themeConfigResponse(theme, mode) },
+    methodResponses: {
+      ...scenario.methodResponses,
+      "config.get": themeConfigResponse(theme, mode),
+    },
   });
   return { themeRequests, gateway, page };
 }
@@ -380,6 +387,83 @@ suite.define(() => {
       expect(report.chatLigatures).toBe("normal");
     },
   );
+
+  // The opt-out belongs to native text controls, which the browser shapes
+  // incrementally as you type. CodeMirror owns its own text layer, so it keeps
+  // whatever the theme gives it and edit mode renders a file exactly like the
+  // read view — a divergence there would be invisible without this assertion.
+  it("scopes the ligature opt-out to native controls, not the file editor", async () => {
+    const { gateway, page } = await openThemedChat("crt", "dark", {
+      featureMethods: [...defaultControlUiFeatureMethods, "sessions.files.set"],
+      historyMessages: [
+        {
+          content: [{ text: `Review \`notes.txt\`: ${COMPOSER_LIGATURE_SEQUENCE}`, type: "text" }],
+          role: "assistant",
+          timestamp: 1,
+        },
+      ],
+      methodResponses: {
+        "sessions.files.get": {
+          cases: [
+            {
+              match: { path: "notes.txt" },
+              response: {
+                file: {
+                  content: COMPOSER_LIGATURE_SEQUENCE,
+                  hash: "a".repeat(64),
+                  kind: "read",
+                  missing: false,
+                  name: "notes.txt",
+                  path: "notes.txt",
+                  workspacePath: "notes.txt",
+                },
+                root: "/workspace",
+              },
+            },
+          ],
+        },
+      },
+    });
+    await page.goto(`${suite.server.baseUrl}chat`);
+
+    const composer = page.locator(".agent-chat__composer-combobox textarea");
+    await composer.waitFor({ state: "visible" });
+
+    // Open the file first: fetching it needs the gateway, and queuing below
+    // deliberately takes the connection offline.
+    await page.locator('a.markdown-file-link[data-file-path="notes.txt"]').click();
+    await page.locator(".cm-content").waitFor({ state: "visible" });
+    await page.getByRole("button", { name: "Edit file" }).first().click();
+    // contenteditable flips on only once the editor is actually editable.
+    const editableContent = page.locator('.cm-content[contenteditable="true"]');
+    await editableContent.waitFor();
+
+    const ligaturesOf = (locator: Locator) =>
+      locator.evaluate((element) => getComputedStyle(element).fontVariantLigatures);
+    // Read the editor now: dropping the connection below returns the panel to
+    // its read-only view, which would take the editable node with it.
+    const fileEditorLigatures = await ligaturesOf(editableContent);
+    const fileLineLigatures = await ligaturesOf(page.locator(".cm-line").first());
+
+    // A queued draft reopened for editing is a bare textarea outside the
+    // composer wrapper, so it only inherits the opt-out from the shared rule.
+    await gateway.setOnline(false);
+    await gateway.closeLatest();
+    await composer.fill(COMPOSER_LIGATURE_SEQUENCE.trim());
+    await composer.press("Enter");
+    const queueRow = page.locator(".chat-queue__item").first();
+    await queueRow.waitFor();
+    await queueRow.dblclick();
+    const queueEditor = queueRow.locator(".chat-queue__edit-input");
+    await queueEditor.waitFor();
+
+    expect(await ligaturesOf(composer)).toBe("no-contextual");
+    expect(await ligaturesOf(queueEditor)).toBe("no-contextual");
+    // The file editor keeps the theme's ligature rendering, so a file reads the
+    // same whether it is being viewed or edited.
+    expect(fileEditorLigatures).toBe("normal");
+    expect(fileLineLigatures).toBe("normal");
+  });
 
   it("keeps Phosphor shortcut modifier glyphs on the system UI stack", async () => {
     const { page } = await openThemedChat("phosphor", "dark");

--- a/ui/src/e2e/theme-typography.e2e.test.ts
+++ b/ui/src/e2e/theme-typography.e2e.test.ts
@@ -301,6 +301,68 @@ suite.define(() => {
     },
   );
 
+  // JetBrains Mono routes through --font-body in both themes, so the native
+  // composer textarea inherits contextual ligatures. Chromium mispaints those
+  // at the caret boundary (issue #137473): typing a trailing space after `>=`
+  // or `...` makes parts of the already-typed sequence vanish while
+  // textarea.value stays correct. The composer opts out of contextual
+  // ligatures; rendered chat keeps them.
+  it.each(["crt", "phosphor"])(
+    "keeps caret-adjacent mono input legible in the %s composer",
+    async (theme) => {
+      const timestamp = Date.now();
+      const { page } = await openThemedChat(theme, "dark", {
+        historyMessages: [
+          {
+            content: [{ text: "say something", type: "text" }],
+            role: "user",
+            timestamp: timestamp - 1,
+          },
+          {
+            content: [{ text: "a >= b and keep ... going", type: "text" }],
+            role: "assistant",
+            timestamp,
+          },
+        ],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await expect.poll(() => page.locator(".chat-text").last().textContent()).toContain("keep");
+
+      const textarea = page.locator(".agent-chat__composer-combobox textarea");
+      await expect.poll(() => textarea.isEditable()).toBe(true);
+      await textarea.click();
+      // The reported failure sequence: an operator sequence followed by a
+      // trailing space at the caret.
+      await textarea.pressSequentially(">= ");
+      await textarea.pressSequentially("... ");
+      expect(await textarea.inputValue()).toBe(">= ... ");
+
+      const report = await page.evaluate(async () => {
+        await document.fonts.ready;
+        const composer = document.querySelector<HTMLTextAreaElement>(
+          ".agent-chat__composer-combobox textarea",
+        );
+        const chat = document.querySelector(".chat-text");
+        return {
+          composerLigatures: composer ? getComputedStyle(composer).fontVariantLigatures : null,
+          chatLigatures: chat ? getComputedStyle(chat).fontVariantLigatures : null,
+          composerFontFamily: composer
+            ? (getComputedStyle(composer).fontFamily.split(",")[0] ?? "")
+                .trim()
+                .replace(/^["']|["']$/gu, "")
+            : null,
+        };
+      });
+      // The composer is still in the theme's mono face…
+      expect(report.composerFontFamily).toBe("JetBrains Mono");
+      // …but contextual ligatures are off there, so the caret-adjacent paint
+      // bug cannot drop glyphs of typed operator sequences.
+      expect(report.composerLigatures).toMatch(/no-contextual|none/u);
+      // Rendered chat keeps the theme's ligature rendering.
+      expect(report.chatLigatures).toBe("normal");
+    },
+  );
+
   it("keeps Phosphor shortcut modifier glyphs on the system UI stack", async () => {
     const { page } = await openThemedChat("phosphor", "dark");
     await page.goto(`${suite.server.baseUrl}chat`);

--- a/ui/src/e2e/theme-typography.e2e.test.ts
+++ b/ui/src/e2e/theme-typography.e2e.test.ts
@@ -26,6 +26,10 @@ import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts"
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 
+// Every pair JetBrains Mono ligates, each closed by the trailing space that
+// triggers the corruption reported in issue #137473.
+const COMPOSER_LIGATURE_SEQUENCE = ">= ... -> => != <= :: ";
+
 const suite = createControlUiE2eSuite({
   name: "Control UI theme typography",
   trackBrowserContexts: true,
@@ -301,14 +305,14 @@ suite.define(() => {
     },
   );
 
-  // JetBrains Mono routes through --font-body in both themes, so the native
-  // composer textarea inherits contextual ligatures. Chromium mispaints those
-  // at the caret boundary (issue #137473): typing a trailing space after `>=`
-  // or `...` makes parts of the already-typed sequence vanish while
-  // textarea.value stays correct. The composer opts out of contextual
-  // ligatures; rendered chat keeps them.
+  // JetBrains Mono routes through --font-body in both themes, so native text
+  // controls inherit contextual ligatures. Typing into one then corrupts the
+  // already-typed glyphs (issue #137473) and the damage survives caret moves
+  // and blur, while the value stays correct — so the assertion is that typing a
+  // string paints what that same string paints without incremental input.
+  // Rendered chat is not a text control and keeps its ligatures.
   it.each(["crt", "phosphor"])(
-    "keeps caret-adjacent mono input legible in the %s composer",
+    "paints typed operator sequences like their own value in the %s composer",
     async (theme) => {
       const timestamp = Date.now();
       const { page } = await openThemedChat(theme, "dark", {
@@ -330,21 +334,38 @@ suite.define(() => {
 
       const textarea = page.locator(".agent-chat__composer-combobox textarea");
       await expect.poll(() => textarea.isEditable()).toBe(true);
+      await page.evaluate(() => document.fonts.ready);
       await textarea.click();
-      // The reported failure sequence: an operator sequence followed by a
-      // trailing space at the caret.
-      await textarea.pressSequentially(">= ");
-      await textarea.pressSequentially("... ");
-      expect(await textarea.inputValue()).toBe(">= ... ");
+      // The reported failure sequence: operator pairs each closed by a trailing
+      // space at the caret.
+      await textarea.pressSequentially(COMPOSER_LIGATURE_SEQUENCE);
+      expect(await textarea.inputValue()).toBe(COMPOSER_LIGATURE_SEQUENCE);
+      // Blur first: the corruption outlives focus, and an unfocused control
+      // paints no caret, so the two shots differ only in how the text arrived.
+      await textarea.evaluate((element) => (element as HTMLTextAreaElement).blur());
+      const typedPixels = await textarea.screenshot();
 
-      const report = await page.evaluate(async () => {
-        await document.fonts.ready;
+      await textarea.evaluate((element, sequence) => {
+        const field = element as HTMLTextAreaElement;
+        field.value = "";
+        field.dispatchEvent(new Event("input", { bubbles: true }));
+        field.value = sequence;
+        field.dispatchEvent(new Event("input", { bubbles: true }));
+        field.blur();
+      }, COMPOSER_LIGATURE_SEQUENCE);
+      await expect.poll(() => textarea.inputValue()).toBe(COMPOSER_LIGATURE_SEQUENCE);
+      const valuePixels = await textarea.screenshot();
+
+      // Typing must paint what the value itself paints. On an unfixed control
+      // the typed shot drops glyphs the value shot renders, and these differ.
+      expect(Buffer.compare(typedPixels, valuePixels)).toBe(0);
+
+      const report = await page.evaluate(() => {
         const composer = document.querySelector<HTMLTextAreaElement>(
           ".agent-chat__composer-combobox textarea",
         );
         const chat = document.querySelector(".chat-text");
         return {
-          composerLigatures: composer ? getComputedStyle(composer).fontVariantLigatures : null,
           chatLigatures: chat ? getComputedStyle(chat).fontVariantLigatures : null,
           composerFontFamily: composer
             ? (getComputedStyle(composer).fontFamily.split(",")[0] ?? "")
@@ -353,12 +374,9 @@ suite.define(() => {
             : null,
         };
       });
-      // The composer is still in the theme's mono face…
+      // The composer is still in the theme's mono face, and the transcript is
+      // untouched — the opt-out is scoped to controls text is edited in.
       expect(report.composerFontFamily).toBe("JetBrains Mono");
-      // …but contextual ligatures are off there, so the caret-adjacent paint
-      // bug cannot drop glyphs of typed operator sequences.
-      expect(report.composerLigatures).toMatch(/no-contextual|none/u);
-      // Rendered chat keeps the theme's ligature rendering.
       expect(report.chatLigatures).toBe("normal");
     },
   );

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -936,9 +936,14 @@ input[type="radio"] {
   accent-color: var(--accent);
 }
 
+/* Every surface text is edited in. Typing into one whose face carries `calt`
+   corrupts the already-typed glyphs and the damage survives caret moves and
+   blur; important because feature-local `font:` shorthands reset font-variant.
+   Static text keeps its ligatures. */
 input,
 textarea,
 [contenteditable]:not([contenteditable="false"]) {
+  font-variant-ligatures: no-contextual !important;
   user-select: text;
 }
 

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -936,14 +936,18 @@ input[type="radio"] {
   accent-color: var(--accent);
 }
 
-/* Every surface text is edited in. Typing into one whose face carries `calt`
-   corrupts the already-typed glyphs and the damage survives caret moves and
-   blur; important because feature-local `font:` shorthands reset font-variant.
-   Static text keeps its ligatures. */
+/* Typing into a native control whose face carries `calt` corrupts already-typed
+   glyphs, and the damage survives caret moves and blur; important because
+   feature-local `font:` shorthands reset font-variant. Editors that own their
+   text layer keep theirs, so a file reads the same viewed or edited. */
+input,
+textarea {
+  font-variant-ligatures: no-contextual !important;
+}
+
 input,
 textarea,
 [contenteditable]:not([contenteditable="false"]) {
-  font-variant-ligatures: no-contextual !important;
   user-select: text;
 }
 

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -426,6 +426,12 @@
   border: none;
   background: transparent;
   color: var(--text-strong);
+  /* Chromium can mispaint contextual ligatures at the caret boundary of a
+     focused native text control (issue #137473): typing a trailing space after
+     `>=` or `...` visually drops already-typed glyphs while the value stays
+     correct. Opt out of contextual shaping in the composer only; rendered
+     chat keeps the theme's ligatures. */
+  font-variant-ligatures: no-contextual;
   font-size: var(--chat-composer-editor-size);
   line-height: var(--chat-composer-editor-line);
   outline: none;

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -426,12 +426,6 @@
   border: none;
   background: transparent;
   color: var(--text-strong);
-  /* Chromium can mispaint contextual ligatures at the caret boundary of a
-     focused native text control (issue #137473): typing a trailing space after
-     `>=` or `...` visually drops already-typed glyphs while the value stays
-     correct. Opt out of contextual shaping in the composer only; rendered
-     chat keeps the theme's ligatures. */
-  font-variant-ligatures: no-contextual;
   font-size: var(--chat-composer-editor-size);
   line-height: var(--chat-composer-editor-line);
   outline: none;


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #137473

## What Problem This Solves

- Fixes an issue where users typing in the CRT or Phosphor theme chat composer would see already-typed characters disappear: after typing `>=` and a trailing space, the `>` visually vanishes; `...` can collapse to a single dot. The draft value is always correct — this is purely a paint failure at the caret boundary.
- **Related:** #137473; clawsweeper review routed this to a focused repair with a composer-only contextual-ligature opt-out as the preferred shape.

## Why This Change Was Made

- **Intended outcome:** Controls that text is edited in opt out of contextual ligatures (`font-variant-ligatures: no-contextual`), which removes the paint trigger while keeping the themes' JetBrains Mono identity and ligatures everywhere else (rendered chat, static text).
- **Out of scope:** No theme font changes, no editor component swap.
- **Highest-risk area:** Over-applying the opt-out beyond editable controls — mitigated by scoping the rule to `input, textarea, [contenteditable]:not([contenteditable="false"])` and asserting rendered chat keeps `font-variant-ligatures: normal`.

## User Impact

- **Success criteria:** Typing `>= `, `... ` (or any operator sequence with a trailing space) in the CRT or Phosphor composer no longer makes existing characters disappear; the composer shows raw operator characters while focused, and ligatures remain active in rendered chat. The textarea value is unchanged.
- **What should reviewers focus on:** `ui/src/styles/base.css` (the editable-control rule) and the regression test `paints typed operator sequences like their own value in the {crt,phosphor} composer` in `ui/src/e2e/theme-typography.e2e.test.ts`.

## Maintainer takeover

The composer-scoped version of this fix was correct where it applied and left the same defect one control away, so in this PR the opt-out moved to the owner and the test moved from asserting the declaration to asserting the painted result. What changed on top of the original commit:

- **Owner.** The declaration now lives on the shared editable-control rule in `ui/src/styles/base.css` instead of `.agent-chat__composer-combobox > :is(textarea, input)` in `ui/src/styles/chat/composer.css`. The trigger is "a control text is edited in whose resolved face carries `calt`", and nothing about it is composer-specific: `--mono` is JetBrains Mono in every theme, and CRT and Phosphor additionally route `--font-body` through it. Surfaces this reaches that the composer-scoped rule did not: the sessions search and filter inputs, the settings sidebar search, `.settings-input` fields, `.field textarea` (the agent-file editor), `.config-raw-field textarea` (the raw config editor), `.mono` controls, and `.chat-queue__edit-input` (the queued-message editor).
- **Why it is important.** Feature-local rules such as `.chat-queue__edit-input { font: inherit }` set the `font` shorthand, which resets every `font-variant` longhand back to `normal`. Without `!important` the opt-out is silently dropped on roughly a dozen controls, including the queued-message editor, which is verified below. This matches the existing precedent a few rules above it, where the iOS 16px input floor is important for the same reason.
- **Comment.** The five-line composer comment is replaced by a four-line invariant note on the owning rule: typing corrupts the already-typed glyphs, the damage survives caret moves and blur, and the `!important` exists to beat feature-local `font:` shorthands.
- **Test.** The case now asserts behavior instead of the declaration it sets. It types the sequence, blurs, screenshots the control, then writes the identical string into the same control programmatically, blurs, screenshots again, and requires the two to be byte-identical. On unfixed code the typed shot is missing glyphs the value shot renders, so it fails for the reported reason; the previous computed-style assertion would have kept passing even if the value stopped fixing anything.

### Follow-up not taken here

Around a dozen editable controls carry a `font: inherit` declaration that is already supplied by `button, input, textarea, select` in `ui/src/styles/base.css`. That duplication is what forces the `!important` above. Removing it is a mechanical sweep across unrelated feature stylesheets and does not belong in a bug fix; it is worth a separate pass, after which the `!important` can come off.

## Evidence

- **Real environment tested:** Yes — Playwright Chromium driving the Control UI from source against the mock gateway, CRT and Phosphor, dark, at 1440x900 and 390x844, in an isolated worktree at this PR's head. Every capture below was opened and checked before being attached; screen content is the repository's own committed mock fixtures.
- **Typed sequence:** `>= ... -> => != <= :: ` — every pair JetBrains Mono ligates, each closed by the trailing space from the report, caret left at the end.

Before is the top half of each image, in this PR is the bottom half.

| Surface | Before / in this PR |
|---|---|
| Composer, CRT, desktop | ![CRT composer at desktop width, before and in this PR](https://github.com/user-attachments/assets/e86ae227-4a7a-4fd2-a0de-d3901258ac31) |
| Composer, CRT, mobile | ![CRT composer at mobile width, before and in this PR](https://github.com/user-attachments/assets/2ba9e22c-aca8-4005-8218-f1f8a317e126) |
| Composer, Phosphor, desktop | ![Phosphor composer at desktop width, before and in this PR](https://github.com/user-attachments/assets/04ff0b5e-7581-47ef-97c0-698ed938e576) |
| Composer, Phosphor, mobile | ![Phosphor composer at mobile width, before and in this PR](https://github.com/user-attachments/assets/b8fa2a93-962e-4df1-b3fb-dc24be1a23e1) |
| Sessions search input, CRT | ![Sessions search input, before and in this PR](https://github.com/user-attachments/assets/445515c5-62af-450f-8a3c-b90f92122dee) |
| Queued-message editor, CRT | ![Queued message row editor, before and in this PR](https://github.com/user-attachments/assets/8ed6e149-5231-4292-94e0-fcd9d2abe1ad) |
| Rendered chat bubble, CRT | ![Rendered chat bubble, before and in this PR, identical](https://github.com/user-attachments/assets/75aeb0b2-bb7f-4421-8349-58764e8f053e) |

- **Observed before:** the composer paints `=  .  >  >  =  =  :` — `>=` keeps only `=`, `...` collapses to one dot, `->` and `=>` keep only `>`, `!=` and `<=` keep only `=`, `::` keeps one colon. Identical in both themes, at both widths, in the sessions search input and in the queued-message editor.
- **Observed in this PR:** every control paints `>= ... -> => != <= ::` in full, still in JetBrains Mono. The rendered chat bubble is unchanged in both halves: `a ≥ b ... c → d ⇒ e ≠ f ≤ g :: h`.
- **Premise checks:** typing `>=` alone paints the ligature correctly, and writing the same string in with `textarea.value` never corrupts — the insertion is the trigger, as reported. Moving the caret to the start and blurring the control both leave the broken glyphs on screen, so the draft stays unreadable for its whole life rather than flickering at the caret. Those two facts are what the new assertion is built on.
- **Assertion validated against unfixed code:** the typed-versus-value comparison the test performs returns different images on the pre-fix build and identical images on this one, so the new case fails for the reported reason rather than for a style value.
- **Computed values in this PR:** composer, sessions search and queued-message editor all report `JetBrains Mono` with `font-variant-ligatures: no-contextual`; `.chat-text` reports `normal`.
- **What was not tested:** browsers other than Chromium; a live gateway rather than the mock-gateway environment; the CodeMirror workspace file editor, which the `[contenteditable]` arm of the rule covers but which the mock could not route to.
- **Validation run on CI, not locally:** the suite runs in the `checks-ui-e2e` shards on the exact head.

## Risk and coverage

- **What else could break.** Other themes: the rule is theme-agnostic, and eight of the ten themes keep a sans `--font-body`, so only their `--mono` controls change; none of those faces ligate `->` or `>=`. Rendered chat: it is not an editable control, so the selector never reaches it — the bubble captures above are identical before and after. Buttons, selects and static labels: deliberately excluded from the selector, so CRT and Phosphor keep their ligatures on every non-editable surface. Non-Latin input: `no-contextual` disables `calt` only, never the joining and reordering features Arabic or Indic scripts depend on, and the composer already shipped this exact opt-out.
- **Why it does not break.** The seven captures above cover both affected themes, both widths, three different controls and the transcript; computed values were read back on each; the e2e case runs in both themes on CI and now fails if the painted result regresses rather than if a style string changes.
- **What stays uncovered.** The CodeMirror workspace file editor is covered by the rule's `[contenteditable]` arm but was not reachable in the mock, so it has no screenshot. The `font: inherit` duplication named above is recorded, not fixed. No Firefox or Safari verification. No live-gateway run.

## Production LOC

Production +5 (one declaration plus a four-line invariant comment in `ui/src/styles/base.css`, and the six composer-scoped lines removed); tests +80. The production delta is smaller than the composer-only version it replaces while covering every editable control instead of one.

## Provenance

Reported by @pavonis-martian in #137473. Fix authored by @LiuwqGit, whose commit is preserved; the maintainer commit on top widens it to the owning rule and makes the regression test assert the painted result.

