### PR TITLE
test(doctor): reuse canonical Claude note call guard

### DIFF
--- a/src/commands/doctor-claude-cli.test.ts
+++ b/src/commands/doctor-claude-cli.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveClaudeCliProjectDirForWorkspace } from "../agents/command/claude-cli-project-dir.js";
 import { noteClaudeCliHealth } from "./doctor-claude-cli.js";
@@ -34,16 +35,8 @@ async function withTempHome<T>(
   }
 }
 
-function noteArg(noteFn: ReturnType<typeof vi.fn>, argIndex: number): unknown {
-  const call = noteFn.mock.calls[0];
-  if (!call) {
-    throw new Error("Expected note call");
-  }
-  return call.at(argIndex);
-}
-
 function noteBody(noteFn: ReturnType<typeof vi.fn>): string {
-  const value = noteArg(noteFn, 0);
+  const value = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call").at(0);
   if (typeof value !== "string") {
     throw new Error("Expected note body");
   }
@@ -51,7 +44,7 @@ function noteBody(noteFn: ReturnType<typeof vi.fn>): string {
 }
 
 function noteTitle(noteFn: ReturnType<typeof vi.fn>): string {
-  const value = noteArg(noteFn, 1);
+  const value = expectDefined<unknown[]>(noteFn.mock.calls[0], "note call").at(1);
   if (typeof value !== "string") {
     throw new Error("Expected note title");
   }


### PR DESCRIPTION
Reuse the canonical presence assertion for the first mocked Claude Doctor note call, retaining argument indexing and the existing string checks. Runtime code and all eight Doctor cases are unchanged.

Validation: the same 12 cases passed before and after on Node 26.5.0. The normal single-file changed check passed, and a fresh Codex P2 review found no actionable defects.
