### PR TITLE
refactor(ui): reuse canonical session test fixtures

### DIFF
--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import {
@@ -11,14 +12,6 @@ import type { SessionCapability } from "./session-capability.ts";
 
 const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
 const SESSION_EVENT_REFRESH_MAX_WAIT_MS = 1_000;
-
-function deferred<T>() {
-  let resolve: (value: T) => void = () => undefined;
-  const promise = new Promise<T>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
-}
 
 function installPageLifecycle() {
   const documentEvents = new EventTarget();
@@ -729,9 +722,9 @@ describe("event-driven session list refresh", () => {
     "preserves queued explicit options when the event debounce fires $timing the active request completes",
     async ({ fireBeforeInitialCompletion }) => {
       vi.useFakeTimers();
-      const firstList = deferred<SessionsListResult>();
-      const secondList = deferred<SessionsListResult>();
-      const secondListStarted = deferred<void>();
+      const firstList = createDeferred<SessionsListResult>();
+      const secondList = createDeferred<SessionsListResult>();
+      const secondListStarted = createDeferred();
       let listCalls = 0;
       const request = vi.fn(async (method: string, _params?: unknown) => {
         if (method !== "sessions.list") {
@@ -832,9 +825,9 @@ describe("event-driven session list refresh", () => {
     "keeps event invalidation $timing",
     async ({ eventBeforeAppend, queueForeground, eventDuringForeground, expectedCalls }) => {
       vi.useFakeTimers();
-      const firstList = deferred<SessionsListResult>();
-      const secondList = deferred<SessionsListResult>();
-      const secondListStarted = deferred<void>();
+      const firstList = createDeferred<SessionsListResult>();
+      const secondList = createDeferred<SessionsListResult>();
+      const secondListStarted = createDeferred();
       let listCalls = 0;
       const request = vi.fn(async (method: string, _params?: unknown) => {
         if (method !== "sessions.list") {
@@ -907,8 +900,8 @@ describe("event-driven session list refresh", () => {
 
   it("queues one trailing refresh for an event during an in-flight refresh", async () => {
     vi.useFakeTimers();
-    const secondList = deferred<SessionsListResult>();
-    const thirdListStarted = deferred<void>();
+    const secondList = createDeferred<SessionsListResult>();
+    const thirdListStarted = createDeferred();
     let listCalls = 0;
     const request = vi.fn(async (method: string) => {
       if (method !== "sessions.list") {
@@ -949,7 +942,7 @@ describe("event-driven session list refresh", () => {
   it("defers a queued filtered refresh when the page hides during its active request", async () => {
     vi.useFakeTimers();
     const page = installPageLifecycle();
-    const activeRefresh = deferred<SessionsListResult>();
+    const activeRefresh = createDeferred<SessionsListResult>();
     let filteredCalls = 0;
     const request = vi.fn(async (method: string, params?: { archived?: string }) => {
       if (method !== "sessions.list") {

--- a/ui/src/lib/sessions/list-options.test.ts
+++ b/ui/src/lib/sessions/list-options.test.ts
@@ -1,27 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionGoal, SessionsListResult } from "../../api/types.ts";
 import { createSessionCapability } from "./index.ts";
-
-function sessionsResult(sessions: SessionsListResult["sessions"], ts: number): SessionsListResult {
-  return {
-    ts,
-    path: "(multiple)",
-    count: sessions.length,
-    defaults: { modelProvider: null, model: null, contextTokens: null },
-    sessions,
-  };
-}
-
-function deferred<T>() {
-  let resolve: (value: T) => void = () => undefined;
-  let reject: (error: unknown) => void = () => undefined;
-  const promise = new Promise<T>((next, fail) => {
-    resolve = next;
-    reject = fail;
-  });
-  return { promise, reject, resolve };
-}
+import { sessionsResult } from "./session-capability.test-support.ts";
 
 function createSessions(client: GatewayBrowserClient, key: string, ownerId?: string) {
   return createSessionCapability({
@@ -122,8 +104,8 @@ describe("session list replacement options", () => {
 
   it("keeps derived titles when a foreground refresh queues behind an archive replacement", async () => {
     const key = "agent:main:untitled";
-    const archiveReplacementStarted = deferred<void>();
-    const archiveReplacement = deferred<SessionsListResult>();
+    const archiveReplacementStarted = createDeferred();
+    const archiveReplacement = createDeferred<SessionsListResult>();
     let listCallCount = 0;
     const request = vi.fn(async (method: string, params?: unknown) => {
       if (method === "sessions.list") {
@@ -556,7 +538,7 @@ describe("session list replacement options", () => {
 
   it("captures foreground list options before concurrent mutation refreshes", async () => {
     const key = "agent:main:concurrent";
-    const firstList = deferred<SessionsListResult>();
+    const firstList = createDeferred<SessionsListResult>();
     let listCalls = 0;
     const request = vi.fn(async (method: string, _params?: unknown) => {
       if (method === "sessions.list") {
@@ -695,7 +677,7 @@ describe("session list replacement options", () => {
   });
 
   it("does not publish a model override when the captured UI owner is already retired", async () => {
-    const pendingPatch = deferred<unknown>();
+    const pendingPatch = createDeferred<unknown>();
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.patch") {
         return await pendingPatch.promise;
@@ -721,7 +703,7 @@ describe("session list replacement options", () => {
   it.each(["resolve", "reject"] as const)(
     "retires an optimistic model patch after the UI owner changes and the request %s",
     async (outcome) => {
-      const pendingPatch = deferred<unknown>();
+      const pendingPatch = createDeferred<unknown>();
       const request = vi.fn(async (method: string) => {
         if (method === "sessions.patch") {
           return await pendingPatch.promise;
@@ -765,8 +747,8 @@ describe("session list replacement options", () => {
   ] as const)(
     "preserves a newer equal-value model claim when an older request %s (owner active: %s)",
     async (outcome, ownerActive) => {
-      const pendingPatch = deferred<unknown>();
-      const replacementPatch = deferred<unknown>();
+      const pendingPatch = createDeferred<unknown>();
+      const replacementPatch = createDeferred<unknown>();
       let patchCount = 0;
       const request = vi.fn(async (method: string) => {
         if (method === "sessions.patch") {
@@ -813,8 +795,8 @@ describe("session list replacement options", () => {
   );
 
   it("does not reuse a retired owner's model baseline for the next owner", async () => {
-    const agentAPatch = deferred<unknown>();
-    const agentBPatch = deferred<unknown>();
+    const agentAPatch = createDeferred<unknown>();
+    const agentBPatch = createDeferred<unknown>();
     let patchCount = 0;
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.patch") {

--- a/ui/src/lib/sessions/message-cut.test.ts
+++ b/ui/src/lib/sessions/message-cut.test.ts
@@ -1,14 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient, GatewayEventFrame, GatewayHelloOk } from "../../api/gateway.ts";
 import { createSessionCapability } from "./index.ts";
-
-function deferred<T>() {
-  let resolve: (value: T) => void = () => undefined;
-  const promise = new Promise<T>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
-}
 
 function createGatewayHarness(client: GatewayBrowserClient) {
   let snapshot: {
@@ -51,7 +44,7 @@ function createGatewayHarness(client: GatewayBrowserClient) {
 
 describe("session capability message cuts", () => {
   it("returns a committed rewind result after the connection is replaced", async () => {
-    const committed = deferred<{
+    const committed = createDeferred<{
       editorText?: string;
       editorAttachments?: Array<{ mimeType: string; data: string }>;
     }>();


### PR DESCRIPTION
## What Problem This Solves

Session tests maintain duplicate promise controls and result fixtures already provided by shared test helpers.

## Why This Change Was Made

Reuse `createDeferred` at 19 sites across three session tests and the identical shared `sessionsResult` fixture. This removes three local deferred constructors and one result factory: production 0 lines; tests +23/−55 (net −32).

## User Impact

No user-visible behavior changes. Existing coverage retains session and model ownership, archive identity, refresh ordering, debounce and hidden-page behavior, and committed rewind/fork results across connection changes.

## Evidence

The same normal three-file route passed all 49 cases before and after the cleanup, with identical observed order. All 136 assertions, 61 timer calls and 17 finally blocks are preserved.

```sh
node scripts/run-vitest.mjs ui/src/lib/sessions/list-options.test.ts ui/src/lib/sessions/index.event-refresh.test.ts ui/src/lib/sessions/message-cut.test.ts
node scripts/check-changed.mjs -- ui/src/lib/sessions/list-options.test.ts ui/src/lib/sessions/index.event-refresh.test.ts ui/src/lib/sessions/message-cut.test.ts
```

The full local changed gate passed, including types, i18n, all dead-export scans and lint. Managed Codex P2 review found no actionable findings; that review was static and did not independently run tests.
