### PR TITLE
improve: reduce command construction test startup

### DIFF
--- a/src/commands/agent-exec.construction.test.ts
+++ b/src/commands/agent-exec.construction.test.ts
@@ -61,6 +61,8 @@ describe("agent exec command composition", () => {
         agents: {
           defaults: {
             model: { primary: "construction-cli/model-a" },
+            // The synthetic backend has no reasoning capability to discover.
+            thinkingDefault: "off",
           },
         },
       }),


### PR DESCRIPTION
## What Problem This Solves

The command-construction regression test spent about a minute discovering model capabilities before reaching its process and timeout checks. That unnecessary work contributes to a slow CI lane.

## Why This Change Was Made

The fixture already registers a synthetic Node process that writes its PID and blocks on an unread secret pipe. Give that fixture an explicit `thinkingDefault: "off"`: it has no reasoning capability to discover. The real command, queue, supervisor, secret delivery, deadlines, result envelope and cleanup remain unchanged.

## User Impact

Faster internal test execution with the same regression coverage. No production code, public configuration surface, shard count or worker policy changes.

## Evidence

- Complete local wrapper: 72.411s before, 10.961s after; the same case passes. Vitest case time fell from 63.79s to 5.35s. The baseline also included 4.569s of worker-artifact preparation, so the entire wrapper difference is not attributed to this field.
- Preserved all assertions: real PID, secret created once, starting at 999ms, timeout at 1000ms, child death, exit 2 and timeout envelope, with awaited cleanup.
- The lower-level real supervisor construction regression passes independently.
- Independent Codex review: no actionable findings through P2.
- Required changed-file gate passes, including command test types, formatting, lint and repository guards.
- Production LOC: 0. Test LOC: +2, consisting of the fixture value and its explanation.

Validation commands:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/agent-exec.construction.test.ts
node scripts/run-vitest.mjs src/process/supervisor/adapters/child.service-lifecycle.test.ts -t 'bounds construction while secret delivery blocks and cleans the real command'
node scripts/check-changed.mjs -- src/commands/agent-exec.construction.test.ts
```

Follow-up: investigate why provider-scoped static thinking lookup expands into unrelated bundled discovery entries. This fixture cleanup does not change that production catalog behavior.
