### PR TITLE
fix(plugin-sdk): accept positional code ranges

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -96,6 +96,11 @@ Retained compatibility entrypoints keep their shipped caller names:
 `resolvePluginProviders`, and `agent-runtime`'s
 `resolveThinkingDefaultWithRuntimeCatalog` accepts `loadModelCatalog`.
 
+`text-chunking` retains positional `CodeRegion` inputs with `start` and `end`
+offsets for `isInsideCode`. Regions returned by `findCodeRegions` additionally
+include parser-owned `block` metadata; callers supplying their own ranges do not
+need to provide it.
+
 ### Harness attempt result migration
 
 In OpenClaw 2026.8.1, `EmbeddedRunAttemptResult` from

--- a/src/plugin-sdk/text-chunking.test.ts
+++ b/src/plugin-sdk/text-chunking.test.ts
@@ -2,7 +2,28 @@
  * Tests text and Markdown chunking helpers exported by the plugin SDK.
  */
 import { describe, expect, it } from "vitest";
-import { chunkTextForOutbound, chunkTextRanges, tokenizeHtmlTags } from "./text-chunking.js";
+import {
+  chunkTextForOutbound,
+  chunkTextRanges,
+  findCodeRegions,
+  isInsideCode,
+  tokenizeHtmlTags,
+  type CodeRegion,
+} from "./text-chunking.js";
+
+it("accepts positional plugin ranges while retaining discovered block metadata", () => {
+  const ranges: CodeRegion[] = [{ start: 1, end: 5 }];
+  expect([0, 1, 4, 5].map((offset) => isInsideCode(offset, ranges))).toEqual([
+    false,
+    true,
+    true,
+    false,
+  ]);
+  const blockKinds: boolean[] = findCodeRegions("`inline`\n\n    indented\n").map(
+    (region) => region.block,
+  );
+  expect(blockKinds).toEqual([false, true]);
+});
 
 describe("tokenizeHtmlTags", () => {
   it("keeps quoted attribute delimiters inside one tag token", () => {

--- a/src/shared/text/code-regions.ts
+++ b/src/shared/text/code-regions.ts
@@ -1,14 +1,14 @@
 // Code region helpers expose Markdown Core spans to sanitizer consumers.
 import { findMarkdownCodeRegions } from "../../../packages/markdown-core/src/reasoning-tags.js";
 
+/** Public range inputs need only offsets; parser-owned metadata belongs to discovered regions. */
 export interface CodeRegion {
-  block: boolean;
   start: number;
   end: number;
 }
 
 /** Finds CommonMark block-aware fenced, indented, and inline code regions. */
-export function findCodeRegions(text: string): CodeRegion[] {
+export function findCodeRegions(text: string): ReturnType<typeof findMarkdownCodeRegions> {
   return findMarkdownCodeRegions(text);
 }
 


### PR DESCRIPTION
Closes #137509
Related: #135945

## What Problem This Solves

Fixes an issue where plugin authors passing their own positional code ranges to `isInsideCode` would get a TypeScript error after upgrading from stable `openclaw@2026.8.2`. The public `CodeRegion` input unexpectedly required the parser's new `block` metadata, despite the helper only reading `start` and `end`.

## Why This Change Was Made

Restore the shipped positional `CodeRegion` interface. Derive `findCodeRegions`' richer return type from the canonical Markdown parser, so computed regions still guarantee `block: boolean` for the code-preserving duplicate projector. Document that input/output distinction and protect it at the existing SDK test boundary.

Best-fix verdict: keep parser metadata on parser output, not as a new obligation for existing callers. Making `block` optional on every computed region would unnecessarily weaken that output guarantee; reverting code preservation or introducing a runtime compatibility path is unnecessary. Production **+2/-2, net0**; tests **+22/-1, net+21**; docs **+5**. No dependencies, configuration, runtime branches, public entrypoints, schema, or protocol changes.

## User Impact

Existing plugins can continue supplying `{start, end}` ranges through `openclaw/plugin-sdk/text-chunking`. Callers using `findCodeRegions` retain its required block/inline metadata. Code preservation and boundary semantics are unchanged. This is a proven source-compatibility break, not a claimed outage in a known deployed plugin.

## Evidence

The same standalone consumer imports only the public package specifier:

```ts
import { isInsideCode, type CodeRegion } from 'openclaw/plugin-sdk/text-chunking';
const tokenizerRanges: Array<[number, number]> = [[1, 5]];
const regions: CodeRegion[] = tokenizerRanges.map(([start, end]) => ({ start, end }));
const protectedOffset: boolean = isInsideCode(3, regions);
```

| Declaration target | Result |
| --- | --- |
| Actual published `openclaw@2026.8.2` declarations | Pass |
| Fresh canonical SDK build at `6d44018b15af7a2b2d16919741cb9b43544baf8d` | TS2322: required `block` missing |
| Fresh canonical SDK build with this patch | Pass |

All use TypeScript6.0.3 with `--noEmit --strict --skipLibCheck --module NodeNext --target ES2022`. A second candidate consumer assigns computed `region.block` values to `boolean[]` successfully. Both declaration builds used `pnpm build:plugin-sdk:dts`, not hand-written declaration substitutes.

- **162 tests passed** across the SDK text-chunking, shared text-projection, and user-facing sanitization/duplicate-block suites. The SDK regression includes custom positional inputs, half-open range boundaries, and computed inline/indented block metadata.
- The full changed-code gate passed, including core/test types, SDK export/surface checks, formatting, lint, dead exports, and runtime import-cycle checks.
- Independent managed Codex review: no actionable P0–P2 findings. The three source hashes stayed unchanged through declarations, tests, gate, and review.
- Erasing types/comments with the same compiler produces **byte-identical JavaScript** for the affected production owner before and after. The real developer-facing flow tested here is compilation against the actual public SDK declarations; no network/channel behavior changed or live provider claim is made.

### Regression provenance

Raw-parent comparison identifies the input narrowing in `cfe80b3edb6729b1ba40d956af2d0783215f82f6`, relative to `e0ab9907621e4340beed2e30528a9f997390ded2`, via #135945 (merged 2026-09-02). PR author: @ruel225; merger: @obviyus; commit committer: GitHub. Specific hunk authorship and automation trigger are not inferred from those roles. The original code-preservation repair remains intact.
