### PR TITLE
fix(android): preserve operator connection during gateway focus

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1115,6 +1115,9 @@ class NodeRuntime private constructor(
   // of the UI request or lifecycle sequence that originally admitted it.
   private class GatewayConnectionContext(
     val auth: GatewayConnectAuth,
+    // A started session owns retries and auth pauses before readiness is published.
+    // Only bootstrap without operator auth may admit this role after the node connects.
+    var operatorConnectAdmitted: Boolean = false,
   )
 
   private var activeGatewayConnection: GatewayConnectionContext? = null
@@ -4562,7 +4565,8 @@ class NodeRuntime private constructor(
   ): Boolean =
     runGatewayConnectOperation {
       beforeConnect()
-      activeGatewayConnection = GatewayConnectionContext(auth)
+      val connection = GatewayConnectionContext(auth)
+      activeGatewayConnection = connection
       val tls = connectionManager.resolveTlsParams(endpoint)
       val storedOperatorEntry = loadStoredRoleDeviceAuthEntry(endpoint, "operator")
       refreshGatewayControlPage(endpoint, auth, storedOperatorEntry?.token)
@@ -4581,6 +4585,7 @@ class NodeRuntime private constructor(
         }
         operatorSession.disconnect()
       } else {
+        connection.operatorConnectAdmitted = true
         operatorSession.connect(
           endpoint,
           operatorAuth.token,
@@ -4878,8 +4883,9 @@ class NodeRuntime private constructor(
       val operatorAuth =
         resolveOperatorSessionConnectAuth(auth, storedOperatorEntry?.token) ?: return@launch
       launchGatewayLifecycle({ activeGatewayConnection === connection && connectedEndpoint?.stableId == endpoint.stableId }) {
-        if (operatorConnected) return@launchGatewayLifecycle
+        if (connection.operatorConnectAdmitted) return@launchGatewayLifecycle
         runGatewayConnectOperation {
+          connection.operatorConnectAdmitted = true
           updateStatus {
             operatorStatusText = "Connecting…"
             operatorConnectionProblem = null

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -671,9 +671,16 @@ class NodeForegroundServiceTest {
   @Config(shadows = [ServiceRuntimePrefsShadow::class, SessionDisconnectShadow::class])
   fun focusingSecondaryReadsItsAcceptedOperatorToken() = assertReconnectDrainsAcceptedOperatorToken(GatewayTokenTransition.SecondaryFocus)
 
+  @Test
+  @Config(shadows = [ServiceRuntimePrefsShadow::class, SessionDisconnectShadow::class, ConnectAdmissionShadow::class])
+  fun focusingSecondaryKeepsItsAdmittedOperatorWhileHelloPersists() = assertReconnectDrainsAcceptedOperatorToken(GatewayTokenTransition.SecondaryFocus, holdPrimaryWriteUntilNode = true)
+
   private enum class GatewayTokenTransition { SecondaryReenable, PrimaryReconnect, SecondaryFocus }
 
-  private fun assertReconnectDrainsAcceptedOperatorToken(transition: GatewayTokenTransition) {
+  private fun assertReconnectDrainsAcceptedOperatorToken(
+    transition: GatewayTokenTransition,
+    holdPrimaryWriteUntilNode: Boolean = false,
+  ) {
     val app = RuntimeEnvironment.getApplication() as NodeApp
     app.prefs.setManualTls(false)
     val runtime = app.ensureBackgroundRuntime()
@@ -681,6 +688,8 @@ class NodeForegroundServiceTest {
     val tokenWrite = RuntimeReturnGate()
     val controller = Robolectric.buildService(NodeForegroundService::class.java).create()
     val helloCount = AtomicInteger()
+    val primaryWrite = RuntimeReturnGate()
+    val heldNodeHello = RuntimeReturnGate()
     val wireTokens = LinkedBlockingQueue<String>()
     val gateway =
       lifetimeGateway(onConnect = { frame ->
@@ -699,6 +708,10 @@ class NodeForegroundServiceTest {
           val token = if (helloCount.incrementAndGet() == 1) "synthetic-old-token" else "synthetic-new-token"
           """{"type":"hello-ok","server":{"host":"lifetime-proof"},"features":{"methods":[]},"snapshot":{},"auth":{"deviceToken":"$token","role":"operator","scopes":["operator.read","operator.write"]}}"""
         } else {
+          if (holdPrimaryWriteUntilNode && heldNodeHello.claimed.compareAndSet(false, true)) {
+            heldNodeHello.entered.countDown()
+            check(heldNodeHello.release.await(10, TimeUnit.SECONDS)) { "Node hello was not released" }
+          }
           """{"type":"hello-ok","server":{"host":"lifetime-proof"},"features":{"methods":[]},"snapshot":{}}"""
         }
       }
@@ -718,6 +731,7 @@ class NodeForegroundServiceTest {
         runtime.setGatewayConnectionEnabled(endpoint.stableId, true)
       }
       assertTrue("First operator hello did not reach token persistence", tokenWrite.entered.await(10, TimeUnit.SECONDS))
+      if (holdPrimaryWriteUntilNode) fixture.operatorTokenWriteGate = primaryWrite
       val first = generateSequence { fixture.sessionConnections.poll() }.first { it.role == "operator" }.session
       assertEquals("synthetic-initial-token", wireTokens.remove())
       val drained = CompletableDeferred<Unit>()
@@ -765,8 +779,29 @@ class NodeForegroundServiceTest {
         } finally {
           tokenWrite.release.countDown()
         }
+        if (holdPrimaryWriteUntilNode) {
+          assertTrue("Primary hello did not reach its held persistence", primaryWrite.entered.await(10, TimeUnit.SECONDS))
+          assertTrue("Node hello did not reach its held response", heldNodeHello.entered.await(10, TimeUnit.SECONDS))
+          val nodeAdmissionFinished = CountDownLatch(1)
+          val admission = Shadow.extract<ConnectAdmissionShadow>(runtime)
+          admission.lifecycleDecision = nodeAdmissionFinished
+          try {
+            heldNodeHello.release.countDown()
+            assertTrue("Node operator admission did not finish", nodeAdmissionFinished.await(10, TimeUnit.SECONDS))
+            assertTrue(runtime.nodeConnected.value)
+          } finally {
+            admission.lifecycleDecision = null
+            primaryWrite.release.countDown()
+          }
+        }
         withTimeout(10_000) {
           while (completedWrites.size < 2) completedWrites += fixture.operatorTokenWrites.receive()
+          if (holdPrimaryWriteUntilNode) {
+            runtime.gatewayConnectionDisplay.first { it.isConnected && runtime.nodeConnected.value }
+          }
+          // Retire the runtime intent before either role is joined; a delayed node hello
+          // must not recover an operator socket deliberately closed by this fixture.
+          runtime.disconnect()
           replacement.disconnectAndJoin()
         }
       }
@@ -780,6 +815,8 @@ class NodeForegroundServiceTest {
       assertEquals("Reconnect must read auth after the accepted old write", "synthetic-old-token", wireTokens.remove())
       assertEquals(listOf("synthetic-old-token", "synthetic-new-token"), completedWrites)
     } finally {
+      primaryWrite.release.countDown()
+      heldNodeHello.release.countDown()
       tokenWrite.release.countDown()
       fixture.operatorTokenWriteGate = null
       closeNodeServiceTestFixture(controller, app)
@@ -1042,6 +1079,35 @@ class NodeForegroundServiceTest {
     @RealObject private lateinit var runtime: NodeRuntime
 
     @Volatile var entryGate: RuntimeReturnGate? = null
+
+    @Volatile var lifecycleDecision: CountDownLatch? = null
+
+    @Implementation
+    protected fun launchGatewayLifecycle(
+      isCurrent: () -> Boolean,
+      block: () -> Unit,
+    ) {
+      val completed = lifecycleDecision
+      val observed =
+        if (completed == null) {
+          block
+        } else {
+          {
+            try {
+              block()
+            } finally {
+              completed.countDown()
+            }
+          }
+        }
+      Shadow.directlyOn<Any, NodeRuntime>(
+        runtime,
+        NodeRuntime::class.java,
+        "launchGatewayLifecycle",
+        ReflectionHelpers.ClassParameter.from(Function0::class.java, isCurrent),
+        ReflectionHelpers.ClassParameter.from(Function0::class.java, observed),
+      )
+    }
 
     @Implementation
     protected fun connectSwitchingGateway(


### PR DESCRIPTION
Closes #137514

## What Problem This Solves

Fixes an issue where Android users focusing a secondary Gateway could replace an operator connection that was already starting when the node connected before the operator finished saving its accepted token. The extra authenticated connection is timing-dependent; message loss and physical-device frequency have not been measured.

## Why This Change Was Made

Each current Gateway connection now records whether it has admitted its operator session. That session owns its handshake, retries, and authentication pauses even before it is ready. A bootstrap connection without operator credentials can still start the operator after the node supplies them, and an explicit connection replacement gets a new admission context.

The token-ordering test also retires the complete runtime before joining its sessions. Closing only its operator socket while leaving the node and runtime intent active could legitimately cause a recovery connection during teardown. The strict two-connection expectation remains unchanged.

## User Impact

Gateway focus and startup no longer replace an in-flight operator solely because its ready callback has not arrived. This restores the documented connection ownership and retry behavior; no settings, protocol, storage schema, or visual changes are introduced.

## Evidence

- Controlled before-ready regression failed old production with exactly `expected:<2> but was:<3>`, without a fixture timeout. A separate diagnostic observed the redundant admission while token persistence was held and the third real loopback WebSocket connection before runtime teardown.
- With the fix, all 120 tests passed: `NodeForegroundServiceTest` (30), `GatewayBootstrapAuthTest` (53), and `GatewaySessionReconnectTest` (37), with zero failures or skips. This is JVM/Robolectric plus synthetic WebSocket-peer proof, not physical-device or real-Gateway proof.
- All 14 changed-check stages passed, including all four Android ktlint modules. Final formatting-only adjustments passed a fresh independent Codex review with no actionable findings.
- Real isolated Gateway smoke passed on the actual Android `NodeRuntime`/`GatewaySession` in a task-only Robolectric proof copy: one test, seven phases, zero failures/errors/skips. A real setup-code RPC and generated Ed25519 identity exercised bootstrap with only the node admitted while its returned operator token was held, then exactly one deferred operator after persistence. The same identity continued through secondary operator, focused node+operator, disconnect, stored-token-only reconnect and final disconnect. Role-token hashes matched the real Gateway store throughout; final device removal left neither connection nor paired credentials. No model/provider/tool call was made.
- [Exact-head CI 33798250572](https://github.com/openclaw/openclaw/actions/runs/33798250572) passed for `837e49bd673a64568092fb36b60631ca28fa77f2`, tested as merge `a24098f3e3a7f7e6320ea37b5d11a55478709e37`. Play and ThirdParty app test tasks executed; Wear and shared Wear tests were restored from Gradle cache. Builds and ktlint passed. The logs do not print test-case totals.
- Root inspection verified the raw native XML, seven phase records plus retirement, normal Gateway shutdown, absent process groups/listeners and removal of task runtime state. Initial proof-scaffold failures (incorrect esbuild sandbox path and obsolete logging key) were corrected before live execution and retained; neither needed a product change.

The forced focused-token-write/node-ready race remains the deterministic synthetic-peer regression; the real-Gateway run proves the production authentication and lifecycle flows, not a physical Android device or a measured message-loss rate. Bootstrap required no manual pairing approval, so that fallback branch was not exercised. No visual UI change is made; no hardware/UI screenshot proof is claimed.

Best-fix verdict: best at the existing serialized `NodeRuntime` lifecycle owner. A display-text guard conflates UI state with admission and previously interfered with bootstrap handoff. Global `GatewaySession` deduplication would alter intentional replacement semantics. Relaxing the test's connection count would hide the demonstrated race.

Code read: `NodeRuntime`, `GatewaySession`, `GatewayConnectionManager`, accepted-token storage and the existing foreground-service/bootstrap/reconnect tests. Production delta: +8/-2; tests and test support: +67/-1.

Provenance: the readiness-only fallback predates #137389, whose test exposed this path in [CI](https://github.com/openclaw/openclaw/actions/runs/33790755072/job/100768303588). Source history shows an older display-text guard was removed for QR bootstrap handoff; this is not evidence that #137389 introduced the production defect.
