### PR TITLE
fix(plugin-sdk): preserve legacy retry inputs

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -667,15 +667,23 @@ catalog, API-key auth, and dynamic model resolution.
         wrapStreamFn: (ctx) => {
           if (!ctx.streamFn) return undefined;
           const inner = ctx.streamFn;
-          return async (params) => {
-            params.headers = {
-              ...params.headers,
-              "X-Acme-Version": "2",
-            };
-            return inner(params);
-          };
+          return (model, context, options) =>
+            inner(model, context, {
+              ...options,
+              headers: {
+                ...options?.headers,
+                "X-Acme-Version": "2",
+              },
+            });
         },
         ```
+
+        Existing wrappers may still pass the deprecated `maxRetries` stream option,
+        including `0`. Built-in text transports ignore it: the embedded runner owns
+        retry budgeting, and SDK-internal retries stay disabled. New wrappers should
+        omit the option. This shipped source contract is retained until a future
+        Plugin SDK major release and a published-plugin reader sweep confirm removal
+        is safe; it does not change image-generation or native-runtime retry policy.
       </Tab>
       <Tab title="Native transport identity">
         For providers that need native request/session headers or metadata on

--- a/packages/ai/src/transports/openai-transport-params.session-header.test.ts
+++ b/packages/ai/src/transports/openai-transport-params.session-header.test.ts
@@ -1,4 +1,4 @@
-import type { Context, Model } from "@openclaw/llm-core";
+import type { Context, Model, SimpleStreamOptions } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
 import { OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH } from "../providers/openai-prompt-cache.js";
 import {
@@ -46,14 +46,15 @@ describe("buildOpenAISdkRequestOptions turn controls", () => {
     baseUrl: "https://api.openai.com/v1",
   } as Model;
 
-  it("includes the turn timeout and pinned zero retries", () => {
+  it.each([undefined, 0, 7])("keeps SDK retries at zero for legacy maxRetries=%s", (maxRetries) => {
     const signal = new AbortController().signal;
+    const options: SimpleStreamOptions = { timeoutMs: 1_234, maxRetries };
 
-    expect(
-      buildOpenAISdkRequestOptions(model, signal, {
-        timeoutMs: 1_234,
-      }),
-    ).toEqual({ signal, timeout: 1_234, maxRetries: 0 });
+    expect(buildOpenAISdkRequestOptions(model, signal, options)).toEqual({
+      signal,
+      timeout: 1_234,
+      maxRetries: 0,
+    });
   });
 
   it("does not add a retry policy when the turn does not specify one", () => {

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -1,5 +1,4 @@
 import type { TSchema } from "typebox";
-// LLM Core type module defines shared TypeScript contracts.
 import type { AssistantMessageDiagnostic } from "./utils/diagnostics.js";
 export type { AssistantMessageDiagnostic, DiagnosticErrorInfo } from "./utils/diagnostics.js";
 
@@ -128,6 +127,8 @@ export interface StreamOptions {
    * For example, OpenAI and Anthropic SDK clients default to 10 minutes.
    */
   timeoutMs?: number;
+  /** @deprecated Ignored by built-in text transports; retries are owned by the host runner. */
+  maxRetries?: number;
   /**
    * Maximum delay in milliseconds to wait for a retry when the server requests a long wait.
    * If the server's requested delay exceeds this value, the request fails immediately
@@ -669,7 +670,6 @@ export interface VercelGatewayRouting {
   order?: string[];
 }
 
-// Model interface for the unified model system
 export interface Model<TApi extends Api = Api> {
   id: string;
   name: string;

--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -1,4 +1,4 @@
-import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/core";
 import type { Model } from "openclaw/plugin-sdk/llm";
 // Provider stream tests cover shared stream-wrapper families and payload compatibility.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
@@ -25,6 +25,8 @@ import {
   OPENROUTER_THINKING_STREAM_HOOKS,
   TOOL_STREAM_DEFAULT_ON_HOOKS,
 } from "./provider-stream.js";
+
+type StreamFn = NonNullable<ProviderWrapStreamFnContext["streamFn"]>;
 
 function requireWrapStreamFn(
   wrapStreamFn: ReturnType<typeof buildProviderStreamFamilyHooks>["wrapStreamFn"],
@@ -258,7 +260,8 @@ describe("composeProviderStreamWrappers", () => {
 
   it("applies wrappers left to right", () => {
     const order: string[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, _options) => {
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      expect(options?.maxRetries).toBe(0);
       order.push("base");
       return {} as never;
     };
@@ -268,7 +271,7 @@ describe("composeProviderStreamWrappers", () => {
       (streamFn: StreamFn | undefined): StreamFn =>
       (model, context, options) => {
         order.push(`${label}:before`);
-        const result = (streamFn ?? baseStreamFn)(model, context, options);
+        const result = (streamFn ?? baseStreamFn)(model, context, { ...options, maxRetries: 0 });
         order.push(`${label}:after`);
         return result;
       };


### PR DESCRIPTION
Closes #137520
Related: #134281

## What Problem This Solves

Fixes an issue where provider plugin authors delegating through the public stream-wrapper hook would get a TypeScript error after upgrading from stable `openclaw@2026.8.2`. A previously valid `maxRetries: 0` input was removed from the hook's options while text retry ownership was consolidated.

## Why This Change Was Made

Retain the shipped optional input as explicitly deprecated, while keeping built-in text transports unchanged and retries owned by the embedded runner. Existing plugins remain source-compatible; new wrappers omit the field. Removal requires a future Plugin SDK major release and a published-plugin reader sweep. No new runtime fallback, configuration, dependency, schema, or protocol surface is introduced.

Best-fix verdict: preserve the public input without reintroducing nested retries. Narrowing it to literal zero would still break previously typed numeric inputs; a second public-wrapper-only options type would duplicate the canonical stream signature. Two obvious narration comments are removed from the same type module: production **+2/-2, net0**; tests **+14/-10, net+4**; docs **+15/-7, net+8**.

The nearby custom-header documentation example also called `inner(params)` with one argument instead of the actual `(model, context, options)` contract. Its exact code block fails compilation independently; the corrected example preserves the context and merges request headers without mutating the model.

## User Impact

Existing provider wrappers compile through both `openclaw/plugin-sdk/core` and `openclaw/plugin-sdk/plugin-entry`. Passing the deprecated option does not re-enable SDK-internal text retries or change image-generation/native-runtime retry policy. The documented header wrapper can now be copied into a typed provider implementation.

## Evidence

The same standalone plugin consumer uses only each public package specifier and delegates with `{ ...options, maxRetries: 0 }`:

| Declaration target | Both public entrypoints |
| --- | --- |
| Actual published `openclaw@2026.8.2` | Pass |
| Fresh canonical SDK build at `a50ffb75e834dbca165b8d0c77be8084df675900` | TS2353: unknown `maxRetries` |
| Fresh canonical SDK build with this patch | Pass |

Both declaration builds used `pnpm build:plugin-sdk:dts`. Consumers use TypeScript6.0.3 with `--noEmit --strict --skipLibCheck --module NodeNext --target ES2022`.

- The modified existing wrapper regression was run through the real repository services typecheck before the production fix: TS2339/TS2353 for the missing field. It derives the stream type from the public provider hook.
- **217 tests passed** across SDK stream wrappers, OpenAI transport options/Responses, and Anthropic. The request-option controls prove absent, zero, and positive legacy values all keep SDK retries at zero.
- The exact old custom-header docs block fails TS2554; the exact candidate block compiles.
- Independent managed Codex review found no actionable P0–P2 findings. The affected production owner's JavaScript is byte-identical after type/comment erasure. This is not a whole packed-runtime equivalence claim.
- Full changed-code gate passed: core/test types, SDK export/surface checks, formatting, lint, deprecated API usage, dead exports, and runtime import-cycle checks.

The developer-facing behavior exercised here is real compilation against published/generated public SDK declarations. No network API changed or live provider proof is claimed, and no deployed external-plugin outage was identified.

### Regression provenance

Raw parent-relative source comparison identifies the input removal in `4a1cc226964a170a5d79139150baab989cac921a`, via #134281 (merged 2026-09-01). PR author and merger: Ayaan Zaidi (@obviyus); commit committer: GitHub. Specific hunk authorship and automation trigger are not inferred from those roles. The original single-owner retry repair is preserved.
